### PR TITLE
🐛 fix(acmm): L3/L4 SURGE no longer pauses the workers (self-tightening dead-end)

### DIFF
--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -15,12 +15,15 @@ governor:
     quiet: 3
     idle: 0
   cadences:
+    # SURGE = queue overloaded, so the workers must keep RUNNING to drain it.
+    # Pausing them was a self-tightening trap (queue never drains → stuck in
+    # SURGE forever → nothing created). Keep workers on their busy cadences.
     surge:
-      supervisor: pause
-      scanner: pause
-      ci-maintainer: pause
-      quality: pause
-      guide: pause
+      supervisor: 5m
+      scanner: 4h
+      ci-maintainer: 4h
+      quality: 2h
+      guide: 4h
     busy:
       supervisor: 5m
       scanner: 4h

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -16,13 +16,19 @@ governor:
     quiet: 2
     idle: 0
   cadences:
+    # SURGE = the queue is overloaded, so the issue/PR-producing agents must
+    # keep RUNNING to drain it — pausing them here was a self-tightening trap: a
+    # hive that tripped the threshold paused every worker, so the queue never
+    # drained and it stayed in SURGE forever (nothing created, e.g. a fresh L4
+    # hive whose first repo scan exceeds threshold=10). Keep the workers on their
+    # busy cadences during surge; only the non-draining/advisory agents pause.
     surge:
-      supervisor: pause
-      scanner: pause
-      ci-maintainer: pause
-      quality: pause
-      guide: pause
-      sec-check: pause
+      supervisor: 5m
+      scanner: 4h
+      ci-maintainer: 4h
+      quality: 2h
+      guide: 4h
+      sec-check: 4h
     busy:
       supervisor: 5m
       scanner: 4h


### PR DESCRIPTION
## Symptom (reported live)
A hosted **L4** hive (`z-aiops-unite`) enabled L4 but creates no issues/PRs. Governor evals show `mode: SURGE, issues:50, prs:78, agents_due:null` on every tick; agents produce advisory findings (412) but never file anything; `last_kick=never` for every worker.

## Root cause
The **L3 and L4 packs pause every issue/PR-producing agent in SURGE mode**:
```yaml
surge: { supervisor: pause, scanner: pause, ci-maintainer: pause, quality: pause, guide: pause, sec-check: pause }
```
SURGE fires on queue overload (L4 threshold **10**, L3 **15**). Pausing the workers means the queue never drains → the hive stays in SURGE **forever** → `agents_due` is always empty → nothing is created. A fresh L4 hive whose first repo scan exceeds 10 actionable items hits this immediately. It's the 'governor surge = all-pause self-tightening trap.'

## Fix
**L5 and L6 already keep workers running in SURGE** (they never pause). Make L3/L4 match — SURGE now uses the same working cadences as BUSY, so the queue drains and the hive recovers to a lower mode. Advisory/non-draining agents can still pause; here none needed to.

Packs are `go:embed`'d, so this ships in the image. Config tests pass; YAML validated.

## For affected running hives (immediate)
Until they roll to this image, a live hive stuck in SURGE can be unblocked by editing its governor surge cadences (dashboard → Governor Config) to non-pause values, or temporarily lowering activity below the surge threshold.