### PR TITLE
✨ feat(hub): image pulls per v2 release (not a daily count)

### DIFF
--- a/v2/pkg/hub/image_pulls.go
+++ b/v2/pkg/hub/image_pulls.go
@@ -44,15 +44,15 @@ import (
 // key is missing and the hive is in dashboard-only mode).
 
 const (
-	// pullSnapshotIntervalHours is the minimum age of the newest snapshot before
-	// a new one is taken. The SHA poller ticks every latestSHAPollInterval (2m),
-	// far more often than we want to record a data point, so the snapshot step is
-	// guarded to run at most once per this many hours.
-	pullSnapshotIntervalHours = 24
-
-	// pullHistoryWindowDays is how many daily snapshots the rolling series
-	// retains. Older entries are pruned on every write so the file stays bounded.
-	pullHistoryWindowDays = 30
+	// pullReleaseWindow is how many recent v2 RELEASES (distinct SHAs) the series
+	// retains. Each release records the cumulative pull count at the moment it was
+	// first seen; the pulls attributed to a release are the cumulative delta from
+	// the PREVIOUS release to the next, i.e. the pulls that landed while that
+	// release was newest. Older entries are pruned on every write.
+	//
+	// One extra is kept internally (window+1 snapshots) because N release BARS
+	// need N+1 cumulative readings to bound N windows.
+	pullReleaseWindow = 10
 
 	// pullPageTimeout bounds the single HTTP GET of the public package page.
 	pullPageTimeout = 10 * time.Second
@@ -74,10 +74,12 @@ var imagePullsPath = "/data/saas/image-pulls.json"
 // the <h3> are separated only by whitespace/markup, matched non-greedily.
 var totalDownloadsRe = regexp.MustCompile(`(?s)Total downloads.*?<h3[^>]*\btitle="(\d+)"`)
 
-// pullSnapshot is one daily data point: the cumulative total-downloads counter
-// as read on Date. Deltas between consecutive snapshots give pulls/day.
+// pullSnapshot is one RELEASE data point: the cumulative total-downloads counter
+// as read when the v2 latest SHA first became SHA. Deltas between consecutive
+// releases give the pulls that landed while a release was newest.
 type pullSnapshot struct {
-	Date       string `json:"date"`       // YYYY-MM-DD (UTC) the snapshot was taken
+	SHA        string `json:"sha"`        // short v2 release SHA this snapshot bounds
+	Date       string `json:"date"`       // YYYY-MM-DD (UTC) the release was first seen
 	Cumulative int64  `json:"cumulative"` // cumulative total downloads at that time
 }
 
@@ -134,42 +136,33 @@ func persistImagePullsLocked(logger *slog.Logger) {
 	}
 }
 
-// pruneOldSnapshots returns the newest pullHistoryWindowDays entries, sorted by
-// date ascending. It also collapses duplicate dates (keeping the last write for
-// a given day) so a same-day re-snapshot never double-counts.
+// pruneOldSnapshots keeps the newest (pullReleaseWindow + 1) RELEASE snapshots in
+// insertion order (chronological — the poller only ever appends the current
+// release), collapsing consecutive duplicates of the same SHA (last-write-wins)
+// so a re-observed release never double-counts. window+1 snapshots bound window
+// release BARS. Legacy day-keyed snapshots (no SHA, from before this change) are
+// dropped so the series cleanly re-seeds on the release model.
 func pruneOldSnapshots(in []pullSnapshot) []pullSnapshot {
 	if len(in) == 0 {
 		return nil
 	}
-	// Collapse by date, last-write-wins.
-	byDate := make(map[string]pullSnapshot, len(in))
-	order := make([]string, 0, len(in))
+	out := make([]pullSnapshot, 0, len(in))
 	for _, s := range in {
-		if _, seen := byDate[s.Date]; !seen {
-			order = append(order, s.Date)
+		if s.SHA == "" {
+			continue // drop legacy day-keyed entries
 		}
-		byDate[s.Date] = s
+		if n := len(out); n > 0 && out[n-1].SHA == s.SHA {
+			out[n-1] = s // same release re-observed → last-write-wins
+			continue
+		}
+		out = append(out, s)
 	}
-	sortStrings(order)
-	out := make([]pullSnapshot, 0, len(order))
-	for _, d := range order {
-		out = append(out, byDate[d])
-	}
-	if len(out) > pullHistoryWindowDays {
-		out = out[len(out)-pullHistoryWindowDays:]
+	if keep := pullReleaseWindow + 1; len(out) > keep {
+		out = out[len(out)-keep:]
 	}
 	return out
 }
 
-// sortStrings sorts a slice of date strings ascending. YYYY-MM-DD sorts
-// lexicographically the same as chronologically, so a plain string sort works.
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j-1] > s[j]; j-- {
-			s[j-1], s[j] = s[j], s[j-1]
-		}
-	}
-}
 
 // fetchCumulativePulls reads the exact cumulative "Total downloads" count from
 // the public package page. A var so tests can stub the network round-trip.
@@ -220,23 +213,27 @@ var fetchCumulativePulls = func(ctx context.Context, logger *slog.Logger) (int64
 	return n, true
 }
 
-// maybeSnapshotImagePulls records a new daily snapshot if the newest one is
-// older than pullSnapshotIntervalHours. Called from the SHA poller each tick;
-// the interval guard makes it a no-op most ticks. It restores from disk on first
-// call. now is injected so tests control the clock.
+// maybeSnapshotImagePulls records a new snapshot when the current v2 RELEASE SHA
+// differs from the newest snapshot's SHA — i.e. at each new release boundary. It
+// captures the cumulative pull count at that moment, so the pulls attributed to
+// the PREVIOUS release are (this snapshot's cumulative − that release's
+// cumulative). Called from the SHA poller each tick; a no-op on ticks where the
+// v2 SHA hasn't advanced. It restores from disk on first call. now is injected so
+// tests control the clock.
 func (s *HubServer) maybeSnapshotImagePulls(ctx context.Context, now time.Time) {
 	loadPersistedImagePulls(s.logger)
 
+	sha := getLatestSHAForBranch("v2")
+	if sha == "" {
+		return // v2 SHA not resolved yet (early boot) — nothing to key on
+	}
+	sha = shortSHA(sha)
 	today := now.UTC().Format("2006-01-02")
 
 	imagePullsMu.Lock()
 	due := true
-	if n := len(imagePullSeries); n > 0 {
-		last := imagePullSeries[n-1]
-		// Already have today's point → nothing to do.
-		if last.Date == today {
-			due = false
-		}
+	if n := len(imagePullSeries); n > 0 && imagePullSeries[n-1].SHA == sha {
+		due = false // already recorded this release
 	}
 	imagePullsMu.Unlock()
 	if !due {
@@ -250,42 +247,51 @@ func (s *HubServer) maybeSnapshotImagePulls(ctx context.Context, now time.Time) 
 
 	imagePullsMu.Lock()
 	defer imagePullsMu.Unlock()
-	// Re-check under lock in case a concurrent tick already wrote today's point.
-	if n := len(imagePullSeries); n > 0 && imagePullSeries[n-1].Date == today {
+	// Re-check under lock in case a concurrent tick already recorded this release.
+	if n := len(imagePullSeries); n > 0 && imagePullSeries[n-1].SHA == sha {
 		return
 	}
 	imagePullSeries = pruneOldSnapshots(append(imagePullSeries, pullSnapshot{
+		SHA:        sha,
 		Date:       today,
 		Cumulative: cumulative,
 	}))
 	persistImagePullsLocked(s.logger)
-	s.logger.Info("image pulls: recorded daily snapshot", "date", today, "cumulative", cumulative)
+	s.logger.Info("image pulls: recorded release snapshot", "sha", sha, "date", today, "cumulative", cumulative)
 }
 
-// imagePullPoint is one day of the DELTA series returned to the frontend.
+// imagePullPoint is one RELEASE's pulls in the series returned to the frontend:
+// the pulls that landed while SHA was the newest v2 release (cumulative delta from
+// the release BEFORE it to the release after it).
 type imagePullPoint struct {
-	Date  string `json:"date"`  // YYYY-MM-DD
-	Pulls int64  `json:"pulls"` // pulls that landed that day (cumulative delta)
+	SHA   string `json:"sha"`   // short v2 release SHA
+	Date  string `json:"date"`  // YYYY-MM-DD the release was first seen
+	Pulls int64  `json:"pulls"` // pulls during this release's window
 }
 
 // imagePullsResponse is the /api/hub/image-pulls payload.
 type imagePullsResponse struct {
-	// Points is the day-over-day delta series. It has one fewer entry than the
-	// snapshot series (a delta needs two cumulative readings), so with only one
-	// snapshot so far it is empty and the frontend shows "collecting…".
+	// Points is the per-release series (oldest→newest), up to pullReleaseWindow
+	// entries. N bars need N+1 cumulative snapshots, so with fewer than two
+	// snapshots it is empty and the frontend shows "collecting…".
 	Points []imagePullPoint `json:"points"`
-	// Total30d is the sum of the deltas in the window (pulls over the period).
-	Total30d int64 `json:"total_30d"`
-	// Latest is the most recent day's pulls, or 0 when not enough data yet.
+	// TotalWindow is the sum of pulls across the releases in the window.
+	TotalWindow int64 `json:"total_window"`
+	// Latest is the most recent release's pulls, or 0 when not enough data yet.
 	Latest int64 `json:"latest"`
-	// Collecting is true until there are at least two snapshots — i.e. until a
-	// delta can be computed. The frontend renders "collecting…" instead of a
-	// broken one-point chart.
+	// Releases is how many release bars are in Points.
+	Releases int `json:"releases"`
+	// Collecting is true until there are at least two release snapshots — i.e.
+	// until one release window can be closed. The frontend renders "collecting…"
+	// instead of a broken zero-bar chart.
 	Collecting bool `json:"collecting"`
 }
 
-// buildImagePullsResponse converts the cumulative snapshot series into daily
-// deltas. Split out from the handler so it is unit-testable without HTTP.
+// buildImagePullsResponse converts the cumulative release-snapshot series into
+// per-release pull windows. Split out from the handler so it is unit-testable
+// without HTTP. Each bar i is the cumulative delta between release i and i+1, so
+// the NEWEST snapshot (the current release, still accruing) does not yet get its
+// own closed bar — its window closes when the next release lands.
 func buildImagePullsResponse(series []pullSnapshot) imagePullsResponse {
 	resp := imagePullsResponse{Points: []imagePullPoint{}}
 	if len(series) < 2 {
@@ -299,12 +305,19 @@ func buildImagePullsResponse(series []pullSnapshot) imagePullsResponse {
 		if delta < 0 {
 			delta = 0
 		}
-		resp.Points = append(resp.Points, imagePullPoint{Date: series[i].Date, Pulls: delta})
-		resp.Total30d += delta
+		// The bar belongs to the EARLIER release (series[i-1]) — those are the
+		// pulls that landed while it was the newest release, up to the next one.
+		resp.Points = append(resp.Points, imagePullPoint{
+			SHA:   series[i-1].SHA,
+			Date:  series[i-1].Date,
+			Pulls: delta,
+		})
+		resp.TotalWindow += delta
 	}
 	if n := len(resp.Points); n > 0 {
 		resp.Latest = resp.Points[n-1].Pulls
 	}
+	resp.Releases = len(resp.Points)
 	return resp
 }
 

--- a/v2/pkg/hub/image_pulls_test.go
+++ b/v2/pkg/hub/image_pulls_test.go
@@ -20,96 +20,112 @@ func resetImagePullsState() {
 	imagePullsMu.Unlock()
 }
 
-func TestBuildImagePullsResponse_Deltas(t *testing.T) {
+// setV2LatestSHA sets the v2 branch's latest-SHA the release snapshotter keys on.
+func setV2LatestSHA(sha string) {
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: sha}
+	latestSHAMu.Unlock()
+}
+
+func TestBuildImagePullsResponse_PerRelease(t *testing.T) {
+	// Four release snapshots → three CLOSED windows (the newest release is still
+	// accruing and gets no bar yet). Each bar belongs to the EARLIER release.
 	series := []pullSnapshot{
-		{Date: "2026-08-01", Cumulative: 1000},
-		{Date: "2026-08-02", Cumulative: 1050}, // +50
-		{Date: "2026-08-03", Cumulative: 1075}, // +25
-		{Date: "2026-08-04", Cumulative: 1200}, // +125
+		{SHA: "aaa1111", Date: "2026-08-01", Cumulative: 1000},
+		{SHA: "bbb2222", Date: "2026-08-02", Cumulative: 1050}, // aaa window = +50
+		{SHA: "ccc3333", Date: "2026-08-03", Cumulative: 1075}, // bbb window = +25
+		{SHA: "ddd4444", Date: "2026-08-04", Cumulative: 1200}, // ccc window = +125
 	}
 	got := buildImagePullsResponse(series)
 	if got.Collecting {
 		t.Fatalf("did not expect Collecting with %d snapshots", len(series))
 	}
 	if len(got.Points) != 3 {
-		t.Fatalf("want 3 delta points, got %d", len(got.Points))
+		t.Fatalf("want 3 release bars, got %d", len(got.Points))
 	}
+	wantSHA := []string{"aaa1111", "bbb2222", "ccc3333"}
 	wantPulls := []int64{50, 25, 125}
 	for i, p := range got.Points {
+		if p.SHA != wantSHA[i] {
+			t.Errorf("bar %d: want sha %s, got %s", i, wantSHA[i], p.SHA)
+		}
 		if p.Pulls != wantPulls[i] {
-			t.Errorf("point %d: want %d pulls, got %d", i, wantPulls[i], p.Pulls)
+			t.Errorf("bar %d: want %d pulls, got %d", i, wantPulls[i], p.Pulls)
 		}
 	}
-	if got.Total30d != 200 {
-		t.Errorf("want Total30d=200, got %d", got.Total30d)
+	if got.TotalWindow != 200 {
+		t.Errorf("want TotalWindow=200, got %d", got.TotalWindow)
 	}
 	if got.Latest != 125 {
 		t.Errorf("want Latest=125, got %d", got.Latest)
 	}
+	if got.Releases != 3 {
+		t.Errorf("want Releases=3, got %d", got.Releases)
+	}
 }
 
 func TestBuildImagePullsResponse_ColdStart(t *testing.T) {
-	// Zero snapshots.
 	if r := buildImagePullsResponse(nil); !r.Collecting || len(r.Points) != 0 {
 		t.Errorf("empty series: want collecting/no points, got %+v", r)
 	}
-	// One snapshot — still no delta possible.
-	one := []pullSnapshot{{Date: "2026-08-01", Cumulative: 42}}
+	// One release snapshot — no window can be closed yet.
+	one := []pullSnapshot{{SHA: "aaa1111", Date: "2026-08-01", Cumulative: 42}}
 	if r := buildImagePullsResponse(one); !r.Collecting || len(r.Points) != 0 {
 		t.Errorf("single snapshot: want collecting/no points, got %+v", r)
 	}
 }
 
 func TestBuildImagePullsResponse_NegativeDeltaClamped(t *testing.T) {
-	// Counter appears to go backwards (reset / bad read): delta must clamp to 0,
-	// never a negative spike, and must not drag the total below the good days.
+	// Counter appears to go backwards (reset / bad read): delta must clamp to 0.
 	series := []pullSnapshot{
-		{Date: "2026-08-01", Cumulative: 5000},
-		{Date: "2026-08-02", Cumulative: 100}, // reset → clamped to 0
-		{Date: "2026-08-03", Cumulative: 130}, // +30
+		{SHA: "aaa1111", Date: "2026-08-01", Cumulative: 5000},
+		{SHA: "bbb2222", Date: "2026-08-02", Cumulative: 100}, // reset → clamped to 0
+		{SHA: "ccc3333", Date: "2026-08-03", Cumulative: 130}, // +30
 	}
 	got := buildImagePullsResponse(series)
 	if got.Points[0].Pulls != 0 {
-		t.Errorf("want clamped 0 for reset day, got %d", got.Points[0].Pulls)
+		t.Errorf("want clamped 0 for reset window, got %d", got.Points[0].Pulls)
 	}
 	if got.Points[1].Pulls != 30 {
-		t.Errorf("want 30 for recovery day, got %d", got.Points[1].Pulls)
+		t.Errorf("want 30 for recovery window, got %d", got.Points[1].Pulls)
 	}
-	if got.Total30d != 30 {
-		t.Errorf("want Total30d=30 (clamped), got %d", got.Total30d)
+	if got.TotalWindow != 30 {
+		t.Errorf("want TotalWindow=30 (clamped), got %d", got.TotalWindow)
 	}
 }
 
-func TestPruneOldSnapshots_WindowAndDedupe(t *testing.T) {
-	// Build more than the window plus a duplicate date to exercise both paths.
+func TestPruneOldSnapshots_WindowDedupeAndLegacyDrop(t *testing.T) {
 	var in []pullSnapshot
-	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	for i := 0; i < pullHistoryWindowDays+5; i++ {
-		d := base.AddDate(0, 0, i).Format("2006-01-02")
-		in = append(in, pullSnapshot{Date: d, Cumulative: int64(i * 10)})
+	// More than window+1 releases, distinct SHAs.
+	for i := 0; i < pullReleaseWindow+5; i++ {
+		in = append(in, pullSnapshot{
+			SHA:        "sha" + string(rune('a'+i)),
+			Date:       "2026-01-01",
+			Cumulative: int64(i * 10),
+		})
 	}
-	// Duplicate the last date with a newer cumulative — last-write should win.
-	lastDate := in[len(in)-1].Date
-	in = append(in, pullSnapshot{Date: lastDate, Cumulative: 99999})
+	// A legacy day-keyed entry (no SHA) must be dropped.
+	in = append([]pullSnapshot{{Date: "2025-12-31", Cumulative: 1}}, in...)
+	// Re-observe the last release with a newer cumulative — last-write wins.
+	lastSHA := in[len(in)-1].SHA
+	in = append(in, pullSnapshot{SHA: lastSHA, Date: "2026-01-02", Cumulative: 99999})
 
 	out := pruneOldSnapshots(in)
-	if len(out) != pullHistoryWindowDays {
-		t.Fatalf("want window of %d, got %d", pullHistoryWindowDays, len(out))
+	if len(out) != pullReleaseWindow+1 {
+		t.Fatalf("want window+1 = %d, got %d", pullReleaseWindow+1, len(out))
 	}
-	// Sorted ascending.
-	for i := 1; i < len(out); i++ {
-		if out[i-1].Date > out[i].Date {
-			t.Fatalf("not sorted ascending at %d: %s > %s", i, out[i-1].Date, out[i].Date)
+	for _, s := range out {
+		if s.SHA == "" {
+			t.Fatalf("legacy day-keyed entry leaked through: %+v", s)
 		}
 	}
-	// Dedupe kept the last write for the duplicated date.
+	// Consecutive dup of the same SHA collapsed, last-write kept.
 	if out[len(out)-1].Cumulative != 99999 {
 		t.Errorf("dedupe last-write-wins failed: got cumulative %d", out[len(out)-1].Cumulative)
 	}
 }
 
 func TestFetchCumulativePulls_ScrapesTitle(t *testing.T) {
-	// Serve a page shaped like the real GHCR package page.
 	page := `<html><body>
 	  <span>Total downloads</span>
 	  <h3 title="127576">128K</h3>
@@ -147,14 +163,13 @@ func TestFetchCumulativePulls_CounterMissing(t *testing.T) {
 	}
 }
 
-func TestMaybeSnapshot_PersistsAndDailyGuard(t *testing.T) {
+func TestMaybeSnapshot_PersistsAndReleaseGuard(t *testing.T) {
 	resetImagePullsState()
 	dir := t.TempDir()
 	origPath := imagePullsPath
 	imagePullsPath = filepath.Join(dir, "image-pulls.json")
 	defer func() { imagePullsPath = origPath }()
 
-	// Stub the network so no real HTTP happens.
 	var cumulative int64 = 1000
 	origFetch := fetchCumulativePulls
 	fetchCumulativePulls = func(ctx context.Context, logger *slog.Logger) (int64, bool) {
@@ -163,38 +178,38 @@ func TestMaybeSnapshot_PersistsAndDailyGuard(t *testing.T) {
 	defer func() { fetchCumulativePulls = origFetch }()
 
 	s := &HubServer{logger: slog.Default()}
-	day1 := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
+	t0 := time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC)
 
-	// Two calls on the SAME day → only one snapshot (daily guard).
-	s.maybeSnapshotImagePulls(context.Background(), day1)
-	cumulative = 1234 // would-be second read, same day
-	s.maybeSnapshotImagePulls(context.Background(), day1.Add(3*time.Hour))
+	// Release 1 (SHA aaa1111). Two ticks with the SAME SHA → only one snapshot.
+	setV2LatestSHA("aaa1111deadbeef")
+	s.maybeSnapshotImagePulls(context.Background(), t0)
+	cumulative = 1234 // would-be second read, same release
+	s.maybeSnapshotImagePulls(context.Background(), t0.Add(3*time.Hour))
 
 	imagePullsMu.Lock()
 	n := len(imagePullSeries)
 	imagePullsMu.Unlock()
 	if n != 1 {
-		t.Fatalf("same-day guard failed: want 1 snapshot, got %d", n)
+		t.Fatalf("same-release guard failed: want 1 snapshot, got %d", n)
 	}
 
-	// Next day → a second snapshot.
-	day2 := day1.AddDate(0, 0, 1)
+	// A NEW release (SHA bbb2222) → a second snapshot.
+	setV2LatestSHA("bbb2222cafef00d")
 	cumulative = 1300
-	s.maybeSnapshotImagePulls(context.Background(), day2)
+	s.maybeSnapshotImagePulls(context.Background(), t0.Add(6*time.Hour))
 
 	imagePullsMu.Lock()
 	n = len(imagePullSeries)
 	imagePullsMu.Unlock()
 	if n != 2 {
-		t.Fatalf("want 2 snapshots across two days, got %d", n)
+		t.Fatalf("want 2 snapshots across two releases, got %d", n)
 	}
 
-	// Persisted to disk.
 	if _, err := os.Stat(imagePullsPath); err != nil {
 		t.Fatalf("series not persisted: %v", err)
 	}
 
-	// Fresh load restores it (simulating a hub restart).
+	// Restore after restart.
 	resetImagePullsState()
 	loadPersistedImagePulls(slog.Default())
 	imagePullsMu.Lock()
@@ -204,9 +219,12 @@ func TestMaybeSnapshot_PersistsAndDailyGuard(t *testing.T) {
 		t.Fatalf("restore after restart failed: want 2, got %d", n)
 	}
 
-	// And the delta comes out as day2-day1 = 300.
+	// The aaa1111 release window = 1300-1000 = 300, keyed to the short SHA.
 	resp := buildImagePullsResponse(imagePullSeries)
-	if resp.Latest != 300 || resp.Total30d != 300 {
-		t.Errorf("want latest/total 300, got latest=%d total=%d", resp.Latest, resp.Total30d)
+	if resp.Latest != 300 || resp.TotalWindow != 300 {
+		t.Errorf("want latest/total 300, got latest=%d total=%d", resp.Latest, resp.TotalWindow)
+	}
+	if len(resp.Points) != 1 || resp.Points[0].SHA != "aaa1111" {
+		t.Errorf("want one bar keyed to short SHA aaa1111, got %+v", resp.Points)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4838,8 +4838,8 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// netAdminReconcileInterval — this poller ticks far more often than the
 	// static drift needs re-checking. See netadmin_reconcile.go / issue #2674.
 	s.reconcileNetAdminIfDue()
-	// Record the daily image-pulls snapshot (external-adoption sparkline). The
-	// call is internally guarded to run at most once per pullSnapshotIntervalHours,
+	// Record the per-release image-pulls snapshot (external-adoption chart). The
+	// call is internally guarded to snapshot only when the v2 release SHA advances,
 	// so ticking it alongside the frequent SHA poll is cheap — no separate
 	// scheduler. See image_pulls.go.
 	s.maybeSnapshotImagePulls(ctx, time.Now())
@@ -8358,7 +8358,7 @@ const dashboardHTML = `<!DOCTYPE html>
              downloads (uniqueness is not measurable). Populated by
              loadImagePulls(). Hidden until there is data to show. -->
         <div id="image-pulls-spark" style="display:none;margin-top:8px"
-             title="Daily container-image pulls of the public hive image (ghcr.io/kubestellar/hive:v2), derived from GitHub's cumulative download counter. This is pulls/day — not unique downloads."></div>
+             title="Container-image pulls per v2 release: the pulls that landed while each of the last ~10 v2 SHAs was the newest release, of the public hive image (ghcr.io/kubestellar/hive:v2). Derived from GitHub's cumulative download counter — pulls, not unique downloads."></div>
       </div>
       <div style="display:flex;gap:8px;align-items:center">
         <button class="btn-primary" id="btn-send-banner-top" style="display:none;background:#d97706" onclick="_bannerTargetHive=null;document.getElementById('banner-modal').style.display='flex';loadBannerHiveList()">Send Banner</button>
@@ -12594,12 +12594,14 @@ const dashboardHTML = `<!DOCTYPE html>
       }
     }
 
-    /* loadImagePulls fetches the 30-day daily-delta series of container-image
-       PULLS of the public spoke image and paints a self-contained inline-SVG
-       sparkline near the header. Honest labelling: "pulls/day", NOT unique
-       downloads — the series is derived from GitHub's cumulative download
-       counter and uniqueness is not measurable. Cold start (fewer than two
-       snapshots → no delta yet) shows "collecting…" rather than a broken chart. */
+    /* loadImagePulls fetches the per-RELEASE pull series (pulls that landed while
+       each of the last ~10 v2 SHAs was the newest release) and paints a small
+       inline-SVG bar chart near the header — one bar per release, newest on the
+       right. Gauges external adoption of the public spoke image
+       (ghcr.io/kubestellar/hive:v2) beyond the hosted fleet. Honest labelling:
+       derived from GitHub's cumulative download counter (pulls, NOT unique
+       downloads). Cold start (fewer than two release snapshots → no window can be
+       closed yet) shows "collecting…". */
     async function loadImagePulls() {
       var host = document.getElementById('image-pulls-spark');
       if (!host) return;
@@ -12609,7 +12611,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!resp.ok) { host.style.display = 'none'; return; }
         data = await resp.json();
       } catch (e) {
-        /* Adoption sparkline is non-critical chrome — never let it break the
+        /* Adoption chart is non-critical chrome — never let it break the
            dashboard. Just leave it hidden on any failure. */
         host.style.display = 'none';
         return;
@@ -12617,52 +12619,52 @@ const dashboardHTML = `<!DOCTYPE html>
       var points = (data && data.points) || [];
       host.style.display = 'block';
 
-      /* Cold start: one or zero snapshots means no day-over-day delta yet. */
-      if (data && data.collecting || points.length < 1) {
-        host.innerHTML = '<div style="font-size:0.7rem;color:var(--muted)">Daily image pulls (v2): <span style="opacity:0.7">collecting… (first full data point appears after ~24h)</span></div>';
+      /* Cold start: needs at least two release snapshots to close one window. */
+      if ((data && data.collecting) || points.length < 1) {
+        host.innerHTML = '<div style="font-size:0.7rem;color:var(--muted)">Image pulls per v2 release: <span style="opacity:0.7">collecting… (a bar appears once a second release is published)</span></div>';
         return;
       }
 
-      /* Sparkline geometry. Named so there are no bare magic numbers in the
-         path math below. */
-      var SPARK_W = 160;   // px, drawing width
-      var SPARK_H = 28;    // px, drawing height
-      var SPARK_PAD = 2;   // px, top/bottom breathing room so peaks aren't clipped
+      /* Bar-chart geometry. Named so there are no bare magic numbers below. */
+      var BAR_W = 14;      // px, per-release bar width
+      var BAR_GAP = 3;     // px, gap between bars
+      var BAR_H = 30;      // px, drawing height
+      var BAR_PAD = 2;     // px, top breathing room so the tallest bar isn't clipped
 
       var vals = points.map(function(p) { return Math.max(0, Number(p.pulls) || 0); });
       var maxV = Math.max.apply(null, vals);
       if (maxV <= 0) maxV = 1; // avoid divide-by-zero on an all-zero window
+      var chartW = points.length * BAR_W + (points.length - 1) * BAR_GAP;
+      var usableH = BAR_H - BAR_PAD;
 
-      var stepX = points.length > 1 ? (SPARK_W / (points.length - 1)) : 0;
-      var usableH = SPARK_H - (SPARK_PAD * 2);
-      var coords = vals.map(function(v, i) {
-        var x = (i * stepX).toFixed(1);
-        var y = (SPARK_PAD + (usableH - (v / maxV) * usableH)).toFixed(1);
-        return x + ',' + y;
+      var bars = '';
+      points.forEach(function(p, i) {
+        var v = vals[i];
+        var h = Math.max(1, (v / maxV) * usableH); // min 1px so a zero-pull release is still visible
+        var x = i * (BAR_W + BAR_GAP);
+        var y = BAR_H - h;
+        var sha = esc(String(p.sha || ''));
+        var tip = sha + ': ' + v + ' pulls' + (p.date ? ' (since ' + esc(String(p.date)) + ')' : '');
+        // The newest bar (last) is highlighted; older ones muted.
+        var fill = (i === points.length - 1) ? '#60a5fa' : 'rgba(96,165,250,0.45)';
+        bars += '<rect x="' + x.toFixed(1) + '" y="' + y.toFixed(1) + '" width="' + BAR_W + '" height="' + h.toFixed(1) + '" rx="1.5" fill="' + fill + '"><title>' + tip + '</title></rect>';
       });
-      var linePts = coords.join(' ');
-      /* Filled area under the line: close the polyline down to the baseline. */
-      var lastX = points.length > 1 ? SPARK_W : 0;
-      var areaPts = '0,' + SPARK_H + ' ' + linePts + ' ' + lastX + ',' + SPARK_H;
-
-      var latest = (data && Number(data.latest)) || 0;
-      var total = (data && Number(data.total_30d)) || 0;
 
       var svg =
-        '<svg width="' + SPARK_W + '" height="' + SPARK_H + '" viewBox="0 0 ' + SPARK_W + ' ' + SPARK_H + '" ' +
-        'preserveAspectRatio="none" style="display:block;overflow:visible">' +
-        '<polygon points="' + areaPts + '" fill="rgba(96,165,250,0.15)" stroke="none"></polygon>' +
-        '<polyline points="' + linePts + '" fill="none" stroke="#60a5fa" stroke-width="1.5" ' +
-        'stroke-linejoin="round" stroke-linecap="round"></polyline>' +
-        '</svg>';
+        '<svg width="' + chartW + '" height="' + BAR_H + '" viewBox="0 0 ' + chartW + ' ' + BAR_H + '" ' +
+        'style="display:block;overflow:visible">' + bars + '</svg>';
+
+      var latest = (data && Number(data.latest)) || 0;
+      var total = (data && Number(data.total_window)) || 0;
+      var newestSHA = points.length ? esc(String(points[points.length - 1].sha || '')) : '';
 
       host.innerHTML =
         '<div style="display:flex;align-items:center;gap:10px">' +
-          '<div style="font-size:0.7rem;color:var(--muted);white-space:nowrap">Daily image pulls (v2)</div>' +
+          '<div style="font-size:0.7rem;color:var(--muted);white-space:nowrap">Pulls per v2 release</div>' +
           svg +
           '<div style="font-size:0.7rem;color:var(--muted);white-space:nowrap">' +
-            '<span style="color:#60a5fa;font-weight:600">' + esc(String(latest)) + '</span> latest' +
-            ' &middot; ' + esc(String(total)) + ' over ' + points.length + 'd' +
+            '<span style="color:#60a5fa;font-weight:600">' + esc(String(latest)) + '</span> on ' + newestSHA +
+            ' &middot; ' + esc(String(total)) + ' over last ' + points.length + ' releases' +
           '</div>' +
         '</div>';
     }


### PR DESCRIPTION
The "Daily image pulls (v2)" number was **dominated by the hosted fleet** re-pulling v2 on every roll — so it didn't answer the real question: *how is each release being adopted externally.*

Re-keys the image-pulls series by **v2 release SHA**:

- **Snapshot on release, not daily** — capture the cumulative GHCR download counter when the v2 latest SHA advances. Each release's pulls = the cumulative delta from that release to the next (the pulls that landed while it was newest).
- **Last ~10 releases** kept; prune drops legacy day-keyed entries so it cleanly re-seeds.
- **UI**: a small **per-release bar chart** on "My Hives" (one bar per SHA, newest highlighted right), per-bar tooltip `<sha>: N pulls`. Header: *"Pulls per v2 release: N on `<sha>` · `<total>` over last K releases"*. Cold start: *"collecting… (a bar appears once a second release is published)"*.
- **API**: `/api/hub/image-pulls` returns `{sha,date,pulls}` points + `total_window` + `releases` (was daily deltas + `total_30d`).

### Honest about the data
Still derived from GitHub's **cumulative** download counter — **pulls, not unique downloads** (GHCR exposes no unique/per-SHA count; this is the honest best-available signal, delta'd at release boundaries).

### Tests
Reworked for the release model: per-release windows, cold start, negative-delta clamp, window+dedupe+legacy-drop, same-release guard, restart restore. Full `pkg/hub` suite green; `go vet` clean.