### PR TITLE
🐛 protect v4 beads reset handlers

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7969,6 +7969,9 @@ func maskToken(token string) string {
 }
 
 func (s *Server) handleBeadsReset(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	if s.deps.BeadStores == nil {
 		jsonError(w, "bead stores not initialized", http.StatusServiceUnavailable)
 		return
@@ -8001,6 +8004,9 @@ func (s *Server) handleBeadsReset(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBeadsResetAgent(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	agentName := r.PathValue("agent")
 	if s.deps.BeadStores == nil {
 		jsonError(w, "bead stores not initialized", http.StatusServiceUnavailable)

--- a/v2/pkg/dashboard/owner_only_handlers_deny_test.go
+++ b/v2/pkg/dashboard/owner_only_handlers_deny_test.go
@@ -1,0 +1,33 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBeadsResetHandlersRejectNonOwners(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{"all agents", "/api/beads/reset", newFullServer(t).handleBeadsReset},
+		{"single agent", "/api/beads/scanner/reset", newFullServer(t).handleBeadsResetAgent},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			req.Header.Set("X-Hive-Role", "read-write")
+			req.SetPathValue("agent", "scanner")
+			w := httptest.NewRecorder()
+
+			tc.handler(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("non-owner status = %d, want %d", w.Code, http.StatusForbidden)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #3430 / #3375.

v4 had the same beads reset handlers but lacked the production owner gate. This adds `requireOwnerRole` to both reset handlers and explicit deny-path coverage for direct non-owner calls.

Deliberate breakage proof:
- Locally removed/commented the owner checks from handleBeadsReset and handleBeadsResetAgent.
- `go test ./pkg/dashboard -run TestBeadsResetHandlersRejectNonOwners -count=1 -v` failed with both subtests returning 200 instead of 403.
- Restored the production checks afterward.

Validation:
- `go test ./pkg/dashboard -run TestBeadsResetHandlersRejectNonOwners -count=1 -v`
- `go test ./pkg/dashboard -count=1`
- `go vet ./pkg/dashboard && go build ./...`
- code-review agent: no issues found