### PR TITLE
🔒 fix(docker): stop shipping su-exec world-executable setuid-root (C6, live on ~64 hives)

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -66,13 +66,36 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
  && curl -fsSL -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/v${SU_EXEC_VERSION}/su-exec.c" \
  && echo "${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \
- && chmod u+s /usr/local/bin/su-exec \
  && rm /tmp/su-exec.c \
  && apt-get purge -y gcc libc6-dev && apt-get autoremove -y
 
 # Non-root user for agent processes (Claude Code refuses --dangerously-skip-permissions as root)
-# node:24-slim already has group 1000 (node), so reuse it
-RUN useradd -m -u 1001 -g node -s /bin/bash dev
+# node:24-slim already has group 1000 (node), so reuse it as dev's primary group.
+#
+# SECURITY (audit C6, CWE-250/732): `hive-launch` is a dedicated supplementary
+# group whose ONLY member is dev. It gates exec of the SUID-root su-exec helper
+# (chmod 4750 below).
+#
+# su-exec was previously `chmod u+s` with the default 755 — SETUID-ROOT AND
+# WORLD-EXECUTABLE. Verified live on this branch across all three production
+# clusters: any agent UID could run `su-exec root sh` and become root inside its
+# own container, defeating the per-agent-UID isolation the whole ACMM capability
+# model rests on. That container holds the GitHub App key and every agent's
+# credentials.
+#
+# Only the hive process (running as dev, UID 1001) ever execs su-exec — see the
+# four call sites in pkg/agent/manager.go. Agents are launched BY it and never
+# invoke it themselves, so restricting exec to dev breaks nothing.
+#
+# root:node 4750 would NOT be enough: dev AND every agent UID share the primary
+# group `node` (agents are created `-g node`), so a node-gated helper is still
+# reachable by every agent. The group must contain dev alone.
+RUN groupadd --system hive-launch \
+ && useradd -m -u 1001 -g node -G hive-launch -s /bin/bash dev \
+ && chown root:hive-launch /usr/local/bin/su-exec \
+ && chmod 4750 /usr/local/bin/su-exec \
+ && [ "$(stat -c '%G' /usr/local/bin/su-exec)" = "hive-launch" ] \
+ && [ "$(stat -c '%a' /usr/local/bin/su-exec)" = "4750" ]
 
 # --- Layer 2: ttyd (pinned version for reproducible builds) ---
 ARG TTYD_VERSION=1.7.7


### PR DESCRIPTION
## The finding

**Any agent UID can become root inside its container on every v2 spoke.** Verified live:

```
$ su-exec hive-scanner sh -c 'su-exec root id'
uid=0(root) gid=0(root) groups=0(root)
```

`v2/Dockerfile` does `chmod u+s /usr/local/bin/su-exec` — that sets the setuid bit but leaves the default `755`, i.e. **setuid-root AND world-executable**.

## Scope — verified, not assumed

Every v2 spoke sampled across **all three production clusters** is `-rwsr-xr-x root:root`:

| cluster | sampled | result |
|---|---|---|
| vllm-d | 5 | all `4755 root:root` |
| akswec2 | 3 | all `4755 root:root` |
| hive-oke | 4 | all `4755 root:root` |
| hive-oke (the one v4 spoke) | 1 | `4750 root:hive-launch` ✅ |

**It tracks the image line, not the cluster.** v2 runs ~64 of the 66 live hives.

**C6 was reported fixed in an earlier audit round — it was fixed on `v4` only.**

## Why it matters

It defeats the per-agent-UID isolation the whole ACMM capability model rests on. In-container root can read the GitHub App key, rewrite `/data` state, manipulate iptables, and bypass the MITM proxy regardless of how egress exemptions are designed. Blast radius is the container rather than the node — but that container holds every agent's credentials.

## The fix

Port v4's: a dedicated `hive-launch` supplementary group whose only member is `dev` (1001), with su-exec `root:hive-launch` mode `4750`.

**`root:node 4750` would not be enough** — `dev` and every agent UID share the primary group `node` (agents are created `-g node`), so a node-gated helper stays reachable by every agent. The group must contain `dev` alone.

Only the hive process (running as `dev`) ever execs su-exec — all four call sites are in `pkg/agent/manager.go`. Agents are launched *by* it and never invoke it themselves, so restricting exec to `dev` breaks nothing.

## What I deliberately did NOT copy from v4

v4 pins `HIVE_LAUNCH_GID=1002` with an already-taken-GID preflight, because **v4's** Kubernetes manifests set `fsGroup`, which takes a numeric GID. **v2 sets `fsGroup` nowhere** (`git grep fsGroup` on this branch is empty), so pinning here would invent a deployment contract this branch doesn't have. `groupadd --system` allocates freely.

Two build-time assertions (group name and `4750`) fail the build if the chown/chmod silently doesn't take.

## Verification

No docker daemon is available to me, so rather than guess I verified the **target configuration in production** — the v4 console spoke already runs exactly it:

```
su-exec:        -rwsr-x---  root:hive-launch
dev groups:     1000(node),1002(hive-launch)
agent groups:   1000(node),993(hive-scanner)

agent → su-exec root id     →  su-exec: Permission denied   ← escalation blocked
dev   → su-exec hive-scanner →  uid=2007(hive-scanner)      ← launch path works
agents mapped: 10
```

So the configuration both blocks the escalation and keeps the agent launch path working, under real load.

CI builds the image, and the two in-Dockerfile assertions gate the result.

## Note

v4 also carries `v2/scripts/check-suid-contract.sh` as a CI gate; it does not exist on v2. Worth porting as a follow-up so this can't regress — flagging rather than bundling, since it needs its own workflow wiring.