### PR TITLE
🐛 Bound public dossier caches

### DIFF
--- a/v2/pkg/dashboard/dossier.go
+++ b/v2/pkg/dashboard/dossier.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -196,6 +198,27 @@ const (
 	heraldryMaxBadges    = 24
 )
 
+const (
+	dossierCacheMaxEntriesEnv = "HIVE_DOSSIER_CACHE_MAX_ENTRIES"
+	// dossierCacheMaxEntriesDefault caps each public dossier cache. 512 entries
+	// keeps normal contributor reuse hot while bounding username-spray memory.
+	dossierCacheMaxEntriesDefault = 512
+)
+
+var dossierCacheMaxEntries = configuredDossierCacheMaxEntries()
+
+func configuredDossierCacheMaxEntries() int {
+	raw := strings.TrimSpace(os.Getenv(dossierCacheMaxEntriesEnv))
+	if raw == "" {
+		return dossierCacheMaxEntriesDefault
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return dossierCacheMaxEntriesDefault
+	}
+	return n
+}
+
 // heraldryBaseURL is a var so tests can point the fetch at a local stub.
 var heraldryBaseURL = "https://www.credly.com"
 
@@ -326,6 +349,52 @@ func fetchCredlyBadges(credlyName string) ([]HeraldryBadge, error) {
 	return out, nil
 }
 
+func effectiveDossierCacheMaxEntries() int {
+	if dossierCacheMaxEntries <= 0 {
+		return dossierCacheMaxEntriesDefault
+	}
+	return dossierCacheMaxEntries
+}
+
+func heraldryEntryExpired(e heraldryCacheEntry, now time.Time) bool {
+	ttl := heraldryCacheTTL
+	if !e.linked {
+		ttl = heraldryNegativeTTL
+	}
+	return now.Sub(e.fetchedAt) >= ttl
+}
+
+func pruneHeraldryCacheLocked(now time.Time) {
+	for k, e := range heraldryCache {
+		if heraldryEntryExpired(e, now) {
+			delete(heraldryCache, k)
+		}
+	}
+}
+
+func enforceHeraldryCacheBoundLocked() {
+	maxEntries := effectiveDossierCacheMaxEntries()
+	for len(heraldryCache) > maxEntries {
+		var oldestKey string
+		var oldestFetchedAt time.Time
+		for k, e := range heraldryCache {
+			if oldestKey == "" || e.fetchedAt.Before(oldestFetchedAt) {
+				oldestKey = k
+				oldestFetchedAt = e.fetchedAt
+			}
+		}
+		delete(heraldryCache, oldestKey)
+	}
+}
+
+func storeHeraldryCache(credlyName string, entry heraldryCacheEntry) {
+	heraldryCacheMu.Lock()
+	defer heraldryCacheMu.Unlock()
+	heraldryCache[credlyName] = entry
+	pruneHeraldryCacheLocked(time.Now())
+	enforceHeraldryCacheBoundLocked()
+}
+
 // heraldryCached returns a live cache entry for credlyName, if one exists and
 // has not aged out.
 func heraldryCached(credlyName string) ([]HeraldryBadge, bool, bool) {
@@ -335,11 +404,8 @@ func heraldryCached(credlyName string) ([]HeraldryBadge, bool, bool) {
 	if !ok {
 		return nil, false, false
 	}
-	ttl := heraldryCacheTTL
-	if !e.linked {
-		ttl = heraldryNegativeTTL
-	}
-	if time.Since(e.fetchedAt) >= ttl {
+	if heraldryEntryExpired(e, time.Now()) {
+		delete(heraldryCache, credlyName)
 		return nil, false, false
 	}
 	return e.badges, e.linked, true
@@ -360,9 +426,7 @@ func heraldryFor(credlyName string) ([]HeraldryBadge, bool) {
 		if badges == nil {
 			badges = []HeraldryBadge{}
 		}
-		heraldryCacheMu.Lock()
-		heraldryCache[credlyName] = heraldryCacheEntry{badges: badges, linked: err == nil, fetchedAt: time.Now()}
-		heraldryCacheMu.Unlock()
+		storeHeraldryCache(credlyName, heraldryCacheEntry{badges: badges, linked: err == nil, fetchedAt: time.Now()})
 	})
 
 	if badges, linked, ok := heraldryCached(credlyName); ok {
@@ -442,6 +506,46 @@ func fetchGitHubPublicUser(username string) (serviceYears, followers int, err er
 	return years, payload.Followers, nil
 }
 
+func githubUserEntryExpired(e githubUserCacheEntry, now time.Time) bool {
+	ttl := githubUserCacheTTL
+	if !e.ok {
+		// A transient failure must not hide service-years/renown for hours.
+		ttl = heraldryNegativeTTL
+	}
+	return now.Sub(e.fetchedAt) >= ttl
+}
+
+func pruneGitHubUserCacheLocked(now time.Time) {
+	for k, e := range githubUserCache {
+		if githubUserEntryExpired(e, now) {
+			delete(githubUserCache, k)
+		}
+	}
+}
+
+func enforceGitHubUserCacheBoundLocked() {
+	maxEntries := effectiveDossierCacheMaxEntries()
+	for len(githubUserCache) > maxEntries {
+		var oldestKey string
+		var oldestFetchedAt time.Time
+		for k, e := range githubUserCache {
+			if oldestKey == "" || e.fetchedAt.Before(oldestFetchedAt) {
+				oldestKey = k
+				oldestFetchedAt = e.fetchedAt
+			}
+		}
+		delete(githubUserCache, oldestKey)
+	}
+}
+
+func storeGitHubUserCache(username string, entry githubUserCacheEntry) {
+	githubUserCacheMu.Lock()
+	defer githubUserCacheMu.Unlock()
+	githubUserCache[username] = entry
+	pruneGitHubUserCacheLocked(time.Now())
+	enforceGitHubUserCacheBoundLocked()
+}
+
 // githubUserCached returns a live cache entry for username, if one exists and
 // has not aged out.
 func githubUserCached(username string) (int, int, bool, bool) {
@@ -451,12 +555,8 @@ func githubUserCached(username string) (int, int, bool, bool) {
 	if !ok {
 		return 0, 0, false, false
 	}
-	ttl := githubUserCacheTTL
-	if !e.ok {
-		// A transient failure must not hide service-years/renown for hours.
-		ttl = heraldryNegativeTTL
-	}
-	if time.Since(e.fetchedAt) >= ttl {
+	if githubUserEntryExpired(e, time.Now()) {
+		delete(githubUserCache, username)
 		return 0, 0, false, false
 	}
 	return e.serviceYears, e.followers, e.ok, true
@@ -476,11 +576,9 @@ func githubPublicFor(username string) (int, int, bool) {
 			return
 		}
 		years, followers, err := fetchGitHubPublicUser(username)
-		githubUserCacheMu.Lock()
-		githubUserCache[username] = githubUserCacheEntry{
+		storeGitHubUserCache(username, githubUserCacheEntry{
 			serviceYears: years, followers: followers, ok: err == nil, fetchedAt: time.Now(),
-		}
-		githubUserCacheMu.Unlock()
+		})
 	})
 
 	years, followers, ok, _ := githubUserCached(username)

--- a/v2/pkg/dashboard/dossier_cache_test.go
+++ b/v2/pkg/dashboard/dossier_cache_test.go
@@ -1,0 +1,162 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func resetDossierPublicCaches() {
+	heraldryCacheMu.Lock()
+	heraldryCache = map[string]heraldryCacheEntry{}
+	heraldryCacheMu.Unlock()
+
+	githubUserCacheMu.Lock()
+	githubUserCache = map[string]githubUserCacheEntry{}
+	githubUserCacheMu.Unlock()
+
+	heraldryFlight = newFetchFlight()
+	githubUserFlight = newFetchFlight()
+}
+
+func useDossierCacheMax(t *testing.T, maxEntries int) {
+	t.Helper()
+	old := dossierCacheMaxEntries
+	dossierCacheMaxEntries = maxEntries
+	t.Cleanup(func() { dossierCacheMaxEntries = old })
+}
+
+func TestDossierPublicCachesBoundEvictExpiredAndPreserveFresh(t *testing.T) {
+	useDossierCacheMax(t, 8)
+	resetDossierPublicCaches()
+	t.Cleanup(resetDossierPublicCaches)
+
+	now := time.Now()
+	olderFresh := now.Add(-time.Hour)
+
+	heraldryCacheMu.Lock()
+	heraldryCache["expired-positive"] = heraldryCacheEntry{linked: true, fetchedAt: now.Add(-heraldryCacheTTL - time.Second)}
+	heraldryCache["expired-negative"] = heraldryCacheEntry{linked: false, fetchedAt: now.Add(-heraldryNegativeTTL - time.Second)}
+	heraldryCacheMu.Unlock()
+	storeHeraldryCache("keeper", heraldryCacheEntry{
+		badges: []HeraldryBadge{{Name: "Keeper"}},
+		linked: true, fetchedAt: now,
+	})
+	for i := 0; i < effectiveDossierCacheMaxEntries()*3; i++ {
+		storeHeraldryCache(fmt.Sprintf("heraldry-%02d", i), heraldryCacheEntry{
+			badges: []HeraldryBadge{{Name: fmt.Sprintf("Badge %02d", i)}},
+			linked: true, fetchedAt: olderFresh.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	heraldryCacheMu.Lock()
+	heraldryLen := len(heraldryCache)
+	heraldryMax := effectiveDossierCacheMaxEntries()
+	_, heraldryExpiredPositive := heraldryCache["expired-positive"]
+	_, heraldryExpiredNegative := heraldryCache["expired-negative"]
+	heraldryCacheMu.Unlock()
+	if heraldryLen > heraldryMax {
+		t.Fatalf("heraldry cache has %d entries, want <= %d", heraldryLen, heraldryMax)
+	}
+	if heraldryExpiredPositive {
+		t.Fatal("expired positive heraldry entry was not removed")
+	}
+	if heraldryExpiredNegative {
+		t.Fatal("expired negative heraldry entry was not removed")
+	}
+	if badges, linked, ok := heraldryCached("keeper"); !ok || !linked || len(badges) != 1 || badges[0].Name != "Keeper" {
+		t.Fatalf("fresh heraldry keeper was not served after eviction pressure: badges=%+v linked=%v ok=%v", badges, linked, ok)
+	}
+
+	githubUserCacheMu.Lock()
+	githubUserCache["expired-positive"] = githubUserCacheEntry{ok: true, fetchedAt: now.Add(-githubUserCacheTTL - time.Second)}
+	githubUserCache["expired-negative"] = githubUserCacheEntry{ok: false, fetchedAt: now.Add(-heraldryNegativeTTL - time.Second)}
+	githubUserCacheMu.Unlock()
+	storeGitHubUserCache("keeper", githubUserCacheEntry{serviceYears: 7, followers: 42, ok: true, fetchedAt: now})
+	for i := 0; i < effectiveDossierCacheMaxEntries()*3; i++ {
+		storeGitHubUserCache(fmt.Sprintf("github-%02d", i), githubUserCacheEntry{
+			serviceYears: i, followers: i + 1, ok: true,
+			fetchedAt: olderFresh.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	githubUserCacheMu.Lock()
+	githubLen := len(githubUserCache)
+	githubMax := effectiveDossierCacheMaxEntries()
+	_, githubExpiredPositive := githubUserCache["expired-positive"]
+	_, githubExpiredNegative := githubUserCache["expired-negative"]
+	githubUserCacheMu.Unlock()
+	if githubLen > githubMax {
+		t.Fatalf("github user cache has %d entries, want <= %d", githubLen, githubMax)
+	}
+	if githubExpiredPositive {
+		t.Fatal("expired positive github entry was not removed")
+	}
+	if githubExpiredNegative {
+		t.Fatal("expired negative github entry was not removed")
+	}
+	if years, followers, ok, fresh := githubUserCached("keeper"); !fresh || !ok || years != 7 || followers != 42 {
+		t.Fatalf("fresh github keeper was not served after eviction pressure: years=%d followers=%d ok=%v fresh=%v", years, followers, ok, fresh)
+	}
+}
+
+func TestDossierPublicCachesConcurrentAccess(t *testing.T) {
+	useDossierCacheMax(t, 16)
+	resetDossierPublicCaches()
+	t.Cleanup(resetDossierPublicCaches)
+
+	heraldryStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"abc","issued_at":"2021-01-01T00:00:00Z","image_url":"https://example.invalid/badge.png","public":true,"badge_template":{"name":"Concurrent Badge"},"issuer":{"summary":"issuer"}}]}`))
+	}))
+	defer heraldryStub.Close()
+
+	githubStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created_at":"2018-01-01T00:00:00Z","followers":9}`))
+	}))
+	defer githubStub.Close()
+
+	origHeraldryBase := heraldryBaseURL
+	origGitHubBase := githubUserAPIBase
+	heraldryBaseURL = heraldryStub.URL
+	githubUserAPIBase = githubStub.URL
+	t.Cleanup(func() {
+		heraldryBaseURL = origHeraldryBase
+		githubUserAPIBase = origGitHubBase
+	})
+
+	const workers = 64
+	var wg sync.WaitGroup
+	errs := make(chan string, workers*2)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if badges, linked := heraldryFor(fmt.Sprintf("credly-%02d", i)); !linked || len(badges) != 1 {
+				errs <- fmt.Sprintf("heraldry worker %d got linked=%v badges=%d", i, linked, len(badges))
+			}
+			if _, followers, ok := githubPublicFor(fmt.Sprintf("spray-%02d", i)); !ok || followers != 9 {
+				errs <- fmt.Sprintf("github worker %d got ok=%v followers=%d", i, ok, followers)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	heraldryCacheMu.Lock()
+	heraldryLen := len(heraldryCache)
+	heraldryCacheMu.Unlock()
+	githubUserCacheMu.Lock()
+	githubLen := len(githubUserCache)
+	githubUserCacheMu.Unlock()
+	if max := effectiveDossierCacheMaxEntries(); heraldryLen > max || githubLen > max {
+		t.Fatalf("cache bounds after concurrent spray: heraldry=%d github=%d max=%d", heraldryLen, githubLen, max)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3103.

The issue was still live on current `origin/v2`: `v2/pkg/dashboard/dossier.go` had the public cache maps (`heraldryCache`, `githubUserCache`) and TTL freshness checks, but no cardinality bound. TTL alone is not a bound: stale keys can remain in the map forever if they are never requested again, so spraying unique Credly or GitHub usernames can grow process memory for the lifetime of the spoke.

This change adds `HIVE_DOSSIER_CACHE_MAX_ENTRIES` with a default of 512 entries per public dossier cache. On writes, each cache sweeps expired entries first and then evicts the oldest fetched entries until the map is within the cap. It does not clear the whole cache, because full flushes would let one attacker evict everyone else's hot entries and amplify upstream Credly/GitHub calls. Expired entries are also deleted when read.

File evidence in this branch:
- Cap/env default: `v2/pkg/dashboard/dossier.go:201-220`.
- Heraldry expiry sweep, oldest-fetched eviction, and locked store/read paths: `v2/pkg/dashboard/dossier.go:359-429`.
- GitHub expiry sweep, oldest-fetched eviction, and locked store/read paths: `v2/pkg/dashboard/dossier.go:509-581`.
- Negative/failed lookups remain short-lived via the existing 5 minute negative TTL.

I did not find an unsynchronised cache map access in the live code; reads and writes were already under the cache mutexes, and the new store/read helpers keep that contract.

## Tests

- `cd v2 && gofmt -l .` (listed pre-existing unrelated files; changed files are gofmt-clean)
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/dashboard/` with `grep -E -e '--- FAIL' -e '^FAIL'` scan
- `cd v2 && go test -race ./pkg/dashboard/ -run Dossier` with `grep -E -e '--- FAIL' -e '^FAIL'` scan

Sabotage verification: I temporarily disabled both bound-enforcement functions and reran `go test ./pkg/dashboard/ -run 'DossierPublicCaches' -count=1 -v`. The new tests failed with `heraldry cache has 25 entries, want <= 8` and `cache bounds after concurrent spray: heraldry=64 github=64 max=16`, proving they catch the unbounded-cache regression. The eviction code was then restored and the tests passed.
