### PR TITLE
📖 docs: Docker prereqs, v1 label, ACMM level-change, min config (#3165 #3176 #3168 #3171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Hive separates decisions into two layers: a **deterministic pipeline** of shell 
 
 ## Quick Start (Docker Compose)
 
+**Prerequisites**
+
+- Docker Engine 24+ with the Compose v2 plugin (`docker compose`, not the legacy `docker-compose`)
+- A Linux, macOS, or Windows (WSL2) host on `amd64` or `arm64` — the pre-built images are multi-arch
+- `git`, and a GitHub token (PAT or App) for the org you want the hive to work on
+
 ```bash
 git clone -b v2 https://github.com/kubestellar/hive.git
 cd hive/v2

--- a/config/agent.env.example
+++ b/config/agent.env.example
@@ -1,5 +1,11 @@
 # /etc/hive/agent.env
 #
+# ⚠️  v1 (systemd/tmux) ONLY. This file configures the legacy v1 deployment,
+#     where systemd runs the hive and loads this env file. It does NOT apply to
+#     v2 (the current Docker/Go deployment): v2 config lives in a single
+#     hive.yaml (see v2/hive.yaml.example) and env vars are set in the container,
+#     not here. Ignore this file unless you are running the v1 systemd install.
+#
 # Configuration for the hive runtime. systemd loads this file via
 # EnvironmentFile= for every unit. Change any value, then either:
 #   sudo systemctl stop hive && \

--- a/v2/docs/acmm-policy-matrix.md
+++ b/v2/docs/acmm-policy-matrix.md
@@ -111,3 +111,36 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 4. **Mode escalation is per-agent.** At L4, some agents are measured (issues only) while others are holdgated (issues + PRs). The level defines the mix.
 5. **Knowledge priming works at all levels.** The `${KNOWLEDGE}` template variable injects relevant facts from git sources and wiki layers regardless of the agent's mode.
 6. **Brainstorm is always advisory.** It produces KB facts and beads, never GitHub issues or PRs. Its role evolves from inception (L1) to ongoing ideation (L2+), but its mode stays advisory at all levels.
+
+## Changing a hive's ACMM level
+
+Promoting or demoting a running hive between levels is a single operation — the
+hive reconciles its agent roster and per-agent modes to match the target level.
+
+**From the dashboard:** open the Governor config and set the ACMM level. This is
+the normal path.
+
+**Over the API:** `PUT /api/packs/level` with `{"level": N}` where N is 1–6.
+
+What happens when the level changes (`handlePackSetLevel` → `ApplyPack`):
+
+1. The new level is written to `acmm_level` in `hive.yaml` and persisted.
+2. Per-agent `mode` overrides are cleared so stale modes from the previous level
+   are not re-applied on the next config reload.
+3. `ApplyPack` cascades the target level's pack-defined agent fields (mode,
+   `kick_template`, description, …) into the live config **and reconciles the
+   roster** — adding every agent the level introduces (for example
+   architect/strategist at higher levels) and applying each agent's mode for
+   that level (advisory → measured → holdgated → full).
+
+Notes:
+
+- **Promotion adds agents and capability; demotion narrows it.** Moving up to L6
+  makes agents auto-merge on green CI; moving down returns them to holdgated or
+  advisory. The per-level capability grid is the table at the top of this page.
+- **Operator-created agents are preserved.** `ApplyPack` reconciles pack agents;
+  agents you created yourself are not removed by a level change (deletion is
+  tombstoned separately — see agent configuration).
+- On a hosted hive the level can also be hub/admin-managed; the ConfigMap seed is
+  authoritative for `acmm_level` on those (see the operator reference on config
+  precedence).

--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -8,6 +8,37 @@ For the full centralized environment variable table, including hub, backup,
 inference, deployment, contributor, and legacy helper-script variables, see
 [Environment variable reference](env-vars.md).
 
+## Minimum required configuration
+
+Most of `hive.yaml.example` is optional. The smallest config the hive will start
+with (enforced by `Config.Validate`) is:
+
+- **`project.org`** — the GitHub org the hive works on. Startup crash-loops with
+  `project.org is required` if missing.
+- **at least one repo** under `project.repos` (bare repo name; the org is
+  `project.org`).
+- **GitHub credentials** — one of `github.token`, `github.app_id` (App auth), or
+  `github.forge`. Missing all three fails with
+  `github.token, github.app_id or github.forge is required`.
+- **at least one agent** under `agents:` (a bare `name: { backend, model }` is
+  enough; defaults fill in the rest — see [agent-configuration.md](agent-configuration.md)).
+
+Everything else — `governor` cadences, `knowledge`, `notifications`,
+`dashboard.auth_token`, gateways, `hub` — is optional and has working defaults.
+A minimal `hive.yaml`:
+
+```yaml
+project:
+  org: my-org
+  repos: [my-repo]
+github:
+  token: ${HIVE_GITHUB_TOKEN}
+agents:
+  scanner:
+    backend: copilot
+    model: claude-sonnet-4-6
+```
+
 ## Configuration blocks
 
 Top-level YAML keys accepted by `config.Config`:


### PR DESCRIPTION
Verified guide fixes:
- **Fixes #3165** — Docker Quick Start prerequisites (Docker 24+/Compose v2, OS/arch, git+token).
- **Fixes #3176** — v1-only banner on config/agent.env.example (it's systemd-era; doesn't apply to v2 Docker/Go).
- **Fixes #3168** — ACMM level-change procedure (dashboard or PUT /api/packs/level; what ApplyPack does).
- **Fixes #3171** — minimum required hive.yaml (project.org, a repo, GitHub creds, one agent) + minimal example.

Docs-only. (Also closed #3183 and #3177 this pass — both were already documented accurately.)