### PR TITLE
🐛 fix(acmm): re-derive governor cadences on an explicit level switch (agents_due:null)

### DIFF
--- a/v2/pkg/dashboard/acmm_roster_reconcile_test.go
+++ b/v2/pkg/dashboard/acmm_roster_reconcile_test.go
@@ -245,3 +245,55 @@ func TestApplyPackPreservesOperatorThreshold(t *testing.T) {
 		break
 	}
 }
+
+// TestApplyPackForceRederivesCadencesOnLevelSwitch guards the level-switch bug:
+// switching to a level whose pack differs only in governor cadences (no NEW
+// agent added) must adopt the target level's cadences. Plain ApplyPack preserves
+// operator customizations on a no-growth merge, which silently kept the previous
+// level's cadences after a switch (e.g. a stale SURGE=pause), leaving agents_due
+// empty. ApplyPackForce (used by the /api/packs level-change + apply handlers)
+// re-derives them.
+func TestApplyPackForceRederivesCadencesOnLevelSwitch(t *testing.T) {
+	srv := newFullServer(t)
+
+	// Bring the roster up to L5 first (adds agents; cadences from L5).
+	if _, err := srv.ApplyPack(5); err != nil {
+		t.Fatalf("ApplyPack(5): %v", err)
+	}
+
+	// Corrupt a governor cadence to simulate a stale/customized value that a
+	// plain merge would preserve — here, pause scanner in surge.
+	if m, ok := srv.deps.Config.Governor.Modes["surge"]; ok {
+		if m.Cadences == nil {
+			m.Cadences = map[string]config.Cadence{}
+		}
+		m.Cadences["scanner"] = config.Cadence("pause")
+		srv.deps.Config.Governor.Modes["surge"] = m
+	}
+
+	// A PLAIN re-apply of the SAME level adds no agents, so it must NOT overwrite
+	// the (now stale) cadence — this is the preserve-customizations path.
+	if _, err := srv.ApplyPack(5); err != nil {
+		t.Fatalf("ApplyPack(5) re-apply: %v", err)
+	}
+	if got := srv.deps.Config.Governor.Modes["surge"].Cadences["scanner"]; got != "pause" {
+		t.Fatalf("plain ApplyPack should preserve the customized surge scanner cadence, got %q", got)
+	}
+
+	// ApplyPackForce (an explicit operator apply) MUST re-derive from the pack,
+	// replacing the stale "pause" with the pack's L5 surge scanner cadence.
+	pack, err := config.ACMMPackByLevel(5)
+	if err != nil {
+		t.Fatalf("ACMMPackByLevel(5): %v", err)
+	}
+	want := pack.Governor.Cadences["surge"]["scanner"]
+	if want == "" || want == "pause" {
+		t.Skip("L5 surge scanner cadence not a distinguishing non-pause value; test assumption changed")
+	}
+	if _, err := srv.ApplyPackForce(5); err != nil {
+		t.Fatalf("ApplyPackForce(5): %v", err)
+	}
+	if got := string(srv.deps.Config.Governor.Modes["surge"].Cadences["scanner"]); got != want {
+		t.Errorf("ApplyPackForce must re-derive surge scanner cadence from the pack: got %q, want %q", got, want)
+	}
+}

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -58,7 +58,27 @@ type ApplyPackResult struct {
 // sets governor config (eval interval, cadences, thresholds, stale timeouts),
 // syncs agent visibility, and persists state. Callable from both the HTTP
 // handler and the startup bootstrap path.
+// ApplyPack reconciles the roster and (on first apply / expansion) the governor
+// config for a level. It preserves operator governor customizations on a pure
+// merge — see ApplyPackForce for the explicit-level-change variant that must
+// re-derive the cadences from the new pack.
 func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
+	return s.applyPack(level, false)
+}
+
+// ApplyPackForce is ApplyPack for an EXPLICIT operator level change / pack
+// apply: it re-derives the governor mode cadences and thresholds from the target
+// pack even when the roster does not grow. Without this, switching to a level
+// whose pack has different cadences for already-existing agents kept the OLD
+// level's cadences — including a carried-over SURGE=pause — leaving agents_due
+// empty and nothing kicked (the bug behind "switching ACMM level makes the hive
+// stop creating anything"). Startup uses ApplyPack (preserve customizations);
+// the /api/packs level-change and apply handlers use this.
+func (s *Server) ApplyPackForce(level int) (*ApplyPackResult, error) {
+	return s.applyPack(level, true)
+}
+
+func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, error) {
 	pack, err := config.ACMMPackByLevel(level)
 	if err != nil {
 		return nil, err
@@ -228,10 +248,14 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 		s.logger.Error("failed to save ACMM level to hive.yaml", "error", err)
 	}
 
-	// Only apply governor config (thresholds, cadences, eval interval) when
-	// new agents are being created. On a pure merge (all agents already exist),
-	// preserve user's governor customizations.
-	isFirstApplyOrExpansion := len(created) > 0
+	// Apply governor config (thresholds, cadences, eval interval) when new agents
+	// are being created OR when this is an explicit operator level change / pack
+	// apply (forceGovernor). On a plain startup merge with no roster growth,
+	// preserve the operator's governor customizations. Without the forceGovernor
+	// path, switching between levels whose packs differ only in cadences (no new
+	// agent) kept the previous level's cadences — including a stale SURGE=pause —
+	// so the hive stopped kicking agents after a level switch.
+	isFirstApplyOrExpansion := len(created) > 0 || forceGovernor
 
 	if pack.Governor.EvalIntervalS > 0 && isFirstApplyOrExpansion {
 		s.deps.Config.Governor.EvalIntervalS = pack.Governor.EvalIntervalS
@@ -336,7 +360,10 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 	s.levelMu.Lock()
 	defer s.levelMu.Unlock()
 
-	result, err := s.ApplyPack(level)
+	// Explicit operator pack-apply: force the governor cadences to the target
+	// pack (see ApplyPackForce) so a level switch that adds no new agent still
+	// picks up the new level's cadences instead of keeping the old ones.
+	result, err := s.ApplyPackForce(level)
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -407,7 +434,7 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 	// 200 here is exactly what left kellyaa at "acmm_level: 5, 8 agents,
 	// strategist missing". Surface the error so the operator sees the drift
 	// and can retry instead of trusting a false success.
-	packResult, packErr := s.ApplyPack(level)
+	packResult, packErr := s.ApplyPackForce(level)
 	if packErr != nil {
 		s.logger.Error("failed to reconcile roster after level change", "level", level, "error", packErr)
 		jsonError(w, "level set but roster reconciliation failed: "+packErr.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Symptom (operator-observed)
Switching a hive's ACMM level via the dashboard makes it stop creating anything — governor evals show `agents_due:null` afterward.

## Root cause
`ApplyPack` only re-applies governor cadences/thresholds when the roster **grows** (`len(created) > 0`) — to preserve operator customizations on a plain startup merge. But an explicit operator **level change that adds no new agent** (a demote, a same-level re-apply, or any switch between packs that differ only in cadences) took the preserve path and **kept the OLD level's cadences** — including a carried-over `SURGE=pause`, the self-tightening stall. (This is also why re-applying L4 didn't un-stick the surge-paused hive.)

## Fix
Split into:
- `ApplyPack` — **startup**: preserve operator governor customizations (unchanged).
- `ApplyPackForce` — **explicit operator apply / level change**: re-derive the governor mode cadences + thresholds from the target pack.

The `/api/packs/level` (PUT) and `/api/packs/{level}/apply` (POST) handlers now use `ApplyPackForce`; startup keeps `ApplyPack`. Test proves a plain re-apply preserves a customized cadence while `ApplyPackForce` re-derives it from the pack.

Pairs with #3462 (L3/L4 surge no longer pauses workers) — together, a level switch now reliably lands the correct working cadences.