### PR TITLE
🐛 fix(config): accept any owner/repo repo target (clears false 'misconfigured' fleet warnings)

### DIFF
--- a/v2/pkg/config/repo_target.go
+++ b/v2/pkg/config/repo_target.go
@@ -43,19 +43,19 @@ func ValidateProjectRepoTargets(org string, repos []string, primaryRepo, forgeHo
 		return issue("project.repos", "repo is empty — expected org/repo")
 	}
 	for _, repo := range repos {
-		if repoIssue := validateRepoName("project.repos", org, repo); repoIssue != nil {
+		if repoIssue := validateRepoName("project.repos", repo); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	if strings.TrimSpace(primaryRepo) != "" {
-		if repoIssue := validateRepoName("project.primary_repo", org, primaryRepo); repoIssue != nil {
+		if repoIssue := validateRepoName("project.primary_repo", primaryRepo); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	return nil
 }
 
-func validateRepoName(field, org, repo string) *RepoTargetIssue {
+func validateRepoName(field, repo string) *RepoTargetIssue {
 	repo = strings.TrimSpace(repo)
 	if repo == "" {
 		return issue(field, "repo is empty — expected org/repo")
@@ -64,20 +64,24 @@ func validateRepoName(field, org, repo string) *RepoTargetIssue {
 		return issue(field, "repo '"+repo+"' is a URL — expected repo name only so the target resolves to org/repo")
 	}
 	if strings.Contains(repo, "/") {
-		// A fully-qualified "<org>/<repo>" is accepted when the org prefix
-		// matches the configured project.org — it is unambiguously the same
-		// target, and the save path strips the prefix down to the bare name.
-		// This is what a user naturally types/pastes when re-adding an existing
-		// repo from the Governor → Repos page (issue #3021). Anything else
-		// (a different org, a trailing slash, or multiple slashes) is still a
-		// misconfiguration.
-		org = strings.TrimSpace(org)
-		prefix := org + "/"
-		bare := strings.TrimPrefix(repo, prefix)
-		if org != "" && strings.HasPrefix(repo, prefix) && bare != "" && !strings.Contains(bare, "/") {
+		// A fully-qualified "<owner>/<repo>" is a VALID target — the runtime
+		// resolves it exactly this way: Client.splitRepo() splits on the single
+		// slash and uses that owner (falling back to project.org only for a bare
+		// name). So a hive can legitimately watch a repo in a DIFFERENT org than
+		// project.org (e.g. project.org=kalantar-msb watching
+		// inference-sim/sim2real). These configs worked for a long time; the
+		// stricter validator added later flagged them as "misconfigured" even
+		// though nothing was wrong — a false positive (see #3021 and the
+		// context-forge/hashicorp/kalantar-msb fleet warnings).
+		//
+		// Accept any well-formed owner/repo (exactly one slash, both parts
+		// non-empty). Only genuinely-broken shapes — a trailing slash, a leading
+		// slash, or multiple slashes — are still rejected.
+		parts := strings.Split(repo, "/")
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 			return nil
 		}
-		return issue(field, "repo '"+repo+"' contains '/' — expected repo name only (or '"+org+"/<repo>') so the target resolves to org/repo")
+		return issue(field, "repo '"+repo+"' is not a valid target — expected 'repo' or 'owner/repo' (exactly one '/')")
 	}
 	return nil
 }

--- a/v2/pkg/config/repo_target_test.go
+++ b/v2/pkg/config/repo_target_test.go
@@ -56,33 +56,42 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 			want:  "Repo target misconfigured: repo is empty — expected org/repo. Fix in Governor Config → Repos.",
 		},
 		{
-			name:  "trailing slash shape",
+			name:  "trailing slash shape rejected",
 			org:   "kubestellar",
 			repos: []string{"hive/"},
 			forge: "github.com",
-			want:  "Repo target misconfigured: repo 'hive/' contains '/' — expected repo name only (or 'kubestellar/<repo>') so the target resolves to org/repo. Fix in Governor Config → Repos.",
+			want:  "Repo target misconfigured: repo 'hive/' is not a valid target — expected 'repo' or 'owner/repo' (exactly one '/'). Fix in Governor Config → Repos.",
 		},
 		{
-			name:  "repo contains slash for a different org",
+			// A repo in a DIFFERENT org than project.org is valid: the runtime
+			// (Client.splitRepo) uses the repo's own owner. This is the
+			// context-forge/kalantar-msb fleet case that the stricter validator
+			// wrongly flagged.
+			name:  "cross-org owner/repo accepted",
 			org:   "kubestellar",
-			repos: []string{"other/hive"},
+			repos: []string{"other-org/hive"},
 			forge: "github.com",
-			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only (or 'kubestellar/<repo>') so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
-			// #3021: re-adding an existing repo as "<org>/<repo>" where the org
-			// matches project.org is unambiguous and must be accepted.
+			// #3021: re-adding an existing repo as "<org>/<repo>" (org matches).
 			name:  "repo qualified with matching org accepted",
 			org:   "kubestellar",
 			repos: []string{"kubestellar/hive"},
 			forge: "github.com",
 		},
 		{
-			name:    "primary qualified with matching org accepted",
+			name:    "primary owner/repo accepted",
 			org:     "kubestellar",
 			repos:   []string{"hive"},
-			primary: "kubestellar/hive",
+			primary: "some-other-org/hive",
 			forge:   "github.com",
+		},
+		{
+			name:  "multiple slashes rejected",
+			org:   "kubestellar",
+			repos: []string{"a/b/c"},
+			forge: "github.com",
+			want:  "Repo target misconfigured: repo 'a/b/c' is not a valid target — expected 'repo' or 'owner/repo' (exactly one '/'). Fix in Governor Config → Repos.",
 		},
 		{
 			name:  "full url pasted into org",


### PR DESCRIPTION
## The bug

Multiple hosted hives suddenly showed **'Repo target misconfigured: repo 'X/Y' contains / — expected repo name only'** warnings (context-forge, hashicorp, spektacular, kalantar-msb, z-mlz-manager) — configs that had worked for a long time.

**Root cause: a validator false-positive, not a config error.** The runtime accepts `owner/repo` fine — `Client.splitRepo()` (github/client.go) splits on the single slash and uses that owner, falling back to `project.org` only for a bare name. So a hive watching a repo in a **different org** than `project.org` (e.g. `project.org=kalantar-msb` watching `inference-sim/sim2real`) resolves correctly end to end. The stricter `ValidateProjectRepoTargets` (added later) flagged these valid configs as misconfigured.

## Fix

Accept **any well-formed `owner/repo`** (exactly one slash, both parts non-empty) — matching what `splitRepo` actually does. #3021 only relaxed the matching-org case; this covers the cross-org case too. Trailing/leading slash and multiple slashes are still rejected. Tests updated (cross-org accepted; malformed rejected).

Clears the warning for every affected hive without touching their configs.

**Separate note:** a `project.org` that is itself a hostname (jorge-endusers has `castrojo.github.io`) is a genuine misconfig still caught by `looksLikeForgeHost` — that one needs the owner to fix their org field.