### PR TITLE
🐛 fix(dashboard): config modal Model dropdown uses live discovery (#3319)

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -16234,6 +16234,13 @@ function burnAreaChart() {
     function renderAgentGeneral(g) {
       const agentName = _configState.agent || '';
       const isCreate = _configState.isCreate === true;
+      // Model options must come from live discovery for THIS agent's backend, not
+      // the frozen KNOWN_MODELS placeholder (#3319). Resolve the agent's actual
+      // backend from the live agent list; fall back to its pinned backend or an
+      // empty backend (modelsForBackend then yields the safe default list).
+      const _liveAgent = (window._lastAgents || []).find(a => a.name === agentName);
+      const _agentBackend = (_liveAgent && _liveAgent.cli) || g.cliPinValue || '';
+      const _modelOpts = modelsForBackend(_agentBackend) || [];
       let html = '';
       if (isCreate) {
         html += `<div class="config-field">
@@ -16364,7 +16371,8 @@ function burnAreaChart() {
           <label>Model <span class="config-info">i<span class="config-tooltip">Override the LLM model for this agent. Select "(from launch command)" to let the CLI choose its default. The governor may downgrade models automatically when budget is tight, unless Model Lock is enabled in Governor Health settings.</span></span></label>
           <select id="cfg-model" onchange="markDirty('general','model',this.value)">
             <option value="">(from launch command)</option>
-            ${KNOWN_MODELS.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
+            ${_modelOpts.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
+            ${(g.model && !_modelOpts.some(m => _modelsEqual(g.model, m.value))) ? `<option value="${esc(g.model)}" selected>${esc(g.model)} (current)</option>` : ''}
           </select>
         </div>
         <div class="config-field">


### PR DESCRIPTION
## Fixes #3319

Reported by `bketelsen`. The agent **config modal** built its Model dropdown from the frozen `KNOWN_MODELS` placeholder (an alias of pre-discovery `COPILOT_CLI_MODELS`), so it showed a stale list (topping out at `claude-opus-4.6` / `gpt-5.4`) and never reflected the live catalog `/api/config/backends` returns — even though the agent **card's** inline dropdown already did it right via `modelsForBackend()` / `BACKEND_MODELS`.

### Fix
- Resolve the agent's actual backend from the live agent list (`window._lastAgents` by `_configState.agent`, falling back to the pinned backend), and build options from `modelsForBackend()` — the same live path the card uses.
- Secondary wart the reporter flagged: a currently-pinned model not in the discovered list is now added as a `(current)` option so it stays selectable/re-savable instead of silently dropping.

JS syntax verified; dashboard tests pass.