### PR TITLE
🐛 Bind automerge approval to PR head

### DIFF
--- a/v2/pkg/dashboard/pr_automerge_test.go
+++ b/v2/pkg/dashboard/pr_automerge_test.go
@@ -38,6 +38,7 @@ func TestQueuePRAutoMergeRoleAndSelfGate(t *testing.T) {
 					json.NewEncoder(w).Encode(map[string]any{
 						"number": 7,
 						"user":   map[string]string{"login": tt.author},
+						"head":   map[string]string{"sha": "head7"},
 					})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/"+ghpkg.AutoMergeQueuedLabel:
 					http.NotFound(w, r)

--- a/v2/pkg/github/automerge_queue_test.go
+++ b/v2/pkg/github/automerge_queue_test.go
@@ -12,12 +12,23 @@ func TestQueuePRAutoMergeApprovesThenLabels(t *testing.T) {
 	var sawReview, sawLabel bool
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+			json.NewEncoder(w).Encode(map[string]any{"head": map[string]string{"sha": "head7"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/"+AutoMergeQueuedLabel:
 			http.NotFound(w, r)
 		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{"name": AutoMergeQueuedLabel})
 		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+			var req struct {
+				CommitID string `json:"commit_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode review request: %v", err)
+			}
+			if req.CommitID != "head7" {
+				t.Fatalf("review commit_id=%q, want head7", req.CommitID)
+			}
 			if sawLabel {
 				t.Fatal("review must be created before the PR is labeled queued")
 			}
@@ -50,6 +61,8 @@ func TestQueuePRAutoMergeUsesConfiguredLabel(t *testing.T) {
 	var sawLabel bool
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+			json.NewEncoder(w).Encode(map[string]any{"head": map[string]string{"sha": "head7"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/"+label:
 			http.NotFound(w, r)
 		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
@@ -107,6 +120,21 @@ func TestQueuePRAutoMergeRequiresQueuedBy(t *testing.T) {
 	}
 	if called {
 		t.Fatal("GitHub API should not be called without queuedBy")
+	}
+}
+
+func TestQueuePRAutoMergeRequiresHeadSHA(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/acme/widget/pulls/7" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"number": 7})
+	}))
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	if err := c.QueuePRAutoMerge(context.Background(), "acme/widget", 7, "alice"); err == nil {
+		t.Fatal("QueuePRAutoMerge returned nil error for missing head SHA")
 	}
 }
 

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -33,6 +34,11 @@ type AutoMergeSweepResult struct {
 	Merged  []AutoMergeSweepEvent
 	Seen    int
 	Skipped int
+}
+
+type hiveQueueApproval struct {
+	QueuedBy string
+	HeadSHA  string
 }
 
 // SweepQueuedAutoMerges consumes the configured Hive merger-queue label. It
@@ -126,13 +132,33 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	}
 
 	author := safeGetLogin(pr.GetUser())
-	queuedBy, ok, err := c.latestHiveQueueApproval(ctx, owner, repo, number)
+	headSHA := ""
+	if pr.GetHead() != nil {
+		headSHA = pr.GetHead().GetSHA()
+	}
+	if headSHA == "" {
+		return AutoMergeSweepEvent{}, "missing-head-sha", nil
+	}
+	approval, ok, err := c.latestHiveQueueApproval(ctx, owner, repo, number)
 	if err != nil {
 		return AutoMergeSweepEvent{}, "queue-approval-check", err
 	}
 	if !ok {
 		return AutoMergeSweepEvent{}, "no-hive-queue-approval", nil
 	}
+	if approval.HeadSHA == "" {
+		if err := c.invalidateQueuedAutoMerge(ctx, owner, repo, number, label, "Hive auto-merge approval is missing a reviewed head SHA — re-queue required."); err != nil {
+			return AutoMergeSweepEvent{}, "queue-approval-missing-head", err
+		}
+		return AutoMergeSweepEvent{}, "queue-approval-missing-head", nil
+	}
+	if approval.HeadSHA != headSHA {
+		if err := c.invalidateQueuedAutoMerge(ctx, owner, repo, number, label, "Hive auto-merge approval head changed since approval — re-queue required."); err != nil {
+			return AutoMergeSweepEvent{}, "queue-approval-head-changed", err
+		}
+		return AutoMergeSweepEvent{}, "queue-approval-head-changed", nil
+	}
+	queuedBy := approval.QueuedBy
 	if strings.EqualFold(author, queuedBy) {
 		return AutoMergeSweepEvent{}, "self-merge-ban", nil
 	}
@@ -140,13 +166,6 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	mergeable := mergeableFromState(pr.GetMergeableState(), pr.Mergeable)
 	if mergeable != MergeableYes {
 		return AutoMergeSweepEvent{}, "not-mergeable", nil
-	}
-	headSHA := ""
-	if pr.GetHead() != nil {
-		headSHA = pr.GetHead().GetSHA()
-	}
-	if headSHA == "" {
-		return AutoMergeSweepEvent{}, "missing-head-sha", nil
 	}
 	green, reason, err := c.commitGreen(ctx, owner, repo, headSHA)
 	if err != nil {
@@ -179,20 +198,20 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	return event, "", nil
 }
 
-func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string, number int) (string, bool, error) {
+func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string, number int) (hiveQueueApproval, bool, error) {
 	opts := &gh.ListOptions{PerPage: 100}
-	latest := ""
+	latest := hiveQueueApproval{}
 	for {
 		reviews, resp, err := c.client.PullRequests.ListReviews(ctx, owner, repo, number, opts)
 		if err != nil {
-			return "", false, err
+			return hiveQueueApproval{}, false, err
 		}
 		for _, review := range reviews {
 			if !strings.EqualFold(review.GetState(), "APPROVED") {
 				continue
 			}
 			if queuedBy := parseHiveQueueReview(review.GetBody()); queuedBy != "" {
-				latest = queuedBy
+				latest = hiveQueueApproval{QueuedBy: queuedBy, HeadSHA: review.GetCommitID()}
 			}
 		}
 		if resp.NextPage == 0 {
@@ -200,7 +219,17 @@ func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string
 		}
 		opts.Page = resp.NextPage
 	}
-	return latest, latest != "", nil
+	return latest, latest.QueuedBy != "", nil
+}
+
+func (c *Client) invalidateQueuedAutoMerge(ctx context.Context, owner, repo string, number int, label, body string) error {
+	if _, err := c.client.Issues.RemoveLabelForIssue(ctx, owner, repo, number, url.PathEscape(label)); err != nil && !isGitHubStatus(err, http.StatusNotFound) {
+		return fmt.Errorf("removing %s label: %w", label, err)
+	}
+	if _, _, err := c.client.Issues.CreateComment(ctx, owner, repo, number, &gh.IssueComment{Body: gh.Ptr(body)}); err != nil {
+		return fmt.Errorf("commenting on stale auto-merge approval: %w", err)
+	}
+	return nil
 }
 
 func parseHiveQueueReview(body string) string {

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -17,6 +17,8 @@ type sweepPR struct {
 	number          int
 	author          string
 	queuedBy        string
+	headSHA         string
+	reviewCommitID  *string
 	label           bool
 	draft           bool
 	mergeableState  string
@@ -52,6 +54,92 @@ func TestSweepQueuedAutoMergesMergesLabelledGreenPRAudits(t *testing.T) {
 	}
 	if len(audits) != 1 || audits[0].Repo != "widget" || audits[0].Number != 7 || audits[0].QueuedBy != "bob" {
 		t.Fatalf("audit events = %#v, want PR 7 queued by bob", audits)
+	}
+	if audits[0].HeadSHA != "sha7" {
+		t.Fatalf("audit head SHA = %q, want sha7", audits[0].HeadSHA)
+	}
+}
+
+func TestSweepQueuedAutoMergesDequeuesWhenApprovalHeadChanged(t *testing.T) {
+	reviewHead := "oldsha"
+	var merged []int
+	var removedLabel, commented bool
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number:          7,
+		author:          "alice",
+		queuedBy:        "bob",
+		headSHA:         "newsha",
+		reviewCommitID:  &reviewHead,
+		label:           true,
+		mergeableState:  "clean",
+		statusState:     "success",
+		checkStatus:     "completed",
+		checkConclusion: "success",
+	}}, &merged, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/acme/widget/issues/7/labels/"+AutoMergeQueuedLabel:
+			removedLabel = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/comments":
+			commented = true
+			json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	})
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want stale approval skipped", result.Merged, merged)
+	}
+	if !removedLabel || !commented {
+		t.Fatalf("removedLabel=%v commented=%v, want queue invalidated with comment", removedLabel, commented)
+	}
+}
+
+func TestSweepQueuedAutoMergesDequeuesWhenApprovalHeadMissing(t *testing.T) {
+	missingHead := ""
+	var merged []int
+	var removedLabel, commented bool
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number:          7,
+		author:          "alice",
+		queuedBy:        "bob",
+		reviewCommitID:  &missingHead,
+		label:           true,
+		mergeableState:  "clean",
+		statusState:     "success",
+		checkStatus:     "completed",
+		checkConclusion: "success",
+	}}, &merged, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/acme/widget/issues/7/labels/"+AutoMergeQueuedLabel:
+			removedLabel = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/comments":
+			commented = true
+			json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	})
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want missing approval head skipped", result.Merged, merged)
+	}
+	if !removedLabel || !commented {
+		t.Fatalf("removedLabel=%v commented=%v, want queue invalidated with comment", removedLabel, commented)
 	}
 }
 
@@ -248,7 +336,7 @@ func TestTrySweepQueuedPRSkipBranches(t *testing.T) {
 					if tt.noReview {
 						json.NewEncoder(w).Encode([]map[string]any{})
 					} else {
-						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI."}})
+						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI.", "commit_id": "sha7"}})
 					}
 				default:
 					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -292,7 +380,7 @@ func TestTrySweepQueuedPRMissingHeadAndMergeNotApplied(t *testing.T) {
 						"labels":          []map[string]string{{"name": AutoMergeQueuedLabel}},
 					})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
-					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI."}})
+					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7"}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
 					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
@@ -327,7 +415,7 @@ func TestTrySweepQueuedPRMergeError(t *testing.T) {
 				"labels": []map[string]string{{"name": AutoMergeQueuedLabel}},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
-			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI."}})
+			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
 			json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
@@ -343,6 +431,88 @@ func TestTrySweepQueuedPRMergeError(t *testing.T) {
 	_, reason, err := c.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
 	if err == nil || reason != "merge-failed" {
 		t.Fatalf("trySweepQueuedPR reason=%q err=%v, want merge-failed error", reason, err)
+	}
+}
+
+func TestLatestHiveQueueApprovalKeepsLatestCommitID(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/acme/widget/pulls/7/reviews" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"state": "APPROVED", "body": "Approved by @old for Hive auto-merge on green CI.", "commit_id": "oldsha"},
+			{"state": "COMMENTED", "body": "Approved by @ignored for Hive auto-merge on green CI.", "commit_id": "ignored"},
+			{"state": "APPROVED", "body": "Approved by @new for Hive auto-merge on green CI.", "commit_id": "newsha"},
+		})
+	}))
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	approval, ok, err := c.latestHiveQueueApproval(context.Background(), "acme", "widget", 7)
+	if err != nil {
+		t.Fatalf("latestHiveQueueApproval returned error: %v", err)
+	}
+	if !ok || approval.QueuedBy != "new" || approval.HeadSHA != "newsha" {
+		t.Fatalf("approval=(%+v,%v), want new/newsha", approval, ok)
+	}
+}
+
+func TestInvalidateQueuedAutoMergeIgnoresMissingLabelAndComments(t *testing.T) {
+	var commented bool
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/repos/acme/widget/issues/7/labels/"+AutoMergeQueuedLabel:
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/comments":
+			commented = true
+			json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	if err := c.invalidateQueuedAutoMerge(context.Background(), "acme", "widget", 7, AutoMergeQueuedLabel, "re-queue required"); err != nil {
+		t.Fatalf("invalidateQueuedAutoMerge returned error: %v", err)
+	}
+	if !commented {
+		t.Fatal("expected stale queue invalidation comment")
+	}
+}
+
+func TestInvalidateQueuedAutoMergeReportsAPIErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		deleteCode int
+		commentOK  bool
+	}{
+		{name: "remove label error", deleteCode: http.StatusInternalServerError, commentOK: true},
+		{name: "comment error", deleteCode: http.StatusOK, commentOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodDelete && r.URL.Path == "/repos/acme/widget/issues/7/labels/"+AutoMergeQueuedLabel:
+					w.WriteHeader(tt.deleteCode)
+				case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/comments":
+					if tt.commentOK {
+						json.NewEncoder(w).Encode(map[string]any{"id": 1})
+						return
+					}
+					http.Error(w, "boom", http.StatusInternalServerError)
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+
+			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			if err := c.invalidateQueuedAutoMerge(context.Background(), "acme", "widget", 7, AutoMergeQueuedLabel, "re-queue required"); err == nil {
+				t.Fatal("invalidateQueuedAutoMerge returned nil error")
+			}
+		})
 	}
 }
 
@@ -407,7 +577,7 @@ func TestListQueuedPullRequestIssuesPaginates(t *testing.T) {
 	}
 }
 
-func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, merged *[]int) *httptest.Server {
+func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, merged *[]int, extras ...func(http.ResponseWriter, *http.Request)) *httptest.Server {
 	t.Helper()
 	byNumber := make(map[int]sweepPR, len(prs))
 	for _, pr := range prs {
@@ -434,10 +604,22 @@ func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, mer
 			number := pathNumber(t, r.URL.Path, "/repos/acme/widget/pulls/", "/reviews")
 			pr := byNumber[number]
 			body := "Approved by @" + pr.queuedBy + " for Hive auto-merge on green CI."
-			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": body}})
+			headSHA := "sha" + strconv.Itoa(pr.number)
+			if pr.headSHA != "" {
+				headSHA = pr.headSHA
+			}
+			reviewCommitID := headSHA
+			if pr.reviewCommitID != nil {
+				reviewCommitID = *pr.reviewCommitID
+			}
+			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": body, "commit_id": reviewCommitID}})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/pulls/"):
 			number := pathNumber(t, r.URL.Path, "/repos/acme/widget/pulls/", "")
 			pr := byNumber[number]
+			headSHA := "sha" + strconv.Itoa(pr.number)
+			if pr.headSHA != "" {
+				headSHA = pr.headSHA
+			}
 			json.NewEncoder(w).Encode(map[string]any{
 				"number":          pr.number,
 				"state":           "open",
@@ -445,7 +627,7 @@ func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, mer
 				"mergeable_state": pr.mergeableState,
 				"mergeable":       pr.mergeableState == "clean",
 				"user":            map[string]string{"login": pr.author},
-				"head":            map[string]string{"sha": "sha" + strconv.Itoa(pr.number)},
+				"head":            map[string]string{"sha": headSHA},
 				"labels":          []map[string]string{{"name": expectedLabel}},
 			})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/commits/") && strings.HasSuffix(r.URL.Path, "/status"):
@@ -472,6 +654,10 @@ func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, mer
 			*merged = append(*merged, number)
 			json.NewEncoder(w).Encode(map[string]any{"merged": true, "sha": "merge" + strconv.Itoa(number)})
 		default:
+			for _, extra := range extras {
+				extra(w, r)
+				return
+			}
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
 		}
 	}))

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -696,14 +696,26 @@ func (c *Client) QueuePRAutoMerge(ctx context.Context, repo string, number int, 
 		return errors.New("queuedBy is required for auto-merge audit and self-merge checks")
 	}
 	owner, repoName := c.splitRepo(repo)
+	pr, _, err := c.client.PullRequests.Get(ctx, owner, repoName, number)
+	if err != nil {
+		return fmt.Errorf("fetching PR head for auto-merge approval: %w", err)
+	}
+	headSHA := ""
+	if pr.GetHead() != nil {
+		headSHA = pr.GetHead().GetSHA()
+	}
+	if headSHA == "" {
+		return errors.New("PR head SHA is required for auto-merge approval")
+	}
 	label := c.AutoMergeLabel()
 	if err := c.ensureLabel(ctx, owner, repoName, label); err != nil {
 		return fmt.Errorf("ensuring %s label: %w", label, err)
 	}
 	body := fmt.Sprintf("Approved by @%s for Hive auto-merge on green CI.", queuedBy)
-	_, _, err := c.client.PullRequests.CreateReview(ctx, owner, repoName, number, &gh.PullRequestReviewRequest{
-		Body:  gh.Ptr(body),
-		Event: gh.Ptr("APPROVE"),
+	_, _, err = c.client.PullRequests.CreateReview(ctx, owner, repoName, number, &gh.PullRequestReviewRequest{
+		CommitID: gh.Ptr(headSHA),
+		Body:     gh.Ptr(body),
+		Event:    gh.Ptr("APPROVE"),
 	})
 	if err != nil {
 		return fmt.Errorf("approving PR: %w", err)


### PR DESCRIPTION
## Summary
- record the current PR head SHA in the Hive queue approval review
- require the latest Hive queue approval commit_id to match the current head before merging
- remove the queue label and comment when the reviewed head is missing or stale

Fixes #3094

## Validation
- go build ./...
- go vet ./...
- go test ./pkg/github/ ./pkg/dashboard/ ./pkg/scheduler/ -count=1