### PR TITLE
🔒 fix(docker): give the hive binary cap_net_admin so forced-proxy egress works on OpenShift

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -302,6 +302,42 @@ RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bi
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
     /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-merge
 
+# SECURITY (audit F5-egress / refs #2674, #2678): give the hive binary
+# CAP_NET_ADMIN as a FILE capability so the MITM proxy's own upstream dials can
+# be exempted from the forced-egress iptables REDIRECT.
+#
+# WHY THIS IS NEEDED
+# The entrypoint installs `-p tcp --dport 443 -j REDIRECT` so every agent's
+# egress is forced through the proxy, then exempts the proxy's OWN traffic three
+# ways. On OKE the `-m owner --uid-owner` matches work. On OpenShift/OVN xt_owner
+# is ABSENT, so those rules silently fail to load (`|| true`) and the only
+# remaining exemption is the SO_MARK packet mark — but setsockopt(SO_MARK)
+# requires CAP_NET_ADMIN in the calling process's EFFECTIVE set. The entrypoint
+# runs as root only long enough to build the chain; the hive process itself is
+# dropped to `dev` via gosu, so without a file capability it loses NET_ADMIN and
+# the mark silently fails ("operation not permitted").
+#
+# Observed live on vllm-d: with neither exemption active the proxy's own :443
+# dials hit the REDIRECT and looped back into itself, returning 502 for every
+# forge request and cutting a live tenant's agents off from their repository.
+#
+# WHY A FILE CAPABILITY IS SAFE HERE
+# File caps are recomputed AT EXEC from the binary being exec'd. Agents are
+# launched via su-exec into their OWN binaries (claude/goose/bob), which carry
+# no file capability, so NET_ADMIN does NOT propagate to any agent process.
+# Agent UIDs (2001+) also cannot exec su-exec itself — it is 4750
+# root:hive-launch and only `dev` is in that group (audit C6) — so there is no
+# path from an agent to a process holding this capability.
+#
+# +ep = permitted AND effective: the hive process needs the cap live at
+# setsockopt time, not merely inheritable.
+RUN apt-get update && apt-get install -y --no-install-recommends libcap2-bin \
+ && setcap cap_net_admin+ep /usr/local/bin/hive \
+ && [ "$(getcap /usr/local/bin/hive)" != "" ] \
+ && getcap /usr/local/bin/hive | grep -q "cap_net_admin" \
+ && apt-get purge -y libcap2-bin \
+ && rm -rf /var/lib/apt/lists/*
+
 # --- Nous framework (strategist experiment engine) ---
 RUN (apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-venv python3-pip jq && rm -rf /var/lib/apt/lists/*) || \

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -106,6 +106,34 @@ check "hive-launch launcher group is created" \
 check "dev is a member of hive-launch" \
   'useradd.*-G[[:space:]]+hive-launch'
 
+# ── File-capability contract (audit F5-egress, refs #2674/#2678) ──────────────
+#
+# The hive binary carries cap_net_admin+ep so the MITM proxy can stamp SO_MARK
+# on its own upstream dials and be exempted from the forced-egress iptables
+# REDIRECT. Without it, on OpenShift (no xt_owner, so the owner-UID exemptions
+# silently fail to load) the proxy redirects its OWN traffic into itself and
+# every forge request 502s — observed live on vllm-d.
+#
+# The capability is SAFE only because it cannot reach an agent:
+#   - file caps are recomputed at exec, and agents exec their own binaries
+#   - agents cannot exec su-exec (4750 root:hive-launch, asserted above)
+# If either invariant breaks, this capability becomes an escalation path — hence
+# both are asserted in the same contract.
+check "hive binary carries cap_net_admin" \
+  'setcap[[:space:]]+cap_net_admin\+ep[[:space:]]+/usr/local/bin/hive'
+check "the capability is verified at build time" \
+  'getcap[[:space:]]+/usr/local/bin/hive'
+
+# No OTHER binary may be given a capability. Agents run their own binaries; a
+# capability on any of them would hand NET_ADMIN straight to an agent process.
+if printf '%s\n' "$CODE" | grep -oE 'setcap[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+' \
+   | grep -qvE 'setcap[[:space:]]+cap_net_admin\+ep[[:space:]]+/usr/local/bin/hive'; then
+  echo "  FAIL: a setcap targets something other than /usr/local/bin/hive"
+  fail=1
+else
+  echo "  ok: no capability is granted to any binary except /usr/local/bin/hive"
+fi
+
 if [[ "$fail" -ne 0 ]]; then
   echo ""
   echo "SUID helper contract check FAILED — a world-exec or unpinned setuid-root"


### PR DESCRIPTION
## The problem

v4's forced-proxy egress is **fail-closed by design**: the entrypoint installs an iptables REDIRECT for all `:443` and refuses to start if it can't, because advisory-only mode lets an agent with a raw token bypass the MITM proxy entirely.

It then exempts the proxy's **own** upstream dials three ways:

```
-m owner --uid-owner 0          -j RETURN  || true   # OKE
-m owner --uid-owner $PROXY_UID -j RETURN  || true   # OKE
-m mark --mark $EGRESS_MARK     -j RETURN            # OpenShift (SO_MARK)
-p tcp --dport 443 -j REDIRECT --to-ports $PROXY_PORT
```

On **OpenShift/OVN `xt_owner` is absent**, so the two owner rules silently fail to load (`|| true`). The only remaining exemption is `SO_MARK` — and `setsockopt(SO_MARK)` needs `CAP_NET_ADMIN` in the **calling process's effective set**. The entrypoint is root only long enough to build the chain; the hive process is then dropped to `dev` via `gosu` and loses the capability.

**Observed live on `vllm-d`:** with neither exemption active, the proxy's own `:443` dials hit the REDIRECT and looped back into itself — 502 on every forge request, cutting a live **L6 tenant's** 10 agents off from their repository. `github.ibm.com` went from `401` (reachable) to `000`.

Granting `NET_ADMIN` to the **container** is not enough. A file capability is what survives the `gosu` uid drop.

## Why this does not hand NET_ADMIN to an agent

- File capabilities are recomputed **at exec** from the binary being exec'd. Agents launch via `su-exec` into their **own** binaries (`claude`/`goose`/`bob`), which carry no capability — nothing propagates.
- Agent UIDs cannot exec `su-exec` itself: it is `4750 root:hive-launch` and only `dev` is in that group (audit C6).

**Both invariants are now asserted in the same contract script**, because this capability is only safe while they hold. If either regresses, CI fails.

## Rejected alternative, and why

The obvious platform-neutral fix is to exempt the proxy by **source port**. I rejected it: any unprivileged process can bind a chosen high port — verified empirically as a non-root user — so an agent could forge the exemption and bypass the proxy completely.

That would have **recreated advisory mode while still looking enforced** — worse than the explicit `HIVE_PROXY_ADVISORY_OK` flag, which at least announces what it disables. The criterion that matters is whether the exempted signal is *forgeable by the agents being constrained*; source port is, `CAP_NET_ADMIN` isn't.

## Verification

`check-suid-contract.sh` gains three assertions, and I verified each by reverting:

```
# remove the setcap
FAIL: hive binary carries cap_net_admin

# add a setcap on /usr/local/bin/gh  (an agent-reachable binary)
FAIL: a setcap targets something other than /usr/local/bin/hive

# restored
SUID helper contract check passed.
```

That second check is the important one — it's exactly the escalation shape this design has to prevent, and it's the check that would have caught the source-port approach.

`libcap2-bin` is installed only to run `setcap` and purged immediately. The purge is deliberately **not** followed by `autoremove`, which could pull `libcap2` (the shared library) out from under other binaries.

## Note on scope

No local Docker daemon was available, so this is not built locally; CI builds the image and the in-Dockerfile `getcap` assertion gates the result. The behavioural claim — that this fixes OpenShift egress — is inferred from the live 502 diagnosis and the SO_MARK/`xt_owner` mechanics, and should be confirmed on a real OpenShift spoke before the fleet is rolled to v4.