### PR TITLE
🐛 [sec-check] guard v4 knowledge client redirects

### DIFF
--- a/v2/pkg/knowledge/client.go
+++ b/v2/pkg/knowledge/client.go
@@ -29,7 +29,8 @@ func NewClient(baseURL string, logger *slog.Logger) *Client {
 	return &Client{
 		baseURL: baseURL,
 		httpClient: &http.Client{
-			Timeout: defaultTimeout,
+			Timeout:       defaultTimeout,
+			CheckRedirect: knowledgeNoRedirectToPrivate,
 		},
 		logger: logger,
 	}

--- a/v2/pkg/knowledge/client_extra_test.go
+++ b/v2/pkg/knowledge/client_extra_test.go
@@ -52,6 +52,21 @@ func TestClient_Stats_Error(t *testing.T) {
 	}
 }
 
+func TestClient_BlocksRedirectToInternalHostname(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{
+		"metadata.attacker.example": {"169.254.169.254"},
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.attacker.example/latest/meta-data", http.StatusFound)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, extraTestLogger())
+	if _, err := c.Search(context.Background(), "secret", "", 1); err == nil {
+		t.Fatal("knowledge client followed a redirect to an internal hostname")
+	}
+}
+
 func TestClient_Healthy(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/stats", func(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -284,6 +284,13 @@ func docRedirectAddressIsPrivate(host string) bool {
 // returns a 302 to an internal address (e.g. 169.254.169.254 or 10.x) would
 // otherwise bypass the pre-fetch isPrivateURL guard in the API handler.
 func docNoRedirectToPrivate(req *http.Request, via []*http.Request) error {
+	return knowledgeNoRedirectToPrivate(req, via)
+}
+
+// knowledgeNoRedirectToPrivate is a CheckRedirect policy for user-configurable
+// knowledge HTTP endpoints. It keeps redirect validation as strong as the
+// dashboard preflight checks on the original URL.
+func knowledgeNoRedirectToPrivate(req *http.Request, via []*http.Request) error {
 	const maxRedirects = 3
 	if len(via) >= maxRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxRedirects)


### PR DESCRIPTION
## Security fix

v4 follow-up from the CheckRedirect audit after #3348.

### Root cause

Knowledge subscription/layer clients followed redirects without re-validating each redirect target. A public wiki endpoint could redirect Search/Read/Ingest/Delete calls to a hostname resolving to cloud metadata or another internal address.

### Fix

- Route knowledge Client redirects through the resolving, fail-closed redirect guard used by document imports.
- Preserve the chain-depth cap, non-http(s) scheme rejection, DNS-failure fail-closed behavior, and any-private-address blocking.

### Tests

- Added TestClient_BlocksRedirectToInternalHostname for a redirect to a hostname resolving to 169.254.169.254.

### Local verification

- cd v2 && go build ./...
- cd v2 && go vet ./pkg/knowledge/
- cd v2 && go test ./pkg/knowledge/ -count=1
