### PR TITLE
🐛 Fix dashboard header clipping on v4

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -25,6 +25,7 @@
     .git-version .git-dirty { color: var(--yellow); }
     .header-spacer { flex: 1; }
     .widget-dl {
+      display: inline-flex; align-items: center; white-space: nowrap;
       font-size: 0.75rem; color: var(--cyan); text-decoration: none;
       border: 1px solid var(--cyan); border-radius: 6px; padding: 4px 10px;
       transition: background 0.2s, color 0.2s; margin-left: auto; margin-right: auto;
@@ -111,26 +112,31 @@
 
     /* Light top bar */
     .oc-topbar {
-      position: fixed; top: 0; left: var(--sidebar-w); right: 0; height: 48px;
+      position: fixed; top: 0; left: var(--sidebar-w); right: 0; min-height: 48px;
       background: #ffffff; border-bottom: 1px solid #e5e7eb;
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
     }
-    .oc-topbar-left { font-size: 0.85rem; color: #6b7280; }
-    .oc-topbar-center { display: flex; align-items: center; gap: 6px; }
+    .oc-topbar-left { font-size: 0.85rem; color: #6b7280; min-width: 0; flex: 1 1 auto; overflow: hidden; }
+    #oc-project-name { display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .oc-topbar-center { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
     .oc-topbar-center .oc-tb-link {
       font-size: 0.72rem; color: #6b7280; cursor: pointer; padding: 4px 10px;
       border-radius: 6px; border: 1px solid transparent; transition: all 0.15s;
     }
     .oc-topbar-center .oc-tb-link:hover { background: #f3f4f6; color: #111827; border-color: #e5e7eb; }
-    .oc-topbar-right { display: flex; align-items: center; gap: 14px; }
+    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 0 auto; flex-wrap: nowrap; }
     .oc-health-badge {
       font-size: 0.78rem; font-weight: 600; color: #16a34a;
       background: #f0fdf4; border: 1px solid #bbf7d0;
       padding: 4px 12px; border-radius: 20px;
     }
-    .oc-topbar-ts { font-size: 0.75rem; color: #6b7280; }
-    .oc-topbar .git-version { color: #9ca3af; }
+    #oc-hive-id {
+      flex: 0 1 auto; min-width: 0; max-width: 22rem;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .oc-topbar-ts { font-size: 0.75rem; color: #6b7280; white-space: nowrap; }
+    .oc-topbar .git-version { color: #9ca3af; white-space: nowrap; }
     .oc-topbar .widget-dl {
       font-size: 0.72rem; color: #dc2626; border-color: #dc2626;
       padding: 3px 10px; border-radius: 6px;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -92,7 +92,7 @@
     .header-spacer { flex: 1; }
     /* .widget-dl / .layout-toggle — ghost buttons (system recipe at end of
        the style block); only placement-specific properties live here. */
-    .widget-dl { display: inline-block; text-decoration: none; margin-left: auto; margin-right: auto; }
+    .widget-dl { display: inline-flex; align-items: center; text-decoration: none; margin-left: auto; margin-right: auto; white-space: nowrap; }
     .layout-toggle { margin-left: 12px; margin-right: 8px; }
     /* Icon-only theme toggle: square-ish, centered glyph, larger for tap target. */
     .layout-toggle { min-width: 34px; padding-left: 8px; padding-right: 8px; font-size: 1rem; line-height: 1; text-align: center; }
@@ -277,14 +277,15 @@
        positioning kept (functionally sticky: content scrolls under it)
        because the sidebar offset layout depends on it. */
     .oc-topbar {
-      position: fixed; top: 0; left: var(--sidebar-w); right: 0; height: 48px;
+      position: fixed; top: 0; left: var(--sidebar-w); right: 0; min-height: 48px;
       background: color-mix(in srgb, var(--bg) 85%, transparent);
       -webkit-backdrop-filter: blur(18px); backdrop-filter: blur(18px);
       border-bottom: 1px solid var(--line);
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
     }
-    .oc-topbar-left { font-size: 0.85rem; color: var(--muted); display: flex; align-items: center; gap: 4px; min-width: 0; }
+    .oc-topbar-left { font-size: 0.85rem; color: var(--muted); display: flex; align-items: center; gap: 4px; min-width: 0; flex: 1 1 auto; overflow: hidden; }
+    #oc-project-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     /* Drawer toggle. Hidden on desktop; the ≤768px block flips it to
        inline-flex. Lives in .oc-topbar-left because that is the shortest
        topbar group — putting it in center/right would risk wrapping the
@@ -311,10 +312,15 @@
     .dashboard-custom-style-note { display: inline-flex; align-items: center; gap: 6px; max-width: 240px; padding: 3px 8px; border: 1px solid rgba(128,191,255,0.35); border-radius: 999px; background: rgba(128,191,255,0.10); color: var(--text); font-size: 0.68rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .dashboard-custom-style-note.warn { border-color: rgba(210,153,34,0.45); background: rgba(210,153,34,0.12); }
     .dashboard-custom-style-note button { border: 0; background: transparent; color: inherit; cursor: pointer; font-size: 0.75rem; line-height: 1; padding: 0; }
-    .oc-topbar-right { display: flex; align-items: center; gap: 14px; min-width: 0; }
+    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 0 auto; flex-wrap: nowrap; }
     .oc-health-badge { --pill-c: var(--green); font-weight: 600; } /* pill recipe at end of style block */
-    .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); }
+    #oc-hive-id {
+      flex: 0 1 auto; min-width: 0; max-width: 22rem;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); white-space: nowrap; }
     .oc-topbar .git-version { color: var(--muted); }
+    .oc-health-badge, #welcome-topbar-btn, #oc-gh-avatar-wrap { flex: 0 0 auto; }
 
     /* Fleet breaker — circular play/pause control + status pill in the topbar.
        Mirrors the Ready-work queue's #queue-suspend-btn / .pill pattern from the
@@ -341,7 +347,7 @@
     #fleet-breaker-pill.pill-passed { background: rgba(63,185,80,.12); color: #3fb950; border-color: rgba(63,185,80,.3); }
     #fleet-breaker-pill.pill-blocked { background: rgba(248,81,73,.12); color: #f85149; border-color: rgba(248,81,73,.3); }
 
-    @media (max-width: 1200px) {
+    @media (max-width: 1280px) {
       body { padding-top: 88px; }
       .oc-topbar {
         flex-wrap: wrap; height: auto; min-height: 48px;
@@ -358,12 +364,13 @@
       }
       .oc-topbar-right .widget-dl { margin-left: 0; margin-right: 0; }
       #oc-hive-id {
-        flex: 0 1 auto; min-width: 0; max-width: clamp(9rem, 32vw, 16rem);
+        flex: 0 1 auto; min-width: 0; max-width: 22rem;
         white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       }
-      .oc-topbar-ts { white-space: nowrap; }
     }
+
     @media (min-width: 769px) and (max-width: 900px) {
+      body { padding-top: 112px; }
       .oc-topbar-ts, #oc-git-version { display: none; }
       #oc-hive-id { max-width: 8rem; }
     }


### PR DESCRIPTION
Refs #3137

Companion to #3202 for the active `v4` branch.

## Summary
- Prevent the dashboard topbar from clipping crowded header content.
- Replace the fixed desktop header height with intrinsic `min-height` sizing.
- Let the left project name shrink/ellipsis first, keep right-side controls on one line, and wrap the topbar at crowded desktop widths before controls are squeezed.
- Preserve the existing mobile `max-width: 768px` wrapping behavior and reserve extra tablet padding for optional multi-row controls.

## Clipped items from #3137
1. Hive instance identifier
2. Timestamp
3. Help / widget controls

## Root cause
The v4 topbar had the same fixed `height: 48px` defect as v2. Long project and hive names wrapped inside that fixed-height bar, so the hive id, timestamp, and Widget button were vertically clipped or pushed off the right edge.

## Verification
- `cd v2 && go build ./...`
- CDP measurements at 1016×800, 1280×800, and 1440×900 with injected long project/hive identifiers. For the topbar and every visible right-side child, `scrollWidth <= clientWidth + 1`, `right <= window.innerWidth`, and no document horizontal overflow.

1016px after screenshot:
![v4-after-1016-visible.png](https://github.com/user-attachments/assets/5db95472-7a39-4899-8d3a-c64d932ace9f)
