### PR TITLE
📖 docs: notifications guide + Discord bot README (#3223 #3253 #3218)

### DIFF
--- a/discord/README.md
+++ b/discord/README.md
@@ -1,0 +1,58 @@
+# Hive Discord bot
+
+An optional Discord bot that lets operators interact with a hive from a Discord
+channel — check status, kick, pause, and resume agents — and receive alerts. It
+talks to the hive's dashboard API; it does **not** need cluster access.
+
+This is separate from the one-way **`notifications.discord.webhook`** channel
+(see [`v2/docs/notifications.md`](../v2/docs/notifications.md)). The webhook only
+pushes alerts; this bot is two-way.
+
+## Setup
+
+1. Create a Discord application and bot at
+   <https://discord.com/developers/applications>, and invite it to your server
+   with permission to read and send messages in the target channel(s).
+2. Install and run:
+
+   ```bash
+   cd discord
+   npm install
+   npm start
+   ```
+
+3. Configure via environment variables (required unless noted):
+
+   | Variable | Purpose |
+   |----------|---------|
+   | `DISCORD_BOT_TOKEN` | Bot token from the Discord developer portal. |
+   | `DISCORD_CHANNEL_PRIMARY` | Channel ID the bot listens in for commands. |
+   | `DISCORD_CHANNEL_ALERTS` | Optional channel ID for alert posts. |
+   | `HIVE_DASHBOARD_URL` | Base URL of the hive dashboard API the bot drives. |
+   | `HIVE_METRICS_DIR` | Optional path to the hive metrics dir for local reads. |
+   | `HIVE_PROJECT_CONFIG` | Optional path to the project config for agent names/prefix. |
+
+   The command prefix defaults to `!` and can be overridden with
+   `command_prefix` in the project config.
+
+## Commands
+
+Send these in the primary channel (default prefix `!`):
+
+| Command | Aliases | What it does |
+|---------|---------|--------------|
+| `!status` | `!s`, `!st` | Fleet status summary from the dashboard. |
+| `!governor` | | Current governor mode and cadences. |
+| `!kick <agent> [prompt]` | `!k <agent>` | Kick an agent (optionally with a prompt). |
+| `!pause <agent>` | `!p <agent>` | Pause an agent. |
+| `!resume <agent>` | `!r <agent>` | Resume a paused agent. |
+| `!help` | `!h`, `!?` | Command usage. |
+
+Unknown agents and unreachable-dashboard conditions are reported back in-channel.
+
+## Security
+
+The bot token and any dashboard auth token are secrets — supply them via
+environment variables, never commit them. Restrict the bot to a private
+operator channel; anyone who can post in `DISCORD_CHANNEL_PRIMARY` can kick,
+pause, and resume agents.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -15,6 +15,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [TLS, HTTPS, and certificates](tls-setup.md) — termination patterns and certificate ownership.
 - [Security notes](security.md) — log scrubbing and secret redaction guarantees/limits.
 - [Token collection and usage tracking](token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
+- [Notifications](notifications.md) — ntfy, Slack, and Discord alert channels, plus the two-way [Discord bot](../../discord/README.md).
 - [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [`bd` beads CLI](beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -317,9 +317,9 @@ Portable agents bundle everything — config plus a `promptTemplate` — in a si
 ## What to read next
 
 - **[Supervisor agent](supervisor.md)** — what the supervisor does, how it differs from the governor, when to enable it, `bead_role` semantics, and policy modes.
-- **[Introduction](https://kubestellar.io/docs/hive/overview/introduction)** — what hive is, setup, and the command surface.
-- **[Architecture](https://kubestellar.io/docs/hive/overview/architecture)** — the two scheduling models and how the supervisor drives agents.
-- **[Troubleshooting](https://kubestellar.io/docs/hive/getting-started/troubleshooting)** — stuck sessions, login expiry, restart loops.
+- **[Documentation index](README.md)** — what hive is, setup, and the full topic-guide surface.
+- **[Architecture](architecture.md)** — the process model, governor loop, and how the supervisor drives agents.
+- **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.
 - **[ACMM policy matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.
 - **[Config layering](config-layering.md)** — precedence for seed, dashboard overlay, agent overlays, and runtime snapshots.
 - **[Cross-cluster migration](cross-cluster-migration.md)** — moving a hive (and its PVC state) between clusters.

--- a/v2/docs/notifications.md
+++ b/v2/docs/notifications.md
@@ -1,0 +1,71 @@
+# Notifications
+
+Hive can push operator alerts — merges, reviews, health warnings — to one or
+more channels. All channels are optional; configure only the ones you want under
+the top-level `notifications` block in `hive.yaml`.
+
+## ntfy
+
+[ntfy](https://ntfy.sh) is a simple pub/sub notification service. Point it at the
+public server or your own self-hosted instance:
+
+```yaml
+notifications:
+  ntfy:
+    server: https://ntfy.sh   # or your self-hosted ntfy URL
+    topic: my-hive-alerts      # subscribe to this topic in the ntfy app
+```
+
+Subscribe to the same `topic` in the ntfy mobile/desktop app or via
+`curl -s https://ntfy.sh/my-hive-alerts/json` to receive alerts. Choose a
+hard-to-guess topic name — anyone who knows a public-server topic can read its
+messages.
+
+## Slack
+
+Create an [Incoming Webhook](https://api.slack.com/messaging/webhooks) for the
+target channel and pass its URL. Keep the URL in an environment variable rather
+than committing it:
+
+```yaml
+notifications:
+  slack:
+    webhook: ${SLACK_WEBHOOK_URL}
+```
+
+## Discord (webhook)
+
+Create a channel webhook (Channel → Edit → Integrations → Webhooks) and pass its
+URL:
+
+```yaml
+notifications:
+  discord:
+    webhook: ${DISCORD_WEBHOOK_URL}
+```
+
+This is one-way alert delivery. For a two-way bot that responds to `!hive`
+commands, see the separate Discord bot below.
+
+## Discord bot (optional, two-way)
+
+A separate optional Discord bot (in [`discord/`](../../discord/)) responds to
+`!hive` commands in a channel. It is configured under the top-level `discord`
+key, **not** under `notifications`:
+
+```yaml
+discord:
+  bot_token: ${DISCORD_BOT_TOKEN}
+  channel_id: "1234567890"
+```
+
+See [`discord/README.md`](../../discord/README.md) for bot setup and the command
+surface.
+
+## Notes
+
+- Webhook URLs and bot tokens are secrets — supply them through environment
+  variables (`${VAR}` interpolation) or a Kubernetes Secret, never inline in a
+  committed `hive.yaml`.
+- Multiple channels can be enabled at once; each configured channel receives the
+  same alerts.


### PR DESCRIPTION
More [guide] fixes, verified against source.

- **Fixes #3223** — new `v2/docs/notifications.md`: operator guide for ntfy/Slack/Discord alert channels + the two-way Discord bot; linked from the docs index.
- **Fixes #3253** — new `discord/README.md`: documents the previously-undocumented Discord bot (setup, env vars, and the `!status`/`!kick`/`!pause`/`!resume` command surface read from `lib/command-router.js`).
- **Fixes #3218** — `agent-configuration.md` 'What to read next' pointed at external kubestellar.io URLs; now links the local docs index, architecture.md, and health-checks.md.

Docs-only.