### PR TITLE
🔒 Port N1 + N6 + N2 (dual-format) to the v2 hub

### DIFF
--- a/v2/pkg/hub/auth_rollout.go
+++ b/v2/pkg/hub/auth_rollout.go
@@ -1,0 +1,135 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// Rollout readiness telemetry for the N1/N2 compatibility lanes (issue #3234).
+//
+// N1 (per-hive heartbeat bearer) and N2 (Ed25519 session cookie) both shipped
+// as verify-both / mint-new: the hub accepts the new credential OR the legacy
+// one, and issues only the new one. That was required — a flag-day cutover
+// would have 401'd every spoke in the fleet at once, the failure mode #2773
+// documented for the v2-hub/v4-spoke split.
+//
+// But each legacy lane IS the vulnerability it replaced. The fleet-wide
+// heartbeat bearer does not bind identity, so an un-rolled spoke can still
+// claim any hive_id; the symmetric session key that verifies a cookie can also
+// mint one, including an admin cookie. They must be removed.
+//
+// The blocker was observability: "has every spoke re-provisioned?" had no
+// answer short of inspecting each Deployment by hand, so the lanes would have
+// lingered indefinitely — which is how a temporary compatibility path becomes
+// permanent. This records which format each spoke actually presents, so the
+// decision is made on evidence.
+
+// authRolloutEntry is the last-seen credential format for one hive.
+type authRolloutEntry struct {
+	// PerHiveBearer is true when this hive's most recent heartbeat used the
+	// identity-bound bearer (N1) rather than the fleet-wide legacy one.
+	PerHiveBearer bool `json:"per_hive_bearer"`
+	// LastSeen is when that observation was made.
+	LastSeen time.Time `json:"last_seen"`
+}
+
+// noteHeartbeatAuthPath records which bearer format hiveID just authenticated
+// with. Called on every accepted heartbeat; cheap and lock-scoped.
+//
+// Deliberately records the CURRENT observation rather than latching "has ever
+// used per-hive": a spoke can roll back, and a stale true would make the fleet
+// look ready when it is not. Readiness must mean "every hive is per-hive NOW".
+func (s *HubServer) noteHeartbeatAuthPath(hiveID string, perHive bool) {
+	if s == nil || hiveID == "" {
+		return
+	}
+	s.authRolloutMu.Lock()
+	defer s.authRolloutMu.Unlock()
+	if s.authRolloutSeen == nil {
+		s.authRolloutSeen = make(map[string]authRolloutEntry)
+	}
+	s.authRolloutSeen[hiveID] = authRolloutEntry{PerHiveBearer: perHive, LastSeen: time.Now()}
+}
+
+// AuthRolloutStatus summarizes fleet readiness for removing the compat lanes.
+type AuthRolloutStatus struct {
+	// TotalHives is how many distinct hives have been observed heartbeating.
+	TotalHives int `json:"total_hives"`
+	// PerHiveBearer is how many of those last used the N1 identity-bound bearer.
+	PerHiveBearer int `json:"per_hive_bearer"`
+	// LegacyBearer is how many last used the fleet-wide legacy bearer. While
+	// this is non-zero, removing the N1 compat lane WILL 401 those spokes.
+	LegacyBearer int `json:"legacy_bearer"`
+	// LegacyHives names the laggards, so an operator can go re-provision them
+	// rather than guessing which ones are holding up the removal.
+	LegacyHives []string `json:"legacy_hives,omitempty"`
+	// StaleAfter is the cutoff beyond which an observation is ignored: a hive
+	// that has not beaten recently is not evidence of anything.
+	StaleAfter string `json:"stale_after"`
+	// HeartbeatLaneReady is true when every recently-seen hive is on the
+	// per-hive bearer — i.e. the N1 legacy lane can be deleted.
+	//
+	// NOTE this covers the HEARTBEAT lane only. The N2 session-cookie lane has a
+	// second precondition this cannot observe: existing browser cookies must
+	// also have aged out (cookieMaxAgeDays, currently 7). Removing that lane
+	// early logs every active user out rather than breaking a spoke.
+	HeartbeatLaneReady bool `json:"heartbeat_lane_ready"`
+}
+
+// authRolloutStaleAfter bounds how old an observation may be and still count.
+// A hive that has not heartbeated within this window is treated as absent, not
+// as legacy — otherwise a long-deleted hive would block the removal forever.
+//
+// 24h is chosen against the two ways this can be wrong, which fail in opposite
+// directions:
+//
+//   - TOO SHORT and a hive that is merely paused, mid-upgrade, or on a
+//     temporarily unreachable cluster drops out of the denominator. The fleet
+//     then reads ready while that spoke is still on the legacy bearer, and
+//     removing the lane 401s it the moment it comes back.
+//   - TOO LONG and every hive ever deleted keeps counting as a legacy laggard,
+//     so readiness never arrives and the compat lane becomes permanent — the
+//     precise failure this whole signal exists to prevent.
+//
+// Spokes beat on the order of a minute, so 24h is ~1000x the cadence: far past
+// any transient blip, but short enough that a decommissioned hive clears within
+// a day. If the fleet ever adopts long-lived paused hives that stop beating
+// entirely, revisit this — a paused hive should ideally be excluded explicitly
+// rather than by timeout.
+const authRolloutStaleAfter = 24 * time.Hour
+
+// AuthRolloutReadiness reports whether the N1 heartbeat compat lane can be
+// removed. Fails CLOSED: with no observations at all it reports not-ready,
+// because "no evidence" must never read as "safe to remove".
+func (s *HubServer) AuthRolloutReadiness() AuthRolloutStatus {
+	out := AuthRolloutStatus{StaleAfter: authRolloutStaleAfter.String()}
+	if s == nil {
+		return out
+	}
+	cutoff := time.Now().Add(-authRolloutStaleAfter)
+	s.authRolloutMu.RLock()
+	defer s.authRolloutMu.RUnlock()
+	for id, e := range s.authRolloutSeen {
+		if e.LastSeen.Before(cutoff) {
+			continue
+		}
+		out.TotalHives++
+		if e.PerHiveBearer {
+			out.PerHiveBearer++
+		} else {
+			out.LegacyBearer++
+			out.LegacyHives = append(out.LegacyHives, id)
+		}
+	}
+	out.HeartbeatLaneReady = out.TotalHives > 0 && out.LegacyBearer == 0
+	return out
+}
+
+// handleAuthRollout serves the readiness summary. Admin-only: it enumerates
+// hive IDs, and while that is not secret it is fleet-shaped information with no
+// reason to be public.
+func (s *HubServer) handleAuthRollout(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(s.AuthRolloutReadiness())
+}

--- a/v2/pkg/hub/auth_rollout_test.go
+++ b/v2/pkg/hub/auth_rollout_test.go
@@ -1,0 +1,107 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// #3234: readiness telemetry for removing the N1/N2 compatibility lanes.
+//
+// Those lanes ARE the vulnerabilities they replaced — a fleet-wide heartbeat
+// bearer does not bind identity, and a symmetric session key that verifies a
+// cookie can also mint one. They exist only so the fleet could roll without a
+// flag-day cutover, and they must not become permanent.
+//
+// The blocker to removing them was observability: "has every spoke
+// re-provisioned?" had no answer short of inspecting each Deployment by hand.
+// These tests pin the signal that answers it.
+
+func rolloutHub() *HubServer {
+	return &HubServer{authRolloutSeen: make(map[string]authRolloutEntry)}
+}
+
+// TestAuthRolloutFailsClosedWithNoData is the most important case: absence of
+// evidence must never read as "safe to remove".
+func TestAuthRolloutFailsClosedWithNoData(t *testing.T) {
+	s := rolloutHub()
+	got := s.AuthRolloutReadiness()
+	if got.HeartbeatLaneReady {
+		t.Fatal("readiness reported with ZERO observations — an operator would delete the " +
+			"compat lane on a hub that has simply never seen a heartbeat, 401ing the fleet")
+	}
+	if got.TotalHives != 0 {
+		t.Errorf("TotalHives = %d, want 0", got.TotalHives)
+	}
+}
+
+// TestAuthRolloutNotReadyWhileAnyLegacy: one laggard blocks removal, and it is
+// named so an operator knows which hive to re-provision.
+func TestAuthRolloutNotReadyWhileAnyLegacy(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-rolled", true)
+	s.noteHeartbeatAuthPath("hive-laggard", false)
+
+	got := s.AuthRolloutReadiness()
+	if got.HeartbeatLaneReady {
+		t.Fatal("reported ready while a spoke is still on the legacy bearer")
+	}
+	if got.TotalHives != 2 || got.PerHiveBearer != 1 || got.LegacyBearer != 1 {
+		t.Errorf("counts = total:%d per-hive:%d legacy:%d, want 2/1/1",
+			got.TotalHives, got.PerHiveBearer, got.LegacyBearer)
+	}
+	if len(got.LegacyHives) != 1 || got.LegacyHives[0] != "hive-laggard" {
+		t.Errorf("LegacyHives = %v, want [hive-laggard] — the laggard must be named", got.LegacyHives)
+	}
+}
+
+// TestAuthRolloutReadyWhenAllPerHive: the positive case that unblocks #3234.
+func TestAuthRolloutReadyWhenAllPerHive(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-a", true)
+	s.noteHeartbeatAuthPath("hive-b", true)
+
+	got := s.AuthRolloutReadiness()
+	if !got.HeartbeatLaneReady {
+		t.Fatalf("not ready with every hive on the per-hive bearer: %+v", got)
+	}
+	if len(got.LegacyHives) != 0 {
+		t.Errorf("LegacyHives = %v, want empty", got.LegacyHives)
+	}
+}
+
+// TestAuthRolloutIgnoresStale: a hive that stopped beating (deleted, migrated)
+// must not block the removal forever.
+func TestAuthRolloutIgnoresStale(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-current", true)
+	// A long-gone hive that last beat on the legacy bearer.
+	s.authRolloutSeen["hive-gone"] = authRolloutEntry{
+		PerHiveBearer: false,
+		LastSeen:      time.Now().Add(-authRolloutStaleAfter - time.Hour),
+	}
+
+	got := s.AuthRolloutReadiness()
+	if got.TotalHives != 1 {
+		t.Errorf("TotalHives = %d, want 1 (the stale hive must be ignored)", got.TotalHives)
+	}
+	if !got.HeartbeatLaneReady {
+		t.Error("a hive that has not beaten in over a day blocked readiness forever")
+	}
+}
+
+// TestAuthRolloutDoesNotLatch: a spoke that rolls BACK must flip the signal
+// back to not-ready. Latching "has ever been per-hive" would make the fleet
+// look ready when it no longer is.
+func TestAuthRolloutDoesNotLatch(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-a", true)
+	if !s.AuthRolloutReadiness().HeartbeatLaneReady {
+		t.Fatal("setup: expected ready")
+	}
+	// Same hive rolls back to an older image and presents the legacy bearer.
+	s.noteHeartbeatAuthPath("hive-a", false)
+	if s.AuthRolloutReadiness().HeartbeatLaneReady {
+		t.Fatal("readiness LATCHED — a rolled-back spoke still reads as ready, which is " +
+			"exactly when removing the lane would break it")
+	}
+}

--- a/v2/pkg/hub/heartbeat_identity_test.go
+++ b/v2/pkg/hub/heartbeat_identity_test.go
@@ -1,0 +1,103 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// N1 (CWE-200/639/862): the heartbeat bearer must be bound to the claimed hive.
+//
+// On v2 the bearer proved only "some provisioned spoke": provisioning injects
+// the RAW master into every spoke, and the fleet-wide derived key is identical
+// everywhere too. The handler then trusted payload.HiveID verbatim, and three
+// key-delivery lanes read off that claimed ID — so any spoke could beat as any
+// victim and be handed the victim's key material.
+//
+// This is the v2 port of the v4 fix (#3230). It keeps BOTH legacy credentials
+// working, because every spoke in the field holds one of them and rejecting
+// them would 401 the entire fleet at once.
+
+const n1v2Master = "test-master-secret-n1-v2"
+
+func n1v2Hub() *HubServer { return &HubServer{logger: slog.Default(), hubSecret: n1v2Master} }
+
+// TestHeartbeatBearerIsPerHive is the core property.
+func TestHeartbeatBearerIsPerHive(t *testing.T) {
+	s := n1v2Hub()
+	alpha := s.heartbeatKeyFor("hive-alpha")
+	bravo := s.heartbeatKeyFor("hive-bravo")
+
+	if alpha == "" || bravo == "" {
+		t.Fatal("per-hive derivation returned empty")
+	}
+	if alpha == bravo {
+		t.Fatal("two hives derived the SAME bearer — identity cannot be bound")
+	}
+	if !s.heartbeatBearerOK("Bearer "+alpha, "hive-alpha") {
+		t.Error("a hive's own per-hive bearer was rejected for its own ID")
+	}
+	// The IDOR: alpha's bearer must not authenticate a beat CLAIMING to be bravo.
+	// Note this only holds because alpha's bearer is not one of the legacy
+	// credentials — those are still accepted for any ID during rollout.
+	if s.heartbeatBearerOK("Bearer "+alpha, "hive-bravo") {
+		t.Fatal("N1: hive-alpha's bearer authenticated a heartbeat claiming to be " +
+			"hive-bravo — the victim's key material would go to the attacker")
+	}
+}
+
+// TestHeartbeatLegacyCredentialsStillAccepted pins the rollout contract. v2
+// provisioning ships the RAW master, so both legacy paths must keep working
+// until the fleet is re-provisioned (#3234).
+func TestHeartbeatLegacyCredentialsStillAccepted(t *testing.T) {
+	s := n1v2Hub()
+
+	if !s.heartbeatBearerOK("Bearer "+n1v2Master, "hive-alpha") {
+		t.Fatal("raw master bearer rejected — every v2 spoke in the field would 401")
+	}
+	if !s.heartbeatBearerOK("Bearer "+s.heartbeatKey(), "hive-alpha") {
+		t.Fatal("fleet-wide derived bearer rejected — spokes on that path would 401")
+	}
+	// ...and they are correctly reported as NOT identity-bound, so an operator
+	// can tell when the compat lanes are safe to remove.
+	if s.heartbeatBearerIsPerHive(n1v2Master, "hive-alpha") {
+		t.Error("raw master misreported as per-hive")
+	}
+	if s.heartbeatBearerIsPerHive(s.heartbeatKey(), "hive-alpha") {
+		t.Error("fleet key misreported as per-hive")
+	}
+	if !s.heartbeatBearerIsPerHive(s.heartbeatKeyFor("hive-alpha"), "hive-alpha") {
+		t.Error("per-hive bearer not reported as per-hive")
+	}
+}
+
+// TestHeartbeatBearerRejectsGarbage — the dual-accept path must not be
+// mistaken for accept-anything.
+func TestHeartbeatBearerRejectsGarbage(t *testing.T) {
+	s := n1v2Hub()
+	for _, bad := range []string{"", "Bearer ", "Bearer nope", "notabearer"} {
+		if s.heartbeatBearerOK(bad, "hive-alpha") {
+			t.Errorf("accepted %q", bad)
+		}
+	}
+}
+
+// TestPerHiveKeyEncodingIsUnambiguous covers the 0x00 separator: with plain
+// concatenation ("ab","c") and ("a","bc") would hash identically, and hive IDs
+// are operator-influenced.
+func TestPerHiveKeyEncodingIsUnambiguous(t *testing.T) {
+	if derivePerHiveKey(n1v2Master, "ab", "c") == derivePerHiveKey(n1v2Master, "a", "bc") {
+		t.Error("domain/identity boundary is not encoded unambiguously")
+	}
+}
+
+// TestPerHiveKeyFailsClosed: no master or no identity yields no key, never a
+// shared fallback.
+func TestPerHiveKeyFailsClosed(t *testing.T) {
+	if derivePerHiveKey("", infoHeartbeatKey, "hive-alpha") != "" {
+		t.Error("empty master derived a usable key")
+	}
+	if derivePerHiveKey(n1v2Master, infoHeartbeatKey, "") != "" {
+		t.Error("empty hiveID derived a usable key — an identity-less caller must " +
+			"not silently fall back to a shared key")
+	}
+}

--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -1,9 +1,11 @@
 package hub
 
 import (
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"strings"
 )
 
@@ -30,6 +32,82 @@ import (
 // hubCookieB64 encodes the signature URL-safe and unpadded so the cookie value
 // stays within the RFC 6265 cookie-octet set.
 var hubCookieB64 = base64.RawURLEncoding
+
+// N2 (CWE-321/798): the session cookie is now ASYMMETRICALLY signed.
+//
+// The HMAC scheme below is verify-capable-implies-mint-capable, and the same key
+// is provisioned into EVERY spoke so each spoke's proxy can check
+// `hive_hub_user`. A spoke operator could therefore read the key out of their pod
+// env and mint `clubanderson.<sig>` — a hub ADMIN cookie, accepted on ~21 admin
+// routes including the cluster App-key writer. That is the whole of N2, and it is
+// unfixable while the signer and the verifier hold the same bytes.
+//
+// The v2 format is Ed25519: the hub holds the private seed, spokes receive only
+// the public key. Same split the SSO handoff already made (C2 follow-up, #2771).
+//
+//	v2 value = <username>.v2.<base64url(Ed25519-Sign(privateKey, username))>
+//
+// The ".v2." marker is what lets one verifier accept both formats during the
+// rollout without ambiguity — a legacy HMAC signature can never contain a "."
+// (base64url has no dot), so the two shapes are distinguishable by structure
+// rather than by guessing.
+const hubCookieV2Marker = ".v2."
+
+// hubUserCookieV2Name is the SECOND cookie the hub emits, carrying the
+// Ed25519-signed value. It is a distinct NAME rather than a second format in
+// the same cookie because each verifier signs over the whole prefix — no single
+// concatenated value satisfies both the HMAC and Ed25519 verifiers (checked
+// both orderings; both fail both). A spoke that does not know this name simply
+// ignores it, which is what makes the mixed fleet work.
+const hubUserCookieV2Name = "hive_hub_user_v2"
+
+// mintHubUserCookieValueV2 mints an Ed25519-signed session cookie. seedHex is
+// the hub's PRIVATE session seed; a spoke cannot produce this value.
+//
+// Returns "" on empty inputs or seed material that is not a valid 32-byte
+// Ed25519 seed (e.g. a public key passed by mistake) — fail closed rather than
+// sign with junk, matching MintSSOToken.
+func mintHubUserCookieValueV2(seedHex, username string) string {
+	if seedHex == "" || username == "" {
+		return ""
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(username)))
+	return username + hubCookieV2Marker + sig
+}
+
+// verifyHubUserCookieValueV2 verifies an Ed25519-signed cookie against the hub's
+// PUBLIC session key. Returns (username, true) only on a valid signature.
+func verifyHubUserCookieValueV2(pubHex, value string) (string, bool) {
+	if pubHex == "" || value == "" {
+		return "", false
+	}
+	idx := strings.LastIndex(value, hubCookieV2Marker)
+	if idx <= 0 {
+		return "", false
+	}
+	username := value[:idx]
+	sigB64 := value[idx+len(hubCookieV2Marker):]
+	if username == "" || sigB64 == "" {
+		return "", false
+	}
+	pub, err := hex.DecodeString(strings.TrimSpace(pubHex))
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return "", false
+	}
+	sig, err := hubCookieB64.DecodeString(sigB64)
+	if err != nil {
+		return "", false
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(username), sig) {
+		return "", false
+	}
+	return username, true
+}
 
 // mintHubUserCookieValue returns the signed, tamper-evident cookie value for
 // username. It returns "" when no secret is configured or the username is empty
@@ -71,4 +149,33 @@ func hubCookieSign(secret, username string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(username))
 	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}
+
+// verifyHubUserCookieEither accepts a v2 (Ed25519) cookie OR a legacy HMAC one,
+// so live sessions survive the N2 cutover.
+//
+// Rollout shape, mirroring the SSO migration: the hub MINTS only v2 while
+// verifying both. Browsers holding a legacy cookie keep working until it is
+// re-minted at their next login; spokes running an older image keep verifying
+// the legacy format until they re-provision.
+//
+// The legacy lane is the vulnerability — anyone holding the symmetric key can
+// forge it — so it is explicitly TEMPORARY. It must be removed once the fleet
+// has rolled and existing cookies have aged out (the cookie's own MaxAge bounds
+// that window). hubCookieIsV2 gives an operator the signal for when that is
+// safe.
+//
+// legacySecret may be "" to disable the legacy lane entirely, which is what the
+// removal PR will pass.
+func verifyHubUserCookieEither(pubHex, legacySecret, value string) (string, bool) {
+	if u, ok := verifyHubUserCookieValueV2(pubHex, value); ok {
+		return u, true
+	}
+	return verifyHubUserCookieValue(legacySecret, value)
+}
+
+// hubCookieIsV2 reports whether a cookie value carries the asymmetric format.
+// Rollout telemetry only — never an authorization decision on its own.
+func hubCookieIsV2(value string) bool {
+	return strings.Contains(value, hubCookieV2Marker)
 }

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -44,6 +44,14 @@ const (
 	// in the existing master — no new secret, no rotation. Distinct label from the
 	// legacy symmetric infoSSOKey so the two can never derive to the same bytes.
 	infoSSOEd25519Seed = "hive-sso-ed25519-v1"
+
+	// infoSessionEd25519Seed derives the Ed25519 signing SEED for the hub SESSION
+	// cookie (audit N2). Same construction as infoSSOEd25519Seed and for the same
+	// reason: a spoke must be able to VERIFY a hub-minted value without being
+	// able to MINT one. The symmetric infoSessionKey cannot give that — an HMAC
+	// key that verifies also signs, so any spoke holding it could mint an admin
+	// cookie. Distinct label so the two can never collide.
+	infoSessionEd25519Seed = "hive-session-ed25519-v1"
 )
 
 // deriveDomainKey returns a domain-separated sub-key of master for the given
@@ -121,11 +129,33 @@ func (s *HubServer) sessionCookieKey() string {
 	return deriveDomainKey(s.hubSecret, infoSessionKey)
 }
 
+// sessionSigningSeed returns the hex Ed25519 SEED the hub signs session cookies
+// with (audit N2). PRIVATE material: never inject it into a spoke.
+func (s *HubServer) sessionSigningSeed() string {
+	return deriveDomainKey(s.hubSecret, infoSessionEd25519Seed)
+}
+
+// sessionPublicKey returns the hex Ed25519 PUBLIC key a spoke verifies hub
+// session cookies with. Safe to place in a Deployment: it verifies, never signs.
+func (s *HubServer) sessionPublicKey() string {
+	return ssoPublicKeyFromSeed(s.sessionSigningSeed())
+}
+
 // verifyHubUserDual verifies the hive_hub_user cookie against the derived
 // session key (how cookies are minted after the C2 session-key cutover) OR
 // the raw master (legacy cookies still in browsers). Additive: never rejects
 // a value the single-key check would have accepted.
 func (s *HubServer) verifyHubUserDual(value string) (string, bool) {
+	// N2 (CWE-321/798): accept the ASYMMETRIC value first. Only the hub can mint
+	// it — a spoke holding just the public key can verify but not forge — so it
+	// is the strongest of the three and should win when present.
+	if u, ok := verifyHubUserCookieValueV2(s.sessionPublicKey(), value); ok {
+		return u, true
+	}
+	// The two symmetric paths below are ROLLOUT ONLY. Both are forgeable by any
+	// spoke that holds the corresponding key, which on v2 is every spoke (the
+	// raw master is injected into each Deployment). They stay until the fleet is
+	// re-provisioned and existing cookies age out; #3234 tracks the removal.
 	if u, ok := verifyHubUserCookieValue(s.sessionCookieKey(), value); ok {
 		return u, true
 	}

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -59,6 +59,51 @@ func deriveDomainKey(master, info string) string {
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
+// derivePerHiveKey returns a sub-key bound to BOTH a trust domain and a single
+// hive: HMAC-SHA256(master, info || 0x00 || hiveID).
+//
+// SECURITY (audit N1/N3, CWE-321/798). deriveDomainKey above takes a FIXED
+// label, so every spoke in the fleet derives byte-identical keys from the one
+// master. Possession therefore proves "some provisioned spoke" and never "this
+// spoke" — which is the whole of the hosted kill chain: spoke A's key verifies
+// on spoke B, so one hostile tenant can forge terminal grants for another and
+// beat heartbeats as any victim.
+//
+// Mixing the hive ID in keeps every property the fleet-wide scheme had:
+// deterministic in the existing master (no new secret to store or rotate),
+// re-derivable by the hub on demand, and stable across re-provisioning.
+//
+// The 0x00 separator matters. Plain concatenation is ambiguous —
+// ("hive-terminal", "a|b") and ("hive-terminal|a", "b") would hash identically —
+// and hive IDs are operator-influenced. A NUL can appear in neither input: info
+// strings are compile-time constants and hive IDs are validated by isValidName.
+//
+// Returns "" for an empty master OR an empty hiveID: a keyless or identity-less
+// caller must fail closed rather than silently sharing one key again.
+func derivePerHiveKey(master, info, hiveID string) string {
+	if master == "" || hiveID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(info))
+	mac.Write([]byte{0})
+	mac.Write([]byte(hiveID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// heartbeatKeyFor returns the per-hive heartbeat bearer the hub EXPECTS from
+// hiveID (audit N1).
+func (s *HubServer) heartbeatKeyFor(hiveID string) string {
+	return derivePerHiveKey(s.hubSecret, infoHeartbeatKey, hiveID)
+}
+
+// heartbeatBearerIsPerHive reports whether the presented bearer is the modern,
+// identity-bound one. Rollout telemetry only — see issue #3234.
+func (s *HubServer) heartbeatBearerIsPerHive(presented, hiveID string) bool {
+	perHive := s.heartbeatKeyFor(hiveID)
+	return perHive != "" && secureCompareHub(presented, perHive)
+}
+
 // heartbeatKey returns the derived heartbeat bearer a v4 spoke presents on
 // /api/heartbeat and /api/task-status. The v2 hub accepts this IN ADDITION to
 // the legacy raw s.hubSecret (see heartbeatBearerOK), never instead of it.

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -239,6 +239,9 @@ func TestAdminReadSurfacesHiddenDuringImpersonation(t *testing.T) {
 	rec = httptest.NewRecorder()
 	guardedExit := s.requireAdmin(next)
 	exitReq := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	// N6: requireAdmin now runs isCSRFSafe, so a POST must look like one the
+	// dashboard actually sends — a same-origin fetch carries Origin.
+	exitReq.Header.Set("Origin", "https://hive.kubestellar.io")
 	exitReq.AddCookie(testAuthCookie(hubAdminUsername))
 	exitReq.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guardedExit(rec, exitReq)
@@ -262,6 +265,9 @@ func TestImpersonateExitClearsCookieAndStaysCallable(t *testing.T) {
 	guarded := s.requireAdmin(s.handleImpersonateExit)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	// N6: requireAdmin now enforces CSRF; send the same-origin Origin a real
+	// dashboard fetch would carry.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	req.AddCookie(testAuthCookie(hubAdminUsername))
 	req.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guarded(rec, req)

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -287,6 +287,34 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 	http.SetCookie(w, cookie)
 
+	// N2 (CWE-321/798): ALSO emit an Ed25519-signed cookie.
+	//
+	// hive_hub_user above stays HMAC because that is the only format v2 spokes
+	// can verify (their proxy checks HMAC and nothing else — see F3/#3243), and
+	// v4 spokes accept either. Minting only Ed25519 would 401 the terminal on
+	// every v2 spoke in the fleet.
+	//
+	// This second cookie is what actually closes N2 for spokes that can read it:
+	// a spoke holding only the PUBLIC key can verify it but cannot mint one, so
+	// it can no longer forge `clubanderson.<sig>` and obtain hub admin. v4's
+	// proxy prefers it; v2's ignores an unknown cookie name.
+	//
+	// Two cookies rather than one hybrid value: each verifier computes its
+	// signature over the whole prefix, so no single concatenation satisfies
+	// both — verified empirically, both orderings fail both verifiers.
+	if v2Value := mintHubUserCookieValueV2(s.sessionSigningSeed(), user.Login); v2Value != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     hubUserCookieV2Name,
+			Value:    v2Value,
+			Path:     "/",
+			Domain:   ".hive.kubestellar.io",
+			MaxAge:   86400 * cookieMaxAgeDays,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
 	saasUser := ensureSaaSUser(user.Login)
 	// A completed OAuth callback IS a login — count it here and nowhere else.
 	// ensureSaaSUser already refreshed LastLogin; the count is the engagement
@@ -359,6 +387,19 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "hive_hub_user",
+		Value:    "",
+		Path:     "/",
+		Domain:   ".hive.kubestellar.io",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	// N2: clear the Ed25519 cookie too, or a logout leaves a still-valid
+	// credential in the browser — the session-invalidation hole in miniature.
+	http.SetCookie(w, &http.Cookie{
+		Name:     hubUserCookieV2Name,
 		Value:    "",
 		Path:     "/",
 		Domain:   ".hive.kubestellar.io",

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -771,6 +771,21 @@ func listAllSaaSUsers() []SaaSUser {
 
 func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// SECURITY (audit N6, CWE-352): admin routes carry the SAME CSRF exposure
+		// as requireAuth ones — the hub session cookie is ambient, so a cross-site
+		// form POST to e.g. /api/saas/hub/upgrade or the cluster-app-key writer
+		// executes with the admin's identity. requireAuth has always checked this;
+		// requireAdmin never did, leaving every admin mutation reachable from ANY
+		// origin — strictly worse than the sibling-tenant lane, which at least
+		// needs a *.hive.kubestellar.io foothold. Checked first, before any
+		// identity resolution, so a forged request never reaches the
+		// impersonation logic below.
+		if !isCSRFSafe(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":"CSRF check failed"}`))
+			return
+		}
 		// Gate on the REAL logged-in user, not the effective (possibly
 		// impersonated) identity. While the admin is viewing as a normal user,
 		// getAuthUser resolves to that user on GETs — but admin routes (and in

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -543,6 +543,17 @@ func isTrustedOrigin(raw string) bool {
 // resolveIdentity — never inside it — so the write-block and the admin gate can
 // always reason about who is really driving the request.
 func (s *HubServer) getRealAuthUser(r *http.Request) string {
+	// N2: prefer the Ed25519 cookie when the browser carries one. It is the only
+	// value a spoke cannot forge, so it must win over the symmetric fallbacks.
+	if c, err := r.Cookie(hubUserCookieV2Name); err == nil && c.Value != "" {
+		if username, ok := verifyHubUserCookieValueV2(s.sessionPublicKey(), c.Value); ok {
+			if loadSaaSUser(username) != nil {
+				return username
+			}
+		}
+		// A stale/invalid v2 cookie is not fatal — fall through to the HMAC one
+		// rather than locking the user out (e.g. after a secret rotation).
+	}
 	cookie, err := r.Cookie("hive_hub_user")
 	if err == nil && cookie.Value != "" {
 		// The cookie value is only trusted when its HMAC signature verifies

--- a/v2/pkg/hub/saas_admin_csrf_test.go
+++ b/v2/pkg/hub/saas_admin_csrf_test.go
@@ -1,0 +1,120 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// N6 (CWE-352): requireAdmin must run the SAME CSRF check requireAuth does.
+//
+// Before this fix requireAdmin resolved identity and nothing else, so every
+// admin mutation (~21 routes: hub upgrade, cluster App key writes, user
+// delete, banners, provisioning approval) was reachable by a cross-site form
+// POST carrying the admin's ambient session cookie — from ANY origin, not just
+// a sibling *.hive.kubestellar.io tenant.
+//
+// These tests present a GENUINELY VALID admin cookie, so a 403 can only come
+// from the CSRF gate. That distinction matters: the pre-existing
+// TestRequireAdminNonAdmin / TestRequireAdminNoAuth also assert 403, but they
+// get it from the identity check and would keep passing with the CSRF hole
+// wide open. The suite had a requireAuth CSRF test (TestRequireAuthCSRFFails)
+// and no requireAdmin counterpart, which is why this shipped.
+
+// adminCSRFHandler builds a requireAdmin-wrapped handler that records whether
+// the protected body ever ran. Reaching the body is the failure condition.
+func adminCSRFHandler(s *HubServer, reached *bool) http.HandlerFunc {
+	return s.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// TestRequireAdminCSRFCrossOriginPostDenied is the regression for N6: a POST
+// from an unrelated origin, with a valid admin session cookie, must be refused
+// before the handler runs.
+func TestRequireAdminCSRFCrossOriginPostDenied(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-origin admin POST: code=%d, want 403 (CSRF); body=%q", rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("cross-origin admin POST reached the protected handler — CSRF gate did not run")
+	}
+}
+
+// TestRequireAdminCSRFSiblingTenantOriginDenied covers the lane the audit
+// reproduced: a hostile tenant spoke. isTrustedOrigin still allows
+// *.hive.kubestellar.io, so this currently passes the CSRF check and is denied
+// only if the wider trusted-origin reduction lands. Asserting the *documented*
+// current behaviour keeps this test honest rather than aspirational — flip it
+// to expect 403 when the exact-origin change ships.
+func TestRequireAdminCSRFSiblingTenantOriginStillTrusted(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://attacker-hive.hive.kubestellar.io")
+
+	if !isCSRFSafe(req) {
+		t.Skip("sibling-tenant origin is no longer trusted — the exact-origin fix has landed; update this test to assert 403 through requireAdmin")
+	}
+	t.Log("KNOWN GAP (N6, second half): a sibling *.hive.kubestellar.io origin is still CSRF-trusted; " +
+		"the requireAdmin gate does not close this lane on its own. Tracked for the exact-origin + CSRF-token work.")
+}
+
+// TestRequireAdminSafeGetStillAllowed guards against over-correction: the CSRF
+// check must not break admin GETs, which is how the dashboard reads admin data.
+func TestRequireAdminSafeGetStillAllowed(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/admin/users", nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if !reached || rec.Code != http.StatusOK {
+		t.Fatalf("admin GET with valid session: code=%d reached=%v, want 200/true", rec.Code, reached)
+	}
+}
+
+// TestRequireAdminSameOriginPostAllowed proves the legitimate dashboard path
+// (a same-origin POST from the hub itself) is unaffected by the new gate.
+func TestRequireAdminSameOriginPostAllowed(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if !reached || rec.Code != http.StatusOK {
+		t.Fatalf("same-origin admin POST: code=%d reached=%v, want 200/true", rec.Code, reached)
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -736,11 +736,33 @@ func secureCompareHub(a, b string) bool {
 // outer `if s.hubSecret != ""` guard, so an unconfigured hub still authenticates
 // nothing here — this only widens WHICH bearer a configured hub accepts, and only
 // ever adds the new scheme alongside the old one.
-func (s *HubServer) heartbeatBearerOK(auth string) bool {
+// heartbeatBearerOK authenticates a heartbeat and, when a hiveID is supplied,
+// BINDS the bearer to that claimed identity (audit N1, CWE-200/639/862).
+//
+// The bearer used to prove only "some provisioned spoke": both accepted
+// credentials — the raw master and the fleet-wide derived key — are identical
+// on every spoke, so the handler had to trust body-supplied hive_id. Three
+// key-delivery lanes read off that claimed ID, making them IDOR.
+//
+// hiveID may be "" for callers that authenticate before parsing a body; that
+// path keeps the pre-existing fleet-wide behaviour rather than failing closed,
+// because tightening it there would reject every spoke in the field.
+func (s *HubServer) heartbeatBearerOK(auth string, hiveID string) bool {
 	if !strings.HasPrefix(auth, "Bearer ") {
 		return false
 	}
 	tok := strings.TrimPrefix(auth, "Bearer ")
+	// N1: the identity-bound bearer. Only this proves "I am THIS hive".
+	if hiveID != "" {
+		if ph := s.heartbeatKeyFor(hiveID); ph != "" && secureCompareHub(tok, ph) {
+			return true
+		}
+	}
+	// ROLLOUT ONLY — neither of the following binds identity. Every spoke in the
+	// field holds one of them (v2 provisioning injects the raw master), so
+	// rejecting them outright would 401 the entire fleet at once. Remove once
+	// spokes have been re-provisioned onto per-hive bearers; #3234 tracks that,
+	// and heartbeatBearerIsPerHive is the readiness signal.
 	if secureCompareHub(tok, s.hubSecret) {
 		return true
 	}
@@ -910,6 +932,11 @@ type HubServer struct {
 	spokeProxyAuthCache map[string]spokeProxyAuthEntry
 	spokeProxyAuthMu    sync.Mutex
 
+	// #3234: per-hive record of which credential FORMAT each spoke last
+	// authenticated with — the readiness signal for removing the N1 legacy lanes.
+	authRolloutSeen map[string]authRolloutEntry
+	authRolloutMu   sync.RWMutex
+
 	// pendingGateways stores OpenRouter gateways funded via the hub's
 	// scan-to-fund flow, to deliver to firewalled/heartbeat-only spokes via the
 	// heartbeat response. Key: hive ID → gateway (carries the secret key VALUE,
@@ -1077,6 +1104,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
 		spokeProxyAuthCache:     make(map[string]spokeProxyAuthEntry),
+		authRolloutSeen:         make(map[string]authRolloutEntry),
 		timeline:                newTimelineStore(),
 		journey:                 newJourneyStore(),
 		alerts:                  newAlertState(),
@@ -1171,11 +1199,13 @@ func (s *HubServer) Shutdown(timeout time.Duration) error {
 }
 
 func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	// N1: the bearer is captured here and VERIFIED below, once the claimed
+	// hive_id is known — the identity-bound bearer is derived from it. The
+	// prefix check stays here so a malformed header is still rejected early.
+	presentedAuth := ""
 	if s.hubSecret != "" {
-		auth := r.Header.Get("Authorization")
-		// Dual-path: accept the legacy raw-secret bearer (old spokes) OR the
-		// derived heartbeat key (v4 spokes). See heartbeatBearerOK.
-		if !s.heartbeatBearerOK(auth) {
+		presentedAuth = r.Header.Get("Authorization")
+		if !strings.HasPrefix(presentedAuth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -1206,6 +1236,18 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if !isValidName(payload.HiveID) {
 		http.Error(w, "invalid hive_id", http.StatusBadRequest)
 		return
+	}
+	// N1 (CWE-200/639/862): bind the bearer to the CLAIMED identity. Until now
+	// the bearer proved only "some provisioned spoke" — the raw master and the
+	// fleet-wide derived key are identical everywhere — so hive_id was trusted
+	// verbatim and three key-delivery lanes read off it.
+	if s.hubSecret != "" {
+		if !s.heartbeatBearerOK(presentedAuth, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.noteHeartbeatAuthPath(payload.HiveID,
+			s.heartbeatBearerIsPerHive(strings.TrimPrefix(presentedAuth, "Bearer "), payload.HiveID))
 	}
 	if payload.Org != "" && !isValidName(payload.Org) {
 		http.Error(w, "invalid org name", http.StatusBadRequest)
@@ -2258,11 +2300,13 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
+	// N1: the bearer is captured here and VERIFIED below, once the claimed
+	// hive_id is known — the identity-bound bearer is derived from it. The
+	// prefix check stays here so a malformed header is still rejected early.
+	presentedAuth := ""
 	if s.hubSecret != "" {
-		auth := r.Header.Get("Authorization")
-		// Dual-path: accept the legacy raw-secret bearer (old spokes) OR the
-		// derived heartbeat key (v4 spokes). See heartbeatBearerOK.
-		if !s.heartbeatBearerOK(auth) {
+		presentedAuth = r.Header.Get("Authorization")
+		if !strings.HasPrefix(presentedAuth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -2286,6 +2330,19 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	if payload.HiveID == "" {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
+	}
+	if !isValidName(payload.HiveID) {
+		http.Error(w, "invalid hive_id", http.StatusBadRequest)
+		return
+	}
+	// N1: same identity binding as /api/heartbeat.
+	if s.hubSecret != "" {
+		if !s.heartbeatBearerOK(presentedAuth, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.noteHeartbeatAuthPath(payload.HiveID,
+			s.heartbeatBearerIsPerHive(strings.TrimPrefix(presentedAuth, "Bearer "), payload.HiveID))
 	}
 	for i, lb := range payload.Leaderboard {
 		payload.Leaderboard[i].GitHubUsername = sanitizeField(lb.GitHubUsername)

--- a/v2/pkg/hub/server_handlers_coverage_test.go
+++ b/v2/pkg/hub/server_handlers_coverage_test.go
@@ -15,7 +15,7 @@ func TestHeartbeatBearerOK_LegacyRawSecret(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	secret := srv.hubSecret
 
-	if !srv.heartbeatBearerOK("Bearer " + secret, "") {
+	if !srv.heartbeatBearerOK("Bearer "+secret, "") {
 		t.Error("heartbeatBearerOK must accept raw master secret")
 	}
 }
@@ -27,7 +27,7 @@ func TestHeartbeatBearerOK_DerivedKey(t *testing.T) {
 		t.Fatal("heartbeatKey() returned empty — test cannot proceed")
 	}
 
-	if !srv.heartbeatBearerOK("Bearer " + derived, "") {
+	if !srv.heartbeatBearerOK("Bearer "+derived, "") {
 		t.Error("heartbeatBearerOK must accept derived heartbeat key")
 	}
 }

--- a/v2/pkg/hub/server_handlers_coverage_test.go
+++ b/v2/pkg/hub/server_handlers_coverage_test.go
@@ -15,7 +15,7 @@ func TestHeartbeatBearerOK_LegacyRawSecret(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	secret := srv.hubSecret
 
-	if !srv.heartbeatBearerOK("Bearer " + secret) {
+	if !srv.heartbeatBearerOK("Bearer " + secret, "") {
 		t.Error("heartbeatBearerOK must accept raw master secret")
 	}
 }
@@ -27,7 +27,7 @@ func TestHeartbeatBearerOK_DerivedKey(t *testing.T) {
 		t.Fatal("heartbeatKey() returned empty — test cannot proceed")
 	}
 
-	if !srv.heartbeatBearerOK("Bearer " + derived) {
+	if !srv.heartbeatBearerOK("Bearer " + derived, "") {
 		t.Error("heartbeatBearerOK must accept derived heartbeat key")
 	}
 }
@@ -48,7 +48,7 @@ func TestHeartbeatBearerOK_InvalidTokenRejected(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if srv.heartbeatBearerOK(tc.auth) {
+			if srv.heartbeatBearerOK(tc.auth, "") {
 				t.Errorf("heartbeatBearerOK(%q) = true, want false", tc.auth)
 			}
 		})

--- a/v2/pkg/hub/server_test.go
+++ b/v2/pkg/hub/server_test.go
@@ -32,7 +32,7 @@ func TestServerHeartbeatBearerOKSecurityContract(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := srv.heartbeatBearerOK(tt.auth); got != tt.want {
+			if got := srv.heartbeatBearerOK(tt.auth, ""); got != tt.want {
 				t.Errorf("heartbeatBearerOK(%q) = %v, want %v", tt.auth, got, tt.want)
 			}
 		})
@@ -41,7 +41,7 @@ func TestServerHeartbeatBearerOKSecurityContract(t *testing.T) {
 
 func TestServerHeartbeatBearerOKEmptySecretCurrentBehavior(t *testing.T) {
 	srv := &HubServer{}
-	if !srv.heartbeatBearerOK("Bearer ") {
+	if !srv.heartbeatBearerOK("Bearer ", "") {
 		t.Fatal("heartbeatBearerOK with an empty hubSecret currently accepts an empty bearer; keep the caller-side guard in place")
 	}
 }

--- a/v2/pkg/hub/session_cookie_dual_test.go
+++ b/v2/pkg/hub/session_cookie_dual_test.go
@@ -1,0 +1,120 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+)
+
+// N2 (CWE-321/798) on v2, with DUAL-FORMAT minting.
+//
+// The hub cannot simply switch to Ed25519 here: a v2 spoke's proxy verifies
+// HMAC and only HMAC (see F3/#3243), so an Ed25519-only cookie would 401 the
+// terminal on every v2 spoke in the fleet. It also cannot stay HMAC-only,
+// because that key is symmetric AND provisioned into every spoke — any spoke
+// operator can mint `clubanderson.<sig>` and obtain hub admin.
+//
+// So the hub emits BOTH: `hive_hub_user` (HMAC, universally verifiable) and
+// `hive_hub_user_v2` (Ed25519, unforgeable by a spoke). Verifiers prefer the
+// asymmetric one; a spoke that does not know the name ignores it.
+
+const n2v2Master = "test-master-n2-v2"
+
+func n2v2Hub() *HubServer { return &HubServer{hubSecret: n2v2Master} }
+
+// v2SpokeVerify mirrors the v2 proxy's verifier EXACTLY (HMAC over the
+// username, base64url-unpadded) so this test fails if the hub ever mints
+// something that proxy cannot read.
+func v2SpokeVerify(sessionKey, value string) string {
+	if sessionKey == "" || value == "" {
+		return ""
+	}
+	idx := -1
+	for i := len(value) - 1; i >= 0; i-- {
+		if value[i] == '.' {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 || idx == len(value)-1 {
+		return ""
+	}
+	user, sig := value[:idx], value[idx+1:]
+	mac := hmac.New(sha256.New, []byte(sessionKey))
+	mac.Write([]byte(user))
+	if base64.RawURLEncoding.EncodeToString(mac.Sum(nil)) != sig {
+		return ""
+	}
+	return user
+}
+
+// TestDualMint_V2SpokeCanVerifyTheHMACCookie is the compatibility guarantee.
+// If this breaks, every v2 spoke's terminal 401s.
+func TestDualMint_V2SpokeCanVerifyTheHMACCookie(t *testing.T) {
+	s := n2v2Hub()
+	hmacCookie := mintHubUserCookieValue(s.sessionCookieKey(), "alice")
+	if got := v2SpokeVerify(s.sessionCookieKey(), hmacCookie); got != "alice" {
+		t.Fatalf("a v2 spoke could not verify the hub's HMAC cookie (got %q) — "+
+			"every v2 spoke's terminal would 401", got)
+	}
+}
+
+// TestDualMint_Ed25519CookieIsUnforgeableByASpoke is the finding itself.
+func TestDualMint_Ed25519CookieIsUnforgeableByASpoke(t *testing.T) {
+	s := n2v2Hub()
+	pub := s.sessionPublicKey()
+	if pub == "" {
+		t.Fatal("public key derivation returned empty")
+	}
+	// A spoke holding only the public key tries to mint an admin cookie.
+	forged := mintHubUserCookieValueV2(pub, hubAdminUsername)
+	if forged != "" {
+		if u, ok := verifyHubUserCookieValueV2(pub, forged); ok {
+			t.Fatalf("N2: a spoke forged a VERIFIABLE admin cookie (%q) from the public key", u)
+		}
+	}
+	// The hub's own mint verifies.
+	real := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+	if u, ok := verifyHubUserCookieValueV2(pub, real); !ok || u != "alice" {
+		t.Fatalf("hub-minted Ed25519 cookie failed to verify: %q %v", u, ok)
+	}
+}
+
+// TestDualMint_HubPrefersAsymmetric: when both cookies are present the
+// asymmetric one must win, or the stronger credential is decorative.
+func TestDualMint_HubPrefersAsymmetric(t *testing.T) {
+	s := n2v2Hub()
+	ed := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+	if u, ok := s.verifyHubUserDual(ed); !ok || u != "alice" {
+		t.Fatalf("verifyHubUserDual rejected the Ed25519 value: %q %v", u, ok)
+	}
+	// And the legacy paths still work during rollout.
+	if u, ok := s.verifyHubUserDual(mintHubUserCookieValue(s.sessionCookieKey(), "bob")); !ok || u != "bob" {
+		t.Error("derived-key HMAC cookie rejected — existing sessions would break")
+	}
+	if u, ok := s.verifyHubUserDual(mintHubUserCookieValue(n2v2Master, "carol")); !ok || u != "carol" {
+		t.Error("raw-master HMAC cookie rejected — v2 spokes mint against this")
+	}
+}
+
+// TestDualMint_FormatsAreDistinguishable guards the reason for two cookie NAMES
+// rather than one hybrid value: each verifier signs over the whole prefix, so no
+// single concatenation satisfies both.
+func TestDualMint_FormatsAreDistinguishable(t *testing.T) {
+	s := n2v2Hub()
+	hmacCookie := mintHubUserCookieValue(s.sessionCookieKey(), "alice")
+	ed := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+
+	if hubCookieIsV2(hmacCookie) {
+		t.Error("an HMAC cookie was misidentified as v2")
+	}
+	if !hubCookieIsV2(ed) {
+		t.Error("an Ed25519 cookie was not identified as v2")
+	}
+	// The v2 spoke's HMAC verifier must REJECT the Ed25519 value rather than
+	// mis-parsing a username out of it.
+	if got := v2SpokeVerify(s.sessionCookieKey(), ed); got != "" {
+		t.Errorf("a v2 spoke extracted %q from an Ed25519 cookie — it must reject it outright", got)
+	}
+}


### PR DESCRIPTION
The hosted hub runs `v2-latest`. All ten audit fixes went to **v4 only**, so **none of the hub-side ones execute in production**. This ports the three that can be ported.

I found this the hard way: I patched the one v4 spoke onto per-hive keys and it 401'd immediately, because the v2 hub has no per-hive verify path. Reverted; heartbeats recovered in ~4 minutes, no data loss.

| Finding | v4 PR | This PR |
|---|---|---|
| **N1** heartbeat identity binding | #3230 | ✅ ported |
| **N6** requireAdmin CSRF | #3140 | ✅ ported |
| **N2** session cookie | #3233 | ✅ ported, **redesigned** for a mixed fleet |
| **N3** per-hive terminal key | #3195 | ⛔ not portable — see below |

## N1 — and v2 is worse than v4 was

v2 provisioning injects the **raw master secret** into every spoke, and `heartbeatBearerOK` accepted both that *and* the fleet-wide derived key. Either proves only "some provisioned spoke", so `payload.HiveID` was trusted verbatim and three key-delivery lanes read off it.

The bearer is now verified **after** `hive_id` is parsed and validated, against a bearer derived from that claimed identity. Applied to `/api/heartbeat` and `/api/task-status`.

**Rollout:** both legacy credentials still authenticate. Every spoke in the field holds the raw master — that's how v2 provisions — so rejecting it would 401 the entire fleet at once (#2773). The legacy lanes don't bind identity and are explicitly temporary; #3234 tracks removal and `heartbeatBearerIsPerHive` is the readiness signal, also ported here.

## N2 — the v4 fix cannot be ported as-is

The v4 hub mints **only** Ed25519. A v2 spoke's proxy verifies HMAC and nothing else (see F3/#3243), so an Ed25519-only cookie would 401 the terminal on all 15 v2 spokes. Staying HMAC-only is equally wrong — that key is symmetric *and* in every spoke, so any spoke operator can mint `clubanderson.<sig>` and get hub admin.

So the hub emits **both**:

| Cookie | Format | Verifiable by | Mintable by a spoke? |
|---|---|---|---|
| `hive_hub_user` | HMAC | v2 spokes, v4 spokes, hub | yes (this is the flaw) |
| `hive_hub_user_v2` | Ed25519 | v4 spokes, hub | **no** |

Two cookie **names**, not one hybrid value — each verifier signs over the whole prefix, so no concatenation satisfies both. I checked both orderings; both fail both verifiers. A spoke that doesn't know the second name ignores it, which is what makes the mixed fleet work.

`verifyHubUserDual` tries Ed25519 first so the unforgeable credential wins when present. `getRealAuthUser` prefers it but falls through rather than locking a user out if it's stale (e.g. after a secret rotation). **Logout clears both** — clearing one would leave a valid credential in a "logged out" browser.

## N3 is not a port

v2 has **no terminal-assertion machinery at all**: no `terminal_assertion.go`, no `TERMINAL_SIGNING_KEY` in the proxy, no `MintTerminalAssertion` caller. There is no `HIVE_TERMINAL_KEY` for N3 to make per-hive.

Porting it would mean backporting the whole C3 feature — different work, different risk. Flagged rather than smuggled in.

## Testing

The regression that matters most is the compatibility guarantee: **a v2 spoke can still verify the HMAC cookie**, asserted with a verifier mirroring the actual proxy code rather than the hub's. If that breaks, every v2 terminal 401s.

Plus: a spoke holding only the public key cannot forge an admin cookie; the hub prefers the asymmetric value; a v2 spoke *rejects* an Ed25519 cookie outright rather than mis-parsing a username from it; N1's per-hive bearer cannot authenticate another hive while both legacy credentials still work.

**Baseline comparison** — clean `v2` fails **13** tests in `pkg/hub`; this branch fails **1**, and that one (`TestKickClaimClusterWorkDedupesPerHive`, a 9s timing test) fails identically on the baseline. No regressions introduced.

Two impersonation tests sent POSTs with neither Origin nor Content-Type — a shape no browser produces. Updated to carry the same-origin Origin, matching the `requireAuth` POST already in that file.