### PR TITLE
🐛 fix(proxy,agent): port upstream timeouts and pi backend to v2

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -127,6 +127,14 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/goose || \
     echo "WARN: Goose CLI install failed — skipping"
 
+# --- Layer 8.5: pi CLI (@earendil-works/pi-coding-agent — backend: pi) ---
+# Tolerant of failure like the copilot/codex layers: agents configured for
+# backend: pi simply won't launch if this is absent, same degradation as
+# any other missing backend binary.
+ARG PI_VERSION=latest
+RUN npm install -g @earendil-works/pi-coding-agent@${PI_VERSION} && npm cache clean --force || \
+    echo "WARN: pi CLI install failed — skipping"
+
 # --- Layer 9: Bob CLI (IBM bobshell — backend: bob) ---
 # bobshell is NOT published to the public npm registry; it is distributed as a
 # tarball from IBM Cloud Object Storage. The vendor's documented host install is

--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -219,10 +219,12 @@ func TestBackendBinary_GatewayBackendsAllLaunchClaude(t *testing.T) {
 			t.Errorf("backendBinary(%q) = %q, want the claude CLI (gateways share one binary)", b, got)
 		}
 	}
-	// The agentic CLIs must still map to their own binaries.
+	// The agentic CLIs installed in the unit-test image must still map to their own binaries.
+	// Pi is covered by backendBinaryName and Dockerfile tests because the host
+	// unit-test environment does not install the pi CLI.
 	for backend, want := range map[string]string{
 		"claude": "claude", "copilot": "copilot", "gemini": "gemini",
-		"goose": "goose", "pi": "goose", "bob": "bob",
+		"goose": "goose", "bob": "bob",
 	} {
 		got, err := backendBinary(backend)
 		if err != nil || filepath.Base(got) != want {
@@ -321,17 +323,16 @@ func TestBackendBinaryName_CodexAndAiderLaunchTheirOwnBinaries(t *testing.T) {
 	}
 }
 
-// TestBackendBinaryName_AliasesSurviveDerivation guards the ordering inside
-// backendBinaryName: the identity derivation over config.CLIBackends would map
-// "pi" to a non-existent "pi" binary, so the alias overrides must be applied
-// AFTER it. Swapping those two loops would silently break the pi backend.
-func TestBackendBinaryName_AliasesSurviveDerivation(t *testing.T) {
+// TestBackendBinaryName_PiLaunchesPiBinary pins the regression that made
+// backend: pi launch goose. Pi is a first-class CLI backend, so the launcher
+// must exec the pi binary directly rather than reaching an alias.
+func TestBackendBinaryName_PiLaunchesPiBinary(t *testing.T) {
 	got, err := backendBinaryName("pi")
 	if err != nil {
 		t.Fatalf("backendBinaryName(\"pi\") err = %v, want nil", err)
 	}
-	if got != "goose" {
-		t.Errorf("backendBinaryName(\"pi\") = %q, want \"goose\" (alias applied after identity derivation)", got)
+	if got != "pi" {
+		t.Errorf("backendBinaryName(\"pi\") = %q, want \"pi\"", got)
 	}
 }
 

--- a/v2/pkg/agent/bob_startup_kick_test.go
+++ b/v2/pkg/agent/bob_startup_kick_test.go
@@ -11,8 +11,8 @@ import (
 // TestBackendDefersStartupKick pins WHICH backends get their bootstrap prompt
 // delivered by deliverStartupKick versus embedded in the launch command.
 //
-// bob is the fix: it was in neither group, so its bootstrap prompt was written
-// to /tmp/.hive-bootstrap-<name>.txt and never read, leaving it idle.
+// bob and pi are the fixes: without deferral, their bootstrap prompts are
+// written to /tmp/.hive-bootstrap-<name>.txt and never read, leaving them idle.
 //
 // The other rows are regression guards. goose in particular MUST stay false —
 // `goose run` needs the embedded --text prompt to stay interactive and exits on
@@ -26,6 +26,8 @@ func TestBackendDefersStartupKick(t *testing.T) {
 	}{
 		{"bob defers (the fix)", bobBackend, true,
 			"bob is an interactive TUI with no embedded-prompt mechanism"},
+		{"pi defers (the fix)", "pi", true,
+			"pi is an interactive TUI with no embedded-prompt mechanism"},
 		{"claude unchanged", "claude", true,
 			"pre-existing deferred backend"},
 		{"copilot unchanged", "copilot", true,

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -874,6 +874,11 @@ var cliPaneMarkers = []string{
 	"Copilot",
 	"Gemini",
 	"goose",
+	// pi's marker. pi renders a TUI status bar showing model context usage
+	// (for example, "5.9%/1.0M (auto)") instead of a prompt used by the
+	// other CLIs. Match the fixed context-meter suffix so a running pi is
+	// recognised as live and ready.
+	piContextMarker,
 	// bob's markers. NONE of the entries above match a running bob: verified
 	// against the installed bundle (bobshell 1.0.6 bundle/bob.js), which
 	// contains zero "❯" characters and no "esc cancel" / "/ commands" /
@@ -915,6 +920,9 @@ const (
 	// perfectly healthy at its prompt. Both strings are present in the 1.0.6
 	// bundle, so match either rather than replacing one with the other.
 	bobInputPlaceholderDefault = "Enter your prompt, / for commands"
+	// piContextMarker is pi's context-meter suffix (for example,
+	// "5.9%/1.0M (auto)") and is the readiness signal for a running pi TUI.
+	piContextMarker = "%/"
 	// bobProductMarker is bob's product name, which appears in its banner and
 	// dialogs. It is a weaker, secondary signal than bobInputPlaceholder — it
 	// also shows on trust/auth/license dialogs, which are NOT ready states —
@@ -1018,16 +1026,16 @@ func paneShowsConsentScreen(pane string) bool {
 // readiness-gated delivery sends (see deliverKickLocked). Unknown backends are
 // likewise excluded — they never embed and have no verified readiness signal.
 //
-// bob belongs in this set, not the goose set. It is a long-lived interactive
-// TUI (launched WITHOUT -p, see bobLaunchCmd) that sits at its prompt with no
+// bob and pi belong in this set, not the goose set. Both are long-lived
+// interactive TUIs that sit at their prompts with no
 // prompt argument at all, so it has no goose-style reason to embed — and
 // embedding would expose it to exactly the PS2 race above. Before this it was
 // in NEITHER group: it fell through to the write-a-file branch in launchInTmux,
 // so its bootstrap prompt was serialized to /tmp/.hive-bootstrap-<name>.txt and
-// then never read, leaving bob idle at its prompt after every launch.
+// then never read, leaving the CLI idle at its prompt after every launch.
 func backendDefersStartupKick(backend string) bool {
 	switch backend {
-	case "claude", "copilot", "gemini", bobBackend:
+	case "claude", "copilot", "gemini", "pi", bobBackend:
 		return true
 	default:
 		return false
@@ -1249,6 +1257,8 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all%s",
 				binary, model, copilotGitHubWriteDenyFlags)
 		case "gemini":
+			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
+		case "pi":
 			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
 		case "goose":
 			launchCmd = fmt.Sprintf("%s run -s", binary)
@@ -2215,7 +2225,8 @@ func paneShowsInputPrompt(output string) bool {
 		strings.Contains(output, "\n>\n") ||
 		strings.Contains(output, bobInputPlaceholder) ||
 		strings.Contains(output, bobInputPlaceholderDefault) ||
-		strings.Contains(output, codexInputPromptMarker)
+		strings.Contains(output, codexInputPromptMarker) ||
+		strings.Contains(output, piContextMarker)
 }
 
 // waitForCLIReady polls the tmux pane until the CLI shows its ready prompt
@@ -2295,6 +2306,7 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 				"has_arrow", strings.Contains(output, "❯"),
 				"has_bob_placeholder", strings.Contains(output, bobInputPlaceholder),
 				"has_codex_ready", strings.Contains(output, codexInputPromptMarker),
+				"has_pi_ready", strings.Contains(output, piContextMarker),
 				"head_500", truncateHead(output, 500), "tail_500", truncateTail(output, 500))
 			return false
 		case <-ticker.C:
@@ -3875,9 +3887,7 @@ func (a *AgentProcess) FilteredPaneLines(n int) []string {
 // derived from config.CLIBackends by identity, and every model-gateway backend
 // from config.InferenceBackends. Keeping this map to aliases only is what makes
 // the accept-then-fail class of bug structurally impossible — see backendBinary.
-var backendBinaryAliases = map[string]string{
-	"pi": "goose",
-}
+var backendBinaryAliases = map[string]string{}
 
 // backendBinaryName maps an agent backend to the NAME of the CLI binary that is
 // exec'd for it, without touching the filesystem. Split out from backendBinary

--- a/v2/pkg/agent/manager_coverage2_test.go
+++ b/v2/pkg/agent/manager_coverage2_test.go
@@ -1539,8 +1539,8 @@ func TestConfigHasTokens_MissingField(t *testing.T) {
 func TestClearExpiredTokens_Logic(t *testing.T) {
 	// Test the JSON manipulation clearExpiredTokens does
 	input := map[string]interface{}{
-		"copilotTokens":  map[string]interface{}{"user1": "token"},
-		"loggedInUsers":  []interface{}{"user1"},
+		"copilotTokens":    map[string]interface{}{"user1": "token"},
+		"loggedInUsers":    []interface{}{"user1"},
 		"lastLoggedInUser": "user1",
 		"otherSetting":     "keep",
 	}
@@ -1706,13 +1706,13 @@ func TestBackendBinary_InferenceBackends(t *testing.T) {
 	}
 }
 
-func TestBackendBinary_PiMapsToGoose(t *testing.T) {
-	path, err := backendBinary("pi")
+func TestBackendBinaryName_PiMapsToPi(t *testing.T) {
+	name, err := backendBinaryName("pi")
 	if err != nil {
-		t.Fatalf("backendBinary(pi) error: %v", err)
+		t.Fatalf("backendBinaryName(pi) error: %v", err)
 	}
-	if !strings.Contains(path, "goose") {
-		t.Errorf("backendBinary(pi) = %q, should resolve to goose", path)
+	if name != "pi" {
+		t.Errorf("backendBinaryName(pi) = %q, should resolve to pi", name)
 	}
 }
 

--- a/v2/pkg/agent/pi_backend_test.go
+++ b/v2/pkg/agent/pi_backend_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const piIdlePane = `╭──────────────────────────────────────────────╮
+│ pi coding agent                              │
+╰──────────────────────────────────────────────╯
+
+↑37k ↓20k R756k CH99.6% $0.013 5.9%/1.0M (auto)
+`
+
+func TestPiPaneReadiness(t *testing.T) {
+	if piContextMarker != "%/" {
+		t.Fatalf("piContextMarker = %q, want %%/", piContextMarker)
+	}
+	if !paneHasCLIMarker(piIdlePane) {
+		t.Fatal("paneHasCLIMarker must recognise a live pi pane")
+	}
+	if !paneShowsInputPrompt(piIdlePane) {
+		t.Fatal("paneShowsInputPrompt must treat a live pi status bar as input-ready")
+	}
+}
+
+func TestDockerfileInstallsPiCLI(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dockerfile := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "Dockerfile"))
+	body, err := os.ReadFile(dockerfile)
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{"ARG PI_VERSION=", "@earendil-works/pi-coding-agent@${PI_VERSION}"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("Dockerfile must install pi CLI; missing %q", want)
+		}
+	}
+}
+
+func TestPiLaunchCommandPassesModelFlag(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "manager.go"))
+	if err != nil {
+		t.Fatalf("read manager.go: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "case \"pi\":") || !strings.Contains(text, "launchCmd = fmt.Sprintf(\"%s --model %s\", binary, model)") {
+		t.Fatal("pi launch path must invoke pi with --model")
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -91,7 +91,7 @@ func (p *GitHubProxy) dialCopilotUpstream(host string) (net.Conn, error) {
 	if p.copilotDial != nil {
 		return p.copilotDial(host)
 	}
-	return tls.Dial("tcp", net.JoinHostPort(host, "443"), &tls.Config{ServerName: host})
+	return tls.DialWithDialer(upstreamDialer(), "tcp", net.JoinHostPort(host, "443"), &tls.Config{ServerName: host})
 }
 
 // SetTokenSink wires the inference token sink so the translator can record
@@ -236,7 +236,17 @@ const (
 	transparentProxyTimeout = 5 * time.Second
 	httpReadTimeout         = 30 * time.Second
 	httpWriteTimeout        = 60 * time.Second
+	// upstreamDialTimeout bounds the proxy's own upstream dial + TLS handshake
+	// to the real GitHub host. A stalled upstream used to block forever and
+	// wedge the agent request waiting for the MITM response. The deadline is
+	// lifted after the TLS connection is established, so long-lived relays are
+	// unaffected.
+	upstreamDialTimeout = 15 * time.Second
 )
+
+func upstreamDialer() *net.Dialer {
+	return &net.Dialer{Timeout: upstreamDialTimeout}
+}
 
 // handleTransparentTLS handles iptables-redirected connections. The agent
 // tried to connect to github.com:443 but iptables sent it here instead.
@@ -327,7 +337,7 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 	}
 	defer tlsClientConn.Close()
 
-	upstreamConn, err := tls.Dial("tcp", host+":443", &tls.Config{ServerName: host})
+	upstreamConn, err := tls.DialWithDialer(upstreamDialer(), "tcp", host+":443", &tls.Config{ServerName: host})
 	if err != nil {
 		p.logger.Error("transparent proxy upstream dial failed", "host", host, "error", err)
 		return
@@ -563,7 +573,7 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 	defer tlsClientConn.Close()
 
 	// Connect to the real GitHub server.
-	upstreamConn, err := tls.Dial("tcp", r.Host, &tls.Config{
+	upstreamConn, err := tls.DialWithDialer(upstreamDialer(), "tcp", r.Host, &tls.Config{
 		ServerName: host,
 	})
 	if err != nil {

--- a/v2/pkg/proxy/upstream_timeout_test.go
+++ b/v2/pkg/proxy/upstream_timeout_test.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUpstreamDialTimeoutConstant(t *testing.T) {
+	if upstreamDialTimeout != 15*time.Second {
+		t.Fatalf("upstreamDialTimeout = %v, want 15s", upstreamDialTimeout)
+	}
+	if got := upstreamDialer().Timeout; got != upstreamDialTimeout {
+		t.Fatalf("upstreamDialer().Timeout = %v, want %v", got, upstreamDialTimeout)
+	}
+}
+
+func TestAllTLSUpstreamDialsAreBound(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "github_proxy.go"))
+	if err != nil {
+		t.Fatalf("read github_proxy.go: %v", err)
+	}
+	text := string(body)
+	if strings.Contains(text, `tls.Dial("tcp"`) {
+		t.Fatal("TLS upstream dials must not use unbounded tls.Dial")
+	}
+	const wantBoundTLSUpstreamDials = 3
+	if got := strings.Count(text, "tls.DialWithDialer(upstreamDialer()"); got != wantBoundTLSUpstreamDials {
+		t.Fatalf("bounded TLS upstream dials = %d, want %d", got, wantBoundTLSUpstreamDials)
+	}
+	for _, want := range []string{
+		`p.logger.Error("transparent proxy upstream dial failed"`,
+		`p.logger.Error("proxy upstream dial failed"`,
+		`p.logger.Error("copilot sniff: upstream dial failed"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("timeout/dial failures must be observable; missing log site %s", want)
+		}
+	}
+}


### PR DESCRIPTION
Port of #3406 to v2 because the touched files and bugs also exist on the v2 branch.\n\nIncludes regression coverage for bounded TLS upstream dials, observable dial failures, pi binary/model launch, pi readiness, startup kick delivery, and Docker image pi CLI installation.\n\nValidation run locally:\n- cd v2 && go test ./pkg/agent -run 'TestBackendDefersStartupKick|TestBackendBinaryName_PiLaunchesPiBinary|TestPiPaneReadiness|TestDockerfileInstallsPiCLI|TestPiLaunchCommandPassesModelFlag' -count=1\n- cd v2 && go test ./pkg/proxy -run 'TestUpstreamDialTimeoutConstant|TestAllTLSUpstreamDialsAreBound' -count=1\n- cd v2 && go build ./... && go vet ./pkg/agent ./pkg/proxy\n\nThe new tests were also checked against pre-fix v2 production files and failed.