### PR TITLE
🧪 test(agent): cover auth probe and Bob settings guards

### DIFF
--- a/v2/pkg/agent/authprobe_test.go
+++ b/v2/pkg/agent/authprobe_test.go
@@ -130,6 +130,74 @@ func TestAgentAuthState_RunningAgentNoBadgeOnMissingFile(t *testing.T) {
 	}
 }
 
+func TestAgentAuthState_ClaudeCredentialFileMissingThenPresent(t *testing.T) {
+	dir := t.TempDir()
+	home := filepath.Join(dir, "home")
+	shared := filepath.Join(dir, "shared", ".claude", ".credentials.json")
+	t.Setenv("HOME", home)
+
+	origClaude, origCopilot := sharedClaudeCredentialPath, sharedCopilotConfigPath
+	sharedClaudeCredentialPath = shared
+	sharedCopilotConfigPath = filepath.Join(dir, "shared", ".copilot", "config.json")
+	t.Cleanup(func() {
+		sharedClaudeCredentialPath = origClaude
+		sharedCopilotConfigPath = origCopilot
+	})
+
+	m := &Manager{}
+	if avail, known := m.AgentAuthState("writer", 0, "claude", false, false); !known || avail {
+		t.Fatalf("missing claude credentials: got (avail=%v, known=%v), want known unauthenticated", avail, known)
+	}
+
+	writeClaudeCreds(t, shared)
+	if avail, known := m.AgentAuthState("writer", 0, "claude", false, false); !known || !avail {
+		t.Fatalf("shared claude credentials present: got (avail=%v, known=%v), want authenticated", avail, known)
+	}
+}
+
+func TestAgentAuthPathConstructionUsesIsolatedHomes(t *testing.T) {
+	emptySharedPaths(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	prefix := filepath.Join(t.TempDir(), "agent-home-")
+	claudeInferenceHomePrefixForTest(t, prefix)
+
+	if got := AgentHome("writer", 0, "claude"); got != home {
+		t.Fatalf("uid 0 AgentHome = %q, want HOME %q", got, home)
+	}
+	if got := AgentHome("writer", 2001, "claude"); got != bobSharedHome {
+		t.Fatalf("claude agent home = %q, want shared home %q", got, bobSharedHome)
+	}
+	if got := AgentHome("writer", 2001, "litellm"); got != prefix+"writer" {
+		t.Fatalf("inference agent home = %q, want %q", got, prefix+"writer")
+	}
+
+	claudePaths := agentClaudeCredentialPaths("writer", 0, "claude")
+	wantClaude := filepath.Join(home, ".claude", ".credentials.json")
+	if len(claudePaths) < 2 || claudePaths[0] != wantClaude || claudePaths[len(claudePaths)-1] != sharedClaudeCredentialPath {
+		t.Fatalf("claude credential paths = %v, want first %q and last shared %q",
+			claudePaths, wantClaude, sharedClaudeCredentialPath)
+	}
+
+	copilotPaths := agentCopilotConfigPaths("writer", 0, "copilot")
+	wantCopilot := []string{
+		filepath.Join(home, ".copilot", "config.json"),
+		filepath.Join(home, ".config", "github-copilot", "apps.json"),
+		filepath.Join(home, ".config", "github-copilot", "hosts.json"),
+	}
+	if len(copilotPaths) < len(wantCopilot)+1 {
+		t.Fatalf("copilot credential paths = %v, want home paths plus shared fallback", copilotPaths)
+	}
+	for i, want := range wantCopilot {
+		if copilotPaths[i] != want {
+			t.Fatalf("copilotPaths[%d] = %q, want %q (all paths %v)", i, copilotPaths[i], want, copilotPaths)
+		}
+	}
+	if copilotPaths[len(copilotPaths)-1] != sharedCopilotConfigPath {
+		t.Fatalf("copilot credential paths = %v, want shared fallback last %q", copilotPaths, sharedCopilotConfigPath)
+	}
+}
+
 // TestAgentAuthState_TruePositivePreserved: an interactive backend with no
 // credentials anywhere and an agent that is NOT running must still report
 // "needs login" — the signal has to keep working.

--- a/v2/pkg/agent/bob_settings_test.go
+++ b/v2/pkg/agent/bob_settings_test.go
@@ -169,6 +169,26 @@ func TestEnsureBobAuthSettingsCorruptFile(t *testing.T) {
 	assertAPIKeyAuth(t, authBlock(t, readBobSettings(t, home)))
 }
 
+func TestEnsureBobAuthSettingsMalformedJSONRewritesWithSharedMode(t *testing.T) {
+	home := t.TempDir()
+	writeBobSettings(t, home, `{"security":`)
+	if err := os.Chmod(bobSettingsPath(home), 0o600); err != nil {
+		t.Fatalf("chmod seed settings: %v", err)
+	}
+
+	m := &Manager{logger: discardLogger()}
+	m.ensureBobAuthSettings("tester", home)
+
+	assertAPIKeyAuth(t, authBlock(t, readBobSettings(t, home)))
+	info, err := os.Stat(bobSettingsPath(home))
+	if err != nil {
+		t.Fatalf("stat settings: %v", err)
+	}
+	if got := info.Mode().Perm(); got != config.BobSettingsFileMode {
+		t.Errorf("rewritten malformed settings mode = %o, want %o", got, config.BobSettingsFileMode)
+	}
+}
+
 // TestEnsureBobAuthSettingsWrongTypes covers intermediates of the wrong JSON
 // type. There is no sane merge, so they are replaced rather than crashing.
 func TestEnsureBobAuthSettingsWrongTypes(t *testing.T) {
@@ -465,6 +485,31 @@ func TestVerifyBobStateDirsWritableFlagsMissingDirWithUnwritableParent(t *testin
 	m := &Manager{logger: discardLogger()}
 	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
 	wantDir := filepath.Dir(bobSettingsPath(home))
+	if len(got) != 1 || got[0] != wantDir {
+		t.Errorf("verifyBobStateDirsWritable() = %v, want [%s]", got, wantDir)
+	}
+}
+
+func TestVerifyBobStateDirsWritableFlagsMissingNestedParent(t *testing.T) {
+	home := t.TempDir()
+	homeBob := filepath.Dir(bobSettingsPath(home))
+	if err := os.MkdirAll(homeBob, 0o770); err != nil {
+		t.Fatalf("mkdir home .bob: %v", err)
+	}
+	if err := os.Chmod(homeBob, 0o770); err != nil {
+		t.Fatalf("chmod home .bob: %v", err)
+	}
+
+	workRoot := t.TempDir()
+	if err := os.Chmod(workRoot, 0o750); err != nil {
+		t.Fatalf("chmod workRoot: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(workRoot, 0o770) })
+	workDir := filepath.Join(workRoot, "agents", "tester")
+
+	m := &Manager{logger: discardLogger()}
+	got := m.verifyBobStateDirsWritable("tester", home, workDir, 2004)
+	wantDir := filepath.Join(workDir, config.BobStateDirName)
 	if len(got) != 1 || got[0] != wantDir {
 		t.Errorf("verifyBobStateDirsWritable() = %v, want [%s]", got, wantDir)
 	}


### PR DESCRIPTION
## Why

Closes #3490.

`v2/pkg/agent/authprobe.go` and `v2/pkg/agent/bob_settings.go` gate credential detection and Bob auth-state persistence. This adds targeted tests that use `t.TempDir()`/existing package seams instead of the developer's real HOME or credentials.

## What changed

- Added authprobe coverage for isolated Claude missing-vs-present credential detection and HOME/shared fallback path ordering (`v2/pkg/agent/authprobe_test.go:133`, `v2/pkg/agent/authprobe_test.go:158`).
- Added Bob settings coverage for malformed JSON rewrites preserving the shared settings file mode (`v2/pkg/agent/bob_settings_test.go:172`).
- Added Bob state-dir coverage for missing nested parents where Bob's recursive mkdir would fail for agent UIDs (`v2/pkg/agent/bob_settings_test.go:493`).

No production seam or production-code change was needed, and no real defect was found while adding these tests.

## Sabotage verification

I deliberately broke the production guards, re-ran the new tests with `-v`, confirmed the specific tests failed, then reverted the sabotage:

- Disabled Claude token probing: `TestAgentAuthState_ClaudeCredentialFileMissingThenPresent` failed.
- Broke `AgentHome` HOME handling: `TestAgentAuthPathConstructionUsesIsolatedHomes` failed.
- Changed Bob settings chmod to `0600`: `TestEnsureBobAuthSettingsMalformedJSONRewritesWithSharedMode` failed.
- Skipped the missing-parent writability append: `TestVerifyBobStateDirsWritableFlagsMissingNestedParent` failed.

## Verification

- `cd /Users/andan02/wt-i3490/v2 && gofmt -l .` (exit 0; modified files were not listed, while existing unrelated gofmt drift remains in the tree)
- `cd /Users/andan02/wt-i3490/v2 && go build ./...`
- `cd /Users/andan02/wt-i3490/v2 && go test ./pkg/agent/`
- Scanned validation output with `grep -E -e '--- FAIL' -e '^FAIL'`; no failure markers were present.
