### PR TITLE
🐛 fix(agent): named model-gateway backends can be kicked (#3302)

### DIFF
--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -343,3 +343,32 @@ func TestBackendBinaryName_RejectsUnknown(t *testing.T) {
 		t.Fatal("backendBinaryName accepted a backend that is in neither canonical list")
 	}
 }
+
+// TestNamedGatewayBackendResolvesToClaude covers #3302: an agent whose backend
+// is a configured model-gateway NAME (e.g. "watsonx-supervisor") passed
+// config.ValidateBackend (which accepts gateway names) but died at kick with
+// "unknown backend" because the launch path resolved the binary from the static
+// list only. A routable gateway backend must resolve to the claude CLI, exactly
+// like the built-in inference backends.
+func TestNamedGatewayBackendResolvesToClaude(t *testing.T) {
+	m := &Manager{logger: discardLogger()}
+	// Inject a gateway checker that recognizes a custom gateway name, mirroring
+	// what config injects at runtime from Governor.ResolvedGateways().
+	m.SetGatewayBackendChecker(func(backend string) bool {
+		return backend == "watsonx-supervisor"
+	})
+
+	if !m.routableBackend("watsonx-supervisor") {
+		t.Fatal("a configured gateway name must be routable")
+	}
+	// The launch path resolves a routable backend to the claude binary; assert
+	// backendBinary("claude") succeeds so the named gateway can actually start.
+	got, err := backendBinary("claude")
+	if err != nil || filepath.Base(got) != "claude" {
+		t.Fatalf("backendBinary(claude) = (%q, %v), want the claude CLI", got, err)
+	}
+	// An unknown, non-gateway backend stays non-routable (no accidental widening).
+	if m.routableBackend("totally-made-up") {
+		t.Error("an unconfigured name must not be treated as routable")
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1076,7 +1076,19 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		backend = agent.BackendOverride
 	}
 
-	binary, err := backendBinary(backend)
+	// A configured model-gateway NAME (e.g. "watsonx-supervisor") is a valid
+	// backend that config.ValidateBackend accepts, but backendBinary only knows
+	// the static CLIBackends/InferenceBackends lists — so a named gateway would
+	// fail here with "unknown backend" even though the test passed (#3302). Every
+	// gateway is OpenAI-compatible and launches the SAME claude CLI pointed at
+	// hive's translator via ANTHROPIC_BASE_URL (identical to InferenceBackends),
+	// so resolve a routable gateway backend to the claude binary directly.
+	resolveBackend := backend
+	if m.routableBackend(backend) {
+		resolveBackend = "claude"
+	}
+
+	binary, err := backendBinary(resolveBackend)
 	if err != nil {
 		agent.State = StateFailed
 		agent.LastError = err.Error()


### PR DESCRIPTION
## Fixes #3302

Reported by `enricom8`: a watsonx gateway tests green, but assigning it to an agent and kicking fails with `unknown backend: watsonx-supervisor`.

### Root cause
An agent whose backend is a configured **gateway NAME** (like `watsonx-supervisor`) passes `config.ValidateBackend` — which accepts any configured gateway name — but the launch path resolved the CLI binary via `backendBinary`, which only knows the static `CLIBackends`/`InferenceBackends` lists. So a named gateway was accepted at config time and died at kick. Classic accept-then-fail, missed by the codex/aider fix (#3278) that only covered the static lists.

### Fix
Every gateway is OpenAI-compatible and launches the same `claude` CLI pointed at hive's translator via `ANTHROPIC_BASE_URL` (like the built-in inference backends). In the launch path, resolve a **routable** gateway backend (`m.routableBackend`, which already consults the injected gateway-name checker) to the `claude` binary.

### Test
`TestNamedGatewayBackendResolvesToClaude` — a configured gateway name is routable and resolves to the claude CLI; an unconfigured name stays non-routable.