### PR TITLE
🐛 make v2 agent TLS restart test race-free

### DIFF
--- a/v2/pkg/agent/poll_coverage_test.go
+++ b/v2/pkg/agent/poll_coverage_test.go
@@ -33,7 +33,10 @@ func TestPollTmuxOutputForAgent_TLSError(t *testing.T) {
 	m.pollTmuxOutputForAgent(agent, ctx)
 	// The restart goroutine may recreate the session; clean it up.
 	defer cleanupAgent(t, m, "covtls")
-	if agent.LastError == "" {
+	m.mu.RLock()
+	lastError := agent.LastError
+	m.mu.RUnlock()
+	if lastError == "" {
 		t.Log("TLS error not recorded (timing-sensitive)")
 	}
 }


### PR DESCRIPTION
Fixes #3434.

The linked run had two failure classes:
- broad dashboard owner-only direct-handler tests returning 403; those are already fixed on v2 by #3423 / cdd17d69 and verified passing on current HEAD.
- `TestPollTmuxOutputForAgent_TLSError` failed under race detection. The test read `agent.LastError` after `pollTmuxOutputForAgent` could spawn a restart goroutine; `Restart`/`launchInTmux` can mutate the same agent. The test now reads under `m.mu.RLock`, matching manager access discipline.

Validation:
- Reproduced representative dashboard 403 failures at fb94172.
- Verified representative dashboard failures pass on current v2.
- CI log for run 31505305848 shows the agent data race at `poll_coverage_test.go:36` vs `manager.go:1409`.
- `go test -race ./pkg/agent -run TestPollTmuxOutputForAgent_TLSError -count=5 -v`
- `go test ./pkg/agent -count=1`
- `go vet ./pkg/agent && go build ./...`
- code-review agent: no issues found

v4 has the same test; twin PR opened.