### PR TITLE
✨ feat(governor): operator-facing budget window reset

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -122,6 +122,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/thresholds", s.handleGovernorThresholds)
 	s.mux.HandleFunc("PUT /api/config/governor/labels", s.handleGovernorLabels)
 	s.mux.HandleFunc("PUT /api/config/governor/budget", s.handleGovernorBudget)
+	s.mux.HandleFunc("POST /api/config/governor/budget/reset", s.handleGovernorBudgetReset)
 	s.mux.HandleFunc("PUT /api/config/governor/notifications", s.handleGovernorNotifications)
 	s.mux.HandleFunc("PUT /api/config/governor/health", s.handleGovernorHealth)
 	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
@@ -4184,6 +4185,22 @@ func (s *Server) handleGovernorBudget(w http.ResponseWriter, r *http.Request) {
 	s.auditFromRequest(r, "config_governor_budget", auditDetail("section", "budget"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// handleGovernorBudgetReset opens a fresh budget window on demand. The
+// operator's recovery path when the window's spend has (or a mis-sized limit
+// has) closed the kick gate: fix the limit via PUT /budget, then reset the
+// window here so kicks resume immediately — budgeting stays ON, unlike the
+// "ignore budget" bypass. Spend re-anchors at zero and the once-per-window
+// alerts rearm.
+func (s *Server) handleGovernorBudgetReset(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	s.deps.Governor.ResetBudgetWindow()
+	s.auditFromRequest(r, "governor_budget_window_reset", auditDetail("section", "budget"), "")
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "reset"})
 }
 
 func (s *Server) handleGovernorNotifications(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/budget_reset_api_test.go
+++ b/v2/pkg/dashboard/budget_reset_api_test.go
@@ -1,0 +1,32 @@
+package dashboard
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// POST /api/config/governor/budget/reset must open a fresh budget window:
+// spend re-anchors at zero (old spend folded into the baseline) so suppressed
+// kicks resume while budget enforcement stays on.
+func TestGovernorBudgetResetEndpoint(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Governor.SetBudgetLimit(100)
+	deps.Governor.SeedBudget(500, nil, nil, time.Now())
+
+	rec := doPost(s, "/api/config/governor/budget/reset", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	b := deps.Governor.GetBudget()
+	if b.CurrentSpend != 0 {
+		t.Errorf("spend = %d, want 0 after reset", b.CurrentSpend)
+	}
+	if b.WindowBaseline != 500 {
+		t.Errorf("baseline = %d, want 500 (old window's spend folded in)", b.WindowBaseline)
+	}
+	if b.ResetAt.IsZero() {
+		t.Error("ResetAt should be stamped by the reset")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6841,6 +6841,25 @@
         .then(r => r.json()).then(d => { budgetIgnored = d.ignored; renderAll(); });
     }
 
+    // Opens a fresh budget window: spend re-anchors at 0, the exhausted gate
+    // reopens, budgeting stays ON. The recovery path when a mis-sized (or
+    // genuinely spent) budget is suppressing kicks — unlike "ignore budget",
+    // which turns enforcement off entirely.
+    async function resetBudgetWindow() {
+      try {
+        const r = await fetch('/api/config/governor/budget/reset', { method: 'POST', headers: _inceptionAuthHeaders() });
+        if (!r.ok) {
+          const d = await r.json().catch(() => ({}));
+          showToast(d.error || ('Failed to reset budget window (HTTP ' + r.status + ')'), 'error');
+          return;
+        }
+        showToast('Budget window reset — spend restarts at 0, suppressed kicks resume', 'success');
+        renderAll();
+      } catch (e) {
+        showToast('Failed to reset budget window: ' + e.message, 'error');
+      }
+    }
+
     function renderBudgetBar(budget) {
       if (!budget || !budget.BUDGET_WEEKLY) return '';
       const PCT_SAFE = 50;
@@ -6863,7 +6882,7 @@
         govAction = '<span style="color:var(--muted)">Budget enforcement disabled by operator</span>';
       } else if (exhausted) {
         const windowEnds = budget.WINDOW_ENDS_AT ? new Date(budget.WINDOW_ENDS_AT).toLocaleString() : 'the next window';
-        govAction = `<span style="color:var(--red)" title="Agents on the budget exempt list keep running">budget exhausted — agent kicks suspended until ${windowEnds}</span>`;
+        govAction = `<span style="color:var(--red)" title="Agents on the budget exempt list keep running">budget exhausted — agent kicks suspended until ${windowEnds}</span> <button onclick="resetBudgetWindow()" title="Open a fresh budget window now: spend restarts at 0 and suspended kicks resume. Budget enforcement stays on — raise Total Tokens in Governor Config first if the limit itself was too small." style="margin-left:8px;padding:1px 8px;font-size:0.66rem;background:var(--bg);border:1px solid var(--border);border-radius:5px;color:var(--fg);cursor:pointer">reset window now</button>`;
       } else if (pctUsed >= PCT_BUDGET_WARN) {
         govAction = `<span style="color:var(--yellow)">Budget warning — ${pctUsed}% of weekly limit used; kicks suspend at 100%</span>`;
       } else if (projPct > PCT_WARN) {
@@ -6876,7 +6895,7 @@
 
       const ignoreCheck = `<label style="font-size:0.68rem;color:var(--muted);cursor:pointer;margin-left:12px" title="When checked, the governor ignores budget limits entirely. No model downgrading, no kick skipping. Use with caution — spending will be uncapped until unchecked.">
         <input type="checkbox" ${budgetIgnored ? 'checked' : ''} onchange="toggleBudgetIgnore()" style="cursor:pointer;vertical-align:middle"> ignore budget
-      </label>`;
+      </label><button onclick="resetBudgetWindow()" title="Open a fresh budget window now: spend re-anchors at 0 and the window timer restarts. Budget enforcement stays on." style="margin-left:8px;padding:0 6px;font-size:0.64rem;background:none;border:1px solid var(--border);border-radius:5px;color:var(--muted);cursor:pointer;vertical-align:middle">reset window</button>`;
 
       return `<div class="budget-bar">
         <div class="budget-bar-label">

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -899,6 +899,28 @@ func (g *Governor) SetBudgetLimit(limit int64) {
 	g.budget.WeeklyLimit = limit
 }
 
+// ResetBudgetWindow opens a fresh budget window immediately, without waiting
+// out the configured period. The baseline re-anchors at the current lifetime
+// totals so window spend restarts at zero, the once-per-window warn/exhausted
+// alert latches rearm, and the exhausted flag clears so suppressed kicks
+// resume on the next eval. This is the operator's recovery path when an
+// exhausted (or mis-sized) budget has closed the kick gate: raise the limit,
+// reset the window, keep budgeting on — instead of the all-or-nothing
+// "ignore budget" bypass.
+func (g *Governor) ResetBudgetWindow() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	// CurrentSpend is (lifetime totals − WindowBaseline); folding it into the
+	// baseline zeroes spend now AND keeps the next UpdateBudgetFromTotals
+	// computing only tokens consumed after this reset.
+	g.budget.WindowBaseline += g.budget.CurrentSpend
+	g.budget.CurrentSpend = 0
+	g.budget.ResetAt = g.now()
+	g.budgetWarned = false
+	g.budgetExhaustedAlerted = false
+	g.state.BudgetExhausted = false
+}
+
 // SetBudgetIgnoreAll toggles the global budget-suppression bypass.
 func (g *Governor) SetBudgetIgnoreAll(ignore bool) {
 	g.mu.Lock()

--- a/v2/pkg/governor/governor_budget_reset_test.go
+++ b/v2/pkg/governor/governor_budget_reset_test.go
@@ -1,0 +1,82 @@
+package governor
+
+import (
+	"testing"
+	"time"
+)
+
+// ResetBudgetWindow must reopen the kick gate immediately: spend re-anchors
+// at zero, the exhausted flag clears, and suppressed agents are due again on
+// the very next eval — without waiting out the configured period.
+func TestResetBudgetWindow_ReopensKickGate(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SeedBudget(1500, nil, nil, time.Now())
+	if due := dueSet(g); due["scanner"] {
+		t.Fatal("precondition: exhausted budget should suppress kicks")
+	}
+	if !g.GetState().BudgetExhausted {
+		t.Fatal("precondition: state should report budget exhausted")
+	}
+
+	g.ResetBudgetWindow()
+
+	if b := g.GetBudget(); b.CurrentSpend != 0 {
+		t.Errorf("spend after reset = %d, want 0", b.CurrentSpend)
+	}
+	if g.GetState().BudgetExhausted {
+		t.Error("exhausted flag should clear on reset")
+	}
+	if due := dueSet(g); !due["scanner"] {
+		t.Error("kicks should resume immediately after window reset")
+	}
+}
+
+// The reset must fold the old window's spend into the baseline so the next
+// collector scan (which reports LIFETIME totals) counts only tokens consumed
+// after the reset — not the whole history again.
+func TestResetBudgetWindow_RebaselinesLifetimeTotals(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+	g.SetBudgetLimit(1000)
+
+	// Open a window at baseline 0, then observe 5000 lifetime tokens: all
+	// 5000 are in-window spend.
+	g.UpdateBudgetFromTotals(0, nil, nil)
+	g.UpdateBudgetFromTotals(5000, nil, nil)
+	if b := g.GetBudget(); b.CurrentSpend != 5000 {
+		t.Fatalf("precondition: in-window spend = %d, want 5000", b.CurrentSpend)
+	}
+
+	g.ResetBudgetWindow()
+
+	// Lifetime grows to 5200 — only the 200 consumed after the reset may
+	// count against the fresh window.
+	g.UpdateBudgetFromTotals(5200, nil, nil)
+	if b := g.GetBudget(); b.CurrentSpend != 200 {
+		t.Errorf("post-reset spend = %d, want 200", b.CurrentSpend)
+	}
+}
+
+// The once-per-window alert latches must rearm on reset, so the next
+// exhaustion of the fresh window alerts again instead of staying silent.
+func TestResetBudgetWindow_RearmsAlertLatches(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+	g.SetBudgetLimit(100)
+
+	g.UpdateBudgetFromTotals(0, nil, nil)
+	trans := g.UpdateBudgetFromTotals(150, nil, nil)
+	if !trans.ExhaustedCrossed {
+		t.Fatal("precondition: first exhaustion should cross the alert latch")
+	}
+
+	g.ResetBudgetWindow()
+
+	trans = g.UpdateBudgetFromTotals(300, nil, nil)
+	if !trans.ExhaustedCrossed {
+		t.Error("exhaustion of the fresh window should alert again after reset")
+	}
+}


### PR DESCRIPTION
## Why

When the governor's token budget window is exhausted, the only operator recovery today is the all-or-nothing **ignore budget** bypass — enforcement off entirely, spending uncapped. An operator who mis-sized the budget (e.g. a limit of 3.3M tokens on a fleet consuming 700M+/window, observed live on a hosted v2 hive 2026-08-12) or who genuinely spent the window and has raised the limit has no way to reopen the kick gate: the stale window keeps `budget exhausted — suppressing kicks` firing until `period_days` elapses (up to 30 days).

This keeps budgeting **on** but makes it flexible: fix the limit, reset the window, kicks resume.

## What

- **`Governor.ResetBudgetWindow()`** — folds the current window's spend into the baseline (spend restarts at 0 and the next collector scan of lifetime totals counts only post-reset tokens), stamps a fresh `ResetAt`, rearms the once-per-window warn/exhausted alert latches, clears the exhausted flag so suppressed kicks resume on the next eval.
- **`POST /api/config/governor/budget/reset`** — owner-only, audited (`governor_budget_window_reset`), persists via the usual refresh path so `budget_window_baseline`/`budget_reset_at` survive restarts.
- **UI** — a `reset window` button beside the `ignore budget` checkbox on the budget bar, and an inline `reset window now` action on the red budget-exhausted banner (the exact spot the operator is staring at when they need it).

## Tests

- `TestResetBudgetWindow_ReopensKickGate` — exhausted → reset → agent due on the very next eval.
- `TestResetBudgetWindow_RebaselinesLifetimeTotals` — post-reset spend counts only tokens consumed after the reset.
- `TestResetBudgetWindow_RearmsAlertLatches` — exhausting the fresh window alerts again.
- `TestGovernorBudgetResetEndpoint` — endpoint zeroes spend, folds old spend into the baseline, stamps ResetAt.

v4 carries the same governor/dashboard code — port to follow with the #3605 port.