### PR TITLE
🐛 fix(hub): block hive rename until assignment completes (prevents identity fork)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -532,8 +532,8 @@ func isCSRFSafe(r *http.Request) bool {
 // accepted every *.hive.kubestellar.io sibling. That single predicate answered
 // two different questions, and conflating them was the bug:
 //
-//   "may this origin AUTHOR a request?"      → only the hub itself
-//   "may we SEND a browser here?"            → any hive's own domain
+//	"may this origin AUTHOR a request?"      → only the hub itself
+//	"may we SEND a browser here?"            → any hive's own domain
 //
 // Because every tenant is a sibling under the same parent domain, the permissive
 // answer let a hostile tenant both drive CSRF mutations and — via the
@@ -3869,6 +3869,22 @@ func (s *HubServer) handleRenameHive(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.Owner != username && username != hubAdminUsername {
 		http.Error(w, `{"error":"only the owner can rename this hive"}`, http.StatusForbidden)
+		return
+	}
+
+	// Refuse a rename while an assignment is still in flight
+	// (assignmentInFlight: Status==statusAssigned && !ClaimDelivered). During
+	// that window the spoke pod is heartbeating under its baked HIVE_ID env
+	// (the slot id), while the claim that would carry the operator-set identity
+	// has not yet been delivered. Rewriting ProjectName now forks the hive's
+	// identity: the half-written renamed record is orphaned while the pod keeps
+	// reporting under the slot id, so the dashboard renders the hive as offline
+	// alongside a duplicate row. This is the only window that is unsafe — a
+	// fully-claimed hive (ClaimDelivered) and an available placeholder
+	// (statusAvailable) are both fine to rename, so only the in-flight window
+	// is blocked, with 409 Conflict.
+	if assignmentInFlight(h) {
+		http.Error(w, `{"error":"cannot rename while assignment is in progress — wait for the hive to finish provisioning, then rename"}`, http.StatusConflict)
 		return
 	}
 

--- a/v2/pkg/hub/saas_rename_hive_test.go
+++ b/v2/pkg/hub/saas_rename_hive_test.go
@@ -102,4 +102,32 @@ func TestHandleRenameHive(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("bad body status = %d, want 400", rec.Code)
 	}
+
+	// Assignment in flight (Status=assigned && !ClaimDelivered) -> 409, and the
+	// hive is NOT renamed on disk. Renaming during this window forks the hive's
+	// identity (pod heartbeats under the baked slot HIVE_ID while the renamed
+	// record is orphaned) -> offline + duplicate row.
+	saveSaaSHive(&SaaSHive{ID: "h7", Owner: "alice", ProjectName: "in-flight", Status: statusAssigned, ClaimDelivered: false})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{"project_name":"too-soon"}`, "alice"), "id", "h7")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("mid-assignment rename status = %d, want 409 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := loadSaaSHive("h7"); got == nil || got.ProjectName != "in-flight" {
+		t.Errorf("mid-assignment rename must not persist; got %+v", got)
+	}
+
+	// A fully-assigned, claim-delivered hive is a LIVE hive: rename still
+	// succeeds (the in-flight guard applies only to the unclaimed window).
+	saveSaaSHive(&SaaSHive{ID: "h8", Owner: "alice", ProjectName: "live-old", Status: statusAssigned, ClaimDelivered: true})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPut, "/name", `{"project_name":"live-new"}`, "alice"), "id", "h8")
+	s.handleRenameHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("claim-delivered rename status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := loadSaaSHive("h8"); got == nil || got.ProjectName != "live-new" {
+		t.Errorf("claim-delivered rename not persisted; got %+v", got)
+	}
 }


### PR DESCRIPTION
## The bug

Renaming a hive's vanity/project name in the hub spoke table **before its assignment completes** forks the hive's identity.

During the assignment window the spoke pod heartbeats under its **baked `HIVE_ID` env (the slot id)**, while the claim that carries the operator-set identity has not yet been delivered. If `handleRenameHive` rewrites `ProjectName` during this window:

- a half-written, renamed identity record gets **orphaned**, and
- the pod keeps reporting under the original slot id.

Result: the dashboard renders the hive as **offline** *and* shows a **duplicate row**.

The unsafe window is exactly `Status == statusAssigned && !ClaimDelivered` — the existing `assignmentInFlight(h)` predicate in `saas_reset_assignment.go`.

## The fix

Add a guard at the top of `handleRenameHive` (after `h` is resolved and the owner/admin auth check passes, before mutating `ProjectName`):

```go
if assignmentInFlight(h) {
    http.Error(w, `{"error":"cannot rename while assignment is in progress — wait for the hive to finish provisioning, then rename"}`, http.StatusConflict)
    return
}
```

Reuses the existing `assignmentInFlight` helper rather than mirroring the predicate. Matches the handler's existing `http.Error(w, ...JSON..., status)` error style.

Scope is deliberately narrow — **only** the in-flight window is blocked (409 Conflict):
- a fully-assigned, **claim-delivered** hive (a LIVE hive) still renames normally, and
- an **available placeholder** (`statusAvailable`) still renames normally.

## Tests

Added to `TestHandleRenameHive` (`saas_rename_hive_test.go`):
- `Status=assigned && !ClaimDelivered` rename → **409**, and the on-disk `ProjectName` is unchanged (positive control that the mutation did not happen).
- `Status=assigned && ClaimDelivered=true` (live hive) rename → **200**, new name persisted.

`go build ./pkg/hub/` OK. `go test ./pkg/hub/ -run 'Rename'` passes.