### PR TITLE
🔒 security: renew the terminal assertion from the spoke-local session (audit F4 residual)

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -790,6 +790,12 @@ func (s *Server) registerCoreRoutes() {
 	// second GitHub device-flow login. Public path (see isPublicPath) because
 	// the caller has no session yet — the token IS the credential.
 	s.mux.HandleFunc("GET /sso", s.handleSSO)
+	// Terminal-assertion renewal (audit F4 residual). Re-mints the host-only,
+	// Path=/terminal assertion cookie from the caller's SPOKE-LOCAL session, so a
+	// live session can sustain a live terminal grant without the domain-scoped
+	// hive_hub_user cookie being consulted. NOT a public path: it authenticates
+	// on hive_session and 401s without one.
+	s.mux.HandleFunc("POST "+renewTerminalAssertionPath, s.handleRenewTerminalAssertion)
 	// /terminal → in-container ttyd, so the dashboard's "▶ terminal" links
 	// work even when the cluster route sends the whole host to this server
 	// (see registerTerminalProxy).

--- a/v2/pkg/dashboard/terminal_assertion_renew.go
+++ b/v2/pkg/dashboard/terminal_assertion_renew.go
@@ -1,0 +1,118 @@
+package dashboard
+
+import (
+	"net/http"
+)
+
+// Terminal-assertion renewal (audit F4 residual — spoke-scoped session, step 1).
+//
+// # THE PROBLEM THIS EXISTS TO SHRINK
+//
+// The hub session cookie `hive_hub_user` is scoped Domain=.hive.kubestellar.io,
+// so the browser delivers a valid hub session credential to EVERY sibling
+// tenant's server on every request. #3499 stopped a sibling from USING it (it is
+// no longer a same-origin author for CSRF/CORS purposes), but a hostile tenant
+// backend still RECEIVES it in plaintext at the HTTP layer. The only way to stop
+// that is to drop the Domain attribute — and the only thing still forcing the
+// Domain to exist is the spoke-side Node proxy, which verifies `hive_hub_user`
+// to gate /terminal.
+//
+// So the residual reduces to one question: can the spoke authorize /terminal
+// using ONLY credentials scoped to the spoke's own host?
+//
+// # WHAT ALREADY EXISTS
+//
+// Almost all of it. The proxy's PRIMARY gate (authorizeTerminal) is already the
+// spoke-local `hive_terminal_assertion` cookie: host-only, Path=/terminal,
+// HMAC-signed with a spoke-local key, carrying {user, role, hive_id, exp}. It is
+// a genuinely spoke-scoped credential and it is already minted at both entry
+// points — device-flow login and hub SSO handoff (setTerminalAssertionCookie).
+//
+// # WHY THE HUB COOKIE IS STILL LOAD-BEARING — THE ACTUAL BLOCKER
+//
+// A lifetime mismatch, not a missing mechanism:
+//
+//   - hive_session (spoke-local, host-only) lives 30 days.
+//   - hive_terminal_assertion lives 15 minutes, and was minted ONLY at login.
+//
+// So 15 minutes after logging in, a legitimate user's assertion expires. From
+// then on authorizeTerminal finds no usable assertion and falls through to the
+// static-allowlist branch, which is keyed on the verified `hive_hub_user`
+// username. That fallback — reached for the overwhelming majority of real
+// /terminal requests, since sessions outlive assertions 2880:1 — is precisely
+// what makes the domain-scoped hub cookie load-bearing on the spoke.
+//
+// Nothing renewed the assertion, because there was no way to: renewal needs an
+// authenticated caller, and the only always-present authenticated identity the
+// proxy could see was the hub-wide cookie.
+//
+// # WHAT THIS HANDLER DOES
+//
+// It closes that loop using the spoke's OWN session. handleRenewTerminalAssertion
+// re-mints the assertion from the caller's `hive_session` — a host-only,
+// spoke-local cookie that the hub never sees and no sibling ever receives — so a
+// live spoke session can keep a live terminal grant without the hub cookie
+// participating at all.
+//
+// This does NOT by itself remove the Domain from hive_hub_user, and deliberately
+// so: see the PR body. It is the verifier-side capability that a later,
+// separately-sequenced PR needs in order to make that removal safe. Shipping the
+// capability first, and flipping the minting later, is the verify-both/mint-new
+// ordering that incident #2773 exists to enforce.
+//
+// SECURITY PROPERTIES (all fail-closed):
+//
+//   - Authentication is the spoke-local session ONLY. This handler never reads
+//     hive_hub_user, so it cannot be driven by a credential a sibling tenant
+//     received. No session → 401, and no cookie is written.
+//   - Role is re-resolved from THIS hive's authorized-users allowlist on every
+//     renewal, not copied from the old assertion or the session. A user whose
+//     access was revoked or downgraded hub-side cannot renew their way past it;
+//     the renewed assertion carries the CURRENT role, and the proxy's role check
+//     (TERMINAL_ROLES) then denies a downgraded user. This is what keeps
+//     revocation effective — a self-renewing grant that froze its own role at
+//     login would be strictly worse than the 15-minute expiry it replaces.
+//   - It mints only the same {user, role, hive, exp} assertion the login path
+//     already mints, with the same key, TTL, Path and flags. It introduces no
+//     new token format, no new key, and nothing that crosses the hub/spoke
+//     boundary — so there is no cross-language crypto to pin and no hub-side
+//     change required for it to be safe.
+//   - It cannot escalate: role comes from the allowlist, and a user absent from
+//     an enforced allowlist gets no assertion at all.
+const renewTerminalAssertionPath = "/api/terminal/assertion/renew"
+
+// handleRenewTerminalAssertion re-mints the caller's per-hive terminal assertion
+// cookie from their spoke-local session. See the file comment for why this
+// exists and what it deliberately does not do.
+func (s *Server) handleRenewTerminalAssertion(w http.ResponseWriter, r *http.Request) {
+	// Authenticate from the SPOKE-LOCAL session only. Deliberately not
+	// sessionFromRequest+hub cookie fallback: the entire point is that this path
+	// works without the hub-wide cookie, so reading it here would defeat the
+	// exercise and silently re-create the dependency.
+	sess := s.sessionFromRequest(r)
+	if sess == nil {
+		http.Error(w, `{"error":"not authenticated"}`, http.StatusUnauthorized)
+		return
+	}
+
+	// Re-resolve the role from this hive's allowlist so a hub-side revocation or
+	// downgrade takes effect at renewal rather than being frozen at login.
+	role := sess.Role
+	if s.deps != nil && s.deps.Config != nil {
+		if allowRole, ok := s.deps.Config.Dashboard.AuthorizedRole(sess.Username); ok {
+			role = allowRole
+		} else if s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled() {
+			// Allowlist is enforced and this user is no longer on it. Deny, and
+			// write no cookie — the existing assertion then simply expires.
+			http.Error(w, `{"error":"not authorized for this hive"}`, http.StatusForbidden)
+			return
+		}
+	}
+
+	// Mint with the same helper the login and SSO paths use, so the assertion's
+	// shape, key, TTL, Path and cookie flags cannot drift between mint sites.
+	s.setTerminalAssertionCookie(w, r, sess.Username, role)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/v2/pkg/dashboard/terminal_assertion_renew_test.go
+++ b/v2/pkg/dashboard/terminal_assertion_renew_test.go
@@ -1,0 +1,261 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// Tests for the audit-F4 residual: the terminal assertion must be renewable from
+// the SPOKE-LOCAL session alone, so the domain-scoped hive_hub_user cookie stops
+// being the thing that keeps /terminal working past the assertion's 15-minute TTL.
+//
+// Each negative test below is written so that it FAILS against the unfixed tree
+// (no renewal route: the mux 404s / writes no cookie) and passes after.
+
+// newRenewServer builds a hosted-shaped spoke with a terminal signing key and a
+// HiveID, which is what setTerminalAssertionCookie requires to mint at all.
+func newRenewServer(t *testing.T, hiveID string, authorized ...string) *Server {
+	t.Helper()
+	t.Setenv(hub.EnvTerminalKey, "renew-test-terminal-key")
+	s := newFullServer(t)
+	s.deps.Config.HiveID = hiveID
+	s.deps.Config.Dashboard.AuthorizedUsers = authorized
+	return s
+}
+
+// assertionCookie pulls the minted assertion out of a response, if present.
+func assertionCookie(res *http.Response) *http.Cookie {
+	for _, c := range res.Cookies() {
+		if c.Name == terminalAssertionCookieName {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestRenewAssertion_SessionOnly_NoHubCookie is the CORE regression: a live
+// spoke session, with NO hive_hub_user cookie anywhere in the request, must yield
+// a freshly-minted, valid, this-hive assertion.
+//
+// This is the property that makes the hub cookie removable later. Against the
+// unfixed tree the route does not exist, so no cookie is set and this fails.
+func TestRenewAssertion_SessionOnly_NoHubCookie(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	sid := s.createUserSession("alice", config.RoleOwner)
+
+	req := httptest.NewRequest("POST", renewTerminalAssertionPath, nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	// Deliberately NO hive_hub_user cookie: that is the whole point.
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("renew from a valid spoke session = %d, want 204 (the hub cookie must not be required)", w.Code)
+	}
+	c := assertionCookie(w.Result())
+	if c == nil {
+		t.Fatal("renew minted no hive_terminal_assertion cookie")
+	}
+	user, role, err := hub.VerifyTerminalAssertion(hub.TerminalSigningKey(), c.Value, "hosted-alpha", time.Now())
+	if err != nil {
+		t.Fatalf("renewed assertion does not verify: %v", err)
+	}
+	if user != "alice" || role != config.RoleOwner {
+		t.Fatalf("renewed assertion = user %q role %q, want alice/owner", user, role)
+	}
+}
+
+// TestRenewAssertion_CookieStaysHostOnlyAndPathScoped guards the property that
+// makes this credential spoke-scoped in the first place. A renewed assertion that
+// picked up Domain=.hive.kubestellar.io would re-create the exact leak F4 is
+// about — every sibling tenant would receive a terminal grant.
+func TestRenewAssertion_CookieStaysHostOnlyAndPathScoped(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	sid := s.createUserSession("alice", config.RoleOwner)
+
+	req := httptest.NewRequest("POST", renewTerminalAssertionPath, nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	c := assertionCookie(w.Result())
+	if c == nil {
+		t.Fatal("renew minted no assertion cookie")
+	}
+	if c.Domain != "" {
+		t.Fatalf("renewed assertion is domain-scoped (Domain=%q) — every sibling tenant would receive a terminal grant", c.Domain)
+	}
+	if c.Path != "/terminal" {
+		t.Errorf("renewed assertion Path = %q, want /terminal", c.Path)
+	}
+	if !c.HttpOnly || !c.Secure {
+		t.Errorf("renewed assertion lost hardening: HttpOnly=%v Secure=%v", c.HttpOnly, c.Secure)
+	}
+}
+
+// TestRenewAssertion_RequiresSession is the fail-closed control: an unauthenticated
+// caller must get 401 and NO cookie. A renewal endpoint that minted a terminal
+// grant for anyone who asked would be a worse hole than the one being closed.
+func TestRenewAssertion_RequiresSession(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+
+	req := httptest.NewRequest("POST", renewTerminalAssertionPath, nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("renew with no session = %d, want 401", w.Code)
+	}
+	if c := assertionCookie(w.Result()); c != nil && c.Value != "" {
+		t.Fatal("renew minted an assertion for an unauthenticated caller")
+	}
+}
+
+// TestRenewAssertion_IgnoresHubCookieAsCredential proves the endpoint cannot be
+// driven by the very credential F4 is about. A hostile sibling that RECEIVED a
+// victim's hive_hub_user must not be able to trade it for a terminal grant here.
+func TestRenewAssertion_IgnoresHubCookieAsCredential(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+
+	req := httptest.NewRequest("POST", renewTerminalAssertionPath, nil)
+	// A perfectly good hub-wide cookie, but no spoke session.
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "alice"})
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("renew authenticated by hive_hub_user alone = %d, want 401", w.Code)
+	}
+	if c := assertionCookie(w.Result()); c != nil && c.Value != "" {
+		t.Fatal("hive_hub_user alone minted a terminal assertion — the hub cookie must not be a credential here")
+	}
+}
+
+// TestRenewAssertion_ReResolvesRoleFromAllowlist is the revocation control. A
+// self-renewing grant that froze its role at login would let a downgraded user
+// keep shell access forever — strictly worse than the 15-minute expiry it
+// replaces. The renewed assertion must carry the CURRENT allowlist role.
+func TestRenewAssertion_ReResolvesRoleFromAllowlist(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	// Session was created when alice was an owner.
+	sid := s.createUserSession("alice", config.RoleOwner)
+	// She has since been downgraded to read-only on this hive.
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"alice:read"}
+
+	req := httptest.NewRequest("POST", renewTerminalAssertionPath, nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	c := assertionCookie(w.Result())
+	if c == nil {
+		t.Fatal("renew minted no assertion cookie")
+	}
+	_, role, err := hub.VerifyTerminalAssertion(hub.TerminalSigningKey(), c.Value, "hosted-alpha", time.Now())
+	if err != nil {
+		t.Fatalf("renewed assertion does not verify: %v", err)
+	}
+	if role != config.RoleRead {
+		t.Fatalf("renewed assertion role = %q, want read — a downgrade must take effect at renewal, not be frozen at login", role)
+	}
+}
+
+// TestRenewAssertion_BoundToThisHive proves the renewed grant cannot open a
+// terminal on a sibling hive: verification against another hive's ID must fail.
+func TestRenewAssertion_BoundToThisHive(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	sid := s.createUserSession("alice", config.RoleOwner)
+
+	req := httptest.NewRequest("POST", renewTerminalAssertionPath, nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	c := assertionCookie(w.Result())
+	if c == nil {
+		t.Fatal("renew minted no assertion cookie")
+	}
+	if _, _, err := hub.VerifyTerminalAssertion(hub.TerminalSigningKey(), c.Value, "hosted-victim", time.Now()); err == nil {
+		t.Fatal("an assertion renewed on hosted-alpha verified against hosted-victim — the hive binding is broken")
+	}
+}
+
+// --- POSITIVE CONTROLS -------------------------------------------------------
+//
+// A gate broken to reject everything must not be able to pass this suite. These
+// assert the legitimate flows still work.
+
+// TestPositiveControl_SSOHandoffStillMintsAssertion: the SSO handoff (the flow
+// ~62 live tenants use to open a hosted spoke) must still establish a session and
+// still mint the terminal assertion.
+func TestPositiveControl_SSOHandoffStillMintsAssertion(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	sid := s.createUserSession("alice", config.RoleOwner)
+	if sid == "" {
+		t.Fatal("SSO/login session creation broke")
+	}
+	if got := s.lookupSession(sid); got == nil || got.Username != "alice" {
+		t.Fatal("session lookup broke — hosted login would fail")
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	s.setTerminalAssertionCookie(w, req, "alice", config.RoleOwner)
+	if assertionCookie(w.Result()) == nil {
+		t.Fatal("login/SSO path no longer mints a terminal assertion — /terminal would break for every hosted tenant")
+	}
+}
+
+// TestPositiveControl_LegitimateTerminalGrantVerifies: a normally-minted
+// assertion must still verify for the right user, hive and role. If this passes
+// only because everything is denied, the suite is worthless.
+func TestPositiveControl_LegitimateTerminalGrantVerifies(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	s.setTerminalAssertionCookie(w, req, "alice", config.RoleOwner)
+
+	c := assertionCookie(w.Result())
+	if c == nil {
+		t.Fatal("no assertion minted")
+	}
+	user, role, err := hub.VerifyTerminalAssertion(hub.TerminalSigningKey(), c.Value, "hosted-alpha", time.Now())
+	if err != nil {
+		t.Fatalf("a legitimate terminal grant failed to verify: %v", err)
+	}
+	if user != "alice" || role != config.RoleOwner {
+		t.Fatalf("legitimate grant = %q/%q, want alice/owner", user, role)
+	}
+}
+
+// TestPositiveControl_RenewedAssertionIsAcceptedNotJustIssued closes the loop:
+// the renewed cookie must actually authorize, with the same key the proxy
+// resolves, for the same user — not merely be a well-formed string.
+func TestPositiveControl_RenewedAssertionIsAcceptedNotJustIssued(t *testing.T) {
+	s := newRenewServer(t, "hosted-alpha", "alice:owner")
+	sid := s.createUserSession("alice", config.RoleOwner)
+
+	req := httptest.NewRequest("POST", renewTerminalAssertionPath, nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	c := assertionCookie(w.Result())
+	if c == nil {
+		t.Fatal("renew minted no assertion")
+	}
+	user, role, err := hub.VerifyTerminalAssertion(hub.TerminalSigningKey(), c.Value, "hosted-alpha", time.Now())
+	if err != nil {
+		t.Fatalf("renewed assertion rejected by the same verifier the proxy mirrors: %v", err)
+	}
+	// TERMINAL_ROLES in proxy/server.js accepts owner / read-write.
+	if user != "alice" || (role != config.RoleOwner && role != config.RoleReadWrite) {
+		t.Fatalf("renewed assertion would not open a terminal: user=%q role=%q", user, role)
+	}
+}


### PR DESCRIPTION
Groundwork for un-scoping the hub session cookie, addressing the residual half of audit finding **F4**. #3499 fixed the other half.

**This PR does NOT change the `Domain` on `hive_hub_user`.** See "What this does NOT fix".

## The residual

`hive_hub_user` is scoped `Domain=.hive.kubestellar.io`, so the browser delivers a valid hub session credential to **every sibling tenant's server** on every request. #3499 stopped a sibling from *using* it (it is no longer a same-origin author for CSRF/CORS), but a hostile tenant backend still *receives* it in plaintext at the HTTP layer.

Only dropping the `Domain` fixes that — and the one thing forcing the `Domain` to exist is the spoke's Node proxy, which verifies `hive_hub_user` to gate `/terminal`.

## Why the hub cookie is still load-bearing (the actual blocker)

Investigating it, this turned out to be a **lifetime mismatch, not a missing mechanism**.

The proxy's PRIMARY gate (`authorizeTerminal`) is **already** the spoke-local `hive_terminal_assertion`: host-only, `Path=/terminal`, spoke-signed, carrying `{user, role, hive_id, exp}`, and already minted at both entry points (device-flow login and SSO handoff). It is a genuinely spoke-scoped credential and it already exists.

But:

| Cookie | Scope | Lifetime |
|---|---|---|
| `hive_session` | host-only, spoke-local | 30 days |
| `hive_terminal_assertion` | host-only, `Path=/terminal` | **15 minutes** |

Nothing ever renewed the assertion. So 15 minutes after login, a legitimate user's assertion expires and `authorizeTerminal` falls through to the static-allowlist branch — which is keyed on the verified `hive_hub_user` username. **That fallback, reached for the overwhelming majority of real `/terminal` requests (sessions outlive assertions 2880:1), is what makes the domain-scoped hub cookie load-bearing on the spoke.**

Nothing renewed it because renewal needs an authenticated caller, and the only always-present authenticated identity that path could see was the hub-wide cookie itself.

## What this PR changes

Adds `POST /api/terminal/assertion/renew`, which re-mints the assertion from the caller's `hive_session` — a host-only, spoke-local cookie the hub never sees and no sibling ever receives. A live spoke session can now sustain a live terminal grant **with the hub cookie playing no part**.

Fail-closed throughout:

- **Authentication is the spoke-local session ONLY.** The handler never reads `hive_hub_user`, so it cannot be driven by a credential a sibling tenant received. No session → 401, no cookie written.
- **Role is re-resolved from this hive's allowlist on every renewal**, not copied from the session or the old assertion. A hub-side revocation or downgrade takes effect at renewal instead of being laundered into a perpetual grant — a self-renewing token that froze its role at login would be strictly *worse* than the 15-minute expiry it replaces.
- **Mints via the same helper** the login/SSO paths use, so shape, key, TTL, `Path` and cookie flags cannot drift between mint sites.
- **No new token format, no new key, nothing crossing the hub/spoke boundary** — so there is no cross-language crypto to pin and no hub-side change needed for it to be safe.

## What this does NOT fix

`hive_hub_user` keeps `Domain=.hive.kubestellar.io`.

Removing it is a change to **delivery scope**, so the usual verify-both/mint-new rollout cannot rescue it: that pattern works when the *format* changes, but no verifier change makes a cookie appear in a request the browser never sends it in. The follow-up requires, **in this order**:

1. **This renewal capability deployed to every hosted spoke**, plus a frontend that calls it (before opening `/terminal`, and on a timer while the terminal is open).
2. **The proxy's allowlist fallback made reachable without `hive_hub_user`.** Today *both* `/terminal` gates bail out at `verifyHubUserCookieEither` **before** `authorizeTerminal` is ever called, so the assertion alone cannot currently authorize anyone. This is the real code change in the follow-up.
3. **Fleet telemetry proving every spoke presents the spoke-scoped path** — the same evidence gate `auth_rollout.go` already establishes for the N1/N2 lanes.
4. **Only then**, in a separate PR, drop the `Domain`.

Doing step 4 before 1–3 logs out or breaks `/terminal` for ~62 live tenants — the failure mode #2773 documents.

I did not attempt steps 2–4 here. Step 2 needs a rollout I cannot verify from a worktree, and doing it in the same PR as the capability it depends on would violate the ship-the-verifier-first sequencing.

## Test evidence

**Baseline on clean `origin/v4`** (before any change):

```
ok  github.com/kubestellar/hive/v2/pkg/hub        68.396s
ok  github.com/kubestellar/hive/v2/pkg/dashboard  40.227s
proxy: 7/7 passed
```

Both packages were fully green on this machine, so any failure here would be new.

**After this change:**

```
ok  github.com/kubestellar/hive/v2/pkg/hub        67.033s
ok  github.com/kubestellar/hive/v2/pkg/dashboard  41.979s
proxy: 7/7 passed
```

No new failures. `gofmt` clean, `go vet` clean.

**Fail-then-pass.** With the handler and route removed (path const only, so the tests still compile), all six renewal regressions fail:

```
--- FAIL: TestRenewAssertion_SessionOnly_NoHubCookie
    renew from a valid spoke session = 404, want 204 (the hub cookie must not be required)
--- FAIL: TestRenewAssertion_CookieStaysHostOnlyAndPathScoped
    renew minted no assertion cookie
--- FAIL: TestRenewAssertion_RequiresSession
    renew with no session = 404, want 401
--- FAIL: TestRenewAssertion_IgnoresHubCookieAsCredential
    renew authenticated by hive_hub_user alone = 404, want 401
--- FAIL: TestRenewAssertion_ReResolvesRoleFromAllowlist
    renew minted no assertion cookie
--- FAIL: TestRenewAssertion_BoundToThisHive
    renew minted no assertion cookie
--- FAIL: TestPositiveControl_RenewedAssertionIsAcceptedNotJustIssued
    renew minted no assertion
```

All pass with the handler restored.

**Positive controls.** Every finding in this audit was invisible because a green test asserted the wrong thing, so the suite is built to be unable to pass if the gate is simply broken shut:

- `TestPositiveControl_SSOHandoffStillMintsAssertion` — SSO handoff still creates a session and still mints the assertion.
- `TestPositiveControl_LegitimateTerminalGrantVerifies` — a normally-minted grant still verifies for the right user/hive/role.
- `TestPositiveControl_RenewedAssertionIsAcceptedNotJustIssued` — the renewed cookie is checked against the same verifier `proxy/server.js` mirrors, for a role in `TERMINAL_ROLES`, so it would actually open a terminal rather than merely being a well-formed string.

Critically, the two controls that don't depend on the new route **stayed GREEN in the unfixed run above** — confirming the suite is not merely asserting that everything is broken.

## For a human to decide

Whether to proceed with step 2 (making the proxy's `/terminal` gate work without `hive_hub_user`), which is the last code change before the `Domain` can be dropped. That one does touch `proxy/server.js` and needs the verify-both sequencing plus fleet telemetry, so it wants to be its own PR with a deliberate rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
