### PR TITLE
🔒 fail closed anonymous contribute writes on hosted spokes

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -6564,12 +6564,19 @@ func pruneQueueHoldReasons(src map[string]string, keep []string) map[string]stri
 // contributor can still register/onboard themselves. As a result the middleware
 // does NOT stop a "read" viewer from calling these mutation endpoints, so each
 // mutation handler must enforce the boundary itself. This mirrors the in-handler
-// role check used by handleConfigDownload / handleSelfUpgrade: read X-Hive-Role,
-// treat an absent header as owner (local/dev, no hub nginx), and reject "read".
-// UI hiding on the ops tab is UX; this is the security boundary.
+// role check used by the operator controls: read X-Hive-Role and reject "read".
+// On hub-proxied hosted spokes, an absent role means the public hub auth-check
+// path admitted an anonymous caller without identity headers, so fail closed.
+// On standalone/local-dev hives, keep the historical permissive default because
+// there is no hub nginx to inject X-Hive-Role. UI hiding on the ops tab is UX;
+// this is the security boundary.
 func (s *Server) requireContributorWrite(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
 	if role == "" {
+		if s != nil && s.deps != nil && s.deps.Config != nil && s.deps.Config.Dashboard.HubProxied {
+			jsonError(w, "your permissions on this hive are read-only, so changes are not allowed. Contact the owner of this hive to ask for write permissions.", http.StatusForbidden)
+			return false
+		}
 		role = "owner"
 	}
 	if role == "read" {

--- a/v2/pkg/dashboard/api_contribute_admin_controls_test.go
+++ b/v2/pkg/dashboard/api_contribute_admin_controls_test.go
@@ -209,6 +209,41 @@ func contributorWriteCases() []contributorWriteCase {
 	}
 }
 
+func contributorWriteRoleGateCases() []contributorWriteCase {
+	return []contributorWriteCase{
+		{"queue_order", (*Server).handleContributeQueueOrder, http.MethodPut, "/api/contribute/queue/order", `{"order":[]}`},
+		{"queue_hold", (*Server).handleContributeQueueHold, http.MethodPost, "/api/contribute/queue/hold", `{"key":"myorg/repo1#1","held":true}`},
+		{"queue_hold_clear", (*Server).handleContributeQueueHoldClear, http.MethodPost, "/api/contribute/queue/hold/clear", ``},
+		{"agent_role", (*Server).handleContributorAgentRole, http.MethodPut, "/api/contributors/alice/agent-role", `{"agent_role":"scanner"}`},
+		{"requeue", (*Server).handleContributorRequeue, http.MethodPost, "/api/contributors/alice/requeue", ``},
+	}
+}
+
+func TestContributorWrite_HubProxiedAnonymousForbidden(t *testing.T) {
+	for _, tc := range contributorWriteRoleGateCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			setupContributeEnv(t)
+			if err := saveContributorProfile(&ContributorProfile{
+				GitHubUsername: "alice", ContributorID: "c-alice", TrustTier: "trusted",
+			}); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			s, deps := apiServer(t)
+			deps.Config.Dashboard.HubProxied = true
+
+			req := httptest.NewRequest(tc.method, tc.target, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.SetPathValue("id", "alice")
+			w := httptest.NewRecorder()
+			tc.invoke(s, w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("hub-proxied anonymous got %d, want 403 (body: %s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 // TestContributorWrite_ReadViewerForbidden proves a "read" viewer is rejected with
 // 403 on every contributor mutation endpoint the ops tab surfaces — the boundary
 // the UI hiding merely shadows. roleEnforcement exempts /api/contribute*, so this

--- a/v2/pkg/dashboard/api_contribute_handler_branches_test.go
+++ b/v2/pkg/dashboard/api_contribute_handler_branches_test.go
@@ -183,16 +183,34 @@ func TestContributeQueue_NilHub(t *testing.T) {
 
 // --- requireContributorWrite ---
 
-func TestRequireContributorWrite_EmptyRoleDefaultsOwner(t *testing.T) {
+func TestRequireContributorWrite_EmptyRoleDefaultsOwnerOnStandalone(t *testing.T) {
 	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
 	s := NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	deps := testDeps(t)
+	deps.Config.Dashboard.HubProxied = false
 	s.RegisterAPI(deps)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	if !s.requireContributorWrite(rec, req) {
-		t.Fatalf("empty role should default to owner and pass, got false")
+		t.Fatalf("standalone empty role should default to owner and pass, got false")
+	}
+}
+
+func TestRequireContributorWrite_EmptyRoleForbiddenOnHubProxied(t *testing.T) {
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
+	s := NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	deps := testDeps(t)
+	deps.Config.Dashboard.HubProxied = true
+	s.RegisterAPI(deps)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	if s.requireContributorWrite(rec, req) {
+		t.Fatalf("hub-proxied empty role should fail closed, got true")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rec.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fail closed for missing `X-Hive-Role` on contributor write controls when the spoke is `Dashboard.HubProxied`
- preserve the existing standalone/local-dev missing-role permissive behavior when `HubProxied` is false
- cover all five `requireContributorWrite` call sites plus both deployment-shape branches

Fixes #3521

## Verification
- `cd v2 && go test ./pkg/dashboard -run 'TestRequireContributorWrite_|TestContributorWrite_HubProxiedAnonymousForbidden' -count=1 -v`
- sabotage: restored the old unconditional empty-role owner default and confirmed every hub-proxied anonymous call-site subtest fails
- sabotage: changed missing-role handling to always deny and confirmed the standalone/local-dev permissive test fails
- `cd v2 && go build ./...`
- `cd v2 && go test ./pkg/dashboard/`
