### PR TITLE
fix(agent): use the latest prompt template on kick (don't reuse the launch-time copy)

### DIFF
--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -105,11 +105,27 @@ func (s *Scheduler) GetLastActionable() *github.ActionableResult {
 	return s.lastActionable
 }
 
+// userSavedPolicyDir is where the dashboard prompt editor
+// (PUT /api/config/agent/{name}/prompt → handleAgentPromptSave) writes a
+// template a user edited in the UI. It must be searched BEFORE the git-cloned
+// policies repo (…/examples/kubestellar/agents/) and the embedded defaults, or
+// an edit made in the UI never reaches the kick — the kick keeps rendering the
+// stale upstream copy that shadows the override (issue #3239). The dashboard's
+// own read path (loadPromptTemplateRaw) already checks this location first; the
+// scheduler must agree so a saved edit takes effect on the next kick.
+//
+// It is a var (not a const) only so tests can point it at a temp dir; production
+// always uses the fixed /data/policies path that handleAgentPromptSave writes to.
+var userSavedPolicyDir = "/data/policies"
+
 // loadPromptTemplate searches standard paths for an agent's policy template.
 // It checks on-disk paths first, then falls back to embedded default policies.
 func (s *Scheduler) loadPromptTemplate(agentName string) string {
 	paths := []string{
 		fmt.Sprintf("/data/agents/%s/CLAUDE.md", agentName),
+		// User-saved override from the dashboard prompt editor wins over the
+		// git-cloned examples copy and embedded defaults (#3239).
+		fmt.Sprintf("%s/%s.md", userSavedPolicyDir, agentName),
 		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s.md", agentName),
 	}
 	if s.cfg.Policies.LocalDir != "" {
@@ -133,6 +149,12 @@ func (s *Scheduler) loadPromptTemplate(agentName string) string {
 // It checks on-disk paths first, then falls back to embedded default policies.
 func (s *Scheduler) loadNamedTemplate(templateName string) string {
 	paths := []string{
+		// User-saved override from the dashboard prompt editor wins over the
+		// git-cloned examples copy and embedded defaults (#3239). handleAgentPromptSave
+		// writes the edited template to /data/policies/<KickTemplate>, so when an
+		// agent has a kick_template set (e.g. quality-advisory.md at ACMM L2) the
+		// edit lands here and must be picked up on the next kick.
+		fmt.Sprintf("%s/%s", userSavedPolicyDir, templateName),
 		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s", templateName),
 	}
 	if s.cfg.Policies.LocalDir != "" {

--- a/v2/pkg/scheduler/template_refresh_on_kick_test.go
+++ b/v2/pkg/scheduler/template_refresh_on_kick_test.go
@@ -1,0 +1,143 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// withUserSavedPolicyDir points the user-saved policy dir at a temp dir for the
+// duration of a test and restores the production default afterward. In
+// production this is the fixed /data/policies path that the dashboard prompt
+// editor (handleAgentPromptSave) writes to.
+func withUserSavedPolicyDir(t *testing.T, dir string) {
+	t.Helper()
+	prev := userSavedPolicyDir
+	userSavedPolicyDir = dir
+	t.Cleanup(func() { userSavedPolicyDir = prev })
+}
+
+// TestKickUsesLatestSavedTemplate is the regression test for issue #3239: after
+// a user edits an agent's prompt template in the dashboard, the NEXT kick must
+// render the freshly-saved template — not the stale git-cloned examples copy
+// that used to shadow the override.
+//
+// It reproduces the reporter's ACMM-L2 quality-agent scenario:
+//   - the agent has a kick_template (quality-advisory.md),
+//   - the git-cloned policies repo has an OLD copy under examples/…/agents/,
+//   - the dashboard save wrote the NEW copy to <userSavedPolicyDir>/quality-advisory.md.
+//
+// The kick must reflect the NEW copy.
+func TestKickUsesLatestSavedTemplate(t *testing.T) {
+	localDir := t.TempDir()   // stands in for the git-cloned /data/policies repo
+	savedDir := t.TempDir()   // stands in for /data/policies (user-saved overrides)
+	withUserSavedPolicyDir(t, savedDir)
+
+	// Old, git-cloned copy that used to win.
+	examplesDir := filepath.Join(localDir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(examplesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const oldWorkflow = "## Workflow\n3. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent\n"
+	if err := os.WriteFile(filepath.Join(examplesDir, "quality-advisory.md"), []byte(oldWorkflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Project: config.ProjectConfig{
+			Org: "testorg", Name: "test", PrimaryRepo: "testrepo",
+			Repos: []string{"testrepo"},
+		},
+		Agents: map[string]config.AgentConfig{
+			"quality": {Role: "quality", KickTemplate: "quality-advisory.md"},
+		},
+		Policies: config.PoliciesConfig{LocalDir: localDir},
+	}
+	s := New(cfg, slog.Default())
+
+	// 1. Before any user edit: the kick uses the git-cloned copy.
+	msg := s.BuildAgentMessage("quality", nil, nil)
+	if !strings.Contains(msg, "coverprofile=coverage.out") {
+		t.Fatalf("expected the git-cloned template before edit; got:\n%s", msg)
+	}
+
+	// 2. User edits the prompt in the dashboard. handleAgentPromptSave writes the
+	//    edited template to <userSavedPolicyDir>/<KickTemplate>.
+	const newWorkflow = "## Workflow\n3. Analyze test coverage.\n   For unit tests, use `go test -coverprofile=coverage.out ./...`.\n   For end-to-end tests, see the attached workflow results.\nUNIQUE_MARKER_3239\n"
+	if err := os.WriteFile(filepath.Join(savedDir, "quality-advisory.md"), []byte(newWorkflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. The NEXT kick must reflect the freshly-saved template.
+	msg = s.BuildAgentMessage("quality", nil, nil)
+	if !strings.Contains(msg, "UNIQUE_MARKER_3239") {
+		t.Fatalf("kick did not pick up the user-saved template edit (#3239); got:\n%s", msg)
+	}
+	if strings.Contains(msg, "or equivalent") {
+		t.Fatalf("kick still rendered the stale git-cloned template (#3239); got:\n%s", msg)
+	}
+}
+
+// TestLoadNamedTemplatePrefersUserSavedOverride proves the read-side precedence
+// directly: a user-saved override wins over the git-cloned examples copy.
+func TestLoadNamedTemplatePrefersUserSavedOverride(t *testing.T) {
+	localDir := t.TempDir()
+	savedDir := t.TempDir()
+	withUserSavedPolicyDir(t, savedDir)
+
+	examplesDir := filepath.Join(localDir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(examplesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(examplesDir, "quality-advisory.md"), []byte("OLD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "quality-advisory.md"), []byte("NEW"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Project:  config.ProjectConfig{Org: "testorg", Name: "test"},
+		Agents:   map[string]config.AgentConfig{},
+		Policies: config.PoliciesConfig{LocalDir: localDir},
+	}
+	s := New(cfg, slog.Default())
+
+	if got := s.loadNamedTemplate("quality-advisory.md"); got != "NEW" {
+		t.Fatalf("loadNamedTemplate: expected user-saved override %q, got %q", "NEW", got)
+	}
+}
+
+// TestLoadPromptTemplatePrefersUserSavedOverride proves the convention-path read
+// (<agent>.md) also prefers a user-saved override.
+func TestLoadPromptTemplatePrefersUserSavedOverride(t *testing.T) {
+	localDir := t.TempDir()
+	savedDir := t.TempDir()
+	withUserSavedPolicyDir(t, savedDir)
+
+	examplesDir := filepath.Join(localDir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(examplesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(examplesDir, "helper.md"), []byte("OLD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "helper.md"), []byte("NEW"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Project:  config.ProjectConfig{Org: "testorg", Name: "test"},
+		Agents:   map[string]config.AgentConfig{},
+		Policies: config.PoliciesConfig{LocalDir: localDir},
+	}
+	s := New(cfg, slog.Default())
+
+	if got := s.loadPromptTemplate("helper"); got != "NEW" {
+		t.Fatalf("loadPromptTemplate: expected user-saved override %q, got %q", "NEW", got)
+	}
+}


### PR DESCRIPTION
## Reporter's repro (#3239)

Mike Spreitzer edited the quality agent's prompt template (the `## Workflow` section) via the per-agent prompt editor at `/#quality`, then kicked the agent. Watching the Terminal, the agent was still running the **previous** edition of `## Workflow` — the revision did not take effect. Expected: the revised template is used on the next kick.

## Root cause (the exact staleness mechanism)

Save and read sides looked at **different files**.

- **Save** — `handleAgentPromptSave` (`v2/pkg/dashboard/api.go:3491-3507`) writes the edited template to `/data/policies/<KickTemplate>` (e.g. `/data/policies/quality-advisory.md` at ACMM L2, matching the reporter's prompt header) and points `KickTemplate` at it.
- **Dashboard read-back** — `loadPromptTemplateRaw` (`v2/pkg/dashboard/api.go:3403`) checks `/data/policies/<name>` **first** ("user-saved templates"), so the editor shows the edit sticking.
- **Kick read (the bug)** — the scheduler assembles the kick prompt fresh each kick via `BuildAgentMessage` → `loadNamedTemplate` / `loadPromptTemplate` (`v2/pkg/scheduler/scheduler.go:134` and `:110`). These functions searched **only** `/data/policies/examples/kubestellar/agents/<name>` (the git-cloned policies repo), the `LocalDir` variants, and the embedded defaults — **never** `/data/policies/<name>`.

On a Hive Hub the policies repo is cloned into `/data/policies` (`v2/cmd/hive/main.go:2290-2299`), so `/data/policies/examples/kubestellar/agents/quality-advisory.md` exists and **shadowed** the user's saved override at `/data/policies/quality-advisory.md`. Every kick kept rendering the stale upstream `## Workflow`.

(The kick is delivered by typing the assembled message into the agent's existing tmux CLI session — `deliverKickLocked`, `v2/pkg/agent/manager.go:2868`. That part was fine; the message text itself was stale because it was assembled from the wrong file.)

## Fix

Search the user-saved override at `/data/policies/<templateName>` **first** in both `loadNamedTemplate` and `loadPromptTemplate`, mirroring the dashboard's own `loadPromptTemplateRaw` precedence. A saved edit now takes effect on the next kick.

Scoped and safe: when no user edit exists, the override path is a clean miss (the file isn't there) and resolution falls through to exactly the previous chain — behavior is unchanged for un-edited agents. No change to who may edit templates (authz stays as-is).

## Budget-429 — not a factor

The `API Error 429 budget_exceeded` in the same terminal is unrelated to the staleness. It fires at **inference** time, downstream of prompt assembly, so it did not cause the old template to be assembled; it only meant the agent couldn't act on the (stale) kick. No budget-handling change is included here. If desired, a "kick no-ops cleanly when budget is exhausted" improvement can be a separate follow-up.

## Tests

`v2/pkg/scheduler/template_refresh_on_kick_test.go`:
- `TestKickUsesLatestSavedTemplate` — reproduces the ACMM-L2 quality scenario end to end: old git-cloned copy present, `BuildAgentMessage` renders it, then a user-saved edit is written and the **next** `BuildAgentMessage` renders the new template (asserts the new marker present and the stale text gone).
- `TestLoadNamedTemplatePrefersUserSavedOverride` / `TestLoadPromptTemplatePrefersUserSavedOverride` — prove the read-side precedence directly (user-saved override wins over the examples copy).

`go build ./...` and `go vet ./...` clean; existing scheduler tests still pass.

Fixes #3239

🤖 Generated with [Claude Code](https://claude.com/claude-code)