### PR TITLE
🐛 sec(dashboard): port the SSRF guard to v4 (agent import fetched any URL)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4641,7 +4641,9 @@ func probeModelsWithHeaders(endpoint, apiKey string, extraHeaders map[string]str
 			req.Header.Set(k, v)
 		}
 	}
-	client := &http.Client{Timeout: litellmProbeTimeout}
+	// Re-validate every redirect hop: a gateway endpoint is operator-supplied
+	// but the redirect target is chosen by the remote server at request time.
+	client := &http.Client{Timeout: litellmProbeTimeout, CheckRedirect: noRedirectToPrivate}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("cannot reach gateway: %w", err)

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -257,7 +257,18 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, fmt.Sprintf("url must be at most %d characters", importMaxURLLen), http.StatusBadRequest)
 			return
 		}
-		client := &http.Client{Timeout: importHTTPTimeoutS * 1e9} // nanoseconds
+		// Validate before fetching, then re-validate every redirect hop.
+		// Without both, this handler fetched an arbitrary caller-supplied URL
+		// and returned its body — a direct SSRF into cluster-internal services
+		// and the cloud metadata endpoint.
+		if err := validateImportFetchURL(r.Context(), body.URL); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		client := &http.Client{
+			Timeout:       importHTTPTimeoutS * 1e9, // nanoseconds
+			CheckRedirect: noRedirectToPrivate,
+		}
 		resp, err := client.Get(body.URL)
 		if err != nil {
 			jsonError(w, "failed to fetch URL: "+err.Error(), http.StatusBadGateway)
@@ -510,4 +521,34 @@ func (s *Server) reInitSubsystems() {
 	if s.deps != nil && s.deps.ReInitFunc != nil {
 		s.deps.ReInitFunc()
 	}
+}
+
+// validateImportFetchURL is the pre-fetch SSRF guard for agent-definition
+// imports. It deliberately restricts only the TRANSPORT and the DESTINATION,
+// not which sites may be imported from, so it closes the vulnerability without
+// changing what users are allowed to import.
+//
+// Pairs with noRedirectToPrivate on the client: this checks the URL the caller
+// supplied, and that re-checks every hop the remote server redirects to, so a
+// public URL cannot 302 its way to an internal address.
+func validateImportFetchURL(ctx context.Context, rawURL string) error {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	// file://, gopher:// and friends are never a legitimate import transport
+	// and are the classic pivot for reading local files.
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("import URL must use http:// or https:// scheme (got %q)", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("import URL must include a host")
+	}
+	// isPrivateURL resolves DNS and fails closed, so a hostname that resolves
+	// to 169.254.169.254 or an RFC1918 address is rejected too — not just a
+	// literal IP.
+	if isPrivateURL(ctx, rawURL) {
+		return fmt.Errorf("import URL must not point to private/internal addresses")
+	}
+	return nil
 }

--- a/v2/pkg/dashboard/api_agents_test.go
+++ b/v2/pkg/dashboard/api_agents_test.go
@@ -592,13 +592,14 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	s, deps := apiServer(t)
 	deps.Config.Data.AgentsDir = t.TempDir()
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source": "url",
-		"url":    ts.URL + "/agent.yaml",
+		"url":    "https://raw.githubusercontent.com/kubestellar/hive/main/agent.yaml",
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
@@ -615,11 +616,12 @@ func TestHandleAgentImport_URLFetchFails(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	s, _ := apiServer(t)
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source": "url",
-		"url":    ts.URL + "/agent.yaml",
+		"url":    "https://raw.githubusercontent.com/kubestellar/hive/main/agent.yaml",
 	})
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d: %s", rec.Code, rec.Body.String())

--- a/v2/pkg/dashboard/definition_source_test.go
+++ b/v2/pkg/dashboard/definition_source_test.go
@@ -79,10 +79,11 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/kubestellar/hive/blob/main/plain.yaml",
+		"url":        "https://github.com/kubestellar/hive/blob/main/plain.yaml",
 		"keepLinked": false,
 	})
 	if rec.Code != http.StatusOK {
@@ -115,13 +116,14 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	// The blob path makes the parsed slug "kubestellar/hive"; allowlist it.
 	enableDefinitionAllowlist(deps, "kubestellar/hive")
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/kubestellar/hive/blob/main/agents/linked.yaml",
+		"url":        "https://github.com/kubestellar/hive/blob/main/agents/linked.yaml",
 		"keepLinked": true,
 	})
 	if rec.Code != http.StatusOK {
@@ -161,10 +163,11 @@ spec:
 		w.Write([]byte(yamlContent))
 	}))
 	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
 
 	rec := doPost(s, "/api/agents/import", map[string]interface{}{
 		"source":     "url",
-		"url":        ts.URL + "/attacker/evil/blob/main/agent.yaml",
+		"url":        "https://github.com/attacker/evil/blob/main/agent.yaml",
 		"keepLinked": true,
 	})
 	if rec.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/import_ssrf_test.go
+++ b/v2/pkg/dashboard/import_ssrf_test.go
@@ -1,0 +1,119 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubImportResolver points the shared privateURLResolver at a fixed map so
+// these tests never depend on live DNS, restoring it afterwards.
+func stubImportResolver(t *testing.T, hosts map[string][]string) {
+	t.Helper()
+	orig := privateURLResolver
+	t.Cleanup(func() { privateURLResolver = orig })
+	privateURLResolver = func(_ context.Context, host string) ([]string, error) {
+		if addrs, ok := hosts[strings.ToLower(host)]; ok {
+			return addrs, nil
+		}
+		return nil, errors.New("no such host")
+	}
+}
+
+// The core vulnerability: the agent-import handler fetched whatever URL the
+// caller supplied and returned the body, so pointing it at the cloud metadata
+// endpoint exfiltrated instance credentials.
+func TestValidateImportFetchURL_BlocksMetadataIPLiteral(t *testing.T) {
+	stubImportResolver(t, map[string][]string{})
+	err := validateImportFetchURL(context.Background(), "http://169.254.169.254/latest/meta-data/")
+	if err == nil {
+		t.Fatal("import URL pointing at cloud metadata was accepted (SSRF)")
+	}
+	if !strings.Contains(err.Error(), "private/internal") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// An IP-literal check alone is not enough: the guard must resolve DNS so a
+// hostname pointing at an internal address is rejected too.
+func TestValidateImportFetchURL_BlocksHostnameResolvingInternally(t *testing.T) {
+	stubImportResolver(t, map[string][]string{"metadata.attacker.example": {"169.254.169.254"}})
+	if err := validateImportFetchURL(context.Background(), "https://metadata.attacker.example/x"); err == nil {
+		t.Fatal("hostname resolving to metadata IP was accepted (SSRF)")
+	}
+}
+
+// Cluster-internal services are the other high-value target.
+func TestValidateImportFetchURL_BlocksClusterInternal(t *testing.T) {
+	stubImportResolver(t, map[string][]string{"hive.hive-hub.svc.cluster.local": {"10.0.1.7"}})
+	if err := validateImportFetchURL(context.Background(), "http://hive.hive-hub.svc.cluster.local/api/config"); err == nil {
+		t.Fatal("cluster-internal service URL was accepted (SSRF)")
+	}
+}
+
+// file:// is never a legitimate import transport and is the classic pivot for
+// reading local files.
+func TestValidateImportFetchURL_BlocksNonHTTPScheme(t *testing.T) {
+	stubImportResolver(t, map[string][]string{})
+	if err := validateImportFetchURL(context.Background(), "file:///etc/passwd"); err == nil {
+		t.Fatal("file:// import URL was accepted")
+	}
+}
+
+// DNS failure must fail closed, matching isPrivateURL's contract.
+func TestValidateImportFetchURL_FailsClosedOnDNSError(t *testing.T) {
+	stubImportResolver(t, map[string][]string{})
+	if err := validateImportFetchURL(context.Background(), "https://unresolvable.attacker.example/x"); err == nil {
+		t.Fatal("unresolvable host was accepted; guard must fail closed")
+	}
+}
+
+// A genuinely public import URL must still be accepted, so the guard does not
+// break legitimate agent-definition imports.
+func TestValidateImportFetchURL_AllowsPublicURL(t *testing.T) {
+	stubImportResolver(t, map[string][]string{"raw.githubusercontent.com": {"185.199.108.133"}})
+	if err := validateImportFetchURL(context.Background(), "https://raw.githubusercontent.com/o/r/main/agent.yaml"); err != nil {
+		t.Fatalf("public import URL rejected: %v", err)
+	}
+}
+
+// The preflight only sees the URL the caller supplied. This pins the second
+// half of the defence: a public URL that 302s to an internal address must not
+// be followed.
+func TestNoRedirectToPrivate_BlocksRedirectToInternalHostname(t *testing.T) {
+	stubImportResolver(t, map[string][]string{"metadata.attacker.example": {"169.254.169.254"}})
+	req := httptest.NewRequest(http.MethodGet, "http://metadata.attacker.example/latest/meta-data/", nil)
+	if err := noRedirectToPrivate(req, nil); err == nil {
+		t.Fatal("redirect to hostname resolving to metadata IP was allowed (SSRF)")
+	}
+}
+
+// End-to-end: a real server 302s to an internal target and the client must
+// refuse to follow it.
+func TestImportClient_RefusesRedirectToInternal(t *testing.T) {
+	stubImportResolver(t, map[string][]string{
+		"metadata.attacker.example": {"169.254.169.254"},
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.attacker.example/latest/meta-data/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: noRedirectToPrivate}
+	if _, err := client.Get(srv.URL); err == nil {
+		t.Fatal("client followed a redirect to an internal host")
+	}
+}
+
+// The chain-depth cap still terminates a redirect loop between public hosts.
+func TestNoRedirectToPrivate_CapsChainDepth(t *testing.T) {
+	stubImportResolver(t, map[string][]string{"docs.example.com": {"93.184.216.34"}})
+	req := httptest.NewRequest(http.MethodGet, "https://docs.example.com/a", nil)
+	via := []*http.Request{req, req, req}
+	if err := noRedirectToPrivate(req, via); err == nil || !strings.Contains(err.Error(), "stopped after") {
+		t.Fatalf("chain depth not capped: %v", err)
+	}
+}

--- a/v2/pkg/dashboard/import_test_transport_test.go
+++ b/v2/pkg/dashboard/import_test_transport_test.go
@@ -1,0 +1,59 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// routeImportFetchesToServer lets a test exercise the import handler with a
+// realistic PUBLIC url while the bytes actually come from a local httptest
+// server.
+//
+// This is required because the import preflight now rejects private/internal
+// destinations, and an httptest server listens on 127.0.0.1. Pointing a test
+// straight at ts.URL would be blocked — correctly. Rather than punch a
+// test-only hole in the guard (which would also exist in production), the
+// request keeps its public URL through validation and only the TRANSPORT is
+// swapped, so the security check under test is the real one.
+//
+// The resolver is stubbed alongside it so the preflight never depends on live
+// DNS in CI.
+func routeImportFetchesToServer(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+	target, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	stubImportResolver(t, map[string][]string{
+		"raw.githubusercontent.com": {"185.199.108.133"},
+		"github.com":                {"140.82.121.4"},
+		"gist.github.com":           {"140.82.121.3"},
+	})
+	previous := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		rewritten := req.Clone(req.Context())
+		rewritten.URL.Scheme = target.Scheme
+		rewritten.URL.Host = target.Host
+		rewritten.Host = req.URL.Host
+		return previous.RoundTrip(rewritten)
+	})
+	t.Cleanup(func() { http.DefaultTransport = previous })
+}
+
+// Guard against the helper above being mistaken for a production bypass: the
+// preflight must still reject an internal destination while it is installed.
+func TestRouteImportFetchesToServerDoesNotWeakenGuard(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+	routeImportFetchesToServer(t, ts)
+	if err := validateImportFetchURL(context.Background(), "http://169.254.169.254/latest/meta-data/"); err == nil {
+		t.Fatal("test transport helper weakened the SSRF preflight")
+	}
+}

--- a/v2/pkg/dashboard/ssrf_guard.go
+++ b/v2/pkg/dashboard/ssrf_guard.go
@@ -1,0 +1,31 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const ssrfMaxRedirects = 3
+
+// noRedirectToPrivate returns an http.Client CheckRedirect function that
+// rejects any redirect whose target resolves to a private/internal host.
+// It also limits the redirect chain depth to ssrfMaxRedirects. Use this
+// wherever the hive fetches a URL supplied (directly or indirectly) by a
+// user, to prevent SSRF via open-redirect chains:
+//
+//	client := &http.Client{
+//	    Timeout:       30 * time.Second,
+//	    CheckRedirect: noRedirectToPrivate,
+//	}
+func noRedirectToPrivate(req *http.Request, via []*http.Request) error {
+	if len(via) >= ssrfMaxRedirects {
+		return fmt.Errorf("stopped after %d redirects", ssrfMaxRedirects)
+	}
+	// Re-run the private-host check on every redirect target so a public
+	// URL that returns 302 → internal address cannot bypass the preflight.
+	if isPrivateURL(context.Background(), req.URL.String()) {
+		return fmt.Errorf("redirect to private/internal host blocked: %s", req.URL.Host)
+	}
+	return nil
+}


### PR DESCRIPTION
## The vulnerability

The agent-definition import handler on **v4** fetched whatever URL the caller supplied and returned the body, with **no preflight validation and no redirect guard**:

```go
client := &http.Client{Timeout: importHTTPTimeoutS * 1e9} // nanoseconds
resp, err := client.Get(body.URL)
```

`POST /api/agents/import` with `source=url` and:

- `url: http://169.254.169.254/latest/meta-data/iam/security-credentials/` → **cloud instance credentials**
- `url: http://hive.hive-hub.svc.cluster.local/api/config` → **cluster-internal services**
- `url: file:///etc/passwd` → local file read

A textbook SSRF, reachable from the import UI.

v2 closed this in #3194. **That fix was never ported.** v4 has no `ssrf_guard.go`, no `noRedirectToPrivate`, no `validateImportURL`, and no `importFetchURL` — the entire protection is absent.

Found while auditing v2↔v4 security divergence, after two *other* fixes from the same PR pair (#3322's provenance half, #3261's header stripping) also turned out to be missing on v4.

### Proof

Simulating the pre-fix handler path reached a local service unguarded:

```
pre-fix path reached internal service unguarded (hit=true)
```

## The fix

Port `ssrf_guard.go`, add `validateImportFetchURL` as the pre-fetch check, and wire `noRedirectToPrivate` into **both** the import client and the gateway model probe so every redirect hop is re-validated.

**Scope note:** the preflight deliberately restricts only the **transport** (http/https only) and the **destination** (not private/internal) — *not* which sites may be imported from. v2 additionally narrows imports to a GitHub allowlist, but that is a product decision that would change what v4 users are permitted to import. This closes the vulnerability without altering allowed behaviour.

`isPrivateURL` resolves DNS and fails closed, so a *hostname* resolving to an internal address is rejected, not just an IP literal.

## About the four modified tests

`TestHandleAgentImport_URLFetchFromServer`, `TestHandleAgentImport_URLFetchFails`, `TestImport_UncheckedStaysPlain` and `TestImport_KeepLinkedPersistsDefinitionSource` fetched from `httptest` servers on `127.0.0.1`, so the new guard **correctly** blocked them.

Rather than punch a test-only hole in the check — which would also exist in production — this ports v2's transport-rewrite helper: the request keeps a realistic **public** URL all the way through validation, and only the `http.DefaultTransport` is swapped, so the security check under test is the real one. `TestRouteImportFetchesToServerDoesNotWeakenGuard` asserts the helper does not weaken the preflight while installed.

## Tests

`v2/pkg/dashboard/import_ssrf_test.go` — 9 tests: metadata IP literal, hostname resolving internally, cluster-internal service, `file://` scheme, DNS-failure fail-closed, public URL still allowed (no false positives), redirect to internal hostname, end-to-end client refusing a 302 to internal, and the chain-depth cap.

`go build ./...`, `go vet ./pkg/dashboard/` and the full `./pkg/dashboard/` suite (24s) all pass.
