### PR TITLE
🐛 sec(dashboard): port v4 owner-role provenance hardening

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1305,17 +1305,16 @@ func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, p
 	})
 }
 
-// requireOwnerRole returns true when the request carries owner-level access.
-// An empty X-Hive-Role is treated as owner (open/dev spokes with no auth_token
-// or hub-proxied spokes where the hub omits the header). Any non-owner role
-// set by the hub or device-flow session is rejected. Call this for state-mutating
-// endpoints that should be restricted to operators (pause, resume, fleet breaker).
+// requireOwnerRole returns true when authenticate established owner-level access.
+// A client-supplied X-Hive-Role is not enough: authenticate strips inbound role
+// headers before auth and sets ownerRoleVerifiedHeader only for trusted owner
+// sessions or proof-verified hub proxy identities. Owner-only mutations must
+// require its server-only verification marker, so legacy/proofless proxy
+// headers and shared-token requests fail closed instead of trusting spoofable
+// client input.
 func requireOwnerRole(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		return true // open spoke or internal automation — treat as owner
-	}
-	if role != "owner" {
+	if role != "owner" || r.Header.Get(ownerRoleVerifiedHeader) != "true" {
 		jsonError(w, "owner access required", http.StatusForbidden)
 		return false
 	}

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -879,7 +879,7 @@ func TestHandleUnpin_NotFound(t *testing.T) {
 
 func TestHandlePause(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -1353,7 +1353,7 @@ func TestHandleModelSet_UnknownAgent(t *testing.T) {
 
 func TestHandleResume_UnknownAgent(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/resume/nonexistent", nil)
+	rec := doOwnerPost(s, "/api/resume/nonexistent", nil)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}

--- a/v2/pkg/dashboard/api_pause_toggle_test.go
+++ b/v2/pkg/dashboard/api_pause_toggle_test.go
@@ -23,7 +23,7 @@ func decodeToggleBody(t *testing.T, body []byte) map[string]interface{} {
 
 func TestHandlePause_RealTransitionReportsChangedTrue(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
@@ -41,10 +41,10 @@ func TestHandlePause_RealTransitionReportsChangedTrue(t *testing.T) {
 
 func TestHandlePause_NoopReturnsChangedFalse(t *testing.T) {
 	s, _ := apiServer(t)
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("first pause status = %d, want 200", rec.Code)
 	}
-	rec := doPost(s, "/api/pause/scanner", nil)
+	rec := doOwnerPost(s, "/api/pause/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("second pause status = %d, want 200 (ok:true is part of the contract)", rec.Code)
 	}
@@ -63,7 +63,7 @@ func TestHandlePause_NoopReturnsChangedFalse(t *testing.T) {
 func TestHandleResume_NoopReturnsChangedFalse(t *testing.T) {
 	s, _ := apiServer(t)
 	// scanner starts un-paused: resuming it is a no-op.
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (no-op resume must not touch tmux)", rec.Code)
 	}
@@ -81,10 +81,10 @@ func TestHandleResume_NoopReturnsChangedFalse(t *testing.T) {
 
 func TestHandleResume_RealTransitionReportsChangedTrue(t *testing.T) {
 	s, _ := apiServer(t)
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("pause status = %d, want 200", rec.Code)
 	}
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	// A real resume relaunches the agent session; in environments without a
 	// working tmux this legitimately fails with 400 (same tolerance as
 	// TestHandleResume). The contract under test is: when it DOES succeed,
@@ -115,7 +115,7 @@ func TestHandleAgentState_ReflectsAuthoritativePause(t *testing.T) {
 		t.Errorf("fresh agent: paused = %v, state = %v; want false/running", m["paused"], m["state"])
 	}
 
-	if rec := doPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
+	if rec := doOwnerPost(s, "/api/pause/scanner", nil); rec.Code != http.StatusOK {
 		t.Fatalf("pause status = %d, want 200", rec.Code)
 	}
 

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -87,6 +87,22 @@ func doPost(s *Server, path string, body interface{}) *httptest.ResponseRecorder
 	return rec
 }
 
+func markOwnerRequest(req *http.Request) {
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
+}
+
+func doOwnerPost(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
+	var b bytes.Buffer
+	json.NewEncoder(&b).Encode(body)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, &b)
+	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
 func doPut(s *Server, path string, body interface{}) *httptest.ResponseRecorder {
 	var b bytes.Buffer
 	json.NewEncoder(&b).Encode(body)
@@ -951,7 +967,7 @@ func TestHandleKick_NoMessage(t *testing.T) {
 
 func TestHandlePause_NotFound(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/pause/nonexistent", map[string]interface{}{})
+	rec := doOwnerPost(s, "/api/pause/nonexistent", map[string]interface{}{})
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}
@@ -1018,7 +1034,7 @@ func TestHandleModelSet_NotFound(t *testing.T) {
 func TestHandleResume(t *testing.T) {
 	s, _ := apiServer(t)
 	// Resume may fail because agent isn't actually running
-	rec := doPost(s, "/api/resume/scanner", nil)
+	rec := doOwnerPost(s, "/api/resume/scanner", nil)
 	// Accept OK or BadRequest (tmux not available)
 	if rec.Code != http.StatusOK && rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d", rec.Code)
@@ -1027,7 +1043,7 @@ func TestHandleResume(t *testing.T) {
 
 func TestHandleResume_NotFound(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/resume/nonexistent", nil)
+	rec := doOwnerPost(s, "/api/resume/nonexistent", nil)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
 	}

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -33,3 +33,137 @@ func TestOwnerOnlyAgentControlsRejectNonOwners(t *testing.T) {
 		})
 	}
 }
+
+func TestOwnerOnlyMutationsRejectSharedTokenWithoutRole(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"pause", "/api/pause/scanner"},
+		{"resume", "/api/resume/scanner"},
+		{"breaker engage", "/api/breaker/engage"},
+		{"breaker release", "/api/breaker/release"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newFullServer(t)
+			s.authToken = "shared-secret-token"
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+s.authToken)
+			w := httptest.NewRecorder()
+
+			s.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("shared-token request without server role status = %d, want 403", w.Code)
+			}
+		})
+	}
+}
+
+func TestOwnerOnlyMutationsRejectSpoofedOwnerRoleWithSharedToken(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	req.Header.Set("X-Hive-User", "attacker")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("spoofed owner role with shared token status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsRejectSpoofedOwnerVerificationMarker(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	req.Header.Set("X-Hive-User", "attacker")
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set("X-Hive-Owner-Role-Verified", "true")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("spoofed owner verification marker with shared token status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsRejectInternalSharedTokenWithoutVerifiedRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("internal shared token without verified role status = %d, want 403", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsAllowOwnerSessionWithInternalAuth(t *testing.T) {
+	s := newDirectRouteServer(t, "owneruser")
+	sid := s.createUserSession("owneruser", "owner")
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner session with internal auth status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestOwnerOnlyMutationsAllowVerifiedHubOwnerRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-User", "owner")
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, s.authToken)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("verified hub owner role status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestOwnerOnlyMutationsRejectProoflessHubOwnerRole(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-User", "owner")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("proofless hub owner role status = %d, want 401", w.Code)
+	}
+}
+
+func TestOwnerOnlyMutationsPreserveOpenSpokeOwnerBehavior(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = ""
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("open spoke owner behavior status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -47,23 +46,15 @@ const terminalAssertionCookieName = "hive_terminal_assertion"
 // network. See authenticate() (F2). Must match the hub's constant.
 const proxyAuthHeader = "X-Hive-Proxy-Auth"
 
-// proxyProofRequired controls F2 enforcement strictness. It now defaults to
-// TRUE (fail closed): a hub-proxied request that carries identity headers but
-// NO valid X-Hive-Proxy-Auth proof is rejected, so a request forged on the pod
-// network that reaches :3002 directly (bypassing the hub nginx) cannot be
-// trusted on its X-Hive-User/X-Hive-Role alone (F7, CWE-306). The hub half is
-// shipped fleet-wide — its auth-check success path injects X-Hive-Proxy-Auth
-// (see hub saas.go handleSaaSAuthCheck) and its nginx forwards it via the
-// auth-response-headers annotation — so the legitimate proxied path always
-// presents a valid proof and stays trusted.
-//
-// A WRONG proof header is ALWAYS rejected regardless of this flag. The only
-// difference this flag makes is how a MISSING proof is treated: strict (default)
-// rejects it; fail-open trusts the identity headers. Set
-// HIVE_PROXY_PROOF_REQUIRED=false ONLY as a temporary escape hatch if a hub is
-// found not to be injecting the proof (e.g. mid-rollback); it re-opens the F7
-// hole and must not be left set in production.
-var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") != "false"
+// ownerRoleVerifiedHeader is a server-only request marker set by authenticate
+// when the owner role came from a trusted source, not an inbound client header.
+const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
+
+// proxyProofRequired controls F2 enforcement strictness. Default true =
+// fail-closed: a request with no X-Hive-Proxy-Auth proof header (or a wrong
+// one) is rejected even if it carries X-Hive-User/X-Hive-Role identity.
+// A WRONG proof header is ALWAYS rejected regardless of this setting.
+var proxyProofRequired = true
 
 type Server struct {
 	port       int
@@ -886,19 +877,28 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+			} else if r.Header.Get("X-Hive-Role") == "" {
+				r.Header.Set("X-Hive-Role", config.RoleOwner)
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
+			} else if r.Header.Get("X-Hive-Role") == config.RoleOwner {
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
 			}
 			next.ServeHTTP(w, r)
 			return
 		}
+		inboundUser := r.Header.Get("X-Hive-User")
+		inboundRole := r.Header.Get("X-Hive-Role")
 
-		// On a direct-route spoke (per-hive allowlist present) we MUST NOT trust
-		// client-supplied X-Hive-User/X-Hive-Role: there is no hub nginx in
-		// front to strip forged identity headers. Strip them here so identity
-		// can only come from a server-side session we minted.
-		if directRouteAuthz {
-			r.Header.Del("X-Hive-User")
-			r.Header.Del("X-Hive-Role")
-		}
+		// Treat identity headers as an internal request attribute. Preserve the
+		// inbound values only in the hub-proxy branch below, after that path has
+		// been authenticated as trusted; all other auth paths must set any role
+		// explicitly so clients cannot spoof owner access with X-Hive-Role.
+		r.Header.Del("X-Hive-User")
+		r.Header.Del("X-Hive-Role")
+		r.Header.Del(ownerRoleVerifiedHeader)
 
 		// Internal automation authenticates with the shared token via the
 		// X-Hive-Internal header; this is a trusted server-to-server path
@@ -907,7 +907,17 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// is TRUE, so without this an absent/empty header would authenticate on
 		// a direct-route spoke that has no token. The shared-token paths are only
 		// valid when a real token is configured.
-		trusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
+		internalTrusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
+		trusted := internalTrusted
+		if internalTrusted {
+			if sess := s.sessionFromRequest(r); sess != nil {
+				r.Header.Set("X-Hive-User", sess.Username)
+				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+			}
+		}
 
 		// Hub-proxied path: nginx injects the identity headers from the hub's
 		// per-user/per-hive auth-check. Only trust them when this spoke is NOT a
@@ -920,27 +930,39 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// only the trusted proxy can produce. Require it as PROOF the request
 		// transited the hub.
 		//
-		// FAIL CLOSED by default (F7): if the hub has NOT sent X-Hive-Proxy-Auth,
-		// the request is rejected — it did not demonstrably transit the hub nginx,
-		// so its identity headers are not trustworthy. The hub half is deployed
-		// fleet-wide, so the legitimate proxied path always carries a valid proof.
-		// The pre-F2 fail-open behavior (trust identity headers when no proof is
-		// present) is available ONLY as a temporary escape hatch by setting
-		// HIVE_PROXY_PROOF_REQUIRED=false; see proxyProofRequired.
+		// Missing or incorrect proof fails closed. Older hub images that do not
+		// inject X-Hive-Proxy-Auth must be upgraded before their identity headers
+		// are accepted.
+		proxyProofRejectReason := ""
 		if !trusted && !directRouteAuthz &&
-			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
+			inboundUser != "" && inboundRole != "" {
 			proof := r.Header.Get(proxyAuthHeader)
 			switch {
 			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
 				// Proof present and valid — definitely came through the hub.
 				trusted = true
+				if inboundRole == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
 			case proof == "" && !proxyProofRequired:
 				// No proof header yet (hub not upgraded) and we're not enforcing
 				// strictly — trust the identity headers as before (rollout window).
+				// Do not mark owner as verified in this legacy path: missing proof
+				// keeps reads/general writes compatible but owner-only mutations
+				// must fail closed.
 				trusted = true
 			default:
 				// Proof header present but WRONG, or strict mode with no proof:
 				// this did not come through the trusted hub proxy — reject.
+				if proof == "" {
+					proxyProofRejectReason = "missing proxy proof header"
+				} else {
+					proxyProofRejectReason = "invalid proxy proof header"
+				}
+			}
+			if trusted {
+				r.Header.Set("X-Hive-User", inboundUser)
+				r.Header.Set("X-Hive-Role", inboundRole)
 			}
 		}
 
@@ -952,6 +974,9 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
+				if sess.Role == config.RoleOwner {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
 				trusted = true
 			}
 		}
@@ -977,6 +1002,10 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		if !trusted {
 			if strings.HasPrefix(r.URL.Path, "/api/") {
 				w.Header().Set("Content-Type", "application/json")
+				if proxyProofRejectReason != "" {
+					http.Error(w, fmt.Sprintf(`{"error":%q}`, proxyProofRejectReason), http.StatusUnauthorized)
+					return
+				}
 				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 			} else {
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -266,17 +265,21 @@ func TestMiddleware_F2ProxyProof(t *testing.T) {
 	}
 }
 
-// TestProxyProofRequiredDefaultsStrict pins F7: the shipped default must be
-// fail-closed. A hub-proxied spoke that receives forged X-Hive-User/X-Hive-Role
-// with NO proof header must be rejected out of the box, not trusted. If someone
-// flips the default back to fail-open, this test breaks.
-func TestProxyProofRequiredDefaultsStrict(t *testing.T) {
-	// Unset means "not =false", which is the production default.
-	if os.Getenv("HIVE_PROXY_PROOF_REQUIRED") == "false" {
-		t.Skip("HIVE_PROXY_PROOF_REQUIRED=false escape hatch set in env; default not under test")
+func TestMiddleware_F2ProxyProofDefaultRejectsMissingProof(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("X-Hive-User", "clubanderson")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing proof with default enforcement = %d, want 401", w.Code)
 	}
-	if !proxyProofRequired {
-		t.Fatal("proxyProofRequired must default to true (fail closed) so forged identity headers with no proof are rejected (F7)")
+	if !strings.Contains(w.Body.String(), "missing proxy proof header") {
+		t.Fatalf("missing proof error = %q, want clear proxy proof error", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Port the v2 dashboard auth-surface hardening to v4.
- Strip inbound `X-Hive-User`, `X-Hive-Role`, and `X-Hive-Owner-Role-Verified` before any auth path trusts identity.
- Require a server-set `X-Hive-Owner-Role-Verified` marker for owner-only pause/resume/fleet-breaker mutations.
- Remove the `HIVE_PROXY_PROOF_REQUIRED=false` fail-open production escape hatch by making proxy proof enforcement fail closed by default.

## Security model
Identity/role headers are request attributes created by `authenticate`, not caller-controlled authorization inputs. Hub-proxied headers are restored only after a valid `X-Hive-Proxy-Auth` proof. Owner-only mutations require both `X-Hive-Role: owner` and the server-only owner verification marker.

## Pre-fix proof
With the new regression tests applied to pre-fix v4 production code, these failed:
- `TestOwnerOnlyMutationsRejectSpoofedOwnerRoleWithSharedToken`: got 200, want 403.
- `TestOwnerOnlyMutationsRejectInternalSharedTokenWithoutVerifiedRole`: got 200, want 403.
- `TestMiddleware_F2ProxyProofDefaultRejectsMissingProof`: returned generic unauthorized instead of the fail-closed proxy-proof path.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go vet ./pkg/dashboard/`
- `cd v2 && go test ./pkg/dashboard/ -count=1`
