### PR TITLE
🐛 Fail closed on invalid Kubernetes CA bundles

### DIFF
--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -605,6 +605,7 @@ func TestSecurityHeaders_WithAuthToken(t *testing.T) {
 	req = httptest.NewRequest("GET", "/api/kick/scanner", nil)
 	req.Header.Set("X-Hive-User", "testuser")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, "secret-token")
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -133,8 +133,8 @@ func TestOwnerOnlyMutationsRejectProoflessHubOwnerRole(t *testing.T) {
 
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("proofless hub owner role status = %d, want 403", w.Code)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("proofless hub owner role status = %d, want 401", w.Code)
 	}
 }
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -46,10 +45,8 @@ const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
 // proxyProofRequired controls F2 enforcement strictness. Default true =
 // fail-closed: a request with no X-Hive-Proxy-Auth proof header (or a wrong
 // one) is rejected even if it carries X-Hive-User/X-Hive-Role identity
-// headers. Set HIVE_PROXY_PROOF_REQUIRED=false only during a temporary
-// rollout window where some hub replicas may not yet inject the proof header.
 // A WRONG proof header is ALWAYS rejected regardless of this setting.
-var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") != "false"
+var proxyProofRequired = true
 
 type Server struct {
 	port       int
@@ -827,12 +824,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// only the trusted proxy can produce. Require it as PROOF the request
 		// transited the hub.
 		//
-		// ROLLOUT SAFETY — fail open until the hub half is everywhere: if the hub
-		// has NOT sent X-Hive-Proxy-Auth (older hub image mid-rollout), fall back
-		// to the pre-F2 behavior (trust the identity headers) so no hosted hive is
-		// locked out. Once the hub half is confirmed deployed fleet-wide, a
-		// follow-up flips proxyProofRequired to make a missing/incorrect proof
-		// header fail closed.
+		// Missing or incorrect proof fails closed. Older hub images that do not
+		// inject X-Hive-Proxy-Auth must be upgraded before their identity headers
+		// are accepted.
+		proxyProofRejectReason := ""
 		if !trusted && !directRouteAuthz &&
 			inboundUser != "" && inboundRole != "" {
 			proof := r.Header.Get(proxyAuthHeader)
@@ -853,6 +848,11 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			default:
 				// Proof header present but WRONG, or strict mode with no proof:
 				// this did not come through the trusted hub proxy — reject.
+				if proof == "" {
+					proxyProofRejectReason = "missing proxy proof header"
+				} else {
+					proxyProofRejectReason = "invalid proxy proof header"
+				}
 			}
 			if trusted {
 				r.Header.Set("X-Hive-User", inboundUser)
@@ -896,6 +896,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		if !trusted {
 			if strings.HasPrefix(r.URL.Path, "/api/") {
 				w.Header().Set("Content-Type", "application/json")
+				if proxyProofRejectReason != "" {
+					http.Error(w, fmt.Sprintf(`{"error":%q}`, proxyProofRejectReason), http.StatusUnauthorized)
+					return
+				}
 				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 			} else {
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -190,6 +190,7 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/config", nil)
 	req.Header.Set("X-Hive-User", "clubanderson")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, s.authToken)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -202,8 +203,7 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 
 // TestMiddleware_F2ProxyProof covers the F2 proof-of-proxy header enforcement on
 // a hub-proxied spoke: a valid proof is trusted; a WRONG proof is always
-// rejected; a MISSING proof is trusted only in the fail-open rollout default and
-// rejected once strict enforcement is enabled.
+// rejected; a MISSING proof is rejected in the default fail-closed mode.
 func TestMiddleware_F2ProxyProof(t *testing.T) {
 	newReq := func(proof string) *http.Request {
 		r := httptest.NewRequest("GET", "/api/config", nil)
@@ -239,12 +239,31 @@ func TestMiddleware_F2ProxyProof(t *testing.T) {
 	if c := run(t, true, "wrong-token"); c == http.StatusOK {
 		t.Error("wrong proof must be rejected in strict mode")
 	}
-	// Missing proof: trusted in fail-open (rollout), rejected in strict.
+	// Missing proof: trusted only when a test explicitly simulates the legacy
+	// rollout mode, rejected in the default strict mode.
 	if c := run(t, false, ""); c != http.StatusOK {
 		t.Errorf("missing proof (fail-open) = %d, want 200 (rollout safety)", c)
 	}
 	if c := run(t, true, ""); c == http.StatusOK {
 		t.Error("missing proof must be rejected in strict mode")
+	}
+}
+
+func TestMiddleware_F2ProxyProofDefaultRejectsMissingProof(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("X-Hive-User", "clubanderson")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing proof with default enforcement = %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "missing proxy proof header") {
+		t.Fatalf("missing proof error = %q, want clear proxy proof error", w.Body.String())
 	}
 }
 

--- a/v2/pkg/hub/cluster_metrics.go
+++ b/v2/pkg/hub/cluster_metrics.go
@@ -384,19 +384,29 @@ var (
 	k8sCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
+func k8sTLSConfig() (*tls.Config, error) {
+	caCert, err := os.ReadFile(k8sCACertPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("k8s CA cert at %s did not contain any PEM certificates, refusing to connect with an empty cert pool", k8sCACertPath)
+	}
+
+	return &tls.Config{RootCAs: pool}, nil
+}
+
 func k8sAPIGet(path string) ([]byte, error) {
 	token, err := os.ReadFile(k8sTokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading service account token: %w", err)
 	}
 
-	tlsConfig := &tls.Config{}
-	if caCert, err := os.ReadFile(k8sCACertPath); err == nil {
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(caCert)
-		tlsConfig.RootCAs = pool
-	} else {
-		return nil, fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
+	tlsConfig, err := k8sTLSConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	client := &http.Client{

--- a/v2/pkg/hub/final_gaps_coverage_test.go
+++ b/v2/pkg/hub/final_gaps_coverage_test.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,13 +51,9 @@ func TestK8sAPIGetWithCACert(t *testing.T) {
 	defer srv.Close()
 	withFakeK8sAPI(t, srv)
 
-	// Write a (PEM-shaped) CA cert so the AppendCertsFromPEM branch runs. It need
-	// not validate against the httptest server's cert because the server is plain
-	// HTTP; the branch simply builds a RootCAs pool.
-	caPEM := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
-	if err := os.WriteFile(k8sCACertPath, []byte(caPEM), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	// Write a valid CA cert so the RootCAs branch runs. It need not validate
+	// against the httptest server's cert because the server is plain HTTP.
+	writeTestK8sCACert(t, k8sCACertPath)
 	if _, err := k8sAPIGet("/api/v1/nodes"); err != nil {
 		t.Fatalf("k8sAPIGet with CA cert: %v", err)
 	}

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -3,8 +3,6 @@ package hub
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -362,13 +360,9 @@ func k8sAPIPatch(path string, body []byte) error {
 		return fmt.Errorf("reading service account token: %w", err)
 	}
 
-	tlsConfig := &tls.Config{}
-	if caCert, err := os.ReadFile(k8sCACertPath); err == nil {
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(caCert)
-		tlsConfig.RootCAs = pool
-	} else {
-		return fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
+	tlsConfig, err := k8sTLSConfig()
+	if err != nil {
+		return err
 	}
 
 	client := &http.Client{

--- a/v2/pkg/hub/self_upgrade_coverage_test.go
+++ b/v2/pkg/hub/self_upgrade_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/pem"
 	"io"
 	"log/slog"
 	"net/http"
@@ -36,11 +37,22 @@ func withFakeK8sAPI(t *testing.T, srv *httptest.Server) {
 	oldServer, oldToken, oldCA, oldNS := k8sAPIServer, k8sTokenPath, k8sCACertPath, k8sNamespacePath
 	k8sAPIServer = srv.URL
 	k8sTokenPath = tokenPath
-	k8sCACertPath = filepath.Join(dir, "ca.crt") // absent -> InsecureSkipVerify branch
+	k8sCACertPath = filepath.Join(dir, "ca.crt")
+	writeTestK8sCACert(t, k8sCACertPath)
 	k8sNamespacePath = nsPath
 	t.Cleanup(func() {
 		k8sAPIServer, k8sTokenPath, k8sCACertPath, k8sNamespacePath = oldServer, oldToken, oldCA, oldNS
 	})
+}
+
+func writeTestK8sCACert(t *testing.T, path string) {
+	t.Helper()
+	certSrv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer certSrv.Close()
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certSrv.Certificate().Raw})
+	if err := os.WriteFile(path, caPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestK8sAPIGetSuccess(t *testing.T) {
@@ -72,6 +84,73 @@ func TestK8sAPIGetNon200(t *testing.T) {
 
 	if _, err := k8sAPIGet("/api/v1/nodes"); err == nil {
 		t.Error("expected error on non-200")
+	}
+}
+
+func TestK8sAPIGetMissingCAFailsClosed(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+	if err := os.Remove(k8sCACertPath); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := k8sAPIGet("/api/v1/nodes")
+	if err == nil {
+		t.Fatal("expected k8sAPIGet to fail when CA cert cannot be read")
+	}
+	if !strings.Contains(err.Error(), "refusing to connect with TLS verification disabled") {
+		t.Fatalf("error = %v, want fail-closed CA message", err)
+	}
+	if hits != 0 {
+		t.Fatalf("server was contacted %d times despite missing CA", hits)
+	}
+}
+
+func TestK8sAPIGetInvalidCAFailsClosed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server must not be contacted with invalid CA")
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+	if err := os.WriteFile(k8sCACertPath, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := k8sAPIGet("/api/v1/nodes")
+	if err == nil {
+		t.Fatal("expected k8sAPIGet to fail when CA cert has no PEM certificates")
+	}
+	if !strings.Contains(err.Error(), "empty cert pool") {
+		t.Fatalf("error = %v, want empty cert pool fail-closed message", err)
+	}
+}
+
+func TestK8sAPIPatchMissingCAFailsClosed(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+	if err := os.Remove(k8sCACertPath); err != nil {
+		t.Fatal(err)
+	}
+
+	err := k8sAPIPatch("/x", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected k8sAPIPatch to fail when CA cert cannot be read")
+	}
+	if !strings.Contains(err.Error(), "refusing to connect with TLS verification disabled") {
+		t.Fatalf("error = %v, want fail-closed CA message", err)
+	}
+	if hits != 0 {
+		t.Fatalf("server was contacted %d times despite missing CA", hits)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #2936 and includes the proxy-proof test/code alignment from #3276 so the v2 coverage gate is green on current base.

## Summary
- Shares Kubernetes API TLS setup across metrics and self-upgrade callers.
- Keeps the #2936 missing-CA fail-closed behavior.
- Also rejects CA files that cannot populate a cert pool, instead of constructing an empty `RootCAs` pool and failing later after attempting a request.
- Updates tests so success paths use a valid CA fixture and fail-closed paths assert the API server is not contacted.
- Removes the proxy proof fail-open env-var bypass and updates dashboard tests for the current fail-closed proxy-proof model, matching #3276.

## Failing-before / passing-after proof
New fail-closed tests were copied onto current `origin/v2` before the CA fix and failed with `prefix_test_rc=1`: missing CA cases returned success after contacting the HTTP test API, and invalid CA contacted the server instead of failing during TLS setup.

After this fix:
- `go test ./pkg/hub -run 'TestK8sAPI(GetMissingCAFailsClosed|GetInvalidCAFailsClosed|PatchMissingCAFailsClosed)'` passes\n- `go test ./pkg/hub -run 'TestK8sAPI(Get|Patch)'` passes\n- `go test ./pkg/hub` passes\n- `go test ./pkg/dashboard -run 'TestSecurityHeaders_WithAuthToken|TestOwnerOnlyMutationsRejectProoflessHubOwnerRole|TestMiddleware_HubProxiedHeadersStillTrusted|TestMiddleware_F2ProxyProof|TestMiddleware_F2ProxyProofDefaultRejectsMissingProof' -count=1` passes