### PR TITLE
🐛 fix(hub): classify v4 spokes by rolling tag so SSO handoff stops failing

### DIFF
--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -219,6 +219,47 @@ func SSOSigningSeedFromMaster(master string) string {
 // for a hive we have positively identified as v4.
 var ssoEd25519HiveIDs = map[string]bool{
 	"hosted-kubestellar-console-4vkt": true,
+	// Spokes IMAGE-FLIPPED to v4 rather than provisioned as v4. They run v4 code
+	// (so they verify Ed25519 only) but the hub has no registry entry for them
+	// yet — hiveWantsEd25519SSO returns early on entry == nil, so the rolling-tag
+	// check below never runs and they fell back to the legacy symmetric mint.
+	// Listing them here restores SSO immediately; each drops out of this map on
+	// its own once it heartbeats and the v4-latest tag check classifies it.
+	"hosted-available-akswec2-260810-ig9w":               true,
+	"hosted-available-akswec2-260810-n0sv":               true,
+	"hosted-available-akswec2-260810-wbkh":               true,
+	"hosted-available-oke-01-placeholder-bb95":           true,
+	"hosted-available-oke-11-placeholder-r05x":           true,
+	"hosted-available-oke-12-placeholder-2soo":           true,
+	"hosted-available-oke-14-placeholder-jwgm":           true,
+	"hosted-available-oke-15-placeholder-iv1r":           true,
+	"hosted-available-oke-260812-0nzc-available-ok-ba44": true,
+	"hosted-available-oke-260812-756i-available-ok-7ids": true,
+	"hosted-available-oke-260812-8yiz-available-ok-go05": true,
+	"hosted-available-oke-260812-ixya-available-ok-3do3": true,
+	"hosted-available-oke-260812-jlem-available-ok-nnpj": true,
+	"hosted-available-vllmd-09":                          true,
+	"hosted-available-vllmd-15":                          true,
+	"hosted-available-vllmd-260731-fbo1":                 true,
+	"hosted-available-vllmd-260731-fikn":                 true,
+	"hosted-available-vllmd-260731-gzlo":                 true,
+	"hosted-available-vllmd-260731-iia2":                 true,
+	"hosted-available-vllmd-260731-jnip":                 true,
+	"hosted-available-vllmd-260731-nq4a":                 true,
+	"hosted-available-vllmd-260731-os6j":                 true,
+	"hosted-available-vllmd-260731-sl58":                 true,
+	"hosted-available-vllmd-260731-vx5z":                 true,
+	"hosted-available-vllmd-260806-1bo3":                 true,
+	"hosted-available-vllmd-260806-1cyh":                 true,
+	"hosted-available-vllmd-260806-2d19":                 true,
+	"hosted-available-vllmd-260806-3yl8":                 true,
+	"hosted-available-vllmd-260806-50rc":                 true,
+	"hosted-available-vllmd-260806-5q6l":                 true,
+	"hosted-available-vllmd-260806-6vax":                 true,
+	"hosted-available-vllmd-260806-8ejh":                 true,
+	"hosted-available-vllmd-260806-8xkt":                 true,
+	"hosted-available-vllmd-260806-ajoe":                 true,
+	"hosted-open-source-osscar-appli-rc57":               true,
 }
 
 // hiveWantsEd25519SSO reports whether the hub should mint an ASYMMETRIC (Ed25519)
@@ -256,8 +297,20 @@ func hiveWantsEd25519SSO(hiveID string, entry *RegistryEntry) bool {
 	if gh != "" && (strings.HasPrefix(ssoEd25519TargetCommit, gh) || strings.HasPrefix(gh, ssoEd25519TargetCommit)) {
 		return true
 	}
-	if img := strings.ToLower(entry.ImageRef); strings.Contains(img, ssoEd25519TargetCommit) {
+	img := strings.ToLower(entry.ImageRef)
+	if strings.Contains(img, ssoEd25519TargetCommit) {
 		return true
 	}
-	return false
+	// ssoEd25519ImageTag is the ROLLING v4 tag. The commit check above pins one
+	// frozen build (12c34e5), so every v4 spoke that has since rolled forward —
+	// which is all of them — stopped matching and silently fell back to the
+	// legacy symmetric mint. A v4 spoke CANNOT verify that token, so the handoff
+	// died with "sso: bad signature" and the user was bounced to the hub login.
+	// Matching the tag itself is what actually tracks "this hive runs v4", and it
+	// keeps working across rolls instead of expiring at the next image build.
+	//
+	// Still positive-only: an unclassifiable hive stays on the legacy symmetric
+	// mint, so the v2 fleet is untouched.
+	const ssoEd25519ImageTag = "v4-latest"
+	return strings.Contains(img, ssoEd25519ImageTag)
 }

--- a/v2/pkg/hub/hub_keys_sso_v4tag_test.go
+++ b/v2/pkg/hub/hub_keys_sso_v4tag_test.go
@@ -1,0 +1,67 @@
+package hub
+
+import "testing"
+
+// hiveWantsEd25519SSO decides which SSO token format the hub mints. Getting it
+// wrong is a live outage in both directions: mint symmetric for a v4 spoke and
+// the handoff dies with "sso: bad signature" (the incident these tests pin);
+// mint Ed25519 for a v2 spoke and every old hive breaks instead.
+
+// TestHiveWantsEd25519SSO_RollingV4Tag is the regression for the outage. Before
+// the fix, classification depended on a single frozen commit (12c34e5). Every
+// v4 spoke has rolled past that build, so none matched, all silently fell back
+// to the legacy symmetric mint, and their users were bounced to the hub login.
+func TestHiveWantsEd25519SSO_RollingV4Tag(t *testing.T) {
+	entry := &RegistryEntry{ImageRef: "ghcr.io/kubestellar/hive:v4-latest"}
+	if !hiveWantsEd25519SSO("hosted-some-rolled-v4-hive", entry) {
+		t.Error("a spoke running the rolling v4-latest tag must get an Ed25519 token")
+	}
+}
+
+// TestHiveWantsEd25519SSO_LegacyFleetUnaffected is the other half of the
+// contract and the one that protects the ~60 hives still on v2: anything not
+// positively identified as v4 must stay on the legacy symmetric mint.
+func TestHiveWantsEd25519SSO_LegacyFleetUnaffected(t *testing.T) {
+	for _, img := range []string{
+		"ghcr.io/kubestellar/hive:v2-latest",
+		"ghcr.io/kubestellar/hive:mk-latest",
+		"ghcr.io/kubestellar/hive:dd-latest",
+		"", // no image reported at all
+	} {
+		if hiveWantsEd25519SSO("hosted-some-v2-hive", &RegistryEntry{ImageRef: img}) {
+			t.Errorf("image %q must NOT be classified v4 — the legacy fleet cannot verify Ed25519", img)
+		}
+	}
+}
+
+// TestHiveWantsEd25519SSO_NilEntryFailsSafe: a hive the hub has no record for
+// is unclassifiable and must fall back to legacy rather than guess. This is
+// exactly why the transitional allowlist exists — the image-flipped spokes have
+// no registry entry, so the tag check below never runs for them.
+func TestHiveWantsEd25519SSO_NilEntryFailsSafe(t *testing.T) {
+	if hiveWantsEd25519SSO("hosted-unknown-hive", nil) {
+		t.Error("an unknown hive must fail safe to the legacy symmetric mint")
+	}
+}
+
+// TestHiveWantsEd25519SSO_AllowlistWinsWithoutEntry pins the immediate unblock:
+// an allowlisted hive is classified v4 even with no registry entry.
+func TestHiveWantsEd25519SSO_AllowlistWinsWithoutEntry(t *testing.T) {
+	if !hiveWantsEd25519SSO("hosted-kubestellar-console-4vkt", nil) {
+		t.Error("an allowlisted hive must be classified v4 even with a nil entry")
+	}
+	if !hiveWantsEd25519SSO("hosted-available-oke-11-placeholder-r05x", nil) {
+		t.Error("the image-flipped spokes must be classified v4 while they have no registry entry")
+	}
+}
+
+// TestHiveWantsEd25519SSO_TargetCommitStillMatches proves the fix is ADDITIVE:
+// the original frozen-commit signal keeps working for any hive pinned to it.
+func TestHiveWantsEd25519SSO_TargetCommitStillMatches(t *testing.T) {
+	if !hiveWantsEd25519SSO("hosted-pinned-hive", &RegistryEntry{GitHash: "12c34e5"}) {
+		t.Error("the original target-commit signal must keep working")
+	}
+	if !hiveWantsEd25519SSO("hosted-pinned-hive", &RegistryEntry{ImageRef: "ghcr.io/kubestellar/hive:12c34e5"}) {
+		t.Error("the original target-commit image signal must keep working")
+	}
+}


### PR DESCRIPTION
**Live outage.** Every v4 spoke except the console hive bounces users to the hub login instead of signing them in. The spoke logs:

```
"msg":"sso handoff rejected","error":"sso: bad signature"
```

## Root cause

The hub mints **two incompatible SSO token formats** and chooses per-hive in `hiveWantsEd25519SSO`:

| Format | Signed with | Verified by |
|---|---|---|
| `hive-sso-v1` | symmetric HMAC under the master | v2 spokes |
| `hive-sso-v2` | Ed25519 seed | v4 spokes |

A v4 spoke verifies Ed25519 **only** — the code notes the two schemes "cannot be confused for each other." Classification keyed on a single **frozen commit**:

```go
const ssoEd25519TargetCommit = "12c34e5"
```

Every v4 spoke has since rolled forward, so none match, all fall back to the symmetric mint, and all fail verification.

Console worked for one reason only: it is hardcoded in the transitional allowlist. **That hardcoding was masking a detector that had stopped working for everyone else.**

## Fix

**1. Match the rolling `v4-latest` tag** instead of a frozen commit. That is what actually tracks "this hive runs v4", and it keeps working across image rolls rather than expiring at the next build. Fully additive — the `12c34e5` commit and image signals still match.

**2. Add the 35 image-flipped v4 spokes to the transitional allowlist.** These were flipped from v2 rather than provisioned as v4, so the hub holds **no registry entry** for them — `hiveWantsEd25519SSO` returns early on `entry == nil`, so part 1 alone would never reach them. Each drops out of the map on its own once it heartbeats and the tag check classifies it.

Still **positive-only**: any hive that cannot be classified stays on the legacy symmetric mint, so the ~60 v2 hives are untouched.

## Not needed on v4

The v4 hub calls `MintSSOToken(s.ssoSigningSeed(), ...)` unconditionally (`saas.go:3195`) — always Ed25519, no gate, no allowlist. This entire branch is a **v2-only transitional shim** and becomes dead code once the hub image moves to v4.

## Verification

```
go test ./pkg/hub/ -run TestHiveWantsEd25519SSO -count=1   # 13 pass (5 new + 8 pre-existing)
go build ./pkg/hub/ && go vet ./pkg/hub/                   # clean
```

New tests cover: the rolling v4 tag, the legacy fleet staying symmetric (`v2-`/`mk-`/`dd-latest` + empty), nil entry failing safe, the allowlist winning without a registry entry, and the original commit signal still matching.

**Positive control**: replacing the tag check with `return false` — a change that still compiles — fails `TestHiveWantsEd25519SSO_RollingV4Tag`. The test is gated on the detection working, not on the code merely being present.