### PR TITLE
✨ feat(hub): canonical provider:subject identity foundation (multi-login phase 1a)

### DIFF
--- a/v2/pkg/hub/identity_canonical.go
+++ b/v2/pkg/hub/identity_canonical.go
@@ -1,0 +1,213 @@
+package hub
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Canonical identity for a HUMAN hub/spoke user.
+//
+// Historically a user WAS their GitHub login: that one bare string was the
+// session-cookie subject, the on-disk user key, the map key for hive grants, and
+// the admin comparison value. To support additional login providers (Google,
+// IBMid, Red Hat) without collisions or cross-provider impersonation, an identity
+// is now a canonical `provider:subject` pair.
+//
+// This is strictly about WHO A HUMAN IS for login + access control. It has
+// nothing to do with the GitHub App installation token (kubestellar-hive[bot])
+// that performs the hive's actual GitHub work, nor with agent/backend logins.
+//
+// Two representations exist:
+//
+//	wire form      "github:clubanderson", "google:1078...":
+//	               used in cookies, X-Hive-User, SaaSUser.Hives keys, Owner
+//	               fields, authorized_users. The signed-cookie machinery signs an
+//	               opaque string, so it carries a canonical id with no change.
+//	filename form  "github.clubanderson", "google.1078...":
+//	               path-safe on-disk key that stays inside safeNamePattern
+//	               (^[a-zA-Z0-9._-]+$), so isValidName and the load/save traversal
+//	               guards keep protecting the storage layer unchanged.
+
+// identityProviders is the fixed, closed set of login providers. A provider name
+// contains no '.', which is what lets the filename form split provider from
+// subject on the FIRST dot. Extend this set (not the parsing) to add a provider.
+var identityProviders = map[string]bool{
+	"github": true,
+	"google": true,
+	"ibmid":  true,
+	"redhat": true,
+}
+
+// legacyProvider is the provider a bare, un-namespaced key is assumed to belong
+// to. Every user before multi-provider login was a GitHub login, so a key with
+// no "provider:" prefix means GitHub. This is the backward-compat shim: existing
+// user files, cookies, and grants keep resolving with no data migration.
+const legacyProvider = "github"
+
+// canonicalSeparator joins provider and subject in the WIRE form.
+const canonicalSeparator = ":"
+
+// maxCanonicalLen bounds the wire form, matching isValidName's len<=100 budget so
+// a canonical id round-trips through the existing name validation.
+const maxCanonicalLen = 100
+
+// makeCanonical builds the wire form "provider:subject" from a provider name and
+// the provider's stable subject (the OIDC `sub`, or the GitHub login). It
+// validates the provider is known, the subject is non-empty and free of the
+// separator and path-hostile characters, and the total length fits. The subject
+// charset is deliberately the same safe set used on disk so the value survives
+// both the cookie/header path and the filename encoding.
+func makeCanonical(provider, subject string) (string, error) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	subject = strings.TrimSpace(subject)
+	if !identityProviders[provider] {
+		return "", fmt.Errorf("unknown identity provider %q", provider)
+	}
+	if subject == "" {
+		return "", fmt.Errorf("empty subject for provider %q", provider)
+	}
+	if strings.ContainsAny(subject, ":/\\") || strings.Contains(subject, "..") {
+		return "", fmt.Errorf("subject %q contains a reserved character", subject)
+	}
+	id := provider + canonicalSeparator + subject
+	if len(id) > maxCanonicalLen {
+		return "", fmt.Errorf("canonical id exceeds %d bytes", maxCanonicalLen)
+	}
+	return id, nil
+}
+
+// parseCanonical splits a wire-form canonical id into provider and subject. A
+// bare, un-namespaced string is treated as a legacy GitHub login (the shim), so
+// callers may pass either form. Returns ok=false only for a malformed value
+// (empty, unknown provider, empty subject).
+func parseCanonical(id string) (provider, subject string, ok bool) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", false
+	}
+	before, after, found := strings.Cut(id, canonicalSeparator)
+	if !found {
+		// Bare login → legacy GitHub identity.
+		return legacyProvider, id, true
+	}
+	provider = strings.ToLower(before)
+	subject = after
+	if !identityProviders[provider] || subject == "" {
+		return "", "", false
+	}
+	return provider, subject, true
+}
+
+// canonicalizeLegacy normalizes any identity string to its canonical wire form:
+// an already-namespaced key (contains the separator) is returned as-is; a bare
+// key is promoted to "github:<key>". This is applied at BOTH sides of every
+// ownership/admin comparison so a legacy stored value ("clubanderson") matches an
+// authenticated canonical id ("github:clubanderson") and vice-versa — the core of
+// the zero-downtime migration shim.
+func canonicalizeLegacy(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	if strings.Contains(id, canonicalSeparator) {
+		return id
+	}
+	return legacyProvider + canonicalSeparator + id
+}
+
+// canonicalEqual reports whether two identity strings denote the same user,
+// tolerant of legacy (bare) vs canonical form and case-insensitive on the
+// GitHub-login subject (GitHub logins are case-insensitive; OIDC subs are exact
+// but a case-fold on an opaque sub is harmless because two subs that differ only
+// by case are not issued). Use this in place of raw string / EqualFold(Owner,…)
+// comparisons.
+func canonicalEqual(a, b string) bool {
+	return strings.EqualFold(canonicalizeLegacy(a), canonicalizeLegacy(b))
+}
+
+// filenameHexUpper is the alphabet for the "-XX-" escape used by
+// encodeUserFilename. Uppercase hex stays inside safeNamePattern.
+const filenameHexUpper = "0123456789ABCDEF"
+
+// encodeUserFilename maps a canonical (or legacy) identity to a path-safe on-disk
+// stem that matches safeNamePattern (^[a-zA-Z0-9._-]+$). The result is
+// "<provider>.<encodedSubject>": the provider name has no dot, so the first dot
+// unambiguously separates it from the subject. Any subject byte outside
+// [A-Za-z0-9_-] (dot included, to keep the split unambiguous) is escaped as
+// "-XX-" hex. github/google/ibmid/redhat subjects are already in this set, so in
+// practice the encoding is the identity for real ids and files read cleanly as
+// "github.clubanderson", "google.1078...".
+//
+// A bare legacy key encodes to the SAME stem the pre-migration code wrote
+// (a plain GitHub login is [a-zA-Z0-9-] with optional dots), so the load path can
+// dual-read: try this encoding, then the legacy "<login>" stem. See loadSaaSUser.
+func encodeUserFilename(id string) (string, error) {
+	provider, subject, ok := parseCanonical(id)
+	if !ok {
+		return "", fmt.Errorf("cannot encode invalid identity %q", id)
+	}
+	var b strings.Builder
+	b.WriteString(provider)
+	b.WriteByte('.')
+	for i := 0; i < len(subject); i++ {
+		c := subject[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('-')
+		b.WriteByte(filenameHexUpper[c>>4])
+		b.WriteByte(filenameHexUpper[c&0x0f])
+		b.WriteByte('-')
+	}
+	stem := b.String()
+	if !isValidName(stem) {
+		return "", fmt.Errorf("encoded filename %q is not path-safe", stem)
+	}
+	return stem, nil
+}
+
+// decodeUserFilename is the inverse of encodeUserFilename: it turns an on-disk
+// stem back into a canonical wire-form id. Used when enumerating the user store
+// so a listed user carries its canonical identity. Returns ok=false for a stem
+// that is not a valid encoding (e.g. a legacy bare "<login>" stem with no
+// provider dot — the caller falls back to treating it as a legacy GitHub login).
+func decodeUserFilename(stem string) (string, bool) {
+	provider, encSubject, found := strings.Cut(stem, ".")
+	if !found || !identityProviders[strings.ToLower(provider)] {
+		return "", false
+	}
+	provider = strings.ToLower(provider)
+	var b strings.Builder
+	for i := 0; i < len(encSubject); {
+		c := encSubject[i]
+		if c == '-' && i+3 < len(encSubject) && encSubject[i+3] == '-' {
+			hi := hexVal(encSubject[i+1])
+			lo := hexVal(encSubject[i+2])
+			if hi >= 0 && lo >= 0 {
+				b.WriteByte(byte(hi<<4 | lo))
+				i += 4
+				continue
+			}
+		}
+		b.WriteByte(c)
+		i++
+	}
+	id, err := makeCanonical(provider, b.String())
+	if err != nil {
+		return "", false
+	}
+	return id, true
+}
+
+func hexVal(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	}
+	return -1
+}

--- a/v2/pkg/hub/identity_canonical_test.go
+++ b/v2/pkg/hub/identity_canonical_test.go
@@ -1,0 +1,127 @@
+package hub
+
+import "testing"
+
+func TestMakeCanonical(t *testing.T) {
+	cases := []struct {
+		provider, subject, want string
+		ok                      bool
+	}{
+		{"github", "clubanderson", "github:clubanderson", true},
+		{"google", "1078xxxx", "google:1078xxxx", true},
+		{"GitHub", "Foo-Bar", "github:Foo-Bar", true}, // provider lowercased
+		{"ibmid", "abc.def", "ibmid:abc.def", true},   // dot allowed in subject (wire form)
+		{"redhat", "s_1", "redhat:s_1", true},
+		{"unknown", "x", "", false},  // unknown provider
+		{"github", "", "", false},    // empty subject
+		{"github", "a:b", "", false}, // separator in subject
+		{"github", "a/b", "", false}, // path char
+		{"github", "..", "", false},  // traversal
+	}
+	for _, c := range cases {
+		got, err := makeCanonical(c.provider, c.subject)
+		if c.ok {
+			if err != nil || got != c.want {
+				t.Errorf("makeCanonical(%q,%q) = %q,%v want %q", c.provider, c.subject, got, err, c.want)
+			}
+		} else if err == nil {
+			t.Errorf("makeCanonical(%q,%q) = %q, want error", c.provider, c.subject, got)
+		}
+	}
+}
+
+func TestParseCanonicalAndLegacyShim(t *testing.T) {
+	// Bare login → legacy github (the shim).
+	if p, s, ok := parseCanonical("clubanderson"); !ok || p != "github" || s != "clubanderson" {
+		t.Errorf("parseCanonical(bare) = %q,%q,%v", p, s, ok)
+	}
+	// Already-canonical passes through.
+	if p, s, ok := parseCanonical("google:1078"); !ok || p != "google" || s != "1078" {
+		t.Errorf("parseCanonical(canonical) = %q,%q,%v", p, s, ok)
+	}
+	// Unknown provider → not ok.
+	if _, _, ok := parseCanonical("bogus:x"); ok {
+		t.Error("parseCanonical(bogus:x) should be !ok")
+	}
+	// canonicalizeLegacy.
+	for in, want := range map[string]string{
+		"clubanderson":        "github:clubanderson",
+		"github:clubanderson": "github:clubanderson",
+		"google:1078":         "google:1078",
+		"":                    "",
+	} {
+		if got := canonicalizeLegacy(in); got != want {
+			t.Errorf("canonicalizeLegacy(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCanonicalEqual is the load-bearing migration property: a legacy stored
+// value matches an authenticated canonical id, and — critically — a same-subject
+// identity on a DIFFERENT provider does NOT match (cross-provider defense).
+func TestCanonicalEqual(t *testing.T) {
+	if !canonicalEqual("clubanderson", "github:clubanderson") {
+		t.Error("legacy bare login must equal github: canonical")
+	}
+	if !canonicalEqual("GitHub:ClubAnderson", "github:clubanderson") {
+		t.Error("github identity compare must be case-insensitive")
+	}
+	if canonicalEqual("google:clubanderson", "github:clubanderson") {
+		t.Fatal("SECURITY: google:clubanderson must NOT equal github:clubanderson")
+	}
+	if canonicalEqual("google:clubanderson", "clubanderson") {
+		t.Fatal("SECURITY: google:clubanderson must NOT equal a legacy github login")
+	}
+}
+
+func TestFilenameRoundTrip(t *testing.T) {
+	ids := []string{
+		"github:clubanderson",
+		"github:foo-bar",
+		"github:foo.bar",
+		"google:1078901234567890",
+		"ibmid:ABCDEF-0123",
+		"redhat:user_name",
+		"github:name+with@odd.chars", // exercises the -XX- escape
+	}
+	for _, id := range ids {
+		stem, err := encodeUserFilename(id)
+		if err != nil {
+			t.Fatalf("encodeUserFilename(%q): %v", id, err)
+		}
+		if !isValidName(stem) {
+			t.Errorf("encoded stem %q for %q is not path-safe", stem, id)
+		}
+		back, ok := decodeUserFilename(stem)
+		if !ok {
+			t.Fatalf("decodeUserFilename(%q) not ok (from %q)", stem, id)
+		}
+		// makeCanonical was applied on encode side (parseCanonical) so compare canonical forms.
+		if canonicalizeLegacy(back) != canonicalizeLegacy(id) {
+			t.Errorf("round-trip: %q -> %q -> %q", id, stem, back)
+		}
+	}
+}
+
+// TestLegacyFilenameStemMatches pins that a bare GitHub login encodes to a stem
+// whose provider is github and subject is the login — so the load path can map a
+// canonical github id to a file while a legacy "<login>.json" still resolves via
+// the dual-read fallback (asserted here structurally).
+func TestLegacyFilenameStemMatches(t *testing.T) {
+	stem, err := encodeUserFilename("clubanderson") // bare → github:clubanderson
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stem != "github.clubanderson" {
+		t.Errorf("bare login stem = %q, want github.clubanderson", stem)
+	}
+	back, ok := decodeUserFilename(stem)
+	if !ok || back != "github:clubanderson" {
+		t.Errorf("decode(%q) = %q,%v", stem, back, ok)
+	}
+	// A pre-migration legacy stem (no provider dot in the github sense) with a
+	// dot in the login must NOT be misread as a provider split.
+	if _, ok := decodeUserFilename("someuser"); ok {
+		t.Error("a bare legacy stem with no provider prefix must decode !ok (caller falls back to legacy github)")
+	}
+}


### PR DESCRIPTION
## What

First step toward **multi-provider human login** (Google → then IBMid, Red Hat, alongside GitHub) for the hub and spoke dashboards. This PR adds **only the pure foundation** — new functions + tests, **zero call-site changes** — so it's safe to land independently.

## Why

Today a human user *is* their GitHub login: that one bare string is the session-cookie subject, the on-disk user key (`/data/saas/users/<login>.json`), the hive-grant map key, and the admin comparison. To support other login providers without collisions or cross-provider impersonation, identity becomes a canonical `provider:subject` pair.

**Scope:** HUMAN login + access control only. Nothing here touches the GitHub **App** installation token (`kubestellar-hive[bot]`) that performs the hive's actual GitHub work (issues/PRs/comments/merges), nor agent/backend logins. A future Google-primary human can own a GitHub-repo hive because the App does the GitHub work.

## What's in this commit (`identity_canonical.go`)

- `makeCanonical`/`parseCanonical` — wire form `github:clubanderson`, `google:1078...`. A **bare** login is treated as `github:` (the backward-compat shim), so existing files/cookies/grants keep resolving with **no data migration**.
- `canonicalizeLegacy`/`canonicalEqual` — normalize both sides of a comparison so a legacy stored `clubanderson` matches an authenticated `github:clubanderson`, while **`google:clubanderson` does NOT match `github:clubanderson`** (the load-bearing cross-provider security property).
- `encodeUserFilename`/`decodeUserFilename` — path-safe on-disk stem (`github.clubanderson`, `google.1078...`) that stays inside the existing `safeNamePattern` (`^[a-zA-Z0-9._-]+$`), so `isValidName` and the load/save traversal guards keep protecting storage unchanged.

## Tests

Round-trips for make/parse and filename across all four providers, the legacy shim, and the **security negative** (`google:clubanderson` != `github:clubanderson` / != legacy). `go build ./pkg/hub/` clean; tests pass.

## Next (subsequent PRs in this phase)

1b: `isHubAdmin`/`primaryHubAdmin` + the ~49 admin-gate sites (env admin list). 1c: dual-read load/save + the ~28 owner-match + `AuthorizedRole` normalization. 1d: `SaaSUser` provider/avatar/email fields. Then Phase 2 = Google OIDC on the hub (hub-proxied spokes inherit it).