### PR TITLE
🐛 fix: codex and aider backends accepted by config but undispatchable

### DIFF
--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -269,3 +269,77 @@ func TestSetBackendOverride_RejectsUndispatchableBackend(t *testing.T) {
 		t.Errorf("SetBackendOverride on a missing agent = %v, want a 'not found' error", err)
 	}
 }
+
+// TestBackendBinaryName_EverySupportedBackendResolves is the guard for the
+// accept-then-fail class of bug. config.ValidateBackend accepts every member of
+// config.SupportedBackends() at config-set time, so the launcher MUST be able to
+// dispatch every one of them — otherwise a backend is persisted happily and then
+// dies hours later at kick time with "unknown backend".
+//
+// This regression was real: config.CLIBackends listed codex and aider, but
+// backendBinary's hand-written map did not, so `backend: codex` was accepted and
+// then failed at launch. The old test enumerated only the backends that were
+// already in the map, so it could never catch a missing one. This test derives
+// its cases from the canonical list instead, which is what makes it able to.
+//
+// backendBinaryName is used rather than backendBinary so this asserts the
+// mapping is COMPLETE without also requiring every CLI to be installed here.
+func TestBackendBinaryName_EverySupportedBackendResolves(t *testing.T) {
+	supported := config.SupportedBackends()
+	if len(supported) == 0 {
+		t.Fatal("config.SupportedBackends() is empty — this test would vacuously pass")
+	}
+	for _, b := range supported {
+		binary, err := backendBinaryName(b)
+		if err != nil {
+			t.Errorf("config accepts backend %q but the launcher cannot dispatch it: %v", b, err)
+			continue
+		}
+		if binary == "" {
+			t.Errorf("backendBinaryName(%q) returned an empty binary name", b)
+		}
+	}
+}
+
+// TestBackendBinaryName_CodexAndAiderLaunchTheirOwnBinaries pins the specific
+// regression: codex and aider are agentic CLIs of their own, not aliases and not
+// gateway backends, so each must exec a binary of its own name. If either were
+// ever folded into the claude derivation this would catch it.
+func TestBackendBinaryName_CodexAndAiderLaunchTheirOwnBinaries(t *testing.T) {
+	for _, backend := range []string{"codex", "aider"} {
+		if !config.IsCLIBackend(backend) {
+			t.Fatalf("precondition failed: %q is no longer a config.CLIBackends member", backend)
+		}
+		got, err := backendBinaryName(backend)
+		if err != nil {
+			t.Errorf("backendBinaryName(%q) err = %v, want nil", backend, err)
+			continue
+		}
+		if got != backend {
+			t.Errorf("backendBinaryName(%q) = %q, want %q", backend, got, backend)
+		}
+	}
+}
+
+// TestBackendBinaryName_AliasesSurviveDerivation guards the ordering inside
+// backendBinaryName: the identity derivation over config.CLIBackends would map
+// "pi" to a non-existent "pi" binary, so the alias overrides must be applied
+// AFTER it. Swapping those two loops would silently break the pi backend.
+func TestBackendBinaryName_AliasesSurviveDerivation(t *testing.T) {
+	got, err := backendBinaryName("pi")
+	if err != nil {
+		t.Fatalf("backendBinaryName(\"pi\") err = %v, want nil", err)
+	}
+	if got != "goose" {
+		t.Errorf("backendBinaryName(\"pi\") = %q, want \"goose\" (alias applied after identity derivation)", got)
+	}
+}
+
+// TestBackendBinaryName_RejectsUnknown keeps the negative path honest: deriving
+// from the canonical lists must not turn backendBinaryName into a function that
+// accepts anything.
+func TestBackendBinaryName_RejectsUnknown(t *testing.T) {
+	if _, err := backendBinaryName("totally-made-up"); err == nil {
+		t.Fatal("backendBinaryName accepted a backend that is in neither canonical list")
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4270,30 +4270,58 @@ func (a *AgentProcess) FilteredPaneLines(n int) []string {
 	return filterPaneOutput(a.lastPaneCapture, n)
 }
 
-// backendBinary maps an agent backend to the CLI binary that is actually
-// exec'd for it. Every model-gateway backend (config.InferenceBackends: vllm,
-// llm-d, litellm, watsonx) launches the SAME claude CLI, pointed at hive's
-// local OpenAI-compatible translator via ANTHROPIC_BASE_URL — the backend name
-// selects the upstream route, not the binary. Those entries are therefore
-// derived from the canonical list rather than written out here, so a backend
-// added to config.InferenceBackends can never again be accepted by config and
-// then rejected at kick time with "unknown backend".
-func backendBinary(backend string) (string, error) {
-	binaries := map[string]string{
-		"claude":  "claude",
-		"copilot": "copilot",
-		"gemini":  "gemini",
-		"goose":   "goose",
-		"pi":      "goose",
-		"bob":     "bob",
+// backendBinaryAliases names the backends whose binary is NOT simply the
+// backend name. Only genuine aliases belong here: every other CLI backend is
+// derived from config.CLIBackends by identity, and every model-gateway backend
+// from config.InferenceBackends. Keeping this map to aliases only is what makes
+// the accept-then-fail class of bug structurally impossible — see backendBinary.
+var backendBinaryAliases = map[string]string{
+	"pi": "goose",
+}
+
+// backendBinaryName maps an agent backend to the NAME of the CLI binary that is
+// exec'd for it, without touching the filesystem. Split out from backendBinary
+// so the "every supported backend resolves" invariant can be tested without
+// requiring each CLI to be installed on the test machine.
+//
+// Both canonical lists are derived rather than written out here:
+//
+//   - config.CLIBackends (claude, copilot, goose, codex, pi, bob, aider, gemini)
+//     each launch a binary of the same name, except for the aliases above.
+//   - config.InferenceBackends (vllm, llm-d, litellm, watsonx) all launch the
+//     SAME claude CLI, pointed at hive's local OpenAI-compatible translator via
+//     ANTHROPIC_BASE_URL — the backend name selects the upstream route, not the
+//     binary.
+//
+// Deriving both means a backend added to either list can never again be
+// accepted by config.ValidateBackend and then rejected hours later at kick time
+// with "unknown backend". Previously only InferenceBackends was derived, so
+// codex and aider were valid config values that failed at launch.
+func backendBinaryName(backend string) (string, error) {
+	binaries := make(map[string]string, len(config.CLIBackends)+len(config.InferenceBackends))
+	for _, b := range config.CLIBackends {
+		binaries[b] = b
 	}
 	for _, b := range config.InferenceBackends {
 		binaries[b] = "claude"
+	}
+	for backend, binary := range backendBinaryAliases {
+		binaries[backend] = binary
 	}
 
 	binary, ok := binaries[backend]
 	if !ok {
 		return "", fmt.Errorf("unknown backend: %s", backend)
+	}
+	return binary, nil
+}
+
+// backendBinary resolves an agent backend to the absolute path of the CLI
+// binary that is actually exec'd for it.
+func backendBinary(backend string) (string, error) {
+	binary, err := backendBinaryName(backend)
+	if err != nil {
+		return "", err
 	}
 
 	path, err := exec.LookPath(binary)


### PR DESCRIPTION
Forward-port of #3278 to v4.

## Root cause
`config.CLIBackends` lists `codex` and `aider`, and backend validation accepts every supported backend, but `backendBinary` used a hand-written CLI map that did not include either backend. That let config persist successfully and then fail at launch time with `unknown backend`.

## Fix
Derive CLI backend binary names from `config.CLIBackends`, keep only the real `pi -> goose` alias in an override map applied after derivation, and split `backendBinaryName` out for PATH-independent completeness tests.

## Validation
- `go test ./pkg/agent/ -run TestBackendBinaryName -count=1`

Also independently verified sabotage on #3278: restoring the old hand-written CLI list fails naming codex/aider, and moving alias application before identity derivation fails the pi -> goose test.