### PR TITLE
🔒 security: let a verified terminal assertion authenticate on its own (F4 final step)

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -298,6 +298,49 @@ function verifyTerminalAssertion(key, token, expectedHiveID, nowSec) {
 // cookieUser is the hub-wide-authenticated user from the verified hive_hub_user
 // cookie (already checked by the caller); assertionCookie is the raw
 // hive_terminal_assertion value (may be undefined).
+// resolveTerminalIdentity decides WHO is asking, from either credential.
+//
+// SECURITY (audit F4, final step). Both /terminal gates used to require a valid
+// hive_hub_user cookie before authorization ran at all, so the hub-wide cookie
+// was load-bearing for every terminal request — and that is precisely the cookie
+// that must stop being delivered to sibling tenants (Domain=.hive.kubestellar.io).
+// Dropping the Domain while the gates still demanded it would have locked every
+// hosted tenant out of /terminal.
+//
+// A verified terminal assertion is a STRICTLY STRONGER credential than the hub
+// cookie for this purpose:
+//
+//   hub cookie   — proves "some real hub user", hub-wide, delivered to EVERY
+//                  sibling tenant, and says nothing about THIS hive.
+//   assertion    — signed with THIS spoke's per-hive key, carries {user, role,
+//                  hive_id, exp}, is host-only + Path=/terminal, and is checked
+//                  against this hive's own ID and a fresh expiry.
+//
+// So accepting a valid assertion on its own is not a relaxation: it removes a
+// weaker requirement that sat in front of a stronger one. The assertion is still
+// fully verified (signature, this-hive binding, expiry, role) inside
+// authorizeTerminal — this only changes whether the hub cookie must ALSO be
+// present.
+//
+// Returns the identity to authorize as, or null if neither credential is usable.
+// Fails closed: an absent, expired, wrong-hive or badly-signed assertion with no
+// valid hub cookie yields null and the caller denies.
+function resolveTerminalIdentity(cookies) {
+  const hubUser = verifyHubUserCookieEither(
+    SESSION_PUBLIC_KEY, SESSION_KEY, cookies['hive_hub_user']);
+  if (hubUser) return hubUser;
+
+  const claim = verifyTerminalAssertion(
+    TERMINAL_SIGNING_KEY, cookies[TERMINAL_ASSERTION_COOKIE], HIVE_ID,
+    Math.floor(Date.now() / 1000));
+  // Only the assertion's OWN username may stand in for the hub cookie. Returning
+  // it here keeps authorizeTerminal's user-binding check meaningful rather than
+  // silently disabling it: the comparison becomes claim.username === itself,
+  // which is exactly the "this assertion authenticates this user" statement, and
+  // the role and expiry checks there still decide the outcome.
+  return claim && claim.username ? claim.username : null;
+}
+
 function authorizeTerminal(cookieUser, assertionCookie) {
   const nowSec = Math.floor(Date.now() / 1000);
   const claim = verifyTerminalAssertion(TERMINAL_SIGNING_KEY, assertionCookie, HIVE_ID, nowSec);
@@ -618,7 +661,7 @@ app.use('/terminal', (req, res, next) => {
     }, {});
     // SECURITY (CWE-345): the cookie is HMAC-signed by the hub. Verify the
     // signature — a non-empty value is NOT proof of authentication.
-    const user = verifyHubUserCookieEither(SESSION_PUBLIC_KEY, SESSION_KEY, cookies['hive_hub_user']);
+    const user = resolveTerminalIdentity(cookies);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -720,7 +763,7 @@ server.on('upgrade', (req, socket, head) => {
         return acc;
       }, {});
       // SECURITY (CWE-345): verify the hub's HMAC signature, not mere existence.
-      const wsUser = verifyHubUserCookieEither(SESSION_PUBLIC_KEY, SESSION_KEY, cookies['hive_hub_user']);
+      const wsUser = resolveTerminalIdentity(cookies);
       if (!wsUser) {
         socket.destroy();
         return;

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -590,6 +590,73 @@ async function testC3F_WrongVersionDenied() {
 // USER MISMATCH: a valid assertion for alice presented alongside bob's hub
 // cookie must NOT admit bob — the assertion user must equal the authenticated
 // cookie user. (bob is also not on the static allowlist, so it falls through.)
+// ── audit F4, final step: the assertion alone must authenticate ──────────────
+//
+// Both /terminal gates used to require a valid hive_hub_user cookie BEFORE
+// authorization ran, so the hub-wide cookie was load-bearing for every terminal
+// request — and that is exactly the cookie that must stop being delivered to
+// sibling tenants. Dropping its Domain while the gates still demanded it would
+// have locked every hosted tenant out of /terminal.
+//
+// A verified assertion is STRICTLY STRONGER than the hub cookie here: it is
+// signed with THIS spoke's per-hive key and carries {user, role, hive_id, exp},
+// whereas the hub cookie only proves "some hub user" and is handed to every
+// sibling. These tests pin that the assertion alone opens a terminal, and that
+// dropping the hub-cookie requirement did NOT weaken any existing denial.
+async function testF4_AssertionAloneAdmits() {
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(null, HOSTED_HOST, assertion);
+  assert.equal(resp.status, 200, `valid owner assertion with NO hub cookie should reach terminal, got ${resp.status}`);
+  const { opened } = await terminalWS(null, HOSTED_HOST, assertion);
+  assert.ok(opened, 'valid owner assertion with NO hub cookie should open WS');
+  console.log('  ✓ F4: assertion alone (no hub cookie) → terminal opens, HTTP + WS');
+}
+
+// NEGATIVE CONTROLS. Removing the hub-cookie precondition must not turn the
+// gate into a rubber stamp: every property the assertion itself asserts has to
+// still be enforced when it is the ONLY credential presented.
+async function testF4_NoCredentialsStillDenied() {
+  const resp = await terminalHTTP(null, HOSTED_HOST, null);
+  assert.equal(resp.status, 401, `no cookie and no assertion must be 401, got ${resp.status}`);
+  const { opened } = await terminalWS(null, HOSTED_HOST, null);
+  assert.ok(!opened, 'no credentials at all must not open a WS');
+  console.log('  ✓ F4: no credentials → 401 / WS refused');
+}
+
+async function testF4_ExpiredAssertionAloneDenied() {
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: HIVE_B_ID, ttlSec: -60 });
+  const resp = await terminalHTTP(null, HOSTED_HOST, assertion);
+  assert.notEqual(resp.status, 200, 'an EXPIRED assertion must not authenticate on its own');
+  console.log('  ✓ F4: expired assertion alone → denied');
+}
+
+async function testF4_WrongHiveAssertionAloneDenied() {
+  // Signed by hive B's key but claiming a different hive id.
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: 'hosted-some-other-hive' });
+  const resp = await terminalHTTP(null, HOSTED_HOST, assertion);
+  assert.notEqual(resp.status, 200, 'an assertion for ANOTHER hive must not authenticate here');
+  console.log('  ✓ F4: wrong-hive assertion alone → denied');
+}
+
+async function testF4_ForgedAssertionAloneDenied() {
+  // Correct shape, wrong signing key — the cross-tenant forgery N3 closed.
+  const assertion = mintTerminalAssertion('not-the-right-key', { username: 'dave', role: 'owner', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(null, HOSTED_HOST, assertion);
+  assert.notEqual(resp.status, 200, 'a forged assertion must not authenticate on its own');
+  const { opened } = await terminalWS(null, HOSTED_HOST, assertion);
+  assert.ok(!opened, 'a forged assertion must not open a WS');
+  console.log('  ✓ F4: forged-signature assertion alone → denied, HTTP + WS');
+}
+
+async function testF4_InsufficientRoleAloneDenied() {
+  // carol:read — a VALID assertion that says "no". Must stay denied, and must
+  // NOT fall through to the static allowlist (audit N4).
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'carol', role: 'read', hiveID: HIVE_B_ID });
+  const resp = await terminalHTTP(null, HOSTED_HOST, assertion);
+  assert.notEqual(resp.status, 200, 'a read-only assertion must not open a terminal, even as sole credential');
+  console.log('  ✓ F4: read-only assertion alone → denied (N4 stays closed)');
+}
+
 async function testC3F_UserMismatchDenied() {
   const cookie = mintCookie(HIVE_B_SECRET, 'bob');
   const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'alice', role: 'owner', hiveID: HIVE_B_ID });
@@ -791,6 +858,12 @@ try {
   await testC3F_ForgedAssertionDenied();
   await testC3F_WrongVersionDenied();
   await testC3F_UserMismatchDenied();
+  await testF4_AssertionAloneAdmits();
+  await testF4_NoCredentialsStillDenied();
+  await testF4_ExpiredAssertionAloneDenied();
+  await testF4_WrongHiveAssertionAloneDenied();
+  await testF4_ForgedAssertionAloneDenied();
+  await testF4_InsufficientRoleAloneDenied();
   await testC3F_StaticAllowlistFallbackPreserved();
 
   console.log('\n✓ C3 tests passed\n');


### PR DESCRIPTION
## What

Audit **F4**, the final code step — the one #3504 deliberately stopped short of.

Both `/terminal` gates required a valid `hive_hub_user` cookie **before** authorization ran:

```js
const user = verifyHubUserCookieEither(...);
if (!user) { return 401; }          // ← bails here
if (!authorizeTerminal(user, ...))  // ← assertion never consulted
```

So the hub-wide cookie was load-bearing for every terminal request — and that is exactly the cookie that must stop being delivered to sibling tenants. **Dropping its `Domain` while the gates still demanded it would have locked every hosted tenant out of `/terminal`.**

## Why accepting the assertion alone is not a relaxation

| credential | what it actually proves |
|---|---|
| `hive_hub_user` | "some real hub user" — hub-wide, delivered to **every** sibling tenant, says nothing about *this* hive |
| `hive_terminal_assertion` | signed with **this spoke's per-hive key**, carries `{user, role, hive_id, exp}`, host-only + `Path=/terminal`, checked against this hive's ID and a fresh expiry |

The assertion is the stronger credential. This removes a weaker requirement that sat in front of a stronger one. The assertion is still **fully** verified inside `authorizeTerminal` — signature, this-hive binding, expiry, and role all still decide the outcome. Only the hub cookie's *presence* stops being mandatory.

Both gates now share one `resolveTerminalIdentity` helper, so the HTTP and WS paths cannot drift apart — the divergence that made N4 possible.

## Why #3504 had to land first

Without the renewal endpoint, the assertion expires after **15 minutes** against a **30-day** session. Making it the sole credential before renewal existed would have logged users out of the terminal a quarter-hour after login. That ordering was the whole reason for splitting these PRs.

## Verification

**Fails against the old gate**, restored and re-run:

```
✗ C3 test failed: valid owner assertion with NO hub cookie should reach terminal, got 401
```

**Passes with the fix**, full suite `7/7`:

```
✓ F4: assertion alone (no hub cookie) → terminal opens, HTTP + WS
✓ F4: no credentials → 401 / WS refused
✓ F4: expired assertion alone → denied
✓ F4: wrong-hive assertion alone → denied
✓ F4: forged-signature assertion alone → denied, HTTP + WS
✓ F4: read-only assertion alone → denied (N4 stays closed)
✓ C3 tests passed
✓ C3 empty-allowlist tests passed
```

**Five negative controls** are the point here: removing an authentication precondition is exactly the change that could turn a gate into a rubber stamp. Each property the assertion asserts is still enforced when it is the *only* credential — including `carol:read`, which keeps N4 closed.

Also **booted the proxy**, not just `node --check`. A temporal-dead-zone error in this same file broke the proxy's startup during N4 and `node --check` passes it cleanly.

## What this does NOT do

It does **not** drop `Domain=.hive.kubestellar.io` from `hive_hub_user`. This PR removes the last code-level *reason* the cookie must be domain-scoped; the scope change itself is a separate deployment-gated step that needs fleet telemetry confirming spokes carry this proxy build first. Shipping both together would invert the ship-the-verifier-first ordering that #2773 exists to enforce.