### PR TITLE
🔒 fix: port F12 write-path and F8 DNS SSRF fixes to v2

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"hash/fnv"
 	"log/slog"
 	"os"
@@ -4581,7 +4582,7 @@ func (m *Manager) seedClaudeUserConfig(agentName, path string) {
 // seeded by older hive versions without the truncated key form the CLI
 // actually matches against (see apiKeyApprovalSuffixLen).
 func (m *Manager) mergeApprovedAPIKeys(agentName, path string) {
-	data, err := os.ReadFile(path)
+	data, err := readInferenceConfigFile(path)
 	if err != nil {
 		return
 	}
@@ -4617,7 +4618,7 @@ func (m *Manager) mergeApprovedAPIKeys(agentName, path string) {
 	if err != nil {
 		return
 	}
-	if err := os.WriteFile(path, out, 0o666); err != nil {
+	if err := writeInferenceConfigFile(path, out); err != nil {
 		m.logger.Warn("failed to write inference config", "agent", agentName, "path", path, "error", err)
 	}
 }
@@ -4636,7 +4637,7 @@ func (m *Manager) seedClaudeSettingsFile(agentName, path string) {
 // parseable file is left untouched.
 func (m *Manager) seedJSONFile(agentName, path string, seed map[string]any) {
 	existing := map[string]any{}
-	if data, err := os.ReadFile(path); err == nil {
+	if data, err := readInferenceConfigFile(path); err == nil {
 		if jsonErr := json.Unmarshal(data, &existing); jsonErr != nil {
 			m.logger.Warn("inference config unparseable, rewriting",
 				"agent", agentName, "path", path, "error", jsonErr)
@@ -4660,7 +4661,7 @@ func (m *Manager) seedJSONFile(agentName, path string, seed map[string]any) {
 		m.logger.Warn("failed to marshal inference config", "agent", agentName, "path", path, "error", err)
 		return
 	}
-	if err := os.WriteFile(path, data, 0o666); err != nil {
+	if err := writeInferenceConfigFile(path, data); err != nil {
 		m.logger.Warn("failed to write inference config", "agent", agentName, "path", path, "error", err)
 	}
 }
@@ -4692,6 +4693,58 @@ func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 	// Pre-populate (or repair) .claude.json so the CLI skips first-run setup.
 	m.seedClaudeUserConfig(agentName, filepath.Join(homePath, ".claude.json"))
 	m.ensureWorldWritable(homePath)
+}
+
+// inferenceConfigFileMode is the mode for a per-agent inference config file.
+//
+// Kept at 0o666 deliberately: these live in a per-agent HOME that the AGENT's
+// own UID must be able to rewrite. The symlink guard below is what closes audit
+// F12 — the exploit was redirection out of the directory, not the mode.
+const inferenceConfigFileMode = 0o666
+
+// readInferenceConfigFile reads a per-agent inference config, refusing to
+// traverse a symlink (audit F12).
+//
+// os.ReadFile follows symlinks, so a planted link let an attacker feed the
+// CONTENTS of any hive-readable file into the merge logic, which then wrote the
+// merged result back out — a read-and-echo primitive on top of the clobber.
+//
+// A missing file is the normal first-run case; callers already treat any error
+// as "start from the seed", so failing closed here costs nothing.
+func readInferenceConfigFile(path string) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+// writeInferenceConfigFile writes a per-agent inference config without following
+// a symlink (audit F12, CWE-59/61).
+//
+// SECURITY: the inference HOME is a predictable path
+// (/tmp/.claude-inference-home-<agent>) inside world-writable /tmp, and the
+// directory is created world-writable so the agent UID can use it. Both writers
+// used a plain os.WriteFile, which opens O_WRONLY|O_CREATE|O_TRUNC with NO
+// O_NOFOLLOW — so another local UID could pre-plant a symlink at the config path
+// and have the hive overwrite any file it can reach.
+//
+// The sibling half of F12 (ensureWorldWritable, which WIDENED a linked file's
+// mode) is already fixed on this branch; this closes the write path, which
+// CLOBBERED its contents.
+func writeInferenceConfigFile(path string, data []byte) error {
+	f, err := os.OpenFile(path,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW,
+		inferenceConfigFileMode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // ensureWorldWritable walks the tree and sets dirs to 0o777, files to 0o666.

--- a/v2/pkg/agent/manager_extra_test.go
+++ b/v2/pkg/agent/manager_extra_test.go
@@ -1,6 +1,9 @@
 package agent
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -326,5 +329,107 @@ func TestDeduplicateBlocks_NearDuplicates(t *testing.T) {
 	if len(result) > 3 {
 		t.Errorf("DeduplicateBlocks should remove near-duplicate block, got %d lines: %v",
 			len(result), result)
+	}
+}
+
+// Audit F12 (CWE-59/61), the WRITE half — ported from v4 (#3500).
+//
+// The sibling half (ensureWorldWritable, which WIDENED a symlinked file's mode)
+// is already fixed on this branch. These cover the two WRITERS, which used a
+// plain os.WriteFile — it follows symlinks, so an attacker who could plant a
+// link at the predictable inference-home path had the hive overwrite the
+// CONTENTS of any file it could reach.
+//
+// The inference HOME is /tmp/.claude-inference-home-<agent>: a guessable path
+// inside world-writable /tmp, in a directory deliberately made world-writable so
+// the agent UID can use it. Planting the link needs no privilege.
+func TestF12_SeedJSONFileDoesNotFollowSymlink(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const victimContent = "hive-owned secret, must survive"
+	victim := filepath.Join(root, "victim.json")
+	if err := os.WriteFile(victim, []byte(victimContent), 0o600); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+	target := filepath.Join(home, ".claude.json")
+	if err := os.Symlink(victim, target); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.seedJSONFile("victim-agent", target, map[string]any{"hasCompletedOnboarding": true})
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(got) != victimContent {
+		t.Fatalf("F12: the hive wrote THROUGH a planted symlink and clobbered a file outside the agent home.\n victim now: %s", got)
+	}
+}
+
+// mergeApprovedAPIKeys is the second writer. It reads the file first, so without
+// the guard it is also a read-and-echo primitive.
+func TestF12_MergeApprovedAPIKeysDoesNotFollowSymlink(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const victimContent = `{"customApiKeyResponses":{"approved":[]}}`
+	victim := filepath.Join(root, "victim.json")
+	if err := os.WriteFile(victim, []byte(victimContent), 0o600); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+	target := filepath.Join(home, ".claude.json")
+	if err := os.Symlink(victim, target); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.mergeApprovedAPIKeys("victim-agent", target)
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if string(got) != victimContent {
+		t.Fatalf("F12: mergeApprovedAPIKeys wrote through a planted symlink.\n victim now: %s", got)
+	}
+}
+
+// POSITIVE CONTROL. The guards must not break the feature: a real (non-symlink)
+// config still has to be seeded and merged, or both tests above would pass
+// against a build that simply never writes anything.
+func TestF12_RealInferenceConfigStillSeeded(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".claude.json")
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.seedJSONFile("real-agent", path, map[string]any{"hasCompletedOnboarding": true})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("test is vacuous: the seed never wrote a real file: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("seeded file is not valid JSON: %v", err)
+	}
+	if parsed["hasCompletedOnboarding"] != true {
+		t.Fatalf("seeded key missing — the guard broke normal seeding: %v", parsed)
+	}
+
+	m.seedJSONFile("real-agent", path, map[string]any{"anotherKey": "v"})
+	data2, _ := os.ReadFile(path)
+	var parsed2 map[string]any
+	if err := json.Unmarshal(data2, &parsed2); err != nil {
+		t.Fatalf("merged file is not valid JSON: %v", err)
+	}
+	if parsed2["anotherKey"] != "v" || parsed2["hasCompletedOnboarding"] != true {
+		t.Fatalf("merge lost keys: %v", parsed2)
 	}
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7227,7 +7227,9 @@ func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	req.URL = strings.TrimSpace(req.URL)
-	if err := knowledge.ValidateGitSourceURL(req.URL); err != nil {
+	// Context-aware so the SSRF DNS lookup inherits this request's deadline
+	// and cancellation rather than running on a background context.
+	if err := knowledge.ValidateGitSourceURLContext(r.Context(), req.URL); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -631,7 +631,7 @@ func (k *KnowledgeAPI) Layers() []LayerType {
 // periodic sync loop. Any layer level can have git sources.
 func (k *KnowledgeAPI) ConnectGitSource(ctx context.Context, config GitSourceConfig) error {
 	config.URL = strings.TrimSpace(config.URL)
-	if err := ValidateGitSourceURL(config.URL); err != nil {
+	if err := ValidateGitSourceURLContext(ctx, config.URL); err != nil {
 		return fmt.Errorf("invalid git source url: %w", err)
 	}
 

--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -77,7 +77,7 @@ func NewGitSource(config GitSourceConfig, baseDir string, logger *slog.Logger) *
 
 // Init clones the repo (or reuses an existing clone) and creates the FileStore.
 func (g *GitSource) Init(ctx context.Context) error {
-	if err := ValidateGitSourceURL(g.config.URL); err != nil {
+	if err := ValidateGitSourceURLContext(ctx, g.config.URL); err != nil {
 		return fmt.Errorf("git source %s: invalid url: %w", g.config.Name, err)
 	}
 	if err := ValidateGitSourceBranch(g.config.Branch); err != nil {
@@ -250,6 +250,13 @@ func (g *GitSource) setupSparseCheckout(ctx context.Context) error {
 // ValidateGitSourceURL enforces the transports permitted for git-backed knowledge sources.
 // It also blocks private/loopback destinations to prevent SSRF via git clone.
 func ValidateGitSourceURL(raw string) error {
+	return ValidateGitSourceURLContext(context.Background(), raw)
+}
+
+// ValidateGitSourceURLContext is ValidateGitSourceURL with a caller-supplied
+// context, so the SSRF DNS lookup inherits the request's deadline and
+// cancellation instead of running unbounded on a background context.
+func ValidateGitSourceURLContext(ctx context.Context, raw string) error {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
 		return fmt.Errorf("git URL is required")
@@ -285,7 +292,7 @@ func ValidateGitSourceURL(raw string) error {
 	// Operators running a legitimately-internal Git server (e.g. an in-cluster
 	// GitLab) set HIVE_ALLOW_PRIVATE_GIT_SOURCE=true to opt in; default is
 	// fail-closed.
-	if !allowPrivateGitSource() && gitSourceHostIsPrivate(parsed.Hostname()) {
+	if !allowPrivateGitSource() && gitSourceHostResolvesPrivate(ctx, parsed.Hostname()) {
 		return fmt.Errorf("git URL host resolves to a private/internal address (set HIVE_ALLOW_PRIVATE_GIT_SOURCE=true for an internal Git server)")
 	}
 
@@ -309,6 +316,49 @@ func ValidateGitSourceBranch(branch string) error {
 // private/internal address is permitted. Default false (fail-closed).
 func allowPrivateGitSource() bool {
 	return os.Getenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE") == "true"
+}
+
+// gitSourceResolver is the DNS lookup used by the SSRF check, replaceable in
+// tests. Mirrors the dashboard's privateURLResolver seam.
+var gitSourceResolver = func(ctx context.Context, host string) ([]string, error) {
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+// gitSourceLookupTimeout bounds the SSRF DNS lookup so a slow or hostile
+// resolver cannot stall the request that triggered validation.
+const gitSourceLookupTimeout = 5 * time.Second
+
+// gitSourceHostResolvesPrivate reports whether host is private either as an IP
+// literal or by DNS resolution.
+//
+// SECURITY (audit F8, CWE-918): the literal check alone was the whole defense,
+// so `http://internal.attacker.tld/` resolving to 169.254.169.254 validated
+// cleanly — an attacker controls their own DNS. Resolving narrows the window to
+// a genuine rebind race; NOT resolving removes the check altogether. The
+// dashboard's isPrivateURL already resolves and fails closed; this brings the
+// git path in line with it.
+//
+// Fails CLOSED on lookup error, matching that precedent.
+func gitSourceHostResolvesPrivate(ctx context.Context, host string) bool {
+	if gitSourceHostIsPrivate(host) {
+		return true
+	}
+	// An IP literal was fully decided above; no DNS to consult.
+	if net.ParseIP(strings.Trim(host, "[]")) != nil {
+		return false
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, gitSourceLookupTimeout)
+	defer cancel()
+	addrs, err := gitSourceResolver(lookupCtx, host)
+	if err != nil {
+		return true
+	}
+	for _, addr := range addrs {
+		if gitSourceHostIsPrivate(addr) {
+			return true
+		}
+	}
+	return false
 }
 
 // gitSourceHostIsPrivate reports whether host is a loopback/private/link-local

--- a/v2/pkg/knowledge/gitsource_ssrf_test.go
+++ b/v2/pkg/knowledge/gitsource_ssrf_test.go
@@ -1,6 +1,10 @@
 package knowledge
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
 func TestValidateGitSourceURL_RejectsPrivateHosts(t *testing.T) {
 	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
@@ -61,5 +65,60 @@ func TestValidateGitSourceURL_OptInAllowsPrivate(t *testing.T) {
 	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
 	if err := ValidateGitSourceURL("http://10.0.0.5/internal.git"); err != nil {
 		t.Errorf("opt-in must allow a private internal Git server, got %v", err)
+	}
+}
+
+// Audit F8 (CWE-918) — ported from v4 (#3433). The SSRF check inspected the
+// host only as an IP LITERAL, so every rejection test above passes while
+// `http://internal.attacker.tld/` resolving to 169.254.169.254 validated
+// cleanly. An attacker controls their own DNS, so a literal-only check is
+// trivially sidestepped.
+func TestF8_RejectsHostnameResolvingToPrivateAddress(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, host string) ([]string, error) {
+		if host == "internal.attacker.tld" {
+			return []string{"169.254.169.254"}, nil
+		}
+		return []string{"93.184.216.34"}, nil
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
+	if err := ValidateGitSourceURL("https://internal.attacker.tld/repo.git"); err == nil {
+		t.Fatal("F8: a hostname resolving to the cloud metadata endpoint was accepted — the SSRF check only inspects IP literals")
+	}
+	// Positive control: a hostname resolving to a public address must still be
+	// allowed, or the fix is just a blanket denial of every non-literal host.
+	if err := ValidateGitSourceURL("https://github.com/kubestellar/hive.git"); err != nil {
+		t.Fatalf("a public hostname was rejected, which would break every legitimate git source: %v", err)
+	}
+}
+
+// A resolver failure must fail CLOSED — otherwise an attacker who can make
+// lookups fail turns the error path itself into the bypass.
+func TestF8_FailsClosedWhenResolverErrors(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, _ string) ([]string, error) {
+		return nil, errors.New("dns unavailable")
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
+	if err := ValidateGitSourceURL("https://unresolvable.example/repo.git"); err == nil {
+		t.Fatal("F8: a host whose DNS lookup failed was accepted — the error path must fail closed")
+	}
+}
+
+// The operator opt-in must still work for a legitimately internal Git server.
+func TestF8_OperatorOptInStillAllowsPrivate(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, _ string) ([]string, error) {
+		return []string{"10.0.0.5"}, nil
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
+	if err := ValidateGitSourceURL("https://git.internal.corp/repo.git"); err != nil {
+		t.Fatalf("operator opt-in no longer permits an internal Git server: %v", err)
 	}
 }

--- a/v2/pkg/knowledge/gitsource_test.go
+++ b/v2/pkg/knowledge/gitsource_test.go
@@ -2,6 +2,7 @@ package knowledge
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -63,15 +64,56 @@ func TestValidateGitSourceURL_HTTPRequiresPrivateOptIn(t *testing.T) {
 }
 
 func TestValidateGitSourceURL_AllowsPublicLegacyIPv4Forms(t *testing.T) {
+	// These forms are not net.ParseIP literals, so they reach the resolver.
+	// Stub it so the test asserts the VALIDATOR's behaviour rather than whether
+	// the machine running it happens to have working DNS.
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, host string) ([]string, error) {
+		switch host {
+		case "134744072":
+			return []string{"8.8.8.8"}, nil
+		case "8.8.8":
+			return []string{"8.8.0.8"}, nil
+		}
+		return nil, errors.New("unexpected host: " + host)
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
 	tests := []string{
-		"https://134744072/repo.git",       // 8.8.8.8 as a single decimal integer.
-		"https://8.8.8/repo.git",           // shortened dotted form: 8.8.0.8.
-		"https://010.010.010.010/repo.git", // 8.8.8.8 in dotted octal form.
+		"https://134744072/repo.git", // 8.8.8.8 as a single decimal integer.
+		"https://8.8.8/repo.git",     // shortened dotted form: 8.8.0.8.
 	}
 	for _, raw := range tests {
 		if err := ValidateGitSourceURL(raw); err != nil {
 			t.Fatalf("expected public legacy IPv4 form %q to pass, got %v", raw, err)
 		}
+	}
+}
+
+// CORRECTION (audit F8). This case used to sit in the list above, commented
+// "8.8.8.8 in dotted octal form" and asserted to PASS. That comment is wrong:
+// Go's resolver — and glibc's, and Python's, all independently checked — read
+// the leading zeros as DECIMAL, so 010.010.010.010 resolves to 10.10.10.10,
+// which is RFC1918 PRIVATE. The old assertion therefore required the validator
+// to accept an SSRF target, and it only "passed" because the literal-only check
+// never resolved the name at all.
+//
+// Once the check resolves (F8), this form is correctly REJECTED. Pinning that
+// here so the corrected behaviour cannot be mistaken for a regression and
+// reverted.
+func TestF8_DottedOctalFormIsPrivateAndRejected(t *testing.T) {
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "")
+	orig := gitSourceResolver
+	gitSourceResolver = func(_ context.Context, host string) ([]string, error) {
+		if host == "010.010.010.010" {
+			return []string{"10.10.10.10"}, nil
+		}
+		return nil, errors.New("unexpected host: " + host)
+	}
+	t.Cleanup(func() { gitSourceResolver = orig })
+
+	if err := ValidateGitSourceURL("https://010.010.010.010/repo.git"); err == nil {
+		t.Fatal("F8: 010.010.010.010 resolves to the RFC1918 address 10.10.10.10 and must be rejected as an SSRF target")
 	}
 }
 


### PR DESCRIPTION
## Why v2

The production hub is built from `v2` (image `hive-hub:62089e9`, verified an ancestor of `origin/v2` and **not** of `origin/v4`), and 15+ of the 17 spokes I can see run `v2-latest`. Both fixes have been on `v4` for a day, protecting exactly **one** hive out of ~61. This ports the two that are self-contained — no protocol change, no hub/spoke coordination.

## F12 (CWE-59/61) — the write half

The sibling half (`ensureWorldWritable`, which *widened* a symlinked file's mode) is **already fixed on this branch**. Both **writers** were not.

`seedJSONFile` and `mergeApprovedAPIKeys` used a plain `os.WriteFile`, which follows symlinks — so a link planted at the predictable inference-home path (`/tmp/.claude-inference-home-<agent>`, inside world-writable `/tmp`) had the hive overwrite the **contents** of any file it could reach.

Both **reads** now go through an `O_NOFOLLOW` helper too: `os.ReadFile` follows symlinks as well, and `mergeApprovedAPIKeys` reads-then-writes, so the pair was also a read-and-echo primitive.

## F8 (CWE-918) — resolve DNS

`ValidateGitSourceURL` inspected the host only as an **IP literal**, so `https://internal.attacker.tld/repo.git` resolving to `169.254.169.254` validated cleanly. An attacker controls their own DNS.

Now resolves and **fails closed** on lookup error, bounded by a 5s timeout, via a new `ValidateGitSourceURLContext` so the lookup inherits the caller's deadline. All three call sites threaded. Original signature preserved.

## ⚠️ This corrects a pre-existing test that asserted a vulnerability

`TestValidateGitSourceURL_AllowsPublicLegacyIPv4Forms` required `010.010.010.010` to **pass**, commented *"8.8.8.8 in dotted octal form"*.

**That comment is wrong.** Go's resolver reads the leading zeros as *decimal*:

```
010.010.010.010 -> 10.10.10.10      (Go net.DefaultResolver)
010.010.010.010 -> 10.10.10.10      (Python socket.gethostbyname)
```

`10.10.10.10` is RFC1918 **private**. So the old assertion required the validator to accept an SSRF target, and only "passed" because the literal-only check never resolved the name at all. Once F8 resolves, that form is correctly **rejected**.

I moved it to `TestF8_DottedOctalFormIsPrivateAndRejected`, which pins the rejection so the corrected behaviour can't later be mistaken for a regression and reverted. The two genuinely-public forms (`134744072` → 8.8.8.8, `8.8.8` → 8.8.0.8) still pass, now with a **stubbed resolver** so they assert the validator rather than whether the test machine has working DNS.

This was caught only because I compared against a clean baseline — it surfaced as `1 new failure` and turned out to be the pre-existing test being wrong, not my change.

## Verification

- **Baseline on clean `origin/v2`**: `pkg/agent` 0 failures, `pkg/knowledge` 0 failures
- **After**: `ok pkg/agent 594s`, `ok pkg/knowledge 33.8s` — **0 failures, identical to baseline**
- `go build ./...` and `go vet` clean

Every regression verified to **fail against the unfixed code**:

```
--- FAIL: TestF12_SeedJSONFileDoesNotFollowSymlink
    victim now: {"hasCompletedOnboarding":true}
--- FAIL: TestF12_MergeApprovedAPIKeysDoesNotFollowSymlink
    victim now: {"customApiKeyResponses":{"approved":["sk-hive-victim-agent"]}}
--- FAIL: TestF8_RejectsHostnameResolvingToPrivateAddress
--- FAIL: TestF8_FailsClosedWhenResolverErrors
```

One note on how that was verified: reverting **only** the writer for `mergeApprovedAPIKeys` left `O_NOFOLLOW` on the read, so the function returned before its write and the test passed for the wrong reason. I had to revert **both** the read and the write to test the genuine original. Reverting one line of a two-part fix does not test the original.

Positive controls throughout — a real config file is still seeded *and* merged on a second pass; a public hostname is still accepted; the `HIVE_ALLOW_PRIVATE_GIT_SOURCE` opt-in still works — so none of these can pass against a build that simply writes nothing or denies everything.