### PR TITLE
🔒 sec(image): verify Goose installs on v4

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -169,16 +169,24 @@ RUN npm install -g @openai/codex@${CODEX_VERSION} && npm cache clean --force || 
 ARG CLAUDE_CODE_VERSION=latest
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
 
-# --- Layer 8: Goose CLI (aaif-goose/goose — supports custom providers via env vars) ---
-ARG GOOSE_VERSION=1.37.0
+# --- Layer 8: Goose CLI (official block/goose upstream) ---
+# Installs from the OFFICIAL block/goose repo, pinned to a fixed release and
+# SHA-256-verified before extraction. Download failures are tolerated because
+# Goose is an optional backend; checksum mismatches must hard-fail the build.
+ARG GOOSE_VERSION=1.45.0
+ARG GOOSE_SHA256_X86_64=e0db638ac437ca0a60b0c1622f45322608d228d1a285214c3bf48fd9763346a5
+ARG GOOSE_SHA256_AARCH64=c9894106c90e404ac8b8d67c628aea2943dd6a1bc83bfd8e2171d482fa43d72a
 RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then GOOSE_ARCH=x86_64; \
-    elif [ "$ARCH" = "aarch64" ]; then GOOSE_ARCH=aarch64; \
-    else GOOSE_ARCH=x86_64; fi && \
-    curl -fsSL "https://github.com/aaif-goose/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" | \
-    tar xz -C /usr/local/bin goose && \
-    chmod +x /usr/local/bin/goose || \
-    echo "WARN: Goose CLI install failed — skipping"
+    if [ "$ARCH" = "aarch64" ]; then GOOSE_ARCH=aarch64; GOOSE_SHA256="$GOOSE_SHA256_AARCH64"; \
+    else GOOSE_ARCH=x86_64; GOOSE_SHA256="$GOOSE_SHA256_X86_64"; fi && \
+    if curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
+      echo "${GOOSE_SHA256}  /tmp/goose.tar.gz" | sha256sum -c - && \
+      tar xz -C /usr/local/bin -f /tmp/goose.tar.gz && \
+      chmod +x /usr/local/bin/goose && \
+      rm -f /tmp/goose.tar.gz; \
+    else \
+      echo "WARN: Goose CLI download failed — skipping (backend: goose will be unavailable)"; \
+    fi
 
 # --- Layer 8.5: pi CLI (@earendil-works/pi-coding-agent — backend: pi) ---
 # Tolerant of failure like the copilot/codex layers: agents configured for

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -62,16 +62,23 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
 
 # Install Goose CLI (Block's AI agent)
+ARG GOOSE_VERSION=1.45.0
+ARG GOOSE_SHA256_X86_64=e0db638ac437ca0a60b0c1622f45322608d228d1a285214c3bf48fd9763346a5
+ARG GOOSE_SHA256_AARCH64=c9894106c90e404ac8b8d67c628aea2943dd6a1bc83bfd8e2171d482fa43d72a
 RUN ARCH=$(dpkg --print-architecture) \
-  && GOOSE_ARCH=$([ "$ARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
+  && if [ "$ARCH" = "arm64" ]; then GOOSE_ARCH=aarch64; GOOSE_SHA256="$GOOSE_SHA256_AARCH64"; \
+     else GOOSE_ARCH=x86_64; GOOSE_SHA256="$GOOSE_SHA256_X86_64"; fi \
   && mkdir -p /tmp/goose-dl \
-  && curl -fsSL "https://github.com/block/goose/releases/latest/download/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" \
-    -o /tmp/goose-dl/goose.tar.gz \
-  && cd /tmp/goose-dl && tar -xzf goose.tar.gz \
-  && find /tmp/goose-dl -name "goose" -type f -exec cp {} /usr/local/bin/goose \; \
-  && chmod +x /usr/local/bin/goose \
-  && rm -rf /tmp/goose-dl \
-  || echo "Goose install skipped"
+  && if curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" \
+       -o /tmp/goose-dl/goose.tar.gz; then \
+       echo "${GOOSE_SHA256}  /tmp/goose-dl/goose.tar.gz" | sha256sum -c - \
+       && cd /tmp/goose-dl && tar -xzf goose.tar.gz \
+       && find /tmp/goose-dl -name "goose" -type f -exec cp {} /usr/local/bin/goose \; \
+       && chmod +x /usr/local/bin/goose \
+       && rm -rf /tmp/goose-dl; \
+     else \
+       echo "Goose install skipped"; \
+     fi
 
 # Install Pi CLI (pi.dev coding agent)
 RUN curl -fsSL https://pi.dev/install.sh | sh \


### PR DESCRIPTION
## Summary
- switch v4 Goose image installs to the official block/goose release path
- pin Goose to v1.45.0 and verify linux tarballs with per-architecture SHA-256 checksums
- preserve optional-backend download tolerance while making checksum mismatches fail the build

Twin of #3427 for branch parity; fixes the same Goose supply-chain issue on v4.

Fixes #3417

## Verification
- confirmed `gh api repos/block/goose` resolves to the high-star official Goose repository now canonicalized as `aaif-goose/goose`
- verified v1.45.0 linux tarball SHA-256 values for x86_64 and aarch64
- corrupt checksum test: `sha256sum -c` reported `FAILED` and exited 1
- Docker daemon unavailable locally (Colima docker service failed to start), so image build is left to CI