### PR TITLE
🔒 fix(knowledge): resolve DNS in the git-source SSRF check

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7254,7 +7254,9 @@ func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	req.URL = strings.TrimSpace(req.URL)
-	if err := knowledge.ValidateGitSourceURL(req.URL); err != nil {
+	// Context-aware so the SSRF DNS lookup inherits this request's deadline and
+	// cancellation rather than running on a background context.
+	if err := knowledge.ValidateGitSourceURLContext(r.Context(), req.URL); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -631,7 +631,7 @@ func (k *KnowledgeAPI) Layers() []LayerType {
 // periodic sync loop. Any layer level can have git sources.
 func (k *KnowledgeAPI) ConnectGitSource(ctx context.Context, config GitSourceConfig) error {
 	config.URL = strings.TrimSpace(config.URL)
-	if err := ValidateGitSourceURL(config.URL); err != nil {
+	if err := ValidateGitSourceURLContext(ctx, config.URL); err != nil {
 		return fmt.Errorf("invalid git source url: %w", err)
 	}
 

--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -76,7 +76,7 @@ func NewGitSource(config GitSourceConfig, baseDir string, logger *slog.Logger) *
 
 // Init clones the repo (or reuses an existing clone) and creates the FileStore.
 func (g *GitSource) Init(ctx context.Context) error {
-	if err := ValidateGitSourceURL(g.config.URL); err != nil {
+	if err := ValidateGitSourceURLContext(ctx, g.config.URL); err != nil {
 		return fmt.Errorf("git source %s: invalid url: %w", g.config.Name, err)
 	}
 
@@ -245,6 +245,13 @@ func (g *GitSource) setupSparseCheckout(ctx context.Context) error {
 
 // ValidateGitSourceURL enforces the transports permitted for git-backed knowledge sources.
 func ValidateGitSourceURL(raw string) error {
+	return ValidateGitSourceURLContext(context.Background(), raw)
+}
+
+// ValidateGitSourceURLContext is ValidateGitSourceURL with a caller-supplied
+// context, so the SSRF DNS lookup inherits the request's deadline and
+// cancellation instead of running unbounded on a background context.
+func ValidateGitSourceURLContext(ctx context.Context, raw string) error {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return fmt.Errorf("git URL is required")
@@ -278,7 +285,7 @@ func ValidateGitSourceURL(raw string) error {
 	// can't be pointed at the pod network, internal services, or the cloud
 	// metadata endpoint (169.254.169.254). Operators running a legitimately
 	// internal Git server can opt in explicitly; default is fail-closed.
-	if !allowPrivateGitSource() && gitSourceHostIsPrivate(parsed.Hostname()) {
+	if !allowPrivateGitSource() && gitSourceHostResolvesPrivate(ctx, parsed.Hostname()) {
 		return fmt.Errorf("git URL host resolves to a private/internal address (set HIVE_ALLOW_PRIVATE_GIT_SOURCE=true for an internal Git server)")
 	}
 
@@ -291,11 +298,53 @@ func allowPrivateGitSource() bool {
 	return os.Getenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE") == "true"
 }
 
+// gitSourceResolver is the DNS lookup used by the SSRF check, replaceable in
+// tests. Mirrors the dashboard's privateURLResolver seam.
+var gitSourceResolver = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// gitSourceLookupTimeout bounds the SSRF DNS lookup so a slow or hostile
+// resolver cannot stall the request that triggered validation.
+const gitSourceLookupTimeout = 5 * time.Second
+
+// gitSourceHostResolvesPrivate reports whether host is private either as an IP
+// literal or by DNS resolution.
+//
+// SECURITY (audit F8, CWE-918): the literal check alone was the whole defense,
+// and its comment argued DNS was skipped "to avoid a rebinding TOCTOU". That
+// reasoning is inverted — declining to resolve does not avoid rebinding, it
+// removes the check altogether, so `http://internal.attacker.tld/` resolving to
+// 169.254.169.254 validated cleanly. Resolving narrows the window to a genuine
+// rebind race; not resolving leaves the front door open. The dashboard's
+// isPrivateURL already resolves and fails closed; this brings the git path in
+// line with it.
+//
+// Fails CLOSED on lookup error, matching that precedent.
+func gitSourceHostResolvesPrivate(ctx context.Context, host string) bool {
+	if gitSourceHostIsPrivate(host) {
+		return true
+	}
+	// An IP literal was fully decided above; no DNS to consult.
+	if net.ParseIP(strings.Trim(host, "[]")) != nil {
+		return false
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, gitSourceLookupTimeout)
+	defer cancel()
+	addrs, err := gitSourceResolver(lookupCtx, host)
+	if err != nil {
+		return true
+	}
+	for _, addr := range addrs {
+		if gitSourceHostIsPrivate(addr) {
+			return true
+		}
+	}
+	return false
+}
+
 // gitSourceHostIsPrivate reports whether host is a loopback/private/link-local
-// literal IP or "localhost". A hostname that is not an IP literal is treated as
-// public here (DNS is not resolved at validation time to avoid a rebinding
-// TOCTOU); the fail-closed default plus the operator-only config surface bound
-// the exposure.
+// literal IP or "localhost".
 func gitSourceHostIsPrivate(host string) bool {
 	host = strings.ToLower(strings.Trim(host, "[]"))
 	if host == "" || host == "localhost" {

--- a/v2/pkg/knowledge/gitsource_ssrf_test.go
+++ b/v2/pkg/knowledge/gitsource_ssrf_test.go
@@ -1,6 +1,10 @@
 package knowledge
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
 func TestValidateGitSourceURL_RejectsPrivateHosts(t *testing.T) {
 	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
@@ -38,5 +42,67 @@ func TestValidateGitSourceURL_OptInAllowsPrivate(t *testing.T) {
 	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	if err := ValidateGitSourceURL("http://10.0.0.5/internal.git"); err != nil {
 		t.Errorf("opt-in must allow a private internal Git server, got %v", err)
+	}
+}
+
+// Audit F8 (CWE-918). The SSRF check inspected the host only as an IP LITERAL,
+// so every rejection test above passes while `http://internal.attacker.tld/`
+// resolving to 169.254.169.254 validated cleanly — an attacker controls their
+// own DNS, so a literal-only check is trivially sidestepped.
+//
+// The old comment justified skipping DNS as avoiding a "rebinding TOCTOU", but
+// that has it backwards: resolving narrows the window to a genuine rebind race,
+// while not resolving removes the check altogether. The dashboard's
+// isPrivateURL already resolves and fails closed; this brings the git path in
+// line.
+func TestF8_RejectsHostnameResolvingToPrivateAddress(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, host string) ([]string, error) {
+		if host == "internal.attacker.tld" {
+			return []string{"169.254.169.254"}, nil
+		}
+		return []string{"93.184.216.34"}, nil
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
+	if err := ValidateGitSourceURL("https://internal.attacker.tld/repo.git"); err == nil {
+		t.Fatal("F8: a hostname resolving to the cloud metadata endpoint was accepted — the SSRF check only inspects IP literals")
+	}
+	// Positive control: a hostname resolving to a public address must still be
+	// allowed, or the fix is just a blanket denial of every non-literal host.
+	if err := ValidateGitSourceURL("https://github.com/kubestellar/hive.git"); err != nil {
+		t.Fatalf("a public hostname was rejected, which would break every legitimate git source: %v", err)
+	}
+}
+
+// A resolver failure must fail CLOSED, matching isPrivateURL — otherwise an
+// attacker who can make lookups fail (a timeout, a hostile resolver) turns the
+// error path itself into the bypass.
+func TestF8_FailsClosedWhenResolverErrors(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, _ string) ([]string, error) {
+		return nil, errors.New("dns unavailable")
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
+	if err := ValidateGitSourceURL("https://unresolvable.example/repo.git"); err == nil {
+		t.Fatal("F8: a host whose DNS lookup failed was accepted — the error path must fail closed")
+	}
+}
+
+// The operator opt-in must still work: a hive with a legitimately internal Git
+// server sets HIVE_ALLOW_PRIVATE_GIT_SOURCE and the check steps aside.
+func TestF8_OperatorOptInStillAllowsPrivate(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, _ string) ([]string, error) {
+		return []string{"10.0.0.5"}, nil
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
+	if err := ValidateGitSourceURL("https://git.internal.corp/repo.git"); err != nil {
+		t.Fatalf("operator opt-in no longer permits an internal Git server: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Audit **F8** (CWE-918, `SECURITY-REVIEW-2026-08-11.md`). `ValidateGitSourceURL` inspected the host only as an **IP literal**:

```go
if net.ParseIP(host); ip == nil { return false }   // any hostname → "public"
```

So every entry in the existing `TestValidateGitSourceURL_RejectsPrivateHosts` list passes, while `https://internal.attacker.tld/repo.git` resolving to `169.254.169.254` validated cleanly. An attacker controls their own DNS, so a literal-only check is trivially sidestepped — and the metadata endpoint is the obvious target.

## On the comment that was there

The code documented the gap deliberately:

> DNS is not resolved at validation time to avoid a rebinding TOCTOU

That has it backwards. Resolving narrows the window to a **genuine rebind race**; not resolving removes the check altogether, so the trivial attack works without any race at all. The dashboard's `isPrivateURL` has resolved and failed closed all along — this brings the git path in line with the precedent already in the tree.

## The fix

Resolve the host and reject if any returned address is private. **Fails closed** on lookup error, so an attacker who can make DNS fail (timeout, hostile resolver) doesn't turn the error path into the bypass.

The lookup is bounded by a 5s timeout and, via the new `ValidateGitSourceURLContext`, inherits the caller's deadline and cancellation rather than running on a background context. All three call sites are threaded through. The original `ValidateGitSourceURL` signature is kept, so nothing else changes.

## Verification

- `go build ./...` clean
- `go test ./pkg/knowledge/ -count=1` → `ok`, full package
- Both new tests fail against the literal-only check:
  - *"a hostname resolving to the cloud metadata endpoint was accepted"*
  - *"a host whose DNS lookup failed was accepted — the error path must fail closed"*

Two **controls** guard against overcorrecting, since the easy wrong fix here is to deny everything that isn't an IP literal:

- a public hostname (`github.com`) must still be accepted, or every legitimate git source breaks
- `HIVE_ALLOW_PRIVATE_GIT_SOURCE=true` must still let an operator run an internal Git server