### PR TITLE
🔒 fix(pushbroker): keep the push token out of git's argv

### DIFF
--- a/v2/pkg/pushbroker/pushbroker.go
+++ b/v2/pkg/pushbroker/pushbroker.go
@@ -32,6 +32,18 @@ var DefaultProtectedPaths = []string{
 	".github/OWNERS",
 }
 
+// pushTokenEnvVar carries the minted push token to git out-of-band (audit F5).
+// It is deliberately NOT in credentialEnvPrefixes: that list strips INHERITED
+// credentials from the push environment, whereas this value is supplied by the
+// broker itself after that filter runs.
+const pushTokenEnvVar = "HIVE_PUSH_TOKEN"
+
+// pushCredentialHelper is a git credential helper that echoes the token from
+// the environment. Only the variable NAME appears here, so nothing secret
+// reaches argv (where it would be world-readable via /proc/<pid>/cmdline) or
+// disk. The leading "!" makes git run it through the shell.
+const pushCredentialHelper = `!f() { echo username=x-access-token; echo "password=$` + pushTokenEnvVar + `"; }; f`
+
 var credentialEnvPrefixes = []string{
 	"GITHUB_TOKEN=", "GH_TOKEN=", "HIVE_GITHUB_TOKEN=", "COPILOT_GITHUB_TOKEN=",
 	"GIT_ASKPASS=", "SSH_ASKPASS=",
@@ -142,12 +154,26 @@ func (b *Broker) Run(ctx context.Context) (Result, error) {
 	if strings.TrimSpace(token) == "" {
 		return b.fail(res, errors.New("pushbroker: minter returned empty token"))
 	}
+	// SECURITY (audit F5, CWE-214): the push token must never appear in git's
+	// argv. This used to pass it as `-c http.extraHeader=Authorization: Bearer
+	// <token>`, which lands in /proc/<pid>/cmdline — world-readable, so any
+	// other UID on the box could read a live push credential while the push
+	// ran. Agents run as their own UIDs in this container, so that is a real
+	// cross-tenant read, not a theoretical one.
+	//
+	// Instead pass the token through the environment (visible only to the
+	// process owner via /proc/<pid>/environ) and have a credential helper echo
+	// it back to git. The helper text itself carries only the variable NAME, so
+	// the secret stays out of argv and off disk.
 	args := []string{
 		"-c", "core.hooksPath=/dev/null",
-		"-c", "http.extraHeader=Authorization: Bearer " + token,
+		"-c", "credential.helper=" + pushCredentialHelper,
 		"push", "--no-verify", b.remote(), "HEAD:refs/heads/" + b.Branch,
 	}
-	if _, err := b.runner().Run(ctx, b.Workspace, PushEnv(os.Environ()), "git", args...); err != nil {
+	// Append AFTER PushEnv: it strips inherited credential variables, and this
+	// one is deliberately supplied rather than inherited.
+	env := append(PushEnv(os.Environ()), pushTokenEnvVar+"="+token)
+	if _, err := b.runner().Run(ctx, b.Workspace, env, "git", args...); err != nil {
 		return b.fail(res, fmt.Errorf("git push failed: %w", err))
 	}
 	res.Pushed = true

--- a/v2/pkg/pushbroker/pushbroker_test.go
+++ b/v2/pkg/pushbroker/pushbroker_test.go
@@ -85,6 +85,61 @@ func TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace(t *testing.T) {
 	})
 }
 
+// Audit F5 (CWE-214). The minted push token used to be passed as
+// `-c http.extraHeader=Authorization: Bearer <token>`, putting a live
+// credential in git's argv and therefore in /proc/<pid>/cmdline, which is
+// world-readable. Agents run under their own UIDs in this container, so any of
+// them could read another tenant's push token for the duration of the push.
+//
+// The token must now travel in the environment (owner-readable only) and reach
+// git through a credential helper. The sibling sanitize test walks the
+// workspace and the inherited environment but never inspected argv, which is
+// why this was invisible to a green suite.
+func TestF5_PushTokenNeverAppearsInGitArgv(t *testing.T) {
+	dir := initRepo(t)
+	writeCommit(t, dir, "safe.txt", "hello\n")
+	r := &recordingRunner{}
+	const token = "ghs_f5_secret_push_token"
+
+	res, err := (&Broker{Workspace: dir, Branch: "work", Repo: "kubestellar/hive", Minter: fakeMinter{token}, Runner: r}).Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v (res=%+v)", err, res)
+	}
+	if !res.Pushed {
+		t.Fatal("Pushed=false")
+	}
+
+	for _, arg := range r.argsOnPush {
+		if strings.Contains(arg, token) {
+			t.Fatalf("F5: push token leaked into git argv (readable via /proc/<pid>/cmdline): %q", arg)
+		}
+	}
+
+	// Positive control: if the token is not actually reaching git, the push is
+	// silently unauthenticated and this test would pass for the wrong reason.
+	var delivered bool
+	for _, env := range r.envOnPush {
+		if env == pushTokenEnvVar+"="+token {
+			delivered = true
+		}
+	}
+	if !delivered {
+		t.Fatalf("F5: token was not delivered via %s — the push would be unauthenticated", pushTokenEnvVar)
+	}
+	var helper bool
+	for _, arg := range r.argsOnPush {
+		if strings.HasPrefix(arg, "credential.helper=") {
+			helper = true
+			if !strings.Contains(arg, pushTokenEnvVar) {
+				t.Fatalf("F5: credential helper does not read %s: %q", pushTokenEnvVar, arg)
+			}
+		}
+	}
+	if !helper {
+		t.Fatal("F5: no credential helper configured — git cannot authenticate from the environment")
+	}
+}
+
 func TestProtectedPathViolationsTable(t *testing.T) {
 	files := []string{"policies/guard.yaml", "OWNERS", "hive.yaml.dashboard", "pkg/safe.go"}
 	got := ProtectedPathViolations(files, DefaultProtectedPaths)


### PR DESCRIPTION
## What

Audit **F5** (CWE-214, `SECURITY-REVIEW-2026-08-11.md`). The minted push token was passed to git as:

```
-c http.extraHeader=Authorization: Bearer <token>
```

Arguments land in `/proc/<pid>/cmdline`, which is **world-readable**. Agents run under their own UIDs in this container, so any agent could read another tenant's live push credential just by reading `/proc` while a push was in flight — no exploit needed, only timing.

## The fix

The token now travels in the environment (`/proc/<pid>/environ` is readable only by the process owner) and reaches git through a credential helper. The helper text contains only the variable **name**, so the secret reaches neither argv nor disk.

Verified empirically against a local HTTP git remote before writing the code: the helper causes git to send a correct `Authorization` header while the token never appears in the command line.

Note the env var is appended **after** `PushEnv()`, not added to `credentialEnvPrefixes` — that list strips *inherited* credentials from the push environment, whereas this value is deliberately supplied by the broker. Adding it there would have stripped the token the broker just minted.

## Why the suite was green against this

`TestBrokerPushSanitizesCredentialEnvironmentAndWorkspace` already walks the workspace and the inherited environment looking for leaked credentials — but it never inspected **argv**, which is precisely where the token was.

`TestF5_PushTokenNeverAppearsInGitArgv` closes that gap and fails against the previous code:

```
F5: push token leaked into git argv (readable via /proc/<pid>/cmdline):
"http.extraHeader=Authorization: Bearer ghs_f5_secret_push_token"
```

It also carries a **positive control** asserting the token still reaches git via the env var and that a helper referencing it is configured. Without that, the test would pass equally well against a push that silently lost its credential and started failing to authenticate.

## Verification

- `go build ./...` clean
- `go test ./pkg/pushbroker/ -count=1` → `ok`, full package
- Reverting the fix makes the new test fail with the message above
- `git grep http.extraHeader` confirms no other call site passes a credential this way