### PR TITLE
🔒 fix: remove dashboard owner auth test bypass

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1234,12 +1234,7 @@ func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, p
 // require its server-only verification marker, so legacy/proofless proxy
 // headers and shared-token requests fail closed instead of trusting spoofable
 // client input.
-var requireOwnerRoleTestBypass func(*http.Request) bool
-
 func requireOwnerRole(w http.ResponseWriter, r *http.Request) bool {
-	if requireOwnerRoleTestBypass != nil && requireOwnerRoleTestBypass(r) {
-		return true
-	}
 	role := r.Header.Get("X-Hive-Role")
 	if role != "owner" || r.Header.Get(ownerRoleVerifiedHeader) != "true" {
 		jsonError(w, "owner access required", http.StatusForbidden)

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -19,15 +19,6 @@ import (
 
 // ---------- helpers ----------
 
-func init() {
-	requireOwnerRoleTestBypass = func(r *http.Request) bool {
-		return r.Header.Get("X-Hive-Role") == "" &&
-			r.Header.Get(ownerRoleVerifiedHeader) == "" &&
-			r.Header.Get("Authorization") == "" &&
-			r.Header.Get("X-Hive-Internal") == ""
-	}
-}
-
 func testDeps(t *testing.T) *Dependencies {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/v2/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/v2/pkg/dashboard/dashboard_owner_authz_test.go
@@ -3,6 +3,8 @@ package dashboard
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -121,6 +123,29 @@ func TestOwnerOnlyMutationsAllowOwnerSessionWithInternalAuth(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("owner session with internal auth status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireOwnerRoleHasNoBypassBeforeHeaderCheck(t *testing.T) {
+	src, err := os.ReadFile("api.go")
+	if err != nil {
+		t.Fatalf("read api.go: %v", err)
+	}
+	text := string(src)
+	if strings.Contains(text, "requireOwnerRoleTestBypass") {
+		t.Fatal("requireOwnerRole must not contain a test bypass hook in production source")
+	}
+	fn := strings.Index(text, "func requireOwnerRole(")
+	if fn < 0 {
+		t.Fatal("requireOwnerRole not found")
+	}
+	body := text[fn:]
+	role := strings.Index(body, `role := r.Header.Get("X-Hive-Role")`)
+	if role < 0 {
+		t.Fatal("requireOwnerRole no longer reads X-Hive-Role")
+	}
+	if earlyAllow := strings.Index(body, "return true"); earlyAllow >= 0 && earlyAllow < role {
+		t.Fatalf("requireOwnerRole returns true before checking owner headers at offset %d", earlyAllow)
 	}
 }
 


### PR DESCRIPTION
## Summary
- removes the production requireOwnerRoleTestBypass hook from v2/pkg/dashboard/api.go
- removes the package-wide dashboard test init that installed the bypass
- adds a source-scanning regression guard to fail if requireOwnerRole grows another pre-header allow path

## Validation
- go test ./pkg/dashboard -run 'TestRequireOwnerRoleHasNoBypassBeforeHeaderCheck|TestOwnerOnly|TestBobKeyEndpoints_ReadOnlyRoleForbidden' -count=1
- go test ./pkg/dashboard -count=1
- go vet ./pkg/dashboard
- go build ./...

Production code touched: v2/pkg/dashboard/api.go