### PR TITLE
sync: merge v2 into dd (top-up, 72 commits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,19 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 ## How we maintain this file
 
 - Add entries under `Unreleased` for user-visible features, fixes, security changes, migrations, deprecations, and breaking changes.
-- Move entries into a dated release section when a release is cut.
+- Move entries into a dated release section when a release is cut. If the repository has no release tag for the change, use the merge date rather than inventing a version.
 - Link issues or PRs when useful, but keep entries readable for operators who are not following every PR.
 - Do not include routine refactors, test-only changes, or dependency churn unless they affect users.
 
 ## Unreleased
 
+No notable user-facing changes have been recorded since the dated entries below.
+
+## 2026-08-10
+
 ### Added
 
 - Contributor onboarding, governance, templates, and local development documentation for the `v2` Go codebase.
-
-## Recent v2 notable changes
-
-### Added
-
 - Timezone-aware time-of-day governor cadences so hives can vary agent activity by local operating windows.
 - Merger contributor tier and configurable automerge queue/label behavior for safer merge delegation.
 - ClankeR contributor role claiming and owner-assigned agent-role grants.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for helping improve KubeStellar Hive. This guide is for contributing code and documentation to this repository. If you want to donate compute to a running hive, see [Contribute to a Hive](README.md#contribute-to-a-hive) instead.
 
+**New here?** Start with the [getting-started guide for first-time contributors](docs/getting-started-contributing.md) — it walks the end-to-end journey (finding an issue, local setup, testing without a cluster, key concepts, and what the review/CI process looks like) and links back into this guide for the mechanics.
+
 ## Where to work
 
 - Open issues and pull requests in this repository. Use the issue templates when they are available, and link related issues from the PR body.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for helping improve KubeStellar Hive. This guide is for contributing c
   - `v2/deploy/` and `v2/examples/` — deployment manifests and example configuration.
   - `v2/docs/` — architecture and operator/developer reference material.
   - `v2/test/` — integration and regression tests.
-- `bin/` — shell helpers used by the existing automation and maintainer workflows.
+- `bin/` — deterministic pipeline, supervision, enforcement, deployment, and maintainer helper scripts. See [`bin/README.md`](bin/README.md) for the script-by-script index.
 - `config/hive-project.yaml.example` — project metadata for the top-level
   deterministic shell pipeline; see [config/README.md](config/README.md). This
   is separate from the v2 Go runtime config in `v2/hive.yaml.example`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,9 @@ Thank you for helping improve KubeStellar Hive. This guide is for contributing c
   - `v2/docs/` — architecture and operator/developer reference material.
   - `v2/test/` — integration and regression tests.
 - `bin/` — shell helpers used by the existing automation and maintainer workflows.
+- `config/hive-project.yaml.example` — project metadata for the top-level
+  deterministic shell pipeline; see [config/README.md](config/README.md). This
+  is separate from the v2 Go runtime config in `v2/hive.yaml.example`.
 - `dashboard/`, `docs/`, `config/`, `systemd/`, `launchd/`, and top-level scripts — supporting assets for hub, dashboard, installation, and operational workflows.
 - `Justfile` — contributor relay recipes; see [Just recipes](docs/development.md#just-recipes).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,24 @@ go test ./...
 
 The Go version is declared in [`v2/go.mod`](v2/go.mod). Install that version or newer compatible tooling before building.
 
+## Contributor `just` recipes
+
+The root [`Justfile`](Justfile) exposes the public contributor relay workflow. Run `just --list` to see the current recipe signatures; private implementation details are intentionally not listed there.
+
+| Recipe | What it does |
+| --- | --- |
+| `just contribute-check <backend>` | Runs the same read-only backend CLI preflight used by setup, then reports whether the machine is ready for `contribute-setup`. |
+| `just contribute-setup <backend>` | Checks the Justfile version, verifies the backend CLI, signs in with GitHub, registers with the configured hub, and writes `${HOME}/.config/hive/contributor.env`. |
+| `just contribute-hive [backend] [mode]` | Starts the contributor relay. The default mode is containerized; pass `local` as the mode to run natively when the local tools are installed. |
+| `just contribute-status` | Queries the configured hub for status and contributor profile information. |
+| `just contribute-browse` | Discovers available public hive projects. |
+| `just contribute-stop` | Stops a background contributor relay if one is running. |
+| `just contribute-k8s [namespace] [outfile] [image_tag]` | Emits Kubernetes manifests for a headless contributor workload. It writes to stdout or the requested file; it does not apply the manifest. |
+| `just hive-api <endpoint>` | Calls a hub API endpoint, defaulting to `/status`, using the configured hive URL. |
+| `just hive-api-docs` | Opens the hub API documentation in a browser. |
+
+See [v2/docs/contributor-relay.md](v2/docs/contributor-relay.md) for the end-to-end contributor relay workflow and Kubernetes workload details.
+
 ## Style and quality
 
 - Format Go changes with `gofmt`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ The repository includes `githooks/post-checkout`. Install it only if you want th
 git config core.hooksPath githooks
 ```
 
-The hook runs after branch checkouts in the primary worktree. It prevents that worktree from staying on a branch other than `main` by printing guidance and checking `main` back out. It is intended for long-running dashboard checkouts where feature work should happen in separate `git worktree add ...` directories. It does not run for file checkouts. Because `core.hooksPath` can apply beyond the primary checkout, install it only in the checkout you want protected; if it fires somewhere else, remove or override that hooksPath setting there.
+The hook runs after branch checkouts in the primary worktree. It prevents that worktree from staying on a branch other than `main` by printing guidance and checking `main` back out. It is intended for long-running dashboard checkouts where feature work should happen in separate `git worktree add ...` directories. It does not run for file checkouts or linked worktrees, because linked worktrees have a `.git` file instead of a `.git` directory.
 
 If the hook is not installed, normal Git behavior applies. If it blocks a checkout unexpectedly, use a separate worktree from an unprotected checkout or remove the hooksPath setting for repositories where the guard is not desired.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ docker compose up -d
 
 Dashboard at `http://localhost:3001`.
 
+The pre-built image tag is documented in [v2/docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest](v2/docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest).
+
 To build from source instead of pulling the pre-built image:
 
 ```bash
@@ -178,7 +180,7 @@ kubectl apply -f v2/deploy/k8s/service.yaml
 
 ## Configuration
 
-All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [v2/hive.yaml.example](v2/hive.yaml.example) for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [v2/hive.yaml.example](v2/hive.yaml.example) for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/AGENT-DEFINITION.md](v2/AGENT-DEFINITION.md) for the portable agent YAML format, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
 
 The top-level deterministic shell pipeline uses a separate project file,
 `config/hive-project.yaml.example`; see [config/README.md](config/README.md)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ docker compose up -d
 
 The [Hive Hub](https://hive.kubestellar.io) provides hosted hives with OAuth-protected dashboards, a public registry, and cross-hive leaderboards. No cluster required.
 
+If you need to run your own private hub instead, see the v2
+[self-hosted hub deployment guide](v2/docs/hub-deployment.md).
+
 ### Self-Hosted Deployment
 
 #### 1. Create the namespace
@@ -175,7 +178,11 @@ kubectl apply -f deploy/k8s/service.yaml
 
 ## Configuration
 
-All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+
+The top-level deterministic shell pipeline uses a separate project file,
+`config/hive-project.yaml.example`; see [config/README.md](config/README.md)
+before running the top-level `bin/` scripts directly.
 
 ```yaml
 project:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you need to run your own private hub instead, see the v2
 #### 1. Create the namespace
 
 ```bash
-kubectl apply -f deploy/k8s/namespace.yaml
+kubectl apply -f v2/deploy/k8s/namespace.yaml
 ```
 
 Or manually:
@@ -74,7 +74,7 @@ kubectl -n hive create secret generic hive-secrets \
 #### 3. Create ConfigMap from hive.yaml
 
 ```bash
-cp hive.yaml.example hive.yaml
+cp v2/hive.yaml.example hive.yaml
 # Edit hive.yaml: set your org, repos, agents, and governor config
 
 kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
@@ -85,7 +85,7 @@ kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
 Apply the provided PVC manifest:
 
 ```bash
-kubectl apply -f deploy/k8s/pvc.yaml
+kubectl apply -f v2/deploy/k8s/pvc.yaml
 ```
 
 The default PVC requests 10Gi with `ReadWriteOnce`. For zero-downtime rollouts with rolling updates, use an NFS-backed StorageClass with `ReadWriteMany`:
@@ -108,8 +108,8 @@ spec:
 #### 5. Deploy
 
 ```bash
-kubectl apply -f deploy/k8s/deployment.yaml
-kubectl apply -f deploy/k8s/service.yaml
+kubectl apply -f v2/deploy/k8s/deployment.yaml
+kubectl apply -f v2/deploy/k8s/service.yaml
 ```
 
 The deployment runs a single replica with liveness and readiness probes on `/api/health`. Resource defaults: 500m CPU / 512Mi memory (requests), 2 CPU / 2Gi memory (limits).
@@ -151,13 +151,13 @@ Long timeouts are needed for SSE streaming connections to the dashboard.
 #### Quick apply (all manifests)
 
 ```bash
-kubectl apply -f deploy/k8s/namespace.yaml
+kubectl apply -f v2/deploy/k8s/namespace.yaml
 kubectl -n hive create secret generic hive-secrets \
   --from-literal=HIVE_GITHUB_TOKEN=ghp_...
 kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
-kubectl apply -f deploy/k8s/pvc.yaml
-kubectl apply -f deploy/k8s/deployment.yaml
-kubectl apply -f deploy/k8s/service.yaml
+kubectl apply -f v2/deploy/k8s/pvc.yaml
+kubectl apply -f v2/deploy/k8s/deployment.yaml
+kubectl apply -f v2/deploy/k8s/service.yaml
 ```
 
 ### Ports
@@ -178,7 +178,7 @@ kubectl apply -f deploy/k8s/service.yaml
 
 ## Configuration
 
-All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
+All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [v2/hive.yaml.example](v2/hive.yaml.example) for the full reference, [v2/docs/env-vars.md](v2/docs/env-vars.md) for the centralized environment variable reference, [v2/docs/agent-configuration.md](v2/docs/agent-configuration.md) for agent configuration, [v2/docs/supervisor.md](v2/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, and [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration.
 
 The top-level deterministic shell pipeline uses a separate project file,
 `config/hive-project.yaml.example`; see [config/README.md](config/README.md)

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,95 @@
+# `bin/` — deterministic pipeline scripts
+
+The shell/Python scripts that make up Hive's **deterministic pipeline** — the
+non-LLM layer that filters, classifies, gates, and enforces before any agent is
+kicked, plus the operational helpers that launch agents, wrap `gh`, and keep
+sessions alive. Agents handle judgment; these scripts handle everything that
+should be deterministic.
+
+Most are invoked by the hive process, the governor, or `run-pipeline.sh` rather
+than run by hand. Each script's own header comment is the authoritative
+description; this index is a map.
+
+## Pipeline (pre-kick stages)
+
+| Script | Purpose |
+|--------|---------|
+| `run-pipeline.sh` | Execute the pre-kick pipeline stages in dependency order. |
+| `enumerate-actionable.sh` | Canonical enumerator for actionable issues and PRs. |
+| `issue-classifier.sh` | Pre-classify actionable issues with deterministic metadata. |
+| `architecture-detector.sh` | Detect issues needing architecture review / lane transfer. |
+| `pr-cluster-detector.sh` | Group related actionable issues into clusters for bundled dispatch. |
+| `contributor-dispatcher.sh` | Report contributor assignment state. |
+| `merge-gate.sh` | Determine which open PRs are eligible for merge. |
+| `conflict-sweeper.sh` | Rebase or close CONFLICTING PRs. |
+
+## Agent lifecycle
+
+| Script | Purpose |
+|--------|---------|
+| `agent-launch.sh` | Unified launcher for any AI coding CLI backend. |
+| `supervisor.sh` | Keep a tmux session alive with an AI CLI agent inside. |
+| `supervisor-kick.sh` | Reliable agent session restart + kick (Copilot backend). |
+| `agent-healthcheck.sh` | Stall detector + auto-respawn + ntfy push. |
+| `kick-agents.sh` | Fire work orders at the scanner/ci-maintainer/architect/outreach sessions. |
+| `kick-governor.sh` | Adaptive kick governor for supervised agents. |
+| `supervisor-kick.sh` | Session restart + kick helper. |
+| `kick-outcome-tracker.sh` | Correlate governor kicks with queue/MTTR/token outcomes. |
+| `ttyd-tmux.sh` | Wrapper for ttyd → tmux (disables mouse mode for the browser). |
+
+## GitHub access and safety
+
+| Script | Purpose |
+|--------|---------|
+| `gh-wrapper.sh` | `gh` wrapper — enforces per-agent + global restrictions and injects the App token. |
+| `gh-app-token.sh` | Generate a GitHub App installation token for the hive. |
+| `git-credential-hive.sh` | Git credential helper using the GitHub App token. |
+| `hive-open-pr.sh` | Open a PR via the App bot (not `gh pr create`). |
+| `gh-rate-check.sh` | Scan agent tmux panes for GitHub API rate-limit messages. |
+| `gh-zombie-reaper.sh` | Kill `gh` API processes older than `MAX_AGE_SECONDS`. |
+| `copilot-comment-checker.sh` | Pre-fetch unaddressed Copilot review comments. |
+| `setup-proxy-iptables.sh` | Force all GitHub HTTPS traffic through the ACMM proxy. |
+
+## Contributor relay (ClankeR)
+
+| Script | Purpose |
+|--------|---------|
+| `contributor-relay.sh` | ClankeR — the WebSocket client connecting a contributor agent to the hub. |
+| `contributor-agent.sh` | Entrypoint for the contributor container. |
+
+## Metrics, notifications, tokens
+
+| Script | Purpose |
+|--------|---------|
+| `token-collector.sh` | Correlate bead data with token usage for per-issue cost attribution. |
+| `token-usage.py` | Token usage aggregator for Hive agents. |
+| `notify.sh` | Shared notification library for hive scripts. |
+| `federation-heartbeat.sh` | Periodically send this hive's live stats to the federation. |
+| `outreach-tracker.sh` | Track outreach PRs opened/merged on external repos. |
+| `ga4-anomaly-detector.sh` | Pre-compute GA4 error anomalies for the ci-maintainer agent. |
+| `copilot-models.mjs` | List Copilot models available to this machine's auth (via `@github/copilot-sdk`). |
+
+## Setup and deployment
+
+| Script | Purpose |
+|--------|---------|
+| `hive.sh` | KubeStellar AI hive entrypoint. |
+| `hive-config.sh` | Shared config reader for all hive scripts. |
+| `hive-setup.sh` | Bootstrap a fresh Ubuntu 24.04 LXC into a Hive v2 instance (Docker). |
+| `hive-prereq-check.sh` | Validate prerequisites for a Docker-based Hive v2 deployment. |
+| `hive-deploy.sh` | Pull the latest hive repo and sync scripts to `/usr/local/bin`. |
+
+## Strategy Lab (Nous)
+
+| Script | Purpose |
+|--------|---------|
+| `nous-install.sh` | Install the Nous framework into `/opt/nous` (venv-based). |
+| `nous-runner.sh` | Strategist helper — invokes the real Nous framework. |
+| `nous-hive-gate.py` | Custom Nous Gate — bridges experiment-approval decisions into Hive. |
+| `nous-sync.py` | Analyst helper — reads Nous output and syncs findings to the dashboard. |
+
+## Tests
+
+`*.test.sh` / `*.test.js` files are regression tests for the scripts alongside
+them (e.g. `gh-wrapper.test.sh`, `contributor-agent.test.sh`,
+`contributor-relay.test.js` — the last is JavaScript despite the extension).

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,95 +1,85 @@
-# `bin/` — deterministic pipeline scripts
+# `bin/` script index
 
-The shell/Python scripts that make up Hive's **deterministic pipeline** — the
-non-LLM layer that filters, classifies, gates, and enforces before any agent is
-kicked, plus the operational helpers that launch agents, wrap `gh`, and keep
-sessions alive. Agents handle judgment; these scripts handle everything that
-should be deterministic.
+The scripts in this directory are the deterministic shell/Node/Python layer around Hive's agent runtime. They enumerate work, classify it, gate merges, enforce GitHub permissions, launch/supervise CLIs, and publish operational telemetry before an LLM is asked to act.
 
-Most are invoked by the hive process, the governor, or `run-pipeline.sh` rather
-than run by hand. Each script's own header comment is the authoritative
-description; this index is a map.
+Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy.sh`; several write machine-readable state under `/var/run/hive-metrics` for the dashboard, governor, and agent prompts. For the architecture context, see [`v2/docs/architecture.md`](../v2/docs/architecture.md#4-the-deterministic-pipeline).
 
-## Pipeline (pre-kick stages)
+## Pre-kick pipeline and merge gates
 
-| Script | Purpose |
-|--------|---------|
-| `run-pipeline.sh` | Execute the pre-kick pipeline stages in dependency order. |
-| `enumerate-actionable.sh` | Canonical enumerator for actionable issues and PRs. |
-| `issue-classifier.sh` | Pre-classify actionable issues with deterministic metadata. |
-| `architecture-detector.sh` | Detect issues needing architecture review / lane transfer. |
-| `pr-cluster-detector.sh` | Group related actionable issues into clusters for bundled dispatch. |
-| `contributor-dispatcher.sh` | Report contributor assignment state. |
-| `merge-gate.sh` | Determine which open PRs are eligible for merge. |
-| `conflict-sweeper.sh` | Rebase or close CONFLICTING PRs. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `run-pipeline.sh` | Orchestrator | Runs configured pre-kick stages in dependency order: enumerator, classifier, gate, and monitor. Supports `--agent` and `--stage` selectors. |
+| `enumerate-actionable.sh` | Enumerator | Builds `/var/run/hive-metrics/actionable.json` with actionable issues and PRs, excluding holds, drafts, selected labels, ADOPTERS-only PRs, and external issues missing a commit SHA. |
+| `issue-classifier.sh` | Classifier | Enriches `actionable.json` with deterministic metadata such as complexity tier, model recommendation, tracker status, cluster key, lane, and architecture-review flag. |
+| `architecture-detector.sh` | Classifier | Adds architecture signals to actionable issues from `hive-project.yaml` rules so the classifier can route them to the architect lane. |
+| `pr-cluster-detector.sh` | Classifier | Groups related actionable issues into clusters using component, reporter timing, label-combo, and failure-mode signals. |
+| `merge-gate.sh` | Gate | Writes `/var/run/hive-metrics/merge-eligible.json`; PRs qualify only when required CI passes, they are not drafts or excluded, and author/review policy allows merge. |
+| `conflict-sweeper.sh` | Gate/enforcer | Processes AI-authored PRs with `mergeable=CONFLICTING`, attempts a rebase, force-pushes clean rebases, or closes unrebasable PRs and reopens the original issue. |
+| `copilot-comment-checker.sh` | Monitor | Prefetches unaddressed Copilot review comments into `/var/run/hive-metrics/copilot-comments.json` for reviewer agents. |
+| `ga4-anomaly-detector.sh` | Monitor | Compares recent GA4 error counts with a 7-day baseline and writes `/var/run/hive-metrics/ga4-anomalies.json`; emits a no-data result if GA4 is unavailable. |
+| `outreach-tracker.sh` | Monitor | Tracks outreach PRs opened or merged on external repositories and writes `/var/run/hive-metrics/outreach-prs.json`. |
+| `contributor-dispatcher.sh` | Monitor | Reports current contributor assignment state from `/var/run/hive-metrics/contributors.json` into `/var/run/hive-metrics/contributor-assignments.json`; assignment itself happens in the dashboard WebSocket server. |
 
-## Agent lifecycle
+## Agent launch, supervision, and scheduling
 
-| Script | Purpose |
-|--------|---------|
-| `agent-launch.sh` | Unified launcher for any AI coding CLI backend. |
-| `supervisor.sh` | Keep a tmux session alive with an AI CLI agent inside. |
-| `supervisor-kick.sh` | Reliable agent session restart + kick (Copilot backend). |
-| `agent-healthcheck.sh` | Stall detector + auto-respawn + ntfy push. |
-| `kick-agents.sh` | Fire work orders at the scanner/ci-maintainer/architect/outreach sessions. |
-| `kick-governor.sh` | Adaptive kick governor for supervised agents. |
-| `supervisor-kick.sh` | Session restart + kick helper. |
-| `kick-outcome-tracker.sh` | Correlate governor kicks with queue/MTTR/token outcomes. |
-| `ttyd-tmux.sh` | Wrapper for ttyd → tmux (disables mouse mode for the browser). |
+| Script | Stage | Purpose |
+|---|---|---|
+| `agent-launch.sh` | Launcher | Unified AI CLI launcher for backends such as Claude and Copilot. Reads `--backend`/`--model` flags or `AGENT_BACKEND`/`AGENT_MODEL` environment variables. |
+| `supervisor.sh` | Supervisor | Keeps a tmux session alive with an AI CLI agent and supports optional rate-limit failover between backends. |
+| `supervisor-kick.sh` | Supervisor | Reliably restarts or creates a Copilot-backed session, sends one kick message, and verifies the agent began processing. |
+| `kick-agents.sh` | Kick sender | Sends work orders directly to named tmux sessions (`scanner`, `ci-maintainer`, `architect`, `outreach`, or `all`), handles backend rate-limit switching, and calls `run-pipeline.sh`. |
+| `kick-governor.sh` | Scheduler | Legacy adaptive governor that measures issue/PR backlog, chooses surge/busy/quiet/idle cadences, records kick audit entries, and calls `kick-agents.sh`. |
+| `agent-healthcheck.sh` | Health | Watches an agent log's mtime, kills stalled tmux sessions for supervisor respawn, and escalates after repeated failed respawns. |
+| `kick-outcome-tracker.sh` | Metrics | Correlates governor kicks with queue, MTTR, and token outcomes after a cooldown period. |
+| `gh-rate-check.sh` | Health | Scans tmux panes for GitHub API rate-limit messages, writes `/var/run/hive-metrics/gh_rate_limits.json`, and temporarily pauses affected CLI cohorts. |
+| `gh-zombie-reaper.sh` | Health | Kills long-running `gh` processes older than the configured threshold to stop rate-limit retry storms. |
+| `ttyd-tmux.sh` | Terminal UI | Wraps ttyd-to-tmux sessions and disables tmux mouse mode while the browser session is attached so normal text selection works. |
 
-## GitHub access and safety
+## GitHub credentials, policy enforcement, and PR creation
 
-| Script | Purpose |
-|--------|---------|
-| `gh-wrapper.sh` | `gh` wrapper — enforces per-agent + global restrictions and injects the App token. |
-| `gh-app-token.sh` | Generate a GitHub App installation token for the hive. |
-| `git-credential-hive.sh` | Git credential helper using the GitHub App token. |
-| `hive-open-pr.sh` | Open a PR via the App bot (not `gh pr create`). |
-| `gh-rate-check.sh` | Scan agent tmux panes for GitHub API rate-limit messages. |
-| `gh-zombie-reaper.sh` | Kill `gh` API processes older than `MAX_AGE_SECONDS`. |
-| `copilot-comment-checker.sh` | Pre-fetch unaddressed Copilot review comments. |
-| `setup-proxy-iptables.sh` | Force all GitHub HTTPS traffic through the ACMM proxy. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `gh-app-token.sh` | Credentials | Generates and caches a GitHub App installation token; `--export` prints shell exports for callers. |
+| `git-credential-hive.sh` | Credentials | Git credential helper that serves cached GitHub App tokens and honors the host requested by Git. |
+| `gh-wrapper.sh` | Enforcement | `gh` wrapper that injects App tokens and enforces global/per-agent restriction rules from `/etc/hive/restrictions/<agent-id>.json`. |
+| `hive-open-pr.sh` | Enforcement | Agent-side wrapper for PR creation requests. It writes a request file for the Hive watcher so PRs are opened by the GitHub App bot and pass the same ACMM authorization checks. |
+| `setup-proxy-iptables.sh` | Enforcement | Installs iptables rules in the container to force GitHub HTTPS traffic through the ACMM proxy even if an agent unsets proxy variables. |
+| `hive-config.sh` | Config | Shared shell config reader that exposes project, repo, agent, dashboard, health, and policy values parsed from `hive-project.yaml`. |
 
-## Contributor relay (ClankeR)
+## Deployment and local operation
 
-| Script | Purpose |
-|--------|---------|
-| `contributor-relay.sh` | ClankeR — the WebSocket client connecting a contributor agent to the hub. |
-| `contributor-agent.sh` | Entrypoint for the contributor container. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `hive.sh` | CLI | Operator command wrapper for starting the supervisor, checking status, attaching, kicking agents, reading logs, and stopping agents. |
+| `hive-setup.sh` | Bootstrap | All-in-one Ubuntu 24.04 LXC setup for a Docker-based Hive v2 instance, including generated `hive.yaml` and env files. |
+| `hive-prereq-check.sh` | Bootstrap | Validates host prerequisites for a Docker-based Hive v2 install and can attempt fixes with `--fix`. |
+| `hive-deploy.sh` | Deploy | Pulls the latest Hive repository and syncs scripts to `/usr/local/bin`; also restarts Discord bot components when their files change. |
+| `federation-heartbeat.sh` | Federation | Sends live contributor and actionable-work stats to the Hive federation registry. |
+| `notify.sh` | Notifications | Shared Bash notification library for ntfy, Slack incoming webhooks, and Discord webhooks. |
 
-## Metrics, notifications, tokens
+## Contributor relay
 
-| Script | Purpose |
-|--------|---------|
-| `token-collector.sh` | Correlate bead data with token usage for per-issue cost attribution. |
-| `token-usage.py` | Token usage aggregator for Hive agents. |
-| `notify.sh` | Shared notification library for hive scripts. |
-| `federation-heartbeat.sh` | Periodically send this hive's live stats to the federation. |
-| `outreach-tracker.sh` | Track outreach PRs opened/merged on external repos. |
-| `ga4-anomaly-detector.sh` | Pre-compute GA4 error anomalies for the ci-maintainer agent. |
-| `copilot-models.mjs` | List Copilot models available to this machine's auth (via `@github/copilot-sdk`). |
+| Script | Stage | Purpose |
+|---|---|---|
+| `contributor-agent.sh` | Contributor runtime | Contributor-container entrypoint: detects authenticated CLI backend, starts the relay, launches the CLI in tmux, and creates `${HOME}/agent.md` only from a verified live knowledge export. |
+| `contributor-relay.sh` | Contributor runtime | Node.js WebSocket client for ClankeR contributor agents. It authenticates to one or more hubs, receives tasks, injects GitHub tokens, reports progress/results, and supports interactive tmux or headless one-shot delivery. |
 
-## Setup and deployment
+## Model, token, and experiment helpers
 
-| Script | Purpose |
-|--------|---------|
-| `hive.sh` | KubeStellar AI hive entrypoint. |
-| `hive-config.sh` | Shared config reader for all hive scripts. |
-| `hive-setup.sh` | Bootstrap a fresh Ubuntu 24.04 LXC into a Hive v2 instance (Docker). |
-| `hive-prereq-check.sh` | Validate prerequisites for a Docker-based Hive v2 deployment. |
-| `hive-deploy.sh` | Pull the latest hive repo and sync scripts to `/usr/local/bin`. |
+| Script | Stage | Purpose |
+|---|---|---|
+| `copilot-models.mjs` | Model discovery | Uses `@github/copilot-sdk` and the installed Copilot CLI's own auth to print the available Copilot model catalog as one JSON line. |
+| `token-collector.sh` | Cost metrics | Reads scanner beads and token metrics to attribute issue cost; supports recent windows and `--all`. |
+| `token-usage.py` | Cost metrics | Aggregates Claude and Copilot CLI session token usage by agent and rolling time window. |
+| `nous-install.sh` | Nous | Clones or updates the external Nous strategy-evolution framework under `NOUS_DIR`, creates a venv, installs it editable, and prepares run directories. |
+| `nous-runner.sh` | Nous | Strategist helper that invokes the installed Nous framework on each kick. |
+| `nous-hive-gate.py` | Nous | Implements the Nous Gate protocol, posting suggest-mode decisions to the dashboard and polling for operator approval. |
+| `nous-sync.py` | Nous | Reads Nous governor/repo outputs, applies confidence decay and conflict detection, and writes principles, recommendations, and ledger data. |
 
-## Strategy Lab (Nous)
+## Regression tests
 
-| Script | Purpose |
-|--------|---------|
-| `nous-install.sh` | Install the Nous framework into `/opt/nous` (venv-based). |
-| `nous-runner.sh` | Strategist helper — invokes the real Nous framework. |
-| `nous-hive-gate.py` | Custom Nous Gate — bridges experiment-approval decisions into Hive. |
-| `nous-sync.py` | Analyst helper — reads Nous output and syncs findings to the dashboard. |
-
-## Tests
-
-`*.test.sh` / `*.test.js` files are regression tests for the scripts alongside
-them (e.g. `gh-wrapper.test.sh`, `contributor-agent.test.sh`,
-`contributor-relay.test.js` — the last is JavaScript despite the extension).
+| Script | Covers |
+|---|---|
+| `contributor-agent.test.sh` | Contributor-agent regression for knowledge export handling. |
+| `contributor-relay.test.js` | Contributor relay task/restart/headless behavior; loads `contributor-relay.sh` as JavaScript with stubs. |
+| `gh-wrapper.test.sh` | `gh-wrapper.sh` author-gate and restriction regressions using a mock `gh` binary. |

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -130,25 +130,39 @@ _extract_author() {
   return 1
 }
 
-# Resolve the bot's GitHub login (cached per invocation for performance).
+# Resolve the authenticated GitHub login (cached per invocation for performance).
+# Initialize internally so caller-controlled environment cannot seed the cache.
+HIVE_AUTH_LOGIN_CACHED=""
 _resolve_self_login() {
-  if [[ -n "${HIVE_BOT_LOGIN_CACHED:-}" ]]; then
-    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-    return
+  if [[ -n "${HIVE_AUTH_LOGIN_CACHED:-}" ]]; then
+    printf '%s\n' "$HIVE_AUTH_LOGIN_CACHED"
+    return 0
   fi
-  if [[ -n "${HIVE_BOT_LOGIN:-}" ]]; then
-    HIVE_BOT_LOGIN_CACHED="$HIVE_BOT_LOGIN"
-    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-    return
+
+  local login
+  if ! login="$("$REAL_GH" api user --jq .login 2>/dev/null)"; then
+    return 1
   fi
-  if [[ -x "$REAL_GH" ]] && [[ -n "${GH_TOKEN:-}" ]]; then
-    HIVE_BOT_LOGIN_CACHED="$("$REAL_GH" api user -q '.login' 2>/dev/null || true)"
-    if [[ -n "$HIVE_BOT_LOGIN_CACHED" ]]; then
-      printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-      return
-    fi
+  if [[ -z "$login" ]]; then
+    return 1
   fi
-  printf '%s\n' ""
+
+  HIVE_AUTH_LOGIN_CACHED="$login"
+  printf '%s\n' "$HIVE_AUTH_LOGIN_CACHED"
+}
+
+_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+_author_matches_login() {
+  local requested_lc login_lc requested_base login_base
+  requested_lc="$(_lower "$1")"
+  login_lc="$(_lower "$2")"
+  requested_base="${requested_lc%\[bot\]}"
+  login_base="${login_lc%\[bot\]}"
+
+  [[ "$requested_lc" = "$login_lc" || "$requested_base" = "$login_base" ]]
 }
 
 # ── READ/WRITE SPLIT for GitHub lookups (fixes #2356; addresses #2393 item 6) ──
@@ -168,21 +182,18 @@ if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" 
   if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
     : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356)
   elif author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
-    self_login="$(_resolve_self_login)"
-    if [[ -n "$self_login" ]] && [[ "$author_value" = "$self_login" ]]; then
-      : # Match: exact bot login
-    elif [[ -n "$self_login" ]] && [[ "$author_value" = "${self_login%\[bot\]}" ]]; then
-      : # Match: bot login without [bot] suffix
-    elif [[ -n "${HIVE_AGENT:-}" ]] && [[ "$author_value" = "${HIVE_AGENT}" ]]; then
-      : # Match: agent name
-    elif [[ -n "${HIVE_AGENT_DISPLAY_NAME:-}" ]] && [[ "$author_value" = "${HIVE_AGENT_DISPLAY_NAME}" ]]; then
-      : # Match: agent display name
-    elif [[ -n "${HIVE_CONTRIBUTOR_USERNAME:-}" ]] && [[ "$author_value" = "${HIVE_CONTRIBUTOR_USERNAME}" ]]; then
-      : # Match: contributor username (self-listing in contributor mode)
+    if [[ "$author_value" = "@me" ]]; then
+      : # GitHub resolves @me server-side to the authenticated token identity.
+    elif ! _resolve_self_login >/dev/null; then
+      echo "⛔ BLOCKED: gh $subcmd list --author requires authenticated GitHub identity." >&2
+      echo "Could not resolve the current token identity with 'gh api user --jq .login'." >&2
+      exit 1
+    elif _author_matches_login "$author_value" "$HIVE_AUTH_LOGIN_CACHED"; then
+      : # Match: authenticated login, case-insensitive, with optional [bot] suffix.
     else
-      echo "⛔ BLOCKED: gh $subcmd list --author must match the current bot/agent identity." >&2
-      echo "--author '$author_value' does not match the current identity." >&2
-      echo "Use --author with your own bot login or agent name to list your own items." >&2
+      echo "⛔ BLOCKED: gh $subcmd list --author must match the authenticated GitHub identity." >&2
+      echo "--author '$author_value' does not match token identity '$HIVE_AUTH_LOGIN_CACHED'." >&2
+      echo "Use --author @me or your authenticated bot login to list your own items." >&2
       exit 1
     fi
   else

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -95,8 +95,18 @@ fi
 args=("$@")
 subcmd=""
 action=""
+skip_next=false
 for arg in "${args[@]}"; do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
   case "$arg" in
+    --repo|--hostname|-R|--jq|-q)
+      skip_next=true
+      continue
+      ;;
+    --repo=*|--hostname=*|--jq=*|-R*) continue ;;
     -*) continue ;;
     *)
       if [ -z "$subcmd" ]; then
@@ -114,19 +124,29 @@ done
 # Extract the --author value from the args array. Returns the value on stdout
 # on success (exit 0) or nothing on failure (exit 1).
 _extract_author() {
-  local i
+  local i author_value="" found=false
   for ((i=0; i<${#args[@]}; i++)); do
-    if [[ "${args[$i]}" = --author=* ]]; then
-      printf '%s\n' "${args[$i]#--author=}"
-      return 0
+    if [[ "${args[$i]}" = --author=* || "${args[$i]}" = -A=* ]]; then
+      author_value="${args[$i]#*=}"
+      found=true
+      continue
     fi
-    if [[ "${args[$i]}" = --author ]]; then
+    if [[ "${args[$i]}" = -A?* ]]; then
+      author_value="${args[$i]#-A}"
+      found=true
+      continue
+    fi
+    if [[ "${args[$i]}" = --author || "${args[$i]}" = -A ]]; then
       if [[ $((i+1)) -lt ${#args[@]} ]] && [[ "${args[$((i+1))]}" != -* ]]; then
-        printf '%s\n' "${args[$((i+1))]}"
-        return 0
+        author_value="${args[$((i+1))]}"
+        found=true
       fi
     fi
   done
+  if $found; then
+    printf '%s\n' "$author_value"
+    return 0
+  fi
   return 1
 }
 
@@ -177,11 +197,9 @@ _author_matches_login() {
 # Block gh issue list and gh pr list for NON-contributor hive agents (they consume
 # assigned work from actionable.json). Contributors are exempt so they can look
 # before they leap. `--author` self-listing is allowed only when the author value
-# matches the current agent/bot identity (fixes #3072).
+# matches the authenticated token identity (fixes #3072 and #3096).
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
-  if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
-    : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356)
-  elif author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
+  if author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
     if [[ "$author_value" = "@me" ]]; then
       : # GitHub resolves @me server-side to the authenticated token identity.
     elif ! _resolve_self_login >/dev/null; then
@@ -193,9 +211,11 @@ if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" 
     else
       echo "⛔ BLOCKED: gh $subcmd list --author must match the authenticated GitHub identity." >&2
       echo "--author '$author_value' does not match token identity '$HIVE_AUTH_LOGIN_CACHED'." >&2
-      echo "Use --author @me or your authenticated bot login to list your own items." >&2
+      echo "Use --author @me or your authenticated login to list your own items." >&2
       exit 1
     fi
+  elif [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
+    : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356).
   else
     echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
     echo "Read /var/run/hive-metrics/actionable.json instead." >&2

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -55,6 +55,7 @@ _run_test() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -161,6 +162,7 @@ _run_test_contributor() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -187,6 +189,18 @@ _run_test 1 "pr list without --author (blocked)" \
 _run_test 1 "issue list --author foreign-user (blocked)" \
   issue list --repo test/repo --author foreign-user
 
+_run_test 1 "issue list with global --repo before subcommand and --author foreign-user (blocked)" \
+  --repo test/repo issue list --author foreign-user
+
+_run_test 1 "pr list with global -R before subcommand and --author foreign-user (blocked)" \
+  -R test/repo pr list --author foreign-user
+
+_run_test 1 "issue list -A foreign-user (blocked, short author flag)" \
+  issue list --repo test/repo -A foreign-user
+
+_run_test 1 "issue list duplicate --author with unsafe effective author (blocked)" \
+  issue list --repo test/repo --author @me --author octocat
+
 _run_test 1 "pr list --author=foreign-user (blocked, equals form)" \
   pr list --repo test/repo --author=foreign-user
 
@@ -198,6 +212,15 @@ _run_test 0 "pr list --author=test-bot[bot] (allowed, equals form)" \
 
 _run_test 0 "issue list --author test-bot (allowed, without [bot] suffix)" \
   issue list --repo test/repo --author test-bot
+
+_run_test 0 "issue list with global -R before subcommand and --author test-bot (allowed)" \
+  -R test/repo issue list --author test-bot
+
+_run_test 0 "issue list -A test-bot (allowed, short author flag)" \
+  issue list --repo test/repo -A test-bot
+
+_run_test 0 "issue list duplicate --author with safe effective author (allowed)" \
+  issue list --repo test/repo --author octocat --author @me
 
 _run_test 0 "issue list --author @me (allowed, server-side token identity)" \
   issue list --repo test/repo --author @me
@@ -229,7 +252,28 @@ _run_test_contributor 0 "issue list contributor mode (allowed without --author)"
 _run_test_contributor 0 "pr list contributor mode (allowed without --author)" \
   pr list --repo test/repo
 
-_run_test_contributor 0 "issue list contributor mode --author self (allowed)" \
+_run_test_contributor 1 "issue list contributor mode --author octocat (blocked)" \
+  issue list --repo test/repo --author octocat
+
+_run_test_contributor 1 "issue list contributor mode -A octocat (blocked)" \
+  issue list --repo test/repo -A octocat
+
+_run_test_contributor 1 "issue list contributor mode global -R --author octocat (blocked)" \
+  -R test/repo issue list --author octocat
+
+_run_test_contributor 1 "issue list contributor mode duplicate --author with unsafe effective author (blocked)" \
+  issue list --repo test/repo --author @me --author octocat
+
+_run_test_contributor 0 "issue list contributor mode --author @me (allowed)" \
+  issue list --repo test/repo --author @me
+
+_run_test_contributor 0 "issue list contributor mode --author token login (allowed)" \
+  issue list --repo test/repo --author test-bot
+
+_run_test_contributor 1 "issue list contributor mode --author unverified contributor username (blocked)" \
+  issue list --repo test/repo --author test-contributor
+
+MOCK_GH_LOGIN="test-contributor" _run_test_contributor 0 "issue list contributor mode --author verified contributor token login (allowed)" \
   issue list --repo test/repo --author test-contributor
 
 echo ""

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -2,7 +2,7 @@
 # Author: RawNuke
 # Copyright (c) 2026 RawNuke. All rights reserved.
 #
-# Regression tests for kubestellar/hive#3072: gh-wrapper --author bypass fix.
+# Regression tests for kubestellar/hive#3072 and #3096: gh-wrapper --author gate.
 # Creates a temporary copy of the wrapper with a mock gh binary so tests
 # can run without requiring /usr/bin/gh.
 #
@@ -18,6 +18,7 @@ TEST_WRAPPER="${WORK_DIR}/gh-wrapper-test.sh"
 PASSED=0
 FAILED=0
 
+# shellcheck disable=SC2329 # invoked via EXIT trap
 cleanup() {
   rm -rf "$WORK_DIR"
 }
@@ -27,17 +28,15 @@ mkdir -p "$WORK_DIR"
 
 cat >"$MOCK_GH" <<'MOCK'
 #!/usr/bin/env bash
-case "$*" in
-  "api user -q .login")
-    echo "test-bot[bot]"
-    ;;
-  "api"*)
-    echo '{"login":"test-bot[bot]"}'
-    ;;
-  *)
-    exit 0
-    ;;
-esac
+if [[ "${1:-}" = "api" && "${2:-}" = "user" ]]; then
+  if [[ "${MOCK_GH_FAIL_IDENTITY:-}" = "true" ]]; then
+    echo "mock identity failure" >&2
+    exit 42
+  fi
+  echo "${MOCK_GH_LOGIN:-test-bot[bot]}"
+  exit 0
+fi
+exit 0
 MOCK
 chmod +x "$MOCK_GH"
 
@@ -45,7 +44,6 @@ sed "s|^REAL_GH=\"/usr/bin/gh\"|REAL_GH=\"${MOCK_GH}\"|" "$WRAPPER" > "$TEST_WRA
 chmod +x "$TEST_WRAPPER"
 
 export GH_TOKEN="test-token-mock"
-export HIVE_BOT_LOGIN="test-bot[bot]"
 
 _run_test() {
   local expected_rc="$1"
@@ -57,7 +55,85 @@ _run_test() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_BOT_LOGIN="test-bot[bot]" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_spoof() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_AGENT="octocat" \
+    HIVE_AGENT_DISPLAY_NAME="octocat" \
+    HIVE_AGENT_ID="scanner" \
+    MOCK_GH_LOGIN="scanner[bot]" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_identity_failure() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    MOCK_GH_FAIL_IDENTITY="true" \
+    GH_TOKEN="test-token-mock" \
+    bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+
+  if [[ "$rc" != "$expected_rc" ]]; then
+    echo "FAIL: $desc"
+    echo "  expected exit code $expected_rc, got $rc"
+    echo "  output: $output"
+    FAILED=$((FAILED + 1))
+    return 1
+  fi
+
+  echo "PASS: $desc"
+  PASSED=$((PASSED + 1))
+}
+
+_run_test_cached_env_spoof() {
+  local expected_rc="$1"
+  local desc="$2"
+  shift 2
+
+  local output rc=0
+  output="$(env \
+    HIVE_AGENT="scanner" \
+    HIVE_AGENT_DISPLAY_NAME="scanner" \
+    HIVE_AGENT_ID="scanner" \
+    HIVE_AUTH_LOGIN_CACHED="octocat" \
+    MOCK_GH_LOGIN="test-bot[bot]" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -85,7 +161,6 @@ _run_test_contributor() {
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_BOT_LOGIN="test-bot[bot]" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
 
@@ -124,11 +199,26 @@ _run_test 0 "pr list --author=test-bot[bot] (allowed, equals form)" \
 _run_test 0 "issue list --author test-bot (allowed, without [bot] suffix)" \
   issue list --repo test/repo --author test-bot
 
-_run_test 0 "issue list --author scanner (allowed, HIVE_AGENT match)" \
+_run_test 0 "issue list --author @me (allowed, server-side token identity)" \
+  issue list --repo test/repo --author @me
+
+_run_test 0 "issue list --author TEST-BOT (allowed, case-insensitive without [bot] suffix)" \
+  issue list --repo test/repo --author TEST-BOT
+
+_run_test 0 "issue list --author test-bot[bot] with spoofed HIVE_AGENT (allowed by token identity)" \
+  issue list --repo test/repo --author "test-bot[bot]"
+
+_run_test 1 "issue list --author scanner from HIVE_AGENT env (blocked)" \
   issue list --repo test/repo --author scanner
 
-_run_test 0 "pr list --author scanner (allowed, HIVE_AGENT match)" \
-  pr list --repo test/repo --author scanner
+_run_test_spoof 1 "issue list --author octocat with spoofed HIVE_AGENT (blocked)" \
+  issue list --repo test/repo --author octocat
+
+_run_test_identity_failure 1 "issue list --author test-bot[bot] when identity lookup fails (blocked)" \
+  issue list --repo test/repo --author "test-bot[bot]"
+
+_run_test_cached_env_spoof 1 "issue list --author env-seeded identity cache octocat (blocked)" \
+  issue list --repo test/repo --author octocat
 
 echo ""
 echo "=== Contributor mode tests ==="

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,22 @@
+# Hive configuration files
+
+This directory contains configuration used by the top-level Hive helper scripts. It is not the same as the v2 Go binary config in `v2/hive.yaml.example`.
+
+## `hive-project.yaml`
+
+`config/hive-project.yaml.example` is the project file consumed by the deterministic shell pipeline under `bin/`:
+
+- `bin/hive-config.sh` reads `${HIVE_PROJECT_CONFIG:-/etc/hive/hive-project.yaml}` and exports project, agent, dashboard, health-check, outreach, and GitHub App values for other scripts.
+- `bin/run-pipeline.sh` and several pipeline stages read `${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}` to find `pipeline.stages` and project-specific classification inputs.
+- If the file is missing, scripts fall back to built-in defaults or to the first example file they can find; those fallbacks are for development and may not match your project.
+
+Install it at `/etc/hive/hive-project.yaml`, or point the scripts at another path with `HIVE_PROJECT_CONFIG` and `HIVE_PROJECT_YAML`.
+
+## How it differs from `v2/hive.yaml`
+
+| File | Used by | Purpose |
+|---|---|---|
+| `config/hive-project.yaml.example` | Top-level `bin/` shell automation and deterministic pre-kick pipeline | Project/org/repo metadata, enabled script agents, beads base directory, health-check workflow names, outreach metadata, and optional GitHub App values for script token minting. |
+| `v2/hive.yaml.example` | The v2 Go `hive` binary, dashboard, governor, agent manager, hub, and API server | Runtime config for the containerized v2 service: project, agents, governor modes, GitHub auth, dashboard auth, data paths, knowledge, hub/spoke settings, and ACMM level. |
+
+Use `v2/hive.yaml` for normal v2 Docker/Kubernetes operation. Use `hive-project.yaml` only when you run the top-level `bin/` scripts or the deterministic pipeline directly.

--- a/config/agent.env.example
+++ b/config/agent.env.example
@@ -132,6 +132,11 @@ SLACK_WEBHOOK=
 # hive appends /slack to use Discord's Slack-compatible endpoint.
 DISCORD_WEBHOOK=
 
+# GitHub webhook secret for agent trigger channels (`type: webhook`).
+# Required when exposing the /webhook receiver; requests without a valid
+# X-Hub-Signature-256 HMAC are rejected.
+HIVE_WEBHOOK_SECRET=
+
 # ---- GITHUB AUTH (choose ONE: PAT or GitHub App) ----------------------------
 #
 # Option A: Personal Access Token (simple, shares your 5000 req/hr pool)

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -125,14 +125,14 @@
       border-radius: 6px; border: 1px solid transparent; transition: all 0.15s;
     }
     .oc-topbar-center .oc-tb-link:hover { background: #f3f4f6; color: #111827; border-color: #e5e7eb; }
-    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 1 auto; flex-wrap: nowrap; }
+    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 0 auto; flex-wrap: nowrap; }
     .oc-health-badge {
       font-size: 0.78rem; font-weight: 600; color: #16a34a;
       background: #f0fdf4; border: 1px solid #bbf7d0;
       padding: 4px 12px; border-radius: 20px;
     }
     #oc-hive-id {
-      flex: 0 1 auto; min-width: 0; max-width: clamp(9rem, 18vw, 22rem);
+      flex: 0 1 auto; min-width: 0; max-width: 22rem;
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
     .oc-topbar-ts { font-size: 0.75rem; color: #6b7280; white-space: nowrap; }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -25,6 +25,7 @@
     .git-version .git-dirty { color: var(--yellow); }
     .header-spacer { flex: 1; }
     .widget-dl {
+      display: inline-flex; align-items: center; white-space: nowrap;
       font-size: 0.75rem; color: var(--cyan); text-decoration: none;
       border: 1px solid var(--cyan); border-radius: 6px; padding: 4px 10px;
       transition: background 0.2s, color 0.2s; margin-left: auto; margin-right: auto;
@@ -111,26 +112,31 @@
 
     /* Light top bar */
     .oc-topbar {
-      position: fixed; top: 0; left: var(--sidebar-w); right: 0; height: 48px;
+      position: fixed; top: 0; left: var(--sidebar-w); right: 0; min-height: 48px;
       background: #ffffff; border-bottom: 1px solid #e5e7eb;
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
     }
-    .oc-topbar-left { font-size: 0.85rem; color: #6b7280; }
-    .oc-topbar-center { display: flex; align-items: center; gap: 6px; }
+    .oc-topbar-left { font-size: 0.85rem; color: #6b7280; min-width: 0; flex: 1 1 auto; overflow: hidden; }
+    #oc-project-name { display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .oc-topbar-center { display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
     .oc-topbar-center .oc-tb-link {
       font-size: 0.72rem; color: #6b7280; cursor: pointer; padding: 4px 10px;
       border-radius: 6px; border: 1px solid transparent; transition: all 0.15s;
     }
     .oc-topbar-center .oc-tb-link:hover { background: #f3f4f6; color: #111827; border-color: #e5e7eb; }
-    .oc-topbar-right { display: flex; align-items: center; gap: 14px; }
+    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 1 auto; flex-wrap: nowrap; }
     .oc-health-badge {
       font-size: 0.78rem; font-weight: 600; color: #16a34a;
       background: #f0fdf4; border: 1px solid #bbf7d0;
       padding: 4px 12px; border-radius: 20px;
     }
-    .oc-topbar-ts { font-size: 0.75rem; color: #6b7280; }
-    .oc-topbar .git-version { color: #9ca3af; }
+    #oc-hive-id {
+      flex: 0 1 auto; min-width: 0; max-width: clamp(9rem, 18vw, 22rem);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .oc-topbar-ts { font-size: 0.75rem; color: #6b7280; white-space: nowrap; }
+    .oc-topbar .git-version { color: #9ca3af; white-space: nowrap; }
     .oc-topbar .widget-dl {
       font-size: 0.72rem; color: #dc2626; border-color: #dc2626;
       padding: 3px 10px; border-radius: 6px;

--- a/discord/README.md
+++ b/discord/README.md
@@ -1,0 +1,58 @@
+# Hive Discord bot
+
+An optional Discord bot that lets operators interact with a hive from a Discord
+channel — check status, kick, pause, and resume agents — and receive alerts. It
+talks to the hive's dashboard API; it does **not** need cluster access.
+
+This is separate from the one-way **`notifications.discord.webhook`** channel
+(see [`v2/docs/notifications.md`](../v2/docs/notifications.md)). The webhook only
+pushes alerts; this bot is two-way.
+
+## Setup
+
+1. Create a Discord application and bot at
+   <https://discord.com/developers/applications>, and invite it to your server
+   with permission to read and send messages in the target channel(s).
+2. Install and run:
+
+   ```bash
+   cd discord
+   npm install
+   npm start
+   ```
+
+3. Configure via environment variables (required unless noted):
+
+   | Variable | Purpose |
+   |----------|---------|
+   | `DISCORD_BOT_TOKEN` | Bot token from the Discord developer portal. |
+   | `DISCORD_CHANNEL_PRIMARY` | Channel ID the bot listens in for commands. |
+   | `DISCORD_CHANNEL_ALERTS` | Optional channel ID for alert posts. |
+   | `HIVE_DASHBOARD_URL` | Base URL of the hive dashboard API the bot drives. |
+   | `HIVE_METRICS_DIR` | Optional path to the hive metrics dir for local reads. |
+   | `HIVE_PROJECT_CONFIG` | Optional path to the project config for agent names/prefix. |
+
+   The command prefix defaults to `!` and can be overridden with
+   `command_prefix` in the project config.
+
+## Commands
+
+Send these in the primary channel (default prefix `!`):
+
+| Command | Aliases | What it does |
+|---------|---------|--------------|
+| `!status` | `!s`, `!st` | Fleet status summary from the dashboard. |
+| `!governor` | | Current governor mode and cadences. |
+| `!kick <agent> [prompt]` | `!k <agent>` | Kick an agent (optionally with a prompt). |
+| `!pause <agent>` | `!p <agent>` | Pause an agent. |
+| `!resume <agent>` | `!r <agent>` | Resume a paused agent. |
+| `!help` | `!h`, `!?` | Command usage. |
+
+Unknown agents and unreachable-dashboard conditions are reported back in-channel.
+
+## Security
+
+The bot token and any dashboard auth token are secrets — supply them via
+environment variables, never commit them. Restrict the bot to a private
+operator channel; anyone who can post in `DISCORD_CHANNEL_PRIMARY` can kick,
+pause, and resume agents.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,11 @@
 # Architecture
 
+> **Legacy v1/systemd documentation.** This root `docs/` page describes the
+> original supervisor, systemd/launchd timers, tmux, and `agent.env` workflow.
+> It is kept for historical context. For the current v2 Docker/Go architecture,
+> start with [`v2/docs/architecture.md`](../v2/docs/architecture.md) and the
+> [`v2/docs/README.md`](../v2/docs/README.md) index.
+
 ## Two scheduling models
 
 hive supports two fundamentally different ways to drive an agent. Choose based on how much control you want to keep.

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -8,12 +8,12 @@ Hive validates backend names in `v2/pkg/config` and launches CLIs in `v2/pkg/age
 | --- | --- | --- | --- |
 | `claude` | `claude` | Install Claude Code and log in once. Hive launches with `--dangerously-skip-permissions`; inference routes add `--bare --settings`. | Advisory/issue modes add disallowed GitHub MCP tools. |
 | `copilot` | `copilot` | Install GitHub Copilot CLI and authenticate with GitHub. Hive also probes Copilot model entitlements live. | Launched with `--no-auto-update --allow-all`; write tools are denied by mode when needed. |
-| `gemini` | `gemini` | Install Gemini CLI and configure its normal auth/API key. | Hive passes `--model`. |
+| `gemini` | `gemini` | Install Gemini CLI and configure its normal auth/API key. | Supported by the server-side manager; Hive launches `gemini` and passes `--model` when a model is configured. |
 | `goose` | `goose` | Install Block Goose and configure provider/model (`GOOSE_PROVIDER`, `GOOSE_MODEL`, or `goose configure`). | Hive launches `goose run -s` and appends `--model` when set. |
-| `pi` | `goose` in the Go manager; `pi` in contributor scripts | In the server-side manager, `pi` is currently a Goose alias because `backendBinary("pi")` maps to `goose`. Configure Goose for pod agents. The contributor relay image/scripts still know a separate `pi` binary. | Do not assume the pod path uses pi.dev until the manager mapping changes. |
+| `pi` | `goose` in the Go manager; `pi` in contributor scripts | In the server-side manager, `backendBinary("pi")` maps to `goose`. Configure Goose for pod agents. The contributor relay image/scripts use a separate `pi` binary. | Server-side pod agents use Goose for `backend: pi`; contributor mode uses the Pi CLI. |
 | `bob` | `bob` | Provide `HIVE_BOB_API_KEY` or `/secrets/bob_api_key` for pods; contributor mode requires `BOBSHELL_API_KEY`. | Hive uses API-key auth headlessly and accepts the Bob license at launch. |
-| `codex` | accepted by config; contributor scripts launch `codex` | Install `@openai/codex` and provide `OPENAI_API_KEY`. Contributor mode sets a per-agent `CODEX_HOME`. | v2 HEAD server-side `backendBinary` does not map `codex`, so use it in contributor mode unless the manager mapping has been updated. |
-| `aider` | accepted by config; contributor scripts launch `aider` | Install Aider and configure its provider/API key normally. | v2 HEAD server-side `backendBinary` does not map `aider`, so use it in contributor mode unless the manager mapping has been updated. |
+| `codex` | contributor scripts launch `codex`; the server-side Go manager does not launch it | Install `@openai/codex` and provide `OPENAI_API_KEY` for contributor mode. Contributor mode sets a per-agent `CODEX_HOME`. | Not supported as a server-side agent backend in this branch: config accepts the name, but `backendBinary("codex")` returns `unknown backend: codex`, so a pod agent will not start. Use contributor mode for Codex. |
+| `aider` | contributor scripts launch `aider`; the server-side Go manager does not launch it | Install Aider and configure its provider/API key normally for contributor mode. | Not supported as a server-side agent backend in this branch: config accepts the name, but `backendBinary("aider")` returns `unknown backend: aider`, so a pod agent will not start. Use contributor mode for Aider. |
 
 ## IBM Bob headless setup
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,7 +64,14 @@ Run `gofmt` on Go files you edit:
 gofmt -w path/to/file.go
 ```
 
-There is no separate documented repository-wide lint command in the current `Justfile`; use the Go build and test commands above unless CI or a maintainer asks for an additional check.
+The v2 CI workflow runs `go vet ./...` after building the Hive binary. Reproduce that check locally from the Go module:
+
+```bash
+cd v2
+go vet ./...
+```
+
+There is no public `just lint` recipe in the current root `Justfile`; use `go vet ./...` for the repository's documented local lint-equivalent check, plus `gofmt`, `go build`, and targeted `go test` for the files you change.
 
 ## Running Hive locally
 

--- a/docs/getting-started-contributing.md
+++ b/docs/getting-started-contributing.md
@@ -1,0 +1,86 @@
+# Getting started as a first-time contributor
+
+This is the end-to-end path for making your first code or documentation
+contribution to Hive. It ties together the reference docs and answers the
+Hive-specific questions those docs don't. If you just want the mechanics
+(branches, DCO, PR format), see [`CONTRIBUTING.md`](../CONTRIBUTING.md); for
+build/test commands, see [`docs/development.md`](development.md).
+
+## 1. Find something to work on
+
+- Browse the [issue tracker](https://github.com/kubestellar/hive/issues). Issues
+  labeled `documentation` and `help wanted` are good entry points; many
+  `[guide]` doc-gap issues are small and self-contained.
+- Docs-only fixes (a wrong path, a dead link, a missing README) are the fastest
+  way to land a first PR and learn the review flow.
+- Comment on the issue before starting anything non-trivial so work isn't
+  duplicated.
+
+## 2. Set up a local environment
+
+For most changes you do **not** need a cluster.
+
+- **Go code:** you need Go (see [`docs/development.md`](development.md) for the
+  version and `make`/`just` targets). `cd v2 && go build ./...` compiles the
+  binary; that's enough to iterate on most code.
+- **Docs:** no toolchain needed — edit Markdown and preview locally.
+- **Running the whole thing:** the fastest full run is Docker Compose from the
+  repo's [Quick Start](../README.md#quick-start-docker-compose) (`cd v2 &&
+  docker compose up -d`). You only need Kubernetes for deployment-specific work.
+
+## 3. Test a change without a cluster
+
+- **Go:** `cd v2 && go test ./...` runs the unit suite. Most tests are
+  hermetic; a few need env like `kubectl` and are skipped otherwise. See the
+  Test section of [`docs/development.md`](development.md).
+- **Shell scripts:** `*.test.sh` / `*.test.js` files under
+  [`bin/`](../bin/README.md) are runnable directly with `bash`/`node`.
+- **The proxy:** `cd v2/proxy && npm test`.
+- Don't run local build/lint as a merge gate — CI is the gate (see step 6).
+
+## 4. Key concepts before touching agent policy
+
+If your change touches how agents behave, understand these first:
+
+- **The deterministic pipeline vs. agents.** Shell scripts in
+  [`bin/`](../bin/README.md) filter, classify, and gate work *before* any LLM
+  runs; agents only make judgment calls. Keep deterministic logic in the
+  pipeline.
+- **ACMM levels.** The [ACMM policy matrix](../v2/docs/acmm-policy-matrix.md)
+  controls what each agent may do at each maturity level (advisory → auto-merge).
+- **Agent configuration.** [`agent-configuration.md`](../v2/docs/agent-configuration.md)
+  is the field-by-field reference; prompt/policy templates live under the
+  policies directory.
+- **The architecture.** [`v2/docs/architecture.md`](../v2/docs/architecture.md)
+  is the system overview — read it before changing the governor loop or guardrails.
+
+## 5. How the Hive dev bot interacts with your PR
+
+Hive maintains its own repository with a hive — so a bot may interact with your
+contribution:
+
+- The hive's agents may **comment on or triage** issues and open their own PRs.
+- If you see automated review comments or a bot-authored PR referencing your
+  issue, that's the hive working its own backlog. Coordinate in the issue thread;
+  a human maintainer still owns merge decisions on community PRs.
+- Bot-posted content is neutralized (no raw `@`-mentions) to avoid notifying
+  everyone on each update — you don't need to do anything special.
+
+## 6. Review and CI: what to expect
+
+- Open your PR against the **`v2`** branch (the active development branch).
+- CI runs build, tests, a coverage check, and container image builds. Some
+  checks (Playwright, `tide`) are non-blocking. The **required** checks are the
+  build/test/coverage/docker ones.
+- Coverage occasionally flakes; a maintainer will re-run it. A red `PR Verifier`
+  status is a known repo-wide quirk, not your change.
+- A maintainer reviews and merges once CI is green. Timelines vary; ping the
+  issue or PR thread if it's been quiet for a few days.
+
+## Next steps
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — branches, DCO sign-off, PR format.
+- [`docs/development.md`](development.md) — build, test, lint, and `just` recipes.
+- [`v2/docs/README.md`](../v2/docs/README.md) — the full documentation index.
+- [ClankeR contributor relay](../v2/docs/contributor-relay.md) — contribute
+  compute to a running hive from your own machine.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,5 +1,12 @@
 # macOS Support (launchd)
 
+> **Legacy v1/launchd documentation.** This page maps the original
+> systemd-style supervised agent workflow to macOS launchd. It does not describe
+> the current v2 Docker/Go deployment. For v2, start with
+> [`v2/docs/README.md`](../v2/docs/README.md), plus
+> [`v2/docs/operator-reference.md`](../v2/docs/operator-reference.md) and
+> [`v2/docs/deployment-scripts.md`](../v2/docs/deployment-scripts.md).
+
 The hive runtime was built on Linux/systemd, but the same concepts map cleanly to macOS using **launchd** — Apple's equivalent of systemd.
 
 This guide shows how to run a supervised agent on a Mac that stays on (Mac Mini, Mac Studio, always-on laptop, etc.).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,11 +2,10 @@
 
 > **Legacy v1/systemd documentation.** This page troubleshoots the original
 > supervisor/tmux/systemd deployment (`bin/supervisor.sh`, `systemctl`, and
-> `/etc/hive/agent.env`). For current v2 Docker/Go operations, use the
-> [`v2/docs/README.md`](../v2/docs/README.md) index, especially
-> [`v2/docs/health-checks.md`](../v2/docs/health-checks.md),
-> [`v2/docs/operator-reference.md`](../v2/docs/operator-reference.md), and
-> [`v2/docs/manual-provisioning.md`](../v2/docs/manual-provisioning.md).
+> `/etc/hive/agent.env`). For current v2 Docker/Go operations, use
+> [v2 troubleshooting](../v2/docs/troubleshooting.md) and the
+> [`v2/docs/README.md`](../v2/docs/README.md) index.
+
 
 ## The `/loop` prompt never fires — the agent just sits at the prompt
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,13 @@
 # Troubleshooting
 
+> **Legacy v1/systemd documentation.** This page troubleshoots the original
+> supervisor/tmux/systemd deployment (`bin/supervisor.sh`, `systemctl`, and
+> `/etc/hive/agent.env`). For current v2 Docker/Go operations, use the
+> [`v2/docs/README.md`](../v2/docs/README.md) index, especially
+> [`v2/docs/health-checks.md`](../v2/docs/health-checks.md),
+> [`v2/docs/operator-reference.md`](../v2/docs/operator-reference.md), and
+> [`v2/docs/manual-provisioning.md`](../v2/docs/manual-provisioning.md).
+
 ## The `/loop` prompt never fires — the agent just sits at the prompt
 
 Cause: the supervisor's `AGENT_READY_MARKER` doesn't appear in the agent's TUI, so the supervisor gives up before sending `AGENT_LOOP_PROMPT`.

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,35 @@
+# Git hooks
+
+This directory contains optional Git hooks for maintainers and contributors who want local guardrails. Git does not run these hooks unless you opt in.
+
+## `post-checkout`
+
+`post-checkout` runs after `git checkout`/`git switch` operations. It only acts on branch checkouts (`BRANCH_FLAG=1`) and exits immediately for file checkouts. It also exits in linked worktrees, because linked worktrees have a `.git` file instead of a `.git` directory.
+
+In the primary worktree, if the checkout leaves `HEAD` on any branch other than `main`, the hook prints a warning and runs `git checkout main --quiet`. The warning tells contributors to create feature branches in separate worktrees. The hook is intended for a long-running primary checkout used by the dashboard, where branch changes would affect the served files.
+
+## Install
+
+Enable the repository hooks in the checkout you want to protect:
+
+```bash
+git config core.hooksPath githooks
+```
+
+This writes a local Git config setting. It is not committed and it does not affect other clones unless you set it there too.
+
+## Bypass or uninstall
+
+If you do not install the hook, normal Git checkout behavior applies. To disable it after installing, unset or override the hooks path:
+
+```bash
+git config --unset core.hooksPath
+# or point this checkout at a different hook directory
+git config core.hooksPath .git/hooks
+```
+
+For feature work, keep the protected primary checkout on `main` and create a linked worktree instead:
+
+```bash
+git worktree add ../hive-my-feature -b my-feature origin/main
+```

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -13,8 +13,8 @@ BRANCH_FLAG="$3"   # 1 = branch checkout, 0 = file checkout
 # Only guard branch checkouts
 [[ "$BRANCH_FLAG" != "1" ]] && exit 0
 
-# Only guard the primary worktree — worktrees have a .git *file*, not dir
-[[ ! -d "$(git rev-parse --git-dir 2>/dev/null)" ]] && exit 0
+# Only guard the primary worktree — linked worktrees have a .git *file*, not dir.
+[[ ! -d .git ]] && exit 0
 
 CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null)"
 

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -73,10 +73,15 @@ RUN ARCH=$(dpkg --print-architecture) \
   && rm -rf /tmp/goose-dl \
   || echo "Goose install skipped"
 
-# Pi CLI (pi.dev coding agent) — disabled: curl-pipe-to-shell is unsafe for
-# reproducible image builds (supply-chain risk, no integrity verification).
-# Re-enable only after pi.dev publishes a versioned binary release with a
-# verifiable SHA256. See: https://github.com/kubestellar/hive/issues/2902
+# Install Pi CLI (pi.dev coding agent). Do not use pi.dev's curl-pipe-to-shell
+# installer here: it is mutable and executes remote shell as root. Pi publishes
+# npm-shrinkwrap.json, so install a pinned npm package with lifecycle scripts
+# disabled and fail the image build if the binary is absent.
+ARG PI_CODING_AGENT_VERSION=0.84.1
+RUN npm install -g --ignore-scripts --no-fund --no-audit \
+    "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
+  && npm cache clean --force \
+  && which pi
 
 # Install Go (needed for building/testing Go projects)
 ARG GO_VERSION=1.24.4

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -73,9 +73,10 @@ RUN ARCH=$(dpkg --print-architecture) \
   && rm -rf /tmp/goose-dl \
   || echo "Goose install skipped"
 
-# Install Pi CLI (pi.dev coding agent)
-RUN curl -fsSL https://pi.dev/install.sh | sh \
-  || echo "Pi install skipped"
+# Pi CLI (pi.dev coding agent) — disabled: curl-pipe-to-shell is unsafe for
+# reproducible image builds (supply-chain risk, no integrity verification).
+# Re-enable only after pi.dev publishes a versioned binary release with a
+# verifiable SHA256. See: https://github.com/kubestellar/hive/issues/2902
 
 # Install Go (needed for building/testing Go projects)
 ARG GO_VERSION=1.24.4

--- a/v2/README.md
+++ b/v2/README.md
@@ -321,6 +321,7 @@ The `deploy/` directory contains pre-built configurations for common deployment 
 ## Additional references
 
 - [Operator reference](docs/operator-reference.md) — config blocks, server flags/env, GitHub token scopes.
+- [Troubleshooting](docs/troubleshooting.md) — v2 container logs, config validation, agent sessions, dashboard auth, and GitHub credential checks.
 - [Config layering](docs/config-layering.md) — effective config provenance and precedence.
 - [Dashboard API reference](docs/api-reference.md) — generated route index.
 - [apiproxy](docs/apiproxy.md) — model API proxy purpose and deployment notes.

--- a/v2/README.md
+++ b/v2/README.md
@@ -37,6 +37,8 @@ docker compose up -d
 
 The default `docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`. To build from source instead, run `docker compose build` before `docker compose up -d`.
 
+For tag provenance, digest pinning, and the release/tagging flow, see [docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest](docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest).
+
 ### Troubleshooting
 
 - **Rancher Desktop / Lima**: Volume mounts from `/tmp` may fail silently (file appears as directory inside container). Clone the repo under your home directory instead.
@@ -64,7 +66,7 @@ operations.
 
 See [docs/hivectl.md](docs/hivectl.md) for the full command reference. The architecture overview also calls out `hivectl` as the non-interactive API client for automation. For raw dashboard endpoints, see [docs/api-reference.md](docs/api-reference.md).
 
-See [docs/README.md](docs/README.md) for the full v2 documentation index.
+See [docs/README.md](docs/README.md) for the full v2 documentation index, including [notifications](docs/notifications.md) and image provenance in the operator reference.
 
 ## Kubernetes
 
@@ -86,7 +88,7 @@ hub-fronted URL probing, and alert hysteresis.
 
 ## Configuration
 
-All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the commented example, [docs/operator-reference.md](docs/operator-reference.md) for operator-only knobs and token scopes, [docs/config-layering.md](docs/config-layering.md) for runtime precedence/provenance, [docs/agent-configuration.md](docs/agent-configuration.md) for agent fields and ACMM packs, [../docs/backend-setup.md](../docs/backend-setup.md) for CLI backend setup, and [../docs/migration-v1-v2.md](../docs/migration-v1-v2.md) for migration from v1.
+All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the commented example, [docs/operator-reference.md](docs/operator-reference.md) for operator-only knobs, token scopes, and image provenance, [docs/config-layering.md](docs/config-layering.md) for runtime precedence/provenance, [docs/agent-configuration.md](docs/agent-configuration.md) for agent fields and ACMM packs, [AGENT-DEFINITION.md](AGENT-DEFINITION.md) for the portable agent YAML format, [../docs/backend-setup.md](../docs/backend-setup.md) for CLI backend setup, and [../docs/migration-v1-v2.md](../docs/migration-v1-v2.md) for migration from v1.
 
 ```yaml
 project:
@@ -162,6 +164,9 @@ policies:
   path: agents/
   poll_interval: 5m
 ```
+
+
+For portable agent overlays and dashboard imports/exports, see [AGENT-DEFINITION.md](AGENT-DEFINITION.md).
 
 ## ClankeR contributor relay
 

--- a/v2/cmd/apiproxy/main.go
+++ b/v2/cmd/apiproxy/main.go
@@ -14,6 +14,7 @@ import (
 
 func main() {
 	port := flag.Int("port", 9000, "port to listen on")
+	host := flag.String("host", "127.0.0.1", "host address to listen on (default localhost; set to 0.0.0.0 to expose externally)")
 	upstream := flag.String("upstream", "https://api.anthropic.com", "upstream API URL")
 	logFile := flag.String("log", "", "log file path (default: stdout)")
 	flag.Parse()
@@ -62,13 +63,16 @@ func main() {
 	authToken := os.Getenv("PROXY_AUTH_TOKEN")
 	if authToken == "" {
 		authToken = os.Getenv("ANTHROPIC_API_KEY")
+		if authToken != "" {
+			log.Println("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
+		}
 	}
 	proxy, err := apiproxy.New(*upstream, handler, authToken)
 	if err != nil {
 		log.Fatalf("failed to create proxy: %v", err)
 	}
 
-	addr := fmt.Sprintf(":%d", *port)
+	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("[apiproxy] listening on %s → %s", addr, *upstream)
 	if err := http.ListenAndServe(addr, proxy); err != nil {
 		log.Fatalf("server error: %v", err)

--- a/v2/cmd/apiproxy/main.go
+++ b/v2/cmd/apiproxy/main.go
@@ -12,9 +12,23 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/apiproxy"
 )
 
+const defaultProxyHost = "127.0.0.1"
+
+func proxyAuthTokenFromEnv(getenv func(string) string, warnf func(string, ...any)) string {
+	authToken := getenv("PROXY_AUTH_TOKEN")
+	if authToken != "" {
+		return authToken
+	}
+	authToken = getenv("ANTHROPIC_API_KEY")
+	if authToken != "" {
+		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
+	}
+	return authToken
+}
+
 func main() {
 	port := flag.Int("port", 9000, "port to listen on")
-	host := flag.String("host", "127.0.0.1", "host address to listen on (default localhost; set to 0.0.0.0 to expose externally)")
+	host := flag.String("host", defaultProxyHost, "host address to listen on (default localhost; set to 0.0.0.0 to expose externally)")
 	upstream := flag.String("upstream", "https://api.anthropic.com", "upstream API URL")
 	logFile := flag.String("log", "", "log file path (default: stdout)")
 	flag.Parse()
@@ -60,13 +74,7 @@ func main() {
 		logWriter.Encode(entry)
 	}
 
-	authToken := os.Getenv("PROXY_AUTH_TOKEN")
-	if authToken == "" {
-		authToken = os.Getenv("ANTHROPIC_API_KEY")
-		if authToken != "" {
-			log.Println("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
-		}
-	}
+	authToken := proxyAuthTokenFromEnv(os.Getenv, log.Printf)
 	proxy, err := apiproxy.New(*upstream, handler, authToken)
 	if err != nil {
 		log.Fatalf("failed to create proxy: %v", err)

--- a/v2/cmd/apiproxy/main_test.go
+++ b/v2/cmd/apiproxy/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestDefaultProxyHostIsLoopback(t *testing.T) {
+	if defaultProxyHost != "127.0.0.1" {
+		t.Fatalf("defaultProxyHost = %q, want loopback 127.0.0.1", defaultProxyHost)
+	}
+}
+
+func TestProxyAuthTokenFromEnvWarnsOnAnthropicFallback(t *testing.T) {
+	var warnings []string
+	getenv := func(key string) string {
+		switch key {
+		case "PROXY_AUTH_TOKEN":
+			return ""
+		case "ANTHROPIC_API_KEY":
+			return "sk-ant"
+		default:
+			return ""
+		}
+	}
+	token := proxyAuthTokenFromEnv(getenv, func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	if token != "sk-ant" {
+		t.Fatalf("token = %q, want ANTHROPIC_API_KEY fallback", token)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "PROXY_AUTH_TOKEN is unset") {
+		t.Fatalf("expected actionable fallback warning, got %#v", warnings)
+	}
+}
+
+func TestProxyAuthTokenFromEnvPrefersProxyAuthToken(t *testing.T) {
+	var warnings []string
+	getenv := func(key string) string {
+		switch key {
+		case "PROXY_AUTH_TOKEN":
+			return "proxy-token"
+		case "ANTHROPIC_API_KEY":
+			return "sk-ant"
+		default:
+			return ""
+		}
+	}
+	token := proxyAuthTokenFromEnv(getenv, func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+	if token != "proxy-token" {
+		t.Fatalf("token = %q, want PROXY_AUTH_TOKEN", token)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no fallback warning when PROXY_AUTH_TOKEN is set, got %#v", warnings)
+	}
+}

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -15,6 +15,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [TLS, HTTPS, and certificates](tls-setup.md) — termination patterns and certificate ownership.
 - [Security notes](security.md) — log scrubbing and secret redaction guarantees/limits.
 - [Token collection and usage tracking](token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
+- [Notifications](notifications.md) — ntfy, Slack, and Discord alert channels, plus the two-way [Discord bot](../../discord/README.md).
 - [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [`bd` beads CLI](beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -21,6 +21,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [`bd` beads CLI](beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
 - [Backup and restore](backup-restore.md) — `hive-backup`, Kubernetes CronJob, and spoke backup scope.
 - [Deployment helper scripts](deployment-scripts.md) — Proxmox LXC and blue-green Compose helpers.
+- [`bin/` pipeline script index](../../bin/README.md) — map of the 45 deterministic pipeline and operational shell/Python scripts, grouped by function.
 - [Dashboard API reference](api-reference.md) — pragmatic route index for dashboard and hub endpoints.
 - [Dashboard OpenAPI spec](../../dashboard/openapi.json) — machine-readable REST API reference for integrations.
 - [ioscan status](ioscan.md) — v2 status of the untrusted-input scanner/canary feature.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -34,8 +34,11 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
+- [Supervisor agent](supervisor.md) — supervisor policy templates and when to use each.
+- [Custom dashboard stylesheets](custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
 - [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
 - [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
+- [Agent definition format](../AGENT-DEFINITION.md) — the portable YAML format for importing/exporting agents.
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [ACMM policy fragments](../../examples/acmm/README.md) — per-level ACMM policy references.
 - [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -7,9 +7,10 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Manual provisioning](manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
 - [Self-hosted hub deployment](hub-deployment.md) — `HIVE_MODE=hub`, hub storage, heartbeat secrets, and SaaS spoke registration.
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
-- [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, and GitHub token scopes.
+- [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, GitHub token scopes, and image provenance.
 - [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
 - [Troubleshooting](troubleshooting.md) — v2 container logs, config validation, agent tmux sessions, dashboard auth, and GitHub credential checks.
+- [Notifications](notifications.md) — ntfy, Slack, and Discord webhook setup, trigger events, and test commands.
 - [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
 - [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
@@ -40,9 +41,9 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
 - [Supervisor agent](supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
 - [Custom dashboard stylesheets](custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
+- [Portable AgentDefinition format](../AGENT-DEFINITION.md) — standalone YAML schema for importing/exporting agent definitions.
 - [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
 - [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
-- [Agent definition format](../AGENT-DEFINITION.md) — the portable YAML format for importing/exporting agents.
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [ACMM policy fragments](../../examples/acmm/README.md) — per-level ACMM policy references.
 - [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -5,8 +5,10 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Operations
 
 - [Manual provisioning](manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
+- [Self-hosted hub deployment](hub-deployment.md) — `HIVE_MODE=hub`, hub storage, heartbeat secrets, and SaaS spoke registration.
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, and GitHub token scopes.
+- [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
 - [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
 - [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -9,6 +9,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, and GitHub token scopes.
 - [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
+- [Troubleshooting](troubleshooting.md) — v2 container logs, config validation, agent tmux sessions, dashboard auth, and GitHub credential checks.
 - [Cross-cluster migration](cross-cluster-migration.md) — moving a hive between clusters without losing state.
 - [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
 - [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
@@ -17,6 +18,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Token collection and usage tracking](token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
 - [Notifications](notifications.md) — ntfy, Slack, and Discord alert channels, plus the two-way [Discord bot](../../discord/README.md).
 - [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
+- [Custom stylesheets](custom-stylesheets.md) — public CSS theme injection for dashboard, leaderboard, and snapshot surfaces.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [`bd` beads CLI](beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
 - [Backup and restore](backup-restore.md) — `hive-backup`, Kubernetes CronJob, and spoke backup scope.
@@ -36,7 +38,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
-- [Supervisor agent](supervisor.md) — supervisor policy templates and when to use each.
+- [Supervisor agent](supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
 - [Custom dashboard stylesheets](custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
 - [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
 - [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.

--- a/v2/docs/acmm-policy-matrix.md
+++ b/v2/docs/acmm-policy-matrix.md
@@ -99,9 +99,9 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 | outreach | full | `outreach-full.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-## Tester lane
+## Example config alignment
 
-`v2/hive.yaml.example` includes a `tester` support agent that runs automated test suites, coverage gates, and nightly regression checks. It is intentionally outside the built-in ACMM policy packs in `v2/pkg/config/packs/`: the packs generate governance lanes, while `tester` is an operator-enabled local lane with cadences in the example config. If enabled, give it an explicit policy/template appropriate for the repository before granting write permissions.
+`v2/hive.yaml.example` uses the built-in `quality` lane for automated test suites, coverage gates, and regression checks. There is no built-in `tester` lane in the ACMM packs, known-agent defaults, or shipped policy templates; operators who want a separate tester must define it as a custom agent with explicit metadata and a policy template.
 
 ## Key Rules
 

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -317,9 +317,9 @@ Portable agents bundle everything — config plus a `promptTemplate` — in a si
 ## What to read next
 
 - **[Supervisor agent](supervisor.md)** — what the supervisor does, how it differs from the governor, when to enable it, `bead_role` semantics, and policy modes.
-- **[Introduction](https://kubestellar.io/docs/hive/overview/introduction)** — what hive is, setup, and the command surface.
-- **[Architecture](https://kubestellar.io/docs/hive/overview/architecture)** — the two scheduling models and how the supervisor drives agents.
-- **[Troubleshooting](https://kubestellar.io/docs/hive/getting-started/troubleshooting)** — stuck sessions, login expiry, restart loops.
+- **[Documentation index](README.md)** — what hive is, setup, and the full topic-guide surface.
+- **[Architecture](architecture.md)** — the process model, governor loop, and how the supervisor drives agents.
+- **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.
 - **[ACMM policy matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.
 - **[Config layering](config-layering.md)** — precedence for seed, dashboard overlay, agent overlays, and runtime snapshots.
 - **[Cross-cluster migration](cross-cluster-migration.md)** — moving a hive (and its PVC state) between clusters.

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -14,7 +14,7 @@ agents:
 ```
 
 
-For a complete portable `AgentDefinition` that exercises advanced display, channel, tool, and connection fields, see [v2/examples/agents/customized-agent.yaml](../examples/agents/customized-agent.yaml).
+For the portable agent definition YAML format, see [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md). For a complete portable `AgentDefinition` that exercises advanced display, channel, tool, and connection fields, see [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
 
 That is a complete, valid agent. Defaults fill in the rest at load time:
 
@@ -297,7 +297,7 @@ At L5, every agent PR gets a `hold` label automatically. The system proposes; it
 
 Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM pack's template for that agent at the current level; otherwise convention — `/data/agents/<name>/CLAUDE.md`, then `<name>.md` in the policies checkout, then the embedded default. Pack templates carry the level's policy in their names — `scanner-holdgated.md` is scanner-at-L5; the same scanner at L6 gets `scanner-automerge.md`.
 
-Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard (see [`v2/examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml)).
+Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard. The reference schema is [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md), and a worked example lives at [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
 
 ## When to add what
 
@@ -321,8 +321,10 @@ Portable agents bundle everything — config plus a `promptTemplate` — in a si
 
 - **[Supervisor agent](supervisor.md)** — what the supervisor does, how it differs from the governor, when to enable it, `bead_role` semantics, and policy modes.
 - **[Documentation index](README.md)** — what hive is, setup, and the full topic-guide surface.
-- **[Architecture](architecture.md)** — the process model, governor loop, and how the supervisor drives agents.
+- **[Architecture](architecture.md)** — process model, deterministic pipeline, governor loop, guardrails, and hub/spoke design.
+- **[Portable AgentDefinition format](../AGENT-DEFINITION.md)** — standalone YAML schema for agent imports, exports, and overlays.
 - **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.
+- **[Troubleshooting](../../docs/troubleshooting.md)** — stuck sessions, login expiry, restart loops, and notification checks.
 - **[ACMM policy matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.
 - **[Config layering](config-layering.md)** — precedence for seed, dashboard overlay, agent overlays, and runtime snapshots.
 - **[Cross-cluster migration](cross-cluster-migration.md)** — moving a hive (and its PVC state) between clusters.

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -113,6 +113,9 @@ agents:
     detect_keywords: [scanner, triage]  # attributes GitHub activity back to this agent
 ```
 
+For prompt file resolution and the complete built-in `${VAR}` reference, see
+[Policy and prompt templates](../policies/README.md).
+
 ### Declarative extensions
 
 Three optional blocks replace hardcoded behavior with declarations:

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -152,7 +152,7 @@ Set `replicas: N` on a declared agent to run a small pool with the same prompt, 
 | Type | Required fields | Behavior |
 |---|---|---|
 | `kick` | none | Keep ordinary governor timer kicks. |
-| `webhook` | `events` | `/webhook`/GitHub webhook receiver matches `X-GitHub-Event` or `event.action` strings such as `issues.opened`; optional `repos` filters by repository name. If `HIVE_WEBHOOK_SECRET` is set, GitHub `X-Hub-Signature-256` HMAC is verified. |
+| `webhook` | `events` | `/webhook`/GitHub webhook receiver matches `X-GitHub-Event` or `event.action` strings such as `issues.opened`; optional `repos` filters by repository name. `HIVE_WEBHOOK_SECRET` is required and every request must include a valid GitHub `X-Hub-Signature-256` HMAC. Missing configuration or invalid signatures fail closed with `401`. |
 | `bead` | `match` | The bead watcher polls the agent's `beads_dir` about every 30 seconds and kicks when an individual JSON file has every `key: value` in `match` at the top level. Current watcher matching is not the nested `metadata` map inside the `bd` ledger file. |
 | `schedule` | `schedule` | Cron-style channel trigger independent of governor-mode cadences. |
 | `discord` | `patterns` | Declared shape for Discord-triggered work; patterns are validated by config load. |

--- a/v2/docs/apiproxy.md
+++ b/v2/docs/apiproxy.md
@@ -29,8 +29,9 @@ Environment:
 
 ## Deployment notes
 
-At v2 HEAD, the binary listens on `:<port>` (all interfaces). Treat it as an
-internal sidecar or bind it behind a firewall/network policy unless you have a
-newer change that binds to localhost by default. Security PR #2935, which tracks
-localhost binding and warning on `ANTHROPIC_API_KEY` key-injection fallback, was still open when
-this document was written.
+By default the binary listens on `:<port>` (all interfaces). Treat it as an
+internal sidecar and bind it behind a firewall or NetworkPolicy so nothing on
+the pod network can reach it directly. If your build exposes a bind-address
+flag, prefer binding to `127.0.0.1` so only same-container callers can reach the
+proxy. Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in
+production — configure `PROXY_AUTH_TOKEN` explicitly instead.

--- a/v2/docs/apiproxy.md
+++ b/v2/docs/apiproxy.md
@@ -10,12 +10,15 @@ client request does not already carry a valid `Authorization` or `X-Api-Key` hea
 ```bash
 go build -o bin/apiproxy ./cmd/apiproxy
 PROXY_AUTH_TOKEN=... bin/apiproxy --port 9000 --upstream https://api.anthropic.com --log apiproxy.jsonl
+# To expose beyond the local host, opt in explicitly:
+PROXY_AUTH_TOKEN=... bin/apiproxy --host 0.0.0.0 --port 9000 --upstream https://api.anthropic.com
 ```
 
 Flags verified from `cmd/apiproxy/main.go`:
 
 | Flag | Default | Purpose |
 |---|---|---|
+| `--host` | `127.0.0.1` | Listen address. The default is localhost-only; use `--host 0.0.0.0` only when another container/pod must reach the proxy and network policy/firewall rules protect it. |
 | `--port` | `9000` | Listen port. |
 | `--upstream` | `https://api.anthropic.com` | Upstream API base URL. |
 | `--log` | stdout | Optional JSONL log file. |
@@ -25,13 +28,12 @@ Environment:
 | Name | Purpose |
 |---|---|
 | `PROXY_AUTH_TOKEN` | Preferred upstream API key used to set an outbound bearer Authorization header when the client did not send a valid key. |
-| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. |
+| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. The proxy logs a warning when this fallback is used because any client that can reach the proxy can use the host Anthropic key. |
 
 ## Deployment notes
 
-By default the binary listens on `:<port>` (all interfaces). Treat it as an
-internal sidecar and bind it behind a firewall or NetworkPolicy so nothing on
-the pod network can reach it directly. If your build exposes a bind-address
-flag, prefer binding to `127.0.0.1` so only same-container callers can reach the
-proxy. Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in
-production — configure `PROXY_AUTH_TOKEN` explicitly instead.
+The binary listens on `127.0.0.1:<port>` by default. Treat `--host 0.0.0.0` as
+an explicit compatibility opt-in for deployments that need cross-container or
+cross-pod access, and pair it with network policy/firewall controls.
+Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in production —
+configure `PROXY_AUTH_TOKEN` explicitly instead.

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -145,6 +145,7 @@ Before any agent is kicked, `run-pipeline.sh` runs the `pre-kick` stages defined
 in `hive-project.yaml`, topologically sorted by their declared dependencies. Each
 stage is a shell script that writes a JSON artifact other stages and agents
 consume — so an agent is handed pre-filtered, pre-classified, merge-gated work.
+For a script-by-script index of this layer, see [`../../bin/README.md`](../../bin/README.md).
 
 ```mermaid
 flowchart LR

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -11,9 +11,10 @@ merge-gating, permission enforcement) from **judgment calls** (reading code,
 reasoning about a fix, writing a PR). Deterministic work runs in Go and shell
 before any LLM sees the task; agents only handle the judgment.
 
-> This document describes the `v2` branch. The planning-intelligence subsystem
-> (goal decomposition, plan review, stall-replan) is **v3-only** and is called
-> out where relevant.
+> This document describes the `v2` branch. Automatic goal decomposition, plan
+> review, and stall-triggered re-planning are not implemented in v2 HEAD; treat
+> any mention of those capabilities outside this page as future/design-only
+> material unless the code grows matching planner/replan paths.
 
 ---
 

--- a/v2/docs/backup-restore.md
+++ b/v2/docs/backup-restore.md
@@ -54,5 +54,77 @@ Before applying it, create Secret `hive-hub-backup-key` with key `backup-key`, e
 
 `pkg/spokebackup` is complementary: it backs up one spoke on demand for its owner and includes the spoke's bead ledger. It is encrypted with the same `HIVE_BACKUP_KEY` mechanism and is sized for browser download, not nightly fleet DR. It includes `hive.yaml.dashboard`, runtime config files, `hive-id`, `hive-state.json`, GitHub App keys, and `/data/beads/*`; it skips bulk/derived data and live dashboard sessions.
 
+## Docker Compose
+
+`v2/docker-compose.yaml` is a standalone deployment. It runs the hive container on a single Docker host, without a Kubernetes cluster.
+
+### Durable state
+
+The compose file persists three things:
+
+- the Docker named volume `hive-data`, mounted at `/data`;
+- the host directory `./secrets`, bind-mounted read-only at `/secrets`;
+- the host file `./hive.yaml`, mounted at `/etc/hive/hive.yaml`.
+
+On Docker and LXC the entrypoint treats `/data` as the boot-time source of truth. It restores `/data/hive.yaml.runtime` over the config path at every boot. `/data/hive.yaml.bak` is the legacy runtime name. `/data/hive.yaml.dashboard` is the dashboard save overlay.
+
+`/data` holds the durable identity and state:
+
+- `hive-id`;
+- `hive-state.json`;
+- `gh-app-key*.pem`, the GitHub App private keys;
+- `beads/`, the agent work ledger.
+
+Hub deployments also keep `hub-registry.json` and `clusters.json` in `/data`. A standalone Compose spoke has neither.
+
+Regenerable bulk state such as `nous/`, `home/`, and `logs/` can be excluded from a backup. `docker compose down -v` deletes the named volume.
+
+### `hive-backup run` does not apply
+
+`hive-backup run` is the Kubernetes hub disaster-recovery path. It cannot run on a Docker Compose deployment. `pkg/hubbackup/run.go` calls `LoadTargets(dataDir)`, which hard-fails when `clusters.json` is absent. `KubectlSecretCollector` collects hub Kubernetes Secrets through in-cluster kubectl. A Compose deployment has no `clusters.json` and no in-cluster kubectl. Use the spoke backup and the host-level pattern below.
+
+### Spoke backup works
+
+The `pkg/spokebackup` path works for a Compose spoke. It reads the data directory from `HIVE_SPOKE_BACKUP_DATA_DIR`, which defaults to `/data`. The dashboard serves it from inside the same hive container.
+
+- `GET /api/backup/status` reports whether a backup can run.
+- `POST /api/backup` builds and streams an encrypted archive.
+
+Both endpoints are owner-only. They require the `X-Hive-Role: owner` header. They require `HIVE_BACKUP_KEY` in the container environment, a 64-character hex AES-256 key. The shipped compose files do not pass `HIVE_BACKUP_KEY`. Add it to `.env` and add `HIVE_BACKUP_KEY=${HIVE_BACKUP_KEY}` to the `environment` block of the `hive` service.
+
+The archive contains the spoke config files (`hive.yaml.dashboard`, `hive.yaml.runtime` or the legacy `hive.yaml.bak`), `hive-id`, `hive-state.json`, the GitHub App private keys, and `beads/`. It is encrypted and sized for browser download, not nightly fleet DR.
+
+### Host-level backup pattern
+
+Back up the named volume and the secrets directory from the host:
+
+```bash
+docker run --rm -v v2_hive-data:/data -v "$(pwd)":/backup alpine tar czf /backup/hive-data-$(date +%F).tar.gz -C /data .
+tar czf secrets-$(date +%F).tar.gz ./secrets
+```
+
+Docker Compose prefixes named volumes with the project name. With `cd v2 && docker compose up -d`, the project is `v2`, so the volume is `v2_hive-data`. `docker volume ls` shows the real name.
+
+To restore:
+
+1. Create a fresh named volume with `docker volume create v2_hive-data`. `docker compose up -d` also creates it when it is missing.
+2. Extract the volume tarball into the volume:
+
+   ```bash
+   docker run --rm -v v2_hive-data:/data -v "$(pwd)":/backup alpine tar xzf /backup/hive-data-$(date +%F).tar.gz -C /data
+   ```
+
+   Use the archive name from the backup step. The example recreates the current-date name.
+
+3. Extract the secrets tarball over the host directory:
+
+   ```bash
+   tar xzf secrets-$(date +%F).tar.gz
+   ```
+
+4. Run `docker compose up -d`.
+
+The entrypoint restores the runtime config at boot. Escrow `HIVE_BACKUP_KEY` outside the host.
+
 Fixes #2986.
 Fixes #2942.

--- a/v2/docs/beads-cli.md
+++ b/v2/docs/beads-cli.md
@@ -42,5 +42,3 @@ bd close bead-123
 | `bd kb ctx7-search <name>` | Search Context7 library IDs. |
 | `bd kb import-ctx7 <library-id> [--name <n>] [--query <topic>]` | Import Context7 docs into the community layer. |
 | `bd kb list-docs` | List imported documents. |
-
-Fixes #2981.

--- a/v2/docs/cncf-reference-architecture.md
+++ b/v2/docs/cncf-reference-architecture.md
@@ -36,6 +36,12 @@ reference_architectures:
   - AI/ML
 ---
 
+> **Purpose:** This page is a **CNCF reference-architecture submission template**,
+> not operator or contributor documentation. It describes how Hive relates to CNCF
+> projects for the CNCF landscape/reference-architecture process. For running or
+> developing Hive, start from the [docs index](README.md) and
+> [architecture.md](architecture.md) instead.
+
 ## Relevant CNCF projects
 
 {{< cardpane >}}

--- a/v2/docs/contributor-relay.md
+++ b/v2/docs/contributor-relay.md
@@ -84,5 +84,3 @@ kubectl -n my-namespace rollout status deploy/hive-contributor
 The generated pod sets `CONTRIBUTOR_MODE=headless` because Kubernetes pods have no TTY; interactive tmux mode would stall. Headless mode is currently verified for `claude`, `litellm`, `copilot`, `codex`, and `goose`. The Deployment has one replica per registered contributor identity and uses readiness/liveness probes that read the relay's headless status file (`waiting`, `working`, `done` pass; missing/failed state fails).
 
 The generated Secret contains the registration token and `GH_TOKEN` as Kubernetes Secret data. Treat it as sensitive cluster-readable material and prefer a pinned image tag/digest for repeatable operation.
-
-Fixes #3024.

--- a/v2/docs/cross-cluster-migration.md
+++ b/v2/docs/cross-cluster-migration.md
@@ -44,6 +44,103 @@ Two reasons it must not be used here:
 > If a previous attempt died mid-flight, clear the field in the hive's
 > `meta.json` (step 4 below).
 
+## When to use the built-in migrate API
+
+The built-in migrate API is the automatic path. It moves a hive from one
+cluster to another. It works as fresh provision on the target plus
+deprovision of the source. It copies no data. The hive rebuilds its state
+from GitHub on the target.
+
+Use it when all of these hold:
+
+1. **The hub can run `kubectl` against both clusters.** Each cluster needs
+   an entry in `/data/saas/clusters.json` on the hub PVC. The entry carries
+   a `kubeconfig_path` and a `context` for the hub to use. The hub runs
+   plain `kubectl` for the in-cluster entry.
+2. **No hive data must be preserved.** The API does not copy volume data.
+3. **You are the hive owner or the hub admin.** The hub rejects any other
+   caller with a 403.
+
+### The API call
+
+The endpoint is `POST /api/saas/hives/{id}/migrate`. The body is JSON with
+one field, `target_cluster_id`. The body is limited to 1024 bytes. The
+endpoint requires hub auth.
+
+```bash
+curl -X POST -b "hive_hub_user=YOUR_USERNAME" \
+  -H "Content-Type: application/json" \
+  -d '{"target_cluster_id":"<target-cluster-id>"}' \
+  https://hive.kubestellar.io/api/saas/hives/<hive-id>/migrate
+```
+
+The hub answers immediately with HTTP 200:
+
+```json
+{"status":"migrating","from":"<source-cluster-id>","to":"<target-cluster-id>"}
+```
+
+The migration runs in a background goroutine. The response above is not the
+outcome. The dashboard Move-to-cluster modal calls the same endpoint.
+
+### What the hub does
+
+1. **Validates the request.** The hive must exist. The caller must be the
+   owner or the hub admin. The hive must not be migrating already. The
+   target cluster must exist and differ from the current cluster.
+2. **Marks the hive as migrating.** It sets `migration_status` to
+   `"migrating"` and saves the hive record.
+3. **Reads the credentials from the source.** It reads the `hive-secrets`
+   Secret and the `hive-config` ConfigMap in the source namespace. It
+   carries the GitHub token, or the GitHub App private key with `app_id`
+   and `installation_id`.
+4. **Provisions a fresh hive on the target.** The new hive keeps the same
+   org, repos, primary repo, and ACMM level. The subdomain becomes
+   `<hive-id>.<target domain>`.
+5. **On provision failure, marks the migration as failed.** It sets
+   `migration_status` to `"failed"` and records the error in the hive
+   record. It restores `status` to `"running"`.
+6. **On success, deprovisions the source.** It deletes the namespace, the
+   PV and OCI resources for NFS storage, the SCC binding on OpenShift, the
+   on-disk hive directory, and the user quota records.
+7. **Updates the hive record.** It sets `cluster_id` to the target, `status`
+   to `"provisioning"`, and `migration_status` to `"completed"`.
+8. **Updates the registry entry.** It sets the new cluster ID, name, and
+   dashboard URL. A claimed hive keeps its vanity URL.
+9. **The provision watcher finishes the move.** It polls the hive
+   deployment on the target. Once the deployment has 1 available replica,
+   it sets `status` to `"running"` and clears the migration fields.
+
+### Failure signals
+
+A failed migration leaves `migration_status` as `"failed"` in the hive
+record. The `error` field of the record carries the message. The record
+lives at `/data/saas/hives/<hive-id>/meta.json` on the hub PVC.
+
+### Verify success
+
+Check the deployment on the target cluster:
+
+```sh
+kubectl get deployment hive -n hive-hosted-<hive-id> \
+  -o jsonpath={.status.availableReplicas}
+```
+
+A value of `1` means the hive runs on the target. The registry entry shows
+the new cluster. The `migration_status`, `migration_from`, and
+`migration_to` fields in `meta.json` are cleared.
+
+### Gotchas
+
+- A hive with `migration_status` set to `"migrating"` rejects any further
+  migrate call with a 409. If an attempt failed mid-flight, clear the field
+  in `meta.json` before you retry.
+- The API is destructive. It provisions fresh and deprovisions the source.
+  It copies no data. State must be rebuildable from GitHub.
+
+Implementation: `handleMigrateHive` in `pkg/hub/saas.go`, plus `migrateHive`,
+`deprovisionHive`, and `startProvisionWatcher` in `pkg/hub/saas_provision.go`.
+
 ## Manual migration procedure
 
 ### 1. Copy the namespace resources to the target

--- a/v2/docs/env-vars.md
+++ b/v2/docs/env-vars.md
@@ -1,0 +1,157 @@
+# Environment variable reference
+
+This reference is generated from the v2 source, deployment manifests, and the top-level helper scripts. The code is authoritative: `hive.yaml` may also expand arbitrary `${NAME}` placeholders through the config resolver, but only the variables below have built-in behavior.
+
+## Core `hive` runtime
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_CONFIG` | No | `/etc/hive/hive.yaml` | Default config path used before the `--config` flag is parsed. The dashboard also uses it when reporting config provenance. |
+| `HIVE_MODE` | No | spoke/dashboard mode | Set to `hub` to run the hub server instead of the spoke dashboard. |
+| `HIVE_HUB_PORT` | No | `3001` | Hub listen port when `HIVE_MODE=hub`. |
+| `HIVE_SINGLETON_LOCK` | No | `/var/run/hive-metrics/hive.singleton.lock` when available, otherwise OS temp dir | Overrides the process singleton lock path. Set exactly `off` only for local development where duplicate processes are intentional. |
+| `HIVE_GITHUB_TOKEN` | Required unless GitHub App auth is configured | none | Main PAT fallback for `github.token`; also used by fleet/stat fallback paths and some deployment manifests. |
+| `GH_APP_KEY_FILE` | No | configured `github.key_file`, then `/data/gh-app-key.pem` or `/secrets/gh-app-key.pem` in provisioned paths | GitHub App private-key file fallback. |
+| `DASHBOARD_AUTH_TOKEN` | No | none | Kubernetes/provisioned secret name for the dashboard shared token; used before `HIVE_DASHBOARD_TOKEN` when `dashboard.auth_token` is empty. |
+| `HIVE_DASHBOARD_TOKEN` | No | none | Dashboard/API shared-token fallback and default `hivectl --token-env` variable. |
+| `HIVE_AUTHORIZED_USERS` | No | none | Comma-separated direct-route dashboard allowlist, with optional `user:role` entries. Used when `dashboard.authorized_users` is empty. |
+| `HIVE_REPO` | No | none | Bootstrap shortcut in `owner/repo` form; fills `project.org`, `project.repos`, and `project.primary_repo` if missing. |
+| `HIVE_LEVEL` | No | config/pack value | ACMM level bootstrap/override used by hosted flows and the entrypoint pack selection. |
+| `HIVE_ID` | No | config or generated id | Stable hive/spoke identifier override; passed through to launched agents. |
+| `HIVE_CLUSTER_ID` | No | config or hub-provisioned value | Hosted cluster identifier override. |
+| `HIVE_HUB_URL` | No | `hub.url` from config | Hub URL override for spoke heartbeats/registration. |
+| `HIVE_HUB_SECRET` | Required for spokes registered to a protected hub; optional for a standalone hub with `/data/saas/hub-secret.key` | `/data/saas/hub-secret.key` on the hub when present; no fallback for spoke heartbeat auth | Bearer secret for spoke heartbeats and hub/spoke SaaS APIs. |
+| `HIVE_COVERAGE_BADGE_URL` | No | none | Optional coverage badge URL exposed in dashboard status. |
+| `HIVE_WORK_DIR` | No | `/data/agents` | Agent manager working directory. |
+| `HIVE_SHA` | No | build SHA | Passed to launched agents and used in hub upgrade/status paths. |
+| `HIVE_ADVISORY_ISSUE` | No | none | Passed to launched agents so advisory findings can target a configured issue. |
+| `HIVE_TTYD_PORT` | No | `7681` | Web terminal port used by the entrypoint and terminal proxy. |
+| `HIVE_METRICS_ENABLED` | No | disabled | Enables unauthenticated Prometheus `/metrics` when set to `1`, `true`, `yes`, or `on`. |
+| `HIVE_METRICS_FILE` | No | `/var/run/hive-metrics/contribute.json` | Contributor metrics JSON file override. |
+| `HIVE_COPILOT_INTEGRATION_ID` | No | compiled Copilot integration id | Overrides the integration id used by Copilot model discovery. |
+| `HIVE_PROXY_PROOF_REQUIRED` | No | `false` | Requires the internal proxy proof header when set to `true`. |
+| `HIVE_CONTRIBUTORS_DIR` | No | hub default | Contributor registry directory override. |
+| `HIVE_FEDERATION_REGISTRY_PATH` | No | `/data/federation/registry.json` | Federation registry path override. |
+| `HIVE_WEBHOOK_SECRET` | No | none | HMAC secret for the spoke `/webhook` channel. |
+| `GITHUB_WEBHOOK_SECRET` | No | `/data/saas/webhook-secret.key` when present | Hub GitHub webhook HMAC secret. |
+
+## Deployment entrypoint and proxy knobs
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_API_PORT` | No | `3002` | Internal Go API port used by `v2/deploy/entrypoint.sh`. |
+| `HIVE_PROXY_PORT` | No | `3001` | Node reverse-proxy/front-door port used by `v2/deploy/entrypoint.sh`. |
+| `HIVE_STATIC_DIR` | No | `/opt/hive/proxy/public` | Static asset directory for the Node proxy. |
+| `HIVE_PROXY_EGRESS_MARK` | No | `0x1112` | Packet mark exempted from the MITM egress redirect. |
+| `HIVE_WIKI_GIT_URL` | No | none | Optional wiki vault URL cloned into `/data/vaults/hive-wiki` on first boot. |
+
+## Inference, CLI backends, and agents
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_VLLM_ENDPOINT` | No | `http://hive-vllm-svc.hive-inference.svc.cluster.local:8000` in code; `v2/deploy/k8s/deployment.yaml` sets `http://vllm-svc.hive-inference.svc.cluster.local:8000` | Comma-separated vLLM endpoint list. |
+| `HIVE_LLMD_ENDPOINT` | No | `http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000` in code; `v2/deploy/k8s/deployment.yaml` sets `http://llm-d-epp.hive-inference.svc.cluster.local:8000` | Comma-separated llm-d endpoint list. |
+| `HIVE_LITELLM_ENDPOINT` | No | YAML `governor.litellm.endpoint`; unset means LiteLLM is unregistered unless `local_proxy` is true | Runtime LiteLLM base URL override. |
+| `HIVE_VLLM_API_KEY` | No | none | Default bearer token for vLLM model discovery when no backend-specific `api_key_env` or file resolves. |
+| `HIVE_LLMD_API_KEY` | No | none | Default bearer token for llm-d model discovery when no backend-specific `api_key_env` or file resolves. |
+| `HIVE_LITELLM_API_KEY` | No | `/secrets/litellm_api_key` or `/data/secrets/litellm_api_key` may be used first | Default LiteLLM API key environment variable. |
+| `HIVE_VLLM_MODELS` | No | static fallback aliases | Comma-separated vLLM model IDs used when discovery returns none. |
+| `HIVE_LLMD_MODELS` | No | static fallback aliases | Comma-separated llm-d model IDs used when discovery returns none. |
+| `HIVE_LITELLM_MODELS` | No | static fallback aliases | Comma-separated LiteLLM model IDs used when discovery returns none. |
+| `HIVE_BOB_API_KEY` | Required only for Bob agents in pods unless a key file is mounted or saved on `/data` | `/secrets/bob_api_key` or `/data/secrets/bob_api_key` may be used first | Hive-side Bob API key source. The value is injected into Bob as `BOBSHELL_API_KEY`. |
+| `HIVE_BOB_API_URL` | No | `https://api.us-east.bob.ibm.com` | Bob key-test endpoint base URL override. |
+| `BOBSHELL_API_KEY` | Required by Bob CLI when Hive injects or contributor mode uses Bob | none | API key name read by bobshell itself. |
+| `COPILOT_GITHUB_TOKEN` | No | dashboard device-flow token file, if present | Copilot completion/model-discovery token and explicit agent injection. |
+| `ANTHROPIC_API_KEY` | Required by `cmd/apiproxy` unless `PROXY_AUTH_TOKEN` is set; agent inference backends receive a synthetic value | none | Anthropic-compatible API key for apiproxy auth or CLI compatibility. |
+| `PROXY_AUTH_TOKEN` | No | `ANTHROPIC_API_KEY` | Preferred auth token for `cmd/apiproxy`. |
+| `CONTEXT7_API_KEY` | No | none | Optional key for Context7 knowledge API integration. |
+| `GOOSE_PROVIDER` | No | Goose CLI default | Provider passed through Goose backend/model resolution. |
+| `GOOSE_MODEL` | No | Goose CLI default | Model passed through Goose backend/model resolution and contributor relay fallback. |
+| `BD_DIR` | No | current directory | `bd` beads CLI data directory. |
+| `BD_DASHBOARD_URL` | No | none | Dashboard URL used by `bd kb` integration. |
+| `HIVE_CONN_<NAME>_URL` | No | generated from agent connection config | Agent API connection URI variable when a connection omits `env_name`; `<NAME>` is the uppercased connection name with `-` replaced by `_`. |
+| Custom connection auth env vars | No | none | If an agent API connection uses `auth.type: env`, Hive reads `auth.env_var` and injects that exact variable into the agent. |
+
+## Hub, SaaS, alerts, and backups
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_HUB_OAUTH_CLIENT_ID` | Required to enable hub OAuth | none | Enables hub `/login` and OAuth callback routes. |
+| `HIVE_HUB_OAUTH_CLIENT_SECRET` | Required when hub OAuth is enabled | none | OAuth client secret used during callback token exchange. |
+| `HIVE_HUB_SLACK_BOT_TOKEN` | No | none | Slack bot token for hub Slack notifications. |
+| `HIVE_NTFY_SERVER` | No | none | ntfy server for hub auth-audit alerts. |
+| `HIVE_NTFY_TOPIC` | No | none | ntfy topic for hub auth-audit alerts. |
+| `HIVE_BACKUP_KEY` | Yes for hub DR backups and browser spoke backups | none | 64-character hex or base64 AES-256 key. Unset makes backup creation fail. |
+| `HIVE_BACKUP_BUCKET` | Required for OCI upload mode | none | OCI Object Storage bucket for hub backup archives. |
+| `HIVE_BACKUP_DATA_DIR` | No | `/data` | Hub data directory used by `hive-backup`. |
+| `HIVE_BACKUP_RETENTION` | No | `30` | Number of backup archives to retain. |
+| `HIVE_BACKUP_OCI_ENDPOINT` | No | OCI SDK default endpoint | OCI Object Storage endpoint override. |
+| `HIVE_HUB_NAMESPACE` | No | current/default namespace | Hub namespace override for backup collection. |
+| `HIVE_KUBECONFIG_DIR` | No | `/etc/hive/kubeconfigs` | Directory containing per-cluster kubeconfigs for remote spoke backup collection. |
+| `HIVE_SPOKE_BACKUP_DATA_DIR` | No | `/data` | Spoke data directory for on-demand spoke backup. |
+| `OCI_TENANCY_OCID` | Required for OCI FSS/Object Storage flows | none | OCI tenancy OCID. |
+| `OCI_USER_OCID` | Required for OCI FSS/Object Storage flows | none | OCI user OCID. |
+| `OCI_FINGERPRINT` | Required for OCI FSS/Object Storage flows | none | OCI API key fingerprint. |
+| `OCI_PRIVATE_KEY` | Required for OCI FSS/Object Storage flows | none | OCI API private key PEM content. |
+| `OCI_REGION` | Required for Object Storage backup | none | OCI Object Storage region. |
+| `OCI_FSS_REGION` | Required for OCI FSS provisioning unless region is otherwise configured | none | OCI File Storage region. |
+| `OCI_COMPARTMENT_ID` | Required for OCI FSS provisioning | none | OCI compartment OCID. |
+| `OCI_AVAILABILITY_DOMAIN` | Required for OCI FSS provisioning | none | OCI availability domain. |
+| `OCI_MOUNT_TARGET_ID` | Required for OCI FSS provisioning | none | OCI mount target OCID. |
+| `OCI_EXPORT_SET_ID` | Required for OCI FSS provisioning | none | OCI export set OCID. |
+
+## Kubernetes downward API and platform variables
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `POD_NAMESPACE` | No | `NAMESPACE`, then `default` | Preferred downward-API namespace value for dashboard/spoke identity. |
+| `NAMESPACE` | No | `default` | Fallback namespace when `POD_NAMESPACE` is unset. |
+| `KUBERNETES_SERVICE_HOST` | Set by Kubernetes | none | Used with `KUBERNETES_SERVICE_PORT` to detect in-cluster execution and build API URLs. |
+| `KUBERNETES_SERVICE_PORT` | Set by Kubernetes | none | Kubernetes API service port. |
+| `HOME` | Set by OS/container | none | Used to locate CLI credentials in several backend probes. |
+| `PATH` | Set by OS/container | none | Used by helper tests and inherited by subprocesses. |
+
+## Contributor relay and top-level helper scripts
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_HUB` | Required after registration for contributor relay; `just` can discover/set it | `wss://hive.kubestellar.io/contribute` in `Justfile`; `wss://hive.kubestellar.io:3001/contribute` in compose/relay defaults | Contributor WebSocket hub URL. Comma-separated values are supported with matching `HIVE_REGISTRATION_TOKEN` entries. |
+| `HIVE_REGISTRATION_TOKEN` | Yes for contributor relay | none | Contributor registration token. Comma-separated values match `HIVE_HUB` by position. |
+| `AGENT_BACKEND` | No | `claude` | Contributor/agent CLI backend selector. |
+| `AGENT_MODEL` | No | backend default, or `GOOSE_MODEL` for Goose fallback | Contributor/agent model override. |
+| `CONTRIBUTOR_MODE` | No | `interactive` | Contributor relay mode: `interactive` uses tmux; `headless` uses one-shot CLI execution for supported backends. |
+| `HIVE_HEADLESS_STATUS_FILE` | No | `/tmp/contributor-headless-status.json` | Status file written by headless contributor relay. |
+| `HIVE_CONTRIBUTOR_IMAGE` | No | `ghcr.io/kubestellar/hive-contributor:latest` | Image used by `just contribute-hive`. |
+| `HIVE_CONTAINER_RUNTIME` | No | autodetect `docker` or `podman` | Container runtime override for contributor helpers. |
+| `HIVE_SKIP_VERSION_CHECK` | No | `false` | Skips `just` version freshness check when set to `true`. |
+| `HIVE_SKIP_PULL` | No | `false` | Skips contributor image pull when set to `true`. |
+| `HIVE_KEEP_CONTAINER` | No | remove failed contributor container | Keeps failed contributor containers for debugging when set to `true`. |
+| `HIVE_PROJECT_CONFIG` | No | `/etc/hive/hive-project.yaml` | Path read by `bin/hive-config.sh` for deterministic pipeline/project metadata. |
+| `HIVE_PROJECT_YAML` | No | `/etc/hive/hive-project.yaml`, then first example found | Path read directly by pipeline stages. |
+| `HIVE_RUNTIME_CONFIG` | No | `/etc/hive/hive-runtime.yaml` | Runtime overlay read by `bin/hive-config.sh`. |
+| `HIVE_REPO_DIR` | No | `/tmp/hive` | Hive checkout path used by top-level deployment scripts. Must not be empty or `/`. |
+| `HIVE_BIN` | No | `/usr/local/bin` | Directory containing helper binaries such as `gh-app-token.sh`. |
+| `HIVE_REPOS` | Required by v1/top-level supervisor scripts if project config is absent | none | Space-separated repos for legacy/top-level script workflows. |
+| `HIVE_BACKENDS` | No | `copilot` in bootstrap example | Backend list for legacy/top-level script setup. |
+| `HIVE_MODEL_SERVICES` | No | none | Optional local model stack selector in legacy bootstrap scripts. |
+| `HIVE_AUTO_INSTALL` | No | script default | Controls CLI auto-install in legacy bootstrap scripts. |
+| `AGENT_SESSION_NAME` | No | `hive` in `config/agent.env.example` | tmux session name for legacy/top-level supervised agent scripts. |
+| `AGENT_LOOP_PROMPT` | No | example executor prompt | Prompt sent by legacy/top-level supervisor scripts. |
+| `AGENT_READY_MARKER` | No | configured in `agent.env` | TUI marker used by legacy/top-level supervisor readiness checks. |
+| `AGENT_AUTO_APPROVE_PHRASE` | No | none | Legacy/top-level supervisor phrase used to auto-dismiss a known prompt. |
+| `AGENT_LOG_FILE` | No | configured in `agent.env` | Legacy/top-level heartbeat/healthcheck log path. |
+| `NTFY_TOPIC` | No | `hive` in `bin/kick-agents.sh`; blank disables `bin/notify.sh` | ntfy topic for top-level script notifications. |
+| `NTFY_SERVER` | No | `https://ntfy.sh` | ntfy server for top-level script notifications. |
+| `SLACK_WEBHOOK` | No | none | Slack incoming webhook for top-level script notifications. |
+| `DISCORD_WEBHOOK` | No | none | Discord webhook for top-level script notifications. |
+
+## Verification commands
+
+The table above was cross-checked with these mechanical searches from the repository root:
+
+```sh
+rg 'os\.(Getenv|LookupEnv)\(' v2 --glob '*.go'
+rg '\bHIVE_[A-Z0-9_]+\b|\bBD_DIR\b|\bGH_APP_KEY_FILE\b|\bAGENT_BACKEND\b' v2 bin config Justfile
+rg '\b(ANTHROPIC|COPILOT|GOOSE|BOBSHELL|OCI|KUBERNETES|POD|NAMESPACE|DASHBOARD|PROXY|SLACK|DISCORD|NTFY)_[A-Z0-9_]+\b' v2 bin config Justfile
+rg 'HIVE_[A-Z0-9_]+|BD_DIR|GH_APP_KEY_FILE|AGENT_BACKEND' v2/deploy
+```

--- a/v2/docs/hub-deployment.md
+++ b/v2/docs/hub-deployment.md
@@ -1,0 +1,112 @@
+# Self-hosted hub deployment
+
+Hive can run either as a spoke dashboard or as the hub. The same Go binary serves both roles; `HIVE_MODE=hub` selects the hub server in `cmd/hive/main.go`.
+
+Use a self-hosted hub when you need a private registry, private SaaS provisioning, air-gapped control, or a hub URL other than `https://hive.kubestellar.io`. If you only need a hosted spoke, use the hosted Hive Hub instead.
+
+## What `Dockerfile.hub` builds
+
+`v2/Dockerfile.hub` builds only `./cmd/hive`, installs `kubectl`, creates `/data` and `/etc/hive`, sets `HIVE_MODE=hub`, and runs:
+
+```sh
+hive --config /etc/hive/hive.yaml
+```
+
+The hub listen port is still controlled by `HIVE_HUB_PORT` in the binary and defaults to `3001`. The Dockerfile exposes port `80`, so set `HIVE_HUB_PORT=80` if your container platform expects the process to bind that exposed port.
+
+## Required storage
+
+Use a persistent volume mounted at `/data`. The production/manual-provisioning docs describe the live hub as namespace `hive-hub`, PVC `hive-hub-data-rwx`, mounted at `/data`.
+
+The hub stores live SaaS state under `/data`:
+
+| Path | Purpose |
+|---|---|
+| `/data/saas/hives/<id>/meta.json` | Per-hive SaaS record used by auth, upgrades, assignments, and dashboard links. |
+| `/data/hub-registry.json` | Fleet registry populated by spoke heartbeats. |
+| `/data/saas/hub-secret.key` | Optional fallback heartbeat bearer secret when `HIVE_HUB_SECRET` is not set on the hub. |
+| `/data/saas/clusters.json` | Cluster definitions used by automated provisioning. |
+
+Use ReadWriteMany storage for hosted spoke PVCs. The provisioning template in `pkg/hub/saas_provision.go` requests `ReadWriteMany` and its rolling update strategy relies on both old and new pods being able to mount `/data` during a surge.
+
+## Minimal hub environment
+
+| Variable | Required | Notes |
+|---|---:|---|
+| `HIVE_MODE=hub` | Yes | Selects hub mode. |
+| `HIVE_HUB_PORT` | No | Defaults to `3001`. Set to `80` for the published hub image contract if needed. |
+| `HIVE_CONFIG` or `--config` | No | Defaults to `/etc/hive/hive.yaml`; `Dockerfile.hub` passes `--config /etc/hive/hive.yaml`. |
+| `HIVE_HUB_SECRET` | Strongly recommended | Shared bearer secret for heartbeat authentication. If unset, the hub reads `/data/saas/hub-secret.key` when present. |
+| `HIVE_HUB_OAUTH_CLIENT_ID` / `HIVE_HUB_OAUTH_CLIENT_SECRET` | Required for hub OAuth login | Without the client id the hub logs OAuth disabled and does not register the login routes. |
+| `HIVE_GITHUB_TOKEN` or GitHub App config | Required for operations that call GitHub | Same GitHub auth rules as a spoke. |
+| `HIVE_HUB_SLACK_BOT_TOKEN`, `HIVE_NTFY_SERVER`, `HIVE_NTFY_TOPIC` | No | Optional hub notifications. |
+| `HIVE_BACKUP_*`, `OCI_*`, `HIVE_KUBECONFIG_DIR` | No | Required only for disaster-recovery backup and OCI/FSS provisioning flows. See `backup-restore.md`. |
+
+## Hub config shape
+
+The hub still reads `hive.yaml`. The hub-specific code mainly uses the `hub` block, GitHub credentials, dashboard/auth settings, and any provisioning-related data under `/data/saas`. A minimal seed keeps the normal project and GitHub validation satisfied:
+
+```yaml
+project:
+  org: your-org
+  repos: [your-repo]
+  primary_repo: your-repo
+
+github:
+  token: ${HIVE_GITHUB_TOKEN}
+
+dashboard:
+  auth_token: ${HIVE_DASHBOARD_TOKEN}
+
+hub:
+  enabled: true
+  url: https://hive.example.com
+```
+
+Keep secret values in Kubernetes Secrets or environment variables; do not write token values directly into `hive.yaml`.
+
+## Registering spokes to your hub
+
+A spoke points at the hub with its config `hub.url` or the `HIVE_HUB_URL` override. Protected hubs require the same heartbeat secret on every spoke:
+
+```yaml
+hub:
+  enabled: true
+  url: https://hive.example.com
+```
+
+```yaml
+env:
+  - name: HIVE_HUB_URL
+    value: https://hive.example.com
+  - name: HIVE_HUB_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: hive-secrets
+        key: HIVE_HUB_SECRET
+```
+
+Without `HIVE_HUB_SECRET`, a protected hub returns `401 unauthorized`, the spoke logs `hub heartbeat rejected status=401`, and the hub shows the hive offline. This matches the gotcha in `manual-provisioning.md`.
+
+## Hosted spoke provisioning model
+
+The hub's SaaS provisioner creates or records:
+
+1. Namespace, RBAC, Secret, ConfigMap, Service, route/ingress, Deployment, and an RWX `hive-data` PVC.
+2. A mounted `/data` volume where the spoke writes runtime config and state.
+3. `HIVE_ID`, `POD_NAMESPACE`, `HIVE_LEVEL`, `HIVE_HUB_URL`, `HIVE_HUB_SECRET`, optional `HIVE_AUTHORIZED_USERS`, and inference endpoint env vars in the spoke Deployment.
+4. `/data/saas/hives/<id>/meta.json` on the hub PVC. Heartbeats can be accepted without this record, but hub-driven upgrades and dashboard links need it.
+
+For heartbeat-only clusters where the hub cannot run `kubectl`, follow the manifest-level workflow in `manual-provisioning.md`; this guide intentionally keeps the hub setup consistent with that battle-tested path.
+
+## API surface to know
+
+The hub registers heartbeat, registry, SaaS, contributor, OAuth, webhook, backup, and callback-related routes from the Go hub packages. Operators normally interact through the dashboard, but the important external contracts are:
+
+- `POST /api/heartbeat` — spoke heartbeat, bearer-authenticated by `HIVE_HUB_SECRET` when configured.
+- `POST /api/saas/hives` — hub-admin SaaS hive creation path.
+- `/api/saas/auth-check` — ingress auth check used by hub-proxied spoke dashboards.
+- `/contribute` and `/api/contribute/*` — contributor relay registration and WebSocket flow.
+- `/api/registry` and leaderboard/fleet views — public or authenticated hub registry views.
+
+See `api-reference.md` and the dashboard OpenAPI file for route details, and `manual-provisioning.md` for known failure modes.

--- a/v2/docs/knowledge-curator.md
+++ b/v2/docs/knowledge-curator.md
@@ -20,7 +20,7 @@ knowledge:
 
 | Field | Current behavior in v2 HEAD |
 | --- | --- |
-| `schedule` | Defaults to `daily` when knowledge is enabled. The config field is stored for the scheduled curator flow described in the design docs; v2 HEAD does not enforce a parser here, so use simple operator conventions such as `daily` until your deployment wires a scheduler. |
+| `schedule` | Defaults to `daily` when knowledge is enabled. The value is stored as `CuratorConfig.Schedule`. No scheduler in v2 HEAD parses or actions it. Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly; see [Scheduling extraction](#scheduling-extraction). |
 | `extract_from` | Sources the curator should inspect. Implemented sources are `pr_comments` and `review_comments`. `ci_failures` appears in the example config/design but is not currently extracted by `Curator.extractFromPR`. |
 | `auto_promote_threshold` | Defaults to `0.9` when knowledge is enabled. `Promoter.AutoPromoteCandidates` selects facts whose llm-wiki page has `status == "verified"` and `confidence >= threshold`. |
 
@@ -37,5 +37,19 @@ The classifier is heuristic. It emits candidates for comments containing signals
 - `decided`, `agreed`, `going forward`, `from now on` → decisions.
 
 Extracted facts are sent to the wiki `/api/ingest` endpoint. Promotion only flows upward (for example project → org), preserving provenance in the promoted fact.
+
+## Scheduling extraction
+
+Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly. No scheduler, CLI command, or HTTP endpoint triggers extraction in v2 HEAD.
+
+A Go caller builds a `Curator` with `NewCurator(ghClient, wikiURL, org, repos, config, logger)`. The caller calls `RunExtraction(ctx, since)` with a `since` time. The caller then calls `Ingest(ctx, facts)`. The call POSTs the facts to the wiki `/api/ingest` endpoint:
+
+```go
+c := NewCurator(ghClient, wikiURL, org, repos, config, logger)
+facts, err := c.RunExtraction(ctx, since)
+err = c.Ingest(ctx, facts)
+```
+
+The design doc `v2/docs/design/knowledge-system.md` plans a `scheduler.RunCurator(schedule)` wiring with a daily or on-merge trigger. This wiring is not implemented in v2 HEAD. The programmatic path above is the only way to run extraction today.
 
 See [Knowledge system design](design/knowledge-system.md) for architecture context; this page documents the implemented operator-facing knobs.

--- a/v2/docs/notifications.md
+++ b/v2/docs/notifications.md
@@ -1,71 +1,96 @@
 # Notifications
 
-Hive can push operator alerts — merges, reviews, health warnings — to one or
-more channels. All channels are optional; configure only the ones you want under
-the top-level `notifications` block in `hive.yaml`.
+Hive can send operator notifications through three outbound channels configured under the top-level `notifications:` block in `hive.yaml`:
 
-## ntfy
+- ntfy topics
+- Slack incoming webhooks
+- Discord webhooks
 
-[ntfy](https://ntfy.sh) is a simple pub/sub notification service. Point it at the
-public server or your own self-hosted instance:
+The notifier is implemented in `v2/pkg/notify/notify.go` and is constructed from `config.NotificationsConfig` in `v2/pkg/config/config.go`. The same notification is sent to every configured channel.
+
+## Configuration
 
 ```yaml
 notifications:
   ntfy:
-    server: https://ntfy.sh   # or your self-hosted ntfy URL
-    topic: my-hive-alerts      # subscribe to this topic in the ntfy app
-```
-
-Subscribe to the same `topic` in the ntfy mobile/desktop app or via
-`curl -s https://ntfy.sh/my-hive-alerts/json` to receive alerts. Choose a
-hard-to-guess topic name — anyone who knows a public-server topic can read its
-messages.
-
-## Slack
-
-Create an [Incoming Webhook](https://api.slack.com/messaging/webhooks) for the
-target channel and pass its URL. Keep the URL in an environment variable rather
-than committing it:
-
-```yaml
-notifications:
+    server: https://ntfy.sh
+    topic: my-hive-alerts
   slack:
     webhook: ${SLACK_WEBHOOK_URL}
-```
-
-## Discord (webhook)
-
-Create a channel webhook (Channel → Edit → Integrations → Webhooks) and pass its
-URL:
-
-```yaml
-notifications:
   discord:
     webhook: ${DISCORD_WEBHOOK_URL}
 ```
 
-This is one-way alert delivery. For a two-way bot that responds to `!hive`
-commands, see the separate Discord bot below.
+All three channels are optional. Configure one channel or several. Webhook URLs are secrets; keep them in environment variables or Kubernetes Secrets rather than committing literal URLs.
 
-## Discord bot (optional, two-way)
+### ntfy
 
-A separate optional Discord bot (in [`discord/`](../../discord/)) responds to
-`!hive` commands in a channel. It is configured under the top-level `discord`
-key, **not** under `notifications`:
+| Field | Required | Notes |
+|---|---:|---|
+| `notifications.ntfy.server` | yes | ntfy base URL, for example `https://ntfy.sh` or your own HTTPS ntfy server. |
+| `notifications.ntfy.topic` | yes | Topic name appended to the server URL. |
 
-```yaml
-discord:
-  bot_token: ${DISCORD_BOT_TOKEN}
-  channel_id: "1234567890"
+Hive posts the notification body to `<server>/<topic>` and sets `Title` and `Priority` headers. Priorities are `high`, `default`, or `low`.
+
+Self-hosted ntfy works the same way as ntfy.sh as long as the Hive process can reach the HTTPS endpoint. On the public ntfy.sh server, choose a hard-to-guess topic because anyone who knows the topic can subscribe to it.
+
+### Slack
+
+| Field | Required | Notes |
+|---|---:|---|
+| `notifications.slack.webhook` | yes | Slack incoming webhook URL. The sender posts `{"text":"*title*\nmessage"}`. |
+
+The notifier accepts `http://` and `https://` URLs in the Go sender, but production configs should use Slack's HTTPS webhook URLs and keep the value in an environment variable.
+
+### Discord webhook
+
+| Field | Required | Notes |
+|---|---:|---|
+| `notifications.discord.webhook` | yes for webhook notifications | Discord webhook URL. The sender posts `{"content":"**title**\nmessage"}`. |
+
+Use a Discord **webhook URL**, not a bot token, for notification delivery.
+
+## What triggers notifications
+
+The v2 Go process sends notifications for these events:
+
+| Event | Priority | Source |
+|---|---|---|
+| Weekly token budget crosses the warning threshold. | default | `applyBudgetAlerts` in `v2/cmd/hive/main.go` |
+| Weekly token budget is exhausted and non-exempt kicks are suspended. | high | `applyBudgetAlerts` in `v2/cmd/hive/main.go` |
+| Actionable issues exceed the SLA threshold; up to three `SLA 2x breach` notifications are sent per refresh cycle for issues older than 60 minutes. | high | dashboard refresh loop in `v2/cmd/hive/main.go` |
+| A running agent pane matches a configured login-required pattern; Hive pauses that agent and sends the backend-specific login instruction. | high | `scanForLoginRequired` in `v2/cmd/hive/main.go` |
+| Trajectory review detects divergence and either pauses the agent or flags the divergence. | high | `v2/pkg/dashboard/trajectory_sink.go` and `v2/pkg/trajectory/lane.go` |
+
+The legacy shell scripts in `bin/` also use `bin/notify.sh` for events such as stale agents, rate limits, backend switches, and kick status when those scripts are deployed. Those scripts read environment variables (`NTFY_TOPIC`, `NTFY_SERVER`, `SLACK_WEBHOOK`, `DISCORD_WEBHOOK`) rather than the v2 YAML block.
+
+## Testing delivery
+
+Test the target channel directly before putting it in `hive.yaml`:
+
+```bash
+# ntfy
+curl -s -H 'Title: Hive test' -H 'Priority: default' \
+  -d 'notification test from hive operator' \
+  https://ntfy.sh/my-hive-alerts
+
+# Slack incoming webhook
+curl -s -X POST -H 'Content-type: application/json' \
+  --data '{"text":"*Hive test*\nnotification test from hive operator"}' \
+  "$SLACK_WEBHOOK_URL"
+
+# Discord webhook
+curl -s -X POST -H 'Content-type: application/json' \
+  --data '{"content":"**Hive test**\nnotification test from hive operator"}' \
+  "$DISCORD_WEBHOOK_URL"
 ```
 
-See [`discord/README.md`](../../discord/README.md) for bot setup and the command
-surface.
+After editing `hive.yaml`, restart or reload Hive through your normal deployment path. The dashboard notification settings endpoint currently persists ntfy and Discord webhook fields; configure Slack in YAML.
 
-## Notes
+## Discord webhook vs Discord bot
 
-- Webhook URLs and bot tokens are secrets — supply them through environment
-  variables (`${VAR}` interpolation) or a Kubernetes Secret, never inline in a
-  committed `hive.yaml`.
-- Multiple channels can be enabled at once; each configured channel receives the
-  same alerts.
+Webhook notifications are the `notifications.discord.webhook` field above.
+
+The repository also contains a separate Discord bot under [`../../discord/`](../../discord/). That bot is a Node.js service using `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_PRIMARY` to connect to Discord, route commands, and bridge dashboard/pipeline status. It is not required for webhook notifications, and a bot token cannot replace `notifications.discord.webhook`.
+
+For the v2 Go process, bot startup uses `notifications.discord.bot_token` and `notifications.discord.channel_id` when both are set. Those fields start the bot integration; they do not send ordinary webhook notifications unless `notifications.discord.webhook` is also configured.

--- a/v2/docs/notifications.md
+++ b/v2/docs/notifications.md
@@ -1,0 +1,71 @@
+# Notifications
+
+Hive can push operator alerts — merges, reviews, health warnings — to one or
+more channels. All channels are optional; configure only the ones you want under
+the top-level `notifications` block in `hive.yaml`.
+
+## ntfy
+
+[ntfy](https://ntfy.sh) is a simple pub/sub notification service. Point it at the
+public server or your own self-hosted instance:
+
+```yaml
+notifications:
+  ntfy:
+    server: https://ntfy.sh   # or your self-hosted ntfy URL
+    topic: my-hive-alerts      # subscribe to this topic in the ntfy app
+```
+
+Subscribe to the same `topic` in the ntfy mobile/desktop app or via
+`curl -s https://ntfy.sh/my-hive-alerts/json` to receive alerts. Choose a
+hard-to-guess topic name — anyone who knows a public-server topic can read its
+messages.
+
+## Slack
+
+Create an [Incoming Webhook](https://api.slack.com/messaging/webhooks) for the
+target channel and pass its URL. Keep the URL in an environment variable rather
+than committing it:
+
+```yaml
+notifications:
+  slack:
+    webhook: ${SLACK_WEBHOOK_URL}
+```
+
+## Discord (webhook)
+
+Create a channel webhook (Channel → Edit → Integrations → Webhooks) and pass its
+URL:
+
+```yaml
+notifications:
+  discord:
+    webhook: ${DISCORD_WEBHOOK_URL}
+```
+
+This is one-way alert delivery. For a two-way bot that responds to `!hive`
+commands, see the separate Discord bot below.
+
+## Discord bot (optional, two-way)
+
+A separate optional Discord bot (in [`discord/`](../../discord/)) responds to
+`!hive` commands in a channel. It is configured under the top-level `discord`
+key, **not** under `notifications`:
+
+```yaml
+discord:
+  bot_token: ${DISCORD_BOT_TOKEN}
+  channel_id: "1234567890"
+```
+
+See [`discord/README.md`](../../discord/README.md) for bot setup and the command
+surface.
+
+## Notes
+
+- Webhook URLs and bot tokens are secrets — supply them through environment
+  variables (`${VAR}` interpolation) or a Kubernetes Secret, never inline in a
+  committed `hive.yaml`.
+- Multiple channels can be enabled at once; each configured channel receives the
+  same alerts.

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -38,6 +38,8 @@ Top-level YAML keys accepted by `config.Config`:
 | `dashboard.snapshot_frame_ancestors` | Empty list means CSP `frame-ancestors 'none'`. | Entries must be exact `https://` origins; paths, wildcards, credentials, query, and fragments are rejected. |
 | `dashboard.authorized_users` | Empty means no per-user direct-route allowlist. | Entries can be `user` or `user:role`; roles are `read`, `read-write`, `merger`, `owner`. |
 | `variables.security.*` | Deny by default. | `allow_exec`, `allow_http`, and GitHub prompt-source allowlists are honored only from the trusted seed, not dashboard overlays. |
+| `data.claude_sessions_dir` | `/data/home/.claude/projects` | Where the dashboard reads Claude Code session JSONL for per-agent token/cost accounting. Point it at the agents' real session directory if you relocate `HOME`. |
+| `data.copilot_sessions_dir` | `/data/home/.copilot/session-state` | Same, for the Copilot CLI backend's session state. |
 
 For runtime precedence and provenance, see [config-layering.md](config-layering.md).
 

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -107,6 +107,12 @@ installation instead of broadening the PAT.
 |---|---|
 | `HIVE_METRICS_ENABLED` | Enables unauthenticated Prometheus `/metrics` when set to `1`, `true`, `yes`, or `on`; off by default because it exposes estimated cost data. |
 
+> **Note on `tokens_24h`:** despite its name, the per-spoke heartbeat field
+> `tokens_24h` (stored on the hub as `totalTokens24h`) is a **cumulative total**,
+> not a rolling 24-hour window. Read it as lifetime token consumption for the
+> spoke. See [token-tracking.md](token-tracking.md) for the full heartbeat and
+> `/api/saas/usage` rollup details.
+
 ### Inference endpoint fallbacks
 
 | Name | Default | Purpose |

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -19,7 +19,7 @@ Top-level YAML keys accepted by `config.Config`:
 | `agents` | Agent definitions and behavior metadata. | Per-agent overlays may also live under `data.agents_dir`. |
 | `governor` | Cadences, labels, sensing, health, budgets, inference gateways, trajectory review. | See notable fields below. |
 | `github` | PAT or GitHub App credentials and forge URLs. | Use one auth method. |
-| `notifications` | ntfy, Slack, and Discord webhooks. | All optional. |
+| `notifications` | ntfy, Slack, and Discord webhooks. | All optional; see [notifications.md](notifications.md). |
 | `dashboard` | Web UI port, snapshots, auth token, frame allowlist, authorized users. | `auth_token` can come from `HIVE_DASHBOARD_TOKEN`. |
 | `data` | Metrics, logs, session, and agent overlay directories. | Defaults are `/data/...` in containers. |
 | `knowledge` | Wiki layers, vaults, git/document sources, primer, curator, bead synthesizer. | Disabled unless `enabled: true`. |
@@ -42,6 +42,58 @@ Top-level YAML keys accepted by `config.Config`:
 | `data.copilot_sessions_dir` | `/data/home/.copilot/session-state` | Same, for the Copilot CLI backend's session state. |
 
 For runtime precedence and provenance, see [config-layering.md](config-layering.md).
+
+## Image provenance for `ghcr.io/kubestellar/hive:v2-latest`
+
+The pre-built Docker image used by `v2/docker-compose.yaml` is built by [`.github/workflows/docker.yml`](../../.github/workflows/docker.yml). On the `v2` branch, that workflow publishes a rolling multi-architecture manifest tag:
+
+- `ghcr.io/kubestellar/hive:v2-latest`
+- `ghcr.io/kubestellar/hive:<git-short-sha>`
+
+### What updates the tag
+
+The workflow runs on pushes to every non-dependabot/non-copilot branch and on `workflow_dispatch`. PR and short-lived branch builds still compile the image as a CI gate, but the `gate` job only pushes to GHCR for long-lived branches listed in the workflow (`v2`, `v3`, `mk`, `dd`) or for manual `workflow_dispatch` runs.
+
+For the main Hive image, the build job uses `v2/Dockerfile` and passes these build arguments:
+
+```text
+GIT_HASH=${{ github.sha }}
+GIT_BRANCH=${{ github.ref_name }}
+```
+
+The merge job then combines the per-architecture digests into a manifest list. Before tagging, it verifies that the workflow SHA is still the current HEAD of the branch; stale queued builds skip tagging instead of moving `v2-latest` backward.
+
+### Stability guarantee
+
+`v2-latest` is a rolling branch tag for the current HEAD of `origin/v2` after the Docker workflow succeeds. It is not immutable and is intended for quick starts and continuously updated hives. Pin production deployments to a digest when you need a reproducible image.
+
+### Verify and pin a digest
+
+Inspect the tag digest:
+
+```bash
+docker buildx imagetools inspect ghcr.io/kubestellar/hive:v2-latest
+```
+
+Pull by digest after choosing the manifest digest you want:
+
+```bash
+docker pull ghcr.io/kubestellar/hive@sha256:<digest>
+```
+
+In Compose, replace the tag with the digest form:
+
+```yaml
+services:
+  hive:
+    image: ghcr.io/kubestellar/hive@sha256:<digest>
+```
+
+To relate an image to source, compare the `<git-short-sha>` tag published by the same workflow with commits on the `v2` branch, or inspect the Docker workflow run for the commit SHA that produced the digest.
+
+### Changelog and release notes
+
+The rolling image follows merged changes on the `v2` branch. Use the GitHub commit/PR history for the exact source change set behind a SHA tag, and use repository releases or changelog files only when this repository publishes them for a specific release line.
 
 ## Fleet breaker
 

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -4,6 +4,10 @@ This page is a concise operator reference for fields and runtime knobs that are
 easy to miss in `hive.yaml.example`. It was checked against `pkg/config/config.go`
 and `cmd/hive/main.go` on v2.
 
+For the full centralized environment variable table, including hub, backup,
+inference, deployment, contributor, and legacy helper-script variables, see
+[Environment variable reference](env-vars.md).
+
 ## Configuration blocks
 
 Top-level YAML keys accepted by `config.Config`:

--- a/v2/docs/sandbox-isolation.md
+++ b/v2/docs/sandbox-isolation.md
@@ -1,18 +1,62 @@
 # Sandbox isolation and agent guardrails
 
-Hive's v2 isolation model is defense in depth rather than a single sandbox switch. Agents run as long-lived CLI sessions, but the deterministic pipeline and proxy layers decide what work they see and what writes they can perform.
+Hive's v2 isolation model is defense in depth rather than a single sandbox switch. Agents are long-lived CLI sessions in the Hive container. Isolation comes from per-agent Unix users, scoped credentials, the ACMM mode pipeline, and a local GitHub proxy that can inspect selected HTTPS traffic.
 
-## Isolation layers
+## What Hive isolates
 
-1. **Policy mode** — ACMM selects advisory, measured, hold-gated, or full behavior per agent.
-2. **Deterministic admission** — Go and shell checks classify work, apply holds, and decide whether an agent is kicked.
-3. **Scoped credentials** — contributor relays and spoke agents use the GitHub identity and token scope appropriate to that actor; a delegated ClankeR role does not grant spoke secrets.
-4. **MITM GitHub proxy** — GitHub API writes are attributed and constrained according to the current mode.
-5. **Merge gates** — hold labels, green checks, self-merge bans, and auto-merge sweeps are enforced outside the LLM prompt.
+- **Agent work directories** — the entrypoint creates `/data/agents/<agent>` for each configured agent and, when UID isolation is available, owns it as `hive-<agent>:node`.
+- **Agent process identity** — the entrypoint assigns UIDs starting at `2001`, creates `hive-<agent>` system users, and writes `/var/run/hive/uid-map.json`. The Go manager reads that map and launches each agent's tmux server through `su-exec` as the mapped user.
+- **GitHub write identity** — push-capable agents can receive per-agent App token cache paths; advisory agents have `GH_TOKEN` and `GITHUB_TOKEN` stripped from tmux sessions.
+- **GitHub API writes** — agent traffic is pointed at the local proxy with `HTTPS_PROXY=http://127.0.0.1:18443` and `HTTP_PROXY=http://127.0.0.1:18443`. When iptables setup succeeds, outbound TCP port 443 is also redirected to the same proxy so unsetting proxy environment variables is not enough to bypass it.
+- **Merge and PR gates** — policy mode, hold labels, green checks, self-merge bans, and automerge logic run outside the prompt and remain enforcement points even if an agent proposes unsafe work.
 
-## Operator notes
+## MITM GitHub proxy
 
-- Prefer the least-capable ACMM level that matches the project phase.
-- Keep privileged delegated roles (`ci-maintainer`, `sec-check`, `architect`) behind explicit grants.
-- Use the docs in this index for concrete setup: [ACMM policy matrix](acmm-policy-matrix.md), [Agent configuration](agent-configuration.md), and [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md).
+The Go proxy listens on `127.0.0.1:18443`. It accepts both explicit HTTP `CONNECT` proxy traffic and transparent TLS connections redirected by iptables.
 
+For `api.github.com`, the proxy forges a leaf certificate signed by Hive's local CA, terminates TLS from the agent, opens a TLS connection to GitHub, reads each HTTP request, and then either forwards or blocks it. The rule table allows read methods in advisory mode, selected issue writes in `issues-only`, PR and git-push writes in `issues-and-prs`, and merge/update-branch requests in `issues-prs-merge`. Unknown operations are denied by default. Direct `POST /repos/<org>/<repo>/pulls` is hard-denied in every mode so agents use Hive's `hive-open-pr` path instead of authoring PRs as the login user.
+
+The proxy also checks write requests under `/repos/<org>/<repo>` against the repositories configured for the hive. A blocked request is logged as `proxy request blocked` and returns HTTP 403 with `X-Hive-Proxy-Blocked: true`.
+
+### Traffic that is not request-inspected
+
+The current `NeedsMITM` implementation only returns true for `api.github.com`. Other hosts are tunneled without request-level ACMM inspection, including non-GitHub hosts. `github.com` is registered as a GitHub host but is intentionally tunneled for OAuth device flow and git smart HTTP paths. GitHub Enterprise hosts can be registered as GitHub hosts, but this code path does not MITM them unless `NeedsMITM` is extended.
+
+Copilot completion hosts (`githubcopilot.com` and `*.githubcopilot.com`) may be MITM-inspected only for token-usage accounting when an agent is identified and a token sink is configured. The proxy forwards the request and response content, except that streaming completion requests can get `stream_options.include_usage` injected so Copilot returns token usage.
+
+## Proxy CA and trust
+
+The proxy persists its CA certificate and key at:
+
+- `/data/proxy-ca.pem`
+- `/data/proxy-ca-key.pem`
+
+On startup, it reuses a valid persisted CA or generates a new `Hive ACMM Proxy CA`. The entrypoint builds a combined bundle at `/data/proxy-ca-bundle.pem` by concatenating the system CA bundle and `/data/proxy-ca.pem` when both files exist. That matters because `SSL_CERT_FILE` replaces the trust set: the combined bundle trusts both public roots and the proxy CA.
+
+Trust is injected in several places:
+
+- Agent shells get `.bashrc` that sets `SSL_CERT_FILE` to `/data/proxy-ca-bundle.pem` when available, otherwise `/data/proxy-ca.pem`.
+- Agent launch environments set `NODE_EXTRA_CA_CERTS=/data/proxy-ca.pem` and `GIT_SSL_CAINFO=/data/proxy-ca.pem`.
+- The entrypoint installs the proxy CA into the system trust store when it can, and watches for CA changes to rebuild the combined bundle.
+- GitHub App token-minting clients in Go build their own trust pool from system roots plus `/data/proxy-ca.pem`, lazily reloading the CA so fresh PVC boots do not depend on entrypoint ordering.
+
+## Verifying isolation is active
+
+On a running hive container, verify the concrete mechanisms rather than assuming the policy level is enough:
+
+1. Check startup logs for per-agent user creation, for example `Agent user: hive-<agent> (UID <uid>)`, and for `UID map written to /var/run/hive/uid-map.json`.
+2. Inspect `/var/run/hive/uid-map.json`; `agents` should map agent names to UIDs and `iptables_active` should be `true` when forced egress was installed.
+3. Check startup logs for `iptables: outbound :443 -> :18443`. If you see `WARN: iptables chain creation failed` or `WARN: iptables not found`, proxy enforcement is advisory-only and relies on the agent environment variables.
+4. Check Go logs for `proxy listening` on `127.0.0.1:18443` and, when the UID map loaded, `proxy loaded UID map`.
+5. Confirm `/data/proxy-ca.pem` exists. When the system bundle exists too, `/data/proxy-ca-bundle.pem` should be rebuilt by the entrypoint.
+6. For a negative test, make a GitHub API write that the current agent mode does not allow. The expected result is HTTP 403, `X-Hive-Proxy-Blocked: true`, and a `proxy request blocked` log line.
+
+## Practical limits
+
+- This is not a kernel sandbox. Agents still execute the configured CLI and tools in the container with access to their workspace and to any credentials deliberately injected for that mode.
+- UID isolation separates agent-owned files and lets the proxy attribute sockets by UID, but all agents still share the container, the `node` group, and selected shared state such as `/data/home` unless a backend uses a dedicated home path.
+- If iptables cannot be installed, agents can bypass request-level proxy enforcement by ignoring or removing proxy environment variables.
+- The proxy's request-level ACMM checks apply to `api.github.com` in the current code. Non-GitHub endpoints and tunneled GitHub web traffic are not inspected at the HTTP request level by this proxy.
+- Advisory mode does not mean network isolation. It means GitHub writes should be denied by the proxy/ruleset and by stripped GitHub write tokens; read traffic and non-inspected destinations can still occur.
+
+Use the rest of this index for setup details: [ACMM policy matrix](acmm-policy-matrix.md), [Agent configuration](agent-configuration.md), and [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md).

--- a/v2/docs/supervisor.md
+++ b/v2/docs/supervisor.md
@@ -103,5 +103,5 @@ ACMM packs may override these values. For example, the pack definitions use `bac
 
 - **[Agent Configuration](agent-configuration.md)** — every agent field, methods, model pinning, cadences, and ACMM packs.
 - **[ACMM Policy Matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.
-- **[Architecture](https://kubestellar.io/docs/hive/overview/architecture)** — the two scheduling models and how the supervisor drives agents.
-- **[Troubleshooting](https://kubestellar.io/docs/hive/getting-started/troubleshooting)** — stuck sessions, login expiry, restart loops.
+- **[Architecture](architecture.md)** — the process model, governor loop, and how the supervisor drives agents.
+- **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.

--- a/v2/docs/troubleshooting.md
+++ b/v2/docs/troubleshooting.md
@@ -1,0 +1,76 @@
+# Hive v2 troubleshooting
+
+This guide covers the current v2 containerized Go service. The older `docs/troubleshooting.md` page is for the legacy v1 systemd supervisor.
+
+## Find the running service logs
+
+Docker Compose deployments define `hive` and `gateway` services in `v2/docker-compose.yaml`. The Hive process healthcheck calls `http://127.0.0.1:3002/api/health`; the gateway publishes `3001` and proxies to Hive. Start with:
+
+```bash
+cd v2
+docker compose ps
+docker compose logs hive --tail=200
+docker compose logs gateway --tail=100
+```
+
+Kubernetes deployments use namespace `hive`, Deployment `hive`, Service `hive`, and probes on `/api/health` and `/api/livez` in `v2/deploy/k8s/deployment.yaml`:
+
+```bash
+kubectl -n hive get deploy,pod,svc,pvc
+kubectl -n hive logs deploy/hive --tail=200
+kubectl -n hive describe pod -l app.kubernetes.io/name=hive
+```
+
+## Config fails to load or save
+
+Hive reads `/etc/hive/hive.yaml` by default, or `HIVE_CONFIG`/`--config` when set. Startup logs `failed to load config` when `config.LoadWithDashboardOverlay` fails. Common validation strings in `v2/pkg/config/config.go` include:
+
+- `project.org is required`
+- `at least one agent must be configured`
+- `github.token, github.app_id or github.forge is required`
+- `agent <name>: invalid caveman_mode ...`
+- `agent <name>: replicas must be between 1 and 5`
+- `governor mode <mode> cadence for <agent>: ...`
+
+In Kubernetes, edit the ConfigMap/Secret source and restart the pod; dashboard edits are stored in the `/data` PVC overlay. In Docker Compose, edit the bind-mounted `v2/hive.yaml` or the dashboard overlay and restart `hive`.
+
+## GitHub credentials are missing or invalid
+
+When no token or App credentials are usable, v2 starts the dashboard but disables write-capable GitHub work. The code logs these exact messages from `v2/cmd/hive/main.go` depending on the state:
+
+- `no GitHub token configured (set github.token or github.app_id in config) — starting in dashboard-only mode`
+- `GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.`
+- `persisted user token is invalid or expired`
+
+Check the configured `github:` block, the `HIVE_GITHUB_TOKEN` secret/env var, or the GitHub App `app_id`, `installation_id`, and `key_file`. For App setup, use the dashboard banner or `/gh-setup`; details are in [GitHub App setup](github-app-setup.md).
+
+## Agents are stuck, paused, or need CLI login
+
+Agents still run in tmux sessions managed by the v2 agent manager, but there is no v1 `AGENT_READY_MARKER` or `bin/supervisor.sh` loop. The v2 login detector scans recent tmux pane output for configured regexes and, on a match, logs `login required detected`, pauses the agent, and sends a notification that says to attach to `hive-<agent>` and run the backend login command.
+
+Useful checks from inside the Hive container/pod:
+
+```bash
+tmux ls
+tmux capture-pane -t hive-scanner -p -S -80
+tmux attach -t hive-scanner
+```
+
+Detach from tmux with `Ctrl+B`, then `D`. If the dashboard shows an agent as paused, resume it from the dashboard/API after completing the CLI login (`claude login`, `copilot auth login`, `gemini auth login`, or the backend-specific command shown in the notification).
+
+## Dashboard auth and access problems
+
+The dashboard config lives under `dashboard:`. `dashboard.auth_token` protects non-public dashboard/API paths; health/liveness, snapshot/style, contribute, leaderboard, user-auth negotiation, SSO, and GitHub App setup paths are intentionally public in `isPublicPath`. `dashboard.authorized_users` controls direct-route user login allowlists; `dashboard.hub_proxied` means trusted hub/nginx headers identify the caller.
+
+If API calls fail, check whether the request is going through the gateway on port `3001` or directly to Hive on `3002`, then inspect the response and Hive logs. Dashboard handlers return concrete messages such as `X-Hive-Role header required`, `insufficient access`, `owner access required`, and `only the owner can back up this hive` for role/header failures.
+
+## Health endpoints
+
+Use the same endpoints as the probes:
+
+```bash
+curl -fsS http://127.0.0.1:3002/api/health
+curl -fsS http://127.0.0.1:3002/api/livez
+```
+
+`/api/livez` is deliberately process-focused: the Kubernetes manifest notes that stale hub heartbeat state belongs in deeper health reporting and should not crash-loop a healthy pod.

--- a/v2/examples/agents/README.md
+++ b/v2/examples/agents/README.md
@@ -1,0 +1,24 @@
+# Example agent definitions
+
+Portable agent definitions in the `AgentDefinition` YAML format (see
+[`v2/AGENT-DEFINITION.md`](../../AGENT-DEFINITION.md) for the full schema). Each
+file here is a self-contained example you can import into a running hive.
+
+## Files
+
+| File | What it shows |
+|------|---------------|
+| [`customized-agent.yaml`](customized-agent.yaml) | A fully-annotated agent definition — backend, model, cadences, prompt source, and beads directory — usable as a starting template. |
+
+## Importing
+
+Import a definition from the dashboard: **+ agent → Import from URL**, and paste
+the raw file URL, for example:
+
+```
+https://raw.githubusercontent.com/kubestellar/hive/v2/v2/examples/agents/customized-agent.yaml
+```
+
+Or copy a file into your hive's agents overlay directory (`data.agents_dir`) and
+reload. See [`v2/docs/agent-configuration.md`](../../docs/agent-configuration.md)
+for the agent fields and how overlays are applied.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -86,14 +86,15 @@ agents:
     display_name: CI Maintainer
     description: Post-merge quality gate — monitors CI health, coverage, GA4 errors
     sort_order: 30
-  tester:
+  quality:
     enabled: true
     backend: claude
     model: claude-sonnet-4-6
-    beads_dir: /data/beads/tester
+    beads_dir: /data/beads/quality
     clear_on_kick: true
-    display_name: Tester
-    description: Runs automated test suites — coverage gates and nightly regression checks
+    display_name: Quality
+    description: Runs automated test suites — coverage gates and regression checks
+    role: quality
     sort_order: 35
   architect:
     enabled: false                        # Disabled by default — enable for design work
@@ -190,7 +191,7 @@ governor:
       threshold: 20                       # Queue depth >= 20 triggers SURGE
       scanner: 15m
       ci-maintainer: pause                # "pause" means don't kick this agent
-      tester: pause                       # coverage isn't urgent during fire-fighting
+      quality: pause                      # coverage isn't urgent during fire-fighting
       architect: pause
       guide: pause
       strategist: pause
@@ -199,7 +200,7 @@ governor:
       threshold: 10
       scanner: 15m
       ci-maintainer: 1h
-      tester: 2h
+      quality: 2h
       architect: pause
       guide: 4h
       strategist: pause
@@ -207,7 +208,7 @@ governor:
       threshold: 2
       scanner: 15m
       ci-maintainer: 45m
-      tester: 45m
+      quality: 45m
       architect: pause
       guide: 4h
       strategist: 4h
@@ -215,7 +216,7 @@ governor:
       threshold: 0
       scanner: 15m
       ci-maintainer: 15m
-      tester: 30m                         # most active when nothing else is happening
+      quality: 30m                        # most active when nothing else is happening
       architect: 30m
       guide: 4h
       strategist: 4h

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -284,7 +284,7 @@ github:
   # installation_id: 67890
   # key_file: /secrets/gh-app-key.pem
 
-# Notifications — configure one or more channels
+# Notifications — configure one or more channels. See docs/notifications.md.
 notifications:
   ntfy:
     server: https://ntfy.sh
@@ -293,11 +293,9 @@ notifications:
   #   webhook: ${SLACK_WEBHOOK_URL}
   # discord:
   #   webhook: ${DISCORD_WEBHOOK_URL}
-
-# Discord bot (optional) — responds to !hive commands
-# discord:
-#   bot_token: ${DISCORD_BOT_TOKEN}
-#   channel_id: "1234567890"
+  #   # Optional Discord bot integration; separate from webhook notifications.
+  #   bot_token: ${DISCORD_BOT_TOKEN}
+  #   channel_id: "1234567890"
 
 # Dashboard — embedded web UI with SSE live updates
 # Security headers (CSP, X-Frame-Options, etc.) are always active.

--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -269,3 +269,77 @@ func TestSetBackendOverride_RejectsUndispatchableBackend(t *testing.T) {
 		t.Errorf("SetBackendOverride on a missing agent = %v, want a 'not found' error", err)
 	}
 }
+
+// TestBackendBinaryName_EverySupportedBackendResolves is the guard for the
+// accept-then-fail class of bug. config.ValidateBackend accepts every member of
+// config.SupportedBackends() at config-set time, so the launcher MUST be able to
+// dispatch every one of them — otherwise a backend is persisted happily and then
+// dies hours later at kick time with "unknown backend".
+//
+// This regression was real: config.CLIBackends listed codex and aider, but
+// backendBinary's hand-written map did not, so `backend: codex` was accepted and
+// then failed at launch. The old test enumerated only the backends that were
+// already in the map, so it could never catch a missing one. This test derives
+// its cases from the canonical list instead, which is what makes it able to.
+//
+// backendBinaryName is used rather than backendBinary so this asserts the
+// mapping is COMPLETE without also requiring every CLI to be installed here.
+func TestBackendBinaryName_EverySupportedBackendResolves(t *testing.T) {
+	supported := config.SupportedBackends()
+	if len(supported) == 0 {
+		t.Fatal("config.SupportedBackends() is empty — this test would vacuously pass")
+	}
+	for _, b := range supported {
+		binary, err := backendBinaryName(b)
+		if err != nil {
+			t.Errorf("config accepts backend %q but the launcher cannot dispatch it: %v", b, err)
+			continue
+		}
+		if binary == "" {
+			t.Errorf("backendBinaryName(%q) returned an empty binary name", b)
+		}
+	}
+}
+
+// TestBackendBinaryName_CodexAndAiderLaunchTheirOwnBinaries pins the specific
+// regression: codex and aider are agentic CLIs of their own, not aliases and not
+// gateway backends, so each must exec a binary of its own name. If either were
+// ever folded into the claude derivation this would catch it.
+func TestBackendBinaryName_CodexAndAiderLaunchTheirOwnBinaries(t *testing.T) {
+	for _, backend := range []string{"codex", "aider"} {
+		if !config.IsCLIBackend(backend) {
+			t.Fatalf("precondition failed: %q is no longer a config.CLIBackends member", backend)
+		}
+		got, err := backendBinaryName(backend)
+		if err != nil {
+			t.Errorf("backendBinaryName(%q) err = %v, want nil", backend, err)
+			continue
+		}
+		if got != backend {
+			t.Errorf("backendBinaryName(%q) = %q, want %q", backend, got, backend)
+		}
+	}
+}
+
+// TestBackendBinaryName_AliasesSurviveDerivation guards the ordering inside
+// backendBinaryName: the identity derivation over config.CLIBackends would map
+// "pi" to a non-existent "pi" binary, so the alias overrides must be applied
+// AFTER it. Swapping those two loops would silently break the pi backend.
+func TestBackendBinaryName_AliasesSurviveDerivation(t *testing.T) {
+	got, err := backendBinaryName("pi")
+	if err != nil {
+		t.Fatalf("backendBinaryName(\"pi\") err = %v, want nil", err)
+	}
+	if got != "goose" {
+		t.Errorf("backendBinaryName(\"pi\") = %q, want \"goose\" (alias applied after identity derivation)", got)
+	}
+}
+
+// TestBackendBinaryName_RejectsUnknown keeps the negative path honest: deriving
+// from the canonical lists must not turn backendBinaryName into a function that
+// accepts anything.
+func TestBackendBinaryName_RejectsUnknown(t *testing.T) {
+	if _, err := backendBinaryName("totally-made-up"); err == nil {
+		t.Fatal("backendBinaryName accepted a backend that is in neither canonical list")
+	}
+}

--- a/v2/pkg/agent/launch_coverage_test.go
+++ b/v2/pkg/agent/launch_coverage_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -128,23 +129,44 @@ func TestDismissInferencePrompts_NavigatesNegative(t *testing.T) {
 	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
 	time.Sleep(400 * time.Millisecond)
 
-	// Run dismissal briefly; flip the pane to ready shortly after so it returns.
-	go func() {
-		time.Sleep(1500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	}()
-
 	done := make(chan struct{})
 	go func() {
 		m.dismissInferencePrompts(agent)
 		close(done)
 	}()
+
+	// Flip the pane to the ready marker and keep re-asserting it until
+	// dismissInferencePrompts returns. A single send-keys/capture-pane can race
+	// with the poll loop under load, and the loop only acts on a *changed* pane
+	// (it skips a capture equal to the previous one), so re-emit a line that
+	// contains the ready marker AND a changing counter each interval. That
+	// guarantees at least one poll sees a changed pane carrying the marker,
+	// rather than depending on one perfectly-timed write.
+	stop := make(chan struct{})
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		n := 0
+		for {
+			n++
+			exec.Command("tmux", "send-keys", "-t", session, "-l",
+				fmt.Sprintf(": esc to interrupt [%d]", n)).Run()
+			exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
 	select {
 	case <-done:
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Error("dismissInferencePrompts should return after pane becomes ready")
 	}
+	close(stop)
 }
 
 // TestDismissInferencePrompts_BypassConsent covers the explicit bypass-consent

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1034,24 +1034,38 @@ func backendDefersStartupKick(backend string) bool {
 	}
 }
 
-// copilotGitHubWriteDenyFlags is the full set of Copilot `--deny-tool` flags for
-// every GitHub MCP write tool. It is denied in EVERY copilot launch mode so no
-// mode can author issues/PRs/comments as the logged-in Copilot USER via the
-// GitHub MCP. The MCP write path executes on GitHub's side using the Copilot
-// session's user OAuth, so the hive's proxy never sees a POST it could gate —
-// denying these tools at launch is the only reliable enforcement, forcing all
-// GitHub writes through the App-gated `gh` wrapper / `hive-open-pr`, which author
-// as the App bot (kubestellar-hive[bot]). READ tools (get_issue, list_issues,
-// get_pull_request, search, ...) stay enabled via --enable-all-github-mcp-tools;
-// only these WRITE tools are denied. The mode-based gh-wrapper/proxy gating
-// (IssuesOnly vs IssuesAndPRs) is a separate, unchanged layer.
+// copilotGitHubWriteDenyFlags is defense-in-depth: explicit `--deny-tool` flags
+// for every GitHub MCP write tool, so no copilot mode can author issues/PRs/
+// comments as the logged-in Copilot USER via the built-in GitHub MCP server.
+//
+// PRIMARY defense is NOT these flags — it is DROPPING `--enable-all-github-mcp-
+// tools` from the launch command (see launch cmd below). The built-in GitHub MCP
+// server ("github-mcp-server") is READ-ONLY BY DEFAULT in Copilot CLI (since
+// v0.0.350); the write tools (create_issue/create_pull_request/...) are ONLY
+// registered when `--enable-all-github-mcp-tools` is passed. Without that flag
+// the write tools never exist, so there is nothing to invoke.
+//
+// The DENY NAMES MUST use the built-in server's real name `github-mcp-server`,
+// NOT `github`. Our earlier fix (#3120/#3121) used `github(create_issue)` — but
+// `github` is only the name for a SEPARATELY-added server; the built-in one is
+// `github-mcp-server` (confirmed via `copilot --help`: "--disable-builtin-mcps
+// ... (currently: github-mcp-server)"). A deny on the wrong server name is a
+// silent no-op, which is why that fix did not actually block the writes and the
+// user-authored issues continued. Deny syntax is ServerName(tool).
+//
+// READ tools (get_issue, list_issues, get_pull_request, search, ...) remain
+// available via the read-only default — agents still investigate; they just
+// cannot WRITE via the MCP. All GitHub writes go through the App-gated `gh`
+// wrapper / `hive-open-pr`, which author as the App bot (kubestellar-hive[bot]).
+// The mode-based gh-wrapper/proxy gating (IssuesOnly vs IssuesAndPRs) is a
+// separate, unchanged layer.
 const copilotGitHubWriteDenyFlags = "" +
-	" --deny-tool='github(create_pull_request)'" +
-	" --deny-tool='github(create_pull_request_with_copilot)'" +
-	" --deny-tool='github(merge_pull_request)'" +
-	" --deny-tool='github(create_issue)'" +
-	" --deny-tool='github(update_issue)'" +
-	" --deny-tool='github(add_issue_comment)'"
+	" --deny-tool='github-mcp-server(create_pull_request)'" +
+	" --deny-tool='github-mcp-server(create_pull_request_with_copilot)'" +
+	" --deny-tool='github-mcp-server(merge_pull_request)'" +
+	" --deny-tool='github-mcp-server(create_issue)'" +
+	" --deny-tool='github-mcp-server(update_issue)'" +
+	" --deny-tool='github-mcp-server(add_issue_comment)'"
 
 func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	if ctx == nil {
@@ -1208,16 +1222,19 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			// in cli_models.go), which lets the Copilot CLI pick/adjust the model
 			// per task. Nothing here assumes a concrete id, so the sentinel flows
 			// through unchanged.
-			// Every mode denies the FULL set of GitHub MCP write tools
-			// (copilotGitHubWriteDenyFlags) so no mode can author issues/PRs/
-			// comments as the login USER via the MCP; all GitHub writes must go
-			// through the App-gated gh wrapper / hive-open-pr. READ tools stay
-			// enabled via --enable-all-github-mcp-tools. The deny set is identical
-			// across ModeIssuesAndPRs / ModeIssuesOnly / advisory — the mode no
-			// longer changes what the MCP can write (it never legitimately should),
-			// it only governs the separate, unchanged gh-wrapper/proxy layer that
-			// still reads Mode for what the App-gated write path allows.
-			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools%s",
+			// PRIMARY authorship defense: do NOT pass --enable-all-github-mcp-
+			// tools. The built-in github-mcp-server is READ-ONLY by default, so
+			// the write tools (create_issue/create_pull_request/...) are never
+			// registered — an agent cannot author issues/PRs as the login USER
+			// via the MCP because those tools do not exist. READ tools
+			// (get_issue/list/search) stay available via the read-only default,
+			// so agents can still investigate. All GitHub WRITES go through the
+			// App-gated gh wrapper / hive-open-pr → authored as kubestellar-hive
+			// [bot]. copilotGitHubWriteDenyFlags is belt-and-suspenders (correctly
+			// named github-mcp-server(tool) denies) in case a future flag re-
+			// enables writes. Mode still governs the separate gh-wrapper/proxy
+			// layer, unchanged.
+			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all%s",
 				binary, model, copilotGitHubWriteDenyFlags)
 		case "gemini":
 			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
@@ -5990,20 +6007,19 @@ func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConf
 		}
 		return cmd
 	case "copilot":
-		hasGHDeny := false
-		for _, p := range denies {
-			if strings.Contains(p, "github") {
-				hasGHDeny = true
-				break
-			}
-		}
+		// Never pass --enable-all-github-mcp-tools: the built-in github-mcp-server
+		// is read-only by default, so GitHub MCP WRITE tools are never registered
+		// and an agent cannot author issues/PRs as the login USER. READ tools stay
+		// available. (Previously this ADDED --enable-all-github-mcp-tools whenever
+		// denies lacked a github entry — enabling all writes — and translated
+		// mcp__github__ to the WRONG server name `github(`; the built-in server is
+		// `github-mcp-server`, so those denies were silent no-ops.)
 		cmd := fmt.Sprintf("%s --model %s --no-auto-update --allow-all", binary, model)
-		if !hasGHDeny {
-			cmd += " --enable-all-github-mcp-tools"
-		}
 		for _, p := range denies {
-			copilotPattern := strings.ReplaceAll(p, "mcp__github__", "github(")
-			if strings.HasPrefix(copilotPattern, "github(") {
+			// Map claude-style mcp__github__<tool> to copilot's
+			// github-mcp-server(<tool>) deny syntax (correct built-in server name).
+			copilotPattern := strings.ReplaceAll(p, "mcp__github__", "github-mcp-server(")
+			if strings.HasPrefix(copilotPattern, "github-mcp-server(") {
 				copilotPattern += ")"
 			}
 			cmd += fmt.Sprintf(" --deny-tool='%s'", copilotPattern)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -3858,30 +3858,58 @@ func (a *AgentProcess) FilteredPaneLines(n int) []string {
 	return filterPaneOutput(a.lastPaneCapture, n)
 }
 
-// backendBinary maps an agent backend to the CLI binary that is actually
-// exec'd for it. Every model-gateway backend (config.InferenceBackends: vllm,
-// llm-d, litellm, watsonx) launches the SAME claude CLI, pointed at hive's
-// local OpenAI-compatible translator via ANTHROPIC_BASE_URL — the backend name
-// selects the upstream route, not the binary. Those entries are therefore
-// derived from the canonical list rather than written out here, so a backend
-// added to config.InferenceBackends can never again be accepted by config and
-// then rejected at kick time with "unknown backend".
-func backendBinary(backend string) (string, error) {
-	binaries := map[string]string{
-		"claude":  "claude",
-		"copilot": "copilot",
-		"gemini":  "gemini",
-		"goose":   "goose",
-		"pi":      "goose",
-		"bob":     "bob",
+// backendBinaryAliases names the backends whose binary is NOT simply the
+// backend name. Only genuine aliases belong here: every other CLI backend is
+// derived from config.CLIBackends by identity, and every model-gateway backend
+// from config.InferenceBackends. Keeping this map to aliases only is what makes
+// the accept-then-fail class of bug structurally impossible — see backendBinary.
+var backendBinaryAliases = map[string]string{
+	"pi": "goose",
+}
+
+// backendBinaryName maps an agent backend to the NAME of the CLI binary that is
+// exec'd for it, without touching the filesystem. Split out from backendBinary
+// so the "every supported backend resolves" invariant can be tested without
+// requiring each CLI to be installed on the test machine.
+//
+// Both canonical lists are derived rather than written out here:
+//
+//   - config.CLIBackends (claude, copilot, goose, codex, pi, bob, aider, gemini)
+//     each launch a binary of the same name, except for the aliases above.
+//   - config.InferenceBackends (vllm, llm-d, litellm, watsonx) all launch the
+//     SAME claude CLI, pointed at hive's local OpenAI-compatible translator via
+//     ANTHROPIC_BASE_URL — the backend name selects the upstream route, not the
+//     binary.
+//
+// Deriving both means a backend added to either list can never again be
+// accepted by config.ValidateBackend and then rejected hours later at kick time
+// with "unknown backend". Previously only InferenceBackends was derived, so
+// codex and aider were valid config values that failed at launch.
+func backendBinaryName(backend string) (string, error) {
+	binaries := make(map[string]string, len(config.CLIBackends)+len(config.InferenceBackends))
+	for _, b := range config.CLIBackends {
+		binaries[b] = b
 	}
 	for _, b := range config.InferenceBackends {
 		binaries[b] = "claude"
+	}
+	for backend, binary := range backendBinaryAliases {
+		binaries[backend] = binary
 	}
 
 	binary, ok := binaries[backend]
 	if !ok {
 		return "", fmt.Errorf("unknown backend: %s", backend)
+	}
+	return binary, nil
+}
+
+// backendBinary resolves an agent backend to the absolute path of the CLI
+// binary that is actually exec'd for it.
+func backendBinary(backend string) (string, error) {
+	binary, err := backendBinaryName(backend)
+	if err != nil {
+		return "", err
 	}
 
 	path, err := exec.LookPath(binary)

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -220,11 +220,15 @@ func TestToolRulesToLaunchCmd_ClaudeInference(t *testing.T) {
 }
 
 func TestToolRulesToLaunchCmd_Copilot(t *testing.T) {
-	// No github deny -> enable-all-github-mcp-tools present.
+	// Authorship fix: copilot must NEVER pass --enable-all-github-mcp-tools —
+	// the built-in github-mcp-server is read-only by default, so GitHub MCP
+	// WRITE tools are never registered and an agent cannot author issues/PRs as
+	// the logged-in user. (This test previously asserted the OPPOSITE — that the
+	// flag was present — which was the bug: it let agents author as the user.)
 	tools := denyTools("mcp__something__else")
 	cmd := toolRulesToLaunchCmd("copilot", "auto", "copilot", tools, false)
-	if !containsBoot(cmd, "--enable-all-github-mcp-tools") {
-		t.Errorf("copilot without github deny should enable github tools: %q", cmd)
+	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
+		t.Errorf("copilot must NOT enable all github mcp tools (read-only default): %q", cmd)
 	}
 	if !containsBoot(cmd, "--deny-tool=") {
 		t.Errorf("copilot cmd should include deny-tool: %q", cmd)
@@ -237,8 +241,13 @@ func TestToolRulesToLaunchCmd_CopilotGithubDeny(t *testing.T) {
 	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
 		t.Errorf("copilot with github deny should NOT enable all github tools: %q", cmd)
 	}
-	if !containsBoot(cmd, "github(create_pull_request)") {
-		t.Errorf("copilot deny should be translated: %q", cmd)
+	// Deny must use the built-in server's REAL name github-mcp-server, not the
+	// bogus `github` name (which was a silent no-op — the source of the leak).
+	if !containsBoot(cmd, "github-mcp-server(create_pull_request)") {
+		t.Errorf("copilot deny should translate to github-mcp-server(tool): %q", cmd)
+	}
+	if containsBoot(cmd, "--deny-tool='github(") {
+		t.Errorf("copilot deny must NOT use the wrong `github(` server name: %q", cmd)
 	}
 }
 

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -223,8 +223,7 @@ func TestToolRulesToLaunchCmd_Copilot(t *testing.T) {
 	// Authorship fix: copilot must NEVER pass --enable-all-github-mcp-tools —
 	// the built-in github-mcp-server is read-only by default, so GitHub MCP
 	// WRITE tools are never registered and an agent cannot author issues/PRs as
-	// the logged-in user. (This test previously asserted the OPPOSITE — that the
-	// flag was present — which was the bug: it let agents author as the user.)
+	// the logged-in user.
 	tools := denyTools("mcp__something__else")
 	cmd := toolRulesToLaunchCmd("copilot", "auto", "copilot", tools, false)
 	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
@@ -241,8 +240,7 @@ func TestToolRulesToLaunchCmd_CopilotGithubDeny(t *testing.T) {
 	if containsBoot(cmd, "--enable-all-github-mcp-tools") {
 		t.Errorf("copilot with github deny should NOT enable all github tools: %q", cmd)
 	}
-	// Deny must use the built-in server's REAL name github-mcp-server, not the
-	// bogus `github` name (which was a silent no-op — the source of the leak).
+	// Deny must use the built-in server's real name, not `github`.
 	if !containsBoot(cmd, "github-mcp-server(create_pull_request)") {
 		t.Errorf("copilot deny should translate to github-mcp-server(tool): %q", cmd)
 	}

--- a/v2/pkg/channels/manager_test.go
+++ b/v2/pkg/channels/manager_test.go
@@ -102,11 +102,12 @@ func TestTriggerKickWithoutBuildMsg(t *testing.T) {
 // A hot reload must be visible to subsequent triggers, which is the whole point
 // of reloading without a restart.
 func TestUpdateConfigIsVisibleToReceivers(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues"}, nil, nil), rec.fn, nil, quietLogger())
 
 	// Before: scanner subscribes to issues.
-	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, ""); w.Code != 200 {
+	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, "s3cr3t"); w.Code != 200 {
 		t.Fatalf("code = %d", w.Code)
 	}
 	if got := rec.waitForKicks(t, 1); len(got) != 1 {
@@ -119,7 +120,7 @@ func TestUpdateConfigIsVisibleToReceivers(t *testing.T) {
 	})
 
 	before := len(rec.snapshot())
-	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, ""); w.Code != 200 {
+	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, "s3cr3t"); w.Code != 200 {
 		t.Fatalf("code = %d", w.Code)
 	}
 	time.Sleep(50 * time.Millisecond)
@@ -127,7 +128,7 @@ func TestUpdateConfigIsVisibleToReceivers(t *testing.T) {
 		t.Fatalf("the old subscription still fired after reload: %d -> %d", before, after)
 	}
 
-	if w := postWebhook(t, m.WebhookHandler(), "push", map[string]any{}, ""); w.Code != 200 {
+	if w := postWebhook(t, m.WebhookHandler(), "push", map[string]any{}, "s3cr3t"); w.Code != 200 {
 		t.Fatalf("code = %d", w.Code)
 	}
 	if got := rec.waitForKicks(t, before+1); len(got) != before+1 {

--- a/v2/pkg/channels/webhook.go
+++ b/v2/pkg/channels/webhook.go
@@ -45,7 +45,8 @@ func (w *WebhookReceiver) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if secret == "" {
 		// HIVE_WEBHOOK_SECRET is required. Accepting unsigned webhooks would allow
 		// any network-accessible client to trigger agent kicks. Fail closed.
-		http.Error(rw, "webhook secret not configured", http.StatusServiceUnavailable)
+		w.mgr.logger.Warn("channels: webhook rejected because HIVE_WEBHOOK_SECRET is not configured")
+		http.Error(rw, "webhook secret not configured; set HIVE_WEBHOOK_SECRET to the GitHub webhook secret", http.StatusUnauthorized)
 		return
 	}
 

--- a/v2/pkg/channels/webhook.go
+++ b/v2/pkg/channels/webhook.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	webhookMaxBodyBytes     = 10 * 1024 * 1024
-	webhookSignatureHeader  = "X-Hub-Signature-256"
-	webhookEventHeader      = "X-GitHub-Event"
-	webhookSecretEnvVar     = "HIVE_WEBHOOK_SECRET"
+	webhookMaxBodyBytes    = 10 * 1024 * 1024
+	webhookSignatureHeader = "X-Hub-Signature-256"
+	webhookEventHeader     = "X-GitHub-Event"
+	webhookSecretEnvVar    = "HIVE_WEBHOOK_SECRET"
 )
 
 // WebhookReceiver handles GitHub webhook events and routes them to agents.
@@ -42,12 +42,17 @@ func (w *WebhookReceiver) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	secret := os.Getenv(webhookSecretEnvVar)
-	if secret != "" {
-		sig := r.Header.Get(webhookSignatureHeader)
-		if !verifyHMAC(body, sig, secret) {
-			http.Error(rw, "invalid signature", http.StatusUnauthorized)
-			return
-		}
+	if secret == "" {
+		// HIVE_WEBHOOK_SECRET is required. Accepting unsigned webhooks would allow
+		// any network-accessible client to trigger agent kicks. Fail closed.
+		http.Error(rw, "webhook secret not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	sig := r.Header.Get(webhookSignatureHeader)
+	if !verifyHMAC(body, sig, secret) {
+		http.Error(rw, "invalid signature", http.StatusUnauthorized)
+		return
 	}
 
 	eventType := r.Header.Get(webhookEventHeader)

--- a/v2/pkg/channels/webhook_test.go
+++ b/v2/pkg/channels/webhook_test.go
@@ -1,6 +1,7 @@
 package channels
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -171,6 +172,28 @@ func TestWebhookRejectsBadSignatureWhenSecretSet(t *testing.T) {
 	}
 }
 
+func TestWebhookRejectsMissingSecretWithActionableLog(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "")
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	rec := &kickRecorder{}
+	m := NewManager(webhookAgents([]string{"issues"}, nil, nil), rec.fn, nil, logger)
+
+	w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), webhookSecretEnvVar) {
+		t.Fatalf("response should tell operators to configure %s, got %s", webhookSecretEnvVar, w.Body.String())
+	}
+	if !strings.Contains(logs.String(), webhookSecretEnvVar) {
+		t.Fatalf("log should name missing %s, got %s", webhookSecretEnvVar, logs.String())
+	}
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("a webhook without configured HMAC secret must not kick any agent, got %v", got)
+	}
+}
+
 func TestWebhookAcceptsCorrectSignature(t *testing.T) {
 	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
@@ -198,21 +221,27 @@ func TestWebhookRejectsNonPost(t *testing.T) {
 }
 
 func TestWebhookRequiresEventHeader(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues"}, nil, nil), rec.fn, nil, quietLogger())
 
-	w := postWebhook(t, m.WebhookHandler(), "", map[string]any{"action": "opened"}, "")
+	w := postWebhook(t, m.WebhookHandler(), "", map[string]any{"action": "opened"}, "s3cr3t")
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
 	}
 }
 
 func TestWebhookRejectsInvalidJSON(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues"}, nil, nil), rec.fn, nil, quietLogger())
 
-	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader("{not json"))
+	raw := []byte("{not json")
+	mac := hmac.New(sha256.New, []byte("s3cr3t"))
+	mac.Write(raw)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(string(raw)))
 	req.Header.Set(webhookEventHeader, "issues")
+	req.Header.Set(webhookSignatureHeader, "sha256="+hex.EncodeToString(mac.Sum(nil)))
 	w := httptest.NewRecorder()
 	m.WebhookHandler().ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
@@ -224,10 +253,11 @@ func TestWebhookRejectsInvalidJSON(t *testing.T) {
 
 // A channel subscribed to the bare event type fires for any action.
 func TestWebhookMatchesBareEventType(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues"}, nil, nil), rec.fn, nil, quietLogger())
 
-	w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, "")
+	w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, "s3cr3t")
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
@@ -243,17 +273,18 @@ func TestWebhookMatchesBareEventType(t *testing.T) {
 // A channel subscribed to "event.action" must fire only for that action, so a
 // scanner watching issues.opened is not woken by every issue comment.
 func TestWebhookMatchesQualifiedEventOnly(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues.opened"}, nil, nil), rec.fn, nil, quietLogger())
 
-	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "closed"}, ""); w.Code != http.StatusOK {
+	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "closed"}, "s3cr3t"); w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
 	if got := rec.snapshot(); len(got) != 0 {
 		t.Fatalf("issues.closed must not trigger an issues.opened channel, got %v", got)
 	}
 
-	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, ""); w.Code != http.StatusOK {
+	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, "s3cr3t"); w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
 	if got := rec.waitForKicks(t, 1); len(got) != 1 {
@@ -263,6 +294,7 @@ func TestWebhookMatchesQualifiedEventOnly(t *testing.T) {
 
 // A repo allowlist confines a channel to its own repositories.
 func TestWebhookHonoursRepoAllowlist(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues"}, []string{"allowed-repo"}, nil), rec.fn, nil, quietLogger())
 
@@ -270,7 +302,7 @@ func TestWebhookHonoursRepoAllowlist(t *testing.T) {
 		"action":     "opened",
 		"repository": map[string]any{"name": "other-repo"},
 	}
-	if w := postWebhook(t, m.WebhookHandler(), "issues", body, ""); w.Code != http.StatusOK {
+	if w := postWebhook(t, m.WebhookHandler(), "issues", body, "s3cr3t"); w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
 	if got := rec.snapshot(); len(got) != 0 {
@@ -278,7 +310,7 @@ func TestWebhookHonoursRepoAllowlist(t *testing.T) {
 	}
 
 	body["repository"] = map[string]any{"name": "allowed-repo"}
-	if w := postWebhook(t, m.WebhookHandler(), "issues", body, ""); w.Code != http.StatusOK {
+	if w := postWebhook(t, m.WebhookHandler(), "issues", body, "s3cr3t"); w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
 	if got := rec.waitForKicks(t, 1); len(got) != 1 {
@@ -288,10 +320,11 @@ func TestWebhookHonoursRepoAllowlist(t *testing.T) {
 
 // A disabled channel must never fire.
 func TestWebhookSkipsDisabledChannel(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues"}, nil, boolPtr(false)), rec.fn, nil, quietLogger())
 
-	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, ""); w.Code != http.StatusOK {
+	if w := postWebhook(t, m.WebhookHandler(), "issues", map[string]any{"action": "opened"}, "s3cr3t"); w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
 	if got := rec.snapshot(); len(got) != 0 {
@@ -301,10 +334,11 @@ func TestWebhookSkipsDisabledChannel(t *testing.T) {
 
 // An event nobody subscribes to is accepted but triggers nothing.
 func TestWebhookUnmatchedEventTriggersNothing(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	m := NewManager(webhookAgents([]string{"issues"}, nil, nil), rec.fn, nil, quietLogger())
 
-	w := postWebhook(t, m.WebhookHandler(), "push", map[string]any{}, "")
+	w := postWebhook(t, m.WebhookHandler(), "push", map[string]any{}, "s3cr3t")
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
@@ -316,6 +350,7 @@ func TestWebhookUnmatchedEventTriggersNothing(t *testing.T) {
 // The trigger context handed to buildMsg must carry the event details, since
 // that is what the agent's kick message is built from.
 func TestWebhookTriggerContextCarriesEventDetail(t *testing.T) {
+	t.Setenv(webhookSecretEnvVar, "s3cr3t")
 	rec := &kickRecorder{}
 	var gotCtx TriggerContext
 	var mu sync.Mutex
@@ -331,7 +366,7 @@ func TestWebhookTriggerContextCarriesEventDetail(t *testing.T) {
 		"action":     "opened",
 		"repository": map[string]any{"name": "my-repo"},
 	}
-	postWebhook(t, m.WebhookHandler(), "issues", body, "")
+	postWebhook(t, m.WebhookHandler(), "issues", body, "s3cr3t")
 	kicks := rec.waitForKicks(t, 1)
 	if len(kicks) != 1 {
 		t.Fatalf("want 1 kick, got %v", kicks)

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -677,6 +677,7 @@ type GatewayConfig struct {
 // gatewayKind values.
 const (
 	GatewayKindOpenRouter = "openrouter"
+	GatewayKindGroq       = "groq"
 	GatewayKindLiteLLM    = "litellm"
 	GatewayKindVLLM       = "vllm"
 	GatewayKindLLMD       = "llm-d"

--- a/v2/pkg/config/dockerfile_contributor_test.go
+++ b/v2/pkg/config/dockerfile_contributor_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestContributorDockerfileInstallsPiWithoutCurlPipeShell(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "Dockerfile.contributor"))
+	if err != nil {
+		t.Fatalf("read Dockerfile.contributor: %v", err)
+	}
+	dockerfile := string(body)
+	if strings.Contains(dockerfile, "https://pi.dev/install.sh | sh") {
+		t.Fatal("Dockerfile.contributor must not execute the mutable pi.dev installer with curl|sh")
+	}
+	for _, want := range []string{
+		"ARG PI_CODING_AGENT_VERSION=0.84.1",
+		"@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}",
+		"npm install -g --ignore-scripts",
+		"which pi",
+	} {
+		if !strings.Contains(dockerfile, want) {
+			t.Fatalf("Dockerfile.contributor missing %q", want)
+		}
+	}
+}

--- a/v2/pkg/config/repo_target.go
+++ b/v2/pkg/config/repo_target.go
@@ -43,19 +43,19 @@ func ValidateProjectRepoTargets(org string, repos []string, primaryRepo, forgeHo
 		return issue("project.repos", "repo is empty — expected org/repo")
 	}
 	for _, repo := range repos {
-		if repoIssue := validateRepoName("project.repos", repo); repoIssue != nil {
+		if repoIssue := validateRepoName("project.repos", org, repo); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	if strings.TrimSpace(primaryRepo) != "" {
-		if repoIssue := validateRepoName("project.primary_repo", primaryRepo); repoIssue != nil {
+		if repoIssue := validateRepoName("project.primary_repo", org, primaryRepo); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	return nil
 }
 
-func validateRepoName(field, repo string) *RepoTargetIssue {
+func validateRepoName(field, org, repo string) *RepoTargetIssue {
 	repo = strings.TrimSpace(repo)
 	if repo == "" {
 		return issue(field, "repo is empty — expected org/repo")
@@ -64,7 +64,20 @@ func validateRepoName(field, repo string) *RepoTargetIssue {
 		return issue(field, "repo '"+repo+"' is a URL — expected repo name only so the target resolves to org/repo")
 	}
 	if strings.Contains(repo, "/") {
-		return issue(field, "repo '"+repo+"' contains '/' — expected repo name only so the target resolves to org/repo")
+		// A fully-qualified "<org>/<repo>" is accepted when the org prefix
+		// matches the configured project.org — it is unambiguously the same
+		// target, and the save path strips the prefix down to the bare name.
+		// This is what a user naturally types/pastes when re-adding an existing
+		// repo from the Governor → Repos page (issue #3021). Anything else
+		// (a different org, a trailing slash, or multiple slashes) is still a
+		// misconfiguration.
+		org = strings.TrimSpace(org)
+		prefix := org + "/"
+		bare := strings.TrimPrefix(repo, prefix)
+		if org != "" && strings.HasPrefix(repo, prefix) && bare != "" && !strings.Contains(bare, "/") {
+			return nil
+		}
+		return issue(field, "repo '"+repo+"' contains '/' — expected repo name only (or '"+org+"/<repo>') so the target resolves to org/repo")
 	}
 	return nil
 }

--- a/v2/pkg/config/repo_target_test.go
+++ b/v2/pkg/config/repo_target_test.go
@@ -60,22 +60,29 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 			org:   "kubestellar",
 			repos: []string{"hive/"},
 			forge: "github.com",
-			want:  "Repo target misconfigured: repo 'hive/' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+			want:  "Repo target misconfigured: repo 'hive/' contains '/' — expected repo name only (or 'kubestellar/<repo>') so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
-			name:  "repo contains slash",
+			name:  "repo contains slash for a different org",
 			org:   "kubestellar",
 			repos: []string{"other/hive"},
 			forge: "github.com",
-			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only (or 'kubestellar/<repo>') so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
-			name:    "primary contains slash",
+			// #3021: re-adding an existing repo as "<org>/<repo>" where the org
+			// matches project.org is unambiguous and must be accepted.
+			name:  "repo qualified with matching org accepted",
+			org:   "kubestellar",
+			repos: []string{"kubestellar/hive"},
+			forge: "github.com",
+		},
+		{
+			name:    "primary qualified with matching org accepted",
 			org:     "kubestellar",
 			repos:   []string{"hive"},
 			primary: "kubestellar/hive",
 			forge:   "github.com",
-			want:    "Repo target misconfigured: repo 'kubestellar/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
 			name:  "full url pasted into org",

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7121,8 +7121,9 @@ func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request)
 		jsonError(w, "name and url are required", http.StatusBadRequest)
 		return
 	}
-	if !strings.HasPrefix(req.URL, "https://") && !strings.HasPrefix(req.URL, "http://") && !strings.HasPrefix(req.URL, "git@") {
-		jsonError(w, "url must start with https://, http://, or git@", http.StatusBadRequest)
+	req.URL = strings.TrimSpace(req.URL)
+	if err := knowledge.ValidateGitSourceURL(req.URL); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if strings.Contains(req.Name, "..") || strings.ContainsAny(req.Name, "/\\") {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7313,6 +7313,16 @@ func (s *Server) handleDocumentsImport(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "url, file_path, or context7_id is required", http.StatusBadRequest)
 		return
 	}
+	if req.URL != "" {
+		if !strings.HasPrefix(req.URL, "https://") && !strings.HasPrefix(req.URL, "http://") {
+			jsonError(w, "document url must use http or https scheme", http.StatusBadRequest)
+			return
+		}
+		if isPrivateURL(r.Context(), req.URL) {
+			jsonError(w, "document url must not point to private/internal addresses", http.StatusBadRequest)
+			return
+		}
+	}
 	if req.Layer == "" {
 		req.Layer = knowledge.LayerProject
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1232,16 +1232,14 @@ func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, p
 }
 
 // requireOwnerRole returns true when the request carries owner-level access.
-// An empty X-Hive-Role is treated as owner (open/dev spokes with no auth_token
-// or hub-proxied spokes where the hub omits the header). Any non-owner role
-// set by the hub or device-flow session is rejected. Call this for state-mutating
-// endpoints that should be restricted to operators (pause, resume, fleet breaker).
+// The authentication middleware owns X-Hive-Role and strips client-supplied
+// values before injecting roles for trusted sources. Owner-only mutations also
+// require its server-only verification marker, so legacy/proofless proxy
+// headers and shared-token requests fail closed instead of trusting spoofable
+// client input.
 func requireOwnerRole(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		return true // open spoke or internal automation — treat as owner
-	}
-	if role != "owner" {
+	if role != "owner" || r.Header.Get(ownerRoleVerifiedHeader) != "true" {
 		jsonError(w, "owner access required", http.StatusForbidden)
 		return false
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4533,7 +4533,10 @@ func probeModelsWithHeaders(endpoint, apiKey string, extraHeaders map[string]str
 			req.Header.Set(k, v)
 		}
 	}
-	client := &http.Client{Timeout: litellmProbeTimeout}
+	client := &http.Client{
+		Timeout:       litellmProbeTimeout,
+		CheckRedirect: noRedirectToPrivate,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("cannot reach gateway: %w", err)

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -346,7 +346,10 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		client := &http.Client{Timeout: importHTTPTimeoutS * 1e9} // nanoseconds
+		client := &http.Client{
+			Timeout:       importHTTPTimeoutS * 1e9, // nanoseconds
+			CheckRedirect: noRedirectToPrivate,
+		}
 		resp, err := client.Get(importFetchURL(body.URL))
 		if err != nil {
 			jsonError(w, "failed to fetch URL: "+err.Error(), http.StatusBadGateway)

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -197,6 +197,88 @@ const (
 	importHTTPTimeoutS  = 10
 )
 
+// importAllowedHosts is the set of GitHub hostnames that agent import URLs may
+// target. Gist URLs are supported for one-shot imports only; keep-linked imports
+// require repository file URLs so they can be stored as owner/repo/ref/path.
+// All other hosts (including localhost, RFC-1918 ranges, and cloud metadata
+// endpoints) are rejected to prevent SSRF.
+var importAllowedHosts = map[string]bool{
+	"github.com":                true,
+	"raw.githubusercontent.com": true,
+	"gist.github.com":           true,
+}
+
+const (
+	importURLFormsOneShot = "https://github.com/<owner>/<repo>/blob/<ref>/<path>, https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>, or https://gist.github.com/<user>/<gist-id>/raw[/<file>]"
+	importURLFormsLinked  = "https://github.com/<owner>/<repo>/blob/<ref>/<path> or https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>"
+)
+
+// validateImportURL rejects URLs that could cause SSRF. Only https:// scheme
+// and GitHub-owned hostnames are permitted. An error is returned if the URL
+// fails any check; the caller should surface it as a 400 Bad Request.
+func validateImportURL(rawURL string, keepLinked bool) error {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("import URL must use https:// scheme (got %q)", u.Scheme)
+	}
+	// Strip port to compare only the hostname.
+	host := strings.ToLower(u.Hostname())
+	if !importAllowedHosts[host] {
+		return fmt.Errorf("import URL host %q is not allowed; supported forms: %s", host, importURLFormsForMode(keepLinked))
+	}
+
+	if host == "gist.github.com" {
+		if keepLinked {
+			return fmt.Errorf("keep linked imports do not support gist URLs; use a GitHub repository file URL (%s), or uncheck Keep linked for a one-shot gist import", importURLFormsLinked)
+		}
+		if !isGistRawURLPath(u.Path) {
+			return fmt.Errorf("gist import URL %q is not a supported raw gist URL; supported forms: %s", rawURL, importURLFormsOneShot)
+		}
+		return nil
+	}
+
+	if host == "raw.githubusercontent.com" {
+		if githubRawURLPattern.FindStringSubmatch(u.Path) == nil {
+			return fmt.Errorf("import URL %q is not a supported raw GitHub file URL; supported forms: %s", rawURL, importURLFormsForMode(keepLinked))
+		}
+		return nil
+	}
+
+	if host == "github.com" && githubBlobURLPattern.FindStringSubmatch(u.Path) != nil {
+		return nil
+	}
+
+	return fmt.Errorf("import URL %q is not a supported GitHub file URL; supported forms: %s", rawURL, importURLFormsForMode(keepLinked))
+}
+
+func importURLFormsForMode(keepLinked bool) string {
+	if keepLinked {
+		return importURLFormsLinked
+	}
+	return importURLFormsOneShot
+}
+
+func isGistRawURLPath(path string) bool {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	return len(parts) >= 3 && parts[0] != "" && parts[1] != "" && strings.EqualFold(parts[2], "raw")
+}
+
+func importFetchURL(rawURL string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
+		return rawURL
+	}
+	m := githubBlobURLPattern.FindStringSubmatch(u.Path)
+	if m == nil {
+		return rawURL
+	}
+	u.Path = strings.Replace(u.Path, "/blob/", "/raw/", 1)
+	return u.String()
+}
+
 // agentConfigFromDefinition maps a parsed AgentDefinition to an AgentConfig with
 // the import defaults applied (backend copilot, immediate restart, worker bead
 // role, enabled). It is the single mapping used by both the whole-agent import
@@ -257,8 +339,15 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, fmt.Sprintf("url must be at most %d characters", importMaxURLLen), http.StatusBadRequest)
 			return
 		}
+		// Validate URL scheme and host before fetching to prevent SSRF.
+		// Only https:// to GitHub domains is accepted; file://, http://, and
+		// internal addresses are rejected regardless of keepLinked.
+		if err := validateImportURL(body.URL, body.KeepLinked); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		client := &http.Client{Timeout: importHTTPTimeoutS * 1e9} // nanoseconds
-		resp, err := client.Get(body.URL)
+		resp, err := client.Get(importFetchURL(body.URL))
 		if err != nil {
 			jsonError(w, "failed to fetch URL: "+err.Error(), http.StatusBadGateway)
 			return
@@ -488,13 +577,13 @@ func (s *Server) definitionSourceFromURL(rawURL string) (*config.DefinitionSourc
 		return nil, fmt.Errorf("could not parse URL %q", rawURL)
 	}
 	var m []string
-	if strings.EqualFold(u.Host, "raw.githubusercontent.com") {
+	if strings.EqualFold(u.Hostname(), "raw.githubusercontent.com") {
 		m = githubRawURLPattern.FindStringSubmatch(u.Path)
 	} else {
 		m = githubBlobURLPattern.FindStringSubmatch(u.Path)
 	}
 	if m == nil {
-		return nil, fmt.Errorf("URL %q is not a recognized GitHub file URL (expected .../<owner>/<repo>/blob/<ref>/<path> or a raw.githubusercontent.com file URL)", rawURL)
+		return nil, fmt.Errorf("URL %q is not a recognized GitHub file URL (expected %s)", rawURL, importURLFormsLinked)
 	}
 	return &config.DefinitionSourceConfig{
 		Type:  "github",

--- a/v2/pkg/dashboard/api_agents_test.go
+++ b/v2/pkg/dashboard/api_agents_test.go
@@ -592,13 +592,14 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	s, deps := apiServer(t)
 	deps.Config.Data.AgentsDir = t.TempDir()
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source": "url",
-		"url":    ts.URL + "/agent.yaml",
+		"url":    "https://raw.githubusercontent.com/kubestellar/hive/main/agent.yaml",
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -615,11 +616,12 @@ func TestHandleAgentImport_URLFetchFails(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	s, _ := apiServer(t)
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source": "url",
-		"url":    ts.URL + "/agent.yaml",
+		"url":    "https://raw.githubusercontent.com/kubestellar/hive/main/agent.yaml",
 	})
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d: %s", rec.Code, rec.Body.String())

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -7397,24 +7397,16 @@ func defaultHostResolver(ctx context.Context, host string) ([]string, error) {
 }
 
 func isPrivateURL(ctx context.Context, rawURL string) bool {
-	for _, scheme := range []string{"https://", "http://", "wss://", "ws://"} {
-		if strings.HasPrefix(rawURL, scheme) {
-			rawURL = strings.TrimPrefix(rawURL, scheme)
-			break
-		}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return true
 	}
-	host := rawURL
-	if idx := strings.IndexAny(host, ":/"); idx >= 0 {
-		host = host[:idx]
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return true
 	}
-	host = strings.ToLower(host)
-	blocked := []string{"localhost", "127.", "10.", "172.16.", "172.17.", "172.18.", "172.19.",
-		"172.20.", "172.21.", "172.22.", "172.23.", "172.24.", "172.25.", "172.26.", "172.27.",
-		"172.28.", "172.29.", "172.30.", "172.31.", "192.168.", "169.254.", "[::1]", "[::ffff:", "0.0.0.0", "0."}
-	for _, p := range blocked {
-		if strings.HasPrefix(host, p) {
-			return true
-		}
+	if isPrivateHost(host) {
+		return true
 	}
 
 	addrs, err := privateURLResolver(ctx, host)
@@ -7423,14 +7415,33 @@ func isPrivateURL(ctx context.Context, rawURL string) bool {
 		return true
 	}
 	for _, addr := range addrs {
-		for _, p := range blocked {
-			if strings.HasPrefix(addr, p) {
-				return true
-			}
+		if isPrivateHost(addr) {
+			return true
 		}
 	}
 
 	return false
+}
+
+func isPrivateHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	if ip == nil {
+		return false
+	}
+	return isPrivateIP(ip)
+}
+
+func isPrivateIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
 }
 
 // validateGitHubToken checks a GitHub personal access token against the GitHub API

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -879,7 +879,7 @@ func TestHandleUnpin_NotFound(t *testing.T) {
 
 func TestHandlePause(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -1353,7 +1353,7 @@ func TestHandleModelSet_UnknownAgent(t *testing.T) {
 
 func TestHandleResume_UnknownAgent(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/resume/nonexistent", nil)
+	rec := doOwnerPost(s, "/api/resume/nonexistent", nil)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1488,11 +1488,11 @@ func TestHandleGovernorRepos_Success(t *testing.T) {
 func TestHandleGovernorRepos_StripOrg(t *testing.T) {
 	s, deps := apiServer(t)
 	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/new-repo"}, "primaryRepo": "myorg/new-repo"})
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want 400", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
 	}
-	if len(deps.Config.Project.Repos) == 1 && deps.Config.Project.Repos[0] == "new-repo" {
-		t.Errorf("repos mutated to stripped value %v despite rejection", deps.Config.Project.Repos)
+	if len(deps.Config.Project.Repos) != 1 || deps.Config.Project.Repos[0] != "new-repo" {
+		t.Errorf("repos = %v, want stripped new-repo", deps.Config.Project.Repos)
 	}
 }
 

--- a/v2/pkg/dashboard/api_pause_toggle_test.go
+++ b/v2/pkg/dashboard/api_pause_toggle_test.go
@@ -23,7 +23,7 @@ func decodeToggleBody(t *testing.T, body []byte) map[string]interface{} {
 
 func TestHandlePause_RealTransitionReportsChangedTrue(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -41,10 +41,10 @@ func TestHandlePause_RealTransitionReportsChangedTrue(t *testing.T) {
 
 func TestHandlePause_NoopReturnsChangedFalse(t *testing.T) {
 	s, _ := apiServer(t)
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("first pause status = %d, want 200", rec.Code)
 	}
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("second pause status = %d, want 200 (ok:true is part of the contract)", rec.Code)
 	}
@@ -63,7 +63,7 @@ func TestHandlePause_NoopReturnsChangedFalse(t *testing.T) {
 func TestHandleResume_NoopReturnsChangedFalse(t *testing.T) {
 	s, _ := apiServer(t)
 	// scanner starts un-paused: resuming it is a no-op.
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (no-op resume must not touch tmux)", rec.Code)
 	}
@@ -81,10 +81,10 @@ func TestHandleResume_NoopReturnsChangedFalse(t *testing.T) {
 
 func TestHandleResume_RealTransitionReportsChangedTrue(t *testing.T) {
 	s, _ := apiServer(t)
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("pause status = %d, want 200", rec.Code)
 	}
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	// A real resume relaunches the agent session; in environments without a
 	// working tmux this legitimately fails with 400 (same tolerance as
 	// TestHandleResume). The contract under test is: when it DOES succeed,
@@ -115,7 +115,7 @@ func TestHandleAgentState_ReflectsAuthoritativePause(t *testing.T) {
 		t.Errorf("fresh agent: paused = %v, state = %v; want false/running", m["paused"], m["state"])
 	}
 
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("pause status = %d, want 200", rec.Code)
 	}
 

--- a/v2/pkg/dashboard/api_provenance_test.go
+++ b/v2/pkg/dashboard/api_provenance_test.go
@@ -201,3 +201,19 @@ func TestProvenanceRedactsSecrets(t *testing.T) {
 		t.Fatal("response leaked the github token")
 	}
 }
+
+// TestProvenanceRejectsEmptyRole is the regression test for PR #3220: when
+// X-Hive-Role is absent (empty string), the handler must fail CLOSED (403)
+// rather than defaulting to "owner". The prior code granted owner access to
+// any request that simply omitted the header — an authorization bypass.
+func TestProvenanceRejectsEmptyRole(t *testing.T) {
+	writeProvenanceFixture(t, "project:\n  org: acme\nagents:\n  scanner: {}\n", "")
+
+	// getProvenance with "" does NOT set X-Hive-Role — simulating a request
+	// from a caller that omits the header entirely.
+	rec, _ := getProvenance(t, "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("empty X-Hive-Role: status = %d, want 403 (fail closed); "+
+			"before #3220 this returned 200 because empty defaulted to owner", rec.Code)
+	}
+}

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -87,6 +87,22 @@ func doPost(s *Server, path string, body interface{}) *httptest.ResponseRecorder
 	return rec
 }
 
+func markOwnerRequest(req *http.Request) {
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
+}
+
+func doOwnerPost(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
+	var b bytes.Buffer
+	json.NewEncoder(&b).Encode(body)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, &b)
+	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
 func doPut(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
 	var b bytes.Buffer
 	json.NewEncoder(&b).Encode(body)
@@ -951,7 +967,7 @@ func TestHandleKick_NoMessage(t *testing.T) {
 
 func TestHandlePause_NotFound(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/nonexistent", map[string]interface{}{})
+	rec := doOwnerPost(s, "/api/pause/nonexistent", map[string]interface{}{})
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
@@ -1018,7 +1034,7 @@ func TestHandleModelSet_NotFound(t *testing.T) {
 func TestHandleResume(t *testing.T) {
 	s, _ := apiServer(t)
 	// Resume may fail because agent isn't actually running
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	// Accept OK or BadRequest (tmux not available)
 	if rec.Code != http.StatusOK && rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d", rec.Code)
@@ -1027,7 +1043,7 @@ func TestHandleResume(t *testing.T) {
 
 func TestHandleResume_NotFound(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/resume/nonexistent", nil)
+	rec := doOwnerPost(s, "/api/resume/nonexistent", nil)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}

--- a/v2/pkg/dashboard/backup_api.go
+++ b/v2/pkg/dashboard/backup_api.go
@@ -33,7 +33,8 @@ const backupBuildTimeout = spokebackup.BuildTimeout
 func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
-		role = "owner"
+		http.Error(w, "X-Hive-Role header required", http.StatusUnauthorized)
+		return
 	}
 	if role != "owner" {
 		jsonError(w, "owner access required", http.StatusForbidden)
@@ -57,7 +58,8 @@ func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleBackupDownload(w http.ResponseWriter, r *http.Request) {
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
-		role = "owner"
+		http.Error(w, "X-Hive-Role header required", http.StatusUnauthorized)
+		return
 	}
 	if role != "owner" {
 		jsonError(w, "only the owner can back up this hive", http.StatusForbidden)

--- a/v2/pkg/dashboard/collaborators_test.go
+++ b/v2/pkg/dashboard/collaborators_test.go
@@ -1,0 +1,108 @@
+package dashboard
+
+import (
+	"testing"
+)
+
+func TestCollabHowRank(t *testing.T) {
+	tests := []struct {
+		how  string
+		want int
+	}{
+		{collabHowIssue, 3},
+		{collabHowInvite, 2},
+		{collabHowPresence, 1},
+		{"", 0},
+		{"unknown", 0},
+	}
+	for _, tc := range tests {
+		if got := collabHowRank(tc.how); got != tc.want {
+			t.Errorf("collabHowRank(%q) = %d, want %d", tc.how, got, tc.want)
+		}
+	}
+}
+
+func TestCollabHowRank_Ordering(t *testing.T) {
+	// issue > invite > presence
+	if collabHowRank(collabHowIssue) <= collabHowRank(collabHowInvite) {
+		t.Error("issue should rank higher than invite")
+	}
+	if collabHowRank(collabHowInvite) <= collabHowRank(collabHowPresence) {
+		t.Error("invite should rank higher than presence")
+	}
+	if collabHowRank(collabHowPresence) <= collabHowRank("") {
+		t.Error("presence should rank higher than unknown")
+	}
+}
+
+func TestSortedCollaborators_NilProfile(t *testing.T) {
+	got := sortedCollaborators(nil)
+	if got == nil || len(got) != 0 {
+		t.Errorf("nil profile: expected empty slice, got %v", got)
+	}
+}
+
+func TestSortedCollaborators_EmptyList(t *testing.T) {
+	p := &ContributorProfile{Collaborators: []CollaboratorRecord{}}
+	got := sortedCollaborators(p)
+	if len(got) != 0 {
+		t.Errorf("empty list: expected empty, got %d items", len(got))
+	}
+}
+
+func TestSortedCollaborators_OrderByOccasions(t *testing.T) {
+	p := &ContributorProfile{
+		Collaborators: []CollaboratorRecord{
+			{Username: "alice", Occasions: 2, FirstMetAt: "2026-01-01T00:00:00Z"},
+			{Username: "bob", Occasions: 5, FirstMetAt: "2026-01-02T00:00:00Z"},
+			{Username: "carol", Occasions: 1, FirstMetAt: "2026-01-03T00:00:00Z"},
+		},
+	}
+	got := sortedCollaborators(p)
+	if got[0].Username != "bob" || got[1].Username != "alice" || got[2].Username != "carol" {
+		t.Errorf("expected bob > alice > carol by occasions, got %s > %s > %s",
+			got[0].Username, got[1].Username, got[2].Username)
+	}
+}
+
+func TestSortedCollaborators_TiebreakByFirstMet(t *testing.T) {
+	p := &ContributorProfile{
+		Collaborators: []CollaboratorRecord{
+			{Username: "bob", Occasions: 3, FirstMetAt: "2026-02-01T00:00:00Z"},
+			{Username: "alice", Occasions: 3, FirstMetAt: "2026-01-01T00:00:00Z"},
+		},
+	}
+	got := sortedCollaborators(p)
+	// Same occasions → earliest-met first
+	if got[0].Username != "alice" {
+		t.Errorf("same occasions: expected alice (earlier met) first, got %s", got[0].Username)
+	}
+}
+
+func TestSortedCollaborators_TiebreakByName(t *testing.T) {
+	p := &ContributorProfile{
+		Collaborators: []CollaboratorRecord{
+			{Username: "zara", Occasions: 1, FirstMetAt: "2026-01-01T00:00:00Z"},
+			{Username: "alice", Occasions: 1, FirstMetAt: "2026-01-01T00:00:00Z"},
+		},
+	}
+	got := sortedCollaborators(p)
+	// Same occasions, same time → alphabetical
+	if got[0].Username != "alice" {
+		t.Errorf("same occasions+time: expected alice first, got %s", got[0].Username)
+	}
+}
+
+func TestSortedCollaborators_DoesNotMutateOriginal(t *testing.T) {
+	p := &ContributorProfile{
+		Collaborators: []CollaboratorRecord{
+			{Username: "bob", Occasions: 1},
+			{Username: "alice", Occasions: 5},
+		},
+	}
+	_ = sortedCollaborators(p)
+	// Original order preserved
+	if p.Collaborators[0].Username != "bob" {
+		t.Error("sortedCollaborators mutated the original slice")
+	}
+}

--- a/v2/pkg/dashboard/contribute_security_test.go
+++ b/v2/pkg/dashboard/contribute_security_test.go
@@ -27,6 +27,8 @@ func TestIsPrivateURLBlocksDNSRebindingAndFailures(t *testing.T) {
 			return []string{"93.184.216.34"}, nil
 		case "rebind.example":
 			return []string{"10.0.0.1"}, nil
+		case "v6-rebind.example":
+			return []string{"::1", "fc00::1"}, nil
 		default:
 			return nil, context.DeadlineExceeded
 		}
@@ -39,9 +41,17 @@ func TestIsPrivateURLBlocksDNSRebindingAndFailures(t *testing.T) {
 		want bool
 	}{
 		{name: "literal localhost", raw: "http://localhost:8080/path", want: true},
+		{name: "literal ipv4 private", raw: "http://10.1.2.3/path", want: true},
+		{name: "literal ipv4 rfc1918", raw: "http://172.16.0.1/path", want: true},
+		{name: "literal ipv4 rfc1918 high", raw: "http://192.168.1.10/path", want: true},
 		{name: "literal metadata", raw: "http://169.254.169.254/latest", want: true},
+		{name: "literal ipv6 loopback", raw: "http://[::1]/path", want: true},
+		{name: "literal ipv6 unique local", raw: "http://[fc00::1]/path", want: true},
+		{name: "literal ipv6 link local", raw: "http://[fe80::1]/path", want: true},
+		{name: "literal ipv6 mapped loopback", raw: "http://[::ffff:127.0.0.1]/path", want: true},
 		{name: "public dns", raw: "https://public.example/path", want: false},
 		{name: "dns rebind", raw: "https://rebind.example/path", want: true},
+		{name: "dns ipv6 rebind", raw: "https://v6-rebind.example/path", want: true},
 		{name: "dns failure", raw: "https://missing.example/path", want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -348,14 +348,12 @@ func TestHandleGovernorRepos_StripOrgPrefix(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("code = %d, want 400", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("code = %d, want 200", w.Code)
 	}
 	repos := srv.deps.Config.Project.Repos
-	for _, r := range repos {
-		if strings.Contains(r, "testorg/") {
-			t.Errorf("repo %q should not contain org prefix", r)
-		}
+	if len(repos) != 1 || repos[0] != "repo1" {
+		t.Errorf("repos = %v, want stripped repo1", repos)
 	}
 }
 

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -605,6 +605,7 @@ func TestSecurityHeaders_WithAuthToken(t *testing.T) {
 	req = httptest.NewRequest("GET", "/api/kick/scanner", nil)
 	req.Header.Set("X-Hive-User", "testuser")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, "secret-token")
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -669,6 +669,7 @@ func TestHandlePause_Boost(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/pause/scanner", strings.NewReader(`{"reason":"testing"}`))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	req.SetPathValue("agent", "scanner")
 	w := httptest.NewRecorder()
 	srv.handlePause(w, req)

--- a/v2/pkg/dashboard/dashboard_config_download_test.go
+++ b/v2/pkg/dashboard/dashboard_config_download_test.go
@@ -412,9 +412,8 @@ func TestHandleGitSourcesConnectGitAtURL(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleGitSourcesConnect(w, req)
 
-	// Valid URL format — will pass validation, then try to connect (may fail or succeed)
-	if w.Code == http.StatusBadRequest {
-		t.Error("git@ URLs should be accepted")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for git@ URL, got %d", w.Code)
 	}
 }
 

--- a/v2/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/v2/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -681,15 +681,13 @@ func TestHandleGovernorReposStripOrgPrefix(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
 	}
-	// Verify org prefix was not silently stripped
+	// Verify a matching org prefix is normalized to the bare repo.
 	repos := srv.deps.Config.Project.Repos
-	for _, r := range repos {
-		if strings.HasPrefix(r, "testorg/") {
-			t.Errorf("org prefix should be stripped: %q", r)
-		}
+	if len(repos) != 2 || repos[0] != "my-repo" || repos[1] != "other-repo" {
+		t.Errorf("repos = %v, want stripped my-repo and other-repo", repos)
 	}
 }
 

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -33,3 +33,120 @@ func TestOwnerOnlyAgentControlsRejectNonOwners(t *testing.T) {
 		})
 	}
 }
+
+func TestOwnerOnlyMutationsRejectSharedTokenWithoutRole(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"pause", "/api/pause/scanner"},
+		{"resume", "/api/resume/scanner"},
+		{"breaker engage", "/api/breaker/engage"},
+		{"breaker release", "/api/breaker/release"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newFullServer(t)
+			s.authToken = "shared-secret-token"
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+s.authToken)
+			w := httptest.NewRecorder()
+
+			s.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("shared-token request without server role status = %d, want 403", w.Code)
+			}
+		})
+	}
+}
+
+func TestOwnerOnlyMutationsRejectSpoofedOwnerRoleWithSharedToken(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	req.Header.Set("X-Hive-User", "attacker")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("spoofed owner role with shared token status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsRejectInternalSharedTokenWithoutVerifiedRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("internal shared token without verified role status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsAllowOwnerSessionWithInternalAuth(t *testing.T) {
+	s := newDirectRouteServer(t, "owneruser")
+	sid := s.createUserSession("owneruser", "owner")
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner session with internal auth status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestOwnerOnlyMutationsAllowVerifiedHubOwnerRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-User", "owner")
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, s.authToken)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("verified hub owner role status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestOwnerOnlyMutationsRejectProoflessHubOwnerRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-User", "owner")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("proofless hub owner role status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsPreserveOpenSpokeOwnerBehavior(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = ""
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("open spoke owner behavior status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -133,8 +133,8 @@ func TestOwnerOnlyMutationsRejectProoflessHubOwnerRole(t *testing.T) {
 
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("proofless hub owner role status = %d, want 403", w.Code)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("proofless hub owner role status = %d, want 401", w.Code)
 	}
 }
 

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -78,6 +78,23 @@ func TestOwnerOnlyMutationsRejectSpoofedOwnerRoleWithSharedToken(t *testing.T) {
 	}
 }
 
+func TestOwnerOnlyMutationsRejectSpoofedOwnerVerificationMarker(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	req.Header.Set("X-Hive-User", "attacker")
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("spoofed owner verification marker with shared token status = %d, want 403", w.Code)
+	}
+}
+
 func TestOwnerOnlyMutationsRejectInternalSharedTokenWithoutVerifiedRole(t *testing.T) {
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"

--- a/v2/pkg/dashboard/definition_source_test.go
+++ b/v2/pkg/dashboard/definition_source_test.go
@@ -4,10 +4,35 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func routeImportFetchesToServer(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+	target, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	previous := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rewritten := req.Clone(req.Context())
+		rewritten.URL.Scheme = target.Scheme
+		rewritten.URL.Host = target.Host
+		rewritten.Host = req.URL.Host
+		return previous.RoundTrip(rewritten)
+	})
+	t.Cleanup(func() { http.DefaultTransport = previous })
+}
 
 // enableDefinitionAllowlist puts a slug on the seed-only GitHub allowlist so the
 // keep-linked / prompt-source paths are permitted for it in tests.
@@ -61,6 +86,110 @@ func TestDefinitionSourceFromURL(t *testing.T) {
 	}
 }
 
+func TestAgentImportURLPolicy(t *testing.T) {
+	defSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			name = "imported-url-policy-agent"
+		}
+		fmt.Fprintf(w, "apiVersion: hive.kubestellar.io/v1\nkind: %s\nmetadata:\n  name: %s\nspec:\n  backend: claude\n", exportKind, name)
+	}))
+	defer defSrv.Close()
+	routeImportFetchesToServer(t, defSrv)
+
+	cases := []struct {
+		name          string
+		importURL     string
+		keepLinked    bool
+		wantStatus    int
+		wantErr       string
+		wantLinked    bool
+		wantAgentName string
+	}{
+		{
+			name:       "gist keep-linked rejected clearly",
+			importURL:  "https://gist.github.com/someone/abcdef/raw/agent.yaml?name=gist-linked",
+			keepLinked: true,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "keep linked imports do not support gist URLs",
+		},
+		{
+			name:          "gist one-shot accepted",
+			importURL:     "https://gist.github.com/someone/abcdef/raw/agent.yaml?name=gist-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "gist-one-shot",
+		},
+		{
+			name:          "github blob one-shot accepted",
+			importURL:     "https://github.com/kubestellar/hive/blob/main/agents/blob-plain.yaml?name=blob-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "blob-one-shot",
+		},
+		{
+			name:          "github blob keep-linked accepted",
+			importURL:     "https://github.com/kubestellar/hive/blob/main/agents/blob-linked.yaml?name=blob-linked",
+			keepLinked:    true,
+			wantStatus:    http.StatusOK,
+			wantLinked:    true,
+			wantAgentName: "blob-linked",
+		},
+		{
+			name:          "raw github one-shot accepted",
+			importURL:     "https://raw.githubusercontent.com/kubestellar/hive/main/agents/raw-plain.yaml?name=raw-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "raw-one-shot",
+		},
+		{
+			name:          "raw github keep-linked accepted",
+			importURL:     "https://raw.githubusercontent.com/kubestellar/hive/main/agents/raw-linked.yaml?name=raw-linked",
+			keepLinked:    true,
+			wantStatus:    http.StatusOK,
+			wantLinked:    true,
+			wantAgentName: "raw-linked",
+		},
+		{
+			name:       "disallowed host rejected",
+			importURL:  "https://example.com/kubestellar/hive/blob/main/agent.yaml?name=bad-host",
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "example.com",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, deps := apiServer(t)
+			deps.Config.Data.AgentsDir = t.TempDir()
+			enableDefinitionAllowlist(deps, "kubestellar/hive")
+
+			rec := doPost(s, "/api/agents/import", map[string]interface{}{
+				"source":     "url",
+				"url":        tc.importURL,
+				"keepLinked": tc.keepLinked,
+			})
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+			if tc.wantErr != "" {
+				if !strings.Contains(rec.Body.String(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %s", tc.wantErr, rec.Body.String())
+				}
+				return
+			}
+
+			agent, ok := deps.Config.Agents[tc.wantAgentName]
+			if !ok {
+				t.Fatalf("expected imported agent %q", tc.wantAgentName)
+			}
+			if tc.wantLinked && agent.DefinitionSource == nil {
+				t.Fatal("expected keep-linked import to set definition_source")
+			}
+			if !tc.wantLinked && agent.DefinitionSource != nil {
+				t.Fatalf("expected one-shot import to leave definition_source unset, got %+v", agent.DefinitionSource)
+			}
+		})
+	}
+}
+
 // TestImport_UncheckedStaysPlain: a normal import (no keepLinked) produces a
 // baked agent with NO definition_source link.
 func TestImport_UncheckedStaysPlain(t *testing.T) {
@@ -79,10 +208,11 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/kubestellar/hive/blob/main/plain.yaml",
+		"url":        "https://github.com/kubestellar/hive/blob/main/plain.yaml",
 		"keepLinked": false,
 	})
 	if rec.Code != http.StatusOK {
@@ -115,13 +245,14 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	// The blob path makes the parsed slug "kubestellar/hive"; allowlist it.
 	enableDefinitionAllowlist(deps, "kubestellar/hive")
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/kubestellar/hive/blob/main/agents/linked.yaml",
+		"url":        "https://github.com/kubestellar/hive/blob/main/agents/linked.yaml",
 		"keepLinked": true,
 	})
 	if rec.Code != http.StatusOK {
@@ -161,10 +292,11 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/attacker/evil/blob/main/agent.yaml",
+		"url":        "https://github.com/attacker/evil/blob/main/agent.yaml",
 		"keepLinked": true,
 	})
 	if rec.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/definition_source_test.go
+++ b/v2/pkg/dashboard/definition_source_test.go
@@ -190,6 +190,36 @@ func TestAgentImportURLPolicy(t *testing.T) {
 	}
 }
 
+func TestAgentImportRejectsRedirectToPrivateHost(t *testing.T) {
+	defSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest/meta-data" {
+			fmt.Fprintf(w, "apiVersion: hive.kubestellar.io/v1\nkind: %s\nmetadata:\n  name: redirected-private-agent\nspec:\n  backend: claude\n", exportKind)
+			return
+		}
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data", http.StatusFound)
+	}))
+	defer defSrv.Close()
+	routeImportFetchesToServer(t, defSrv)
+
+	s, deps := apiServer(t)
+	deps.Config.Data.AgentsDir = t.TempDir()
+	enableDefinitionAllowlist(deps, "kubestellar/hive")
+
+	rec := doPost(s, "/api/agents/import", map[string]interface{}{
+		"source": "url",
+		"url":    "https://raw.githubusercontent.com/kubestellar/hive/main/agents/redirect.yaml",
+	})
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected redirect to private host to fail with 502, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "redirect to private/internal host blocked") {
+		t.Fatalf("expected private redirect error, got %s", rec.Body.String())
+	}
+	if _, ok := deps.Config.Agents["redirected-private-agent"]; ok {
+		t.Fatal("redirected private response must not be imported")
+	}
+}
+
 // TestImport_UncheckedStaysPlain: a normal import (no keepLinked) produces a
 // baked agent with NO definition_source link.
 func TestImport_UncheckedStaysPlain(t *testing.T) {

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -93,6 +93,7 @@ const (
 // accepted and treated as custom (the endpoint is what actually routes).
 var validGatewayKinds = map[string]bool{
 	config.GatewayKindOpenRouter: true,
+	config.GatewayKindGroq:       true,
 	config.GatewayKindLiteLLM:    true,
 	config.GatewayKindVLLM:       true,
 	config.GatewayKindLLMD:       true,

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -211,6 +211,10 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if isPrivateURL(r.Context(), endpoint) {
+		jsonError(w, "gateway endpoint must not point to private/internal addresses", http.StatusBadRequest)
+		return
+	}
 
 	// Guardrail: an env-var NAME field must never hold a key VALUE (which would
 	// bake the key into hive.yaml and resolve empty at runtime — the LiteLLM leak).
@@ -403,6 +407,10 @@ func (s *Server) handleGovernorGatewaysDiscover(w http.ResponseWriter, r *http.R
 	}
 	if err := validateGatewayEndpoint(endpoint); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if isPrivateURL(r.Context(), endpoint) {
+		jsonError(w, "gateway endpoint must not point to private/internal addresses", http.StatusBadRequest)
 		return
 	}
 	key := strings.TrimSpace(body.APIKey)

--- a/v2/pkg/dashboard/gateways_coverage_test.go
+++ b/v2/pkg/dashboard/gateways_coverage_test.go
@@ -24,6 +24,7 @@ func TestCovD_GatewaysList(t *testing.T) {
 // endpoint, bad endpoint, invalid kind, api_key_env-looks-like-key guardrail).
 func TestCovD_GatewaysUpsert(t *testing.T) {
 	s, _ := apiServer(t)
+	allowPrivateURLHostsForTest(t, "public.example", "openrouter.ai", "x")
 
 	// Point the secret store at a temp dir so a submitted key VALUE can be
 	// stored without touching the real PVC path.
@@ -35,7 +36,7 @@ func TestCovD_GatewaysUpsert(t *testing.T) {
 	rec := doPut(s, "/api/config/governor/gateways", map[string]interface{}{
 		"name":     "mygw",
 		"kind":     "custom",
-		"endpoint": "http://127.0.0.1:1/v1",
+		"endpoint": "https://public.example/v1",
 		"api_key":  "sk-test-value",
 	})
 	if rec.Code != http.StatusOK {
@@ -135,6 +136,7 @@ func TestCovD_GatewaysDelete(t *testing.T) {
 // endpoint, and a probe against an unreachable endpoint (error path).
 func TestCovD_GatewaysDiscover(t *testing.T) {
 	s, _ := apiServer(t)
+	allowPrivateURLHostsForTest(t, "public.example")
 
 	rec := doPostRawCovD(s, "/api/config/governor/gateways/discover", "{bad")
 	if rec.Code != http.StatusBadRequest {
@@ -150,7 +152,7 @@ func TestCovD_GatewaysDiscover(t *testing.T) {
 	}
 	// Reachability probe against an unroutable endpoint → {ok:false,error}.
 	rec = doPost(s, "/api/config/governor/gateways/discover", map[string]interface{}{
-		"name": "x", "endpoint": "http://127.0.0.1:1/v1",
+		"name": "x", "endpoint": "https://public.example/v1",
 	})
 	if rec.Code != http.StatusOK {
 		t.Errorf("discover probe = %d, want 200: %s", rec.Code, rec.Body.String())

--- a/v2/pkg/dashboard/gateways_test.go
+++ b/v2/pkg/dashboard/gateways_test.go
@@ -205,3 +205,15 @@ func TestGatewaysUpsert_PreservesKeyOnEdit(t *testing.T) {
 		t.Errorf("default_model not updated: %q", gw.DefaultModel)
 	}
 }
+
+// TestGroqIsValidGatewayKind guards the Groq gateway support (#3304): Groq is an
+// OpenAI-compatible endpoint, so it only needs to be an accepted kind with its
+// preset base URL — no special token minting like watsonx.
+func TestGroqIsValidGatewayKind(t *testing.T) {
+	if !validGatewayKinds[config.GatewayKindGroq] {
+		t.Fatal("groq must be an accepted gateway kind so the Governor → Gateways form can save it")
+	}
+	if config.GatewayKindGroq != "groq" {
+		t.Fatalf("GatewayKindGroq = %q, want \"groq\"", config.GatewayKindGroq)
+	}
+}

--- a/v2/pkg/dashboard/gateways_test.go
+++ b/v2/pkg/dashboard/gateways_test.go
@@ -110,6 +110,31 @@ func TestGatewaysUpsert_RejectsInvalidEndpoint(t *testing.T) {
 	}
 }
 
+func TestGatewaysUpsert_RejectsPrivateEndpoint(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"name":"bad","kind":"custom","endpoint":"https://169.254.169.254/v1"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysUpsert(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+	if len(srv.deps.Config.Governor.Gateways) != 0 {
+		t.Errorf("config mutated on private endpoint")
+	}
+}
+
+func TestGatewaysDiscover_RejectsPrivateEndpoint(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"name":"bad","kind":"custom","endpoint":"https://[::1]/v1"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/gateways/discover", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysDiscover(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
+	}
+}
+
 // TestGatewaysDelete_InUseConflict verifies deleting a gateway an agent
 // references returns 409 and lists the agent.
 func TestGatewaysDelete_InUseConflict(t *testing.T) {

--- a/v2/pkg/dashboard/litellm_probe_test.go
+++ b/v2/pkg/dashboard/litellm_probe_test.go
@@ -70,6 +70,24 @@ func TestProbeLiteLLMModels_LenientShape(t *testing.T) {
 	}
 }
 
+func TestProbeLiteLLMModelsRejectsRedirectToPrivateHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest/meta-data/v1/models" {
+			fmt.Fprint(w, `{"data":[{"id":"stolen-token-sink"}]}`)
+			return
+		}
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/v1/models", http.StatusFound)
+	}))
+	defer srv.Close()
+	routeImportFetchesToServer(t, srv)
+
+	if _, err := probeLiteLLMModels("https://gateway.example.invalid", "sk-livekeyvalue"); err == nil {
+		t.Fatal("expected redirect to private host to be blocked")
+	} else if !strings.Contains(err.Error(), "redirect to private/internal host blocked") {
+		t.Fatalf("expected private redirect error, got %v", err)
+	}
+}
+
 // parseModelsResponse is the shared source of truth; verify it returns
 // provider-prefixed ids verbatim and skips id-less entries.
 func TestParseModelsResponse_VerbatimIDs(t *testing.T) {

--- a/v2/pkg/dashboard/private_url_test.go
+++ b/v2/pkg/dashboard/private_url_test.go
@@ -1,0 +1,22 @@
+package dashboard
+
+import (
+	"context"
+	"testing"
+)
+
+func allowPrivateURLHostsForTest(t *testing.T, hosts ...string) {
+	t.Helper()
+	allowed := make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		allowed[host] = struct{}{}
+	}
+	origResolver := privateURLResolver
+	privateURLResolver = func(_ context.Context, host string) ([]string, error) {
+		if _, ok := allowed[host]; !ok {
+			t.Fatalf("resolved unexpected host %q", host)
+		}
+		return []string{"93.184.216.34"}, nil
+	}
+	t.Cleanup(func() { privateURLResolver = origResolver })
+}

--- a/v2/pkg/dashboard/repo_add_form_test.go
+++ b/v2/pkg/dashboard/repo_add_form_test.go
@@ -28,7 +28,7 @@ func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 for a cross-forge repo", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "expected repo name only so the target resolves to org/repo") {
+	if !strings.Contains(w.Body.String(), "expected repo name only") {
 		t.Errorf("expected canonical-shape message, got: %s", w.Body.String())
 	}
 	// The hive's forge must be left untouched.

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -43,13 +43,13 @@ const proxyAuthHeader = "X-Hive-Proxy-Auth"
 // when the owner role came from a trusted source, not an inbound client header.
 const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
 
-// proxyProofRequired controls F2 enforcement strictness. Default false =
-// fail-open rollout: a request with no proof header is still trusted on its
-// identity headers (so hosted hives aren't locked out while the hub half rolls
-// out fleet-wide). Set HIVE_PROXY_PROOF_REQUIRED=true (once every hub is
-// confirmed injecting the header) to fail closed: a missing/incorrect proof
-// header is rejected. A WRONG proof header is ALWAYS rejected regardless.
-var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") == "true"
+// proxyProofRequired controls F2 enforcement strictness. Default true =
+// fail-closed: a request with no X-Hive-Proxy-Auth proof header (or a wrong
+// one) is rejected even if it carries X-Hive-User/X-Hive-Role identity
+// headers. Set HIVE_PROXY_PROOF_REQUIRED=false only during a temporary
+// rollout window where some hub replicas may not yet inject the proof header.
+// A WRONG proof header is ALWAYS rejected regardless of this setting.
+var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") != "false"
 
 type Server struct {
 	port       int

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -46,10 +45,8 @@ const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
 // proxyProofRequired controls F2 enforcement strictness. Default true =
 // fail-closed: a request with no X-Hive-Proxy-Auth proof header (or a wrong
 // one) is rejected even if it carries X-Hive-User/X-Hive-Role identity
-// headers. Set HIVE_PROXY_PROOF_REQUIRED=false only during a temporary
-// rollout window where some hub replicas may not yet inject the proof header.
 // A WRONG proof header is ALWAYS rejected regardless of this setting.
-var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") != "false"
+var proxyProofRequired = true
 
 type Server struct {
 	port       int
@@ -827,12 +824,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// only the trusted proxy can produce. Require it as PROOF the request
 		// transited the hub.
 		//
-		// ROLLOUT SAFETY — fail open until the hub half is everywhere: if the hub
-		// has NOT sent X-Hive-Proxy-Auth (older hub image mid-rollout), fall back
-		// to the pre-F2 behavior (trust the identity headers) so no hosted hive is
-		// locked out. Once the hub half is confirmed deployed fleet-wide, a
-		// follow-up flips proxyProofRequired to make a missing/incorrect proof
-		// header fail closed.
+		// Missing or incorrect proof fails closed. Older hub images that do not
+		// inject X-Hive-Proxy-Auth must be upgraded before their identity headers
+		// are accepted.
+		proxyProofRejectReason := ""
 		if !trusted && !directRouteAuthz &&
 			inboundUser != "" && inboundRole != "" {
 			proof := r.Header.Get(proxyAuthHeader)
@@ -853,6 +848,11 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			default:
 				// Proof header present but WRONG, or strict mode with no proof:
 				// this did not come through the trusted hub proxy — reject.
+				if proof == "" {
+					proxyProofRejectReason = "missing proxy proof header"
+				} else {
+					proxyProofRejectReason = "invalid proxy proof header"
+				}
 			}
 			if trusted {
 				r.Header.Set("X-Hive-User", inboundUser)
@@ -896,6 +896,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		if !trusted {
 			if strings.HasPrefix(r.URL.Path, "/api/") {
 				w.Header().Set("Content-Type", "application/json")
+				if proxyProofRejectReason != "" {
+					http.Error(w, fmt.Sprintf(`{"error":%q}`, proxyProofRejectReason), http.StatusUnauthorized)
+					return
+				}
 				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 			} else {
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -39,6 +39,10 @@ const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
 // network. See authenticate() (F2). Must match the hub's constant.
 const proxyAuthHeader = "X-Hive-Proxy-Auth"
 
+// ownerRoleVerifiedHeader is a server-only request marker set by authenticate
+// when the owner role came from a trusted source, not an inbound client header.
+const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
+
 // proxyProofRequired controls F2 enforcement strictness. Default false =
 // fail-open rollout: a request with no proof header is still trusted on its
 // identity headers (so hosted hives aren't locked out while the hub half rolls
@@ -770,19 +774,28 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+			} else if r.Header.Get("X-Hive-Role") == "" {
+				r.Header.Set("X-Hive-Role", config.RoleOwner)
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
+			} else if r.Header.Get("X-Hive-Role") == config.RoleOwner {
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
 			}
 			next.ServeHTTP(w, r)
 			return
 		}
+		inboundUser := r.Header.Get("X-Hive-User")
+		inboundRole := r.Header.Get("X-Hive-Role")
 
-		// On a direct-route spoke (per-hive allowlist present) we MUST NOT trust
-		// client-supplied X-Hive-User/X-Hive-Role: there is no hub nginx in
-		// front to strip forged identity headers. Strip them here so identity
-		// can only come from a server-side session we minted.
-		if directRouteAuthz {
-			r.Header.Del("X-Hive-User")
-			r.Header.Del("X-Hive-Role")
-		}
+		// Treat identity headers as an internal request attribute. Preserve the
+		// inbound values only in the hub-proxy branch below, after that path has
+		// been authenticated as trusted; all other auth paths must set any role
+		// explicitly so clients cannot spoof owner access with X-Hive-Role.
+		r.Header.Del("X-Hive-User")
+		r.Header.Del("X-Hive-Role")
+		r.Header.Del(ownerRoleVerifiedHeader)
 
 		// Internal automation authenticates with the shared token via the
 		// X-Hive-Internal header; this is a trusted server-to-server path
@@ -791,7 +804,17 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// is TRUE, so without this an absent/empty header would authenticate on
 		// a direct-route spoke that has no token. The shared-token paths are only
 		// valid when a real token is configured.
-		trusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
+		internalTrusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
+		trusted := internalTrusted
+		if internalTrusted {
+			if sess := s.sessionFromRequest(r); sess != nil {
+				r.Header.Set("X-Hive-User", sess.Username)
+				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+			}
+		}
 
 		// Hub-proxied path: nginx injects the identity headers from the hub's
 		// per-user/per-hive auth-check. Only trust them when this spoke is NOT a
@@ -811,19 +834,29 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// follow-up flips proxyProofRequired to make a missing/incorrect proof
 		// header fail closed.
 		if !trusted && !directRouteAuthz &&
-			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
+			inboundUser != "" && inboundRole != "" {
 			proof := r.Header.Get(proxyAuthHeader)
 			switch {
 			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
 				// Proof present and valid — definitely came through the hub.
 				trusted = true
+				if inboundRole == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
 			case proof == "" && !proxyProofRequired:
 				// No proof header yet (hub not upgraded) and we're not enforcing
 				// strictly — trust the identity headers as before (rollout window).
+				// Do not mark owner as verified in this legacy path: missing proof
+				// keeps reads/general writes compatible but owner-only mutations
+				// must fail closed.
 				trusted = true
 			default:
 				// Proof header present but WRONG, or strict mode with no proof:
 				// this did not come through the trusted hub proxy — reject.
+			}
+			if trusted {
+				r.Header.Set("X-Hive-User", inboundUser)
+				r.Header.Set("X-Hive-Role", inboundRole)
 			}
 		}
 
@@ -835,6 +868,9 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
 				trusted = true
 			}
 		}

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -190,6 +190,7 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/config", nil)
 	req.Header.Set("X-Hive-User", "clubanderson")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, s.authToken)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -202,8 +203,7 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 
 // TestMiddleware_F2ProxyProof covers the F2 proof-of-proxy header enforcement on
 // a hub-proxied spoke: a valid proof is trusted; a WRONG proof is always
-// rejected; a MISSING proof is trusted only in the fail-open rollout default and
-// rejected once strict enforcement is enabled.
+// rejected; a MISSING proof is rejected in the default fail-closed mode.
 func TestMiddleware_F2ProxyProof(t *testing.T) {
 	newReq := func(proof string) *http.Request {
 		r := httptest.NewRequest("GET", "/api/config", nil)
@@ -239,12 +239,31 @@ func TestMiddleware_F2ProxyProof(t *testing.T) {
 	if c := run(t, true, "wrong-token"); c == http.StatusOK {
 		t.Error("wrong proof must be rejected in strict mode")
 	}
-	// Missing proof: trusted in fail-open (rollout), rejected in strict.
+	// Missing proof: trusted only when a test explicitly simulates the legacy
+	// rollout mode, rejected in the default strict mode.
 	if c := run(t, false, ""); c != http.StatusOK {
 		t.Errorf("missing proof (fail-open) = %d, want 200 (rollout safety)", c)
 	}
 	if c := run(t, true, ""); c == http.StatusOK {
 		t.Error("missing proof must be rejected in strict mode")
+	}
+}
+
+func TestMiddleware_F2ProxyProofDefaultRejectsMissingProof(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("X-Hive-User", "clubanderson")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing proof with default enforcement = %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "missing proxy proof header") {
+		t.Fatalf("missing proof error = %q, want clear proxy proof error", w.Body.String())
 	}
 }
 

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -182,7 +182,8 @@ func TestHandleRoleIgnoresLeakedHubCookie(t *testing.T) {
 }
 
 func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
-	// Empty allowlist = hub-proxied hive; nginx-injected headers must still work.
+	// Empty allowlist = hub-proxied hive; nginx-injected headers plus the
+	// proof-of-proxy header must still work.
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"
 	old := proxyProofRequired

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -185,6 +185,9 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	// Empty allowlist = hub-proxied hive; nginx-injected headers must still work.
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"
+	old := proxyProofRequired
+	proxyProofRequired = false
+	t.Cleanup(func() { proxyProofRequired = old })
 	var sawUser string
 	handler := s.authenticate(recordingHandler(&sawUser, nil))
 	req := httptest.NewRequest("GET", "/api/config", nil)

--- a/v2/pkg/dashboard/ssrf_guard.go
+++ b/v2/pkg/dashboard/ssrf_guard.go
@@ -1,0 +1,31 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const ssrfMaxRedirects = 3
+
+// noRedirectToPrivate returns an http.Client CheckRedirect function that
+// rejects any redirect whose target resolves to a private/internal host.
+// It also limits the redirect chain depth to ssrfMaxRedirects. Use this
+// wherever the hive fetches a URL supplied (directly or indirectly) by a
+// user, to prevent SSRF via open-redirect chains:
+//
+//	client := &http.Client{
+//	    Timeout:       30 * time.Second,
+//	    CheckRedirect: noRedirectToPrivate,
+//	}
+func noRedirectToPrivate(req *http.Request, via []*http.Request) error {
+	if len(via) >= ssrfMaxRedirects {
+		return fmt.Errorf("stopped after %d redirects", ssrfMaxRedirects)
+	}
+	// Re-run the private-host check on every redirect target so a public
+	// URL that returns 302 → internal address cannot bypass the preflight.
+	if isPrivateURL(context.Background(), req.URL.String()) {
+		return fmt.Errorf("redirect to private/internal host blocked: %s", req.URL.Host)
+	}
+	return nil
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14403,7 +14403,7 @@ function burnAreaChart() {
           '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button onclick="previewImportFromURL()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg);white-space:nowrap">Preview</button></div>' +
           '<label style="display:flex;align-items:center;gap:8px;margin-top:8px;font-size:0.78rem;cursor:pointer;font-weight:400">' +
             '<input type="checkbox" id="import-keep-linked" style="width:auto;margin:0">' +
-            '<span>Keep linked to repo (live) <span style="color:var(--muted)">— re-fetch this definition on reload so repo edits propagate. Only its presentation/behavior fields are re-applied; security and privilege fields are never changed. The repo must be on the operator\'s allowlist. (URL import only.)</span></span>' +
+            '<span>Keep linked to repo (live) <span style="color:var(--muted)">— re-fetch this definition on reload so repo edits propagate. Keep-linked URL imports support GitHub blob URLs and raw.githubusercontent.com file URLs only; gist URLs are one-shot imports, so uncheck this box for gists. Only presentation/behavior fields are re-applied; security and privilege fields are never changed. The repo must be on the operator\'s allowlist. (URL import only.)</span></span>' +
           '</label>' +
         '</div>' +
         '<div class="config-field" style="margin-bottom:12px">' +

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14994,6 +14994,7 @@ function burnAreaChart() {
     // fills it (self-hosted / custom). OpenRouter has a well-known base URL.
     const GATEWAY_PRESETS = [
       { kind: 'openrouter', label: 'OpenRouter', endpoint: 'https://openrouter.ai/api/v1' },
+      { kind: 'groq',       label: 'Groq',       endpoint: 'https://api.groq.com/openai/v1' },
       { kind: 'litellm',    label: 'LiteLLM',    endpoint: '' },
       { kind: 'vllm',       label: 'vLLM',       endpoint: '' },
       { kind: 'llm-d',      label: 'llm-d',      endpoint: '' },

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -370,6 +370,7 @@
       .oc-topbar-ts { white-space: nowrap; }
     }
     @media (min-width: 769px) and (max-width: 900px) {
+      body { padding-top: 112px; }
       .oc-topbar-ts, #oc-git-version { display: none; }
       #oc-hive-id { max-width: 8rem; }
     }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -16235,6 +16235,13 @@ function burnAreaChart() {
     function renderAgentGeneral(g) {
       const agentName = _configState.agent || '';
       const isCreate = _configState.isCreate === true;
+      // Model options must come from live discovery for THIS agent's backend, not
+      // the frozen KNOWN_MODELS placeholder (#3319). Resolve the agent's actual
+      // backend from the live agent list; fall back to its pinned backend or an
+      // empty backend (modelsForBackend then yields the safe default list).
+      const _liveAgent = (window._lastAgents || []).find(a => a.name === agentName);
+      const _agentBackend = (_liveAgent && _liveAgent.cli) || g.cliPinValue || '';
+      const _modelOpts = modelsForBackend(_agentBackend) || [];
       let html = '';
       if (isCreate) {
         html += `<div class="config-field">
@@ -16365,7 +16372,8 @@ function burnAreaChart() {
           <label>Model <span class="config-info">i<span class="config-tooltip">Override the LLM model for this agent. Select "(from launch command)" to let the CLI choose its default. The governor may downgrade models automatically when budget is tight, unless Model Lock is enabled in Governor Health settings.</span></span></label>
           <select id="cfg-model" onchange="markDirty('general','model',this.value)">
             <option value="">(from launch command)</option>
-            ${KNOWN_MODELS.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
+            ${_modelOpts.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
+            ${(g.model && !_modelOpts.some(m => _modelsEqual(g.model, m.value))) ? `<option value="${esc(g.model)}" selected>${esc(g.model)} (current)</option>` : ''}
           </select>
         </div>
         <div class="config-field">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -92,7 +92,7 @@
     .header-spacer { flex: 1; }
     /* .widget-dl / .layout-toggle — ghost buttons (system recipe at end of
        the style block); only placement-specific properties live here. */
-    .widget-dl { display: inline-block; text-decoration: none; margin-left: auto; margin-right: auto; }
+    .widget-dl { display: inline-flex; align-items: center; text-decoration: none; margin-left: auto; margin-right: auto; white-space: nowrap; }
     .layout-toggle { margin-left: 12px; margin-right: 8px; }
     /* Icon-only theme toggle: square-ish, centered glyph, larger for tap target. */
     .layout-toggle { min-width: 34px; padding-left: 8px; padding-right: 8px; font-size: 1rem; line-height: 1; text-align: center; }
@@ -277,14 +277,15 @@
        positioning kept (functionally sticky: content scrolls under it)
        because the sidebar offset layout depends on it. */
     .oc-topbar {
-      position: fixed; top: 0; left: var(--sidebar-w); right: 0; height: 48px;
+      position: fixed; top: 0; left: var(--sidebar-w); right: 0; min-height: 48px;
       background: color-mix(in srgb, var(--bg) 85%, transparent);
       -webkit-backdrop-filter: blur(18px); backdrop-filter: blur(18px);
       border-bottom: 1px solid var(--line);
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
     }
-    .oc-topbar-left { font-size: 0.85rem; color: var(--muted); display: flex; align-items: center; gap: 4px; min-width: 0; }
+    .oc-topbar-left { font-size: 0.85rem; color: var(--muted); display: flex; align-items: center; gap: 4px; min-width: 0; flex: 1 1 auto; overflow: hidden; }
+    #oc-project-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     /* Drawer toggle. Hidden on desktop; the ≤768px block flips it to
        inline-flex. Lives in .oc-topbar-left because that is the shortest
        topbar group — putting it in center/right would risk wrapping the
@@ -311,10 +312,15 @@
     .dashboard-custom-style-note { display: inline-flex; align-items: center; gap: 6px; max-width: 240px; padding: 3px 8px; border: 1px solid rgba(128,191,255,0.35); border-radius: 999px; background: rgba(128,191,255,0.10); color: var(--text); font-size: 0.68rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .dashboard-custom-style-note.warn { border-color: rgba(210,153,34,0.45); background: rgba(210,153,34,0.12); }
     .dashboard-custom-style-note button { border: 0; background: transparent; color: inherit; cursor: pointer; font-size: 0.75rem; line-height: 1; padding: 0; }
-    .oc-topbar-right { display: flex; align-items: center; gap: 14px; min-width: 0; }
+    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 1 auto; flex-wrap: nowrap; }
     .oc-health-badge { --pill-c: var(--green); font-weight: 600; } /* pill recipe at end of style block */
-    .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); }
+    #oc-hive-id {
+      flex: 0 1 auto; min-width: 0; max-width: clamp(9rem, 18vw, 22rem);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); white-space: nowrap; }
     .oc-topbar .git-version { color: var(--muted); }
+    .oc-health-badge, #welcome-topbar-btn, #oc-gh-avatar-wrap { flex: 0 0 auto; }
 
     /* Fleet breaker — circular play/pause control + status pill in the topbar.
        Mirrors the Ready-work queue's #queue-suspend-btn / .pill pattern from the

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -312,10 +312,10 @@
     .dashboard-custom-style-note { display: inline-flex; align-items: center; gap: 6px; max-width: 240px; padding: 3px 8px; border: 1px solid rgba(128,191,255,0.35); border-radius: 999px; background: rgba(128,191,255,0.10); color: var(--text); font-size: 0.68rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .dashboard-custom-style-note.warn { border-color: rgba(210,153,34,0.45); background: rgba(210,153,34,0.12); }
     .dashboard-custom-style-note button { border: 0; background: transparent; color: inherit; cursor: pointer; font-size: 0.75rem; line-height: 1; padding: 0; }
-    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 1 auto; flex-wrap: nowrap; }
+    .oc-topbar-right { display: flex; align-items: center; justify-content: flex-end; gap: 14px; min-width: 0; flex: 0 0 auto; flex-wrap: nowrap; }
     .oc-health-badge { --pill-c: var(--green); font-weight: 600; } /* pill recipe at end of style block */
     #oc-hive-id {
-      flex: 0 1 auto; min-width: 0; max-width: clamp(9rem, 18vw, 22rem);
+      flex: 0 1 auto; min-width: 0; max-width: 22rem;
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
     .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); white-space: nowrap; }
@@ -347,7 +347,7 @@
     #fleet-breaker-pill.pill-passed { background: rgba(63,185,80,.12); color: #3fb950; border-color: rgba(63,185,80,.3); }
     #fleet-breaker-pill.pill-blocked { background: rgba(248,81,73,.12); color: #f85149; border-color: rgba(248,81,73,.3); }
 
-    @media (max-width: 1200px) {
+    @media (max-width: 1280px) {
       body { padding-top: 88px; }
       .oc-topbar {
         flex-wrap: wrap; height: auto; min-height: 48px;
@@ -364,7 +364,7 @@
       }
       .oc-topbar-right .widget-dl { margin-left: 0; margin-right: 0; }
       #oc-hive-id {
-        flex: 0 1 auto; min-width: 0; max-width: clamp(9rem, 32vw, 16rem);
+        flex: 0 1 auto; min-width: 0; max-width: 22rem;
         white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       }
       .oc-topbar-ts { white-space: nowrap; }

--- a/v2/pkg/dashboard/watsonx_gateway_test.go
+++ b/v2/pkg/dashboard/watsonx_gateway_test.go
@@ -55,6 +55,7 @@ func TestWatsonxUpsert_RejectsMissingKey(t *testing.T) {
 // stored as a file ref (never inlined) and project_id/region persist inline.
 func TestWatsonxUpsert_StoresGateway(t *testing.T) {
 	srv := newFullServer(t)
+	allowPrivateURLHostsForTest(t, "public.example")
 	dir := t.TempDir()
 	orig := gatewaySecretsDir
 	gatewaySecretsDir = dir
@@ -76,7 +77,7 @@ func TestWatsonxUpsert_StoresGateway(t *testing.T) {
 	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
 
 	const secret = "ibm-cloud-key-super-secret-1234567890"
-	body := `{"name":"watsonx","kind":"watsonx","endpoint":"` + fake.URL + `/ml/gateway","project_id":"proj-42","region":"us-south","api_key":"` + secret + `","default_model":"ibm/granite-4-h-small"}`
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"https://public.example/ml/gateway","project_id":"proj-42","region":"us-south","api_key":"` + secret + `","default_model":"ibm/granite-4-h-small"}`
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -208,6 +209,7 @@ func TestWatsonxEndpointForRegion(t *testing.T) {
 // project + key.
 func TestWatsonxUpsert_DerivesEndpointFromRegion(t *testing.T) {
 	srv := newFullServer(t)
+	allowPrivateURLHostsForTest(t, "eu-de.ml.cloud.ibm.com")
 	dir := t.TempDir()
 	orig := gatewaySecretsDir
 	gatewaySecretsDir = dir
@@ -247,6 +249,7 @@ func TestWatsonxUpsert_DerivesEndpointFromRegion(t *testing.T) {
 // verdict here.
 func TestWatsonxDiscover_InvalidKeyReturnsNoModels(t *testing.T) {
 	srv := newFullServer(t)
+	allowPrivateURLHostsForTest(t, "public.example")
 	// Minter that always fails the exchange (invalid key).
 	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"errorMessage":"Provided API key could not be found"}`, http.StatusBadRequest)
@@ -256,7 +259,7 @@ func TestWatsonxDiscover_InvalidKeyReturnsNoModels(t *testing.T) {
 	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(fake.URL+"/identity/token", nil)
 	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
 
-	body := `{"name":"watsonx","kind":"watsonx","endpoint":"` + fake.URL + `/ml/gateway","project_id":"p","api_key":"bad-key-1234567890"}`
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"https://public.example/ml/gateway","project_id":"p","api_key":"bad-key-1234567890"}`
 	req := httptest.NewRequest("POST", "/api/config/governor/gateways/discover", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -291,6 +294,7 @@ func TestWatsonxDiscover_InvalidKeyReturnsNoModels(t *testing.T) {
 // dead end — fallback is allowed only behind a validated key.
 func TestWatsonxDiscover_ValidKeyListingFailureFallsBack(t *testing.T) {
 	srv := newFullServer(t)
+	allowPrivateURLHostsForTest(t, "public.example")
 	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/identity/token") {
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "IAM-JWT", "expires_in": 3600})
@@ -303,7 +307,7 @@ func TestWatsonxDiscover_ValidKeyListingFailureFallsBack(t *testing.T) {
 	watsonx.DefaultMinter = watsonx.NewTokenMinterForTest(fake.URL+"/identity/token", nil)
 	t.Cleanup(func() { watsonx.DefaultMinter = origMinter })
 
-	body := `{"name":"watsonx","kind":"watsonx","endpoint":"` + fake.URL + `/ml/gateway","project_id":"p","api_key":"good-key-1234567890"}`
+	body := `{"name":"watsonx","kind":"watsonx","endpoint":"https://public.example/ml/gateway","project_id":"p","api_key":"good-key-1234567890"}`
 	req := httptest.NewRequest("POST", "/api/config/governor/gateways/discover", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/v2/pkg/hub/auth_rollout.go
+++ b/v2/pkg/hub/auth_rollout.go
@@ -1,0 +1,135 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// Rollout readiness telemetry for the N1/N2 compatibility lanes (issue #3234).
+//
+// N1 (per-hive heartbeat bearer) and N2 (Ed25519 session cookie) both shipped
+// as verify-both / mint-new: the hub accepts the new credential OR the legacy
+// one, and issues only the new one. That was required — a flag-day cutover
+// would have 401'd every spoke in the fleet at once, the failure mode #2773
+// documented for the v2-hub/v4-spoke split.
+//
+// But each legacy lane IS the vulnerability it replaced. The fleet-wide
+// heartbeat bearer does not bind identity, so an un-rolled spoke can still
+// claim any hive_id; the symmetric session key that verifies a cookie can also
+// mint one, including an admin cookie. They must be removed.
+//
+// The blocker was observability: "has every spoke re-provisioned?" had no
+// answer short of inspecting each Deployment by hand, so the lanes would have
+// lingered indefinitely — which is how a temporary compatibility path becomes
+// permanent. This records which format each spoke actually presents, so the
+// decision is made on evidence.
+
+// authRolloutEntry is the last-seen credential format for one hive.
+type authRolloutEntry struct {
+	// PerHiveBearer is true when this hive's most recent heartbeat used the
+	// identity-bound bearer (N1) rather than the fleet-wide legacy one.
+	PerHiveBearer bool `json:"per_hive_bearer"`
+	// LastSeen is when that observation was made.
+	LastSeen time.Time `json:"last_seen"`
+}
+
+// noteHeartbeatAuthPath records which bearer format hiveID just authenticated
+// with. Called on every accepted heartbeat; cheap and lock-scoped.
+//
+// Deliberately records the CURRENT observation rather than latching "has ever
+// used per-hive": a spoke can roll back, and a stale true would make the fleet
+// look ready when it is not. Readiness must mean "every hive is per-hive NOW".
+func (s *HubServer) noteHeartbeatAuthPath(hiveID string, perHive bool) {
+	if s == nil || hiveID == "" {
+		return
+	}
+	s.authRolloutMu.Lock()
+	defer s.authRolloutMu.Unlock()
+	if s.authRolloutSeen == nil {
+		s.authRolloutSeen = make(map[string]authRolloutEntry)
+	}
+	s.authRolloutSeen[hiveID] = authRolloutEntry{PerHiveBearer: perHive, LastSeen: time.Now()}
+}
+
+// AuthRolloutStatus summarizes fleet readiness for removing the compat lanes.
+type AuthRolloutStatus struct {
+	// TotalHives is how many distinct hives have been observed heartbeating.
+	TotalHives int `json:"total_hives"`
+	// PerHiveBearer is how many of those last used the N1 identity-bound bearer.
+	PerHiveBearer int `json:"per_hive_bearer"`
+	// LegacyBearer is how many last used the fleet-wide legacy bearer. While
+	// this is non-zero, removing the N1 compat lane WILL 401 those spokes.
+	LegacyBearer int `json:"legacy_bearer"`
+	// LegacyHives names the laggards, so an operator can go re-provision them
+	// rather than guessing which ones are holding up the removal.
+	LegacyHives []string `json:"legacy_hives,omitempty"`
+	// StaleAfter is the cutoff beyond which an observation is ignored: a hive
+	// that has not beaten recently is not evidence of anything.
+	StaleAfter string `json:"stale_after"`
+	// HeartbeatLaneReady is true when every recently-seen hive is on the
+	// per-hive bearer — i.e. the N1 legacy lane can be deleted.
+	//
+	// NOTE this covers the HEARTBEAT lane only. The N2 session-cookie lane has a
+	// second precondition this cannot observe: existing browser cookies must
+	// also have aged out (cookieMaxAgeDays, currently 7). Removing that lane
+	// early logs every active user out rather than breaking a spoke.
+	HeartbeatLaneReady bool `json:"heartbeat_lane_ready"`
+}
+
+// authRolloutStaleAfter bounds how old an observation may be and still count.
+// A hive that has not heartbeated within this window is treated as absent, not
+// as legacy — otherwise a long-deleted hive would block the removal forever.
+//
+// 24h is chosen against the two ways this can be wrong, which fail in opposite
+// directions:
+//
+//   - TOO SHORT and a hive that is merely paused, mid-upgrade, or on a
+//     temporarily unreachable cluster drops out of the denominator. The fleet
+//     then reads ready while that spoke is still on the legacy bearer, and
+//     removing the lane 401s it the moment it comes back.
+//   - TOO LONG and every hive ever deleted keeps counting as a legacy laggard,
+//     so readiness never arrives and the compat lane becomes permanent — the
+//     precise failure this whole signal exists to prevent.
+//
+// Spokes beat on the order of a minute, so 24h is ~1000x the cadence: far past
+// any transient blip, but short enough that a decommissioned hive clears within
+// a day. If the fleet ever adopts long-lived paused hives that stop beating
+// entirely, revisit this — a paused hive should ideally be excluded explicitly
+// rather than by timeout.
+const authRolloutStaleAfter = 24 * time.Hour
+
+// AuthRolloutReadiness reports whether the N1 heartbeat compat lane can be
+// removed. Fails CLOSED: with no observations at all it reports not-ready,
+// because "no evidence" must never read as "safe to remove".
+func (s *HubServer) AuthRolloutReadiness() AuthRolloutStatus {
+	out := AuthRolloutStatus{StaleAfter: authRolloutStaleAfter.String()}
+	if s == nil {
+		return out
+	}
+	cutoff := time.Now().Add(-authRolloutStaleAfter)
+	s.authRolloutMu.RLock()
+	defer s.authRolloutMu.RUnlock()
+	for id, e := range s.authRolloutSeen {
+		if e.LastSeen.Before(cutoff) {
+			continue
+		}
+		out.TotalHives++
+		if e.PerHiveBearer {
+			out.PerHiveBearer++
+		} else {
+			out.LegacyBearer++
+			out.LegacyHives = append(out.LegacyHives, id)
+		}
+	}
+	out.HeartbeatLaneReady = out.TotalHives > 0 && out.LegacyBearer == 0
+	return out
+}
+
+// handleAuthRollout serves the readiness summary. Admin-only: it enumerates
+// hive IDs, and while that is not secret it is fleet-shaped information with no
+// reason to be public.
+func (s *HubServer) handleAuthRollout(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(s.AuthRolloutReadiness())
+}

--- a/v2/pkg/hub/auth_rollout_test.go
+++ b/v2/pkg/hub/auth_rollout_test.go
@@ -1,0 +1,107 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// #3234: readiness telemetry for removing the N1/N2 compatibility lanes.
+//
+// Those lanes ARE the vulnerabilities they replaced — a fleet-wide heartbeat
+// bearer does not bind identity, and a symmetric session key that verifies a
+// cookie can also mint one. They exist only so the fleet could roll without a
+// flag-day cutover, and they must not become permanent.
+//
+// The blocker to removing them was observability: "has every spoke
+// re-provisioned?" had no answer short of inspecting each Deployment by hand.
+// These tests pin the signal that answers it.
+
+func rolloutHub() *HubServer {
+	return &HubServer{authRolloutSeen: make(map[string]authRolloutEntry)}
+}
+
+// TestAuthRolloutFailsClosedWithNoData is the most important case: absence of
+// evidence must never read as "safe to remove".
+func TestAuthRolloutFailsClosedWithNoData(t *testing.T) {
+	s := rolloutHub()
+	got := s.AuthRolloutReadiness()
+	if got.HeartbeatLaneReady {
+		t.Fatal("readiness reported with ZERO observations — an operator would delete the " +
+			"compat lane on a hub that has simply never seen a heartbeat, 401ing the fleet")
+	}
+	if got.TotalHives != 0 {
+		t.Errorf("TotalHives = %d, want 0", got.TotalHives)
+	}
+}
+
+// TestAuthRolloutNotReadyWhileAnyLegacy: one laggard blocks removal, and it is
+// named so an operator knows which hive to re-provision.
+func TestAuthRolloutNotReadyWhileAnyLegacy(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-rolled", true)
+	s.noteHeartbeatAuthPath("hive-laggard", false)
+
+	got := s.AuthRolloutReadiness()
+	if got.HeartbeatLaneReady {
+		t.Fatal("reported ready while a spoke is still on the legacy bearer")
+	}
+	if got.TotalHives != 2 || got.PerHiveBearer != 1 || got.LegacyBearer != 1 {
+		t.Errorf("counts = total:%d per-hive:%d legacy:%d, want 2/1/1",
+			got.TotalHives, got.PerHiveBearer, got.LegacyBearer)
+	}
+	if len(got.LegacyHives) != 1 || got.LegacyHives[0] != "hive-laggard" {
+		t.Errorf("LegacyHives = %v, want [hive-laggard] — the laggard must be named", got.LegacyHives)
+	}
+}
+
+// TestAuthRolloutReadyWhenAllPerHive: the positive case that unblocks #3234.
+func TestAuthRolloutReadyWhenAllPerHive(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-a", true)
+	s.noteHeartbeatAuthPath("hive-b", true)
+
+	got := s.AuthRolloutReadiness()
+	if !got.HeartbeatLaneReady {
+		t.Fatalf("not ready with every hive on the per-hive bearer: %+v", got)
+	}
+	if len(got.LegacyHives) != 0 {
+		t.Errorf("LegacyHives = %v, want empty", got.LegacyHives)
+	}
+}
+
+// TestAuthRolloutIgnoresStale: a hive that stopped beating (deleted, migrated)
+// must not block the removal forever.
+func TestAuthRolloutIgnoresStale(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-current", true)
+	// A long-gone hive that last beat on the legacy bearer.
+	s.authRolloutSeen["hive-gone"] = authRolloutEntry{
+		PerHiveBearer: false,
+		LastSeen:      time.Now().Add(-authRolloutStaleAfter - time.Hour),
+	}
+
+	got := s.AuthRolloutReadiness()
+	if got.TotalHives != 1 {
+		t.Errorf("TotalHives = %d, want 1 (the stale hive must be ignored)", got.TotalHives)
+	}
+	if !got.HeartbeatLaneReady {
+		t.Error("a hive that has not beaten in over a day blocked readiness forever")
+	}
+}
+
+// TestAuthRolloutDoesNotLatch: a spoke that rolls BACK must flip the signal
+// back to not-ready. Latching "has ever been per-hive" would make the fleet
+// look ready when it no longer is.
+func TestAuthRolloutDoesNotLatch(t *testing.T) {
+	s := rolloutHub()
+	s.noteHeartbeatAuthPath("hive-a", true)
+	if !s.AuthRolloutReadiness().HeartbeatLaneReady {
+		t.Fatal("setup: expected ready")
+	}
+	// Same hive rolls back to an older image and presents the legacy bearer.
+	s.noteHeartbeatAuthPath("hive-a", false)
+	if s.AuthRolloutReadiness().HeartbeatLaneReady {
+		t.Fatal("readiness LATCHED — a rolled-back spoke still reads as ready, which is " +
+			"exactly when removing the lane would break it")
+	}
+}

--- a/v2/pkg/hub/cluster_metrics.go
+++ b/v2/pkg/hub/cluster_metrics.go
@@ -396,7 +396,7 @@ func k8sAPIGet(path string) ([]byte, error) {
 		pool.AppendCertsFromPEM(caCert)
 		tlsConfig.RootCAs = pool
 	} else {
-		tlsConfig.InsecureSkipVerify = true
+		return nil, fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
 	}
 
 	client := &http.Client{

--- a/v2/pkg/hub/cluster_metrics.go
+++ b/v2/pkg/hub/cluster_metrics.go
@@ -384,19 +384,29 @@ var (
 	k8sCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
+func k8sTLSConfig() (*tls.Config, error) {
+	caCert, err := os.ReadFile(k8sCACertPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("k8s CA cert at %s did not contain any PEM certificates, refusing to connect with an empty cert pool", k8sCACertPath)
+	}
+
+	return &tls.Config{RootCAs: pool}, nil
+}
+
 func k8sAPIGet(path string) ([]byte, error) {
 	token, err := os.ReadFile(k8sTokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading service account token: %w", err)
 	}
 
-	tlsConfig := &tls.Config{}
-	if caCert, err := os.ReadFile(k8sCACertPath); err == nil {
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(caCert)
-		tlsConfig.RootCAs = pool
-	} else {
-		return nil, fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
+	tlsConfig, err := k8sTLSConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	client := &http.Client{

--- a/v2/pkg/hub/final_gaps_coverage_test.go
+++ b/v2/pkg/hub/final_gaps_coverage_test.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -52,13 +51,9 @@ func TestK8sAPIGetWithCACert(t *testing.T) {
 	defer srv.Close()
 	withFakeK8sAPI(t, srv)
 
-	// Write a (PEM-shaped) CA cert so the AppendCertsFromPEM branch runs. It need
-	// not validate against the httptest server's cert because the server is plain
-	// HTTP; the branch simply builds a RootCAs pool.
-	caPEM := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
-	if err := os.WriteFile(k8sCACertPath, []byte(caPEM), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	// Write a valid CA cert so the RootCAs branch runs. It need not validate
+	// against the httptest server's cert because the server is plain HTTP.
+	writeTestK8sCACert(t, k8sCACertPath)
 	if _, err := k8sAPIGet("/api/v1/nodes"); err != nil {
 		t.Fatalf("k8sAPIGet with CA cert: %v", err)
 	}

--- a/v2/pkg/hub/heartbeat_identity_test.go
+++ b/v2/pkg/hub/heartbeat_identity_test.go
@@ -1,0 +1,103 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// N1 (CWE-200/639/862): the heartbeat bearer must be bound to the claimed hive.
+//
+// On v2 the bearer proved only "some provisioned spoke": provisioning injects
+// the RAW master into every spoke, and the fleet-wide derived key is identical
+// everywhere too. The handler then trusted payload.HiveID verbatim, and three
+// key-delivery lanes read off that claimed ID — so any spoke could beat as any
+// victim and be handed the victim's key material.
+//
+// This is the v2 port of the v4 fix (#3230). It keeps BOTH legacy credentials
+// working, because every spoke in the field holds one of them and rejecting
+// them would 401 the entire fleet at once.
+
+const n1v2Master = "test-master-secret-n1-v2"
+
+func n1v2Hub() *HubServer { return &HubServer{logger: slog.Default(), hubSecret: n1v2Master} }
+
+// TestHeartbeatBearerIsPerHive is the core property.
+func TestHeartbeatBearerIsPerHive(t *testing.T) {
+	s := n1v2Hub()
+	alpha := s.heartbeatKeyFor("hive-alpha")
+	bravo := s.heartbeatKeyFor("hive-bravo")
+
+	if alpha == "" || bravo == "" {
+		t.Fatal("per-hive derivation returned empty")
+	}
+	if alpha == bravo {
+		t.Fatal("two hives derived the SAME bearer — identity cannot be bound")
+	}
+	if !s.heartbeatBearerOK("Bearer "+alpha, "hive-alpha") {
+		t.Error("a hive's own per-hive bearer was rejected for its own ID")
+	}
+	// The IDOR: alpha's bearer must not authenticate a beat CLAIMING to be bravo.
+	// Note this only holds because alpha's bearer is not one of the legacy
+	// credentials — those are still accepted for any ID during rollout.
+	if s.heartbeatBearerOK("Bearer "+alpha, "hive-bravo") {
+		t.Fatal("N1: hive-alpha's bearer authenticated a heartbeat claiming to be " +
+			"hive-bravo — the victim's key material would go to the attacker")
+	}
+}
+
+// TestHeartbeatLegacyCredentialsStillAccepted pins the rollout contract. v2
+// provisioning ships the RAW master, so both legacy paths must keep working
+// until the fleet is re-provisioned (#3234).
+func TestHeartbeatLegacyCredentialsStillAccepted(t *testing.T) {
+	s := n1v2Hub()
+
+	if !s.heartbeatBearerOK("Bearer "+n1v2Master, "hive-alpha") {
+		t.Fatal("raw master bearer rejected — every v2 spoke in the field would 401")
+	}
+	if !s.heartbeatBearerOK("Bearer "+s.heartbeatKey(), "hive-alpha") {
+		t.Fatal("fleet-wide derived bearer rejected — spokes on that path would 401")
+	}
+	// ...and they are correctly reported as NOT identity-bound, so an operator
+	// can tell when the compat lanes are safe to remove.
+	if s.heartbeatBearerIsPerHive(n1v2Master, "hive-alpha") {
+		t.Error("raw master misreported as per-hive")
+	}
+	if s.heartbeatBearerIsPerHive(s.heartbeatKey(), "hive-alpha") {
+		t.Error("fleet key misreported as per-hive")
+	}
+	if !s.heartbeatBearerIsPerHive(s.heartbeatKeyFor("hive-alpha"), "hive-alpha") {
+		t.Error("per-hive bearer not reported as per-hive")
+	}
+}
+
+// TestHeartbeatBearerRejectsGarbage — the dual-accept path must not be
+// mistaken for accept-anything.
+func TestHeartbeatBearerRejectsGarbage(t *testing.T) {
+	s := n1v2Hub()
+	for _, bad := range []string{"", "Bearer ", "Bearer nope", "notabearer"} {
+		if s.heartbeatBearerOK(bad, "hive-alpha") {
+			t.Errorf("accepted %q", bad)
+		}
+	}
+}
+
+// TestPerHiveKeyEncodingIsUnambiguous covers the 0x00 separator: with plain
+// concatenation ("ab","c") and ("a","bc") would hash identically, and hive IDs
+// are operator-influenced.
+func TestPerHiveKeyEncodingIsUnambiguous(t *testing.T) {
+	if derivePerHiveKey(n1v2Master, "ab", "c") == derivePerHiveKey(n1v2Master, "a", "bc") {
+		t.Error("domain/identity boundary is not encoded unambiguously")
+	}
+}
+
+// TestPerHiveKeyFailsClosed: no master or no identity yields no key, never a
+// shared fallback.
+func TestPerHiveKeyFailsClosed(t *testing.T) {
+	if derivePerHiveKey("", infoHeartbeatKey, "hive-alpha") != "" {
+		t.Error("empty master derived a usable key")
+	}
+	if derivePerHiveKey(n1v2Master, infoHeartbeatKey, "") != "" {
+		t.Error("empty hiveID derived a usable key — an identity-less caller must " +
+			"not silently fall back to a shared key")
+	}
+}

--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -1,9 +1,11 @@
 package hub
 
 import (
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"strings"
 )
 
@@ -30,6 +32,82 @@ import (
 // hubCookieB64 encodes the signature URL-safe and unpadded so the cookie value
 // stays within the RFC 6265 cookie-octet set.
 var hubCookieB64 = base64.RawURLEncoding
+
+// N2 (CWE-321/798): the session cookie is now ASYMMETRICALLY signed.
+//
+// The HMAC scheme below is verify-capable-implies-mint-capable, and the same key
+// is provisioned into EVERY spoke so each spoke's proxy can check
+// `hive_hub_user`. A spoke operator could therefore read the key out of their pod
+// env and mint `clubanderson.<sig>` — a hub ADMIN cookie, accepted on ~21 admin
+// routes including the cluster App-key writer. That is the whole of N2, and it is
+// unfixable while the signer and the verifier hold the same bytes.
+//
+// The v2 format is Ed25519: the hub holds the private seed, spokes receive only
+// the public key. Same split the SSO handoff already made (C2 follow-up, #2771).
+//
+//	v2 value = <username>.v2.<base64url(Ed25519-Sign(privateKey, username))>
+//
+// The ".v2." marker is what lets one verifier accept both formats during the
+// rollout without ambiguity — a legacy HMAC signature can never contain a "."
+// (base64url has no dot), so the two shapes are distinguishable by structure
+// rather than by guessing.
+const hubCookieV2Marker = ".v2."
+
+// hubUserCookieV2Name is the SECOND cookie the hub emits, carrying the
+// Ed25519-signed value. It is a distinct NAME rather than a second format in
+// the same cookie because each verifier signs over the whole prefix — no single
+// concatenated value satisfies both the HMAC and Ed25519 verifiers (checked
+// both orderings; both fail both). A spoke that does not know this name simply
+// ignores it, which is what makes the mixed fleet work.
+const hubUserCookieV2Name = "hive_hub_user_v2"
+
+// mintHubUserCookieValueV2 mints an Ed25519-signed session cookie. seedHex is
+// the hub's PRIVATE session seed; a spoke cannot produce this value.
+//
+// Returns "" on empty inputs or seed material that is not a valid 32-byte
+// Ed25519 seed (e.g. a public key passed by mistake) — fail closed rather than
+// sign with junk, matching MintSSOToken.
+func mintHubUserCookieValueV2(seedHex, username string) string {
+	if seedHex == "" || username == "" {
+		return ""
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(username)))
+	return username + hubCookieV2Marker + sig
+}
+
+// verifyHubUserCookieValueV2 verifies an Ed25519-signed cookie against the hub's
+// PUBLIC session key. Returns (username, true) only on a valid signature.
+func verifyHubUserCookieValueV2(pubHex, value string) (string, bool) {
+	if pubHex == "" || value == "" {
+		return "", false
+	}
+	idx := strings.LastIndex(value, hubCookieV2Marker)
+	if idx <= 0 {
+		return "", false
+	}
+	username := value[:idx]
+	sigB64 := value[idx+len(hubCookieV2Marker):]
+	if username == "" || sigB64 == "" {
+		return "", false
+	}
+	pub, err := hex.DecodeString(strings.TrimSpace(pubHex))
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return "", false
+	}
+	sig, err := hubCookieB64.DecodeString(sigB64)
+	if err != nil {
+		return "", false
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(username), sig) {
+		return "", false
+	}
+	return username, true
+}
 
 // mintHubUserCookieValue returns the signed, tamper-evident cookie value for
 // username. It returns "" when no secret is configured or the username is empty
@@ -71,4 +149,33 @@ func hubCookieSign(secret, username string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(username))
 	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}
+
+// verifyHubUserCookieEither accepts a v2 (Ed25519) cookie OR a legacy HMAC one,
+// so live sessions survive the N2 cutover.
+//
+// Rollout shape, mirroring the SSO migration: the hub MINTS only v2 while
+// verifying both. Browsers holding a legacy cookie keep working until it is
+// re-minted at their next login; spokes running an older image keep verifying
+// the legacy format until they re-provision.
+//
+// The legacy lane is the vulnerability — anyone holding the symmetric key can
+// forge it — so it is explicitly TEMPORARY. It must be removed once the fleet
+// has rolled and existing cookies have aged out (the cookie's own MaxAge bounds
+// that window). hubCookieIsV2 gives an operator the signal for when that is
+// safe.
+//
+// legacySecret may be "" to disable the legacy lane entirely, which is what the
+// removal PR will pass.
+func verifyHubUserCookieEither(pubHex, legacySecret, value string) (string, bool) {
+	if u, ok := verifyHubUserCookieValueV2(pubHex, value); ok {
+		return u, true
+	}
+	return verifyHubUserCookieValue(legacySecret, value)
+}
+
+// hubCookieIsV2 reports whether a cookie value carries the asymmetric format.
+// Rollout telemetry only — never an authorization decision on its own.
+func hubCookieIsV2(value string) bool {
+	return strings.Contains(value, hubCookieV2Marker)
 }

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -44,6 +44,14 @@ const (
 	// in the existing master — no new secret, no rotation. Distinct label from the
 	// legacy symmetric infoSSOKey so the two can never derive to the same bytes.
 	infoSSOEd25519Seed = "hive-sso-ed25519-v1"
+
+	// infoSessionEd25519Seed derives the Ed25519 signing SEED for the hub SESSION
+	// cookie (audit N2). Same construction as infoSSOEd25519Seed and for the same
+	// reason: a spoke must be able to VERIFY a hub-minted value without being
+	// able to MINT one. The symmetric infoSessionKey cannot give that — an HMAC
+	// key that verifies also signs, so any spoke holding it could mint an admin
+	// cookie. Distinct label so the two can never collide.
+	infoSessionEd25519Seed = "hive-session-ed25519-v1"
 )
 
 // deriveDomainKey returns a domain-separated sub-key of master for the given
@@ -57,6 +65,51 @@ func deriveDomainKey(master, info string) string {
 	mac := hmac.New(sha256.New, []byte(master))
 	mac.Write([]byte(info))
 	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// derivePerHiveKey returns a sub-key bound to BOTH a trust domain and a single
+// hive: HMAC-SHA256(master, info || 0x00 || hiveID).
+//
+// SECURITY (audit N1/N3, CWE-321/798). deriveDomainKey above takes a FIXED
+// label, so every spoke in the fleet derives byte-identical keys from the one
+// master. Possession therefore proves "some provisioned spoke" and never "this
+// spoke" — which is the whole of the hosted kill chain: spoke A's key verifies
+// on spoke B, so one hostile tenant can forge terminal grants for another and
+// beat heartbeats as any victim.
+//
+// Mixing the hive ID in keeps every property the fleet-wide scheme had:
+// deterministic in the existing master (no new secret to store or rotate),
+// re-derivable by the hub on demand, and stable across re-provisioning.
+//
+// The 0x00 separator matters. Plain concatenation is ambiguous —
+// ("hive-terminal", "a|b") and ("hive-terminal|a", "b") would hash identically —
+// and hive IDs are operator-influenced. A NUL can appear in neither input: info
+// strings are compile-time constants and hive IDs are validated by isValidName.
+//
+// Returns "" for an empty master OR an empty hiveID: a keyless or identity-less
+// caller must fail closed rather than silently sharing one key again.
+func derivePerHiveKey(master, info, hiveID string) string {
+	if master == "" || hiveID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(master))
+	mac.Write([]byte(info))
+	mac.Write([]byte{0})
+	mac.Write([]byte(hiveID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// heartbeatKeyFor returns the per-hive heartbeat bearer the hub EXPECTS from
+// hiveID (audit N1).
+func (s *HubServer) heartbeatKeyFor(hiveID string) string {
+	return derivePerHiveKey(s.hubSecret, infoHeartbeatKey, hiveID)
+}
+
+// heartbeatBearerIsPerHive reports whether the presented bearer is the modern,
+// identity-bound one. Rollout telemetry only — see issue #3234.
+func (s *HubServer) heartbeatBearerIsPerHive(presented, hiveID string) bool {
+	perHive := s.heartbeatKeyFor(hiveID)
+	return perHive != "" && secureCompareHub(presented, perHive)
 }
 
 // heartbeatKey returns the derived heartbeat bearer a v4 spoke presents on
@@ -76,11 +129,33 @@ func (s *HubServer) sessionCookieKey() string {
 	return deriveDomainKey(s.hubSecret, infoSessionKey)
 }
 
+// sessionSigningSeed returns the hex Ed25519 SEED the hub signs session cookies
+// with (audit N2). PRIVATE material: never inject it into a spoke.
+func (s *HubServer) sessionSigningSeed() string {
+	return deriveDomainKey(s.hubSecret, infoSessionEd25519Seed)
+}
+
+// sessionPublicKey returns the hex Ed25519 PUBLIC key a spoke verifies hub
+// session cookies with. Safe to place in a Deployment: it verifies, never signs.
+func (s *HubServer) sessionPublicKey() string {
+	return ssoPublicKeyFromSeed(s.sessionSigningSeed())
+}
+
 // verifyHubUserDual verifies the hive_hub_user cookie against the derived
 // session key (how cookies are minted after the C2 session-key cutover) OR
 // the raw master (legacy cookies still in browsers). Additive: never rejects
 // a value the single-key check would have accepted.
 func (s *HubServer) verifyHubUserDual(value string) (string, bool) {
+	// N2 (CWE-321/798): accept the ASYMMETRIC value first. Only the hub can mint
+	// it — a spoke holding just the public key can verify but not forge — so it
+	// is the strongest of the three and should win when present.
+	if u, ok := verifyHubUserCookieValueV2(s.sessionPublicKey(), value); ok {
+		return u, true
+	}
+	// The two symmetric paths below are ROLLOUT ONLY. Both are forgeable by any
+	// spoke that holds the corresponding key, which on v2 is every spoke (the
+	// raw master is injected into each Deployment). They stay until the fleet is
+	// re-provisioned and existing cookies age out; #3234 tracks the removal.
 	if u, ok := verifyHubUserCookieValue(s.sessionCookieKey(), value); ok {
 		return u, true
 	}

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -239,6 +239,9 @@ func TestAdminReadSurfacesHiddenDuringImpersonation(t *testing.T) {
 	rec = httptest.NewRecorder()
 	guardedExit := s.requireAdmin(next)
 	exitReq := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	// N6: requireAdmin now runs isCSRFSafe, so a POST must look like one the
+	// dashboard actually sends — a same-origin fetch carries Origin.
+	exitReq.Header.Set("Origin", "https://hive.kubestellar.io")
 	exitReq.AddCookie(testAuthCookie(hubAdminUsername))
 	exitReq.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guardedExit(rec, exitReq)
@@ -262,6 +265,9 @@ func TestImpersonateExitClearsCookieAndStaysCallable(t *testing.T) {
 	guarded := s.requireAdmin(s.handleImpersonateExit)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, impersonateExitPath, nil)
+	// N6: requireAdmin now enforces CSRF; send the same-origin Origin a real
+	// dashboard fetch would carry.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	req.AddCookie(testAuthCookie(hubAdminUsername))
 	req.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guarded(rec, req)

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -287,6 +287,34 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 	http.SetCookie(w, cookie)
 
+	// N2 (CWE-321/798): ALSO emit an Ed25519-signed cookie.
+	//
+	// hive_hub_user above stays HMAC because that is the only format v2 spokes
+	// can verify (their proxy checks HMAC and nothing else — see F3/#3243), and
+	// v4 spokes accept either. Minting only Ed25519 would 401 the terminal on
+	// every v2 spoke in the fleet.
+	//
+	// This second cookie is what actually closes N2 for spokes that can read it:
+	// a spoke holding only the PUBLIC key can verify it but cannot mint one, so
+	// it can no longer forge `clubanderson.<sig>` and obtain hub admin. v4's
+	// proxy prefers it; v2's ignores an unknown cookie name.
+	//
+	// Two cookies rather than one hybrid value: each verifier computes its
+	// signature over the whole prefix, so no single concatenation satisfies
+	// both — verified empirically, both orderings fail both verifiers.
+	if v2Value := mintHubUserCookieValueV2(s.sessionSigningSeed(), user.Login); v2Value != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     hubUserCookieV2Name,
+			Value:    v2Value,
+			Path:     "/",
+			Domain:   ".hive.kubestellar.io",
+			MaxAge:   86400 * cookieMaxAgeDays,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
 	saasUser := ensureSaaSUser(user.Login)
 	// A completed OAuth callback IS a login — count it here and nowhere else.
 	// ensureSaaSUser already refreshed LastLogin; the count is the engagement
@@ -359,6 +387,19 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "hive_hub_user",
+		Value:    "",
+		Path:     "/",
+		Domain:   ".hive.kubestellar.io",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	// N2: clear the Ed25519 cookie too, or a logout leaves a still-valid
+	// credential in the browser — the session-invalidation hole in miniature.
+	http.SetCookie(w, &http.Cookie{
+		Name:     hubUserCookieV2Name,
 		Value:    "",
 		Path:     "/",
 		Domain:   ".hive.kubestellar.io",

--- a/v2/pkg/hub/placeholder_health.go
+++ b/v2/pkg/hub/placeholder_health.go
@@ -56,6 +56,34 @@ const healthCheckTokens = "tokens"
 // detail on an unassigned row, for the same reason as placeholderAuthNote.
 const placeholderTokensNote = "Unassigned — no workload by design"
 
+// healthCheckRepoTarget is the spoke's repo-target validation check
+// (HealthSummary, pkg/dashboard/server.go). It warns whenever
+// config.ValidateRepoTargets reports an issue. On an unassigned pool slot the
+// issue is always the empty-repo shape — a placeholder is provisioned with
+// repos: [] until a project is claimed — so that shape is designed state,
+// exactly like github_auth being unconfigured. A malformed VALUE (a URL, a
+// slash, a forge host) is a genuine misconfiguration even on a placeholder
+// and keeps its warning.
+const healthCheckRepoTarget = "repo_target"
+
+// placeholderRepoTargetNote replaces the repo_target check's empty-repo
+// warning detail on an unassigned row, for the same reason as
+// placeholderAuthNote.
+const placeholderRepoTargetNote = "Unassigned — repo target set when claimed by design"
+
+// repoTargetEmptyMarker is the substring config.ValidateRepoTargets puts in
+// every empty-shape issue ("org is empty …" / "repo is empty …"). Malformed
+// value shapes (URL / slash / forge host) never carry it.
+const repoTargetEmptyMarker = "is empty"
+
+// repoTargetWarnIsUnassignedEmpty reports whether a repo_target warning is
+// warning ONLY because the slot has no org/repo configured yet — the designed
+// state of an unassigned pool slot — and not because a configured value is
+// malformed.
+func repoTargetWarnIsUnassignedEmpty(detail string) bool {
+	return strings.Contains(detail, repoTargetEmptyMarker)
+}
+
 // healthCheckAgents is the spoke's agent-liveness check (HealthSummary,
 // pkg/dashboard/server.go). It fails with a detail line like
 // "0 running, 1 paused, 4 need login: guide, quality, scanner, supervisor"
@@ -114,6 +142,8 @@ func placeholderDesignedCheckNote(name, detail string) string {
 		return placeholderAuthNote
 	case name == healthCheckTokens:
 		return placeholderTokensNote
+	case name == healthCheckRepoTarget && repoTargetWarnIsUnassignedEmpty(detail):
+		return placeholderRepoTargetNote
 	case name == healthCheckAgents && agentsFailIsLoginPending(detail):
 		return placeholderAgentsNote
 	}

--- a/v2/pkg/hub/placeholder_health_test.go
+++ b/v2/pkg/hub/placeholder_health_test.go
@@ -213,6 +213,82 @@ func TestPlaceholderRowGreenWhenTokensWarnZeroConsumed(t *testing.T) {
 	}
 }
 
+// An UNASSIGNED placeholder whose only warning is the empty-repo repo_target
+// shape is the pool working as designed — repos are set when the slot is
+// claimed — so the row must ship GREEN with the check reclassified as skip.
+func TestPlaceholderRowGreenWhenRepoTargetEmpty(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "warning",
+		"fails":  0,
+		"warns":  1,
+		"checks": []any{
+			map[string]any{"name": "ready", "status": "pass"},
+			map[string]any{"name": healthCheckRepoTarget, "status": "warn", "detail": "Repo target misconfigured: repo is empty — expected org/repo. Fix in Governor Config → Repos."},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusOK {
+		t.Fatalf("placeholder with only the empty-repo repo_target warning: status = %q, want %q", st, healthStatusOK)
+	}
+	if warns, _ := got["warns"].(int); warns != 0 {
+		t.Errorf("warns = %v, want 0 — the pill must not render", got["warns"])
+	}
+	st, detail := checkStatusByName(t, got, healthCheckRepoTarget)
+	if st != healthCheckStatusSkip {
+		t.Errorf("repo_target status = %q, want %q", st, healthCheckStatusSkip)
+	}
+	if detail != placeholderRepoTargetNote {
+		t.Errorf("repo_target detail = %q, want the unassigned note %q", detail, placeholderRepoTargetNote)
+	}
+}
+
+// A MALFORMED repo-target value (URL / slash / forge host) is a genuine
+// misconfiguration even on a placeholder — the warning must survive.
+func TestPlaceholderRowKeepsMalformedRepoTargetWarning(t *testing.T) {
+	e := placeholderEntryWithHealth(map[string]any{
+		"status": "warning",
+		"checks": []any{
+			map[string]any{"name": healthCheckRepoTarget, "status": "warn", "detail": "Repo target misconfigured: org 'github.ibm.com' looks like a forge host — expected org/repo. Fix in Governor Config → Repos."},
+		},
+	})
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	got := rows[0].Health
+
+	if st := healthStatusOf(got); st != healthStatusWarning {
+		t.Fatalf("placeholder with malformed repo target: status = %q, want %q — a bad VALUE is a real fault", st, healthStatusWarning)
+	}
+	if st, _ := checkStatusByName(t, got, healthCheckRepoTarget); st != healthCheckStatusWarn {
+		t.Errorf("repo_target = %q, want warn untouched", st)
+	}
+}
+
+// The SAME empty-repo warning on a CLAIMED hive is a real misconfiguration
+// (a claimed project must have repos) and must pass through untouched.
+func TestClaimedRowKeepsEmptyRepoTargetWarning(t *testing.T) {
+	e := MyHiveEntry{RegistryEntry: RegistryEntry{
+		ID:     "claimed-3",
+		Org:    "acme",
+		Online: true,
+		Health: map[string]any{
+			"status": "warning",
+			"checks": []any{
+				map[string]any{"name": healthCheckRepoTarget, "status": "warn", "detail": "Repo target misconfigured: repo is empty — expected org/repo. Fix in Governor Config → Repos."},
+			},
+		},
+	}}
+	e.ProvStatus = "active"
+
+	rows := []MyHiveEntry{e}
+	sanitizePlaceholderRows(rows)
+	if st := healthStatusOf(rows[0].Health); st != healthStatusWarning {
+		t.Fatalf("claimed hive status = %q, want %q — the repo_target exemption must not leak", st, healthStatusWarning)
+	}
+}
+
 // The SAME zero-consumed warning on a CLAIMED hive is a real signal (an
 // assigned project spending nothing is worth noticing) and must pass through
 // untouched.

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -543,6 +543,17 @@ func isTrustedOrigin(raw string) bool {
 // resolveIdentity — never inside it — so the write-block and the admin gate can
 // always reason about who is really driving the request.
 func (s *HubServer) getRealAuthUser(r *http.Request) string {
+	// N2: prefer the Ed25519 cookie when the browser carries one. It is the only
+	// value a spoke cannot forge, so it must win over the symmetric fallbacks.
+	if c, err := r.Cookie(hubUserCookieV2Name); err == nil && c.Value != "" {
+		if username, ok := verifyHubUserCookieValueV2(s.sessionPublicKey(), c.Value); ok {
+			if loadSaaSUser(username) != nil {
+				return username
+			}
+		}
+		// A stale/invalid v2 cookie is not fatal — fall through to the HMAC one
+		// rather than locking the user out (e.g. after a secret rotation).
+	}
 	cookie, err := r.Cookie("hive_hub_user")
 	if err == nil && cookie.Value != "" {
 		// The cookie value is only trusted when its HMAC signature verifies
@@ -771,6 +782,21 @@ func listAllSaaSUsers() []SaaSUser {
 
 func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// SECURITY (audit N6, CWE-352): admin routes carry the SAME CSRF exposure
+		// as requireAuth ones — the hub session cookie is ambient, so a cross-site
+		// form POST to e.g. /api/saas/hub/upgrade or the cluster-app-key writer
+		// executes with the admin's identity. requireAuth has always checked this;
+		// requireAdmin never did, leaving every admin mutation reachable from ANY
+		// origin — strictly worse than the sibling-tenant lane, which at least
+		// needs a *.hive.kubestellar.io foothold. Checked first, before any
+		// identity resolution, so a forged request never reaches the
+		// impersonation logic below.
+		if !isCSRFSafe(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":"CSRF check failed"}`))
+			return
+		}
 		// Gate on the REAL logged-in user, not the effective (possibly
 		// impersonated) identity. While the admin is viewing as a normal user,
 		// getAuthUser resolves to that user on GETs — but admin routes (and in

--- a/v2/pkg/hub/saas_admin_csrf_test.go
+++ b/v2/pkg/hub/saas_admin_csrf_test.go
@@ -1,0 +1,120 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// N6 (CWE-352): requireAdmin must run the SAME CSRF check requireAuth does.
+//
+// Before this fix requireAdmin resolved identity and nothing else, so every
+// admin mutation (~21 routes: hub upgrade, cluster App key writes, user
+// delete, banners, provisioning approval) was reachable by a cross-site form
+// POST carrying the admin's ambient session cookie — from ANY origin, not just
+// a sibling *.hive.kubestellar.io tenant.
+//
+// These tests present a GENUINELY VALID admin cookie, so a 403 can only come
+// from the CSRF gate. That distinction matters: the pre-existing
+// TestRequireAdminNonAdmin / TestRequireAdminNoAuth also assert 403, but they
+// get it from the identity check and would keep passing with the CSRF hole
+// wide open. The suite had a requireAuth CSRF test (TestRequireAuthCSRFFails)
+// and no requireAdmin counterpart, which is why this shipped.
+
+// adminCSRFHandler builds a requireAdmin-wrapped handler that records whether
+// the protected body ever ran. Reaching the body is the failure condition.
+func adminCSRFHandler(s *HubServer, reached *bool) http.HandlerFunc {
+	return s.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// TestRequireAdminCSRFCrossOriginPostDenied is the regression for N6: a POST
+// from an unrelated origin, with a valid admin session cookie, must be refused
+// before the handler runs.
+func TestRequireAdminCSRFCrossOriginPostDenied(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-origin admin POST: code=%d, want 403 (CSRF); body=%q", rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("cross-origin admin POST reached the protected handler — CSRF gate did not run")
+	}
+}
+
+// TestRequireAdminCSRFSiblingTenantOriginDenied covers the lane the audit
+// reproduced: a hostile tenant spoke. isTrustedOrigin still allows
+// *.hive.kubestellar.io, so this currently passes the CSRF check and is denied
+// only if the wider trusted-origin reduction lands. Asserting the *documented*
+// current behaviour keeps this test honest rather than aspirational — flip it
+// to expect 403 when the exact-origin change ships.
+func TestRequireAdminCSRFSiblingTenantOriginStillTrusted(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://attacker-hive.hive.kubestellar.io")
+
+	if !isCSRFSafe(req) {
+		t.Skip("sibling-tenant origin is no longer trusted — the exact-origin fix has landed; update this test to assert 403 through requireAdmin")
+	}
+	t.Log("KNOWN GAP (N6, second half): a sibling *.hive.kubestellar.io origin is still CSRF-trusted; " +
+		"the requireAdmin gate does not close this lane on its own. Tracked for the exact-origin + CSRF-token work.")
+}
+
+// TestRequireAdminSafeGetStillAllowed guards against over-correction: the CSRF
+// check must not break admin GETs, which is how the dashboard reads admin data.
+func TestRequireAdminSafeGetStillAllowed(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/admin/users", nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if !reached || rec.Code != http.StatusOK {
+		t.Fatalf("admin GET with valid session: code=%d reached=%v, want 200/true", rec.Code, reached)
+	}
+}
+
+// TestRequireAdminSameOriginPostAllowed proves the legitimate dashboard path
+// (a same-origin POST from the hub itself) is unaffected by the new gate.
+func TestRequireAdminSameOriginPostAllowed(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if !reached || rec.Code != http.StatusOK {
+		t.Fatalf("same-origin admin POST: code=%d reached=%v, want 200/true", rec.Code, reached)
+	}
+}

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -368,7 +368,7 @@ func k8sAPIPatch(path string, body []byte) error {
 		pool.AppendCertsFromPEM(caCert)
 		tlsConfig.RootCAs = pool
 	} else {
-		tlsConfig.InsecureSkipVerify = true
+		return fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
 	}
 
 	client := &http.Client{

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -3,8 +3,6 @@ package hub
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -362,13 +360,9 @@ func k8sAPIPatch(path string, body []byte) error {
 		return fmt.Errorf("reading service account token: %w", err)
 	}
 
-	tlsConfig := &tls.Config{}
-	if caCert, err := os.ReadFile(k8sCACertPath); err == nil {
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(caCert)
-		tlsConfig.RootCAs = pool
-	} else {
-		return fmt.Errorf("cannot read k8s CA cert at %s, refusing to connect with TLS verification disabled: %w", k8sCACertPath, err)
+	tlsConfig, err := k8sTLSConfig()
+	if err != nil {
+		return err
 	}
 
 	client := &http.Client{

--- a/v2/pkg/hub/self_upgrade_coverage_test.go
+++ b/v2/pkg/hub/self_upgrade_coverage_test.go
@@ -33,7 +33,6 @@ func withFakeK8sAPI(t *testing.T, srv *httptest.Server) {
 	if err := os.WriteFile(nsPath, []byte("hive-hosted-test"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-
 	oldServer, oldToken, oldCA, oldNS := k8sAPIServer, k8sTokenPath, k8sCACertPath, k8sNamespacePath
 	k8sAPIServer = srv.URL
 	k8sTokenPath = tokenPath

--- a/v2/pkg/hub/self_upgrade_coverage_test.go
+++ b/v2/pkg/hub/self_upgrade_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/pem"
 	"io"
 	"log/slog"
 	"net/http"
@@ -36,11 +37,22 @@ func withFakeK8sAPI(t *testing.T, srv *httptest.Server) {
 	oldServer, oldToken, oldCA, oldNS := k8sAPIServer, k8sTokenPath, k8sCACertPath, k8sNamespacePath
 	k8sAPIServer = srv.URL
 	k8sTokenPath = tokenPath
-	k8sCACertPath = filepath.Join(dir, "ca.crt") // absent -> InsecureSkipVerify branch
+	k8sCACertPath = filepath.Join(dir, "ca.crt")
+	writeTestK8sCACert(t, k8sCACertPath)
 	k8sNamespacePath = nsPath
 	t.Cleanup(func() {
 		k8sAPIServer, k8sTokenPath, k8sCACertPath, k8sNamespacePath = oldServer, oldToken, oldCA, oldNS
 	})
+}
+
+func writeTestK8sCACert(t *testing.T, path string) {
+	t.Helper()
+	certSrv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer certSrv.Close()
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certSrv.Certificate().Raw})
+	if err := os.WriteFile(path, caPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestK8sAPIGetSuccess(t *testing.T) {
@@ -72,6 +84,73 @@ func TestK8sAPIGetNon200(t *testing.T) {
 
 	if _, err := k8sAPIGet("/api/v1/nodes"); err == nil {
 		t.Error("expected error on non-200")
+	}
+}
+
+func TestK8sAPIGetMissingCAFailsClosed(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+	if err := os.Remove(k8sCACertPath); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := k8sAPIGet("/api/v1/nodes")
+	if err == nil {
+		t.Fatal("expected k8sAPIGet to fail when CA cert cannot be read")
+	}
+	if !strings.Contains(err.Error(), "refusing to connect with TLS verification disabled") {
+		t.Fatalf("error = %v, want fail-closed CA message", err)
+	}
+	if hits != 0 {
+		t.Fatalf("server was contacted %d times despite missing CA", hits)
+	}
+}
+
+func TestK8sAPIGetInvalidCAFailsClosed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server must not be contacted with invalid CA")
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+	if err := os.WriteFile(k8sCACertPath, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := k8sAPIGet("/api/v1/nodes")
+	if err == nil {
+		t.Fatal("expected k8sAPIGet to fail when CA cert has no PEM certificates")
+	}
+	if !strings.Contains(err.Error(), "empty cert pool") {
+		t.Fatalf("error = %v, want empty cert pool fail-closed message", err)
+	}
+}
+
+func TestK8sAPIPatchMissingCAFailsClosed(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	withFakeK8sAPI(t, srv)
+	if err := os.Remove(k8sCACertPath); err != nil {
+		t.Fatal(err)
+	}
+
+	err := k8sAPIPatch("/x", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected k8sAPIPatch to fail when CA cert cannot be read")
+	}
+	if !strings.Contains(err.Error(), "refusing to connect with TLS verification disabled") {
+		t.Fatalf("error = %v, want fail-closed CA message", err)
+	}
+	if hits != 0 {
+		t.Fatalf("server was contacted %d times despite missing CA", hits)
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -333,6 +333,9 @@ func downsampleSpark(points []SparkPoint, max int) []SparkPoint {
 	if len(points) <= max {
 		return points
 	}
+	if max == 1 {
+		return []SparkPoint{points[0]}
+	}
 	out := make([]SparkPoint, 0, max)
 	// Spread max samples across the series, inclusive of both endpoints.
 	step := float64(len(points)-1) / float64(max-1)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -739,11 +739,33 @@ func secureCompareHub(a, b string) bool {
 // outer `if s.hubSecret != ""` guard, so an unconfigured hub still authenticates
 // nothing here — this only widens WHICH bearer a configured hub accepts, and only
 // ever adds the new scheme alongside the old one.
-func (s *HubServer) heartbeatBearerOK(auth string) bool {
+// heartbeatBearerOK authenticates a heartbeat and, when a hiveID is supplied,
+// BINDS the bearer to that claimed identity (audit N1, CWE-200/639/862).
+//
+// The bearer used to prove only "some provisioned spoke": both accepted
+// credentials — the raw master and the fleet-wide derived key — are identical
+// on every spoke, so the handler had to trust body-supplied hive_id. Three
+// key-delivery lanes read off that claimed ID, making them IDOR.
+//
+// hiveID may be "" for callers that authenticate before parsing a body; that
+// path keeps the pre-existing fleet-wide behaviour rather than failing closed,
+// because tightening it there would reject every spoke in the field.
+func (s *HubServer) heartbeatBearerOK(auth string, hiveID string) bool {
 	if !strings.HasPrefix(auth, "Bearer ") {
 		return false
 	}
 	tok := strings.TrimPrefix(auth, "Bearer ")
+	// N1: the identity-bound bearer. Only this proves "I am THIS hive".
+	if hiveID != "" {
+		if ph := s.heartbeatKeyFor(hiveID); ph != "" && secureCompareHub(tok, ph) {
+			return true
+		}
+	}
+	// ROLLOUT ONLY — neither of the following binds identity. Every spoke in the
+	// field holds one of them (v2 provisioning injects the raw master), so
+	// rejecting them outright would 401 the entire fleet at once. Remove once
+	// spokes have been re-provisioned onto per-hive bearers; #3234 tracks that,
+	// and heartbeatBearerIsPerHive is the readiness signal.
 	if secureCompareHub(tok, s.hubSecret) {
 		return true
 	}
@@ -913,6 +935,11 @@ type HubServer struct {
 	spokeProxyAuthCache map[string]spokeProxyAuthEntry
 	spokeProxyAuthMu    sync.Mutex
 
+	// #3234: per-hive record of which credential FORMAT each spoke last
+	// authenticated with — the readiness signal for removing the N1 legacy lanes.
+	authRolloutSeen map[string]authRolloutEntry
+	authRolloutMu   sync.RWMutex
+
 	// pendingGateways stores OpenRouter gateways funded via the hub's
 	// scan-to-fund flow, to deliver to firewalled/heartbeat-only spokes via the
 	// heartbeat response. Key: hive ID → gateway (carries the secret key VALUE,
@@ -1080,6 +1107,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
 		spokeProxyAuthCache:     make(map[string]spokeProxyAuthEntry),
+		authRolloutSeen:         make(map[string]authRolloutEntry),
 		timeline:                newTimelineStore(),
 		journey:                 newJourneyStore(),
 		alerts:                  newAlertState(),
@@ -1174,11 +1202,13 @@ func (s *HubServer) Shutdown(timeout time.Duration) error {
 }
 
 func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	// N1: the bearer is captured here and VERIFIED below, once the claimed
+	// hive_id is known — the identity-bound bearer is derived from it. The
+	// prefix check stays here so a malformed header is still rejected early.
+	presentedAuth := ""
 	if s.hubSecret != "" {
-		auth := r.Header.Get("Authorization")
-		// Dual-path: accept the legacy raw-secret bearer (old spokes) OR the
-		// derived heartbeat key (v4 spokes). See heartbeatBearerOK.
-		if !s.heartbeatBearerOK(auth) {
+		presentedAuth = r.Header.Get("Authorization")
+		if !strings.HasPrefix(presentedAuth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -1209,6 +1239,18 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if !isValidName(payload.HiveID) {
 		http.Error(w, "invalid hive_id", http.StatusBadRequest)
 		return
+	}
+	// N1 (CWE-200/639/862): bind the bearer to the CLAIMED identity. Until now
+	// the bearer proved only "some provisioned spoke" — the raw master and the
+	// fleet-wide derived key are identical everywhere — so hive_id was trusted
+	// verbatim and three key-delivery lanes read off it.
+	if s.hubSecret != "" {
+		if !s.heartbeatBearerOK(presentedAuth, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.noteHeartbeatAuthPath(payload.HiveID,
+			s.heartbeatBearerIsPerHive(strings.TrimPrefix(presentedAuth, "Bearer "), payload.HiveID))
 	}
 	if payload.Org != "" && !isValidName(payload.Org) {
 		http.Error(w, "invalid org name", http.StatusBadRequest)
@@ -2261,11 +2303,13 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
+	// N1: the bearer is captured here and VERIFIED below, once the claimed
+	// hive_id is known — the identity-bound bearer is derived from it. The
+	// prefix check stays here so a malformed header is still rejected early.
+	presentedAuth := ""
 	if s.hubSecret != "" {
-		auth := r.Header.Get("Authorization")
-		// Dual-path: accept the legacy raw-secret bearer (old spokes) OR the
-		// derived heartbeat key (v4 spokes). See heartbeatBearerOK.
-		if !s.heartbeatBearerOK(auth) {
+		presentedAuth = r.Header.Get("Authorization")
+		if !strings.HasPrefix(presentedAuth, "Bearer ") {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -2289,6 +2333,19 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	if payload.HiveID == "" {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
+	}
+	if !isValidName(payload.HiveID) {
+		http.Error(w, "invalid hive_id", http.StatusBadRequest)
+		return
+	}
+	// N1: same identity binding as /api/heartbeat.
+	if s.hubSecret != "" {
+		if !s.heartbeatBearerOK(presentedAuth, payload.HiveID) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.noteHeartbeatAuthPath(payload.HiveID,
+			s.heartbeatBearerIsPerHive(strings.TrimPrefix(presentedAuth, "Bearer "), payload.HiveID))
 	}
 	for i, lb := range payload.Leaderboard {
 		payload.Leaderboard[i].GitHubUsername = sanitizeField(lb.GitHubUsername)

--- a/v2/pkg/hub/server_engagement_coverage_test.go
+++ b/v2/pkg/hub/server_engagement_coverage_test.go
@@ -1,0 +1,361 @@
+package hub
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func engagementTestHub() *HubServer {
+	return &HubServer{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func TestMarkUsersEngaged_BasicMark(t *testing.T) {
+	s := engagementTestHub()
+	s.markUsersEngaged([]string{"alice", "bob"})
+
+	s.liveHiveUsersMu.RLock()
+	defer s.liveHiveUsersMu.RUnlock()
+	if len(s.engagedHiveUsers) != 2 {
+		t.Fatalf("engagedHiveUsers has %d entries, want 2", len(s.engagedHiveUsers))
+	}
+	for _, name := range []string{"alice", "bob"} {
+		if _, ok := s.engagedHiveUsers[name]; !ok {
+			t.Errorf("user %q not in engagedHiveUsers", name)
+		}
+	}
+}
+
+func TestMarkUsersEngaged_SkipsInvalid(t *testing.T) {
+	s := engagementTestHub()
+	s.markUsersEngaged([]string{"", "../etc/passwd", "valid-user"})
+
+	s.liveHiveUsersMu.RLock()
+	defer s.liveHiveUsersMu.RUnlock()
+	if len(s.engagedHiveUsers) != 1 {
+		t.Fatalf("engagedHiveUsers has %d entries, want 1", len(s.engagedHiveUsers))
+	}
+}
+
+func TestMarkUsersEngaged_EmptySliceNoOp(t *testing.T) {
+	s := engagementTestHub()
+	s.markUsersEngaged(nil)
+	s.markUsersEngaged([]string{})
+
+	s.liveHiveUsersMu.RLock()
+	defer s.liveHiveUsersMu.RUnlock()
+	if s.engagedHiveUsers != nil && len(s.engagedHiveUsers) != 0 {
+		t.Error("empty call should not create map entries")
+	}
+}
+
+func TestEngagedHiveUsernames_ReturnsFreshOnly(t *testing.T) {
+	s := engagementTestHub()
+	s.markUsersEngaged([]string{"alice", "bob"})
+
+	s.liveHiveUsersMu.Lock()
+	s.engagedHiveUsers["bob"] = time.Now().Add(-2 * liveHiveUserStaleness)
+	s.liveHiveUsersMu.Unlock()
+
+	engaged := s.engagedHiveUsernames()
+	if len(engaged) != 1 || engaged[0] != "alice" {
+		t.Errorf("engagedHiveUsernames() = %v, want [alice]", engaged)
+	}
+
+	s.liveHiveUsersMu.RLock()
+	_, bobExists := s.engagedHiveUsers["bob"]
+	s.liveHiveUsersMu.RUnlock()
+	if bobExists {
+		t.Error("stale engaged entry should have been pruned")
+	}
+}
+
+func TestEngagedHiveUsernames_ReturnsSorted(t *testing.T) {
+	s := engagementTestHub()
+	s.markUsersEngaged([]string{"charlie", "alice", "bob"})
+	engaged := s.engagedHiveUsernames()
+	if len(engaged) != 3 || engaged[0] != "alice" || engaged[1] != "bob" || engaged[2] != "charlie" {
+		t.Errorf("engagedHiveUsernames() = %v, want sorted", engaged)
+	}
+}
+
+func TestEngagedHiveUsernames_EmptyOnNoEngagement(t *testing.T) {
+	s := engagementTestHub()
+	engaged := s.engagedHiveUsernames()
+	if len(engaged) != 0 {
+		t.Errorf("engagedHiveUsernames() = %v, want empty", engaged)
+	}
+}
+
+func TestIsUserEngagedNow_TrueForFreshUser(t *testing.T) {
+	s := engagementTestHub()
+	s.markUsersEngaged([]string{"alice"})
+	if !s.isUserEngagedNow("alice") {
+		t.Error("isUserEngagedNow(alice) = false, want true")
+	}
+}
+
+func TestIsUserEngagedNow_FalseForStaleUser(t *testing.T) {
+	s := engagementTestHub()
+	s.markUsersEngaged([]string{"alice"})
+	s.liveHiveUsersMu.Lock()
+	s.engagedHiveUsers["alice"] = time.Now().Add(-2 * liveHiveUserStaleness)
+	s.liveHiveUsersMu.Unlock()
+	if s.isUserEngagedNow("alice") {
+		t.Error("isUserEngagedNow(alice) = true, want false")
+	}
+}
+
+func TestIsUserEngagedNow_FalseForUnknownUser(t *testing.T) {
+	s := engagementTestHub()
+	if s.isUserEngagedNow("nobody") {
+		t.Error("isUserEngagedNow(nobody) = true, want false")
+	}
+}
+
+func TestApplyUserLastActions_UpdatesLastActionAt(t *testing.T) {
+	orig := saasUsersDir
+	saasUsersDir = filepath.Join(t.TempDir(), "users")
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasUsersDir = orig })
+
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice"})
+
+	s := engagementTestHub()
+	ts := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	s.applyUserLastActions(map[string]string{"alice": ts})
+
+	u := loadSaaSUser("alice")
+	if u == nil {
+		t.Fatal("alice not found")
+	}
+	if u.LastActionAt != ts {
+		t.Errorf("LastActionAt = %q, want %q", u.LastActionAt, ts)
+	}
+}
+
+func TestApplyUserLastActions_NeverMovesBackward(t *testing.T) {
+	orig := saasUsersDir
+	saasUsersDir = filepath.Join(t.TempDir(), "users")
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasUsersDir = orig })
+
+	newer := time.Now().UTC().Format(time.RFC3339)
+	older := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", LastActionAt: newer})
+
+	s := engagementTestHub()
+	s.applyUserLastActions(map[string]string{"alice": older})
+
+	u := loadSaaSUser("alice")
+	if u.LastActionAt != newer {
+		t.Errorf("LastActionAt moved backward: %q, want %q", u.LastActionAt, newer)
+	}
+}
+
+func TestApplyUserLastActions_SkipsUnknownUser(t *testing.T) {
+	orig := saasUsersDir
+	saasUsersDir = filepath.Join(t.TempDir(), "users")
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasUsersDir = orig })
+
+	s := engagementTestHub()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	s.applyUserLastActions(map[string]string{"ghost": ts})
+
+	if u := loadSaaSUser("ghost"); u != nil {
+		t.Error("must not create unknown users")
+	}
+}
+
+func TestApplyUserLastActions_SkipsInvalidTimestamps(t *testing.T) {
+	orig := saasUsersDir
+	saasUsersDir = filepath.Join(t.TempDir(), "users")
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasUsersDir = orig })
+
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice"})
+
+	s := engagementTestHub()
+	s.applyUserLastActions(map[string]string{"alice": "not-a-date"})
+
+	u := loadSaaSUser("alice")
+	if u.LastActionAt != "" {
+		t.Errorf("LastActionAt = %q, want empty", u.LastActionAt)
+	}
+}
+
+func TestApplyUserLastActions_NilMapNoOp(t *testing.T) {
+	s := engagementTestHub()
+	s.applyUserLastActions(nil)
+	s.applyUserLastActions(map[string]string{})
+}
+
+func TestApplyUserLastActions_SkipsInvalidUsernames(t *testing.T) {
+	orig := saasUsersDir
+	saasUsersDir = filepath.Join(t.TempDir(), "users")
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasUsersDir = orig })
+
+	s := engagementTestHub()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	s.applyUserLastActions(map[string]string{
+		"":              ts,
+		"../etc/passwd": ts,
+		"has space":     ts,
+	})
+	entries, _ := os.ReadDir(saasUsersDir)
+	if len(entries) != 0 {
+		t.Errorf("expected no user files, found %d", len(entries))
+	}
+}
+
+func TestFindContributeHive_ReturnsFirstEligible(t *testing.T) {
+	s := engagementTestHub()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "offline", Online: false, IsPublic: true, DashboardURL: "https://example.com", Owner: "u1"},
+		{ID: "private", Online: true, IsPublic: false, DashboardURL: "https://example.com", Owner: "u2"},
+		{ID: "no-url", Online: true, IsPublic: true, DashboardURL: "", Owner: "u3"},
+		{ID: "no-owner", Online: true, IsPublic: true, DashboardURL: "https://example.com", Owner: ""},
+		{ID: "eligible", Online: true, IsPublic: true, DashboardURL: "https://example.com", Owner: "u5"},
+	}
+
+	h := s.findContributeHive()
+	if h == nil {
+		t.Fatal("findContributeHive returned nil")
+	}
+	if h.ID != "eligible" {
+		t.Errorf("got %q, want eligible", h.ID)
+	}
+}
+
+func TestFindContributeHive_ReturnsNilWhenNoneEligible(t *testing.T) {
+	s := engagementTestHub()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "offline", Online: false, IsPublic: true, DashboardURL: "https://example.com", Owner: "u1"},
+	}
+	if h := s.findContributeHive(); h != nil {
+		t.Errorf("expected nil, got %+v", h)
+	}
+}
+
+func TestFindContributeHive_RejectsPrivateURLs(t *testing.T) {
+	s := engagementTestHub()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "local", Online: true, IsPublic: true, DashboardURL: "https://localhost:8080", Owner: "u1"},
+		{ID: "internal", Online: true, IsPublic: true, DashboardURL: "https://192.168.1.1", Owner: "u2"},
+	}
+	if h := s.findContributeHive(); h != nil {
+		t.Errorf("should reject private URLs, got %q", h.ID)
+	}
+}
+
+func TestHandleContributeStatus_NoHiveAvailable(t *testing.T) {
+	s := engagementTestHub()
+	s.registry.Hives = nil
+
+	req := httptest.NewRequest("GET", "/api/contribute/status", nil)
+	w := httptest.NewRecorder()
+	s.handleContributeStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["available"] != false {
+		t.Errorf("available = %v, want false", resp["available"])
+	}
+}
+
+func TestHandleContributeStatus_HiveAvailable(t *testing.T) {
+	s := engagementTestHub()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "prod-1", Name: "ProdHive", Org: "acme", Online: true, IsPublic: true,
+			DashboardURL: "https://example.com", Owner: "op"},
+	}
+
+	req := httptest.NewRequest("GET", "/api/contribute/status", nil)
+	w := httptest.NewRecorder()
+	s.handleContributeStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["available"] != true {
+		t.Errorf("available = %v, want true", resp["available"])
+	}
+	if resp["hive_id"] != "prod-1" {
+		t.Errorf("hive_id = %v, want prod-1", resp["hive_id"])
+	}
+}
+
+func TestHandleContributeProxy_NoHive(t *testing.T) {
+	s := engagementTestHub()
+	s.registry.Hives = nil
+
+	req := httptest.NewRequest("POST", "/api/contribute/register", nil)
+	w := httptest.NewRecorder()
+	s.handleContributeProxy(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestIsPrivateURL_DetectsPrivateAddresses(t *testing.T) {
+	privates := []string{
+		"https://localhost:8080/path",
+		"http://127.0.0.1:3000",
+		"https://10.0.0.1",
+		"http://172.16.0.1",
+		"http://192.168.1.100/api",
+		"https://169.254.0.1",
+		"http://0.0.0.0",
+	}
+	for _, u := range privates {
+		if !isPrivateURL(nil, u) {
+			t.Errorf("isPrivateURL(%q) = false, want true", u)
+		}
+	}
+}
+
+func TestCreditActiveSessionTime_EngagedUsersGetEngagedSeconds(t *testing.T) {
+	orig := saasUsersDir
+	saasUsersDir = filepath.Join(t.TempDir(), "users")
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasUsersDir = orig })
+
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice"})
+	saveSaaSUser(&SaaSUser{GitHubUsername: "bob"})
+
+	s := engagementTestHub()
+	prev := &RegistryEntry{LastHeartbeat: time.Now().Add(-120 * time.Second).UTC().Format(time.RFC3339)}
+	s.creditActiveSessionTime(prev, true, []string{"alice", "bob"}, []string{"alice"})
+
+	alice := loadSaaSUser("alice")
+	bob := loadSaaSUser("bob")
+	if alice.SessionSeconds < 110 {
+		t.Errorf("alice SessionSeconds = %d, want ~120", alice.SessionSeconds)
+	}
+	if alice.EngagedSeconds < 110 {
+		t.Errorf("alice EngagedSeconds = %d, want ~120", alice.EngagedSeconds)
+	}
+	if alice.LastEngagedAt == "" {
+		t.Error("alice LastEngagedAt should be set")
+	}
+	if bob.SessionSeconds < 110 {
+		t.Errorf("bob SessionSeconds = %d, want ~120", bob.SessionSeconds)
+	}
+	if bob.EngagedSeconds != 0 {
+		t.Errorf("bob EngagedSeconds = %d, want 0", bob.EngagedSeconds)
+	}
+}

--- a/v2/pkg/hub/server_handlers_coverage_test.go
+++ b/v2/pkg/hub/server_handlers_coverage_test.go
@@ -15,7 +15,7 @@ func TestHeartbeatBearerOK_LegacyRawSecret(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	secret := srv.hubSecret
 
-	if !srv.heartbeatBearerOK("Bearer " + secret) {
+	if !srv.heartbeatBearerOK("Bearer "+secret, "") {
 		t.Error("heartbeatBearerOK must accept raw master secret")
 	}
 }
@@ -27,7 +27,7 @@ func TestHeartbeatBearerOK_DerivedKey(t *testing.T) {
 		t.Fatal("heartbeatKey() returned empty — test cannot proceed")
 	}
 
-	if !srv.heartbeatBearerOK("Bearer " + derived) {
+	if !srv.heartbeatBearerOK("Bearer "+derived, "") {
 		t.Error("heartbeatBearerOK must accept derived heartbeat key")
 	}
 }
@@ -48,7 +48,7 @@ func TestHeartbeatBearerOK_InvalidTokenRejected(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if srv.heartbeatBearerOK(tc.auth) {
+			if srv.heartbeatBearerOK(tc.auth, "") {
 				t.Errorf("heartbeatBearerOK(%q) = true, want false", tc.auth)
 			}
 		})

--- a/v2/pkg/hub/server_pure_helpers_test.go
+++ b/v2/pkg/hub/server_pure_helpers_test.go
@@ -1,0 +1,350 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// ============================================================
+// downsampleSpark
+// ============================================================
+
+func TestDownsampleSpark_NilAndEmpty(t *testing.T) {
+	if got := downsampleSpark(nil, 5); got != nil {
+		t.Errorf("nil input: got %v, want nil", got)
+	}
+	if got := downsampleSpark([]SparkPoint{}, 5); len(got) != 0 {
+		t.Errorf("empty input: got %v, want empty", got)
+	}
+}
+
+func TestDownsampleSpark_MaxZeroOrNegative(t *testing.T) {
+	pts := []SparkPoint{{V: 1}, {V: 2}}
+	if got := downsampleSpark(pts, 0); got != nil {
+		t.Errorf("max=0: got %v, want nil", got)
+	}
+	if got := downsampleSpark(pts, -1); got != nil {
+		t.Errorf("max=-1: got %v, want nil", got)
+	}
+}
+
+func TestDownsampleSpark_BelowMax(t *testing.T) {
+	pts := []SparkPoint{{V: 1}, {V: 2}, {V: 3}}
+	got := downsampleSpark(pts, 10)
+	if len(got) != 3 {
+		t.Errorf("below max: got %d points, want 3", len(got))
+	}
+}
+
+func TestDownsampleSpark_ExactMax(t *testing.T) {
+	pts := []SparkPoint{{V: 1}, {V: 2}, {V: 3}}
+	got := downsampleSpark(pts, 3)
+	if len(got) != 3 {
+		t.Errorf("exact max: got %d points, want 3", len(got))
+	}
+}
+
+func TestDownsampleSpark_ReducesToMax(t *testing.T) {
+	pts := make([]SparkPoint, 100)
+	for i := range pts {
+		pts[i] = SparkPoint{V: i}
+	}
+	got := downsampleSpark(pts, 10)
+	if len(got) != 10 {
+		t.Fatalf("got %d points, want 10", len(got))
+	}
+	if got[0].V != 0 {
+		t.Errorf("first point V = %v, want 0", got[0].V)
+	}
+	if got[9].V != 99 {
+		t.Errorf("last point V = %v, want 99", got[9].V)
+	}
+}
+
+func TestDownsampleSpark_MaxOne(t *testing.T) {
+	pts := []SparkPoint{{V: 10}, {V: 20}, {V: 30}}
+	got := downsampleSpark(pts, 1)
+	if len(got) != 1 {
+		t.Fatalf("max=1: got %d, want 1", len(got))
+	}
+	if got[0].V != 10 {
+		t.Errorf("max=1: V = %v, want first point (10)", got[0].V)
+	}
+}
+
+// ============================================================
+// sanitizeField
+// ============================================================
+
+func TestSanitizeField_Basic(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"empty", "", ""},
+		{"plain text", "hello", "hello"},
+		{"trims whitespace", "  hello  ", "hello"},
+		{"escapes HTML", "<script>alert(1)</script>", "&lt;script&gt;alert(1)&lt;/script&gt;"},
+		{"ampersand", "a & b", "a &amp; b"},
+		{"quotes", `say "hi"`, "say &#34;hi&#34;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeField(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeField(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeField_TruncatesAt200Runes(t *testing.T) {
+	long := strings.Repeat("a", 250)
+	got := sanitizeField(long)
+	if len([]rune(got)) != 200 {
+		t.Errorf("expected 200 runes, got %d", len([]rune(got)))
+	}
+}
+
+func TestSanitizeField_MultibyteTruncation(t *testing.T) {
+	long := strings.Repeat("\u65e5", 250)
+	got := sanitizeField(long)
+	if len([]rune(got)) != 200 {
+		t.Errorf("multibyte: expected 200 runes, got %d", len([]rune(got)))
+	}
+}
+
+// ============================================================
+// normalizeForgeHost
+// ============================================================
+
+func TestNormalizeForgeHost(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantHost string
+		wantOK   bool
+	}{
+		{"github.com", "github.com", true},
+		{"https://github.com", "github.com", true},
+		{"https://github.com/", "github.com", true},
+		{"GITHUB.COM", "github.com", true},
+		{"github.ibm.com", "github.ibm.com", true},
+		{"https://github.ibm.com/", "github.ibm.com", true},
+		{"  https://GitHub.Enterprise.org  ", "github.enterprise.org", true},
+		{"", "", false},
+		{"   ", "", false},
+	}
+	for _, tc := range cases {
+		host, ok := normalizeForgeHost(tc.in)
+		if host != tc.wantHost || ok != tc.wantOK {
+			t.Errorf("normalizeForgeHost(%q) = (%q, %v), want (%q, %v)", tc.in, host, ok, tc.wantHost, tc.wantOK)
+		}
+	}
+}
+
+// ============================================================
+// normalizeOrgRef
+// ============================================================
+
+func TestNormalizeOrgRef(t *testing.T) {
+	cases := []struct {
+		in                string
+		wantHost, wantOrg string
+	}{
+		{"", "", ""},
+		{"  ", "", ""},
+		{"myorg", "", "myorg"},
+		{"github.com/myorg", "github.com", "myorg"},
+		{"https://github.ibm.com/myorg", "github.ibm.com", "myorg"},
+		{"http://github.ibm.com/myorg/", "github.ibm.com", "myorg"},
+		{"github.com", "github.com", ""},
+		{"github.ibm.com", "github.ibm.com", ""},
+		{"my.org", "", "my.org"},
+	}
+	for _, tc := range cases {
+		host, org := normalizeOrgRef(tc.in)
+		if host != tc.wantHost || org != tc.wantOrg {
+			t.Errorf("normalizeOrgRef(%q) = (%q, %q), want (%q, %q)", tc.in, host, org, tc.wantHost, tc.wantOrg)
+		}
+	}
+}
+
+// ============================================================
+// normalizeProjectRef
+// ============================================================
+
+func TestNormalizeProjectRef(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantHost  string
+		wantOrg   string
+		wantRepos []string
+	}{
+		{"", "", "", nil},
+		{"  ", "", "", nil},
+		{"myorg/repo", "", "myorg", []string{"repo"}},
+		{"https://github.com/org/repo", "github.com", "org", []string{"repo"}},
+		{"github.ibm.com/org/repo.git", "github.ibm.com", "org", []string{"repo"}},
+		{"https://github.com/org/repo/", "github.com", "org", []string{"repo"}},
+		{"github.com", "github.com", "", nil},
+		{"github.com/org", "github.com", "org", nil},
+	}
+	for _, tc := range cases {
+		host, org, repos := normalizeProjectRef(tc.in)
+		if host != tc.wantHost || org != tc.wantOrg {
+			t.Errorf("normalizeProjectRef(%q) host/org = (%q, %q), want (%q, %q)", tc.in, host, org, tc.wantHost, tc.wantOrg)
+		}
+		if len(repos) != len(tc.wantRepos) {
+			t.Errorf("normalizeProjectRef(%q) repos = %v, want %v", tc.in, repos, tc.wantRepos)
+			continue
+		}
+		for i := range repos {
+			if repos[i] != tc.wantRepos[i] {
+				t.Errorf("normalizeProjectRef(%q) repos[%d] = %q, want %q", tc.in, i, repos[i], tc.wantRepos[i])
+			}
+		}
+	}
+}
+
+// ============================================================
+// validateSingleRepoHost
+// ============================================================
+
+func TestValidateSingleRepoHost_AllSameHost(t *testing.T) {
+	err := validateSingleRepoHost("github.ibm.com", "github.ibm.com/org/main-repo", []string{
+		"github.ibm.com/org/other",
+		"bare-repo",
+		"owner/repo",
+	})
+	if err != nil {
+		t.Errorf("all same host: unexpected error: %v", err)
+	}
+}
+
+func TestValidateSingleRepoHost_MismatchedRepo(t *testing.T) {
+	err := validateSingleRepoHost("github.ibm.com", "", []string{
+		"github.com/other-org/repo",
+	})
+	if err == nil {
+		t.Error("expected error for mismatched host")
+	}
+	if !strings.Contains(err.Error(), "github.com") {
+		t.Errorf("error should mention the offending host, got: %v", err)
+	}
+}
+
+func TestValidateSingleRepoHost_PublicHostAllowsBareRepos(t *testing.T) {
+	err := validateSingleRepoHost("", "org/repo", []string{"bare-repo", "other/thing"})
+	if err != nil {
+		t.Errorf("public host with bare repos: unexpected error: %v", err)
+	}
+}
+
+func TestValidateSingleRepoHost_EmptyRepos(t *testing.T) {
+	err := validateSingleRepoHost("github.ibm.com", "", nil)
+	if err != nil {
+		t.Errorf("no repos: unexpected error: %v", err)
+	}
+}
+
+func TestValidateSingleRepoHost_PrimaryRepoMismatch(t *testing.T) {
+	err := validateSingleRepoHost("github.ibm.com", "github.com/org/repo", nil)
+	if err == nil {
+		t.Error("expected error when primary repo is on different host")
+	}
+}
+
+// ============================================================
+// isValidRepoRef
+// ============================================================
+
+func TestIsValidRepoRef(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"repo", true},
+		{"owner/repo", true},
+		{"my-repo_v2.1", true},
+		{"", false},
+		{"a/b/c", false},
+		{strings.Repeat("x", 202), false},
+		{"has space", false},
+		{"has:colon", false},
+	}
+	for _, tc := range cases {
+		got := isValidRepoRef(tc.in)
+		if got != tc.want {
+			t.Errorf("isValidRepoRef(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ============================================================
+// sanitizeProseField
+// ============================================================
+
+func TestSanitizeProseField(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"strips angle brackets", "hello <b>world</b>", "hello bworld/b"},
+		{"strips ampersand", "a & b", "a b"},
+		{"strips backticks", "use `foo`", "use foo"},
+		{"newlines become spaces", "line1\nline2\rline3", "line1 line2 line3"},
+		{"collapses whitespace", "too    much   space", "too much space"},
+		{"trims result", "  hello  ", "hello"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeProseField(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeProseField(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeProseField_TruncatesAtMaxRunes(t *testing.T) {
+	long := strings.Repeat("x", 600)
+	got := sanitizeProseField(long)
+	if len([]rune(got)) != maxProseFieldRunes {
+		t.Errorf("expected %d runes, got %d", maxProseFieldRunes, len([]rune(got)))
+	}
+}
+
+func TestSanitizeProseField_ControlCharsStripped(t *testing.T) {
+	// ESC sequences and NUL should be removed
+	input := "hello\x00world\x1b[31mred"
+	got := sanitizeProseField(input)
+	if strings.ContainsAny(got, "\x00\x1b") {
+		t.Errorf("control chars not stripped: %q", got)
+	}
+	if !strings.Contains(got, "hello") || !strings.Contains(got, "world") {
+		t.Errorf("readable text should survive: %q", got)
+	}
+}
+
+// ============================================================
+// sanitizeImageRef
+// ============================================================
+
+func TestSanitizeImageRef(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"ghcr.io/kubestellar/hive:v2-latest", "ghcr.io/kubestellar/hive:v2-latest"},
+		{"registry:5000/org/repo:tag", "registry:5000/org/repo:tag"},
+		{"repo@sha256:abc123", "repo@sha256:abc123"},
+		{"has spaces and <html>", "hasspacesandhtml"},
+		{"normal-image_v1.2/path", "normal-image_v1.2/path"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := sanitizeImageRef(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeImageRef(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/v2/pkg/hub/server_test.go
+++ b/v2/pkg/hub/server_test.go
@@ -32,7 +32,7 @@ func TestServerHeartbeatBearerOKSecurityContract(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := srv.heartbeatBearerOK(tt.auth); got != tt.want {
+			if got := srv.heartbeatBearerOK(tt.auth, ""); got != tt.want {
 				t.Errorf("heartbeatBearerOK(%q) = %v, want %v", tt.auth, got, tt.want)
 			}
 		})
@@ -41,7 +41,7 @@ func TestServerHeartbeatBearerOKSecurityContract(t *testing.T) {
 
 func TestServerHeartbeatBearerOKEmptySecretCurrentBehavior(t *testing.T) {
 	srv := &HubServer{}
-	if !srv.heartbeatBearerOK("Bearer ") {
+	if !srv.heartbeatBearerOK("Bearer ", "") {
 		t.Fatal("heartbeatBearerOK with an empty hubSecret currently accepts an empty bearer; keep the caller-side guard in place")
 	}
 }

--- a/v2/pkg/hub/server_test.go
+++ b/v2/pkg/hub/server_test.go
@@ -1,0 +1,273 @@
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestServerHeartbeatBearerOKSecurityContract(t *testing.T) {
+	srv := &HubServer{hubSecret: "test-master-secret"}
+	derived := srv.heartbeatKey()
+	if derived == "" || derived == srv.hubSecret {
+		t.Fatalf("derived heartbeat key = %q, want non-empty value distinct from raw secret", derived)
+	}
+
+	tests := []struct {
+		name string
+		auth string
+		want bool
+	}{
+		{name: "legacy raw bearer", auth: "Bearer " + srv.hubSecret, want: true},
+		{name: "derived heartbeat bearer", auth: "Bearer " + derived, want: true},
+		{name: "missing header", auth: "", want: false},
+		{name: "missing bearer scheme", auth: srv.hubSecret, want: false},
+		{name: "lowercase scheme rejected", auth: "bearer " + srv.hubSecret, want: false},
+		{name: "wrong token", auth: "Bearer wrong", want: false},
+		{name: "extra leading token space", auth: "Bearer  " + srv.hubSecret, want: false},
+		{name: "extra trailing token space", auth: "Bearer " + srv.hubSecret + " ", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := srv.heartbeatBearerOK(tt.auth); got != tt.want {
+				t.Errorf("heartbeatBearerOK(%q) = %v, want %v", tt.auth, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerHeartbeatBearerOKEmptySecretCurrentBehavior(t *testing.T) {
+	srv := &HubServer{}
+	if !srv.heartbeatBearerOK("Bearer ") {
+		t.Fatal("heartbeatBearerOK with an empty hubSecret currently accepts an empty bearer; keep the caller-side guard in place")
+	}
+}
+
+func TestServerIsPrivateURLSSRFGuard(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "loopback localhost", url: "https://localhost/api", want: true},
+		{name: "loopback ipv4", url: "http://127.0.0.1:8080", want: true},
+		{name: "link local metadata", url: "http://169.254.169.254/latest/meta-data", want: true},
+		{name: "rfc1918 ten dot", url: "http://10.20.30.40", want: true},
+		{name: "rfc1918172", url: "http://172.31.255.255", want: true},
+		{name: "rfc1918 192", url: "http://192.168.1.10", want: true},
+		{name: "ipv6 loopback", url: "http://[::1]:8080", want: true},
+		{name: "ipv6 ula fails closed", url: "http://[fd00::1]", want: true},
+		{name: "dot local fails closed", url: "http://printer.local/status", want: true},
+		{name: "hostname resolves to loopback", url: "http://lvh.me/dashboard", want: true},
+		{name: "public ipv4", url: "https://8.8.8.8/dns-query", want: false},
+		{name: "public hostname", url: "https://example.com", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+			if got := isPrivateURL(ctx, tt.url); got != tt.want {
+				t.Errorf("isPrivateURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerHubBannersPersistenceRoundTripAndPrune(t *testing.T) {
+	orig := hubBannersPath
+	hubBannersPath = filepath.Join(t.TempDir(), "hub-banners.json")
+	t.Cleanup(func() { hubBannersPath = orig })
+
+	now := time.Now().UTC()
+	saved := &HubServer{logger: slog.Default(), hubBanners: map[string]*HubBannerEntry{
+		"fresh": {ID: "fresh-banner", Message: "maintenance tonight", Color: "amber", SentAt: now.Format(time.RFC3339)},
+		"stale": {ID: "stale-banner", Message: "old news", Color: "gray", SentAt: now.Add(-hubBannerMaxAge - time.Minute).Format(time.RFC3339)},
+	}}
+	saved.saveHubBanners()
+
+	loaded := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	loaded.loadHubBanners()
+	if len(loaded.hubBanners) != 1 {
+		t.Fatalf("loaded %d banners, want only the fresh one: %+v", len(loaded.hubBanners), loaded.hubBanners)
+	}
+	got := loaded.hubBanners["fresh"]
+	if got == nil {
+		t.Fatalf("fresh banner was not restored: %+v", loaded.hubBanners)
+	}
+	if got.ID != "fresh-banner" || got.Message != "maintenance tonight" || got.Color != "amber" {
+		t.Errorf("restored banner = %+v, want id/message/color preserved", got)
+	}
+	if _, ok := loaded.hubBanners["stale"]; ok {
+		t.Fatalf("stale banner was not pruned: %+v", loaded.hubBanners)
+	}
+
+	reloaded := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	reloaded.loadHubBanners()
+	if len(reloaded.hubBanners) != 1 || reloaded.hubBanners["fresh"] == nil {
+		t.Errorf("pruned banner file did not persist, reloaded map = %+v", reloaded.hubBanners)
+	}
+}
+
+func TestServerLoadHubBannersMissingAndInvalidFiles(t *testing.T) {
+	orig := hubBannersPath
+	hubBannersPath = filepath.Join(t.TempDir(), "hub-banners.json")
+	t.Cleanup(func() { hubBannersPath = orig })
+
+	srv := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	srv.loadHubBanners()
+	if len(srv.hubBanners) != 0 {
+		t.Fatalf("missing banner file loaded %+v, want empty map", srv.hubBanners)
+	}
+
+	if err := os.WriteFile(hubBannersPath, []byte("{"), 0o644); err != nil {
+		t.Fatalf("write invalid banner file: %v", err)
+	}
+	srv.hubBanners["existing"] = &HubBannerEntry{ID: "keep"}
+	srv.loadHubBanners()
+	if got := srv.hubBanners["existing"]; got == nil || got.ID != "keep" {
+		t.Errorf("invalid persisted JSON should leave existing in-memory banners untouched, got %+v", srv.hubBanners)
+	}
+}
+
+func TestServerHubBannersPersistenceErrorPaths(t *testing.T) {
+	orig := hubBannersPath
+	t.Cleanup(func() { hubBannersPath = orig })
+
+	t.Run("save mkdir failure is non-fatal", func(t *testing.T) {
+		parentFile := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(parentFile, []byte("file"), 0o644); err != nil {
+			t.Fatalf("write parent file: %v", err)
+		}
+		hubBannersPath = filepath.Join(parentFile, "hub-banners.json")
+		srv := &HubServer{logger: slog.Default(), hubBanners: map[string]*HubBannerEntry{
+			"hive": {ID: "banner", SentAt: time.Now().UTC().Format(time.RFC3339)},
+		}}
+		srv.saveHubBanners()
+	})
+
+	t.Run("save write failure is non-fatal", func(t *testing.T) {
+		dir := t.TempDir()
+		hubBannersPath = filepath.Join(dir, "hub-banners.json")
+		if err := os.Mkdir(hubBannersPath+".tmp", 0o755); err != nil {
+			t.Fatalf("create tmp-path directory: %v", err)
+		}
+		srv := &HubServer{logger: slog.Default(), hubBanners: map[string]*HubBannerEntry{
+			"hive": {ID: "banner", SentAt: time.Now().UTC().Format(time.RFC3339)},
+		}}
+		srv.saveHubBanners()
+	})
+
+	t.Run("save rename failure is non-fatal", func(t *testing.T) {
+		hubBannersPath = t.TempDir()
+		srv := &HubServer{logger: slog.Default(), hubBanners: map[string]*HubBannerEntry{
+			"hive": {ID: "banner", SentAt: time.Now().UTC().Format(time.RFC3339)},
+		}}
+		srv.saveHubBanners()
+	})
+
+	t.Run("load read failure is non-fatal", func(t *testing.T) {
+		hubBannersPath = t.TempDir()
+		srv := &HubServer{logger: slog.Default(), hubBanners: map[string]*HubBannerEntry{
+			"existing": {ID: "keep"},
+		}}
+		srv.loadHubBanners()
+		if got := srv.hubBanners["existing"]; got == nil || got.ID != "keep" {
+			t.Errorf("read failure should leave in-memory banners untouched, got %+v", srv.hubBanners)
+		}
+	})
+}
+
+func TestServerComputeFleetStatsPriorityScenarios(t *testing.T) {
+	count := func(v int) *int { return &v }
+	now := time.Now()
+
+	tests := []struct {
+		name  string
+		hives []RegistryEntry
+		want  FleetStats
+	}{
+		{name: "empty fleet", want: FleetStats{}},
+		{
+			name: "mixed assigned available offline and private hives",
+			hives: []RegistryEntry{
+				{ID: "available", Org: placeholderOrgPrefix + "pool", Online: true, ProvStatus: statusAvailable, Repos: []string{"ignored"}, PRsMerged90d: count(99)},
+				{ID: "offline", Org: "team", Online: false, Repos: []string{"offline"}, PRsMerged90d: count(99)},
+				{ID: "private", Org: "team", Online: true, IsPublic: false, Repos: []string{"repo", "team/repo", "other/repo"}, AgentCount: 2, ContributorCount: 5, ActiveContributors: 1, PRsMerged90d: count(7), PRsRejected90d: count(2), CVEsClosed: count(1), FleetStatsCollectedAt: now},
+				{ID: "repoless", Org: "team", Online: true, IsPublic: true, AgentCount: 1, ContributorCount: 3, ActiveContributors: 2},
+			},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 7, PRsRejected: 2, CVEsClosed: 1, Hives: 2, TotalHives: 3, AvailableHives: 1, AgentsRunning: 3, Contributors: 3, ContributorsTotal: 8, Reporting: 1, Eligible: 1},
+		},
+		{
+			name: "stale count is excluded but eligible and visible",
+			hives: []RegistryEntry{
+				{ID: "fresh", Org: "team", Online: true, Repos: []string{"fresh"}, PRsMerged90d: count(4), FleetStatsCollectedAt: now},
+				{ID: "stale", Org: "team", Online: true, Repos: []string{"stale"}, PRsMerged90d: count(100), FleetStatsCollectedAt: now.Add(-2 * fleetStatsMaxAge)},
+			},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 4, Hives: 2, TotalHives: 2, Reporting: 1, Eligible: 2, Stale: 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &HubServer{logger: slog.Default()}
+			srv.registry.Hives = tt.hives
+			if got := srv.computeFleetStats(); got != tt.want {
+				t.Errorf("computeFleetStats() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerPureSanitizersAndRepoHelpers(t *testing.T) {
+	t.Run("heartbeat field strips unsafe characters", func(t *testing.T) {
+		if got := sanitizeHeartbeatField("ok_1/branch.<script>alert(1)</script>\n"); got != "ok_1/branch.scriptalert1/script" {
+			t.Errorf("sanitizeHeartbeatField returned %q", got)
+		}
+	})
+
+	t.Run("prose field preserves readable text while dropping markup", func(t *testing.T) {
+		got := sanitizeProseField("The GitHub App <b>failed</b> & needs `repair`.\nTry again.")
+		want := "The GitHub App bfailed/b needs repair. Try again."
+		if got != want {
+			t.Errorf("sanitizeProseField() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("image ref keeps OCI separators only", func(t *testing.T) {
+		got := sanitizeImageRef(" ghcr.io/kubestellar/hive:v2-latest@sha256:abc<script>")
+		want := "ghcr.io/kubestellar/hive:v2-latest@sha256:abcscript"
+		if got != want {
+			t.Errorf("sanitizeImageRef() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("repo entry normalizes pasted URLs", func(t *testing.T) {
+		tests := map[string]string{
+			"https://github.ibm.com/org/repo.git": "org/repo",
+			"github.com/org/team/repo":            "team/repo",
+			" /already/owner/repo/ ":              "owner/repo",
+			"single-repo":                         "single-repo",
+		}
+		for in, want := range tests {
+			if got := sanitizeRepoEntry(in); got != want {
+				t.Errorf("sanitizeRepoEntry(%q) = %q, want %q", in, got, want)
+			}
+		}
+	})
+
+	t.Run("enterprise API URL derived only for non-public GitHub hosts", func(t *testing.T) {
+		tests := map[string]string{
+			"":               "",
+			"github.com":     "",
+			"api.github.com": "",
+			"GitHub.IBM.com": "https://github.ibm.com/api/v3",
+		}
+		for in, want := range tests {
+			if got := gheAPIURLForHost(in); got != want {
+				t.Errorf("gheAPIURLForHost(%q) = %q, want %q", in, got, want)
+			}
+		}
+	})
+}

--- a/v2/pkg/hub/session_cookie_dual_test.go
+++ b/v2/pkg/hub/session_cookie_dual_test.go
@@ -1,0 +1,120 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+)
+
+// N2 (CWE-321/798) on v2, with DUAL-FORMAT minting.
+//
+// The hub cannot simply switch to Ed25519 here: a v2 spoke's proxy verifies
+// HMAC and only HMAC (see F3/#3243), so an Ed25519-only cookie would 401 the
+// terminal on every v2 spoke in the fleet. It also cannot stay HMAC-only,
+// because that key is symmetric AND provisioned into every spoke — any spoke
+// operator can mint `clubanderson.<sig>` and obtain hub admin.
+//
+// So the hub emits BOTH: `hive_hub_user` (HMAC, universally verifiable) and
+// `hive_hub_user_v2` (Ed25519, unforgeable by a spoke). Verifiers prefer the
+// asymmetric one; a spoke that does not know the name ignores it.
+
+const n2v2Master = "test-master-n2-v2"
+
+func n2v2Hub() *HubServer { return &HubServer{hubSecret: n2v2Master} }
+
+// v2SpokeVerify mirrors the v2 proxy's verifier EXACTLY (HMAC over the
+// username, base64url-unpadded) so this test fails if the hub ever mints
+// something that proxy cannot read.
+func v2SpokeVerify(sessionKey, value string) string {
+	if sessionKey == "" || value == "" {
+		return ""
+	}
+	idx := -1
+	for i := len(value) - 1; i >= 0; i-- {
+		if value[i] == '.' {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 || idx == len(value)-1 {
+		return ""
+	}
+	user, sig := value[:idx], value[idx+1:]
+	mac := hmac.New(sha256.New, []byte(sessionKey))
+	mac.Write([]byte(user))
+	if base64.RawURLEncoding.EncodeToString(mac.Sum(nil)) != sig {
+		return ""
+	}
+	return user
+}
+
+// TestDualMint_V2SpokeCanVerifyTheHMACCookie is the compatibility guarantee.
+// If this breaks, every v2 spoke's terminal 401s.
+func TestDualMint_V2SpokeCanVerifyTheHMACCookie(t *testing.T) {
+	s := n2v2Hub()
+	hmacCookie := mintHubUserCookieValue(s.sessionCookieKey(), "alice")
+	if got := v2SpokeVerify(s.sessionCookieKey(), hmacCookie); got != "alice" {
+		t.Fatalf("a v2 spoke could not verify the hub's HMAC cookie (got %q) — "+
+			"every v2 spoke's terminal would 401", got)
+	}
+}
+
+// TestDualMint_Ed25519CookieIsUnforgeableByASpoke is the finding itself.
+func TestDualMint_Ed25519CookieIsUnforgeableByASpoke(t *testing.T) {
+	s := n2v2Hub()
+	pub := s.sessionPublicKey()
+	if pub == "" {
+		t.Fatal("public key derivation returned empty")
+	}
+	// A spoke holding only the public key tries to mint an admin cookie.
+	forged := mintHubUserCookieValueV2(pub, hubAdminUsername)
+	if forged != "" {
+		if u, ok := verifyHubUserCookieValueV2(pub, forged); ok {
+			t.Fatalf("N2: a spoke forged a VERIFIABLE admin cookie (%q) from the public key", u)
+		}
+	}
+	// The hub's own mint verifies.
+	real := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+	if u, ok := verifyHubUserCookieValueV2(pub, real); !ok || u != "alice" {
+		t.Fatalf("hub-minted Ed25519 cookie failed to verify: %q %v", u, ok)
+	}
+}
+
+// TestDualMint_HubPrefersAsymmetric: when both cookies are present the
+// asymmetric one must win, or the stronger credential is decorative.
+func TestDualMint_HubPrefersAsymmetric(t *testing.T) {
+	s := n2v2Hub()
+	ed := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+	if u, ok := s.verifyHubUserDual(ed); !ok || u != "alice" {
+		t.Fatalf("verifyHubUserDual rejected the Ed25519 value: %q %v", u, ok)
+	}
+	// And the legacy paths still work during rollout.
+	if u, ok := s.verifyHubUserDual(mintHubUserCookieValue(s.sessionCookieKey(), "bob")); !ok || u != "bob" {
+		t.Error("derived-key HMAC cookie rejected — existing sessions would break")
+	}
+	if u, ok := s.verifyHubUserDual(mintHubUserCookieValue(n2v2Master, "carol")); !ok || u != "carol" {
+		t.Error("raw-master HMAC cookie rejected — v2 spokes mint against this")
+	}
+}
+
+// TestDualMint_FormatsAreDistinguishable guards the reason for two cookie NAMES
+// rather than one hybrid value: each verifier signs over the whole prefix, so no
+// single concatenation satisfies both.
+func TestDualMint_FormatsAreDistinguishable(t *testing.T) {
+	s := n2v2Hub()
+	hmacCookie := mintHubUserCookieValue(s.sessionCookieKey(), "alice")
+	ed := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
+
+	if hubCookieIsV2(hmacCookie) {
+		t.Error("an HMAC cookie was misidentified as v2")
+	}
+	if !hubCookieIsV2(ed) {
+		t.Error("an Ed25519 cookie was not identified as v2")
+	}
+	// The v2 spoke's HMAC verifier must REJECT the Ed25519 value rather than
+	// mis-parsing a username out of it.
+	if got := v2SpokeVerify(s.sessionCookieKey(), ed); got != "" {
+		t.Errorf("a v2 spoke extracted %q from an Ed25519 cookie — it must reject it outright", got)
+	}
+}

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -630,6 +630,11 @@ func (k *KnowledgeAPI) Layers() []LayerType {
 // repo (sparse if subpath is set), indexes the markdown files, and starts a
 // periodic sync loop. Any layer level can have git sources.
 func (k *KnowledgeAPI) ConnectGitSource(ctx context.Context, config GitSourceConfig) error {
+	config.URL = strings.TrimSpace(config.URL)
+	if err := ValidateGitSourceURL(config.URL); err != nil {
+		return fmt.Errorf("invalid git source url: %w", err)
+	}
+
 	k.mu.RLock()
 	for _, gs := range k.gitSources {
 		if gs.Config().URL == config.URL && gs.Config().Subpath == config.Subpath {

--- a/v2/pkg/knowledge/api_coverage2_test.go
+++ b/v2/pkg/knowledge/api_coverage2_test.go
@@ -87,7 +87,7 @@ func TestKnowledgeAPI_ListGetReimportDeleteDocument(t *testing.T) {
 	api, vaultDir := apiWithVault(t)
 
 	storageBase := t.TempDir()
-	srcFile := filepath.Join(t.TempDir(), "doc.txt")
+	srcFile := filepath.Join(storageBase, "doc.txt")
 	if err := os.WriteFile(srcFile, []byte("Para one.\n\nPara two."), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -44,6 +44,7 @@ type DocumentSource struct {
 	config         DocSourceConfig
 	metadata       DocMetadata
 	storageDir     string
+	knowledgeDir   string
 	vaultDir       string
 	graphStore     *GraphStore
 	logger         *slog.Logger
@@ -57,6 +58,7 @@ func NewDocumentSource(config DocSourceConfig, baseDir, vaultDir string, graphSt
 		slug:           slug,
 		config:         config,
 		storageDir:     filepath.Join(baseDir, docStorageDir, slug),
+		knowledgeDir:   baseDir,
 		vaultDir:       vaultDir,
 		graphStore:     graphStore,
 		logger:         logger,
@@ -126,6 +128,9 @@ func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {
 			return nil, fmt.Errorf("fetching URL: %w", err)
 		}
 	} else if ds.config.FilePath != "" {
+		if err := ds.validateFilePath(ds.config.FilePath); err != nil {
+			return nil, err
+		}
 		content, err = os.ReadFile(ds.config.FilePath)
 		if err != nil {
 			return nil, fmt.Errorf("reading file: %w", err)
@@ -258,6 +263,43 @@ func (ds *DocumentSource) fetchURL(ctx context.Context, url string) ([]byte, str
 		ct = detectContentType(url)
 	}
 	return body, normalizeContentType(ct), nil
+}
+
+// allowedFilePrefixes is the list of directory prefixes from which the hive
+// may read local documents. Restricting to /data/knowledge prevents an
+// authenticated caller from using file_path to read arbitrary server files
+// (e.g. /data/hive.yaml, /secrets/*, /etc/passwd).
+// Tests that use a DocumentSource with a file outside the knowledge dir must
+// override this variable for the duration of the test.
+var allowedFilePrefixes = []string{localKnowledgeDir + "/"}
+
+// validateLocalFilePath rejects any file_path that falls outside the
+// allowed knowledge directory. The path is cleaned before comparison to
+// block ../ traversal.
+func validateLocalFilePath(path string) error {
+	clean := filepath.Clean(path)
+	for _, prefix := range allowedFilePrefixes {
+		if strings.HasPrefix(clean, prefix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("file_path %q is outside the allowed knowledge directory (%s)", path, localKnowledgeDir)
+}
+
+// validateFilePath checks the file_path on this DocumentSource. Uses the
+// instance's knowledgeDir (set at construction time) when available, so that
+// unit tests constructing a DocumentSource with a temporary baseDir get their
+// correct prefix automatically. Falls back to the global allowedFilePrefixes.
+func (ds *DocumentSource) validateFilePath(path string) error {
+	if ds.knowledgeDir != "" {
+		clean := filepath.Clean(path)
+		prefix := ds.knowledgeDir + string(filepath.Separator)
+		if strings.HasPrefix(clean, prefix) {
+			return nil
+		}
+		return fmt.Errorf("file_path %q is outside the allowed knowledge directory (%s)", path, ds.knowledgeDir)
+	}
+	return validateLocalFilePath(path)
 }
 
 func (ds *DocumentSource) parseContent(content []byte, contentType string) ([]DocChunk, string) {

--- a/v2/pkg/knowledge/docsource_test.go
+++ b/v2/pkg/knowledge/docsource_test.go
@@ -17,8 +17,11 @@ func TestDocumentSource_ImportFile(t *testing.T) {
 	vaultDir := filepath.Join(tmpDir, "vault")
 	baseDir := filepath.Join(tmpDir, "knowledge")
 
-	srcFile := filepath.Join(tmpDir, "test.txt")
+	srcFile := filepath.Join(baseDir, "test.txt")
 	content := "First paragraph about transformers.\n\nSecond paragraph about attention mechanisms.\n\nThird paragraph about KV cache management."
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(srcFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +119,10 @@ func TestDocumentSource_Delete(t *testing.T) {
 	vaultDir := filepath.Join(tmpDir, "vault")
 	baseDir := filepath.Join(tmpDir, "knowledge")
 
-	srcFile := filepath.Join(tmpDir, "test.txt")
+	srcFile := filepath.Join(baseDir, "test.txt")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(srcFile, []byte("Some content to import."), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +165,10 @@ func TestDocumentSource_Reimport(t *testing.T) {
 	vaultDir := filepath.Join(tmpDir, "vault")
 	baseDir := filepath.Join(tmpDir, "knowledge")
 
-	srcFile := filepath.Join(tmpDir, "test.txt")
+	srcFile := filepath.Join(baseDir, "test.txt")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(srcFile, []byte("Version 1 content."), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -273,7 +274,43 @@ func ValidateGitSourceURL(raw string) error {
 		return fmt.Errorf("git URL must not contain git transport helper separator")
 	}
 
+	// SSRF: reject private/loopback/link-local hosts so a git knowledge source
+	// can't be pointed at the pod network, internal services, or the cloud
+	// metadata endpoint (169.254.169.254). Mirrors the document-import guard.
+	// Operators running a legitimately-internal Git server (e.g. an in-cluster
+	// GitLab) set HIVE_ALLOW_PRIVATE_GIT_SOURCE=true to opt in; default is
+	// fail-closed.
+	if !allowPrivateGitSource() && gitSourceHostIsPrivate(parsed.Hostname()) {
+		return fmt.Errorf("git URL host resolves to a private/internal address (set HIVE_ALLOW_PRIVATE_GIT_SOURCE=true for an internal Git server)")
+	}
+
 	return nil
+}
+
+// allowPrivateGitSource reports whether a git knowledge source pointing at a
+// private/internal address is permitted. Default false (fail-closed).
+func allowPrivateGitSource() bool {
+	return os.Getenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE") == "true"
+}
+
+// gitSourceHostIsPrivate reports whether host is a loopback/private/link-local
+// literal IP or "localhost". A hostname that is not an IP literal is treated as
+// public here (DNS is not resolved at validation time to avoid a rebinding
+// TOCTOU); the fail-closed default plus the operator-only config surface bound
+// the exposure.
+func gitSourceHostIsPrivate(host string) bool {
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	if host == "" || host == "localhost" {
+		return host == "localhost"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
 }
 
 func isSCPStyleGitURL(raw string) bool {

--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,8 @@ import (
 const (
 	// gitSourceCloneTimeout caps how long the initial clone can take.
 	gitSourceCloneTimeout = 120 * time.Second
+
+	gitAllowedProtocols = "https:http"
 
 	// gitSourceSyncInterval is how often we pull updates from the remote.
 	gitSourceSyncInterval = 5 * time.Minute
@@ -49,6 +52,7 @@ type GitSource struct {
 // NewGitSource creates a git source. Call Init() to clone the repo and start
 // the FileStore. The clone lands under baseDir/git-sources/<slug>.
 func NewGitSource(config GitSourceConfig, baseDir string, logger *slog.Logger) *GitSource {
+	config.URL = strings.TrimSpace(config.URL)
 	slug := gitSourceSlug(config.URL, config.Subpath)
 	cloneDir := filepath.Join(baseDir, gitSourceCacheDir, slug)
 
@@ -71,6 +75,10 @@ func NewGitSource(config GitSourceConfig, baseDir string, logger *slog.Logger) *
 
 // Init clones the repo (or reuses an existing clone) and creates the FileStore.
 func (g *GitSource) Init(ctx context.Context) error {
+	if err := ValidateGitSourceURL(g.config.URL); err != nil {
+		return fmt.Errorf("git source %s: invalid url: %w", g.config.Name, err)
+	}
+
 	if err := g.ensureCloned(ctx); err != nil {
 		return fmt.Errorf("git source %s: clone failed: %w", g.config.Name, err)
 	}
@@ -130,7 +138,7 @@ func (g *GitSource) Sync(ctx context.Context) error {
 		return fmt.Errorf("clone dir %s is not a git repo", g.cloneDir)
 	}
 
-	if err := gitPull(ctx, g.cloneDir); err != nil {
+	if err := gitSourcePull(ctx, g.cloneDir); err != nil {
 		return fmt.Errorf("git source %s: pull failed: %w", g.config.Name, err)
 	}
 
@@ -173,7 +181,7 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 			"name", g.config.Name,
 			"dir", g.cloneDir,
 		)
-		return gitPull(ctx, g.cloneDir)
+		return gitSourcePull(ctx, g.cloneDir)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(g.cloneDir), 0o755); err != nil {
@@ -189,10 +197,10 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 		args = append(args, "--filter=blob:none", "--sparse")
 	}
 
-	args = append(args, g.config.URL, g.cloneDir)
+	args = append(args, "--", g.config.URL, g.cloneDir)
 
 	cmd := exec.CommandContext(cloneCtx, "git", args...)
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = gitSourceEnv()
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -219,19 +227,69 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 func (g *GitSource) setupSparseCheckout(ctx context.Context) error {
 	initCmd := exec.CommandContext(ctx, "git", "sparse-checkout", "init", "--cone")
 	initCmd.Dir = g.cloneDir
-	initCmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	initCmd.Env = gitSourceEnv()
 	if out, err := initCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("sparse-checkout init: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	setCmd := exec.CommandContext(ctx, "git", "sparse-checkout", "set", g.config.Subpath)
 	setCmd.Dir = g.cloneDir
-	setCmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	setCmd.Env = gitSourceEnv()
 	if out, err := setCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("sparse-checkout set: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	return nil
+}
+
+// ValidateGitSourceURL enforces the transports permitted for git-backed knowledge sources.
+func ValidateGitSourceURL(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("git URL is required")
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return fmt.Errorf("git URL must not start with '-'")
+	}
+	if isSCPStyleGitURL(trimmed) {
+		return fmt.Errorf("git URL scp-like syntax is not allowed")
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return fmt.Errorf("git URL is invalid")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "https" && scheme != "http" {
+		if scheme == "" {
+			return fmt.Errorf("git URL scheme is required")
+		}
+		return fmt.Errorf("git URL scheme %q is not allowed", scheme)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("git URL host is required")
+	}
+	if strings.Contains(trimmed, "::") {
+		return fmt.Errorf("git URL must not contain git transport helper separator")
+	}
+
+	return nil
+}
+
+func isSCPStyleGitURL(raw string) bool {
+	if strings.Contains(raw, "://") {
+		return false
+	}
+	at := strings.Index(raw, "@")
+	colon := strings.Index(raw, ":")
+	return at > 0 && colon > at+1
+}
+
+func gitSourceEnv() []string {
+	return append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ALLOW_PROTOCOL="+gitAllowedProtocols,
+	)
 }
 
 // gitSourceSlug creates a filesystem-safe directory name from a git URL + subpath.

--- a/v2/pkg/knowledge/gitsource_ssrf_test.go
+++ b/v2/pkg/knowledge/gitsource_ssrf_test.go
@@ -1,0 +1,42 @@
+package knowledge
+
+import "testing"
+
+func TestValidateGitSourceURL_RejectsPrivateHosts(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	blocked := []string{
+		"http://127.0.0.1:8080/repo.git",
+		"http://10.0.0.1/internal-repo.git",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://192.168.1.1/sensitive-path",
+		"https://localhost/repo.git",
+		"http://[::1]/repo.git",
+		"http://0.0.0.0/repo.git",
+	}
+	for _, u := range blocked {
+		if err := ValidateGitSourceURL(u); err == nil {
+			t.Errorf("expected %q to be rejected as private/internal, got nil", u)
+		}
+	}
+}
+
+func TestValidateGitSourceURL_AllowsPublicHosts(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	ok := []string{
+		"https://github.com/kubestellar/hive.git",
+		"https://gitlab.com/group/project.git",
+		"https://8.8.8.8/repo.git", // public IP literal
+	}
+	for _, u := range ok {
+		if err := ValidateGitSourceURL(u); err != nil {
+			t.Errorf("expected %q to pass, got %v", u, err)
+		}
+	}
+}
+
+func TestValidateGitSourceURL_OptInAllowsPrivate(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
+	if err := ValidateGitSourceURL("http://10.0.0.5/internal.git"); err != nil {
+		t.Errorf("opt-in must allow a private internal Git server, got %v", err)
+	}
+}

--- a/v2/pkg/knowledge/gitsource_test.go
+++ b/v2/pkg/knowledge/gitsource_test.go
@@ -8,6 +8,51 @@ import (
 	"testing"
 )
 
+func TestValidateGitSourceURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "https", raw: "https://github.com/org/repo.git"},
+		{name: "http", raw: "http://example.com/org/repo"},
+		{name: "file scheme", raw: "file:///etc/passwd", wantErr: true},
+		{name: "ssh scheme", raw: "ssh://github.com/org/repo.git", wantErr: true},
+		{name: "git scheme", raw: "git://github.com/org/repo.git", wantErr: true},
+		{name: "ext helper", raw: "ext::sh -c 'id'", wantErr: true},
+		{name: "scp like", raw: "git@github.com:o/r.git", wantErr: true},
+		{name: "missing scheme", raw: "github.com/org/repo.git", wantErr: true},
+		{name: "invalid escape", raw: "https://example.com/%zz", wantErr: true},
+		{name: "empty host", raw: "https:///org/repo.git", wantErr: true},
+		{name: "leading dash", raw: "--upload-pack=/bin/sh", wantErr: true},
+		{name: "transport helper separator", raw: "https://github.com/org/repo::helper", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGitSourceURL(tc.raw)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateGitSourceURL(%q) succeeded, want error", tc.raw)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateGitSourceURL(%q) error = %v", tc.raw, err)
+			}
+		})
+	}
+}
+
+func TestGitSourceInitRejectsInvalidURL(t *testing.T) {
+	gs := NewGitSource(GitSourceConfig{
+		Name:  "bad",
+		URL:   "ssh://github.com/org/repo.git",
+		Layer: LayerProject,
+	}, t.TempDir(), slog.Default())
+
+	if err := gs.Init(context.Background()); err == nil {
+		t.Fatal("expected invalid URL error")
+	}
+}
+
 func TestGitSourceSlug(t *testing.T) {
 	tests := []struct {
 		url     string
@@ -39,8 +84,8 @@ func TestGitSourceSlug(t *testing.T) {
 
 func TestNewGitSource_Defaults(t *testing.T) {
 	config := GitSourceConfig{
-		Name: "test",
-		URL:  "https://github.com/org/repo",
+		Name:  "test",
+		URL:   "https://github.com/org/repo",
 		Layer: LayerProject,
 	}
 

--- a/v2/pkg/knowledge/gitsync.go
+++ b/v2/pkg/knowledge/gitsync.go
@@ -100,13 +100,21 @@ func isGitRepo(dir string) bool {
 // gitPull runs `git pull --ff-only` in the given directory.
 // --ff-only avoids creating merge commits if there are local changes.
 func gitPull(ctx context.Context, dir string) error {
+	return gitPullWithEnv(ctx, dir, append(os.Environ(), "GIT_TERMINAL_PROMPT=0"))
+}
+
+func gitSourcePull(ctx context.Context, dir string) error {
+	return gitPullWithEnv(ctx, dir, gitSourceEnv())
+}
+
+func gitPullWithEnv(ctx context.Context, dir string, env []string) error {
 	const gitPullTimeoutSeconds = 30
 	pullCtx, cancel := context.WithTimeout(ctx, gitPullTimeoutSeconds*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(pullCtx, "git", "pull", "--ff-only")
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = env
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/v2/pkg/knowledge/knowledge_coverage3_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage3_test.go
@@ -20,11 +20,11 @@ import (
 func TestKnowledgeAPI_ConnectGitSource_Duplicate(t *testing.T) {
 	api := &KnowledgeAPI{logger: covLogger()}
 	// Pre-seed a git source so the duplicate check fires before any clone.
-	gs := NewGitSource(GitSourceConfig{URL: "file:///x", Subpath: "docs"}, t.TempDir(), covLogger())
+	gs := NewGitSource(GitSourceConfig{URL: "https://example.com/x.git", Subpath: "docs"}, t.TempDir(), covLogger())
 	api.gitSources = append(api.gitSources, gs)
 
 	err := api.ConnectGitSource(context.Background(), GitSourceConfig{
-		URL:     "file:///x",
+		URL:     " https://example.com/x.git ",
 		Subpath: "docs",
 		Layer:   LayerProject,
 	})
@@ -37,11 +37,23 @@ func TestKnowledgeAPI_ConnectGitSource_InitFailure(t *testing.T) {
 	api := &KnowledgeAPI{logger: covLogger()}
 	err := api.ConnectGitSource(context.Background(), GitSourceConfig{
 		Name:  "bad",
-		URL:   "file:///nonexistent/repo/xyz",
+		URL:   "http://127.0.0.1:1/repo.git",
 		Layer: LayerProject,
 	})
 	if err == nil {
 		t.Error("expected init failure")
+	}
+}
+
+func TestKnowledgeAPI_ConnectGitSource_InvalidURL(t *testing.T) {
+	api := &KnowledgeAPI{logger: covLogger()}
+	err := api.ConnectGitSource(context.Background(), GitSourceConfig{
+		Name:  "bad",
+		URL:   "git@github.com:org/repo.git",
+		Layer: LayerProject,
+	})
+	if err == nil {
+		t.Error("expected invalid URL error")
 	}
 }
 

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -1,6 +1,7 @@
 package knowledge
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -746,7 +748,7 @@ func TestBeadLifecycle_HasOpenDependents(t *testing.T) {
 	}
 }
 
-// --- gitsource: real git via file:// clone ---
+// --- gitsource: real git via HTTP clone ---
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
@@ -784,13 +786,84 @@ func makeSourceRepo(t *testing.T) string {
 	return repo
 }
 
-func TestGitSource_InitSyncFullClone(t *testing.T) {
+func makeHTTPSourceRepo(t *testing.T) string {
+	t.Helper()
 	src := makeSourceRepo(t)
+	parent := t.TempDir()
+	bare := filepath.Join(parent, "repo.git")
+	runGit(t, src, "clone", "--bare", src, bare)
+
+	srv := httptest.NewServer(gitHTTPBackend(t, parent))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/repo.git"
+}
+
+func gitHTTPBackend(t *testing.T, projectRoot string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		cmd := exec.Command("git", "http-backend")
+		cmd.Env = append(os.Environ(),
+			"GIT_PROJECT_ROOT="+projectRoot,
+			"GIT_HTTP_EXPORT_ALL=1",
+			"REQUEST_METHOD="+r.Method,
+			"PATH_INFO="+r.URL.Path,
+			"QUERY_STRING="+r.URL.RawQuery,
+			"CONTENT_TYPE="+r.Header.Get("Content-Type"),
+			"CONTENT_LENGTH="+strconv.FormatInt(r.ContentLength, 10),
+		)
+		cmd.Stdin = r.Body
+
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Logf("git http-backend failed: %v: %s", err, stderr.String())
+			http.Error(w, "git http-backend failed", http.StatusInternalServerError)
+			return
+		}
+
+		headerBlock, body, ok := bytes.Cut(stdout.Bytes(), []byte("\r\n\r\n"))
+		if !ok {
+			headerBlock, body, ok = bytes.Cut(stdout.Bytes(), []byte("\n\n"))
+		}
+		if !ok {
+			http.Error(w, "bad git http-backend response", http.StatusInternalServerError)
+			return
+		}
+
+		status := http.StatusOK
+		for _, line := range strings.Split(string(headerBlock), "\n") {
+			line = strings.TrimRight(line, "\r")
+			if line == "" {
+				continue
+			}
+			key, value, found := strings.Cut(line, ":")
+			if !found {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if strings.EqualFold(key, "Status") {
+				code, _, _ := strings.Cut(value, " ")
+				if parsed, err := strconv.Atoi(code); err == nil {
+					status = parsed
+				}
+				continue
+			}
+			w.Header().Add(key, value)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}
+}
+
+func TestGitSource_InitSyncFullClone(t *testing.T) {
+	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "docs-src",
-		URL:   "file://" + src,
+		URL:   src,
 		Layer: LayerProject,
 	}, base, covLogger())
 
@@ -808,7 +881,7 @@ func TestGitSource_InitSyncFullClone(t *testing.T) {
 	// Re-init (already cloned path -> ensureCloned pulls).
 	gs2 := NewGitSource(GitSourceConfig{
 		Name:  "docs-src",
-		URL:   "file://" + src,
+		URL:   src,
 		Layer: LayerProject,
 	}, base, covLogger())
 	if err := gs2.Init(ctx); err != nil {
@@ -822,12 +895,12 @@ func TestGitSource_InitSyncFullClone(t *testing.T) {
 }
 
 func TestGitSource_InitSparseSubpath(t *testing.T) {
-	src := makeSourceRepo(t)
+	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
 	gs := NewGitSource(GitSourceConfig{
 		Name:    "docs-only",
-		URL:     "file://" + src,
+		URL:     src,
 		Subpath: "docs",
 		Layer:   LayerProject,
 	}, base, covLogger())
@@ -845,9 +918,11 @@ func TestGitSource_InitSparseSubpath(t *testing.T) {
 
 func TestGitSource_InitCloneFailure(t *testing.T) {
 	base := t.TempDir()
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(srv.Close)
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "bad",
-		URL:   "file:///nonexistent/repo/path/does/not/exist",
+		URL:   srv.URL + "/repo.git",
 		Layer: LayerProject,
 	}, base, covLogger())
 
@@ -860,7 +935,7 @@ func TestGitSource_SyncNotARepo(t *testing.T) {
 	base := t.TempDir()
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "norepo",
-		URL:   "file:///tmp",
+		URL:   "https://example.com/repo.git",
 		Layer: LayerProject,
 	}, base, covLogger())
 	// cloneDir does not exist / is not a git repo.
@@ -870,11 +945,11 @@ func TestGitSource_SyncNotARepo(t *testing.T) {
 }
 
 func TestGitSource_StartSyncLoop_Cancels(t *testing.T) {
-	src := makeSourceRepo(t)
+	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 	gs := NewGitSource(GitSourceConfig{
 		Name:  "loop",
-		URL:   "file://" + src,
+		URL:   src,
 		Layer: LayerProject,
 	}, base, covLogger())
 	if err := gs.Init(context.Background()); err != nil {

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -146,6 +146,29 @@ func TestSplitAtParagraphs_SingleShort(t *testing.T) {
 	}
 }
 
+func TestValidateLocalFilePath(t *testing.T) {
+	orig := allowedFilePrefixes
+	t.Cleanup(func() { allowedFilePrefixes = orig })
+
+	base := t.TempDir()
+	allowedFilePrefixes = []string{base + string(filepath.Separator)}
+
+	if err := validateLocalFilePath(filepath.Join(base, "doc.md")); err != nil {
+		t.Fatalf("expected allowed local document path: %v", err)
+	}
+	if err := validateLocalFilePath(filepath.Join(base, "..", "secret.md")); err == nil {
+		t.Fatal("expected path outside allowed prefix to be rejected")
+	}
+
+	ds := &DocumentSource{knowledgeDir: base}
+	if err := ds.validateFilePath(filepath.Join(base, "nested", "doc.md")); err != nil {
+		t.Fatalf("expected DocumentSource path under knowledge dir: %v", err)
+	}
+	if err := ds.validateFilePath(filepath.Join(base, "..", "secret.md")); err == nil {
+		t.Fatal("expected DocumentSource path outside knowledge dir to be rejected")
+	}
+}
+
 // --- Context7 coverage (context7Get and wrappers) ---
 
 func TestContext7Get_Success(t *testing.T) {

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -999,6 +999,19 @@ func TestGitSource_StartSyncLoop_Cancels(t *testing.T) {
 	}
 }
 
+func TestImportDocumentRejectsDuplicateName(t *testing.T) {
+	api := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true, Engine: "file"}, covLogger())
+	api.docSources = append(api.docSources, &DocumentSource{slug: "existing-doc"})
+
+	_, err := api.ImportDocument(context.Background(), DocSourceConfig{Name: "Existing Doc"})
+	if err == nil {
+		t.Fatal("expected duplicate document name to be rejected before import")
+	}
+	if !strings.Contains(err.Error(), "already imported") {
+		t.Fatalf("expected duplicate import error, got %v", err)
+	}
+}
+
 // --- gitsync: gitPull error path, syncAll ---
 
 func TestGitPull_NotARepo(t *testing.T) {

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -393,8 +393,11 @@ func TestDocumentSource_ImportWithGraph(t *testing.T) {
 	baseDir := filepath.Join(tmpDir, "knowledge")
 	gs := newTestGraphStore(t)
 
-	srcFile := filepath.Join(tmpDir, "test.txt")
+	srcFile := filepath.Join(baseDir, "test.txt")
 	content := "First para about one thing.\n\nSecond para about another thing.\n\nThird para wraps up."
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(srcFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -861,6 +861,7 @@ func gitHTTPBackend(t *testing.T, projectRoot string) http.HandlerFunc {
 }
 
 func TestGitSource_InitSyncFullClone(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
@@ -898,6 +899,7 @@ func TestGitSource_InitSyncFullClone(t *testing.T) {
 }
 
 func TestGitSource_InitSparseSubpath(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
@@ -948,6 +950,7 @@ func TestGitSource_SyncNotARepo(t *testing.T) {
 }
 
 func TestGitSource_StartSyncLoop_Cancels(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 	gs := NewGitSource(GitSourceConfig{

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -105,11 +105,27 @@ func (s *Scheduler) GetLastActionable() *github.ActionableResult {
 	return s.lastActionable
 }
 
+// userSavedPolicyDir is where the dashboard prompt editor
+// (PUT /api/config/agent/{name}/prompt → handleAgentPromptSave) writes a
+// template a user edited in the UI. It must be searched BEFORE the git-cloned
+// policies repo (…/examples/kubestellar/agents/) and the embedded defaults, or
+// an edit made in the UI never reaches the kick — the kick keeps rendering the
+// stale upstream copy that shadows the override (issue #3239). The dashboard's
+// own read path (loadPromptTemplateRaw) already checks this location first; the
+// scheduler must agree so a saved edit takes effect on the next kick.
+//
+// It is a var (not a const) only so tests can point it at a temp dir; production
+// always uses the fixed /data/policies path that handleAgentPromptSave writes to.
+var userSavedPolicyDir = "/data/policies"
+
 // loadPromptTemplate searches standard paths for an agent's policy template.
 // It checks on-disk paths first, then falls back to embedded default policies.
 func (s *Scheduler) loadPromptTemplate(agentName string) string {
 	paths := []string{
 		fmt.Sprintf("/data/agents/%s/CLAUDE.md", agentName),
+		// User-saved override from the dashboard prompt editor wins over the
+		// git-cloned examples copy and embedded defaults (#3239).
+		fmt.Sprintf("%s/%s.md", userSavedPolicyDir, agentName),
 		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s.md", agentName),
 	}
 	if s.cfg.Policies.LocalDir != "" {
@@ -133,6 +149,12 @@ func (s *Scheduler) loadPromptTemplate(agentName string) string {
 // It checks on-disk paths first, then falls back to embedded default policies.
 func (s *Scheduler) loadNamedTemplate(templateName string) string {
 	paths := []string{
+		// User-saved override from the dashboard prompt editor wins over the
+		// git-cloned examples copy and embedded defaults (#3239). handleAgentPromptSave
+		// writes the edited template to /data/policies/<KickTemplate>, so when an
+		// agent has a kick_template set (e.g. quality-advisory.md at ACMM L2) the
+		// edit lands here and must be picked up on the next kick.
+		fmt.Sprintf("%s/%s", userSavedPolicyDir, templateName),
 		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s", templateName),
 	}
 	if s.cfg.Policies.LocalDir != "" {

--- a/v2/pkg/scheduler/template_refresh_on_kick_test.go
+++ b/v2/pkg/scheduler/template_refresh_on_kick_test.go
@@ -1,0 +1,143 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// withUserSavedPolicyDir points the user-saved policy dir at a temp dir for the
+// duration of a test and restores the production default afterward. In
+// production this is the fixed /data/policies path that the dashboard prompt
+// editor (handleAgentPromptSave) writes to.
+func withUserSavedPolicyDir(t *testing.T, dir string) {
+	t.Helper()
+	prev := userSavedPolicyDir
+	userSavedPolicyDir = dir
+	t.Cleanup(func() { userSavedPolicyDir = prev })
+}
+
+// TestKickUsesLatestSavedTemplate is the regression test for issue #3239: after
+// a user edits an agent's prompt template in the dashboard, the NEXT kick must
+// render the freshly-saved template — not the stale git-cloned examples copy
+// that used to shadow the override.
+//
+// It reproduces the reporter's ACMM-L2 quality-agent scenario:
+//   - the agent has a kick_template (quality-advisory.md),
+//   - the git-cloned policies repo has an OLD copy under examples/…/agents/,
+//   - the dashboard save wrote the NEW copy to <userSavedPolicyDir>/quality-advisory.md.
+//
+// The kick must reflect the NEW copy.
+func TestKickUsesLatestSavedTemplate(t *testing.T) {
+	localDir := t.TempDir()   // stands in for the git-cloned /data/policies repo
+	savedDir := t.TempDir()   // stands in for /data/policies (user-saved overrides)
+	withUserSavedPolicyDir(t, savedDir)
+
+	// Old, git-cloned copy that used to win.
+	examplesDir := filepath.Join(localDir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(examplesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const oldWorkflow = "## Workflow\n3. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent\n"
+	if err := os.WriteFile(filepath.Join(examplesDir, "quality-advisory.md"), []byte(oldWorkflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Project: config.ProjectConfig{
+			Org: "testorg", Name: "test", PrimaryRepo: "testrepo",
+			Repos: []string{"testrepo"},
+		},
+		Agents: map[string]config.AgentConfig{
+			"quality": {Role: "quality", KickTemplate: "quality-advisory.md"},
+		},
+		Policies: config.PoliciesConfig{LocalDir: localDir},
+	}
+	s := New(cfg, slog.Default())
+
+	// 1. Before any user edit: the kick uses the git-cloned copy.
+	msg := s.BuildAgentMessage("quality", nil, nil)
+	if !strings.Contains(msg, "coverprofile=coverage.out") {
+		t.Fatalf("expected the git-cloned template before edit; got:\n%s", msg)
+	}
+
+	// 2. User edits the prompt in the dashboard. handleAgentPromptSave writes the
+	//    edited template to <userSavedPolicyDir>/<KickTemplate>.
+	const newWorkflow = "## Workflow\n3. Analyze test coverage.\n   For unit tests, use `go test -coverprofile=coverage.out ./...`.\n   For end-to-end tests, see the attached workflow results.\nUNIQUE_MARKER_3239\n"
+	if err := os.WriteFile(filepath.Join(savedDir, "quality-advisory.md"), []byte(newWorkflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. The NEXT kick must reflect the freshly-saved template.
+	msg = s.BuildAgentMessage("quality", nil, nil)
+	if !strings.Contains(msg, "UNIQUE_MARKER_3239") {
+		t.Fatalf("kick did not pick up the user-saved template edit (#3239); got:\n%s", msg)
+	}
+	if strings.Contains(msg, "or equivalent") {
+		t.Fatalf("kick still rendered the stale git-cloned template (#3239); got:\n%s", msg)
+	}
+}
+
+// TestLoadNamedTemplatePrefersUserSavedOverride proves the read-side precedence
+// directly: a user-saved override wins over the git-cloned examples copy.
+func TestLoadNamedTemplatePrefersUserSavedOverride(t *testing.T) {
+	localDir := t.TempDir()
+	savedDir := t.TempDir()
+	withUserSavedPolicyDir(t, savedDir)
+
+	examplesDir := filepath.Join(localDir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(examplesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(examplesDir, "quality-advisory.md"), []byte("OLD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "quality-advisory.md"), []byte("NEW"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Project:  config.ProjectConfig{Org: "testorg", Name: "test"},
+		Agents:   map[string]config.AgentConfig{},
+		Policies: config.PoliciesConfig{LocalDir: localDir},
+	}
+	s := New(cfg, slog.Default())
+
+	if got := s.loadNamedTemplate("quality-advisory.md"); got != "NEW" {
+		t.Fatalf("loadNamedTemplate: expected user-saved override %q, got %q", "NEW", got)
+	}
+}
+
+// TestLoadPromptTemplatePrefersUserSavedOverride proves the convention-path read
+// (<agent>.md) also prefers a user-saved override.
+func TestLoadPromptTemplatePrefersUserSavedOverride(t *testing.T) {
+	localDir := t.TempDir()
+	savedDir := t.TempDir()
+	withUserSavedPolicyDir(t, savedDir)
+
+	examplesDir := filepath.Join(localDir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(examplesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(examplesDir, "helper.md"), []byte("OLD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(savedDir, "helper.md"), []byte("NEW"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Project:  config.ProjectConfig{Org: "testorg", Name: "test"},
+		Agents:   map[string]config.AgentConfig{},
+		Policies: config.PoliciesConfig{LocalDir: localDir},
+	}
+	s := New(cfg, slog.Default())
+
+	if got := s.loadPromptTemplate("helper"); got != "NEW" {
+		t.Fatalf("loadPromptTemplate: expected user-saved override %q, got %q", "NEW", got)
+	}
+}

--- a/v2/pkg/tokens/copilot_scanner_test.go
+++ b/v2/pkg/tokens/copilot_scanner_test.go
@@ -1,0 +1,474 @@
+package tokens
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// detectAgentFromCwd
+// ---------------------------------------------------------------------------
+
+func TestDetectAgentFromCwd(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{"standard agent path", "/data/agents/quality", "quality"},
+		{"nested agent path", "/data/agents/sec-check/subdir", "sec-check"},
+		{"trailing slash", "/data/agents/supervisor/", "supervisor"},
+		{"no agent prefix", "/home/user/projects", ""},
+		{"empty string", "", ""},
+		{"prefix only no agent", "/data/agents/", ""},
+		{"embedded prefix", "/var/run/data/agents/scanner/work", "scanner"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectAgentFromCwd(tt.cwd)
+			if got != tt.want {
+				t.Errorf("detectAgentFromCwd(%q) = %q, want %q", tt.cwd, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseCopilotSessionFile
+// ---------------------------------------------------------------------------
+
+func TestParseCopilotSessionFile_FullLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	events := []copilotEvent{
+		{
+			Type: "session.start",
+			Data: mustMarshal(t, copilotSessionStart{
+				SessionID:     "abcdef123456789",
+				SelectedModel: "gpt-4o",
+				Context:       copilotContext{Cwd: "/data/agents/quality"},
+			}),
+		},
+		{
+			Type:      "user.message",
+			Timestamp: "2026-08-10T12:00:00.000Z",
+			Data:      mustMarshal(t, copilotUserMessage{Content: "analyze coverage gaps"}),
+		},
+		{
+			Type:      "assistant.message",
+			Timestamp: "2026-08-10T12:00:05.000Z",
+			Data:      json.RawMessage(`{}`),
+		},
+		{
+			Type: "tool.execution_complete",
+			Data: mustMarshal(t, copilotToolComplete{Model: "claude-sonnet-4-20250514"}),
+		},
+		{
+			Type: "session.shutdown",
+			Data: mustMarshal(t, copilotShutdown{
+				CurrentModel: "claude-sonnet-4-20250514",
+				ModelMetrics: map[string]copilotModelMetric{
+					"claude-sonnet-4-20250514": {
+						Usage: copilotUsage{
+							InputTokens:      1000,
+							OutputTokens:     500,
+							CacheReadTokens:  200,
+							CacheWriteTokens: 100,
+						},
+					},
+				},
+			}),
+		},
+	}
+
+	path := writeEventsFile(t, dir, events)
+
+	summary, err := parseCopilotSessionFile(path)
+	if err != nil {
+		t.Fatalf("parseCopilotSessionFile: %v", err)
+	}
+
+	if summary.SessionID != "abcdef123456" {
+		t.Errorf("SessionID = %q, want truncated to 12 chars", summary.SessionID)
+	}
+	if summary.Agent != "quality" {
+		t.Errorf("Agent = %q, want 'quality'", summary.Agent)
+	}
+	if summary.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("Model = %q, want 'claude-sonnet-4-20250514'", summary.Model)
+	}
+	if summary.Messages != 2 {
+		t.Errorf("Messages = %d, want 2", summary.Messages)
+	}
+	if summary.InputTokens != 1000 {
+		t.Errorf("InputTokens = %d, want 1000", summary.InputTokens)
+	}
+	if summary.OutputTokens != 500 {
+		t.Errorf("OutputTokens = %d, want 500", summary.OutputTokens)
+	}
+	if summary.CacheRead != 200 {
+		t.Errorf("CacheRead = %d, want 200", summary.CacheRead)
+	}
+	if summary.CacheCreate != 100 {
+		t.Errorf("CacheCreate = %d, want 100", summary.CacheCreate)
+	}
+	if summary.TotalTokens != 1800 {
+		t.Errorf("TotalTokens = %d, want 1800", summary.TotalTokens)
+	}
+	if summary.LastActive == 0 {
+		t.Error("LastActive should be set from message timestamps")
+	}
+}
+
+func TestParseCopilotSessionFile_MalformedLinesSkipped(t *testing.T) {
+	dir := t.TempDir()
+	content := "not json at all\n" +
+		`{"type":"session.start","data":{"sessionId":"sess123","selectedModel":"gpt-4","context":{"cwd":"/data/agents/scanner"}}}` + "\n" +
+		"{broken json\n" +
+		`{"type":"user.message","timestamp":"2026-01-01T00:00:00Z","data":{"content":"hello"}}` + "\n"
+
+	path := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := parseCopilotSessionFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.Agent != "scanner" {
+		t.Errorf("Agent = %q, want 'scanner'", summary.Agent)
+	}
+	if summary.Messages != 1 {
+		t.Errorf("Messages = %d, want 1 (malformed lines skipped)", summary.Messages)
+	}
+}
+
+func TestParseCopilotSessionFile_AgentDetectionFromMessages(t *testing.T) {
+	// When CWD doesn't reveal agent, fall back to message content detection.
+	dir := t.TempDir()
+	events := []copilotEvent{
+		{
+			Type: "session.start",
+			Data: mustMarshal(t, copilotSessionStart{
+				SessionID:     "xyz999",
+				SelectedModel: "gpt-4",
+				Context:       copilotContext{Cwd: "/home/user"},
+			}),
+		},
+		{
+			Type:      "user.message",
+			Timestamp: "2026-01-01T00:00:00Z",
+			Data:      mustMarshal(t, copilotUserMessage{Content: "generic message no agent hint"}),
+		},
+	}
+
+	path := writeEventsFile(t, dir, events)
+	summary, err := parseCopilotSessionFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Agent stays "unknown" if CWD and messages don't match
+	if summary.Agent == "" {
+		t.Error("Agent should not be empty (defaults to 'unknown')")
+	}
+}
+
+func TestParseCopilotSessionFile_MultipleModelMetrics(t *testing.T) {
+	dir := t.TempDir()
+	events := []copilotEvent{
+		{
+			Type: "session.start",
+			Data: mustMarshal(t, copilotSessionStart{
+				SessionID:     "multi-model",
+				SelectedModel: "gpt-4",
+				Context:       copilotContext{Cwd: "/data/agents/ci"},
+			}),
+		},
+		{
+			Type: "session.shutdown",
+			Data: mustMarshal(t, copilotShutdown{
+				CurrentModel: "claude-sonnet-4-20250514",
+				ModelMetrics: map[string]copilotModelMetric{
+					"gpt-4": {Usage: copilotUsage{InputTokens: 100, OutputTokens: 50}},
+					"claude-sonnet-4-20250514": {Usage: copilotUsage{InputTokens: 200, OutputTokens: 100}},
+				},
+			}),
+		},
+	}
+
+	path := writeEventsFile(t, dir, events)
+	summary, err := parseCopilotSessionFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Tokens from all models are summed
+	if summary.InputTokens != 300 {
+		t.Errorf("InputTokens = %d, want 300 (sum of both models)", summary.InputTokens)
+	}
+	if summary.OutputTokens != 150 {
+		t.Errorf("OutputTokens = %d, want 150 (sum of both models)", summary.OutputTokens)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ScanCopilotSessions
+// ---------------------------------------------------------------------------
+
+func TestScanCopilotSessions_EmptyDirReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	agg, err := ScanCopilotSessions(dir, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agg.SessionCount != 0 {
+		t.Errorf("SessionCount = %d, want 0", agg.SessionCount)
+	}
+}
+
+func TestScanCopilotSessions_EmptyStringPath(t *testing.T) {
+	agg, err := ScanCopilotSessions("", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agg.SessionCount != 0 {
+		t.Errorf("SessionCount = %d, want 0", agg.SessionCount)
+	}
+}
+
+func TestScanCopilotSessions_MissingDirReturnsZero(t *testing.T) {
+	agg, err := ScanCopilotSessions("/nonexistent/path/xyz", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agg.SessionCount != 0 {
+		t.Errorf("SessionCount = %d, want 0 for nonexistent dir", agg.SessionCount)
+	}
+}
+
+func TestScanCopilotSessions_AggregatesMultipleSessions(t *testing.T) {
+	dir := t.TempDir()
+
+	// Session 1: quality agent
+	sess1Dir := filepath.Join(dir, "session-001")
+	os.MkdirAll(sess1Dir, 0o755)
+	writeEventsFileAt(t, sess1Dir, []copilotEvent{
+		{Type: "session.start", Data: mustMarshal(t, copilotSessionStart{
+			SessionID: "s1", SelectedModel: "gpt-4", Context: copilotContext{Cwd: "/data/agents/quality"},
+		})},
+		{Type: "user.message", Timestamp: "2026-08-10T10:00:00Z", Data: mustMarshal(t, copilotUserMessage{Content: "hi"})},
+		{Type: "session.shutdown", Data: mustMarshal(t, copilotShutdown{
+			ModelMetrics: map[string]copilotModelMetric{
+				"gpt-4": {Usage: copilotUsage{InputTokens: 500, OutputTokens: 200}},
+			},
+		})},
+	})
+
+	// Session 2: scanner agent
+	sess2Dir := filepath.Join(dir, "session-002")
+	os.MkdirAll(sess2Dir, 0o755)
+	writeEventsFileAt(t, sess2Dir, []copilotEvent{
+		{Type: "session.start", Data: mustMarshal(t, copilotSessionStart{
+			SessionID: "s2", SelectedModel: "claude-sonnet-4-20250514", Context: copilotContext{Cwd: "/data/agents/scanner"},
+		})},
+		{Type: "user.message", Timestamp: "2026-08-10T11:00:00Z", Data: mustMarshal(t, copilotUserMessage{Content: "scan"})},
+		{Type: "session.shutdown", Data: mustMarshal(t, copilotShutdown{
+			ModelMetrics: map[string]copilotModelMetric{
+				"claude-sonnet-4-20250514": {Usage: copilotUsage{InputTokens: 300, OutputTokens: 100}},
+			},
+		})},
+	})
+
+	agg, err := ScanCopilotSessions(dir, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agg.SessionCount != 2 {
+		t.Errorf("SessionCount = %d, want 2", agg.SessionCount)
+	}
+	if agg.TotalInput != 800 {
+		t.Errorf("TotalInput = %d, want 800", agg.TotalInput)
+	}
+	if agg.TotalOutput != 300 {
+		t.Errorf("TotalOutput = %d, want 300", agg.TotalOutput)
+	}
+	if agg.TotalMessages != 2 {
+		t.Errorf("TotalMessages = %d, want 2", agg.TotalMessages)
+	}
+	if agg.ByAgent["quality"] != 700 {
+		t.Errorf("ByAgent[quality] = %d, want 700", agg.ByAgent["quality"])
+	}
+	if agg.ByAgent["scanner"] != 400 {
+		t.Errorf("ByAgent[scanner] = %d, want 400", agg.ByAgent["scanner"])
+	}
+}
+
+func TestScanCopilotSessions_DoubleCountAvoidance(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate liveCaptureSinceMs = a time BEFORE the session's last activity
+	// So the session was active after live capture started → tokens should be zeroed.
+	liveCaptureSince := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC).UnixMilli()
+
+	sessDir := filepath.Join(dir, "session-live")
+	os.MkdirAll(sessDir, 0o755)
+	writeEventsFileAt(t, sessDir, []copilotEvent{
+		{Type: "session.start", Data: mustMarshal(t, copilotSessionStart{
+			SessionID: "live1", SelectedModel: "gpt-4", Context: copilotContext{Cwd: "/data/agents/quality"},
+		})},
+		{Type: "user.message", Timestamp: "2026-08-10T10:00:00Z", Data: mustMarshal(t, copilotUserMessage{Content: "work"})},
+		{Type: "session.shutdown", Data: mustMarshal(t, copilotShutdown{
+			ModelMetrics: map[string]copilotModelMetric{
+				"gpt-4": {Usage: copilotUsage{InputTokens: 1000, OutputTokens: 500}},
+			},
+		})},
+	})
+
+	agg, err := ScanCopilotSessions(dir, liveCaptureSince)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tokens zeroed (proxy captured them live) but messages kept
+	if agg.TotalTokens != 0 {
+		t.Errorf("TotalTokens = %d, want 0 (double-count avoidance)", agg.TotalTokens)
+	}
+	if agg.TotalMessages != 1 {
+		t.Errorf("TotalMessages = %d, want 1 (messages always counted)", agg.TotalMessages)
+	}
+}
+
+func TestScanCopilotSessions_OldSessionKeepsTokens(t *testing.T) {
+	dir := t.TempDir()
+
+	// liveCaptureSince is AFTER the session ended → tokens should be kept
+	liveCaptureSince := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC).UnixMilli()
+
+	sessDir := filepath.Join(dir, "session-old")
+	os.MkdirAll(sessDir, 0o755)
+	writeEventsFileAt(t, sessDir, []copilotEvent{
+		{Type: "session.start", Data: mustMarshal(t, copilotSessionStart{
+			SessionID: "old1", SelectedModel: "gpt-4", Context: copilotContext{Cwd: "/data/agents/quality"},
+		})},
+		{Type: "user.message", Timestamp: "2026-08-10T10:00:00Z", Data: mustMarshal(t, copilotUserMessage{Content: "work"})},
+		{Type: "session.shutdown", Data: mustMarshal(t, copilotShutdown{
+			ModelMetrics: map[string]copilotModelMetric{
+				"gpt-4": {Usage: copilotUsage{InputTokens: 1000, OutputTokens: 500}},
+			},
+		})},
+	})
+
+	agg, err := ScanCopilotSessions(dir, liveCaptureSince)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tokens kept (session ended before live capture started)
+	if agg.TotalTokens != 1500 {
+		t.Errorf("TotalTokens = %d, want 1500 (session predates live capture)", agg.TotalTokens)
+	}
+}
+
+func TestScanCopilotSessions_SkipsNonDirEntries(t *testing.T) {
+	dir := t.TempDir()
+	// Create a file (not a directory) in the sessions dir
+	os.WriteFile(filepath.Join(dir, "not-a-session.txt"), []byte("hello"), 0o644)
+
+	agg, err := ScanCopilotSessions(dir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.SessionCount != 0 {
+		t.Errorf("SessionCount = %d, want 0 (non-dirs skipped)", agg.SessionCount)
+	}
+}
+
+func TestScanCopilotSessions_ByAgentDetail(t *testing.T) {
+	dir := t.TempDir()
+
+	sessDir := filepath.Join(dir, "session-detail")
+	os.MkdirAll(sessDir, 0o755)
+	writeEventsFileAt(t, sessDir, []copilotEvent{
+		{Type: "session.start", Data: mustMarshal(t, copilotSessionStart{
+			SessionID: "d1", SelectedModel: "gpt-4", Context: copilotContext{Cwd: "/data/agents/quality"},
+		})},
+		{Type: "user.message", Timestamp: "2026-08-10T10:00:00Z", Data: mustMarshal(t, copilotUserMessage{Content: "check"})},
+		{Type: "session.shutdown", Data: mustMarshal(t, copilotShutdown{
+			ModelMetrics: map[string]copilotModelMetric{
+				"gpt-4": {Usage: copilotUsage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 25, CacheWriteTokens: 10}},
+			},
+		})},
+	})
+
+	agg, err := ScanCopilotSessions(dir, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	detail := agg.ByAgentDetail["quality"]
+	if detail == nil {
+		t.Fatal("ByAgentDetail[quality] is nil")
+	}
+	if detail.Input != 100 {
+		t.Errorf("detail.Input = %d, want 100", detail.Input)
+	}
+	if detail.Output != 50 {
+		t.Errorf("detail.Output = %d, want 50", detail.Output)
+	}
+	if detail.CacheRead != 25 {
+		t.Errorf("detail.CacheRead = %d, want 25", detail.CacheRead)
+	}
+	if detail.CacheCreate != 10 {
+		t.Errorf("detail.CacheCreate = %d, want 10", detail.CacheCreate)
+	}
+	if detail.Messages != 1 {
+		t.Errorf("detail.Messages = %d, want 1", detail.Messages)
+	}
+	if detail.Sessions != 1 {
+		t.Errorf("detail.Sessions = %d, want 1", detail.Sessions)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mustMarshal(t *testing.T, v interface{}) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("mustMarshal: %v", err)
+	}
+	return json.RawMessage(b)
+}
+
+func writeEventsFile(t *testing.T, dir string, events []copilotEvent) string {
+	t.Helper()
+	path := filepath.Join(dir, "events.jsonl")
+	return writeEventsToPath(t, path, events)
+}
+
+func writeEventsFileAt(t *testing.T, dir string, events []copilotEvent) {
+	t.Helper()
+	path := filepath.Join(dir, "events.jsonl")
+	writeEventsToPath(t, path, events)
+}
+
+func writeEventsToPath(t *testing.T, path string, events []copilotEvent) string {
+	t.Helper()
+	var content []byte
+	for _, evt := range events {
+		line, err := json.Marshal(evt)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		content = append(content, line...)
+		content = append(content, '\n')
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("writeEventsFile: %v", err)
+	}
+	return path
+}

--- a/v2/policies/README.md
+++ b/v2/policies/README.md
@@ -43,7 +43,49 @@ Do not put secrets in policy Markdown. Prompts are shown in logs, dashboard hist
 
 ## Variables
 
-Templates are rendered with runtime context such as `${AGENT_NAME}`, `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, `${ISSUE_LIST}`, `${PR_LIST}`, `${KNOWLEDGE}`, and mode/auth fragments. Variables that are not available for a mode render empty; for example advisory/no-GitHub policies do not get write-capable GitHub auth instructions.
+Kick templates reference variables as `${NAME}`. The scheduler replaces the built-in variables below on every scheduled kick; an unknown `${NAME}` is left literal. Operator-defined variables from the top-level `variables:` config block are resolved by the same engine, but built-ins win on name conflicts.
+
+The complete built-in scheduler set in v2 HEAD is:
+
+| Variable | Runtime value | Notes |
+| --- | --- | --- |
+| `${AGENT_NAME}` | Configured agent key receiving the kick, such as `scanner` or `scanner-2`. | Replicas use the materialized name. |
+| `${AGENT_DISPLAY_NAME}` | `agents.<name>.display_name` when set; otherwise the agent key. | Dashboard label. |
+| `${TIMESTAMP}` | Local wall-clock time formatted like `1/2 3:04 PM MST`. | Generated at kick render time. |
+| `${QUEUE_ISSUES}` | Count of actionable issues in the current GitHub scan. | From `ActionableResult.Issues.Count`. |
+| `${QUEUE_PRS}` | Count of actionable pull requests in the current GitHub scan. | From `ActionableResult.PRs.Count`. |
+| `${QUEUE_HOLD}` | Count of hold-gated items. | From `ActionableResult.Hold.Total`. |
+| `${SLA_VIOLATIONS}` | Count of actionable issues past the configured SLA. | From `ActionableResult.Issues.SLAViolations`. |
+| `${ISSUE_LIST}` | Formatted issue list for the agent's lane. | `scanner` sees all passed issues; other agents get lane-filtered issues. |
+| `${PR_LIST}` | Formatted pull-request list. | Empty/none formatting comes from the scheduler formatter. |
+| `${AUTHORIZED_REPOS}` | Repository authorization section for the configured project repos and GitHub host. | Built by the scheduler. |
+| `${GH_AUTH}` | GitHub App/CLI authentication instructions for the agent. | Templates/policies decide whether using GitHub writes is allowed; supervisor no-GitHub policies should not rely on this fragment. |
+| `${PROJECT_ORG}` | `project.org`. | GitHub organization/owner. |
+| `${PROJECT_NAME}` | `project.name`. | May be empty if not configured. |
+| `${PROJECT_PRIMARY_REPO}` | Primary repo as `org/repo`. | Combines `project.org` and `project.primary_repo`. |
+| `${PROJECT_AI_AUTHOR}` | Effective AI author username. | Uses config defaulting from `EffectiveAIAuthor()`. |
+| `${PROJECT_REPOS_LIST}` | Comma-separated `project.repos`. | Plain repo names as configured. |
+| `${PROJECT_HOMEBREW_REPO}` | `<project.org>/homebrew-tap`. | Convenience repo name. |
+| `${HIVE_REPO}` | `<project.org>/hive`. | Convenience repo name. |
+| `${HIVE_ID}` | `hive_id`. | May be empty for standalone configs. |
+| `${AGENT_LIST}` | Formatted enabled-agent list. | Same value as `${ENABLED_AGENTS}`. |
+| `${ENABLED_AGENTS}` | Formatted enabled-agent list. | Alias of `${AGENT_LIST}`. |
+| `${AGENT_ROLES}` | Formatted role/metadata summary for configured agents. | Built from current config. |
+| `${KNOWLEDGE}` | Knowledge priming section for relevant issues. | Populated by configured knowledge layers; otherwise renders the scheduler's empty/none text. |
+| `${INCEPTION_IDEA}` | Current inception idea text. | Empty when no inception run is active. |
+| `${INCEPTION_PHASE}` | Current inception phase. | Empty when inactive. |
+| `${INCEPTION_MODE}` | Current inception mode. | Empty when inactive. |
+| `${INCEPTION_ANSWERS}` | Collected inception answers. | Empty when inactive. |
+| `${INCEPTION_SLUG}` | Inception slug. | Empty when inactive. |
+| `${INCEPTION_REPO_URL}` | Inception repository URL. | Empty when inactive. |
+| `${MERGE_ELIGIBLE}` | Formatted merge-eligible PR list from `/var/run/hive-metrics/merge-eligible.json`. | Renders `(none)` when the file is absent, invalid, or empty. |
+| `${CI_FAILING}` | Formatted failing-CI PR list from `/var/run/hive-metrics/ci-failing.json`. | Renders `(none)` when the file is absent, invalid, or empty. |
+
+Dashboard prompt previews substitute only the config-only subset that does not require a live GitHub scan: `${AGENT_NAME}`, `${AGENT_DISPLAY_NAME}`, `${PROJECT_NAME}`, `${PROJECT_ORG}`, `${PROJECT_PRIMARY_REPO}`, `${PROJECT_AI_AUTHOR}`, `${PROJECT_REPOS_LIST}`, `${HIVE_REPO}`, and `${HIVE_ID}`. Live-only variables such as `${ISSUE_LIST}`, `${PR_LIST}`, `${QUEUE_ISSUES}`, `${KNOWLEDGE}`, `${MERGE_ELIGIBLE}`, and `${CI_FAILING}` are resolved when the scheduler sends an actual kick.
+
+### Custom variables
+
+Custom variables are declared under `variables.defs` in `hive.yaml` and use the same `${NAME}` syntax. Names must match letters/digits/underscore and not start with a digit. `static` and `env` variables can be managed from the dashboard; `script` and `http` variables are seed/GitOps-only and require their corresponding security gates. Scope controls where a custom variable resolves: `template`, `config`, or `both`. Unresolved custom variables remain literal, matching built-in unknown-variable behavior.
 
 ## Operator checklist
 

--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js"
+    "test": "node server.test.js && node terminal_cookie_verify.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node terminal_cookie_verify.test.js"
+    "test": "node server.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/redoc_pin.test.js
+++ b/v2/proxy/redoc_pin.test.js
@@ -1,0 +1,30 @@
+import { strict as assert } from 'assert';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+// Regression guard for the /api-docs Redoc supply-chain hardening: the CDN
+// script must be pinned to a specific version and carry a Subresource Integrity
+// hash, never the mutable 'latest' tag without SRI.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+
+assert.ok(
+  !/cdn\.redoc\.ly\/redoc\/latest\//.test(src),
+  "server.js must not load Redoc from the mutable 'latest' tag",
+);
+const script = src.match(/<script[^>]*cdn\.redoc\.ly\/redoc\/[^>]*>/);
+assert.ok(script, 'expected a Redoc <script> tag referencing cdn.redoc.ly');
+assert.ok(
+  /cdn\.redoc\.ly\/redoc\/v\d+\.\d+\.\d+\//.test(script[0]),
+  'Redoc script must be pinned to a specific vMAJOR.MINOR.PATCH version',
+);
+assert.ok(
+  /integrity="sha(256|384|512)-[A-Za-z0-9+/=]+"/.test(script[0]),
+  'Redoc script must carry a Subresource Integrity hash',
+);
+assert.ok(
+  /crossorigin=/.test(script[0]),
+  'Redoc script must set crossorigin for SRI to be enforced',
+);
+console.log('redoc_pin.test.js: OK');

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -217,7 +217,13 @@ app.get('/api-docs', (_req, res) => {
   <style>body { margin: 0; padding: 0; }</style>
 </head><body>
   <redoc spec-url="/api/openapi.json"></redoc>
-  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  <!-- Pinned to a specific Redoc version with a Subresource Integrity hash so a
+       compromise of the CDN or a silent 'latest'-tag update cannot execute
+       arbitrary script in the dashboard origin. crossorigin is required for SRI
+       to be enforced on a cross-origin script. -->
+  <script src="https://cdn.redoc.ly/redoc/v2.1.5/bundles/redoc.standalone.js"
+          integrity="sha384-0GrsyTQc9Oqd8h+b2dbc4XdR2T/DYpy0tLNNstyx+LBMUyiBbcWPbEs9aRmUcaxD"
+          crossorigin="anonymous"></script>
 </body></html>`);
 });
 

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -14,6 +14,58 @@ const TTYD_PORT = parseInt(process.env.HIVE_TTYD_PORT || '7681', 10);
 const TTYD_URL = `http://127.0.0.1:${TTYD_PORT}`;
 const DASHBOARD_TOKEN = process.env.HIVE_DASHBOARD_TOKEN || '';
 const STATIC_DIR = process.env.HIVE_STATIC_DIR || path.join(__dirname, 'public');
+
+// SECURITY (audit F3, CWE-345): the /terminal gate below used to accept ANY
+// non-empty `hive_hub_user` cookie. `Cookie: hive_hub_user=x` therefore opened a
+// shell in a container holding the GitHub App key, every agent token, and the
+// hub secret — with no hub account required at all. This verifies the hub's
+// signature instead, mirroring verifyHubUserCookieValue in
+// v2/pkg/hub/hub_cookie.go.
+//
+// The cookie value is `<username>.<sig>` where sig is base64url-unpadded
+// HMAC-SHA256(key=SESSION_KEY, msg=username).
+//
+// SESSION_KEY resolution mirrors the Go SpokeSessionKey() helper:
+//   1. HIVE_SESSION_KEY (least-privilege provisioning), else
+//   2. derive from HIVE_HUB_SECRET via HMAC-SHA256(master, "hive-session-v1"),
+//      the backward-compatible path for spokes that still hold the master.
+// The info string MUST stay byte-for-byte identical to infoSessionKey in
+// v2/pkg/hub/hub_keys.go.
+const INFO_SESSION_KEY = 'hive-session-v1';
+function deriveSessionKey() {
+  const explicit = (process.env.HIVE_SESSION_KEY || '').trim();
+  if (explicit) return explicit;
+  const master = (process.env.HIVE_HUB_SECRET || '').trim();
+  if (!master) return '';
+  return crypto.createHmac('sha256', master).update(INFO_SESSION_KEY).digest('hex');
+}
+const SESSION_KEY = deriveSessionKey();
+
+// verifyHubUserCookie returns the verified username, or '' when the signature
+// does not verify / the key is unset / the value is malformed. Constant-time
+// comparison; a forged, edited, or legacy-unsigned cookie fails closed.
+function verifyHubUserCookie(secret, value) {
+  if (!secret || !value) return '';
+  const idx = value.lastIndexOf('.');
+  if (idx <= 0 || idx === value.length - 1) return '';
+  const username = value.slice(0, idx);
+  const sig = value.slice(idx + 1);
+  const expected = crypto.createHmac('sha256', secret).update(username).digest('base64url');
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return '';
+  return username;
+}
+
+// parseCookies is shared by the HTTP and WebSocket terminal gates so the two
+// cannot drift — they are equally exploitable and must stay in lockstep.
+function parseCookies(header) {
+  return (header || '').split(';').reduce((acc, c) => {
+    const [k, ...v] = c.trim().split('=');
+    if (k) acc[k] = v.join('=');
+    return acc;
+  }, {});
+}
 const SNAPSHOT_FRAME_ANCESTORS_FALLBACK = parseSnapshotFrameAncestors(process.env.HIVE_SNAPSHOT_FRAME_ANCESTORS || '');
 
 if (!DASHBOARD_TOKEN && process.env.NODE_ENV === 'production') {
@@ -189,12 +241,15 @@ app.use('/terminal', (req, res, next) => {
   const host = req.headers.host || '';
   const isHosted = host.endsWith('.hive.kubestellar.io');
   if (isHosted) {
-    const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
-      const [k, ...v] = c.trim().split('=');
-      if (k) acc[k] = v.join('=');
-      return acc;
-    }, {});
-    const user = cookies['hive_hub_user'];
+    // SECURITY (audit F3, CWE-345): VERIFY the cookie's signature. This gate
+    // previously accepted any non-empty value, so `Cookie: hive_hub_user=x`
+    // opened a shell in a credential-holding container with no hub account.
+    //
+    // Fails closed when SESSION_KEY is unset: a hosted spoke with no way to
+    // verify must deny, not wave everyone through — that is the same bug in a
+    // different disguise.
+    const cookies = parseCookies(req.headers.cookie);
+    const user = verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user']);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -274,12 +329,12 @@ server.on('upgrade', (req, socket, head) => {
     const host = req.headers.host || '';
     const isHosted = host.endsWith('.hive.kubestellar.io');
     if (isHosted) {
-      const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
-        const [k, ...v] = c.trim().split('=');
-        if (k) acc[k] = v.join('=');
-        return acc;
-      }, {});
-      if (!cookies['hive_hub_user']) {
+      // SECURITY (audit F3, CWE-345): same signature verification as the HTTP
+      // gate. A WebSocket upgrade reaches the SAME ttyd shell, so leaving this
+      // path on presence-only would leave the hole fully open — the HTTP fix
+      // alone would be security theatre.
+      const cookies = parseCookies(req.headers.cookie);
+      if (!verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user'])) {
         socket.destroy();
         return;
       }

--- a/v2/proxy/terminal_cookie_verify.test.js
+++ b/v2/proxy/terminal_cookie_verify.test.js
@@ -1,0 +1,165 @@
+// F3 (CWE-345): the /terminal gate must VERIFY the hub cookie's signature.
+//
+// Run: node terminal_cookie_verify.test.js
+//
+// Before this fix both terminal gates — the HTTP route and the WebSocket
+// upgrade — checked only that `hive_hub_user` was NON-EMPTY:
+//
+//     const user = cookies['hive_hub_user'];
+//     if (!user) { ...401... }
+//     next();                       // <-- any value proceeded
+//
+// So `curl -H 'Cookie: hive_hub_user=x' https://<hive>.hive.kubestellar.io/terminal`
+// opened a shell in a container holding the GitHub App private key, every agent
+// token, and the hub secret — with no hub account required at all.
+//
+// Both gates are covered here. Fixing only the HTTP one would be security
+// theatre: a WebSocket upgrade reaches the same ttyd.
+
+import { WebSocket, WebSocketServer } from 'ws';
+import { createServer, request as httpRequest } from 'http';
+import { spawn } from 'child_process';
+import path from 'path';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+import assert from 'assert';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROXY_PORT = 19101;
+const GO_PORT = 19102;
+const TTYD_PORT = 19103;
+const HOSTED_HOST = 'hive-f3.hive.kubestellar.io';
+
+// The master this spoke is provisioned with; the proxy derives SESSION_KEY from
+// it exactly as Go's SpokeSessionKey() does.
+const MASTER = 'f3-test-master-secret';
+const SESSION_KEY = crypto.createHmac('sha256', MASTER).update('hive-session-v1').digest('hex');
+
+// mintCookie mirrors the hub's mintHubUserCookieValue.
+function mintCookie(username) {
+  const sig = crypto.createHmac('sha256', SESSION_KEY).update(username).digest('base64url');
+  return `${username}.${sig}`;
+}
+
+function mockBackend(port, body) {
+  return new Promise(resolve => {
+    const s = createServer((req, res) => { res.writeHead(200); res.end(body); });
+    s.listen(port, () => resolve(s));
+  });
+}
+
+// The ttyd mock must speak WebSocket, not just HTTP: the terminal is a WS
+// upgrade, so a plain HTTP mock makes the "valid cookie opens a shell" control
+// fail for the wrong reason and hides whether the gate actually passed.
+function mockTtydWS(port) {
+  return new Promise(resolve => {
+    const s = createServer((req, res) => { res.writeHead(200); res.end('ttyd'); });
+    const wss = new WebSocketServer({ server: s });
+    wss.on('connection', ws => ws.send('shell'));
+    s.listen(port, () => resolve(s));
+  });
+}
+
+function startProxy() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        HIVE_PROXY_PORT: String(PROXY_PORT),
+        HIVE_API_PORT: String(GO_PORT),
+        HIVE_TTYD_PORT: String(TTYD_PORT),
+        HIVE_DASHBOARD_TOKEN: '',
+        HIVE_STATIC_DIR: __dirname,
+        HIVE_HUB_SECRET: MASTER,
+        NODE_ENV: 'test',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', d => {
+      if (!started && d.toString().includes('hive-proxy')) { started = true; resolve(proc); }
+    });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('proxy start timeout')); }, 10000);
+  });
+}
+
+// NOTE: uses http.request, not fetch. fetch() silently DROPS a custom Host
+// header, so the proxy would see 127.0.0.1 and take the non-hosted branch —
+// the terminal gate would never run and the test would pass vacuously against
+// vulnerable code. That is exactly the failure mode this file exists to catch.
+function terminalHTTP(cookie) {
+  return new Promise((resolve, reject) => {
+    const headers = { Host: HOSTED_HOST };
+    if (cookie !== null) headers.Cookie = `hive_hub_user=${cookie}`;
+    const req = httpRequest(
+      { host: '127.0.0.1', port: PROXY_PORT, path: '/terminal', method: 'GET', headers },
+      res => { res.resume(); resolve(res.statusCode); },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function terminalWS(cookie) {
+  return new Promise(resolve => {
+    const headers = { Host: HOSTED_HOST };
+    if (cookie !== null) headers.Cookie = `hive_hub_user=${cookie}`;
+    const ws = new WebSocket(`ws://127.0.0.1:${PROXY_PORT}/terminal`, { headers });
+    const done = opened => { try { ws.close(); } catch {} resolve(opened); };
+    ws.on('open', () => done(true));
+    ws.on('error', () => done(false));
+    ws.on('close', () => done(false));
+    setTimeout(() => done(false), 4000);
+  });
+}
+
+let proxy, go, ttyd;
+try {
+  go = await mockBackend(GO_PORT, 'go');
+  ttyd = await mockTtydWS(TTYD_PORT);
+  proxy = await startProxy();
+  await new Promise(r => setTimeout(r, 400));
+
+  // --- THE VULNERABILITY: a garbage cookie must NOT open a shell -------------
+  for (const forged of ['x', 'anything-at-all', 'clubanderson.not-a-real-signature']) {
+    const status = await terminalHTTP(forged);
+    assert.equal(status, 401,
+      `F3: HTTP /terminal accepted the forged cookie ${JSON.stringify(forged)} (got ${status}) — ` +
+      `this is a shell in a credential-holding container for anyone who can set a header`);
+    const opened = await terminalWS(forged);
+    assert.ok(!opened,
+      `F3: WebSocket /terminal accepted the forged cookie ${JSON.stringify(forged)} — ` +
+      `the upgrade path reaches the SAME ttyd`);
+  }
+  console.log('  ✓ forged / unsigned cookies denied on BOTH the HTTP and WS gates');
+
+  // --- No cookie at all still denied (unchanged behaviour) -------------------
+  assert.equal(await terminalHTTP(null), 401, 'missing cookie must be 401');
+  assert.ok(!(await terminalWS(null)), 'missing cookie WS must be refused');
+  console.log('  ✓ absent cookie denied');
+
+  // --- CONTROL: a genuinely hub-signed cookie still works --------------------
+  const good = mintCookie('alice');
+  assert.equal(await terminalHTTP(good), 200,
+    'a VALID hub-signed cookie must still reach the terminal — the fix must not lock out real users');
+  assert.ok(await terminalWS(good), 'a VALID hub-signed cookie must still open the WS');
+  console.log('  ✓ valid hub-signed cookie still granted (HTTP + WS)');
+
+  // --- Tampering: right shape, wrong signature ------------------------------
+  const tampered = 'mallory.' + good.split('.')[1];
+  assert.equal(await terminalHTTP(tampered), 401,
+    'a re-labelled cookie (alice signature, different username) must be denied');
+  console.log('  ✓ re-labelled cookie denied (signature covers the username)');
+
+  console.log('\n✓ F3 terminal cookie verification tests passed\n');
+} catch (e) {
+  console.error('\n✗ F3 test failed:', e.message, '\n');
+  process.exitCode = 1;
+} finally {
+  if (proxy) proxy.kill();
+  if (go) go.close();
+  if (ttyd) ttyd.close();
+  await new Promise(r => setTimeout(r, 200));
+}


### PR DESCRIPTION
Top-up sync of dd to latest v2 (72 commits). Merge (not squash) to preserve history; dd stays 0-behind v2.

One conflict resolved: `v2/pkg/agent/manager.go` — took v2's derived backend-binary logic (backendBinaryName/backendBinaryAliases, which prevents the accept-then-fail class of bug) AND kept a `backendCommand` shim so dd's specialist subsystem callers still compile. dd's specialist manager and all other divergent work preserved.