### PR TITLE
🐛 sec(dashboard): fail closed when X-Hive-Role is absent on config provenance (v4)

### DIFF
--- a/v2/pkg/dashboard/api_provenance.go
+++ b/v2/pkg/dashboard/api_provenance.go
@@ -78,10 +78,14 @@ type layerInfo struct {
 // and effective values, so it is operator information rather than public
 // status. Secret values are redacted regardless.
 func (s *Server) handleConfigProvenance(w http.ResponseWriter, r *http.Request) {
+	// Fail CLOSED on an absent role. This previously defaulted an empty
+	// X-Hive-Role to "owner", so any request that simply omitted the header
+	// read the full config provenance. The header is server-set: the auth
+	// middleware strips every inbound copy and re-stamps it only after
+	// authenticating, and the token-less "open by design" branch stamps
+	// owner explicitly — so an empty value here means the request never
+	// transited a path that established an owner identity.
 	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		role = "owner"
-	}
 	if role != "owner" {
 		http.Error(w, "owner access required", http.StatusForbidden)
 		return

--- a/v2/pkg/dashboard/api_provenance_test.go
+++ b/v2/pkg/dashboard/api_provenance_test.go
@@ -201,3 +201,39 @@ func TestProvenanceRedactsSecrets(t *testing.T) {
 		t.Fatal("response leaked the github token")
 	}
 }
+
+// TestProvenanceRejectsEmptyRole is the regression test for the empty-role
+// authorization bypass: when X-Hive-Role is absent, the handler must fail
+// CLOSED (403) rather than defaulting to "owner". The prior code granted owner
+// access to any request that simply omitted the header.
+func TestProvenanceRejectsEmptyRole(t *testing.T) {
+	writeProvenanceFixture(t, "project:\n  org: acme\nagents:\n  scanner: {}\n", "")
+
+	// getProvenance with "" does NOT set X-Hive-Role — simulating a request
+	// from a caller that omits the header entirely.
+	rec, _ := getProvenance(t, "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("empty X-Hive-Role: status = %d, want 403 (fail closed); "+
+			"before this fix an omitted header defaulted to owner", rec.Code)
+	}
+}
+
+// A non-owner role must still be rejected, so the fail-closed change did not
+// merely move the bypass to a different value.
+func TestProvenanceRejectsNonOwnerRole(t *testing.T) {
+	writeProvenanceFixture(t, "project:\n  org: acme\nagents:\n  scanner: {}\n", "")
+	rec, _ := getProvenance(t, "viewer")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("viewer role: status = %d, want 403", rec.Code)
+	}
+}
+
+// A genuine owner must still be served, so failing closed did not lock out the
+// legitimate caller.
+func TestProvenanceAllowsOwnerRole(t *testing.T) {
+	writeProvenanceFixture(t, "project:\n  org: acme\nagents:\n  scanner: {}\n", "")
+	rec, _ := getProvenance(t, "owner")
+	if rec.Code != http.StatusOK {
+		t.Errorf("owner role: status = %d, want 200", rec.Code)
+	}
+}


### PR DESCRIPTION
## The bug

`handleConfigProvenance` defaulted an empty `X-Hive-Role` to `"owner"`:

```go
role := r.Header.Get("X-Hive-Role")
if role == "" {
    role = "owner"     // <-- any request that OMITS the header becomes owner
}
if role != "owner" {
    http.Error(w, "owner access required", http.StatusForbidden)
```

So the way to get owner access was to **send no role header at all**. The endpoint returns full config provenance — seed and overlay values, per-field origins, and the GHE identity.

This was fixed on **v2** in #3322. **v4 still carried it.** Found while independently verifying that PR's merge.

## Why failing closed is safe

The role header is server-set, not client-supplied. `v2/pkg/dashboard/server.go` deletes every inbound copy of `X-Hive-User`, `X-Hive-Role` and `X-Hive-Owner-Role-Verified` *before* any auth path runs, then re-stamps them only after authenticating — and the token-less "open by design" branch stamps `owner` explicitly, so a local install is not locked out.

An empty value at this handler therefore means the request never transited a path that established an owner identity, which is precisely when it should be refused. The shared-token internal path carries no user identity and now correctly gets a 403 instead of silently inheriting owner.

## Proof the test isn't vacuous

Restored the `empty defaults to owner` branch and re-ran the regression test:

```
--- FAIL: TestProvenanceRejectsEmptyRole (0.00s)
    empty X-Hive-Role: status = 200, want 403 (fail closed)
```

**200** — the full config leak. The fix returns it to 403.

## Tests

`v2/pkg/dashboard/api_provenance_test.go`:

- `TestProvenanceRejectsEmptyRole` — the bypass, 403.
- `TestProvenanceRejectsNonOwnerRole` — confirms failing closed did not just move the bypass to another value.
- `TestProvenanceAllowsOwnerRole` — confirms a genuine owner is still served 200, so the legitimate caller is not locked out.

`go build ./...`, `go vet ./pkg/dashboard/` and the full `./pkg/dashboard/` suite (24s) all pass.
