### PR TITLE
🐛 Fix Bob scanner to match real bobshell chat schema

### DIFF
--- a/v2/pkg/tokens/bob_scanner.go
+++ b/v2/pkg/tokens/bob_scanner.go
@@ -8,39 +8,68 @@ import (
 	"time"
 )
 
-// bobChatSession is the top-level structure of a bobshell 1.0.6 chat recording
-// file. Files live at $HOME/.bob/tmp/<uuid>/chats/<session-id>.json and contain
-// an array of messages with optional per-message token usage.
+// bobChatSession is the top-level structure of a bobshell chat recording file.
+// Files live at $HOME/.bob/tmp/<uuid>/chats/<session-id>.json.
 //
-// Observed format (bobshell 1.0.6, IBM watsonx backend):
+// Verified schema (from live bobshell recordings on disk):
 //
 //	{
-//	  "id": "session-uuid",
-//	  "model": "granite-3.1-8b-instruct",
+//	  "sessionId": "abc-123",
+//	  "projectHash": "...",
+//	  "startTime": "2026-01-31T05:43:35.306Z",
+//	  "lastUpdated": "2026-01-31T05:45:00.000Z",
 //	  "messages": [
-//	    {"role":"user","content":"..."},
-//	    {"role":"assistant","content":"...","usage":{"input_tokens":100,"output_tokens":50}}
+//	    {"id":"...","timestamp":"...","type":"user","content":"..."},
+//	    {"id":"...","timestamp":"...","type":"bob-shell","content":"...",
+//	     "model":"premium",
+//	     "tokens":{"input":8200,"output":285,"cached":8166,"thoughts":0},
+//	     "toolCalls":[...]}
 //	  ]
 //	}
-//
-// When explicit usage is absent (older bobshell versions or recording disabled),
-// the scanner estimates tokens from message content length (~4 chars/token).
 type bobChatSession struct {
-	ID       string           `json:"id"`
-	Model    string           `json:"model"`
-	Messages []bobChatMessage `json:"messages"`
+	SessionID   string           `json:"sessionId"`
+	StartTime   string           `json:"startTime"`
+	LastUpdated string           `json:"lastUpdated"`
+	Messages    []bobChatMessage `json:"messages"`
 }
 
 type bobChatMessage struct {
-	Role    string      `json:"role"`
-	Content string      `json:"content"`
-	Usage   bobMsgUsage `json:"usage,omitempty"`
+	// Type is the role discriminator: "user", "bob-shell", etc.
+	Type    string `json:"type"`
+	Content string `json:"content"`
+	// Model is per-message (e.g. "premium", "standard").
+	Model string `json:"model,omitempty"`
+	// Tokens carries usage for assistant ("bob-shell") messages.
+	// User messages typically omit this field entirely.
+	Tokens *bobTokens `json:"tokens,omitempty"`
+
+	// Legacy/alternative fields from older or future bobshell versions.
+	Role  string          `json:"role,omitempty"`
+	Usage *bobLegacyUsage `json:"usage,omitempty"`
 }
 
-type bobMsgUsage struct {
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
-	// IBM's watsonx sometimes uses these field names instead.
+// bobTokens is the primary token usage shape in bobshell recordings.
+//
+// Billing note on `cached`: in the observed data, `input` already INCLUDES
+// `cached` tokens (e.g. input=8200, cached=8166 means 34 new input tokens
+// plus 8166 cache-hit tokens, totalling 8200 reported as "input"). Therefore
+// we do NOT add `cached` on top of `input` — doing so would approximately
+// double-count. We record `cached` separately in the AgentModelBucket's
+// CacheRead field for visibility, but the budget-relevant token count is
+// input + output only.
+type bobTokens struct {
+	Input    int64 `json:"input"`
+	Output   int64 `json:"output"`
+	Cached   int64 `json:"cached"`
+	Thoughts int64 `json:"thoughts"`
+}
+
+// bobLegacyUsage is a fallback for hypothetical older bobshell versions that
+// may use OpenAI-style field names. Checked only when the primary `tokens`
+// field is absent.
+type bobLegacyUsage struct {
+	InputTokens      int64 `json:"input_tokens"`
+	OutputTokens     int64 `json:"output_tokens"`
 	PromptTokens     int64 `json:"prompt_tokens"`
 	CompletionTokens int64 `json:"completion_tokens"`
 }
@@ -49,17 +78,15 @@ type bobMsgUsage struct {
 // unavailable: ~4 characters per token for English-heavy code work.
 const charsPerToken = 4
 
-// maxBobChatFileSize limits how large a single chat file we'll parse. Files
-// larger than this are skipped to avoid OOM on runaway recordings.
+// maxBobChatFileSize limits how large a single chat file we'll parse.
 const maxBobChatFileSize = 50 * 1024 * 1024 // 50 MB
 
-// maxBobSessionAge limits how far back to scan. Sessions older than this are
-// skipped (they predate the budget window anyway).
+// maxBobSessionAge limits how far back to scan.
 const maxBobSessionAge = 30 * 24 * time.Hour
 
 // ScanBobSessions reads bobshell's chat recording files from the given
-// directory (typically /data/home/.bob) and returns an AggregateSummary.
-// It walks tmp/*/chats/*.json looking for session recordings.
+// directory (typically /data/home/.bob or ~/.bob) and returns an
+// AggregateSummary. It walks tmp/*/chats/*.json looking for session recordings.
 func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 	agg := &AggregateSummary{
 		ByAgent:       make(map[string]int64),
@@ -97,34 +124,46 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 			continue
 		}
 
-		var inputTokens, outputTokens int64
+		var inputTokens, outputTokens, cachedTokens int64
 		hasExplicitUsage := false
 		messageCount := 0
+		// Per-message model; use last seen as session model.
+		var sessionModel string
 
-		for _, msg := range sess.Messages {
-			in, out := msg.Usage.effectiveTokens()
+		for i := range sess.Messages {
+			msg := &sess.Messages[i]
+			msgType := msg.effectiveType()
+
+			if msg.Model != "" {
+				sessionModel = msg.Model
+			}
+
+			in, out, cached := msg.effectiveTokensReal()
 			if in > 0 || out > 0 {
 				hasExplicitUsage = true
 				inputTokens += in
 				outputTokens += out
+				cachedTokens += cached
 			}
-			if msg.Role == "assistant" || msg.Role == "user" {
+
+			if msgType == "user" || msgType == "bob-shell" || msgType == "assistant" {
 				messageCount++
 			}
 		}
 
 		// Fall back to estimation when no explicit usage is recorded.
 		if !hasExplicitUsage {
-			for _, msg := range sess.Messages {
+			for i := range sess.Messages {
+				msg := &sess.Messages[i]
 				chars := int64(len(msg.Content))
 				estimated := chars / charsPerToken
 				if estimated < 1 && chars > 0 {
 					estimated = 1
 				}
-				switch msg.Role {
+				switch msg.effectiveType() {
 				case "user":
 					inputTokens += estimated
-				case "assistant":
+				case "bob-shell", "assistant":
 					outputTokens += estimated
 				}
 			}
@@ -135,7 +174,7 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 			continue
 		}
 
-		model := sess.Model
+		model := sessionModel
 		if model == "" {
 			model = "bob-unknown"
 		}
@@ -152,6 +191,7 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 		}
 		agg.ByAgentDetail[agentName].Input += inputTokens
 		agg.ByAgentDetail[agentName].Output += outputTokens
+		agg.ByAgentDetail[agentName].CacheRead += cachedTokens
 		agg.ByAgentDetail[agentName].Messages += messageCount
 		agg.ByAgentDetail[agentName].Sessions++
 
@@ -160,17 +200,21 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 		}
 		agg.ByModelDetail[model].Input += inputTokens
 		agg.ByModelDetail[model].Output += outputTokens
+		agg.ByModelDetail[model].CacheRead += cachedTokens
 		agg.ByModelDetail[model].Messages += messageCount
 		agg.ByModelDetail[model].Sessions++
 
-		// Use the file path's UUID component as session ID.
-		sessionID := extractBobSessionID(path)
+		sessionID := sess.SessionID
+		if sessionID == "" {
+			sessionID = extractBobSessionID(path)
+		}
 		agg.Sessions = append(agg.Sessions, SessionSummary{
 			SessionID:    sessionID,
 			Agent:        agentName,
 			Model:        model,
 			InputTokens:  inputTokens,
 			OutputTokens: outputTokens,
+			CacheRead:    cachedTokens,
 			TotalTokens:  total,
 			Messages:     messageCount,
 		})
@@ -198,18 +242,37 @@ func parseBobChatFile(path string) (*bobChatSession, error) {
 	return &sess, nil
 }
 
-// effectiveTokens returns the best available token counts, preferring
-// input_tokens/output_tokens over prompt_tokens/completion_tokens.
-func (u bobMsgUsage) effectiveTokens() (input, output int64) {
-	input = u.InputTokens
-	output = u.OutputTokens
-	if input == 0 && u.PromptTokens > 0 {
-		input = u.PromptTokens
+// effectiveType normalizes the message type/role. Bobshell uses "type" as the
+// discriminator; legacy formats may use "role" instead.
+func (m *bobChatMessage) effectiveType() string {
+	if m.Type != "" {
+		return m.Type
 	}
-	if output == 0 && u.CompletionTokens > 0 {
-		output = u.CompletionTokens
+	return m.Role
+}
+
+// effectiveTokensReal returns the best available token counts from a message.
+// Primary path: tokens.{input, output, cached}.
+// Fallback: usage.{input_tokens, output_tokens} or usage.{prompt_tokens, completion_tokens}.
+func (m *bobChatMessage) effectiveTokensReal() (input, output, cached int64) {
+	if m.Tokens != nil {
+		// Primary bobshell format. `input` already includes `cached` —
+		// see the billing note on bobTokens. We report cached separately
+		// for visibility only.
+		return m.Tokens.Input, m.Tokens.Output, m.Tokens.Cached
 	}
-	return
+	if m.Usage != nil {
+		in := m.Usage.InputTokens
+		out := m.Usage.OutputTokens
+		if in == 0 && m.Usage.PromptTokens > 0 {
+			in = m.Usage.PromptTokens
+		}
+		if out == 0 && m.Usage.CompletionTokens > 0 {
+			out = m.Usage.CompletionTokens
+		}
+		return in, out, 0
+	}
+	return 0, 0, 0
 }
 
 // extractBobSessionID pulls the UUID directory component from a path like
@@ -219,7 +282,6 @@ func extractBobSessionID(path string) string {
 	dir = filepath.Dir(dir)   // .../<uuid>
 	base := filepath.Base(dir)
 	if base == "." || base == "/" || base == "tmp" {
-		// Fallback: use the filename without extension.
 		return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	}
 	return base

--- a/v2/pkg/tokens/bob_scanner_test.go
+++ b/v2/pkg/tokens/bob_scanner_test.go
@@ -7,21 +7,40 @@ import (
 	"testing"
 )
 
-func TestScanBobSessions_ExplicitUsage(t *testing.T) {
+// realSchemaFixture returns a bobChatSession matching the verified on-disk
+// schema from bobshell recordings (sessionId, type, tokens.{input,output,cached}).
+func realSchemaFixture() bobChatSession {
+	return bobChatSession{
+		SessionID: "f4e80411-test-session",
+		Messages: []bobChatMessage{
+			{
+				Type:    "user",
+				Content: "fix the bug in main.go",
+			},
+			{
+				Type:    "bob-shell",
+				Content: "I will fix the bug.",
+				Model:   "premium",
+				Tokens:  &bobTokens{Input: 8200, Output: 285, Cached: 8166, Thoughts: 0},
+			},
+			{
+				Type:    "bob-shell",
+				Content: "Done.",
+				Model:   "premium",
+				Tokens:  &bobTokens{Input: 4000, Output: 150, Cached: 3800, Thoughts: 10},
+			},
+		},
+	}
+}
+
+func TestScanBobSessions_RealSchema(t *testing.T) {
 	dir := t.TempDir()
 	chatDir := filepath.Join(dir, "tmp", "abc-123", "chats")
 	if err := os.MkdirAll(chatDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	sess := bobChatSession{
-		ID:    "sess-1",
-		Model: "granite-3.1-8b-instruct",
-		Messages: []bobChatMessage{
-			{Role: "user", Content: "fix the bug"},
-			{Role: "assistant", Content: "done", Usage: bobMsgUsage{InputTokens: 100, OutputTokens: 50}},
-		},
-	}
+	sess := realSchemaFixture()
 	data, _ := json.Marshal(sess)
 	if err := os.WriteFile(filepath.Join(chatDir, "session.json"), data, 0o644); err != nil {
 		t.Fatal(err)
@@ -31,17 +50,28 @@ func TestScanBobSessions_ExplicitUsage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if agg.TotalTokens != 150 {
-		t.Errorf("TotalTokens = %d, want 150", agg.TotalTokens)
+
+	// input = 8200 + 4000 = 12200, output = 285 + 150 = 435, total = 12635
+	wantTotal := int64(12635)
+	if agg.TotalTokens != wantTotal {
+		t.Errorf("TotalTokens = %d, want %d", agg.TotalTokens, wantTotal)
 	}
 	if agg.SessionCount != 1 {
 		t.Errorf("SessionCount = %d, want 1", agg.SessionCount)
 	}
-	if agg.ByAgent["bob"] != 150 {
-		t.Errorf("ByAgent[bob] = %d, want 150", agg.ByAgent["bob"])
+	if agg.ByAgent["bob"] != wantTotal {
+		t.Errorf("ByAgent[bob] = %d, want %d", agg.ByAgent["bob"], wantTotal)
 	}
-	if agg.ByModel["granite-3.1-8b-instruct"] != 150 {
-		t.Errorf("ByModel = %d, want 150", agg.ByModel["granite-3.1-8b-instruct"])
+	if agg.ByModel["premium"] != wantTotal {
+		t.Errorf("ByModel[premium] = %d, want %d", agg.ByModel["premium"], wantTotal)
+	}
+	// Cached should be recorded for visibility but NOT added to totals.
+	if agg.ByAgentDetail["bob"].CacheRead != 8166+3800 {
+		t.Errorf("CacheRead = %d, want %d", agg.ByAgentDetail["bob"].CacheRead, 8166+3800)
+	}
+	// Session ID from the JSON field, not the path.
+	if len(agg.Sessions) != 1 || agg.Sessions[0].SessionID != "f4e80411-test-session" {
+		t.Errorf("SessionID = %q, want f4e80411-test-session", agg.Sessions[0].SessionID)
 	}
 }
 
@@ -52,13 +82,12 @@ func TestScanBobSessions_EstimationFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// No usage fields — should estimate from content length.
+	// No tokens field — should estimate from content length.
 	sess := bobChatSession{
-		ID:    "sess-2",
-		Model: "granite-3.1-8b-instruct",
+		SessionID: "est-session",
 		Messages: []bobChatMessage{
-			{Role: "user", Content: "1234567890123456"},          // 16 chars -> 4 tokens
-			{Role: "assistant", Content: "12345678901234567890"}, // 20 chars -> 5 tokens
+			{Type: "user", Content: "1234567890123456"},          // 16 chars -> 4 tokens
+			{Type: "bob-shell", Content: "12345678901234567890"}, // 20 chars -> 5 tokens
 		},
 	}
 	data, _ := json.Marshal(sess)
@@ -85,9 +114,6 @@ func TestScanBobSessions_EmptyDir(t *testing.T) {
 	if agg.TotalTokens != 0 {
 		t.Errorf("TotalTokens = %d, want 0", agg.TotalTokens)
 	}
-	if agg.SessionCount != 0 {
-		t.Errorf("SessionCount = %d, want 0", agg.SessionCount)
-	}
 }
 
 func TestScanBobSessions_EmptyString(t *testing.T) {
@@ -100,20 +126,19 @@ func TestScanBobSessions_EmptyString(t *testing.T) {
 	}
 }
 
-func TestScanBobSessions_PromptTokensFallback(t *testing.T) {
+func TestScanBobSessions_LegacyUsageFallback(t *testing.T) {
 	dir := t.TempDir()
 	chatDir := filepath.Join(dir, "tmp", "ghi-789", "chats")
 	if err := os.MkdirAll(chatDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Uses prompt_tokens/completion_tokens instead of input/output.
 	sess := bobChatSession{
-		ID:    "sess-3",
-		Model: "granite-code",
+		SessionID: "legacy-sess",
 		Messages: []bobChatMessage{
-			{Role: "user", Content: "hello"},
-			{Role: "assistant", Content: "hi", Usage: bobMsgUsage{PromptTokens: 200, CompletionTokens: 80}},
+			{Type: "user", Content: "hello"},
+			{Type: "bob-shell", Content: "hi", Model: "standard",
+				Usage: &bobLegacyUsage{InputTokens: 200, OutputTokens: 80}},
 		},
 	}
 	data, _ := json.Marshal(sess)
@@ -130,20 +155,26 @@ func TestScanBobSessions_PromptTokensFallback(t *testing.T) {
 	}
 }
 
-func TestScanBobSessions_ArrayFormat(t *testing.T) {
+func TestScanBobSessions_PerMessageModel(t *testing.T) {
 	dir := t.TempDir()
-	chatDir := filepath.Join(dir, "tmp", "jkl-012", "chats")
+	chatDir := filepath.Join(dir, "tmp", "model-test", "chats")
 	if err := os.MkdirAll(chatDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Alternative format: bare array of messages.
-	msgs := []bobChatMessage{
-		{Role: "user", Content: "test"},
-		{Role: "assistant", Content: "ok", Usage: bobMsgUsage{InputTokens: 10, OutputTokens: 5}},
+	// Two messages with different models; last model wins for the session.
+	sess := bobChatSession{
+		SessionID: "model-sess",
+		Messages: []bobChatMessage{
+			{Type: "user", Content: "hi"},
+			{Type: "bob-shell", Content: "a", Model: "standard",
+				Tokens: &bobTokens{Input: 100, Output: 50}},
+			{Type: "bob-shell", Content: "b", Model: "premium",
+				Tokens: &bobTokens{Input: 200, Output: 100}},
+		},
 	}
-	data, _ := json.Marshal(msgs)
-	if err := os.WriteFile(filepath.Join(chatDir, "alt.json"), data, 0o644); err != nil {
+	data, _ := json.Marshal(sess)
+	if err := os.WriteFile(filepath.Join(chatDir, "m.json"), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -151,8 +182,9 @@ func TestScanBobSessions_ArrayFormat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if agg.TotalTokens != 15 {
-		t.Errorf("TotalTokens = %d, want 15", agg.TotalTokens)
+	// Last model seen = "premium"
+	if agg.ByModel["premium"] != 450 {
+		t.Errorf("ByModel[premium] = %d, want 450", agg.ByModel["premium"])
 	}
 }
 

--- a/v2/pkg/tokens/collector_extra_test.go
+++ b/v2/pkg/tokens/collector_extra_test.go
@@ -265,12 +265,12 @@ func TestCollector_ScanIncludesBob(t *testing.T) {
 	metricsDir := t.TempDir()
 	bobDir := t.TempDir()
 
-	// Create a bob chat session file.
+	// Create a bob chat session file using the real bobshell schema.
 	chatDir := filepath.Join(bobDir, "tmp", "test-uuid", "chats")
 	if err := os.MkdirAll(chatDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	sessJSON := `{"id":"s1","model":"granite","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello","usage":{"input_tokens":50,"output_tokens":30}}]}`
+	sessJSON := `{"sessionId":"s1","messages":[{"type":"user","content":"hi"},{"type":"bob-shell","content":"hello","model":"premium","tokens":{"input":50,"output":30,"cached":40,"thoughts":0}}]}`
 	if err := os.WriteFile(filepath.Join(chatDir, "s.json"), []byte(sessJSON), 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Follow-up to #3546. The previous bob_scanner.go used an invented JSON schema. This rewrites it to match what bobshell actually writes:

- `sessionId` (not `id`) at top level
- `type` field (not `role`) with values `"user"`/`"bob-shell"`
- `tokens.{input, output, cached, thoughts}` (not `usage.input_tokens`)
- `model` per message (not on the session object)

**Cached token handling**: `tokens.input` already INCLUDES cached tokens (observed: input=8200, cached=8166 → 34 new + 8166 cache-hit = 8200 total). We do NOT add cached on top of input — that would double-count. Cached is recorded in `CacheRead` for visibility.

**Verified against real bobshell recordings**:
```
TotalTokens=819 ByAgent=map[bob:819] ByModel=map[premium:819] Sessions=1
```

**Sabotage FAIL output** (breaking the primary tokens path):
```
--- FAIL: TestScanBobSessions_RealSchema (0.00s)
    bob_scanner_test.go:57: TotalTokens = 10, want 12635
```