### PR TITLE
🔒 diagnose unverifiable automerge approvals

### DIFF
--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -13,6 +13,15 @@ import (
 
 const DefaultAutoMergeSweepMaxMerges = 3
 
+const (
+	autoMergeReasonNoHiveQueueApproval        = "no-hive-queue-approval"
+	autoMergeReasonNoAppBotLogin              = "no-app-bot-login"
+	autoMergeReasonUntrustedQueueApproval     = "untrusted-hive-queue-approval"
+	autoMergeWarnNoAppBotLogin                = "automerge sweep disabled: no GitHub App bot login configured"
+	autoMergeWarnUntrustedQueueApproval       = "rejected untrusted Hive auto-merge queue approval"
+	autoMergeNoAppBotLoginOperatorRemediation = "Hive has no usable GitHub App, so App-authorship cannot be verified and auto-merge is disabled"
+)
+
 var hiveQueueReviewRE = regexp.MustCompile(`(?i)^Approved by @([A-Za-z0-9-]+) for Hive auto-merge on green CI\.`)
 
 type AutoMergeSweepOptions struct {
@@ -55,6 +64,7 @@ func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepO
 	}
 	label := c.AutoMergeLabel()
 	result := &AutoMergeSweepResult{}
+	noAppBotLoginWarned := false
 
 	for _, repo := range c.getRepos() {
 		if len(result.Merged) >= maxMerges {
@@ -76,6 +86,14 @@ func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepO
 			event, reason, err := c.trySweepQueuedPR(ctx, repo, owner, repoName, issue.GetNumber(), label)
 			if err != nil {
 				c.warn("automerge sweep skipped PR", "repo", repo, "pr", issue.GetNumber(), "reason", reason, "error", err)
+				result.Skipped++
+				continue
+			}
+			if reason == autoMergeReasonNoAppBotLogin {
+				if !noAppBotLoginWarned {
+					c.warn(autoMergeWarnNoAppBotLogin, "repo", repo, "pr", issue.GetNumber(), "reason", reason, "cause", autoMergeNoAppBotLoginOperatorRemediation)
+					noAppBotLoginWarned = true
+				}
 				result.Skipped++
 				continue
 			}
@@ -139,12 +157,18 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	if headSHA == "" {
 		return AutoMergeSweepEvent{}, "missing-head-sha", nil
 	}
-	approval, ok, err := c.latestHiveQueueApproval(ctx, owner, repo, number)
+	if strings.TrimSpace(c.appBotLogin) == "" {
+		return AutoMergeSweepEvent{}, autoMergeReasonNoAppBotLogin, nil
+	}
+	approval, ok, reason, err := c.latestHiveQueueApproval(ctx, owner, repo, number)
 	if err != nil {
 		return AutoMergeSweepEvent{}, "queue-approval-check", err
 	}
 	if !ok {
-		return AutoMergeSweepEvent{}, "no-hive-queue-approval", nil
+		if reason != "" {
+			return AutoMergeSweepEvent{}, reason, nil
+		}
+		return AutoMergeSweepEvent{}, autoMergeReasonNoHiveQueueApproval, nil
 	}
 	if approval.HeadSHA == "" {
 		if err := c.invalidateQueuedAutoMerge(ctx, owner, repo, number, label, "Hive auto-merge approval is missing a reviewed head SHA — re-queue required."); err != nil {
@@ -198,31 +222,42 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	return event, "", nil
 }
 
-func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string, number int) (hiveQueueApproval, bool, error) {
+func (c *Client) latestHiveQueueApproval(ctx context.Context, owner, repo string, number int) (hiveQueueApproval, bool, string, error) {
 	opts := &gh.ListOptions{PerPage: 100}
 	latest := hiveQueueApproval{}
+	untrusted := false
 	for {
 		reviews, resp, err := c.client.PullRequests.ListReviews(ctx, owner, repo, number, opts)
 		if err != nil {
-			return hiveQueueApproval{}, false, err
+			return hiveQueueApproval{}, false, "", err
 		}
 		for _, review := range reviews {
 			if !strings.EqualFold(review.GetState(), "APPROVED") {
 				continue
 			}
-			if !c.isHiveAppReviewAuthor(review) {
+			queuedBy := parseHiveQueueReview(review.GetBody())
+			if queuedBy == "" {
 				continue
 			}
-			if queuedBy := parseHiveQueueReview(review.GetBody()); queuedBy != "" {
-				latest = hiveQueueApproval{QueuedBy: queuedBy, HeadSHA: review.GetCommitID()}
+			if !c.isHiveAppReviewAuthor(review) {
+				untrusted = true
+				c.warn(autoMergeWarnUntrustedQueueApproval, "owner", owner, "repo", repo, "pr", number, "review_author", safeGetLogin(review.GetUser()), "claimed_queued_by", queuedBy, "expected_app_bot", c.appBotLogin)
+				continue
 			}
+			latest = hiveQueueApproval{QueuedBy: queuedBy, HeadSHA: review.GetCommitID()}
 		}
 		if resp.NextPage == 0 {
 			break
 		}
 		opts.Page = resp.NextPage
 	}
-	return latest, latest.QueuedBy != "", nil
+	if latest.QueuedBy != "" {
+		return latest, true, "", nil
+	}
+	if untrusted {
+		return latest, false, autoMergeReasonUntrustedQueueApproval, nil
+	}
+	return latest, false, "", nil
 }
 
 func (c *Client) isHiveAppReviewAuthor(review *gh.PullRequestReview) bool {

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -85,6 +86,32 @@ func TestSweepQueuedAutoMergesIgnoresForgedNonAppQueueApproval(t *testing.T) {
 	}
 	if len(result.Merged) != 0 || len(merged) != 0 || result.Skipped != 1 {
 		t.Fatalf("result=%+v merge calls=%v, want non-App review ignored and PR skipped", result, merged)
+	}
+}
+
+func TestSweepQueuedAutoMergesReportsMissingAppBotLoginOnce(t *testing.T) {
+	var logs bytes.Buffer
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{
+		{number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "clean"},
+		{number: 8, author: "carol", queuedBy: "dave", label: true, mergeableState: "clean"},
+	}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, slog.New(slog.NewTextHandler(&logs, nil)), api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 || result.Skipped != 2 {
+		t.Fatalf("result=%+v merge calls=%v, want both PRs skipped without merging", result, merged)
+	}
+	logText := logs.String()
+	if count := strings.Count(logText, autoMergeWarnNoAppBotLogin); count != 1 {
+		t.Fatalf("missing app bot login warnings = %d in %q, want exactly one", count, logText)
+	}
+	if !strings.Contains(logText, autoMergeReasonNoAppBotLogin) || !strings.Contains(logText, "App-authorship cannot be verified") {
+		t.Fatalf("missing app bot login log = %q, want reason and cause", logText)
 	}
 }
 
@@ -344,6 +371,7 @@ func TestTrySweepQueuedPRSkipBranches(t *testing.T) {
 		{name: "closed", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true}, state: "closed", want: "closed"},
 		{name: "label removed", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true}, state: "open", labels: nil, want: "label-removed"},
 		{name: "missing queue approval", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "clean"}, state: "open", labels: []map[string]string{{"name": AutoMergeQueuedLabel}}, noReview: true, want: "no-hive-queue-approval"},
+		{name: "untrusted queue approval", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", reviewAuthor: "mallory", label: true, mergeableState: "clean"}, state: "open", labels: []map[string]string{{"name": AutoMergeQueuedLabel}}, want: autoMergeReasonUntrustedQueueApproval},
 		{name: "not mergeable", pr: sweepPR{number: 7, author: "alice", queuedBy: "bob", label: true, mergeableState: "dirty"}, state: "open", labels: []map[string]string{{"name": AutoMergeQueuedLabel}}, want: "not-mergeable"},
 	}
 	for _, tt := range tests {
@@ -364,7 +392,11 @@ func TestTrySweepQueuedPRSkipBranches(t *testing.T) {
 					if tt.noReview {
 						json.NewEncoder(w).Encode([]map[string]any{})
 					} else {
-						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]string{"login": testHiveAppBotLogin}}})
+						reviewAuthor := tt.pr.reviewAuthor
+						if reviewAuthor == "" {
+							reviewAuthor = testHiveAppBotLogin
+						}
+						json.NewEncoder(w).Encode([]map[string]any{{"state": "APPROVED", "body": "Approved by @" + tt.pr.queuedBy + " for Hive auto-merge on green CI.", "commit_id": "sha7", "user": map[string]string{"login": reviewAuthor}}})
 					}
 				default:
 					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -463,6 +495,7 @@ func TestTrySweepQueuedPRMergeError(t *testing.T) {
 }
 
 func TestLatestHiveQueueApprovalDoesNotTrustBodyWhenReviewerIsNotApp(t *testing.T) {
+	var logs bytes.Buffer
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/repos/acme/widget/pulls/7/reviews" {
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -477,12 +510,17 @@ func TestLatestHiveQueueApprovalDoesNotTrustBodyWhenReviewerIsNotApp(t *testing.
 	defer api.Close()
 
 	c := newAutoMergeSweepClient(api.URL)
-	approval, ok, err := c.latestHiveQueueApproval(context.Background(), "acme", "widget", 7)
+	c.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	approval, ok, reason, err := c.latestHiveQueueApproval(context.Background(), "acme", "widget", 7)
 	if err != nil {
 		t.Fatalf("latestHiveQueueApproval returned error: %v", err)
 	}
-	if ok || approval.QueuedBy != "" {
-		t.Fatalf("approval=(%+v,%v), want forged body ignored", approval, ok)
+	if ok || approval.QueuedBy != "" || reason != autoMergeReasonUntrustedQueueApproval {
+		t.Fatalf("approval=(%+v,%v,%q), want forged body ignored with untrusted reason", approval, ok, reason)
+	}
+	logText := logs.String()
+	if !strings.Contains(logText, autoMergeWarnUntrustedQueueApproval) || !strings.Contains(logText, "mallory") || !strings.Contains(logText, "alice") {
+		t.Fatalf("untrusted approval log = %q, want warning with review author and claimed user", logText)
 	}
 }
 
@@ -500,12 +538,12 @@ func TestLatestHiveQueueApprovalKeepsLatestCommitID(t *testing.T) {
 	defer api.Close()
 
 	c := newAutoMergeSweepClient(api.URL)
-	approval, ok, err := c.latestHiveQueueApproval(context.Background(), "acme", "widget", 7)
+	approval, ok, reason, err := c.latestHiveQueueApproval(context.Background(), "acme", "widget", 7)
 	if err != nil {
 		t.Fatalf("latestHiveQueueApproval returned error: %v", err)
 	}
-	if !ok || approval.QueuedBy != "new" || approval.HeadSHA != "newsha" {
-		t.Fatalf("approval=(%+v,%v), want new/newsha", approval, ok)
+	if !ok || reason != "" || approval.QueuedBy != "new" || approval.HeadSHA != "newsha" {
+		t.Fatalf("approval=(%+v,%v,%q), want new/newsha", approval, ok, reason)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #2988.

## Problem

The #2988 fix correctly fails closed when the sweep cannot verify that a queue approval review was authored by the Hive GitHub App. One reachable configuration fault still produced a misleading diagnosis: if `appBotLogin` is empty, `isHiveAppReviewAuthor` can never accept any queue review, but the sweep previously collapsed that into `no-hive-queue-approval`.

That is wrong for hives without a usable GitHub App, including placeholder App ID or `installation_id: 0` cases. Operators need to know auto-merge is disabled because App authorship cannot be verified, not because nobody queued the PR.

## Change

- Added explicit reason constants, including `no-app-bot-login` and `untrusted-hive-queue-approval` (`v2/pkg/github/automerge_sweep.go:16-22`).
- If `appBotLogin` is empty, `trySweepQueuedPR` returns `no-app-bot-login` before reading reviews (`v2/pkg/github/automerge_sweep.go:160-162`). `SweepQueuedAutoMerges` logs a WARN with the configuration cause at most once per sweep (`v2/pkg/github/automerge_sweep.go:67,92-98`).
- If an APPROVED review body matches the Hive queue marker but the review author is not the configured App bot, the sweep logs a WARN with the review author, claimed queued-by user, PR number, and expected App bot, then returns `untrusted-hive-queue-approval` if no valid App-authored approval exists (`v2/pkg/github/automerge_sweep.go:238-258`).

## Tests and sabotage verification

Added regression tests for:

- empty `appBotLogin` producing one WARN per sweep with reason `no-app-bot-login`, rather than per-review spam;
- a matching queue approval from a non-App author producing `untrusted-hive-queue-approval`;
- the untrusted approval WARN naming the actual review author and claimed queued-by user.

Sabotage verification: I temporarily removed the empty-`appBotLogin` guard and suppressed the untrusted reason. Running:

`go test -v ./pkg/github/ -run 'Test(SweepQueuedAutoMergesReportsMissingAppBotLoginOnce|TrySweepQueuedPRSkipBranches|LatestHiveQueueApprovalDoesNotTrustBodyWhenReviewerIsNotApp)'`

failed as expected: the empty-App case fell back to `no-hive-queue-approval` with no missing-App warning, and the untrusted review case returned `no-hive-queue-approval` instead of `untrusted-hive-queue-approval`. Restoring the checks made the tests pass.

## Validation

- `git diff origin/v2 --name-only -- '*.go' | xargs gofmt -l` (no changed files listed)
- `gofmt -l .` still reports pre-existing unrelated files such as `extract.go` and `v2/cmd/bd/kb.go`
- `go build ./...`
- `go test ./pkg/github/` with `grep -E -e '--- FAIL' -e '^FAIL'` scan clean
- Code-review agent reported no significant issues.
