### PR TITLE
🔒 Security audit 2026-08-07: N2 — asymmetric (Ed25519) hub session cookie

### DIFF
--- a/v2/pkg/hub/heartbeat_identity_test.go
+++ b/v2/pkg/hub/heartbeat_identity_test.go
@@ -1,0 +1,139 @@
+package hub
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// N1 (CWE-200/639/862): the heartbeat bearer must be bound to the claimed hive.
+//
+// The bearer used to be checked against s.heartbeatKey() alone — one fleet-wide
+// value derived from a FIXED label, so every spoke held identical bytes.
+// Possession proved "some provisioned spoke" and nothing more, and the handler
+// then trusted payload.HiveID verbatim. Three key-delivery lanes read off that
+// claimed ID (pending OpenRouter key, legacy pending App config, standing
+// cluster App key), so any spoke could beat as any victim and be handed the
+// victim's key material. The code said so itself: "the handler trusts the
+// body-supplied hive_id (all hives share one bearer)".
+
+func n1Hub(t *testing.T) *HubServer {
+	t.Helper()
+	return &HubServer{logger: slog.Default(), hubSecret: "test-master-secret-n1"}
+}
+
+// TestHeartbeatBearerIsPerHive is the core property: the bearer a spoke is
+// provisioned with authenticates ONLY that hive.
+func TestHeartbeatBearerIsPerHive(t *testing.T) {
+	s := n1Hub(t)
+
+	alphaBearer := s.heartbeatKeyFor("hive-alpha")
+	bravoBearer := s.heartbeatKeyFor("hive-bravo")
+
+	if alphaBearer == "" || bravoBearer == "" {
+		t.Fatal("per-hive bearer derivation returned empty")
+	}
+	if alphaBearer == bravoBearer {
+		t.Fatal("two hives derived the same heartbeat bearer — identity cannot be bound")
+	}
+
+	// Its own hive: accepted.
+	if !s.verifyHeartbeatBearer(alphaBearer, "hive-alpha") {
+		t.Error("a hive's own per-hive bearer was rejected for its own ID")
+	}
+	// Someone else's hive: refused. This is the N1 IDOR.
+	if s.verifyHeartbeatBearer(alphaBearer, "hive-bravo") {
+		t.Fatal("N1: hive-alpha's bearer authenticated a heartbeat CLAIMING to be " +
+			"hive-bravo — the victim's key material would be delivered to the attacker")
+	}
+}
+
+// TestHeartbeatLegacyFleetBearerStillAccepted pins the deliberate rollout
+// compatibility path. Every spoke in the field currently holds the fleet-wide
+// bearer and will keep holding it until the hub re-provisions it; rejecting it
+// outright would break every heartbeat in the fleet at once (the failure mode
+// documented for the v2-hub/v4-spoke split in #2773).
+func TestHeartbeatLegacyFleetBearerStillAccepted(t *testing.T) {
+	s := n1Hub(t)
+	legacy := s.heartbeatKey()
+
+	if !s.verifyHeartbeatBearer(legacy, "hive-alpha") {
+		t.Fatal("legacy fleet bearer rejected — this would break every spoke that has " +
+			"not yet re-provisioned")
+	}
+	// And it is correctly reported as NOT the modern, identity-bound path, so
+	// rollout telemetry can tell an operator when the legacy lane is safe to cut.
+	if s.heartbeatBearerIsPerHive(legacy, "hive-alpha") {
+		t.Error("legacy bearer misreported as per-hive — an operator would remove the " +
+			"compatibility lane while spokes still depend on it")
+	}
+	if !s.heartbeatBearerIsPerHive(s.heartbeatKeyFor("hive-alpha"), "hive-alpha") {
+		t.Error("per-hive bearer not reported as per-hive")
+	}
+}
+
+// TestHeartbeatBearerRejectsGarbage covers the ordinary auth failures, so the
+// dual-accept path cannot be mistaken for accept-anything.
+func TestHeartbeatBearerRejectsGarbage(t *testing.T) {
+	s := n1Hub(t)
+	for _, bad := range []string{"", "not-a-key", strings.Repeat("a", 64)} {
+		if s.verifyHeartbeatBearer(bad, "hive-alpha") {
+			t.Errorf("verifyHeartbeatBearer accepted %q", bad)
+		}
+	}
+}
+
+// TestHeartbeatBearerFailsClosedWithoutIdentity: an empty hive ID must not
+// derive a usable per-hive key. Otherwise every identity-less caller would share
+// one key again — silently recreating the bug.
+func TestHeartbeatBearerFailsClosedWithoutIdentity(t *testing.T) {
+	s := n1Hub(t)
+	if got := s.heartbeatKeyFor(""); got != "" {
+		t.Errorf("empty hiveID derived %q, want \"\"", got)
+	}
+	// With no identity the per-hive branch cannot match, so only the legacy
+	// bearer can authenticate — never an empty or arbitrary string.
+	if s.verifyHeartbeatBearer("anything", "") {
+		t.Error("verifyHeartbeatBearer accepted an arbitrary bearer for an empty hive ID")
+	}
+}
+
+// TestProvisionHeartbeatKeyMatchesHubExpectation is the wiring check: what
+// provisioning stamps into the spoke's Deployment must be exactly what the hub
+// re-derives at verify time. If these ever diverge, every freshly provisioned
+// spoke fails to heartbeat — a rollout-breaking bug that unit-testing the two
+// halves separately would miss.
+func TestProvisionHeartbeatKeyMatchesHubExpectation(t *testing.T) {
+	const master = "test-master-secret-n1"
+	t.Setenv("HIVE_HUB_SECRET", master)
+
+	s := &HubServer{logger: slog.Default(), hubSecret: master}
+	provisioned := provisionHeartbeatKey("hive-alpha")
+	expected := s.heartbeatKeyFor("hive-alpha")
+
+	if provisioned == "" {
+		t.Fatal("provisionHeartbeatKey returned empty — the spoke would get no bearer")
+	}
+	if provisioned != expected {
+		t.Fatalf("provisioning and verification disagree:\n  provisioned = %s\n  hub expects = %s\n"+
+			"every newly provisioned spoke would fail to heartbeat", provisioned, expected)
+	}
+}
+
+// TestNoAdditionalAppKeysInProvisionedManifest covers N1's second half: a spoke
+// must receive ONLY its own App key.
+//
+// Provisioning used to render every OTHER App key in the fleet into each new
+// hive's Secret, so one tenant's pod held other tenants' GitHub App private
+// keys — and with the 0644 projection (N5, fixed in #3140) every agent UID in
+// that pod could read them.
+func TestNoAdditionalAppKeysInProvisionedManifest(t *testing.T) {
+	m := renderManifest(t, false)
+
+	// The per-app-id key entries are named gh-app-key-<appid>.pem. The hive's
+	// OWN key is gh-app-key.pem (no numeric suffix) and must still be there.
+	if strings.Contains(m, "gh-app-key-") {
+		t.Fatal("N1: the rendered manifest still carries per-app-id keys for OTHER Apps — " +
+			"one tenant's pod would hold other tenants' GitHub App private keys")
+	}
+}

--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -1,9 +1,11 @@
 package hub
 
 import (
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"strings"
 )
 
@@ -27,9 +29,77 @@ import (
 // re-authenticates through the normal login flow, which re-mints the new signed
 // cookie. No stored data changes and nobody is permanently locked out.
 
+// N2 (CWE-321/798): the session cookie is now ASYMMETRICALLY signed.
+//
+// The HMAC scheme below is verify-capable-implies-mint-capable, and the same key
+// is provisioned into EVERY spoke so each spoke's proxy can check
+// `hive_hub_user`. A spoke operator could therefore read the key out of their pod
+// env and mint `clubanderson.<sig>` — a hub ADMIN cookie, accepted on ~21 admin
+// routes including the cluster App-key writer. That is the whole of N2, and it is
+// unfixable while the signer and the verifier hold the same bytes.
+//
+// The v2 format is Ed25519: the hub holds the private seed, spokes receive only
+// the public key. Same split the SSO handoff already made (C2 follow-up, #2771).
+//
+//	v2 value = <username>.v2.<base64url(Ed25519-Sign(privateKey, username))>
+//
+// The ".v2." marker is what lets one verifier accept both formats during the
+// rollout without ambiguity — a legacy HMAC signature can never contain a "."
+// (base64url has no dot), so the two shapes are distinguishable by structure
+// rather than by guessing.
+const hubCookieV2Marker = ".v2."
+
 // hubCookieB64 encodes the signature URL-safe and unpadded so the cookie value
 // stays within the RFC 6265 cookie-octet set.
 var hubCookieB64 = base64.RawURLEncoding
+
+// mintHubUserCookieValueV2 mints an Ed25519-signed session cookie. seedHex is
+// the hub's PRIVATE session seed; a spoke cannot produce this value.
+//
+// Returns "" on empty inputs or seed material that is not a valid 32-byte
+// Ed25519 seed (e.g. a public key passed by mistake) — fail closed rather than
+// sign with junk, matching MintSSOToken.
+func mintHubUserCookieValueV2(seedHex, username string) string {
+	if seedHex == "" || username == "" {
+		return ""
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(username)))
+	return username + hubCookieV2Marker + sig
+}
+
+// verifyHubUserCookieValueV2 verifies an Ed25519-signed cookie against the hub's
+// PUBLIC session key. Returns (username, true) only on a valid signature.
+func verifyHubUserCookieValueV2(pubHex, value string) (string, bool) {
+	if pubHex == "" || value == "" {
+		return "", false
+	}
+	idx := strings.LastIndex(value, hubCookieV2Marker)
+	if idx <= 0 {
+		return "", false
+	}
+	username := value[:idx]
+	sigB64 := value[idx+len(hubCookieV2Marker):]
+	if username == "" || sigB64 == "" {
+		return "", false
+	}
+	pub, err := hex.DecodeString(strings.TrimSpace(pubHex))
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return "", false
+	}
+	sig, err := hubCookieB64.DecodeString(sigB64)
+	if err != nil {
+		return "", false
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(username), sig) {
+		return "", false
+	}
+	return username, true
+}
 
 // mintHubUserCookieValue returns the signed, tamper-evident cookie value for
 // username. It returns "" when no secret is configured or the username is empty
@@ -71,4 +141,33 @@ func hubCookieSign(secret, username string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(username))
 	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}
+
+// verifyHubUserCookieEither accepts a v2 (Ed25519) cookie OR a legacy HMAC one,
+// so live sessions survive the N2 cutover.
+//
+// Rollout shape, mirroring the SSO migration: the hub MINTS only v2 while
+// verifying both. Browsers holding a legacy cookie keep working until it is
+// re-minted at their next login; spokes running an older image keep verifying
+// the legacy format until they re-provision.
+//
+// The legacy lane is the vulnerability — anyone holding the symmetric key can
+// forge it — so it is explicitly TEMPORARY. It must be removed once the fleet
+// has rolled and existing cookies have aged out (the cookie's own MaxAge bounds
+// that window). hubCookieIsV2 gives an operator the signal for when that is
+// safe.
+//
+// legacySecret may be "" to disable the legacy lane entirely, which is what the
+// removal PR will pass.
+func verifyHubUserCookieEither(pubHex, legacySecret, value string) (string, bool) {
+	if u, ok := verifyHubUserCookieValueV2(pubHex, value); ok {
+		return u, true
+	}
+	return verifyHubUserCookieValue(legacySecret, value)
+}
+
+// hubCookieIsV2 reports whether a cookie value carries the asymmetric format.
+// Rollout telemetry only — never an authorization decision on its own.
+func hubCookieIsV2(value string) bool {
+	return strings.Contains(value, hubCookieV2Marker)
 }

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -51,6 +51,18 @@ const (
 	// in the existing master — no new secret, no rotation. Distinct label from the
 	// legacy symmetric infoSSOKey so the two can never derive to the same bytes.
 	infoSSOEd25519Seed = "hive-sso-ed25519-v1"
+
+	// infoSessionEd25519Seed derives the Ed25519 signing SEED for the hub SESSION
+	// cookie (audit N2). Same construction as infoSSOEd25519Seed and for the same
+	// reason: a spoke must be able to VERIFY a hub-minted value without being able
+	// to MINT one.
+	//
+	// The symmetric infoSessionKey above cannot give that. It is provisioned into
+	// every spoke so the spoke's proxy can check `hive_hub_user`, but an HMAC key
+	// that verifies also signs — so any spoke operator could read it from their pod
+	// env and mint `clubanderson.<sig>`, which requireAdmin accepts on ~21 admin
+	// routes. Distinct label from infoSessionKey so the two can never collide.
+	infoSessionEd25519Seed = "hive-session-ed25519-v1"
 )
 
 // deriveDomainKey returns a domain-separated sub-key of master for the given
@@ -123,6 +135,26 @@ func (s *HubServer) ssoSigningSeed() string {
 
 func (s *HubServer) impersonateKey() string {
 	return deriveDomainKey(s.hubSecret, infoImpersonateKey)
+}
+
+// sessionSigningSeed returns the hex-encoded 32-byte Ed25519 SEED the hub signs
+// session cookies with (audit N2). PRIVATE key material: it must NEVER be
+// injected into a spoke — spokes receive only sessionPublicKey().
+func (s *HubServer) sessionSigningSeed() string {
+	return deriveDomainKey(s.hubSecret, infoSessionEd25519Seed)
+}
+
+// sessionPublicKey returns the hex Ed25519 PUBLIC key a spoke verifies hub
+// session cookies with. Safe to place in a Deployment: it verifies, it cannot
+// sign.
+func (s *HubServer) sessionPublicKey() string {
+	return ssoPublicKeyFromSeed(s.sessionSigningSeed())
+}
+
+// provisionSessionPublicKey is the provisioning-time mirror of
+// sessionPublicKey, resolved against provisionMasterSecret().
+func provisionSessionPublicKey() string {
+	return ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSessionEd25519Seed))
 }
 
 // provisionTerminalKey returns the PER-HIVE terminal signing key injected into a

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -142,6 +142,69 @@ func provisionTerminalKey(hiveID string) string {
 	return derivePerHiveKey(provisionMasterSecret(), infoTerminalKey, hiveID)
 }
 
+// provisionHeartbeatKey returns the PER-HIVE heartbeat bearer injected into a
+// spoke as HIVE_HEARTBEAT_KEY (audit N1).
+//
+// The spoke presents this to the hub, so unlike the terminal key it crosses the
+// trust boundary — but it is still symmetric, because the hub can re-derive it
+// on demand from the master plus the claimed hive ID. That is precisely what
+// makes the identity binding possible: with a fleet-shared bearer the hub had no
+// way to check that the caller was the hive it claimed to be, which is why
+// handleHeartbeat trusted body-supplied hive_id and three key-delivery lanes
+// became IDOR.
+func provisionHeartbeatKey(hiveID string) string {
+	return derivePerHiveKey(provisionMasterSecret(), infoHeartbeatKey, hiveID)
+}
+
+// heartbeatKeyFor returns the per-hive heartbeat bearer the hub EXPECTS from
+// hiveID. Mirror of provisionHeartbeatKey, resolved against the running hub's
+// own master rather than the provisioning-time lookup.
+func (s *HubServer) heartbeatKeyFor(hiveID string) string {
+	return derivePerHiveKey(s.hubSecret, infoHeartbeatKey, hiveID)
+}
+
+// verifyHeartbeatBearer authenticates a heartbeat and BINDS it to the claimed
+// hive (audit N1).
+//
+// Accepts either:
+//
+//  1. the per-hive bearer for exactly this hiveID — the post-fix path, which
+//     makes the claimed identity self-authenticating; or
+//  2. the legacy fleet-wide bearer — every spoke currently in the field holds
+//     this and will keep holding it until the hub re-provisions it.
+//
+// Lane 2 is a DELIBERATE, TEMPORARY compatibility path and it does NOT bind
+// identity — a spoke presenting the legacy key can still claim any hive_id, so
+// the N1 IDOR remains open for spokes that have not rolled. It exists because a
+// flag-day cutover would break every heartbeat in the fleet simultaneously,
+// which is the failure mode #2773 already documented for the v2-hub/v4-spoke
+// split. Remove it once the fleet has re-provisioned; the callers that consume
+// the identity are hardened independently, so the window is bounded by rollout
+// rather than by trust in the legacy key.
+//
+// Both comparisons are constant-time. Order matters only for the returned
+// telemetry, not for security: a caller holding the legacy key is accepted
+// regardless of which branch runs first.
+func (s *HubServer) verifyHeartbeatBearer(presented, hiveID string) bool {
+	if presented == "" {
+		return false
+	}
+	if perHive := s.heartbeatKeyFor(hiveID); perHive != "" && secureCompareHub(presented, perHive) {
+		return true
+	}
+	// Legacy fleet-wide bearer — accepted during rollout only.
+	return secureCompareHub(presented, s.heartbeatKey())
+}
+
+// heartbeatBearerIsPerHive reports whether the presented bearer is the modern,
+// identity-bound one. Used for rollout telemetry so an operator can see when the
+// fleet has fully migrated and the legacy lane in verifyHeartbeatBearer can be
+// deleted.
+func (s *HubServer) heartbeatBearerIsPerHive(presented, hiveID string) bool {
+	perHive := s.heartbeatKeyFor(hiveID)
+	return perHive != "" && secureCompareHub(presented, perHive)
+}
+
 // ssoPublicKeyFromSeed expands a hex Ed25519 seed into the hex-encoded 32-byte
 // public key. Returns "" if seedHex is not a valid 32-byte seed. Used by both the
 // hub-side public-key accessor and provisioning so the spoke and hub agree on the
@@ -194,6 +257,17 @@ func spokeDomainKey(envVar, info string) string {
 
 // SpokeHeartbeatKey returns the bearer a spoke presents on /api/heartbeat and
 // /api/task-status. Exported for use from the dashboard/heartbeat call sites.
+//
+// N1 note: a hub-provisioned spoke gets HIVE_HEARTBEAT_KEY, which is now the
+// PER-HIVE bearer — no spoke-side change is needed, the value in the env var
+// simply becomes identity-bound at the next re-provision.
+//
+// The HIVE_HUB_SECRET fallback below still derives the FLEET-wide bearer, and
+// deliberately so: it serves self-hosted operators who legitimately hold the
+// master and beat against their own hub, where "any spoke can claim any ID" is
+// not a cross-tenant concern because there is exactly one tenant. The hub keeps
+// accepting that value through verifyHeartbeatBearer's legacy lane. A hosted
+// spoke cannot reach this path — it never receives the master.
 func SpokeHeartbeatKey() string { return spokeDomainKey(EnvHeartbeatKey, infoHeartbeatKey) }
 
 // SpokeSessionKey returns the key a spoke uses to VERIFY the hub-minted

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -269,7 +269,10 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// Set the session cookie to a signed, tamper-evident value so it cannot be
 	// forged. If the hub has no secret to sign with, fail the login rather than
 	// emit an unsigned (trusted-by-default) cookie.
-	cookieValue := mintHubUserCookieValue(s.sessionKey(), user.Login)
+	// N2: mint ASYMMETRICALLY. The hub holds the Ed25519 private seed; spokes
+	// receive only the public key, so a spoke operator can verify this cookie but
+	// can no longer forge one (notably an admin cookie).
+	cookieValue := mintHubUserCookieValueV2(s.sessionSigningSeed(), user.Login)
 	if cookieValue == "" {
 		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", user.Login)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
@@ -320,7 +323,8 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	}
 	// Trust the carried username only when its signature verifies; a legacy
 	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
-	username, ok := verifyHubUserCookieValue(s.sessionKey(), cookie.Value)
+	// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
+	username, ok := verifyHubUserCookieEither(s.sessionPublicKey(), s.sessionKey(), cookie.Value)
 	if !ok || loadSaaSUser(username) == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -106,8 +106,19 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	if sessionCookie.Value == "octocat" {
 		t.Error("session cookie must be signed, not the raw username")
 	}
-	if user, ok := verifyHubUserCookieValue(deriveDomainKey(testHubSecret, infoSessionKey), sessionCookie.Value); !ok || user != "octocat" {
+	// N2: the hub now mints ASYMMETRICALLY (Ed25519). Verify through the same
+	// dual-accept path production uses, against the PUBLIC key — a spoke holds
+	// only that and must be able to verify with it.
+	pub := ssoPublicKeyFromSeed(deriveDomainKey(testHubSecret, infoSessionEd25519Seed))
+	legacy := deriveDomainKey(testHubSecret, infoSessionKey)
+	if user, ok := verifyHubUserCookieEither(pub, legacy, sessionCookie.Value); !ok || user != "octocat" {
 		t.Errorf("minted cookie did not verify: (%q, %v)", user, ok)
+	}
+	// And it must be the v2 format, not a legacy HMAC cookie that merely still
+	// verifies — otherwise the hub is silently minting the forgeable format.
+	if !hubCookieIsV2(sessionCookie.Value) {
+		t.Errorf("hub minted a LEGACY (symmetric) session cookie %q — any spoke could forge one",
+			sessionCookie.Value)
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -573,7 +573,8 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 		// against the hub secret. A legacy unsigned cookie or a forged value
 		// fails here and is treated as logged out, so the user re-authenticates
 		// through the normal login flow (which re-mints a signed cookie).
-		if username, ok := verifyHubUserCookieValue(s.sessionKey(), cookie.Value); ok {
+		// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
+		if username, ok := verifyHubUserCookieEither(s.sessionPublicKey(), s.sessionKey(), cookie.Value); ok {
 			if loadSaaSUser(username) != nil {
 				return username
 			}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1694,17 +1694,26 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 			}
 			return strings.Join(lines, "\n")
 		}(),
-		// AdditionalAppKeys delivers the fleet's OTHER App keys at provision time,
-		// each in its own per-app-id Secret entry. Naming is by APP ID, not by
-		// cluster: a key's identity is the App it belongs to, and the spoke selects
-		// by matching its configured app_id (resolveAppKeyFile). Per-cluster naming
-		// would be a lie here — the same PEM is valid on every cluster whose hives
-		// authenticate as that App, and a spoke has no way to know which cluster a
-		// file named for one was meant to serve. The primary key is excluded: it is
-		// already written as gh-app-key.pem above, and duplicating it would let the
-		// two copies drift.
-		"AdditionalAppKeys": provisionAdditionalAppKeys(
-			fleetKeys, resolveProvisionAppID(req.AppID, h, cluster)),
+		// SECURITY (audit N1, CWE-200): a spoke receives ONLY its own App key.
+		//
+		// This used to render every OTHER App key in the fleet into each new
+		// hive's Secret, so one tenant's pod held other tenants' GitHub App
+		// private keys — and with the 0644 projection (N5) every agent UID in
+		// that pod could read them. The stated rationale was pre-positioning a
+		// key for a possible future forge switch.
+		//
+		// That is the SAME argument this codebase already rejected when it
+		// removed the heartbeat's fleet-wide broadcast (see the note above
+		// appKeySyncDecision in cluster_app_key.go): speculative distribution of
+		// private key material is not justified by a migration that may never
+		// happen. When a hive IS re-assigned to a different App, that App's key
+		// is delivered at that moment through the reconcile / pending-identity
+		// lanes, keyed to the hive authoritatively assigned it.
+		//
+		// Kept as an empty list rather than deleting the template block, so a
+		// spoke rolling on an older manifest sees the field disappear cleanly
+		// instead of failing to render.
+		"AdditionalAppKeys": []provisionAppKey{},
 		"CPURequest":            cpuRequest,
 		"CPULimit":              cpuLimit,
 		"MemRequest":            memRequest,
@@ -1731,7 +1740,11 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// C2 follow-up: SSO is asymmetric — the spoke gets only the Ed25519 PUBLIC
 		// key (SSOPublicKey), derived from the same master seed the hub signs with,
 		// so even a hostile spoke operator holding this value cannot mint a token.
-		"HeartbeatKey": deriveDomainKey(provisionMasterSecret(), infoHeartbeatKey),
+		// N1: the heartbeat bearer is PER-HIVE. A fleet-wide bearer proved only
+		// "some provisioned spoke", so the hub had to trust body-supplied
+		// hive_id — and three key-delivery lanes read off that claimed ID.
+		// Binding the bearer to the hive makes the claim self-authenticating.
+		"HeartbeatKey": provisionHeartbeatKey(h.ID),
 		"SessionKey":   deriveDomainKey(provisionMasterSecret(), infoSessionKey),
 		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
 		// N3: the terminal key is PER-HIVE, not fleet-wide. Without it

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1747,6 +1747,12 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		"HeartbeatKey": provisionHeartbeatKey(h.ID),
 		"SessionKey":   deriveDomainKey(provisionMasterSecret(), infoSessionKey),
 		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
+		// N2: the Ed25519 PUBLIC key for hub session cookies. A spoke verifies
+		// hive_hub_user with this and cannot mint one — unlike SessionKey below,
+		// which is symmetric and therefore let any spoke forge a hub ADMIN cookie.
+		// SessionKey is still shipped for the rollout window so a spoke on an older
+		// image keeps verifying legacy cookies; remove it once the fleet has rolled.
+		"SessionPublicKey": provisionSessionPublicKey(),
 		// N3: the terminal key is PER-HIVE, not fleet-wide. Without it
 		// TerminalSigningKey() falls through to the fleet-uniform SessionKey
 		// above, so an assertion minted on one spoke verifies on every other —
@@ -2584,6 +2590,15 @@ spec:
         # seed, can). Replaces the earlier symmetric HIVE_SSO_KEY.
         - name: HIVE_SSO_PUBLIC_KEY
           value: "{{.SSOPublicKey}}"
+        # N2 (CWE-321/798): the Ed25519 PUBLIC key for hub SESSION cookies.
+        # HIVE_SESSION_KEY above is symmetric, so every spoke that could VERIFY
+        # hive_hub_user could also MINT it — including "clubanderson.<sig>",
+        # which requireAdmin accepts on ~21 admin routes. With this the spoke
+        # verifies and cannot forge. HIVE_SESSION_KEY is still injected for the
+        # rollout window (a spoke on an older image only knows the legacy
+        # format); drop it once the fleet has rolled.
+        - name: HIVE_SESSION_PUBLIC_KEY
+          value: "{{.SessionPublicKey}}"
         # N3 (CWE-862): the terminal signing key is PER-HIVE. This spoke both
         # mints the assertion (dashboard/session.go, at login) and verifies it
         # (proxy/server.js, on /terminal), so a symmetric key is the right shape

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1177,12 +1177,18 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// secret — the master never leaves the hub (C2 domain separation). Spokes are
 	// injected only this sub-key, so a spoke operator's bearer can prove
 	// "I am a provisioned spoke" but cannot sign a session/SSO/impersonation value.
+	// The bearer is captured here but VERIFIED below, after the body is parsed:
+	// the per-hive bearer (N1) can only be checked once the claimed hive_id is
+	// known. The legacy fleet-wide key is still accepted during the rollout —
+	// see verifyHeartbeatBearer.
+	presentedBearer := ""
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.heartbeatKey()) {
+		if !strings.HasPrefix(auth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		presentedBearer = strings.TrimPrefix(auth, "Bearer ")
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadBytes))
@@ -1202,15 +1208,34 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "hive_id required", http.StatusBadRequest)
 		return
 	}
+	if !isValidName(payload.HiveID) {
+		http.Error(w, "invalid hive_id", http.StatusBadRequest)
+		return
+	}
+
+	// SECURITY (audit N1, CWE-200/639/862): bind the bearer to the CLAIMED
+	// identity.
+	//
+	// The bearer used to be checked against s.heartbeatKey() alone — one
+	// fleet-wide value derived from a fixed label, so every spoke held the same
+	// bytes. Possession proved "some provisioned spoke" and nothing more, and
+	// payload.HiveID was then trusted verbatim. Three key-delivery lanes read
+	// off that claimed ID (pending OpenRouter key, legacy pending App config,
+	// standing cluster App key), so any spoke could beat as any victim and be
+	// handed the victim's key material.
+	if s.hubSecret != "" {
+		if !s.verifyHeartbeatBearer(presentedBearer, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
 	// Normalize the reported SHA to the canonical short length up front so every
 	// downstream comparison is same-length against the hub's 7-char stored SHAs.
 	// (Spokes now build gitShort with `--short=7`; this covers any that predate
 	// that or report a longer value.)
 	payload.GitHash = shortSHA(payload.GitHash)
-	if !isValidName(payload.HiveID) {
-		http.Error(w, "invalid hive_id", http.StatusBadRequest)
-		return
-	}
+	// (hive_id is validated above, before the bearer check — the per-hive bearer
+	// is derived from it, so it must be well-formed before it can authenticate.)
 	if payload.Org != "" && !isValidName(payload.Org) {
 		http.Error(w, "invalid org name", http.StatusBadRequest)
 		return
@@ -2287,12 +2312,17 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	// Same derived HEARTBEAT sub-key as /api/heartbeat (task-status is the spoke's
 	// other beat channel); the master secret is never accepted here.
+	//
+	// N1: like /api/heartbeat, the bearer is captured here and verified below,
+	// once the claimed hive_id is known — the per-hive bearer is derived from it.
+	presentedBearer := ""
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.heartbeatKey()) {
+		if !strings.HasPrefix(auth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		presentedBearer = strings.TrimPrefix(auth, "Bearer ")
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadBytes))
@@ -2313,6 +2343,17 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	if payload.HiveID == "" {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
+	}
+	if !isValidName(payload.HiveID) {
+		http.Error(w, "invalid hive_id", http.StatusBadRequest)
+		return
+	}
+	// N1: bind the bearer to the claimed hive, same as /api/heartbeat.
+	if s.hubSecret != "" {
+		if !s.verifyHeartbeatBearer(presentedBearer, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
 	}
 	for i, lb := range payload.Leaderboard {
 		payload.Leaderboard[i].GitHubUsername = sanitizeField(lb.GitHubUsername)

--- a/v2/pkg/hub/session_cookie_asym_test.go
+++ b/v2/pkg/hub/session_cookie_asym_test.go
@@ -1,0 +1,180 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// N2 (CWE-321/798): the hub session cookie must be ASYMMETRICALLY signed.
+//
+// The cookie is `hive_hub_user`, and requireAdmin gates ~21 admin routes on
+// nothing but a string compare of its carried username against
+// hubAdminUsername. It used to be HMAC'd with the SESSION sub-key — which
+// provisioning injects into EVERY spoke so each spoke's proxy can verify it.
+//
+// An HMAC key that verifies also signs. So any spoke operator could read
+// HIVE_SESSION_KEY out of their own pod env and mint `clubanderson.<sig>`,
+// producing a hub ADMIN session — including access to the cluster App-key
+// writer, which loops straight back into N1's key material.
+//
+// Ed25519 splits the two capabilities: the hub holds the private seed, spokes
+// receive only the public key. Same split the SSO handoff already made (#2771).
+
+const n2Master = "test-master-secret-n2"
+
+func n2Hub() *HubServer { return &HubServer{hubSecret: n2Master} }
+
+// TestSessionCookieV2RoundTrips is the basic contract.
+func TestSessionCookieV2RoundTrips(t *testing.T) {
+	s := n2Hub()
+	c := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+	if c == "" {
+		t.Fatal("mint returned empty for valid inputs")
+	}
+	if !strings.Contains(c, hubCookieV2Marker) {
+		t.Fatalf("minted cookie %q carries no v2 marker", c)
+	}
+	u, ok := verifyHubUserCookieValueV2(s.sessionPublicKey(), c)
+	if !ok || u != "alice" {
+		t.Fatalf("verify = (%q,%v), want (alice,true)", u, ok)
+	}
+}
+
+// TestSpokePublicKeyCannotMint is the finding itself: the value a spoke holds
+// must not yield a cookie the hub will accept.
+//
+// Note what is and is not checked here. An Ed25519 public key and a seed are
+// BOTH 32 bytes, so a length check cannot tell them apart — mint will happily
+// treat a public key as a seed and emit a syntactically valid cookie. (The
+// comment on MintSSOToken's identical guard claims it catches "a public key
+// passed by mistake"; it does not, for the same reason.) That is harmless
+// because the resulting signature is made by a DIFFERENT private key than the
+// one the hub's public key corresponds to, so it cannot verify. Verification —
+// not the mint-side guard — is the boundary, which is exactly what this asserts.
+func TestSpokePublicKeyCannotMint(t *testing.T) {
+	s := n2Hub()
+	pub := s.sessionPublicKey()
+	if pub == "" {
+		t.Fatal("public key derivation returned empty")
+	}
+
+	// A spoke tries to mint an ADMIN cookie with the only key it has.
+	forged := mintHubUserCookieValueV2(pub, hubAdminUsername)
+	if forged == "" {
+		return // even better: it failed closed at mint
+	}
+	if u, ok := verifyHubUserCookieValueV2(pub, forged); ok {
+		t.Fatalf("N2: a spoke minted a VERIFIABLE admin cookie (%q) from the public key alone — "+
+			"the spoke-held value is still signing material", u)
+	}
+	// Also confirm it is rejected through the dual-verify path the hub actually
+	// calls, legacy lane included.
+	if u, ok := verifyHubUserCookieEither(pub, s.sessionKey(), forged); ok {
+		t.Fatalf("N2: the spoke-forged admin cookie was accepted by the live verify path as %q", u)
+	}
+}
+
+// TestSessionCookieV2RejectsTampering covers the forgery shapes that matter: a
+// swapped username (privilege escalation to admin) and an edited signature.
+func TestSessionCookieV2RejectsTampering(t *testing.T) {
+	s := n2Hub()
+	pub := s.sessionPublicKey()
+	legit := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+	sig := legit[strings.LastIndex(legit, hubCookieV2Marker)+len(hubCookieV2Marker):]
+
+	// Alice's signature re-labelled as the admin — the escalation an attacker
+	// actually wants.
+	if u, ok := verifyHubUserCookieValueV2(pub, hubAdminUsername+hubCookieV2Marker+sig); ok {
+		t.Fatalf("N2: a re-labelled cookie verified as %q — username is not covered by the signature", u)
+	}
+	// Edited signature.
+	if _, ok := verifyHubUserCookieValueV2(pub, "alice"+hubCookieV2Marker+"AAAA"); ok {
+		t.Fatal("a garbage signature verified")
+	}
+	// Wrong hub's key.
+	other := (&HubServer{hubSecret: "a-different-master"}).sessionPublicKey()
+	if _, ok := verifyHubUserCookieValueV2(other, legit); ok {
+		t.Fatal("a cookie verified under a DIFFERENT hub's public key")
+	}
+}
+
+// TestSessionCookieDualVerifyDuringRollout pins the compatibility contract: the
+// hub mints v2 but must keep accepting legacy HMAC cookies, or every live
+// browser session breaks at deploy.
+func TestSessionCookieDualVerifyDuringRollout(t *testing.T) {
+	s := n2Hub()
+	pub, legacySecret := s.sessionPublicKey(), s.sessionKey()
+
+	v2Cookie := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+	legacyCookie := mintHubUserCookieValue(legacySecret, "bob")
+
+	if u, ok := verifyHubUserCookieEither(pub, legacySecret, v2Cookie); !ok || u != "alice" {
+		t.Errorf("v2 cookie failed dual-verify: (%q,%v)", u, ok)
+	}
+	if u, ok := verifyHubUserCookieEither(pub, legacySecret, legacyCookie); !ok || u != "bob" {
+		t.Errorf("legacy cookie failed dual-verify: (%q,%v) — live sessions would break at deploy", u, ok)
+	}
+
+	// And once the legacy secret is withdrawn (the follow-up removal PR), the
+	// legacy cookie must stop verifying while v2 keeps working.
+	if _, ok := verifyHubUserCookieEither(pub, "", legacyCookie); ok {
+		t.Error("legacy cookie still verified with the legacy lane disabled")
+	}
+	if u, ok := verifyHubUserCookieEither(pub, "", v2Cookie); !ok || u != "alice" {
+		t.Errorf("v2 cookie broke when the legacy lane was disabled: (%q,%v)", u, ok)
+	}
+}
+
+// TestHubCookieIsV2 covers the rollout telemetry helper.
+func TestHubCookieIsV2(t *testing.T) {
+	s := n2Hub()
+	if !hubCookieIsV2(mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")) {
+		t.Error("v2 cookie not reported as v2")
+	}
+	if hubCookieIsV2(mintHubUserCookieValue(s.sessionKey(), "alice")) {
+		t.Error("legacy cookie misreported as v2 — an operator would cut the compatibility " +
+			"lane while sessions still depend on it")
+	}
+}
+
+// TestSessionSeedIsNotTheSpokeValue guards the whole point of the change: what
+// the hub signs with and what a spoke receives must be different values, and the
+// signing seed must not be derivable from the shipped one.
+func TestSessionSeedIsNotTheSpokeValue(t *testing.T) {
+	s := n2Hub()
+	seed, pub, legacy := s.sessionSigningSeed(), s.sessionPublicKey(), s.sessionKey()
+
+	if seed == "" || pub == "" {
+		t.Fatal("seed or public key empty")
+	}
+	if seed == pub {
+		t.Fatal("the signing seed IS the value shipped to spokes — nothing was gained")
+	}
+	// Distinct domain label, so the asymmetric seed can never collide with the
+	// symmetric session key still shipped during rollout.
+	if seed == legacy {
+		t.Fatal("the Ed25519 seed collides with the legacy symmetric session key")
+	}
+}
+
+// TestSessionCookieV2FailsClosed: no key material, no cookie.
+func TestSessionCookieV2FailsClosed(t *testing.T) {
+	if got := mintHubUserCookieValueV2("", "alice"); got != "" {
+		t.Errorf("mint with no seed returned %q", got)
+	}
+	if got := mintHubUserCookieValueV2("not-hex", "alice"); got != "" {
+		t.Errorf("mint with garbage seed returned %q", got)
+	}
+	s := n2Hub()
+	if got := mintHubUserCookieValueV2(s.sessionSigningSeed(), ""); got != "" {
+		t.Errorf("mint with no username returned %q", got)
+	}
+	if _, ok := verifyHubUserCookieValueV2("", "alice.v2.AAAA"); ok {
+		t.Error("verify succeeded with no public key")
+	}
+	// An empty-master hub derives nothing at all.
+	empty := &HubServer{hubSecret: ""}
+	if empty.sessionSigningSeed() != "" || empty.sessionPublicKey() != "" {
+		t.Error("an empty master produced usable key material")
+	}
+}

--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js"
+    "test": "node server.test.js && node session_cookie_v2.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -35,10 +35,52 @@ function deriveSessionKey() {
   return crypto.createHmac('sha256', master).update(INFO_SESSION_KEY).digest('hex');
 }
 const SESSION_KEY = deriveSessionKey();
+
+// SESSION_PUBLIC_KEY is the hub's Ed25519 PUBLIC key for session cookies (audit
+// N2). The hub holds the private seed and is the only party that can MINT a
+// cookie; this spoke can only VERIFY.
+//
+// SESSION_KEY above is symmetric, so a spoke able to verify was equally able to
+// mint — any spoke operator could read it from the pod env and forge
+// `clubanderson.<sig>`, a hub ADMIN cookie honoured on ~21 admin routes. Both
+// are read during the rollout window: this spoke may be running an older image
+// than the hub, or vice versa. Once the fleet has rolled, HIVE_SESSION_KEY (and
+// the legacy branch in verifyHubUserCookieEither) go away.
+//
+// Derived from HIVE_HUB_SECRET as a fallback for self-hosted spokes whose
+// operator legitimately holds the master. The info string MUST stay byte-for-byte
+// identical to infoSessionEd25519Seed in v2/pkg/hub/hub_keys.go.
+const INFO_SESSION_ED25519_SEED = 'hive-session-ed25519-v1';
+function deriveSessionPublicKey() {
+  const explicit = (process.env.HIVE_SESSION_PUBLIC_KEY || '').trim();
+  if (explicit) return explicit;
+  const master = (process.env.HIVE_HUB_SECRET || '').trim();
+  if (!master) return '';
+  const seedHex = crypto.createHmac('sha256', master).update(INFO_SESSION_ED25519_SEED).digest('hex');
+  try {
+    // Node cannot expand a raw Ed25519 seed directly, so wrap it in the PKCS#8
+    // prefix for a 32-byte Ed25519 private key and export the public half. This
+    // mirrors Go's ed25519.NewKeyFromSeed(seed).Public().
+    const pkcs8 = Buffer.concat([
+      Buffer.from('302e020100300506032b657004220420', 'hex'),
+      Buffer.from(seedHex, 'hex'),
+    ]);
+    const priv = crypto.createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+    const spki = crypto.createPublicKey(priv).export({ format: 'der', type: 'spki' });
+    // Strip the 12-byte SPKI header to get the raw 32-byte public key, matching
+    // the hex encoding the hub ships in HIVE_SESSION_PUBLIC_KEY.
+    return Buffer.from(spki.subarray(spki.length - 32)).toString('hex');
+  } catch (_) {
+    return '';
+  }
+}
+const SESSION_PUBLIC_KEY = deriveSessionPublicKey();
 // Boot-time "am I hub-hosted?" signal. Either the injected session key (modern)
 // or a master secret (legacy) proves hosted mode, where identity comes from the
 // hub cookie rather than a shared dashboard token.
-const IS_HOSTED = SESSION_KEY !== '';
+// N2: either key proves hosted mode. A freshly provisioned spoke may hold only
+// the public key once HIVE_SESSION_KEY is dropped after the rollout.
+const IS_HOSTED = SESSION_KEY !== '' || SESSION_PUBLIC_KEY !== '';
 
 // HIVE_ID is this spoke's own hive identity, injected by the hub at provision
 // time (mirrors the HIVE_ID env the Go dashboard reads). It is the anchor for
@@ -326,6 +368,46 @@ function verifyHubUserCookie(secret, value) {
   return username;
 }
 
+// HUB_COOKIE_V2_MARKER separates the username from an Ed25519 signature. It must
+// stay byte-identical to hubCookieV2Marker in v2/pkg/hub/hub_cookie.go. A legacy
+// HMAC signature is base64url and so can never contain a '.', which is what makes
+// the two formats distinguishable by structure rather than by guessing.
+const HUB_COOKIE_V2_MARKER = '.v2.';
+
+// verifyHubUserCookieV2 mirrors verifyHubUserCookieValueV2 in
+// v2/pkg/hub/hub_cookie.go EXACTLY: value is `<username>.v2.<base64url(sig)>`
+// where sig is Ed25519 over the username, verified against the hub's PUBLIC key.
+// Returns the verified username, or '' on any failure.
+function verifyHubUserCookieV2(pubHex, value) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(HUB_COOKIE_V2_MARKER);
+  if (idx <= 0) return '';
+  const username = value.slice(0, idx);
+  const sigB64 = value.slice(idx + HUB_COOKIE_V2_MARKER.length);
+  if (!username || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    // Wrap the raw 32-byte key in its SPKI header so Node can import it.
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    const sig = Buffer.from(sigB64, 'base64url');
+    return crypto.verify(null, Buffer.from(username), pub, sig) ? username : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+// verifyHubUserCookieEither accepts a v2 (Ed25519) cookie or, during the rollout
+// window only, a legacy HMAC one — mirroring the Go helper of the same name.
+// The legacy branch is the N2 vulnerability (verify-capable implies mint-capable)
+// and is removed once the fleet has rolled and existing cookies have aged out.
+function verifyHubUserCookieEither(pubHex, legacySecret, value) {
+  const v2 = verifyHubUserCookieV2(pubHex, value);
+  if (v2) return v2;
+  return verifyHubUserCookie(legacySecret, value);
+}
+
 app.use((req, res, next) => {
   res.setHeader('Content-Security-Policy', [
     "default-src 'self'",
@@ -434,7 +516,7 @@ app.use('/terminal', (req, res, next) => {
     }, {});
     // SECURITY (CWE-345): the cookie is HMAC-signed by the hub. Verify the
     // signature — a non-empty value is NOT proof of authentication.
-    const user = verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user']);
+    const user = verifyHubUserCookieEither(SESSION_PUBLIC_KEY, SESSION_KEY, cookies['hive_hub_user']);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -536,7 +618,7 @@ server.on('upgrade', (req, socket, head) => {
         return acc;
       }, {});
       // SECURITY (CWE-345): verify the hub's HMAC signature, not mere existence.
-      const wsUser = verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user']);
+      const wsUser = verifyHubUserCookieEither(SESSION_PUBLIC_KEY, SESSION_KEY, cookies['hive_hub_user']);
       if (!wsUser) {
         socket.destroy();
         return;

--- a/v2/proxy/session_cookie_v2.test.js
+++ b/v2/proxy/session_cookie_v2.test.js
@@ -1,0 +1,173 @@
+// N2 (CWE-321/798): the proxy must verify Ed25519-signed hub session cookies,
+// and a spoke must NOT be able to forge one.
+//
+// Run: node session_cookie_v2.test.js
+//
+// The hub session cookie (`hive_hub_user`) used to be HMAC'd with the SESSION
+// sub-key, which provisioning injects into EVERY spoke so each spoke's proxy can
+// verify it. An HMAC key that verifies also signs, so any spoke operator could
+// read HIVE_SESSION_KEY from their pod env and mint `clubanderson.<sig>` — a hub
+// ADMIN cookie honoured on ~21 admin routes.
+//
+// These tests are self-contained (no proxy process): they exercise the exact
+// verification logic server.js uses, against vectors produced the way the Go hub
+// produces them. The cross-language agreement is the risky part — if Go and Node
+// disagree on the encoding, every hosted login breaks at deploy.
+
+import crypto from 'crypto';
+import assert from 'assert';
+
+const INFO_SESSION_ED25519_SEED = 'hive-session-ed25519-v1';
+const INFO_SESSION_KEY = 'hive-session-v1';
+const MARKER = '.v2.';
+
+// --- helpers mirroring the hub (Go) side -----------------------------------
+
+// seedFromMaster mirrors deriveDomainKey(master, infoSessionEd25519Seed).
+function seedFromMaster(master) {
+  return crypto.createHmac('sha256', master).update(INFO_SESSION_ED25519_SEED).digest('hex');
+}
+
+function privFromSeed(seedHex) {
+  const pkcs8 = Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'),
+    Buffer.from(seedHex, 'hex'),
+  ]);
+  return crypto.createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+}
+
+function pubHexFromSeed(seedHex) {
+  const spki = crypto.createPublicKey(privFromSeed(seedHex)).export({ format: 'der', type: 'spki' });
+  return Buffer.from(spki.subarray(spki.length - 32)).toString('hex');
+}
+
+// mintV2 mirrors mintHubUserCookieValueV2 — HUB-ONLY, needs the private seed.
+function mintV2(seedHex, username) {
+  const sig = crypto.sign(null, Buffer.from(username), privFromSeed(seedHex));
+  return username + MARKER + sig.toString('base64url');
+}
+
+// --- the code under test (copied from server.js, kept in lockstep) ---------
+
+function verifyHubUserCookieV2(pubHex, value) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(MARKER);
+  if (idx <= 0) return '';
+  const username = value.slice(0, idx);
+  const sigB64 = value.slice(idx + MARKER.length);
+  if (!username || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    const sig = Buffer.from(sigB64, 'base64url');
+    return crypto.verify(null, Buffer.from(username), pub, sig) ? username : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function verifyHubUserCookie(secret, value) {
+  if (!secret || !value) return '';
+  const idx = value.lastIndexOf('.');
+  if (idx <= 0 || idx === value.length - 1) return '';
+  const username = value.slice(0, idx);
+  const sig = value.slice(idx + 1);
+  const expected = crypto.createHmac('sha256', secret).update(username).digest('base64url');
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return '';
+  return username;
+}
+
+function verifyHubUserCookieEither(pubHex, legacySecret, value) {
+  return verifyHubUserCookieV2(pubHex, value) || verifyHubUserCookie(legacySecret, value);
+}
+
+// --- tests ------------------------------------------------------------------
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+const MASTER = 'test-master-secret-n2';
+const SEED = seedFromMaster(MASTER);
+const PUB = pubHexFromSeed(SEED);
+const LEGACY = crypto.createHmac('sha256', MASTER).update(INFO_SESSION_KEY).digest('hex');
+
+test('a hub-minted v2 cookie verifies against the public key', () => {
+  const c = mintV2(SEED, 'alice');
+  assert.strictEqual(verifyHubUserCookieV2(PUB, c), 'alice');
+});
+
+test('THE FINDING: a spoke holding only the public key cannot forge an admin cookie', () => {
+  // The spoke's only key material is PUB. Treating it as a seed yields a
+  // syntactically valid cookie (a public key and a seed are both 32 bytes, so
+  // nothing can tell them apart by length) — but it is signed by a DIFFERENT
+  // private key, so it must not verify.
+  const forged = mintV2(PUB, 'clubanderson');
+  assert.strictEqual(
+    verifyHubUserCookieV2(PUB, forged), '',
+    'a spoke forged a verifiable hub ADMIN cookie from the public key alone');
+  assert.strictEqual(
+    verifyHubUserCookieEither(PUB, LEGACY, forged), '',
+    'the spoke-forged admin cookie was accepted by the live verify path');
+});
+
+test('a re-labelled cookie (alice signature, admin username) is rejected', () => {
+  const c = mintV2(SEED, 'alice');
+  const sig = c.slice(c.lastIndexOf(MARKER) + MARKER.length);
+  assert.strictEqual(verifyHubUserCookieV2(PUB, 'clubanderson' + MARKER + sig), '',
+    'username is not covered by the signature');
+});
+
+test('a cookie from a different hub is rejected', () => {
+  const otherPub = pubHexFromSeed(seedFromMaster('a-different-master'));
+  assert.strictEqual(verifyHubUserCookieV2(otherPub, mintV2(SEED, 'alice')), '');
+});
+
+test('garbage and malformed values fail closed', () => {
+  for (const v of ['', 'alice', 'alice.v2.', '.v2.AAAA', 'alice.v2.!!!!']) {
+    assert.strictEqual(verifyHubUserCookieV2(PUB, v), '', `accepted ${JSON.stringify(v)}`);
+  }
+  assert.strictEqual(verifyHubUserCookieV2('', mintV2(SEED, 'alice')), '', 'accepted with no public key');
+  assert.strictEqual(verifyHubUserCookieV2('abcd', mintV2(SEED, 'alice')), '', 'accepted a short public key');
+});
+
+test('ROLLOUT: legacy HMAC cookies still verify alongside v2', () => {
+  const legacyCookie = 'bob.' + crypto.createHmac('sha256', LEGACY).update('bob').digest('base64url');
+  assert.strictEqual(verifyHubUserCookieEither(PUB, LEGACY, legacyCookie), 'bob',
+    'a live browser session would break at deploy');
+  assert.strictEqual(verifyHubUserCookieEither(PUB, LEGACY, mintV2(SEED, 'alice')), 'alice');
+  // With the legacy lane withdrawn (the follow-up removal), legacy stops working
+  // and v2 keeps working.
+  assert.strictEqual(verifyHubUserCookieEither(PUB, '', legacyCookie), '');
+  assert.strictEqual(verifyHubUserCookieEither(PUB, '', mintV2(SEED, 'alice')), 'alice');
+});
+
+test('INTEROP: the public key derived here matches the Go hub byte-for-byte', () => {
+  // Vector generated from the Go implementation with master "interop-master":
+  //   s := &HubServer{hubSecret: "interop-master"}; s.sessionPublicKey()
+  const GO_MASTER = 'interop-master';
+  const GO_PUB = 'fd5a5ba6610c75a66deb729adba31b2b5768d2e72f3621fcab6e16ad3b9a6520';
+  const GO_COOKIE =
+    'clubanderson.v2.plC1ZL1n1nxCIwemNsm0SQ4eZXfDhzY63b-QfaQs7gy2Pllc3V4d86bnVcWmsFExzAMo9ZMqJucVU0mRQY0UCg';
+
+  assert.strictEqual(pubHexFromSeed(seedFromMaster(GO_MASTER)), GO_PUB,
+    'Node and Go derive DIFFERENT public keys from the same master — every hosted login would break');
+  assert.strictEqual(verifyHubUserCookieV2(GO_PUB, GO_COOKIE), 'clubanderson',
+    'Node cannot verify a real Go-minted cookie');
+});
+
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`ok   ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`FAIL ${name}\n     ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} passed`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
**Stacked on #3196** (N1), which is stacked on the merged #3195 (N3). Merge in order.

Third and last of the hosted kill chain (N1/N2/N3 = the prior audit's C1/C2/C3).

## The bug

`hive_hub_user` was HMAC'd with the SESSION sub-key, and `requireAdmin` gates ~21 admin routes on nothing but a string compare of its carried username against `hubAdminUsername`.

That key is provisioned into **every** spoke, because each spoke's proxy has to verify the cookie. But an HMAC key that verifies also **signs**. Any spoke operator could read `HIVE_SESSION_KEY` from their own pod env and mint `clubanderson.<sig>` — a hub **admin** session, including `PUT /api/saas/admin/cluster-app-keys/{clusterID}`, which loops straight back into N1's key material.

## The fix

Ed25519 — the same split the SSO handoff already made in #2771. The hub holds the private seed; spokes receive only `HIVE_SESSION_PUBLIC_KEY`. Verify-capable no longer implies mint-capable.

```
v2 value = <username>.v2.<base64url(Ed25519-Sign(priv, username))>
```

The `.v2.` marker makes the two formats distinguishable by **structure** rather than by guessing: a legacy HMAC signature is base64url and can never contain a dot.

## Rollout: verify-both, mint-new

The hub mints only v2, while `verifyHubUserCookieEither` accepts either format — on **both** the Go and Node sides. Live browser sessions keep working until their cookie is re-minted at next login; a spoke on an older image keeps verifying legacy cookies until it re-provisions. `HIVE_SESSION_KEY` is still injected for that window.

The legacy lane **is** the vulnerability, so it's explicitly temporary. Removing it (and the env var) is a follow-up gated on the fleet having rolled and cookies having aged out — bounded by the cookie's own `MaxAge`. `hubCookieIsV2` provides the telemetry for when that's safe.

## Cross-language interop is the real risk

The cookie is minted in Go and verified in Node, so an encoding disagreement breaks **every hosted login** at deploy — silently, and only in production.

I generated vectors from the Go implementation and confirmed Node derives a byte-identical public key and verifies a real Go-minted cookie. Those vectors are frozen into `proxy/session_cookie_v2.test.js`, and that file is now wired into `npm test`, so drift fails CI instead of production. (Node can't import a raw Ed25519 seed directly — it needs PKCS#8/SPKI wrapping. That plumbing is exactly what the interop test pins.)

## Change surface traced, not assumed

I checked every `hive_hub_user` consumer:
- **Node proxy** — the only spoke-side verifier. Updated (2 call sites + `IS_HOSTED`).
- **`dashboard/api.go:705`** — only **forwards** the cookie to the hub, never verifies it. Format-agnostic, unaffected.
- **`SpokeSessionKey()`** — no production callers.

## A note on the mint-side guard

An Ed25519 public key and a seed are **both 32 bytes**, so a length check cannot tell them apart — mint will emit a syntactically valid cookie from a public key. `MintSSOToken`'s identical guard carries a comment claiming it catches "a public key passed by mistake"; it does not, for the same reason.

That's harmless, because the signature is then made by a different private key and cannot verify. But it means the boundary is **verification**, not the mint-side guard — so the tests assert it where it actually holds. Worth knowing before someone relies on that comment.

## Regression

Go: round-trip; spoke-with-public-key-only cannot produce a cookie the live verify path accepts; a re-labelled cookie (alice's signature, admin username) is rejected; a different hub's key is rejected; dual-verify works and the legacy lane can be cleanly withdrawn; fail-closed on every missing/garbage input.

Node: the same, plus the frozen Go interop vectors.

`TestHandleOAuthCallbackSuccess` verified with the old symmetric helper and correctly **failed** on this change. Updated to verify through the same dual-accept path production uses — plus an assertion that the minted cookie is genuinely v2, since without it the hub could silently keep minting the forgeable format and the test would still pass.

## CI note

`test` job failures on v4 are pre-existing (#3162 data race, #3163 beads/sandbox — #3199 fixes the sandbox half). This PR touches neither package.