### PR TITLE
🐛 fix(hub): hive delete purges the hub record so it cannot resurrect

### DIFF
--- a/v2/pkg/hub/delete_hive_registry_test.go
+++ b/v2/pkg/hub/delete_hive_registry_test.go
@@ -25,15 +25,20 @@ func helperDeleteHiveEnv(t *testing.T) (*HubServer, *http.ServeMux) {
 	oldHives := saasHivesDir
 	oldUsers := saasUsersDir
 	oldRegistry := registryPath
+	oldTimeline := timelineDir
 
 	saasHivesDir = filepath.Join(dir, "hives")
 	saasUsersDir = filepath.Join(dir, "users")
 	registryPath = filepath.Join(dir, "hub-registry.json")
+	timelineDir = filepath.Join(dir, "timeline")
 	if err := os.MkdirAll(saasHivesDir, 0o755); err != nil {
 		t.Fatalf("mkdir hives: %v", err)
 	}
 	if err := os.MkdirAll(saasUsersDir, 0o755); err != nil {
 		t.Fatalf("mkdir users: %v", err)
+	}
+	if err := os.MkdirAll(timelineDir, 0o755); err != nil {
+		t.Fatalf("mkdir timeline: %v", err)
 	}
 
 	t.Cleanup(func() {
@@ -41,12 +46,37 @@ func helperDeleteHiveEnv(t *testing.T) (*HubServer, *http.ServeMux) {
 		saasHivesDir = oldHives
 		saasUsersDir = oldUsers
 		registryPath = oldRegistry
+		timelineDir = oldTimeline
 	})
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
 	return srv, mux
+}
+
+// helperHiveRecordExists reports whether the on-disk SaaS hive record dir
+// (hives/<id>/) still exists. This husk is what resurrected the hive: a delete
+// that left it behind — with status:"available" — kept the hive in the
+// unassigned/available listing across a hub restart.
+func helperHiveRecordExists(id string) bool {
+	if _, err := os.Stat(filepath.Join(saasHivesDir, id)); err == nil {
+		return true
+	}
+	return false
+}
+
+// helperTimelineFileExists reports whether the hive's timeline file
+// (timelineDir/<id>.json) still exists on disk.
+func helperTimelineFileExists(id string) bool {
+	tp := timelinePath(id)
+	if tp == "" {
+		return false
+	}
+	if _, err := os.Stat(tp); err == nil {
+		return true
+	}
+	return false
 }
 
 // helperRegistryHasHive reports whether the in-memory registry holds an entry.
@@ -119,6 +149,98 @@ func TestDeleteHiveRemovesRegistryEntryFromMemoryAndDisk(t *testing.T) {
 	}
 	if helperPersistedRegistryHasHive(t, hiveID) {
 		t.Error("hive still present in the persisted registry after delete (would resurrect on hub restart)")
+	}
+}
+
+// TestDeleteHiveWithNoClusterConfigPurgesOnDiskRecord is the direct regression
+// for the resurrection bug. When clusterForHive returns nil, deprovisionHive is
+// skipped — and deprovisionHive was the ONLY code that removed the hives/<id>/
+// dir. A slot record with status:"available" therefore survived on disk and the
+// hive reappeared in the unassigned/available listing after a hub restart, still
+// pointing at a namespace that no longer existed. After the fix the delete must
+// purge the on-disk record (and the timeline file) even with no cluster config.
+func TestDeleteHiveWithNoClusterConfigPurgesOnDiskRecord(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_purge", "del-purge-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+	// No cluster config → clusterForHive returns nil → deprovision is skipped.
+	srv.clusters = map[string]ClusterConfig{}
+
+	const hiveID = "hosted-del-purge-hive"
+	// The exact husk that resurrects: an available-looking slot record on disk.
+	if err := saveSaaSHive(&SaaSHive{
+		ID:        hiveID,
+		Owner:     "del-purge-owner",
+		ClusterID: "cluster-that-was-removed",
+		Status:    statusAvailable,
+	}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	// A timeline file that nothing else in the delete path ever removed.
+	srv.recordTimeline(hiveID, TimelineOwnership, "seeded", "tester")
+
+	if !helperHiveRecordExists(hiveID) {
+		t.Fatal("precondition: seeded hive record dir should exist on disk")
+	}
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-purge-owner"}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_purge")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	if helperRegistryHasHive(srv, hiveID) || helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("registry entry survived a no-cluster delete")
+	}
+	if helperHiveRecordExists(hiveID) {
+		t.Error("resurrection bug: on-disk hive record dir survived delete with no cluster config")
+	}
+	if helperTimelineFileExists(hiveID) {
+		t.Error("resurrection bug: timeline file survived delete")
+	}
+}
+
+// TestDeleteHivePurgesTimelineFile pins that the timeline file is removed on a
+// normal delete too. deprovisionHive removes the hive dir but never touched the
+// timeline; removeHiveRecord closes that gap.
+func TestDeleteHivePurgesTimelineFile(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_tl", "del-tl-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-tl-hive"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-tl-owner", ClusterID: defaultClusterID}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.recordTimeline(hiveID, TimelineOwnership, "seeded", "tester")
+	if !helperTimelineFileExists(hiveID) {
+		t.Fatal("precondition: seeded timeline file should exist on disk")
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-tl-owner"}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_tl")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if helperHiveRecordExists(hiveID) {
+		t.Error("on-disk hive record dir survived delete")
+	}
+	if helperTimelineFileExists(hiveID) {
+		t.Error("timeline file survived delete")
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -532,8 +532,8 @@ func isCSRFSafe(r *http.Request) bool {
 // accepted every *.hive.kubestellar.io sibling. That single predicate answered
 // two different questions, and conflating them was the bug:
 //
-//   "may this origin AUTHOR a request?"      → only the hub itself
-//   "may we SEND a browser here?"            → any hive's own domain
+//	"may this origin AUTHOR a request?"      → only the hub itself
+//	"may we SEND a browser here?"            → any hive's own domain
 //
 // Because every tenant is a sibling under the same parent domain, the permissive
 // answer let a hostile tenant both drive CSRF mutations and — via the
@@ -3133,9 +3133,12 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 
 	h := loadSaaSHive(id)
 	if h == nil {
-		// SaaS entry already gone — still clean up the in-memory registry
-		// so the hive disappears from the listing immediately.
+		// SaaS meta.json already gone — still clean up the in-memory registry so
+		// the hive disappears from the listing immediately, and best-effort purge
+		// any leftover record dir / timeline file so a partial prior delete cannot
+		// leave a status:"available" husk that resurrects in the listing.
 		s.removeRegistryEntry(id, username)
+		removeHiveRecord(id, s.logger)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 		return
@@ -3163,6 +3166,21 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("no cluster config for deprovision; removing registry entry anyway",
 			"hive_id", id, "cluster_id", h.ClusterID)
 	}
+	// Durably purge the hub-side record. This is what stops the "resurrection":
+	// deprovisionHive removes the hive directory only when a cluster config is
+	// available (the else branch above skips it), and NEITHER path removes the
+	// timeline file. Without this, a delete with no cluster config left the
+	// hives/<id>/ dir — status:"available" — behind, so the hive reappeared in
+	// the unassigned/available list forever. removeHiveRecord is idempotent, so
+	// calling it after a successful deprovision (which already removed the dir)
+	// is harmless and still cleans up the timeline file deprovision never touched.
+	//
+	// NOTE: this is the genuine, user-initiated delete path. It is deliberately
+	// NOT the placeholder-recycle path — resetting a slot to status:"available"
+	// (handleResetAssignment / sweepStuckAssignments in saas_reset_assignment.go)
+	// rewrites meta.json in place and KEEPS the record, and never reaches this
+	// handler. So purging the record here cannot break placeholder recycling.
+	removeHiveRecord(id, s.logger)
 	s.removeRegistryEntry(id, username)
 
 	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username,

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1479,6 +1479,40 @@ func saveSaaSHive(h *SaaSHive) error {
 	return os.Rename(tmpPath, path)
 }
 
+// removeHiveRecord durably purges the hub-side, on-disk record for a deleted
+// hive: the per-hive directory under saasHivesDir/<id>/ (meta.json + manifests +
+// requests.json) and the hive's timeline file under timelineDir/<id>.json.
+//
+// This is the counterpart to saveSaaSHive and closes the "resurrection" bug:
+// deprovisionHive removes the hive directory only when a cluster config is
+// available, and NOTHING removed the timeline file. A delete that could not run
+// deprovision (no cluster config) therefore left the hive/<id>/ directory —
+// with status:"available" — on disk, so the hive reappeared in the
+// unassigned/available listing forever, pointing at a namespace that no longer
+// existed. Removing the record here makes the delete stick across a hub restart.
+//
+// Best-effort by design: a delete must never be blocked by a leftover file, and
+// the registry entry is the row the user actually sees. Failures are logged, not
+// returned. The path-traversal guard mirrors loadSaaSHive/saveSaaSHive so a
+// hostile id can never escape the record dirs.
+func removeHiveRecord(id string, logger *slog.Logger) {
+	if strings.Contains(id, "..") || strings.Contains(id, "/") || strings.Contains(id, "\\") {
+		logger.Warn("removeHiveRecord: refusing unsafe hive id", "hive_id", id)
+		return
+	}
+	hiveDir := filepath.Join(saasHivesDir, id)
+	if err := os.RemoveAll(hiveDir); err != nil {
+		logger.Warn("removeHiveRecord: failed to remove hive directory", "path", hiveDir, "error", err)
+	}
+	// timelinePath applies its own traversal guard and returns "" if the id is
+	// not a safe filename; skip the removal in that case.
+	if tp := timelinePath(id); tp != "" {
+		if err := os.Remove(tp); err != nil && !os.IsNotExist(err) {
+			logger.Warn("removeHiveRecord: failed to remove timeline file", "path", tp, "error", err)
+		}
+	}
+}
+
 func listSaaSHives() []SaaSHive {
 	entries, err := os.ReadDir(saasHivesDir)
 	if err != nil {


### PR DESCRIPTION
## The resurrection bug

Deleting a hosted hive tore down the running namespace/pods but did not fully purge the **hub-side, on-disk record**. Two gaps left a husk behind:

1. **No cluster config → deprovision skipped.** `handleDeleteHive` only calls `deprovisionHive` when `clusterForHive(h) != nil`. `deprovisionHive` (Step 4) was the *only* code that `os.RemoveAll`ed the `hives/<id>/` record dir. When the cluster config had been removed (a real production state), deprovision never ran, so the `hives/<id>/meta.json` record — often with `status:"available"` — survived on disk.
2. **Timeline file never removed.** Nothing in the delete path ever removed `timeline/<id>.json`.

On the next hub restart the surviving `status:"available"` record re-materialized the hive in the **unassigned/available** listing forever, pointing at a namespace that no longer existed — the "zombie" that reappears no matter how many times you click Delete. (The in-memory + on-disk *registry* entry was already removed correctly by an earlier fix; the record dir + timeline were the remaining leak.)

## The fix

- New helper `removeHiveRecord(id, logger)` in `saas_provision.go` — the counterpart to `saveSaaSHive`. Best-effort (log-not-fatal), it `os.RemoveAll`s the `hives/<id>/` dir and `os.Remove`s the `timeline/<id>.json` file, with the same path-traversal guard the load/save helpers use.
- `handleDeleteHive` now calls `removeHiveRecord(id, s.logger)` on both delete paths:
  - the main path (unconditionally, so it covers the `cluster == nil` case deprovision skips, and also purges the timeline deprovision never touched — idempotent after a successful deprovision),
  - the `loadSaaSHive == nil` early-return (best-effort cleanup of any leftover husk).
- Reuses the existing `removeRegistryEntry` / `saveRegistryNow` for the registry side — no reinvention.

## Placeholder-recycle distinction preserved

There are two very different "remove" intents in the codebase, and I gated only the genuine-delete one:

- **Genuine delete** — `handleDeleteHive` (`DELETE /api/saas/hives/{id}`). User wants it gone. This is the only path that now calls `removeHiveRecord`.
- **Reset to available (placeholder recycle)** — `handleResetAssignment` / `sweepStuckAssignments` in `saas_reset_assignment.go`. This *rewrites* `meta.json` in place to `status:"available"` (via `resetHiveToAvailablePlaceholder`) and deliberately **keeps** the record so the slot can be re-armed and re-assigned. It never routes through `handleDeleteHive`.

Because the two paths are separate handlers and the reset path never reaches the delete handler, purging the record on delete cannot break placeholder recycling. A code comment on the `removeHiveRecord` call documents this.

## Tests

Added to `delete_hive_registry_test.go` (mirrors the existing helper/table patterns; env helper now also redirects `timelineDir` to a temp dir):

- `TestDeleteHiveWithNoClusterConfigPurgesOnDiskRecord` — the direct regression: delete with `clusters={}` (deprovision skipped) must remove the registry entry **and** the on-disk `hives/<id>/` dir **and** the timeline file.
- `TestDeleteHivePurgesTimelineFile` — normal delete also removes the timeline file deprovision never touched.

Both were verified to **fail** without the fix and **pass** with it.

```
go build ./pkg/hub/    → OK
go test ./pkg/hub/ -run 'Delete|Remove|Registry'  → ok
```
gofmt -w applied to changed files.
