### PR TITLE
✨ feat(dashboard): optional hard-delete when removing a knowledge channel

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -7122,6 +7122,9 @@ func (s *Server) handleVaultsDisconnect(w http.ResponseWriter, r *http.Request) 
 
 	var req struct {
 		Path string `json:"path"`
+		// Purge=true deletes the channel's files from disk (destructive), not just
+		// un-indexing it. Defaults false so a plain remove stays non-destructive.
+		Purge bool `json:"purge"`
 	}
 	if err := decodeBody(r, &req); err != nil {
 		jsonError(w, "invalid request body", http.StatusBadRequest)
@@ -7140,6 +7143,15 @@ func (s *Server) handleVaultsDisconnect(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if req.Purge {
+		if err := s.deps.Knowledge.PurgeVault(req.Path); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.auditFromRequest(r, "vault_purge", auditDetail("path", req.Path), "")
+		jsonResponse(w, map[string]interface{}{"ok": true, "removed": req.Path, "purged": true})
+		return
+	}
 	if err := s.deps.Knowledge.DisconnectVault(req.Path); err != nil {
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -10156,7 +10156,9 @@ function burnAreaChart() {
         await hiveAlert('"' + name + '" is a built-in layer, not a removable channel.');
         return;
       }
-      if (!await hiveConfirm('Remove channel "' + name + '"? It stops feeding agents; the imported files stay on disk.', 'Remove channel')) return;
+      if (!await hiveConfirm('Remove channel "' + name + '"? It stops feeding agents. By default the imported files stay on disk (you can re-add the channel later).', 'Remove channel')) return;
+      // Offer the destructive option separately, defaulting to keep-files.
+      const purge = await hiveConfirm('Also DELETE the imported files permanently? This cannot be undone.\n\nOK = delete files · Cancel = keep files on disk', 'Delete files?');
       try {
         // Resolve the channel name → on-disk path from the channels list.
         const listR = await fetch('/api/knowledge/channels');
@@ -10165,7 +10167,7 @@ function burnAreaChart() {
         if (!match || !match.root_dir) { await hiveAlert('Could not resolve the channel path to remove.'); return; }
         const r = await fetch('/api/knowledge/vaults', {
           method: 'DELETE', headers: _inceptionAuthHeaders(),
-          body: JSON.stringify({ path: match.root_dir }),
+          body: JSON.stringify({ path: match.root_dir, purge }),
         });
         const data = await r.json();
         if (!r.ok) { await hiveAlert(data.error || 'Failed to remove channel'); return; }

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -16,8 +16,9 @@ const localKnowledgeDir = "/data/knowledge"
 
 // vaultsBaseDir is where user-created knowledge channels (vaults) are stored on
 // the spoke's data volume, one directory per channel. It mirrors the location the
-// bead synthesizer uses for its own vault.
-const vaultsBaseDir = "/data/vaults"
+// bead synthesizer uses for its own vault. A var (not const) only so purge/create
+// tests can point it at a temp dir; production never reassigns it.
+var vaultsBaseDir = "/data/vaults"
 
 // reservedVaultName is the automation vault the bead synthesizer writes into. It
 // must never be offered to users as an import target nor be creatable/writable by
@@ -601,6 +602,34 @@ func (k *KnowledgeAPI) DisconnectVault(rootDir string) error {
 	}
 	k.vaults = newVaults
 	k.logger.Info("vault disconnected", "dir", rootDir)
+	return nil
+}
+
+// PurgeVault disconnects a vault AND deletes its files from disk. This is the
+// destructive "delete channel" path (vs DisconnectVault, which only un-indexes
+// and leaves files in place). It is guarded hard: the directory MUST live under
+// vaultsBaseDir and MUST NOT be the reserved automation vault — a purge outside
+// the vaults tree, or of bead-synth-wiki, is refused. The disconnect happens
+// first so agents stop reading it before the files vanish.
+func (k *KnowledgeAPI) PurgeVault(rootDir string) error {
+	clean := filepath.Clean(rootDir)
+	base := filepath.Clean(vaultsBaseDir)
+	// Must be strictly inside vaultsBaseDir (not the base itself, not a sibling).
+	if clean == base || !strings.HasPrefix(clean, base+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to purge %q: not inside %s", rootDir, base)
+	}
+	if filepath.Base(clean) == reservedVaultName {
+		return fmt.Errorf("%q is reserved for automation and cannot be purged", reservedVaultName)
+	}
+	// Disconnect first (best effort — a vault may be purged even if it was never
+	// indexed as a connected vault, e.g. a leftover dir), then remove the files.
+	if err := k.DisconnectVault(rootDir); err != nil {
+		k.logger.Info("purge: vault not connected, removing files anyway", "dir", clean, "err", err)
+	}
+	if err := os.RemoveAll(clean); err != nil {
+		return fmt.Errorf("deleting channel files: %w", err)
+	}
+	k.logger.Info("vault purged", "dir", clean)
 	return nil
 }
 

--- a/v2/pkg/knowledge/purge_vault_test.go
+++ b/v2/pkg/knowledge/purge_vault_test.go
@@ -1,0 +1,52 @@
+package knowledge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPurgeVault_RefusesOutsideBase: a purge path outside vaultsBaseDir (or the
+// base itself) is refused — the hard guard against deleting arbitrary dirs.
+func TestPurgeVault_RefusesOutsideBase(t *testing.T) {
+	k := newTestAPI(t)
+	if err := k.PurgeVault("/etc"); err == nil {
+		t.Error("purge outside vaults base must be refused")
+	}
+	if err := k.PurgeVault(vaultsBaseDir); err == nil {
+		t.Error("purge of the base dir itself must be refused")
+	}
+	if err := k.PurgeVault(filepath.Join(vaultsBaseDir, reservedVaultName)); err == nil {
+		t.Error("purge of the reserved vault must be refused")
+	}
+}
+
+// TestPurgeVault_DeletesFiles: a valid channel under a (test-overridden) base is
+// disconnected AND its files removed.
+func TestPurgeVault_DeletesFiles(t *testing.T) {
+	// Point vaultsBaseDir at a temp dir so the guard passes for a real path.
+	orig := vaultsBaseDir
+	tmp := t.TempDir()
+	vaultsBaseDir = tmp
+	t.Cleanup(func() { vaultsBaseDir = orig })
+
+	dir := filepath.Join(tmp, "runbooks")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("# x\n\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	k := newTestAPI(t)
+	_ = k.ConnectVault(dir, "runbooks")
+
+	if err := k.PurgeVault(dir); err != nil {
+		t.Fatalf("PurgeVault: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("channel dir should be gone, stat err=%v", err)
+	}
+	if k.vaultByName("runbooks") != nil {
+		t.Error("channel should be disconnected after purge")
+	}
+}


### PR DESCRIPTION
Follow-up to #3592. Remove-channel was non-destructive (un-index only; files stayed on `/data/vaults/<name>`, so re-adding a same-named channel picked them back up). This adds an **explicit purge** so a user can also delete the files permanently.

- **`KnowledgeAPI.PurgeVault(rootDir)`** — disconnects the vault **and** `os.RemoveAll`s its dir. Guarded hard: the path MUST be strictly inside `vaultsBaseDir` (not the base itself, not a sibling) and MUST NOT be the reserved automation vault; anything else is refused. Disconnect runs before the delete so agents stop reading it first.
- **`DELETE /api/knowledge/vaults`** gains an optional `{purge:true}`; default `false` keeps the existing non-destructive remove.
- **UI**: Remove now asks a second, separately-defaulted question — *"Also DELETE the imported files permanently?"* — OK deletes, Cancel keeps files on disk. Plain remove stays safe; a purge is a deliberate two-step confirm.

Tests: guards (outside-base / base-itself / reserved all refused) + a real purge deleting files and disconnecting. `pkg/knowledge` suite green; `go vet` clean.