### PR TITLE
🐛 fix(dashboard): resolve discovery key via gateway and sync legacy litellm store on rotation (v4 port of #3605)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -6392,7 +6392,15 @@ func (s *Server) inferenceAPIKey(backend string) string {
 	// made discovery send the revoked key and log "no models found from any
 	// endpoint" (surfaced as a sticky error toast) while the save-time probe
 	// — which uses the submitted key — reported the models fine.
-	return gov.ResolveLiteLLMInferenceKey(backend)
+	//
+	// A matching gateway that resolves NO key of its own still falls back to
+	// the legacy store: keyless gateway entries (e.g. an endpoint-only entry
+	// with the key kept in the classic litellm: block) predate per-gateway
+	// keys and must keep discovering with the legacy key.
+	if key := gov.ResolveLiteLLMInferenceKey(backend); key != "" {
+		return key
+	}
+	return gov.LiteLLM.ResolveAPIKey()
 }
 
 // inferenceStaticModelAliases is the FALLBACK model list for the inference

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -6385,7 +6385,14 @@ func (s *Server) inferenceAPIKey(backend string) string {
 			return key
 		}
 	}
-	return gov.LiteLLM.ResolveAPIKey()
+	// Same contract as inference-time forwarding: an explicit gateway for
+	// this backend wins over the legacy litellm: key store (see
+	// ResolveLiteLLMInferenceKey). A key rotated via the Model Gateways tab
+	// lands only in the gateway's key file, so resolving the legacy file here
+	// made discovery send the revoked key and log "no models found from any
+	// endpoint" (surfaced as a sticky error toast) while the save-time probe
+	// — which uses the submitted key — reported the models fine.
+	return gov.ResolveLiteLLMInferenceKey(backend)
 }
 
 // inferenceStaticModelAliases is the FALLBACK model list for the inference

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -320,6 +320,21 @@ func (s *Server) handleGovernorGatewaysUpsert(w http.ResponseWriter, r *http.Req
 			return
 		}
 		gw.APIKeyFile = path
+		// The legacy litellm: section keeps a SEPARATE key store
+		// (/data/secrets/litellm_api_key + the hive-secrets Secret) that
+		// pre-gateways code paths (local proxy, env fallbacks) still resolve.
+		// When this gateway is the one the legacy section points at, sync the
+		// legacy store too — otherwise a key rotated here leaves the legacy
+		// file holding the old (possibly revoked) key, and anything resolving
+		// through it fails against the gateway from then on.
+		if kind == config.GatewayKindLiteLLM && s.legacyLiteLLMSectionMatches(gw) {
+			if legacyPath, syncErr := s.storeLiteLLMAPIKey(submittedKey); syncErr != nil {
+				s.logger.Warn("legacy litellm key store not synced after gateway key save",
+					"gateway", name, "error", syncErr)
+			} else {
+				cfg.Governor.LiteLLM.APIKeyFile = legacyPath
+			}
+		}
 	}
 
 	if idx >= 0 {
@@ -616,4 +631,20 @@ func (s *Server) storeGatewayAPIKey(name, key string) (string, error) {
 	}
 	s.logger.Info("gateway api key stored", "gateway", name, "api_key_file", path)
 	return path, nil
+}
+
+// legacyLiteLLMSectionMatches reports whether the legacy governor.litellm
+// section refers to the same proxy as gw, meaning its key store must be kept
+// in sync when gw's key rotates. Matching is by endpoint; an unset legacy
+// endpoint falls back to the conventional gateway name "litellm" (the
+// built-in method's gateway shares its name with its kind).
+func (s *Server) legacyLiteLLMSectionMatches(gw config.GatewayConfig) bool {
+	if s.deps == nil || s.deps.Config == nil {
+		return false
+	}
+	legacy := strings.TrimRight(strings.TrimSpace(s.deps.Config.Governor.LiteLLM.Endpoint), "/")
+	if legacy == "" {
+		return strings.EqualFold(gw.Name, config.GatewayKindLiteLLM)
+	}
+	return strings.EqualFold(legacy, strings.TrimRight(strings.TrimSpace(gw.Endpoint), "/"))
 }

--- a/v2/pkg/dashboard/gateways_legacy_sync_test.go
+++ b/v2/pkg/dashboard/gateways_legacy_sync_test.go
@@ -25,6 +25,9 @@ import (
 func TestInferenceAPIKeyPrefersGatewayKey(t *testing.T) {
 	s, _ := apiServer(t)
 	dir := t.TempDir()
+	// v4's audit-N8 gate confines api_key_file reads to the managed secrets
+	// dirs; admit the test dir so the temp key files resolve.
+	defer config.SetSecretFileRootsForTest(dir)()
 	gwKey := filepath.Join(dir, "gateway_litellm_api_key")
 	if err := os.WriteFile(gwKey, []byte("sk-gateway-FRESH\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -56,6 +59,9 @@ func TestInferenceAPIKeyPrefersGatewayKey(t *testing.T) {
 func TestInferenceAPIKeyKeylessGatewayFallsBackToLegacy(t *testing.T) {
 	s, _ := apiServer(t)
 	dir := t.TempDir()
+	// v4's audit-N8 gate confines api_key_file reads to the managed secrets
+	// dirs; admit the test dir so the temp key file resolves.
+	defer config.SetSecretFileRootsForTest(dir)()
 	legacyKey := filepath.Join(dir, "litellm_api_key")
 	if err := os.WriteFile(legacyKey, []byte("sk-legacy-ONLY\n"), 0o600); err != nil {
 		t.Fatal(err)

--- a/v2/pkg/dashboard/gateways_legacy_sync_test.go
+++ b/v2/pkg/dashboard/gateways_legacy_sync_test.go
@@ -49,6 +49,32 @@ func TestInferenceAPIKeyPrefersGatewayKey(t *testing.T) {
 	}
 }
 
+// A gateway entry that resolves no key of its own (endpoint-only, key kept in
+// the classic litellm: block) must keep falling back to the legacy store —
+// pinned by TestInferenceModelsNonWatsonxUsesRawKeyPath too; this is the
+// direct-unit twin.
+func TestInferenceAPIKeyKeylessGatewayFallsBackToLegacy(t *testing.T) {
+	s, _ := apiServer(t)
+	dir := t.TempDir()
+	legacyKey := filepath.Join(dir, "litellm_api_key")
+	if err := os.WriteFile(legacyKey, []byte("sk-legacy-ONLY\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	gov := &s.deps.Config.Governor
+	gov.LiteLLM.Endpoint = "https://litellm.example.com"
+	gov.LiteLLM.APIKeyFile = legacyKey
+	gov.Gateways = []config.GatewayConfig{{
+		Name:     "litellm",
+		Kind:     config.GatewayKindLiteLLM,
+		Endpoint: "https://litellm.example.com",
+	}}
+
+	if got := s.inferenceAPIKey("litellm"); got != "sk-legacy-ONLY" {
+		t.Fatalf("inferenceAPIKey = %q, want the legacy fallback for a keyless gateway", got)
+	}
+}
+
 // Upserting the litellm gateway with a new key must also sync the legacy
 // litellm: key store, so pre-gateways resolution paths never see a revoked key.
 func TestGatewaysUpsertSyncsLegacyLiteLLMKey(t *testing.T) {

--- a/v2/pkg/dashboard/gateways_legacy_sync_test.go
+++ b/v2/pkg/dashboard/gateways_legacy_sync_test.go
@@ -1,0 +1,116 @@
+package dashboard
+
+// Regression tests for the post-rotation key split-brain on the DISCOVERY
+// side: rotating the litellm key via the Model Gateways tab wrote only the
+// gateway's key file, leaving the legacy litellm: section's file holding the
+// revoked key. Model discovery (inferenceAPIKey) resolved the legacy file and
+// 401'd — logged as "no models found from any endpoint" and surfaced as a
+// sticky error toast — while the save-time probe used the submitted key and
+// reported the models fine. Inference-time forwarding was already fixed to
+// resolve through the gateway (ResolveLiteLLMInferenceKey); these tests pin
+// discovery to the same contract and pin the upsert-side legacy-store sync.
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// inferenceAPIKey must resolve the same key the inference/entitlement paths
+// use — the explicit gateway's key file — never the stale legacy file.
+func TestInferenceAPIKeyPrefersGatewayKey(t *testing.T) {
+	s, _ := apiServer(t)
+	dir := t.TempDir()
+	gwKey := filepath.Join(dir, "gateway_litellm_api_key")
+	if err := os.WriteFile(gwKey, []byte("sk-gateway-FRESH\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	legacyKey := filepath.Join(dir, "litellm_api_key")
+	if err := os.WriteFile(legacyKey, []byte("sk-legacy-STALE\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	gov := &s.deps.Config.Governor
+	gov.LiteLLM.Endpoint = "https://litellm.example.com"
+	gov.LiteLLM.APIKeyFile = legacyKey
+	gov.Gateways = []config.GatewayConfig{{
+		Name:       "litellm",
+		Kind:       config.GatewayKindLiteLLM,
+		Endpoint:   "https://litellm.example.com",
+		APIKeyFile: gwKey,
+	}}
+
+	if got := s.inferenceAPIKey("litellm"); got != "sk-gateway-FRESH" {
+		t.Fatalf("inferenceAPIKey = %q, want the gateway's fresh key (the stale legacy key is what caused the post-rotation 'no models found' sticky toast)", got)
+	}
+}
+
+// Upserting the litellm gateway with a new key must also sync the legacy
+// litellm: key store, so pre-gateways resolution paths never see a revoked key.
+func TestGatewaysUpsertSyncsLegacyLiteLLMKey(t *testing.T) {
+	s, _ := apiServer(t)
+	allowPrivateURLHostsForTest(t, "litellm.example")
+
+	oldDir := gatewaySecretsDir
+	gatewaySecretsDir = t.TempDir()
+	defer func() { gatewaySecretsDir = oldDir }()
+
+	oldLegacy := writableLiteLLMKeyFile
+	writableLiteLLMKeyFile = filepath.Join(t.TempDir(), "litellm_api_key")
+	defer func() { writableLiteLLMKeyFile = oldLegacy }()
+
+	// The legacy section points at the same proxy the gateway names.
+	s.deps.Config.Governor.LiteLLM.Endpoint = "https://litellm.example"
+
+	rec := doPut(s, "/api/config/governor/gateways", map[string]interface{}{
+		"name":     "litellm",
+		"kind":     "litellm",
+		"endpoint": "https://litellm.example",
+		"api_key":  "sk-rotated-NEW",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upsert = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	data, err := os.ReadFile(writableLiteLLMKeyFile)
+	if err != nil {
+		t.Fatalf("legacy key store not synced: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "sk-rotated-NEW" {
+		t.Fatalf("legacy key store holds %q, want the rotated key", got)
+	}
+	if got := s.deps.Config.Governor.LiteLLM.APIKeyFile; got != writableLiteLLMKeyFile {
+		t.Fatalf("legacy api_key_file = %q, want %q (must repoint at the synced store)", got, writableLiteLLMKeyFile)
+	}
+}
+
+// A non-litellm gateway (different kind) must NOT touch the legacy store.
+func TestGatewaysUpsertLeavesLegacyStoreAloneForOtherKinds(t *testing.T) {
+	s, _ := apiServer(t)
+	allowPrivateURLHostsForTest(t, "other.example")
+
+	oldDir := gatewaySecretsDir
+	gatewaySecretsDir = t.TempDir()
+	defer func() { gatewaySecretsDir = oldDir }()
+
+	oldLegacy := writableLiteLLMKeyFile
+	writableLiteLLMKeyFile = filepath.Join(t.TempDir(), "litellm_api_key")
+	defer func() { writableLiteLLMKeyFile = oldLegacy }()
+
+	rec := doPut(s, "/api/config/governor/gateways", map[string]interface{}{
+		"name":     "othergw",
+		"kind":     "custom",
+		"endpoint": "https://other.example/v1",
+		"api_key":  "sk-custom-key",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upsert = %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(writableLiteLLMKeyFile); !os.IsNotExist(err) {
+		t.Fatalf("legacy litellm key store written by a custom-kind gateway upsert (err=%v)", err)
+	}
+}


### PR DESCRIPTION
v4 port of #3605 (merged to v2 at 0f04f350) — clean cherry-pick of both commits, no conflicts; all dependencies (`ResolveLiteLLMInferenceKey`, `storeLiteLLMAPIKey`, test helpers) already present on v4.

Ref #3603.

## What

Rotating the LiteLLM key via the Model Gateways form updated only `gateway_<name>_api_key`, leaving the legacy `litellm:` section's key store holding the old (revoked) key. Model discovery (`inferenceAPIKey`) still resolved the legacy store, so every save produced a green save-time-probe toast immediately followed by a sticky red toast from discovery 401-ing (`no models found from any endpoint`).

## How

- `inferenceAPIKey` resolves via `ResolveLiteLLMInferenceKey(backend)` when it yields a key — the same contract inference-time forwarding uses; keyless gateway entries (endpoint-only, key in the classic `litellm:` block) keep the legacy fallback.
- The gateway upsert syncs the legacy litellm store when the saved gateway is the one the legacy section points at, and repoints `governor.litellm.api_key_file`.

## Tests

Same four as v2: fresh-key preference, keyless-gateway legacy fallback, upsert legacy-store sync, non-litellm gateways leave the legacy store alone.

Note: v4 has pre-existing test failures in beads/sandbox/hub packages on clean CI runs — unrelated to this change.