### PR TITLE
🔒 fix(dashboard): count unauthenticated sockets toward the WebSocket cap (v2 port of #3422)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -293,7 +293,15 @@ type ContributeWSHub struct {
 	// h.mu.RLock): a mu-guarded counter would deadlock (RLock-then-Lock on the same
 	// RWMutex). Lock-free is also what the -race coverage job wants — see the standing
 	// "never re-lock m.mu from a path that holds it" rule.
-	taskGen        atomic.Uint64
+	taskGen atomic.Uint64
+	// pendingConns counts sockets that have been upgraded but have not yet
+	// authenticated (audit F9). h.connections only gains an entry AFTER auth
+	// succeeds, so capping on that map alone left the pre-auth window — a full
+	// wsAuthTimeout per socket — completely unbounded. Atomic rather than
+	// mu-guarded to match taskGen's reasoning above: it is touched from the
+	// upgrade path and from deferred cleanup, and must never contend with or
+	// re-enter h.mu.
+	pendingConns atomic.Int64
 	activityMu     sync.RWMutex
 	activity       []ActivityEntry
 	server         *Server
@@ -1682,10 +1690,19 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 const maxWSConnections = 50
 
 func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
+	// SECURITY (audit F9, CWE-770): the cap must count sockets that are still
+	// authenticating, not just authenticated ones.
+	//
+	// h.connections only gains an entry after auth succeeds, so capping on it
+	// alone bounded exactly the connections that had already proven who they
+	// were, while leaving the pre-auth window unbounded. An unauthenticated
+	// client could hold arbitrarily many sockets — each costing a goroutine, a
+	// file descriptor and a read buffer for a full wsAuthTimeout — and the only
+	// parties actually limited were legitimate contributors.
 	h.mu.RLock()
 	count := len(h.connections)
 	h.mu.RUnlock()
-	if count >= maxWSConnections {
+	if int64(count)+h.pendingConns.Load() >= maxWSConnections {
 		http.Error(w, "too many WebSocket connections", http.StatusServiceUnavailable)
 		return
 	}
@@ -1695,6 +1712,17 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		h.logger.Warn("ws upgrade failed", "error", err)
 		return
 	}
+	// Held for the whole handler: a socket occupies a slot from upgrade until
+	// this function returns, whether it authenticates, times out, or errors.
+	// Released exactly once so no early return can leak a slot and permanently
+	// shrink the cap.
+	h.pendingConns.Add(1)
+	pendingReleased := false
+	defer func() {
+		if !pendingReleased {
+			h.pendingConns.Add(-1)
+		}
+	}()
 	conn.SetReadLimit(wsMaxMessageSize)
 
 	connID := randomHex(8)
@@ -1883,9 +1911,17 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				capabilities: caps,
 			}
 
+			// Hand the slot over from the pending counter to h.connections so
+			// the connection is counted exactly once: the total never dips
+			// (which would briefly let the cap be exceeded) nor double-counts
+			// (which would halve it). Disarms the deferred release above.
 			h.mu.Lock()
 			h.connections[connID] = contributor
 			h.mu.Unlock()
+			if !pendingReleased {
+				pendingReleased = true
+				h.pendingConns.Add(-1)
+			}
 
 			var perms []string
 			switch profile.TrustTier {

--- a/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/v2/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -5,8 +5,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func covK2Hub(t *testing.T) (*ContributeWSHub, *Server) {
@@ -255,4 +258,89 @@ func TestCovK2_HandleWSNonWebsocket(t *testing.T) {
 	if rec.Code < 400 {
 		t.Fatalf("expected an error status for a non-websocket upgrade, got %d", rec.Code)
 	}
+}
+
+// Audit F9 (CWE-770). The connection cap counted len(h.connections), but a
+// connection is only added to that map AFTER it authenticates. So the cap
+// bounded exactly the clients that had already proven who they were, and left
+// the pre-auth window — one goroutine, one socket and a read buffer for a full
+// wsAuthTimeout each — completely unbounded.
+//
+// An unauthenticated client could therefore hold arbitrarily many sockets while
+// the only parties actually limited were legitimate contributors. Sockets must
+// occupy a slot from the moment they are upgraded.
+func TestF9_UnauthenticatedConnectionsCountTowardCap(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	srv := httptest.NewServer(http.HandlerFunc(hub.HandleWS))
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	// Open sockets and never authenticate. Each should hold a slot.
+	var open []*websocket.Conn
+	defer func() {
+		for _, c := range open {
+			c.Close()
+		}
+	}()
+	for i := 0; i < maxWSConnections; i++ {
+		c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("dial %d (below the cap) failed: %v", i, err)
+		}
+		open = append(open, c)
+	}
+
+	// Positive control: the pre-auth sockets must actually be tracked. If they
+	// are not, the assertion below would be testing nothing.
+	if got := hub.pendingConns.Load(); got == 0 {
+		t.Fatalf("test is vacuous: %d unauthenticated sockets are open but pendingConns is 0", len(open))
+	}
+	// None of them authenticated, so the authenticated map must still be empty.
+	hub.mu.RLock()
+	authed := len(hub.connections)
+	hub.mu.RUnlock()
+	if authed != 0 {
+		t.Fatalf("no connection authenticated, but h.connections holds %d", authed)
+	}
+
+	// The next dial is over the cap and must be refused.
+	c, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err == nil {
+		c.Close()
+		t.Fatal("F9: a connection beyond the cap was accepted — unauthenticated sockets do not count, so the limit only ever restrained authenticated contributors")
+	}
+	if resp != nil && resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("rejected with %d, want 503", resp.StatusCode)
+	}
+}
+
+// A socket that goes away must give its slot back, or the cap ratchets down to
+// zero over time and the endpoint dies on its own.
+func TestF9_ClosedPreAuthConnectionReleasesItsSlot(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	srv := httptest.NewServer(http.HandlerFunc(hub.HandleWS))
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.pendingConns.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if hub.pendingConns.Load() == 0 {
+		t.Fatal("test is vacuous: the open socket was never counted as pending")
+	}
+	c.Close()
+
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if hub.pendingConns.Load() == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("F9: closed pre-auth connection never released its slot (pendingConns=%d) — the cap would ratchet down permanently", hub.pendingConns.Load())
 }


### PR DESCRIPTION
## What

Port of #3422 (audit **F9**, CWE-770) to `v2`. **v2 runs the entire production fleet**, so this matters more here than on the single v4 hive.

The cap read `len(h.connections)`, but a connection only enters that map **after** it authenticates. So the limit bounded exactly the clients that had already proven who they were, and the pre-auth window — one goroutine, one file descriptor and a 64KiB read buffer per socket for a full 30s `wsAuthTimeout` — was unbounded. The only parties actually restrained were legitimate contributors.

## The fix

Sockets occupy a slot from upgrade, tracked in an atomic `pendingConns`; admission checks `connections + pending`. The slot is handed over on successful auth so each connection is counted exactly once — never double-counted (which would halve the cap), never dipping between the two (which would briefly allow exceeding it), never leaked on an error path (which would ratchet the cap to zero permanently).

`atomic` rather than mutex-guarded, matching the reasoning already documented on `taskGen` in this struct.

## Verification

- `go build ./...` clean
- `go test ./pkg/dashboard/ -run TestF9_ -race` → `ok`, no data races
- Reverting the cap makes the test fail: *"a connection beyond the cap was accepted"*
- **Baselined against clean `origin/v2`**: 380 pre-existing `pkg/dashboard` failures before and after, **zero new**. Those failures are environmental (shared `/data`/HOME) and unrelated.

## Scope note — F6 deliberately NOT ported

I also investigated porting F6 (the gateway-probe credential leak). **v2 has two defenses v4 lacked**: `requireOwnerRole` on the upsert handler, and an `isPrivateURL` guard that resolves DNS and fails closed.

I could not construct a test demonstrating the leak is reachable on v2 — every attempt was blocked by one of those guards, and my vacuity guards correctly caught each one rather than letting a green result stand. Rather than ship a fix for a vulnerability I have not shown to exist here, I am leaving F6 out of this PR.

Two things worth flagging separately, both **pre-existing on `origin/v2`** and neither introduced here:

1. `TestGatewaysUpsert_*` (4 tests) fail on clean `origin/v2` because they never set the owner headers `requireOwnerRole` demands — they assert against a `403` and so prove nothing about the handler body.
2. `TestGatewaysUpsert_RejectsPrivateEndpoint` and `TestGatewaysDiscover_RejectsPrivateEndpoint` pass for the same wrong reason (403 arrives before the SSRF check runs).