### PR TITLE
🔒 fix(hub): port the F10 v3 session-cookie verifier to v2 (verifier only)

### DIFF
--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -3,10 +3,13 @@ package hub
 import (
 	"crypto/ed25519"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"strings"
+	"time"
 )
 
 // Hub session cookie integrity.
@@ -178,4 +181,232 @@ func verifyHubUserCookieEither(pubHex, legacySecret, value string) (string, bool
 // Rollout telemetry only — never an authorization decision on its own.
 func hubCookieIsV2(value string) bool {
 	return strings.Contains(value, hubCookieV2Marker)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F10: signed session lifetime + revocable session ID (v3 cookie lane).
+//
+// VERIFIER ONLY ON THIS BRANCH. mintHubUserCookieValueV3 exists so the format
+// is defined and testable, but NOTHING in production calls it — the hub still
+// mints v2. That is deliberate: this cookie is verified by the hub (Go) AND
+// independently by every spoke's Node proxy, so minting a shape a not-yet-rolled
+// spoke cannot parse breaks /terminal fleet-wide (incident #2773). Minting flips
+// only once every spoke verifies v3.
+//
+// Ported from v4 (#3505). The v2 and legacy HMAC lanes are untouched — they are
+// the F1/F2 compatibility paths and removing them 401s the fleet (#3234).
+// ─────────────────────────────────────────────────────────────────────────────
+// AUDIT F10 (session lifetime is neither signed nor revocable).
+//
+// The v2 signature above covers ONLY the username. That leaves two holes:
+//
+//  1. The cookie's lifetime lives entirely in the browser's `MaxAge`. MaxAge is
+//     a hint to the browser, not a server-side claim — a copied cookie value is
+//     accepted forever, because nothing in the signed bytes says when it was
+//     issued or when it stops being valid.
+//  2. Logout only deletes the browser's copy. Anyone who captured the value
+//     keeps a working session across logout, password change, or account
+//     removal, for as long as the signing key stays accepted.
+//
+// v3 closes both by moving the claims INSIDE the signature:
+//
+//	v3 value = <base64url(JSON{u,iat,exp,sid})>.v3.<base64url(Ed25519-Sign(payload))>
+//
+// The signature covers the encoded payload bytes, so issued-at, expiry, and the
+// session ID are all tamper-evident. Expiry is then enforced by the VERIFIER
+// (hub and spoke alike) rather than trusted to the browser, and `sid` gives
+// logout something concrete to revoke — see hub_session_revocation.go.
+//
+// Unlike v2, the username is no longer in the clear at the head of the value;
+// it is a field of the signed payload. That is why v3 needs its own marker: the
+// two shapes are not parseable by the same code, and the marker is what lets a
+// single verifier route the value to the right parser without guessing.
+const hubCookieV3Marker = ".v3."
+
+// hubCookieClaims are the signed contents of a v3 session cookie. Field names
+// are SHORT and FROZEN: the Node proxy (v2/proxy/server.js) parses these exact
+// JSON keys, and a rename on one side alone silently 401s every hosted login at
+// deploy time. Do not "tidy" them.
+type hubCookieClaims struct {
+	// U is the GitHub login this session authenticates as.
+	U string `json:"u"`
+	// IAT is the issued-at time, Unix seconds.
+	IAT int64 `json:"iat"`
+	// EXP is the hard expiry, Unix seconds. Enforced server-side, unlike the
+	// browser's MaxAge, so a copied cookie dies on schedule.
+	EXP int64 `json:"exp"`
+	// SID is the unguessable per-session ID that revocation is keyed on. It is
+	// what makes logout mean something for a value that has already left the
+	// browser.
+	SID string `json:"sid"`
+}
+
+// hubCookieSessionIDBytes is the entropy behind a session ID. Matches
+// oauthStateNonceBytes: a revocation key that can be guessed is a revocation
+// key that can be exhausted by an attacker probing which sessions are live.
+const hubCookieSessionIDBytes = 32
+
+// newHubCookieSessionID mints an unguessable session ID, or "" if the system
+// CSPRNG fails — callers must fail closed rather than mint a predictable SID.
+func newHubCookieSessionID() string {
+	buf := make([]byte, hubCookieSessionIDBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(buf)
+}
+
+// mintHubUserCookieValueV3 mints an Ed25519-signed session cookie carrying a
+// signed lifetime and session ID. seedHex is the hub's PRIVATE session seed.
+//
+// NOTHING CALLS THIS IN PRODUCTION YET, deliberately. The cookie is verified by
+// the hub (Go) AND independently by every spoke's Node proxy; minting a shape a
+// not-yet-rolled spoke cannot parse breaks /terminal fleet-wide. That is
+// incident #2773. Minting flips only once the whole fleet verifies v3 — see the
+// rollout note on verifyHubUserCookieEither.
+//
+// Returns "" on empty inputs, a bad seed, a non-positive ttl, or a CSPRNG
+// failure — fail closed rather than sign junk, matching mintHubUserCookieValueV2.
+func mintHubUserCookieValueV3(seedHex, username string, now time.Time, ttl time.Duration) (value, sid string) {
+	if seedHex == "" || username == "" || ttl <= 0 {
+		return "", ""
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return "", ""
+	}
+	sid = newHubCookieSessionID()
+	if sid == "" {
+		return "", ""
+	}
+	payload, err := json.Marshal(hubCookieClaims{
+		U:   username,
+		IAT: now.Unix(),
+		EXP: now.Add(ttl).Unix(),
+		SID: sid,
+	})
+	if err != nil {
+		return "", ""
+	}
+	body := hubCookieB64.EncodeToString(payload)
+	priv := ed25519.NewKeyFromSeed(seed)
+	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(body)))
+	return body + hubCookieV3Marker + sig, sid
+}
+
+// hubSessionRevokedFunc reports whether a session ID has been revoked. Passed in
+// rather than reached for so the cookie layer stays a pure function of its
+// inputs and the tests can drive revocation directly. A nil func means "nothing
+// is revoked" — which is the correct behaviour for the spoke-side verifier,
+// which has no revocation store of its own.
+type hubSessionRevokedFunc func(sid string) bool
+
+// verifyHubUserCookieValueV3 verifies a v3 cookie against the hub's PUBLIC
+// session key AND enforces its signed lifetime and revocation state. Returns
+// (username, true) only when the signature verifies, the clock window is
+// satisfied, and the session ID has not been revoked.
+//
+// Order matters: the signature is checked BEFORE any payload byte is trusted,
+// exactly as VerifyTerminalAssertion does. Parsing attacker-controlled JSON
+// before authenticating it is how payload parsers become the attack surface.
+func verifyHubUserCookieValueV3(pubHex, value string, now time.Time, revoked hubSessionRevokedFunc) (string, bool) {
+	if pubHex == "" || value == "" {
+		return "", false
+	}
+	idx := strings.LastIndex(value, hubCookieV3Marker)
+	if idx <= 0 {
+		return "", false
+	}
+	body := value[:idx]
+	sigB64 := value[idx+len(hubCookieV3Marker):]
+	if body == "" || sigB64 == "" {
+		return "", false
+	}
+	pub, err := hex.DecodeString(strings.TrimSpace(pubHex))
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return "", false
+	}
+	sig, err := hubCookieB64.DecodeString(sigB64)
+	if err != nil {
+		return "", false
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(body), sig) {
+		return "", false
+	}
+	raw, err := hubCookieB64.DecodeString(body)
+	if err != nil {
+		return "", false
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return "", false
+	}
+	if claims.U == "" || claims.SID == "" {
+		return "", false
+	}
+	// Clock-skew tolerance mirrors VerifyTerminalAssertion: hub and spoke are
+	// separate clusters and their clocks drift, so a strict comparison would
+	// reject freshly minted cookies on a spoke running seconds ahead.
+	nowUnix := now.Unix()
+	skew := int64(ssoClockSkew / time.Second)
+	if claims.IAT > nowUnix+skew {
+		return "", false // not yet valid
+	}
+	if claims.EXP < nowUnix-skew {
+		return "", false // expired
+	}
+	if revoked != nil && revoked(claims.SID) {
+		return "", false
+	}
+	return claims.U, true
+}
+
+// hubCookieSessionID returns the session ID carried by a v3 cookie, or "" for
+// any other shape. Used by logout to learn WHICH session to revoke.
+//
+// This deliberately does NOT verify the signature: it is only ever called on a
+// value that a verifier already accepted, and its result is used solely to add
+// an entry to the revocation set. The worst an unverified caller could achieve
+// is revoking a session ID it already knows — which is not an escalation.
+func hubCookieSessionID(value string) string {
+	idx := strings.LastIndex(value, hubCookieV3Marker)
+	if idx <= 0 {
+		return ""
+	}
+	raw, err := hubCookieB64.DecodeString(value[:idx])
+	if err != nil {
+		return ""
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return ""
+	}
+	return claims.SID
+}
+
+// hubCookieExpiry returns the signed expiry (Unix seconds) carried by a v3
+// cookie, or 0 for any other shape. Like hubCookieSessionID this reads the
+// payload without re-verifying; it bounds how long a revocation entry is kept,
+// and an attacker who inflated it would only be lengthening the revocation of
+// their OWN session.
+func hubCookieExpiry(value string) int64 {
+	idx := strings.LastIndex(value, hubCookieV3Marker)
+	if idx <= 0 {
+		return 0
+	}
+	raw, err := hubCookieB64.DecodeString(value[:idx])
+	if err != nil {
+		return 0
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return 0
+	}
+	return claims.EXP
+}
+
+// hubCookieIsV3 reports whether a cookie value carries the F10 format. Rollout
+// telemetry only — never an authorization decision on its own.
+func hubCookieIsV3(value string) bool {
+	return strings.Contains(value, hubCookieV3Marker)
 }

--- a/v2/pkg/hub/hub_cookie_v3_test.go
+++ b/v2/pkg/hub/hub_cookie_v3_test.go
@@ -1,0 +1,99 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// F10 on v2 — VERIFIER ONLY. These pin the v3 lane's behaviour so a later mint
+// flip has something to flip against, and so the lane cannot silently rot.
+//
+// Nothing in production mints v3 on this branch; TestF10_V2_MintingHasNotFlipped
+// is the tripwire that makes any future change to that deliberate and visible.
+
+func testSeedHex(t *testing.T) (seed, pub string) {
+	t.Helper()
+	s := &HubServer{hubSecret: testHubSecret}
+	return s.sessionSigningSeed(), s.sessionPublicKey()
+}
+
+func TestF10_V2_V3CookieVerifiesWithSignedLifetime(t *testing.T) {
+	seed, pub := testSeedHex(t)
+	now := time.Now()
+	value, sid := mintHubUserCookieValueV3(seed, "clubanderson", now, time.Hour)
+	if value == "" || sid == "" {
+		t.Fatal("mint returned empty — the v3 lane is not usable")
+	}
+	got, ok := verifyHubUserCookieValueV3(pub, value, now, nil)
+	if !ok || got != "clubanderson" {
+		t.Fatalf("valid v3 cookie failed to verify: got=%q ok=%v", got, ok)
+	}
+}
+
+// The whole point of F10: a captured cookie must stop working.
+func TestF10_V2_ExpiredV3CookieIsRejected(t *testing.T) {
+	seed, pub := testSeedHex(t)
+	issued := time.Now().Add(-2 * time.Hour)
+	value, _ := mintHubUserCookieValueV3(seed, "clubanderson", issued, time.Hour)
+	if _, ok := verifyHubUserCookieValueV3(pub, value, time.Now(), nil); ok {
+		t.Fatal("F10: an EXPIRED v3 cookie still verified — the signed lifetime is not enforced")
+	}
+}
+
+// The other half: logout must be able to kill a session server-side.
+func TestF10_V2_RevokedSessionIsRejected(t *testing.T) {
+	seed, pub := testSeedHex(t)
+	now := time.Now()
+	value, sid := mintHubUserCookieValueV3(seed, "clubanderson", now, time.Hour)
+	revoked := func(s string) bool { return s == sid }
+	if _, ok := verifyHubUserCookieValueV3(pub, value, now, revoked); ok {
+		t.Fatal("F10: a REVOKED session id still verified — logout cannot invalidate a cookie")
+	}
+	// Control: a different sid must not be collaterally revoked.
+	other := func(s string) bool { return s == "some-other-sid" }
+	if _, ok := verifyHubUserCookieValueV3(pub, value, now, other); !ok {
+		t.Fatal("revoking one session invalidated an unrelated one")
+	}
+}
+
+func TestF10_V2_TamperedV3PayloadIsRejected(t *testing.T) {
+	seed, pub := testSeedHex(t)
+	now := time.Now()
+	value, _ := mintHubUserCookieValueV3(seed, "alice", now, time.Hour)
+	// Flip a byte in the signed body.
+	b := []byte(value)
+	b[0] ^= 0xFF
+	if _, ok := verifyHubUserCookieValueV3(pub, string(b), now, nil); ok {
+		t.Fatal("F10: a tampered v3 payload verified")
+	}
+}
+
+// verifyHubUserDual must PREFER v3 and must NOT have broken the older lanes —
+// they are the F1/F2 compatibility paths and removing them 401s the fleet.
+func TestF10_V2_DualStillAcceptsV2AndLegacy(t *testing.T) {
+	s := &HubServer{hubSecret: testHubSecret}
+
+	v3, _ := mintHubUserCookieValueV3(s.sessionSigningSeed(), "clubanderson", time.Now(), time.Hour)
+	if u, ok := s.verifyHubUserDual(v3); !ok || u != "clubanderson" {
+		t.Fatalf("v3 cookie not accepted by verifyHubUserDual: %q %v", u, ok)
+	}
+	v2 := mintHubUserCookieValueV2(s.sessionSigningSeed(), "clubanderson")
+	if u, ok := s.verifyHubUserDual(v2); !ok || u != "clubanderson" {
+		t.Fatalf("REGRESSION: the v2 lane stopped verifying: %q %v", u, ok)
+	}
+	legacy := mintHubUserCookieValue(s.sessionCookieKey(), "clubanderson")
+	if u, ok := s.verifyHubUserDual(legacy); !ok || u != "clubanderson" {
+		t.Fatalf("REGRESSION: the legacy HMAC lane stopped verifying: %q %v", u, ok)
+	}
+}
+
+// TRIPWIRE. Nothing may mint v3 until every verifier in the fleet — including
+// each spoke's Node proxy — accepts it. If this fails, someone flipped minting;
+// that is incident #2773's shape and must be a deliberate, reviewed change.
+func TestF10_V2_MintingHasNotFlipped(t *testing.T) {
+	s := &HubServer{hubSecret: testHubSecret}
+	minted := mintHubUserCookieValueV2(s.sessionSigningSeed(), "clubanderson")
+	if hubCookieIsV3(minted) {
+		t.Fatal("F10: production minting has flipped to v3 — every spoke proxy must verify v3 FIRST")
+	}
+}

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
+	"time"
 )
 
 // Domain-separated key derivation for the hub master secret — v2 hub-side
@@ -149,6 +150,16 @@ func (s *HubServer) verifyHubUserDual(value string) (string, bool) {
 	// N2 (CWE-321/798): accept the ASYMMETRIC value first. Only the hub can mint
 	// it — a spoke holding just the public key can verify but not forge — so it
 	// is the strongest of the three and should win when present.
+	// F10: a v3 cookie is the strongest form — same Ed25519 asymmetry as v2, PLUS
+	// a signed expiry and a revocable session ID. Try it first so a v3 value is
+	// never silently downgraded to a weaker lane.
+	//
+	// revoked is nil here: this branch has no revocation store yet, and nil means
+	// "nothing is revoked", which is the correct behaviour while nothing mints v3.
+	// Wiring a real store is part of the mint flip, not of shipping the verifier.
+	if u, ok := verifyHubUserCookieValueV3(s.sessionPublicKey(), value, time.Now(), nil); ok {
+		return u, true
+	}
 	if u, ok := verifyHubUserCookieValueV2(s.sessionPublicKey(), value); ok {
 		return u, true
 	}


### PR DESCRIPTION
## Why v2

The **production hub is built from `v2`** (image `1162522`, verified an ancestor of `origin/v2`), and the F10 v3 lane was **v4-only**. So the fix was code-complete and doing nothing where it matters — the same trap as N1/N2/N6 before #3272.

## What this adds

The v3 cookie format from #3505: `base64url(JSON{u,iat,exp,sid}) + ".v3." + Ed25519 sig`. The signature is verified **before any payload byte is parsed**, and verification enforces the signed expiry plus a revocation callback.

Wired into **`verifyHubUserDual`** — v2's real verification path, which v4 doesn't have — ahead of the v2 and legacy HMAC lanes, so a v3 value is never silently downgraded to a weaker one.

Both older lanes are untouched. They're the F1/F2 compatibility paths and removing them 401s the fleet (#3234); a regression test pins that both still verify.

`revoked` is `nil` for now: this branch has no revocation store, and `nil` means "nothing is revoked" — correct while nothing mints v3. Wiring a real store belongs to the mint flip.

## ⚠️ Verifier only — and the Node half is deliberately NOT ported

Nothing mints v3 here; production still mints v2. `TestF10_V2_MintingHasNotFlipped` is a tripwire so any future flip is deliberate and visible.

**v2's proxy verifies HMAC only.** `verifyHubUserCookie(SESSION_KEY, ...)`, with **zero** references to `SESSION_PUBLIC_KEY` — it has no Ed25519 lane at all, not even v2's. On this branch the hub emits *two* cookies (`hive_hub_user` HMAC and `hive_hub_user_v2` Ed25519) and the proxy only knows the first.

A v3 lane there would need a **third cookie name and its own rollout** — a much larger change that shouldn't ride along inside a verifier port.

**Consequence, stated plainly: the v2 fleet is not yet ready for a mint flip.** That needs the Node verifier too. This PR removes one of the two blockers, not both.

## Verification

- **Baseline on clean `origin/v2`**: `pkg/hub` → 0 failures. **After**: 0 failures.
- `go build`, `go vet`, `gofmt` clean.
- Removing the v3 lane from `verifyHubUserDual` fails the wiring test — `v3 cookie not accepted by verifyHubUserDual: "" false` — and restoring it passes.

Tests cover the lane working, an **expired** cookie rejected, a **revoked** sid rejected (with a control proving an unrelated session isn't collaterally revoked), a tampered payload rejected, and both older lanes still verifying.