### PR TITLE
🌱 Make inference prompt dismissal tests deterministic

### DIFF
--- a/v2/pkg/agent/dismiss_coverage_test.go
+++ b/v2/pkg/agent/dismiss_coverage_test.go
@@ -1,79 +1,18 @@
 package agent
 
-import (
-	"os/exec"
-	"testing"
-	"time"
-
-	"github.com/kubestellar/hive/v2/pkg/config"
-)
+import "testing"
 
 // TestDismissInferencePrompts_PressEnter covers the "Press Enter to continue"
 // branch: the pane shows that text, then flips to a ready marker so the loop
 // returns.
 func TestDismissInferencePrompts_PressEnter(t *testing.T) {
-	if !tmuxAvailable() {
-		t.Skip("tmux not available")
-	}
-	session := "hive-covpressenter"
-	newRawTmuxSession(t, session)
-	m := NewManager(map[string]config.AgentConfig{"covpe": {Backend: "litellm"}}, discardLogger(), ProjectContext{})
-	m.mu.RLock()
-	agent := m.agents["covpe"]
-	m.mu.RUnlock()
-	agent.tmuxSession = session
-
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Press Enter to continue").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	time.Sleep(400 * time.Millisecond)
-
-	go func() {
-		time.Sleep(1200 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	}()
-
-	done := make(chan struct{})
-	go func() { m.dismissInferencePrompts(agent); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Error("dismissInferencePrompts should return")
-	}
+	m, agent, script := newDismissPromptHarness(t, "covpe", ": Press Enter to continue", 1)
+	runDismissPromptScript(t, m, agent, script, []string{"Enter"})
 }
 
 // TestDismissInferencePrompts_FixWithSettingsError covers the settings-error
 // "Fix with Claude" navigation branch (double Down past Fix/Exit to Continue).
 func TestDismissInferencePrompts_FixWith(t *testing.T) {
-	if !tmuxAvailable() {
-		t.Skip("tmux not available")
-	}
-	session := "hive-covfixwith"
-	newRawTmuxSession(t, session)
-	m := NewManager(map[string]config.AgentConfig{"covfw": {Backend: "vllm"}}, discardLogger(), ProjectContext{})
-	m.mu.RLock()
-	agent := m.agents["covfw"]
-	m.mu.RUnlock()
-	agent.tmuxSession = session
-
-	// Selection menu whose selected line begins with "Fix with".
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Enter to confirm").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ Fix with Claude").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	time.Sleep(400 * time.Millisecond)
-
-	go func() {
-		time.Sleep(1500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	}()
-
-	done := make(chan struct{})
-	go func() { m.dismissInferencePrompts(agent); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Error("dismissInferencePrompts should return")
-	}
+	m, agent, script := newDismissPromptHarness(t, "covfw", ": Enter to confirm\n❯ Fix with Claude", 3)
+	runDismissPromptScript(t, m, agent, script, []string{"Down", "Down", "Enter"})
 }

--- a/v2/pkg/agent/dismiss_prompts_fake_test.go
+++ b/v2/pkg/agent/dismiss_prompts_fake_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"runtime"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+const readyPromptPane = ": esc to interrupt"
+
+type scriptedPromptPane struct {
+	mu             sync.Mutex
+	initialPane    string
+	afterDownPane  string
+	readyAfterKeys int
+	keys           []string
+}
+
+func newDismissPromptHarness(t *testing.T, name, initialPane string, readyAfterKeys int) (*Manager, *AgentProcess, *scriptedPromptPane) {
+	t.Helper()
+	m := NewManager(map[string]config.AgentConfig{name: {Backend: "litellm"}}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents[name]
+	m.mu.RUnlock()
+
+	script := &scriptedPromptPane{initialPane: initialPane, readyAfterKeys: readyAfterKeys}
+	m.visiblePaneCapture = script.capture
+	m.sendKeysForAgent = script.sendKeys
+	m.promptDismissSleep = func(time.Duration) { runtime.Gosched() }
+	m.promptDismissTimeout = 200 * time.Millisecond
+	return m, agent, script
+}
+
+func (s *scriptedPromptPane) capture(*AgentProcess) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.keys) >= s.readyAfterKeys {
+		return readyPromptPane
+	}
+	if s.afterDownPane != "" && slices.Contains(s.keys, "Down") {
+		return s.afterDownPane
+	}
+	return s.initialPane
+}
+
+func (s *scriptedPromptPane) sendKeys(_ *AgentProcess, keys ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys = append(s.keys, keys...)
+}
+
+func (s *scriptedPromptPane) keySnapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.keys...)
+}
+
+func runDismissPromptScript(t *testing.T, m *Manager, agent *AgentProcess, script *scriptedPromptPane, wantKeys []string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		m.dismissInferencePrompts(agent)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dismissInferencePrompts should return")
+	}
+	if got := script.keySnapshot(); !slices.Equal(got, wantKeys) {
+		t.Fatalf("dismissInferencePrompts keys = %v, want %v", got, wantKeys)
+	}
+}

--- a/v2/pkg/agent/launch_coverage_test.go
+++ b/v2/pkg/agent/launch_coverage_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -111,98 +110,14 @@ func TestStart_CopilotAdoptsRunning(t *testing.T) {
 // ("No, exit") so the function presses Down then Enter, then the pane flips to
 // a ready marker so it returns.
 func TestDismissInferencePrompts_NavigatesNegative(t *testing.T) {
-	if !tmuxAvailable() {
-		t.Skip("tmux not available")
-	}
-	session := "hive-covdismiss2"
-	newRawTmuxSession(t, session)
-	m := NewManager(map[string]config.AgentConfig{"covdismiss2": {Backend: "litellm"}}, discardLogger(), ProjectContext{})
-	m.mu.RLock()
-	agent := m.agents["covdismiss2"]
-	m.mu.RUnlock()
-	agent.tmuxSession = session
-
-	// Render a selection prompt with a negative selected option.
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Enter to confirm").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ 1. No, exit").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	time.Sleep(400 * time.Millisecond)
-
-	done := make(chan struct{})
-	go func() {
-		m.dismissInferencePrompts(agent)
-		close(done)
-	}()
-
-	// Flip the pane to the ready marker and keep re-asserting it until
-	// dismissInferencePrompts returns. A single send-keys/capture-pane can race
-	// with the poll loop under load, and the loop only acts on a *changed* pane
-	// (it skips a capture equal to the previous one), so re-emit a line that
-	// contains the ready marker AND a changing counter each interval. That
-	// guarantees at least one poll sees a changed pane carrying the marker,
-	// rather than depending on one perfectly-timed write.
-	stop := make(chan struct{})
-	go func() {
-		time.Sleep(1500 * time.Millisecond)
-		ticker := time.NewTicker(500 * time.Millisecond)
-		defer ticker.Stop()
-		n := 0
-		for {
-			n++
-			exec.Command("tmux", "send-keys", "-t", session, "-l",
-				fmt.Sprintf(": esc to interrupt [%d]", n)).Run()
-			exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-			}
-		}
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Error("dismissInferencePrompts should return after pane becomes ready")
-	}
-	close(stop)
+	m, agent, script := newDismissPromptHarness(t, "covdismiss2", ": Enter to confirm\n❯ 1. No, exit", 2)
+	runDismissPromptScript(t, m, agent, script, []string{"Down", "Enter"})
 }
 
 // TestDismissInferencePrompts_BypassConsent covers the explicit bypass-consent
 // handling branch (confirmMenuOption with Down navigation).
 func TestDismissInferencePrompts_BypassConsent(t *testing.T) {
-	if !tmuxAvailable() {
-		t.Skip("tmux not available")
-	}
-	session := "hive-covdismiss3"
-	newRawTmuxSession(t, session)
-	m := NewManager(map[string]config.AgentConfig{"covdismiss3": {Backend: "vllm"}}, discardLogger(), ProjectContext{})
-	m.mu.RLock()
-	agent := m.agents["covdismiss3"]
-	m.mu.RUnlock()
-	agent.tmuxSession = session
-
-	exec.Command("tmux", "send-keys", "-t", session, "-l", ": Bypass Permissions mode").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "-l", "❯ 2. Yes, I accept").Run()
-	exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	time.Sleep(400 * time.Millisecond)
-
-	go func() {
-		time.Sleep(1500 * time.Millisecond)
-		exec.Command("tmux", "send-keys", "-t", session, "-l", ": esc to interrupt").Run()
-		exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
-	}()
-
-	done := make(chan struct{})
-	go func() {
-		m.dismissInferencePrompts(agent)
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Error("dismissInferencePrompts should return")
-	}
+	m, agent, script := newDismissPromptHarness(t, "covdismiss3", ": Bypass Permissions mode\n❯ 1. No, exit", 2)
+	script.afterDownPane = ": Bypass Permissions mode\n❯ 2. Yes, I accept"
+	runDismissPromptScript(t, m, agent, script, []string{"Down", "Enter"})
 }

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -243,6 +243,11 @@ type Manager struct {
 	// non-reentrant RWMutex, so reading the callback under a second Lock there
 	// would deadlock the kick path.
 	recordPromptCallback atomic.Pointer[func(agent, trigger, prompt string)]
+
+	visiblePaneCapture   func(agent *AgentProcess) string
+	sendKeysForAgent     func(agent *AgentProcess, keys ...string)
+	promptDismissSleep   func(time.Duration)
+	promptDismissTimeout time.Duration
 }
 
 // SetPersistPauseCallback wires a function that persists an agent's paused
@@ -2371,6 +2376,9 @@ func (m *Manager) captureTmuxPaneForAgent(agent *AgentProcess) string {
 
 // captureVisiblePaneForAgent captures only the visible pane (no scrollback).
 func (m *Manager) captureVisiblePaneForAgent(agent *AgentProcess) string {
+	if m.visiblePaneCapture != nil {
+		return m.visiblePaneCapture(agent)
+	}
 	cmd := m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p")
 	out, err := cmd.Output()
 	if err != nil {
@@ -3155,7 +3163,11 @@ func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
 	)
 
 	start := time.Now()
-	deadline := start.Add(promptDismissTimeout)
+	timeout := promptDismissTimeout
+	if m.promptDismissTimeout > 0 {
+		timeout = m.promptDismissTimeout
+	}
+	deadline := start.Add(timeout)
 	lastPane := ""
 
 	for time.Now().Before(deadline) {
@@ -3163,7 +3175,7 @@ func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
 		if time.Since(start) < promptFastPollWindow {
 			interval = promptFastPollInterval
 		}
-		time.Sleep(interval)
+		m.sleepDuringPromptDismiss(interval)
 
 		pane := m.captureVisiblePaneForAgent(agent)
 		if pane == "" {
@@ -3228,19 +3240,27 @@ func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
 			strings.Contains(selectedLower, "exit") {
 			// Try moving down first (most prompts put the positive option below)
 			m.tmuxSendKeysForAgent(agent, "Down")
-			time.Sleep(postKeystrokeDelay)
+			m.sleepDuringPromptDismiss(postKeystrokeDelay)
 		} else if strings.Contains(selectedLower, "fix with") {
 			// Settings error: skip past "Fix with Claude" and "Exit" to "Continue without"
 			m.tmuxSendKeysForAgent(agent, "Down")
-			time.Sleep(postKeystrokeDelay)
+			m.sleepDuringPromptDismiss(postKeystrokeDelay)
 			m.tmuxSendKeysForAgent(agent, "Down")
-			time.Sleep(postKeystrokeDelay)
+			m.sleepDuringPromptDismiss(postKeystrokeDelay)
 		}
 
 		m.tmuxSendKeysForAgent(agent, "Enter")
 	}
 
 	m.logger.Warn("inference prompt dismissal timed out", "agent", agent.Name)
+}
+
+func (m *Manager) sleepDuringPromptDismiss(d time.Duration) {
+	if m.promptDismissSleep != nil {
+		m.promptDismissSleep(d)
+		return
+	}
+	time.Sleep(d)
 }
 
 // selectedMenuOption returns the trimmed text of the "❯"-selected line of an
@@ -3276,11 +3296,11 @@ func (m *Manager) confirmMenuOption(agent *AgentProcess, title, want, navKey str
 		}
 		if strings.Contains(selectedMenuOption(pane), want) {
 			m.tmuxSendKeysForAgent(agent, "Enter")
-			time.Sleep(postKeystrokeDelay)
+			m.sleepDuringPromptDismiss(postKeystrokeDelay)
 			return true
 		}
 		m.tmuxSendKeysForAgent(agent, navKey)
-		time.Sleep(postKeystrokeDelay)
+		m.sleepDuringPromptDismiss(postKeystrokeDelay)
 	}
 	m.logger.Warn("inference menu: wanted option not reached",
 		"agent", agent.Name, "title", title, "want", want)
@@ -3546,6 +3566,10 @@ func (m *Manager) tmuxSendEntersForAgent(agent *AgentProcess) {
 
 // tmuxSendKeysForAgent sends key sequences (C-c, C-u, etc.) using the agent's tmux socket.
 func (m *Manager) tmuxSendKeysForAgent(agent *AgentProcess, keys ...string) {
+	if m.sendKeysForAgent != nil {
+		m.sendKeysForAgent(agent, keys...)
+		return
+	}
 	args := append([]string{"send-keys", "-t", agent.tmuxSession}, keys...)
 	_ = m.tmuxCmd(agent, args...).Run()
 }

--- a/v2/pkg/agent/tmux_coverage_test.go
+++ b/v2/pkg/agent/tmux_coverage_test.go
@@ -542,29 +542,8 @@ func TestConfirmMenuOption_SelectsOption(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDismissInferencePrompts_ReadyReturnsFast(t *testing.T) {
-	if !tmuxAvailable() {
-		t.Skip("tmux not available")
-	}
-	session := "hive-covdismiss"
-	newRawTmuxSession(t, session)
-	m := NewManager(map[string]config.AgentConfig{"covdismiss": {Backend: "litellm"}}, discardLogger(), ProjectContext{})
-	m.mu.RLock()
-	agent := m.agents["covdismiss"]
-	m.mu.RUnlock()
-	agent.tmuxSession = session
-	// "esc to interrupt" is the ready marker -> function returns quickly.
-	paneInject(t, session, "bypass permissions on")
-
-	done := make(chan struct{})
-	go func() {
-		m.dismissInferencePrompts(agent)
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Error("dismissInferencePrompts should return promptly when ready")
-	}
+	m, agent, script := newDismissPromptHarness(t, "covdismiss", "bypass permissions on", 0)
+	runDismissPromptScript(t, m, agent, script, nil)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add test seams for visible pane capture, key sends, and prompt-dismiss timing while preserving real tmux defaults
- Replace the tmux/sleep-driven dismissInferencePrompts coverage with scripted fake pane transitions
- Assert the exact dismissal keys for Press Enter, Fix with, negative navigation, and bypass-consent flows

Fixes #3528

## Verification
- Reproduced baseline locally: TestDismissInferencePrompts passed on this machine in 9.913s (the reported macOS failures did not reproduce here)
- go test ./pkg/agent/ -run TestDismissInferencePrompts -count=20 -race
- go test ./pkg/agent/ -count=1 (352.582s / real 5m53.390s, down from ~400s baseline)
- Sabotage check: inserted an immediate return in dismissInferencePrompts; PressEnter, FixWith, NavigatesNegative, and BypassConsent failed on missing expected keys; restored and tests passed
- Code review agent: no significant issues found