### PR TITLE
🐛 [sec-check] resolve DNS on document-import redirects (SSRF bypass)

### DIFF
--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -233,6 +234,46 @@ func (ds *DocumentSource) Metadata() DocMetadata {
 	return ds.metadata
 }
 
+// docRedirectResolver resolves a redirect target's hostname to IPs. A package
+// var so tests can point it at a stub instead of real DNS.
+var docRedirectResolver = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// docRedirectHostIsPrivate reports whether a redirect target points at a
+// private/internal address, RESOLVING DNS to do so.
+//
+// It deliberately does not reuse gitSourceHostIsPrivate, which by design checks
+// IP literals only: that function guards operator-supplied git sources at
+// config time, where skipping DNS avoids a rebinding TOCTOU and the
+// fail-closed HIVE_ALLOW_PRIVATE_GIT_SOURCE default bounds the exposure.
+// Neither of those conditions holds here. A redirect target is chosen by the
+// remote server at fetch time, is fully attacker-controlled, and has no
+// operator gate — so an IP-literal-only check let a public URL 302 to a
+// hostname that resolves to 169.254.169.254 and reach cloud metadata, which is
+// exactly the bypass the pre-fetch isPrivateURL guard in the API handler
+// (which does resolve) was added to close.
+//
+// Fails closed: an unparseable target or a DNS error is treated as private.
+func docRedirectHostIsPrivate(ctx context.Context, host string) bool {
+	if host == "" {
+		return true
+	}
+	if gitSourceHostIsPrivate(host) {
+		return true
+	}
+	addrs, err := docRedirectResolver(ctx, host)
+	if err != nil || len(addrs) == 0 {
+		return true
+	}
+	for _, addr := range addrs {
+		if gitSourceHostIsPrivate(addr) {
+			return true
+		}
+	}
+	return false
+}
+
 // docNoRedirectToPrivate is a CheckRedirect policy that prevents the HTTP
 // client from following redirects to private/internal hosts. A public URL that
 // returns a 302 to an internal address (e.g. 169.254.169.254 or 10.x) would
@@ -242,7 +283,12 @@ func docNoRedirectToPrivate(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxRedirects)
 	}
-	if gitSourceHostIsPrivate(req.URL.Hostname()) {
+	// Only http(s) may be followed: a redirect to file://, gopher:// or similar
+	// is never legitimate for a document fetch and is a classic SSRF pivot.
+	if scheme := strings.ToLower(req.URL.Scheme); scheme != "http" && scheme != "https" {
+		return fmt.Errorf("redirect to non-http(s) scheme blocked: %s", scheme)
+	}
+	if docRedirectHostIsPrivate(req.Context(), req.URL.Hostname()) {
 		return fmt.Errorf("redirect to private/internal host blocked: %s", req.URL.Host)
 	}
 	return nil

--- a/v2/pkg/knowledge/docsource_redirect_ssrf_test.go
+++ b/v2/pkg/knowledge/docsource_redirect_ssrf_test.go
@@ -1,0 +1,118 @@
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubDocRedirectResolver points docRedirectResolver at a fixed map for the
+// duration of a test, restoring the real resolver afterwards so no test leaks a
+// stubbed DNS into the rest of the package.
+func stubDocRedirectResolver(t *testing.T, hosts map[string][]string) {
+	t.Helper()
+	orig := docRedirectResolver
+	t.Cleanup(func() { docRedirectResolver = orig })
+	docRedirectResolver = func(_ context.Context, host string) ([]string, error) {
+		if addrs, ok := hosts[strings.ToLower(host)]; ok {
+			return addrs, nil
+		}
+		return nil, errors.New("no such host")
+	}
+}
+
+// The exploit this guard exists to stop: a public URL that passes the
+// handler's pre-fetch isPrivateURL check, then 302s to a HOSTNAME (not an IP
+// literal) that resolves to the cloud metadata address. Checking IP literals
+// only let this through and reached 169.254.169.254.
+func TestDocNoRedirectToPrivate_BlocksHostnameResolvingToMetadata(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{
+		"metadata.attacker.example": {"169.254.169.254"},
+	})
+	req := httptest.NewRequest(http.MethodGet, "http://metadata.attacker.example/latest/meta-data/", nil)
+	err := docNoRedirectToPrivate(req, nil)
+	if err == nil {
+		t.Fatal("redirect to hostname resolving to 169.254.169.254 was allowed (SSRF)")
+	}
+	if !strings.Contains(err.Error(), "private/internal host blocked") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Same bypass shape against an RFC1918 target.
+func TestDocNoRedirectToPrivate_BlocksHostnameResolvingToRFC1918(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"internal.attacker.example": {"10.0.0.5"}})
+	req := httptest.NewRequest(http.MethodGet, "https://internal.attacker.example/secret", nil)
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect to hostname resolving to 10.0.0.5 was allowed (SSRF)")
+	}
+}
+
+// A host with several A records must be blocked if ANY of them is internal —
+// otherwise an attacker just adds one public record alongside the private one.
+func TestDocNoRedirectToPrivate_BlocksMixedPublicAndPrivateRecords(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"mixed.attacker.example": {"93.184.216.34", "127.0.0.1"}})
+	req := httptest.NewRequest(http.MethodGet, "https://mixed.attacker.example/x", nil)
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect to host with one private record was allowed (SSRF)")
+	}
+}
+
+// DNS failure must fail CLOSED, matching isPrivateURL in the dashboard.
+func TestDocNoRedirectToPrivate_FailsClosedOnDNSError(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{})
+	req := httptest.NewRequest(http.MethodGet, "https://unresolvable.attacker.example/x", nil)
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect with failing DNS was allowed; guard must fail closed")
+	}
+}
+
+// A redirect to a non-http(s) scheme is never legitimate for a document fetch.
+func TestDocNoRedirectToPrivate_BlocksNonHTTPScheme(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"evil.example": {"93.184.216.34"}})
+	req := httptest.NewRequest(http.MethodGet, "https://evil.example/x", nil)
+	req.URL.Scheme = "file"
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect to file:// was allowed")
+	}
+}
+
+// A genuinely public redirect target must still be followed, so the guard does
+// not break legitimate document imports behind a CDN or shortener.
+func TestDocNoRedirectToPrivate_AllowsPublicTarget(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"docs.example.com": {"93.184.216.34"}})
+	req := httptest.NewRequest(http.MethodGet, "https://docs.example.com/guide.md", nil)
+	if err := docNoRedirectToPrivate(req, nil); err != nil {
+		t.Fatalf("public redirect target blocked: %v", err)
+	}
+}
+
+// The chain-depth cap is enforced before any host check, so a redirect loop
+// between public hosts still terminates.
+func TestDocNoRedirectToPrivate_CapsChainDepth(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"docs.example.com": {"93.184.216.34"}})
+	req := httptest.NewRequest(http.MethodGet, "https://docs.example.com/guide.md", nil)
+	via := []*http.Request{req, req, req}
+	err := docNoRedirectToPrivate(req, via)
+	if err == nil || !strings.Contains(err.Error(), "stopped after") {
+		t.Fatalf("chain depth not capped: %v", err)
+	}
+}
+
+// End-to-end through fetchURL: a real server 302s to a hostname that resolves
+// internally, and the fetch must fail rather than return metadata content.
+func TestFetchURL_RejectsRedirectToInternalHostname(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"metadata.attacker.example": {"169.254.169.254"}})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.attacker.example/latest/meta-data/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	ds := &DocumentSource{}
+	if _, _, err := ds.fetchURL(context.Background(), srv.URL); err == nil {
+		t.Fatal("fetchURL followed a redirect to an internal hostname")
+	}
+}

--- a/v2/pkg/proxy/inference_route_test.go
+++ b/v2/pkg/proxy/inference_route_test.go
@@ -112,7 +112,7 @@ func TestUpdateMaxContextLen(t *testing.T) {
 // applyInferenceAuth — header injection and security guards
 // ---------------------------------------------------------------------------
 
-func TestApplyInferenceAuth(t *testing.T) {
+func TestApplyInferenceAuthRouteHeaders(t *testing.T) {
 	t.Run("no api key sets no auth header", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "http://localhost:8000/v1/chat/completions", nil)
 		route := &InferenceRoute{Backend: "vllm"}
@@ -256,4 +256,3 @@ func TestDefaultInferenceTools(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
## The gap

Found while independently verifying #3194 (SSRF redirect-chain guard, merged `d6a63051`). That PR is correct — but the **knowledge document-import route** guards its two SSRF surfaces asymmetrically:

| surface | guard | resolves DNS? |
|---|---|---|
| pre-fetch, `v2/pkg/dashboard/api.go:7324` | `isPrivateURL` | ✅ yes, fails closed |
| redirect follow-up, `v2/pkg/knowledge/docsource.go` | `gitSourceHostIsPrivate` | ❌ **IP literals only** |

So the exact bypass #3194 was written to close is still open on this route:

1. Submit `https://evil.example/doc.md` — public, passes the preflight.
2. Server responds `302 → http://metadata.attacker.example/latest/meta-data/`.
3. `net.ParseIP("metadata.attacker.example")` returns `nil` → guard returns `false`.
4. Redirect followed; the host resolves to `169.254.169.254` and the fetch reaches **cloud metadata**.

### Proof it was exploitable

Ran against the unmodified pre-fix `docsource.go`:

```
--- FAIL: TestPreFixProof (0.00s)
    VULNERABLE: redirect to hostname (resolving to metadata IP) allowed
```

## The fix

Give the redirect policy its **own** resolving check rather than change `gitSourceHostIsPrivate`.

That function's IP-literal-only behaviour is *correct for what it guards*: operator-supplied git sources validated at config time, where skipping DNS deliberately avoids a rebinding TOCTOU and the fail-closed `HIVE_ALLOW_PRIVATE_GIT_SOURCE` default bounds the exposure. **Neither condition holds for a redirect target**, which the remote server chooses at fetch time, is fully attacker-controlled, and has no operator gate. Changing the shared helper would have silently altered git-source semantics.

`docRedirectHostIsPrivate`:
- resolves the target hostname;
- blocks if **any** returned address is loopback / RFC1918 / link-local / unspecified — so adding one public A record alongside the private one does not help;
- **fails closed** on a DNS error or an empty answer, matching `isPrivateURL`.

Also rejects a redirect to a non-`http(s)` scheme (`file://`, `gopher://`), which is never legitimate for a document fetch and is a standard SSRF pivot.

The resolver is a package var so tests stub it rather than depending on live DNS.

## Tests

`v2/pkg/knowledge/docsource_redirect_ssrf_test.go` — 8 tests: hostname→metadata, hostname→RFC1918, mixed public+private A records, DNS-failure fail-closed, non-http scheme, public target still allowed (no false positives), chain-depth cap, and an end-to-end `fetchURL` test against a real `httptest` server that 302s to an internal hostname.

All 8 pass; the 3 pre-existing `docNoRedirectToPrivate` tests still pass. `go build ./...`, `go vet ./pkg/knowledge/` and the full `./pkg/knowledge/` suite are green.
