### PR TITLE
🐛 bug fix: restore v2 test stability

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5237,9 +5237,8 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 
 	prevTrigger := agent.PausedTrigger
 	prevReason := agent.PausedReason
-	// Snapshot backend/model while m.mu is still held — the audit call below
-	// runs after the deliberate early Unlock, where touching agent fields
-	// would be an unsynchronized read.
+	// Snapshot backend/model while m.mu is held so audit details stay stable
+	// even when Resume relaunches the agent before returning.
 	resumeBackend := agent.effectiveBackend()
 	resumeModel := agent.effectiveModel()
 	agent.Paused = false
@@ -5254,11 +5253,6 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	if needsRelaunch {
 		agent.forceRelaunch = true
 	}
-	// Release the global agents-map lock before slow per-agent tmux
-	// operations (ensureTmuxSession + launchInTmux ~2s each). This allows
-	// concurrent Resume() calls for different agents to run in parallel
-	// instead of serializing on the mutex.
-	m.mu.Unlock()
 
 	m.logger.Info("audit: agent resumed",
 		"name", name,
@@ -5276,10 +5270,14 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	))
 	if needsRelaunch {
 		if err := m.ensureTmuxSession(agent); err != nil {
+			m.mu.Unlock()
 			return err
 		}
-		return m.launchInTmux(ctx, agent)
+		err := m.launchInTmux(ctx, agent)
+		m.mu.Unlock()
+		return err
 	}
+	m.mu.Unlock()
 	return nil
 }
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2087,6 +2087,10 @@ func (s *Server) handleQueuePRAutoMerge(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, "merger or owner access required", http.StatusForbidden)
 		return
 	}
+	if role == config.RoleOwner && r.Header.Get(ownerRoleVerifiedHeader) != "true" {
+		jsonError(w, "owner access required", http.StatusForbidden)
+		return
+	}
 	if user == "" {
 		jsonError(w, "authenticated GitHub user required", http.StatusForbidden)
 		return

--- a/v2/pkg/dashboard/pr_automerge_test.go
+++ b/v2/pkg/dashboard/pr_automerge_test.go
@@ -65,6 +65,9 @@ func TestQueuePRAutoMergeRoleAndSelfGate(t *testing.T) {
 			}
 			req := httptest.NewRequest(http.MethodPost, "/api/prs/acme/widget/7/queue-automerge", nil)
 			req.Header.Set("X-Hive-Role", tt.role)
+			if tt.role == config.RoleOwner {
+				req.Header.Set(ownerRoleVerifiedHeader, "true")
+			}
 			req.Header.Set("X-Hive-User", tt.user)
 			req.SetPathValue("owner", "acme")
 			req.SetPathValue("repo", "widget")

--- a/v2/pkg/hub/final2_coverage_test.go
+++ b/v2/pkg/hub/final2_coverage_test.go
@@ -38,6 +38,10 @@ func TestTriggerAutoUpgradesRemoteStale(t *testing.T) {
 func TestTriggerAutoUpgradesRemoteNotStale(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
+	resetCommitOrderState(t)
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "behind", nil
+	})
 
 	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "remote"})

--- a/v2/pkg/hub/sha_poll_coverage_test.go
+++ b/v2/pkg/hub/sha_poll_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ============================================================
@@ -17,15 +18,34 @@ import (
 // endpoints and points githubAPIBase/ghcrBase at itself for the test's duration.
 func fakeGitHubGHCR(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
+	waitForCommitOrderResolvers(t)
 	srv := httptest.NewServer(handler)
 	oldGH, oldGHCR := githubAPIBase, ghcrBase
 	githubAPIBase = srv.URL
 	ghcrBase = srv.URL
 	t.Cleanup(func() {
+		waitForCommitOrderResolvers(t)
 		githubAPIBase, ghcrBase = oldGH, oldGHCR
 		srv.Close()
 	})
 	return srv
+}
+
+func waitForCommitOrderResolvers(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		commitOrderMu.Lock()
+		inFlight := len(commitOrderInFlight)
+		commitOrderMu.Unlock()
+		if inFlight == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d commit order resolver(s)", inFlight)
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 func TestListRepoBranches(t *testing.T) {


### PR DESCRIPTION
Closes #3459

## What failed

The scheduled v2 run 31515877787 failed in `go test ./pkg/... -short -race -count=1` with:

```text
--- FAIL: TestGovernorRepos_RejectsCrossForge (0.00s)
    repo_add_form_test.go:33: expected canonical-shape message, got: {"error":"Repo target misconfigured: repo 'github.ibm.com/acme/widget' is not a valid target — expected 'repo' or 'owner/repo' (exactly one '/'). Fix in Governor Config → Repos.","ok":false}
FAIL	github.com/kubestellar/hive/v2/pkg/dashboard	29.611s
```

That exact test is fixed on current v2, but newer scheduled runs on current v2 still fail in `pkg/dashboard`:

```text
31551491866: --- FAIL: TestRoleEnforcement_EmptyRoleRejected/handleVaultsConnect_empty_role
31551491866: --- FAIL: TestRoleEnforcement_UnverifiedOwnerRoleRejected/handleVaultsConnect
31551491866: --- FAIL: TestRoleEnforcement_QueuePRAutoMerge_EmptyRoleRejected
```

## Why

`handleVaultsConnect` still had the older fail-open role logic: empty `X-Hive-Role` became owner before dependency/body validation, so the role-enforcement tests saw 503 instead of 403. `handleQueuePRAutoMerge` also defaulted an empty role to owner before checking merger/owner authorization. The fix removes the PR queue default and requires the owner verification marker for owner role (`v2/pkg/dashboard/api.go:2083-2093`), and makes vault connection use `requireOwnerRole` (`v2/pkg/dashboard/api.go:7051-7057`).

While validating the full current v2 CI command after rebasing, `-race` exposed two current v2 flakes: `Resume` unlocked before relaunching an agent and raced concurrent `Pause`/`Resume` on the same `AgentProcess`, so relaunch now stays under `m.mu` (`v2/pkg/agent/manager.go:5238-5279`). Hub SHA-poll tests also changed fake GitHub globals while a background commit-order resolver could still read them; the fake waits for in-flight resolvers and the remote-not-stale test stubs the compare fetcher (`v2/pkg/hub/sha_poll_coverage_test.go:19-48`, `v2/pkg/hub/final2_coverage_test.go:38-44`).

## Verification

Original failure reproduced from Actions with `unset GITHUB_TOKEN && gh run view 31515877787 --repo kubestellar/hive --log-failed`.

Current v2 original test passes locally:

```text
$ cd /Users/andan02/wt-i3459/v2 && go test ./pkg/dashboard/ -run TestGovernorRepos_RejectsCrossForge -v
=== RUN   TestGovernorRepos_RejectsCrossForge
--- PASS: TestGovernorRepos_RejectsCrossForge (0.00s)
PASS
ok  	github.com/kubestellar/hive/v2/pkg/dashboard	1.535s
```

Current v2 dashboard failures reproduced locally before this fix:

```text
$ go test ./pkg/dashboard/ -run 'TestRoleEnforcement_(EmptyRoleRejected|UnverifiedOwnerRoleRejected|QueuePRAutoMerge_EmptyRoleRejected)' -v
--- FAIL: TestRoleEnforcement_EmptyRoleRejected/handleVaultsConnect_empty_role: got status 503, want 403
--- FAIL: TestRoleEnforcement_UnverifiedOwnerRoleRejected/handleVaultsConnect: got status 503, want 403
--- FAIL: TestRoleEnforcement_QueuePRAutoMerge_EmptyRoleRejected: got status 503, want 403
FAIL	github.com/kubestellar/hive/v2/pkg/dashboard	0.502s
```

Sabotage verification: I temporarily restored the old vault fail-open default and confirmed the regression tests failed with 503 instead of 403, then reverted that sabotage before committing.

Final local verification after the fix and rebase:

```text
$ go test ./pkg/dashboard/ -run 'TestRoleEnforcement_(EmptyRoleRejected|UnverifiedOwnerRoleRejected|QueuePRAutoMerge_EmptyRoleRejected)|TestQueuePRAutoMergeRoleAndSelfGate|TestGovernorRepos_RejectsCrossForge' -count=20
ok  	github.com/kubestellar/hive/v2/pkg/dashboard	1.695s

$ go test -race ./pkg/agent/ -run TestConcurrentPauseResume_NoPanic -count=5
ok  	github.com/kubestellar/hive/v2/pkg/agent	27.969s

$ go test -race ./pkg/hub/ -run 'TestHandleSwitchBranchUnknownBranch|TestTriggerAutoUpgradesRemoteNotStale' -count=20
ok  	github.com/kubestellar/hive/v2/pkg/hub	8.511s

$ go test ./pkg/... -short -race -count=1
ok  	github.com/kubestellar/hive/v2/pkg/advisory	1.520s
ok  	github.com/kubestellar/hive/v2/pkg/agent	521.864s
ok  	github.com/kubestellar/hive/v2/pkg/dashboard	126.238s
ok  	github.com/kubestellar/hive/v2/pkg/hub	184.435s
ok  	github.com/kubestellar/hive/v2/pkg/watsonx	1.366s
(no `--- FAIL` or leading `FAIL` lines)
```
