### PR TITLE
🔒 Verify hub kubectl download

### DIFF
--- a/v2/Dockerfile.hub
+++ b/v2/Dockerfile.hub
@@ -9,9 +9,19 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT}" -o /hive ./cmd/hive
 
 FROM alpine:3.24
+ARG TARGETARCH
+ARG KUBECTL_VERSION=v1.36.3
+ARG KUBECTL_SHA256_AMD64=ebbd080e7c2e275093b55915722043257eb24004363e20acb3c4d71919f88336
+ARG KUBECTL_SHA256_ARM64=3d86f24401c41ae5a46ac50eef8865fe891d3647d324a0836f6c63757a126e62
 RUN apk add --no-cache ca-certificates curl && \
-    ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/') && \
-    curl -sLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl" && \
+    ARCH="${TARGETARCH:-$(uname -m)}" && \
+    case "$ARCH" in \
+      amd64|x86_64) KUBECTL_ARCH=amd64; KUBECTL_SHA256="$KUBECTL_SHA256_AMD64" ;; \
+      arm64|aarch64) KUBECTL_ARCH=arm64; KUBECTL_SHA256="$KUBECTL_SHA256_ARM64" ;; \
+      *) echo "unsupported arch for kubectl: $ARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl" && \
+    echo "${KUBECTL_SHA256}  /usr/local/bin/kubectl" | sha256sum -c - && \
     chmod +x /usr/local/bin/kubectl
 COPY --from=builder /hive /usr/local/bin/hive
 RUN chmod +x /usr/local/bin/hive


### PR DESCRIPTION
Refs #2933

## Summary
- Replace floating `stable.txt` kubectl with exact `v1.36.3`
- Verify `linux/amd64` and `linux/arm64` kubectl binaries with official Kubernetes SHA-256 files before chmod/install

## Checksum evidence
Commands used:

```sh
curl -fsSL https://dl.k8s.io/release/v1.36.3/bin/linux/amd64/kubectl.sha256
curl -fsSL https://dl.k8s.io/release/v1.36.3/bin/linux/arm64/kubectl.sha256
```

Values:
- `KUBECTL_SHA256_AMD64=ebbd080e7c2e275093b55915722043257eb24004363e20acb3c4d71919f88336`
- `KUBECTL_SHA256_ARM64=3d86f24401c41ae5a46ac50eef8865fe891d3647d324a0836f6c63757a126e62`

## Fail-closed sanity check
Deliberately used an all-zero checksum in the same `sha256sum -c - && next-command` shape. Output:

```text
.kubectl-sabotage: FAILED
fail-closed ok: rc=1 and chained command did not run
```
