### PR TITLE
📖 docs: add guide references for Hive operations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for helping improve KubeStellar Hive. This guide is for contributing c
   - `v2/deploy/` and `v2/examples/` — deployment manifests and example configuration.
   - `v2/docs/` — architecture and operator/developer reference material.
   - `v2/test/` — integration and regression tests.
-- `bin/` — shell helpers used by the existing automation and maintainer workflows.
+- `bin/` — deterministic pipeline, supervision, enforcement, deployment, and maintainer helper scripts. See [`bin/README.md`](bin/README.md) for the script-by-script index.
 - `config/hive-project.yaml.example` — project metadata for the top-level
   deterministic shell pipeline; see [config/README.md](config/README.md). This
   is separate from the v2 Go runtime config in `v2/hive.yaml.example`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ docker compose up -d
 
 Dashboard at `http://localhost:3001`.
 
+The pre-built image tag is documented in [v2/docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest](v2/docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest).
+
 To build from source instead of pulling the pre-built image:
 
 ```bash
@@ -178,7 +180,7 @@ kubectl apply -f v2/deploy/k8s/service.yaml
 
 ## Configuration
 
-All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [v2/hive.yaml.example](v2/hive.yaml.example) for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [v2/hive.yaml.example](v2/hive.yaml.example) for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/AGENT-DEFINITION.md](v2/AGENT-DEFINITION.md) for the portable agent YAML format, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
 
 The top-level deterministic shell pipeline uses a separate project file,
 `config/hive-project.yaml.example`; see [config/README.md](config/README.md)

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,95 +1,85 @@
-# `bin/` — deterministic pipeline scripts
+# `bin/` script index
 
-The shell/Python scripts that make up Hive's **deterministic pipeline** — the
-non-LLM layer that filters, classifies, gates, and enforces before any agent is
-kicked, plus the operational helpers that launch agents, wrap `gh`, and keep
-sessions alive. Agents handle judgment; these scripts handle everything that
-should be deterministic.
+The scripts in this directory are the deterministic shell/Node/Python layer around Hive's agent runtime. They enumerate work, classify it, gate merges, enforce GitHub permissions, launch/supervise CLIs, and publish operational telemetry before an LLM is asked to act.
 
-Most are invoked by the hive process, the governor, or `run-pipeline.sh` rather
-than run by hand. Each script's own header comment is the authoritative
-description; this index is a map.
+Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy.sh`; several write machine-readable state under `/var/run/hive-metrics` for the dashboard, governor, and agent prompts. For the architecture context, see [`v2/docs/architecture.md`](../v2/docs/architecture.md#4-the-deterministic-pipeline).
 
-## Pipeline (pre-kick stages)
+## Pre-kick pipeline and merge gates
 
-| Script | Purpose |
-|--------|---------|
-| `run-pipeline.sh` | Execute the pre-kick pipeline stages in dependency order. |
-| `enumerate-actionable.sh` | Canonical enumerator for actionable issues and PRs. |
-| `issue-classifier.sh` | Pre-classify actionable issues with deterministic metadata. |
-| `architecture-detector.sh` | Detect issues needing architecture review / lane transfer. |
-| `pr-cluster-detector.sh` | Group related actionable issues into clusters for bundled dispatch. |
-| `contributor-dispatcher.sh` | Report contributor assignment state. |
-| `merge-gate.sh` | Determine which open PRs are eligible for merge. |
-| `conflict-sweeper.sh` | Rebase or close CONFLICTING PRs. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `run-pipeline.sh` | Orchestrator | Runs configured pre-kick stages in dependency order: enumerator, classifier, gate, and monitor. Supports `--agent` and `--stage` selectors. |
+| `enumerate-actionable.sh` | Enumerator | Builds `/var/run/hive-metrics/actionable.json` with actionable issues and PRs, excluding holds, drafts, selected labels, ADOPTERS-only PRs, and external issues missing a commit SHA. |
+| `issue-classifier.sh` | Classifier | Enriches `actionable.json` with deterministic metadata such as complexity tier, model recommendation, tracker status, cluster key, lane, and architecture-review flag. |
+| `architecture-detector.sh` | Classifier | Adds architecture signals to actionable issues from `hive-project.yaml` rules so the classifier can route them to the architect lane. |
+| `pr-cluster-detector.sh` | Classifier | Groups related actionable issues into clusters using component, reporter timing, label-combo, and failure-mode signals. |
+| `merge-gate.sh` | Gate | Writes `/var/run/hive-metrics/merge-eligible.json`; PRs qualify only when required CI passes, they are not drafts or excluded, and author/review policy allows merge. |
+| `conflict-sweeper.sh` | Gate/enforcer | Processes AI-authored PRs with `mergeable=CONFLICTING`, attempts a rebase, force-pushes clean rebases, or closes unrebasable PRs and reopens the original issue. |
+| `copilot-comment-checker.sh` | Monitor | Prefetches unaddressed Copilot review comments into `/var/run/hive-metrics/copilot-comments.json` for reviewer agents. |
+| `ga4-anomaly-detector.sh` | Monitor | Compares recent GA4 error counts with a 7-day baseline and writes `/var/run/hive-metrics/ga4-anomalies.json`; emits a no-data result if GA4 is unavailable. |
+| `outreach-tracker.sh` | Monitor | Tracks outreach PRs opened or merged on external repositories and writes `/var/run/hive-metrics/outreach-prs.json`. |
+| `contributor-dispatcher.sh` | Monitor | Reports current contributor assignment state from `/var/run/hive-metrics/contributors.json` into `/var/run/hive-metrics/contributor-assignments.json`; assignment itself happens in the dashboard WebSocket server. |
 
-## Agent lifecycle
+## Agent launch, supervision, and scheduling
 
-| Script | Purpose |
-|--------|---------|
-| `agent-launch.sh` | Unified launcher for any AI coding CLI backend. |
-| `supervisor.sh` | Keep a tmux session alive with an AI CLI agent inside. |
-| `supervisor-kick.sh` | Reliable agent session restart + kick (Copilot backend). |
-| `agent-healthcheck.sh` | Stall detector + auto-respawn + ntfy push. |
-| `kick-agents.sh` | Fire work orders at the scanner/ci-maintainer/architect/outreach sessions. |
-| `kick-governor.sh` | Adaptive kick governor for supervised agents. |
-| `supervisor-kick.sh` | Session restart + kick helper. |
-| `kick-outcome-tracker.sh` | Correlate governor kicks with queue/MTTR/token outcomes. |
-| `ttyd-tmux.sh` | Wrapper for ttyd → tmux (disables mouse mode for the browser). |
+| Script | Stage | Purpose |
+|---|---|---|
+| `agent-launch.sh` | Launcher | Unified AI CLI launcher for backends such as Claude and Copilot. Reads `--backend`/`--model` flags or `AGENT_BACKEND`/`AGENT_MODEL` environment variables. |
+| `supervisor.sh` | Supervisor | Keeps a tmux session alive with an AI CLI agent and supports optional rate-limit failover between backends. |
+| `supervisor-kick.sh` | Supervisor | Reliably restarts or creates a Copilot-backed session, sends one kick message, and verifies the agent began processing. |
+| `kick-agents.sh` | Kick sender | Sends work orders directly to named tmux sessions (`scanner`, `ci-maintainer`, `architect`, `outreach`, or `all`), handles backend rate-limit switching, and calls `run-pipeline.sh`. |
+| `kick-governor.sh` | Scheduler | Legacy adaptive governor that measures issue/PR backlog, chooses surge/busy/quiet/idle cadences, records kick audit entries, and calls `kick-agents.sh`. |
+| `agent-healthcheck.sh` | Health | Watches an agent log's mtime, kills stalled tmux sessions for supervisor respawn, and escalates after repeated failed respawns. |
+| `kick-outcome-tracker.sh` | Metrics | Correlates governor kicks with queue, MTTR, and token outcomes after a cooldown period. |
+| `gh-rate-check.sh` | Health | Scans tmux panes for GitHub API rate-limit messages, writes `/var/run/hive-metrics/gh_rate_limits.json`, and temporarily pauses affected CLI cohorts. |
+| `gh-zombie-reaper.sh` | Health | Kills long-running `gh` processes older than the configured threshold to stop rate-limit retry storms. |
+| `ttyd-tmux.sh` | Terminal UI | Wraps ttyd-to-tmux sessions and disables tmux mouse mode while the browser session is attached so normal text selection works. |
 
-## GitHub access and safety
+## GitHub credentials, policy enforcement, and PR creation
 
-| Script | Purpose |
-|--------|---------|
-| `gh-wrapper.sh` | `gh` wrapper — enforces per-agent + global restrictions and injects the App token. |
-| `gh-app-token.sh` | Generate a GitHub App installation token for the hive. |
-| `git-credential-hive.sh` | Git credential helper using the GitHub App token. |
-| `hive-open-pr.sh` | Open a PR via the App bot (not `gh pr create`). |
-| `gh-rate-check.sh` | Scan agent tmux panes for GitHub API rate-limit messages. |
-| `gh-zombie-reaper.sh` | Kill `gh` API processes older than `MAX_AGE_SECONDS`. |
-| `copilot-comment-checker.sh` | Pre-fetch unaddressed Copilot review comments. |
-| `setup-proxy-iptables.sh` | Force all GitHub HTTPS traffic through the ACMM proxy. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `gh-app-token.sh` | Credentials | Generates and caches a GitHub App installation token; `--export` prints shell exports for callers. |
+| `git-credential-hive.sh` | Credentials | Git credential helper that serves cached GitHub App tokens and honors the host requested by Git. |
+| `gh-wrapper.sh` | Enforcement | `gh` wrapper that injects App tokens and enforces global/per-agent restriction rules from `/etc/hive/restrictions/<agent-id>.json`. |
+| `hive-open-pr.sh` | Enforcement | Agent-side wrapper for PR creation requests. It writes a request file for the Hive watcher so PRs are opened by the GitHub App bot and pass the same ACMM authorization checks. |
+| `setup-proxy-iptables.sh` | Enforcement | Installs iptables rules in the container to force GitHub HTTPS traffic through the ACMM proxy even if an agent unsets proxy variables. |
+| `hive-config.sh` | Config | Shared shell config reader that exposes project, repo, agent, dashboard, health, and policy values parsed from `hive-project.yaml`. |
 
-## Contributor relay (ClankeR)
+## Deployment and local operation
 
-| Script | Purpose |
-|--------|---------|
-| `contributor-relay.sh` | ClankeR — the WebSocket client connecting a contributor agent to the hub. |
-| `contributor-agent.sh` | Entrypoint for the contributor container. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `hive.sh` | CLI | Operator command wrapper for starting the supervisor, checking status, attaching, kicking agents, reading logs, and stopping agents. |
+| `hive-setup.sh` | Bootstrap | All-in-one Ubuntu 24.04 LXC setup for a Docker-based Hive v2 instance, including generated `hive.yaml` and env files. |
+| `hive-prereq-check.sh` | Bootstrap | Validates host prerequisites for a Docker-based Hive v2 install and can attempt fixes with `--fix`. |
+| `hive-deploy.sh` | Deploy | Pulls the latest Hive repository and syncs scripts to `/usr/local/bin`; also restarts Discord bot components when their files change. |
+| `federation-heartbeat.sh` | Federation | Sends live contributor and actionable-work stats to the Hive federation registry. |
+| `notify.sh` | Notifications | Shared Bash notification library for ntfy, Slack incoming webhooks, and Discord webhooks. |
 
-## Metrics, notifications, tokens
+## Contributor relay
 
-| Script | Purpose |
-|--------|---------|
-| `token-collector.sh` | Correlate bead data with token usage for per-issue cost attribution. |
-| `token-usage.py` | Token usage aggregator for Hive agents. |
-| `notify.sh` | Shared notification library for hive scripts. |
-| `federation-heartbeat.sh` | Periodically send this hive's live stats to the federation. |
-| `outreach-tracker.sh` | Track outreach PRs opened/merged on external repos. |
-| `ga4-anomaly-detector.sh` | Pre-compute GA4 error anomalies for the ci-maintainer agent. |
-| `copilot-models.mjs` | List Copilot models available to this machine's auth (via `@github/copilot-sdk`). |
+| Script | Stage | Purpose |
+|---|---|---|
+| `contributor-agent.sh` | Contributor runtime | Contributor-container entrypoint: detects authenticated CLI backend, starts the relay, launches the CLI in tmux, and creates `${HOME}/agent.md` only from a verified live knowledge export. |
+| `contributor-relay.sh` | Contributor runtime | Node.js WebSocket client for ClankeR contributor agents. It authenticates to one or more hubs, receives tasks, injects GitHub tokens, reports progress/results, and supports interactive tmux or headless one-shot delivery. |
 
-## Setup and deployment
+## Model, token, and experiment helpers
 
-| Script | Purpose |
-|--------|---------|
-| `hive.sh` | KubeStellar AI hive entrypoint. |
-| `hive-config.sh` | Shared config reader for all hive scripts. |
-| `hive-setup.sh` | Bootstrap a fresh Ubuntu 24.04 LXC into a Hive v2 instance (Docker). |
-| `hive-prereq-check.sh` | Validate prerequisites for a Docker-based Hive v2 deployment. |
-| `hive-deploy.sh` | Pull the latest hive repo and sync scripts to `/usr/local/bin`. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `copilot-models.mjs` | Model discovery | Uses `@github/copilot-sdk` and the installed Copilot CLI's own auth to print the available Copilot model catalog as one JSON line. |
+| `token-collector.sh` | Cost metrics | Reads scanner beads and token metrics to attribute issue cost; supports recent windows and `--all`. |
+| `token-usage.py` | Cost metrics | Aggregates Claude and Copilot CLI session token usage by agent and rolling time window. |
+| `nous-install.sh` | Nous | Clones or updates the external Nous strategy-evolution framework under `NOUS_DIR`, creates a venv, installs it editable, and prepares run directories. |
+| `nous-runner.sh` | Nous | Strategist helper that invokes the installed Nous framework on each kick. |
+| `nous-hive-gate.py` | Nous | Implements the Nous Gate protocol, posting suggest-mode decisions to the dashboard and polling for operator approval. |
+| `nous-sync.py` | Nous | Reads Nous governor/repo outputs, applies confidence decay and conflict detection, and writes principles, recommendations, and ledger data. |
 
-## Strategy Lab (Nous)
+## Regression tests
 
-| Script | Purpose |
-|--------|---------|
-| `nous-install.sh` | Install the Nous framework into `/opt/nous` (venv-based). |
-| `nous-runner.sh` | Strategist helper — invokes the real Nous framework. |
-| `nous-hive-gate.py` | Custom Nous Gate — bridges experiment-approval decisions into Hive. |
-| `nous-sync.py` | Analyst helper — reads Nous output and syncs findings to the dashboard. |
-
-## Tests
-
-`*.test.sh` / `*.test.js` files are regression tests for the scripts alongside
-them (e.g. `gh-wrapper.test.sh`, `contributor-agent.test.sh`,
-`contributor-relay.test.js` — the last is JavaScript despite the extension).
+| Script | Covers |
+|---|---|
+| `contributor-agent.test.sh` | Contributor-agent regression for knowledge export handling. |
+| `contributor-relay.test.js` | Contributor relay task/restart/headless behavior; loads `contributor-relay.sh` as JavaScript with stubs. |
+| `gh-wrapper.test.sh` | `gh-wrapper.sh` author-gate and restriction regressions using a mock `gh` binary. |

--- a/v2/README.md
+++ b/v2/README.md
@@ -37,6 +37,8 @@ docker compose up -d
 
 The default `docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`. To build from source instead, run `docker compose build` before `docker compose up -d`.
 
+For tag provenance, digest pinning, and the release/tagging flow, see [docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest](docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest).
+
 ### Troubleshooting
 
 - **Rancher Desktop / Lima**: Volume mounts from `/tmp` may fail silently (file appears as directory inside container). Clone the repo under your home directory instead.
@@ -64,7 +66,7 @@ operations.
 
 See [docs/hivectl.md](docs/hivectl.md) for the full command reference. The architecture overview also calls out `hivectl` as the non-interactive API client for automation. For raw dashboard endpoints, see [docs/api-reference.md](docs/api-reference.md).
 
-See [docs/README.md](docs/README.md) for the full v2 documentation index.
+See [docs/README.md](docs/README.md) for the full v2 documentation index, including [notifications](docs/notifications.md) and image provenance in the operator reference.
 
 ## Kubernetes
 
@@ -86,7 +88,7 @@ hub-fronted URL probing, and alert hysteresis.
 
 ## Configuration
 
-All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the commented example, [docs/operator-reference.md](docs/operator-reference.md) for operator-only knobs and token scopes, [docs/config-layering.md](docs/config-layering.md) for runtime precedence/provenance, [docs/agent-configuration.md](docs/agent-configuration.md) for agent fields and ACMM packs, [../docs/backend-setup.md](../docs/backend-setup.md) for CLI backend setup, and [../docs/migration-v1-v2.md](../docs/migration-v1-v2.md) for migration from v1.
+All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the commented example, [docs/operator-reference.md](docs/operator-reference.md) for operator-only knobs, token scopes, and image provenance, [docs/config-layering.md](docs/config-layering.md) for runtime precedence/provenance, [docs/agent-configuration.md](docs/agent-configuration.md) for agent fields and ACMM packs, [AGENT-DEFINITION.md](AGENT-DEFINITION.md) for the portable agent YAML format, [../docs/backend-setup.md](../docs/backend-setup.md) for CLI backend setup, and [../docs/migration-v1-v2.md](../docs/migration-v1-v2.md) for migration from v1.
 
 ```yaml
 project:
@@ -162,6 +164,9 @@ policies:
   path: agents/
   poll_interval: 5m
 ```
+
+
+For portable agent overlays and dashboard imports/exports, see [AGENT-DEFINITION.md](AGENT-DEFINITION.md).
 
 ## ClankeR contributor relay
 

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -7,9 +7,10 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Manual provisioning](manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
 - [Self-hosted hub deployment](hub-deployment.md) — `HIVE_MODE=hub`, hub storage, heartbeat secrets, and SaaS spoke registration.
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
-- [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, and GitHub token scopes.
+- [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, GitHub token scopes, and image provenance.
 - [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
 - [Troubleshooting](troubleshooting.md) — v2 container logs, config validation, agent tmux sessions, dashboard auth, and GitHub credential checks.
+- [Notifications](notifications.md) — ntfy, Slack, and Discord webhook setup, trigger events, and test commands.
 - [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
 - [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
@@ -40,9 +41,9 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
 - [Supervisor agent](supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
 - [Custom dashboard stylesheets](custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
+- [Portable AgentDefinition format](../AGENT-DEFINITION.md) — standalone YAML schema for importing/exporting agent definitions.
 - [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
 - [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
-- [Agent definition format](../AGENT-DEFINITION.md) — the portable YAML format for importing/exporting agents.
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [ACMM policy fragments](../../examples/acmm/README.md) — per-level ACMM policy references.
 - [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -14,7 +14,7 @@ agents:
 ```
 
 
-For a complete portable `AgentDefinition` that exercises advanced display, channel, tool, and connection fields, see [v2/examples/agents/customized-agent.yaml](../examples/agents/customized-agent.yaml).
+For the portable agent definition YAML format, see [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md). For a complete portable `AgentDefinition` that exercises advanced display, channel, tool, and connection fields, see [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
 
 That is a complete, valid agent. Defaults fill in the rest at load time:
 
@@ -297,7 +297,7 @@ At L5, every agent PR gets a `hold` label automatically. The system proposes; it
 
 Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM pack's template for that agent at the current level; otherwise convention — `/data/agents/<name>/CLAUDE.md`, then `<name>.md` in the policies checkout, then the embedded default. Pack templates carry the level's policy in their names — `scanner-holdgated.md` is scanner-at-L5; the same scanner at L6 gets `scanner-automerge.md`.
 
-Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard (see [`v2/examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml)).
+Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard. The reference schema is [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md), and a worked example lives at [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
 
 ## When to add what
 
@@ -321,8 +321,10 @@ Portable agents bundle everything — config plus a `promptTemplate` — in a si
 
 - **[Supervisor agent](supervisor.md)** — what the supervisor does, how it differs from the governor, when to enable it, `bead_role` semantics, and policy modes.
 - **[Documentation index](README.md)** — what hive is, setup, and the full topic-guide surface.
-- **[Architecture](architecture.md)** — the process model, governor loop, and how the supervisor drives agents.
+- **[Architecture](architecture.md)** — process model, deterministic pipeline, governor loop, guardrails, and hub/spoke design.
+- **[Portable AgentDefinition format](../AGENT-DEFINITION.md)** — standalone YAML schema for agent imports, exports, and overlays.
 - **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.
+- **[Troubleshooting](../../docs/troubleshooting.md)** — stuck sessions, login expiry, restart loops, and notification checks.
 - **[ACMM policy matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.
 - **[Config layering](config-layering.md)** — precedence for seed, dashboard overlay, agent overlays, and runtime snapshots.
 - **[Cross-cluster migration](cross-cluster-migration.md)** — moving a hive (and its PVC state) between clusters.

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -145,6 +145,7 @@ Before any agent is kicked, `run-pipeline.sh` runs the `pre-kick` stages defined
 in `hive-project.yaml`, topologically sorted by their declared dependencies. Each
 stage is a shell script that writes a JSON artifact other stages and agents
 consume — so an agent is handed pre-filtered, pre-classified, merge-gated work.
+For a script-by-script index of this layer, see [`../../bin/README.md`](../../bin/README.md).
 
 ```mermaid
 flowchart LR

--- a/v2/docs/notifications.md
+++ b/v2/docs/notifications.md
@@ -1,71 +1,96 @@
 # Notifications
 
-Hive can push operator alerts — merges, reviews, health warnings — to one or
-more channels. All channels are optional; configure only the ones you want under
-the top-level `notifications` block in `hive.yaml`.
+Hive can send operator notifications through three outbound channels configured under the top-level `notifications:` block in `hive.yaml`:
 
-## ntfy
+- ntfy topics
+- Slack incoming webhooks
+- Discord webhooks
 
-[ntfy](https://ntfy.sh) is a simple pub/sub notification service. Point it at the
-public server or your own self-hosted instance:
+The notifier is implemented in `v2/pkg/notify/notify.go` and is constructed from `config.NotificationsConfig` in `v2/pkg/config/config.go`. The same notification is sent to every configured channel.
+
+## Configuration
 
 ```yaml
 notifications:
   ntfy:
-    server: https://ntfy.sh   # or your self-hosted ntfy URL
-    topic: my-hive-alerts      # subscribe to this topic in the ntfy app
-```
-
-Subscribe to the same `topic` in the ntfy mobile/desktop app or via
-`curl -s https://ntfy.sh/my-hive-alerts/json` to receive alerts. Choose a
-hard-to-guess topic name — anyone who knows a public-server topic can read its
-messages.
-
-## Slack
-
-Create an [Incoming Webhook](https://api.slack.com/messaging/webhooks) for the
-target channel and pass its URL. Keep the URL in an environment variable rather
-than committing it:
-
-```yaml
-notifications:
+    server: https://ntfy.sh
+    topic: my-hive-alerts
   slack:
     webhook: ${SLACK_WEBHOOK_URL}
-```
-
-## Discord (webhook)
-
-Create a channel webhook (Channel → Edit → Integrations → Webhooks) and pass its
-URL:
-
-```yaml
-notifications:
   discord:
     webhook: ${DISCORD_WEBHOOK_URL}
 ```
 
-This is one-way alert delivery. For a two-way bot that responds to `!hive`
-commands, see the separate Discord bot below.
+All three channels are optional. Configure one channel or several. Webhook URLs are secrets; keep them in environment variables or Kubernetes Secrets rather than committing literal URLs.
 
-## Discord bot (optional, two-way)
+### ntfy
 
-A separate optional Discord bot (in [`discord/`](../../discord/)) responds to
-`!hive` commands in a channel. It is configured under the top-level `discord`
-key, **not** under `notifications`:
+| Field | Required | Notes |
+|---|---:|---|
+| `notifications.ntfy.server` | yes | ntfy base URL, for example `https://ntfy.sh` or your own HTTPS ntfy server. |
+| `notifications.ntfy.topic` | yes | Topic name appended to the server URL. |
 
-```yaml
-discord:
-  bot_token: ${DISCORD_BOT_TOKEN}
-  channel_id: "1234567890"
+Hive posts the notification body to `<server>/<topic>` and sets `Title` and `Priority` headers. Priorities are `high`, `default`, or `low`.
+
+Self-hosted ntfy works the same way as ntfy.sh as long as the Hive process can reach the HTTPS endpoint. On the public ntfy.sh server, choose a hard-to-guess topic because anyone who knows the topic can subscribe to it.
+
+### Slack
+
+| Field | Required | Notes |
+|---|---:|---|
+| `notifications.slack.webhook` | yes | Slack incoming webhook URL. The sender posts `{"text":"*title*\nmessage"}`. |
+
+The notifier accepts `http://` and `https://` URLs in the Go sender, but production configs should use Slack's HTTPS webhook URLs and keep the value in an environment variable.
+
+### Discord webhook
+
+| Field | Required | Notes |
+|---|---:|---|
+| `notifications.discord.webhook` | yes for webhook notifications | Discord webhook URL. The sender posts `{"content":"**title**\nmessage"}`. |
+
+Use a Discord **webhook URL**, not a bot token, for notification delivery.
+
+## What triggers notifications
+
+The v2 Go process sends notifications for these events:
+
+| Event | Priority | Source |
+|---|---|---|
+| Weekly token budget crosses the warning threshold. | default | `applyBudgetAlerts` in `v2/cmd/hive/main.go` |
+| Weekly token budget is exhausted and non-exempt kicks are suspended. | high | `applyBudgetAlerts` in `v2/cmd/hive/main.go` |
+| Actionable issues exceed the SLA threshold; up to three `SLA 2x breach` notifications are sent per refresh cycle for issues older than 60 minutes. | high | dashboard refresh loop in `v2/cmd/hive/main.go` |
+| A running agent pane matches a configured login-required pattern; Hive pauses that agent and sends the backend-specific login instruction. | high | `scanForLoginRequired` in `v2/cmd/hive/main.go` |
+| Trajectory review detects divergence and either pauses the agent or flags the divergence. | high | `v2/pkg/dashboard/trajectory_sink.go` and `v2/pkg/trajectory/lane.go` |
+
+The legacy shell scripts in `bin/` also use `bin/notify.sh` for events such as stale agents, rate limits, backend switches, and kick status when those scripts are deployed. Those scripts read environment variables (`NTFY_TOPIC`, `NTFY_SERVER`, `SLACK_WEBHOOK`, `DISCORD_WEBHOOK`) rather than the v2 YAML block.
+
+## Testing delivery
+
+Test the target channel directly before putting it in `hive.yaml`:
+
+```bash
+# ntfy
+curl -s -H 'Title: Hive test' -H 'Priority: default' \
+  -d 'notification test from hive operator' \
+  https://ntfy.sh/my-hive-alerts
+
+# Slack incoming webhook
+curl -s -X POST -H 'Content-type: application/json' \
+  --data '{"text":"*Hive test*\nnotification test from hive operator"}' \
+  "$SLACK_WEBHOOK_URL"
+
+# Discord webhook
+curl -s -X POST -H 'Content-type: application/json' \
+  --data '{"content":"**Hive test**\nnotification test from hive operator"}' \
+  "$DISCORD_WEBHOOK_URL"
 ```
 
-See [`discord/README.md`](../../discord/README.md) for bot setup and the command
-surface.
+After editing `hive.yaml`, restart or reload Hive through your normal deployment path. The dashboard notification settings endpoint currently persists ntfy and Discord webhook fields; configure Slack in YAML.
 
-## Notes
+## Discord webhook vs Discord bot
 
-- Webhook URLs and bot tokens are secrets — supply them through environment
-  variables (`${VAR}` interpolation) or a Kubernetes Secret, never inline in a
-  committed `hive.yaml`.
-- Multiple channels can be enabled at once; each configured channel receives the
-  same alerts.
+Webhook notifications are the `notifications.discord.webhook` field above.
+
+The repository also contains a separate Discord bot under [`../../discord/`](../../discord/). That bot is a Node.js service using `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_PRIMARY` to connect to Discord, route commands, and bridge dashboard/pipeline status. It is not required for webhook notifications, and a bot token cannot replace `notifications.discord.webhook`.
+
+For the v2 Go process, bot startup uses `notifications.discord.bot_token` and `notifications.discord.channel_id` when both are set. Those fields start the bot integration; they do not send ordinary webhook notifications unless `notifications.discord.webhook` is also configured.

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -19,7 +19,7 @@ Top-level YAML keys accepted by `config.Config`:
 | `agents` | Agent definitions and behavior metadata. | Per-agent overlays may also live under `data.agents_dir`. |
 | `governor` | Cadences, labels, sensing, health, budgets, inference gateways, trajectory review. | See notable fields below. |
 | `github` | PAT or GitHub App credentials and forge URLs. | Use one auth method. |
-| `notifications` | ntfy, Slack, and Discord webhooks. | All optional. |
+| `notifications` | ntfy, Slack, and Discord webhooks. | All optional; see [notifications.md](notifications.md). |
 | `dashboard` | Web UI port, snapshots, auth token, frame allowlist, authorized users. | `auth_token` can come from `HIVE_DASHBOARD_TOKEN`. |
 | `data` | Metrics, logs, session, and agent overlay directories. | Defaults are `/data/...` in containers. |
 | `knowledge` | Wiki layers, vaults, git/document sources, primer, curator, bead synthesizer. | Disabled unless `enabled: true`. |
@@ -42,6 +42,58 @@ Top-level YAML keys accepted by `config.Config`:
 | `data.copilot_sessions_dir` | `/data/home/.copilot/session-state` | Same, for the Copilot CLI backend's session state. |
 
 For runtime precedence and provenance, see [config-layering.md](config-layering.md).
+
+## Image provenance for `ghcr.io/kubestellar/hive:v2-latest`
+
+The pre-built Docker image used by `v2/docker-compose.yaml` is built by [`.github/workflows/docker.yml`](../../.github/workflows/docker.yml). On the `v2` branch, that workflow publishes a rolling multi-architecture manifest tag:
+
+- `ghcr.io/kubestellar/hive:v2-latest`
+- `ghcr.io/kubestellar/hive:<git-short-sha>`
+
+### What updates the tag
+
+The workflow runs on pushes to every non-dependabot/non-copilot branch and on `workflow_dispatch`. PR and short-lived branch builds still compile the image as a CI gate, but the `gate` job only pushes to GHCR for long-lived branches listed in the workflow (`v2`, `v3`, `mk`, `dd`) or for manual `workflow_dispatch` runs.
+
+For the main Hive image, the build job uses `v2/Dockerfile` and passes these build arguments:
+
+```text
+GIT_HASH=${{ github.sha }}
+GIT_BRANCH=${{ github.ref_name }}
+```
+
+The merge job then combines the per-architecture digests into a manifest list. Before tagging, it verifies that the workflow SHA is still the current HEAD of the branch; stale queued builds skip tagging instead of moving `v2-latest` backward.
+
+### Stability guarantee
+
+`v2-latest` is a rolling branch tag for the current HEAD of `origin/v2` after the Docker workflow succeeds. It is not immutable and is intended for quick starts and continuously updated hives. Pin production deployments to a digest when you need a reproducible image.
+
+### Verify and pin a digest
+
+Inspect the tag digest:
+
+```bash
+docker buildx imagetools inspect ghcr.io/kubestellar/hive:v2-latest
+```
+
+Pull by digest after choosing the manifest digest you want:
+
+```bash
+docker pull ghcr.io/kubestellar/hive@sha256:<digest>
+```
+
+In Compose, replace the tag with the digest form:
+
+```yaml
+services:
+  hive:
+    image: ghcr.io/kubestellar/hive@sha256:<digest>
+```
+
+To relate an image to source, compare the `<git-short-sha>` tag published by the same workflow with commits on the `v2` branch, or inspect the Docker workflow run for the commit SHA that produced the digest.
+
+### Changelog and release notes
+
+The rolling image follows merged changes on the `v2` branch. Use the GitHub commit/PR history for the exact source change set behind a SHA tag, and use repository releases or changelog files only when this repository publishes them for a specific release line.
 
 ## Fleet breaker
 

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -284,7 +284,7 @@ github:
   # installation_id: 67890
   # key_file: /secrets/gh-app-key.pem
 
-# Notifications — configure one or more channels
+# Notifications — configure one or more channels. See docs/notifications.md.
 notifications:
   ntfy:
     server: https://ntfy.sh
@@ -293,11 +293,9 @@ notifications:
   #   webhook: ${SLACK_WEBHOOK_URL}
   # discord:
   #   webhook: ${DISCORD_WEBHOOK_URL}
-
-# Discord bot (optional) — responds to !hive commands
-# discord:
-#   bot_token: ${DISCORD_BOT_TOKEN}
-#   channel_id: "1234567890"
+  #   # Optional Discord bot integration; separate from webhook notifications.
+  #   bot_token: ${DISCORD_BOT_TOKEN}
+  #   channel_id: "1234567890"
 
 # Dashboard — embedded web UI with SSE live updates
 # Security headers (CSP, X-Frame-Options, etc.) are always active.

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -223,8 +223,7 @@ func TestToolRulesToLaunchCmd_Copilot(t *testing.T) {
 	// Authorship fix: copilot must NEVER pass --enable-all-github-mcp-tools —
 	// the built-in github-mcp-server is read-only by default, so GitHub MCP
 	// WRITE tools are never registered and an agent cannot author issues/PRs as
-	// the logged-in user. (This test previously asserted the OPPOSITE — that the
-	// flag was present — which was the bug: it let agents author as the user.)
+	// the logged-in user.
 	tools := denyTools("mcp__something__else")
 	cmd := toolRulesToLaunchCmd("copilot", "auto", "copilot", tools, false)
 	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
@@ -241,8 +240,7 @@ func TestToolRulesToLaunchCmd_CopilotGithubDeny(t *testing.T) {
 	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
 		t.Errorf("copilot with github deny should NOT enable all github tools: %q", cmd)
 	}
-	// Deny must use the built-in server's REAL name github-mcp-server, not the
-	// bogus `github` name (which was a silent no-op — the source of the leak).
+	// Deny must use the built-in server's real name, not `github`.
 	if !containsBoot(cmd, "github-mcp-server(create_pull_request)") {
 		t.Errorf("copilot deny should translate to github-mcp-server(tool): %q", cmd)
 	}

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -182,7 +182,8 @@ func TestHandleRoleIgnoresLeakedHubCookie(t *testing.T) {
 }
 
 func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
-	// Empty allowlist = hub-proxied hive; nginx-injected headers must still work.
+	// Empty allowlist = hub-proxied hive; nginx-injected headers plus the
+	// proof-of-proxy header must still work.
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"
 	old := proxyProofRequired


### PR DESCRIPTION
## Summary
- add a bin/ script index for deterministic pipeline and operational helpers
- document ntfy, Slack, and Discord notification setup and trigger events
- fix agent configuration next links and add AgentDefinition links
- document v2-latest image provenance, digest pinning, and tagging flow
- refresh stale coverage tests to match current secure Copilot/proxy/Kubernetes defaults

Fixes #3224
Fixes #3223
Fixes #3218
Fixes #3217
Fixes #3219

## Validation
- go test ./pkg/agent -run 'TestToolRulesToLaunchCmd_Copilot|TestToolRulesToLaunchCmd_CopilotGithubDeny' -count=1
- go test ./pkg/dashboard -run 'TestSecurityHeaders_WithAuthToken|TestOwnerOnlyMutationsRejectProoflessHubOwnerRole|TestMiddleware_HubProxiedHeadersStillTrusted' -count=1
- go test ./pkg/hub -run 'TestCollectClusterHealthUncachedFull|TestSelfDeploymentImageReadsContainerImage|TestSelfDeploymentImageIsMemoised|TestSelfDeploymentImageCachesFailureAsEmpty|TestK8sAPIGetSuccess|TestK8sAPIPatchSuccess|TestRolloutRestartSelfSuccess|TestK8sDeploymentContainerNames|TestSwitchImageSelfSuccess|TestUpgradeSelfMutableTagForcesRollout|TestUpgradeSelfMutableTagPatchFailureIsReported|TestUpgradeSelfPinnedStillPatchesImage' -count=1
- go test ./pkg/notify ./pkg/config
- changed Markdown link check
- git diff --check
- code-review agent: no significant issues