### PR TITLE
🐛 fix(proxy,agent): bound upstream dials; make backend: pi run pi

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -180,6 +180,14 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/goose || \
     echo "WARN: Goose CLI install failed — skipping"
 
+# --- Layer 8.5: pi CLI (@earendil-works/pi-coding-agent — backend: pi) ---
+# Tolerant of failure like the copilot/codex layers: agents configured for
+# backend: pi simply won't launch if this is absent, same degradation as
+# any other missing backend binary.
+ARG PI_VERSION=latest
+RUN npm install -g @earendil-works/pi-coding-agent@${PI_VERSION} && npm cache clean --force || \
+    echo "WARN: pi CLI install failed — skipping"
+
 # --- Layer 9: Bob CLI (IBM bobshell — backend: bob) ---
 # bobshell is NOT published to the public npm registry; it is distributed as a
 # tarball from IBM Cloud Object Storage. The vendor's documented host install is

--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -321,17 +321,16 @@ func TestBackendBinaryName_CodexAndAiderLaunchTheirOwnBinaries(t *testing.T) {
 	}
 }
 
-// TestBackendBinaryName_AliasesSurviveDerivation guards the ordering inside
-// backendBinaryName: the identity derivation over config.CLIBackends would map
-// "pi" to a non-existent "pi" binary, so the alias overrides must be applied
-// AFTER it. Swapping those two loops would silently break the pi backend.
-func TestBackendBinaryName_AliasesSurviveDerivation(t *testing.T) {
+// TestBackendBinaryName_PiLaunchesPiBinary pins the regression that made
+// backend: pi launch goose. Pi is a first-class CLI backend, so the launcher
+// must exec the pi binary directly rather than reaching an alias.
+func TestBackendBinaryName_PiLaunchesPiBinary(t *testing.T) {
 	got, err := backendBinaryName("pi")
 	if err != nil {
 		t.Fatalf("backendBinaryName(\"pi\") err = %v, want nil", err)
 	}
-	if got != "goose" {
-		t.Errorf("backendBinaryName(\"pi\") = %q, want \"goose\" (alias applied after identity derivation)", got)
+	if got != "pi" {
+		t.Errorf("backendBinaryName(\"pi\") = %q, want \"pi\"", got)
 	}
 }
 

--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -219,10 +219,12 @@ func TestBackendBinary_GatewayBackendsAllLaunchClaude(t *testing.T) {
 			t.Errorf("backendBinary(%q) = %q, want the claude CLI (gateways share one binary)", b, got)
 		}
 	}
-	// The agentic CLIs must still map to their own binaries.
+	// The agentic CLIs installed in the unit-test image must still map to their own binaries.
+	// Pi is covered by backendBinaryName and Dockerfile tests because the host
+	// unit-test environment does not install the pi CLI.
 	for backend, want := range map[string]string{
 		"claude": "claude", "copilot": "copilot", "gemini": "gemini",
-		"goose": "goose", "pi": "goose", "bob": "bob",
+		"goose": "goose", "bob": "bob",
 	} {
 		got, err := backendBinary(backend)
 		if err != nil || filepath.Base(got) != want {

--- a/v2/pkg/agent/bob_startup_kick_test.go
+++ b/v2/pkg/agent/bob_startup_kick_test.go
@@ -11,8 +11,8 @@ import (
 // TestBackendDefersStartupKick pins WHICH backends get their bootstrap prompt
 // delivered by deliverStartupKick versus embedded in the launch command.
 //
-// bob is the fix: it was in neither group, so its bootstrap prompt was written
-// to /tmp/.hive-bootstrap-<name>.txt and never read, leaving it idle.
+// bob and pi are the fixes: without deferral, their bootstrap prompts are
+// written to /tmp/.hive-bootstrap-<name>.txt and never read, leaving them idle.
 //
 // The other rows are regression guards. goose in particular MUST stay false —
 // `goose run` needs the embedded --text prompt to stay interactive and exits on
@@ -26,6 +26,8 @@ func TestBackendDefersStartupKick(t *testing.T) {
 	}{
 		{"bob defers (the fix)", bobBackend, true,
 			"bob is an interactive TUI with no embedded-prompt mechanism"},
+		{"pi defers (the fix)", "pi", true,
+			"pi is an interactive TUI with no embedded-prompt mechanism"},
 		{"claude unchanged", "claude", true,
 			"pre-existing deferred backend"},
 		{"copilot unchanged", "copilot", true,

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1289,16 +1289,16 @@ func paneShowsConsentScreen(pane string) bool {
 // readiness-gated delivery sends (see deliverKickLocked). Unknown backends are
 // likewise excluded — they never embed and have no verified readiness signal.
 //
-// bob belongs in this set, not the goose set. It is a long-lived interactive
-// TUI (launched WITHOUT -p, see bobLaunchCmd) that sits at its prompt with no
+// bob and pi belong in this set, not the goose set. Both are long-lived
+// interactive TUIs that sit at their prompts with no
 // prompt argument at all, so it has no goose-style reason to embed — and
 // embedding would expose it to exactly the PS2 race above. Before this it was
 // in NEITHER group: it fell through to the write-a-file branch in launchInTmux,
 // so its bootstrap prompt was serialized to /tmp/.hive-bootstrap-<name>.txt and
-// then never read, leaving bob idle at its prompt after every launch.
+// then never read, leaving the CLI idle at its prompt after every launch.
 func backendDefersStartupKick(backend string) bool {
 	switch backend {
-	case "claude", "copilot", "gemini", bobBackend:
+	case "claude", "copilot", "gemini", "pi", bobBackend:
 		return true
 	default:
 		return false

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1129,6 +1129,14 @@ var cliPaneMarkers = []string{
 	"Copilot",
 	"Gemini",
 	"goose",
+	// pi's marker. pi renders a TUI status bar showing model context usage
+	// (e.g. "↑37k ↓20k R756k CH99.6% $0.013 5.9%/1.0M (auto)") instead of a
+	// "❯"/"goose is ready" prompt, so none of the entries above match a
+	// running pi: waitForCLIReadyForAgent would never see it as ready and the
+	// startup kick would be dropped after cliReadyTimeout even though pi is
+	// healthy. "%/" matches the fixed "%%/1.0M" context-meter suffix pi
+	// renders at every context size.
+	piContextMarker,
 	// bob's markers. NONE of the entries above match a running bob: verified
 	// against the installed bundle (bobshell 1.0.6 bundle/bob.js), which
 	// contains zero "❯" characters and no "esc cancel" / "/ commands" /
@@ -1176,6 +1184,14 @@ const (
 	// so it is used only for coarse CLI-presence detection (is anything other
 	// than bash in this pane?), never as the input-ready gate.
 	bobProductMarker = "Bob-Shell"
+	// piContextMarker is pi's context-meter suffix ("5.9%/1.0M (auto)" in
+	// its TUI status bar). It is the PRIMARY readiness signal for a running
+	// pi: the status bar renders only when the agent TUI is live and has a
+	// model configured, and it is the only marker pi renders in common with
+	// no other CLI (pi never shows "❯"/"goose is ready"). Matching on "%/"
+	// rather than a context size keeps it valid at any model/context
+	// configuration.
+	piContextMarker = "%/"
 )
 
 // paneHasCLIMarker reports whether the given pane content contains any known
@@ -1456,6 +1472,11 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all%s",
 				binary, model, copilotGitHubWriteDenyFlags)
 		case "gemini":
+			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
+		case "pi":
+			// pi takes the model as a CLI flag, not a subcommand. Without
+			// this case the launch command never receives the configured
+			// model (previously it also hit the goose binary via the alias).
 			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
 		case "goose":
 			launchCmd = fmt.Sprintf("%s run -s", binary)
@@ -2425,7 +2446,8 @@ func paneShowsInputPrompt(output string) bool {
 		strings.Contains(output, "\n>\n") ||
 		strings.Contains(output, bobInputPlaceholder) ||
 		strings.Contains(output, bobInputPlaceholderDefault) ||
-		strings.Contains(output, codexInputPromptMarker)
+		strings.Contains(output, codexInputPromptMarker) ||
+		strings.Contains(output, piContextMarker)
 }
 
 // waitForCLIReady polls the tmux pane until the CLI shows its ready prompt
@@ -4276,7 +4298,10 @@ func (a *AgentProcess) FilteredPaneLines(n int) []string {
 // from config.InferenceBackends. Keeping this map to aliases only is what makes
 // the accept-then-fail class of bug structurally impossible — see backendBinary.
 var backendBinaryAliases = map[string]string{
-	"pi": "goose",
+	// pi was previously aliased to "goose", which made every pi-configured
+	// agent exec the goose CLI instead of pi (the backend launch command
+	// switch now has a real pi case). pi is a first-class CLI backend
+	// (config.CLIBackends includes "pi"), so identity mapping applies.
 }
 
 // backendBinaryName maps an agent backend to the NAME of the CLI binary that is

--- a/v2/pkg/agent/manager_coverage2_test.go
+++ b/v2/pkg/agent/manager_coverage2_test.go
@@ -1706,13 +1706,13 @@ func TestBackendBinary_InferenceBackends(t *testing.T) {
 	}
 }
 
-func TestBackendBinary_PiMapsToGoose(t *testing.T) {
-	path, err := backendBinary("pi")
+func TestBackendBinaryName_PiMapsToPi(t *testing.T) {
+	name, err := backendBinaryName("pi")
 	if err != nil {
-		t.Fatalf("backendBinary(pi) error: %v", err)
+		t.Fatalf("backendBinaryName(pi) error: %v", err)
 	}
-	if !strings.Contains(path, "goose") {
-		t.Errorf("backendBinary(pi) = %q, should resolve to goose", path)
+	if name != "pi" {
+		t.Errorf("backendBinaryName(pi) = %q, should resolve to pi", name)
 	}
 }
 

--- a/v2/pkg/agent/pi_backend_test.go
+++ b/v2/pkg/agent/pi_backend_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const piIdlePane = `╭──────────────────────────────────────────────╮
+│ pi coding agent                              │
+╰──────────────────────────────────────────────╯
+
+↑37k ↓20k R756k CH99.6% $0.013 5.9%/1.0M (auto)
+`
+
+func TestPiPaneReadiness(t *testing.T) {
+	if piContextMarker != "%/" {
+		t.Fatalf("piContextMarker = %q, want %%/", piContextMarker)
+	}
+	if !paneHasCLIMarker(piIdlePane) {
+		t.Fatal("paneHasCLIMarker must recognise a live pi pane")
+	}
+	if !paneShowsInputPrompt(piIdlePane) {
+		t.Fatal("paneShowsInputPrompt must treat a live pi status bar as input-ready")
+	}
+}
+
+func TestDockerfileInstallsPiCLI(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dockerfile := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "Dockerfile"))
+	body, err := os.ReadFile(dockerfile)
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{"ARG PI_VERSION=", "@earendil-works/pi-coding-agent@${PI_VERSION}"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Dockerfile must install pi CLI; missing %q", want)
+		}
+	}
+}
+
+func TestPiLaunchCommandPassesModelFlag(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "manager.go"))
+	if err != nil {
+		t.Fatalf("read manager.go: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "case \"pi\":") || !strings.Contains(text, "launchCmd = fmt.Sprintf(\"%s --model %s\", binary, model)") {
+		t.Fatal("pi launch path must invoke pi with --model")
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -192,7 +192,7 @@ func (p *GitHubProxy) dialCopilotUpstream(host string) (net.Conn, error) {
 	// SO_MARK the outbound socket so the forced-egress redirect exempts the
 	// proxy's own upstream traffic (see proxyEgressMark). The override hook above
 	// still wins when set, so tests are unaffected.
-	return tls.DialWithDialer(markDialer(0), "tcp", net.JoinHostPort(host, "443"), &tls.Config{ServerName: host})
+	return tls.DialWithDialer(markDialer(upstreamDialTimeout), "tcp", net.JoinHostPort(host, "443"), &tls.Config{ServerName: host})
 }
 
 // SetTokenSink wires the inference token sink so the translator can record
@@ -344,6 +344,15 @@ const (
 	transparentProxyTimeout = 5 * time.Second
 	httpReadTimeout         = 30 * time.Second
 	httpWriteTimeout        = 60 * time.Second
+	// upstreamDialTimeout bounds the proxy's OWN upstream dial + TLS handshake
+	// to the real GitHub host. Before this, a stalled upstream (DNS, TCP, or
+	// TLS) blocked forever — the agent's curl sat in poll() waiting for the
+	// MITM response that never came, permanently wedging the request and
+	// freezing the agent's session (the multi-hour "egress hang").
+	// tls.DialWithDialer's dialer Timeout covers connect + handshake; the
+	// deadline is lifted once established so long-lived relays (git smart
+	// HTTP) are unaffected.
+	upstreamDialTimeout = 15 * time.Second
 )
 
 // handleTransparentTLS handles iptables-redirected connections. The agent
@@ -440,7 +449,7 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 	}
 	defer tlsClientConn.Close()
 
-	upstreamConn, err := tls.DialWithDialer(markDialer(0), "tcp", host+":443", &tls.Config{ServerName: host})
+	upstreamConn, err := tls.DialWithDialer(markDialer(upstreamDialTimeout), "tcp", host+":443", &tls.Config{ServerName: host})
 	if err != nil {
 		p.logger.Error("transparent proxy upstream dial failed", "host", host, "error", err)
 		return
@@ -740,7 +749,12 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 
 	// Connect to the real GitHub server. SO_MARK the socket so the forced-egress
 	// redirect exempts this proxy-originated dial (see proxyEgressMark).
-	upstreamConn, err := tls.DialWithDialer(markDialer(0), "tcp", r.Host, &tls.Config{
+	// A dialer Timeout bounds both the TCP connect and the TLS handshake —
+	// without it a stalled upstream wedges this CONNECT forever (the agent's
+	// curl sits in poll() waiting for "200 Connection established" that never
+	// comes). The deadline is lifted once established so the relay is not
+	// time-boxed.
+	upstreamConn, err := tls.DialWithDialer(markDialer(upstreamDialTimeout), "tcp", r.Host, &tls.Config{
 		ServerName: host,
 	})
 	if err != nil {

--- a/v2/pkg/proxy/upstream_timeout_test.go
+++ b/v2/pkg/proxy/upstream_timeout_test.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUpstreamDialTimeoutConstant(t *testing.T) {
+	if upstreamDialTimeout != 15*time.Second {
+		t.Fatalf("upstreamDialTimeout = %v, want 15s", upstreamDialTimeout)
+	}
+	if got := markDialer(upstreamDialTimeout).Timeout; got != upstreamDialTimeout {
+		t.Fatalf("markDialer(upstreamDialTimeout).Timeout = %v, want %v", got, upstreamDialTimeout)
+	}
+}
+
+func TestAllTLSUpstreamDialsAreBound(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "github_proxy.go"))
+	if err != nil {
+		t.Fatalf("read github_proxy.go: %v", err)
+	}
+	text := string(body)
+	if strings.Contains(text, "tls.DialWithDialer(markDialer(0)") {
+		t.Fatal("TLS upstream dials must not use an unbounded zero-timeout dialer")
+	}
+	const wantBoundTLSUpstreamDials = 3
+	if got := strings.Count(text, "tls.DialWithDialer(markDialer(upstreamDialTimeout)"); got != wantBoundTLSUpstreamDials {
+		t.Fatalf("bounded TLS upstream dials = %d, want %d", got, wantBoundTLSUpstreamDials)
+	}
+	for _, want := range []string{
+		`p.logger.Error("transparent proxy upstream dial failed"`,
+		`p.logger.Error("proxy upstream dial failed"`,
+		`p.logger.Error("copilot sniff: upstream dial failed"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("timeout/dial failures must be observable; missing log site %s", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two fixes that kept a self-hosted spoke from working on the v2/v4 lines, verified live:

### 1. Proxy: bound upstream dials — stops permanent "egress hang"

The MITM proxy's upstream dials to the real GitHub host used `tls.DialWithDialer(markDialer(0), ...)` — a zero dialer `Timeout`, i.e. no bound on the TCP connect or the TLS handshake. When an upstream stall occurred (DNS, TCP, or TLS), the proxy goroutine blocked **forever**: the agent's `curl` sat in `poll()` waiting for the MITM response that never came, permanently wedging the request and freezing the agent's session. Observed live for 7+ hours across every agent — the governor kept kicking, but every kick's first egress call re-hung (the "egress hang").

`markDialer` already accepts a timeout; this passes `upstreamDialTimeout` (15s) on the transparent-MITM, CONNECT-MITM, and Copilot upstream dials. The deadline is lifted once the connection is established, so long-lived relays (git smart HTTP) are unaffected. A stalled upstream now fails the dial and the agent's request errors out instead of hanging forever — the agent retries/moves on instead of freezing.

### 2. Agent + Dockerfile: make `backend: pi` actually run pi

- `backendBinaryAliases` mapped `"pi"` to `"goose"`, so every pi-configured agent exec'd the **goose** CLI. pi is a first-class CLI backend in `config.CLIBackends`, so identity mapping applies — the alias is removed.
- The launch-command switch had no `pi` case, so the configured model was never passed. Added `case "pi": launchCmd = fmt.Sprintf("%s --model %s", binary, model)`.
- pi renders a TUI status bar (`↑37k ↓20k R756k CH99.6% $0.013 5.9%/1.0M (auto)`) instead of a `❯` / `goose is ready` prompt, so the CLI-ready and input-prompt checks never saw a booted pi and every startup kick was dropped after `cliReadyTimeout`. Added `piContextMarker` (`%/`) to `cliPaneMarkers` and `paneShowsInputPrompt`.
- Installed the pi CLI (`@earendil-works/pi-coding-agent`) in the Dockerfile, tolerant of failure like the copilot/codex layers.

## Testing

- `go build ./...` clean on v4 HEAD (`1afa6a0a`).
- `go test ./pkg/proxy/` passes. `./pkg/agent/` has one pre-existing flaky tmux test (`TestConfirmMenuOption_SelectsOption`) that fails on clean v4 in this environment too (tmux pane-capture timing), unrelated to these changes.
- The proxy timeout fix was validated against the live hive (v2 lineage): with the dial bounded, wedged requests fail fast and agent sessions un-wedge.

## Notes

- The `X-Hive-Public-Route` read-only ingress feature (a deployment-specific addition on the fork's v2) is deliberately **not** included — it was tied to a specific public-ingress setup that is no longer used.
- Happy to split into separate PRs if preferred.