### PR TITLE
🔒 Security audit 2026-08-07: N3 — per-hive terminal signing key

### DIFF
--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -66,6 +66,40 @@ func deriveDomainKey(master, info string) string {
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
+// derivePerHiveKey returns a sub-key bound to BOTH a trust domain and a single
+// hive: HMAC-SHA256(master, info || 0x00 || hiveID).
+//
+// SECURITY (audit N1/N3, CWE-321/798). deriveDomainKey above takes a FIXED label,
+// so every spoke in the fleet derives byte-identical keys from the one master.
+// Possession therefore proves "some provisioned spoke" and never "this spoke" —
+// which is the whole of the hosted kill chain: spoke A's key verifies on spoke B,
+// so one hostile tenant can forge terminal grants for any other tenant and beat
+// heartbeats as any victim.
+//
+// Mixing the hive ID into the derivation makes the key per-spoke while keeping
+// every property the fleet-wide scheme had: deterministic in the existing master
+// (no new secret to store, rotate, or escrow), reproducible by the hub on demand,
+// and stable across re-provisioning.
+//
+// The 0x00 separator matters. Plain concatenation is ambiguous — ("hive-terminal",
+// "a|b") and ("hive-terminal|a", "b") would hash identically — and hive IDs are
+// operator-influenced, so an ambiguous encoding is a real (if narrow) collision
+// lane. A NUL byte cannot appear in either input: info strings are compile-time
+// constants and hive IDs are validated by isValidName.
+//
+// Returns "" for an empty master OR an empty hiveID: a keyless or identity-less
+// caller must fail closed rather than silently sharing one key again.
+func derivePerHiveKey(master, info, hiveID string) string {
+	if master == "" || hiveID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(info))
+	mac.Write([]byte{0})
+	mac.Write([]byte(hiveID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
 // The four per-domain accessors below are the ONLY way hub code should obtain
 // signing material. Nothing outside the heartbeat verify path should ever touch
 // s.hubSecret (the master) directly again.
@@ -89,6 +123,23 @@ func (s *HubServer) ssoSigningSeed() string {
 
 func (s *HubServer) impersonateKey() string {
 	return deriveDomainKey(s.hubSecret, infoImpersonateKey)
+}
+
+// provisionTerminalKey returns the PER-HIVE terminal signing key injected into a
+// spoke as HIVE_TERMINAL_KEY (audit N3).
+//
+// The terminal assertion is minted on the spoke (dashboard/session.go) and
+// verified on that same spoke (proxy/server.js), so a symmetric key is the right
+// shape here — unlike the hub session cookie, no other party needs to verify it.
+// What was wrong was that TerminalSigningKey() fell through to HIVE_SESSION_KEY,
+// which is fleet-uniform: an assertion minted with spoke A's key verified on
+// spoke B, so any spoke could forge a shell grant for any user on any tenant.
+//
+// Binding the key to the hive ID closes that without changing the mint/verify
+// code on either side — TerminalSigningKey() and the proxy's mirror already
+// prefer HIVE_TERMINAL_KEY; provisioning simply never set it.
+func provisionTerminalKey(hiveID string) string {
+	return derivePerHiveKey(provisionMasterSecret(), infoTerminalKey, hiveID)
 }
 
 // ssoPublicKeyFromSeed expands a hex Ed25519 seed into the hex-encoded 32-byte

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1734,6 +1734,13 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		"HeartbeatKey": deriveDomainKey(provisionMasterSecret(), infoHeartbeatKey),
 		"SessionKey":   deriveDomainKey(provisionMasterSecret(), infoSessionKey),
 		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
+		// N3: the terminal key is PER-HIVE, not fleet-wide. Without it
+		// TerminalSigningKey() falls through to the fleet-uniform SessionKey
+		// above, so an assertion minted on one spoke verifies on every other —
+		// any tenant could forge a shell grant on any other tenant. The spoke
+		// both mints and verifies this key locally, so symmetric is correct;
+		// only the sharing was wrong.
+		"TerminalKey": provisionTerminalKey(h.ID),
 		// Cluster-aware fields.
 		"DashboardHost":      dashboardHost,
 		"DashboardURL":       dashboardURL,
@@ -2564,6 +2571,16 @@ spec:
         # seed, can). Replaces the earlier symmetric HIVE_SSO_KEY.
         - name: HIVE_SSO_PUBLIC_KEY
           value: "{{.SSOPublicKey}}"
+        # N3 (CWE-862): the terminal signing key is PER-HIVE. This spoke both
+        # mints the assertion (dashboard/session.go, at login) and verifies it
+        # (proxy/server.js, on /terminal), so a symmetric key is the right shape
+        # — but it must not be shared. Without this var TerminalSigningKey()
+        # fell through to HIVE_SESSION_KEY, which is byte-identical fleet-wide,
+        # so an assertion minted here verified on EVERY other tenant's spoke:
+        # one hostile operator could forge a shell grant for an arbitrary user
+        # on an arbitrary hive. Both resolvers already prefer this var.
+        - name: HIVE_TERMINAL_KEY
+          value: "{{.TerminalKey}}"
 {{- if .IsNginxIngress}}
         # HIVE_INGRESS_AUTHZ tells the Node proxy that an nginx ingress
         # auth-proxy sits IN FRONT of this pod and per-hive-authorizes every

--- a/v2/pkg/hub/saas_provision_secretmode_test.go
+++ b/v2/pkg/hub/saas_provision_secretmode_test.go
@@ -51,6 +51,7 @@ func renderManifest(t *testing.T, requiresSCC bool) string {
 		"HeartbeatKey":      "hb",
 		"SessionKey":        "sk",
 		"SSOPublicKey":      "pk",
+		"TerminalKey":       "per-hive-terminal-key",
 		"AuthorizedUsers":   "alice:owner",
 		"IsNginxIngress":    false,
 		"HasInference":      false,

--- a/v2/pkg/hub/terminal_key_per_hive_test.go
+++ b/v2/pkg/hub/terminal_key_per_hive_test.go
@@ -1,0 +1,166 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// N3 (CWE-862): the terminal signing key must be PER-HIVE.
+//
+// The assertion is minted on a spoke (dashboard/session.go, at login) and
+// verified on that same spoke (proxy/server.js, on /terminal), so a symmetric
+// key is architecturally correct — this is NOT the SSO case, where a second
+// party has to verify and therefore the hub must hold a private signer.
+//
+// What was wrong is that TerminalSigningKey() fell through to HIVE_SESSION_KEY,
+// which provisioning derives with a FIXED label from the one hub master and so
+// is byte-identical on every spoke in the fleet. An assertion minted on spoke A
+// therefore verified on spoke B: one hostile tenant operator could read the key
+// out of their own pod env and forge a shell grant for an arbitrary username on
+// an arbitrary hive. The hiveID claim is no obstacle — the forger simply mints
+// with the victim's hive ID.
+
+const n3TestMaster = "test-master-secret-n3"
+
+// TestPerHiveKeysDifferAcrossHives is the core property: two hives provisioned
+// from the SAME master must not receive the same terminal key.
+func TestPerHiveKeysDifferAcrossHives(t *testing.T) {
+	a := derivePerHiveKey(n3TestMaster, infoTerminalKey, "hive-alpha")
+	b := derivePerHiveKey(n3TestMaster, infoTerminalKey, "hive-bravo")
+
+	if a == "" || b == "" {
+		t.Fatal("derivePerHiveKey returned empty for valid inputs")
+	}
+	if a == b {
+		t.Fatal("two hives derived the SAME terminal key — this is exactly N3: " +
+			"an assertion minted on one spoke would verify on the other")
+	}
+	// Deterministic: re-provisioning the same hive must not rotate its key, or
+	// every re-provision would invalidate live terminal sessions.
+	if again := derivePerHiveKey(n3TestMaster, infoTerminalKey, "hive-alpha"); again != a {
+		t.Error("derivation is not deterministic — a re-provision would rotate the key")
+	}
+}
+
+// TestPerHiveKeyDiffersFromFleetKey guards the actual regression: the per-hive
+// key must not coincide with the fleet-wide session key it replaces.
+func TestPerHiveKeyDiffersFromFleetKey(t *testing.T) {
+	fleetSession := deriveDomainKey(n3TestMaster, infoSessionKey)
+	fleetTerminal := deriveDomainKey(n3TestMaster, infoTerminalKey)
+	perHive := derivePerHiveKey(n3TestMaster, infoTerminalKey, "hive-alpha")
+
+	if perHive == fleetSession {
+		t.Error("per-hive terminal key equals the fleet session key — the N3 lane is still open")
+	}
+	if perHive == fleetTerminal {
+		t.Error("per-hive terminal key equals the fleet-wide terminal key — hiveID is not being mixed in")
+	}
+}
+
+// TestPerHiveKeyDomainSeparation proves the key is bound to its trust domain as
+// well as the hive, so a terminal key can never double as a heartbeat bearer.
+func TestPerHiveKeyDomainSeparation(t *testing.T) {
+	term := derivePerHiveKey(n3TestMaster, infoTerminalKey, "hive-alpha")
+	beat := derivePerHiveKey(n3TestMaster, infoHeartbeatKey, "hive-alpha")
+	if term == beat {
+		t.Error("same hive derived identical keys for two different domains")
+	}
+}
+
+// TestPerHiveKeyEncodingIsUnambiguous covers the reason for the 0x00 separator.
+// With plain concatenation ("hive-terminal-v1" + "a|b") and ("hive-terminal-v1|a"
+// + "b") would hash identically. Hive IDs are operator-influenced, so an
+// ambiguous encoding is a real, if narrow, collision lane.
+func TestPerHiveKeyEncodingIsUnambiguous(t *testing.T) {
+	x := derivePerHiveKey(n3TestMaster, "ab", "c")
+	y := derivePerHiveKey(n3TestMaster, "a", "bc")
+	if x == y {
+		t.Error("(info=ab,hive=c) and (info=a,hive=bc) collide — the domain/identity " +
+			"boundary is not encoded unambiguously")
+	}
+}
+
+// TestPerHiveKeyFailsClosed: no master or no hive identity must yield no key,
+// never a shared fallback.
+func TestPerHiveKeyFailsClosed(t *testing.T) {
+	if got := derivePerHiveKey("", infoTerminalKey, "hive-alpha"); got != "" {
+		t.Errorf("empty master derived %q, want \"\" (fail closed)", got)
+	}
+	if got := derivePerHiveKey(n3TestMaster, infoTerminalKey, ""); got != "" {
+		t.Errorf("empty hiveID derived %q, want \"\" — an identity-less caller must not "+
+			"silently fall back to a shared key", got)
+	}
+}
+
+// TestCrossHiveAssertionForgeryFails is the end-to-end statement of N3, driven
+// through the real mint/verify pair.
+//
+// Attacker holds spoke A's terminal key (they operate that tenant) and mints an
+// assertion naming a victim hive and an arbitrary username. Under the old
+// fleet-shared key that assertion verified on the victim's spoke. With per-hive
+// keys it must not.
+func TestCrossHiveAssertionForgeryFails(t *testing.T) {
+	now := time.Now()
+	attackerKey := derivePerHiveKey(n3TestMaster, infoTerminalKey, "attacker-hive")
+	victimKey := derivePerHiveKey(n3TestMaster, infoTerminalKey, "victim-hive")
+
+	// The forger mints for the VICTIM hive — the hiveID claim alone was never
+	// the protection, since an attacker just writes the victim's ID.
+	forged := MintTerminalAssertion(attackerKey, "mallory-not-registered", "owner", "victim-hive", now)
+	if forged == "" {
+		t.Fatal("mint returned empty; test setup is wrong")
+	}
+
+	// The victim spoke verifies with ITS OWN key.
+	if _, _, err := VerifyTerminalAssertion(victimKey, forged, "victim-hive", now); err == nil {
+		t.Fatal("N3: an assertion forged with ANOTHER hive's key verified on the victim hive — " +
+			"a hostile tenant can open a shell as any user on any hive")
+	}
+
+	// Control: the victim's own key still mints assertions that verify, so the
+	// fix does not break legitimate terminal access.
+	legit := MintTerminalAssertion(victimKey, "alice", "owner", "victim-hive", now)
+	user, role, err := VerifyTerminalAssertion(victimKey, legit, "victim-hive", now)
+	if err != nil || user != "alice" || role != "owner" {
+		t.Fatalf("legitimate assertion failed to verify: user=%q role=%q err=%v", user, role, err)
+	}
+}
+
+// TestProvisionTerminalKeyIsPerHive checks the PROVISIONING accessor, not just
+// the derivation primitive. This is the wiring that actually ships the key into
+// the Deployment, and it is where an empty value would silently reintroduce the
+// bug: HIVE_TERMINAL_KEY="" makes TerminalSigningKey() fall straight back to the
+// fleet-wide HIVE_SESSION_KEY, so the manifest would look fixed while the spoke
+// behaved exactly as before.
+func TestProvisionTerminalKeyIsPerHive(t *testing.T) {
+	t.Setenv("HIVE_HUB_SECRET", n3TestMaster)
+
+	a := provisionTerminalKey("hive-alpha")
+	b := provisionTerminalKey("hive-bravo")
+
+	if a == "" {
+		t.Fatal("provisionTerminalKey returned empty — HIVE_TERMINAL_KEY would be unset in the " +
+			"Deployment and TerminalSigningKey() would fall back to the fleet-wide session key")
+	}
+	if a == b {
+		t.Fatal("provisioning derived the same terminal key for two hives")
+	}
+	if a == deriveDomainKey(n3TestMaster, infoSessionKey) {
+		t.Fatal("provisioned terminal key equals the fleet session key")
+	}
+}
+
+// TestFleetSharedKeyWouldHaveForged documents the pre-fix behaviour explicitly,
+// so the test file states what the vulnerability WAS rather than only asserting
+// the fixed state. If this ever stops holding, the shared-key lane is back.
+func TestFleetSharedKeyWouldHaveForged(t *testing.T) {
+	now := time.Now()
+	shared := deriveDomainKey(n3TestMaster, infoSessionKey) // what both spokes used to hold
+
+	forged := MintTerminalAssertion(shared, "mallory", "owner", "victim-hive", now)
+	if _, _, err := VerifyTerminalAssertion(shared, forged, "victim-hive", now); err != nil {
+		t.Skip("shared-key forgery no longer reproduces; mint/verify shape changed")
+	}
+	t.Log("confirmed: under a fleet-shared key, an assertion minted anywhere verifies " +
+		"on the victim hive — this is the lane per-hive keys close")
+}


### PR DESCRIPTION
First of three PRs closing the hosted kill chain (N1/N2/N3 — which are the *prior* audit's C1/C2/C3 under new numbers). Follows the merged §7.1 work (#3140, #3147, #3155, #3164, #3172).

## Root cause, shared by all three findings

`saas_provision.go` derives every spoke key as `deriveDomainKey(provisionMasterSecret(), <fixed label>)`. The label is a compile-time constant and the master is one value, so **every spoke in the fleet gets byte-identical keys**. Possession proves "some provisioned spoke", never "*this* spoke.

## This PR: the terminal key

`TerminalSigningKey()` falls through to `HIVE_SESSION_KEY` when `HIVE_TERMINAL_KEY` is unset — and provisioning never set it. So an assertion minted with spoke A's key **verified on spoke B**: a hostile tenant operator reads the key from their own pod env and forges a shell grant for an arbitrary username on an arbitrary hive. The signed `hiveID` claim is no obstacle; the forger just writes the victim's ID.

## Why this one is NOT asymmetric

Worth being explicit, because "apply the Ed25519 SSO pattern" is the obvious-but-wrong instinct here.

The assertion is minted on a spoke (`dashboard/session.go`, at login) and verified on **that same spoke** (`proxy/server.js`). No second party verifies it, so a symmetric key is architecturally correct — only the *sharing* was wrong. That's the opposite of the SSO and hub-session-cookie cases, where spokes must verify something the hub minted, and the hub therefore has to hold a private signer.

Getting this distinction right matters for the next two PRs:

| Finding | Minted by | Verified by | Correct shape |
|---|---|---|---|
| **N3** (this PR) | the spoke | that same spoke | per-spoke symmetric |
| **N1** heartbeat | the spoke | the hub | per-spoke symmetric + server-side identity binding |
| **N2** session cookie | the hub | hub **and** spokes | asymmetric (Ed25519) |

## The derivation

`derivePerHiveKey(master, info, hiveID)` = `HMAC(master, info ‖ 0x00 ‖ hiveID)`.

- **Deterministic in the existing master** — no new secret to store, rotate, or escrow, and a re-provision doesn't rotate the key out from under live sessions.
- **The `0x00` separator is load-bearing.** Plain concatenation makes `("hive-terminal-v1", "a|b")` and `("hive-terminal-v1|a", "b")` hash identically, and hive IDs are operator-influenced — a narrow but real collision lane. A NUL can appear in neither input (info strings are constants; hive IDs pass `isValidName`).
- **Fails closed on an empty master *or* an empty hiveID** — an identity-less caller must not silently fall back to a shared key.

## No mint/verify code changed

`TerminalSigningKey()` and the proxy's `TERMINAL_SIGNING_KEY` **already** prefer `HIVE_TERMINAL_KEY` (both document the order). This PR activates plumbing that was already in place.

## Compatibility

No dual-verify needed here, because the spoke mints *and* verifies with the same value: a spoke rolling with the old fallback keeps working until it re-provisions, at which point both sides pick up the new key together. That is not true of N1/N2, which cross the hub/spoke boundary — those will ship verify-both / mint-new so the fleet can roll without a flag day (cf. #2773).

## Regression

Proves the actual attack: mint with hive A's key, verify on hive B, must fail. Plus determinism, domain separation, the encoding-ambiguity case, fail-closed inputs, and a control that legitimate same-hive assertions still verify.

`TestProvisionTerminalKeyIsPerHive` covers the wiring specifically — an empty `HIVE_TERMINAL_KEY` would make the manifest *look* fixed while the spoke fell straight back to the fleet key and behaved exactly as before. `TestFleetSharedKeyWouldHaveForged` documents what the vulnerability was, so the file records the lane rather than only asserting the fixed state.

## CI note

`test` job failures on v4 are pre-existing: #3162 (a real data race in `requestHostedLiteSpoke`) and #3163 (beads setgid + sandbox podman). This PR touches neither package.