### PR TITLE
🔒 fix(v2): restore CWE-59 symlink guard dropped by #3487 (coverage RED on v2)

### DIFF
--- a/v2/pkg/agent/permissions_sharedrepo_test.go
+++ b/v2/pkg/agent/permissions_sharedrepo_test.go
@@ -61,6 +61,37 @@ func TestSharedRepoClonesFindsOnlyGitTrees(t *testing.T) {
 	}
 }
 
+// TestSharedRepoClonesRejectsSymlinks pins the CWE-59 guard on the discovery
+// path: a symlinked child (even one whose target is a real git repo) must NOT be
+// returned, because the widening walk would otherwise follow it out of the shared
+// HOME. This mirrors the fixEntry symlink guard for the new scan.
+func TestSharedRepoClonesRejectsSymlinks(t *testing.T) {
+	root := t.TempDir()
+	origParent := SharedRepoParent
+	SharedRepoParent = root
+	t.Cleanup(func() { SharedRepoParent = origParent })
+
+	// A real repo OUTSIDE the parent, then a symlink to it inside the parent.
+	outside := t.TempDir()
+	realRepo := mkRepoDir(t, outside, "api-server")
+	link := filepath.Join(root, "api-server")
+	if err := os.Symlink(realRepo, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Also plant a repo whose .git is itself a symlink — must be skipped too.
+	sneaky := filepath.Join(root, "ui")
+	if err := os.MkdirAll(sneaky, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "api-server", ".git"), filepath.Join(sneaky, ".git")); err != nil {
+		t.Fatalf("symlink .git: %v", err)
+	}
+
+	if got := sharedRepoClones(); len(got) != 0 {
+		t.Errorf("sharedRepoClones() = %v, want empty: symlinked entries must be skipped (CWE-59)", got)
+	}
+}
+
 // TestSharedRepoClonesMissingParentIsSafe verifies the best-effort contract: an
 // absent parent yields nil, never an error or panic (the watcher must never
 // abort a tick).

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -83,11 +83,11 @@ var WatchedHomeDirs = []string{
 // "Permission denied", so ISSUES_AND_PRS agents can open issues but never PRs.
 //
 // The watcher self-heals this the same way it does .bob: it finds each git-repo
-// directory directly under SharedRepoParent (a child containing .git) and walks
-// it, bringing dirs to >=0770 and files to >=0660 for the shared node group. We
-// scan only repo children — not all of /data/home — to avoid walking the large
-// dotdir tree (.cache, .local, node_modules) every tick; those are already
-// covered by their own WatchedHomeDirs entries.
+// directory directly under SharedRepoParent (a real, non-symlink child that
+// holds a .git) and walks it, bringing dirs to >=0770 and files to >=0660 for
+// the shared node group. We scan only repo children — not all of /data/home — to
+// avoid walking the large dotdir tree (.cache, .local, node_modules) every tick;
+// those are already covered by their own WatchedHomeDirs entries.
 //
 // A var (not const) so tests can point the scan at a writable temp tree, matching
 // GooseLogsDir/WatchedHomeDirs. Production value is unchanged.
@@ -151,11 +151,18 @@ func ensureWatchedDirs(logger *slog.Logger) {
 }
 
 // sharedRepoClones returns the git-repo directories directly under
-// SharedRepoParent — a child dir that itself contains a .git entry. These are
-// the project-repo working trees agents share (and symlink into their
+// SharedRepoParent — a real (non-symlink) child dir whose tree holds a .git.
+// These are the project-repo working trees agents share (and symlink into their
 // workspaces). Non-repo children (dotdirs, node caches) are skipped so we don't
-// walk the whole shared HOME tree on every tick. Never errors: an unreadable
-// parent yields an empty list, matching the watcher's best-effort contract.
+// walk the whole shared HOME tree on every tick.
+//
+// SECURITY (CWE-59): children are inspected with os.Lstat and any symlink is
+// skipped, so a planted link under /data/home can never redirect the widening
+// walk onto a path outside the shared HOME — mirroring the symlink guard in
+// fixEntry. Only a genuine directory (created by `git clone`) is returned.
+//
+// Never errors: an unreadable parent yields an empty list, matching the
+// watcher's best-effort contract (it must never abort a tick).
 func sharedRepoClones() []string {
 	entries, err := os.ReadDir(SharedRepoParent)
 	if err != nil {
@@ -163,21 +170,22 @@ func sharedRepoClones() []string {
 	}
 	var repos []string
 	for _, e := range entries {
-		// Match real subdirectories only. A repo child is a dir (or a dir
-		// symlink) whose tree holds a .git — checking for .git avoids widening
-		// unrelated shared state like .cache or .config here (those have their
-		// own WatchedHomeDirs entries).
 		name := e.Name()
 		if len(name) > 0 && name[0] == '.' {
 			continue // skip dotdirs — covered by WatchedHomeDirs
 		}
 		repoPath := filepath.Join(SharedRepoParent, name)
-		info, statErr := os.Stat(repoPath) // Stat (not Lstat) so a dir symlink resolves
-		if statErr != nil || !info.IsDir() {
+		// Lstat (not Stat) so a symlinked child is seen AS a link and rejected —
+		// we must never follow a link out of the shared HOME (CWE-59).
+		fi, statErr := os.Lstat(repoPath)
+		if statErr != nil || fi.Mode()&os.ModeSymlink != 0 || !fi.IsDir() {
 			continue
 		}
-		if _, gitErr := os.Stat(filepath.Join(repoPath, ".git")); gitErr != nil {
-			continue // not a git working tree
+		// A real dir that holds a .git is a clone. Lstat the .git too so a
+		// planted ".git" symlink can't be used to smuggle a non-repo dir in.
+		gitFI, gitErr := os.Lstat(filepath.Join(repoPath, ".git"))
+		if gitErr != nil || gitFI.Mode()&os.ModeSymlink != 0 {
+			continue
 		}
 		repos = append(repos, repoPath)
 	}
@@ -190,8 +198,8 @@ func sharedRepoClones() []string {
 func fixPermissions(logger *slog.Logger) {
 	// Widen the shared project-repo clones so agent UIDs (group node) can
 	// write/commit/push and therefore open PRs. fixEntry already brings each
-	// dir to >=0770 and each file to >=0660 for the node group, which is
-	// exactly what the clone (created 0755 dev:node) is missing.
+	// dir to >=0770 and each file to >=0660 for the node group (and skips
+	// symlinks), which is exactly what the clone (created 0755 dev:node) needs.
 	roots := append([]string{}, WatchedHomeDirs...)
 	roots = append(roots, sharedRepoClones()...)
 	for _, root := range roots {
@@ -226,6 +234,17 @@ func fixPermissions(logger *slog.Logger) {
 // fixEntry checks a single file or directory and corrects ownership/mode
 // if needed.
 func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
+	// SECURITY (audit F12, CWE-59): never act on a symlink. This walks the
+	// agent HOME dirs, which agents can write to, and both os.Chmod and
+	// os.Chown FOLLOW symlinks — so a planted link would redirect this
+	// repair loop onto a file outside the tree. filepath.Walk reports
+	// entries via Lstat, so the link is visible as a link here; the ownership
+	// check below reads the LINK's metadata, not the target's, and so cannot
+	// be relied on to catch this. Mirrors ensureWorldWritable's symlink skip.
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+
 	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
 		return


### PR DESCRIPTION
## Urgent — v2 is currently broken

#3487 (merged as `d33384b2`) was authored on a **stale base**: its `permissions_watcher.go` was copied from an older checkout, which silently **removed the `fixEntry` symlink guard added in #3432**. This:

1. **Reintroduces a CWE-59 symlink-following hole** — `os.Chmod`/`os.Chown` follow symlinks, so the watcher's repair loop can be redirected onto an arbitrary path outside the shared HOME by a planted link.
2. **Turns the coverage gate RED on v2 right now** — `TestFixEntrySkipsSymlinks`, `TestFixEntrySkipsRelativeSymlinkToOutsideRoot`, and `TestFixEntrySkipsSymlinkToDirectory` all FAIL.

(This is my regression — #3487 should never have merged with the coverage check failing; it was auto-merged before I could push the corrected commit.)

## Fix
Restores the guard and re-implements the shared-repo-clone widening **on top of it**, so v2 keeps BOTH properties:

1. **Security**: `fixEntry` early-returns on any `os.ModeSymlink` entry.
2. **The workspace-write fix (intent of #3487)**: `sharedRepoClones()` discovers project-repo clones under `/data/home` so agents can commit + open PRs — but now uses `os.Lstat` and **skips symlinked children** (and a symlinked `.git`), so the new scan can't smuggle a link out of the shared HOME either.

## Tests
`go test ./pkg/agent/ -run 'TestFixEntrySkips|TestSharedRepoClones|TestFixPermissionsWidens'` — **all PASS**, including the three symlink-guard tests currently red on v2, plus a new `TestSharedRepoClonesRejectsSymlinks` covering the CWE-59 guard on the new scan path.

## Lesson
Always branch fixes from fresh `origin/<branch>`; never copy a whole source file from an older checkout over a newer one.