### PR TITLE
test(agent): fix stale copilot launch-cmd tests after authorship fix #3259

### DIFF
--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -220,11 +220,15 @@ func TestToolRulesToLaunchCmd_ClaudeInference(t *testing.T) {
 }
 
 func TestToolRulesToLaunchCmd_Copilot(t *testing.T) {
-	// No github deny -> enable-all-github-mcp-tools present.
+	// Authorship fix: copilot must NEVER pass --enable-all-github-mcp-tools —
+	// the built-in github-mcp-server is read-only by default, so GitHub MCP
+	// WRITE tools are never registered and an agent cannot author issues/PRs as
+	// the logged-in user. (This test previously asserted the OPPOSITE — that the
+	// flag was present — which was the bug: it let agents author as the user.)
 	tools := denyTools("mcp__something__else")
 	cmd := toolRulesToLaunchCmd("copilot", "auto", "copilot", tools, false)
-	if !containsBoot(cmd, "--enable-all-github-mcp-tools") {
-		t.Errorf("copilot without github deny should enable github tools: %q", cmd)
+	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
+		t.Errorf("copilot must NOT enable all github mcp tools (read-only default): %q", cmd)
 	}
 	if !containsBoot(cmd, "--deny-tool=") {
 		t.Errorf("copilot cmd should include deny-tool: %q", cmd)
@@ -237,8 +241,13 @@ func TestToolRulesToLaunchCmd_CopilotGithubDeny(t *testing.T) {
 	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
 		t.Errorf("copilot with github deny should NOT enable all github tools: %q", cmd)
 	}
-	if !containsBoot(cmd, "github(create_pull_request)") {
-		t.Errorf("copilot deny should be translated: %q", cmd)
+	// Deny must use the built-in server's REAL name github-mcp-server, not the
+	// bogus `github` name (which was a silent no-op — the source of the leak).
+	if !containsBoot(cmd, "github-mcp-server(create_pull_request)") {
+		t.Errorf("copilot deny should translate to github-mcp-server(tool): %q", cmd)
+	}
+	if containsBoot(cmd, "--deny-tool='github(") {
+		t.Errorf("copilot deny must NOT use the wrong `github(` server name: %q", cmd)
 	}
 }
 


### PR DESCRIPTION
#3259 corrected the copilot launch command (drop `--enable-all-github-mcp-tools` → read-only default; deny names `github-mcp-server(tool)` not the bogus `github(tool)`). Two tests still asserted the OLD buggy behavior and now fail on v2 main:
- `TestToolRulesToLaunchCmd_Copilot` — asserted enable-all present (now must be absent)
- `TestToolRulesToLaunchCmd_CopilotGithubDeny` — asserted `github(create_pull_request)` (now `github-mcp-server(...)`)

This updates the assertions to the corrected behavior + adds a guard that the wrong `github(` name never returns. Follow-up to #3259 (which I merged before the full test suite finished — my miss).