### PR TITLE
✨ feat(snapshot): allowlisted frame-ancestors for the public snapshot page

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"net/netip"
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2105,6 +2107,12 @@ type DashboardConfig struct {
 	SnapshotDir        string `yaml:"snapshot_dir"`
 	AuthToken          string `yaml:"auth_token"`
 	AgentPollIntervalS int    `yaml:"agent_poll_interval_s"`
+	// SnapshotFrameAncestors is the explicit set of HTTPS origins allowed to
+	// embed the public, read-only /snapshot document. Empty keeps the historical
+	// fail-closed framing policy (X-Frame-Options: DENY plus CSP
+	// frame-ancestors 'none'). Wildcards and paths are deliberately rejected so
+	// the configured value is a small, auditable origin allowlist.
+	SnapshotFrameAncestors []string `yaml:"snapshot_frame_ancestors,omitempty" json:"snapshot_frame_ancestors,omitempty"`
 	// AuthorizedUsers is the allowlist of GitHub usernames permitted to log in
 	// to a direct-route (non-hub-proxied) spoke via the device flow. The first
 	// entry is treated as the owner (read-write); the rest are granted viewers
@@ -2127,6 +2135,63 @@ type DashboardConfig struct {
 	// wrongly forced into direct-route mode (which broke their dashboard link and
 	// snapshot preview) the moment they were granted an authorized_users list.
 	HubProxied bool `yaml:"hub_proxied"`
+}
+
+var snapshotFrameAncestorHostPattern = regexp.MustCompile(`(?i)^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*\.?$`)
+
+// ValidateSnapshotFrameAncestors validates and normalizes the /snapshot framing
+// allowlist. Only exact HTTPS origins are accepted: scheme + host with optional
+// port, and no path, query, fragment, credentials, or wildcard hostnames.
+func ValidateSnapshotFrameAncestors(origins []string) ([]string, error) {
+	normalized := make([]string, 0, len(origins))
+	seen := map[string]struct{}{}
+	for _, raw := range origins {
+		origin := strings.TrimSpace(raw)
+		if origin == "" {
+			continue
+		}
+		u, err := url.Parse(origin)
+		if err != nil || u.Scheme != "https" || u.Host == "" {
+			return nil, fmt.Errorf("snapshot_frame_ancestors entry %q must be an https origin", raw)
+		}
+		if u.User != nil || (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" || strings.Contains(u.Hostname(), "*") {
+			return nil, fmt.Errorf("snapshot_frame_ancestors entry %q must be an exact https origin with no path, credentials, query, fragment, or wildcard", raw)
+		}
+		if !validSnapshotFrameAncestorHost(u.Hostname()) {
+			return nil, fmt.Errorf("snapshot_frame_ancestors entry %q has an invalid host", raw)
+		}
+		if port := u.Port(); port != "" {
+			n, err := strconv.Atoi(port)
+			if err != nil || n < 1 || n > 65535 {
+				return nil, fmt.Errorf("snapshot_frame_ancestors entry %q has an invalid port", raw)
+			}
+		}
+		origin = "https://" + u.Host
+		if _, ok := seen[origin]; ok {
+			continue
+		}
+		seen[origin] = struct{}{}
+		normalized = append(normalized, origin)
+	}
+	return normalized, nil
+}
+
+func validSnapshotFrameAncestorHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if _, err := netip.ParseAddr(host); err == nil {
+		return true
+	}
+	return snapshotFrameAncestorHostPattern.MatchString(host)
+}
+
+// SnapshotFrameAncestorsCSP returns the CSP source list for /snapshot framing.
+func (d DashboardConfig) SnapshotFrameAncestorsCSP() string {
+	if len(d.SnapshotFrameAncestors) == 0 {
+		return "'none'"
+	}
+	return strings.Join(d.SnapshotFrameAncestors, " ")
 }
 
 // Role strings used for direct-route spoke authorization. These mirror the
@@ -2673,6 +2738,9 @@ func (c *Config) applyDefaults() {
 	if c.Dashboard.AgentPollIntervalS == 0 {
 		c.Dashboard.AgentPollIntervalS = defaultAgentPollIntervalS
 	}
+	if normalized, err := ValidateSnapshotFrameAncestors(c.Dashboard.SnapshotFrameAncestors); err == nil {
+		c.Dashboard.SnapshotFrameAncestors = normalized
+	}
 	if c.Governor.EvalIntervalS == 0 {
 		c.Governor.EvalIntervalS = defaultEvalIntervalS
 	}
@@ -3128,6 +3196,11 @@ func (c *Config) validate() error {
 	}
 	if err := c.Governor.LiteLLM.Validate(); err != nil {
 		return err
+	}
+	if normalized, err := ValidateSnapshotFrameAncestors(c.Dashboard.SnapshotFrameAncestors); err != nil {
+		return err
+	} else {
+		c.Dashboard.SnapshotFrameAncestors = normalized
 	}
 	for modeName, mode := range c.Governor.Modes {
 		for agentName, cadence := range mode.Cadences {

--- a/v2/pkg/config/snapshot_frame_ancestors_test.go
+++ b/v2/pkg/config/snapshot_frame_ancestors_test.go
@@ -1,0 +1,54 @@
+package config
+
+import "testing"
+
+func TestValidateSnapshotFrameAncestors(t *testing.T) {
+	got, err := ValidateSnapshotFrameAncestors([]string{
+		" https://docs.projectbluefin.io ",
+		"https://docs.projectbluefin.io",
+		"https://example.com:8443",
+		"",
+	})
+	if err != nil {
+		t.Fatalf("ValidateSnapshotFrameAncestors returned error: %v", err)
+	}
+	want := []string{"https://docs.projectbluefin.io", "https://example.com:8443"}
+	if len(got) != len(want) {
+		t.Fatalf("normalized origins = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("normalized origins = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestValidateSnapshotFrameAncestorsRejectsUnsafeOrigins(t *testing.T) {
+	tests := []string{
+		"http://docs.projectbluefin.io",
+		"https://docs.projectbluefin.io/factory",
+		"https://*.example.com",
+		"not a url",
+		"https://user:pass@example.com",
+		"https://x'-alert(1)-'",
+		"https://bad_host.example.com",
+		"https://example.com:99999",
+	}
+	for _, origin := range tests {
+		t.Run(origin, func(t *testing.T) {
+			if _, err := ValidateSnapshotFrameAncestors([]string{origin}); err == nil {
+				t.Fatalf("expected %q to be rejected", origin)
+			}
+		})
+	}
+}
+
+func TestDashboardConfigSnapshotFrameAncestorsCSP(t *testing.T) {
+	if got := (DashboardConfig{}).SnapshotFrameAncestorsCSP(); got != "'none'" {
+		t.Fatalf("empty allowlist CSP = %q, want 'none'", got)
+	}
+	cfg := DashboardConfig{SnapshotFrameAncestors: []string{"https://docs.projectbluefin.io"}}
+	if got := cfg.SnapshotFrameAncestorsCSP(); got != "https://docs.projectbluefin.io" {
+		t.Fatalf("allowlist CSP = %q", got)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -52,6 +52,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/backup/status", s.handleBackupStatus)
 	s.mux.HandleFunc("POST /api/backup", s.handleBackupDownload)
 	s.mux.HandleFunc("POST /api/banner-dismissed", s.handleBannerDismissed)
+	s.mux.HandleFunc("GET /api/snapshot/frame-ancestors", s.handleSnapshotFrameAncestors)
 	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)
 	s.mux.HandleFunc("GET /snapshot", s.handleSnapshotPage)
 	s.mux.HandleFunc("GET /api/history", s.handleHistory)
@@ -736,6 +737,14 @@ func (s *Server) handleSnapshotAPI(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=60")
 	json.NewEncoder(w).Encode(status)
+}
+
+func (s *Server) handleSnapshotFrameAncestors(w http.ResponseWriter, r *http.Request) {
+	var origins []string
+	if s.deps != nil && s.deps.Config != nil {
+		origins = s.deps.Config.Dashboard.SnapshotFrameAncestors
+	}
+	jsonResponse(w, map[string]any{"origins": origins})
 }
 
 func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
@@ -3840,6 +3849,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"snapshot_url":                       cfg.Hub.SnapshotURL,
 			"is_public":                          cfg.Hub.IsPublic,
 			"auto_snapshot":                      cfg.Hub.AutoSnapshot,
+			"snapshot_frame_ancestors":           cfg.Dashboard.SnapshotFrameAncestors,
 			"auto_upgrade":                       cfg.Hub.AutoUpgrade,
 			"snapshot_interval_min":              cfg.Hub.SnapshotIntervalMin,
 			"contribute_suspended":               cfg.Hub.ContributeSuspended,
@@ -4292,6 +4302,7 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 		SnapshotURL                    string                     `json:"snapshot_url"`
 		IsPublic                       *bool                      `json:"is_public"`
 		AutoSnapshot                   *bool                      `json:"auto_snapshot"`
+		SnapshotFrameAncestors         []string                   `json:"snapshot_frame_ancestors"`
 		AutoUpgrade                    *bool                      `json:"auto_upgrade"`
 		ContributeSuspended            *bool                      `json:"contribute_suspended"`
 		ContributeTitlesMode           *string                    `json:"contribute_titles_mode"`
@@ -4331,6 +4342,14 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.AutoSnapshot != nil {
 		cfg.Hub.AutoSnapshot = *body.AutoSnapshot
+	}
+	if body.SnapshotFrameAncestors != nil {
+		normalized, err := config.ValidateSnapshotFrameAncestors(body.SnapshotFrameAncestors)
+		if err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		cfg.Dashboard.SnapshotFrameAncestors = normalized
 	}
 	if body.AutoUpgrade != nil {
 		cfg.Hub.AutoUpgrade = *body.AutoUpgrade

--- a/v2/pkg/dashboard/security_headers_test.go
+++ b/v2/pkg/dashboard/security_headers_test.go
@@ -1,0 +1,74 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestSecurityHeadersSnapshotFrameAncestorsMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		ancestors   []string
+		wantFrame   string
+		wantNoXFO   bool
+		wantXFODeny bool
+	}{
+		{
+			name:        "default denies snapshot framing",
+			path:        "/snapshot",
+			wantFrame:   "frame-ancestors 'none'",
+			wantXFODeny: true,
+		},
+		{
+			name:      "allowlist applies to snapshot document only",
+			path:      "/snapshot",
+			ancestors: []string{"https://docs.projectbluefin.io", "https://example.com:8443"},
+			wantFrame: "frame-ancestors https://docs.projectbluefin.io https://example.com:8443",
+			wantNoXFO: true,
+		},
+		{
+			name:        "other routes stay denied with allowlist configured",
+			path:        "/",
+			ancestors:   []string{"https://docs.projectbluefin.io"},
+			wantFrame:   "frame-ancestors 'none'",
+			wantXFODeny: true,
+		},
+		{
+			name:        "snapshot dependencies do not get framing exemption",
+			path:        "/api/snapshot",
+			ancestors:   []string{"https://docs.projectbluefin.io"},
+			wantFrame:   "frame-ancestors 'none'",
+			wantXFODeny: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{deps: &Dependencies{Config: &config.Config{
+				Dashboard: config.DashboardConfig{SnapshotFrameAncestors: tt.ancestors},
+			}}}
+			handler := s.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			csp := rec.Header().Get("Content-Security-Policy")
+			if !strings.Contains(csp, tt.wantFrame) {
+				t.Fatalf("CSP = %q, want to contain %q", csp, tt.wantFrame)
+			}
+			xfo := rec.Header().Get("X-Frame-Options")
+			if tt.wantNoXFO && xfo != "" {
+				t.Fatalf("X-Frame-Options = %q, want omitted", xfo)
+			}
+			if tt.wantXFODeny && xfo != "DENY" {
+				t.Fatalf("X-Frame-Options = %q, want DENY", xfo)
+			}
+		})
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -715,11 +715,22 @@ func (s *Server) Start() error {
 
 func (s *Server) securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Frame-Options", "DENY")
+		frameAncestors := "'none'"
+		snapshotAllowlist := false
+		if r.URL.Path == "/snapshot" && s.deps != nil && s.deps.Config != nil && len(s.deps.Config.Dashboard.SnapshotFrameAncestors) > 0 {
+			frameAncestors = s.deps.Config.Dashboard.SnapshotFrameAncestorsCSP()
+			snapshotAllowlist = true
+		}
+		// X-Frame-Options cannot express an origin allowlist. When /snapshot has
+		// an explicit CSP frame-ancestors allowlist, omit XFO for that document
+		// only; every other route keeps DENY, and an empty allowlist fails closed.
+		if !snapshotAllowlist {
+			w.Header().Set("X-Frame-Options", "DENY")
+		}
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 		w.Header().Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'")
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors "+frameAncestors)
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		next.ServeHTTP(w, r)
 	})

--- a/v2/pkg/dashboard/snapshot_test.go
+++ b/v2/pkg/dashboard/snapshot_test.go
@@ -143,3 +143,25 @@ func TestSnapshotCacheHeaders(t *testing.T) {
 		t.Errorf("expected application/json, got %q", ct)
 	}
 }
+
+func TestSnapshotFrameAncestorsEndpoint(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Dashboard.SnapshotFrameAncestors = []string{"https://docs.projectbluefin.io"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/snapshot/frame-ancestors", nil)
+	w := httptest.NewRecorder()
+	srv.handleSnapshotFrameAncestors(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Origins []string `json:"origins"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(body.Origins) != 1 || body.Origins[0] != "https://docs.projectbluefin.io" {
+		t.Fatalf("origins = %#v", body.Origins)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -15826,6 +15826,7 @@ function burnAreaChart() {
       const denyTitles = (hub.contribute_deny_titles || []);
       const denyAuthors = (hub.contribute_deny_authors || []);
       const allowModels = (hub.contribute_allow_models || []);
+      const frameAncestors = (hub.snapshot_frame_ancestors || []);
       const rejectUnknownModels = hub.contribute_reject_unknown_models || false;
       const delegatableRoles = (hub.contribute_delegatable_roles || ['scanner','quality','outreach']).map(function(r) { return String(r || '').toLowerCase(); });
       const privilegedDelegatableRoles = ['ci-maintainer', 'sec-check', 'architect'];
@@ -15876,6 +15877,12 @@ function burnAreaChart() {
         <div class="config-field">
           <label>Snapshot / Preview URL <span class="config-info">i<span class="config-tooltip">${hub.auto_snapshot ? 'Auto-generated from Dashboard URL. Read-only while auto-publish is on.' : 'Enter a custom preview URL (e.g. your own static dashboard). Sent to hub as the Preview link.'}</span></span></label>
           <input type="text" id="hub-snapshot-url" value="${esc(snapUrl)}" onchange="markDirty('hub','snapshot_url',this.value)" ${hub.auto_snapshot ? 'disabled style="opacity:0.5"' : ''} placeholder="${hub.auto_snapshot ? '' : 'https://your-site.com/dashboard-preview'}">
+        </div>
+        <div class="config-field">
+          <label>Snapshot frame allowlist <span class="config-info">i<span class="config-tooltip">Exact HTTPS origins allowed to embed the public read-only /snapshot page. Empty keeps frame-ancestors 'none' and X-Frame-Options: DENY. X-Frame-Options is omitted for /snapshot only when this allowlist is non-empty because XFO cannot express allowlists.</span></span></label>
+          <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px">${frameAncestors.map(function(o) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(96,165,250,0.15);color:var(--blue);border:1px solid rgba(96,165,250,0.3)">' + esc(o) + ' <span onclick="removeHubFilter(\'snapshot_frame_ancestors\',' + esc(JSON.stringify(o)) + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('') || '<span style="font-size:0.72rem;color:var(--muted)">No origins allowed — /snapshot cannot be framed.</span>'}</div>
+          <textarea rows="3" style="width:100%;font-family:var(--font-mono);font-size:0.72rem;resize:vertical" placeholder="https://docs.projectbluefin.io" onchange="setSnapshotFrameAncestorsFromText(this.value)">${esc(frameAncestors.join('\n'))}</textarea>
+          <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">One exact origin per line: <code>https://host</code> or <code>https://host:port</code>. Paths, http://, credentials, and wildcards are rejected.</span>
         </div>
 
         <hr style="border-color:var(--border);margin:16px 0">
@@ -16130,6 +16137,14 @@ function burnAreaChart() {
       if (!_configState.data.hub || !_configState.data.hub[key]) return;
       _configState.data.hub[key] = _configState.data.hub[key].filter(function(v) { return v !== val; });
       markDirty('hub', key, _configState.data.hub[key]);
+      renderConfigTab('Hub');
+    }
+
+    function setSnapshotFrameAncestorsFromText(value) {
+      const origins = (value || '').split(/\r?\n|,/).map(function(v) { return v.trim(); }).filter(Boolean);
+      if (!_configState.data.hub) _configState.data.hub = {};
+      _configState.data.hub.snapshot_frame_ancestors = origins;
+      markDirty('hub', 'snapshot_frame_ancestors', origins);
       renderConfigTab('Hub');
     }
 

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -14,6 +14,7 @@ const TTYD_PORT = parseInt(process.env.HIVE_TTYD_PORT || '7681', 10);
 const TTYD_URL = `http://127.0.0.1:${TTYD_PORT}`;
 const DASHBOARD_TOKEN = process.env.HIVE_DASHBOARD_TOKEN || '';
 const STATIC_DIR = process.env.HIVE_STATIC_DIR || path.join(__dirname, 'public');
+const SNAPSHOT_FRAME_ANCESTORS_FALLBACK = parseSnapshotFrameAncestors(process.env.HIVE_SNAPSHOT_FRAME_ANCESTORS || '');
 
 if (!DASHBOARD_TOKEN && process.env.NODE_ENV === 'production') {
   console.error('[SECURITY] HIVE_DASHBOARD_TOKEN is not set — all mutations are unauthenticated!');
@@ -22,6 +23,39 @@ if (!DASHBOARD_TOKEN && process.env.NODE_ENV === 'production') {
 
 const app = express();
 app.disable('x-powered-by');
+
+function parseSnapshotFrameAncestors(raw) {
+  const origins = raw.split(/[\s,]+/).map(v => v.trim()).filter(Boolean);
+  const seen = new Set();
+  const dnsHostPattern = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*\.?$/i;
+  const ipHostPattern = /^(?:\d{1,3}\.){3}\d{1,3}$|^\[[0-9a-f:.]+\]$/i;
+  return origins.map((origin) => {
+    let parsed;
+    try {
+      parsed = new URL(origin);
+    } catch {
+      throw new Error(`invalid HIVE_SNAPSHOT_FRAME_ANCESTORS entry ${origin}: expected an https origin`);
+    }
+    if (
+      parsed.protocol !== 'https:' ||
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== '/' ||
+      parsed.search ||
+      parsed.hash ||
+      parsed.hostname.includes('*') ||
+      (!dnsHostPattern.test(parsed.hostname) && !ipHostPattern.test(parsed.hostname)) ||
+      (parsed.port && (Number(parsed.port) < 1 || Number(parsed.port) > 65535))
+    ) {
+      throw new Error(`invalid HIVE_SNAPSHOT_FRAME_ANCESTORS entry ${origin}: expected exact https://host[:port] origin`);
+    }
+    const normalized = `https://${parsed.host}`;
+    if (seen.has(normalized)) return '';
+    seen.add(normalized);
+    return normalized;
+  }).filter(Boolean);
+}
 
 function requireAuth(req, res, next) {
   if (!DASHBOARD_TOKEN) return next();
@@ -36,7 +70,23 @@ function requireAuth(req, res, next) {
   next();
 }
 
-app.use((req, res, next) => {
+async function snapshotFrameAncestors() {
+  try {
+    const headers = {};
+    if (DASHBOARD_TOKEN) headers['X-Hive-Internal'] = DASHBOARD_TOKEN;
+    const resp = await fetch(`${GO_API_URL}/api/snapshot/frame-ancestors`, { headers });
+    if (!resp.ok) return SNAPSHOT_FRAME_ANCESTORS_FALLBACK;
+    const data = await resp.json();
+    return parseSnapshotFrameAncestors((data.origins || []).join(' '));
+  } catch {
+    return SNAPSHOT_FRAME_ANCESTORS_FALLBACK;
+  }
+}
+
+app.use(async (req, res, next) => {
+  const frameAllowlist = req.path === '/snapshot' ? await snapshotFrameAncestors() : [];
+  const snapshotFramingAllowed = frameAllowlist.length > 0;
+  const frameAncestors = snapshotFramingAllowed ? frameAllowlist.join(' ') : "'none'";
   res.setHeader('Content-Security-Policy', [
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' https://cdn.redoc.ly",
@@ -48,10 +98,12 @@ app.use((req, res, next) => {
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
-    "frame-ancestors 'none'",
+    `frame-ancestors ${frameAncestors}`,
   ].join('; '));
   res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader('X-Frame-Options', 'DENY');
+  // X-Frame-Options has no allowlist form; rely on CSP frame-ancestors for the
+  // explicitly allowlisted public /snapshot document, keep DENY everywhere else.
+  if (!snapshotFramingAllowed) res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
   res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
   res.setHeader('Pragma', 'no-cache');

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -11,6 +11,7 @@ const GO_PORT = 19002;
 const TTYD_PORT = 19003;
 
 let goServer, ttydServer, proxyProcess;
+let mockSnapshotFrameAncestors = [];
 
 async function waitForPort(port, timeoutMs = 10000) {
   const start = Date.now();
@@ -43,6 +44,16 @@ function setupMockGoBackend() {
       res.end('{"hub":"online","active_contributors":0,"total_registered":0,"actionable_items":0}');
       return;
     }
+    if (req.url === '/api/snapshot/frame-ancestors') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ origins: mockSnapshotFrameAncestors }));
+      return;
+    }
+    if (req.url === '/snapshot') {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<!doctype html><title>snapshot</title>');
+      return;
+    }
     res.writeHead(404);
     res.end('not found');
   });
@@ -73,7 +84,7 @@ function setupMockTtyd() {
   });
 }
 
-function startProxy() {
+function startProxy(extraEnv = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', ['server.js'], {
       cwd: __dirname,
@@ -85,6 +96,7 @@ function startProxy() {
         HIVE_DASHBOARD_TOKEN: '',
         HIVE_STATIC_DIR: __dirname,
         NODE_ENV: 'test',
+        ...extraEnv,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -105,10 +117,10 @@ function startProxy() {
   });
 }
 
-async function setup() {
+async function setup(extraEnv = {}) {
   goServer = await setupMockGoBackend();
   ttydServer = await setupMockTtyd();
-  proxyProcess = await startProxy();
+  proxyProcess = await startProxy(extraEnv);
   await new Promise(r => setTimeout(r, 500));
 }
 
@@ -156,6 +168,30 @@ async function testHTTPHealth() {
   console.log('  ✓ /api/health returns 200');
 }
 
+async function testDefaultFrameDeny() {
+  const resp = await fetch(`http://localhost:${PROXY_PORT}/snapshot`);
+  assert.equal(resp.status, 200);
+  assert.equal(resp.headers.get('x-frame-options'), 'DENY');
+  assert.match(resp.headers.get('content-security-policy') || '', /frame-ancestors 'none'/);
+  console.log('  ✓ default /snapshot framing is denied');
+}
+
+async function testSnapshotFrameAllowlist() {
+  const resp = await fetch(`http://localhost:${PROXY_PORT}/snapshot`);
+  assert.equal(resp.status, 200);
+  assert.equal(resp.headers.get('x-frame-options'), null);
+  assert.match(resp.headers.get('content-security-policy') || '', /frame-ancestors https:\/\/docs\.projectbluefin\.io/);
+  console.log('  ✓ /snapshot uses CSP frame allowlist without XFO');
+}
+
+async function testOtherRoutesStillDenyFraming() {
+  const resp = await fetch(`http://localhost:${PROXY_PORT}/api/health`);
+  assert.equal(resp.status, 200);
+  assert.equal(resp.headers.get('x-frame-options'), 'DENY');
+  assert.match(resp.headers.get('content-security-policy') || '', /frame-ancestors 'none'/);
+  console.log('  ✓ non-snapshot routes still deny framing');
+}
+
 async function testNoFINError() {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(`ws://localhost:${PROXY_PORT}/api/contribute/ws`);
@@ -193,15 +229,25 @@ async function testNoFINError() {
 console.log('\nProxy WebSocket Tests\n');
 
 try {
+  mockSnapshotFrameAncestors = [];
   await setup();
 
   console.log('HTTP tests:');
   await testHTTPHealth();
   await testHTTPContributeStatus();
+  await testDefaultFrameDeny();
 
   console.log('\nWebSocket tests:');
   await testWSContributeConnect();
   await testNoFINError();
+
+  await teardown();
+  mockSnapshotFrameAncestors = ['https://docs.projectbluefin.io'];
+  await setup();
+
+  console.log('\nFrame allowlist tests:');
+  await testSnapshotFrameAllowlist();
+  await testOtherRoutesStillDenyFraming();
 
   console.log('\n✓ All tests passed\n');
 } catch (e) {


### PR DESCRIPTION
Fixes #3014

## Security notes
- `dashboard.snapshot_frame_ancestors` defaults empty, preserving `X-Frame-Options: DENY` and CSP `frame-ancestors 'none'` everywhere.\n- When configured, only the `/snapshot` document emits the allowlisted CSP `frame-ancestors` and omits X-Frame-Options because XFO cannot express origin allowlists. Other routes and snapshot API/style dependencies remain unframeable.\n- Entries are validated as exact HTTPS origins only: no `http://`, paths, credentials, queries, fragments, or wildcards.\n- Snapshot remains read-only: existing tests cover non-GET methods for `/snapshot` and `/api/snapshot`, and this change adds only header/config behavior.