### PR TITLE
🐛 fix: resolve Resume() deadlock when persistence callback re-enters manager

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5306,6 +5306,9 @@ func (m *Manager) SeedPauseState(name string, pausedAt time.Time, trigger, reaso
 }
 
 func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	m.mu.Lock()
 	agent, ok := m.agents[name]
 	if !ok {
@@ -5315,15 +5318,14 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 
 	prevTrigger := agent.PausedTrigger
 	prevReason := agent.PausedReason
-	// Snapshot backend/model while m.mu is held so audit details stay stable
-	// even when Resume relaunches the agent before returning.
+	// Snapshot backend/model while m.mu is still held — the audit call below
+	// runs after the deliberate early Unlock, where touching agent fields
+	// would be an unsynchronized read.
 	resumeBackend := agent.effectiveBackend()
 	resumeModel := agent.effectiveModel()
 	agent.Paused = false
 	agent.Config.Paused = false
-	if m.persistPauseCallback != nil {
-		m.persistPauseCallback(name, false)
-	}
+	persistPause := m.persistPauseCallback
 	agent.PausedAt = time.Time{}
 	agent.PausedReason = ""
 	agent.PausedTrigger = ""
@@ -5331,7 +5333,17 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	if needsRelaunch {
 		agent.forceRelaunch = true
 	}
+	// Release the global agents-map lock before slow per-agent tmux
+	// operations (ensureTmuxSession + launchInTmux ~2s each). This allows
+	// concurrent Resume() calls for different agents to run in parallel
+	// instead of serializing on the mutex.
+	m.mu.Unlock()
 
+	// Persistence republishes the complete runtime config and re-enters the
+	// manager to update agent snapshots. Never invoke it while holding m.mu.
+	if persistPause != nil {
+		persistPause(name, false)
+	}
 	m.logger.Info("audit: agent resumed",
 		"name", name,
 		"trigger", trigger,
@@ -5348,14 +5360,10 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	))
 	if needsRelaunch {
 		if err := m.ensureTmuxSession(agent); err != nil {
-			m.mu.Unlock()
 			return err
 		}
-		err := m.launchInTmux(ctx, agent)
-		m.mu.Unlock()
-		return err
+		return m.launchInTmux(ctx, agent)
 	}
-	m.mu.Unlock()
 	return nil
 }
 

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -767,3 +767,39 @@ func TestStart_EnvIncludesHiveVars(t *testing.T) {
 		t.Error("HIVE_AGENT=env-test not found in env pairs")
 	}
 }
+func TestResume_PersistenceCallbackCanReenterManager(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+	m.agents["worker"].Paused = true
+	m.agents["worker"].Config.Paused = true
+
+	callbackCalled := make(chan struct{}, 1)
+	m.SetPersistPauseCallback(func(name string, paused bool) {
+		if name != "worker" || paused {
+			t.Errorf("persist callback = (%q, %v), want (worker, false)", name, paused)
+		}
+		_ = m.AllStatuses()
+		callbackCalled <- struct{}{}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Resume(context.Background(), "worker", "test", "test resume")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Resume() error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resume() deadlocked while persistence callback re-entered manager")
+	}
+
+	select {
+	case <-callbackCalled:
+	default:
+		t.Fatal("resume persistence callback was not called")
+	}
+}


### PR DESCRIPTION
fix: resolve Resume() deadlock when persistence callback re-enters manager

Resume() invoked persistPauseCallback while holding m.mu, directly
contradicting its own documented contract ("Never invoke it while
holding m.mu"). The persistence callback republishes the complete
runtime config and re-enters the manager to update agent snapshots, so
any re-entrant read (e.g. AllStatuses) blocks forever on the mutex
Resume still holds.

Ports the fix already proven on dd:
- snapshot persistPauseCallback and the audit backend/model fields while
  m.mu is held
- release m.mu before invoking persistence, auditing, and the slow
  per-agent tmux operations (ensureTmuxSession + launchInTmux, ~2s each)

Releasing the global agents-map lock before the tmux work also lets
concurrent Resume() calls for different agents proceed in parallel
instead of serializing on the mutex.

Adds TestResume_PersistenceCallbackCanReenterManager (also from dd).
Verified by sabotage: restoring the old locking makes the new test fail
with "Resume() deadlocked while persistence callback re-entered manager"
after the 2s timeout. Full pkg/agent suite passes with the fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
