### PR TITLE
🔒 Security audit 2026-08-07: N9 — wrong task_id must not clear the assignment

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -2259,15 +2259,34 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				completedTask := contributor.currentTask
-				contributor.currentTask = nil
-				// #2539: drop the previewable prompt with the task it belonged to so
-				// the ops tab does not show a stale instruction after completion.
-				contributor.currentPrompt = ""
-				contributor.currentLabels = nil
-				contributor.tokenMintedAt = time.Time{}
-				// #2537: clear any pending/delivered credential state with the task.
-				contributor.pendingToken = ""
-				contributor.credentialDelivered = false
+				// SECURITY (audit N9, CWE-862/639): clear ONLY when the reported
+				// task_id actually matches the held assignment.
+				//
+				// This block used to run unconditionally, while revokeLease and
+				// markTaskCompleted below run only `if hasTask`. So a completion
+				// naming ANY other task released the assignment without revoking the
+				// lease or booking a cooldown: the contributor went `ready` and was
+				// minted a SECOND live repo credential under max_concurrent=1, and
+				// the "unassigned task ignored" warning below said otherwise while
+				// the state had in fact already been mutated.
+				//
+				// The #2568 Gate does not cover this: generationAccepted() returns
+				// true whenever clientGen == 0, and omitting task_gen yields 0, so
+				// the guard is opt-in from the client.
+				if hasTask {
+					contributor.currentTask = nil
+					// #2539: drop the previewable prompt with the task it belonged to
+					// so the ops tab does not show a stale instruction after completion.
+					contributor.currentPrompt = ""
+					contributor.currentLabels = nil
+					contributor.tokenMintedAt = time.Time{}
+					// #2537: clear any pending/delivered credential state with the task.
+					contributor.pendingToken = ""
+					contributor.credentialDelivered = false
+				}
+				// tmuxOutput is diagnostic only and carries no authority, so it is
+				// recorded either way — it is often the only evidence of what a
+				// confused relay was doing when it reported the wrong task.
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
 
@@ -2344,7 +2363,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					}
 					_ = saveContributorProfile(contributor.profile)
 				} else {
-					h.logger.Warn("[contribute-ws] task_complete for unassigned task ignored",
+					// N9: this is now literally true. It previously logged "ignored"
+					// after the handler had already cleared currentTask and the
+					// credential state, which made the bypass look like a no-op in the
+					// logs.
+					h.logger.Warn("[contribute-ws] task_complete for unassigned task ignored (assignment left intact)",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
 					)
@@ -2372,11 +2395,19 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				}
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				failedTask := contributor.currentTask
-				contributor.currentTask = nil
-				contributor.tokenMintedAt = time.Time{}
-				// #2537: clear any pending/delivered credential state with the task.
-				contributor.pendingToken = ""
-				contributor.credentialDelivered = false
+				// SECURITY (audit N9, CWE-862/639): same hole as task_complete —
+				// clear only on a genuine TaskID match. Unconditionally, a failure
+				// naming any other task released the assignment while revokeLease
+				// and recordTaskFailure below stayed inside `if hasTask`, so no
+				// cooldown was booked and the abandoned issue became instantly
+				// re-admissible while the credential stayed live.
+				if hasTask {
+					contributor.currentTask = nil
+					contributor.tokenMintedAt = time.Time{}
+					// #2537: clear any pending/delivered credential state with the task.
+					contributor.pendingToken = ""
+					contributor.credentialDelivered = false
+				}
 				contributor.mu.Unlock()
 
 				if hasTask {

--- a/v2/pkg/dashboard/contribute_ws_sec_n9_test.go
+++ b/v2/pkg/dashboard/contribute_ws_sec_n9_test.go
@@ -1,0 +1,234 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// N9 (CWE-862/639): a task_complete / task_failed carrying the WRONG task_id
+// must not clear the assignment.
+//
+// Both handlers computed `hasTask` from a TaskID equality check and then cleared
+// currentTask, pendingToken, credentialDelivered and tokenMintedAt
+// UNCONDITIONALLY — before the `if hasTask` block — while every protective
+// action (revokeLease, markTaskCompleted / recordTaskFailure, verifyReportedPR)
+// sat INSIDE it. The else branch logged "ignored", which was false: the state
+// had already been mutated.
+//
+// The result: a contributor capped at max_concurrent=1 could send
+// {"type":"task_complete","task_id":"anything-wrong"} to clear its assignment
+// without the lease being revoked or a cooldown booked, go `ready` again, and
+// be minted a SECOND live repo credential. Repeat for N.
+//
+// The Gate (#2568) does not stop this. generationAccepted returns true whenever
+// clientGen == 0, and a client that simply OMITS task_gen gets 0 — so the guard
+// is opt-in from the client side, which is exactly what an attacker chooses.
+//
+// The existing coverage misses it in both directions: contribute_ws_test.go's
+// wrong-id case asserts only profile counters (which the bug does not touch),
+// and contribute_lease_test.go's Gate test always sends a NON-ZERO TaskGen, so
+// it never reaches the TaskGen=0 + wrong-id combination.
+
+// leaseCountFor reports how many leases the hub holds for an identity. The lease
+// map is the server-side accounting the credential cap is enforced from, so it
+// is the thing that must survive a bogus completion.
+func leaseCountFor(h *ContributeWSHub, identity string) int {
+	h.leaseMu.Lock()
+	defer h.leaseMu.Unlock()
+	n := 0
+	for id := range h.leases {
+		if id == identity {
+			n++
+		}
+	}
+	return n
+}
+
+// TestWrongTaskIDCompletionDoesNotClearAssignment is the N9 regression: a
+// completion for a task the contributor does not hold must be a no-op.
+func TestWrongTaskIDCompletionDoesNotClearAssignment(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"n9user"}`
+	req := httptest.NewRequest("POST", "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	setStatusIssues(s, intgIssue(900, "N9 issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+	realTaskID := assign.TaskID
+
+	// Send a completion for a task this contributor was never assigned, with
+	// task_gen OMITTED — the shape the official relay uses, and the shape that
+	// slips past the Gate.
+	conn.WriteJSON(WSMessage{
+		Type:   "task_complete",
+		TaskID: "not-the-assigned-task",
+		Result: "pr_created",
+		PRURL:  "https://github.com/myorg/repo1/pull/1",
+	})
+	time.Sleep(80 * time.Millisecond)
+
+	// The assignment must survive. Before the fix currentTask was nil here, which
+	// is what let the contributor go `ready` and collect a second credential.
+	s.contributeHub.mu.RLock()
+	var held *ContributorConnection
+	for _, c := range s.contributeHub.connections {
+		if c.profile != nil && c.profile.GitHubUsername == "n9user" {
+			held = c
+		}
+	}
+	s.contributeHub.mu.RUnlock()
+	if held == nil {
+		t.Fatal("connection vanished")
+	}
+
+	held.mu.Lock()
+	cur := held.currentTask
+	held.mu.Unlock()
+
+	if cur == nil {
+		t.Fatal("N9: a wrong-task_id completion CLEARED the assignment — the contributor " +
+			"can now go ready and be minted a second concurrent credential under max_concurrent=1")
+	}
+	if cur.TaskID != realTaskID {
+		t.Fatalf("N9: assignment changed to %q, want the original %q", cur.TaskID, realTaskID)
+	}
+
+	// The lease is the server-side accounting the cap is enforced from; a bogus
+	// completion must not release it either.
+	if n := leaseCountFor(s.contributeHub, identityOf(held)); n != 1 {
+		t.Fatalf("N9: lease count is %d after a wrong-id completion, want 1 (the lease must not be released)", n)
+	}
+}
+
+// TestWrongTaskIDFailureDoesNotClearAssignment covers task_failed, which carries
+// the identical hole — and additionally books no failure cooldown, so the
+// abandoned issue becomes instantly re-assignable.
+func TestWrongTaskIDFailureDoesNotClearAssignment(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"n9fail"}`
+	req := httptest.NewRequest("POST", "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	setStatusIssues(s, intgIssue(901, "N9 fail issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+
+	conn.WriteJSON(WSMessage{Type: "task_failed", TaskID: "not-the-assigned-task", Permanent: false})
+	time.Sleep(80 * time.Millisecond)
+
+	s.contributeHub.mu.RLock()
+	var held *ContributorConnection
+	for _, c := range s.contributeHub.connections {
+		if c.profile != nil && c.profile.GitHubUsername == "n9fail" {
+			held = c
+		}
+	}
+	s.contributeHub.mu.RUnlock()
+	if held == nil {
+		t.Fatal("connection vanished")
+	}
+	held.mu.Lock()
+	cur := held.currentTask
+	held.mu.Unlock()
+
+	if cur == nil {
+		t.Fatal("N9: a wrong-task_id task_failed CLEARED the assignment without booking a " +
+			"failure cooldown — the issue is instantly re-admissible and the credential stays live")
+	}
+}
+
+// TestCorrectTaskIDCompletionStillClears is the control: the fix must not break
+// the legitimate path. A matching task_id still clears the assignment and
+// releases the lease.
+func TestCorrectTaskIDCompletionStillClears(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"n9ok"}`
+	req := httptest.NewRequest("POST", "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	setStatusIssues(s, intgIssue(902, "N9 control issue", "someone", nil))
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+
+	conn.WriteJSON(WSMessage{Type: "task_complete", TaskID: assign.TaskID, Result: "pr_created"})
+	time.Sleep(80 * time.Millisecond)
+
+	s.contributeHub.mu.RLock()
+	var held *ContributorConnection
+	for _, c := range s.contributeHub.connections {
+		if c.profile != nil && c.profile.GitHubUsername == "n9ok" {
+			held = c
+		}
+	}
+	s.contributeHub.mu.RUnlock()
+	if held == nil {
+		t.Fatal("connection vanished")
+	}
+	held.mu.Lock()
+	cur := held.currentTask
+	held.mu.Unlock()
+
+	if cur != nil {
+		t.Fatalf("a MATCHING task_complete must still clear the assignment, but currentTask is %q", cur.TaskID)
+	}
+}


### PR DESCRIPTION
Follows #3147 (merged). Closes **N9**, the third of the audit's four mandatory self-hosted fixes.

*(Recreated from #3143, auto-closed when its base branch was deleted on merge.)*

## The bug

`task_complete` and `task_failed` computed `hasTask` from a TaskID equality check, then cleared `currentTask`, `pendingToken`, `credentialDelivered` and `tokenMintedAt` **unconditionally — before** the `if hasTask` block, while every protective action (`revokeLease`, `markTaskCompleted`/`recordTaskFailure`, `verifyReportedPR`) sat *inside* it.

So a completion naming **any other task** released the assignment without revoking the lease or booking a cooldown:

```json
{"type":"task_complete","task_id":"anything-wrong"}
```

→ contributor goes `ready` → minted a **second** live repo credential under `max_concurrent=1`. Repeat for N.

The `else` branch logged `"task_complete for unassigned task ignored"`, which was **false** — the state had already been mutated, so the bypass looked like a no-op in the logs. That message is now literally true.

## Why the Gate didn't catch it

`generationAccepted()` returns `true` whenever `clientGen == 0`, and a client that simply **omits** `task_gen` gets 0. The #2568 Gate is opt-in from the client side — exactly what an attacker chooses. Its stale-generation semantics are preserved unchanged.

## Why the existing tests didn't catch it

Both near-misses, from opposite directions:
- `contribute_ws_test.go`'s wrong-id case asserts only **profile counters**, which the bug never touched — it passed against the vulnerable code.
- `contribute_lease_test.go`'s Gate test always sends a **non-zero** `TaskGen`, so it never reached the `TaskGen=0` + wrong-id combination that is the actual bypass.

## Regression

Drives the real WebSocket end to end and asserts **both** that the assignment survives **and** that the lease — the accounting the credential cap is enforced from — is not released. Verified to fail against the unfixed handler in both handlers. A control leg proves a matching `task_id` still clears.

`tmuxOutput` is still recorded on the mismatch path: it carries no authority and is often the only evidence of what a confused relay was doing.

## Follow-up (not fixed here)

**There is no GitHub token revocation anywhere in this flow.** `revokeLease` only does `delete(h.leases, identity)` — it does not invalidate the credential already in the contributor's hands, so even the *correct* completion path leaves a live token until ~1h natural expiry. This closes the unbounded-concurrency bypass; closing the credential window needs net-new code, worth tracking separately.

## CI note

The `test` job's three failures (`TestNewStore_CreatesGroupWritableDir`, `TestPodmanRunSkippedWhenUnavailable`, `TestHandleLiteEnrollHostedSpokeRequestedWhenNoExistingSpoke`) are **pre-existing on `v4`** — confirmed by a `workflow_dispatch` run against untouched `v4` (run 31407709737), which produced the identical three. This stack modifies no file in `pkg/beads` or `pkg/sandbox`.