### PR TITLE
🔒 Security audit 2026-08-07: N15 — owner-only, symlink-safe per-agent /tmp state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ node_modules/
 # Scratch output from extracting index.html's inline <script> bodies for
 # `node --check`. A build artifact of the verification step, never source.
 _inline.js
+
+# Test-run scratch: pkg/agent tests create stub CLI binaries under a
+# randomly-suffixed dir. Generated per run; never part of the tree.
+.hive-agent-stubs-*/

--- a/v2/pkg/agent/agent_state_file_test.go
+++ b/v2/pkg/agent/agent_state_file_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// N15 (CWE-367/732/20): per-agent control state in the pod-shared /tmp must be
+// owner-only and must not follow symlinks.
+//
+// Two files matter, both at paths derived from the agent NAME (guessable):
+//
+//   - /tmp/.hive-mode-<name>       — bin/gh-wrapper.sh takes its enforcement mode
+//     from this file IN PREFERENCE to the trustworthy env var, so planting it
+//     un-gates the victim agent (that half is the N15A fail-closed fix).
+//   - /tmp/.hive-bootstrap-<name>.txt — goose is launched with the contents as
+//     its first instruction, so planting it injects an attacker-chosen prompt
+//     that runs with the victim's credentials at message zero.
+//
+// Both were written with a plain os.WriteFile at 0o644: world-readable, and
+// symlink-following (os.WriteFile passes no O_NOFOLLOW), so a pre-planted link
+// redirected the hive's own write to any file the process could reach.
+//
+// NOTE on scope: an earlier reading of this called the bootstrap path arbitrary
+// CODE execution, on the theory that a nested $(...) inside the file would be
+// expanded because the launch string is run by a shell. That is wrong — POSIX
+// shells expand command substitution once and do not re-scan the result, so the
+// content reaches goose as literal text. The finding is prompt injection, which
+// these file permissions are the correct fix for.
+
+func TestWriteAgentStateFileIsOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".hive-mode-victim")
+
+	if err := writeAgentStateFile(path, []byte("ISSUES_ONLY")); err != nil {
+		t.Fatalf("writeAgentStateFile: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 600 — a group/world-readable control file lets one agent read "+
+			"or (with a writable /tmp) steer another", got)
+	}
+	if b, err := os.ReadFile(path); err != nil || string(b) != "ISSUES_ONLY" {
+		t.Errorf("content = %q err=%v, want ISSUES_ONLY", b, err)
+	}
+}
+
+// TestWriteAgentStateFileTightensExistingMode covers the upgrade path: a file
+// left at 0644 by a previous release must be tightened, not inherited. O_CREATE
+// applies its mode only when creating, so without the explicit Chmod the old
+// permissive mode would survive every rewrite.
+func TestWriteAgentStateFileTightensExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".hive-mode-legacy")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := writeAgentStateFile(path, []byte("ADVISORY")); err != nil {
+		t.Fatalf("writeAgentStateFile: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 600 — a pre-existing 0644 file must be tightened on rewrite", got)
+	}
+}
+
+// TestWriteAgentStateFileRefusesSymlink is the core of N15: a symlink planted at
+// the predictable path must make the write FAIL, not silently redirect it.
+func TestWriteAgentStateFileRefusesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim-target")
+	if err := os.WriteFile(victim, []byte("ORIGINAL"), 0o600); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	link := filepath.Join(dir, ".hive-mode-planted")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	err := writeAgentStateFile(link, []byte("ISSUES_PRS_MERGE"))
+	if err == nil {
+		t.Fatal("writing through a planted symlink SUCCEEDED — O_NOFOLLOW is not in effect; " +
+			"an attacker can redirect the hive's own write to an arbitrary file")
+	}
+
+	// The symlink target must be untouched.
+	b, readErr := os.ReadFile(victim)
+	if readErr != nil {
+		t.Fatalf("read victim: %v", readErr)
+	}
+	if string(b) != "ORIGINAL" {
+		t.Fatalf("symlink target was CLOBBERED (now %q) — the write followed the link", b)
+	}
+}
+
+// TestWriteAgentStateFileOverwritesRegularFile guards against over-correction:
+// these files are legitimately rewritten on every mode change and relaunch, so
+// the hardening must not be O_EXCL.
+func TestWriteAgentStateFileOverwritesRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".hive-mode-rewrite")
+
+	if err := writeAgentStateFile(path, []byte("ISSUES_ONLY")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeAgentStateFile(path, []byte("NO_GITHUB")); err != nil {
+		t.Fatalf("rewrite must succeed (mode changes rewrite this file): %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil || string(b) != "NO_GITHUB" {
+		t.Fatalf("content = %q err=%v, want NO_GITHUB (truncating rewrite)", b, err)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1492,7 +1492,8 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		// written for them. bob used to land here and get a file nothing ever
 		// read; that dead write is gone with the deferral above.
 		promptFile := fmt.Sprintf("/tmp/.hive-bootstrap-%s.txt", agent.Name)
-		if err := os.WriteFile(promptFile, []byte(bootstrapPrompt), 0o644); err != nil {
+		// N15: owner-only + O_NOFOLLOW (see writeAgentStateFile).
+		if err := writeAgentStateFile(promptFile, []byte(bootstrapPrompt)); err != nil {
 			m.logger.Warn("failed to write bootstrap prompt", "name", agent.Name, "error", err)
 		} else if backend == "goose" {
 			launchCmd += fmt.Sprintf(" --text \"$(cat %s)\"", promptFile)
@@ -1504,7 +1505,9 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	// visible to tmux capture-pane (--instructions - uses hidden TUI).
 	if backend == "goose" && bootstrapPrompt == "" {
 		minimalPrompt := fmt.Sprintf("/tmp/.hive-bootstrap-%s.txt", agent.Name)
-		os.WriteFile(minimalPrompt, []byte("You are an AI agent. Wait for instructions from the supervisor."), 0o644)
+		if err := writeAgentStateFile(minimalPrompt, []byte("You are an AI agent. Wait for instructions from the supervisor.")); err != nil {
+			m.logger.Warn("failed to write minimal bootstrap prompt", "name", agent.Name, "error", err)
+		}
 		launchCmd += fmt.Sprintf(" --text \"$(cat %s)\"", minimalPrompt)
 	}
 
@@ -5146,6 +5149,55 @@ func (m *Manager) ClearAllModeOverrides() {
 	}
 }
 
+// agentStateFileMode is owner-only. These files sit in the pod-shared /tmp and
+// carry per-agent CONTROL state — the enforcement mode the gh wrapper reads, and
+// the bootstrap prompt goose is launched with — so anything group- or
+// world-writable lets one agent steer another.
+const agentStateFileMode = 0o600
+
+// writeAgentStateFile writes per-agent control state to a shared-/tmp path
+// without following symlinks.
+//
+// SECURITY (audit N15, CWE-367/732/20). These files were written with a plain
+// os.WriteFile at 0o644, which:
+//
+//   - follows symlinks — os.WriteFile opens O_WRONLY|O_CREATE|O_TRUNC with no
+//     O_NOFOLLOW, so a pre-planted symlink at the (predictable) path redirects
+//     the hive's own write to any file the process can reach; and
+//   - left the result world-readable, and the containing /tmp world-writable,
+//     so any agent UID could replace another agent's file afterwards.
+//
+// Both matter because the path is derived from the agent NAME, which is
+// guessable, and because the readers treat these files as authoritative:
+// bin/gh-wrapper.sh takes its enforcement mode from .hive-mode-<name> in
+// preference to the trustworthy env var, and goose is launched with whatever
+// .hive-bootstrap-<name>.txt contains as its first instruction.
+//
+// O_NOFOLLOW makes a planted symlink fail loudly instead of redirecting the
+// write. The file is deliberately NOT O_EXCL: these are rewritten on every
+// mode change and every relaunch, so failing when the file already exists would
+// break the normal path.
+func writeAgentStateFile(path string, data []byte) error {
+	f, err := os.OpenFile(path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW,
+		agentStateFileMode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// O_CREATE honours the mode only when the file did not already exist, so an
+	// existing 0644 file from a previous release keeps its old mode without
+	// this. Chmod on the path is acceptable here because O_NOFOLLOW above has
+	// already established it is not a symlink.
+	return os.Chmod(path, agentStateFileMode)
+}
+
 // SyncModeFiles rewrites /tmp/.hive-mode-* for all running agents to reflect the given ACMM level.
 func (m *Manager) SyncModeFiles(level int) {
 	m.mu.RLock()
@@ -5165,7 +5217,7 @@ func (m *Manager) SyncModeFiles(level int) {
 			}
 		}
 		modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", name)
-		if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
+		if err := writeAgentStateFile(modeFile, []byte(mode.String())); err != nil {
 			m.logger.Warn("SyncModeFiles: write failed", "file", modeFile, "error", err)
 		}
 	}
@@ -5422,7 +5474,7 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 		vars = append(vars, agentEnvPair{"HIVE_AGENT_MODE", mode.String(), false})
 	}
 	modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", agent.Name)
-	if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
+	if err := writeAgentStateFile(modeFile, []byte(mode.String())); err != nil {
 		m.logger.Warn("agentBootstrapEnv: mode file write failed", "file", modeFile, "error", err)
 	}
 	// Plain proxy URL without userinfo — Claude Code's native binary fails


### PR DESCRIPTION
Follows #3164. This is §7.4 hardening — the four **mandatory** §7.1 fixes are all merged now (#3140, #3147, #3155, #3164).

## The problem

Two per-agent control files live in the pod-shared `/tmp` at paths derived from the agent **name** (guessable), both written with a plain `os.WriteFile` at `0o644`:

| File | Who reads it | Why it's authoritative |
|---|---|---|
| `/tmp/.hive-mode-<name>` | `bin/gh-wrapper.sh` | Takes its enforcement mode from this file **in preference to** the trustworthy env var |
| `/tmp/.hive-bootstrap-<name>.txt` | goose launch | Contents become the agent's first instruction |

`os.WriteFile` opens `O_WRONLY|O_CREATE|O_TRUNC` with **no `O_NOFOLLOW`**, so a pre-planted symlink at the predictable path redirects the hive's own write to any file the process can reach. Combined with a world-writable `/tmp` and world-readable results, one agent UID could steer another — un-gate the victim's `gh` access, or supply the prompt it executes at message zero with its own credentials.

All four write sites now route through `writeAgentStateFile`: `0600`, `O_NOFOLLOW`, plus an explicit `Chmod` so a `0644` file left by a previous release is **tightened** rather than inherited (`O_CREATE` applies its mode only when creating). Deliberately **not** `O_EXCL` — these are rewritten on every mode change and relaunch.

## Scope correction — this is prompt injection, not RCE

I want to be explicit, because I previously characterized this as arbitrary **code** execution and that was wrong.

The theory was that since the goose launch string is run by a shell and contains `--text "$(cat <file>)"`, a nested `$(...)` inside the planted file would execute. **It does not.** POSIX shells expand command substitution once and do not re-scan the result, so the content reaches goose as literal text. Verified three ways:

- nested substitution — `$(touch /tmp/pwned)` inside the file → not executed
- double evaluation — `sh -c "sh -c \"...\""` → not executed
- quote breakout — `safe" ; touch /tmp/pwn ; echo "` → not executed, the substitution result is never re-parsed

The audit's original classification (prompt injection) was correct. That also changes the **fix**: the right answer is file permissions, not the argv restructuring the RCE theory would have implied — argv restructuring would not have addressed the actual attack, which is a planted *prompt*.

## Blast radius

Goose-only for the bootstrap half — `backendDefersStartupKick` routes claude, copilot, gemini and bob down a path that never writes the file. `bob_startup_kick_test.go:194` guards bob; nothing guarded goose. The mode-file half affects every backend.

## Regression

Four tests: the mode, the upgrade path from a pre-existing `0644` file, the symlink refusal (asserting the link **target** is not clobbered), and an over-correction guard proving legitimate rewrites still work. **Three of the four fail against the previous `os.WriteFile` behaviour.**

Also gitignores `.hive-agent-stubs-*/` — `pkg/agent` tests generate stub CLI binaries under a randomly-suffixed directory, which is scratch and should never be committed.

## CI note

`test` job failures on v4 are pre-existing and tracked in #3162 (a real data race in `requestHostedLiteSpoke`) and #3163 (beads setgid + sandbox podman). Separately, `TestDismissInferencePrompts_FixWith` is flaky under full-package load — it drives a real tmux session with `sleep`-based timing and a 10s deadline, and passes in isolation. Unrelated to this change, which touches no tmux path.