### PR TITLE
🔒 feat(hub): env-driven admin list + generalize the admin gate (multi-login phase 1b)

### DIFF
--- a/v2/pkg/hub/admin_gate_test.go
+++ b/v2/pkg/hub/admin_gate_test.go
@@ -1,0 +1,66 @@
+package hub
+
+import "testing"
+
+// TestIsHubAdmin_DefaultAndLegacyShim: with no HIVE_HUB_ADMINS, the default
+// admin (github:clubanderson) matches whether presented bare-legacy or canonical.
+func TestIsHubAdmin_DefaultAndLegacyShim(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "") // force default
+
+	for _, id := range []string{"clubanderson", "github:clubanderson", "GitHub:ClubAnderson"} {
+		if !isHubAdmin(id) {
+			t.Errorf("isHubAdmin(%q) = false, want true (default admin, legacy/canonical/case)", id)
+		}
+	}
+	for _, id := range []string{"", "someone-else", "github:someone-else"} {
+		if isHubAdmin(id) {
+			t.Errorf("isHubAdmin(%q) = true, want false", id)
+		}
+	}
+}
+
+// TestIsHubAdmin_CrossProviderIsNotAdmin is the load-bearing security property
+// (plan Risk #1): a user whose SUBJECT happens to be "clubanderson" on a
+// DIFFERENT provider must NOT inherit GitHub admin. If this ever passes as true,
+// registering the admin's name on Google/IBMid would grant admin.
+func TestIsHubAdmin_CrossProviderIsNotAdmin(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "")
+	for _, id := range []string{"google:clubanderson", "ibmid:clubanderson", "redhat:clubanderson"} {
+		if isHubAdmin(id) {
+			t.Fatalf("SECURITY: isHubAdmin(%q) = true — a same-subject identity on another provider must NEVER be admin", id)
+		}
+	}
+}
+
+// TestIsHubAdmin_EnvOverride: HIVE_HUB_ADMINS replaces the default set and
+// accepts both bare-legacy and canonical (incl. non-GitHub) entries.
+func TestIsHubAdmin_EnvOverride(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "github:alice, google:1078, bob")
+
+	for _, id := range []string{"alice", "github:alice", "google:1078", "bob", "github:bob"} {
+		if !isHubAdmin(id) {
+			t.Errorf("isHubAdmin(%q) = false, want true under env override", id)
+		}
+	}
+	// The default is NO LONGER admin once the env overrides the set.
+	if isHubAdmin("clubanderson") {
+		t.Error("isHubAdmin(clubanderson) should be false when HIVE_HUB_ADMINS excludes it")
+	}
+	// Cross-provider still isolated.
+	if isHubAdmin("google:alice") {
+		t.Error("google:alice must not match github:alice admin entry")
+	}
+}
+
+// TestPrimaryHubAdmin returns the canonical primary admin — the first env entry,
+// else the canonicalized default.
+func TestPrimaryHubAdmin(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "")
+	if got := primaryHubAdmin(); got != "github:clubanderson" {
+		t.Errorf("primaryHubAdmin() default = %q, want github:clubanderson", got)
+	}
+	t.Setenv(hubAdminsEnv, "google:1078, github:alice")
+	if got := primaryHubAdmin(); got != "google:1078" {
+		t.Errorf("primaryHubAdmin() = %q, want google:1078 (first env entry)", got)
+	}
+}

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -257,7 +257,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can switch forges"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/identity.go
+++ b/v2/pkg/hub/identity.go
@@ -344,7 +344,7 @@ func SpokeIdentityFromPayload(p *HeartbeatPayload) IdentitySet {
 // are untouched, so a reset on a healthy hive costs one re-install rather than
 // an outage.
 func (s *HubServer) handleResetApp(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -409,7 +409,7 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 	// Fold impersonation status into the auth payload the dashboard already
 	// fetches, so the "Viewing as … read-only" banner renders without a second
 	// round-trip. When an admin is impersonating, report the effective identity

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -1,11 +1,11 @@
 package hub
 
 import (
-	"net/url"
-	"strings"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 )
 

--- a/v2/pkg/hub/openrouter.go
+++ b/v2/pkg/hub/openrouter.go
@@ -65,7 +65,7 @@ func (s *HubServer) openRouterState() *openrouter.StateStore {
 // read-write grantee, or the hub admin). Funding stores a spend-capable key on
 // the hive, so it is restricted to those who administer the hive.
 func (s *HubServer) ownsHiveForFunding(username, hiveID string) bool {
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		return true
 	}
 	h := loadSaaSHive(hiveID)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -28,7 +28,62 @@ import (
 
 var saasUsersDir = "/data/saas/users"
 
+// hubAdminUsername is the DEFAULT primary hub admin — a legacy bare GitHub login,
+// canonicalized to github:clubanderson by the identity shim. It is the fallback
+// admin when HIVE_HUB_ADMINS is unset, and the identity written where the code
+// needs "the admin" as a concrete owner. Prefer isHubAdmin()/primaryHubAdmin()
+// over comparing against this constant directly, so multi-provider admins work
+// and so a same-subject identity on a DIFFERENT provider can never inherit admin.
 const hubAdminUsername = "clubanderson"
+
+// hubAdminsEnv is the env var (comma-separated canonical ids, e.g.
+// "github:clubanderson,google:1078...") that overrides the admin set. A bare
+// login in the list is accepted and treated as github: via the identity shim.
+const hubAdminsEnv = "HIVE_HUB_ADMINS"
+
+// hubAdminSet returns the canonicalized set of admin identities. Sourced from
+// HIVE_HUB_ADMINS when set, else the single default hubAdminUsername. Every entry
+// is run through canonicalizeLegacy so a bare login becomes github:<login>; this
+// is what stops a Google/IBMid user whose subject happens to be "clubanderson"
+// from matching the GitHub admin.
+func hubAdminSet() map[string]bool {
+	raw := strings.TrimSpace(os.Getenv(hubAdminsEnv))
+	entries := []string{hubAdminUsername}
+	if raw != "" {
+		entries = splitCSV(raw)
+	}
+	set := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if c := canonicalizeLegacy(e); c != "" {
+			set[strings.ToLower(c)] = true
+		}
+	}
+	return set
+}
+
+// isHubAdmin reports whether the given identity (bare-legacy or canonical) is a
+// hub admin. Both the input and the configured admin ids are canonicalized, so
+// "clubanderson", "github:clubanderson", and "GitHub:ClubAnderson" all match the
+// default admin, while "google:clubanderson" does NOT.
+func isHubAdmin(id string) bool {
+	if id == "" {
+		return false
+	}
+	return hubAdminSet()[strings.ToLower(canonicalizeLegacy(id))]
+}
+
+// primaryHubAdmin returns the canonical identity of the primary hub admin — the
+// first entry of HIVE_HUB_ADMINS, else the default. Used where the code needs a
+// concrete admin identity to WRITE (e.g. stamping a placeholder's Owner).
+func primaryHubAdmin() string {
+	raw := strings.TrimSpace(os.Getenv(hubAdminsEnv))
+	if raw != "" {
+		if list := splitCSV(raw); len(list) > 0 {
+			return canonicalizeLegacy(list[0])
+		}
+	}
+	return canonicalizeLegacy(hubAdminUsername)
+}
 
 func splitCSV(s string) []string {
 	parts := strings.Split(s, ",")
@@ -454,7 +509,7 @@ func (s *HubServer) blockIfImpersonatingWrite(w http.ResponseWriter, r *http.Req
 // read used for messaging/audit/status; the security decisions live in
 // resolveIdentity.
 func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGrant, bool) {
-	if s.getRealAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getRealAuthUser(r)) {
 		return impersonationGrant{}, false
 	}
 	cookie, err := r.Cookie(impersonateCookieName)
@@ -462,7 +517,7 @@ func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGran
 		return impersonationGrant{}, false
 	}
 	grant, ok := verifyImpersonateCookieValue(s.hubSecret, cookie.Value, time.Now())
-	if !ok || grant.Admin != hubAdminUsername {
+	if !ok || !isHubAdmin(grant.Admin) {
 		return impersonationGrant{}, false
 	}
 	if loadSaaSUser(grant.Target) == nil {
@@ -636,7 +691,7 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 // the target is always a normal user, and writes never run under it.
 func (s *HubServer) resolveIdentity(r *http.Request) (effective, realUser string, impersonating bool) {
 	realUser = s.getRealAuthUser(r)
-	if realUser == "" || realUser != hubAdminUsername {
+	if realUser == "" || !isHubAdmin(realUser) {
 		return realUser, realUser, false
 	}
 	cookie, err := r.Cookie(impersonateCookieName)
@@ -783,7 +838,7 @@ func ensureSaaSUser(username string) *SaaSUser {
 		return u
 	}
 	quota := 0
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		quota = -1
 	}
 	u = &SaaSUser{
@@ -839,7 +894,7 @@ func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 		// particular the impersonation exit) must still be reachable by the real
 		// admin, and no admin-only surface may leak to the impersonated target.
 		username := s.getRealAuthUser(r)
-		if username != hubAdminUsername {
+		if !isHubAdmin(username) {
 			http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 			return
 		}
@@ -1062,7 +1117,7 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 // record (login state, quota, encrypted token).
 func (s *HubServer) handleAdminDeleteUser(w http.ResponseWriter, r *http.Request) {
 	username := r.PathValue("username")
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		writeJSONError(w, http.StatusForbidden, "cannot delete the hub admin")
 		return
 	}
@@ -2455,7 +2510,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
 			if isAdmin && role != "owner" {
@@ -2760,7 +2815,7 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	hiveAccess := make(map[string]hiveAccessInfo)
 
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
 			hiveAccess[h.ID] = hiveAccessInfo{Role: role, Status: "accepted"}
@@ -3092,7 +3147,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	// the spoke. The role we pass is advisory — the spoke re-checks its own
 	// allowlist and uses that role authoritatively.
 	role := saasRoleRead
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		role = saasRoleOwner
 	} else {
 		user := loadSaaSUser(username)
@@ -5540,7 +5595,7 @@ func userIsHiveOwner(username string, h *SaaSHive) bool {
 	if username == "" || h == nil {
 		return false
 	}
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		return true
 	}
 	if strings.EqualFold(h.Owner, username) {
@@ -5564,7 +5619,7 @@ func (s *HubServer) handleAccessList(w http.ResponseWriter, r *http.Request) {
 	}
 	// Notes is admin-only; a non-admin owner viewing their hive's access gets
 	// name+Slack but not the admin's private CRM notes.
-	access := accessForHive(hiveID, listAllSaaSUsers(), username == hubAdminUsername)
+	access := accessForHive(hiveID, listAllSaaSUsers(), isHubAdmin(username))
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"access": access})
 }
@@ -5580,7 +5635,7 @@ func (s *HubServer) handleGrantableUsers(w http.ResponseWriter, r *http.Request)
 	username := s.getAuthUser(r)
 	// Any user who owns at least one hive may see the roster; that is the same
 	// bar as being able to open Manage Access at all. Admin always qualifies.
-	owns := username == hubAdminUsername
+	owns := isHubAdmin(username)
 	if !owns {
 		for _, h := range listSaaSHives() {
 			h := h
@@ -5802,7 +5857,7 @@ func (s *HubServer) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	role := user.Hives[hiveID]
-	if !config.RoleAtLeast(role, config.RoleReadWrite) && username != hubAdminUsername {
+	if !config.RoleAtLeast(role, config.RoleReadWrite) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5836,7 +5891,7 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	approverRole := approverUser.Hives[hiveID]
-	if !config.RoleAtLeast(approverRole, config.RoleReadWrite) && approver != hubAdminUsername {
+	if !config.RoleAtLeast(approverRole, config.RoleReadWrite) && !isHubAdmin(approver) {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5853,7 +5908,7 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 		http.Error(w, `{"error":"role must be read, read-write, merger, or owner"}`, http.StatusBadRequest)
 		return
 	}
-	if approver != hubAdminUsername && config.RoleAtLeast(body.Role, approverRole) {
+	if !isHubAdmin(approver) && config.RoleAtLeast(body.Role, approverRole) {
 		http.Error(w, `{"error":"cannot grant a role equal to or higher than your own"}`, http.StatusForbidden)
 		return
 	}
@@ -5894,7 +5949,7 @@ func (s *HubServer) handleDenyRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	denierRole := denierUser.Hives[hiveID]
-	if !config.RoleAtLeast(denierRole, config.RoleReadWrite) && denier != hubAdminUsername {
+	if !config.RoleAtLeast(denierRole, config.RoleReadWrite) && !isHubAdmin(denier) {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5931,7 +5986,7 @@ func (s *HubServer) handleApproveAccess(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	approverRole := approverUser.Hives[hiveID]
-	if approverRole != "owner" && approver != hubAdminUsername {
+	if approverRole != "owner" && !isHubAdmin(approver) {
 		http.Error(w, `{"error":"only the owner can approve access"}`, http.StatusForbidden)
 		return
 	}
@@ -5977,7 +6032,7 @@ func (s *HubServer) handleDenyAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	denierRole := denierUser.Hives[hiveID]
-	if denierRole != "owner" && denier != hubAdminUsername {
+	if denierRole != "owner" && !isHubAdmin(denier) {
 		http.Error(w, `{"error":"only the owner can deny access"}`, http.StatusForbidden)
 		return
 	}
@@ -6475,7 +6530,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		// Admin chose a specific placeholder — validate it is an available
 		// placeholder (same check the assign path uses) before using it. The
 		// full status recheck under loadSaaSHive below still guards the race.
-		if sel := loadSaaSHive(hiveID); sel == nil || sel.Status != statusAvailable || sel.Owner != hubAdminUsername {
+		if sel := loadSaaSHive(hiveID); sel == nil || sel.Status != statusAvailable || !isHubAdmin(sel.Owner) {
 			http.Error(w, `{"error":"selected placeholder is not available"}`, http.StatusConflict)
 			return
 		}
@@ -6747,7 +6802,7 @@ func findAvailablePlaceholder(clusterID string) string {
 		if h.Status != statusAvailable {
 			continue
 		}
-		if h.Owner != hubAdminUsername {
+		if !isHubAdmin(h.Owner) {
 			continue
 		}
 		if clusterIDForHive(&h) != clusterID {
@@ -6776,7 +6831,7 @@ func listAvailablePlaceholders(pool string) []AvailablePlaceholder {
 		if h.Status != statusAvailable {
 			continue
 		}
-		if h.Owner != hubAdminUsername {
+		if !isHubAdmin(h.Owner) {
 			continue
 		}
 		cluster := clusterIDForHive(&h)
@@ -7206,7 +7261,7 @@ type AssignHiveRequest struct {
 // both reachable (hive-oke) and heartbeat-only (vllm-d) clusters: NO hub→spoke
 // push or kubectl is used, so a vllm-d claim is delivered entirely by heartbeat.
 func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 		return
 	}
@@ -7538,7 +7593,7 @@ func (s *HubServer) handleUserToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requester := s.getAuthUser(r)
-	if requester != body.Username && requester != hubAdminUsername {
+	if requester != body.Username && !isHubAdmin(requester) {
 		http.Error(w, `{"error":"can only retrieve your own token"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -107,7 +107,7 @@ func (s *HubServer) registerBulkRoutes() {
 
 // authorizeBulkHive re-derives authorization for one hive from the hub's own
 // store, mirroring the owner check every single-hive handler performs
-// (h.Owner != username && username != hubAdminUsername). It returns the loaded
+// (h.Owner != username && !isHubAdmin(username)). It returns the loaded
 // hive on success, or a reason string on refusal. The client's list is never
 // trusted: an ID that does not resolve, or resolves to someone else's hive, is
 // refused here rather than acted on.
@@ -119,7 +119,7 @@ func authorizeBulkHive(id, username string) (*SaaSHive, string) {
 	if h == nil {
 		return nil, "hive not found"
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		return nil, "not authorized for this hive"
 	}
 	return h, ""

--- a/v2/pkg/hub/saas_provision_gaps_coverage_test.go
+++ b/v2/pkg/hub/saas_provision_gaps_coverage_test.go
@@ -19,7 +19,6 @@ func gapsLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-
 // ── mintClaimVanityURL ──────────────────────────────────────────────────────
 
 func TestMintClaimVanityURLNilHive(t *testing.T) {
@@ -254,4 +253,3 @@ func TestKubectlArgsForClusterRemote(t *testing.T) {
 		t.Errorf("command args not appended correctly: %v", args)
 	}
 }
-

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -2837,7 +2837,7 @@ func (s *HubServer) saveRegistryNow() error {
 }
 
 func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, "admin access required", http.StatusForbidden)
 		return
 	}
@@ -2858,7 +2858,7 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 			s.logger.Error("admin registry removal persist failed", "id", id, "error", err)
 			s.requestSave()
 		}
-		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", hubAdminUsername)
+		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", primaryHubAdmin())
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"removed": removed, "id": id})

--- a/v2/pkg/hub/slack.go
+++ b/v2/pkg/hub/slack.go
@@ -385,7 +385,7 @@ func (s *HubServer) handleSlackMessageUser(w http.ResponseWriter, r *http.Reques
 	}
 	actor := s.getAuthUser(r)
 	username := r.PathValue("username")
-	if actor != hubAdminUsername && !strings.EqualFold(actor, username) {
+	if !isHubAdmin(actor) && !strings.EqualFold(actor, username) {
 		http.Error(w, `{"error":"only an admin can message another user"}`, http.StatusForbidden)
 		return
 	}
@@ -441,7 +441,7 @@ func (s *HubServer) handleSlackMessageHiveOwner(w http.ResponseWriter, r *http.R
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != actor && actor != hubAdminUsername {
+	if h.Owner != actor && !isHubAdmin(actor) {
 		http.Error(w, `{"error":"only the owner can message this hive's owner"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/spoke_restart.go
+++ b/v2/pkg/hub/spoke_restart.go
@@ -152,7 +152,7 @@ func (s *HubServer) restartSpokeForHeartbeat(hiveID string) bool {
 // (RolloutRestartSelf): a stale pod is replaced and never comes back, while
 // the healthy instance suffers one rolling restart.
 func (s *HubServer) handleRestartSpoke(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/timeline.go
+++ b/v2/pkg/hub/timeline.go
@@ -564,7 +564,7 @@ func (s *HubServer) handleHiveTimeline(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can view this hive's timeline"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/usage.go
+++ b/v2/pkg/hub/usage.go
@@ -375,7 +375,7 @@ func (s *HubServer) usageHistorySnapshot() []UsageSnapshot {
 // unauthenticated caller never reaches this handler at all.
 func (s *HubServer) handleUsage(w http.ResponseWriter, r *http.Request) {
 	username := s.getAuthUser(r)
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 
 	s.mu.RLock()
 	scoped := make([]RegistryEntry, 0, len(s.registry.Hives))


### PR DESCRIPTION
## What

Phase **1b** of multi-provider login (builds on the canonical-identity foundation from #3566). Generalizes the hub **admin gate** so it works across login providers and can't be spoofed cross-provider. No user-visible change.

## Why

The admin gate was a bare GitHub login compared by `==` across **49 sites** (`hubAdminUsername = "clubanderson"`). Once other providers can log in, a bare-subject compare is unsafe: registering "clubanderson" on Google/IBMid would inherit admin.

## Changes

- **`isHubAdmin(id)` / `primaryHubAdmin()` / `hubAdminSet()`** — admin set from env `HIVE_HUB_ADMINS` (comma-separated canonical ids, default `github:clubanderson`). Both the configured entries and the checked identity are canonicalized, so `clubanderson`, `github:clubanderson`, `GitHub:ClubAnderson` all match the default admin while **`google:clubanderson` does NOT**.
- **All 49 `hubAdminUsername` comparison sites → `isHubAdmin()`.** Compound owner-OR-admin checks keep the owner clause unchanged (owner-field canonicalization is phase 1c) and convert only the admin clause; the audit-log admin value uses `primaryHubAdmin()`. **No Owner *write* value changes here** (kept bare; 1c's job).

## Safety

Backward-compatible: with `HIVE_HUB_ADMINS` unset, behavior is identical to today. Scope is HUMAN login + access control only — the GitHub **App** token and agent/backend logins are untouched.

## Tests (`admin_gate_test.go`)

Default + legacy-shim + case-insensitive match; the **SECURITY negative** (`google/ibmid/redhat:clubanderson` is NOT admin — plan Risk #1 gate); env-override replaces the set and stays cross-provider-isolated; `primaryHubAdmin` ordering.

Verified locally: `go build ./pkg/hub ./pkg/dashboard` clean; **FULL `go test ./pkg/hub/` passes (62s)** — the 49-site sweep breaks no existing admin/owner authz test.

## Next
1c: dual-read user store + the ~28 owner-match sites + `AuthorizedRole` canonicalization (incl. canonicalizing Owner writes). 1d: `SaaSUser` provider/avatar/email fields. Then Phase 2 = Google OIDC on the hub.