### PR TITLE
🐛 ci: retry transient network failures in Dockerfile downloads

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       arm64) TMUX_SHA256="$TMUX_SHA256_ARM64" ;; \
       *) echo "unsupported arch for tmux: $ARCH" >&2; exit 1 ;; \
     esac \
- && curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" \
+ && curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" \
  && echo "${TMUX_SHA256}  /tmp/tmux.tar.gz" | sha256sum -c - \
  && tar xz -C /tmp -f /tmp/tmux.tar.gz \
  && cd /tmp/tmux-${TMUX_VERSION} && ./configure --prefix=/usr/local && make -j$(nproc) && make install \
@@ -63,7 +63,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
       arm64) SU_EXEC_SHA256="$SU_EXEC_SHA256_ARM64" ;; \
       *) echo "unsupported arch for su-exec: $ARCH" >&2; exit 1 ;; \
     esac \
- && curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/v${SU_EXEC_VERSION}/su-exec.c" \
+ && curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/v${SU_EXEC_VERSION}/su-exec.c" \
  && echo "${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \
  && rm /tmp/su-exec.c \
@@ -107,7 +107,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) TTYD_ARCH=aarch64; TTYD_SHA256="$TTYD_SHA256_ARM64" ;; \
       *) echo "unsupported arch for ttyd: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /usr/local/bin/ttyd \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /usr/local/bin/ttyd \
       "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${TTYD_ARCH}" && \
     echo "${TTYD_SHA256}  /usr/local/bin/ttyd" | sha256sum -c - && \
     chmod +x /usr/local/bin/ttyd
@@ -123,7 +123,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       *) echo "unsupported arch for gh: $ARCH" >&2; exit 1 ;; \
     esac && \
     mkdir -p /opt/hive/bin && \
-    curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" && \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" && \
     echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - && \
     tar xz --strip-components=2 -C /opt/hive/bin -f /tmp/gh.tar.gz "gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh" && \
     mv /opt/hive/bin/gh /opt/hive/bin/gh-real && \
@@ -190,7 +190,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) GOOSE_ARCH=aarch64; GOOSE_SHA256="$GOOSE_SHA256_ARM64" ;; \
       *) echo "unsupported arch for goose: $ARCH" >&2; exit 1 ;; \
     esac && \
-    if curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
+    if curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
       echo "${GOOSE_SHA256}  /tmp/goose.tar.gz" | sha256sum -c - && \
       tar xz -C /usr/local/bin -f /tmp/goose.tar.gz && \
       chmod +x /usr/local/bin/goose && \
@@ -236,7 +236,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) BOBSHELL_SHA256="$BOBSHELL_SHA256_ARM64" ;; \
       *) echo "unsupported arch for bobshell: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/bobshell.tgz "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz" && \
+    curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 300 --retry-connrefused --retry-all-errors -o /tmp/bobshell.tgz "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz" && \
     echo "${BOBSHELL_SHA256}  /tmp/bobshell.tgz" | sha256sum -c - && \
     npm install -g /tmp/bobshell.tgz && \
     npm cache clean --force && \

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       arm64) TMUX_SHA256="$TMUX_SHA256_ARM64" ;; \
       *) echo "unsupported arch for tmux: $ARCH" >&2; exit 1 ;; \
     esac \
- && curl -fsSL -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" \
+ && curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" \
  && echo "${TMUX_SHA256}  /tmp/tmux.tar.gz" | sha256sum -c - \
  && tar xz -C /tmp -f /tmp/tmux.tar.gz \
  && cd /tmp/tmux-${TMUX_VERSION} && ./configure --prefix=/usr/local && make -j$(nproc) && make install \
@@ -63,7 +63,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" \
       arm64) SU_EXEC_SHA256="$SU_EXEC_SHA256_ARM64" ;; \
       *) echo "unsupported arch for su-exec: $ARCH" >&2; exit 1 ;; \
     esac \
- && curl -fsSL -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/v${SU_EXEC_VERSION}/su-exec.c" \
+ && curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/su-exec.c "https://raw.githubusercontent.com/ncopa/su-exec/v${SU_EXEC_VERSION}/su-exec.c" \
  && echo "${SU_EXEC_SHA256}  /tmp/su-exec.c" | sha256sum -c - \
  && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \
  && rm /tmp/su-exec.c \
@@ -107,7 +107,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) TTYD_ARCH=aarch64; TTYD_SHA256="$TTYD_SHA256_ARM64" ;; \
       *) echo "unsupported arch for ttyd: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL -o /usr/local/bin/ttyd \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /usr/local/bin/ttyd \
       "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${TTYD_ARCH}" && \
     echo "${TTYD_SHA256}  /usr/local/bin/ttyd" | sha256sum -c - && \
     chmod +x /usr/local/bin/ttyd
@@ -123,7 +123,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       *) echo "unsupported arch for gh: $ARCH" >&2; exit 1 ;; \
     esac && \
     mkdir -p /opt/hive/bin && \
-    curl -fsSL -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" && \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" && \
     echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - && \
     tar xz --strip-components=2 -C /opt/hive/bin -f /tmp/gh.tar.gz "gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh" && \
     mv /opt/hive/bin/gh /opt/hive/bin/gh-real && \
@@ -190,7 +190,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) GOOSE_ARCH=aarch64; GOOSE_SHA256="$GOOSE_SHA256_ARM64" ;; \
       *) echo "unsupported arch for goose: $ARCH" >&2; exit 1 ;; \
     esac && \
-    if curl -fsSL "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
+    if curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/goose.tar.gz; then \
       echo "${GOOSE_SHA256}  /tmp/goose.tar.gz" | sha256sum -c - && \
       tar xz -C /usr/local/bin -f /tmp/goose.tar.gz && \
       chmod +x /usr/local/bin/goose && \
@@ -236,7 +236,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
       arm64) BOBSHELL_SHA256="$BOBSHELL_SHA256_ARM64" ;; \
       *) echo "unsupported arch for bobshell: $ARCH" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL -o /tmp/bobshell.tgz "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz" && \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors -o /tmp/bobshell.tgz "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz" && \
     echo "${BOBSHELL_SHA256}  /tmp/bobshell.tgz" | sha256sum -c - && \
     npm install -g /tmp/bobshell.tgz && \
     npm cache clean --force && \


### PR DESCRIPTION
## The problem

The image build makes **six unretried network fetches** — tmux, su-exec, ttyd, gh, goose, bobshell — and **none** used `--retry`. Every build is six coin flips against a transient 5xx.

Not theoretical: **four builds failed today across four different PRs**, all `curl: (22) ... error: 503`:

| PR | artifact | source |
|---|---|---|
| #3572 | ttyd | GitHub releases |
| #3574 (×2) | ttyd | GitHub releases |
| #3580 (×2) | ttyd | GitHub releases |
| earlier | bobshell | IBM object storage |

Each cost a full rerun cycle on work unrelated to the failing layer — and each one first had to be *diagnosed* as unrelated, since a red build on a security PR has to be taken seriously until proven otherwise.

## The fix

`--retry 5 --retry-delay 3 --retry-connrefused --retry-all-errors` on all six.

`--retry-all-errors` is the important flag: curl's default `--retry` only covers a subset of transient conditions, and a bare `503` on a GET isn't reliably among them.

## This does not weaken supply-chain integrity

All six downloads are still verified by `sha256sum -c` against a pinned digest — **6 sites, 6 verifications**, unchanged. Retrying changes *when* we fetch, never *what* we accept. A corrupted or substituted artifact still fails the build exactly as before.

## Verification

Against a stub server that returns 503 twice then 200:

```
without retry -> curl: (22) ... 503     exit=22   ← today's failure mode
with retry    -> http=200               exit=0    ← rides through both
```

Flags also confirmed valid against the real ttyd release URL (HTTP 200).

## Note

`v4`'s Dockerfile has the same six unretried fetches. Happy to port on request — keeping this to one branch so the change is easy to reason about, and v2 is where the production hub image is built.