### PR TITLE
🔒 fix automerge queue approval identity binding

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -602,7 +602,7 @@ func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger
 		// the very first token this process mints is scoped to the right org
 		// rather than 403ing on every write until the self-heal tick runs.
 		healGitHubAppInstallation(ctx, out.AppAuth, cfg, logger)
-		out.Client = github.NewClientFromApp(out.AppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+		out.Client = github.NewClientFromAppWithBotLogin(out.AppAuth, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.BotLogin())
 		startDocsTokenRefresh(ctx, cfg, appKeyFile, logger)
 		return out
 	}
@@ -1995,7 +1995,7 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("initializing app auth: %w", err)
 			}
-			newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+			newClient := github.NewClientFromAppWithBotLogin(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.BotLogin())
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
@@ -2398,7 +2398,7 @@ func main() {
 				if appErr != nil {
 					logger.Error("github app auth rebuild after config reload failed", "error", appErr)
 				} else {
-					newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+					newClient := github.NewClientFromAppWithBotLogin(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.BotLogin())
 					if len(cfg.Governor.Labels.Exempt) > 0 {
 						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 						newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
@@ -3487,7 +3487,7 @@ func main() {
 				// easily as a hand-edited config; correct (and persist) it
 				// before building a client that would 403 on every write.
 				healGitHubAppInstallation(ctx, newAppAuth, cfg, logger)
-				newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+				newClient := github.NewClientFromAppWithBotLogin(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.BotLogin())
 				if len(cfg.Governor.Labels.Exempt) > 0 {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 					newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -435,6 +435,10 @@ func (t *appTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func NewClientFromApp(auth *AppAuth, org string, repos []string, logger *slog.Logger) *Client {
+	return NewClientFromAppWithBotLogin(auth, org, repos, logger, "")
+}
+
+func NewClientFromAppWithBotLogin(auth *AppAuth, org string, repos []string, logger *slog.Logger, appBotLogin string) *Client {
 	transport := &appTransport{
 		auth: auth,
 		base: http.DefaultTransport,
@@ -445,10 +449,11 @@ func NewClientFromApp(auth *AppAuth, org string, repos []string, logger *slog.Lo
 	setBaseURL(client, auth.apiURL)
 
 	return &Client{
-		client:  client,
-		org:     org,
-		repos:   repos,
-		logger:  logger,
-		appAuth: auth,
+		client:      client,
+		org:         org,
+		repos:       repos,
+		logger:      logger,
+		appAuth:     auth,
+		appBotLogin: appBotLogin,
 	}
 }

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -44,7 +44,7 @@ type hiveQueueApproval struct {
 // SweepQueuedAutoMerges consumes the configured Hive merger-queue label. It
 // only squashes open, labelled, non-draft PRs in managed repos after GitHub
 // reports them mergeable, commit statuses/check-runs are green, and the latest
-// Hive queue approval body proves the queuer is not the PR author.
+// Hive App-authored queue approval proves the queuer is not the PR author.
 func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepOptions) (*AutoMergeSweepResult, error) {
 	if c == nil {
 		return nil, ErrNoGitHubClient
@@ -210,6 +210,9 @@ func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string
 			if !strings.EqualFold(review.GetState(), "APPROVED") {
 				continue
 			}
+			if !c.isHiveAppReviewAuthor(review) {
+				continue
+			}
 			if queuedBy := parseHiveQueueReview(review.GetBody()); queuedBy != "" {
 				latest = hiveQueueApproval{QueuedBy: queuedBy, HeadSHA: review.GetCommitID()}
 			}
@@ -220,6 +223,13 @@ func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string
 		opts.Page = resp.NextPage
 	}
 	return latest, latest.QueuedBy != "", nil
+}
+
+func (c *Client) isHiveAppReviewAuthor(review *gh.PullRequestReview) bool {
+	if c == nil || review == nil || strings.TrimSpace(c.appBotLogin) == "" {
+		return false
+	}
+	return strings.EqualFold(safeGetLogin(review.GetUser()), c.appBotLogin)
 }
 
 func (c *Client) invalidateQueuedAutoMerge(ctx context.Context, owner, repo string, number int, label, body string) error {

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -13,10 +13,13 @@ import (
 	gh "github.com/google/go-github/v72/github"
 )
 
+const testHiveAppBotLogin = "kubestellar-hive[bot]"
+
 type sweepPR struct {
 	number          int
 	author          string
 	queuedBy        string
+	reviewAuthor    string
 	headSHA         string
 	reviewCommitID  *string
 	label           bool
@@ -42,7 +45,7 @@ func TestSweepQueuedAutoMergesMergesLabelledGreenPRAudits(t *testing.T) {
 	}}, &merged)
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{
 		Audit: func(event AutoMergeSweepEvent) { audits = append(audits, event) },
 	})
@@ -57,6 +60,31 @@ func TestSweepQueuedAutoMergesMergesLabelledGreenPRAudits(t *testing.T) {
 	}
 	if audits[0].HeadSHA != "sha7" {
 		t.Fatalf("audit head SHA = %q, want sha7", audits[0].HeadSHA)
+	}
+}
+
+func TestSweepQueuedAutoMergesIgnoresForgedNonAppQueueApproval(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number:          7,
+		author:          "alice",
+		queuedBy:        "bob",
+		reviewAuthor:    "mallory",
+		label:           true,
+		mergeableState:  "clean",
+		statusState:     "success",
+		checkStatus:     "completed",
+		checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 || result.Skipped != 1 {
+		t.Fatalf("result=%+v merge calls=%v, want non-App review ignored and PR skipped", result, merged)
 	}
 }
 
@@ -89,7 +117,7 @@ func TestSweepQueuedAutoMergesDequeuesWhenApprovalHeadChanged(t *testing.T) {
 	})
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
 	if err != nil {
 		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
@@ -130,7 +158,7 @@ func TestSweepQueuedAutoMergesDequeuesWhenApprovalHeadMissing(t *testing.T) {
 	})
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
 	if err != nil {
 		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
@@ -152,7 +180,7 @@ func TestSweepQueuedAutoMergesSkipsRedUnlabelledAndDraft(t *testing.T) {
 	}, &merged)
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
 	if err != nil {
 		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
@@ -173,7 +201,7 @@ func TestSweepQueuedAutoMergesRespectsCap(t *testing.T) {
 	}, &merged)
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{MaxMerges: 1})
 	if err != nil {
 		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
@@ -192,7 +220,7 @@ func TestSweepQueuedAutoMergesHonorsConfiguredLabel(t *testing.T) {
 	}}, &merged)
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	c.SetAutoMergeLabel(label)
 	if _, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != nil {
 		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
@@ -210,7 +238,7 @@ func TestSweepQueuedAutoMergesRechecksSelfMergeBan(t *testing.T) {
 	}}, &merged)
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
 	if err != nil {
 		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
@@ -292,7 +320,7 @@ func TestCommitGreenStatusAndCheckBranches(t *testing.T) {
 				}
 			}))
 			defer api.Close()
-			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			c := newAutoMergeSweepClient(api.URL)
 			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
 			if err != nil {
 				t.Fatalf("commitGreen returned error: %v", err)
@@ -336,14 +364,14 @@ func TestTrySweepQueuedPRSkipBranches(t *testing.T) {
 					if tt.noReview {
 						json.NewEncoder(w).Encode([]map[string]any{})
 					} else {
-						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI.", "commit_id": "sha7"}})
+						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]string{"login": testHiveAppBotLogin}}})
 					}
 				default:
 					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 				}
 			}))
 			defer api.Close()
-			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			c := newAutoMergeSweepClient(api.URL)
 			_, reason, err := c.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
 			if err != nil {
 				t.Fatalf("trySweepQueuedPR returned error: %v", err)
@@ -380,7 +408,7 @@ func TestTrySweepQueuedPRMissingHeadAndMergeNotApplied(t *testing.T) {
 						"labels":          []map[string]string{{"name": AutoMergeQueuedLabel}},
 					})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
-					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7"}})
+					json.NewEncoder(w).Encode([]map[string]any{{"state": "COMMENTED", "body": "noise"}, {"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]string{"login": testHiveAppBotLogin}}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
 					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
@@ -392,7 +420,7 @@ func TestTrySweepQueuedPRMissingHeadAndMergeNotApplied(t *testing.T) {
 				}
 			}))
 			defer api.Close()
-			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			c := newAutoMergeSweepClient(api.URL)
 			_, reason, err := c.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
 			if err != nil {
 				t.Fatalf("trySweepQueuedPR returned error: %v", err)
@@ -415,7 +443,7 @@ func TestTrySweepQueuedPRMergeError(t *testing.T) {
 				"labels": []map[string]string{{"name": AutoMergeQueuedLabel}},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
-			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7"}})
+			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @bob for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]string{"login": testHiveAppBotLogin}}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/status":
 			json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 1, "statuses": []map[string]string{{"context": "ci/build", "state": "success"}}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha7/check-runs":
@@ -427,10 +455,34 @@ func TestTrySweepQueuedPRMergeError(t *testing.T) {
 		}
 	}))
 	defer api.Close()
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	_, reason, err := c.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
 	if err == nil || reason != "merge-failed" {
 		t.Fatalf("trySweepQueuedPR reason=%q err=%v, want merge-failed error", reason, err)
+	}
+}
+
+func TestLatestHiveQueueApprovalDoesNotTrustBodyWhenReviewerIsNotApp(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/acme/widget/pulls/7/reviews" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]map[string]any{{
+			"state":     "APPROVED",
+			"body":      "Approved by @alice for Hive auto-merge on green CI.",
+			"commit_id": "sha7",
+			"user":      map[string]string{"login": "mallory"},
+		}})
+	}))
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	approval, ok, err := c.latestHiveQueueApproval(context.Background(), "acme", "widget", 7)
+	if err != nil {
+		t.Fatalf("latestHiveQueueApproval returned error: %v", err)
+	}
+	if ok || approval.QueuedBy != "" {
+		t.Fatalf("approval=(%+v,%v), want forged body ignored", approval, ok)
 	}
 }
 
@@ -440,14 +492,14 @@ func TestLatestHiveQueueApprovalKeepsLatestCommitID(t *testing.T) {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 		json.NewEncoder(w).Encode([]map[string]any{
-			{"state": "APPROVED", "body": "Approved by @old for Hive auto-merge on green CI.", "commit_id": "oldsha"},
-			{"state": "COMMENTED", "body": "Approved by @ignored for Hive auto-merge on green CI.", "commit_id": "ignored"},
-			{"state": "APPROVED", "body": "Approved by @new for Hive auto-merge on green CI.", "commit_id": "newsha"},
+			{"state": "APPROVED", "body": "Approved by @old for Hive auto-merge on green CI.", "commit_id": "oldsha", "user": map[string]string{"login": testHiveAppBotLogin}},
+			{"state": "COMMENTED", "body": "Approved by @ignored for Hive auto-merge on green CI.", "commit_id": "ignored", "user": map[string]string{"login": testHiveAppBotLogin}},
+			{"state": "APPROVED", "body": "Approved by @new for Hive auto-merge on green CI.", "commit_id": "newsha", "user": map[string]string{"login": testHiveAppBotLogin}},
 		})
 	}))
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	approval, ok, err := c.latestHiveQueueApproval(context.Background(), "acme", "widget", 7)
 	if err != nil {
 		t.Fatalf("latestHiveQueueApproval returned error: %v", err)
@@ -472,7 +524,7 @@ func TestInvalidateQueuedAutoMergeIgnoresMissingLabelAndComments(t *testing.T) {
 	}))
 	defer api.Close()
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	if err := c.invalidateQueuedAutoMerge(context.Background(), "acme", "widget", 7, AutoMergeQueuedLabel, "re-queue required"); err != nil {
 		t.Fatalf("invalidateQueuedAutoMerge returned error: %v", err)
 	}
@@ -508,7 +560,7 @@ func TestInvalidateQueuedAutoMergeReportsAPIErrors(t *testing.T) {
 			}))
 			defer api.Close()
 
-			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			c := newAutoMergeSweepClient(api.URL)
 			if err := c.invalidateQueuedAutoMerge(context.Background(), "acme", "widget", 7, AutoMergeQueuedLabel, "re-queue required"); err == nil {
 				t.Fatal("invalidateQueuedAutoMerge returned nil error")
 			}
@@ -542,7 +594,7 @@ func TestCommitGreenAPIErrors(t *testing.T) {
 				}
 			}))
 			defer api.Close()
-			c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+			c := newAutoMergeSweepClient(api.URL)
 			_, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
 			if err == nil || reason != tt.wantReason {
 				t.Fatalf("commitGreen reason=%q err=%v, want %q error", reason, err, tt.wantReason)
@@ -567,7 +619,7 @@ func TestListQueuedPullRequestIssuesPaginates(t *testing.T) {
 	defer api.Close()
 	base = api.URL
 
-	c := NewClient("token", "acme", []string{"widget"}, nil, api.URL)
+	c := newAutoMergeSweepClient(api.URL)
 	issues, err := c.listQueuedPullRequestIssues(context.Background(), "acme", "widget", AutoMergeQueuedLabel)
 	if err != nil {
 		t.Fatalf("listQueuedPullRequestIssues returned error: %v", err)
@@ -575,6 +627,12 @@ func TestListQueuedPullRequestIssuesPaginates(t *testing.T) {
 	if len(issues) != 2 || issues[0].GetNumber() != 1 || issues[1].GetNumber() != 2 {
 		t.Fatalf("issues = %#v, want pages 1 and 2", issues)
 	}
+}
+
+func newAutoMergeSweepClient(apiURL string) *Client {
+	c := NewClient("token", "acme", []string{"widget"}, nil, apiURL)
+	c.SetAppBotLogin(testHiveAppBotLogin)
+	return c
 }
 
 func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, merged *[]int, extras ...func(http.ResponseWriter, *http.Request)) *httptest.Server {
@@ -612,7 +670,16 @@ func newAutoMergeSweepAPI(t *testing.T, expectedLabel string, prs []sweepPR, mer
 			if pr.reviewCommitID != nil {
 				reviewCommitID = *pr.reviewCommitID
 			}
-			json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": body, "commit_id": reviewCommitID}})
+			reviewAuthor := pr.reviewAuthor
+			if reviewAuthor == "" {
+				reviewAuthor = testHiveAppBotLogin
+			}
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"state":     "APPROVED",
+				"body":      body,
+				"commit_id": reviewCommitID,
+				"user":      map[string]string{"login": reviewAuthor},
+			}})
 		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/acme/widget/pulls/"):
 			number := pathNumber(t, r.URL.Path, "/repos/acme/widget/pulls/", "")
 			pr := byNumber[number]

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	autoMergeLabel   string
 	logger           *slog.Logger
 	appAuth          *AppAuth // nil for token-authenticated clients
+	appBotLogin      string   // "<app-slug>[bot]" when the client authenticates as a GitHub App
 	// prAuthz gates PR-open requests from the request-file watcher against the
 	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
 	// StartPRRequestWatcher.
@@ -66,6 +67,15 @@ func (c *Client) AppAuth() *AppAuth {
 		return nil
 	}
 	return c.appAuth
+}
+
+// SetAppBotLogin records the GitHub App bot account that authors App-created
+// artifacts. Empty values fail closed for checks that require App authorship.
+func (c *Client) SetAppBotLogin(login string) {
+	if c == nil {
+		return
+	}
+	c.appBotLogin = strings.TrimSpace(login)
 }
 
 type Issue struct {


### PR DESCRIPTION
Closes #2988.

## Threat model and live finding

The issue was still live on `origin/v2`: `latestHiveQueueApproval` accepted any APPROVED review whose body matched `Approved by @... for Hive auto-merge on green CI.` and copied that body-captured name into `QueuedBy` without checking `review.GetUser()` or App authorship (`origin/v2:v2/pkg/github/automerge_sweep.go:209-215`). That made the audit trail forgeable and let a collaborator-controlled review body name a third party so the self-merge ban compared the PR author against attacker-controlled text.

## Fix

This PR records the configured Hive App bot login on App-backed GitHub clients and passes `cfg.GitHub.BotLogin()` through the production App client construction (`v2/pkg/github/client.go:41-78`, `v2/pkg/github/app.go:441-458`, `v2/cmd/hive/main.go`). The sweep now rejects queue reviews unless `review.GetUser().GetLogin()` equals that configured App bot login (`v2/pkg/github/automerge_sweep.go:209-233`). Only after App authorship is verified does it trust the App-written review body's human username for `QueuedBy`, so the self-merge ban is evaluated against the verified App-authored queue identity.

This preserves legitimate automerge because the dashboard queues by having the Hive App create the approval review. Already-queued PRs with App-authored reviews continue to merge. Queued PRs whose review was authored by a non-App account now fail closed as `no-hive-queue-approval` and must be re-queued through Hive.

## Regression tests and sabotage verification

Added tests for forged body/non-App reviewer rejection, non-App collaborator reviews not queuing a merge, App-authored approval still merging, and the self-merge ban firing when the verified App-authored queued-by user is the PR author.

Sabotage verification: I temporarily removed the `isHiveAppReviewAuthor` check and reran:

`go test -v ./pkg/github/ -run 'Test(SweepQueuedAutoMergesIgnoresForgedNonAppQueueApproval|LatestHiveQueueApprovalDoesNotTrustBodyWhenReviewerIsNotApp)'`

Both regression tests failed: the forged non-App review merged PR 7, and `latestHiveQueueApproval` returned `QueuedBy:alice` from a review authored by `mallory`. Restoring the check made them pass.

## Validation

- `git diff --name-only -- '*.go' | xargs gofmt -l` (no changed files listed)
- `gofmt -l .` was also run; it reports pre-existing unrelated unformatted files such as `extract.go` and `v2/cmd/bd/kb.go`.
- `go build ./...`
- `go test ./pkg/github/` and scanned output with `grep -E -e '--- FAIL' -e '^FAIL'` (no matches)
- Code-review agent reported no significant issues.

## v4 check

`origin/v4` does not have this same body-forged identity flaw: its `latestHiveQueueApproval` explicitly uses `safeGetLogin(review.GetUser())` for `QueuedBy` and keeps the parsed body marker only as an opt-in marker (`origin/v4:v2/pkg/github/automerge_sweep.go:232-260`). I did not include v4 changes in this v2-scoped PR.
