### PR TITLE
🔒 sec(image): Goose from official block/goose + checksum (#3417)

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -116,18 +116,29 @@ RUN npm install -g @openai/codex@${CODEX_VERSION} && npm cache clean --force || 
 ARG CLAUDE_CODE_VERSION=2.1.226
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
 
-# --- Layer 8: Goose CLI (block/goose — official upstream, matches Dockerfile.contributor) ---
-# Pinned to match Dockerfile.contributor. aaif-goose was an unofficial fork;
-# block/goose is the official repository (Block/Square). sec-check #3417.
+# --- Layer 8: Goose CLI (official block/goose upstream) ---
+# Installs from the OFFICIAL block/goose repo (was the unofficial aaif-goose
+# fork, a supply-chain risk — #3417), pinned to a version matching
+# Dockerfile.contributor, and SHA-256-verified before extraction so a tampered
+# release cannot inject code into the spoke image. Bump GOOSE_SHA256_* whenever
+# GOOSE_VERSION changes (compute from the release's linux-gnu tarballs).
+# A download/extract failure is still tolerated (agents on backend: goose just
+# won't launch, same as other optional backends), but a CHECKSUM MISMATCH is a
+# hard failure — a tampered binary must never be installed.
 ARG GOOSE_VERSION=1.45.0
+ARG GOOSE_SHA256_X86_64=e0db638ac437ca0a60b0c1622f45322608d228d1a285214c3bf48fd9763346a5
+ARG GOOSE_SHA256_AARCH64=c9894106c90e404ac8b8d67c628aea2943dd6a1bc83bfd8e2171d482fa43d72a
 RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then GOOSE_ARCH=x86_64; \
-    elif [ "$ARCH" = "aarch64" ]; then GOOSE_ARCH=aarch64; \
-    else GOOSE_ARCH=x86_64; fi && \
-    curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" | \
-    tar xz -C /usr/local/bin goose && \
-    chmod +x /usr/local/bin/goose || \
-    echo "WARN: Goose CLI install failed — skipping"
+    if [ "$ARCH" = "aarch64" ]; then GOOSE_ARCH=aarch64; GOOSE_SHA256="$GOOSE_SHA256_AARCH64"; \
+    else GOOSE_ARCH=x86_64; GOOSE_SHA256="$GOOSE_SHA256_X86_64"; fi && \
+    if curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
+      echo "${GOOSE_SHA256}  /tmp/goose.tar.gz" | sha256sum -c - && \
+      tar xz -C /usr/local/bin -f /tmp/goose.tar.gz && \
+      chmod +x /usr/local/bin/goose && \
+      rm -f /tmp/goose.tar.gz; \
+    else \
+      echo "WARN: Goose CLI download failed — skipping (backend: goose will be unavailable)"; \
+    fi
 
 # --- Layer 8.5: pi CLI (@earendil-works/pi-coding-agent — backend: pi) ---
 # Tolerant of failure like the copilot/codex layers: agents configured for

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -70,18 +70,26 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # Install Goose CLI (Block's AI agent)
 # Version pinned — was fetching releases/latest which resolves to HEAD at
-# build time (sec-check issue #2919). Pin to a specific release tag.
+# build time (sec-check issue #2919). Pin to a specific release tag and verify
+# the tarball before extraction. Download failures are tolerated because Goose
+# is an optional contributor backend; checksum mismatches are not tolerated.
 ARG GOOSE_VERSION=1.45.0
+ARG GOOSE_SHA256_X86_64=e0db638ac437ca0a60b0c1622f45322608d228d1a285214c3bf48fd9763346a5
+ARG GOOSE_SHA256_AARCH64=c9894106c90e404ac8b8d67c628aea2943dd6a1bc83bfd8e2171d482fa43d72a
 RUN ARCH=$(dpkg --print-architecture) \
-  && GOOSE_ARCH=$([ "$ARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
+  && if [ "$ARCH" = "arm64" ]; then GOOSE_ARCH=aarch64; GOOSE_SHA256="$GOOSE_SHA256_AARCH64"; \
+     else GOOSE_ARCH=x86_64; GOOSE_SHA256="$GOOSE_SHA256_X86_64"; fi \
   && mkdir -p /tmp/goose-dl \
-  && curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" \
-    -o /tmp/goose-dl/goose.tar.gz \
-  && cd /tmp/goose-dl && tar -xzf goose.tar.gz \
-  && find /tmp/goose-dl -name "goose" -type f -exec cp {} /usr/local/bin/goose \; \
-  && chmod +x /usr/local/bin/goose \
-  && rm -rf /tmp/goose-dl \
-  || echo "Goose install skipped"
+  && if curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" \
+       -o /tmp/goose-dl/goose.tar.gz; then \
+       echo "${GOOSE_SHA256}  /tmp/goose-dl/goose.tar.gz" | sha256sum -c - \
+       && cd /tmp/goose-dl && tar -xzf goose.tar.gz \
+       && find /tmp/goose-dl -name "goose" -type f -exec cp {} /usr/local/bin/goose \; \
+       && chmod +x /usr/local/bin/goose \
+       && rm -rf /tmp/goose-dl; \
+     else \
+       echo "Goose install skipped"; \
+     fi
 
 # Install Pi CLI (pi.dev coding agent). Do not use pi.dev's curl-pipe-to-shell
 # installer here: it is mutable and executes remote shell as root. Pi publishes


### PR DESCRIPTION
## Fixes #3417

The main `v2/Dockerfile` installed Goose from the **unofficial `aaif-goose/goose` fork** at v1.37.0 with no integrity check — a supply-chain risk (a malicious fork release runs inside every spoke image with agent-credential access). `Dockerfile.contributor` already used official `block/goose`.

**Fix:** switch to official `block/goose`, pin to **v1.45.0** (matching the contributor image), and SHA-256-verify per-arch (x86_64 + aarch64) before extraction. Download failure stays tolerated (goose degrades gracefully); a **checksum mismatch hard-fails** the build.

Checksums computed from the official v1.45.0 linux-gnu release tarballs. Custom OpenAI-compatible providers (hive's gateway routing) work on official Goose via env — no functional regression.