### PR TITLE
🐛 Set the full forge identity at assign, and let it converge

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -444,7 +444,16 @@ func resolveAppKeyFile(configured, envOverride string, appID int64) string {
 		// only when a usable per-app-id key exists. Any other path is a genuine
 		// operator override (a hive on a third App with a bespoke key location)
 		// and still wins outright.
-		if v == spokeAppKeyPath {
+		//
+		// BOTH generic paths qualify. /data/gh-app-key.pem is what older builds
+		// wrote on every key delivery; /secrets/gh-app-key.pem is what the
+		// PROVISIONING TEMPLATE hardcodes for every App-using hive
+		// (saas_provision.go). Neither names the App it holds, and neither was
+		// typed by an operator. Until /secrets was included here, a provisioned
+		// hive could never change forges: the hub could correct app_id all it
+		// liked and the spoke kept signing with the provisioned key, which on
+		// the a-ks-wec2 pool was a placeholder matching NEITHER real App.
+		if v == spokeAppKeyPath || v == spokeProvisionedAppKeyPath {
 			if p := perAppIDKeyPath(appID); p != "" {
 				if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
 					return p

--- a/v2/cmd/hive/provisioned_key_pin_test.go
+++ b/v2/cmd/hive/provisioned_key_pin_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// testRSAPrivateKeyPEM is a throwaway key generated for this test only — it
+// authenticates nothing. resolveAppKeyFile gates on a parseable fingerprint,
+// so the bytes must be a real RSA key rather than a placeholder string.
+const testRSAPrivateKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDUE14M+R+F+Rd7
+aq9Qb9gQEVX7hbZm8/ujygzB7ztu7Sx+KZhj8gYs4HppK4B/Q5xBQxwWV+0/WM8q
+hnn3x2Ycw8Wiz8B2C8nGvdhkEs8En0DOdoEZ8mi3XNZNwFuyTkFr9vDdVT9hlv9i
+9A6Qdc9ozr1MdHxwmca8RG5xWUj6P1G2UtpwACFGqFfnrNCT5w1dQImumCiidCaP
+paEmmgg4X1CElz3Z9KhWiaLAaZHaCuj5Km3tqn0xwDvSRO+tB2d9GOphW7sq85Gt
+yWVytUYEVkdL0x94rhJ+HmLY12oYJQj1txr1SMd6NHKmSQuI95nEgNdEMQgoJquD
+i397C7sLAgMBAAECggEAI17pkEtalRsy7ewguk81H5TsnMsz3V7zCOHRl+ThKkKX
+aaFhX8YFfqWf9PuC7nbl0EKzpAxdLvQOdV7BZ/CTWNfUFjAFPwr/R8zxEtvKOFCh
+W+4K4Tt7eJ2cxpH/GTGRGsMwcBHgRNQM20GuTiy//5B/pQlGmfcj3NGjA/eqwsXP
+ucI/A+N/xwDcdnqiHZ25w1CBiMZatQaoeHP19Qktr7nlmVG2Udq0Y3/zZcZwE5fc
+2k6La4yGNVVyKWzb0IZqwSnwtRkmmCKJrq3ECZVDrzBve4jST5z9x1WjzOnnpt7U
+caBSKg1E3K2VZp0rM5t4gQkn7vNPYy4UFMeGi/wR3QKBgQD/n89V1LZHieqmUrV9
+8O8IkZRt/E0HBtnQw2wJSt29TMdBZ8xm7Rs5RqBDFtOBuLZJyshhFGu8zWBpH+0O
+SMBxYqAPiGOFGpB3m6NH8aFjhRkzfSDQpv9NtDFsrNac/+Bq9b57i/QzUUE5QXz8
+Mdk0NDgoCWKGTYnZsH3u0TjQlQKBgQDUYyudGfuBH/6j3HGfnVcBFR0C4Cpgurtt
+vimWVgkGf7pc3Tik7qD1+OqPD4dVuV4SxST8sqYr3H7YByMwoG2HWFJUsV5VKPbM
+DSxXEGrB8X5hyY9tJoFhxSZT1Hyi91nFOwgwz2Y9bzCnpF74eakFceRN2AwtgShy
+n2JpIQVVHwKBgQC08TRcNyOH5BIbBXS+3yr0T8hXSj5j+O95nLr+oOXwt0Zb/9Nq
+D/AzTNDobGHu8wblmQrZ3RCeJmpWP2kXsVu3Zu6R0CNR9onIgHzF0j5BKde64Jm3
+2F3jbOeHW5jWrTD3xVe+MET9hki69KY6BjcPgt81R99b3cr0MsARqjujOQKBgCc4
+IOej0qOnitgrbvfwkA5tHaxYRLsUAGRlhzxxqrz+fSWE3F7oieSiEH5WecFEt7Bz
+oz7epnzW/L1bpA3oshEaKCnnjune5KQNkrCJIY2q0JGyLMAVKjMpusgkJtfZIUSg
+gASzZ8fUboGmgrsTjDirLWOKj8UfYp63++454Mg1AoGAYh6Tkh8RxlKzBWaGBg5r
+D9ORLzfPZui0jADyXec18icdJSWgXhIhC6p1rb1SSAMsxsQ51AOR0unIeQ/eYHnU
+wdpaOjVWzXbzKMptPWdh5tBPOK9gIlyH3ppOAVgAWUjuWOJoIkS+fQ3OjP3AEF2U
+JGT4DUmsTBF8RD1/Aqff5Hc=
+-----END PRIVATE KEY-----`
+
+// writeTestAppKey writes a syntactically valid RSA private key so
+// AppKeyFingerprintFromFile accepts it — resolveAppKeyFile requires a
+// fingerprint, not mere existence, before preferring a per-app-id file.
+func writeTestAppKey(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(testRSAPrivateKeyPEM), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// TestResolveAppKeyFileProvisionedGenericPinYieldsToPerAppID is the spoke half
+// of the a-ks-wec2 outage.
+//
+// The provisioning template hardcodes key_file: /secrets/gh-app-key.pem for
+// every App-using hive (saas_provision.go). That value is written by the
+// PLATFORM, not chosen by an operator, and it does not name the App it holds —
+// on the a-ks-wec2 pool it held a key matching NEITHER real App. While
+// resolveAppKeyFile treated it as an explicit override, it short-circuited
+// per-app-id selection, so the hub could correct app_id forever and the spoke
+// would still sign with the wrong key and get "404 Integration not found".
+func TestResolveAppKeyFileProvisionedGenericPinYieldsToPerAppID(t *testing.T) {
+	dir := isolateAppKeyLookup(t)
+
+	origDir := spokeAppKeyDir
+	spokeAppKeyDir = dir
+	t.Cleanup(func() { spokeAppKeyDir = origDir })
+
+	const appID int64 = 5686
+	perApp := filepath.Join(dir, "gh-app-key-5686.pem")
+	writeTestAppKey(t, perApp)
+
+	// Exactly what provisioning writes into hive.yaml.
+	got := resolveAppKeyFile(spokeProvisionedAppKeyPath, "", appID)
+	if got != perApp {
+		t.Errorf("resolveAppKeyFile(%q) = %q, want the per-app-id key %q — "+
+			"the provisioned generic pin must not block per-app-id selection",
+			spokeProvisionedAppKeyPath, got, perApp)
+	}
+}
+
+// TestResolveAppKeyFileRealOperatorOverrideStillWins is the guard: only the two
+// PLATFORM-WRITTEN generic paths yield. A path an operator actually typed (a
+// hive on a third App with a bespoke key location) must still win outright.
+func TestResolveAppKeyFileRealOperatorOverrideStillWins(t *testing.T) {
+	dir := isolateAppKeyLookup(t)
+
+	origDir := spokeAppKeyDir
+	spokeAppKeyDir = dir
+	t.Cleanup(func() { spokeAppKeyDir = origDir })
+
+	const appID int64 = 5686
+	writeTestAppKey(t, filepath.Join(dir, "gh-app-key-5686.pem"))
+
+	bespoke := filepath.Join(dir, "operator-chosen.pem")
+	writeTestAppKey(t, bespoke)
+
+	if got := resolveAppKeyFile(bespoke, "", appID); got != bespoke {
+		t.Errorf("resolveAppKeyFile(%q) = %q, want the operator's own path", bespoke, got)
+	}
+}
+
+// TestResolveAppKeyFileProvisionedPinKeptWithoutPerAppKey makes sure the change
+// cannot BLANK a working setup: with no per-app-id key on disk, the provisioned
+// path is still the best answer available and must be returned unchanged.
+func TestResolveAppKeyFileProvisionedPinKeptWithoutPerAppKey(t *testing.T) {
+	dir := isolateAppKeyLookup(t)
+
+	origDir := spokeAppKeyDir
+	spokeAppKeyDir = dir
+	t.Cleanup(func() { spokeAppKeyDir = origDir })
+
+	if got := resolveAppKeyFile(spokeProvisionedAppKeyPath, "", 5686); got != spokeProvisionedAppKeyPath {
+		t.Errorf("resolveAppKeyFile = %q, want %q kept when no per-app-id key exists",
+			got, spokeProvisionedAppKeyPath)
+	}
+}

--- a/v2/pkg/hub/assign_forge_identity_test.go
+++ b/v2/pkg/hub/assign_forge_identity_test.go
@@ -1,0 +1,200 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestAssignTimeAppIdentityUnregisteredGHECluster reproduces the a-ks-wec2
+// outage shape: five spokes assigned onto a GitHub Enterprise cluster that is
+// ABSENT from clusters.json sat on config.PlaceholderAppID in dashboard-only
+// mode, because appIdentityForHive returns nil for an unknown cluster before
+// any App logic runs and assign had no other source of identity.
+//
+// The hive's elected forge is a fact independent of the cluster registry, and
+// the GHE App is a build constant, so assign must still answer with the full
+// identity set.
+func TestAssignTimeAppIdentityUnregisteredGHECluster(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.clusters = map[string]ClusterConfig{
+		"hive-oke": {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
+	}
+
+	h := &SaaSHive{
+		ID:         "hosted-available-akswec2-260810-hvam",
+		Owner:      "clubanderson",
+		Org:        "polaris-staging",
+		Status:     "active",
+		ClusterID:  "a-ks-wec2",
+		GitHubHost: "github.ibm.com",
+	}
+
+	cfg := srv.assignTimeAppIdentity(h)
+	if cfg == nil {
+		t.Fatal("assignTimeAppIdentity returned nil for a GHE hive on an unregistered cluster: " +
+			"the spoke keeps the placeholder app_id and never authenticates")
+	}
+	if cfg.AppID != config.EnterpriseGitHubAppID {
+		t.Errorf("AppID = %d, want the enterprise App %d", cfg.AppID, config.EnterpriseGitHubAppID)
+	}
+	if cfg.AppID == config.PlaceholderAppID {
+		t.Error("assign must never deliver the placeholder sentinel as a real App ID")
+	}
+	// An App ID presented to the wrong forge returns "404 Integration not
+	// found", so the forge URLs must ride along with it.
+	if cfg.APIURL != config.EnterpriseGitHubAPIURL {
+		t.Errorf("APIURL = %q, want %q", cfg.APIURL, config.EnterpriseGitHubAPIURL)
+	}
+	if cfg.BaseURL != config.EnterpriseGitHubBaseURL {
+		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, config.EnterpriseGitHubBaseURL)
+	}
+	if cfg.AppSlug != config.EnterpriseGitHubAppSlug {
+		t.Errorf("AppSlug = %q, want %q", cfg.AppSlug, config.EnterpriseGitHubAppSlug)
+	}
+	// installation_id is discovered by the spoke once it can authenticate as
+	// the App; a non-zero value here would pin a guess, and requiring one is
+	// what made the automatic path unreachable.
+	if cfg.InstallationID != 0 {
+		t.Errorf("InstallationID = %d, want 0 (spoke auto-discovers it)", cfg.InstallationID)
+	}
+}
+
+// TestAssignTimeAppIdentityPublicForge covers the other build-constant forge and
+// asserts the public case does NOT pin forge URLs — the spoke already defaults
+// to public github.com, so writing them would state a value as an override.
+func TestAssignTimeAppIdentityPublicForge(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.clusters = map[string]ClusterConfig{}
+
+	h := &SaaSHive{
+		ID:         "hosted-public-1",
+		Owner:      "clubanderson",
+		Org:        "kubestellar",
+		Status:     "active",
+		ClusterID:  "not-registered",
+		GitHubHost: "github.com",
+	}
+
+	cfg := srv.assignTimeAppIdentity(h)
+	if cfg == nil {
+		t.Fatal("assignTimeAppIdentity returned nil for a public-github hive")
+	}
+	if cfg.AppID != config.PublicGitHubAppID {
+		t.Errorf("AppID = %d, want the public App %d", cfg.AppID, config.PublicGitHubAppID)
+	}
+	if cfg.APIURL != "" || cfg.BaseURL != "" {
+		t.Errorf("public forge must not pin URLs, got APIURL=%q BaseURL=%q", cfg.APIURL, cfg.BaseURL)
+	}
+}
+
+// TestAssignTimeAppIdentityUnknownForgeSaysNothing guards the invention risk:
+// a forge this build cannot name must yield nil so assign leaves the spoke
+// alone rather than guessing an App ID that would 404 against that host.
+func TestAssignTimeAppIdentityUnknownForgeSaysNothing(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.clusters = map[string]ClusterConfig{}
+
+	h := &SaaSHive{
+		ID:         "hosted-thirdparty-1",
+		Owner:      "someone",
+		Org:        "acme",
+		Status:     "active",
+		ClusterID:  "not-registered",
+		GitHubHost: "github.acme.example",
+	}
+
+	if cfg := srv.assignTimeAppIdentity(h); cfg != nil {
+		t.Errorf("expected nil for an unnameable forge, got AppID=%d", cfg.AppID)
+	}
+}
+
+// TestAssignTimeAppIdentityRegisteredClusterWins keeps the cluster registry
+// authoritative when it IS present: the builtin constants are a fallback for an
+// unregistered cluster, never an override of a configured App.
+func TestAssignTimeAppIdentityRegisteredClusterWins(t *testing.T) {
+	const customAppID int64 = 4242
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.clusters = map[string]ClusterConfig{
+		"custom": {
+			ID:            "custom",
+			Domain:        "custom.example",
+			GitHubAppID:   customAppID,
+			GitHubAppSlug: "custom-app",
+			GitHubBaseURL: "https://github.ibm.com",
+			GitHubAPIURL:  "https://github.ibm.com/api/v3",
+		},
+	}
+
+	h := &SaaSHive{
+		ID:         "hosted-custom-1",
+		Owner:      "clubanderson",
+		Org:        "team",
+		Status:     "active",
+		ClusterID:  "custom",
+		GitHubHost: "github.ibm.com",
+	}
+
+	cfg := srv.assignTimeAppIdentity(h)
+	if cfg == nil {
+		t.Fatal("assignTimeAppIdentity returned nil for a registered cluster")
+	}
+	if cfg.AppID != customAppID {
+		t.Errorf("AppID = %d, want the cluster's configured App %d (builtin must not override)", cfg.AppID, customAppID)
+	}
+}
+
+// TestAppIdentityForHiveUnregisteredClusterRepairs covers the ONGOING repair
+// path, not just assign. Delivery at assign is a single pending push consumed
+// by one heartbeat; if it is missed, the every-beat reconcile is what must
+// still converge. That reconcile runs through appIdentityForHive, which
+// returned nil for an unknown cluster and produced the misleading
+// "cluster names no github app — cannot repair" warning forever.
+func TestAppIdentityForHiveUnregisteredClusterRepairs(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.clusters = map[string]ClusterConfig{
+		"hive-oke": {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
+	}
+
+	h := &SaaSHive{
+		ID:         "hosted-available-akswec2-260810-hvam",
+		Owner:      "clubanderson",
+		Org:        "polaris-staging",
+		Status:     "active",
+		ClusterID:  "a-ks-wec2",
+		GitHubHost: "github.ibm.com",
+	}
+
+	identity := srv.appIdentityForHive(h, clusterIDForHive(h))
+	if identity == nil {
+		t.Fatal("appIdentityForHive returned nil for a GHE hive on an unregistered cluster: " +
+			"the every-beat repair can never converge and the spoke keeps the placeholder")
+	}
+	if identity.AppID != config.EnterpriseGitHubAppID {
+		t.Errorf("AppID = %d, want %d", identity.AppID, config.EnterpriseGitHubAppID)
+	}
+	if identity.APIURL != config.EnterpriseGitHubAPIURL {
+		t.Errorf("APIURL = %q, want %q", identity.APIURL, config.EnterpriseGitHubAPIURL)
+	}
+}
+
+// TestAppIdentityForHiveUnregisteredClusterUnclaimedSaysNothing is the guard on
+// the change above: the fallback keys off HIVE INTENT only. An unclaimed
+// placeholder has elected nothing, so inferring a forge for it would be exactly
+// the 2026-08-05 mistake (public hives flipped onto the GHE App).
+func TestAppIdentityForHiveUnregisteredClusterUnclaimedSaysNothing(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.clusters = map[string]ClusterConfig{}
+
+	h := &SaaSHive{
+		ID:        "hosted-available-1",
+		Owner:     hubAdminUsername,
+		Status:    statusAvailable,
+		ClusterID: "a-ks-wec2",
+	}
+
+	if identity := srv.appIdentityForHive(h, clusterIDForHive(h)); identity != nil {
+		t.Errorf("unclaimed placeholder on an unregistered cluster must yield nil, got AppID=%d", identity.AppID)
+	}
+}

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -258,7 +258,19 @@ func (s *HubServer) appIdentityForHive(h *SaaSHive, clusterID string) *clusterAp
 	}
 	c, ok := s.clusters[clusterID]
 	if !ok {
-		return nil
+		// UNREGISTERED CLUSTER. Returning nil here meant a hive whose cluster is
+		// missing from clusters.json got no answer at all, beat after beat —
+		// the hub logged "cluster names no github app — cannot repair" and
+		// offered a remedy (set github_app_id on the cluster) for a cluster
+		// entry that does not exist. Five a-ks-wec2 spokes stayed on
+		// config.PlaceholderAppID that way.
+		//
+		// A hive's ELECTED forge does not depend on the cluster registry, and
+		// the two build-constant Apps are per-forge facts, so this is the one
+		// answer that is still knowable. It is deliberately narrow: hive
+		// intent only (an unclaimed placeholder elects nothing and still gets
+		// nil), and only forges this build can name.
+		return s.builtinIdentityForForge(electedForgeForHive(h, nil))
 	}
 	resolved := ResolveHiveIdentityInFleet(h, &c, s.forgeAppsAcrossFleet())
 	// A hive that ELECTED a forge no cluster entry names an App on still has a
@@ -315,6 +327,90 @@ func (s *HubServer) appIdentityForHive(h *SaaSHive, clusterID string) *clusterAp
 	}
 	identity.PrivateKey = pem
 	identity.Fingerprint = fp
+	return identity
+}
+
+// assignTimeAppIdentity resolves the COMPLETE forge identity set an assigning
+// hive should be given — app_id, app_slug, base_url and api_url, plus the key
+// when this hub holds one.
+//
+// WHY ASSIGN NEEDS ITS OWN ENTRY POINT
+//
+// Assign already knows the forge: handleAssignHive records h.GitHubHost from
+// the requested org before it reaches the credential step. Yet until now the
+// only way a spoke received an App at assign was an admin pasting app_id,
+// installation_id AND a PEM into the dialog — all three, or nothing was sent.
+// Leave one blank and the hive kept config.PlaceholderAppID, which is how five
+// spokes on a-ks-wec2 sat in dashboard-only mode carrying 999999999 while the
+// hub knew their forge was github.ibm.com and held that App's key the whole
+// time.
+//
+// installation_id is deliberately NOT part of the answer. The spoke discovers
+// it itself once it can authenticate as the App ("github app installation
+// auto-discovered"), so requiring an operator to supply a value the spoke
+// derives is what made the automatic path unreachable. A zero installation in
+// HeartbeatGitHubAppConfig means "not speaking to this field", so omitting it
+// can never blank a working one.
+//
+// Returns nil when the forge is unknown or names no App this hub can identify —
+// "say nothing" rather than guess, so assign never invents an identity.
+func (s *HubServer) assignTimeAppIdentity(h *SaaSHive) *HeartbeatGitHubAppConfig {
+	if s == nil || h == nil {
+		return nil
+	}
+	identity := s.appIdentityForHive(h, clusterIDForHive(h))
+	if identity == nil {
+		// The hive's cluster is absent from clusters.json (or names no App on
+		// the elected forge), so appIdentityForHive returned before any App
+		// logic. The elected forge is still a fact, and the two build-constant
+		// Apps are per-forge constants — positive knowledge, not invention.
+		identity = s.builtinIdentityForForge(electedForgeForHive(h, s.clusterForHive(h)))
+	}
+	if identity == nil || identity.AppID == 0 {
+		return nil
+	}
+	cfg := &HeartbeatGitHubAppConfig{
+		AppID:   identity.AppID,
+		AppSlug: identity.AppSlug,
+		APIURL:  identity.APIURL,
+		BaseURL: identity.BaseURL,
+	}
+	// Only ever ride a key we actually hold: an empty private_key means "leave
+	// the spoke's key alone", and the spoke prefers its own per-app-id file
+	// (/data/gh-app-key-<app_id>.pem) when it already has the right one.
+	if identity.HasKey() {
+		cfg.PrivateKey = identity.PrivateKey
+	}
+	return cfg
+}
+
+// builtinIdentityForForge builds the identity set for a forge whose App is a
+// build constant, filling in the forge URLs that make an app_id usable. An App
+// ID presented to the wrong forge returns "404 Integration not found", so the
+// URLs travel with it rather than being left for a later repair.
+func (s *HubServer) builtinIdentityForForge(forge string) *clusterAppIdentity {
+	if s == nil || forge == "" {
+		return nil
+	}
+	appID, slug := builtinAppOfForge(forge)
+	if appID == 0 {
+		return nil
+	}
+	identity := &clusterAppIdentity{AppID: appID, AppSlug: slug, Forge: forge}
+	// Public github.com is the spoke's default forge, so its URLs stay empty —
+	// writing them would pin a value the spoke already assumes. Enterprise must
+	// be stated explicitly.
+	if !isPublicForgeHost(forge) {
+		identity.BaseURL = config.EnterpriseGitHubBaseURL
+		identity.APIURL = config.EnterpriseGitHubAPIURL
+	}
+	if k, found := s.appKeysByAppID()[appID]; found && k.PrivateKey != "" {
+		identity.PrivateKey = k.PrivateKey
+		identity.Fingerprint = k.Fingerprint
+		if identity.AppSlug == "" {
+			identity.AppSlug = k.AppSlug
+		}
+	}
 	return identity
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7294,6 +7294,37 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		appDelivered = true
 	}
 
+	// NO CREDS PASTED: derive the identity from the forge we already know.
+	//
+	// The three-way AND above is an ADMIN OVERRIDE, not the normal path — it
+	// fires only when someone hand-carries an app_id, an installation_id and a
+	// PEM into the dialog. Every other assignment fell through it silently and
+	// left the hive on config.PlaceholderAppID, even though h.GitHubHost was
+	// resolved a hundred lines earlier and the hub holds that forge's App key.
+	// Deriving here is what makes "assign knows the forge, so assign sets the
+	// forge identity" true in code rather than only in intent.
+	if !appDelivered {
+		if appCfg := s.assignTimeAppIdentity(h); appCfg != nil {
+			s.storePendingGitHubAppConfig(hiveID, appCfg)
+			appDelivered = true
+			s.logger.Info("assign: derived github app identity from the hive's forge",
+				"hive_id", hiveID,
+				"forge", h.GitHubHost,
+				"app_id", appCfg.AppID,
+				"app_slug", appCfg.AppSlug,
+				"api_url", appCfg.APIURL,
+				"key_delivered", appCfg.PrivateKey != "",
+			)
+		} else {
+			s.logger.Warn("assign: no github app identity for this hive's forge — spoke keeps the placeholder app_id and starts in dashboard-only mode",
+				"hive_id", hiveID,
+				"forge", h.GitHubHost,
+				"cluster", clusterIDForHive(h),
+				"remedy", "name an App for this forge in clusters.json, or supply app_id/installation_id/app_private_key on the assign request",
+			)
+		}
+	}
+
 	// The project config itself is delivered by handleHeartbeat via
 	// projectConfigForHiveID on the next beat — it keeps sending until the spoke
 	// reports the matching project. No hub→spoke push or kubectl is needed, so


### PR DESCRIPTION
🐛 Set the full forge identity at assign, and let it converge

Five spokes on a-ks-wec2 sat in dashboard-only mode carrying the
placeholder app_id 999999999 while the hub knew their forge was
github.ibm.com and held that App's key the whole time. Three
independent gaps had to line up.

1. ASSIGN NEVER DERIVED THE IDENTITY.

handleAssignHive delivered App credentials only when an admin pasted
app_id AND installation_id AND a PEM into the dialog. Any blank field
and the hive silently kept the placeholder — even though h.GitHubHost
is resolved a hundred lines earlier and builtinAppOfForge() answers
for that host. assignTimeAppIdentity now derives the COMPLETE set
(app_id, app_slug, base_url, api_url) from the forge assign already
knows, with the pasted values still winning as an admin override.

installation_id is deliberately not part of the answer: the spoke
discovers it once it can authenticate ("github app installation
auto-discovered"), so requiring an operator to supply a value the
spoke derives is what made the automatic path unreachable. Zero means
"not speaking to this field", so omitting it cannot blank a working one.

2. THE ONGOING REPAIR COULD NOT CONVERGE.

appIdentityForHive returned nil for a cluster absent from
clusters.json before any App logic ran, so the every-beat reconcile
logged "cluster names no github app — cannot repair" and offered a
remedy (set github_app_id on the cluster) for a cluster entry that
does not exist. A hive's ELECTED forge does not depend on the cluster
registry, so that case now falls back to the build-constant App for
the elected forge. Narrow by construction: hive intent only, so an
unclaimed placeholder still yields nil and cannot be flipped onto the
wrong App — the 2026-08-05 failure mode.

Delivery at assign is one pending push consumed by a single heartbeat;
without this, a missed beat meant the hive stayed broken forever.

3. THE SPOKE IGNORED THE CORRECTED APP ID.

The provisioning template hardcodes key_file: /secrets/gh-app-key.pem
for every App-using hive, but resolveAppKeyFile treated only the /data
generic path as platform-written. The /secrets pin was honoured as an
operator override and short-circuited per-app-id selection, so the hub
could correct app_id forever while the spoke kept signing with the
provisioned key — which on this pool matched NEITHER real App. Both
platform-written generic paths now yield to a per-app-id key; a path an
operator actually typed still wins outright.

Verified on the live fleet: both assigned hives now mint real GHE
tokens (installation 43019 polaris-staging, 43311 z-innersource), and
every spoke already carried gh-app-key-5686.pem on its PVC, so no key
material needs to ride the wire.

Each change was confirmed to fail its test when reverted.
