### PR TITLE
fix(agent): deny all GitHub MCP write tools so agents author as the App, not the user

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1034,6 +1034,25 @@ func backendDefersStartupKick(backend string) bool {
 	}
 }
 
+// copilotGitHubWriteDenyFlags is the full set of Copilot `--deny-tool` flags for
+// every GitHub MCP write tool. It is denied in EVERY copilot launch mode so no
+// mode can author issues/PRs/comments as the logged-in Copilot USER via the
+// GitHub MCP. The MCP write path executes on GitHub's side using the Copilot
+// session's user OAuth, so the hive's proxy never sees a POST it could gate —
+// denying these tools at launch is the only reliable enforcement, forcing all
+// GitHub writes through the App-gated `gh` wrapper / `hive-open-pr`, which author
+// as the App bot (kubestellar-hive[bot]). READ tools (get_issue, list_issues,
+// get_pull_request, search, ...) stay enabled via --enable-all-github-mcp-tools;
+// only these WRITE tools are denied. The mode-based gh-wrapper/proxy gating
+// (IssuesOnly vs IssuesAndPRs) is a separate, unchanged layer.
+const copilotGitHubWriteDenyFlags = "" +
+	" --deny-tool='github(create_pull_request)'" +
+	" --deny-tool='github(create_pull_request_with_copilot)'" +
+	" --deny-tool='github(merge_pull_request)'" +
+	" --deny-tool='github(create_issue)'" +
+	" --deny-tool='github(update_issue)'" +
+	" --deny-tool='github(add_issue_comment)'"
+
 func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -1189,23 +1208,17 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			// in cli_models.go), which lets the Copilot CLI pick/adjust the model
 			// per task. Nothing here assumes a concrete id, so the sentinel flows
 			// through unchanged.
-			switch {
-			case mode >= ModeIssuesAndPRs:
-				launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools",
-					binary, model)
-			case mode == ModeIssuesOnly:
-				launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools"+
-					" --deny-tool='github(create_pull_request)'"+
-					" --deny-tool='github(merge_pull_request)'",
-					binary, model)
-			default:
-				launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all"+
-					" --deny-tool='github(create_pull_request)'"+
-					" --deny-tool='github(create_issue)'"+
-					" --deny-tool='github(update_issue)'"+
-					" --deny-tool='github(merge_pull_request)'",
-					binary, model)
-			}
+			// Every mode denies the FULL set of GitHub MCP write tools
+			// (copilotGitHubWriteDenyFlags) so no mode can author issues/PRs/
+			// comments as the login USER via the MCP; all GitHub writes must go
+			// through the App-gated gh wrapper / hive-open-pr. READ tools stay
+			// enabled via --enable-all-github-mcp-tools. The deny set is identical
+			// across ModeIssuesAndPRs / ModeIssuesOnly / advisory — the mode no
+			// longer changes what the MCP can write (it never legitimately should),
+			// it only governs the separate, unchanged gh-wrapper/proxy layer that
+			// still reads Mode for what the App-gated write path allows.
+			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools%s",
+				binary, model, copilotGitHubWriteDenyFlags)
 		case "gemini":
 			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
 		case "goose":

--- a/v2/pkg/config/tool_presets.go
+++ b/v2/pkg/config/tool_presets.go
@@ -3,14 +3,22 @@ package config
 // ToolPresets maps preset names to their default deny rules.
 // These match the existing Mode-based hardcoded behavior in agent/manager.go.
 var ToolPresets = map[string][]ToolRule{
+	// The deny sets below cover the FULL GitHub MCP write surface so an agent
+	// cannot author issues/PRs/comments as the login USER via the MCP; the same
+	// write-tool set is denied at Copilot launch (copilotGitHubWriteDenyFlags in
+	// agent/manager.go). All GitHub writes must route through the App-gated gh
+	// wrapper / hive-open-pr so they are authored by the App bot.
 	"advisory": {
 		{Pattern: "mcp__github__create_pull_request", Action: "deny"},
+		{Pattern: "mcp__github__create_pull_request_with_copilot", Action: "deny"},
 		{Pattern: "mcp__github__create_issue", Action: "deny"},
 		{Pattern: "mcp__github__update_issue", Action: "deny"},
+		{Pattern: "mcp__github__add_issue_comment", Action: "deny"},
 		{Pattern: "mcp__github__merge_pull_request", Action: "deny"},
 	},
 	"issues-only": {
 		{Pattern: "mcp__github__create_pull_request", Action: "deny"},
+		{Pattern: "mcp__github__create_pull_request_with_copilot", Action: "deny"},
 		{Pattern: "mcp__github__merge_pull_request", Action: "deny"},
 	},
 	"issues-prs": {},


### PR DESCRIPTION
## Problem

Copilot agents were opening GitHub issues/PRs (and could add comments) authored as the logged-in Copilot **user** (`clubanderson`) instead of the App (`kubestellar-hive[bot]`).

The agent launch-command builder in `v2/pkg/agent/manager.go` (`case "copilot":`) set `--enable-all-github-mcp-tools` and then denied GitHub MCP write tools **inconsistently per mode**:

- `ModeIssuesAndPRs` — enabled all github MCP tools and denied **nothing** → agents created both issues and PRs via the Copilot GitHub MCP, authored as the login user.
- `ModeIssuesOnly` — denied only `create_pull_request` / `merge_pull_request`; `create_issue` / `update_issue` (and comment creation) stayed enabled → issues authored as the user.
- `default` (advisory) — correctly denied create_pull_request/create_issue/update_issue/merge_pull_request.

The GitHub MCP write path executes **on GitHub's side using the Copilot session's user OAuth**, so the hive's agent proxy never sees a POST it could gate (see `v2/pkg/proxy/rules.go` — the proxy only blocks `POST /repos/*/pulls` for `gh pr create`, not the MCP OAuth path). The **only** reliable enforcement is to deny these MCP write tools at agent launch, forcing all GitHub writes through the App-gated `gh` wrapper / `hive-open-pr`, which author as the App bot.

## Fix

- Define the full GitHub MCP write-tool deny set **once** (`copilotGitHubWriteDenyFlags`) and apply it in **every** copilot launch mode, so no mode can author issues/PRs/comments as the user via the MCP. Denied: `create_pull_request`, `create_pull_request_with_copilot`, `merge_pull_request`, `create_issue`, `update_issue`, `add_issue_comment`.
- Keep `--enable-all-github-mcp-tools` — agents still need the **READ** tools (`get_issue`, `list_issues`, `get_pull_request`, `search`, …). Only WRITE tools are denied.
- Extend `v2/pkg/config/tool_presets.go` deny presets to the same full write surface (added `create_pull_request_with_copilot` and `add_issue_comment`) for consistency across the two layers.

The mode (`IssuesOnly` vs `IssuesAndPRs`) still governs the separate, **unchanged** gh-wrapper/proxy layer that reads Mode for what the App-gated write path allows. The gh-wrapper, proxy rules, App-token injection, and read tools are untouched.

## Enforcement design (reference)

The `default`/advisory case already denied `create_issue` — proof that the intended design is "no MCP writes; open issues/PRs via the App-gated gh wrapper." This change makes every mode consistent with that intent.