### PR TITLE
📖 docs: close guide documentation gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,9 @@ Thank you for helping improve KubeStellar Hive. This guide is for contributing c
   - `v2/docs/` — architecture and operator/developer reference material.
   - `v2/test/` — integration and regression tests.
 - `bin/` — shell helpers used by the existing automation and maintainer workflows.
+- `config/hive-project.yaml.example` — project metadata for the top-level
+  deterministic shell pipeline; see [config/README.md](config/README.md). This
+  is separate from the v2 Go runtime config in `v2/hive.yaml.example`.
 - `dashboard/`, `docs/`, `config/`, `systemd/`, `launchd/`, and top-level scripts — supporting assets for hub, dashboard, installation, and operational workflows.
 - `Justfile` — contributor relay recipes; see [Just recipes](docs/development.md#just-recipes).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ docker compose up -d
 
 The [Hive Hub](https://hive.kubestellar.io) provides hosted hives with OAuth-protected dashboards, a public registry, and cross-hive leaderboards. No cluster required.
 
+If you need to run your own private hub instead, see the v2
+[self-hosted hub deployment guide](v2/docs/hub-deployment.md).
+
 ### Self-Hosted Deployment
 
 #### 1. Create the namespace
@@ -175,7 +178,11 @@ kubectl apply -f deploy/k8s/service.yaml
 
 ## Configuration
 
-All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+
+The top-level deterministic shell pipeline uses a separate project file,
+`config/hive-project.yaml.example`; see [config/README.md](config/README.md)
+before running the top-level `bin/` scripts directly.
 
 ```yaml
 project:

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,22 @@
+# Hive configuration files
+
+This directory contains configuration used by the top-level Hive helper scripts. It is not the same as the v2 Go binary config in `v2/hive.yaml.example`.
+
+## `hive-project.yaml`
+
+`config/hive-project.yaml.example` is the project file consumed by the deterministic shell pipeline under `bin/`:
+
+- `bin/hive-config.sh` reads `${HIVE_PROJECT_CONFIG:-/etc/hive/hive-project.yaml}` and exports project, agent, dashboard, health-check, outreach, and GitHub App values for other scripts.
+- `bin/run-pipeline.sh` and several pipeline stages read `${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}` to find `pipeline.stages` and project-specific classification inputs.
+- If the file is missing, scripts fall back to built-in defaults or to the first example file they can find; those fallbacks are for development and may not match your project.
+
+Install it at `/etc/hive/hive-project.yaml`, or point the scripts at another path with `HIVE_PROJECT_CONFIG` and `HIVE_PROJECT_YAML`.
+
+## How it differs from `v2/hive.yaml`
+
+| File | Used by | Purpose |
+|---|---|---|
+| `config/hive-project.yaml.example` | Top-level `bin/` shell automation and deterministic pre-kick pipeline | Project/org/repo metadata, enabled script agents, beads base directory, health-check workflow names, outreach metadata, and optional GitHub App values for script token minting. |
+| `v2/hive.yaml.example` | The v2 Go `hive` binary, dashboard, governor, agent manager, hub, and API server | Runtime config for the containerized v2 service: project, agents, governor modes, GitHub auth, dashboard auth, data paths, knowledge, hub/spoke settings, and ACMM level. |
+
+Use `v2/hive.yaml` for normal v2 Docker/Kubernetes operation. Use `hive-project.yaml` only when you run the top-level `bin/` scripts or the deterministic pipeline directly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,11 @@
 # Architecture
 
+> **Legacy v1/systemd documentation.** This root `docs/` page describes the
+> original supervisor, systemd/launchd timers, tmux, and `agent.env` workflow.
+> It is kept for historical context. For the current v2 Docker/Go architecture,
+> start with [`v2/docs/architecture.md`](../v2/docs/architecture.md) and the
+> [`v2/docs/README.md`](../v2/docs/README.md) index.
+
 ## Two scheduling models
 
 hive supports two fundamentally different ways to drive an agent. Choose based on how much control you want to keep.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,5 +1,12 @@
 # macOS Support (launchd)
 
+> **Legacy v1/launchd documentation.** This page maps the original
+> systemd-style supervised agent workflow to macOS launchd. It does not describe
+> the current v2 Docker/Go deployment. For v2, start with
+> [`v2/docs/README.md`](../v2/docs/README.md), plus
+> [`v2/docs/operator-reference.md`](../v2/docs/operator-reference.md) and
+> [`v2/docs/deployment-scripts.md`](../v2/docs/deployment-scripts.md).
+
 The hive runtime was built on Linux/systemd, but the same concepts map cleanly to macOS using **launchd** — Apple's equivalent of systemd.
 
 This guide shows how to run a supervised agent on a Mac that stays on (Mac Mini, Mac Studio, always-on laptop, etc.).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,13 @@
 # Troubleshooting
 
+> **Legacy v1/systemd documentation.** This page troubleshoots the original
+> supervisor/tmux/systemd deployment (`bin/supervisor.sh`, `systemctl`, and
+> `/etc/hive/agent.env`). For current v2 Docker/Go operations, use the
+> [`v2/docs/README.md`](../v2/docs/README.md) index, especially
+> [`v2/docs/health-checks.md`](../v2/docs/health-checks.md),
+> [`v2/docs/operator-reference.md`](../v2/docs/operator-reference.md), and
+> [`v2/docs/manual-provisioning.md`](../v2/docs/manual-provisioning.md).
+
 ## The `/loop` prompt never fires — the agent just sits at the prompt
 
 Cause: the supervisor's `AGENT_READY_MARKER` doesn't appear in the agent's TUI, so the supervisor gives up before sending `AGENT_LOOP_PROMPT`.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -5,8 +5,10 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Operations
 
 - [Manual provisioning](manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
+- [Self-hosted hub deployment](hub-deployment.md) — `HIVE_MODE=hub`, hub storage, heartbeat secrets, and SaaS spoke registration.
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, and GitHub token scopes.
+- [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
 - [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
 - [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -11,9 +11,10 @@ merge-gating, permission enforcement) from **judgment calls** (reading code,
 reasoning about a fix, writing a PR). Deterministic work runs in Go and shell
 before any LLM sees the task; agents only handle the judgment.
 
-> This document describes the `v2` branch. The planning-intelligence subsystem
-> (goal decomposition, plan review, stall-replan) is **v3-only** and is called
-> out where relevant.
+> This document describes the `v2` branch. Automatic goal decomposition, plan
+> review, and stall-triggered re-planning are not implemented in v2 HEAD; treat
+> any mention of those capabilities outside this page as future/design-only
+> material unless the code grows matching planner/replan paths.
 
 ---
 

--- a/v2/docs/env-vars.md
+++ b/v2/docs/env-vars.md
@@ -1,0 +1,157 @@
+# Environment variable reference
+
+This reference is generated from the v2 source, deployment manifests, and the top-level helper scripts. The code is authoritative: `hive.yaml` may also expand arbitrary `${NAME}` placeholders through the config resolver, but only the variables below have built-in behavior.
+
+## Core `hive` runtime
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_CONFIG` | No | `/etc/hive/hive.yaml` | Default config path used before the `--config` flag is parsed. The dashboard also uses it when reporting config provenance. |
+| `HIVE_MODE` | No | spoke/dashboard mode | Set to `hub` to run the hub server instead of the spoke dashboard. |
+| `HIVE_HUB_PORT` | No | `3001` | Hub listen port when `HIVE_MODE=hub`. |
+| `HIVE_SINGLETON_LOCK` | No | `/var/run/hive-metrics/hive.singleton.lock` when available, otherwise OS temp dir | Overrides the process singleton lock path. Set exactly `off` only for local development where duplicate processes are intentional. |
+| `HIVE_GITHUB_TOKEN` | Required unless GitHub App auth is configured | none | Main PAT fallback for `github.token`; also used by fleet/stat fallback paths and some deployment manifests. |
+| `GH_APP_KEY_FILE` | No | configured `github.key_file`, then `/data/gh-app-key.pem` or `/secrets/gh-app-key.pem` in provisioned paths | GitHub App private-key file fallback. |
+| `DASHBOARD_AUTH_TOKEN` | No | none | Kubernetes/provisioned secret name for the dashboard shared token; used before `HIVE_DASHBOARD_TOKEN` when `dashboard.auth_token` is empty. |
+| `HIVE_DASHBOARD_TOKEN` | No | none | Dashboard/API shared-token fallback and default `hivectl --token-env` variable. |
+| `HIVE_AUTHORIZED_USERS` | No | none | Comma-separated direct-route dashboard allowlist, with optional `user:role` entries. Used when `dashboard.authorized_users` is empty. |
+| `HIVE_REPO` | No | none | Bootstrap shortcut in `owner/repo` form; fills `project.org`, `project.repos`, and `project.primary_repo` if missing. |
+| `HIVE_LEVEL` | No | config/pack value | ACMM level bootstrap/override used by hosted flows and the entrypoint pack selection. |
+| `HIVE_ID` | No | config or generated id | Stable hive/spoke identifier override; passed through to launched agents. |
+| `HIVE_CLUSTER_ID` | No | config or hub-provisioned value | Hosted cluster identifier override. |
+| `HIVE_HUB_URL` | No | `hub.url` from config | Hub URL override for spoke heartbeats/registration. |
+| `HIVE_HUB_SECRET` | Required for spokes registered to a protected hub; optional for a standalone hub with `/data/saas/hub-secret.key` | `/data/saas/hub-secret.key` on the hub when present; no fallback for spoke heartbeat auth | Bearer secret for spoke heartbeats and hub/spoke SaaS APIs. |
+| `HIVE_COVERAGE_BADGE_URL` | No | none | Optional coverage badge URL exposed in dashboard status. |
+| `HIVE_WORK_DIR` | No | `/data/agents` | Agent manager working directory. |
+| `HIVE_SHA` | No | build SHA | Passed to launched agents and used in hub upgrade/status paths. |
+| `HIVE_ADVISORY_ISSUE` | No | none | Passed to launched agents so advisory findings can target a configured issue. |
+| `HIVE_TTYD_PORT` | No | `7681` | Web terminal port used by the entrypoint and terminal proxy. |
+| `HIVE_METRICS_ENABLED` | No | disabled | Enables unauthenticated Prometheus `/metrics` when set to `1`, `true`, `yes`, or `on`. |
+| `HIVE_METRICS_FILE` | No | `/var/run/hive-metrics/contribute.json` | Contributor metrics JSON file override. |
+| `HIVE_COPILOT_INTEGRATION_ID` | No | compiled Copilot integration id | Overrides the integration id used by Copilot model discovery. |
+| `HIVE_PROXY_PROOF_REQUIRED` | No | `false` | Requires the internal proxy proof header when set to `true`. |
+| `HIVE_CONTRIBUTORS_DIR` | No | hub default | Contributor registry directory override. |
+| `HIVE_FEDERATION_REGISTRY_PATH` | No | `/data/federation/registry.json` | Federation registry path override. |
+| `HIVE_WEBHOOK_SECRET` | No | none | HMAC secret for the spoke `/webhook` channel. |
+| `GITHUB_WEBHOOK_SECRET` | No | `/data/saas/webhook-secret.key` when present | Hub GitHub webhook HMAC secret. |
+
+## Deployment entrypoint and proxy knobs
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_API_PORT` | No | `3002` | Internal Go API port used by `v2/deploy/entrypoint.sh`. |
+| `HIVE_PROXY_PORT` | No | `3001` | Node reverse-proxy/front-door port used by `v2/deploy/entrypoint.sh`. |
+| `HIVE_STATIC_DIR` | No | `/opt/hive/proxy/public` | Static asset directory for the Node proxy. |
+| `HIVE_PROXY_EGRESS_MARK` | No | `0x1112` | Packet mark exempted from the MITM egress redirect. |
+| `HIVE_WIKI_GIT_URL` | No | none | Optional wiki vault URL cloned into `/data/vaults/hive-wiki` on first boot. |
+
+## Inference, CLI backends, and agents
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_VLLM_ENDPOINT` | No | `http://hive-vllm-svc.hive-inference.svc.cluster.local:8000` in code; `v2/deploy/k8s/deployment.yaml` sets `http://vllm-svc.hive-inference.svc.cluster.local:8000` | Comma-separated vLLM endpoint list. |
+| `HIVE_LLMD_ENDPOINT` | No | `http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000` in code; `v2/deploy/k8s/deployment.yaml` sets `http://llm-d-epp.hive-inference.svc.cluster.local:8000` | Comma-separated llm-d endpoint list. |
+| `HIVE_LITELLM_ENDPOINT` | No | YAML `governor.litellm.endpoint`; unset means LiteLLM is unregistered unless `local_proxy` is true | Runtime LiteLLM base URL override. |
+| `HIVE_VLLM_API_KEY` | No | none | Default bearer token for vLLM model discovery when no backend-specific `api_key_env` or file resolves. |
+| `HIVE_LLMD_API_KEY` | No | none | Default bearer token for llm-d model discovery when no backend-specific `api_key_env` or file resolves. |
+| `HIVE_LITELLM_API_KEY` | No | `/secrets/litellm_api_key` or `/data/secrets/litellm_api_key` may be used first | Default LiteLLM API key environment variable. |
+| `HIVE_VLLM_MODELS` | No | static fallback aliases | Comma-separated vLLM model IDs used when discovery returns none. |
+| `HIVE_LLMD_MODELS` | No | static fallback aliases | Comma-separated llm-d model IDs used when discovery returns none. |
+| `HIVE_LITELLM_MODELS` | No | static fallback aliases | Comma-separated LiteLLM model IDs used when discovery returns none. |
+| `HIVE_BOB_API_KEY` | Required only for Bob agents in pods unless a key file is mounted or saved on `/data` | `/secrets/bob_api_key` or `/data/secrets/bob_api_key` may be used first | Hive-side Bob API key source. The value is injected into Bob as `BOBSHELL_API_KEY`. |
+| `HIVE_BOB_API_URL` | No | `https://api.us-east.bob.ibm.com` | Bob key-test endpoint base URL override. |
+| `BOBSHELL_API_KEY` | Required by Bob CLI when Hive injects or contributor mode uses Bob | none | API key name read by bobshell itself. |
+| `COPILOT_GITHUB_TOKEN` | No | dashboard device-flow token file, if present | Copilot completion/model-discovery token and explicit agent injection. |
+| `ANTHROPIC_API_KEY` | Required by `cmd/apiproxy` unless `PROXY_AUTH_TOKEN` is set; agent inference backends receive a synthetic value | none | Anthropic-compatible API key for apiproxy auth or CLI compatibility. |
+| `PROXY_AUTH_TOKEN` | No | `ANTHROPIC_API_KEY` | Preferred auth token for `cmd/apiproxy`. |
+| `CONTEXT7_API_KEY` | No | none | Optional key for Context7 knowledge API integration. |
+| `GOOSE_PROVIDER` | No | Goose CLI default | Provider passed through Goose backend/model resolution. |
+| `GOOSE_MODEL` | No | Goose CLI default | Model passed through Goose backend/model resolution and contributor relay fallback. |
+| `BD_DIR` | No | current directory | `bd` beads CLI data directory. |
+| `BD_DASHBOARD_URL` | No | none | Dashboard URL used by `bd kb` integration. |
+| `HIVE_CONN_<NAME>_URL` | No | generated from agent connection config | Agent API connection URI variable when a connection omits `env_name`; `<NAME>` is the uppercased connection name with `-` replaced by `_`. |
+| Custom connection auth env vars | No | none | If an agent API connection uses `auth.type: env`, Hive reads `auth.env_var` and injects that exact variable into the agent. |
+
+## Hub, SaaS, alerts, and backups
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_HUB_OAUTH_CLIENT_ID` | Required to enable hub OAuth | none | Enables hub `/login` and OAuth callback routes. |
+| `HIVE_HUB_OAUTH_CLIENT_SECRET` | Required when hub OAuth is enabled | none | OAuth client secret used during callback token exchange. |
+| `HIVE_HUB_SLACK_BOT_TOKEN` | No | none | Slack bot token for hub Slack notifications. |
+| `HIVE_NTFY_SERVER` | No | none | ntfy server for hub auth-audit alerts. |
+| `HIVE_NTFY_TOPIC` | No | none | ntfy topic for hub auth-audit alerts. |
+| `HIVE_BACKUP_KEY` | Yes for hub DR backups and browser spoke backups | none | 64-character hex or base64 AES-256 key. Unset makes backup creation fail. |
+| `HIVE_BACKUP_BUCKET` | Required for OCI upload mode | none | OCI Object Storage bucket for hub backup archives. |
+| `HIVE_BACKUP_DATA_DIR` | No | `/data` | Hub data directory used by `hive-backup`. |
+| `HIVE_BACKUP_RETENTION` | No | `30` | Number of backup archives to retain. |
+| `HIVE_BACKUP_OCI_ENDPOINT` | No | OCI SDK default endpoint | OCI Object Storage endpoint override. |
+| `HIVE_HUB_NAMESPACE` | No | current/default namespace | Hub namespace override for backup collection. |
+| `HIVE_KUBECONFIG_DIR` | No | `/etc/hive/kubeconfigs` | Directory containing per-cluster kubeconfigs for remote spoke backup collection. |
+| `HIVE_SPOKE_BACKUP_DATA_DIR` | No | `/data` | Spoke data directory for on-demand spoke backup. |
+| `OCI_TENANCY_OCID` | Required for OCI FSS/Object Storage flows | none | OCI tenancy OCID. |
+| `OCI_USER_OCID` | Required for OCI FSS/Object Storage flows | none | OCI user OCID. |
+| `OCI_FINGERPRINT` | Required for OCI FSS/Object Storage flows | none | OCI API key fingerprint. |
+| `OCI_PRIVATE_KEY` | Required for OCI FSS/Object Storage flows | none | OCI API private key PEM content. |
+| `OCI_REGION` | Required for Object Storage backup | none | OCI Object Storage region. |
+| `OCI_FSS_REGION` | Required for OCI FSS provisioning unless region is otherwise configured | none | OCI File Storage region. |
+| `OCI_COMPARTMENT_ID` | Required for OCI FSS provisioning | none | OCI compartment OCID. |
+| `OCI_AVAILABILITY_DOMAIN` | Required for OCI FSS provisioning | none | OCI availability domain. |
+| `OCI_MOUNT_TARGET_ID` | Required for OCI FSS provisioning | none | OCI mount target OCID. |
+| `OCI_EXPORT_SET_ID` | Required for OCI FSS provisioning | none | OCI export set OCID. |
+
+## Kubernetes downward API and platform variables
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `POD_NAMESPACE` | No | `NAMESPACE`, then `default` | Preferred downward-API namespace value for dashboard/spoke identity. |
+| `NAMESPACE` | No | `default` | Fallback namespace when `POD_NAMESPACE` is unset. |
+| `KUBERNETES_SERVICE_HOST` | Set by Kubernetes | none | Used with `KUBERNETES_SERVICE_PORT` to detect in-cluster execution and build API URLs. |
+| `KUBERNETES_SERVICE_PORT` | Set by Kubernetes | none | Kubernetes API service port. |
+| `HOME` | Set by OS/container | none | Used to locate CLI credentials in several backend probes. |
+| `PATH` | Set by OS/container | none | Used by helper tests and inherited by subprocesses. |
+
+## Contributor relay and top-level helper scripts
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_HUB` | Required after registration for contributor relay; `just` can discover/set it | `wss://hive.kubestellar.io/contribute` in `Justfile`; `wss://hive.kubestellar.io:3001/contribute` in compose/relay defaults | Contributor WebSocket hub URL. Comma-separated values are supported with matching `HIVE_REGISTRATION_TOKEN` entries. |
+| `HIVE_REGISTRATION_TOKEN` | Yes for contributor relay | none | Contributor registration token. Comma-separated values match `HIVE_HUB` by position. |
+| `AGENT_BACKEND` | No | `claude` | Contributor/agent CLI backend selector. |
+| `AGENT_MODEL` | No | backend default, or `GOOSE_MODEL` for Goose fallback | Contributor/agent model override. |
+| `CONTRIBUTOR_MODE` | No | `interactive` | Contributor relay mode: `interactive` uses tmux; `headless` uses one-shot CLI execution for supported backends. |
+| `HIVE_HEADLESS_STATUS_FILE` | No | `/tmp/contributor-headless-status.json` | Status file written by headless contributor relay. |
+| `HIVE_CONTRIBUTOR_IMAGE` | No | `ghcr.io/kubestellar/hive-contributor:latest` | Image used by `just contribute-hive`. |
+| `HIVE_CONTAINER_RUNTIME` | No | autodetect `docker` or `podman` | Container runtime override for contributor helpers. |
+| `HIVE_SKIP_VERSION_CHECK` | No | `false` | Skips `just` version freshness check when set to `true`. |
+| `HIVE_SKIP_PULL` | No | `false` | Skips contributor image pull when set to `true`. |
+| `HIVE_KEEP_CONTAINER` | No | remove failed contributor container | Keeps failed contributor containers for debugging when set to `true`. |
+| `HIVE_PROJECT_CONFIG` | No | `/etc/hive/hive-project.yaml` | Path read by `bin/hive-config.sh` for deterministic pipeline/project metadata. |
+| `HIVE_PROJECT_YAML` | No | `/etc/hive/hive-project.yaml`, then first example found | Path read directly by pipeline stages. |
+| `HIVE_RUNTIME_CONFIG` | No | `/etc/hive/hive-runtime.yaml` | Runtime overlay read by `bin/hive-config.sh`. |
+| `HIVE_REPO_DIR` | No | `/tmp/hive` | Hive checkout path used by top-level deployment scripts. Must not be empty or `/`. |
+| `HIVE_BIN` | No | `/usr/local/bin` | Directory containing helper binaries such as `gh-app-token.sh`. |
+| `HIVE_REPOS` | Required by v1/top-level supervisor scripts if project config is absent | none | Space-separated repos for legacy/top-level script workflows. |
+| `HIVE_BACKENDS` | No | `copilot` in bootstrap example | Backend list for legacy/top-level script setup. |
+| `HIVE_MODEL_SERVICES` | No | none | Optional local model stack selector in legacy bootstrap scripts. |
+| `HIVE_AUTO_INSTALL` | No | script default | Controls CLI auto-install in legacy bootstrap scripts. |
+| `AGENT_SESSION_NAME` | No | `hive` in `config/agent.env.example` | tmux session name for legacy/top-level supervised agent scripts. |
+| `AGENT_LOOP_PROMPT` | No | example executor prompt | Prompt sent by legacy/top-level supervisor scripts. |
+| `AGENT_READY_MARKER` | No | configured in `agent.env` | TUI marker used by legacy/top-level supervisor readiness checks. |
+| `AGENT_AUTO_APPROVE_PHRASE` | No | none | Legacy/top-level supervisor phrase used to auto-dismiss a known prompt. |
+| `AGENT_LOG_FILE` | No | configured in `agent.env` | Legacy/top-level heartbeat/healthcheck log path. |
+| `NTFY_TOPIC` | No | `hive` in `bin/kick-agents.sh`; blank disables `bin/notify.sh` | ntfy topic for top-level script notifications. |
+| `NTFY_SERVER` | No | `https://ntfy.sh` | ntfy server for top-level script notifications. |
+| `SLACK_WEBHOOK` | No | none | Slack incoming webhook for top-level script notifications. |
+| `DISCORD_WEBHOOK` | No | none | Discord webhook for top-level script notifications. |
+
+## Verification commands
+
+The table above was cross-checked with these mechanical searches from the repository root:
+
+```sh
+rg 'os\.(Getenv|LookupEnv)\(' v2 --glob '*.go'
+rg '\bHIVE_[A-Z0-9_]+\b|\bBD_DIR\b|\bGH_APP_KEY_FILE\b|\bAGENT_BACKEND\b' v2 bin config Justfile
+rg '\b(ANTHROPIC|COPILOT|GOOSE|BOBSHELL|OCI|KUBERNETES|POD|NAMESPACE|DASHBOARD|PROXY|SLACK|DISCORD|NTFY)_[A-Z0-9_]+\b' v2 bin config Justfile
+rg 'HIVE_[A-Z0-9_]+|BD_DIR|GH_APP_KEY_FILE|AGENT_BACKEND' v2/deploy
+```

--- a/v2/docs/hub-deployment.md
+++ b/v2/docs/hub-deployment.md
@@ -1,0 +1,112 @@
+# Self-hosted hub deployment
+
+Hive can run either as a spoke dashboard or as the hub. The same Go binary serves both roles; `HIVE_MODE=hub` selects the hub server in `cmd/hive/main.go`.
+
+Use a self-hosted hub when you need a private registry, private SaaS provisioning, air-gapped control, or a hub URL other than `https://hive.kubestellar.io`. If you only need a hosted spoke, use the hosted Hive Hub instead.
+
+## What `Dockerfile.hub` builds
+
+`v2/Dockerfile.hub` builds only `./cmd/hive`, installs `kubectl`, creates `/data` and `/etc/hive`, sets `HIVE_MODE=hub`, and runs:
+
+```sh
+hive --config /etc/hive/hive.yaml
+```
+
+The hub listen port is still controlled by `HIVE_HUB_PORT` in the binary and defaults to `3001`. The Dockerfile exposes port `80`, so set `HIVE_HUB_PORT=80` if your container platform expects the process to bind that exposed port.
+
+## Required storage
+
+Use a persistent volume mounted at `/data`. The production/manual-provisioning docs describe the live hub as namespace `hive-hub`, PVC `hive-hub-data-rwx`, mounted at `/data`.
+
+The hub stores live SaaS state under `/data`:
+
+| Path | Purpose |
+|---|---|
+| `/data/saas/hives/<id>/meta.json` | Per-hive SaaS record used by auth, upgrades, assignments, and dashboard links. |
+| `/data/hub-registry.json` | Fleet registry populated by spoke heartbeats. |
+| `/data/saas/hub-secret.key` | Optional fallback heartbeat bearer secret when `HIVE_HUB_SECRET` is not set on the hub. |
+| `/data/saas/clusters.json` | Cluster definitions used by automated provisioning. |
+
+Use ReadWriteMany storage for hosted spoke PVCs. The provisioning template in `pkg/hub/saas_provision.go` requests `ReadWriteMany` and its rolling update strategy relies on both old and new pods being able to mount `/data` during a surge.
+
+## Minimal hub environment
+
+| Variable | Required | Notes |
+|---|---:|---|
+| `HIVE_MODE=hub` | Yes | Selects hub mode. |
+| `HIVE_HUB_PORT` | No | Defaults to `3001`. Set to `80` for the published hub image contract if needed. |
+| `HIVE_CONFIG` or `--config` | No | Defaults to `/etc/hive/hive.yaml`; `Dockerfile.hub` passes `--config /etc/hive/hive.yaml`. |
+| `HIVE_HUB_SECRET` | Strongly recommended | Shared bearer secret for heartbeat authentication. If unset, the hub reads `/data/saas/hub-secret.key` when present. |
+| `HIVE_HUB_OAUTH_CLIENT_ID` / `HIVE_HUB_OAUTH_CLIENT_SECRET` | Required for hub OAuth login | Without the client id the hub logs OAuth disabled and does not register the login routes. |
+| `HIVE_GITHUB_TOKEN` or GitHub App config | Required for operations that call GitHub | Same GitHub auth rules as a spoke. |
+| `HIVE_HUB_SLACK_BOT_TOKEN`, `HIVE_NTFY_SERVER`, `HIVE_NTFY_TOPIC` | No | Optional hub notifications. |
+| `HIVE_BACKUP_*`, `OCI_*`, `HIVE_KUBECONFIG_DIR` | No | Required only for disaster-recovery backup and OCI/FSS provisioning flows. See `backup-restore.md`. |
+
+## Hub config shape
+
+The hub still reads `hive.yaml`. The hub-specific code mainly uses the `hub` block, GitHub credentials, dashboard/auth settings, and any provisioning-related data under `/data/saas`. A minimal seed keeps the normal project and GitHub validation satisfied:
+
+```yaml
+project:
+  org: your-org
+  repos: [your-repo]
+  primary_repo: your-repo
+
+github:
+  token: ${HIVE_GITHUB_TOKEN}
+
+dashboard:
+  auth_token: ${HIVE_DASHBOARD_TOKEN}
+
+hub:
+  enabled: true
+  url: https://hive.example.com
+```
+
+Keep secret values in Kubernetes Secrets or environment variables; do not write token values directly into `hive.yaml`.
+
+## Registering spokes to your hub
+
+A spoke points at the hub with its config `hub.url` or the `HIVE_HUB_URL` override. Protected hubs require the same heartbeat secret on every spoke:
+
+```yaml
+hub:
+  enabled: true
+  url: https://hive.example.com
+```
+
+```yaml
+env:
+  - name: HIVE_HUB_URL
+    value: https://hive.example.com
+  - name: HIVE_HUB_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: hive-secrets
+        key: HIVE_HUB_SECRET
+```
+
+Without `HIVE_HUB_SECRET`, a protected hub returns `401 unauthorized`, the spoke logs `hub heartbeat rejected status=401`, and the hub shows the hive offline. This matches the gotcha in `manual-provisioning.md`.
+
+## Hosted spoke provisioning model
+
+The hub's SaaS provisioner creates or records:
+
+1. Namespace, RBAC, Secret, ConfigMap, Service, route/ingress, Deployment, and an RWX `hive-data` PVC.
+2. A mounted `/data` volume where the spoke writes runtime config and state.
+3. `HIVE_ID`, `POD_NAMESPACE`, `HIVE_LEVEL`, `HIVE_HUB_URL`, `HIVE_HUB_SECRET`, optional `HIVE_AUTHORIZED_USERS`, and inference endpoint env vars in the spoke Deployment.
+4. `/data/saas/hives/<id>/meta.json` on the hub PVC. Heartbeats can be accepted without this record, but hub-driven upgrades and dashboard links need it.
+
+For heartbeat-only clusters where the hub cannot run `kubectl`, follow the manifest-level workflow in `manual-provisioning.md`; this guide intentionally keeps the hub setup consistent with that battle-tested path.
+
+## API surface to know
+
+The hub registers heartbeat, registry, SaaS, contributor, OAuth, webhook, backup, and callback-related routes from the Go hub packages. Operators normally interact through the dashboard, but the important external contracts are:
+
+- `POST /api/heartbeat` — spoke heartbeat, bearer-authenticated by `HIVE_HUB_SECRET` when configured.
+- `POST /api/saas/hives` — hub-admin SaaS hive creation path.
+- `/api/saas/auth-check` — ingress auth check used by hub-proxied spoke dashboards.
+- `/contribute` and `/api/contribute/*` — contributor relay registration and WebSocket flow.
+- `/api/registry` and leaderboard/fleet views — public or authenticated hub registry views.
+
+See `api-reference.md` and the dashboard OpenAPI file for route details, and `manual-provisioning.md` for known failure modes.

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -4,6 +4,10 @@ This page is a concise operator reference for fields and runtime knobs that are
 easy to miss in `hive.yaml.example`. It was checked against `pkg/config/config.go`
 and `cmd/hive/main.go` on v2.
 
+For the full centralized environment variable table, including hub, backup,
+inference, deployment, contributor, and legacy helper-script variables, see
+[Environment variable reference](env-vars.md).
+
 ## Configuration blocks
 
 Top-level YAML keys accepted by `config.Config`:


### PR DESCRIPTION
## Summary
- add a centralized v2 environment variable reference generated from code/deploy/script greps
- add a self-hosted hub deployment guide consistent with manual provisioning and SaaS manifests
- document config/hive-project.yaml for the deterministic bin/ pipeline
- clarify v2 architecture planning features as not implemented in v2 HEAD
- label root docs/ systemd/launchd pages as legacy v1 material

Fixes #3209
Fixes #3208
Fixes #3207
Fixes #3206
Fixes #3204

## Validation
- git diff --check
- verified links/files referenced by the new docs exist
- docs-only change; no build/test required