### PR TITLE
🐛 sec(celtrigger): bound rule evaluation cost

### DIFF
--- a/v2/pkg/celtrigger/celtrigger.go
+++ b/v2/pkg/celtrigger/celtrigger.go
@@ -44,6 +44,10 @@ const (
 // priority sorts first in Match results.
 const defaultPriority = 0
 
+// maxEvalCost bounds CEL runtime work per rule evaluation. A rule that exceeds
+// this budget is treated like any other runtime evaluation error: no match.
+const maxEvalCost uint64 = 100
+
 // activationVarEvent is the top-level CEL variable name under which the
 // normalized event fields are exposed to expressions.
 const activationVarEvent = "event"
@@ -188,7 +192,7 @@ func Compile(rules []Rule) (*Engine, error) {
 			return nil, fmt.Errorf("celtrigger: rule %q: expression must return bool, got %s", name, ast.OutputType())
 		}
 
-		prg, err := env.Program(ast)
+		prg, err := env.Program(ast, cel.CostLimit(maxEvalCost), cel.InterruptCheckFrequency(100))
 		if err != nil {
 			return nil, fmt.Errorf("celtrigger: rule %q: program: %w", name, err)
 		}

--- a/v2/pkg/celtrigger/celtrigger_test.go
+++ b/v2/pkg/celtrigger/celtrigger_test.go
@@ -1,6 +1,7 @@
 package celtrigger
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -225,4 +226,34 @@ func containsName(rules []Rule, name string) bool {
 		}
 	}
 	return false
+}
+
+func TestMatchSkipsRuleThatExceedsCostLimit(t *testing.T) {
+	rules := []Rule{{
+		Name:  "expensive",
+		Agent: "scanner",
+		Expr:  `event.labels.all(a, event.labels.all(b, event.labels.all(c, a != "" && b != "" && c != "")))`,
+	}}
+	engine, err := Compile(rules)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	labels := make([]string, 0, 200)
+	for i := 0; i < 200; i++ {
+		labels = append(labels, fmt.Sprintf("label-%03d", i))
+	}
+	if got := engine.Match(NormalizedEvent{Kind: KindIssueOpened, Labels: labels}); len(got) != 0 {
+		t.Fatalf("expensive CEL rule matched despite exceeding cost limit: %+v", got)
+	}
+}
+
+func TestMatchAllowsNormalRuleWithinCostLimit(t *testing.T) {
+	engine, err := Compile([]Rule{{Name: "bug", Agent: "scanner", Expr: `hasLabel(event.labels, "bug")`}})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got := engine.Match(NormalizedEvent{Kind: KindIssueOpened, Labels: []string{"bug"}})
+	if len(got) != 1 || got[0].Agent != "scanner" {
+		t.Fatalf("normal CEL rule did not match: %+v", got)
+	}
 }


### PR DESCRIPTION
## Summary
- add CEL runtime cost accounting and a per-rule evaluation limit
- treat cost-limit failures like other evaluation errors: no match
- add regression coverage for expensive rules plus a normal-rule control

## Pre-fix proof
`go test ./pkg/celtrigger -run TestMatchSkipsRuleThatExceedsCostLimit -count=1` failed because the expensive rule matched without a runtime cost bound.

## Validation
- `go test ./pkg/celtrigger -run TestMatchSkipsRuleThatExceedsCostLimit -count=1` (pre-fix failure)
- `go test ./pkg/celtrigger -count=1`
- `go build ./...`
- `go vet ./pkg/celtrigger/`