### PR TITLE
✨ feat(hub): add "Upgrade" grouping to the hive table (group by off/instant/1p)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -9958,6 +9958,7 @@ const dashboardHTML = `<!DOCTYPE html>
     var HIVE_GROUP_OWNER = 'owner';
     var HIVE_GROUP_ACMM = 'acmm';
     var HIVE_GROUP_BRANCH = 'branch';
+    var HIVE_GROUP_UPGRADE = 'upgrade';
 
     /* Label shown for a hive whose grouping field is empty/unreported. Kept as
        one constant so every dimension buckets blanks identically. */
@@ -10030,7 +10031,20 @@ const dashboardHTML = `<!DOCTYPE html>
         var na = _acmmGroupOrder(a), nb = _acmmGroupOrder(b);
         return na - nb;
       }},
-      {key: HIVE_GROUP_BRANCH, label: 'Branch', of: function(h) { return (h && h.gitBranch) || ''; }}
+      {key: HIVE_GROUP_BRANCH, label: 'Branch', of: function(h) { return (h && h.gitBranch) || ''; }},
+      {key: HIVE_GROUP_UPGRADE, label: 'Upgrade', of: function(h) {
+        /* Group by the EFFECTIVE auto-upgrade mode, computed exactly as the
+           Version column's select does (see AUTO_UPGRADE_* around the render):
+           autoUpgrade:false is 'off' regardless of the stored mode; otherwise
+           the normalized mode 'daily' shows as '1p' and everything else as
+           'instant'. Labels are the bare mode words used by AUTO_UPGRADE_OPTIONS
+           ('off' / 'instant' / '1p'), not the glyph-prefixed control labels, so
+           the group header reads as plain text. Absent flags fall through to
+           HIVE_GROUP_UNKNOWN_LABEL like every other dimension. */
+        if (!h) return '';
+        if (!h.autoUpgrade) return 'off';
+        return h.autoUpgradeMode === AUTO_UPGRADE_DAILY ? '1p' : 'instant';
+      }}
     ];
 
     /* Sort weight for an ACMM group label. "Level N" → N; anything else (the


### PR DESCRIPTION
Adds an **Upgrade** option to the hub dashboard's "Group by" control, so an operator can group the hive table by each hive's effective auto-upgrade setting.

## What changed
- New group-by dimension constant `HIVE_GROUP_UPGRADE = 'upgrade'`, alongside the existing `HIVE_GROUP_*` constants.
- New entry in `HIVE_GROUP_DIMENSIONS` (right after **Branch**): `{key: HIVE_GROUP_UPGRADE, label: 'Upgrade', of: ...}`.

## Field used
The row object already carries the two fields written by the version-column render:
- `h.autoUpgrade` (bool, JSON `autoUpgrade` from `MyHiveEntry.AutoUpgrade`)
- `h.autoUpgradeMode` (string, JSON `autoUpgradeMode` from `MyHiveEntry.AutoUpgradeMode`, server-normalized to `instant`/`daily`)

The grouping computes the **effective** mode exactly the way the Version-column select already does (`AUTO_UPGRADE_*`, ~line 13428):

```
if (!h.autoUpgrade) return 'off';
return h.autoUpgradeMode === AUTO_UPGRADE_DAILY ? '1p' : 'instant';
```

`autoUpgrade:false` buckets as **off** regardless of stored mode; enabled hives bucket as **1p** (daily) or **instant**. No field had to be added to the row object — both were already present.

## Labels
Group headers use the bare mode words `off` / `instant` / `1p`, matching the `AUTO_UPGRADE_OPTIONS` control labels (`⦸ off`, `⚡ instant`, `🕐 1p`) minus the glyph prefixes, so the group header reads as plain text. Empty/absent flags fall through to the existing `Unspecified` bucket like every other dimension.

## Scope
Hub UI grouping only — no server, API, storage, or auto-upgrade-behavior changes. No existing test asserts the dimension list contents/count, so none needed updating.