### PR TITLE
🐛 sec(celtrigger): surface CEL cost overruns

### DIFF
--- a/v2/pkg/celtrigger/celtrigger.go
+++ b/v2/pkg/celtrigger/celtrigger.go
@@ -12,7 +12,9 @@
 package celtrigger
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"sort"
 	"strings"
@@ -22,6 +24,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/ext"
+	"github.com/google/cel-go/interpreter"
 )
 
 // Event kind constants. These are the forge-neutral event kinds that a
@@ -44,9 +47,12 @@ const (
 // priority sorts first in Match results.
 const defaultPriority = 0
 
-// maxEvalCost bounds CEL runtime work per rule evaluation. A rule that exceeds
-// this budget is treated like any other runtime evaluation error: no match.
-const maxEvalCost uint64 = 100
+// maxEvalCost bounds CEL runtime work per rule evaluation. The budget is high
+// enough for realistic operator rules that combine field checks, string
+// predicates, and modest label scans, while still stopping pathological nested
+// comprehensions. A rule that exceeds this budget fails closed as no-match and
+// emits a warning so operators can diagnose why it stopped firing.
+const maxEvalCost uint64 = 10_000
 
 // activationVarEvent is the top-level CEL variable name under which the
 // normalized event fields are exposed to expressions.
@@ -221,6 +227,9 @@ func (e *Engine) Match(event NormalizedEvent) []Rule {
 	for i, cr := range e.rules {
 		out, _, err := cr.program.Eval(act)
 		if err != nil {
+			if isCostLimitExceeded(err) {
+				slog.Warn("celtrigger: rule exceeded evaluation cost budget; treating as no-match", "rule", cr.rule.Name, "budget", maxEvalCost)
+			}
 			// Fail closed: a runtime error means "did not match".
 			continue
 		}
@@ -240,6 +249,11 @@ func (e *Engine) Match(event NormalizedEvent) []Rule {
 		matched = append(matched, h.rule)
 	}
 	return matched
+}
+
+func isCostLimitExceeded(err error) bool {
+	var cancelled interpreter.EvalCancelledError
+	return errors.As(err, &cancelled) && cancelled.Cause == interpreter.CostLimitExceeded
 }
 
 // Len reports the number of compiled rules held by the engine.

--- a/v2/pkg/celtrigger/celtrigger_test.go
+++ b/v2/pkg/celtrigger/celtrigger_test.go
@@ -1,7 +1,10 @@
 package celtrigger
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -229,6 +232,11 @@ func containsName(rules []Rule, name string) bool {
 }
 
 func TestMatchSkipsRuleThatExceedsCostLimit(t *testing.T) {
+	var logs bytes.Buffer
+	origLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(origLogger) })
+
 	rules := []Rule{{
 		Name:  "expensive",
 		Agent: "scanner",
@@ -245,6 +253,12 @@ func TestMatchSkipsRuleThatExceedsCostLimit(t *testing.T) {
 	if got := engine.Match(NormalizedEvent{Kind: KindIssueOpened, Labels: labels}); len(got) != 0 {
 		t.Fatalf("expensive CEL rule matched despite exceeding cost limit: %+v", got)
 	}
+	gotLog := logs.String()
+	if !strings.Contains(gotLog, "celtrigger: rule exceeded evaluation cost budget; treating as no-match") ||
+		!strings.Contains(gotLog, "rule=expensive") ||
+		!strings.Contains(gotLog, fmt.Sprintf("budget=%d", maxEvalCost)) {
+		t.Fatalf("cost-limit overrun was not observable in logs: %q", gotLog)
+	}
 }
 
 func TestMatchAllowsNormalRuleWithinCostLimit(t *testing.T) {
@@ -255,5 +269,25 @@ func TestMatchAllowsNormalRuleWithinCostLimit(t *testing.T) {
 	got := engine.Match(NormalizedEvent{Kind: KindIssueOpened, Labels: []string{"bug"}})
 	if len(got) != 1 || got[0].Agent != "scanner" {
 		t.Fatalf("normal CEL rule did not match: %+v", got)
+	}
+}
+
+func TestMatchAllowsRealisticOperatorRuleWithinCostLimit(t *testing.T) {
+	engine, err := Compile([]Rule{{
+		Name:  "realistic",
+		Agent: "scanner",
+		Expr:  `event.repo.startsWith("kubestellar/") && event.title.matches("(?i).*(bug|fix|security).*") && event.labels.exists(l, l == "security")`,
+	}})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got := engine.Match(NormalizedEvent{
+		Kind:   KindIssueOpened,
+		Repo:   "kubestellar/hive",
+		Title:  "Security fix for CEL trigger limits",
+		Labels: []string{"help wanted", "security", "v4"},
+	})
+	if len(got) != 1 || got[0].Name != "realistic" {
+		t.Fatalf("realistic operator rule did not match within cost budget %d: %+v", maxEvalCost, got)
 	}
 }


### PR DESCRIPTION
## Summary
- log CEL evaluation cost-limit overruns at WARN with the rule name and cost budget
- keep fail-closed no-match behavior for over-budget rules
- raise the runtime budget from 100 to 10,000 so realistic operator predicates have headroom while pathological nested comprehensions remain bounded

## Budget rationale
10,000 is intentionally above ordinary trigger rules that combine field checks, string predicates, and modest label scans. The new realistic-rule test covers `event.repo.startsWith(...) && event.title.matches(...) && event.labels.exists(...)`, which matches within the budget. The existing nested-comprehension regression still exceeds the budget and fails closed, so the cap remains effective for pathological evaluation.

## Pre-fix proof
With only the new log assertion applied to the previous production code, `go test ./pkg/celtrigger -run TestMatchSkipsRuleThatExceedsCostLimit -count=1` failed because the cost-limit overrun produced no log output.

## Validation
- `go test ./pkg/celtrigger -count=1`
- `go build ./...`
- `go vet ./pkg/celtrigger/`