### PR TITLE
🐛 Remove proxy proof fail-open bypass

### DIFF
--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -605,6 +605,7 @@ func TestSecurityHeaders_WithAuthToken(t *testing.T) {
 	req = httptest.NewRequest("GET", "/api/kick/scanner", nil)
 	req.Header.Set("X-Hive-User", "testuser")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, "secret-token")
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -133,8 +133,8 @@ func TestOwnerOnlyMutationsRejectProoflessHubOwnerRole(t *testing.T) {
 
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("proofless hub owner role status = %d, want 403", w.Code)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("proofless hub owner role status = %d, want 401", w.Code)
 	}
 }
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -46,10 +45,8 @@ const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
 // proxyProofRequired controls F2 enforcement strictness. Default true =
 // fail-closed: a request with no X-Hive-Proxy-Auth proof header (or a wrong
 // one) is rejected even if it carries X-Hive-User/X-Hive-Role identity
-// headers. Set HIVE_PROXY_PROOF_REQUIRED=false only during a temporary
-// rollout window where some hub replicas may not yet inject the proof header.
 // A WRONG proof header is ALWAYS rejected regardless of this setting.
-var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") != "false"
+var proxyProofRequired = true
 
 type Server struct {
 	port       int
@@ -827,12 +824,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// only the trusted proxy can produce. Require it as PROOF the request
 		// transited the hub.
 		//
-		// ROLLOUT SAFETY — fail open until the hub half is everywhere: if the hub
-		// has NOT sent X-Hive-Proxy-Auth (older hub image mid-rollout), fall back
-		// to the pre-F2 behavior (trust the identity headers) so no hosted hive is
-		// locked out. Once the hub half is confirmed deployed fleet-wide, a
-		// follow-up flips proxyProofRequired to make a missing/incorrect proof
-		// header fail closed.
+		// Missing or incorrect proof fails closed. Older hub images that do not
+		// inject X-Hive-Proxy-Auth must be upgraded before their identity headers
+		// are accepted.
+		proxyProofRejectReason := ""
 		if !trusted && !directRouteAuthz &&
 			inboundUser != "" && inboundRole != "" {
 			proof := r.Header.Get(proxyAuthHeader)
@@ -853,6 +848,11 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			default:
 				// Proof header present but WRONG, or strict mode with no proof:
 				// this did not come through the trusted hub proxy — reject.
+				if proof == "" {
+					proxyProofRejectReason = "missing proxy proof header"
+				} else {
+					proxyProofRejectReason = "invalid proxy proof header"
+				}
 			}
 			if trusted {
 				r.Header.Set("X-Hive-User", inboundUser)
@@ -896,6 +896,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		if !trusted {
 			if strings.HasPrefix(r.URL.Path, "/api/") {
 				w.Header().Set("Content-Type", "application/json")
+				if proxyProofRejectReason != "" {
+					http.Error(w, fmt.Sprintf(`{"error":%q}`, proxyProofRejectReason), http.StatusUnauthorized)
+					return
+				}
 				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 			} else {
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -190,6 +190,7 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/config", nil)
 	req.Header.Set("X-Hive-User", "clubanderson")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, s.authToken)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -202,8 +203,7 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 
 // TestMiddleware_F2ProxyProof covers the F2 proof-of-proxy header enforcement on
 // a hub-proxied spoke: a valid proof is trusted; a WRONG proof is always
-// rejected; a MISSING proof is trusted only in the fail-open rollout default and
-// rejected once strict enforcement is enabled.
+// rejected; a MISSING proof is rejected in the default fail-closed mode.
 func TestMiddleware_F2ProxyProof(t *testing.T) {
 	newReq := func(proof string) *http.Request {
 		r := httptest.NewRequest("GET", "/api/config", nil)
@@ -239,12 +239,31 @@ func TestMiddleware_F2ProxyProof(t *testing.T) {
 	if c := run(t, true, "wrong-token"); c == http.StatusOK {
 		t.Error("wrong proof must be rejected in strict mode")
 	}
-	// Missing proof: trusted in fail-open (rollout), rejected in strict.
+	// Missing proof: trusted only when a test explicitly simulates the legacy
+	// rollout mode, rejected in the default strict mode.
 	if c := run(t, false, ""); c != http.StatusOK {
 		t.Errorf("missing proof (fail-open) = %d, want 200 (rollout safety)", c)
 	}
 	if c := run(t, true, ""); c == http.StatusOK {
 		t.Error("missing proof must be rejected in strict mode")
+	}
+}
+
+func TestMiddleware_F2ProxyProofDefaultRejectsMissingProof(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("X-Hive-User", "clubanderson")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing proof with default enforcement = %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "missing proxy proof header") {
+		t.Fatalf("missing proof error = %q, want clear proxy proof error", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
Refs #3045

Follow-up to #3047 after the branch landed while still carrying the old rollout escape hatch.

## Security intent
- Keep the new fail-closed default for hub identity headers.
- Remove the production `HIVE_PROXY_PROOF_REQUIRED=false` opt-out so there is no fail-open environment bypass.
- Return a clear `missing proxy proof header` / `invalid proxy proof header` 401 for older or misconfigured proxy paths instead of silently trusting forged identity headers.
- Update dashboard tests to require `X-Hive-Proxy-Auth` on hub-proxied identity-header paths.

## Verification
- go test ./pkg/dashboard -run 'TestSecurityHeaders_WithAuthToken|TestOwnerOnlyMutationsRejectProoflessHubOwnerRole|TestMiddleware_(HubProxiedHeadersStillTrusted|F2ProxyProof|F2ProxyProofDefaultRejectsMissingProof)$' -count=1\n- go test ./pkg/dashboard -count=1