### PR TITLE
🐛 Fix gh-wrapper author identity spoofing

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -130,25 +130,39 @@ _extract_author() {
   return 1
 }
 
-# Resolve the bot's GitHub login (cached per invocation for performance).
+# Resolve the authenticated GitHub login (cached per invocation for performance).
+# Initialize internally so caller-controlled environment cannot seed the cache.
+HIVE_AUTH_LOGIN_CACHED=""
 _resolve_self_login() {
-  if [[ -n "${HIVE_BOT_LOGIN_CACHED:-}" ]]; then
-    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-    return
+  if [[ -n "${HIVE_AUTH_LOGIN_CACHED:-}" ]]; then
+    printf '%s\n' "$HIVE_AUTH_LOGIN_CACHED"
+    return 0
   fi
-  if [[ -n "${HIVE_BOT_LOGIN:-}" ]]; then
-    HIVE_BOT_LOGIN_CACHED="$HIVE_BOT_LOGIN"
-    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-    return
+
+  local login
+  if ! login="$("$REAL_GH" api user --jq .login 2>/dev/null)"; then
+    return 1
   fi
-  if [[ -x "$REAL_GH" ]] && [[ -n "${GH_TOKEN:-}" ]]; then
-    HIVE_BOT_LOGIN_CACHED="$("$REAL_GH" api user -q '.login' 2>/dev/null || true)"
-    if [[ -n "$HIVE_BOT_LOGIN_CACHED" ]]; then
-      printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-      return
-    fi
+  if [[ -z "$login" ]]; then
+    return 1
   fi
-  printf '%s\n' ""
+
+  HIVE_AUTH_LOGIN_CACHED="$login"
+  printf '%s\n' "$HIVE_AUTH_LOGIN_CACHED"
+}
+
+_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+_author_matches_login() {
+  local requested_lc login_lc requested_base login_base
+  requested_lc="$(_lower "$1")"
+  login_lc="$(_lower "$2")"
+  requested_base="${requested_lc%\[bot\]}"
+  login_base="${login_lc%\[bot\]}"
+
+  [[ "$requested_lc" = "$login_lc" || "$requested_base" = "$login_base" ]]
 }
 
 # ── READ/WRITE SPLIT for GitHub lookups (fixes #2356; addresses #2393 item 6) ──
@@ -168,21 +182,18 @@ if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" 
   if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
     : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356)
   elif author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
-    self_login="$(_resolve_self_login)"
-    if [[ -n "$self_login" ]] && [[ "$author_value" = "$self_login" ]]; then
-      : # Match: exact bot login
-    elif [[ -n "$self_login" ]] && [[ "$author_value" = "${self_login%\[bot\]}" ]]; then
-      : # Match: bot login without [bot] suffix
-    elif [[ -n "${HIVE_AGENT:-}" ]] && [[ "$author_value" = "${HIVE_AGENT}" ]]; then
-      : # Match: agent name
-    elif [[ -n "${HIVE_AGENT_DISPLAY_NAME:-}" ]] && [[ "$author_value" = "${HIVE_AGENT_DISPLAY_NAME}" ]]; then
-      : # Match: agent display name
-    elif [[ -n "${HIVE_CONTRIBUTOR_USERNAME:-}" ]] && [[ "$author_value" = "${HIVE_CONTRIBUTOR_USERNAME}" ]]; then
-      : # Match: contributor username (self-listing in contributor mode)
+    if [[ "$author_value" = "@me" ]]; then
+      : # GitHub resolves @me server-side to the authenticated token identity.
+    elif ! _resolve_self_login >/dev/null; then
+      echo "⛔ BLOCKED: gh $subcmd list --author requires authenticated GitHub identity." >&2
+      echo "Could not resolve the current token identity with 'gh api user --jq .login'." >&2
+      exit 1
+    elif _author_matches_login "$author_value" "$HIVE_AUTH_LOGIN_CACHED"; then
+      : # Match: authenticated login, case-insensitive, with optional [bot] suffix.
     else
-      echo "⛔ BLOCKED: gh $subcmd list --author must match the current bot/agent identity." >&2
-      echo "--author '$author_value' does not match the current identity." >&2
-      echo "Use --author with your own bot login or agent name to list your own items." >&2
+      echo "⛔ BLOCKED: gh $subcmd list --author must match the authenticated GitHub identity." >&2
+      echo "--author '$author_value' does not match token identity '$HIVE_AUTH_LOGIN_CACHED'." >&2
+      echo "Use --author @me or your authenticated bot login to list your own items." >&2
       exit 1
     fi
   else

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -95,8 +95,18 @@ fi
 args=("$@")
 subcmd=""
 action=""
+skip_next=false
 for arg in "${args[@]}"; do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
   case "$arg" in
+    --repo|--hostname|-R|--jq|-q)
+      skip_next=true
+      continue
+      ;;
+    --repo=*|--hostname=*|--jq=*|-R*) continue ;;
     -*) continue ;;
     *)
       if [ -z "$subcmd" ]; then
@@ -114,19 +124,29 @@ done
 # Extract the --author value from the args array. Returns the value on stdout
 # on success (exit 0) or nothing on failure (exit 1).
 _extract_author() {
-  local i
+  local i author_value="" found=false
   for ((i=0; i<${#args[@]}; i++)); do
-    if [[ "${args[$i]}" = --author=* ]]; then
-      printf '%s\n' "${args[$i]#--author=}"
-      return 0
+    if [[ "${args[$i]}" = --author=* || "${args[$i]}" = -A=* ]]; then
+      author_value="${args[$i]#*=}"
+      found=true
+      continue
     fi
-    if [[ "${args[$i]}" = --author ]]; then
+    if [[ "${args[$i]}" = -A?* ]]; then
+      author_value="${args[$i]#-A}"
+      found=true
+      continue
+    fi
+    if [[ "${args[$i]}" = --author || "${args[$i]}" = -A ]]; then
       if [[ $((i+1)) -lt ${#args[@]} ]] && [[ "${args[$((i+1))]}" != -* ]]; then
-        printf '%s\n' "${args[$((i+1))]}"
-        return 0
+        author_value="${args[$((i+1))]}"
+        found=true
       fi
     fi
   done
+  if $found; then
+    printf '%s\n' "$author_value"
+    return 0
+  fi
   return 1
 }
 
@@ -177,11 +197,9 @@ _author_matches_login() {
 # Block gh issue list and gh pr list for NON-contributor hive agents (they consume
 # assigned work from actionable.json). Contributors are exempt so they can look
 # before they leap. `--author` self-listing is allowed only when the author value
-# matches the current agent/bot identity (fixes #3072).
+# matches the authenticated token identity (fixes #3072 and #3096).
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
-  if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
-    : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356)
-  elif author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
+  if author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
     if [[ "$author_value" = "@me" ]]; then
       : # GitHub resolves @me server-side to the authenticated token identity.
     elif ! _resolve_self_login >/dev/null; then
@@ -193,9 +211,11 @@ if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" 
     else
       echo "⛔ BLOCKED: gh $subcmd list --author must match the authenticated GitHub identity." >&2
       echo "--author '$author_value' does not match token identity '$HIVE_AUTH_LOGIN_CACHED'." >&2
-      echo "Use --author @me or your authenticated bot login to list your own items." >&2
+      echo "Use --author @me or your authenticated login to list your own items." >&2
       exit 1
     fi
+  elif [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
+    : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356).
   else
     echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
     echo "Read /var/run/hive-metrics/actionable.json instead." >&2

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -55,6 +55,7 @@ _run_test() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -161,6 +162,7 @@ _run_test_contributor() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -187,6 +189,18 @@ _run_test 1 "pr list without --author (blocked)" \
 _run_test 1 "issue list --author foreign-user (blocked)" \
   issue list --repo test/repo --author foreign-user
 
+_run_test 1 "issue list with global --repo before subcommand and --author foreign-user (blocked)" \
+  --repo test/repo issue list --author foreign-user
+
+_run_test 1 "pr list with global -R before subcommand and --author foreign-user (blocked)" \
+  -R test/repo pr list --author foreign-user
+
+_run_test 1 "issue list -A foreign-user (blocked, short author flag)" \
+  issue list --repo test/repo -A foreign-user
+
+_run_test 1 "issue list duplicate --author with unsafe effective author (blocked)" \
+  issue list --repo test/repo --author @me --author octocat
+
 _run_test 1 "pr list --author=foreign-user (blocked, equals form)" \
   pr list --repo test/repo --author=foreign-user
 
@@ -198,6 +212,15 @@ _run_test 0 "pr list --author=test-bot[bot] (allowed, equals form)" \
 
 _run_test 0 "issue list --author test-bot (allowed, without [bot] suffix)" \
   issue list --repo test/repo --author test-bot
+
+_run_test 0 "issue list with global -R before subcommand and --author test-bot (allowed)" \
+  -R test/repo issue list --author test-bot
+
+_run_test 0 "issue list -A test-bot (allowed, short author flag)" \
+  issue list --repo test/repo -A test-bot
+
+_run_test 0 "issue list duplicate --author with safe effective author (allowed)" \
+  issue list --repo test/repo --author octocat --author @me
 
 _run_test 0 "issue list --author @me (allowed, server-side token identity)" \
   issue list --repo test/repo --author @me
@@ -229,7 +252,28 @@ _run_test_contributor 0 "issue list contributor mode (allowed without --author)"
 _run_test_contributor 0 "pr list contributor mode (allowed without --author)" \
   pr list --repo test/repo
 
-_run_test_contributor 0 "issue list contributor mode --author self (allowed)" \
+_run_test_contributor 1 "issue list contributor mode --author octocat (blocked)" \
+  issue list --repo test/repo --author octocat
+
+_run_test_contributor 1 "issue list contributor mode -A octocat (blocked)" \
+  issue list --repo test/repo -A octocat
+
+_run_test_contributor 1 "issue list contributor mode global -R --author octocat (blocked)" \
+  -R test/repo issue list --author octocat
+
+_run_test_contributor 1 "issue list contributor mode duplicate --author with unsafe effective author (blocked)" \
+  issue list --repo test/repo --author @me --author octocat
+
+_run_test_contributor 0 "issue list contributor mode --author @me (allowed)" \
+  issue list --repo test/repo --author @me
+
+_run_test_contributor 0 "issue list contributor mode --author token login (allowed)" \
+  issue list --repo test/repo --author test-bot
+
+_run_test_contributor 1 "issue list contributor mode --author unverified contributor username (blocked)" \
+  issue list --repo test/repo --author test-contributor
+
+MOCK_GH_LOGIN="test-contributor" _run_test_contributor 0 "issue list contributor mode --author verified contributor token login (allowed)" \
   issue list --repo test/repo --author test-contributor
 
 echo ""

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -2,7 +2,7 @@
 # Author: RawNuke
 # Copyright (c) 2026 RawNuke. All rights reserved.
 #
-# Regression tests for kubestellar/hive#3072: gh-wrapper --author bypass fix.
+# Regression tests for kubestellar/hive#3072 and #3096: gh-wrapper --author gate.
 # Creates a temporary copy of the wrapper with a mock gh binary so tests
 # can run without requiring /usr/bin/gh.
 #
@@ -18,6 +18,7 @@ TEST_WRAPPER="${WORK_DIR}/gh-wrapper-test.sh"
 PASSED=0
 FAILED=0
 
+# shellcheck disable=SC2329 # invoked via EXIT trap
 cleanup() {
   rm -rf "$WORK_DIR"
 }
@@ -27,17 +28,15 @@ mkdir -p "$WORK_DIR"
 
 cat >"$MOCK_GH" <<'MOCK'
 #!/usr/bin/env bash
-case "$*" in
-  "api user -q .login")
-    echo "test-bot[bot]"
-    ;;
-  "api"*)
-    echo '{"login":"test-bot[bot]"}'
-    ;;
-  *)
-    exit 0
-    ;;
-esac
+if [[ "${1:-}" = "api" && "${2:-}" = "user" ]]; then
+  if [[ "${MOCK_GH_FAIL_IDENTITY:-}" = "true" ]]; then
+    echo "mock identity failure" >&2
+    exit 42
+  fi
+  echo "${MOCK_GH_LOGIN:-test-bot[bot]}"
+  exit 0
+fi
+exit 0
 MOCK
 chmod +x "$MOCK_GH"
 
@@ -45,7 +44,6 @@ sed "s|^REAL_GH=\"/usr/bin/gh\"|REAL_GH=\"${MOCK_GH}\"|" "$WRAPPER" > "$TEST_WRA
 chmod +x "$TEST_WRAPPER"
 
 export GH_TOKEN="test-token-mock"
-export HIVE_BOT_LOGIN="test-bot[bot]"
 
 _run_test() {
   local expected_rc="$1"
@@ -57,7 +55,85 @@ _run_test() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_BOT_LOGIN="test-bot[bot]" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_spoof() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_AGENT="octocat" \
+    HIVE_AGENT_DISPLAY_NAME="octocat" \
+    HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="scanner[bot]" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_identity_failure() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    MOCK_GH_FAIL_IDENTITY="true" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_cached_env_spoof() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    HIVE_AUTH_LOGIN_CACHED="octocat" \
+    MOCK_GH_LOGIN="test-bot[bot]" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -85,7 +161,6 @@ _run_test_contributor() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_BOT_LOGIN="test-bot[bot]" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -124,11 +199,26 @@ _run_test 0 "pr list --author=test-bot[bot] (allowed, equals form)" \
 _run_test 0 "issue list --author test-bot (allowed, without [bot] suffix)" \
   issue list --repo test/repo --author test-bot
 
-_run_test 0 "issue list --author scanner (allowed, HIVE_AGENT match)" \
+_run_test 0 "issue list --author @me (allowed, server-side token identity)" \
+  issue list --repo test/repo --author @me
+
+_run_test 0 "issue list --author TEST-BOT (allowed, case-insensitive without [bot] suffix)" \
+  issue list --repo test/repo --author TEST-BOT
+
+_run_test 0 "issue list --author test-bot[bot] with spoofed HIVE_AGENT (allowed by token identity)" \
+  issue list --repo test/repo --author "test-bot[bot]"
+
+_run_test 1 "issue list --author scanner from HIVE_AGENT env (blocked)" \
   issue list --repo test/repo --author scanner
 
-_run_test 0 "pr list --author scanner (allowed, HIVE_AGENT match)" \
-  pr list --repo test/repo --author scanner
+_run_test_spoof 1 "issue list --author octocat with spoofed HIVE_AGENT (blocked)" \
+  issue list --repo test/repo --author octocat
+
+_run_test_identity_failure 1 "issue list --author test-bot[bot] when identity lookup fails (blocked)" \
+  issue list --repo test/repo --author "test-bot[bot]"
+
+_run_test_cached_env_spoof 1 "issue list --author env-seeded identity cache octocat (blocked)" \
+  issue list --repo test/repo --author octocat
 
 echo ""
 echo "=== Contributor mode tests ==="


### PR DESCRIPTION
Fixes #3096

## Summary
- Stops `gh issue list` / `gh pr list --author` from trusting caller-controlled `HIVE_AGENT`, `HIVE_AGENT_DISPLAY_NAME`, `HIVE_CONTRIBUTOR_USERNAME`, pre-seeded cache environment values, or `HIVE_CONTRIBUTOR_MODE` exemptions.
- Resolves the allowed identity from the authenticated token with the real `gh api user --jq .login` binary path and caches it only inside the wrapper invocation.
- Allows `--author @me`, compares logins case-insensitively, and normalizes the optional `[bot]` suffix.
- Handles `-A`, duplicate author flags using the effective last author value, and global `--repo` / `-R` flags before the subcommand.
- Fails closed with a clear error if token identity lookup fails.

## Bypass explanation
Before this change, a caller could set `HIVE_AGENT=octocat` and then run `gh-wrapper.sh issue list --author octocat`; the gate accepted the mutable environment value as proof of identity. A second variant existed with `HIVE_CONTRIBUTOR_MODE=true`, which bypassed the author check entirely and allowed arbitrary `--author` filters such as `octocat`.

## New trust model
The author gate now treats the GitHub token identity returned by `gh api user --jq .login` as the only authoritative identity source for `--author` self-listing, including contributor mode. Runtime Hive environment variables remain available for display/logging/routing behavior, but not for author authorization. Contributor mode may still list without `--author` for duplicate-PR avoidance; when it supplies `--author`, it must use `@me` or a value matching the token-derived login. Unverified `HIVE_CONTRIBUTOR_USERNAME` values are not accepted as authorization input.

## Tests
- `bash -n bin/gh-wrapper.sh`
- `bash -n bin/gh-wrapper.test.sh`
- `bash bin/gh-wrapper.test.sh`