### PR TITLE
📖 docs: add contributor onboarding guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible problem in Hive
+title: "🐛 bug: "
+labels: bug
+assignees: ""
+---
+
+## What happened?
+
+Describe the problem and the impact.
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Environment
+
+- Branch/version: `v2` / commit SHA / release tag:
+- Deployment method: Docker Compose / Kubernetes / local binary / Hive Hub / other:
+- Operating system or Kubernetes version:
+- Relevant configuration (redact secrets):
+
+## Logs or screenshots
+
+Paste relevant logs, command output, or screenshots. Redact tokens and private data.
+
+## Additional context
+
+Anything else maintainers should know?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability for Hive
+title: "✨ feature: "
+labels: enhancement
+assignees: ""
+---
+
+## Use case
+
+What problem are you trying to solve, and who is affected?
+
+## Proposed solution
+
+Describe the behavior, API, UI, policy, or documentation change you want.
+
+## Alternatives considered
+
+What workarounds or other designs have you considered?
+
+## Scope and compatibility
+
+- Target branch or version:
+- Operator impact:
+- Contributor/agent impact:
+- Migration or backwards-compatibility concerns:
+
+## Additional context
+
+Links, examples, diagrams, or related issues.

--- a/.github/ISSUE_TEMPLATE/guide-gap.md
+++ b/.github/ISSUE_TEMPLATE/guide-gap.md
@@ -1,0 +1,27 @@
+---
+name: Documentation gap
+about: Report missing, stale, or confusing documentation
+title: "📖 docs: "
+labels: documentation, guide
+assignees: ""
+---
+
+## Documentation gap
+
+What is missing, stale, or confusing?
+
+## Where did you look?
+
+List the files, pages, commands, or searches you tried.
+
+## Who needs this?
+
+New contributors, operators, maintainers, Hive Hub users, ClankeR contributors, or another audience?
+
+## Suggested fix
+
+Describe the guide, section, command, or link that would close the gap.
+
+## Related code or issues
+
+Add links if known.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+- 
+
+## Related issues
+
+Fixes #
+
+## Testing
+
+- [ ] `cd v2 && go build ./...`
+- [ ] `cd v2 && go test ./...`
+- [ ] Other / not run (explain):
+
+## Contributor checklist
+
+- [ ] PR targets `v2` unless a maintainer requested another branch.
+- [ ] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
+- [ ] Commits include DCO sign-off (`git commit -s`).
+- [ ] Docs, examples, and policies are updated when behavior changes.
+- [ ] No secrets, credentials, or local runtime state are committed.

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,13 +19,13 @@ Listed below are organizations that have adopted, or benefitted from, KubeStella
 ## Adopter Tiers
 
 ### 🥇 Production Adopters
-Organizations running KubeStellar Console in production environments.
+Organizations running KubeStellar Hive in production environments.
 
 ### 🥈 Development Adopters
-Organizations using KubeStellar Console in development or staging environments.
+Organizations using KubeStellar Hive in development or staging environments.
 
 ### 🥉 Evaluation Adopters
-Organizations actively evaluating KubeStellar Console for future use.
+Organizations actively evaluating KubeStellar Hive for future use.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+Hive did not historically maintain a complete changelog. This file starts a pragmatic, forward-looking record for operators and contributors. We are not reconstructing every old change retroactively; instead, maintainers should add notable user-facing changes as PRs land.
+
+## How we maintain this file
+
+- Add entries under `Unreleased` for user-visible features, fixes, security changes, migrations, deprecations, and breaking changes.
+- Move entries into a dated release section when a release is cut.
+- Link issues or PRs when useful, but keep entries readable for operators who are not following every PR.
+- Do not include routine refactors, test-only changes, or dependency churn unless they affect users.
+
+## Unreleased
+
+### Added
+
+- Contributor onboarding, governance, templates, and local development documentation for the `v2` Go codebase.
+
+## Recent v2 notable changes
+
+### Added
+
+- Timezone-aware time-of-day governor cadences so hives can vary agent activity by local operating windows.
+- Merger contributor tier and configurable automerge queue/label behavior for safer merge delegation.
+- ClankeR contributor role claiming and owner-assigned agent-role grants.
+- Multi-hub relay subscriptions so one contributor session can subscribe to more than one hub.
+- Custom dashboard CSS support with sanitizer hardening and operator-facing feedback about dropped rules.
+- Replicated agent instances for scaling selected agent roles.
+
+### Changed
+
+- Dashboard and contributor operations views received queue, pause/resume, management, and live-activity improvements.
+- Contributor Kubernetes workload generation now supports headless deployments for relay contributors.
+
+### Fixed
+
+- Automerge sweep behavior no longer treats pending CI as green.
+- Multi-hub relay control frames are isolated per subscription.
+- Custom CSS popovers and dashboard fallback UI received usability fixes.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# KubeStellar Hive Code of Conduct
+
+Hive follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md), consistent with the KubeStellar project community.
+
+As contributors, maintainers, and participants, we pledge to make participation in this project open, welcoming, inclusive, and harassment-free for everyone. Examples of positive behavior include empathy, respectful disagreement, constructive feedback, accountability, and focusing on what is best for the community.
+
+Unacceptable behavior includes harassment, discriminatory language, personal attacks, publishing private information without permission, threats or violence, sustained disruption, or other conduct that would be inappropriate in a professional open source community.
+
+## Scope
+
+This code applies in Hive project spaces, including GitHub issues, pull requests, discussions, meetings, events, and project-operated communication channels. It also applies when an individual's words or actions are directed at Hive, KubeStellar, CNCF, or another community participant.
+
+## Reporting
+
+For incidents in the KubeStellar community, contact the KubeStellar Code of Conduct Committee at [kubestellar-dev-private@googlegroups.com](mailto:kubestellar-dev-private@googlegroups.com). You can expect a response within three business days.
+
+For project-agnostic incidents or incidents affecting multiple CNCF projects, contact the CNCF Code of Conduct Committee at [conduct@cncf.io](mailto:conduct@cncf.io). CNCF also documents [incident resolution procedures](https://www.cncf.io/conduct/procedures/) and [jurisdiction policy](https://www.cncf.io/conduct/jurisdiction/).
+
+## Enforcement
+
+Maintainers may remove, edit, or reject comments, commits, issues, pull requests, and other contributions that do not align with this Code of Conduct. Enforcement and escalation follow the CNCF Code of Conduct and KubeStellar community process.
+
+## Acknowledgements
+
+This document summarizes the CNCF Code of Conduct and follows the convention used by the KubeStellar community. The CNCF Code of Conduct is adapted from the Contributor Covenant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Hive
+
+Thank you for helping improve KubeStellar Hive. This guide is for contributing code and documentation to this repository. If you want to donate compute to a running hive, see [Contribute to a Hive](README.md#contribute-to-a-hive) instead.
+
+## Where to work
+
+- Open issues and pull requests in this repository. Use the issue templates when they are available, and link related issues from the PR body.
+- Discuss design and review questions in GitHub issues and PRs so decisions remain public and searchable.
+- Follow the [KubeStellar Code of Conduct](CODE_OF_CONDUCT.md) and [Hive governance](GOVERNANCE.md).
+- Report vulnerabilities privately; see [SECURITY.md](SECURITY.md).
+
+## Repository layout
+
+- `v2/` — the current Go module (`github.com/kubestellar/hive/v2`) and the main development target for this repository.
+  - `v2/cmd/hive` — main Hive binary.
+  - `v2/cmd/hivectl`, `v2/cmd/apiproxy`, `v2/cmd/hive-backup` — supporting command-line tools.
+  - `v2/pkg/` — Go packages for agents, GitHub integration, scheduling, policies, dashboards, hubs, backups, and related runtime behavior.
+  - `v2/policies/` — policy prompts and rule files used by the deterministic/agent pipeline. Treat policy changes like code: review the behavior they enable, test where possible, and explain risk in the PR.
+  - `v2/deploy/` and `v2/examples/` — deployment manifests and example configuration.
+  - `v2/docs/` — architecture and operator/developer reference material.
+  - `v2/test/` — integration and regression tests.
+- `bin/` — shell helpers used by the existing automation and maintainer workflows.
+- `dashboard/`, `docs/`, `config/`, `systemd/`, `launchd/`, and top-level scripts — supporting assets for hub, dashboard, installation, and operational workflows.
+- `Justfile` — contributor relay recipes; see [Just recipes](docs/development.md#just-recipes).
+
+## Branches
+
+Use `v2` as the base branch for Hive v2 work and PRs unless a maintainer asks otherwise. The `main` branch is not the active target for v2 changes. The `v4` branch is a separate forward-looking/synchronization line; do not target it for ordinary v2 fixes.
+
+Before starting work:
+
+```bash
+git fetch origin
+git switch -c <topic-branch> origin/v2
+```
+
+## Local development
+
+See [docs/development.md](docs/development.md) for the full local setup guide. The short path is:
+
+```bash
+cd v2
+go build ./...
+go test ./...
+```
+
+The Go version is declared in [`v2/go.mod`](v2/go.mod). Install that version or newer compatible tooling before building.
+
+## Style and quality
+
+- Format Go changes with `gofmt`.
+- Prefer small, focused PRs with tests or a clear explanation when tests are not practical.
+- Keep configuration values configurable instead of hard-coding environment-specific paths, tokens, or endpoints.
+- Do not commit secrets, generated credentials, or local runtime state.
+- For documentation changes, verify every command, path, and branch name you mention.
+
+## DCO sign-off
+
+Every commit must include a Developer Certificate of Origin sign-off. Use:
+
+```bash
+git commit -s
+```
+
+The sign-off adds a `Signed-off-by:` trailer certifying that you have the right to submit the contribution under this repository's license. If you forget, amend the commit with `git commit --amend -s` and force-push your branch.
+
+## Pull requests
+
+- Target `v2` for v2 code and documentation.
+- Start PR titles with the repository's emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
+- Include `Fixes #<issue>` lines for issues the PR closes.
+- Describe what changed, why, and how you tested it.
+- Include the relevant command output or a short note such as `Not run (docs only)` when tests are not applicable.
+- Expect maintainers to ask for focused follow-up changes rather than broad drive-by edits.
+
+## Maintainer resources
+
+Project governance lives in [GOVERNANCE.md](GOVERNANCE.md). The current owner/approver signal is also reflected in [OWNERS](OWNERS). Security disclosure is handled through [SECURITY.md](SECURITY.md), not public issues.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,24 @@
 # Hive Project Governance
 
-This subproject's governance is maintained in the main KubeStellar repository:
+Hive is a KubeStellar subproject. The canonical umbrella governance for the subproject is maintained in the main KubeStellar repository at [GOVERNANCE-HIVE.md](https://github.com/kubestellar/kubestellar/blob/main/GOVERNANCE-HIVE.md). This file summarizes how that governance applies in this repository.
 
-**[GOVERNANCE-HIVE.md](https://github.com/kubestellar/kubestellar/blob/main/GOVERNANCE-HIVE.md)**
+## Maintainers and authority
+
+The Hive maintainer committee owns day-to-day decisions for this repository: issue triage, PR review, merge decisions, release readiness, security response coordination, and project-specific policy changes. Current maintainer ownership is reflected in [OWNERS](OWNERS) and in the upstream governance document.
+
+Routine changes use lazy consensus through GitHub review. Maintainers may merge when CI and review expectations are satisfied, DCO sign-off is present, and no unresolved objection remains.
+
+## Decision process
+
+1. Proposals are opened as GitHub issues or pull requests.
+2. Discussion happens in public on the issue or PR whenever possible.
+3. Maintainers seek consensus. For routine changes, no objection after review is treated as approval.
+4. Controversial or cross-project decisions may be escalated to the KubeStellar governance process.
+
+## Contributor ladder
+
+Hive follows the [KubeStellar Contributor Ladder](https://github.com/kubestellar/community/blob/main/CONTRIBUTOR_LADDER.md). Contributors earn additional responsibility through sustained, high-quality participation. Requests or nominations for expanded responsibility should be raised with maintainers.
+
+## Conduct and security
+
+All participants must follow the [Code of Conduct](CODE_OF_CONDUCT.md). Security issues are reported privately through [SECURITY.md](SECURITY.md), not public GitHub issues.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,11 @@ See the [Hive Hub contribute page](https://hive.kubestellar.io) for details.
 
 See the [Hive Hub](https://hive.kubestellar.io) to browse registered hives, view leaderboards, and find hives accepting contributions.
 
-To contribute to Hive itself, open issues and PRs on this repository.
+To contribute to Hive itself, see [CONTRIBUTING.md](CONTRIBUTING.md) and open issues or PRs on this repository.
+
+## Security
+
+Please see [SECURITY.md](SECURITY.md) for the vulnerability disclosure process. Do not report security vulnerabilities through public issues or pull requests.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,106 @@
+# Local development
+
+This guide describes the local workflow for contributing to the Hive Go codebase on the `v2` branch.
+
+## Prerequisites
+
+- Git and GitHub CLI (`gh`) for normal issue and PR workflows.
+- Go `1.25.6`, as declared by [`v2/go.mod`](../v2/go.mod).
+- Docker or Podman if you are exercising containerized contributor relay or deployment paths.
+- `tmux` for local agent/contributor workflows that attach CLIs to terminal sessions.
+- `just` if you use the repository's helper recipes (`brew install just` on macOS, or install from the `just` project for your platform).
+- Optional agent CLIs depending on what you test locally: Claude Code, GitHub Copilot/`gh`, Gemini, Bob, Goose, Codex, Pi, or Antigravity.
+
+## Clone and branch
+
+```bash
+git clone -b v2 https://github.com/kubestellar/hive.git
+cd hive
+git switch -c <topic-branch> origin/v2
+```
+
+Use `v2` as the PR base for ordinary Hive development. Rebase or recreate your branch from a fresh `origin/v2` before opening or updating a PR.
+
+## Build
+
+Build every package in the Go module:
+
+```bash
+cd v2
+go build ./...
+```
+
+To build only the main Hive binary during quick iteration:
+
+```bash
+cd v2
+go build ./cmd/hive
+```
+
+## Test
+
+Run the module tests from `v2/`:
+
+```bash
+cd v2
+go test ./...
+```
+
+The `v2/test/` package contains integration/regression coverage and may exercise local ports, temporary state, and helper processes. If a local environment dependency prevents a full run, include the failing package and error summary in the PR and still run the narrower package tests affected by your change.
+
+Useful narrower loops:
+
+```bash
+cd v2
+go test ./pkg/...
+go test ./cmd/hive
+```
+
+## Format and lint expectations
+
+Run `gofmt` on Go files you edit:
+
+```bash
+gofmt -w path/to/file.go
+```
+
+There is no separate documented repository-wide lint command in the current `Justfile`; use the Go build and test commands above unless CI or a maintainer asks for an additional check.
+
+## Running Hive locally
+
+The quickest operator path remains Docker Compose from the root README:
+
+```bash
+cd v2
+cp hive.yaml.example hive.yaml
+export HIVE_GITHUB_TOKEN=ghp_...
+docker compose up -d
+```
+
+For source-level debugging, build with `go build ./cmd/hive` and run the generated binary with a local `hive.yaml`. Keep real tokens in your shell or local ignored files, never in commits.
+
+## Just recipes
+
+The root [`Justfile`](../Justfile) is the discoverable entry point for contributor relay automation. List the public recipes with:
+
+```bash
+just --list
+```
+
+Current public recipes are centered on the **contribute** workflow:
+
+- `just contribute-check <backend>` — read-only preflight for an agent backend CLI.
+- `just contribute-setup <backend>` — one-time setup for GitHub auth, hub registration, and backend readiness.
+- `just contribute-hive [backend] [mode]` — start contributing work to a hive, using a container by default or local mode when requested.
+- `just contribute-status`, `just contribute-browse`, and `just contribute-stop` — inspect, discover, or stop contributor relay activity.
+- `just contribute-k8s [namespace] [outfile] [image_tag]` — print Kubernetes manifests for a headless contributor workload; it prints or writes the manifest you request and does not apply it.
+- `just hive-api <endpoint>` and `just hive-api-docs` — inspect hub API endpoints for the configured hive.
+
+Deployment and development tasks that are not listed by `just --list` are not public recipes today. Use the Go, Docker Compose, and Kubernetes commands documented in the README and `v2/docs/` for those workflows.
+
+## Before opening a PR
+
+1. Rebase on the latest `origin/v2`.
+2. Run the build and tests that match your change.
+3. Commit with DCO sign-off: `git commit -s`.
+4. Open a PR against `v2` with an emoji-prefixed title, testing notes, and `Fixes #...` lines for closing issues.


### PR DESCRIPTION
## Summary

- add root contributor guide plus local development guide for the v2 Go module
- document current public Justfile contributor recipes and verified build/test entry points
- add Code of Conduct, governance summary, issue/PR templates, changelog policy, README security/contributing links, and ADOPTERS product-name fix

Fixes #3105
Fixes #3035
Fixes #2871
Fixes #2995
Fixes #2980
Fixes #2970
Fixes #2979
Fixes #2873
Fixes #2978
Fixes #2971
Fixes #2911

## Testing

- `cd v2 && go build ./...` ✅
- `just --list` ✅ (used to verify public Justfile recipes)
- `cd v2 && go test ./...` ❌ local pre-existing integration timeout/failure in Go test packages unrelated to docs-only changes
