### PR TITLE
✨ feat(dashboard): per-sandbox and per-session cost breakdowns

### DIFF
--- a/v2/pkg/dashboard/cost.go
+++ b/v2/pkg/dashboard/cost.go
@@ -31,6 +31,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -103,7 +104,39 @@ type costEstimated struct {
 	ByModel        []costModelEntry `json:"by_model"`
 	ByAgent        []costModelEntry `json:"by_agent"`
 	UnpricedModels []string         `json:"unpriced_models"`
+	// BySession is the estimated cost for each individual agent session
+	// (sandbox run), letting the UI show "usage by sandbox and cost per
+	// session" rather than only per-model/per-agent aggregates. Each entry is
+	// priced from its own token splits × list price, exactly like the
+	// aggregate rows. Omitted (empty slice) when no session data is available.
+	BySession []costSessionEntry `json:"by_session"`
 }
+
+// costSessionEntry is one session's estimated cost. A "session" is one agent
+// run inside its sandbox, keyed by SessionID; Agent identifies which sandbox
+// (agent) owned it and Model the model it used. Source is "estimated" for
+// priced models and "unpriced" for models absent from the price table.
+type costSessionEntry struct {
+	SessionID string  `json:"session_id"`
+	Agent     string  `json:"agent"`
+	Model     string  `json:"model"`
+	USD       float64 `json:"usd"`
+	Source    string  `json:"source"` // "estimated" | "unpriced"
+	Input     int64   `json:"input"`
+	Output    int64   `json:"output"`
+	CacheRead int64   `json:"cache_read"`
+	// Messages and LastActive give the UI enough to show session size and
+	// recency without a second round-trip. LastActive is a unix-seconds stamp
+	// (0 when the scanner could not determine it).
+	Messages   int   `json:"messages"`
+	LastActive int64 `json:"last_active,omitempty"`
+}
+
+// maxCostSessions caps how many per-session rows the /api/cost payload carries,
+// so a long-lived fleet with thousands of scanned sessions can't bloat the
+// response. The most-expensive sessions are kept (the UI sorts by cost), which
+// is what an operator hunting a cost spike wants to see first.
+const maxCostSessions = 200
 
 const costEstimateDisclaimer = "Estimated from token counts × published list prices. " +
 	"Subscription plans (Claude, Copilot), self-hosted inference (vLLM), and negotiated rates differ from list price. " +
@@ -146,6 +179,7 @@ func (s *Server) estimatedCost() costEstimated {
 	if s.deps != nil && s.deps.Tokens != nil {
 		if summary := s.deps.Tokens.Summary(); summary != nil {
 			est = flattenEstimated(tokens.EstimateFromSummary(summary))
+			est.BySession = estimatedSessions(summary)
 		}
 	}
 	if est.ByModel == nil {
@@ -157,7 +191,47 @@ func (s *Server) estimatedCost() costEstimated {
 	if est.UnpricedModels == nil {
 		est.UnpricedModels = []string{}
 	}
+	if est.BySession == nil {
+		est.BySession = []costSessionEntry{}
+	}
 	return est
+}
+
+// estimatedSessions prices every scanned session individually so the UI can
+// show cost per session (and, via the Agent field, group sessions by sandbox).
+// It is a pure function of the summary — each session's own token splits are
+// priced at list price, identically to the aggregate rows. The result is sorted
+// most-expensive first and capped at maxCostSessions so the payload stays
+// bounded on a large fleet. Returns an empty (non-nil) slice when there is no
+// session data.
+func estimatedSessions(summary *tokens.AggregateSummary) []costSessionEntry {
+	if summary == nil {
+		return []costSessionEntry{}
+	}
+	sessions := summary.Sessions
+	out := make([]costSessionEntry, 0, len(sessions))
+	for _, sess := range sessions {
+		usd, exact := tokens.EstimateCostUSD(sess.Model, sess.InputTokens, sess.OutputTokens, sess.CacheRead, sess.CacheCreate)
+		out = append(out, costSessionEntry{
+			SessionID:  sess.SessionID,
+			Agent:      sess.Agent,
+			Model:      sess.Model,
+			USD:        usd,
+			Source:     sourceForPriced(exact),
+			Input:      sess.InputTokens,
+			Output:     sess.OutputTokens,
+			CacheRead:  sess.CacheRead,
+			Messages:   sess.Messages,
+			LastActive: sess.LastActive,
+		})
+	}
+	// Most-expensive first — that's what an operator hunting a cost spike wants,
+	// and it makes the maxCostSessions cap keep the rows that matter.
+	sort.Slice(out, func(i, j int) bool { return out[i].USD > out[j].USD })
+	if len(out) > maxCostSessions {
+		out = out[:maxCostSessions]
+	}
+	return out
 }
 
 // flattenEstimated converts the map-keyed EstimatedCost into sorted-agnostic

--- a/v2/pkg/dashboard/cost_sessions_test.go
+++ b/v2/pkg/dashboard/cost_sessions_test.go
@@ -1,0 +1,113 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/tokens"
+)
+
+// TestEstimatedSessions_NilAndEmpty verifies the builder never returns a nil
+// slice, matching the /api/cost contract (UI guards with (arr||[]) but the
+// backend should still emit []).
+func TestEstimatedSessions_NilAndEmpty(t *testing.T) {
+	if got := estimatedSessions(nil); got == nil || len(got) != 0 {
+		t.Fatalf("nil summary: got %v, want empty non-nil slice", got)
+	}
+	empty := &tokens.AggregateSummary{}
+	if got := estimatedSessions(empty); got == nil || len(got) != 0 {
+		t.Fatalf("empty summary: got %v, want empty non-nil slice", got)
+	}
+}
+
+// TestEstimatedSessions_PricesAndSorts verifies each session is priced from its
+// own token splits, carries its sandbox (agent)/model/session id, and rows come
+// back most-expensive first.
+func TestEstimatedSessions_PricesAndSorts(t *testing.T) {
+	summary := &tokens.AggregateSummary{
+		Sessions: []tokens.SessionSummary{
+			{SessionID: "sess-small", Agent: "scanner", Model: "claude-opus-4.7", InputTokens: 1_000, OutputTokens: 500, Messages: 3, LastActive: 111},
+			{SessionID: "sess-big", Agent: "quality", Model: "claude-opus-4.7", InputTokens: 5_000_000, OutputTokens: 2_000_000, Messages: 40, LastActive: 222},
+		},
+	}
+
+	got := estimatedSessions(summary)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+
+	// Most-expensive first: the big session must lead.
+	if got[0].SessionID != "sess-big" {
+		t.Errorf("row[0] = %q, want sess-big (should sort most-expensive first)", got[0].SessionID)
+	}
+	if got[0].USD <= got[1].USD {
+		t.Errorf("not sorted by cost desc: %v <= %v", got[0].USD, got[1].USD)
+	}
+
+	// Per-session pricing must equal EstimateCostUSD over that session's splits.
+	wantUSD, exact := tokens.EstimateCostUSD("claude-opus-4.7", 5_000_000, 2_000_000, 0, 0)
+	if got[0].USD != wantUSD {
+		t.Errorf("big session USD = %v, want %v (priced from its own splits)", got[0].USD, wantUSD)
+	}
+	if got[0].Source != sourceForPriced(exact) {
+		t.Errorf("big session source = %q, want %q", got[0].Source, sourceForPriced(exact))
+	}
+
+	// Identity fields survive.
+	if got[0].Agent != "quality" || got[0].Model != "claude-opus-4.7" {
+		t.Errorf("big session identity = %q/%q, want quality/claude-opus-4.7", got[0].Agent, got[0].Model)
+	}
+	if got[0].Messages != 40 || got[0].LastActive != 222 {
+		t.Errorf("big session meta = msgs %d last %d, want 40/222", got[0].Messages, got[0].LastActive)
+	}
+	if got[0].Input != 5_000_000 || got[0].Output != 2_000_000 {
+		t.Errorf("big session token splits = %d/%d, want 5000000/2000000", got[0].Input, got[0].Output)
+	}
+}
+
+// TestEstimatedSessions_UnpricedModelSource verifies a model absent from the
+// exact price table is tagged "unpriced" (still tier-priced, non-zero) rather
+// than silently dropped.
+func TestEstimatedSessions_UnpricedModelSource(t *testing.T) {
+	summary := &tokens.AggregateSummary{
+		Sessions: []tokens.SessionSummary{
+			{SessionID: "s1", Agent: "a", Model: "some-unknown-mid-model", InputTokens: 1000, OutputTokens: 1000},
+		},
+	}
+	got := estimatedSessions(summary)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Source != "unpriced" {
+		t.Errorf("source = %q, want unpriced for a model absent from the price table", got[0].Source)
+	}
+	if got[0].USD <= 0 {
+		t.Errorf("USD = %v, want > 0 (tier fallback, never $0)", got[0].USD)
+	}
+}
+
+// TestEstimatedSessions_CapsRows verifies the payload is bounded at
+// maxCostSessions and keeps the most-expensive rows.
+func TestEstimatedSessions_CapsRows(t *testing.T) {
+	over := maxCostSessions + 25
+	sessions := make([]tokens.SessionSummary, over)
+	for i := range sessions {
+		// Larger i → more tokens → higher cost, so the top rows are the tail.
+		sessions[i] = tokens.SessionSummary{
+			SessionID:   "s",
+			Agent:       "a",
+			Model:       "claude-opus-4.7",
+			InputTokens: int64(i+1) * 1000,
+		}
+	}
+	summary := &tokens.AggregateSummary{Sessions: sessions}
+
+	got := estimatedSessions(summary)
+	if len(got) != maxCostSessions {
+		t.Fatalf("len = %d, want cap %d", len(got), maxCostSessions)
+	}
+	// The single most-expensive session (largest i) must be present at row 0.
+	wantTop, _ := tokens.EstimateCostUSD("claude-opus-4.7", int64(over)*1000, 0, 0, 0)
+	if got[0].USD != wantTop {
+		t.Errorf("row[0] USD = %v, want %v (most-expensive kept after cap)", got[0].USD, wantTop)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1335,6 +1335,8 @@
     .cost-table td { padding: 4px 8px; border-bottom: 1px solid rgba(128,128,128,0.08); }
     .cost-table td.cnum { text-align: right; font-family: var(--font-mono); }
     .cost-table td.cmodel { color: var(--purple); font-family: var(--font-mono); }
+    .cost-table td.csession { color: var(--muted); font-family: var(--font-mono); }
+    .cost-subtable-title { font-size: 0.72rem; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; margin: 16px 0 4px; }
     .cost-disclaimer { font-size: 0.65rem; color: var(--muted); margin-top: 10px; line-height: 1.4; }
 
     /* Cost spend-over-time: range pills + bucketed bar chart */
@@ -7852,6 +7854,10 @@ function burnAreaChart() {
     // spend reported by OpenRouter / LiteLLM gateways). Estimates are always
     // labeled "est." so they never masquerade as actual billing.
     const COST_POLL_MS = 60000;
+    // How many leading characters of a session id to show before eliding — full
+    // id stays available on hover (title). Session ids are UUID-length, so a
+    // short prefix is enough to disambiguate visually.
+    const COST_SESSION_ID_CHARS = 8;
     // Format a dollar amount with thousands separators (commas). Small amounts
     // keep 2-decimal cents; amounts >= $100 are shown as whole dollars but still
     // comma-grouped (e.g. $20,849). Sentinels for null / sub-cent are preserved.
@@ -7965,6 +7971,59 @@ function burnAreaChart() {
         ? `<div class="cost-disclaimer">Tier-estimated (no exact list price, marked ~ and included in the total): ${est.unpriced_models.map(esc).join(', ')}.</div>`
         : '';
 
+      // ── Per-sandbox (per-agent) estimated cost ──
+      // In hive each agent runs in its own sandbox, so "usage by sandbox" is the
+      // per-agent breakdown. Sorted most-expensive first.
+      const bySandbox = (est.by_agent || []).slice().sort((a, b) => b.usd - a.usd);
+      const sandboxRows = bySandbox.map(a => {
+        const approx = a.source === 'unpriced';
+        const usdCell = approx
+          ? `<span title="tier estimate — no exact list price for this sandbox's model">~${fmtUSD(a.usd)}</span>`
+          : fmtUSD(a.usd);
+        return `<tr>
+          <td class="cmodel">${esc(a.name || 'unknown')}</td>
+          <td class="cnum">${fmtTokens(a.input)}</td>
+          <td class="cnum">${fmtTokens(a.output)}</td>
+          <td class="cnum">${usdCell}</td>
+        </tr>`;
+      }).join('');
+      const sandboxTable = `
+        <div class="cost-subtable-title" title="Estimated cost grouped by sandbox — one agent per sandbox (token × list price)">usage by sandbox</div>
+        <table class="cost-table">
+          <thead><tr><th>sandbox (agent)</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
+          <tbody>${sandboxRows || '<tr><td colspan="4" style="color:var(--muted)">no usage yet</td></tr>'}</tbody>
+        </table>`;
+
+      // ── Cost per session ──
+      // Each row is one agent run (session) inside its sandbox, priced from its
+      // own token splits. Backend already sorts most-expensive first and caps
+      // the count; we show the session id (shortened), owning sandbox, and model.
+      const bySession = est.by_session || [];
+      const shortId = (id) => {
+        const s = String(id || '');
+        return s.length > COST_SESSION_ID_CHARS ? s.slice(0, COST_SESSION_ID_CHARS) + '…' : (s || '—');
+      };
+      const sessionRows = bySession.map(sn => {
+        const approx = sn.source === 'unpriced';
+        const usdCell = approx
+          ? `<span title="tier estimate — no exact list price for this model">~${fmtUSD(sn.usd)}</span>`
+          : fmtUSD(sn.usd);
+        return `<tr>
+          <td class="csession" title="${esc(sn.session_id || '')}">${esc(shortId(sn.session_id))}</td>
+          <td class="cmodel">${esc(sn.agent || 'unknown')}</td>
+          <td class="cmodel">${esc(sn.model || '—')}</td>
+          <td class="cnum">${fmtTokens(sn.input)}</td>
+          <td class="cnum">${fmtTokens(sn.output)}</td>
+          <td class="cnum">${usdCell}</td>
+        </tr>`;
+      }).join('');
+      const sessionTable = `
+        <div class="cost-subtable-title" title="Estimated cost for each individual agent session (sandbox run), most expensive first (token × list price)">cost per session</div>
+        <table class="cost-table">
+          <thead><tr><th>session</th><th>sandbox</th><th>model</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
+          <tbody>${sessionRows || '<tr><td colspan="6" style="color:var(--muted)">no sessions yet</td></tr>'}</tbody>
+        </table>`;
+
       el.innerHTML = `<div class="cost-panel">
         <div class="cost-title">Cost <span class="cost-badge est" title="Estimated from token counts × list prices; subscription/self-hosted billing may differ">est.</span></div>
         <div class="cost-subtitle">Estimated from token counts × list prices (as of ${esc(cost.price_table_date || '')}); models without an exact price use a coarse tier estimate (~). Where a metered gateway reports actual spend it refines the estimate, but the figure is always an estimate.</div>
@@ -7977,6 +8036,8 @@ function burnAreaChart() {
           <thead><tr><th>model</th><th style="text-align:center" title="Running agents on this model right now — hover the count for names">running agents</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
           <tbody>${modelRows || '<tr><td colspan="5" style="color:var(--muted)">no usage yet</td></tr>'}</tbody>
         </table>
+        ${sandboxTable}
+        ${sessionTable}
         ${unpricedNote}
         <div class="cost-disclaimer">${esc(cost.disclaimer || '')} vLLM / self-hosted figures are estimated (reflect list price, not your infra cost).</div>
       </div>`;


### PR DESCRIPTION
## What
The Cost view showed only aggregate totals (daily/weekly/monthly). This adds **usage by sandbox** and **cost per session**, so spend can be attributed to individual agents and sessions.

## Data model note
There is no separate "sandbox" entity in the code — in hive **each agent runs in its own sandbox**, so **per-sandbox == per-agent** (keyed by `Agent`). **Per-session** is keyed by `SessionID` (with `Agent`/`Model`).

## Backend was genuinely missing per-session cost
The token `AggregateSummary` already carried a full `Sessions []SessionSummary` list (per-session token splits), and `tokens.EstimateCostUSD` is an exported pure pricing function — but `/api/cost` did **not** expose per-session cost at all. This PR prices each **real** scanned session from its own token splits (no fabricated data).

- **`v2/pkg/dashboard/cost.go`** — new `costSessionEntry` + `BySession []costSessionEntry` on `costEstimated`; `estimatedSessions(summary)` prices each real session via `tokens.EstimateCostUSD`, tags estimated/unpriced, sorts most-expensive-first, caps at `maxCostSessions = 200` (named const). Wired into `estimatedCost()`, always emits a non-nil slice.
- **`v2/pkg/dashboard/static/index.html`** — two tables in `renderCost`: **"usage by sandbox"** (per-agent, from `est.by_agent`) and **"cost per session"** (shortened session id w/ full id on hover, sandbox, model, tokens, est. $, from new `est.by_session`). Existing total, trend chart, and gateway cards untouched. Array ops guarded with `(arr||[])`; `COST_SESSION_ID_CHARS = 8` named const; two small CSS rules matching existing cost-table styling.
- **`v2/pkg/dashboard/cost_sessions_test.go`** (new) — nil/empty safety, per-session pricing matches `EstimateCostUSD`, most-expensive-first ordering, unpriced-model tagging, and the cap keeping the priciest rows.

`go test` on new + existing cost tests passed; `go vet ./pkg/dashboard/` clean.