### PR TITLE
✨ feat(hub): 30-day image-pulls sparkline on the My Hives dashboard

### DIFF
--- a/v2/pkg/hub/image_pulls.go
+++ b/v2/pkg/hub/image_pulls.go
@@ -1,0 +1,322 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// image_pulls.go tracks external adoption of the hive spoke image by charting
+// how many container-image PULLS (downloads) the public GHCR package receives
+// per day.
+//
+// WHY THIS IS A DAILY-DELTA, NOT A UNIQUE-DOWNLOAD COUNT
+// -----------------------------------------------------
+// GitHub exposes exactly ONE adoption number for a container package: a single
+// CUMULATIVE "Total downloads" counter, rendered on the public package page
+//
+//	https://github.com/kubestellar/hive/pkgs/container/hive
+//
+// as `<h3 title="127576">128K</h3>` under a "Total downloads" label. There is
+// NO public per-day metric and NO unique-IP / unique-puller metric anywhere in
+// the REST, GraphQL, or web surface — the REST Packages API's PackageVersion
+// object (google/go-github v72) carries no download field at all.
+//
+// So we cannot measure "how many distinct people pulled today". What we CAN do
+// is snapshot the cumulative counter once per day and plot the day-over-day
+// DELTA (cumulative[today] - cumulative[yesterday]) = pulls that landed that
+// day. That is what the sparkline shows, and it is labelled honestly as
+// "pulls/day" — never "unique downloads".
+//
+// The counter is scraped from the PUBLIC package HTML page, which needs no
+// authentication (the package is public). We deliberately do not depend on the
+// GitHub App installation token here: the REST Packages API cannot serve this
+// number even with the token, and the public page can, so scraping the public
+// page is both the only option and the more robust one (works even if the app
+// key is missing and the hive is in dashboard-only mode).
+
+const (
+	// pullSnapshotIntervalHours is the minimum age of the newest snapshot before
+	// a new one is taken. The SHA poller ticks every latestSHAPollInterval (2m),
+	// far more often than we want to record a data point, so the snapshot step is
+	// guarded to run at most once per this many hours.
+	pullSnapshotIntervalHours = 24
+
+	// pullHistoryWindowDays is how many daily snapshots the rolling series
+	// retains. Older entries are pruned on every write so the file stays bounded.
+	pullHistoryWindowDays = 30
+
+	// pullPageTimeout bounds the single HTTP GET of the public package page.
+	pullPageTimeout = 10 * time.Second
+)
+
+// pullPackagePageURL is the PUBLIC GHCR package page carrying the cumulative
+// "Total downloads" counter for the spoke image (ghcrRepoSpoke). A var so tests
+// can point it at a local test server.
+var pullPackagePageURL = "https://github.com/" + ghcrRepoSpoke + "/pkgs/container/hive"
+
+// imagePullsPath is the PVC-backed JSON file holding the rolling snapshot
+// series, alongside the other /data/saas state files (latest-shas.json, etc.).
+var imagePullsPath = "/data/saas/image-pulls.json"
+
+// totalDownloadsRe extracts the exact cumulative count from the package page.
+// The page renders `<h3 title="127576">128K</h3>` immediately after the
+// "Total downloads" label; the title attribute carries the exact integer while
+// the visible text is abbreviated ("128K"), so we read the title. The label and
+// the <h3> are separated only by whitespace/markup, matched non-greedily.
+var totalDownloadsRe = regexp.MustCompile(`(?s)Total downloads.*?<h3[^>]*\btitle="(\d+)"`)
+
+// pullSnapshot is one daily data point: the cumulative total-downloads counter
+// as read on Date. Deltas between consecutive snapshots give pulls/day.
+type pullSnapshot struct {
+	Date       string `json:"date"`       // YYYY-MM-DD (UTC) the snapshot was taken
+	Cumulative int64  `json:"cumulative"` // cumulative total downloads at that time
+}
+
+var (
+	imagePullsMu    sync.Mutex
+	imagePullSeries []pullSnapshot
+	// imagePullsLoaded gates the one-time restore of the series from disk so the
+	// SHA poller can call maybeSnapshotImagePulls every tick without re-reading
+	// the file each time.
+	imagePullsLoaded bool
+)
+
+// loadPersistedImagePulls restores the rolling series from the PVC so a freshly
+// restarted hub keeps its history (the hub restarts on every auto-upgrade). Safe
+// to call repeatedly; it only reads disk the first time.
+func loadPersistedImagePulls(logger *slog.Logger) {
+	imagePullsMu.Lock()
+	defer imagePullsMu.Unlock()
+	if imagePullsLoaded {
+		return
+	}
+	imagePullsLoaded = true
+	data, err := os.ReadFile(imagePullsPath)
+	if err != nil {
+		return // first run or no PVC — start empty
+	}
+	var persisted []pullSnapshot
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		logger.Warn("image pulls: persisted series unreadable, ignoring", "path", imagePullsPath, "error", err)
+		return
+	}
+	imagePullSeries = pruneOldSnapshots(persisted)
+}
+
+// persistImagePullsLocked writes the current series to disk (atomic tmp+rename,
+// same pattern as persistLatestSHAs). Caller must hold imagePullsMu.
+func persistImagePullsLocked(logger *slog.Logger) {
+	if len(imagePullSeries) == 0 {
+		return // never overwrite a good file with an empty series
+	}
+	data, err := json.MarshalIndent(imagePullSeries, "", "  ")
+	if err != nil {
+		logger.Warn("image pulls: persist marshal failed", "error", err)
+		return
+	}
+	os.MkdirAll(filepath.Dir(imagePullsPath), 0o755)
+	tmpPath := imagePullsPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		logger.Warn("image pulls: persist write failed", "path", imagePullsPath, "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, imagePullsPath); err != nil {
+		logger.Warn("image pulls: persist rename failed", "path", imagePullsPath, "error", err)
+	}
+}
+
+// pruneOldSnapshots returns the newest pullHistoryWindowDays entries, sorted by
+// date ascending. It also collapses duplicate dates (keeping the last write for
+// a given day) so a same-day re-snapshot never double-counts.
+func pruneOldSnapshots(in []pullSnapshot) []pullSnapshot {
+	if len(in) == 0 {
+		return nil
+	}
+	// Collapse by date, last-write-wins.
+	byDate := make(map[string]pullSnapshot, len(in))
+	order := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, seen := byDate[s.Date]; !seen {
+			order = append(order, s.Date)
+		}
+		byDate[s.Date] = s
+	}
+	sortStrings(order)
+	out := make([]pullSnapshot, 0, len(order))
+	for _, d := range order {
+		out = append(out, byDate[d])
+	}
+	if len(out) > pullHistoryWindowDays {
+		out = out[len(out)-pullHistoryWindowDays:]
+	}
+	return out
+}
+
+// sortStrings sorts a slice of date strings ascending. YYYY-MM-DD sorts
+// lexicographically the same as chronologically, so a plain string sort works.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// fetchCumulativePulls reads the exact cumulative "Total downloads" count from
+// the public package page. A var so tests can stub the network round-trip.
+var fetchCumulativePulls = func(ctx context.Context, logger *slog.Logger) (int64, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pullPackagePageURL, nil)
+	if err != nil {
+		logger.Warn("image pulls: build request failed", "error", err)
+		return 0, false
+	}
+	// A UA is polite and avoids some bot-shaping; the page is public either way.
+	req.Header.Set("User-Agent", "kubestellar-hive-hub")
+	req.Header.Set("Accept", "text/html")
+	client := &http.Client{Timeout: pullPageTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Warn("image pulls: fetch package page failed", "url", pullPackagePageURL, "error", err)
+		return 0, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		logger.Warn("image pulls: package page non-200", "url", pullPackagePageURL, "status", resp.StatusCode)
+		return 0, false
+	}
+	// The counter lives high in the page; cap the read so a huge/hostile body
+	// can't blow up memory. 512 KiB comfortably covers the package page head.
+	const maxPackagePageBytes = 512 * 1024
+	body := make([]byte, 0, maxPackagePageBytes)
+	buf := make([]byte, 32*1024)
+	for len(body) < maxPackagePageBytes {
+		n, rerr := resp.Body.Read(buf)
+		if n > 0 {
+			body = append(body, buf[:n]...)
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	m := totalDownloadsRe.FindSubmatch(body)
+	if m == nil {
+		logger.Warn("image pulls: 'Total downloads' counter not found on package page (page layout may have changed)")
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(m[1])), 10, 64)
+	if err != nil {
+		logger.Warn("image pulls: could not parse counter", "raw", string(m[1]), "error", err)
+		return 0, false
+	}
+	return n, true
+}
+
+// maybeSnapshotImagePulls records a new daily snapshot if the newest one is
+// older than pullSnapshotIntervalHours. Called from the SHA poller each tick;
+// the interval guard makes it a no-op most ticks. It restores from disk on first
+// call. now is injected so tests control the clock.
+func (s *HubServer) maybeSnapshotImagePulls(ctx context.Context, now time.Time) {
+	loadPersistedImagePulls(s.logger)
+
+	today := now.UTC().Format("2006-01-02")
+
+	imagePullsMu.Lock()
+	due := true
+	if n := len(imagePullSeries); n > 0 {
+		last := imagePullSeries[n-1]
+		// Already have today's point → nothing to do.
+		if last.Date == today {
+			due = false
+		}
+	}
+	imagePullsMu.Unlock()
+	if !due {
+		return
+	}
+
+	cumulative, ok := fetchCumulativePulls(ctx, s.logger)
+	if !ok {
+		return // transient fetch failure — try again next tick
+	}
+
+	imagePullsMu.Lock()
+	defer imagePullsMu.Unlock()
+	// Re-check under lock in case a concurrent tick already wrote today's point.
+	if n := len(imagePullSeries); n > 0 && imagePullSeries[n-1].Date == today {
+		return
+	}
+	imagePullSeries = pruneOldSnapshots(append(imagePullSeries, pullSnapshot{
+		Date:       today,
+		Cumulative: cumulative,
+	}))
+	persistImagePullsLocked(s.logger)
+	s.logger.Info("image pulls: recorded daily snapshot", "date", today, "cumulative", cumulative)
+}
+
+// imagePullPoint is one day of the DELTA series returned to the frontend.
+type imagePullPoint struct {
+	Date  string `json:"date"`  // YYYY-MM-DD
+	Pulls int64  `json:"pulls"` // pulls that landed that day (cumulative delta)
+}
+
+// imagePullsResponse is the /api/hub/image-pulls payload.
+type imagePullsResponse struct {
+	// Points is the day-over-day delta series. It has one fewer entry than the
+	// snapshot series (a delta needs two cumulative readings), so with only one
+	// snapshot so far it is empty and the frontend shows "collecting…".
+	Points []imagePullPoint `json:"points"`
+	// Total30d is the sum of the deltas in the window (pulls over the period).
+	Total30d int64 `json:"total_30d"`
+	// Latest is the most recent day's pulls, or 0 when not enough data yet.
+	Latest int64 `json:"latest"`
+	// Collecting is true until there are at least two snapshots — i.e. until a
+	// delta can be computed. The frontend renders "collecting…" instead of a
+	// broken one-point chart.
+	Collecting bool `json:"collecting"`
+}
+
+// buildImagePullsResponse converts the cumulative snapshot series into daily
+// deltas. Split out from the handler so it is unit-testable without HTTP.
+func buildImagePullsResponse(series []pullSnapshot) imagePullsResponse {
+	resp := imagePullsResponse{Points: []imagePullPoint{}}
+	if len(series) < 2 {
+		resp.Collecting = true
+		return resp
+	}
+	for i := 1; i < len(series); i++ {
+		delta := series[i].Cumulative - series[i-1].Cumulative
+		// A negative delta means the counter reset or a snapshot was bad; clamp
+		// to zero so one glitch can't paint a downward spike or skew the total.
+		if delta < 0 {
+			delta = 0
+		}
+		resp.Points = append(resp.Points, imagePullPoint{Date: series[i].Date, Pulls: delta})
+		resp.Total30d += delta
+	}
+	if n := len(resp.Points); n > 0 {
+		resp.Latest = resp.Points[n-1].Pulls
+	}
+	return resp
+}
+
+// handleImagePulls serves the daily-delta series for the sparkline.
+func (s *HubServer) handleImagePulls(w http.ResponseWriter, r *http.Request) {
+	loadPersistedImagePulls(s.logger)
+	imagePullsMu.Lock()
+	seriesCopy := make([]pullSnapshot, len(imagePullSeries))
+	copy(seriesCopy, imagePullSeries)
+	imagePullsMu.Unlock()
+
+	resp := buildImagePullsResponse(seriesCopy)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/v2/pkg/hub/image_pulls_test.go
+++ b/v2/pkg/hub/image_pulls_test.go
@@ -1,0 +1,212 @@
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// resetImagePullsState clears the package-level series between tests so cases
+// don't bleed into one another (mirrors how the SHA-cache tests reset state).
+func resetImagePullsState() {
+	imagePullsMu.Lock()
+	imagePullSeries = nil
+	imagePullsLoaded = false
+	imagePullsMu.Unlock()
+}
+
+func TestBuildImagePullsResponse_Deltas(t *testing.T) {
+	series := []pullSnapshot{
+		{Date: "2026-08-01", Cumulative: 1000},
+		{Date: "2026-08-02", Cumulative: 1050}, // +50
+		{Date: "2026-08-03", Cumulative: 1075}, // +25
+		{Date: "2026-08-04", Cumulative: 1200}, // +125
+	}
+	got := buildImagePullsResponse(series)
+	if got.Collecting {
+		t.Fatalf("did not expect Collecting with %d snapshots", len(series))
+	}
+	if len(got.Points) != 3 {
+		t.Fatalf("want 3 delta points, got %d", len(got.Points))
+	}
+	wantPulls := []int64{50, 25, 125}
+	for i, p := range got.Points {
+		if p.Pulls != wantPulls[i] {
+			t.Errorf("point %d: want %d pulls, got %d", i, wantPulls[i], p.Pulls)
+		}
+	}
+	if got.Total30d != 200 {
+		t.Errorf("want Total30d=200, got %d", got.Total30d)
+	}
+	if got.Latest != 125 {
+		t.Errorf("want Latest=125, got %d", got.Latest)
+	}
+}
+
+func TestBuildImagePullsResponse_ColdStart(t *testing.T) {
+	// Zero snapshots.
+	if r := buildImagePullsResponse(nil); !r.Collecting || len(r.Points) != 0 {
+		t.Errorf("empty series: want collecting/no points, got %+v", r)
+	}
+	// One snapshot — still no delta possible.
+	one := []pullSnapshot{{Date: "2026-08-01", Cumulative: 42}}
+	if r := buildImagePullsResponse(one); !r.Collecting || len(r.Points) != 0 {
+		t.Errorf("single snapshot: want collecting/no points, got %+v", r)
+	}
+}
+
+func TestBuildImagePullsResponse_NegativeDeltaClamped(t *testing.T) {
+	// Counter appears to go backwards (reset / bad read): delta must clamp to 0,
+	// never a negative spike, and must not drag the total below the good days.
+	series := []pullSnapshot{
+		{Date: "2026-08-01", Cumulative: 5000},
+		{Date: "2026-08-02", Cumulative: 100}, // reset → clamped to 0
+		{Date: "2026-08-03", Cumulative: 130}, // +30
+	}
+	got := buildImagePullsResponse(series)
+	if got.Points[0].Pulls != 0 {
+		t.Errorf("want clamped 0 for reset day, got %d", got.Points[0].Pulls)
+	}
+	if got.Points[1].Pulls != 30 {
+		t.Errorf("want 30 for recovery day, got %d", got.Points[1].Pulls)
+	}
+	if got.Total30d != 30 {
+		t.Errorf("want Total30d=30 (clamped), got %d", got.Total30d)
+	}
+}
+
+func TestPruneOldSnapshots_WindowAndDedupe(t *testing.T) {
+	// Build more than the window plus a duplicate date to exercise both paths.
+	var in []pullSnapshot
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < pullHistoryWindowDays+5; i++ {
+		d := base.AddDate(0, 0, i).Format("2006-01-02")
+		in = append(in, pullSnapshot{Date: d, Cumulative: int64(i * 10)})
+	}
+	// Duplicate the last date with a newer cumulative — last-write should win.
+	lastDate := in[len(in)-1].Date
+	in = append(in, pullSnapshot{Date: lastDate, Cumulative: 99999})
+
+	out := pruneOldSnapshots(in)
+	if len(out) != pullHistoryWindowDays {
+		t.Fatalf("want window of %d, got %d", pullHistoryWindowDays, len(out))
+	}
+	// Sorted ascending.
+	for i := 1; i < len(out); i++ {
+		if out[i-1].Date > out[i].Date {
+			t.Fatalf("not sorted ascending at %d: %s > %s", i, out[i-1].Date, out[i].Date)
+		}
+	}
+	// Dedupe kept the last write for the duplicated date.
+	if out[len(out)-1].Cumulative != 99999 {
+		t.Errorf("dedupe last-write-wins failed: got cumulative %d", out[len(out)-1].Cumulative)
+	}
+}
+
+func TestFetchCumulativePulls_ScrapesTitle(t *testing.T) {
+	// Serve a page shaped like the real GHCR package page.
+	page := `<html><body>
+	  <span>Total downloads</span>
+	  <h3 title="127576">128K</h3>
+	</body></html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(page))
+	}))
+	defer srv.Close()
+
+	orig := pullPackagePageURL
+	pullPackagePageURL = srv.URL
+	defer func() { pullPackagePageURL = orig }()
+
+	n, ok := fetchCumulativePulls(context.Background(), slog.Default())
+	if !ok {
+		t.Fatal("expected successful scrape")
+	}
+	if n != 127576 {
+		t.Errorf("want 127576, got %d", n)
+	}
+}
+
+func TestFetchCumulativePulls_CounterMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<html><body>no counter here</body></html>"))
+	}))
+	defer srv.Close()
+	orig := pullPackagePageURL
+	pullPackagePageURL = srv.URL
+	defer func() { pullPackagePageURL = orig }()
+
+	if _, ok := fetchCumulativePulls(context.Background(), slog.Default()); ok {
+		t.Error("expected failure when counter is absent")
+	}
+}
+
+func TestMaybeSnapshot_PersistsAndDailyGuard(t *testing.T) {
+	resetImagePullsState()
+	dir := t.TempDir()
+	origPath := imagePullsPath
+	imagePullsPath = filepath.Join(dir, "image-pulls.json")
+	defer func() { imagePullsPath = origPath }()
+
+	// Stub the network so no real HTTP happens.
+	var cumulative int64 = 1000
+	origFetch := fetchCumulativePulls
+	fetchCumulativePulls = func(ctx context.Context, logger *slog.Logger) (int64, bool) {
+		return cumulative, true
+	}
+	defer func() { fetchCumulativePulls = origFetch }()
+
+	s := &HubServer{logger: slog.Default()}
+	day1 := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+
+	// Two calls on the SAME day → only one snapshot (daily guard).
+	s.maybeSnapshotImagePulls(context.Background(), day1)
+	cumulative = 1234 // would-be second read, same day
+	s.maybeSnapshotImagePulls(context.Background(), day1.Add(3*time.Hour))
+
+	imagePullsMu.Lock()
+	n := len(imagePullSeries)
+	imagePullsMu.Unlock()
+	if n != 1 {
+		t.Fatalf("same-day guard failed: want 1 snapshot, got %d", n)
+	}
+
+	// Next day → a second snapshot.
+	day2 := day1.AddDate(0, 0, 1)
+	cumulative = 1300
+	s.maybeSnapshotImagePulls(context.Background(), day2)
+
+	imagePullsMu.Lock()
+	n = len(imagePullSeries)
+	imagePullsMu.Unlock()
+	if n != 2 {
+		t.Fatalf("want 2 snapshots across two days, got %d", n)
+	}
+
+	// Persisted to disk.
+	if _, err := os.Stat(imagePullsPath); err != nil {
+		t.Fatalf("series not persisted: %v", err)
+	}
+
+	// Fresh load restores it (simulating a hub restart).
+	resetImagePullsState()
+	loadPersistedImagePulls(slog.Default())
+	imagePullsMu.Lock()
+	n = len(imagePullSeries)
+	imagePullsMu.Unlock()
+	if n != 2 {
+		t.Fatalf("restore after restart failed: want 2, got %d", n)
+	}
+
+	// And the delta comes out as day2-day1 = 300.
+	resp := buildImagePullsResponse(imagePullSeries)
+	if resp.Latest != 300 || resp.Total30d != 300 {
+		t.Errorf("want latest/total 300, got latest=%d total=%d", resp.Latest, resp.Total30d)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -418,6 +418,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /dashboard", s.handleDashboard)
 	s.mux.HandleFunc("GET /access-denied", s.handleAccessDenied)
 	s.mux.HandleFunc("GET /api/saas/my-hives", s.requireAuth(s.handleMyHives))
+	// Daily image-pulls sparkline series (external adoption gauge). requireAuth,
+	// not requireAdmin: any signed-in hub user sees the same public-adoption
+	// number, and the underlying data is scraped from the PUBLIC package page.
+	s.mux.HandleFunc("GET /api/hub/image-pulls", s.requireAuth(s.handleImagePulls))
 	// Token attribution rollups. requireAuth (not requireAdmin) because a
 	// non-admin legitimately sees their OWN hives' usage; the handler scopes
 	// fleet-wide data to admins itself.
@@ -4834,6 +4838,11 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// netAdminReconcileInterval — this poller ticks far more often than the
 	// static drift needs re-checking. See netadmin_reconcile.go / issue #2674.
 	s.reconcileNetAdminIfDue()
+	// Record the daily image-pulls snapshot (external-adoption sparkline). The
+	// call is internally guarded to run at most once per pullSnapshotIntervalHours,
+	// so ticking it alongside the frequent SHA poll is cheap — no separate
+	// scheduler. See image_pulls.go.
+	s.maybeSnapshotImagePulls(ctx, time.Now())
 	ticker := time.NewTicker(latestSHAPollInterval)
 	defer ticker.Stop()
 	for {
@@ -4856,6 +4865,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		s.sweepOrphanedUpgrades()
 		s.sweepStuckAssignments()
 		s.reconcileNetAdminIfDue()
+		s.maybeSnapshotImagePulls(ctx, time.Now())
 		changed := false
 		for branch, sha := range newSHAs {
 			if sha != "" && sha != oldSHAs[branch] {
@@ -8341,6 +8351,14 @@ const dashboardHTML = `<!DOCTYPE html>
         <h1>My Hives</h1>
         <p class="subtitle">Hive instances you own or have access to</p>
         <p id="latest-image-sha" style="font-size:0.7rem;color:var(--muted);margin-top:4px"></p>
+        <!-- Image-pulls sparkline: 30-day daily-delta of container-image PULLS
+             of the public spoke image (ghcr.io/kubestellar/hive:v2). Gauges
+             external adoption beyond the hosted fleet. Derived from GitHub's
+             cumulative "Total downloads" counter — it is pulls/day, NOT unique
+             downloads (uniqueness is not measurable). Populated by
+             loadImagePulls(). Hidden until there is data to show. -->
+        <div id="image-pulls-spark" style="display:none;margin-top:8px"
+             title="Daily container-image pulls of the public hive image (ghcr.io/kubestellar/hive:v2), derived from GitHub's cumulative download counter. This is pulls/day — not unique downloads."></div>
       </div>
       <div style="display:flex;gap:8px;align-items:center">
         <button class="btn-primary" id="btn-send-banner-top" style="display:none;background:#d97706" onclick="_bannerTargetHive=null;document.getElementById('banner-modal').style.display='flex';loadBannerHiveList()">Send Banner</button>
@@ -12558,6 +12576,7 @@ const dashboardHTML = `<!DOCTYPE html>
         renderAdminProvisionRequests(data.provision_requests || []);
         loadPublicHives(data.hives || []);
         loadUsage();
+        loadImagePulls();
       } catch(e) {
         /* Surface EVERY failure in the load→render path, not just fetch errors.
            The old guard only painted a message when _allDashHives was empty —
@@ -12573,6 +12592,79 @@ const dashboardHTML = `<!DOCTYPE html>
       } finally {
         _hivesLoading = false;
       }
+    }
+
+    /* loadImagePulls fetches the 30-day daily-delta series of container-image
+       PULLS of the public spoke image and paints a self-contained inline-SVG
+       sparkline near the header. Honest labelling: "pulls/day", NOT unique
+       downloads — the series is derived from GitHub's cumulative download
+       counter and uniqueness is not measurable. Cold start (fewer than two
+       snapshots → no delta yet) shows "collecting…" rather than a broken chart. */
+    async function loadImagePulls() {
+      var host = document.getElementById('image-pulls-spark');
+      if (!host) return;
+      var data;
+      try {
+        var resp = await fetch('/api/hub/image-pulls');
+        if (!resp.ok) { host.style.display = 'none'; return; }
+        data = await resp.json();
+      } catch (e) {
+        /* Adoption sparkline is non-critical chrome — never let it break the
+           dashboard. Just leave it hidden on any failure. */
+        host.style.display = 'none';
+        return;
+      }
+      var points = (data && data.points) || [];
+      host.style.display = 'block';
+
+      /* Cold start: one or zero snapshots means no day-over-day delta yet. */
+      if (data && data.collecting || points.length < 1) {
+        host.innerHTML = '<div style="font-size:0.7rem;color:var(--muted)">Daily image pulls (v2): <span style="opacity:0.7">collecting… (first full data point appears after ~24h)</span></div>';
+        return;
+      }
+
+      /* Sparkline geometry. Named so there are no bare magic numbers in the
+         path math below. */
+      var SPARK_W = 160;   // px, drawing width
+      var SPARK_H = 28;    // px, drawing height
+      var SPARK_PAD = 2;   // px, top/bottom breathing room so peaks aren't clipped
+
+      var vals = points.map(function(p) { return Math.max(0, Number(p.pulls) || 0); });
+      var maxV = Math.max.apply(null, vals);
+      if (maxV <= 0) maxV = 1; // avoid divide-by-zero on an all-zero window
+
+      var stepX = points.length > 1 ? (SPARK_W / (points.length - 1)) : 0;
+      var usableH = SPARK_H - (SPARK_PAD * 2);
+      var coords = vals.map(function(v, i) {
+        var x = (i * stepX).toFixed(1);
+        var y = (SPARK_PAD + (usableH - (v / maxV) * usableH)).toFixed(1);
+        return x + ',' + y;
+      });
+      var linePts = coords.join(' ');
+      /* Filled area under the line: close the polyline down to the baseline. */
+      var lastX = points.length > 1 ? SPARK_W : 0;
+      var areaPts = '0,' + SPARK_H + ' ' + linePts + ' ' + lastX + ',' + SPARK_H;
+
+      var latest = (data && Number(data.latest)) || 0;
+      var total = (data && Number(data.total_30d)) || 0;
+
+      var svg =
+        '<svg width="' + SPARK_W + '" height="' + SPARK_H + '" viewBox="0 0 ' + SPARK_W + ' ' + SPARK_H + '" ' +
+        'preserveAspectRatio="none" style="display:block;overflow:visible">' +
+        '<polygon points="' + areaPts + '" fill="rgba(96,165,250,0.15)" stroke="none"></polygon>' +
+        '<polyline points="' + linePts + '" fill="none" stroke="#60a5fa" stroke-width="1.5" ' +
+        'stroke-linejoin="round" stroke-linecap="round"></polyline>' +
+        '</svg>';
+
+      host.innerHTML =
+        '<div style="display:flex;align-items:center;gap:10px">' +
+          '<div style="font-size:0.7rem;color:var(--muted);white-space:nowrap">Daily image pulls (v2)</div>' +
+          svg +
+          '<div style="font-size:0.7rem;color:var(--muted);white-space:nowrap">' +
+            '<span style="color:#60a5fa;font-weight:600">' + esc(String(latest)) + '</span> latest' +
+            ' &middot; ' + esc(String(total)) + ' over ' + points.length + 'd' +
+          '</div>' +
+        '</div>';
     }
 
     /* renderHivesError replaces the eternal spinner with an actionable message.


### PR DESCRIPTION
## What
Adds a 30-day sparkline of **daily container-image pulls** for the v2 image to the top of the hub's **My Hives** dashboard, so the hub owner can gauge adoption **outside** the ~66 SaaS hives — which is currently invisible.

## The GHCR constraint (important — read before reviewing)
**The GitHub Packages REST API exposes no download/pull count.** Verified directly: the `PackageVersion` object (`GET /orgs/{org}/packages/container/{name}/versions`) has **no download field**, and the app installation token can't surface it. The only place the cumulative counter is exposed is the **public package page** `github.com/kubestellar/hive/pkgs/container/hive`, whose `title=` attribute carries the exact integer (live value at authoring time: **127,576**).

Because of that, this is a **daily-delta of a cumulative counter**, labeled honestly as **"Daily image pulls (v2)"** — **never "unique downloads"**, since uniqueness is not measurable from any GHCR surface. A short tooltip notes it's derived from the cumulative GHCR counter.

## How
- **`v2/pkg/hub/image_pulls.go`** (new) — scrape helper (`fetchCumulativePulls`, a `var` for test stubbing); a **once-per-day** snapshot (`maybeSnapshotImagePulls`) that appends `{date, cumulative}` and prunes to 30 entries; atomic tmp+rename PVC persistence (mirrors `persistLatestSHAs`); the cumulative→delta builder; and `GET /api/hub/image-pulls`. Named constants (`pullSnapshotIntervalHours=24`, `pullHistoryWindowDays=30`, `pullPageTimeout`).
- **`v2/pkg/hub/saas.go`** — registers the route; ticks the snapshot from the **existing** `StartLatestSHAPoller` loop (no new scheduler; internally guarded to once/day); adds the `#image-pulls-spark` anchor under the My Hives header and `loadImagePulls()` JS drawing a **self-contained inline-SVG** sparkline (line + filled area, latest value + 30-day total), showing "collecting…" when there are <2 snapshots.
- **`v2/pkg/hub/image_pulls_test.go`** (new) — deltas, negative-delta clamp (counter-reset guard), cold start (0 and 1 snapshot), window+dedupe prune, live-shaped page scrape, missing-counter failure, and a full daily-guard → persist → restore-after-restart round-trip.

## Storage
`/data/saas/image-pulls.json` (PVC-backed, same dir as `latest-shas.json`), rolling 30 daily entries, atomic writes, restored on restart.

## Note
Real data appears after ~24h of uptime (first delta needs two daily snapshots); until then the sparkline renders "collecting…". No secrets touched.