### PR TITLE
🔒 fix(agent): skip symlinks in world-writable repair

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4699,6 +4699,12 @@ func (m *Manager) ensureWorldWritable(root string) {
 		if err != nil {
 			return nil
 		}
+		// SECURITY (CWE-59): filepath.Walk reports entries via Lstat, so a
+		// planted symlink is visible here. os.Chmod follows symlinks; never let
+		// this agent-writable HOME repair loop chmod a target outside root.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
 		if info.IsDir() {
 			if info.Mode().Perm() != 0o777 {
 				_ = os.Chmod(path, 0o777)

--- a/v2/pkg/agent/manager_symlink_test.go
+++ b/v2/pkg/agent/manager_symlink_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func quietManager() *Manager {
+	return &Manager{logger: quietLogger()}
+}
+
+func assertWorldWritableTargetMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	if got := statMode(t, path); got != want {
+		t.Fatalf("%s mode = %v, want %v: ensureWorldWritable followed a symlink (CWE-59 regression)",
+			filepath.Base(path), got, want)
+	}
+}
+
+func TestEnsureWorldWritableSkipsSymlinkToOutsideFile(t *testing.T) {
+	root := t.TempDir()
+
+	target := filepath.Join(root, "outside-target")
+	if err := os.WriteFile(target, []byte("sensitive"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatalf("chmod target: %v", err)
+	}
+
+	watched := filepath.Join(root, "watched")
+	if err := os.Mkdir(watched, 0o755); err != nil {
+		t.Fatalf("mkdir watched: %v", err)
+	}
+	link := filepath.Join(watched, "planted-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	quietManager().ensureWorldWritable(watched)
+
+	assertWorldWritableTargetMode(t, target, 0o600)
+}
+
+func TestEnsureWorldWritableSkipsRelativeSymlinkToOutsideFile(t *testing.T) {
+	root := t.TempDir()
+	watched := filepath.Join(root, "watched")
+	outside := filepath.Join(root, "outside")
+	if err := os.Mkdir(watched, 0o755); err != nil {
+		t.Fatalf("mkdir watched: %v", err)
+	}
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	target := filepath.Join(outside, "secret")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatalf("chmod target: %v", err)
+	}
+
+	link := filepath.Join(watched, "relative-link")
+	if err := os.Symlink(filepath.Join("..", "outside", "secret"), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	quietManager().ensureWorldWritable(watched)
+
+	assertWorldWritableTargetMode(t, target, 0o600)
+}
+
+func TestEnsureWorldWritableSkipsSymlinkToOutsideDirectory(t *testing.T) {
+	root := t.TempDir()
+	watched := filepath.Join(root, "watched")
+	targetDir := filepath.Join(root, "outside-dir")
+	if err := os.Mkdir(watched, 0o755); err != nil {
+		t.Fatalf("mkdir watched: %v", err)
+	}
+	if err := os.Mkdir(targetDir, 0o700); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.Chmod(targetDir, 0o700); err != nil {
+		t.Fatalf("chmod target dir: %v", err)
+	}
+
+	link := filepath.Join(watched, "dir-link")
+	if err := os.Symlink(targetDir, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	quietManager().ensureWorldWritable(watched)
+
+	assertWorldWritableTargetMode(t, targetDir, 0o700)
+}

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -170,7 +170,7 @@ func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
 	// repair loop onto a file outside the tree. filepath.Walk reports
 	// entries via Lstat, so the link is visible as a link here; the ownership
 	// check below reads the LINK's metadata, not the target's, and so cannot
-	// be relied on to catch this. Same guard as ensureWorldWritable.
+	// be relied on to catch this. Mirrors ensureWorldWritable's symlink skip.
 	if fi.Mode()&os.ModeSymlink != 0 {
 		return
 	}


### PR DESCRIPTION
Fixes a CWE-59 symlink-following bug in ensureWorldWritable on v2. filepath.Walk reports symlinks via Lstat, so the repair loop now skips symlinks before os.Chmod. Adds load-bearing tests for absolute file symlink, relative file symlink, and directory symlink targets outside the repaired root.

Validation:
- go test -v ./pkg/agent -run 'TestEnsureWorldWritableSkips' -count=1
- go build ./...
- go vet ./pkg/agent/

Full local go test ./pkg/agent was attempted; unrelated existing tests TestDismissInferencePrompts_FixWith and TestDismissInferencePrompts_BypassConsent timed out locally.