### PR TITLE
🔒 Security audit 2026-08-07: N1 — bind the heartbeat bearer to the claimed hive

### DIFF
--- a/v2/pkg/hub/heartbeat_identity_test.go
+++ b/v2/pkg/hub/heartbeat_identity_test.go
@@ -1,0 +1,139 @@
+package hub
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// N1 (CWE-200/639/862): the heartbeat bearer must be bound to the claimed hive.
+//
+// The bearer used to be checked against s.heartbeatKey() alone — one fleet-wide
+// value derived from a FIXED label, so every spoke held identical bytes.
+// Possession proved "some provisioned spoke" and nothing more, and the handler
+// then trusted payload.HiveID verbatim. Three key-delivery lanes read off that
+// claimed ID (pending OpenRouter key, legacy pending App config, standing
+// cluster App key), so any spoke could beat as any victim and be handed the
+// victim's key material. The code said so itself: "the handler trusts the
+// body-supplied hive_id (all hives share one bearer)".
+
+func n1Hub(t *testing.T) *HubServer {
+	t.Helper()
+	return &HubServer{logger: slog.Default(), hubSecret: "test-master-secret-n1"}
+}
+
+// TestHeartbeatBearerIsPerHive is the core property: the bearer a spoke is
+// provisioned with authenticates ONLY that hive.
+func TestHeartbeatBearerIsPerHive(t *testing.T) {
+	s := n1Hub(t)
+
+	alphaBearer := s.heartbeatKeyFor("hive-alpha")
+	bravoBearer := s.heartbeatKeyFor("hive-bravo")
+
+	if alphaBearer == "" || bravoBearer == "" {
+		t.Fatal("per-hive bearer derivation returned empty")
+	}
+	if alphaBearer == bravoBearer {
+		t.Fatal("two hives derived the same heartbeat bearer — identity cannot be bound")
+	}
+
+	// Its own hive: accepted.
+	if !s.verifyHeartbeatBearer(alphaBearer, "hive-alpha") {
+		t.Error("a hive's own per-hive bearer was rejected for its own ID")
+	}
+	// Someone else's hive: refused. This is the N1 IDOR.
+	if s.verifyHeartbeatBearer(alphaBearer, "hive-bravo") {
+		t.Fatal("N1: hive-alpha's bearer authenticated a heartbeat CLAIMING to be " +
+			"hive-bravo — the victim's key material would be delivered to the attacker")
+	}
+}
+
+// TestHeartbeatLegacyFleetBearerStillAccepted pins the deliberate rollout
+// compatibility path. Every spoke in the field currently holds the fleet-wide
+// bearer and will keep holding it until the hub re-provisions it; rejecting it
+// outright would break every heartbeat in the fleet at once (the failure mode
+// documented for the v2-hub/v4-spoke split in #2773).
+func TestHeartbeatLegacyFleetBearerStillAccepted(t *testing.T) {
+	s := n1Hub(t)
+	legacy := s.heartbeatKey()
+
+	if !s.verifyHeartbeatBearer(legacy, "hive-alpha") {
+		t.Fatal("legacy fleet bearer rejected — this would break every spoke that has " +
+			"not yet re-provisioned")
+	}
+	// And it is correctly reported as NOT the modern, identity-bound path, so
+	// rollout telemetry can tell an operator when the legacy lane is safe to cut.
+	if s.heartbeatBearerIsPerHive(legacy, "hive-alpha") {
+		t.Error("legacy bearer misreported as per-hive — an operator would remove the " +
+			"compatibility lane while spokes still depend on it")
+	}
+	if !s.heartbeatBearerIsPerHive(s.heartbeatKeyFor("hive-alpha"), "hive-alpha") {
+		t.Error("per-hive bearer not reported as per-hive")
+	}
+}
+
+// TestHeartbeatBearerRejectsGarbage covers the ordinary auth failures, so the
+// dual-accept path cannot be mistaken for accept-anything.
+func TestHeartbeatBearerRejectsGarbage(t *testing.T) {
+	s := n1Hub(t)
+	for _, bad := range []string{"", "not-a-key", strings.Repeat("a", 64)} {
+		if s.verifyHeartbeatBearer(bad, "hive-alpha") {
+			t.Errorf("verifyHeartbeatBearer accepted %q", bad)
+		}
+	}
+}
+
+// TestHeartbeatBearerFailsClosedWithoutIdentity: an empty hive ID must not
+// derive a usable per-hive key. Otherwise every identity-less caller would share
+// one key again — silently recreating the bug.
+func TestHeartbeatBearerFailsClosedWithoutIdentity(t *testing.T) {
+	s := n1Hub(t)
+	if got := s.heartbeatKeyFor(""); got != "" {
+		t.Errorf("empty hiveID derived %q, want \"\"", got)
+	}
+	// With no identity the per-hive branch cannot match, so only the legacy
+	// bearer can authenticate — never an empty or arbitrary string.
+	if s.verifyHeartbeatBearer("anything", "") {
+		t.Error("verifyHeartbeatBearer accepted an arbitrary bearer for an empty hive ID")
+	}
+}
+
+// TestProvisionHeartbeatKeyMatchesHubExpectation is the wiring check: what
+// provisioning stamps into the spoke's Deployment must be exactly what the hub
+// re-derives at verify time. If these ever diverge, every freshly provisioned
+// spoke fails to heartbeat — a rollout-breaking bug that unit-testing the two
+// halves separately would miss.
+func TestProvisionHeartbeatKeyMatchesHubExpectation(t *testing.T) {
+	const master = "test-master-secret-n1"
+	t.Setenv("HIVE_HUB_SECRET", master)
+
+	s := &HubServer{logger: slog.Default(), hubSecret: master}
+	provisioned := provisionHeartbeatKey("hive-alpha")
+	expected := s.heartbeatKeyFor("hive-alpha")
+
+	if provisioned == "" {
+		t.Fatal("provisionHeartbeatKey returned empty — the spoke would get no bearer")
+	}
+	if provisioned != expected {
+		t.Fatalf("provisioning and verification disagree:\n  provisioned = %s\n  hub expects = %s\n"+
+			"every newly provisioned spoke would fail to heartbeat", provisioned, expected)
+	}
+}
+
+// TestNoAdditionalAppKeysInProvisionedManifest covers N1's second half: a spoke
+// must receive ONLY its own App key.
+//
+// Provisioning used to render every OTHER App key in the fleet into each new
+// hive's Secret, so one tenant's pod held other tenants' GitHub App private
+// keys — and with the 0644 projection (N5, fixed in #3140) every agent UID in
+// that pod could read them.
+func TestNoAdditionalAppKeysInProvisionedManifest(t *testing.T) {
+	m := renderManifest(t, false)
+
+	// The per-app-id key entries are named gh-app-key-<appid>.pem. The hive's
+	// OWN key is gh-app-key.pem (no numeric suffix) and must still be there.
+	if strings.Contains(m, "gh-app-key-") {
+		t.Fatal("N1: the rendered manifest still carries per-app-id keys for OTHER Apps — " +
+			"one tenant's pod would hold other tenants' GitHub App private keys")
+	}
+}

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -142,6 +142,69 @@ func provisionTerminalKey(hiveID string) string {
 	return derivePerHiveKey(provisionMasterSecret(), infoTerminalKey, hiveID)
 }
 
+// provisionHeartbeatKey returns the PER-HIVE heartbeat bearer injected into a
+// spoke as HIVE_HEARTBEAT_KEY (audit N1).
+//
+// The spoke presents this to the hub, so unlike the terminal key it crosses the
+// trust boundary — but it is still symmetric, because the hub can re-derive it
+// on demand from the master plus the claimed hive ID. That is precisely what
+// makes the identity binding possible: with a fleet-shared bearer the hub had no
+// way to check that the caller was the hive it claimed to be, which is why
+// handleHeartbeat trusted body-supplied hive_id and three key-delivery lanes
+// became IDOR.
+func provisionHeartbeatKey(hiveID string) string {
+	return derivePerHiveKey(provisionMasterSecret(), infoHeartbeatKey, hiveID)
+}
+
+// heartbeatKeyFor returns the per-hive heartbeat bearer the hub EXPECTS from
+// hiveID. Mirror of provisionHeartbeatKey, resolved against the running hub's
+// own master rather than the provisioning-time lookup.
+func (s *HubServer) heartbeatKeyFor(hiveID string) string {
+	return derivePerHiveKey(s.hubSecret, infoHeartbeatKey, hiveID)
+}
+
+// verifyHeartbeatBearer authenticates a heartbeat and BINDS it to the claimed
+// hive (audit N1).
+//
+// Accepts either:
+//
+//  1. the per-hive bearer for exactly this hiveID — the post-fix path, which
+//     makes the claimed identity self-authenticating; or
+//  2. the legacy fleet-wide bearer — every spoke currently in the field holds
+//     this and will keep holding it until the hub re-provisions it.
+//
+// Lane 2 is a DELIBERATE, TEMPORARY compatibility path and it does NOT bind
+// identity — a spoke presenting the legacy key can still claim any hive_id, so
+// the N1 IDOR remains open for spokes that have not rolled. It exists because a
+// flag-day cutover would break every heartbeat in the fleet simultaneously,
+// which is the failure mode #2773 already documented for the v2-hub/v4-spoke
+// split. Remove it once the fleet has re-provisioned; the callers that consume
+// the identity are hardened independently, so the window is bounded by rollout
+// rather than by trust in the legacy key.
+//
+// Both comparisons are constant-time. Order matters only for the returned
+// telemetry, not for security: a caller holding the legacy key is accepted
+// regardless of which branch runs first.
+func (s *HubServer) verifyHeartbeatBearer(presented, hiveID string) bool {
+	if presented == "" {
+		return false
+	}
+	if perHive := s.heartbeatKeyFor(hiveID); perHive != "" && secureCompareHub(presented, perHive) {
+		return true
+	}
+	// Legacy fleet-wide bearer — accepted during rollout only.
+	return secureCompareHub(presented, s.heartbeatKey())
+}
+
+// heartbeatBearerIsPerHive reports whether the presented bearer is the modern,
+// identity-bound one. Used for rollout telemetry so an operator can see when the
+// fleet has fully migrated and the legacy lane in verifyHeartbeatBearer can be
+// deleted.
+func (s *HubServer) heartbeatBearerIsPerHive(presented, hiveID string) bool {
+	perHive := s.heartbeatKeyFor(hiveID)
+	return perHive != "" && secureCompareHub(presented, perHive)
+}
+
 // ssoPublicKeyFromSeed expands a hex Ed25519 seed into the hex-encoded 32-byte
 // public key. Returns "" if seedHex is not a valid 32-byte seed. Used by both the
 // hub-side public-key accessor and provisioning so the spoke and hub agree on the
@@ -194,6 +257,17 @@ func spokeDomainKey(envVar, info string) string {
 
 // SpokeHeartbeatKey returns the bearer a spoke presents on /api/heartbeat and
 // /api/task-status. Exported for use from the dashboard/heartbeat call sites.
+//
+// N1 note: a hub-provisioned spoke gets HIVE_HEARTBEAT_KEY, which is now the
+// PER-HIVE bearer — no spoke-side change is needed, the value in the env var
+// simply becomes identity-bound at the next re-provision.
+//
+// The HIVE_HUB_SECRET fallback below still derives the FLEET-wide bearer, and
+// deliberately so: it serves self-hosted operators who legitimately hold the
+// master and beat against their own hub, where "any spoke can claim any ID" is
+// not a cross-tenant concern because there is exactly one tenant. The hub keeps
+// accepting that value through verifyHeartbeatBearer's legacy lane. A hosted
+// spoke cannot reach this path — it never receives the master.
 func SpokeHeartbeatKey() string { return spokeDomainKey(EnvHeartbeatKey, infoHeartbeatKey) }
 
 // SpokeSessionKey returns the key a spoke uses to VERIFY the hub-minted

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1694,17 +1694,26 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 			}
 			return strings.Join(lines, "\n")
 		}(),
-		// AdditionalAppKeys delivers the fleet's OTHER App keys at provision time,
-		// each in its own per-app-id Secret entry. Naming is by APP ID, not by
-		// cluster: a key's identity is the App it belongs to, and the spoke selects
-		// by matching its configured app_id (resolveAppKeyFile). Per-cluster naming
-		// would be a lie here — the same PEM is valid on every cluster whose hives
-		// authenticate as that App, and a spoke has no way to know which cluster a
-		// file named for one was meant to serve. The primary key is excluded: it is
-		// already written as gh-app-key.pem above, and duplicating it would let the
-		// two copies drift.
-		"AdditionalAppKeys": provisionAdditionalAppKeys(
-			fleetKeys, resolveProvisionAppID(req.AppID, h, cluster)),
+		// SECURITY (audit N1, CWE-200): a spoke receives ONLY its own App key.
+		//
+		// This used to render every OTHER App key in the fleet into each new
+		// hive's Secret, so one tenant's pod held other tenants' GitHub App
+		// private keys — and with the 0644 projection (N5) every agent UID in
+		// that pod could read them. The stated rationale was pre-positioning a
+		// key for a possible future forge switch.
+		//
+		// That is the SAME argument this codebase already rejected when it
+		// removed the heartbeat's fleet-wide broadcast (see the note above
+		// appKeySyncDecision in cluster_app_key.go): speculative distribution of
+		// private key material is not justified by a migration that may never
+		// happen. When a hive IS re-assigned to a different App, that App's key
+		// is delivered at that moment through the reconcile / pending-identity
+		// lanes, keyed to the hive authoritatively assigned it.
+		//
+		// Kept as an empty list rather than deleting the template block, so a
+		// spoke rolling on an older manifest sees the field disappear cleanly
+		// instead of failing to render.
+		"AdditionalAppKeys": []provisionAppKey{},
 		"CPURequest":            cpuRequest,
 		"CPULimit":              cpuLimit,
 		"MemRequest":            memRequest,
@@ -1731,7 +1740,11 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// C2 follow-up: SSO is asymmetric — the spoke gets only the Ed25519 PUBLIC
 		// key (SSOPublicKey), derived from the same master seed the hub signs with,
 		// so even a hostile spoke operator holding this value cannot mint a token.
-		"HeartbeatKey": deriveDomainKey(provisionMasterSecret(), infoHeartbeatKey),
+		// N1: the heartbeat bearer is PER-HIVE. A fleet-wide bearer proved only
+		// "some provisioned spoke", so the hub had to trust body-supplied
+		// hive_id — and three key-delivery lanes read off that claimed ID.
+		// Binding the bearer to the hive makes the claim self-authenticating.
+		"HeartbeatKey": provisionHeartbeatKey(h.ID),
 		"SessionKey":   deriveDomainKey(provisionMasterSecret(), infoSessionKey),
 		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
 		// N3: the terminal key is PER-HIVE, not fleet-wide. Without it

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1177,12 +1177,18 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// secret — the master never leaves the hub (C2 domain separation). Spokes are
 	// injected only this sub-key, so a spoke operator's bearer can prove
 	// "I am a provisioned spoke" but cannot sign a session/SSO/impersonation value.
+	// The bearer is captured here but VERIFIED below, after the body is parsed:
+	// the per-hive bearer (N1) can only be checked once the claimed hive_id is
+	// known. The legacy fleet-wide key is still accepted during the rollout —
+	// see verifyHeartbeatBearer.
+	presentedBearer := ""
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.heartbeatKey()) {
+		if !strings.HasPrefix(auth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		presentedBearer = strings.TrimPrefix(auth, "Bearer ")
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadBytes))
@@ -1202,15 +1208,34 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "hive_id required", http.StatusBadRequest)
 		return
 	}
+	if !isValidName(payload.HiveID) {
+		http.Error(w, "invalid hive_id", http.StatusBadRequest)
+		return
+	}
+
+	// SECURITY (audit N1, CWE-200/639/862): bind the bearer to the CLAIMED
+	// identity.
+	//
+	// The bearer used to be checked against s.heartbeatKey() alone — one
+	// fleet-wide value derived from a fixed label, so every spoke held the same
+	// bytes. Possession proved "some provisioned spoke" and nothing more, and
+	// payload.HiveID was then trusted verbatim. Three key-delivery lanes read
+	// off that claimed ID (pending OpenRouter key, legacy pending App config,
+	// standing cluster App key), so any spoke could beat as any victim and be
+	// handed the victim's key material.
+	if s.hubSecret != "" {
+		if !s.verifyHeartbeatBearer(presentedBearer, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
 	// Normalize the reported SHA to the canonical short length up front so every
 	// downstream comparison is same-length against the hub's 7-char stored SHAs.
 	// (Spokes now build gitShort with `--short=7`; this covers any that predate
 	// that or report a longer value.)
 	payload.GitHash = shortSHA(payload.GitHash)
-	if !isValidName(payload.HiveID) {
-		http.Error(w, "invalid hive_id", http.StatusBadRequest)
-		return
-	}
+	// (hive_id is validated above, before the bearer check — the per-hive bearer
+	// is derived from it, so it must be well-formed before it can authenticate.)
 	if payload.Org != "" && !isValidName(payload.Org) {
 		http.Error(w, "invalid org name", http.StatusBadRequest)
 		return
@@ -2287,12 +2312,17 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	// Same derived HEARTBEAT sub-key as /api/heartbeat (task-status is the spoke's
 	// other beat channel); the master secret is never accepted here.
+	//
+	// N1: like /api/heartbeat, the bearer is captured here and verified below,
+	// once the claimed hive_id is known — the per-hive bearer is derived from it.
+	presentedBearer := ""
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.heartbeatKey()) {
+		if !strings.HasPrefix(auth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		presentedBearer = strings.TrimPrefix(auth, "Bearer ")
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadBytes))
@@ -2313,6 +2343,17 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	if payload.HiveID == "" {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
+	}
+	if !isValidName(payload.HiveID) {
+		http.Error(w, "invalid hive_id", http.StatusBadRequest)
+		return
+	}
+	// N1: bind the bearer to the claimed hive, same as /api/heartbeat.
+	if s.hubSecret != "" {
+		if !s.verifyHeartbeatBearer(presentedBearer, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
 	}
 	for i, lb := range payload.Leaderboard {
 		payload.Leaderboard[i].GitHubUsername = sanitizeField(lb.GitHubUsername)


### PR DESCRIPTION
**Stacked on #3195** (N3, per-hive terminal key) — it introduces `derivePerHiveKey`, which this PR reuses. Merge #3195 first; this retargets to `v4` automatically.

Second of three PRs closing the hosted kill chain.

## The bug

The bearer was checked against `s.heartbeatKey()` alone — one fleet-wide value derived with a **fixed** label from the single hub master, so every spoke holds identical bytes. Possession proved "some provisioned spoke" and nothing more, and `handleHeartbeat` then trusted `payload.HiveID` verbatim.

The code said so itself:

> *"the handler trusts the body-supplied hive_id (all hives share one bearer)"*

Three key-delivery lanes read off that claimed ID — pending OpenRouter key, legacy pending App config, and the standing cluster App key — so any spoke could beat as any victim and be handed the victim's key material.

## The fix

Derive the bearer **per hive** and verify it against the claimed `hive_id`, so the claim becomes self-authenticating. Applied to **both** heartbeat-authenticated handlers: `/api/heartbeat` and `/api/task-status`.

Note the bearer check necessarily moves *after* body parsing, since the expected bearer is derived from the claimed ID. `hive_id` is validated (`isValidName`) **before** it is used as key material, and the previously-duplicated validation further down is now redundant.

Symmetric is still the right shape here — the hub can re-derive the spoke's bearer on demand from the master plus the hive ID. That is exactly what makes the binding possible, and it's why this is not the Ed25519 case (that's N2, where the hub mints something *spokes* must verify).

## Rollout: verify-both, mint-new

`verifyHeartbeatBearer` accepts the per-hive bearer **or** the legacy fleet-wide one. Every spoke in the field holds the legacy value until the hub re-provisions it, and rejecting it outright would break every heartbeat in the fleet at once — the failure mode #2773 documented for the v2-hub/v4-spoke split.

The legacy lane **does not bind identity** and is explicitly temporary: the N1 IDOR stays open for spokes that have not rolled. `heartbeatBearerIsPerHive` exists so an operator can see when the fleet has fully migrated and the lane can be deleted. That removal is a follow-up PR, gated on rollout rather than on trusting the legacy key.

**Self-hosted is unaffected.** `SpokeHeartbeatKey`'s `HIVE_HUB_SECRET` fallback still derives the fleet bearer, which the legacy lane accepts. "Any spoke can claim any ID" isn't a cross-tenant concern where there's one tenant, and a hosted spoke can't reach that path — it never receives the master.

## Second half: no more fleet App keys per spoke

Provisioning rendered every **other** App key in the fleet into each new hive's Secret. One tenant's pod held other tenants' GitHub App private keys — and with the 0644 projection (N5, fixed in #3140) every agent UID in that pod could read them.

The stated rationale was pre-positioning a key for a possible forge switch. That is the **same argument this codebase already rejected** when it removed the heartbeat's fleet-wide broadcast — from the note above `appKeySyncDecision`:

> *"did not justify broadcasting private key material: when a hive is actually re-assigned to a different App, that App's key is delivered at that time through the reconcile/pending-identity lanes, keyed to the hive that is authoritatively assigned it — not speculatively pushed to every spoke."*

The provisioning lane is the same speculative push, so it goes. I checked first that this doesn't break forge switching: re-assignment delivers the key through the reconcile lanes at the time it happens.

## Regression

A hive's own bearer authenticates only its own ID; another hive's bearer is refused for it; the legacy bearer is still accepted but correctly reported as *not* per-hive; garbage and identity-less inputs fail closed.

`TestProvisionHeartbeatKeyMatchesHubExpectation` pins provisioning against hub verification — if those two derivations ever diverge, every newly provisioned spoke silently fails to heartbeat, which unit-testing the two halves separately would miss entirely.

Verified: removing the per-hive branch (i.e. reverting to legacy-only) makes `TestHeartbeatBearerIsPerHive` fail.