### PR TITLE
🔒 sec(dashboard): optional bearer token for /metrics (#3399)

### DIFF
--- a/v2/docs/operator-reference.md
+++ b/v2/docs/operator-reference.md
@@ -191,6 +191,7 @@ installation instead of broadening the PAT.
 | Name | Purpose |
 |---|---|
 | `HIVE_METRICS_ENABLED` | Enables unauthenticated Prometheus `/metrics` when set to `1`, `true`, `yes`, or `on`; off by default because it exposes estimated cost data. |
+| `HIVE_METRICS_TOKEN` | Optional bearer token for `/metrics`. When set, scrapers must send `Authorization: Bearer <token>` (configure Prometheus `bearer_token`); when empty, `/metrics` stays open. Set it to stop the cost/agent series leaking to anyone on the pod network. |
 
 > **Note on `tokens_24h`:** despite its name, the per-spoke heartbeat field
 > `tokens_24h` (stored on the hub as `totalTokens24h`) is a **cumulative total**,

--- a/v2/pkg/dashboard/metrics_prometheus.go
+++ b/v2/pkg/dashboard/metrics_prometheus.go
@@ -20,6 +20,15 @@ func metricsEnabled() bool {
 	return false
 }
 
+// metricsToken returns the optional bearer token that guards /metrics. When set
+// (HIVE_METRICS_TOKEN), the endpoint requires "Authorization: Bearer <token>";
+// when empty, /metrics stays open (backward-compatible — existing scrapers keep
+// working). Configure a token AND point Prometheus at it via bearer_token to
+// stop the endpoint from leaking cost/agent data to anyone on the pod network.
+func metricsToken() string {
+	return strings.TrimSpace(os.Getenv("HIVE_METRICS_TOKEN"))
+}
+
 // Prometheus text-exposition endpoint for hive's ESTIMATED LLM cost.
 //
 // This is deliberately dependency-free (no prometheus/client_golang): it writes
@@ -40,6 +49,18 @@ func metricsEnabled() bool {
 //	hive_model_input_tokens_total{hive_id,model}    — per-model input tokens
 //	hive_model_output_tokens_total{hive_id,model}   — per-model output tokens
 func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	// Optional bearer auth (#3399): when HIVE_METRICS_TOKEN is set, /metrics
+	// requires "Authorization: Bearer <token>" so the cost/agent series aren't
+	// readable by anyone on the pod network. Empty token = open, as before.
+	if want := metricsToken(); want != "" {
+		got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if !secureCompare(got, want) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="hive-metrics"`)
+			http.Error(w, "metrics require a bearer token", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	est := s.estimatedCost()
 
 	hiveID := ""

--- a/v2/pkg/dashboard/metrics_prometheus_test.go
+++ b/v2/pkg/dashboard/metrics_prometheus_test.go
@@ -43,3 +43,56 @@ func TestHandleMetricsExposition(t *testing.T) {
 		t.Errorf("Content-Type = %q, want text/plain exposition", ct)
 	}
 }
+
+// TestHandleMetricsBearerToken covers the optional HIVE_METRICS_TOKEN gate
+// (#3399): open when unset (backward-compatible), and requires a matching
+// Bearer token when set.
+func TestHandleMetricsBearerToken(t *testing.T) {
+	newRec := func(auth string) *httptest.ResponseRecorder {
+		s := covApiServer(t)
+		s.deps.Config.HiveID = "test-hive"
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		rec := httptest.NewRecorder()
+		s.handleMetrics(rec, req)
+		return rec
+	}
+
+	t.Run("no token configured stays open", func(t *testing.T) {
+		t.Setenv("HIVE_METRICS_TOKEN", "")
+		if rec := newRec(""); rec.Code != http.StatusOK {
+			t.Errorf("unauthenticated /metrics with no token = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("token configured rejects missing bearer", func(t *testing.T) {
+		t.Setenv("HIVE_METRICS_TOKEN", "sk-metrics")
+		rec := newRec("")
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("missing bearer = %d, want 401", rec.Code)
+		}
+		if got := rec.Header().Get("WWW-Authenticate"); !strings.Contains(got, "Bearer") {
+			t.Errorf("WWW-Authenticate = %q, want a Bearer challenge", got)
+		}
+	})
+
+	t.Run("token configured rejects wrong bearer", func(t *testing.T) {
+		t.Setenv("HIVE_METRICS_TOKEN", "sk-metrics")
+		if rec := newRec("Bearer wrong"); rec.Code != http.StatusUnauthorized {
+			t.Errorf("wrong bearer = %d, want 401", rec.Code)
+		}
+	})
+
+	t.Run("token configured accepts correct bearer", func(t *testing.T) {
+		t.Setenv("HIVE_METRICS_TOKEN", "sk-metrics")
+		rec := newRec("Bearer sk-metrics")
+		if rec.Code != http.StatusOK {
+			t.Errorf("correct bearer = %d, want 200", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "hive_estimated_cost_usd_total") {
+			t.Error("authenticated /metrics should return the exposition")
+		}
+	})
+}


### PR DESCRIPTION
## Fixes #3399

`/metrics` (when `HIVE_METRICS_ENABLED=1`) served cost/agent/token data + `hive_id` unauthenticated. Add an **optional** bearer gate:

- `HIVE_METRICS_TOKEN` **unset** → `/metrics` stays open (backward-compatible; existing scrapers keep working).
- `HIVE_METRICS_TOKEN` **set** → requires `Authorization: Bearer <token>` (constant-time compare); 401 + `WWW-Authenticate` otherwise. Point Prometheus at it with `bearer_token`.

Documented the env var in operator-reference.md. Tests cover open-when-unset, and missing/wrong/correct bearer when set.