### PR TITLE
🐛 sec(knowledge): guard Context7 redirects on v4

### DIFF
--- a/v2/pkg/knowledge/context7.go
+++ b/v2/pkg/knowledge/context7.go
@@ -7,16 +7,17 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
 const (
-	context7BaseURL        = "https://context7.com"
-	context7SearchPath     = "/api/v2/libs/search"
-	context7LLMsTxtSuffix  = "/llms.txt"
-	context7Timeout        = 30 * time.Second
-	context7MaxBody        = 10 * 1024 * 1024 // 10 MB
-	context7DefaultTokens  = 10000
+	context7BaseURL       = "https://context7.com"
+	context7SearchPath    = "/api/v2/libs/search"
+	context7LLMsTxtSuffix = "/llms.txt"
+	context7Timeout       = 30 * time.Second
+	context7MaxBody       = 10 * 1024 * 1024 // 10 MB
+	context7DefaultTokens = 10000
 )
 
 // Context7SearchResult is a single library match from Context7's search API.
@@ -64,6 +65,13 @@ func SearchContext7(ctx context.Context, name, apiKey string) ([]Context7SearchR
 // FetchContext7Docs retrieves documentation for a library via its llms.txt
 // endpoint, which returns curated content optimized for LLM consumption.
 func FetchContext7Docs(ctx context.Context, libraryID, query, apiKey string) (*Context7DocsResult, error) {
+	// Validate that libraryID starts with "/" so that concatenating it with
+	// context7BaseURL cannot produce a URL with an attacker-controlled authority
+	// component. For example, a libraryID of "@evil.com/path" would produce
+	// "https://context7.com@evil.com/path/llms.txt" where evil.com is the host.
+	if !strings.HasPrefix(libraryID, "/") {
+		return nil, fmt.Errorf("context7 library ID must start with '/': %q", libraryID)
+	}
 	params := url.Values{
 		"tokens": {fmt.Sprintf("%d", context7DefaultTokens)},
 	}
@@ -84,6 +92,15 @@ func FetchContext7Docs(ctx context.Context, libraryID, query, apiKey string) (*C
 	}, nil
 }
 
+// context7Client is an HTTP client that refuses to follow redirects to
+// private/internal addresses. context7.com requests go to a fixed hardcoded
+// base URL, but an adversary-controlled redirect (or a crafted libraryID)
+// could pivot to cloud metadata or internal services without this guard.
+var context7Client = &http.Client{
+	Timeout:       context7Timeout,
+	CheckRedirect: knowledgeNoRedirectToPrivate,
+}
+
 func context7Get(ctx context.Context, reqURL, apiKey string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, context7Timeout)
 	defer cancel()
@@ -97,7 +114,7 @@ func context7Get(ctx context.Context, reqURL, apiKey string) ([]byte, error) {
 	}
 	req.Header.Set("User-Agent", "hive-knowledge/1.0")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := context7Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/knowledge/context7_ssrf_test.go
+++ b/v2/pkg/knowledge/context7_ssrf_test.go
@@ -1,0 +1,60 @@
+package knowledge
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestFetchContext7Docs_RejectsNonSlashLibraryID verifies that a libraryID
+// not beginning with "/" is rejected before any HTTP request is made.
+// A libraryID like "@evil.com/path" would produce the URL
+// "https://context7.com@evil.com/path/llms.txt" where evil.com is the host
+// (Go's net/url treats context7.com as userinfo), enabling SSRF.
+func TestFetchContext7Docs_RejectsNonSlashLibraryID(t *testing.T) {
+	_, err := FetchContext7Docs(context.Background(), "@evil.com/path", "", "")
+	if err == nil {
+		t.Fatal("FetchContext7Docs accepted a libraryID without leading slash (authority injection)")
+	}
+	if !strings.Contains(err.Error(), "must start with '/'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestFetchContext7Docs_RejectsEmptyLibraryID checks that an empty libraryID is
+// also rejected (empty string does not start with "/").
+func TestFetchContext7Docs_RejectsEmptyLibraryID(t *testing.T) {
+	_, err := FetchContext7Docs(context.Background(), "", "", "")
+	if err == nil {
+		t.Fatal("FetchContext7Docs accepted an empty libraryID")
+	}
+}
+
+// TestContext7Client_BlocksRedirectToInternalHostname verifies the end-to-end
+// SSRF redirect guard: a server that 302s to a hostname resolving to the
+// cloud metadata address must be blocked by context7Client.CheckRedirect.
+func TestContext7Client_BlocksRedirectToInternalHostname(t *testing.T) {
+	stubDocRedirectResolver(t, map[string][]string{
+		"metadata.attacker.example": {"169.254.169.254"},
+	})
+
+	// Real HTTP server that redirects to the internal hostname.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.attacker.example/latest/meta-data/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	_, err = context7Client.Do(req)
+	if err == nil {
+		t.Fatal("context7Client followed a redirect to a hostname resolving to 169.254.169.254 (SSRF)")
+	}
+	if !strings.Contains(err.Error(), "private/internal host blocked") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Port the v2 Context7 SSRF hardening to v4.
- Reject library IDs that do not start with `/`, preventing authority-smuggling when composing the Context7 URL.
- Use the shared knowledge redirect guard so Context7 fetches cannot follow redirects to private/internal destinations.

## Audit finding
The v2-only file `v2/pkg/knowledge/context7_ssrf_test.go` exposed that v4 still used `http.DefaultClient` for Context7 fetches and did not validate the library ID prefix.

## Validation
- `cd v2 && go test ./pkg/knowledge -run TestContext7 -count=1`
- `cd v2 && go test ./pkg/knowledge -count=1`
- `cd v2 && go build ./...`
- `cd v2 && go vet ./pkg/knowledge/`
