### PR TITLE
📖 docs: resolve guide documentation gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,19 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 ## How we maintain this file
 
 - Add entries under `Unreleased` for user-visible features, fixes, security changes, migrations, deprecations, and breaking changes.
-- Move entries into a dated release section when a release is cut.
+- Move entries into a dated release section when a release is cut. If the repository has no release tag for the change, use the merge date rather than inventing a version.
 - Link issues or PRs when useful, but keep entries readable for operators who are not following every PR.
 - Do not include routine refactors, test-only changes, or dependency churn unless they affect users.
 
 ## Unreleased
 
+No notable user-facing changes have been recorded since the dated entries below.
+
+## 2026-08-10
+
 ### Added
 
 - Contributor onboarding, governance, templates, and local development documentation for the `v2` Go codebase.
-
-## Recent v2 notable changes
-
-### Added
-
 - Timezone-aware time-of-day governor cadences so hives can vary agent activity by local operating windows.
 - Merger contributor tier and configurable automerge queue/label behavior for safer merge delegation.
 - ClankeR contributor role claiming and owner-assigned agent-role grants.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,24 @@ go test ./...
 
 The Go version is declared in [`v2/go.mod`](v2/go.mod). Install that version or newer compatible tooling before building.
 
+## Contributor `just` recipes
+
+The root [`Justfile`](Justfile) exposes the public contributor relay workflow. Run `just --list` to see the current recipe signatures; private implementation details are intentionally not listed there.
+
+| Recipe | What it does |
+| --- | --- |
+| `just contribute-check <backend>` | Runs the same read-only backend CLI preflight used by setup, then reports whether the machine is ready for `contribute-setup`. |
+| `just contribute-setup <backend>` | Checks the Justfile version, verifies the backend CLI, signs in with GitHub, registers with the configured hub, and writes `${HOME}/.config/hive/contributor.env`. |
+| `just contribute-hive [backend] [mode]` | Starts the contributor relay. The default mode is containerized; pass `local` as the mode to run natively when the local tools are installed. |
+| `just contribute-status` | Queries the configured hub for status and contributor profile information. |
+| `just contribute-browse` | Discovers available public hive projects. |
+| `just contribute-stop` | Stops a background contributor relay if one is running. |
+| `just contribute-k8s [namespace] [outfile] [image_tag]` | Emits Kubernetes manifests for a headless contributor workload. It writes to stdout or the requested file; it does not apply the manifest. |
+| `just hive-api <endpoint>` | Calls a hub API endpoint, defaulting to `/status`, using the configured hive URL. |
+| `just hive-api-docs` | Opens the hub API documentation in a browser. |
+
+See [v2/docs/contributor-relay.md](v2/docs/contributor-relay.md) for the end-to-end contributor relay workflow and Kubernetes workload details.
+
 ## Style and quality
 
 - Format Go changes with `gofmt`.

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -8,12 +8,12 @@ Hive validates backend names in `v2/pkg/config` and launches CLIs in `v2/pkg/age
 | --- | --- | --- | --- |
 | `claude` | `claude` | Install Claude Code and log in once. Hive launches with `--dangerously-skip-permissions`; inference routes add `--bare --settings`. | Advisory/issue modes add disallowed GitHub MCP tools. |
 | `copilot` | `copilot` | Install GitHub Copilot CLI and authenticate with GitHub. Hive also probes Copilot model entitlements live. | Launched with `--no-auto-update --allow-all`; write tools are denied by mode when needed. |
-| `gemini` | `gemini` | Install Gemini CLI and configure its normal auth/API key. | Hive passes `--model`. |
+| `gemini` | `gemini` | Install Gemini CLI and configure its normal auth/API key. | Supported by the server-side manager; Hive launches `gemini` and passes `--model` when a model is configured. |
 | `goose` | `goose` | Install Block Goose and configure provider/model (`GOOSE_PROVIDER`, `GOOSE_MODEL`, or `goose configure`). | Hive launches `goose run -s` and appends `--model` when set. |
-| `pi` | `goose` in the Go manager; `pi` in contributor scripts | In the server-side manager, `pi` is currently a Goose alias because `backendBinary("pi")` maps to `goose`. Configure Goose for pod agents. The contributor relay image/scripts still know a separate `pi` binary. | Do not assume the pod path uses pi.dev until the manager mapping changes. |
+| `pi` | `goose` in the Go manager; `pi` in contributor scripts | In the server-side manager, `backendBinary("pi")` maps to `goose`. Configure Goose for pod agents. The contributor relay image/scripts use a separate `pi` binary. | Server-side pod agents use Goose for `backend: pi`; contributor mode uses the Pi CLI. |
 | `bob` | `bob` | Provide `HIVE_BOB_API_KEY` or `/secrets/bob_api_key` for pods; contributor mode requires `BOBSHELL_API_KEY`. | Hive uses API-key auth headlessly and accepts the Bob license at launch. |
-| `codex` | accepted by config; contributor scripts launch `codex` | Install `@openai/codex` and provide `OPENAI_API_KEY`. Contributor mode sets a per-agent `CODEX_HOME`. | v2 HEAD server-side `backendBinary` does not map `codex`, so use it in contributor mode unless the manager mapping has been updated. |
-| `aider` | accepted by config; contributor scripts launch `aider` | Install Aider and configure its provider/API key normally. | v2 HEAD server-side `backendBinary` does not map `aider`, so use it in contributor mode unless the manager mapping has been updated. |
+| `codex` | contributor scripts launch `codex`; the server-side Go manager does not launch it | Install `@openai/codex` and provide `OPENAI_API_KEY` for contributor mode. Contributor mode sets a per-agent `CODEX_HOME`. | Not supported as a server-side agent backend in this branch: config accepts the name, but `backendBinary("codex")` returns `unknown backend: codex`, so a pod agent will not start. Use contributor mode for Codex. |
+| `aider` | contributor scripts launch `aider`; the server-side Go manager does not launch it | Install Aider and configure its provider/API key normally for contributor mode. | Not supported as a server-side agent backend in this branch: config accepts the name, but `backendBinary("aider")` returns `unknown backend: aider`, so a pod agent will not start. Use contributor mode for Aider. |
 
 ## IBM Bob headless setup
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,7 +64,14 @@ Run `gofmt` on Go files you edit:
 gofmt -w path/to/file.go
 ```
 
-There is no separate documented repository-wide lint command in the current `Justfile`; use the Go build and test commands above unless CI or a maintainer asks for an additional check.
+The v2 CI workflow runs `go vet ./...` after building the Hive binary. Reproduce that check locally from the Go module:
+
+```bash
+cd v2
+go vet ./...
+```
+
+There is no public `just lint` recipe in the current root `Justfile`; use `go vet ./...` for the repository's documented local lint-equivalent check, plus `gofmt`, `go build`, and targeted `go test` for the files you change.
 
 ## Running Hive locally
 

--- a/v2/docs/sandbox-isolation.md
+++ b/v2/docs/sandbox-isolation.md
@@ -1,18 +1,62 @@
 # Sandbox isolation and agent guardrails
 
-Hive's v2 isolation model is defense in depth rather than a single sandbox switch. Agents run as long-lived CLI sessions, but the deterministic pipeline and proxy layers decide what work they see and what writes they can perform.
+Hive's v2 isolation model is defense in depth rather than a single sandbox switch. Agents are long-lived CLI sessions in the Hive container. Isolation comes from per-agent Unix users, scoped credentials, the ACMM mode pipeline, and a local GitHub proxy that can inspect selected HTTPS traffic.
 
-## Isolation layers
+## What Hive isolates
 
-1. **Policy mode** — ACMM selects advisory, measured, hold-gated, or full behavior per agent.
-2. **Deterministic admission** — Go and shell checks classify work, apply holds, and decide whether an agent is kicked.
-3. **Scoped credentials** — contributor relays and spoke agents use the GitHub identity and token scope appropriate to that actor; a delegated ClankeR role does not grant spoke secrets.
-4. **MITM GitHub proxy** — GitHub API writes are attributed and constrained according to the current mode.
-5. **Merge gates** — hold labels, green checks, self-merge bans, and auto-merge sweeps are enforced outside the LLM prompt.
+- **Agent work directories** — the entrypoint creates `/data/agents/<agent>` for each configured agent and, when UID isolation is available, owns it as `hive-<agent>:node`.
+- **Agent process identity** — the entrypoint assigns UIDs starting at `2001`, creates `hive-<agent>` system users, and writes `/var/run/hive/uid-map.json`. The Go manager reads that map and launches each agent's tmux server through `su-exec` as the mapped user.
+- **GitHub write identity** — push-capable agents can receive per-agent App token cache paths; advisory agents have `GH_TOKEN` and `GITHUB_TOKEN` stripped from tmux sessions.
+- **GitHub API writes** — agent traffic is pointed at the local proxy with `HTTPS_PROXY=http://127.0.0.1:18443` and `HTTP_PROXY=http://127.0.0.1:18443`. When iptables setup succeeds, outbound TCP port 443 is also redirected to the same proxy so unsetting proxy environment variables is not enough to bypass it.
+- **Merge and PR gates** — policy mode, hold labels, green checks, self-merge bans, and automerge logic run outside the prompt and remain enforcement points even if an agent proposes unsafe work.
 
-## Operator notes
+## MITM GitHub proxy
 
-- Prefer the least-capable ACMM level that matches the project phase.
-- Keep privileged delegated roles (`ci-maintainer`, `sec-check`, `architect`) behind explicit grants.
-- Use the docs in this index for concrete setup: [ACMM policy matrix](acmm-policy-matrix.md), [Agent configuration](agent-configuration.md), and [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md).
+The Go proxy listens on `127.0.0.1:18443`. It accepts both explicit HTTP `CONNECT` proxy traffic and transparent TLS connections redirected by iptables.
 
+For `api.github.com`, the proxy forges a leaf certificate signed by Hive's local CA, terminates TLS from the agent, opens a TLS connection to GitHub, reads each HTTP request, and then either forwards or blocks it. The rule table allows read methods in advisory mode, selected issue writes in `issues-only`, PR and git-push writes in `issues-and-prs`, and merge/update-branch requests in `issues-prs-merge`. Unknown operations are denied by default. Direct `POST /repos/<org>/<repo>/pulls` is hard-denied in every mode so agents use Hive's `hive-open-pr` path instead of authoring PRs as the login user.
+
+The proxy also checks write requests under `/repos/<org>/<repo>` against the repositories configured for the hive. A blocked request is logged as `proxy request blocked` and returns HTTP 403 with `X-Hive-Proxy-Blocked: true`.
+
+### Traffic that is not request-inspected
+
+The current `NeedsMITM` implementation only returns true for `api.github.com`. Other hosts are tunneled without request-level ACMM inspection, including non-GitHub hosts. `github.com` is registered as a GitHub host but is intentionally tunneled for OAuth device flow and git smart HTTP paths. GitHub Enterprise hosts can be registered as GitHub hosts, but this code path does not MITM them unless `NeedsMITM` is extended.
+
+Copilot completion hosts (`githubcopilot.com` and `*.githubcopilot.com`) may be MITM-inspected only for token-usage accounting when an agent is identified and a token sink is configured. The proxy forwards the request and response content, except that streaming completion requests can get `stream_options.include_usage` injected so Copilot returns token usage.
+
+## Proxy CA and trust
+
+The proxy persists its CA certificate and key at:
+
+- `/data/proxy-ca.pem`
+- `/data/proxy-ca-key.pem`
+
+On startup, it reuses a valid persisted CA or generates a new `Hive ACMM Proxy CA`. The entrypoint builds a combined bundle at `/data/proxy-ca-bundle.pem` by concatenating the system CA bundle and `/data/proxy-ca.pem` when both files exist. That matters because `SSL_CERT_FILE` replaces the trust set: the combined bundle trusts both public roots and the proxy CA.
+
+Trust is injected in several places:
+
+- Agent shells get `.bashrc` that sets `SSL_CERT_FILE` to `/data/proxy-ca-bundle.pem` when available, otherwise `/data/proxy-ca.pem`.
+- Agent launch environments set `NODE_EXTRA_CA_CERTS=/data/proxy-ca.pem` and `GIT_SSL_CAINFO=/data/proxy-ca.pem`.
+- The entrypoint installs the proxy CA into the system trust store when it can, and watches for CA changes to rebuild the combined bundle.
+- GitHub App token-minting clients in Go build their own trust pool from system roots plus `/data/proxy-ca.pem`, lazily reloading the CA so fresh PVC boots do not depend on entrypoint ordering.
+
+## Verifying isolation is active
+
+On a running hive container, verify the concrete mechanisms rather than assuming the policy level is enough:
+
+1. Check startup logs for per-agent user creation, for example `Agent user: hive-<agent> (UID <uid>)`, and for `UID map written to /var/run/hive/uid-map.json`.
+2. Inspect `/var/run/hive/uid-map.json`; `agents` should map agent names to UIDs and `iptables_active` should be `true` when forced egress was installed.
+3. Check startup logs for `iptables: outbound :443 -> :18443`. If you see `WARN: iptables chain creation failed` or `WARN: iptables not found`, proxy enforcement is advisory-only and relies on the agent environment variables.
+4. Check Go logs for `proxy listening` on `127.0.0.1:18443` and, when the UID map loaded, `proxy loaded UID map`.
+5. Confirm `/data/proxy-ca.pem` exists. When the system bundle exists too, `/data/proxy-ca-bundle.pem` should be rebuilt by the entrypoint.
+6. For a negative test, make a GitHub API write that the current agent mode does not allow. The expected result is HTTP 403, `X-Hive-Proxy-Blocked: true`, and a `proxy request blocked` log line.
+
+## Practical limits
+
+- This is not a kernel sandbox. Agents still execute the configured CLI and tools in the container with access to their workspace and to any credentials deliberately injected for that mode.
+- UID isolation separates agent-owned files and lets the proxy attribute sockets by UID, but all agents still share the container, the `node` group, and selected shared state such as `/data/home` unless a backend uses a dedicated home path.
+- If iptables cannot be installed, agents can bypass request-level proxy enforcement by ignoring or removing proxy environment variables.
+- The proxy's request-level ACMM checks apply to `api.github.com` in the current code. Non-GitHub endpoints and tunneled GitHub web traffic are not inspected at the HTTP request level by this proxy.
+- Advisory mode does not mean network isolation. It means GitHub writes should be denied by the proxy/ruleset and by stripped GitHub write tokens; read traffic and non-inspected destinations can still occur.
+
+Use the rest of this index for setup details: [ACMM policy matrix](acmm-policy-matrix.md), [Agent configuration](agent-configuration.md), and [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md).


### PR DESCRIPTION
## Summary
- clarify current server-side backend support for gemini, codex, and aider
- aggregate public contributor Justfile recipes in CONTRIBUTING
- expand sandbox isolation docs with MITM proxy, CA trust, UID isolation, verification, and limits
- document local go vet lint-equivalent check
- move stale changelog entries to a dated 2026-08-10 section

Fixes #3184
Fixes #3185
Fixes #3186
Fixes #3187
Fixes #3188

## Testing
- go vet ./... (from v2/)
- just --list (to verify public recipes)
- code-review agent reviewed the docs diff