### PR TITLE
fix(github): self-merge sweep must ignore cancelled/failing non-required checks

### DIFF
--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -530,6 +530,17 @@ func parseHiveQueueReview(body string) string {
 // required. Meta gates (tide, netlify previews, ...) are excluded on both
 // surfaces — tide in particular posts a commit status that stays "pending"
 // forever on Prow-managed repos and must never wedge the queue.
+//
+// A non-success CONCLUSION (cancelled, failure, timed_out, ...) on an
+// ignorable/non-required check (isIgnorableCICheck — Playwright, Mobile
+// Browser Tests, the chromium shard matrix, plus the isMetaCheck set) is
+// likewise not a blocker: those suites are routinely cancelled mid-flight
+// (matrix/concurrency-group cancellation, flake reruns) with zero bearing on
+// mergeability, and treating a cancelled Playwright/Mobile shard as red left
+// otherwise-green, MERGEABLE PRs (build-gate success) permanently skipped by
+// the self-merge sweep with reason "check-cancelled" (#22438, #22440).
+// Required checks (build-gate, build/test/docker, ...) still gate: only the
+// ignorable set gets a pass on a bad conclusion.
 func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool, string, error) {
 	statusOpts := &gh.ListOptions{PerPage: 100}
 	for {
@@ -546,6 +557,9 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			case "pending":
 				return false, "status-pending", nil
 			default: // "failure", "error"
+				if isIgnorableCICheck(s.GetContext()) {
+					continue
+				}
 				return false, "status-" + s.GetState(), nil
 			}
 		}
@@ -566,11 +580,17 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 				continue
 			}
 			if cr.GetStatus() != "completed" {
+				if isIgnorableCICheck(cr.GetName()) {
+					continue
+				}
 				return false, "check-pending", nil
 			}
 			switch cr.GetConclusion() {
 			case "success", "neutral", "skipped":
 			default:
+				if isIgnorableCICheck(cr.GetName()) {
+					continue
+				}
 				return false, "check-" + cr.GetConclusion(), nil
 			}
 		}

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -321,6 +321,12 @@ func TestCommitGreenStatusAndCheckBranches(t *testing.T) {
 		{name: "check failure blocks", statuses: []status{{"ci/build", "success"}}, checks: []check{{"build", "completed", "failure"}}, wantReason: "check-failure"},
 		{name: "pending meta status and check are ignored", statuses: []status{{"tide", "pending"}, {"ci/build", "success"}}, checks: []check{{"tide", "in_progress", ""}, {"build", "completed", "success"}}, wantGreen: true},
 		{name: "no statuses or checks is green after mergeable gate", wantGreen: true},
+		{name: "cancelled Playwright check with green build-gate is green", checks: []check{{"build-gate", "completed", "success"}, {"Playwright", "completed", "cancelled"}}, wantGreen: true},
+		{name: "cancelled Mobile Browser Tests check with green build-gate is green", checks: []check{{"build-gate", "completed", "success"}, {"Mobile Browser Tests", "completed", "cancelled"}}, wantGreen: true},
+		{name: "cancelled chromium shard check with green build-gate is green", checks: []check{{"build-gate", "completed", "success"}, {"Test (chromium, shard 3)", "completed", "cancelled"}}, wantGreen: true},
+		{name: "in-progress chromium shard does not block", checks: []check{{"build-gate", "completed", "success"}, {"Test (chromium, shard 1)", "in_progress", ""}}, wantGreen: true},
+		{name: "cancelled build-gate still blocks", checks: []check{{"build-gate", "completed", "cancelled"}}, wantReason: "check-cancelled"},
+		{name: "failing build-gate still blocks alongside cancelled Playwright", checks: []check{{"build-gate", "completed", "failure"}, {"Playwright", "completed", "cancelled"}}, wantReason: "check-failure"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -677,6 +677,44 @@ func isMetaCheck(name string) bool {
 	return false
 }
 
+// chromiumShardCheckRE matches the Playwright matrix's per-shard check-run
+// names, e.g. "Test (chromium, shard 1)", "Test (chromium, shard 2/4)".
+var chromiumShardCheckRE = regexp.MustCompile(`(?i)^test \(chromium,\s*shard`)
+
+// isIgnorableCICheck reports check runs this project's standing merge policy
+// treats as non-required: it is the superset used to decide whether a
+// check-run's COMPLETED CONCLUSION (not just its presence) is allowed to
+// block a merge. It always includes the meta/deploy-gate checks from
+// isMetaCheck, plus the browser/E2E suites (Playwright, Mobile Browser Tests,
+// the chromium shard matrix) and coverage reporting that GitHub's own
+// mergeable_state="unstable" already treats as non-required (see
+// mergeableFromState) but that isMetaCheck deliberately does NOT cover —
+// isMetaCheck's own test locks in that a chromium shard IS real code CI for
+// CIStatus classification purposes, so that name-blocking logic must stay
+// separate from this one.
+//
+// This predicate exists because commitGreen (automerge_sweep.go) must ignore
+// a CANCELLED conclusion on these checks: Playwright/Mobile/chromium-shard
+// runs routinely get cancelled mid-flight (matrix cancellation, concurrency
+// groups, flake reruns) even though nothing about them is required for
+// branch protection, and a cancelled non-required check must never wedge an
+// otherwise-green, MERGEABLE PR out of the self-merge sweep (#22438,
+// #22440 — build-gate success, PR mergeable, only blocker was a cancelled
+// Playwright/Mobile shard).
+func isIgnorableCICheck(name string) bool {
+	if isMetaCheck(name) {
+		return true
+	}
+	switch name {
+	case "Playwright", "Mobile Browser Tests", "coverage-report":
+		return true
+	}
+	if strings.HasPrefix(name, "Playwright") || strings.HasPrefix(name, "Mobile Browser Tests") {
+		return true
+	}
+	return chromiumShardCheckRE.MatchString(name)
+}
+
 // Bounds for fetchFailureExcerpt: annotations are fetched for at most
 // excerptMaxRuns failing check runs, keeping at most excerptMaxLines lines and
 // excerptMaxChars characters total. Enough to carry a stack of real errors

--- a/v2/pkg/github/metacheck_test.go
+++ b/v2/pkg/github/metacheck_test.go
@@ -27,3 +27,34 @@ func TestIsMetaCheck(t *testing.T) {
 		}
 	}
 }
+
+// TestIsIgnorableCICheck locks in the wider non-required set that
+// commitGreen uses to decide whether a bad CONCLUSION (cancelled, failure,
+// ...) is allowed to pass: it includes everything isMetaCheck already
+// covers, plus the browser/E2E suites that routinely get cancelled
+// mid-flight (Playwright, Mobile Browser Tests, the chromium shard matrix).
+// Required build/test/docker checks must NOT be in this set.
+func TestIsIgnorableCICheck(t *testing.T) {
+	ignorable := []string{
+		"tide",
+		"enforce-guardrails",
+		"netlify/kubestellarconsole/deploy-preview",
+		"copilot-pull-request-reviewer",
+		"Playwright",
+		"Mobile Browser Tests",
+		"Test (chromium, shard 1)",
+		"Test (chromium, shard 2/4)",
+		"coverage-report",
+	}
+	for _, name := range ignorable {
+		if !isIgnorableCICheck(name) {
+			t.Errorf("isIgnorableCICheck(%q) = false, want true (non-required check)", name)
+		}
+	}
+	required := []string{"build-gate", "build", "test", "docker", "unit-test", "TypeScript & ESLint"}
+	for _, name := range required {
+		if isIgnorableCICheck(name) {
+			t.Errorf("isIgnorableCICheck(%q) = true, want false (required check must still gate)", name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The App self-merge sweep added by #3591 (`commitGreen` in `v2/pkg/github/automerge_sweep.go`) treated ANY non-success check-run conclusion — including `cancelled` — as a blocker, gated only by the narrow `isMetaCheck` exclusion list (tide/netlify/guardrails/copilot).

Playwright, Mobile Browser Tests, and the chromium shard matrix are non-required checks that routinely get cancelled mid-flight (matrix/concurrency-group cancellation, flake reruns). A cancelled shard on an otherwise fully green, MERGEABLE PR made `commitGreen` return false with reason `check-cancelled`, so the self-authored sweep skipped the PR forever — logged as:

```
"self-authored automerge sweep skipped PR" ... reason:"check-cancelled"
```

Live evidence: #22438 and #22440 both had `build-gate: success` (the required check) and were MERGEABLE; the only non-success check was a CANCELLED Playwright/Mobile shard. The sweep should have merged them.

## Fix

Added `isIgnorableCICheck` in `v2/pkg/github/client.go` — a wider non-required-check predicate that wraps the existing `isMetaCheck` (tide/netlify/guardrails/copilot) and additionally covers Playwright, Mobile Browser Tests, and the `Test (chromium, shard N)` matrix, plus coverage-report.

`commitGreen` now consults `isIgnorableCICheck` before treating a non-success conclusion (or a still-in-progress check) as a blocker, on both the commit-status loop and the check-run loop. Since both the queued-sweep and self-authored-sweep paths call the same `commitGreen`, both benefit from this fix.

`isMetaCheck` itself is left untouched — its own existing test (`metacheck_test.go`) intentionally locks in that a chromium shard counts as real code CI for `CIStatus` classification (used by `EnrichCIStatus`), so broadening `isMetaCheck` directly would have flipped that unrelated classification. `isIgnorableCICheck` is a separate, wider predicate scoped to `commitGreen`'s merge-eligibility decision only.

Required checks (build-gate, build, test, docker, ...) are **not** in the ignorable set and still gate exactly as before — a cancelled or failing build-gate still returns `check-cancelled` / `check-failure` and blocks the merge.

## Tests

- `automerge_sweep_test.go`: extended `TestCommitGreenStatusAndCheckBranches` with cases for a cancelled Playwright/Mobile/chromium-shard check alongside a green `build-gate` (green), an in-progress chromium shard (green), a cancelled `build-gate` (still blocks), and a failing `build-gate` alongside a cancelled Playwright check (still blocks on the required failure).
- `metacheck_test.go`: added `TestIsIgnorableCICheck` locking in the ignorable set vs. the required set.

CI validates build/vet/tests; not run locally per project policy.