### PR TITLE
🔒 sec(proxy): pin Redoc CDN + SRI on /api-docs (#3265)

### DIFF
--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node terminal_cookie_verify.test.js"
+    "test": "node server.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/redoc_pin.test.js
+++ b/v2/proxy/redoc_pin.test.js
@@ -1,0 +1,30 @@
+import { strict as assert } from 'assert';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+// Regression guard for the /api-docs Redoc supply-chain hardening: the CDN
+// script must be pinned to a specific version and carry a Subresource Integrity
+// hash, never the mutable 'latest' tag without SRI.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+
+assert.ok(
+  !/cdn\.redoc\.ly\/redoc\/latest\//.test(src),
+  "server.js must not load Redoc from the mutable 'latest' tag",
+);
+const script = src.match(/<script[^>]*cdn\.redoc\.ly\/redoc\/[^>]*>/);
+assert.ok(script, 'expected a Redoc <script> tag referencing cdn.redoc.ly');
+assert.ok(
+  /cdn\.redoc\.ly\/redoc\/v\d+\.\d+\.\d+\//.test(script[0]),
+  'Redoc script must be pinned to a specific vMAJOR.MINOR.PATCH version',
+);
+assert.ok(
+  /integrity="sha(256|384|512)-[A-Za-z0-9+/=]+"/.test(script[0]),
+  'Redoc script must carry a Subresource Integrity hash',
+);
+assert.ok(
+  /crossorigin=/.test(script[0]),
+  'Redoc script must set crossorigin for SRI to be enforced',
+);
+console.log('redoc_pin.test.js: OK');

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -217,7 +217,13 @@ app.get('/api-docs', (_req, res) => {
   <style>body { margin: 0; padding: 0; }</style>
 </head><body>
   <redoc spec-url="/api/openapi.json"></redoc>
-  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  <!-- Pinned to a specific Redoc version with a Subresource Integrity hash so a
+       compromise of the CDN or a silent 'latest'-tag update cannot execute
+       arbitrary script in the dashboard origin. crossorigin is required for SRI
+       to be enforced on a cross-origin script. -->
+  <script src="https://cdn.redoc.ly/redoc/v2.1.5/bundles/redoc.standalone.js"
+          integrity="sha384-0GrsyTQc9Oqd8h+b2dbc4XdR2T/DYpy0tLNNstyx+LBMUyiBbcWPbEs9aRmUcaxD"
+          crossorigin="anonymous"></script>
 </body></html>`);
 });
 


### PR DESCRIPTION
## Fixes #3265

`/api-docs` loaded Redoc from `cdn.redoc.ly/redoc/latest/` with no SRI — a CDN compromise or silent `latest` update could run arbitrary script in the dashboard origin (localStorage `DASHBOARD_TOKEN` + all API endpoints).

### Fix
- Pin to `redoc/v2.1.5` + `integrity="sha384-…"` + `crossorigin="anonymous"` so the browser refuses a mismatched bundle. CSP `script-src` still allows `cdn.redoc.ly` (source unchanged, now verified).
- New `redoc_pin.test.js` (wired into the proxy `test` script) asserts version-pinned + SRI + crossorigin and no `latest`.

### Follow-up (not in this PR)
The `script-src 'unsafe-inline'` directive needs a CSP nonce/hash refactor of the `DASHBOARD_TOKEN` inline injection — larger change, tracked separately.