### PR TITLE
🔒 fix: port F11 OAuth state nonce and F4 exact-origin CSRF to v2

### DIFF
--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -238,7 +238,7 @@ const forgeSwitchNeedsInstallNote = "installation_id was cleared because it belo
 // channel for this, already implemented on both ends.
 func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/v2/pkg/hub/hub_misc_coverage_test.go
+++ b/v2/pkg/hub/hub_misc_coverage_test.go
@@ -297,7 +297,9 @@ func TestBulkHandlerPreflightOnlyTrustsKnownOrigins(t *testing.T) {
 
 	trusted := []string{
 		"https://hive.kubestellar.io",
-		"https://console.hive.kubestellar.io",
+		// F4: "https://console.hive.kubestellar.io" was here and is now
+		// deliberately absent — a sibling tenant must NOT receive a
+		// credentialed CORS reflection. See the untrusted list below.
 		"http://localhost:5174",
 		"http://127.0.0.1:8080",
 	}

--- a/v2/pkg/hub/hub_saas_handlers_test.go
+++ b/v2/pkg/hub/hub_saas_handlers_test.go
@@ -912,24 +912,54 @@ func TestGetAuthUserBearer(t *testing.T) {
 	ghTokenCacheMu.Unlock()
 }
 
-func TestIsTrustedOriginSubdomain(t *testing.T) {
-	if !isTrustedOrigin("https://dashboard.hive.kubestellar.io") {
-		t.Error("subdomain of hive.kubestellar.io should be trusted")
+// CORRECTED (audit F4). This test used to assert that any
+// *.hive.kubestellar.io sibling "should be trusted" — i.e. it encoded the
+// vulnerability as a passing assertion, which is why the finding stayed green
+// for so long. Authoring authority is now the exact hub origin only.
+func TestIsSameOriginAsHub(t *testing.T) {
+	if !isSameOriginAsHub("https://hive.kubestellar.io") {
+		t.Error("the hub's own origin must be able to author requests")
 	}
-	if !isTrustedOrigin("https://my-hive.hive.kubestellar.io") {
-		t.Error("any subdomain of hive.kubestellar.io should be trusted")
+	if isSameOriginAsHub("https://dashboard.hive.kubestellar.io") {
+		t.Error("F4: a sibling tenant origin must NOT be able to author requests")
 	}
-	if !isTrustedOrigin("http://localhost:3001") {
-		t.Error("localhost should be trusted")
+	if isSameOriginAsHub("https://my-hive.hive.kubestellar.io") {
+		t.Error("F4: a sibling tenant origin must NOT be able to author requests")
 	}
-	if !isTrustedOrigin("http://127.0.0.1:8080") {
-		t.Error("127.0.0.1 should be trusted")
+	// Local development has no hostile sibling.
+	if !isSameOriginAsHub("http://localhost:3001") {
+		t.Error("localhost should be able to author requests")
+	}
+	if !isSameOriginAsHub("http://127.0.0.1:8080") {
+		t.Error("127.0.0.1 should be able to author requests")
 	}
 }
 
-func TestIsTrustedOriginBadParse(t *testing.T) {
-	if isTrustedOrigin("://invalid") {
-		t.Error("unparseable URL should not be trusted")
+// Sending a BROWSER to a sibling is still correct and is load-bearing: every
+// hosted hive's ingress carries auth-signin=.../login?redirect=<its own host>,
+// so rejecting siblings here would break sign-in fleet-wide.
+func TestIsTrustedRedirectTarget(t *testing.T) {
+	for _, ok := range []string{
+		"https://hive.kubestellar.io",
+		"https://dashboard.hive.kubestellar.io",
+		"https://my-hive.hive.kubestellar.io",
+		"http://localhost:3001",
+	} {
+		if !isTrustedRedirectTarget(ok) {
+			t.Errorf("%q must remain a valid redirect target — sign-in depends on it", ok)
+		}
+	}
+	if isTrustedRedirectTarget("https://evil.example.com") {
+		t.Error("an unrelated domain must not be a redirect target")
+	}
+}
+
+func TestOriginPredicatesBadParse(t *testing.T) {
+	if isSameOriginAsHub("://invalid") {
+		t.Error("unparseable URL must not be able to author requests")
+	}
+	if isTrustedRedirectTarget("://invalid") {
+		t.Error("unparseable URL must not be a redirect target")
 	}
 }
 

--- a/v2/pkg/hub/hub_test.go
+++ b/v2/pkg/hub/hub_test.go
@@ -9,7 +9,37 @@ import (
 	"testing"
 )
 
-func TestIsTrustedOrigin(t *testing.T) {
+// SPLIT (audit F4). The old single table asserted that sibling tenants were
+// trusted, which conflated "may AUTHOR a request" with "may we SEND a browser
+// here". The two entries that changed answer are the two sibling hosts.
+func TestIsSameOriginAsHub_Table(t *testing.T) {
+	tests := []struct {
+		origin string
+		want   bool
+	}{
+		{"https://hive.kubestellar.io", true},
+		// F4: siblings may NOT author requests against the hub.
+		{"https://hosted-test.hive.kubestellar.io", false},
+		{"https://my.hosted.hive.kubestellar.io", false},
+		{"http://localhost", true},
+		{"http://127.0.0.1", true},
+		{"https://evil.com", false},
+		{"https://hive.kubestellar.io.evil.com", false},
+		{"https://evil-hive.kubestellar.io", false},
+		{"", false},
+		{"not-a-url", false},
+		{"https://localhost.evil.com", false},
+	}
+	for _, tt := range tests {
+		if got := isSameOriginAsHub(tt.origin); got != tt.want {
+			t.Errorf("isSameOriginAsHub(%q) = %v, want %v", tt.origin, got, tt.want)
+		}
+	}
+}
+
+// Redirect targets keep the original (sibling-accepting) semantics — the fleet's
+// sign-in flow depends on it. Same table, original expectations.
+func TestIsTrustedRedirectTarget_Table(t *testing.T) {
 	tests := []struct {
 		origin string
 		want   bool
@@ -27,9 +57,8 @@ func TestIsTrustedOrigin(t *testing.T) {
 		{"https://localhost.evil.com", false},
 	}
 	for _, tt := range tests {
-		got := isTrustedOrigin(tt.origin)
-		if got != tt.want {
-			t.Errorf("isTrustedOrigin(%q) = %v, want %v", tt.origin, got, tt.want)
+		if got := isTrustedRedirectTarget(tt.origin); got != tt.want {
+			t.Errorf("isTrustedRedirectTarget(%q) = %v, want %v", tt.origin, got, tt.want)
 		}
 	}
 }

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -1,6 +1,9 @@
 package hub
 
 import (
+	cryptoRand "crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -167,11 +170,43 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		redirect = r.URL.Query().Get("rd")
 	}
 	if redirect != "" && (!strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//")) {
-		if !isTrustedOrigin(redirect) {
+		if !isTrustedRedirectTarget(redirect) {
 			redirect = "/dashboard"
 		}
 	}
-	state := url.QueryEscape(redirect)
+	// SECURITY (audit F11, CWE-352): bind this login to THIS browser.
+	//
+	// `state` used to be nothing but the redirect target, so it proved only that
+	// the callback carried a URL — never that this browser had actually STARTED
+	// a login. An attacker could complete an OAuth flow against their own GitHub
+	// account and hand the victim the resulting callback URL, logging the victim
+	// into the ATTACKER's account (login CSRF / session fixation); anything the
+	// victim then did landed in the attacker's account.
+	//
+	// Mint an unguessable nonce, set it in a short-lived host-scoped cookie, and
+	// carry it in state. The callback requires the two to match, so a state the
+	// victim's browser did not mint cannot be replayed against them. The
+	// redirect target rides along after the separator and is still validated on
+	// the way out — the open-redirect half was already handled and is unchanged.
+	nonce, err := oauthStateNonce()
+	if err != nil {
+		s.logger.Warn("OAuth: cannot mint login state nonce", "error", err)
+		http.Error(w, "login unavailable", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    nonce,
+		Path:     "/",
+		MaxAge:   int(oauthStateTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   true,
+		// Lax, not Strict: the callback arrives as a top-level GET redirect
+		// FROM github.com, and Strict would withhold the cookie on exactly that
+		// navigation and break every login.
+		SameSite: http.SameSiteLaxMode,
+	})
+	state := url.QueryEscape(nonce + oauthStateSeparator + redirect)
 	// An EMPTY scope is deliberate, not an omission. The hub only needs to know
 	// WHO is logging in: the callback reads GET /user for the login name and
 	// signs it into the session cookie. GitHub serves /user's public profile —
@@ -198,6 +233,24 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "missing code", http.StatusBadRequest)
 		return
 	}
+
+	// SECURITY (audit F11, CWE-352): verify the login started in THIS browser
+	// BEFORE exchanging the code or minting any session. A callback whose state
+	// does not match this browser's cookie is a login the victim never began —
+	// most likely an attacker replaying their own completed flow to log the
+	// victim into the attacker's account.
+	//
+	// Checked first, so a forged callback never reaches the token exchange:
+	// exchanging burns a real one-time code and touches the SaaS user record,
+	// neither of which should happen for a request we are about to reject.
+	if !s.verifyOAuthStateNonce(r) {
+		s.clearOAuthStateCookie(w)
+		s.logger.Warn("OAuth: rejected callback with missing or mismatched state nonce")
+		http.Error(w, "invalid login state — please start the login again", http.StatusBadRequest)
+		return
+	}
+	// Single-use: clear it now so a captured callback URL cannot be replayed.
+	s.clearOAuthStateCookie(w)
 
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
 	clientSecret := os.Getenv("HIVE_HUB_OAUTH_CLIENT_SECRET")
@@ -329,11 +382,13 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	saveSaaSUser(saasUser)
 
 	redirect := "/dashboard"
-	if state := r.URL.Query().Get("state"); state != "" {
-		if decoded, err := url.QueryUnescape(state); err == nil && decoded != "" {
-			if (strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedOrigin(decoded) {
-				redirect = decoded
-			}
+	if decoded, err := url.QueryUnescape(r.URL.Query().Get("state")); err == nil && decoded != "" {
+		// The nonce was already verified above; take only the redirect half.
+		if _, target, ok := strings.Cut(decoded, oauthStateSeparator); ok {
+			decoded = target
+		}
+		if decoded != "" && ((strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedRedirectTarget(decoded)) {
+			redirect = decoded
 		}
 	}
 	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
@@ -410,4 +465,69 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	})
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"ok":true}`))
+}
+
+const (
+	// oauthStateCookieName holds the per-login nonce that binds an OAuth
+	// callback to the browser that started it (audit F11). Host-scoped
+	// deliberately: unlike hive_hub_user it carries no Domain, so sibling
+	// tenants never receive it.
+	oauthStateCookieName = "hive_oauth_state"
+
+	// oauthStateSeparator splits the nonce from the redirect target inside the
+	// state parameter. ":" cannot appear in a nonce (hex) and any ":" in the
+	// redirect lands in the second half, which strings.Cut keeps intact.
+	oauthStateSeparator = ":"
+
+	// oauthStateTTL bounds how long a started login may sit unfinished. Long
+	// enough to authorize on GitHub (including a fresh GitHub login), short
+	// enough that a captured state is not indefinitely useful.
+	oauthStateTTL = 15 * time.Minute
+
+	// oauthStateNonceBytes is the entropy behind the nonce.
+	oauthStateNonceBytes = 32
+)
+
+// oauthStateNonce mints an unguessable login nonce.
+func oauthStateNonce() (string, error) {
+	buf := make([]byte, oauthStateNonceBytes)
+	if _, err := io.ReadFull(cryptoRand.Reader, buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// verifyOAuthStateNonce reports whether the callback's state carries the same
+// nonce this browser was issued at login.
+//
+// Fails CLOSED: a missing cookie, a missing or malformed state, or any mismatch
+// is a rejection. Compared in constant time — the nonce is a secret, and a
+// length-or-content leak would let an attacker narrow it by timing.
+func (s *HubServer) verifyOAuthStateNonce(r *http.Request) bool {
+	cookie, err := r.Cookie(oauthStateCookieName)
+	if err != nil || cookie.Value == "" {
+		return false
+	}
+	decoded, err := url.QueryUnescape(r.URL.Query().Get("state"))
+	if err != nil || decoded == "" {
+		return false
+	}
+	got, _, ok := strings.Cut(decoded, oauthStateSeparator)
+	if !ok || got == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(cookie.Value)) == 1
+}
+
+// clearOAuthStateCookie expires the login nonce, making it single-use.
+func (s *HubServer) clearOAuthStateCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -1,6 +1,8 @@
 package hub
 
 import (
+	"net/url"
+	"strings"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +35,7 @@ func TestHandleOAuthCallbackTokenExchangeFails(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc", nil)
+	req := newCallbackRequestWithState(t, "abc")
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("bad token json status = %d, want 502", rec.Code)
@@ -51,7 +53,7 @@ func TestHandleOAuthCallbackNoAccessToken_Cov(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc", nil)
+	req := newCallbackRequestWithState(t, "abc")
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("empty token status = %d, want 502", rec.Code)
@@ -80,7 +82,12 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	rec := httptest.NewRecorder()
 	// A safe relative redirect state should be honored.
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state=%2Fmy-hives", nil)
+	nonce, err := oauthStateNonce()
+	if err != nil {
+		t.Fatalf("mint nonce: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state="+url.QueryEscape(nonce+oauthStateSeparator+"/my-hives"), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("success status = %d, want 307 (body=%s)", rec.Code, rec.Body.String())
@@ -135,7 +142,7 @@ func TestHandleOAuthCallbackInvalidLogin(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default()}
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc", nil)
+	req := newCallbackRequestWithState(t, "abc")
 	s.handleOAuthCallback(rec, req)
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("invalid login status = %d, want 502", rec.Code)
@@ -304,5 +311,142 @@ func TestClusterNameForID_Cov(t *testing.T) {
 	}
 	if got := s.clusterNameForID("missing"); got != "" {
 		t.Errorf("unknown -> %q, want empty", got)
+	}
+}
+
+// newCallbackRequestWithState builds an OAuth callback carrying a matching state
+// nonce in both the query and the cookie — i.e. a login this browser genuinely
+// started (audit F11). Tests exercising the token-exchange path need this or
+// they are rejected at the state gate and never reach it.
+func newCallbackRequestWithState(t *testing.T, code string) *http.Request {
+	t.Helper()
+	nonce, err := oauthStateNonce()
+	if err != nil {
+		t.Fatalf("mint nonce: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code="+code+"&state="+url.QueryEscape(nonce+oauthStateSeparator+"/dashboard"), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+	return req
+}
+
+// Audit F11 (CWE-352) — ported from v4 (#3435). `state` used to be nothing but
+// the redirect target, so it proved only that the callback carried a URL, never
+// that this browser had STARTED a login.
+//
+// The attack: complete an OAuth flow against your own GitHub account, capture
+// the callback URL, hand it to a victim. Their browser completes it and they are
+// silently logged into the ATTACKER's account — every issue they file and repo
+// they connect afterwards lands there. Redirect validation does nothing about
+// it: the URL is valid; it is the SESSION that is forged.
+func TestF11_CallbackWithoutStateNonceIsRejected(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	var exchanged bool
+	tok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		exchanged = true
+		w.Write([]byte(`{"access_token":"gho_attacker"}`))
+	}))
+	defer tok.Close()
+	usr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"login":"attacker","avatar_url":"https://x/a.png"}`))
+	}))
+	defer usr.Close()
+	oldTok, oldUsr := defaultGHTokenURL, defaultGHUserURL
+	defaultGHTokenURL, defaultGHUserURL = tok.URL, usr.URL
+	defer func() { defaultGHTokenURL, defaultGHUserURL = oldTok, oldUsr }()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	rec := httptest.NewRecorder()
+	// The victim's browser holds NO state cookie: it never started this login.
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=attacker-code&state=%2Fdashboard", nil)
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code == http.StatusTemporaryRedirect {
+		t.Fatal("F11: a callback the browser never initiated completed a login — an attacker can log a victim into the attacker's account")
+	}
+	if exchanged {
+		t.Error("F11: the forged callback reached the token exchange; the state gate must reject it before burning a code")
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			t.Fatalf("F11: a session cookie was minted for a forged callback: %q", c.Value)
+		}
+	}
+}
+
+func TestF11_CallbackWithMismatchedStateNonceIsRejected(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state="+url.QueryEscape("attacker-nonce"+oauthStateSeparator+"/dashboard"), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: "victim-nonce"})
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code == http.StatusTemporaryRedirect {
+		t.Fatal("F11: a callback whose state did not match the browser's cookie completed a login")
+	}
+}
+
+// /login must actually issue the nonce — the callback gate is worth nothing if
+// the login side never mints one.
+func TestF11_LoginIssuesStateNonceCookieAndParameter(t *testing.T) {
+	t.Setenv("HIVE_HUB_OAUTH_CLIENT_ID", "test-client-id")
+	s := &HubServer{logger: slog.Default()}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/login?redirect=/my-hives", nil)
+	s.handleLogin(rec, req)
+
+	var nonce string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == oauthStateCookieName {
+			nonce = c.Value
+			if !c.HttpOnly || !c.Secure {
+				t.Error("F11: the state cookie must be HttpOnly and Secure")
+			}
+			if c.Domain != "" {
+				t.Errorf("F11: the state cookie must be host-scoped, got Domain=%q — a sibling tenant would receive it", c.Domain)
+			}
+		}
+	}
+	if nonce == "" {
+		t.Fatal("F11: /login issued no state nonce cookie, so the callback gate can never pass")
+	}
+
+	parsed, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	state := parsed.Query().Get("state")
+	if !strings.HasPrefix(state, nonce+oauthStateSeparator) {
+		t.Fatalf("F11: state %q does not carry the issued nonce", state)
+	}
+	if !strings.HasSuffix(state, "/my-hives") {
+		t.Errorf("F11: the redirect target was lost from state: %q", state)
+	}
+}
+
+// Audit F4 (CWE-352/942) — ported from v4 (#3499). A sibling tenant origin must
+// not be able to author a state change, and must not receive a credentialed
+// CORS reflection (which would be a scripted cross-tenant READ).
+func TestF4_SiblingOriginCannotAuthorMutation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/hives/x/visibility", nil)
+	req.Header.Set("Origin", "https://evil.hive.kubestellar.io")
+	req.Header.Set("Content-Type", "application/json")
+	if isCSRFSafe(req) {
+		t.Fatal("F4: a sibling tenant Origin was accepted as CSRF-safe — it can drive cross-tenant mutations")
+	}
+}
+
+// POSITIVE CONTROL: the hub's own origin must still be able to author, or the
+// fix is just a gate broken shut and every legitimate mutation breaks.
+func TestF4_HubOriginStillAuthorsMutation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/hives/x/visibility", nil)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	req.Header.Set("Content-Type", "application/json")
+	if !isCSRFSafe(req) {
+		t.Fatal("the hub's own origin must remain CSRF-safe — rejecting it breaks every legitimate mutation")
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -515,17 +515,52 @@ func isCSRFSafe(r *http.Request) bool {
 	}
 	origin := r.Header.Get("Origin")
 	if origin != "" {
-		return isTrustedOrigin(origin)
+		return isSameOriginAsHub(origin)
 	}
 	referer := r.Header.Get("Referer")
 	if referer != "" {
-		return isTrustedOrigin(referer)
+		return isSameOriginAsHub(referer)
 	}
 	ct := r.Header.Get("Content-Type")
 	return strings.Contains(ct, "application/json")
 }
 
-func isTrustedOrigin(raw string) bool {
+// isSameOriginAsHub reports whether raw is the hub's OWN origin — i.e. whether
+// a request claiming to come from it may AUTHOR a state change here.
+//
+// SECURITY (audit F4, CWE-352/942): this used to be isTrustedOrigin, which
+// accepted every *.hive.kubestellar.io sibling. That single predicate answered
+// two different questions, and conflating them was the bug:
+//
+//   "may this origin AUTHOR a request?"      → only the hub itself
+//   "may we SEND a browser here?"            → any hive's own domain
+//
+// Because every tenant is a sibling under the same parent domain, the permissive
+// answer let a hostile tenant both drive CSRF mutations and — via the
+// credentialed CORS reflection below — script a cross-tenant READ of the hub
+// API. Authoring authority is now the exact hub origin only.
+//
+// localhost/127.0.0.1 stay for local development, where there is no sibling to
+// be hostile.
+func isSameOriginAsHub(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "hive.kubestellar.io" ||
+		host == "localhost" ||
+		host == "127.0.0.1"
+}
+
+// isTrustedRedirectTarget reports whether we may send a BROWSER to raw.
+//
+// Siblings are still accepted here, and must be: every hosted hive's ingress
+// carries auth-signin=.../login?redirect=$scheme://$http_host$request_uri, so
+// tightening this lane would break sign-in for the entire fleet. Sending a
+// browser to a tenant's own domain grants that tenant nothing it does not
+// already have — unlike accepting a request it authored.
+func isTrustedRedirectTarget(raw string) bool {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return false
@@ -3504,7 +3539,7 @@ func (s *HubServer) handleHubSelfUpgrade(w http.ResponseWriter, r *http.Request)
 
 func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -3593,7 +3628,7 @@ func branchToTag(branch string) string {
 
 func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -3727,7 +3762,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 
 func (s *HubServer) handleToggleVisibility(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
@@ -3814,7 +3849,7 @@ const maxHiveDisplayNameLen = 100
 //     original label — a known, documented staleness, not a silent one.
 func (s *HubServer) handleRenameHive(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")
@@ -3916,7 +3951,7 @@ func (s *HubServer) pushVisibilityToSpoke(id string, isPublic bool) {
 
 func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, OPTIONS")

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -127,7 +127,7 @@ func authorizeBulkHive(id, username string) (*SaaSHive, string) {
 
 func (s *HubServer) handleBulkHiveAction(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/v2/pkg/hub/slack.go
+++ b/v2/pkg/hub/slack.go
@@ -345,7 +345,7 @@ func decodeSlackRequest(w http.ResponseWriter, r *http.Request) (slackSendReques
 // the caller should return.
 func slackPreflight(w http.ResponseWriter, r *http.Request) bool {
 	origin := r.Header.Get("Origin")
-	if isTrustedOrigin(origin) {
+	if isSameOriginAsHub(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")

--- a/v2/pkg/hub/slack_send_coverage_test.go
+++ b/v2/pkg/hub/slack_send_coverage_test.go
@@ -276,7 +276,8 @@ func TestSlackPreflightDoesNotReflectUntrustedOrigin(t *testing.T) {
 func TestSlackPreflightAllowsTrustedOrigins(t *testing.T) {
 	for _, origin := range []string{
 		"https://hive.kubestellar.io",
-		"https://my-hive.hive.kubestellar.io",
+		// F4: "https://my-hive.hive.kubestellar.io" removed — a sibling tenant
+		// must NOT receive a credentialed CORS reflection.
 		"http://localhost:5174",
 	} {
 		rec := httptest.NewRecorder()
@@ -360,5 +361,20 @@ func TestRequireSlackTokenReturnsTrimmedToken(t *testing.T) {
 	}
 	if rec.Code != http.StatusOK {
 		t.Errorf("a configured hub must not write an error status, got %d", rec.Code)
+	}
+}
+
+// F4 (CWE-942): a sibling tenant origin must be REFUSED the credentialed CORS
+// reflection. Reflecting it with Allow-Credentials gave a hostile tenant a
+// scripted cross-tenant READ of the hub API.
+func TestF4_SlackPreflightRefusesSiblingOrigin(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("Origin", "https://evil.hive.kubestellar.io")
+
+	slackPreflight(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("F4: sibling origin was reflected for credentialed CORS: %q", got)
 	}
 }


### PR DESCRIPTION
## Why v2

The **production hub is built from `v2`** (`hive-hub:62089e9`, verified an ancestor of `origin/v2` and not of `origin/v4`). Both of these are hub-side findings, so fixing them on v4 alone left them live where they actually matter. Neither needs spoke coordination — they take effect as soon as the hub rolls.

## F11 (CWE-352) — login CSRF

`state` was the redirect target and nothing else, so it proved only that the callback carried a URL — never that **this browser started a login**.

The attack: complete an OAuth flow against your own GitHub account, capture the callback URL, get a victim to visit it. They're silently logged into the **attacker's** account, and everything they do afterwards lands there. The redirect validation already present does nothing — the URL is valid; it's the *session* that's forged.

`/login` now mints an unguessable nonce in a short-lived **HttpOnly, Secure, host-scoped** cookie and carries it in `state`. The callback requires both to match — **checked before the token exchange**, so a forged callback never burns a real one-time code or touches the SaaS user record. Constant-time compare, single-use, fails closed.

`SameSite=Lax`, not `Strict`: the callback is a top-level GET redirect *from github.com*, and `Strict` would withhold the cookie on exactly that navigation and break every login.

## F4 (CWE-352/942) — sibling-origin CSRF and CORS

`isTrustedOrigin` accepted every `*.hive.kubestellar.io` sibling, answering two different questions with one predicate. Split:

| predicate | question | siblings? |
|---|---|---|
| `isSameOriginAsHub` | may this origin **author** a request? | **no** |
| `isTrustedRedirectTarget` | may we **send a browser** here? | yes |

The first now gates `isCSRFSafe` (both `Origin` and `Referer`) and **all seven credentialed CORS reflections** (`saas.go` ×3, `forge.go`, `saas_bulk.go`, `slack.go`).

The CORS half isn't in the finding text but is equally serious: the same predicate decided whether to reflect `Access-Control-Allow-Origin` **with `Allow-Credentials`** — so a hostile tenant also had a scripted cross-tenant *read* of the hub API.

**The sibling redirect lane is load-bearing and deliberately unchanged.** Every hosted hive's ingress carries `auth-signin=.../login?redirect=<its own host>` — 17 confirmed live. Narrowing that would break sign-in fleet-wide. That's why this is a split rather than one tightened predicate.

## ⚠️ Four pre-existing tests asserted the vulnerability

All four were **green the entire time the finding was live**:

| test | asserted |
|---|---|
| `TestIsTrustedOriginSubdomain` | *"any subdomain of hive.kubestellar.io should be trusted"* |
| `TestIsTrustedOrigin` (table) | two sibling hosts expected `true` |
| `TestBulkHandlerPreflightOnlyTrustsKnownOrigins` | sibling in the trusted list |
| `TestSlackPreflightAllowsTrustedOrigins` | sibling in the trusted list |

Each is now split or narrowed to assert the corrected boundary, and the sibling cases are moved into **explicit rejection assertions** so the fix can't later look like a regression and get reverted. The redirect-target table keeps the original sibling-accepting expectations, since that behaviour is still correct.

## About the three modified OAuth tests

`TestHandleOAuthCallback{TokenExchangeFails,NoAccessToken_Cov,Success}` sent callbacks with no state and asserted on results from the token exchange. They now stop at the state gate — **that is the fix working**, not a test bent to fit. They carry a valid nonce now and still test what they were written to test, including the redirect-preservation assertion.

## Verification

- **Baseline on clean `origin/v2`**: `pkg/hub` → **0 failures**
- **After**: `pkg/hub` → **0 failures**, identical
- `go build ./...` and `go vet ./pkg/hub/` clean

Both regressions **fail against the unfixed code**:

```
--- FAIL: TestF11_CallbackWithoutStateNonceIsRejected
    F11: a callback the browser never initiated completed a login —
         an attacker can log a victim into the attacker's account
--- FAIL: TestF4_SiblingOriginCannotAuthorMutation
    F4: a sibling tenant Origin was accepted as CSRF-safe —
        it can drive cross-tenant mutations
```

The F11 test also asserts the forged callback never reaches the token exchange and no session cookie is minted, so it fails if the request is rejected too *late* rather than only if it's accepted. Positive controls confirm the hub's own origin still authors mutations and `/login` still issues the nonce — a gate broken shut would not satisfy them.