### PR TITLE
✨ feat(contribute): owner assigns agent roles from the clanker card

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1312,6 +1312,10 @@ function handleMessage(data, hub) {
       }, TASK_UNAVAILABLE_RETRY_MS);
       break;
 
+    case 'notice':
+      console.log(msg.message || msg.reason || 'Notice from hub');
+      break;
+
     case 'ping':
       sendTo(hub, { type: 'pong', seq: msg.seq });
       break;

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -722,6 +722,20 @@ test('an idle non-active hub cannot assign work until the poll slot reaches it',
   } finally { teardown(relay); }
 });
 
+test('hub notice messages are logged for operators', () => {
+  const relay = loadRelay();
+  const lines = [];
+  const oldLog = console.log;
+  console.log = (msg) => { lines.push(String(msg)); };
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'notice', message: 'role assigned: scanner — your next task will be scanner work' }));
+    assert.ok(lines.some(l => l.includes('role assigned: scanner')), 'notice message was not logged');
+  } finally {
+    console.log = oldLog;
+    teardown(relay);
+  }
+});
+
 test('token_refresh, task_revoke, and blocked progress only affect the hub that owns the active task', () => {
   const blockedPane = 'Should I open a pull request for this change?\n> \n';
   const relay = loadRelay({ backend: 'goose', cliStates: [blockedPane, blockedPane], env: MULTI_HUB_ENV });

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2055,11 +2055,11 @@ var defaultContributeDelegatableRoles = []string{"scanner", "quality", "outreach
 // a clanker may claim. Empty config preserves the safe v1 default; supervisor is
 // deliberately removed even if an operator lists it because it manages the fleet.
 func (h HubConfig) ContributeDelegatableRoleSet() map[string]bool {
-	roles := h.ContributeDelegatableRoles
-	if len(roles) == 0 {
-		roles = defaultContributeDelegatableRoles
+	out := make(map[string]bool, len(defaultContributeDelegatableRoles)+len(h.ContributeDelegatableRoles))
+	for _, role := range defaultContributeDelegatableRoles {
+		out[role] = true
 	}
-	out := make(map[string]bool, len(roles))
+	roles := h.ContributeDelegatableRoles
 	for _, role := range roles {
 		role = strings.ToLower(strings.TrimSpace(role))
 		if role == "" || role == "supervisor" {

--- a/v2/pkg/config/contribute_agent_roles_test.go
+++ b/v2/pkg/config/contribute_agent_roles_test.go
@@ -27,7 +27,7 @@ func TestContributeDelegatableRoleSet_ExplicitAllowListStillDeniesSupervisor(t *
 	if h.IsContributeRoleDelegatable("supervisor") {
 		t.Fatal("supervisor must never be delegatable, even when listed")
 	}
-	if h.IsContributeRoleDelegatable("quality") {
-		t.Fatal("non-listed role must not be enabled when explicit allow-list is set")
+	if !h.IsContributeRoleDelegatable("quality") || !h.IsContributeRoleDelegatable("outreach") {
+		t.Fatal("safe default trio must stay enabled even when privileged roles are explicitly allow-listed")
 	}
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3858,11 +3858,12 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			// switch state; contribute_cooldown_hours is the EFFECTIVE period (the
 			// 168h default surfaces when unset) so the number input shows the value
 			// actually in force.
-			"contribute_cooldown_enabled": cfg.Hub.IsContributeCooldownEnabled(),
-			"contribute_cooldown_hours":   cfg.Hub.ContributeCooldownHoursOrDefault(),
-			"disabled_repos":              cfg.Hub.DisabledRepos,
-			"disabled_tiers":              cfg.Hub.DisabledTiers,
-			"tier_limits":                 cfg.Hub.TierLimits,
+			"contribute_cooldown_enabled":  cfg.Hub.IsContributeCooldownEnabled(),
+			"contribute_cooldown_hours":    cfg.Hub.ContributeCooldownHoursOrDefault(),
+			"contribute_delegatable_roles": normalizeContributeDelegatableRoles(cfg.Hub.ContributeDelegatableRoles),
+			"disabled_repos":               cfg.Hub.DisabledRepos,
+			"disabled_tiers":               cfg.Hub.DisabledTiers,
+			"tier_limits":                  cfg.Hub.TierLimits,
 			// available_repos is the READ-ONLY list of repo full-names the hive knows
 			// about (from the live status snapshot), so the Management tab can render
 			// a per-repo enable toggle mirror of the Governor Hub "Repos for Contribute"
@@ -4263,6 +4264,26 @@ func (s *Server) handleGovernorAttribution(w http.ResponseWriter, r *http.Reques
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
+func normalizeContributeDelegatableRoles(roles []string) []string {
+	seen := map[string]bool{}
+	for _, role := range []string{"scanner", "quality", "outreach"} {
+		seen[role] = true
+	}
+	for _, role := range roles {
+		role = normalizeAgentRole(role)
+		if role == "" || role == "supervisor" {
+			continue
+		}
+		seen[role] = true
+	}
+	out := make([]string, 0, len(seen))
+	for role := range seen {
+		out = append(out, role)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Enabled                        *bool                      `json:"enabled"`
@@ -4285,6 +4306,7 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 		ContributeSkipAssignedToOthers *bool                      `json:"contribute_skip_assigned_to_others"`
 		ContributeCooldownEnabled      *bool                      `json:"contribute_cooldown_enabled"`
 		ContributeCooldownHours        *int                       `json:"contribute_cooldown_hours"`
+		ContributeDelegatableRoles     []string                   `json:"contribute_delegatable_roles"`
 		DisabledRepos                  []string                   `json:"disabled_repos"`
 		DisabledTiers                  []string                   `json:"disabled_tiers"`
 		TierLimits                     map[string]config.TierRate `json:"tier_limits"`
@@ -4359,6 +4381,9 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	// issue forever. A client sending 0 means "use the default".
 	if body.ContributeCooldownHours != nil {
 		cfg.Hub.ContributeCooldownHours = *body.ContributeCooldownHours
+	}
+	if body.ContributeDelegatableRoles != nil {
+		cfg.Hub.ContributeDelegatableRoles = normalizeContributeDelegatableRoles(body.ContributeDelegatableRoles)
 	}
 	if body.DisabledRepos != nil {
 		cfg.Hub.DisabledRepos = body.DisabledRepos

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -175,11 +175,15 @@ type ContributorProfile struct {
 	// AgentRoleGrants is the operator-managed per-contributor allow-list for
 	// claiming spoke agent roles that require explicit grant (for example
 	// ci-maintainer). It never changes the contributor's trust tier or credentials.
-	AgentRoleGrants []string       `json:"agent_role_grants,omitempty"`
-	Active          bool           `json:"active,omitempty"`
-	CurrentTask     *WSTaskAssign  `json:"current_task,omitempty"`
-	ActiveTasks     []WSTaskAssign `json:"active_tasks,omitempty"`
-	Sessions        int            `json:"sessions,omitempty"`
+	AgentRoleGrants []string `json:"agent_role_grants,omitempty"`
+	// AssignedAgentRole is the owner-selected effective clanker role. Empty means
+	// no owner override (the relay's optional HIVE_AGENT_ROLE claim may apply);
+	// "none" is an explicit owner override to general contribute work.
+	AssignedAgentRole string         `json:"assigned_agent_role,omitempty"`
+	Active            bool           `json:"active,omitempty"`
+	CurrentTask       *WSTaskAssign  `json:"current_task,omitempty"`
+	ActiveTasks       []WSTaskAssign `json:"active_tasks,omitempty"`
+	Sessions          int            `json:"sessions,omitempty"`
 }
 
 type ContributorRateLimits struct {
@@ -290,6 +294,7 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
 	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
+	s.mux.HandleFunc("PUT /api/contributors/{id}/agent-role", s.handleContributorAgentRole)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/agent-role-grants", s.handleContributorAgentRoleGrants)
 	s.mux.HandleFunc("POST /api/contributors/{id}/revoke", s.handleContributorRevoke)
 	s.mux.HandleFunc("POST /api/contributors/{id}/requeue", s.handleContributorRequeue)
@@ -941,6 +946,7 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .admin-act select{background:var(--cc-bg);border:1px solid var(--cc-border);color:var(--cc-text-2);font-size:.7rem;border-radius:6px;padding:2px 4px;font-family:inherit}
 .agent-role-grants{display:flex;align-items:center;gap:6px;flex-wrap:wrap;width:100%%;font-size:.7rem;color:var(--cc-muted)}
 .agent-role-grants__label{font-weight:600;color:var(--cc-text-2)}
+.clanker-act-as{display:inline-flex;align-items:center;gap:4px;color:var(--cc-muted);font-size:.72rem}
 .agent-role-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 7px;border-radius:999px;border:1px solid rgba(88,166,255,.28);background:rgba(88,166,255,.08);color:#79c0ff}
 .agent-role-chip button{border:none;background:transparent;color:inherit;cursor:pointer;padding:0;line-height:1;opacity:.75;font:inherit}
 .agent-role-chip button:hover{opacity:1;color:#f85149}
@@ -2791,6 +2797,7 @@ var adminEnabled=false;
 var adminHub=null;      // last-loaded Config.Hub.* snapshot (contribute_* fields)
 var adminDirty=false;   // filter edits pending Save
 var adminGrantableAgentRoles=[];
+var adminAssignableAgentRoles=['outreach','quality','scanner'];
 var privilegedAgentRoles={};
 ['ci-maintainer','sec-check','architect'].forEach(function(r){privilegedAgentRoles[r]=true;});
 
@@ -3240,6 +3247,14 @@ onEl('clanker-list','change',function(e){
     if(addRole)updateContributorAgentRoleGrants(sel.getAttribute('data-cid'),null,addRole);
     return;
   }
+  if(controlRole==='agent-role'){
+    var cidRole=sel.getAttribute('data-cid'),acting=sel.value||'none';
+    fetch('/api/contributors/'+encodeURIComponent(cidRole)+'/agent-role',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({agent_role:acting})})
+      .then(function(r){return r.json().then(function(d){return{ok:r.ok,d:d};});})
+      .then(function(x){if(x.ok){toast(acting==='none'?'Acting as general work':'Acting as '+acting,true);opsPoll();}else{toast((x.d&&x.d.error)||'Failed to set acting role',false);opsPoll();}})
+      .catch(function(){toast('Failed to set acting role',false);opsPoll();});
+    return;
+  }
   if(controlRole!=='tier')return;
   var cid=sel.getAttribute('data-cid'),tier=sel.value;
   fetch('/api/contributors/'+encodeURIComponent(cid)+'/trust',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({tier:tier})})
@@ -3385,6 +3400,29 @@ function syncGrantableAgentRoles(policy){
   });
   adminGrantableAgentRoles=out.sort();
 }
+function syncAssignableAgentRoles(policy){
+  var roles=(policy&&policy.agent_role_assignable_roles)||[];
+  if((!roles||!roles.length)&&adminHub&&adminHub.contribute_delegatable_roles){
+    roles=['scanner','quality','outreach'].concat(adminHub.contribute_delegatable_roles||[]);
+  }
+  if(!roles||!roles.length)roles=['scanner','quality','outreach'];
+  var seen={},out=[];
+  (roles||[]).forEach(function(r){
+    r=String(r||'').trim().toLowerCase();
+    if(r&&r!=='supervisor'&&!seen[r]){seen[r]=true;out.push(r);}
+  });
+  adminAssignableAgentRoles=out.sort();
+}
+function clankerActingAsControl(c,cid){
+  var current=String(c.role||'').trim().toLowerCase();
+  var roles=adminAssignableAgentRoles.slice();
+  if(current&&roles.indexOf(current)<0)roles.push(current);
+  roles.sort();
+  var opts='<option value="none"'+(!current?' selected':'')+'>none (general work)</option>'+
+    roles.map(function(r){return '<option value="'+esc(r)+'"'+(r===current?' selected':'')+'>'+esc(r)+'</option>';}).join('');
+  var tip=c.role_mismatch||'Owner assignment takes effect on the next task request and never rewrites the current in-flight task.';
+  return '<select class="admin-act" title="'+esc(tip)+'" data-cid="'+cid+'" data-role="agent-role">'+opts+'</select>';
+}
 function clankerAgentRoleGrantControl(c,cid){
   var grants=(c.agent_role_grants||[]).map(function(r){return String(r||'').trim().toLowerCase();}).filter(Boolean);
   var seen={};grants=grants.filter(function(r){if(seen[r])return false;seen[r]=true;return true;}).sort();
@@ -3474,6 +3512,7 @@ function renderClankers(list){
         :'';
       actions='<div class="admin-actions" data-role-grants-cid="'+cid+'">'+
         '<select class="admin-act" title="Set trust tier (maintainer voucher)" data-cid="'+cid+'" data-role="tier">'+opts+'</select>'+
+        '<label class="clanker-act-as">Acting as '+clankerActingAsControl(c,cid)+'</label>'+
         requeueBtn+
         '<button type="button" class="admin-act danger" data-cid="'+cid+'" data-user="'+esc(user)+'" data-role="revoke">Revoke</button>'+
         '<button type="button" class="admin-act danger" data-cid="'+cid+'" data-user="'+esc(user)+'" data-role="remove">Remove</button>'+
@@ -3493,7 +3532,8 @@ function renderClankers(list){
     // Enter pop-in for a clanker we haven't seen in the previous render (army framing).
     var isNew=key&&!ccKnownClankers[key];
     var rowCls='clanker-row'+(isNew?' cc-enter':'');
-    return '<div class="'+rowCls+'" data-clanker="'+esc(key)+'"><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
+    var rowTitle=c.role_mismatch?(' title="'+esc(c.role_mismatch)+'"'):'';
+    return '<div class="'+rowCls+'" data-clanker="'+esc(key)+'"'+rowTitle+'><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
       '<div class="clanker-main"><div class="clanker-user">'+esc(user)+statusPill+tierPill+'</div>'+
       '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+capsLine+interestsLine+'</div>'+
       (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
@@ -3645,6 +3685,7 @@ function renderPolicy(p){
     ['Skip assigned-to-others',p.skip_assigned_to_others?'yes':'no'],
     ['Disabled tiers',list(p.disabled_tiers)],
     ['Disabled repos',list(p.disabled_repos)],
+    ['Assignable agent roles',list(p.agent_role_assignable_roles)],
     ['Privileged agent-role grants',list(p.agent_role_grantable_roles)],
     ['Auto-promote at',esc(p.auto_promote_at)+' tasks that produced a PR &rarr; contributor'],
     ['Trusted at','~'+esc(p.trusted_at)+' PR tasks, then granted by a maintainer']
@@ -3661,6 +3702,7 @@ async function opsPoll(){
     var res=await fetch('/api/contribute/fleet');
     var data=await res.json();
     syncGrantableAgentRoles(data&&data.policy);
+    syncAssignableAgentRoles(data&&data.policy);
     // Each panel renders independently — one failing does not block the others.
     safeRender('clankers',function(){renderClankers((data&&data.clankers)||[]);});
     safeRender('work',function(){renderWork((data&&data.work)||[]);});
@@ -5272,6 +5314,7 @@ type ContributeAdmissionPolicy struct {
 	DisabledTiers        []string `json:"disabled_tiers,omitempty"`
 	DisabledRepos        []string `json:"disabled_repos,omitempty"`
 	AgentRoleGrantable   []string `json:"agent_role_grantable_roles,omitempty"`
+	AgentRoleAssignable  []string `json:"agent_role_assignable_roles,omitempty"`
 	AutoPromoteAt        int      `json:"auto_promote_at"`
 	TrustedAt            int      `json:"trusted_at"`
 }
@@ -5302,7 +5345,33 @@ func (s *Server) buildContributeAdmissionPolicy() ContributeAdmissionPolicy {
 	p.DisabledTiers = h.DisabledTiers
 	p.DisabledRepos = h.DisabledRepos
 	p.AgentRoleGrantable = contributorAgentRoleGrantableRoles(s.deps.Config)
+	p.AgentRoleAssignable = contributorAgentRoleAssignableRoles(s.deps.Config)
 	return p
+}
+
+func contributorAgentRoleAssignableRoles(cfg *config.Config) []string {
+	roles := []string{"scanner", "quality", "outreach"}
+	if cfg != nil {
+		set := cfg.Hub.ContributeDelegatableRoleSet()
+		for role := range roleClaimNeedsGrant {
+			role = normalizeAgentRole(role)
+			if set[role] {
+				roles = append(roles, role)
+			}
+		}
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(roles))
+	for _, role := range roles {
+		role = normalizeAgentRole(role)
+		if role == "" || role == "supervisor" || seen[role] {
+			continue
+		}
+		seen[role] = true
+		out = append(out, role)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func contributorAgentRoleGrantableRoles(cfg *config.Config) []string {
@@ -5864,7 +5933,6 @@ func (s *Server) handleContributorAgentRoleGrants(w http.ResponseWriter, r *http
 	for _, role := range grantable {
 		allowed[role] = true
 	}
-	seen := map[string]bool{}
 	grants := make([]string, 0, len(req.AgentRoleGrants))
 	for _, role := range req.AgentRoleGrants {
 		role = normalizeAgentRole(role)
@@ -5875,19 +5943,103 @@ func (s *Server) handleContributorAgentRoleGrants(w http.ResponseWriter, r *http
 			jsonError(w, fmt.Sprintf("agent role %q is not a grantable delegated privileged role", role), http.StatusBadRequest)
 			return
 		}
-		if !seen[role] {
-			seen[role] = true
-			grants = append(grants, role)
-		}
+		grants = append(grants, role)
 	}
-	sort.Strings(grants)
+	grants = normalizeUniqueAgentRoles(grants)
+	assigned := effectiveAssignedAgentRole(p.AssignedAgentRole)
+	if roleClaimNeedsGrant[assigned] && !hasAgentRoleGrant(&ContributorProfile{AgentRoleGrants: grants}, assigned) {
+		grants = normalizeUniqueAgentRoles(append(grants, assigned))
+	}
 	p.AgentRoleGrants = grants
 	if err := saveContributorProfile(p); err != nil {
 		jsonError(w, "Failed to save", http.StatusInternalServerError)
 		return
 	}
+	if s.contributeHub != nil {
+		s.contributeHub.SetContributorAgentRoleGrants(p.ContributorID, grants)
+	}
 	s.logger.Info("contributor agent-role grants changed", "username", p.GitHubUsername, "grants", strings.Join(grants, ","))
 	jsonResponse(w, map[string]any{"ok": true, "agent_role_grants": grants, "grantable_roles": grantable})
+}
+
+func (s *Server) handleContributorAgentRole(w http.ResponseWriter, r *http.Request) {
+	if !s.requireContributorWrite(w, r) {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	id := r.PathValue("id")
+	p := findContributor(id)
+	if p == nil {
+		jsonError(w, "Contributor not found", http.StatusNotFound)
+		return
+	}
+	var req struct {
+		AgentRole string `json:"agent_role"`
+		Role      string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	role := normalizeAgentRole(req.AgentRole)
+	if role == "" {
+		role = normalizeAgentRole(req.Role)
+	}
+	if role == "" || role == "none" {
+		p.AssignedAgentRole = "none"
+	} else {
+		probeProfile := *p
+		if roleClaimNeedsGrant[role] && !hasAgentRoleGrant(&probeProfile, role) {
+			probeProfile.AgentRoleGrants = append(probeProfile.AgentRoleGrants, role)
+		}
+		probe := &ContributorConnection{profile: &probeProfile}
+		if s.contributeHub == nil {
+			s.contributeHub = NewContributeWSHub(s.logger, s)
+		}
+		if ok, reason := s.contributeHub.roleClaimAllowed(probe, role); !ok {
+			jsonError(w, reason, http.StatusBadRequest)
+			return
+		}
+		if roleClaimNeedsGrant[role] && !hasAgentRoleGrant(p, role) {
+			p.AgentRoleGrants = append(p.AgentRoleGrants, role)
+			p.AgentRoleGrants = normalizeUniqueAgentRoles(p.AgentRoleGrants)
+		}
+		p.AssignedAgentRole = role
+	}
+	if err := saveContributorProfile(p); err != nil {
+		jsonError(w, "Failed to save", http.StatusInternalServerError)
+		return
+	}
+	if s.contributeHub != nil {
+		s.contributeHub.SetAssignedAgentRole(p.ContributorID, p.AssignedAgentRole, p.AgentRoleGrants)
+	}
+	s.logger.Info("contributor assigned agent role changed", "username", p.GitHubUsername, "assigned_role", p.AssignedAgentRole)
+	var cfg *config.Config
+	if s.deps != nil {
+		cfg = s.deps.Config
+	}
+	jsonResponse(w, map[string]any{
+		"ok":                  true,
+		"assigned_agent_role": p.AssignedAgentRole,
+		"effective_role":      effectiveAssignedAgentRole(p.AssignedAgentRole),
+		"agent_role_grants":   p.AgentRoleGrants,
+		"assignable_roles":    contributorAgentRoleAssignableRoles(cfg),
+	})
+}
+
+func normalizeUniqueAgentRoles(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, role := range in {
+		role = normalizeAgentRole(role)
+		if role == "" || seen[role] {
+			continue
+		}
+		seen[role] = true
+		out = append(out, role)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_contribute_admin_controls_test.go
+++ b/v2/pkg/dashboard/api_contribute_admin_controls_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -43,6 +44,7 @@ func TestOpsTabHasAdminControlsMarkup(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
+
 	body := w.Body.String()
 
 	// Admin controls area + the role gate that only shows it for owner/read-write.
@@ -75,6 +77,10 @@ func TestOpsTabHasAdminControlsMarkup(t *testing.T) {
 		`/trust`,
 		`/revoke`,
 		`data-role="tier"`,
+		`data-role="agent-role"`,
+		`Acting as`,
+		`none (general work)`,
+		`/agent-role`,
 		`data-role="revoke"`,
 		`data-role="remove"`,
 		`data-role="agent-role-add"`,
@@ -140,6 +146,49 @@ func TestOpsTabHasAdminControlsMarkup(t *testing.T) {
 	}
 }
 
+func TestGovernorHubDelegatableRolesUIAndRoundTrip(t *testing.T) {
+	static, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("read static index: %v", err)
+	}
+	body := string(static)
+	for _, want := range []string{
+		"Contributor Agent Roles",
+		"Delegatable to contributors",
+		"toggleDelegatableAgentRole",
+		"contribute_delegatable_roles",
+		"scanner','quality','outreach",
+		"ci-maintainer",
+		"sec-check",
+		"architect",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("Governor Hub agent-role UI missing %q", want)
+		}
+	}
+
+	s, deps := apiServer(t)
+	rec := doPut(s, "/api/config/governor/hub", map[string]any{
+		"contribute_delegatable_roles": []string{"scanner", "quality", "outreach", "sec-check", "supervisor"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /api/config/governor/hub got %d: %s", rec.Code, rec.Body.String())
+	}
+	if deps.Config.Hub.IsContributeRoleDelegatable("supervisor") {
+		t.Fatal("supervisor must not become delegatable")
+	}
+	if !deps.Config.Hub.IsContributeRoleDelegatable("scanner") || !deps.Config.Hub.IsContributeRoleDelegatable("sec-check") {
+		t.Fatalf("delegatable roles not persisted/resolved: %+v", deps.Config.Hub.ContributeDelegatableRoles)
+	}
+	got := doGet(s, "/api/config/governor")
+	if got.Code != http.StatusOK {
+		t.Fatalf("GET governor got %d", got.Code)
+	}
+	if !strings.Contains(got.Body.String(), `"contribute_delegatable_roles"`) || !strings.Contains(got.Body.String(), `"sec-check"`) {
+		t.Fatalf("GET did not round-trip delegatable roles: %s", got.Body.String())
+	}
+}
+
 // contributorWriteCase is one mutation endpoint exercised by the tab.
 type contributorWriteCase struct {
 	name   string
@@ -152,6 +201,7 @@ type contributorWriteCase struct {
 func contributorWriteCases() []contributorWriteCase {
 	return []contributorWriteCase{
 		{"trust", (*Server).handleContributorTrust, http.MethodPut, "/api/contributors/alice/trust", `{"tier":"trusted"}`},
+		{"agent_role", (*Server).handleContributorAgentRole, http.MethodPut, "/api/contributors/alice/agent-role", `{"agent_role":"scanner"}`},
 		{"agent_role_grants", (*Server).handleContributorAgentRoleGrants, http.MethodPut, "/api/contributors/alice/agent-role-grants", `{"agent_role_grants":["ci-maintainer"]}`},
 		{"revoke", (*Server).handleContributorRevoke, http.MethodPost, "/api/contributors/alice/revoke", ``},
 		{"requeue", (*Server).handleContributorRequeue, http.MethodPost, "/api/contributors/alice/requeue", ``},

--- a/v2/pkg/dashboard/contribute_agent_role_assignment_test.go
+++ b/v2/pkg/dashboard/contribute_agent_role_assignment_test.go
@@ -1,0 +1,209 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func seedAssignableRoleConfig(deps *Dependencies) {
+	deps.Config.Agents["scanner"] = config.AgentConfig{Role: "scanner", Enabled: true}
+	deps.Config.Agents["quality"] = config.AgentConfig{Role: "quality", Enabled: true, LaneKeywords: []string{"quality"}}
+	deps.Config.Agents["ci-maintainer"] = config.AgentConfig{Role: "ci-maintainer", Enabled: true}
+	deps.Config.Hub.ContributeDelegatableRoles = []string{"scanner", "quality", "outreach", "ci-maintainer"}
+}
+
+func putAssignedRole(t *testing.T, s *Server, id, role string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/contributors/"+id+"/agent-role", strings.NewReader(`{"agent_role":"`+role+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestContributorAgentRoleAssignmentValidationAndPersistence(t *testing.T) {
+	setupContributeEnv(t)
+	if err := saveContributorProfile(&ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "trusted"}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s, deps := apiServer(t)
+	seedAssignableRoleConfig(deps)
+
+	deps.Config.Hub.ContributeDelegatableRoles = []string{"scanner", "quality", "outreach"}
+	rec := putAssignedRole(t, s, "c-alice", "ci-maintainer")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("allow-list off got %d, want 400", rec.Code)
+	}
+
+	deps.Config.Hub.ContributeDelegatableRoles = []string{"scanner", "quality", "outreach", "ci-maintainer"}
+	p := findContributor("c-alice")
+	p.TrustTier = "contributor"
+	if err := saveContributorProfile(p); err != nil {
+		t.Fatalf("save tier: %v", err)
+	}
+	rec = putAssignedRole(t, s, "c-alice", "ci-maintainer")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("tier too low got %d, want 400", rec.Code)
+	}
+
+	p = findContributor("c-alice")
+	p.TrustTier = "trusted"
+	if err := saveContributorProfile(p); err != nil {
+		t.Fatalf("save trusted: %v", err)
+	}
+	rec = putAssignedRole(t, s, "c-alice", "supervisor")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("supervisor got %d, want 400", rec.Code)
+	}
+
+	rec = putAssignedRole(t, s, "c-alice", "ci-maintainer")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign ci-maintainer got %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	p = findContributor("c-alice")
+	if p.AssignedAgentRole != "ci-maintainer" || !hasAgentRoleGrant(p, "ci-maintainer") {
+		t.Fatalf("assignment did not persist with auto-grant: %+v", p)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/contributors/c-alice/agent-role-grants", strings.NewReader(`{"agent_role_grants":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
+	rec = httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("grant replacement got %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if p = findContributor("c-alice"); !hasAgentRoleGrant(p, "ci-maintainer") {
+		t.Fatalf("active privileged assignment lost its required grant: %+v", p)
+	}
+
+	rec = putAssignedRole(t, s, "c-alice", "none")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear-to-none got %d, want 200", rec.Code)
+	}
+	p = findContributor("c-alice")
+	if p.AssignedAgentRole != "none" {
+		t.Fatalf("clear-to-none persisted %q, want none", p.AssignedAgentRole)
+	}
+}
+
+func TestOwnerAssignmentPrecedenceAndReconnect(t *testing.T) {
+	setupContributeEnv(t)
+	token := "tok-" + randomHex(8)
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername:    "alice",
+		ContributorID:     "c-alice",
+		RegistrationToken: sha256Hex(token),
+		TrustTier:         "contributor",
+		AssignedAgentRole: "scanner",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s, deps := apiServer(t)
+	seedAssignableRoleConfig(deps)
+	ts := httptest.NewServer(s.mux)
+	defer ts.Close()
+
+	dial := func(role string) (*websocket.Conn, WSMessage) {
+		t.Helper()
+		conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		if msg := readMsg(t, conn); msg.Type != "auth_challenge" {
+			t.Fatalf("challenge = %+v", msg)
+		}
+		if err := conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: token, CLIBackend: "claude", Model: "sonnet", Role: role}); err != nil {
+			t.Fatalf("auth write: %v", err)
+		}
+		return conn, readMsg(t, conn)
+	}
+
+	conn, auth := dial("quality")
+	if auth.Type != "auth_ok" || auth.Role != "scanner" {
+		t.Fatalf("owner assignment should beat client claim, got %+v", auth)
+	}
+	snap := s.contributeHub.FleetSnapshot()
+	if len(snap.Clankers) != 1 || snap.Clankers[0].Role != "scanner" || snap.Clankers[0].ClientRole != "quality" || !strings.Contains(snap.Clankers[0].RoleMismatch, "client requested quality") {
+		t.Fatalf("fleet mismatch fields not surfaced: %+v", snap.Clankers)
+	}
+	conn.Close()
+
+	conn2, auth2 := dial("")
+	defer conn2.Close()
+	if auth2.Type != "auth_ok" || auth2.Role != "scanner" {
+		t.Fatalf("persisted owner assignment not used on reconnect: %+v", auth2)
+	}
+}
+
+func TestAssignedRoleAppliesNextTaskNotCurrent(t *testing.T) {
+	hub, _ := roleTestHub(t)
+	setStatusIssues(hub.server,
+		map[string]any{"number": float64(1), "title": "ordinary bug", "author": "bob"},
+		map[string]any{"number": float64(2), "title": "quality regression", "author": "bob", "labels": []any{"quality"}, "lane": "quality"},
+	)
+	conn := &ContributorConnection{
+		profile:      &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "contributor"},
+		role:         "scanner",
+		assignedRole: "scanner",
+		currentTask:  &WSTaskAssign{TaskID: "old", Role: "scanner", Repo: "myorg/repo1", Number: 1, Title: "ordinary bug"},
+		lastPong:     time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["c"] = conn
+	hub.mu.Unlock()
+
+	hub.SetAssignedAgentRole("c-alice", "quality", nil)
+	if conn.currentTask == nil || conn.currentTask.Role != "scanner" {
+		t.Fatalf("in-flight task was rewritten: %+v", conn.currentTask)
+	}
+	conn.mu.Lock()
+	conn.currentTask = nil
+	conn.mu.Unlock()
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.Role != "quality" || msg.Number != 2 {
+		b, _ := json.Marshal(msg)
+		t.Fatalf("next task did not use new role: %s", b)
+	}
+}
+
+func TestAgentRoleGrantUpdateSyncsLiveConnection(t *testing.T) {
+	setupContributeEnv(t)
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "trusted", AgentRoleGrants: []string{"ci-maintainer"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s, deps := apiServer(t)
+	seedAssignableRoleConfig(deps)
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "trusted", AgentRoleGrants: []string{"ci-maintainer"}},
+		role:     "ci-maintainer",
+		lastPong: time.Now(),
+	}
+	s.contributeHub.mu.Lock()
+	s.contributeHub.connections["live"] = conn
+	s.contributeHub.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/contributors/c-alice/agent-role-grants", strings.NewReader(`{"agent_role_grants":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-Role", "owner")
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("grant replacement got %d: %s", rec.Code, rec.Body.String())
+	}
+	if hasAgentRoleGrant(conn.profile, "ci-maintainer") {
+		t.Fatalf("live connection kept removed privileged grant: %+v", conn.profile.AgentRoleGrants)
+	}
+	if ok, _ := s.contributeHub.roleClaimAllowed(conn, "ci-maintainer"); ok {
+		t.Fatal("live connection can still claim removed privileged role")
+	}
+}

--- a/v2/pkg/dashboard/contribute_agent_roles.go
+++ b/v2/pkg/dashboard/contribute_agent_roles.go
@@ -32,6 +32,18 @@ func normalizeAgentRole(role string) string {
 	return strings.ToLower(strings.TrimSpace(role))
 }
 
+func effectiveAssignedAgentRole(assigned string) string {
+	assigned = normalizeAgentRole(assigned)
+	if assigned == "none" {
+		return ""
+	}
+	return assigned
+}
+
+func hasOwnerAgentRoleAssignment(profile *ContributorProfile) bool {
+	return profile != nil && normalizeAgentRole(profile.AssignedAgentRole) != ""
+}
+
 func hasAgentRoleGrant(profile *ContributorProfile, role string) bool {
 	if profile == nil {
 		return false

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -71,13 +71,15 @@ var wsUpgrader = websocket.Upgrader{
 }
 
 type ContributorConnection struct {
-	ws          *websocket.Conn
-	profile     *ContributorProfile
-	cliBackend  string
-	model       string
-	role        string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
-	connectedAt time.Time
-	currentTask *WSTaskAssign
+	ws           *websocket.Conn
+	profile      *ContributorProfile
+	cliBackend   string
+	model        string
+	role         string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
+	clientRole   string // relay-requested HIVE_AGENT_ROLE; owner assignment may override it
+	assignedRole string // owner-selected role; "none" forces general work
+	connectedAt  time.Time
+	currentTask  *WSTaskAssign
 	// currentTaskGen is the assignment GENERATION stamped on currentTask (kubestellar/
 	// hive#2568, the Gate). It is a monotonically increasing token minted per
 	// assignment (task_assign, and the task_progress RESUME path that adopts a task).
@@ -176,6 +178,7 @@ type WSMessage struct {
 	TrustTier         string   `json:"trust_tier,omitempty"`
 	Permissions       []string `json:"permissions,omitempty"`
 	Reason            string   `json:"reason,omitempty"`
+	Message           string   `json:"message,omitempty"`
 	RegistrationToken string   `json:"registration_token,omitempty"`
 	CLIBackend        string   `json:"cli_backend,omitempty"`
 	Model             string   `json:"model,omitempty"`
@@ -1314,6 +1317,72 @@ func (h *ContributeWSHub) RoleBreakdown() map[string]int {
 	return breakdown
 }
 
+func (h *ContributeWSHub) SetAssignedAgentRole(contributorID, assignedRole string, grants []string) {
+	if h == nil || contributorID == "" {
+		return
+	}
+	assignedRole = normalizeAgentRole(assignedRole)
+	effectiveRole := effectiveAssignedAgentRole(assignedRole)
+	h.mu.RLock()
+	var targets []*ContributorConnection
+	for _, c := range h.connections {
+		c.mu.Lock()
+		matches := c.profile != nil && (c.profile.ContributorID == contributorID || strings.EqualFold(c.profile.GitHubUsername, contributorID))
+		c.mu.Unlock()
+		if matches {
+			targets = append(targets, c)
+		}
+	}
+	h.mu.RUnlock()
+	for _, c := range targets {
+		c.mu.Lock()
+		if c.profile != nil {
+			c.profile.AssignedAgentRole = assignedRole
+			c.profile.AgentRoleGrants = append([]string(nil), grants...)
+		}
+		c.assignedRole = assignedRole
+		c.role = effectiveRole
+		c.mu.Unlock()
+		label := effectiveRole
+		if label == "" {
+			label = "general work"
+		}
+		msg := fmt.Sprintf("role assigned: %s — your next task will be %s", label, label)
+		if effectiveRole != "" {
+			msg = fmt.Sprintf("role assigned: %s — your next task will be %s work", effectiveRole, effectiveRole)
+		}
+		if c.ws != nil {
+			if err := c.send(WSMessage{Type: "notice", Seq: h.nextSeq(), Message: msg}); err != nil {
+				h.logger.Warn("[contribute-ws] failed to send role assignment notice", "error", err)
+			}
+		}
+	}
+}
+
+func (h *ContributeWSHub) SetContributorAgentRoleGrants(contributorID string, grants []string) {
+	if h == nil || contributorID == "" {
+		return
+	}
+	h.mu.RLock()
+	var targets []*ContributorConnection
+	for _, c := range h.connections {
+		c.mu.Lock()
+		matches := c.profile != nil && (c.profile.ContributorID == contributorID || strings.EqualFold(c.profile.GitHubUsername, contributorID))
+		c.mu.Unlock()
+		if matches {
+			targets = append(targets, c)
+		}
+	}
+	h.mu.RUnlock()
+	for _, c := range targets {
+		c.mu.Lock()
+		if c.profile != nil {
+			c.profile.AgentRoleGrants = append([]string(nil), grants...)
+		}
+		c.mu.Unlock()
+	}
+}
+
 // FleetClanker is a read-only view of one connected contributor ("clanker")
 // session as the operator-facing Management & Operations tab renders it. It
 // carries only what the contributor handshake already put on the wire plus the
@@ -1324,6 +1393,9 @@ type FleetClanker struct {
 	CLIBackend     string        `json:"cli_backend,omitempty"`
 	Model          string        `json:"model,omitempty"`
 	Role           string        `json:"role,omitempty"`
+	ClientRole     string        `json:"client_role,omitempty"`
+	AssignedRole   string        `json:"assigned_agent_role,omitempty"`
+	RoleMismatch   string        `json:"role_mismatch,omitempty"`
 	TrustTier      string        `json:"trust_tier,omitempty"`
 	ConnectedAt    string        `json:"connected_at,omitempty"`
 	LastActivity   string        `json:"last_activity,omitempty"`
@@ -1408,9 +1480,18 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 			CLIBackend:   c.cliBackend,
 			Model:        c.model,
 			Role:         c.role,
+			ClientRole:   c.clientRole,
+			AssignedRole: c.assignedRole,
 			ConnectedAt:  c.connectedAt.UTC().Format(time.RFC3339),
 			LastActivity: c.lastPong.UTC().Format(time.RFC3339),
 			Stale:        time.Since(c.lastPong) > wsHeartbeatTimeout,
+		}
+		if c.assignedRole != "" && normalizeAgentRole(c.clientRole) != "" && normalizeAgentRole(c.clientRole) != effectiveAssignedAgentRole(c.assignedRole) {
+			if c.assignedRole == "none" {
+				fc.RoleMismatch = fmt.Sprintf("client requested %s; owner assigned general work", c.clientRole)
+			} else {
+				fc.RoleMismatch = fmt.Sprintf("client requested %s; owner assigned %s", c.clientRole, c.assignedRole)
+			}
 		}
 		// #2547: surface the client-declared capabilities read-only (a copy so the
 		// snapshot never aliases live connection state). Nil for unversioned clients.
@@ -1583,13 +1664,15 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	for _, c := range h.connections {
 		c.mu.Lock()
 		out = append(out, ContributorConnection{
-			profile:     c.profile,
-			cliBackend:  c.cliBackend,
-			model:       c.model,
-			role:        c.role,
-			connectedAt: c.connectedAt,
-			currentTask: c.currentTask,
-			tmuxOutput:  append([]string{}, c.tmuxOutput...),
+			profile:      c.profile,
+			cliBackend:   c.cliBackend,
+			model:        c.model,
+			role:         c.role,
+			clientRole:   c.clientRole,
+			assignedRole: c.assignedRole,
+			connectedAt:  c.connectedAt,
+			currentTask:  c.currentTask,
+			tmuxOutput:   append([]string{}, c.tmuxOutput...),
 		})
 		c.mu.Unlock()
 	}
@@ -1735,7 +1818,12 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			requestedRole := normalizeAgentRole(msg.Role)
+			clientRole := normalizeAgentRole(msg.Role)
+			assignedRole := normalizeAgentRole(profile.AssignedAgentRole)
+			requestedRole := clientRole
+			if hasOwnerAgentRoleAssignment(profile) {
+				requestedRole = effectiveAssignedAgentRole(assignedRole)
+			}
 			probeContributor := &ContributorConnection{profile: profile}
 			if requestedRole != "" {
 				if ok, reason := h.roleClaimAllowed(probeContributor, requestedRole); !ok {
@@ -1758,8 +1846,8 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if profile.AvatarURL == "" {
 				profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
 			}
-			if requestedRole != "" {
-				profile.PreferredRole = requestedRole
+			if clientRole != "" {
+				profile.PreferredRole = clientRole
 			}
 			_ = saveContributorProfile(profile)
 
@@ -1788,6 +1876,8 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				cliBackend:   msg.CLIBackend,
 				model:        msg.Model,
 				role:         requestedRole,
+				clientRole:   clientRole,
+				assignedRole: assignedRole,
 				connectedAt:  time.Now(),
 				lastPong:     time.Now(),
 				capabilities: caps,

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -15827,6 +15827,8 @@ function burnAreaChart() {
       const denyAuthors = (hub.contribute_deny_authors || []);
       const allowModels = (hub.contribute_allow_models || []);
       const rejectUnknownModels = hub.contribute_reject_unknown_models || false;
+      const delegatableRoles = (hub.contribute_delegatable_roles || ['scanner','quality','outreach']).map(function(r) { return String(r || '').toLowerCase(); });
+      const privilegedDelegatableRoles = ['ci-maintainer', 'sec-check', 'architect'];
       // Filter modes: 'allow' = only matching pass; 'deny' (default) = matching skipped.
       const titlesMode = (hub.contribute_titles_mode === 'allow') ? 'allow' : 'deny';
       const authorsMode = (hub.contribute_authors_mode === 'allow') ? 'allow' : 'deny';
@@ -15896,6 +15898,19 @@ function burnAreaChart() {
         <div class="config-field" style="margin-left:44px" ${hub.contribute_cooldown_enabled ? '' : 'title="Enable Task Cooldown to edit the period"'}>
           <label>Cooldown Period (hours) <span class="config-info">i<span class="config-tooltip">The with-PR completion cooldown, in hours. 168 = one week (default). Range 1–8760.</span></span></label>
           <input type="number" id="hub-cooldown-hours" min="1" max="8760" value="${hub.contribute_cooldown_hours || 168}" onchange="markDirty('hub','contribute_cooldown_hours',parseInt(this.value,10)||168)" ${hub.contribute_cooldown_enabled ? '' : 'disabled style="opacity:0.5"'}>
+        </div>
+
+        <div class="config-field">
+          <label>Contributor Agent Roles <span class="config-info">i<span class="config-tooltip">Default roles scanner, quality, and outreach are always delegatable. Check privileged roles to let owners assign them from a clanker's card; supervisor is never delegatable.</span></span></label>
+          <div style="display:flex;flex-direction:column;gap:6px">
+            ${['scanner','quality','outreach'].map(function(r) {
+              return '<label style="display:flex;align-items:center;gap:8px;font-size:0.78rem;color:var(--muted)" title="Default contributor role; always delegatable"><input type="checkbox" checked disabled> ' + r + ' <span style="font-size:0.65rem;color:var(--green)">always on</span></label>';
+            }).join('')}
+            ${privilegedDelegatableRoles.map(function(r) {
+              const checked = delegatableRoles.includes(r);
+              return '<label style="display:flex;align-items:center;gap:8px;font-size:0.78rem"><input type="checkbox" ' + (checked ? 'checked ' : '') + 'onchange="toggleDelegatableAgentRole(\'' + r + '\',this.checked)"> ' + r + ' <span style="font-size:0.65rem;color:var(--muted)">Delegatable to contributors</span></label>';
+            }).join('')}
+          </div>
         </div>
 
         ${renderFilterWithMode({
@@ -16018,6 +16033,19 @@ function burnAreaChart() {
         hoursInput.disabled = !isOn;
         hoursInput.style.opacity = isOn ? '1' : '0.5';
       }
+    }
+
+    function toggleDelegatableAgentRole(role, enabled) {
+      var hub = (_configState.data && _configState.data.hub) || {};
+      var base = ['scanner', 'quality', 'outreach'];
+      var roles = (hub.contribute_delegatable_roles || base).map(function(r) { return String(r || '').toLowerCase(); });
+      base.forEach(function(r) { if (!roles.includes(r)) roles.push(r); });
+      role = String(role || '').toLowerCase();
+      roles = roles.filter(function(r) { return r && r !== 'supervisor' && (enabled || r !== role); });
+      if (enabled && role && !roles.includes(role)) roles.push(role);
+      roles.sort();
+      hub.contribute_delegatable_roles = roles;
+      markDirty('hub', 'contribute_delegatable_roles', roles);
     }
 
     // renderFilterWithMode renders one contribute filter as a mode toggle


### PR DESCRIPTION
## Summary
- add owner-only PUT /api/contributors/{id}/agent-role for persisted live clanker role assignment, clear-to-none, grant auto-add, client-claim precedence, and relay notices
- add Acting as dropdown on connected clanker rows and mismatch tooltip for ignored client HIVE_AGENT_ROLE claims
- add Governor Config → Hub delegatable privileged role checkboxes persisted through /api/config/governor/hub

## Validation
- cd v2 && go build ./... && go vet ./... && go test ./pkg/dashboard/ ./pkg/config/ -count=1
- node --test bin/contributor-relay.test.js