### PR TITLE
📖 docs: document curator schedule wiring and trigger path

### DIFF
--- a/v2/docs/knowledge-curator.md
+++ b/v2/docs/knowledge-curator.md
@@ -20,7 +20,7 @@ knowledge:
 
 | Field | Current behavior in v2 HEAD |
 | --- | --- |
-| `schedule` | Defaults to `daily` when knowledge is enabled. The config field is stored for the scheduled curator flow described in the design docs; v2 HEAD does not enforce a parser here, so use simple operator conventions such as `daily` until your deployment wires a scheduler. |
+| `schedule` | Defaults to `daily` when knowledge is enabled. The value is stored as `CuratorConfig.Schedule`. No scheduler in v2 HEAD parses or actions it. Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly; see [Scheduling extraction](#scheduling-extraction). |
 | `extract_from` | Sources the curator should inspect. Implemented sources are `pr_comments` and `review_comments`. `ci_failures` appears in the example config/design but is not currently extracted by `Curator.extractFromPR`. |
 | `auto_promote_threshold` | Defaults to `0.9` when knowledge is enabled. `Promoter.AutoPromoteCandidates` selects facts whose llm-wiki page has `status == "verified"` and `confidence >= threshold`. |
 
@@ -37,5 +37,19 @@ The classifier is heuristic. It emits candidates for comments containing signals
 - `decided`, `agreed`, `going forward`, `from now on` → decisions.
 
 Extracted facts are sent to the wiki `/api/ingest` endpoint. Promotion only flows upward (for example project → org), preserving provenance in the promoted fact.
+
+## Scheduling extraction
+
+Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly. No scheduler, CLI command, or HTTP endpoint triggers extraction in v2 HEAD.
+
+A Go caller builds a `Curator` with `NewCurator(ghClient, wikiURL, org, repos, config, logger)`. The caller calls `RunExtraction(ctx, since)` with a `since` time. The caller then calls `Ingest(ctx, facts)`. The call POSTs the facts to the wiki `/api/ingest` endpoint:
+
+```go
+c := NewCurator(ghClient, wikiURL, org, repos, config, logger)
+facts, err := c.RunExtraction(ctx, since)
+err = c.Ingest(ctx, facts)
+```
+
+The design doc `v2/docs/design/knowledge-system.md` plans a `scheduler.RunCurator(schedule)` wiring with a daily or on-merge trigger. This wiring is not implemented in v2 HEAD. The programmatic path above is the only way to run extraction today.
 
 See [Knowledge system design](design/knowledge-system.md) for architecture context; this page documents the implemented operator-facing knobs.


### PR DESCRIPTION
Fixes #3286

## What changed

`v2/docs/knowledge-curator.md` claimed the `schedule` field works with
"simple operator conventions such as `daily`". In v2 HEAD the value is
stored and defaulted to `daily`, but no scheduler parses or actions it.
The doc implied the value was enforced, which it is not.

This change:

- rewrites the `schedule` field-table row: the value is stored as
  `CuratorConfig.Schedule` and no scheduler in v2 HEAD parses or actions
  it;
- removes the misleading "use simple operator conventions such as
  `daily`" phrase;
- adds a "Scheduling extraction" section documenting the only trigger
  path that exists today: Go code that builds a `Curator` with
  `NewCurator`, then calls `RunExtraction(ctx, since)` and
  `Ingest(ctx, facts)`;
- points to the planned `scheduler.RunCurator(schedule)` wiring in
  `v2/docs/design/knowledge-system.md`, which is not implemented.

## Why

Operators cannot wire an external scheduler today: there is no CLI
command, no HTTP endpoint, and no scheduler slot that runs extraction.
Documenting a CronJob would describe something that does not exist.
The doc now states the current behavior and the programmatic trigger
path instead.

## How tested

Not run (docs only). The Go signatures quoted were verified against
`v2/pkg/knowledge/curator.go`; the design-doc reference was verified
against `v2/docs/design/knowledge-system.md`.

---

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke