### PR TITLE
🐛 fix: keep Context7 test seam out of production

### DIFF
--- a/v2/pkg/knowledge/context7.go
+++ b/v2/pkg/knowledge/context7.go
@@ -11,23 +11,14 @@ import (
 	"time"
 )
 
-// context7BaseURL is a var (not const) so tests can point it at httptest servers.
-var context7BaseURL = "https://context7.com"
-
 const (
-	context7SearchPath     = "/api/v2/libs/search"
-	context7LLMsTxtSuffix  = "/llms.txt"
-	context7Timeout        = 30 * time.Second
-	context7MaxBody        = 10 * 1024 * 1024 // 10 MB
-	context7DefaultTokens  = 10000
+	context7BaseURL       = "https://context7.com"
+	context7SearchPath    = "/api/v2/libs/search"
+	context7LLMsTxtSuffix = "/llms.txt"
+	context7Timeout       = 30 * time.Second
+	context7MaxBody       = 10 * 1024 * 1024 // 10 MB
+	context7DefaultTokens = 10000
 )
-
-// setContext7BaseURL overrides the base URL (for tests). Returns the old value.
-func setContext7BaseURL(u string) string {
-	old := context7BaseURL
-	context7BaseURL = u
-	return old
-}
 
 // Context7SearchResult is a single library match from Context7's search API.
 type Context7SearchResult struct {

--- a/v2/pkg/knowledge/context7_test.go
+++ b/v2/pkg/knowledge/context7_test.go
@@ -36,10 +36,7 @@ func TestSearchContext7_HappyPath(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Temporarily override the base URL.
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	got, err := SearchContext7(context.Background(), "nextjs", "test-key")
 	if err != nil {
@@ -56,9 +53,7 @@ func TestSearchContext7_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	_, err := SearchContext7(context.Background(), "test", "")
 	if err == nil {
@@ -72,9 +67,7 @@ func TestSearchContext7_InvalidJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	_, err := SearchContext7(context.Background(), "test", "")
 	if err == nil {
@@ -95,9 +88,7 @@ func TestSearchContext7_NoAPIKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	_, err := SearchContext7(context.Background(), "test", "")
 	if err != nil {
@@ -121,9 +112,7 @@ func TestFetchContext7Docs_HappyPath(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	got, err := FetchContext7Docs(context.Background(), "/vercel/next.js", "", "")
 	if err != nil {
@@ -146,9 +135,7 @@ func TestFetchContext7Docs_WithTopicQuery(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	got, err := FetchContext7Docs(context.Background(), "/vercel/next.js", "routing", "")
 	if err != nil {
@@ -166,9 +153,7 @@ func TestFetchContext7Docs_RateLimited(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	_, err := FetchContext7Docs(context.Background(), "/test/lib", "", "")
 	if err == nil {
@@ -182,9 +167,7 @@ func TestFetchContext7Docs_CancelledContext(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(srv.URL)
+	useContext7TestServer(t, srv.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -196,13 +179,7 @@ func TestFetchContext7Docs_CancelledContext(t *testing.T) {
 
 func TestFetchContext7Docs_RejectsAuthorityInjectionLibraryID(t *testing.T) {
 	var hits atomic.Int32
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL("https://context7.com")
-
-	origClient := context7Client
-	defer func() { context7Client = origClient }()
-	context7Client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	useContext7Client(t, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		hits.Add(1)
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -210,7 +187,7 @@ func TestFetchContext7Docs_RejectsAuthorityInjectionLibraryID(t *testing.T) {
 			Header:     make(http.Header),
 			Request:    req,
 		}, nil
-	})}
+	})})
 
 	_, err := FetchContext7Docs(context.Background(), "@evil.com/path", "", "")
 	if err == nil {
@@ -234,9 +211,7 @@ func TestFetchContext7Docs_BlocksRedirectToPrivateHost(t *testing.T) {
 	}))
 	defer redirector.Close()
 
-	origBase := context7BaseURL
-	defer func() { setContext7BaseURL(origBase) }()
-	setContext7BaseURL(redirector.URL)
+	useContext7TestServer(t, redirector.URL)
 
 	_, err := FetchContext7Docs(context.Background(), "/safe/lib", "", "")
 	if err == nil {

--- a/v2/pkg/knowledge/export_test.go
+++ b/v2/pkg/knowledge/export_test.go
@@ -1,0 +1,48 @@
+package knowledge
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+var context7TestMu sync.Mutex
+
+// useContext7TestServer routes production Context7 URLs to an httptest server.
+// It serializes client swaps so these tests remain safe if a future subtest is
+// marked parallel.
+func useContext7TestServer(t testing.TB, rawURL string) {
+	t.Helper()
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse Context7 test server URL: %v", err)
+	}
+	useContext7Client(t, &http.Client{
+		Timeout:       context7Timeout,
+		CheckRedirect: knowledgeNoRedirectToPrivate,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host != "context7.com" {
+				return http.DefaultTransport.RoundTrip(req)
+			}
+			clone := req.Clone(req.Context())
+			rewritten := *clone.URL
+			rewritten.Scheme = target.Scheme
+			rewritten.Host = target.Host
+			clone.URL = &rewritten
+			clone.Host = ""
+			return http.DefaultTransport.RoundTrip(clone)
+		}),
+	})
+}
+
+func useContext7Client(t testing.TB, client *http.Client) {
+	t.Helper()
+	context7TestMu.Lock()
+	old := context7Client
+	context7Client = client
+	t.Cleanup(func() {
+		context7Client = old
+		context7TestMu.Unlock()
+	})
+}


### PR DESCRIPTION
## Summary
- restore Context7 base URL to a production const
- move httptest routing into test-only export_test.go helper
- serialize Context7 client swaps during tests to avoid future parallel-test races

## Validation
- go test ./pkg/knowledge -count=1
- go test ./pkg/knowledge -coverprofile=knowledge.coverage.out -count=1 (90.3%)
- go build ./...

No coverage thresholds or PKG_THRESHOLD overrides changed.