### PR TITLE
🐛 [sec-check] block document-import SSRF redirects on v4

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7446,6 +7446,16 @@ func (s *Server) handleDocumentsImport(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "url, file_path, or context7_id is required", http.StatusBadRequest)
 		return
 	}
+	if req.URL != "" {
+		if !strings.HasPrefix(req.URL, "https://") && !strings.HasPrefix(req.URL, "http://") {
+			jsonError(w, "document url must use http or https scheme", http.StatusBadRequest)
+			return
+		}
+		if isPrivateURL(r.Context(), req.URL) {
+			jsonError(w, "document url must not point to private/internal addresses", http.StatusBadRequest)
+			return
+		}
+	}
 	if req.Layer == "" {
 		req.Layer = knowledge.LayerProject
 	}

--- a/v2/pkg/dashboard/api_knowledge_coverage_test.go
+++ b/v2/pkg/dashboard/api_knowledge_coverage_test.go
@@ -275,6 +275,16 @@ func TestCovC_DocumentsImport(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("no source status = %d, want 400", rec.Code)
 	}
+
+	rec = doPost(s, "/api/knowledge/documents", map[string]any{"name": "doc", "url": "file:///etc/passwd"})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("non-http document URL status = %d, want 400", rec.Code)
+	}
+
+	rec = doPost(s, "/api/knowledge/documents", map[string]any{"name": "doc", "url": "http://169.254.169.254/latest/meta-data"})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("private document URL status = %d, want 400", rec.Code)
+	}
 }
 
 func TestCovC_DocumentGetNotFound(t *testing.T) {

--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -228,6 +229,76 @@ func (ds *DocumentSource) Metadata() DocMetadata {
 	return ds.metadata
 }
 
+// docRedirectResolver resolves a redirect target's hostname to IPs. A package
+// var so tests can point it at a stub instead of real DNS.
+var docRedirectResolver = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// docRedirectHostIsPrivate reports whether a redirect target points at a
+// private/internal address, RESOLVING DNS to do so.
+//
+// A redirect target is chosen by the remote server at fetch time, is fully
+// attacker-controlled, and has no operator gate. An IP-literal-only check would
+// let a public URL 302 to a hostname that resolves to 169.254.169.254 and reach
+// cloud metadata, which is exactly the bypass the pre-fetch isPrivateURL guard
+// in the API handler (which does resolve) was added to close.
+//
+// Fails closed: an unparseable target or a DNS error is treated as private.
+func docRedirectHostIsPrivate(ctx context.Context, host string) bool {
+	if host == "" {
+		return true
+	}
+	if docRedirectAddressIsPrivate(host) {
+		return true
+	}
+	addrs, err := docRedirectResolver(ctx, host)
+	if err != nil || len(addrs) == 0 {
+		return true
+	}
+	for _, addr := range addrs {
+		if docRedirectAddressIsPrivate(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func docRedirectAddressIsPrivate(host string) bool {
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	if host == "" || host == "localhost" {
+		return host == "localhost"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+}
+
+// docNoRedirectToPrivate is a CheckRedirect policy that prevents the HTTP
+// client from following redirects to private/internal hosts. A public URL that
+// returns a 302 to an internal address (e.g. 169.254.169.254 or 10.x) would
+// otherwise bypass the pre-fetch isPrivateURL guard in the API handler.
+func docNoRedirectToPrivate(req *http.Request, via []*http.Request) error {
+	const maxRedirects = 3
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	// Only http(s) may be followed: a redirect to file://, gopher:// or similar
+	// is never legitimate for a document fetch and is a classic SSRF pivot.
+	if scheme := strings.ToLower(req.URL.Scheme); scheme != "http" && scheme != "https" {
+		return fmt.Errorf("redirect to non-http(s) scheme blocked: %s", scheme)
+	}
+	if docRedirectHostIsPrivate(req.Context(), req.URL.Hostname()) {
+		return fmt.Errorf("redirect to private/internal host blocked: %s", req.URL.Host)
+	}
+	return nil
+}
+
 func (ds *DocumentSource) fetchURL(ctx context.Context, url string) ([]byte, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, docFetchTimeout)
 	defer cancel()
@@ -238,7 +309,8 @@ func (ds *DocumentSource) fetchURL(ctx context.Context, url string) ([]byte, str
 	}
 	req.Header.Set("User-Agent", docUserAgent)
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{CheckRedirect: docNoRedirectToPrivate}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", fmt.Errorf("HTTP GET: %w", err)
 	}

--- a/v2/pkg/knowledge/docsource_redirect_ssrf_test.go
+++ b/v2/pkg/knowledge/docsource_redirect_ssrf_test.go
@@ -1,0 +1,118 @@
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubDocRedirectResolver points docRedirectResolver at a fixed map for the
+// duration of a test, restoring the real resolver afterwards so no test leaks a
+// stubbed DNS into the rest of the package.
+func stubDocRedirectResolver(t *testing.T, hosts map[string][]string) {
+	t.Helper()
+	orig := docRedirectResolver
+	t.Cleanup(func() { docRedirectResolver = orig })
+	docRedirectResolver = func(_ context.Context, host string) ([]string, error) {
+		if addrs, ok := hosts[strings.ToLower(host)]; ok {
+			return addrs, nil
+		}
+		return nil, errors.New("no such host")
+	}
+}
+
+// The exploit this guard exists to stop: a public URL that passes the
+// handler's pre-fetch isPrivateURL check, then 302s to a HOSTNAME (not an IP
+// literal) that resolves to the cloud metadata address. Checking IP literals
+// only let this through and reached 169.254.169.254.
+func TestDocNoRedirectToPrivate_BlocksHostnameResolvingToMetadata(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{
+		"metadata.attacker.example": {"169.254.169.254"},
+	})
+	req := httptest.NewRequest(http.MethodGet, "http://metadata.attacker.example/latest/meta-data/", nil)
+	err := docNoRedirectToPrivate(req, nil)
+	if err == nil {
+		t.Fatal("redirect to hostname resolving to 169.254.169.254 was allowed (SSRF)")
+	}
+	if !strings.Contains(err.Error(), "private/internal host blocked") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Same bypass shape against an RFC1918 target.
+func TestDocNoRedirectToPrivate_BlocksHostnameResolvingToRFC1918(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"internal.attacker.example": {"10.0.0.5"}})
+	req := httptest.NewRequest(http.MethodGet, "https://internal.attacker.example/secret", nil)
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect to hostname resolving to 10.0.0.5 was allowed (SSRF)")
+	}
+}
+
+// A host with several A records must be blocked if ANY of them is internal —
+// otherwise an attacker just adds one public record alongside the private one.
+func TestDocNoRedirectToPrivate_BlocksMixedPublicAndPrivateRecords(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"mixed.attacker.example": {"93.184.216.34", "127.0.0.1"}})
+	req := httptest.NewRequest(http.MethodGet, "https://mixed.attacker.example/x", nil)
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect to host with one private record was allowed (SSRF)")
+	}
+}
+
+// DNS failure must fail CLOSED, matching isPrivateURL in the dashboard.
+func TestDocNoRedirectToPrivate_FailsClosedOnDNSError(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{})
+	req := httptest.NewRequest(http.MethodGet, "https://unresolvable.attacker.example/x", nil)
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect with failing DNS was allowed; guard must fail closed")
+	}
+}
+
+// A redirect to a non-http(s) scheme is never legitimate for a document fetch.
+func TestDocNoRedirectToPrivate_BlocksNonHTTPScheme(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"evil.example": {"93.184.216.34"}})
+	req := httptest.NewRequest(http.MethodGet, "https://evil.example/x", nil)
+	req.URL.Scheme = "file"
+	if err := docNoRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect to file:// was allowed")
+	}
+}
+
+// A genuinely public redirect target must still be followed, so the guard does
+// not break legitimate document imports behind a CDN or shortener.
+func TestDocNoRedirectToPrivate_AllowsPublicTarget(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"docs.example.com": {"93.184.216.34"}})
+	req := httptest.NewRequest(http.MethodGet, "https://docs.example.com/guide.md", nil)
+	if err := docNoRedirectToPrivate(req, nil); err != nil {
+		t.Fatalf("public redirect target blocked: %v", err)
+	}
+}
+
+// The chain-depth cap is enforced before any host check, so a redirect loop
+// between public hosts still terminates.
+func TestDocNoRedirectToPrivate_CapsChainDepth(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"docs.example.com": {"93.184.216.34"}})
+	req := httptest.NewRequest(http.MethodGet, "https://docs.example.com/guide.md", nil)
+	via := []*http.Request{req, req, req}
+	err := docNoRedirectToPrivate(req, via)
+	if err == nil || !strings.Contains(err.Error(), "stopped after") {
+		t.Fatalf("chain depth not capped: %v", err)
+	}
+}
+
+// End-to-end through fetchURL: a real server 302s to a hostname that resolves
+// internally, and the fetch must fail rather than return metadata content.
+func TestFetchURL_RejectsRedirectToInternalHostname(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{"metadata.attacker.example": {"169.254.169.254"}})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.attacker.example/latest/meta-data/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	ds := &DocumentSource{}
+	if _, _, err := ds.fetchURL(context.Background(), srv.URL); err == nil {
+		t.Fatal("fetchURL followed a redirect to an internal hostname")
+	}
+}


### PR DESCRIPTION
## Security fix

Backports the document-import SSRF redirect guard to v4 and restores the missing API preflight for document URLs.

### Root cause

The v4 document import handler accepted user-supplied document URLs without the v2 preflight, and DocumentSource.fetchURL used the default HTTP client, which follows redirects without re-validating the target. A public URL could therefore redirect to a hostname resolving to cloud metadata/private IPs.

### Fix

- Reject non-http(s) and private/internal initial document URLs in the dashboard handler.
- Add docNoRedirectToPrivate for document fetches.
- Resolve every redirect hostname, block if any returned address is internal, fail closed on DNS errors/empty answers, cap redirect chains at 3, and reject non-http(s) redirect schemes.

### Tests

- Hostname resolving to 169.254.169.254 is blocked.
- RFC1918 and mixed public/private DNS answers are blocked.
- DNS failures fail closed.
- Non-http(s) redirect schemes are blocked.
- Public redirect target still works.
- Redirect chain depth is capped.
- End-to-end fetch refuses the internal-host redirect.
- Direct private document URLs are rejected by the API preflight.

Local verification:
- cd v2 && go build ./...
- cd v2 && go vet ./pkg/knowledge/ ./pkg/dashboard/
- cd v2 && go test ./pkg/knowledge/ -count=1
- cd v2 && go test ./pkg/dashboard/ -run 'TestCovC_DocumentsImport' -count=1
