### PR TITLE
sec: pin reusable workflow, switch to pull_request, reduce permissions

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -9,17 +9,15 @@ on:
         type: string
   issues:
     types: [labeled]
-  pull_request_target:
+  pull_request:
     types: [opened]
 
 permissions:
-  contents: write
   issues: write
-  pull-requests: write
 
 jobs:
   ai-fix:
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@50f6dd45dad477e9815b557b40649c68942f8159
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:


### PR DESCRIPTION
## Summary

This pull request fixes the CI supply-chain risk reported in #3073.

## Changes

1. **Pin the reusable workflow to a commit SHA** — replaced `@main` with `@50f6dd45dad477e9815b557b40649c68942f8159` (the latest commit to the reusable workflow in kubestellar/infra)
2. **Replace `pull_request_target` with `pull_request`** — the reusable workflow already rejects fork PRs, but `pull_request` provides defense-in-depth with native fork sandboxing
3. **Reduce permissions** — removed `contents: write` and `pull-requests: write`, kept only `issues: write` which is what the reusable workflow actually needs (comment, label, assignee API calls)

## Verification

- The reusable workflow at the pinned commit was reviewed. It calls only issue APIs: `issues.createComment`, `issues.addLabels`, `issues.removeLabel`, `issues.removeAssignees`, `issues.get`
- The reusable workflow already has guards: strict Copilot bot identity check and fork PR rejection
- The YAML is valid and the file passes syntax check

Closes #3073

---

*Authored by RawNuke with AI assistance*

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke