### PR TITLE
🔒 security: define Codex contributor execution contract

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -109,7 +109,16 @@ contribute-check-backend backend="claude":
         ;;
       codex)
         if command -v codex &>/dev/null; then
-          echo "Codex CLI detected — uses OPENAI_API_KEY from environment."
+          CODEX_AUTH_FILE="${CODEX_HOME:-${HOME}/.codex}/auth.json"
+          if [[ -n "${CODEX_API_KEY:-}" || -n "${OPENAI_API_KEY:-}" ]]; then
+            echo "Codex CLI detected — API-key auth is present in the environment."
+          elif [[ -s "$CODEX_AUTH_FILE" ]]; then
+            echo "Codex CLI detected — auth file present at ${CODEX_AUTH_FILE}."
+          else
+            echo "ERROR: Codex CLI detected but ${CODEX_AUTH_FILE} is missing."
+            echo "  Run: codex login --device-auth (or export CODEX_API_KEY for API-key mode)."
+            exit 1
+          fi
         else
           echo "ERROR: Codex CLI not found. Install: npm i -g @openai/codex"
           exit 1
@@ -581,6 +590,7 @@ contribute-hive backend="" mode="docker": check-version
         ${HIVE_LITELLM_ENDPOINT:+-e HIVE_LITELLM_ENDPOINT="${HIVE_LITELLM_ENDPOINT}"} \
         ${HIVE_LITELLM_API_KEY:+-e HIVE_LITELLM_API_KEY="${HIVE_LITELLM_API_KEY}"} \
         ${AGENT_MODEL:+-e AGENT_MODEL="${AGENT_MODEL}"} \
+        ${AGENT_REASONING_EFFORT:+-e AGENT_REASONING_EFFORT="${AGENT_REASONING_EFFORT}"} \
         {{hive_image}} > /dev/null
 
       echo "Container: ${CONTAINER_NAME}"

--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -6,6 +6,7 @@
 # Usage (in .env files):
 #   AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-opus-4.6"
 #   AGENT_LAUNCH_CMD="agent-launch.sh --backend claude --model claude-opus-4.6"
+#   AGENT_LAUNCH_CMD="agent-launch.sh --backend codex --model gpt-5.6-luna --reasoning-effort low"
 #
 # Or override with env vars:
 #   AGENT_BACKEND=copilot AGENT_MODEL=claude-opus-4.6 agent-launch.sh
@@ -58,12 +59,14 @@ fi
 
 BACKEND="${AGENT_BACKEND:-claude}"
 MODEL="${AGENT_MODEL:-}"
+REASONING_EFFORT="${AGENT_REASONING_EFFORT:-}"
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --backend)  BACKEND="$2"; shift 2 ;;
     --model)    MODEL="$2"; shift 2 ;;
+    --reasoning-effort) REASONING_EFFORT="$2"; shift 2 ;;
     *)          EXTRA_ARGS+=("$1"); shift ;;
   esac
 done
@@ -83,10 +86,17 @@ if [[ -z "$CMD" || -z "$PERM_FLAG" ]]; then
   exit 1
 fi
 
-FULL_CMD=("$CMD" "$PERM_FLAG")
+PERM_ARGS=()
+if [[ -n "$PERM_FLAG" ]]; then
+  read -r -a PERM_ARGS <<< "$PERM_FLAG"
+fi
+FULL_CMD=("$CMD" "${PERM_ARGS[@]}")
 if [[ -n "$MODEL" && -n "$MODEL_FLAG" ]]; then
   MODEL=$(normalize_model_for_backend "$BACKEND" "$MODEL")
   FULL_CMD+=("$MODEL_FLAG" "$MODEL")
+fi
+if [[ "$BACKEND" == "codex" && -n "$REASONING_EFFORT" ]]; then
+  FULL_CMD+=("-c" "model_reasoning_effort=\"${REASONING_EFFORT}\"")
 fi
 if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
   FULL_CMD+=("${EXTRA_ARGS[@]}")

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -172,6 +172,52 @@ if [[ "${HIVE_CONTRIBUTOR_AGENT_TEST_KNOWLEDGE_FETCH:-}" == "1" ]]; then
   exit 1
 fi
 
+codex_auth_file() {
+  local codex_home="${CODEX_HOME:-${HOME}/.codex}"
+  echo "${codex_home}/auth.json"
+}
+
+codex_auth_json_has_credentials() {
+  local auth_file="$1"
+  python3 - "$auth_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    data = json.loads(Path(sys.argv[1]).read_text())
+except Exception:
+    sys.exit(1)
+
+if not isinstance(data, dict):
+    sys.exit(1)
+
+def nonempty_string(value):
+    return isinstance(value, str) and bool(value.strip())
+
+tokens = data.get("tokens")
+if isinstance(tokens, dict):
+    for key in ("access_token", "refresh_token", "id_token"):
+        if nonempty_string(tokens.get(key)):
+            sys.exit(0)
+
+for key in ("OPENAI_API_KEY", "api_key", "openai_api_key"):
+    if nonempty_string(data.get(key)):
+        sys.exit(0)
+
+sys.exit(1)
+PY
+}
+
+codex_is_authenticated() {
+  local auth_file
+  if [[ -n "${CODEX_API_KEY:-}" || -n "${OPENAI_API_KEY:-}" ]]; then
+    return 0
+  fi
+  auth_file="$(codex_auth_file)"
+  [[ -f "$auth_file" ]] && codex_auth_json_has_credentials "$auth_file"
+}
+
 # Detect CLI authentication
 detect_cli() {
   local backend="$1"
@@ -201,7 +247,13 @@ detect_cli() {
       if goose --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
       ;;
     codex)
-      if codex --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      if ! codex --version &>/dev/null; then
+        echo "BROKEN"
+      elif codex_is_authenticated; then
+        echo "OK"
+      else
+        echo "NOT_AUTHED"
+      fi
       ;;
     pi)
       if pi --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
@@ -214,6 +266,11 @@ detect_cli() {
       ;;
   esac
 }
+
+if [[ "${HIVE_CONTRIBUTOR_AGENT_TEST_DETECT_CLI:-}" == "1" ]]; then
+  detect_cli "$AGENT_BACKEND"
+  exit 0
+fi
 
 echo "=== Hive Contributor Agent (ClankeR) ==="
 echo "Hub:     $HIVE_HUB"
@@ -229,8 +286,18 @@ case "$STATUS" in
     exit 1
     ;;
   NOT_AUTHED)
-    echo "WARNING: $AGENT_BACKEND CLI may not be authenticated."
-    echo "You may need to log in. The agent will start and prompt if needed."
+    if [[ "$AGENT_BACKEND" == "codex" ]]; then
+      echo "ERROR: codex CLI is installed but not authenticated."
+      echo "Run: CODEX_HOME=\${CODEX_HOME:-\$HOME/.codex} codex login --device-auth"
+      exit 1
+    else
+      echo "WARNING: $AGENT_BACKEND CLI may not be authenticated."
+      echo "You may need to log in. The agent will start and prompt if needed."
+    fi
+    ;;
+  BROKEN)
+    echo "ERROR: $AGENT_BACKEND CLI is installed but did not run successfully."
+    exit 1
     ;;
   OK)
     echo "$AGENT_BACKEND CLI detected and ready."
@@ -413,6 +480,10 @@ if [[ -n "${AGENT_MODEL:-}" ]]; then
     *) MODEL_FLAG="--model $AGENT_MODEL" ;;
   esac
 fi
+REASONING_FLAG=""
+if [[ "$AGENT_BACKEND" == "codex" && -n "${AGENT_REASONING_EFFORT:-}" ]]; then
+  REASONING_FLAG="-c 'model_reasoning_effort=\"${AGENT_REASONING_EFFORT}\"'"
+fi
 
 # Copy host .claude.json from hive config dir (Colima can't bind-mount files)
 if [[ "$AGENT_BACKEND" == "claude" ]] && [[ -f "${CONFIG_DIR}/claude-config.json" ]]; then
@@ -457,7 +528,7 @@ fi
 # relay launches a one-shot CLI per task, and one-shot invocations do not draw
 # the trust/theme/onboarding dialogs this loop dismisses.
 if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
-  tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG" Enter
+  tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG $REASONING_FLAG" Enter
 
   # Auto-dismiss startup prompts (workspace trust, theme picker, etc.)
   AUTO_DISMISS_ATTEMPTS=10

--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -190,3 +190,138 @@ done
 
 echo "contributor-agent hook override tests passed"
 echo "contributor-agent knowledge fetch tests passed"
+
+codex_flags_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+case "$codex_flags_output" in
+  *"backend_perm_flag=--ask-for-approval on-request --sandbox workspace-write"* ) ;;
+  *)
+    echo "expected codex default posture to be explicit and non-bypass; got:" >&2
+    echo "$codex_flags_output" >&2
+    exit 1
+    ;;
+esac
+
+codex_bypass_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1 \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+case "$codex_bypass_output" in
+  *"backend_perm_flag=--dangerously-bypass-approvals-and-sandbox"* ) ;;
+  *)
+    echo "expected codex dangerous bypass to be opt-in; got:" >&2
+    echo "$codex_bypass_output" >&2
+    exit 1
+    ;;
+esac
+
+FAKE_BIN="${WORK_DIR}/bin"
+mkdir -p "$FAKE_BIN"
+cat >"${FAKE_BIN}/codex" <<'CODEX'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  if [[ "${FAKE_CODEX_VERSION_FAIL:-}" == "1" ]]; then
+    exit 42
+  fi
+  echo "codex 0.146.0"
+fi
+CODEX
+chmod +x "${FAKE_BIN}/codex"
+CODEX_HOME_DIR="${WORK_DIR}/codex-home"
+mkdir -p "$CODEX_HOME_DIR"
+
+run_codex_detect() {
+  env -i \
+    PATH="${FAKE_BIN}:${PATH}" \
+    HOME="$HOME_DIR" \
+    CODEX_HOME="$CODEX_HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_DETECT_CLI=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+}
+
+rm -f "${CODEX_HOME_DIR}/auth.json"
+if output="$(run_codex_detect)"; [[ "$output" != "NOT_AUTHED" ]]; then
+  echo "expected codex without CODEX_HOME/auth.json to be NOT_AUTHED; got: $output" >&2
+  exit 1
+fi
+
+cat >"${CODEX_HOME_DIR}/auth.json" <<'JSON'
+{"tokens":{"access_token":"oauth-access-token"}}
+JSON
+if output="$(run_codex_detect)"; [[ "$output" != "OK" ]]; then
+  echo "expected codex OAuth auth.json to be OK; got: $output" >&2
+  exit 1
+fi
+
+cat >"${CODEX_HOME_DIR}/auth.json" <<'JSON'
+{"OPENAI_API_KEY":"api-key-login"}
+JSON
+if output="$(run_codex_detect)"; [[ "$output" != "OK" ]]; then
+  echo "expected codex API-key auth.json to be OK; got: $output" >&2
+  exit 1
+fi
+
+rm -f "${CODEX_HOME_DIR}/auth.json"
+if output="$(
+  env -i \
+    PATH="${FAKE_BIN}:${PATH}" \
+    HOME="$HOME_DIR" \
+    CODEX_HOME="$CODEX_HOME_DIR" \
+    CODEX_API_KEY="api-key-env" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_DETECT_CLI=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"; [[ "$output" != "OK" ]]; then
+  echo "expected codex CODEX_API_KEY environment auth to be OK; got: $output" >&2
+  exit 1
+fi
+
+if output="$(
+  env -i \
+    PATH="${FAKE_BIN}:${PATH}" \
+    HOME="$HOME_DIR" \
+    CODEX_HOME="$CODEX_HOME_DIR" \
+    CODEX_API_KEY="api-key-env" \
+    FAKE_CODEX_VERSION_FAIL=1 \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_DETECT_CLI=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"; [[ "$output" != "BROKEN" ]]; then
+  echo "expected codex version failure to be BROKEN; got: $output" >&2
+  exit 1
+fi
+
+if output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    CODEX_HOME="$CODEX_HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_DETECT_CLI=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"; [[ "$output" != "NOT_INSTALLED" ]]; then
+  echo "expected missing codex binary to be NOT_INSTALLED; got: $output" >&2
+  exit 1
+fi
+
+echo "contributor-agent codex contract tests passed"

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -13,6 +13,7 @@
 //                           the same order as HIVE_HUB
 //   AGENT_BACKEND          — CLI backend name (claude, copilot, gemini, etc.)
 //   AGENT_MODEL            — model override (optional)
+//   AGENT_REASONING_EFFORT — Codex reasoning effort override (optional)
 //   HIVE_AGENT_ROLE        — optional spoke agent role to claim (scanner,
 //                           quality, outreach, etc.; hub-enforced)
 //   HIVE_AGENT_SESSION     — tmux session name for the agent (default: contributor)
@@ -39,6 +40,7 @@ if (rawHubList.length > 1 && rawTokenList.length !== rawHubList.length) {
 }
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
+const REASONING_EFFORT = process.env.AGENT_REASONING_EFFORT || '';
 const AGENT_ROLE = (process.env.HIVE_AGENT_ROLE || '').trim();
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
 const GH_TOKEN_CACHE = process.env.HIVE_GH_TOKEN_CACHE || (fs.existsSync('/var/run/hive-metrics')
@@ -292,7 +294,10 @@ function buildLaunchCommand() {
   if (cachedLaunchCommand) return cachedLaunchCommand;
   const { cmd, perm } = resolveBackend();
   const modelFlag = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? `--model ${MODEL}` : '';
-  cachedLaunchCommand = [cmd, perm, modelFlag].filter(Boolean).join(' ');
+  const reasoningFlag = BACKEND === 'codex' && REASONING_EFFORT
+    ? `-c 'model_reasoning_effort="${REASONING_EFFORT}"'`
+    : '';
+  cachedLaunchCommand = [cmd, perm, modelFlag, reasoningFlag].filter(Boolean).join(' ');
   return cachedLaunchCommand;
 }
 
@@ -354,11 +359,12 @@ function buildHeadlessArgv(prompt) {
   const { cmd, perm } = resolveBackend();
   const permArgs = perm ? perm.split(/\s+/).filter(Boolean) : [];
   const modelArgs = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? ['--model', MODEL] : [];
+  const reasoningArgs = BACKEND === 'codex' && REASONING_EFFORT ? ['-c', `model_reasoning_effort="${REASONING_EFFORT}"`] : [];
   // spec.flag is a single token for most backends, or an array of leading
   // tokens for backends needing a sub-command plus a flag (goose). Normalize
   // to an array so both shapes spread the same way ahead of the prompt.
   const oneShotArgs = Array.isArray(spec.flag) ? spec.flag : [spec.flag];
-  const args = [...permArgs, ...modelArgs, ...oneShotArgs, prompt];
+  const args = [...permArgs, ...modelArgs, ...reasoningArgs, ...oneShotArgs, prompt];
   return { bin: cmd, args };
 }
 
@@ -1179,6 +1185,7 @@ function handleMessage(data, hub) {
         registration_token: hub.regToken,
         cli_backend: BACKEND,
         model: MODEL,
+        reasoning_effort: REASONING_EFFORT || undefined,
         role: AGENT_ROLE,
         // #2547 declare half + #2567: additive, optional self-report of runtime
         // posture and protocol version. An older hub ignores these unknown fields.

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -25,7 +25,7 @@ const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
 // bash and no WebSocket are ever touched.
 // ---------------------------------------------------------------------------
 
-function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, env = {} } = {}) {
+function loadRelay({ backend = 'copilot', model = '', reasoningEffort = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, env = {} } = {}) {
   const commands = [];
   const sent = [];
   // Records every execFile (headless one-shot) invocation: { bin, args, opts }.
@@ -98,6 +98,7 @@ function loadRelay({ backend = 'copilot', model = '', cliStates = ['ready'], pro
   process.env.HIVE_REGISTRATION_TOKEN = 'test-token';
   process.env.AGENT_BACKEND = backend;
   process.env.AGENT_MODEL = model;
+  process.env.AGENT_REASONING_EFFORT = reasoningEffort;
   process.env.GOOSE_MODEL = '';
   process.env.HIVE_AGENT_SESSION = 'contributor';
   process.env.CONTRIBUTOR_MODE = mode;
@@ -1051,6 +1052,60 @@ test('goose headless passes the prompt as -t\'s value and skips --model', () => 
       ['run', '--no-session', '-t', "it's a prompt with quotes"],
       'the prompt is -t\'s value, passed verbatim as its own argv element');
   } finally { teardown(relay); }
+});
+
+test('codex headless transports model and reasoning effort without affecting other backends', () => {
+  const relay = loadRelay({
+    backend: 'codex',
+    mode: 'headless',
+    model: 'gpt-5.6-luna',
+    reasoningEffort: 'low',
+  });
+  try {
+    const a = relay.buildHeadlessArgv('review this');
+    assert.ok(a.args.includes('--model'), `codex must receive --model: ${JSON.stringify(a.args)}`);
+    assert.ok(a.args.includes('gpt-5.6-luna'), `codex must receive the configured model: ${JSON.stringify(a.args)}`);
+    assert.ok(a.args.includes('-c'), `codex must receive a config override: ${JSON.stringify(a.args)}`);
+    assert.ok(a.args.includes('model_reasoning_effort="low"'), `codex must receive the configured effort: ${JSON.stringify(a.args)}`);
+    assert.deepStrictEqual(a.args.slice(-2), ['exec', 'review this'],
+      'codex one-shot mode and prompt must remain at the tail');
+  } finally { teardown(relay); }
+
+  const goose = loadRelay({
+    backend: 'goose',
+    mode: 'headless',
+    model: 'some-model',
+    reasoningEffort: 'low',
+  });
+  try {
+    const a = goose.buildHeadlessArgv('review this');
+    assert.ok(!a.args.includes('--model'), `goose must still skip --model: ${JSON.stringify(a.args)}`);
+    assert.ok(!a.args.includes('model_reasoning_effort="low"'), `goose must not inherit codex effort: ${JSON.stringify(a.args)}`);
+  } finally { teardown(goose); }
+});
+
+test('codex interactive launch transports reasoning effort only for codex', () => {
+  const codex = loadRelay({
+    backend: 'codex',
+    model: 'gpt-5.6-luna',
+    reasoningEffort: 'low',
+  });
+  try {
+    const cmd = codex.buildLaunchCommand();
+    assert.match(cmd, /--model gpt-5\.6-luna/);
+    assert.match(cmd, /-c 'model_reasoning_effort="low"'/);
+  } finally { teardown(codex); }
+
+  const copilot = loadRelay({
+    backend: 'copilot',
+    model: 'gpt-5.6-luna',
+    reasoningEffort: 'low',
+  });
+  try {
+    const cmd = copilot.buildLaunchCommand();
+    assert.match(cmd, /--model gpt-5\.6-luna/);
+    assert.doesNotMatch(cmd, /model_reasoning_effort/);
+  } finally { teardown(copilot); }
 });
 
 test('goose runs headless end-to-end and reports completion on exit 0', () => {

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -74,7 +74,13 @@ backend_perm_flag() {
     # block of bin/contributor-agent.sh.
     bob)     echo "--accept-license --auth-method api-key --approval-mode yolo --trust" ;;
 
-    codex)   echo "--dangerously-bypass-approvals-and-sandbox" ;;
+    codex)
+      if is_truthy "${HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}"; then
+        echo "--dangerously-bypass-approvals-and-sandbox"
+      else
+        echo "--ask-for-approval ${HIVE_CODEX_APPROVAL_POLICY:-on-request} --sandbox ${HIVE_CODEX_SANDBOX_MODE:-workspace-write}"
+      fi
+      ;;
     agy)     echo "--dangerously-skip-permissions" ;;
     goose)   echo "" ;;
     pi)      echo "" ;;
@@ -82,6 +88,13 @@ backend_perm_flag() {
     # Same flags as claude — litellm launches the claude binary
     litellm) echo "--dangerously-skip-permissions --permission-mode bypassPermissions" ;;
     *)       echo "" ;;
+  esac
+}
+
+is_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
   esac
 }
 

--- a/config/contributor.env.example
+++ b/config/contributor.env.example
@@ -11,6 +11,19 @@ HIVE_HUB=wss://hive.kubestellar.io:3001/contribute
 # Preferred CLI backend (claude, copilot, gemini, goose, bob)
 AGENT_BACKEND=claude
 
+# Optional model/effort overrides. AGENT_REASONING_EFFORT is currently
+# transported only to Codex as a model_reasoning_effort config override.
+# AGENT_MODEL=gpt-5.6-luna
+# AGENT_REASONING_EFFORT=low
+
+# Codex approval/sandbox posture. Defaults are explicit and non-bypass:
+#   --ask-for-approval on-request --sandbox workspace-write
+# Uncomment the dangerous flag only when you intentionally want the old
+# full bypass of approvals and sandboxing.
+# HIVE_CODEX_APPROVAL_POLICY=on-request
+# HIVE_CODEX_SANDBOX_MODE=workspace-write
+# HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1
+
 # Task-delivery mode (kubestellar/hive#2538). Default: interactive.
 #   interactive — types tasks into an attached tmux pane (needs a TTY; the
 #                 classic `just contribute-run` container).

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -12,7 +12,7 @@ Hive validates backend names in `v2/pkg/config` and launches CLIs in `v2/pkg/age
 | `goose` | `goose` | Install Block Goose and configure provider/model (`GOOSE_PROVIDER`, `GOOSE_MODEL`, or `goose configure`). | Hive launches `goose run -s` and appends `--model` when set. |
 | `pi` | `goose` in the Go manager; `pi` in contributor scripts | In the server-side manager, `backendBinary("pi")` maps to `goose`. Configure Goose for pod agents. The contributor relay image/scripts use a separate `pi` binary. | Server-side pod agents use Goose for `backend: pi`; contributor mode uses the Pi CLI. |
 | `bob` | `bob` | Provide `HIVE_BOB_API_KEY` or `/secrets/bob_api_key` for pods; contributor mode requires `BOBSHELL_API_KEY`. | Hive uses API-key auth headlessly and accepts the Bob license at launch. |
-| `codex` | contributor scripts launch `codex`; the server-side Go manager does not launch it | Install `@openai/codex` and provide `OPENAI_API_KEY` for contributor mode. Contributor mode sets a per-agent `CODEX_HOME`. | Not supported as a server-side agent backend in this branch: config accepts the name, but `backendBinary("codex")` returns `unknown backend: codex`, so a pod agent will not start. Use contributor mode for Codex. |
+| `codex` | `codex` | Install `@openai/codex` and run `codex login --device-auth` for subscription/OAuth auth. The CLI stores credentials in `CODEX_HOME/auth.json` (default `${HOME}/.codex/auth.json`); API-key mode can use `CODEX_API_KEY`/`OPENAI_API_KEY` or a populated auth file, but it is not required for subscription users. | Hive gives each agent its own `CODEX_HOME` and probes `auth.json` for OAuth tokens/API-key state (or API-key env presence). Contributor mode defaults to `--ask-for-approval on-request --sandbox workspace-write`; override with `HIVE_CODEX_APPROVAL_POLICY`/`HIVE_CODEX_SANDBOX_MODE`, or set `HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` only when you intentionally want the old bypass posture. `AGENT_REASONING_EFFORT` is passed to Codex as `-c model_reasoning_effort="..."`. |
 | `aider` | contributor scripts launch `aider`; the server-side Go manager does not launch it | Install Aider and configure its provider/API key normally for contributor mode. | Not supported as a server-side agent backend in this branch: config accepts the name, but `backendBinary("aider")` returns `unknown backend: aider`, so a pod agent will not start. Use contributor mode for Aider. |
 
 ## IBM Bob headless setup
@@ -44,7 +44,7 @@ AGENT_BACKEND=goose GOOSE_PROVIDER=anthropic GOOSE_MODEL=claude-sonnet-4-6 just 
 AGENT_BACKEND=litellm HIVE_LITELLM_ENDPOINT=https://litellm.example.com just contribute-hive
 ```
 
-`AGENT_BACKEND` selects the CLI, `AGENT_MODEL` optionally pins the model, and `CONTRIBUTOR_MODE` defaults to `interactive` (tmux with a TTY). `CONTRIBUTOR_MODE=headless` is reserved for one-shot/no-TTY task delivery.
+`AGENT_BACKEND` selects the CLI, `AGENT_MODEL` optionally pins the model, and `CONTRIBUTOR_MODE` defaults to `interactive` (tmux with a TTY). For Codex, `AGENT_REASONING_EFFORT` optionally pins the reasoning effort. `CONTRIBUTOR_MODE=headless` is reserved for one-shot/no-TTY task delivery.
 
 `just contribute-check <backend>` runs a read-only preflight before registration. It checks that the chosen CLI exists and that obvious auth prerequisites are present.
 

--- a/v2/compose-contributor.yaml
+++ b/v2/compose-contributor.yaml
@@ -17,6 +17,7 @@ services:
       - HIVE_HUB=${HIVE_HUB:-wss://hive.kubestellar.io:3001/contribute}
       - AGENT_BACKEND=${AGENT_BACKEND:-claude}
       - AGENT_MODEL=${AGENT_MODEL:-}
+      - AGENT_REASONING_EFFORT=${AGENT_REASONING_EFFORT:-}
       # Task-delivery mode (kubestellar/hive#2538): interactive (default, tmux)
       # or headless (one-shot CLI, no TTY). This compose file keeps stdin/tty on
       # for the default interactive path; a headless deployment (a future K8s

--- a/v2/pkg/agent/authprobe.go
+++ b/v2/pkg/agent/authprobe.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kubestellar/hive/v2/pkg/claude"
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -52,6 +54,7 @@ import (
 var interactiveAuthBackends = map[string]bool{
 	"claude":  true,
 	"copilot": true,
+	"codex":   true,
 	"gemini":  true,
 }
 
@@ -125,6 +128,54 @@ func agentCopilotConfigPaths(agentName string, uid int, backend string) []string
 	return paths
 }
 
+// agentCodexAuthPaths returns the auth.json locations to try for one Codex
+// agent: the per-agent CODEX_HOME first, then the shared login location.
+func agentCodexAuthPaths(agentName string, uid int, backend string) []string {
+	paths := []string{}
+	if uid > 0 {
+		paths = append(paths, filepath.Join(codexHomePath(agentName), "auth.json"))
+	} else if home := AgentHome(agentName, uid, backend); home != "" {
+		paths = append(paths, filepath.Join(home, ".codex", "auth.json"))
+	}
+	if !containsPath(paths, codexSharedAuthFile) {
+		paths = append(paths, codexSharedAuthFile)
+	}
+	return paths
+}
+
+func codexAuthFileHasCredentials(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var data map[string]any
+	if err := json.Unmarshal(b, &data); err != nil {
+		return false
+	}
+	nonEmpty := func(v any) bool {
+		s, ok := v.(string)
+		return ok && strings.TrimSpace(s) != ""
+	}
+	if tokens, ok := data["tokens"].(map[string]any); ok {
+		for _, key := range []string{"access_token", "refresh_token", "id_token"} {
+			if nonEmpty(tokens[key]) {
+				return true
+			}
+		}
+	}
+	for _, key := range []string{"OPENAI_API_KEY", "api_key", "openai_api_key"} {
+		if nonEmpty(data[key]) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexEnvHasCredentials() bool {
+	return strings.TrimSpace(os.Getenv("CODEX_API_KEY")) != "" ||
+		strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != ""
+}
+
 // AgentAuthState reports the auth state for ONE agent, applying the precedence
 // rule documented at the top of this file. `known == false` means "no opinion"
 // and the dashboard must not render a login badge.
@@ -184,6 +235,16 @@ func (m *Manager) AgentAuthState(agentName string, uid int, backend string, runn
 		}
 		for _, p := range agentCopilotConfigPaths(agentName, uid, backend) {
 			if copilotCredentialFileHasTokens(p) {
+				return true, true
+			}
+		}
+		return false, true
+	case "codex":
+		if codexEnvHasCredentials() {
+			return true, true
+		}
+		for _, p := range agentCodexAuthPaths(agentName, uid, backend) {
+			if codexAuthFileHasCredentials(p) {
 				return true, true
 			}
 		}

--- a/v2/pkg/agent/authprobe_test.go
+++ b/v2/pkg/agent/authprobe_test.go
@@ -36,6 +36,16 @@ func writeClaudeCreds(t *testing.T, path string) {
 	}
 }
 
+func writeCodexAuth(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir codex auth dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write codex auth: %v", err)
+	}
+}
+
 // emptySharedPaths redirects the shared/legacy credential locations to a
 // nonexistent temp dir — the exact condition observed on a per-agent-UID spoke,
 // where /data/home/.claude/.credentials.json is absent and
@@ -49,6 +59,25 @@ func emptySharedPaths(t *testing.T) {
 	t.Cleanup(func() {
 		sharedClaudeCredentialPath = origClaude
 		sharedCopilotConfigPath = origCopilot
+	})
+}
+
+func emptyCodexSharedPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	orig := codexSharedAuthFile
+	codexSharedAuthFile = filepath.Join(dir, "absent-codex-auth.json")
+	t.Cleanup(func() {
+		codexSharedAuthFile = orig
+	})
+}
+
+func overrideCodexHomePrefix(t *testing.T, prefix string) {
+	t.Helper()
+	orig := codexHomePrefix
+	codexHomePrefix = prefix
+	t.Cleanup(func() {
+		codexHomePrefix = orig
 	})
 }
 
@@ -196,6 +225,44 @@ func TestAgentAuthState_CopilotCredentials(t *testing.T) {
 	emptySharedPaths(t)
 	if avail, known := m.AgentAuthState("planner", 0, "copilot", false, false); !known || avail {
 		t.Fatalf("copilot without tokens: got (avail=%v, known=%v), want known unauthenticated", avail, known)
+	}
+}
+
+func TestAgentAuthState_CodexCredentials(t *testing.T) {
+	emptyCodexSharedPath(t)
+	t.Setenv("HOME", t.TempDir())
+	m := &Manager{}
+
+	if !BackendRequiresInteractiveAuth("codex") {
+		t.Fatal("codex must be classified as an interactive OAuth/device-login backend")
+	}
+	if avail, known := m.AgentAuthState("coder", 0, "codex", false, false); !known || avail {
+		t.Fatalf("codex without auth.json: got (avail=%v, known=%v), want known unauthenticated", avail, known)
+	}
+
+	t.Setenv("CODEX_API_KEY", "env-api-key")
+	if avail, known := m.AgentAuthState("coder", 0, "codex", false, false); !known || !avail {
+		t.Fatalf("codex CODEX_API_KEY: got (avail=%v, known=%v), want authenticated", avail, known)
+	}
+	t.Setenv("CODEX_API_KEY", "")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeCodexAuth(t, filepath.Join(home, ".codex", "auth.json"), `{"tokens":{"access_token":"oauth-token"}}`)
+	if avail, known := m.AgentAuthState("coder", 0, "codex", false, false); !known || !avail {
+		t.Fatalf("codex OAuth auth.json: got (avail=%v, known=%v), want authenticated", avail, known)
+	}
+
+	emptyCodexSharedPath(t)
+	overrideCodexHomePrefix(t, filepath.Join(t.TempDir(), ".codex-"))
+	writeCodexAuth(t, filepath.Join(codexHomePath("coder"), "auth.json"), `{"OPENAI_API_KEY":"api-key-login"}`)
+	if avail, known := m.AgentAuthState("coder", 2007, "codex", false, false); !known || !avail {
+		t.Fatalf("codex per-agent CODEX_HOME auth.json: got (avail=%v, known=%v), want authenticated", avail, known)
+	}
+
+	paths := agentCodexAuthPaths("coder", 2007, "codex")
+	if len(paths) < 2 || paths[0] != filepath.Join(codexHomePath("coder"), "auth.json") {
+		t.Fatalf("agentCodexAuthPaths should prefer CODEX_HOME auth.json; got %v", paths)
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4453,7 +4453,7 @@ func bobLaunchCmd(binary string) string {
 // its own dir so Codex's owner-gated app-server sees a directory the agent UID
 // actually owns (a shared, merely group-writable dir is not sufficient for
 // Codex, unlike claude/copilot). Lives on the persistent /data volume.
-const codexHomePrefix = "/data/home/.codex-"
+var codexHomePrefix = "/data/home/.codex-"
 
 // codexHomePath returns the per-agent CODEX_HOME directory.
 func codexHomePath(agentName string) string {
@@ -4469,7 +4469,7 @@ func codexHomePath(agentName string) string {
 // prompt for sign-in again. setupCodexHome bridges this by symlinking each
 // agent's auth.json to this shared file, so ONE login propagates to every agent
 // and token refreshes are shared.
-const codexSharedAuthFile = "/data/home/.codex/auth.json"
+var codexSharedAuthFile = "/data/home/.codex/auth.json"
 
 // setupCodexHome pre-creates the agent's CODEX_HOME directory AS the agent, so
 // it is owned by the agent UID. Codex 0.144.1 refuses to create CODEX_HOME

--- a/v2/pkg/agent/watsonx_backend_test.go
+++ b/v2/pkg/agent/watsonx_backend_test.go
@@ -73,7 +73,7 @@ func TestWatsonxNeverRequiresInteractiveAuth(t *testing.T) {
 		}
 	}
 	// The interactive CLIs must still require it, or the badge dies everywhere.
-	for _, b := range []string{"claude", "copilot", "gemini"} {
+	for _, b := range []string{"claude", "copilot", "codex", "gemini"} {
 		if !BackendRequiresInteractiveAuth(b) {
 			t.Errorf("BackendRequiresInteractiveAuth(%q) = false, want true", b)
 		}


### PR DESCRIPTION
Closes #3471

## Why

The contributor Codex path advertised `codex` but only checked `codex --version`, then continued after `NOT_AUTHED`. That made downstream callers unable to distinguish missing/broken CLI, unauthenticated Codex, and a ready contributor. The previous backend config also always emitted `--dangerously-bypass-approvals-and-sandbox`, which silently selected the most permissive Codex posture for every invocation.

## What changed

- Codex readiness now requires a runnable binary plus auth evidence: `CODEX_API_KEY`/`OPENAI_API_KEY`, or credentials in `CODEX_HOME/auth.json` / the per-agent shared auth path (`bin/contributor-agent.sh:212`, `bin/contributor-agent.sh:249`, `v2/pkg/agent/authprobe.go:131`, `v2/pkg/agent/authprobe.go:242`). Missing binary remains `NOT_INSTALLED`, broken binary is `BROKEN`, missing auth is `NOT_AUTHED` and exits for Codex.
- Codex approval/sandbox posture is explicit: default `--ask-for-approval on-request --sandbox workspace-write`; the old full bypass is only emitted when `HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` (`config/backends.conf:77`). This is behavior-visible: contributors no longer get unconditional no-sandbox/no-approval Codex execution by default.
- Codex reasoning effort is transported as Codex config (`-c model_reasoning_effort="..."`) alongside existing model transport in interactive and headless paths (`bin/contributor-agent.sh:483`, `bin/contributor-relay.sh:297`, `bin/contributor-relay.sh:362`, `bin/agent-launch.sh:98`).
- Docs/examples now describe OAuth/device auth, API-key mode, Codex posture env vars, and `AGENT_REASONING_EFFORT` (`docs/backend-setup.md:15`, `config/contributor.env.example`).

## Sabotage verification

I deliberately broke each new guard and confirmed the targeted tests failed, then restored the production code:

- Made `codex_is_authenticated` always succeed: `bin/contributor-agent.test.sh` failed on unauthenticated Codex (`got: OK`, expected `NOT_AUTHED`).
- Removed the Codex version/run check: `bin/contributor-agent.test.sh` failed on broken Codex (`got: OK`, expected `BROKEN`).
- Reverted the safe Codex default to the dangerous bypass: `bin/contributor-agent.test.sh` failed the default-posture assertion.
- Removed `CODEX_API_KEY` handling: `bin/contributor-agent.test.sh` failed the env API-key auth assertion.
- Removed Codex reasoning-effort transport in headless and interactive relay paths: the corresponding `bin/contributor-relay.test.js` tests failed.
- Removed Codex from the Go interactive-auth map: `go test ./pkg/agent -run TestAgentAuthState_CodexCredentials` failed.

## Verification

- `bash -n bin/contributor-agent.sh bin/agent-launch.sh`
- `bash bin/contributor-agent.test.sh`
- `node bin/contributor-relay.test.js` (49/49 passed)
- `cd v2 && go test ./pkg/agent -run 'TestAgentAuthState|TestWatsonxNeverRequiresInteractiveAuth'`
- `cd v2 && go build ./...`
- Scanned validation output with `grep -E -e '--- FAIL' -e '^FAIL'` (no matches)
- `gofmt -l .` was run; it still lists pre-existing unformatted files outside this change. The touched Go files are gofmt-clean.

## Judgment calls

I treated `CODEX_HOME/auth.json` as the primary subscription/OAuth contract, while preserving API-key mode as authenticated when `CODEX_API_KEY`/`OPENAI_API_KEY` is present. For Codex 0.146.0, reasoning effort is a config key rather than a first-class CLI flag, so the transport uses `-c model_reasoning_effort="..."` instead of inventing an unsupported flag.
