### PR TITLE
🐛 keep dashboard placeholder ordering in lockstep

### DIFF
--- a/v2/pkg/hub/assigned_not_placeholder_test.go
+++ b/v2/pkg/hub/assigned_not_placeholder_test.go
@@ -1,6 +1,10 @@
 package hub
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 // A freshly-approved placeholder still reports its pool org over the heartbeat
 // until the spoke adopts the pushed config. It must NOT be classified as
@@ -71,6 +75,33 @@ func TestIsAvailableRegistryEntry_LockstepWithPlaceholderEntry(t *testing.T) {
 		if got, want := isAvailableRegistryEntry(re), isPlaceholderEntry(mine); got != want {
 			t.Fatalf("org=%q provStatus=%q: isAvailableRegistryEntry=%v isPlaceholderEntry=%v", re.Org, re.ProvStatus, got, want)
 		}
+	}
+}
+
+// The embedded dashboard JS is not executed by Go tests, so pin the ordering
+// that keeps it in lockstep with the Go predicates: statusAvailable wins before
+// assigned/assignedUnclaimed can short-circuit the prefix fallback.
+func TestEmbeddedPlaceholderHiveAvailableWins(t *testing.T) {
+	src, err := os.ReadFile("saas.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyStart := strings.Index(string(src), "function isPlaceholderHive(h) {")
+	if bodyStart < 0 {
+		t.Fatal("isPlaceholderHive not found")
+	}
+	bodyEnd := strings.Index(string(src)[bodyStart:], "function hiveNamespace")
+	if bodyEnd < 0 {
+		t.Fatal("isPlaceholderHive body end not found")
+	}
+	body := string(src)[bodyStart : bodyStart+bodyEnd]
+	availableAt := strings.Index(body, "h.provStatus === 'available'")
+	assignedAt := strings.Index(body, "h.provStatus === 'assigned'")
+	if availableAt < 0 || assignedAt < 0 {
+		t.Fatalf("expected available and assigned checks in isPlaceholderHive, got body:\n%s", body)
+	}
+	if availableAt > assignedAt {
+		t.Fatal("isPlaceholderHive checks assigned before available; statusAvailable must remain authoritative")
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -12435,6 +12435,7 @@ const dashboardHTML = `<!DOCTYPE html>
        two can never disagree about what counts as a placeholder. */
     function isPlaceholderHive(h) {
       if (!h) return false;
+      if (h.provStatus === 'available') return true;
       /* An assigned slot is NOT inventory, even while its org still reads
          "available-<id>". The assign path writes the real org/repo to meta
          immediately, but entry.org is spoke-reported and only catches up on the
@@ -12444,7 +12445,7 @@ const dashboardHTML = `<!DOCTYPE html>
          assignedUnclaimed both come from meta, so either one settles it the
          instant the approval lands. */
       if (h.provStatus === 'assigned' || h.assignedUnclaimed) return false;
-      return h.provStatus === 'available' || (!!h.org && h.org.indexOf('available-') === 0);
+      return !!h.org && h.org.indexOf('available-') === 0;
     }
 
     /* hiveNamespace returns the Kubernetes namespace a hosted hive's spoke


### PR DESCRIPTION
Follow-up to #3333. Keeps the embedded dashboard isPlaceholderHive predicate aligned with the Go mirrors by ensuring provStatus=available remains authoritative before assigned/assignedUnclaimed short-circuits. Adds a Go regression test that pins the embedded JS ordering.