### PR TITLE
✨ feat(hub): Google OIDC human login + provider abstraction (multi-login phase 2)

### DIFF
--- a/v2/pkg/auth/coverage_test.go
+++ b/v2/pkg/auth/coverage_test.go
@@ -1,0 +1,308 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// --- registry helpers ---
+
+func TestNewRegistry_OrderAndNilSkip(t *testing.T) {
+	a := &Provider{Name: "github", DisplayName: "GitHub"}
+	b := &Provider{Name: "Google", DisplayName: "Google", IsOIDC: true}
+	reg := NewRegistry(a, nil, b) // nil is skipped
+	if reg.Count() != 2 {
+		t.Fatalf("Count = %d, want 2", reg.Count())
+	}
+	ps := reg.Providers()
+	if len(ps) != 2 || ps[0].Name != "github" || ps[1].Name != "Google" {
+		t.Errorf("order = %v", providerNames(ps))
+	}
+	// Get is case-insensitive on the registered name.
+	if reg.Get("google") == nil {
+		t.Error("Get(google) should resolve the Google provider case-insensitively")
+	}
+	if reg.Get("nope") != nil {
+		t.Error("Get(nope) should be nil")
+	}
+}
+
+func TestRegistry_NilReceiverSafe(t *testing.T) {
+	var reg *Registry
+	if reg.Get("x") != nil {
+		t.Error("nil Registry Get must be nil")
+	}
+	if reg.Providers() != nil {
+		t.Error("nil Registry Providers must be nil")
+	}
+	if reg.Count() != 0 {
+		t.Error("nil Registry Count must be 0")
+	}
+	if len(reg.OIDCProviders()) != 0 {
+		t.Error("nil Registry OIDCProviders must be empty")
+	}
+}
+
+// --- claim helpers ---
+
+func TestClaimNameOverrideAndDefault(t *testing.T) {
+	p := &Provider{}
+	if got := p.claimName("", "sub"); got != "sub" {
+		t.Errorf("default = %q", got)
+	}
+	if got := p.claimName("custom_sub", "sub"); got != "custom_sub" {
+		t.Errorf("override = %q", got)
+	}
+}
+
+func TestStringClaim_MissingAndWrongType(t *testing.T) {
+	m := jwt.MapClaims{"s": "v", "n": 42}
+	if stringClaim(m, "s") != "v" {
+		t.Error("string claim not read")
+	}
+	if stringClaim(m, "n") != "" {
+		t.Error("non-string claim must yield empty")
+	}
+	if stringClaim(m, "absent") != "" {
+		t.Error("absent claim must yield empty")
+	}
+}
+
+// --- non-OIDC guardrails ---
+
+func TestExchange_NonOIDCErrors(t *testing.T) {
+	p := &Provider{Name: "github", IsOIDC: false}
+	if _, err := p.Exchange(context.Background(), "code", "cb", "nonce"); err == nil {
+		t.Fatal("Exchange on a non-OIDC provider must error")
+	}
+}
+
+func TestAuthCodeURL_NonOIDCOmitsNonce(t *testing.T) {
+	// A non-OIDC provider needs no discovery and must not add a nonce param.
+	p := &Provider{
+		Name: "github", IsOIDC: false,
+		AuthorizeURL: "https://github.com/login/oauth/authorize",
+		ClientID:     "cid", Scopes: []string{""},
+	}
+	u, err := p.AuthCodeURL("https://h/cb", "state1", "nonce1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "client_id=cid"; !contains(u, want) {
+		t.Errorf("url %q missing %q", u, want)
+	}
+	if contains(u, "nonce=") {
+		t.Errorf("non-OIDC url must not carry a nonce: %s", u)
+	}
+}
+
+func TestAuthCodeURL_AppendsWithExistingQuery(t *testing.T) {
+	// AuthorizeURL already containing a query must get "&", not "?".
+	p := &Provider{
+		Name: "github", IsOIDC: false,
+		AuthorizeURL: "https://github.com/login/oauth/authorize?foo=bar",
+		ClientID:     "cid", Scopes: []string{""},
+	}
+	u, err := p.AuthCodeURL("https://h/cb", "s", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(u, "?foo=bar&") {
+		t.Errorf("expected & separator on existing query: %s", u)
+	}
+}
+
+// --- discovery / JWKS error paths ---
+
+func TestFetchDiscovery_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if _, err := fetchDiscovery(context.Background(), srv.URL); err == nil {
+		t.Fatal("non-200 discovery must error")
+	}
+}
+
+func TestFetchDiscovery_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	if _, err := fetchDiscovery(context.Background(), srv.URL); err == nil {
+		t.Fatal("malformed discovery must error")
+	}
+}
+
+func TestFetchDiscovery_MissingEndpoints(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"issuer": "https://x"}) // no endpoints
+	}))
+	defer srv.Close()
+	if _, err := fetchDiscovery(context.Background(), srv.URL); err == nil {
+		t.Fatal("discovery missing endpoints must error")
+	}
+}
+
+func TestFetchJWKS_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	if _, err := fetchJWKS(context.Background(), srv.URL); err == nil {
+		t.Fatal("non-200 JWKS must error")
+	}
+}
+
+func TestFetchJWKS_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{"))
+	}))
+	defer srv.Close()
+	if _, err := fetchJWKS(context.Background(), srv.URL); err == nil {
+		t.Fatal("malformed JWKS must error")
+	}
+}
+
+func TestFetchJWKS_NoUsableKeys(t *testing.T) {
+	// A JWKS with only a non-RSA key (or a malformed RSA key) yields no usable keys.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{
+				{"kty": "EC", "kid": "ec1"},              // skipped: not RSA
+				{"kty": "RSA", "kid": "bad", "n": "!!", "e": "AQAB"}, // skipped: bad n
+			},
+		})
+	}))
+	defer srv.Close()
+	if _, err := fetchJWKS(context.Background(), srv.URL); err == nil {
+		t.Fatal("JWKS with no usable RSA keys must error")
+	}
+}
+
+func TestRSAPublicKeyFromJWK_Errors(t *testing.T) {
+	if _, err := rsaPublicKeyFromJWK(jwkKey{N: "!!bad", E: "AQAB"}); err == nil {
+		t.Error("bad modulus must error")
+	}
+	if _, err := rsaPublicKeyFromJWK(jwkKey{N: "AQAB", E: "!!bad"}); err == nil {
+		t.Error("bad exponent must error")
+	}
+	if _, err := rsaPublicKeyFromJWK(jwkKey{N: "AQAB", E: "AQ"}); err == nil {
+		// E="AQ" -> 1, which is < 2 -> invalid exponent
+		t.Error("exponent < 2 must error")
+	}
+}
+
+func TestRefreshJWKS_NoURL(t *testing.T) {
+	p := &Provider{Name: "google", IsOIDC: true}
+	if err := p.refreshJWKS(context.Background()); err == nil {
+		t.Fatal("refreshJWKS with no URL must error")
+	}
+}
+
+func TestEnsureDiscovered_NoIssuer(t *testing.T) {
+	p := &Provider{Name: "google", IsOIDC: true} // no Issuer
+	if err := p.ensureDiscovered(context.Background()); err == nil {
+		t.Fatal("OIDC provider with no issuer must error on discovery")
+	}
+}
+
+func TestEnsureDiscovered_NonOIDCNoop(t *testing.T) {
+	p := &Provider{Name: "github", IsOIDC: false}
+	if err := p.ensureDiscovered(context.Background()); err != nil {
+		t.Fatalf("non-OIDC ensureDiscovered must be a no-op, got %v", err)
+	}
+}
+
+func TestKeyForKID_ThrottledUnknown(t *testing.T) {
+	// A provider whose JWKS was just refreshed (jwksSetAt=now) but does not carry
+	// the requested kid must REFUSE rather than immediately re-fetch — the
+	// throttle that stops an unknown-kid flood from hammering the JWKS endpoint.
+	p := &Provider{Name: "google", IsOIDC: true}
+	p.jwks = map[string]*rsa.PublicKey{"known": {}}
+	p.jwksSetAt = nowUTC() // fresh → within jwksRefreshMinInterval
+	if _, err := p.keyForKID(context.Background(), "unknown-kid"); err == nil {
+		t.Fatal("keyForKID must refuse an unknown kid right after a refresh (throttle)")
+	}
+}
+
+func TestFetchIDToken_ErrorPaths(t *testing.T) {
+	// non-200 from the token endpoint
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv1.Close()
+	p1 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv1.URL, ClientID: "c"}
+	if _, err := p1.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("non-200 token endpoint must error")
+	}
+
+	// token endpoint returns an OAuth error object
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant", "error_description": "bad code"})
+	}))
+	defer srv2.Close()
+	p2 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv2.URL, ClientID: "c"}
+	if _, err := p2.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("token endpoint error object must error")
+	}
+
+	// 200 but no id_token in the response
+	srv3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"access_token": "at-only"})
+	}))
+	defer srv3.Close()
+	p3 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv3.URL, ClientID: "c"}
+	if _, err := p3.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("missing id_token must error")
+	}
+
+	// malformed JSON body
+	srv4 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("nope"))
+	}))
+	defer srv4.Close()
+	p4 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv4.URL, ClientID: "c"}
+	if _, err := p4.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("malformed token response must error")
+	}
+}
+
+func TestKeyForKID_RefreshFindsRotatedKey(t *testing.T) {
+	// keyForKID with a stale JWKS (jwksSetAt zero → older than the throttle) must
+	// re-fetch and resolve a rotated kid it didn't previously hold.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	p := &Provider{Name: "google", IsOIDC: true, Issuer: o.issuer, JWKSURL: o.issuer + "/jwks", ClientID: "c"}
+	// jwks empty and jwksSetAt zero-value → treated as stale, triggers a refresh.
+	key, err := p.keyForKID(context.Background(), o.kid)
+	if err != nil {
+		t.Fatalf("keyForKID should resolve after refresh: %v", err)
+	}
+	if key == nil {
+		t.Fatal("resolved key is nil")
+	}
+	// A second call hits the cache (kid now present).
+	if _, err := p.keyForKID(context.Background(), o.kid); err != nil {
+		t.Fatalf("cached keyForKID: %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/v2/pkg/auth/oidc_provider.go
+++ b/v2/pkg/auth/oidc_provider.go
@@ -1,0 +1,471 @@
+// Package auth provides a small, self-contained OIDC/OAuth provider abstraction
+// for HUMAN dashboard login on the hive Hub (and, later, direct-route spokes).
+//
+// Scope boundary (important): this is ONLY about authenticating a human and
+// deriving their canonical `provider:subject` identity for access control. It
+// has nothing to do with:
+//   - the GitHub App installation token (kubestellar-hive[bot]) that performs the
+//     hive's actual GitHub work — that path is untouched; a non-GitHub human can
+//     fully own a GitHub-repo hive because the App, not the user, does the work.
+//   - agent/backend logins (Copilot→GitHub, Claude→Gmail) — those are how the AI
+//     CLIs authenticate to do work, entirely separate from human login.
+//
+// A provider is either:
+//   - GitHub OAuth (IsOIDC=false): the legacy path — authorize, exchange code,
+//     read GET /user for the login. The hub keeps its own GitHub handler; this
+//     package models GitHub only so the picker can enumerate it uniformly.
+//   - OIDC (IsOIDC=true): Google/IBMid/Red Hat — authorize with an OIDC `nonce`,
+//     exchange code for an id_token (a signed JWT), and verify that JWT against
+//     the provider's JWKS, enforcing iss/aud/exp AND the nonce. The stable `sub`
+//     claim (NEVER email — emails are reassignable) becomes the canonical subject.
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// httpTimeout bounds every outbound call this package makes (discovery, JWKS,
+// token exchange). Matches the hub's existing oauthTimeout so behavior is
+// consistent across the two login paths.
+const httpTimeout = 10 * time.Second
+
+// maxResponseBytes caps how much of any provider response we read, mirroring the
+// hub's maxOAuthResponseBytes. A discovery/JWKS/token document is a few KB; this
+// is a memory-safety bound against a hostile or broken endpoint.
+const maxResponseBytes = 1 << 16
+
+// jwksRefreshMinInterval throttles JWKS re-fetches triggered by an unknown `kid`.
+// Providers rotate signing keys occasionally; a flood of tokens with an unknown
+// kid (garbage or an attack) must not turn into a fetch-per-request DoS on the
+// provider's JWKS endpoint.
+const jwksRefreshMinInterval = 60 * time.Second
+
+// Provider describes one human-login provider. GitHub is modeled with IsOIDC
+// false (the hub owns its handler); Google/IBMid/Red Hat are OIDC.
+type Provider struct {
+	// Name is the canonical provider slug used in the identity wire form
+	// ("github", "google", "ibmid", "redhat"). Must match the hub's
+	// identityProviders set.
+	Name string
+	// DisplayName is the human label on the login picker ("Google", "Red Hat").
+	DisplayName string
+	// IsOIDC distinguishes the OIDC path (id_token + JWKS) from GitHub OAuth.
+	IsOIDC bool
+
+	// Issuer is the OIDC issuer URL. Discovery is fetched from
+	// Issuer + "/.well-known/openid-configuration". Required for OIDC.
+	Issuer string
+	// Endpoints. For OIDC these are normally filled from discovery; for GitHub
+	// they are set explicitly by the hub. AuthorizeURL/TokenURL are always set;
+	// JWKSURL/UserInfoURL only for OIDC.
+	AuthorizeURL string
+	TokenURL     string
+	JWKSURL      string
+
+	// ClientID / ClientSecret from the provider's app registration. A provider is
+	// enabled iff ClientID is set (mirrors the hub's registerOAuth gate).
+	ClientID     string
+	ClientSecret string
+
+	// Scopes requested at authorize time. OIDC always needs "openid"; "email
+	// profile" get the display name/avatar. GitHub uses "" (identity-only).
+	Scopes []string
+
+	// Claim names for extracting identity from the id_token. Defaults suit the
+	// standard OIDC claim set (sub/name/picture/email); overridable per provider.
+	SubjectClaim string
+	NameClaim    string
+	AvatarClaim  string
+	EmailClaim   string
+
+	// discovered caches the OIDC discovery document + JWKS behind mu.
+	mu         sync.Mutex
+	discovered bool
+	jwks       map[string]*rsa.PublicKey // kid -> RSA public key
+	jwksSetAt  time.Time
+}
+
+// Claims is the identity extracted from a verified id_token (or GitHub /user).
+type Claims struct {
+	Subject   string // the stable `sub` — becomes the canonical subject
+	Name      string // display name (optional)
+	AvatarURL string // picture (optional)
+	Email     string // email (display only; NEVER the identity key)
+}
+
+// scopeString renders the space-delimited scope parameter.
+func (p *Provider) scopeString() string {
+	return strings.Join(p.Scopes, " ")
+}
+
+// AuthCodeURL builds the provider's authorization URL. state carries the hub's
+// CSRF nonce (+ redirect); nonce is the OIDC replay-protection nonce echoed back
+// in the id_token (ignored by non-OIDC providers). redirectURI must exactly match
+// a URI registered on the provider side.
+func (p *Provider) AuthCodeURL(redirectURI, state, nonce string) (string, error) {
+	if err := p.ensureDiscovered(context.Background()); err != nil {
+		return "", err
+	}
+	v := neturlValues()
+	v.Set("client_id", p.ClientID)
+	v.Set("redirect_uri", redirectURI)
+	v.Set("response_type", "code")
+	v.Set("scope", p.scopeString())
+	v.Set("state", state)
+	if p.IsOIDC && nonce != "" {
+		v.Set("nonce", nonce)
+	}
+	sep := "?"
+	if strings.Contains(p.AuthorizeURL, "?") {
+		sep = "&"
+	}
+	return p.AuthorizeURL + sep + v.Encode(), nil
+}
+
+// Exchange trades an authorization code for identity claims. For OIDC it fetches
+// the token endpoint, extracts the id_token, and VERIFIES it (signature via JWKS,
+// plus iss/aud/exp and the expected nonce) before returning any claim. For a
+// non-OIDC (GitHub) provider it returns an error — the hub owns that path.
+func (p *Provider) Exchange(ctx context.Context, code, redirectURI, expectNonce string) (*Claims, error) {
+	if !p.IsOIDC {
+		return nil, errors.New("Exchange is only for OIDC providers; GitHub uses the hub's own handler")
+	}
+	if err := p.ensureDiscovered(ctx); err != nil {
+		return nil, err
+	}
+	rawIDToken, err := p.fetchIDToken(ctx, code, redirectURI)
+	if err != nil {
+		return nil, err
+	}
+	return p.verifyIDToken(ctx, rawIDToken, expectNonce)
+}
+
+// fetchIDToken posts the code to the token endpoint and returns the raw id_token.
+func (p *Provider) fetchIDToken(ctx context.Context, code, redirectURI string) (string, error) {
+	form := neturlValues()
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", p.ClientID)
+	form.Set("client_secret", p.ClientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token exchange: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %d", resp.StatusCode)
+	}
+	var tok struct {
+		IDToken     string `json:"id_token"`
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+		ErrorDesc   string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+	if tok.Error != "" {
+		return "", fmt.Errorf("token endpoint error %q: %s", tok.Error, tok.ErrorDesc)
+	}
+	if tok.IDToken == "" {
+		return "", errors.New("token response carried no id_token")
+	}
+	return tok.IDToken, nil
+}
+
+// verifyIDToken validates the id_token's signature and claims, then extracts
+// identity. It enforces, in order: a supported RS256/RS384/RS512 alg (never
+// "none", never HMAC — which would let a client-known secret forge a token); the
+// signing key resolved from JWKS by `kid`; iss == p.Issuer; aud contains
+// p.ClientID; exp not passed (with the library's small leeway); and nonce ==
+// expectNonce. Any failure returns an error and NO claims.
+func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (*Claims, error) {
+	keyFunc := func(t *jwt.Token) (interface{}, error) {
+		// Reject anything but RSA signing. "none" and HMAC ("HS*") are the two
+		// classic OIDC token-forgery vectors; the parser options below also pin
+		// valid methods, this is defense in depth on the key side.
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method %q", t.Header["alg"])
+		}
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, errors.New("id_token has no kid")
+		}
+		key, err := p.keyForKID(ctx, kid)
+		if err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512"}),
+		jwt.WithIssuer(p.Issuer),
+		jwt.WithAudience(p.ClientID),
+		jwt.WithExpirationRequired(),
+	)
+	claims := jwt.MapClaims{}
+	if _, err := parser.ParseWithClaims(raw, claims, keyFunc); err != nil {
+		return nil, fmt.Errorf("id_token verification failed: %w", err)
+	}
+
+	// Nonce binds the id_token to the login THIS browser started (replay/
+	// injection defense). Enforced explicitly because jwt has no built-in nonce
+	// validator. This MUST fail closed: the caller always mints and cookies a
+	// nonce before authorize, so an empty expectNonce at verify time means the
+	// browser's nonce cookie was missing/cleared — exactly the state a token-
+	// injection attacker engineers. Rejecting on empty is what closes that hole
+	// (an earlier version skipped the check when expectNonce=="", failing OPEN).
+	if expectNonce == "" {
+		return nil, errors.New("no expected nonce for OIDC verification (nonce cookie missing) — refusing to skip replay protection")
+	}
+	got, _ := claims[claimNonce].(string)
+	if got == "" || got != expectNonce {
+		return nil, errors.New("id_token nonce mismatch")
+	}
+
+	sub := stringClaim(claims, p.claimName(p.SubjectClaim, claimSub))
+	if sub == "" {
+		return nil, errors.New("id_token has no subject")
+	}
+	return &Claims{
+		Subject:   sub,
+		Name:      stringClaim(claims, p.claimName(p.NameClaim, claimName)),
+		AvatarURL: stringClaim(claims, p.claimName(p.AvatarClaim, claimPicture)),
+		Email:     stringClaim(claims, p.claimName(p.EmailClaim, claimEmail)),
+	}, nil
+}
+
+// keyForKID returns the RSA public key for a JWKS key id, fetching/refreshing the
+// JWKS on an unknown kid (rate-limited) to handle key rotation.
+func (p *Provider) keyForKID(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	p.mu.Lock()
+	key := p.jwks[kid]
+	stale := time.Since(p.jwksSetAt) >= jwksRefreshMinInterval
+	p.mu.Unlock()
+	if key != nil {
+		return key, nil
+	}
+	if !stale {
+		// Unknown kid but we refreshed very recently: refuse rather than hammer
+		// the JWKS endpoint. A legitimate rotation resolves on the next attempt
+		// after the throttle window.
+		return nil, fmt.Errorf("unknown id_token kid %q (JWKS recently refreshed)", kid)
+	}
+	if err := p.refreshJWKS(ctx); err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	key = p.jwks[kid]
+	p.mu.Unlock()
+	if key == nil {
+		return nil, fmt.Errorf("unknown id_token kid %q", kid)
+	}
+	return key, nil
+}
+
+// ensureDiscovered lazily runs OIDC discovery (once) to populate the authorize/
+// token/JWKS endpoints, then fetches the JWKS. GitHub (non-OIDC) needs no
+// discovery — its endpoints are set by the hub.
+func (p *Provider) ensureDiscovered(ctx context.Context) error {
+	if !p.IsOIDC {
+		return nil
+	}
+	p.mu.Lock()
+	done := p.discovered
+	p.mu.Unlock()
+	if done {
+		return nil
+	}
+	if p.Issuer == "" {
+		return errors.New("OIDC provider has no issuer")
+	}
+	doc, err := fetchDiscovery(ctx, p.Issuer)
+	if err != nil {
+		return err
+	}
+	// Discovery's issuer MUST be present AND equal the configured issuer. This
+	// prevents a swapped/hostile discovery doc from redirecting token/JWKS to an
+	// attacker origin. Requiring it (rather than skipping the check when the doc
+	// omits `issuer`) closes the downgrade where a doc with no issuer but hostile
+	// jwks_uri would be trusted; per OIDC Discovery the issuer field is REQUIRED.
+	if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(p.Issuer, "/") {
+		return fmt.Errorf("discovery issuer %q != configured issuer %q", doc.Issuer, p.Issuer)
+	}
+	p.mu.Lock()
+	if p.AuthorizeURL == "" {
+		p.AuthorizeURL = doc.AuthorizationEndpoint
+	}
+	if p.TokenURL == "" {
+		p.TokenURL = doc.TokenEndpoint
+	}
+	if p.JWKSURL == "" {
+		p.JWKSURL = doc.JWKSURI
+	}
+	p.discovered = true
+	p.mu.Unlock()
+	return p.refreshJWKS(ctx)
+}
+
+// refreshJWKS fetches and parses the provider's JWKS into RSA public keys.
+func (p *Provider) refreshJWKS(ctx context.Context) error {
+	if p.JWKSURL == "" {
+		return errors.New("no JWKS URL")
+	}
+	keys, err := fetchJWKS(ctx, p.JWKSURL)
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.jwks = keys
+	p.jwksSetAt = nowUTC()
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *Provider) claimName(override, def string) string {
+	if override != "" {
+		return override
+	}
+	return def
+}
+
+// --- discovery / JWKS wire types ---
+
+type discoveryDoc struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+func fetchDiscovery(ctx context.Context, issuer string) (*discoveryDoc, error) {
+	url := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC discovery: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OIDC discovery returned %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	var doc discoveryDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("parse discovery: %w", err)
+	}
+	if doc.Issuer == "" || doc.TokenEndpoint == "" || doc.JWKSURI == "" || doc.AuthorizationEndpoint == "" {
+		return nil, errors.New("discovery document missing required fields (issuer/authorization/token/jwks)")
+	}
+	return &doc, nil
+}
+
+type jwksResponse struct {
+	Keys []jwkKey `json:"keys"`
+}
+
+type jwkKey struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+func fetchJWKS(ctx context.Context, jwksURL string) (map[string]*rsa.PublicKey, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", jwksURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("JWKS fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("JWKS returned %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	var set jwksResponse
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("parse JWKS: %w", err)
+	}
+	out := map[string]*rsa.PublicKey{}
+	for _, k := range set.Keys {
+		if k.Kty != "RSA" || k.Kid == "" {
+			continue
+		}
+		pk, err := rsaPublicKeyFromJWK(k)
+		if err != nil {
+			continue // skip a malformed key rather than fail the whole set
+		}
+		out[k.Kid] = pk
+	}
+	if len(out) == 0 {
+		return nil, errors.New("JWKS contained no usable RSA keys")
+	}
+	return out, nil
+}
+
+// rsaPublicKeyFromJWK reconstructs an RSA public key from a JWK's base64url n/e.
+func rsaPublicKeyFromJWK(k jwkKey) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, err
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, err
+	}
+	n := new(big.Int).SetBytes(nBytes)
+	e := new(big.Int).SetBytes(eBytes)
+	if !e.IsInt64() || e.Int64() < 2 {
+		return nil, errors.New("invalid RSA exponent")
+	}
+	return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
+}
+
+// --- standard claim names ---
+
+const (
+	claimSub     = "sub"
+	claimName    = "name"
+	claimPicture = "picture"
+	claimEmail   = "email"
+	claimNonce   = "nonce"
+)
+
+func stringClaim(m jwt.MapClaims, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/v2/pkg/auth/oidc_provider_test.go
+++ b/v2/pkg/auth/oidc_provider_test.go
@@ -1,0 +1,381 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// oidcTestServer is a minimal OIDC provider: discovery, JWKS, and a token
+// endpoint that returns a pre-seeded id_token. It signs with one RSA key.
+type oidcTestServer struct {
+	srv    *httptest.Server
+	key    *rsa.PrivateKey
+	kid    string
+	issuer string
+	// idToken is what the token endpoint returns for any code.
+	idToken string
+}
+
+func newOIDCTestServer(t *testing.T) *oidcTestServer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ots := &oidcTestServer{key: key, kid: "test-kid-1"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 ots.issuer,
+			"authorization_endpoint": ots.issuer + "/authorize",
+			"token_endpoint":         ots.issuer + "/token",
+			"jwks_uri":               ots.issuer + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		pub := key.Public().(*rsa.PublicKey)
+		n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+		json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{
+				{"kty": "RSA", "kid": ots.kid, "use": "sig", "alg": "RS256", "n": n, "e": e},
+			},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"id_token": ots.idToken})
+	})
+	ots.srv = httptest.NewServer(mux)
+	ots.issuer = ots.srv.URL
+	return ots
+}
+
+func (o *oidcTestServer) close() { o.srv.Close() }
+
+// signToken signs claims as an RS256 JWT with the server's key and kid.
+func (o *oidcTestServer) signToken(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = o.kid
+	s, err := tok.SignedString(o.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// baseClaims returns a valid claim set for the given audience/nonce.
+func baseClaims(issuer, aud, nonce string) jwt.MapClaims {
+	return jwt.MapClaims{
+		"iss":     issuer,
+		"aud":     aud,
+		"sub":     "1078901234567890",
+		"exp":     time.Now().Add(1 * time.Hour).Unix(),
+		"iat":     time.Now().Unix(),
+		"nonce":   nonce,
+		"email":   "person@example.com",
+		"name":    "A Person",
+		"picture": "https://example.com/p.png",
+	}
+}
+
+func googleLikeProvider(o *oidcTestServer, clientID string) *Provider {
+	return &Provider{
+		Name:        "google",
+		DisplayName: "Google",
+		IsOIDC:      true,
+		Issuer:      o.issuer,
+		ClientID:    clientID,
+		Scopes:      []string{"openid", "email", "profile"},
+	}
+}
+
+func TestOIDC_HappyPath(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, nonce))
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "code123", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Subject != "1078901234567890" {
+		t.Errorf("subject = %q", claims.Subject)
+	}
+	if claims.Email != "person@example.com" || claims.Name != "A Person" || claims.AvatarURL != "https://example.com/p.png" {
+		t.Errorf("claims = %+v", claims)
+	}
+}
+
+func TestOIDC_RejectsWrongAudience(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Token minted for a DIFFERENT audience — the classic token-confusion attack.
+	o.idToken = o.signToken(t, baseClaims(o.issuer, "some-other-client", nonce))
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for wrong audience, got nil")
+	}
+}
+
+func TestOIDC_RejectsWrongIssuer(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	o.idToken = o.signToken(t, baseClaims("https://evil.example.com", clientID, nonce))
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for wrong issuer, got nil")
+	}
+}
+
+func TestOIDC_RejectsExpired(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	c := baseClaims(o.issuer, clientID, nonce)
+	c["exp"] = time.Now().Add(-1 * time.Hour).Unix()
+	o.idToken = o.signToken(t, c)
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for expired token, got nil")
+	}
+}
+
+func TestOIDC_RejectsBadNonce(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, "the-real-nonce"))
+
+	p := googleLikeProvider(o, clientID)
+	// We expected a different nonce than the token carries → replay/injection.
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", "a-different-nonce"); err == nil {
+		t.Fatal("expected rejection for nonce mismatch, got nil")
+	}
+}
+
+func TestOIDC_RejectsAlgNone(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Forge an unsigned ("alg":"none") token — must be rejected outright.
+	claims := baseClaims(o.issuer, clientID, nonce)
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tok.Header["kid"] = o.kid
+	raw, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.idToken = raw
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for alg=none, got nil")
+	}
+}
+
+func TestOIDC_RejectsHMACConfusion(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Sign HS256 using the RSA public modulus bytes as the HMAC secret — the
+	// classic RS→HS confusion. keyFunc must refuse the non-RSA method before the
+	// secret is ever consulted.
+	pub := o.key.Public().(*rsa.PublicKey)
+	claims := baseClaims(o.issuer, clientID, nonce)
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tok.Header["kid"] = o.kid
+	raw, err := tok.SignedString(pub.N.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.idToken = raw
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for HS256 confusion, got nil")
+	}
+}
+
+func TestOIDC_RejectsUnknownKID(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Sign with a kid the JWKS does not publish.
+	claims := baseClaims(o.issuer, clientID, nonce)
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = "kid-not-in-jwks"
+	raw, err := tok.SignedString(o.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.idToken = raw
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for unknown kid, got nil")
+	}
+}
+
+func TestOIDC_DiscoveryIssuerMismatchFails(t *testing.T) {
+	// A discovery doc whose issuer disagrees with the configured issuer must be
+	// rejected (prevents a swapped discovery pointing token/JWKS at an attacker).
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	_ = key
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 "https://not-me.example.com",
+			"authorization_endpoint": "https://x/authorize",
+			"token_endpoint":         "https://x/token",
+			"jwks_uri":               "https://x/jwks",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p := &Provider{Name: "google", IsOIDC: true, Issuer: srv.URL, ClientID: "c", Scopes: []string{"openid"}}
+	if err := p.ensureDiscovered(context.Background()); err == nil {
+		t.Fatal("expected discovery issuer-mismatch rejection, got nil")
+	}
+}
+
+func TestOIDC_RejectsEmptyExpectedNonce(t *testing.T) {
+	// A missing/cleared browser nonce cookie surfaces as expectNonce=="" at the
+	// hub. Verification MUST fail closed rather than skip the nonce check (the
+	// token-injection fail-open). Even a token that carries a valid-looking nonce
+	// must be rejected when we have nothing to compare it against.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, "some-nonce"))
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", ""); err == nil {
+		t.Fatal("expected hard rejection when expected nonce is empty, got nil")
+	}
+}
+
+func TestOIDC_DiscoveryMissingIssuerFails(t *testing.T) {
+	// A discovery doc that OMITS `issuer` must be rejected (an empty issuer used
+	// to skip the cross-check, trusting a possibly-hostile jwks_uri).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			// no "issuer"
+			"authorization_endpoint": "https://x/authorize",
+			"token_endpoint":         "https://x/token",
+			"jwks_uri":               "https://x/jwks",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p := &Provider{Name: "google", IsOIDC: true, Issuer: srv.URL, ClientID: "c", Scopes: []string{"openid"}}
+	if err := p.ensureDiscovered(context.Background()); err == nil {
+		t.Fatal("expected rejection for discovery doc with no issuer, got nil")
+	}
+}
+
+func TestAuthCodeURL_CarriesNonceAndState(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	p := googleLikeProvider(o, "client-abc")
+	u, err := p.AuthCodeURL(o.issuer+"/cb", "state-val", "nonce-val")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, _ := url.Parse(u)
+	q := parsed.Query()
+	if q.Get("state") != "state-val" || q.Get("nonce") != "nonce-val" {
+		t.Errorf("authorize URL missing state/nonce: %s", u)
+	}
+	if q.Get("client_id") != "client-abc" || q.Get("response_type") != "code" {
+		t.Errorf("authorize URL wrong params: %s", u)
+	}
+	if q.Get("scope") != "openid email profile" {
+		t.Errorf("scope = %q", q.Get("scope"))
+	}
+}
+
+func TestBuildRegistry_EnabledByClientID(t *testing.T) {
+	// GitHub always present when its client id is set. Google enabled via env;
+	// IBMid without an issuer is skipped (not fatal).
+	t.Setenv("HIVE_HUB_OIDC_GOOGLE_CLIENT_ID", "g-client")
+	t.Setenv("HIVE_HUB_OIDC_GOOGLE_CLIENT_SECRET", "g-secret")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_CLIENT_ID", "ibm-client") // no issuer → skipped
+	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "")
+	t.Setenv("HIVE_HUB_OIDC_REDHAT_CLIENT_ID", "") // disabled
+
+	reg := BuildRegistry("gh-client", "https://github/authorize", "https://github/token")
+	if reg.Get("github") == nil {
+		t.Error("github should be enabled")
+	}
+	if reg.Get("google") == nil {
+		t.Error("google should be enabled")
+	}
+	if reg.Get("ibmid") != nil {
+		t.Error("ibmid must be skipped when it has no issuer")
+	}
+	if reg.Get("redhat") != nil {
+		t.Error("redhat must be disabled when no client id")
+	}
+	// GitHub first, then Google.
+	ps := reg.Providers()
+	if len(ps) != 2 || ps[0].Name != "github" || ps[1].Name != "google" {
+		t.Errorf("provider order = %v", providerNames(ps))
+	}
+	if len(reg.OIDCProviders()) != 1 {
+		t.Errorf("OIDCProviders = %v", providerNames(reg.OIDCProviders()))
+	}
+}
+
+func TestBuildRegistry_IBMidWithIssuerEnabled(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_IBMID_CLIENT_ID", "ibm-client")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "https://us-south.appid.cloud.ibm.com/oauth/v4/tenant123")
+	reg := BuildRegistry("", "", "")
+	p := reg.Get("ibmid")
+	if p == nil {
+		t.Fatal("ibmid should be enabled with an explicit issuer")
+	}
+	if p.Issuer != "https://us-south.appid.cloud.ibm.com/oauth/v4/tenant123" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+}
+
+func providerNames(ps []*Provider) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.Name
+	}
+	return out
+}
+
+// sanity: ensure the test file's fmt import is used even if a case is trimmed.
+var _ = fmt.Sprintf

--- a/v2/pkg/auth/registry.go
+++ b/v2/pkg/auth/registry.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// httpClient returns a client with this package's uniform timeout. A fresh client
+// per call is cheap and keeps the package free of shared mutable state; the
+// transport's connection pooling still applies at the default-transport level.
+func httpClient() *http.Client {
+	return &http.Client{Timeout: httpTimeout}
+}
+
+// neturlValues is a tiny indirection so the file that builds query/form bodies
+// does not import net/url directly (keeps the OIDC file's import list focused on
+// crypto/JWT). It returns an empty url.Values.
+func neturlValues() url.Values {
+	return url.Values{}
+}
+
+// nowUTC is the single clock reference, so a test can reason about jwksSetAt
+// without reaching into time inside the OIDC file.
+func nowUTC() time.Time {
+	return time.Now().UTC()
+}
+
+// Registry holds the enabled human-login providers, in a stable display order.
+type Registry struct {
+	providers []*Provider
+	byName    map[string]*Provider
+}
+
+// NewRegistry builds a registry from an explicit provider list, preserving order.
+// BuildRegistry is the production path (env-driven); this exists for composition
+// and tests that need a registry with a specific provider set.
+func NewRegistry(providers ...*Provider) *Registry {
+	r := &Registry{byName: map[string]*Provider{}}
+	for _, p := range providers {
+		if p == nil {
+			continue
+		}
+		r.providers = append(r.providers, p)
+		r.byName[strings.ToLower(p.Name)] = p
+	}
+	return r
+}
+
+// Get returns the provider with the given canonical name, or nil.
+func (r *Registry) Get(name string) *Provider {
+	if r == nil {
+		return nil
+	}
+	return r.byName[strings.ToLower(name)]
+}
+
+// Providers returns the enabled providers in display order (GitHub first when
+// present, then OIDC providers alphabetically by display name).
+func (r *Registry) Providers() []*Provider {
+	if r == nil {
+		return nil
+	}
+	return r.providers
+}
+
+// OIDCProviders returns only the enabled OIDC providers (excludes GitHub).
+func (r *Registry) OIDCProviders() []*Provider {
+	var out []*Provider
+	for _, p := range r.Providers() {
+		if p.IsOIDC {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Count is the number of enabled providers.
+func (r *Registry) Count() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.providers)
+}
+
+// oidcProviderSpec is the static per-provider config the env-driven registry
+// builds from. Issuer defaults live here; env can override the issuer (needed for
+// IBMid/Red Hat whose issuer is tenant-specific).
+type oidcProviderSpec struct {
+	name          string
+	display       string
+	defaultIssuer string // "" means the issuer MUST come from env
+	envPrefix     string // e.g. "HIVE_HUB_OIDC_GOOGLE"
+	scopes        []string
+}
+
+// oidcSpecs is the closed set of OIDC providers the hub can enable. A provider is
+// enabled iff its <PREFIX>_CLIENT_ID env var is set — mirroring the GitHub OAuth
+// gate (HIVE_HUB_OAUTH_CLIENT_ID). Order here is the fallback display order among
+// OIDC providers.
+var oidcSpecs = []oidcProviderSpec{
+	{
+		name:          "google",
+		display:       "Google",
+		defaultIssuer: "https://accounts.google.com",
+		envPrefix:     "HIVE_HUB_OIDC_GOOGLE",
+		scopes:        []string{"openid", "email", "profile"},
+	},
+	{
+		name:          "ibmid",
+		display:       "IBMid",
+		defaultIssuer: "", // tenant-specific (IBM App ID): must set _ISSUER
+		envPrefix:     "HIVE_HUB_OIDC_IBMID",
+		scopes:        []string{"openid", "email", "profile"},
+	},
+	{
+		name:          "redhat",
+		display:       "Red Hat",
+		defaultIssuer: "https://sso.redhat.com/auth/realms/redhat-external",
+		envPrefix:     "HIVE_HUB_OIDC_REDHAT",
+		scopes:        []string{"openid", "email", "profile"},
+	},
+}
+
+// BuildRegistry assembles the enabled human-login providers from the environment.
+//
+//   - githubClientID: the hub's existing HIVE_HUB_OAUTH_CLIENT_ID. When non-empty,
+//     GitHub is added as the first (non-OIDC) provider using the passed endpoints
+//     (the hub already has these as vars for its test seam).
+//   - Each OIDC spec is enabled iff <PREFIX>_CLIENT_ID is set; it reads
+//     _CLIENT_SECRET and an optional _ISSUER override (required when the spec has
+//     no default issuer).
+//
+// A provider whose env is present but invalid (e.g. IBMid with no issuer) is
+// SKIPPED, not fatal — a misconfigured provider must never take down login for
+// the working ones.
+func BuildRegistry(githubClientID, ghAuthorizeURL, ghTokenURL string) *Registry {
+	reg := &Registry{byName: map[string]*Provider{}}
+
+	if githubClientID != "" {
+		gh := &Provider{
+			Name:         "github",
+			DisplayName:  "GitHub",
+			IsOIDC:       false,
+			AuthorizeURL: ghAuthorizeURL,
+			TokenURL:     ghTokenURL,
+			ClientID:     githubClientID,
+			Scopes:       []string{""},
+		}
+		reg.providers = append(reg.providers, gh)
+		reg.byName[gh.Name] = gh
+	}
+
+	var oidc []*Provider
+	for _, spec := range oidcSpecs {
+		clientID := os.Getenv(spec.envPrefix + "_CLIENT_ID")
+		if clientID == "" {
+			continue // provider not configured → not enabled
+		}
+		issuer := os.Getenv(spec.envPrefix + "_ISSUER")
+		if issuer == "" {
+			issuer = spec.defaultIssuer
+		}
+		if issuer == "" {
+			// Configured client id but no issuer we can use → skip, don't crash.
+			continue
+		}
+		p := &Provider{
+			Name:         spec.name,
+			DisplayName:  spec.display,
+			IsOIDC:       true,
+			Issuer:       strings.TrimRight(issuer, "/"),
+			ClientID:     clientID,
+			ClientSecret: os.Getenv(spec.envPrefix + "_CLIENT_SECRET"),
+			Scopes:       spec.scopes,
+		}
+		oidc = append(oidc, p)
+	}
+	// Stable display order among OIDC providers: by display name.
+	sort.Slice(oidc, func(i, j int) bool { return oidc[i].DisplayName < oidc[j].DisplayName })
+	for _, p := range oidc {
+		reg.providers = append(reg.providers, p)
+		reg.byName[p.Name] = p
+	}
+	return reg
+}

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -6,17 +6,29 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/auth"
 )
 
 const (
 	oauthTimeout     = 10 * time.Second
 	cookieMaxAgeDays = 7 // login session cookie lifetime
+
+	// oauthRedirectURI is the single OAuth/OIDC callback registered on every
+	// provider's side. All providers share one callback path; the state parameter
+	// carries which provider to complete against.
+	oauthRedirectURI = "https://hive.kubestellar.io/api/auth/callback"
+
+	// oidcNonceCookieName holds the per-login OIDC replay nonce. Host-scoped like
+	// the CSRF state cookie; the id_token must echo it back or the callback fails.
+	oidcNonceCookieName = "hive_oidc_nonce"
 )
 
 // These GitHub.com OAuth/API endpoints are vars (not consts) so tests can point
@@ -33,15 +45,33 @@ var (
 
 func (s *HubServer) registerOAuth() {
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
-	if clientID == "" {
-		s.logger.Info("hub OAuth disabled (no HIVE_HUB_OAUTH_CLIENT_ID)")
+
+	// Build the human-login provider set: GitHub (when its client id is set) plus
+	// any configured OIDC providers (Google/IBMid/Red Hat — enabled iff their
+	// <PREFIX>_CLIENT_ID env is present). The GitHub endpoints come from the
+	// existing test-overridable vars so the auth registry shares the hub's seam.
+	s.authProviders = auth.BuildRegistry(clientID, defaultGHAuthorizeURL, defaultGHTokenURL)
+
+	// Nothing to serve if no provider at all is configured. Historically the hub
+	// keyed entirely on GitHub; now it stays "OAuth disabled" only when NEITHER
+	// GitHub nor any OIDC provider is set.
+	if s.authProviders.Count() == 0 {
+		s.logger.Info("hub OAuth disabled (no login provider configured)")
 		return
 	}
 	s.mux.HandleFunc("GET /login", s.handleLogin)
+	// Per-provider entry point. GitHub keeps its existing behavior; an OIDC
+	// provider ("google"/"ibmid"/"redhat") starts the OIDC authorize.
+	s.mux.HandleFunc("GET /login/{provider}", s.handleProviderLogin)
 	s.mux.HandleFunc("GET /api/auth/callback", s.handleOAuthCallback)
 	s.mux.HandleFunc("GET /api/auth/user", s.handleAuthUser)
 	s.mux.HandleFunc("POST /api/auth/logout", s.handleLogout)
-	s.logger.Info("hub OAuth enabled", "client_id", clientID)
+
+	names := make([]string, 0, s.authProviders.Count())
+	for _, p := range s.authProviders.Providers() {
+		names = append(names, p.Name)
+	}
+	s.logger.Info("hub login enabled", "providers", strings.Join(names, ","), "github_client_id", clientID)
 }
 
 // linkPreviewUserAgents are the crawlers that fetch a URL purely to build a
@@ -157,14 +187,57 @@ func (s *HubServer) handleOGCard(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
+// handleLogin is the login entry point. With exactly one provider enabled
+// (today: GitHub) it redirects straight into that provider, preserving the
+// pre-multi-provider UX byte-for-byte. With more than one enabled it renders a
+// small provider picker; each button links to /login/{provider} carrying the
+// redirect target through.
 func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// Serve Hive's own card to preview crawlers instead of redirecting them into
-	// GitHub's OAuth page, whose Open Graph tags they would otherwise scrape.
+	// a provider's OAuth page, whose Open Graph tags they would otherwise scrape.
 	if isLinkPreviewCrawler(r) {
 		writeLinkPreview(w)
 		return
 	}
-	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
+	redirect := s.loginRedirectTarget(r)
+	providers := s.authProviders.Providers()
+	if len(providers) == 0 {
+		// Registry not built (a HubServer constructed without registerOAuth — the
+		// unit-test path) but GitHub is configured: behave as single-GitHub so the
+		// pre-multi-provider UX is preserved with no registry.
+		if gh := s.resolveProvider(legacyProvider); gh != nil {
+			s.startProviderLogin(w, r, gh, redirect)
+			return
+		}
+		http.Error(w, "login unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if len(providers) == 1 {
+		// Single provider: go straight in — no picker, unchanged UX.
+		s.startProviderLogin(w, r, providers[0], redirect)
+		return
+	}
+	s.writeProviderPicker(w, providers, redirect)
+}
+
+// handleProviderLogin starts login for a specific provider named in the path.
+func (s *HubServer) handleProviderLogin(w http.ResponseWriter, r *http.Request) {
+	if isLinkPreviewCrawler(r) {
+		writeLinkPreview(w)
+		return
+	}
+	name := r.PathValue("provider")
+	p := s.authProviders.Get(name)
+	if p == nil {
+		http.Error(w, "unknown login provider", http.StatusNotFound)
+		return
+	}
+	s.startProviderLogin(w, r, p, s.loginRedirectTarget(r))
+}
+
+// loginRedirectTarget extracts and validates the post-login redirect from the
+// request (?redirect= / ?rd=), defaulting to /dashboard for anything untrusted.
+func (s *HubServer) loginRedirectTarget(r *http.Request) string {
 	redirect := r.URL.Query().Get("redirect")
 	if redirect == "" {
 		redirect = r.URL.Query().Get("rd")
@@ -174,20 +247,26 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 			redirect = "/dashboard"
 		}
 	}
+	return redirect
+}
+
+// startProviderLogin mints the CSRF state nonce (and, for OIDC, the replay nonce)
+// and redirects the browser into the provider's authorize endpoint. GitHub keeps
+// its exact original request shape; OIDC providers get an OIDC nonce too.
+func (s *HubServer) startProviderLogin(w http.ResponseWriter, r *http.Request, p *auth.Provider, redirect string) {
 	// SECURITY (audit F11, CWE-352): bind this login to THIS browser.
 	//
 	// `state` used to be nothing but the redirect target, so it proved only that
 	// the callback carried a URL — never that this browser had actually STARTED
-	// a login. An attacker could complete an OAuth flow against their own GitHub
-	// account and hand the victim the resulting callback URL, logging the victim
-	// into the ATTACKER's account (login CSRF / session fixation); anything the
-	// victim then did landed in the attacker's account.
+	// a login. An attacker could complete an OAuth flow against their own account
+	// and hand the victim the resulting callback URL, logging the victim into the
+	// ATTACKER's account (login CSRF / session fixation).
 	//
 	// Mint an unguessable nonce, set it in a short-lived host-scoped cookie, and
 	// carry it in state. The callback requires the two to match, so a state the
-	// victim's browser did not mint cannot be replayed against them. The
-	// redirect target rides along after the separator and is still validated on
-	// the way out — the open-redirect half was already handled and is unchanged.
+	// victim's browser did not mint cannot be replayed against them. The provider
+	// name and redirect target ride along after the separators and are validated
+	// on the way out.
 	nonce, err := oauthStateNonce()
 	if err != nil {
 		s.logger.Warn("OAuth: cannot mint login state nonce", "error", err)
@@ -201,30 +280,115 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   int(oauthStateTTL.Seconds()),
 		HttpOnly: true,
 		Secure:   true,
-		// Lax, not Strict: the callback arrives as a top-level GET redirect
-		// FROM github.com, and Strict would withhold the cookie on exactly that
+		// Lax, not Strict: the callback arrives as a top-level GET redirect FROM
+		// the provider, and Strict would withhold the cookie on exactly that
 		// navigation and break every login.
 		SameSite: http.SameSiteLaxMode,
 	})
-	state := url.QueryEscape(nonce + oauthStateSeparator + redirect)
-	// An EMPTY scope is deliberate, not an omission. The hub only needs to know
-	// WHO is logging in: the callback reads GET /user for the login name and
-	// signs it into the session cookie. GitHub serves /user's public profile —
-	// including "login" — for a token with no scopes at all, so identity works
-	// unscoped.
-	//
-	// The hub used to ask for read:user because the request wizard listed the
-	// user's repositories for them to pick from. That listing is gone: it could
-	// only ever see public github.com, and it could never generalize to GitLab
-	// or Gitea. Requesters now type a repository URL instead, which needs no
-	// permission on the requester's account whatsoever.
-	//
-	// Do NOT restore a scope here without also restoring a feature that needs
-	// it — asking for access the product does not use is a consent prompt users
-	// are right to refuse.
-	authURL := fmt.Sprintf("%s?client_id=%s&scope=&redirect_uri=%s&state=%s",
-		defaultGHAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback", state)
+
+	// state = nonce : provider : redirect. The provider name is carried so the
+	// callback knows which provider to complete against without a second cookie.
+	state := url.QueryEscape(nonce + oauthStateSeparator + p.Name + oauthStateSeparator + redirect)
+
+	if !p.IsOIDC {
+		// GitHub: identical request shape to the pre-multi-provider hub. An EMPTY
+		// scope is deliberate — the hub only needs WHO is logging in, and GitHub
+		// serves /user's public profile (including "login") unscoped. Do NOT add a
+		// scope without a feature that needs it.
+		authURL := fmt.Sprintf("%s?client_id=%s&scope=&redirect_uri=%s&state=%s",
+			p.AuthorizeURL, p.ClientID, oauthRedirectURI, state)
+		http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
+		return
+	}
+
+	// OIDC: mint a replay nonce, cookie it, and pass it in the authorize request;
+	// the callback requires the id_token to echo it back.
+	oidcNonce, err := oauthStateNonce()
+	if err != nil {
+		s.logger.Warn("OIDC: cannot mint nonce", "provider", p.Name, "error", err)
+		http.Error(w, "login unavailable", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     oidcNonceCookieName,
+		Value:    oidcNonce,
+		Path:     "/",
+		MaxAge:   int(oauthStateTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	authURL, err := p.AuthCodeURL(oauthRedirectURI, state, oidcNonce)
+	if err != nil {
+		s.logger.Warn("OIDC: cannot build authorize URL", "provider", p.Name, "error", err)
+		http.Error(w, "login unavailable — provider not reachable", http.StatusBadGateway)
+		return
+	}
 	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
+}
+
+// providerGlyph returns a tiny inline SVG/emoji-free label mark per provider for
+// the picker. Kept as plain text marks (no remote assets) so the picker page is
+// fully self-contained and needs no external fetch.
+func providerGlyph(name string) string {
+	switch name {
+	case "github":
+		return "&#xf09b;" // rendered as text fallback; see picker CSS note
+	case "google":
+		return "G"
+	case "ibmid":
+		return "IBM"
+	case "redhat":
+		return "&#x1f452;"
+	default:
+		return "&#x2022;"
+	}
+}
+
+// writeProviderPicker renders the multi-provider sign-in page. Shown only when
+// more than one provider is enabled; a single-provider hub never reaches here.
+// The redirect target is preserved by threading it through each button's link.
+func (s *HubServer) writeProviderPicker(w http.ResponseWriter, providers []*auth.Provider, redirect string) {
+	rd := ""
+	if redirect != "" {
+		rd = "?redirect=" + url.QueryEscape(redirect)
+	}
+	var buttons strings.Builder
+	for _, p := range providers {
+		// Each button is a plain link to /login/{provider}; startProviderLogin
+		// mints the nonces there. Provider name/display are from our closed set,
+		// not user input, so they are safe to embed.
+		buttons.WriteString(fmt.Sprintf(
+			`<a class="prov prov-%s" href="/login/%s%s"><span class="glyph">%s</span><span>Continue with %s</span></a>`+"\n",
+			html.EscapeString(p.Name), html.EscapeString(p.Name), rd, providerGlyph(p.Name), html.EscapeString(p.DisplayName)))
+	}
+	page := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sign in — Hive</title>
+<style>
+:root{color-scheme:light dark}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0d1117;color:#e6edf3}
+.card{width:min(360px,92vw);padding:32px 28px;border:1px solid #30363d;border-radius:14px;background:#161b22;text-align:center}
+h1{font-size:20px;margin:0 0 4px}
+p.sub{color:#8b949e;font-size:13px;margin:0 0 24px}
+.prov{display:flex;align-items:center;gap:12px;justify-content:center;width:100%;box-sizing:border-box;
+padding:11px 14px;margin:8px 0;border:1px solid #30363d;border-radius:9px;background:#21262d;color:#e6edf3;
+text-decoration:none;font-size:14px;font-weight:600;transition:background .12s,border-color .12s}
+.prov:hover{background:#30363d;border-color:#8b949e}
+.glyph{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;
+border-radius:5px;background:#0d1117;font-size:11px;font-weight:700}
+.foot{margin-top:20px;color:#6e7681;font-size:11px}
+</style></head><body>
+<div class="card">
+<h1>Sign in to Hive</h1>
+<p class="sub">Choose how you'd like to continue.</p>
+` + buttons.String() + `<div class="foot">Your login provider controls access only. Hive's GitHub work runs through its own app.</div>
+</div></body></html>`
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(page))
 }
 
 func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
@@ -252,6 +416,157 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// Single-use: clear it now so a captured callback URL cannot be replayed.
 	s.clearOAuthStateCookie(w)
 
+	// state = nonce : provider : redirect. The provider name tells us which flow
+	// to complete; it defaults to github so a stale two-part state (from a login
+	// begun on the pre-multi-provider hub, mid-deploy) still completes as GitHub.
+	providerName, redirect := s.parseCallbackState(r)
+	p := s.resolveProvider(providerName)
+	if p == nil {
+		s.logger.Warn("OAuth: callback for unconfigured provider", "provider", providerName)
+		http.Error(w, "unknown login provider", http.StatusBadRequest)
+		return
+	}
+
+	// Resolve the login into a canonical identity (+ optional avatar/email and, for
+	// GitHub, the user access token to store). Each branch fully validates its own
+	// response; a failure returns an HTTP error and no session is minted.
+	var (
+		canonicalID string
+		avatarURL   string
+		email       string
+		ghToken     string // GitHub user access token, if any (stored encrypted)
+	)
+	if p.IsOIDC {
+		claims, err := p.Exchange(r.Context(), code, oauthRedirectURI, s.oidcNonceFromCookie(r))
+		s.clearOIDCNonceCookie(w)
+		if err != nil {
+			s.logger.Warn("OIDC: callback verification failed", "provider", p.Name, "error", err)
+			http.Error(w, "login failed — could not verify your identity", http.StatusBadGateway)
+			return
+		}
+		id, err := makeCanonical(p.Name, claims.Subject)
+		if err != nil {
+			s.logger.Warn("OIDC: subject not usable as identity", "provider", p.Name, "error", err)
+			http.Error(w, "login failed — invalid identity", http.StatusBadGateway)
+			return
+		}
+		canonicalID = id
+		avatarURL = claims.AvatarURL
+		email = claims.Email
+		s.logger.Info("audit: hub OIDC login", "provider", p.Name, "user", canonicalID)
+	} else {
+		login, avatar, token, ok := s.exchangeGitHubLogin(w, code)
+		if !ok {
+			return // exchangeGitHubLogin already wrote the error
+		}
+		// GitHub primary identity is the bare login (the shim reads it as
+		// github:<login>); keep it bare so legacy files/grants/cookies are
+		// byte-identical to the pre-multi-provider hub.
+		canonicalID = login
+		avatarURL = avatar
+		ghToken = token
+		s.logger.Info("audit: hub OAuth login", "user", login)
+	}
+
+	// From here the two paths converge: mint the session cookies over the
+	// canonical id (the signing machinery signs an opaque string, so this is
+	// provider-agnostic) and persist the user record.
+	if !s.mintSessionCookies(w, canonicalID) {
+		return // mintSessionCookies wrote the error
+	}
+
+	saasUser := ensureSaaSUser(canonicalID)
+	// Stamp the provider fields so the Users-table badge and dual-read storage
+	// have an explicit canonical identity (Phase 1d fields). For a legacy GitHub
+	// user these are derivable, but writing them makes the record self-describing.
+	provider, _, _ := parseCanonical(canonicalizeLegacy(canonicalID))
+	saasUser.CanonicalID = canonicalizeLegacy(canonicalID)
+	saasUser.Provider = provider
+	if avatarURL != "" {
+		saasUser.AvatarURL = avatarURL
+	}
+	if email != "" {
+		saasUser.Email = email
+	}
+	// A completed callback IS a login — count it here and nowhere else.
+	saasUser.LoginCount++
+	if ghToken != "" {
+		if encrypted, err := encryptToken(ghToken); err == nil {
+			saasUser.EncryptedToken = encrypted
+		}
+	}
+	saveSaaSUser(saasUser)
+
+	if redirect == "" {
+		redirect = "/dashboard"
+	}
+	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
+}
+
+// resolveProvider returns the auth.Provider to complete a callback against. It
+// reads the built registry, but falls back to synthesizing a GitHub provider
+// from the current env/endpoint vars when the registry is absent (a HubServer
+// constructed without registerOAuth — the unit-test path) or does not carry
+// GitHub. This keeps the GitHub callback working exactly as before regardless of
+// whether the registry was built, while OIDC always requires the registry.
+func (s *HubServer) resolveProvider(name string) *auth.Provider {
+	if p := s.authProviders.Get(name); p != nil {
+		return p
+	}
+	// GitHub is always resolvable by synthesizing it from the current env/endpoint
+	// vars: the registry may not carry it (a HubServer built without registerOAuth
+	// — the unit-test path — or one where the GitHub client id was unset). An empty
+	// client id is a production-config concern, not a handler concern; the pre-
+	// multi-provider hub also redirected to GitHub's authorize with whatever client
+	// id was in env. OIDC providers, by contrast, MUST come from the built registry.
+	if name == legacyProvider || name == "" {
+		return &auth.Provider{
+			Name:         "github",
+			DisplayName:  "GitHub",
+			IsOIDC:       false,
+			AuthorizeURL: defaultGHAuthorizeURL,
+			TokenURL:     defaultGHTokenURL,
+			ClientID:     os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID"),
+			Scopes:       []string{""},
+		}
+	}
+	return nil
+}
+
+// parseCallbackState extracts the provider name and validated redirect target
+// from the (already nonce-verified) state parameter. State is
+// "nonce:provider:redirect". A two-part legacy state (nonce:redirect, from a
+// login begun before this deploy) yields provider "github" and treats the second
+// half as the redirect.
+func (s *HubServer) parseCallbackState(r *http.Request) (provider, redirect string) {
+	provider = "github"
+	redirect = "/dashboard"
+	decoded, err := url.QueryUnescape(r.URL.Query().Get("state"))
+	if err != nil || decoded == "" {
+		return provider, redirect
+	}
+	// Strip the already-verified nonce.
+	_, rest, ok := strings.Cut(decoded, oauthStateSeparator)
+	if !ok {
+		return provider, redirect
+	}
+	// rest is "provider:redirect" (new) or just "redirect" (legacy two-part).
+	maybeProvider, maybeRedirect, ok := strings.Cut(rest, oauthStateSeparator)
+	if ok && s.authProviders.Get(maybeProvider) != nil {
+		provider = maybeProvider
+		rest = maybeRedirect
+	}
+	if rest != "" && ((strings.HasPrefix(rest, "/") && !strings.HasPrefix(rest, "//")) || isTrustedRedirectTarget(rest)) {
+		redirect = rest
+	}
+	return provider, redirect
+}
+
+// exchangeGitHubLogin runs the GitHub OAuth code→token→/user flow and returns the
+// login, avatar, and user access token. On any failure it writes the HTTP error
+// and returns ok=false. This is the original callback logic, factored out so the
+// dispatcher can share the surrounding cookie/persistence code with OIDC.
+func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (login, avatar, token string, ok bool) {
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
 	clientSecret := os.Getenv("HIVE_HUB_OAUTH_CLIENT_SECRET")
 
@@ -268,7 +583,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		s.logger.Warn("OAuth token exchange failed", "error", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
 	defer resp.Body.Close()
 
@@ -282,13 +597,12 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		s.logger.Warn("OAuth: failed to parse token response", "error", err)
 		http.Error(w, "invalid token response", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
-
 	if tokenResp.AccessToken == "" {
 		s.logger.Warn("OAuth: no access token in response")
 		http.Error(w, "no access token", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
 
 	userReq, _ := http.NewRequest("GET", defaultGHUserURL, nil)
@@ -296,7 +610,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	userResp, err := client.Do(userReq)
 	if err != nil {
 		http.Error(w, "user fetch failed", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
 	defer userResp.Body.Close()
 
@@ -308,27 +622,28 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	if err := json.Unmarshal(userBody, &user); err != nil {
 		s.logger.Warn("OAuth: failed to parse user response", "error", err)
 		http.Error(w, "invalid user response", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
-
 	if user.Login == "" || !isValidName(user.Login) {
 		s.logger.Warn("OAuth: invalid or empty login", "login", user.Login)
 		http.Error(w, "invalid user login", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
+	return user.Login, user.AvatarURL, tokenResp.AccessToken, true
+}
 
-	s.logger.Info("audit: hub OAuth login", "user", user.Login)
-
-	// Set the session cookie to a signed, tamper-evident value so it cannot be
-	// forged. If the hub has no secret to sign with, fail the login rather than
-	// emit an unsigned (trusted-by-default) cookie.
-	cookieValue := mintHubUserCookieValue(s.sessionCookieKey(), user.Login)
+// mintSessionCookies sets both the HMAC (hive_hub_user) and Ed25519
+// (hive_hub_user_v2) session cookies over the given canonical identity. Returns
+// false (after writing an HTTP error) if the hub has no secret to sign with — an
+// unsigned cookie would be trusted by default and must never be emitted.
+func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
+	cookieValue := mintHubUserCookieValue(s.sessionCookieKey(), canonicalID)
 	if cookieValue == "" {
-		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", user.Login)
+		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", canonicalID)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
-		return
+		return false
 	}
-	cookie := &http.Cookie{
+	http.SetCookie(w, &http.Cookie{
 		Name:     "hive_hub_user",
 		Value:    cookieValue,
 		Path:     "/",
@@ -337,25 +652,16 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
-	}
-	http.SetCookie(w, cookie)
+	})
 
-	// N2 (CWE-321/798): ALSO emit an Ed25519-signed cookie.
-	//
-	// hive_hub_user above stays HMAC because that is the only format v2 spokes
-	// can verify (their proxy checks HMAC and nothing else — see F3/#3243), and
-	// v4 spokes accept either. Minting only Ed25519 would 401 the terminal on
-	// every v2 spoke in the fleet.
-	//
-	// This second cookie is what actually closes N2 for spokes that can read it:
-	// a spoke holding only the PUBLIC key can verify it but cannot mint one, so
-	// it can no longer forge `clubanderson.<sig>` and obtain hub admin. v4's
-	// proxy prefers it; v2's ignores an unknown cookie name.
-	//
-	// Two cookies rather than one hybrid value: each verifier computes its
-	// signature over the whole prefix, so no single concatenation satisfies
-	// both — verified empirically, both orderings fail both verifiers.
-	if v2Value := mintHubUserCookieValueV2(s.sessionSigningSeed(), user.Login); v2Value != "" {
+	// N2 (CWE-321/798): ALSO emit an Ed25519-signed cookie. hive_hub_user stays
+	// HMAC because that is the only format v2 spokes verify; v4 accepts either.
+	// This second cookie is what actually closes N2 for spokes that can read it: a
+	// spoke holding only the PUBLIC key can verify but not mint one, so it can no
+	// longer forge a hub-admin cookie. Two cookies rather than one hybrid value:
+	// each verifier signs the whole prefix, so no single concatenation satisfies
+	// both.
+	if v2Value := mintHubUserCookieValueV2(s.sessionSigningSeed(), canonicalID); v2Value != "" {
 		http.SetCookie(w, &http.Cookie{
 			Name:     hubUserCookieV2Name,
 			Value:    v2Value,
@@ -367,31 +673,56 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 			SameSite: http.SameSiteLaxMode,
 		})
 	}
+	return true
+}
 
-	saasUser := ensureSaaSUser(user.Login)
-	// A completed OAuth callback IS a login — count it here and nowhere else.
-	// ensureSaaSUser already refreshed LastLogin; the count is the engagement
-	// signal the admin Users card reads. Persist unconditionally below so a login
-	// is recorded even when there is no token to encrypt (the token branch used to
-	// be the only save path, so a token-encrypt failure silently dropped the whole
-	// record update).
-	saasUser.LoginCount++
-	if encrypted, err := encryptToken(tokenResp.AccessToken); err == nil {
-		saasUser.EncryptedToken = encrypted
+// oidcNonceFromCookie returns the OIDC replay nonce this browser was issued at
+// login start, or "" if absent. The id_token must echo it back.
+func (s *HubServer) oidcNonceFromCookie(r *http.Request) string {
+	c, err := r.Cookie(oidcNonceCookieName)
+	if err != nil || c.Value == "" {
+		return ""
 	}
-	saveSaaSUser(saasUser)
+	return c.Value
+}
 
-	redirect := "/dashboard"
-	if decoded, err := url.QueryUnescape(r.URL.Query().Get("state")); err == nil && decoded != "" {
-		// The nonce was already verified above; take only the redirect half.
-		if _, target, ok := strings.Cut(decoded, oauthStateSeparator); ok {
-			decoded = target
-		}
-		if decoded != "" && ((strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedRedirectTarget(decoded)) {
-			redirect = decoded
-		}
+// clearOIDCNonceCookie expires the OIDC nonce, making it single-use.
+func (s *HubServer) clearOIDCNonceCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oidcNonceCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// displayIdentity returns the human-facing login label and avatar URL for a
+// canonical (or legacy bare) identity. For a GitHub user this is the bare login
+// and the derived github.com/<login>.png avatar — byte-identical to the
+// pre-multi-provider behavior. For an OIDC user it prefers the STORED avatar
+// (Google/IBMid provide a picture) and a friendly display label (email, else
+// display name, else the canonical id), never the opaque provider:sub.
+func (s *HubServer) displayIdentity(identity string) (login, avatarURL string) {
+	provider, subject, ok := parseCanonical(canonicalizeLegacy(identity))
+	if !ok {
+		return identity, ""
 	}
-	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
+	if provider == legacyProvider {
+		// GitHub: unchanged. subject is the bare login.
+		return subject, fmt.Sprintf("https://github.com/%s.png", subject)
+	}
+	// Non-GitHub: use the stored record for a good label + avatar.
+	login = identity
+	if u := loadSaaSUser(canonicalizeLegacy(identity)); u != nil {
+		if u.Email != "" {
+			login = u.Email
+		}
+		avatarURL = u.AvatarURL
+	}
+	return login, avatarURL
 }
 
 func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
@@ -410,6 +741,7 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	isAdmin := isHubAdmin(username)
+	displayLogin, avatar := s.displayIdentity(username)
 	// Fold impersonation status into the auth payload the dashboard already
 	// fetches, so the "Viewing as … read-only" banner renders without a second
 	// round-trip. When an admin is impersonating, report the effective identity
@@ -418,17 +750,18 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	// user, so admin-only affordances hide via the existing role checks.
 	payload := map[string]any{
 		"authenticated": true,
-		"login":         username,
-		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", username),
+		"login":         displayLogin,
+		"avatar_url":    avatar,
 		"hub_admin":     isAdmin,
 	}
 	if grant, ok := s.activeImpersonationGrant(r); ok {
-		payload["login"] = grant.Target
-		payload["avatar_url"] = fmt.Sprintf("https://github.com/%s.png", grant.Target)
+		targetLogin, targetAvatar := s.displayIdentity(grant.Target)
+		payload["login"] = targetLogin
+		payload["avatar_url"] = targetAvatar
 		payload["hub_admin"] = false
 		payload["impersonating"] = true
-		payload["viewing_as"] = grant.Target
-		payload["real_user"] = username
+		payload["viewing_as"] = targetLogin
+		payload["real_user"] = displayLogin
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/v2/pkg/hub/oidc_login_test.go
+++ b/v2/pkg/hub/oidc_login_test.go
@@ -1,0 +1,213 @@
+package hub
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/kubestellar/hive/v2/pkg/auth"
+)
+
+// fakeOIDCProvider is a minimal OIDC server (discovery + JWKS + token endpoint)
+// returning one signed id_token, used to drive the hub's OIDC callback end to end.
+type fakeOIDCProvider struct {
+	srv     *httptest.Server
+	key     *rsa.PrivateKey
+	kid     string
+	issuer  string
+	idToken string
+}
+
+func newFakeOIDCProvider(t *testing.T) *fakeOIDCProvider {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeOIDCProvider{key: key, kid: "hub-test-kid"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 f.issuer,
+			"authorization_endpoint": f.issuer + "/authorize",
+			"token_endpoint":         f.issuer + "/token",
+			"jwks_uri":               f.issuer + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		pub := key.Public().(*rsa.PublicKey)
+		n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+		json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{{"kty": "RSA", "kid": f.kid, "use": "sig", "alg": "RS256", "n": n, "e": e}},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"id_token": f.idToken})
+	})
+	f.srv = httptest.NewServer(mux)
+	f.issuer = f.srv.URL
+	return f
+}
+
+func (f *fakeOIDCProvider) close() { f.srv.Close() }
+
+func (f *fakeOIDCProvider) sign(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = f.kid
+	s, err := tok.SignedString(f.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// TestOIDCCallback_CreatesCanonicalUser drives a full Google login through the
+// hub callback: the id_token verifies, a canonical google:<sub> user is created
+// with provider/avatar/email stamped, and both session cookies are minted over
+// the canonical id.
+func TestOIDCCallback_CreatesCanonicalUser(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	f := newFakeOIDCProvider(t)
+	defer f.close()
+
+	const clientID = "hub-oidc-client"
+	const nonce = "oidc-nonce-123"
+	const sub = "108877665544332211"
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss":     f.issuer,
+		"aud":     clientID,
+		"sub":     sub,
+		"exp":     time.Now().Add(time.Hour).Unix(),
+		"iat":     time.Now().Unix(),
+		"nonce":   nonce,
+		"email":   "person@example.com",
+		"name":    "A Person",
+		"picture": "https://example.com/p.png",
+	})
+
+	// A hub with a real secret (mints signed cookies) and a registry carrying our
+	// fake Google provider.
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	s.authProviders = auth.NewRegistry(&auth.Provider{
+		Name:        "google",
+		DisplayName: "Google",
+		IsOIDC:      true,
+		Issuer:      f.issuer,
+		ClientID:    clientID,
+		Scopes:      []string{"openid", "email", "profile"},
+	})
+
+	// state = nonce : google : /dashboard, with matching state + OIDC nonce cookies.
+	stateNonce, _ := oauthStateNonce()
+	state := url.QueryEscape(stateNonce + oauthStateSeparator + "google" + oauthStateSeparator + "/dashboard")
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=xyz&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: stateNonce})
+	req.AddCookie(&http.Cookie{Name: oidcNonceCookieName, Value: nonce})
+
+	rec := httptest.NewRecorder()
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want 307 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/dashboard" {
+		t.Errorf("redirect = %q, want /dashboard", loc)
+	}
+
+	// A canonical google user must exist with the provider fields stamped.
+	u := loadSaaSUser("google:" + sub)
+	if u == nil {
+		t.Fatalf("expected google:%s user to be created", sub)
+	}
+	if u.Provider != "google" {
+		t.Errorf("Provider = %q, want google", u.Provider)
+	}
+	if u.CanonicalID != "google:"+sub {
+		t.Errorf("CanonicalID = %q, want google:%s", u.CanonicalID, sub)
+	}
+	if u.AvatarURL != "https://example.com/p.png" {
+		t.Errorf("AvatarURL = %q", u.AvatarURL)
+	}
+	if u.Email != "person@example.com" {
+		t.Errorf("Email = %q", u.Email)
+	}
+	if u.EncryptedToken != "" {
+		t.Error("a Google user must NOT carry a GitHub EncryptedToken")
+	}
+
+	// Both session cookies minted over the canonical id.
+	var gotHMAC, gotEd bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			gotHMAC = true
+			if user, ok := s.verifyHubUserDual(c.Value); !ok || user != "google:"+sub {
+				t.Errorf("hive_hub_user verifies to %q (ok=%v), want google:%s", user, ok, sub)
+			}
+		}
+		if c.Name == hubUserCookieV2Name && c.Value != "" {
+			gotEd = true
+		}
+	}
+	if !gotHMAC || !gotEd {
+		t.Errorf("expected both session cookies; hmac=%v ed=%v", gotHMAC, gotEd)
+	}
+}
+
+// TestOIDCCallback_RejectsBadNonce confirms the hub callback fails closed when
+// the id_token's nonce does not match the browser's OIDC nonce cookie (replay /
+// injection), minting NO session.
+func TestOIDCCallback_RejectsBadNonce(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	f := newFakeOIDCProvider(t)
+	defer f.close()
+
+	const clientID = "hub-oidc-client"
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss": f.issuer, "aud": clientID, "sub": "s1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": "the-real-nonce",
+	})
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	s.authProviders = auth.NewRegistry(&auth.Provider{
+		Name: "google", DisplayName: "Google", IsOIDC: true,
+		Issuer: f.issuer, ClientID: clientID, Scopes: []string{"openid"},
+	})
+
+	stateNonce, _ := oauthStateNonce()
+	state := url.QueryEscape(stateNonce + oauthStateSeparator + "google" + oauthStateSeparator + "/dashboard")
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=xyz&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: stateNonce})
+	// The browser's cookie carries a DIFFERENT nonce than the token.
+	req.AddCookie(&http.Cookie{Name: oidcNonceCookieName, Value: "a-different-nonce"})
+
+	rec := httptest.NewRecorder()
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code == http.StatusTemporaryRedirect {
+		t.Fatal("callback must not succeed on nonce mismatch")
+	}
+	if loadSaaSUser("google:s1") != nil {
+		t.Error("no user should be created on a rejected login")
+	}
+	for _, c := range rec.Result().Cookies() {
+		if (c.Name == "hive_hub_user" || c.Name == hubUserCookieV2Name) && c.Value != "" {
+			t.Errorf("a session cookie %q was minted on a rejected login", c.Name)
+		}
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/v2/pkg/auth"
 	"github.com/kubestellar/hive/v2/pkg/openrouter"
 )
 
@@ -792,6 +793,13 @@ type HubServer struct {
 	mu       sync.RWMutex
 	logger   *slog.Logger
 	saveCh   chan struct{}
+
+	// authProviders is the enabled human-login provider set (GitHub OAuth plus any
+	// configured OIDC providers — Google/IBMid/Red Hat). Built once in
+	// registerOAuth from the environment; nil until then. The login picker and the
+	// OIDC callback read it. It governs ONLY human dashboard login/access — never
+	// the GitHub App token or agent logins.
+	authProviders *auth.Registry
 	// registryPath is this server's on-disk registry file, captured from the
 	// package-level default at construction and immutable afterwards. It is a
 	// per-instance field (not a use-time read of the global) so the saveLoop


### PR DESCRIPTION
## Multi-login Phase 2 — Google OIDC on the hub

Builds on the Phase 1 canonical-identity foundation (#3566/#3568/#3569/#3573) to add **multi-provider human login, Google first**. Strictly human dashboard login + access control — this does **not** touch the GitHub App installation token (which does the hive's actual GitHub work) or agent/backend logins.

### New `v2/pkg/auth`
- Provider abstraction (GitHub OAuth + OIDC) with an **env-driven registry** — a provider is enabled iff its `<PREFIX>_CLIENT_ID` is set (mirrors the existing `HIVE_HUB_OAUTH_CLIENT_ID` gate). Google / IBMid / Red Hat specs; IBMid & Red Hat require an explicit `_ISSUER`.
- **OIDC id_token verification** via the already-vendored `golang-jwt/jwt/v5`:
  - RS256/384/512 only — `none` and HMAC-confusion blocked at both the parser (`WithValidMethods`) and the keyfunc (RSA type assertion)
  - signing key resolved from **JWKS by `kid`**, with rate-limited refresh-on-unknown-kid for rotation
  - `iss` / `aud` / `exp` **and the OIDC nonce** all enforced (nonce **fails closed** on a missing browser cookie)
  - identity from the stable **`sub`** claim, never email
  - OIDC discovery with a **required issuer cross-check** against the configured issuer
- Adversarial test suite: happy path + wrong-aud, wrong-iss, expired, bad-nonce, **empty-expected-nonce**, alg=none, HS256-confusion, unknown-kid, **discovery-missing-issuer**, discovery-issuer-mismatch, and registry gating.

### Hub (`v2/pkg/hub/oauth.go`)
- `/login` renders a **provider picker** when >1 provider is enabled; redirects straight into GitHub when it's the only one — **pre-multi-provider UX is byte-identical**. `/login/{provider}` starts a specific provider.
- `state` now carries `nonce:provider:redirect`; the **CSRF state-nonce check is unchanged and still runs before any token exchange**. A legacy two-part state still completes as GitHub (mid-deploy safety).
- The callback **dispatches** GitHub (unchanged `/user` flow) vs OIDC (verified claims), both converging on `ensureSaaSUser` over the canonical id and minting **both** session cookies (HMAC + Ed25519) over that opaque string.
- OIDC users get a canonical `google:<sub>` record with `Provider`/`AvatarURL`/`Email` stamped (Phase 1d fields); `/api/auth/user` serves the **stored avatar** and a friendly display label instead of `github.com/<login>.png`.
- End-to-end hub test drives a full Google login through the callback and asserts a rejected login mints **no** session.

### Security review
Reviewed for the risk-#3 (hand-rolled OIDC verification) surface. Two findings fixed before this PR: (1) OIDC nonce fail-open on a missing cookie → now a hard reject; (2) discovery issuer cross-check skipped when the doc omitted `issuer` → issuer now required and always checked.

### Operator step at deploy
Set `HIVE_HUB_OIDC_GOOGLE_CLIENT_ID` / `_SECRET` on the hub (Google client already created + published). Google then appears in the picker; **hub-proxied spokes inherit it for free** via the canonical `X-Hive-User` (Phase 3 covers direct-route spokes only).

Full hub suite green; `go vet` clean.