### PR TITLE
🐛 fix v2 owner-only dashboard tests

### DIFF
--- a/v2/pkg/dashboard/acmm_eval_coverage_test.go
+++ b/v2/pkg/dashboard/acmm_eval_coverage_test.go
@@ -23,6 +23,7 @@ func covBPostRaw(s *Server, path, body string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/v2/pkg/dashboard/acmm_roster_reconcile_test.go
+++ b/v2/pkg/dashboard/acmm_roster_reconcile_test.go
@@ -130,6 +130,7 @@ func TestSetLevelFailsWhenRosterReconcileFails(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":5}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code == 200 {

--- a/v2/pkg/dashboard/api_agentcfg_coverage_test.go
+++ b/v2/pkg/dashboard/api_agentcfg_coverage_test.go
@@ -153,6 +153,7 @@ func TestCovACfg_Export(t *testing.T) {
 	yrec := httptest.NewRecorder()
 	yreq := httptest.NewRequest(http.MethodGet, "/api/config/agent/scanner/export", nil)
 	yreq.Header.Set("Accept", "text/yaml")
+	markOwnerRequest(yreq)
 	s.mux.ServeHTTP(yrec, yreq)
 	if yrec.Code != http.StatusOK {
 		t.Fatalf("export yaml: %d", yrec.Code)

--- a/v2/pkg/dashboard/api_agents_test.go
+++ b/v2/pkg/dashboard/api_agents_test.go
@@ -663,6 +663,7 @@ func TestHandleAgentExport_YAML(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/config/agent/scanner/export", nil)
 	req.Header.Set("Accept", "text/yaml")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {

--- a/v2/pkg/dashboard/api_broad_coverage_test.go
+++ b/v2/pkg/dashboard/api_broad_coverage_test.go
@@ -13,6 +13,7 @@ func doPutRaw(s *Server, path, raw string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString(raw))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }
@@ -21,6 +22,7 @@ func doPostRaw(s *Server, path, raw string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(raw))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/v2/pkg/dashboard/api_contribute_admin_controls_test.go
+++ b/v2/pkg/dashboard/api_contribute_admin_controls_test.go
@@ -342,6 +342,7 @@ func TestGovernorHubAcceptsSkipAssigned(t *testing.T) {
 		strings.NewReader(`{"contribute_skip_assigned_to_others":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.handleGovernorHub(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("governor hub update got %d, want 200 (body: %s)", w.Code, w.Body.String())

--- a/v2/pkg/dashboard/api_coverage2_test.go
+++ b/v2/pkg/dashboard/api_coverage2_test.go
@@ -17,6 +17,7 @@ func httpPutRaw(s *Server, path string, rawBody string) *httptest.ResponseRecord
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(rawBody))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1519,6 +1519,7 @@ func TestHandleGovernorSensing_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/sensing", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -1530,6 +1531,7 @@ func TestHandleGovernorThresholds_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/thresholds", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -1541,6 +1543,7 @@ func TestHandleGovernorLabels_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/labels", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -1552,6 +1555,7 @@ func TestHandleGovernorBudget_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -1563,6 +1567,7 @@ func TestHandleGovernorRepos_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/repos", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -1574,6 +1579,7 @@ func TestHandleGovernorHealth_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/health", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2021,6 +2027,7 @@ func TestHandleKnowledgeToggle_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/knowledge/enabled", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2139,6 +2146,7 @@ func TestHandleSidebarSet_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/sidebar", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2152,6 +2160,7 @@ func TestHandleAgentConfigGeneral_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/agent/scanner/general", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2165,6 +2174,7 @@ func TestHandleAgentConfigModels_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/agent/scanner/models", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2178,6 +2188,7 @@ func TestHandleAgentConfigCadences_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/agent/scanner/cadences", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2191,6 +2202,7 @@ func TestHandleAgentConfigPipeline_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/agent/scanner/pipeline", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2204,6 +2216,7 @@ func TestHandleAgentConfigHooks_InvalidBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/config/agent/scanner/hooks", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2218,6 +2231,7 @@ func TestHandleKnowledgeUpdate_InvalidBody2(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/knowledge/project/fact-1", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2368,6 +2382,7 @@ func TestHandleGovernorNotifications_InvalidBody(t *testing.T) {
 	s, _ := apiServer(t)
 	req := httptest.NewRequest("PUT", "/api/config/governor/notifications", strings.NewReader("not-json"))
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2842,6 +2857,7 @@ func TestHandleNousConfigSection_InvalidBody(t *testing.T) {
 	s, _ := apiServerWithNous(t)
 	req := httptest.NewRequest("PUT", "/api/nous/config/goals", strings.NewReader("not-json"))
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2854,6 +2870,7 @@ func TestHandleNousGateRespond_InvalidBody(t *testing.T) {
 	s, _ := apiServerWithNous(t)
 	req := httptest.NewRequest("POST", "/api/nous/gate-respond", strings.NewReader("not-json"))
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2975,6 +2992,7 @@ func TestHandleSidebarSet_InvalidBody_AltPath(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/sidebar", strings.NewReader("not-json"))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2987,6 +3005,7 @@ func TestHandleAgentConfigRestrictions_InvalidBody(t *testing.T) {
 	s, _ := apiServer(t)
 	req := httptest.NewRequest("PUT", "/api/config/agent/scanner/restrictions", strings.NewReader("not-json"))
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -2999,6 +3018,7 @@ func TestHandleAgentConfigStats_InvalidBody(t *testing.T) {
 	s, _ := apiServer(t)
 	req := httptest.NewRequest("PUT", "/api/config/agent/scanner/stats", strings.NewReader("not-json"))
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)

--- a/v2/pkg/dashboard/api_handlers_coverage_test.go
+++ b/v2/pkg/dashboard/api_handlers_coverage_test.go
@@ -78,6 +78,7 @@ func TestCovI_AgentConfigRestrictions(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/api/config/agent/scanner/restrictions", stringReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("restrictions bad body: expected 400, got %d", rec.Code)
@@ -103,6 +104,7 @@ func TestCovI_AgentPromptSave(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/api/config/agent/scanner/prompt", stringReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("prompt bad body: expected 400, got %d", rec.Code)
@@ -175,6 +177,7 @@ func TestCovI_GitSourcesConnect(t *testing.T) {
 	// Bad body → 400.
 	req := httptest.NewRequest(http.MethodPost, "/api/knowledge/git-sources", stringReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/api_packs_coverage_test.go
+++ b/v2/pkg/dashboard/api_packs_coverage_test.go
@@ -82,6 +82,7 @@ func TestHandlePackApplyResponseBody(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/packs/1/apply", nil)
 	req.SetPathValue("level", "1")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackApply(w, req)
 
 	if w.Code != 200 {
@@ -114,6 +115,7 @@ func TestHandlePackApplyInvalidLevelZero(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/packs/0/apply", nil)
 	req.SetPathValue("level", "0")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackApply(w, req)
 
 	if w.Code == 200 {
@@ -245,6 +247,7 @@ func TestHandlePackSetLevelZero(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":0}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code != 400 {
@@ -258,6 +261,7 @@ func TestHandlePackSetLevelNegative(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":-1}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code != 400 {

--- a/v2/pkg/dashboard/api_routes_coverage_test.go
+++ b/v2/pkg/dashboard/api_routes_coverage_test.go
@@ -12,6 +12,7 @@ func covG2ServeRaw(s *Server, method, path, body string) *httptest.ResponseRecor
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(method, path, stringReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -83,6 +83,7 @@ func doPost(s *Server, path string, body interface{}) *httptest.ResponseRecorder
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, path, &b)
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }
@@ -109,6 +110,7 @@ func doPut(s *Server, path string, body interface{}) *httptest.ResponseRecorder 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, path, &b)
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }
@@ -121,6 +123,7 @@ func doDelete(s *Server, path string, body interface{}) *httptest.ResponseRecord
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodDelete, path, &b)
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }
@@ -304,6 +307,7 @@ func TestHandleBudgetIgnoreSet_InvalidBody(t *testing.T) {
 	s, _ := apiServer(t)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/budget-ignore", bytes.NewReader([]byte("not-json")))
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)

--- a/v2/pkg/dashboard/bob_key_probe_test.go
+++ b/v2/pkg/dashboard/bob_key_probe_test.go
@@ -349,6 +349,7 @@ func TestHandleGovernorBobKey_InteriorWhitespaceRefused(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob",
 		strings.NewReader(`{"apiKey":"bob_prod_abc def"}`))
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.handleGovernorBobKey(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())

--- a/v2/pkg/dashboard/bob_key_store_test.go
+++ b/v2/pkg/dashboard/bob_key_store_test.go
@@ -208,6 +208,7 @@ func TestHandleGovernorBobKey(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob", strings.NewReader(tc.body))
 			rec := httptest.NewRecorder()
+			markOwnerRequest(req)
 			s.handleGovernorBobKey(rec, req)
 
 			if rec.Code != tc.wantStatus {
@@ -255,6 +256,7 @@ func TestHandleGovernorBobKeyClear(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/config/governor/bob", nil)
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.handleGovernorBobKeyClear(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -343,7 +345,7 @@ func TestBobKeyEndpoints_ReadOnlyRoleForbidden(t *testing.T) {
 			wantStatus: http.StatusForbidden},
 		{name: "read role may view presence", method: http.MethodGet, role: "read",
 			wantStatus: http.StatusOK},
-		{name: "admin role may set", method: http.MethodPut, role: "admin",
+		{name: "owner role may set", method: http.MethodPut, role: "owner",
 			body: `{"apiKey":"` + bobTestKey + `"}`, wantStatus: http.StatusOK},
 	}
 
@@ -356,6 +358,9 @@ func TestBobKeyEndpoints_ReadOnlyRoleForbidden(t *testing.T) {
 			var bodyReader *strings.Reader = strings.NewReader(tc.body)
 			req := httptest.NewRequest(tc.method, "/api/config/governor/bob", bodyReader)
 			req.Header.Set("X-Hive-Role", tc.role)
+			if tc.role == "owner" {
+				req.Header.Set(ownerRoleVerifiedHeader, "true")
+			}
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
 

--- a/v2/pkg/dashboard/contribute_ws_model_test.go
+++ b/v2/pkg/dashboard/contribute_ws_model_test.go
@@ -128,6 +128,7 @@ func TestHandleGovernorHubNewFields(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/hub", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorHub(w, req)
 
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -54,6 +54,7 @@ func TestHandleGovernorRepos_EmptyBody(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -66,6 +67,7 @@ func TestHandleGovernorRepos_InvalidBody_Boost(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader("invalid"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -81,6 +83,7 @@ func TestHandleGovernorRepos_SimpleRepos(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusOK {
@@ -94,6 +97,7 @@ func TestHandleGovernorRepos_URLParsingRejected(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -144,6 +148,7 @@ func TestHandleGovernorRepos_InvalidRepoName(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -160,6 +165,7 @@ func TestHandleGovernorRepos_PrimaryRepo(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusOK {
@@ -180,6 +186,7 @@ func TestHandleGovernorRepos_GHE_URL(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -198,6 +205,7 @@ func TestHandleAgentPromptSave_NotFound(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "nonexistent")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentPromptSave(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -211,6 +219,7 @@ func TestHandleAgentPromptSave_BadBody(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "scanner")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentPromptSave(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -346,6 +355,7 @@ func TestHandleGovernorRepos_StripOrgPrefix(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusOK {
@@ -673,6 +683,7 @@ func TestHandleAgentConfigRestrictions_NotFound_Boost(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "nonexistent")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentConfigRestrictions(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -729,6 +740,7 @@ func TestHandleGovernorAddAgent_InvalidBody(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader("invalid"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -742,6 +754,7 @@ func TestHandleGovernorAddAgent_MissingName_Boost(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -780,6 +793,7 @@ func TestHandleKnowledgeToggle_Enable_Boost(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/knowledge/toggle", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleKnowledgeToggle(w, req)
 
 	if w.Code != http.StatusOK {
@@ -793,6 +807,7 @@ func TestHandleKnowledgeToggle_Disable_Boost(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/knowledge/toggle", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleKnowledgeToggle(w, req)
 
 	if w.Code != http.StatusOK {
@@ -998,6 +1013,7 @@ func TestHandleNousGateDecision_NoNous(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/nous/gate", strings.NewReader(`{"decision":"approve"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleNousGateDecision(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -1012,6 +1028,7 @@ func TestHandleHiveIDSet_EmptyID_Boost(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/hive-id", strings.NewReader(`{"id":""}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleHiveIDSet(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -1024,6 +1041,7 @@ func TestHandleHiveIDSet_Valid(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/hive-id", strings.NewReader(`{"id":"my-hive"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleHiveIDSet(w, req)
 
 	if w.Code != http.StatusOK {
@@ -1042,6 +1060,7 @@ func TestHandleAgentConfigGeneral_NotFound_Boost(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "nonexistent")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentConfigGeneral(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -1055,6 +1074,7 @@ func TestHandleAgentConfigGeneral_InvalidBody_Boost(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "scanner")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentConfigGeneral(w, req)
 
 	if w.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -41,6 +41,7 @@ func TestHandlePackApply_InvalidLevel(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/packs/abc/apply", nil)
 	req.SetPathValue("level", "abc")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackApply(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -53,6 +54,7 @@ func TestHandlePackSetLevel_InvalidBody(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader("invalid"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -65,6 +67,7 @@ func TestHandlePackSetLevel_OutOfRange(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":99}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -77,6 +80,7 @@ func TestHandlePackSetLevel_Valid(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":1}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code != http.StatusOK {
@@ -263,6 +267,7 @@ func TestHandleAgentConfigRestrictions_ValidAgent(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "scanner")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentConfigRestrictions(w, req)
 
 	// Should not be 404
@@ -279,6 +284,7 @@ func TestHandleGovernorLogging_SetLevel(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/logging", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLogging(w, req)
 
 	if w.Code != http.StatusOK {
@@ -292,6 +298,7 @@ func TestHandleGovernorLogging_SetSize(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/logging", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLogging(w, req)
 
 	if w.Code != http.StatusOK {
@@ -308,6 +315,7 @@ func TestHandleGovernorAddAgent_ValidAgent(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusOK {
@@ -322,6 +330,7 @@ func TestHandleGovernorRemoveAgent_NotFound_Boost(t *testing.T) {
 	req := httptest.NewRequest("DELETE", "/api/governor/agents/nonexistent", nil)
 	req.SetPathValue("name", "nonexistent")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRemoveAgent(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -353,6 +362,7 @@ func TestHandleNousGatePending_NoNous(t *testing.T) {
 	srv.deps.Nous = nil
 	req := httptest.NewRequest("GET", "/api/nous/gate/pending", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleNousGatePending(w, req)
 
 	if w.Code != http.StatusOK {
@@ -368,6 +378,7 @@ func TestHandleNousGateRespond_Valid(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/nous/gate/respond", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleNousGateRespond(w, req)
 
 	if w.Code != http.StatusOK {
@@ -380,6 +391,7 @@ func TestHandleNousGateRespond_InvalidBody_Boost(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/nous/gate/respond", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleNousGateRespond(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -657,6 +669,7 @@ func TestHandleAgentConfigGeneral_SetEnabled(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "scanner")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentConfigGeneral(w, req)
 
 	if w.Code != http.StatusOK {
@@ -713,6 +726,7 @@ func TestHandleGitSourcesList(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("GET", "/api/git-sources", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesList(w, req)
 
 	if w.Code != http.StatusOK {
@@ -727,6 +741,7 @@ func TestHandleGitSourcesConnect_InvalidBody(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/git-sources/connect", strings.NewReader("invalid"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -742,6 +757,7 @@ func TestHandleGitSourcesDisconnect_NoKnowledge(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/git-sources/disconnect", strings.NewReader("invalid"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesDisconnect(w, req)
 
 	// Without knowledge, should fail with service unavailable or bad request
@@ -803,6 +819,7 @@ func TestHandleAgentConfigRestrictions_AddRestriction(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "scanner")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentConfigRestrictions(w, req)
 
 	if w.Code == http.StatusNotFound {
@@ -916,6 +933,7 @@ func TestHandleGovernorRepos_PrimaryRepoURL(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/coverage_boost4_test.go
+++ b/v2/pkg/dashboard/coverage_boost4_test.go
@@ -180,6 +180,7 @@ func TestHandlePackApply_ValidLevel(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/packs/1/apply", nil)
 	req.SetPathValue("level", "1")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackApply(w, req)
 
 	if w.Code != http.StatusOK {
@@ -194,6 +195,7 @@ func TestHandlePackSetLevel_WithCadences(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":2}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code != http.StatusOK {
@@ -248,6 +250,7 @@ func TestHandleGitSourcesConnect_ValidBody(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/git-sources/connect", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	// May fail (no git available for clone) but should exercise the handler
@@ -269,6 +272,7 @@ func TestHandleGitSourcesDisconnect_ValidBody(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/git-sources/disconnect", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesDisconnect(w, req)
 
 	if w.Code == 0 {
@@ -467,6 +471,7 @@ func TestPackApplyAndSetLevel_Sequential(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":2}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handlePackSetLevel(w, req)
 
 	if w.Code != http.StatusOK {
@@ -484,6 +489,7 @@ func TestHandleGovernorRepos_WithEnumerateFunc(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusOK {
@@ -537,6 +543,7 @@ func TestHandleAgentConfigGeneral_SetDisplayName(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("name", "scanner")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleAgentConfigGeneral(w, req)
 
 	if w.Code != http.StatusOK {
@@ -571,6 +578,7 @@ func TestHandleHiveIDSet_TooLong(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/hive-id", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleHiveIDSet(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -584,6 +592,7 @@ func TestHandleHiveIDSet_InvalidChars(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/hive-id", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleHiveIDSet(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -663,6 +672,7 @@ func TestHandleGovernorAddAgent_FullAgent(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -337,6 +337,7 @@ func TestHandleBeadsReset(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/beads/reset", strings.NewReader(`{"reason":"test"}`))
 	req.Header.Set("Content-Type", "application/json")
+	setOwnerHeaders(req)
 	w := httptest.NewRecorder()
 	srv.handleBeadsReset(w, req)
 
@@ -353,6 +354,7 @@ func TestHandleBeadsReset(t *testing.T) {
 func TestHandleBeadsReset_NoBody(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/beads/reset", strings.NewReader(""))
+	setOwnerHeaders(req)
 	w := httptest.NewRecorder()
 	srv.handleBeadsReset(w, req)
 	if w.Code != http.StatusOK {
@@ -365,6 +367,7 @@ func TestHandleBeadsReset_NilStores(t *testing.T) {
 	srv.deps.BeadStores = nil
 	req := httptest.NewRequest("POST", "/api/beads/reset", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
+	setOwnerHeaders(req)
 	w := httptest.NewRecorder()
 	srv.handleBeadsReset(w, req)
 	if w.Code != http.StatusServiceUnavailable {
@@ -376,6 +379,7 @@ func TestHandleBeadsResetAgent(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/beads/scanner/reset", strings.NewReader(`{"reason":"agent test"}`))
 	req.Header.Set("Content-Type", "application/json")
+	setOwnerHeaders(req)
 	req.SetPathValue("agent", "scanner")
 	w := httptest.NewRecorder()
 	srv.handleBeadsResetAgent(w, req)
@@ -389,6 +393,7 @@ func TestHandleBeadsResetAgent_Unknown(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/beads/unknown/reset", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
+	setOwnerHeaders(req)
 	req.SetPathValue("agent", "unknown")
 	w := httptest.NewRecorder()
 	srv.handleBeadsResetAgent(w, req)
@@ -402,6 +407,7 @@ func TestHandleBeadsResetAgent_NilStores(t *testing.T) {
 	srv.deps.BeadStores = nil
 	req := httptest.NewRequest("POST", "/api/beads/scanner/reset", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
+	setOwnerHeaders(req)
 	req.SetPathValue("agent", "scanner")
 	w := httptest.NewRecorder()
 	srv.handleBeadsResetAgent(w, req)
@@ -1669,6 +1675,7 @@ func TestHandleInceptionStart_NoInception(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/start", strings.NewReader(`{"idea":"test"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionStart(w, req)
 
 	if w.Code != http.StatusServiceUnavailable {
@@ -1682,6 +1689,7 @@ func TestHandleInceptionStart_BadBody(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/start", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionStart(w, req)
 
 	if w.Code != http.StatusServiceUnavailable {

--- a/v2/pkg/dashboard/dashboard_config_download_test.go
+++ b/v2/pkg/dashboard/dashboard_config_download_test.go
@@ -29,6 +29,7 @@ func TestHandleConfigDownloadSuccess(t *testing.T) {
 	srv.deps = &Dependencies{Config: cfg, Logger: slog.Default()}
 
 	req := httptest.NewRequest("GET", "/api/config/download", nil)
+	setOwnerHeaders(req)
 	w := httptest.NewRecorder()
 	srv.handleConfigDownload(w, req)
 
@@ -60,6 +61,7 @@ func TestHandleConfigDownloadMissingFile(t *testing.T) {
 
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("GET", "/api/config/download", nil)
+	setOwnerHeaders(req)
 	w := httptest.NewRecorder()
 	srv.handleConfigDownload(w, req)
 
@@ -221,6 +223,7 @@ func TestHandleSelfUpgradeWithHubURL(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/api/self-upgrade", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleSelfUpgrade(w, req)
 
 	if w.Code != http.StatusOK {
@@ -243,6 +246,7 @@ func TestHandleSelfUpgradeHubUnreachable(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/api/self-upgrade", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleSelfUpgrade(w, req)
 
 	if w.Code != http.StatusBadGateway {
@@ -306,6 +310,7 @@ func TestHandleGitSourcesConnectMissingName(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -319,6 +324,7 @@ func TestHandleGitSourcesConnectMissingURL(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -332,6 +338,7 @@ func TestHandleGitSourcesConnectBadURLScheme(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -345,6 +352,7 @@ func TestHandleGitSourcesConnectPathTraversal(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -358,6 +366,7 @@ func TestHandleGitSourcesConnectBadBranch(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -371,6 +380,7 @@ func TestHandleGitSourcesConnectBadSubpath(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -384,6 +394,7 @@ func TestHandleGitSourcesConnectSubpathDash(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -397,6 +408,7 @@ func TestHandleGitSourcesConnectNameWithSlash(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -410,6 +422,7 @@ func TestHandleGitSourcesConnectGitAtURL(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -426,6 +439,7 @@ func TestHandleGitSourcesDisconnectMissingURL(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources/disconnect", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesDisconnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -440,6 +454,7 @@ func TestHandleGitSourcesDisconnectBadJSON(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources/disconnect", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesDisconnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -452,6 +467,7 @@ func TestHandleGitSourcesConnectBadJSON(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -468,6 +484,7 @@ func TestHandleConfigDownloadEnvVar(t *testing.T) {
 
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("GET", "/api/config/download", nil)
+	setOwnerHeaders(req)
 	w := httptest.NewRecorder()
 	srv.handleConfigDownload(w, req)
 

--- a/v2/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/v2/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -67,6 +67,7 @@ func TestHandleGovernorSensingInvalidRegex(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -80,6 +81,7 @@ func TestHandleGovernorSensingInvalidCLIExclude(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -93,6 +95,7 @@ func TestHandleGovernorSensingInvalidLoginPattern(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -106,6 +109,7 @@ func TestHandleGovernorSensingEvalIntervalTooLow(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -119,6 +123,7 @@ func TestHandleGovernorSensingEvalIntervalTooHigh(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -132,6 +137,7 @@ func TestHandleGovernorSensingValidPatterns(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusOK {
@@ -144,6 +150,7 @@ func TestHandleGovernorSensingBadJSON(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -189,6 +196,7 @@ func TestHandleAgentConfigGeneralBadJSON(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/agent/scanner/general", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.mux.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -201,6 +209,7 @@ func TestHandleAgentConfigRestrictionsBadJSON(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/agent/scanner/restrictions", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.mux.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -213,6 +222,7 @@ func TestHandleGovernorReposBadJSON(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -228,6 +238,7 @@ func TestHandleGovernorReposValid(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusOK {
@@ -313,6 +324,7 @@ func TestHandleGovernorSensingTTLTooHigh(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -326,6 +338,7 @@ func TestHandleAgentConfigGeneralMultiField(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/agent/scanner/general", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.mux.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
@@ -339,6 +352,7 @@ func TestHandleAgentConfigGeneralInvalidMode(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/agent/scanner/general", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.mux.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -355,6 +369,7 @@ func TestHandleAgentConfigGeneralAllModes(t *testing.T) {
 			req := httptest.NewRequest("PUT", "/api/config/agent/scanner/general", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
+			markOwnerRequest(req)
 			srv.mux.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {
 				t.Errorf("mode %s: expected 200, got %d", mode, w.Code)
@@ -369,6 +384,7 @@ func TestHandleAgentConfigGeneralUnknownAgent(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/agent/nonexistent/general", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.mux.ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -382,6 +398,7 @@ func TestHandleAgentConfigRestrictionsUnknownAgent(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/agent/nonexistent/restrictions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.mux.ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -437,6 +454,7 @@ func TestHandleGovernorLoggingBadJSON(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/logging", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLogging(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -449,6 +467,7 @@ func TestHandleGovernorAddAgentBadJSON(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -462,6 +481,7 @@ func TestHandleGovernorAddAgentMissingName(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -475,6 +495,7 @@ func TestHandleGovernorAddAgentDuplicate(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	// scanner already exists
@@ -489,6 +510,7 @@ func TestHandleGovernorHubUpdate(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/hub", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorHub(w, req)
 
 	if w.Code != http.StatusOK {
@@ -501,6 +523,7 @@ func TestHandleGovernorHubBadJSON(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/hub", strings.NewReader(`{bad`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorHub(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -514,6 +537,7 @@ func TestHandleGovernorHubPartialUpdate(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/hub", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorHub(w, req)
 
 	if w.Code != http.StatusOK {
@@ -530,6 +554,7 @@ func TestHandleGovernorAddAgentNewAgent(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusOK && w.Code != http.StatusCreated {
@@ -543,6 +568,7 @@ func TestHandleGovernorLoggingValid(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/logging", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLogging(w, req)
 
 	if w.Code != http.StatusOK {
@@ -639,6 +665,7 @@ func TestHandleGovernorReposEmpty(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -652,6 +679,7 @@ func TestHandleGovernorReposInvalidName(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -666,6 +694,7 @@ func TestHandleGovernorReposSpecialChars(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -679,6 +708,7 @@ func TestHandleGovernorReposStripOrgPrefix(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusOK {
@@ -697,6 +727,7 @@ func TestHandleGovernorAddAgentWithRole(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/governor/agents", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorAddAgent(w, req)
 
 	if w.Code != http.StatusOK && w.Code != http.StatusCreated {
@@ -936,6 +967,7 @@ func TestHandleGovernorSensingPullbackTooHigh(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/governor/sensing", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorSensing(w, req)
 
 	if w.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/dashboard_inception_handlers_test.go
+++ b/v2/pkg/dashboard/dashboard_inception_handlers_test.go
@@ -32,6 +32,7 @@ func TestHandleInceptionStartNilEngine(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/start", strings.NewReader(`{"idea":"test"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionStart(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -42,6 +43,7 @@ func TestHandleInceptionScanNilEngine(t *testing.T) {
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("POST", "/api/inception/scan", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionScan(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -63,6 +65,7 @@ func TestHandleInceptionSetQuestionsNilEngine(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/questions", strings.NewReader(`{"questions":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionSetQuestions(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -74,6 +77,7 @@ func TestHandleInceptionAnswerNilEngine(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/answer", strings.NewReader(`{"answers":{}}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionAnswer(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -85,6 +89,7 @@ func TestHandleInceptionRecordFactsNilEngine(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/facts", strings.NewReader(`{"facts":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionRecordFacts(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -105,6 +110,7 @@ func TestHandleInceptionApproveNilEngine(t *testing.T) {
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("POST", "/api/inception/approve", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionApprove(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -115,6 +121,7 @@ func TestHandleInceptionResetNilEngine(t *testing.T) {
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("POST", "/api/inception/reset", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionReset(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -159,6 +166,7 @@ func TestHandleInceptionRenameWikiNilEngine(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/rename-wiki", strings.NewReader(`{"name":"test"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionRenameWiki(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -170,6 +178,7 @@ func TestHandleInceptionImportNilEngine(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/inception/import", strings.NewReader(`{"files":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleInceptionImport(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503, got %d", w.Code)
@@ -250,6 +259,7 @@ func TestHandleSelfUpgradeNoHubURL(t *testing.T) {
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("POST", "/api/self-upgrade", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleSelfUpgrade(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", w.Code)
@@ -283,6 +293,7 @@ func TestHandleGitSourcesListNilKnowledge(t *testing.T) {
 	srv := newMinimalServer(t)
 	req := httptest.NewRequest("GET", "/api/knowledge/git-sources", nil)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesList(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d", w.Code)
@@ -295,6 +306,7 @@ func TestHandleGitSourcesConnectNoKnowledge(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesConnect(w, req)
 	// Should get 400 (invalid request body or missing fields) since ensureKnowledge creates a fallback
 	if w.Code != http.StatusBadRequest {
@@ -307,6 +319,7 @@ func TestHandleGitSourcesDisconnectNilKnowledge(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/knowledge/git-sources/disconnect", strings.NewReader(`{"url":"https://example.com"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGitSourcesDisconnect(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Logf("git sources disconnect: got %d", w.Code)

--- a/v2/pkg/dashboard/forge_apps_test.go
+++ b/v2/pkg/dashboard/forge_apps_test.go
@@ -41,6 +41,7 @@ func getForgeApps(t *testing.T, s *Server) (*httptest.ResponseRecorder, map[stri
 	t.Helper()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/config/github/forge-apps", nil)
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	var body map[string]any
 	if rec.Code == http.StatusOK {

--- a/v2/pkg/dashboard/gateways_test.go
+++ b/v2/pkg/dashboard/gateways_test.go
@@ -55,6 +55,7 @@ func TestGatewaysUpsert_StoresKeyAsFileRef(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
@@ -101,6 +102,7 @@ func TestGatewaysUpsert_RejectsInvalidEndpoint(t *testing.T) {
 	body := `{"name":"bad","endpoint":"not-a-url"}`
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400", w.Code)
@@ -115,6 +117,7 @@ func TestGatewaysUpsert_RejectsPrivateEndpoint(t *testing.T) {
 	body := `{"name":"bad","kind":"custom","endpoint":"https://169.254.169.254/v1"}`
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
@@ -148,6 +151,7 @@ func TestGatewaysDelete_InUseConflict(t *testing.T) {
 	req := httptest.NewRequest("DELETE", "/api/config/governor/gateways/openrouter", nil)
 	req.SetPathValue("name", "openrouter")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysDelete(w, req)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("code = %d, want 409 (body %s)", w.Code, w.Body.String())
@@ -170,6 +174,7 @@ func TestGatewaysDelete_Succeeds(t *testing.T) {
 	req := httptest.NewRequest("DELETE", "/api/config/governor/gateways/openrouter", nil)
 	req.SetPathValue("name", "openrouter")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysDelete(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
@@ -190,6 +195,7 @@ func TestGatewaysUpsert_PreservesKeyOnEdit(t *testing.T) {
 	body := `{"name":"corp","kind":"litellm","endpoint":"https://new.example.com","default_model":"gpt-4o-mini"}`
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())

--- a/v2/pkg/dashboard/inception_handlers_coverage_test.go
+++ b/v2/pkg/dashboard/inception_handlers_coverage_test.go
@@ -178,6 +178,7 @@ func TestCovF_InceptionImport(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/inception/import", &body)
 	req.Header.Set("Content-Type", mw.FormDataContentType())
 	wrec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(wrec, req)
 	if wrec.Code != http.StatusOK {
 		t.Fatalf("import: expected 200, got %d body=%s", wrec.Code, wrec.Body.String())
@@ -226,6 +227,7 @@ func TestCovF_InceptionBadBodies(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/inception/start", strings.NewReader("{not json"))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("start bad json: expected 400, got %d", rec.Code)

--- a/v2/pkg/dashboard/litellm_api_test.go
+++ b/v2/pkg/dashboard/litellm_api_test.go
@@ -25,6 +25,7 @@ func TestHandleGovernorLiteLLM_Update(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLiteLLM(w, req)
 
 	if w.Code != http.StatusOK {
@@ -53,6 +54,7 @@ func TestHandleGovernorLiteLLM_InvalidEndpointRejected(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLiteLLM(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -116,6 +118,7 @@ func TestHandleGovernorLiteLLM_EnvNameGuardrail(t *testing.T) {
 			req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
+			markOwnerRequest(req)
 			srv.handleGovernorLiteLLM(w, req)
 			if tc.wantOK && w.Code != http.StatusOK {
 				t.Fatalf("code = %d, want 200 (body: %s)", w.Code, w.Body.String())
@@ -158,6 +161,7 @@ func TestHandleGovernorLiteLLM_APIKeyValueStored(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLiteLLM(w, req)
 
 	if w.Code != http.StatusOK {
@@ -219,6 +223,7 @@ func TestHandleGovernorLiteLLM_ProbeSurfacesGatewayError(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLiteLLM(w, req)
 
 	if w.Code != http.StatusOK {
@@ -305,6 +310,7 @@ func TestHandleGovernorLiteLLM_KeyFileGuardrail(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLiteLLM(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 for key-like file path", w.Code)
@@ -318,6 +324,7 @@ func TestHandleGovernorLiteLLM_KeyFileGuardrail(t *testing.T) {
 	req = httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv2.handleGovernorLiteLLM(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d, want 200 for absolute path (body: %s)", w.Code, w.Body.String())
@@ -397,6 +404,7 @@ func TestHandleGovernorLiteLLM_StoringKeyScrubsPastedEnvValue(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorLiteLLM(w, req)
 
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/misc_coverage_test.go
+++ b/v2/pkg/dashboard/misc_coverage_test.go
@@ -25,6 +25,7 @@ func doPutRawCovD(s *Server, path, body string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }
@@ -33,6 +34,7 @@ func doPostRawCovD(s *Server, path, body string) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/v2/pkg/dashboard/queue_play_pause_test.go
+++ b/v2/pkg/dashboard/queue_play_pause_test.go
@@ -93,6 +93,7 @@ func TestQueuePlayPauseSharesGovernorHubPUT(t *testing.T) {
 		strings.NewReader(`{"contribute_suspended":true}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	s.handleGovernorHub(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("governor hub update got %d, want 200 (body: %s)", w.Code, w.Body.String())
@@ -113,6 +114,7 @@ func TestQueuePlayPauseSharesGovernorHubPUT(t *testing.T) {
 		strings.NewReader(`{"contribute_suspended":false}`))
 	req2.Header.Set("Content-Type", "application/json")
 	w2 := httptest.NewRecorder()
+	markOwnerRequest(req2)
 	s.handleGovernorHub(w2, req2)
 	if w2.Code != http.StatusOK {
 		t.Fatalf("governor hub resume got %d, want 200 (body: %s)", w2.Code, w2.Body.String())

--- a/v2/pkg/dashboard/repo_add_form_test.go
+++ b/v2/pkg/dashboard/repo_add_form_test.go
@@ -23,6 +23,7 @@ func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -50,6 +51,7 @@ func TestGovernorRepos_GHEHiveHostRules(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(ok))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("same-forge URL add: code = %d, want 400 (body: %s)", w.Code, w.Body.String())
@@ -63,6 +65,7 @@ func TestGovernorRepos_GHEHiveHostRules(t *testing.T) {
 	req = httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(bad))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("cross-forge add on GHE hive: code = %d, want 400", w.Code)
@@ -82,6 +85,7 @@ func TestGovernorRepos_RejectsSaveWithNoDefault(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -109,6 +113,7 @@ func TestGovernorRepos_RejectsRemovingDefault(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 when the default is removed with no replacement", w.Code)
@@ -119,6 +124,7 @@ func TestGovernorRepos_RejectsRemovingDefault(t *testing.T) {
 	req = httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d, want 200 once a new default is named (body: %s)", w.Code, w.Body.String())

--- a/v2/pkg/dashboard/variables_api_test.go
+++ b/v2/pkg/dashboard/variables_api_test.go
@@ -27,6 +27,7 @@ func putVar(t *testing.T, srv *Server, name, body string) int {
 	req := httptest.NewRequest("PUT", "/api/config/variables/"+name, strings.NewReader(body))
 	req.SetPathValue("name", name)
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleVariableUpsert(w, req)
 	return w.Code
 }
@@ -82,6 +83,7 @@ func TestVariableDelete_GuardsSeedTypes(t *testing.T) {
 	req := httptest.NewRequest("DELETE", "/api/config/variables/SEED_SCRIPT", nil)
 	req.SetPathValue("name", "SEED_SCRIPT")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleVariableDelete(w, req)
 	if w.Code != 403 {
 		t.Errorf("deleting script var should be 403, got %d", w.Code)
@@ -90,6 +92,7 @@ func TestVariableDelete_GuardsSeedTypes(t *testing.T) {
 	req2 := httptest.NewRequest("DELETE", "/api/config/variables/UI_STATIC", nil)
 	req2.SetPathValue("name", "UI_STATIC")
 	w2 := httptest.NewRecorder()
+	markOwnerRequest(req2)
 	srv.handleVariableDelete(w2, req2)
 	if w2.Code != 200 {
 		t.Errorf("deleting static var should be 200, got %d", w2.Code)

--- a/v2/pkg/dashboard/watsonx_gateway_test.go
+++ b/v2/pkg/dashboard/watsonx_gateway_test.go
@@ -20,6 +20,7 @@ func TestWatsonxUpsert_RejectsMissingProjectID(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
@@ -39,6 +40,7 @@ func TestWatsonxUpsert_RejectsMissingKey(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 (body %s)", w.Code, w.Body.String())
@@ -81,6 +83,7 @@ func TestWatsonxUpsert_StoresGateway(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())
@@ -233,6 +236,7 @@ func TestWatsonxUpsert_DerivesEndpointFromRegion(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/config/governor/gateways", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
+	markOwnerRequest(req)
 	srv.handleGovernorGatewaysUpsert(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d, want 200 (body %s)", w.Code, w.Body.String())


### PR DESCRIPTION
Fixes #3375.

The failures started after owner-only gates were added to dashboard mutation handlers. The production gate is correct: direct handler unit tests that intend to exercise owner-only mutation behavior must simulate the authenticated owner marker set by middleware.

Validation:
- reproduced at 6f3e718 with TestHandleBeadsReset* returning 403 instead of expected handler responses
- go test ./pkg/dashboard -run 'TestHandleBeadsReset|TestHandleBeadsReset_NoBody|TestHandleBeadsReset_NilStores|TestHandleBeadsResetAgent|TestHandleBeadsResetAgent_Unknown|TestHandleBeadsResetAgent_NilStores' -count=1 -v
- go test ./pkg/dashboard -count=1
- go vet ./pkg/dashboard
- go build ./...

v4 shares the affected code/tests; twin PR to follow.