### PR TITLE
🔒 Security audit 2026-08-07: N7 — real flag parsing in the gh wrapper merge gate

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -4,6 +4,17 @@ on:
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:
+  # Gate PRs, not just the cron. `go test ./pkg/...` runs nowhere else — v2-ci.yml
+  # builds and vets but never runs the unit tests — so before this, a Go
+  # regression test could only fail AFTER merge, as a cron-filed ci-failure
+  # issue. That is the wrong end of the loop for security regressions: the test
+  # proving a fix works has to be able to block the PR that breaks it again.
+  #
+  # create-issue-on-failure below stays gated on `github.event_name == 'schedule'`,
+  # so a red PR fails the check without also filing an issue.
+  pull_request:
+    branches: [v2, v4]
+    paths: ['v2/**', '.github/workflows/v2-tests.yml']
 
 permissions:
   contents: read

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -116,9 +116,58 @@ fi
 args=("$@")
 subcmd=""
 action=""
+
+# SECURITY (audit N7/H5, CWE-863): extracting the subcommand and action needs
+# REAL flag parsing, not "skip anything starting with -".
+#
+# The old loop skipped only tokens beginning with '-'. A SEPARATED flag VALUE
+# does not begin with '-', so it was consumed as a positional:
+#
+#   gh pr --repo owner/repo merge 123
+#          ^^^^^^ skipped   ^^^^^^^^^^ read as the action
+#
+# giving action="owner/repo" instead of "merge" — so EVERY gate keyed on
+# `action = "merge"` silently skipped: the ADVISORY / ISSUES_ONLY /
+# ISSUES_AND_PRS mode arms, the level-based fallback, AND the merge-eligibility
+# check. Any value-taking flag placed before the action worked: --repo, -R,
+# --title, --body, --label, --head, --base. The audit reproduced this against
+# real gh v2.47.0: an agent at ISSUES_PRS_MERGE (or below) could merge unvetted
+# code by reordering two flags.
+#
+# gh_flag_takes_value: does this flag consume the NEXT argv element?
+# `--flag=value` is self-contained and never does. Long forms are matched by
+# name; short forms are enumerated because gh's short flags are not uniform.
+gh_flag_takes_value() {
+  case "$1" in
+    *=*) return 1 ;;  # --flag=value carries its own value
+    # Long flags that take a value. Listed explicitly: a value-taking flag we
+    # fail to list would let its value be misread as the action again, so new
+    # flags must be added here rather than inferred.
+    --repo|--title|--body|--body-file|--label|--head|--base|--assignee|--reviewer| \
+    --milestone|--project|--template|--field|--raw-field|--method|--header| \
+    --hostname|--jq|--template-file|--search|--state|--author|--mention|--app| \
+    --branch|--subject|--match-body|--match-comments|--limit|--sort|--direction| \
+    --add-label|--remove-label|--add-assignee|--remove-assignee|--add-reviewer| \
+    --remove-reviewer|--add-project|--remove-project|--input|--cache|--comment| \
+    --file|--key|--value|--env|--org|--user|--owner|--commit-title|--commit-body| \
+    --match|--paginate-limit)
+      return 0 ;;
+    # Short flags that take a value.
+    -R|-t|-b|-B|-F|-f|-H|-l|-a|-A|-m|-p|-q|-c|-s|-L|-e|-d|-i|-k|-o|-u|-w|-x)
+      return 0 ;;
+    -*) return 1 ;;   # any other flag is boolean
+    *)  return 1 ;;
+  esac
+}
+
+_skip_next_gw=false
 for arg in "${args[@]}"; do
+  if $_skip_next_gw; then _skip_next_gw=false; continue; fi
   case "$arg" in
-    -*) continue ;;
+    --) # everything after -- is positional-only; stop flag interpretation
+        continue ;;
+    -*) if gh_flag_takes_value "$arg"; then _skip_next_gw=true; fi
+        continue ;;
     *)
       if [ -z "$subcmd" ]; then
         subcmd="$arg"
@@ -329,32 +378,80 @@ fi
 # Enforce merge gate — only PRs in merge-eligible.json can be merged
 MERGE_ELIGIBLE_FILE="/var/run/hive-metrics/merge-eligible.json"
 if [ "$subcmd" = "pr" ] && [ "$action" = "merge" ]; then
+  # SECURITY (audit N7): parse the PR identifier with the SAME flag table the
+  # subcommand extractor uses, so a value can never be mistaken for the PR
+  # number (or vice versa). The previous loop special-cased only --repo, so
+  # `-R owner/repo` left "owner/repo" to be read as pr_num — which then failed
+  # the eligibility lookup and DENIED a legitimate merge (fail-closed, but a
+  # real availability bug), while other value-taking flags could feed it junk.
+  #
+  # gh accepts the PR as a number, a URL, or a branch name; all three are
+  # positionals after the `merge` action.
   pr_num=""
   pr_repo=""
   skip_next=false
-  past_merge=false
+  seen_pr=false
+  seen_merge=false
   for arg in "${args[@]}"; do
     if $skip_next; then skip_next=false; continue; fi
     case "$arg" in
-      pr|merge) past_merge=true; continue ;;
-      --repo) skip_next=true; continue ;;
-      --repo=*) pr_repo="${arg#--repo=}"; continue ;;
-      -*) continue ;;
+      --repo=*|-R=*) pr_repo="${arg#*=}"; continue ;;
+      --repo|-R)     skip_next=true; continue ;;
+      -*)
+        if gh_flag_takes_value "$arg"; then skip_next=true; fi
+        continue ;;
       *)
-        if $past_merge && [ -z "$pr_num" ]; then
-          pr_num="$arg"
-        fi
+        # Consume the subcommand and action positionals first, then take the
+        # next positional as the identifier.
+        if ! $seen_pr; then seen_pr=true; continue; fi
+        if ! $seen_merge; then seen_merge=true; continue; fi
+        [ -z "$pr_num" ] && pr_num="$arg"
         ;;
     esac
   done
 
+  # Recover a separated --repo/-R value (the loop above skips it by design).
   if [ -z "$pr_repo" ]; then
     for i in "${!args[@]}"; do
-      if [ "${args[$i]}" = "--repo" ] && [ -n "${args[$((i+1))]:-}" ]; then
-        pr_repo="${args[$((i+1))]}"
-        break
-      fi
+      case "${args[$i]}" in
+        --repo|-R)
+          if [ -n "${args[$((i+1))]:-}" ]; then pr_repo="${args[$((i+1))]}"; fi
+          break ;;
+      esac
     done
+  fi
+
+  # Normalize a PR URL to its number so the eligibility lookup can match it.
+  # `gh pr merge https://github.com/o/r/pull/123` is a legitimate form that the
+  # old parser passed through verbatim and therefore always denied.
+  case "$pr_num" in
+    http://*|https://*)
+      url_repo="$(printf '%s' "$pr_num" | sed -n 's#^https\{0,1\}://[^/]*/\([^/]*/[^/]*\)/pull/.*#\1#p')"
+      url_num="$(printf '%s' "$pr_num" | sed -n 's#.*/pull/\([0-9][0-9]*\).*#\1#p')"
+      if [ -n "$url_num" ]; then
+        pr_num="$url_num"
+        [ -z "$pr_repo" ] && pr_repo="$url_repo"
+      fi
+      ;;
+  esac
+
+  # SECURITY (audit N7): fail CLOSED when no PR identifier is present.
+  #
+  # `gh pr merge` (merge whatever PR belongs to the current branch) and
+  # `gh pr merge --repo owner/repo` carry no number, so pr_num stayed empty —
+  # and BOTH eligibility branches below were guarded on `[ -n "$pr_num" ]` with
+  # no else. Execution fell straight through to `exec "$REAL_GH"`, so the most
+  # permissive mode had no wall at all: an agent could merge the current
+  # branch's PR without it ever appearing in merge-eligible.json.
+  #
+  # The wrapper cannot resolve the current branch's PR without calling gh (which
+  # is the thing being gated), so the only safe answer is to require an explicit,
+  # checkable identifier.
+  if [ -z "$pr_num" ]; then
+    echo "⛔ BLOCKED: 'gh pr merge' needs an explicit PR number or URL." >&2
+    echo "The merge gate verifies the PR against ${MERGE_ELIGIBLE_FILE}, which it cannot do for an implicit current-branch merge." >&2
+    echo "Re-run as: gh pr merge <number> [--repo owner/repo]" >&2
+    exit 1
   fi
 
   if [ -n "$pr_num" ] && [ -f "$MERGE_ELIGIBLE_FILE" ]; then

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -80,6 +80,7 @@ run_wrapper() {
   local gate=other
   [[ "$out" == *"unrecognized agent mode"* ]] && gate=mode-default
   [[ "$out" == *"NOT in merge-eligible.json"* || "$out" == *"cannot verify merge eligibility"* ]] && gate=eligibility
+  [[ "$out" == *"needs an explicit PR number or URL"* ]] && gate=no-identifier
 
   echo "exit=${rc} stub=${reached} gate=${gate}"
   # Surface wrapper output only when debugging a failure.
@@ -154,24 +155,48 @@ assert_reached "NO_GITHUB allows a non-issue/pr subcommand (repo view)" \
 # VALUE as the action, so action != "merge" and every gate is skipped. The fix
 # is a real flag parser; until it lands these cases record the live bypass so
 # the harness fails loudly the moment behaviour changes in either direction.
-echo "-- N7 flag-reorder bypass (expected to FAIL until the parser is fixed) --"
-reorder="$(run_wrapper "ISSUES_AND_PRS" 5 -- pr --repo owner/repo merge 123)"
-if [[ "$reorder" == "exit=1 stub=no" ]]; then
-  echo "  PASS: flag-reorder merge is gated (N7 parser fix has landed)"
-  PASS=$((PASS + 1))
-else
-  echo "  KNOWN-GAP (N7): 'gh pr --repo owner/repo merge 123' bypassed the merge gate under ISSUES_AND_PRS"
-  echo "                  got '$reorder'; the flag value is parsed as the action. Fix: real flag parsing."
-fi
+# ── N7: the flag-reorder bypass ───────────────────────────────────────────────
+# `gh pr --repo o/r merge 123` used to make the subcmd/action extractor read
+# --repo's VALUE as the action, so action != "merge" and every gate was skipped.
+# Each of these must be gated for the SAME reason the un-reordered form is.
+echo "-- N7 flag-reorder must not skip the gates --"
+assert_blocked "reordered merge is gated under ISSUES_AND_PRS" \
+  "$(run_wrapper "ISSUES_AND_PRS" 5 -- pr --repo owner/repo merge 123)"
+assert_blocked "reordered merge is gated under ISSUES_ONLY" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- pr --repo owner/repo merge 123)"
+assert_blocked "reordered merge is gated under ADVISORY" \
+  "$(run_wrapper "ADVISORY" 5 -- pr --repo owner/repo merge 123)"
+assert_blocked "-R short form is gated too" \
+  "$(run_wrapper "ISSUES_AND_PRS" 5 -- pr -R owner/repo merge 123)"
+assert_blocked "a value-taking flag before the action does not hide it (--title)" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- pr --title 'merge me' merge 123)"
+# --flag=value is self-contained and must NOT consume the next token.
+assert_blocked "--repo=value form is gated" \
+  "$(run_wrapper "ISSUES_AND_PRS" 5 -- pr --repo=owner/repo merge 123)"
 
-bare="$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge)"
-if [[ "$bare" == "exit=1 stub=no" ]]; then
-  echo "  PASS: bare 'pr merge' is gated (eligibility fix has landed)"
-  PASS=$((PASS + 1))
-else
-  echo "  KNOWN-GAP (N7): bare 'gh pr merge' skipped the eligibility check (empty pr_num)"
-  echo "                  got '$bare'"
-fi
+# At the most permissive mode the merge-eligibility gate is the wall. A PR that
+# is not in merge-eligible.json must be refused however the args are arranged.
+echo "-- N7 eligibility gate applies to every merge form --"
+assert_blocked "reordered merge still hits eligibility at ISSUES_PRS_MERGE" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr --repo owner/repo merge 123)" eligibility
+assert_blocked "plain merge hits eligibility at ISSUES_PRS_MERGE" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123)" eligibility
+# No identifier => cannot be checked against merge-eligible.json => denied.
+# The wrapper cannot resolve the current branch's PR without calling gh, which
+# is the very thing under gate, so requiring an explicit number is the only
+# fail-closed answer.
+assert_blocked "bare 'pr merge' (current branch, no number) is not a free pass" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge)" no-identifier
+assert_blocked "'pr merge --repo o/r' with no number is not a free pass" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge --repo owner/repo)" no-identifier
+
+# Availability: forms that gh accepts must reach the eligibility check rather
+# than being wrongly denied. A PR URL previously landed in pr_num verbatim and
+# never matched a number, so a legitimate merge was refused.
+assert_blocked "PR URL is normalized and reaches the eligibility gate" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge https://github.com/owner/repo/pull/123)" eligibility
+assert_blocked "-R form reaches the eligibility gate (not a parse denial)" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123 -R owner/repo)" eligibility
 
 echo
 echo "=== $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
Follows #3140 (merged). Closes **N7/H5** — the audit's #1 mandatory self-hosted fix, and the one it singled out: *"the merge boundary's second wall is decorative against a prompt-injected agent that reorders two flags."*

*(Recreated from #3142, which GitHub auto-closed when its base branch was deleted on merge.)*

## Defect 1 — flag values were read as the action

The extractor skipped only tokens starting with `-`. A **separated flag value** does not:

```
gh pr --repo owner/repo merge 123
       ^^^^^^ skipped   ^^^^^^^^^^ read as the action
```

`action` became `owner/repo` instead of `merge`, so **every** gate keyed on `action = "merge"` silently skipped: the ADVISORY / ISSUES_ONLY / ISSUES_AND_PRS mode arms, the level-based fallback, **and** the merge-eligibility check. Any value-taking flag before the action worked — `--repo`, `-R`, `--title`, `--body`, `--label`, `--head`, `--base`.

Both parsers now share `gh_flag_takes_value()`, an **explicit** table. Explicit rather than inferred: a flag we fail to list lets its value be misread as the action again, so new flags must be added deliberately.

## Defect 2 — a missing PR number was a free pass

`gh pr merge` and `gh pr merge --repo o/r` carry no number. Both eligibility branches were guarded on `[ -n "$pr_num" ]` **with no `else`**, so execution fell straight through to `exec "$REAL_GH"`. At `ISSUES_PRS_MERGE` there was no wall at all — an agent could merge the current branch's PR without it ever appearing in `merge-eligible.json`.

The wrapper cannot resolve the current branch's PR without calling `gh` (the thing being gated), so a missing identifier now fails closed with an actionable message.

## Also fixed: two availability bugs

The audit flagged these as fail-closed quirks; both wrongly **denied** legitimate merges:
- A PR URL landed in `pr_num` verbatim and never matched a number → now normalized.
- `-R` was not recognized as taking a value, so `owner/repo` became `pr_num` → now recognized.

## Test matrix: 8 → 22 cases

Covers each mode, short and long flag forms, `--flag=value`, PR URLs, and both no-identifier forms. Assertions are pinned to *which* gate blocked, so a case cannot pass because an unrelated gate fired.

**Verified: 8 of the 22 fail against the previous parser.**

## CI change

`v2-tests.yml` now also runs on `pull_request`. `go test ./pkg/...` runs **nowhere else** — `v2-ci.yml` builds and vets but never runs the unit tests — so a Go regression test could previously only fail *after* merge, as a cron-filed `ci-failure` issue. A test that proves a security fix works has to be able to block the PR that breaks it again. The issue-filing job stays gated on `schedule`, so a red PR fails the check without also filing an issue.