### PR TITLE
🐛 fix(ci): pin infra reusable workflows to SHA and drop secrets: inherit

### DIFF
--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,5 +10,6 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
-    secrets: inherit
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,5 +11,4 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@main
-    secrets: inherit
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3


### PR DESCRIPTION
## Summary

- Pin the reusable workflow callsites in `feedback.yml` and `label-helper.yml` to commit `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3` on `kubestellar/infra`.
- Replace `secrets: inherit` with explicit secret passing. `reusable-feedback.yml` consumes only `secrets.GITHUB_TOKEN`. `reusable-label-helper.yml` consumes no secrets.
- No triggers, job names, or permissions change.

## Related issues

Fixes #3330

## Testing

- [ ] `cd v2 && go build ./...`
- [ ] `cd v2 && go test ./...`
- [x] Other / not run (explain): YAML validation only. Both workflow files parse as valid YAML. The pinned commit on `kubestellar/infra` holds the same reusable workflow contents as `main` HEAD. No Go code changes.

## Contributor checklist

- [x] PR targets `v2` unless a maintainer requested another branch.
- [x] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [x] Commits include DCO sign-off (`git commit -s`).
- [ ] Docs, examples, and policies are updated when behavior changes.
- [x] No secrets, credentials, or local runtime state are committed.

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke
