### PR TITLE
📖 docs: local supervisor links + examples/agents README (#3254 #3170)

### DIFF
--- a/v2/docs/supervisor.md
+++ b/v2/docs/supervisor.md
@@ -103,5 +103,5 @@ ACMM packs may override these values. For example, the pack definitions use `bac
 
 - **[Agent Configuration](agent-configuration.md)** — every agent field, methods, model pinning, cadences, and ACMM packs.
 - **[ACMM Policy Matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.
-- **[Architecture](https://kubestellar.io/docs/hive/overview/architecture)** — the two scheduling models and how the supervisor drives agents.
-- **[Troubleshooting](https://kubestellar.io/docs/hive/getting-started/troubleshooting)** — stuck sessions, login expiry, restart loops.
+- **[Architecture](architecture.md)** — the process model, governor loop, and how the supervisor drives agents.
+- **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.

--- a/v2/examples/agents/README.md
+++ b/v2/examples/agents/README.md
@@ -1,0 +1,24 @@
+# Example agent definitions
+
+Portable agent definitions in the `AgentDefinition` YAML format (see
+[`v2/AGENT-DEFINITION.md`](../../AGENT-DEFINITION.md) for the full schema). Each
+file here is a self-contained example you can import into a running hive.
+
+## Files
+
+| File | What it shows |
+|------|---------------|
+| [`customized-agent.yaml`](customized-agent.yaml) | A fully-annotated agent definition — backend, model, cadences, prompt source, and beads directory — usable as a starting template. |
+
+## Importing
+
+Import a definition from the dashboard: **+ agent → Import from URL**, and paste
+the raw file URL, for example:
+
+```
+https://raw.githubusercontent.com/kubestellar/hive/v2/v2/examples/agents/customized-agent.yaml
+```
+
+Or copy a file into your hive's agents overlay directory (`data.agents_dir`) and
+reload. See [`v2/docs/agent-configuration.md`](../../docs/agent-configuration.md)
+for the agent fields and how overlays are applied.


### PR DESCRIPTION
More [guide] cheap fixes, verified against source.

- **Fixes #3254** — supervisor.md 'What to read next' linked Architecture/Troubleshooting to external kubestellar.io; now points at local architecture.md and health-checks.md.
- **Fixes #3170** — added v2/examples/agents/README.md (the directory had no README; describes customized-agent.yaml and how to import).

Docs-only.