### PR TITLE
🔒 feat(hub): canonical owner-match + dual-read user store (multi-login phase 1c)

### DIFF
--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -257,7 +257,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can switch forges"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/openrouter.go
+++ b/v2/pkg/hub/openrouter.go
@@ -69,7 +69,7 @@ func (s *HubServer) ownsHiveForFunding(username, hiveID string) bool {
 		return true
 	}
 	h := loadSaaSHive(hiveID)
-	if h != nil && strings.EqualFold(h.Owner, username) {
+	if h != nil && canonicalEqual(h.Owner, username) {
 		return true
 	}
 	if u := loadSaaSUser(username); u != nil {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -781,12 +781,73 @@ func (s *HubServer) validateGitHubToken(token string) string {
 	return user.Login
 }
 
+// saaSUserFilePaths returns the candidate on-disk paths for an identity, in
+// read/try order: the canonical filename first, then the legacy "<login>.json"
+// fallback for a bare or github: identity. The caller has already rejected
+// path-traversal characters in the raw username.
+func saaSUserFilePaths(username string) []string {
+	var paths []string
+	if stem, err := encodeUserFilename(username); err == nil {
+		paths = append(paths, filepath.Join(saasUsersDir, stem+".json"))
+	}
+	provider, subject, ok := parseCanonical(username)
+	if ok && provider == legacyProvider {
+		legacy := filepath.Join(saasUsersDir, subject+".json")
+		if len(paths) == 0 || paths[0] != legacy {
+			paths = append(paths, legacy)
+		}
+	}
+	return paths
+}
+
+// readSaaSUserFile reads a user's JSON, trying the canonical filename then the
+// legacy fallback (see saaSUserFilePaths). Returns the first file that reads.
+func readSaaSUserFile(username string) ([]byte, error) {
+	var firstErr error
+	for _, p := range saaSUserFilePaths(username) {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return data, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr == nil {
+		firstErr = os.ErrNotExist
+	}
+	return nil, firstErr
+}
+
+// saveSaaSUserPath returns the file path a user record is written to. A GitHub
+// (or bare-legacy) primary keeps its legacy "<login>.json" so existing records
+// are updated in place with no rename; a non-GitHub primary writes the canonical
+// "<provider>.<subject>.json".
+func saveSaaSUserPath(u *SaaSUser) (string, error) {
+	// The record's primary identity. Today this is GitHubUsername (a bare login
+	// for GitHub users, or a canonical id once non-GitHub records exist in 1d+).
+	id := u.GitHubUsername
+	provider, subject, ok := parseCanonical(id)
+	if !ok {
+		return "", fmt.Errorf("invalid identity for save: %q", id)
+	}
+	if provider == legacyProvider {
+		return filepath.Join(saasUsersDir, subject+".json"), nil
+	}
+	stem, err := encodeUserFilename(id)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(saasUsersDir, stem+".json"), nil
+}
+
 func loadSaaSUser(username string) *SaaSUser {
 	if strings.Contains(username, "..") || strings.Contains(username, "/") || strings.Contains(username, "\\") {
 		return nil
 	}
-	path := filepath.Join(saasUsersDir, username+".json")
-	data, err := os.ReadFile(path)
+	// Dual-read: try the canonical filename ("google.1078.json") then the legacy
+	// "<login>.json". No file is rewritten — existing users resolve via legacy.
+	data, err := readSaaSUserFile(username)
 	if err != nil {
 		return nil
 	}
@@ -819,7 +880,10 @@ func saveSaaSUser(u *SaaSUser) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(saasUsersDir, u.GitHubUsername+".json")
+	path, err := saveSaaSUserPath(u)
+	if err != nil {
+		return err
+	}
 	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		return err
@@ -863,7 +927,14 @@ func listAllSaaSUsers() []SaaSUser {
 		if !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
-		u := loadSaaSUser(strings.TrimSuffix(e.Name(), ".json"))
+		stem := strings.TrimSuffix(e.Name(), ".json")
+		// A canonical filename ("google.1078", "github.foo") decodes to its wire
+		// id; a legacy filename ("foo") does not — load it as the bare login.
+		key := stem
+		if id, ok := decodeUserFilename(stem); ok {
+			key = id
+		}
+		u := loadSaaSUser(key)
 		if u != nil {
 			users = append(users, *u)
 		}
@@ -2521,7 +2592,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			result = append(result, entry)
 			continue
 		}
-		if strings.EqualFold(h.Owner, username) {
+		if canonicalEqual(h.Owner, username) {
 			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID], AutoUpgradeMode: autoUpgradeModeMap[h.ID]}
 			enrichFromSaaSMeta(&entry)
 			result = append(result, entry)
@@ -2569,7 +2640,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, sh := range listSaaSHives() {
-		if (sh.Owner == username || isAdmin) && !seen[sh.ID] {
+		if (canonicalEqual(sh.Owner, username) || isAdmin) && !seen[sh.ID] {
 			user.Hives[sh.ID] = "owner"
 			entry := MyHiveEntry{
 				RegistryEntry: RegistryEntry{
@@ -2821,7 +2892,7 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 			hiveAccess[h.ID] = hiveAccessInfo{Role: role, Status: "accepted"}
 			continue
 		}
-		if strings.EqualFold(h.Owner, username) {
+		if canonicalEqual(h.Owner, username) {
 			hiveAccess[h.ID] = hiveAccessInfo{Role: "owner", Status: "accepted"}
 			continue
 		}
@@ -3155,7 +3226,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 			return
 		}
-		if h := loadSaaSHive(id); h != nil && h.Owner == username {
+		if h := loadSaaSHive(id); h != nil && canonicalEqual(h.Owner, username) {
 			role = saasRoleOwner
 		} else if r, ok := user.Hives[id]; ok {
 			role = r
@@ -5598,7 +5669,7 @@ func userIsHiveOwner(username string, h *SaaSHive) bool {
 	if isHubAdmin(username) {
 		return true
 	}
-	if strings.EqualFold(h.Owner, username) {
+	if canonicalEqual(h.Owner, username) {
 		return true
 	}
 	u := loadSaaSUser(username)

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -107,7 +107,7 @@ func (s *HubServer) registerBulkRoutes() {
 
 // authorizeBulkHive re-derives authorization for one hive from the hub's own
 // store, mirroring the owner check every single-hive handler performs
-// (h.Owner != username && !isHubAdmin(username)). It returns the loaded
+// (!canonicalEqual(h.Owner, username) && !isHubAdmin(username)). It returns the loaded
 // hive on success, or a reason string on refusal. The client's list is never
 // trusted: an ID that does not resolve, or resolves to someone else's hive, is
 // refused here rather than acted on.
@@ -119,7 +119,7 @@ func authorizeBulkHive(id, username string) (*SaaSHive, string) {
 	if h == nil {
 		return nil, "hive not found"
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		return nil, "not authorized for this hive"
 	}
 	return h, ""

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1594,7 +1594,7 @@ func listSaaSHives() []SaaSHive {
 func countUserHives(username string) int {
 	count := 0
 	for _, h := range listSaaSHives() {
-		if h.Owner == username {
+		if canonicalEqual(h.Owner, username) {
 			count++
 		}
 	}

--- a/v2/pkg/hub/saas_user_dualread_test.go
+++ b/v2/pkg/hub/saas_user_dualread_test.go
@@ -1,0 +1,104 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempUsersDir points saasUsersDir at a fresh temp dir and restores it.
+func withTempUsersDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "users")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := saasUsersDir
+	saasUsersDir = dir
+	t.Cleanup(func() { saasUsersDir = orig })
+	return dir
+}
+
+func writeRawUser(t *testing.T, dir, filename string, u SaaSUser) {
+	t.Helper()
+	data, _ := json.MarshalIndent(&u, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, filename), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDualRead_LegacyAndCanonical: a pre-migration legacy file "<login>.json" and
+// a canonical "<provider>.<subject>.json" both resolve through loadSaaSUser, by
+// bare login, by github: canonical, and by non-github canonical.
+func TestDualRead_LegacyAndCanonical(t *testing.T) {
+	dir := withTempUsersDir(t)
+
+	// Legacy GitHub user on disk as "alice.json" (no provider prefix).
+	writeRawUser(t, dir, "alice.json", SaaSUser{GitHubUsername: "alice"})
+	// Canonical Google user on disk as "google.1078.json".
+	writeRawUser(t, dir, "google.1078.json", SaaSUser{GitHubUsername: "google:1078"})
+
+	// Legacy user resolves by bare login AND by github: canonical.
+	if u := loadSaaSUser("alice"); u == nil || u.GitHubUsername != "alice" {
+		t.Errorf("loadSaaSUser(alice) = %+v", u)
+	}
+	if u := loadSaaSUser("github:alice"); u == nil || u.GitHubUsername != "alice" {
+		t.Errorf("loadSaaSUser(github:alice) should resolve the legacy file, got %+v", u)
+	}
+	// Google user resolves by its canonical id (and NOT via a legacy path).
+	if u := loadSaaSUser("google:1078"); u == nil || u.GitHubUsername != "google:1078" {
+		t.Errorf("loadSaaSUser(google:1078) = %+v", u)
+	}
+	// A non-existent user is nil.
+	if u := loadSaaSUser("nobody"); u != nil {
+		t.Errorf("loadSaaSUser(nobody) = %+v, want nil", u)
+	}
+}
+
+// TestSave_LegacyStaysInPlace_CanonicalWritesCanonical: saving a GitHub user
+// updates the legacy "<login>.json" (no rename/migration), while a non-GitHub
+// user writes the canonical filename.
+func TestSave_LegacyStaysInPlace_CanonicalWritesCanonical(t *testing.T) {
+	dir := withTempUsersDir(t)
+
+	// GitHub user → legacy file, in place.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "bob", Hives: map[string]string{}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "bob.json")); err != nil {
+		t.Errorf("expected legacy bob.json, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "github.bob.json")); err == nil {
+		t.Error("GitHub user must NOT create a canonical github.bob.json (no migration on save)")
+	}
+
+	// Google user → canonical file.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "google:2222", Hives: map[string]string{}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "google.2222.json")); err != nil {
+		t.Errorf("expected canonical google.2222.json, got %v", err)
+	}
+	// And it round-trips through load.
+	if u := loadSaaSUser("google:2222"); u == nil || u.GitHubUsername != "google:2222" {
+		t.Errorf("round-trip loadSaaSUser(google:2222) = %+v", u)
+	}
+}
+
+// TestListAllSaaSUsers_MixedFilenames: enumeration decodes canonical filenames
+// and leaves legacy ones as-is, returning both users.
+func TestListAllSaaSUsers_MixedFilenames(t *testing.T) {
+	dir := withTempUsersDir(t)
+	writeRawUser(t, dir, "carol.json", SaaSUser{GitHubUsername: "carol"})
+	writeRawUser(t, dir, "google.3333.json", SaaSUser{GitHubUsername: "google:3333"})
+
+	users := listAllSaaSUsers()
+	got := map[string]bool{}
+	for _, u := range users {
+		got[u.GitHubUsername] = true
+	}
+	if !got["carol"] || !got["google:3333"] {
+		t.Errorf("listAllSaaSUsers missing an entry: %+v", got)
+	}
+}

--- a/v2/pkg/hub/slack.go
+++ b/v2/pkg/hub/slack.go
@@ -441,7 +441,7 @@ func (s *HubServer) handleSlackMessageHiveOwner(w http.ResponseWriter, r *http.R
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != actor && !isHubAdmin(actor) {
+	if !canonicalEqual(h.Owner, actor) && !isHubAdmin(actor) {
 		http.Error(w, `{"error":"only the owner can message this hive's owner"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/timeline.go
+++ b/v2/pkg/hub/timeline.go
@@ -564,7 +564,7 @@ func (s *HubServer) handleHiveTimeline(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can view this hive's timeline"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/usage.go
+++ b/v2/pkg/hub/usage.go
@@ -380,7 +380,7 @@ func (s *HubServer) handleUsage(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	scoped := make([]RegistryEntry, 0, len(s.registry.Hives))
 	for _, h := range s.registry.Hives {
-		if isAdmin || strings.EqualFold(strings.TrimSpace(h.Owner), strings.TrimSpace(username)) {
+		if isAdmin || canonicalEqual(h.Owner, username) {
 			scoped = append(scoped, h)
 		}
 	}


### PR DESCRIPTION
## What

Phase **1c** of multi-provider login. Makes **hive-ownership matching** and the **user store** provider-agnostic, so a canonical identity (`google:1078`, `github:foo`) and a legacy bare login resolve to the same user and match the same grants — with **NO data migration**.

> **Stacks on #3566 (1a) + #3568 (1b).** Until #3568 merges, this PR's diff includes 1b's admin-gate changes; it resolves to just the owner-match + dual-read changes once 1b lands (I'll rebase then).

## Changes

- **Owner-match (10 sites):** every `h.Owner`/`sh.Owner` compare that gated owner-vs-not (`EqualFold(h.Owner, username)`, `h.Owner == username`, and the compound `h.Owner != X && !isHubAdmin(X)`) now uses `canonicalEqual()` — canonicalizes both sides. Legacy `Owner="clubanderson"` matches authenticated `github:clubanderson`; `google:clubanderson` does **not** (cross-provider isolation). Owner *writes* stay bare — the shim makes that correct, no record rewritten.
- **Dual-read user store:** `loadSaaSUser` tries the canonical filename (`google.1078.json`, `github.foo.json`) then falls back to the legacy `<login>.json` for a bare/`github:` id — every pre-migration user keeps resolving with no rename. `saveSaaSUser` writes the legacy file in place for a GitHub/bare primary, the canonical file for a non-GitHub primary. `listAllSaaSUsers` decodes canonical filenames (leaving legacy stems as-is).

## Safety / scope

Human login + access control only — GitHub **App** token and agent/backend logins untouched. `AuthorizedRole` (config pkg, direct-route spokes) is deferred to Phase 2/3 where the shared auth package lands.

## Tests (`saas_user_dualread_test.go`)

Legacy + canonical both resolve by bare / `github:` / non-github id; save keeps legacy in place and writes canonical for non-GitHub; listAll enumerates mixed filenames. Verified: `go build` clean; **FULL `go test ./pkg/hub/` passes (60s)**.

## Next
1d: `SaaSUser` provider/avatar/email fields **+ a provider badge in the admin Users table** (auth-method indicator). Then Phase 2 = Google OIDC on the hub.