### PR TITLE
📖 docs: fix misleading paths, dangling refs, stray artifacts (5 [guide] issues)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you need to run your own private hub instead, see the v2
 #### 1. Create the namespace
 
 ```bash
-kubectl apply -f deploy/k8s/namespace.yaml
+kubectl apply -f v2/deploy/k8s/namespace.yaml
 ```
 
 Or manually:
@@ -74,7 +74,7 @@ kubectl -n hive create secret generic hive-secrets \
 #### 3. Create ConfigMap from hive.yaml
 
 ```bash
-cp hive.yaml.example hive.yaml
+cp v2/hive.yaml.example hive.yaml
 # Edit hive.yaml: set your org, repos, agents, and governor config
 
 kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
@@ -85,7 +85,7 @@ kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
 Apply the provided PVC manifest:
 
 ```bash
-kubectl apply -f deploy/k8s/pvc.yaml
+kubectl apply -f v2/deploy/k8s/pvc.yaml
 ```
 
 The default PVC requests 10Gi with `ReadWriteOnce`. For zero-downtime rollouts with rolling updates, use an NFS-backed StorageClass with `ReadWriteMany`:
@@ -108,8 +108,8 @@ spec:
 #### 5. Deploy
 
 ```bash
-kubectl apply -f deploy/k8s/deployment.yaml
-kubectl apply -f deploy/k8s/service.yaml
+kubectl apply -f v2/deploy/k8s/deployment.yaml
+kubectl apply -f v2/deploy/k8s/service.yaml
 ```
 
 The deployment runs a single replica with liveness and readiness probes on `/api/health`. Resource defaults: 500m CPU / 512Mi memory (requests), 2 CPU / 2Gi memory (limits).
@@ -151,13 +151,13 @@ Long timeouts are needed for SSE streaming connections to the dashboard.
 #### Quick apply (all manifests)
 
 ```bash
-kubectl apply -f deploy/k8s/namespace.yaml
+kubectl apply -f v2/deploy/k8s/namespace.yaml
 kubectl -n hive create secret generic hive-secrets \
   --from-literal=HIVE_GITHUB_TOKEN=ghp_...
 kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
-kubectl apply -f deploy/k8s/pvc.yaml
-kubectl apply -f deploy/k8s/deployment.yaml
-kubectl apply -f deploy/k8s/service.yaml
+kubectl apply -f v2/deploy/k8s/pvc.yaml
+kubectl apply -f v2/deploy/k8s/deployment.yaml
+kubectl apply -f v2/deploy/k8s/service.yaml
 ```
 
 ### Ports
@@ -178,7 +178,7 @@ kubectl apply -f deploy/k8s/service.yaml
 
 ## Configuration
 
-All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [v2/hive.yaml.example](v2/hive.yaml.example) for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
 
 The top-level deterministic shell pipeline uses a separate project file,
 `config/hive-project.yaml.example`; see [config/README.md](config/README.md)

--- a/v2/docs/apiproxy.md
+++ b/v2/docs/apiproxy.md
@@ -29,8 +29,9 @@ Environment:
 
 ## Deployment notes
 
-At v2 HEAD, the binary listens on `:<port>` (all interfaces). Treat it as an
-internal sidecar or bind it behind a firewall/network policy unless you have a
-newer change that binds to localhost by default. Security PR #2935, which tracks
-localhost binding and warning on `ANTHROPIC_API_KEY` key-injection fallback, was still open when
-this document was written.
+By default the binary listens on `:<port>` (all interfaces). Treat it as an
+internal sidecar and bind it behind a firewall or NetworkPolicy so nothing on
+the pod network can reach it directly. If your build exposes a bind-address
+flag, prefer binding to `127.0.0.1` so only same-container callers can reach the
+proxy. Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in
+production — configure `PROXY_AUTH_TOKEN` explicitly instead.

--- a/v2/docs/beads-cli.md
+++ b/v2/docs/beads-cli.md
@@ -42,5 +42,3 @@ bd close bead-123
 | `bd kb ctx7-search <name>` | Search Context7 library IDs. |
 | `bd kb import-ctx7 <library-id> [--name <n>] [--query <topic>]` | Import Context7 docs into the community layer. |
 | `bd kb list-docs` | List imported documents. |
-
-Fixes #2981.

--- a/v2/docs/contributor-relay.md
+++ b/v2/docs/contributor-relay.md
@@ -84,5 +84,3 @@ kubectl -n my-namespace rollout status deploy/hive-contributor
 The generated pod sets `CONTRIBUTOR_MODE=headless` because Kubernetes pods have no TTY; interactive tmux mode would stall. Headless mode is currently verified for `claude`, `litellm`, `copilot`, `codex`, and `goose`. The Deployment has one replica per registered contributor identity and uses readiness/liveness probes that read the relay's headless status file (`waiting`, `working`, `done` pass; missing/failed state fails).
 
 The generated Secret contains the registration token and `GH_TOKEN` as Kubernetes Secret data. Treat it as sensitive cluster-readable material and prefer a pinned image tag/digest for repeatable operation.
-
-Fixes #3024.

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -107,6 +107,12 @@ installation instead of broadening the PAT.
 |---|---|
 | `HIVE_METRICS_ENABLED` | Enables unauthenticated Prometheus `/metrics` when set to `1`, `true`, `yes`, or `on`; off by default because it exposes estimated cost data. |
 
+> **Note on `tokens_24h`:** despite its name, the per-spoke heartbeat field
+> `tokens_24h` (stored on the hub as `totalTokens24h`) is a **cumulative total**,
+> not a rolling 24-hour window. Read it as lifetime token consumption for the
+> spoke. See [token-tracking.md](token-tracking.md) for the full heartbeat and
+> `/api/saas/usage` rollup details.
+
 ### Inference endpoint fallbacks
 
 | Name | Default | Purpose |


### PR DESCRIPTION
Batch of verified quick-fix doc corrections from the [guide] queue. Each was checked against source.

- **Fixes #3246, #3248** — README Kubernetes section used `deploy/k8s/` and `hive.yaml.example`, but those live at `v2/deploy/k8s/` and `v2/hive.yaml.example` and that section (unlike Quick Start) never `cd`s into `v2/`. Prefixed the paths with `v2/`.
- **Fixes #3178** — `v2/docs/apiproxy.md` had a dangling reference to still-open PR #2935. Replaced with self-contained guidance (firewall/NetworkPolicy, prefer `127.0.0.1`, use `PROXY_AUTH_TOKEN`).
- **Fixes #3255** — removed stray trailing `Fixes #NNNN.` commit-message artifacts that leaked into `beads-cli.md` and `contributor-relay.md`.
- **Fixes #3257** — `operator-reference.md` was silent on `tokens_24h`; added a note that it's a cumulative total, not a rolling 24h window (pointing at `token-tracking.md`).

Docs-only; lands on v2 and flows to v4/dd/mk via sync.