### PR TITLE
🔒 fix(github): take auto-merge authority from the review actor, not its body

### DIFF
--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -36,9 +36,22 @@ type AutoMergeSweepResult struct {
 	Skipped int
 }
 
+// hiveQueueApproval separates the two identities an auto-merge approval
+// carries, because they answer different questions and have different trust.
+//
+//   - QueuedBy is the GitHub account that SUBMITTED the review. GitHub
+//     attributes it, a caller cannot choose it, and it is the only one of the
+//     two that may carry merge authority.
+//   - ClaimedBy is the name written in the review BODY. On the hosted path the
+//     hive posts the approval as its App bot on a human's behalf, so this is
+//     the only record of which human asked. It is caller-controlled text and
+//     must never gate anything — it is used solely to keep the self-merge ban
+//     working, where treating it as untrusted is safe: the worst a forged
+//     value can do is ban a merge that would otherwise be allowed.
 type hiveQueueApproval struct {
-	QueuedBy string
-	HeadSHA  string
+	QueuedBy  string
+	ClaimedBy string
+	HeadSHA   string
 }
 
 // SweepQueuedAutoMerges consumes the configured Hive merger-queue label. It
@@ -159,7 +172,14 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 		return AutoMergeSweepEvent{}, "queue-approval-head-changed", nil
 	}
 	queuedBy := approval.QueuedBy
-	if strings.EqualFold(author, queuedBy) {
+	// The self-merge ban must catch BOTH shapes of approval: a human approving
+	// directly (author == the submitting actor) and the hosted path, where the
+	// hive posts as its App bot on a human's behalf so the only trace of that
+	// human is the claimed name in the body. Checking the actor alone would
+	// silently retire the ban on the hosted path, since a bot login never
+	// equals a human author. ClaimedBy is untrusted input, but only ever
+	// widens the ban — a forged value can block a merge, never permit one.
+	if strings.EqualFold(author, queuedBy) || strings.EqualFold(author, approval.ClaimedBy) {
 		return AutoMergeSweepEvent{}, "self-merge-ban", nil
 	}
 
@@ -210,8 +230,34 @@ func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string
 			if !strings.EqualFold(review.GetState(), "APPROVED") {
 				continue
 			}
-			if queuedBy := parseHiveQueueReview(review.GetBody()); queuedBy != "" {
-				latest = hiveQueueApproval{QueuedBy: queuedBy, HeadSHA: review.GetCommitID()}
+			// SECURITY (audit F3, CWE-863): the merge authority is the actor who
+			// SUBMITTED the review, never a name parsed out of its body.
+			//
+			// This used to read queuedBy from parseHiveQueueReview(review.Body).
+			// Contributor tokens carry pull-request write permission, so any
+			// contributor could approve their own PR with a body reading
+			// "Approved by @trusted-maintainer ..." and merge under that name.
+			// The self-merge ban made it worse rather than better: it compares
+			// the PR author against the CLAIMED name, so naming someone else
+			// both forged the authority and slipped the ban.
+			//
+			// The body marker is still REQUIRED — it is what distinguishes an
+			// ordinary code-review approval from an explicit request to queue
+			// for auto-merge, and an approving reviewer must opt in deliberately.
+			// It just no longer decides WHO did it.
+			if marker := parseHiveQueueReview(review.GetBody()); marker != "" {
+				actor := safeGetLogin(review.GetUser())
+				if actor == "" {
+					// No identifiable actor (deleted account, or an API shape we
+					// do not recognise) — fail closed rather than fall back to
+					// the body, which is exactly the trust we are removing.
+					continue
+				}
+				latest = hiveQueueApproval{
+					QueuedBy:  actor,
+					ClaimedBy: marker,
+					HeadSHA:   review.GetCommitID(),
+				}
 			}
 		}
 		if resp.NextPage == 0 {

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -14,9 +14,15 @@ import (
 )
 
 type sweepPR struct {
-	number          int
-	author          string
-	queuedBy        string
+	number   int
+	author   string
+	queuedBy string
+	// reviewAuthor is the GitHub login that actually SUBMITTED the approval.
+	// Distinct from queuedBy, which is only what the review BODY claims (F3):
+	// the fixture previously emitted reviews with no user at all, so no test
+	// could express "an untrusted actor claimed a trusted merger's name".
+	// Defaults to queuedBy when unset, preserving every existing case.
+	reviewAuthor    string
 	headSHA         string
 	reviewCommitID  *string
 	label           bool
@@ -336,7 +342,7 @@ func TestTrySweepQueuedPRSkipBranches(t *testing.T) {
 					if tt.noReview {
 						json.NewEncoder(w).Encode([]map[string]any{})
 					} else {
-						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI.", "commit_id": "sha7"}})
+						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]any{"login": tt.pr.queuedBy}}})
 					}
 				default:
 					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -380,7 +386,7 @@ func TestTrySweepQueuedPRMissingHeadAndMergeNotApplied(t *testing.T) {
 						"labels":          []map[string]string{{"name": AutoMergeQueuedLabel}},
 					})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
-					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7"}})
+					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]any{"login": "bob"}}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
 					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
@@ -415,7 +421,7 @@ func TestTrySweepQueuedPRMergeError(t *testing.T) {
 				"labels": []map[string]string{{"name": AutoMergeQueuedLabel}},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
-			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7"}})
+			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]any{"login": "bob"}}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
 			json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
@@ -440,9 +446,9 @@ func TestLatestHiveQueueApprovalKeepsLatestCommitID(t *testing.T) {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		json.NewEncoder(w).Encode([]map[string]any{
-			{"state": "APPROVED", "body": "Approved by @old for Hive auto-merge on green CI.", "commit_id": "oldsha"},
+			{"state": "APPROVED", "body": "Approved by @old for Hive auto-merge on green CI.", "commit_id": "oldsha", "user": map[string]any{"login": "old"}},
 			{"state": "COMMENTED", "body": "Approved by @ignored for Hive auto-merge on green CI.", "commit_id": "ignored"},
-			{"state": "APPROVED", "body": "Approved by @new for Hive auto-merge on green CI.", "commit_id": "newsha"},
+			{"state": "APPROVED", "body": "Approved by @new for Hive auto-merge on green CI.", "commit_id": "newsha", "user": map[string]any{"login": "new"}},
 		})
 	}))
 	defer api.Close()
@@ -612,7 +618,14 @@ func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, mer
 			if pr.reviewCommitID != nil {
 				reviewCommitID = *pr.reviewCommitID
 			}
-			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": body, "commit_id": reviewCommitID}})
+			reviewAuthor := pr.reviewAuthor
+			if reviewAuthor == "" {
+				reviewAuthor = pr.queuedBy
+			}
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"state": "APPROVED", "body": body, "commit_id": reviewCommitID,
+				"user": map[string]any{"login": reviewAuthor},
+			}})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/pulls/"):
 			number := pathNumber(t, r.URL.Path, "/repos/acme/widget/pulls/", "")
 			pr := byNumber[number]
@@ -690,4 +703,105 @@ func shaNumber(t *testing.T, path string) int {
 	}
 	t.Fatalf("sha number not found in %q", path)
 	return 0
+}
+
+// F3 (CWE-863): auto-merge must bind approval to the review's ACTUAL author,
+// not to a name parsed out of the review body.
+//
+// latestHiveQueueApproval took the merger identity from
+// parseHiveQueueReview(review.GetBody()) and never looked at review.User.Login.
+// Contributor tokens carry pull-request write permission, so any contributor
+// could submit an APPROVED review reading "Approved by @trusted-maintainer for
+// Hive auto-merge on green CI." and have their own PR merged under that name.
+//
+// The self-merge ban made it worse rather than better: it compares the PR
+// author against the CLAIMED queuedBy, so naming someone else both forges the
+// authority AND slips the ban.
+func TestF3_AutoMergeRejectsForgedApprovalActor(t *testing.T) {
+	var merged []int
+	// mallory opens the PR and submits the approval herself, but writes
+	// "Approved by @alice" in the body.
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number: 7, author: "mallory", queuedBy: "alice", reviewAuthor: "mallory",
+		label: true, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(merged) != 0 || len(result.Merged) != 0 {
+		t.Fatalf("F3: merged PR %v on an approval whose BODY claimed @alice but which "+
+			"@mallory actually submitted — merge authority came from review text, not the actor",
+			merged)
+	}
+}
+
+// The self-merge ban must key off the REAL reviewer. Claiming someone else's
+// name must not launder a self-merge.
+func TestF3_SelfMergeBanUsesRealReviewer(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number: 7, author: "mallory", queuedBy: "someone-else", reviewAuthor: "mallory",
+		label: true, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	if _, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(merged) != 0 {
+		t.Fatal("F3: the self-merge ban was bypassed by claiming another user's name in the body")
+	}
+}
+
+// The hosted path posts approvals as the Hive App bot on a human's behalf, so
+// the submitting actor is the bot and the requesting human survives only as the
+// claimed name in the body. Gating the self-merge ban on the actor alone would
+// silently retire it there: "hive[bot]" never equals a human author, so mallory
+// could queue their own PR through the dashboard and merge it. The ban has to
+// consider the claimed name too — safe, because a forged claim can only ever
+// block a merge, never authorise one.
+func TestF3_SelfMergeBanCatchesBotPostedApproval(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number: 7, author: "mallory", queuedBy: "mallory", reviewAuthor: "kubestellar-hive[bot]",
+		label: true, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	if _, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(merged) != 0 {
+		t.Fatal("F3: mallory self-merged via a bot-posted approval — the self-merge ban does not survive the hosted path")
+	}
+}
+
+// CONTROL: a legitimate approval — a different, real reviewer whose body names
+// themselves — must still merge. The fix must not break the feature.
+func TestF3_GenuineApprovalStillMerges(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number: 7, author: "mallory", queuedBy: "alice", reviewAuthor: "alice",
+		label: true, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(merged) != 1 || len(result.Merged) != 1 {
+		t.Fatalf("a genuine approval by @alice failed to merge (merged=%v) — the fix is too strict", merged)
+	}
 }


### PR DESCRIPTION
## What

Audit **F3** (CWE-863, `SECURITY-REVIEW-2026-08-11.md`). `latestHiveQueueApproval` took the queuer's identity from the review **body** instead of the account that submitted it.

Contributor tokens carry pull-request write permission, so a contributor could approve their own PR with a body reading `Approved by @trusted-maintainer for Hive auto-merge on green CI.` and the sweep would merge it under that name.

The self-merge ban made it worse rather than better: it compared the PR author against the **claimed** name, so naming somebody else both forged the authority and slipped the ban in one step.

## The fix

Authority comes from `review.User.Login` — GitHub attributes it and a caller cannot choose it. An unidentifiable actor fails closed rather than falling back to the body.

The body marker is still **required**: it is what distinguishes an ordinary code-review approval from a deliberate request to queue for auto-merge. It just no longer decides *who* did it.

## Why the claimed name is still read

The hosted path posts approvals as the Hive App bot on a human's behalf (`QueuePRAutoMerge`), so the submitting actor is the bot and the requesting human survives only in the body text.

Gating the self-merge ban on the actor alone would have **silently retired it on that path** — a bot login never equals a human author, so a user could queue their own PR from the dashboard and merge it. So the ban checks both identities. `ClaimedBy` stays untrusted and can only ever *widen* the ban: a forged value blocks a merge, it never authorises one. `TestF3_SelfMergeBanCatchesBotPostedApproval` pins that, and fails against an actor-only check.

## Why the suite was green against this

The `sweepPR` fixture emitted reviews with **no `user` field at all**, so nothing could observe the actor. It now emits a real one.

Four regressions, each verified to fail against the vulnerable code before the fix:

- `TestF3_AutoMergeRejectsForgedApprovalActor` — forged body must not merge
- `TestF3_SelfMergeBanUsesRealReviewer` — ban survives a body naming someone else
- `TestF3_SelfMergeBanCatchesBotPostedApproval` — ban survives the hosted bot-posted shape
- `TestF3_GenuineApprovalStillMerges` — control; the feature still works

## Verification

- `go build ./...` clean
- `go test ./pkg/github/ -count=1` → `ok` (43s), full package, zero failures
- Reverting either half of the fix makes the corresponding test fail

## Blast radius

Scanned the 25 most recently merged PRs in this repo: **zero** carry a Hive queue approval, so no in-flight approval changes meaning on deploy.