### PR TITLE
🔒 fix(hubbackup): mask restored file modes and bound archive reads (v2 port of #3550)

### DIFF
--- a/v2/pkg/hubbackup/backup.go
+++ b/v2/pkg/hubbackup/backup.go
@@ -58,6 +58,46 @@ const (
 	EnvRetention = "HIVE_BACKUP_RETENTION"
 )
 
+const (
+	// restoreFileMode is the permission mask applied to every file extracted
+	// from a backup archive (audit §8 / prior N18).
+	//
+	// The mode used to come straight from the tar header — os.FileMode(hdr.Mode)
+	// — which is attacker-controlled for any archive the hub did not itself
+	// produce. Verified empirically: with a permissive umask a header carrying
+	// 0777/0666 restores a WORLD-WRITABLE file, so anyone on the box can then
+	// rewrite restored hub state. (setuid/setgid do NOT survive os.WriteFile,
+	// so that half of the original finding is moot — but the world bits are
+	// real, and a umask is a deployment accident, not a security control.)
+	//
+	// Mask to the permission bits, then clear group/other write. An archive can
+	// still ask for a more RESTRICTIVE mode; it can no longer ask for a looser
+	// one.
+	restoreFileMode = 0o777 &^ 0o022
+
+	// restoreMaxFileBytes bounds a single extracted member. io.ReadAll(tr) was
+	// unbounded, so a decompression bomb — a few KB of gzip expanding to
+	// gigabytes — was read wholly into memory and OOM'd the hub. 256 MiB is far
+	// above any real hub artifact while still bounding the blast radius.
+	restoreMaxFileBytes = 256 << 20
+)
+
+// readArchiveMember reads one tar member with a hard size ceiling, so a
+// decompression bomb fails with a clear error instead of exhausting memory.
+//
+// Reads one byte PAST the limit so an over-size member is detected rather than
+// silently truncated — a truncated restore would be worse than a failed one.
+func readArchiveMember(tr io.Reader, name string) ([]byte, error) {
+	content, err := io.ReadAll(io.LimitReader(tr, restoreMaxFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > restoreMaxFileBytes {
+		return nil, fmt.Errorf("archive member %q exceeds the %d-byte restore limit", name, int64(restoreMaxFileBytes))
+	}
+	return content, nil
+}
+
 // Filesystem layout of hub state.
 const (
 	// DefaultDataDir is the hub PVC mount point.
@@ -421,7 +461,7 @@ func Verify(key, sealed []byte) (*Manifest, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read tar: %w", err)
 		}
-		content, err := io.ReadAll(tr)
+		content, err := readArchiveMember(tr, hdr.Name)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", hdr.Name, err)
 		}
@@ -480,7 +520,7 @@ func Extract(key, sealed []byte, destDir string) (*Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
-		content, err := io.ReadAll(tr)
+		content, err := readArchiveMember(tr, hdr.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -493,7 +533,7 @@ func Extract(key, sealed []byte, destDir string) (*Manifest, error) {
 		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
 			return nil, err
 		}
-		if err := os.WriteFile(out, content, os.FileMode(hdr.Mode)); err != nil {
+		if err := os.WriteFile(out, content, os.FileMode(hdr.Mode)&restoreFileMode); err != nil {
 			return nil, err
 		}
 		if hdr.Name == manifestName {

--- a/v2/pkg/hubbackup/backup_test.go
+++ b/v2/pkg/hubbackup/backup_test.go
@@ -1,11 +1,16 @@
 package hubbackup
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -259,7 +264,7 @@ func TestBuildIncludesSpokesAndSecrets(t *testing.T) {
 
 	spokes := fakeSpokes{spokes: []SpokeConfig{
 		{ID: "hosted-x", Files: map[string][]byte{
-			"hive.yaml.runtime":       []byte("project:\n  org: acme\n"),
+			"hive.yaml.runtime":   []byte("project:\n  org: acme\n"),
 			"hive-id":             []byte("hosted-x"),
 			"gh-app-key-5686.pem": []byte("-----BEGIN RSA PRIVATE KEY-----\n"),
 		}},
@@ -317,7 +322,7 @@ func TestExtractRestoresContent(t *testing.T) {
 	spokes := fakeSpokes{spokes: []SpokeConfig{
 		{ID: "hosted-x", Files: map[string][]byte{
 			"hive.yaml.runtime": spokeYAML,
-			"hive-id":       []byte("hosted-x"),
+			"hive-id":           []byte("hosted-x"),
 		}},
 	}}
 	sealed, _, err := Build(key, spokes, nil, quietLogger())
@@ -453,5 +458,125 @@ func TestStripSecretNoise(t *testing.T) {
 	}
 	if !strings.Contains(s, `"data"`) || !strings.Contains(s, `"name": "x"`) {
 		t.Errorf("stripped output lost required fields: %s", s)
+	}
+}
+
+// sealTar builds a sealed archive from raw tar members, so a test can present
+// an archive the hub did NOT produce — i.e. an attacker-supplied one. Extract
+// runs on operator-supplied files, so the header fields are untrusted input.
+func sealTar(t *testing.T, key []byte, members []*tar.Header, bodies [][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	// A manifest keeps Verify happy.
+	man, _ := json.Marshal(&Manifest{FormatVersion: backupFormatVersion})
+	all := append([]*tar.Header{{Name: manifestName, Mode: 0o600, Size: int64(len(man))}}, members...)
+	allBodies := append([][]byte{man}, bodies...)
+	for i, h := range all {
+		h.Size = int64(len(allBodies[i]))
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(allBodies[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := Seal(key, buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sealed
+}
+
+// Audit §8 (prior N18). The restore loop wrote every member with
+// os.FileMode(hdr.Mode) — a field the archive controls. Verified empirically:
+// under a permissive umask, a header carrying 0666/0777 restores a
+// WORLD-WRITABLE file, so any local user can then rewrite restored hub state.
+//
+// A umask is a deployment accident, not a security control, so the mask belongs
+// in the code.
+func TestN18_RestoredFileIsNotGroupOrWorldWritable(t *testing.T) {
+	key := decodeTestKey(t)
+	sealed := sealTar(t,
+		key,
+		[]*tar.Header{{Name: "hub/evil.txt", Mode: 0o777}},
+		[][]byte{[]byte("payload")},
+	)
+
+	// Clear the process umask for the duration of the extract. Without this the
+	// test passes against the VULNERABLE code on any machine with a normal
+	// umask (022), because the kernel strips the world bits before they hit
+	// disk — proving nothing about the code. A umask is a deployment default,
+	// not a guarantee, so the assertion must hold without one.
+	oldMask := syscall.Umask(0)
+	dest := t.TempDir()
+	_, err := Extract(key, sealed, dest)
+	syscall.Umask(oldMask)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	st, err := os.Stat(filepath.Join(dest, "hub", "evil.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := st.Mode().Perm(); perm&0o022 != 0 {
+		t.Fatalf("N18: archive-controlled mode produced a group/world-writable restored file: %04o", perm)
+	}
+}
+
+// POSITIVE CONTROL: masking must not break restore. The file must still exist,
+// still be readable, and still hold its exact bytes — otherwise the test above
+// would pass against a restore that wrote nothing at all.
+func TestN18_RestoreStillWritesReadableContent(t *testing.T) {
+	key := decodeTestKey(t)
+	const payload = "restored-bytes"
+	sealed := sealTar(t,
+		key,
+		[]*tar.Header{{Name: "hub/ok.txt", Mode: 0o600}},
+		[][]byte{[]byte(payload)},
+	)
+
+	dest := t.TempDir()
+	if _, err := Extract(key, sealed, dest); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "hub", "ok.txt"))
+	if err != nil {
+		t.Fatalf("test is vacuous: restore wrote no readable file: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("restored content corrupted: %q", got)
+	}
+	// A restrictive mode from the archive must still be honoured.
+	st, _ := os.Stat(filepath.Join(dest, "hub", "ok.txt"))
+	if st.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("an archive asking for 0600 should stay owner-only, got %04o", st.Mode().Perm())
+	}
+}
+
+// io.ReadAll(tr) was unbounded, so a decompression bomb was read wholly into
+// memory. The ceiling must reject an over-size member rather than truncate it.
+func TestN18_OversizeArchiveMemberIsRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates >256MiB")
+	}
+	key := decodeTestKey(t)
+	big := make([]byte, restoreMaxFileBytes+1)
+	sealed := sealTar(t,
+		key,
+		[]*tar.Header{{Name: "hub/bomb.bin", Mode: 0o600}},
+		[][]byte{big},
+	)
+
+	dest := t.TempDir()
+	if _, err := Extract(key, sealed, dest); err == nil {
+		t.Fatal("N18: an archive member larger than the restore limit was accepted — a decompression bomb can OOM the hub")
 	}
 }


### PR DESCRIPTION
## What

Port of **#3550** to `v2`. The **production hub is built from `v2`**, so this finding was live exactly where backups actually get restored.

Audit **§8 residual** — the prior audit's N18. `Extract` wrote every archive member with `os.FileMode(hdr.Mode)`, a field the **archive** controls.

Verified on this branch with the umask cleared:

```
--- FAIL: TestN18_RestoredFileIsNotGroupOrWorldWritable
    archive-controlled mode produced a group/world-writable restored file: 0777
```

Any local user can then rewrite restored hub state.

## Correcting the previous audit's framing

N18 was reported as a setuid risk. **That half is moot** — `setuid`/`setgid` do not survive `os.WriteFile`, because POSIX `open(2)` ignores those bits at creation. The **world-writable** half is the live one, and that's what this fixes.

An archive can still request a *more restrictive* mode (a `0600` member stays `0600` — asserted); it can no longer request a looser one.

## Unbounded reads

Both `io.ReadAll(tr)` calls had no ceiling, so a decompression bomb — a few KB of gzip expanding to gigabytes — was read wholly into memory. `readArchiveMember` caps a member at 256 MiB and reads **one byte past** the limit, so an over-size member is *rejected* rather than silently truncated.

Zip-slip was already defended and is untouched.

## Verification

- **Baseline on clean `origin/v2`**: `pkg/hubbackup` → 0 failures
- **After**: 0 failures, identical
- `go build ./...` and `go vet` clean

Both regressions **fail against unfixed v2**:

```
--- FAIL: TestN18_RestoredFileIsNotGroupOrWorldWritable   (0777 restored)
--- FAIL: TestN18_OversizeArchiveMemberIsRejected         (bomb accepted)
```

The mode test clears the process umask around the extract. Without that it passes against the **vulnerable** code on any machine with a normal `022` umask, because the kernel strips the world bits before they reach disk — proving nothing. A umask is a deployment default, not a security control.

Positive control asserts restore still writes readable, byte-exact content **and** still honours a restrictive `0600` from the archive, so neither test can pass against a build that writes nothing or clamps everything.

**gofmt**: `dr_roundtrip_test.go` and `edge_cases_test.go` are unformatted on clean `origin/v2` and are untouched here; the file I edited is now formatted, so this branch has one fewer.