### PR TITLE
📖 docs: update v2 guide references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ The repository includes `githooks/post-checkout`. Install it only if you want th
 git config core.hooksPath githooks
 ```
 
-The hook runs after branch checkouts in the primary worktree. It prevents that worktree from staying on a branch other than `main` by printing guidance and checking `main` back out. It is intended for long-running dashboard checkouts where feature work should happen in separate `git worktree add ...` directories. It does not run for file checkouts. Because `core.hooksPath` can apply beyond the primary checkout, install it only in the checkout you want protected; if it fires somewhere else, remove or override that hooksPath setting there.
+The hook runs after branch checkouts in the primary worktree. It prevents that worktree from staying on a branch other than `main` by printing guidance and checking `main` back out. It is intended for long-running dashboard checkouts where feature work should happen in separate `git worktree add ...` directories. It does not run for file checkouts or linked worktrees, because linked worktrees have a `.git` file instead of a `.git` directory.
 
 If the hook is not installed, normal Git behavior applies. If it blocks a checkout unexpectedly, use a separate worktree from an unprotected checkout or remove the hooksPath setting for repositories where the guard is not desired.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,11 +2,10 @@
 
 > **Legacy v1/systemd documentation.** This page troubleshoots the original
 > supervisor/tmux/systemd deployment (`bin/supervisor.sh`, `systemctl`, and
-> `/etc/hive/agent.env`). For current v2 Docker/Go operations, use the
-> [`v2/docs/README.md`](../v2/docs/README.md) index, especially
-> [`v2/docs/health-checks.md`](../v2/docs/health-checks.md),
-> [`v2/docs/operator-reference.md`](../v2/docs/operator-reference.md), and
-> [`v2/docs/manual-provisioning.md`](../v2/docs/manual-provisioning.md).
+> `/etc/hive/agent.env`). For current v2 Docker/Go operations, use
+> [v2 troubleshooting](../v2/docs/troubleshooting.md) and the
+> [`v2/docs/README.md`](../v2/docs/README.md) index.
+
 
 ## The `/loop` prompt never fires — the agent just sits at the prompt
 

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,35 @@
+# Git hooks
+
+This directory contains optional Git hooks for maintainers and contributors who want local guardrails. Git does not run these hooks unless you opt in.
+
+## `post-checkout`
+
+`post-checkout` runs after `git checkout`/`git switch` operations. It only acts on branch checkouts (`BRANCH_FLAG=1`) and exits immediately for file checkouts. It also exits in linked worktrees, because linked worktrees have a `.git` file instead of a `.git` directory.
+
+In the primary worktree, if the checkout leaves `HEAD` on any branch other than `main`, the hook prints a warning and runs `git checkout main --quiet`. The warning tells contributors to create feature branches in separate worktrees. The hook is intended for a long-running primary checkout used by the dashboard, where branch changes would affect the served files.
+
+## Install
+
+Enable the repository hooks in the checkout you want to protect:
+
+```bash
+git config core.hooksPath githooks
+```
+
+This writes a local Git config setting. It is not committed and it does not affect other clones unless you set it there too.
+
+## Bypass or uninstall
+
+If you do not install the hook, normal Git checkout behavior applies. To disable it after installing, unset or override the hooks path:
+
+```bash
+git config --unset core.hooksPath
+# or point this checkout at a different hook directory
+git config core.hooksPath .git/hooks
+```
+
+For feature work, keep the protected primary checkout on `main` and create a linked worktree instead:
+
+```bash
+git worktree add ../hive-my-feature -b my-feature origin/main
+```

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -13,8 +13,8 @@ BRANCH_FLAG="$3"   # 1 = branch checkout, 0 = file checkout
 # Only guard branch checkouts
 [[ "$BRANCH_FLAG" != "1" ]] && exit 0
 
-# Only guard the primary worktree — worktrees have a .git *file*, not dir
-[[ ! -d "$(git rev-parse --git-dir 2>/dev/null)" ]] && exit 0
+# Only guard the primary worktree — linked worktrees have a .git *file*, not dir.
+[[ ! -d .git ]] && exit 0
 
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null)"
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -321,6 +321,7 @@ The `deploy/` directory contains pre-built configurations for common deployment 
 ## Additional references
 
 - [Operator reference](docs/operator-reference.md) — config blocks, server flags/env, GitHub token scopes.
+- [Troubleshooting](docs/troubleshooting.md) — v2 container logs, config validation, agent sessions, dashboard auth, and GitHub credential checks.
 - [Config layering](docs/config-layering.md) — effective config provenance and precedence.
 - [Dashboard API reference](docs/api-reference.md) — generated route index.
 - [apiproxy](docs/apiproxy.md) — model API proxy purpose and deployment notes.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -9,6 +9,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, and GitHub token scopes.
 - [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
+- [Troubleshooting](troubleshooting.md) — v2 container logs, config validation, agent tmux sessions, dashboard auth, and GitHub credential checks.
 - [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
 - [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
@@ -16,6 +17,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Security notes](security.md) — log scrubbing and secret redaction guarantees/limits.
 - [Token collection and usage tracking](token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
 - [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
+- [Custom stylesheets](custom-stylesheets.md) — public CSS theme injection for dashboard, leaderboard, and snapshot surfaces.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [`bd` beads CLI](beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
 - [Backup and restore](backup-restore.md) — `hive-backup`, Kubernetes CronJob, and spoke backup scope.
@@ -34,7 +36,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
-- [Supervisor agent](supervisor.md) — supervisor policy templates and when to use each.
+- [Supervisor agent](supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
 - [Custom dashboard stylesheets](custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
 - [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
 - [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.

--- a/v2/docs/acmm-policy-matrix.md
+++ b/v2/docs/acmm-policy-matrix.md
@@ -99,9 +99,9 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 | outreach | full | `outreach-full.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-## Tester lane
+## Example config alignment
 
-`v2/hive.yaml.example` includes a `tester` support agent that runs automated test suites, coverage gates, and nightly regression checks. It is intentionally outside the built-in ACMM policy packs in `v2/pkg/config/packs/`: the packs generate governance lanes, while `tester` is an operator-enabled local lane with cadences in the example config. If enabled, give it an explicit policy/template appropriate for the repository before granting write permissions.
+`v2/hive.yaml.example` uses the built-in `quality` lane for automated test suites, coverage gates, and regression checks. There is no built-in `tester` lane in the ACMM packs, known-agent defaults, or shipped policy templates; operators who want a separate tester must define it as a custom agent with explicit metadata and a policy template.
 
 ## Key Rules
 

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -113,6 +113,9 @@ agents:
     detect_keywords: [scanner, triage]  # attributes GitHub activity back to this agent
 ```
 
+For prompt file resolution and the complete built-in `${VAR}` reference, see
+[Policy and prompt templates](../policies/README.md).
+
 ### Declarative extensions
 
 Three optional blocks replace hardcoded behavior with declarations:

--- a/v2/docs/troubleshooting.md
+++ b/v2/docs/troubleshooting.md
@@ -1,0 +1,76 @@
+# Hive v2 troubleshooting
+
+This guide covers the current v2 containerized Go service. The older `docs/troubleshooting.md` page is for the legacy v1 systemd supervisor.
+
+## Find the running service logs
+
+Docker Compose deployments define `hive` and `gateway` services in `v2/docker-compose.yaml`. The Hive process healthcheck calls `http://127.0.0.1:3002/api/health`; the gateway publishes `3001` and proxies to Hive. Start with:
+
+```bash
+cd v2
+docker compose ps
+docker compose logs hive --tail=200
+docker compose logs gateway --tail=100
+```
+
+Kubernetes deployments use namespace `hive`, Deployment `hive`, Service `hive`, and probes on `/api/health` and `/api/livez` in `v2/deploy/k8s/deployment.yaml`:
+
+```bash
+kubectl -n hive get deploy,pod,svc,pvc
+kubectl -n hive logs deploy/hive --tail=200
+kubectl -n hive describe pod -l app.kubernetes.io/name=hive
+```
+
+## Config fails to load or save
+
+Hive reads `/etc/hive/hive.yaml` by default, or `HIVE_CONFIG`/`--config` when set. Startup logs `failed to load config` when `config.LoadWithDashboardOverlay` fails. Common validation strings in `v2/pkg/config/config.go` include:
+
+- `project.org is required`
+- `at least one agent must be configured`
+- `github.token, github.app_id or github.forge is required`
+- `agent <name>: invalid caveman_mode ...`
+- `agent <name>: replicas must be between 1 and 5`
+- `governor mode <mode> cadence for <agent>: ...`
+
+In Kubernetes, edit the ConfigMap/Secret source and restart the pod; dashboard edits are stored in the `/data` PVC overlay. In Docker Compose, edit the bind-mounted `v2/hive.yaml` or the dashboard overlay and restart `hive`.
+
+## GitHub credentials are missing or invalid
+
+When no token or App credentials are usable, v2 starts the dashboard but disables write-capable GitHub work. The code logs these exact messages from `v2/cmd/hive/main.go` depending on the state:
+
+- `no GitHub token configured (set github.token or github.app_id in config) — starting in dashboard-only mode`
+- `GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.`
+- `persisted user token is invalid or expired`
+
+Check the configured `github:` block, the `HIVE_GITHUB_TOKEN` secret/env var, or the GitHub App `app_id`, `installation_id`, and `key_file`. For App setup, use the dashboard banner or `/gh-setup`; details are in [GitHub App setup](github-app-setup.md).
+
+## Agents are stuck, paused, or need CLI login
+
+Agents still run in tmux sessions managed by the v2 agent manager, but there is no v1 `AGENT_READY_MARKER` or `bin/supervisor.sh` loop. The v2 login detector scans recent tmux pane output for configured regexes and, on a match, logs `login required detected`, pauses the agent, and sends a notification that says to attach to `hive-<agent>` and run the backend login command.
+
+Useful checks from inside the Hive container/pod:
+
+```bash
+tmux ls
+tmux capture-pane -t hive-scanner -p -S -80
+tmux attach -t hive-scanner
+```
+
+Detach from tmux with `Ctrl+B`, then `D`. If the dashboard shows an agent as paused, resume it from the dashboard/API after completing the CLI login (`claude login`, `copilot auth login`, `gemini auth login`, or the backend-specific command shown in the notification).
+
+## Dashboard auth and access problems
+
+The dashboard config lives under `dashboard:`. `dashboard.auth_token` protects non-public dashboard/API paths; health/liveness, snapshot/style, contribute, leaderboard, user-auth negotiation, SSO, and GitHub App setup paths are intentionally public in `isPublicPath`. `dashboard.authorized_users` controls direct-route user login allowlists; `dashboard.hub_proxied` means trusted hub/nginx headers identify the caller.
+
+If API calls fail, check whether the request is going through the gateway on port `3001` or directly to Hive on `3002`, then inspect the response and Hive logs. Dashboard handlers return concrete messages such as `X-Hive-Role header required`, `insufficient access`, `owner access required`, and `only the owner can back up this hive` for role/header failures.
+
+## Health endpoints
+
+Use the same endpoints as the probes:
+
+```bash
+curl -fsS http://127.0.0.1:3002/api/health
+curl -fsS http://127.0.0.1:3002/api/livez
+```
+
+`/api/livez` is deliberately process-focused: the Kubernetes manifest notes that stale hub heartbeat state belongs in deeper health reporting and should not crash-loop a healthy pod.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -86,14 +86,15 @@ agents:
     display_name: CI Maintainer
     description: Post-merge quality gate — monitors CI health, coverage, GA4 errors
     sort_order: 30
-  tester:
+  quality:
     enabled: true
     backend: claude
     model: claude-sonnet-4-6
-    beads_dir: /data/beads/tester
+    beads_dir: /data/beads/quality
     clear_on_kick: true
-    display_name: Tester
-    description: Runs automated test suites — coverage gates and nightly regression checks
+    display_name: Quality
+    description: Runs automated test suites — coverage gates and regression checks
+    role: quality
     sort_order: 35
   architect:
     enabled: false                        # Disabled by default — enable for design work
@@ -190,7 +191,7 @@ governor:
       threshold: 20                       # Queue depth >= 20 triggers SURGE
       scanner: 15m
       ci-maintainer: pause                # "pause" means don't kick this agent
-      tester: pause                       # coverage isn't urgent during fire-fighting
+      quality: pause                      # coverage isn't urgent during fire-fighting
       architect: pause
       guide: pause
       strategist: pause
@@ -199,7 +200,7 @@ governor:
       threshold: 10
       scanner: 15m
       ci-maintainer: 1h
-      tester: 2h
+      quality: 2h
       architect: pause
       guide: 4h
       strategist: pause
@@ -207,7 +208,7 @@ governor:
       threshold: 2
       scanner: 15m
       ci-maintainer: 45m
-      tester: 45m
+      quality: 45m
       architect: pause
       guide: 4h
       strategist: 4h
@@ -215,7 +216,7 @@ governor:
       threshold: 0
       scanner: 15m
       ci-maintainer: 15m
-      tester: 30m                         # most active when nothing else is happening
+      quality: 30m                        # most active when nothing else is happening
       architect: 30m
       guide: 4h
       strategist: 4h

--- a/v2/policies/README.md
+++ b/v2/policies/README.md
@@ -43,7 +43,49 @@ Do not put secrets in policy Markdown. Prompts are shown in logs, dashboard hist
 
 ## Variables
 
-Templates are rendered with runtime context such as `${AGENT_NAME}`, `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, `${ISSUE_LIST}`, `${PR_LIST}`, `${KNOWLEDGE}`, and mode/auth fragments. Variables that are not available for a mode render empty; for example advisory/no-GitHub policies do not get write-capable GitHub auth instructions.
+Kick templates reference variables as `${NAME}`. The scheduler replaces the built-in variables below on every scheduled kick; an unknown `${NAME}` is left literal. Operator-defined variables from the top-level `variables:` config block are resolved by the same engine, but built-ins win on name conflicts.
+
+The complete built-in scheduler set in v2 HEAD is:
+
+| Variable | Runtime value | Notes |
+| --- | --- | --- |
+| `${AGENT_NAME}` | Configured agent key receiving the kick, such as `scanner` or `scanner-2`. | Replicas use the materialized name. |
+| `${AGENT_DISPLAY_NAME}` | `agents.<name>.display_name` when set; otherwise the agent key. | Dashboard label. |
+| `${TIMESTAMP}` | Local wall-clock time formatted like `1/2 3:04 PM MST`. | Generated at kick render time. |
+| `${QUEUE_ISSUES}` | Count of actionable issues in the current GitHub scan. | From `ActionableResult.Issues.Count`. |
+| `${QUEUE_PRS}` | Count of actionable pull requests in the current GitHub scan. | From `ActionableResult.PRs.Count`. |
+| `${QUEUE_HOLD}` | Count of hold-gated items. | From `ActionableResult.Hold.Total`. |
+| `${SLA_VIOLATIONS}` | Count of actionable issues past the configured SLA. | From `ActionableResult.Issues.SLAViolations`. |
+| `${ISSUE_LIST}` | Formatted issue list for the agent's lane. | `scanner` sees all passed issues; other agents get lane-filtered issues. |
+| `${PR_LIST}` | Formatted pull-request list. | Empty/none formatting comes from the scheduler formatter. |
+| `${AUTHORIZED_REPOS}` | Repository authorization section for the configured project repos and GitHub host. | Built by the scheduler. |
+| `${GH_AUTH}` | GitHub App/CLI authentication instructions for the agent. | Templates/policies decide whether using GitHub writes is allowed; supervisor no-GitHub policies should not rely on this fragment. |
+| `${PROJECT_ORG}` | `project.org`. | GitHub organization/owner. |
+| `${PROJECT_NAME}` | `project.name`. | May be empty if not configured. |
+| `${PROJECT_PRIMARY_REPO}` | Primary repo as `org/repo`. | Combines `project.org` and `project.primary_repo`. |
+| `${PROJECT_AI_AUTHOR}` | Effective AI author username. | Uses config defaulting from `EffectiveAIAuthor()`. |
+| `${PROJECT_REPOS_LIST}` | Comma-separated `project.repos`. | Plain repo names as configured. |
+| `${PROJECT_HOMEBREW_REPO}` | `<project.org>/homebrew-tap`. | Convenience repo name. |
+| `${HIVE_REPO}` | `<project.org>/hive`. | Convenience repo name. |
+| `${HIVE_ID}` | `hive_id`. | May be empty for standalone configs. |
+| `${AGENT_LIST}` | Formatted enabled-agent list. | Same value as `${ENABLED_AGENTS}`. |
+| `${ENABLED_AGENTS}` | Formatted enabled-agent list. | Alias of `${AGENT_LIST}`. |
+| `${AGENT_ROLES}` | Formatted role/metadata summary for configured agents. | Built from current config. |
+| `${KNOWLEDGE}` | Knowledge priming section for relevant issues. | Populated by configured knowledge layers; otherwise renders the scheduler's empty/none text. |
+| `${INCEPTION_IDEA}` | Current inception idea text. | Empty when no inception run is active. |
+| `${INCEPTION_PHASE}` | Current inception phase. | Empty when inactive. |
+| `${INCEPTION_MODE}` | Current inception mode. | Empty when inactive. |
+| `${INCEPTION_ANSWERS}` | Collected inception answers. | Empty when inactive. |
+| `${INCEPTION_SLUG}` | Inception slug. | Empty when inactive. |
+| `${INCEPTION_REPO_URL}` | Inception repository URL. | Empty when inactive. |
+| `${MERGE_ELIGIBLE}` | Formatted merge-eligible PR list from `/var/run/hive-metrics/merge-eligible.json`. | Renders `(none)` when the file is absent, invalid, or empty. |
+| `${CI_FAILING}` | Formatted failing-CI PR list from `/var/run/hive-metrics/ci-failing.json`. | Renders `(none)` when the file is absent, invalid, or empty. |
+
+Dashboard prompt previews substitute only the config-only subset that does not require a live GitHub scan: `${AGENT_NAME}`, `${AGENT_DISPLAY_NAME}`, `${PROJECT_NAME}`, `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, `${PROJECT_AI_AUTHOR}`, `${PROJECT_REPOS_LIST}`, `${HIVE_REPO}`, and `${HIVE_ID}`. Live-only variables such as `${ISSUE_LIST}`, `${PR_LIST}`, `${QUEUE_ISSUES}`, `${KNOWLEDGE}`, `${MERGE_ELIGIBLE}`, and `${CI_FAILING}` are resolved when the scheduler sends an actual kick.
+
+### Custom variables
+
+Custom variables are declared under `variables.defs` in `hive.yaml` and use the same `${NAME}` syntax. Names must match letters/digits/underscore and not start with a digit. `static` and `env` variables can be managed from the dashboard; `script` and `http` variables are seed/GitOps-only and require their corresponding security gates. Scope controls where a custom variable resolves: `template`, `config`, or `both`. Unresolved custom variables remain literal, matching built-in unknown-variable behavior.
 
 ## Operator checklist
 


### PR DESCRIPTION
## Summary
- document the optional post-checkout hook, install/uninstall flow, and make its linked-worktree guard match the documented behavior
- add current v2 troubleshooting and mark the old troubleshooting page as v1 legacy
- link supervisor, custom stylesheet, and troubleshooting docs from the v2 indexes
- replace the stale `tester` example lane with the built-in `quality` lane; users who copied `tester` should rename it or provide a custom tester policy/metadata
- add the complete built-in kick-template variable reference and link it from agent configuration

## Evidence checked
- `githooks/post-checkout` branch/file checkout behavior
- `v2/pkg/scheduler/scheduler.go` runtime template variable map
- `v2/pkg/config/config.go` known-agent defaults, ACMM packs, and validation strings
- `v2/cmd/hive/main.go` GitHub credential and login-detector logs
- `v2/deploy/k8s/deployment.yaml` and `v2/docker-compose.yaml` runtime/probe paths

## Validation
- `bash -n githooks/post-checkout`
- `./githooks/post-checkout HEAD HEAD 1` from linked worktree
- `git diff --check`
- `cd v2 && go test ./pkg/config ./pkg/scheduler`

Fixes #3216
Fixes #3215
Fixes #3214
Fixes #3211
Fixes #3210