### PR TITLE
🐛 Validate knowledge git source URLs

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7121,8 +7121,9 @@ func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request)
 		jsonError(w, "name and url are required", http.StatusBadRequest)
 		return
 	}
-	if !strings.HasPrefix(req.URL, "https://") && !strings.HasPrefix(req.URL, "http://") && !strings.HasPrefix(req.URL, "git@") {
-		jsonError(w, "url must start with https://, http://, or git@", http.StatusBadRequest)
+	req.URL = strings.TrimSpace(req.URL)
+	if err := knowledge.ValidateGitSourceURL(req.URL); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if strings.Contains(req.Name, "..") || strings.ContainsAny(req.Name, "/\\") {

--- a/v2/pkg/dashboard/dashboard_config_download_test.go
+++ b/v2/pkg/dashboard/dashboard_config_download_test.go
@@ -412,9 +412,8 @@ func TestHandleGitSourcesConnectGitAtURL(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleGitSourcesConnect(w, req)
 
-	// Valid URL format — will pass validation, then try to connect (may fail or succeed)
-	if w.Code == http.StatusBadRequest {
-		t.Error("git@ URLs should be accepted")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for git@ URL, got %d", w.Code)
 	}
 }
 

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -630,6 +630,11 @@ func (k *KnowledgeAPI) Layers() []LayerType {
 // repo (sparse if subpath is set), indexes the markdown files, and starts a
 // periodic sync loop. Any layer level can have git sources.
 func (k *KnowledgeAPI) ConnectGitSource(ctx context.Context, config GitSourceConfig) error {
+	config.URL = strings.TrimSpace(config.URL)
+	if err := ValidateGitSourceURL(config.URL); err != nil {
+		return fmt.Errorf("invalid git source url: %w", err)
+	}
+
 	k.mu.RLock()
 	for _, gs := range k.gitSources {
 		if gs.Config().URL == config.URL && gs.Config().Subpath == config.Subpath {

--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,8 @@ import (
 const (
 	// gitSourceCloneTimeout caps how long the initial clone can take.
 	gitSourceCloneTimeout = 120 * time.Second
+
+	gitAllowedProtocols = "https:http"
 
 	// gitSourceSyncInterval is how often we pull updates from the remote.
 	gitSourceSyncInterval = 5 * time.Minute
@@ -49,6 +52,7 @@ type GitSource struct {
 // NewGitSource creates a git source. Call Init() to clone the repo and start
 // the FileStore. The clone lands under baseDir/git-sources/<slug>.
 func NewGitSource(config GitSourceConfig, baseDir string, logger *slog.Logger) *GitSource {
+	config.URL = strings.TrimSpace(config.URL)
 	slug := gitSourceSlug(config.URL, config.Subpath)
 	cloneDir := filepath.Join(baseDir, gitSourceCacheDir, slug)
 
@@ -71,6 +75,10 @@ func NewGitSource(config GitSourceConfig, baseDir string, logger *slog.Logger) *
 
 // Init clones the repo (or reuses an existing clone) and creates the FileStore.
 func (g *GitSource) Init(ctx context.Context) error {
+	if err := ValidateGitSourceURL(g.config.URL); err != nil {
+		return fmt.Errorf("git source %s: invalid url: %w", g.config.Name, err)
+	}
+
 	if err := g.ensureCloned(ctx); err != nil {
 		return fmt.Errorf("git source %s: clone failed: %w", g.config.Name, err)
 	}
@@ -130,7 +138,7 @@ func (g *GitSource) Sync(ctx context.Context) error {
 		return fmt.Errorf("clone dir %s is not a git repo", g.cloneDir)
 	}
 
-	if err := gitPull(ctx, g.cloneDir); err != nil {
+	if err := gitSourcePull(ctx, g.cloneDir); err != nil {
 		return fmt.Errorf("git source %s: pull failed: %w", g.config.Name, err)
 	}
 
@@ -173,7 +181,7 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 			"name", g.config.Name,
 			"dir", g.cloneDir,
 		)
-		return gitPull(ctx, g.cloneDir)
+		return gitSourcePull(ctx, g.cloneDir)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(g.cloneDir), 0o755); err != nil {
@@ -189,10 +197,10 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 		args = append(args, "--filter=blob:none", "--sparse")
 	}
 
-	args = append(args, g.config.URL, g.cloneDir)
+	args = append(args, "--", g.config.URL, g.cloneDir)
 
 	cmd := exec.CommandContext(cloneCtx, "git", args...)
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = gitSourceEnv()
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -219,19 +227,69 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 func (g *GitSource) setupSparseCheckout(ctx context.Context) error {
 	initCmd := exec.CommandContext(ctx, "git", "sparse-checkout", "init", "--cone")
 	initCmd.Dir = g.cloneDir
-	initCmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	initCmd.Env = gitSourceEnv()
 	if out, err := initCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("sparse-checkout init: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	setCmd := exec.CommandContext(ctx, "git", "sparse-checkout", "set", g.config.Subpath)
 	setCmd.Dir = g.cloneDir
-	setCmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	setCmd.Env = gitSourceEnv()
 	if out, err := setCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("sparse-checkout set: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	return nil
+}
+
+// ValidateGitSourceURL enforces the transports permitted for git-backed knowledge sources.
+func ValidateGitSourceURL(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("git URL is required")
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return fmt.Errorf("git URL must not start with '-'")
+	}
+	if isSCPStyleGitURL(trimmed) {
+		return fmt.Errorf("git URL scp-like syntax is not allowed")
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return fmt.Errorf("git URL is invalid")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" && scheme != "http" {
+		if scheme == "" {
+			return fmt.Errorf("git URL scheme is required")
+		}
+		return fmt.Errorf("git URL scheme %q is not allowed", scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("git URL host is required")
+	}
+	if strings.Contains(trimmed, "::") {
+		return fmt.Errorf("git URL must not contain git transport helper separator")
+	}
+
+	return nil
+}
+
+func isSCPStyleGitURL(raw string) bool {
+	if strings.Contains(raw, "://") {
+		return false
+	}
+	at := strings.Index(raw, "@")
+	colon := strings.Index(raw, ":")
+	return at > 0 && colon > at+1
+}
+
+func gitSourceEnv() []string {
+	return append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ALLOW_PROTOCOL="+gitAllowedProtocols,
+	)
 }
 
 // gitSourceSlug creates a filesystem-safe directory name from a git URL + subpath.

--- a/v2/pkg/knowledge/gitsource_test.go
+++ b/v2/pkg/knowledge/gitsource_test.go
@@ -21,6 +21,8 @@ func TestValidateGitSourceURL(t *testing.T) {
 		{name: "git scheme", raw: "git://github.com/org/repo.git", wantErr: true},
 		{name: "ext helper", raw: "ext::sh -c 'id'", wantErr: true},
 		{name: "scp like", raw: "git@github.com:o/r.git", wantErr: true},
+		{name: "missing scheme", raw: "github.com/org/repo.git", wantErr: true},
+		{name: "invalid escape", raw: "https://example.com/%zz", wantErr: true},
 		{name: "empty host", raw: "https:///org/repo.git", wantErr: true},
 		{name: "leading dash", raw: "--upload-pack=/bin/sh", wantErr: true},
 		{name: "transport helper separator", raw: "https://github.com/org/repo::helper", wantErr: true},
@@ -36,6 +38,18 @@ func TestValidateGitSourceURL(t *testing.T) {
 				t.Fatalf("ValidateGitSourceURL(%q) error = %v", tc.raw, err)
 			}
 		})
+	}
+}
+
+func TestGitSourceInitRejectsInvalidURL(t *testing.T) {
+	gs := NewGitSource(GitSourceConfig{
+		Name:  "bad",
+		URL:   "ssh://github.com/org/repo.git",
+		Layer: LayerProject,
+	}, t.TempDir(), slog.Default())
+
+	if err := gs.Init(context.Background()); err == nil {
+		t.Fatal("expected invalid URL error")
 	}
 }
 

--- a/v2/pkg/knowledge/gitsource_test.go
+++ b/v2/pkg/knowledge/gitsource_test.go
@@ -8,6 +8,37 @@ import (
 	"testing"
 )
 
+func TestValidateGitSourceURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "https", raw: "https://github.com/org/repo.git"},
+		{name: "http", raw: "http://example.com/org/repo"},
+		{name: "file scheme", raw: "file:///etc/passwd", wantErr: true},
+		{name: "ssh scheme", raw: "ssh://github.com/org/repo.git", wantErr: true},
+		{name: "git scheme", raw: "git://github.com/org/repo.git", wantErr: true},
+		{name: "ext helper", raw: "ext::sh -c 'id'", wantErr: true},
+		{name: "scp like", raw: "git@github.com:o/r.git", wantErr: true},
+		{name: "empty host", raw: "https:///org/repo.git", wantErr: true},
+		{name: "leading dash", raw: "--upload-pack=/bin/sh", wantErr: true},
+		{name: "transport helper separator", raw: "https://github.com/org/repo::helper", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGitSourceURL(tc.raw)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateGitSourceURL(%q) succeeded, want error", tc.raw)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateGitSourceURL(%q) error = %v", tc.raw, err)
+			}
+		})
+	}
+}
+
 func TestGitSourceSlug(t *testing.T) {
 	tests := []struct {
 		url     string
@@ -39,8 +70,8 @@ func TestGitSourceSlug(t *testing.T) {
 
 func TestNewGitSource_Defaults(t *testing.T) {
 	config := GitSourceConfig{
-		Name: "test",
-		URL:  "https://github.com/org/repo",
+		Name:  "test",
+		URL:   "https://github.com/org/repo",
 		Layer: LayerProject,
 	}
 

--- a/v2/pkg/knowledge/gitsync.go
+++ b/v2/pkg/knowledge/gitsync.go
@@ -100,13 +100,21 @@ func isGitRepo(dir string) bool {
 // gitPull runs `git pull --ff-only` in the given directory.
 // --ff-only avoids creating merge commits if there are local changes.
 func gitPull(ctx context.Context, dir string) error {
+	return gitPullWithEnv(ctx, dir, append(os.Environ(), "GIT_TERMINAL_PROMPT=0"))
+}
+
+func gitSourcePull(ctx context.Context, dir string) error {
+	return gitPullWithEnv(ctx, dir, gitSourceEnv())
+}
+
+func gitPullWithEnv(ctx context.Context, dir string, env []string) error {
 	const gitPullTimeoutSeconds = 30
 	pullCtx, cancel := context.WithTimeout(ctx, gitPullTimeoutSeconds*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(pullCtx, "git", "pull", "--ff-only")
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = env
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/v2/pkg/knowledge/knowledge_coverage3_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage3_test.go
@@ -20,11 +20,11 @@ import (
 func TestKnowledgeAPI_ConnectGitSource_Duplicate(t *testing.T) {
 	api := &KnowledgeAPI{logger: covLogger()}
 	// Pre-seed a git source so the duplicate check fires before any clone.
-	gs := NewGitSource(GitSourceConfig{URL: "file:///x", Subpath: "docs"}, t.TempDir(), covLogger())
+	gs := NewGitSource(GitSourceConfig{URL: "https://example.com/x.git", Subpath: "docs"}, t.TempDir(), covLogger())
 	api.gitSources = append(api.gitSources, gs)
 
 	err := api.ConnectGitSource(context.Background(), GitSourceConfig{
-		URL:     "file:///x",
+		URL:     " https://example.com/x.git ",
 		Subpath: "docs",
 		Layer:   LayerProject,
 	})
@@ -37,11 +37,23 @@ func TestKnowledgeAPI_ConnectGitSource_InitFailure(t *testing.T) {
 	api := &KnowledgeAPI{logger: covLogger()}
 	err := api.ConnectGitSource(context.Background(), GitSourceConfig{
 		Name:  "bad",
-		URL:   "file:///nonexistent/repo/xyz",
+		URL:   "http://127.0.0.1:1/repo.git",
 		Layer: LayerProject,
 	})
 	if err == nil {
 		t.Error("expected init failure")
+	}
+}
+
+func TestKnowledgeAPI_ConnectGitSource_InvalidURL(t *testing.T) {
+	api := &KnowledgeAPI{logger: covLogger()}
+	err := api.ConnectGitSource(context.Background(), GitSourceConfig{
+		Name:  "bad",
+		URL:   "git@github.com:org/repo.git",
+		Layer: LayerProject,
+	})
+	if err == nil {
+		t.Error("expected invalid URL error")
 	}
 }
 

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -1,6 +1,7 @@
 package knowledge
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -746,7 +748,7 @@ func TestBeadLifecycle_HasOpenDependents(t *testing.T) {
 	}
 }
 
-// --- gitsource: real git via file:// clone ---
+// --- gitsource: real git via HTTP clone ---
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
@@ -784,13 +786,84 @@ func makeSourceRepo(t *testing.T) string {
 	return repo
 }
 
-func TestGitSource_InitSyncFullClone(t *testing.T) {
+func makeHTTPSourceRepo(t *testing.T) string {
+	t.Helper()
 	src := makeSourceRepo(t)
+	parent := t.TempDir()
+	bare := filepath.Join(parent, "repo.git")
+	runGit(t, src, "clone", "--bare", src, bare)
+
+	srv := httptest.NewServer(gitHTTPBackend(t, parent))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/repo.git"
+}
+
+func gitHTTPBackend(t *testing.T, projectRoot string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		cmd := exec.Command("git", "http-backend")
+		cmd.Env = append(os.Environ(),
+			"GIT_PROJECT_ROOT="+projectRoot,
+			"GIT_HTTP_EXPORT_ALL=1",
+			"REQUEST_METHOD="+r.Method,
+			"PATH_INFO="+r.URL.Path,
+			"QUERY_STRING="+r.URL.RawQuery,
+			"CONTENT_TYPE="+r.Header.Get("Content-Type"),
+			"CONTENT_LENGTH="+strconv.FormatInt(r.ContentLength, 10),
+		)
+		cmd.Stdin = r.Body
+
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Logf("git http-backend failed: %v: %s", err, stderr.String())
+			http.Error(w, "git http-backend failed", http.StatusInternalServerError)
+			return
+		}
+
+		headerBlock, body, ok := bytes.Cut(stdout.Bytes(), []byte("\r\n\r\n"))
+		if !ok {
+			headerBlock, body, ok = bytes.Cut(stdout.Bytes(), []byte("\n\n"))
+		}
+		if !ok {
+			http.Error(w, "bad git http-backend response", http.StatusInternalServerError)
+			return
+		}
+
+		status := http.StatusOK
+		for _, line := range strings.Split(string(headerBlock), "\n") {
+			line = strings.TrimRight(line, "\r")
+			if line == "" {
+				continue
+			}
+			key, value, found := strings.Cut(line, ":")
+			if !found {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if strings.EqualFold(key, "Status") {
+				code, _, _ := strings.Cut(value, " ")
+				if parsed, err := strconv.Atoi(code); err == nil {
+					status = parsed
+				}
+				continue
+			}
+			w.Header().Add(key, value)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}
+}
+
+func TestGitSource_InitSyncFullClone(t *testing.T) {
+	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "docs-src",
-		URL:   "file://" + src,
+		URL:   src,
 		Layer: LayerProject,
 	}, base, covLogger())
 
@@ -808,7 +881,7 @@ func TestGitSource_InitSyncFullClone(t *testing.T) {
 	// Re-init (already cloned path -> ensureCloned pulls).
 	gs2 := NewGitSource(GitSourceConfig{
 		Name:  "docs-src",
-		URL:   "file://" + src,
+		URL:   src,
 		Layer: LayerProject,
 	}, base, covLogger())
 	if err := gs2.Init(ctx); err != nil {
@@ -822,12 +895,12 @@ func TestGitSource_InitSyncFullClone(t *testing.T) {
 }
 
 func TestGitSource_InitSparseSubpath(t *testing.T) {
-	src := makeSourceRepo(t)
+	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
 	gs := NewGitSource(GitSourceConfig{
 		Name:    "docs-only",
-		URL:     "file://" + src,
+		URL:     src,
 		Subpath: "docs",
 		Layer:   LayerProject,
 	}, base, covLogger())
@@ -845,9 +918,11 @@ func TestGitSource_InitSparseSubpath(t *testing.T) {
 
 func TestGitSource_InitCloneFailure(t *testing.T) {
 	base := t.TempDir()
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(srv.Close)
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "bad",
-		URL:   "file:///nonexistent/repo/path/does/not/exist",
+		URL:   srv.URL + "/repo.git",
 		Layer: LayerProject,
 	}, base, covLogger())
 
@@ -860,7 +935,7 @@ func TestGitSource_SyncNotARepo(t *testing.T) {
 	base := t.TempDir()
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "norepo",
-		URL:   "file:///tmp",
+		URL:   "https://example.com/repo.git",
 		Layer: LayerProject,
 	}, base, covLogger())
 	// cloneDir does not exist / is not a git repo.
@@ -870,11 +945,11 @@ func TestGitSource_SyncNotARepo(t *testing.T) {
 }
 
 func TestGitSource_StartSyncLoop_Cancels(t *testing.T) {
-	src := makeSourceRepo(t)
+	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "loop",
-		URL:   "file://" + src,
+		URL:   src,
 		Layer: LayerProject,
 	}, base, covLogger())
 	if err := gs.Init(context.Background()); err != nil {


### PR DESCRIPTION
Fixes #3160

Companion v4 PR: #3227.

## Threat model
Knowledge git source URLs can come from config or dashboard input and are passed to git. Git supports transports beyond ordinary HTTP(S), so untrusted URLs could trigger local file reads via file://, outbound SSH/git connections, metadata SSRF over arbitrary transports, or ext:: transport helper command execution on susceptible builds.

## Breaking change
SSH/scp-style knowledge git source URLs such as git@host:path are no longer accepted. Existing configured sources using that form now fail validation with a clear error. On startup, the invalid source is skipped with a logged warning and the process continues; the knowledge subsystem is not bricked by a stale source entry. Migrate those sources to the equivalent https:// URL, using a token/credential helper for private repositories.

## Validation rules implemented
- Validate configured and dashboard-provided knowledge git source URLs before connecting, and again before clone/init at the exec boundary.
- Parse with net/url and allow only http and https schemes.
- Require a non-empty host.
- Reject scp-like git@host:path syntax.
- Reject leading dash values.
- Reject URLs containing the git transport-helper separator ::.
- Set GIT_ALLOW_PROTOCOL=https:http for knowledge git source clone/pull operations and pass -- before the clone URL.

## Verification
- go build ./...
- go vet ./pkg/knowledge/
- go test ./pkg/knowledge/ -count=1