### PR TITLE
🐛 fix(gh-wrapper): derive contributor mode from trusted image marker

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -18,6 +18,14 @@ set -euo pipefail
 
 REAL_GH="/usr/bin/gh"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
+HIVE_CONTRIBUTOR_MODE_MARKER="${HIVE_CONTRIBUTOR_MODE_MARKER:-/etc/hive/contributor-mode}"
+
+# Contributor mode comes from a root-owned marker file at the image
+# boundary. The env var HIVE_CONTRIBUTOR_MODE is caller-controlled and
+# must never switch token injection or PR routing.
+_contributor_mode() {
+  [[ -f "$HIVE_CONTRIBUTOR_MODE_MARKER" ]]
+}
 
 # Guard: if the real gh binary is not installed, tell the agent to use MCP instead.
 if [[ ! -x "$REAL_GH" ]]; then
@@ -35,7 +43,7 @@ fi
 # Contributors keep their personal token — they fork+PR with their own identity.
 GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
 TOKEN_ACCESS_LOG="/var/run/hive-metrics/token-access.jsonl"
-if [[ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]]; then
+if ! _contributor_mode; then
   # Per-agent scoped token (Phase 4) — 0600, owned by agent UID, least-privilege.
   if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
     export GH_TOKEN="$(cat "$HIVE_AGENT_TOKEN_CACHE")"
@@ -50,7 +58,7 @@ if [[ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]]; then
 fi
 
 # Contributor mode — extra restrictions for remote contributor agents
-if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
+if _contributor_mode; then
   case "$*" in
     *"auth "*)
       echo "⛔ BLOCKED: gh auth is disabled for contributor agents." >&2
@@ -214,7 +222,7 @@ if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" 
       echo "Use --author @me or your authenticated login to list your own items." >&2
       exit 1
     fi
-  elif [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
+  elif _contributor_mode; then
     : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356).
   else
     echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
@@ -243,7 +251,7 @@ ADVISORY_ISSUE="${HIVE_ADVISORY_ISSUE:-}"
 # SAME ACMM write-gate + forge-resistance, so this changes WHO opens the PR, not
 # WHAT an agent is allowed to do. Contributors are EXEMPT: they fork and PR under
 # their OWN identity by design, so their gh pr create must pass through unchanged.
-if [ "$subcmd" = "pr" ] && [ "$action" = "create" ] && [ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]; then
+if [ "$subcmd" = "pr" ] && [ "$action" = "create" ] && ! _contributor_mode; then
   if command -v hive-open-pr >/dev/null 2>&1; then
     # Pass the original gh-pr-create flags straight through — hive-open-pr accepts
     # the same --repo/--head/--base/--title/--body shape and ignores the rest.
@@ -467,7 +475,7 @@ if [ "$subcmd" = "api" ]; then
   # Any mutating gh api (POST/PATCH/PUT/DELETE) stays blocked for contributor
   # agents — the read/write split opens READS only, never writes. Non-contributor
   # hive agents keep their existing write paths (governed by mode/ACMM gates above).
-  if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]] && [ "$api_method" != "GET" ]; then
+  if _contributor_mode && [ "$api_method" != "GET" ]; then
     echo "⛔ BLOCKED: mutating gh api (${api_method}) is disabled for contributor agents." >&2
     exit 1
   fi
@@ -537,7 +545,7 @@ if [[ -n "$AGENT_NAME" ]]; then
   LABELS_CSV="agent/${AGENT_DISPLAY_NAME}"
   [[ -n "$HIVE_INSTANCE_ID" ]] && LABELS_CSV="${LABELS_CSV},hive/${HIVE_INSTANCE_ID}"
   # Contributor labels
-  if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
+  if _contributor_mode; then
     [[ -n "${HIVE_CONTRIBUTOR_USERNAME:-}" ]] && LABELS_CSV="${LABELS_CSV},contributor/${HIVE_CONTRIBUTOR_USERNAME}"
     [[ -n "${HIVE_CONTRIBUTOR_CLI:-}" ]] && LABELS_CSV="${LABELS_CSV},cli/${HIVE_CONTRIBUTOR_CLI}"
   fi

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -51,10 +51,12 @@ _run_test() {
   shift 2
 
   local output rc=0
+  rm -f "${WORK_DIR}/no-contributor-marker"
   output="$(env \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
@@ -77,10 +79,12 @@ _run_test_spoof() {
   shift 2
 
   local output rc=0
+  rm -f "${WORK_DIR}/no-contributor-marker"
   output="$(env \
     HIVE_AGENT="octocat" \
     HIVE_AGENT_DISPLAY_NAME="octocat" \
     HIVE_AGENT_ID="scanner" \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     MOCK_GH_LOGIN="scanner[bot]" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
@@ -103,10 +107,12 @@ _run_test_identity_failure() {
   shift 2
 
   local output rc=0
+  rm -f "${WORK_DIR}/no-contributor-marker"
   output="$(env \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     MOCK_GH_FAIL_IDENTITY="true" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
@@ -129,10 +135,12 @@ _run_test_cached_env_spoof() {
   shift 2
 
   local output rc=0
+  rm -f "${WORK_DIR}/no-contributor-marker"
   output="$(env \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     HIVE_AUTH_LOGIN_CACHED="octocat" \
     MOCK_GH_LOGIN="test-bot[bot]" \
     GH_TOKEN="test-token-mock" \
@@ -156,8 +164,10 @@ _run_test_contributor() {
   shift 2
 
   local output rc=0
+  touch "${WORK_DIR}/contributor-marker"
   output="$(env \
     HIVE_CONTRIBUTOR_MODE="true" \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/contributor-marker" \
     HIVE_CONTRIBUTOR_USERNAME="test-contributor" \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
@@ -165,6 +175,65 @@ _run_test_contributor() {
     MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+  rm -f "${WORK_DIR}/contributor-marker"
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_env_only() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  rm -f "${WORK_DIR}/no-contributor-marker"
+  output="$(env \
+    HIVE_CONTRIBUTOR_MODE="true" \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_marker_only() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  touch "${WORK_DIR}/contributor-marker"
+  output="$(env \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/contributor-marker" \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+  rm -f "${WORK_DIR}/contributor-marker"
 
   if [[ "$rc" != "$expected_rc" ]]; then
     echo "FAIL: $desc"
@@ -275,6 +344,15 @@ _run_test_contributor 1 "issue list contributor mode --author unverified contrib
 
 MOCK_GH_LOGIN="test-contributor" _run_test_contributor 0 "issue list contributor mode --author verified contributor token login (allowed)" \
   issue list --repo test/repo --author test-contributor
+
+echo ""
+echo "=== Marker trust boundary regression tests ==="
+
+_run_test_env_only 1 "issue list with HIVE_CONTRIBUTOR_MODE=true but no marker (blocked, env var ignored)" \
+  issue list --repo test/repo
+
+_run_test_marker_only 0 "issue list with marker present and no env var (allowed, marker alone grants contributor mode)" \
+  issue list --repo test/repo
 
 echo ""
 echo "Results: ${PASSED} passed, ${FAILED} failed"

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -111,8 +111,10 @@ COPY config/restrictions/contributor-default.json /etc/hive/restrictions/
 RUN chmod +x /usr/local/bin/contributor-agent.sh /usr/local/bin/contributor-relay.sh \
     /usr/local/bin/agent-launch.sh /usr/local/bin/gh
 
+# Contributor mode is a root-owned marker file, not a caller-controlled env var.
+RUN mkdir -p /etc/hive && touch /etc/hive/contributor-mode
+
 ENV NODE_PATH=/opt/hive/node_modules
-ENV HIVE_CONTRIBUTOR_MODE=true
 USER dev
 WORKDIR /home/dev
 


### PR DESCRIPTION
Fixes #3280

## Summary

- Removes `HIVE_CONTRIBUTOR_MODE` from the wrapper's trust model. The env var is caller-controlled and any agent process could set it to change token injection, `gh pr create` routing, list gating, api write blocking, and labels.
- Adds `_contributor_mode()`, which reads a root-owned marker file at `/etc/hive/contributor-mode`.
- The contributor image creates the marker at build time. The agent image never creates it.
- The env var now has no effect on wrapper behavior.

## Trust model

Contributor mode comes from the image boundary, not from the process environment. A caller can no longer flip the mode with `HIVE_CONTRIBUTOR_MODE=true gh ...`.

The marker path is overridable via `HIVE_CONTRIBUTOR_MODE_MARKER` for tests and deployments.

## Tests

- `bash -n bin/gh-wrapper.sh`
- `bash -n bin/gh-wrapper.test.sh`
- `bash bin/gh-wrapper.test.sh` — 33 passed, 0 failed

New regression tests cover both directions: env var without marker stays blocked, marker alone grants contributor mode.

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke