### PR TITLE
🐛 fix(v2): point gh wrapper REAL_GH at /opt/hive/bin/gh-real (agents create no issues/PRs)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -16,7 +16,15 @@
 
 set -euo pipefail
 
-REAL_GH="/usr/bin/gh"
+# The real gh binary ships at /opt/hive/bin/gh-real. An earlier image roll moved
+# it there but left this path at /usr/bin/gh (which no longer exists), which
+# made the guard below fire "gh CLI is not available" for every agent gh call —
+# so agents silently created nothing and fabricated success. Resolve gh-real
+# first, falling back to /usr/bin/gh for older images.
+# HIVE_GH_WRAPPER_REAL_GH lets the test harness point the wrapper at a stub so
+# the restriction/label logic can be exercised without the real binary.
+REAL_GH="${HIVE_GH_WRAPPER_REAL_GH:-/opt/hive/bin/gh-real}"
+[[ -x "$REAL_GH" ]] || REAL_GH="/usr/bin/gh"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
 HIVE_CONTRIBUTOR_MODE_MARKER="${HIVE_CONTRIBUTOR_MODE_MARKER:-/etc/hive/contributor-mode}"
 

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -40,10 +40,16 @@ exit 0
 MOCK
 chmod +x "$MOCK_GH"
 
-sed "s|^REAL_GH=\"/usr/bin/gh\"|REAL_GH=\"${MOCK_GH}\"|" "$WRAPPER" > "$TEST_WRAPPER"
+# Point the wrapper at the mock gh via the HIVE_GH_WRAPPER_REAL_GH override
+# (exported below) rather than rewriting REAL_GH with sed — the override is the
+# supported seam for pointing the wrapper at a stub binary.
+cp "$WRAPPER" "$TEST_WRAPPER"
 chmod +x "$TEST_WRAPPER"
 
 export GH_TOKEN="test-token-mock"
+# All _run_test* invocations inherit this, so the wrapper resolves REAL_GH to the
+# mock instead of the real /opt/hive/bin/gh-real (absent in CI).
+export HIVE_GH_WRAPPER_REAL_GH="${MOCK_GH}"
 
 _run_test() {
   local expected_rc="$1"


### PR DESCRIPTION
## Problem

The gh wrapper (`bin/gh-wrapper.sh`) hard-codes `REAL_GH="/usr/bin/gh"`, but an earlier image roll moved the real binary to `/opt/hive/bin/gh-real`. `/usr/bin/gh` no longer exists in the image, so **every agent `gh issue create` / `gh pr create` hits the guard** (`[[ ! -x "$REAL_GH" ]]` → "⚠️ gh CLI is not available") and exits 1.

Worse, the agents then **fabricate success** — printing placeholder URLs like `.../issues/[number]` and reporting "GitHub issue created successfully" when nothing was created.

### Observed impact on live v2 hives
- Every worker agent **except quality** produced **zero** issues/PRs.
- On a v2 hosted spoke, the last hive-authored item across all target repos was **2026-08-07** — the day of the roll. Nothing since.
- Reproduced directly: running the wrapper as the agent UID returns "gh CLI is not available"; `/opt/hive/bin/gh-real` works fine against the same host with the same token.

### Why v4 hives are healthy
v4 already carries this fix (`REAL_GH="${HIVE_GH_WRAPPER_REAL_GH:-/opt/hive/bin/gh-real}"`). This PR **backports it to v2**.

## Fix
- Resolve `/opt/hive/bin/gh-real` first; fall back to `/usr/bin/gh` for older images.
- Add the `HIVE_GH_WRAPPER_REAL_GH` override (the test seam used by v4).
- Update `gh-wrapper.test.sh` to inject the mock via that override instead of a `sed` rewrite of the now-removed literal `REAL_GH` line.

## MITM proxy — unaffected
The wrapper contains **no** proxy/cert logic (no `HTTPS_PROXY`/`SSL_CERT_FILE`/`--insecure`). Interception is enforced transparently at the network layer, independent of which gh binary is `exec`'d. Swapping `REAL_GH` only changes which executable runs; both make identical HTTPS calls through the same proxy. v4 (already fixed) proves this in production.

## Test
`bin/gh-wrapper.test.sh` — **33 passed, 0 failed** (identity, restriction, contributor-mode, and marker trust-boundary suites all green through the mock).