### PR TITLE
🔒 F3: verify the hub cookie signature on /terminal (CWE-345)

### DIFF
--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js"
+    "test": "node server.test.js && node terminal_cookie_verify.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -14,6 +14,58 @@ const TTYD_PORT = parseInt(process.env.HIVE_TTYD_PORT || '7681', 10);
 const TTYD_URL = `http://127.0.0.1:${TTYD_PORT}`;
 const DASHBOARD_TOKEN = process.env.HIVE_DASHBOARD_TOKEN || '';
 const STATIC_DIR = process.env.HIVE_STATIC_DIR || path.join(__dirname, 'public');
+
+// SECURITY (audit F3, CWE-345): the /terminal gate below used to accept ANY
+// non-empty `hive_hub_user` cookie. `Cookie: hive_hub_user=x` therefore opened a
+// shell in a container holding the GitHub App key, every agent token, and the
+// hub secret — with no hub account required at all. This verifies the hub's
+// signature instead, mirroring verifyHubUserCookieValue in
+// v2/pkg/hub/hub_cookie.go.
+//
+// The cookie value is `<username>.<sig>` where sig is base64url-unpadded
+// HMAC-SHA256(key=SESSION_KEY, msg=username).
+//
+// SESSION_KEY resolution mirrors the Go SpokeSessionKey() helper:
+//   1. HIVE_SESSION_KEY (least-privilege provisioning), else
+//   2. derive from HIVE_HUB_SECRET via HMAC-SHA256(master, "hive-session-v1"),
+//      the backward-compatible path for spokes that still hold the master.
+// The info string MUST stay byte-for-byte identical to infoSessionKey in
+// v2/pkg/hub/hub_keys.go.
+const INFO_SESSION_KEY = 'hive-session-v1';
+function deriveSessionKey() {
+  const explicit = (process.env.HIVE_SESSION_KEY || '').trim();
+  if (explicit) return explicit;
+  const master = (process.env.HIVE_HUB_SECRET || '').trim();
+  if (!master) return '';
+  return crypto.createHmac('sha256', master).update(INFO_SESSION_KEY).digest('hex');
+}
+const SESSION_KEY = deriveSessionKey();
+
+// verifyHubUserCookie returns the verified username, or '' when the signature
+// does not verify / the key is unset / the value is malformed. Constant-time
+// comparison; a forged, edited, or legacy-unsigned cookie fails closed.
+function verifyHubUserCookie(secret, value) {
+  if (!secret || !value) return '';
+  const idx = value.lastIndexOf('.');
+  if (idx <= 0 || idx === value.length - 1) return '';
+  const username = value.slice(0, idx);
+  const sig = value.slice(idx + 1);
+  const expected = crypto.createHmac('sha256', secret).update(username).digest('base64url');
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return '';
+  return username;
+}
+
+// parseCookies is shared by the HTTP and WebSocket terminal gates so the two
+// cannot drift — they are equally exploitable and must stay in lockstep.
+function parseCookies(header) {
+  return (header || '').split(';').reduce((acc, c) => {
+    const [k, ...v] = c.trim().split('=');
+    if (k) acc[k] = v.join('=');
+    return acc;
+  }, {});
+}
 const SNAPSHOT_FRAME_ANCESTORS_FALLBACK = parseSnapshotFrameAncestors(process.env.HIVE_SNAPSHOT_FRAME_ANCESTORS || '');
 
 if (!DASHBOARD_TOKEN && process.env.NODE_ENV === 'production') {
@@ -189,12 +241,15 @@ app.use('/terminal', (req, res, next) => {
   const host = req.headers.host || '';
   const isHosted = host.endsWith('.hive.kubestellar.io');
   if (isHosted) {
-    const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
-      const [k, ...v] = c.trim().split('=');
-      if (k) acc[k] = v.join('=');
-      return acc;
-    }, {});
-    const user = cookies['hive_hub_user'];
+    // SECURITY (audit F3, CWE-345): VERIFY the cookie's signature. This gate
+    // previously accepted any non-empty value, so `Cookie: hive_hub_user=x`
+    // opened a shell in a credential-holding container with no hub account.
+    //
+    // Fails closed when SESSION_KEY is unset: a hosted spoke with no way to
+    // verify must deny, not wave everyone through — that is the same bug in a
+    // different disguise.
+    const cookies = parseCookies(req.headers.cookie);
+    const user = verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user']);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -274,12 +329,12 @@ server.on('upgrade', (req, socket, head) => {
     const host = req.headers.host || '';
     const isHosted = host.endsWith('.hive.kubestellar.io');
     if (isHosted) {
-      const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
-        const [k, ...v] = c.trim().split('=');
-        if (k) acc[k] = v.join('=');
-        return acc;
-      }, {});
-      if (!cookies['hive_hub_user']) {
+      // SECURITY (audit F3, CWE-345): same signature verification as the HTTP
+      // gate. A WebSocket upgrade reaches the SAME ttyd shell, so leaving this
+      // path on presence-only would leave the hole fully open — the HTTP fix
+      // alone would be security theatre.
+      const cookies = parseCookies(req.headers.cookie);
+      if (!verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user'])) {
         socket.destroy();
         return;
       }

--- a/v2/proxy/terminal_cookie_verify.test.js
+++ b/v2/proxy/terminal_cookie_verify.test.js
@@ -1,0 +1,165 @@
+// F3 (CWE-345): the /terminal gate must VERIFY the hub cookie's signature.
+//
+// Run: node terminal_cookie_verify.test.js
+//
+// Before this fix both terminal gates — the HTTP route and the WebSocket
+// upgrade — checked only that `hive_hub_user` was NON-EMPTY:
+//
+//     const user = cookies['hive_hub_user'];
+//     if (!user) { ...401... }
+//     next();                       // <-- any value proceeded
+//
+// So `curl -H 'Cookie: hive_hub_user=x' https://<hive>.hive.kubestellar.io/terminal`
+// opened a shell in a container holding the GitHub App private key, every agent
+// token, and the hub secret — with no hub account required at all.
+//
+// Both gates are covered here. Fixing only the HTTP one would be security
+// theatre: a WebSocket upgrade reaches the same ttyd.
+
+import { WebSocket, WebSocketServer } from 'ws';
+import { createServer, request as httpRequest } from 'http';
+import { spawn } from 'child_process';
+import path from 'path';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+import assert from 'assert';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROXY_PORT = 19101;
+const GO_PORT = 19102;
+const TTYD_PORT = 19103;
+const HOSTED_HOST = 'hive-f3.hive.kubestellar.io';
+
+// The master this spoke is provisioned with; the proxy derives SESSION_KEY from
+// it exactly as Go's SpokeSessionKey() does.
+const MASTER = 'f3-test-master-secret';
+const SESSION_KEY = crypto.createHmac('sha256', MASTER).update('hive-session-v1').digest('hex');
+
+// mintCookie mirrors the hub's mintHubUserCookieValue.
+function mintCookie(username) {
+  const sig = crypto.createHmac('sha256', SESSION_KEY).update(username).digest('base64url');
+  return `${username}.${sig}`;
+}
+
+function mockBackend(port, body) {
+  return new Promise(resolve => {
+    const s = createServer((req, res) => { res.writeHead(200); res.end(body); });
+    s.listen(port, () => resolve(s));
+  });
+}
+
+// The ttyd mock must speak WebSocket, not just HTTP: the terminal is a WS
+// upgrade, so a plain HTTP mock makes the "valid cookie opens a shell" control
+// fail for the wrong reason and hides whether the gate actually passed.
+function mockTtydWS(port) {
+  return new Promise(resolve => {
+    const s = createServer((req, res) => { res.writeHead(200); res.end('ttyd'); });
+    const wss = new WebSocketServer({ server: s });
+    wss.on('connection', ws => ws.send('shell'));
+    s.listen(port, () => resolve(s));
+  });
+}
+
+function startProxy() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        HIVE_PROXY_PORT: String(PROXY_PORT),
+        HIVE_API_PORT: String(GO_PORT),
+        HIVE_TTYD_PORT: String(TTYD_PORT),
+        HIVE_DASHBOARD_TOKEN: '',
+        HIVE_STATIC_DIR: __dirname,
+        HIVE_HUB_SECRET: MASTER,
+        NODE_ENV: 'test',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', d => {
+      if (!started && d.toString().includes('hive-proxy')) { started = true; resolve(proc); }
+    });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('proxy start timeout')); }, 10000);
+  });
+}
+
+// NOTE: uses http.request, not fetch. fetch() silently DROPS a custom Host
+// header, so the proxy would see 127.0.0.1 and take the non-hosted branch —
+// the terminal gate would never run and the test would pass vacuously against
+// vulnerable code. That is exactly the failure mode this file exists to catch.
+function terminalHTTP(cookie) {
+  return new Promise((resolve, reject) => {
+    const headers = { Host: HOSTED_HOST };
+    if (cookie !== null) headers.Cookie = `hive_hub_user=${cookie}`;
+    const req = httpRequest(
+      { host: '127.0.0.1', port: PROXY_PORT, path: '/terminal', method: 'GET', headers },
+      res => { res.resume(); resolve(res.statusCode); },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function terminalWS(cookie) {
+  return new Promise(resolve => {
+    const headers = { Host: HOSTED_HOST };
+    if (cookie !== null) headers.Cookie = `hive_hub_user=${cookie}`;
+    const ws = new WebSocket(`ws://127.0.0.1:${PROXY_PORT}/terminal`, { headers });
+    const done = opened => { try { ws.close(); } catch {} resolve(opened); };
+    ws.on('open', () => done(true));
+    ws.on('error', () => done(false));
+    ws.on('close', () => done(false));
+    setTimeout(() => done(false), 4000);
+  });
+}
+
+let proxy, go, ttyd;
+try {
+  go = await mockBackend(GO_PORT, 'go');
+  ttyd = await mockTtydWS(TTYD_PORT);
+  proxy = await startProxy();
+  await new Promise(r => setTimeout(r, 400));
+
+  // --- THE VULNERABILITY: a garbage cookie must NOT open a shell -------------
+  for (const forged of ['x', 'anything-at-all', 'clubanderson.not-a-real-signature']) {
+    const status = await terminalHTTP(forged);
+    assert.equal(status, 401,
+      `F3: HTTP /terminal accepted the forged cookie ${JSON.stringify(forged)} (got ${status}) — ` +
+      `this is a shell in a credential-holding container for anyone who can set a header`);
+    const opened = await terminalWS(forged);
+    assert.ok(!opened,
+      `F3: WebSocket /terminal accepted the forged cookie ${JSON.stringify(forged)} — ` +
+      `the upgrade path reaches the SAME ttyd`);
+  }
+  console.log('  ✓ forged / unsigned cookies denied on BOTH the HTTP and WS gates');
+
+  // --- No cookie at all still denied (unchanged behaviour) -------------------
+  assert.equal(await terminalHTTP(null), 401, 'missing cookie must be 401');
+  assert.ok(!(await terminalWS(null)), 'missing cookie WS must be refused');
+  console.log('  ✓ absent cookie denied');
+
+  // --- CONTROL: a genuinely hub-signed cookie still works --------------------
+  const good = mintCookie('alice');
+  assert.equal(await terminalHTTP(good), 200,
+    'a VALID hub-signed cookie must still reach the terminal — the fix must not lock out real users');
+  assert.ok(await terminalWS(good), 'a VALID hub-signed cookie must still open the WS');
+  console.log('  ✓ valid hub-signed cookie still granted (HTTP + WS)');
+
+  // --- Tampering: right shape, wrong signature ------------------------------
+  const tampered = 'mallory.' + good.split('.')[1];
+  assert.equal(await terminalHTTP(tampered), 401,
+    'a re-labelled cookie (alice signature, different username) must be denied');
+  console.log('  ✓ re-labelled cookie denied (signature covers the username)');
+
+  console.log('\n✓ F3 terminal cookie verification tests passed\n');
+} catch (e) {
+  console.error('\n✗ F3 test failed:', e.message, '\n');
+  process.exitCode = 1;
+} finally {
+  if (proxy) proxy.kill();
+  if (go) go.close();
+  if (ttyd) ttyd.close();
+  await new Promise(r => setTimeout(r, 200));
+}


### PR DESCRIPTION
**Targets `v2`, deliberately** — unlike the audit fixes, which are v4-only. This one has to go to v2 because the vulnerability is live on the 16 hosted spokes running `v2-latest` today.

## The vulnerability

Both `/terminal` gates accepted **any non-empty** `hive_hub_user` cookie:

```js
const user = cookies['hive_hub_user'];
if (!user) { ...401... }
next();                       // <-- any value proceeded
```

So:

```
curl -H 'Cookie: hive_hub_user=x' https://<hive>.hive.kubestellar.io/terminal
```

opens a shell in a container holding the **GitHub App private key, every agent token, and the hub secret** — with no hub account required at all. Reproduced against the real proxy: forged cookie → HTTP 200 and an open WebSocket.

This is audit finding **F3 (CWE-345)**. It's fixed on `v4`; it was never ported to `v2`, where the fleet actually runs.

## Both gates, not one

The HTTP route and the WebSocket upgrade reach the **same ttyd**. Fixing only the HTTP one would be security theatre — an attacker just upgrades instead.

They now share `parseCookies` / `verifyHubUserCookie`. They were duplicated inline before, which is precisely how they came to be equally wrong.

## Compatibility — checked against the live fleet, not assumed

- `verifyHubUserCookie` mirrors `verifyHubUserCookieValue` in `pkg/hub/hub_cookie.go` (constant-time HMAC over `<username>.<sig>`).
- `SESSION_KEY` resolves exactly as `SpokeSessionKey()` does: `HIVE_SESSION_KEY`, else derived from `HIVE_HUB_SECRET` with the `"hive-session-v1"` label.
- **Verified every deployed spoke (17/17) can derive the key**, so this locks nobody out. The only deployment that can't is `hive-hub` itself, which doesn't serve `/terminal`.
- **Self-hosted is untouched** — the gate only runs for a `*.hive.kubestellar.io` Host.
- **Fails closed** with no resolvable key: a hosted spoke that cannot verify must deny, not wave everyone through. That would be the same bug wearing a different hat.

## Regression

Drives a **real proxy** with a WebSocket-capable ttyd mock, asserting both gates: forged, unsigned, absent, and re-labelled cookies denied; a genuinely hub-signed cookie still granted on HTTP **and** WS. Wired into `npm test`.

Two things would have made this test pass vacuously against vulnerable code, both now handled and commented in the file:

1. **`fetch()` silently drops a custom `Host` header** — the proxy then sees `127.0.0.1`, takes the non-hosted branch, and the gate never runs. Uses `http.request` instead.
2. **A plain-HTTP ttyd mock can't complete a WS upgrade** — so the positive control fails for the wrong reason and tells you nothing.

**Verified the suite FAILS against the pre-fix code** (forged cookie → 200).

## Context

Found while investigating why my v4 hub-side fixes weren't taking effect in production. The hub runs `v2-latest`, so the v4-only security work doesn't execute there — that's a separate thread. This one is the most urgent piece: an unauthenticated path to a shell on every hosted tenant.