### PR TITLE
🐛 sec(knowledge): reject private git source URLs on v4

### DIFF
--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -273,7 +274,41 @@ func ValidateGitSourceURL(raw string) error {
 		return fmt.Errorf("git URL must not contain git transport helper separator")
 	}
 
+	// SSRF: reject private/loopback/link-local hosts so a git knowledge source
+	// can't be pointed at the pod network, internal services, or the cloud
+	// metadata endpoint (169.254.169.254). Operators running a legitimately
+	// internal Git server can opt in explicitly; default is fail-closed.
+	if !allowPrivateGitSource() && gitSourceHostIsPrivate(parsed.Hostname()) {
+		return fmt.Errorf("git URL host resolves to a private/internal address (set HIVE_ALLOW_PRIVATE_GIT_SOURCE=true for an internal Git server)")
+	}
+
 	return nil
+}
+
+// allowPrivateGitSource reports whether a git knowledge source pointing at a
+// private/internal address is permitted. Default false (fail-closed).
+func allowPrivateGitSource() bool {
+	return os.Getenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE") == "true"
+}
+
+// gitSourceHostIsPrivate reports whether host is a loopback/private/link-local
+// literal IP or "localhost". A hostname that is not an IP literal is treated as
+// public here (DNS is not resolved at validation time to avoid a rebinding
+// TOCTOU); the fail-closed default plus the operator-only config surface bound
+// the exposure.
+func gitSourceHostIsPrivate(host string) bool {
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	if host == "" || host == "localhost" {
+		return host == "localhost"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
 }
 
 func isSCPStyleGitURL(raw string) bool {

--- a/v2/pkg/knowledge/gitsource_ssrf_test.go
+++ b/v2/pkg/knowledge/gitsource_ssrf_test.go
@@ -1,0 +1,42 @@
+package knowledge
+
+import "testing"
+
+func TestValidateGitSourceURL_RejectsPrivateHosts(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	blocked := []string{
+		"http://127.0.0.1:8080/repo.git",
+		"http://10.0.0.1/internal-repo.git",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://192.168.1.1/sensitive-path",
+		"https://localhost/repo.git",
+		"http://[::1]/repo.git",
+		"http://0.0.0.0/repo.git",
+	}
+	for _, u := range blocked {
+		if err := ValidateGitSourceURL(u); err == nil {
+			t.Errorf("expected %q to be rejected as private/internal, got nil", u)
+		}
+	}
+}
+
+func TestValidateGitSourceURL_AllowsPublicHosts(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	ok := []string{
+		"https://github.com/kubestellar/hive.git",
+		"https://gitlab.com/group/project.git",
+		"https://8.8.8.8/repo.git", // public IP literal
+	}
+	for _, u := range ok {
+		if err := ValidateGitSourceURL(u); err != nil {
+			t.Errorf("expected %q to pass, got %v", u, err)
+		}
+	}
+}
+
+func TestValidateGitSourceURL_OptInAllowsPrivate(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
+	if err := ValidateGitSourceURL("http://10.0.0.5/internal.git"); err != nil {
+		t.Errorf("opt-in must allow a private internal Git server, got %v", err)
+	}
+}

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -858,6 +858,7 @@ func gitHTTPBackend(t *testing.T, projectRoot string) http.HandlerFunc {
 }
 
 func TestGitSource_InitSyncFullClone(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
@@ -895,6 +896,7 @@ func TestGitSource_InitSyncFullClone(t *testing.T) {
 }
 
 func TestGitSource_InitSparseSubpath(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 
@@ -945,6 +947,7 @@ func TestGitSource_SyncNotARepo(t *testing.T) {
 }
 
 func TestGitSource_StartSyncLoop_Cancels(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	src := makeHTTPSourceRepo(t)
 	base := t.TempDir()
 	gs := NewGitSource(GitSourceConfig{


### PR DESCRIPTION
## Summary
- Port the v2 git knowledge-source SSRF guard to v4.
- Reject private, loopback, link-local, and unspecified literal hosts by default.
- Preserve an explicit `HIVE_ALLOW_PRIVATE_GIT_SOURCE=true` operator opt-in for legitimate internal Git servers.

## Audit finding
The v2-only file `v2/pkg/knowledge/gitsource_ssrf_test.go` exposed that v4 kept transport validation but missed the private-host rejection added on v2.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go vet ./pkg/knowledge/`
- `cd v2 && go test ./pkg/knowledge -count=1`
