### PR TITLE
fix(github): gate self-authored auto-merge sweep on ACMM level

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1380,10 +1380,13 @@ func main() {
 		// SweepSelfAuthoredAutoMerges for the full rationale and the safety
 		// properties preserved (green required checks, head-SHA re-verified
 		// immediately before merge, squash method, all tiers included).
-		// Default ON; `auto_merge.self_authored: false` disables it.
-		if cfg.AutoMerge.SelfAuthoredEnabled() {
-			ghClient.StartSelfAuthoredAutoMergeSweep(ctx, cfg.AutoMerge.MaxMerges)
-		}
+		// Default ON; `auto_merge.self_authored: false` disables it. ALSO
+		// gated on ACMM level (config.SelfMergeMinACMMLevel): l4.md/l5.md
+		// both forbid the App merging its own PRs, so an L4/L5 hive must
+		// never start this loop regardless of the flag above — see
+		// AutoMergeConfig.SelfAuthoredAutoMergeAllowed. StartSelfAuthoredAutoMergeSweep
+		// itself no-ops (with a one-time INFO log) when acmmAllowed is false.
+		ghClient.StartSelfAuthoredAutoMergeSweep(ctx, cfg.AutoMerge.MaxMerges, cfg.AutoMerge.SelfAuthoredAutoMergeAllowed(cfg.ACMMLevel), cfg.ACMMLevel)
 	}
 
 	// Opt-in mint credential: when mint.enabled, build a Minter from the config

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -4567,6 +4567,35 @@ func (a AutoMergeConfig) SelfAuthoredEnabled() bool {
 	return a.SelfAuthored == nil || *a.SelfAuthored
 }
 
+// SelfMergeMinACMMLevel is the lowest ACMM level at which the App is allowed
+// to self-merge its own PRs. examples/acmm/l5.md is explicit that L5 does NOT
+// grant merge authority ("Merge pull requests — no; L5 PRs remain hold-gated
+// for human review"), and examples/acmm/l4.md is even more explicit ("DO NOT
+// merge pull requests — L4 is not an auto-merge level"). examples/acmm/l6.md
+// is the first level whose Responsibilities include "Merge PRs when CI
+// passes". So the gate sits at L6, not L5: an L4 (or L5) hive must never run
+// the self-authored auto-merge sweep, regardless of the auto_merge.self_authored
+// flag below. This was the root cause of ks/hive (acmm_level: 4) wrongly
+// self-merging its own PR — the sweep previously had no ACMM check at all.
+const SelfMergeMinACMMLevel = 6
+
+// SelfAuthoredAutoMergeAllowed reports whether the App-self-merge sweep may
+// run at all for this hive, given its ACMM level. Both conditions must hold:
+// the auto_merge.self_authored flag must be ON (SelfAuthoredEnabled) AND the
+// hive's ACMM level must be at or above SelfMergeMinACMMLevel. A nil/unset
+// ACMM level is treated as NOT high enough (fail closed) — an operator who
+// has not explicitly opted a hive into a high ACMM level never gets
+// self-merge by accident.
+func (a AutoMergeConfig) SelfAuthoredAutoMergeAllowed(acmmLevel *int) bool {
+	if !a.SelfAuthoredEnabled() {
+		return false
+	}
+	if acmmLevel == nil {
+		return false
+	}
+	return *acmmLevel >= SelfMergeMinACMMLevel
+}
+
 // DefaultEscalationThreshold matches escalation.DefaultThreshold; duplicated
 // here (a constant, checked by test) to avoid a config→escalation import.
 const DefaultEscalationThreshold = 3

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -1108,3 +1108,37 @@ func TestEffectiveOTel_LegacyTracingFallback(t *testing.T) {
 		t.Errorf("default service name = %q", got.ServiceNameOrDefault())
 	}
 }
+
+// TestSelfAuthoredAutoMergeAllowed guards the bug fix: the self-authored
+// auto-merge sweep must be OFF at ACMM L4 (examples/acmm/l4.md: "DO NOT merge
+// pull requests — L4 is not an auto-merge level") and at L5 (l5.md: "Merge
+// pull requests — no; L5 PRs remain hold-gated for human review"), and ON
+// only at SelfMergeMinACMMLevel (L6, l6.md: "Merge PRs when CI passes") and
+// above — matching console, which runs at L6 and must be unaffected. Both the
+// auto_merge.self_authored flag AND the ACMM level must independently allow
+// it.
+func TestSelfAuthoredAutoMergeAllowed(t *testing.T) {
+	l4, l5, l6, l7 := 4, 5, 6, 7
+	cases := []struct {
+		name  string
+		cfg   AutoMergeConfig
+		level *int
+		want  bool
+	}{
+		{"nil acmm level fails closed even with flag on", AutoMergeConfig{SelfAuthored: boolPtr(true)}, nil, false},
+		{"nil acmm level fails closed with default flag", AutoMergeConfig{}, nil, false},
+		{"L4 hive (ks/hive bug repro) stays disabled despite default-on flag", AutoMergeConfig{}, &l4, false},
+		{"L4 hive stays disabled with explicit flag on", AutoMergeConfig{SelfAuthored: boolPtr(true)}, &l4, false},
+		{"L5 hive stays disabled: L5 is hold-gated, not auto-merge", AutoMergeConfig{}, &l5, false},
+		{"L6 hive (console) is enabled by default", AutoMergeConfig{}, &l6, true},
+		{"L6 hive with flag explicitly off stays disabled", AutoMergeConfig{SelfAuthored: boolPtr(false)}, &l6, false},
+		{"L7 (above minimum) stays enabled", AutoMergeConfig{}, &l7, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.SelfAuthoredAutoMergeAllowed(tc.level); got != tc.want {
+				t.Errorf("SelfAuthoredAutoMergeAllowed(%v) = %v, want %v", tc.level, got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 const DefaultAutoMergeSweepMaxMerges = 3
@@ -203,8 +204,25 @@ func (c *Client) SweepSelfAuthoredAutoMerges(ctx context.Context, opts AutoMerge
 // DefaultAutoMergeSweepMaxMerges there). Mirrors
 // StartMergeRequestWatcher/StartPRRequestWatcher's own-ticker-goroutine
 // pattern so all three App-identity-dependent watchers share one shape.
-func (c *Client) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges int) {
+//
+// acmmAllowed is the caller-computed
+// config.AutoMergeConfig.SelfAuthoredAutoMergeAllowed(acmmLevel) result (both
+// the auto_merge.self_authored flag AND the hive's ACMM level gate self-merge
+// authority — see config.SelfMergeMinACMMLevel). When false the loop is never
+// started at all: an ACMM L4/L5 hive (l4.md/l5.md both forbid the App
+// merging its own PRs) must not self-merge, matching console's L6 hive which
+// is unaffected and keeps self-merging as before.
+func (c *Client) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges int, acmmAllowed bool, acmmLevel *int) {
 	if c == nil {
+		return
+	}
+	if !acmmAllowed {
+		level := "unset"
+		if acmmLevel != nil {
+			level = fmt.Sprintf("%d", *acmmLevel)
+		}
+		c.info("self-authored auto-merge sweep disabled: acmm_level below minimum (or auto_merge.self_authored is off)",
+			"acmm_level", level, "min_acmm_level", config.SelfMergeMinACMMLevel)
 		return
 	}
 	go func() {

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 const testHiveAppBotLogin = "kubestellar-hive[bot]"
@@ -877,6 +878,67 @@ func TestSweepSelfAuthoredAutoMergesNilClient(t *testing.T) {
 	if _, err := nilClient.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != ErrNoGitHubClient {
 		t.Fatalf("nil sweep error = %v, want ErrNoGitHubClient", err)
 	}
+}
+
+// TestStartSelfAuthoredAutoMergeSweepDisabledBelowMinACMMLevel reproduces the
+// ks/hive bug: an ACMM L4 hive (acmm_level: 4) must never start the
+// self-authored auto-merge loop, even though the auto_merge.self_authored
+// config flag defaults to ON. l4.md is explicit: "DO NOT merge pull requests
+// — L4 is not an auto-merge level." The starter must no-op (no goroutine, no
+// HTTP calls) and log once explaining why.
+func TestStartSelfAuthoredAutoMergeSweepDisabledBelowMinACMMLevel(t *testing.T) {
+	var logs bytes.Buffer
+	var merged []int
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 1, author: testHiveAppBotLogin, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := NewClient("token", "acme", []string{"widget"}, slog.New(slog.NewTextHandler(&logs, nil)), api.URL)
+	c.SetAppBotLogin(testHiveAppBotLogin)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l4 := 4
+	c.StartSelfAuthoredAutoMergeSweep(ctx, 0, false, &l4)
+
+	if !strings.Contains(logs.String(), "self-authored auto-merge sweep disabled") {
+		t.Fatalf("logs = %q, want disabled-sweep INFO log", logs.String())
+	}
+	if len(merged) != 0 {
+		t.Fatalf("merged = %v, want no merges at ACMM L4 (below config.SelfMergeMinACMMLevel)", merged)
+	}
+}
+
+// TestStartSelfAuthoredAutoMergeSweepEnabledAtMinACMMLevel is the positive
+// case: at config.SelfMergeMinACMMLevel (L6, matching console) the loop
+// starts and logs its normal startup message, not the disabled message.
+func TestStartSelfAuthoredAutoMergeSweepEnabledAtMinACMMLevel(t *testing.T) {
+	var logs bytes.Buffer
+	c := NewClient("token", "acme", []string{"widget"}, slog.New(slog.NewTextHandler(&logs, nil)), "http://127.0.0.1:0")
+	c.SetAppBotLogin(testHiveAppBotLogin)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l6 := config.SelfMergeMinACMMLevel
+	c.StartSelfAuthoredAutoMergeSweep(ctx, 0, true, &l6)
+	cancel()
+
+	if strings.Contains(logs.String(), "self-authored auto-merge sweep disabled") {
+		t.Fatalf("logs = %q, want no disabled-sweep log at min ACMM level", logs.String())
+	}
+	if !strings.Contains(logs.String(), "self-authored automerge sweep started") {
+		t.Fatalf("logs = %q, want normal startup log at min ACMM level", logs.String())
+	}
+}
+
+// TestStartSelfAuthoredAutoMergeSweepNilClient guards the nil-client no-op
+// path still holds with the new acmmAllowed/acmmLevel parameters.
+func TestStartSelfAuthoredAutoMergeSweepNilClient(t *testing.T) {
+	var nilClient *Client
+	l6 := config.SelfMergeMinACMMLevel
+	nilClient.StartSelfAuthoredAutoMergeSweep(context.Background(), 0, true, &l6)
 }
 
 func newAutoMergeSweepClient(apiURL string) *Client {


### PR DESCRIPTION
## Bug

The self-authored auto-merge sweep (`SweepSelfAuthoredAutoMerges` / `StartSelfAuthoredAutoMergeSweep` in `v2/pkg/github/automerge_sweep.go`) merges the App's own open PRs purely based on the `auto_merge.self_authored` config flag (`SelfAuthoredEnabled()`, default ON). It had **no ACMM-level check at all**.

`examples/acmm/l4.md` states verbatim:

> **DO NOT merge pull requests** — L4 is not an auto-merge level.

Because the sweep ignored `acmm_level`, an L4 hive (ks/hive, `acmm_level: 4`) wrongly self-merged its own PR (#3601).

## Fix

- Added `config.SelfMergeMinACMMLevel = 6` in `v2/pkg/config/config.go`, following the same ACMM-gating pattern already used by `planFromLabelMinACMM`.
- Threshold justification (read `examples/acmm/l4.md`, `l5.md`, `l6.md`):
  - L4 (`l4.md`): "DO NOT merge pull requests — L4 is not an auto-merge level."
  - L5 (`l5.md`): "Merge pull requests — no; L5 PRs remain hold-gated for human review." L5 grants broader autonomy (create PRs, choose fix strategies) but explicitly *not* merge authority.
  - L6 (`l6.md`): the first level whose Responsibilities include "Merge PRs when CI passes."
  - So the gate is set at **L6**, not L5.
- Added `AutoMergeConfig.SelfAuthoredAutoMergeAllowed(acmmLevel *int) bool`, which requires **both** the existing `auto_merge.self_authored` flag to be ON **and** `acmmLevel != nil && *acmmLevel >= SelfMergeMinACMMLevel`. A nil/unset ACMM level fails closed (sweep off).
- `StartSelfAuthoredAutoMergeSweep` now takes `acmmAllowed bool` and `acmmLevel *int`. When `acmmAllowed` is false it never starts the loop at all, and logs a one-time INFO explaining why (not spammy per-tick): `self-authored auto-merge sweep disabled: acmm_level below minimum (or auto_merge.self_authored is off)`.
- `v2/cmd/hive/main.go` now always calls `StartSelfAuthoredAutoMergeSweep`, passing `cfg.AutoMerge.SelfAuthoredAutoMergeAllowed(cfg.ACMMLevel)` and `cfg.ACMMLevel`, and lets the starter decide — matching how `PlanFromLabelEnabled` gates on ACMM level at the config layer.
- The existing `auto_merge.self_authored` flag is preserved as an **additional**, independent off-switch — not removed.

## Console (L6) impact

None. Console runs ACMM L6, at or above `SelfMergeMinACMMLevel`, so `SelfAuthoredAutoMergeAllowed` returns true (assuming the flag stays default-on) and self-merge behavior is unchanged.

## Tests

- `v2/pkg/config/config_test.go`: `TestSelfAuthoredAutoMergeAllowed` — table test across L4, L5, L6, L7, and nil ACMM level, with the flag on/off/default.
- `v2/pkg/github/automerge_sweep_test.go`:
  - `TestStartSelfAuthoredAutoMergeSweepDisabledBelowMinACMMLevel` — reproduces the ks/hive bug: starter no-ops and logs at L4, zero merge calls even against a green, mergeable, App-authored PR.
  - `TestStartSelfAuthoredAutoMergeSweepEnabledAtMinACMMLevel` — starter proceeds normally at L6 (the threshold).
  - `TestStartSelfAuthoredAutoMergeSweepNilClient` — nil-client safety preserved with the new signature.

Scope: v4 only (this branch's `automerge_sweep.go`/`config.go`/`main.go` do not exist on v2 in this form — no v2 changes made).