### PR TITLE
fix(ci): don't cancel in-progress Docker builds on release branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,10 +12,15 @@ on:
       - '!copilot/**'
   workflow_dispatch:
 
-# Serialize Docker builds per branch so concurrent merges don't race.
+# Serialize Docker builds per branch so concurrent merges don't race. Do NOT
+# cancel in-progress builds: on a fast-merging release branch (v2 saw ~34 merges
+# in 2h), cancel-in-progress meant every build was killed by the next merge and
+# NONE ever completed, freezing <branch>-latest and blocking all deploys. With
+# cancel-in-progress:false the builds queue and each runs to completion, so
+# <branch>-latest always advances to the newest merged commit.
 concurrency:
   group: docker-build-${{ github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
The docker-build workflow used `cancel-in-progress: true`. On a fast-merging release branch (v2 saw ~34 merges in 2h — a merge every ~3-4 min, shorter than a build), **every build was cancelled by the next merge's build and none ever completed**. `v2-latest` froze at `c67d70f`, blocking ALL v2 deploys (hives auto-upgrade off `<branch>-latest`) — including merged security fixes.

Fix: `cancel-in-progress: false` so builds queue and each runs to completion; `<branch>-latest` always advances to the newest merged commit.

Impact: unblocks the frozen v2 image pipeline (authorship fix #3120, breaker, etc. can finally deploy).