### PR TITLE
🔒 Security audit 2026-08-07: N4 — terminal fallback must fail closed on insufficient role

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -90,6 +90,20 @@ const IS_HOSTED = SESSION_KEY !== '' || SESSION_PUBLIC_KEY !== '';
 // never "a user allowed on THIS hive".
 const HIVE_ID = process.env.HIVE_ID || '';
 
+// TERMINAL_ROLES are the roles sufficient to open a shell: owner and read-write.
+// A `read`-only grant authenticates and authorizes the DASHBOARD but is NOT
+// enough for a terminal — the finding asks role sufficiency (owner/operator) be
+// enforced, and a read-only user with shell access would be a privilege
+// escalation. Role strings mirror pkg/config (RoleOwner, RoleReadWrite) and the
+// hub saasRole* constants.
+const TERMINAL_ROLES = new Set(['owner', 'read-write']);
+
+// Declared ABOVE the HIVE_AUTHORIZED_USERS parse below, because
+// parseAuthorizedUsernames now consults it (N4 role-aware allowlist). A `const`
+// sits in a temporal dead zone until its declaration executes, and that parse
+// runs at module load — with this further down, the proxy threw "Cannot access
+// 'TERMINAL_ROLES' before initialization" and failed to start at all.
+
 // HIVE_AUTHORIZED_USERS is this hive's per-hive allowlist, injected by the hub
 // (authorizedUsersForHive): a comma-separated list of `username` or
 // `username:role` entries (owner + everyone with this hive in their SaaS
@@ -115,6 +129,8 @@ const HIVE_AUTHORIZED_USERS = parseAuthorizedUsernames(process.env.HIVE_AUTHORIZ
 // the ingress" — there is no ingress to defer to — so the terminal must deny.
 const HIVE_INGRESS_AUTHZ = (process.env.HIVE_INGRESS_AUTHZ || '') === 'true';
 
+
+
 // parseAuthorizedUsernames turns "owner:owner,alice:read,bob" into a Set of
 // lowercased usernames. It mirrors the Go parseAuthorizedUsers split (comma
 // list, ":role" suffix optional) but keeps only the identity, which is all the
@@ -122,8 +138,23 @@ const HIVE_INGRESS_AUTHZ = (process.env.HIVE_INGRESS_AUTHZ || '') === 'true';
 function parseAuthorizedUsernames(raw) {
   const set = new Set();
   for (const entry of raw.split(',')) {
-    const name = entry.split(':')[0].trim().toLowerCase();
-    if (name) set.add(name);
+    const parts = entry.split(':');
+    const name = parts[0].trim().toLowerCase();
+    if (!name) continue;
+    // SECURITY (audit N4, CWE-862): the role suffix is NOT decoration — honour it.
+    //
+    // This used to keep only `parts[0]`, discarding ":read". authorizedUsersForHive
+    // emits EVERY user granted the hive, as `owner:owner` plus `name:read` for the
+    // rest, so dropping the suffix made a read-only viewer indistinguishable from
+    // an owner in this set — and the terminal gate then handed them a shell in a
+    // credential-holding container.
+    //
+    // A missing suffix means "no role stated"; those entries are kept, since the
+    // list has historically carried bare names and the caller (isAuthorizedForThisHive)
+    // is only reached when there is no authoritative assertion to read a role from.
+    const role = (parts[1] || '').trim().toLowerCase();
+    if (role && !TERMINAL_ROLES.has(role)) continue;
+    set.add(name);
   }
   return set;
 }
@@ -210,14 +241,6 @@ const TERMINAL_ASSERTION_COOKIE = 'hive_terminal_assertion';
 // bounds. Matches the Go ssoClockSkew (30s).
 const TERMINAL_CLOCK_SKEW_S = 30;
 
-// TERMINAL_ROLES are the roles sufficient to open a shell: owner and read-write.
-// A `read`-only grant authenticates and authorizes the DASHBOARD but is NOT
-// enough for a terminal — the finding asks role sufficiency (owner/operator) be
-// enforced, and a read-only user with shell access would be a privilege
-// escalation. Role strings mirror pkg/config (RoleOwner, RoleReadWrite) and the
-// hub saasRole* constants.
-const TERMINAL_ROLES = new Set(['owner', 'read-write']);
-
 // verifyTerminalAssertion mirrors Go hub.VerifyTerminalAssertion. It returns
 // { username, role } on success, or null on ANY failure (bad signature, wrong
 // version, wrong hive, expired/not-yet-valid, malformed) — fail closed, never
@@ -273,17 +296,37 @@ function verifyTerminalAssertion(key, token, expectedHiveID, nowSec) {
 function authorizeTerminal(cookieUser, assertionCookie) {
   const nowSec = Math.floor(Date.now() / 1000);
   const claim = verifyTerminalAssertion(TERMINAL_SIGNING_KEY, assertionCookie, HIVE_ID, nowSec);
-  if (claim && TERMINAL_ROLES.has((claim.role || '').toLowerCase())) {
-    // A valid this-hive assertion with a sufficient role is the primary grant.
-    // Bind it to the SAME user the hub-wide cookie authenticated: an attacker
-    // must present BOTH a validly-signed hub cookie for user X AND a validly-
-    // signed terminal assertion for user X on THIS hive.
-    if (claim.username && cookieUser &&
-        claim.username.toLowerCase() === cookieUser.toLowerCase()) {
-      return true;
-    }
+
+  if (claim) {
+    // The assertion VERIFIED — a correctly signed, unexpired, this-hive grant.
+    // Its role is therefore authoritative, and this function must answer from it
+    // alone. It must NOT fall through to the allowlist.
+    //
+    // SECURITY (audit N4, CWE-862/613): the fallback below used to be reached
+    // for every non-grant outcome, including a valid assertion whose role was
+    // merely insufficient. That silently upgraded read-only users to a shell,
+    // because the allowlist parse (parseAuthorizedUsernames) DISCARDS the
+    // ":read" suffix and authorizedUsersForHive puts every granted user in the
+    // list — so `carol:read` was indistinguishable from `alice:owner` there.
+    //
+    // Worse, the allowlist is a provision-time env snapshot: hub-side revocation
+    // never reaches a running spoke, so a revoked user kept shell access
+    // indefinitely on a stale list. Honouring the assertion's own role — and its
+    // expiry — is what makes revocation and downgrade actually take effect.
+    const roleOK = TERMINAL_ROLES.has((claim.role || '').toLowerCase());
+    const userOK = !!claim.username && !!cookieUser &&
+      claim.username.toLowerCase() === cookieUser.toLowerCase();
+    // Bind the grant to the SAME user the hub-wide cookie authenticated: an
+    // attacker must present BOTH a validly-signed hub cookie for user X AND a
+    // validly-signed terminal assertion for user X on THIS hive.
+    return roleOK && userOK;
   }
-  // No usable assertion → fall back to the #2756 static allowlist + fail-closed.
+
+  // No USABLE assertion — absent, expired, wrong hive, or bad signature. There
+  // is no authoritative role to read, so fall back to the #2756 static allowlist
+  // (itself fail-closed). Note this is deliberately narrower than before: it is
+  // now reached only when the assertion tells us NOTHING, never when it tells us
+  // "no".
   return isAuthorizedForThisHive(cookieUser);
 }
 

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -472,6 +472,67 @@ async function testC3F_InsufficientRoleDenied() {
   console.log('  ✓ read-only role assertion → denied (owner/read-write required for a shell)');
 }
 
+// N4 (CWE-862/613) — THE TESTS THE SUITE WAS MISSING.
+//
+// Every C3F case above uses `dave`, who is deliberately NOT on the static
+// allowlist. Their 403s are therefore produced by the FALLBACK denying a
+// non-member — they prove nothing about role enforcement, and they passed
+// against the vulnerable code.
+//
+// `carol:read` IS on the allowlist (see the HIVE_AUTHORIZED_USERS fixture). She
+// is the case that mattered: authorizeTerminal treated "valid assertion, role
+// too low" the same as "no assertion", fell through to the allowlist, and the
+// allowlist parse discarded her ":read" suffix — so a read-only viewer got a
+// shell in a credential-holding container.
+async function testN4_AllowlistedReadOnlyDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'carol');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'carol', role: 'read', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403,
+    `N4: carol is allowlisted but read-only — a valid read assertion must DENY, got ${resp.status}`);
+  const { opened } = await terminalWS(cookie, HOSTED_HOST, assertion);
+  assert.ok(!opened, 'N4: carol read-only WS must be closed');
+  console.log('  ✓ allowlisted READ-ONLY user + valid read assertion → denied (no fallback)');
+}
+
+// Same user with NO assertion at all. This one legitimately reaches the
+// fallback — there is no authoritative role to read — and the role-aware
+// allowlist is what must deny her now that ":read" is honoured.
+async function testN4_AllowlistedReadOnlyNoAssertionDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'carol');
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, null);
+  assert.equal(resp.status, 403,
+    `N4: carol with NO assertion must be denied by the role-aware allowlist, got ${resp.status}`);
+  const { opened } = await terminalWS(cookie, HOSTED_HOST, null);
+  assert.ok(!opened, 'N4: carol with no assertion WS must be closed');
+  console.log('  ✓ allowlisted READ-ONLY user, no assertion → denied (:read honoured in allowlist)');
+}
+
+// An EXPIRED assertion is "tells us nothing", so it falls back — and the
+// role-aware allowlist must still deny a read-only user. Under the old code this
+// was a shell.
+async function testN4_AllowlistedReadOnlyExpiredDenied() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'carol');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'carol', role: 'owner', hiveID: HIVE_B_ID, ttlSec: 600, iatOffsetSec: -1000 });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 403,
+    `N4: carol with an EXPIRED owner assertion must be denied, got ${resp.status}`);
+  console.log('  ✓ allowlisted READ-ONLY user + expired assertion → denied (revocation/expiry take effect)');
+}
+
+// CONTROL: the fix must not break legitimate access. alice:owner still gets in,
+// both with a valid owner assertion and via the allowlist fallback.
+async function testN4_OwnerStillAllowed() {
+  const cookie = mintCookie(HIVE_B_SECRET, 'alice');
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'alice', role: 'owner', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 200, `alice:owner with a valid assertion must be 200, got ${resp.status}`);
+  const noAssertion = await terminalHTTP(cookie, HOSTED_HOST, null);
+  assert.equal(noAssertion.status, 200,
+    `alice:owner must still pass via the allowlist fallback, got ${noAssertion.status}`);
+  console.log('  ✓ owner still allowed (with assertion and via fallback) — fix is not over-broad');
+}
+
 // FORGED assertion (wrong signing secret) → signature fails → not usable → denied.
 async function testC3F_ForgedAssertionDenied() {
   const cookie = mintCookie(HIVE_B_SECRET, 'dave');
@@ -677,6 +738,10 @@ try {
   await testC3F_ExpiredAssertionDenied();
   await testC3F_WrongHiveAssertionDenied();
   await testC3F_InsufficientRoleDenied();
+  await testN4_AllowlistedReadOnlyDenied();
+  await testN4_AllowlistedReadOnlyNoAssertionDenied();
+  await testN4_AllowlistedReadOnlyExpiredDenied();
+  await testN4_OwnerStillAllowed();
   await testC3F_ForgedAssertionDenied();
   await testC3F_WrongVersionDenied();
   await testC3F_UserMismatchDenied();


### PR DESCRIPTION
Follows the merged #3195 (N3), #3230 (N1), and #3233 (N2). **This completes the hosted kill chain: N1, N2, N3, N4.**

*(Recreated from #3231, auto-closed when its base branch was deleted on merge.)*

## The bug

`authorizeTerminal` treated every non-grant outcome identically. A valid assertion whose role was merely **insufficient** fell through to `isAuthorizedForThisHive` exactly like an absent or expired one:

```js
if (claim && TERMINAL_ROLES.has(claim.role)) { ... return true; }
// No usable assertion → fall back to the static allowlist.
return isAuthorizedForThisHive(cookieUser);
```

And `parseAuthorizedUsernames` discarded the `":role"` suffix, while `authorizedUsersForHive` puts **every** granted user in the list as `name:read`. A read-only viewer was therefore indistinguishable from an owner in that set — and got a shell in a credential-holding container.

## Two changes, one per half

1. **A verified assertion is authoritative.** Its role decides and the function returns from it — no fallback. The fallback is now reached only when the assertion tells us *nothing* (absent, expired, wrong hive, bad signature), never when it tells us *"no"*.
2. **The allowlist honours `:role`.** `carol:read` is no longer a terminal grant. A bare name with no suffix is still accepted — the list has historically carried those, and that path is only reached when there's no assertion to read a role from.

This also makes **revocation and downgrade actually take effect**. The allowlist is a provision-time env snapshot, so hub-side revocation never reaches a running spoke; honouring the assertion's own role and expiry is what closes that.

## A startup crash caught by running it, not checking it

`TERMINAL_ROLES` had to move above the `HIVE_AUTHORIZED_USERS` parse. That parse now consults it and runs at module load, and a `const` sits in a temporal dead zone until its declaration executes — so with it left below, the proxy threw `Cannot access 'TERMINAL_ROLES' before initialization` and **failed to start at all**.

`node --check` passes that file happily. It only surfaced by actually booting the proxy — worth knowing for anyone touching module-level init here.

## The tests the suite was missing

This is *why* N4 survived five audits. **Every** existing `C3F` case uses `dave`, who is deliberately **not** allowlisted — so their 403s come from the fallback denying a non-member. They prove nothing about role enforcement and **passed against the vulnerable code**.

`carol:read` *is* allowlisted (already in the fixture) and is the case that mattered. She was defined and never asserted on. Added across three lanes — valid read assertion, no assertion, expired assertion — plus an owner control proving the fix isn't over-broad (owners still get in, both with an assertion and via the fallback).

**Verified against the vulnerable code: carol gets HTTP 200 — a shell.**

A green suite testing the wrong fixture is worse than no test, because it actively signals safety. Worth watching for elsewhere.

## CI note

`test` job failures on v4 are pre-existing and unrelated to the proxy: #3162 (data race) and #3232 (merge watcher). #3163 was fixed by #3199. This PR changes only `v2/proxy/`.

## Follow-up

#3234 tracks removing the temporary legacy compatibility lanes added in N1/N2 once the fleet has re-provisioned — those lanes *are* the vulnerabilities, kept only to avoid a flag-day cutover.