### PR TITLE
🔒 Security audit 2026-08-07: N8 — confine api_key_file, close the credentialed-probe exfil

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -1102,6 +1103,97 @@ func (g GovernorConfig) ResolveLiteLLMInferenceKey(backend string) string {
 // ResolveAPIKey returns this gateway's key value, preferring the env var when
 // set and falling back to the file. Returns "" when neither yields a value
 // (a keyless endpoint). Mirrors LiteLLMConfig key resolution.
+// secretFileRoots are the ONLY directories an api_key_file may live under.
+//
+//   - /secrets      — the read-only Kubernetes Secret projection
+//   - /data/secrets — the PVC-backed dir the dashboard writes UI-entered keys to
+//
+// Anything else is refused. See SecretFilePathAllowed.
+//
+// A package var, not a const slice, so tests can point it at a t.TempDir()
+// (production never reassigns it). Use SetSecretFileRootsForTest.
+var secretFileRoots = []string{"/secrets", WritableSecretsDir}
+
+// SetSecretFileRootsForTest overrides the allowed secret-file roots and returns
+// a function restoring the previous value. Intended for tests, which must write
+// key files into a t.TempDir() rather than the real /secrets.
+//
+// This is not a security hole: it is compiled into the binary but never called
+// outside tests, and anyone able to call it already has in-process code
+// execution — at which point they can read the files directly.
+func SetSecretFileRootsForTest(roots ...string) func() {
+	prev := secretFileRoots
+	secretFileRoots = roots
+	return func() { secretFileRoots = prev }
+}
+
+// AllowSecretFileRoot registers an ADDITIONAL directory whose files may be read
+// as a secret, returning a function that removes it again.
+//
+// This exists so a component that WRITES key files keeps its write location and
+// this package's READ gate in lockstep. pkg/dashboard writes per-gateway keys to
+// its own gatewaySecretsDir — a package var tests repoint at a temp dir — and
+// without this the two seams disagree: the dashboard writes a key it can then
+// never read back. Callers register the same directory they write to, so the
+// gate stays a real confinement rather than something each test disables.
+func AllowSecretFileRoot(dir string) func() {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return func() {}
+	}
+	prev := secretFileRoots
+	secretFileRoots = append(append([]string(nil), secretFileRoots...), dir)
+	return func() { secretFileRoots = prev }
+}
+
+// SecretFilePathAllowed reports whether p is a path hive may read a secret from.
+//
+// SECURITY (audit N8, CWE-200/918): api_key_file is attacker-controllable — the
+// gateway upsert stores whatever absolute path it is given, and the save-time
+// probe then reads that file and ships its contents to the gateway endpoint as
+// an `Authorization: Bearer` header. Without confinement that is an arbitrary
+// file read wired directly to an arbitrary outbound request: /data/secrets/*.pem
+// (the GitHub App key), /proc/self/environ, token caches.
+//
+// The check is a prefix test against secretFileRoots, applied AFTER resolving
+// symlinks, so a symlink inside an allowed directory cannot point out of it. A
+// path that does not exist yet is still validated lexically — the dashboard
+// legitimately writes a key file before anything reads it.
+func SecretFilePathAllowed(p string) bool {
+	p = strings.TrimSpace(p)
+	if p == "" || !filepath.IsAbs(p) {
+		return false
+	}
+	clean := filepath.Clean(p)
+	// Resolve symlinks when the path (or its parent) exists, so a link planted
+	// inside an allowed root cannot escape it. EvalSymlinks fails on a
+	// not-yet-created file, in which case the lexical check below still applies.
+	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
+		clean = resolved
+	} else if resolvedDir, err := filepath.EvalSymlinks(filepath.Dir(clean)); err == nil {
+		clean = filepath.Join(resolvedDir, filepath.Base(clean))
+	}
+	for _, root := range secretFileRoots {
+		rootClean := filepath.Clean(root)
+		// Resolve the ROOT too. On macOS /var is a symlink to /private/var, so a
+		// resolved path under a temp dir would never prefix-match an unresolved
+		// root — the comparison has to be symlink-resolved on both sides or it
+		// is inconsistent.
+		if resolvedRoot, err := filepath.EvalSymlinks(rootClean); err == nil {
+			rootClean = resolvedRoot
+		}
+		if clean == rootClean {
+			continue // the directory itself is not a key file
+		}
+		// The separator suffix keeps "/data/secrets-evil" from matching the
+		// "/data/secrets" root.
+		if strings.HasPrefix(clean, rootClean+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 func (gw GatewayConfig) ResolveAPIKey() string {
 	if gw.APIKeyEnv != "" {
 		if v := os.Getenv(gw.APIKeyEnv); v != "" {
@@ -1109,6 +1201,13 @@ func (gw GatewayConfig) ResolveAPIKey() string {
 		}
 	}
 	if gw.APIKeyFile != "" {
+		// SECURITY (audit N8): confine the read to the managed secrets dirs. This
+		// gate lives HERE, not only in the HTTP handler, so every caller is
+		// covered — including a path that reached hive.yaml some other way (a
+		// hand-edited config, an older build, a restored backup).
+		if !SecretFilePathAllowed(gw.APIKeyFile) {
+			return ""
+		}
 		if b, err := os.ReadFile(gw.APIKeyFile); err == nil {
 			return strings.TrimSpace(string(b))
 		}
@@ -1280,7 +1379,9 @@ type InferenceAuthConfig struct {
 // api_key_env → defaultEnv. Returns "" when no key is configured. The key
 // value itself is never stored in hive.yaml.
 func (c *InferenceAuthConfig) ResolveAPIKey(defaultEnv string) string {
-	if c.APIKeyFile != "" {
+	// SECURITY (audit N8): same confinement as GatewayConfig.ResolveAPIKey — an
+	// api_key_file is only ever read from the managed secrets dirs.
+	if c.APIKeyFile != "" && SecretFilePathAllowed(c.APIKeyFile) {
 		if data, err := os.ReadFile(c.APIKeyFile); err == nil {
 			if key := strings.TrimSpace(string(data)); key != "" {
 				return key
@@ -1581,6 +1682,12 @@ func (c *LiteLLMConfig) resolveAPIKeyWithSource() (string, string) {
 			continue
 		}
 		seen[f] = true
+		// SECURITY (audit N8): only the managed secrets dirs. The two defaults
+		// appended above already satisfy this; the gate is for c.APIKeyFile,
+		// which is operator/API-supplied.
+		if !SecretFilePathAllowed(f) {
+			continue
+		}
 		if data, err := os.ReadFile(f); err == nil {
 			if key := strings.TrimSpace(string(data)); key != "" {
 				return key, "file:" + f

--- a/v2/pkg/config/config_uncovered_coverage_test.go
+++ b/v2/pkg/config/config_uncovered_coverage_test.go
@@ -124,6 +124,9 @@ func TestGatewayConfig_ResolveAPIKey(t *testing.T) {
 
 	t.Run("from file when env unset", func(t *testing.T) {
 		dir := t.TempDir()
+		// N8: api_key_file reads are confined to the managed secrets dirs, so a
+		// test using a temp dir must declare it as an allowed root.
+		defer SetSecretFileRootsForTest(dir)()
 		keyPath := filepath.Join(dir, "key.txt")
 		if err := os.WriteFile(keyPath, []byte("  file-key-value  \n"), 0o600); err != nil {
 			t.Fatal(err)
@@ -167,6 +170,8 @@ func TestGatewayConfig_ResolveAPIKey(t *testing.T) {
 func TestInferenceAuthConfig_ResolveAPIKey(t *testing.T) {
 	t.Run("from file", func(t *testing.T) {
 		dir := t.TempDir()
+		// N8: key-file reads are confined to the managed secrets dirs.
+		defer SetSecretFileRootsForTest(dir)()
 		keyPath := filepath.Join(dir, "key.txt")
 		os.WriteFile(keyPath, []byte("file-key"), 0o600)
 		c := &InferenceAuthConfig{APIKeyFile: keyPath}
@@ -217,6 +222,8 @@ func TestInferenceAuthConfig_ResolveAPIKey(t *testing.T) {
 func TestLiteLLMConfig_ResolveAPIKeySource(t *testing.T) {
 	t.Run("from configured file", func(t *testing.T) {
 		dir := t.TempDir()
+		// N8: key-file reads are confined to the managed secrets dirs.
+		defer SetSecretFileRootsForTest(dir)()
 		keyPath := filepath.Join(dir, "key.txt")
 		os.WriteFile(keyPath, []byte("secretvalue"), 0o600)
 		c := &LiteLLMConfig{APIKeyFile: keyPath}

--- a/v2/pkg/config/gateways_test.go
+++ b/v2/pkg/config/gateways_test.go
@@ -15,6 +15,9 @@ import (
 // while entitlement validated the fresh gateway key, causing inference 401s.
 func TestResolveLiteLLMInferenceKeyMatchesEntitlement(t *testing.T) {
 	dir := t.TempDir()
+	// N8: api_key_file reads are confined to the managed secrets dirs; declare
+	// this test's temp dir as an allowed root.
+	defer SetSecretFileRootsForTest(dir)()
 	// Key A: the fresh key saved via the Gateways tab (the gateway's file).
 	gatewayKeyFile := filepath.Join(dir, "gateway_litellm_api_key")
 	if err := os.WriteFile(gatewayKeyFile, []byte("sk-gateway-FRESH\n"), 0o600); err != nil {
@@ -62,6 +65,9 @@ func TestResolveLiteLLMInferenceKeyMatchesEntitlement(t *testing.T) {
 // must not change behavior for these hives.
 func TestResolveLiteLLMInferenceKeyLegacyFallback(t *testing.T) {
 	dir := t.TempDir()
+	// N8: api_key_file reads are confined to the managed secrets dirs; declare
+	// this test's temp dir as an allowed root.
+	defer SetSecretFileRootsForTest(dir)()
 	legacyKeyFile := filepath.Join(dir, "litellm_api_key")
 	if err := os.WriteFile(legacyKeyFile, []byte("sk-legacy-ONLY\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/v2/pkg/config/litellm_test.go
+++ b/v2/pkg/config/litellm_test.go
@@ -12,6 +12,9 @@ import (
 
 func TestLiteLLMResolveAPIKey_FromFile(t *testing.T) {
 	dir := t.TempDir()
+	// N8: api_key_file reads are confined to the managed secrets dirs; declare
+	// this test's temp dir as an allowed root.
+	defer SetSecretFileRootsForTest(dir)()
 	keyPath := filepath.Join(dir, "litellm_api_key")
 	if err := os.WriteFile(keyPath, []byte("sk-file-key\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/v2/pkg/config/secret_path_test.go
+++ b/v2/pkg/config/secret_path_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// N8 (CWE-200/918): api_key_file must be confined to the managed secrets dirs.
+//
+// The gateway upsert stores whatever absolute path it is handed, and the
+// save-time probe then reads that file and ships its contents to the gateway
+// endpoint as an `Authorization: Bearer` header. Unconfined, that is an
+// arbitrary file read wired to an arbitrary outbound request — the GitHub App
+// private key under /data/secrets, /proc/self/environ, App token caches.
+//
+// The gate lives in ResolveAPIKey rather than only in the HTTP handler, so a
+// path that reached hive.yaml some other way (hand-edited config, older build,
+// restored backup) is also refused.
+
+func TestSecretFilePathAllowed(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// The two legitimate roots.
+		{"read-only secret mount", "/secrets/litellm_api_key", true},
+		{"writable PVC secrets dir", "/data/secrets/gateway_openrouter_api_key", true},
+		{"nested under an allowed root", "/data/secrets/sub/key", true},
+
+		// The exfiltration targets the audit reproduced.
+		{"github app private key outside the roots", "/data/gh-app-key.pem", false},
+		{"proc environ", "/proc/self/environ", false},
+		{"app token cache", "/var/run/hive-metrics/gh-app-token.cache", false},
+		{"etc shadow", "/etc/shadow", false},
+		{"ssh key", "/root/.ssh/id_rsa", false},
+
+		// Traversal and prefix tricks.
+		{"traversal out of an allowed root", "/data/secrets/../gh-app-key.pem", false},
+		{"deep traversal", "/secrets/../../etc/shadow", false},
+		{"sibling dir sharing a name prefix", "/data/secrets-evil/key", false},
+		{"prefix of a root without separator", "/data/secretsevil", false},
+
+		// Shape requirements.
+		{"relative path", "data/secrets/key", false},
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+		{"the root directory itself is not a key file", "/secrets", false},
+		{"the writable root itself is not a key file", "/data/secrets", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SecretFilePathAllowed(tc.path); got != tc.want {
+				t.Errorf("SecretFilePathAllowed(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSecretFilePathSymlinkEscape covers the bypass a purely lexical check would
+// miss: a symlink INSIDE an allowed root pointing out of it. The check resolves
+// symlinks before the prefix test, so the link's target is what is judged.
+func TestSecretFilePathSymlinkEscape(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "stolen.pem")
+	if err := os.WriteFile(target, []byte("-----BEGIN PRIVATE KEY-----"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	// Point the allowed root at a temp dir so the test does not need /data.
+	realRoots := secretFileRoots
+	root := filepath.Join(tmp, "secrets")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	secretFileRoots = []string{root}
+	defer func() { secretFileRoots = realRoots }()
+
+	// A regular file inside the root is fine.
+	inside := filepath.Join(root, "ok_key")
+	if err := os.WriteFile(inside, []byte("k"), 0o600); err != nil {
+		t.Fatalf("seed inside: %v", err)
+	}
+	if !SecretFilePathAllowed(inside) {
+		t.Error("a real file inside the allowed root should be permitted")
+	}
+
+	// A symlink inside the root pointing OUT of it must be refused.
+	link := filepath.Join(root, "escape")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if SecretFilePathAllowed(link) {
+		t.Error("a symlink inside the allowed root that resolves OUTSIDE it must be refused — " +
+			"otherwise the confinement is bypassed by planting one link")
+	}
+}
+
+// TestResolveAPIKeyRefusesUnconfinedFile is the end-to-end assertion that
+// matters: the exfiltration primitive is ResolveAPIKey returning file contents
+// the caller then sends upstream. An out-of-root path must resolve to "" so the
+// probe carries no credential at all.
+func TestResolveAPIKeyRefusesUnconfinedFile(t *testing.T) {
+	tmp := t.TempDir()
+	secret := filepath.Join(tmp, "app-key.pem")
+	if err := os.WriteFile(secret, []byte("SUPER-SECRET-KEY"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	gw := GatewayConfig{Name: "evil", Endpoint: "http://attacker.example", APIKeyFile: secret}
+	if got := gw.ResolveAPIKey(); got != "" {
+		t.Fatalf("ResolveAPIKey read an out-of-root file and returned %q — this is the N8 "+
+			"exfiltration primitive: the save-time probe ships it to the attacker's endpoint "+
+			"as an Authorization: Bearer header", got)
+	}
+
+	// Control: a file inside an allowed root still resolves, or the fix would
+	// have broken every legitimate gateway.
+	realRoots := secretFileRoots
+	root := filepath.Join(tmp, "secrets")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	secretFileRoots = []string{root}
+	defer func() { secretFileRoots = realRoots }()
+
+	good := filepath.Join(root, "gateway_key")
+	if err := os.WriteFile(good, []byte("  legit-key\n"), 0o600); err != nil {
+		t.Fatalf("seed good: %v", err)
+	}
+	gw2 := GatewayConfig{Name: "ok", APIKeyFile: good}
+	if got := gw2.ResolveAPIKey(); got != "legit-key" {
+		t.Fatalf("ResolveAPIKey(confined file) = %q, want the trimmed key — the fix must not "+
+			"break legitimate gateways", got)
+	}
+}

--- a/v2/pkg/config/watsonx_gateway_test.go
+++ b/v2/pkg/config/watsonx_gateway_test.go
@@ -14,6 +14,9 @@ import (
 // any other gateway. project_id/region are plain (non-secret) inline fields.
 func TestWatsonxGatewayParse(t *testing.T) {
 	dir := t.TempDir()
+	// N8: api_key_file reads are confined to the managed secrets dirs; declare
+	// this test's temp dir as an allowed root.
+	defer SetSecretFileRootsForTest(dir)()
 	keyFile := filepath.Join(dir, "wx_api_key")
 	if err := os.WriteFile(keyFile, []byte("ibm-cloud-key-VALUE\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4788,6 +4788,15 @@ func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
 				http.StatusBadRequest)
 			return
 		}
+		// SECURITY (audit N8, CWE-200/918): the same confinement the gateway
+		// upsert applies. This is the LiteLLM twin of that handler and carries
+		// the identical defect — the guardrail above short-circuits for ANY
+		// absolute path, so an arbitrary file could be stored and later read.
+		if keyFile != "" && !config.SecretFilePathAllowed(keyFile) {
+			jsonError(w, "api_key_file must be under /secrets or "+config.WritableSecretsDir,
+				http.StatusBadRequest)
+			return
+		}
 		lc.APIKeyFile = keyFile
 	}
 	if body.DefaultModel != nil {

--- a/v2/pkg/dashboard/gateway_onboarding_test.go
+++ b/v2/pkg/dashboard/gateway_onboarding_test.go
@@ -17,7 +17,12 @@ import (
 // path, mirroring how the server records keys (api_key_file, never inline).
 func writeTempKeyFile(t *testing.T, key string) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "gateway_api_key")
+	dir := t.TempDir()
+	// N8: api_key_file reads are confined to the managed secrets dirs, so this
+	// temp dir has to be registered as an allowed root for the duration of the
+	// test — otherwise ResolveAPIKey correctly refuses to read it.
+	t.Cleanup(config.AllowSecretFileRoot(dir))
+	path := filepath.Join(dir, "gateway_api_key")
 	if err := os.WriteFile(path, []byte(key), 0o600); err != nil {
 		t.Fatalf("writing key file: %v", err)
 	}

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -227,6 +227,19 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 			jsonError(w, "this looks like an API key — send it as api_key instead; api_key_file takes a file PATH", http.StatusBadRequest)
 			return
 		}
+		// SECURITY (audit N8, CWE-200/918): reject an out-of-root path at the
+		// door with a clear 400, rather than storing it and letting it resolve
+		// to "" later (which would look like a mysteriously broken gateway).
+		//
+		// Note the guardrail ABOVE only fires for a RELATIVE key-looking string —
+		// `!strings.HasPrefix(keyFile, "/")` short-circuits it for every absolute
+		// path, which is precisely why any absolute path used to be accepted and
+		// stored verbatim. ResolveAPIKey enforces the same confinement at read
+		// time for paths that reach hive.yaml by other routes.
+		if keyFile != "" && !config.SecretFilePathAllowed(keyFile) {
+			jsonError(w, "api_key_file must be under /secrets or "+config.WritableSecretsDir, http.StatusBadRequest)
+			return
+		}
 	}
 
 	cfg := s.deps.Config
@@ -531,6 +544,24 @@ func validateGatewayEndpoint(endpoint string) error {
 // key so it survives pod restarts and hosted users can set keys without cluster
 // access.
 var gatewaySecretsDir = config.WritableSecretsDir
+
+// setGatewaySecretsDirForTest repoints where gateway key VALUES are written AND
+// registers that directory with config's secret-file read gate (audit N8), then
+// returns a restore func.
+//
+// The two must move together. The read gate confines api_key_file to the managed
+// secrets dirs; a test that repoints only the write var would store a key it can
+// never read back, and "just disable the gate in tests" would mean the
+// confinement is never actually exercised.
+func setGatewaySecretsDirForTest(dir string) func() {
+	prevDir := gatewaySecretsDir
+	gatewaySecretsDir = dir
+	restoreRoot := config.AllowSecretFileRoot(dir)
+	return func() {
+		restoreRoot()
+		gatewaySecretsDir = prevDir
+	}
+}
 
 // storeGatewayAPIKey writes a gateway's key VALUE to an owner-only file on the
 // PVC and returns the file PATH to record in hive.yaml (api_key_file). The key

--- a/v2/pkg/dashboard/gateways_coverage_test.go
+++ b/v2/pkg/dashboard/gateways_coverage_test.go
@@ -27,9 +27,8 @@ func TestCovD_GatewaysUpsert(t *testing.T) {
 
 	// Point the secret store at a temp dir so a submitted key VALUE can be
 	// stored without touching the real PVC path.
-	oldDir := gatewaySecretsDir
-	gatewaySecretsDir = t.TempDir()
-	defer func() { gatewaySecretsDir = oldDir }()
+	// N8: repoint the write dir AND register it with the read gate together.
+	defer setGatewaySecretsDirForTest(t.TempDir())()
 
 	// success: create a new custom gateway with a key value.
 	rec := doPut(s, "/api/config/governor/gateways", map[string]interface{}{
@@ -219,9 +218,8 @@ func TestCovD_GatewayHelpers(t *testing.T) {
 
 	// storeGatewayAPIKey writes an owner-only file and returns its path.
 	dir := t.TempDir()
-	oldDir := gatewaySecretsDir
-	gatewaySecretsDir = dir
-	defer func() { gatewaySecretsDir = oldDir }()
+	// N8: repoint the write dir AND register it with the read gate together.
+	defer setGatewaySecretsDirForTest(dir)()
 	path, err := s.storeGatewayAPIKey("MyGW", "sk-value")
 	if err != nil {
 		t.Fatalf("storeGatewayAPIKey: %v", err)

--- a/v2/pkg/dashboard/openrouter_more_coverage_test.go
+++ b/v2/pkg/dashboard/openrouter_more_coverage_test.go
@@ -20,9 +20,8 @@ func covK2ORServer(t *testing.T) *Server {
 // upsertOpenRouterGateway / ApplyDeliveredGateway success paths) can write.
 func covK2RedirectSecrets(t *testing.T) {
 	t.Helper()
-	orig := gatewaySecretsDir
-	gatewaySecretsDir = t.TempDir()
-	t.Cleanup(func() { gatewaySecretsDir = orig })
+	// N8: repoint the write dir AND register it with the read gate together.
+	t.Cleanup(setGatewaySecretsDirForTest(t.TempDir()))
 }
 
 func TestCovK2_UpsertOpenRouterGateway(t *testing.T) {


### PR DESCRIPTION
Follows #3155 (merged). Closes **N8** — the last code fix in the audit's §7.1. With this, all four mandatory self-hosted items are done (the fourth, "keep autonomy ≤ ACMM L5", is policy, not code).

*(Recreated from #3151, auto-closed when its base branch was deleted on merge.)*

## The exfiltration chain

The gateway upsert accepted **any** absolute `api_key_file` path and stored it verbatim. The save-time probe then read that file and shipped its contents to the caller-supplied endpoint as an `Authorization: Bearer` header — an arbitrary file read wired directly to an arbitrary outbound request. Reachable targets in a real pod: the GitHub App private key, `/proc/self/environ`, App token caches.

The existing guardrail could never have stopped it:

```go
!strings.HasPrefix(keyFile, "/") && looksLikeAPIKeyValue(keyFile)
```

The absolute-path clause **short-circuits for every absolute path** — the check only ever fired for a *relative* key-looking string. It was a UX guardrail (stop a user pasting a key into a path field), never a confinement.

## The fix

`config.SecretFilePathAllowed` confines reads to `/secrets` (read-only Secret projection) and `/data/secrets` (writable PVC dir), enforced in **`ResolveAPIKey`** — not only in the HTTP handler — so a path that reached `hive.yaml` by another route (hand-edited config, older build, restored backup) is refused too. Applied to all three readers: `GatewayConfig`, `InferenceAuthConfig`, `LiteLLMConfig`. The handler additionally rejects an out-of-root path up front with a 400, rather than storing it and having it silently resolve to `""` later.

Symlinks are resolved on **both** the path and the roots before the prefix test — so a link planted inside an allowed root cannot escape, and the comparison stays consistent on macOS where `/var` is itself a symlink to `/private/var`.

The same short-circuit existed in the LiteLLM twin handler; fixed there too.

## A note on the test seam

The read gate and the dashboard's **write** location must stay in lockstep. `setGatewaySecretsDirForTest` repoints `gatewaySecretsDir` *and* registers that directory with the read gate in one call. Without pairing them a test stores a key it can never read back — and "just disable the gate in tests" would mean the confinement is never actually exercised.

## Deliberately not included: endpoint SSRF blocking

In-cluster gateways are legitimate and shipped — the provisioning template injects `HIVE_VLLM_ENDPOINT` into hosted spokes, and `vllm`/`llm-d`/`litellm` gateway kinds routinely point at `*.svc.cluster.local` (ClusterIP in 10.0.0.0/8) or a `127.0.0.1` sidecar. A blanket private-address deny would 400 those at save time.

Note #3055 (open, targeting v2) adds exactly that blanket deny; I've left a comment there suggesting either gating on gateway kind or an explicit opt-in, since as written it would break those deployments.

The exploitable primitive is the **credentialed** read, which this PR closes: with no readable key the probe carries no credential, which removes the exfiltration value of an SSRF here regardless.

## Regression

Covers the audit's reproduced targets (App key, `/proc/self/environ`, token cache), traversal, prefix-collision (`/data/secrets-evil` must not match `/data/secrets`), the symlink escape, and a control proving legitimate confined keys still resolve. **Verified to fail against the unconfined `ResolveAPIKey`**, returning the seeded secret.

## CI note

The `test` job's three failures are **pre-existing on `v4`**, now filed as #3162 (a real data race in `requestHostedLiteSpoke`, found while triaging this) and #3163 (beads setgid + sandbox podman). Confirmed by a `workflow_dispatch` run against untouched `v4` (run 31407709737), which produced the identical three. This PR modifies no file in `pkg/beads`, `pkg/sandbox`, or `pkg/hub`.