### PR TITLE
docs: add deploy examples reference and inference deploy link

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -282,10 +282,10 @@ The `deploy/` directory contains pre-built configurations for common deployment 
 
 | File | Use Case |
 |------|----------|
-| `deploy/hive-quickstart.yaml` | Full ACMM L1 roster (10 agents) targeting `kubestellar/hive-tester` — safe for evaluation and level testing |
+| `deploy/hive-quickstart.yaml` | Quick-start evaluation roster targeting `kubestellar/hive-tester` with all ten built-in agent lanes enabled under `acmm_level: 1` |
 | `deploy/architect-only.yaml` | Single `architect` agent managing KubeStellar Console repos — Docker on Proxmox LXC, ntfy notifications |
 | `deploy/hive-level2-knuckle.yaml` | ACMM L2 advisory config for `projectbluefin/knuckle` — agents observe and report, no issues or PRs |
-| `deploy/hive-level3-knuckle.yaml` | ACMM L3 measured config for `projectbluefin/knuckle` — quality opens testing issues and hold-gated PRs, other agents stay advisory |
+| `deploy/hive-level3-knuckle.yaml` | ACMM L3 measured config for `projectbluefin/knuckle` — quality uses the measured policy for testing issues, other agents stay advisory |
 
 ## Build from Source
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -276,6 +276,17 @@ For GitHub App setup, configure the app's **Setup URL** to
 operator installs the app from the dashboard banner, GitHub redirects back and
 the hive verifies and saves the installation ID automatically.
 
+## Deployment Examples
+
+The `deploy/` directory contains pre-built configurations for common deployment patterns. Copy the one that matches your use case to `hive.yaml` and adjust the `github:` section.
+
+| File | Use Case |
+|------|----------|
+| `deploy/hive-quickstart.yaml` | Full ACMM L1 roster (10 agents) targeting `kubestellar/hive-tester` — safe for evaluation and level testing |
+| `deploy/architect-only.yaml` | Single `architect` agent managing KubeStellar Console repos — Docker on Proxmox LXC, ntfy notifications |
+| `deploy/hive-level2-knuckle.yaml` | ACMM L2 advisory config for `projectbluefin/knuckle` — agents observe and report, no issues or PRs |
+| `deploy/hive-level3-knuckle.yaml` | ACMM L3 measured config for `projectbluefin/knuckle` — quality opens testing issues and hold-gated PRs, other agents stay advisory |
+
 ## Build from Source
 
 ```bash

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -162,6 +162,8 @@ Two rules of thumb:
 - **CLI methods are subscriptions.** You log in once per method from the dashboard, and every agent using that method shares the login.
 - **Inference methods are endpoints.** You configure a base URL and a key *reference* (env var name or key-file path — the value goes in `/data/secrets/`, never in YAML). Agents on `vllm`/`llm-d`/`litellm` launch the Claude CLI routed through hive's inference translator, so there is no separate login.
 
+Kubernetes manifests for deploying inference backends (vllm Deployment, EPP RBAC, kustomization) are in [`deploy/inference/`](../deploy/inference/).
+
 Every discovery probe is best-effort: a failed or absent probe falls back to a current static list, so a model dropdown is never empty. Fallback entries are marked "unverified" in the UI.
 
 ### Model pinning and auto-switching


### PR DESCRIPTION
## Summary

Documents the pre-built hive YAML configurations in `v2/deploy/` and links Kubernetes inference deployment manifests.

## Changes

1. **Added "Deployment Examples" section to `v2/README.md`** — lists `hive-quickstart.yaml`, `architect-only.yaml`, `hive-level2-knuckle.yaml`, and `hive-level3-knuckle.yaml` with one-line use-case descriptions
2. **Added inference deploy link to `v2/docs/agent-configuration.md`** — references `deploy/inference/` (vllm Deployment, EPP RBAC, kustomization) from the inference methods section

## Verification

- All four YAML configs already have descriptive header comments
- Both edited files pass lint review
- Links use correct relative paths

Closes #3075

---

*Filed by RawNuke guide agent*

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke