### PR TITLE
✨ feat(gateways): add Groq as a preset gateway kind (#3304)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -677,6 +677,7 @@ type GatewayConfig struct {
 // gatewayKind values.
 const (
 	GatewayKindOpenRouter = "openrouter"
+	GatewayKindGroq       = "groq"
 	GatewayKindLiteLLM    = "litellm"
 	GatewayKindVLLM       = "vllm"
 	GatewayKindLLMD       = "llm-d"

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -93,6 +93,7 @@ const (
 // accepted and treated as custom (the endpoint is what actually routes).
 var validGatewayKinds = map[string]bool{
 	config.GatewayKindOpenRouter: true,
+	config.GatewayKindGroq:       true,
 	config.GatewayKindLiteLLM:    true,
 	config.GatewayKindVLLM:       true,
 	config.GatewayKindLLMD:       true,

--- a/v2/pkg/dashboard/gateways_test.go
+++ b/v2/pkg/dashboard/gateways_test.go
@@ -205,3 +205,15 @@ func TestGatewaysUpsert_PreservesKeyOnEdit(t *testing.T) {
 		t.Errorf("default_model not updated: %q", gw.DefaultModel)
 	}
 }
+
+// TestGroqIsValidGatewayKind guards the Groq gateway support (#3304): Groq is an
+// OpenAI-compatible endpoint, so it only needs to be an accepted kind with its
+// preset base URL — no special token minting like watsonx.
+func TestGroqIsValidGatewayKind(t *testing.T) {
+	if !validGatewayKinds[config.GatewayKindGroq] {
+		t.Fatal("groq must be an accepted gateway kind so the Governor → Gateways form can save it")
+	}
+	if config.GatewayKindGroq != "groq" {
+		t.Fatalf("GatewayKindGroq = %q, want \"groq\"", config.GatewayKindGroq)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14994,6 +14994,7 @@ function burnAreaChart() {
     // fills it (self-hosted / custom). OpenRouter has a well-known base URL.
     const GATEWAY_PRESETS = [
       { kind: 'openrouter', label: 'OpenRouter', endpoint: 'https://openrouter.ai/api/v1' },
+      { kind: 'groq',       label: 'Groq',       endpoint: 'https://api.groq.com/openai/v1' },
       { kind: 'litellm',    label: 'LiteLLM',    endpoint: '' },
       { kind: 'vllm',       label: 'vLLM',       endpoint: '' },
       { kind: 'llm-d',      label: 'llm-d',      endpoint: '' },


### PR DESCRIPTION
## Fixes #3304

Requested by `enricom8` — use Groq's inference platform via a gateway config.

Groq exposes an **OpenAI-compatible** API, so it fits the generic model-gateway path with no special handling (unlike watsonx, which mints an IAM token). It worked already via a Custom gateway; this adds a dedicated preset so users get the right default endpoint and a labeled dropdown entry.

- `GatewayKindGroq = "groq"` constant
- Added `groq` to `validGatewayKinds` (the save-time allowlist)
- UI preset: `{ kind: 'groq', label: 'Groq', endpoint: 'https://api.groq.com/openai/v1' }`
- No `cost.go` change: Groq has no native-spend API, so it uses the estimated-cost path like vllm/llm-d/custom
- Test: `groq` is an accepted kind

Users supply their own Groq API key in the gateway form as usual.