### PR TITLE
🔒 sec(dashboard): owner-role gate on config-download, self-upgrade, hive-id, hub (#3316 #3400)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -635,12 +635,11 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
-	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		role = "owner"
-	}
-	if role != "owner" {
-		http.Error(w, "owner access required", http.StatusForbidden)
+	// Owner-only: hive.yaml can contain sensitive references. Use the hardened
+	// requireOwnerRole (which fails closed for an empty/unverified role on a
+	// protected spoke) rather than the old inline check that defaulted an empty
+	// X-Hive-Role to "owner" (#3316).
+	if !requireOwnerRole(w, r) {
 		return
 	}
 	configPath := "/etc/hive/hive.yaml"
@@ -670,12 +669,10 @@ func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
-	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		role = "owner"
-	}
-	if role != "owner" {
-		jsonError(w, "owner access required", http.StatusForbidden)
+	// Owner-only: self-upgrade replaces the running image. Use the hardened
+	// requireOwnerRole rather than the inline check that defaulted an empty
+	// X-Hive-Role to "owner" (#3316).
+	if !requireOwnerRole(w, r) {
 		return
 	}
 	if s.deps == nil || s.deps.Config == nil {
@@ -4389,6 +4386,11 @@ func normalizeContributeDelegatableRoles(roles []string) []string {
 }
 
 func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
+	// Owner-only: changes the hub URL, autoupgrade, snapshot, and public-listing
+	// settings — all persisted to hive config (#3400).
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	var body struct {
 		Enabled                        *bool                      `json:"enabled"`
 		URL                            string                     `json:"url"`
@@ -7535,6 +7537,11 @@ func (s *Server) handleHiveIDGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleHiveIDSet(w http.ResponseWriter, r *http.Request) {
+	// Owner-only: the hive ID is persisted to disk and identifies the hive to
+	// the hub (#3400).
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	var body struct {
 		ID string `json:"id"`
 	}


### PR DESCRIPTION
## Fixes #3316, Fixes #3400

Aligns four config-mutation/sensitive handlers to the hardened `requireOwnerRole` (fails closed for an empty/unverified `X-Hive-Role` on a protected spoke) established by #3261/#3396.

**#3316** — replaced fail-open inline checks (`if role == "" { role = "owner" }`) on `handleConfigDownload` and `handleSelfUpgrade`.
**#3400** — added the missing owner gate on `handleHiveIDSet` (`PUT /api/hive-id`) and `handleGovernorHub` (`PUT /api/config/governor/hub`). The other 7 handlers #3400 named were already fixed by the #3396 sweep.

Also closed as already-fixed this pass: #3367, #3373 (already have requireOwnerRole), #3289 (docsource fetchURL already uses a private-host CheckRedirect).