### PR TITLE
🔒 fix(dashboard): count unauthenticated sockets toward the WebSocket cap

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -292,7 +292,15 @@ type ContributeWSHub struct {
 	// h.mu.RLock): a mu-guarded counter would deadlock (RLock-then-Lock on the same
 	// RWMutex). Lock-free is also what the -race coverage job wants — see the standing
 	// "never re-lock m.mu from a path that holds it" rule.
-	taskGen        atomic.Uint64
+	taskGen atomic.Uint64
+	// pendingConns counts sockets that have been upgraded but have not yet
+	// authenticated (audit F9). h.connections only gains an entry AFTER auth
+	// succeeds, so capping on that map alone left the pre-auth window — a full
+	// wsAuthTimeout per socket — completely unbounded. Atomic rather than
+	// mu-guarded to match taskGen's reasoning above: it is touched from the
+	// upgrade path and from deferred cleanup, and must never contend with or
+	// re-enter h.mu.
+	pendingConns atomic.Int64
 	activityMu     sync.RWMutex
 	activity       []ActivityEntry
 	server         *Server
@@ -1858,10 +1866,19 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 const maxWSConnections = 50
 
 func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
+	// SECURITY (audit F9, CWE-770): the cap must count sockets that are still
+	// authenticating, not just authenticated ones.
+	//
+	// h.connections only gains an entry after auth succeeds, so capping on it
+	// alone bounded exactly the connections that had already proven who they
+	// were, while leaving the pre-auth window unbounded. An unauthenticated
+	// client could hold arbitrarily many sockets — each costing a goroutine, a
+	// file descriptor and a read buffer for a full wsAuthTimeout — and the only
+	// parties actually limited were legitimate contributors.
 	h.mu.RLock()
 	count := len(h.connections)
 	h.mu.RUnlock()
-	if count >= maxWSConnections {
+	if int64(count)+h.pendingConns.Load() >= maxWSConnections {
 		http.Error(w, "too many WebSocket connections", http.StatusServiceUnavailable)
 		return
 	}
@@ -1871,6 +1888,17 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		h.logger.Warn("ws upgrade failed", "error", err)
 		return
 	}
+	// Held for the whole handler: a socket occupies a slot from upgrade until
+	// this function returns, whether it authenticates, times out, or errors.
+	// Released exactly once, here, so no early return can leak a slot and
+	// permanently shrink the cap.
+	h.pendingConns.Add(1)
+	pendingReleased := false
+	defer func() {
+		if !pendingReleased {
+			h.pendingConns.Add(-1)
+		}
+	}()
 	conn.SetReadLimit(wsMaxMessageSize)
 
 	connID := randomHex(8)
@@ -2059,9 +2087,18 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				capabilities: caps,
 			}
 
+			// Hand the slot over from the pending counter to h.connections
+			// under the same lock, so the connection is counted exactly once
+			// and the total never dips (which would briefly let the cap be
+			// exceeded) nor double-counts (which would halve it). The deferred
+			// Add(-1) in HandleWS is disarmed by this flag.
 			h.mu.Lock()
 			h.connections[connID] = contributor
 			h.mu.Unlock()
+			if !pendingReleased {
+				pendingReleased = true
+				h.pendingConns.Add(-1)
+			}
 
 			var perms []string
 			switch profile.TrustTier {

--- a/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -5,8 +5,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func covK2Hub(t *testing.T) (*ContributeWSHub, *Server) {
@@ -255,4 +258,89 @@ func TestCovK2_HandleWSNonWebsocket(t *testing.T) {
 	if rec.Code < 400 {
 		t.Fatalf("expected an error status for a non-websocket upgrade, got %d", rec.Code)
 	}
+}
+
+// Audit F9 (CWE-770). The connection cap counted len(h.connections), but a
+// connection is only added to that map AFTER it authenticates. So the cap
+// bounded exactly the clients that had already proven who they were, and left
+// the pre-auth window — one goroutine, one socket and a read buffer for a full
+// wsAuthTimeout each — completely unbounded.
+//
+// An unauthenticated client could therefore hold arbitrarily many sockets while
+// the only parties actually limited were legitimate contributors. Sockets must
+// occupy a slot from the moment they are upgraded.
+func TestF9_UnauthenticatedConnectionsCountTowardCap(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	srv := httptest.NewServer(http.HandlerFunc(hub.HandleWS))
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	// Open sockets and never authenticate. Each should hold a slot.
+	var open []*websocket.Conn
+	defer func() {
+		for _, c := range open {
+			c.Close()
+		}
+	}()
+	for i := 0; i < maxWSConnections; i++ {
+		c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("dial %d (below the cap) failed: %v", i, err)
+		}
+		open = append(open, c)
+	}
+
+	// Positive control: the pre-auth sockets must actually be tracked. If they
+	// are not, the assertion below would be testing nothing.
+	if got := hub.pendingConns.Load(); got == 0 {
+		t.Fatalf("test is vacuous: %d unauthenticated sockets are open but pendingConns is 0", len(open))
+	}
+	// None of them authenticated, so the authenticated map must still be empty.
+	hub.mu.RLock()
+	authed := len(hub.connections)
+	hub.mu.RUnlock()
+	if authed != 0 {
+		t.Fatalf("no connection authenticated, but h.connections holds %d", authed)
+	}
+
+	// The next dial is over the cap and must be refused.
+	c, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err == nil {
+		c.Close()
+		t.Fatal("F9: a connection beyond the cap was accepted — unauthenticated sockets do not count, so the limit only ever restrained authenticated contributors")
+	}
+	if resp != nil && resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("rejected with %d, want 503", resp.StatusCode)
+	}
+}
+
+// A socket that goes away must give its slot back, or the cap ratchets down to
+// zero over time and the endpoint dies on its own.
+func TestF9_ClosedPreAuthConnectionReleasesItsSlot(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	srv := httptest.NewServer(http.HandlerFunc(hub.HandleWS))
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.pendingConns.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if hub.pendingConns.Load() == 0 {
+		t.Fatal("test is vacuous: the open socket was never counted as pending")
+	}
+	c.Close()
+
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if hub.pendingConns.Load() == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("F9: closed pre-auth connection never released its slot (pendingConns=%d) — the cap would ratchet down permanently", hub.pendingConns.Load())
 }


### PR DESCRIPTION
## What

Audit **F9** (CWE-770, `SECURITY-REVIEW-2026-08-11.md`). The connection cap read:

```go
count := len(h.connections)
if count >= maxWSConnections { /* 503 */ }
```

But `h.connections` only gains an entry **after** a connection authenticates. So the cap bounded exactly the clients that had already proven who they were, and the pre-auth window was unbounded.

Each un-upgraded socket costs a goroutine, a file descriptor and a 64KiB read buffer for a full `wsAuthTimeout` (30s). An unauthenticated client could hold arbitrarily many of them — meaning the only parties actually restrained were legitimate contributors, capped at 50, while an attacker was capped at nothing.

## The fix

Sockets occupy a slot from the moment they are upgraded, tracked in an atomic `pendingConns`. Admission checks `connections + pending`.

The slot is **handed over** to `h.connections` on successful auth, so a connection is counted exactly once:

- never double-counted (which would halve the effective cap)
- the total never dips between the two (which would briefly allow the cap to be exceeded)

A deferred release covers every other exit path, so a socket that times out or errors can't leak a slot and ratchet the cap down permanently — `TestF9_ClosedPreAuthConnectionReleasesItsSlot` pins that, because a leak here would slowly kill the endpoint on its own.

`atomic` rather than mutex-guarded, matching the reasoning already documented on `taskGen` in this struct: it's touched from the upgrade path and from deferred cleanup, and must never contend with or re-enter `h.mu`. Verified under `-race`.

## Verification

- `go build ./...` and `go vet` clean
- `go test ./pkg/dashboard/ -run TestF9_ -race` → `ok`, no data races
- `go test ./pkg/dashboard/ -count=1` → `ok` (26.8s), full package, zero failures
- Reverting to the old cap makes the test fail: *"a connection beyond the cap was accepted — unauthenticated sockets do not count"*

Both regressions carry **positive controls** that fail loudly if the scenario stops being loaded (e.g. sockets never counted as pending), rather than quietly passing for the wrong reason — the recurring failure mode across this audit.