### PR TITLE
[sec-check] fix: remove dangerous default-to-owner fallback in backup_api.go role check

### DIFF
--- a/v2/pkg/dashboard/backup_api.go
+++ b/v2/pkg/dashboard/backup_api.go
@@ -33,7 +33,8 @@ const backupBuildTimeout = spokebackup.BuildTimeout
 func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
-		role = "owner"
+		http.Error(w, "X-Hive-Role header required", http.StatusUnauthorized)
+		return
 	}
 	if role != "owner" {
 		jsonError(w, "owner access required", http.StatusForbidden)
@@ -57,7 +58,8 @@ func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleBackupDownload(w http.ResponseWriter, r *http.Request) {
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
-		role = "owner"
+		http.Error(w, "X-Hive-Role header required", http.StatusUnauthorized)
+		return
 	}
 	if role != "owner" {
 		jsonError(w, "only the owner can back up this hive", http.StatusForbidden)


### PR DESCRIPTION
## Security Fix

Removes the dangerous `if role == "" { role = "owner" }` fallback in `backup_api.go`.

Previously, any HTTP client that omitted the `X-Hive-Role` header was silently treated as an owner, allowing unauthorized access to hive backups which contain GitHub App private keys and spoke credentials.

After this fix, the backup endpoint returns 401 Unauthorized when the header is absent, eliminating the privilege escalation.

Fixes #2998

---
*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*