### PR TITLE
🐛 fix(hub): copy the hive record before handing it to async provisioning

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3039,9 +3039,13 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	user.Hives[hiveID] = "owner"
 	saveSaaSUser(user)
 
+	provisionHiveRecord := *h
+	provisionHiveRecord.Repos = append([]string(nil), h.Repos...)
+	provisionReq := req
 	provisionWG.Add(1)
 	go func() {
 		defer provisionWG.Done()
+		h := &provisionHiveRecord
 		cluster := s.clusterForHive(h)
 		if cluster == nil {
 			h.Status = "error"
@@ -3050,7 +3054,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 			s.logger.Error("no cluster config for provisioning", "hive_id", hiveID, "cluster_id", h.ClusterID)
 			return
 		}
-		if err := provisionHive(h, &req, cluster, s.appKeysByAppID(), s.logger); err != nil {
+		if err := provisionHive(h, &provisionReq, cluster, s.appKeysByAppID(), s.logger); err != nil {
 			h.Status = "error"
 			h.Error = err.Error()
 			saveSaaSHive(h)


### PR DESCRIPTION
The SaaS create handler kicks provisioning off in a goroutine but passed the **handler's own** hive record and request by pointer. The handler keeps mutating and serialising that record for the HTTP response after the goroutine has started, so the two race: the response can observe fields provisioning wrote, and provisioning can observe fields the response path changed.

## Fix

Take an independent copy before crossing the goroutine boundary:

```go
provisionHiveRecord := *h
provisionHiveRecord.Repos = append([]string(nil), h.Repos...)
provisionReq := req
```

The explicit `Repos` copy matters — a struct copy shares the backing array, so without it both sides would still alias the same slice and the race would survive the fix.

5 insertions, 1 deletion, one file.

## Verification

```
go build ./pkg/hub/ && go vet ./pkg/hub/   # clean
```

No behaviour change on the success path: provisioning receives the same values, just its own copy of them.

Fixes #3162