### PR TITLE
🔒 fix(hub): sign session lifetime and make sessions revocable (audit F10)

### DIFF
--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -3,10 +3,13 @@ package hub
 import (
 	"crypto/ed25519"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"strings"
+	"time"
 )
 
 // Hub session cookie integrity.
@@ -101,6 +104,215 @@ func verifyHubUserCookieValueV2(pubHex, value string) (string, bool) {
 	return username, true
 }
 
+// AUDIT F10 (session lifetime is neither signed nor revocable).
+//
+// The v2 signature above covers ONLY the username. That leaves two holes:
+//
+//  1. The cookie's lifetime lives entirely in the browser's `MaxAge`. MaxAge is
+//     a hint to the browser, not a server-side claim — a copied cookie value is
+//     accepted forever, because nothing in the signed bytes says when it was
+//     issued or when it stops being valid.
+//  2. Logout only deletes the browser's copy. Anyone who captured the value
+//     keeps a working session across logout, password change, or account
+//     removal, for as long as the signing key stays accepted.
+//
+// v3 closes both by moving the claims INSIDE the signature:
+//
+//	v3 value = <base64url(JSON{u,iat,exp,sid})>.v3.<base64url(Ed25519-Sign(payload))>
+//
+// The signature covers the encoded payload bytes, so issued-at, expiry, and the
+// session ID are all tamper-evident. Expiry is then enforced by the VERIFIER
+// (hub and spoke alike) rather than trusted to the browser, and `sid` gives
+// logout something concrete to revoke — see hub_session_revocation.go.
+//
+// Unlike v2, the username is no longer in the clear at the head of the value;
+// it is a field of the signed payload. That is why v3 needs its own marker: the
+// two shapes are not parseable by the same code, and the marker is what lets a
+// single verifier route the value to the right parser without guessing.
+const hubCookieV3Marker = ".v3."
+
+// hubCookieClaims are the signed contents of a v3 session cookie. Field names
+// are SHORT and FROZEN: the Node proxy (v2/proxy/server.js) parses these exact
+// JSON keys, and a rename on one side alone silently 401s every hosted login at
+// deploy time. Do not "tidy" them.
+type hubCookieClaims struct {
+	// U is the GitHub login this session authenticates as.
+	U string `json:"u"`
+	// IAT is the issued-at time, Unix seconds.
+	IAT int64 `json:"iat"`
+	// EXP is the hard expiry, Unix seconds. Enforced server-side, unlike the
+	// browser's MaxAge, so a copied cookie dies on schedule.
+	EXP int64 `json:"exp"`
+	// SID is the unguessable per-session ID that revocation is keyed on. It is
+	// what makes logout mean something for a value that has already left the
+	// browser.
+	SID string `json:"sid"`
+}
+
+// hubCookieSessionIDBytes is the entropy behind a session ID. Matches
+// oauthStateNonceBytes: a revocation key that can be guessed is a revocation
+// key that can be exhausted by an attacker probing which sessions are live.
+const hubCookieSessionIDBytes = 32
+
+// newHubCookieSessionID mints an unguessable session ID, or "" if the system
+// CSPRNG fails — callers must fail closed rather than mint a predictable SID.
+func newHubCookieSessionID() string {
+	buf := make([]byte, hubCookieSessionIDBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(buf)
+}
+
+// mintHubUserCookieValueV3 mints an Ed25519-signed session cookie carrying a
+// signed lifetime and session ID. seedHex is the hub's PRIVATE session seed.
+//
+// NOTHING CALLS THIS IN PRODUCTION YET, deliberately. The cookie is verified by
+// the hub (Go) AND independently by every spoke's Node proxy; minting a shape a
+// not-yet-rolled spoke cannot parse breaks /terminal fleet-wide. That is
+// incident #2773. Minting flips only once the whole fleet verifies v3 — see the
+// rollout note on verifyHubUserCookieEither.
+//
+// Returns "" on empty inputs, a bad seed, a non-positive ttl, or a CSPRNG
+// failure — fail closed rather than sign junk, matching mintHubUserCookieValueV2.
+func mintHubUserCookieValueV3(seedHex, username string, now time.Time, ttl time.Duration) (value, sid string) {
+	if seedHex == "" || username == "" || ttl <= 0 {
+		return "", ""
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return "", ""
+	}
+	sid = newHubCookieSessionID()
+	if sid == "" {
+		return "", ""
+	}
+	payload, err := json.Marshal(hubCookieClaims{
+		U:   username,
+		IAT: now.Unix(),
+		EXP: now.Add(ttl).Unix(),
+		SID: sid,
+	})
+	if err != nil {
+		return "", ""
+	}
+	body := hubCookieB64.EncodeToString(payload)
+	priv := ed25519.NewKeyFromSeed(seed)
+	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(body)))
+	return body + hubCookieV3Marker + sig, sid
+}
+
+// hubSessionRevokedFunc reports whether a session ID has been revoked. Passed in
+// rather than reached for so the cookie layer stays a pure function of its
+// inputs and the tests can drive revocation directly. A nil func means "nothing
+// is revoked" — which is the correct behaviour for the spoke-side verifier,
+// which has no revocation store of its own.
+type hubSessionRevokedFunc func(sid string) bool
+
+// verifyHubUserCookieValueV3 verifies a v3 cookie against the hub's PUBLIC
+// session key AND enforces its signed lifetime and revocation state. Returns
+// (username, true) only when the signature verifies, the clock window is
+// satisfied, and the session ID has not been revoked.
+//
+// Order matters: the signature is checked BEFORE any payload byte is trusted,
+// exactly as VerifyTerminalAssertion does. Parsing attacker-controlled JSON
+// before authenticating it is how payload parsers become the attack surface.
+func verifyHubUserCookieValueV3(pubHex, value string, now time.Time, revoked hubSessionRevokedFunc) (string, bool) {
+	if pubHex == "" || value == "" {
+		return "", false
+	}
+	idx := strings.LastIndex(value, hubCookieV3Marker)
+	if idx <= 0 {
+		return "", false
+	}
+	body := value[:idx]
+	sigB64 := value[idx+len(hubCookieV3Marker):]
+	if body == "" || sigB64 == "" {
+		return "", false
+	}
+	pub, err := hex.DecodeString(strings.TrimSpace(pubHex))
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return "", false
+	}
+	sig, err := hubCookieB64.DecodeString(sigB64)
+	if err != nil {
+		return "", false
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(body), sig) {
+		return "", false
+	}
+	raw, err := hubCookieB64.DecodeString(body)
+	if err != nil {
+		return "", false
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return "", false
+	}
+	if claims.U == "" || claims.SID == "" {
+		return "", false
+	}
+	// Clock-skew tolerance mirrors VerifyTerminalAssertion: hub and spoke are
+	// separate clusters and their clocks drift, so a strict comparison would
+	// reject freshly minted cookies on a spoke running seconds ahead.
+	nowUnix := now.Unix()
+	skew := int64(ssoClockSkew / time.Second)
+	if claims.IAT > nowUnix+skew {
+		return "", false // not yet valid
+	}
+	if claims.EXP < nowUnix-skew {
+		return "", false // expired
+	}
+	if revoked != nil && revoked(claims.SID) {
+		return "", false
+	}
+	return claims.U, true
+}
+
+// hubCookieSessionID returns the session ID carried by a v3 cookie, or "" for
+// any other shape. Used by logout to learn WHICH session to revoke.
+//
+// This deliberately does NOT verify the signature: it is only ever called on a
+// value that a verifier already accepted, and its result is used solely to add
+// an entry to the revocation set. The worst an unverified caller could achieve
+// is revoking a session ID it already knows — which is not an escalation.
+func hubCookieSessionID(value string) string {
+	idx := strings.LastIndex(value, hubCookieV3Marker)
+	if idx <= 0 {
+		return ""
+	}
+	raw, err := hubCookieB64.DecodeString(value[:idx])
+	if err != nil {
+		return ""
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return ""
+	}
+	return claims.SID
+}
+
+// hubCookieExpiry returns the signed expiry (Unix seconds) carried by a v3
+// cookie, or 0 for any other shape. Like hubCookieSessionID this reads the
+// payload without re-verifying; it bounds how long a revocation entry is kept,
+// and an attacker who inflated it would only be lengthening the revocation of
+// their OWN session.
+func hubCookieExpiry(value string) int64 {
+	idx := strings.LastIndex(value, hubCookieV3Marker)
+	if idx <= 0 {
+		return 0
+	}
+	raw, err := hubCookieB64.DecodeString(value[:idx])
+	if err != nil {
+		return 0
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return 0
+	}
+	return claims.EXP
+}
+
 // mintHubUserCookieValue returns the signed, tamper-evident cookie value for
 // username. It returns "" when no secret is configured or the username is empty
 // — callers must treat that as "cannot establish a session" rather than emitting
@@ -159,11 +371,36 @@ func hubCookieSign(secret, username string) string {
 //
 // legacySecret may be "" to disable the legacy lane entirely, which is what the
 // removal PR will pass.
+// F10 adds a THIRD lane, tried first: v3 → v2 → legacy HMAC. Strictly additive.
+// The v2 and legacy lanes are the N2/F1/F2 compatibility paths — removing either
+// one 401s the part of the fleet that has not rolled, so neither goes away here.
+//
+// verifyHubUserCookieEither keeps its original 3-argument shape so no existing
+// call site changes. It cannot consult the revocation store (it has no server
+// handle), so it passes nil: a v3 cookie is still checked for signature and for
+// signed expiry, just not for revocation. Call sites that CAN revoke use
+// verifyHubUserCookieEitherAt via HubServer.verifyHubUserCookie.
 func verifyHubUserCookieEither(pubHex, legacySecret, value string) (string, bool) {
+	return verifyHubUserCookieEitherAt(pubHex, legacySecret, value, time.Now(), nil)
+}
+
+// verifyHubUserCookieEitherAt is verifyHubUserCookieEither with the verifier's
+// clock and revocation lookup made explicit, so expiry and revocation are
+// testable without touching global state.
+func verifyHubUserCookieEitherAt(pubHex, legacySecret, value string, now time.Time, revoked hubSessionRevokedFunc) (string, bool) {
+	if u, ok := verifyHubUserCookieValueV3(pubHex, value, now, revoked); ok {
+		return u, true
+	}
 	if u, ok := verifyHubUserCookieValueV2(pubHex, value); ok {
 		return u, true
 	}
 	return verifyHubUserCookieValue(legacySecret, value)
+}
+
+// hubCookieIsV3 reports whether a cookie value carries the F10 format. Rollout
+// telemetry only — never an authorization decision on its own.
+func hubCookieIsV3(value string) bool {
+	return strings.Contains(value, hubCookieV3Marker)
 }
 
 // hubCookieIsV2 reports whether a cookie value carries the asymmetric format.

--- a/v2/pkg/hub/hub_cookie_v3_test.go
+++ b/v2/pkg/hub/hub_cookie_v3_test.go
@@ -1,0 +1,415 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// AUDIT F10 regressions.
+//
+// The finding: the v2 signature covers only the username, so the cookie's
+// lifetime is whatever the BROWSER chooses to honour, and logout only deletes
+// the browser's copy. A captured cookie therefore outlives both its MaxAge and
+// its own logout.
+//
+// Every test here that asserts a REJECTION is paired with a POSITIVE CONTROL
+// that asserts acceptance. A rejection-only suite passes just as green against a
+// verifier that rejects everything, which is precisely how the original finding
+// stayed invisible.
+
+// f10TestSeed is a deterministic 32-byte Ed25519 seed. Test-only key material.
+const f10TestSeed = "4f2c9a1b7e3d5068a4c2e6f81937bd50a1c3e5f7092b4d6688aa11cc33ee5577"
+
+func f10PubKey(t *testing.T) string {
+	t.Helper()
+	pub := ssoPublicKeyFromSeed(f10TestSeed)
+	if pub == "" {
+		t.Fatal("could not derive public key from test seed")
+	}
+	return pub
+}
+
+// TestF10_V3CookieCarriesSignedLifetimeAndSession is the core of the finding:
+// the signed bytes must actually contain iat/exp/sid. Against unfixed code there
+// is no v3 minter at all, so this cannot compile — which is the strongest form
+// of "fails against the unfixed code".
+func TestF10_V3CookieCarriesSignedLifetimeAndSession(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	value, sid := mintHubUserCookieValueV3(f10TestSeed, "clubanderson", now, time.Hour)
+	if value == "" || sid == "" {
+		t.Fatal("mint returned empty value/sid")
+	}
+	if !strings.Contains(value, hubCookieV3Marker) {
+		t.Fatalf("v3 cookie missing %q marker: %q", hubCookieV3Marker, value)
+	}
+	body := value[:strings.LastIndex(value, hubCookieV3Marker)]
+	raw, err := hubCookieB64.DecodeString(body)
+	if err != nil {
+		t.Fatalf("payload is not base64url: %v", err)
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		t.Fatalf("payload is not the frozen JSON shape: %v", err)
+	}
+	if claims.U != "clubanderson" {
+		t.Errorf("u = %q, want clubanderson", claims.U)
+	}
+	if claims.IAT != now.Unix() {
+		t.Errorf("iat = %d, want %d", claims.IAT, now.Unix())
+	}
+	if claims.EXP != now.Add(time.Hour).Unix() {
+		t.Errorf("exp = %d, want %d", claims.EXP, now.Add(time.Hour).Unix())
+	}
+	if claims.SID != sid {
+		t.Errorf("sid in payload = %q, want %q", claims.SID, sid)
+	}
+	// Frozen wire contract shared with the Node proxy. A rename here without the
+	// matching rename there 401s every hosted login at deploy, production-only.
+	for _, key := range []string{`"u"`, `"iat"`, `"exp"`, `"sid"`} {
+		if !strings.Contains(string(raw), key) {
+			t.Errorf("payload JSON missing frozen key %s: %s", key, raw)
+		}
+	}
+}
+
+// TestF10_V3VerificationBoundaries table-tests every way a v3 cookie can be
+// bad, and — critically — the ways it must still be GOOD.
+func TestF10_V3VerificationBoundaries(t *testing.T) {
+	pub := f10PubKey(t)
+	now := time.Unix(1_700_000_000, 0)
+
+	valid, validSID := mintHubUserCookieValueV3(f10TestSeed, "alice", now, time.Hour)
+	expired, _ := mintHubUserCookieValueV3(f10TestSeed, "alice", now.Add(-2*time.Hour), time.Hour)
+	future, _ := mintHubUserCookieValueV3(f10TestSeed, "alice", now.Add(time.Hour), time.Hour)
+
+	// Tampered payload: re-encode claims with a different username but keep the
+	// original signature. This is the impersonation attempt the signature exists
+	// to stop.
+	tamperedPayload := func() string {
+		idx := strings.LastIndex(valid, hubCookieV3Marker)
+		raw, _ := hubCookieB64.DecodeString(valid[:idx])
+		var c hubCookieClaims
+		_ = json.Unmarshal(raw, &c)
+		c.U = "clubanderson" // the hub admin
+		forged, _ := json.Marshal(c)
+		return hubCookieB64.EncodeToString(forged) + valid[idx:]
+	}()
+
+	// Tampered expiry only: extend exp far into the future, keep everything else.
+	// Without a signature over the payload this would be a free session extension.
+	tamperedExpiry := func() string {
+		idx := strings.LastIndex(valid, hubCookieV3Marker)
+		raw, _ := hubCookieB64.DecodeString(valid[:idx])
+		var c hubCookieClaims
+		_ = json.Unmarshal(raw, &c)
+		c.EXP = now.Add(100 * 365 * 24 * time.Hour).Unix()
+		forged, _ := json.Marshal(c)
+		return hubCookieB64.EncodeToString(forged) + valid[idx:]
+	}()
+
+	tamperedSig := func() string {
+		idx := strings.LastIndex(valid, hubCookieV3Marker)
+		sig := []byte(valid[idx+len(hubCookieV3Marker):])
+		if sig[0] == 'A' {
+			sig[0] = 'B'
+		} else {
+			sig[0] = 'A'
+		}
+		return valid[:idx+len(hubCookieV3Marker)] + string(sig)
+	}()
+
+	revokeSID := func(target string) hubSessionRevokedFunc {
+		return func(sid string) bool { return sid == target }
+	}
+
+	tests := []struct {
+		name     string
+		value    string
+		now      time.Time
+		revoked  hubSessionRevokedFunc
+		wantUser string
+		wantOK   bool
+	}{
+		// --- POSITIVE CONTROLS. Without these the suite would pass against a
+		// verifier that simply returns false for everything.
+		{"valid unexpired unrevoked verifies", valid, now, nil, "alice", true},
+		{"valid with a revocation set that does not contain it", valid, now, revokeSID("someone-else"), "alice", true},
+		{"valid just inside expiry", valid, now.Add(59 * time.Minute), nil, "alice", true},
+		{"expired but within clock skew still verifies", valid, now.Add(time.Hour + 20*time.Second), nil, "alice", true},
+		{"iat slightly ahead but within clock skew verifies", future, now.Add(time.Hour - 20*time.Second), nil, "alice", true},
+
+		// --- REJECTIONS. Each is a distinct arm of the finding.
+		{"expired cookie is rejected", expired, now, nil, "", false},
+		{"expired well past skew is rejected", valid, now.Add(2 * time.Hour), nil, "", false},
+		{"not-yet-valid (iat in the future) is rejected", future, now, nil, "", false},
+		{"revoked sid is rejected despite a good signature", valid, now, revokeSID(validSID), "", false},
+		{"tampered payload (username swap) is rejected", tamperedPayload, now, nil, "", false},
+		{"tampered expiry is rejected", tamperedExpiry, now, nil, "", false},
+		{"tampered signature is rejected", tamperedSig, now, nil, "", false},
+		{"wrong marker (.v2.) is not parsed as v3", strings.Replace(valid, ".v3.", ".v2.", 1), now, nil, "", false},
+		{"empty value", "", now, nil, "", false},
+		{"marker only", ".v3.", now, nil, "", false},
+		{"garbage payload", "!!!not-base64!!!.v3.sig", now, nil, "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			user, ok := verifyHubUserCookieValueV3(pub, tc.value, tc.now, tc.revoked)
+			if ok != tc.wantOK || user != tc.wantUser {
+				t.Errorf("verify = (%q, %v), want (%q, %v)", user, ok, tc.wantUser, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestF10_V3RejectsWrongKey proves the spoke-side split still holds: a cookie
+// minted under a different seed does not verify. Without this, a "verifier" that
+// ignored the key entirely would pass everything above.
+func TestF10_V3RejectsWrongKey(t *testing.T) {
+	const otherSeed = "1111111111111111111111111111111111111111111111111111111111111111"
+	now := time.Unix(1_700_000_000, 0)
+	value, _ := mintHubUserCookieValueV3(otherSeed, "alice", now, time.Hour)
+	if value == "" {
+		t.Fatal("mint failed")
+	}
+	if _, ok := verifyHubUserCookieValueV3(f10PubKey(t), value, now, nil); ok {
+		t.Fatal("cookie minted under a foreign seed verified — key is not being checked")
+	}
+	// Positive control: it DOES verify under its own key.
+	if _, ok := verifyHubUserCookieValueV3(ssoPublicKeyFromSeed(otherSeed), value, now, nil); !ok {
+		t.Fatal("cookie failed to verify under its own key — test setup is wrong")
+	}
+}
+
+// TestF10_MintFailsClosed: bad inputs must yield "" rather than a junk-signed
+// cookie, matching mintHubUserCookieValueV2.
+func TestF10_MintFailsClosed(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cases := []struct {
+		name string
+		seed string
+		user string
+		ttl  time.Duration
+	}{
+		{"empty seed", "", "alice", time.Hour},
+		{"empty username", f10TestSeed, "", time.Hour},
+		{"non-hex seed", "zzzz", "alice", time.Hour},
+		{"short seed", "abcd", "alice", time.Hour},
+		{"zero ttl", f10TestSeed, "alice", 0},
+		{"negative ttl", f10TestSeed, "alice", -time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if v, sid := mintHubUserCookieValueV3(tc.seed, tc.user, now, tc.ttl); v != "" || sid != "" {
+				t.Errorf("minted %q/%q on bad input, want empty", v, sid)
+			}
+		})
+	}
+}
+
+// TestF10_EitherLaneIsAdditive is the outage guard. Removing or shadowing the v2
+// or legacy lane 401s every spoke that has not rolled — F1/F2 compatibility.
+func TestF10_EitherLaneIsAdditive(t *testing.T) {
+	pub := f10PubKey(t)
+	const legacySecret = "legacy-hmac-secret"
+	now := time.Unix(1_700_000_000, 0)
+
+	v3, _ := mintHubUserCookieValueV3(f10TestSeed, "v3user", now, time.Hour)
+	v2 := mintHubUserCookieValueV2(f10TestSeed, "v2user")
+	legacy := mintHubUserCookieValue(legacySecret, "legacyuser")
+	if v3 == "" || v2 == "" || legacy == "" {
+		t.Fatal("test setup: a mint returned empty")
+	}
+
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"v3 lane", v3, "v3user"},
+		{"v2 lane still verifies", v2, "v2user"},
+		{"legacy HMAC lane still verifies", legacy, "legacyuser"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			user, ok := verifyHubUserCookieEitherAt(pub, legacySecret, tc.value, now, nil)
+			if !ok || user != tc.want {
+				t.Errorf("verify = (%q, %v), want (%q, true) — a compatibility lane was broken", user, ok, tc.want)
+			}
+		})
+	}
+
+	// An expired v3 must NOT silently fall through to the v2 or legacy lane and
+	// get accepted there. That fallthrough would re-open the finding completely.
+	expired, _ := mintHubUserCookieValueV3(f10TestSeed, "v3user", now.Add(-48*time.Hour), time.Hour)
+	if user, ok := verifyHubUserCookieEitherAt(pub, legacySecret, expired, now, nil); ok {
+		t.Errorf("expired v3 cookie was accepted as %q by a fallback lane", user)
+	}
+
+	// Likewise a revoked v3 must not fall through.
+	revoked, sid := mintHubUserCookieValueV3(f10TestSeed, "v3user", now, time.Hour)
+	rf := func(s string) bool { return s == sid }
+	if user, ok := verifyHubUserCookieEitherAt(pub, legacySecret, revoked, now, rf); ok {
+		t.Errorf("revoked v3 cookie was accepted as %q by a fallback lane", user)
+	}
+}
+
+// TestF10_MintingHasNotFlipped is the anti-outage assertion. This PR ships the
+// VERIFIER only. If someone flips the minter to v3 before the whole fleet
+// verifies v3, /terminal breaks fleet-wide (incident #2773). This test is the
+// tripwire — when minting legitimately flips, this test is updated in the SAME
+// PR, which forces the change to be seen.
+func TestF10_MintingHasNotFlipped(t *testing.T) {
+	value := mintHubUserCookieValueV2(f10TestSeed, "alice")
+	if hubCookieIsV3(value) {
+		t.Fatal("the production minter now emits v3 — do not land this until every spoke verifies v3")
+	}
+	if !hubCookieIsV2(value) {
+		t.Fatal("the production minter no longer emits v2")
+	}
+}
+
+// --- revocation store ------------------------------------------------------
+
+func f10TestServer(t *testing.T) *HubServer {
+	t.Helper()
+	dir := t.TempDir()
+	orig := revokedSessionsPath
+	revokedSessionsPath = filepath.Join(dir, "saas", "hub-revoked-sessions.json")
+	t.Cleanup(func() { revokedSessionsPath = orig })
+	return &HubServer{
+		logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		revokedSessions: newRevokedSessions(),
+	}
+}
+
+// TestF10_RevocationSurvivesRestart is the second half of the finding. The hub
+// rolls several times a day; an in-memory-only revocation set would un-revoke
+// every logged-out session on the next roll, on a schedule an attacker can wait
+// for.
+func TestF10_RevocationSurvivesRestart(t *testing.T) {
+	s := f10TestServer(t)
+	// Anchored to the REAL clock, not a fixed timestamp: loadRevokedSessions
+	// prunes against time.Now() on startup (that pruning is what bounds the
+	// file), so a cookie dated 2023 would be correctly evicted on load and the
+	// test would be asserting the wrong thing.
+	now := time.Now()
+	value, sid := mintHubUserCookieValueV3(f10TestSeed, "alice", now, 24*time.Hour)
+
+	// Positive control BEFORE logout: the session is live.
+	if _, ok := verifyHubUserCookieValueV3(f10PubKey(t), value, now, s.hubSessionRevokedLookup(now)); !ok {
+		t.Fatal("freshly minted cookie did not verify — setup is wrong")
+	}
+
+	if !s.revokeHubSessionCookieAt(value, now) {
+		t.Fatal("revokeHubSessionCookie reported no revocation")
+	}
+	if !s.revokedSessions.isRevoked(sid, now) {
+		t.Fatal("session not revoked in memory")
+	}
+
+	// Simulate a hub restart: brand-new server object, same PVC path.
+	restarted := &HubServer{logger: s.logger, revokedSessions: newRevokedSessions()}
+	restarted.loadRevokedSessions()
+	if !restarted.revokedSessions.isRevoked(sid, now) {
+		t.Fatal("revocation did NOT survive restart — a logged-out cookie works again after a roll")
+	}
+	if _, ok := verifyHubUserCookieValueV3(f10PubKey(t), value, now, restarted.hubSessionRevokedLookup(now)); ok {
+		t.Fatal("revoked cookie verified after restart")
+	}
+
+	// Positive control AFTER restart: an unrelated live session still works, so
+	// the restart did not simply break all verification.
+	other, _ := mintHubUserCookieValueV3(f10TestSeed, "bob", now, time.Hour)
+	if _, ok := verifyHubUserCookieValueV3(f10PubKey(t), other, now, restarted.hubSessionRevokedLookup(now)); !ok {
+		t.Fatal("an unrevoked session was rejected after restart")
+	}
+}
+
+// TestF10_RevocationSetStaysBounded: entries evict at their own expiry, so the
+// file cannot grow without limit on a long-lived hub.
+func TestF10_RevocationSetStaysBounded(t *testing.T) {
+	s := f10TestServer(t)
+	now := time.Now()
+
+	short, shortSID := mintHubUserCookieValueV3(f10TestSeed, "alice", now, time.Minute)
+	long, longSID := mintHubUserCookieValueV3(f10TestSeed, "bob", now, 24*time.Hour)
+	s.revokeHubSessionCookieAt(short, now)
+	s.revokeHubSessionCookieAt(long, now)
+
+	later := now.Add(time.Hour)
+	if !s.revokedSessions.pruneExpired(later) {
+		t.Fatal("prune reported no change though one entry was long expired")
+	}
+	if _, present := s.revokedSessions.snapshot()[shortSID]; present {
+		t.Error("expired revocation entry was not evicted — the file grows unbounded")
+	}
+	if _, present := s.revokedSessions.snapshot()[longSID]; !present {
+		t.Error("a still-live revocation entry was evicted — a revoked session came back")
+	}
+	// The evicted entry is safe to drop only because the cookie itself is now
+	// expired. Confirm that, rather than assuming it.
+	if _, ok := verifyHubUserCookieValueV3(f10PubKey(t), short, later, nil); ok {
+		t.Error("evicted entry's cookie still verifies on expiry alone — eviction is unsafe")
+	}
+
+	// Expired entries are dropped at load time too, not just by prune.
+	reloaded := newRevokedSessions()
+	reloaded.load(map[string]int64{shortSID: now.Unix() - 1, longSID: now.Add(24 * time.Hour).Unix()}, later)
+	if _, present := reloaded.snapshot()[shortSID]; present {
+		t.Error("load kept an already-expired entry")
+	}
+	if _, present := reloaded.snapshot()[longSID]; !present {
+		t.Error("load dropped a live entry")
+	}
+}
+
+// TestF10_CorruptRevocationFileFailsClosed: a revocation set the hub cannot read
+// must not be treated as empty. "Empty" means "nothing is revoked", which is the
+// finding restored by an I/O error.
+func TestF10_CorruptRevocationFileFailsClosed(t *testing.T) {
+	s := f10TestServer(t)
+	if err := os.MkdirAll(filepath.Dir(revokedSessionsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(revokedSessionsPath, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.loadRevokedSessions()
+
+	if !s.revokedSessions.isRevoked("any-session-at-all", time.Now()) {
+		t.Fatal("corrupt revocation file was treated as an empty set — revoked sessions silently work again")
+	}
+	if _, err := os.Stat(revokedSessionsPath + revokedSessionsQuarantineSuffix); err != nil {
+		t.Errorf("corrupt file was not quarantined for inspection: %v", err)
+	}
+
+	// Positive control: a HEALTHY store does not fail closed. Without this the
+	// test above would pass against a store that rejects everything always.
+	healthy := f10TestServer(t)
+	healthy.loadRevokedSessions() // missing file — normal
+	if healthy.revokedSessions.isRevoked("any-session-at-all", time.Now()) {
+		t.Fatal("a healthy (missing-file) store rejected an unrevoked session")
+	}
+}
+
+// TestF10_RevokeIsNoOpForV2 documents the residual honestly: a v2 cookie carries
+// no session ID, so logout cannot revoke it. This is WHY the finding is not
+// closed until minting flips to v3, and the test exists so that fact cannot be
+// quietly forgotten.
+func TestF10_RevokeIsNoOpForV2(t *testing.T) {
+	s := f10TestServer(t)
+	v2 := mintHubUserCookieValueV2(f10TestSeed, "alice")
+	if s.revokeHubSessionCookie(v2) {
+		t.Fatal("claimed to revoke a v2 cookie, which carries no session ID")
+	}
+	// And the v3 case DOES revoke — positive control.
+	v3, _ := mintHubUserCookieValueV3(f10TestSeed, "alice", time.Now(), time.Hour)
+	if !s.revokeHubSessionCookie(v3) {
+		t.Fatal("failed to revoke a v3 cookie")
+	}
+}

--- a/v2/pkg/hub/hub_session_revocation.go
+++ b/v2/pkg/hub/hub_session_revocation.go
@@ -1,0 +1,319 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// AUDIT F10, part 2: server-side session revocation.
+//
+// Signing the expiry (hub_cookie.go) bounds how long a copied cookie survives.
+// It does not make logout mean anything before that bound: a value captured
+// while it was valid keeps working until its own `exp` passes. Revocation is
+// what closes that window on demand — logout, a compromised account, an admin
+// pulling a session — by recording the session ID and rejecting it at verify
+// time regardless of what the signature says.
+//
+// WHY THIS IS ON DISK AND NOT IN A MAP.
+//
+// The hub restarts frequently (auto-upgrades roll it several times a day). An
+// in-memory-only revocation set is therefore not merely lossy, it is a
+// vulnerability with a published schedule: revoke a session, wait for the next
+// roll, and the cookie you revoked works again. /data is a real RWX PVC
+// (hive-hub-data-rwx) that already holds alert acks, banners and registry
+// state, so the revocation set persists exactly as those do.
+//
+// The stored shape is deliberately minimal — {sid: exp} and nothing else. There
+// is no reason for the hub to retain who a revoked session belonged to, and an
+// entry is useless once the cookie it names would fail the expiry check anyway,
+// so entries are evicted at their own `exp`. That eviction is what keeps the
+// file bounded: the set can only ever be as large as the sessions revoked
+// within one cookie lifetime, not the sessions revoked ever.
+
+// revokedSessionsPath is the on-disk file holding revoked session IDs so a
+// logout survives a hub restart. A var (not a const) so tests can point it at a
+// temp dir — same shape as alertAcksPath.
+var revokedSessionsPath = "/data/saas/hub-revoked-sessions.json"
+
+// revokedSessionsQuarantineSuffix is appended to revokedSessionsPath when the
+// file on disk will not parse.
+//
+// NOTE the difference from alert acks, and it is deliberate: a corrupt ack file
+// is quarantined and the system continues with an empty set, because losing an
+// ack merely un-silences an alert. Losing revocations UN-REVOKES SESSIONS, which
+// is the unsafe direction. So a corrupt file is quarantined for inspection and
+// the load FAILS LOUDLY rather than pretending the set is empty; see
+// loadRevokedSessions.
+const revokedSessionsQuarantineSuffix = ".corrupt"
+
+// revokedSessions is the in-memory view of the persisted revocation set, keyed
+// by session ID with the value being the revoked cookie's own expiry (Unix
+// seconds) — the point after which the entry can be dropped.
+type revokedSessions struct {
+	mu  sync.RWMutex
+	sid map[string]int64
+	// failedLoad records that the persisted set could not be read. While true
+	// the store fails CLOSED: see isRevoked.
+	failedLoad bool
+}
+
+func newRevokedSessions() *revokedSessions {
+	return &revokedSessions{sid: make(map[string]int64)}
+}
+
+// isRevoked reports whether a session ID must be rejected.
+//
+// Fails CLOSED on a load failure. If the hub could not read its revocation set,
+// it does not know which sessions are revoked, and answering "false" there is
+// precisely the F10 bug re-introduced by an I/O error. Refusing every v3 cookie
+// degrades to "everyone re-authenticates", which is recoverable; honouring a
+// revoked admin cookie is not.
+//
+// An entry whose own expiry has passed is treated as not-revoked: the cookie it
+// names now fails the signed-expiry check on its own, so the entry is dead
+// weight. Eviction from the map happens in pruneExpired, off the read path.
+func (r *revokedSessions) isRevoked(sid string, now time.Time) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.failedLoad {
+		return true
+	}
+	exp, ok := r.sid[sid]
+	if !ok {
+		return false
+	}
+	return exp >= now.Unix()
+}
+
+// revoke records a session ID as revoked until exp. Returns false when the entry
+// was already present and nothing changed, so callers can skip a pointless disk
+// write.
+//
+// A non-positive exp is ignored rather than stored: an entry that is already
+// expired would be evicted on the next prune without ever having rejected
+// anything, and storing it would let a caller grow the file with dead keys.
+func (r *revokedSessions) revoke(sid string, exp int64, now time.Time) bool {
+	if r == nil || sid == "" || exp <= now.Unix() {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.sid[sid]; ok && existing >= exp {
+		return false
+	}
+	r.sid[sid] = exp
+	return true
+}
+
+// pruneExpired drops entries whose expiry has passed, reporting whether anything
+// was removed so the caller knows if the file needs rewriting. This is the only
+// thing keeping the persisted set bounded.
+func (r *revokedSessions) pruneExpired(now time.Time) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	nowUnix := now.Unix()
+	changed := false
+	for sid, exp := range r.sid {
+		if exp < nowUnix {
+			delete(r.sid, sid)
+			changed = true
+		}
+	}
+	return changed
+}
+
+// snapshot returns a copy of the revocation set for persistence.
+func (r *revokedSessions) snapshot() map[string]int64 {
+	if r == nil {
+		return map[string]int64{}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]int64, len(r.sid))
+	for sid, exp := range r.sid {
+		out[sid] = exp
+	}
+	return out
+}
+
+// load replaces the set from persisted data, dropping already-expired entries.
+// Reports whether anything was pruned, so the caller can rewrite the file.
+func (r *revokedSessions) load(stored map[string]int64, now time.Time) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	nowUnix := now.Unix()
+	r.sid = make(map[string]int64, len(stored))
+	pruned := false
+	for sid, exp := range stored {
+		if sid == "" {
+			continue
+		}
+		if exp < nowUnix {
+			pruned = true
+			continue
+		}
+		r.sid[sid] = exp
+	}
+	r.failedLoad = false
+	return pruned
+}
+
+// markLoadFailed puts the store into fail-closed mode.
+func (r *revokedSessions) markLoadFailed() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failedLoad = true
+}
+
+// revokedSessionsFileMu serialises writers of the revocation file, for the same
+// reason alertAcksFileMu exists: two concurrent logouts writing the SAME tmp
+// path with os.WriteFile truncate each other mid-write, and the interleaved
+// bytes that get renamed into place are not JSON. For acks that cost a silenced
+// alert; here it would cost the entire revocation set on the next restart.
+var revokedSessionsFileMu sync.Mutex
+
+// saveRevokedSessions persists the revocation set to the PVC. Mirrors
+// saveAlertAcks exactly: atomic tmp+rename, failures logged not fatal.
+func (s *HubServer) saveRevokedSessions() {
+	if s == nil || s.revokedSessions == nil {
+		return
+	}
+	revokedSessionsFileMu.Lock()
+	defer revokedSessionsFileMu.Unlock()
+	data, err := json.MarshalIndent(s.revokedSessions.snapshot(), "", "  ")
+	if err != nil {
+		s.logger.Error("failed to marshal revoked sessions for persistence", "error", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(revokedSessionsPath), 0o755); err != nil {
+		s.logger.Error("failed to create revoked sessions dir", "error", err)
+		return
+	}
+	tmpPath := revokedSessionsPath + ".tmp"
+	// 0o600, not 0o644: the set of live-but-revoked session IDs is not
+	// something any other process on the PVC needs to read.
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		s.logger.Error("failed to write revoked sessions tmp file", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, revokedSessionsPath); err != nil {
+		s.logger.Error("failed to rename revoked sessions file", "error", err)
+	}
+}
+
+// loadRevokedSessions reads the persisted revocation set at startup. A missing
+// file is normal (nothing has been revoked yet) and yields an empty set.
+//
+// Any OTHER failure — unreadable file, unparseable JSON — marks the store
+// fail-closed, so every v3 cookie is rejected until an operator resolves it.
+// That is a blunt outcome and it is the intended one: the alternative is a hub
+// that has silently forgotten which sessions were revoked while continuing to
+// honour them.
+func (s *HubServer) loadRevokedSessions() {
+	if s == nil || s.revokedSessions == nil {
+		return
+	}
+	data, err := os.ReadFile(revokedSessionsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		s.logger.Error("failed to read revoked sessions — rejecting v3 sessions until resolved", "error", err)
+		s.revokedSessions.markLoadFailed()
+		return
+	}
+	var stored map[string]int64
+	if err := json.Unmarshal(data, &stored); err != nil {
+		quarantine := revokedSessionsPath + revokedSessionsQuarantineSuffix
+		if renameErr := os.Rename(revokedSessionsPath, quarantine); renameErr != nil {
+			s.logger.Error("failed to quarantine corrupt revoked sessions file",
+				"error", renameErr, "parseError", err)
+		} else {
+			s.logger.Error("persisted revoked sessions were corrupt — quarantined; rejecting v3 sessions until resolved",
+				"error", err, "quarantined", quarantine)
+		}
+		s.revokedSessions.markLoadFailed()
+		return
+	}
+	if s.revokedSessions.load(stored, time.Now()) {
+		s.saveRevokedSessions()
+	}
+}
+
+// revokeHubSessionCookie revokes the session carried by a cookie value, if that
+// value is a v3 cookie. Returns whether anything was revoked.
+//
+// A v2 or legacy cookie carries no session ID, so there is nothing to revoke and
+// this is a no-op — which is exactly why F10 is not fixed until minting flips to
+// v3. Logout on a v2 cookie still deletes the browser copy and still leaves a
+// captured value working; that residual is called out in the PR body rather than
+// papered over here.
+func (s *HubServer) revokeHubSessionCookie(value string) bool {
+	return s.revokeHubSessionCookieAt(value, time.Now())
+}
+
+// revokeHubSessionCookieAt is revokeHubSessionCookie with the clock made
+// explicit. Revocation is entirely a statement about time — "reject this until
+// its expiry" — so a hidden time.Now() makes the whole thing untestable except
+// against the wall clock.
+func (s *HubServer) revokeHubSessionCookieAt(value string, now time.Time) bool {
+	if s == nil || s.revokedSessions == nil || value == "" {
+		return false
+	}
+	sid := hubCookieSessionID(value)
+	if sid == "" {
+		return false
+	}
+	// Revoke until the cookie's own signed expiry: past that point the expiry
+	// check rejects it anyway and the entry is dead weight.
+	exp := hubCookieExpiry(value)
+	if exp <= 0 {
+		return false
+	}
+	if !s.revokedSessions.revoke(sid, exp, now) {
+		return false
+	}
+	s.revokedSessions.pruneExpired(now)
+	s.saveRevokedSessions()
+	s.logger.Info("audit: hub session revoked", "sid", sid)
+	return true
+}
+
+// hubSessionRevokedLookup adapts the store to the hubSessionRevokedFunc the
+// cookie verifier takes.
+func (s *HubServer) hubSessionRevokedLookup(now time.Time) hubSessionRevokedFunc {
+	if s == nil || s.revokedSessions == nil {
+		return nil
+	}
+	return func(sid string) bool { return s.revokedSessions.isRevoked(sid, now) }
+}
+
+// verifyHubUserCookie is the hub-side entry point: it accepts v3, v2 or legacy
+// cookies and, for v3, additionally enforces signed expiry AND revocation.
+//
+// Spokes deliberately get less: their proxy enforces the signature and the
+// signed expiry, but has no revocation store, so a revoked session can still
+// reach a spoke until its expiry. Closing that needs the spoke to ask the hub,
+// which is a network dependency on the terminal path and out of scope here.
+func (s *HubServer) verifyHubUserCookie(value string) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	now := time.Now()
+	return verifyHubUserCookieEitherAt(s.sessionPublicKey(), s.sessionKey(), value, now, s.hubSessionRevokedLookup(now))
+}

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -413,7 +413,8 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	// Trust the carried username only when its signature verifies; a legacy
 	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
 	// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
-	username, ok := verifyHubUserCookieEither(s.sessionPublicKey(), s.sessionKey(), cookie.Value)
+	// F10: also enforces a v3 cookie's signed expiry and revocation state.
+	username, ok := s.verifyHubUserCookie(cookie.Value)
 	if !ok || loadSaaSUser(username) == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))
@@ -450,6 +451,17 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
+	// AUDIT F10: deleting the browser's copy is not logging out. Anyone who
+	// captured the cookie value keeps a working session until its own expiry.
+	// Record the session ID server-side so the verifier rejects it from now on.
+	//
+	// This is a no-op today because minting still emits v2, which carries no
+	// session ID — that is the point of this PR being verifier-only. It becomes
+	// load-bearing the moment minting flips to v3, with no further change to
+	// this handler.
+	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
+		s.revokeHubSessionCookie(c.Value)
+	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     "hive_hub_user",
 		Value:    "",

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -641,7 +641,9 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 		// fails here and is treated as logged out, so the user re-authenticates
 		// through the normal login flow (which re-mints a signed cookie).
 		// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
-		if username, ok := verifyHubUserCookieEither(s.sessionPublicKey(), s.sessionKey(), cookie.Value); ok {
+		// F10: verifyHubUserCookie additionally enforces a v3 cookie's SIGNED
+		// expiry and its revocation state, which MaxAge alone never did.
+		if username, ok := s.verifyHubUserCookie(cookie.Value); ok {
 			if loadSaaSUser(username) != nil {
 				return username
 			}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -964,6 +964,13 @@ type HubServer struct {
 	// alerts.go.
 	alerts *alertState
 
+	// revokedSessions holds session IDs invalidated before their signed expiry
+	// (audit F10 — logout used to only delete the browser's copy). Persisted to
+	// the PVC because the hub restarts often and an in-memory-only set would
+	// un-revoke everything on the next roll. Carries its own leaf mutex and is
+	// never touched while s.mu is held — see hub_session_revocation.go.
+	revokedSessions *revokedSessions
+
 	// urlHealth remembers how many consecutive times each hive's PUBLIC
 	// dashboard URL failed to serve, so a transient blip can be told apart from
 	// a link that has been dead for hours. Populated by the auth-audit loop,
@@ -1105,6 +1112,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		timeline:                newTimelineStore(),
 		journey:                 newJourneyStore(),
 		alerts:                  newAlertState(),
+		revokedSessions:         newRevokedSessions(),
 		urlHealth:               newURLHealthState(),
 	}
 
@@ -1121,6 +1129,9 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		logger.Error("failed to load journey nudge state", "error", err)
 	}
 	s.loadAlertAcks()
+	// F10: restore the session revocation set BEFORE the mux starts serving, so
+	// a hub that has just rolled never honours a session revoked before it.
+	s.loadRevokedSessions()
 
 	s.mux.HandleFunc("POST /api/heartbeat", s.handleHeartbeat)
 	s.mux.HandleFunc("POST /api/task-status", s.handleTaskStatus)

--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node session_cookie_v2.test.js"
+    "test": "node server.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -479,11 +479,80 @@ function verifyHubUserCookieV2(pubHex, value) {
   }
 }
 
-// verifyHubUserCookieEither accepts a v2 (Ed25519) cookie or, during the rollout
-// window only, a legacy HMAC one — mirroring the Go helper of the same name.
-// The legacy branch is the N2 vulnerability (verify-capable implies mint-capable)
-// and is removed once the fleet has rolled and existing cookies have aged out.
+// HUB_COOKIE_V3_MARKER separates the signed claims payload from its Ed25519
+// signature. Must stay byte-identical to hubCookieV3Marker in
+// v2/pkg/hub/hub_cookie.go.
+const HUB_COOKIE_V3_MARKER = '.v3.';
+
+// HUB_COOKIE_CLOCK_SKEW_SECONDS mirrors ssoClockSkew in v2/pkg/hub/sso.go. The
+// hub and this spoke are separate clusters with separate clocks; without a
+// tolerance a freshly minted cookie is rejected by a spoke running seconds
+// ahead of the hub.
+const HUB_COOKIE_CLOCK_SKEW_SECONDS = 30;
+
+// verifyHubUserCookieV3 mirrors verifyHubUserCookieValueV3 in
+// v2/pkg/hub/hub_cookie.go EXACTLY.
+//
+// AUDIT F10: the v2 cookie signs only the username, so its lifetime lives in the
+// browser's MaxAge — which is a hint the browser may ignore and a copied cookie
+// never had in the first place. v3 moves the claims inside the signature:
+//
+//   value = base64url(JSON{u,iat,exp,sid}) + '.v3.' + base64url(Ed25519 sig)
+//
+// so this proxy can enforce the expiry itself rather than trusting the browser.
+//
+// The JSON keys (u/iat/exp/sid) and the base64url alphabet are a FROZEN wire
+// contract with the Go hub. If the two sides disagree by a single byte, every
+// hosted login breaks at deploy — silently, and production-only, because nothing
+// but a real hub-minted cookie exercises the disagreement. session_cookie_v3.test.js
+// pins Go-minted vectors for exactly this reason.
+//
+// Revocation is deliberately NOT checked here: the spoke has no revocation store
+// and asking the hub would put a network dependency on the terminal path. The
+// spoke enforces signature + expiry; the hub additionally enforces revocation.
+//
+// Returns the verified username, or '' on any failure.
+function verifyHubUserCookieV3(pubHex, value, nowSeconds) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(HUB_COOKIE_V3_MARKER);
+  if (idx <= 0) return '';
+  const body = value.slice(0, idx);
+  const sigB64 = value.slice(idx + HUB_COOKIE_V3_MARKER.length);
+  if (!body || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    // Wrap the raw 32-byte key in its SPKI header so Node can import it.
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    const sig = Buffer.from(sigB64, 'base64url');
+    // Verify the signature over the ENCODED body BEFORE parsing any payload
+    // byte — never let attacker-controlled JSON reach the parser first.
+    if (!crypto.verify(null, Buffer.from(body), pub, sig)) return '';
+    const claims = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+    if (!claims || typeof claims.u !== 'string' || !claims.u) return '';
+    if (typeof claims.sid !== 'string' || !claims.sid) return '';
+    if (typeof claims.iat !== 'number' || typeof claims.exp !== 'number') return '';
+    const now = Number.isFinite(nowSeconds) ? nowSeconds : Math.floor(Date.now() / 1000);
+    if (claims.iat > now + HUB_COOKIE_CLOCK_SKEW_SECONDS) return ''; // not yet valid
+    if (claims.exp < now - HUB_COOKIE_CLOCK_SKEW_SECONDS) return ''; // expired
+    return claims.u;
+  } catch (_) {
+    return '';
+  }
+}
+
+// verifyHubUserCookieEither accepts a v3 (F10: signed lifetime), a v2 (Ed25519)
+// cookie or, during the rollout window only, a legacy HMAC one — mirroring the Go
+// helper of the same name. Lanes are tried v3 → v2 → legacy.
+//
+// The v2 and legacy branches are STRICTLY additive compatibility paths. Removing
+// either one 401s every part of the fleet that has not rolled. The legacy branch
+// is additionally the N2 vulnerability (verify-capable implies mint-capable) and
+// is removed once the fleet has rolled and existing cookies have aged out.
 function verifyHubUserCookieEither(pubHex, legacySecret, value) {
+  const v3 = verifyHubUserCookieV3(pubHex, value);
+  if (v3) return v3;
   const v2 = verifyHubUserCookieV2(pubHex, value);
   if (v2) return v2;
   return verifyHubUserCookie(legacySecret, value);

--- a/v2/proxy/session_cookie_v3.test.js
+++ b/v2/proxy/session_cookie_v3.test.js
@@ -1,0 +1,217 @@
+// AUDIT F10: the hub session cookie's lifetime must be SIGNED and enforced by
+// the verifier, not left to the browser's MaxAge.
+//
+// Run: node session_cookie_v3.test.js
+//
+// Why this file exists separately from the Go tests: the `hive_hub_user` cookie
+// is minted by the hub (Go) and verified INDEPENDENTLY here, in every spoke's
+// proxy. The two implementations share no code — only a wire format. If they
+// disagree by one byte, every hosted login breaks at deploy, silently, and only
+// in production, because nothing but a real hub-minted cookie exercises the
+// disagreement.
+//
+// So the vectors below are FROZEN OUTPUT FROM THE REAL GO MINTER
+// (mintHubUserCookieValueV3, seed and clock as noted). They are not
+// Node-generated: a Node-generated vector would only prove Node agrees with
+// itself, which is exactly the kind of green-but-meaningless test this audit
+// kept finding.
+
+import crypto from 'crypto';
+import assert from 'assert';
+
+const MARKER_V3 = '.v3.';
+const MARKER_V2 = '.v2.';
+const CLOCK_SKEW_SECONDS = 30;
+
+// --- FROZEN VECTORS, produced by the Go hub -------------------------------
+// Seed: 4f2c9a1b...5577 (test-only). Minted at Unix 1700000000 with ttl 1h.
+const PUB = '1784545353abb533e166dad23a6363f573ff0ee6ce9c1d0cf7a1ce056640898b';
+const MINT_TIME = 1700000000;
+const SID = 'f19b65b4add0761dc7aa71fb49a3a3df9056faf0f8dee442fcc461653598e082';
+
+// Valid: iat=1700000000, exp=1700003600, u=alice
+const GO_V3_VALID =
+  'eyJ1IjoiYWxpY2UiLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTcwMDAwMzYwMCwic2lkIjoiZjE5YjY1YjRhZGQwNzYxZGM3YWE3MWZiNDlhM2EzZGY5MDU2ZmFmMGY4ZGVlNDQyZmNjNDYxNjUzNTk4ZTA4MiJ9.v3.MCqKVIDZ4cEVs5mQ9Mve822nb5nSrXXAbRhr6FiH6sjtD3JyCIeTIj-O3ZeTempyxMDK721hgQJl23axvwiLAg';
+// Minted 48h before MINT_TIME, so exp=1699830800 is long past.
+const GO_V3_EXPIRED =
+  'eyJ1IjoiYWxpY2UiLCJpYXQiOjE2OTk4MjcyMDAsImV4cCI6MTY5OTgzMDgwMCwic2lkIjoiZTIyZDY2YWM3ODllZDdmN2IyYzE5ODhmNzEzNThjZDUwYzcyYTdlOTBjZTY0MDJiMDg0NTIwNGE1Y2JiYjhkNiJ9.v3.liw-rbWHQR1_uVFlMpN_TigJ80E0N2g6CJt0o-TR1m-nRbvB7Y7oNA19FBdEmOrG9yQoIlJ33iR9Qte2CdFiCQ';
+// Minted 2h AFTER MINT_TIME: iat=1700007200 is in the future at MINT_TIME.
+const GO_V3_FUTURE =
+  'eyJ1IjoiYWxpY2UiLCJpYXQiOjE3MDAwMDcyMDAsImV4cCI6MTcwMDAxMDgwMCwic2lkIjoiMzNjNzY2Y2E3ZmM5NzA5YWQzODM2YTg1N2UxOTg3OGIxNmZjNGU0NDNiMzQ1Y2U2YWJhNGVkZDYzYmUwOGY2NCJ9.v3.TH_eBfSf2dM8Y0GDs2RNo0oP3bg0TksrnT6zjWBgpUnd_Mp7OBL-nvEJwyeuzGX5ZhxDbxTqQGinacGcMEyxCA';
+// A v2 cookie minted by the same Go hub, for the compatibility-lane control.
+const GO_V2 =
+  'v2user.v2.nNS44t2T-svaTHmr6dLBoAiaR0d9LP0VQTac8qHdXeinxw0pj-_HwpNKxbDYjAzFDDTlT2Xmhu5pt7IvgxQWDg';
+
+// --- code under test (copied from server.js, kept in lockstep) -------------
+
+function verifyHubUserCookieV3(pubHex, value, nowSeconds) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(MARKER_V3);
+  if (idx <= 0) return '';
+  const body = value.slice(0, idx);
+  const sigB64 = value.slice(idx + MARKER_V3.length);
+  if (!body || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    const sig = Buffer.from(sigB64, 'base64url');
+    if (!crypto.verify(null, Buffer.from(body), pub, sig)) return '';
+    const claims = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+    if (!claims || typeof claims.u !== 'string' || !claims.u) return '';
+    if (typeof claims.sid !== 'string' || !claims.sid) return '';
+    if (typeof claims.iat !== 'number' || typeof claims.exp !== 'number') return '';
+    const now = Number.isFinite(nowSeconds) ? nowSeconds : Math.floor(Date.now() / 1000);
+    if (claims.iat > now + CLOCK_SKEW_SECONDS) return '';
+    if (claims.exp < now - CLOCK_SKEW_SECONDS) return '';
+    return claims.u;
+  } catch (_) {
+    return '';
+  }
+}
+
+function verifyHubUserCookieV2(pubHex, value) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(MARKER_V2);
+  if (idx <= 0) return '';
+  const username = value.slice(0, idx);
+  const sigB64 = value.slice(idx + MARKER_V2.length);
+  if (!username || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    const sig = Buffer.from(sigB64, 'base64url');
+    return crypto.verify(null, Buffer.from(username), pub, sig) ? username : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function verifyHubUserCookieEither(pubHex, legacySecret, value, nowSeconds) {
+  const v3 = verifyHubUserCookieV3(pubHex, value, nowSeconds);
+  if (v3) return v3;
+  return verifyHubUserCookieV2(pubHex, value);
+}
+
+// --- tests ----------------------------------------------------------------
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+console.log('F10 v3 session cookie — Node/Go cross-language agreement');
+
+// POSITIVE CONTROLS FIRST. Without these the whole file passes against a
+// verifier that returns '' unconditionally.
+test('a real Go-minted v3 cookie verifies in Node at mint time', () => {
+  assert.strictEqual(verifyHubUserCookieV3(PUB, GO_V3_VALID, MINT_TIME), 'alice');
+});
+
+test('the frozen payload decodes to the exact claim keys Go wrote', () => {
+  const body = GO_V3_VALID.slice(0, GO_V3_VALID.lastIndexOf(MARKER_V3));
+  const claims = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+  assert.deepStrictEqual(Object.keys(claims).sort(), ['exp', 'iat', 'sid', 'u']);
+  assert.strictEqual(claims.u, 'alice');
+  assert.strictEqual(claims.iat, MINT_TIME);
+  assert.strictEqual(claims.exp, MINT_TIME + 3600);
+  assert.strictEqual(claims.sid, SID);
+});
+
+test('valid just inside expiry still verifies', () => {
+  assert.strictEqual(verifyHubUserCookieV3(PUB, GO_V3_VALID, MINT_TIME + 3599), 'alice');
+});
+
+test('clock skew tolerance: slightly past exp still verifies', () => {
+  assert.strictEqual(verifyHubUserCookieV3(PUB, GO_V3_VALID, MINT_TIME + 3600 + 20), 'alice');
+});
+
+test('clock skew tolerance: iat slightly ahead still verifies', () => {
+  // FUTURE has iat = MINT_TIME + 7200; check 20s before that.
+  assert.strictEqual(verifyHubUserCookieV3(PUB, GO_V3_FUTURE, MINT_TIME + 7200 - 20), 'alice');
+});
+
+// REJECTIONS — the finding itself.
+test('an expired Go-minted cookie is REJECTED (F10 arm 1)', () => {
+  assert.strictEqual(verifyHubUserCookieV3(PUB, GO_V3_EXPIRED, MINT_TIME), '');
+});
+
+test('expired well past the skew window is rejected', () => {
+  assert.strictEqual(verifyHubUserCookieV3(PUB, GO_V3_VALID, MINT_TIME + 7200), '');
+});
+
+test('not-yet-valid (iat in the future) is rejected', () => {
+  assert.strictEqual(verifyHubUserCookieV3(PUB, GO_V3_FUTURE, MINT_TIME), '');
+});
+
+test('tampered payload (username swapped to the admin) is rejected', () => {
+  const idx = GO_V3_VALID.lastIndexOf(MARKER_V3);
+  const claims = JSON.parse(Buffer.from(GO_V3_VALID.slice(0, idx), 'base64url').toString('utf8'));
+  claims.u = 'clubanderson';
+  const forged = Buffer.from(JSON.stringify(claims)).toString('base64url') + GO_V3_VALID.slice(idx);
+  assert.strictEqual(verifyHubUserCookieV3(PUB, forged, MINT_TIME), '');
+});
+
+test('tampered expiry (session extension) is rejected', () => {
+  const idx = GO_V3_VALID.lastIndexOf(MARKER_V3);
+  const claims = JSON.parse(Buffer.from(GO_V3_VALID.slice(0, idx), 'base64url').toString('utf8'));
+  claims.exp = MINT_TIME + 10 * 365 * 24 * 3600;
+  const forged = Buffer.from(JSON.stringify(claims)).toString('base64url') + GO_V3_VALID.slice(idx);
+  assert.strictEqual(verifyHubUserCookieV3(PUB, forged, MINT_TIME), '');
+});
+
+test('tampered signature is rejected', () => {
+  const idx = GO_V3_VALID.lastIndexOf(MARKER_V3);
+  const sig = GO_V3_VALID.slice(idx + MARKER_V3.length);
+  const flipped = (sig[0] === 'A' ? 'B' : 'A') + sig.slice(1);
+  assert.strictEqual(
+    verifyHubUserCookieV3(PUB, GO_V3_VALID.slice(0, idx + MARKER_V3.length) + flipped, MINT_TIME),
+    ''
+  );
+});
+
+test('a cookie under a different key is rejected', () => {
+  const otherPub = '1111111111111111111111111111111111111111111111111111111111111111';
+  assert.strictEqual(verifyHubUserCookieV3(otherPub, GO_V3_VALID, MINT_TIME), '');
+});
+
+test('wrong marker: a v3 body carrying .v2. is not parsed as v3', () => {
+  assert.strictEqual(
+    verifyHubUserCookieV3(PUB, GO_V3_VALID.replace(MARKER_V3, MARKER_V2), MINT_TIME),
+    ''
+  );
+});
+
+test('malformed values are rejected', () => {
+  for (const bad of ['', '.v3.', 'abc.v3.', '.v3.sig', '!!!.v3.!!!', 'no-marker-at-all']) {
+    assert.strictEqual(verifyHubUserCookieV3(PUB, bad, MINT_TIME), '', `accepted ${JSON.stringify(bad)}`);
+  }
+});
+
+// COMPATIBILITY — the outage guard. The v2 lane must survive untouched.
+test('the v2 lane still verifies through Either (no fleet 401)', () => {
+  assert.strictEqual(verifyHubUserCookieEither(PUB, '', GO_V2, MINT_TIME), 'v2user');
+});
+
+test('an expired v3 does NOT fall through to the v2 lane and get accepted', () => {
+  assert.strictEqual(verifyHubUserCookieEither(PUB, '', GO_V3_EXPIRED, MINT_TIME), '');
+});
+
+test('Either routes a valid v3 to the v3 lane', () => {
+  assert.strictEqual(verifyHubUserCookieEither(PUB, '', GO_V3_VALID, MINT_TIME), 'alice');
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} F10 cookie test(s) failed`);
+  process.exit(1);
+}
+console.log('\nall F10 v3 session cookie tests passed');


### PR DESCRIPTION
## Audit F10 — hub session lifetime isn't signed or revocable

> The v2 signature covers only the username (`v2/pkg/hub/hub_cookie.go:56-101`). Browser `MaxAge` isn't a signed server-side expiry, and logout only deletes the browser cookie. A copied cookie remains valid despite logout or account changes while its signature key remains accepted.

## ⚠️ This PR ships the VERIFIER ONLY. It mints nothing. Behaviour is unchanged.

This is the single most important thing to know when reviewing.

`hive_hub_user` is minted by the hub (Go) and verified **independently** by every spoke's Node proxy (`v2/proxy/server.js`). Minting a cookie shape a not-yet-rolled spoke cannot parse breaks `/terminal` fleet-wide — that is incident #2773 and it is not to be repeated. So:

- Minting still emits **v2**, unchanged. Nothing calls `mintHubUserCookieValueV3` in production.
- The v3 lane is added to the verifier on **both** the Go and Node sides.
- The **v2 and legacy HMAC lanes are untouched** — they are the F1/F2 compatibility paths, and removing either 401s the part of the fleet that has not rolled.
- Since nothing mints v3, no cookie in existence today takes the new path. Deploying this changes no observable behaviour.

There is a test, `TestF10_MintingHasNotFlipped`, that asserts the production minter still emits v2. It is a deliberate tripwire: when minting legitimately flips, that test must be updated in the same PR, which forces the change to be seen rather than slipped in.

### Exact follow-up needed to flip minting

1. Confirm **every** spoke runs an image containing the `verifyHubUserCookieV3` in `v2/proxy/server.js` from this PR. Not "the rollout started" — every spoke, verified from the image digest, because a single stale spoke means a broken terminal for that tenant.
2. Then, in one PR: change `handleOAuthCallback` to call `mintHubUserCookieValueV3(s.sessionSigningSeed(), user.Login, time.Now(), cookieMaxAgeDays*24*time.Hour)`, persist nothing extra (the `sid` returns from the mint and only matters at logout), and update `TestF10_MintingHasNotFlipped`.
3. Keep the v2 verify lane for at least one full cookie lifetime (7 days) after that, so browsers holding a v2 cookie are not logged out mid-session.

Only after step 2 lands is F10 actually closed. Until then logout still cannot revoke anything, because a v2 cookie carries no session ID — `TestF10_RevokeIsNoOpForV2` pins that residual so it cannot be quietly forgotten.

## What's implemented

**v3 cookie format** (`v2/pkg/hub/hub_cookie.go`) — claims move inside the signature:

```
base64url(JSON{u,iat,exp,sid}) + ".v3." + base64url(Ed25519-Sign(payload))
```

Same Ed25519 seed, same `hubCookieB64` alphabet, same marker style as v2. Signature is verified **before** any payload byte is parsed. Expiry is enforced by the verifier with the same 30s `ssoClockSkew` tolerance `VerifyTerminalAssertion` uses, since hub and spoke are separate clusters with separate clocks.

**Revocation store** (`v2/pkg/hub/hub_session_revocation.go`, new file) — follows the `alertAcks` load/save/mutex shape exactly: atomic tmp+rename, dedicated file mutex, quarantine-on-corrupt.

Two deliberate departures from the alertAcks precedent, both because the failure directions differ:

- **Persisted, not in-memory.** The hub rolls several times a day. An in-memory set would un-revoke every logged-out session on the next roll — a vulnerability with a published schedule an attacker can simply wait for. `/data` is a real RWX PVC (`hive-hub-data-rwx`).
- **Fails closed on an unreadable set.** A corrupt ack file is quarantined and the system continues with an empty set, because losing an ack merely un-silences an alert. Losing revocations *un-revokes sessions*. So an unreadable or unparseable file rejects every v3 cookie until an operator resolves it. That is blunt and intended: "everyone re-authenticates" is recoverable, honouring a revoked admin cookie is not.

Stored shape is `{sid: exp}` and nothing else; entries evict at their own expiry, which bounds the file to sessions revoked within one cookie lifetime rather than sessions revoked ever.

**Logout** (`v2/pkg/hub/oauth.go`) records the session ID server-side. **Hub auth paths** route through `s.verifyHubUserCookie`, which adds revocation checking on top of signature and expiry.

Spokes deliberately get less: the proxy enforces signature + signed expiry but has no revocation store, so a revoked session can still reach a spoke until its expiry. Closing that would put a network dependency on the terminal path; out of scope here and called out rather than hidden.

## Cross-language safety

If Go and Node disagree on encoding by one byte, every hosted login breaks at deploy — silently, and production-only, since nothing but a real hub-minted cookie exercises the disagreement.

So `v2/proxy/session_cookie_v3.test.js` pins **frozen vectors produced by the real Go minter**, not Node-generated ones (a Node-generated vector only proves Node agrees with itself). The JSON keys `u`/`iat`/`exp`/`sid` are a frozen wire contract, asserted on both sides. Wired into `npm test`.

## Fail-then-pass evidence

The finding stated as an executable assertion, run against **unfixed `origin/v4`**:

```
$ go test ./pkg/hub/ -run TestF10_Demonstration -count=1 -v
=== RUN   TestF10_Demonstration
    f10_demo_test.go:20: ARM 1 FAIL: cookie still verifies as "clubanderson" with no signed
                         expiry — a copied cookie is valid forever
    f10_demo_test.go:28: ARM 2 FAIL: the cookie carries no session ID, so logout can only
                         delete the browser copy; a captured value survives logout
--- FAIL: TestF10_Demonstration (0.00s)
FAIL
```

Both arms of the finding reproduce. The full F10 suite additionally fails to **compile** against `origin/v4` (`undefined: mintHubUserCookieValueV3`, `undefined: hubCookieClaims`, …). After the fix, all pass.

The tests caught two real defects during development, which is the point of writing them to fail first:
- `revokeHubSessionCookie` had a hidden `time.Now()`, making revocation untestable except against the wall clock — now injectable.
- Restart tests anchored to a fixed 2023 timestamp were passing for the wrong reason: `loadRevokedSessions` prunes against the real clock, so those entries were being correctly evicted on load while the test believed it was asserting persistence.

**Positive controls** are included throughout, because a suite that only proves rejection passes equally against a verifier that rejects everything: an unexpired unrevoked v3 must verify, a v2 cookie must still verify, a legacy HMAC cookie must still verify, a healthy revocation store must not fail closed, and an unrelated session must survive a restart.

Boundaries table-tested: expired, expired-within-skew, not-yet-valid, iat-ahead-within-skew, revoked sid, tampered payload (username swapped to the admin), tampered expiry (session extension), tampered signature, wrong key, wrong marker, malformed values.

## Baseline vs branch

Package `pkg/hub` has known pre-existing failures on some environments; measured both sides on the same machine.

| | Result |
|---|---|
| `origin/v4` clean (baseline) | `ok github.com/kubestellar/hive/v2/pkg/hub 74.487s` — 0 failures |
| this branch | `ok github.com/kubestellar/hive/v2/pkg/hub 49.093s` — 0 failures |

**No new failures.** `go vet ./pkg/hub/` clean; `go build ./...` clean; `gofmt` clean on all touched files (the repo has pre-existing gofmt drift in files this PR does not touch).

`cd v2/proxy && npm test` — all three suites green (`server.test.js`, `session_cookie_v2.test.js` 7/7, `session_cookie_v3.test.js` 17/17).

## For a human to weigh

1. **The fail-closed choice on an unreadable revocation file.** Once minting flips to v3, a corrupt or unreadable `/data/saas/hub-revoked-sessions.json` logs the whole fleet out until an operator fixes it. I think that is the right direction for a security control, but it is a real availability tradeoff on a PVC-backed file and worth an explicit yes/no.
2. **Spokes cannot see revocations.** A revoked session still reaches a spoke's `/terminal` until its expiry. Fixing it needs a hub round-trip on the terminal path. Should that be tracked as a follow-up issue?
3. **Session TTL at flip time.** I did not change `cookieMaxAgeDays` (7). Signing the expiry makes that 7 days genuinely enforced rather than advisory — worth deciding whether 7 days is still the intent under real enforcement.
4. Touches `oauth.go` and `saas.go` in two spots each; another agent is working F4 in those files. Changes are one-line call-site swaps plus the logout hook, so conflicts should be trivial.

Do not merge without a maintainer's review — this is auth-path code.
