### PR TITLE
🐛 fail closed owner-only dashboard mutations

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1232,16 +1232,17 @@ func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, p
 }
 
 // requireOwnerRole returns true when the request carries owner-level access.
-// An empty X-Hive-Role is treated as owner (open/dev spokes with no auth_token
-// or hub-proxied spokes where the hub omits the header). Any non-owner role
-// set by the hub or device-flow session is rejected. Call this for state-mutating
-// endpoints that should be restricted to operators (pause, resume, fleet breaker).
+// The authentication middleware owns X-Hive-Role and strips client-supplied
+// values before injecting roles for trusted sources. Owner-only mutations also
+// require its server-only verification marker, so legacy/proofless proxy
+// headers and shared-token requests fail closed instead of trusting spoofable
+// client input.
 func requireOwnerRole(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		return true // open spoke or internal automation — treat as owner
+	if role == "" && r.Header.Get(authCheckedHeader) != "true" {
+		return true
 	}
-	if role != "owner" {
+	if role != "owner" || r.Header.Get(ownerRoleVerifiedHeader) != "true" {
 		jsonError(w, "owner access required", http.StatusForbidden)
 		return false
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1239,9 +1239,6 @@ func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, p
 // client input.
 func requireOwnerRole(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
-	if role == "" && r.Header.Get(authCheckedHeader) != "true" {
-		return true
-	}
 	if role != "owner" || r.Header.Get(ownerRoleVerifiedHeader) != "true" {
 		jsonError(w, "owner access required", http.StatusForbidden)
 		return false

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -879,7 +879,7 @@ func TestHandleUnpin_NotFound(t *testing.T) {
 
 func TestHandlePause(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -1353,7 +1353,7 @@ func TestHandleModelSet_UnknownAgent(t *testing.T) {
 
 func TestHandleResume_UnknownAgent(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/resume/nonexistent", nil)
+	rec := doOwnerPost(s, "/api/resume/nonexistent", nil)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}

--- a/v2/pkg/dashboard/api_pause_toggle_test.go
+++ b/v2/pkg/dashboard/api_pause_toggle_test.go
@@ -23,7 +23,7 @@ func decodeToggleBody(t *testing.T, body []byte) map[string]interface{} {
 
 func TestHandlePause_RealTransitionReportsChangedTrue(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -41,10 +41,10 @@ func TestHandlePause_RealTransitionReportsChangedTrue(t *testing.T) {
 
 func TestHandlePause_NoopReturnsChangedFalse(t *testing.T) {
 	s, _ := apiServer(t)
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("first pause status = %d, want 200", rec.Code)
 	}
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("second pause status = %d, want 200 (ok:true is part of the contract)", rec.Code)
 	}
@@ -63,7 +63,7 @@ func TestHandlePause_NoopReturnsChangedFalse(t *testing.T) {
 func TestHandleResume_NoopReturnsChangedFalse(t *testing.T) {
 	s, _ := apiServer(t)
 	// scanner starts un-paused: resuming it is a no-op.
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (no-op resume must not touch tmux)", rec.Code)
 	}
@@ -81,10 +81,10 @@ func TestHandleResume_NoopReturnsChangedFalse(t *testing.T) {
 
 func TestHandleResume_RealTransitionReportsChangedTrue(t *testing.T) {
 	s, _ := apiServer(t)
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("pause status = %d, want 200", rec.Code)
 	}
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	// A real resume relaunches the agent session; in environments without a
 	// working tmux this legitimately fails with 400 (same tolerance as
 	// TestHandleResume). The contract under test is: when it DOES succeed,
@@ -115,7 +115,7 @@ func TestHandleAgentState_ReflectsAuthoritativePause(t *testing.T) {
 		t.Errorf("fresh agent: paused = %v, state = %v; want false/running", m["paused"], m["state"])
 	}
 
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("pause status = %d, want 200", rec.Code)
 	}
 

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -87,6 +87,22 @@ func doPost(s *Server, path string, body interface{}) *httptest.ResponseRecorder
 	return rec
 }
 
+func markOwnerRequest(req *http.Request) {
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
+}
+
+func doOwnerPost(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
+	var b bytes.Buffer
+	json.NewEncoder(&b).Encode(body)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, &b)
+	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
 func doPut(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
 	var b bytes.Buffer
 	json.NewEncoder(&b).Encode(body)
@@ -951,7 +967,7 @@ func TestHandleKick_NoMessage(t *testing.T) {
 
 func TestHandlePause_NotFound(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/nonexistent", map[string]interface{}{})
+	rec := doOwnerPost(s, "/api/pause/nonexistent", map[string]interface{}{})
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
@@ -1018,7 +1034,7 @@ func TestHandleModelSet_NotFound(t *testing.T) {
 func TestHandleResume(t *testing.T) {
 	s, _ := apiServer(t)
 	// Resume may fail because agent isn't actually running
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	// Accept OK or BadRequest (tmux not available)
 	if rec.Code != http.StatusOK && rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d", rec.Code)
@@ -1027,7 +1043,7 @@ func TestHandleResume(t *testing.T) {
 
 func TestHandleResume_NotFound(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/resume/nonexistent", nil)
+	rec := doOwnerPost(s, "/api/resume/nonexistent", nil)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -669,6 +669,7 @@ func TestHandlePause_Boost(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/pause/scanner", strings.NewReader(`{"reason":"testing"}`))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	req.SetPathValue("agent", "scanner")
 	w := httptest.NewRecorder()
 	srv.handlePause(w, req)

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -33,3 +33,120 @@ func TestOwnerOnlyAgentControlsRejectNonOwners(t *testing.T) {
 		})
 	}
 }
+
+func TestOwnerOnlyMutationsRejectSharedTokenWithoutRole(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"pause", "/api/pause/scanner"},
+		{"resume", "/api/resume/scanner"},
+		{"breaker engage", "/api/breaker/engage"},
+		{"breaker release", "/api/breaker/release"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newFullServer(t)
+			s.authToken = "shared-secret-token"
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+s.authToken)
+			w := httptest.NewRecorder()
+
+			s.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("shared-token request without server role status = %d, want 403", w.Code)
+			}
+		})
+	}
+}
+
+func TestOwnerOnlyMutationsRejectSpoofedOwnerRoleWithSharedToken(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	req.Header.Set("X-Hive-User", "attacker")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("spoofed owner role with shared token status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsRejectInternalSharedTokenWithoutVerifiedRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("internal shared token without verified role status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsAllowOwnerSessionWithInternalAuth(t *testing.T) {
+	s := newDirectRouteServer(t, "owneruser")
+	sid := s.createUserSession("owneruser", "owner")
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner session with internal auth status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestOwnerOnlyMutationsAllowVerifiedHubOwnerRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-User", "owner")
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, s.authToken)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("verified hub owner role status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestOwnerOnlyMutationsRejectProoflessHubOwnerRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-User", "owner")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("proofless hub owner role status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsPreserveOpenSpokeOwnerBehavior(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = ""
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("open spoke owner behavior status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -43,11 +43,6 @@ const proxyAuthHeader = "X-Hive-Proxy-Auth"
 // when the owner role came from a trusted source, not an inbound client header.
 const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
 
-// authCheckedHeader marks requests that passed through authenticate. It keeps
-// owner checks fail-closed on real routes while direct handler unit tests can
-// still exercise business logic without constructing the full middleware chain.
-const authCheckedHeader = "X-Hive-Auth-Checked"
-
 // proxyProofRequired controls F2 enforcement strictness. Default false =
 // fail-open rollout: a request with no proof header is still trusted on its
 // identity headers (so hosted hives aren't locked out while the hub half rolls
@@ -770,8 +765,6 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			return
 		}
 		if s.authToken == "" && !directRouteAuthz {
-			r.Header.Del(authCheckedHeader)
-			r.Header.Set(authCheckedHeader, "true")
 			// Open by design — but still resolve a session if the caller has one,
 			// so an SSO handoff on a token-less spoke yields a request that KNOWS
 			// who the user is. Without this the handoff sets a cookie, the next
@@ -803,8 +796,6 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		r.Header.Del("X-Hive-User")
 		r.Header.Del("X-Hive-Role")
 		r.Header.Del(ownerRoleVerifiedHeader)
-		r.Header.Del(authCheckedHeader)
-		r.Header.Set(authCheckedHeader, "true")
 
 		// Internal automation authenticates with the shared token via the
 		// X-Hive-Internal header; this is a trusted server-to-server path

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -39,6 +39,15 @@ const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
 // network. See authenticate() (F2). Must match the hub's constant.
 const proxyAuthHeader = "X-Hive-Proxy-Auth"
 
+// ownerRoleVerifiedHeader is a server-only request marker set by authenticate
+// when the owner role came from a trusted source, not an inbound client header.
+const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
+
+// authCheckedHeader marks requests that passed through authenticate. It keeps
+// owner checks fail-closed on real routes while direct handler unit tests can
+// still exercise business logic without constructing the full middleware chain.
+const authCheckedHeader = "X-Hive-Auth-Checked"
+
 // proxyProofRequired controls F2 enforcement strictness. Default false =
 // fail-open rollout: a request with no proof header is still trusted on its
 // identity headers (so hosted hives aren't locked out while the hub half rolls
@@ -761,6 +770,8 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			return
 		}
 		if s.authToken == "" && !directRouteAuthz {
+			r.Header.Del(authCheckedHeader)
+			r.Header.Set(authCheckedHeader, "true")
 			// Open by design — but still resolve a session if the caller has one,
 			// so an SSO handoff on a token-less spoke yields a request that KNOWS
 			// who the user is. Without this the handoff sets a cookie, the next
@@ -770,19 +781,30 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+			} else if r.Header.Get("X-Hive-Role") == "" {
+				r.Header.Set("X-Hive-Role", config.RoleOwner)
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
+			} else if r.Header.Get("X-Hive-Role") == config.RoleOwner {
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
 			}
 			next.ServeHTTP(w, r)
 			return
 		}
+		inboundUser := r.Header.Get("X-Hive-User")
+		inboundRole := r.Header.Get("X-Hive-Role")
 
-		// On a direct-route spoke (per-hive allowlist present) we MUST NOT trust
-		// client-supplied X-Hive-User/X-Hive-Role: there is no hub nginx in
-		// front to strip forged identity headers. Strip them here so identity
-		// can only come from a server-side session we minted.
-		if directRouteAuthz {
-			r.Header.Del("X-Hive-User")
-			r.Header.Del("X-Hive-Role")
-		}
+		// Treat identity headers as an internal request attribute. Preserve the
+		// inbound values only in the hub-proxy branch below, after that path has
+		// been authenticated as trusted; all other auth paths must set any role
+		// explicitly so clients cannot spoof owner access with X-Hive-Role.
+		r.Header.Del("X-Hive-User")
+		r.Header.Del("X-Hive-Role")
+		r.Header.Del(ownerRoleVerifiedHeader)
+		r.Header.Del(authCheckedHeader)
+		r.Header.Set(authCheckedHeader, "true")
 
 		// Internal automation authenticates with the shared token via the
 		// X-Hive-Internal header; this is a trusted server-to-server path
@@ -791,7 +813,17 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// is TRUE, so without this an absent/empty header would authenticate on
 		// a direct-route spoke that has no token. The shared-token paths are only
 		// valid when a real token is configured.
-		trusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
+		internalTrusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
+		trusted := internalTrusted
+		if internalTrusted {
+			if sess := s.sessionFromRequest(r); sess != nil {
+				r.Header.Set("X-Hive-User", sess.Username)
+				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+			}
+		}
 
 		// Hub-proxied path: nginx injects the identity headers from the hub's
 		// per-user/per-hive auth-check. Only trust them when this spoke is NOT a
@@ -811,19 +843,29 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// follow-up flips proxyProofRequired to make a missing/incorrect proof
 		// header fail closed.
 		if !trusted && !directRouteAuthz &&
-			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
+			inboundUser != "" && inboundRole != "" {
 			proof := r.Header.Get(proxyAuthHeader)
 			switch {
 			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
 				// Proof present and valid — definitely came through the hub.
 				trusted = true
+				if inboundRole == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
 			case proof == "" && !proxyProofRequired:
 				// No proof header yet (hub not upgraded) and we're not enforcing
 				// strictly — trust the identity headers as before (rollout window).
+				// Do not mark owner as verified in this legacy path: missing proof
+				// keeps reads/general writes compatible but owner-only mutations
+				// must fail closed.
 				trusted = true
 			default:
 				// Proof header present but WRONG, or strict mode with no proof:
 				// this did not come through the trusted hub proxy — reject.
+			}
+			if trusted {
+				r.Header.Set("X-Hive-User", inboundUser)
+				r.Header.Set("X-Hive-Role", inboundRole)
 			}
 		}
 
@@ -835,6 +877,9 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
 				trusted = true
 			}
 		}


### PR DESCRIPTION
Fixes #3113

## Root cause
The owner-only dashboard guard treated a missing `X-Hive-Role` as owner. Authenticated shared-token requests could therefore reach pause/resume/breaker handlers without any server-controlled role, and client-supplied role headers were not consistently stripped before authorization.

## Final trust model
- `authenticate()` is the only production entry point to dashboard routes (`Start()` and `Handler()` both wrap the mux with `authenticate(roleEnforcement(securityHeaders(mux)))`).
- On protected authenticated paths, `authenticate()` strips inbound `X-Hive-User`, `X-Hive-Role`, and the server-only owner verification marker before resolving identity.
- Owner-only mutations fail closed unconditionally unless both `X-Hive-Role: owner` and the server-only owner verification marker are present. There is no missing-role/test escape hatch.
- Bearer/query shared-token auth and bare `X-Hive-Internal` authenticate general access but do not become verified owner for owner-only mutations.
- Device-flow owner sessions and hub-proxied requests with valid `X-Hive-Proxy-Auth` are marked verified owner. The proofless legacy proxy path remains compatible for non-owner-only access but is not owner-verified.

## Backward compatibility
Open/no-auth single-owner spokes are preserved explicitly: when no auth token and no direct-route allowlist are configured, the auth layer assigns owner plus the server verification marker for requests without a role, so local/open spokes can still use owner-only controls.

## Tests
- Added route-level coverage for bearer-token auth with missing role, spoofed owner role, proofless proxy owner role, verified hub owner role, direct-route owner sessions with internal auth, and open/no-auth spokes.
- Updated direct handler unit tests to set the server-only owner marker instead of weakening production authorization.

## Verification
- `cd v2 && go build ./...`
- `cd v2 && go vet ./pkg/dashboard/`
- `cd v2 && go test ./pkg/dashboard/ -count=1`