### PR TITLE
🔒 Security audit 2026-08-07: N9 — wrong task_id must not clear the assignment

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -4,6 +4,17 @@ on:
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:
+  # Gate PRs, not just the cron. `go test ./pkg/...` runs nowhere else — v2-ci.yml
+  # builds and vets but never runs the unit tests — so before this, a Go
+  # regression test could only fail AFTER merge, as a cron-filed ci-failure
+  # issue. That is the wrong end of the loop for security regressions: the test
+  # proving a fix works has to be able to block the PR that breaks it again.
+  #
+  # create-issue-on-failure below stays gated on `github.event_name == 'schedule'`,
+  # so a red PR fails the check without also filing an issue.
+  pull_request:
+    branches: [v2, v4]
+    paths: ['v2/**', '.github/workflows/v2-tests.yml']
 
 permissions:
   contents: read

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -116,9 +116,58 @@ fi
 args=("$@")
 subcmd=""
 action=""
+
+# SECURITY (audit N7/H5, CWE-863): extracting the subcommand and action needs
+# REAL flag parsing, not "skip anything starting with -".
+#
+# The old loop skipped only tokens beginning with '-'. A SEPARATED flag VALUE
+# does not begin with '-', so it was consumed as a positional:
+#
+#   gh pr --repo owner/repo merge 123
+#          ^^^^^^ skipped   ^^^^^^^^^^ read as the action
+#
+# giving action="owner/repo" instead of "merge" — so EVERY gate keyed on
+# `action = "merge"` silently skipped: the ADVISORY / ISSUES_ONLY /
+# ISSUES_AND_PRS mode arms, the level-based fallback, AND the merge-eligibility
+# check. Any value-taking flag placed before the action worked: --repo, -R,
+# --title, --body, --label, --head, --base. The audit reproduced this against
+# real gh v2.47.0: an agent at ISSUES_PRS_MERGE (or below) could merge unvetted
+# code by reordering two flags.
+#
+# gh_flag_takes_value: does this flag consume the NEXT argv element?
+# `--flag=value` is self-contained and never does. Long forms are matched by
+# name; short forms are enumerated because gh's short flags are not uniform.
+gh_flag_takes_value() {
+  case "$1" in
+    *=*) return 1 ;;  # --flag=value carries its own value
+    # Long flags that take a value. Listed explicitly: a value-taking flag we
+    # fail to list would let its value be misread as the action again, so new
+    # flags must be added here rather than inferred.
+    --repo|--title|--body|--body-file|--label|--head|--base|--assignee|--reviewer| \
+    --milestone|--project|--template|--field|--raw-field|--method|--header| \
+    --hostname|--jq|--template-file|--search|--state|--author|--mention|--app| \
+    --branch|--subject|--match-body|--match-comments|--limit|--sort|--direction| \
+    --add-label|--remove-label|--add-assignee|--remove-assignee|--add-reviewer| \
+    --remove-reviewer|--add-project|--remove-project|--input|--cache|--comment| \
+    --file|--key|--value|--env|--org|--user|--owner|--commit-title|--commit-body| \
+    --match|--paginate-limit)
+      return 0 ;;
+    # Short flags that take a value.
+    -R|-t|-b|-B|-F|-f|-H|-l|-a|-A|-m|-p|-q|-c|-s|-L|-e|-d|-i|-k|-o|-u|-w|-x)
+      return 0 ;;
+    -*) return 1 ;;   # any other flag is boolean
+    *)  return 1 ;;
+  esac
+}
+
+_skip_next_gw=false
 for arg in "${args[@]}"; do
+  if $_skip_next_gw; then _skip_next_gw=false; continue; fi
   case "$arg" in
-    -*) continue ;;
+    --) # everything after -- is positional-only; stop flag interpretation
+        continue ;;
+    -*) if gh_flag_takes_value "$arg"; then _skip_next_gw=true; fi
+        continue ;;
     *)
       if [ -z "$subcmd" ]; then
         subcmd="$arg"
@@ -329,32 +378,80 @@ fi
 # Enforce merge gate — only PRs in merge-eligible.json can be merged
 MERGE_ELIGIBLE_FILE="/var/run/hive-metrics/merge-eligible.json"
 if [ "$subcmd" = "pr" ] && [ "$action" = "merge" ]; then
+  # SECURITY (audit N7): parse the PR identifier with the SAME flag table the
+  # subcommand extractor uses, so a value can never be mistaken for the PR
+  # number (or vice versa). The previous loop special-cased only --repo, so
+  # `-R owner/repo` left "owner/repo" to be read as pr_num — which then failed
+  # the eligibility lookup and DENIED a legitimate merge (fail-closed, but a
+  # real availability bug), while other value-taking flags could feed it junk.
+  #
+  # gh accepts the PR as a number, a URL, or a branch name; all three are
+  # positionals after the `merge` action.
   pr_num=""
   pr_repo=""
   skip_next=false
-  past_merge=false
+  seen_pr=false
+  seen_merge=false
   for arg in "${args[@]}"; do
     if $skip_next; then skip_next=false; continue; fi
     case "$arg" in
-      pr|merge) past_merge=true; continue ;;
-      --repo) skip_next=true; continue ;;
-      --repo=*) pr_repo="${arg#--repo=}"; continue ;;
-      -*) continue ;;
+      --repo=*|-R=*) pr_repo="${arg#*=}"; continue ;;
+      --repo|-R)     skip_next=true; continue ;;
+      -*)
+        if gh_flag_takes_value "$arg"; then skip_next=true; fi
+        continue ;;
       *)
-        if $past_merge && [ -z "$pr_num" ]; then
-          pr_num="$arg"
-        fi
+        # Consume the subcommand and action positionals first, then take the
+        # next positional as the identifier.
+        if ! $seen_pr; then seen_pr=true; continue; fi
+        if ! $seen_merge; then seen_merge=true; continue; fi
+        [ -z "$pr_num" ] && pr_num="$arg"
         ;;
     esac
   done
 
+  # Recover a separated --repo/-R value (the loop above skips it by design).
   if [ -z "$pr_repo" ]; then
     for i in "${!args[@]}"; do
-      if [ "${args[$i]}" = "--repo" ] && [ -n "${args[$((i+1))]:-}" ]; then
-        pr_repo="${args[$((i+1))]}"
-        break
-      fi
+      case "${args[$i]}" in
+        --repo|-R)
+          if [ -n "${args[$((i+1))]:-}" ]; then pr_repo="${args[$((i+1))]}"; fi
+          break ;;
+      esac
     done
+  fi
+
+  # Normalize a PR URL to its number so the eligibility lookup can match it.
+  # `gh pr merge https://github.com/o/r/pull/123` is a legitimate form that the
+  # old parser passed through verbatim and therefore always denied.
+  case "$pr_num" in
+    http://*|https://*)
+      url_repo="$(printf '%s' "$pr_num" | sed -n 's#^https\{0,1\}://[^/]*/\([^/]*/[^/]*\)/pull/.*#\1#p')"
+      url_num="$(printf '%s' "$pr_num" | sed -n 's#.*/pull/\([0-9][0-9]*\).*#\1#p')"
+      if [ -n "$url_num" ]; then
+        pr_num="$url_num"
+        [ -z "$pr_repo" ] && pr_repo="$url_repo"
+      fi
+      ;;
+  esac
+
+  # SECURITY (audit N7): fail CLOSED when no PR identifier is present.
+  #
+  # `gh pr merge` (merge whatever PR belongs to the current branch) and
+  # `gh pr merge --repo owner/repo` carry no number, so pr_num stayed empty —
+  # and BOTH eligibility branches below were guarded on `[ -n "$pr_num" ]` with
+  # no else. Execution fell straight through to `exec "$REAL_GH"`, so the most
+  # permissive mode had no wall at all: an agent could merge the current
+  # branch's PR without it ever appearing in merge-eligible.json.
+  #
+  # The wrapper cannot resolve the current branch's PR without calling gh (which
+  # is the thing being gated), so the only safe answer is to require an explicit,
+  # checkable identifier.
+  if [ -z "$pr_num" ]; then
+    echo "⛔ BLOCKED: 'gh pr merge' needs an explicit PR number or URL." >&2
+    echo "The merge gate verifies the PR against ${MERGE_ELIGIBLE_FILE}, which it cannot do for an implicit current-branch merge." >&2
+    echo "Re-run as: gh pr merge <number> [--repo owner/repo]" >&2
+    exit 1
   fi
 
   if [ -n "$pr_num" ] && [ -f "$MERGE_ELIGIBLE_FILE" ]; then

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -80,6 +80,7 @@ run_wrapper() {
   local gate=other
   [[ "$out" == *"unrecognized agent mode"* ]] && gate=mode-default
   [[ "$out" == *"NOT in merge-eligible.json"* || "$out" == *"cannot verify merge eligibility"* ]] && gate=eligibility
+  [[ "$out" == *"needs an explicit PR number or URL"* ]] && gate=no-identifier
 
   echo "exit=${rc} stub=${reached} gate=${gate}"
   # Surface wrapper output only when debugging a failure.
@@ -154,24 +155,48 @@ assert_reached "NO_GITHUB allows a non-issue/pr subcommand (repo view)" \
 # VALUE as the action, so action != "merge" and every gate is skipped. The fix
 # is a real flag parser; until it lands these cases record the live bypass so
 # the harness fails loudly the moment behaviour changes in either direction.
-echo "-- N7 flag-reorder bypass (expected to FAIL until the parser is fixed) --"
-reorder="$(run_wrapper "ISSUES_AND_PRS" 5 -- pr --repo owner/repo merge 123)"
-if [[ "$reorder" == "exit=1 stub=no" ]]; then
-  echo "  PASS: flag-reorder merge is gated (N7 parser fix has landed)"
-  PASS=$((PASS + 1))
-else
-  echo "  KNOWN-GAP (N7): 'gh pr --repo owner/repo merge 123' bypassed the merge gate under ISSUES_AND_PRS"
-  echo "                  got '$reorder'; the flag value is parsed as the action. Fix: real flag parsing."
-fi
+# ── N7: the flag-reorder bypass ───────────────────────────────────────────────
+# `gh pr --repo o/r merge 123` used to make the subcmd/action extractor read
+# --repo's VALUE as the action, so action != "merge" and every gate was skipped.
+# Each of these must be gated for the SAME reason the un-reordered form is.
+echo "-- N7 flag-reorder must not skip the gates --"
+assert_blocked "reordered merge is gated under ISSUES_AND_PRS" \
+  "$(run_wrapper "ISSUES_AND_PRS" 5 -- pr --repo owner/repo merge 123)"
+assert_blocked "reordered merge is gated under ISSUES_ONLY" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- pr --repo owner/repo merge 123)"
+assert_blocked "reordered merge is gated under ADVISORY" \
+  "$(run_wrapper "ADVISORY" 5 -- pr --repo owner/repo merge 123)"
+assert_blocked "-R short form is gated too" \
+  "$(run_wrapper "ISSUES_AND_PRS" 5 -- pr -R owner/repo merge 123)"
+assert_blocked "a value-taking flag before the action does not hide it (--title)" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- pr --title 'merge me' merge 123)"
+# --flag=value is self-contained and must NOT consume the next token.
+assert_blocked "--repo=value form is gated" \
+  "$(run_wrapper "ISSUES_AND_PRS" 5 -- pr --repo=owner/repo merge 123)"
 
-bare="$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge)"
-if [[ "$bare" == "exit=1 stub=no" ]]; then
-  echo "  PASS: bare 'pr merge' is gated (eligibility fix has landed)"
-  PASS=$((PASS + 1))
-else
-  echo "  KNOWN-GAP (N7): bare 'gh pr merge' skipped the eligibility check (empty pr_num)"
-  echo "                  got '$bare'"
-fi
+# At the most permissive mode the merge-eligibility gate is the wall. A PR that
+# is not in merge-eligible.json must be refused however the args are arranged.
+echo "-- N7 eligibility gate applies to every merge form --"
+assert_blocked "reordered merge still hits eligibility at ISSUES_PRS_MERGE" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr --repo owner/repo merge 123)" eligibility
+assert_blocked "plain merge hits eligibility at ISSUES_PRS_MERGE" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123)" eligibility
+# No identifier => cannot be checked against merge-eligible.json => denied.
+# The wrapper cannot resolve the current branch's PR without calling gh, which
+# is the very thing under gate, so requiring an explicit number is the only
+# fail-closed answer.
+assert_blocked "bare 'pr merge' (current branch, no number) is not a free pass" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge)" no-identifier
+assert_blocked "'pr merge --repo o/r' with no number is not a free pass" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge --repo owner/repo)" no-identifier
+
+# Availability: forms that gh accepts must reach the eligibility check rather
+# than being wrongly denied. A PR URL previously landed in pr_num verbatim and
+# never matched a number, so a legitimate merge was refused.
+assert_blocked "PR URL is normalized and reaches the eligibility gate" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge https://github.com/owner/repo/pull/123)" eligibility
+assert_blocked "-R form reaches the eligibility gate (not a parse denial)" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123 -R owner/repo)" eligibility
 
 echo
 echo "=== $PASS passed, $FAIL failed ==="

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -2259,15 +2259,34 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				completedTask := contributor.currentTask
-				contributor.currentTask = nil
-				// #2539: drop the previewable prompt with the task it belonged to so
-				// the ops tab does not show a stale instruction after completion.
-				contributor.currentPrompt = ""
-				contributor.currentLabels = nil
-				contributor.tokenMintedAt = time.Time{}
-				// #2537: clear any pending/delivered credential state with the task.
-				contributor.pendingToken = ""
-				contributor.credentialDelivered = false
+				// SECURITY (audit N9, CWE-862/639): clear ONLY when the reported
+				// task_id actually matches the held assignment.
+				//
+				// This block used to run unconditionally, while revokeLease and
+				// markTaskCompleted below run only `if hasTask`. So a completion
+				// naming ANY other task released the assignment without revoking the
+				// lease or booking a cooldown: the contributor went `ready` and was
+				// minted a SECOND live repo credential under max_concurrent=1, and
+				// the "unassigned task ignored" warning below said otherwise while
+				// the state had in fact already been mutated.
+				//
+				// The #2568 Gate does not cover this: generationAccepted() returns
+				// true whenever clientGen == 0, and omitting task_gen yields 0, so
+				// the guard is opt-in from the client.
+				if hasTask {
+					contributor.currentTask = nil
+					// #2539: drop the previewable prompt with the task it belonged to
+					// so the ops tab does not show a stale instruction after completion.
+					contributor.currentPrompt = ""
+					contributor.currentLabels = nil
+					contributor.tokenMintedAt = time.Time{}
+					// #2537: clear any pending/delivered credential state with the task.
+					contributor.pendingToken = ""
+					contributor.credentialDelivered = false
+				}
+				// tmuxOutput is diagnostic only and carries no authority, so it is
+				// recorded either way — it is often the only evidence of what a
+				// confused relay was doing when it reported the wrong task.
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
 
@@ -2344,7 +2363,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					}
 					_ = saveContributorProfile(contributor.profile)
 				} else {
-					h.logger.Warn("[contribute-ws] task_complete for unassigned task ignored",
+					// N9: this is now literally true. It previously logged "ignored"
+					// after the handler had already cleared currentTask and the
+					// credential state, which made the bypass look like a no-op in the
+					// logs.
+					h.logger.Warn("[contribute-ws] task_complete for unassigned task ignored (assignment left intact)",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
 					)
@@ -2372,11 +2395,19 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				failedTask := contributor.currentTask
-				contributor.currentTask = nil
-				contributor.tokenMintedAt = time.Time{}
-				// #2537: clear any pending/delivered credential state with the task.
-				contributor.pendingToken = ""
-				contributor.credentialDelivered = false
+				// SECURITY (audit N9, CWE-862/639): same hole as task_complete —
+				// clear only on a genuine TaskID match. Unconditionally, a failure
+				// naming any other task released the assignment while revokeLease
+				// and recordTaskFailure below stayed inside `if hasTask`, so no
+				// cooldown was booked and the abandoned issue became instantly
+				// re-admissible while the credential stayed live.
+				if hasTask {
+					contributor.currentTask = nil
+					contributor.tokenMintedAt = time.Time{}
+					// #2537: clear any pending/delivered credential state with the task.
+					contributor.pendingToken = ""
+					contributor.credentialDelivered = false
+				}
 				contributor.mu.Unlock()
 
 				if hasTask {

--- a/v2/pkg/dashboard/contribute_ws_sec_n9_test.go
+++ b/v2/pkg/dashboard/contribute_ws_sec_n9_test.go
@@ -1,0 +1,234 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// N9 (CWE-862/639): a task_complete / task_failed carrying the WRONG task_id
+// must not clear the assignment.
+//
+// Both handlers computed `hasTask` from a TaskID equality check and then cleared
+// currentTask, pendingToken, credentialDelivered and tokenMintedAt
+// UNCONDITIONALLY — before the `if hasTask` block — while every protective
+// action (revokeLease, markTaskCompleted / recordTaskFailure, verifyReportedPR)
+// sat INSIDE it. The else branch logged "ignored", which was false: the state
+// had already been mutated.
+//
+// The result: a contributor capped at max_concurrent=1 could send
+// {"type":"task_complete","task_id":"anything-wrong"} to clear its assignment
+// without the lease being revoked or a cooldown booked, go `ready` again, and
+// be minted a SECOND live repo credential. Repeat for N.
+//
+// The Gate (#2568) does not stop this. generationAccepted returns true whenever
+// clientGen == 0, and a client that simply OMITS task_gen gets 0 — so the guard
+// is opt-in from the client side, which is exactly what an attacker chooses.
+//
+// The existing coverage misses it in both directions: contribute_ws_test.go's
+// wrong-id case asserts only profile counters (which the bug does not touch),
+// and contribute_lease_test.go's Gate test always sends a NON-ZERO TaskGen, so
+// it never reaches the TaskGen=0 + wrong-id combination.
+
+// leaseCountFor reports how many leases the hub holds for an identity. The lease
+// map is the server-side accounting the credential cap is enforced from, so it
+// is the thing that must survive a bogus completion.
+func leaseCountFor(h *ContributeWSHub, identity string) int {
+	h.leaseMu.Lock()
+	defer h.leaseMu.Unlock()
+	n := 0
+	for id := range h.leases {
+		if id == identity {
+			n++
+		}
+	}
+	return n
+}
+
+// TestWrongTaskIDCompletionDoesNotClearAssignment is the N9 regression: a
+// completion for a task the contributor does not hold must be a no-op.
+func TestWrongTaskIDCompletionDoesNotClearAssignment(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"n9user"}`
+	req := httptest.NewRequest("POST", "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	setStatusIssues(s, intgIssue(900, "N9 issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+	realTaskID := assign.TaskID
+
+	// Send a completion for a task this contributor was never assigned, with
+	// task_gen OMITTED — the shape the official relay uses, and the shape that
+	// slips past the Gate.
+	conn.WriteJSON(WSMessage{
+		Type:   "task_complete",
+		TaskID: "not-the-assigned-task",
+		Result: "pr_created",
+		PRURL:  "https://github.com/myorg/repo1/pull/1",
+	})
+	time.Sleep(80 * time.Millisecond)
+
+	// The assignment must survive. Before the fix currentTask was nil here, which
+	// is what let the contributor go `ready` and collect a second credential.
+	s.contributeHub.mu.RLock()
+	var held *ContributorConnection
+	for _, c := range s.contributeHub.connections {
+		if c.profile != nil && c.profile.GitHubUsername == "n9user" {
+			held = c
+		}
+	}
+	s.contributeHub.mu.RUnlock()
+	if held == nil {
+		t.Fatal("connection vanished")
+	}
+
+	held.mu.Lock()
+	cur := held.currentTask
+	held.mu.Unlock()
+
+	if cur == nil {
+		t.Fatal("N9: a wrong-task_id completion CLEARED the assignment — the contributor " +
+			"can now go ready and be minted a second concurrent credential under max_concurrent=1")
+	}
+	if cur.TaskID != realTaskID {
+		t.Fatalf("N9: assignment changed to %q, want the original %q", cur.TaskID, realTaskID)
+	}
+
+	// The lease is the server-side accounting the cap is enforced from; a bogus
+	// completion must not release it either.
+	if n := leaseCountFor(s.contributeHub, identityOf(held)); n != 1 {
+		t.Fatalf("N9: lease count is %d after a wrong-id completion, want 1 (the lease must not be released)", n)
+	}
+}
+
+// TestWrongTaskIDFailureDoesNotClearAssignment covers task_failed, which carries
+// the identical hole — and additionally books no failure cooldown, so the
+// abandoned issue becomes instantly re-assignable.
+func TestWrongTaskIDFailureDoesNotClearAssignment(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"n9fail"}`
+	req := httptest.NewRequest("POST", "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	setStatusIssues(s, intgIssue(901, "N9 fail issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+
+	conn.WriteJSON(WSMessage{Type: "task_failed", TaskID: "not-the-assigned-task", Permanent: false})
+	time.Sleep(80 * time.Millisecond)
+
+	s.contributeHub.mu.RLock()
+	var held *ContributorConnection
+	for _, c := range s.contributeHub.connections {
+		if c.profile != nil && c.profile.GitHubUsername == "n9fail" {
+			held = c
+		}
+	}
+	s.contributeHub.mu.RUnlock()
+	if held == nil {
+		t.Fatal("connection vanished")
+	}
+	held.mu.Lock()
+	cur := held.currentTask
+	held.mu.Unlock()
+
+	if cur == nil {
+		t.Fatal("N9: a wrong-task_id task_failed CLEARED the assignment without booking a " +
+			"failure cooldown — the issue is instantly re-admissible and the credential stays live")
+	}
+}
+
+// TestCorrectTaskIDCompletionStillClears is the control: the fix must not break
+// the legitimate path. A matching task_id still clears the assignment and
+// releases the lease.
+func TestCorrectTaskIDCompletionStillClears(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"n9ok"}`
+	req := httptest.NewRequest("POST", "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	setStatusIssues(s, intgIssue(902, "N9 control issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+
+	conn.WriteJSON(WSMessage{Type: "task_complete", TaskID: assign.TaskID, Result: "pr_created"})
+	time.Sleep(80 * time.Millisecond)
+
+	s.contributeHub.mu.RLock()
+	var held *ContributorConnection
+	for _, c := range s.contributeHub.connections {
+		if c.profile != nil && c.profile.GitHubUsername == "n9ok" {
+			held = c
+		}
+	}
+	s.contributeHub.mu.RUnlock()
+	if held == nil {
+		t.Fatal("connection vanished")
+	}
+	held.mu.Lock()
+	cur := held.currentTask
+	held.mu.Unlock()
+
+	if cur != nil {
+		t.Fatalf("a MATCHING task_complete must still clear the assignment, but currentTask is %q", cur.TaskID)
+	}
+}


### PR DESCRIPTION
**Stacked on #3142** (which is stacked on #3140). Merge in order; each retargets automatically.

Closes **N9**, the third of the audit's four mandatory self-hosted fixes.

## The bug

`task_complete` and `task_failed` computed `hasTask` from a TaskID equality check, then cleared `currentTask`, `pendingToken`, `credentialDelivered` and `tokenMintedAt` **unconditionally — before** the `if hasTask` block, while every protective action (`revokeLease`, `markTaskCompleted`/`recordTaskFailure`, `verifyReportedPR`) sat *inside* it.

So a completion naming **any other task** released the assignment without revoking the lease or booking a cooldown:

```json
{"type":"task_complete","task_id":"anything-wrong"}
```

→ contributor goes `ready` → minted a **second** live repo credential under `max_concurrent=1`. Repeat for N.

The `else` branch logged `"task_complete for unassigned task ignored"`, which was **false** — the state had already been mutated, so the bypass looked like a no-op in the logs. That message is now literally true.

## Why the Gate didn't catch it

`generationAccepted()` returns `true` whenever `clientGen == 0`, and a client that simply **omits** `task_gen` gets 0. The #2568 Gate is opt-in from the client side — which is exactly what an attacker chooses. Its stale-generation semantics are preserved unchanged by this fix.

## Why the existing tests didn't catch it

Both near-misses, in opposite directions:
- `contribute_ws_test.go`'s wrong-id case asserts only **profile counters**, which the bug never touched — it passed against the vulnerable code.
- `contribute_lease_test.go`'s Gate test always sends a **non-zero** `TaskGen`, so it never reached the `TaskGen=0` + wrong-id combination that is the actual bypass.

## Regression

Drives the real WebSocket end to end and asserts **both** that the assignment survives **and** that the lease — the server-side accounting the credential cap is enforced from — is not released. Verified to fail against the unfixed handler in both `task_complete` and `task_failed`. A control leg proves a matching `task_id` still clears, so the legitimate path is intact.

`tmuxOutput` is still recorded on the mismatch path: it carries no authority and is often the only evidence of what a confused relay was doing.

## Follow-up (not fixed here)

**There is no GitHub token revocation anywhere in this flow.** `revokeLease` only does `delete(h.leases, identity)` — it does not invalidate the credential already in the contributor's hands, so even the *correct* completion path leaves a live token until its ~1h natural expiry. This PR closes the unbounded-concurrency bypass; genuinely closing the credential window needs net-new code and should be tracked separately.