### PR TITLE
📖 docs: resolve guide documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ kubectl apply -f deploy/k8s/service.yaml
 
 ## Configuration
 
-All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, and [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for the full agent configuration guide — every field, methods and model discovery, pinning, cadences, and ACMM packs. Read [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent — what it does, how it differs from the governor, when to enable it, and how `bead_role` and policy modes work.
+All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
 
 ```yaml
 project:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,14 @@ The agent starts, reads its policy, then **waits at the prompt** for the supervi
 
 ---
 
+
+## v2 runtime and control plane
+
+v2 runs the dashboard/API service, agent manager, governor, policy resolver, and optional contributor hub from the Go server plus the Node reverse proxy in `v2/proxy`. Operators automate it through the dashboard API or `hivectl`, the non-interactive CLI documented in [`v2/docs/hivectl.md`](../v2/docs/hivectl.md).
+
+Agent behavior is controlled by layered config and policy templates: see [`v2/docs/agent-configuration.md`](../v2/docs/agent-configuration.md), [`v2/policies/README.md`](../v2/policies/README.md), and [`docs/backend-setup.md`](backend-setup.md).
+
+---
 ## Four components, four failure modes
 
 | # | Unit | Trigger | Catches |

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -1,0 +1,32 @@
+# Agent backend setup
+
+Hive validates backend names in `v2/pkg/config` and launches CLIs in `v2/pkg/agent/manager.go`. `backend:` selects the runtime for an agent; inference backends are covered separately in [inference-backends.md](inference-backends.md).
+
+## CLI backends
+
+| Backend | Binary launched by the Go manager | Auth / setup | Notes |
+| --- | --- | --- | --- |
+| `claude` | `claude` | Install Claude Code and log in once. Hive launches with `--dangerously-skip-permissions`; inference routes add `--bare --settings`. | Advisory/issue modes add disallowed GitHub MCP tools. |
+| `copilot` | `copilot` | Install GitHub Copilot CLI and authenticate with GitHub. Hive also probes Copilot model entitlements live. | Launched with `--no-auto-update --allow-all`; write tools are denied by mode when needed. |
+| `gemini` | `gemini` | Install Gemini CLI and configure its normal auth/API key. | Hive passes `--model`. |
+| `goose` | `goose` | Install Block Goose and configure provider/model (`GOOSE_PROVIDER`, `GOOSE_MODEL`, or `goose configure`). | Hive launches `goose run -s` and appends `--model` when set. |
+| `pi` | `goose` in the Go manager; `pi` in contributor scripts | In the server-side manager, `pi` is currently a Goose alias because `backendBinary("pi")` maps to `goose`. Configure Goose for pod agents. The contributor relay image/scripts still know a separate `pi` binary. | Do not assume the pod path uses pi.dev until the manager mapping changes. |
+| `bob` | `bob` | Provide `HIVE_BOB_API_KEY` or `/secrets/bob_api_key` for pods; contributor mode requires `BOBSHELL_API_KEY`. | Hive uses API-key auth headlessly and accepts the Bob license at launch. |
+| `codex` | accepted by config; contributor scripts launch `codex` | Install `@openai/codex` and provide `OPENAI_API_KEY`. Contributor mode sets a per-agent `CODEX_HOME`. | v2 HEAD server-side `backendBinary` does not map `codex`, so use it in contributor mode unless the manager mapping has been updated. |
+| `aider` | accepted by config; contributor scripts launch `aider` | Install Aider and configure its provider/API key normally. | v2 HEAD server-side `backendBinary` does not map `aider`, so use it in contributor mode unless the manager mapping has been updated. |
+
+## Contributor relay image
+
+`v2/Dockerfile.contributor` builds the ClankeR image used by `just contribute-hive`. It installs Claude Code, Copilot, Codex, Bob, Goose, Pi, `gh`, Go, tmux, and the relay scripts. `v2/compose-contributor.yaml` runs that image with your local Hive config and selected backend:
+
+```bash
+AGENT_BACKEND=claude just contribute-hive
+AGENT_BACKEND=goose GOOSE_PROVIDER=anthropic GOOSE_MODEL=claude-sonnet-4-6 just contribute-hive
+AGENT_BACKEND=litellm HIVE_LITELLM_ENDPOINT=https://litellm.example.com just contribute-hive
+```
+
+`just contribute-check <backend>` runs a read-only preflight before registration. It checks that the chosen CLI exists and that obvious auth prerequisites are present.
+
+## Secrets
+
+Store secret values outside `hive.yaml`. YAML should contain env var names or key-file paths, not keys. The dashboard and config save path rewrite YAML, so a literal secret in YAML would be persisted in plaintext.

--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -2,52 +2,23 @@
 
 ## Overview
 
-Hive Federation allows any open source project to run their own Hive instance
-and join a network where contributors can discover and join any participating
-project's swarm. A contributor runs `just contribute-browse` to find projects
-that need help, then `just contribute-hive` pointed at that project's hub —
-**ClankeR**, the contributor relay, carries that project's tasks to the agent on
-their machine.
+Hive Federation lets independent Hive instances publish themselves in a registry so contributors can discover projects and connect a local ClankeR contributor relay to one or more hubs. The registry is a directory, not a control plane: every hive keeps its own credentials, queue, agents, contributor registry, and trust policy.
 
-## How a New Project Signs Up
+## Current v2 implementation
 
-### 1. Install the Hive GitHub App
+The v2 Go dashboard API implements the federation endpoints in `v2/pkg/dashboard/api_contribute.go`:
 
-The project maintainer installs the shared [Hive GitHub App](https://github.com/apps/kubestellar-hive-bot) on their GitHub org/repos. This gives their Hive instance the ability to mint scoped installation tokens for contributors.
+- `GET /api/hives` — list registered hives.
+- `POST /api/hives/register` — add or update a hive entry.
+- `POST /api/hives/:id/heartbeat` — update live counts such as active contributors/agents and actionable work.
+- `DELETE /api/hives/:id` — remove a hive.
+- `POST /api/hives/onboard` — generate starter deployment/config text.
 
-### 2. Generate Starter Config
+Registry storage defaults to `/data/federation/registry.json` in v2 and can be overridden for tests with `HIVE_FEDERATION_REGISTRY_PATH`.
 
-```bash
-curl -X POST https://hive.kubestellar.io/api/hives/onboard \
-  -H "Content-Type: application/json" \
-  -d '{
-    "project_name": "drasi",
-    "org": "drasi-project",
-    "repos": ["drasi-project/drasi-platform", "drasi-project/drasi-docs"],
-    "github_app_id": "123456",
-    "github_app_installation_id": "789012"
-  }'
-```
+## Project onboarding
 
-Returns:
-- `hive-project.yaml` — project config with repos, agents, dashboard settings
-- `docker-compose.yaml` — ready to deploy
-- Step-by-step instructions
-
-### 3. Deploy Their Hive
-
-```bash
-# On their server/VM
-mkdir -p /etc/hive
-# Save hive-project.yaml to /etc/hive/
-# Save GitHub App private key to /etc/hive/gh-app-key.pem
-docker compose up -d
-```
-
-The Hive starts with `scanner` and `supervisor` agents by default.
-The project can enable more agents as their needs grow.
-
-### 4. Register with the Federation
+A project maintainer installs/configures GitHub auth for their Hive, generates or writes v2 config, deploys the Hive, and registers it:
 
 ```bash
 curl -X POST https://hive.kubestellar.io/api/hives/register \
@@ -57,62 +28,31 @@ curl -X POST https://hive.kubestellar.io/api/hives/register \
     "org": "drasi-project",
     "hub_url": "wss://drasi-hive.example.com:3001/contribute",
     "dashboard_url": "https://drasi-hive.example.com:3001",
-    "contact_email": "maintainer@drasi.io"
+    "contact_email": "maintainer@example.com"
   }'
 ```
 
-Now the project appears in `just contribute-browse` and on the
-federation directory at `https://hive.kubestellar.io/api/hives`.
+The starter endpoint can produce bootstrap text, but it is not a substitute for reviewing secrets, storage, ingress, and ACMM level before production.
 
-## Contributor Flow
+## Contributor flow
 
-```
-$ just contribute-browse
-
-=== Available Hives ===
-
-  KubeStellar Console (kubestellar)
-    Hub: wss://hive.kubestellar.io:3001/contribute
-    Dashboard: https://hive.kubestellar.io:3001
-    Contributors: 12 active
-    Actionable: 8 items
-
-  Drasi (drasi-project)
-    Hub: wss://drasi-hive.example.com:3001/contribute
-    Dashboard: https://drasi-hive.example.com:3001
-    Contributors: 3 active
-    Actionable: 15 items
-
-  Keptn (keptn)
-    Hub: wss://keptn-hive.cncf.io:3001/contribute
-    Dashboard: https://keptn-hive.cncf.io:3001
-    Contributors: 0 active
-    Actionable: 23 items
-```
-
-The contributor can then target a specific hive:
+A contributor can browse hives, then point ClankeR at one or more hubs:
 
 ```bash
+just contribute-browse
 HIVE_HUB=wss://drasi-hive.example.com:3001/contribute just contribute-hive
 ```
 
-Or register with multiple hives and subscribe to them from one relay session (added by [@hanthor](https://github.com/hanthor) in [#2846](https://github.com/kubestellar/hive/pull/2846)):
+Multiple hubs are supported by comma-separated `HIVE_HUB` and `HIVE_REGISTRATION_TOKEN` values in the same order. The relay keeps separate WebSocket connections/heartbeats and works on one task at a time.
 
-```bash
-export HIVE_HUB=wss://drasi-hive.example.com:3001/contribute,wss://keptn-hive.cncf.io:3001/contribute
-export HIVE_REGISTRATION_TOKEN=drasi-token,keptn-token
-just contribute-hive
-```
-
-Keep the tokens in the same order as the hub URLs. The relay uses one CLI/tmux session, keeps a separate WebSocket connection and heartbeat per hub, works on one task at a time, and only round-robins to the next hub when the active hub explicitly reports that no task is available.
-
-## Federation Architecture
+## Architecture
 
 ```
 ┌──────────────────────────┐
-│  Federation Registry     │  hive.kubestellar.io
-│  GET /api/hives          │  (the KubeStellar hive doubles as registry)
-│  POST /api/hives/register│
+│ Federation registry      │
+│ GET /api/hives           │
+│ POST /api/hives/register │
+│ POST /api/hives/:id/heartbeat
 └──────────┬───────────────┘
            │ lists
     ┌──────┴──────┬──────────────┐
@@ -120,58 +60,30 @@ Keep the tokens in the same order as the hub URLs. The relay uses one CLI/tmux s
 ┌─────────┐ ┌─────────┐  ┌─────────┐
 │ KS Hive │ │ Drasi   │  │ Keptn   │
 │ Hub     │ │ Hive Hub│  │ Hive Hub│
-│ :3001   │ │ :3001   │  │ :3001   │
 └────┬────┘ └────┬────┘  └────┬────┘
      │           │            │
-  Contributors connect directly to each hub
+  contributors connect directly to each hub
 ```
 
-Each hive is fully independent:
-- Own GitHub App credentials
-- Own agent fleet
-- Own work queue
-- Own contributor registry
-- Own trust tiers
+Each hive owns:
 
-The federation registry is just a directory — it doesn't proxy traffic or
-manage credentials across hives. Each hub handles its own WebSocket
-connections and token minting.
+- GitHub App/PAT credentials.
+- Agent fleet and ACMM level.
+- Work queue and claims.
+- Contributor registration and trust tier.
+- Dashboard and `/contribute` WebSocket endpoint.
 
-## What Each Hive Gets
+## Operational notes
 
-- **Dashboard** at port 3001 with agent status, queue, sparklines
-- **Agent fleet** (scanner, supervisor, + whatever they enable)
-- **Contributor WebSocket** (ClankeR) at `/contribute`
-- **Scoped GitHub tokens** via the shared Hive GitHub App
-- **Governor** that adapts agent cadence to queue depth
-- **Nous Strategy Lab** for automated experimentation (optional)
+- The registry does not proxy contributor traffic or mint credentials for remote hives.
+- Heartbeats are implemented; operators still need to run the heartbeat sender or otherwise call the endpoint.
+- Registration has validation and a maximum registry size, but production deployments should still place the public registry behind normal rate limiting and abuse controls.
 
-## Future: Cross-Hive Contributor Reputation
+## Design-future items
 
-A contributor who builds trust in one hive could have that reputation
-portable to other hives. A signed attestation from Hive A saying
-"this contributor completed 20 tasks with 0 revocations" could be
-presented to Hive B to skip the newcomer tier.
+These are not complete in v2 HEAD and should be treated as future design work:
 
-This is out of scope for the initial implementation but the
-per-hive contributor profile (`/etc/hive/contributors/<user>.json`)
-already tracks the data needed to issue such attestations.
-
-## Implementation Status
-
-### Done (in PR #798)
-- `GET /api/hives` — list registered hives
-- `POST /api/hives/register` — register a remote hive
-- `DELETE /api/hives/:id` — remove a hive
-- `POST /api/hives/onboard` — generate starter config
-- `just contribute-browse` — discover available hives
-- Federation registry storage at `/etc/hive/federation/registry.json`
-
-### TODO
-- [ ] Heartbeat: registered hives periodically ping the registry with
-      their current active contributor count and actionable items
-- [ ] Web UI: add a "Join a Hive" page at `/contribute` with project
-      cards showing description, star count, contributor needs
-- [ ] GitHub App installation guide with screenshots
-- [ ] Cross-hive reputation attestations
-- [ ] Rate limiting on registration endpoint
+- A polished web UI for joining hives from project cards.
+- Screenshot-level GitHub App installation guide.
+- Portable cross-hive contributor reputation attestations.
+- Stronger public registry abuse controls beyond the current API validation and size cap.

--- a/docs/inference-backends.md
+++ b/docs/inference-backends.md
@@ -1,0 +1,60 @@
+# Inference backends
+
+Hive can route agents through OpenAI-compatible model gateways instead of a subscription CLI model. The supported gateway backend IDs in v2 HEAD are `vllm`, `llm-d`, `litellm`, and `watsonx`; this guide focuses on `vllm`, `llm-d`, and `litellm`.
+
+## How routing works
+
+The agent still launches Claude Code in bare mode. Hive writes Claude settings that point `ANTHROPIC_BASE_URL` at Hive's local translator, then the translator converts Anthropic Messages API calls to OpenAI-compatible requests and forwards them to the selected gateway. The backend name selects the upstream route; it is not a separate agent binary.
+
+## Configure a gateway
+
+Use the dashboard's **Governor Config → Model Gateways** UI, or YAML. A gateway needs a name, kind, endpoint, optional key reference, and optional default model. Agents can then set `backend:` to either the built-in kind (`vllm`, `llm-d`, `litellm`) or to a configured gateway name.
+
+LiteLLM also has a dedicated config block:
+
+```yaml
+governor:
+  litellm:
+    endpoint: https://litellm.example.com
+    api_key_env: HIVE_LITELLM_API_KEY
+    api_key_file: /secrets/litellm_api_key
+    default_model: gpt-4o
+    ca_bundle: /secrets/litellm-ca.pem
+    local_proxy: false
+```
+
+Endpoint environment overrides used by v2 include:
+
+- `HIVE_VLLM_ENDPOINT` for `vllm`
+- `HIVE_LLMD_ENDPOINT` for `llm-d`
+- `HIVE_LITELLM_ENDPOINT` for LiteLLM
+- `HIVE_LITELLM_API_KEY` or `api_key_file` for LiteLLM bearer auth
+- `HIVE_LITELLM_MODELS` as a comma-separated fallback model list when discovery fails
+
+Never put the key value itself in YAML.
+
+## Model discovery
+
+Hive probes `/v1/models` on OpenAI-compatible gateways. LiteLLM discovery includes bearer auth when a key is configured. If discovery fails, the UI falls back to static or configured model lists and marks entries as unverified; fallback data should not be treated as proof that the endpoint is healthy.
+
+## Guided example: Watsonx via gateway
+
+The watsonx path uses the same gateway machinery: configure the gateway endpoint and credentials, verify `/v1/models`, then assign an agent to that backend/gateway. Use it as the guided flow for any enterprise gateway:
+
+1. Create the gateway in the Model Gateways UI.
+2. Store the key in a secret file or env var reference.
+3. Click model discovery and choose an entitlement-visible model.
+4. Assign a low-risk agent and run one manual kick.
+5. Check agent logs for route/model passthrough and upstream HTTP errors.
+
+## Common failures
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `401` or repeated gateway auth errors | Missing/stale API key or wrong LiteLLM virtual key | Rotate the key, update the env/file reference, restart or reload the hive. |
+| Model dropdown empty or unverified | `/v1/models` unreachable or blocked | Check endpoint URL, network policy, TLS CA bundle, and gateway logs. |
+| Agent starts but every prompt fails | Endpoint does not implement OpenAI chat completions for the selected model | Select a chat-capable model or fix gateway routing. |
+| Connection refused / timeout | Service name or port is wrong, or NetworkPolicy blocks it | From the Hive pod, curl the gateway health and `/v1/models` endpoints. |
+| Model rejected despite discovery | The agent model differs from the gateway entitlement name | Use the exact model ID returned by `/v1/models`; Hive passes it through verbatim. |
+
+See also [`v2/deploy/inference/README.md`](../v2/deploy/inference/README.md) for the sample in-cluster vLLM-compatible deployment.

--- a/docs/migration-v1-v2.md
+++ b/docs/migration-v1-v2.md
@@ -1,0 +1,59 @@
+# Migrating from Hive v1 to v2
+
+This guide is practical rather than automatic: v2 changes the runtime layout, config model, and agent policy system enough that you should migrate deliberately.
+
+## Before you start
+
+1. Stop v1 agents cleanly.
+2. Back up the hub/dashboard data and any persistent `/data` or `/etc/hive` volumes. If you use the hosted hub, export the registry/contributor state before changing deployments.
+3. Save a copy of your v1 `hive.yaml`, agent policy files, secrets, GitHub App IDs, and private key mounts.
+4. Create a new v2 branch/deployment and test it before pointing production traffic at it.
+
+## What changes
+
+| Area | v1 | v2 |
+| --- | --- | --- |
+| Layout | Top-level scripts and dashboard pieces were the main operator surface. | Runtime code and examples live under `v2/`; root docs still link to shared concepts. |
+| Config | Mostly one static `hive.yaml`. | Layered config: seed `/etc/hive/hive.yaml`, dashboard overlay `/data/hive.yaml.dashboard`, per-agent files in `/data/agent-configs/`, runtime snapshot, and secret dirs. |
+| Agents | Hand-built rosters and policies. | ACMM packs generate/merge curated rosters, modes, templates, and cadences. |
+| Prompts | Local policy files. | Policy checkout, embedded defaults in `v2/policies`, dashboard/`hivectl` prompt edits, and optional allowlisted GitHub prompt sources. |
+| Backends | Mainly subscription CLIs. | CLI backends plus OpenAI-compatible inference gateways (`vllm`, `llm-d`, `litellm`, `watsonx`). |
+| Contributor flow | Local worker scripts. | ClankeR contributor relay, `Dockerfile.contributor`, `compose-contributor.yaml`, and `just contribute-*` commands. |
+
+## What carries over
+
+- GitHub org/repo lists and the primary repo.
+- GitHub App identity, installation ID, and private key, or PAT-based auth if you still use it.
+- Agent intent: scanner, ci-maintainer, quality, guide, architect, security, supervisor, strategist, and outreach all map to v2 agents.
+- Custom prompts, after renaming them to v2 `kick_template` files or importing them through the dashboard/`hivectl`.
+- Knowledge/wiki content if mounted or exported into the v2 knowledge layer.
+
+## Suggested migration path
+
+1. Check out v2 and copy the example config:
+
+   ```bash
+   git clone -b v2 https://github.com/kubestellar/hive.git hive-v2
+   cd hive-v2/v2
+   cp hive.yaml.example hive.yaml
+   ```
+
+2. Port `project:` and `github:` first. Keep secrets as env vars or files under `/secrets`; do not paste key values into YAML.
+3. Pick an ACMM level close to your current operating model. Start lower than production autonomy; L2/L3 is a safer first boot than L5/L6.
+4. Port custom agents one at a time. Preserve `backend`, `model`, `beads_dir`, `clear_on_kick`, and cadence intent, but use v2 mode names and templates.
+5. Copy or configure policy files. Prefer a policy checkout under `/data/policies/...` so prompt changes do not require rebuilding Hive.
+6. Start v2 with one or two agents enabled. Verify dashboard health, GitHub auth, model discovery, and a manual kick.
+7. Enable the rest of the roster, then raise ACMM level only after CI and merge gates behave as expected.
+
+## Validation checklist
+
+- `hivectl system status` returns healthy.
+- Dashboard shows the expected agents and ACMM modes.
+- Each enabled backend reports authenticated or has a configured gateway endpoint.
+- A manual kick uses the expected policy template.
+- GitHub writes happen only at the intended ACMM level.
+- Backups and rollback instructions are stored outside the new deployment.
+
+## Rollback
+
+Keep the v1 deployment and data untouched until v2 has run through at least one full agent cycle. If rollback is needed, stop v2, restore the old DNS/ingress/service target, and restart v1 with the backed-up config and volumes.

--- a/examples/agents/brainstorm.md
+++ b/examples/agents/brainstorm.md
@@ -1,0 +1,44 @@
+# ${PROJECT_NAME} Brainstorm
+
+You are the **brainstorm** agent for ${PROJECT_ORG}/${PROJECT_PRIMARY_REPO}. You turn raw ideas into structured proposals, project knowledge, and advisory beads for humans and specialist agents.
+
+## Pre-flight (MANDATORY — every kick)
+
+1. Re-read this policy file from disk.
+2. Re-read your ACMM level fragment.
+3. Read the tail of your heartbeat log.
+
+**Do NOT rely on in-context memory from previous iterations.**
+
+## Core responsibilities
+
+1. **Inception** — turn an operator idea into vision, requirements, constraints, risks, and acceptance criteria.
+2. **Ideation** — propose feature directions, architecture options, and experiment candidates.
+3. **Knowledge capture** — write durable facts that guide later scanner, guide, architect, and strategist work.
+4. **Handoff** — produce concise beads for humans or specialist agents; do not implement the work yourself.
+
+## Output format
+
+Use this structure for proposals:
+
+```markdown
+## Idea
+## User / stakeholder
+## Problem
+## Proposed direction
+## Constraints
+## Risks
+## Acceptance criteria
+## Suggested owner agent
+```
+
+## Constraints
+
+- Brainstorm runs advisory in the shipped ACMM packs.
+- It is normally `on_demand: true`; wait for an inception/user prompt rather than polling the queue.
+- Do not open PRs or issues unless the ACMM fragment explicitly grants that ability.
+- Do not invent project facts. Mark assumptions and ask a human or guide agent to verify them.
+
+## Heartbeat — MANDATORY
+
+Log every iteration. Write BEFORE doing work.

--- a/examples/kubestellar-fixer.md
+++ b/examples/kubestellar-fixer.md
@@ -1,0 +1,34 @@
+# KubeStellar fixer case study
+
+This example documents the original KubeStellar fixer pattern referenced by the launchd and worker examples in this repository.
+
+## Goal
+
+Run a small supervised worker on an always-on machine that repeatedly finds actionable KubeStellar issues, asks an AI coding CLI to fix one item, opens a signed PR, and reports status without giving the agent direct control over scheduling or credentials.
+
+## Pieces
+
+- `examples/worker.sh.example` shows the outer worker loop.
+- `launchd/com.hive.scanner.plist.example` shows how macOS keeps the loop alive.
+- `bin/enumerate-actionable.sh`, `bin/run-pipeline.sh`, and `bin/merge-gate.sh` are the deterministic shell gates that decide what reaches the agent.
+- Agent policy files under `examples/kubestellar/agents/` define lane boundaries and heartbeat rules.
+
+## Flow
+
+1. The scheduler starts the worker on a cadence.
+2. The deterministic pipeline lists candidate issues/PRs and filters out unsafe or already-claimed work.
+3. The agent receives one bounded task plus policy instructions.
+4. The worker verifies tests/builds and opens a PR rather than pushing to the protected branch.
+5. Merge gates and humans decide whether the PR lands.
+
+## Why this pattern matters
+
+The important design choice is separation of duties: shell scripts own credentials, filtering, and merge gates; the AI agent owns reasoning and code changes. That makes failures observable and keeps policy enforceable even when an agent misunderstands a prompt.
+
+## Adapting it
+
+- Replace the KubeStellar repo list with your own `project.repos`.
+- Start with advisory or issue-only mode before enabling PR creation.
+- Keep a heartbeat log and stale timeout longer than the worker cadence.
+- Require signed commits and CI before merge.
+- Prefer v2 ACMM packs for new deployments; use this case study when you need the older standalone worker shape.

--- a/v2/README.md
+++ b/v2/README.md
@@ -62,7 +62,7 @@ When dashboard authentication is enabled, `hivectl` reads
 output, stdin-based imports, and explicit confirmation for destructive
 operations.
 
-See [docs/hivectl.md](docs/hivectl.md) for the full command reference.
+See [docs/hivectl.md](docs/hivectl.md) for the full command reference. The architecture overview also calls out `hivectl` as the non-interactive API client for automation.
 
 See [docs/README.md](docs/README.md) for the full v2 documentation index.
 
@@ -86,7 +86,7 @@ hub-fronted URL probing, and alert hysteresis.
 
 ## Configuration
 
-All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference.
+All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [docs/agent-configuration.md](docs/agent-configuration.md) for agent fields and ACMM packs, [../docs/backend-setup.md](../docs/backend-setup.md) for CLI backend setup, and [../docs/migration-v1-v2.md](../docs/migration-v1-v2.md) for migration from v1.
 
 ```yaml
 project:
@@ -197,6 +197,10 @@ governor:
       threshold: 0
 ```
 
+## Contributor relay image
+
+`Dockerfile.contributor` and `compose-contributor.yaml` build/run the ClankeR contributor image used by `just contribute-hive`. The image contains the relay scripts plus common CLIs; compose mounts your local contributor config read-only and selects `AGENT_BACKEND`. See [../docs/backend-setup.md](../docs/backend-setup.md#contributor-relay-image).
+
 ## Inference Backends
 
 Besides CLI backends (claude, copilot, …), agents can run against
@@ -229,6 +233,8 @@ for litellm); `HIVE_LITELLM_MODELS` is a comma-separated fallback list.
 With `local_proxy: true`, hive supervises a bundled `litellm` process on
 loopback (config at `/data/litellm/config.yaml`) and routes through it
 instead of the remote endpoint — agents never bypass the Go translator.
+
+See [../docs/inference-backends.md](../docs/inference-backends.md) for setup and troubleshooting, and [deploy/inference/README.md](deploy/inference/README.md) for the sample in-cluster vLLM-compatible deployment.
 
 ## Knowledge
 

--- a/v2/deploy/inference/README.md
+++ b/v2/deploy/inference/README.md
@@ -1,0 +1,40 @@
+# Inference deployment manifests
+
+This directory contains a small in-cluster inference example for Hive's `vllm`/OpenAI-compatible backend path.
+
+## What it deploys
+
+- `vllm-deployment.yaml` creates namespace `hive-inference`, a placeholder `hf-token` Secret, a single `vllm` Deployment, and `vllm-svc` on port 8000.
+- The container is `ghcr.io/ggml-org/llama.cpp:server`, not CUDA vLLM. It serves the OpenAI-compatible API shape Hive needs, which is why it works with `backend: vllm` despite running llama.cpp.
+- An init container downloads `Qwen2.5-0.5B-Instruct` GGUF into an `emptyDir` volume.
+- `hive-epp-rbac.yaml` adds durable RBAC plus an `InferencePool` for the live llm-d endpoint picker service account.
+- `kustomization.yaml` applies both resources.
+
+## Prerequisites
+
+- A Kubernetes cluster that can pull the images and has enough CPU/memory for the sample model.
+- Network reachability from the Hive pod to `http://vllm-svc.hive-inference.svc:8000` or your chosen Service DNS name.
+- For `hive-epp-rbac.yaml`, the InferencePool CRDs must be installed before applying that file.
+
+## Apply
+
+```bash
+kubectl apply -k v2/deploy/inference
+kubectl -n hive-inference rollout status deploy/vllm
+kubectl -n hive-inference get svc vllm-svc
+```
+
+Then configure Hive:
+
+```yaml
+agents:
+  guide:
+    backend: vllm
+    model: qwen2.5-0.5b-instruct
+```
+
+If the service DNS differs, set `HIVE_VLLM_ENDPOINT` or configure a named Model Gateway in the dashboard.
+
+## Relationship to the `vllm` backend
+
+`backend: vllm` does not execute a `vllm` binary. Hive launches Claude Code in bare mode and routes model traffic through its translator to the configured OpenAI-compatible endpoint. These manifests are only one possible endpoint implementation.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -10,6 +10,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
 - [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
+- [ioscan status](ioscan.md) — v2 status of the untrusted-input scanner/canary feature.
 
 ## Contributors and access
 
@@ -23,6 +24,9 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.
 - [Podman rootless CI](podman-rootless-ci.md) — rootless Podman contract for `contribute-hive`.
+- [CLI backend setup](../../docs/backend-setup.md) — setup notes for Claude, Copilot, Goose, Bob, Pi, Codex, and Aider.
+- [Inference backends](../../docs/inference-backends.md) — vLLM, llm-d, LiteLLM, and Model Gateway troubleshooting.
+- [v1 to v2 migration](../../docs/migration-v1-v2.md) — migration checklist and rollback notes.
 
 ## Architecture and design
 
@@ -33,5 +37,4 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 
 ## Historical/design notes
 
-Some documents describe planned or design-only work rather than live features. Those pages are marked at the top, for example [Credly badges](credly-badges.md).
-
+Some documents describe planned or design-only work rather than live features. Those pages are marked at the top, for example [Credly badges](credly-badges.md). `ioscan` is also documented as absent from v2 HEAD until code is reintroduced.

--- a/v2/docs/acmm-policy-matrix.md
+++ b/v2/docs/acmm-policy-matrix.md
@@ -25,7 +25,7 @@ A single interactive advisor helps with repo setup and architecture decisions. G
 | Agent | Mode | Template |
 |-------|------|----------|
 | guide | advisory | `guide-advisory.md` |
-| brainstorm | advisory | `brainstorm-inception.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
 
 ### L2 — Advisory (Instructed) (5 agents)
 

--- a/v2/docs/ioscan.md
+++ b/v2/docs/ioscan.md
@@ -1,0 +1,29 @@
+# ioscan status in v2
+
+`ioscan` is not present in v2 HEAD. There is no `ioscan` package, no `ioscan:` config block in `v2/hive.yaml.example`, and no canary/fail-mode implementation wired into the v2 kick path.
+
+If you are reading older notes that mention:
+
+```yaml
+ioscan:
+  enabled: true
+  fail_mode: open
+  canaries: false
+```
+
+that configuration is stale for v2 and has no effect unless a downstream fork has added its own scanner.
+
+## What exists today
+
+- Prompt and agent-definition sourcing fail closed on unallowlisted GitHub repositories.
+- Prompt fetch failures fail open to the last cached or embedded template so kicks are not blanked by transient GitHub/API outages.
+- GitHub PR claim and trust checks generally fail closed where duplicate work or privilege escalation is possible.
+
+## What does not exist today
+
+- No v2 canary injection for kick prompts.
+- No v2 canary-trip handling.
+- No v2 `fail_mode: open` redaction path.
+- No v2 `fail_mode: closed` kick-blocking path.
+
+Operators should not enable ioscan in v2 configs. If ioscan is reintroduced, document the exact package, config schema, fail-open/fail-closed behavior, canary format, logging, and interaction with the deterministic pipeline in this file as part of the same change.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -29,7 +29,7 @@ agents:
   scanner:
     # id: scan-01                         # Stable internal key (defaults to YAML key)
     enabled: true
-    backend: claude                       # claude | copilot | gemini | goose
+    backend: claude                       # claude | copilot | gemini | goose | bob | pi | codex | aider | vllm | llm-d | litellm | watsonx
     model: claude-sonnet-4-6
     caveman_mode: full                    # lite | full | ultra | wenyan — compresses output ~65%
     beads_dir: /data/beads/scanner
@@ -132,6 +132,50 @@ agents:
     display_name: Security
     description: Audits dependencies, container images, secrets exposure
     sort_order: 60
+  guide:
+    enabled: false
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/guide
+    clear_on_kick: true
+    display_name: Guide
+    description: Documentation and architecture guide — explains, documents, and files doc work
+    role: guide
+    sort_order: 15
+    emoji: "🧭"
+    color: "#8e44ad"
+    kick_template: guide-advisory.md
+    include_repos: true
+  strategist:
+    enabled: false
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/strategist
+    clear_on_kick: true
+    display_name: Strategist
+    description: Roadmap alignment, experiments, and cross-agent trend analysis
+    role: strategist
+    sort_order: 70
+    emoji: "🧠"
+    color: "#f39c12"
+    kick_template: strategist-holdgated.md
+    include_repos: false
+  brainstorm:
+    enabled: false
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/brainstorm
+    clear_on_kick: true
+    display_name: Brainstorm
+    description: On-demand inception and ideation agent
+    role: brainstorm
+    sort_order: 5
+    emoji: "💡"
+    color: "#f39c12"
+    kick_template: brainstorm-advisory.md
+    include_repos: false
+    on_demand: true
+    stale_timeout: 7200
 
 # Governor — adaptive scheduler that adjusts agent cadences based on queue depth
 governor:
@@ -143,24 +187,33 @@ governor:
       ci-maintainer: pause                # "pause" means don't kick this agent
       tester: pause                       # coverage isn't urgent during fire-fighting
       architect: pause
+      guide: pause
+      strategist: pause
+      # brainstorm is on_demand and is not kicked by the governor
     busy:
       threshold: 10
       scanner: 15m
       ci-maintainer: 1h
       tester: 2h
       architect: pause
+      guide: 4h
+      strategist: pause
     quiet:
       threshold: 2
       scanner: 15m
       ci-maintainer: 45m
       tester: 45m
       architect: pause
+      guide: 4h
+      strategist: 4h
     idle:
       threshold: 0
       scanner: 15m
       ci-maintainer: 15m
       tester: 30m                         # most active when nothing else is happening
       architect: 30m
+      guide: 4h
+      strategist: 4h
 
   # LiteLLM inference backend (optional) — route agents through an
   # OpenAI-compatible LiteLLM proxy. Agents using backend "litellm" launch

--- a/v2/policies/README.md
+++ b/v2/policies/README.md
@@ -1,0 +1,53 @@
+# Policy and prompt templates
+
+Hive kicks an agent by resolving a Markdown prompt template, substituting runtime variables, and typing the result into that agent's CLI session. This directory is the human-editable source mirror for the shipped policy templates. The Go binary embeds the copies under `v2/pkg/policies/defaults/`; keep both locations in mind when changing defaults.
+
+## Resolution order
+
+For a scheduled kick, Hive uses the agent's configured `kick_template` when present. ACMM packs set that field explicitly in `v2/pkg/config/packs/level-*.yaml`; for example L4 sets `scanner-issues.md` and `guide-issues.md`, L5 sets `*-holdgated.md`, and L6 sets `*-full.md`/`scanner-automerge.md`.
+
+The scheduler resolves the template from the configured policies directory (`policies.local_dir` plus `policies.path`, commonly `/data/policies/examples/kubestellar/agents/`) and falls back to the embedded defaults in this package. A prompt source may also fetch Markdown from an allowlisted GitHub repository at kick time; if the fetch fails, Hive uses its last cached copy or the inline/baked template rather than sending an empty kick.
+
+If an agent has no explicit template, Hive falls back by convention: first an agent-local `CLAUDE.md` style policy when present, then `<agent>.md`, then the embedded default for the role.
+
+## Mode variants
+
+Template suffixes mirror the ACMM interaction mode:
+
+| Suffix | Mode | Meaning |
+| --- | --- | --- |
+| `-advisory` | `ADVISORY` | Analyze and write advisory beads; no GitHub writes. |
+| `-issues` | `ISSUES_ONLY` | May open/update issues; no pull requests. |
+| `-holdgated` | `ISSUES_AND_PRS` at L5 | May open issues and PRs; PRs are hold-gated for humans. |
+| `-full` | `ISSUES_AND_PRS` outside L5 | May open issues and PRs without the L5 hold-gate wording. |
+| `-automerge` | `ISSUES_PRS_MERGE` | Scanner may merge on green CI when policy allows. |
+| `-nogithub` | advisory variant | Explicit no-GitHub policy used by supervisor packs. |
+
+Examples in the current packs:
+
+- `guide-issues.md` is the L4 guide policy: documentation issues are allowed, PRs are not.
+- `scanner-issues.md` is the L4 scanner policy: issue filing only.
+- `supervisor-nogithub.md` is the supervisor policy from L2 through L6; it keeps orchestration separate from GitHub mutation.
+- `brainstorm-advisory.md` is the only brainstorm template referenced by v2 HEAD, including L1 inception. `brainstorm-inception.md` is mentioned only by stale documentation, so operators should not create or rely on that filename unless they also set `kick_template` to it.
+
+## Customizing prompts
+
+Use one of these supported paths:
+
+1. **Policy checkout** — set `policies.repo`, `policies.path`, and `policies.local_dir` in `hive.yaml`. Put files with the same names as the pack templates in that directory. Hive polls the checkout and the next kick picks up changes.
+2. **Per-agent override** — set `agents.<name>.kick_template` to a filename in the policy checkout/defaults.
+3. **Dashboard or `hivectl`** — use the agent prompt editor or `hivectl agent prompt set <agent> --file policy.md`; writes land in the server's writable policy directory.
+4. **Portable agent definition** — import an `AgentDefinition` with `spec.promptTemplate`; Hive stores a baked copy and can keep selected safe fields linked to an allowlisted source.
+
+Do not put secrets in policy Markdown. Prompts are shown in logs, dashboard history, and agent panes.
+
+## Variables
+
+Templates are rendered with runtime context such as `${AGENT_NAME}`, `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, `${ISSUE_LIST}`, `${PR_LIST}`, `${KNOWLEDGE}`, and mode/auth fragments. Variables that are not available for a mode render empty; for example advisory/no-GitHub policies do not get write-capable GitHub auth instructions.
+
+## Operator checklist
+
+- Match the template to the agent's `mode`; do not give an advisory agent a hold-gated template and expect GitHub writes to work.
+- Keep `stale_timeout` longer than the longest cadence in the selected ACMM pack.
+- Prefer replacing a shipped filename in a policy checkout over editing embedded files; embedded defaults change only when Hive is rebuilt.
+- After changing prompts, kick the agent once and inspect the prompt history or pane output to verify the expected file was used.

--- a/v2/proxy/README.md
+++ b/v2/proxy/README.md
@@ -1,0 +1,28 @@
+# Hive dashboard reverse proxy
+
+`v2/proxy` is the Node/Express reverse proxy that fronts the dashboard, Go API, terminal, contribution, leaderboard, and snapshot routes.
+
+## Role in the architecture
+
+The proxy listens on `HIVE_PROXY_PORT` (default `3001`) and forwards API traffic to the Go dashboard API at `HIVE_API_URL` or `127.0.0.1:${HIVE_API_PORT}` (default `3002`). It also proxies ttyd on `/terminal`, contribution WebSockets on `/api/contribute/ws`, and selected public pages such as `/leaderboard` and `/snapshot`.
+
+## Auth headers
+
+For mutating `/api` requests, the proxy requires a bearer token when `HIVE_DASHBOARD_TOKEN` is set. It strips user-supplied `X-Hive-User`, `X-Hive-Role`, and `X-Hive-Internal` headers before proxying and injects `X-Hive-Internal` itself for trusted API calls. This prevents a browser client from forging dashboard-internal identity headers.
+
+Hosted terminal access (`*.hive.kubestellar.io`) requires the hub user cookie. Non-hosted terminal WebSockets require the dashboard token query parameter when a token is configured.
+
+## Security headers
+
+Every response gets a restrictive CSP, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and no-store cache headers. `X-Frame-Options: DENY` is set except for `/snapshot` when the Go API returns an explicit HTTPS frame-ancestor allowlist; that route relies on CSP `frame-ancestors` because `X-Frame-Options` has no allowlist form.
+
+## Local development
+
+```bash
+cd v2/proxy
+npm install
+HIVE_DASHBOARD_TOKEN=dev HIVE_API_URL=http://127.0.0.1:3002 npm start
+npm test
+```
+
+Set `HIVE_STATIC_DIR` to serve a built dashboard from a non-default path.


### PR DESCRIPTION
## Summary
- add policy/prompt, backend, inference, proxy, deployment, migration, and ioscan status docs
- add missing brainstorm example policy and guide/strategist/brainstorm example config entries
- refresh federation design and link hivectl/backend docs from README/architecture

Fixes #2937
Fixes #3083
Fixes #3106
Fixes #2938
Fixes #2923
Fixes #3023
Fixes #3037
Fixes #2941
Fixes #3107
Fixes #2874
Fixes #3061
Fixes #2896
Fixes #2872
Fixes #2963
Fixes #2983

## Validation
- go test ./pkg/config
- npm run build/lint unavailable: no root package.json scripts
- go test -timeout 90s ./pkg/agent ./pkg/dashboard: dashboard passed; agent timed out in TestRunCopilotDiagnostic_NoBinary waiting on copilot diagnostic (environment/tooling issue, unrelated docs)