### PR TITLE
🐛 test(agent): de-flake TestDismissInferencePrompts_NavigatesNegative (#3277)

### DIFF
--- a/v2/pkg/agent/launch_coverage_test.go
+++ b/v2/pkg/agent/launch_coverage_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -128,23 +129,44 @@ func TestDismissInferencePrompts_NavigatesNegative(t *testing.T) {
 	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
-	// Run dismissal briefly; flip the pane to ready shortly after so it returns.
-	go func() {
-		time.Sleep(1500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	}()
-
 	done := make(chan struct{})
 	go func() {
 		m.dismissInferencePrompts(agent)
 		close(done)
 	}()
+
+	// Flip the pane to the ready marker and keep re-asserting it until
+	// dismissInferencePrompts returns. A single send-keys/capture-pane can race
+	// with the poll loop under load, and the loop only acts on a *changed* pane
+	// (it skips a capture equal to the previous one), so re-emit a line that
+	// contains the ready marker AND a changing counter each interval. That
+	// guarantees at least one poll sees a changed pane carrying the marker,
+	// rather than depending on one perfectly-timed write.
+	stop := make(chan struct{})
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		n := 0
+		for {
+			n++
+			exec.Command("tmux", "send-keys", "-t", session, "-l",
+				fmt.Sprintf(": esc to interrupt [%d]", n)).Run()
+			exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
 	select {
 	case <-done:
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Error("dismissInferencePrompts should return after pane becomes ready")
 	}
+	close(stop)
 }
 
 // TestDismissInferencePrompts_BypassConsent covers the explicit bypass-consent


### PR DESCRIPTION
## Fixes #3277

The auto-filed **[Coverage] packages below 90%** issue is mislabeled — `pkg/agent` coverage is **91.1%**, above the 90% floor. The job FAIL came from a flaky test, `TestDismissInferencePrompts_NavigatesNegative` (~3-in-5 failures at `-race`), which the coverage cron reported as a coverage failure.

### Root cause (test timing)
The test flipped the tmux pane to the 'esc to interrupt' ready marker **once** at 1500ms and waited 10s. `dismissInferencePrompts` only acts on a *changed* pane, so under `-race` a single racy send-keys/capture-pane left the dismiss loop polling to the deadline.

### Fix
Re-emit the ready marker every 500ms **with a changing counter** until dismiss returns, so at least one poll always sees a changed pane carrying the marker. Widen the guard to 30s. Production `dismissInferencePrompts` unchanged — test-only.

### Verification
12× `-race` runs clean (was ~3-in-5 failing).