### PR TITLE
🐛 fix(ci): pass actions env to v4 PR verifier

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -32,6 +32,7 @@ jobs:
           docker run --rm \
             -e INPUT_GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             -e GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            -e GITHUB_ACTIONS="true" \
             -e GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
             -e GITHUB_EVENT_PATH="/github/event.json" \
             -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary
- pass `GITHUB_ACTIONS=true` into the inlined PR verifier container
- preserves the pinned verifier image/action setup from the v4 workflow dependency fix

## Validation
- Ruby YAML parse of `.github/workflows/pr-verifier.yml`
- `git diff --check`

Signed-off-by: Andrew Anderson <andy@clubanderson.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>