### PR TITLE
🔒 gate shared AI credential mutations to owners (v4 twin of #3503)

### DIFF
--- a/v2/pkg/dashboard/claude_auth.go
+++ b/v2/pkg/dashboard/claude_auth.go
@@ -71,6 +71,10 @@ func (s *Server) handleClaudeAuthStatus(w http.ResponseWriter, r *http.Request) 
 // After the user authorizes, they paste the resulting URL back to the dashboard,
 // which POSTs the code to /api/claude-auth/exchange.
 func (s *Server) handleClaudeAuthStart(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	verifier, challenge, err := claude.GeneratePKCE()
 	if err != nil {
 		jsonError(w, "PKCE generation failed: "+err.Error(), http.StatusInternalServerError)
@@ -101,6 +105,10 @@ func (s *Server) handleClaudeAuthStart(w http.ResponseWriter, r *http.Request) {
 // handleClaudeAuthExchange receives the authorization code (either extracted
 // from the pasted callback URL or sent directly) and exchanges it for tokens.
 func (s *Server) handleClaudeAuthExchange(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		jsonError(w, "failed to read request body", http.StatusBadRequest)
@@ -186,6 +194,10 @@ func (s *Server) handleClaudeAuthExchange(w http.ResponseWriter, r *http.Request
 
 // handleClaudeAuthLogout removes the Claude credentials.
 func (s *Server) handleClaudeAuthLogout(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	claudeRemoveFile(claudeCredPath)
 	claudeRemoveFile(claudeTokenFilePath)
 

--- a/v2/pkg/dashboard/claude_auth_deep_coverage_test.go
+++ b/v2/pkg/dashboard/claude_auth_deep_coverage_test.go
@@ -137,6 +137,7 @@ func TestClaudeDeep_Start_ReturnsAuthorizeURL(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/start", nil)
+	markOwnerRequest(req)
 	s.handleClaudeAuthStart(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -164,6 +165,7 @@ func TestClaudeDeep_Start_StoresPKCEState(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/start", nil)
+	markOwnerRequest(req)
 	s.handleClaudeAuthStart(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -193,12 +195,14 @@ func TestClaudeDeep_Start_UniqueState(t *testing.T) {
 
 	// Call start twice, states should differ.
 	req1 := httptest.NewRequest("POST", "/api/claude-auth/start", nil)
+	markOwnerRequest(req1)
 	s.handleClaudeAuthStart(httptest.NewRecorder(), req1)
 	s.claudeOAuthFlow.mu.Lock()
 	state1 := s.claudeOAuthFlow.state
 	s.claudeOAuthFlow.mu.Unlock()
 
 	req2 := httptest.NewRequest("POST", "/api/claude-auth/start", nil)
+	markOwnerRequest(req2)
 	s.handleClaudeAuthStart(httptest.NewRecorder(), req2)
 	s.claudeOAuthFlow.mu.Lock()
 	state2 := s.claudeOAuthFlow.state
@@ -219,6 +223,7 @@ func TestClaudeDeep_Exchange_InvalidJSON(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange", strings.NewReader("not json"))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
@@ -236,6 +241,7 @@ func TestClaudeDeep_Exchange_NoCode(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
@@ -257,6 +263,7 @@ func TestClaudeDeep_Exchange_ExpiredFlow(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"code":"auth-code-123"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
@@ -274,6 +281,7 @@ func TestClaudeDeep_Exchange_EmptyVerifier(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"code":"auth-code-123"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
@@ -291,6 +299,7 @@ func TestClaudeDeep_Exchange_CallbackURLWithError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"callback_url":"https://example.com/cb?error=access_denied&error_description=user+denied"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
@@ -324,6 +333,7 @@ func TestClaudeDeep_Exchange_CallbackURLExtractsCode(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"callback_url":"https://example.com/cb?code=extracted-456"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -349,6 +359,7 @@ func TestClaudeDeep_Exchange_InvalidGrant(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"code":"used-code"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
@@ -374,6 +385,7 @@ func TestClaudeDeep_Exchange_GenericError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"code":"some-code"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusInternalServerError {
@@ -402,6 +414,7 @@ func TestClaudeDeep_Exchange_WriteCredsError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"code":"some-code"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusInternalServerError {
@@ -451,6 +464,7 @@ func TestClaudeDeep_Exchange_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"code":"good-code"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -509,6 +523,7 @@ func TestClaudeDeep_Exchange_DirectCodePreferred(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/exchange",
 		strings.NewReader(`{"code":"direct-code","callback_url":"https://x/cb?code=from-url"}`))
+	markOwnerRequest(req)
 	s.handleClaudeAuthExchange(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -542,6 +557,7 @@ func TestClaudeDeep_Logout_RemovesFiles(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/logout", nil)
+	markOwnerRequest(req)
 	s.handleClaudeAuthLogout(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -573,6 +589,7 @@ func TestClaudeDeep_Logout_NilAgentMgr(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/claude-auth/logout", nil)
+	markOwnerRequest(req)
 	s.handleClaudeAuthLogout(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -603,7 +620,12 @@ func TestClaudeDeep_Routes_Smoke(t *testing.T) {
 	}
 
 	// POST start endpoint.
-	resp, err = http.Post(ts.URL+"/api/claude-auth/start", "application/json", nil)
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/claude-auth/start", nil)
+	if err != nil {
+		t.Fatalf("build POST /api/claude-auth/start: %v", err)
+	}
+	markOwnerRequest(req)
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("POST /api/claude-auth/start: %v", err)
 	}

--- a/v2/pkg/dashboard/claude_auth_owner_gate_test.go
+++ b/v2/pkg/dashboard/claude_auth_owner_gate_test.go
@@ -1,0 +1,68 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClaudeAuthMutationsRequireOwnerRole(t *testing.T) {
+	stubClaudeSeams(t)
+
+	for _, tc := range []struct {
+		name   string
+		path   string
+		body   string
+		invoke func(*Server, http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:   "start",
+			path:   "/api/claude-auth/start",
+			invoke: (*Server).handleClaudeAuthStart,
+		},
+		{
+			name:   "exchange",
+			path:   "/api/claude-auth/exchange",
+			body:   `{"code":"test-code"}`,
+			invoke: (*Server).handleClaudeAuthExchange,
+		},
+		{
+			name:   "logout",
+			path:   "/api/claude-auth/logout",
+			invoke: (*Server).handleClaudeAuthLogout,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, role := range []string{"", "read-write"} {
+				t.Run("denies_"+role, func(t *testing.T) {
+					s := claudeDeepServer(t)
+					rec := httptest.NewRecorder()
+					req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+					if role != "" {
+						req.Header.Set("X-Hive-Role", role)
+					}
+
+					tc.invoke(s, rec, req)
+
+					if rec.Code != http.StatusForbidden {
+						t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+					}
+				})
+			}
+
+			t.Run("allows_owner", func(t *testing.T) {
+				s := claudeDeepServer(t)
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+				markOwnerRequest(req)
+
+				tc.invoke(s, rec, req)
+
+				if rec.Code == http.StatusForbidden {
+					t.Fatalf("owner was denied: body=%s", rec.Body.String())
+				}
+			})
+		})
+	}
+}

--- a/v2/pkg/dashboard/copilot_auth.go
+++ b/v2/pkg/dashboard/copilot_auth.go
@@ -97,6 +97,10 @@ func (s *Server) handleCopilotAuthStatus(w http.ResponseWriter, r *http.Request)
 // returns the one-time code the user must enter at github.com/login/device.
 // A background goroutine polls GitHub until the user approves.
 func (s *Server) handleCopilotAuthStart(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	client := &http.Client{Timeout: copilotHTTPTimeout}
 	req, err := http.NewRequest(http.MethodPost, copilotDeviceCodeURL,
 		strings.NewReader(url.Values{"client_id": {copilotClientID}}.Encode()))
@@ -300,6 +304,10 @@ func (s *Server) saveCopilotToken(token string) error {
 
 // handleCopilotAuthLogout removes the stored Copilot token.
 func (s *Server) handleCopilotAuthLogout(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	os.Remove(copilotUserTokenPath)
 	if s.deps != nil && s.deps.AgentMgr != nil {
 		s.deps.AgentMgr.SetCopilotToken("")

--- a/v2/pkg/dashboard/copilot_auth_owner_gate_test.go
+++ b/v2/pkg/dashboard/copilot_auth_owner_gate_test.go
@@ -1,0 +1,43 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCopilotAuthMutationsRequireOwnerRole(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		path   string
+		invoke func(*Server, http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:   "start",
+			path:   "/api/copilot-auth/start",
+			invoke: (*Server).handleCopilotAuthStart,
+		},
+		{
+			name:   "logout",
+			path:   "/api/copilot-auth/logout",
+			invoke: (*Server).handleCopilotAuthLogout,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, role := range []string{"", "read-write"} {
+				s := covApiServer(t)
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+				if role != "" {
+					req.Header.Set("X-Hive-Role", role)
+				}
+
+				tc.invoke(s, rec, req)
+
+				if rec.Code != http.StatusForbidden {
+					t.Fatalf("role %q: status = %d, want 403", role, rec.Code)
+				}
+			}
+		})
+	}
+}

--- a/v2/pkg/dashboard/metrics_more_coverage_test.go
+++ b/v2/pkg/dashboard/metrics_more_coverage_test.go
@@ -162,6 +162,7 @@ func TestCovK2_ClaudeAuthExchangeBranches(t *testing.T) {
 	// Bad JSON body → 400.
 	req := httptest.NewRequest(http.MethodPost, "/api/claude-auth/exchange", stringReader("{bad"))
 	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {


### PR DESCRIPTION
The Claude and Copilot OAuth mutation handlers carried no authorization
check. The roleEnforcement middleware only blocks POSTs from read-role
callers, so any read-write contributor could reach all five:

  POST /api/claude-auth/start
  POST /api/claude-auth/exchange
  POST /api/claude-auth/logout
  POST /api/copilot-auth/start
  POST /api/copilot-auth/logout

Three consequences, worst first. A contributor with their own Claude
account could call /start to plant their PKCE verifier, complete the real
OAuth flow, then /exchange to replace the stored credentials with tokens
tied to their account — every Claude-backed agent then runs, and bills,
under the attacker. /logout unconditionally deletes the credential files
and reloads the token, so it is a one-request outage of all Claude agents
until an operator re-authenticates by hand. /start also overwrites the
server-side verifier and state, so it can invalidate an owner's in-flight
login at will.

These are shared operator credentials, not per-caller ones, which is why
read-write is the wrong bar: a contributor is trusted to do work, not to
replace the fleet's identity.

Gate all five with the existing requireOwnerRole helper. On v4 that helper
is the stricter one — it demands both X-Hive-Role: owner and the
server-only verification marker, so a spoofed header or a shared-token
call fails closed.

Tests assert each handler denies a read-write caller AND a caller sending
no role header at all, and still admits a verified owner. The
missing-header case is the one that matters: elsewhere in this package a
missing role is still promoted to owner, so it must be proven closed here
rather than assumed.

Sabotage-verified: removing the three claude_auth.go guards fails 6
subtests, removing the two copilot_auth.go guards fails 2, and both pass
again once restored.

Pre-existing tests in claude_auth_deep_coverage_test.go and
metrics_more_coverage_test.go drove these handlers without owner headers;
they are updated to mark their requests as owner, matching v2.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Andrew Anderson <andy@clubanderson.com>

Twin of #3503, which merged to v2. Verified v4 was still ungated before this change: neither `v2/pkg/dashboard/claude_auth.go` nor `copilot_auth.go` contained a single `requireOwnerRole` call on `origin/v4`.

Full `go test ./pkg/dashboard/` on v4: ok, 25.1s.