### PR TITLE
📖 docs: recent v2 feature guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Hive uses an **AI-native Capability Maturity Model** (ACMM) with six levels that
 | L5 | Semi-Autonomous (Semi-Automated) | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
 | L6 | Fully Autonomous | 10 | Agents open PRs and auto-merge on green CI. No hold label required. |
 
-Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). See `v2/docs/acmm-policy-matrix.md` for the full matrix.
+Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). See `v2/docs/acmm-policy-matrix.md` for the full matrix. Browse the [v2 docs index](v2/docs/README.md) for operations, contributor relay, snapshots, health checks, and design guides.
 
 ## Architecture
 
@@ -274,7 +274,7 @@ flowchart LR
     dash["Dashboard :3001"] -.->|"SSE"| gov
 ```
 
-**See [v2/docs/architecture.md](v2/docs/architecture.md) for the full reference architecture** — process model, the governor loop, the deterministic pipeline, layered guardrails, ACMM, beads, hub & spoke, and an end-to-end walkthrough, with Mermaid diagrams throughout.
+**See [v2/docs/architecture.md](v2/docs/architecture.md) for the full reference architecture** — process model, the governor loop, the deterministic pipeline, layered guardrails, ACMM, beads, hub & spoke, and an end-to-end walkthrough, with Mermaid diagrams throughout. Operator safety references include [trajectory review](v2/docs/trajectory-review.md), [dashboard health checks](v2/docs/health-checks.md), and [sandbox guardrails](v2/docs/sandbox-isolation.md).
 
 ## Contribute to a Hive
 
@@ -290,6 +290,8 @@ just contribute-hive
 ```
 
 Supported CLIs: Claude Code, GitHub Copilot, Pi, Goose, Bob. Contributors start as newcomer (rate-limited) and auto-promote based on completed tasks. Your credentials never leave your machine.
+
+A relay can subscribe to multiple hives with comma-separated `HIVE_HUB` and matching `HIVE_REGISTRATION_TOKEN` values, and operators can delegate selected spoke roles through **Acting as** / `HIVE_AGENT_ROLE`. See [v2/docs/contributor-relay.md](v2/docs/contributor-relay.md) and [v2/docs/contributor-trust-and-roles.md](v2/docs/contributor-trust-and-roles.md).
 
 See the [Hive Hub contribute page](https://hive.kubestellar.io) for details.
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -64,6 +64,8 @@ operations.
 
 See [docs/hivectl.md](docs/hivectl.md) for the full command reference.
 
+See [docs/README.md](docs/README.md) for the full v2 documentation index.
+
 ## Kubernetes
 
 ```bash
@@ -75,7 +77,12 @@ kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
 kubectl apply -f deploy/k8s/pvc.yaml
 kubectl apply -f deploy/k8s/deployment.yaml
 kubectl apply -f deploy/k8s/service.yaml
+kubectl apply -f deploy/k8s/dashboard-route-rbac.yaml
 ```
+
+`dashboard-route-rbac.yaml` lets the spoke report `route_exists` in heartbeats.
+See [docs/health-checks.md](docs/health-checks.md) for listener probes,
+hub-fronted URL probing, and alert hysteresis.
 
 ## Configuration
 
@@ -94,31 +101,18 @@ project:
 ### Custom stylesheets
 
 The ClankeR leaderboard, the spoke dashboard, and the read-only `/snapshot`
-preview accept a shareable custom stylesheet parameter:
+preview accept a shareable sanitized CSS theme from a public GitHub repo:
 
-`/contribute/leaderboard?style=owner/repo/path/to/theme.css@ref`
-`/?style=owner/repo/path/to/theme.css@ref`
-`/snapshot?style=owner/repo/path/to/theme.css@ref`
+```text
+/contribute/leaderboard?style=owner/repo/path/to/theme.css@ref
+/?style=owner/repo/path/to/theme.css@ref
+/snapshot?style=owner/repo/path/to/theme.css@ref
+```
 
-The `@ref` suffix is optional and defaults to the repo's `HEAD`. Hive only
-accepts the `owner/repo/path.css` triplet form, fetches public GitHub raw content
-server-side without credentials, sanitizes CSS, strips external imports/URLs, and
-serves it from same-origin endpoints with a 128 KiB size cap. The sanitizer keeps
-normal declarations including custom properties (`--x`/`var(--x)`), attribute and
-pseudo selectors, gradients, `calc()`/`clamp()`/modern color functions, and the
-recursive at-rules `@media`, `@supports`, `@container`, and `@keyframes`.
-`@font-face` blocks are kept only when every `src` URL is same-origin/relative or
-`data:`. It removes `@import`, external or protocol-relative `url()` fetches,
-CSS escape sequences, `image-set()`, and legacy executable CSS vectors such as
-`expression()`, `behavior`, and `-moz-binding`.
-
-Sanitized style responses include `X-Hive-Style-Dropped: N` when anything was
-removed. Add `&report=1` to `/api/style` or `/api/leaderboard/style` to get JSON
-with the sanitized CSS and a short list of sanitizer reasons. Leaderboard CSS is
-scoped to `#tab-leaderboard`; dashboard and snapshot CSS is scoped to
-`#hive-dashboard-root`, which deliberately leaves login/setup overlays outside
-the custom-theme surface. `/api/style` is public so unauthenticated snapshots can
-load sanitized CSS, and the existing `style-src 'self'` CSP remains sufficient.
+See [docs/custom-stylesheets.md](docs/custom-stylesheets.md) for sanitizer
+rules, `report=1`, scoping, and examples. See
+[docs/snapshots.md](docs/snapshots.md) for the public snapshot page and
+frame-ancestor sharing configuration.
 
 ## Agents
 
@@ -168,6 +162,22 @@ policies:
   path: agents/
   poll_interval: 5m
 ```
+
+## ClankeR contributor relay
+
+ClankeR lets contributors lend their own AI CLI subscription to a hive through
+`/contribute`. Contributors start as `newcomer`, auto-promote to `contributor`
+after 5 PR-backed completions and `trusted` after 20, and may receive
+maintainer-granted tiers such as `merger`. The merger tier can queue **other
+people's** PRs for Hive's auto-merge-on-green sweep, never its own.
+
+Relays can subscribe to multiple hubs by setting comma-separated `HIVE_HUB` and
+matching `HIVE_REGISTRATION_TOKEN` lists. Operators can also allow contributors
+to act as selected spoke roles with `HIVE_AGENT_ROLE` / **Acting as**,
+profile-level grant chips, and `hub.contribute_delegatable_roles`.
+
+See [docs/contributor-relay.md](docs/contributor-relay.md) and
+[docs/contributor-trust-and-roles.md](docs/contributor-trust-and-roles.md).
 
 ## Governor
 
@@ -243,6 +253,15 @@ knowledge:
 An experiment framework that lets you test configuration changes (models, cadences, thresholds) against live data before committing them. Experiments run in a sandbox with rollback on failure.
 
 Configure via the dashboard or the `/api/nous/*` endpoints. See `hive.yaml.example` for available options.
+
+## Further reading
+
+- [v2 docs index](docs/README.md) — all operator, contributor, and design docs.
+- [Cross-cluster migration](docs/cross-cluster-migration.md) — move a hive between clusters.
+- [Manual provisioning](docs/manual-provisioning.md) — hosted/spoke provisioning and hub access.
+- [Config layering](docs/config-layering.md) — ConfigMap vs PVC overlay precedence.
+- [Trajectory review](docs/trajectory-review.md) — trajectory safety lane.
+- [Credly badges](docs/credly-badges.md) — planned badge integration placeholder.
 
 ## Ports and Volumes
 

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -1,0 +1,37 @@
+# Hive v2 documentation
+
+Start with [Architecture](architecture.md) for the system overview, then use the topic guides below.
+
+## Operations
+
+- [Manual provisioning](manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
+- [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
+- [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
+- [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
+- [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
+- [hivectl](hivectl.md) — command-line client for the dashboard API.
+
+## Contributors and access
+
+- [ClankeR contributor relay](contributor-relay.md) — local contributor setup, multi-hub subscriptions, and role requests.
+- [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md) — newcomer/contributor/trusted/merger/advisor semantics, **Acting as**, grants, and delegatable roles.
+- [Credly badges](credly-badges.md) — planned integration design; currently a placeholder mapping only.
+
+## Configuration and agents
+
+- [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, and ACMM packs.
+- [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
+- [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.
+- [Podman rootless CI](podman-rootless-ci.md) — rootless Podman contract for `contribute-hive`.
+
+## Architecture and design
+
+- [Architecture](architecture.md) — process model, governor loop, guardrails, hub/spoke, and walkthrough.
+- [CNCF reference architecture](cncf-reference-architecture.md) — CNCF submission/reference template.
+- [Knowledge system design](design/knowledge-system.md) — llm-wiki layers, subscriptions, and APIs.
+- [Trajectory review](trajectory-review.md) — trajectory safety lane and review signals.
+
+## Historical/design notes
+
+Some documents describe planned or design-only work rather than live features. Those pages are marked at the top, for example [Credly badges](credly-badges.md).
+

--- a/v2/docs/contributor-relay.md
+++ b/v2/docs/contributor-relay.md
@@ -1,0 +1,41 @@
+# ClankeR contributor relay
+
+ClankeR lets a contributor lend their local AI CLI subscription to a hive. The relay connects to `/contribute`, receives one task at a time, runs the selected CLI in the contributor's environment, and reports completion/PR metadata back to the hive.
+
+## Basic setup
+
+From a checkout of this repository:
+
+```bash
+export HIVE_HUB=wss://hive.example.com/contribute
+just contribute-setup claude
+just contribute-hive
+```
+
+`compose-contributor.yaml`, `Dockerfile.contributor`, and the `just contribute-hive` recipe are the reference container path. Native mode is available through `just contribute-hive <backend> local` when a container runtime is not desired.
+
+## Multi-hub subscription
+
+A single relay can subscribe to multiple hives. Register with each hive first, then provide matching comma-separated lists:
+
+```bash
+export HIVE_HUB='wss://hive-a.example.com/contribute,wss://hive-b.example.com/contribute'
+export HIVE_REGISTRATION_TOKEN='token-from-hive-a,token-from-hive-b'
+just contribute-hive
+```
+
+The lists are positional: the first token belongs to the first hub, the second token belongs to the second hub, and so on. If the counts differ, the relay refuses to start rather than sending a token to the wrong hub.
+
+The relay keeps a WebSocket and heartbeat for each subscribed hub, but shares one CLI/tmux session and works on only one task at a time. It rotates to another hub when the active hub has no assignable work. A task that is blocked on human action stays with its owning hub; the relay does not mix task state across hubs.
+
+## Acting as a spoke agent role
+
+Set `HIVE_AGENT_ROLE` to request a delegated role, or use the **Acting as** control in `/contribute` where available:
+
+```bash
+export HIVE_AGENT_ROLE=quality
+just contribute-hive
+```
+
+The hive may override the request with an owner-assigned role. See [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md) for tier, grant, and allow-list requirements.
+

--- a/v2/docs/contributor-trust-and-roles.md
+++ b/v2/docs/contributor-trust-and-roles.md
@@ -1,0 +1,76 @@
+# Contributor trust tiers and delegated agent roles
+
+Hive exposes two related but separate authorization models:
+
+- **ClankeR contributor trust tiers** on `/contribute` decide what a community contributor relay may claim.
+- **Hub dashboard access roles** in **Manage Access** decide what an authenticated dashboard user may do to a hosted hive.
+
+They intentionally overlap in names only where the capability is similar. A contributor's AI CLI still runs with the contributor's own GitHub identity and scoped credential; taking a role never grants the spoke agent's secrets.
+
+## Contributor trust tiers
+
+Contributor profiles carry a `trust_tier` field. The current tier order is:
+
+| Tier | How it is reached | What it means |
+| --- | --- | --- |
+| `newcomer` | default self-registration | Rate-limited entry tier. |
+| `contributor` | auto-promoted after 5 completed tasks with PRs | May claim default delegated roles such as `scanner`, `quality`, and `outreach`. |
+| `trusted` | auto-promoted after 20 completed tasks with PRs, or granted by an operator | May use higher-trust workflows and, with explicit grants, privileged delegated roles. |
+| `merger` | maintainer/owner grant; it is not auto-promoted | May queue **other people's** PRs for Hive's auto-merge-on-green flow. |
+| `advisor` | maintainer/owner grant | Advisory/invite tier; it is not ordered above `merger` for role-claim checks. |
+
+The merger tier is deliberately **never allowed to own its own merge**. Queueing a PR as `merger` or `owner` is rejected when the authenticated dashboard user matches the PR author, and the auto-merge sweep re-checks the queued-by user before merging.
+
+## Merger capability and setup
+
+Operators grant merger from the hosted hive's **Manage Access** UI. The role sits between `read-write` and `owner` for dashboard access:
+
+`read` < `read-write` < `merger` < `owner`
+
+A merger inherits read/write dashboard access and can queue another contributor's PR. Queueing:
+
+1. approves the PR as the Hive GitHub App,
+2. applies the configured auto-merge label, and
+3. lets the auto-merge sweep merge once the PR is clean, non-draft, and green.
+
+Configure the label under `governor.labels.automerge`:
+
+```yaml
+governor:
+  labels:
+    automerge: lgtm
+```
+
+The default is `lgtm`, matching the Kubernetes/Prow convention. Hive creates the label on demand if it does not already exist.
+
+Merger appears in contributor tier listings, profile badges, leaderboard tier filters, and the Credly milestone mapping so operators and contributors can see that it is a distinct maintainer-granted trust tier.
+
+## Delegated ClankeR agent roles
+
+A contributor relay can request an agent role with `HIVE_AGENT_ROLE` or the WebSocket `auth_response.role`. The `/contribute` UI labels this as **Acting as**. Operators may also assign a role directly from a contributor card; that owner assignment is shown as the active role and takes precedence over whatever the relay requested.
+
+The current role gates are:
+
+| Role | Minimum contributor tier | Extra grant required? |
+| --- | --- | --- |
+| `scanner` | `contributor` | No |
+| `quality` | `contributor` | No |
+| `outreach` | `contributor` | No |
+| `ci-maintainer` | `trusted` | Yes |
+| `sec-check` | `trusted` | Yes |
+| `architect` | `trusted` | Yes |
+| `supervisor` | never delegatable | N/A |
+
+Hive also checks that the corresponding agent is enabled and that the role is in the hive-wide allow-list:
+
+```yaml
+hub:
+  contribute_delegatable_roles:
+    - scanner
+    - quality
+    - outreach
+    - ci-maintainer
+```
+
+If the list is empty, Hive uses the safe default: `scanner`, `quality`, and `outreach`. Privileged roles must be both listed here and granted on the contributor profile. The owner UI exposes these grants as chips/check boxes; assigning a privileged role auto-preserves the matching grant so reconnects keep working.
+

--- a/v2/docs/credly-badges.md
+++ b/v2/docs/credly-badges.md
@@ -1,5 +1,7 @@
 # Credly badges — integration design (planned, not yet built)
 
+> **Planned feature.** Hive currently ships only the contributor-card placeholder and milestone mapping. No live Credly API calls, credentials, or badge issuance exist yet.
+
 Status: **design only.** The contributor "Me" card (Leaderboard tab of
 `/contribute`) already shows a **Badges** section, but it is a labeled
 placeholder — it displays the milestone → badge *mapping* and makes **no external

--- a/v2/docs/custom-stylesheets.md
+++ b/v2/docs/custom-stylesheets.md
@@ -1,0 +1,46 @@
+# Custom stylesheets
+
+Hive can apply a shareable CSS theme from a public GitHub repository. The feature is available on three public/read-only surfaces:
+
+| Surface | Example |
+| --- | --- |
+| ClankeR leaderboard | `/contribute/leaderboard?style=owner/repo/path/to/theme.css@ref` |
+| Spoke dashboard | `/?style=owner/repo/path/to/theme.css@ref` |
+| Snapshot preview | `/snapshot?style=owner/repo/path/to/theme.css@ref` |
+
+The `@ref` suffix is optional and defaults to `HEAD`. Use the `owner/repo/path.css` triplet form, not a raw URL.
+
+## Fetching and scoping
+
+Hive fetches public GitHub raw content server-side without credentials, limits the response to 128 KiB, sanitizes it, then serves the sanitized stylesheet from same-origin endpoints. Dashboard and snapshot CSS is scoped to `#hive-dashboard-root`; leaderboard CSS is scoped to `#tab-leaderboard`. Login and setup overlays remain outside the dashboard theme surface.
+
+## Sanitizer rules
+
+Allowed CSS includes normal declarations, custom properties (`--name` and `var(--name)`), attribute and pseudo selectors, gradients, `calc()` / `clamp()`, modern color functions, and recursive `@media`, `@supports`, `@container`, and `@keyframes` rules. `@font-face` is retained only when every `src` URL is same-origin, relative, or `data:`.
+
+Hive removes `@import`, external or protocol-relative `url()` fetches, CSS escape sequences, `image-set()`, and legacy executable CSS vectors such as `expression()`, `behavior`, and `-moz-binding`.
+
+When anything is removed, the response includes `X-Hive-Style-Dropped: N`. Add `report=1` to `/api/style` or `/api/leaderboard/style` to get JSON containing the sanitized CSS and a short list of drop reasons.
+
+## Example
+
+```css
+:root {
+  --hive-accent: #f59e0b;
+}
+
+.card, .panel {
+  border-color: var(--hive-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  .metric-value { color: color-mix(in srgb, var(--hive-accent), white 20%); }
+}
+```
+
+Share it as:
+
+```text
+/snapshot?style=your-org/your-theme/hive.css@main
+```
+

--- a/v2/docs/health-checks.md
+++ b/v2/docs/health-checks.md
@@ -1,0 +1,43 @@
+# Dashboard route and health checks
+
+Hive reports dashboard health from both the spoke and hub vantage points. The newer checks replace the old assumption that the public hub can always probe every spoke URL directly.
+
+## Kubernetes RBAC
+
+Apply the dashboard route RBAC manifest with the other Kubernetes resources:
+
+```bash
+kubectl apply -f deploy/k8s/dashboard-route-rbac.yaml
+```
+
+It grants the `hive` ServiceAccount permission to list same-namespace `networking.k8s.io` Ingresses and OpenShift `route.openshift.io` Routes. Without this RBAC, the spoke reports route existence as `unknown` with an RBAC error; Hive treats unknown as non-fatal.
+
+## Heartbeat fields
+
+Each heartbeat may include:
+
+- `public_url_self_check` — the spoke dials its own listener through `127.0.0.1:3002` while preserving the advertised Host header. HTTP statuses below 500 are OK; repeated 5xx responses become fail; DNS/timeouts are unknown rather than dead-link alarms.
+- `route_exists` — the spoke confirms an Ingress or OpenShift Route for the advertised dashboard host in its namespace. Values are `found`, `missing`, or `unknown`.
+
+Both probes run at most every five minutes and use short timeouts. Missing fields mean an older spoke or a non-Kubernetes/local deployment and are treated as unknown.
+
+## Hub-side probing
+
+The hub still probes dashboard URLs, but only treats a failed public probe as critical for hub-fronted domains. Private-network or cluster-local hives can be unreachable from the public hub while healthy from their own users' path, so a fresh heartbeat plus an OK/unknown spoke self-check suppresses false dead-link alerts.
+
+A dashboard URL is considered healthy from the hub when it returns 200, a redirect, 401, or 403. 5xx, 404, and transport errors are failures.
+
+## Alert matrix and hysteresis
+
+Hive raises URL health alerts conservatively:
+
+| Signal | Alert behavior |
+| --- | --- |
+| Spoke listener self-check `fail` | Critical after three consecutive spoke failures. |
+| `route_exists: missing` | Critical; there is no Ingress/Route for the advertised host. |
+| Hub-fronted URL fails and heartbeat is stale/offline | Critical once hub-side failure thresholds are met. |
+| Hub-fronted URL fails but heartbeat is fresh and spoke self-check is OK/unknown | Informational/private-vantage signal, not a dead-link page. |
+| DNS blip, timeout, missing RBAC, or old spoke | Unknown; no alert by itself. |
+
+Hub-side hysteresis requires consecutive failures, a minimum hive age, and repeated dashboard evaluations before a critical URL alert reaches the Attention panel. Cluster-wide outages are rolled up instead of paging every hive individually.
+

--- a/v2/docs/sandbox-isolation.md
+++ b/v2/docs/sandbox-isolation.md
@@ -1,0 +1,18 @@
+# Sandbox isolation and agent guardrails
+
+Hive's v2 isolation model is defense in depth rather than a single sandbox switch. Agents run as long-lived CLI sessions, but the deterministic pipeline and proxy layers decide what work they see and what writes they can perform.
+
+## Isolation layers
+
+1. **Policy mode** — ACMM selects advisory, measured, hold-gated, or full behavior per agent.
+2. **Deterministic admission** — Go and shell checks classify work, apply holds, and decide whether an agent is kicked.
+3. **Scoped credentials** — contributor relays and spoke agents use the GitHub identity and token scope appropriate to that actor; a delegated ClankeR role does not grant spoke secrets.
+4. **MITM GitHub proxy** — GitHub API writes are attributed and constrained according to the current mode.
+5. **Merge gates** — hold labels, green checks, self-merge bans, and auto-merge sweeps are enforced outside the LLM prompt.
+
+## Operator notes
+
+- Prefer the least-capable ACMM level that matches the project phase.
+- Keep privileged delegated roles (`ci-maintainer`, `sec-check`, `architect`) behind explicit grants.
+- Use the docs in this index for concrete setup: [ACMM policy matrix](acmm-policy-matrix.md), [Agent configuration](agent-configuration.md), and [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md).
+

--- a/v2/docs/snapshots.md
+++ b/v2/docs/snapshots.md
@@ -1,0 +1,40 @@
+# Public snapshots
+
+`/snapshot` is a read-only, public view of a hive's current dashboard state. It is intended for sharing status with communities, embedding in project pages, or linking from a hub without granting dashboard write access.
+
+Snapshots are available when the spoke has auto-snapshots enabled:
+
+```yaml
+hub:
+  auto_snapshot: true
+```
+
+The backing JSON is served from `/api/snapshot` with public cache headers. Both `/snapshot` and `/api/snapshot` are public paths, but they reject write methods and expose only the status payload, not mutating dashboard APIs.
+
+## Custom CSS
+
+The snapshot page accepts the same sanitized stylesheet parameter as the dashboard:
+
+```text
+/snapshot?style=owner/repo/path/to/theme.css@ref
+```
+
+See [Custom stylesheets](custom-stylesheets.md) for allowed CSS and sanitizer reporting.
+
+## Embedding and frame ancestors
+
+By default Hive fails closed: snapshot pages send `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'`.
+
+To allow selected HTTPS origins to embed `/snapshot`, configure:
+
+```yaml
+dashboard:
+  snapshot_frame_ancestors:
+    - https://docs.example.org
+    - https://status.example.org:8443
+```
+
+Only exact HTTPS origins are accepted. Paths, wildcards, non-HTTPS origins, and malformed hosts are rejected. When an allow-list is present, `/snapshot` omits `X-Frame-Options` because that header cannot express multiple allowed origins; every other route keeps `DENY`.
+
+The current allow-list is visible at `/api/snapshot/frame-ancestors` for operators debugging embed configuration.
+


### PR DESCRIPTION
## Summary
- add v2 docs index and link previously hidden operator/contributor docs
- document merger trust tier, owner-assigned ClankeR roles, multi-hub relay, custom stylesheets, snapshots, and health checks
- mark Credly badges as planned and link it from the docs index

## Validation
- python markdown link check

Fixes #3015
Fixes #3064
Fixes #3018
Fixes #3017
Fixes #2968
Fixes #3051
Fixes #2955
Fixes #3052
Fixes #2895
Fixes #3001
Fixes #2909
Fixes #3066
Fixes #2912