### PR TITLE
🐛 fix coverage gate auth regressions

### DIFF
--- a/v2/pkg/agent/dismiss_coverage_test.go
+++ b/v2/pkg/agent/dismiss_coverage_test.go
@@ -37,7 +37,7 @@ func TestDismissInferencePrompts_PressEnter(t *testing.T) {
 	go func() { m.dismissInferencePrompts(agent); close(done) }()
 	select {
 	case <-done:
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Error("dismissInferencePrompts should return")
 	}
 }
@@ -73,7 +73,7 @@ func TestDismissInferencePrompts_FixWith(t *testing.T) {
 	go func() { m.dismissInferencePrompts(agent); close(done) }()
 	select {
 	case <-done:
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Error("dismissInferencePrompts should return")
 	}
 }

--- a/v2/pkg/agent/sendkick_coverage_test.go
+++ b/v2/pkg/agent/sendkick_coverage_test.go
@@ -1,9 +1,7 @@
 package agent
 
 import (
-	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
@@ -25,18 +23,14 @@ func TestSendKick_DeliversToReadyPane(t *testing.T) {
 
 	m.mu.RLock()
 	agent := m.agents["cxa"]
-	session := agent.tmuxSession
 	m.mu.RUnlock()
 
-	if err := exec.Command("tmux", "new-session", "-d", "-s", session).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
-	}
-	defer exec.Command("tmux", "kill-session", "-t", session).Run()
+	session := "hive-sendkick-ready"
+	agent.tmuxSession = session
+	newRawTmuxSession(t, session)
 	// Render a ready input prompt so the crash/consent checks pass and
 	// waitForInputPromptForAgent returns on its first tick.
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": goose is ready").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	time.Sleep(500 * time.Millisecond)
+	paneInject(t, session, "goose is ready")
 
 	m.mu.Lock()
 	agent.State = StateRunning

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1236,8 +1236,21 @@ func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, p
 // client input.
 func requireOwnerRole(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
-	if role != "owner" || r.Header.Get(ownerRoleVerifiedHeader) != "true" {
+	if !isOwnerRole(role) || r.Header.Get(ownerRoleVerifiedHeader) != "true" {
 		jsonError(w, "owner access required", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+func requireMergerOrOwnerRole(w http.ResponseWriter, r *http.Request) bool {
+	role := r.Header.Get("X-Hive-Role")
+	if isOwnerRole(role) && r.Header.Get(ownerRoleVerifiedHeader) != "true" {
+		jsonError(w, "merger or owner access required", http.StatusForbidden)
+		return false
+	}
+	if !config.RoleAtLeast(role, config.RoleMerger) {
+		jsonError(w, "merger or owner access required", http.StatusForbidden)
 		return false
 	}
 	return true
@@ -2081,14 +2094,8 @@ func (s *Server) handleSummaries(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleQueuePRAutoMerge(w http.ResponseWriter, r *http.Request) {
-	role := r.Header.Get("X-Hive-Role")
 	user := strings.TrimSpace(r.Header.Get("X-Hive-User"))
-	if !config.RoleAtLeast(role, config.RoleMerger) {
-		jsonError(w, "merger or owner access required", http.StatusForbidden)
-		return
-	}
-	if role == config.RoleOwner && r.Header.Get(ownerRoleVerifiedHeader) != "true" {
-		jsonError(w, "owner access required", http.StatusForbidden)
+	if !requireMergerOrOwnerRole(w, r) {
 		return
 	}
 	if user == "" {

--- a/v2/pkg/dashboard/dossier_cache_test.go
+++ b/v2/pkg/dashboard/dossier_cache_test.go
@@ -104,7 +104,8 @@ func TestDossierPublicCachesBoundEvictExpiredAndPreserveFresh(t *testing.T) {
 }
 
 func TestDossierPublicCachesConcurrentAccess(t *testing.T) {
-	useDossierCacheMax(t, 16)
+	const workers = 64
+	useDossierCacheMax(t, workers)
 	resetDossierPublicCaches()
 	t.Cleanup(resetDossierPublicCaches)
 
@@ -129,7 +130,6 @@ func TestDossierPublicCachesConcurrentAccess(t *testing.T) {
 		githubUserAPIBase = origGitHubBase
 	})
 
-	const workers = 64
 	var wg sync.WaitGroup
 	errs := make(chan string, workers*2)
 	for i := 0; i < workers; i++ {

--- a/v2/pkg/dashboard/role_enforcement_3453_test.go
+++ b/v2/pkg/dashboard/role_enforcement_3453_test.go
@@ -218,3 +218,25 @@ func TestRoleEnforcement_QueuePRAutoMerge_EmptyRoleRejected(t *testing.T) {
 		t.Fatalf("empty role on queue-automerge: got status %d, want 403; body=%q", w.Code, w.Body.String())
 	}
 }
+
+func TestRoleEnforcement_QueuePRAutoMerge_UnverifiedOwnerRejected(t *testing.T) {
+	srv := newMinimalServer(t)
+
+	for _, role := range []string{"owner", " OWNER "} {
+		t.Run(role, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/prs/testorg/testrepo/42/queue-automerge", nil)
+			req.SetPathValue("owner", "testorg")
+			req.SetPathValue("repo", "testrepo")
+			req.SetPathValue("number", "42")
+			req.Header.Set("X-Hive-User", "attacker")
+			req.Header.Set("X-Hive-Role", role)
+			// ownerRoleVerifiedHeader intentionally NOT set.
+			w := httptest.NewRecorder()
+			srv.handleQueuePRAutoMerge(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("unverified owner role %q on queue-automerge: got status %d, want 403; body=%q", role, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -42,6 +42,10 @@ const proxyAuthHeader = "X-Hive-Proxy-Auth"
 // when the owner role came from a trusted source, not an inbound client header.
 const ownerRoleVerifiedHeader = "X-Hive-Owner-Role-Verified"
 
+func isOwnerRole(role string) bool {
+	return strings.EqualFold(strings.TrimSpace(role), config.RoleOwner)
+}
+
 // proxyProofRequired controls F2 enforcement strictness. Default true =
 // fail-closed: a request with no X-Hive-Proxy-Auth proof header (or a wrong
 // one) is rejected even if it carries X-Hive-User/X-Hive-Role identity
@@ -772,13 +776,13 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
-				if sess.Role == config.RoleOwner {
+				if isOwnerRole(sess.Role) {
 					r.Header.Set(ownerRoleVerifiedHeader, "true")
 				}
 			} else if r.Header.Get("X-Hive-Role") == "" {
 				r.Header.Set("X-Hive-Role", config.RoleOwner)
 				r.Header.Set(ownerRoleVerifiedHeader, "true")
-			} else if r.Header.Get("X-Hive-Role") == config.RoleOwner {
+			} else if isOwnerRole(r.Header.Get("X-Hive-Role")) {
 				r.Header.Set(ownerRoleVerifiedHeader, "true")
 			}
 			next.ServeHTTP(w, r)
@@ -808,7 +812,7 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
-				if sess.Role == config.RoleOwner {
+				if isOwnerRole(sess.Role) {
 					r.Header.Set(ownerRoleVerifiedHeader, "true")
 				}
 			}
@@ -836,7 +840,7 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
 				// Proof present and valid — definitely came through the hub.
 				trusted = true
-				if inboundRole == config.RoleOwner {
+				if isOwnerRole(inboundRole) {
 					r.Header.Set(ownerRoleVerifiedHeader, "true")
 				}
 			case proof == "" && !proxyProofRequired:
@@ -869,7 +873,7 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			if sess := s.sessionFromRequest(r); sess != nil {
 				r.Header.Set("X-Hive-User", sess.Username)
 				r.Header.Set("X-Hive-Role", sess.Role)
-				if sess.Role == config.RoleOwner {
+				if isOwnerRole(sess.Role) {
 					r.Header.Set(ownerRoleVerifiedHeader, "true")
 				}
 				trusted = true


### PR DESCRIPTION
## Why

Issue #3461 was filed from the Coverage Hourly workflow. The workflow runs from `v2` with:

- `.github/workflows/coverage-hourly.yml:49-55`: `go test ./pkg/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s`
- `.github/workflows/coverage-hourly.yml:57-89`: a second `go test -cover ./pkg/... -short -count=1 -timeout 600s` pass, then per-package floor parsing
- `.github/workflows/coverage-hourly.yml:60-76`: default floor 90%, with documented floors `dashboard=78`, `hub=89`, `agent=89`

The issue run 31516769468 failed because `pkg/dashboard` could not be scored (`dashboard: TESTS FAILING`), not because an `ok` package printed below its configured floor. Reproducing the workflow locally on the starting worktree showed the same class of failure: `TestRoleEnforcement_EmptyRoleRejected/handleVaultsConnect_empty_role`, `TestRoleEnforcement_UnverifiedOwnerRoleRejected/handleVaultsConnect`, and `TestRoleEnforcement_QueuePRAutoMerge_EmptyRoleRejected` returned 503 instead of failing closed with 403.

## What changed

- `v2/pkg/dashboard/api.go:1246-1257` adds one merger-or-owner gate that rejects empty roles and requires the server-only owner verification marker for owner-equivalent roles.
- `v2/pkg/dashboard/api.go:2096-2099` uses that gate before queue-automerge reaches the GitHub client.
- `v2/pkg/dashboard/server.go:45-47` and `v2/pkg/dashboard/server.go:776-840` normalize owner role detection consistently when setting the server-only verification marker.
- `v2/pkg/dashboard/role_enforcement_3453_test.go:205-242` asserts empty queue-automerge roles and unverified canonical/non-canonical owner roles fail closed.
- Stabilized existing tmux and dossier-cache coverage tests so the workflow can finish consistently under the same package coverage commands.

## Coverage evidence

Before (local reproduction on the starting worktree):

- `pkg/dashboard`: FAIL (`handleVaultsConnect` empty/unverified owner and `handleQueuePRAutoMerge` empty role returned 503 instead of 403)
- Gate result: `dashboard: TESTS FAILING`
- Packages that did print coverage were at or above their configured floors; examples from that run: `agent 91.0%`, `hub 90.1%`, `dashboard FAIL`.

After (rebased on latest `origin/v2`):

Command: `go test -cover ./pkg/... -short -count=1 -timeout 600s`

- advisory 94.0%
- agent 91.0% (floor 89%)
- apiproxy 95.7%
- beads 97.0%
- channels 98.4%
- classify 100.0%
- claude 91.0%
- config 92.4%
- dashboard 83.0% (floor 78%)
- defsrc 97.9%
- discord 91.9%
- github 90.4%
- governor 90.3%
- hivectl 93.1%
- hivectl/commands 94.8%
- hub 90.1% (floor 89%)
- hubbackup 91.4%
- knowledge 90.2%
- logscrub 100.0%
- notify 90.6%
- openrouter 94.8%
- policies 93.4%
- proclock 90.3%
- promptsrc 93.9%
- proxy 90.3%
- resolve 96.4%
- scheduler 91.3%
- snapshot 90.4%
- spokebackup 92.9%
- tokens 94.3%
- trajectory 97.6%
- watsonx 97.9%

Gate classification: `All packages meet their coverage floor`. Total coverage from `coverage.out`: 88.4%.

## Sabotage verification

I deliberately broke the production checks and reran the relevant tests with `-v`:

- Removed the vault owner gate: `TestRoleEnforcement_EmptyRoleRejected/handleVaultsConnect_empty_role` and `TestRoleEnforcement_UnverifiedOwnerRoleRejected/handleVaultsConnect` failed with 503 instead of 403.
- Bypassed the empty-role queue gate: `TestRoleEnforcement_QueuePRAutoMerge_EmptyRoleRejected` failed with 503 instead of 403.
- Reverted owner-role normalization to an exact comparison: `TestRoleEnforcement_QueuePRAutoMerge_UnverifiedOwnerRejected/_OWNER_` failed with 503 instead of 403.

Those failures prove the tests catch the fail-open behavior rather than just painting lines green.

## Validation

- `go test ./pkg/dashboard ./pkg/agent -short -count=1 -timeout 600s`
- `go test ./pkg/dashboard -short -count=1 -run TestDossierPublicCachesConcurrentAccess -v`
- `go build ./...`
- `go test ./pkg/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s`
- `go test -cover ./pkg/... -short -count=1 -timeout 600s`
- `gofmt -l <changed files>`: clean
- `gofmt -l .` was also run; it still lists unrelated pre-existing files on `v2`, but none of the changed files are listed.

Closes #3461

