### PR TITLE
fix(gh-wrapper): validate --author value in list gate (fixes #3072)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -109,6 +109,48 @@ for arg in "${args[@]}"; do
   esac
 done
 
+# ── Helpers: author validation for the list gate ──
+
+# Extract the --author value from the args array. Returns the value on stdout
+# on success (exit 0) or nothing on failure (exit 1).
+_extract_author() {
+  local i
+  for ((i=0; i<${#args[@]}; i++)); do
+    if [[ "${args[$i]}" = --author=* ]]; then
+      printf '%s\n' "${args[$i]#--author=}"
+      return 0
+    fi
+    if [[ "${args[$i]}" = --author ]]; then
+      if [[ $((i+1)) -lt ${#args[@]} ]] && [[ "${args[$((i+1))]}" != -* ]]; then
+        printf '%s\n' "${args[$((i+1))]}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+# Resolve the bot's GitHub login (cached per invocation for performance).
+_resolve_self_login() {
+  if [[ -n "${HIVE_BOT_LOGIN_CACHED:-}" ]]; then
+    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
+    return
+  fi
+  if [[ -n "${HIVE_BOT_LOGIN:-}" ]]; then
+    HIVE_BOT_LOGIN_CACHED="$HIVE_BOT_LOGIN"
+    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
+    return
+  fi
+  if [[ -x "$REAL_GH" ]] && [[ -n "${GH_TOKEN:-}" ]]; then
+    HIVE_BOT_LOGIN_CACHED="$("$REAL_GH" api user -q '.login' 2>/dev/null || true)"
+    if [[ -n "$HIVE_BOT_LOGIN_CACHED" ]]; then
+      printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
+      return
+    fi
+  fi
+  printf '%s\n' ""
+}
+
 # ── READ/WRITE SPLIT for GitHub lookups (fixes #2356; addresses #2393 item 6) ──
 # Contributor agents MUST be able to do READ-ONLY lookups before starting work so
 # they can check whether a PR already exists for their assigned issue — otherwise
@@ -120,12 +162,29 @@ done
 #
 # Block gh issue list and gh pr list for NON-contributor hive agents (they consume
 # assigned work from actionable.json). Contributors are exempt so they can look
-# before they leap. `--author` self-listing stays allowed for everyone.
+# before they leap. `--author` self-listing is allowed only when the author value
+# matches the current agent/bot identity (fixes #3072).
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
   if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
     : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356)
-  elif echo "$FULL_CMD" | grep -q "\-\-author"; then
-    : # Allow any agent to list their own PRs for review
+  elif author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
+    self_login="$(_resolve_self_login)"
+    if [[ -n "$self_login" ]] && [[ "$author_value" = "$self_login" ]]; then
+      : # Match: exact bot login
+    elif [[ -n "$self_login" ]] && [[ "$author_value" = "${self_login%\[bot\]}" ]]; then
+      : # Match: bot login without [bot] suffix
+    elif [[ -n "${HIVE_AGENT:-}" ]] && [[ "$author_value" = "${HIVE_AGENT}" ]]; then
+      : # Match: agent name
+    elif [[ -n "${HIVE_AGENT_DISPLAY_NAME:-}" ]] && [[ "$author_value" = "${HIVE_AGENT_DISPLAY_NAME}" ]]; then
+      : # Match: agent display name
+    elif [[ -n "${HIVE_CONTRIBUTOR_USERNAME:-}" ]] && [[ "$author_value" = "${HIVE_CONTRIBUTOR_USERNAME}" ]]; then
+      : # Match: contributor username (self-listing in contributor mode)
+    else
+      echo "⛔ BLOCKED: gh $subcmd list --author must match the current bot/agent identity." >&2
+      echo "--author '$author_value' does not match the current identity." >&2
+      echo "Use --author with your own bot login or agent name to list your own items." >&2
+      exit 1
+    fi
   else
     echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
     echo "Read /var/run/hive-metrics/actionable.json instead." >&2

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Author: RawNuke
+# Copyright (c) 2026 RawNuke. All rights reserved.
+#
+# Regression tests for kubestellar/hive#3072: gh-wrapper --author bypass fix.
+# Creates a temporary copy of the wrapper with a mock gh binary so tests
+# can run without requiring /usr/bin/gh.
+#
+# Run: bash bin/gh-wrapper.test.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="${ROOT_DIR}/bin/gh-wrapper.sh"
+WORK_DIR="${ROOT_DIR}/.gh-wrapper-test-work-$$"
+MOCK_GH="${WORK_DIR}/mock-gh"
+TEST_WRAPPER="${WORK_DIR}/gh-wrapper-test.sh"
+PASSED=0
+FAILED=0
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$WORK_DIR"
+
+cat >"$MOCK_GH" <<'MOCK'
+#!/usr/bin/env bash
+case "$*" in
+  "api user -q .login")
+    echo "test-bot[bot]"
+    ;;
+  "api"*)
+    echo '{"login":"test-bot[bot]"}'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+MOCK
+chmod +x "$MOCK_GH"
+
+sed "s|^REAL_GH=\"/usr/bin/gh\"|REAL_GH=\"${MOCK_GH}\"|" "$WRAPPER" > "$TEST_WRAPPER"
+chmod +x "$TEST_WRAPPER"
+
+export GH_TOKEN="test-token-mock"
+export HIVE_BOT_LOGIN="test-bot[bot]"
+
+_run_test() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    HIVE_BOT_LOGIN="test-bot[bot]" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_contributor() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_CONTRIBUTOR_MODE="true" \
+    HIVE_CONTRIBUTOR_USERNAME="test-contributor" \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    HIVE_BOT_LOGIN="test-bot[bot]" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+echo "=== Non-contributor agent tests ==="
+
+_run_test 1 "issue list without --author (blocked)" \
+  issue list --repo test/repo
+
+_run_test 1 "pr list without --author (blocked)" \
+  pr list --repo test/repo
+
+_run_test 1 "issue list --author foreign-user (blocked)" \
+  issue list --repo test/repo --author foreign-user
+
+_run_test 1 "pr list --author=foreign-user (blocked, equals form)" \
+  pr list --repo test/repo --author=foreign-user
+
+_run_test 0 "issue list --author test-bot[bot] (allowed, exact match)" \
+  issue list --repo test/repo --author "test-bot[bot]"
+
+_run_test 0 "pr list --author=test-bot[bot] (allowed, equals form)" \
+  pr list --repo test/repo --author="test-bot[bot]"
+
+_run_test 0 "issue list --author test-bot (allowed, without [bot] suffix)" \
+  issue list --repo test/repo --author test-bot
+
+_run_test 0 "issue list --author scanner (allowed, HIVE_AGENT match)" \
+  issue list --repo test/repo --author scanner
+
+_run_test 0 "pr list --author scanner (allowed, HIVE_AGENT match)" \
+  pr list --repo test/repo --author scanner
+
+echo ""
+echo "=== Contributor mode tests ==="
+
+_run_test_contributor 0 "issue list contributor mode (allowed without --author)" \
+  issue list --repo test/repo
+
+_run_test_contributor 0 "pr list contributor mode (allowed without --author)" \
+  pr list --repo test/repo
+
+_run_test_contributor 0 "issue list contributor mode --author self (allowed)" \
+  issue list --repo test/repo --author test-contributor
+
+echo ""
+echo "Results: ${PASSED} passed, ${FAILED} failed"
+if [[ "$FAILED" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #3072

The `bin/gh-wrapper.sh` list gate previously allowed any non-contributor agent to bypass the `gh issue list` / `gh pr list` block by passing any `--author` flag, because the check only tested for flag presence via `grep -q`. This change replaces that check with proper value extraction and identity validation.

## Changes

1. Added `_extract_author()` helper to parse `--author` and `--author=<value>` from the args array.
2. Added `_resolve_self_login()` helper to get the bot's GitHub login (cached, with `HIVE_BOT_LOGIN` env var support for pre-configuration).
3. The list gate now validates the `--author` value against:
   - Exact bot login (e.g. `test-bot[bot]`)
   - Bot login without `[bot]` suffix (e.g. `test-bot`)
   - `HIVE_AGENT` name (e.g. `scanner`)
   - `HIVE_AGENT_DISPLAY_NAME`
   - `HIVE_CONTRIBUTOR_USERNAME` (in contributor mode self-listing)
4. Foreign `--author` values are blocked. Empty or missing `--author` on a non-contributor agent is blocked (unchanged). Contributor mode bypass is unchanged.

## Test coverage

Added `bin/gh-wrapper.test.sh` with 12 regression tests covering:
- Bare list without `--author` → blocked
- Foreign `--author` → blocked (both space and equals forms)
- Self-author exact match → allowed
- Self-author without `[bot]` suffix → allowed
- `HIVE_AGENT` name match → allowed
- Contributor mode bare list → allowed (unchanged)
- Contributor mode self-author → allowed

All 12 tests pass.

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke