### PR TITLE
fix(agent): actually stop copilot authoring as user on v4 (drop enable-all + correct MCP server name)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1440,16 +1440,20 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			// in cli_models.go), which lets the Copilot CLI pick/adjust the model
 			// per task. Nothing here assumes a concrete id, so the sentinel flows
 			// through unchanged.
-			// Every mode denies the FULL set of GitHub MCP write tools
-			// (copilotGitHubWriteDenyFlags) so no mode can author issues/PRs/
-			// comments as the login USER via the MCP; all GitHub writes must go
-			// through the App-gated gh wrapper / hive-open-pr. READ tools stay
-			// enabled via --enable-all-github-mcp-tools. The deny set is identical
-			// across ModeIssuesAndPRs / ModeIssuesOnly / advisory — the mode no
-			// longer changes what the MCP can write (it never legitimately should),
-			// it only governs the separate, unchanged gh-wrapper/proxy layer that
-			// still reads Mode for what the App-gated write path allows.
-			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools%s",
+			// PRIMARY defense against authoring as the login USER via the MCP:
+			// we do NOT pass --enable-all-github-mcp-tools. Copilot CLI's built-in
+			// GitHub MCP server is READ-ONLY BY DEFAULT (v0.0.350+), so the write
+			// tools (create_issue/create_pull_request/…) are never registered.
+			// READ tools (get_issue/list/search) stay available in that read-only
+			// default, so nothing here disables useful lookups. All GitHub writes
+			// must go through the App-gated gh wrapper / hive-open-pr.
+			// copilotGitHubWriteDenyFlags is applied as belt-and-suspenders (with
+			// the CORRECT `github-mcp-server(` server name) on top of the read-only
+			// default. This is identical across ModeIssuesAndPRs / ModeIssuesOnly /
+			// advisory — the mode never changes what the MCP can write (it never
+			// legitimately should), it only governs the separate, unchanged
+			// gh-wrapper/proxy layer that still reads Mode for the App-gated writes.
+			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all%s",
 				binary, model, copilotGitHubWriteDenyFlags)
 		case "gemini":
 			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
@@ -4726,15 +4730,26 @@ const bobBackend = "bob"
 // CLI. Agents must never author issues/PRs via the GitHub MCP — those calls run
 // with the logged-in user's OAuth token, bypass the proxy, and skip the App gate.
 // All GitHub writes route through the App-gated `gh` wrapper / hive-open-pr, which
-// authors as kubestellar-hive[bot]. Applied in EVERY agent mode so the mode only
-// governs the gh-wrapper/proxy layer, never what the MCP may write. Read tools
-// (get_issue/list/search) stay enabled via --enable-all-github-mcp-tools.
-const copilotGitHubWriteDenyFlags = " --deny-tool='github(create_pull_request)'" +
-	" --deny-tool='github(create_pull_request_with_copilot)'" +
-	" --deny-tool='github(merge_pull_request)'" +
-	" --deny-tool='github(create_issue)'" +
-	" --deny-tool='github(update_issue)'" +
-	" --deny-tool='github(add_issue_comment)'"
+// authors as kubestellar-hive[bot].
+//
+// PRIMARY defense is dropping --enable-all-github-mcp-tools from the launch
+// command: Copilot CLI's built-in GitHub MCP server is READ-ONLY BY DEFAULT
+// (v0.0.350+), so the write tools are never registered in the first place. These
+// deny flags are belt-and-suspenders on top of that.
+//
+// The built-in server is named `github-mcp-server` (per `copilot --help`:
+// `--disable-builtin-mcps ... (currently: github-mcp-server)`), NOT `github`.
+// The prior deny names used the bare `github` server prefix, which was a SILENT
+// NO-OP: `github` is only the name of a separately-added server, so a deny on it
+// matched nothing and the writes stayed live. These use the CORRECT server name so the
+// belt-and-suspenders denies actually match. Read tools (get_issue/list/search)
+// stay available (read-only default), so no enable-all flag is needed.
+const copilotGitHubWriteDenyFlags = " --deny-tool='github-mcp-server(create_pull_request)'" +
+	" --deny-tool='github-mcp-server(create_pull_request_with_copilot)'" +
+	" --deny-tool='github-mcp-server(merge_pull_request)'" +
+	" --deny-tool='github-mcp-server(create_issue)'" +
+	" --deny-tool='github-mcp-server(update_issue)'" +
+	" --deny-tool='github-mcp-server(add_issue_comment)'"
 
 // claudeGitHubWriteDenyFlags denies EVERY GitHub MCP write tool for the claude
 // CLI — the same logical set as copilotGitHubWriteDenyFlags, in claude's
@@ -6594,20 +6609,18 @@ func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConf
 		}
 		return cmd
 	case "copilot":
-		hasGHDeny := false
-		for _, p := range denies {
-			if strings.Contains(p, "github") {
-				hasGHDeny = true
-				break
-			}
-		}
+		// Never pass --enable-all-github-mcp-tools: Copilot CLI's built-in GitHub
+		// MCP server is READ-ONLY BY DEFAULT (v0.0.350+), so the write tools are
+		// never registered and read tools stay available. Enabling it would turn
+		// writes on and let agents author as the login USER via the MCP.
 		cmd := fmt.Sprintf("%s --model %s --no-auto-update --allow-all", binary, model)
-		if !hasGHDeny {
-			cmd += " --enable-all-github-mcp-tools"
-		}
 		for _, p := range denies {
-			copilotPattern := strings.ReplaceAll(p, "mcp__github__", "github(")
-			if strings.HasPrefix(copilotPattern, "github(") {
+			// Translate claude-style `mcp__github__<tool>` deny patterns to
+			// copilot's built-in server syntax `github-mcp-server(<tool>)`. The
+			// server is named `github-mcp-server` (per `copilot --help`), NOT
+			// `github` — the old `github(` name matched nothing (silent no-op).
+			copilotPattern := strings.ReplaceAll(p, "mcp__github__", "github-mcp-server(")
+			if strings.HasPrefix(copilotPattern, "github-mcp-server(") {
 				copilotPattern += ")"
 			}
 			cmd += fmt.Sprintf(" --deny-tool='%s'", copilotPattern)

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -220,11 +220,15 @@ func TestToolRulesToLaunchCmd_ClaudeInference(t *testing.T) {
 }
 
 func TestToolRulesToLaunchCmd_Copilot(t *testing.T) {
-	// No github deny -> enable-all-github-mcp-tools present.
+	// Authorship fix: copilot must NEVER pass --enable-all-github-mcp-tools —
+	// the built-in github-mcp-server is read-only by default, so GitHub MCP
+	// WRITE tools are never registered and an agent cannot author issues/PRs as
+	// the logged-in user. (This test previously asserted the OPPOSITE — that the
+	// flag was present — which was the bug: it let agents author as the user.)
 	tools := denyTools("mcp__something__else")
 	cmd := toolRulesToLaunchCmd("copilot", "auto", "copilot", tools, false)
-	if !containsBoot(cmd, "--enable-all-github-mcp-tools") {
-		t.Errorf("copilot without github deny should enable github tools: %q", cmd)
+	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
+		t.Errorf("copilot must NOT enable all github mcp tools (read-only default): %q", cmd)
 	}
 	if !containsBoot(cmd, "--deny-tool=") {
 		t.Errorf("copilot cmd should include deny-tool: %q", cmd)
@@ -237,8 +241,13 @@ func TestToolRulesToLaunchCmd_CopilotGithubDeny(t *testing.T) {
 	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
 		t.Errorf("copilot with github deny should NOT enable all github tools: %q", cmd)
 	}
-	if !containsBoot(cmd, "github(create_pull_request)") {
-		t.Errorf("copilot deny should be translated: %q", cmd)
+	// Deny must use the built-in server's REAL name github-mcp-server, not the
+	// bogus `github` name (which was a silent no-op — the source of the leak).
+	if !containsBoot(cmd, "github-mcp-server(create_pull_request)") {
+		t.Errorf("copilot deny should translate to github-mcp-server(tool): %q", cmd)
+	}
+	if containsBoot(cmd, "--deny-tool='github(") {
+		t.Errorf("copilot deny must NOT use the wrong `github(` server name: %q", cmd)
 	}
 }
 


### PR DESCRIPTION
The prior authorship fix (#3120/#3121, ported to v4 as #3121) is a **silent no-op**. Two reasons, both confirmed empirically on Copilot CLI 1.0.59:

1. **Wrong MCP server name.** The denies used `--deny-tool='github(<tool>)'`, but the built-in Copilot GitHub MCP server is named **`github-mcp-server`**, not `github` (per `copilot --help`: `--disable-builtin-mcps ... (currently: github-mcp-server)`). `github` is only the name for a *separately-added* server, so a deny on that name matched nothing → `create_issue`/`create_pull_request` stayed fully enabled → agents authored issues/PRs as the logged-in **USER**, not the App bot.

2. **We explicitly enabled the writes.** `--enable-all-github-mcp-tools` is the flag that *registers* all write tools. The built-in server is **read-only by default** (Copilot CLI v0.0.350+). Passing that flag turned writes on; the mistyped deny then failed to turn them back off.

## Fix (mirrors v2 #3259 exactly)
- **Drop `--enable-all-github-mcp-tools`** from both copilot launch builders (the launch-switch `case "copilot":` and `toolRulesToLaunchCmd`). Read-only default ⇒ write tools are never registered; read tools (`get_issue`/`list`/`search`) stay available. This is the **primary** defense.
- **Correct the deny server name** `github(` → `github-mcp-server(` in `copilotGitHubWriteDenyFlags` and in `toolRulesToLaunchCmd`'s claude→copilot pattern translation, as belt-and-suspenders on top of the read-only default.

## Claude path
Unchanged. Claude uses `--disallowed-tools 'mcp__github__<tool>'` (a denylist in claude's own naming) and does **not** pass any `--enable-all`-style flag that would register github MCP writes. Verified both claude launch builders — nothing enables github MCP writes for claude.

This is the **v4 companion to v2 #3259**.