### PR TITLE
📖 docs: final guide gaps

### DIFF
--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -15,6 +15,9 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Token collection and usage tracking](token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
 - [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
+- [`bd` beads CLI](beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
+- [Backup and restore](backup-restore.md) — `hive-backup`, Kubernetes CronJob, and spoke backup scope.
+- [Deployment helper scripts](deployment-scripts.md) — Proxmox LXC and blue-green Compose helpers.
 - [Dashboard API reference](api-reference.md) — pragmatic route index for dashboard and hub endpoints.
 - [Dashboard OpenAPI spec](../../dashboard/openapi.json) — machine-readable REST API reference for integrations.
 - [ioscan status](ioscan.md) — v2 status of the untrusted-input scanner/canary feature.

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -108,6 +108,7 @@ agents:
                                  #   must exceed its longest cadence
     restart_strategy: immediate  # how to bring a dead session back
     beads_dir: /data/beads/scanner   # work-record (bead) storage; default per-agent
+    replicas: 3                  # materialize scanner, scanner-2, scanner-3 (max 5)
     lane_keywords: [bug, triage, fix]   # routes matching issues into this agent's lane
     detect_keywords: [scanner, triage]  # attributes GitHub activity back to this agent
 ```
@@ -119,6 +120,11 @@ Three optional blocks replace hardcoded behavior with declarations:
 ```yaml
     channels:                    # how the agent gets triggered. Omit = governor timer.
       - type: kick               # kick | webhook | discord | schedule | bead
+      - type: webhook
+        events: ["issues.opened", "issues.labeled"]
+        repos: [repo-one]        # optional repo-name filter
+      - type: bead
+        match: { nudge_target: scanner }
       - type: schedule
         schedule: "0 */4 * * *"  # cron; required for type: schedule
     tools:                       # tool permissions. Omit = the mode field governs.
@@ -134,6 +140,22 @@ Three optional blocks replace hardcoded behavior with declarations:
 ```
 
 Presets map onto modes (`advisory` denies issue and PR creation, `issues-only` denies PRs, `issues-prs` and `full` deny nothing), and an explicit `allow` rule overrides a preset `deny`.
+
+### Replicated agents
+
+Set `replicas: N` on a declared agent to run a small pool with the same prompt, backend, model, mode, channel, tool, and metadata settings. `N` defaults to `1` and is capped at `5`; config load fails if it is outside `1..5`. Hive materializes derived names as `<base>-2`, `<base>-3`, ... (`scanner`, `scanner-2`, `scanner-3`). Do not declare those derived names yourself: a real `scanner-2` entry collides with `scanner: { replicas: 2 }` and is rejected. Derived replicas get their own IDs and bead directories (`/data/beads/scanner-2`) but inherit the base agent's kick template/prompt selection. Runtime-derived replicas are stripped before saving and recreated on the next load.
+
+### Trigger channels
+
+`channels:` declares non-default ways to wake an agent. If the block is omitted, governor timer kicks still work. If you include the block, add `type: kick` when the agent should keep normal governor kicks alongside other triggers.
+
+| Type | Required fields | Behavior |
+|---|---|---|
+| `kick` | none | Keep ordinary governor timer kicks. |
+| `webhook` | `events` | `/webhook`/GitHub webhook receiver matches `X-GitHub-Event` or `event.action` strings such as `issues.opened`; optional `repos` filters by repository name. If `HIVE_WEBHOOK_SECRET` is set, GitHub `X-Hub-Signature-256` HMAC is verified. |
+| `bead` | `match` | The bead watcher polls the agent's `beads_dir` about every 30 seconds and kicks when an individual JSON file has every `key: value` in `match` at the top level. Current watcher matching is not the nested `metadata` map inside the `bd` ledger file. |
+| `schedule` | `schedule` | Cron-style channel trigger independent of governor-mode cadences. |
+| `discord` | `patterns` | Declared shape for Discord-triggered work; patterns are validated by config load. |
 
 Rounding out the schema — fields you will rarely touch:
 

--- a/v2/docs/backup-restore.md
+++ b/v2/docs/backup-restore.md
@@ -1,0 +1,58 @@
+# Hive backup and restore
+
+Hive has two backup paths with different scopes.
+
+## Hub disaster recovery: `hive-backup`
+
+`v2/cmd/hive-backup` creates encrypted hub disaster-recovery archives. It captures:
+
+- hub SaaS state under `/data/saas/**`;
+- `/data/hub-registry.json`;
+- required hub Kubernetes Secrets (`hive-hub-secrets`, `oci-api-key`, `hive-hub-kubeconfigs`, and `hive-hub-tls` when present);
+- each spoke's authoritative config files (`hive.yaml.dashboard`, `hive.yaml.runtime` or legacy `hive.yaml.bak`, `hive-id`) and GitHub App key files.
+
+It deliberately excludes regenerable bulk state such as hub `nous/`, `home/`, `beads/`, and `logs/` so a nightly fleet backup stays small and restorable.
+
+`HIVE_BACKUP_KEY` is required and must be a 64-character hex AES-256 key. Escrow it outside the cluster; a backup encrypted by a key that only exists in the lost cluster is not recoverable.
+
+```bash
+openssl rand -hex 32   # generate the value to store as HIVE_BACKUP_KEY
+hive-backup run                 # encrypt, upload, verify, and prune object storage
+hive-backup run -local backup.enc
+hive-backup run -skip-spokes=true
+hive-backup verify              # newest object-storage archive
+hive-backup verify -file backup.enc
+hive-backup list
+hive-backup extract -file backup.enc -dest restore-dir
+```
+
+Environment:
+
+| Variable | Purpose |
+|---|---|
+| `HIVE_BACKUP_KEY` | Required AES-256 key, hex encoded. |
+| `HIVE_BACKUP_BUCKET` | OCI Object Storage bucket. |
+| `HIVE_BACKUP_DATA_DIR` | Hub data directory; default `/data`. |
+| `HIVE_BACKUP_RETENTION` | Archive count to retain; default `30`. |
+| `HIVE_HUB_NAMESPACE` | Hub namespace for Secret collection; default `hive-hub`. |
+| `HIVE_KUBECONFIG_DIR` | Mounted kubeconfig directory for remote spoke clusters; default `/etc/hive/kubeconfigs`. |
+
+`extract` decrypts into a directory and verifies hashes. It does **not** mutate a live cluster. A restore operator should inspect the extracted `MANIFEST.json`, re-apply the captured Secret JSON to the new hub namespace, copy `hub/` files back to the hub PVC, and recreate or patch spokes from `spokes/<hive-id>/`. Any `spoke_errors` in the manifest are honest gaps: those spokes were not captured and need separate recovery.
+
+## Kubernetes CronJob
+
+`v2/deploy/k8s/backup-cronjob.yaml` wires the hub DR path into Kubernetes. It creates:
+
+- ServiceAccount `hive-hub-backup` in namespace `hive-hub`;
+- a ClusterRole/Binding that can read Secrets/namespaces/pods and exec into spoke pods to read their PVC state;
+- a daily `CronJob` scheduled at `17 3 * * *`, `concurrencyPolicy: Forbid`, one-hour active deadline;
+- ConfigMap `hive-hub-backup-config` with object-storage bucket and retention.
+
+Before applying it, create Secret `hive-hub-backup-key` with key `backup-key`, ensure `oci-api-key` and `hive-hub-kubeconfigs` exist, and confirm the PVC claim name (`hive-hub-data-rwx`) matches your deployment.
+
+## Owner-triggered spoke backup
+
+`pkg/spokebackup` is complementary: it backs up one spoke on demand for its owner and includes the spoke's bead ledger. It is encrypted with the same `HIVE_BACKUP_KEY` mechanism and is sized for browser download, not nightly fleet DR. It includes `hive.yaml.dashboard`, runtime config files, `hive-id`, `hive-state.json`, GitHub App keys, and `/data/beads/*`; it skips bulk/derived data and live dashboard sessions.
+
+Fixes #2986.
+Fixes #2942.

--- a/v2/docs/beads-cli.md
+++ b/v2/docs/beads-cli.md
@@ -1,0 +1,46 @@
+# `bd` beads CLI reference
+
+`bd` is the operator/contributor CLI for Hive's bead work ledger. It stores data in `BD_DIR`, or in the current agent's conventional bead directory (`/data/beads/<agent>` or `/data/agents/<agent>` → `/data/beads/<agent>`). Stores are created on first use.
+
+## Work ledger commands
+
+| Command | Use |
+|---|---|
+| `bd list [--json] [--status <s>] [--actor <a>]` | List beads; filter by status or actor. |
+| `bd ready [--json] [--actor <a>]` | Show open, unblocked work ready to claim. |
+| `bd create --title "..." --type <type> --priority <0-4> --actor <name> [--external-ref <ref>]` | Create work. Types include `bug`, `feature`, `task`, `epic`, `chore`, `decision`, and `advisory`; priority `0` is highest. |
+| `bd update <id> --claim` | Mark a bead `in_progress`. |
+| `bd update <id> --status open|in_progress|blocked|done|closed` | Change status directly. |
+| `bd update <id> --set-metadata key=value` / `--unset-metadata key` | Add or remove custom metadata in the bead ledger. |
+| `bd close <id>` | Close one bead. |
+| `bd reset [--reason "..."]` | Close all open/in-progress/blocked beads with an audit reason. |
+| `bd remember "fact"` | Quick-add an advisory bead authored by `system`. |
+| `bd init` | No-op compatibility command; opening the store creates it. |
+| `bd dolt push` | No-op compatibility command; v2 data is already persisted on disk. |
+
+Examples:
+
+```bash
+export BD_DIR=/data/beads/scanner
+bd ready --actor scanner
+bd create --title "Document backup restore" --type task --priority 2 --actor guide --external-ref https://github.com/kubestellar/hive/issues/2986
+bd update bead-123 --claim
+bd update bead-123 --set-metadata reviewer=guide
+bd close bead-123
+```
+
+## Knowledge commands
+
+`bd kb` talks to the dashboard API (`BD_DASHBOARD_URL`, default `http://localhost:3001`) rather than the local bead store.
+
+| Command | Use |
+|---|---|
+| `bd kb search "query"` | Search knowledge facts. |
+| `bd kb read <slug>` | Print the body for a fact slug returned by search. |
+| `bd kb import-url <url> [--name <n>]` | Import a document URL into the project layer. |
+| `bd kb import-file <path> [--name <n>]` | Import a local document path into the project layer. |
+| `bd kb ctx7-search <name>` | Search Context7 library IDs. |
+| `bd kb import-ctx7 <library-id> [--name <n>] [--query <topic>]` | Import Context7 docs into the community layer. |
+| `bd kb list-docs` | List imported documents. |
+
+Fixes #2981.

--- a/v2/docs/contributor-relay.md
+++ b/v2/docs/contributor-relay.md
@@ -39,3 +39,22 @@ just contribute-hive
 
 The hive may override the request with an owner-assigned role. See [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md) for tier, grant, and allow-list requirements.
 
+
+## Kubernetes contributor workload
+
+`just contribute-k8s` emits a complete Kubernetes workload for a long-lived contributor relay: Namespace, ConfigMap, Secret, and Deployment. It prints YAML to stdout by default, or writes a file when an output path is supplied:
+
+```bash
+just contribute-setup claude
+just contribute-k8s                          # default namespace hive-contributor
+just contribute-k8s my-namespace relay.yaml  # write a manifest
+just contribute-k8s my-namespace relay.yaml v2  # pin image tag
+kubectl apply -f relay.yaml
+kubectl -n my-namespace rollout status deploy/hive-contributor
+```
+
+The generated pod sets `CONTRIBUTOR_MODE=headless` because Kubernetes pods have no TTY; interactive tmux mode would stall. Headless mode is currently verified for `claude`, `litellm`, `copilot`, `codex`, and `goose`. The Deployment has one replica per registered contributor identity and uses readiness/liveness probes that read the relay's headless status file (`waiting`, `working`, `done` pass; missing/failed state fails).
+
+The generated Secret contains the registration token and `GH_TOKEN` as Kubernetes Secret data. Treat it as sensitive cluster-readable material and prefer a pinned image tag/digest for repeatable operation.
+
+Fixes #3024.

--- a/v2/docs/deployment-scripts.md
+++ b/v2/docs/deployment-scripts.md
@@ -1,0 +1,19 @@
+# Deployment helper scripts
+
+The main supported paths remain Docker Compose and Kubernetes. `v2/deploy/` also contains operator helpers for smaller bare-metal installs and safer Compose upgrades.
+
+## Proxmox LXC helpers
+
+`deploy/create-lxc.sh` runs on a Proxmox host. It creates an Ubuntu 24.04 LXC with Docker-compatible settings (`nesting=1`, `keyctl=1`, unconfined AppArmor, no capability drop), then starts SSH. Tunable flags include `--ctid`, `--hostname`, `--password`, `--disk`, `--memory`, and `--cores`.
+
+`deploy/bootstrap-lxc.sh` runs inside that LXC. It installs Docker Engine and the Compose plugin, clones the `v2` branch to `/opt/hive`, builds the Hive image, and writes `/opt/hive/.env` with placeholders for GitHub, dashboard, model, and notification credentials.
+
+Use this path when you operate Hive on Proxmox or another LXC-first host and want a lightweight VM-like container that still runs the normal Docker Compose deployment. Do not use it inside Kubernetes.
+
+## Blue-green Compose deploy
+
+`deploy/blue-green-deploy.sh [--skip-build]` is a zero/low-downtime Compose upgrade helper. It builds a fresh `hive` image unless `--skip-build` is set, starts it as `hive-next` on the existing Docker network and volumes, waits for `/api/health`, then stops the old `hive`, renames `hive-next` to `hive`, and reloads `hive-gateway` nginx.
+
+Use it for production Docker Compose installs where an in-place `docker compose up -d` restart would be too disruptive. Preconditions: existing `hive` and `hive-gateway` containers, a `/data` volume, mounted `hive.yaml`, mounted `/secrets`, Docker Compose, and enough disk for a second image/container during the cutover.
+
+Fixes #2939.

--- a/v2/docs/design/knowledge-system.md
+++ b/v2/docs/design/knowledge-system.md
@@ -8,6 +8,14 @@ This design is informed by contrasting MetaSwarm (dsifry/metaswarm) with Hive. M
 
 ---
 
+## Pre-seeded deployment wiki
+
+The container image includes a small Obsidian-compatible seed vault in `v2/deploy/data/wiki/`. Current seed files are `agents.md` and `getting-started.md`; they introduce Hive agent roles, governor modes, beads, and the knowledge layer. Operators can extend these Markdown files in a derived image or mount/clone their own vault.
+
+The image copies `v2/deploy/data/` to `/opt/hive/seed-data/`. At startup, `deploy/entrypoint.sh` copies missing seed files from there into `/data/`, so the wiki seed lands at `/data/wiki/` without overwriting existing operator content. The entrypoint also prepares `/data/vaults/hive-wiki`; if `HIVE_WIKI_GIT_URL` is set and the vault is not already a git checkout, it clones that URL there, otherwise the local vault directory is created for the knowledge service to use. The seed files are intended as starter knowledge, not immutable product documentation: edit or replace them with project-specific runbooks, gotchas, and policies that should be available to agent priming.
+
+Fixes #2924.
+
 ## 1. Layered Knowledge Architecture
 
 ### Implementation: geronimo-iia/llm-wiki (Rust)

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -37,6 +37,14 @@ Top-level YAML keys accepted by `config.Config`:
 
 For runtime precedence and provenance, see [config-layering.md](config-layering.md).
 
+## Fleet breaker
+
+The dashboard top bar includes a fleet breaker: a circular pause/play control plus a status pill. The `GET /api/breaker` state is readable by authenticated viewers, but engaging or releasing the breaker is owner-only (`POST /api/breaker/engage`, `POST /api/breaker/release`).
+
+Engage pauses every agent that is currently running and is not `on_demand`. Agents already paused before engage are skipped and keep their original pause reason. Release resumes only the exact agents the breaker paused and still owns (`PausedTrigger == fleet-breaker`); if an operator manually re-pauses an agent while the breaker is engaged, release leaves it paused. The breaker state is persisted so a crash/restart can still release the same captured set.
+
+Fixes #2953.
+
 ## `HIVE_GITHUB_TOKEN` permissions
 
 `github.token: ${HIVE_GITHUB_TOKEN}` creates the main GitHub client when a GitHub

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -33,6 +33,7 @@ agents:
     model: claude-sonnet-4-6
     caveman_mode: full                    # lite | full | ultra | wenyan — compresses output ~65%
     beads_dir: /data/beads/scanner
+    # replicas: 3                         # Optional pool: scanner, scanner-2, scanner-3 (max 5)
     clear_on_kick: true                   # Send /clear before each kick to reset context
     display_name: Code Scanner
     description: Triages GitHub issues and PRs — dispatches fix agents, enforces SLA
@@ -218,6 +219,18 @@ governor:
       architect: 30m
       guide: 4h
       strategist: 4h
+
+  # Time-of-day cadences are available anywhere an interval appears above.
+  # Each entry must use exactly one of: interval string (e.g. 4h/pause),
+  # times+tz, or cron+tz. Do not mix interval, times, and cron in one value.
+  # examples:
+  #   guide:
+  #     times: ["09:00", "17:00"]        # wall-clock local times
+  #     days: [mon, tue, wed, thu, fri]   # optional; omit for every day
+  #     tz: America/New_York              # required for times/cron
+  #   strategist:
+  #     cron: "30 8 * * mon-fri"          # five-field cron expression
+  #     tz: UTC
 
   # Trajectory review lane — periodic second-model review of running agents.
   # Enabled by default; it no-ops until endpoint+model resolve here or via litellm.


### PR DESCRIPTION
## Summary
- document agent replicas, time-of-day cadence examples, channel triggers, and fleet breaker semantics
- add bd CLI, backup/restore, and deployment helper references
- document wiki seed files and Kubernetes contributor relay workload; link new docs from the v2 index

Fixes #2921
Fixes #3019
Fixes #2953
Fixes #3039
Fixes #2981
Fixes #2986
Fixes #2942
Fixes #2939
Fixes #2924
Fixes #3024

## Validation
- git diff --check
- code-review agent (addressed findings)
- attempted `go test ./...`; existing suite did not complete cleanly during local run, docs-only diff validated with diff check