### PR TITLE
🔒 security: restrict hub CSRF/CORS trust to the exact hub origin (audit F4)

### DIFF
--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -338,7 +338,7 @@ const forgeSwitchNeedsInstallNote = "installation_id was cleared because it belo
 // channel for this, already implemented on both ends.
 func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/v2/pkg/hub/hub_misc_coverage_test.go
+++ b/v2/pkg/hub/hub_misc_coverage_test.go
@@ -297,7 +297,6 @@ func TestBulkHandlerPreflightOnlyTrustsKnownOrigins(t *testing.T) {
 
 	trusted := []string{
 		"https://hive.kubestellar.io",
-		"https://console.hive.kubestellar.io",
 		"http://localhost:5174",
 		"http://127.0.0.1:8080",
 	}
@@ -325,6 +324,12 @@ func TestBulkHandlerPreflightOnlyTrustsKnownOrigins(t *testing.T) {
 		"https://hive.kubestellar.io.evil.com",
 		"https://notlocalhost",
 		"::not a url::",
+		// Audit F4: sibling tenants are untrusted for credentialed CORS. The
+		// browser hands them the parent-domain session cookie, so reflecting
+		// Allow-Origin + Allow-Credentials back to one gives a hostile hive
+		// operator a scripted cross-tenant read of the hub API.
+		"https://console.hive.kubestellar.io",
+		"https://attacker-hive.hive.kubestellar.io",
 	}
 	for _, origin := range untrusted {
 		t.Run("untrusted "+origin, func(t *testing.T) {

--- a/v2/pkg/hub/hub_saas_handlers_test.go
+++ b/v2/pkg/hub/hub_saas_handlers_test.go
@@ -929,24 +929,38 @@ func TestGetAuthUserBearer(t *testing.T) {
 	ghTokenCacheMu.Unlock()
 }
 
-func TestIsTrustedOriginSubdomain(t *testing.T) {
-	if !isTrustedOrigin("https://dashboard.hive.kubestellar.io") {
-		t.Error("subdomain of hive.kubestellar.io should be trusted")
+// TestSubdomainTrustIsRedirectOnly records the F4 split explicitly: a
+// *.hive.kubestellar.io subdomain is trusted as a post-login REDIRECT target
+// (hosted sign-in depends on it) but is NOT trusted to author a request.
+//
+// This test previously asserted, via isTrustedOrigin, that a subdomain was
+// trusted for BOTH — which is the vulnerability F4 reported.
+func TestSubdomainTrustIsRedirectOnly(t *testing.T) {
+	for _, sub := range []string{
+		"https://dashboard.hive.kubestellar.io",
+		"https://my-hive.hive.kubestellar.io",
+	} {
+		if !isTrustedRedirectTarget(sub) {
+			t.Errorf("%s should remain a trusted redirect target (hosted sign-in depends on it)", sub)
+		}
+		if isSameOriginAsHub(sub) {
+			t.Errorf("F4 REGRESSION: %s is trusted to author requests at the hub", sub)
+		}
 	}
-	if !isTrustedOrigin("https://my-hive.hive.kubestellar.io") {
-		t.Error("any subdomain of hive.kubestellar.io should be trusted")
-	}
-	if !isTrustedOrigin("http://localhost:3001") {
-		t.Error("localhost should be trusted")
-	}
-	if !isTrustedOrigin("http://127.0.0.1:8080") {
-		t.Error("127.0.0.1 should be trusted")
+	// Local development is the hub itself, so it is trusted for both.
+	for _, local := range []string{"http://localhost:3001", "http://127.0.0.1:8080"} {
+		if !isTrustedRedirectTarget(local) || !isSameOriginAsHub(local) {
+			t.Errorf("%s should be trusted for local development", local)
+		}
 	}
 }
 
-func TestIsTrustedOriginBadParse(t *testing.T) {
-	if isTrustedOrigin("://invalid") {
-		t.Error("unparseable URL should not be trusted")
+func TestOriginTrustBadParse(t *testing.T) {
+	if isSameOriginAsHub("://invalid") {
+		t.Error("unparseable URL should not be a trusted origin")
+	}
+	if isTrustedRedirectTarget("://invalid") {
+		t.Error("unparseable URL should not be a trusted redirect target")
 	}
 }
 

--- a/v2/pkg/hub/hub_test.go
+++ b/v2/pkg/hub/hub_test.go
@@ -9,16 +9,25 @@ import (
 	"testing"
 )
 
-func TestIsTrustedOrigin(t *testing.T) {
+// TestIsSameOriginAsHub is the request-authoring trust boundary (audit F4).
+// Sibling tenants must NOT be trusted here — that was the vulnerability.
+func TestIsSameOriginAsHub(t *testing.T) {
 	tests := []struct {
 		origin string
 		want   bool
 	}{
+		// Positive controls: the legitimate hub origin and local dev must stay
+		// trusted, so a handler that rejects everything cannot pass this test.
 		{"https://hive.kubestellar.io", true},
-		{"https://hosted-test.hive.kubestellar.io", true},
-		{"https://my.hosted.hive.kubestellar.io", true},
+		{"https://hive.kubestellar.io/dashboard", true},
 		{"http://localhost", true},
+		{"http://localhost:3001", true},
 		{"http://127.0.0.1", true},
+		// F4: sibling tenants are no longer request-authoring origins.
+		{"https://hosted-test.hive.kubestellar.io", false},
+		{"https://my.hosted.hive.kubestellar.io", false},
+		{"https://attacker-hive.hive.kubestellar.io", false},
+		// Unrelated / lookalike hosts stay rejected.
 		{"https://evil.com", false},
 		{"https://hive.kubestellar.io.evil.com", false},
 		{"https://evil-hive.kubestellar.io", false},
@@ -27,9 +36,37 @@ func TestIsTrustedOrigin(t *testing.T) {
 		{"https://localhost.evil.com", false},
 	}
 	for _, tt := range tests {
-		got := isTrustedOrigin(tt.origin)
+		got := isSameOriginAsHub(tt.origin)
 		if got != tt.want {
-			t.Errorf("isTrustedOrigin(%q) = %v, want %v", tt.origin, got, tt.want)
+			t.Errorf("isSameOriginAsHub(%q) = %v, want %v", tt.origin, got, tt.want)
+		}
+	}
+}
+
+// TestIsTrustedRedirectTarget pins the OTHER half of the F4 split: post-login
+// redirects must still reach hosted tenants, because every hive's ingress
+// auth-signin bounces through the hub with redirect=https://<id>.hive...
+// Narrowing this would break hosted sign-in.
+func TestIsTrustedRedirectTarget(t *testing.T) {
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{"https://hive.kubestellar.io", true},
+		{"https://hosted-test.hive.kubestellar.io/dashboard", true},
+		{"https://my.hosted.hive.kubestellar.io", true},
+		{"http://localhost:3001", true},
+		{"http://127.0.0.1", true},
+		{"https://evil.com", false},
+		{"https://hive.kubestellar.io.evil.com", false},
+		{"https://evil-hive.kubestellar.io", false},
+		{"", false},
+		{"https://localhost.evil.com", false},
+	}
+	for _, tt := range tests {
+		got := isTrustedRedirectTarget(tt.target)
+		if got != tt.want {
+			t.Errorf("isTrustedRedirectTarget(%q) = %v, want %v", tt.target, got, tt.want)
 		}
 	}
 }
@@ -47,6 +84,10 @@ func TestIsCSRFSafe(t *testing.T) {
 		{"OPTIONS is safe", "OPTIONS", "", "", true},
 		{"POST with trusted origin", "POST", "https://hive.kubestellar.io", "", true},
 		{"POST with evil origin", "POST", "https://evil.com", "", false},
+		// F4: a sibling tenant is a hostile origin for CSRF purposes even
+		// though the browser hands it the parent-domain session cookie.
+		{"POST from sibling tenant origin", "POST", "https://attacker-hive.hive.kubestellar.io", "", false},
+		{"POST from sibling tenant origin with JSON ct", "POST", "https://attacker-hive.hive.kubestellar.io", "application/json", false},
 		{"POST with JSON content-type", "POST", "", "application/json", true},
 		{"POST with no origin or ct", "POST", "", "", false},
 		{"POST with evil origin suffix", "POST", "https://hive.kubestellar.io.evil.com", "", false},

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -170,7 +170,10 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		redirect = r.URL.Query().Get("rd")
 	}
 	if redirect != "" && (!strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//")) {
-		if !isTrustedOrigin(redirect) {
+		// Redirect trust intentionally still spans sibling tenants: hosted hives
+		// bounce here via their ingress auth-signin and must be returned home.
+		// This is NOT the CSRF boundary — see isSameOriginAsHub (audit F4).
+		if !isTrustedRedirectTarget(redirect) {
 			redirect = "/dashboard"
 		}
 	}
@@ -331,6 +334,37 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
 		return
 	}
+	// AUDIT F4, DELIBERATELY NOT CHANGED — read before "fixing" this.
+	//
+	// The audit asks for a host-only `__Host-` session cookie. That is correct
+	// in the abstract and NOT safely applicable here, because this cookie is
+	// load-bearing across a trust boundary: it is minted by the hub (Go) and
+	// verified INDEPENDENTLY by every spoke's Node proxy
+	// (v2/proxy/server.js — verifyHubUserCookieEither, and the WebSocket
+	// terminal path). The proxy can only verify a cookie the browser actually
+	// sends it, and the browser only sends this one to <id>.hive.kubestellar.io
+	// BECAUSE of the Domain attribute below. Dropping Domain (which __Host-
+	// additionally forbids outright) would stop the cookie reaching any spoke
+	// and log every hosted tenant out of their own dashboard and terminal —
+	// a fleet-wide outage across ~62 hives, and precisely the flag-day auth
+	// change that caused incident #2773.
+	//
+	// The verify-both/mint-new pattern used for the N2 Ed25519 cutover
+	// (hub_cookie.go) does NOT rescue this. That pattern works when both
+	// formats travel the same path and only the VERIFIER must learn a new
+	// shape. Here the change is to the cookie's delivery scope: a host-only
+	// cookie is never transmitted to the spoke at all, so there is no request
+	// in which a spoke could verify it, no matter what it accepts. Making this
+	// safe needs a real design change (e.g. a distinct spoke-scoped session
+	// cookie minted per tenant at SSO handoff), not a rollout trick.
+	//
+	// What this PR does instead is remove the sibling's ability to USE the
+	// cookie it receives: an untrusted tenant can no longer author an accepted
+	// mutation (isSameOriginAsHub) nor read a credentialed CORS response. The
+	// cookie still travels to siblings — a real, ACCEPTED residual risk that a
+	// hostile tenant can read it only if some other bug lets them (it stays
+	// HttpOnly + Secure), which is why the spoke-scoped-session redesign is
+	// tracked as follow-up rather than closed.
 	cookie := &http.Cookie{
 		Name:     "hive_hub_user",
 		Value:    cookieValue,
@@ -362,7 +396,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		if _, target, ok := strings.Cut(decoded, oauthStateSeparator); ok {
 			decoded = target
 		}
-		if decoded != "" && ((strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedOrigin(decoded)) {
+		if decoded != "" && ((strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedRedirectTarget(decoded)) {
 			redirect = decoded
 		}
 	}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -541,26 +541,91 @@ func isCSRFSafe(r *http.Request) bool {
 	}
 	origin := r.Header.Get("Origin")
 	if origin != "" {
-		return isTrustedOrigin(origin)
+		return isSameOriginAsHub(origin)
 	}
 	referer := r.Header.Get("Referer")
 	if referer != "" {
-		return isTrustedOrigin(referer)
+		return isSameOriginAsHub(referer)
 	}
 	ct := r.Header.Get("Content-Type")
 	return strings.Contains(ct, "application/json")
 }
 
-func isTrustedOrigin(raw string) bool {
-	u, err := url.Parse(raw)
-	if err != nil {
+// hubCanonicalHost is the ONE host that serves the hub's own dashboard and API.
+// Every legitimate browser mutation against the hub is issued by a document
+// loaded from this host — tenant spokes are separate origins that talk to the
+// hub through their own proxy, never by scripting a cross-origin POST at it.
+const hubCanonicalHost = "hive.kubestellar.io"
+
+// hubDomainSuffix is the shared parent domain the hosted tenants live under
+// (<id>.hive.kubestellar.io). It is a REDIRECT-trust boundary only — see
+// isTrustedRedirectTarget — and deliberately NOT a CSRF or CORS boundary.
+const hubDomainSuffix = ".hive.kubestellar.io"
+
+// isSameOriginAsHub reports whether raw names the hub's own origin, i.e. the
+// only origin permitted to drive a state-changing request or to receive a
+// credentialed CORS response.
+//
+// SECURITY (audit F4): this used to be isTrustedOrigin, which accepted EVERY
+// suffix match of .hive.kubestellar.io. Because the hub session cookie is
+// scoped Domain=.hive.kubestellar.io, the browser attaches it to requests
+// issued from any sibling tenant — so a hostile hive operator, serving script
+// from their own <id>.hive.kubestellar.io dashboard, could POST at the hub with
+// the victim admin's ambient cookie and have the CSRF gate wave it through. The
+// audit demonstrated exactly this by flipping another tenant's visibility from
+// a sibling Origin. Suffix-matching a domain whose subdomains are handed out to
+// untrusted third parties is not an origin check at all.
+//
+// localhost/127.0.0.1 stay trusted for local development, where the hub is
+// served from those hosts and there is no multi-tenant sibling to speak of.
+func isSameOriginAsHub(raw string) bool {
+	host, ok := originHost(raw)
+	if !ok {
 		return false
 	}
-	host := u.Hostname()
-	return host == "hive.kubestellar.io" ||
-		strings.HasSuffix(host, ".hive.kubestellar.io") ||
+	return host == hubCanonicalHost || host == "localhost" || host == "127.0.0.1"
+}
+
+// isTrustedRedirectTarget reports whether raw is a URL the hub may bounce a
+// browser BACK to after login.
+//
+// This one MUST keep accepting sibling tenants, and that is not an oversight:
+// every hosted hive's ingress carries
+//
+//	auth-signin: https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri
+//
+// (see saas_provision.go), so the ordinary "open my hive" flow arrives at the
+// hub with redirect=https://<id>.hive.kubestellar.io/... and must be allowed to
+// return there. Narrowing this to the exact hub origin would break sign-in for
+// all hosted tenants.
+//
+// Sending a browser to a sibling is a far weaker capability than accepting a
+// mutation FROM one: the tenant already controls that host and can navigate the
+// user there unaided. The dangerous half — trusting a sibling to author a
+// request — is what isSameOriginAsHub now refuses.
+func isTrustedRedirectTarget(raw string) bool {
+	host, ok := originHost(raw)
+	if !ok {
+		return false
+	}
+	return host == hubCanonicalHost ||
+		strings.HasSuffix(host, hubDomainSuffix) ||
 		host == "localhost" ||
 		host == "127.0.0.1"
+}
+
+// originHost extracts the hostname from raw, rejecting values that do not parse.
+// Shared by both trust predicates so they can never disagree about how a URL is
+// decomposed.
+func originHost(raw string) (string, bool) {
+	if raw == "" {
+		return "", false
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+	return u.Hostname(), true
 }
 
 // getRealAuthUser resolves the REAL authenticated user from the signed session
@@ -883,22 +948,34 @@ func (s *HubServer) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{"users": views})
 }
 
-// impersonateCookieDomain matches the session cookie's domain so the two are
-// scoped identically across the hive.kubestellar.io hosts. It mirrors the
-// hive_hub_user cookie set in oauth.go.
-const impersonateCookieDomain = ".hive.kubestellar.io"
-
 // setImpersonateCookie writes (value != "") or clears (value == "") the signed
 // impersonation cookie with the same hardened attributes as the session cookie:
 // HttpOnly (no JS access), Secure (HTTPS only), SameSite=Lax. The short MaxAge
 // mirrors impersonateTTL so the browser drops the cookie about when the server
 // would stop honoring it.
+//
+// SECURITY (audit F4): this cookie is HOST-ONLY. It previously carried
+// Domain=.hive.kubestellar.io, copied from the session cookie, which meant the
+// admin's live impersonation grant was transmitted to every hosted tenant's
+// dashboard — i.e. handed to ~62 untrusted third parties on every request they
+// received. Unlike hive_hub_user, NOTHING outside the hub ever reads it:
+// grep confirms hive_hub_impersonate appears only in this package
+// (activeImpersonationGrant / resolveIdentity), never in the spoke proxy
+// (v2/proxy/server.js) or any manifest. Dropping Domain therefore costs
+// nothing and removes the cookie from the sibling attack surface entirely.
+//
+// Omitting Domain (rather than setting it) is what makes a cookie host-only per
+// RFC 6265 §4.1.2.3 — there is no "Domain=host" spelling that achieves this.
+//
+// No flag day: the mint and the read both happen on hive.kubestellar.io, so a
+// browser holding the OLD domain-scoped cookie still presents it to the hub and
+// still verifies. The next impersonate/exit re-mints it host-only. Worst case
+// for an in-flight grant is that it expires on its own 30-minute TTL.
 func setImpersonateCookie(w http.ResponseWriter, value string) {
 	c := &http.Cookie{
 		Name:     impersonateCookieName,
 		Value:    value,
 		Path:     "/",
-		Domain:   impersonateCookieDomain,
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
@@ -909,7 +986,34 @@ func setImpersonateCookie(w http.ResponseWriter, value string) {
 		c.MaxAge = int(impersonateTTL / time.Second)
 	}
 	http.SetCookie(w, c)
+	if value == "" {
+		// Also expire the legacy DOMAIN-scoped cookie. A host-only Set-Cookie
+		// cannot delete a domain-scoped one — they are distinct entries in the
+		// jar, and the browser would keep sending the old one on every hub
+		// request until its own TTL lapsed, leaving "Exit impersonation"
+		// silently ineffective for admins mid-migration. Emitting both
+		// deletions is unconditional and idempotent: if no legacy cookie
+		// exists, this is a no-op the browser discards.
+		//
+		// Removable once no admin can still be holding a pre-fix grant, which
+		// the 30-minute impersonateTTL bounds.
+		http.SetCookie(w, &http.Cookie{
+			Name:     impersonateCookieName,
+			Value:    "",
+			Path:     "/",
+			Domain:   legacyImpersonateCookieDomain,
+			MaxAge:   -1,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
 }
+
+// legacyImpersonateCookieDomain is the sibling-wide scope the impersonation
+// cookie used to carry before audit F4 made it host-only. Retained ONLY so the
+// exit path can expire cookies minted by the previous build.
+const legacyImpersonateCookieDomain = ".hive.kubestellar.io"
 
 // handleImpersonateStart begins an admin read-only "View as user" session.
 // Registered behind requireAdmin, so only the real hub admin reaches it (and
@@ -3510,7 +3614,7 @@ func (s *HubServer) handleHubSelfUpgrade(w http.ResponseWriter, r *http.Request)
 
 func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -3599,7 +3703,7 @@ func branchToTag(branch string) string {
 
 func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -3733,7 +3837,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 
 func (s *HubServer) handleToggleVisibility(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
@@ -3820,7 +3924,7 @@ const maxHiveDisplayNameLen = 100
 //     original label — a known, documented staleness, not a silent one.
 func (s *HubServer) handleRenameHive(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
@@ -3922,7 +4026,7 @@ func (s *HubServer) pushVisibilityToSpoke(id string, isPublic bool) {
 
 func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")

--- a/v2/pkg/hub/saas_admin_csrf_test.go
+++ b/v2/pkg/hub/saas_admin_csrf_test.go
@@ -57,23 +57,37 @@ func TestRequireAdminCSRFCrossOriginPostDenied(t *testing.T) {
 }
 
 // TestRequireAdminCSRFSiblingTenantOriginDenied covers the lane the audit
-// reproduced: a hostile tenant spoke. isTrustedOrigin still allows
-// *.hive.kubestellar.io, so this currently passes the CSRF check and is denied
-// only if the wider trusted-origin reduction lands. Asserting the *documented*
-// current behaviour keeps this test honest rather than aspirational — flip it
-// to expect 403 when the exact-origin change ships.
-func TestRequireAdminCSRFSiblingTenantOriginStillTrusted(t *testing.T) {
+// reproduced: a hostile tenant spoke.
+//
+// This test previously existed as TestRequireAdminCSRFSiblingTenantOriginStillTrusted
+// — it ASSERTED the vulnerable behaviour and t.Skip'd if it were ever fixed,
+// documenting the gap as "tracked for the exact-origin work". That work is
+// audit F4 and it has now landed, so the test is flipped to a real assertion.
+//
+// The request carries a GENUINELY VALID admin cookie, so a 403 can only come
+// from the CSRF gate; the pre-existing TestRequireAdminNonAdmin would get its
+// 403 from the identity check and would keep passing with this hole open.
+func TestRequireAdminCSRFSiblingTenantOriginDenied(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+
+	reached := false
+	handler := adminCSRFHandler(s, &reached)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/saas/admin/hub-banner", nil)
 	req.Header.Set("Origin", "https://attacker-hive.hive.kubestellar.io")
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
 
-	if !isCSRFSafe(req) {
-		t.Skip("sibling-tenant origin is no longer trusted — the exact-origin fix has landed; update this test to assert 403 through requireAdmin")
+	if reached {
+		t.Fatal("F4 REGRESSION: an admin mutation from a hostile sibling tenant origin reached the handler")
 	}
-	t.Log("KNOWN GAP (N6, second half): a sibling *.hive.kubestellar.io origin is still CSRF-trusted; " +
-		"the requireAdmin gate does not close this lane on its own. Tracked for the exact-origin + CSRF-token work.")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("sibling-origin admin POST: code=%d, want 403 (CSRF); body=%q", rec.Code, rec.Body.String())
+	}
 }
 
 // TestRequireAdminSafeGetStillAllowed guards against over-correction: the CSRF

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -127,7 +127,7 @@ func authorizeBulkHive(id, username string) (*SaaSHive, string) {
 
 func (s *HubServer) handleBulkHiveAction(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/v2/pkg/hub/saas_sibling_origin_test.go
+++ b/v2/pkg/hub/saas_sibling_origin_test.go
@@ -1,0 +1,291 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Audit F4 (CWE-352/CWE-346): hosted sibling-domain CSRF boundary.
+//
+// The hub session cookie is minted with Domain=.hive.kubestellar.io so that each
+// tenant spoke's proxy can verify it. The consequence is that the browser
+// attaches the victim's hub session to requests issued by ANY
+// <id>.hive.kubestellar.io document — including one served by a hostile tenant,
+// whose operator fully controls the script running there.
+//
+// isTrustedOrigin used to accept every suffix match of that shared domain, so
+// the CSRF gate treated a hostile tenant's Origin as the hub's own. The audit
+// demonstrated the end-to-end consequence by changing a victim hive's
+// visibility from a sibling Origin. These tests reproduce that PoC at the
+// handler boundary and pin it shut.
+//
+// WHY THESE TESTS EXIST IN THIS SHAPE: every finding in this audit round hid
+// behind a green test that asserted the wrong thing — and this one literally
+// did. saas_admin_csrf_test.go carried
+// TestRequireAdminCSRFSiblingTenantOriginStillTrusted, which ASSERTED the
+// vulnerable behaviour and t.Skip'd once it was fixed. So each test below is
+// paired with a positive control proving the legitimate same-origin request is
+// still ACCEPTED. A test that only checks rejection passes equally well against
+// a handler that rejects everything.
+
+// siblingOrigin is a hostile hosted tenant: a real, suffix-matching
+// *.hive.kubestellar.io host whose operator is not the victim.
+const siblingOrigin = "https://attacker-hive.hive.kubestellar.io"
+
+// hubOrigin is the hub's own dashboard origin — the only legitimate author of a
+// state-changing request.
+const hubOrigin = "https://hive.kubestellar.io"
+
+// visibilityReq builds the audit's PoC request: the exact mutation the report
+// reproduced, carrying a genuinely VALID victim session cookie. Because the
+// cookie is valid, a 403 can only come from the CSRF gate — not from the
+// identity check, which would mask the finding.
+func visibilityReq(t *testing.T, origin, username string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPut, "/api/saas/hives/victim-hive/visibility",
+		strings.NewReader(`{"visibility":"public"}`))
+	r.Header.Set("Content-Type", "application/json")
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	r.AddCookie(testAuthCookie(username))
+	return setPathValue(r, "id", "victim-hive")
+}
+
+// TestVisibilityMutationFromSiblingOriginDenied is the direct regression for the
+// audit's proof of concept. Against the unfixed code this returns 200/handler
+// reached; it must now be refused 403 before the handler body runs.
+func TestVisibilityMutationFromSiblingOriginDenied(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "victim")
+
+	reached := false
+	handler := s.requireAuth(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	handler(rec, visibilityReq(t, siblingOrigin, "victim"))
+
+	if reached {
+		t.Fatal("F4 REGRESSION: a mutation from a hostile sibling tenant origin reached the handler — " +
+			"the sibling holds the victim's parent-domain session cookie, so this is a cross-tenant write")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("sibling-origin visibility mutation: code=%d, want 403 (CSRF); body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestVisibilityMutationFromHubOriginAllowed is the POSITIVE CONTROL for the
+// test above. Without it, a handler that refused every request — or a CSRF gate
+// broken to always fail closed — would satisfy the regression and look fixed
+// while the dashboard was entirely non-functional.
+func TestVisibilityMutationFromHubOriginAllowed(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "victim")
+
+	reached := false
+	handler := s.requireAuth(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	handler(rec, visibilityReq(t, hubOrigin, "victim"))
+
+	if !reached || rec.Code != http.StatusOK {
+		t.Fatalf("OVER-CORRECTION: the legitimate same-origin dashboard mutation was blocked: "+
+			"code=%d reached=%v, want 200/true", rec.Code, reached)
+	}
+}
+
+// TestSiblingOriginDeniedByRefererToo covers the second lane of isCSRFSafe: when
+// no Origin header is present the gate falls back to Referer, and that fallback
+// used the same suffix match. A hostile tenant can control its Referer just as
+// easily as its Origin.
+func TestSiblingOriginDeniedByRefererToo(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "/api/saas/hives/victim-hive/visibility", nil)
+	req.Header.Set("Referer", siblingOrigin+"/dashboard")
+	if isCSRFSafe(req) {
+		t.Fatal("F4 REGRESSION: sibling tenant trusted via the Referer fallback")
+	}
+
+	// Positive control: the hub's own Referer must still pass, or the dashboard
+	// breaks for any browser that suppresses Origin.
+	ok := httptest.NewRequest(http.MethodPut, "/api/saas/hives/victim-hive/visibility", nil)
+	ok.Header.Set("Referer", hubOrigin+"/dashboard")
+	if !isCSRFSafe(ok) {
+		t.Fatal("OVER-CORRECTION: the hub's own Referer is no longer trusted")
+	}
+}
+
+// TestSiblingOriginGetsNoCredentialedCORS covers the third lane. isTrustedOrigin
+// did not only gate CSRF: the same predicate decided whether to reflect
+// Access-Control-Allow-Origin together with Allow-Credentials. Reflecting a
+// sibling there let a hostile tenant READ cross-tenant hub responses from
+// script, which is the disclosure counterpart to the write PoC.
+func TestSiblingOriginGetsNoCredentialedCORS(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	// OPTIONS preflight: short-circuits before any auth work, so the response
+	// headers isolate exactly the CORS decision.
+	req := httptest.NewRequest(http.MethodOptions, "/api/saas/hives/victim-hive/visibility", nil)
+	req.Header.Set("Origin", siblingOrigin)
+	rec := httptest.NewRecorder()
+	s.handleToggleVisibility(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("F4 REGRESSION: reflected Access-Control-Allow-Origin=%q to a hostile sibling tenant "+
+			"(with Allow-Credentials=%q) — that is a cross-tenant read channel",
+			got, rec.Header().Get("Access-Control-Allow-Credentials"))
+	}
+
+	// Positive control: the hub's own origin must still get the CORS headers,
+	// otherwise this test would pass against a build that emitted none at all.
+	okReq := httptest.NewRequest(http.MethodOptions, "/api/saas/hives/victim-hive/visibility", nil)
+	okReq.Header.Set("Origin", hubOrigin)
+	okRec := httptest.NewRecorder()
+	s.handleToggleVisibility(okRec, okReq)
+
+	if got := okRec.Header().Get("Access-Control-Allow-Origin"); got != hubOrigin {
+		t.Fatalf("OVER-CORRECTION: hub origin got Access-Control-Allow-Origin=%q, want %q", got, hubOrigin)
+	}
+}
+
+// TestHostedLoginRedirectToSiblingStillWorks is the guard on what this fix
+// deliberately did NOT narrow. Every hosted hive's ingress carries
+// auth-signin: https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri
+// so the ordinary "open my hive" sign-in arrives at the hub asking to be sent
+// back to a sibling host. If the exact-origin tightening were applied to the
+// redirect allowlist too, sign-in would break for all ~62 hosted tenants — a
+// far more visible outage than the bug being fixed.
+//
+// Sending a browser TO a tenant is not the same capability as accepting a
+// mutation FROM one: the tenant already controls that host.
+func TestHostedLoginRedirectToSiblingStillWorks(t *testing.T) {
+	if !isTrustedRedirectTarget("https://hosted-acme-web-xyz.hive.kubestellar.io/dashboard") {
+		t.Fatal("hosted tenant login redirect rejected — this breaks the ingress auth-signin flow " +
+			"for every hosted hive; the exact-origin fix must apply to CSRF/CORS only")
+	}
+	// Positive control: the redirect allowlist is still an allowlist.
+	if isTrustedRedirectTarget("https://hive.kubestellar.io.evil.com/") {
+		t.Fatal("redirect allowlist accepts a lookalike host — open redirect")
+	}
+}
+
+// TestImpersonateCookieIsHostOnly pins the second half of F4: the admin's
+// impersonation grant must not be broadcast to every tenant. Unlike
+// hive_hub_user (which spokes must receive in order to verify it), nothing
+// outside this package ever reads hive_hub_impersonate, so it costs nothing to
+// scope it to the hub host alone.
+func TestImpersonateCookieIsHostOnly(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setImpersonateCookie(rec, "admin|target|123.sig")
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("mint should emit exactly one cookie, got %d", len(cookies))
+	}
+	c := cookies[0]
+	if c.Domain != "" {
+		t.Fatalf("F4 REGRESSION: impersonation cookie carries Domain=%q — it is transmitted to every "+
+			"hosted tenant, handing the admin's live grant to ~62 untrusted third parties", c.Domain)
+	}
+	// Positive controls: dropping Domain must not have weakened anything else,
+	// and the cookie must still actually be set.
+	if c.Value == "" {
+		t.Fatal("impersonation cookie value empty — the grant would never be established")
+	}
+	if !c.Secure || !c.HttpOnly || c.Path != "/" {
+		t.Fatalf("impersonation cookie lost a hardening attribute: Secure=%v HttpOnly=%v Path=%q",
+			c.Secure, c.HttpOnly, c.Path)
+	}
+}
+
+// TestSessionCookieStillDomainScopedForSpokes pins the ONE part of F4 this
+// change deliberately does not fix, so the decision is explicit in the suite
+// rather than an unexplained omission.
+//
+// hive_hub_user MUST keep Domain=.hive.kubestellar.io: each spoke's Node proxy
+// (v2/proxy/server.js) independently verifies this cookie to authenticate the
+// tenant dashboard and terminal, and it can only verify a cookie the browser
+// sends it — which happens solely because of that Domain attribute. Making it
+// host-only or __Host- would log every hosted tenant out fleet-wide.
+//
+// If you are here because you want the __Host- prefix the audit asked for: the
+// prerequisite is a spoke-scoped session minted at SSO handoff, so the hub
+// cookie no longer has to reach the spoke at all. Change this test when that
+// lands, together with proxy/server.js — never on its own.
+// Asserted against the real handler (handleLogout mints the same cookie shape
+// as the OAuth callback, and needs no GitHub round-trip to exercise), so this
+// tracks the production code rather than restating net/http's behaviour.
+func TestSessionCookieStillDomainScopedForSpokes(t *testing.T) {
+	s := newHandlerHub()
+	rec := httptest.NewRecorder()
+	s.handleLogout(rec, httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil))
+
+	var found bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != "hive_hub_user" {
+			continue
+		}
+		found = true
+		if c.Domain == "" {
+			t.Fatal("hive_hub_user is no longer domain-scoped. Each spoke's Node proxy " +
+				"(v2/proxy/server.js) verifies this cookie and only receives it because of the " +
+				"Domain attribute — host-only/__Host- logs out every hosted tenant fleet-wide. " +
+				"See the F4 note in oauth.go before changing this.")
+		}
+		// The hardening that IS in place must not regress either.
+		if !c.Secure || !c.HttpOnly {
+			t.Errorf("hive_hub_user lost hardening: Secure=%v HttpOnly=%v", c.Secure, c.HttpOnly)
+		}
+	}
+	if !found {
+		t.Fatal("handleLogout emitted no hive_hub_user cookie")
+	}
+}
+
+// TestImpersonateExitClearsLegacyDomainCookie guards the migration edge. A
+// host-only Set-Cookie cannot delete a domain-scoped cookie — they are separate
+// jar entries — so without an explicit legacy deletion, "Exit impersonation"
+// would appear to work while the browser kept replaying the old domain-scoped
+// grant to the hub until its TTL lapsed.
+func TestImpersonateExitClearsLegacyDomainCookie(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setImpersonateCookie(rec, "")
+
+	var clearedHostOnly, clearedLegacy bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != impersonateCookieName || c.MaxAge >= 0 {
+			continue
+		}
+		if c.Domain == "" {
+			clearedHostOnly = true
+		}
+		// http.SetCookie serializes Domain=".hive.kubestellar.io" as
+		// "Domain=hive.kubestellar.io" — RFC 6265 §5.2.3 says a leading dot is
+		// ignored, and the cookie is domain-scoped (i.e. covers subdomains)
+		// either way, so this still matches and deletes the legacy cookie in a
+		// real browser. Compare against the normalized form.
+		if c.Domain == strings.TrimPrefix(legacyImpersonateCookieDomain, ".") {
+			clearedLegacy = true
+		}
+	}
+	if !clearedHostOnly {
+		t.Error("exit did not expire the host-only impersonation cookie")
+	}
+	if !clearedLegacy {
+		t.Errorf("exit did not expire the legacy Domain=%s impersonation cookie — an admin who "+
+			"started impersonating on the previous build cannot exit it", legacyImpersonateCookieDomain)
+	}
+}

--- a/v2/pkg/hub/slack.go
+++ b/v2/pkg/hub/slack.go
@@ -345,7 +345,7 @@ func decodeSlackRequest(w http.ResponseWriter, r *http.Request) (slackSendReques
 // the caller should return.
 func slackPreflight(w http.ResponseWriter, r *http.Request) bool {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/v2/pkg/hub/slack_send_coverage_test.go
+++ b/v2/pkg/hub/slack_send_coverage_test.go
@@ -276,7 +276,6 @@ func TestSlackPreflightDoesNotReflectUntrustedOrigin(t *testing.T) {
 func TestSlackPreflightAllowsTrustedOrigins(t *testing.T) {
 	for _, origin := range []string{
 		"https://hive.kubestellar.io",
-		"https://my-hive.hive.kubestellar.io",
 		"http://localhost:5174",
 	} {
 		rec := httptest.NewRecorder()
@@ -287,6 +286,24 @@ func TestSlackPreflightAllowsTrustedOrigins(t *testing.T) {
 
 		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != origin {
 			t.Errorf("trusted origin %q not allowed (got %q)", origin, got)
+		}
+	}
+
+	// Audit F4: a sibling tenant is NOT a trusted CORS origin. It used to be
+	// echoed here with Allow-Credentials, which let a hostile hive operator
+	// script credentialed cross-tenant reads against the hub.
+	for _, origin := range []string{
+		"https://my-hive.hive.kubestellar.io",
+		"https://attacker-hive.hive.kubestellar.io",
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req.Header.Set("Origin", origin)
+
+		slackPreflight(rec, req)
+
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("F4 REGRESSION: sibling origin %q reflected as %q", origin, got)
 		}
 	}
 }


### PR DESCRIPTION
## Audit F4 — hosted sibling-domain session and CSRF boundary

**Severity: High (hosted).** The audit's PoC changed a victim hive's visibility from a sibling Origin.

### Root cause

The hub session cookie is scoped `Domain=.hive.kubestellar.io` so that each spoke's proxy can verify it. The consequence is that the browser attaches a victim's hub session to requests issued by **any** `<id>.hive.kubestellar.io` document — including one served by a hostile tenant, whose operator fully controls the script running there.

`isTrustedOrigin` accepted **every suffix match** of that shared domain. Suffix-matching a domain whose subdomains are handed out to untrusted third parties is not an origin check. Worse, the same predicate did triple duty: CSRF gate, credentialed-CORS reflection, *and* post-login redirect allowlist — three boundaries with genuinely different requirements.

### What I fixed

**(a) Exact-origin CSRF + CORS trust** — the requested change, done in full.

Split the overloaded predicate in two:

| predicate | question | sibling tenants |
|---|---|---|
| `isSameOriginAsHub` | may this origin **author** a request? | **rejected** |
| `isTrustedRedirectTarget` | may we send a browser here after login? | accepted |

`isSameOriginAsHub` now gates `isCSRFSafe` (both the `Origin` and `Referer` lanes) and every credentialed CORS reflection: visibility, rename, upgrade, branch switch, auto-upgrade, bulk actions, forge switch, Slack.

The CORS half matters as much as the CSRF half and wasn't called out in the finding: reflecting `Access-Control-Allow-Origin` **together with `Allow-Credentials`** to a sibling gave a hostile tenant a scripted cross-tenant *read* of the hub API — the disclosure counterpart to the write PoC.

**Verified nothing legitimate depends on a sibling Origin posting to the hub.** The one real sibling dependency is the *redirect* lane, and it is load-bearing: every hosted hive's ingress carries

```
auth-signin: https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri
```

(`saas_provision.go:2711,2775`), so ordinary "open my hive" sign-in arrives at the hub asking to be returned to a sibling host. Narrowing that too would have broken sign-in for all ~62 hosted tenants — a much bigger outage than the bug. Sending a browser *to* a tenant is a far weaker capability than accepting a mutation *from* one: the tenant already controls that host and can navigate the user there unaided. `TestHostedLoginRedirectToSiblingStillWorks` pins this.

The only host removed from CORS trust that wasn't a tenant is `console.hive.kubestellar.io`, which appears **only** in a test fixture — no manifest, config, or code references it.

**(b) Host-only cookie — done for the impersonation cookie, NOT for the session cookie.**

`hive_hub_impersonate` is now host-only. It carried `Domain=.hive.kubestellar.io` copied from the session cookie, which broadcast the admin's live impersonation grant to every tenant on every request they received. Unlike `hive_hub_user`, **nothing outside `pkg/hub` ever reads it** (`grep` confirms: only `activeImpersonationGrant`/`resolveIdentity`; absent from `v2/proxy/server.js` and all manifests), so dropping `Domain` costs nothing.

Migration edge handled: a host-only `Set-Cookie` **cannot** delete a domain-scoped one — they're separate jar entries — so without an explicit legacy deletion, "Exit impersonation" would have appeared to work while the browser kept replaying the old grant until its TTL lapsed. The exit path now expires both. (`TestImpersonateExitClearsLegacyDomainCookie` — this caught a real bug in my own first draft.)

### What I deliberately did NOT fix, and why

**`hive_hub_user` keeps `Domain` and does not get the `__Host-` prefix.**

This cookie is minted by the hub (Go) and verified **independently by every spoke's Node proxy** (`v2/proxy/server.js` — `verifyHubUserCookieEither`, plus the WebSocket terminal path). The proxy can only verify a cookie the browser actually sends it, and the browser sends it to `<id>.hive.kubestellar.io` *solely because of* the `Domain` attribute. Dropping `Domain` (which `__Host-` additionally forbids outright) would stop the cookie reaching any spoke and log every hosted tenant out of their dashboard and terminal — a fleet-wide outage across ~62 hives, and precisely the flag-day auth change behind incident #2773.

**The verify-both/mint-new pattern does not rescue this.** That pattern (used for the N2 Ed25519 cutover in `hub_cookie.go`) works when both formats travel the same path and only the *verifier* must learn a new shape. Here the change is to the cookie's **delivery scope**: a host-only cookie is never transmitted to the spoke at all, so there is no request in which a spoke could verify it, regardless of what it accepts. I did not invent a rollout I cannot verify.

Making this safe needs a real design change — e.g. a distinct spoke-scoped session cookie minted per tenant at SSO handoff, so the hub cookie never has to reach the spoke. That is a follow-up, not a line edit.

**Residual risk, explicitly accepted:** the session cookie still travels to sibling tenants. It remains `HttpOnly` + `Secure`, so a hostile tenant cannot read it from script, but it is present in requests they receive. What this PR removes is their ability to *use* it — they can no longer author an accepted mutation nor read a credentialed CORS response. **This should be weighed by a human before the hosted release is called clear on F4.**

**(c) Per-session CSRF tokens on mutations — not attempted.** With (a) landed, the remaining value is defense-in-depth against a *future* origin-check regression. It touches every mutating handler and the dashboard's fetch layer at once, which is not a change I can validate without a browser-level integration story. It is the right next step, but it should be its own PR.

**One adjacent hole found and left, flagged for triage:** `isCSRFSafe` still falls through to `strings.Contains(ct, "application/json")` when *no* `Origin` **and** no `Referer` is present, i.e. a header-less POST is trusted on content-type alone. Browsers always send `Origin` on cross-origin `fetch`, so this is not reachable in the sibling-tenant scenario F4 describes, and I did not want to fold an unrelated behaviour change into a security fix whose blast radius I'd then be unable to attribute. Worth its own finding — the existing `TestIsCSRFSafe` case `{"POST with JSON content-type", ..., true}` asserts this bypass is *correct*.

### Test evidence (fail-then-pass)

Method: restored the fix, then surgically reintroduced the vulnerable behaviour **inside the new functions** (sibling suffix match back in `isSameOriginAsHub`; `Domain` back on the impersonation cookie; legacy-clear removed) so the new tests compile against both states and the comparison is real rather than a build error.

**Against reintroduced-vulnerable behaviour — 9 tests FAIL:**

```
--- FAIL: TestBulkHandlerPreflightOnlyTrustsKnownOrigins
    --- FAIL: .../untrusted_https://console.hive.kubestellar.io
    --- FAIL: .../untrusted_https://attacker-hive.hive.kubestellar.io
--- FAIL: TestSubdomainTrustIsRedirectOnly
--- FAIL: TestIsSameOriginAsHub
--- FAIL: TestIsCSRFSafe
    --- FAIL: TestIsCSRFSafe/POST_from_sibling_tenant_origin
    --- FAIL: TestIsCSRFSafe/POST_from_sibling_tenant_origin_with_JSON_ct
--- FAIL: TestRequireAdminCSRFSiblingTenantOriginDenied
--- FAIL: TestVisibilityMutationFromSiblingOriginDenied
--- FAIL: TestSiblingOriginDeniedByRefererToo
--- FAIL: TestSiblingOriginGetsNoCredentialedCORS
--- FAIL: TestImpersonateCookieIsHostOnly
--- FAIL: TestImpersonateExitClearsLegacyDomainCookie
--- FAIL: TestSlackPreflightAllowsTrustedOrigins
FAIL    github.com/kubestellar/hive/v2/pkg/hub  0.950s
```

**Positive controls PASS in *both* states** — this is what proves the tests aren't vacuous. A gate broken to reject everything would satisfy the rejection assertions while leaving the dashboard dead:

```
--- PASS: TestVisibilityMutationFromHubOriginAllowed      (legit same-origin mutation still accepted)
--- PASS: TestHostedLoginRedirectToSiblingStillWorks      (hosted sign-in redirect still works)
--- PASS: TestIsTrustedRedirectTarget                     (redirect lane deliberately unchanged)
--- PASS: TestIsCSRFSafe/POST_with_trusted_origin
--- PASS: .../trusted_https://hive.kubestellar.io         (hub still gets CORS headers)
```

**After restoring the fix — all PASS:**

```
--- PASS: TestBulkHandlerPreflightOnlyTrustsKnownOrigins
--- PASS: TestSubdomainTrustIsRedirectOnly
--- PASS: TestIsSameOriginAsHub
--- PASS: TestIsTrustedRedirectTarget
--- PASS: TestIsCSRFSafe
--- PASS: TestRequireAdminCSRFSiblingTenantOriginDenied
--- PASS: TestVisibilityMutationFromSiblingOriginDenied
--- PASS: TestVisibilityMutationFromHubOriginAllowed
--- PASS: TestSiblingOriginDeniedByRefererToo
--- PASS: TestSiblingOriginGetsNoCredentialedCORS
--- PASS: TestHostedLoginRedirectToSiblingStillWorks
--- PASS: TestImpersonateCookieIsHostOnly
--- PASS: TestImpersonateExitClearsLegacyDomainCookie
ok      github.com/kubestellar/hive/v2/pkg/hub  0.542s
```

### Baseline vs branch

| | result |
|---|---|
| clean `origin/v4` (`git stash`) | `ok github.com/kubestellar/hive/v2/pkg/hub 94.454s` — **0 failures** |
| this branch | `ok github.com/kubestellar/hive/v2/pkg/hub 73.055s` — **0 failures** |

**No new failures.** (This package is documented as having pre-existing failures in CI while passing on macOS; on macOS the baseline was clean, so the comparison is 0 vs 0.) `gofmt -l pkg/hub/` reports an identical 6-file list before and after — all pre-existing, none introduced here.

### The test that hid this finding

`saas_admin_csrf_test.go` contained `TestRequireAdminCSRFSiblingTenantOriginStillTrusted`, which **asserted the vulnerable behaviour** and `t.Skip`'d itself if the sibling origin ever became untrusted, logging `KNOWN GAP ... tracked for the exact-origin work`. It was green the entire time. That work is this PR, so the test is flipped into a real assertion that a sibling-origin admin mutation is refused 403 with a genuinely valid admin cookie (so the 403 can only come from the CSRF gate, not the identity check).

Similarly, `TestIsTrustedOriginSubdomain` asserted `my-hive.hive.kubestellar.io` *should* be trusted, and `TestIsCSRFSafe` had no sibling case at all. Both updated.

### Scope

Does not touch `v2/pkg/agent/manager.go` (concurrent F12 work).
