### PR TITLE
📖 docs: backend guide gaps

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,29 @@
+# Root dashboard directory
+
+This directory is a **legacy/static dashboard support area**, not the primary v2 dashboard server.
+
+The live v2 dashboard is implemented in Go under `v2/pkg/dashboard/`, with the current frontend embedded from `v2/pkg/dashboard/static/index.html` and served through the Node auth/rewrite proxy in `v2/proxy/`. The v2 image still copies this root `dashboard/` directory to `/opt/hive/dashboard/` because the v2 dashboard API calls `build-snapshot.mjs` from there when it builds read-only `/snapshot` pages, and the publish scripts use the same builder for kubestellar.io live snapshots.
+
+## What is here
+
+- `build-snapshot.mjs` — supported v2 snapshot builder. It reads the live v2 dashboard HTML, fetches dashboard API data, and writes a self-contained static snapshot.
+- `publish-snapshot-v2.sh` — publishes per-instance v2 static snapshots and API docs into the `kubestellar/docs` site.
+- `publish-snapshot.sh` — older single-instance snapshot publisher retained for the original `/live/hive` path.
+- `openapi.json` — static OpenAPI snapshot used as a fallback when live `/api/openapi.json` is unavailable during snapshot publishing.
+- `server.js` and `index.html` — legacy Node dashboard assets from the pre-v2 dashboard path. They are useful historical/reference material, but v2 production does not start `dashboard/server.js`.
+- `agent-activity.py`, `agent-metrics.sh`, `agent-summaries.sh`, `api-collector.sh`, `token-collector.sh`, `health-check.sh` — operational/metrics helper scripts from the legacy dashboard stack.
+- `ubersicht/` — macOS Übersicht widget assets.
+- `test/` — Node tests for contributor/dashboard behavior that still lives with the legacy Node package.
+
+## Running tests
+
+```bash
+cd dashboard
+npm test
+```
+
+The package only declares the Node test script; it is separate from the v2 Go test suite under `v2/`.
+
+## Editing guidance
+
+For live v2 dashboard features, edit `v2/pkg/dashboard/`, `v2/pkg/dashboard/static/index.html`, or `v2/proxy/`. Edit this directory when changing snapshot generation/publishing, the fallback OpenAPI bundle, or legacy helper scripts.

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -15,15 +15,36 @@ Hive validates backend names in `v2/pkg/config` and launches CLIs in `v2/pkg/age
 | `codex` | accepted by config; contributor scripts launch `codex` | Install `@openai/codex` and provide `OPENAI_API_KEY`. Contributor mode sets a per-agent `CODEX_HOME`. | v2 HEAD server-side `backendBinary` does not map `codex`, so use it in contributor mode unless the manager mapping has been updated. |
 | `aider` | accepted by config; contributor scripts launch `aider` | Install Aider and configure its provider/API key normally. | v2 HEAD server-side `backendBinary` does not map `aider`, so use it in contributor mode unless the manager mapping has been updated. |
 
+## IBM Bob headless setup
+
+`backend: bob` launches IBM bobshell (`bob`), the IBM watsonx Code Assistant CLI. In a Hive pod or contributor container it must use API-key auth: the default IBMid/W3ID browser SSO flow opens a browser and waits on a localhost callback, which a headless pod cannot satisfy, then times out after about three minutes. Hive checks for a key before launch and parks the agent with an actionable error instead of burning that timeout.
+
+Configure the key in one of these ways:
+
+```yaml
+governor:
+  bob:
+    api_key_env: HIVE_BOB_API_KEY       # hive-side env var name
+    api_key_file: /secrets/bob_api_key  # mounted Secret path
+```
+
+Defaults are already wired: Hive consults `/secrets/bob_api_key`, then `/data/secrets/bob_api_key` (where the dashboard's Governor → Bob tab stores a key), then the `HIVE_BOB_API_KEY` environment variable. Use the dashboard tab when you do not have cluster Secret access; it writes the key to the PVC-backed `/data/secrets/bob_api_key` and relaunches parked bob agents. The value is injected into bob as `BOBSHELL_API_KEY`, and Hive launches bob with the hidden-but-supported `--auth-method api-key` flag plus full approval/trust flags for unattended operation. Store only the location in YAML, never the key value.
+
+Contributor relay containers use the same bobshell package, but contributor-mode scripts expect `BOBSHELL_API_KEY` in the container environment when `AGENT_BACKEND=bob`.
+
+The dashboard **Test key** probe intentionally sends `User-Agent: bobshell`. IBM's edge has been observed to block generic Go/curl user agents with an HTML 403 before the request reaches bob auth, while the bobshell UA returns the real backend verdict. If you reproduce a key test manually, use that UA or treat a generic-UA 403 as an inconclusive edge block, not proof that the key is invalid.
+
 ## Contributor relay image
 
-`v2/Dockerfile.contributor` builds the ClankeR image used by `just contribute-hive`. It installs Claude Code, Copilot, Codex, Bob, Goose, Pi, `gh`, Go, tmux, and the relay scripts. `v2/compose-contributor.yaml` runs that image with your local Hive config and selected backend:
+`v2/Dockerfile.contributor` builds the ClankeR image used by `just contribute-hive`. It installs Claude Code, Copilot, Codex, Bob, Goose, Pi, `gh`, Go, tmux, and the relay scripts. `v2/compose-contributor.yaml` runs that image with your local Hive config and selected backend. It mounts `${HOME}/.config/hive`, `${HOME}/.claude`, and `${HOME}/.config/claude-code` read-only, then reads the registered `HIVE_HUB` and `HIVE_REGISTRATION_TOKEN` from `${HOME}/.config/hive/contributor.env` inside the container.
 
 ```bash
 AGENT_BACKEND=claude just contribute-hive
 AGENT_BACKEND=goose GOOSE_PROVIDER=anthropic GOOSE_MODEL=claude-sonnet-4-6 just contribute-hive
 AGENT_BACKEND=litellm HIVE_LITELLM_ENDPOINT=https://litellm.example.com just contribute-hive
 ```
+
+`AGENT_BACKEND` selects the CLI, `AGENT_MODEL` optionally pins the model, and `CONTRIBUTOR_MODE` defaults to `interactive` (tmux with a TTY). `CONTRIBUTOR_MODE=headless` is reserved for one-shot/no-TTY task delivery.
 
 `just contribute-check <backend>` runs a read-only preflight before registration. It checks that the chosen CLI exists and that obvious auth prerequisites are present.
 

--- a/docs/inference-backends.md
+++ b/docs/inference-backends.md
@@ -1,6 +1,6 @@
 # Inference backends
 
-Hive can route agents through OpenAI-compatible model gateways instead of a subscription CLI model. The supported gateway backend IDs in v2 HEAD are `vllm`, `llm-d`, `litellm`, and `watsonx`; this guide focuses on `vllm`, `llm-d`, and `litellm`.
+Hive can route agents through OpenAI-compatible model gateways instead of a subscription CLI model. The supported gateway backend IDs in v2 HEAD are `vllm`, `llm-d`, `litellm`, `watsonx`, and named Model Gateways such as `openrouter`.
 
 ## How routing works
 
@@ -8,7 +8,7 @@ The agent still launches Claude Code in bare mode. Hive writes Claude settings t
 
 ## Configure a gateway
 
-Use the dashboard's **Governor Config → Model Gateways** UI, or YAML. A gateway needs a name, kind, endpoint, optional key reference, and optional default model. Agents can then set `backend:` to either the built-in kind (`vllm`, `llm-d`, `litellm`) or to a configured gateway name.
+Use the dashboard's **Governor Config → Model Gateways** UI, or YAML. A gateway needs a name, kind, endpoint, optional key reference, and optional default model. Agents can then set `backend:` to either the built-in kind (`vllm`, `llm-d`, `litellm`, `watsonx`) or to a configured gateway name such as `openrouter`.
 
 LiteLLM also has a dedicated config block:
 
@@ -32,6 +32,46 @@ Endpoint environment overrides used by v2 include:
 - `HIVE_LITELLM_MODELS` as a comma-separated fallback model list when discovery fails
 
 Never put the key value itself in YAML.
+
+
+## OpenRouter scan-to-fund gateway
+
+OpenRouter is both a Model Gateway kind (`kind: openrouter`) and a guided funding flow. It routes through OpenRouter's OpenAI-compatible API at `https://openrouter.ai/api/v1`, so agents use it like any other gateway after a key is stored.
+
+### Operator setup with Model Gateways
+
+1. Open **Governor Config → Model Gateways**.
+2. Add a gateway named `openrouter` with kind `openrouter`. The UI preset fills the endpoint as `https://openrouter.ai/api/v1`.
+3. Store the key as a secret value in the UI, or point `api_key_env` / `api_key_file` at a key that already exists. Hive stores only the file path or env-var name in `hive.yaml`.
+4. Pick a `default_model` from discovery or enter an OpenRouter model id manually. The curated fallback default is `deepseek/deepseek-chat`.
+5. Assign an agent with `backend: openrouter` (the gateway name) and either leave `model:` empty to use the default or set an explicit OpenRouter model id.
+
+Equivalent YAML looks like:
+
+```yaml
+governor:
+  gateways:
+    - name: openrouter
+      kind: openrouter
+      endpoint: https://openrouter.ai/api/v1
+      api_key_file: /data/secrets/gateway_openrouter_api_key
+      default_model: deepseek/deepseek-chat
+
+agents:
+  guide:
+    backend: openrouter
+    model: deepseek/deepseek-chat
+```
+
+### Scan-to-fund flow
+
+The dashboard can start an OpenRouter OAuth PKCE flow from the OpenRouter funding card. A sponsor picks a default model, scans the QR code or opens the returned `openrouter.ai/auth` link, authorizes on OpenRouter, and returns to `/openrouter/callback`. Hive exchanges the code for a user-controlled OpenRouter API key and upserts the `openrouter` gateway.
+
+For a spoke dashboard, the key is written to the per-gateway secret-file store on that hive's PVC and `hive.yaml` records only `api_key_file`. For a hub-funded hive, the hub queues a pending gateway named `openrouter` and delivers it over the existing TLS heartbeat response; heartbeat-only/firewalled spokes therefore receive funding without the hub POSTing into the cluster. The spoke confirms arrival by reporting configured gateway names, after which the hub stops offering the pending secret. The hub does not persist or display the key.
+
+### Credit display and quotas
+
+A spoke with an OpenRouter key proxies OpenRouter's `/api/v1/key` credit endpoint and displays limit, usage, and remaining credit without returning the key. The hub can only show whether a funded gateway is still pending delivery; after delivery, credit is read from the spoke because the hub no longer has the key.
 
 ## Model discovery
 

--- a/v2/deploy/README.md
+++ b/v2/deploy/README.md
@@ -1,0 +1,24 @@
+# v2 deployment scripts
+
+This directory contains Kubernetes/LXC manifests plus runtime helper scripts used by the Hive container. The dashboard terminal pane uses two small helpers that are easy to miss:
+
+## Dashboard TTY helpers
+
+### `ttyd-tmux.sh`
+
+`ttyd` serves the browser terminal websocket, but agent tmux sessions may be owned by per-agent UIDs. Because tmux only lets the socket owner attach, `ttyd-tmux.sh <session>` finds the matching `/tmp/tmux-*/<session>` socket, derives its numeric UID/GID, and uses `su-exec` to attach as that owner. It temporarily disables tmux mouse mode while attached and restores it on exit.
+
+Use it indirectly through the dashboard terminal link. If a terminal pane says no tmux socket was found, check that the agent session name exists and that the socket is present under `/tmp/tmux-*` in the container.
+
+### `hive-panes.sh`
+
+`hive-panes [lines]` prints the last N raw-output lines from every other agent's pluk JSONL log in `/var/run/pluk/logs`. It skips the caller named by `HIVE_PROXY_AGENT`, strips ANSI/control sequences, and never attaches to another tmux session. Agents can run it for read-only peer awareness when diagnosing fleet activity.
+
+## Other files
+
+- `entrypoint.sh` — container startup, config layering, proxy/agent setup, and long-lived process supervision.
+- `k8s/` — namespace, deployment, service, PVC, Secret, ConfigMap, and route/RBAC manifests.
+- `inference/` — sample in-cluster OpenAI-compatible inference deployment and RBAC.
+- `docker-compose.architect.yaml`, `hive-quickstart.yaml`, `hive-level*.yaml`, `architect-only.yaml`, `hive.yaml` — example deployment/configuration manifests.
+- `blue-green-deploy.sh`, `bootstrap-lxc.sh`, `create-lxc.sh` — operational scripts for non-Kubernetes deployments.
+- `test_*.sh` — shell tests for entrypoint/runtime deployment behavior.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -17,6 +17,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [Dashboard API reference](api-reference.md) — pragmatic route index for dashboard and hub endpoints.
 - [ioscan status](ioscan.md) — v2 status of the untrusted-input scanner/canary feature.
+- [Deployment scripts](../deploy/README.md) — inventory of v2 deployment helpers, including dashboard TTY panes and `hive-panes`.
 
 ## Contributors and access
 

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -77,7 +77,7 @@ agents:
 ```yaml
     backend: copilot             # the method: claude | copilot | goose | codex | pi |
                                  #   bob | aider, or an inference backend:
-                                 #   vllm | llm-d | litellm
+                                 #   vllm | llm-d | litellm | watsonx | named gateway
     model: claude-sonnet-4-6     # model id for that method
     cli_pinned: true             # pin the CLI so nothing auto-switches it
     launch_cmd: "/usr/bin/copilot --allow-all --model claude-sonnet-4-6"
@@ -156,6 +156,7 @@ Rounding out the schema — fields you will rarely touch:
 | `vllm` | inference | endpoint + optional key — no login | **live** — `/v1/models` |
 | `llm-d` | inference | endpoint + optional key — no login | **live** — `/v1/models` |
 | `litellm` | inference | endpoint + API key — no login | **live** — `/v1/models`, entitlement-filtered per key |
+| `openrouter` (gateway name) | inference | Model Gateway key or scan-to-fund flow — no CLI login | **live** — OpenRouter `/v1/models`, plus curated fallback |
 
 Two rules of thumb:
 
@@ -163,6 +164,8 @@ Two rules of thumb:
 - **Inference methods are endpoints.** You configure a base URL and a key *reference* (env var name or key-file path — the value goes in `/data/secrets/`, never in YAML). Agents on `vllm`/`llm-d`/`litellm` launch the Claude CLI routed through hive's inference translator, so there is no separate login.
 
 Kubernetes manifests for deploying inference backends (vllm Deployment, EPP RBAC, kustomization) are in [`deploy/inference/`](../deploy/inference/).
+
+Agents can inspect peer panes with `hive-panes [lines]` when the deployment includes `v2/deploy/hive-panes.sh`. It reads pluk JSONL logs from `/var/run/pluk/logs`, skips the calling agent named by `HIVE_PROXY_AGENT`, strips terminal escapes, and prints the last N raw-output lines for every other agent. Use it for situational awareness; it is read-only and does not attach to another agent's tmux session.
 
 Every discovery probe is best-effort: a failed or absent probe falls back to a current static list, so a model dropdown is never empty. Fallback entries are marked "unverified" in the UI.
 

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -342,6 +342,8 @@ flowchart LR
   trajectory-drift pauses, and other governor events.
 - Log output is wrapped by `pkg/logscrub`, which redacts recognized GitHub token and JWT-like strings from messages and string attributes. See [Security notes](security.md) for guarantees and limits.
 - Network exposure and TLS termination are documented in [Network and port requirements](network-requirements.md) and [TLS setup](tls-setup.md).
+- `/terminal` is served by `ttyd`, which invokes `deploy/ttyd-tmux.sh` to attach to the selected `hive-<agent>` tmux session as the socket-owning UID. This is required when agents run under per-agent users and tmux rejects attaches from the proxy user.
+- `deploy/hive-panes.sh` backs a read-only peer-observation workflow: it reads pluk JSONL logs from `/var/run/pluk/logs`, skips the calling agent, strips terminal escapes, and prints recent output without opening another agent's tmux socket.
 
 ---
 

--- a/v2/docs/contributor-relay.md
+++ b/v2/docs/contributor-relay.md
@@ -14,6 +14,34 @@ just contribute-hive
 
 `compose-contributor.yaml`, `Dockerfile.contributor`, and the `just contribute-hive` recipe are the reference container path. Native mode is available through `just contribute-hive <backend> local` when a container runtime is not desired.
 
+## Docker Compose workflow
+
+The containerized path is `v2/compose-contributor.yaml` plus `v2/Dockerfile.contributor`; the `just contribute-hive` recipe wraps it. From the repository root you can also run Compose directly after `just contribute-setup` has written `${HOME}/.config/hive/contributor.env`:
+
+```bash
+export AGENT_BACKEND=claude
+docker compose -f v2/compose-contributor.yaml up --build
+```
+
+The compose file mounts local contributor state read-only into the container:
+
+- `${HOME}/.config/hive` for Hive registration/config.
+- `${HOME}/.claude` and `${HOME}/.config/claude-code` for Claude-family CLI auth.
+
+Important environment variables:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `HIVE_HUB` | value from `contributor.env`, else public hub default | WebSocket hub(s) to subscribe to. Use comma-separated URLs for multi-hub mode. Direct Compose reads the registered value from the mounted config file. |
+| `HIVE_REGISTRATION_TOKEN` | value from `contributor.env` | Registration token(s), positional with `HIVE_HUB` when multiple hubs are listed. Required; run `just contribute-setup` / `just contribute-register` first. |
+| `AGENT_BACKEND` | `claude` | CLI/backend to run (`claude`, `copilot`, `goose`, `bob`, `codex`, `litellm`, etc., depending on image support and credentials). |
+| `AGENT_MODEL` | unset | Optional model override passed to the contributor agent. |
+| `CONTRIBUTOR_MODE` | `interactive` | `interactive` keeps a tmux/TTY session. `headless` is for one-shot/no-TTY task delivery. |
+
+To change hubs for direct Compose, re-run the registration/setup flow for the target hub or edit `${HOME}/.config/hive/contributor.env` so `HIVE_HUB` and `HIVE_REGISTRATION_TOKEN` stay matched.
+
+Backend credentials stay local to the contributor container. For example, `AGENT_BACKEND=bob` needs `BOBSHELL_API_KEY` in the container environment, while LiteLLM-style backends need their endpoint/key variables. Use `just contribute-check <backend>` before registering to catch missing CLIs or obvious auth gaps.
+
 ## Multi-hub subscription
 
 A single relay can subscribe to multiple hives. Register with each hive first, then provide matching comma-separated lists:


### PR DESCRIPTION
## Summary
- document OpenRouter Model Gateways setup, scan-to-fund delivery, and credit display
- document IBM Bob headless API-key setup, dashboard key storage, and bobshell User-Agent probe behavior
- add root dashboard and v2 deploy helper READMEs, plus ClankeR Compose relay workflow details

## Validation
- dashboard npm test
- markdown link check for changed docs
- root npm build/lint unavailable: no root package.json

Fixes #3115
Fixes #3004
Fixes #3097
Fixes #3084
Fixes #3003