### PR TITLE
fix(beads,sandbox): deterministic setgid + podman-unavailable tests

### DIFF
--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -127,7 +127,13 @@ func NewStore(dir string) (*Store, error) {
 	// UIDs (2001+) sharing only the node group — the dir must be group-writable
 	// with setgid, and MkdirAll's mode is clipped by the umask, so set it
 	// explicitly. Best-effort: an already-correct or foreign-owned dir is fine.
-	_ = os.Chmod(dir, 0o2770)
+	//
+	// NOTE the constant: os.Chmod takes an os.FileMode, where setgid is
+	// os.ModeSetgid (1<<29) and NOT the Unix octal 0o2000. Passing 0o2770 here
+	// silently requests plain 0770 — the setgid bit is dropped before the
+	// syscall, with no error — which is why the dir came out drwxrwx--- and the
+	// regression test caught it only on Linux (where the assertion is guarded).
+	_ = os.Chmod(dir, 0o770|os.ModeSetgid)
 
 	s := &Store{
 		dir:   dir,

--- a/v2/pkg/beads/beads_perms_test.go
+++ b/v2/pkg/beads/beads_perms_test.go
@@ -41,7 +41,14 @@ func TestNewStore_CreatesGroupWritableDir(t *testing.T) {
 	if mode := fi.Mode().Perm(); mode != 0o770 {
 		t.Errorf("dir mode = %o, want 770", mode)
 	}
-	if runtime.GOOS == "linux" && fi.Mode()&os.ModeSetgid == 0 {
+	// Deliberately NOT guarded on runtime.GOOS: setgid is set through the
+	// portable os.ModeSetgid, which macOS honours too. The old linux-only guard
+	// is exactly why the underlying bug survived — os.Chmod(dir, 0o2770) drops
+	// setgid before the syscall (os.FileMode expects os.ModeSetgid, not the Unix
+	// octal 0o2000), so the dir came out plain 0770 everywhere, but only Linux
+	// CI ever asserted it. Keeping this cross-platform means a dev machine
+	// catches the next regression instead of shipping it to CI.
+	if fi.Mode()&os.ModeSetgid == 0 {
 		t.Errorf("dir mode %v lacks setgid bit", fi.Mode())
 	}
 

--- a/v2/pkg/sandbox/sandbox_test.go
+++ b/v2/pkg/sandbox/sandbox_test.go
@@ -49,7 +49,44 @@ func TestPodmanArgsHonorsRestrictedNetworkMode(t *testing.T) {
 	}
 }
 
+// TestPodmanRunSkippedWhenUnavailable asserts the behavior the name promises:
+// Run must fail fast with a clear error (never hang or panic) when its podman
+// binary can't be found, instead of depending on whichever binary happens to
+// be on the host PATH. exec.LookPath("podman") is true on some CI runner
+// images and false on others (and on developer machines), so gating this on
+// the real Available()/PATH made the test's outcome depend on the
+// environment rather than on the code under test — it silently switched from
+// exercising the "unavailable" path (skip) to actually shelling out to a real
+// podman daemon, which then failed for unrelated reasons (no rootless
+// subuid/subgid mapping, network egress restrictions, etc.) on CI runners
+// that happen to ship podman.
+//
+// Using PodmanLauncher.Binary to point at a name that cannot exist on PATH
+// makes the "podman unavailable" branch deterministic on every OS/runner,
+// while still exercising the exact code path (the exec.LookPath check inside
+// Run) that Available() is a thin wrapper around.
 func TestPodmanRunSkippedWhenUnavailable(t *testing.T) {
+	launcher := PodmanLauncher{Binary: "hive-sandbox-test-nonexistent-podman-binary"}
+	_, err := launcher.Run(context.Background(), LaunchSpec{Image: "docker.io/library/alpine:latest", Workspace: t.TempDir(), Command: []string{"sh", "-c", "test -d /workspace"}, NetworkNone: true})
+	if err == nil {
+		t.Fatal("Run: expected error when podman binary is unavailable, got nil")
+	}
+	if !strings.Contains(err.Error(), "podman is required but was not found in PATH") {
+		t.Fatalf("Run error = %q, want it to report podman missing from PATH", err.Error())
+	}
+}
+
+// TestPodmanRunIntegration actually shells out to a real podman binary and
+// runs a container. It only makes sense — and only reliably succeeds — on a
+// host with a working rootless podman installation (subuid/subgid mapping,
+// network egress to pull the test image, etc.), which CI's -short unit-test
+// run does not guarantee even when a podman binary happens to be on PATH.
+// Skipped under -short; run explicitly with `go test -run Integration` (no
+// -short) on a machine known to have podman configured.
+func TestPodmanRunIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping podman integration test in -short mode")
+	}
 	if !Available() {
 		t.Skip("podman not available")
 	}


### PR DESCRIPTION
Fixes #3163

## 1. `TestNewStore_CreatesGroupWritableDir` (`pkg/beads`)

**Root cause (verified, not just reasoned):** `NewStore` called `os.Chmod(dir, 0o2770)` to add the setgid bit after `MkdirAll` (working around umask clipping `MkdirAll`'s mode). But `os.Chmod` takes an `os.FileMode`, and in Go's `os.FileMode` bit layout the setgid flag is `os.ModeSetgid` — a high bit (`1<<29`) — **not** the Unix octal `0o2000` that `chmod(1)`/`chmod(2)` use. Passing the raw literal `0o2770` requests a mode with none of Go's named special-mode bits set, so `os.Chmod` silently applied only the low `0770` permission bits and returned **no error** — the directory came out `drwxrwx---` instead of `drwxrwx--S`.

I confirmed this directly (not just from documentation) with a throwaway diagnostic test dispatched against this branch's own CI runner:
- `os.Chmod(dir, 0o2770)` → no error, but `setgid=false` afterward
- `os.Chmod(dir, 0o770|os.ModeSetgid)` → `setgid=true`
- `syscall.Chmod(dir, 0o2770)` (raw syscall, not `os.Chmod`) → also `setgid=true`, confirming the bug is specifically in how the octal literal maps onto `os.FileMode`, not a kernel/permission issue

This turned out to be a real, **cross-platform** application bug — not a Linux-only environment quirk, and I do **not** conclude the test's assertion was wrong. The setgid requirement itself is correct and intentional per the existing comments: agent UIDs (2001+) and the hub process (1001) share only the node group, so bead files must inherit that shared group via setgid. The fix is `os.FileMode(0770)|os.ModeSetgid` instead of the raw octal literal.

I also removed the test's `runtime.GOOS == "linux"` guard on the setgid assertion. `os.ModeSetgid` is portable and macOS honors it too — the guard is exactly why this bug shipped undetected: `go test` on every contributor's Mac showed green while the dir was silently missing setgid everywhere, and only Linux CI (which is where this guard let the assertion actually run) could have caught it. With the guard removed, `TestNewStore_CreatesGroupWritableDir` now genuinely passes on macOS too, confirming the fix works cross-platform rather than merely "unblocking Linux CI."

## 2. `TestPodmanRunSkippedWhenUnavailable` (`pkg/sandbox`)

**Root cause:** the test gated its behavior on `Available()`, which is `exec.LookPath("podman") == nil` — i.e. purely "is a `podman` binary anywhere on PATH". On a developer Mac without podman installed, this is false and the test takes the `t.Skip` branch, so it always passes trivially. But GitHub's `ubuntu-latest` hosted runner images ship a `podman` binary preinstalled, so on CI, `Available()` is true and the test instead falls through to actually invoking `(PodmanLauncher{}).Run(...)`, which shells out to real `podman run` to pull `docker.io/library/alpine:latest` and execute a container. That fails on the hosted runner for reasons unrelated to the code under test (no rootless subuid/subgid mapping configured, network egress restrictions, etc.) — the test was never meant to be an integration test of a live podman daemon, but its environment-dependent gate silently promoted it into one whenever a matching binary happened to exist on PATH.

**Fix:** rewrote `TestPodmanRunSkippedWhenUnavailable` to use `PodmanLauncher{Binary: "hive-sandbox-test-nonexistent-podman-binary"}` — a name guaranteed absent from PATH on any host — so it deterministically exercises the exact `exec.LookPath` check inside `Run` (the same code `Available()` wraps) and asserts the specific "podman is required but was not found in PATH" error, on every OS and every CI runner regardless of what happens to be installed. This is still testing the real behavior the name promises (the unavailable-binary path returns a clear, immediate error rather than hanging or behaving unpredictably) — it's just no longer at the mercy of the host's PATH contents.

I did **not** delete the real-podman exercise; I split it into a new `TestPodmanRunIntegration`, gated on `testing.Short()` (CI's `v2-tests.yml` already runs with `-short`), so it's still available to run explicitly (`go test -run Integration` without `-short`) on a machine with a properly configured rootless podman, but no longer blocks the unit-test gate on CI runner podman availability/configuration it doesn't control.

## Verification

- `cd v2 && go test ./pkg/beads/ ./pkg/sandbox/ -count=1 -v` — all pass, **including the setgid assertion on macOS** now that it's no longer Linux-gated (the earlier PR revision's chown-based fix looked plausible but was empirically wrong — CI still failed identically after it — so I dispatched a throwaway diagnostic test against this branch's CI to get real Linux syscall-level evidence rather than guessing twice).
- `go build ./...` — clean.
- `go vet ./pkg/beads/ ./pkg/sandbox/` — clean.

Only `v2/pkg/beads/` and `v2/pkg/sandbox/` were touched.