### PR TITLE
✨ feat(hub): Microsoft Entra login incl. multi-tenant (tenant-aware issuer)

### DIFF
--- a/v2/pkg/auth/entra_multitenant_test.go
+++ b/v2/pkg/auth/entra_multitenant_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestTenantFromIssuer(t *testing.T) {
+	const tmpl = "https://login.microsoftonline.com/{tenantid}/v2.0"
+	cases := []struct {
+		iss    string
+		want   string
+		wantOK bool
+	}{
+		{"https://login.microsoftonline.com/9188040d-abc/v2.0", "9188040d-abc", true},
+		{"https://login.microsoftonline.com/9188040d-abc/v2.0/", "9188040d-abc", true}, // trailing slash
+		{"https://login.microsoftonline.com//v2.0", "", false},                          // empty tenant
+		{"https://evil.example.com/9188040d/v2.0", "", false},                           // wrong host
+		{"https://login.microsoftonline.com/9188040d/v3.0", "", false},                  // wrong suffix
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := tenantFromIssuer(tmpl, c.iss)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("tenantFromIssuer(%q) = (%q,%v), want (%q,%v)", c.iss, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestBuildRegistry_MicrosoftMultiTenant(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_SECRET", "s")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_TENANT", "organizations")
+	p := BuildRegistry("", "", "").Get("microsoft")
+	if p == nil {
+		t.Fatal("microsoft should be enabled")
+	}
+	if p.Issuer != "https://login.microsoftonline.com/organizations/v2.0" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+	if p.IssuerTemplate != "https://login.microsoftonline.com/{tenantid}/v2.0" {
+		t.Errorf("issuerTemplate = %q (multi-tenant should template it)", p.IssuerTemplate)
+	}
+}
+
+func TestBuildRegistry_MicrosoftSingleTenantIsStrict(t *testing.T) {
+	// A concrete directory GUID → single-tenant: strict issuer, NO template.
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_TENANT", "11112222-3333-4444-5555-666677778888")
+	p := BuildRegistry("", "", "").Get("microsoft")
+	if p == nil {
+		t.Fatal("microsoft should be enabled")
+	}
+	if p.IssuerTemplate != "" {
+		t.Errorf("single-tenant must NOT set a template, got %q", p.IssuerTemplate)
+	}
+	if p.Issuer != "https://login.microsoftonline.com/11112222-3333-4444-5555-666677778888/v2.0" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+}
+
+func TestBuildRegistry_MicrosoftAllowedTenants(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_TENANT", "common")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_ALLOWED_TENANTS", "aaa-111, bbb-222")
+	p := BuildRegistry("", "", "").Get("microsoft")
+	if p == nil || len(p.AllowedTenants) != 2 {
+		t.Fatalf("allowed tenants not parsed: %+v", p)
+	}
+}
+
+// TestVerify_MultiTenant drives a full multi-tenant token verify: the token's iss
+// carries a real tenant GUID, which must match the template, gate on the allowed
+// set, and namespace the subject as "<tenant>.<sub>".
+func TestVerify_MultiTenant(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ms-client"
+	const nonce = "n-ms"
+	const tenant = "9188040d-6c67-4c5b-b112-36a304b66dad"
+	const sub = "AAAAAAAAAAAAAAAAAAAAAA"
+	// The token issuer is the tenant-specific issuer (what Entra actually emits).
+	tokenIss := "https://login.microsoftonline.com/" + tenant + "/v2.0"
+	o.discoveryIssuer = "https://login.microsoftonline.com/{tenantid}/v2.0"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": tokenIss, "aud": clientID, "sub": sub,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce, "name": "MS User", "email": "user@contoso.com",
+	})
+	// Provider validates against the TEMPLATE (not a fixed issuer), and the JWKS/
+	// token endpoints point at our fake server via explicit URLs.
+	p := &Provider{
+		Name: "microsoft", DisplayName: "Microsoft", IsOIDC: true,
+		Issuer:         o.issuer,
+		IssuerTemplate: "https://login.microsoftonline.com/{tenantid}/v2.0",
+		TokenURL:       o.issuer + "/token", JWKSURL: o.issuer + "/jwks",
+		ClientID: clientID, Scopes: []string{"openid"},
+		AllowedTenants: []string{tenant},
+	}
+	claims, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	want := tenant + "." + sub
+	if claims.Subject != want {
+		t.Errorf("subject = %q, want tenant-namespaced %q", claims.Subject, want)
+	}
+}
+
+// TestVerify_MultiTenant_DisallowedTenantRejected: a token from a tenant not in
+// the allowed set is refused even though it's validly signed.
+func TestVerify_MultiTenant_DisallowedTenantRejected(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ms-client"
+	const nonce = "n-ms"
+	tokenIss := "https://login.microsoftonline.com/UNWANTED-TENANT/v2.0"
+	o.discoveryIssuer = "https://login.microsoftonline.com/{tenantid}/v2.0"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": tokenIss, "aud": clientID, "sub": "s",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(), "nonce": nonce,
+	})
+	p := &Provider{
+		Name: "microsoft", IsOIDC: true, Issuer: o.issuer,
+		IssuerTemplate: "https://login.microsoftonline.com/{tenantid}/v2.0",
+		TokenURL:       o.issuer + "/token", JWKSURL: o.issuer + "/jwks",
+		ClientID: clientID, Scopes: []string{"openid"},
+		AllowedTenants: []string{"only-this-tenant"},
+	}
+	if _, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("a token from a disallowed tenant must be rejected")
+	}
+}

--- a/v2/pkg/auth/oidc_provider.go
+++ b/v2/pkg/auth/oidc_provider.go
@@ -91,6 +91,22 @@ type Provider struct {
 	AvatarClaim  string
 	EmailClaim   string
 
+	// IssuerTemplate enables MULTI-TENANT providers (Microsoft Entra "common"/
+	// "organizations", multi-tenant Okta orgs). Multi-tenant issuers embed a
+	// per-tenant id: the discovery/config issuer contains a literal "{tenantid}"
+	// placeholder while each id_token's `iss` carries the REAL tenant id. A single
+	// strict `iss == Issuer` check can't express that, so when IssuerTemplate is
+	// set (e.g. "https://login.microsoftonline.com/{tenantid}/v2.0") the verifier
+	// instead matches the token's `iss` against the template, extracts the tenant,
+	// enforces AllowedTenants (if any), and namespaces the subject as
+	// "<tenant>:<sub>" so identities never collide across tenants. Empty means the
+	// single-tenant strict-issuer path (unchanged).
+	IssuerTemplate string
+	// AllowedTenants optionally restricts a multi-tenant provider to specific
+	// tenant ids (Entra directory GUIDs). Empty = any tenant that satisfies the
+	// template is accepted.
+	AllowedTenants []string
+
 	// discovered caches the OIDC discovery document + JWKS behind mu.
 	mu         sync.Mutex
 	discovered bool
@@ -221,15 +237,37 @@ func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (
 		return key, nil
 	}
 
-	parser := jwt.NewParser(
+	// Issuer validation differs for single- vs multi-tenant. Single-tenant: the
+	// jwt parser enforces iss == p.Issuer. Multi-tenant: iss is per-tenant, so we
+	// validate it against IssuerTemplate ourselves AFTER parsing (below) and do
+	// NOT pin a fixed issuer here.
+	parserOpts := []jwt.ParserOption{
 		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512"}),
-		jwt.WithIssuer(p.Issuer),
 		jwt.WithAudience(p.ClientID),
 		jwt.WithExpirationRequired(),
-	)
+	}
+	if p.IssuerTemplate == "" {
+		parserOpts = append(parserOpts, jwt.WithIssuer(p.Issuer))
+	}
+	parser := jwt.NewParser(parserOpts...)
 	claims := jwt.MapClaims{}
 	if _, err := parser.ParseWithClaims(raw, claims, keyFunc); err != nil {
 		return nil, fmt.Errorf("id_token verification failed: %w", err)
+	}
+
+	// Multi-tenant: match the token issuer against the template, extract + gate the
+	// tenant. Fails closed on a non-matching iss or a disallowed tenant.
+	tenant := ""
+	if p.IssuerTemplate != "" {
+		iss, _ := claims["iss"].(string)
+		t, ok := tenantFromIssuer(p.IssuerTemplate, iss)
+		if !ok {
+			return nil, fmt.Errorf("id_token issuer %q does not match template %q", iss, p.IssuerTemplate)
+		}
+		if len(p.AllowedTenants) > 0 && !containsFold(p.AllowedTenants, t) {
+			return nil, fmt.Errorf("id_token tenant %q is not in the allowed set", t)
+		}
+		tenant = t
 	}
 
 	// Nonce binds the id_token to the login THIS browser started (replay/
@@ -251,12 +289,58 @@ func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (
 	if sub == "" {
 		return nil, errors.New("id_token has no subject")
 	}
+	// Multi-tenant: namespace the subject by tenant so the SAME sub value in two
+	// different tenants yields two distinct identities ("<tenant>:<sub>"). A bare
+	// sub is per-issuer-unique, and in multi-tenant mode the issuer varies, so
+	// without this two tenants could collide. Uses a '.' separator, not ':',
+	// because ':' is the canonical provider separator upstream.
+	if tenant != "" {
+		sub = tenant + "." + sub
+	}
 	return &Claims{
 		Subject:   sub,
 		Name:      stringClaim(claims, p.claimName(p.NameClaim, claimName)),
 		AvatarURL: stringClaim(claims, p.claimName(p.AvatarClaim, claimPicture)),
 		Email:     stringClaim(claims, p.claimName(p.EmailClaim, claimEmail)),
 	}, nil
+}
+
+// tenantFromIssuer matches a concrete token issuer against a template containing
+// a single "{tenantid}" placeholder and returns the substituted tenant value.
+// The non-placeholder parts must match exactly (trailing slashes normalized), and
+// the tenant must be a plausible id (non-empty, no '/'). Returns ok=false on any
+// mismatch — this is a security check, so it fails closed.
+func tenantFromIssuer(template, iss string) (string, bool) {
+	const ph = "{tenantid}"
+	i := strings.Index(template, ph)
+	if i < 0 || iss == "" {
+		return "", false
+	}
+	prefix := template[:i]
+	suffix := template[i+len(ph):]
+	// Normalize trailing slashes on the whole strings before splitting.
+	iss = strings.TrimRight(iss, "/")
+	suffix = strings.TrimRight(suffix, "/")
+	if !strings.HasPrefix(iss, prefix) || !strings.HasSuffix(iss, suffix) {
+		return "", false
+	}
+	tenant := iss[len(prefix) : len(iss)-len(suffix)]
+	tenant = strings.Trim(tenant, "/")
+	if tenant == "" || strings.ContainsAny(tenant, "/{}") {
+		return "", false
+	}
+	return tenant, true
+}
+
+// containsFold reports whether s is in list, case-insensitively (tenant GUIDs are
+// case-insensitive).
+func containsFold(list []string, s string) bool {
+	for _, x := range list {
+		if strings.EqualFold(strings.TrimSpace(x), s) {
+			return true
+		}
+	}
+	return false
 }
 
 // keyForKID returns the RSA public key for a JWKS key id, fetching/refreshing the
@@ -307,12 +391,20 @@ func (p *Provider) ensureDiscovered(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Discovery's issuer MUST be present AND equal the configured issuer. This
+	// Discovery's issuer MUST be present AND consistent with configuration. This
 	// prevents a swapped/hostile discovery doc from redirecting token/JWKS to an
-	// attacker origin. Requiring it (rather than skipping the check when the doc
-	// omits `issuer`) closes the downgrade where a doc with no issuer but hostile
-	// jwks_uri would be trusted; per OIDC Discovery the issuer field is REQUIRED.
-	if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(p.Issuer, "/") {
+	// attacker origin. Per OIDC Discovery the issuer field is REQUIRED.
+	//
+	// Single-tenant: strict equality with p.Issuer.
+	// Multi-tenant: the doc's issuer legitimately carries the "{tenantid}"
+	// placeholder (e.g. Entra's common/organizations metadata), so it must equal
+	// the configured IssuerTemplate instead — still an exact, non-attacker-
+	// controllable match, just against the templated form.
+	if p.IssuerTemplate != "" {
+		if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(p.IssuerTemplate, "/") {
+			return fmt.Errorf("discovery issuer %q != configured issuer template %q", doc.Issuer, p.IssuerTemplate)
+		}
+	} else if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(p.Issuer, "/") {
 		return fmt.Errorf("discovery issuer %q != configured issuer %q", doc.Issuer, p.Issuer)
 	}
 	p.mu.Lock()

--- a/v2/pkg/auth/oidc_provider_test.go
+++ b/v2/pkg/auth/oidc_provider_test.go
@@ -24,6 +24,10 @@ type oidcTestServer struct {
 	key    *rsa.PrivateKey
 	kid    string
 	issuer string
+	// discoveryIssuer, when set, is served as the discovery doc's `issuer` instead
+	// of the server URL. Multi-tenant tests set this to the "{tenantid}" template
+	// so ensureDiscovered's template cross-check passes (real Entra does the same).
+	discoveryIssuer string
 	// idToken is what the token endpoint returns for any code.
 	idToken string
 }
@@ -37,8 +41,12 @@ func newOIDCTestServer(t *testing.T) *oidcTestServer {
 	ots := &oidcTestServer{key: key, kid: "test-kid-1"}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		iss := ots.issuer
+		if ots.discoveryIssuer != "" {
+			iss = ots.discoveryIssuer
+		}
 		json.NewEncoder(w).Encode(map[string]string{
-			"issuer":                 ots.issuer,
+			"issuer":                 iss,
 			"authorization_endpoint": ots.issuer + "/authorize",
 			"token_endpoint":         ots.issuer + "/token",
 			"jwks_uri":               ots.issuer + "/jwks",

--- a/v2/pkg/auth/registry.go
+++ b/v2/pkg/auth/registry.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -118,6 +119,15 @@ type oidcProviderSpec struct {
 	// be the key. An env override (<PREFIX>_SUBJECT_CLAIM) lets us retune from a
 	// real token without a code change if IBMid does emit a usable "sub".
 	subjectClaim string
+	// multiTenant marks a provider whose issuer is per-tenant (Microsoft Entra
+	// common/organizations). When set, <PREFIX>_TENANT selects the tenant segment
+	// used for DISCOVERY ("common"/"organizations"/a specific directory GUID),
+	// while token validation uses issuerTemplateFmt with a "{tenantid}" marker so
+	// each token's real tenant is matched + namespaced.
+	multiTenant bool
+	// issuerTemplateFmt is the issuer with a "%s" for the tenant segment, e.g.
+	// "https://login.microsoftonline.com/%s/v2.0".
+	issuerTemplateFmt string
 }
 
 // oidcSpecs is the closed set of OIDC providers the hub can enable. A provider is
@@ -149,6 +159,22 @@ var oidcSpecs = []oidcProviderSpec{
 		defaultIssuer: "https://sso.redhat.com/auth/realms/redhat-external",
 		envPrefix:     "HIVE_HUB_OIDC_REDHAT",
 		scopes:        []string{"openid", "email", "profile"},
+	},
+	{
+		// Microsoft Entra ID (Azure AD). Multi-tenant capable: HIVE_HUB_OIDC_
+		// MICROSOFT_TENANT selects the tenant segment for discovery — a specific
+		// directory GUID for SINGLE-tenant, or "common"/"organizations" for
+		// MULTI-tenant. In multi-tenant mode each token's real tenant is validated
+		// against the issuer template and the subject is namespaced per tenant;
+		// HIVE_HUB_OIDC_MICROSOFT_ALLOWED_TENANTS optionally restricts which tenants
+		// may sign in. Free to set up: any Microsoft 365 / Entra tenant (incl. the
+		// free M365 Developer Program) can register an app at no cost.
+		name:              "microsoft",
+		display:           "Microsoft",
+		envPrefix:         "HIVE_HUB_OIDC_MICROSOFT",
+		scopes:            []string{"openid", "email", "profile"},
+		multiTenant:       true,
+		issuerTemplateFmt: "https://login.microsoftonline.com/%s/v2.0",
 	},
 	{
 		// Generic/BYO OIDC provider. Lets an operator wire ANY standards-compliant
@@ -200,9 +226,30 @@ func BuildRegistry(githubClientID, ghAuthorizeURL, ghTokenURL string) *Registry 
 		if clientID == "" {
 			continue // provider not configured → not enabled
 		}
-		issuer := os.Getenv(spec.envPrefix + "_ISSUER")
-		if issuer == "" {
-			issuer = spec.defaultIssuer
+		// Resolve issuer. Multi-tenant providers (Microsoft Entra) derive it from a
+		// tenant segment; everyone else uses _ISSUER or the spec default.
+		var issuer, issuerTemplate string
+		var allowedTenants []string
+		if spec.multiTenant {
+			tenant := strings.TrimSpace(os.Getenv(spec.envPrefix + "_TENANT"))
+			if tenant == "" {
+				tenant = "organizations" // sensible default: any work/school Entra org
+			}
+			issuer = fmt.Sprintf(spec.issuerTemplateFmt, tenant)
+			// A concrete directory GUID is single-tenant (strict issuer); the
+			// well-known multi-tenant segments need the {tenantid} template so each
+			// token's real tenant is validated + namespaced.
+			if tenant == "common" || tenant == "organizations" || tenant == "consumers" {
+				issuerTemplate = fmt.Sprintf(spec.issuerTemplateFmt, "{tenantid}")
+			}
+			if a := strings.TrimSpace(os.Getenv(spec.envPrefix + "_ALLOWED_TENANTS")); a != "" {
+				allowedTenants = splitScopes(a) // reuse comma/space splitter
+			}
+		} else {
+			issuer = os.Getenv(spec.envPrefix + "_ISSUER")
+			if issuer == "" {
+				issuer = spec.defaultIssuer
+			}
 		}
 		if issuer == "" {
 			// Configured client id but no issuer we can use → skip, don't crash.
@@ -226,14 +273,16 @@ func BuildRegistry(githubClientID, ghAuthorizeURL, ghTokenURL string) *Registry 
 			subjectClaim = spec.subjectClaim
 		}
 		p := &Provider{
-			Name:         spec.name,
-			DisplayName:  display,
-			IsOIDC:       true,
-			Issuer:       strings.TrimRight(issuer, "/"),
-			ClientID:     clientID,
-			ClientSecret: os.Getenv(spec.envPrefix + "_CLIENT_SECRET"),
-			Scopes:       scopes,
-			SubjectClaim: subjectClaim,
+			Name:           spec.name,
+			DisplayName:    display,
+			IsOIDC:         true,
+			Issuer:         strings.TrimRight(issuer, "/"),
+			IssuerTemplate: strings.TrimRight(issuerTemplate, "/"),
+			AllowedTenants: allowedTenants,
+			ClientID:       clientID,
+			ClientSecret:   os.Getenv(spec.envPrefix + "_CLIENT_SECRET"),
+			Scopes:         scopes,
+			SubjectClaim:   subjectClaim,
 		}
 		oidc = append(oidc, p)
 	}

--- a/v2/pkg/hub/identity_canonical.go
+++ b/v2/pkg/hub/identity_canonical.go
@@ -41,6 +41,9 @@ var identityProviders = map[string]bool{
 	// every branded provider, so an operator's IdP can never collide identities
 	// with github:/google:/etc.
 	"custom": true,
+	// Microsoft Entra ID (Azure AD), single- or multi-tenant. Multi-tenant subjects
+	// are namespaced per Entra tenant inside the OIDC layer before this sees them.
+	"microsoft": true,
 }
 
 // legacyProvider is the provider a bare, un-namespaced key is assumed to belong

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -345,6 +345,9 @@ func providerGlyph(name string) string {
 		return `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M2 4h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2z"/></svg>`
 	case "redhat":
 		return `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>`
+	case "microsoft":
+		// Microsoft's four-square logo (official brand colors).
+		return `<svg viewBox="0 0 23 23" aria-hidden="true"><path fill="#F25022" d="M0 0h11v11H0z"/><path fill="#7FBA00" d="M12 0h11v11H12z"/><path fill="#00A4EF" d="M0 12h11v11H0z"/><path fill="#FFB900" d="M12 12h11v11H12z"/></svg>`
 	case "custom":
 		// Generic OIDC provider (operator-configured): a neutral key mark, since
 		// we can't ship a third party's brand logo we don't know in advance.


### PR DESCRIPTION
Adds **Microsoft Entra ID (Azure AD)** as a first-class provider, and gives the OIDC layer the **tenant-aware issuer validation** multi-tenant providers require (the follow-up flagged in #3590).

## The multi-tenant problem this solves
With a `common`/`organizations` issuer, each id_token's `iss` carries the **real tenant GUID**, not `common` — so a single strict `iss == Issuer` check fails. This adds:
- **`Provider.IssuerTemplate` + `AllowedTenants`.** When `IssuerTemplate` is set, the verifier matches the token's `iss` against the `{tenantid}` template, extracts the tenant, enforces `AllowedTenants` (if set), and **namespaces the subject as `<tenant>.<sub>`** so the same sub in two tenants stays two identities. The discovery cross-check accepts the templated issuer (Entra's common/organizations metadata returns it literally). Single-tenant is unchanged (strict).
- **`tenantFromIssuer` fails closed**: wrong host/suffix, empty tenant, or path/brace chars in the tenant are all rejected.

## Config
```
HIVE_HUB_OIDC_MICROSOFT_CLIENT_ID
HIVE_HUB_OIDC_MICROSOFT_CLIENT_SECRET
HIVE_HUB_OIDC_MICROSOFT_TENANT           # directory GUID = single-tenant (strict);
                                         # common/organizations/consumers = multi-tenant
HIVE_HUB_OIDC_MICROSOFT_ALLOWED_TENANTS  # optional: restrict which tenants may sign in
```
`microsoft` is a canonical identity namespace; the picker shows Microsoft's four-square logo.

## Free setup
Any Microsoft 365 / Entra tenant (incl. the **free M365 Developer Program**) registers an app at no cost.

## Tests
`tenantFromIssuer` table, single- vs multi-tenant registry wiring, allowed-tenants parsing, and end-to-end multi-tenant verify (subject namespacing + disallowed-tenant rejection). `pkg/auth` coverage 93.5%; hub builds; `go vet` clean.