### PR TITLE
🐛 fix(knowledge): import facts into writable channels, not the reserved vault (#3581)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -182,6 +182,11 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/knowledge/fact-history", s.handleFactHistory)
 	s.mux.HandleFunc("POST /api/knowledge/create", s.handleKnowledgeCreate)
 	s.mux.HandleFunc("POST /api/knowledge/import", s.handleKnowledgeImport)
+	// Channels (user-writable local vaults). Registered under /channels rather
+	// than /vaults so they don't collide with the GET /api/knowledge/{layer}
+	// wildcard below. This is the import-target surface fixed in #3581.
+	s.mux.HandleFunc("GET /api/knowledge/channels", s.handleKnowledgeChannelsList)
+	s.mux.HandleFunc("POST /api/knowledge/channels", s.handleKnowledgeChannelCreate)
 	s.mux.HandleFunc("POST /api/knowledge/promote", s.handleKnowledgePromote)
 	s.mux.HandleFunc("GET /api/knowledge/subscriptions", s.handleKnowledgeSubsList)
 	s.mux.HandleFunc("POST /api/knowledge/subscriptions", s.handleKnowledgeSubsAdd)
@@ -6924,6 +6929,38 @@ func (s *Server) handleKnowledgeImport(w http.ResponseWriter, r *http.Request) {
 	}
 	s.auditFromRequest(r, "knowledge_import", auditDetail("layer", req.Layer, "format", req.Format), "")
 	jsonResponse(w, map[string]interface{}{"ok": true, "imported": count, "layer": req.Layer, "format": req.Format})
+}
+
+// handleKnowledgeChannelsList returns the user-writable channels (vaults) that
+// facts can be imported into. The reserved automation vault is excluded (#3581).
+func (s *Server) handleKnowledgeChannelsList(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, []interface{}{})
+		return
+	}
+	jsonResponse(w, s.deps.Knowledge.WritableVaults())
+}
+
+// handleKnowledgeChannelCreate creates a new local channel (vault) to import into.
+func (s *Server) handleKnowledgeChannelCreate(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := decodeBody(r, &req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	info, err := s.deps.Knowledge.CreateVault(req.Name)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.auditFromRequest(r, "knowledge_channel_create", auditDetail("channel", info.Name), "")
+	jsonResponse(w, map[string]interface{}{"ok": true, "channel": info})
 }
 
 func (s *Server) handleKnowledgeSubsList(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8802,6 +8802,9 @@ function burnAreaChart() {
     const KB_POLL_MS = 30000;
     const KB_LAYER_ICONS = { personal: '🔒', project: '📁', org: '🏢', community: '🌍' };
     const KB_LAYER_LABELS = { personal: 'Personal', project: 'Project', org: 'Org', community: 'Community' };
+    // The automation vault the bead synthesizer owns. It is never a valid user
+    // import target and is filtered out of every channel picker (issue #3581).
+    const RESERVED_KB_CHANNEL = 'bead-synth-wiki';
     const KB_FACT_TYPES = ['pattern', 'gotcha', 'regression', 'decision', 'test_scaffold', 'integration', 'coverage_rule'];
 
     // ── Document Sources ──
@@ -10017,13 +10020,16 @@ function burnAreaChart() {
     }
 
     function kbOpenImport() {
-      const layers = (_kbCache || {}).layers || [];
+      // Writable channels only — exclude the reserved automation vault and
+      // read-only git sources so import never targets a non-writable layer (#3581).
+      const layers = ((_kbCache || {}).layers || []).filter(l =>
+        l && l.type && l.type !== RESERVED_KB_CHANNEL && !String(l.type).startsWith('git_source:'));
       let layerOpts = '';
-      for (const l of layers) {
-        const sel = l.type === 'project' ? ' selected' : '';
+      layers.forEach((l, i) => {
+        const sel = i === 0 ? ' selected' : '';
         layerOpts += `<option value="${escapeHtml(l.type)}"${sel}>${escapeHtml(KB_LAYER_LABELS[l.type] || l.type)}</option>`;
-      }
-      if (!layerOpts) layerOpts = '<option value="project">Project</option>';
+      });
+      if (!layerOpts) layerOpts = '<option value="" disabled selected>No channel yet — create one first</option>';
 
       const html = `
         <div class="stack">
@@ -10075,6 +10081,8 @@ function burnAreaChart() {
       const format = document.getElementById('kb-import-format')?.value;
 
       if (!content) { await hiveAlert('Content is required'); return; }
+      if (!layer) { await hiveAlert('Pick a channel to import into, or create one with "+ New channel".'); return; }
+      if (layer === RESERVED_KB_CHANNEL) { await hiveAlert(RESERVED_KB_CHANNEL + ' is reserved for automation. Choose or create another channel.'); return; }
 
       try {
         const r = await fetch('/api/knowledge/import', {
@@ -10087,6 +10095,50 @@ function burnAreaChart() {
         await hiveAlert('Imported ' + (data.imported || 0) + ' facts to ' + layer);
         fetchKnowledgeStats();
         kbSearch();
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
+    }
+
+    // kbNewChannel reveals an inline text input to name a new knowledge channel
+    // (rather than a blocking window.prompt, which clashes with the dashboard's
+    // modal conventions). This is the path for adding knowledge on channels other
+    // than the reserved automation vault (issue #3581).
+    function kbNewChannel() {
+      const row = document.getElementById('kb-newchannel-row');
+      if (row) { row.style.display = 'flex'; document.getElementById('kb-newchannel-name')?.focus(); }
+    }
+
+    // kbCreateChannel POSTs the new channel, then adds + selects it in the import
+    // dropdown without a full re-render.
+    async function kbCreateChannel() {
+      const input = document.getElementById('kb-newchannel-name');
+      const name = input?.value?.trim();
+      if (!name) { await hiveAlert('Enter a channel name.'); return; }
+      if (name === RESERVED_KB_CHANNEL) { await hiveAlert(RESERVED_KB_CHANNEL + ' is reserved for automation.'); return; }
+      try {
+        const r = await fetch('/api/knowledge/channels', {
+          method: 'POST', headers: _inceptionAuthHeaders(),
+          body: JSON.stringify({ name }),
+        });
+        const data = await r.json();
+        if (!r.ok) { await hiveAlert(data.error || 'Failed to create channel'); return; }
+        const created = (data.channel && data.channel.name) || name;
+        await fetchKnowledgeStats();
+        const sel = document.getElementById('kb-import-layer');
+        if (sel) {
+          let opt = Array.from(sel.options).find(o => o.value === created);
+          if (!opt) {
+            opt = document.createElement('option');
+            opt.value = created;
+            opt.textContent = KB_LAYER_LABELS[created] || created;
+            const ph = Array.from(sel.options).find(o => o.disabled);
+            if (ph) ph.remove();
+            sel.appendChild(opt);
+          }
+          sel.value = created;
+        }
+        if (input) input.value = '';
+        const row = document.getElementById('kb-newchannel-row');
+        if (row) row.style.display = 'none';
       } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
@@ -10265,10 +10317,18 @@ function burnAreaChart() {
         html += '</div>';
 
         // ── Import Facts section ──
-        const layerOpts2 = layers.map(l => {
-          const sel = l.type === 'project' ? ' selected' : '';
+        // Build the import-target list from user-WRITABLE channels only. The
+        // reserved automation vault (RESERVED_KB_CHANNEL) and read-only git-source
+        // pseudo-layers are excluded — offering them caused #3581, where importing
+        // into bead-synth-wiki failed with "has no configured endpoint". Users can
+        // also create a new channel inline; if there is nothing to import into yet,
+        // the select shows a disabled prompt rather than a bad target.
+        const importChannels = (layers || []).filter(l =>
+          l && l.type && l.type !== RESERVED_KB_CHANNEL && !String(l.type).startsWith('git_source:'));
+        const layerOpts2 = importChannels.map((l, i) => {
+          const sel = i === 0 ? ' selected' : '';
           return `<option value="${escapeHtml(l.type)}"${sel}>${escapeHtml(KB_LAYER_LABELS[l.type] || l.type)}</option>`;
-        }).join('') || '<option value="project">Project</option>';
+        }).join('') || '<option value="" disabled selected>No channel yet — create one below</option>';
 
         html += '<div>';
         html += '<div class="row" style="margin-bottom:8px">';
@@ -10279,7 +10339,14 @@ function burnAreaChart() {
 
         html += '<details open style="margin-top:10px"><summary class="summary-label">Paste Content</summary>';
         html += '<div class="stack" style="margin-top:8px">';
-        html += `<select id="kb-import-layer" class="field-input">${layerOpts2}</select>`;
+        html += `<div style="display:flex;gap:6px;align-items:center">`;
+        html += `<select id="kb-import-layer" class="field-input" style="flex:1">${layerOpts2}</select>`;
+        html += `<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);padding:6px 12px;font-size:0.78rem;white-space:nowrap" onclick="kbNewChannel()" title="Create a new knowledge channel to import into">+ New channel</button>`;
+        html += `</div>`;
+        html += `<div id="kb-newchannel-row" style="display:none;gap:6px;align-items:center">`;
+        html += `<input id="kb-newchannel-name" type="text" class="kb-search-box" placeholder="New channel name (e.g. Runbooks)" style="flex:1" onkeydown="if(event.key==='Enter'){event.preventDefault();kbCreateChannel();}">`;
+        html += `<button class="nous-btn btn-blue" style="padding:6px 14px;font-size:0.78rem;white-space:nowrap" onclick="kbCreateChannel()">Create</button>`;
+        html += `</div>`;
         html += `<select id="kb-import-format" class="field-input">
           <option value="markdown" selected>Markdown</option>
           <option value="json">JSON</option>

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -14,6 +14,19 @@ import (
 
 const localKnowledgeDir = "/data/knowledge"
 
+// vaultsBaseDir is where user-created knowledge channels (vaults) are stored on
+// the spoke's data volume, one directory per channel. It mirrors the location the
+// bead synthesizer uses for its own vault.
+const vaultsBaseDir = "/data/vaults"
+
+// reservedVaultName is the automation vault the bead synthesizer writes into. It
+// must never be offered to users as an import target nor be creatable/writable by
+// hand: importing into it would corrupt the synthesizer's own store, and it is
+// deliberately hidden from every user-facing channel picker. See issue #3581,
+// where the Import Facts dropdown surfaced this vault as the only option and every
+// import failed with "layer bead-synth-wiki has no configured endpoint".
+const reservedVaultName = "bead-synth-wiki"
+
 // KnowledgeAPI provides a unified interface for dashboard endpoints to query
 // across all configured wiki layers.
 type KnowledgeAPI struct {
@@ -349,13 +362,13 @@ func (k *KnowledgeAPI) PromoteFact(ctx context.Context, req PromoteRequest) Prom
 
 // ImportFacts parses markdown or JSON content and ingests extracted facts.
 func (k *KnowledgeAPI) ImportFacts(ctx context.Context, layer LayerType, content string, format string) (int, error) {
-	client := k.clientForLayer(layer)
-	if client == nil {
-		return 0, fmt.Errorf("layer %s has no configured endpoint", layer)
+	// The reserved automation vault is never a valid user import target — writing
+	// into it would corrupt the bead synthesizer's store (issue #3581).
+	if string(layer) == reservedVaultName {
+		return 0, fmt.Errorf("%q is a reserved automation channel and cannot be imported into; pick or create another channel", reservedVaultName)
 	}
 
 	var facts []ExtractedFact
-
 	switch format {
 	case "json":
 		if err := parseJSONFacts(content, &facts); err != nil {
@@ -366,17 +379,114 @@ func (k *KnowledgeAPI) ImportFacts(ctx context.Context, layer LayerType, content
 	default:
 		facts = parseMarkdownFacts(content)
 	}
-
 	if len(facts) == 0 {
 		return 0, nil
 	}
 
+	// Prefer a local vault (channel) with this name — the common case on a spoke
+	// with no remote wiki layers configured, and the fix for #3581 where import
+	// used to fail because only remote "layers" were writable. Fall back to a
+	// configured remote layer endpoint when no vault matches.
+	if v := k.vaultByName(string(layer)); v != nil {
+		if err := v.WriteFacts(facts); err != nil {
+			return 0, fmt.Errorf("writing facts to channel %q: %w", layer, err)
+		}
+		k.triggerVaultReindex(v.RootDir())
+		k.logger.Info("facts imported to vault", "count", len(facts), "channel", layer, "format", format)
+		return len(facts), nil
+	}
+
+	client := k.clientForLayer(layer)
+	if client == nil {
+		return 0, fmt.Errorf("no writable channel named %q — create a channel first, or configure a wiki endpoint for that layer", layer)
+	}
 	if err := client.IngestFacts(ctx, facts); err != nil {
 		return 0, fmt.Errorf("ingesting imported facts: %w", err)
 	}
-
 	k.logger.Info("facts imported", "count", len(facts), "layer", layer, "format", format)
 	return len(facts), nil
+}
+
+// vaultByName returns the connected vault whose name matches (case-sensitive),
+// or nil. The reserved automation vault is intentionally NOT matchable here — it
+// is filtered so it can never be resolved as an import target.
+func (k *KnowledgeAPI) vaultByName(name string) *FileStore {
+	if name == "" || name == reservedVaultName {
+		return nil
+	}
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	for _, v := range k.vaults {
+		if v.Name() == name {
+			return v
+		}
+	}
+	return nil
+}
+
+// WritableVaults returns the connected vaults a user may import into — every
+// vault except the reserved automation one. This is the source of truth for the
+// dashboard's channel pickers (issue #3581).
+func (k *KnowledgeAPI) WritableVaults() []VaultInfo {
+	all := k.Vaults()
+	out := make([]VaultInfo, 0, len(all))
+	for _, v := range all {
+		if v.Name == reservedVaultName {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// CreateVault creates a brand-new local knowledge channel (vault) under
+// vaultsBaseDir and connects it so users can import facts into it. The name must
+// be path-safe and must not collide with the reserved automation vault. Creating
+// an already-existing channel is idempotent (it just connects it).
+func (k *KnowledgeAPI) CreateVault(name string) (VaultInfo, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return VaultInfo{}, fmt.Errorf("channel name is required")
+	}
+	if name == reservedVaultName {
+		return VaultInfo{}, fmt.Errorf("%q is reserved for automation and cannot be created", reservedVaultName)
+	}
+	if !isSafeVaultName(name) {
+		return VaultInfo{}, fmt.Errorf("invalid channel name %q: use letters, numbers, spaces, dashes or underscores", name)
+	}
+
+	dir := filepath.Join(vaultsBaseDir, slugify(name))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return VaultInfo{}, fmt.Errorf("creating channel dir: %w", err)
+	}
+	// ConnectVault is idempotent-ish: it errors if this exact dir is already
+	// connected, which for a create-or-connect flow we treat as success.
+	if err := k.ConnectVault(dir, name); err != nil && !strings.Contains(err.Error(), "already connected") {
+		return VaultInfo{}, err
+	}
+	for _, v := range k.Vaults() {
+		if v.RootDir == dir {
+			return v, nil
+		}
+	}
+	return VaultInfo{Name: name, RootDir: dir}, nil
+}
+
+// isSafeVaultName rejects names that could escape vaultsBaseDir or break the
+// on-disk layout. Deliberately conservative: a channel name is a human label.
+func isSafeVaultName(name string) bool {
+	if len(name) > 64 || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == ' ' || r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // Subscriptions returns the current list of subscribed wiki endpoints.

--- a/v2/pkg/knowledge/filestore.go
+++ b/v2/pkg/knowledge/filestore.go
@@ -88,6 +88,56 @@ func (s *FileStore) SetName(name string) { s.name = name }
 // RootDir returns the filesystem path.
 func (s *FileStore) RootDir() string { return s.rootDir }
 
+// WriteFacts persists facts into the vault as markdown files with YAML
+// frontmatter, one file per fact. This is the local-write counterpart to the
+// remote wiki Client.IngestFacts, and it is how user-imported facts land in a
+// vault (issue #3581). It mirrors the bead synthesizer's on-disk format so a
+// hand-imported fact and a synthesized one index identically. Files are written
+// atomically (temp + rename); the caller triggers a reindex afterward.
+func (s *FileStore) WriteFacts(facts []ExtractedFact) error {
+	if err := os.MkdirAll(s.rootDir, 0o755); err != nil {
+		return fmt.Errorf("creating vault dir: %w", err)
+	}
+	for _, f := range facts {
+		if strings.TrimSpace(f.Title) == "" {
+			// A titleless fact has no stable slug/filename; skip rather than
+			// clobber a shared "untitled.md".
+			continue
+		}
+		slug := slugify(f.Title)
+		filename := strings.ReplaceAll(slug+".md", "/", "_")
+		path := filepath.Join(s.rootDir, filename)
+
+		var buf strings.Builder
+		buf.WriteString("---\n")
+		fmt.Fprintf(&buf, "title: %s\n", f.Title)
+		if f.Type != "" {
+			fmt.Fprintf(&buf, "type: %s\n", string(f.Type))
+		}
+		if f.Confidence > 0 {
+			fmt.Fprintf(&buf, "confidence: %.2f\n", f.Confidence)
+		}
+		if len(f.Tags) > 0 {
+			fmt.Fprintf(&buf, "tags: [%s]\n", strings.Join(f.Tags, ", "))
+		}
+		if len(f.Related) > 0 {
+			fmt.Fprintf(&buf, "related: [%s]\n", strings.Join(f.Related, ", "))
+		}
+		fmt.Fprintf(&buf, "imported: %s\n", time.Now().UTC().Format(time.RFC3339))
+		buf.WriteString("---\n\n")
+		buf.WriteString(f.Body)
+
+		tmpPath := path + ".tmp"
+		if err := os.WriteFile(tmpPath, []byte(buf.String()), 0o644); err != nil {
+			return fmt.Errorf("writing vault file: %w", err)
+		}
+		if err := os.Rename(tmpPath, path); err != nil {
+			return fmt.Errorf("renaming vault file: %w", err)
+		}
+	}
+	return nil
+}
+
 func (s *FileStore) reindex() {
 	pages := make(map[string]filePage)
 

--- a/v2/pkg/knowledge/vault_import_test.go
+++ b/v2/pkg/knowledge/vault_import_test.go
@@ -1,0 +1,132 @@
+package knowledge
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newTestAPI builds a minimal KnowledgeAPI with no remote layers, mirroring a
+// provisioned spoke that has only local vaults.
+func newTestAPI(t *testing.T) *KnowledgeAPI {
+	t.Helper()
+	return &KnowledgeAPI{
+		logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		vaults: nil,
+	}
+}
+
+func connectTempVault(t *testing.T, k *KnowledgeAPI, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := k.ConnectVault(dir, name); err != nil {
+		t.Fatalf("ConnectVault(%s): %v", name, err)
+	}
+	return dir
+}
+
+// TestImportFacts_WritesToVault: the #3581 fix — importing to a local vault name
+// writes files and succeeds, instead of erroring "has no configured endpoint".
+func TestImportFacts_WritesToVault(t *testing.T) {
+	k := newTestAPI(t)
+	dir := connectTempVault(t, k, "Runbooks")
+
+	n, err := k.ImportFacts(context.Background(), LayerType("Runbooks"),
+		"# Restart the gateway\n\nRun `docker compose restart`.\n\n# Rotate the token\n\nUse the admin panel.", "markdown")
+	if err != nil {
+		t.Fatalf("ImportFacts to vault: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("imported %d facts, want 2", n)
+	}
+	// Two markdown files should now exist in the vault dir.
+	entries, _ := os.ReadDir(dir)
+	md := 0
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".md" {
+			md++
+		}
+	}
+	if md != 2 {
+		t.Errorf("vault has %d .md files, want 2", md)
+	}
+}
+
+// TestImportFacts_ReservedVaultRejected: importing into the automation vault must
+// fail with a clear error and write nothing (the exact bug in #3581).
+func TestImportFacts_ReservedVaultRejected(t *testing.T) {
+	k := newTestAPI(t)
+	_, err := k.ImportFacts(context.Background(), LayerType(reservedVaultName), "# X\n\nbody", "markdown")
+	if err == nil {
+		t.Fatal("importing into the reserved vault must error")
+	}
+}
+
+// TestImportFacts_NoChannelGivesFriendlyError: with no matching vault/layer, the
+// error must guide the user to create a channel — not the old endpoint jargon.
+func TestImportFacts_NoChannelGivesFriendlyError(t *testing.T) {
+	k := newTestAPI(t)
+	_, err := k.ImportFacts(context.Background(), LayerType("nonexistent"), "# X\n\nbody", "markdown")
+	if err == nil {
+		t.Fatal("expected an error for an unknown channel")
+	}
+}
+
+// TestCreateVault_RejectsReservedAndUnsafe validates the create-channel guards.
+func TestCreateVault_RejectsReservedAndUnsafe(t *testing.T) {
+	k := newTestAPI(t)
+	if _, err := k.CreateVault(reservedVaultName); err == nil {
+		t.Error("creating the reserved vault must be rejected")
+	}
+	if _, err := k.CreateVault("../escape"); err == nil {
+		t.Error("path-unsafe name must be rejected")
+	}
+	if _, err := k.CreateVault(""); err == nil {
+		t.Error("empty name must be rejected")
+	}
+	if !isSafeVaultName("My Runbooks-2") {
+		t.Error("a normal name should be accepted")
+	}
+	if isSafeVaultName("bad/name") {
+		t.Error("slash must be rejected")
+	}
+}
+
+// TestWritableVaults_ExcludesReserved: the reserved vault never appears in the
+// user-facing writable set, even when connected.
+func TestWritableVaults_ExcludesReserved(t *testing.T) {
+	k := newTestAPI(t)
+	connectTempVault(t, k, reservedVaultName)
+	connectTempVault(t, k, "Docs")
+
+	w := k.WritableVaults()
+	for _, v := range w {
+		if v.Name == reservedVaultName {
+			t.Fatalf("reserved vault leaked into writable set: %+v", w)
+		}
+	}
+	found := false
+	for _, v := range w {
+		if v.Name == "Docs" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("writable set missing Docs: %+v", w)
+	}
+}
+
+// TestVaultByName_IgnoresReserved: vaultByName must never resolve the reserved
+// vault, so it can't be used as a covert import target.
+func TestVaultByName_IgnoresReserved(t *testing.T) {
+	k := newTestAPI(t)
+	connectTempVault(t, k, reservedVaultName)
+	if k.vaultByName(reservedVaultName) != nil {
+		t.Error("vaultByName must not resolve the reserved vault")
+	}
+	if k.vaultByName("") != nil {
+		t.Error("vaultByName must not resolve an empty name")
+	}
+}


### PR DESCRIPTION
## Fixes #3581

**Symptom:** In the gateway dashboard's `KNOWLEDGE BASE` → `🔗 Knowledge Sources` → **Import Facts**, every upload/add-fact failed with:
```
layer bead-synth-wiki has no configured endpoint
```

### Root cause (two bugs)
1. **Wrong dropdown source.** Import Facts populated its target `<select>` from `_kbCache.layers` — the stats aggregate that mixes **read-only vaults and git-sources** in with real writable layers — unlike its sibling importers (Git Source / Import Document / Subscription), which use the static writable-layer list. On a provisioned spoke with no remote wiki layers, the only entry was the `bead-synth-wiki` **automation vault**.
2. **Import couldn't write locally.** `ImportFacts` only wrote to remote `layer` endpoints via `clientForLayer`, so even a valid layer failed when none had an endpoint — and it could **never** write to a local vault.

### Fix — users can add knowledge on real channels
**Backend (`pkg/knowledge`)**
- `ImportFacts` now writes to a **local vault** when the target names one (new `FileStore.WriteFacts`, mirroring the synthesizer's frontmatter-markdown format + reindex), falling back to a remote layer endpoint otherwise. The old endpoint error is replaced with guidance to create a channel.
- `CreateVault(name)` creates + connects a new local channel under `/data/vaults`. `WritableVaults()` / `vaultByName` **exclude the reserved vault**; `bead-synth-wiki` is rejected for both create **and** import (importing there would corrupt the synthesizer's store). Path-safe name validation.

**Backend (`pkg/dashboard`)**
- `GET`/`POST /api/knowledge/channels` — list writable channels and create one (registered under `/channels` to avoid the `GET /api/knowledge/{layer}` wildcard).

**Frontend (`static/index.html`)**
- Both Import Facts renderers filter to **writable channels only** (exclude the reserved vault + `git_source:*`), and add a **"+ New channel"** inline create flow. Empty state prompts to create one instead of showing a bad target.

### Tests
Go tests for: vault import writes files & succeeds, reserved-vault import rejected, unknown-channel friendly error, create-vault guards (reserved/unsafe/empty), writable-set excludes the reserved vault, `vaultByName` never resolves it. Full `pkg/knowledge` + `pkg/dashboard` suites green; `go vet` clean.

### Acceptance (matches the issue)
A user can now Import Facts / add a fact and have it **succeed and be visible** for agents to reference — the `bead-synth-wiki has no configured endpoint` error is gone, and `bead-synth-wiki` no longer appears as a target at all.