### PR TITLE
🐛 keep an approved hive out of the Unassigned section

### DIFF
--- a/v2/pkg/hub/assigned_not_placeholder_test.go
+++ b/v2/pkg/hub/assigned_not_placeholder_test.go
@@ -1,0 +1,93 @@
+package hub
+
+import "testing"
+
+// A freshly-approved placeholder still reports its pool org over the heartbeat
+// until the spoke adopts the pushed config. It must NOT be classified as
+// inventory during that window, or the dashboard parks it under "Unassigned
+// hives" right after the operator approved it.
+func TestIsPlaceholderEntry_AssignedStillPoolOrg(t *testing.T) {
+	h := MyHiveEntry{
+		RegistryEntry: RegistryEntry{ID: "hosted-available-vllmd-14", Org: placeholderOrgPrefix + "vllmd-14"},
+		ProvStatus:    statusAssigned,
+	}
+	if isPlaceholderEntry(h) {
+		t.Fatal("assigned hive classified as placeholder despite statusAssigned")
+	}
+	online := h
+	online.Online = true
+	if !driftEligibleForNorm(online) {
+		t.Fatal("assigned online hive excluded from the fleet norm")
+	}
+}
+
+// The same window seen through the meta-derived signal: a legacy wedge carries
+// a null/empty Status but a real identity, which enrichFromSaaSMeta surfaces as
+// AssignedUnclaimed.
+func TestIsPlaceholderEntry_AssignedUnclaimedPoolOrg(t *testing.T) {
+	h := MyHiveEntry{
+		RegistryEntry:     RegistryEntry{ID: "hosted-available-vllmd-14", Org: placeholderOrgPrefix + "vllmd-14"},
+		AssignedUnclaimed: true,
+	}
+	if isPlaceholderEntry(h) {
+		t.Fatal("assigned-unclaimed hive classified as placeholder")
+	}
+}
+
+// statusAvailable stays authoritative: a slot that was reset back to the pool is
+// inventory again even though AssignedUnclaimed may still be stale on the row.
+func TestIsPlaceholderEntry_AvailableWins(t *testing.T) {
+	h := MyHiveEntry{
+		RegistryEntry:     RegistryEntry{ID: "hosted-available-vllmd-14", Org: "flashsystems"},
+		ProvStatus:        statusAvailable,
+		AssignedUnclaimed: true,
+	}
+	if !isPlaceholderEntry(h) {
+		t.Fatal("statusAvailable slot not classified as placeholder")
+	}
+}
+
+// A clean unclaimed slot with no provStatus at all must still fall through to
+// the org-prefix fallback.
+func TestIsPlaceholderEntry_PrefixFallbackIntact(t *testing.T) {
+	h := MyHiveEntry{RegistryEntry: RegistryEntry{ID: "hosted-available-oke-13", Org: placeholderOrgPrefix + "oke-13"}}
+	if !isPlaceholderEntry(h) {
+		t.Fatal("bare pool-org slot no longer recognised as placeholder")
+	}
+}
+
+// The landing-page mirror must move in lockstep with isPlaceholderEntry, or the
+// fleet tiles and the dashboard sections disagree about the same hive.
+func TestIsAvailableRegistryEntry_LockstepWithPlaceholderEntry(t *testing.T) {
+	cases := []RegistryEntry{
+		{Org: placeholderOrgPrefix + "vllmd-14", ProvStatus: statusAssigned},
+		{Org: placeholderOrgPrefix + "oke-13"},
+		{Org: "flashsystems", ProvStatus: statusAvailable},
+		{Org: "flashsystems", ProvStatus: statusAssigned},
+		{Org: "z-innersource"},
+	}
+	for _, re := range cases {
+		mine := MyHiveEntry{RegistryEntry: re, ProvStatus: re.ProvStatus}
+		if got, want := isAvailableRegistryEntry(re), isPlaceholderEntry(mine); got != want {
+			t.Fatalf("org=%q provStatus=%q: isAvailableRegistryEntry=%v isPlaceholderEntry=%v", re.Org, re.ProvStatus, got, want)
+		}
+	}
+}
+
+// A placeholder that has been assigned is a real hive, so its failing
+// auth-class checks must stop being sanitized away to green — the row should
+// surface as claim-pending, not as healthy inventory.
+func TestSanitizePlaceholderRows_SkipsAssigned(t *testing.T) {
+	rows := []MyHiveEntry{{
+		RegistryEntry: RegistryEntry{
+			ID:     "hosted-available-vllmd-14",
+			Org:    placeholderOrgPrefix + "vllmd-14",
+			Health: map[string]any{"status": "degraded"},
+		},
+		ProvStatus: statusAssigned,
+	}}
+	sanitizePlaceholderRows(rows)
+	if got := rows[0].Health["status"]; got != "degraded" {
+		t.Fatalf("assigned hive health sanitized: got %v, want degraded", got)
+	}
+}

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -216,9 +216,18 @@ func driftEligibleForNorm(h MyHiveEntry) bool {
 // for placeholders that have not reported provStatus yet. Kept in lockstep with
 // the JS so server-computed drift and client-rendered sections can never
 // disagree about what counts as a claimed hive.
+//
+// An assigned slot short-circuits to false before the prefix fallback runs: Org
+// is spoke-reported and still reads "available-<id>" until the spoke adopts the
+// pushed config, so the fallback alone would keep calling a freshly-approved
+// hive inventory for that whole window. ProvStatus and AssignedUnclaimed are
+// both meta-derived and flip the moment the approval is recorded.
 func isPlaceholderEntry(h MyHiveEntry) bool {
 	if h.ProvStatus == statusAvailable {
 		return true
+	}
+	if h.ProvStatus == statusAssigned || h.AssignedUnclaimed {
+		return false
 	}
 	return strings.HasPrefix(h.Org, placeholderOrgPrefix)
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -12435,6 +12435,15 @@ const dashboardHTML = `<!DOCTYPE html>
        two can never disagree about what counts as a placeholder. */
     function isPlaceholderHive(h) {
       if (!h) return false;
+      /* An assigned slot is NOT inventory, even while its org still reads
+         "available-<id>". The assign path writes the real org/repo to meta
+         immediately, but entry.org is spoke-reported and only catches up on the
+         next heartbeat + config adoption. Keying on the org prefix alone parked
+         a freshly-approved hive under "Unassigned hives" for that whole window,
+         which reads as the approval having silently failed. provStatus and
+         assignedUnclaimed both come from meta, so either one settles it the
+         instant the approval lands. */
+      if (h.provStatus === 'assigned' || h.assignedUnclaimed) return false;
       return h.provStatus === 'available' || (!!h.org && h.org.indexOf('available-') === 0);
     }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -2505,9 +2505,18 @@ const fleetStatsMaxAge = 6 * time.Hour
 // Keeping this in lockstep with the JS and drift.go is what lets the landing
 // tiles, the dashboard's Assigned/Unassigned split, and server-side drift never
 // disagree about what is claimed.
+//
+// statusAssigned short-circuits BEFORE the org-prefix fallback. Org here is
+// spoke-reported and keeps reading "available-<id>" until the spoke adopts the
+// pushed config on a later heartbeat, so the fallback alone counted a
+// freshly-approved hive as inventory for that whole window — parking it under
+// "Unassigned hives" right after an approval.
 func isAvailableRegistryEntry(h RegistryEntry) bool {
 	if h.ProvStatus == statusAvailable {
 		return true
+	}
+	if h.ProvStatus == statusAssigned {
+		return false
 	}
 	return strings.HasPrefix(h.Org, placeholderOrgPrefix)
 }


### PR DESCRIPTION
## Problem

Approving a provision request on a pool placeholder writes the real org/repo to the hive's meta record immediately, but the org the dashboard renders is **spoke-reported** and keeps reading `available-<id>` until the spoke adopts the pushed config on a later heartbeat.

All three placeholder predicates fell through to that org prefix, so for the whole adoption window a freshly-approved hive was classified as unclaimed inventory:

- the dashboard parked it under **Unassigned hives**
- the landing tiles counted it as available
- `sanitizePlaceholderRows` rewrote its failing auth-class checks to green

From the operator's seat the approval looked like it had silently done nothing.

Live example: `hosted-available-vllmd-14` was approved to `flashsystems/ess` (L3, owner `fexcoffibm`). Hub meta and the registry entry were both correct — `provStatus: assigned`, `org: flashsystems` — yet the row did not appear in the assigned area during the window where the spoke was still reporting `available-vllmd-14`.

## Fix

Short-circuit on the meta-derived signals **before** the prefix fallback runs. `provStatus == "assigned"` — and, for legacy null-status wedges, `assignedUnclaimed` — flip the instant the approval is recorded.

`statusAvailable` stays authoritative ahead of both, so resetting a slot back to the pool still returns it to inventory. A bare pool-org slot with no `provStatus` still reaches the prefix fallback unchanged.

The three predicates are documented as exact mirrors of each other, so all three move together:

| | file |
|---|---|
| `isPlaceholderHive` (JS) | `v2/pkg/hub/saas.go` |
| `isPlaceholderEntry` | `v2/pkg/hub/drift.go` |
| `isAvailableRegistryEntry` | `v2/pkg/hub/server.go` |

## Tests

`v2/pkg/hub/assigned_not_placeholder_test.go` — 6 tests covering the assigned-with-pool-org case, the legacy `assignedUnclaimed` wedge, `statusAvailable` still winning, the prefix fallback staying intact, health no longer being sanitized on an assigned row, and a table that pins `isAvailableRegistryEntry` and `isPlaceholderEntry` in lockstep across five shapes.

`go build ./...`, `go vet ./pkg/hub/` and the full `./pkg/hub/` suite (41s) all pass.