### PR TITLE
🔒 fix(hub): bind the OAuth login to the browser that started it

### DIFF
--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -1,6 +1,9 @@
 package hub
 
 import (
+	cryptoRand "crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -171,7 +174,39 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 			redirect = "/dashboard"
 		}
 	}
-	state := url.QueryEscape(redirect)
+	// SECURITY (audit F11, CWE-352): bind this login to THIS browser.
+	//
+	// `state` used to be nothing but the redirect target, so it proved only that
+	// the callback carried a URL — never that this browser had actually STARTED
+	// a login. An attacker could complete an OAuth flow against their own GitHub
+	// account and hand the victim the resulting callback URL, logging the victim
+	// into the ATTACKER's account (login CSRF / session fixation); anything the
+	// victim then did landed in the attacker's account.
+	//
+	// Mint an unguessable nonce, set it in a short-lived host-scoped cookie, and
+	// carry it in state. The callback requires the two to match, so a state the
+	// victim's browser did not mint cannot be replayed against them. The
+	// redirect target rides along after the separator and is still validated on
+	// the way out — the open-redirect half was already handled and is unchanged.
+	nonce, err := oauthStateNonce()
+	if err != nil {
+		s.logger.Warn("OAuth: cannot mint login state nonce", "error", err)
+		http.Error(w, "login unavailable", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    nonce,
+		Path:     "/",
+		MaxAge:   int(oauthStateTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   true,
+		// Lax, not Strict: the callback arrives as a top-level GET redirect
+		// FROM github.com, and Strict would withhold the cookie on exactly that
+		// navigation and break every login.
+		SameSite: http.SameSiteLaxMode,
+	})
+	state := url.QueryEscape(nonce + oauthStateSeparator + redirect)
 	// An EMPTY scope is deliberate, not an omission. The hub only needs to know
 	// WHO is logging in: the callback reads GET /user for the login name and
 	// signs it into the session cookie. GitHub serves /user's public profile —
@@ -198,6 +233,24 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "missing code", http.StatusBadRequest)
 		return
 	}
+
+	// SECURITY (audit F11, CWE-352): verify the login started in THIS browser
+	// BEFORE exchanging the code or minting any session. A callback whose state
+	// does not match this browser's cookie is a login the victim never began —
+	// most likely an attacker replaying their own completed flow to log the
+	// victim into the attacker's account.
+	//
+	// Checked first, so a forged callback never reaches the token exchange:
+	// exchanging burns a real one-time code and touches the SaaS user record,
+	// neither of which should happen for a request we are about to reject.
+	if !s.verifyOAuthStateNonce(r) {
+		s.clearOAuthStateCookie(w)
+		s.logger.Warn("OAuth: rejected callback with missing or mismatched state nonce")
+		http.Error(w, "invalid login state — please start the login again", http.StatusBadRequest)
+		return
+	}
+	// Single-use: clear it now so a captured callback URL cannot be replayed.
+	s.clearOAuthStateCookie(w)
 
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
 	clientSecret := os.Getenv("HIVE_HUB_OAUTH_CLIENT_SECRET")
@@ -304,11 +357,13 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	saveSaaSUser(saasUser)
 
 	redirect := "/dashboard"
-	if state := r.URL.Query().Get("state"); state != "" {
-		if decoded, err := url.QueryUnescape(state); err == nil && decoded != "" {
-			if (strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedOrigin(decoded) {
-				redirect = decoded
-			}
+	if decoded, err := url.QueryUnescape(r.URL.Query().Get("state")); err == nil && decoded != "" {
+		// The nonce was already verified above; take only the redirect half.
+		if _, target, ok := strings.Cut(decoded, oauthStateSeparator); ok {
+			decoded = target
+		}
+		if decoded != "" && ((strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedOrigin(decoded)) {
+			redirect = decoded
 		}
 	}
 	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
@@ -373,4 +428,70 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	})
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"ok":true}`))
+}
+
+const (
+	// oauthStateCookieName holds the per-login nonce that binds an OAuth
+	// callback to the browser that started it (audit F11). Host-scoped
+	// deliberately: unlike hive_hub_user it carries no Domain, so sibling
+	// tenants never receive it.
+	oauthStateCookieName = "hive_oauth_state"
+
+	// oauthStateSeparator splits the nonce from the redirect target inside the
+	// state parameter. ":" cannot appear in a nonce (hex) and any ":" in the
+	// redirect lands in the second half, which strings.Cut keeps intact.
+	oauthStateSeparator = ":"
+
+	// oauthStateTTL bounds how long a started login may sit unfinished. Long
+	// enough to authorize on GitHub (including a fresh GitHub login), short
+	// enough that a captured state is not indefinitely useful.
+	oauthStateTTL = 15 * time.Minute
+
+	// oauthStateNonceBytes is the entropy behind the nonce. 32 bytes is far
+	// beyond guessing and matches the other random values minted in this package.
+	oauthStateNonceBytes = 32
+)
+
+// oauthStateNonce mints an unguessable login nonce.
+func oauthStateNonce() (string, error) {
+	buf := make([]byte, oauthStateNonceBytes)
+	if _, err := io.ReadFull(cryptoRand.Reader, buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// verifyOAuthStateNonce reports whether the callback's state carries the same
+// nonce this browser was issued at login.
+//
+// Fails CLOSED: a missing cookie, a missing or malformed state, or any mismatch
+// is a rejection. Compared in constant time — the nonce is a secret, and a
+// length-or-content leak would let an attacker narrow it by timing.
+func (s *HubServer) verifyOAuthStateNonce(r *http.Request) bool {
+	cookie, err := r.Cookie(oauthStateCookieName)
+	if err != nil || cookie.Value == "" {
+		return false
+	}
+	decoded, err := url.QueryUnescape(r.URL.Query().Get("state"))
+	if err != nil || decoded == "" {
+		return false
+	}
+	got, _, ok := strings.Cut(decoded, oauthStateSeparator)
+	if !ok || got == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(cookie.Value)) == 1
+}
+
+// clearOAuthStateCookie expires the login nonce, making it single-use.
+func (s *HubServer) clearOAuthStateCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -2,6 +2,8 @@ package hub
 
 import (
 	"log/slog"
+	"net/url"
+	"strings"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,7 +35,7 @@ func TestHandleOAuthCallbackTokenExchangeFails(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc", nil)
+	req := newCallbackRequestWithState(t, "abc")
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("bad token json status = %d, want 502", rec.Code)
@@ -51,7 +53,7 @@ func TestHandleOAuthCallbackNoAccessToken_Cov(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc", nil)
+	req := newCallbackRequestWithState(t, "abc")
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("empty token status = %d, want 502", rec.Code)
@@ -79,8 +81,14 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	// A configured secret lets the login path mint a signed session cookie.
 	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	rec := httptest.NewRecorder()
-	// A safe relative redirect state should be honored.
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state=%2Fmy-hives", nil)
+	// A safe relative redirect state should be honored. The state now also
+	// carries the per-browser nonce (audit F11); the redirect rides after it.
+	nonce, err := oauthStateNonce()
+	if err != nil {
+		t.Fatalf("mint nonce: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state="+url.QueryEscape(nonce+oauthStateSeparator+"/my-hives"), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("success status = %d, want 307 (body=%s)", rec.Code, rec.Body.String())
@@ -139,7 +147,7 @@ func TestHandleOAuthCallbackInvalidLogin(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc", nil)
+	req := newCallbackRequestWithState(t, "abc")
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("invalid login status = %d, want 502", rec.Code)
@@ -308,5 +316,126 @@ func TestClusterNameForID_Cov(t *testing.T) {
 	}
 	if got := s.clusterNameForID("missing"); got != "" {
 		t.Errorf("unknown -> %q, want empty", got)
+	}
+}
+
+// newCallbackRequestWithState builds an OAuth callback that carries a matching
+// state nonce in both the query and the cookie, i.e. a login this browser
+// genuinely started (audit F11). Tests exercising the token-exchange path need
+// this or they are rejected at the state gate and never reach it.
+func newCallbackRequestWithState(t *testing.T, code string) *http.Request {
+	t.Helper()
+	nonce, err := oauthStateNonce()
+	if err != nil {
+		t.Fatalf("mint nonce: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code="+code+"&state="+url.QueryEscape(nonce+oauthStateSeparator+"/dashboard"), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+	return req
+}
+
+// Audit F11 (CWE-352). The OAuth `state` parameter used to be nothing but the
+// redirect target, so it proved only that the callback carried a URL — never
+// that this browser had STARTED a login.
+//
+// The attack: complete an OAuth flow against your own GitHub account, capture
+// the callback URL, and hand it to a victim. Their browser completes it and
+// they are silently logged into the ATTACKER's account — every issue they file
+// and every repo they connect afterwards lands in the attacker's account. The
+// redirect-target validation already present does nothing about this: the URL
+// is perfectly valid, it is the SESSION that is forged.
+func TestF11_CallbackWithoutStateNonceIsRejected(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// If the state gate does not fire, these get hit and the login succeeds.
+	var exchanged bool
+	tok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		exchanged = true
+		w.Write([]byte(`{"access_token":"gho_attacker"}`))
+	}))
+	defer tok.Close()
+	usr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"login":"attacker","avatar_url":"https://x/a.png"}`))
+	}))
+	defer usr.Close()
+	oldTok, oldUsr := defaultGHTokenURL, defaultGHUserURL
+	defaultGHTokenURL, defaultGHUserURL = tok.URL, usr.URL
+	defer func() { defaultGHTokenURL, defaultGHUserURL = oldTok, oldUsr }()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	rec := httptest.NewRecorder()
+	// The victim's browser holds NO state cookie: it never started this login.
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=attacker-code&state=%2Fdashboard", nil)
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code == http.StatusTemporaryRedirect {
+		t.Fatal("F11: a callback the browser never initiated completed a login — an attacker can log a victim into the attacker's account")
+	}
+	if exchanged {
+		t.Error("F11: the forged callback reached the token exchange; the state gate must reject it before burning a code")
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			t.Fatalf("F11: a session cookie was minted for a forged callback: %q", c.Value)
+		}
+	}
+}
+
+// A callback whose state does not match this browser's cookie must be rejected
+// too — otherwise an attacker who can set ANY state (but not read the cookie)
+// still gets in.
+func TestF11_CallbackWithMismatchedStateNonceIsRejected(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state="+url.QueryEscape("attacker-nonce"+oauthStateSeparator+"/dashboard"), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: "victim-nonce"})
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code == http.StatusTemporaryRedirect {
+		t.Fatal("F11: a callback whose state did not match the browser's cookie completed a login")
+	}
+}
+
+// /login must actually issue the nonce, in both the cookie and the state — the
+// callback gate is worth nothing if the login side never mints one.
+func TestF11_LoginIssuesStateNonceCookieAndParameter(t *testing.T) {
+	t.Setenv("HIVE_HUB_OAUTH_CLIENT_ID", "test-client-id")
+	s := &HubServer{logger: slog.Default()}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/login?redirect=/my-hives", nil)
+	s.handleLogin(rec, req)
+
+	var nonce string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == oauthStateCookieName {
+			nonce = c.Value
+			if !c.HttpOnly || !c.Secure {
+				t.Error("F11: the state cookie must be HttpOnly and Secure")
+			}
+			if c.Domain != "" {
+				t.Errorf("F11: the state cookie must be host-scoped, got Domain=%q — a sibling tenant would receive it", c.Domain)
+			}
+		}
+	}
+	if nonce == "" {
+		t.Fatal("F11: /login issued no state nonce cookie, so the callback gate can never pass")
+	}
+
+	loc := rec.Header().Get("Location")
+	parsed, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	state := parsed.Query().Get("state")
+	if !strings.HasPrefix(state, nonce+oauthStateSeparator) {
+		t.Fatalf("F11: state %q does not carry the issued nonce", state)
+	}
+	// The redirect target must survive alongside the nonce.
+	if !strings.HasSuffix(state, "/my-hives") {
+		t.Errorf("F11: the redirect target was lost from state: %q", state)
 	}
 }


### PR DESCRIPTION
## What

Audit **F11** (CWE-352, `SECURITY-REVIEW-2026-08-11.md`). The OAuth `state` parameter was the redirect target and nothing else:

```go
state := url.QueryEscape(redirect)
```

So it proved only that the callback carried a URL — never that **this browser started a login**.

## The attack

1. Attacker completes an OAuth flow against **their own** GitHub account and captures the callback URL.
2. Victim's browser is made to visit it.
3. The victim is silently logged into the **attacker's** account.

Every issue the victim files and every repository they connect afterwards lands in the attacker's account. The redirect-target validation already in the code does nothing here: the URL is perfectly valid — it is the *session* that is forged.

## The fix

`/login` mints an unguessable nonce, sets it in a short-lived **HttpOnly, Secure, host-scoped** cookie, and carries it in `state` ahead of the redirect target. The callback requires the two to match.

Details that matter:

- **Checked before the token exchange.** Exchanging burns a real one-time code and touches the SaaS user record; neither should happen for a request we're about to reject.
- **Fails closed** — missing cookie, missing/malformed state, or any mismatch is a rejection.
- **Constant-time compare** — the nonce is a secret, so a timing leak would let an attacker narrow it.
- **Single-use** — the cookie is cleared on the callback, so a captured URL can't be replayed.
- **Host-scoped** (no `Domain`), unlike `hive_hub_user`, so sibling tenants never receive it. Asserted by a test.
- **`SameSite=Lax`, not `Strict`** — deliberate: the callback is a top-level GET redirect *from github.com*, and `Strict` would withhold the cookie on exactly that navigation and break every login.

## About the three modified tests

`TestHandleOAuthCallback{TokenExchangeFails,NoAccessToken_Cov,Success}` sent callbacks with no state and asserted on results from the token exchange. They now stop at the state gate — **that is the fix working**, not a test being bent to fit. They're updated to carry a valid nonce so they still test what they were written to test, including the redirect-preservation assertion (`/my-hives` still survives into `Location`).

## Verification

- `go build ./...` clean
- `go test ./pkg/hub/ -count=1` → **zero failures**, full package
- Removing just the callback gate makes the regression fail: *"a callback the browser never initiated completed a login"*

The main regression also asserts the forged callback never reaches the token exchange and that no `hive_hub_user` cookie is minted — so it fails if the request is rejected too late, not just if it's accepted. A third test pins that `/login` actually issues the nonce, since the callback gate is worth nothing if the login side never mints one.