### PR TITLE
✨ feat(hub): generic BYO-OIDC provider — wire any OIDC IdP via env

### DIFF
--- a/v2/pkg/auth/generic_provider_test.go
+++ b/v2/pkg/auth/generic_provider_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import "testing"
+
+// TestBuildRegistry_GenericCustomProvider: an operator can wire ANY OIDC IdP via
+// the "custom" env prefix — enabled by CLIENT_ID, issuer required, with an
+// overridable display label, scopes, and subject claim.
+func TestBuildRegistry_GenericCustomProvider(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_ID", "acme-client")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_SECRET", "s")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_ISSUER", "https://acme.okta.com")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_DISPLAY", "Acme SSO")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_SCOPES", "openid,email,groups")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_SUBJECT_CLAIM", "oid")
+
+	p := BuildRegistry("", "", "").Get("custom")
+	if p == nil {
+		t.Fatal("custom provider should be enabled")
+	}
+	if p.DisplayName != "Acme SSO" {
+		t.Errorf("display = %q, want Acme SSO", p.DisplayName)
+	}
+	if p.Issuer != "https://acme.okta.com" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+	if len(p.Scopes) != 3 || p.Scopes[2] != "groups" {
+		t.Errorf("scopes = %v", p.Scopes)
+	}
+	if p.SubjectClaim != "oid" {
+		t.Errorf("subjectClaim = %q, want oid", p.SubjectClaim)
+	}
+}
+
+// TestBuildRegistry_GenericDefaults: with only the required env, sensible
+// defaults apply (label "Single Sign-On", standard scopes, sub subject).
+func TestBuildRegistry_GenericDefaults(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_ID", "c")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_ISSUER", "https://idp.example.com")
+	p := BuildRegistry("", "", "").Get("custom")
+	if p == nil {
+		t.Fatal("custom should be enabled with just client id + issuer")
+	}
+	if p.DisplayName != "Single Sign-On" {
+		t.Errorf("default display = %q", p.DisplayName)
+	}
+	if p.SubjectClaim != "" {
+		t.Errorf("default subjectClaim should be empty (→ sub), got %q", p.SubjectClaim)
+	}
+	if len(p.Scopes) != 3 {
+		t.Errorf("default scopes = %v", p.Scopes)
+	}
+}
+
+// TestBuildRegistry_GenericNeedsIssuer: no issuer → skipped, not fatal.
+func TestBuildRegistry_GenericNeedsIssuer(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_ID", "c")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_ISSUER", "")
+	if BuildRegistry("", "", "").Get("custom") != nil {
+		t.Error("custom must be skipped when no issuer is configured")
+	}
+}
+
+func TestSplitScopes(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want int
+	}{
+		{"openid email profile", 3},
+		{"openid,email,profile", 3},
+		{"openid, email ,  profile", 3},
+		{"", 0},
+		{"  openid  ", 1},
+	} {
+		if got := len(splitScopes(c.in)); got != c.want {
+			t.Errorf("splitScopes(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/v2/pkg/auth/registry.go
+++ b/v2/pkg/auth/registry.go
@@ -29,6 +29,22 @@ func nowUTC() time.Time {
 	return time.Now().UTC()
 }
 
+// splitScopes parses a scope override env value. Accepts space- or comma-
+// separated scopes ("openid email profile" or "openid,email,profile"); empties
+// are dropped. Used for <PREFIX>_SCOPES, chiefly the generic "custom" provider
+// whose IdP may need different scopes than the openid/email/profile default.
+func splitScopes(s string) []string {
+	f := func(r rune) bool { return r == ' ' || r == ',' || r == '\t' || r == '\n' }
+	parts := strings.FieldsFunc(s, f)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // Registry holds the enabled human-login providers, in a stable display order.
 type Registry struct {
 	providers []*Provider
@@ -134,6 +150,19 @@ var oidcSpecs = []oidcProviderSpec{
 		envPrefix:     "HIVE_HUB_OIDC_REDHAT",
 		scopes:        []string{"openid", "email", "profile"},
 	},
+	{
+		// Generic/BYO OIDC provider. Lets an operator wire ANY standards-compliant
+		// OIDC IdP (Okta, Auth0, Microsoft Entra single-tenant, Keycloak, Ping,
+		// ForgeRock, Dex, Cognito, …) with no code change — everything comes from
+		// env. The issuer MUST be provided (no default); the display label defaults
+		// to "Single Sign-On" but is overridable via _DISPLAY. Its canonical
+		// provider slug is "custom", so users key as custom:<sub>.
+		name:          "custom",
+		display:       "Single Sign-On",
+		defaultIssuer: "", // must set HIVE_HUB_OIDC_CUSTOM_ISSUER
+		envPrefix:     "HIVE_HUB_OIDC_CUSTOM",
+		scopes:        []string{"openid", "email", "profile"},
+	},
 }
 
 // BuildRegistry assembles the enabled human-login providers from the environment.
@@ -179,19 +208,31 @@ func BuildRegistry(githubClientID, ghAuthorizeURL, ghTokenURL string) *Registry 
 			// Configured client id but no issuer we can use → skip, don't crash.
 			continue
 		}
-		// Subject claim: env override wins, else the spec default, else "sub".
-		subjectClaim := os.Getenv(spec.envPrefix + "_SUBJECT_CLAIM")
+		// Optional per-provider env overrides. These matter most for the generic
+		// "custom" provider (whose brand/label/scopes we can't know in advance),
+		// but are honored for any provider so an operator can retune without code.
+		display := spec.display
+		if d := strings.TrimSpace(os.Getenv(spec.envPrefix + "_DISPLAY")); d != "" {
+			display = d
+		}
+		scopes := spec.scopes
+		if s := strings.TrimSpace(os.Getenv(spec.envPrefix + "_SCOPES")); s != "" {
+			scopes = splitScopes(s)
+		}
+		// Subject claim: env override wins, else the spec default (e.g. IBMid "uid"),
+		// else empty → the verifier falls back to the OIDC-standard "sub".
+		subjectClaim := strings.TrimSpace(os.Getenv(spec.envPrefix + "_SUBJECT_CLAIM"))
 		if subjectClaim == "" {
 			subjectClaim = spec.subjectClaim
 		}
 		p := &Provider{
 			Name:         spec.name,
-			DisplayName:  spec.display,
+			DisplayName:  display,
 			IsOIDC:       true,
 			Issuer:       strings.TrimRight(issuer, "/"),
 			ClientID:     clientID,
 			ClientSecret: os.Getenv(spec.envPrefix + "_CLIENT_SECRET"),
-			Scopes:       spec.scopes,
+			Scopes:       scopes,
 			SubjectClaim: subjectClaim,
 		}
 		oidc = append(oidc, p)

--- a/v2/pkg/hub/identity_canonical.go
+++ b/v2/pkg/hub/identity_canonical.go
@@ -36,6 +36,11 @@ var identityProviders = map[string]bool{
 	"google": true,
 	"ibmid":  true,
 	"redhat": true,
+	// Generic/BYO OIDC provider (operator-configured: Okta, Auth0, Entra,
+	// Keycloak, …). Its subjects are namespaced as custom:<sub>, distinct from
+	// every branded provider, so an operator's IdP can never collide identities
+	// with github:/google:/etc.
+	"custom": true,
 }
 
 // legacyProvider is the provider a bare, un-namespaced key is assumed to belong

--- a/v2/pkg/hub/identity_custom_test.go
+++ b/v2/pkg/hub/identity_custom_test.go
@@ -1,0 +1,33 @@
+package hub
+
+import "testing"
+
+// TestCanonical_CustomProvider: the generic "custom" provider is a first-class
+// canonical namespace, distinct from every branded provider, and it accepts the
+// real-world OIDC subject shapes IdPs emit (Okta/Auth0 subs contain '|').
+func TestCanonical_CustomProvider(t *testing.T) {
+	// A path-hostile subject (contains ':') is still rejected.
+	if _, err := makeCanonical("custom", "a:b"); err == nil {
+		t.Fatal("subject with ':' must be rejected")
+	}
+	// A realistic Okta-style subject ('|' is allowed) round-trips, and its
+	// on-disk filename stays path-safe via the -XX- escape.
+	id, err := makeCanonical("custom", "okta|00u123")
+	if err != nil {
+		t.Fatalf("makeCanonical(custom, okta|00u123): %v", err)
+	}
+	if id != "custom:okta|00u123" {
+		t.Errorf("id = %q", id)
+	}
+	stem, err := encodeUserFilename(id)
+	if err != nil {
+		t.Fatalf("encodeUserFilename: %v", err)
+	}
+	if got, ok := decodeUserFilename(stem); !ok || got != id {
+		t.Errorf("filename round-trip: stem=%q got=%q ok=%v", stem, got, ok)
+	}
+	// Cross-provider isolation: custom:x is NOT github:x.
+	if canonicalEqual("custom:x", "github:x") {
+		t.Error("custom:x must NOT equal github:x — cross-provider collision")
+	}
+}


### PR DESCRIPTION
## What
Adds a **`custom`** OIDC provider so an operator can enable **any** standards-compliant OIDC IdP — **Okta, Auth0, Microsoft Entra (single-tenant), Keycloak, Ping, ForgeRock, Dex, Cognito, …** — with **no code change**. This turns "which OIDC providers does hive support?" into "any OIDC-compliant one."

## Config (env-only, mirrors the branded-provider gate)
```
HIVE_HUB_OIDC_CUSTOM_CLIENT_ID       # enables the provider
HIVE_HUB_OIDC_CUSTOM_CLIENT_SECRET
HIVE_HUB_OIDC_CUSTOM_ISSUER          # required; no default
HIVE_HUB_OIDC_CUSTOM_DISPLAY         # picker label; default "Single Sign-On"
HIVE_HUB_OIDC_CUSTOM_SCOPES          # optional; default "openid email profile"
HIVE_HUB_OIDC_CUSTOM_SUBJECT_CLAIM   # optional; default "sub"
```

## Details
- **`custom` is a first-class canonical namespace** (`custom:<sub>`), distinct from `github:`/`google:`/`ibmid:`/`redhat:` — an operator's IdP can never collide identities with a branded provider. Verified that real-world **Okta/Auth0 subjects (which contain `|`)** round-trip through the path-safe on-disk filename encoding.
- The `_DISPLAY` / `_SCOPES` / `_SUBJECT_CLAIM` overrides are honored for **every** provider, not just custom, so any provider can be retuned without a code change.
- A neutral **key** glyph is used in the picker (we can't ship an unknown third party's brand mark).

## Follow-up (not in this PR)
Microsoft Entra **multi-tenant** and Okta multi-tenant need **tenant/issuer-template validation** (the `iss` carries the actual tenant GUID, not `common`). Single-tenant works today via `custom` with the tenant issuer URL. I'll do tenant-aware validation as a separate change.

## Tests
Enable/skip gating, env overrides, default fallbacks, scope parsing, and cross-provider identity isolation. `pkg/auth` coverage 92.9%; hub suite green; `go vet` clean.