### PR TITLE
🐛 Wire Bob token usage into the budget collector (#3537)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1523,6 +1523,7 @@ func main() {
 	tokenCollector := tokens.NewCollector(cfg.Data.MetricsDir, logger)
 	tokenCollector.SetClaudeSessionsDir(cfg.Data.ClaudeSessionsDir)
 	tokenCollector.SetCopilotSessionsDir(cfg.Data.CopilotSessionsDir)
+	tokenCollector.SetBobSessionsDir(cfg.Data.BobSessionsDir)
 	if len(savedIssueCosts) > 0 {
 		tokenCollector.SeedIssueCosts(savedIssueCosts)
 		logger.Info("issue costs restored", "entries", len(savedIssueCosts))

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2314,6 +2314,7 @@ type DataConfig struct {
 	LogsDir            string `yaml:"logs_dir"`
 	ClaudeSessionsDir  string `yaml:"claude_sessions_dir"`
 	CopilotSessionsDir string `yaml:"copilot_sessions_dir"`
+	BobSessionsDir     string `yaml:"bob_sessions_dir"`
 	AgentsDir          string `yaml:"agents_dir"`
 }
 
@@ -2764,6 +2765,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Data.CopilotSessionsDir == "" {
 		c.Data.CopilotSessionsDir = "/data/home/.copilot/session-state"
+	}
+	if c.Data.BobSessionsDir == "" {
+		c.Data.BobSessionsDir = "/data/home/.bob"
 	}
 	if c.Data.AgentsDir == "" {
 		c.Data.AgentsDir = "/data/agent-configs"

--- a/v2/pkg/tokens/bob_scanner.go
+++ b/v2/pkg/tokens/bob_scanner.go
@@ -1,0 +1,226 @@
+package tokens
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// bobChatSession is the top-level structure of a bobshell 1.0.6 chat recording
+// file. Files live at $HOME/.bob/tmp/<uuid>/chats/<session-id>.json and contain
+// an array of messages with optional per-message token usage.
+//
+// Observed format (bobshell 1.0.6, IBM watsonx backend):
+//
+//	{
+//	  "id": "session-uuid",
+//	  "model": "granite-3.1-8b-instruct",
+//	  "messages": [
+//	    {"role":"user","content":"..."},
+//	    {"role":"assistant","content":"...","usage":{"input_tokens":100,"output_tokens":50}}
+//	  ]
+//	}
+//
+// When explicit usage is absent (older bobshell versions or recording disabled),
+// the scanner estimates tokens from message content length (~4 chars/token).
+type bobChatSession struct {
+	ID       string           `json:"id"`
+	Model    string           `json:"model"`
+	Messages []bobChatMessage `json:"messages"`
+}
+
+type bobChatMessage struct {
+	Role    string      `json:"role"`
+	Content string      `json:"content"`
+	Usage   bobMsgUsage `json:"usage,omitempty"`
+}
+
+type bobMsgUsage struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	// IBM's watsonx sometimes uses these field names instead.
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+}
+
+// charsPerToken is the estimation factor when explicit token counts are
+// unavailable: ~4 characters per token for English-heavy code work.
+const charsPerToken = 4
+
+// maxBobChatFileSize limits how large a single chat file we'll parse. Files
+// larger than this are skipped to avoid OOM on runaway recordings.
+const maxBobChatFileSize = 50 * 1024 * 1024 // 50 MB
+
+// maxBobSessionAge limits how far back to scan. Sessions older than this are
+// skipped (they predate the budget window anyway).
+const maxBobSessionAge = 30 * 24 * time.Hour
+
+// ScanBobSessions reads bobshell's chat recording files from the given
+// directory (typically /data/home/.bob) and returns an AggregateSummary.
+// It walks tmp/*/chats/*.json looking for session recordings.
+func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
+	agg := &AggregateSummary{
+		ByAgent:       make(map[string]int64),
+		ByModel:       make(map[string]int64),
+		ByAgentDetail: make(map[string]*AgentModelBucket),
+		ByModelDetail: make(map[string]*AgentModelBucket),
+	}
+
+	if bobHomeDir == "" {
+		return agg, nil
+	}
+
+	chatsGlob := filepath.Join(bobHomeDir, "tmp", "*", "chats", "*.json")
+	matches, err := filepath.Glob(chatsGlob)
+	if err != nil {
+		return agg, err
+	}
+
+	cutoff := time.Now().Add(-maxBobSessionAge)
+
+	for _, path := range matches {
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			continue
+		}
+		if info.Size() > maxBobChatFileSize {
+			continue
+		}
+
+		sess, err := parseBobChatFile(path)
+		if err != nil || sess == nil {
+			continue
+		}
+
+		var inputTokens, outputTokens int64
+		hasExplicitUsage := false
+		messageCount := 0
+
+		for _, msg := range sess.Messages {
+			in, out := msg.Usage.effectiveTokens()
+			if in > 0 || out > 0 {
+				hasExplicitUsage = true
+				inputTokens += in
+				outputTokens += out
+			}
+			if msg.Role == "assistant" || msg.Role == "user" {
+				messageCount++
+			}
+		}
+
+		// Fall back to estimation when no explicit usage is recorded.
+		if !hasExplicitUsage {
+			for _, msg := range sess.Messages {
+				chars := int64(len(msg.Content))
+				estimated := chars / charsPerToken
+				if estimated < 1 && chars > 0 {
+					estimated = 1
+				}
+				switch msg.Role {
+				case "user":
+					inputTokens += estimated
+				case "assistant":
+					outputTokens += estimated
+				}
+			}
+		}
+
+		total := inputTokens + outputTokens
+		if total == 0 {
+			continue
+		}
+
+		model := sess.Model
+		if model == "" {
+			model = "bob-unknown"
+		}
+
+		const agentName = "bob"
+		agg.TotalTokens += total
+		agg.TotalMessages += messageCount
+		agg.SessionCount++
+		agg.ByAgent[agentName] += total
+		agg.ByModel[model] += total
+
+		if agg.ByAgentDetail[agentName] == nil {
+			agg.ByAgentDetail[agentName] = &AgentModelBucket{}
+		}
+		agg.ByAgentDetail[agentName].Input += inputTokens
+		agg.ByAgentDetail[agentName].Output += outputTokens
+		agg.ByAgentDetail[agentName].Messages += messageCount
+		agg.ByAgentDetail[agentName].Sessions++
+
+		if agg.ByModelDetail[model] == nil {
+			agg.ByModelDetail[model] = &AgentModelBucket{}
+		}
+		agg.ByModelDetail[model].Input += inputTokens
+		agg.ByModelDetail[model].Output += outputTokens
+		agg.ByModelDetail[model].Messages += messageCount
+		agg.ByModelDetail[model].Sessions++
+
+		// Use the file path's UUID component as session ID.
+		sessionID := extractBobSessionID(path)
+		agg.Sessions = append(agg.Sessions, SessionSummary{
+			SessionID:    sessionID,
+			Agent:        agentName,
+			Model:        model,
+			InputTokens:  inputTokens,
+			OutputTokens: outputTokens,
+			TotalTokens:  total,
+			Messages:     messageCount,
+		})
+	}
+
+	return agg, nil
+}
+
+func parseBobChatFile(path string) (*bobChatSession, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var sess bobChatSession
+	if err := json.Unmarshal(data, &sess); err != nil {
+		// Try as a JSON array of messages (alternative format).
+		var msgs []bobChatMessage
+		if err2 := json.Unmarshal(data, &msgs); err2 != nil {
+			return nil, err
+		}
+		sess.Messages = msgs
+	}
+
+	return &sess, nil
+}
+
+// effectiveTokens returns the best available token counts, preferring
+// input_tokens/output_tokens over prompt_tokens/completion_tokens.
+func (u bobMsgUsage) effectiveTokens() (input, output int64) {
+	input = u.InputTokens
+	output = u.OutputTokens
+	if input == 0 && u.PromptTokens > 0 {
+		input = u.PromptTokens
+	}
+	if output == 0 && u.CompletionTokens > 0 {
+		output = u.CompletionTokens
+	}
+	return
+}
+
+// extractBobSessionID pulls the UUID directory component from a path like
+// .bob/tmp/<uuid>/chats/session.json.
+func extractBobSessionID(path string) string {
+	dir := filepath.Dir(path) // .../chats
+	dir = filepath.Dir(dir)   // .../<uuid>
+	base := filepath.Base(dir)
+	if base == "." || base == "/" || base == "tmp" {
+		// Fallback: use the filename without extension.
+		return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+	return base
+}

--- a/v2/pkg/tokens/bob_scanner_test.go
+++ b/v2/pkg/tokens/bob_scanner_test.go
@@ -1,0 +1,173 @@
+package tokens
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanBobSessions_ExplicitUsage(t *testing.T) {
+	dir := t.TempDir()
+	chatDir := filepath.Join(dir, "tmp", "abc-123", "chats")
+	if err := os.MkdirAll(chatDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sess := bobChatSession{
+		ID:    "sess-1",
+		Model: "granite-3.1-8b-instruct",
+		Messages: []bobChatMessage{
+			{Role: "user", Content: "fix the bug"},
+			{Role: "assistant", Content: "done", Usage: bobMsgUsage{InputTokens: 100, OutputTokens: 50}},
+		},
+	}
+	data, _ := json.Marshal(sess)
+	if err := os.WriteFile(filepath.Join(chatDir, "session.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agg, err := ScanBobSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.TotalTokens != 150 {
+		t.Errorf("TotalTokens = %d, want 150", agg.TotalTokens)
+	}
+	if agg.SessionCount != 1 {
+		t.Errorf("SessionCount = %d, want 1", agg.SessionCount)
+	}
+	if agg.ByAgent["bob"] != 150 {
+		t.Errorf("ByAgent[bob] = %d, want 150", agg.ByAgent["bob"])
+	}
+	if agg.ByModel["granite-3.1-8b-instruct"] != 150 {
+		t.Errorf("ByModel = %d, want 150", agg.ByModel["granite-3.1-8b-instruct"])
+	}
+}
+
+func TestScanBobSessions_EstimationFallback(t *testing.T) {
+	dir := t.TempDir()
+	chatDir := filepath.Join(dir, "tmp", "def-456", "chats")
+	if err := os.MkdirAll(chatDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// No usage fields — should estimate from content length.
+	sess := bobChatSession{
+		ID:    "sess-2",
+		Model: "granite-3.1-8b-instruct",
+		Messages: []bobChatMessage{
+			{Role: "user", Content: "1234567890123456"},          // 16 chars -> 4 tokens
+			{Role: "assistant", Content: "12345678901234567890"}, // 20 chars -> 5 tokens
+		},
+	}
+	data, _ := json.Marshal(sess)
+	if err := os.WriteFile(filepath.Join(chatDir, "chat.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agg, err := ScanBobSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 16/4 = 4 input, 20/4 = 5 output, total = 9
+	if agg.TotalTokens != 9 {
+		t.Errorf("TotalTokens = %d, want 9", agg.TotalTokens)
+	}
+}
+
+func TestScanBobSessions_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	agg, err := ScanBobSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.TotalTokens != 0 {
+		t.Errorf("TotalTokens = %d, want 0", agg.TotalTokens)
+	}
+	if agg.SessionCount != 0 {
+		t.Errorf("SessionCount = %d, want 0", agg.SessionCount)
+	}
+}
+
+func TestScanBobSessions_EmptyString(t *testing.T) {
+	agg, err := ScanBobSessions("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.TotalTokens != 0 {
+		t.Errorf("TotalTokens = %d, want 0", agg.TotalTokens)
+	}
+}
+
+func TestScanBobSessions_PromptTokensFallback(t *testing.T) {
+	dir := t.TempDir()
+	chatDir := filepath.Join(dir, "tmp", "ghi-789", "chats")
+	if err := os.MkdirAll(chatDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Uses prompt_tokens/completion_tokens instead of input/output.
+	sess := bobChatSession{
+		ID:    "sess-3",
+		Model: "granite-code",
+		Messages: []bobChatMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi", Usage: bobMsgUsage{PromptTokens: 200, CompletionTokens: 80}},
+		},
+	}
+	data, _ := json.Marshal(sess)
+	if err := os.WriteFile(filepath.Join(chatDir, "s.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agg, err := ScanBobSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.TotalTokens != 280 {
+		t.Errorf("TotalTokens = %d, want 280", agg.TotalTokens)
+	}
+}
+
+func TestScanBobSessions_ArrayFormat(t *testing.T) {
+	dir := t.TempDir()
+	chatDir := filepath.Join(dir, "tmp", "jkl-012", "chats")
+	if err := os.MkdirAll(chatDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Alternative format: bare array of messages.
+	msgs := []bobChatMessage{
+		{Role: "user", Content: "test"},
+		{Role: "assistant", Content: "ok", Usage: bobMsgUsage{InputTokens: 10, OutputTokens: 5}},
+	}
+	data, _ := json.Marshal(msgs)
+	if err := os.WriteFile(filepath.Join(chatDir, "alt.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agg, err := ScanBobSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.TotalTokens != 15 {
+		t.Errorf("TotalTokens = %d, want 15", agg.TotalTokens)
+	}
+}
+
+func TestExtractBobSessionID(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/data/home/.bob/tmp/abc-123/chats/session.json", "abc-123"},
+		{"/data/home/.bob/tmp/xyz/chats/foo.json", "xyz"},
+	}
+	for _, tc := range tests {
+		got := extractBobSessionID(tc.path)
+		if got != tc.want {
+			t.Errorf("extractBobSessionID(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -75,6 +75,7 @@ type Collector struct {
 	sessionsDir               string
 	claudeSessionsDir         string
 	copilotSessionsDir        string
+	bobSessionsDir            string
 	copilotLiveCaptureSinceMs int64
 	persistPath               string
 	detector                  func(string) string
@@ -113,6 +114,10 @@ func (c *Collector) SetClaudeSessionsDir(dir string) {
 
 func (c *Collector) SetCopilotSessionsDir(dir string) {
 	c.copilotSessionsDir = dir
+}
+
+func (c *Collector) SetBobSessionsDir(dir string) {
+	c.bobSessionsDir = dir
 }
 
 // SetCopilotLiveCapture tells the collector that the MITM proxy began recording
@@ -176,6 +181,15 @@ func (c *Collector) scan() {
 			c.logger.Warn("copilot session scan failed", "error", err)
 		} else if copilotAgg != nil && copilotAgg.SessionCount > 0 {
 			MergeAggregates(agg, copilotAgg)
+		}
+	}
+
+	if c.bobSessionsDir != "" {
+		bobAgg, err := ScanBobSessions(c.bobSessionsDir)
+		if err != nil {
+			c.logger.Warn("bob session scan failed", "error", err)
+		} else if bobAgg != nil && bobAgg.SessionCount > 0 {
+			MergeAggregates(agg, bobAgg)
 		}
 	}
 

--- a/v2/pkg/tokens/collector_extra_test.go
+++ b/v2/pkg/tokens/collector_extra_test.go
@@ -260,3 +260,33 @@ func TestCollectFromDir_NilDetector(t *testing.T) {
 		t.Errorf("agent = %q, want unknown", agg.Sessions[0].Agent)
 	}
 }
+
+func TestCollector_ScanIncludesBob(t *testing.T) {
+	metricsDir := t.TempDir()
+	bobDir := t.TempDir()
+
+	// Create a bob chat session file.
+	chatDir := filepath.Join(bobDir, "tmp", "test-uuid", "chats")
+	if err := os.MkdirAll(chatDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessJSON := `{"id":"s1","model":"granite","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello","usage":{"input_tokens":50,"output_tokens":30}}]}`
+	if err := os.WriteFile(filepath.Join(chatDir, "s.json"), []byte(sessJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector(metricsDir, testLogger())
+	c.SetBobSessionsDir(bobDir)
+	c.scan()
+
+	summary := c.Summary()
+	if summary == nil {
+		t.Fatal("summary is nil after scan")
+	}
+	if summary.TotalTokens != 80 {
+		t.Errorf("TotalTokens = %d, want 80", summary.TotalTokens)
+	}
+	if summary.ByAgent["bob"] != 80 {
+		t.Errorf("ByAgent[bob] = %d, want 80", summary.ByAgent["bob"])
+	}
+}


### PR DESCRIPTION
Bob (bobshell) agents talk directly to IBM's backend without going through the inference proxy, so their token usage was never recorded by the token collector. This caused two symptoms reported in #3537:

1. The budget panel showed zero tokens consumed even though the external IBM-side budget was exhausted.
2. The weekly token limit was never enforced because `CurrentSpend` stayed at 0, so `budgetExhausted()` never triggered.

**Root cause**: `v2/cmd/hive/main.go:1523-1525` wires only Claude and Copilot session dirs into the collector. Bob is absent. Since Bob does not go through the inference proxy (it runs interactively in tmux talking directly to IBM), the `InferenceSink` never records its usage either. Result: Bob's tokens are invisible to the budget system.

**Fix**: Add a `bob_scanner.go` that reads bobshell's chat recording files from `$HOME/.bob/tmp/<uuid>/chats/*.json`, extracts token usage (with character-length estimation as fallback), and feeds it into the collector→governor budget pipeline via `SetBobSessionsDir`.

**Evidence**:
- `v2/pkg/tokens/collector.go:78` — new `bobSessionsDir` field
- `v2/pkg/tokens/collector.go:187-194` — bob scan in the `scan()` loop  
- `v2/pkg/config/config.go:2317` — `BobSessionsDir` config field
- `v2/pkg/config/config.go:2769-2770` — default `/data/home/.bob`
- `v2/cmd/hive/main.go:1526` — `SetBobSessionsDir` wiring

**Enforcement was already present** at `governor.go:474` (`budgetExhausted()`) and `governor.go:503-505` (kick suppression). The only missing piece was the data feed.

Closes #3537