### PR TITLE
🐛 fix(config): accept org/repo form when re-adding repos (#3021)

### DIFF
--- a/v2/pkg/config/repo_target.go
+++ b/v2/pkg/config/repo_target.go
@@ -43,19 +43,19 @@ func ValidateProjectRepoTargets(org string, repos []string, primaryRepo, forgeHo
 		return issue("project.repos", "repo is empty — expected org/repo")
 	}
 	for _, repo := range repos {
-		if repoIssue := validateRepoName("project.repos", repo); repoIssue != nil {
+		if repoIssue := validateRepoName("project.repos", org, repo); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	if strings.TrimSpace(primaryRepo) != "" {
-		if repoIssue := validateRepoName("project.primary_repo", primaryRepo); repoIssue != nil {
+		if repoIssue := validateRepoName("project.primary_repo", org, primaryRepo); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	return nil
 }
 
-func validateRepoName(field, repo string) *RepoTargetIssue {
+func validateRepoName(field, org, repo string) *RepoTargetIssue {
 	repo = strings.TrimSpace(repo)
 	if repo == "" {
 		return issue(field, "repo is empty — expected org/repo")
@@ -64,7 +64,20 @@ func validateRepoName(field, repo string) *RepoTargetIssue {
 		return issue(field, "repo '"+repo+"' is a URL — expected repo name only so the target resolves to org/repo")
 	}
 	if strings.Contains(repo, "/") {
-		return issue(field, "repo '"+repo+"' contains '/' — expected repo name only so the target resolves to org/repo")
+		// A fully-qualified "<org>/<repo>" is accepted when the org prefix
+		// matches the configured project.org — it is unambiguously the same
+		// target, and the save path strips the prefix down to the bare name.
+		// This is what a user naturally types/pastes when re-adding an existing
+		// repo from the Governor → Repos page (issue #3021). Anything else
+		// (a different org, a trailing slash, or multiple slashes) is still a
+		// misconfiguration.
+		org = strings.TrimSpace(org)
+		prefix := org + "/"
+		bare := strings.TrimPrefix(repo, prefix)
+		if org != "" && strings.HasPrefix(repo, prefix) && bare != "" && !strings.Contains(bare, "/") {
+			return nil
+		}
+		return issue(field, "repo '"+repo+"' contains '/' — expected repo name only (or '"+org+"/<repo>') so the target resolves to org/repo")
 	}
 	return nil
 }

--- a/v2/pkg/config/repo_target_test.go
+++ b/v2/pkg/config/repo_target_test.go
@@ -60,22 +60,29 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 			org:   "kubestellar",
 			repos: []string{"hive/"},
 			forge: "github.com",
-			want:  "Repo target misconfigured: repo 'hive/' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+			want:  "Repo target misconfigured: repo 'hive/' contains '/' — expected repo name only (or 'kubestellar/<repo>') so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
-			name:  "repo contains slash",
+			name:  "repo contains slash for a different org",
 			org:   "kubestellar",
 			repos: []string{"other/hive"},
 			forge: "github.com",
-			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only (or 'kubestellar/<repo>') so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
-			name:    "primary contains slash",
+			// #3021: re-adding an existing repo as "<org>/<repo>" where the org
+			// matches project.org is unambiguous and must be accepted.
+			name:  "repo qualified with matching org accepted",
+			org:   "kubestellar",
+			repos: []string{"kubestellar/hive"},
+			forge: "github.com",
+		},
+		{
+			name:    "primary qualified with matching org accepted",
 			org:     "kubestellar",
 			repos:   []string{"hive"},
 			primary: "kubestellar/hive",
 			forge:   "github.com",
-			want:    "Repo target misconfigured: repo 'kubestellar/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
 			name:  "full url pasted into org",


### PR DESCRIPTION
## Fixes #3021

Reported by `bketelsen` on a k3s deployment: adding a repo from **Governor → Repos** re-validates the existing repos and rejects them because `ValidateProjectRepoTargets` refused any repo containing a `/`. A user who types or re-adds an existing repo as `myorg/myrepo` (the natural form) got `repo 'myorg/myrepo' contains '/' — expected repo name only`, even though it names exactly the configured target.

### Fix
Accept the fully-qualified `<org>/<repo>` form **when the org prefix equals the configured `project.org`** — it's unambiguous, and the save handler (`api.go`) already strips the prefix to the bare name before storing. Anything else (a different org, a trailing slash, or multiple slashes) stays rejected, preserving the one-org model.

- `validateRepoName` now takes the configured `org` to make that decision.
- Tests: added `kubestellar/hive` (repos + primary) as **accepted**; kept `other/hive` and `hive/` as **rejected** (message updated to mention the accepted form).

Docs/behavior: no schema change; the stored config still holds bare repo names.