### PR TITLE
🐛 sec(github): bound app token mint calls on v4

### DIFF
--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -123,6 +123,14 @@ func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string,
 	return auth, nil
 }
 
+// mintContext derives a child context bounded by tokenMintTimeout from the
+// caller's context. It guarantees a deadline even when the caller passed a
+// background/process context with none, so a token mint is a bounded operation
+// end to end. The returned cancel MUST be called by the caller.
+func mintContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, tokenMintTimeout)
+}
+
 func (a *AppAuth) generateJWT() (string, error) {
 	now := time.Now()
 	claims := jwt.RegisteredClaims{
@@ -222,8 +230,10 @@ func (a *AppAuth) mintInstallationTokenWithOptions(ctx context.Context, opts *gh
 	// Proxy-trusting client: on a fresh-PVC boot with forced egress this call is
 	// MITM'd by the in-process proxy, whose CA must be trusted for the mint to
 	// succeed. See proxytrust.go for the chicken-and-egg this breaks.
+	mintCtx, cancel := mintContext(ctx)
+	defer cancel()
 	jwtClient := newJWTClient(jwtToken, a.apiURL)
-	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, opts)
+	installToken, _, err := jwtClient.Apps.CreateInstallationToken(mintCtx, a.installationID, opts)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("creating installation token: %w", err)
 	}
@@ -295,8 +305,10 @@ func (a *AppAuth) ScopedTokenForRepos(ctx context.Context, tier string, repos []
 	if len(repos) > 0 {
 		opts.Repositories = repos
 	}
+	mintCtx, cancel := mintContext(ctx)
+	defer cancel()
 	jwtClient := newJWTClient(jwtToken, a.apiURL)
-	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, opts)
+	installToken, _, err := jwtClient.Apps.CreateInstallationToken(mintCtx, a.installationID, opts)
 	if err != nil {
 		return "", fmt.Errorf("creating scoped token for tier %s: %w", tier, err)
 	}
@@ -399,8 +411,10 @@ func (a *AppAuth) VerifyInstallation(ctx context.Context) (*InstallationInfo, er
 		return nil, fmt.Errorf("generating JWT: %w", err)
 	}
 
+	mintCtx, cancel := mintContext(ctx)
+	defer cancel()
 	jwtClient := newJWTClient(jwtToken, a.apiURL)
-	inst, _, err := jwtClient.Apps.GetInstallation(ctx, a.installationID)
+	inst, _, err := jwtClient.Apps.GetInstallation(mintCtx, a.installationID)
 	if err != nil {
 		return nil, fmt.Errorf("resolving installation %d: %w", a.installationID, err)
 	}

--- a/v2/pkg/github/app_mint_timeout_test.go
+++ b/v2/pkg/github/app_mint_timeout_test.go
@@ -1,0 +1,157 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// These tests lock in the #2439 root-cause fix: a GitHub App installation-token
+// mint against an unreachable / firewalled GHE endpoint (github.ibm.com with no
+// installation) must NOT hang. It used to run on a bare gh.NewClient(nil) (no
+// per-client Timeout) and was sometimes reached with an undeadlined process
+// context — so a stuck TCP/TLS connect blocked the caller for minutes. That
+// froze the first heartbeat attempt and readiness, crash-looping the pod and
+// wedging the hub at "Upgrading". Every mint is now bounded by tokenMintTimeout
+// end to end and returns a soft error the caller treats as "App not usable".
+
+// blockingMintServer returns a handler that sleeps past tokenMintTimeout before
+// (never) replying, simulating an endpoint that accepts the connection but never
+// answers — the exact hang the fix must bound.
+func blockingMintServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sleep past the mint timeout so the client gives up first, but bail the
+		// moment the request context is cancelled (client hangup / test teardown)
+		// so server Close() — which waits for in-flight handlers — returns
+		// promptly and the test stays fast.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(tokenMintTimeout + 2*time.Second):
+		}
+	}))
+}
+
+// TestMintInstallationToken_HungEndpointReturnsBoundedError proves a hung mint
+// endpoint yields an error within a small multiple of tokenMintTimeout even
+// when the caller passes context.Background() (no deadline of its own).
+func TestMintInstallationToken_HungEndpointReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+	}
+
+	start := time.Now()
+	// Deliberately an undeadlined context: the mint's own bound must apply.
+	_, _, err := auth.mintInstallationToken(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("mintInstallationToken returned nil error against a hung endpoint; expected a bounded timeout error")
+	}
+	// Allow generous slack over tokenMintTimeout for CI scheduling, but it MUST
+	// be far under the server's 3x sleep — proving the client, not the server,
+	// ended the call.
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("mintInstallationToken took %v, want < %v (the mint did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}
+
+// TestToken_HungEndpointNoCacheReturnsBoundedError proves the public Token()
+// path (used by appTransport.RoundTrip → EnumerateActionable, the heartbeat/
+// eval loops) also stays bounded: with no cached token and a hung endpoint it
+// errors quickly instead of hanging the loop.
+func TestToken_HungEndpointNoCacheReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+		// No cached token: Token() must attempt a live mint, which hangs.
+	}
+
+	start := time.Now()
+	_, err := auth.Token(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Token() returned nil error against a hung endpoint with no cache; expected a bounded error")
+	}
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("Token() took %v, want < %v (mint did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}
+
+// TestVerifyInstallation_HungEndpointReturnsBoundedError proves the
+// installation-probe path (VerifyInstallation, used by the self-heal / re-check
+// flows) is bounded too.
+func TestVerifyInstallation_HungEndpointReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+	}
+
+	start := time.Now()
+	_, err := auth.VerifyInstallation(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("VerifyInstallation returned nil error against a hung endpoint; expected a bounded error")
+	}
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("VerifyInstallation took %v, want < %v (probe did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}
+
+// TestScopedToken_HungEndpointReturnsBoundedError proves the per-agent scoped
+// token mint (WriteAgentToken → ScopedToken, on the agent-launch path) is
+// bounded, so a GHE stall cannot wedge agent startup either.
+func TestScopedToken_HungEndpointReturnsBoundedError(t *testing.T) {
+	key, _ := generateTestKey(t)
+	server := blockingMintServer(t)
+	defer server.Close()
+
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         quietLogger(),
+		apiURL:         server.URL,
+		cachePath:      t.TempDir() + "/token-cache",
+	}
+
+	start := time.Now()
+	_, err := auth.ScopedToken(context.Background(), "contributor")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("ScopedToken returned nil error against a hung endpoint; expected a bounded error")
+	}
+	if elapsed > tokenMintTimeout*2 {
+		t.Fatalf("ScopedToken took %v, want < %v (mint did not honor its bound)", elapsed, tokenMintTimeout*2)
+	}
+}


### PR DESCRIPTION
## Summary
- Port the v2 GitHub App token mint timeout guard to v4.
- Wrap installation-token minting, scoped token minting, and installation verification in a `tokenMintTimeout`-bounded context.
- Add the v2 regression tests proving hung GitHub endpoints return bounded errors instead of wedging callers.

## Audit finding
The v2-only file `v2/pkg/github/app_mint_timeout_test.go` exposed that v4 had the timeout constant/comment but did not apply the bounded context to live mint/probe calls.

## Validation
- `cd v2 && go build ./...`
- `cd v2 && go vet ./pkg/github/`
- `cd v2 && go test ./pkg/github -count=1`
