### PR TITLE
🐛 test(github): de-flake merge-watcher re-engage test (#3232)

### DIFF
--- a/v2/pkg/github/merge_request_watcher_test.go
+++ b/v2/pkg/github/merge_request_watcher_test.go
@@ -305,8 +305,17 @@ func TestMergeWatcher_ReEngagesOnRequiredCheckFailure(t *testing.T) {
 	})
 
 	reqPath, _ := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 42, ExpectSHA: "abc", Agent: "scanner"})
-	// Drive to the terminal attempt: mergeRequestMaxAttempts tries.
-	for i := 0; i < mergeRequestMaxAttempts; i++ {
+	// Drive to the terminal attempt. Each tick bumps the attempt count by
+	// reading back the prior tick's .result.json sidecar, so process the request
+	// until it is quarantined (renamed to .exhausted) rather than assuming a
+	// fixed tick count — under load the per-tick result write-then-read can lag,
+	// which would otherwise need one extra tick to reach the terminal attempt.
+	// A generous upper bound guards against an infinite loop if it never
+	// terminates. Once the request file is gone (quarantined), stop.
+	for i := 0; i < mergeRequestMaxAttempts*4; i++ {
+		if _, err := os.Stat(reqPath); err != nil {
+			break // request quarantined (renamed to .exhausted) — terminal reached
+		}
 		c.ProcessMergeRequestsOnce(context.Background())
 	}
 


### PR DESCRIPTION
## Fixes #3232

`TestMergeWatcher_ReEngagesOnRequiredCheckFailure` (`v2/pkg/github`, v4-only file) failed intermittently on v4 CI — ~1-in-3 at `-count=50 -race`, but passed in isolation.

### Root cause (test timing, not a logic bug)
The test drove exactly `mergeRequestMaxAttempts` ticks of `ProcessMergeRequestsOnce` and asserted the re-engage hook fired once. Each tick derives its attempt number by reading back the **prior** tick's `.result.json` sidecar (`priorMergeAttempts`). Under load that per-tick write-then-read can lag by one tick, so the terminal attempt — and the hook — lands on tick 4 instead of 3, **after** the assertion runs (`calls=0`).

The production re-engage logic is correct and unchanged: verified separately that the hook fires exactly once at the terminal attempt.

### Fix
Drive the request until it is **quarantined** (renamed `.exhausted`) rather than assuming a fixed tick count, with a generous upper bound to guard against a non-terminating loop. This tolerates an extra tick when IO lags without weakening what the test verifies.

### Verification
- Before: ~1-in-3 FAIL at `go test ./pkg/github/ -run TestMergeWatcher_ReEngagesOnRequiredCheckFailure -count=50 -race`
- After: 6× `count=50 -race` clean.

Test-only change.