### PR TITLE
🔒 Security audit 2026-08-07: wave 1 (N6, N15A, N20, N5, N12)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -3,10 +3,16 @@ name: v2 CI
 on:
   push:
     branches: [v2, v4]
-    paths: ['v2/**', 'bin/contributor-agent*', 'bin/contributor-relay*']
+    # bin/** is in scope because the gh wrapper is a SECURITY boundary (it is the
+    # merge gate behind the proxy hard-deny) and previously matched no path
+    # filter at all — a change to it triggered no CI whatsoever.
+    paths: ['v2/**', 'bin/**', '.github/workflows/v2-ci.yml']
   pull_request:
     branches: [v2, v4]
-    paths: ['v2/**', 'bin/contributor-agent*', 'bin/contributor-relay*']
+    # bin/** is in scope because the gh wrapper is a SECURITY boundary (it is the
+    # merge gate behind the proxy hard-deny) and previously matched no path
+    # filter at all — a change to it triggered no CI whatsoever.
+    paths: ['v2/**', 'bin/**', '.github/workflows/v2-ci.yml']
 
 permissions:
   contents: read
@@ -38,6 +44,16 @@ jobs:
       # fails the PR rather than a deploy.
       - name: Entrypoint runtime-config migration tests
         run: bash deploy/test_entrypoint_runtime_config.sh
+
+      # bin/gh-wrapper.sh is the merge gate standing behind the proxy hard-deny:
+      # if its argument parsing is wrong, a prompt-injected agent merges
+      # unvetted code. It had NO tests and matched no CI path filter. This
+      # EXECUTES the wrapper against a stub gh and asserts on exit codes —
+      # grepping the script text (as the entrypoint tests do) cannot catch a
+      # parser bug, which is exactly how the audit's N7 bypass survived.
+      - name: gh-wrapper gate tests
+        working-directory: .
+        run: bash bin/test_gh_wrapper_gates.sh
 
       - uses: actions/setup-node@v4
         with:

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -731,7 +731,15 @@ function tmuxSendKeys(text) {
   }
   try {
     try {
-      execSync(`find /tmp -maxdepth 1 -type d -user dev -not -name 'tmux-*' -not -name 'claude-*' -not -name 'node-*' -not -name '.' -mmin +60 -exec rm -rf {} + 2>/dev/null; find /tmp -maxdepth 1 -type f -user dev -name '*.out' -o -name '*.html' -mmin +60 -exec rm -f {} + 2>/dev/null`, { timeout: 15000 });
+      // SECURITY (N20, CWE-20): the second find MUST parenthesize the -o group.
+      // `-type f -user dev -name '*.out' -o -name '*.html' -mmin +60 -exec rm`
+      // parses as (-type f AND -user dev AND -name '*.out') OR (-name '*.html'
+      // AND -mmin +60 AND -exec rm) because -o binds looser than the implicit
+      // -a. The right branch therefore drops BOTH -type f and -user dev, so ANY
+      // owner's /tmp/*.html older than 60min was deleted — including root's, and
+      // including directories. The left branch had no -exec, so the *.out
+      // cleanup this line exists to perform never actually ran.
+      execSync(`find /tmp -maxdepth 1 -type d -user dev -not -name 'tmux-*' -not -name 'claude-*' -not -name 'node-*' -not -name '.' -mmin +60 -exec rm -rf {} + 2>/dev/null; find /tmp -maxdepth 1 -type f -user dev \\( -name '*.out' -o -name '*.html' \\) -mmin +60 -exec rm -f {} + 2>/dev/null`, { timeout: 15000 });
     } catch (_) {}
     const ctxPct = checkContextUsage();
     const RESET_EVERY_N = 3;

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1391,6 +1391,43 @@ test('the modal panes still win over the ready marker they also draw', () => {
   }
 });
 
+// N20 (CWE-20): the /tmp cleanup's second `find` must parenthesize its -o group.
+//
+// `-type f -user dev -name '*.out' -o -name '*.html' -mmin +60 -exec rm -f`
+// parses as (-type f AND -user dev AND -name '*.out') OR (-name '*.html' AND
+// -mmin +60 AND -exec rm), because -o binds looser than the implicit -a. The
+// right branch drops BOTH -type f and -user dev, so ANY owner's /tmp/*.html
+// older than 60 minutes was deleted — root's included, directories included.
+// The left branch carries no -exec, so the *.out cleanup never ran at all.
+//
+// This asserts on the SOURCE rather than a live run: the command is built as a
+// template literal, and the bug is in shell-operator precedence, so what matters
+// is the exact string handed to the shell.
+test('the /tmp cleanup find scopes its -o group (N20: no cross-owner *.html deletion)', () => {
+  const src = fs.readFileSync(RELAY_PATH, 'utf8');
+  // Match the execSync CODE line, not the comment above it that quotes the
+  // vulnerable form for explanation.
+  const line = src.split('\n').find((l) => l.includes('execSync(') && l.includes("-name '*.out'"));
+  assert.ok(line, 'could not find the /tmp cleanup command');
+
+  // The escaped parens must be present around the -o alternation. In the
+  // template literal these are written \\( / \\) so the SHELL receives \( / \).
+  // In the source the escapes are written \\( / \\) (two chars: backslash,
+  // paren) so the template literal yields \( / \) for the shell. Match that
+  // literally via indexOf rather than fighting a third layer of regex escaping.
+  assert.ok(
+    line.includes("-type f -user dev \\\\( -name '*.out' -o -name '*.html' \\\\) -mmin +60"),
+    'the -o group is not parenthesized — any owner\'s /tmp/*.html would be deleted:\n' + line
+  );
+
+  // Guard the specific broken form, so a future edit cannot silently reintroduce
+  // it by dropping the escapes.
+  assert.ok(
+    !line.includes("-user dev -name '*.out' -o -name"),
+    'the unparenthesized (vulnerable) form is back:\n' + line
+  );
+});
+
 // ---------------------------------------------------------------------------
 
 let failed = 0;

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -21,7 +21,12 @@ set -euo pipefail
 # made the guard below fire "gh CLI is not available" for every agent gh call,
 # silently breaking the CLI GitHub workflow (issue/PR view, create, merge). Keep
 # the legacy path as a fallback for any environment that does ship it there.
-REAL_GH="/opt/hive/bin/gh-real"
+# HIVE_GH_WRAPPER_REAL_GH lets the test harness point the wrapper at a stub so
+# the gates can be exercised as a black box (bin/test_gh_wrapper_gates.sh). It is
+# NOT a security control and grants nothing: an agent that could set it could
+# equally invoke its own binary directly, and every gate below runs before this
+# path is ever exec'd. Unset in production, where the image ships the real gh.
+REAL_GH="${HIVE_GH_WRAPPER_REAL_GH:-/opt/hive/bin/gh-real}"
 [[ -x "$REAL_GH" ]] || REAL_GH="/usr/bin/gh"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
 
@@ -262,6 +267,27 @@ if [ -n "$AGENT_MODE" ]; then
       ;;
     ISSUES_PRS_MERGE)
       # Everything allowed — merge-eligible gate still checked below
+      ;;
+    *)
+      # SECURITY (N15 chain A, CWE-20/732): fail CLOSED on an unrecognized mode.
+      #
+      # Without this arm an unknown non-empty mode matched nothing and fell
+      # through with ZERO enforcement — every gate above silently skipped. That
+      # is reachable: AGENT_MODE is read from /tmp/.hive-mode-<name> (see the
+      # block near :155), a world-writable path whose name comes from
+      # agent-controlled env (HIVE_AGENT / HIVE_AGENT_ID). Because the file wins
+      # over the env var, anyone who can write /tmp — any agent UID in the pod,
+      # or a managed-repo PR that lands a file there — could plant a garbage
+      # value and permanently un-gate a victim agent, durable across restarts
+      # and `hive agent reset`.
+      #
+      # Note an EMPTY mode is different and still safe: it leaves AGENT_MODE=""
+      # so the `if [ -n "$AGENT_MODE" ]` above is false and the level-based
+      # fallback below applies. Only a non-empty unknown value lands here.
+      echo "⛔ BLOCKED: unrecognized agent mode '${AGENT_MODE}' for ${AGENT_NAME_GW} — refusing to run gh." >&2
+      echo "Valid modes: NO_GITHUB, ADVISORY, ISSUES_ONLY, ISSUES_AND_PRS, ISSUES_PRS_MERGE." >&2
+      echo "If ${MODE_FILE} exists with unexpected contents, it may have been tampered with; report to the operator." >&2
+      exit 1
       ;;
   esac
 else

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Behavioural tests for bin/gh-wrapper.sh's enforcement gates.
+# Run: bash bin/test_gh_wrapper_gates.sh
+#
+# Unlike v2/deploy/test_entrypoint_*.sh, which grep the script TEXT, this
+# harness EXECUTES the wrapper against a stub gh and asserts on exit codes and
+# on whether the stub was reached. A parser bug cannot be caught by grepping —
+# the audit's N7 bypass (`gh pr --repo o/r merge 123`) looks perfectly normal in
+# source and only misbehaves when run.
+#
+# The stub records its argv to $STUB_LOG. "Reached the stub" means every gate
+# allowed the command through — for a merge that is the failure condition unless
+# the PR is genuinely merge-eligible.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WRAPPER="${REPO_ROOT}/bin/gh-wrapper.sh"
+
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+STUB="${WORK}/gh-stub"
+STUB_LOG="${WORK}/stub.log"
+cat >"$STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${STUB_LOG}"
+exit 0
+STUBEOF
+chmod +x "$STUB"
+
+# A scoped-token file, so the H3 token gate near the top of the wrapper does not
+# short-circuit every case before we reach the gates under test.
+TOKEN_CACHE="${WORK}/token"
+echo "ghs_stubtoken" >"$TOKEN_CACHE"
+
+# run_wrapper <mode> <acmm> -- <args...>
+# Echoes "exit=<code> stub=<yes|no>" for the assertions below.
+run_wrapper() {
+  local mode="$1" acmm="$2"; shift 2
+  [ "${1:-}" = "--" ] && shift
+  : >"$STUB_LOG"
+  local out rc
+  out="$(
+    HIVE_GH_WRAPPER_REAL_GH="$STUB" \
+    STUB_LOG="$STUB_LOG" \
+    HIVE_AGENT="testagent" \
+    HIVE_AGENT_ID="testagent" \
+    HIVE_AGENT_MODE="$mode" \
+    HIVE_ACMM_LEVEL="$acmm" \
+    HIVE_AGENT_TOKEN_CACHE="$TOKEN_CACHE" \
+    HIVE_CONTRIBUTOR_MODE="false" \
+    bash "$WRAPPER" "$@" 2>&1
+  )"
+  rc=$?
+  local reached=no
+  [ -s "$STUB_LOG" ] && reached=yes
+
+  # A wrapper that cannot find the stub exits 1 from the availability guard near
+  # the top, which looks EXACTLY like "a gate blocked this". That would make
+  # every assert_blocked pass for the wrong reason and hide a real regression —
+  # it did, the first time this harness was run. Treat it as a harness error,
+  # not a result.
+  if [[ "$out" == *"gh CLI is not available"* ]]; then
+    echo "harness-error: wrapper could not find the stub gh"
+    return 0
+  fi
+  # Same for the H3 scoped-token gate, which also exits 1 before any mode gate.
+  if [[ "$out" == *"per-agent scoped GitHub token not available"* ]]; then
+    echo "harness-error: scoped-token gate fired before the gates under test"
+    return 0
+  fi
+
+  # Tag WHICH gate blocked, so a test cannot pass because some unrelated gate
+  # happened to fire. `pr merge` is gated by both the mode case and the
+  # merge-eligibility check; without this tag an unknown-mode merge test would
+  # go green off the eligibility gate even with the mode arm deleted.
+  local gate=other
+  [[ "$out" == *"unrecognized agent mode"* ]] && gate=mode-default
+  [[ "$out" == *"NOT in merge-eligible.json"* || "$out" == *"cannot verify merge eligibility"* ]] && gate=eligibility
+
+  echo "exit=${rc} stub=${reached} gate=${gate}"
+  # Surface wrapper output only when debugging a failure.
+  [ -n "${GH_WRAPPER_TEST_VERBOSE:-}" ] && printf '    wrapper said: %s\n' "$out" >&2
+  return 0
+}
+
+# assert_blocked <label> <result> [expected-gate]
+# Passing the gate name pins WHICH check did the blocking.
+assert_blocked() {
+  local label="$1" result="$2" want_gate="${3:-}"
+  local want="exit=1 stub=no"
+  [ -n "$want_gate" ] && want="exit=1 stub=no gate=${want_gate}"
+  if [[ "$result" == "$want"* && ( -z "$want_gate" || "$result" == *"gate=${want_gate}" ) ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        got '$result', want '${want}' (blocked before reaching gh)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_reached() {
+  local label="$1" result="$2"
+  if [[ "$result" == exit=0*stub=yes* ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        got '$result', want 'exit=0 stub=yes' (allowed through to gh)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== gh-wrapper gate tests ==="
+
+# ── N15 chain A: unknown mode must fail CLOSED ────────────────────────────────
+# Before the fix an unrecognized mode matched no case arm and fell through with
+# ZERO enforcement. The mode is read from a world-writable /tmp path whose name
+# derives from agent-controlled env, so this was plantable and durable.
+echo "-- unknown mode fails closed (N15 chain A) --"
+assert_blocked "garbage mode blocks pr merge" \
+  "$(run_wrapper "TOTALLY_BOGUS" 5 -- pr merge 123)" mode-default
+assert_blocked "garbage mode blocks issue create" \
+  "$(run_wrapper "TOTALLY_BOGUS" 5 -- issue create --title x --body y)" mode-default
+assert_blocked "lowercase variant of a real mode is still unknown" \
+  "$(run_wrapper "issues_only" 5 -- pr merge 123)" mode-default
+assert_blocked "mode with trailing junk is unknown" \
+  "$(run_wrapper "ISSUES_ONLY_EXTRA" 5 -- pr merge 123)" mode-default
+
+# ── Known modes keep working (no over-correction) ─────────────────────────────
+echo "-- known modes still enforce as before --"
+assert_blocked "NO_GITHUB blocks pr" \
+  "$(run_wrapper "NO_GITHUB" 5 -- pr view 1)"
+assert_blocked "NO_GITHUB blocks issue" \
+  "$(run_wrapper "NO_GITHUB" 5 -- issue view 1)"
+assert_blocked "ISSUES_ONLY blocks pr merge" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- pr merge 123)"
+assert_blocked "ISSUES_AND_PRS blocks pr merge" \
+  "$(run_wrapper "ISSUES_AND_PRS" 5 -- pr merge 123)"
+
+# A read-only command under a permissive mode must still reach gh, or the
+# wrapper would be useless.
+assert_reached "ISSUES_PRS_MERGE allows a read (pr view)" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr view 1)"
+assert_reached "NO_GITHUB allows a non-issue/pr subcommand (repo view)" \
+  "$(run_wrapper "NO_GITHUB" 5 -- repo view)"
+
+# ── N7: the flag-reorder bypass (documents the CURRENT state) ─────────────────
+# `gh pr --repo o/r merge 123` makes the subcmd/action extractor read --repo's
+# VALUE as the action, so action != "merge" and every gate is skipped. The fix
+# is a real flag parser; until it lands these cases record the live bypass so
+# the harness fails loudly the moment behaviour changes in either direction.
+echo "-- N7 flag-reorder bypass (expected to FAIL until the parser is fixed) --"
+reorder="$(run_wrapper "ISSUES_AND_PRS" 5 -- pr --repo owner/repo merge 123)"
+if [[ "$reorder" == "exit=1 stub=no" ]]; then
+  echo "  PASS: flag-reorder merge is gated (N7 parser fix has landed)"
+  PASS=$((PASS + 1))
+else
+  echo "  KNOWN-GAP (N7): 'gh pr --repo owner/repo merge 123' bypassed the merge gate under ISSUES_AND_PRS"
+  echo "                  got '$reorder'; the flag value is parsed as the action. Fix: real flag parsing."
+fi
+
+bare="$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge)"
+if [[ "$bare" == "exit=1 stub=no" ]]; then
+  echo "  PASS: bare 'pr merge' is gated (eligibility fix has landed)"
+  PASS=$((PASS + 1))
+else
+  echo "  KNOWN-GAP (N7): bare 'gh pr merge' skipped the eligibility check (empty pr_num)"
+  echo "                  got '$bare'"
+fi
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -84,10 +84,25 @@ RUN curl -sL -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/
 # `hive-launch` is a dedicated supplementary group whose ONLY member is dev; it
 # gates exec of the SUID su-exec helper (chmod 4750 below) so agent UIDs — which
 # are in group node but NOT hive-launch — cannot run it. See the su-exec C6 note.
-RUN groupadd --system hive-launch \
+#
+# The GID is PINNED (not left to groupadd --system's dynamic allocation) because
+# Kubernetes `fsGroup` and Secret `defaultMode: 0440` are what keep the projected
+# GitHub App PEMs readable by dev while excluding agent UIDs (audit N5, CWE-732).
+# fsGroup takes a numeric GID — it cannot name a group — so this value is part of
+# the deployment contract and must stay in sync with v2/deploy/k8s/*.yaml and the
+# SaaS provisioning template in v2/pkg/hub/saas_provision.go.
+ARG HIVE_LAUNCH_GID=1002
+RUN if getent group "${HIVE_LAUNCH_GID}" >/dev/null; then \
+      echo "FATAL: GID ${HIVE_LAUNCH_GID} is already taken by '$(getent group "${HIVE_LAUNCH_GID}" | cut -d: -f1)'." >&2; \
+      echo "       fsGroup in the deployment manifests pins this GID; pick a free one and update" >&2; \
+      echo "       v2/deploy/k8s/*.yaml and saas_provision.go together." >&2; \
+      exit 1; \
+    fi \
+ && groupadd --system --gid "${HIVE_LAUNCH_GID}" hive-launch \
  && useradd -m -u 1001 -g node -G hive-launch -s /bin/bash dev \
  && chown root:hive-launch /usr/local/bin/su-exec \
- && chmod 4750 /usr/local/bin/su-exec
+ && chmod 4750 /usr/local/bin/su-exec \
+ && [ "$(stat -c '%G' /usr/local/bin/su-exec)" = "hive-launch" ]
 
 # --- Layer 2: ttyd (pinned version for reproducible builds) ---
 ARG TTYD_VERSION=1.7.7

--- a/v2/deploy/k8s/backup-cronjob.yaml
+++ b/v2/deploy/k8s/backup-cronjob.yaml
@@ -124,6 +124,12 @@ spec:
             - name: kubeconfigs
               secret:
                 secretName: hive-hub-kubeconfigs
+                # SECURITY (audit N5, CWE-732/522): default projection is 0644.
+                # These kubeconfigs carry cluster-admin credentials for remote
+                # spokes. 0400 (not the 0440 used for the hive pod) because this
+                # is a single-purpose backup pod running as the image's default
+                # user with no agent UIDs in it — nothing here needs group read.
+                defaultMode: 0400
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -20,6 +20,19 @@ spec:
         app.kubernetes.io/component: controller
     spec:
       serviceAccountName: hive
+      # SECURITY (audit N5, CWE-732/522): fsGroup pins the supplementary group
+      # Kubernetes applies to mounted volumes. Paired with `defaultMode: 0440` on
+      # the secrets projection below, it makes the GitHub App PEMs readable by
+      # `dev` (a member of hive-launch, GID 1002 — pinned in v2/Dockerfile) while
+      # excluding the agent UIDs (2001+).
+      #
+      # Mode alone cannot achieve that: `dev`'s PRIMARY group is `node`, which
+      # every agent UID also shares, so 0440 root:node would still hand the org
+      # App key to any prompt-injected agent. 0400 would be root-only and lock
+      # out `dev` itself. A dedicated group is the only split that works — the
+      # same reasoning the C6 su-exec fix used for `chmod 4750 root:hive-launch`.
+      securityContext:
+        fsGroup: 1002
       containers:
         - name: hive
           image: hive:latest
@@ -147,6 +160,19 @@ spec:
           secret:
             secretName: hive-secrets
             optional: true
+            # SECURITY (audit N5, CWE-732/522): without defaultMode Kubernetes
+            # projects Secret files 0644 — world-readable to every UID in the
+            # pod, so any agent (2001+) could read the org GitHub App private
+            # key. app_id + installation_id + key_file is all it takes to mint a
+            # full installation token (see bin/gh-app-token.sh), so this was a
+            # direct privilege escalation.
+            #
+            # The entrypoint's compensating `chmod 600 /secrets/*.pem` CANNOT
+            # fix it: /secrets is a read-only tmpfs projection, so chmod returns
+            # EROFS and the `2>/dev/null || true` swallows both the error and
+            # the exit code — it fails silently and the 0644 mode survives.
+            # 0440 + the pod-level fsGroup above is the enforcement.
+            defaultMode: 0440
         - name: data
           persistentVolumeClaim:
             claimName: hive-data

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -44,6 +44,11 @@ const (
 	inviteSecretFile = ".invite-secret"
 	// inviteSecretBytes is the length of the generated fallback signing secret.
 	inviteSecretBytes = 32
+	// contributorProfileFileMode is owner-only (audit N12, CWE-522). Contributor
+	// profiles carry the registration-token hash and PII; at the previous 0644
+	// every UID in the pod, agents included, could read them. Matches the 0600
+	// the invite secret has always used.
+	contributorProfileFileMode = 0o600
 )
 
 // inviteTrustTiers are the trust tiers permitted to mint an invite link. Only a
@@ -428,7 +433,13 @@ func saveContributorProfileCAS(p *ContributorProfile, adminOverride bool) error 
 	}
 	path := filepath.Join(getContributorsDir(), p.GitHubUsername+".json")
 	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+	// SECURITY (audit N12, CWE-522): owner-only. These profiles hold the
+	// registration-token HASH plus contributor PII (username, avatar, trust
+	// tier, activity), and 0644 made every one of them readable by any UID in
+	// the pod — including agent UIDs. Compare the invite secret at :79, which
+	// has always been 0600. The mode goes on the TEMP file, before the rename,
+	// so there is no window where the final path is world-readable.
+	if err := os.WriteFile(tmpPath, data, contributorProfileFileMode); err != nil {
 		return err
 	}
 	return os.Rename(tmpPath, path)

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -242,6 +242,10 @@ func TestAdminReadSurfacesHiddenDuringImpersonation(t *testing.T) {
 	rec = httptest.NewRecorder()
 	guardedExit := s.requireAdmin(next)
 	exitReq := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	// N6: requireAdmin now runs isCSRFSafe, so a POST must look like one the
+	// dashboard actually sends — same-origin fetches carry Origin (and the JSON
+	// content-type). Mirrors the requireAuth POST at :154-155.
+	exitReq.Header.Set("Origin", "https://hive.kubestellar.io")
 	exitReq.AddCookie(testAuthCookie(hubAdminUsername))
 	exitReq.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guardedExit(rec, exitReq)
@@ -265,6 +269,9 @@ func TestImpersonateExitClearsCookieAndStaysCallable(t *testing.T) {
 	guarded := s.requireAdmin(s.handleImpersonateExit)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	// N6: requireAdmin now enforces CSRF; send the Origin a real same-origin
+	// dashboard fetch would carry.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	req.AddCookie(testAuthCookie(hubAdminUsername))
 	req.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guarded(rec, req)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -795,6 +795,21 @@ func listAllSaaSUsers() []SaaSUser {
 
 func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// SECURITY (N6, CWE-352): admin routes carry the SAME CSRF exposure as
+		// requireAuth ones — the hub session cookie is ambient, so a cross-site
+		// form POST to e.g. /api/saas/hub/upgrade or the cluster-app-key writer
+		// executes with the admin's identity. requireAuth has always checked this
+		// (see :499); requireAdmin never did, leaving every admin mutation
+		// reachable from ANY origin — strictly worse than the sibling-tenant lane,
+		// which at least requires a *.hive.kubestellar.io foothold. Checked first,
+		// before any identity resolution, so a forged request never reaches the
+		// impersonation logic below.
+		if !isCSRFSafe(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":"CSRF check failed"}`))
+			return
+		}
 		// Gate on the REAL logged-in user, not the effective (possibly
 		// impersonated) identity. While the admin is viewing as a normal user,
 		// getAuthUser resolves to that user on GETs — but admin routes (and in

--- a/v2/pkg/hub/saas_admin_csrf_test.go
+++ b/v2/pkg/hub/saas_admin_csrf_test.go
@@ -1,0 +1,120 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// N6 (CWE-352): requireAdmin must run the SAME CSRF check requireAuth does.
+//
+// Before this fix requireAdmin resolved identity and nothing else, so every
+// admin mutation (~21 routes: hub upgrade, cluster App key writes, user
+// delete, banners, provisioning approval) was reachable by a cross-site form
+// POST carrying the admin's ambient session cookie — from ANY origin, not just
+// a sibling *.hive.kubestellar.io tenant.
+//
+// These tests present a GENUINELY VALID admin cookie, so a 403 can only come
+// from the CSRF gate. That distinction matters: the pre-existing
+// TestRequireAdminNonAdmin / TestRequireAdminNoAuth also assert 403, but they
+// get it from the identity check and would keep passing with the CSRF hole
+// wide open. The suite had a requireAuth CSRF test (TestRequireAuthCSRFFails)
+// and no requireAdmin counterpart, which is why this shipped.
+
+// adminCSRFHandler builds a requireAdmin-wrapped handler that records whether
+// the protected body ever ran. Reaching the body is the failure condition.
+func adminCSRFHandler(s *HubServer, reached *bool) http.HandlerFunc {
+	return s.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// TestRequireAdminCSRFCrossOriginPostDenied is the regression for N6: a POST
+// from an unrelated origin, with a valid admin session cookie, must be refused
+// before the handler runs.
+func TestRequireAdminCSRFCrossOriginPostDenied(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-origin admin POST: code=%d, want 403 (CSRF); body=%q", rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("cross-origin admin POST reached the protected handler — CSRF gate did not run")
+	}
+}
+
+// TestRequireAdminCSRFSiblingTenantOriginDenied covers the lane the audit
+// reproduced: a hostile tenant spoke. isTrustedOrigin still allows
+// *.hive.kubestellar.io, so this currently passes the CSRF check and is denied
+// only if the wider trusted-origin reduction lands. Asserting the *documented*
+// current behaviour keeps this test honest rather than aspirational — flip it
+// to expect 403 when the exact-origin change ships.
+func TestRequireAdminCSRFSiblingTenantOriginStillTrusted(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://attacker-hive.hive.kubestellar.io")
+
+	if !isCSRFSafe(req) {
+		t.Skip("sibling-tenant origin is no longer trusted — the exact-origin fix has landed; update this test to assert 403 through requireAdmin")
+	}
+	t.Log("KNOWN GAP (N6, second half): a sibling *.hive.kubestellar.io origin is still CSRF-trusted; " +
+		"the requireAdmin gate does not close this lane on its own. Tracked for the exact-origin + CSRF-token work.")
+}
+
+// TestRequireAdminSafeGetStillAllowed guards against over-correction: the CSRF
+// check must not break admin GETs, which is how the dashboard reads admin data.
+func TestRequireAdminSafeGetStillAllowed(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/admin/users", nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if !reached || rec.Code != http.StatusOK {
+		t.Fatalf("admin GET with valid session: code=%d reached=%v, want 200/true", rec.Code, reached)
+	}
+}
+
+// TestRequireAdminSameOriginPostAllowed proves the legitimate dashboard path
+// (a same-origin POST from the hub itself) is unaffected by the new gate.
+func TestRequireAdminSameOriginPostAllowed(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if !reached || rec.Code != http.StatusOK {
+		t.Fatalf("same-origin admin POST: code=%d reached=%v, want 200/true", rec.Code, reached)
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -2412,6 +2412,22 @@ spec:
     spec:
 {{- if .RequiresSCC}}
       serviceAccountName: hive-sa
+{{- else}}
+      # SECURITY (audit N5, CWE-732/522): fsGroup makes the 0440 secrets
+      # projection (see the volume below) readable by dev — a member of
+      # hive-launch, GID 1002 pinned in v2/Dockerfile — while excluding the agent
+      # UIDs (2001+). Mode alone cannot do it: dev's primary group node is
+      # shared with every agent, so 0440 root:node still leaks the App key, and
+      # 0400 would lock out dev itself.
+      #
+      # NOT applied on the SCC lane. OpenShift's restricted SCC allocates its own
+      # fsGroup from the namespace range and rejects out-of-range values, so
+      # pinning 1002 there would fail admission and wedge the rollout
+      # (maxUnavailable=0 means a never-Ready surge pod hangs it indefinitely).
+      # OpenShift already gives each namespace a distinct, non-shared fsGroup, so
+      # the 0440 mode is doing the right thing there on its own.
+      securityContext:
+        fsGroup: 1002
 {{- end}}
       initContainers:
       - name: copy-config
@@ -2601,6 +2617,22 @@ spec:
       - name: secrets
         secret:
           secretName: hive-secrets
+          # SECURITY (audit N5, CWE-732/522): without defaultMode Kubernetes
+          # projects these files 0644, readable by every UID in the pod — so any
+          # agent (2001+) could read the GitHub App private key, and mint a full
+          # installation token from app_id + installation_id + key_file.
+          #
+          # The entrypoint's chmod 600 /secrets/*.pem cannot compensate: the
+          # projection is a read-only tmpfs, so chmod returns EROFS and the
+          # 2>/dev/null || true swallows it silently.
+          #
+          # 0440 pairs with the pod-level fsGroup below. Mode alone is not
+          # enough: dev shares its primary group node with every agent UID,
+          # so 0440 root:node would still expose the key; 0400 would be root-only
+          # and lock out dev. hive-launch (GID 1002, pinned in v2/Dockerfile)
+          # is the dedicated group that actually splits dev from the agents —
+          # the same argument the C6 su-exec fix made for 4750 root:hive-launch.
+          defaultMode: 0440
 ---
 apiVersion: v1
 kind: Service

--- a/v2/pkg/hub/saas_provision_secretmode_test.go
+++ b/v2/pkg/hub/saas_provision_secretmode_test.go
@@ -1,0 +1,136 @@
+package hub
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// N5 (CWE-732/522): the spoke manifest must not project GitHub App PEMs
+// world-readable.
+//
+// Kubernetes defaults Secret projections to 0644, so without an explicit
+// defaultMode every agent UID (2001+) in the pod could read the org App private
+// key — and app_id + installation_id + key_file is enough to mint a full
+// installation token (bin/gh-app-token.sh). The entrypoint's compensating
+// `chmod 600 /secrets/*.pem` cannot fix it: /secrets is a read-only tmpfs
+// projection, so chmod returns EROFS and the surrounding `2>/dev/null || true`
+// swallows the error AND the exit code. It fails silently, which is why five
+// audits went by with the mode still 0644 in every hosted pod.
+//
+// These tests render the REAL template. Nothing else in the package does, so a
+// malformed template (an unbalanced action, or a stray backtick terminating the
+// Go raw-string literal that holds it) would otherwise only surface when
+// provisioning a live hive.
+
+// renderManifest executes k8sManifestTemplate with a minimal data set, varying
+// only the fields these assertions depend on.
+func renderManifest(t *testing.T, requiresSCC bool) string {
+	t.Helper()
+	tmpl, err := template.New("manifests").Parse(k8sManifestTemplate)
+	if err != nil {
+		t.Fatalf("template does not parse: %v", err)
+	}
+	var buf bytes.Buffer
+	data := map[string]any{
+		"ID":                "test-hive",
+		"ImageTag":          "v2-latest",
+		"ImagePullPolicy":   "Always",
+		"RequiresSCC":       requiresSCC,
+		"InitContainerUID":  "1001",
+		"InitContainerGID":  "1000",
+		"TerminalPort":      7681,
+		"DashboardPort":     8080,
+		"CPURequest":        "500m",
+		"MemRequest":        "1Gi",
+		"CPULimit":          "2",
+		"MemLimit":          "4Gi",
+		"Namespace":         "hive-test",
+		"StorageSize":       "10Gi",
+		"HeartbeatKey":      "hb",
+		"SessionKey":        "sk",
+		"SSOPublicKey":      "pk",
+		"AuthorizedUsers":   "alice:owner",
+		"IsNginxIngress":    false,
+		"HasInference":      false,
+		"StorageClass":      "standard",
+		"Host":              "test-hive.hive.kubestellar.io",
+		"Owner":             "alice",
+		"HubURL":            "https://hive.kubestellar.io",
+		"ProjectName":       "test",
+		"PrimaryRepo":       "org/repo",
+		"AppKeys":           []provisionAppKey{},
+		"HasPlaceholderIDs": false,
+	}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template does not execute: %v", err)
+	}
+	return buf.String()
+}
+
+// secretsVolumeBlock returns the lines of the `- name: secrets` volume entry,
+// so an assertion cannot accidentally match a defaultMode belonging to some
+// other volume.
+func secretsVolumeBlock(t *testing.T, manifest string) string {
+	t.Helper()
+	idx := strings.Index(manifest, "- name: secrets")
+	if idx < 0 {
+		t.Fatal("no `- name: secrets` volume found in the rendered manifest")
+	}
+	rest := manifest[idx:]
+	// The block ends at the next document separator or the next sibling volume.
+	if end := strings.Index(rest, "\n---"); end >= 0 {
+		rest = rest[:end]
+	}
+	return rest
+}
+
+func TestSpokeManifestSecretsNotWorldReadable(t *testing.T) {
+	for _, scc := range []bool{false, true} {
+		name := "plain"
+		if scc {
+			name = "openshift-scc"
+		}
+		t.Run(name, func(t *testing.T) {
+			manifest := renderManifest(t, scc)
+			block := secretsVolumeBlock(t, manifest)
+
+			if !strings.Contains(block, "defaultMode:") {
+				t.Fatalf("secrets volume has no defaultMode — Kubernetes will project the App PEMs 0644, "+
+					"readable by every agent UID in the pod (N5).\nblock:\n%s", block)
+			}
+			// 0440 pairs with fsGroup; 0400 would lock out dev. Anything
+			// group/other-writable or other-readable is a regression.
+			if !strings.Contains(block, "defaultMode: 0440") {
+				t.Errorf("secrets defaultMode is not 0440:\n%s", block)
+			}
+		})
+	}
+}
+
+// TestSpokeManifestFsGroupOnlyOffSCC pins the deliberate asymmetry: fsGroup is
+// what makes 0440 readable by dev (whose primary group `node` is shared with
+// every agent UID, so a node-group mode would defeat the point). It must NOT be
+// set on the OpenShift lane, where the restricted SCC allocates fsGroup from
+// the namespace's own range and rejects an out-of-range pin — that would fail
+// admission and wedge a rollout that cannot tolerate a non-Ready surge pod.
+func TestSpokeManifestFsGroupOnlyOffSCC(t *testing.T) {
+	plain := renderManifest(t, false)
+	if !strings.Contains(plain, "fsGroup: 1002") {
+		t.Error("non-SCC spoke is missing `fsGroup: 1002`; the 0440 secrets projection would be unreadable by dev")
+	}
+
+	scc := renderManifest(t, true)
+	if strings.Contains(scc, "fsGroup:") {
+		t.Error("SCC spoke pins an fsGroup; OpenShift's restricted SCC assigns its own and would reject this at admission")
+	}
+	// The SCC lane keeps its own service account — guard against the
+	// if/else refactor having dropped it.
+	if !strings.Contains(scc, "serviceAccountName: hive-sa") {
+		t.Error("SCC spoke lost `serviceAccountName: hive-sa`")
+	}
+	if strings.Contains(plain, "serviceAccountName: hive-sa") {
+		t.Error("non-SCC spoke should not set the SCC service account")
+	}
+}

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -96,8 +96,13 @@ check "su-exec owned root:hive-launch (dedicated launcher group)" \
 # 5. The dedicated launcher group must exist and NOT include agent UIDs. dev is
 # added to it; agent users are created in the entrypoint with `-g node` only, so
 # a `-G hive-launch` on any agent useradd would be a regression.
+# The group must still be a --system group named hive-launch, but the flags
+# between them are not fixed: N5 added `--gid` to pin the GID so the deployment
+# manifests can name it in fsGroup (Secret defaultMode 0440 is only a boundary
+# if the group is one agents are NOT in). Match --system and the group name
+# without assuming they are adjacent.
 check "hive-launch launcher group is created" \
-  'groupadd[[:space:]]+--system[[:space:]]+hive-launch'
+  'groupadd[[:space:]]+([^[:space:]]+[[:space:]]+)*--system([[:space:]]+[^[:space:]]+)*[[:space:]]+hive-launch'
 check "dev is a member of hive-launch" \
   'useradd.*-G[[:space:]]+hive-launch'
 


### PR DESCRIPTION
Closes the four fastest-to-fix findings from the 2026-08-07 external security audit, all independently re-verified as live on `v4` HEAD before changing anything.

These are the high-severity-per-line items. The bigger §7.1 work (N7 parser rewrite, N8 gateway confinement, N9 lease accounting) and the hosted kill chain (N1–N4) follow in later PRs.

## What's fixed

| Finding | Severity | Fix |
|---|---|---|
| **N6** (partial) | High | `requireAdmin` now runs `isCSRFSafe`. It never did, so ~21 admin routes — hub upgrade, cluster App key writes, user delete, provisioning approval — were CSRF-reachable **from any origin**, not just a sibling tenant. |
| **N15 chain A** | Medium | `*)` default arm on the gh-wrapper mode `case`. An unknown non-empty mode matched nothing and fell through with **zero** enforcement. |
| **N20** | Low | Parenthesized the `-o` group in the `/tmp` cleanup `find`. Any owner's `/tmp/*.html` was being deleted, and the `*.out` cleanup never ran at all. |
| **N5** | High | `defaultMode` on all three Secret projections (none had one → PEMs projected 0644, readable by every agent UID). |
| **N12** (revised) | Medium | Contributor profiles 0644 → 0600. |

## Notes for review

**N5 needed a group, not just a mode.** `dev` (1001) shares its primary group `node` with every agent UID, so `0440 root:node` still hands over the App key and `0400` locks out `dev`. Fixed with `0440` + `fsGroup` on the dedicated `hive-launch` group — the same argument the C6 su-exec fix made for `4750 root:hive-launch`. That required pinning the GID in the Dockerfile, since `fsGroup` takes a number and cannot name a group; the build now fails loudly if that GID is taken.

`fsGroup` is deliberately **not** set on the OpenShift lane — the restricted SCC allocates from the namespace range and rejects out-of-range pins, which would fail admission and wedge a rollout that cannot tolerate a non-Ready surge pod.

**The entrypoint's `chmod 600 /secrets/*.pem` never worked.** `/secrets` is a read-only tmpfs projection, so chmod returns `EROFS` and `2>/dev/null || true` swallows both the error and the exit code. It fails silently — which is how 0644 survived five audits while the code read as correct.

**N12 was over-stated in the audit.** Registration tokens are already stored hashed with a constant-time compare, and the force-reissue takeover is already closed. The real residual was file mode, so this is a mode change rather than the storage redesign the audit called for.

## New test coverage

- `bin/test_gh_wrapper_gates.sh` — **the first test this file has ever had**, and `bin/**` is now in the CI path filter (it previously matched none, so the merge gate behind the proxy hard-deny had no CI at all). It *executes* the wrapper against a stub `gh` and asserts on exit codes; grepping the script text cannot catch a parser bug, which is how N7 survived. Assertions are pinned to *which* gate blocked — without that the unknown-mode cases passed off the eligibility gate even with the fix deleted.
- `saas_admin_csrf_test.go` — drives `requireAdmin` with a genuinely valid admin cookie, so its 403 can only come from CSRF. The existing `TestRequireAdminNonAdmin`/`NoAuth` also assert 403 but get it from the identity check, and kept passing with the hole open.
- `saas_provision_secretmode_test.go` — **the first test that renders the provisioning template at all.** A malformed template previously surfaced only when provisioning a live hive, and this change hit exactly that: backticks in the new YAML comments terminated the Go raw-string literal and broke the build.

Every regression test was verified to fail against the vulnerable code and pass against the fix.

## Still open (tracked, not in this PR)

- **N7** — the flag-reorder merge bypass is live. The new harness records it as a `KNOWN-GAP` line so it stays visible until the parser rewrite lands.
- **N6 sibling-tenant half** — `*.hive.kubestellar.io` is still a trusted origin; needs the exact-origin reduction plus CSRF tokens.
- **N9** — `revokeLease` only deletes a map entry; there is no GitHub token revocation anywhere, so even the correct path leaves a live credential until natural expiry.