### PR TITLE
📖 docs: v2 feature operator guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,19 @@ The Go version is declared in [`v2/go.mod`](v2/go.mod). Install that version or 
 - Do not commit secrets, generated credentials, or local runtime state.
 - For documentation changes, verify every command, path, and branch name you mention.
 
+
+## Optional git hooks
+
+The repository includes `githooks/post-checkout`. Install it only if you want the local checkout guard:
+
+```bash
+git config core.hooksPath githooks
+```
+
+The hook runs after branch checkouts in the primary worktree. It prevents that worktree from staying on a branch other than `main` by printing guidance and checking `main` back out. It is intended for long-running dashboard checkouts where feature work should happen in separate `git worktree add ...` directories. It does not run for file checkouts. Because `core.hooksPath` can apply beyond the primary checkout, install it only in the checkout you want protected; if it fires somewhere else, remove or override that hooksPath setting there.
+
+If the hook is not installed, normal Git behavior applies. If it blocks a checkout unexpectedly, use a separate worktree from an unprotected checkout or remove the hooksPath setting for repositories where the guard is not desired.
+
 ## DCO sign-off
 
 Every commit must include a Developer Certificate of Origin sign-off. Use:

--- a/v2/README.md
+++ b/v2/README.md
@@ -268,6 +268,8 @@ Configure via the dashboard or the `/api/nous/*` endpoints. See `hive.yaml.examp
 - [Config layering](docs/config-layering.md) — ConfigMap vs PVC overlay precedence.
 - [Network requirements](docs/network-requirements.md) and [TLS setup](docs/tls-setup.md) — firewall, port, and HTTPS guidance.
 - [Token tracking](docs/token-tracking.md) and [security notes](docs/security.md) — cost/usage rollups and log redaction.
+- [GitHub App setup](docs/github-app-setup.md) — production App auth and `/gh-setup`.
+- [Knowledge curator](docs/knowledge-curator.md) — automatic fact extraction and promotion settings.
 - [Trajectory review](docs/trajectory-review.md) — trajectory safety lane.
 - [Credly badges](docs/credly-badges.md) — planned badge integration placeholder.
 
@@ -301,7 +303,9 @@ github:
 For GitHub App setup, configure the app's **Setup URL** to
 `https://<hive-host>/gh-setup` and enable **Redirect on update**. After an
 operator installs the app from the dashboard banner, GitHub redirects back and
-the hive verifies and saves the installation ID automatically.
+the hive verifies and saves the installation ID automatically. See
+[GitHub App setup](docs/github-app-setup.md) for permissions, key handling, and
+the callback flow.
 
 ## Deployment Examples
 

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -26,7 +26,9 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 
 ## Configuration and agents
 
-- [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, and ACMM packs.
+- [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
+- [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
+- [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.
 - [Podman rootless CI](podman-rootless-ci.md) — rootless Podman contract for `contribute-hive`.

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -138,10 +138,29 @@ Rounding out the schema — fields you will rarely touch:
 |---|---|---|
 | `id` | Stable identifier | agent name |
 | `acmm_levels` | ACMM levels this agent participates in | all |
-| `caveman_mode` | Prompt-compression experiment: `lite`, `full`, `ultra`, `wenyan` | off |
+| `caveman_mode` | Prompt-compression experiment: `lite`, `full`, `ultra`, `wenyan`; see below | off |
 | `metrics_collector` | Named metrics source for the stats panel | none |
 | `stats_display` | Custom sidebar metrics (key, label, source, field, style) | none |
 | `hidden` (packs only) | Keep a pack agent out of the default roster view | false |
+
+## Caveman prompt compression
+
+`caveman_mode` installs the upstream `JuliusBrussee/caveman` skill/proxy for supported backends before an agent starts. It is optional and experimental; leave it empty for maximum output fidelity.
+
+| Mode | Dashboard description | When to use |
+| --- | --- | --- |
+| `lite` | Removes filler while preserving normal language. | Lowest-risk token reduction for routine agents. |
+| `full` | Converts output toward terse "caveman-speak". | Default example mode when cost matters and operators accept rougher prose. |
+| `ultra` | Telegraphic compression. | High-volume lanes where compact summaries are more important than nuance. |
+| `wenyan` | Classical Chinese-style compression. | Specialized/experimental mode; use only when readers and downstream tools can tolerate it. |
+
+Implementation notes from v2 HEAD:
+
+- Config validation accepts only `lite`, `full`, `ultra`, `wenyan`, or empty.
+- `claude`, `copilot`, and `gemini` are auto-wired before first message.
+- `goose`, `codex`, and `aider` get the skill installed and then receive `/caveman <mode>` after the CLI reaches an input prompt.
+- Unsupported backends log that caveman is not supported and continue without compression.
+- The UI describes the feature as roughly 65% output reduction, but exact savings vary by prompt, backend, and task.
 
 ## Methods: subscription CLIs vs self-hosted inference
 

--- a/v2/docs/github-app-setup.md
+++ b/v2/docs/github-app-setup.md
@@ -1,0 +1,71 @@
+# GitHub App setup
+
+Hive can authenticate with either a personal access token or a GitHub App. Use a GitHub App for production hives because installation tokens are scoped to selected repositories and can author PRs as the app bot when `github.app_authored_prs` is enabled.
+
+## Create the app
+
+In GitHub, open **Settings → Developer settings → GitHub Apps → New GitHub App** (or the equivalent organization settings page).
+
+Recommended values:
+
+- **GitHub App name**: any unique operator-owned name.
+- **Homepage URL**: your project or Hive dashboard URL.
+- **Setup URL**: `https://<hive-host>/gh-setup`.
+- **Redirect on update**: enabled.
+- **Webhook**: inactive unless you separately configure webhook channels; the dashboard setup flow does not require webhooks.
+- **Device Flow**: enabled, so dashboard login can use the app's client ID.
+- **Visibility**: private for an organization-specific app; public only if you intentionally operate one app for many unrelated owners.
+
+Repository permissions used by the dashboard setup UI are:
+
+| Permission | Level | Why |
+| --- | --- | --- |
+| Metadata | Read-only | Required by GitHub. |
+| Contents | Read/write | Clone, branch, and push agent changes. |
+| Issues | Read/write | Enumerate, comment on, create, and close issues. |
+| Pull requests | Read/write | Create, update, approve/merge, and inspect PRs. |
+| Checks | Read-only | Monitor CI status. |
+| Actions | Read-only | Inspect workflow runs. |
+
+Organization permission:
+
+| Permission | Level | Why |
+| --- | --- | --- |
+| Members | Read-only | Identify contributors and owners where configured. |
+
+## Install and configure Hive
+
+1. After creating the app, note the **App ID**, **Client ID**, and app slug from the app page/URL.
+2. Generate a private key and mount it into the hive, for example `./secrets/gh-app-key.pem` on the host mounted as `/secrets/gh-app-key.pem`.
+3. Install the app on the organization/repositories Hive manages.
+4. Configure Hive:
+
+```yaml
+github:
+  app_id: <app-id>
+  installation_id: <installation-id>  # optional when /gh-setup can complete it
+  app_slug: <app-slug>
+  key_file: /secrets/gh-app-key.pem
+  oauth_client_id: <client-id>
+```
+
+For GitHub Enterprise, also set `api_url`/`base_url` or the supported `forge` value so install URLs and API calls target the same host.
+
+## `/gh-setup` flow
+
+When the app's Setup URL points at `https://<hive-host>/gh-setup`, GitHub redirects back with `setup_action` and, for install/update, `installation_id`.
+
+Hive accepts `setup_action=install` and `setup_action=update`, verifies that:
+
+- a real `github.app_id` is configured,
+- a private key file is resolvable,
+- the installation ID can mint/verify a GitHub App installation, and
+- the installation account matches the configured project org.
+
+If verification succeeds, Hive persists `github.installation_id`, reinitializes the GitHub client, and redirects the browser to `/?ghSetup=ok`. `setup_action=request` records a pending approval redirect but does not configure an installation.
+
+The setup endpoint is intentionally public because GitHub opens it in a browser that may not have a Hive session. The query string is not trusted; verification is done with the app key and GitHub API.
+
+## Rotation and recovery
+
+To rotate a private key, generate a new key in GitHub, mount it at the configured `key_file`, restart Hive, then delete the old key in GitHub after the new one is confirmed working. If an installation was replaced, use `/gh-setup` again or update `github.installation_id` and restart/reload the hive.

--- a/v2/docs/knowledge-curator.md
+++ b/v2/docs/knowledge-curator.md
@@ -1,0 +1,41 @@
+# Knowledge curator configuration
+
+The knowledge curator extracts candidate facts from merged PR activity and can prepare high-confidence facts for promotion between llm-wiki layers. The live code is in `pkg/knowledge/curator.go` and `pkg/knowledge/promote.go`.
+
+Enable the knowledge system before tuning the curator:
+
+```yaml
+knowledge:
+  enabled: true
+  engine: llm-wiki
+  curator:
+    schedule: daily
+    extract_from:
+      - pr_comments
+      - review_comments
+    auto_promote_threshold: 0.9
+```
+
+## Fields
+
+| Field | Current behavior in v2 HEAD |
+| --- | --- |
+| `schedule` | Defaults to `daily` when knowledge is enabled. The config field is stored for the scheduled curator flow described in the design docs; v2 HEAD does not enforce a parser here, so use simple operator conventions such as `daily` until your deployment wires a scheduler. |
+| `extract_from` | Sources the curator should inspect. Implemented sources are `pr_comments` and `review_comments`. `ci_failures` appears in the example config/design but is not currently extracted by `Curator.extractFromPR`. |
+| `auto_promote_threshold` | Defaults to `0.9` when knowledge is enabled. `Promoter.AutoPromoteCandidates` selects facts whose llm-wiki page has `status == "verified"` and `confidence >= threshold`. |
+
+## Extraction behavior
+
+`RunExtraction(ctx, since)` lists up to 50 recently updated closed PRs per configured repo, keeps merged PRs newer than `since`, and examines configured comment sources. Comments shorter than 20 characters are ignored.
+
+The classifier is heuristic. It emits candidates for comments containing signals such as:
+
+- `always`, `never`, `must`, `do not` → gotchas,
+- `regression`, `broke`, `reverted` → regressions,
+- `pattern`, `convention`, `prefer`, `best practice` → patterns,
+- `test`, `coverage`, `mock`, `fixture`, `assert` → test scaffolding,
+- `decided`, `agreed`, `going forward`, `from now on` → decisions.
+
+Extracted facts are sent to the wiki `/api/ingest` endpoint. Promotion only flows upward (for example project → org), preserving provenance in the promoted fact.
+
+See [Knowledge system design](design/knowledge-system.md) for architecture context; this page documents the implemented operator-facing knobs.


### PR DESCRIPTION
## Summary
- add a GitHub App creation and /gh-setup installation guide
- document knowledge curator extraction/promotion settings and implemented sources
- expand caveman_mode guidance and document the optional post-checkout hook

Fixes #3100
Fixes #3101
Fixes #3099
Fixes #2993

## Validation
- feature docs sanity script
- code-review agent pass after updating githook wording