### PR TITLE
fix(hub): stop available-slot placeholders reverting to public on heartbeat

### DIFF
--- a/v2/pkg/hub/heartbeat_visibility_preserve_test.go
+++ b/v2/pkg/hub/heartbeat_visibility_preserve_test.go
@@ -1,0 +1,137 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHeartbeatPreservesHubSetPrivate verifies that a hive whose operator set it
+// PRIVATE in the SaaS store keeps that setting even though its spoke keeps
+// reporting is_public: true on every heartbeat. This is the available-placeholder
+// revert bug: pre-provisioned "Available slot" spokes report their provisioning
+// default (public) forever, and the hub used to let that report overwrite the
+// operator's private choice on the very next beat — then, because the registry
+// value had been made to match the spoke, never sent the correction back.
+//
+// The fix anchors the registry entry's IsPublic to the SaaS store (the operator's
+// source of truth) so the registry the dashboard reads stays private AND the hub
+// pushes is_public=false back to the spoke via the heartbeat response.
+func TestHeartbeatPreservesHubSetPrivate(t *testing.T) {
+	dir := t.TempDir()
+	origHives, origRegistry := saasHivesDir, registryPath
+	saasHivesDir = filepath.Join(dir, "hives")
+	registryPath = filepath.Join(dir, "hub-registry.json")
+	t.Cleanup(func() { saasHivesDir, registryPath = origHives, origRegistry })
+
+	const hiveID = "hosted-available-oke-260812-test-available-ok-1234"
+
+	// Operator has set this available placeholder PRIVATE (is_public=false) in
+	// the SaaS store — exactly what handleToggleVisibility persists.
+	if err := saveSaaSHive(&SaaSHive{
+		ID:       hiveID,
+		Owner:    "clubanderson",
+		Status:   statusAvailable,
+		IsPublic: false,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.hubSecret = ""
+
+	// The placeholder spoke reports its provisioning default: is_public=true.
+	body := `{"hive_id":"` + hiveID + `","org":"available-oke-260812-test","is_public":true}`
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	// (a) The registry the dashboard reads must stay PRIVATE — the spoke's
+	// public self-report must not revert the operator's setting.
+	var gotEntry *RegistryEntry
+	srv.mu.RLock()
+	for i := range srv.registry.Hives {
+		if srv.registry.Hives[i].ID == hiveID {
+			gotEntry = &srv.registry.Hives[i]
+			break
+		}
+	}
+	srv.mu.RUnlock()
+	if gotEntry == nil {
+		t.Fatalf("hive %s missing from registry after heartbeat", hiveID)
+	}
+	if gotEntry.IsPublic {
+		t.Errorf("registry IsPublic = true; operator-set PRIVATE was reverted to public by the spoke report")
+	}
+
+	// (b) The hub must push the authoritative is_public=false back to the spoke
+	// in the heartbeat response so the spoke re-syncs (entry.IsPublic !=
+	// payload.IsPublic). Before the fix, entry.IsPublic had been made equal to
+	// the spoke's true, so no correction was sent.
+	var resp HeartbeatResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid response JSON: %v", err)
+	}
+	if resp.IsPublic == nil {
+		t.Fatalf("response did not push authoritative visibility to the spoke")
+	}
+	if *resp.IsPublic {
+		t.Errorf("response IsPublic = true; want false (the hub's authoritative value)")
+	}
+}
+
+// TestHeartbeatPreservesHubSetPrivateOnFirstBeat covers the first-heartbeat path
+// (no pre-existing registry row): a brand-new available placeholder that has
+// never been in the registry, set private in the SaaS store, whose first beat
+// reports public, must still land in the registry as private.
+func TestHeartbeatPreservesHubSetPrivateOnFirstBeat(t *testing.T) {
+	dir := t.TempDir()
+	origHives, origRegistry := saasHivesDir, registryPath
+	saasHivesDir = filepath.Join(dir, "hives")
+	registryPath = filepath.Join(dir, "hub-registry.json")
+	t.Cleanup(func() { saasHivesDir, registryPath = origHives, origRegistry })
+
+	const hiveID = "hosted-available-oke-260812-fresh-available-ok-5678"
+	if err := saveSaaSHive(&SaaSHive{
+		ID:       hiveID,
+		Owner:    "clubanderson",
+		Status:   statusAvailable,
+		IsPublic: false,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.hubSecret = ""
+
+	body := `{"hive_id":"` + hiveID + `","org":"available-oke-260812-fresh","is_public":true}`
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	for i := range srv.registry.Hives {
+		if srv.registry.Hives[i].ID == hiveID {
+			if srv.registry.Hives[i].IsPublic {
+				t.Errorf("first-beat registry IsPublic = true; operator-set PRIVATE not honored on initial registration")
+			}
+			return
+		}
+	}
+	t.Fatalf("hive %s missing from registry after first heartbeat", hiveID)
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1457,9 +1457,17 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// from a CLAIMED one that still carries the "hosted-available-" ID — the ID
 	// prefix alone over-counts available hives because it never changes on claim.
 	clusterID := ""
+	// saasVisibility carries the SaaS store's authoritative is_public for this
+	// hive when a SaaSHive record exists. handleToggleVisibility persists the
+	// operator's choice there (meta.json) as the source of truth, so it — not the
+	// spoke's self-report — is what entry.IsPublic must reflect. nil means "no
+	// SaaS record" (a bare/BYO spoke), in which case the spoke's own report stands.
+	var saasVisibility *bool
 	if sh := loadSaaSHive(payload.HiveID); sh != nil {
 		clusterID = sh.ClusterID
 		entry.ProvStatus = sh.Status
+		isPub := sh.IsPublic
+		saasVisibility = &isPub
 		// The SaaS store is authoritative for the operator-editable display name
 		// (handleRenameHive persists it here), so overlay it onto the registry
 		// entry the dashboard renders. The spoke never reports this, so a blank
@@ -1473,6 +1481,18 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// self-hosted/BYO hive keeps Namespace empty rather than being wrongly
 		// labelled with a namespace it does not run in.
 		entry.Namespace = hostedNamespaceForHive(sh)
+	}
+	// The SaaS store's is_public is authoritative over the spoke's self-report.
+	// Apply it here so BOTH the update path (existing registry entry) and the
+	// first-heartbeat path (new entry, no previous registry row to preserve
+	// from) reflect the operator's choice rather than the spoke's provisioning
+	// default. Without this, an available placeholder — which keeps reporting
+	// is_public: true every heartbeat — reverted the operator's PRIVATE setting
+	// back to public on the next beat, and the authoritative-visibility push to
+	// the spoke (gated on entry.IsPublic != payload.IsPublic below) never fired
+	// because the two had been made equal.
+	if saasVisibility != nil {
+		entry.IsPublic = *saasVisibility
 	}
 	if clusterID == "" && payload.ClusterID != "" {
 		clusterID = sanitizeHeartbeatField(payload.ClusterID)
@@ -1530,9 +1550,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			if entry.SnapshotURL == "" {
 				entry.SnapshotURL = h.SnapshotURL
 			}
-			// Preserve hub-side visibility: if the hub set this hive
-			// to public, don't let the spoke's heartbeat revert it.
-			if h.IsPublic && !payload.IsPublic {
+			// Preserve hub-side visibility. When the hive has a SaaS record its
+			// is_public was already applied above (authoritative in BOTH
+			// directions). This fallback covers a bare/BYO spoke with no SaaS
+			// record: keep a hub-set PUBLIC from being reverted by a spoke that
+			// reports private.
+			if saasVisibility == nil && h.IsPublic && !payload.IsPublic {
 				entry.IsPublic = h.IsPublic
 			}
 			// Carry the last known fleet-stat counts forward when this


### PR DESCRIPTION
## Problem

Setting a pre-provisioned **Available slot** placeholder spoke (e.g. `available-oke-260812-0nzc` on `hive-oke`) to **private** does not stick: it reverts to **public** on its own within a heartbeat interval.

## Root cause

`handleHeartbeat` (`v2/pkg/hub/server.go`) derives the registry entry's `IsPublic` directly from the spoke's self-reported `payload.IsPublic`. Available placeholders keep reporting their provisioning default `is_public: true` on **every** beat.

The only preservation guard was **one-directional**:

```go
// old
if h.IsPublic && !payload.IsPublic {   // only protects hub-set PUBLIC
    entry.IsPublic = h.IsPublic
}
```

So a hub-set **PRIVATE** was left unprotected — the spoke's `true` overwrote it every beat. And because `entry.IsPublic` was thereby made equal to `payload.IsPublic`, the authoritative-visibility push in the heartbeat **response** (gated on `entry.IsPublic != payload.IsPublic`) never fired, so the spoke was never corrected back either. The two writers diverged and self-perpetuated.

## Live evidence (hive-oke, `hive-hub` pod)

All five `available-oke-260812-*` placeholders:
- `/data/saas/hives/<id>/meta.json` → `"is_public": false`  ← operator's setting persisted correctly
- `/data/hub-registry.json` → `"isPublic": true`  ← reverted by heartbeat; this is what the dashboard reads

## Fix

The SaaS store (`meta.json`), written by `handleToggleVisibility`, is the operator's source of truth. Anchor the registry entry's `IsPublic` to it whenever a `SaaSHive` record exists — authoritative in **both** directions, on both the update path and the first-heartbeat path. The registry the dashboard reads now stays private, and the response push (`resp.IsPublic`) re-syncs the spoke. A bare/BYO spoke with no SaaS record keeps the prior one-directional fallback.

## Tests

`v2/pkg/hub/heartbeat_visibility_preserve_test.go`:
- `TestHeartbeatPreservesHubSetPrivate` — SaaS-private + spoke-reports-public ⇒ registry stays private **and** response pushes `is_public=false`.
- `TestHeartbeatPreservesHubSetPrivateOnFirstBeat` — same on initial registration (no prior registry row).

Positive control verified: both tests **fail** against the unfixed handler with exactly the observed symptom, and pass with the fix. Full `pkg/hub` suite passes.