### PR TITLE
🐛 fix: reject migration to or from a pull-only cluster

### DIFF
--- a/v2/docs/cross-cluster-migration.md
+++ b/v2/docs/cross-cluster-migration.md
@@ -57,6 +57,12 @@ Use it when all of these hold:
    an entry in `/data/saas/clusters.json` on the hub PVC. The entry carries
    a `kubeconfig_path` and a `context` for the hub to use. The hub runs
    plain `kubectl` for the in-cluster entry.
+
+   A cluster marked `"pull_only": true` is excluded. Its spokes connect
+   outbound over the heartbeat and the hub cannot `kubectl` into them, so
+   it can be neither the source nor the target of a migrate call — the API
+   rejects both with a 400 before any migration state is recorded. Move
+   those hives by hand using the manual procedure below.
 2. **No hive data must be preserved.** The API does not copy volume data.
 3. **You are the hive owner or the hub admin.** The hub rejects any other
    caller with a 403.

--- a/v2/pkg/hub/pull_only_cluster_test.go
+++ b/v2/pkg/hub/pull_only_cluster_test.go
@@ -3,9 +3,12 @@ package hub
 import (
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -174,4 +177,52 @@ func loadClusterConfigsFrom(t *testing.T, path string) map[string]ClusterConfig 
 	clustersConfigPath = path
 	t.Cleanup(func() { clustersConfigPath = orig })
 	return loadClusters(slog.Default())
+}
+
+// migrateHive is provision-on-target plus deprovision-of-source, and both
+// halves are kubectl. A pull-only cluster cannot serve either half, so the
+// handler must refuse BEFORE it flips the hive into the migrating state —
+// otherwise a hive is left marked migrating for work that can never run.
+func TestMigrateRejectsPullOnlyCluster(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		sourcePullOnly bool
+		targetPullOnly bool
+	}{
+		{"target is pull-only", false, true},
+		{"source is pull-only", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(helperSetupTempDirs(t))
+			if err := saveSaaSUser(&SaaSUser{GitHubUsername: "po-user"}); err != nil {
+				t.Fatalf("seed user: %v", err)
+			}
+
+			srv := NewHubServer(0, slog.Default(), "test", "v2")
+			srv.clusters = map[string]ClusterConfig{
+				defaultClusterID: {ID: defaultClusterID, KubeconfigPath: "/tmp/kc", PullOnly: tc.sourcePullOnly},
+				"pool-b":         {ID: "pool-b", KubeconfigPath: "/tmp/kc", PullOnly: tc.targetPullOnly},
+			}
+			if err := saveSaaSHive(&SaaSHive{ID: "hosted-po", Owner: "po-user"}); err != nil {
+				t.Fatalf("seed hive: %v", err)
+			}
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /api/saas/hives/{id}/migrate", srv.handleMigrateHive)
+			req := httptest.NewRequest("POST", "/api/saas/hives/hosted-po/migrate",
+				strings.NewReader(`{"target_cluster_id":"pool-b"}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(testAuthCookie("po-user"))
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("migration involving a pull-only cluster must be refused with 400, got %d: %s", w.Code, w.Body.String())
+			}
+			// The refusal must leave no migration state behind.
+			if h := loadSaaSHive("hosted-po"); h != nil && h.MigrationStatus != "" {
+				t.Errorf("hive was flipped into migration state %q despite the migration being refused", h.MigrationStatus)
+			}
+		})
+	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3290,6 +3290,21 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Migration is provision-on-target plus deprovision-of-source, and BOTH
+	// halves are kubectl. A pull-only cluster cannot be reached from the hub
+	// at all, so neither half can run against it. Reject up front: accepting
+	// the call would mark the hive migrating, then fail (or, worse, aim the
+	// kubectl at whatever cluster is reachable) after the state was already
+	// flipped. Hives on a pull-only cluster must be moved by hand.
+	if toCluster.PullOnly {
+		http.Error(w, `{"error":"target cluster is pull-only: the hub cannot kubectl into it, so a hive cannot be migrated there"}`, http.StatusBadRequest)
+		return
+	}
+	if fromCluster.PullOnly {
+		http.Error(w, `{"error":"current cluster is pull-only: the hub cannot kubectl into it, so a hive cannot be migrated off it"}`, http.StatusBadRequest)
+		return
+	}
+
 	// Set migration status and launch background goroutine.
 	h.MigrationStatus = "migrating"
 	h.MigrationFrom = currentClusterID


### PR DESCRIPTION
fix: reject migration to or from a pull-only cluster

Cross-cluster migration is provision-on-target plus deprovision-of-source,
and both halves run kubectl. A pull-only cluster cannot be reached from
the hub at all, so neither half can run against it.

handleMigrateHive validated that the target existed and differed from the
source, but never that either end was actually reachable. A migrate call
naming a pull-only cluster was accepted, the hive was flipped into the
migrating state and saved, and only then did the kubectl work fail — the
hive left marked as migrating for work that could never run.

Both ends are now checked, and the checks sit before the migration state
is persisted, so a refusal leaves no state behind. The test asserts both
the 400 and that MigrationStatus is still empty afterwards.

Documents the exclusion in cross-cluster-migration.md, whose "the hub can
run kubectl against both clusters" precondition was previously only
advisory.

Verified by sabotage: disabling either guard fails the corresponding
subtest. Full pkg/hub suite passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
