### PR TITLE
✨ feat(hub): hover tooltip on the hive status dot (namespace + status)

### DIFF
--- a/v2/pkg/hub/offline_dot_tooltip_test.go
+++ b/v2/pkg/hub/offline_dot_tooltip_test.go
@@ -1,0 +1,45 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOfflineStatusDotCarriesTooltip pins the native `title` tooltip on the
+// My Hives status dot in its OFFLINE state. The online dot has always carried a
+// rich hover via healthBadge() (status + ns: + heartbeat age), but the grey
+// offline dot rendered as a bare '<span class="online-dot off"></span>' with no
+// title at all — so an operator hovering a dead row could not even see which
+// Kubernetes namespace the hive runs in without cross-referencing the registry
+// by hand. This asserts the offline dot now builds a defensive title from the
+// same facts an operator needs to go find the hive on the cluster.
+//
+// String-anchored on the raw dashboardHTML, same as the other JS structure
+// tests (see TestDashboardHeartbeatHeartFlashesOnReceipt).
+func TestOfflineStatusDotCarriesTooltip(t *testing.T) {
+	// The offline dot span must now carry a title attribute (and a help cursor),
+	// no longer the bare untitled span.
+	if strings.Contains(dashboardHTML, `: '<span class="online-dot off"></span>');`) {
+		t.Error("offline status dot is still the bare untitled '<span class=\"online-dot off\"></span>' — it must carry a title tooltip")
+	}
+	if !strings.Contains(dashboardHTML, `'<span class="online-dot off" title="' + escAttr(offlineDotTitle) + '" style="cursor:help"></span>'`) {
+		t.Error("offline status dot lost its escAttr(offlineDotTitle) title attribute")
+	}
+
+	// The tooltip is built defensively: a status word, then the namespace,
+	// cluster and last-seen lines, each skipped when its field is empty.
+	for _, part := range []string{
+		`var offlineDotTitle = (function() {`,
+		`var parts = ['Offline'];`,
+		`var ns = hiveNamespace(h);`,
+		`if (ns) parts.push('ns: ' + ns);`,
+		`var cluster = h.clusterName || h.clusterId || '';`,
+		`if (cluster) parts.push('cluster: ' + cluster);`,
+		`if (h.lastHeartbeat) parts.push('last seen: ' + fmtUserTS(h.lastHeartbeat));`,
+		`return parts.join('\n');`,
+	} {
+		if !strings.Contains(dashboardHTML, part) {
+			t.Errorf("offline status dot tooltip is missing its %q builder line", part)
+		}
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -532,8 +532,8 @@ func isCSRFSafe(r *http.Request) bool {
 // accepted every *.hive.kubestellar.io sibling. That single predicate answered
 // two different questions, and conflating them was the bug:
 //
-//   "may this origin AUTHOR a request?"      → only the hub itself
-//   "may we SEND a browser here?"            → any hive's own domain
+//	"may this origin AUTHOR a request?"      → only the hub itself
+//	"may we SEND a browser here?"            → any hive's own domain
 //
 // Because every tenant is a sibling under the same parent domain, the permissive
 // answer let a hostile tenant both drive CSRF mutations and — via the
@@ -12882,9 +12882,25 @@ const dashboardHTML = `<!DOCTYPE html>
         // blue glowing/slow-blinking "upgrading" dot (see .online-dot.upgrading) —
         // it outranks the normal online/offline health dot so an upgrade reads at
         // a glance and is never mistaken for the ok/degraded/critical/unknown state.
+        // The OFFLINE dot (grey, no heartbeat) previously carried no tooltip, so
+        // an operator hovering a dead row learned nothing \u2014 not even which
+        // Kubernetes namespace the hive lives in. healthBadge() already gives the
+        // ONLINE dot a rich hover (status + ns: + heartbeat age); this mirrors the
+        // reference facts an operator needs to go find the offline hive on the
+        // cluster. Built defensively \u2014 every part is skipped when its field is
+        // empty \u2014 and escaped with escAttr since it lands inside a quoted title.
+        var offlineDotTitle = (function() {
+          var parts = ['Offline'];
+          var ns = hiveNamespace(h);            // 'hive-hosted-<id>' or '' for local
+          if (ns) parts.push('ns: ' + ns);
+          var cluster = h.clusterName || h.clusterId || '';
+          if (cluster) parts.push('cluster: ' + cluster);
+          if (h.lastHeartbeat) parts.push('last seen: ' + fmtUserTS(h.lastHeartbeat));
+          return parts.join('\n');
+        })();
         var dot = h.upgrading
           ? '<span class="online-dot upgrading" title="Upgrading \u2014 a rollout is in progress"></span>'
-          : (h.online ? healthBadge(h) : '<span class="online-dot off"></span>');
+          : (h.online ? healthBadge(h) : '<span class="online-dot off" title="' + escAttr(offlineDotTitle) + '" style="cursor:help"></span>');
         var rp = repoPath(h);
         // Link on the hive's own GitHub instance (github_host) so a GHE repo
         // points at github.ibm.com, not 404 on github.com.


### PR DESCRIPTION
## The gap

In the HUB **My Hives** table, the **offline** status dot (grey, no heartbeat) rendered as a bare `<span class="online-dot off"></span>` with **no `title` tooltip at all**. Hovering a dead row told an operator nothing — not even which Kubernetes namespace the hive runs in — so mapping "this offline hive" back to a namespace/cluster on the cluster meant cross-referencing the registry by hand.

The **online** dot already had a rich hover via `healthBadge(h)` (status + `ns:` + heartbeat age). Only the offline dot was mute.

## What changed

Added a native `title` tooltip to the offline dot (`v2/pkg/hub/saas.go`, the `buildRow` status-dot construction). It shows the reference facts an operator needs to go find the hive on the cluster:

```
Offline
ns: hive-hosted-<id>
cluster: <clusterName || clusterId>
last seen: <lastHeartbeat>
```

Details:
- **Namespace** is derived exactly as the online hover derives it — `hiveNamespace(h)` → `hive-hosted-<id>` for hosted hives, empty for local (no such namespace), so the two hovers can never disagree.
- Built **defensively**: each line is skipped when its field is empty (a local hive shows no `ns:`, a hive that never beat shows no `last seen:`).
- Escaped with the existing `escAttr` helper since it lands inside a quoted attribute.
- **No custom hover panel/popup** — just a native `title`, so there is zero layout risk. `cursor:help` hints the affordance.

## Test

Added `v2/pkg/hub/offline_dot_tooltip_test.go`, a string-anchored structural test in the same style as the other `dashboardHTML` JS-structure tests (e.g. `TestDashboardHeartbeatHeartFlashesOnReceipt`): it asserts the bare untitled span is gone and pins the defensive title builder.

`go build ./pkg/hub/` passes; the new test and the neighbouring `heartbeatHeart` / namespace-overlay tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)