### PR TITLE
🐛 Prevent stale contributor resume duplicates

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -401,7 +401,7 @@ function runHeadlessTask(task) {
   const { bin, args } = buildHeadlessArgv(prompt);
   console.log(`Headless: running ${bin} (one-shot) for ${task.repo}#${task.number}`);
   writeHeadlessStatus(HEADLESS_STATE_WORKING, { task_id: task.task_id, repo: task.repo, number: task.number });
-  send({ type: 'task_progress', seq: nextSeq(), task_id: task.task_id, kind: task.kind, repo: task.repo, number: task.number, title: task.title, status: 'working' });
+  send({ type: 'task_progress', seq: nextSeq(), task_id: task.task_id, task_gen: task.task_gen, kind: task.kind, repo: task.repo, number: task.number, title: task.title, status: 'working' });
 
   let settled = false;
   const finish = (fn) => { if (settled) return; settled = true; fn(); };
@@ -436,7 +436,7 @@ function runHeadlessTask(task) {
       const prURL = detectPRURL(outTail, task.repo);
       if (prURL) console.log(`Detected PR for ${task.task_id}: ${prURL}`);
       writeHeadlessStatus(HEADLESS_STATE_DONE, { task_id: task.task_id, pr_url: prURL });
-      send({ type: 'task_complete', seq: nextSeq(), task_id: task.task_id, result: 'completed', summary: 'Headless one-shot invocation exited 0', tmux_output: outTail, pr_url: prURL });
+      send({ type: 'task_complete', seq: nextSeq(), task_id: task.task_id, task_gen: task.task_gen, result: 'completed', summary: 'Headless one-shot invocation exited 0', tmux_output: outTail, pr_url: prURL });
       currentTask = null;
       taskAssignedAt = 0;
       tasksCompletedCount++;
@@ -1014,9 +1014,10 @@ function failCurrentTask(reason, opts) {
   if (!currentTask) return;
   const permanent = !!(opts && opts.permanent);
   const taskId = currentTask.task_id;
+  const taskGen = currentTask.task_gen;
   const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
   console.error(`Task ${taskId} failed${permanent ? ' permanently' : ''}: ${reason}`);
-  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, reason, permanent, tmux_output: tmuxLines });
+  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, task_gen: taskGen, reason, permanent, tmux_output: tmuxLines });
   currentTask = null;
   taskAssignedAt = 0;
   if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
@@ -1110,7 +1111,7 @@ function progressTick() {
     // Empty when no PR link is found — the hub then applies the short cooldown.
     const prURL = detectPRURL(tmuxLines, currentTask.repo);
     if (prURL) console.log(`Detected PR for ${currentTask.task_id}: ${prURL}`);
-    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines, pr_url: prURL });
+    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines, pr_url: prURL });
     // bob exits after each turn, so the pane is now a bare shell. Bring it
     // back up before the next task, or the prompt would be typed into bash
     // ("-bash: <prompt>: command not found") and silently lost.
@@ -1149,13 +1150,14 @@ function progressTick() {
       type: 'task_progress',
       seq: nextSeq(),
       task_id: currentTask.task_id,
+      task_gen: currentTask.task_gen,
       status: 'blocked_on_human',
       attention: true,
       summary: 'Agent is waiting for human input in the tmux pane',
       tmux_output: tmuxLines,
     });
   } else {
-    send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, status: 'working', tmux_output: tmuxLines });
+    send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: tmuxLines });
   }
 }
 
@@ -1200,7 +1202,7 @@ function handleMessage(data, hub) {
       if (currentTask && hub === currentTaskHub()) {
         console.log(`Reconnected while working on ${currentTask.repo}#${currentTask.number} — resuming`);
         sendTo(hub, { type: 'task_accepted', seq: nextSeq(), task_id: currentTask.task_id });
-        sendTo(hub, { type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, kind: currentTask.kind, repo: currentTask.repo, number: currentTask.number, title: currentTask.title, status: 'working' });
+        sendTo(hub, { type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, kind: currentTask.kind, repo: currentTask.repo, number: currentTask.number, title: currentTask.title, status: 'working' });
         startProgressReporting();
       } else if (!currentTask && hub === hubs[activeHubIndex]) {
         // Only the hub currently in the poll rotation asks for work. A hub
@@ -1266,7 +1268,7 @@ function handleMessage(data, hub) {
         tokenExpiresAt = msg.token_expires_at ? new Date(msg.token_expires_at).getTime() : null;
       }
       fs.writeFileSync(TASK_FILE, JSON.stringify(msg, null, 2));
-      send({ type: 'task_accepted', seq: nextSeq(), task_id: msg.task_id });
+      send({ type: 'task_accepted', seq: nextSeq(), task_id: msg.task_id, task_gen: msg.task_gen });
       if (CONTRIBUTOR_MODE === MODE_HEADLESS) {
         // Non-interactive path (kubestellar/hive#2538): drive a one-shot CLI
         // invocation and report completion/failure from its exit status — no

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -2082,6 +2082,25 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				// progress ping for a task the hub already tracks.
 				resumed := false
 				if contributor.currentTask == nil && msg.TaskID != "" {
+					contributor.mu.Unlock()
+					h.selectMu.Lock()
+					if h.taskHeldByAnotherConnection(contributor, msg.Repo, msg.Number) {
+						h.selectMu.Unlock()
+						h.logger.Warn("[contribute-ws] stale task_progress resume rejected: task held by another connection",
+							"username", contributor.profile.GitHubUsername,
+							"task", msg.TaskID,
+							"repo", h.canonicalRepoKey(msg.Repo),
+							"number", msg.Number,
+						)
+						continue
+					}
+					contributor.mu.Lock()
+					if contributor.currentTask != nil {
+						contributor.lastLeaseRenew = time.Now()
+						contributor.mu.Unlock()
+						h.selectMu.Unlock()
+						continue
+					}
 					contributor.currentTask = &WSTaskAssign{
 						TaskID: msg.TaskID,
 						Kind:   msg.Kind,
@@ -2102,6 +2121,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					// #2568: a RESUME adopts the task under a FRESH generation so the
 					// hub, not the client, owns the authoritative token from here on.
 					contributor.currentTaskGen = h.nextTaskGen()
+					h.selectMu.Unlock()
 				}
 				// #2568: renew the hub-owned lease on every progress report. This is
 				// what distinguishes "working slowly but alive" (lease keeps renewing,
@@ -2380,6 +2400,29 @@ func (h *ContributeWSHub) maybeRefreshToken(c *ContributorConnection) {
 // an empty token (no App auth / no cache) leaves the relay's existing token in
 // place — the same lenient policy maybeRefreshToken uses — and tokenMintedAt stays
 // zero, so the next reconnect (or a later mint success) can still arm it.
+func (h *ContributeWSHub) taskHeldByAnotherConnection(candidate *ContributorConnection, repo string, number int) bool {
+	if h == nil || number <= 0 {
+		return false
+	}
+	canonicalRepo := h.canonicalRepoKey(repo)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, conn := range h.connections {
+		if conn == nil || conn == candidate {
+			continue
+		}
+		conn.mu.Lock()
+		held := conn.currentTask != nil &&
+			conn.currentTask.Number == number &&
+			h.canonicalRepoKey(conn.currentTask.Repo) == canonicalRepo
+		conn.mu.Unlock()
+		if held {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *ContributeWSHub) resumeTaskToken(c *ContributorConnection) {
 	tier := ""
 	if c.profile != nil {

--- a/v2/pkg/dashboard/contribute_ws_dupe_assign_test.go
+++ b/v2/pkg/dashboard/contribute_ws_dupe_assign_test.go
@@ -192,3 +192,48 @@ func TestDupeAssign_ResumedTaskExcludedFromSelection(t *testing.T) {
 		t.Fatalf("expected a task_unavailable no-work ack (the only issue is in-flight), got %+v", msg)
 	}
 }
+
+// TestDupeAssign_StaleReconnectCannotResumeIssueHeldByAnotherConnection covers
+// the #3093 seam: after a disconnect/lease expiry, an old relay can reconnect
+// and re-assert its locally retained task via task_progress. If the issue was
+// already granted to another connection while the first relay was away, the
+// resume path must not create a second in-flight owner for the same repo#issue.
+func TestDupeAssign_StaleReconnectCannotResumeIssueHeldByAnotherConnection(t *testing.T) {
+	hub, s := covK2Hub(t)
+	singleIssueStatus(s)
+
+	holder := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "new-owner", ContributorID: "c-new", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	holder.mu.Lock()
+	holder.currentTask = &WSTaskAssign{TaskID: "ct-new-48", Kind: "issue", Repo: "projectbluefin/fsdk-containers", Number: 48}
+	holder.mu.Unlock()
+
+	returning := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "stale-owner", ContributorID: "c-old", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+
+	hub.mu.Lock()
+	hub.connections["conn-new"] = holder
+	hub.connections["conn-old"] = returning
+	hub.mu.Unlock()
+
+	if !hub.taskHeldByAnotherConnection(returning, "fsdk-containers", 48) {
+		t.Fatalf("stale reconnect did not detect that projectbluefin/fsdk-containers#48 is already held")
+	}
+
+	returning.mu.Lock()
+	if hub.taskHeldByAnotherConnection(returning, "fsdk-containers", 48) {
+		// This is the branch the task_progress resume handler now takes: reject the
+		// stale resume and leave currentTask nil.
+	} else {
+		returning.currentTask = &WSTaskAssign{TaskID: "ct-old-48", Kind: "issue", Repo: hub.canonicalRepoKey("fsdk-containers"), Number: 48}
+	}
+	got := returning.currentTask
+	returning.mu.Unlock()
+	if got != nil {
+		t.Fatalf("stale reconnect resurrected duplicate ownership: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- root cause: a reconnecting relay could reassert a retained task via task_progress after the same repo#issue was already leased to another connection; the resume path did not consult other active leases and the stock relay also failed to echo task_gen on lifecycle messages
- serialize resume claim checks with selectTask using selectMu and reject stale resumes when another connection already holds the canonical repo#issue
- echo task_gen from the relay on progress, complete, failed, and accepted lifecycle frames

Fixes #3093

## Validation
- go build ./...
- go vet ./...
- go test ./pkg/github/ ./pkg/dashboard/ ./pkg/scheduler/ -count=1
- go test -race ./pkg/dashboard/ -run 'TestDupeAssign|TestLease' -count=1