### PR TITLE
🐛 ci: add job-level timeout to the coverage job so hung runs auto-fail

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -18,6 +18,10 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    # Hard cap so a hung runner / stuck -race build auto-fails instead of
+    # blocking PR merges indefinitely (the go test -timeout only bounds the test
+    # step, not checkout/setup/build/post-processing or a wedged runner). #3615.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: v2


### PR DESCRIPTION
Fixes #3615.

The `coverage` check has hung `in_progress` for 10+ min across many PRs today (normal ~2 min), blocking merges (required check) and needing manual cancel+re-trigger. The job runs `go test ... -timeout 600s`, but that only bounds the test *step* — not checkout / Go setup / the `-race` build / post-processing / a wedged runner — and the job had **no `timeout-minutes`**, so a stuck run hangs forever.

Adds `timeout-minutes: 20` to the `coverage:` job so a hung run **auto-fails** (and can be re-run) instead of blocking merges. A real coverage regression still fails as before; this only bounds hung runs.

One-line workflow change; no product code.