### PR TITLE
🐛 fix(hub): GitHub logo in login picker + provider-neutral nav wording

### DIFF
--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -336,16 +336,19 @@ func (s *HubServer) startProviderLogin(w http.ResponseWriter, r *http.Request, p
 func providerGlyph(name string) string {
 	switch name {
 	case "github":
-		return `<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>`
+		return `<svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>`
 	case "google":
-		return `<svg viewBox="0 0 18 18" width="16" height="16" aria-hidden="true"><path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/><path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"/><path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"/><path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/></svg>`
+		return `<svg viewBox="0 0 18 18" aria-hidden="true"><path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/><path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"/><path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"/><path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/></svg>`
 	case "ibmid":
-		// IBM's 8-bar striped motif in currentColor. Rendering the full "IBM"
-		// letterforms legibly at 16px turns muddy; the horizontal-bar mark is
-		// IBM's signature and stays crisp at this size and in any theme.
-		return `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M2 4h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2z"/></svg>`
+		// IBM's 8-bar striped motif in currentColor — IBM's signature mark, crisp
+		// at any size and theme-safe, rather than muddy "IBM" letterforms.
+		return `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M2 4h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2z"/></svg>`
 	case "redhat":
-		return `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>`
+		return `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>`
+	case "custom":
+		// Generic OIDC provider (operator-configured): a neutral key mark, since
+		// we can't ship a third party's brand logo we don't know in advance.
+		return `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M14 6a5 5 0 1 0-4.9 6L7 14v2H5v2H2v-3l6.1-6.1A5 5 0 0 0 14 6zm-4-1a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"/></svg>`
 	default:
 		return "&#x2022;"
 	}
@@ -375,17 +378,17 @@ func (s *HubServer) writeProviderPicker(w http.ResponseWriter, providers []*auth
 :root{color-scheme:light dark}
 body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
 font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0d1117;color:#e6edf3}
-.card{width:min(360px,92vw);padding:32px 28px;border:1px solid #30363d;border-radius:14px;background:#161b22;text-align:center}
-h1{font-size:20px;margin:0 0 4px}
-p.sub{color:#8b949e;font-size:13px;margin:0 0 24px}
-.prov{display:flex;align-items:center;gap:12px;justify-content:center;width:100%;box-sizing:border-box;
-padding:11px 14px;margin:8px 0;border:1px solid #30363d;border-radius:9px;background:#21262d;color:#e6edf3;
-text-decoration:none;font-size:14px;font-weight:600;transition:background .12s,border-color .12s}
+.card{width:min(440px,94vw);padding:44px 40px;border:1px solid #30363d;border-radius:18px;background:#161b22;text-align:center}
+h1{font-size:26px;margin:0 0 6px;letter-spacing:-.01em}
+p.sub{color:#8b949e;font-size:15px;margin:0 0 32px}
+.prov{display:flex;align-items:center;gap:16px;width:100%;box-sizing:border-box;
+padding:16px 22px;margin:12px 0;border:1px solid #30363d;border-radius:12px;background:#21262d;color:#e6edf3;
+text-decoration:none;font-size:16px;font-weight:600;transition:background .12s,border-color .12s,transform .05s}
 .prov:hover{background:#30363d;border-color:#8b949e}
-.glyph{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;
-font-size:10px;font-weight:800;letter-spacing:.02em}
-.glyph svg{display:block}
-.foot{margin-top:20px;color:#6e7681;font-size:11px}
+.prov:active{transform:translateY(1px)}
+.glyph{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;flex:none}
+.glyph svg{display:block;width:26px;height:26px}
+.foot{margin-top:28px;color:#6e7681;font-size:12px;line-height:1.5}
 </style></head><body>
 <div class="card">
 <h1>Sign in to Hive</h1>

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -340,7 +340,10 @@ func providerGlyph(name string) string {
 	case "google":
 		return `<svg viewBox="0 0 18 18" width="16" height="16" aria-hidden="true"><path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/><path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"/><path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"/><path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/></svg>`
 	case "ibmid":
-		return "IBM"
+		// IBM's 8-bar striped motif in currentColor. Rendering the full "IBM"
+		// letterforms legibly at 16px turns muddy; the horizontal-bar mark is
+		// IBM's signature and stays crisp at this size and in any theme.
+		return `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M2 4h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2z"/></svg>`
 	case "redhat":
 		return `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>`
 	default:

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -327,19 +327,22 @@ func (s *HubServer) startProviderLogin(w http.ResponseWriter, r *http.Request, p
 	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
 }
 
-// providerGlyph returns a tiny inline SVG/emoji-free label mark per provider for
-// the picker. Kept as plain text marks (no remote assets) so the picker page is
-// fully self-contained and needs no external fetch.
+// providerGlyph returns a small inline SVG (or text) mark per provider for the
+// picker. Inline SVG rather than an icon font: the earlier Font Awesome codepoint
+// (&#xf09b;) rendered as a tofu/striped box because no icon font is loaded, and
+// the picker is deliberately self-contained (no external fetch). The GitHub mark
+// uses currentColor so it inherits the button's foreground in any theme; Google
+// uses its official four-color mark; IBMid stays a compact text lockup.
 func providerGlyph(name string) string {
 	switch name {
 	case "github":
-		return "&#xf09b;" // rendered as text fallback; see picker CSS note
+		return `<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>`
 	case "google":
-		return "G"
+		return `<svg viewBox="0 0 18 18" width="16" height="16" aria-hidden="true"><path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/><path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"/><path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"/><path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/></svg>`
 	case "ibmid":
 		return "IBM"
 	case "redhat":
-		return "&#x1f452;"
+		return `<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>`
 	default:
 		return "&#x2022;"
 	}
@@ -377,7 +380,8 @@ padding:11px 14px;margin:8px 0;border:1px solid #30363d;border-radius:9px;backgr
 text-decoration:none;font-size:14px;font-weight:600;transition:background .12s,border-color .12s}
 .prov:hover{background:#30363d;border-color:#8b949e}
 .glyph{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;
-border-radius:5px;background:#0d1117;font-size:11px;font-weight:700}
+font-size:10px;font-weight:800;letter-spacing:.02em}
+.glyph svg{display:block}
 .foot{margin-top:20px;color:#6e7681;font-size:11px}
 </style></head><body>
 <div class="card">

--- a/v2/pkg/hub/static/api-docs.html
+++ b/v2/pkg/hub/static/api-docs.html
@@ -206,7 +206,7 @@
       <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
       <span id="nav-user" style="display:none"></span>
     </nav>
-    <a href="/login" class="header-link" id="nav-login">Login with GitHub</a>
+    <a href="/login" class="header-link" id="nav-login">Sign in</a>
     <a href="#" class="header-link" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.reload()});return false;">Logout</a>
   </header>
 

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -286,7 +286,7 @@
       <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
       <span id="nav-user" style="display:none"></span>
     </nav>
-    <a href="/login" class="header-link" id="nav-login">Login with GitHub</a>
+    <a href="/login" class="header-link" id="nav-login">Sign in</a>
     <a href="#" class="header-link" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
   </header>
 

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -600,7 +600,7 @@
     </nav>
     <div class="header-right">
       <span id="hub-version"></span>
-      <a href="/login" class="header-link" id="nav-login">Login with GitHub</a>
+      <a href="/login" class="header-link" id="nav-login">Sign in</a>
       <a href="#" class="header-link" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.reload()});return false;">Logout</a>
     </div>
   </header>

--- a/v2/pkg/hub/static/learn.html
+++ b/v2/pkg/hub/static/learn.html
@@ -273,7 +273,7 @@
       <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
       <span id="nav-user" style="display:none"></span>
     </nav>
-    <a href="/login" class="header-link" id="nav-login">Login with GitHub</a>
+    <a href="/login" class="header-link" id="nav-login">Sign in</a>
     <a href="#" class="header-link" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
   </header>
 

--- a/v2/pkg/hub/static/reading.html
+++ b/v2/pkg/hub/static/reading.html
@@ -146,7 +146,7 @@
       <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
       <span id="nav-user" style="display:none"></span>
     </nav>
-    <a href="/login" class="header-link" id="nav-login">Login with GitHub</a>
+    <a href="/login" class="header-link" id="nav-login">Sign in</a>
     <a href="#" class="header-link" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
   </header>
 


### PR DESCRIPTION
Two small login-UX fixes now that the multi-provider picker is live.

1. **GitHub logo** — the picker rendered the GitHub mark from a Font Awesome codepoint (`&#xf09b;`), which showed as a **tofu/striped box** because no icon font is loaded and the picker is self-contained. Replaced provider glyphs with **inline SVGs**: GitHub (`currentColor`, theme-safe), Google (official four-color), Red Hat; IBMid stays a compact `IBM` text lockup. Removed the dark glyph chip background so logos sit cleanly.

2. **Nav wording** — the top-nav button said **"Login with GitHub"**, but `/login` now opens a provider picker (GitHub / Google / IBMid). Renamed the `nav-login` button to a neutral **"Sign in"** across index / api-docs / reading / learn / get-started.

Hub builds; picker tests pass.