### PR TITLE
🔒 Verify su-exec source download

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -42,7 +42,18 @@ COPY --from=tmux-builder /usr/local/bin/tmux /usr/local/bin/tmux
 # su-exec: lightweight setuid exec for UID switching from non-root.
 # gosu rejects SUID mode, so we use su-exec (which is designed for it)
 # for the manager's dev→agent UID switches.
-RUN curl -sL -o /tmp/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c \
+ARG TARGETARCH
+ARG SU_EXEC_VERSION=0.3
+ARG SU_EXEC_SHA256_AMD64=0c90fe15804f2670037b90e72eb496579fe00d2c15765e5fe2ddec0f5afa35fa
+ARG SU_EXEC_SHA256_ARM64=0c90fe15804f2670037b90e72eb496579fe00d2c15765e5fe2ddec0f5afa35fa
+RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
+ && case "$ARCH" in \
+      amd64) SU_EXEC_SHA256="$SU_EXEC_SHA256_AMD64" ;; \
+      arm64) SU_EXEC_SHA256="$SU_EXEC_SHA256_ARM64" ;; \
+      *) echo "unsupported arch for su-exec: $ARCH" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/v${SU_EXEC_VERSION}/su-exec.c" \
+ && echo "${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \
  && chmod u+s /usr/local/bin/su-exec \
  && rm /tmp/su-exec.c \


### PR DESCRIPTION
Refs #2933

## Summary
- Pin `su-exec.c` to upstream tag `v0.3` instead of fetching `master`
- Verify the source with per-arch SHA-256 args before compiling the SUID helper

## Checksum evidence
- Source URL: `https://raw.githubusercontent.com/ncopa/su-exec/v0.3/su-exec.c`
- Command used: `curl -fsSL https://raw.githubusercontent.com/ncopa/su-exec/v0.3/su-exec.c | sha256sum`
- `SU_EXEC_SHA256_AMD64=0c90fe15804f2670037b90e72eb496579fe00d2c15765e5fe2ddec0f5afa35fa`
- `SU_EXEC_SHA256_ARM64=0c90fe15804f2670037b90e72eb496579fe00d2c15765e5fe2ddec0f5afa35fa`

Note: `su-exec` does not publish a separate SHA-256 checksum asset for its single C source file, so this pins the immutable upstream tag URL and verifies the exact source bytes before the SUID compile.

## Fail-closed sanity check
Deliberately used an all-zero checksum in the same `sha256sum -c - && next-command` shape. Output:

```text
.su-exec-sabotage.c: FAILED
fail-closed ok: rc=1 and chained command did not run
```
