### PR TITLE
fix(contribute): completion detector distinguishes finished from blocked-waiting-for-human

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -819,6 +819,34 @@ function paneLooksBlockedOnHuman(text) {
     /\b(?:choose|select|option|pick|which|how (?:should|to) proceed|what (?:would|should).+like)\b/i.test(recent) &&
     currentMenuLine &&
     (recent.match(/(?:^|\n)\s*(?:[❯>]\s*)?\d+[\).]\s+\S+/g) || []).length >= 2;
+
+  // Elicitation / fill-in-a-form prompt (kubestellar/hive#2844). Goose (and any
+  // backend that raises an MCP elicitation) can pause mid-turn and render a form
+  // for the operator to fill in. Such a pane usually ends in a bare "> " or
+  // still shows goose's "> Enter to send" hint, so the per-backend classifier
+  // sees hasIdlePrompt && hasCompletionMarker and calls the turn DONE — the exact
+  // false "complete" this function exists to prevent. A form does NOT necessarily
+  // carry a trailing "?", a y/N, a numbered menu, or a permission keyword, so the
+  // checks above miss it. Detect it POSITIVELY and CONTEXTUALLY: require an
+  // explicit request-for-input lead-in AND a form/field structure (or one of
+  // goose's own elicitation-timeout markers). Requiring both — the lead-in is the
+  // load-bearing half — keeps ordinary finished output that merely contains a
+  // "label: value" line (e.g. "opened a PR: https://…") from matching, the same
+  // bare-substring lesson as the /login false-positive fix.
+  const hasInputRequestLeadIn =
+    /\b(?:needs?|need)\s+(?:some\s+|more\s+|the\s+following\s+)?(?:information|input|details|details? to proceed)\b/i.test(recent) ||
+    /\b(?:please\s+)?(?:fill\s+in|provide|enter|supply|complete|specify)\b.*\b(?:the\s+following|form|field|details|information|value|below)\b/i.test(recent) ||
+    /\b(?:the\s+following|these)\s+(?:information|details|fields|values)\b.*\b(?:required|needed|to proceed)\b/i.test(recent) ||
+    /\bwaiting\s+for\s+(?:your\s+|user\s+)?(?:input|response|answer)\b/i.test(recent);
+  const hasFormStructure =
+    /\[\s*[^\]\n]*\s*\]/.test(recent) ||             // a bracketed input/field or [ Submit ]/[ Cancel ] button
+    /^\s*\S.*:\s*(?:_+|\[.*\]|)\s*$/m.test(recent);  // "Label:" field rows (optionally blank/underscore/bracket)
+  // Goose bounds elicitation with its own timeout; these strings are an
+  // unambiguous "was blocked on a human" signal all on their own.
+  const hasElicitationMarker =
+    /\bElicitation request timed out\b/i.test(recent) ||
+    /\bTimeout waiting for user response\b/i.test(recent);
+  const hasElicitationForm = (hasInputRequestLeadIn && hasFormStructure) || hasElicitationMarker;
   const blockingPatterns = [
     // Confirmation prompts and TUI continuation screens.
     /\[[Yy]\/[Nn]\]|\([Yy]\/[Nn]\)|\b[Yy]es\/[Nn]o\b/,
@@ -833,7 +861,7 @@ function paneLooksBlockedOnHuman(text) {
     /\b(?:Paste|Enter).*(?:API key|token|code|password)\b/i,
   ];
 
-  return hasQuestion || hasNumberedMenu || blockingPatterns.some(re => re.test(beforePrompt));
+  return hasQuestion || hasNumberedMenu || hasElicitationForm || blockingPatterns.some(re => re.test(beforePrompt));
 }
 
 function classifyTmuxPane(text) {

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -590,10 +590,57 @@ test('interactive pane classifier distinguishes complete, blocked, and working s
         pane: 'calling tool github.create_pull_request\n> Enter to send\n',
         want: relay.PANE_STATE_WORKING,
       },
+      // kubestellar/hive#2844 — MCP elicitation forms. Each of these leaves the
+      // pane at goose's idle chrome ("> " / "> Enter to send") with no working
+      // word, so the pre-fix classifier called them IDLE_COMPLETE and the relay
+      // reported the unanswered form as a finished task.
+      {
+        name: 'elicitation form ending in a bare > input line',
+        pane: 'Extension needs some information to proceed:\n\n  Project name: my-service\n  Environment:  production\n  Region:       us-east-1\n\n> \n',
+        want: relay.PANE_STATE_BLOCKED_ON_HUMAN,
+      },
+      {
+        name: 'elicitation form with bracketed fields and no > at all',
+        pane: 'Extension needs some information to proceed:\n\n  Project name: [                    ]\n  Environment:  [ production        ]\n\n  [ Submit ]   [ Cancel ]\n',
+        want: relay.PANE_STATE_BLOCKED_ON_HUMAN,
+      },
+      {
+        name: 'elicitation form while goose "> Enter to send" hint is still on screen',
+        pane: 'Please fill in the deployment details below:\n\n  Namespace: default\n  Replicas:  3\n\n> Enter to send\n',
+        want: relay.PANE_STATE_BLOCKED_ON_HUMAN,
+      },
+      {
+        name: 'goose elicitation timeout marker',
+        pane: 'Elicitation request timed out or failed\n> Enter to send\n',
+        want: relay.PANE_STATE_BLOCKED_ON_HUMAN,
+      },
     ];
 
     for (const tc of fixtures) {
       assert.strictEqual(relay.classifyTmuxPane(tc.pane), tc.want, tc.name);
+    }
+  } finally { teardown(relay); }
+});
+
+test('elicitation-form detection does not false-positive on ordinary finished output (#2844)', () => {
+  const relay = loadRelay({ backend: 'goose' });
+  try {
+    // Finished panes that happen to contain form-ish shapes or words like
+    // "provide"/"continue" mid-sentence, or a "label: value" line, must stay
+    // COMPLETE. The elicitation matcher requires BOTH an explicit request-for-
+    // input lead-in AND a form structure, so none of these should trip it — the
+    // same bare-substring lesson as the /login false-positive fix.
+    const finished = [
+      'Implemented the fix and opened a PR: https://github.com/x/y/pull/1\n\ngoose is ready\n> Enter to send\n',
+      'Done.\nFiles changed: 3\nTests: passing\n> Enter to send\n',
+      'I updated the docs to provide the following context for readers.\n> Enter to send\n',
+      'The build will continue to run in CI. All done.\n> Enter to send\n',
+      'Refactored the parser [see commit abc123]. Complete.\n> Enter to send\n',
+    ];
+    for (const pane of finished) {
+      assert.strictEqual(
+        relay.classifyTmuxPane(pane), relay.PANE_STATE_IDLE_COMPLETE,
+        `finished pane wrongly classified as blocked/working: ${JSON.stringify(pane)}`);
     }
   } finally { teardown(relay); }
 });
@@ -620,6 +667,26 @@ test('blocked interactive panes report attention instead of task_complete', () =
     assert.ok(progress, `expected blocked_on_human progress, got: ${JSON.stringify(relay.__sent)}`);
     assert.strictEqual(progress.attention, true, 'blocked status must request human attention');
     assert.ok(relay.getCurrentTask(), 'the task must remain active while waiting for a human');
+  } finally { teardown(relay); }
+});
+
+test('goose elicitation form is reported as blocked, never as task_complete (#2844)', () => {
+  // The exact scenario Jorge reported: an MCP elicitation form left the pane at
+  // goose's "> Enter to send" chrome, and the relay sent task_complete for work
+  // that had not happened. It must now go out as attention/blocked instead.
+  const formPane = 'Extension needs some information to proceed:\n\n  Project name: my-service\n  Region:       us-east-1\n\n> Enter to send\n';
+  const relay = loadRelay({ backend: 'goose', cliStates: [formPane, formPane] });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 'ct-elicit');
+    relay.__crashTick();
+
+    assert.ok(!relay.__sent.some(m => m.type === 'task_complete'),
+      'an unanswered elicitation form must never be reported as completed');
+    const progress = relay.__sent.find(m => m.type === 'task_progress' && m.status === 'blocked_on_human');
+    assert.ok(progress, `expected blocked_on_human progress, got: ${JSON.stringify(relay.__sent)}`);
+    assert.strictEqual(progress.attention, true, 'blocked status must request human attention');
+    assert.ok(relay.getCurrentTask(), 'the task must remain active while the form is unanswered');
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
Fixes #2844

## The reporter's scenario (Jorge / @castrojo)

In interactive mode, an agent that is **blocked waiting for a human** is scored the same as an agent that **finished its task**. Goose can pause mid-turn on an [MCP elicitation](https://github.com/aaif-goose/goose/blob/main/documentation/docs/guides/mcp-elicitation.md) form — it renders a fill-in form in the terminal and waits for the operator. That form leaves the pane at goose's idle chrome (a bare `> ` or `> Enter to send`) with no "working" word, so the completion detector concludes the turn is over and the relay sends `task_complete` for work that has not happened. The contributor is returned to `ready`, the assignment is closed out, and the actual task is left sitting at an unanswered question. A wrong "done" is worse than a stall: nothing retries it and the output looks legitimate.

## The signal that conflated the two

`classifyTmuxPane()` in `bin/contributor-relay.sh` (goose branch, ~line 856) declares completion from `hasIdlePrompt && hasCompletionMarker && !isWorking`, where for goose `hasCompletionMarker` is hard-coded `true` and `hasIdlePrompt` matches `> Enter to send` / `>\s*$`. An elicitation form satisfies all three. The existing `paneLooksBlockedOnHuman()` (added in #2857) already caught trailing `?`, y/N, numbered menus, and permission prompts — but a form carries none of those, so it fell through to `IDLE_COMPLETE`. Confirmed at classifier level: the pre-fix code returns `IDLE_COMPLETE` for the elicitation renderings in the issue.

## The three-state classification

The detector splits quiescence into three states (unchanged vocabulary): `WORKING`, `BLOCKED_ON_HUMAN`, `IDLE_COMPLETE`. This PR closes the remaining hole feeding a blocked form into `IDLE_COMPLETE`. `paneLooksBlockedOnHuman()` now also returns true for an elicitation/fill-in-a-form prompt, so such panes classify `BLOCKED_ON_HUMAN`; the relay emits a `blocked_on_human` `task_progress` event with `attention: true` and keeps the task active — never `task_complete`. The overall task timeout remains the backstop for a truly stuck agent, so a blocked form is surfaced, not silently hung forever.

## Prompt shapes matched (elicitation form)

Detected **positively and contextually** — requires BOTH:
- an explicit request-for-input lead-in: `needs (some/more/the following) information/input/details to proceed`, `please fill in / provide / enter / complete the following/form/field/details/below`, `the following information/details/fields required/needed`, `waiting for your/user input/response/answer`; **and**
- a form/field structure: a bracketed field or `[ Submit ]`/`[ Cancel ]` button, or a `Label:` field row (optionally blank / underscore / bracketed).

Plus goose's own elicitation-timeout markers as a standalone signal: `Elicitation request timed out`, `Timeout waiting for user response`.

## How the opposite false-positive is avoided

Requiring the request-for-input lead-in (the load-bearing half) keeps ordinary finished output from tripping it — a summary line like `opened a PR: https://…` or `Files changed: 3` has the `label: value` shape but no lead-in, and prose containing `provide the following context` or `continue to run in CI` mid-sentence has a lead-in-ish word but no form structure. This is the same bare-substring lesson as the earlier `/login` false-positive fix. A dedicated regression test asserts a suite of such finished panes stay `IDLE_COMPLETE`.

## Tests

`node bin/contributor-relay.test.js` — 46/46 pass. Added: elicitation forms (bare `>`, bracketed fields, goose hint still on screen, timeout marker) classify `BLOCKED_ON_HUMAN`; finished-output panes stay `IDLE_COMPLETE` (opposite-regression guard); end-to-end, a goose elicitation form reports `blocked_on_human` with `attention` and never `task_complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
