### PR TITLE
🐛 fix(dashboard): reject gist URLs for keep-linked agent imports

### DIFF
--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -201,6 +201,18 @@ const (
 	importHTTPTimeoutS  = 10
 )
 
+var importAllowedHosts = map[string]struct{}{
+	"github.com":                 {},
+	"raw.githubusercontent.com":  {},
+	"gist.github.com":            {},
+	"gist.githubusercontent.com": {},
+}
+
+const (
+	importURLFormsOneShot = "https://github.com/<owner>/<repo>/blob/<ref>/<path>, https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>, https://gist.github.com/<user>/<gist-id>[/raw[/<file>]], or https://gist.githubusercontent.com/<user>/<gist-id>/raw/<path>"
+	importURLFormsLinked  = "https://github.com/<owner>/<repo>/blob/<ref>/<path> or https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>"
+)
+
 // agentConfigFromDefinition maps a parsed AgentDefinition to an AgentConfig with
 // the import defaults applied (backend copilot, immediate restart, worker bead
 // role, enabled). It is the single mapping used by both the whole-agent import
@@ -259,6 +271,13 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 		}
 		if len(body.URL) > importMaxURLLen {
 			jsonError(w, fmt.Sprintf("url must be at most %d characters", importMaxURLLen), http.StatusBadRequest)
+			return
+		}
+		// Reject a gist URL for a KEEP-LINKED import before anything else: a gist
+		// has no stable raw URL across revisions, so a linked import would silently
+		// pin to a snapshot that never updates. One-shot gist imports stay allowed.
+		if err := s.validateImportURL(body.URL, body.KeepLinked); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		// Validate before fetching, then re-validate every redirect hop.
@@ -492,6 +511,68 @@ var githubBlobURLPattern = regexp.MustCompile(`^/([^/]+)/([^/]+)/blob/([^/]+)/(.
 //	https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path...>
 var githubRawURLPattern = regexp.MustCompile(`^/([^/]+)/([^/]+)/([^/]+)/(.+)$`)
 
+func (s *Server) validateImportURL(rawURL string, keepLinked bool) error {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("import URL must be an https URL; supported forms: %s", importURLFormsOneShot)
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if _, ok := importAllowedHosts[host]; !ok {
+		return fmt.Errorf("import URL host %q is not supported; supported forms: %s", host, importURLFormsOneShot)
+	}
+
+	if isGistImportHost(host) {
+		if keepLinked {
+			return fmt.Errorf("keep linked imports do not support gist URLs; use a GitHub repository file URL (%s), or uncheck Keep linked for a one-shot gist import", importURLFormsLinked)
+		}
+		if strings.Trim(u.Path, "/") == "" {
+			return fmt.Errorf("gist import URL must include a gist path; supported forms: %s", importURLFormsOneShot)
+		}
+		return nil
+	}
+
+	if host == "raw.githubusercontent.com" {
+		if githubRawURLPattern.FindStringSubmatch(u.Path) == nil {
+			return fmt.Errorf("import URL %q is not a supported raw GitHub file URL; supported forms: %s", rawURL, importURLFormsOneShot)
+		}
+		return nil
+	}
+
+	if host == "github.com" && githubBlobURLPattern.FindStringSubmatch(u.Path) != nil {
+		return nil
+	}
+
+	forms := importURLFormsOneShot
+	if keepLinked {
+		forms = importURLFormsLinked
+	}
+	return fmt.Errorf("import URL %q is not a supported GitHub file URL; supported forms: %s", rawURL, forms)
+}
+
+func isGistImportHost(host string) bool {
+	return host == "gist.github.com" || host == "gist.githubusercontent.com"
+}
+
+func importFetchURL(rawURL string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
+		return rawURL
+	}
+	m := githubBlobURLPattern.FindStringSubmatch(u.Path)
+	if m == nil {
+		return rawURL
+	}
+	raw := url.URL{
+		Scheme:   "https",
+		Host:     "raw.githubusercontent.com",
+		Path:     "/" + strings.Join([]string{m[1], m[2], m[3], m[4]}, "/"),
+		RawQuery: u.RawQuery,
+		Fragment: u.Fragment,
+	}
+	return raw.String()
+}
+
 // definitionSourceFromURL parses a GitHub blob or raw file URL into a
 // DefinitionSourceConfig (owner/repo/path/ref). It is used when an operator
 // imports an agent with "keep linked" checked, so the pasted human-facing URL
@@ -509,7 +590,7 @@ func (s *Server) definitionSourceFromURL(rawURL string) (*config.DefinitionSourc
 		m = githubBlobURLPattern.FindStringSubmatch(u.Path)
 	}
 	if m == nil {
-		return nil, fmt.Errorf("URL %q is not a recognized GitHub file URL (expected .../<owner>/<repo>/blob/<ref>/<path> or a raw.githubusercontent.com file URL)", rawURL)
+		return nil, fmt.Errorf("URL %q is not a recognized GitHub file URL (expected a GitHub blob URL .../<owner>/<repo>/blob/<ref>/<path> or https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>)", rawURL)
 	}
 	return &config.DefinitionSourceConfig{
 		Type:  "github",

--- a/v2/pkg/dashboard/definition_source_test.go
+++ b/v2/pkg/dashboard/definition_source_test.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
-// enableDefinitionAllowlist puts a slug on the seed-only GitHub allowlist so the
-// keep-linked / prompt-source paths are permitted for it in tests.
 func enableDefinitionAllowlist(deps *Dependencies, slugs ...string) {
 	deps.Config.Variables.Security.AllowGitHubPrompt = true
 	deps.Config.Variables.Security.GitHubPromptAllowlist = slugs
@@ -56,6 +55,110 @@ func TestDefinitionSourceFromURL(t *testing.T) {
 			}
 			if ds.URL != tc.url {
 				t.Errorf("URL not round-tripped: %q", ds.URL)
+			}
+		})
+	}
+}
+
+func TestAgentImportURLPolicy(t *testing.T) {
+	defSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			name = "imported-url-policy-agent"
+		}
+		fmt.Fprintf(w, "apiVersion: hive.kubestellar.io/v1\nkind: %s\nmetadata:\n  name: %s\nspec:\n  backend: claude\n", exportKind, name)
+	}))
+	defer defSrv.Close()
+	routeImportFetchesToServer(t, defSrv)
+
+	cases := []struct {
+		name          string
+		importURL     string
+		keepLinked    bool
+		wantStatus    int
+		wantErr       string
+		wantLinked    bool
+		wantAgentName string
+	}{
+		{
+			name:       "gist keep-linked rejected clearly",
+			importURL:  "https://gist.github.com/someone/abcdef/raw/agent.yaml?name=gist-linked",
+			keepLinked: true,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "keep linked imports do not support gist URLs",
+		},
+		{
+			name:          "gist one-shot accepted",
+			importURL:     "https://gist.github.com/someone/abcdef/raw/agent.yaml?name=gist-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "gist-one-shot",
+		},
+		{
+			name:          "github blob one-shot accepted",
+			importURL:     "https://github.com/kubestellar/hive/blob/main/agents/blob-plain.yaml?name=blob-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "blob-one-shot",
+		},
+		{
+			name:          "github blob keep-linked accepted",
+			importURL:     "https://github.com/kubestellar/hive/blob/main/agents/blob-linked.yaml?name=blob-linked",
+			keepLinked:    true,
+			wantStatus:    http.StatusOK,
+			wantLinked:    true,
+			wantAgentName: "blob-linked",
+		},
+		{
+			name:          "raw github one-shot accepted",
+			importURL:     "https://raw.githubusercontent.com/kubestellar/hive/main/agents/raw-plain.yaml?name=raw-one-shot",
+			wantStatus:    http.StatusOK,
+			wantAgentName: "raw-one-shot",
+		},
+		{
+			name:          "raw github keep-linked accepted",
+			importURL:     "https://raw.githubusercontent.com/kubestellar/hive/main/agents/raw-linked.yaml?name=raw-linked",
+			keepLinked:    true,
+			wantStatus:    http.StatusOK,
+			wantLinked:    true,
+			wantAgentName: "raw-linked",
+		},
+		{
+			name:       "disallowed host rejected",
+			importURL:  "https://example.com/kubestellar/hive/blob/main/agent.yaml?name=bad-host",
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "example.com",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, deps := apiServer(t)
+			deps.Config.Data.AgentsDir = t.TempDir()
+			enableDefinitionAllowlist(deps, "kubestellar/hive")
+
+			rec := doPost(s, "/api/agents/import", map[string]interface{}{
+				"source":     "url",
+				"url":        tc.importURL,
+				"keepLinked": tc.keepLinked,
+			})
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+			if tc.wantErr != "" {
+				if !strings.Contains(rec.Body.String(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %s", tc.wantErr, rec.Body.String())
+				}
+				return
+			}
+
+			agent, ok := deps.Config.Agents[tc.wantAgentName]
+			if !ok {
+				t.Fatalf("expected imported agent %q", tc.wantAgentName)
+			}
+			if tc.wantLinked && agent.DefinitionSource == nil {
+				t.Fatal("expected keep-linked import to set definition_source")
+			}
+			if !tc.wantLinked && agent.DefinitionSource != nil {
+				t.Fatalf("expected one-shot import to leave definition_source unset, got %+v", agent.DefinitionSource)
 			}
 		})
 	}

--- a/v2/pkg/dashboard/import_gist_keeplinked_test.go
+++ b/v2/pkg/dashboard/import_gist_keeplinked_test.go
@@ -1,0 +1,52 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// A gist has no stable raw URL across revisions, so a KEEP-LINKED import would
+// silently pin to a snapshot that never updates again — the user believes the
+// agent tracks the gist, and it does not. One-shot gist imports are fine and
+// must keep working, so the guard has to reject exactly one combination.
+
+// TestValidateImportURL_GistRejectedWhenKeepLinked is the regression: a gist URL
+// with keepLinked=true must be refused, with a message that points at the fix.
+func TestValidateImportURL_GistRejectedWhenKeepLinked(t *testing.T) {
+	s := &Server{}
+	err := s.validateImportURL("https://gist.github.com/someone/abc123", true)
+	if err == nil {
+		t.Fatal("a keep-linked gist import must be rejected — it would pin to a snapshot forever")
+	}
+	if !strings.Contains(err.Error(), "gist") {
+		t.Errorf("error should name gists so the user knows what to change, got: %v", err)
+	}
+}
+
+// TestValidateImportURL_GistAllowedOneShot is the positive control. Without it,
+// a guard that rejected every gist would satisfy the test above while breaking
+// a supported workflow.
+func TestValidateImportURL_GistAllowedOneShot(t *testing.T) {
+	s := &Server{}
+	if err := s.validateImportURL("https://gist.github.com/someone/abc123", false); err != nil {
+		t.Errorf("a one-shot gist import is supported and must be allowed, got: %v", err)
+	}
+}
+
+// TestValidateImportURL_GistPathRequired: a bare gist host carries no document.
+func TestValidateImportURL_GistPathRequired(t *testing.T) {
+	s := &Server{}
+	if err := s.validateImportURL("https://gist.github.com/", false); err == nil {
+		t.Error("a gist URL with no path identifies no document and must be rejected")
+	}
+}
+
+// TestValidateImportURL_NonGistKeepLinkedStillWorks proves the gist branch did
+// not accidentally capture ordinary repo file URLs, which are the main
+// keep-linked case.
+func TestValidateImportURL_NonGistKeepLinkedStillWorks(t *testing.T) {
+	s := &Server{}
+	if err := s.validateImportURL("https://raw.githubusercontent.com/o/r/main/a.md", true); err != nil {
+		t.Errorf("a raw GitHub file URL is the canonical keep-linked import, got: %v", err)
+	}
+}


### PR DESCRIPTION
A gist has **no stable raw URL across revisions**, so a *keep-linked* import silently pins to a snapshot that never updates again — the user believes the agent tracks the gist, and it does not. One-shot gist imports are unaffected and must keep working.

`validateImportURL` now rejects exactly that one combination (gist host + `keepLinked`), with an error naming the supported alternative. `isGistImportHost` centralises the host test.

## Conflict resolution — both protections kept

This began as a v2-era branch cherry-picked onto `v4`, and it conflicted on the same handler. **v4 had since grown a stronger SSRF guard**: `validateImportFetchURL` with per-redirect-hop revalidation plus `noRedirectToPrivate`.

The resolution **keeps v4's guard** and puts the gist check in front of it, so neither protection is lost:

```go
// gist keep-linked check (this PR)
if err := s.validateImportURL(body.URL, body.KeepLinked); err != nil { ... }
// v4's SSRF guard — retained
if err := validateImportFetchURL(r.Context(), body.URL); err != nil { ... }
client := &http.Client{ CheckRedirect: noRedirectToPrivate, ... }
```

The older non-context `importFetchURL` path from the v2 branch was **dropped in favour of v4's**.

Also removed duplicate `roundTripFunc` / `routeImportFetchesToServer` test helpers the branch carried — v4 already defines them in `import_test_transport_test.go`, and its version routes through `stubImportResolver`, which is the correct shape for v4's resolver.

## Verification

```
go build ./pkg/dashboard/ && go vet ./pkg/dashboard/    # clean
go test ./pkg/dashboard/ -run 'TestValidateImportURL_|TestImport_' -count=1   # 7 pass
```

4 new tests: the keep-linked gist rejection; a **positive control** that a one-shot gist import is still allowed (without it, a guard rejecting *every* gist would pass); a bare-host case; and proof ordinary `raw.githubusercontent.com` keep-linked imports still work.

**Positive control**: replacing `if keepLinked` with `if false` — a change that still compiles — fails `TestValidateImportURL_GistRejectedWhenKeepLinked`.

Fixes #3059