### PR TITLE
🐛 unassigned hives with no repos yet show ready, not warning

### DIFF
--- a/v2/pkg/hub/placeholder_health.go
+++ b/v2/pkg/hub/placeholder_health.go
@@ -56,6 +56,34 @@ const healthCheckTokens = "tokens"
 // detail on an unassigned row, for the same reason as placeholderAuthNote.
 const placeholderTokensNote = "Unassigned — no workload by design"
 
+// healthCheckRepoTarget is the spoke's repo-target validation check
+// (HealthSummary, pkg/dashboard/server.go). It warns whenever
+// config.ValidateRepoTargets reports an issue. On an unassigned pool slot the
+// issue is always the empty-repo shape — a placeholder is provisioned with
+// repos: [] until a project is claimed — so that shape is designed state,
+// exactly like github_auth being unconfigured. A malformed VALUE (a URL, a
+// slash, a forge host) is a genuine misconfiguration even on a placeholder
+// and keeps its warning.
+const healthCheckRepoTarget = "repo_target"
+
+// placeholderRepoTargetNote replaces the repo_target check's empty-repo
+// warning detail on an unassigned row, for the same reason as
+// placeholderAuthNote.
+const placeholderRepoTargetNote = "Unassigned — repo target set when claimed by design"
+
+// repoTargetEmptyMarker is the substring config.ValidateRepoTargets puts in
+// every empty-shape issue ("org is empty …" / "repo is empty …"). Malformed
+// value shapes (URL / slash / forge host) never carry it.
+const repoTargetEmptyMarker = "is empty"
+
+// repoTargetWarnIsUnassignedEmpty reports whether a repo_target warning is
+// warning ONLY because the slot has no org/repo configured yet — the designed
+// state of an unassigned pool slot — and not because a configured value is
+// malformed.
+func repoTargetWarnIsUnassignedEmpty(detail string) bool {
+	return strings.Contains(detail, repoTargetEmptyMarker)
+}
+
 // healthCheckAgents is the spoke's agent-liveness check (HealthSummary,
 // pkg/dashboard/server.go). It fails with a detail line like
 // "0 running, 1 paused, 4 need login: guide, quality, scanner, supervisor"
@@ -114,6 +142,8 @@ func placeholderDesignedCheckNote(name, detail string) string {
 		return placeholderAuthNote
 	case name == healthCheckTokens:
 		return placeholderTokensNote
+	case name == healthCheckRepoTarget && repoTargetWarnIsUnassignedEmpty(detail):
+		return placeholderRepoTargetNote
 	case name == healthCheckAgents && agentsFailIsLoginPending(detail):
 		return placeholderAgentsNote
 	}

--- a/v2/pkg/hub/placeholder_health_test.go
+++ b/v2/pkg/hub/placeholder_health_test.go
@@ -213,6 +213,82 @@ func TestPlaceholderRowGreenWhenTokensWarnZeroConsumed(t *testing.T) {
 	}
 }
 
+// An UNASSIGNED placeholder whose only warning is the empty-repo repo_target
+// shape is the pool working as designed — repos are set when the slot is
+// claimed — so the row must ship GREEN with the check reclassified as skip.
+func TestPlaceholderRowGreenWhenRepoTargetEmpty(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "warning",
+		"fails":  0,
+		"warns":  1,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": healthCheckRepoTarget, "status": "warn", "detail": "Repo target misconfigured: repo is empty — expected org/repo. Fix in Governor Config → Repos."},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusOK {
+		t.Fatalf("placeholder with only the empty-repo repo_target warning: status = %q, want %q", st, healthStatusOK)
+	}
+	if warns, _ := got["warns"].(int); warns != 0 {
+		t.Errorf("warns = %v, want 0 — the pill must not render", got["warns"])
+	}
+	st, detail := checkStatusByName(t, got, healthCheckRepoTarget)
+	if st != healthCheckStatusSkip {
+		t.Errorf("repo_target status = %q, want %q", st, healthCheckStatusSkip)
+	}
+	if detail != placeholderRepoTargetNote {
+		t.Errorf("repo_target detail = %q, want the unassigned note %q", detail, placeholderRepoTargetNote)
+	}
+}
+
+// A MALFORMED repo-target value (URL / slash / forge host) is a genuine
+// misconfiguration even on a placeholder — the warning must survive.
+func TestPlaceholderRowKeepsMalformedRepoTargetWarning(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "warning",
+		"checks": []any{
+			map[string]any{"name": healthCheckRepoTarget, "status": "warn", "detail": "Repo target misconfigured: org 'github.ibm.com' looks like a forge host — expected org/repo. Fix in Governor Config → Repos."},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusWarning {
+		t.Fatalf("placeholder with malformed repo target: status = %q, want %q — a bad VALUE is a real fault", st, healthStatusWarning)
+	}
+	if st, _ := checkStatusByName(t, got, healthCheckRepoTarget); st != healthCheckStatusWarn {
+		t.Errorf("repo_target = %q, want warn untouched", st)
+	}
+}
+
+// The SAME empty-repo warning on a CLAIMED hive is a real misconfiguration
+// (a claimed project must have repos) and must pass through untouched.
+func TestClaimedRowKeepsEmptyRepoTargetWarning(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "claimed-3",
+		Org:    "acme",
+		Online: true,
+		Health: map[string]any{
+			"status": "warning",
+			"checks": []any{
+				map[string]any{"name": healthCheckRepoTarget, "status": "warn", "detail": "Repo target misconfigured: repo is empty — expected org/repo. Fix in Governor Config → Repos."},
+			},
+		},
+	}}
+	e.ProvStatus = "active"
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusWarning {
+		t.Fatalf("claimed hive status = %q, want %q — the repo_target exemption must not leak", st, healthStatusWarning)
+	}
+}
+
 // The SAME zero-consumed warning on a CLAIMED hive is a real signal (an
 // assigned project spending nothing is worth noticing) and must pass through
 // untouched.


### PR DESCRIPTION
## Problem

Every unassigned pool slot renders **yellow** in **Unassigned Hives** — a warning dot, a ⚠ icon, a `repo_target` failing-check chip, and a "Warning" hover — even though the slot is working exactly as designed.

The cause is the spoke's `repo_target` health check. A placeholder is provisioned with `repos: []` until a project is claimed, so `config.ValidateRepoTargets` returns *"Repo target misconfigured: repo is empty — expected org/repo"* on **every** placeholder, which the spoke reports as a `warn`.

This is visible in the fleet today: the only unassigned rows that read green are the older ones that were seeded with a literal `placeholder/placeholder` org/repo — i.e. they are green by accident, because a junk repo value happens to pass validation. The correctly-provisioned slots (unique org, empty repos, per `docs/manual-provisioning.md`) are the ones flagged.

## Fix

`pkg/hub/placeholder_health.go` already neutralises exactly this class of false signal on unassigned rows — the auth-class family, the zero-consumed `tokens` warning, and a login-pending `agents` check. This adds `repo_target` to that set: on a placeholder it is reclassified as `skip` with a note saying why, and overall `status` / `warns` are recomputed from the surviving checks.

Because the row dot, the warning icon, the failing-check chip and the hover all read the sanitized health, this one change greens all four.

## The exemption is narrow — real faults still turn the row yellow

It keys off the `"is empty"` marker that `config.ValidateRepoTargets` puts **only** in the empty-shape issues:

| Case | Result |
|---|---|
| Placeholder, `repos: []` | `skip` — "Unassigned — repo target set when claimed by design" ✅ green |
| Placeholder, `org: github.ibm.com` (forge host) | **warn kept** — a bad *value* is a real fault |
| Placeholder, repo is a URL / contains `/` | **warn kept** |
| **Claimed** hive, `repos: []` | **warn kept** — a claimed project with no repos is a real fault |
| Placeholder, empty repos **+** a genuine failure | stays degraded — neutralising must not mask a real fault |

## Testing

Four new tests in `placeholder_health_test.go` covering the green case, the malformed-value case, and the claimed-hive leak case, following the existing tokens/agents test pattern.

```
go test ./pkg/hub/ ./pkg/config/ -count=1
ok  github.com/kubestellar/hive/v2/pkg/hub     107.672s
ok  github.com/kubestellar/hive/v2/pkg/config    5.977s

go build ./...   # clean
go vet ./pkg/hub/  # clean
```

## Note

No change is needed to `saas.go`'s dot logic — `repoTargetBad` already excludes placeholders (`!isPlaceholderHive(h) && !!h.repoTargetMisconfigured`), and the tooltip's placeholder branch already precedes the `repoTargetMisconfigured` branch. The residual yellow came entirely from the spoke-reported `warns` count flowing through unsanitized, which is what this fixes.
