### PR TITLE
📖 docs: link orphaned index pages + document session dirs (#3214 #3219 #3180 #3182)

### DIFF
--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -34,8 +34,11 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
+- [Supervisor agent](supervisor.md) — supervisor policy templates and when to use each.
+- [Custom dashboard stylesheets](custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
 - [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
 - [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
+- [Agent definition format](../AGENT-DEFINITION.md) — the portable YAML format for importing/exporting agents.
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [ACMM policy fragments](../../examples/acmm/README.md) — per-level ACMM policy references.
 - [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.

--- a/v2/docs/cncf-reference-architecture.md
+++ b/v2/docs/cncf-reference-architecture.md
@@ -36,6 +36,12 @@ reference_architectures:
   - AI/ML
 ---
 
+> **Purpose:** This page is a **CNCF reference-architecture submission template**,
+> not operator or contributor documentation. It describes how Hive relates to CNCF
+> projects for the CNCF landscape/reference-architecture process. For running or
+> developing Hive, start from the [docs index](README.md) and
+> [architecture.md](architecture.md) instead.
+
 ## Relevant CNCF projects
 
 {{< cardpane >}}

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -38,6 +38,8 @@ Top-level YAML keys accepted by `config.Config`:
 | `dashboard.snapshot_frame_ancestors` | Empty list means CSP `frame-ancestors 'none'`. | Entries must be exact `https://` origins; paths, wildcards, credentials, query, and fragments are rejected. |
 | `dashboard.authorized_users` | Empty means no per-user direct-route allowlist. | Entries can be `user` or `user:role`; roles are `read`, `read-write`, `merger`, `owner`. |
 | `variables.security.*` | Deny by default. | `allow_exec`, `allow_http`, and GitHub prompt-source allowlists are honored only from the trusted seed, not dashboard overlays. |
+| `data.claude_sessions_dir` | `/data/home/.claude/projects` | Where the dashboard reads Claude Code session JSONL for per-agent token/cost accounting. Point it at the agents' real session directory if you relocate `HOME`. |
+| `data.copilot_sessions_dir` | `/data/home/.copilot/session-state` | Same, for the Copilot CLI backend's session state. |
 
 For runtime precedence and provenance, see [config-layering.md](config-layering.md).
 


### PR DESCRIPTION
Index/linking fixes from the [guide] queue. **Stacked on #3290** (base is that branch); will retarget to v2 once #3290 merges.

- **Fixes #3214** — link `supervisor.md` and `custom-stylesheets.md` from the docs index (files existed, weren't reachable).
- **Fixes #3219** — link `v2/AGENT-DEFINITION.md` from the docs index.
- **Fixes #3180** — document `data.claude_sessions_dir` / `data.copilot_sessions_dir` in operator-reference (were in hive.yaml.example only).
- **Fixes #3182** — add a top-of-page purpose note to `cncf-reference-architecture.md` (it's a CNCF submission template, not operator docs).

Docs-only.