### PR TITLE
🔒 fix(agent): never chmod through a symlink in agent HOME repair walks

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"hash/fnv"
 	"log/slog"
 	"os"
@@ -5154,16 +5155,37 @@ func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 }
 
 // ensureWorldWritable walks the tree and sets dirs to 0o777, files to 0o666.
+//
+// SECURITY (audit F12, CWE-59/CWE-61): this walk must never follow a symlink.
+//
+// The tree it repairs is an agent's own HOME and is world-writable by design,
+// so the agent can plant entries in it. os.Chmod FOLLOWS symlinks, so a link
+// planted here pointed the hive's own chmod at any file the hive user can
+// reach — hive.yaml, key files, state — and turned it 0666. The agent supplies
+// the link; the hive supplies the privilege. Verified: a 0600 file outside the
+// tree became 0666 through a planted link, and stays 0600 with this guard.
+//
+// filepath.WalkDir reports entries via Lstat, so the symlink is visible as a
+// symlink here; the danger is only in acting on it. Non-regular files (fifos,
+// sockets, devices) are skipped for the same reason: chmod on them is never
+// something this repair loop intends.
 func (m *Manager) ensureWorldWritable(root string) {
-	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if info.IsDir() {
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return nil
+		}
+		if d.IsDir() {
 			if info.Mode().Perm() != 0o777 {
 				_ = os.Chmod(path, 0o777)
 			}
-		} else {
+		} else if info.Mode().IsRegular() {
 			if info.Mode().Perm() != 0o666 {
 				_ = os.Chmod(path, 0o666)
 			}

--- a/v2/pkg/agent/manager_extra_test.go
+++ b/v2/pkg/agent/manager_extra_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -326,5 +328,56 @@ func TestDeduplicateBlocks_NearDuplicates(t *testing.T) {
 	if len(result) > 3 {
 		t.Errorf("DeduplicateBlocks should remove near-duplicate block, got %d lines: %v",
 			len(result), result)
+	}
+}
+
+// Audit F12 (CWE-59/CWE-61). ensureWorldWritable repairs an agent's HOME, a
+// tree that is world-writable BY DESIGN — so the agent itself can plant entries
+// in it. os.Chmod follows symlinks, so a link planted there aimed the hive's
+// own chmod at any file the hive user could reach and made it 0666. The agent
+// supplies the link; the hive supplies the privilege.
+//
+// Config, key files and state all live within reach of that user, so this is a
+// privilege-escalation primitive, not a tidiness issue.
+func TestF12_EnsureWorldWritableDoesNotFollowSymlinks(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+
+	victim := filepath.Join(root, "victim.txt")
+	if err := os.WriteFile(victim, []byte("hive-owned secret"), 0o600); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+	// The agent plants a link inside its own HOME pointing outside it.
+	if err := os.Symlink(victim, filepath.Join(home, "innocent.json")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	// A real file in the tree, to prove the walk still does its job.
+	realFile := filepath.Join(home, "settings.json")
+	if err := os.WriteFile(realFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write real file: %v", err)
+	}
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.ensureWorldWritable(home)
+
+	info, err := os.Lstat(victim)
+	if err != nil {
+		t.Fatalf("lstat victim: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("F12: a symlink planted in the agent HOME made the hive chmod a file OUTSIDE that tree to %o (want 0600 untouched)", info.Mode().Perm())
+	}
+
+	// Positive control: if the walk did nothing at all, the assertion above
+	// would hold for the wrong reason.
+	rinfo, err := os.Stat(realFile)
+	if err != nil {
+		t.Fatalf("stat real file: %v", err)
+	}
+	if rinfo.Mode().Perm() != 0o666 {
+		t.Fatalf("test is vacuous: the walk did not repair a genuine file (mode %o, want 0666)", rinfo.Mode().Perm())
 	}
 }

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -170,6 +170,16 @@ func fixPermissions(logger *slog.Logger) {
 // fixEntry checks a single file or directory and corrects ownership/mode
 // if needed.
 func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
+	// SECURITY (audit F12, CWE-59): never act on a symlink. This walks the
+	// agent HOME dirs, which agents can write to, and both os.Chmod and
+	// os.Chown FOLLOW symlinks — so a planted link would redirect this
+	// repair loop onto a file outside the tree. filepath.Walk reports
+	// entries via Lstat, so the link is visible as a link here; the ownership
+	// check below reads the LINK's metadata, not the target's, and so cannot
+	// be relied on to catch this. Same guard as ensureWorldWritable.
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return
+	}
 	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
 		return


### PR DESCRIPTION
## What

Audit **F12** (CWE-59/CWE-61, `SECURITY-REVIEW-2026-08-11.md`).

`ensureWorldWritable` repairs an agent's HOME directory — a tree that is world-writable **by design**, so the agent can plant entries in it — and `os.Chmod` **follows symlinks**. A link planted there pointed the hive's own `chmod` at any file the hive user could reach and made it `0666`.

The agent supplies the link; the hive supplies the privilege. Config, key files and state all live within reach of that user, so this is a privilege-escalation primitive rather than a tidiness issue.

Verified empirically before writing the fix:

```
before: -rw-------      # victim outside the walked tree
walk done
after:  -rw-rw-rw-      # hive chmod'd it through the planted link
```

and with the guard in place it stays `-rw-------`.

## The fix

Skip symlinks in the walk. `filepath.WalkDir` reports entries via `Lstat`, so the link is visible as a link at the callback — the bug was only in *acting* on it. Non-regular files (fifos, sockets, devices) are skipped for the same reason: chmod on those is never what this repair loop intends.

The same guard goes into `permissions_watcher.fixEntry`, which walks the **same** agent-writable homes and calls both `chmod` and `chown`. Its existing "only touch files we own" check cannot substitute for it: that reads the **link's** ownership via `Lstat`, not the target's, so it does not see where the write actually lands.

## Verification

- `go build ./...` clean
- `go test ./pkg/agent/ -count=1` → **zero failures**, full package
- The regression fails against the pristine original: *"a symlink planted in the agent HOME made the hive chmod a file OUTSIDE that tree to 666"*

One note on how that verification was done: my first revert attempt made the test pass, because I had *also* changed the walk to skip non-regular files and that condition alone was catching the symlink. I re-reverted to the genuine original implementation to confirm the test really does catch the shipped bug — it does. The test also carries a positive control asserting a real file in the tree still gets repaired, so it cannot pass by the walk simply doing nothing.