### PR TITLE
feat(hub): auth-rollout readiness signal for the N1/N2 compatibility lanes

### DIFF
--- a/v2/pkg/hub/auth_rollout.go
+++ b/v2/pkg/hub/auth_rollout.go
@@ -80,6 +80,23 @@ type AuthRolloutStatus struct {
 // authRolloutStaleAfter bounds how old an observation may be and still count.
 // A hive that has not heartbeated within this window is treated as absent, not
 // as legacy — otherwise a long-deleted hive would block the removal forever.
+//
+// 24h is chosen against the two ways this can be wrong, which fail in opposite
+// directions:
+//
+//   - TOO SHORT and a hive that is merely paused, mid-upgrade, or on a
+//     temporarily unreachable cluster drops out of the denominator. The fleet
+//     then reads ready while that spoke is still on the legacy bearer, and
+//     removing the lane 401s it the moment it comes back.
+//   - TOO LONG and every hive ever deleted keeps counting as a legacy laggard,
+//     so readiness never arrives and the compat lane becomes permanent — the
+//     precise failure this whole signal exists to prevent.
+//
+// Spokes beat on the order of a minute, so 24h is ~1000x the cadence: far past
+// any transient blip, but short enough that a decommissioned hive clears within
+// a day. If the fleet ever adopts long-lived paused hives that stop beating
+// entirely, revisit this — a paused hive should ideally be excluded explicitly
+// rather than by timeout.
 const authRolloutStaleAfter = 24 * time.Hour
 
 // AuthRolloutReadiness reports whether the N1 heartbeat compat lane can be

--- a/v2/pkg/hub/auth_rollout.go
+++ b/v2/pkg/hub/auth_rollout.go
@@ -1,0 +1,118 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// Rollout readiness telemetry for the N1/N2 compatibility lanes (issue #3234).
+//
+// N1 (per-hive heartbeat bearer) and N2 (Ed25519 session cookie) both shipped
+// as verify-both / mint-new: the hub accepts the new credential OR the legacy
+// one, and issues only the new one. That was required — a flag-day cutover
+// would have 401'd every spoke in the fleet at once, the failure mode #2773
+// documented for the v2-hub/v4-spoke split.
+//
+// But each legacy lane IS the vulnerability it replaced. The fleet-wide
+// heartbeat bearer does not bind identity, so an un-rolled spoke can still
+// claim any hive_id; the symmetric session key that verifies a cookie can also
+// mint one, including an admin cookie. They must be removed.
+//
+// The blocker was observability: "has every spoke re-provisioned?" had no
+// answer short of inspecting each Deployment by hand, so the lanes would have
+// lingered indefinitely — which is how a temporary compatibility path becomes
+// permanent. This records which format each spoke actually presents, so the
+// decision is made on evidence.
+
+// authRolloutEntry is the last-seen credential format for one hive.
+type authRolloutEntry struct {
+	// PerHiveBearer is true when this hive's most recent heartbeat used the
+	// identity-bound bearer (N1) rather than the fleet-wide legacy one.
+	PerHiveBearer bool `json:"per_hive_bearer"`
+	// LastSeen is when that observation was made.
+	LastSeen time.Time `json:"last_seen"`
+}
+
+// noteHeartbeatAuthPath records which bearer format hiveID just authenticated
+// with. Called on every accepted heartbeat; cheap and lock-scoped.
+//
+// Deliberately records the CURRENT observation rather than latching "has ever
+// used per-hive": a spoke can roll back, and a stale true would make the fleet
+// look ready when it is not. Readiness must mean "every hive is per-hive NOW".
+func (s *HubServer) noteHeartbeatAuthPath(hiveID string, perHive bool) {
+	if s == nil || hiveID == "" {
+		return
+	}
+	s.authRolloutMu.Lock()
+	defer s.authRolloutMu.Unlock()
+	if s.authRolloutSeen == nil {
+		s.authRolloutSeen = make(map[string]authRolloutEntry)
+	}
+	s.authRolloutSeen[hiveID] = authRolloutEntry{PerHiveBearer: perHive, LastSeen: time.Now()}
+}
+
+// AuthRolloutStatus summarizes fleet readiness for removing the compat lanes.
+type AuthRolloutStatus struct {
+	// TotalHives is how many distinct hives have been observed heartbeating.
+	TotalHives int `json:"total_hives"`
+	// PerHiveBearer is how many of those last used the N1 identity-bound bearer.
+	PerHiveBearer int `json:"per_hive_bearer"`
+	// LegacyBearer is how many last used the fleet-wide legacy bearer. While
+	// this is non-zero, removing the N1 compat lane WILL 401 those spokes.
+	LegacyBearer int `json:"legacy_bearer"`
+	// LegacyHives names the laggards, so an operator can go re-provision them
+	// rather than guessing which ones are holding up the removal.
+	LegacyHives []string `json:"legacy_hives,omitempty"`
+	// StaleAfter is the cutoff beyond which an observation is ignored: a hive
+	// that has not beaten recently is not evidence of anything.
+	StaleAfter string `json:"stale_after"`
+	// HeartbeatLaneReady is true when every recently-seen hive is on the
+	// per-hive bearer — i.e. the N1 legacy lane can be deleted.
+	//
+	// NOTE this covers the HEARTBEAT lane only. The N2 session-cookie lane has a
+	// second precondition this cannot observe: existing browser cookies must
+	// also have aged out (cookieMaxAgeDays, currently 7). Removing that lane
+	// early logs every active user out rather than breaking a spoke.
+	HeartbeatLaneReady bool `json:"heartbeat_lane_ready"`
+}
+
+// authRolloutStaleAfter bounds how old an observation may be and still count.
+// A hive that has not heartbeated within this window is treated as absent, not
+// as legacy — otherwise a long-deleted hive would block the removal forever.
+const authRolloutStaleAfter = 24 * time.Hour
+
+// AuthRolloutReadiness reports whether the N1 heartbeat compat lane can be
+// removed. Fails CLOSED: with no observations at all it reports not-ready,
+// because "no evidence" must never read as "safe to remove".
+func (s *HubServer) AuthRolloutReadiness() AuthRolloutStatus {
+	out := AuthRolloutStatus{StaleAfter: authRolloutStaleAfter.String()}
+	if s == nil {
+		return out
+	}
+	cutoff := time.Now().Add(-authRolloutStaleAfter)
+	s.authRolloutMu.RLock()
+	defer s.authRolloutMu.RUnlock()
+	for id, e := range s.authRolloutSeen {
+		if e.LastSeen.Before(cutoff) {
+			continue
+		}
+		out.TotalHives++
+		if e.PerHiveBearer {
+			out.PerHiveBearer++
+		} else {
+			out.LegacyBearer++
+			out.LegacyHives = append(out.LegacyHives, id)
+		}
+	}
+	out.HeartbeatLaneReady = out.TotalHives > 0 && out.LegacyBearer == 0
+	return out
+}
+
+// handleAuthRollout serves the readiness summary. Admin-only: it enumerates
+// hive IDs, and while that is not secret it is fleet-shaped information with no
+// reason to be public.
+func (s *HubServer) handleAuthRollout(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(s.AuthRolloutReadiness())
+}

--- a/v2/pkg/hub/auth_rollout_endpoint_test.go
+++ b/v2/pkg/hub/auth_rollout_endpoint_test.go
@@ -1,0 +1,56 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestAuthRolloutEndpointE2E exercises the real admin route: the authorization
+// gate and the JSON shape an operator will actually read.
+//
+// Unit-testing AuthRolloutReadiness alone would not catch a route registered
+// without requireAdmin, or a response body that does not marshal — and this
+// endpoint enumerates hive IDs, so the auth gate is part of the contract.
+func TestAuthRolloutEndpointE2E(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	s.authRolloutSeen = make(map[string]authRolloutEntry)
+	mkUser(t, hubAdminUsername)
+
+	s.noteHeartbeatAuthPath("hive-rolled", true)
+	s.noteHeartbeatAuthPath("hive-laggard", false)
+
+	h := s.requireAdmin(s.handleAuthRollout)
+
+	// Non-admin must not read fleet-shaped data.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/admin/auth-rollout", nil)
+	req.AddCookie(testAuthCookie("someuser"))
+	h(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-admin got %d, want 403", rec.Code)
+	}
+
+	// Admin gets the summary.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/saas/admin/auth-rollout", nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	h(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var got AuthRolloutStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v (%s)", err, rec.Body.String())
+	}
+	if got.TotalHives != 2 || got.LegacyBearer != 1 || got.HeartbeatLaneReady {
+		t.Fatalf("unexpected summary: %+v", got)
+	}
+	if len(got.LegacyHives) != 1 || got.LegacyHives[0] != "hive-laggard" {
+		t.Fatalf("laggard not named: %+v", got.LegacyHives)
+	}
+	t.Logf("endpoint OK: %s", rec.Body.String())
+}

--- a/v2/pkg/hub/auth_rollout_test.go
+++ b/v2/pkg/hub/auth_rollout_test.go
@@ -1,0 +1,107 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// #3234: readiness telemetry for removing the N1/N2 compatibility lanes.
+//
+// Those lanes ARE the vulnerabilities they replaced — a fleet-wide heartbeat
+// bearer does not bind identity, and a symmetric session key that verifies a
+// cookie can also mint one. They exist only so the fleet could roll without a
+// flag-day cutover, and they must not become permanent.
+//
+// The blocker to removing them was observability: "has every spoke
+// re-provisioned?" had no answer short of inspecting each Deployment by hand.
+// These tests pin the signal that answers it.
+
+func rolloutHub() *HubServer {
+	return &HubServer{authRolloutSeen: make(map[string]authRolloutEntry)}
+}
+
+// TestAuthRolloutFailsClosedWithNoData is the most important case: absence of
+// evidence must never read as "safe to remove".
+func TestAuthRolloutFailsClosedWithNoData(t *testing.T) {
+	s := rolloutHub()
+	got := s.AuthRolloutReadiness()
+	if got.HeartbeatLaneReady {
+		t.Fatal("readiness reported with ZERO observations — an operator would delete the " +
+			"compat lane on a hub that has simply never seen a heartbeat, 401ing the fleet")
+	}
+	if got.TotalHives != 0 {
+		t.Errorf("TotalHives = %d, want 0", got.TotalHives)
+	}
+}
+
+// TestAuthRolloutNotReadyWhileAnyLegacy: one laggard blocks removal, and it is
+// named so an operator knows which hive to re-provision.
+func TestAuthRolloutNotReadyWhileAnyLegacy(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-rolled", true)
+	s.noteHeartbeatAuthPath("hive-laggard", false)
+
+	got := s.AuthRolloutReadiness()
+	if got.HeartbeatLaneReady {
+		t.Fatal("reported ready while a spoke is still on the legacy bearer")
+	}
+	if got.TotalHives != 2 || got.PerHiveBearer != 1 || got.LegacyBearer != 1 {
+		t.Errorf("counts = total:%d per-hive:%d legacy:%d, want 2/1/1",
+			got.TotalHives, got.PerHiveBearer, got.LegacyBearer)
+	}
+	if len(got.LegacyHives) != 1 || got.LegacyHives[0] != "hive-laggard" {
+		t.Errorf("LegacyHives = %v, want [hive-laggard] — the laggard must be named", got.LegacyHives)
+	}
+}
+
+// TestAuthRolloutReadyWhenAllPerHive: the positive case that unblocks #3234.
+func TestAuthRolloutReadyWhenAllPerHive(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-a", true)
+	s.noteHeartbeatAuthPath("hive-b", true)
+
+	got := s.AuthRolloutReadiness()
+	if !got.HeartbeatLaneReady {
+		t.Fatalf("not ready with every hive on the per-hive bearer: %+v", got)
+	}
+	if len(got.LegacyHives) != 0 {
+		t.Errorf("LegacyHives = %v, want empty", got.LegacyHives)
+	}
+}
+
+// TestAuthRolloutIgnoresStale: a hive that stopped beating (deleted, migrated)
+// must not block the removal forever.
+func TestAuthRolloutIgnoresStale(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-current", true)
+	// A long-gone hive that last beat on the legacy bearer.
+	s.authRolloutSeen["hive-gone"] = authRolloutEntry{
+		PerHiveBearer: false,
+		LastSeen:      time.Now().Add(-authRolloutStaleAfter - time.Hour),
+	}
+
+	got := s.AuthRolloutReadiness()
+	if got.TotalHives != 1 {
+		t.Errorf("TotalHives = %d, want 1 (the stale hive must be ignored)", got.TotalHives)
+	}
+	if !got.HeartbeatLaneReady {
+		t.Error("a hive that has not beaten in over a day blocked readiness forever")
+	}
+}
+
+// TestAuthRolloutDoesNotLatch: a spoke that rolls BACK must flip the signal
+// back to not-ready. Latching "has ever been per-hive" would make the fleet
+// look ready when it no longer is.
+func TestAuthRolloutDoesNotLatch(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-a", true)
+	if !s.AuthRolloutReadiness().HeartbeatLaneReady {
+		t.Fatal("setup: expected ready")
+	}
+	// Same hive rolls back to an older image and presents the legacy bearer.
+	s.noteHeartbeatAuthPath("hive-a", false)
+	if s.AuthRolloutReadiness().HeartbeatLaneReady {
+		t.Fatal("readiness LATCHED — a rolled-back spoke still reads as ready, which is " +
+			"exactly when removing the lane would break it")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -384,6 +384,8 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", s.requireAdmin(s.handleDenyProvision))
 	s.mux.HandleFunc("GET /api/saas/admin/available-placeholders", s.requireAdmin(s.handleAvailablePlaceholders))
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
+	// #3234: fleet readiness for removing the N1/N2 legacy compatibility lanes.
+	s.mux.HandleFunc("GET /api/saas/admin/auth-rollout", s.requireAdmin(s.handleAuthRollout))
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
 	s.mux.HandleFunc("DELETE /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminDeleteUser))
 	// Admin read-only "View as user" impersonation. Enter is admin-only and

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -912,6 +912,21 @@ type HubServer struct {
 	spokeProxyAuthCache map[string]spokeProxyAuthEntry
 	spokeProxyAuthMu    sync.Mutex
 
+	// authRolloutSeen records, per hive, which credential FORMAT that spoke last
+	// authenticated with — the readiness signal for #3234.
+	//
+	// N1 and N2 shipped verify-both/mint-new compatibility lanes so the fleet
+	// could roll without a flag day. Those lanes ARE the vulnerabilities they
+	// replaced (a fleet-wide bearer does not bind identity; a symmetric session
+	// key that verifies can also mint), so they must be deleted — but deleting
+	// them before every spoke has re-provisioned 401s the whole fleet.
+	//
+	// Without this, "has the fleet rolled?" is unanswerable except by inspecting
+	// every Deployment by hand. Key: hive ID → last-seen auth path. Guarded by
+	// authRolloutMu.
+	authRolloutSeen map[string]authRolloutEntry
+	authRolloutMu   sync.RWMutex
+
 	// pendingGateways stores OpenRouter gateways funded via the hub's
 	// scan-to-fund flow, to deliver to firewalled/heartbeat-only spokes via the
 	// heartbeat response. Key: hive ID → gateway (carries the secret key VALUE,
@@ -1079,6 +1094,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
 		spokeProxyAuthCache:     make(map[string]spokeProxyAuthEntry),
+		authRolloutSeen:         make(map[string]authRolloutEntry),
 		timeline:                newTimelineStore(),
 		journey:                 newJourneyStore(),
 		alerts:                  newAlertState(),
@@ -1228,6 +1244,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		// #3234: record WHICH format authenticated, so an operator can tell when
+		// every spoke has re-provisioned and the legacy compat lane — which does
+		// not bind identity — can finally be deleted.
+		s.noteHeartbeatAuthPath(payload.HiveID, s.heartbeatBearerIsPerHive(presentedBearer, payload.HiveID))
 	}
 	// Normalize the reported SHA to the canonical short length up front so every
 	// downstream comparison is same-length against the hub's 7-char stored SHAs.
@@ -2354,6 +2374,10 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		// #3234: record WHICH format authenticated, so an operator can tell when
+		// every spoke has re-provisioned and the legacy compat lane — which does
+		// not bind identity — can finally be deleted.
+		s.noteHeartbeatAuthPath(payload.HiveID, s.heartbeatBearerIsPerHive(presentedBearer, payload.HiveID))
 	}
 	for i, lb := range payload.Leaderboard {
 		payload.Leaderboard[i].GitHubUsername = sanitizeField(lb.GitHubUsername)


### PR DESCRIPTION
Unblocks #3234. **This does not remove the compatibility lanes** — it makes removing them possible to decide.

## Why not just remove them

N1 (#3230) and N2 (#3233) merged today. No spoke has re-provisioned onto an image containing them yet, and the N2 cookie lane additionally needs existing browser cookies to age out (`cookieMaxAgeDays = 7`).

I simulated the removal against the current code rather than reasoning about it:

```
WITH compat lanes:    un-rolled spoke heartbeats OK, existing cookie OK
WITHOUT compat lane:  EVERY existing browser session is logged out
WITHOUT compat lane:  EVERY un-rolled spoke fails to heartbeat (401)
```

That's the fleet-wide outage the lanes were added to prevent — the failure mode #2773 documented for the v2-hub/v4-spoke split.

## What was actually blocking removal

`heartbeatBearerIsPerHive` and `hubCookieIsV2` were added alongside those fixes as "rollout telemetry" — but **neither was ever called**. So "has every spoke re-provisioned?" had no answer short of inspecting each Deployment by hand.

That matters because each legacy lane **is** the vulnerability it replaced: a fleet-wide heartbeat bearer doesn't bind identity, and a symmetric session key that verifies a cookie can also mint one (including an admin cookie). A compatibility path with no way to judge when it can go is how it becomes permanent.

## What this adds

Per-hive recording of which credential format each heartbeat actually used, on **both** authenticated handlers (`/api/heartbeat` and `/api/task-status`), exposed at:

```
GET /api/saas/admin/auth-rollout
```

```json
{
  "total_hives": 12,
  "per_hive_bearer": 11,
  "legacy_bearer": 1,
  "legacy_hives": ["hosted-kubestellar-hive-abcd"],
  "stale_after": "24h0m0s",
  "heartbeat_lane_ready": false
}
```

`legacy_hives` names the laggards, so an operator re-provisions those specific hives instead of guessing which one is holding up the removal.

## Three deliberate behaviours, each with a test

- **Fails closed.** Zero observations reports *not* ready. Absence of evidence must never read as "safe to remove" — otherwise a hub that has simply never seen a heartbeat looks ready.
- **Does not latch.** It records the *current* observation, not "has ever been per-hive". A spoke that rolls back to an older image flips the signal back to not-ready — which is exactly when removing the lane would break it.
- **Ignores stale.** Observations older than 24h are dropped, so a deleted or migrated hive can't block the removal forever.

## Scope note

This reports readiness for the **heartbeat** lane only. The N2 cookie lane has a second precondition the hub cannot observe — browser cookies aging out — so that's documented on the `heartbeat_lane_ready` field rather than implied by a green flag. A half-true readiness signal would be worse than none.

## The removal, when it's time

1. **Heartbeat (N1):** watch until `heartbeat_lane_ready: true` with non-zero `total_hives`, then delete the legacy branch in `verifyHeartbeatBearer`.
2. **Cookie (N2):** additionally wait ≥7 days from #3233, then pass `""` as `legacySecret` (already supported and tested), delete the branch, drop `HIVE_SESSION_KEY` from the spoke template, and remove the `SESSION_KEY` fallback in `proxy/server.js`.

Full procedure is on #3234.

## CI note

Pre-existing v4 `test` failures are #3162 (data race) and #3232 (merge watcher); this PR touches neither. Full `pkg/hub` suite passes locally.