### PR TITLE
🐛 Fix flaky merge watcher re-engagement test

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1241,7 +1241,7 @@ func (h *ContributeWSHub) DisconnectContributor(contributorID, reason string) in
 		h.logger.Info("[contribute-ws] disconnecting contributor session", "username", username, "reason", reason)
 		if c.ws != nil {
 			// Best-effort notify then close; the read loop's defer does the release.
-			_ = sendJSON(c.ws, WSMessage{Type: "auth_failed", Seq: h.nextSeq(), Reason: reason})
+			_ = c.send(WSMessage{Type: "auth_failed", Seq: h.nextSeq(), Reason: reason})
 			c.ws.Close()
 		}
 	}

--- a/v2/pkg/github/merge_request_watcher.go
+++ b/v2/pkg/github/merge_request_watcher.go
@@ -125,7 +125,7 @@ func (c *Client) SetMergeReEngageHook(fn MergeReEngageFunc) {
 func isRequiredCheckMergeBlocker(errMsg string) bool {
 	m := strings.ToLower(errMsg)
 	// Unfixable-by-code blockers take precedence: never re-engage these.
-	for _, deny := range []string{"merge conflict", "not accessible by integration", "permission", "403", "must be a member"} {
+	for _, deny := range []string{"merge conflict", "not accessible by integration", "permission", "403 forbidden", "status code: 403", "http 403", "must be a member"} {
 		if strings.Contains(m, deny) {
 			return false
 		}

--- a/v2/pkg/github/merge_request_watcher_test.go
+++ b/v2/pkg/github/merge_request_watcher_test.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // newMergeMockServer mocks PUT /pulls/{n}/merge. When failWith != 0 it returns
@@ -254,6 +256,7 @@ func TestIsRequiredCheckMergeBlocker(t *testing.T) {
 		"At least 1 approving review is required by reviewers ... required status checks have not",
 		"Changes must be made through a pull request",
 		"the base branch requires all commits to be signed ... has not succeeded",
+		`merging PR o/r#42 (squash): PUT http://127.0.0.1:64031/repos/o/r/pulls/42/merge: 405 Required status check "build" is expected.`,
 	}
 	for _, m := range reEngage {
 		if !isRequiredCheckMergeBlocker(m) {
@@ -265,6 +268,7 @@ func TestIsRequiredCheckMergeBlocker(t *testing.T) {
 		"merge conflict between base and head",
 		"Resource not accessible by integration",
 		"403 Forbidden: you do not have permission",
+		"GitHub API returned status code: 403",
 	}
 	for _, m := range unfixable {
 		if isRequiredCheckMergeBlocker(m) {
@@ -274,10 +278,12 @@ func TestIsRequiredCheckMergeBlocker(t *testing.T) {
 }
 
 // requiredCheckMergeServer always fails PUT /merge with a required-check message.
-func requiredCheckMergeServer(t *testing.T) *httptest.Server {
+func requiredCheckMergeServer(t *testing.T, attempts *atomic.Int32) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "PUT" && strings.HasSuffix(r.URL.Path, "/merge") {
+			attempts.Add(1)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			_, _ = io.WriteString(w, `{"message":"Required status check \"build\" is expected."}`)
 			return
@@ -287,40 +293,43 @@ func requiredCheckMergeServer(t *testing.T) *httptest.Server {
 }
 
 func TestMergeWatcher_ReEngagesOnRequiredCheckFailure(t *testing.T) {
-	srv := requiredCheckMergeServer(t)
+	var mergeAttempts atomic.Int32
+	srv := requiredCheckMergeServer(t, &mergeAttempts)
 	defer srv.Close()
 	c := testMergeClient(t, srv.URL)
 	dir := t.TempDir()
-	mergeRequestDirForTest = dir
-	defer func() { mergeRequestDirForTest = "" }()
 
 	var reEngagedRepo string
 	var reEngagedNum int
-	var calls int
-	allow := true
+	var calls atomic.Int32
 	c.SetMergeReEngageHook(func(repo string, number int) bool {
-		calls++
+		calls.Add(1)
 		reEngagedRepo, reEngagedNum = repo, number
-		return allow
+		return true
 	})
 
 	reqPath, _ := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
-	// Drive to the terminal attempt. Each tick bumps the attempt count by
-	// reading back the prior tick's .result.json sidecar, so process the request
-	// until it is quarantined (renamed to .exhausted) rather than assuming a
-	// fixed tick count — under load the per-tick result write-then-read can lag,
-	// which would otherwise need one extra tick to reach the terminal attempt.
-	// A generous upper bound guards against an infinite loop if it never
-	// terminates. Once the request file is gone (quarantined), stop.
-	for i := 0; i < mergeRequestMaxAttempts*4; i++ {
-		if _, err := os.Stat(reqPath); err != nil {
-			break // request quarantined (renamed to .exhausted) — terminal reached
-		}
-		c.ProcessMergeRequestsOnce(context.Background())
+	now := func() time.Time { return time.Unix(1700000000, 0) }
+	// Drive the same request to the terminal attempt. Calling the handler
+	// directly keeps this regression focused on the terminal merge-failure
+	// re-engagement path instead of coupling it to the package-level test
+	// directory override used by the scan-loop tests above.
+	for i := 0; i < mergeRequestMaxAttempts; i++ {
+		c.handleOneMergeRequest(context.Background(), reqPath, now)
 	}
 
-	if calls != 1 {
-		t.Fatalf("re-engage hook should fire exactly once at terminal failure, got %d", calls)
+	if got := mergeAttempts.Load(); got != int32(mergeRequestMaxAttempts) {
+		t.Fatalf("server should see %d merge attempts, got %d", mergeRequestMaxAttempts, got)
+	}
+	resp := readMergeResult(t, reqPath)
+	if resp.Attempts != mergeRequestMaxAttempts {
+		t.Fatalf("result should record terminal attempt %d, got %+v", mergeRequestMaxAttempts, resp)
+	}
+	if !isRequiredCheckMergeBlocker(resp.Error) {
+		t.Fatalf("terminal error should be classified as a required-check blocker: %q", resp.Error)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("re-engage hook should fire exactly once at terminal failure, got %d (result=%+v)", got, resp)
 	}
 	if reEngagedRepo != "o/r" || reEngagedNum != 42 {
 		t.Fatalf("hook got (%q,%d), want (o/r,42)", reEngagedRepo, reEngagedNum)


### PR DESCRIPTION
Fixes #3232

## Summary
- Fix required-check merge-blocker classification so a mock/API URL containing `403` digits in its port is not mistaken for a permission failure.
- Keep real permission blockers (`403 Forbidden`, `status code: 403`, `http 403`, permission text) non-reengageable.
- Harden `TestMergeWatcher_ReEngagesOnRequiredCheckFailure` to drive terminal attempts directly, assert attempts/error classification, and use synchronized counters.

## Root cause
Production classifier bug: `isRequiredCheckMergeBlocker` denied any error string containing the substring `403`. The wrapped `MergePR` error includes the full request URL, so an ephemeral httptest port such as `64031` caused a required-check failure to be misclassified as non-reengageable. The hook then did not fire, making the test flaky.

## Verification
- `go test ./... -run TestMergeWatcher_ReEngagesOnRequiredCheckFailure -count=20`
- `go test -race ./... -run TestMergeWatcher_ReEngagesOnRequiredCheckFailure -count=20`
- `go test -race ./pkg/github -run TestMergeWatcher_ReEngagesOnRequiredCheckFailure -count=50`
- Sabotage check: temporarily disabled the re-engagement branch; the test failed with `got 0` hook calls, then the sabotage was reverted.

## v2 check
`origin/v2` does not contain `v2/pkg/github/merge_request_watcher.go` or this merge watcher test, so the root cause is v4-only.


## CI follow-up
The first PR run exposed an independent dashboard websocket race in `TestH2_RevokeDisconnectsLiveSessionAndDeniesReconnect`: `DisconnectContributor` wrote directly with `sendJSON` while the live connection read-loop could write through `ContributorConnection.send`. Updated the revoke path to use the per-connection write lock.

Additional verification:
- `go test -race ./pkg/dashboard -run TestH2_RevokeDisconnectsLiveSessionAndDeniesReconnect -count=50`
- `go test -race ./pkg/dashboard -count=1`
- `go test -race ./pkg/github -count=1`
