### PR TITLE
✨ feat(governor): record a name for the configured API key (#3596)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1116,6 +1116,14 @@ const (
 type BobConfig struct {
 	APIKeyEnv  string `yaml:"api_key_env" json:"api_key_env,omitempty"`   // env var NAME holding the key; default HIVE_BOB_API_KEY
 	APIKeyFile string `yaml:"api_key_file" json:"api_key_file,omitempty"` // path to a file holding the key; default /secrets/bob_api_key
+	// KeyName is an optional, human-chosen LABEL for the configured key
+	// ("Team inference key", "andy personal", …). It is safe-to-show metadata,
+	// NOT a secret — it records WHICH key a hive is set to use so managers can
+	// tell keys apart without ever seeing the value. omitempty keeps hive.yaml
+	// on existing hives (which never recorded a name) byte-identical on
+	// round-trip; an absent name is a normal, backwards-compatible state that
+	// the dashboard renders as "(unnamed)" rather than an error.
+	KeyName string `yaml:"key_name,omitempty" json:"key_name,omitempty"`
 }
 
 // ResolveAPIKey returns the bob API key, or "" when none is configured.

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4878,6 +4878,10 @@ func (s *Server) handleGovernorBobStatus(w http.ResponseWriter, r *http.Request)
 		// configured is presence-only; the key value is never serialized.
 		"configured": source != "",
 		"source":     source,
+		// keyName is the operator-chosen LABEL for the key, not the key value —
+		// safe to serialize. Empty on hives that never recorded a name (the
+		// dashboard renders that as "(unnamed)"), so no backwards-compat break.
+		"keyName": bc.KeyName,
 	})
 }
 
@@ -4898,6 +4902,11 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 	}
 	var body struct {
 		APIKey *string `json:"apiKey"`
+		// KeyName is an optional human LABEL recorded alongside the key so
+		// managers can tell WHICH key a hive uses without seeing the value.
+		// It is not a secret and is stored in plaintext in hive.yaml. Absent
+		// (nil) leaves any existing name untouched; present-but-empty clears it.
+		KeyName *string `json:"keyName"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -4931,6 +4940,21 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Normalize the optional key NAME. It is a label, not a secret: leading
+	// and trailing whitespace is trimmed (a name is a display string, not a
+	// token), interior whitespace is allowed ("Team inference key"), and only
+	// the length is bounded. nil means "leave the existing name as-is".
+	var keyName string
+	nameProvided := body.KeyName != nil
+	if nameProvided {
+		keyName = strings.TrimSpace(*body.KeyName)
+		if len(keyName) > bobKeyNameMaxLen {
+			jsonError(w, fmt.Sprintf("keyName is too long (limit %d characters)", bobKeyNameMaxLen),
+				http.StatusBadRequest)
+			return
+		}
+	}
+
 	cfg := s.deps.Config
 	// Apply to a copy so a store failure leaves config untouched.
 	bc := cfg.Governor.Bob
@@ -4949,6 +4973,12 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 	if looksLikeAPIKeyValue(bc.APIKeyEnv) {
 		bc.APIKeyEnv = ""
 		s.logger.Info("cleared key-like value from bob api_key_env (replaced by stored API key)")
+	}
+	// Record the label only when the caller supplied the field, so a
+	// name-less "Replace key" PUT keeps the existing name rather than wiping
+	// it. A provided empty string intentionally clears it.
+	if nameProvided {
+		bc.KeyName = keyName
 	}
 	cfg.Governor.Bob = bc
 
@@ -4986,6 +5016,8 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 		"configured": true,
 		// Path only, never the value.
 		"source": "file:" + keyFile,
+		// The operator-chosen label for the key (safe to echo; not the value).
+		"keyName": bc.KeyName,
 		// The pod does not need restarting; the resolver reads the key live.
 		"restartNeeded": false,
 		// How many parked bob agents were started by this save, so the UI can
@@ -5018,9 +5050,12 @@ func (s *Server) handleGovernorBobKeyClear(w http.ResponseWriter, r *http.Reques
 	cfg := s.deps.Config
 	bc := cfg.Governor.Bob
 	// Only drop the pointer if it names the file we just removed; an operator
-	// who pointed api_key_file at their own path keeps that setting.
+	// who pointed api_key_file at their own path keeps that setting. The label
+	// describes the key we just cleared, so drop it in the same case — leaving
+	// a stale "Team inference key" beside a now-empty slot would mislead.
 	if bc.APIKeyFile == writableBobKeyFile {
 		bc.APIKeyFile = ""
+		bc.KeyName = ""
 	}
 	cfg.Governor.Bob = bc
 

--- a/v2/pkg/dashboard/bob_key_name_test.go
+++ b/v2/pkg/dashboard/bob_key_name_test.go
@@ -1,0 +1,237 @@
+package dashboard
+
+// Tests for the optional key NAME/label recorded alongside the bob API key
+// (#3596). The name is safe-to-show metadata that lets managers tell WHICH key
+// a hive uses without ever exposing the value. These tests pin the round-trip,
+// the backwards-compatible absent-name state, and that the label is never
+// confused with (nor allowed to leak) the secret.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+// Setting a key WITH a name records the label and returns it in the response,
+// while the key value itself never appears.
+func TestHandleGovernorBobKey_SetWithNameRecordsLabel(t *testing.T) {
+	pointBobKeyAtTempDir(t)
+	s := newBobTestServer(t)
+
+	const wantName = "Team inference key"
+	body := `{"apiKey":"` + bobTestKey + `","keyName":"` + wantName + `"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
+	s.handleGovernorBobKey(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), bobTestKey) {
+		t.Error("response body leaks the key value")
+	}
+	if got := s.deps.Config.Governor.Bob.KeyName; got != wantName {
+		t.Errorf("stored KeyName = %q, want %q", got, wantName)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["keyName"] != wantName {
+		t.Errorf("response keyName = %v, want %q", resp["keyName"], wantName)
+	}
+}
+
+// A name is trimmed of surrounding whitespace (it is a display string) but
+// interior spaces are preserved.
+func TestHandleGovernorBobKey_NameIsTrimmed(t *testing.T) {
+	pointBobKeyAtTempDir(t)
+	s := newBobTestServer(t)
+
+	body := `{"apiKey":"` + bobTestKey + `","keyName":"   spaced label   "}`
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
+	s.handleGovernorBobKey(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := s.deps.Config.Governor.Bob.KeyName; got != "spaced label" {
+		t.Errorf("KeyName = %q, want %q", got, "spaced label")
+	}
+}
+
+// An oversized name is rejected and nothing is stored.
+func TestHandleGovernorBobKey_OversizedNameRejected(t *testing.T) {
+	path := pointBobKeyAtTempDir(t)
+	s := newBobTestServer(t)
+
+	body := `{"apiKey":"` + bobTestKey + `","keyName":"` + strings.Repeat("x", bobKeyNameMaxLen+1) + `"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
+	s.handleGovernorBobKey(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("key file written for a request rejected on name length")
+	}
+	if s.deps.Config.Governor.Bob.KeyName != "" {
+		t.Error("a rejected oversized name was still recorded")
+	}
+}
+
+// BACKWARDS COMPAT: setting a key with NO keyName field leaves the response and
+// config name empty — never an error. This is how existing hives (which never
+// recorded a name) behave.
+func TestHandleGovernorBobKey_AbsentNameIsSafe(t *testing.T) {
+	pointBobKeyAtTempDir(t)
+	s := newBobTestServer(t)
+
+	body := `{"apiKey":"` + bobTestKey + `"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
+	s.handleGovernorBobKey(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := s.deps.Config.Governor.Bob.KeyName; got != "" {
+		t.Errorf("KeyName = %q, want empty when no name is supplied", got)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["keyName"] != "" {
+		t.Errorf("response keyName = %v, want empty string", resp["keyName"])
+	}
+}
+
+// An absent (nil) keyName on a "Replace key" PUT keeps the existing name, so
+// rotating a key without re-typing its label does not silently wipe it. An
+// explicit empty string clears it.
+func TestHandleGovernorBobKey_ReplaceKeepsThenClearsName(t *testing.T) {
+	pointBobKeyAtTempDir(t)
+	s := newBobTestServer(t)
+	s.deps.Config.Governor.Bob.KeyName = "existing label"
+
+	// Replace the key, sending no keyName field: the label must survive.
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/bob",
+		strings.NewReader(`{"apiKey":"`+bobTestKey+`"}`))
+	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
+	s.handleGovernorBobKey(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("replace status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := s.deps.Config.Governor.Bob.KeyName; got != "existing label" {
+		t.Errorf("name after nameless replace = %q, want it preserved", got)
+	}
+
+	// Now send an explicit empty string: the label is cleared.
+	req = httptest.NewRequest(http.MethodPut, "/api/config/governor/bob",
+		strings.NewReader(`{"apiKey":"`+bobTestKey+`","keyName":""}`))
+	rec = httptest.NewRecorder()
+	markOwnerRequest(req)
+	s.handleGovernorBobKey(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear-name status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := s.deps.Config.Governor.Bob.KeyName; got != "" {
+		t.Errorf("name after explicit empty = %q, want cleared", got)
+	}
+}
+
+// The status endpoint surfaces the recorded name (safe metadata) and never the
+// key value.
+func TestHandleGovernorBobStatus_ReturnsKeyName(t *testing.T) {
+	path := pointBobKeyAtTempDir(t)
+	s := newBobTestServer(t)
+
+	if err := writeBobKeyFile(bobTestKey); err != nil {
+		t.Fatal(err)
+	}
+	s.deps.Config.Governor.Bob.APIKeyFile = path
+	s.deps.Config.Governor.Bob.KeyName = "prod key"
+
+	rec := httptest.NewRecorder()
+	s.handleGovernorBobStatus(rec, httptest.NewRequest(http.MethodGet, "/api/config/governor/bob", nil))
+	if strings.Contains(rec.Body.String(), bobTestKey) {
+		t.Fatal("status response leaks the key value")
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["keyName"] != "prod key" {
+		t.Errorf("status keyName = %v, want %q", resp["keyName"], "prod key")
+	}
+}
+
+// Clearing the key drops the label too, so a stale name never sits beside an
+// empty key slot.
+func TestHandleGovernorBobKeyClear_DropsName(t *testing.T) {
+	path := pointBobKeyAtTempDir(t)
+	s := newBobTestServer(t)
+
+	if err := writeBobKeyFile(bobTestKey); err != nil {
+		t.Fatal(err)
+	}
+	s.deps.Config.Governor.Bob.APIKeyFile = path
+	s.deps.Config.Governor.Bob.KeyName = "to be removed"
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/config/governor/bob", nil)
+	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
+	s.handleGovernorBobKeyClear(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := s.deps.Config.Governor.Bob.KeyName; got != "" {
+		t.Errorf("KeyName = %q, want cleared alongside the key", got)
+	}
+}
+
+// BACKWARDS COMPAT at the config layer: a BobConfig with no key_name
+// round-trips through YAML byte-identically (the omitempty tag), so existing
+// hives that never recorded a name are not rewritten with a spurious field.
+func TestBobConfig_KeyNameOmitemptyRoundTrip(t *testing.T) {
+	// No name set: the field must NOT appear in the marshaled YAML.
+	noName := config.BobConfig{APIKeyFile: "/data/secrets/bob_api_key"}
+	out, err := yaml.Marshal(noName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "key_name") {
+		t.Errorf("empty KeyName leaked a key_name field into YAML:\n%s", out)
+	}
+
+	// Name set: it round-trips.
+	withName := config.BobConfig{APIKeyFile: "/data/secrets/bob_api_key", KeyName: "Team key"}
+	out, err = yaml.Marshal(withName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "key_name: Team key") {
+		t.Errorf("KeyName did not marshal as key_name:\n%s", out)
+	}
+	var back config.BobConfig
+	if err := yaml.Unmarshal(out, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.KeyName != "Team key" {
+		t.Errorf("KeyName after round-trip = %q, want %q", back.KeyName, "Team key")
+	}
+}

--- a/v2/pkg/dashboard/bob_key_store.go
+++ b/v2/pkg/dashboard/bob_key_store.go
@@ -63,6 +63,11 @@ const (
 	// aimed at the field) cannot write an unbounded blob onto the PVC.
 	// bobshell keys are far shorter than this; the limit only rejects abuse.
 	bobKeyMaxLen = 4096
+	// bobKeyNameMaxLen bounds the optional human LABEL for the key. It is a
+	// short display string ("Team inference key"), not the secret, so the
+	// limit is generous enough for a descriptive name yet small enough that a
+	// stray paste into the name field cannot bloat hive.yaml.
+	bobKeyNameMaxLen = 128
 )
 
 // writableBobKeyFile is a package var (not a const) so tests can point it at

--- a/v2/pkg/dashboard/bob_key_store_test.go
+++ b/v2/pkg/dashboard/bob_key_store_test.go
@@ -401,8 +401,8 @@ func TestBobKeyUILivesOnGovernorTab(t *testing.T) {
 		{"tab is wired into render dispatch", "case GOVERNOR_BOB_TAB: return renderGovBob();"},
 		{"tab renderer exists", "function renderGovBob() {"},
 		{"status loader exists", "async function loadBobKeyStatus() {"},
-		{"panel renderer exists", "function renderBobKeyPanel(host, configured, source) {"},
-		{"dialog is opened from the panel", "openBobKeyDialog(configured, source)"},
+		{"panel renderer exists", "function renderBobKeyPanel(host, configured, source, keyName) {"},
+		{"dialog is opened from the panel", "openBobKeyDialog(configured, source, keyName)"},
 		{"clear is reachable from the panel", "clearBtn.addEventListener('click', clearBobKey)"},
 	}
 	for _, tc := range cases {
@@ -496,9 +496,10 @@ func TestBobKeyUINeverRendersTheKeyValue(t *testing.T) {
 	if !strings.Contains(html, "// Drop the secret from the DOM before removing the node.") {
 		t.Error("the dialog must clear the input value before removing the node")
 	}
-	// The panel must render presence + source only, never a value field.
-	if !strings.Contains(html, "renderBobKeyPanel(host, d.configured === true, d.source || '')") {
-		t.Error("the panel must be fed only `configured` and the safe `source` string")
+	// The panel must render presence + source + the safe key NAME only, never a
+	// value field. keyName is an operator-chosen label, not the secret.
+	if !strings.Contains(html, "renderBobKeyPanel(host, d.configured === true, d.source || '', d.keyName || '')") {
+		t.Error("the panel must be fed only `configured`, the safe `source` string, and the safe `keyName` label")
 	}
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14878,7 +14878,7 @@ function burnAreaChart() {
         if (!host) return;
         if (!r.ok) throw new Error('HTTP ' + r.status);
         const d = await r.json();
-        renderBobKeyPanel(host, d.configured === true, d.source || '');
+        renderBobKeyPanel(host, d.configured === true, d.source || '', d.keyName || '');
       } catch (e) {
         host = host || document.getElementById('gov-bob-host');
         if (host) host.innerHTML = '<div style="color:var(--red);font-size:0.8rem">Failed to load bob key status: ' + esc(e.message) + '</div>';
@@ -14886,11 +14886,17 @@ function burnAreaChart() {
     }
 
     // renderBobKeyPanel paints the bob credential card. `source` is the safe
-    // source string only; the key value never reaches this function.
-    function renderBobKeyPanel(host, configured, source) {
+    // source string only; the key value never reaches this function. `keyName`
+    // is the operator-chosen LABEL for the key (also safe to show) — it lets a
+    // manager see WHICH key this hive uses without the secret. Empty on hives
+    // that never recorded a name, which we render as "(unnamed)".
+    function renderBobKeyPanel(host, configured, source, keyName) {
       if (!host) return;
+      const nameLabel = configured
+        ? ' <strong style="color:var(--fg)">' + esc(keyName || '(unnamed)') + '</strong>'
+        : '';
       const statusLine = configured
-        ? '<span style="color:var(--green)">✓ Key set</span>' + (source ? ' <span style="color:var(--muted)">(' + esc(source) + ')</span>' : '')
+        ? '<span style="color:var(--green)">✓ Key set</span>' + nameLabel + (source ? ' <span style="color:var(--muted)">(' + esc(source) + ')</span>' : '')
         : '<span style="color:var(--muted)">No key set — agents using bob cannot start.</span>';
       host.innerHTML = `
         <div style="border:1px solid var(--border);border-radius:8px;padding:14px;background:var(--surface);max-width:640px">
@@ -14918,7 +14924,7 @@ function burnAreaChart() {
       // via the agent-card dispatcher) because this panel is repainted on every
       // set/clear and owns its own buttons.
       const setBtn = host.querySelector('[data-action="bobKeySet"]');
-      if (setBtn) setBtn.addEventListener('click', () => openBobKeyDialog(configured, source));
+      if (setBtn) setBtn.addEventListener('click', () => openBobKeyDialog(configured, source, keyName));
       const clearBtn = host.querySelector('[data-action="bobKeyClear"]');
       if (clearBtn) clearBtn.addEventListener('click', clearBobKey);
       // Test the SAVED key from the card: result goes to the card's inline
@@ -19470,7 +19476,7 @@ function burnAreaChart() {
       }
     }
 
-    function openBobKeyDialog(configured, source) {
+    function openBobKeyDialog(configured, source, keyName) {
       var overlay = document.getElementById('bob-key-overlay');
       if (overlay) { overlay.remove(); }
       overlay = document.createElement('div');
@@ -19507,6 +19513,16 @@ function burnAreaChart() {
               'style="color:#4589ff">bob Shell setup</a>' +
           '</div>' +
         '</div>' +
+        /* Optional label. Not a secret — it records WHICH key this is
+           (e.g. "Team inference key") so managers can tell keys apart later
+           without ever seeing the value. Pre-filled with the current name so
+           a plain "Replace key" keeps it. */
+        '<label for="bob-key-name-input" style="display:block;font-size:0.78rem;color:var(--muted);margin:8px 0 4px">' +
+          'Key name <span style="color:var(--muted)">(optional label, not the secret)</span></label>' +
+        '<input id="bob-key-name-input" type="text" autocomplete="off" spellcheck="false" maxlength="128" ' +
+          'placeholder="e.g. Team inference key" value="' + esc(keyName || '') + '" ' +
+          'style="width:100%;box-sizing:border-box;padding:8px;border-radius:6px;border:1px solid var(--border);' +
+          'background:var(--panel);color:var(--fg);margin:0 0 8px">' +
         '<input id="bob-key-input" type="password" autocomplete="off" spellcheck="false" ' +
           'placeholder="Paste the bob API key" ' +
           'style="width:100%;box-sizing:border-box;padding:8px;border-radius:6px;border:1px solid var(--border);' +
@@ -19559,13 +19575,18 @@ function burnAreaChart() {
       if (saveBtn) saveBtn.addEventListener('click', async function() {
         var key = (input && input.value || '').trim();
         if (!key) { setStatus('Paste a key first.', 'var(--red)'); return; }
+        // The name is an optional plaintext label sent alongside the key. Always
+        // sending the field (even empty) lets the operator clear a stale name by
+        // blanking it; the server trims and length-bounds it.
+        var nameInput = document.getElementById('bob-key-name-input');
+        var keyName = (nameInput && nameInput.value || '').trim();
         saveBtn.disabled = true;
         setStatus('Saving…');
         try {
           var resp = await fetch('/api/config/governor/bob', {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ apiKey: key })
+            body: JSON.stringify({ apiKey: key, keyName: keyName })
           });
           var data = await resp.json().catch(function() { return {}; });
           if (!resp.ok) {


### PR DESCRIPTION
## What

Hive managers want to record a **name/label for the configured API key** so they can see WHICH key a hive is set to use, **without exposing the secret value**. Today you can set a bob API key but can't tell keys apart. This adds an optional key name, stored and displayed alongside the key status.

## Changes

- **`pkg/config/config.go`** — add optional `BobConfig.KeyName` (`yaml:"key_name,omitempty"`). It is safe-to-show metadata, not a secret. `omitempty` keeps existing hives' `hive.yaml` byte-identical on round-trip.
- **`pkg/dashboard/api.go`**
  - `handleGovernorBobKey` (PUT set-key) now accepts an optional `keyName` alongside `apiKey`. The name is trimmed (a display string), length-bounded, and stored in plaintext. A **nil** `keyName` on a "Replace key" PUT **keeps** the existing name; an explicit `""` clears it.
  - `handleGovernorBobStatus` returns `keyName` (safe metadata, never the value).
  - `handleGovernorBobKeyClear` drops the label when it drops the PVC key, so a stale name never sits beside an empty key slot.
- **`pkg/dashboard/bob_key_store.go`** — add `bobKeyNameMaxLen = 128` (named constant, no magic numbers).
- **`pkg/dashboard/static/index.html`** — the set-key dialog gains an optional "Key name" text field (pre-filled with the current name so a plain replace keeps it); the panel status line shows `✓ Key set **<name>**`, rendering `(unnamed)` when absent. The secret value is still never rendered (password input, cleared from the DOM).

## Backwards compatibility

Existing hives never recorded a name. An absent name resolves to an empty label that the dashboard displays as **"(unnamed)"** — never an error — and `hive.yaml` is **not** rewritten with a spurious `key_name` field (verified by a round-trip test).

## Tests

New `pkg/dashboard/bob_key_name_test.go`:
- set-with-name records + echoes the label (value never leaks)
- name is trimmed; oversized name rejected with nothing stored
- absent-name PUT is safe (empty, no error)
- nameless "Replace key" keeps the existing name; explicit `""` clears it
- status endpoint returns the name; clear drops it
- `BobConfig.KeyName` `omitempty` YAML round-trip (no field when empty)

Existing UI-snippet guards updated for the new `renderBobKeyPanel`/`openBobKeyDialog` signatures. `go build`, `go vet`, and the dashboard + config test suites pass locally.

Fixes #3596

🤖 Generated with [Claude Code](https://claude.com/claude-code)