### PR TITLE
✨ feat(acmm): port the ACMM level-up advisor from v4 to v2

### DIFF
--- a/v2/pkg/acmmadvisor/acmmadvisor.go
+++ b/v2/pkg/acmmadvisor/acmmadvisor.go
@@ -1,0 +1,463 @@
+// Package acmmadvisor computes coverage-driven, guided level-up
+// recommendations for a hive's ACMM (Agentic Contribution Maturity Model)
+// level.
+//
+// The core product thesis is "you earn automation with test coverage": a hive
+// should only be advanced to a higher-trust ACMM level once it has demonstrated
+// the operational signals that justify that trust — sustained test coverage, a
+// green-CI / merge-success track record, a controlled actionable-issue backlog,
+// and few outstanding holds. This package turns that thesis into a concrete,
+// auditable computation.
+//
+// This package is ADVISORY ONLY. It never changes the applied ACMM level; it
+// only computes a Recommendation describing whether the caller should keep the
+// current level or propose raising to the next one, together with the exact
+// criteria that are met and unmet. A human always approves the actual level
+// change. The recommendation is a pure, deterministic function of its inputs
+// (stdlib only, no I/O, no clocks, no randomness).
+package acmmadvisor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ── Level bounds ────────────────────────────────────────────────────────────
+//
+// ACMM levels run L1 (Assisted) through L6 (Fully Autonomous), matching the
+// level-*.yaml packs and the dashboard's 1..6 bound (pkg/dashboard/api_packs.go
+// handlePackSetLevel). The advisor never proposes a target below MinLevel,
+// above MaxLevel, or more than one level above the current level.
+const (
+	// MinLevel is the lowest ACMM level a hive can run at.
+	MinLevel = 1
+	// MaxLevel is the highest ACMM level (Fully Autonomous). No recommendation
+	// ever proposes a target above this.
+	MaxLevel = 6
+	// levelStep is the number of levels a single recommendation may raise.
+	// Advancement is always one level at a time — the advisor never proposes
+	// skipping a level, because each level unlocks trust that must be earned
+	// incrementally.
+	levelStep = 1
+)
+
+// ── Coverage thresholds ─────────────────────────────────────────────────────
+//
+// The coverage bar is anchored on the real 90% gate the hive codebase enforces
+// (see pkg/dashboard/metrics_collector.go collectCoverage, coverageTarget=91).
+// Lower levels use gentler coverage bars so that a young project can still make
+// early progress; the bar tightens as the level (and the trust it grants)
+// rises, culminating at the real 90% gate for the fully-automated levels.
+const (
+	// coverageGate is the project's real, enforced coverage target. Proposing
+	// the highest-trust levels requires meeting it in full.
+	coverageGate = 90.0
+
+	// Per-level coverage floors required to PROPOSE raising *to* the target
+	// level. They increase monotonically with level.
+	coverageFloorL2 = 0.0          // L1→L2: instruction files, not yet coverage-gated.
+	coverageFloorL3 = 40.0         // L2→L3: measurement infra appearing; baseline coverage.
+	coverageFloorL4 = 60.0         // L3→L4: closed-loop feedback needs a real safety net.
+	coverageFloorL5 = 75.0         // L4→L5: semi-automated PRs demand strong coverage.
+	coverageFloorL6 = coverageGate // L5→L6: full autonomy requires the full gate.
+)
+
+// ── Green-CI streak thresholds ──────────────────────────────────────────────
+//
+// GreenStreak is the count of consecutive green CI runs (or merges) with no red.
+// A streak is the clearest evidence that the pipeline gates work in practice.
+// Higher levels require a longer proven streak before granting more autonomy.
+const (
+	greenStreakL3 = 3  // L2→L3: a short proven streak.
+	greenStreakL4 = 5  // L3→L4.
+	greenStreakL5 = 8  // L4→L5.
+	greenStreakL6 = 12 // L5→L6: full autonomy requires a long, stable streak.
+)
+
+// ── Merge-success-rate thresholds ───────────────────────────────────────────
+//
+// MergeSuccessRate is the fraction (0.0–1.0) of recently opened PRs that merged
+// cleanly without being reverted or abandoned. It measures whether the hive's
+// proposals are actually good. Autonomy is only warranted when most proposals
+// land.
+const (
+	mergeRateL4 = 0.70 // L3→L4.
+	mergeRateL5 = 0.85 // L4→L5.
+	mergeRateL6 = 0.95 // L5→L6: near-flawless track record for full autonomy.
+)
+
+// ── Backlog / hold thresholds ───────────────────────────────────────────────
+//
+// ActionableIssues is the count of open, actionable issues the hive itself has
+// surfaced but not yet resolved — a large backlog means the loop is not keeping
+// up and should not be trusted with more autonomy. HoldCount is the number of
+// open PRs still carrying a `hold` label awaiting human review; a pile of
+// unreviewed holds means humans are already the bottleneck, so adding autonomy
+// is premature. Both are ceilings (Actual must be at or below the ceiling).
+const (
+	maxActionableL5 = 25 // L4→L5: backlog must be under control.
+	maxActionableL6 = 10 // L5→L6: near-empty backlog for full autonomy.
+
+	maxHoldsL5 = 15 // L4→L5: holds must be drained regularly.
+	maxHoldsL6 = 5  // L5→L6: almost no unreviewed holds for full autonomy.
+)
+
+// AdviseAction is the top-level recommendation verb.
+type AdviseAction string
+
+const (
+	// AdviseStay means the hive should remain at its current level, either
+	// because it is already at the maximum or because it has not yet earned the
+	// next level.
+	AdviseStay AdviseAction = "stay"
+	// AdviseRaise means the advisor proposes raising to the next level. It is
+	// only ever emitted when every criterion for that next level is met; a
+	// human still approves the actual change.
+	AdviseRaise AdviseAction = "raise"
+)
+
+// Signals is the forge-neutral set of operational inputs the advisor evaluates.
+// "Forge-neutral" means these are abstract measurements (coverage %, streaks,
+// rates, counts) rather than GitHub- or GitLab-specific objects, so the advisor
+// works regardless of the underlying code-forge.
+type Signals struct {
+	// CurrentLevel is the ACMM level the hive is applying right now (1–6).
+	// Values outside [MinLevel, MaxLevel] are clamped defensively.
+	CurrentLevel int
+	// CoveragePct is the current test-coverage percentage (0–100).
+	CoveragePct float64
+	// GreenStreak is the number of consecutive green CI runs with no red.
+	GreenStreak int
+	// MergeSuccessRate is the fraction (0.0–1.0) of recent PRs that merged
+	// cleanly. Values outside [0,1] are clamped defensively.
+	MergeSuccessRate float64
+	// ActionableIssues is the count of open actionable issues the hive has
+	// surfaced but not yet resolved (a backlog ceiling, lower is better).
+	ActionableIssues int
+	// HoldCount is the number of open PRs still carrying a hold label awaiting
+	// human review (a ceiling, lower is better).
+	HoldCount int
+	// HasQualityAgent reports whether a quality/coverage agent is present and
+	// active. Coverage-gated advancement is meaningless without one, so it is a
+	// prerequisite for the coverage-driven levels.
+	HasQualityAgent bool
+}
+
+// Comparator describes how a Criterion's Actual is compared to its Required.
+type Comparator string
+
+const (
+	// AtLeast means the criterion passes when Actual >= Required (floors).
+	AtLeast Comparator = ">="
+	// AtMost means the criterion passes when Actual <= Required (ceilings).
+	AtMost Comparator = "<="
+	// IsTrue means the criterion passes when a boolean signal is true.
+	IsTrue Comparator = "is"
+)
+
+// Criterion is a single, renderable requirement for advancing to a target
+// level. The dashboard can render a checklist directly from a slice of these.
+type Criterion struct {
+	// Name is a short human-readable label, e.g. "Test coverage".
+	Name string
+	// Comparator describes the pass relationship (>=, <=, is).
+	Comparator Comparator
+	// Required is the threshold, formatted for display (e.g. "90%", "12").
+	Required string
+	// Actual is the observed value, formatted for display.
+	Actual string
+	// Met reports whether this criterion is currently satisfied.
+	Met bool
+	// Detail is an optional one-line rationale for why this criterion exists.
+	Detail string
+}
+
+// Recommendation is the advisor's output. It is advisory only: the caller (and
+// ultimately a human) decides whether to act on it.
+type Recommendation struct {
+	// Advise is stay or raise.
+	Advise AdviseAction
+	// CurrentLevel echoes the (clamped) level that was evaluated.
+	CurrentLevel int
+	// TargetLevel is the level being proposed. When Advise is stay, TargetLevel
+	// equals CurrentLevel.
+	TargetLevel int
+	// Ready reports whether every criterion for TargetLevel is met. When Advise
+	// is raise, Ready is always true. When Advise is stay because criteria are
+	// unmet, Ready is false; when Advise is stay because the hive is already at
+	// MaxLevel, Ready is true (nothing left to earn).
+	Ready bool
+	// Met lists the satisfied criteria for the evaluated next level.
+	Met []Criterion
+	// Unmet lists the unsatisfied criteria, i.e. exactly what is blocking the
+	// level-up. Empty when Ready is true.
+	Unmet []Criterion
+	// Rationale is a human-readable summary suitable for a dashboard tooltip.
+	Rationale string
+}
+
+// Recommend computes a level-up recommendation from the given Signals. It is a
+// pure, deterministic function: identical Signals always yield an identical
+// Recommendation. It never changes any applied level.
+func Recommend(s Signals) Recommendation {
+	level := clampLevel(s.CurrentLevel)
+
+	// Already at the ceiling: nothing higher to propose.
+	if level >= MaxLevel {
+		return Recommendation{
+			Advise:       AdviseStay,
+			CurrentLevel: level,
+			TargetLevel:  level,
+			Ready:        true,
+			Rationale: fmt.Sprintf(
+				"At the maximum ACMM level (L%d, Fully Autonomous). No higher level to propose.",
+				MaxLevel,
+			),
+		}
+	}
+
+	target := level + levelStep
+	criteria := criteriaForTarget(target, s)
+
+	met := make([]Criterion, 0, len(criteria))
+	unmet := make([]Criterion, 0, len(criteria))
+	for _, c := range criteria {
+		if c.Met {
+			met = append(met, c)
+		} else {
+			unmet = append(unmet, c)
+		}
+	}
+
+	rec := Recommendation{
+		CurrentLevel: level,
+		TargetLevel:  target,
+		Met:          met,
+		Unmet:        unmet,
+	}
+
+	if len(unmet) == 0 {
+		rec.Advise = AdviseRaise
+		rec.Ready = true
+		rec.Rationale = fmt.Sprintf(
+			"Ready to propose raising L%d→L%d: all %d criteria met. Human approval required.",
+			level, target, len(met),
+		)
+		return rec
+	}
+
+	rec.Advise = AdviseStay
+	rec.Ready = false
+	rec.Rationale = fmt.Sprintf(
+		"Stay at L%d. %d of %d criteria for L%d not yet met: %s.",
+		level, len(unmet), len(criteria), target, summarizeUnmet(unmet),
+	)
+	return rec
+}
+
+// criteriaForTarget returns the ordered checklist required to propose raising
+// *to* the given target level, evaluated against the supplied signals. The bar
+// is gentler for the low levels (L1→L2) and strictest for full autonomy
+// (L5→L6). target is assumed to be in [MinLevel+1, MaxLevel].
+func criteriaForTarget(target int, s Signals) []Criterion {
+	switch target {
+	case 2:
+		// L1→L2 (Assisted → Instructed): the gentlest gate. Advancing here only
+		// asks that a quality agent be present so future coverage gating has an
+		// owner; no numeric coverage/streak bars yet.
+		return []Criterion{
+			boolCriterion(
+				"Quality agent present",
+				s.HasQualityAgent,
+				"A quality/coverage agent must own the coverage loop before higher levels.",
+			),
+		}
+	case 3:
+		// L2→L3 (Instructed → Measured): baseline measurement. A quality agent
+		// plus a modest coverage floor and a short green streak.
+		return []Criterion{
+			boolCriterion("Quality agent present", s.HasQualityAgent,
+				"Measured level requires an active quality agent."),
+			floorPctCriterion("Test coverage", s.CoveragePct, coverageFloorL3,
+				"Baseline coverage so measurements are meaningful."),
+			floorIntCriterion("Green-CI streak", s.GreenStreak, greenStreakL3,
+				"A short proven streak of green CI runs."),
+		}
+	case 4:
+		// L3→L4 (Measured → Adaptive): closed-loop feedback needs a real safety
+		// net — stronger coverage, a longer streak, and a merge-success record.
+		return []Criterion{
+			boolCriterion("Quality agent present", s.HasQualityAgent,
+				"Adaptive feedback loops require an active quality agent."),
+			floorPctCriterion("Test coverage", s.CoveragePct, coverageFloorL4,
+				"Closed-loop changes need a real coverage safety net."),
+			floorIntCriterion("Green-CI streak", s.GreenStreak, greenStreakL4,
+				"A sustained streak proving CI gates hold."),
+			floorRateCriterion("Merge success rate", s.MergeSuccessRate, mergeRateL4,
+				"Most proposed PRs must land cleanly."),
+		}
+	case 5:
+		// L4→L5 (Adaptive → Semi-Automated): the system now proposes PRs at
+		// scale. Strong coverage, a long streak, a high merge rate, and a
+		// controlled backlog / hold queue.
+		return []Criterion{
+			boolCriterion("Quality agent present", s.HasQualityAgent,
+				"Semi-automated PRs require an active quality agent."),
+			floorPctCriterion("Test coverage", s.CoveragePct, coverageFloorL5,
+				"Semi-automated PRs demand strong coverage."),
+			floorIntCriterion("Green-CI streak", s.GreenStreak, greenStreakL5,
+				"A long streak proving stability under load."),
+			floorRateCriterion("Merge success rate", s.MergeSuccessRate, mergeRateL5,
+				"A high fraction of proposals must merge cleanly."),
+			ceilIntCriterion("Actionable-issue backlog", s.ActionableIssues, maxActionableL5,
+				"The backlog must be under control before scaling PRs."),
+			ceilIntCriterion("Open holds", s.HoldCount, maxHoldsL5,
+				"Humans must be draining the hold queue, not drowning in it."),
+		}
+	default: // target == 6
+		// L5→L6 (Semi-Automated → Fully Autonomous): the strictest gate. Full
+		// autonomy (auto-merge on green) requires meeting the real 90% coverage
+		// gate, a long streak, a near-flawless merge rate, a near-empty backlog,
+		// and almost no outstanding holds.
+		return []Criterion{
+			boolCriterion("Quality agent present", s.HasQualityAgent,
+				"Full autonomy requires an active quality agent."),
+			floorPctCriterion("Test coverage", s.CoveragePct, coverageFloorL6,
+				"Full autonomy requires meeting the enforced coverage gate."),
+			floorIntCriterion("Green-CI streak", s.GreenStreak, greenStreakL6,
+				"A long, stable streak before auto-merge is granted."),
+			floorRateCriterion("Merge success rate", s.MergeSuccessRate, mergeRateL6,
+				"A near-flawless merge track record for auto-merge."),
+			ceilIntCriterion("Actionable-issue backlog", s.ActionableIssues, maxActionableL6,
+				"A near-empty backlog before granting full autonomy."),
+			ceilIntCriterion("Open holds", s.HoldCount, maxHoldsL6,
+				"Almost no unreviewed holds before removing the hold gate."),
+		}
+	}
+}
+
+// ── Criterion builders ──────────────────────────────────────────────────────
+
+// floorPctCriterion builds a >= criterion over a percentage signal.
+func floorPctCriterion(name string, actual, required float64, detail string) Criterion {
+	return Criterion{
+		Name:       name,
+		Comparator: AtLeast,
+		Required:   formatPct(required),
+		Actual:     formatPct(clampPct(actual)),
+		Met:        clampPct(actual) >= required,
+		Detail:     detail,
+	}
+}
+
+// floorRateCriterion builds a >= criterion over a 0–1 rate signal, rendered as
+// a percentage for readability.
+func floorRateCriterion(name string, actual, required float64, detail string) Criterion {
+	return Criterion{
+		Name:       name,
+		Comparator: AtLeast,
+		Required:   formatPct(required * pctScale),
+		Actual:     formatPct(clampRate(actual) * pctScale),
+		Met:        clampRate(actual) >= required,
+		Detail:     detail,
+	}
+}
+
+// floorIntCriterion builds a >= criterion over an integer signal.
+func floorIntCriterion(name string, actual, required int, detail string) Criterion {
+	return Criterion{
+		Name:       name,
+		Comparator: AtLeast,
+		Required:   fmt.Sprintf("%d", required),
+		Actual:     fmt.Sprintf("%d", actual),
+		Met:        actual >= required,
+		Detail:     detail,
+	}
+}
+
+// ceilIntCriterion builds a <= criterion over an integer signal (a ceiling).
+func ceilIntCriterion(name string, actual, required int, detail string) Criterion {
+	return Criterion{
+		Name:       name,
+		Comparator: AtMost,
+		Required:   fmt.Sprintf("%d", required),
+		Actual:     fmt.Sprintf("%d", actual),
+		Met:        actual <= required,
+		Detail:     detail,
+	}
+}
+
+// boolCriterion builds an "is true" criterion over a boolean signal.
+func boolCriterion(name string, actual bool, detail string) Criterion {
+	return Criterion{
+		Name:       name,
+		Comparator: IsTrue,
+		Required:   "yes",
+		Actual:     boolWord(actual),
+		Met:        actual,
+		Detail:     detail,
+	}
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+// pctScale converts a 0–1 fraction to a 0–100 percentage.
+const pctScale = 100.0
+
+// clampLevel constrains an arbitrary level to [MinLevel, MaxLevel] so degenerate
+// inputs (0, negative, or >MaxLevel) are handled safely.
+func clampLevel(level int) int {
+	if level < MinLevel {
+		return MinLevel
+	}
+	if level > MaxLevel {
+		return MaxLevel
+	}
+	return level
+}
+
+// clampPct constrains a percentage to [0, 100].
+func clampPct(pct float64) float64 {
+	if pct < 0 {
+		return 0
+	}
+	if pct > pctScale {
+		return pctScale
+	}
+	return pct
+}
+
+// clampRate constrains a fraction to [0, 1].
+func clampRate(rate float64) float64 {
+	if rate < 0 {
+		return 0
+	}
+	if rate > 1 {
+		return 1
+	}
+	return rate
+}
+
+// formatPct renders a percentage without trailing zeros (e.g. "90%", "62.5%").
+func formatPct(pct float64) string {
+	return strings.TrimSuffix(strings.TrimRight(fmt.Sprintf("%.1f", pct), "0"), ".") + "%"
+}
+
+// boolWord renders a boolean as a human word.
+func boolWord(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// summarizeUnmet joins unmet criterion names into a readable clause.
+func summarizeUnmet(unmet []Criterion) string {
+	names := make([]string, 0, len(unmet))
+	for _, c := range unmet {
+		names = append(names, c.Name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/v2/pkg/acmmadvisor/acmmadvisor_test.go
+++ b/v2/pkg/acmmadvisor/acmmadvisor_test.go
@@ -1,0 +1,372 @@
+package acmmadvisor
+
+import (
+	"strings"
+	"testing"
+)
+
+// readySignals returns a Signals value that satisfies EVERY criterion for a
+// raise from the given current level, so tests can then knock out one signal at
+// a time to exercise not-ready paths.
+func readySignals(currentLevel int) Signals {
+	return Signals{
+		CurrentLevel:     currentLevel,
+		CoveragePct:      100,
+		GreenStreak:      100,
+		MergeSuccessRate: 1.0,
+		ActionableIssues: 0,
+		HoldCount:        0,
+		HasQualityAgent:  true,
+	}
+}
+
+func TestRecommend_ReadyRaisesEachLevel(t *testing.T) {
+	// From L1 through L5, fully-satisfied signals must advise raising exactly
+	// one level with Ready and no unmet criteria.
+	for from := MinLevel; from < MaxLevel; from++ {
+		from := from
+		t.Run("L"+itoa(from), func(t *testing.T) {
+			rec := Recommend(readySignals(from))
+			if rec.Advise != AdviseRaise {
+				t.Fatalf("L%d: want raise, got %q (%s)", from, rec.Advise, rec.Rationale)
+			}
+			if rec.TargetLevel != from+1 {
+				t.Fatalf("L%d: want target %d, got %d", from, from+1, rec.TargetLevel)
+			}
+			if !rec.Ready {
+				t.Fatalf("L%d: want Ready=true", from)
+			}
+			if len(rec.Unmet) != 0 {
+				t.Fatalf("L%d: want no unmet, got %+v", from, rec.Unmet)
+			}
+			if len(rec.Met) == 0 {
+				t.Fatalf("L%d: want some met criteria", from)
+			}
+			if !strings.Contains(rec.Rationale, "Human approval required") {
+				t.Fatalf("L%d: rationale must note human approval, got %q", from, rec.Rationale)
+			}
+		})
+	}
+}
+
+func TestRecommend_L6NeverProposesHigher(t *testing.T) {
+	rec := Recommend(readySignals(MaxLevel))
+	if rec.Advise != AdviseStay {
+		t.Fatalf("L6: want stay, got %q", rec.Advise)
+	}
+	if rec.TargetLevel != MaxLevel {
+		t.Fatalf("L6: target must stay at %d, got %d", MaxLevel, rec.TargetLevel)
+	}
+	if !rec.Ready {
+		t.Fatalf("L6: at max should be Ready (nothing to earn)")
+	}
+	if len(rec.Unmet) != 0 || len(rec.Met) != 0 {
+		t.Fatalf("L6: no criteria expected, got met=%d unmet=%d", len(rec.Met), len(rec.Unmet))
+	}
+	if !strings.Contains(rec.Rationale, "maximum") {
+		t.Fatalf("L6: rationale should mention maximum, got %q", rec.Rationale)
+	}
+}
+
+func TestRecommend_NeverSkipsLevels(t *testing.T) {
+	// Even with maximal signals, the proposed target is never more than one
+	// level above current.
+	for from := MinLevel; from <= MaxLevel; from++ {
+		rec := Recommend(readySignals(from))
+		if rec.TargetLevel > from+levelStep {
+			t.Fatalf("L%d: proposed skipping to %d", from, rec.TargetLevel)
+		}
+		if rec.TargetLevel > MaxLevel {
+			t.Fatalf("L%d: proposed above MaxLevel: %d", from, rec.TargetLevel)
+		}
+	}
+}
+
+func TestRecommend_L1GentleGate(t *testing.T) {
+	// L1→L2 must NOT require coverage/streak/merge — only a quality agent.
+	s := Signals{
+		CurrentLevel:    1,
+		CoveragePct:     0,
+		GreenStreak:     0,
+		HasQualityAgent: true,
+	}
+	rec := Recommend(s)
+	if rec.Advise != AdviseRaise {
+		t.Fatalf("L1 gentle gate: want raise with only quality agent, got %q (%s)", rec.Advise, rec.Rationale)
+	}
+	if len(rec.Met) != 1 {
+		t.Fatalf("L1 gentle gate: want exactly 1 criterion, got %d", len(rec.Met))
+	}
+}
+
+func TestRecommend_L1MissingQualityAgentStays(t *testing.T) {
+	rec := Recommend(Signals{CurrentLevel: 1, HasQualityAgent: false})
+	if rec.Advise != AdviseStay {
+		t.Fatalf("want stay without quality agent, got %q", rec.Advise)
+	}
+	if len(rec.Unmet) != 1 || rec.Unmet[0].Name != "Quality agent present" {
+		t.Fatalf("want quality-agent unmet, got %+v", rec.Unmet)
+	}
+	if !strings.Contains(rec.Rationale, "Quality agent present") {
+		t.Fatalf("rationale must name the unmet criterion, got %q", rec.Rationale)
+	}
+}
+
+func TestRecommend_L2GentlerThanL3(t *testing.T) {
+	// A hive at L2 with only a quality agent (no coverage/streak) must NOT
+	// advance, proving L2→L3 is stricter than L1→L2.
+	rec := Recommend(Signals{CurrentLevel: 2, HasQualityAgent: true})
+	if rec.Advise != AdviseStay {
+		t.Fatalf("L2→L3: want stay without coverage/streak, got %q", rec.Advise)
+	}
+	// Coverage and streak should both be unmet; quality agent should be met.
+	names := unmetNames(rec)
+	if !names["Test coverage"] || !names["Green-CI streak"] {
+		t.Fatalf("L2→L3: want coverage+streak unmet, got %+v", names)
+	}
+	if names["Quality agent present"] {
+		t.Fatalf("L2→L3: quality agent should be met")
+	}
+}
+
+func TestRecommend_NotReadyListsExactUnmet(t *testing.T) {
+	// From L5 (target L6), knock out coverage only; everything else satisfied.
+	// The unmet list must contain exactly the coverage criterion.
+	s := readySignals(5)
+	s.CoveragePct = coverageFloorL6 - 1 // just below the gate
+	rec := Recommend(s)
+	if rec.Advise != AdviseStay {
+		t.Fatalf("want stay when coverage below gate, got %q", rec.Advise)
+	}
+	if len(rec.Unmet) != 1 {
+		t.Fatalf("want exactly 1 unmet, got %d: %+v", len(rec.Unmet), rec.Unmet)
+	}
+	if rec.Unmet[0].Name != "Test coverage" {
+		t.Fatalf("want coverage unmet, got %q", rec.Unmet[0].Name)
+	}
+	if !rec.Unmet[0].Met == false { // sanity
+		t.Fatalf("unmet criterion should have Met=false")
+	}
+}
+
+func TestRecommend_L6RequiresFullGate(t *testing.T) {
+	// Exactly at the gate → met; one below → unmet.
+	atGate := readySignals(5)
+	atGate.CoveragePct = coverageGate
+	if rec := Recommend(atGate); rec.Advise != AdviseRaise {
+		t.Fatalf("coverage exactly at gate should raise, got %q", rec.Advise)
+	}
+
+	belowGate := readySignals(5)
+	belowGate.CoveragePct = coverageGate - 0.1
+	if rec := Recommend(belowGate); rec.Advise != AdviseStay {
+		t.Fatalf("coverage just below gate should stay, got %q", rec.Advise)
+	}
+}
+
+func TestRecommend_BoundaryValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Signals)
+		from      int
+		wantRaise bool
+	}{
+		{"streak exactly at L4 floor", func(s *Signals) { s.GreenStreak = greenStreakL4 }, 3, true},
+		{"streak one below L4 floor", func(s *Signals) { s.GreenStreak = greenStreakL4 - 1 }, 3, false},
+		{"merge rate exactly at L4", func(s *Signals) { s.MergeSuccessRate = mergeRateL4 }, 3, true},
+		{"merge rate just below L4", func(s *Signals) { s.MergeSuccessRate = mergeRateL4 - 0.001 }, 3, false},
+		{"backlog exactly at L5 ceil", func(s *Signals) { s.ActionableIssues = maxActionableL5 }, 4, true},
+		{"backlog one over L5 ceil", func(s *Signals) { s.ActionableIssues = maxActionableL5 + 1 }, 4, false},
+		{"holds exactly at L6 ceil", func(s *Signals) { s.HoldCount = maxHoldsL6 }, 5, true},
+		{"holds one over L6 ceil", func(s *Signals) { s.HoldCount = maxHoldsL6 + 1 }, 5, false},
+		{"coverage exactly at L3 floor", func(s *Signals) { s.CoveragePct = coverageFloorL3 }, 2, true},
+		{"coverage just below L3 floor", func(s *Signals) { s.CoveragePct = coverageFloorL3 - 0.1 }, 2, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := readySignals(tt.from)
+			tt.mutate(&s)
+			rec := Recommend(s)
+			gotRaise := rec.Advise == AdviseRaise
+			if gotRaise != tt.wantRaise {
+				t.Fatalf("%s: wantRaise=%v got advise=%q (%s)", tt.name, tt.wantRaise, rec.Advise, rec.Rationale)
+			}
+		})
+	}
+}
+
+func TestRecommend_ZeroSignalsSafe(t *testing.T) {
+	// The zero value must not panic and must advise staying at L1 (clamped).
+	rec := Recommend(Signals{})
+	if rec.CurrentLevel != MinLevel {
+		t.Fatalf("zero signals: want current clamped to %d, got %d", MinLevel, rec.CurrentLevel)
+	}
+	if rec.Advise != AdviseStay {
+		t.Fatalf("zero signals: want stay, got %q", rec.Advise)
+	}
+	if rec.Ready {
+		t.Fatalf("zero signals: should not be ready")
+	}
+}
+
+func TestRecommend_ClampsDegenerateLevels(t *testing.T) {
+	tests := []struct {
+		in   int
+		want int
+	}{
+		{-5, MinLevel},
+		{0, MinLevel},
+		{7, MaxLevel},
+		{999, MaxLevel},
+	}
+	for _, tt := range tests {
+		rec := Recommend(readySignals(tt.in))
+		if rec.CurrentLevel != tt.want {
+			t.Fatalf("level %d: want clamped to %d, got %d", tt.in, tt.want, rec.CurrentLevel)
+		}
+	}
+}
+
+func TestRecommend_ClampsOutOfRangeMetrics(t *testing.T) {
+	// Negative coverage / rate and >max values must be clamped and not panic.
+	s := readySignals(4)
+	s.CoveragePct = -50
+	s.MergeSuccessRate = -1
+	rec := Recommend(s)
+	if rec.Advise != AdviseStay {
+		t.Fatalf("negative coverage/rate should not pass, got %q", rec.Advise)
+	}
+	// Actual should render clamped to 0%.
+	var covActual string
+	for _, c := range rec.Unmet {
+		if c.Name == "Test coverage" {
+			covActual = c.Actual
+		}
+	}
+	if covActual != "0%" {
+		t.Fatalf("want clamped coverage Actual 0%%, got %q", covActual)
+	}
+
+	// Over-max coverage and rate clamp to the max and pass.
+	s2 := readySignals(4)
+	s2.CoveragePct = 500
+	s2.MergeSuccessRate = 5
+	if rec2 := Recommend(s2); rec2.Advise != AdviseRaise {
+		t.Fatalf("over-max coverage/rate should still pass, got %q", rec2.Advise)
+	}
+}
+
+func TestRecommend_Deterministic(t *testing.T) {
+	s := readySignals(3)
+	s.CoveragePct = 55
+	a := Recommend(s)
+	b := Recommend(s)
+	if a.Advise != b.Advise || a.Rationale != b.Rationale || len(a.Unmet) != len(b.Unmet) {
+		t.Fatalf("non-deterministic output: %+v vs %+v", a, b)
+	}
+}
+
+func TestRecommend_MergeRateRenderedAsPercent(t *testing.T) {
+	s := readySignals(3)
+	s.MergeSuccessRate = mergeRateL4 - 0.01 // 0.69
+	rec := Recommend(s)
+	var actual, required string
+	for _, c := range rec.Unmet {
+		if c.Name == "Merge success rate" {
+			actual, required = c.Actual, c.Required
+		}
+	}
+	if !strings.HasSuffix(actual, "%") || !strings.HasSuffix(required, "%") {
+		t.Fatalf("merge rate should render as percent, got actual=%q required=%q", actual, required)
+	}
+	if required != "70%" {
+		t.Fatalf("want required 70%%, got %q", required)
+	}
+}
+
+func TestRecommendFromStatus_PassThrough(t *testing.T) {
+	in := StatusInputs{
+		CurrentLevel:     5,
+		CoveragePct:      95,
+		GreenStreak:      20,
+		MergeSuccessRate: 0.99,
+		ActionableIssues: 2,
+		HoldCount:        1,
+		HasQualityAgent:  true,
+	}
+	rec := RecommendFromStatus(in)
+	direct := Recommend(Signals(in)) // StatusInputs mirrors Signals field-for-field.
+	if rec.Advise != direct.Advise || rec.TargetLevel != direct.TargetLevel {
+		t.Fatalf("RecommendFromStatus mismatch: %+v vs %+v", rec, direct)
+	}
+	if rec.Advise != AdviseRaise {
+		t.Fatalf("healthy L5 status should advise raise, got %q", rec.Advise)
+	}
+}
+
+func TestCriterionFieldsRenderable(t *testing.T) {
+	// Each criterion must carry a name, comparator, both values, and a detail
+	// so the dashboard can render a checklist row.
+	s := readySignals(4)
+	s.CoveragePct = 10 // force some unmet
+	rec := Recommend(s)
+	all := append(append([]Criterion{}, rec.Met...), rec.Unmet...)
+	if len(all) == 0 {
+		t.Fatal("expected criteria")
+	}
+	for _, c := range all {
+		if c.Name == "" || c.Required == "" || c.Actual == "" || c.Comparator == "" || c.Detail == "" {
+			t.Fatalf("criterion missing renderable field: %+v", c)
+		}
+	}
+}
+
+func TestFormatPct(t *testing.T) {
+	cases := map[float64]string{
+		90:   "90%",
+		62.5: "62.5%",
+		0:    "0%",
+		100:  "100%",
+		70:   "70%",
+	}
+	for in, want := range cases {
+		if got := formatPct(in); got != want {
+			t.Fatalf("formatPct(%v)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestBoolWord(t *testing.T) {
+	if boolWord(true) != "yes" || boolWord(false) != "no" {
+		t.Fatal("boolWord mapping wrong")
+	}
+}
+
+// ── small test helpers ──────────────────────────────────────────────────────
+
+func unmetNames(rec Recommendation) map[string]bool {
+	m := map[string]bool{}
+	for _, c := range rec.Unmet {
+		m[c.Name] = true
+	}
+	return m
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}

--- a/v2/pkg/acmmadvisor/wire.go
+++ b/v2/pkg/acmmadvisor/wire.go
@@ -1,0 +1,49 @@
+package acmmadvisor
+
+// This file holds the thin, forge-neutral bridge the dashboard/status builder
+// would call to attach a level-up recommendation to the status payload. It is
+// deliberately kept as a PURE computation here: it takes already-collected
+// signals and returns a recommendation. It does NOT read the config, apply a
+// level, or perform any I/O.
+//
+// TODO(acmm2-wiring): wire RecommendFromStatus into pkg/dashboard's
+// status_builder.go — populate a StatusPayload.ACMMAdvice field from the same
+// inputs the dashboard already gathers:
+//   - CurrentLevel: dashboard.detectACMMLevel(cfg)
+//   - CoveragePct:  MetricsCollector coverage ("coverage" key, collectCoverage)
+//   - GreenStreak / MergeSuccessRate: from issue-to-merge / CI metrics
+//   - ActionableIssues: len(actionable) already passed to buildRepos/buildHold
+//   - HoldCount: buildHold(actionable) count
+//   - HasQualityAgent: presence of an active "quality" agent in the pack
+// The dashboard must render Recommendation.Met/Unmet as a checklist and must
+// NEVER auto-apply the target level — a human approves via handlePackSetLevel.
+
+// StatusInputs is the forge-neutral bundle a status builder assembles from
+// already-collected metrics. It mirrors Signals but exists as a distinct
+// boundary type so the dashboard can populate it without importing internal
+// advisor thresholds.
+type StatusInputs struct {
+	CurrentLevel     int
+	CoveragePct      float64
+	GreenStreak      int
+	MergeSuccessRate float64
+	ActionableIssues int
+	HoldCount        int
+	HasQualityAgent  bool
+}
+
+// RecommendFromStatus adapts already-collected status inputs into a
+// Recommendation. It is a pure pass-through to Recommend and performs no I/O,
+// so it is safe to call from a hot status-build path. Callers attach the result
+// to their status payload; they must not act on it automatically.
+func RecommendFromStatus(in StatusInputs) Recommendation {
+	return Recommend(Signals{
+		CurrentLevel:     in.CurrentLevel,
+		CoveragePct:      in.CoveragePct,
+		GreenStreak:      in.GreenStreak,
+		MergeSuccessRate: in.MergeSuccessRate,
+		ActionableIssues: in.ActionableIssues,
+		HoldCount:        in.HoldCount,
+		HasQualityAgent:  in.HasQualityAgent,
+	})
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -36,6 +36,10 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
 	s.mux.HandleFunc("GET /api/style", s.handleStyle)
+	// ACMM level-up advice (ported from v4). ADVISORY ONLY — it computes a
+	// recommendation from already-collected signals and never applies a level;
+	// a human approves the actual change via handlePackSetLevel.
+	s.mux.HandleFunc("GET /api/acmm-recommendation", s.handleACMMRecommendation)
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
 	s.mux.HandleFunc("GET /api/config/provenance", s.handleConfigProvenance)

--- a/v2/pkg/dashboard/api_acmm_recommendation.go
+++ b/v2/pkg/dashboard/api_acmm_recommendation.go
@@ -1,0 +1,122 @@
+package dashboard
+
+import (
+	"net/http"
+
+	"github.com/kubestellar/hive/v2/pkg/acmmadvisor"
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// qualityAgentName is the config-level name of the quality/coverage agent that
+// owns the coverage loop. The ACMM advisor treats its presence in the active
+// config as the HasQualityAgent prerequisite (see pkg/config default agents and
+// pkg/acmmadvisor criteria).
+const qualityAgentName = "quality"
+
+// agentMetricsCIMaintainerKey is the AgentMetrics sub-map that carries the
+// coverage reading collected from the coverage badge (see
+// MetricsCollector.collect / collectCoverage). The coverage percentage lives at
+// AgentMetrics["ci-maintainer"]["coverage"].
+const agentMetricsCIMaintainerKey = "ci-maintainer"
+
+// agentMetricsCoverageKey is the field within the ci-maintainer metrics map
+// holding the integer coverage percentage.
+const agentMetricsCoverageKey = "coverage"
+
+// handleACMMRecommendation serves an advisory ACMM level-up recommendation
+// derived from the live status. It is additive, read-only, and ADVISORY ONLY:
+// it never changes the applied level (a human approves that via
+// handlePackSetLevel). Missing data degrades to conservative zero signals and
+// never panics, so the endpoint is safe on a freshly-booted hive with no
+// status yet.
+//
+// The response body is an acmmadvisor.Recommendation: the advise verb,
+// current/target level, readiness, and the Met/Unmet criteria checklist the UI
+// renders directly.
+func (s *Server) handleACMMRecommendation(w http.ResponseWriter, r *http.Request) {
+	rec := acmmadvisor.RecommendFromStatus(s.buildACMMStatusInputs())
+	jsonResponse(w, rec)
+}
+
+// buildACMMStatusInputs assembles the forge-neutral advisor inputs from the
+// signals the dashboard already gathers. It is nil-safe at every step: a nil
+// Server, nil deps, nil config, or nil cached status all collapse to safe zero
+// values rather than panicking. It fabricates nothing — signals the hive does
+// not yet track (green-CI streak, merge-success rate) are left at zero, which
+// the advisor treats as "not yet earned" rather than inventing a number.
+func (s *Server) buildACMMStatusInputs() acmmadvisor.StatusInputs {
+	in := acmmadvisor.StatusInputs{
+		// A hive with no explicit level detects as MinLevel (L1); see
+		// detectACMMLevel. Zero-value fallbacks keep this at a safe default.
+		CurrentLevel: acmmadvisor.MinLevel,
+		// GreenStreak and MergeSuccessRate are intentionally left at zero: the
+		// hive does not yet track a real green-CI streak or a merge-success
+		// rate as first-class signals, and the advisor must never fabricate
+		// them. They therefore read as "unknown / not yet earned", which only
+		// ever makes the advisor MORE conservative (it will not propose a raise
+		// on the strength of a made-up streak). When those signals become
+		// available, populate them here.
+		// TODO(acmm-signals): thread a real GreenStreak / MergeSuccessRate from
+		// CI/merge history once tracked.
+	}
+
+	var cfg *config.Config
+	if s != nil && s.deps != nil {
+		cfg = s.deps.Config
+	}
+	if cfg != nil {
+		in.CurrentLevel = detectACMMLevel(cfg)
+		in.HasQualityAgent = hasQualityAgent(cfg)
+	}
+
+	// Live queue/coverage signals come from the most recent status snapshot the
+	// eval loop published. Read it under the status lock and tolerate a nil
+	// snapshot (no eval has run yet).
+	if s != nil {
+		s.statusMu.RLock()
+		status := s.status
+		s.statusMu.RUnlock()
+		if status != nil {
+			in.ActionableIssues = status.Governor.Issues
+			in.HoldCount = status.Hold.Total
+			in.CoveragePct = coverageFromAgentMetrics(status.AgentMetrics)
+		}
+	}
+
+	return in
+}
+
+// hasQualityAgent reports whether an active quality/coverage agent is present
+// in the config. Nil-safe.
+func hasQualityAgent(cfg *config.Config) bool {
+	if cfg == nil || cfg.Agents == nil {
+		return false
+	}
+	_, ok := cfg.Agents[qualityAgentName]
+	return ok
+}
+
+// coverageFromAgentMetrics extracts the integer coverage percentage from the
+// AgentMetrics map, returning 0 when absent or malformed. The value is stored
+// under AgentMetrics["ci-maintainer"]["coverage"] by collectCoverage; JSON
+// round-trips can render it as int or float64, so both numeric forms are
+// handled.
+func coverageFromAgentMetrics(metrics map[string]any) float64 {
+	if metrics == nil {
+		return 0
+	}
+	ci, ok := metrics[agentMetricsCIMaintainerKey].(map[string]any)
+	if !ok {
+		return 0
+	}
+	switch v := ci[agentMetricsCoverageKey].(type) {
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case float64:
+		return v
+	default:
+		return 0
+	}
+}

--- a/v2/pkg/dashboard/api_acmm_recommendation_test.go
+++ b/v2/pkg/dashboard/api_acmm_recommendation_test.go
@@ -1,0 +1,201 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/acmmadvisor"
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestHandleACMMRecommendationEmpty verifies the endpoint is safe with a
+// zero/empty server (no deps, no status): it returns 200 JSON with a valid
+// recommendation and never panics.
+func TestHandleACMMRecommendationEmpty(t *testing.T) {
+	s := newTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/acmm-recommendation", nil)
+	rr := httptest.NewRecorder()
+	s.handleACMMRecommendation(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type = %q", ct)
+	}
+
+	var rec acmmadvisor.Recommendation
+	if err := json.Unmarshal(rr.Body.Bytes(), &rec); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, rr.Body.String())
+	}
+	// Empty status → conservative L1, no quality agent → advise stay.
+	if rec.CurrentLevel != acmmadvisor.MinLevel {
+		t.Fatalf("CurrentLevel = %d, want %d", rec.CurrentLevel, acmmadvisor.MinLevel)
+	}
+	if rec.Advise != acmmadvisor.AdviseStay {
+		t.Fatalf("Advise = %q, want stay (no quality agent)", rec.Advise)
+	}
+	if rec.Rationale == "" {
+		t.Fatal("Rationale must be populated")
+	}
+}
+
+// TestHandleACMMRecommendationWithSignals drives the endpoint with a live
+// config + status snapshot and asserts the advisor consumes the real signals.
+func TestHandleACMMRecommendationWithSignals(t *testing.T) {
+	s := newTestServer()
+
+	// L1 with a quality agent present → the gentle L1→L2 gate is satisfied.
+	lvl := 1
+	s.deps = &Dependencies{
+		Config: &config.Config{
+			ACMMLevel: &lvl,
+			Agents: map[string]config.AgentConfig{
+				qualityAgentName: {},
+			},
+		},
+	}
+
+	// Publish a status snapshot carrying live queue/coverage signals.
+	status := minimalPayload()
+	status.ACMMLevel = 1
+	status.Governor.Issues = 3
+	status.Hold.Total = 2
+	status.AgentMetrics = map[string]any{
+		agentMetricsCIMaintainerKey: map[string]any{
+			agentMetricsCoverageKey: 42,
+		},
+	}
+	s.UpdateStatus(status)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/acmm-recommendation", nil)
+	rr := httptest.NewRecorder()
+	s.handleACMMRecommendation(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var rec acmmadvisor.Recommendation
+	if err := json.Unmarshal(rr.Body.Bytes(), &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rec.CurrentLevel != 1 {
+		t.Fatalf("CurrentLevel = %d, want 1", rec.CurrentLevel)
+	}
+	// L1→L2 only requires a quality agent, which is present → advise raise.
+	if rec.Advise != acmmadvisor.AdviseRaise {
+		t.Fatalf("Advise = %q, want raise (quality agent present at L1); rationale=%q", rec.Advise, rec.Rationale)
+	}
+	if rec.TargetLevel != 2 {
+		t.Fatalf("TargetLevel = %d, want 2", rec.TargetLevel)
+	}
+}
+
+// TestBuildACMMStatusInputs_ReadsLiveSignals unit-tests the signal mapping in
+// isolation, including the coverage extraction and nil-safety.
+func TestBuildACMMStatusInputs_ReadsLiveSignals(t *testing.T) {
+	s := newTestServer()
+	lvl := 3
+	s.deps = &Dependencies{
+		Config: &config.Config{
+			ACMMLevel: &lvl,
+			Agents:    map[string]config.AgentConfig{qualityAgentName: {}},
+		},
+	}
+	status := minimalPayload()
+	status.Governor.Issues = 7
+	status.Hold.Total = 4
+	status.AgentMetrics = map[string]any{
+		agentMetricsCIMaintainerKey: map[string]any{
+			// float64 form (as after a JSON round-trip) must also parse.
+			agentMetricsCoverageKey: float64(88),
+		},
+	}
+	s.UpdateStatus(status)
+
+	in := s.buildACMMStatusInputs()
+	if in.CurrentLevel != 3 {
+		t.Fatalf("CurrentLevel = %d, want 3", in.CurrentLevel)
+	}
+	if !in.HasQualityAgent {
+		t.Fatal("HasQualityAgent = false, want true")
+	}
+	if in.ActionableIssues != 7 {
+		t.Fatalf("ActionableIssues = %d, want 7", in.ActionableIssues)
+	}
+	if in.HoldCount != 4 {
+		t.Fatalf("HoldCount = %d, want 4", in.HoldCount)
+	}
+	if in.CoveragePct != 88 {
+		t.Fatalf("CoveragePct = %v, want 88", in.CoveragePct)
+	}
+	// Signals the hive does not track must remain zero (never fabricated).
+	if in.GreenStreak != 0 || in.MergeSuccessRate != 0 {
+		t.Fatalf("GreenStreak/MergeSuccessRate should be 0, got %d / %v", in.GreenStreak, in.MergeSuccessRate)
+	}
+}
+
+// TestBuildACMMStatusInputs_NilSafe confirms zero signals on a bare server.
+func TestBuildACMMStatusInputs_NilSafe(t *testing.T) {
+	s := newTestServer()
+	in := s.buildACMMStatusInputs()
+	if in.CurrentLevel != acmmadvisor.MinLevel {
+		t.Fatalf("CurrentLevel = %d, want %d", in.CurrentLevel, acmmadvisor.MinLevel)
+	}
+	if in.HasQualityAgent {
+		t.Fatal("HasQualityAgent should be false on a bare server")
+	}
+	if in.CoveragePct != 0 || in.ActionableIssues != 0 || in.HoldCount != 0 {
+		t.Fatalf("expected zero signals, got %+v", in)
+	}
+}
+
+// TestCoverageFromAgentMetrics covers the numeric-form and malformed cases.
+func TestCoverageFromAgentMetrics(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want float64
+	}{
+		{"nil map", nil, 0},
+		{"missing ci-maintainer", map[string]any{"x": 1}, 0},
+		{"int", map[string]any{agentMetricsCIMaintainerKey: map[string]any{agentMetricsCoverageKey: 91}}, 91},
+		{"float64", map[string]any{agentMetricsCIMaintainerKey: map[string]any{agentMetricsCoverageKey: float64(75)}}, 75},
+		{"wrong type", map[string]any{agentMetricsCIMaintainerKey: map[string]any{agentMetricsCoverageKey: "nope"}}, 0},
+		{"ci not a map", map[string]any{agentMetricsCIMaintainerKey: 5}, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := coverageFromAgentMetrics(c.in); got != c.want {
+				t.Fatalf("coverageFromAgentMetrics = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestHandleACMMRecommendationViaMux exercises route registration end-to-end.
+func TestHandleACMMRecommendationViaMux(t *testing.T) {
+	s := newTestServer()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/acmm-recommendation", s.handleACMMRecommendation)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/acmm-recommendation")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var rec acmmadvisor.Recommendation
+	if err := json.NewDecoder(resp.Body).Decode(&rec); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

First step in shrinking the v2↔v4 divergence — currently **275 commits, 446 files, ~50k insertions**.

`acmmadvisor` is the cleanest candidate in that diff: **stdlib only, no I/O, no clocks, no randomness, and zero hive-internal imports**. It ported with no adaptation.

## What it does

Computes a coverage-driven, guided **level-up recommendation** for a hive's ACMM level. The thesis is *"you earn automation with test coverage"* — a hive advances only once it demonstrates sustained coverage, a green-CI / merge-success record, a controlled actionable backlog, and few outstanding holds.

**Advisory only.** It never changes the applied level; it returns a recommendation plus the exact met/unmet criteria. A human still approves via `handlePackSetLevel`. That's what makes it safe to land on v2 while the fleet stays on v2.

Ported verbatim — `acmmadvisor.go`, `wire.go`, its test, plus the dashboard handler and its test — and registered the single route v4 uses:

```
GET /api/acmm-recommendation
```

## How this candidate was chosen — and two wrong answers first

I recommended **`skillreg`**, then **`retro`**, on the strength of import-count scripts. Both were wrong:

- `skillreg` pulls in `agentsmd`
- `retro` pulls in `escalation` + `outputschema` + `timeline` — and `timeline` alone touches **8** existing v2 files

A "corrected" script then reported `retro` as clean. **That script was also broken** — a `grep -qx` against a newline-joined string, which silently matched. Only checking each import directly against v2's real package list was trustworthy, and that's what selected `acmmadvisor`.

Recording this because the diff-shrinking exercise depends on the dependency analysis being right, and two plausible-looking scripts gave confidently wrong answers.

## The handler compiled before it was routed

Building and passing tests proved only that the code **existed**, not that anything could reach it — v2's router had no entry for it. That's a silent no-op of exactly the kind this codebase keeps producing.

Added the route, then drove the **real mux** in a throwaway test to confirm reachability:

```
route reachable: HTTP 200, body={"Advise":"stay","CurrentLevel":2,"TargetLevel":3,
"Ready":false,"Met":[],"Unmet":[{"Name":"Quality agent present",...
```

A live recommendation payload, not a 404.

## Verification

- `go build`, `go vet`, `gofmt` all clean
- `pkg/acmmadvisor` → `ok`
- `pkg/dashboard` → `ok`, **0 failures**

## Next candidates

`intent` (1,175 LOC) imports only `beads`, which is already on v2 — the next-cleanest port on the same criteria.