### PR TITLE
🐛 Fix data race in async hive provisioning

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2909,9 +2909,13 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	user.Hives[hiveID] = "owner"
 	saveSaaSUser(user)
 
+	provisionHiveRecord := *h
+	provisionHiveRecord.Repos = append([]string(nil), h.Repos...)
+	provisionReq := req
 	provisionWG.Add(1)
 	go func() {
 		defer provisionWG.Done()
+		h := &provisionHiveRecord
 		cluster := s.clusterForHive(h)
 		if cluster == nil {
 			h.Status = "error"
@@ -2920,7 +2924,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("no cluster config for provisioning", "hive_id", hiveID, "cluster_id", h.ClusterID)
 			return
 		}
-		if err := provisionHive(h, &req, cluster, s.appKeysByAppID(), s.logger); err != nil {
+		if err := provisionHive(h, &provisionReq, cluster, s.appKeysByAppID(), s.logger); err != nil {
 			h.Status = "error"
 			h.Error = err.Error()
 			saveSaaSHive(h)


### PR DESCRIPTION
Fixes #3162

Root cause: the hosted hive creation handler passed the same `SaaSHive` pointer to the provisioning goroutine that the handler still owned while preparing its response. The goroutine can update `Status`/`Error` and persist the record concurrently.

Fix: snapshot the hive metadata and request before starting async provisioning, then let the goroutine mutate and save only its private copy.