### PR TITLE
🐛 sec(hub): block private lite enrollment hosts

### DIFF
--- a/v2/pkg/hub/lite_enrollment.go
+++ b/v2/pkg/hub/lite_enrollment.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	liteDefaultACMMLevel = 2
-	liteMaxACMMLevel     = 2
+	liteDefaultACMMLevel      = 2
+	liteMaxACMMLevel          = 2
+	liteRepoAccessHTTPTimeout = 10 * time.Second
 )
 
 type LiteEnrollmentConfig struct {
@@ -89,6 +90,10 @@ func (s *HubServer) handleLiteEnroll(w http.ResponseWriter, r *http.Request) {
 	}
 	if !isValidName(host) {
 		writeJSONError(w, http.StatusBadRequest, "invalid github_host")
+		return
+	}
+	if err := validateLiteGitHubHost(r.Context(), host); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	token := bearerTokenFromRequest(r)
@@ -491,7 +496,35 @@ func bearerTokenFromRequest(r *http.Request) string {
 	return strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
 }
 
+func validateLiteGitHubHost(ctx context.Context, host string) error {
+	if host == "" || host == publicGitHubHost {
+		return nil
+	}
+	if isPrivateURL(ctx, "https://"+host) {
+		return fmt.Errorf("github_host resolves to a private/internal address")
+	}
+	return nil
+}
+
+func liteRepoAccessHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: liteRepoAccessHTTPTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after %d redirects", len(via))
+			}
+			if isPrivateURL(req.Context(), req.URL.String()) {
+				return fmt.Errorf("redirect to private/internal github_host blocked")
+			}
+			return nil
+		},
+	}
+}
+
 func verifyGitHubRepoAccess(ctx context.Context, token, host, owner, repo string) (bool, error) {
+	if err := validateLiteGitHubHost(ctx, host); err != nil {
+		return false, err
+	}
 	apiBase := "https://api.github.com"
 	if host != "" && host != publicGitHubHost {
 		apiBase = "https://" + host + "/api/v3"
@@ -506,7 +539,7 @@ func verifyGitHubRepoAccess(ctx context.Context, token, host, owner, repo string
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := liteRepoAccessHTTPClient().Do(req)
 	if err != nil {
 		return false, fmt.Errorf("GitHub repo access check failed: %w", err)
 	}

--- a/v2/pkg/hub/lite_enrollment_test.go
+++ b/v2/pkg/hub/lite_enrollment_test.go
@@ -116,6 +116,29 @@ func TestHandleLiteEnrollTable(t *testing.T) {
 	}
 }
 
+func TestHandleLiteEnrollRejectsPrivateGitHubHostBeforeAccessCheck(t *testing.T) {
+	s, cleanup := newLiteTestHub(t)
+	defer cleanup()
+	called := false
+	oldVerify := verifyLiteRepoAccess
+	verifyLiteRepoAccess = func(context.Context, string, string, string, string) (bool, error) {
+		called = true
+		return true, nil
+	}
+	t.Cleanup(func() { verifyLiteRepoAccess = oldVerify })
+
+	rec := httptest.NewRecorder()
+	req := liteReqWithUser(http.MethodPost, "/api/saas/lite/enroll", `{"owner":"kubestellar","repo":"hive","github_host":"169.254.169.254","installation_id":123}`, "lite-user")
+	s.handleLiteEnroll(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Fatal("private github_host reached repo access verifier; request-driven SSRF preflight must run first")
+	}
+}
+
 func TestHandleLiteEnrollDuplicateIdempotent(t *testing.T) {
 	s, cleanup := newLiteTestHub(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- validate request-supplied lite enrollment GitHub hosts before repo access checks
- use a bounded repo-access HTTP client that refuses private/internal redirects
- add regression coverage proving private hosts are rejected before the access verifier runs

## Pre-fix proof
`go test ./pkg/hub -run TestHandleLiteEnrollRejectsPrivateGitHubHostBeforeAccessCheck -count=1` failed with status 403 from the later quota path instead of the expected 400, proving the private host reached downstream flow.

## Validation
- `go test ./pkg/hub -run TestHandleLiteEnrollRejectsPrivateGitHubHostBeforeAccessCheck -count=1`
- `go test ./pkg/hub -count=1`
- `go build ./...`
- `go vet ./pkg/hub/`