### PR TITLE
🐛 make v4 agent TLS restart test race-free

### DIFF
--- a/v2/pkg/agent/poll_coverage_test.go
+++ b/v2/pkg/agent/poll_coverage_test.go
@@ -32,7 +32,10 @@ func TestPollTmuxOutputForAgent_TLSError(t *testing.T) {
 	m.pollTmuxOutputForAgent(agent, ctx)
 	// The restart goroutine may recreate the session; clean it up.
 	defer cleanupAgent(t, m, "covtls")
-	if agent.LastError == "" {
+	m.mu.RLock()
+	lastError := agent.LastError
+	m.mu.RUnlock()
+	if lastError == "" {
 		t.Log("TLS error not recorded (timing-sensitive)")
 	}
 }


### PR DESCRIPTION
Twin of the #3434 v2 fix because v4 shares `TestPollTmuxOutputForAgent_TLSError`.

The test read `agent.LastError` after `pollTmuxOutputForAgent` could spawn a restart goroutine; `Restart`/`launchInTmux` can mutate the same agent. The test now reads under `m.mu.RLock`, matching manager access discipline.

Validation:
- `go test -race ./pkg/agent -run TestPollTmuxOutputForAgent_TLSError -count=3 -v`
- `go test ./pkg/agent -count=1`
- `go vet ./pkg/agent && go build ./...`
- code-review agent: no issues found