### PR TITLE
🐛 fix(style): CSS sanitizer preserves custom properties and at-rules, reports what it drops

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -103,9 +103,19 @@ preview accept a shareable custom stylesheet parameter:
 The `@ref` suffix is optional and defaults to the repo's `HEAD`. Hive only
 accepts the `owner/repo/path.css` triplet form, fetches public GitHub raw content
 server-side without credentials, sanitizes CSS, strips external imports/URLs, and
-serves it from same-origin endpoints with a 128 KiB size cap. The sanitizer
-removes legacy executable CSS vectors and CSS escape sequences. Leaderboard CSS
-is scoped to `#tab-leaderboard`; dashboard and snapshot CSS is scoped to
+serves it from same-origin endpoints with a 128 KiB size cap. The sanitizer keeps
+normal declarations including custom properties (`--x`/`var(--x)`), attribute and
+pseudo selectors, gradients, `calc()`/`clamp()`/modern color functions, and the
+recursive at-rules `@media`, `@supports`, `@container`, and `@keyframes`.
+`@font-face` blocks are kept only when every `src` URL is same-origin/relative or
+`data:`. It removes `@import`, external or protocol-relative `url()` fetches,
+CSS escape sequences, `image-set()`, and legacy executable CSS vectors such as
+`expression()`, `behavior`, and `-moz-binding`.
+
+Sanitized style responses include `X-Hive-Style-Dropped: N` when anything was
+removed. Add `&report=1` to `/api/style` or `/api/leaderboard/style` to get JSON
+with the sanitized CSS and a short list of sanitizer reasons. Leaderboard CSS is
+scoped to `#tab-leaderboard`; dashboard and snapshot CSS is scoped to
 `#hive-dashboard-root`, which deliberately leaves login/setup overlays outside
 the custom-theme surface. `/api/style` is public so unauthenticated snapshots can
 load sanitized CSS, and the existing `style-src 'self'` CSP remains sufficient.

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -538,16 +538,22 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	customStyleHeadHTML := ""
 	customStyleNoticeHTML := ""
 	if rawStyle := strings.TrimSpace(r.URL.Query().Get("style")); rawStyle != "" {
-		if _, src, err := getLeaderboardCustomStyle(r.Context(), rawStyle); err == nil {
+		if _, src, report, err := getCustomStyle(r.Context(), rawStyle, customStyleScopeLeaderboard); err == nil {
 			styleKey := leaderboardCustomStyleCacheKey(src)
 			escapedSrc := html.EscapeString(styleKey)
 			styleKeyJSON, _ := json.Marshal(styleKey)
+			droppedJSON, _ := json.Marshal(report.Dropped)
 			customStyleHeadHTML = fmt.Sprintf(
-				`<link id="leaderboard-custom-style-link" rel="stylesheet" href="/api/leaderboard/style?src=%s"><script>window.HIVE_LEADERBOARD_CUSTOM_STYLE_SRC=%s;</script>`,
+				`<link id="leaderboard-custom-style-link" rel="stylesheet" href="/api/leaderboard/style?src=%s"><script>window.HIVE_LEADERBOARD_CUSTOM_STYLE_SRC=%s;window.HIVE_LEADERBOARD_CUSTOM_STYLE_DROPPED=%s;</script>`,
 				url.QueryEscape(styleKey),
 				string(styleKeyJSON),
+				string(droppedJSON),
 			)
-			customStyleNoticeHTML = fmt.Sprintf(`<div class="lb-custom-style-note" id="leaderboard-custom-style-note" role="status">Custom style active: <code>%s</code></div>`, escapedSrc)
+			if report.Dropped > 0 {
+				customStyleNoticeHTML = fmt.Sprintf(`<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status" title="Some CSS was removed because it can fetch external resources, uses unsupported at-rules, or contains legacy executable CSS.">Custom style active: <code>%s</code> (%d rules removed by sanitizer)</div>`, escapedSrc, report.Dropped)
+			} else {
+				customStyleNoticeHTML = fmt.Sprintf(`<div class="lb-custom-style-note" id="leaderboard-custom-style-note" role="status">Custom style active: <code>%s</code></div>`, escapedSrc)
+			}
 		} else {
 			customStyleNoticeHTML = `<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status">Custom style could not be loaded — using default <button type="button" onclick="this.parentElement.remove()">Dismiss</button></div>`
 		}
@@ -2593,7 +2599,11 @@ function renderMeCard(mount,p){
   for(var i=1;i<=ME_STYLE_COUNT;i++){
     styleOpts+='<option value="'+i+'"'+(!customStyleSrc&&i===styleN?' selected':'')+'>'+esc(ME_STYLE_NAMES[i-1]||('Style '+i))+'</option>';
   }
-  if(customStyleSrc)styleOpts+='<option value="custom" selected>Custom ('+esc(leaderboardCustomStyleLabel(customStyleSrc))+')</option>';
+  if(customStyleSrc){
+    var dropped=parseInt(window.HIVE_LEADERBOARD_CUSTOM_STYLE_DROPPED||'0',10)||0;
+    var customLabel=dropped>0?('Custom ('+dropped+' rules removed by sanitizer)'):('Custom ('+leaderboardCustomStyleLabel(customStyleSrc)+')');
+    styleOpts+='<option value="custom" selected title="'+esc(dropped>0?'Some CSS was removed by the sanitizer; see Custom CSS help.':leaderboardCustomStyleLabel(customStyleSrc))+'">'+esc(customLabel)+'</option>';
+  }
 
   var html=''
   +'<div class="me-card me-card--style'+styleN+'" id="me-card">'
@@ -2622,7 +2632,7 @@ function renderMeCard(mount,p){
     +'<div class="info-pop custom-css-pop" id="custom-css-info-pop" role="tooltip" hidden><h4>Custom CSS</h4>'
     +'Use <code>?style=owner/repo/path/theme.css@ref</code> to load a theme. Example:'
     +'<input class="custom-css-example" readonly aria-label="Custom CSS example" value="?style=castrojo/themes/lb/bluefin.css@main" onclick="this.select()">'
-    +'Omit <code>@ref</code> to use the repo&rsquo;s <code>HEAD</code>. Public GitHub repos only; CSS is sanitized server-side and capped at <code>128 KiB</code>. The same param works on <code>/</code> and <code>/snapshot</code>.</div></span>'
+    +'Omit <code>@ref</code> to use the repo&rsquo;s <code>HEAD</code>. Public GitHub repos only; CSS is sanitized server-side and capped at <code>128 KiB</code>. Allowed: custom properties, attribute and pseudo selectors, <code>calc()</code>/<code>clamp()</code>/gradients, and <code>@media</code>, <code>@supports</code>, <code>@container</code>, <code>@keyframes</code>. <code>@font-face</code> is kept only with same-origin or <code>data:</code> sources. Removed: <code>@import</code>, external <code>url()</code> fetches, CSS escapes, and legacy executable CSS. Add <code>&amp;report=1</code> to the style API URL for sanitizer details. The same param works on <code>/</code> and <code>/snapshot</code>.</div></span>'
   +'</div>'
   +meInviteSection(p)
   +'</div></div>';

--- a/v2/pkg/dashboard/api_leaderboard_style.go
+++ b/v2/pkg/dashboard/api_leaderboard_style.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,7 +40,13 @@ type customStyleSource struct {
 
 type customStyleCacheEntry struct {
 	css       []byte
+	report    customStyleSanitizeReport
 	expiresAt time.Time
+}
+
+type customStyleSanitizeReport struct {
+	Dropped int      `json:"dropped"`
+	Reasons []string `json:"reasons,omitempty"`
 }
 
 var (
@@ -53,7 +60,6 @@ var (
 	githubRepoNameRE  = regexp.MustCompile(`^[A-Za-z0-9._-]{1,100}$`)
 	githubRefNameRE   = regexp.MustCompile(`^[A-Za-z0-9._/-]{1,100}$`)
 	githubCSSPathRE   = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
-	cssImportRE       = regexp.MustCompile(`(?is)@import\b[^;]*(;|$)`)
 	cssURLRE          = regexp.MustCompile(`(?is)url\(\s*(['"]?)([^'")]+)['"]?\s*\)`)
 )
 
@@ -146,28 +152,29 @@ func normalizeCustomStyleScope(scope string) (string, string, error) {
 	return scope, root, nil
 }
 
-func getCustomStyle(ctx context.Context, rawSrc, rawScope string) ([]byte, customStyleSource, error) {
+func getCustomStyle(ctx context.Context, rawSrc, rawScope string) ([]byte, customStyleSource, customStyleSanitizeReport, error) {
 	scope, root, err := normalizeCustomStyleScope(rawScope)
 	if err != nil {
-		return nil, customStyleSource{}, err
+		return nil, customStyleSource{}, customStyleSanitizeReport{}, err
 	}
 	src, err := validateCustomStyleSource(rawSrc)
 	if err != nil {
-		return nil, customStyleSource{}, err
+		return nil, customStyleSource{}, customStyleSanitizeReport{}, err
 	}
 	key := customStyleCacheKey(src, scope)
 	now := time.Now()
 	customStyleCacheMu.Lock()
 	if entry, ok := customStyleCache[key]; ok && now.Before(entry.expiresAt) {
 		css := append([]byte(nil), entry.css...)
+		report := entry.report.clone()
 		customStyleCacheMu.Unlock()
-		return css, src, nil
+		return css, src, report, nil
 	}
 	customStyleCacheMu.Unlock()
 
-	css, err := fetchAndSanitizeCustomStyle(ctx, src, root)
+	css, report, err := fetchAndSanitizeCustomStyle(ctx, src, root)
 	if err != nil {
-		return nil, src, err
+		return nil, src, report, err
 	}
 	customStyleCacheMu.Lock()
 	if len(customStyleCache) >= customStyleMaxCache {
@@ -176,84 +183,131 @@ func getCustomStyle(ctx context.Context, rawSrc, rawScope string) ([]byte, custo
 			break
 		}
 	}
-	customStyleCache[key] = customStyleCacheEntry{css: append([]byte(nil), css...), expiresAt: now.Add(customStyleCacheTTL)}
+	customStyleCache[key] = customStyleCacheEntry{css: append([]byte(nil), css...), report: report.clone(), expiresAt: now.Add(customStyleCacheTTL)}
 	customStyleCacheMu.Unlock()
-	return css, src, nil
+	return css, src, report, nil
 }
 
-func fetchAndSanitizeCustomStyle(ctx context.Context, src customStyleSource, scopeRoot string) ([]byte, error) {
+func fetchAndSanitizeCustomStyle(ctx context.Context, src customStyleSource, scopeRoot string) ([]byte, customStyleSanitizeReport, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, customStyleRawURL(src), nil)
 	if err != nil {
-		return nil, err
+		return nil, customStyleSanitizeReport{}, err
 	}
 	resp, err := customStyleClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, customStyleSanitizeReport{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, errCustomStyleNotFound
+		return nil, customStyleSanitizeReport{}, errCustomStyleNotFound
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("style fetch failed")
+		return nil, customStyleSanitizeReport{}, fmt.Errorf("style fetch failed")
 	}
 	ct := strings.ToLower(resp.Header.Get("Content-Type"))
 	if ct != "" && !strings.Contains(ct, "text/css") && !strings.Contains(ct, "text/plain") {
-		return nil, fmt.Errorf("style response is not CSS")
+		return nil, customStyleSanitizeReport{}, fmt.Errorf("style response is not CSS")
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, customStyleMaxBytes+1))
 	if err != nil {
-		return nil, err
+		return nil, customStyleSanitizeReport{}, err
 	}
 	return sanitizeCustomStyle(body, scopeRoot)
 }
 
 var errCustomStyleNotFound = fmt.Errorf("style not found")
 
-func sanitizeCustomStyle(css []byte, scopeRoot string) ([]byte, error) {
+func sanitizeCustomStyle(css []byte, scopeRoot string) ([]byte, customStyleSanitizeReport, error) {
 	if len(css) > customStyleMaxBytes {
-		return nil, fmt.Errorf("style exceeds %d byte limit", customStyleMaxBytes)
+		return nil, customStyleSanitizeReport{}, fmt.Errorf("style exceeds %d byte limit", customStyleMaxBytes)
 	}
-	s := cssImportRE.ReplaceAllString(string(css), "")
-	s = cssURLRE.ReplaceAllStringFunc(s, sanitizeCSSURLToken)
-	var kept []string
-	for _, line := range strings.Split(s, "\n") {
-		lower := strings.ToLower(line)
-		if strings.Contains(line, `\`) {
-			continue
-		}
-		if strings.Contains(lower, "://") || strings.Contains(lower, "image-set(") {
-			continue
-		}
-		if strings.Contains(lower, "expression(") || strings.Contains(lower, "-moz-binding") || strings.Contains(lower, "behavior:") {
-			continue
-		}
-		kept = append(kept, line)
-	}
-	return []byte(scopeCustomStyle(strings.Join(kept, "\n"), scopeRoot)), nil
+	report := customStyleSanitizeReport{}
+	out := parseCustomStyleRules(stripCSSComments(string(css)), scopeRoot, &report)
+	return []byte(out), report, nil
 }
 
-func scopeCustomStyle(css, scopeRoot string) string {
+func (r customStyleSanitizeReport) clone() customStyleSanitizeReport {
+	out := customStyleSanitizeReport{Dropped: r.Dropped}
+	if len(r.Reasons) > 0 {
+		out.Reasons = append([]string(nil), r.Reasons...)
+	}
+	return out
+}
+
+func (r *customStyleSanitizeReport) drop(reason string) {
+	r.Dropped++
+	if len(r.Reasons) < 25 {
+		r.Reasons = append(r.Reasons, reason)
+	}
+}
+
+func stripCSSComments(css string) string {
 	var out strings.Builder
-	remaining := css
-	for {
-		open := strings.Index(remaining, "{")
-		if open < 0 {
+	for i := 0; i < len(css); {
+		if i+1 < len(css) && css[i] == '/' && css[i+1] == '*' {
+			i += 2
+			for i+1 < len(css) && !(css[i] == '*' && css[i+1] == '/') {
+				if css[i] == '\n' {
+					out.WriteByte('\n')
+				}
+				i++
+			}
+			if i+1 < len(css) {
+				i += 2
+			}
+			continue
+		}
+		out.WriteByte(css[i])
+		i++
+	}
+	return out.String()
+}
+
+func parseCustomStyleRules(css, scopeRoot string, report *customStyleSanitizeReport) string {
+	var out strings.Builder
+	for i := 0; i < len(css); {
+		i = skipCSSSpace(css, i)
+		if i >= len(css) {
 			break
 		}
-		selector := strings.TrimSpace(remaining[:open])
-		remaining = remaining[open+1:]
-		close := strings.Index(remaining, "}")
-		if close < 0 {
+		if css[i] == '@' {
+			next, rule := sanitizeCustomAtRule(css, i, scopeRoot, report)
+			if rule != "" {
+				out.WriteString(rule)
+				out.WriteByte('\n')
+			}
+			if next <= i {
+				break
+			}
+			i = next
+			continue
+		}
+		headerEnd := findCSSControl(css, i)
+		if headerEnd < 0 || css[headerEnd] != '{' {
 			break
 		}
-		body := remaining[:close]
-		remaining = remaining[close+1:]
-		if selector == "" || strings.Contains(selector, "@") {
+		selector := strings.TrimSpace(css[i:headerEnd])
+		body, next, ok := readCSSBlock(css, headerEnd)
+		if !ok {
+			break
+		}
+		i = next
+		if selector == "" {
+			report.drop("empty selector")
+			continue
+		}
+		if strings.Contains(selector, `\`) {
+			report.drop("CSS escape sequence")
 			continue
 		}
 		scoped := scopeCustomStyleSelectors(selector, scopeRoot)
 		if scoped == "" {
+			report.drop("empty selector")
+			continue
+		}
+		body = sanitizeCSSDeclarations(body, report, sanitizeCSSOptions{})
+		if strings.TrimSpace(body) == "" {
+			report.drop("empty rule")
 			continue
 		}
 		out.WriteString(scoped)
@@ -264,23 +318,345 @@ func scopeCustomStyle(css, scopeRoot string) string {
 	return out.String()
 }
 
+func sanitizeCustomAtRule(css string, start int, scopeRoot string, report *customStyleSanitizeReport) (int, string) {
+	headerEnd := findCSSControl(css, start)
+	if headerEnd < 0 {
+		report.drop("unterminated at-rule")
+		return len(css), ""
+	}
+	header := strings.TrimSpace(css[start:headerEnd])
+	name := strings.ToLower(strings.TrimPrefix(readAtRuleName(header), "@"))
+	if strings.Contains(header, `\`) {
+		report.drop("escaped at-rule")
+		if css[headerEnd] == '{' {
+			_, next, ok := readCSSBlock(css, headerEnd)
+			if ok {
+				return next, ""
+			}
+		}
+		return headerEnd + 1, ""
+	}
+	if css[headerEnd] == ';' {
+		report.drop("unsupported at-rule: " + name)
+		return headerEnd + 1, ""
+	}
+	body, next, ok := readCSSBlock(css, headerEnd)
+	if !ok {
+		report.drop("unterminated at-rule: " + name)
+		return len(css), ""
+	}
+	switch name {
+	case "import":
+		report.drop("@import")
+		return next, ""
+	case "media", "supports", "container":
+		inner := parseCustomStyleRules(body, scopeRoot, report)
+		if strings.TrimSpace(inner) == "" {
+			report.drop("empty at-rule: " + name)
+			return next, ""
+		}
+		return next, header + "{" + inner + "}"
+	case "keyframes", "-webkit-keyframes":
+		inner := sanitizeKeyframes(body, report)
+		if strings.TrimSpace(inner) == "" {
+			report.drop("empty keyframes")
+			return next, ""
+		}
+		return next, header + "{" + inner + "}"
+	case "font-face":
+		if !fontFaceSrcAllowed(body) {
+			report.drop("@font-face external src")
+			return next, ""
+		}
+		decls := sanitizeCSSDeclarations(body, report, sanitizeCSSOptions{allowAnyDataURL: true})
+		if strings.TrimSpace(decls) == "" {
+			report.drop("empty @font-face")
+			return next, ""
+		}
+		return next, header + "{" + decls + "}"
+	default:
+		report.drop("unsupported at-rule: " + name)
+		return next, ""
+	}
+}
+
+func readAtRuleName(header string) string {
+	for i, r := range header {
+		if i == 0 {
+			continue
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '-' {
+			continue
+		}
+		return header[:i]
+	}
+	return header
+}
+
+func skipCSSSpace(css string, i int) int {
+	for i < len(css) {
+		switch css[i] {
+		case ' ', '\n', '\r', '\t', '\f':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func findCSSControl(css string, start int) int {
+	parenDepth, bracketDepth := 0, 0
+	var quote byte
+	for i := start; i < len(css); i++ {
+		ch := css[i]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '{', ';':
+			if parenDepth == 0 && bracketDepth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func readCSSBlock(css string, open int) (string, int, bool) {
+	if open < 0 || open >= len(css) || css[open] != '{' {
+		return "", open, false
+	}
+	depth := 1
+	var quote byte
+	for i := open + 1; i < len(css); i++ {
+		ch := css[i]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return css[open+1 : i], i + 1, true
+			}
+		}
+	}
+	return "", len(css), false
+}
+
+type sanitizeCSSOptions struct {
+	allowAnyDataURL bool
+}
+
+func sanitizeCSSDeclarations(body string, report *customStyleSanitizeReport, opts sanitizeCSSOptions) string {
+	decls := splitCSSDeclarations(body)
+	kept := make([]string, 0, len(decls))
+	for _, decl := range decls {
+		decl = strings.TrimSpace(decl)
+		if decl == "" {
+			continue
+		}
+		colon := findDeclarationColon(decl)
+		if colon <= 0 {
+			report.drop("malformed declaration")
+			continue
+		}
+		lower := strings.ToLower(decl)
+		prop := strings.TrimSpace(strings.ToLower(decl[:colon]))
+		if strings.Contains(decl, `\`) {
+			report.drop("CSS escape sequence")
+			continue
+		}
+		if prop == "behavior" || strings.Contains(lower, "expression(") || strings.Contains(lower, "-moz-binding") {
+			report.drop("legacy executable CSS")
+			continue
+		}
+		if strings.Contains(lower, "image-set(") {
+			report.drop("image-set")
+			continue
+		}
+		next := sanitizeCSSURLsInDeclaration(decl, report, opts)
+		kept = append(kept, next)
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	return strings.Join(kept, ";")
+}
+
+func splitCSSDeclarations(body string) []string {
+	var out []string
+	start, parenDepth := 0, 0
+	var quote byte
+	for i := 0; i < len(body); i++ {
+		ch := body[i]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case ';':
+			if parenDepth == 0 {
+				out = append(out, body[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start < len(body) {
+		out = append(out, body[start:])
+	}
+	return out
+}
+
+func findDeclarationColon(decl string) int {
+	parenDepth := 0
+	var quote byte
+	for i := 0; i < len(decl); i++ {
+		ch := decl[i]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case ':':
+			if parenDepth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func sanitizeKeyframes(body string, report *customStyleSanitizeReport) string {
+	var out strings.Builder
+	for i := 0; i < len(body); {
+		i = skipCSSSpace(body, i)
+		if i >= len(body) {
+			break
+		}
+		headerEnd := findCSSControl(body, i)
+		if headerEnd < 0 || body[headerEnd] != '{' {
+			break
+		}
+		step := strings.TrimSpace(body[i:headerEnd])
+		declBody, next, ok := readCSSBlock(body, headerEnd)
+		if !ok {
+			break
+		}
+		i = next
+		decls := sanitizeCSSDeclarations(declBody, report, sanitizeCSSOptions{})
+		if strings.Contains(step, `\`) {
+			report.drop("CSS escape sequence")
+			continue
+		}
+		if step == "" || strings.TrimSpace(decls) == "" {
+			report.drop("empty keyframe step")
+			continue
+		}
+		out.WriteString(step)
+		out.WriteString("{")
+		out.WriteString(decls)
+		out.WriteString("}")
+	}
+	return out.String()
+}
+
+func fontFaceSrcAllowed(body string) bool {
+	for _, decl := range splitCSSDeclarations(body) {
+		colon := findDeclarationColon(decl)
+		if colon <= 0 {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(decl[:colon]), "src") {
+			return cssURLsAllowedForFontSrc(decl[colon+1:])
+		}
+	}
+	return true
+}
+
+func cssURLsAllowedForFontSrc(value string) bool {
+	allowed := true
+	cssURLRE.ReplaceAllStringFunc(value, func(token string) string {
+		matches := cssURLRE.FindStringSubmatch(token)
+		if len(matches) < 3 || !isAllowedCSSURL(matches[2], true) {
+			allowed = false
+		}
+		return token
+	})
+	return allowed
+}
+
 func scopeCustomStyleSelectors(selector, scopeRoot string) string {
-	parts := strings.Split(selector, ",")
+	parts := splitSelectorList(selector)
 	scoped := make([]string, 0, len(parts))
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}
-		if part == scopeRoot || (scopeRoot == customStyleAllowedScopes[customStyleScopeDashboard] && (strings.HasPrefix(part, scopeRoot+" ") || strings.HasPrefix(part, scopeRoot+".") || strings.HasPrefix(part, scopeRoot+":"))) {
+		if scopeRootEscapesWithSiblingCombinator(part, scopeRoot) {
+			continue
+		}
+		if part == scopeRoot || strings.HasPrefix(part, scopeRoot+" ") || strings.HasPrefix(part, scopeRoot+".") || strings.HasPrefix(part, scopeRoot+":") || strings.HasPrefix(part, scopeRoot+"[") {
 			scoped = append(scoped, part)
 			continue
 		}
-		if scopeRoot == customStyleAllowedScopes[customStyleScopeDashboard] {
-			if part == "body" || part == "html" || part == ":root" {
-				scoped = append(scoped, scopeRoot)
-				continue
+		if part == "body" || part == "html" || part == ":root" {
+			scoped = append(scoped, scopeRoot)
+			continue
+		}
+		if themed, ok := scopeThemeAncestorSelector(part, scopeRoot); ok {
+			if themed != "" {
+				scoped = append(scoped, themed)
 			}
+			continue
+		}
+		if scopeRoot == customStyleAllowedScopes[customStyleScopeDashboard] {
 			for _, rootSelector := range []string{"body", "html", ":root"} {
 				if strings.HasPrefix(part, rootSelector+".") || strings.HasPrefix(part, rootSelector+":") || strings.HasPrefix(part, rootSelector+"#") {
 					part = scopeRoot + strings.TrimPrefix(part, rootSelector)
@@ -295,6 +671,116 @@ func scopeCustomStyleSelectors(selector, scopeRoot string) string {
 	return strings.Join(scoped, ", ")
 }
 
+func scopeRootEscapesWithSiblingCombinator(selector, scopeRoot string) bool {
+	if !strings.HasPrefix(selector, scopeRoot) {
+		return false
+	}
+	i := len(scopeRoot)
+	parenDepth, bracketDepth := 0, 0
+	var quote byte
+	for i < len(selector) {
+		ch := selector[i]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '+', '~':
+			if parenDepth == 0 && bracketDepth == 0 {
+				return true
+			}
+		case ' ', '\n', '\r', '\t', '\f', '>':
+			if parenDepth == 0 && bracketDepth == 0 {
+				return nextNonSpaceIsSiblingCombinator(selector, i)
+			}
+		}
+		i++
+	}
+	return false
+}
+
+func nextNonSpaceIsSiblingCombinator(selector string, i int) bool {
+	for i < len(selector) {
+		switch selector[i] {
+		case ' ', '\n', '\r', '\t', '\f':
+			i++
+			continue
+		}
+		return selector[i] == '+' || selector[i] == '~'
+	}
+	return false
+}
+
+func splitSelectorList(selector string) []string {
+	var out []string
+	start, parenDepth, bracketDepth := 0, 0, 0
+	var quote byte
+	for i := 0; i < len(selector); i++ {
+		ch := selector[i]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case ',':
+			if parenDepth == 0 && bracketDepth == 0 {
+				out = append(out, selector[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, selector[start:])
+	return out
+}
+
+func scopeThemeAncestorSelector(selector, scopeRoot string) (string, bool) {
+	for _, prefix := range []string{"[data-theme", "html[data-theme", "body[data-theme", ":root[data-theme"} {
+		if strings.HasPrefix(selector, prefix) {
+			if end := strings.Index(selector, "]"); end >= 0 {
+				themed := strings.TrimSpace(selector[:end+1]) + " " + scopeRoot + selector[end+1:]
+				if idx := strings.Index(themed, scopeRoot); idx >= 0 && scopeRootEscapesWithSiblingCombinator(strings.TrimSpace(themed[idx:]), scopeRoot) {
+					return "", true
+				}
+				return themed, true
+			}
+		}
+	}
+	return "", false
+}
+
 func sanitizeCSSURLToken(token string) string {
 	matches := cssURLRE.FindStringSubmatch(token)
 	if len(matches) < 3 {
@@ -302,30 +788,90 @@ func sanitizeCSSURLToken(token string) string {
 	}
 	raw := strings.TrimSpace(matches[2])
 	raw = strings.Trim(raw, `"'`)
-	lower := strings.ToLower(raw)
-	if strings.HasPrefix(lower, "data:image/") {
-		return "url(" + raw + ")"
-	}
-	if colon := strings.Index(raw, ":"); colon >= 0 {
-		slash := strings.IndexAny(raw, "/?#")
-		if slash == -1 || colon < slash {
-			return "url(\"\")"
-		}
-	}
-	if strings.HasPrefix(raw, "//") || strings.Contains(lower, "://") || strings.HasPrefix(lower, "data:") {
-		return "url(\"\")"
+	if !isAllowedCSSURL(raw, false) {
+		return `url("")`
 	}
 	return "url(" + raw + ")"
 }
 
+func sanitizeCSSURLsInDeclaration(decl string, report *customStyleSanitizeReport, opts sanitizeCSSOptions) string {
+	return cssURLRE.ReplaceAllStringFunc(decl, func(token string) string {
+		matches := cssURLRE.FindStringSubmatch(token)
+		if len(matches) < 3 {
+			report.drop("malformed url()")
+			return `url("")`
+		}
+		if !isAllowedCSSURL(matches[2], opts.allowAnyDataURL) {
+			report.drop("external url()")
+			return `url("")`
+		}
+		return sanitizeCSSURLTokenWithDataOption(token, opts.allowAnyDataURL)
+	})
+}
+
+func sanitizeCSSURLTokenWithDataOption(token string, allowAnyDataURL bool) string {
+	matches := cssURLRE.FindStringSubmatch(token)
+	if len(matches) < 3 {
+		return ""
+	}
+	raw := strings.TrimSpace(matches[2])
+	raw = strings.Trim(raw, `"'`)
+	if !isAllowedCSSURL(raw, allowAnyDataURL) {
+		return `url("")`
+	}
+	return "url(" + raw + ")"
+}
+
+func isAllowedCSSURL(raw string, allowAnyDataURL bool) bool {
+	raw = strings.TrimSpace(raw)
+	raw = strings.Trim(raw, `"'`)
+	lower := strings.ToLower(raw)
+	if strings.Contains(raw, `\`) {
+		return false
+	}
+	if allowAnyDataURL && strings.HasPrefix(lower, "data:") {
+		return true
+	}
+	if strings.HasPrefix(lower, "data:image/") {
+		return true
+	}
+	if colon := strings.Index(raw, ":"); colon >= 0 {
+		slash := strings.IndexAny(raw, "/?#")
+		if slash == -1 || colon < slash {
+			return false
+		}
+	}
+	if strings.HasPrefix(raw, "//") || strings.Contains(lower, "://") || strings.HasPrefix(lower, "data:") {
+		return false
+	}
+	return true
+}
+
 func (s *Server) handleStyle(w http.ResponseWriter, r *http.Request) {
-	css, _, err := getCustomStyle(r.Context(), r.URL.Query().Get("src"), r.URL.Query().Get("scope"))
+	css, src, report, err := getCustomStyle(r.Context(), r.URL.Query().Get("src"), r.URL.Query().Get("scope"))
 	if err != nil {
 		status := http.StatusUnprocessableEntity
 		if err == errCustomStyleNotFound {
 			status = http.StatusNotFound
 		}
 		http.Error(w, err.Error(), status)
+		return
+	}
+	if report.Dropped > 0 {
+		w.Header().Set("X-Hive-Style-Dropped", fmt.Sprintf("%d", report.Dropped))
+	}
+	if r.URL.Query().Get("report") == "1" {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Cache-Control", "public, max-age=300")
+		_ = json.NewEncoder(w).Encode(struct {
+			Source string                    `json:"source"`
+			CSS    string                    `json:"css"`
+			Report customStyleSanitizeReport `json:"report"`
+		}{
+			Source: customStyleSourceKey(src),
+			CSS:    string(css),
+			Report: report,
+		})
 		return
 	}
 	w.Header().Set("Content-Type", "text/css; charset=utf-8")
@@ -358,9 +904,11 @@ func leaderboardCustomStyleCacheKey(src leaderboardCustomStyleSource) string {
 }
 
 func getLeaderboardCustomStyle(ctx context.Context, rawSrc string) ([]byte, leaderboardCustomStyleSource, error) {
-	return getCustomStyle(ctx, rawSrc, customStyleScopeLeaderboard)
+	css, src, _, err := getCustomStyle(ctx, rawSrc, customStyleScopeLeaderboard)
+	return css, src, err
 }
 
 func sanitizeLeaderboardCustomStyle(css []byte) ([]byte, error) {
-	return sanitizeCustomStyle(css, customStyleAllowedScopes[customStyleScopeLeaderboard])
+	out, _, err := sanitizeCustomStyle(css, customStyleAllowedScopes[customStyleScopeLeaderboard])
+	return out, err
 }

--- a/v2/pkg/dashboard/api_leaderboard_style_test.go
+++ b/v2/pkg/dashboard/api_leaderboard_style_test.go
@@ -65,6 +65,7 @@ https://evil.example/wrap.png
 body{display:none}
 .a,.b{color:blue}
 #tab-leaderboard ~ footer{display:none}
+[data-theme="light"] ~ footer{display:none}
 .data{background:url(data:image/png;base64,abc)}
 .relative{background:url(/assets/bg.png)}
 .dot{background:url(./bg.png)}
@@ -87,13 +88,97 @@ body{display:none}
 			t.Fatalf("sanitized CSS missing %q:\n%s", good, out)
 		}
 	}
-	for _, scoped := range []string{"#tab-leaderboard body{display:none}", "#tab-leaderboard .a, #tab-leaderboard .b{color:blue}", "#tab-leaderboard #tab-leaderboard ~ footer{display:none}"} {
+	for _, scoped := range []string{"#tab-leaderboard{display:none}", "#tab-leaderboard .a, #tab-leaderboard .b{color:blue}"} {
 		if !strings.Contains(out, scoped) {
 			t.Fatalf("sanitized CSS missing scoped selector %q:\n%s", scoped, out)
 		}
 	}
+	if strings.Contains(out, "footer") {
+		t.Fatalf("sanitized CSS allowed a selector outside the leaderboard scope:\n%s", out)
+	}
 	if _, err := sanitizeLeaderboardCustomStyle([]byte(strings.Repeat("a", customStyleMaxBytes+1))); err == nil {
 		t.Fatal("oversized CSS did not fail")
+	}
+}
+
+func TestSanitizeLeaderboardCustomStylePreservesModernThemeCSS(t *testing.T) {
+	css := []byte(`
+	/* Header comments should not eat the next rule. */
+	:root{
+	  --bf-accent:#5c7bd1;
+	  --bf-soft:color-mix(in srgb, var(--bf-accent) 20%, transparent);
+	}
+	[data-theme="light"] .me-card{background:linear-gradient(180deg,#fff,#eef);border-color:var(--bf-accent)}
+	.me-card:is(.featured,.mine) .me-card__band{padding:clamp(12px,2vw,24px);width:calc(100% - 2rem)}
+	.lb-row[data-rank="1"]::before{content:"★"}
+	@media (prefers-reduced-motion:no-preference){
+	  .me-medallion{animation:pulse 1s ease-in-out}
+	}
+	@supports (color: color-mix(in srgb, red, blue)){
+	  .me-rankpill__num{color:var(--bf-accent)}
+	}
+	@container (min-width: 40rem){
+	  .me-card .me-sec__title{letter-spacing:.04em}
+	}
+	@keyframes pulse{
+	  from{opacity:.7;transform:scale(.98)}
+	  to{opacity:1;transform:scale(1)}
+	}
+	`)
+	got, report, err := sanitizeCustomStyle(css, customStyleAllowedScopes[customStyleScopeLeaderboard])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Dropped != 0 {
+		t.Fatalf("report.Dropped = %d reasons=%v", report.Dropped, report.Reasons)
+	}
+	out := string(got)
+	for _, want := range []string{
+		"#tab-leaderboard{--bf-accent:#5c7bd1;--bf-soft:color-mix(in srgb, var(--bf-accent) 20%, transparent)}",
+		`[data-theme="light"] #tab-leaderboard .me-card{background:linear-gradient(180deg,#fff,#eef);border-color:var(--bf-accent)}`,
+		"#tab-leaderboard .me-card:is(.featured,.mine) .me-card__band{padding:clamp(12px,2vw,24px);width:calc(100% - 2rem)}",
+		`#tab-leaderboard .lb-row[data-rank="1"]::before{content:"★"}`,
+		"@media (prefers-reduced-motion:no-preference){#tab-leaderboard .me-medallion{animation:pulse 1s ease-in-out}",
+		"@supports (color: color-mix(in srgb, red, blue)){#tab-leaderboard .me-rankpill__num{color:var(--bf-accent)}",
+		"@container (min-width: 40rem){#tab-leaderboard .me-card .me-sec__title{letter-spacing:.04em}",
+		"@keyframes pulse{from{opacity:.7;transform:scale(.98)}to{opacity:1;transform:scale(1)}}",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("sanitized CSS missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSanitizeLeaderboardCustomStyleReportsDroppedConstructs(t *testing.T) {
+	css := []byte(`
+	@import url("https://evil.example/theme.css");
+	@font-face{font-family:Bad;src:url(https://evil.example/font.woff2)}
+	@font-face{font-family:Good;src:url(/assets/good.woff2),url(data:font/woff2;base64,abc)}
+	.bad{background:url(https://evil.example/pixel.png);color:red}
+	.foo\31{color:red}
+	@keyframes badstep{fr\6fm{opacity:1}to{opacity:0}}
+	@\69mport "https://evil.example/escaped.css";
+	`)
+	got, report, err := sanitizeCustomStyle(css, customStyleAllowedScopes[customStyleScopeLeaderboard])
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	for _, bad := range []string{"@import", "evil.example", `\69`, `\31`, `\6f`} {
+		if strings.Contains(out, bad) {
+			t.Fatalf("sanitized CSS still contains %q:\n%s", bad, out)
+		}
+	}
+	for _, want := range []string{
+		"@font-face{font-family:Good;src:url(/assets/good.woff2),url(data:font/woff2;base64,abc)}",
+		`#tab-leaderboard .bad{background:url("");color:red}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("sanitized CSS missing %q:\n%s", want, out)
+		}
+	}
+	if report.Dropped < 6 {
+		t.Fatalf("report.Dropped = %d, want at least 6 reasons=%v", report.Dropped, report.Reasons)
 	}
 }
 
@@ -124,6 +209,9 @@ func TestHandleLeaderboardStyleFetchesSanitizesAndCaches(t *testing.T) {
 	if body := rec.Body.String(); !strings.Contains(body, "#tab-leaderboard .ok{color:red}") || strings.Contains(body, "evil.example") {
 		t.Fatalf("unexpected sanitized body: %s", body)
 	}
+	if got := rec.Header().Get("X-Hive-Style-Dropped"); got != "1" {
+		t.Fatalf("X-Hive-Style-Dropped = %q, want 1", got)
+	}
 
 	rec = httptest.NewRecorder()
 	srv.handleLeaderboardStyle(rec, req)
@@ -132,6 +220,16 @@ func TestHandleLeaderboardStyleFetchesSanitizesAndCaches(t *testing.T) {
 	}
 	if hits != 1 {
 		t.Fatalf("raw hits = %d, want cache hit after first fetch", hits)
+	}
+
+	reportReq := httptest.NewRequest(http.MethodGet, "/api/leaderboard/style?src=owner/repo/lb/theme.css@main&report=1", nil)
+	rec = httptest.NewRecorder()
+	srv.handleLeaderboardStyle(rec, reportReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("report status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Header().Get("Content-Type"), "application/json") || !strings.Contains(rec.Body.String(), `"dropped":1`) {
+		t.Fatalf("unexpected report response headers=%v body=%s", rec.Header(), rec.Body.String())
 	}
 }
 
@@ -167,7 +265,7 @@ func TestContributeLeaderboardCustomStyleMarkup(t *testing.T) {
 	for _, snippet := range []string{
 		`id="leaderboard-custom-style-link" rel="stylesheet" href="/api/leaderboard/style?src=owner%2Frepo%2Flb%2Ftheme.css%40main"`,
 		`window.HIVE_LEADERBOARD_CUSTOM_STYLE_SRC="owner/repo/lb/theme.css@main";`,
-		`Custom (` + `'+esc(leaderboardCustomStyleLabel(customStyleSrc))+'` + `)`,
+		`rules removed by sanitizer`,
 		`clearLeaderboardCustomStyleParam();`,
 	} {
 		if !strings.Contains(html, snippet) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2556,9 +2556,10 @@
     var note=document.getElementById('dashboard-custom-style-note');
     if(!note)return;
     var src=window.HIVE_DASHBOARD_CUSTOM_STYLE_SRC||currentStyleSrc();
+    var dropped=parseInt(window.HIVE_DASHBOARD_CUSTOM_STYLE_DROPPED||'0',10)||0;
     note.classList.toggle('warn', !ok);
-    note.title=ok?'Custom style active: '+src+' — remove ?style= to reset':'Custom style could not be loaded — using default dashboard styles';
-    note.textContent=ok?'Custom style: '+styleLabel(src):'Custom style failed';
+    note.title=ok?(dropped>0?('Custom style active: '+src+' — '+dropped+' rules removed by sanitizer'):'Custom style active: '+src+' — remove ?style= to reset'):'Custom style could not be loaded — using default dashboard styles';
+    note.textContent=ok?(dropped>0?('Custom style: '+styleLabel(src)+' ('+dropped+' removed)'):'Custom style: '+styleLabel(src)):'Custom style failed';
     var btn=document.createElement('button');
     btn.type='button';
     btn.textContent='×';
@@ -2586,7 +2587,13 @@
     link.id='dashboard-custom-style-link';
     link.rel='stylesheet';
     link.href='/api/style?src='+encodeURIComponent(src)+'&scope='+encodeURIComponent(STYLE_SCOPE);
-    link.onload=function(){ styleState='loaded'; renderStyleState(); };
+    link.onload=function(){
+      styleState='loaded';
+      fetch('/api/style?src='+encodeURIComponent(src)+'&scope='+encodeURIComponent(STYLE_SCOPE)+'&report=1',{cache:'no-store'})
+        .then(function(r){return r.ok?r.json():null;})
+        .then(function(j){window.HIVE_DASHBOARD_CUSTOM_STYLE_DROPPED=(j&&j.report&&j.report.dropped)||0;renderStyleState();})
+        .catch(function(){renderStyleState();});
+    };
     link.onerror=function(){ styleState='failed'; renderStyleState(); };
     document.head.appendChild(link);
     document.addEventListener('DOMContentLoaded', renderStyleState);


### PR DESCRIPTION
Fixes #2972

Before: the published Project Bluefin leaderboard theme loaded as Custom but rendered as a no-op because comments confused string scoping, custom properties were dropped, at-rules were discarded, and removals were silent.

After: custom properties, modern selectors/functions, @media/@supports/@container/@keyframes, safe @font-face, and the reporter's theme shapes survive sanitization; unsafe @import/external url()/legacy executable CSS are still removed. The API now reports sanitizer removals via X-Hive-Style-Dropped and ?report=1 JSON, and the UI/docs surface allowed CSS and removal counts.

Validation:
- go build ./...
- go vet ./...
- go test ./pkg/dashboard/ -count=1