### PR TITLE
🔒 fix(agent): close the write half of the inference-home symlink hole (F12)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"hash/fnv"
 	"log/slog"
@@ -5041,7 +5042,7 @@ func (m *Manager) seedClaudeUserConfig(agentName, path string) {
 // seeded by older hive versions without the truncated key form the CLI
 // actually matches against (see apiKeyApprovalSuffixLen).
 func (m *Manager) mergeApprovedAPIKeys(agentName, path string) {
-	data, err := os.ReadFile(path)
+	data, err := readInferenceConfigFile(path)
 	if err != nil {
 		return
 	}
@@ -5077,7 +5078,7 @@ func (m *Manager) mergeApprovedAPIKeys(agentName, path string) {
 	if err != nil {
 		return
 	}
-	if err := os.WriteFile(path, out, 0o666); err != nil {
+	if err := writeInferenceConfigFile(path, out); err != nil {
 		m.logger.Warn("failed to write inference config", "agent", agentName, "path", path, "error", err)
 	}
 }
@@ -5096,7 +5097,7 @@ func (m *Manager) seedClaudeSettingsFile(agentName, path string) {
 // parseable file is left untouched.
 func (m *Manager) seedJSONFile(agentName, path string, seed map[string]any) {
 	existing := map[string]any{}
-	if data, err := os.ReadFile(path); err == nil {
+	if data, err := readInferenceConfigFile(path); err == nil {
 		if jsonErr := json.Unmarshal(data, &existing); jsonErr != nil {
 			m.logger.Warn("inference config unparseable, rewriting",
 				"agent", agentName, "path", path, "error", jsonErr)
@@ -5120,7 +5121,7 @@ func (m *Manager) seedJSONFile(agentName, path string, seed map[string]any) {
 		m.logger.Warn("failed to marshal inference config", "agent", agentName, "path", path, "error", err)
 		return
 	}
-	if err := os.WriteFile(path, data, 0o666); err != nil {
+	if err := writeInferenceConfigFile(path, data); err != nil {
 		m.logger.Warn("failed to write inference config", "agent", agentName, "path", path, "error", err)
 	}
 }
@@ -5140,10 +5141,23 @@ func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 	settingsDir := filepath.Join(homePath, ".claude")
 	settingsFile := filepath.Join(settingsDir, "settings.json")
 
-	if err := os.MkdirAll(settingsDir, 0o777); err != nil {
+	if err := os.MkdirAll(settingsDir, inferenceHomeDirMode); err != nil {
 		m.logger.Warn("failed to create claude inference home", "agent", agentName, "error", err)
 		return
 	}
+	// SECURITY (audit F12): prefer an agent-OWNED 0700 home over a world-writable
+	// one. The audit's fix is "UID-owned 0700 homes"; the surrounding code
+	// assumed that was impossible ("hive runs as dev, not root, so chown is not
+	// available"), but the hosted container runs as root and chown succeeds
+	// there — verified live. Where it does succeed, no other UID can enter the
+	// directory and the symlink cannot be planted in the first place.
+	//
+	// Falls back to the historical world-writable mode when chown is refused
+	// (a genuinely unprivileged deployment), because a home the agent's own UID
+	// cannot write is a hard launch failure. The O_NOFOLLOW guards on the
+	// writers hold in BOTH cases — this narrows who can reach the path, it is
+	// not what closes the finding.
+	m.tightenInferenceHome(agentName, homePath, settingsDir, uid)
 	// Write (or repair) both settings files: the HOME userSettings file and
 	// the standalone file passed via --settings. The CLI honors
 	// skipDangerousModePermissionPrompt from either source.
@@ -5151,7 +5165,13 @@ func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 	m.seedClaudeSettingsFile(agentName, claudeInferenceSettingsPath)
 	// Pre-populate (or repair) .claude.json so the CLI skips first-run setup.
 	m.seedClaudeUserConfig(agentName, filepath.Join(homePath, ".claude.json"))
-	m.ensureWorldWritable(homePath)
+	// Only widen when the home is NOT agent-owned. tightenInferenceHome may have
+	// just established a 0700 home owned by the agent UID; running the widening
+	// walk unconditionally would chmod it straight back to 0777 and silently
+	// undo the hardening (audit F12).
+	if !m.inferenceHomeIsOwnedBy(homePath, uid) {
+		m.ensureWorldWritable(homePath)
+	}
 }
 
 // ensureWorldWritable walks the tree and sets dirs to 0o777, files to 0o666.
@@ -5277,6 +5297,133 @@ const agentStateFileMode = 0o600
 // write. The file is deliberately NOT O_EXCL: these are rewritten on every
 // mode change and every relaunch, so failing when the file already exists would
 // break the normal path.
+// inferenceHomeDirMode / inferenceHomeSharedDirMode are the two shapes a
+// per-agent inference HOME can take (audit F12).
+//
+// The 0700 form is preferred and is what tightenInferenceHome establishes once
+// the directory is chowned to the agent UID: nobody else can even enter it, so
+// the predictable path stops being reachable. The 0777 form is the historical
+// fallback for a deployment where chown is refused — the agent must be able to
+// write its own HOME, and a home it cannot write is a hard launch failure.
+const (
+	inferenceHomeDirMode       = 0o700
+	inferenceHomeSharedDirMode = 0o777
+)
+
+// tightenInferenceHome tries to give the agent UID sole ownership of its
+// inference HOME, falling back to the historical world-writable mode when the
+// hive lacks the privilege to chown. Best-effort by design: every failure path
+// leaves a WORKING home, because the O_NOFOLLOW writers — not this — are what
+// close audit F12.
+func (m *Manager) tightenInferenceHome(agentName, homePath, settingsDir string, uid int) {
+	if uid <= 0 {
+		// No per-agent UID: the hive itself is the only writer, so 0700 owned
+		// by the hive is already correct.
+		return
+	}
+	for _, dir := range []string{homePath, settingsDir} {
+		if err := os.Chown(dir, uid, -1); err != nil {
+			// Unprivileged deployment. Restore the shared mode so the agent can
+			// still use its HOME, and say so once at debug level rather than
+			// warning on every launch.
+			m.logger.Debug("inference home left world-writable (chown unavailable)",
+				"agent", agentName, "dir", dir, "error", err)
+			if cerr := os.Chmod(dir, inferenceHomeSharedDirMode); cerr != nil {
+				m.logger.Warn("failed to restore inference home mode",
+					"agent", agentName, "dir", dir, "error", cerr)
+			}
+			continue
+		}
+		if err := os.Chmod(dir, inferenceHomeDirMode); err != nil {
+			m.logger.Warn("failed to tighten inference home mode",
+				"agent", agentName, "dir", dir, "error", err)
+		}
+	}
+}
+
+// inferenceHomeIsOwnedBy reports whether homePath is already owned by uid, i.e.
+// tightenInferenceHome succeeded and the widening walk must be skipped.
+//
+// Fails SAFE for availability rather than for security: on any doubt (uid<=0,
+// stat error, or a platform without Stat_t) it returns false, so the caller
+// widens and the agent keeps a usable HOME. The O_NOFOLLOW writers are what
+// close F12 in that case.
+func (m *Manager) inferenceHomeIsOwnedBy(homePath string, uid int) bool {
+	if uid <= 0 {
+		return false
+	}
+	info, err := os.Stat(homePath)
+	if err != nil {
+		return false
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return int(st.Uid) == uid
+}
+
+// inferenceConfigFileMode is the mode for a per-agent inference config file.
+//
+// NOT 0600 like agentStateFileMode: these live in a per-agent HOME that the
+// AGENT's own UID must be able to rewrite (the CLI updates its own config), and
+// the hive cannot chown them to that UID on every deployment shape. 0666 in a
+// directory only that agent can enter is the trade-off the surrounding code
+// already makes; the symlink guard below is what actually closes audit F12,
+// because the exploit was redirection out of the directory, not the mode.
+const inferenceConfigFileMode = 0o666
+
+// readInferenceConfigFile reads a per-agent inference config, refusing to
+// traverse a symlink (audit F12).
+//
+// os.ReadFile follows symlinks, so a planted link let an attacker feed the
+// CONTENTS of any hive-readable file into the merge logic below, which then
+// wrote the merged result back out — a read-and-echo primitive on top of the
+// clobber. O_NOFOLLOW makes that fail loudly instead.
+//
+// A missing file is the normal first-run case; callers already treat any error
+// as "start from the seed", so failing closed here costs nothing.
+func readInferenceConfigFile(path string) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+// writeInferenceConfigFile writes a per-agent inference config without
+// following a symlink (audit F12, CWE-59/61).
+//
+// SECURITY: the inference HOME is a predictable path
+// (/tmp/.claude-inference-home-<agent>) inside world-writable /tmp, and the
+// directory itself is created world-writable so the agent UID can use it. Both
+// writers here used a plain os.WriteFile, which opens O_WRONLY|O_CREATE|O_TRUNC
+// with NO O_NOFOLLOW — so another local UID could pre-plant a symlink at the
+// config path and have the hive overwrite any file it can reach.
+//
+// Verified before and after: a planted link at <home>/.claude.json had the
+// VICTIM file's contents replaced with the seeded JSON; with this guard the
+// write fails with ELOOP and the victim file is untouched.
+//
+// Note #3432 fixed only the sibling half of F12 — the chmod walk in
+// ensureWorldWritable, which WIDENED a linked file's mode. This closes the
+// write path, which CLOBBERED its contents. The audit named three sinks; all
+// three are now covered.
+func writeInferenceConfigFile(path string, data []byte) error {
+	f, err := os.OpenFile(path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW,
+		inferenceConfigFileMode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
 func writeAgentStateFile(path string, data []byte) error {
 	f, err := os.OpenFile(path,
 		os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW,

--- a/v2/pkg/agent/manager_extra_test.go
+++ b/v2/pkg/agent/manager_extra_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -379,5 +380,118 @@ func TestF12_EnsureWorldWritableDoesNotFollowSymlinks(t *testing.T) {
 	}
 	if rinfo.Mode().Perm() != 0o666 {
 		t.Fatalf("test is vacuous: the walk did not repair a genuine file (mode %o, want 0666)", rinfo.Mode().Perm())
+	}
+}
+
+// Audit F12 (CWE-59/61), the WRITE half.
+//
+// PR #3432 closed only one of the three sinks the audit named: the chmod walk
+// in ensureWorldWritable, which WIDENED a symlinked file's mode. The two
+// writers — seedJSONFile and mergeApprovedAPIKeys — kept using a plain
+// os.WriteFile, which follows symlinks, so an attacker who could plant a link
+// at the predictable inference-home path had the hive overwrite the CONTENTS of
+// any file it could reach.
+//
+// The inference HOME is /tmp/.claude-inference-home-<agent>: a guessable path
+// inside world-writable /tmp, in a directory deliberately made world-writable
+// so the agent UID can use it. Planting the link needs no privilege at all.
+func TestF12_SeedJSONFileDoesNotFollowSymlink(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	const victimContent = "hive-owned secret, must survive"
+	victim := filepath.Join(root, "victim.json")
+	if err := os.WriteFile(victim, []byte(victimContent), 0o600); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+	// The attacker plants a link where the hive is about to write.
+	target := filepath.Join(home, ".claude.json")
+	if err := os.Symlink(victim, target); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.seedJSONFile("victim-agent", target, map[string]any{"hasCompletedOnboarding": true})
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(got) != victimContent {
+		t.Fatalf("F12: the hive wrote THROUGH a planted symlink and clobbered a file outside the agent home.\n victim now: %s", got)
+	}
+}
+
+// mergeApprovedAPIKeys is the second writer named by the finding, reached via
+// seedClaudeUserConfig. It reads the file first, so it is also a read-and-echo
+// primitive: without the guard it slurps a hive-readable file and writes the
+// merged result back.
+func TestF12_MergeApprovedAPIKeysDoesNotFollowSymlink(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Valid JSON with the shape mergeApprovedAPIKeys mutates, so the function
+	// reaches its write path rather than bailing out early.
+	const victimContent = `{"customApiKeyResponses":{"approved":[]}}`
+	victim := filepath.Join(root, "victim.json")
+	if err := os.WriteFile(victim, []byte(victimContent), 0o600); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+	target := filepath.Join(home, ".claude.json")
+	if err := os.Symlink(victim, target); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.mergeApprovedAPIKeys("victim-agent", target)
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(got) != victimContent {
+		t.Fatalf("F12: mergeApprovedAPIKeys wrote through a planted symlink.\n victim now: %s", got)
+	}
+}
+
+// POSITIVE CONTROL. The guards must not break the feature: a real (non-symlink)
+// config file still has to be seeded and merged, or both tests above would pass
+// against a build that simply never writes anything.
+func TestF12_RealInferenceConfigStillSeeded(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".claude.json")
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.seedJSONFile("real-agent", path, map[string]any{"hasCompletedOnboarding": true})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("test is vacuous: the seed never wrote a real file: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("seeded file is not valid JSON: %v", err)
+	}
+	if parsed["hasCompletedOnboarding"] != true {
+		t.Fatalf("seeded key missing — the guard broke normal seeding: %v", parsed)
+	}
+
+	// And a second pass must merge into the existing file, not fail on it.
+	m.seedJSONFile("real-agent", path, map[string]any{"anotherKey": "v"})
+	data2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	var parsed2 map[string]any
+	if err := json.Unmarshal(data2, &parsed2); err != nil {
+		t.Fatalf("merged file is not valid JSON: %v", err)
+	}
+	if parsed2["anotherKey"] != "v" || parsed2["hasCompletedOnboarding"] != true {
+		t.Fatalf("merge lost keys: %v", parsed2)
 	}
 }


### PR DESCRIPTION
## What

Audit **F12** (CWE-59/61) — completing it. **#3432 only fixed one of the three sinks the finding names.**

The audit lists `ensureWorldWritable`, `seedJSONFile`, and `mergeApprovedAPIKeys`. #3432 fixed the first — the chmod walk, which *widened* a symlinked file's mode. Both **writers** kept a plain `os.WriteFile(path, data, 0o666)`, which follows symlinks and **clobbers the target's contents**.

I reported F12 as complete last round. That was wrong, and this closes the rest.

## Why it's reachable

The inference HOME is `/tmp/.claude-inference-home-<agent>` — a guessable path in world-writable `/tmp`, in a directory deliberately made world-writable so the agent UID can use it. Planting the link needs no privilege.

Reproduced against the unfixed code:

```
before: victim.json (0600) = "hive-owned secret, must survive"
after:  victim.json         = {"hasCompletedOnboarding":true}
```

and via the second writer:

```
after:  victim.json = {"customApiKeyResponses":{"approved":["sk-hive-victim-agent"]}}
```

With the guard the write fails with `ELOOP` and the victim file is untouched.

## The fix

- Both writers route through `writeInferenceConfigFile` (`O_NOFOLLOW`), mirroring the existing `writeAgentStateFile` from N15.
- Both **reads** route through `readInferenceConfigFile`. `os.ReadFile` follows symlinks too, and `mergeApprovedAPIKeys` reads-then-writes — so without this the pair is also a read-and-echo primitive: slurp a hive-readable file, write the merged result back.
- Prefer an **agent-owned 0700 home**. The surrounding code assumed this was impossible (*"hive runs as dev, not root, so chown is not available"*), but the hosted container runs as **root** and `chown` succeeds — verified live in the pod. Where it works, no other UID can enter the directory, so the link cannot be planted at all. Where it's refused, the historical world-writable mode is restored so the agent still has a usable HOME — a home the agent cannot write is a hard launch failure.

**The `O_NOFOLLOW` guards are what close the finding.** The ownership change narrows who can reach the path; it is defence in depth, not the fix.

## One trap worth flagging

`ensureWorldWritable` runs immediately after the tightening and would have chmod'd the new 0700 home **straight back to 0777**, silently undoing it. It's now skipped for an agent-owned home. Without that check this PR would have looked correct and done nothing — the same shape as the original mistake.

## Verification

- `go build ./...` and `go vet ./pkg/agent/` clean
- `go test ./pkg/agent/ -count=1` → **zero failures**, full package
- Both regressions **fail against the unfixed writers**, with the victim's clobbered contents printed in the failure
- `TestF12_RealInferenceConfigStillSeeded` is a **positive control**: it asserts a genuine config file is still seeded *and* merged on a second pass, so the two attack tests cannot pass against a build that simply never writes

## Ownership-fallback caveat

`tightenInferenceHome` is best-effort by design and `inferenceHomeIsOwnedBy` fails **safe for availability** — on any doubt (`uid<=0`, stat error, non-Linux `Stat_t`) it returns false and the home is widened as before. That is deliberate: the security property comes from `O_NOFOLLOW`, so trading strictness here for a guaranteed-usable HOME is the right side to err on.