### PR TITLE
docs: document gateway key_name field in inference-backends.md and hive.yaml.example

### DIFF
--- a/docs/inference-backends.md
+++ b/docs/inference-backends.md
@@ -10,6 +10,8 @@ The agent still launches Claude Code in bare mode. Hive writes Claude settings t
 
 Use the dashboard's **Governor Config → Model Gateways** UI, or YAML. A gateway needs a name, kind, endpoint, optional key reference, and optional default model. Agents can then set `backend:` to either the built-in kind (`vllm`, `llm-d`, `litellm`, `watsonx`) or to a configured gateway name such as `openrouter`.
 
+Each gateway also accepts an optional `key_name` — a human-chosen LABEL for the configured key ("Team inference key", "andy personal", …). It is safe-to-show metadata, not a secret: it records WHICH key a gateway is set to use so operators can tell keys apart without ever seeing the value. The dashboard's gateway row displays it as "Using key: `<name>`", or "(unnamed)" when no label is set. `key_name` mirrors the bob backend's `KeyName` field and is optional on every gateway kind (litellm / openrouter / watsonx / vllm); omitting it keeps existing gateways byte-identical in `hive.yaml`.
+
 LiteLLM also has a dedicated config block:
 
 ```yaml
@@ -56,6 +58,7 @@ governor:
       endpoint: https://openrouter.ai/api/v1
       api_key_file: /data/secrets/gateway_openrouter_api_key
       default_model: deepseek/deepseek-chat
+      key_name: openrouter-prod-key  # optional: audit label shown in the dashboard, not a secret
 
 agents:
   guide:

--- a/v2/docs/agent-configuration.md
+++ b/v2/docs/agent-configuration.md
@@ -210,6 +210,8 @@ Two rules of thumb:
 - **CLI methods are subscriptions.** You log in once per method from the dashboard, and every agent using that method shares the login.
 - **Inference methods are endpoints.** You configure a base URL and a key *reference* (env var name or key-file path — the value goes in `/data/secrets/`, never in YAML). Agents on `vllm`/`llm-d`/`litellm` launch the Claude CLI routed through hive's inference translator, so there is no separate login.
 
+Every Model Gateway (and the bob backend) also accepts an optional `key_name` — a human-chosen LABEL for the configured key, e.g. `key_name: openrouter-prod-key`. It is safe-to-show metadata, not a secret: the dashboard's gateway row displays it as "Using key: `<name>`", or "(unnamed)" when no label is set, so operators can tell keys apart without ever seeing the value. See [`inference-backends.md`](../../docs/inference-backends.md) for a full YAML example.
+
 Kubernetes manifests for deploying inference backends (vllm Deployment, EPP RBAC, kustomization) are in [`deploy/inference/`](../deploy/inference/).
 
 Agents can inspect peer panes with `hive-panes [lines]` when the deployment includes `v2/deploy/hive-panes.sh`. It reads pluk JSONL logs from `/var/run/pluk/logs`, skips the calling agent named by `HIVE_PROXY_AGENT`, strips terminal escapes, and prints the last N raw-output lines for every other agent. Use it for situational awareness; it is read-only and does not attach to another agent's tmux session.

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -262,6 +262,22 @@ governor:
   #   local_proxy: false                      # run the bundled litellm binary locally
   #                                           # (config at /data/litellm/config.yaml)
 
+  # Named Model Gateways (optional) — configure one or more OpenAI-compatible
+  # gateways at once (e.g. OpenRouter for public models plus a private LiteLLM
+  # proxy for internal ones); each agent picks one by naming it as its
+  # backend. When this list is empty, a single implicit gateway named
+  # "litellm" is synthesized from the litellm block above, so existing hives
+  # keep working with zero config change.
+  # gateways:
+  #   - name: openrouter                        # unique gateway id; agents set backend: <name>
+  #     kind: openrouter                        # openrouter | litellm | vllm | llm-d | watsonx | custom
+  #     endpoint: https://openrouter.ai/api/v1  # OpenAI-compatible base URL
+  #     api_key_env: OPENROUTER_API_KEY         # env var NAME holding the key (or use api_key_file)
+  #     default_model: deepseek/deepseek-chat   # model used when an agent has none selected
+  #     key_name: openrouter-prod-key           # optional: human LABEL for the configured key,
+  #                                             # shown in the dashboard as "Using key: <name>"
+  #                                             # (or "(unnamed)"); safe-to-show, NOT a secret
+
   # IBM bobshell ("bob") backend credentials. REQUIRED for agents with
   # backend: bob — bob's default IBMid/W3ID auth opens a browser and waits on a
   # localhost callback, which no pod can satisfy, so it fails after a 3-minute
@@ -273,6 +289,9 @@ governor:
   # bob:
   #   api_key_env: HIVE_BOB_API_KEY       # env var NAME holding the key (default)
   #   api_key_file: /secrets/bob_api_key  # or a mounted key file (default path)
+  #   key_name: bob-shared-key            # optional: human LABEL for the configured key,
+  #                                       # shown in the dashboard as "Using key: <name>"
+  #                                       # (or "(unnamed)"); safe-to-show, NOT a secret
 
 # GitHub authentication — use ONE of these methods
 github:


### PR DESCRIPTION
## What

Documents the `key_name` field on `GatewayConfig` (and `BobConfig`), added in #3598/#3606, which was missing from the docs.

`key_name` is an optional, human-chosen label recorded alongside a Model Gateway's (or bob's) configured key. It is safe-to-show metadata, not a secret — it lets operators tell keys apart in the dashboard, which renders it as "Using key: `<name>`" or "(unnamed)" when unset.

## Changes

- `docs/inference-backends.md` — explain `key_name` in the gateway configuration section and add it to the OpenRouter YAML example
- `v2/hive.yaml.example` — add a commented `governor.gateways` block (this field had no example at all previously) documenting `key_name`, and add `key_name` to the existing `bob:` block
- `v2/docs/agent-configuration.md` — cross-reference `key_name` from the inference methods section, linking back to the full example

Fixes #3622

🤖 Generated with [Claude Code](https://claude.com/claude-code)