### PR TITLE
✨ feat(hub): enable IBMid OIDC login (uid subject claim) — multi-login phase 4

### DIFF
--- a/v2/pkg/auth/oidc_provider_test.go
+++ b/v2/pkg/auth/oidc_provider_test.go
@@ -358,14 +358,63 @@ func TestBuildRegistry_EnabledByClientID(t *testing.T) {
 
 func TestBuildRegistry_IBMidWithIssuerEnabled(t *testing.T) {
 	t.Setenv("HIVE_HUB_OIDC_IBMID_CLIENT_ID", "ibm-client")
-	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "https://us-south.appid.cloud.ibm.com/oauth/v4/tenant123")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "https://login.ibm.com/oidc/endpoint/default")
 	reg := BuildRegistry("", "", "")
 	p := reg.Get("ibmid")
 	if p == nil {
 		t.Fatal("ibmid should be enabled with an explicit issuer")
 	}
-	if p.Issuer != "https://us-south.appid.cloud.ibm.com/oauth/v4/tenant123" {
+	if p.Issuer != "https://login.ibm.com/oidc/endpoint/default" {
 		t.Errorf("issuer = %q", p.Issuer)
+	}
+	// IBMid keys on "uid", not the OIDC-standard "sub" (which it doesn't advertise).
+	if p.SubjectClaim != "uid" {
+		t.Errorf("ibmid SubjectClaim = %q, want uid", p.SubjectClaim)
+	}
+}
+
+func TestBuildRegistry_SubjectClaimEnvOverride(t *testing.T) {
+	// If a real IBMid token turns out to carry "sub", an operator can override the
+	// default "uid" via env without a code change.
+	t.Setenv("HIVE_HUB_OIDC_IBMID_CLIENT_ID", "ibm-client")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "https://login.ibm.com/oidc/endpoint/default")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM", "sub")
+	p := BuildRegistry("", "", "").Get("ibmid")
+	if p == nil || p.SubjectClaim != "sub" {
+		t.Fatalf("env override not applied: %+v", p)
+	}
+	// Google keeps the default (empty → sub).
+	t.Setenv("HIVE_HUB_OIDC_GOOGLE_CLIENT_ID", "g")
+	g := BuildRegistry("", "", "").Get("google")
+	if g == nil || g.SubjectClaim != "" {
+		t.Errorf("google SubjectClaim = %q, want empty (defaults to sub)", g.SubjectClaim)
+	}
+}
+
+func TestVerify_IBMidUidSubject(t *testing.T) {
+	// An IBMid-shaped id_token carries the stable id in "uid" and NO "sub".
+	// Verification with SubjectClaim="uid" must extract the uid as the subject.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ibm-client"
+	const nonce = "n-ibm"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": o.issuer, "aud": clientID,
+		"uid": "2700ABC123", // stable IBMid serial, no "sub"
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce, "preferred_username": "someone@ibm.com", "email": "someone@ibm.com",
+	})
+	p := &Provider{
+		Name: "ibmid", DisplayName: "IBMid", IsOIDC: true,
+		Issuer: o.issuer, ClientID: clientID, Scopes: []string{"openid"},
+		SubjectClaim: "uid",
+	}
+	claims, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Subject != "2700ABC123" {
+		t.Errorf("subject = %q, want the uid 2700ABC123", claims.Subject)
 	}
 }
 

--- a/v2/pkg/auth/registry.go
+++ b/v2/pkg/auth/registry.go
@@ -95,6 +95,13 @@ type oidcProviderSpec struct {
 	defaultIssuer string // "" means the issuer MUST come from env
 	envPrefix     string // e.g. "HIVE_HUB_OIDC_GOOGLE"
 	scopes        []string
+	// subjectClaim overrides which id_token claim carries the STABLE per-user
+	// identifier. Empty means the OIDC-standard "sub". IBMid does not advertise
+	// "sub" in its discovery claims_supported — its stable identifier is "uid"
+	// (an IBMid serial); preferred_username/email are reassignable and must NOT
+	// be the key. An env override (<PREFIX>_SUBJECT_CLAIM) lets us retune from a
+	// real token without a code change if IBMid does emit a usable "sub".
+	subjectClaim string
 }
 
 // oidcSpecs is the closed set of OIDC providers the hub can enable. A provider is
@@ -112,9 +119,13 @@ var oidcSpecs = []oidcProviderSpec{
 	{
 		name:          "ibmid",
 		display:       "IBMid",
-		defaultIssuer: "", // tenant-specific (IBM App ID): must set _ISSUER
+		defaultIssuer: "", // tenant-specific (IBM App ID / w3id): must set _ISSUER
 		envPrefix:     "HIVE_HUB_OIDC_IBMID",
 		scopes:        []string{"openid", "email", "profile"},
+		// IBMid's discovery does not list "sub"; "uid" is the stable IBMid serial.
+		// Confirmed against the live IBMid discovery claims_supported (uid present,
+		// sub absent). Overridable via HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM.
+		subjectClaim: "uid",
 	},
 	{
 		name:          "redhat",
@@ -168,6 +179,11 @@ func BuildRegistry(githubClientID, ghAuthorizeURL, ghTokenURL string) *Registry 
 			// Configured client id but no issuer we can use → skip, don't crash.
 			continue
 		}
+		// Subject claim: env override wins, else the spec default, else "sub".
+		subjectClaim := os.Getenv(spec.envPrefix + "_SUBJECT_CLAIM")
+		if subjectClaim == "" {
+			subjectClaim = spec.subjectClaim
+		}
 		p := &Provider{
 			Name:         spec.name,
 			DisplayName:  spec.display,
@@ -176,6 +192,7 @@ func BuildRegistry(githubClientID, ghAuthorizeURL, ghTokenURL string) *Registry 
 			ClientID:     clientID,
 			ClientSecret: os.Getenv(spec.envPrefix + "_CLIENT_SECRET"),
 			Scopes:       spec.scopes,
+			SubjectClaim: subjectClaim,
 		}
 		oidc = append(oidc, p)
 	}


### PR DESCRIPTION
## Multi-login Phase 4 — IBMid

Wires **IBMid** as a human-login provider on top of the Phase 2 OIDC foundation (#3579). Nothing is provider-specific beyond config — IBMid rides the same verified-id_token flow as Google.

### Key detail: subject claim
IBMid's discovery does **not** advertise the OIDC-standard `sub` claim (verified against the live `claims_supported`). Its stable per-user identifier is **`uid`** (an IBMid serial); `preferred_username`/`email` are reassignable and must never be the identity key.

- `oidcProviderSpec` gains a `subjectClaim` field; IBMid sets it to `"uid"`.
- Env override `HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM` lets an operator retune (e.g. to `sub`) from a real token without a code change.
- `verifyIDToken` already keys on `Provider.SubjectClaim` (defaulting to `sub`).

### Deploy (already applied on the hub)
- `HIVE_HUB_OIDC_IBMID_CLIENT_ID` (literal)
- `HIVE_HUB_OIDC_IBMID_ISSUER=https://login.ibm.com/oidc/endpoint/default` (literal)
- `HIVE_HUB_OIDC_IBMID_CLIENT_SECRET` → `secretKeyRef` `hive-hub-secrets/oidc-ibmid-client-secret`

IBMid then appears in the login picker; hub-proxied spokes inherit it for free via the canonical `X-Hive-User`.

### Tests
IBMid enabled + `uid` subject claim, env override, Google keeps the default, and an end-to-end verify of a `uid`-keyed (sub-less) IBMid id_token. `pkg/auth` coverage 93.0%.

> Note: verify the subject claim against a real IBMid token after first login — if IBMid does emit a usable `sub`, flip `HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM=sub`.