### PR TITLE
📖 docs: v2 operations reference

### DIFF
--- a/dashboard/openapi.json
+++ b/dashboard/openapi.json
@@ -23,6 +23,7 @@
     { "name": "Status", "description": "Live hive status and monitoring" },
     { "name": "History", "description": "Sparkline, trend, and timeline data" },
     { "name": "Tokens", "description": "Token usage and cost tracking" },
+    { "name": "Audit", "description": "Recent dashboard and agent lifecycle audit entries" },
     { "name": "Governor", "description": "Governor mode and configuration" },
     { "name": "Agents", "description": "Agent configuration and state" },
     { "name": "Strategy Lab", "description": "Nous experiment engine" },
@@ -31,6 +32,41 @@
     { "name": "System", "description": "Version, config, and diagnostics" }
   ],
   "paths": {
+    "/api/audit": {
+      "get": {
+        "tags": ["Audit"],
+        "summary": "Recent audit log entries",
+        "description": "Returns up to 200 newest audit entries from the dashboard audit ring. Requires read-write or higher access.",
+        "responses": {
+          "200": {
+            "description": "Audit entries, newest first",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "ts": { "type": "string", "format": "date-time" },
+                          "user": { "type": "string" },
+                          "action": { "type": "string" },
+                          "detail": { "type": "string" },
+                          "agent": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": { "description": "Insufficient access" }
+        }
+      }
+    },
     "/api/status": {
       "get": {
         "tags": ["Status"],

--- a/v2/README.md
+++ b/v2/README.md
@@ -266,6 +266,8 @@ Configure via the dashboard or the `/api/nous/*` endpoints. See `hive.yaml.examp
 - [Cross-cluster migration](docs/cross-cluster-migration.md) — move a hive between clusters.
 - [Manual provisioning](docs/manual-provisioning.md) — hosted/spoke provisioning and hub access.
 - [Config layering](docs/config-layering.md) — ConfigMap vs PVC overlay precedence.
+- [Network requirements](docs/network-requirements.md) and [TLS setup](docs/tls-setup.md) — firewall, port, and HTTPS guidance.
+- [Token tracking](docs/token-tracking.md) and [security notes](docs/security.md) — cost/usage rollups and log redaction.
 - [Trajectory review](docs/trajectory-review.md) — trajectory safety lane.
 - [Credly badges](docs/credly-badges.md) — planned badge integration placeholder.
 

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -8,6 +8,10 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
+- [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
+- [TLS, HTTPS, and certificates](tls-setup.md) — termination patterns and certificate ownership.
+- [Security notes](security.md) — log scrubbing and secret redaction guarantees/limits.
+- [Token collection and usage tracking](token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
 - [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [ioscan status](ioscan.md) — v2 status of the untrusted-input scanner/canary feature.

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -315,6 +315,8 @@ reroutes Anthropic-shaped calls to OpenAI-shaped endpoints where needed.
 each backend's **session JSONL** files (plus a live proxy sniff of Copilot's
 usage block) and multiplies token counts by a dated per-model price table. This
 feeds the dashboard's live cost, hourly spend, and per-agent/model attribution.
+See [Token collection and usage tracking](token-tracking.md) for the data shape,
+`/api/cost`, and hub `/api/saas/usage` rollups.
 
 ---
 
@@ -331,12 +333,15 @@ flowchart LR
 ```
 
 - `/api/status` — full fleet + governor state (`BuildFrontendStatus`).
+- `/api/audit` — recent audit entries for read-write users: dashboard config changes, logins, GitHub App setup changes, and agent lifecycle events such as start, stop, launch failure, pause/resume/kick, add/remove, backend changes, and model changes. Entries are kept in memory and, when `/data` exists, appended to `/data/audit.jsonl` with lumberjack rotation (5 MB files, 3 backups, 90 days).
 - `/api/events` — Server-Sent Events; the dashboard is pushed a fresh snapshot on
   every eval cycle (and a lighter agent-only update on the fast poll).
 - `/api/health`, `/api/health/deep`, `/api/livez` — readiness and liveness; the
   `livez` probe catches the "HTTP up but eval loop / heartbeat stalled" case.
 - Notifications (`ntfy` / Slack / Discord) fire on budget warnings, SLA breaches,
   trajectory-drift pauses, and other governor events.
+- Log output is wrapped by `pkg/logscrub`, which redacts recognized GitHub token and JWT-like strings from messages and string attributes. See [Security notes](security.md) for guarantees and limits.
+- Network exposure and TLS termination are documented in [Network and port requirements](network-requirements.md) and [TLS setup](tls-setup.md).
 
 ---
 

--- a/v2/docs/network-requirements.md
+++ b/v2/docs/network-requirements.md
@@ -1,0 +1,50 @@
+# Network and port requirements
+
+This page is derived from the v2 code and manifests. Treat it as the operator-facing firewall matrix for standalone Docker Compose, Kubernetes spokes, and hub deployments.
+
+## Inbound listeners
+
+| Port | Where it binds | External? | Purpose |
+| ---: | --- | --- | --- |
+| 3001 | Docker gateway (`deploy/nginx.conf`); hub mode (`HIVE_MODE=hub`, `HIVE_HUB_PORT` override) | Yes for standalone dashboard or hub | Public dashboard front door, hub UI/API, `/contribute`, `/api/heartbeat`, SSE, and WebSocket proxy paths. |
+| 3002 | Go dashboard in Kubernetes examples (`deploy/k8s/configmap.yaml` + Service) | Expose through Ingress/Route only | Dashboard/API process in Kubernetes. The Service targets 3002; TLS should terminate before it. |
+| 7681 | `ttyd` and Docker stream proxy | Usually no; expose only to trusted operators | Web terminal for `/terminal`/tmux access. In Docker Compose it is published; in Kubernetes it is a Service port. |
+| 18443 | Go process, loopback/agent namespace | No | MITM GitHub proxy used by iptables redirection for agent GitHub egress. Do not expose. |
+| 18444 | Go process, loopback/agent namespace | No | Inference translator for OpenAI-compatible gateway backends. Do not expose. |
+| 9000 | `cmd/apiproxy` default | Only if you run `apiproxy` separately | Standalone API proxy/debug tool, not part of the default hive container. |
+
+Notes:
+
+- `hive.yaml.example` defaults `dashboard.port` to 3001 for local/source runs. The Kubernetes ConfigMap sets it to 3002 because the cluster Service/Ingress owns the public edge.
+- Docker Compose publishes 3001 and 7681 from the `gateway` container and only `expose`s 3001/3002/7681 on the `hive` container.
+- The hub is also a Go HTTP server on 3001 unless `HIVE_HUB_PORT` is set. Contributor relay defaults to `wss://hive.kubestellar.io:3001/contribute`.
+
+## HTTP/WebSocket paths that must pass through proxies
+
+Reverse proxies, Routes, and Ingresses must preserve HTTP upgrade headers and long read timeouts for:
+
+- `/api/events` — dashboard Server-Sent Events.
+- `/api/contribute/ws` and hub `/contribute/ws` — contributor relay WebSocket.
+- `/terminal` — ttyd WebSocket terminal.
+- `/gh-setup` — GitHub App Setup URL callback.
+- `/api/heartbeat` — spoke-to-hub heartbeat POSTs.
+
+## Outbound egress
+
+| Destination | Required by | Notes |
+| --- | --- | --- |
+| GitHub web/API host (`github.com`/`api.github.com` or configured GHE `base_url`/`api_url`) | Issue/PR enumeration, App token minting, git operations, `/gh-setup` verification | Agents may be routed through the local MITM proxy; the hive process itself also calls GitHub APIs. |
+| Hub URL (`hub.url`) | Spokes | Heartbeats and callback polling. Must be reachable from firewalled spokes even when the hub cannot initiate inbound connections. |
+| Model backends and CLI auth endpoints | Agents | Claude/Copilot/Gemini CLIs and OpenAI-compatible gateways (`vllm`, `llm-d`, `litellm`, OpenRouter, custom). |
+| Notification endpoints | Optional | `ntfy`, Slack webhooks, and Discord webhooks/bot API only when configured. |
+| Container/image registries | Deployment/auto-update | Pull hive images, watchtower updates, and any inference backend images. |
+| npm/GitHub for caveman mode | Optional | `npx github:JuliusBrussee/caveman#...` runs when `caveman_mode` is enabled for supported backends. |
+| Kubernetes API | In-cluster spokes/hub | Used for health/provisioning/route discovery when those features are configured. |
+
+## Firewall recommendations
+
+- Public edge: expose only the dashboard/hub front door (3001 for Docker/hub, or your HTTPS Ingress/Route for Kubernetes). Keep 3002 and 7681 cluster/private unless you have an explicit operator access path.
+- Internal-only: never publish 18443 or 18444 outside the pod/container network.
+- Kubernetes: use a `ClusterIP` Service and terminate HTTPS at an Ingress/Route. Open 3002 from the Ingress/Route controller to the Service, and 7681 only if terminal access is required.
+- Docker Compose: restrict published 7681 to trusted networks or remove that port mapping if operators do not need web terminal access.
+- GitHub App callbacks: configure DNS and HTTPS so GitHub can reach `https://<hive-host>/gh-setup` when using the Setup URL flow.

--- a/v2/docs/security.md
+++ b/v2/docs/security.md
@@ -1,0 +1,30 @@
+# Security notes: log scrubbing and secret redaction
+
+Hive wraps its structured `slog` handler with `pkg/logscrub`. The wrapper redacts recognized token-like strings before log records reach the underlying handler.
+
+## What is scrubbed
+
+The current redaction pattern replaces matches with `[REDACTED]` in:
+
+- log messages,
+- string-valued attributes,
+- string attributes inside slog groups, and
+- attributes attached with `logger.With(...)`.
+
+Recognized patterns are:
+
+- GitHub token prefixes `ghs_`, `ghp_`, `gho_`, and `github_pat_` followed by at least ten token characters.
+- JWT-like strings beginning with `eyJ` and containing three base64url segments.
+
+The cost endpoint also redacts the configured gateway API key from native-cost probe errors before returning the error text.
+
+## Limits
+
+- Scrubbing is pattern-based, not a general secret scanner. A secret with another shape can still appear if code logs it directly.
+- Non-string slog values are passed through unchanged unless they are inside a group containing string attributes.
+- Redaction happens in the Hive logging path. Data written by external tools, agent CLIs, terminal transcripts, or third-party proxies is not automatically covered unless it flows through Hive's scrubbed logger.
+- False positives are replaced with `[REDACTED]`; there is no runtime allow-list or custom pattern configuration today.
+
+## Operator checks
+
+To validate a deployment, emit a test log through Hive code or a local unit test using a fake `ghp_...` value and confirm that only `[REDACTED]` reaches the configured log sink. Never test with a real credential.

--- a/v2/docs/tls-setup.md
+++ b/v2/docs/tls-setup.md
@@ -1,0 +1,42 @@
+# TLS, HTTPS, and certificates
+
+Hive v2 does not implement native TLS configuration in `hive.yaml`. The dashboard and hub servers call Go `ListenAndServe`, and the bundled Docker gateway listens with plain HTTP. Production HTTPS is therefore an edge concern: terminate TLS at an ingress controller, OpenShift Route, load balancer, or reverse proxy, then proxy HTTP to Hive.
+
+## What the spoke serves
+
+- Standalone/source runs: the Go dashboard serves HTTP on `dashboard.port` (3001 by default).
+- Kubernetes examples: the Go dashboard serves HTTP on 3002 behind the `hive` Service.
+- Docker Compose: nginx listens on 3001 and proxies HTTP to the hive process; the compose example does not mount certificates or enable TLS.
+- Internal local listeners 18443 and 18444 are not public TLS endpoints.
+
+## Kubernetes Ingress or Route
+
+Use a normal TLS-terminating Ingress/Route:
+
+1. Create or reference a certificate Secret for the public host.
+2. Route HTTPS traffic to Service `hive`, port `dashboard`/3002.
+3. Preserve WebSocket/SSE behavior with HTTP/1.1 upgrades and long read timeouts.
+4. Include `/gh-setup` on the same host if using GitHub App Setup URL callbacks.
+
+For cert-manager, annotate the Ingress with your cluster issuer and put the desired host in `spec.tls[].hosts`. On OKE or any other Kubernetes distribution, Hive has no special cert-manager integration; use the platform's normal ingress controller/certificate flow.
+
+OpenShift Routes may use edge or re-encrypt termination. Edge termination is enough for the stock manifests because the backend Service is HTTP. Use re-encrypt only if you add a sidecar/proxy that serves HTTPS to the Service.
+
+## External reverse proxy
+
+A Caddy/nginx/HAProxy/load-balancer deployment should terminate HTTPS and forward to Hive over HTTP:
+
+- Docker Compose: proxy to the published gateway on `http://127.0.0.1:3001`.
+- Kubernetes: proxy to the Ingress/Route or Service as appropriate.
+- Pass `Upgrade`/`Connection` headers for `/terminal` and contributor WebSockets.
+- Use long read/send timeouts for `/api/events` and terminal sessions.
+
+## Certificate handling
+
+Hive does not read a dashboard TLS certificate/key from config. Certificate renewal, key rotation, HSTS, and public CA/private CA policy belong to the terminating proxy or ingress controller.
+
+Do not confuse dashboard TLS certificates with GitHub App private keys. The GitHub App key is configured with `github.key_file` (for example `/secrets/gh-app-key.pem`) and is used only to mint GitHub installation tokens.
+
+## Framing and HTTPS origins
+
+`dashboard.snapshot_frame_ancestors` controls which HTTPS origins may embed the read-only `/snapshot` page. It is not a TLS setting. Keep it empty unless you intentionally allow embedding; when set, use exact origins such as `https://status.example.com`.

--- a/v2/docs/token-tracking.md
+++ b/v2/docs/token-tracking.md
@@ -1,0 +1,37 @@
+# Token collection and usage tracking
+
+Hive tracks token usage for local budgeting, dashboard cost estimates, and hub-level fleet rollups. The implementation lives in `pkg/tokens`, `pkg/dashboard/cost.go`, and `pkg/hub/usage.go`.
+
+## Collection sources
+
+The collector starts from `data.metrics_dir` and rescans every 30 seconds. It merges:
+
+- Hive JSONL session files in `data.metrics_dir` (`*.jsonl`) using the flat `SessionEntry` schema.
+- Claude Code session JSONL under `data.claude_sessions_dir` when configured. It reads assistant `message.usage` blocks from recent files (30-day mtime window).
+- Copilot CLI `events.jsonl` under `data.copilot_sessions_dir` when configured. It reads `session.shutdown.modelMetrics` and avoids double-counting sessions already captured live by the proxy.
+- Inference usage files written by `InferenceSink` as `inference-<agent>.jsonl` under `data.metrics_dir` for `vllm`, `llm-d`, `litellm`, and live Copilot proxy usage.
+
+A flat session entry can include `role`, `agent`, `model`, `input_tokens`, `output_tokens`, `cache_read`, and `cache_creation`. When `agent` is absent, Hive infers the agent from session path or configured detection keywords.
+
+## Stored summary
+
+The collector keeps the latest aggregate in memory and writes `/data/token-summary.json` by default. The summary includes:
+
+- total input/output/cache-read/cache-create tokens,
+- per-agent and per-model totals,
+- detailed per-agent/per-model token buckets,
+- session count and recent session metadata.
+
+`data.metrics_dir` is therefore both an input directory for Hive/inference JSONL and the durable location for per-agent inference usage files.
+
+## Dashboard and API
+
+- `/api/status` includes token/cost fields used by the dashboard.
+- `/api/cost` returns estimated cost from token counts × the static price table plus native spend for gateways that report it (OpenRouter `/key`, LiteLLM `/key/info`). Estimated rows are labelled `estimated` or `unpriced`; native gateway rows are labelled `native`.
+- Cost estimates are not invoices. Subscription plans, self-hosted inference, negotiated rates, and provider billing semantics can differ from list prices.
+
+## Hub rollups
+
+Each spoke heartbeat sends one scalar `tokens_24h` value. Despite the historical name, current code sends the cumulative total from the spoke's token summary. The hub stores it as `totalTokens24h`, samples a 7-day fleet history every 15 minutes, and serves `/api/saas/usage` with rollups by org/repo, owner, and cluster plus zero-consumption hives.
+
+The hub cannot compute dollars or per-model/per-agent attribution because the heartbeat does not include model or agent token splits. Use the individual spoke's `/api/cost` for those details.


### PR DESCRIPTION
## Summary
- add v2 network/port and TLS termination operator guides
- document log scrubbing/redaction guarantees and token/cost usage tracking
- document audit log storage/API and add /api/audit to the OpenAPI reference

Fixes #3119
Fixes #3118
Fixes #3117
Fixes #3116
Fixes #3104

## Validation
- python3 -m json.tool dashboard/openapi.json
- docs sanity script for new pages