### PR TITLE
🔒 harden reusable workflow callers

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   ai-fix:
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@50f6dd45dad477e9815b557b40649c68942f8159
+    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -7,7 +7,7 @@ on:
         description: PR number to process
         required: true
         type: string
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   copilot-dco:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,6 +10,4 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,7 +1,7 @@
 name: Greetings
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened]
   issues:
     types: [opened, reopened]
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   greet:
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11


### PR DESCRIPTION
Closes #2967

This removes the remaining mutable/reusable workflow exposure in hive's callers. The threat model is a compromised or retargeted `kubestellar/infra` reusable workflow running through hive with broad repository token or inherited repository secrets, especially from `pull_request_target` events.

Changes:

- Pins every `kubestellar/infra/.github/workflows/reusable-*.yml` caller in this repo to `1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3`, verified as the current `kubestellar/infra` `main` head.
- Moves `greetings.yml` from `pull_request_target` to `pull_request`; it only posts first-time contributor comments and does not need base-repository PR context.
- Moves `copilot-automation.yml` from `pull_request_target` to `pull_request`; the reusable workflow already filters to Copilot bot PRs and does not checkout fork code.
- Removes the unnecessary token secret passed to `feedback.yml`; the pinned reusable workflow does not declare a `workflow_call` secret.
- Leaves only explicit `token: ${{ secrets.GITHUB_TOKEN }}` forwarding where the pinned reusable workflow declares and uses a `token` secret (`ai-fix.yml`, `copilot-automation.yml`). No `secrets: inherit` remains.

Verification commands run before opening this PR:

```bash
unset GITHUB_TOKEN && gh api repos/kubestellar/infra/git/ref/heads/main --jq '.object.sha'
unset GITHUB_TOKEN && gh api repos/kubestellar/infra/git/commits/1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 --jq .sha
unset GITHUB_TOKEN && gh api repos/kubestellar/infra/contents/.github/workflows/reusable-feedback.yml --jq .content | base64 -d | grep -nE 'workflow_call|secrets|GITHUB_TOKEN|token'
unset GITHUB_TOKEN && gh api repos/kubestellar/infra/contents/.github/workflows/reusable-ai-fix.yml --jq .content | base64 -d | grep -nE 'secrets|github-token|GITHUB_TOKEN|pull_request_target'
unset GITHUB_TOKEN && gh api repos/kubestellar/infra/contents/.github/workflows/reusable-copilot-automation.yml --jq .content | base64 -d | grep -nE 'secrets|github-token|GITHUB_TOKEN|pull_request_target|pull_request'
git diff --check
ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }'
rg 'secrets: inherit|uses: kubestellar/infra/.+@main' .github/workflows
```

PR checks will exercise the workflows triggered by pull request events, including the changed greetings and copilot automation callers. Scheduled-only or event-specific workflows (`scorecard.yml`, `stale.yml`, issue-comment helpers, issue-labeled helpers, merged-PR feedback) cannot be fully exercised by this PR and are not claimed as PR-verified.
