### PR TITLE
🔒 fix prompt history fail-closed role gate

### DIFF
--- a/v2/pkg/dashboard/prompt_history.go
+++ b/v2/pkg/dashboard/prompt_history.go
@@ -335,14 +335,11 @@ func (p *PromptHistory) Query(agent string, windowHours int, now time.Time) []Pr
 
 // handlePromptHistory serves GET /api/prompt-history.
 //
-// Access is gated exactly like GET /api/audit (handleAuditLog): prompt bodies
-// embed repo names, issue titles and knowledge-base content, so this must not
-// be readable by anyone who cannot already read the audit log.
+// Access fails closed exactly like GET /api/audit (handleAuditLog): prompt
+// bodies embed repo names, issue titles and knowledge-base content, so this
+// must not be readable by anyone who cannot already read the audit log.
 func (s *Server) handlePromptHistory(w http.ResponseWriter, r *http.Request) {
 	role := r.Header.Get("X-Hive-Role")
-	if role == "" {
-		role = "owner"
-	}
 	if !config.RoleAtLeast(role, config.RoleReadWrite) {
 		http.Error(w, "insufficient access", http.StatusForbidden)
 		return

--- a/v2/pkg/dashboard/prompt_history_test.go
+++ b/v2/pkg/dashboard/prompt_history_test.go
@@ -482,7 +482,7 @@ func TestHandlePromptHistoryRoleGating(t *testing.T) {
 	}{
 		{name: "owner allowed", role: "owner", wantCode: http.StatusOK},
 		{name: "read-write allowed", role: "read-write", wantCode: http.StatusOK},
-		{name: "empty role defaults to owner", role: "", wantCode: http.StatusOK},
+		{name: "missing role fails closed", role: "", wantCode: http.StatusForbidden},
 		{name: "read-only forbidden", role: "read-only", wantCode: http.StatusForbidden},
 		{name: "unknown role forbidden", role: "guest", wantCode: http.StatusForbidden},
 	}


### PR DESCRIPTION
## Summary
- make `/api/prompt-history` fail closed when `X-Hive-Role` is missing, matching `/api/audit`
- update the handler comment to describe the fail-closed behavior
- update role-gating coverage so missing role gets 403

## Verification
- `cd v2 && go test ./pkg/dashboard -run 'TestHandlePromptHistoryRoleGating' -count=1 -v`
- sabotage: re-added the old empty-role-to-owner default and confirmed `TestHandlePromptHistoryRoleGating/missing_role_fails_closed` fails, then restored
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/dashboard/`
