### PR TITLE
🔒 restore v4 owner gates for dashboard mutations

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -650,6 +650,10 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	// F9 (CWE-862): the raw hive.yaml carries secrets, so a MISSING X-Hive-Role
 	// must NOT default to owner on a spoke that has an auth boundary. Least
 	// privilege: only a genuinely open/dev spoke treats an empty role as owner.
@@ -684,6 +688,10 @@ func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
 		role = "owner"
@@ -1650,6 +1658,10 @@ func (s *Server) handleBudgetIgnoreGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBudgetIgnoreSet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	// The dashboard checkbox sends {"ignored": bool} (global bypass);
 	// {"ignored": [names]} sets the per-agent exemption list.
 	var body struct {
@@ -2660,6 +2672,10 @@ func (s *Server) handleAuthorizedUsersList(w http.ResponseWriter, r *http.Reques
 // rejects them. The change is persisted to the dashboard overlay like any other
 // dashboard config edit.
 func (s *Server) handleVariableUpsert(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps == nil || s.deps.Config == nil {
 		jsonError(w, "config not loaded", http.StatusInternalServerError)
 		return
@@ -2723,6 +2739,10 @@ func (s *Server) handleVariableUpsert(w http.ResponseWriter, r *http.Request) {
 // are dashboard-managed, so this refuses to delete a script/http variable
 // (those are seed-only and must be removed via the seed config).
 func (s *Server) handleVariableDelete(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps == nil || s.deps.Config == nil {
 		jsonError(w, "config not loaded", http.StatusInternalServerError)
 		return
@@ -2807,6 +2827,10 @@ func (s *Server) loadAgentStats(name string) []any {
 }
 
 func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -3123,6 +3147,10 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleAgentConfigCadences(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -3176,6 +3204,10 @@ func (s *Server) handleAgentConfigCadences(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleAgentConfigModels(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	var body struct {
 		Backend string `json:"backend"`
@@ -3233,6 +3265,10 @@ func (s *Server) handleAgentConfigModels(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleAgentConfigPipeline(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -3255,6 +3291,10 @@ func (s *Server) handleAgentConfigPipeline(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleAgentConfigHooks(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -3277,6 +3317,10 @@ func (s *Server) handleAgentConfigHooks(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleAgentConfigRestrictions(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -3319,6 +3363,10 @@ func (s *Server) handleAgentConfigRestrictions(w http.ResponseWriter, r *http.Re
 }
 
 func (s *Server) handleAgentConfigStats(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -3352,6 +3400,10 @@ func (s *Server) handleAgentConfigStats(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleAgentConfigChannels(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	agentCfg, ok := s.deps.Config.Agents[name]
 	if !ok {
@@ -3375,6 +3427,10 @@ func (s *Server) handleAgentConfigChannels(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleAgentConfigTools(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	agentCfg, ok := s.deps.Config.Agents[name]
 	if !ok {
@@ -3396,6 +3452,10 @@ func (s *Server) handleAgentConfigTools(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleAgentConfigConnections(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	agentCfg, ok := s.deps.Config.Agents[name]
 	if !ok {
@@ -3521,6 +3581,10 @@ func (s *Server) loadPromptTemplateRaw(name string) string {
 const promptTemplateSaveDir = "/data/policies"
 
 func (s *Server) handleAgentPromptSave(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -4048,6 +4112,10 @@ func (s *Server) contributeAvailableRepos() []string {
 }
 
 func (s *Server) handleGovernorSensing(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		EvalIntervalS      int      `json:"eval_interval_s"`
 		GHRatePatterns     []string `json:"ghRatePatterns"`
@@ -4129,6 +4197,10 @@ func (s *Server) handleGovernorSensing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGovernorThresholds(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body map[string]int
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -4163,6 +4235,10 @@ func (s *Server) handleGovernorThresholds(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleGovernorLabels(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Labels []string `json:"labels"`
 	}
@@ -4207,6 +4283,10 @@ func (s *Server) handleGovernorLabels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGovernorBudget(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	// Pointer fields distinguish "field absent from the JSON" (nil) from
 	// "field explicitly set to 0". The dashboard sends only the inputs the
 	// user actually touched, so editing Total Tokens alone POSTs
@@ -4264,6 +4344,10 @@ func (s *Server) handleGovernorBudget(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGovernorNotifications(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		NtfyServer     string `json:"ntfyServer"`
 		NtfyTopic      string `json:"ntfyTopic"`
@@ -4309,6 +4393,10 @@ func (s *Server) handleGovernorNotifications(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) handleGovernorHealth(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		HealthcheckInterval int   `json:"healthcheckInterval"`
 		RestartCooldown     int   `json:"restartCooldown"`
@@ -4341,6 +4429,10 @@ func (s *Server) handleGovernorHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		MaxSizeMB  int    `json:"maxSizeMB"`
 		MaxAgeDays int    `json:"maxAgeDays"`
@@ -4392,6 +4484,10 @@ func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
 // The audit-log entry for every such creation is written unconditionally, so
 // turning the trailer off never loses the invocation record.
 func (s *Server) handleGovernorAttribution(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		AttributionTrailer *bool `json:"attributionTrailer"`
 	}
@@ -4431,6 +4527,10 @@ func normalizeContributeDelegatableRoles(roles []string) []string {
 }
 
 func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Enabled                        *bool                      `json:"enabled"`
 		URL                            string                     `json:"url"`
@@ -4824,6 +4924,10 @@ func (s *Server) handleGovernorLiteLLMTest(w http.ResponseWriter, r *http.Reques
 // and the result returned so a bad endpoint/key fails visibly at save
 // time instead of as agent 401s later.
 func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Endpoint     *string `json:"endpoint"`
 		APIKey       *string `json:"apiKey"`
@@ -4973,6 +5077,10 @@ func (s *Server) handleGovernorBobStatus(w http.ResponseWriter, r *http.Request)
 // roleEnforcement middleware rejects a read-only role with 403 before the
 // handler runs.
 func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		APIKey *string `json:"apiKey"`
 	}
@@ -5083,6 +5191,10 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 // is still supplied by an admin-managed store instead of falsely claiming it
 // was cleared.
 func (s *Server) handleGovernorBobKeyClear(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	removed, err := clearBobKeyFile()
 	if err != nil {
 		jsonError(w, "failed to clear API key: "+err.Error(), http.StatusInternalServerError)
@@ -5115,6 +5227,10 @@ func (s *Server) handleGovernorBobKeyClear(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Name    string `json:"name"`
 		Backend string `json:"backend"`
@@ -5181,6 +5297,10 @@ func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleGovernorRemoveAgent(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
 		jsonError(w, "agent not found", http.StatusNotFound)
@@ -5301,6 +5421,10 @@ func agentDeletionResponse(status, name string, packLevels []int) map[string]any
 }
 
 func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Repos       []string `json:"repos"`
 		PrimaryRepo *string  `json:"primaryRepo,omitempty"`
@@ -5669,6 +5793,10 @@ func newGitHubConfigUpdateError(message string, code int) *githubConfigUpdateErr
 }
 
 func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		AppID          *int64 `json:"app_id"`
 		InstallationID *int64 `json:"installation_id"`
@@ -6405,6 +6533,10 @@ func inferenceModelsFromEnv(envVar, defaultModel string) []string {
 // --- Knowledge endpoints ---
 
 func (s *Server) handleKnowledgeToggle(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Enabled bool `json:"enabled"`
 	}
@@ -6470,6 +6602,10 @@ func (s *Server) handleBeadSynthStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBeadSynthToggle(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Enabled bool `json:"enabled"`
 	}
@@ -7233,6 +7369,10 @@ func (s *Server) handleGitSourcesList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if !s.ensureKnowledge() {
 		jsonError(w, "knowledge not available", http.StatusServiceUnavailable)
 		return
@@ -7313,6 +7453,10 @@ func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleGitSourcesDisconnect(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Knowledge == nil {
 		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
 		return
@@ -7566,6 +7710,10 @@ func (s *Server) handleHiveIDGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleHiveIDSet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		ID string `json:"id"`
 	}
@@ -7667,16 +7815,28 @@ func (s *Server) handleNousPrinciples(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleNousApprove(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	s.auditFromRequest(r, "nous_approve", "", "")
 	okResponse(w, map[string]string{"status": "approved"})
 }
 
 func (s *Server) handleNousAbort(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	s.auditFromRequest(r, "nous_abort", "", "")
 	okResponse(w, map[string]string{"status": "aborted"})
 }
 
 func (s *Server) handleNousMode(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Mode string `json:"mode"`
 	}
@@ -7700,6 +7860,10 @@ func (s *Server) handleNousMode(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleNousScope(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Scope string `json:"scope"`
 	}
@@ -7731,6 +7895,10 @@ func (s *Server) handleNousPhase(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleNousGateDecision(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Nous == nil {
 		jsonError(w, "nous not configured", http.StatusNotFound)
 		return
@@ -7773,6 +7941,10 @@ func (s *Server) handleNousGatePending(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleNousGateRespond(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body map[string]interface{}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -7835,6 +8007,10 @@ func (s *Server) handleNousConfigPrinciples(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *Server) handleNousDeletePrinciple(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	id := r.PathValue("id")
 	if s.deps.Nous == nil {
 		jsonError(w, "nous not configured", http.StatusNotFound)
@@ -7856,6 +8032,10 @@ func (s *Server) handleNousDeletePrinciple(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleNousConfigSection(w http.ResponseWriter, r *http.Request, section string) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Nous == nil {
 		jsonError(w, "nous not configured", http.StatusNotFound)
 		return

--- a/v2/pkg/dashboard/api_acmm_eval.go
+++ b/v2/pkg/dashboard/api_acmm_eval.go
@@ -125,6 +125,10 @@ func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
 
 // handleACMMCreateIssue creates a GitHub issue for a failed ACMM criterion.
 func (s *Server) handleACMMCreateIssue(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var req ACMMIssueRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -131,6 +131,10 @@ func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := r.PathValue("name")
 	agentCfg, ok := s.deps.Config.Agents[name]
 	if !ok {

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -323,6 +323,10 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 }
 
 func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	levelStr := r.PathValue("level")
 	level, err := strconv.Atoi(levelStr)
 	if err != nil {
@@ -356,6 +360,10 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Level int `json:"level"`
 	}

--- a/v2/pkg/dashboard/api_trajectory.go
+++ b/v2/pkg/dashboard/api_trajectory.go
@@ -11,6 +11,10 @@ import (
 // are optional; only those present in the body are changed. Takes effect on
 // the next hive restart, like other governor config changes.
 func (s *Server) handleGovernorTrajectory(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Enabled         *bool   `json:"enabled"`
 		IntervalS       *int    `json:"intervalS"`

--- a/v2/pkg/dashboard/backup_api.go
+++ b/v2/pkg/dashboard/backup_api.go
@@ -31,6 +31,10 @@ const backupBuildTimeout = spokebackup.BuildTimeout
 // can show the menu entry in a disabled state with a real reason instead of
 // failing only after the owner clicks.
 func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
 		role = "owner"
@@ -55,6 +59,10 @@ func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
 // handleBackupDownload builds an encrypted backup of this spoke and streams it
 // to the owner.
 func (s *Server) handleBackupDownload(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
 		role = "owner"

--- a/v2/pkg/dashboard/backup_api_test.go
+++ b/v2/pkg/dashboard/backup_api_test.go
@@ -68,7 +68,7 @@ func TestBackupRefusesWithoutEncryptionKey(t *testing.T) {
 	s := backupTestServer()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/backup", nil)
-	req.Header.Set("X-Hive-Role", "owner")
+	markOwnerRequest(req)
 	rec := httptest.NewRecorder()
 	s.handleBackupDownload(rec, req)
 
@@ -87,7 +87,7 @@ func TestBackupStatusReportsUnavailableWithoutKey(t *testing.T) {
 	s := backupTestServer()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/backup/status", nil)
-	req.Header.Set("X-Hive-Role", "owner")
+	markOwnerRequest(req)
 	rec := httptest.NewRecorder()
 	s.handleBackupStatus(rec, req)
 
@@ -106,7 +106,7 @@ func TestBackupStatusAvailableWithKey(t *testing.T) {
 	s := backupTestServer()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/backup/status", nil)
-	req.Header.Set("X-Hive-Role", "owner")
+	markOwnerRequest(req)
 	rec := httptest.NewRecorder()
 	s.handleBackupStatus(rec, req)
 
@@ -127,7 +127,7 @@ func TestBackupResponseIsNotCacheable(t *testing.T) {
 	s := backupTestServer()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/backup", nil)
-	req.Header.Set("X-Hive-Role", "owner")
+	markOwnerRequest(req)
 	rec := httptest.NewRecorder()
 	s.handleBackupDownload(rec, req)
 

--- a/v2/pkg/dashboard/dashboard_config_download_test.go
+++ b/v2/pkg/dashboard/dashboard_config_download_test.go
@@ -504,7 +504,7 @@ func TestHandleConfigDownloadOwnerRoleAllowed(t *testing.T) {
 	srv := newMinimalServer(t)
 	srv.authToken = "shared-secret-token"
 	req := httptest.NewRequest("GET", "/api/config/download", nil)
-	req.Header.Set("X-Hive-Role", "owner")
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleConfigDownload(w, req)
 	if w.Code != http.StatusOK {
@@ -513,8 +513,8 @@ func TestHandleConfigDownloadOwnerRoleAllowed(t *testing.T) {
 }
 
 // TestHandleConfigDownloadMissingRoleOpenSpoke confirms the open/dev spoke (no
-// authToken, no allowlist) still treats a missing role as owner — the documented
-// convenience where there is no security boundary to protect.
+// authToken, no allowlist) still treats a routed missing-role request as owner:
+// authenticate stamps the verified owner marker before the owner-only handler.
 func TestHandleConfigDownloadMissingRoleOpenSpoke(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "hive.yaml")
@@ -524,7 +524,7 @@ func TestHandleConfigDownloadMissingRoleOpenSpoke(t *testing.T) {
 	srv := newMinimalServer(t) // NewServer => authToken=="" and no allowlist
 	req := httptest.NewRequest("GET", "/api/config/download", nil)
 	w := httptest.NewRecorder()
-	srv.handleConfigDownload(w, req)
+	srv.Handler().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("open/dev spoke should still serve missing-role as owner; got %d, want 200", w.Code)
 	}

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -146,6 +146,10 @@ func (s *Server) handleGovernorGatewaysList(w http.ResponseWriter, r *http.Reque
 // is stored — never inlined into hive.yaml. After persisting, the gateway's
 // endpoint is registered for model discovery so routing picks it up.
 func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	// Optional string fields use pointers so an ABSENT key (the form omits it)
 	// is distinguishable from an explicit empty string (clear the field). This
 	// lets the UI PUT only the fields it manages without wiping the others on
@@ -374,6 +378,10 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 // delete a gateway that an agent currently references as its backend, listing
 // the offending agents so the operator can repoint them first.
 func (s *Server) handleGovernorGatewaysDelete(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	name := strings.TrimSpace(r.PathValue("name"))
 	if name == "" {
 		jsonError(w, "gateway name is required", http.StatusBadRequest)

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -21,6 +21,10 @@ import (
 const maxInceptionBodyBytes = 64 * 1024
 
 func (s *Server) handleInceptionStart(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return
@@ -65,6 +69,10 @@ func (s *Server) handleInceptionStart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleInceptionScan(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return
@@ -119,6 +127,10 @@ func (s *Server) handleInceptionState(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleInceptionSetQuestions(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return
@@ -142,6 +154,10 @@ func (s *Server) handleInceptionSetQuestions(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) handleInceptionAnswer(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return
@@ -174,6 +190,10 @@ func (s *Server) handleInceptionAnswer(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleInceptionRecordFacts(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return
@@ -215,6 +235,10 @@ func (s *Server) handleInceptionScaffold(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleInceptionApprove(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return
@@ -253,6 +277,10 @@ func (s *Server) clearInceptionBeads(store *beads.Store) {
 }
 
 func (s *Server) handleInceptionReset(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return
@@ -362,6 +390,10 @@ func (s *Server) handleInceptionHasFiles(w http.ResponseWriter, r *http.Request)
 const maxWikiNameLen = 80
 
 func (s *Server) handleInceptionRenameWiki(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var req struct {
 		Name string `json:"name"`
 	}
@@ -395,6 +427,10 @@ func (s *Server) handleInceptionRenameWiki(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleInceptionImport(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	if s.deps.Inception == nil {
 		jsonError(w, "inception engine not initialized", http.StatusServiceUnavailable)
 		return

--- a/v2/pkg/dashboard/owner_only_handlers_deny_test.go
+++ b/v2/pkg/dashboard/owner_only_handlers_deny_test.go
@@ -31,3 +31,109 @@ func TestBeadsResetHandlersRejectNonOwners(t *testing.T) {
 		})
 	}
 }
+
+func TestV4OwnerOnlyHandlerGapsRejectUnverifiedOwners(t *testing.T) {
+	srv := &Server{}
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{"ACMM create issue", http.MethodPost, "/api/acmm/issues", srv.handleACMMCreateIssue},
+		{"agent config cadences", http.MethodPut, "/api/config/agent/scanner/cadences", srv.handleAgentConfigCadences},
+		{"agent config channels", http.MethodPut, "/api/config/agent/scanner/channels", srv.handleAgentConfigChannels},
+		{"agent config connections", http.MethodPut, "/api/config/agent/scanner/connections", srv.handleAgentConfigConnections},
+		{"agent config general", http.MethodPut, "/api/config/agent/scanner/general", srv.handleAgentConfigGeneral},
+		{"agent config hooks", http.MethodPut, "/api/config/agent/scanner/hooks", srv.handleAgentConfigHooks},
+		{"agent config models", http.MethodPut, "/api/config/agent/scanner/models", srv.handleAgentConfigModels},
+		{"agent config pipeline", http.MethodPut, "/api/config/agent/scanner/pipeline", srv.handleAgentConfigPipeline},
+		{"agent config restrictions", http.MethodPut, "/api/config/agent/scanner/restrictions", srv.handleAgentConfigRestrictions},
+		{"agent config stats", http.MethodPut, "/api/config/agent/scanner/stats", srv.handleAgentConfigStats},
+		{"agent config tools", http.MethodPut, "/api/config/agent/scanner/tools", srv.handleAgentConfigTools},
+		{"agent delete", http.MethodDelete, "/api/agents/scanner", srv.handleAgentDelete},
+		{"agent prompt save", http.MethodPut, "/api/config/agent/scanner/prompt", srv.handleAgentPromptSave},
+		{"backup download", http.MethodPost, "/api/backup", srv.handleBackupDownload},
+		{"backup status", http.MethodGet, "/api/backup/status", srv.handleBackupStatus},
+		{"bead synth toggle", http.MethodPut, "/api/bead-synth/enabled", srv.handleBeadSynthToggle},
+		{"budget ignore", http.MethodPut, "/api/config/governor/budget/ignore", srv.handleBudgetIgnoreSet},
+		{"config download", http.MethodGet, "/api/config/download", srv.handleConfigDownload},
+		{"github config", http.MethodPut, "/api/config/github", srv.handleConfigGitHub},
+		{"git sources connect", http.MethodPost, "/api/config/git-sources/connect", srv.handleGitSourcesConnect},
+		{"git sources disconnect", http.MethodPost, "/api/config/git-sources/disconnect", srv.handleGitSourcesDisconnect},
+		{"governor add agent", http.MethodPost, "/api/config/governor/agents", srv.handleGovernorAddAgent},
+		{"governor attribution", http.MethodPut, "/api/config/governor/attribution", srv.handleGovernorAttribution},
+		{"governor bob key", http.MethodPut, "/api/config/governor/bob", srv.handleGovernorBobKey},
+		{"governor bob key clear", http.MethodDelete, "/api/config/governor/bob", srv.handleGovernorBobKeyClear},
+		{"governor budget", http.MethodPut, "/api/config/governor/budget", srv.handleGovernorBudget},
+		{"gateway delete", http.MethodDelete, "/api/config/governor/gateways/openrouter", srv.handleGovernorGatewaysDelete},
+		{"gateway upsert", http.MethodPut, "/api/config/governor/gateways", srv.handleGovernorGatewaysUpsert},
+		{"governor health", http.MethodPut, "/api/config/governor/health", srv.handleGovernorHealth},
+		{"governor hub", http.MethodPut, "/api/config/governor/hub", srv.handleGovernorHub},
+		{"governor labels", http.MethodPut, "/api/config/governor/labels", srv.handleGovernorLabels},
+		{"governor litellm", http.MethodPut, "/api/config/governor/litellm", srv.handleGovernorLiteLLM},
+		{"governor logging", http.MethodPut, "/api/config/governor/logging", srv.handleGovernorLogging},
+		{"governor notifications", http.MethodPut, "/api/config/governor/notifications", srv.handleGovernorNotifications},
+		{"governor remove agent", http.MethodDelete, "/api/config/governor/agents/scanner", srv.handleGovernorRemoveAgent},
+		{"governor repos", http.MethodPut, "/api/config/governor/repos", srv.handleGovernorRepos},
+		{"governor sensing", http.MethodPut, "/api/config/governor/sensing", srv.handleGovernorSensing},
+		{"governor thresholds", http.MethodPut, "/api/config/governor/thresholds", srv.handleGovernorThresholds},
+		{"governor trajectory", http.MethodPut, "/api/config/governor/trajectory", srv.handleGovernorTrajectory},
+		{"hive id set", http.MethodPut, "/api/hive-id", srv.handleHiveIDSet},
+		{"inception answer", http.MethodPost, "/api/inception/answer", srv.handleInceptionAnswer},
+		{"inception approve", http.MethodPost, "/api/inception/approve", srv.handleInceptionApprove},
+		{"inception import", http.MethodPost, "/api/inception/import", srv.handleInceptionImport},
+		{"inception record facts", http.MethodPost, "/api/inception/facts", srv.handleInceptionRecordFacts},
+		{"inception rename wiki", http.MethodPost, "/api/inception/rename-wiki", srv.handleInceptionRenameWiki},
+		{"inception reset", http.MethodPost, "/api/inception/reset", srv.handleInceptionReset},
+		{"inception scan", http.MethodPost, "/api/inception/scan", srv.handleInceptionScan},
+		{"inception set questions", http.MethodPost, "/api/inception/questions", srv.handleInceptionSetQuestions},
+		{"inception start", http.MethodPost, "/api/inception/start", srv.handleInceptionStart},
+		{"knowledge toggle", http.MethodPut, "/api/knowledge/enabled", srv.handleKnowledgeToggle},
+		{"nous abort", http.MethodPost, "/api/nous/abort", srv.handleNousAbort},
+		{"nous approve", http.MethodPost, "/api/nous/approve", srv.handleNousApprove},
+		{"nous config section", http.MethodPut, "/api/nous/config/goals", func(w http.ResponseWriter, r *http.Request) { srv.handleNousConfigSection(w, r, "goals") }},
+		{"nous delete principle", http.MethodDelete, "/api/nous/config/principles/0", srv.handleNousDeletePrinciple},
+		{"nous gate decision", http.MethodPost, "/api/nous/gate/decision", srv.handleNousGateDecision},
+		{"nous gate respond", http.MethodPost, "/api/nous/gate/respond", srv.handleNousGateRespond},
+		{"nous mode", http.MethodPut, "/api/nous/mode", srv.handleNousMode},
+		{"nous scope", http.MethodPut, "/api/nous/scope", srv.handleNousScope},
+		{"pack apply", http.MethodPost, "/api/packs/apply", srv.handlePackApply},
+		{"pack set level", http.MethodPut, "/api/packs/level", srv.handlePackSetLevel},
+		{"self upgrade", http.MethodPost, "/api/self-upgrade", srv.handleSelfUpgrade},
+		{"variable delete", http.MethodDelete, "/api/config/variables/VAR", srv.handleVariableDelete},
+		{"variable upsert", http.MethodPut, "/api/config/variables/VAR", srv.handleVariableUpsert},
+	}
+
+	authCases := []struct {
+		name string
+		role string
+	}{
+		{"read-write", "read-write"},
+		{"proofless owner", "owner"},
+	}
+	for _, tc := range tests {
+		for _, ac := range authCases {
+			t.Run(tc.name+"/"+ac.name, func(t *testing.T) {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("handler panicked for unverified request: %v; want status %d", r, http.StatusForbidden)
+					}
+				}()
+				req := httptest.NewRequest(tc.method, tc.path, nil)
+				req.Header.Set("X-Hive-Role", ac.role)
+				req.SetPathValue("agent", "scanner")
+				req.SetPathValue("name", "openrouter")
+				req.SetPathValue("key", "VAR")
+				req.SetPathValue("index", "0")
+				w := httptest.NewRecorder()
+
+				tc.handler(w, req)
+
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("unverified %q status = %d, want %d", ac.role, w.Code, http.StatusForbidden)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Security follow-up to #3437.

A scripted comparison found 69 dashboard handlers with `requireOwnerRole` on v2 and only 6 on current v4. After #3437 fixed beads reset, 63 common v2-owner-gated handlers still existed on v4 without the hardened owner gate. v4 only had the broad `roleEnforcement` middleware, which blocks read-only writes but still allows read-write/merger users; that is not equivalent to owner-only authorization.

This PR restores `requireOwnerRole` parity for the common v4 handlers covering config, credentials, agent execution/config, gateways, packs, backup/config download, Git sources, ACMM, Nous, inception, and trajectory mutations.

Tests:
- Added direct deny coverage for every restored v4 gate using both read-write and proofless-owner requests.
- Confirmed the new deny test failed before the gates: handlers returned non-403 statuses or panicked instead of returning 403.
- Existing positive direct-handler tests now use the pre-existing `markOwnerRequest` helper, or route through `Handler` where authenticate stamps the verified owner marker.

Validation:
- `go test ./pkg/dashboard -run 'TestBeadsResetHandlersRejectNonOwners|TestV4OwnerOnlyHandlerGapsRejectUnverifiedOwners|TestBackup|TestHandleConfigDownload' -count=1 -v`
- `go test ./pkg/dashboard -count=1`
- `go vet ./pkg/dashboard && go build ./...`
- code-review agent: no issues found