### PR TITLE
🐛 fix agent import gist keep-linked validation

### DIFF
--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/defsrc"
@@ -197,6 +198,18 @@ const (
 	importHTTPTimeoutS  = 10
 )
 
+var importAllowedHosts = map[string]struct{}{
+	"github.com":                 {},
+	"raw.githubusercontent.com":  {},
+	"gist.github.com":            {},
+	"gist.githubusercontent.com": {},
+}
+
+const (
+	importURLFormsOneShot = "https://github.com/<owner>/<repo>/blob/<ref>/<path>, https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>, https://gist.github.com/<user>/<gist-id>[/raw[/<file>]], or https://gist.githubusercontent.com/<user>/<gist-id>/raw/<path>"
+	importURLFormsLinked  = "https://github.com/<owner>/<repo>/blob/<ref>/<path> or https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>"
+)
+
 // agentConfigFromDefinition maps a parsed AgentDefinition to an AgentConfig with
 // the import defaults applied (backend copilot, immediate restart, worker bead
 // role, enabled). It is the single mapping used by both the whole-agent import
@@ -257,8 +270,13 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, fmt.Sprintf("url must be at most %d characters", importMaxURLLen), http.StatusBadRequest)
 			return
 		}
-		client := &http.Client{Timeout: importHTTPTimeoutS * 1e9} // nanoseconds
-		resp, err := client.Get(body.URL)
+		if err := s.validateImportURL(body.URL, body.KeepLinked); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		fetchURL := importFetchURL(body.URL)
+		client := &http.Client{Timeout: time.Duration(importHTTPTimeoutS) * time.Second}
+		resp, err := client.Get(fetchURL)
 		if err != nil {
 			jsonError(w, "failed to fetch URL: "+err.Error(), http.StatusBadGateway)
 			return
@@ -477,6 +495,68 @@ var githubBlobURLPattern = regexp.MustCompile(`^/([^/]+)/([^/]+)/blob/([^/]+)/(.
 //	https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path...>
 var githubRawURLPattern = regexp.MustCompile(`^/([^/]+)/([^/]+)/([^/]+)/(.+)$`)
 
+func (s *Server) validateImportURL(rawURL string, keepLinked bool) error {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("import URL must be an https URL; supported forms: %s", importURLFormsOneShot)
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if _, ok := importAllowedHosts[host]; !ok {
+		return fmt.Errorf("import URL host %q is not supported; supported forms: %s", host, importURLFormsOneShot)
+	}
+
+	if isGistImportHost(host) {
+		if keepLinked {
+			return fmt.Errorf("keep linked imports do not support gist URLs; use a GitHub repository file URL (%s), or uncheck Keep linked for a one-shot gist import", importURLFormsLinked)
+		}
+		if strings.Trim(u.Path, "/") == "" {
+			return fmt.Errorf("gist import URL must include a gist path; supported forms: %s", importURLFormsOneShot)
+		}
+		return nil
+	}
+
+	if host == "raw.githubusercontent.com" {
+		if githubRawURLPattern.FindStringSubmatch(u.Path) == nil {
+			return fmt.Errorf("import URL %q is not a supported raw GitHub file URL; supported forms: %s", rawURL, importURLFormsOneShot)
+		}
+		return nil
+	}
+
+	if host == "github.com" && githubBlobURLPattern.FindStringSubmatch(u.Path) != nil {
+		return nil
+	}
+
+	forms := importURLFormsOneShot
+	if keepLinked {
+		forms = importURLFormsLinked
+	}
+	return fmt.Errorf("import URL %q is not a supported GitHub file URL; supported forms: %s", rawURL, forms)
+}
+
+func isGistImportHost(host string) bool {
+	return host == "gist.github.com" || host == "gist.githubusercontent.com"
+}
+
+func importFetchURL(rawURL string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
+		return rawURL
+	}
+	m := githubBlobURLPattern.FindStringSubmatch(u.Path)
+	if m == nil {
+		return rawURL
+	}
+	raw := url.URL{
+		Scheme:   "https",
+		Host:     "raw.githubusercontent.com",
+		Path:     "/" + strings.Join([]string{m[1], m[2], m[3], m[4]}, "/"),
+		RawQuery: u.RawQuery,
+		Fragment: u.Fragment,
+	}
+	return raw.String()
+}
+
 // definitionSourceFromURL parses a GitHub blob or raw file URL into a
 // DefinitionSourceConfig (owner/repo/path/ref). It is used when an operator
 // imports an agent with "keep linked" checked, so the pasted human-facing URL
@@ -494,7 +574,7 @@ func (s *Server) definitionSourceFromURL(rawURL string) (*config.DefinitionSourc
 		m = githubBlobURLPattern.FindStringSubmatch(u.Path)
 	}
 	if m == nil {
-		return nil, fmt.Errorf("URL %q is not a recognized GitHub file URL (expected .../<owner>/<repo>/blob/<ref>/<path> or a raw.githubusercontent.com file URL)", rawURL)
+		return nil, fmt.Errorf("URL %q is not a recognized GitHub file URL (expected a GitHub blob URL .../<owner>/<repo>/blob/<ref>/<path> or https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>)", rawURL)
 	}
 	return &config.DefinitionSourceConfig{
 		Type:  "github",

--- a/v2/pkg/dashboard/api_agents_test.go
+++ b/v2/pkg/dashboard/api_agents_test.go
@@ -592,13 +592,14 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	s, deps := apiServer(t)
 	deps.Config.Data.AgentsDir = t.TempDir()
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source": "url",
-		"url":    ts.URL + "/agent.yaml",
+		"url":    "https://raw.githubusercontent.com/kubestellar/hive/main/agent.yaml",
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -615,11 +616,12 @@ func TestHandleAgentImport_URLFetchFails(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	s, _ := apiServer(t)
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source": "url",
-		"url":    ts.URL + "/agent.yaml",
+		"url":    "https://raw.githubusercontent.com/kubestellar/hive/main/agent.yaml",
 	})
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d: %s", rec.Code, rec.Body.String())

--- a/v2/pkg/dashboard/definition_source_test.go
+++ b/v2/pkg/dashboard/definition_source_test.go
@@ -4,10 +4,35 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func routeImportFetchesToServer(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+	target, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	previous := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rewritten := req.Clone(req.Context())
+		rewritten.URL.Scheme = target.Scheme
+		rewritten.URL.Host = target.Host
+		rewritten.Host = req.URL.Host
+		return previous.RoundTrip(rewritten)
+	})
+	t.Cleanup(func() { http.DefaultTransport = previous })
+}
 
 // enableDefinitionAllowlist puts a slug on the seed-only GitHub allowlist so the
 // keep-linked / prompt-source paths are permitted for it in tests.
@@ -61,6 +86,110 @@ func TestDefinitionSourceFromURL(t *testing.T) {
 	}
 }
 
+func TestAgentImportURLPolicy(t *testing.T) {
+	defSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			name = "imported-url-policy-agent"
+		}
+		fmt.Fprintf(w, "apiVersion: hive.kubestellar.io/v1\nkind: %s\nmetadata:\n  name: %s\nspec:\n  backend: claude\n", exportKind, name)
+	}))
+	defer defSrv.Close()
+	routeImportFetchesToServer(t, defSrv)
+
+	cases := []struct {
+		name          string
+		importURL     string
+		keepLinked    bool
+		wantStatus    int
+		wantErr       string
+		wantLinked    bool
+		wantAgentName string
+	}{
+		{
+			name:       "gist keep-linked rejected clearly",
+			importURL:  "https://gist.github.com/someone/abcdef/raw/agent.yaml?name=gist-linked",
+			keepLinked: true,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "keep linked imports do not support gist URLs",
+		},
+		{
+			name:          "gist one-shot accepted",
+			importURL:     "https://gist.github.com/someone/abcdef/raw/agent.yaml?name=gist-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "gist-one-shot",
+		},
+		{
+			name:          "github blob one-shot accepted",
+			importURL:     "https://github.com/kubestellar/hive/blob/main/agents/blob-plain.yaml?name=blob-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "blob-one-shot",
+		},
+		{
+			name:          "github blob keep-linked accepted",
+			importURL:     "https://github.com/kubestellar/hive/blob/main/agents/blob-linked.yaml?name=blob-linked",
+			keepLinked:    true,
+			wantStatus:    http.StatusOK,
+			wantLinked:    true,
+			wantAgentName: "blob-linked",
+		},
+		{
+			name:          "raw github one-shot accepted",
+			importURL:     "https://raw.githubusercontent.com/kubestellar/hive/main/agents/raw-plain.yaml?name=raw-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "raw-one-shot",
+		},
+		{
+			name:          "raw github keep-linked accepted",
+			importURL:     "https://raw.githubusercontent.com/kubestellar/hive/main/agents/raw-linked.yaml?name=raw-linked",
+			keepLinked:    true,
+			wantStatus:    http.StatusOK,
+			wantLinked:    true,
+			wantAgentName: "raw-linked",
+		},
+		{
+			name:       "disallowed host rejected",
+			importURL:  "https://example.com/kubestellar/hive/blob/main/agent.yaml?name=bad-host",
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "example.com",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, deps := apiServer(t)
+			deps.Config.Data.AgentsDir = t.TempDir()
+			enableDefinitionAllowlist(deps, "kubestellar/hive")
+
+			rec := doPost(s, "/api/agents/import", map[string]interface{}{
+				"source":     "url",
+				"url":        tc.importURL,
+				"keepLinked": tc.keepLinked,
+			})
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+			if tc.wantErr != "" {
+				if !strings.Contains(rec.Body.String(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %s", tc.wantErr, rec.Body.String())
+				}
+				return
+			}
+
+			agent, ok := deps.Config.Agents[tc.wantAgentName]
+			if !ok {
+				t.Fatalf("expected imported agent %q", tc.wantAgentName)
+			}
+			if tc.wantLinked && agent.DefinitionSource == nil {
+				t.Fatal("expected keep-linked import to set definition_source")
+			}
+			if !tc.wantLinked && agent.DefinitionSource != nil {
+				t.Fatalf("expected one-shot import to leave definition_source unset, got %+v", agent.DefinitionSource)
+			}
+		})
+	}
+}
+
 // TestImport_UncheckedStaysPlain: a normal import (no keepLinked) produces a
 // baked agent with NO definition_source link.
 func TestImport_UncheckedStaysPlain(t *testing.T) {
@@ -79,10 +208,11 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/kubestellar/hive/blob/main/plain.yaml",
+		"url":        "https://github.com/kubestellar/hive/blob/main/plain.yaml",
 		"keepLinked": false,
 	})
 	if rec.Code != http.StatusOK {
@@ -115,13 +245,14 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	// The blob path makes the parsed slug "kubestellar/hive"; allowlist it.
 	enableDefinitionAllowlist(deps, "kubestellar/hive")
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/kubestellar/hive/blob/main/agents/linked.yaml",
+		"url":        "https://github.com/kubestellar/hive/blob/main/agents/linked.yaml",
 		"keepLinked": true,
 	})
 	if rec.Code != http.StatusOK {
@@ -161,10 +292,11 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/attacker/evil/blob/main/agent.yaml",
+		"url":        "https://github.com/attacker/evil/blob/main/agent.yaml",
 		"keepLinked": true,
 	})
 	if rec.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14403,7 +14403,7 @@ function burnAreaChart() {
           '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button onclick="previewImportFromURL()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg);white-space:nowrap">Preview</button></div>' +
           '<label style="display:flex;align-items:center;gap:8px;margin-top:8px;font-size:0.78rem;cursor:pointer;font-weight:400">' +
             '<input type="checkbox" id="import-keep-linked" style="width:auto;margin:0">' +
-            '<span>Keep linked to repo (live) <span style="color:var(--muted)">— re-fetch this definition on reload so repo edits propagate. Only its presentation/behavior fields are re-applied; security and privilege fields are never changed. The repo must be on the operator\'s allowlist. (URL import only.)</span></span>' +
+            '<span>Keep linked to repo (live) <span style="color:var(--muted)">— re-fetch this definition on reload so repo edits propagate. Keep-linked URL imports support GitHub blob URLs and raw.githubusercontent.com file URLs only; gist URLs are one-shot imports, so uncheck this box for gists. Only presentation/behavior fields are re-applied; security and privilege fields are never changed. The repo must be on the operator\'s allowlist. (URL import only.)</span></span>' +
           '</label>' +
         '</div>' +
         '<div class="config-field" style="margin-bottom:12px">' +


### PR DESCRIPTION
Fixes #3059

## Summary
- Keep one-shot gist URL imports supported, but reject gist URLs early when `keepLinked=true` with an actionable error.
- Validate agent import URL hosts/forms before fetching and align errors with the supported contract.
- Convert GitHub blob URLs to `raw.githubusercontent.com` for the fetch path so both blob and raw forms work for one-shot and keep-linked imports.
- Update dashboard copy to explain that gists are one-shot only.

## Chosen option
I chose not to remove gist import support outright. Reading the handler showed non-linked URL imports fetch and parse the URL content without needing `definition_source`, so gist URLs can still be useful for one-shot imports. The inconsistency only appears when `keepLinked=true`, where durable linking requires a GitHub repo owner/repo/ref/path and gist URLs cannot provide that contract.

## Tests
- `cd /Users/andan02/hive-wt-i3059/v2 && go build ./... && go vet ./pkg/dashboard/ && go test ./pkg/dashboard/ -count=1`