### PR TITLE
🔒 lock down pluk command directory permissions

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -285,7 +285,8 @@ RUN pip3 install --no-cache-dir --break-system-packages "specify-cli==${SPECIFY_
 ARG PLUK_VERSION=0.8.0
 RUN npm install -g @kubestellar/pluk@${PLUK_VERSION} && npm cache clean --force
 RUN mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
-    chmod 1777 /var/run/pluk/logs /var/run/pluk/commands
+    chown dev:node /var/run/pluk/logs /var/run/pluk/commands && \
+    chmod 2770 /var/run/pluk/logs /var/run/pluk/commands
 # Nous framework: pinned to a specific commit SHA to prevent supply-chain
 # injection via a push to the mutable branch ref. Update NOUS_COMMIT
 # deliberately when pulling upstream changes, after reviewing the diff at

--- a/v2/deploy/hive-panes.sh
+++ b/v2/deploy/hive-panes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hive-panes — show the last N lines of every OTHER agent's tmux pane.
-# Uses pluk JSONL logs (world-readable) so any agent can call it.
+# Uses pluk JSONL logs (readable by the shared node group) so any agent can call it.
 # Automatically skips the calling agent's own session (via HIVE_PROXY_AGENT).
 #
 # Usage:  hive-panes [lines]    (default: 30)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -817,8 +817,9 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 	// Attach pluk publisher if available — streams structured events
 	// from the agent's tmux output to a JSONL log for subscribers.
 	if plukPath, err := exec.LookPath("pluk"); err == nil {
-		_ = os.MkdirAll("/var/run/pluk/logs", 0o1777)
-		_ = os.MkdirAll("/var/run/pluk/commands", 0o1777)
+		if err := ensurePlukRunDirs(plukRunDir); err != nil {
+			m.logger.Warn("pluk run directory setup failed; pluk publisher may be degraded", "error", err)
+		}
 		backend := agent.Config.Backend
 		if agent.BackendOverride != "" {
 			backend = agent.BackendOverride

--- a/v2/pkg/agent/pluk_dirs.go
+++ b/v2/pkg/agent/pluk_dirs.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	plukRunDir = "/var/run/pluk"
+)
+
+// pluk runs from per-agent tmux servers. Agent UIDs differ, but they all share
+// the node group, so setgid keeps new entries group-owned without opening the
+// directory to unrelated container users.
+var plukSharedDirMode = os.FileMode(0o770) | os.ModeSetgid
+
+func ensurePlukRunDirs(runDir string) error {
+	for _, name := range []string{"logs", "commands"} {
+		dir := filepath.Join(runDir, name)
+		if err := os.MkdirAll(dir, plukSharedDirMode); err != nil {
+			return fmt.Errorf("creating %s: %w", dir, err)
+		}
+		if os.Geteuid() == 0 {
+			if err := os.Chown(dir, DevUID, NodeGID); err != nil {
+				return fmt.Errorf("chowning %s to %d:%d: %w", dir, DevUID, NodeGID, err)
+			}
+		}
+		if err := os.Chmod(dir, plukSharedDirMode); err != nil {
+			return fmt.Errorf("chmoding %s to %s: %w", dir, plukSharedDirMode, err)
+		}
+	}
+	return nil
+}

--- a/v2/pkg/agent/pluk_dirs_test.go
+++ b/v2/pkg/agent/pluk_dirs_test.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func setUmask(mask int) int {
+	return syscall.Umask(mask)
+}
+
+func TestEnsurePlukRunDirsUsesGroupOnlySetgidMode(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "pluk")
+	oldUmask := setUmask(0o077)
+	defer setUmask(oldUmask)
+
+	if err := ensurePlukRunDirs(runDir); err != nil {
+		t.Fatalf("ensure pluk dirs: %v", err)
+	}
+
+	for _, name := range []string{"logs", "commands"} {
+		path := filepath.Join(runDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", path)
+		}
+		if got := info.Mode().Perm(); got != 0o770 {
+			t.Errorf("%s mode = %04o, want 0770", path, got)
+		}
+		if info.Mode()&os.ModeSetgid == 0 {
+			t.Errorf("%s mode missing setgid bit: %s", path, info.Mode())
+		}
+		if info.Mode().Perm()&0o002 != 0 {
+			t.Errorf("%s is world-writable: %s", path, info.Mode())
+		}
+	}
+}


### PR DESCRIPTION
Closes #3424

## Threat model checked

I inspected the pinned `@kubestellar/pluk@0.8.0` package used by `v2/Dockerfile`. The `pluk watch <session> --cli=<backend>` path classifies stdin from `tmux pipe-pane` and emits JSON events; it does not read `/var/run/pluk/commands`. The `pluk send` command can inject text into tmux, but it does so directly with `tmux send-keys`, not by consuming files from that directory. In the current pinned pluk, the reported cross-agent command injection path through `/var/run/pluk/commands` is therefore not active.

## Why this mode still works

Agents run as distinct UIDs but share the `node` group. This changes both image setup and runtime repair to create `/var/run/pluk/logs` and `/var/run/pluk/commands` as `dev:node` with mode `2770`: owner/group rwx, no access for other container users, and setgid so new entries stay in the shared group. That preserves access for hive-managed agent processes while removing world-writable `1777`.

Runtime setup now calls `chmod` after `MkdirAll`, so the final mode is not left to the process umask. When running as root it also chowns the directories to `dev:node`, matching the Dockerfile.

## What this does and does not close

This closes the world-writable directory bug and prevents unrelated container users from writing pluk run files. It does not provide per-agent authentication between processes that are legitimately in the shared `node` group. If a future pluk version starts treating `/var/run/pluk/commands` as a command channel, it must authenticate/validate command content rather than relying only on directory mode.

## Verification

- Sabotage verification: changed the runtime mode back to `0o1777` and ran `go test ./pkg/agent/ -run TestEnsurePlukRunDirsUsesGroupOnlySetgidMode -v`; the test failed on mode `0777`, missing setgid, and world-writable checks. Restored the secure mode and the test passed.
- `go build ./...` passed in `v2`.
- `go test -timeout 15m -count=1 ./pkg/agent/` passed after cleaning stale test tmux sessions; output was scanned with `grep -E -e '--- FAIL' -e '^FAIL'` and had no matches.
- `gofmt -l` on changed Go files passed. `gofmt -l .` still lists pre-existing unrelated files on this branch, so I did not reformat unrelated code in this security PR.

I could verify the Go runtime mode logic locally. I could not locally verify full container agent startup with the built image; CI image/build jobs should cover that before merge.
