### PR TITLE
✨ port skillreg + agentsmd from v4, wire skills into v2 status

### DIFF
--- a/v2/pkg/agentsmd/agentsmd.go
+++ b/v2/pkg/agentsmd/agentsmd.go
@@ -1,0 +1,362 @@
+// Package agentsmd reads a maintained repository's AGENTS.md file (the emerging
+// cross-tool convention for per-repo agent instructions) and a lightweight
+// "skills" mechanism, turning both into text that Hive prepends to an agent's
+// kick prompt.
+//
+// # AGENTS.md format
+//
+// AGENTS.md is a plain Markdown file at the repository root. Hive supports two
+// additive extensions on top of ordinary Markdown:
+//
+//  1. Optional YAML front-matter: a block delimited by a line containing only
+//     "---" at the very top of the file, closed by a second "---" line. The only
+//     key Hive reads is an optional "skills:" list naming skills to request into
+//     the agent's context by default. Everything else in the block is ignored.
+//     Example:
+//
+//     ---
+//     skills:
+//       - go-testing
+//       - pr-etiquette
+//     ---
+//
+//  2. Inline skill sections: any section whose heading is "## Skill: <name>"
+//     defines a reusable, named instruction snippet. The section body runs from
+//     the heading to the next "## " heading (or end of file). Skills may also be
+//     defined as standalone files at "skills/<name>.md" relative to the repo
+//     root; when both a file and an inline section define the same name, the
+//     inline section wins.
+//
+// The "body" is the Markdown document with the front-matter block and all
+// "## Skill:" sections removed — the general instructions that always apply.
+//
+// # Nested AGENTS.md (closest-wins)
+//
+// A repository may carry per-directory AGENTS.md files. When resolving
+// instructions for a file at a relative path, ParseNearest walks from that
+// file's directory up to the repo root and uses the closest AGENTS.md it finds.
+// The root AGENTS.md is the required baseline; nested files override it for
+// their subtree.
+//
+// # Tolerance
+//
+// Parsing never fails a kick. A missing AGENTS.md yields an empty config and a
+// nil error. Malformed front-matter is logged and skipped (the body is still
+// used). Callers may safely ignore the returned error for injection purposes.
+package agentsmd
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// AgentsFileName is the conventional filename Hive looks for.
+	AgentsFileName = "AGENTS.md"
+
+	// SkillsDirName is the directory holding standalone "<name>.md" skill files.
+	SkillsDirName = "skills"
+
+	// SkillFileExt is the extension for standalone skill files.
+	SkillFileExt = ".md"
+
+	// frontMatterDelim is the line (trimmed) that opens and closes the optional
+	// YAML front-matter block.
+	frontMatterDelim = "---"
+
+	// skillHeadingPrefix marks an inline skill section. A heading of the form
+	// "## Skill: <name>" begins a named skill snippet.
+	skillHeadingPrefix = "## Skill:"
+
+	// sectionHeadingPrefix is any level-2 Markdown heading; it terminates a
+	// skill section.
+	sectionHeadingPrefix = "## "
+
+	// injectionHeader titles the injected AGENTS.md block in the kick prompt,
+	// mirroring the "# Relevant Knowledge" convention used by the Primer.
+	injectionHeader = "# Repository Agent Instructions (AGENTS.md)"
+
+	// injectionSkillsHeader titles the resolved-skills subsection.
+	injectionSkillsHeader = "## Requested Skills"
+)
+
+// AgentsConfig is the parsed contents of an AGENTS.md file (and any adjacent
+// skills/ directory).
+type AgentsConfig struct {
+	// Body is the Markdown document with front-matter and "## Skill:" sections
+	// removed — the general instructions that always apply.
+	Body string
+
+	// Skills maps a skill name to its instruction text.
+	Skills map[string]string
+
+	// RequestedSkills lists skill names named in the front-matter "skills:" key,
+	// in file order. These are the skills the repo asks Hive to include by
+	// default.
+	RequestedSkills []string
+}
+
+// frontMatter is the subset of the YAML front-matter block Hive reads.
+type frontMatter struct {
+	Skills []string `yaml:"skills"`
+}
+
+// logger returns lg or a discarding default so callers may pass nil.
+func logger(lg *slog.Logger) *slog.Logger {
+	if lg != nil {
+		return lg
+	}
+	return slog.New(slog.DiscardHandler)
+}
+
+// Parse finds and parses the root AGENTS.md under repoRoot. It is tolerant:
+// a missing file yields an empty (non-nil) config and a nil error; malformed
+// front-matter is logged and skipped rather than failing.
+func Parse(repoRoot string, lg *slog.Logger) (*AgentsConfig, error) {
+	return parseAt(repoRoot, filepath.Join(repoRoot, AgentsFileName), logger(lg))
+}
+
+// ParseNearest resolves the closest-wins AGENTS.md for a file at relPath
+// (relative to repoRoot). It walks from relPath's directory up to repoRoot and
+// parses the first AGENTS.md it finds; if none exist in the subtree, it falls
+// back to the root AGENTS.md. Behaves tolerantly like Parse.
+func ParseNearest(repoRoot, relPath string, lg *slog.Logger) (*AgentsConfig, error) {
+	lg = logger(lg)
+
+	// Normalize and confine relPath to the repo. A path escaping the root falls
+	// back to the root file.
+	clean := filepath.Clean(relPath)
+	dir := filepath.Dir(filepath.Join(repoRoot, clean))
+
+	rootAbs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		rootAbs = repoRoot
+	}
+
+	for {
+		candidate := filepath.Join(dir, AgentsFileName)
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			return parseAt(dir, candidate, lg)
+		}
+
+		dirAbs, absErr := filepath.Abs(dir)
+		if absErr != nil {
+			break
+		}
+		if dirAbs == rootAbs || !strings.HasPrefix(dirAbs, rootAbs) {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// Fall back to the root baseline.
+	return Parse(repoRoot, lg)
+}
+
+// parseAt parses the AGENTS.md at agentsPath, treating baseDir as the directory
+// whose skills/ subdirectory supplies standalone skill files.
+func parseAt(baseDir, agentsPath string, lg *slog.Logger) (*AgentsConfig, error) {
+	cfg := &AgentsConfig{Skills: map[string]string{}}
+
+	raw, err := os.ReadFile(agentsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Missing file is not an error — empty config.
+			return cfg, nil
+		}
+		// Unreadable file: tolerate, log, return empty config.
+		lg.Warn("agentsmd: cannot read AGENTS.md, skipping", "path", agentsPath, "error", err)
+		return cfg, nil
+	}
+
+	content := string(raw)
+
+	// 1. Strip and parse optional front-matter.
+	fm, rest := splitFrontMatter(content)
+	if fm != "" {
+		var meta frontMatter
+		if yErr := yaml.Unmarshal([]byte(fm), &meta); yErr != nil {
+			// Malformed front-matter: log and skip, keep the body.
+			lg.Warn("agentsmd: malformed front-matter, ignoring", "path", agentsPath, "error", yErr)
+		} else {
+			for _, s := range meta.Skills {
+				if s = strings.TrimSpace(s); s != "" {
+					cfg.RequestedSkills = append(cfg.RequestedSkills, s)
+				}
+			}
+		}
+	}
+
+	// 2. Extract inline "## Skill: <name>" sections; the remainder is the body.
+	body, inline := extractSkillSections(rest)
+	cfg.Body = strings.TrimSpace(body)
+
+	// 3. Load standalone skills/<name>.md files first, then let inline sections
+	//    override them (inline wins on name collision).
+	loadSkillFiles(baseDir, cfg.Skills, lg)
+	for name, text := range inline {
+		cfg.Skills[name] = text
+	}
+
+	return cfg, nil
+}
+
+// splitFrontMatter returns the YAML front-matter (without delimiters) and the
+// remaining document. If no front-matter block is present, front-matter is ""
+// and the whole content is returned as rest.
+func splitFrontMatter(content string) (fm, rest string) {
+	// Front-matter must be at the very top (after an optional BOM/leading
+	// whitespace-free start). Tolerate a leading newline only.
+	trimmed := strings.TrimLeft(content, "\r\n")
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != frontMatterDelim {
+		return "", content
+	}
+
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == frontMatterDelim {
+			fm = strings.Join(lines[1:i], "\n")
+			rest = strings.Join(lines[i+1:], "\n")
+			return fm, rest
+		}
+	}
+
+	// Opening delimiter with no close: not valid front-matter, treat as body.
+	return "", content
+}
+
+// extractSkillSections splits a Markdown body into (body-without-skills, skills).
+// A skill section starts at a "## Skill: <name>" heading and runs until the next
+// "## " heading or end of document.
+func extractSkillSections(body string) (string, map[string]string) {
+	skills := map[string]string{}
+	lines := strings.Split(body, "\n")
+
+	var bodyLines []string
+	var curName string
+	var curLines []string
+
+	flush := func() {
+		if curName != "" {
+			skills[curName] = strings.TrimSpace(strings.Join(curLines, "\n"))
+		}
+		curName = ""
+		curLines = nil
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, skillHeadingPrefix) {
+			flush()
+			curName = strings.TrimSpace(strings.TrimPrefix(trimmed, skillHeadingPrefix))
+			continue
+		}
+		if curName != "" && strings.HasPrefix(line, sectionHeadingPrefix) {
+			// A new non-skill section ends the current skill.
+			flush()
+			bodyLines = append(bodyLines, line)
+			continue
+		}
+		if curName != "" {
+			curLines = append(curLines, line)
+			continue
+		}
+		bodyLines = append(bodyLines, line)
+	}
+	flush()
+
+	return strings.Join(bodyLines, "\n"), skills
+}
+
+// loadSkillFiles reads standalone "<name>.md" files from baseDir/skills into
+// dst. Unreadable files are skipped tolerantly.
+func loadSkillFiles(baseDir string, dst map[string]string, lg *slog.Logger) {
+	skillsDir := filepath.Join(baseDir, SkillsDirName)
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		// No skills dir (or unreadable) — nothing to load.
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, SkillFileExt) {
+			continue
+		}
+		text, rErr := os.ReadFile(filepath.Join(skillsDir, name))
+		if rErr != nil {
+			lg.Warn("agentsmd: cannot read skill file, skipping", "file", name, "error", rErr)
+			continue
+		}
+		skillName := strings.TrimSuffix(name, SkillFileExt)
+		dst[skillName] = strings.TrimSpace(string(text))
+	}
+}
+
+// Resolve concatenates the instruction text of the named skills, in the order
+// requested. Unknown names are silently skipped. Returns "" when nothing
+// resolves.
+func (c *AgentsConfig) Resolve(names []string) string {
+	if c == nil || len(names) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		if text, ok := c.Skills[n]; ok && strings.TrimSpace(text) != "" {
+			parts = append(parts, "### "+n+"\n\n"+strings.TrimSpace(text))
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// InjectionText renders the config's body plus the resolved skills as a Markdown
+// block ready to prepend to an agent kick. requestedSkills are the skills the
+// caller wants included; when nil, the config's own RequestedSkills (from
+// front-matter) are used. Returns "" when there is nothing to inject.
+func (c *AgentsConfig) InjectionText(requestedSkills []string) string {
+	if c == nil {
+		return ""
+	}
+
+	skills := requestedSkills
+	if skills == nil {
+		skills = c.RequestedSkills
+	}
+	resolved := c.Resolve(skills)
+
+	if strings.TrimSpace(c.Body) == "" && resolved == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(injectionHeader)
+	b.WriteString("\n\n")
+	if body := strings.TrimSpace(c.Body); body != "" {
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+	if resolved != "" {
+		if strings.TrimSpace(c.Body) != "" {
+			b.WriteString("\n")
+		}
+		b.WriteString(injectionSkillsHeader)
+		b.WriteString("\n\n")
+		b.WriteString(resolved)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/v2/pkg/agentsmd/agentsmd_test.go
+++ b/v2/pkg/agentsmd/agentsmd_test.go
@@ -1,0 +1,262 @@
+package agentsmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile writes content to path under dir, creating parent directories.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const sampleAgents = `---
+skills:
+  - go-testing
+  - pr-etiquette
+---
+
+# Project Instructions
+
+Always run gofmt before committing.
+Use table-driven tests.
+
+## Skill: go-testing
+
+Prefer t.TempDir over manual temp dirs.
+Never hit the network in unit tests.
+
+## Style Guide
+
+Two-space indent in YAML.
+
+## Skill: pr-etiquette
+
+Keep PRs small and focused.
+`
+
+func TestParse_BodyAndSkills(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, AgentsFileName), sampleAgents)
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	// Front-matter skills requested, in order.
+	want := []string{"go-testing", "pr-etiquette"}
+	if len(cfg.RequestedSkills) != len(want) {
+		t.Fatalf("RequestedSkills = %v, want %v", cfg.RequestedSkills, want)
+	}
+	for i, s := range want {
+		if cfg.RequestedSkills[i] != s {
+			t.Errorf("RequestedSkills[%d] = %q, want %q", i, cfg.RequestedSkills[i], s)
+		}
+	}
+
+	// Body keeps general instructions and non-skill sections, drops skills and FM.
+	if !strings.Contains(cfg.Body, "Always run gofmt") {
+		t.Errorf("body missing general instruction: %q", cfg.Body)
+	}
+	if !strings.Contains(cfg.Body, "## Style Guide") {
+		t.Errorf("body missing non-skill section: %q", cfg.Body)
+	}
+	if strings.Contains(cfg.Body, "## Skill:") {
+		t.Errorf("body should not contain skill headings: %q", cfg.Body)
+	}
+	if strings.Contains(cfg.Body, "Keep PRs small") {
+		t.Errorf("body should not contain skill text: %q", cfg.Body)
+	}
+	if strings.Contains(cfg.Body, "skills:") {
+		t.Errorf("body should not contain front-matter: %q", cfg.Body)
+	}
+
+	// Inline skills extracted.
+	if got := cfg.Skills["go-testing"]; !strings.Contains(got, "t.TempDir") {
+		t.Errorf("go-testing skill = %q", got)
+	}
+	if got := cfg.Skills["pr-etiquette"]; !strings.Contains(got, "Keep PRs small") {
+		t.Errorf("pr-etiquette skill = %q", got)
+	}
+}
+
+func TestParse_MissingFile(t *testing.T) {
+	dir := t.TempDir() // no AGENTS.md
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("cfg should be non-nil for missing file")
+	}
+	if cfg.Body != "" || len(cfg.Skills) != 0 || len(cfg.RequestedSkills) != 0 {
+		t.Errorf("missing file should yield empty config, got %+v", cfg)
+	}
+}
+
+func TestParse_MalformedFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	// Invalid YAML in the front-matter block; body must still parse.
+	content := "---\nskills: [unterminated\n : : :\n---\n\n# Title\n\nBody text here.\n"
+	writeFile(t, filepath.Join(dir, AgentsFileName), content)
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("malformed front-matter should not error, got %v", err)
+	}
+	if len(cfg.RequestedSkills) != 0 {
+		t.Errorf("malformed front-matter should yield no requested skills, got %v", cfg.RequestedSkills)
+	}
+	if !strings.Contains(cfg.Body, "Body text here.") {
+		t.Errorf("body should survive malformed front-matter, got %q", cfg.Body)
+	}
+}
+
+func TestParse_NoFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, AgentsFileName), "# Just Markdown\n\nNo front matter.\n")
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if !strings.Contains(cfg.Body, "No front matter.") {
+		t.Errorf("body = %q", cfg.Body)
+	}
+	if len(cfg.RequestedSkills) != 0 {
+		t.Errorf("unexpected requested skills: %v", cfg.RequestedSkills)
+	}
+}
+
+func TestResolve_KnownAndUnknown(t *testing.T) {
+	cfg := &AgentsConfig{
+		Skills: map[string]string{
+			"a": "alpha text",
+			"b": "beta text",
+		},
+	}
+
+	out := cfg.Resolve([]string{"a", "missing", "b"})
+	if !strings.Contains(out, "alpha text") || !strings.Contains(out, "beta text") {
+		t.Errorf("resolve missing known skills: %q", out)
+	}
+	if strings.Contains(out, "missing") {
+		t.Errorf("unknown skill should be skipped, got %q", out)
+	}
+
+	if cfg.Resolve(nil) != "" {
+		t.Error("Resolve(nil) should be empty")
+	}
+	if cfg.Resolve([]string{"nope"}) != "" {
+		t.Error("Resolve of only-unknown should be empty")
+	}
+}
+
+func TestSkillFiles_AndInlineOverride(t *testing.T) {
+	dir := t.TempDir()
+	// Inline defines "shared"; a file also defines "shared" and a unique "fileskill".
+	agents := "---\nskills:\n  - shared\n  - fileskill\n---\n\n# Title\n\n## Skill: shared\n\ninline version\n"
+	writeFile(t, filepath.Join(dir, AgentsFileName), agents)
+	writeFile(t, filepath.Join(dir, SkillsDirName, "shared.md"), "file version")
+	writeFile(t, filepath.Join(dir, SkillsDirName, "fileskill.md"), "standalone skill")
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	if got := cfg.Skills["shared"]; got != "inline version" {
+		t.Errorf("inline should override file, got %q", got)
+	}
+	if got := cfg.Skills["fileskill"]; got != "standalone skill" {
+		t.Errorf("file skill = %q", got)
+	}
+}
+
+func TestParseNearest_ClosestWins(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, AgentsFileName), "# Root\n\nroot baseline instructions\n")
+	writeFile(t, filepath.Join(root, "sub", "pkg", AgentsFileName), "# Sub\n\nnested instructions\n")
+
+	// A file deep under the nested AGENTS.md picks the nested one.
+	cfg, err := ParseNearest(root, filepath.Join("sub", "pkg", "deep", "file.go"), nil)
+	if err != nil {
+		t.Fatalf("ParseNearest error: %v", err)
+	}
+	if !strings.Contains(cfg.Body, "nested instructions") {
+		t.Errorf("expected nested, got %q", cfg.Body)
+	}
+
+	// A file only under root (no nested dir) falls back to the root baseline.
+	cfg2, err := ParseNearest(root, filepath.Join("other", "file.go"), nil)
+	if err != nil {
+		t.Fatalf("ParseNearest error: %v", err)
+	}
+	if !strings.Contains(cfg2.Body, "root baseline") {
+		t.Errorf("expected root baseline, got %q", cfg2.Body)
+	}
+}
+
+func TestParseNearest_MissingRoot(t *testing.T) {
+	root := t.TempDir() // no AGENTS.md anywhere
+	cfg, err := ParseNearest(root, filepath.Join("a", "b.go"), nil)
+	if err != nil {
+		t.Fatalf("should not error, got %v", err)
+	}
+	if cfg.Body != "" {
+		t.Errorf("expected empty body, got %q", cfg.Body)
+	}
+}
+
+func TestInjectionText(t *testing.T) {
+	cfg := &AgentsConfig{
+		Body: "Do the thing carefully.",
+		Skills: map[string]string{
+			"go-testing": "Use t.TempDir.",
+		},
+		RequestedSkills: []string{"go-testing"},
+	}
+
+	// nil requestedSkills -> use config's own front-matter skills.
+	out := cfg.InjectionText(nil)
+	if !strings.Contains(out, injectionHeader) {
+		t.Errorf("missing header: %q", out)
+	}
+	if !strings.Contains(out, "Do the thing carefully.") {
+		t.Errorf("missing body: %q", out)
+	}
+	if !strings.Contains(out, "Use t.TempDir.") {
+		t.Errorf("missing resolved skill: %q", out)
+	}
+	if !strings.Contains(out, injectionSkillsHeader) {
+		t.Errorf("missing skills subheader: %q", out)
+	}
+
+	// Explicit empty slice -> body only, no skills section.
+	bodyOnly := cfg.InjectionText([]string{})
+	if strings.Contains(bodyOnly, injectionSkillsHeader) {
+		t.Errorf("empty requestedSkills should omit skills section: %q", bodyOnly)
+	}
+	if !strings.Contains(bodyOnly, "Do the thing carefully.") {
+		t.Errorf("body should still be present: %q", bodyOnly)
+	}
+
+	// Empty config -> empty injection.
+	if got := (&AgentsConfig{}).InjectionText(nil); got != "" {
+		t.Errorf("empty config should inject nothing, got %q", got)
+	}
+	// nil receiver safe.
+	var nilCfg *AgentsConfig
+	if got := nilCfg.InjectionText(nil); got != "" {
+		t.Errorf("nil config should inject nothing, got %q", got)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -232,7 +232,11 @@ type StatusPayload struct {
 	Tokens    FrontendTokens   `json:"tokens"`
 	Repos     []FrontendRepo   `json:"repos"`
 	Beads     FrontendBeads    `json:"beads"`
-	Health    map[string]any   `json:"health"`
+	// Skills reports the agent-skill registry state (ported from v4). It is
+	// honest-empty — available=false / loaded=0 — when /data/skills does not
+	// exist, rather than fabricating a count for an unconfigured hive.
+	Skills FrontendSkills `json:"skills"`
+	Health map[string]any `json:"health"`
 	// DeepHealth carries the spoke's own deep health checks (HealthSummary:
 	// ready, github_auth, agents, …) — the same checks the heartbeat reports
 	// to the hub. The dashboard's header Health pill renders from these, NOT
@@ -419,6 +423,13 @@ type FrontendRepo struct {
 	PRs              int    `json:"prs"`
 	ActionableIssues []any  `json:"actionableIssues"`
 	OpenPrs          []any  `json:"openPrs"`
+}
+
+// FrontendSkills reports the agent-skill registry state for the dashboard.
+type FrontendSkills struct {
+	Available bool   `json:"available"`
+	Loaded    int    `json:"loaded"`
+	Dir       string `json:"dir,omitempty"`
 }
 
 type FrontendBeads struct {

--- a/v2/pkg/dashboard/skills_status_test.go
+++ b/v2/pkg/dashboard/skills_status_test.go
@@ -1,0 +1,65 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBuildSkills_HonestEmptyWhenUnconfigured proves the "not configured" case
+// reports available=false / loaded=0 rather than fabricating a count. A hive
+// with no /data/skills must not claim a skill registry it does not have.
+func TestBuildSkills_HonestEmptyWhenUnconfigured(t *testing.T) {
+	orig := skillsDir
+	t.Cleanup(func() { skillsDir = orig })
+	skillsDir = filepath.Join(t.TempDir(), "does-not-exist")
+
+	got := buildSkills()
+	if got.Available {
+		t.Errorf("available = true for a missing skills dir, want false")
+	}
+	if got.Loaded != 0 {
+		t.Errorf("loaded = %d for a missing skills dir, want 0", got.Loaded)
+	}
+	if got.Dir != "" {
+		t.Errorf("dir = %q for a missing skills dir, want empty", got.Dir)
+	}
+}
+
+// TestBuildSkills_CountsRealSkills is the end-to-end proof that the ported
+// skillreg registry actually parses skill files and that the count reaches the
+// status payload. Compiling is not the same as working: this asserts a real
+// non-zero count from real files on disk, and that a malformed file is
+// tolerated (skipped) rather than failing the whole probe.
+func TestBuildSkills_CountsRealSkills(t *testing.T) {
+	dir := t.TempDir()
+	orig := skillsDir
+	t.Cleanup(func() { skillsDir = orig })
+	skillsDir = dir
+
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write("triage.md", "---\nname: triage\ndescription: triage inbound issues\n---\n\nBody.\n")
+	write("review.md", "---\nname: review\ndescription: review a pull request\n---\n\nBody.\n")
+	// Not a skill file — must be ignored by extension, not counted.
+	write("notes.txt", "not a skill")
+	// Subdirectories are skipped.
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	got := buildSkills()
+	if !got.Available {
+		t.Fatalf("available = false with a populated skills dir, want true")
+	}
+	if got.Loaded != 2 {
+		t.Errorf("loaded = %d, want 2 (triage.md + review.md; notes.txt and nested/ must not count)", got.Loaded)
+	}
+	if got.Dir != dir {
+		t.Errorf("dir = %q, want %q", got.Dir, dir)
+	}
+}

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+
+	"github.com/kubestellar/hive/v2/pkg/skillreg"
 	"regexp"
 	"runtime"
 	"sort"
@@ -199,6 +201,7 @@ func BuildFrontendStatus(
 		HiveID:              cfg.HiveID,
 		Agents:              buildAgents(agentStatuses, cfg, govState),
 		Governor:            buildGovernor(govState, cfg),
+		Skills:              buildSkills(),
 		Tokens:              buildTokens(tokenCollector),
 		Repos:               buildRepos(cfg, actionable),
 		Beads:               BuildBeadsFromConfig(beadStores, cfg),
@@ -1528,4 +1531,29 @@ func redactTokens(s string) string {
 	s = deviceCodeRedactor.ReplaceAllString(s, "${1}****-****")
 	s = deviceCodeLineRedactor.ReplaceAllString(s, "[auth flow redacted]")
 	return s
+}
+
+// buildSkills probes the conventional skills directory and reports the registry
+// state. The registry is not wired into the runtime yet, so this is best-effort
+// and honest-empty: when the directory does not exist it reports available=false
+// / loaded=0 ("not configured") rather than fabricating a count. When the dir is
+// present, skillreg.Load tolerates unreadable/malformed files and returns the
+// number of skills successfully loaded.
+// skillsDir is the conventional agent-skill registry directory. It is a var,
+// not a const, purely so tests can point it at a temp dir.
+var skillsDir = dataVolumePath + "/skills"
+
+func buildSkills() FrontendSkills {
+	dir := skillsDir
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return FrontendSkills{Available: false, Loaded: 0}
+	}
+	// Load tolerates a missing/unreadable dir and bad files; a returned error is
+	// only for a truly unexpected condition, so treat any error as "unavailable".
+	loaded, lErr := skillreg.NewRegistry().Load(dir, nil)
+	if lErr != nil {
+		return FrontendSkills{Available: false, Loaded: 0, Dir: dir}
+	}
+	return FrontendSkills{Available: true, Loaded: loaded, Dir: dir}
 }

--- a/v2/pkg/governor/governor_cel_kick_test.go
+++ b/v2/pkg/governor/governor_cel_kick_test.go
@@ -1,0 +1,117 @@
+package governor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// AgentEligibleForCELKick (added by the celtrigger port, #3608) is the gate a
+// CEL-selected agent must pass before an event-driven kick. CEL triggering is
+// strictly ADDITIVE: it may only ever add an agent the governor's own gates
+// already allow. These tests pin each of those gates, because a regression here
+// would let a declarative rule bypass a pause or an exhausted budget — the one
+// thing the design promises it cannot do.
+
+// TestAgentEligibleForCELKick_AllowsNormalAgent is the positive control: with
+// no gate engaged, an ordinary agent is eligible. Without this, every negative
+// assertion below could pass for the wrong reason (a function that always
+// returns false would satisfy them all).
+func TestAgentEligibleForCELKick_AllowsNormalAgent(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	if !g.AgentEligibleForCELKick("scanner") {
+		t.Error("an unpaused, in-budget, kick-channel agent should be CEL-eligible")
+	}
+}
+
+// TestAgentEligibleForCELKick_DeniedWhenCadencePaused: a paused agent must never
+// be kicked, no matter what event fired. A CEL rule is not an override.
+func TestAgentEligibleForCELKick_DeniedWhenCadencePaused(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	g.mu.Lock()
+	cadence := g.state.Cadences["scanner"]
+	cadence.Paused = true
+	g.state.Cadences["scanner"] = cadence
+	g.mu.Unlock()
+
+	if g.AgentEligibleForCELKick("scanner") {
+		t.Error("a paused agent must not be CEL-eligible")
+	}
+}
+
+// TestAgentEligibleForCELKick_DeniedForOnDemand: on-demand agents are triggered
+// only explicitly, never by the governor and never by an event rule.
+func TestAgentEligibleForCELKick_DeniedForOnDemand(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	agents["scanner"] = config.AgentConfig{Enabled: true, OnDemand: true}
+	g := New(cfg, agents, testLogger())
+
+	if g.AgentEligibleForCELKick("scanner") {
+		t.Error("an on-demand agent must not be CEL-eligible")
+	}
+}
+
+// TestAgentEligibleForCELKick_DeniedWithoutKickChannel: an agent that does not
+// subscribe to the kick channel is not governor-kickable, so CEL cannot kick it
+// either.
+func TestAgentEligibleForCELKick_DeniedWithoutKickChannel(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	agents["scanner"] = config.AgentConfig{
+		Enabled:  true,
+		Channels: []config.ChannelConfig{{Type: "review"}},
+	}
+	g := New(cfg, agents, testLogger())
+
+	if g.AgentEligibleForCELKick("scanner") {
+		t.Error("an agent without the kick channel must not be CEL-eligible")
+	}
+}
+
+// TestAgentEligibleForCELKick_DeniedWhenBudgetExhausted: the weekly budget is a
+// hard stop. This is the gate whose bypass would be most expensive.
+func TestAgentEligibleForCELKick_DeniedWhenBudgetExhausted(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SeedBudget(1500, nil, nil, time.Now())
+
+	if g.AgentEligibleForCELKick("scanner") {
+		t.Error("an exhausted budget must make an agent CEL-ineligible")
+	}
+}
+
+// TestAgentEligibleForCELKick_BudgetExemptStillEligible mirrors agentsDueForKick:
+// budget-exempt agents keep running even when the budget is exhausted.
+func TestAgentEligibleForCELKick_BudgetExemptStillEligible(t *testing.T) {
+	cfg, agents := standardConfig("scanner", "outreach")
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SeedBudget(1500, nil, nil, time.Now())
+	g.SetBudgetIgnored([]string{"outreach"})
+
+	if !g.AgentEligibleForCELKick("outreach") {
+		t.Error("a budget-exempt agent should stay CEL-eligible when the budget is exhausted")
+	}
+	if g.AgentEligibleForCELKick("scanner") {
+		t.Error("a non-exempt agent must stay ineligible when the budget is exhausted")
+	}
+}
+
+// TestAgentEligibleForCELKick_UnknownAgent: an agent absent from the config map
+// has no OnDemand/channel entry to consult. It is not gated by those checks, so
+// this pins the documented behaviour rather than leaving it to chance.
+func TestAgentEligibleForCELKick_UnknownAgent(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	if !g.AgentEligibleForCELKick("no-such-agent") {
+		t.Error("an unknown agent hits no gate and should be reported eligible")
+	}
+}

--- a/v2/pkg/skillreg/agentspec.go
+++ b/v2/pkg/skillreg/agentspec.go
@@ -1,0 +1,135 @@
+package skillreg
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// # Agent SDK contract (BYO-agent)
+//
+// AgentSpec is the minimal, stable contract a third party declares to plug a
+// custom ("bring-your-own") agent into Hive. It names the agent, the backend
+// that runs it, the model to use, the operating mode/policy, and the skills to
+// load by default. It is deliberately small: everything a catalog needs to list
+// and launch a custom agent, and nothing that couples callers to Hive internals.
+//
+// The Go interface AgentSpec is the contract; SpecData is the plain, YAML-backed
+// value that satisfies it, so a declaration on disk and a programmatic
+// implementation are interchangeable.
+
+// AgentMode is an agent's operating policy — how much autonomy it is granted.
+type AgentMode string
+
+const (
+	// ModeObserve means the agent only reports; it takes no repository actions.
+	ModeObserve AgentMode = "observe"
+	// ModeSuggest means the agent proposes changes (e.g. draft PRs) for review.
+	ModeSuggest AgentMode = "suggest"
+	// ModeAutonomous means the agent may act (e.g. open and merge PRs) within
+	// its configured guardrails.
+	ModeAutonomous AgentMode = "autonomous"
+
+	// DefaultMode is applied when a spec omits mode.
+	DefaultMode = ModeSuggest
+)
+
+// AgentSpec is the BYO-agent contract. Any type providing these accessors can be
+// registered as a custom agent. Accessors (not fields) keep the contract stable
+// while allowing alternate backing implementations.
+type AgentSpec interface {
+	// AgentName is the unique identifier for the agent.
+	AgentName() string
+	// Backend names the execution backend (e.g. "claude-code", "codex", a
+	// custom runner). Opaque to Hive; interpreted by the launcher.
+	Backend() string
+	// Model is the model identifier the backend should use.
+	Model() string
+	// Mode is the operating policy (observe/suggest/autonomous).
+	Mode() AgentMode
+	// DefaultSkills lists skill names to resolve into the agent's context by
+	// default. Resolved against a Registry via ResolveRequested.
+	DefaultSkills() []string
+}
+
+// SpecData is the concrete, YAML-backed AgentSpec. It is the wire and disk
+// format for declaring a custom agent.
+type SpecData struct {
+	Name          string    `yaml:"name"`
+	BackendID     string    `yaml:"backend"`
+	ModelID       string    `yaml:"model"`
+	OperatingMode AgentMode `yaml:"mode"`
+	Skills        []string  `yaml:"skills"`
+}
+
+// Compile-time assertion that SpecData satisfies the AgentSpec contract.
+var _ AgentSpec = (*SpecData)(nil)
+
+// AgentName implements AgentSpec.
+func (s *SpecData) AgentName() string { return s.Name }
+
+// Backend implements AgentSpec.
+func (s *SpecData) Backend() string { return s.BackendID }
+
+// Model implements AgentSpec.
+func (s *SpecData) Model() string { return s.ModelID }
+
+// Mode implements AgentSpec. It returns DefaultMode when unset.
+func (s *SpecData) Mode() AgentMode {
+	if s.OperatingMode == "" {
+		return DefaultMode
+	}
+	return s.OperatingMode
+}
+
+// DefaultSkills implements AgentSpec.
+func (s *SpecData) DefaultSkills() []string { return s.Skills }
+
+// validModes is the set of accepted operating modes.
+var validModes = map[AgentMode]struct{}{
+	ModeObserve:    {},
+	ModeSuggest:    {},
+	ModeAutonomous: {},
+}
+
+// ParseAgentSpec parses an AgentSpec from YAML bytes. Unlike skill loading,
+// which is best-effort, a spec is a contract: a malformed document, a missing
+// name/backend/model, or an unknown mode is rejected with an error so a
+// misconfigured agent never launches silently.
+func ParseAgentSpec(data []byte) (*SpecData, error) {
+	var spec SpecData
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("skillreg: malformed agent spec: %w", err)
+	}
+	spec.Name = strings.TrimSpace(spec.Name)
+	spec.BackendID = strings.TrimSpace(spec.BackendID)
+	spec.ModelID = strings.TrimSpace(spec.ModelID)
+
+	if spec.Name == "" {
+		return nil, fmt.Errorf("skillreg: agent spec missing required field: name")
+	}
+	if spec.BackendID == "" {
+		return nil, fmt.Errorf("skillreg: agent spec missing required field: backend")
+	}
+	if spec.ModelID == "" {
+		return nil, fmt.Errorf("skillreg: agent spec missing required field: model")
+	}
+	if spec.OperatingMode == "" {
+		spec.OperatingMode = DefaultMode
+	}
+	if _, ok := validModes[spec.OperatingMode]; !ok {
+		return nil, fmt.Errorf("skillreg: agent spec has unknown mode %q", spec.OperatingMode)
+	}
+	return &spec, nil
+}
+
+// LoadAgentSpec reads and parses an AgentSpec from a YAML file at path.
+func LoadAgentSpec(path string) (*SpecData, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("skillreg: cannot read agent spec %q: %w", path, err)
+	}
+	return ParseAgentSpec(data)
+}

--- a/v2/pkg/skillreg/agentspec_test.go
+++ b/v2/pkg/skillreg/agentspec_test.go
@@ -1,0 +1,105 @@
+package skillreg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const validSpec = `name: reviewer
+backend: claude-code
+model: claude-opus
+mode: suggest
+skills:
+  - go-testing
+  - pr-etiquette
+`
+
+func TestParseAgentSpec_Valid(t *testing.T) {
+	spec, err := ParseAgentSpec([]byte(validSpec))
+	if err != nil {
+		t.Fatalf("ParseAgentSpec: %v", err)
+	}
+	if spec.AgentName() != "reviewer" {
+		t.Errorf("name = %q", spec.AgentName())
+	}
+	if spec.Backend() != "claude-code" {
+		t.Errorf("backend = %q", spec.Backend())
+	}
+	if spec.Model() != "claude-opus" {
+		t.Errorf("model = %q", spec.Model())
+	}
+	if spec.Mode() != ModeSuggest {
+		t.Errorf("mode = %q", spec.Mode())
+	}
+	if got := spec.DefaultSkills(); len(got) != 2 || got[0] != "go-testing" {
+		t.Errorf("skills = %v", got)
+	}
+}
+
+func TestParseAgentSpec_DefaultMode(t *testing.T) {
+	spec, err := ParseAgentSpec([]byte("name: a\nbackend: b\nmodel: m\n"))
+	if err != nil {
+		t.Fatalf("ParseAgentSpec: %v", err)
+	}
+	if spec.Mode() != DefaultMode {
+		t.Errorf("mode = %q, want default %q", spec.Mode(), DefaultMode)
+	}
+}
+
+func TestSpecData_ModeAccessorDefault(t *testing.T) {
+	// A zero-value SpecData's Mode accessor also returns the default.
+	var s SpecData
+	if s.Mode() != DefaultMode {
+		t.Errorf("zero Mode = %q, want %q", s.Mode(), DefaultMode)
+	}
+}
+
+func TestParseAgentSpec_Rejections(t *testing.T) {
+	cases := map[string]string{
+		"malformed yaml":  "name: [oops\n\tbad",
+		"missing name":    "backend: b\nmodel: m\n",
+		"missing backend": "name: a\nmodel: m\n",
+		"missing model":   "name: a\nbackend: b\n",
+		"unknown mode":    "name: a\nbackend: b\nmodel: m\nmode: rogue\n",
+	}
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseAgentSpec([]byte(doc)); err == nil {
+				t.Errorf("expected rejection for %s", name)
+			}
+		})
+	}
+}
+
+func TestParseAgentSpec_AllModes(t *testing.T) {
+	for _, m := range []AgentMode{ModeObserve, ModeSuggest, ModeAutonomous} {
+		doc := "name: a\nbackend: b\nmodel: m\nmode: " + string(m) + "\n"
+		spec, err := ParseAgentSpec([]byte(doc))
+		if err != nil {
+			t.Fatalf("mode %q rejected: %v", m, err)
+		}
+		if spec.Mode() != m {
+			t.Errorf("mode = %q, want %q", spec.Mode(), m)
+		}
+	}
+}
+
+func TestLoadAgentSpec_FileAndMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte(validSpec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	spec, err := LoadAgentSpec(path)
+	if err != nil {
+		t.Fatalf("LoadAgentSpec: %v", err)
+	}
+	if spec.AgentName() != "reviewer" {
+		t.Errorf("name = %q", spec.AgentName())
+	}
+
+	if _, err := LoadAgentSpec(filepath.Join(dir, "nope.yaml")); err == nil {
+		t.Error("missing file should error")
+	}
+}

--- a/v2/pkg/skillreg/skillreg.go
+++ b/v2/pkg/skillreg/skillreg.go
@@ -1,0 +1,527 @@
+// Package skillreg is a local, shareable registry of named, versioned agent
+// "skills" plus a minimal bring-your-own-agent (BYO) contract. It extends the
+// agentsmd package, which parses skills inline in a single AGENTS.md, into a
+// reusable registry so skills can be named, versioned, listed, searched, and
+// resolved across repos and agents — the seed of a community catalog.
+//
+// # Relationship to agentsmd
+//
+// agentsmd.AgentsConfig carries skills as a flat map[name]body, defined inline
+// in one AGENTS.md (or adjacent skills/*.md files) with no version or metadata.
+// This package does not re-parse AGENTS.md; instead it holds richer Skill values
+// (name, version, description, tags, source) and provides a bridge
+// (ResolveRequested) that folds an AgentsConfig's inline skills together with
+// registry skills under a documented precedence.
+//
+// # Skill file format
+//
+// A registry loads skills from a directory of "<file>.md" files. Each file may
+// carry optional YAML front-matter delimited by "---" lines at the very top:
+//
+//	---
+//	name: go-testing
+//	version: 1.2.0
+//	description: How this repo writes Go tests.
+//	tags: [go, testing]
+//	---
+//	Prefer t.TempDir over manual temp dirs.
+//	Never hit the network in unit tests.
+//
+// The text after the front-matter is the skill body. When "name" is omitted it
+// defaults to the file's base name (without ".md"). When "version" is omitted it
+// defaults to DefaultVersion ("0.0.0"). Files are tolerated: a file that cannot
+// be read or whose front-matter is malformed is skipped (with a log line), never
+// fatal, so one bad file cannot break a load.
+//
+// # Precedence (ResolveRequested)
+//
+// For each requested name, the registry is consulted first (a curated,
+// versioned, shareable definition wins), and the AgentsConfig's inline skill is
+// used only as a fallback when the registry has no such skill. This lets a
+// shared catalog override ad-hoc inline snippets while still honoring repo-local
+// skills the catalog has never heard of.
+//
+// # Agent SDK contract (BYO-agent)
+//
+// AgentSpec is the minimal contract a third party implements (or declares in
+// YAML) to plug a custom agent into Hive: a name, a backend identifier, a model,
+// an operating mode/policy, and a list of default skills. LoadAgentSpec reads
+// such a declaration from YAML. The contract is intentionally small and stable.
+//
+// # Concurrency
+//
+// Registry is safe for concurrent use by multiple goroutines.
+package skillreg
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/kubestellar/hive/v2/pkg/agentsmd"
+)
+
+const (
+	// SkillFileExt is the extension for registry skill files.
+	SkillFileExt = ".md"
+
+	// DefaultVersion is assigned to a skill whose file omits "version".
+	DefaultVersion = "0.0.0"
+
+	// frontMatterDelim opens and closes the optional YAML front-matter block.
+	frontMatterDelim = "---"
+
+	// injectionHeader titles the resolved-skills block produced by InjectionText.
+	injectionHeader = "## Requested Skills"
+
+	// versionWildcard, as a constraint, matches any version.
+	versionWildcard = "*"
+
+	// versionPrefixCaret requests the newest version sharing a major with the
+	// constraint (semver-caret style, e.g. "^1.2.0").
+	versionPrefixCaret = "^"
+
+	// versionPrefixGTE requests the newest version at or above the constraint.
+	versionPrefixGTE = ">="
+)
+
+// SkillSource identifies where a Skill came from, for provenance and precedence.
+type SkillSource string
+
+const (
+	// SourceRepo means the skill was loaded from a repository's AGENTS.md or
+	// skills/ directory (an inline or repo-local definition).
+	SourceRepo SkillSource = "repo"
+
+	// SourceBuiltin means the skill was contributed programmatically (e.g. a
+	// curated default baked into a binary).
+	SourceBuiltin SkillSource = "builtin"
+
+	// SourceURLLocalFile means the skill was loaded from a local skill file on
+	// disk (the registry's own skills/ directory).
+	SourceURLLocalFile SkillSource = "url-local-file"
+)
+
+// Skill is a named, versioned instruction snippet plus metadata.
+type Skill struct {
+	// Name is the stable identifier used to request the skill. Required.
+	Name string
+	// Version is a dotted numeric version ("major.minor.patch"); missing parts
+	// read as zero. Defaults to DefaultVersion.
+	Version string
+	// Description is a one-line human summary.
+	Description string
+	// Body is the instruction text injected into an agent's context.
+	Body string
+	// Source records provenance (see SkillSource).
+	Source SkillSource
+	// Tags are free-form labels for Search.
+	Tags []string
+}
+
+// skillFrontMatter is the subset of a skill file's front-matter the loader reads.
+type skillFrontMatter struct {
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags"`
+}
+
+// logger returns lg or a discarding default so callers may pass nil.
+func logger(lg *slog.Logger) *slog.Logger {
+	if lg != nil {
+		return lg
+	}
+	return slog.New(slog.DiscardHandler)
+}
+
+// Registry is a concurrency-safe collection of skills keyed by name. When more
+// than one version of a name is added, all are retained so a version constraint
+// can select among them; Get and unconstrained resolution return the highest
+// version.
+type Registry struct {
+	mu sync.RWMutex
+	// byName maps a skill name to its versions, unordered.
+	byName map[string][]Skill
+}
+
+// NewRegistry returns an empty, ready-to-use Registry.
+func NewRegistry() *Registry {
+	return &Registry{byName: map[string][]Skill{}}
+}
+
+// Add inserts or replaces a skill. A skill with the same name and version as an
+// existing entry replaces it; otherwise it is added as an additional version.
+// A skill with an empty Name is rejected.
+func (r *Registry) Add(s Skill) error {
+	if strings.TrimSpace(s.Name) == "" {
+		return fmt.Errorf("skillreg: skill has empty name")
+	}
+	if strings.TrimSpace(s.Version) == "" {
+		s.Version = DefaultVersion
+	}
+	if s.Source == "" {
+		s.Source = SourceBuiltin
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	versions := r.byName[s.Name]
+	for i, existing := range versions {
+		if existing.Version == s.Version {
+			versions[i] = s
+			r.byName[s.Name] = versions
+			return nil
+		}
+	}
+	r.byName[s.Name] = append(versions, s)
+	return nil
+}
+
+// Load reads every "<file>.md" in dir as a skill and Adds it. Missing or
+// unreadable directories, unreadable files, and files with malformed
+// front-matter are tolerated (logged and skipped); Load returns an error only
+// for a truly unexpected condition, never for a bad individual file. The number
+// of skills successfully loaded is returned.
+func (r *Registry) Load(dir string, lg *slog.Logger) (int, error) {
+	lg = logger(lg)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No directory — nothing to load, not an error.
+			return 0, nil
+		}
+		lg.Warn("skillreg: cannot read skills dir, skipping", "dir", dir, "error", err)
+		return 0, nil
+	}
+	loaded := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), SkillFileExt) {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		raw, rErr := os.ReadFile(path)
+		if rErr != nil {
+			lg.Warn("skillreg: cannot read skill file, skipping", "file", e.Name(), "error", rErr)
+			continue
+		}
+		skill := parseSkillFile(e.Name(), string(raw), lg)
+		if skill.Name == "" {
+			// Unrecoverable (should not happen: name defaults to file base).
+			continue
+		}
+		if aErr := r.Add(skill); aErr != nil {
+			lg.Warn("skillreg: cannot add skill, skipping", "file", e.Name(), "error", aErr)
+			continue
+		}
+		loaded++
+	}
+	return loaded, nil
+}
+
+// parseSkillFile turns a single skill file's contents into a Skill. It never
+// fails: malformed front-matter is logged and skipped, and name/version default
+// sensibly. fileName is used to default the skill name.
+func parseSkillFile(fileName, content string, lg *slog.Logger) Skill {
+	base := strings.TrimSuffix(fileName, SkillFileExt)
+	s := Skill{
+		Name:    base,
+		Version: DefaultVersion,
+		Body:    strings.TrimSpace(content),
+		Source:  SourceURLLocalFile,
+	}
+
+	fm, rest := splitFrontMatter(content)
+	if fm != "" {
+		var meta skillFrontMatter
+		if yErr := yaml.Unmarshal([]byte(fm), &meta); yErr != nil {
+			lg.Warn("skillreg: malformed skill front-matter, using defaults", "file", fileName, "error", yErr)
+		} else {
+			if n := strings.TrimSpace(meta.Name); n != "" {
+				s.Name = n
+			}
+			if v := strings.TrimSpace(meta.Version); v != "" {
+				s.Version = v
+			}
+			s.Description = strings.TrimSpace(meta.Description)
+			s.Tags = normalizeTags(meta.Tags)
+		}
+		s.Body = strings.TrimSpace(rest)
+	}
+	return s
+}
+
+// normalizeTags trims and drops empty tags.
+func normalizeTags(tags []string) []string {
+	var out []string
+	for _, t := range tags {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// splitFrontMatter returns the YAML front-matter (without delimiters) and the
+// remaining document. If no front-matter block is present, front-matter is ""
+// and the whole content is returned as rest.
+func splitFrontMatter(content string) (fm, rest string) {
+	trimmed := strings.TrimLeft(content, "\r\n")
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != frontMatterDelim {
+		return "", content
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == frontMatterDelim {
+			fm = strings.Join(lines[1:i], "\n")
+			rest = strings.Join(lines[i+1:], "\n")
+			return fm, rest
+		}
+	}
+	// Opening delimiter with no close: not valid front-matter, treat as body.
+	return "", content
+}
+
+// Get returns the highest-versioned skill registered under name.
+func (r *Registry) Get(name string) (Skill, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.highestLocked(name)
+}
+
+// highestLocked returns the highest-versioned skill for name. Caller holds mu.
+func (r *Registry) highestLocked(name string) (Skill, bool) {
+	versions := r.byName[name]
+	if len(versions) == 0 {
+		return Skill{}, false
+	}
+	best := versions[0]
+	for _, s := range versions[1:] {
+		if compareVersions(s.Version, best.Version) > 0 {
+			best = s
+		}
+	}
+	return best, true
+}
+
+// Resolve selects the skill named name whose version satisfies constraint. An
+// empty constraint or the wildcard "*" selects the highest version. A "^X.Y.Z"
+// constraint selects the highest version sharing X's major component. A ">=X.Y.Z"
+// constraint selects the highest version at or above X.Y.Z. Any other constraint
+// is treated as an exact version match. Returns false when nothing satisfies it.
+func (r *Registry) Resolve(name, constraint string) (Skill, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" || constraint == versionWildcard {
+		return r.highestLocked(name)
+	}
+
+	versions := r.byName[name]
+	if len(versions) == 0 {
+		return Skill{}, false
+	}
+
+	var best Skill
+	found := false
+	for _, s := range versions {
+		if !satisfies(s.Version, constraint) {
+			continue
+		}
+		if !found || compareVersions(s.Version, best.Version) > 0 {
+			best = s
+			found = true
+		}
+	}
+	return best, found
+}
+
+// satisfies reports whether version meets constraint. See Resolve for the
+// supported constraint grammar.
+func satisfies(version, constraint string) bool {
+	switch {
+	case strings.HasPrefix(constraint, versionPrefixCaret):
+		want := strings.TrimSpace(strings.TrimPrefix(constraint, versionPrefixCaret))
+		return sameMajor(version, want) && compareVersions(version, want) >= 0
+	case strings.HasPrefix(constraint, versionPrefixGTE):
+		want := strings.TrimSpace(strings.TrimPrefix(constraint, versionPrefixGTE))
+		return compareVersions(version, want) >= 0
+	default:
+		return compareVersions(version, constraint) == 0
+	}
+}
+
+// sameMajor reports whether a and b share a major version component.
+func sameMajor(a, b string) bool {
+	return versionParts(a)[0] == versionParts(b)[0]
+}
+
+// versionParts splits a dotted version into three numeric components; missing or
+// non-numeric parts read as zero.
+func versionParts(v string) [3]int {
+	var parts [3]int
+	for i, seg := range strings.SplitN(strings.TrimSpace(v), ".", 3) {
+		if i > 2 {
+			break
+		}
+		n := 0
+		for _, c := range seg {
+			if c < '0' || c > '9' {
+				n = 0
+				break
+			}
+			n = n*10 + int(c-'0')
+		}
+		parts[i] = n
+	}
+	return parts
+}
+
+// compareVersions returns -1, 0, or 1 as a is less than, equal to, or greater
+// than b, comparing major.minor.patch numerically.
+func compareVersions(a, b string) int {
+	pa, pb := versionParts(a), versionParts(b)
+	for i := 0; i < 3; i++ {
+		if pa[i] < pb[i] {
+			return -1
+		}
+		if pa[i] > pb[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// List returns every skill (all versions) sorted by name then descending
+// version, so the newest version of each name comes first.
+func (r *Registry) List() []Skill {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []Skill
+	for _, versions := range r.byName {
+		out = append(out, versions...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return compareVersions(out[i].Version, out[j].Version) > 0
+	})
+	return out
+}
+
+// Search returns the highest version of every skill whose name, description, or
+// any tag contains term (case-insensitively). An empty term matches everything.
+// Results are sorted by name.
+func (r *Registry) Search(term string) []Skill {
+	term = strings.ToLower(strings.TrimSpace(term))
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var out []Skill
+	for name := range r.byName {
+		best, ok := r.highestLocked(name)
+		if !ok {
+			continue
+		}
+		if term == "" || skillMatches(best, term) {
+			out = append(out, best)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// skillMatches reports whether s contains term (already lowercased) in its name,
+// description, or any tag.
+func skillMatches(s Skill, term string) bool {
+	if strings.Contains(strings.ToLower(s.Name), term) ||
+		strings.Contains(strings.ToLower(s.Description), term) {
+		return true
+	}
+	for _, t := range s.Tags {
+		if strings.Contains(strings.ToLower(t), term) {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveRequested bridges an agentsmd.AgentsConfig to the registry. For each
+// requested name it prefers a registry skill (curated, versioned, shareable) and
+// falls back to the config's inline skill only when the registry has none. When
+// requested is nil, the config's own front-matter RequestedSkills are used.
+// Unknown names (in neither the registry nor the config) are skipped. The
+// returned slice preserves request order; ok is false only for a nil registry.
+//
+// This is the documented precedence: registry overrides/augments inline.
+func (r *Registry) ResolveRequested(cfg *agentsmd.AgentsConfig, requested []string) []Skill {
+	if r == nil {
+		return nil
+	}
+	if requested == nil && cfg != nil {
+		requested = cfg.RequestedSkills
+	}
+
+	var out []Skill
+	for _, name := range requested {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if s, ok := r.Get(name); ok {
+			out = append(out, s)
+			continue
+		}
+		if cfg != nil {
+			if body, ok := cfg.Skills[name]; ok && strings.TrimSpace(body) != "" {
+				out = append(out, Skill{
+					Name:    name,
+					Version: DefaultVersion,
+					Body:    strings.TrimSpace(body),
+					Source:  SourceRepo,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// InjectionText renders resolved skills as a Markdown block ready to fold into an
+// agent kick prompt. Returns "" for an empty slice, so a caller with no registry
+// contributes nothing. This is the guarded wire-in point for the kick-assembly
+// path.
+//
+// TODO(sdkskills): deep-wire this into the kick-assembly pipeline alongside
+// agentsmd.InjectionText so registry-resolved skills are appended to the injected
+// context. Kept as a standalone helper here to avoid rewriting the pipeline.
+func InjectionText(skills []Skill) string {
+	if len(skills) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(injectionHeader)
+	b.WriteString("\n\n")
+	for i, s := range skills {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString("### ")
+		b.WriteString(s.Name)
+		if v := strings.TrimSpace(s.Version); v != "" && v != DefaultVersion {
+			b.WriteString(" (v")
+			b.WriteString(v)
+			b.WriteString(")")
+		}
+		b.WriteString("\n\n")
+		b.WriteString(strings.TrimSpace(s.Body))
+	}
+	b.WriteString("\n")
+	return b.String()
+}

--- a/v2/pkg/skillreg/skillreg_test.go
+++ b/v2/pkg/skillreg/skillreg_test.go
@@ -1,0 +1,479 @@
+package skillreg
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agentsmd"
+)
+
+// writeSkill writes content to <dir>/<name> creating the dir as needed.
+func writeSkill(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+const goTestingSkill = `---
+name: go-testing
+version: 1.2.0
+description: How this repo writes Go tests.
+tags: [go, testing, quality]
+---
+Prefer t.TempDir over manual temp dirs.
+Never hit the network in unit tests.`
+
+const prEtiquetteSkill = `---
+name: pr-etiquette
+version: 2.0.0
+description: PR conventions.
+tags: [git, github]
+---
+Sign commits with DCO.
+Keep PRs small.`
+
+// noFrontMatter has no front-matter; name defaults to file base, version default.
+const noFrontMatter = `Just a body of instructions with no metadata.`
+
+func TestLoad_FrontMatterVersionsTags(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "go-testing.md", goTestingSkill)
+	writeSkill(t, dir, "pr-etiquette.md", prEtiquetteSkill)
+	writeSkill(t, dir, "plain.md", noFrontMatter)
+	// Non-.md files and subdirs must be ignored.
+	writeSkill(t, dir, "README.txt", "ignore me")
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry()
+	n, err := r.Load(dir, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("loaded = %d, want 3", n)
+	}
+
+	got, ok := r.Get("go-testing")
+	if !ok {
+		t.Fatal("go-testing not found")
+	}
+	if got.Version != "1.2.0" {
+		t.Errorf("version = %q, want 1.2.0", got.Version)
+	}
+	if got.Description != "How this repo writes Go tests." {
+		t.Errorf("description = %q", got.Description)
+	}
+	if len(got.Tags) != 3 || got.Tags[0] != "go" {
+		t.Errorf("tags = %v", got.Tags)
+	}
+	if got.Source != SourceURLLocalFile {
+		t.Errorf("source = %q, want %q", got.Source, SourceURLLocalFile)
+	}
+	if want := "Prefer t.TempDir over manual temp dirs.\nNever hit the network in unit tests."; got.Body != want {
+		t.Errorf("body = %q", got.Body)
+	}
+
+	// plain.md: name defaults to base, version to DefaultVersion.
+	plain, ok := r.Get("plain")
+	if !ok {
+		t.Fatal("plain not found")
+	}
+	if plain.Version != DefaultVersion {
+		t.Errorf("plain version = %q, want %q", plain.Version, DefaultVersion)
+	}
+	if plain.Body != noFrontMatter {
+		t.Errorf("plain body = %q", plain.Body)
+	}
+}
+
+func TestLoad_UnreadableDirTolerated(t *testing.T) {
+	dir := t.TempDir()
+	// Point Load at a path that is a file, not a directory: ReadDir errors with
+	// a non-NotExist error, which Load must tolerate (0 loaded, nil error).
+	writeSkill(t, dir, "afile.md", goTestingSkill)
+	r := NewRegistry()
+	n, err := r.Load(filepath.Join(dir, "afile.md"), nil)
+	if err != nil {
+		t.Fatalf("Load on a file path: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("loaded = %d, want 0", n)
+	}
+}
+
+func TestLoad_UnreadableSkillFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "good.md", goTestingSkill)
+	writeSkill(t, dir, "locked.md", "body")
+	// Make locked.md unreadable so os.ReadFile errors; it must be skipped.
+	if err := os.Chmod(filepath.Join(dir, "locked.md"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "locked.md"), 0o644) })
+
+	r := NewRegistry()
+	n, err := r.Load(dir, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if n != 1 {
+		t.Skipf("expected 1 loaded (root may bypass perms); got %d", n)
+	}
+}
+
+func TestVersionParts_NonNumericReadsZero(t *testing.T) {
+	// A non-numeric segment reads as zero, so "abc" == "0.0.0".
+	if compareVersions("abc", "0.0.0") != 0 {
+		t.Errorf("non-numeric version should compare equal to 0.0.0")
+	}
+	if compareVersions("1.x.3", "1.0.3") != 0 {
+		t.Errorf("non-numeric minor should read as zero")
+	}
+}
+
+func TestMissingDirIsSafe(t *testing.T) {
+	r := NewRegistry()
+	n, err := r.Load(filepath.Join(t.TempDir(), "does-not-exist"), nil)
+	if err != nil {
+		t.Fatalf("Load missing dir: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("loaded = %d, want 0", n)
+	}
+}
+
+func TestLoad_MalformedFileTolerated(t *testing.T) {
+	dir := t.TempDir()
+	// Malformed front-matter (tab in YAML flow) — must fall back to defaults,
+	// not crash the whole load.
+	writeSkill(t, dir, "broken.md", "---\nname: [oops\n\tbad yaml\n---\nbody here")
+	writeSkill(t, dir, "good.md", goTestingSkill)
+
+	r := NewRegistry()
+	n, err := r.Load(dir, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// good.md always loads; broken.md loads with defaults (name from filename).
+	if n != 2 {
+		t.Fatalf("loaded = %d, want 2", n)
+	}
+	if _, ok := r.Get("go-testing"); !ok {
+		t.Error("good skill should still load past a malformed neighbor")
+	}
+	// broken.md keeps its filename as name and full content as body.
+	broken, ok := r.Get("broken")
+	if !ok {
+		t.Fatal("broken skill should load with default name")
+	}
+	if broken.Version != DefaultVersion {
+		t.Errorf("broken version = %q, want default", broken.Version)
+	}
+}
+
+func TestAddGet(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Add(Skill{Name: "a", Version: "1.0.0", Body: "one"}); err != nil {
+		t.Fatal(err)
+	}
+	// Add with no version defaults it; no source defaults to builtin.
+	if err := r.Add(Skill{Name: "b", Body: "two"}); err != nil {
+		t.Fatal(err)
+	}
+	b, ok := r.Get("b")
+	if !ok {
+		t.Fatal("b missing")
+	}
+	if b.Version != DefaultVersion {
+		t.Errorf("b version = %q", b.Version)
+	}
+	if b.Source != SourceBuiltin {
+		t.Errorf("b source = %q, want builtin", b.Source)
+	}
+
+	if _, ok := r.Get("missing"); ok {
+		t.Error("missing should not be found")
+	}
+}
+
+func TestAdd_EmptyNameRejected(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Add(Skill{Name: "  ", Body: "x"}); err == nil {
+		t.Fatal("empty name should be rejected")
+	}
+}
+
+func TestAdd_SameVersionReplaces(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "a", Version: "1.0.0", Body: "old"})
+	_ = r.Add(Skill{Name: "a", Version: "1.0.0", Body: "new"})
+	got, _ := r.Get("a")
+	if got.Body != "new" {
+		t.Errorf("body = %q, want new (same version replaces)", got.Body)
+	}
+	if len(r.List()) != 1 {
+		t.Errorf("List len = %d, want 1", len(r.List()))
+	}
+}
+
+func TestGet_HighestVersion(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "a", Version: "1.0.0", Body: "v1"})
+	_ = r.Add(Skill{Name: "a", Version: "2.3.0", Body: "v2"})
+	_ = r.Add(Skill{Name: "a", Version: "1.9.9", Body: "v1.9"})
+	got, ok := r.Get("a")
+	if !ok || got.Version != "2.3.0" {
+		t.Fatalf("Get highest = %q, want 2.3.0", got.Version)
+	}
+}
+
+func TestResolve_ConstraintHitAndMiss(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "a", Version: "1.0.0"})
+	_ = r.Add(Skill{Name: "a", Version: "1.5.0"})
+	_ = r.Add(Skill{Name: "a", Version: "2.1.0"})
+
+	cases := []struct {
+		name       string
+		constraint string
+		wantVer    string
+		wantOK     bool
+	}{
+		{"empty->highest", "", "2.1.0", true},
+		{"wildcard->highest", "*", "2.1.0", true},
+		{"exact hit", "1.5.0", "1.5.0", true},
+		{"exact miss", "9.9.9", "", false},
+		{"caret major1", "^1.0.0", "1.5.0", true},
+		{"caret major2", "^2.0.0", "2.1.0", true},
+		{"caret above all in major", "^1.9.0", "", false},
+		{"gte spanning", ">=1.5.0", "2.1.0", true},
+		{"gte too high", ">=3.0.0", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := r.Resolve("a", c.constraint)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if ok && got.Version != c.wantVer {
+				t.Errorf("version = %q, want %q", got.Version, c.wantVer)
+			}
+		})
+	}
+}
+
+func TestResolve_UnknownName(t *testing.T) {
+	r := NewRegistry()
+	if _, ok := r.Resolve("nope", "1.0.0"); ok {
+		t.Error("unknown name should not resolve")
+	}
+	if _, ok := r.Resolve("nope", ""); ok {
+		t.Error("unknown name should not resolve (empty constraint)")
+	}
+}
+
+func TestList_SortedNameThenDescVersion(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "b", Version: "1.0.0"})
+	_ = r.Add(Skill{Name: "a", Version: "1.0.0"})
+	_ = r.Add(Skill{Name: "a", Version: "2.0.0"})
+	list := r.List()
+	if len(list) != 3 {
+		t.Fatalf("len = %d, want 3", len(list))
+	}
+	// a@2.0.0, a@1.0.0, b@1.0.0
+	if list[0].Name != "a" || list[0].Version != "2.0.0" {
+		t.Errorf("list[0] = %v", list[0])
+	}
+	if list[1].Name != "a" || list[1].Version != "1.0.0" {
+		t.Errorf("list[1] = %v", list[1])
+	}
+	if list[2].Name != "b" {
+		t.Errorf("list[2] = %v", list[2])
+	}
+}
+
+func TestList_Empty(t *testing.T) {
+	r := NewRegistry()
+	if got := r.List(); len(got) != 0 {
+		t.Errorf("empty List = %v", got)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "go-testing", Description: "Go test rules", Tags: []string{"go", "testing"}})
+	_ = r.Add(Skill{Name: "pr-etiquette", Description: "PR conventions", Tags: []string{"git"}})
+	_ = r.Add(Skill{Name: "go-lint", Description: "linting", Tags: []string{"go"}})
+
+	// Tag match.
+	if got := r.Search("go"); len(got) != 2 {
+		t.Errorf("search go = %d results, want 2", len(got))
+	}
+	// Name substring.
+	if got := r.Search("etiquette"); len(got) != 1 || got[0].Name != "pr-etiquette" {
+		t.Errorf("search etiquette = %v", got)
+	}
+	// Description substring, case-insensitive.
+	if got := r.Search("LINT"); len(got) != 1 || got[0].Name != "go-lint" {
+		t.Errorf("search LINT = %v", got)
+	}
+	// Empty term matches everything.
+	if got := r.Search(""); len(got) != 3 {
+		t.Errorf("search '' = %d, want 3", len(got))
+	}
+	// No match.
+	if got := r.Search("zzz"); len(got) != 0 {
+		t.Errorf("search zzz = %v", got)
+	}
+}
+
+func TestSearch_HighestVersionOnly(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "a", Version: "1.0.0", Tags: []string{"x"}})
+	_ = r.Add(Skill{Name: "a", Version: "2.0.0", Tags: []string{"x"}})
+	got := r.Search("x")
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (highest only)", len(got))
+	}
+	if got[0].Version != "2.0.0" {
+		t.Errorf("version = %q, want 2.0.0", got[0].Version)
+	}
+}
+
+func TestResolveRequested_Precedence(t *testing.T) {
+	r := NewRegistry()
+	// Registry has a curated go-testing; config has an inline one too.
+	_ = r.Add(Skill{Name: "go-testing", Version: "3.0.0", Body: "REGISTRY body", Source: SourceBuiltin})
+
+	cfg := &agentsmd.AgentsConfig{
+		Skills: map[string]string{
+			"go-testing":  "INLINE body",   // registry wins
+			"repo-only":   "repo local",    // only in config -> fallback
+			"empty-inline": "   ",          // empty inline -> skipped
+		},
+		RequestedSkills: []string{"go-testing", "repo-only", "unknown", "empty-inline"},
+	}
+
+	got := r.ResolveRequested(cfg, nil) // nil -> use cfg.RequestedSkills
+	if len(got) != 2 {
+		t.Fatalf("resolved %d skills, want 2: %+v", len(got), got)
+	}
+	// Order preserved: go-testing (registry), then repo-only (fallback).
+	if got[0].Name != "go-testing" || got[0].Body != "REGISTRY body" {
+		t.Errorf("first = %+v, want registry go-testing", got[0])
+	}
+	if got[0].Source != SourceBuiltin {
+		t.Errorf("registry skill source = %q", got[0].Source)
+	}
+	if got[1].Name != "repo-only" || got[1].Body != "repo local" {
+		t.Errorf("second = %+v, want repo-only fallback", got[1])
+	}
+	if got[1].Source != SourceRepo {
+		t.Errorf("fallback source = %q, want repo", got[1].Source)
+	}
+}
+
+func TestResolveRequested_ExplicitList(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "a", Body: "A"})
+	cfg := &agentsmd.AgentsConfig{Skills: map[string]string{}, RequestedSkills: []string{"ignored"}}
+	got := r.ResolveRequested(cfg, []string{"a", " ", ""})
+	if len(got) != 1 || got[0].Name != "a" {
+		t.Fatalf("got %+v, want [a]", got)
+	}
+}
+
+func TestResolveRequested_NilRegistryAndNilConfig(t *testing.T) {
+	var r *Registry
+	if got := r.ResolveRequested(nil, []string{"a"}); got != nil {
+		t.Errorf("nil registry should return nil, got %v", got)
+	}
+	r = NewRegistry()
+	if got := r.ResolveRequested(nil, []string{"a"}); len(got) != 0 {
+		t.Errorf("nil config with unknown names should resolve nothing, got %v", got)
+	}
+}
+
+func TestInjectionText(t *testing.T) {
+	if got := InjectionText(nil); got != "" {
+		t.Errorf("empty injection = %q, want ''", got)
+	}
+	skills := []Skill{
+		{Name: "go-testing", Version: "1.2.0", Body: "test rules"},
+		{Name: "plain", Version: DefaultVersion, Body: "no version tag"},
+	}
+	got := InjectionText(skills)
+	if !contains(got, injectionHeader) {
+		t.Errorf("missing header: %q", got)
+	}
+	if !contains(got, "### go-testing (v1.2.0)") {
+		t.Errorf("missing versioned heading: %q", got)
+	}
+	// DefaultVersion is not rendered.
+	if contains(got, "(v0.0.0)") {
+		t.Errorf("default version should be hidden: %q", got)
+	}
+	if !contains(got, "### plain\n") {
+		t.Errorf("missing plain heading: %q", got)
+	}
+	if !contains(got, "test rules") || !contains(got, "no version tag") {
+		t.Errorf("missing bodies: %q", got)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestConcurrency(t *testing.T) {
+	r := NewRegistry()
+	const workers = 16
+	const iters = 200
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_ = r.Add(Skill{Name: "shared", Version: "1.0.0", Body: "x"})
+				_ = r.Add(Skill{Name: nameFor(w), Version: verFor(i), Body: "y"})
+				_, _ = r.Get("shared")
+				_, _ = r.Resolve("shared", ">=1.0.0")
+				_ = r.List()
+				_ = r.Search("y")
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if _, ok := r.Get("shared"); !ok {
+		t.Error("shared skill missing after concurrent access")
+	}
+}
+
+func nameFor(w int) string {
+	return "w" + string(rune('a'+w%26))
+}
+
+func verFor(i int) string {
+	return "1." + string(rune('0'+i%10)) + ".0"
+}


### PR DESCRIPTION
Part of the ongoing effort to shrink the v2↔v4 divergence by moving v4-only features onto v2.

## What this ports

| Package | Role |
|---|---|
| `pkg/skillreg` | Agent-skill registry — parses `/data/skills/*.md` |
| `pkg/agentsmd` | `AGENTS.md` parser (a `skillreg` dependency) |

Both are copied verbatim from `v4` and pass their own upstream tests unmodified on `v2`.

## Wiring

`skillreg` gets a real caller: a new `skills` field on the dashboard status payload, populated by `buildSkills()` — mirroring how `v4` uses it in `status_builder.go`.

**Honest-empty by design.** A hive with no `/data/skills` reports `available=false` / `loaded=0` rather than fabricating a count for an unconfigured hive.

## What is deliberately NOT ported

v4 nests skills inside a `FrontendPlatform` card alongside forge and mint. Those two halves depend on **v4-only config that does not exist on v2** — multi-forge (`cfg.Project.ForgeKind()`, `cfg.GitLab`, `cfg.Gitea`) and the mint subsystem (`cfg.Mint`). Porting the whole card would mean dragging in multi-forge support, so only the skills half is carried over, as its own top-level status field.

Worth noting: `platform` has no frontend consumer on v4 either — it is a JSON-only payload field there today.

`agentsmd` is also dormant on v4 (`agentsRepoRoot()` returns `""` unconditionally, gated behind a `TODO(agentsmd)`), so it comes over as a `skillreg` dependency rather than as an active feature. No v2 behaviour changes from it.

## Verification

```
go test ./pkg/dashboard/ ./pkg/skillreg/ ./pkg/agentsmd/ -count=1
ok  .../pkg/dashboard  40.687s
ok  .../pkg/skillreg    1.232s
ok  .../pkg/agentsmd    1.726s
```

`TestBuildSkills_CountsRealSkills` asserts a real non-zero count parsed from actual files on disk — not merely that the code compiles — plus that `.txt` files and subdirectories are excluded.

**Positive control**: replacing the `skillreg.NewRegistry().Load(...)` call with a hardcoded `0` that *still compiles* makes the test fail with `loaded = 0, want 2`. The test is gated on the registry actually working, not on the code merely being present.