### PR TITLE
✨ feat(gateway): record a key name for all model gateways (#3606)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -675,6 +675,16 @@ type GatewayConfig struct {
 	// preset uses to build the endpoint template. Purely a convenience for the
 	// preset; Endpoint is authoritative. Only meaningful for Kind == watsonx.
 	Region string `yaml:"region,omitempty" json:"region,omitempty"`
+	// KeyName is an optional, human-chosen LABEL for this gateway's configured
+	// key ("Team inference key", "andy personal", …). It is safe-to-show
+	// metadata, NOT a secret — it records WHICH key a gateway is set to use so
+	// managers can tell keys apart without ever seeing the value. Mirrors the
+	// bob key's KeyName (#3596/#3598), now generalized to every gateway kind
+	// (litellm / openrouter / watsonx / vllm). omitempty keeps hive.yaml on
+	// existing gateways (which never recorded a name) byte-identical on
+	// round-trip; an absent name is a normal, backwards-compatible state the
+	// dashboard renders as "(unnamed)" rather than an error.
+	KeyName string `yaml:"key_name,omitempty" json:"key_name,omitempty"`
 }
 
 // gatewayKind values.

--- a/v2/pkg/dashboard/gateway_key_name_test.go
+++ b/v2/pkg/dashboard/gateway_key_name_test.go
@@ -1,0 +1,221 @@
+package dashboard
+
+// Tests for the optional key NAME/label recorded alongside a model gateway's
+// API key (#3606). The name generalizes the bob key's KeyName (#3596/#3598) to
+// every gateway kind (litellm / openrouter / watsonx / vllm). It is
+// safe-to-show metadata that lets managers tell WHICH key a gateway uses
+// without ever exposing the value. These tests pin the round-trip, the
+// backwards-compatible absent-name state, and that the label is never confused
+// with (nor allowed to leak) the secret.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+const gwKeyNameTestKey = "sk-key-name-test-value-1234567890"
+
+// upsertGatewayForNameTest points the secret dir at a temp dir and PUTs the
+// given JSON body through the upsert handler, returning the recorder.
+func upsertGatewayForNameTest(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	dir := t.TempDir()
+	orig := gatewaySecretsDir
+	gatewaySecretsDir = dir
+	t.Cleanup(func() { gatewaySecretsDir = orig })
+
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/gateways", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorGatewaysUpsert(rec, req)
+	return rec
+}
+
+// Setting a gateway key WITH a name records the label and returns it in the
+// response and list, while the key value itself never appears.
+func TestGatewayUpsert_SetWithNameRecordsLabel(t *testing.T) {
+	srv := newFullServer(t)
+	const wantName = "Team inference key"
+	body := `{"name":"openrouter","kind":"openrouter","endpoint":"https://openrouter.ai/api/v1",` +
+		`"api_key":"` + gwKeyNameTestKey + `","key_name":"` + wantName + `"}`
+	rec := upsertGatewayForNameTest(t, srv, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), gwKeyNameTestKey) {
+		t.Error("response body leaks the key value")
+	}
+	gws := srv.deps.Config.Governor.Gateways
+	if len(gws) != 1 || gws[0].KeyName != wantName {
+		t.Fatalf("stored KeyName = %q, want %q", func() string {
+			if len(gws) == 1 {
+				return gws[0].KeyName
+			}
+			return "<no gateway>"
+		}(), wantName)
+	}
+	var resp struct {
+		Gateway map[string]interface{} `json:"gateway"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Gateway["keyName"] != wantName {
+		t.Errorf("response keyName = %v, want %q", resp.Gateway["keyName"], wantName)
+	}
+}
+
+// A name is trimmed of surrounding whitespace (it is a display string) but
+// interior spaces are preserved.
+func TestGatewayUpsert_NameIsTrimmed(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"name":"openrouter","kind":"openrouter","endpoint":"https://openrouter.ai/api/v1",` +
+		`"api_key":"` + gwKeyNameTestKey + `","key_name":"   spaced label   "}`
+	rec := upsertGatewayForNameTest(t, srv, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := srv.deps.Config.Governor.Gateways[0].KeyName; got != "spaced label" {
+		t.Errorf("KeyName = %q, want %q", got, "spaced label")
+	}
+}
+
+// An oversized name is rejected and nothing is stored.
+func TestGatewayUpsert_OversizedNameRejected(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"name":"openrouter","kind":"openrouter","endpoint":"https://openrouter.ai/api/v1",` +
+		`"api_key":"` + gwKeyNameTestKey + `","key_name":"` + strings.Repeat("x", gatewayKeyNameMaxLen+1) + `"}`
+	rec := upsertGatewayForNameTest(t, srv, body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if len(srv.deps.Config.Governor.Gateways) != 0 {
+		t.Error("a gateway was stored for a request rejected on name length")
+	}
+}
+
+// BACKWARDS COMPAT: setting a gateway key with NO key_name field leaves the
+// name empty — never an error. This is how existing gateways (which never
+// recorded a name) behave.
+func TestGatewayUpsert_AbsentNameIsSafe(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"name":"openrouter","kind":"openrouter","endpoint":"https://openrouter.ai/api/v1",` +
+		`"api_key":"` + gwKeyNameTestKey + `"}`
+	rec := upsertGatewayForNameTest(t, srv, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := srv.deps.Config.Governor.Gateways[0].KeyName; got != "" {
+		t.Errorf("KeyName = %q, want empty when no name is supplied", got)
+	}
+	var resp struct {
+		Gateway map[string]interface{} `json:"gateway"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Gateway["keyName"] != "" {
+		t.Errorf("response keyName = %v, want empty string", resp.Gateway["keyName"])
+	}
+}
+
+// An absent (nil) key_name on an edit keeps the existing name, so rotating a
+// key without re-typing its label does not silently wipe it. An explicit empty
+// string clears it.
+func TestGatewayUpsert_EditKeepsThenClearsName(t *testing.T) {
+	srv := newFullServer(t)
+	// Seed a gateway that already has a name.
+	seed := `{"name":"openrouter","kind":"openrouter","endpoint":"https://openrouter.ai/api/v1",` +
+		`"api_key":"` + gwKeyNameTestKey + `","key_name":"existing label"}`
+	if rec := upsertGatewayForNameTest(t, srv, seed); rec.Code != http.StatusOK {
+		t.Fatalf("seed status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	// Edit sending no key_name field: the label must survive.
+	edit := `{"name":"openrouter","kind":"openrouter","endpoint":"https://openrouter.ai/api/v1"}`
+	if rec := upsertGatewayForNameTest(t, srv, edit); rec.Code != http.StatusOK {
+		t.Fatalf("edit status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := srv.deps.Config.Governor.Gateways[0].KeyName; got != "existing label" {
+		t.Errorf("name after nameless edit = %q, want it preserved", got)
+	}
+
+	// Now send an explicit empty string: the label is cleared.
+	clear := `{"name":"openrouter","kind":"openrouter","endpoint":"https://openrouter.ai/api/v1","key_name":""}`
+	if rec := upsertGatewayForNameTest(t, srv, clear); rec.Code != http.StatusOK {
+		t.Fatalf("clear-name status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := srv.deps.Config.Governor.Gateways[0].KeyName; got != "" {
+		t.Errorf("name after explicit empty = %q, want cleared", got)
+	}
+}
+
+// The list endpoint surfaces the recorded name (safe metadata) and never the
+// key value.
+func TestGatewaysList_ReturnsKeyName(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Governor.Gateways = []config.GatewayConfig{{
+		Name:     "openrouter",
+		Kind:     "openrouter",
+		Endpoint: "https://openrouter.ai/api/v1",
+		KeyName:  "prod key",
+	}}
+	req := httptest.NewRequest(http.MethodGet, "/api/config/governor/gateways", nil)
+	rec := httptest.NewRecorder()
+	srv.handleGovernorGatewaysList(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Gateways []map[string]interface{} `json:"gateways"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Gateways) != 1 || resp.Gateways[0]["keyName"] != "prod key" {
+		t.Errorf("list keyName = %v, want %q", resp.Gateways, "prod key")
+	}
+}
+
+// BACKWARDS COMPAT at the config layer: a GatewayConfig with no key_name
+// round-trips through YAML byte-identically (the omitempty tag), so existing
+// gateways that never recorded a name are not rewritten with a spurious field.
+func TestGatewayConfig_KeyNameOmitemptyRoundTrip(t *testing.T) {
+	// No name set: the field must NOT appear in the marshaled YAML.
+	noName := config.GatewayConfig{Name: "openrouter", Endpoint: "https://openrouter.ai/api/v1"}
+	out, err := yaml.Marshal(noName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "key_name") {
+		t.Errorf("empty KeyName leaked a key_name field into YAML:\n%s", out)
+	}
+
+	// Name set: it round-trips.
+	withName := config.GatewayConfig{Name: "openrouter", Endpoint: "https://openrouter.ai/api/v1", KeyName: "Team key"}
+	out, err = yaml.Marshal(withName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "key_name: Team key") {
+		t.Errorf("KeyName did not marshal as key_name:\n%s", out)
+	}
+	var back config.GatewayConfig
+	if err := yaml.Unmarshal(out, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.KeyName != "Team key" {
+		t.Errorf("KeyName after round-trip = %q, want %q", back.KeyName, "Team key")
+	}
+}

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -87,6 +87,13 @@ const (
 	// maxGatewayNameLen bounds a gateway name so it stays usable as an agent
 	// backend id and as a filesystem-safe secret filename component.
 	maxGatewayNameLen = 64
+
+	// gatewayKeyNameMaxLen bounds the optional human LABEL for a gateway's key.
+	// It is a short display string ("Team inference key"), not the secret, so
+	// the limit is generous enough for a descriptive name yet small enough that
+	// a stray paste into the name field cannot bloat hive.yaml. Matches the bob
+	// key's bobKeyNameMaxLen (#3598).
+	gatewayKeyNameMaxLen = 128
 )
 
 // validGatewayKinds is the set of kinds the UI presets map to. An empty kind is
@@ -126,6 +133,11 @@ func gatewaySectionResponse(gw config.GatewayConfig) map[string]interface{} {
 		"region":     gw.Region,
 		"hasKey":     key != "",
 		"keyHint":    keyHint,
+		// keyName is the operator-chosen LABEL for this gateway's key, not the
+		// key value — safe to serialize. Empty on gateways that never recorded
+		// a name (the dashboard renders that as "(unnamed)"), so no
+		// backwards-compat break.
+		"keyName": gw.KeyName,
 	}
 }
 
@@ -165,6 +177,11 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 		CABundle     *string `json:"ca_bundle"`
 		ProjectID    *string `json:"project_id"`
 		Region       *string `json:"region"`
+		// KeyName is an optional human LABEL recorded alongside the key so
+		// managers can tell WHICH key a gateway uses without seeing the value.
+		// It is not a secret and is stored in plaintext in hive.yaml. Absent
+		// (nil) leaves any existing name untouched; present-but-empty clears it.
+		KeyName *string `json:"key_name"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -237,6 +254,22 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 		}
 	}
 
+	// Normalize the optional key NAME. It is a label, not a secret: leading and
+	// trailing whitespace is trimmed (a name is a display string, not a token),
+	// interior whitespace is allowed ("Team inference key"), and only the length
+	// is bounded. nil means "leave the existing name as-is"; an explicit empty
+	// string clears it. Validated before any secret file is written so a
+	// rejected name never leaves a stray key behind.
+	var keyName string
+	keyNameProvided := body.KeyName != nil
+	if keyNameProvided {
+		keyName = strings.TrimSpace(*body.KeyName)
+		if len(keyName) > gatewayKeyNameMaxLen {
+			jsonError(w, fmt.Sprintf("key name is too long (limit %d characters)", gatewayKeyNameMaxLen), http.StatusBadRequest)
+			return
+		}
+	}
+
 	cfg := s.deps.Config
 
 	// Find an existing entry so we can preserve fields the caller left blank
@@ -261,6 +294,7 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 		gw.CABundle = gws[idx].CABundle
 		gw.ProjectID = gws[idx].ProjectID
 		gw.Region = gws[idx].Region
+		gw.KeyName = gws[idx].KeyName
 	}
 	if body.APIKeyEnv != nil {
 		gw.APIKeyEnv = strings.TrimSpace(*body.APIKeyEnv)
@@ -279,6 +313,12 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 	}
 	if body.Region != nil {
 		gw.Region = strings.TrimSpace(*body.Region)
+	}
+	// Record the label only when the caller supplied the field, so a name-less
+	// "Replace key" PUT keeps the existing name rather than wiping it. A
+	// provided empty string intentionally clears it.
+	if keyNameProvided {
+		gw.KeyName = keyName
 	}
 
 	submittedKey := strings.TrimSpace(body.APIKey)

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -15581,8 +15581,12 @@ function burnAreaChart() {
       }
       host.innerHTML = _gateways.map(function(gw) {
         const meta = gatewayKindMeta(gw.kind);
+        // keyName is the operator-chosen LABEL for the key (safe to show, never
+        // the secret). When a key is set we surface it — a recorded name, or
+        // "(unnamed)" for gateways that never recorded one — so a manager can
+        // tell WHICH key each gateway uses without seeing the value.
         const keyLine = gw.hasKey
-          ? `key set${gw.keyHint ? ' (' + esc(gw.keyHint) + ')' : ''}`
+          ? `key set${gw.keyHint ? ' (' + esc(gw.keyHint) + ')' : ''} · Using key: ${esc(gw.keyName || '(unnamed)')}`
           : 'no key';
         return `
         <div style="border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:10px;background:var(--surface)">
@@ -15723,7 +15727,7 @@ function burnAreaChart() {
       const host = document.getElementById('gateways-form-host');
       if (!host) return;
       const isEdit = !!existing;
-      const gw = existing || { name: '', kind: 'custom', endpoint: '', default_model: '', hasKey: false, project_id: '' };
+      const gw = existing || { name: '', kind: 'custom', endpoint: '', default_model: '', hasKey: false, project_id: '', keyName: '' };
       const presetButtons = GATEWAY_PRESETS.map(function(p) {
         const active = gw.kind === p.kind;
         return `<button type="button" onclick="applyGatewayPreset('${p.kind}')" data-gw-preset="${p.kind}" style="padding:5px 12px;border:1px solid ${active ? 'var(--cyan)' : 'var(--border)'};border-radius:6px;background:${active ? 'var(--cyan)' : 'var(--bg)'};color:${active ? 'var(--bg)' : 'var(--fg)'};cursor:pointer;font-size:0.74rem;font-weight:600">${esc(p.label)}</button>`;
@@ -15753,6 +15757,11 @@ function burnAreaChart() {
             <label>API Key</label>
             <input type="password" id="gw-apikey" value="" autocomplete="new-password" placeholder="${gw.hasKey ? '(key is set — enter a new key to replace it)' : 'sk-…'}" onchange="onGatewayEndpointOrKeyChange()">
             <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Stored as a secret on this hive (owner-only file), never in config.</div>
+          </div>
+          <div class="config-field" style="margin-bottom:10px">
+            <label>Key name <span style="color:var(--muted);font-weight:400">(optional label, not the secret)</span></label>
+            <input type="text" id="gw-key-name" value="${esc(gw.keyName || '')}" autocomplete="off" spellcheck="false" maxlength="128" placeholder="e.g. Team inference key">
+            <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">A plaintext label that records WHICH key this is so you can tell keys apart later — never the value. Leave blank for "(unnamed)".</div>
           </div>
           <div class="config-field" style="margin-bottom:10px">
             <label>Default Model</label>
@@ -15920,6 +15929,7 @@ function burnAreaChart() {
       const endpoint = (document.getElementById('gw-endpoint') || {}).value || '';
       const apiKey = (document.getElementById('gw-apikey') || {}).value || '';
       const projectId = (document.getElementById('gw-project-id') || {}).value || '';
+      const keyName = (document.getElementById('gw-key-name') || {}).value || '';
       const defaultModel = gatewayCurrentDefaultModel();
       const resultEl = document.getElementById('gw-form-result');
       if (!name.trim()) { showToast('Gateway name is required', 'error'); return; }
@@ -15933,6 +15943,11 @@ function burnAreaChart() {
         // Always sent so clearing the field on a non-watsonx gateway persists;
         // omitempty on the server keeps it out of hive.yaml when blank.
         project_id: projectId.trim(),
+        // The optional plaintext LABEL for the key (never the value). Always
+        // sent (even empty) so blanking the field clears a stale name; the
+        // server trims and length-bounds it, and omitempty keeps it out of
+        // hive.yaml when blank.
+        key_name: keyName.trim(),
       };
       // Persist the watsonx region (the preset derives the endpoint from it and
       // the server can too when the endpoint is blank).


### PR DESCRIPTION
## What

Follow-up to #3596 (merged as #3598), which added an optional **key name** to the Bob/governor API key. This generalizes the same pattern to the unified **`GatewayConfig`**, so a hive manager can tell *which* key each model gateway (litellm / openrouter / watsonx / vllm) uses — **without ever seeing the secret**.

## Changes

- **`v2/pkg/config/config.go`** — add optional `KeyName string` with `yaml:"key_name,omitempty" json:"key_name,omitempty"` to `GatewayConfig`, mirroring `BobConfig.KeyName`. Safe-to-show label, not a secret.
- **`v2/pkg/dashboard/gateways.go`** — the upsert handler (`handleGovernorGatewaysUpsert`) accepts an optional `key_name`: trimmed, interior spaces allowed, length-bounded by the new named const `gatewayKeyNameMaxLen = 128` (no magic number; matches the bob key's `bobKeyNameMaxLen`). Same **nil-keeps / empty-clears** semantics as #3598 — a name-less "Replace key" edit preserves the existing label. Both the list (`gatewaySectionResponse`) and upsert responses return the gateway's `keyName` (metadata only, never the value). Deleting a gateway removes the whole `GatewayConfig`, so no stale name can linger.
- **`v2/pkg/dashboard/static/index.html`** — the gateway form gains an optional "Key name" field (pre-filled with the current name, `maxlength=128`); the gateway row shows `Using key: <name>` or `(unnamed)` beside a set key. The secret is never rendered.

## Backwards-compatibility

- `omitempty` → existing gateways round-trip `hive.yaml` byte-identically (no migration).
- Absent name → rendered as `(unnamed)`, never an error.
- Rotating a key with a `nil` name keeps the label; an explicit `""` clears it.

## Tests

New `v2/pkg/dashboard/gateway_key_name_test.go`:
- set-with-name records the label and echoes it (never the value)
- name is trimmed; interior spaces preserved
- oversized name rejected, nothing stored
- absent name is safe (empty, not an error)
- edit keeps the name on a nameless PUT, then clears on explicit `""`
- list endpoint returns `keyName`
- `omitempty` YAML round-trip (no `key_name` when empty; round-trips when set)

All new + existing `Gateway` tests pass; `go vet` clean on `pkg/config` and `pkg/dashboard`.

Fixes #3606

🤖 Generated with [Claude Code](https://claude.com/claude-code)