### PR TITLE
🔒 fix(proxy): verify Ed25519 session cookies on v2 spokes (F10/N2)

### DIFF
--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -2,12 +2,12 @@
   "name": "hive-dashboard-proxy",
   "version": "2.0.0",
   "private": true,
-  "description": "Thin proxy: auth + static files → Go binary API",
+  "description": "Thin proxy: auth + static files \u2192 Go binary API",
   "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js"
+    "test": "node server.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node session_cookie_v3.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -57,6 +57,192 @@ function verifyHubUserCookie(secret, value) {
   return username;
 }
 
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F10 / N2: Ed25519 session-cookie verification (ported from v4).
+//
+// This proxy previously verified ONLY the symmetric HMAC cookie. That is the
+// weakest of the three formats the hub can emit and — because the session key
+// is derived from a master every spoke holds — it is forgeable by any spoke.
+//
+// Dispatch is on the MARKER INSIDE THE VALUE, not on the cookie name, so this
+// works whether the value arrives as `hive_hub_user` or `hive_hub_user_v2`
+// (the v2 hub emits both; see #3272). No new cookie name is required.
+//
+// VERIFIER ONLY: nothing here mints. The hub still mints v2-format values, so
+// behaviour is unchanged at deploy — this simply lets a spoke ACCEPT the
+// stronger formats once the hub begins emitting them.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// INFO_SESSION_ED25519_SEED must stay byte-identical to infoSessionEd25519Seed
+// in v2/pkg/hub/hub_keys.go — verified identical on v2 and v4.
+const INFO_SESSION_ED25519_SEED = 'hive-session-ed25519-v1';
+
+function deriveSessionPublicKey() {
+  const explicit = (process.env.HIVE_SESSION_PUBLIC_KEY || '').trim();
+  if (explicit) return explicit;
+  const master = (process.env.HIVE_HUB_SECRET || '').trim();
+  if (!master) return '';
+  const seedHex = crypto.createHmac('sha256', master).update(INFO_SESSION_ED25519_SEED).digest('hex');
+  try {
+    // Node cannot expand a raw Ed25519 seed directly, so wrap it in the PKCS#8
+    // prefix for a 32-byte Ed25519 private key and export the public half. This
+    // mirrors Go's ed25519.NewKeyFromSeed(seed).Public().
+    const pkcs8 = Buffer.concat([
+      Buffer.from('302e020100300506032b657004220420', 'hex'),
+      Buffer.from(seedHex, 'hex'),
+    ]);
+    const priv = crypto.createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+    const spki = crypto.createPublicKey(priv).export({ format: 'der', type: 'spki' });
+    // Strip the 12-byte SPKI header to get the raw 32-byte public key, matching
+    // the hex encoding the hub ships in HIVE_SESSION_PUBLIC_KEY.
+    return Buffer.from(spki.subarray(spki.length - 32)).toString('hex');
+  } catch (_) {
+    return '';
+  }
+}
+
+const SESSION_PUBLIC_KEY = deriveSessionPublicKey();
+
+// HUB_COOKIE_V2_MARKER separates the username from its Ed25519 signature.
+const HUB_COOKIE_V2_MARKER = '.v2.';
+
+// verifyHubUserCookieV2 mirrors verifyHubUserCookieValueV2 in
+// v2/pkg/hub/hub_cookie.go EXACTLY: value is `<username>.v2.<base64url(sig)>`
+// where sig is Ed25519 over the username, verified against the hub's PUBLIC key.
+// Returns the verified username, or '' on any failure.
+function verifyHubUserCookieV2(pubHex, value) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(HUB_COOKIE_V2_MARKER);
+  if (idx <= 0) return '';
+  const username = value.slice(0, idx);
+  const sigB64 = value.slice(idx + HUB_COOKIE_V2_MARKER.length);
+  if (!username || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    // Wrap the raw 32-byte key in its SPKI header so Node can import it.
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    const sig = Buffer.from(sigB64, 'base64url');
+    return crypto.verify(null, Buffer.from(username), pub, sig) ? username : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+// HUB_COOKIE_V3_MARKER separates the signed claims payload from its Ed25519
+// signature. Must stay byte-identical to hubCookieV3Marker in
+// v2/pkg/hub/hub_cookie.go.
+const HUB_COOKIE_V3_MARKER = '.v3.';
+
+// HUB_COOKIE_CLOCK_SKEW_SECONDS mirrors ssoClockSkew in v2/pkg/hub/sso.go. The
+// hub and this spoke are separate clusters with separate clocks; without a
+// tolerance a freshly minted cookie is rejected by a spoke running seconds
+// ahead of the hub.
+const HUB_COOKIE_CLOCK_SKEW_SECONDS = 30;
+
+// verifyHubUserCookieV3 mirrors verifyHubUserCookieValueV3 in
+// v2/pkg/hub/hub_cookie.go EXACTLY.
+//
+// AUDIT F10: the v2 cookie signs only the username, so its lifetime lives in the
+// browser's MaxAge — which is a hint the browser may ignore and a copied cookie
+// never had in the first place. v3 moves the claims inside the signature:
+//
+//   value = base64url(JSON{u,iat,exp,sid}) + '.v3.' + base64url(Ed25519 sig)
+//
+// so this proxy can enforce the expiry itself rather than trusting the browser.
+//
+// The JSON keys (u/iat/exp/sid) and the base64url alphabet are a FROZEN wire
+// contract with the Go hub. If the two sides disagree by a single byte, every
+// hosted login breaks at deploy — silently, and production-only, because nothing
+// but a real hub-minted cookie exercises the disagreement. session_cookie_v3.test.js
+// pins Go-minted vectors for exactly this reason.
+//
+// Revocation is deliberately NOT checked here: the spoke has no revocation store
+// and asking the hub would put a network dependency on the terminal path. The
+// spoke enforces signature + expiry; the hub additionally enforces revocation.
+//
+// Returns the verified username, or '' on any failure.
+
+// verifyHubUserCookieV3 mirrors verifyHubUserCookieValueV3 in
+// v2/pkg/hub/hub_cookie.go EXACTLY.
+//
+// AUDIT F10: the v2 cookie signs only the username, so its lifetime lives in the
+// browser's MaxAge — which is a hint the browser may ignore and a copied cookie
+// never had in the first place. v3 moves the claims inside the signature:
+//
+//   value = base64url(JSON{u,iat,exp,sid}) + '.v3.' + base64url(Ed25519 sig)
+//
+// so this proxy can enforce the expiry itself rather than trusting the browser.
+//
+// The JSON keys (u/iat/exp/sid) and the base64url alphabet are a FROZEN wire
+// contract with the Go hub. If the two sides disagree by a single byte, every
+// hosted login breaks at deploy — silently, and production-only, because nothing
+// but a real hub-minted cookie exercises the disagreement. session_cookie_v3.test.js
+// pins Go-minted vectors for exactly this reason.
+//
+// Revocation is deliberately NOT checked here: the spoke has no revocation store
+// and asking the hub would put a network dependency on the terminal path. The
+// spoke enforces signature + expiry; the hub additionally enforces revocation.
+//
+// Returns the verified username, or '' on any failure.
+function verifyHubUserCookieV3(pubHex, value, nowSeconds) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(HUB_COOKIE_V3_MARKER);
+  if (idx <= 0) return '';
+  const body = value.slice(0, idx);
+  const sigB64 = value.slice(idx + HUB_COOKIE_V3_MARKER.length);
+  if (!body || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    // Wrap the raw 32-byte key in its SPKI header so Node can import it.
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    const sig = Buffer.from(sigB64, 'base64url');
+    // Verify the signature over the ENCODED body BEFORE parsing any payload
+    // byte — never let attacker-controlled JSON reach the parser first.
+    if (!crypto.verify(null, Buffer.from(body), pub, sig)) return '';
+    const claims = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+    if (!claims || typeof claims.u !== 'string' || !claims.u) return '';
+    if (typeof claims.sid !== 'string' || !claims.sid) return '';
+    if (typeof claims.iat !== 'number' || typeof claims.exp !== 'number') return '';
+    const now = Number.isFinite(nowSeconds) ? nowSeconds : Math.floor(Date.now() / 1000);
+    if (claims.iat > now + HUB_COOKIE_CLOCK_SKEW_SECONDS) return ''; // not yet valid
+    if (claims.exp < now - HUB_COOKIE_CLOCK_SKEW_SECONDS) return ''; // expired
+    return claims.u;
+  } catch (_) {
+    return '';
+  }
+}
+
+// verifyHubUserCookieEither accepts a v3 (F10: signed lifetime), a v2 (Ed25519)
+// cookie or, during the rollout window only, a legacy HMAC one — mirroring the Go
+// helper of the same name. Lanes are tried v3 → v2 → legacy.
+//
+// The v2 and legacy branches are STRICTLY additive compatibility paths. Removing
+// either one 401s every part of the fleet that has not rolled. The legacy branch
+// is additionally the N2 vulnerability (verify-capable implies mint-capable) and
+// is removed once the fleet has rolled and existing cookies have aged out.
+
+// verifyHubUserCookieEither accepts a v3 (F10: signed lifetime), a v2 (Ed25519)
+// cookie or, during the rollout window only, a legacy HMAC one — mirroring the Go
+// helper of the same name. Lanes are tried v3 → v2 → legacy.
+//
+// The v2 and legacy branches are STRICTLY additive compatibility paths. Removing
+// either one 401s every part of the fleet that has not rolled. The legacy branch
+// is additionally the N2 vulnerability (verify-capable implies mint-capable) and
+// is removed once the fleet has rolled and existing cookies have aged out.
+function verifyHubUserCookieEither(pubHex, legacySecret, value) {
+  const v3 = verifyHubUserCookieV3(pubHex, value);
+  if (v3) return v3;
+  const v2 = verifyHubUserCookieV2(pubHex, value);
+  if (v2) return v2;
+  return verifyHubUserCookie(legacySecret, value);
+}
+
+
 // parseCookies is shared by the HTTP and WebSocket terminal gates so the two
 // cannot drift — they are equally exploitable and must stay in lockstep.
 function parseCookies(header) {
@@ -255,7 +441,12 @@ app.use('/terminal', (req, res, next) => {
     // verify must deny, not wave everyone through — that is the same bug in a
     // different disguise.
     const cookies = parseCookies(req.headers.cookie);
-    const user = verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user']);
+    // Accept the strongest format present: v3 (signed lifetime + revocable sid)
+    // → v2 (Ed25519) → legacy HMAC. Additive — never rejects a value the
+    // HMAC-only check would have accepted.
+    const user = verifyHubUserCookieEither(
+      SESSION_PUBLIC_KEY, SESSION_KEY,
+      cookies['hive_hub_user_v2'] || cookies['hive_hub_user']);
     if (!user) {
       if (req.headers.upgrade === 'websocket') {
         req.socket.destroy();
@@ -340,7 +531,9 @@ server.on('upgrade', (req, socket, head) => {
       // path on presence-only would leave the hole fully open — the HTTP fix
       // alone would be security theatre.
       const cookies = parseCookies(req.headers.cookie);
-      if (!verifyHubUserCookie(SESSION_KEY, cookies['hive_hub_user'])) {
+      if (!verifyHubUserCookieEither(
+        SESSION_PUBLIC_KEY, SESSION_KEY,
+        cookies['hive_hub_user_v2'] || cookies['hive_hub_user'])) {
         socket.destroy();
         return;
       }

--- a/v2/proxy/session_cookie_v3.test.js
+++ b/v2/proxy/session_cookie_v3.test.js
@@ -1,0 +1,136 @@
+// Cross-language session-cookie vectors, frozen from the REAL Go minter.
+//
+// WHY THIS FILE EXISTS
+// The hub session cookie is MINTED in Go (v2/pkg/hub/hub_cookie.go) and
+// VERIFIED here in JavaScript. If the two disagree by a single byte — base64
+// alphabet, JSON field order, marker placement — every hosted login breaks at
+// deploy, silently, and only in production. A Node-generated vector would only
+// prove Node agrees with itself, so every value below was minted by the actual
+// Go code and pasted verbatim.
+//
+// If one of these fails, do NOT edit the expected value. Find out which side
+// changed its encoding.
+//
+// Run: node session_cookie_v3.test.js
+
+import { createServer, request as httpRequest } from 'http';
+import { WebSocketServer } from 'ws';
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import assert from 'assert';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROXY_PORT = 19111;
+const GO_PORT = 19112;
+const TTYD_PORT = 19113;
+const HOSTED_HOST = 'hive-v3.hive.kubestellar.io';
+const MASTER = 'f3-test-master-secret';
+
+// Minted by Go with the master above at iat=1700000000 (in the PAST, so the vector is valid now; a future iat is correctly rejected as not-yet-valid). V3_VALID carries a
+// deliberately LONG ttl so the frozen vector cannot rot out of its validity
+// window and start failing for a reason unrelated to encoding agreement;
+// V3_EXPIRED keeps a 1h ttl and is therefore always in the past.
+const V3_VALID   = 'eyJ1IjoiY2x1YmFuZGVyc29uIiwiaWF0IjoxNzAwMDAwMDAwLCJleHAiOjM1MDAwMDAwMDAsInNpZCI6Ijk3NjMzYjI1MWI0YmUzMjUwMmY2ZTQ0MjkyZjBlYzI3ZDk3Y2UxY2FjNzJlZGFmNjliOTBkYTdmMGUxMzBiZTUifQ.v3.ijJ_P2d5GrZqFOSnd5-c4ImJ_ItpPx_7ts_YI9lcV665ATC7EpTmGLD-awrcjkX7DtMs3GhE3cVOt2AvgKV7Ag';
+const V2_VALID   = 'clubanderson.v2.qcKTjay3VjXCiaQ8qRUebT0ElrS4T0G0wiuegEZ6acIC3f8QNDG33K1o4tTZ7GKa_RQQtZH0Tsii1i8Tu0JdAw';
+const V3_EXPIRED = 'eyJ1IjoiY2x1YmFuZGVyc29uIiwiaWF0IjoxNzAwMDAwMDAwLCJleHAiOjE3MDAwMDM2MDAsInNpZCI6Ijg3YzI4MDVhZjg1NTA2YzI1YTExNWQ0MDBmMGM4ZmM0OTQwMDM1NTJhOWUwYTM4ODIyNjk0Yjk0MDhlZDVlZmIifQ.v3.2wu1P0WD70mVNev2AGfsISvz58sU3MpQ_00Ga4eqtB2wvOWcz9pKZ3ane8P2xQfgH7PXKeBd27TT0AScUMrmDg';
+
+function mockBackend(port, body) {
+  return new Promise(resolve => {
+    const s = createServer((req, res) => { res.writeHead(200); res.end(body); });
+    s.listen(port, () => resolve(s));
+  });
+}
+// ttyd must speak WebSocket: a plain HTTP mock makes the "valid cookie opens a
+// shell" control fail for the wrong reason.
+function mockTtydWS(port) {
+  return new Promise(resolve => {
+    const s = createServer((req, res) => { res.writeHead(200); res.end('ttyd'); });
+    const wss = new WebSocketServer({ server: s });
+    wss.on('connection', ws => ws.send('shell'));
+    s.listen(port, () => resolve(s));
+  });
+}
+function startProxy() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: { ...process.env,
+        HIVE_PROXY_PORT: String(PROXY_PORT), HIVE_API_PORT: String(GO_PORT),
+        HIVE_TTYD_PORT: String(TTYD_PORT), HIVE_DASHBOARD_TOKEN: '',
+        HIVE_STATIC_DIR: __dirname, HIVE_HUB_SECRET: MASTER, NODE_ENV: 'test' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', d => {
+      if (!started && d.toString().includes('hive-proxy')) { started = true; resolve(proc); }
+    });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('proxy start timeout')); }, 10000);
+  });
+}
+// http.request, not fetch(): fetch silently DROPS a custom Host header, so the
+// proxy would take the non-hosted branch and the gate would never run.
+function terminalHTTP(cookieName, cookieVal) {
+  return new Promise((resolve, reject) => {
+    const headers = { Host: HOSTED_HOST };
+    if (cookieVal !== null) headers.Cookie = `${cookieName}=${cookieVal}`;
+    const req = httpRequest({ host: '127.0.0.1', port: PROXY_PORT, path: '/terminal',
+      method: 'GET', headers }, res => { res.resume(); resolve(res.statusCode); });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+let go, ttyd, proxy, pass = 0, fail = 0;
+async function check(name, fn) {
+  try { await fn(); console.log('  \u2713 ' + name); pass++; }
+  catch (e) { console.error('  \u2717 ' + name + ': ' + e.message); fail++; }
+}
+
+try {
+  go = await mockBackend(GO_PORT, 'go');
+  ttyd = await mockTtydWS(TTYD_PORT);
+  proxy = await startProxy();
+  await new Promise(r => setTimeout(r, 400));
+
+  // A Go-minted v3 value must be ACCEPTED by the Node verifier. Before this
+  // change the proxy understood only the HMAC format and would 401 it.
+  await check('Go-minted v3 cookie is accepted (hive_hub_user)', async () => {
+    const s = await terminalHTTP('hive_hub_user', V3_VALID);
+    assert.notStrictEqual(s, 401, `expected the v3 vector to authenticate, got ${s}`);
+  });
+
+  // The v2 hub emits the Ed25519 value under a SECOND cookie name. Dispatch is
+  // on the marker inside the value, so this must work too.
+  await check('Go-minted v2 cookie is accepted (hive_hub_user_v2)', async () => {
+    const s = await terminalHTTP('hive_hub_user_v2', V2_VALID);
+    assert.notStrictEqual(s, 401, `expected the v2 vector to authenticate, got ${s}`);
+  });
+
+  // NEGATIVE CONTROLS — the verifier must not have become a rubber stamp.
+  await check('EXPIRED v3 is rejected (signed lifetime enforced)', async () => {
+    const s = await terminalHTTP('hive_hub_user', V3_EXPIRED);
+    assert.strictEqual(s, 401, `an expired v3 cookie authenticated (got ${s})`);
+  });
+  await check('tampered v3 payload is rejected', async () => {
+    const bad = 'X' + V3_VALID.slice(1);
+    const s = await terminalHTTP('hive_hub_user', bad);
+    assert.strictEqual(s, 401, `a tampered v3 cookie authenticated (got ${s})`);
+  });
+  await check('no cookie is rejected', async () => {
+    const s = await terminalHTTP('hive_hub_user', null);
+    assert.strictEqual(s, 401, `no cookie authenticated (got ${s})`);
+  });
+  await check('garbage value is rejected', async () => {
+    const s = await terminalHTTP('hive_hub_user', 'x');
+    assert.strictEqual(s, 401, `a garbage cookie authenticated (got ${s})`);
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+} finally {
+  if (proxy) proxy.kill();
+  if (go) go.close();
+  if (ttyd) ttyd.close();
+}
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## What

v2's proxy verified **only the symmetric HMAC cookie** — the weakest of the three formats the hub can emit, and forgeable by any spoke since the session key derives from a master every spoke holds. It had **zero** references to `SESSION_PUBLIC_KEY`: no Ed25519 lane at all, not even v2's.

This is the **second of the two blockers** on the F10 mint flip. The Go half landed in #3580; this is the Node half.

## No new cookie name is needed — I was wrong about that

I previously said this would need a **third cookie name**, since the v2 hub emits two (`hive_hub_user` HMAC, `hive_hub_user_v2` Ed25519). Reading v4 disproved it: dispatch is on the **marker inside the value**, not on the name. Both gates now read either cookie and let the marker decide, exactly as v4 does.

## Verifier only

Nothing here mints. The hub still emits v2-format values, so **behaviour is unchanged at deploy** — this only lets a spoke *accept* the stronger formats once the hub begins emitting them.

## Frozen cross-language vectors

The cookie is minted in Go and verified in JavaScript. A one-byte disagreement — base64 alphabet, JSON field order, marker placement — breaks **every hosted login** at deploy, silently and production-only.

`session_cookie_v3.test.js` drives the **real proxy over HTTP** with values minted by the **real Go minter**. A Node-generated vector would only prove Node agrees with itself. Wired into `npm test`.

## Three bugs the tests caught — none visible to `node --check`

1. **`INFO_SESSION_ED25519_SEED` missing** → the proxy failed to **boot**. Only an actual boot finds this; `node --check` passes it cleanly. (Same class as the TDZ crash during N4.)
2. **`HUB_COOKIE_V2_MARKER` missing** → the v2 lane **threw**, so every unrecognised cookie returned **500 instead of 401**. A crash, not a rejection — and a 500 on an auth path is its own problem.
3. **My first two vector sets used a future `iat`** (`1800000000`), which the verifier correctly rejects as *not yet valid*. The bug was my generator, not the code. Regenerated with a past `iat` and a long TTL so the frozen vector can't rot and start failing for a reason unrelated to encoding agreement.

## Verification

```
with the fix        6 passed, 0 failed
gates reverted to HMAC-only:
  ✗ Go-minted v3 cookie is accepted ... got 401
  ✗ Go-minted v2 cookie is accepted ... got 401
  ✓ EXPIRED v3 rejected      ✓ tampered v3 rejected
  ✓ no cookie rejected       ✓ garbage rejected
```

The four negative controls stay green in **both** states, so the suite cannot pass by breaking the gate shut. Full `npm test` green across all four test files.

## What this unblocks

Both F10 verifier halves are now on v2. The mint flip still requires confirming **every spoke image** carries this build — per digest, not "rollout started" — and remains a separate, deliberate step.