### PR TITLE
✨ feat(hub): port multi-provider human login to v4 (v2 #3566-#3595)

### DIFF
--- a/v2/pkg/auth/coverage_test.go
+++ b/v2/pkg/auth/coverage_test.go
@@ -1,0 +1,308 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// --- registry helpers ---
+
+func TestNewRegistry_OrderAndNilSkip(t *testing.T) {
+	a := &Provider{Name: "github", DisplayName: "GitHub"}
+	b := &Provider{Name: "Google", DisplayName: "Google", IsOIDC: true}
+	reg := NewRegistry(a, nil, b) // nil is skipped
+	if reg.Count() != 2 {
+		t.Fatalf("Count = %d, want 2", reg.Count())
+	}
+	ps := reg.Providers()
+	if len(ps) != 2 || ps[0].Name != "github" || ps[1].Name != "Google" {
+		t.Errorf("order = %v", providerNames(ps))
+	}
+	// Get is case-insensitive on the registered name.
+	if reg.Get("google") == nil {
+		t.Error("Get(google) should resolve the Google provider case-insensitively")
+	}
+	if reg.Get("nope") != nil {
+		t.Error("Get(nope) should be nil")
+	}
+}
+
+func TestRegistry_NilReceiverSafe(t *testing.T) {
+	var reg *Registry
+	if reg.Get("x") != nil {
+		t.Error("nil Registry Get must be nil")
+	}
+	if reg.Providers() != nil {
+		t.Error("nil Registry Providers must be nil")
+	}
+	if reg.Count() != 0 {
+		t.Error("nil Registry Count must be 0")
+	}
+	if len(reg.OIDCProviders()) != 0 {
+		t.Error("nil Registry OIDCProviders must be empty")
+	}
+}
+
+// --- claim helpers ---
+
+func TestClaimNameOverrideAndDefault(t *testing.T) {
+	p := &Provider{}
+	if got := p.claimName("", "sub"); got != "sub" {
+		t.Errorf("default = %q", got)
+	}
+	if got := p.claimName("custom_sub", "sub"); got != "custom_sub" {
+		t.Errorf("override = %q", got)
+	}
+}
+
+func TestStringClaim_MissingAndWrongType(t *testing.T) {
+	m := jwt.MapClaims{"s": "v", "n": 42}
+	if stringClaim(m, "s") != "v" {
+		t.Error("string claim not read")
+	}
+	if stringClaim(m, "n") != "" {
+		t.Error("non-string claim must yield empty")
+	}
+	if stringClaim(m, "absent") != "" {
+		t.Error("absent claim must yield empty")
+	}
+}
+
+// --- non-OIDC guardrails ---
+
+func TestExchange_NonOIDCErrors(t *testing.T) {
+	p := &Provider{Name: "github", IsOIDC: false}
+	if _, err := p.Exchange(context.Background(), "code", "cb", "nonce"); err == nil {
+		t.Fatal("Exchange on a non-OIDC provider must error")
+	}
+}
+
+func TestAuthCodeURL_NonOIDCOmitsNonce(t *testing.T) {
+	// A non-OIDC provider needs no discovery and must not add a nonce param.
+	p := &Provider{
+		Name: "github", IsOIDC: false,
+		AuthorizeURL: "https://github.com/login/oauth/authorize",
+		ClientID:     "cid", Scopes: []string{""},
+	}
+	u, err := p.AuthCodeURL("https://h/cb", "state1", "nonce1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "client_id=cid"; !contains(u, want) {
+		t.Errorf("url %q missing %q", u, want)
+	}
+	if contains(u, "nonce=") {
+		t.Errorf("non-OIDC url must not carry a nonce: %s", u)
+	}
+}
+
+func TestAuthCodeURL_AppendsWithExistingQuery(t *testing.T) {
+	// AuthorizeURL already containing a query must get "&", not "?".
+	p := &Provider{
+		Name: "github", IsOIDC: false,
+		AuthorizeURL: "https://github.com/login/oauth/authorize?foo=bar",
+		ClientID:     "cid", Scopes: []string{""},
+	}
+	u, err := p.AuthCodeURL("https://h/cb", "s", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(u, "?foo=bar&") {
+		t.Errorf("expected & separator on existing query: %s", u)
+	}
+}
+
+// --- discovery / JWKS error paths ---
+
+func TestFetchDiscovery_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if _, err := fetchDiscovery(context.Background(), srv.URL); err == nil {
+		t.Fatal("non-200 discovery must error")
+	}
+}
+
+func TestFetchDiscovery_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	if _, err := fetchDiscovery(context.Background(), srv.URL); err == nil {
+		t.Fatal("malformed discovery must error")
+	}
+}
+
+func TestFetchDiscovery_MissingEndpoints(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"issuer": "https://x"}) // no endpoints
+	}))
+	defer srv.Close()
+	if _, err := fetchDiscovery(context.Background(), srv.URL); err == nil {
+		t.Fatal("discovery missing endpoints must error")
+	}
+}
+
+func TestFetchJWKS_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	if _, err := fetchJWKS(context.Background(), srv.URL); err == nil {
+		t.Fatal("non-200 JWKS must error")
+	}
+}
+
+func TestFetchJWKS_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{"))
+	}))
+	defer srv.Close()
+	if _, err := fetchJWKS(context.Background(), srv.URL); err == nil {
+		t.Fatal("malformed JWKS must error")
+	}
+}
+
+func TestFetchJWKS_NoUsableKeys(t *testing.T) {
+	// A JWKS with only a non-RSA key (or a malformed RSA key) yields no usable keys.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{
+				{"kty": "EC", "kid": "ec1"},                          // skipped: not RSA
+				{"kty": "RSA", "kid": "bad", "n": "!!", "e": "AQAB"}, // skipped: bad n
+			},
+		})
+	}))
+	defer srv.Close()
+	if _, err := fetchJWKS(context.Background(), srv.URL); err == nil {
+		t.Fatal("JWKS with no usable RSA keys must error")
+	}
+}
+
+func TestRSAPublicKeyFromJWK_Errors(t *testing.T) {
+	if _, err := rsaPublicKeyFromJWK(jwkKey{N: "!!bad", E: "AQAB"}); err == nil {
+		t.Error("bad modulus must error")
+	}
+	if _, err := rsaPublicKeyFromJWK(jwkKey{N: "AQAB", E: "!!bad"}); err == nil {
+		t.Error("bad exponent must error")
+	}
+	if _, err := rsaPublicKeyFromJWK(jwkKey{N: "AQAB", E: "AQ"}); err == nil {
+		// E="AQ" -> 1, which is < 2 -> invalid exponent
+		t.Error("exponent < 2 must error")
+	}
+}
+
+func TestRefreshJWKS_NoURL(t *testing.T) {
+	p := &Provider{Name: "google", IsOIDC: true}
+	if err := p.refreshJWKS(context.Background()); err == nil {
+		t.Fatal("refreshJWKS with no URL must error")
+	}
+}
+
+func TestEnsureDiscovered_NoIssuer(t *testing.T) {
+	p := &Provider{Name: "google", IsOIDC: true} // no Issuer
+	if err := p.ensureDiscovered(context.Background()); err == nil {
+		t.Fatal("OIDC provider with no issuer must error on discovery")
+	}
+}
+
+func TestEnsureDiscovered_NonOIDCNoop(t *testing.T) {
+	p := &Provider{Name: "github", IsOIDC: false}
+	if err := p.ensureDiscovered(context.Background()); err != nil {
+		t.Fatalf("non-OIDC ensureDiscovered must be a no-op, got %v", err)
+	}
+}
+
+func TestKeyForKID_ThrottledUnknown(t *testing.T) {
+	// A provider whose JWKS was just refreshed (jwksSetAt=now) but does not carry
+	// the requested kid must REFUSE rather than immediately re-fetch — the
+	// throttle that stops an unknown-kid flood from hammering the JWKS endpoint.
+	p := &Provider{Name: "google", IsOIDC: true}
+	p.jwks = map[string]*rsa.PublicKey{"known": {}}
+	p.jwksSetAt = nowUTC() // fresh → within jwksRefreshMinInterval
+	if _, err := p.keyForKID(context.Background(), "unknown-kid"); err == nil {
+		t.Fatal("keyForKID must refuse an unknown kid right after a refresh (throttle)")
+	}
+}
+
+func TestFetchIDToken_ErrorPaths(t *testing.T) {
+	// non-200 from the token endpoint
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv1.Close()
+	p1 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv1.URL, ClientID: "c"}
+	if _, err := p1.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("non-200 token endpoint must error")
+	}
+
+	// token endpoint returns an OAuth error object
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant", "error_description": "bad code"})
+	}))
+	defer srv2.Close()
+	p2 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv2.URL, ClientID: "c"}
+	if _, err := p2.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("token endpoint error object must error")
+	}
+
+	// 200 but no id_token in the response
+	srv3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"access_token": "at-only"})
+	}))
+	defer srv3.Close()
+	p3 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv3.URL, ClientID: "c"}
+	if _, err := p3.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("missing id_token must error")
+	}
+
+	// malformed JSON body
+	srv4 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("nope"))
+	}))
+	defer srv4.Close()
+	p4 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv4.URL, ClientID: "c"}
+	if _, err := p4.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+		t.Error("malformed token response must error")
+	}
+}
+
+func TestKeyForKID_RefreshFindsRotatedKey(t *testing.T) {
+	// keyForKID with a stale JWKS (jwksSetAt zero → older than the throttle) must
+	// re-fetch and resolve a rotated kid it didn't previously hold.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	p := &Provider{Name: "google", IsOIDC: true, Issuer: o.issuer, JWKSURL: o.issuer + "/jwks", ClientID: "c"}
+	// jwks empty and jwksSetAt zero-value → treated as stale, triggers a refresh.
+	key, err := p.keyForKID(context.Background(), o.kid)
+	if err != nil {
+		t.Fatalf("keyForKID should resolve after refresh: %v", err)
+	}
+	if key == nil {
+		t.Fatal("resolved key is nil")
+	}
+	// A second call hits the cache (kid now present).
+	if _, err := p.keyForKID(context.Background(), o.kid); err != nil {
+		t.Fatalf("cached keyForKID: %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/v2/pkg/auth/entra_multitenant_test.go
+++ b/v2/pkg/auth/entra_multitenant_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestTenantFromIssuer(t *testing.T) {
+	const tmpl = "https://login.microsoftonline.com/{tenantid}/v2.0"
+	cases := []struct {
+		iss    string
+		want   string
+		wantOK bool
+	}{
+		{"https://login.microsoftonline.com/9188040d-abc/v2.0", "9188040d-abc", true},
+		{"https://login.microsoftonline.com/9188040d-abc/v2.0/", "9188040d-abc", true}, // trailing slash
+		{"https://login.microsoftonline.com//v2.0", "", false},                         // empty tenant
+		{"https://evil.example.com/9188040d/v2.0", "", false},                          // wrong host
+		{"https://login.microsoftonline.com/9188040d/v3.0", "", false},                 // wrong suffix
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := tenantFromIssuer(tmpl, c.iss)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("tenantFromIssuer(%q) = (%q,%v), want (%q,%v)", c.iss, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestBuildRegistry_MicrosoftMultiTenant(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_SECRET", "s")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_TENANT", "organizations")
+	p := BuildRegistry("", "", "").Get("microsoft")
+	if p == nil {
+		t.Fatal("microsoft should be enabled")
+	}
+	if p.Issuer != "https://login.microsoftonline.com/organizations/v2.0" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+	if p.IssuerTemplate != "https://login.microsoftonline.com/{tenantid}/v2.0" {
+		t.Errorf("issuerTemplate = %q (multi-tenant should template it)", p.IssuerTemplate)
+	}
+}
+
+func TestBuildRegistry_MicrosoftSingleTenantIsStrict(t *testing.T) {
+	// A concrete directory GUID → single-tenant: strict issuer, NO template.
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_TENANT", "11112222-3333-4444-5555-666677778888")
+	p := BuildRegistry("", "", "").Get("microsoft")
+	if p == nil {
+		t.Fatal("microsoft should be enabled")
+	}
+	if p.IssuerTemplate != "" {
+		t.Errorf("single-tenant must NOT set a template, got %q", p.IssuerTemplate)
+	}
+	if p.Issuer != "https://login.microsoftonline.com/11112222-3333-4444-5555-666677778888/v2.0" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+}
+
+func TestBuildRegistry_MicrosoftAllowedTenants(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_TENANT", "common")
+	t.Setenv("HIVE_HUB_OIDC_MICROSOFT_ALLOWED_TENANTS", "aaa-111, bbb-222")
+	p := BuildRegistry("", "", "").Get("microsoft")
+	if p == nil || len(p.AllowedTenants) != 2 {
+		t.Fatalf("allowed tenants not parsed: %+v", p)
+	}
+}
+
+// TestVerify_MultiTenant drives a full multi-tenant token verify: the token's iss
+// carries a real tenant GUID, which must match the template, gate on the allowed
+// set, and namespace the subject as "<tenant>.<sub>".
+func TestVerify_MultiTenant(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ms-client"
+	const nonce = "n-ms"
+	const tenant = "9188040d-6c67-4c5b-b112-36a304b66dad"
+	const sub = "AAAAAAAAAAAAAAAAAAAAAA"
+	// The token issuer is the tenant-specific issuer (what Entra actually emits).
+	tokenIss := "https://login.microsoftonline.com/" + tenant + "/v2.0"
+	o.discoveryIssuer = "https://login.microsoftonline.com/{tenantid}/v2.0"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": tokenIss, "aud": clientID, "sub": sub,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce, "name": "MS User", "email": "user@contoso.com",
+	})
+	// Provider validates against the TEMPLATE (not a fixed issuer), and the JWKS/
+	// token endpoints point at our fake server via explicit URLs.
+	p := &Provider{
+		Name: "microsoft", DisplayName: "Microsoft", IsOIDC: true,
+		Issuer:         o.issuer,
+		IssuerTemplate: "https://login.microsoftonline.com/{tenantid}/v2.0",
+		TokenURL:       o.issuer + "/token", JWKSURL: o.issuer + "/jwks",
+		ClientID: clientID, Scopes: []string{"openid"},
+		AllowedTenants: []string{tenant},
+	}
+	claims, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	want := tenant + "." + sub
+	if claims.Subject != want {
+		t.Errorf("subject = %q, want tenant-namespaced %q", claims.Subject, want)
+	}
+}
+
+// TestVerify_MultiTenant_DisallowedTenantRejected: a token from a tenant not in
+// the allowed set is refused even though it's validly signed.
+func TestVerify_MultiTenant_DisallowedTenantRejected(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ms-client"
+	const nonce = "n-ms"
+	tokenIss := "https://login.microsoftonline.com/UNWANTED-TENANT/v2.0"
+	o.discoveryIssuer = "https://login.microsoftonline.com/{tenantid}/v2.0"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": tokenIss, "aud": clientID, "sub": "s",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(), "nonce": nonce,
+	})
+	p := &Provider{
+		Name: "microsoft", IsOIDC: true, Issuer: o.issuer,
+		IssuerTemplate: "https://login.microsoftonline.com/{tenantid}/v2.0",
+		TokenURL:       o.issuer + "/token", JWKSURL: o.issuer + "/jwks",
+		ClientID: clientID, Scopes: []string{"openid"},
+		AllowedTenants: []string{"only-this-tenant"},
+	}
+	if _, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("a token from a disallowed tenant must be rejected")
+	}
+}

--- a/v2/pkg/auth/generic_provider_test.go
+++ b/v2/pkg/auth/generic_provider_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import "testing"
+
+// TestBuildRegistry_GenericCustomProvider: an operator can wire ANY OIDC IdP via
+// the "custom" env prefix — enabled by CLIENT_ID, issuer required, with an
+// overridable display label, scopes, and subject claim.
+func TestBuildRegistry_GenericCustomProvider(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_ID", "acme-client")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_SECRET", "s")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_ISSUER", "https://acme.okta.com")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_DISPLAY", "Acme SSO")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_SCOPES", "openid,email,groups")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_SUBJECT_CLAIM", "oid")
+
+	p := BuildRegistry("", "", "").Get("custom")
+	if p == nil {
+		t.Fatal("custom provider should be enabled")
+	}
+	if p.DisplayName != "Acme SSO" {
+		t.Errorf("display = %q, want Acme SSO", p.DisplayName)
+	}
+	if p.Issuer != "https://acme.okta.com" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+	if len(p.Scopes) != 3 || p.Scopes[2] != "groups" {
+		t.Errorf("scopes = %v", p.Scopes)
+	}
+	if p.SubjectClaim != "oid" {
+		t.Errorf("subjectClaim = %q, want oid", p.SubjectClaim)
+	}
+}
+
+// TestBuildRegistry_GenericDefaults: with only the required env, sensible
+// defaults apply (label "Single Sign-On", standard scopes, sub subject).
+func TestBuildRegistry_GenericDefaults(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_ID", "c")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_ISSUER", "https://idp.example.com")
+	p := BuildRegistry("", "", "").Get("custom")
+	if p == nil {
+		t.Fatal("custom should be enabled with just client id + issuer")
+	}
+	if p.DisplayName != "Single Sign-On" {
+		t.Errorf("default display = %q", p.DisplayName)
+	}
+	if p.SubjectClaim != "" {
+		t.Errorf("default subjectClaim should be empty (→ sub), got %q", p.SubjectClaim)
+	}
+	if len(p.Scopes) != 3 {
+		t.Errorf("default scopes = %v", p.Scopes)
+	}
+}
+
+// TestBuildRegistry_GenericNeedsIssuer: no issuer → skipped, not fatal.
+func TestBuildRegistry_GenericNeedsIssuer(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_CLIENT_ID", "c")
+	t.Setenv("HIVE_HUB_OIDC_CUSTOM_ISSUER", "")
+	if BuildRegistry("", "", "").Get("custom") != nil {
+		t.Error("custom must be skipped when no issuer is configured")
+	}
+}
+
+func TestSplitScopes(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want int
+	}{
+		{"openid email profile", 3},
+		{"openid,email,profile", 3},
+		{"openid, email ,  profile", 3},
+		{"", 0},
+		{"  openid  ", 1},
+	} {
+		if got := len(splitScopes(c.in)); got != c.want {
+			t.Errorf("splitScopes(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/v2/pkg/auth/oidc_provider.go
+++ b/v2/pkg/auth/oidc_provider.go
@@ -1,0 +1,563 @@
+// Package auth provides a small, self-contained OIDC/OAuth provider abstraction
+// for HUMAN dashboard login on the hive Hub (and, later, direct-route spokes).
+//
+// Scope boundary (important): this is ONLY about authenticating a human and
+// deriving their canonical `provider:subject` identity for access control. It
+// has nothing to do with:
+//   - the GitHub App installation token (kubestellar-hive[bot]) that performs the
+//     hive's actual GitHub work — that path is untouched; a non-GitHub human can
+//     fully own a GitHub-repo hive because the App, not the user, does the work.
+//   - agent/backend logins (Copilot→GitHub, Claude→Gmail) — those are how the AI
+//     CLIs authenticate to do work, entirely separate from human login.
+//
+// A provider is either:
+//   - GitHub OAuth (IsOIDC=false): the legacy path — authorize, exchange code,
+//     read GET /user for the login. The hub keeps its own GitHub handler; this
+//     package models GitHub only so the picker can enumerate it uniformly.
+//   - OIDC (IsOIDC=true): Google/IBMid/Red Hat — authorize with an OIDC `nonce`,
+//     exchange code for an id_token (a signed JWT), and verify that JWT against
+//     the provider's JWKS, enforcing iss/aud/exp AND the nonce. The stable `sub`
+//     claim (NEVER email — emails are reassignable) becomes the canonical subject.
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// httpTimeout bounds every outbound call this package makes (discovery, JWKS,
+// token exchange). Matches the hub's existing oauthTimeout so behavior is
+// consistent across the two login paths.
+const httpTimeout = 10 * time.Second
+
+// maxResponseBytes caps how much of any provider response we read, mirroring the
+// hub's maxOAuthResponseBytes. A discovery/JWKS/token document is a few KB; this
+// is a memory-safety bound against a hostile or broken endpoint.
+const maxResponseBytes = 1 << 16
+
+// jwksRefreshMinInterval throttles JWKS re-fetches triggered by an unknown `kid`.
+// Providers rotate signing keys occasionally; a flood of tokens with an unknown
+// kid (garbage or an attack) must not turn into a fetch-per-request DoS on the
+// provider's JWKS endpoint.
+const jwksRefreshMinInterval = 60 * time.Second
+
+// Provider describes one human-login provider. GitHub is modeled with IsOIDC
+// false (the hub owns its handler); Google/IBMid/Red Hat are OIDC.
+type Provider struct {
+	// Name is the canonical provider slug used in the identity wire form
+	// ("github", "google", "ibmid", "redhat"). Must match the hub's
+	// identityProviders set.
+	Name string
+	// DisplayName is the human label on the login picker ("Google", "Red Hat").
+	DisplayName string
+	// IsOIDC distinguishes the OIDC path (id_token + JWKS) from GitHub OAuth.
+	IsOIDC bool
+
+	// Issuer is the OIDC issuer URL. Discovery is fetched from
+	// Issuer + "/.well-known/openid-configuration". Required for OIDC.
+	Issuer string
+	// Endpoints. For OIDC these are normally filled from discovery; for GitHub
+	// they are set explicitly by the hub. AuthorizeURL/TokenURL are always set;
+	// JWKSURL/UserInfoURL only for OIDC.
+	AuthorizeURL string
+	TokenURL     string
+	JWKSURL      string
+
+	// ClientID / ClientSecret from the provider's app registration. A provider is
+	// enabled iff ClientID is set (mirrors the hub's registerOAuth gate).
+	ClientID     string
+	ClientSecret string
+
+	// Scopes requested at authorize time. OIDC always needs "openid"; "email
+	// profile" get the display name/avatar. GitHub uses "" (identity-only).
+	Scopes []string
+
+	// Claim names for extracting identity from the id_token. Defaults suit the
+	// standard OIDC claim set (sub/name/picture/email); overridable per provider.
+	SubjectClaim string
+	NameClaim    string
+	AvatarClaim  string
+	EmailClaim   string
+
+	// IssuerTemplate enables MULTI-TENANT providers (Microsoft Entra "common"/
+	// "organizations", multi-tenant Okta orgs). Multi-tenant issuers embed a
+	// per-tenant id: the discovery/config issuer contains a literal "{tenantid}"
+	// placeholder while each id_token's `iss` carries the REAL tenant id. A single
+	// strict `iss == Issuer` check can't express that, so when IssuerTemplate is
+	// set (e.g. "https://login.microsoftonline.com/{tenantid}/v2.0") the verifier
+	// instead matches the token's `iss` against the template, extracts the tenant,
+	// enforces AllowedTenants (if any), and namespaces the subject as
+	// "<tenant>:<sub>" so identities never collide across tenants. Empty means the
+	// single-tenant strict-issuer path (unchanged).
+	IssuerTemplate string
+	// AllowedTenants optionally restricts a multi-tenant provider to specific
+	// tenant ids (Entra directory GUIDs). Empty = any tenant that satisfies the
+	// template is accepted.
+	AllowedTenants []string
+
+	// discovered caches the OIDC discovery document + JWKS behind mu.
+	mu         sync.Mutex
+	discovered bool
+	jwks       map[string]*rsa.PublicKey // kid -> RSA public key
+	jwksSetAt  time.Time
+}
+
+// Claims is the identity extracted from a verified id_token (or GitHub /user).
+type Claims struct {
+	Subject   string // the stable `sub` — becomes the canonical subject
+	Name      string // display name (optional)
+	AvatarURL string // picture (optional)
+	Email     string // email (display only; NEVER the identity key)
+}
+
+// scopeString renders the space-delimited scope parameter.
+func (p *Provider) scopeString() string {
+	return strings.Join(p.Scopes, " ")
+}
+
+// AuthCodeURL builds the provider's authorization URL. state carries the hub's
+// CSRF nonce (+ redirect); nonce is the OIDC replay-protection nonce echoed back
+// in the id_token (ignored by non-OIDC providers). redirectURI must exactly match
+// a URI registered on the provider side.
+func (p *Provider) AuthCodeURL(redirectURI, state, nonce string) (string, error) {
+	if err := p.ensureDiscovered(context.Background()); err != nil {
+		return "", err
+	}
+	v := neturlValues()
+	v.Set("client_id", p.ClientID)
+	v.Set("redirect_uri", redirectURI)
+	v.Set("response_type", "code")
+	v.Set("scope", p.scopeString())
+	v.Set("state", state)
+	if p.IsOIDC && nonce != "" {
+		v.Set("nonce", nonce)
+	}
+	sep := "?"
+	if strings.Contains(p.AuthorizeURL, "?") {
+		sep = "&"
+	}
+	return p.AuthorizeURL + sep + v.Encode(), nil
+}
+
+// Exchange trades an authorization code for identity claims. For OIDC it fetches
+// the token endpoint, extracts the id_token, and VERIFIES it (signature via JWKS,
+// plus iss/aud/exp and the expected nonce) before returning any claim. For a
+// non-OIDC (GitHub) provider it returns an error — the hub owns that path.
+func (p *Provider) Exchange(ctx context.Context, code, redirectURI, expectNonce string) (*Claims, error) {
+	if !p.IsOIDC {
+		return nil, errors.New("Exchange is only for OIDC providers; GitHub uses the hub's own handler")
+	}
+	if err := p.ensureDiscovered(ctx); err != nil {
+		return nil, err
+	}
+	rawIDToken, err := p.fetchIDToken(ctx, code, redirectURI)
+	if err != nil {
+		return nil, err
+	}
+	return p.verifyIDToken(ctx, rawIDToken, expectNonce)
+}
+
+// fetchIDToken posts the code to the token endpoint and returns the raw id_token.
+func (p *Provider) fetchIDToken(ctx context.Context, code, redirectURI string) (string, error) {
+	form := neturlValues()
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", p.ClientID)
+	form.Set("client_secret", p.ClientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token exchange: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %d", resp.StatusCode)
+	}
+	var tok struct {
+		IDToken     string `json:"id_token"`
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+		ErrorDesc   string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+	if tok.Error != "" {
+		return "", fmt.Errorf("token endpoint error %q: %s", tok.Error, tok.ErrorDesc)
+	}
+	if tok.IDToken == "" {
+		return "", errors.New("token response carried no id_token")
+	}
+	return tok.IDToken, nil
+}
+
+// verifyIDToken validates the id_token's signature and claims, then extracts
+// identity. It enforces, in order: a supported RS256/RS384/RS512 alg (never
+// "none", never HMAC — which would let a client-known secret forge a token); the
+// signing key resolved from JWKS by `kid`; iss == p.Issuer; aud contains
+// p.ClientID; exp not passed (with the library's small leeway); and nonce ==
+// expectNonce. Any failure returns an error and NO claims.
+func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (*Claims, error) {
+	keyFunc := func(t *jwt.Token) (interface{}, error) {
+		// Reject anything but RSA signing. "none" and HMAC ("HS*") are the two
+		// classic OIDC token-forgery vectors; the parser options below also pin
+		// valid methods, this is defense in depth on the key side.
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method %q", t.Header["alg"])
+		}
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, errors.New("id_token has no kid")
+		}
+		key, err := p.keyForKID(ctx, kid)
+		if err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+
+	// Issuer validation differs for single- vs multi-tenant. Single-tenant: the
+	// jwt parser enforces iss == p.Issuer. Multi-tenant: iss is per-tenant, so we
+	// validate it against IssuerTemplate ourselves AFTER parsing (below) and do
+	// NOT pin a fixed issuer here.
+	parserOpts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512"}),
+		jwt.WithAudience(p.ClientID),
+		jwt.WithExpirationRequired(),
+	}
+	if p.IssuerTemplate == "" {
+		parserOpts = append(parserOpts, jwt.WithIssuer(p.Issuer))
+	}
+	parser := jwt.NewParser(parserOpts...)
+	claims := jwt.MapClaims{}
+	if _, err := parser.ParseWithClaims(raw, claims, keyFunc); err != nil {
+		return nil, fmt.Errorf("id_token verification failed: %w", err)
+	}
+
+	// Multi-tenant: match the token issuer against the template, extract + gate the
+	// tenant. Fails closed on a non-matching iss or a disallowed tenant.
+	tenant := ""
+	if p.IssuerTemplate != "" {
+		iss, _ := claims["iss"].(string)
+		t, ok := tenantFromIssuer(p.IssuerTemplate, iss)
+		if !ok {
+			return nil, fmt.Errorf("id_token issuer %q does not match template %q", iss, p.IssuerTemplate)
+		}
+		if len(p.AllowedTenants) > 0 && !containsFold(p.AllowedTenants, t) {
+			return nil, fmt.Errorf("id_token tenant %q is not in the allowed set", t)
+		}
+		tenant = t
+	}
+
+	// Nonce binds the id_token to the login THIS browser started (replay/
+	// injection defense). Enforced explicitly because jwt has no built-in nonce
+	// validator. This MUST fail closed: the caller always mints and cookies a
+	// nonce before authorize, so an empty expectNonce at verify time means the
+	// browser's nonce cookie was missing/cleared — exactly the state a token-
+	// injection attacker engineers. Rejecting on empty is what closes that hole
+	// (an earlier version skipped the check when expectNonce=="", failing OPEN).
+	if expectNonce == "" {
+		return nil, errors.New("no expected nonce for OIDC verification (nonce cookie missing) — refusing to skip replay protection")
+	}
+	got, _ := claims[claimNonce].(string)
+	if got == "" || got != expectNonce {
+		return nil, errors.New("id_token nonce mismatch")
+	}
+
+	sub := stringClaim(claims, p.claimName(p.SubjectClaim, claimSub))
+	if sub == "" {
+		return nil, errors.New("id_token has no subject")
+	}
+	// Multi-tenant: namespace the subject by tenant so the SAME sub value in two
+	// different tenants yields two distinct identities ("<tenant>:<sub>"). A bare
+	// sub is per-issuer-unique, and in multi-tenant mode the issuer varies, so
+	// without this two tenants could collide. Uses a '.' separator, not ':',
+	// because ':' is the canonical provider separator upstream.
+	if tenant != "" {
+		sub = tenant + "." + sub
+	}
+	return &Claims{
+		Subject:   sub,
+		Name:      stringClaim(claims, p.claimName(p.NameClaim, claimName)),
+		AvatarURL: stringClaim(claims, p.claimName(p.AvatarClaim, claimPicture)),
+		Email:     stringClaim(claims, p.claimName(p.EmailClaim, claimEmail)),
+	}, nil
+}
+
+// tenantFromIssuer matches a concrete token issuer against a template containing
+// a single "{tenantid}" placeholder and returns the substituted tenant value.
+// The non-placeholder parts must match exactly (trailing slashes normalized), and
+// the tenant must be a plausible id (non-empty, no '/'). Returns ok=false on any
+// mismatch — this is a security check, so it fails closed.
+func tenantFromIssuer(template, iss string) (string, bool) {
+	const ph = "{tenantid}"
+	i := strings.Index(template, ph)
+	if i < 0 || iss == "" {
+		return "", false
+	}
+	prefix := template[:i]
+	suffix := template[i+len(ph):]
+	// Normalize trailing slashes on the whole strings before splitting.
+	iss = strings.TrimRight(iss, "/")
+	suffix = strings.TrimRight(suffix, "/")
+	if !strings.HasPrefix(iss, prefix) || !strings.HasSuffix(iss, suffix) {
+		return "", false
+	}
+	tenant := iss[len(prefix) : len(iss)-len(suffix)]
+	tenant = strings.Trim(tenant, "/")
+	if tenant == "" || strings.ContainsAny(tenant, "/{}") {
+		return "", false
+	}
+	return tenant, true
+}
+
+// containsFold reports whether s is in list, case-insensitively (tenant GUIDs are
+// case-insensitive).
+func containsFold(list []string, s string) bool {
+	for _, x := range list {
+		if strings.EqualFold(strings.TrimSpace(x), s) {
+			return true
+		}
+	}
+	return false
+}
+
+// keyForKID returns the RSA public key for a JWKS key id, fetching/refreshing the
+// JWKS on an unknown kid (rate-limited) to handle key rotation.
+func (p *Provider) keyForKID(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	p.mu.Lock()
+	key := p.jwks[kid]
+	stale := time.Since(p.jwksSetAt) >= jwksRefreshMinInterval
+	p.mu.Unlock()
+	if key != nil {
+		return key, nil
+	}
+	if !stale {
+		// Unknown kid but we refreshed very recently: refuse rather than hammer
+		// the JWKS endpoint. A legitimate rotation resolves on the next attempt
+		// after the throttle window.
+		return nil, fmt.Errorf("unknown id_token kid %q (JWKS recently refreshed)", kid)
+	}
+	if err := p.refreshJWKS(ctx); err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	key = p.jwks[kid]
+	p.mu.Unlock()
+	if key == nil {
+		return nil, fmt.Errorf("unknown id_token kid %q", kid)
+	}
+	return key, nil
+}
+
+// ensureDiscovered lazily runs OIDC discovery (once) to populate the authorize/
+// token/JWKS endpoints, then fetches the JWKS. GitHub (non-OIDC) needs no
+// discovery — its endpoints are set by the hub.
+func (p *Provider) ensureDiscovered(ctx context.Context) error {
+	if !p.IsOIDC {
+		return nil
+	}
+	p.mu.Lock()
+	done := p.discovered
+	p.mu.Unlock()
+	if done {
+		return nil
+	}
+	if p.Issuer == "" {
+		return errors.New("OIDC provider has no issuer")
+	}
+	doc, err := fetchDiscovery(ctx, p.Issuer)
+	if err != nil {
+		return err
+	}
+	// Discovery's issuer MUST be present AND consistent with configuration. This
+	// prevents a swapped/hostile discovery doc from redirecting token/JWKS to an
+	// attacker origin. Per OIDC Discovery the issuer field is REQUIRED.
+	//
+	// Single-tenant: strict equality with p.Issuer.
+	// Multi-tenant: the doc's issuer legitimately carries the "{tenantid}"
+	// placeholder (e.g. Entra's common/organizations metadata), so it must equal
+	// the configured IssuerTemplate instead — still an exact, non-attacker-
+	// controllable match, just against the templated form.
+	if p.IssuerTemplate != "" {
+		if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(p.IssuerTemplate, "/") {
+			return fmt.Errorf("discovery issuer %q != configured issuer template %q", doc.Issuer, p.IssuerTemplate)
+		}
+	} else if strings.TrimRight(doc.Issuer, "/") != strings.TrimRight(p.Issuer, "/") {
+		return fmt.Errorf("discovery issuer %q != configured issuer %q", doc.Issuer, p.Issuer)
+	}
+	p.mu.Lock()
+	if p.AuthorizeURL == "" {
+		p.AuthorizeURL = doc.AuthorizationEndpoint
+	}
+	if p.TokenURL == "" {
+		p.TokenURL = doc.TokenEndpoint
+	}
+	if p.JWKSURL == "" {
+		p.JWKSURL = doc.JWKSURI
+	}
+	p.discovered = true
+	p.mu.Unlock()
+	return p.refreshJWKS(ctx)
+}
+
+// refreshJWKS fetches and parses the provider's JWKS into RSA public keys.
+func (p *Provider) refreshJWKS(ctx context.Context) error {
+	if p.JWKSURL == "" {
+		return errors.New("no JWKS URL")
+	}
+	keys, err := fetchJWKS(ctx, p.JWKSURL)
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	p.jwks = keys
+	p.jwksSetAt = nowUTC()
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *Provider) claimName(override, def string) string {
+	if override != "" {
+		return override
+	}
+	return def
+}
+
+// --- discovery / JWKS wire types ---
+
+type discoveryDoc struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+func fetchDiscovery(ctx context.Context, issuer string) (*discoveryDoc, error) {
+	url := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC discovery: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OIDC discovery returned %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	var doc discoveryDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("parse discovery: %w", err)
+	}
+	if doc.Issuer == "" || doc.TokenEndpoint == "" || doc.JWKSURI == "" || doc.AuthorizationEndpoint == "" {
+		return nil, errors.New("discovery document missing required fields (issuer/authorization/token/jwks)")
+	}
+	return &doc, nil
+}
+
+type jwksResponse struct {
+	Keys []jwkKey `json:"keys"`
+}
+
+type jwkKey struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+func fetchJWKS(ctx context.Context, jwksURL string) (map[string]*rsa.PublicKey, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", jwksURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("JWKS fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("JWKS returned %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	var set jwksResponse
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("parse JWKS: %w", err)
+	}
+	out := map[string]*rsa.PublicKey{}
+	for _, k := range set.Keys {
+		if k.Kty != "RSA" || k.Kid == "" {
+			continue
+		}
+		pk, err := rsaPublicKeyFromJWK(k)
+		if err != nil {
+			continue // skip a malformed key rather than fail the whole set
+		}
+		out[k.Kid] = pk
+	}
+	if len(out) == 0 {
+		return nil, errors.New("JWKS contained no usable RSA keys")
+	}
+	return out, nil
+}
+
+// rsaPublicKeyFromJWK reconstructs an RSA public key from a JWK's base64url n/e.
+func rsaPublicKeyFromJWK(k jwkKey) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, err
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, err
+	}
+	n := new(big.Int).SetBytes(nBytes)
+	e := new(big.Int).SetBytes(eBytes)
+	if !e.IsInt64() || e.Int64() < 2 {
+		return nil, errors.New("invalid RSA exponent")
+	}
+	return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
+}
+
+// --- standard claim names ---
+
+const (
+	claimSub     = "sub"
+	claimName    = "name"
+	claimPicture = "picture"
+	claimEmail   = "email"
+	claimNonce   = "nonce"
+)
+
+func stringClaim(m jwt.MapClaims, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/v2/pkg/auth/oidc_provider_test.go
+++ b/v2/pkg/auth/oidc_provider_test.go
@@ -1,0 +1,438 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// oidcTestServer is a minimal OIDC provider: discovery, JWKS, and a token
+// endpoint that returns a pre-seeded id_token. It signs with one RSA key.
+type oidcTestServer struct {
+	srv    *httptest.Server
+	key    *rsa.PrivateKey
+	kid    string
+	issuer string
+	// discoveryIssuer, when set, is served as the discovery doc's `issuer` instead
+	// of the server URL. Multi-tenant tests set this to the "{tenantid}" template
+	// so ensureDiscovered's template cross-check passes (real Entra does the same).
+	discoveryIssuer string
+	// idToken is what the token endpoint returns for any code.
+	idToken string
+}
+
+func newOIDCTestServer(t *testing.T) *oidcTestServer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ots := &oidcTestServer{key: key, kid: "test-kid-1"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		iss := ots.issuer
+		if ots.discoveryIssuer != "" {
+			iss = ots.discoveryIssuer
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 iss,
+			"authorization_endpoint": ots.issuer + "/authorize",
+			"token_endpoint":         ots.issuer + "/token",
+			"jwks_uri":               ots.issuer + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		pub := key.Public().(*rsa.PublicKey)
+		n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+		json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{
+				{"kty": "RSA", "kid": ots.kid, "use": "sig", "alg": "RS256", "n": n, "e": e},
+			},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"id_token": ots.idToken})
+	})
+	ots.srv = httptest.NewServer(mux)
+	ots.issuer = ots.srv.URL
+	return ots
+}
+
+func (o *oidcTestServer) close() { o.srv.Close() }
+
+// signToken signs claims as an RS256 JWT with the server's key and kid.
+func (o *oidcTestServer) signToken(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = o.kid
+	s, err := tok.SignedString(o.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// baseClaims returns a valid claim set for the given audience/nonce.
+func baseClaims(issuer, aud, nonce string) jwt.MapClaims {
+	return jwt.MapClaims{
+		"iss":     issuer,
+		"aud":     aud,
+		"sub":     "1078901234567890",
+		"exp":     time.Now().Add(1 * time.Hour).Unix(),
+		"iat":     time.Now().Unix(),
+		"nonce":   nonce,
+		"email":   "person@example.com",
+		"name":    "A Person",
+		"picture": "https://example.com/p.png",
+	}
+}
+
+func googleLikeProvider(o *oidcTestServer, clientID string) *Provider {
+	return &Provider{
+		Name:        "google",
+		DisplayName: "Google",
+		IsOIDC:      true,
+		Issuer:      o.issuer,
+		ClientID:    clientID,
+		Scopes:      []string{"openid", "email", "profile"},
+	}
+}
+
+func TestOIDC_HappyPath(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, nonce))
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "code123", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Subject != "1078901234567890" {
+		t.Errorf("subject = %q", claims.Subject)
+	}
+	if claims.Email != "person@example.com" || claims.Name != "A Person" || claims.AvatarURL != "https://example.com/p.png" {
+		t.Errorf("claims = %+v", claims)
+	}
+}
+
+func TestOIDC_RejectsWrongAudience(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Token minted for a DIFFERENT audience — the classic token-confusion attack.
+	o.idToken = o.signToken(t, baseClaims(o.issuer, "some-other-client", nonce))
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for wrong audience, got nil")
+	}
+}
+
+func TestOIDC_RejectsWrongIssuer(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	o.idToken = o.signToken(t, baseClaims("https://evil.example.com", clientID, nonce))
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for wrong issuer, got nil")
+	}
+}
+
+func TestOIDC_RejectsExpired(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	c := baseClaims(o.issuer, clientID, nonce)
+	c["exp"] = time.Now().Add(-1 * time.Hour).Unix()
+	o.idToken = o.signToken(t, c)
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for expired token, got nil")
+	}
+}
+
+func TestOIDC_RejectsBadNonce(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, "the-real-nonce"))
+
+	p := googleLikeProvider(o, clientID)
+	// We expected a different nonce than the token carries → replay/injection.
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", "a-different-nonce"); err == nil {
+		t.Fatal("expected rejection for nonce mismatch, got nil")
+	}
+}
+
+func TestOIDC_RejectsAlgNone(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Forge an unsigned ("alg":"none") token — must be rejected outright.
+	claims := baseClaims(o.issuer, clientID, nonce)
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tok.Header["kid"] = o.kid
+	raw, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.idToken = raw
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for alg=none, got nil")
+	}
+}
+
+func TestOIDC_RejectsHMACConfusion(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Sign HS256 using the RSA public modulus bytes as the HMAC secret — the
+	// classic RS→HS confusion. keyFunc must refuse the non-RSA method before the
+	// secret is ever consulted.
+	pub := o.key.Public().(*rsa.PublicKey)
+	claims := baseClaims(o.issuer, clientID, nonce)
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tok.Header["kid"] = o.kid
+	raw, err := tok.SignedString(pub.N.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.idToken = raw
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for HS256 confusion, got nil")
+	}
+}
+
+func TestOIDC_RejectsUnknownKID(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	// Sign with a kid the JWKS does not publish.
+	claims := baseClaims(o.issuer, clientID, nonce)
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = "kid-not-in-jwks"
+	raw, err := tok.SignedString(o.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.idToken = raw
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for unknown kid, got nil")
+	}
+}
+
+func TestOIDC_DiscoveryIssuerMismatchFails(t *testing.T) {
+	// A discovery doc whose issuer disagrees with the configured issuer must be
+	// rejected (prevents a swapped discovery pointing token/JWKS at an attacker).
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	_ = key
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 "https://not-me.example.com",
+			"authorization_endpoint": "https://x/authorize",
+			"token_endpoint":         "https://x/token",
+			"jwks_uri":               "https://x/jwks",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p := &Provider{Name: "google", IsOIDC: true, Issuer: srv.URL, ClientID: "c", Scopes: []string{"openid"}}
+	if err := p.ensureDiscovered(context.Background()); err == nil {
+		t.Fatal("expected discovery issuer-mismatch rejection, got nil")
+	}
+}
+
+func TestOIDC_RejectsEmptyExpectedNonce(t *testing.T) {
+	// A missing/cleared browser nonce cookie surfaces as expectNonce=="" at the
+	// hub. Verification MUST fail closed rather than skip the nonce check (the
+	// token-injection fail-open). Even a token that carries a valid-looking nonce
+	// must be rejected when we have nothing to compare it against.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, "some-nonce"))
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", ""); err == nil {
+		t.Fatal("expected hard rejection when expected nonce is empty, got nil")
+	}
+}
+
+func TestOIDC_DiscoveryMissingIssuerFails(t *testing.T) {
+	// A discovery doc that OMITS `issuer` must be rejected (an empty issuer used
+	// to skip the cross-check, trusting a possibly-hostile jwks_uri).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			// no "issuer"
+			"authorization_endpoint": "https://x/authorize",
+			"token_endpoint":         "https://x/token",
+			"jwks_uri":               "https://x/jwks",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p := &Provider{Name: "google", IsOIDC: true, Issuer: srv.URL, ClientID: "c", Scopes: []string{"openid"}}
+	if err := p.ensureDiscovered(context.Background()); err == nil {
+		t.Fatal("expected rejection for discovery doc with no issuer, got nil")
+	}
+}
+
+func TestAuthCodeURL_CarriesNonceAndState(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	p := googleLikeProvider(o, "client-abc")
+	u, err := p.AuthCodeURL(o.issuer+"/cb", "state-val", "nonce-val")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, _ := url.Parse(u)
+	q := parsed.Query()
+	if q.Get("state") != "state-val" || q.Get("nonce") != "nonce-val" {
+		t.Errorf("authorize URL missing state/nonce: %s", u)
+	}
+	if q.Get("client_id") != "client-abc" || q.Get("response_type") != "code" {
+		t.Errorf("authorize URL wrong params: %s", u)
+	}
+	if q.Get("scope") != "openid email profile" {
+		t.Errorf("scope = %q", q.Get("scope"))
+	}
+}
+
+func TestBuildRegistry_EnabledByClientID(t *testing.T) {
+	// GitHub always present when its client id is set. Google enabled via env;
+	// IBMid without an issuer is skipped (not fatal).
+	t.Setenv("HIVE_HUB_OIDC_GOOGLE_CLIENT_ID", "g-client")
+	t.Setenv("HIVE_HUB_OIDC_GOOGLE_CLIENT_SECRET", "g-secret")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_CLIENT_ID", "ibm-client") // no issuer → skipped
+	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "")
+	t.Setenv("HIVE_HUB_OIDC_REDHAT_CLIENT_ID", "") // disabled
+
+	reg := BuildRegistry("gh-client", "https://github/authorize", "https://github/token")
+	if reg.Get("github") == nil {
+		t.Error("github should be enabled")
+	}
+	if reg.Get("google") == nil {
+		t.Error("google should be enabled")
+	}
+	if reg.Get("ibmid") != nil {
+		t.Error("ibmid must be skipped when it has no issuer")
+	}
+	if reg.Get("redhat") != nil {
+		t.Error("redhat must be disabled when no client id")
+	}
+	// GitHub first, then Google.
+	ps := reg.Providers()
+	if len(ps) != 2 || ps[0].Name != "github" || ps[1].Name != "google" {
+		t.Errorf("provider order = %v", providerNames(ps))
+	}
+	if len(reg.OIDCProviders()) != 1 {
+		t.Errorf("OIDCProviders = %v", providerNames(reg.OIDCProviders()))
+	}
+}
+
+func TestBuildRegistry_IBMidWithIssuerEnabled(t *testing.T) {
+	t.Setenv("HIVE_HUB_OIDC_IBMID_CLIENT_ID", "ibm-client")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "https://login.ibm.com/oidc/endpoint/default")
+	reg := BuildRegistry("", "", "")
+	p := reg.Get("ibmid")
+	if p == nil {
+		t.Fatal("ibmid should be enabled with an explicit issuer")
+	}
+	if p.Issuer != "https://login.ibm.com/oidc/endpoint/default" {
+		t.Errorf("issuer = %q", p.Issuer)
+	}
+	// IBMid keys on "uid", not the OIDC-standard "sub" (which it doesn't advertise).
+	if p.SubjectClaim != "uid" {
+		t.Errorf("ibmid SubjectClaim = %q, want uid", p.SubjectClaim)
+	}
+}
+
+func TestBuildRegistry_SubjectClaimEnvOverride(t *testing.T) {
+	// If a real IBMid token turns out to carry "sub", an operator can override the
+	// default "uid" via env without a code change.
+	t.Setenv("HIVE_HUB_OIDC_IBMID_CLIENT_ID", "ibm-client")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_ISSUER", "https://login.ibm.com/oidc/endpoint/default")
+	t.Setenv("HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM", "sub")
+	p := BuildRegistry("", "", "").Get("ibmid")
+	if p == nil || p.SubjectClaim != "sub" {
+		t.Fatalf("env override not applied: %+v", p)
+	}
+	// Google keeps the default (empty → sub).
+	t.Setenv("HIVE_HUB_OIDC_GOOGLE_CLIENT_ID", "g")
+	g := BuildRegistry("", "", "").Get("google")
+	if g == nil || g.SubjectClaim != "" {
+		t.Errorf("google SubjectClaim = %q, want empty (defaults to sub)", g.SubjectClaim)
+	}
+}
+
+func TestVerify_IBMidUidSubject(t *testing.T) {
+	// An IBMid-shaped id_token carries the stable id in "uid" and NO "sub".
+	// Verification with SubjectClaim="uid" must extract the uid as the subject.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ibm-client"
+	const nonce = "n-ibm"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": o.issuer, "aud": clientID,
+		"uid": "2700ABC123", // stable IBMid serial, no "sub"
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce, "preferred_username": "someone@ibm.com", "email": "someone@ibm.com",
+	})
+	p := &Provider{
+		Name: "ibmid", DisplayName: "IBMid", IsOIDC: true,
+		Issuer: o.issuer, ClientID: clientID, Scopes: []string{"openid"},
+		SubjectClaim: "uid",
+	}
+	claims, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Subject != "2700ABC123" {
+		t.Errorf("subject = %q, want the uid 2700ABC123", claims.Subject)
+	}
+}
+
+func providerNames(ps []*Provider) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.Name
+	}
+	return out
+}
+
+// sanity: ensure the test file's fmt import is used even if a case is trimmed.
+var _ = fmt.Sprintf

--- a/v2/pkg/auth/registry.go
+++ b/v2/pkg/auth/registry.go
@@ -1,0 +1,296 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// httpClient returns a client with this package's uniform timeout. A fresh client
+// per call is cheap and keeps the package free of shared mutable state; the
+// transport's connection pooling still applies at the default-transport level.
+func httpClient() *http.Client {
+	return &http.Client{Timeout: httpTimeout}
+}
+
+// neturlValues is a tiny indirection so the file that builds query/form bodies
+// does not import net/url directly (keeps the OIDC file's import list focused on
+// crypto/JWT). It returns an empty url.Values.
+func neturlValues() url.Values {
+	return url.Values{}
+}
+
+// nowUTC is the single clock reference, so a test can reason about jwksSetAt
+// without reaching into time inside the OIDC file.
+func nowUTC() time.Time {
+	return time.Now().UTC()
+}
+
+// splitScopes parses a scope override env value. Accepts space- or comma-
+// separated scopes ("openid email profile" or "openid,email,profile"); empties
+// are dropped. Used for <PREFIX>_SCOPES, chiefly the generic "custom" provider
+// whose IdP may need different scopes than the openid/email/profile default.
+func splitScopes(s string) []string {
+	f := func(r rune) bool { return r == ' ' || r == ',' || r == '\t' || r == '\n' }
+	parts := strings.FieldsFunc(s, f)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Registry holds the enabled human-login providers, in a stable display order.
+type Registry struct {
+	providers []*Provider
+	byName    map[string]*Provider
+}
+
+// NewRegistry builds a registry from an explicit provider list, preserving order.
+// BuildRegistry is the production path (env-driven); this exists for composition
+// and tests that need a registry with a specific provider set.
+func NewRegistry(providers ...*Provider) *Registry {
+	r := &Registry{byName: map[string]*Provider{}}
+	for _, p := range providers {
+		if p == nil {
+			continue
+		}
+		r.providers = append(r.providers, p)
+		r.byName[strings.ToLower(p.Name)] = p
+	}
+	return r
+}
+
+// Get returns the provider with the given canonical name, or nil.
+func (r *Registry) Get(name string) *Provider {
+	if r == nil {
+		return nil
+	}
+	return r.byName[strings.ToLower(name)]
+}
+
+// Providers returns the enabled providers in display order (GitHub first when
+// present, then OIDC providers alphabetically by display name).
+func (r *Registry) Providers() []*Provider {
+	if r == nil {
+		return nil
+	}
+	return r.providers
+}
+
+// OIDCProviders returns only the enabled OIDC providers (excludes GitHub).
+func (r *Registry) OIDCProviders() []*Provider {
+	var out []*Provider
+	for _, p := range r.Providers() {
+		if p.IsOIDC {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Count is the number of enabled providers.
+func (r *Registry) Count() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.providers)
+}
+
+// oidcProviderSpec is the static per-provider config the env-driven registry
+// builds from. Issuer defaults live here; env can override the issuer (needed for
+// IBMid/Red Hat whose issuer is tenant-specific).
+type oidcProviderSpec struct {
+	name          string
+	display       string
+	defaultIssuer string // "" means the issuer MUST come from env
+	envPrefix     string // e.g. "HIVE_HUB_OIDC_GOOGLE"
+	scopes        []string
+	// subjectClaim overrides which id_token claim carries the STABLE per-user
+	// identifier. Empty means the OIDC-standard "sub". IBMid does not advertise
+	// "sub" in its discovery claims_supported — its stable identifier is "uid"
+	// (an IBMid serial); preferred_username/email are reassignable and must NOT
+	// be the key. An env override (<PREFIX>_SUBJECT_CLAIM) lets us retune from a
+	// real token without a code change if IBMid does emit a usable "sub".
+	subjectClaim string
+	// multiTenant marks a provider whose issuer is per-tenant (Microsoft Entra
+	// common/organizations). When set, <PREFIX>_TENANT selects the tenant segment
+	// used for DISCOVERY ("common"/"organizations"/a specific directory GUID),
+	// while token validation uses issuerTemplateFmt with a "{tenantid}" marker so
+	// each token's real tenant is matched + namespaced.
+	multiTenant bool
+	// issuerTemplateFmt is the issuer with a "%s" for the tenant segment, e.g.
+	// "https://login.microsoftonline.com/%s/v2.0".
+	issuerTemplateFmt string
+}
+
+// oidcSpecs is the closed set of OIDC providers the hub can enable. A provider is
+// enabled iff its <PREFIX>_CLIENT_ID env var is set — mirroring the GitHub OAuth
+// gate (HIVE_HUB_OAUTH_CLIENT_ID). Order here is the fallback display order among
+// OIDC providers.
+var oidcSpecs = []oidcProviderSpec{
+	{
+		name:          "google",
+		display:       "Google",
+		defaultIssuer: "https://accounts.google.com",
+		envPrefix:     "HIVE_HUB_OIDC_GOOGLE",
+		scopes:        []string{"openid", "email", "profile"},
+	},
+	{
+		name:          "ibmid",
+		display:       "IBMid",
+		defaultIssuer: "", // tenant-specific (IBM App ID / w3id): must set _ISSUER
+		envPrefix:     "HIVE_HUB_OIDC_IBMID",
+		scopes:        []string{"openid", "email", "profile"},
+		// IBMid's discovery does not list "sub"; "uid" is the stable IBMid serial.
+		// Confirmed against the live IBMid discovery claims_supported (uid present,
+		// sub absent). Overridable via HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM.
+		subjectClaim: "uid",
+	},
+	{
+		name:          "redhat",
+		display:       "Red Hat",
+		defaultIssuer: "https://sso.redhat.com/auth/realms/redhat-external",
+		envPrefix:     "HIVE_HUB_OIDC_REDHAT",
+		scopes:        []string{"openid", "email", "profile"},
+	},
+	{
+		// Microsoft Entra ID (Azure AD). Multi-tenant capable: HIVE_HUB_OIDC_
+		// MICROSOFT_TENANT selects the tenant segment for discovery — a specific
+		// directory GUID for SINGLE-tenant, or "common"/"organizations" for
+		// MULTI-tenant. In multi-tenant mode each token's real tenant is validated
+		// against the issuer template and the subject is namespaced per tenant;
+		// HIVE_HUB_OIDC_MICROSOFT_ALLOWED_TENANTS optionally restricts which tenants
+		// may sign in. Free to set up: any Microsoft 365 / Entra tenant (incl. the
+		// free M365 Developer Program) can register an app at no cost.
+		name:              "microsoft",
+		display:           "Microsoft",
+		envPrefix:         "HIVE_HUB_OIDC_MICROSOFT",
+		scopes:            []string{"openid", "email", "profile"},
+		multiTenant:       true,
+		issuerTemplateFmt: "https://login.microsoftonline.com/%s/v2.0",
+	},
+	{
+		// Generic/BYO OIDC provider. Lets an operator wire ANY standards-compliant
+		// OIDC IdP (Okta, Auth0, Microsoft Entra single-tenant, Keycloak, Ping,
+		// ForgeRock, Dex, Cognito, …) with no code change — everything comes from
+		// env. The issuer MUST be provided (no default); the display label defaults
+		// to "Single Sign-On" but is overridable via _DISPLAY. Its canonical
+		// provider slug is "custom", so users key as custom:<sub>.
+		name:          "custom",
+		display:       "Single Sign-On",
+		defaultIssuer: "", // must set HIVE_HUB_OIDC_CUSTOM_ISSUER
+		envPrefix:     "HIVE_HUB_OIDC_CUSTOM",
+		scopes:        []string{"openid", "email", "profile"},
+	},
+}
+
+// BuildRegistry assembles the enabled human-login providers from the environment.
+//
+//   - githubClientID: the hub's existing HIVE_HUB_OAUTH_CLIENT_ID. When non-empty,
+//     GitHub is added as the first (non-OIDC) provider using the passed endpoints
+//     (the hub already has these as vars for its test seam).
+//   - Each OIDC spec is enabled iff <PREFIX>_CLIENT_ID is set; it reads
+//     _CLIENT_SECRET and an optional _ISSUER override (required when the spec has
+//     no default issuer).
+//
+// A provider whose env is present but invalid (e.g. IBMid with no issuer) is
+// SKIPPED, not fatal — a misconfigured provider must never take down login for
+// the working ones.
+func BuildRegistry(githubClientID, ghAuthorizeURL, ghTokenURL string) *Registry {
+	reg := &Registry{byName: map[string]*Provider{}}
+
+	if githubClientID != "" {
+		gh := &Provider{
+			Name:         "github",
+			DisplayName:  "GitHub",
+			IsOIDC:       false,
+			AuthorizeURL: ghAuthorizeURL,
+			TokenURL:     ghTokenURL,
+			ClientID:     githubClientID,
+			Scopes:       []string{""},
+		}
+		reg.providers = append(reg.providers, gh)
+		reg.byName[gh.Name] = gh
+	}
+
+	var oidc []*Provider
+	for _, spec := range oidcSpecs {
+		clientID := os.Getenv(spec.envPrefix + "_CLIENT_ID")
+		if clientID == "" {
+			continue // provider not configured → not enabled
+		}
+		// Resolve issuer. Multi-tenant providers (Microsoft Entra) derive it from a
+		// tenant segment; everyone else uses _ISSUER or the spec default.
+		var issuer, issuerTemplate string
+		var allowedTenants []string
+		if spec.multiTenant {
+			tenant := strings.TrimSpace(os.Getenv(spec.envPrefix + "_TENANT"))
+			if tenant == "" {
+				tenant = "organizations" // sensible default: any work/school Entra org
+			}
+			issuer = fmt.Sprintf(spec.issuerTemplateFmt, tenant)
+			// A concrete directory GUID is single-tenant (strict issuer); the
+			// well-known multi-tenant segments need the {tenantid} template so each
+			// token's real tenant is validated + namespaced.
+			if tenant == "common" || tenant == "organizations" || tenant == "consumers" {
+				issuerTemplate = fmt.Sprintf(spec.issuerTemplateFmt, "{tenantid}")
+			}
+			if a := strings.TrimSpace(os.Getenv(spec.envPrefix + "_ALLOWED_TENANTS")); a != "" {
+				allowedTenants = splitScopes(a) // reuse comma/space splitter
+			}
+		} else {
+			issuer = os.Getenv(spec.envPrefix + "_ISSUER")
+			if issuer == "" {
+				issuer = spec.defaultIssuer
+			}
+		}
+		if issuer == "" {
+			// Configured client id but no issuer we can use → skip, don't crash.
+			continue
+		}
+		// Optional per-provider env overrides. These matter most for the generic
+		// "custom" provider (whose brand/label/scopes we can't know in advance),
+		// but are honored for any provider so an operator can retune without code.
+		display := spec.display
+		if d := strings.TrimSpace(os.Getenv(spec.envPrefix + "_DISPLAY")); d != "" {
+			display = d
+		}
+		scopes := spec.scopes
+		if s := strings.TrimSpace(os.Getenv(spec.envPrefix + "_SCOPES")); s != "" {
+			scopes = splitScopes(s)
+		}
+		// Subject claim: env override wins, else the spec default (e.g. IBMid "uid"),
+		// else empty → the verifier falls back to the OIDC-standard "sub".
+		subjectClaim := strings.TrimSpace(os.Getenv(spec.envPrefix + "_SUBJECT_CLAIM"))
+		if subjectClaim == "" {
+			subjectClaim = spec.subjectClaim
+		}
+		p := &Provider{
+			Name:           spec.name,
+			DisplayName:    display,
+			IsOIDC:         true,
+			Issuer:         strings.TrimRight(issuer, "/"),
+			IssuerTemplate: strings.TrimRight(issuerTemplate, "/"),
+			AllowedTenants: allowedTenants,
+			ClientID:       clientID,
+			ClientSecret:   os.Getenv(spec.envPrefix + "_CLIENT_SECRET"),
+			Scopes:         scopes,
+			SubjectClaim:   subjectClaim,
+		}
+		oidc = append(oidc, p)
+	}
+	// Stable display order among OIDC providers: by display name.
+	sort.Slice(oidc, func(i, j int) bool { return oidc[i].DisplayName < oidc[j].DisplayName })
+	for _, p := range oidc {
+		reg.providers = append(reg.providers, p)
+		reg.byName[p.Name] = p
+	}
+	return reg
+}

--- a/v2/pkg/hub/admin_gate_test.go
+++ b/v2/pkg/hub/admin_gate_test.go
@@ -1,0 +1,70 @@
+package hub
+
+import "testing"
+
+// TestIsHubAdmin_DefaultAndLegacyShim: with no HIVE_HUB_ADMINS, the default
+// admin (github:<hubAdminUsername>) matches whether presented bare-legacy or
+// canonical. On v4 hubAdminUsername is itself resolved once at init from
+// HIVE_HUB_ADMIN_USERNAME (falling back to "clubanderson"); the multi-admin
+// gate layers on top of that resolved value.
+func TestIsHubAdmin_DefaultAndLegacyShim(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "") // force default
+
+	for _, id := range []string{hubAdminUsername, "github:" + hubAdminUsername, "GitHub:ClubAnderson"} {
+		if !isHubAdmin(id) {
+			t.Errorf("isHubAdmin(%q) = false, want true (default admin, legacy/canonical/case)", id)
+		}
+	}
+	for _, id := range []string{"", "someone-else", "github:someone-else"} {
+		if isHubAdmin(id) {
+			t.Errorf("isHubAdmin(%q) = true, want false", id)
+		}
+	}
+}
+
+// TestIsHubAdmin_CrossProviderIsNotAdmin is the load-bearing security property
+// (plan Risk #1): a user whose SUBJECT happens to be the admin's login on a
+// DIFFERENT provider must NOT inherit GitHub admin. If this ever passes as true,
+// registering the admin's name on Google/IBMid would grant admin.
+func TestIsHubAdmin_CrossProviderIsNotAdmin(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "")
+	for _, provider := range []string{"google", "ibmid", "redhat", "microsoft", "custom"} {
+		id := provider + ":" + hubAdminUsername
+		if isHubAdmin(id) {
+			t.Fatalf("SECURITY: isHubAdmin(%q) = true — a same-subject identity on another provider must NEVER be admin", id)
+		}
+	}
+}
+
+// TestIsHubAdmin_EnvOverride: HIVE_HUB_ADMINS replaces the default set and
+// accepts both bare-legacy and canonical (incl. non-GitHub) entries.
+func TestIsHubAdmin_EnvOverride(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "github:alice, google:1078, bob")
+
+	for _, id := range []string{"alice", "github:alice", "google:1078", "bob", "github:bob"} {
+		if !isHubAdmin(id) {
+			t.Errorf("isHubAdmin(%q) = false, want true under env override", id)
+		}
+	}
+	// The default is NO LONGER admin once the env overrides the set.
+	if isHubAdmin(hubAdminUsername) {
+		t.Errorf("isHubAdmin(%q) should be false when HIVE_HUB_ADMINS excludes it", hubAdminUsername)
+	}
+	// Cross-provider still isolated.
+	if isHubAdmin("google:alice") {
+		t.Error("google:alice must not match github:alice admin entry")
+	}
+}
+
+// TestPrimaryHubAdmin returns the canonical primary admin — the first env entry,
+// else the canonicalized default.
+func TestPrimaryHubAdmin(t *testing.T) {
+	t.Setenv(hubAdminsEnv, "")
+	if got := primaryHubAdmin(); got != "github:"+hubAdminUsername {
+		t.Errorf("primaryHubAdmin() default = %q, want github:%s", got, hubAdminUsername)
+	}
+	t.Setenv(hubAdminsEnv, "google:1078, github:alice")
+	if got := primaryHubAdmin(); got != "google:1078" {
+		t.Errorf("primaryHubAdmin() = %q, want google:1078 (first env entry)", got)
+	}
+}

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -357,7 +357,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can switch forges"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/forge.go
+++ b/v2/pkg/hub/forge.go
@@ -357,7 +357,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can switch forges"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/identity.go
+++ b/v2/pkg/hub/identity.go
@@ -344,7 +344,7 @@ func SpokeIdentityFromPayload(p *HeartbeatPayload) IdentitySet {
 // are untouched, so a reset on a healthy hive costs one re-install rather than
 // an outage.
 func (s *HubServer) handleResetApp(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/identity_canonical.go
+++ b/v2/pkg/hub/identity_canonical.go
@@ -1,0 +1,221 @@
+package hub
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Canonical identity for a HUMAN hub/spoke user.
+//
+// Historically a user WAS their GitHub login: that one bare string was the
+// session-cookie subject, the on-disk user key, the map key for hive grants, and
+// the admin comparison value. To support additional login providers (Google,
+// IBMid, Red Hat) without collisions or cross-provider impersonation, an identity
+// is now a canonical `provider:subject` pair.
+//
+// This is strictly about WHO A HUMAN IS for login + access control. It has
+// nothing to do with the GitHub App installation token (kubestellar-hive[bot])
+// that performs the hive's actual GitHub work, nor with agent/backend logins.
+//
+// Two representations exist:
+//
+//	wire form      "github:clubanderson", "google:1078...":
+//	               used in cookies, X-Hive-User, SaaSUser.Hives keys, Owner
+//	               fields, authorized_users. The signed-cookie machinery signs an
+//	               opaque string, so it carries a canonical id with no change.
+//	filename form  "github.clubanderson", "google.1078...":
+//	               path-safe on-disk key that stays inside safeNamePattern
+//	               (^[a-zA-Z0-9._-]+$), so isValidName and the load/save traversal
+//	               guards keep protecting the storage layer unchanged.
+
+// identityProviders is the fixed, closed set of login providers. A provider name
+// contains no '.', which is what lets the filename form split provider from
+// subject on the FIRST dot. Extend this set (not the parsing) to add a provider.
+var identityProviders = map[string]bool{
+	"github": true,
+	"google": true,
+	"ibmid":  true,
+	"redhat": true,
+	// Generic/BYO OIDC provider (operator-configured: Okta, Auth0, Entra,
+	// Keycloak, …). Its subjects are namespaced as custom:<sub>, distinct from
+	// every branded provider, so an operator's IdP can never collide identities
+	// with github:/google:/etc.
+	"custom": true,
+	// Microsoft Entra ID (Azure AD), single- or multi-tenant. Multi-tenant subjects
+	// are namespaced per Entra tenant inside the OIDC layer before this sees them.
+	"microsoft": true,
+}
+
+// legacyProvider is the provider a bare, un-namespaced key is assumed to belong
+// to. Every user before multi-provider login was a GitHub login, so a key with
+// no "provider:" prefix means GitHub. This is the backward-compat shim: existing
+// user files, cookies, and grants keep resolving with no data migration.
+const legacyProvider = "github"
+
+// canonicalSeparator joins provider and subject in the WIRE form.
+const canonicalSeparator = ":"
+
+// maxCanonicalLen bounds the wire form, matching isValidName's len<=100 budget so
+// a canonical id round-trips through the existing name validation.
+const maxCanonicalLen = 100
+
+// makeCanonical builds the wire form "provider:subject" from a provider name and
+// the provider's stable subject (the OIDC `sub`, or the GitHub login). It
+// validates the provider is known, the subject is non-empty and free of the
+// separator and path-hostile characters, and the total length fits. The subject
+// charset is deliberately the same safe set used on disk so the value survives
+// both the cookie/header path and the filename encoding.
+func makeCanonical(provider, subject string) (string, error) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	subject = strings.TrimSpace(subject)
+	if !identityProviders[provider] {
+		return "", fmt.Errorf("unknown identity provider %q", provider)
+	}
+	if subject == "" {
+		return "", fmt.Errorf("empty subject for provider %q", provider)
+	}
+	if strings.ContainsAny(subject, ":/\\") || strings.Contains(subject, "..") {
+		return "", fmt.Errorf("subject %q contains a reserved character", subject)
+	}
+	id := provider + canonicalSeparator + subject
+	if len(id) > maxCanonicalLen {
+		return "", fmt.Errorf("canonical id exceeds %d bytes", maxCanonicalLen)
+	}
+	return id, nil
+}
+
+// parseCanonical splits a wire-form canonical id into provider and subject. A
+// bare, un-namespaced string is treated as a legacy GitHub login (the shim), so
+// callers may pass either form. Returns ok=false only for a malformed value
+// (empty, unknown provider, empty subject).
+func parseCanonical(id string) (provider, subject string, ok bool) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", "", false
+	}
+	before, after, found := strings.Cut(id, canonicalSeparator)
+	if !found {
+		// Bare login → legacy GitHub identity.
+		return legacyProvider, id, true
+	}
+	provider = strings.ToLower(before)
+	subject = after
+	if !identityProviders[provider] || subject == "" {
+		return "", "", false
+	}
+	return provider, subject, true
+}
+
+// canonicalizeLegacy normalizes any identity string to its canonical wire form:
+// an already-namespaced key (contains the separator) is returned as-is; a bare
+// key is promoted to "github:<key>". This is applied at BOTH sides of every
+// ownership/admin comparison so a legacy stored value ("clubanderson") matches an
+// authenticated canonical id ("github:clubanderson") and vice-versa — the core of
+// the zero-downtime migration shim.
+func canonicalizeLegacy(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	if strings.Contains(id, canonicalSeparator) {
+		return id
+	}
+	return legacyProvider + canonicalSeparator + id
+}
+
+// canonicalEqual reports whether two identity strings denote the same user,
+// tolerant of legacy (bare) vs canonical form and case-insensitive on the
+// GitHub-login subject (GitHub logins are case-insensitive; OIDC subs are exact
+// but a case-fold on an opaque sub is harmless because two subs that differ only
+// by case are not issued). Use this in place of raw string / EqualFold(Owner,…)
+// comparisons.
+func canonicalEqual(a, b string) bool {
+	return strings.EqualFold(canonicalizeLegacy(a), canonicalizeLegacy(b))
+}
+
+// filenameHexUpper is the alphabet for the "-XX-" escape used by
+// encodeUserFilename. Uppercase hex stays inside safeNamePattern.
+const filenameHexUpper = "0123456789ABCDEF"
+
+// encodeUserFilename maps a canonical (or legacy) identity to a path-safe on-disk
+// stem that matches safeNamePattern (^[a-zA-Z0-9._-]+$). The result is
+// "<provider>.<encodedSubject>": the provider name has no dot, so the first dot
+// unambiguously separates it from the subject. Any subject byte outside
+// [A-Za-z0-9_-] (dot included, to keep the split unambiguous) is escaped as
+// "-XX-" hex. github/google/ibmid/redhat subjects are already in this set, so in
+// practice the encoding is the identity for real ids and files read cleanly as
+// "github.clubanderson", "google.1078...".
+//
+// A bare legacy key encodes to the SAME stem the pre-migration code wrote
+// (a plain GitHub login is [a-zA-Z0-9-] with optional dots), so the load path can
+// dual-read: try this encoding, then the legacy "<login>" stem. See loadSaaSUser.
+func encodeUserFilename(id string) (string, error) {
+	provider, subject, ok := parseCanonical(id)
+	if !ok {
+		return "", fmt.Errorf("cannot encode invalid identity %q", id)
+	}
+	var b strings.Builder
+	b.WriteString(provider)
+	b.WriteByte('.')
+	for i := 0; i < len(subject); i++ {
+		c := subject[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('-')
+		b.WriteByte(filenameHexUpper[c>>4])
+		b.WriteByte(filenameHexUpper[c&0x0f])
+		b.WriteByte('-')
+	}
+	stem := b.String()
+	if !isValidName(stem) {
+		return "", fmt.Errorf("encoded filename %q is not path-safe", stem)
+	}
+	return stem, nil
+}
+
+// decodeUserFilename is the inverse of encodeUserFilename: it turns an on-disk
+// stem back into a canonical wire-form id. Used when enumerating the user store
+// so a listed user carries its canonical identity. Returns ok=false for a stem
+// that is not a valid encoding (e.g. a legacy bare "<login>" stem with no
+// provider dot — the caller falls back to treating it as a legacy GitHub login).
+func decodeUserFilename(stem string) (string, bool) {
+	provider, encSubject, found := strings.Cut(stem, ".")
+	if !found || !identityProviders[strings.ToLower(provider)] {
+		return "", false
+	}
+	provider = strings.ToLower(provider)
+	var b strings.Builder
+	for i := 0; i < len(encSubject); {
+		c := encSubject[i]
+		if c == '-' && i+3 < len(encSubject) && encSubject[i+3] == '-' {
+			hi := hexVal(encSubject[i+1])
+			lo := hexVal(encSubject[i+2])
+			if hi >= 0 && lo >= 0 {
+				b.WriteByte(byte(hi<<4 | lo))
+				i += 4
+				continue
+			}
+		}
+		b.WriteByte(c)
+		i++
+	}
+	id, err := makeCanonical(provider, b.String())
+	if err != nil {
+		return "", false
+	}
+	return id, true
+}
+
+func hexVal(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	}
+	return -1
+}

--- a/v2/pkg/hub/identity_canonical_test.go
+++ b/v2/pkg/hub/identity_canonical_test.go
@@ -1,0 +1,127 @@
+package hub
+
+import "testing"
+
+func TestMakeCanonical(t *testing.T) {
+	cases := []struct {
+		provider, subject, want string
+		ok                      bool
+	}{
+		{"github", "clubanderson", "github:clubanderson", true},
+		{"google", "1078xxxx", "google:1078xxxx", true},
+		{"GitHub", "Foo-Bar", "github:Foo-Bar", true}, // provider lowercased
+		{"ibmid", "abc.def", "ibmid:abc.def", true},   // dot allowed in subject (wire form)
+		{"redhat", "s_1", "redhat:s_1", true},
+		{"unknown", "x", "", false},  // unknown provider
+		{"github", "", "", false},    // empty subject
+		{"github", "a:b", "", false}, // separator in subject
+		{"github", "a/b", "", false}, // path char
+		{"github", "..", "", false},  // traversal
+	}
+	for _, c := range cases {
+		got, err := makeCanonical(c.provider, c.subject)
+		if c.ok {
+			if err != nil || got != c.want {
+				t.Errorf("makeCanonical(%q,%q) = %q,%v want %q", c.provider, c.subject, got, err, c.want)
+			}
+		} else if err == nil {
+			t.Errorf("makeCanonical(%q,%q) = %q, want error", c.provider, c.subject, got)
+		}
+	}
+}
+
+func TestParseCanonicalAndLegacyShim(t *testing.T) {
+	// Bare login → legacy github (the shim).
+	if p, s, ok := parseCanonical("clubanderson"); !ok || p != "github" || s != "clubanderson" {
+		t.Errorf("parseCanonical(bare) = %q,%q,%v", p, s, ok)
+	}
+	// Already-canonical passes through.
+	if p, s, ok := parseCanonical("google:1078"); !ok || p != "google" || s != "1078" {
+		t.Errorf("parseCanonical(canonical) = %q,%q,%v", p, s, ok)
+	}
+	// Unknown provider → not ok.
+	if _, _, ok := parseCanonical("bogus:x"); ok {
+		t.Error("parseCanonical(bogus:x) should be !ok")
+	}
+	// canonicalizeLegacy.
+	for in, want := range map[string]string{
+		"clubanderson":        "github:clubanderson",
+		"github:clubanderson": "github:clubanderson",
+		"google:1078":         "google:1078",
+		"":                    "",
+	} {
+		if got := canonicalizeLegacy(in); got != want {
+			t.Errorf("canonicalizeLegacy(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCanonicalEqual is the load-bearing migration property: a legacy stored
+// value matches an authenticated canonical id, and — critically — a same-subject
+// identity on a DIFFERENT provider does NOT match (cross-provider defense).
+func TestCanonicalEqual(t *testing.T) {
+	if !canonicalEqual("clubanderson", "github:clubanderson") {
+		t.Error("legacy bare login must equal github: canonical")
+	}
+	if !canonicalEqual("GitHub:ClubAnderson", "github:clubanderson") {
+		t.Error("github identity compare must be case-insensitive")
+	}
+	if canonicalEqual("google:clubanderson", "github:clubanderson") {
+		t.Fatal("SECURITY: google:clubanderson must NOT equal github:clubanderson")
+	}
+	if canonicalEqual("google:clubanderson", "clubanderson") {
+		t.Fatal("SECURITY: google:clubanderson must NOT equal a legacy github login")
+	}
+}
+
+func TestFilenameRoundTrip(t *testing.T) {
+	ids := []string{
+		"github:clubanderson",
+		"github:foo-bar",
+		"github:foo.bar",
+		"google:1078901234567890",
+		"ibmid:ABCDEF-0123",
+		"redhat:user_name",
+		"github:name+with@odd.chars", // exercises the -XX- escape
+	}
+	for _, id := range ids {
+		stem, err := encodeUserFilename(id)
+		if err != nil {
+			t.Fatalf("encodeUserFilename(%q): %v", id, err)
+		}
+		if !isValidName(stem) {
+			t.Errorf("encoded stem %q for %q is not path-safe", stem, id)
+		}
+		back, ok := decodeUserFilename(stem)
+		if !ok {
+			t.Fatalf("decodeUserFilename(%q) not ok (from %q)", stem, id)
+		}
+		// makeCanonical was applied on encode side (parseCanonical) so compare canonical forms.
+		if canonicalizeLegacy(back) != canonicalizeLegacy(id) {
+			t.Errorf("round-trip: %q -> %q -> %q", id, stem, back)
+		}
+	}
+}
+
+// TestLegacyFilenameStemMatches pins that a bare GitHub login encodes to a stem
+// whose provider is github and subject is the login — so the load path can map a
+// canonical github id to a file while a legacy "<login>.json" still resolves via
+// the dual-read fallback (asserted here structurally).
+func TestLegacyFilenameStemMatches(t *testing.T) {
+	stem, err := encodeUserFilename("clubanderson") // bare → github:clubanderson
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stem != "github.clubanderson" {
+		t.Errorf("bare login stem = %q, want github.clubanderson", stem)
+	}
+	back, ok := decodeUserFilename(stem)
+	if !ok || back != "github:clubanderson" {
+		t.Errorf("decode(%q) = %q,%v", stem, back, ok)
+	}
+	// A pre-migration legacy stem (no provider dot in the github sense) with a
+	// dot in the login must NOT be misread as a provider split.
+	if _, ok := decodeUserFilename("someuser"); ok {
+		t.Error("a bare legacy stem with no provider prefix must decode !ok (caller falls back to legacy github)")
+	}
+}

--- a/v2/pkg/hub/identity_custom_test.go
+++ b/v2/pkg/hub/identity_custom_test.go
@@ -1,0 +1,33 @@
+package hub
+
+import "testing"
+
+// TestCanonical_CustomProvider: the generic "custom" provider is a first-class
+// canonical namespace, distinct from every branded provider, and it accepts the
+// real-world OIDC subject shapes IdPs emit (Okta/Auth0 subs contain '|').
+func TestCanonical_CustomProvider(t *testing.T) {
+	// A path-hostile subject (contains ':') is still rejected.
+	if _, err := makeCanonical("custom", "a:b"); err == nil {
+		t.Fatal("subject with ':' must be rejected")
+	}
+	// A realistic Okta-style subject ('|' is allowed) round-trips, and its
+	// on-disk filename stays path-safe via the -XX- escape.
+	id, err := makeCanonical("custom", "okta|00u123")
+	if err != nil {
+		t.Fatalf("makeCanonical(custom, okta|00u123): %v", err)
+	}
+	if id != "custom:okta|00u123" {
+		t.Errorf("id = %q", id)
+	}
+	stem, err := encodeUserFilename(id)
+	if err != nil {
+		t.Fatalf("encodeUserFilename: %v", err)
+	}
+	if got, ok := decodeUserFilename(stem); !ok || got != id {
+		t.Errorf("filename round-trip: stem=%q got=%q ok=%v", stem, got, ok)
+	}
+	// Cross-provider isolation: custom:x is NOT github:x.
+	if canonicalEqual("custom:x", "github:x") {
+		t.Error("custom:x must NOT equal github:x — cross-provider collision")
+	}
+}

--- a/v2/pkg/hub/multilogin_coverage_gaps_test.go
+++ b/v2/pkg/hub/multilogin_coverage_gaps_test.go
@@ -1,0 +1,195 @@
+package hub
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestSaaSUserFilePaths_NonGitHubHasNoLegacyFallback: a non-GitHub provider
+// (google, ibmid, redhat) produces ONLY the canonical filename path — there is
+// no legacy "<subject>.json" to try. A bug here would make loadSaaSUser read
+// the wrong file or miss a canonical record entirely.
+func TestSaaSUserFilePaths_NonGitHubHasNoLegacyFallback(t *testing.T) {
+	paths := saaSUserFilePaths("google:1078")
+	if len(paths) != 1 {
+		t.Fatalf("saaSUserFilePaths(google:1078) = %v, want exactly 1 path", paths)
+	}
+	if filepath.Base(paths[0]) != "google.1078.json" {
+		t.Errorf("expected google.1078.json, got %q", filepath.Base(paths[0]))
+	}
+}
+
+// TestSaaSUserFilePaths_GitHubHasLegacyFallback: a github: or bare identity
+// produces TWO paths — canonical first, then legacy fallback.
+func TestSaaSUserFilePaths_GitHubHasLegacyFallback(t *testing.T) {
+	for _, id := range []string{"github:alice", "alice"} {
+		paths := saaSUserFilePaths(id)
+		if len(paths) != 2 {
+			t.Fatalf("saaSUserFilePaths(%q) = %v, want 2 paths", id, paths)
+		}
+		if filepath.Base(paths[0]) != "github.alice.json" {
+			t.Errorf("first path for %q: got %q, want github.alice.json", id, filepath.Base(paths[0]))
+		}
+		if filepath.Base(paths[1]) != "alice.json" {
+			t.Errorf("second path for %q: got %q, want alice.json", id, filepath.Base(paths[1]))
+		}
+	}
+}
+
+// TestSaveSaaSUserPath_InvalidIdentityErrors: saveSaaSUserPath must reject a
+// GitHubUsername that does not parse as a valid canonical identity. A silent
+// fallback here could write user data to a garbage path.
+func TestSaveSaaSUserPath_InvalidIdentityErrors(t *testing.T) {
+	_, err := saveSaaSUserPath(&SaaSUser{GitHubUsername: ""})
+	if err == nil {
+		t.Error("saveSaaSUserPath with empty identity should error")
+	}
+	_, err = saveSaaSUserPath(&SaaSUser{GitHubUsername: "bogus:x"})
+	if err == nil {
+		t.Error("saveSaaSUserPath with unknown provider should error")
+	}
+}
+
+// TestEnsureSaaSUser_CanonicalAdminGetsUnlimitedQuota: when a hub admin logs in
+// with a canonical identity ("github:clubanderson"), ensureSaaSUser must assign
+// quota=-1 (unlimited). A failure here means the admin loses unlimited quota on
+// the multi-provider path and hits rate limits on their own hub.
+func TestEnsureSaaSUser_CanonicalAdminGetsUnlimitedQuota(t *testing.T) {
+	dir := withTempUsersDir(t)
+	_ = dir
+
+	// Default admin is github:clubanderson. Bare and canonical forms should
+	// both produce quota=-1.
+	for _, id := range []string{"clubanderson", "github:clubanderson"} {
+		u := ensureSaaSUser(id)
+		if u == nil {
+			t.Fatalf("ensureSaaSUser(%q) returned nil", id)
+		}
+		if u.SaaSQuota != -1 {
+			t.Errorf("ensureSaaSUser(%q).SaaSQuota = %d, want -1 (unlimited for admin)", id, u.SaaSQuota)
+		}
+	}
+
+	// A non-admin user gets quota=0.
+	u := ensureSaaSUser("someuser")
+	if u == nil {
+		t.Fatal("ensureSaaSUser(someuser) returned nil")
+	}
+	if u.SaaSQuota != 0 {
+		t.Errorf("ensureSaaSUser(someuser).SaaSQuota = %d, want 0", u.SaaSQuota)
+	}
+}
+
+// TestEnsureSaaSUser_ExistingUserUpdatesLastLogin: when ensureSaaSUser finds a
+// pre-existing record, it updates LastLogin and saves. A regression here would
+// silently stop tracking login recency.
+func TestEnsureSaaSUser_ExistingUserUpdatesLastLogin(t *testing.T) {
+	dir := withTempUsersDir(t)
+	writeRawUser(t, dir, "existing.json", SaaSUser{
+		GitHubUsername: "existing",
+		CreatedAt:      "2024-01-01T00:00:00Z",
+		LastLogin:      "2024-01-01T00:00:00Z",
+		Hives:          map[string]string{},
+	})
+
+	u := ensureSaaSUser("existing")
+	if u == nil {
+		t.Fatal("ensureSaaSUser(existing) returned nil")
+	}
+	if u.LastLogin == "2024-01-01T00:00:00Z" {
+		t.Error("ensureSaaSUser should update LastLogin, but it was not changed")
+	}
+	if u.CreatedAt != "2024-01-01T00:00:00Z" {
+		t.Errorf("ensureSaaSUser should preserve CreatedAt, got %q", u.CreatedAt)
+	}
+}
+
+// TestListAllSaaSUsers_DuplicateFiles: if both "alice.json" (legacy) AND
+// "github.alice.json" (canonical) exist on disk — possible during a partial
+// migration — listAllSaaSUsers returns entries for both filenames. This test
+// documents the current behavior so a future dedup does not regress silently.
+func TestListAllSaaSUsers_DuplicateFiles(t *testing.T) {
+	dir := withTempUsersDir(t)
+	writeRawUser(t, dir, "alice.json", SaaSUser{GitHubUsername: "alice"})
+	writeRawUser(t, dir, "github.alice.json", SaaSUser{GitHubUsername: "github:alice"})
+
+	users := listAllSaaSUsers()
+	// Both files are enumerated. The legacy "alice.json" loads as "alice", the
+	// canonical "github.alice.json" decodes to "github:alice" and also loads
+	// (the dual-read finds the canonical file). Count how many we get.
+	count := 0
+	for _, u := range users {
+		if u.GitHubUsername == "alice" || u.GitHubUsername == "github:alice" {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Errorf("expected both legacy and canonical entries enumerated, got %d matching users out of %v", count, users)
+	}
+}
+
+// TestReadSaaSUserFile_NonExistentReturnsError: readSaaSUserFile for a user with
+// no file on disk returns an error (not nil data).
+func TestReadSaaSUserFile_NonExistentReturnsError(t *testing.T) {
+	_ = withTempUsersDir(t)
+	data, err := readSaaSUserFile("no-such-user")
+	if err == nil {
+		t.Errorf("readSaaSUserFile(no-such-user) returned nil error with data=%v", data)
+	}
+}
+
+// TestEnsureSaaSUser_EnvOverrideAdminQuota: when HIVE_HUB_ADMINS overrides the
+// admin set, ensureSaaSUser gives unlimited quota to the NEW admin and quota=0
+// to the old default admin (since they are no longer in the set).
+func TestEnsureSaaSUser_EnvOverrideAdminQuota(t *testing.T) {
+	_ = withTempUsersDir(t)
+	t.Setenv("HIVE_HUB_ADMINS", "github:newadmin")
+
+	u := ensureSaaSUser("newadmin")
+	if u == nil {
+		t.Fatal("ensureSaaSUser(newadmin) returned nil")
+	}
+	if u.SaaSQuota != -1 {
+		t.Errorf("ensureSaaSUser(newadmin).SaaSQuota = %d, want -1 (new admin)", u.SaaSQuota)
+	}
+
+	// Old default admin is no longer in the set → quota=0.
+	u2 := ensureSaaSUser("clubanderson")
+	if u2 == nil {
+		t.Fatal("ensureSaaSUser(clubanderson) returned nil")
+	}
+	if u2.SaaSQuota != 0 {
+		t.Errorf("ensureSaaSUser(clubanderson).SaaSQuota = %d, want 0 (not admin when overridden)", u2.SaaSQuota)
+	}
+}
+
+// TestCanonicalEqual_OwnerMatchSites: the owner-match change at ~10 HTTP handler
+// sites replaced EqualFold/== with canonicalEqual. This test asserts the specific
+// identity pairs those sites will encounter: a bare Owner field stored on-disk
+// matched against the authenticated canonical identity from the session cookie.
+func TestCanonicalEqual_OwnerMatchSites(t *testing.T) {
+	cases := []struct {
+		owner, authenticated string
+		want                 bool
+	}{
+		// Legacy owner, canonical auth — the core migration shim.
+		{"clubanderson", "github:clubanderson", true},
+		// Legacy owner, bare auth — pre-migration path, still works.
+		{"clubanderson", "clubanderson", true},
+		// Case-insensitive GitHub login.
+		{"ClubAnderson", "github:clubanderson", true},
+		// SECURITY: cross-provider owner spoof must fail.
+		{"clubanderson", "google:clubanderson", false},
+		{"clubanderson", "ibmid:clubanderson", false},
+		// Non-GitHub owner matches its own canonical form.
+		{"google:1078", "google:1078", true},
+		// Non-GitHub owner does NOT match a different provider.
+		{"google:1078", "ibmid:1078", false},
+	}
+	for _, c := range cases {
+		got := canonicalEqual(c.owner, c.authenticated)
+		if got != c.want {
+			t.Errorf("canonicalEqual(%q, %q) = %v, want %v", c.owner, c.authenticated, got, c.want)
+		}
+	}
+}

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -420,7 +420,7 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 	// Fold impersonation status into the auth payload the dashboard already
 	// fetches, so the "Viewing as … read-only" banner renders without a second
 	// round-trip. When an admin is impersonating, report the effective identity

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -6,17 +6,29 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/auth"
 )
 
 const (
 	oauthTimeout     = 10 * time.Second
 	cookieMaxAgeDays = 7 // login session cookie lifetime
+
+	// oauthRedirectURI is the single OAuth/OIDC callback registered on every
+	// provider's side. All providers share one callback path; the state parameter
+	// carries which provider to complete against.
+	oauthRedirectURI = "https://hive.kubestellar.io/api/auth/callback"
+
+	// oidcNonceCookieName holds the per-login OIDC replay nonce. Host-scoped like
+	// the CSRF state cookie; the id_token must echo it back or the callback fails.
+	oidcNonceCookieName = "hive_oidc_nonce"
 )
 
 // These GitHub.com OAuth/API endpoints are vars (not consts) so tests can point
@@ -33,15 +45,34 @@ var (
 
 func (s *HubServer) registerOAuth() {
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
-	if clientID == "" {
-		s.logger.Info("hub OAuth disabled (no HIVE_HUB_OAUTH_CLIENT_ID)")
+
+	// Build the human-login provider set: GitHub (when its client id is set) plus
+	// any configured OIDC providers (Google/IBMid/Red Hat/Microsoft/custom —
+	// enabled iff their <PREFIX>_CLIENT_ID env is present). The GitHub endpoints
+	// come from the existing test-overridable vars so the auth registry shares the
+	// hub's seam.
+	s.authProviders = auth.BuildRegistry(clientID, defaultGHAuthorizeURL, defaultGHTokenURL)
+
+	// Nothing to serve if no provider at all is configured. Historically the hub
+	// keyed entirely on GitHub; now it stays "OAuth disabled" only when NEITHER
+	// GitHub nor any OIDC provider is set.
+	if s.authProviders.Count() == 0 {
+		s.logger.Info("hub OAuth disabled (no login provider configured)")
 		return
 	}
 	s.mux.HandleFunc("GET /login", s.handleLogin)
+	// Per-provider entry point. GitHub keeps its existing behavior; an OIDC
+	// provider ("google"/"ibmid"/"redhat"/…) starts the OIDC authorize.
+	s.mux.HandleFunc("GET /login/{provider}", s.handleProviderLogin)
 	s.mux.HandleFunc("GET /api/auth/callback", s.handleOAuthCallback)
 	s.mux.HandleFunc("GET /api/auth/user", s.handleAuthUser)
 	s.mux.HandleFunc("POST /api/auth/logout", s.handleLogout)
-	s.logger.Info("hub OAuth enabled", "client_id", clientID)
+
+	names := make([]string, 0, s.authProviders.Count())
+	for _, p := range s.authProviders.Providers() {
+		names = append(names, p.Name)
+	}
+	s.logger.Info("hub login enabled", "providers", strings.Join(names, ","), "github_client_id", clientID)
 }
 
 // linkPreviewUserAgents are the crawlers that fetch a URL purely to build a
@@ -157,14 +188,57 @@ func (s *HubServer) handleOGCard(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
+// handleLogin is the login entry point. With exactly one provider enabled
+// (today: GitHub) it redirects straight into that provider, preserving the
+// pre-multi-provider UX byte-for-byte. With more than one enabled it renders a
+// small provider picker; each button links to /login/{provider} carrying the
+// redirect target through.
 func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// Serve Hive's own card to preview crawlers instead of redirecting them into
-	// GitHub's OAuth page, whose Open Graph tags they would otherwise scrape.
+	// a provider's OAuth page, whose Open Graph tags they would otherwise scrape.
 	if isLinkPreviewCrawler(r) {
 		writeLinkPreview(w)
 		return
 	}
-	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
+	redirect := s.loginRedirectTarget(r)
+	providers := s.authProviders.Providers()
+	if len(providers) == 0 {
+		// Registry not built (a HubServer constructed without registerOAuth — the
+		// unit-test path) but GitHub is configured: behave as single-GitHub so the
+		// pre-multi-provider UX is preserved with no registry.
+		if gh := s.resolveProvider(legacyProvider); gh != nil {
+			s.startProviderLogin(w, r, gh, redirect)
+			return
+		}
+		http.Error(w, "login unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if len(providers) == 1 {
+		// Single provider: go straight in — no picker, unchanged UX.
+		s.startProviderLogin(w, r, providers[0], redirect)
+		return
+	}
+	s.writeProviderPicker(w, providers, redirect)
+}
+
+// handleProviderLogin starts login for a specific provider named in the path.
+func (s *HubServer) handleProviderLogin(w http.ResponseWriter, r *http.Request) {
+	if isLinkPreviewCrawler(r) {
+		writeLinkPreview(w)
+		return
+	}
+	name := r.PathValue("provider")
+	p := s.authProviders.Get(name)
+	if p == nil {
+		http.Error(w, "unknown login provider", http.StatusNotFound)
+		return
+	}
+	s.startProviderLogin(w, r, p, s.loginRedirectTarget(r))
+}
+
+// loginRedirectTarget extracts and validates the post-login redirect from the
+// request (?redirect= / ?rd=), defaulting to /dashboard for anything untrusted.
+func (s *HubServer) loginRedirectTarget(r *http.Request) string {
 	redirect := r.URL.Query().Get("redirect")
 	if redirect == "" {
 		redirect = r.URL.Query().Get("rd")
@@ -177,20 +251,26 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 			redirect = "/dashboard"
 		}
 	}
+	return redirect
+}
+
+// startProviderLogin mints the CSRF state nonce (and, for OIDC, the replay nonce)
+// and redirects the browser into the provider's authorize endpoint. GitHub keeps
+// its exact original request shape; OIDC providers get an OIDC nonce too.
+func (s *HubServer) startProviderLogin(w http.ResponseWriter, r *http.Request, p *auth.Provider, redirect string) {
 	// SECURITY (audit F11, CWE-352): bind this login to THIS browser.
 	//
 	// `state` used to be nothing but the redirect target, so it proved only that
 	// the callback carried a URL — never that this browser had actually STARTED
-	// a login. An attacker could complete an OAuth flow against their own GitHub
-	// account and hand the victim the resulting callback URL, logging the victim
-	// into the ATTACKER's account (login CSRF / session fixation); anything the
-	// victim then did landed in the attacker's account.
+	// a login. An attacker could complete an OAuth flow against their own account
+	// and hand the victim the resulting callback URL, logging the victim into the
+	// ATTACKER's account (login CSRF / session fixation).
 	//
 	// Mint an unguessable nonce, set it in a short-lived host-scoped cookie, and
 	// carry it in state. The callback requires the two to match, so a state the
-	// victim's browser did not mint cannot be replayed against them. The
-	// redirect target rides along after the separator and is still validated on
-	// the way out — the open-redirect half was already handled and is unchanged.
+	// victim's browser did not mint cannot be replayed against them. The provider
+	// name and redirect target ride along after the separators and are validated
+	// on the way out.
 	nonce, err := oauthStateNonce()
 	if err != nil {
 		s.logger.Warn("OAuth: cannot mint login state nonce", "error", err)
@@ -204,30 +284,134 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		MaxAge:   int(oauthStateTTL.Seconds()),
 		HttpOnly: true,
 		Secure:   true,
-		// Lax, not Strict: the callback arrives as a top-level GET redirect
-		// FROM github.com, and Strict would withhold the cookie on exactly that
+		// Lax, not Strict: the callback arrives as a top-level GET redirect FROM
+		// the provider, and Strict would withhold the cookie on exactly that
 		// navigation and break every login.
 		SameSite: http.SameSiteLaxMode,
 	})
-	state := url.QueryEscape(nonce + oauthStateSeparator + redirect)
-	// An EMPTY scope is deliberate, not an omission. The hub only needs to know
-	// WHO is logging in: the callback reads GET /user for the login name and
-	// signs it into the session cookie. GitHub serves /user's public profile —
-	// including "login" — for a token with no scopes at all, so identity works
-	// unscoped.
-	//
-	// The hub used to ask for read:user because the request wizard listed the
-	// user's repositories for them to pick from. That listing is gone: it could
-	// only ever see public github.com, and it could never generalize to GitLab
-	// or Gitea. Requesters now type a repository URL instead, which needs no
-	// permission on the requester's account whatsoever.
-	//
-	// Do NOT restore a scope here without also restoring a feature that needs
-	// it — asking for access the product does not use is a consent prompt users
-	// are right to refuse.
-	authURL := fmt.Sprintf("%s?client_id=%s&scope=&redirect_uri=%s&state=%s",
-		defaultGHAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback", state)
+
+	// state = nonce : provider : redirect. The provider name is carried so the
+	// callback knows which provider to complete against without a second cookie.
+	state := url.QueryEscape(nonce + oauthStateSeparator + p.Name + oauthStateSeparator + redirect)
+
+	if !p.IsOIDC {
+		// GitHub: identical request shape to the pre-multi-provider hub. An EMPTY
+		// scope is deliberate — the hub only needs WHO is logging in, and GitHub
+		// serves /user's public profile (including "login") unscoped. Do NOT add a
+		// scope without a feature that needs it.
+		authURL := fmt.Sprintf("%s?client_id=%s&scope=&redirect_uri=%s&state=%s",
+			p.AuthorizeURL, p.ClientID, oauthRedirectURI, state)
+		http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
+		return
+	}
+
+	// OIDC: mint a replay nonce, cookie it, and pass it in the authorize request;
+	// the callback requires the id_token to echo it back.
+	oidcNonce, err := oauthStateNonce()
+	if err != nil {
+		s.logger.Warn("OIDC: cannot mint nonce", "provider", p.Name, "error", err)
+		http.Error(w, "login unavailable", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     oidcNonceCookieName,
+		Value:    oidcNonce,
+		Path:     "/",
+		MaxAge:   int(oauthStateTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	authURL, err := p.AuthCodeURL(oauthRedirectURI, state, oidcNonce)
+	if err != nil {
+		s.logger.Warn("OIDC: cannot build authorize URL", "provider", p.Name, "error", err)
+		http.Error(w, "login unavailable — provider not reachable", http.StatusBadGateway)
+		return
+	}
 	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
+}
+
+// ibmLogoSVG is the official IBM 8-bar wordmark (the striped "IBM" letters), in
+// IBM Blue. Used for the IBMid provider in the login picker. viewBox is wide
+// (~2.4:1); callers give IBMid a wider glyph slot so it isn't squashed.
+const ibmLogoSVG = `<svg viewBox="0 0 512 205" fill="#1F70C1" aria-hidden="true"><path d="M99.55552,190.060579 L99.55552,204.282819 L0,204.282819 L0,190.060579 L99.55552,190.060579 Z M255.1384,190.059939 C245.151671,199.241068 232.070596,204.31949 218.50496,204.282019 L218.50496,204.282019 L113.77792,204.141379 L113.77792,190.059939 Z M403.1664,190.059779 L398.2,204.282179 L393.2784,190.059779 L403.1664,190.059779 Z M355.55584,190.060579 L355.55584,204.282819 L284.44464,204.282819 L284.44464,190.060579 L355.55584,190.060579 Z M512,190.060579 L512,204.282819 L440.8888,204.282819 L440.8888,190.060579 L512,190.060579 Z M271.24672,162.908899 C270.026362,167.89787 268.099708,172.686973 265.52512,177.131139 L265.52512,177.131139 L113.77792,177.131139 L113.77792,162.908899 Z M412.6976,162.909379 L407.7056,177.131779 L388.7392,177.131779 L383.7472,162.909379 L412.6976,162.909379 Z M355.55584,162.908899 L355.55584,177.131139 L284.44464,177.131139 L284.44464,162.908899 L355.55584,162.908899 Z M512,162.908899 L512,177.131139 L440.8888,177.131139 L440.8888,162.908899 L512,162.908899 Z M99.55552,162.908899 L99.55552,177.131139 L0,177.131139 L0,162.908899 L99.55552,162.908899 Z M71.11104,135.757379 L71.11104,149.979779 L28.44432,149.979779 L28.44432,135.757379 L71.11104,135.757379 Z M184.88896,135.757379 L184.88896,149.979779 L142.22224,149.979779 L142.22224,135.757379 L184.88896,135.757379 Z M270.90576,135.757379 C272.166041,140.393192 272.805755,145.175711 272.80816,149.979779 L272.80816,149.979779 L224.96976,149.979779 L224.96976,135.757379 Z M422.2304,135.757379 L417.2368,149.979779 L379.208,149.979779 L374.2144,135.757379 L422.2304,135.757379 Z M355.55568,135.757379 L355.55568,149.979779 L312.88896,149.979779 L312.88896,135.757379 L355.55568,135.757379 Z M483.55552,135.757379 L483.55552,149.979779 L440.8888,149.979779 L440.8888,135.757379 L483.55552,135.757379 Z M71.11104,108.606019 L71.11104,122.828259 L28.44432,122.828259 L28.44432,108.606019 L71.11104,108.606019 Z M355.55568,108.606019 L355.55568,122.828259 L312.88896,122.828259 L312.88896,108.606019 L355.55568,108.606019 Z M483.55552,108.606019 L483.55552,122.828259 L440.8888,122.828259 L440.8888,108.606019 L483.55552,108.606019 Z M253.64576,108.605379 C258.382421,112.634795 262.394807,117.444874 265.50928,122.827459 L265.50928,122.827459 L142.22176,122.827459 L142.22176,108.605379 Z M431.7616,108.605379 L426.7696,122.827779 L369.6752,122.827779 L364.6832,108.605379 L431.7616,108.605379 Z M394.224,81.4549786 L398.2224,92.9509786 L402.2192,81.4549786 L483.5552,81.4549786 L483.5552,95.6773786 L440.8896,95.6773786 L440.8896,82.6085786 L436.3008,95.6773786 L360.144,95.6773786 L355.5552,82.6069786 L355.5552,95.6773786 L312.8896,95.6773786 L312.8896,81.4549786 L394.224,81.4549786 Z M142.22224,81.4543386 L265.51024,81.4551386 C262.395586,86.8377816 258.383042,91.6479099 253.64624,95.6773786 L253.64624,95.6773786 L142.22224,95.6773786 L142.22224,81.4543386 Z M71.11104,81.4543386 L71.11104,95.6765786 L28.44432,95.6765786 L28.44432,81.4543386 L71.11104,81.4543386 Z M71.11104,54.3029786 L71.11104,68.5252186 L28.44432,68.5252186 L28.44432,54.3029786 L71.11104,54.3029786 Z M184.88896,54.3029786 L184.88896,68.5252186 L142.22224,68.5252186 L142.22224,54.3029786 L184.88896,54.3029786 Z M272.80816,54.3031386 C272.805733,59.1071522 272.166019,63.8896155 270.90576,68.5253786 L270.90576,68.5253786 L224.96976,68.5253786 L224.96976,54.3031386 Z M384.7824,54.3029786 L389.728,68.5253786 L312.8896,68.5253786 L312.8896,54.3029786 L384.7824,54.3029786 Z M483.5552,54.3029786 L483.5552,68.5253786 L406.7168,68.5253786 L411.6624,54.3029786 L483.5552,54.3029786 Z M99.55552,27.1514586 L99.55552,41.3736986 L0,41.3736986 L0,27.1514586 L99.55552,27.1514586 Z M265.52512,27.1514586 C268.099627,31.5955505 270.026276,36.3845354 271.24672,41.3733786 L271.24672,41.3733786 L113.77792,41.3733786 L113.77792,27.1514586 Z M512,27.1509786 L512,41.3733786 L416.1584,41.3733786 L421.104,27.1509786 L512,27.1509786 Z M375.3408,27.1509786 L380.2864,41.3733786 L284.4448,41.3733786 L284.4448,27.1509786 L375.3408,27.1509786 Z M99.55552,9.85716419e-05 L99.55552,14.2223386 L0,14.2223386 L0,9.85716419e-05 L99.55552,9.85716419e-05 Z M218.50496,4.91529226e-05 C232.066886,-0.0182214039 245.141087,5.05759937 255.13792,14.2221786 L255.13792,14.2221786 L113.77792,14.2221786 L113.77792,4.91529226e-05 Z M512,0.000578571642 L512,14.2229786 L425.6,14.2229786 L430.5456,0.000578571642 L512,0.000578571642 Z M365.8992,0.000578571642 L370.8448,14.2229786 L284.4448,14.2229786 L284.4448,0.000578571642 L365.8992,0.000578571642 Z"/></svg>`
+
+// providerGlyph returns a small inline SVG (or text) mark per provider for the
+// picker. Inline SVG rather than an icon font: a Font Awesome codepoint would
+// render as a tofu/striped box because no icon font is loaded, and the picker is
+// deliberately self-contained (no external fetch). The GitHub mark uses
+// currentColor so it inherits the button's foreground in any theme; Google and
+// Microsoft use their official multi-color marks; IBMid is the striped wordmark.
+func providerGlyph(name string) string {
+	switch name {
+	case "github":
+		return `<svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>`
+	case "google":
+		return `<svg viewBox="0 0 18 18" aria-hidden="true"><path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/><path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"/><path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"/><path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/></svg>`
+	case "ibmid":
+		// Official IBM 8-bar wordmark (the striped "IBM" letterform), in IBM Blue.
+		// Wide aspect (~2.4:1); the .glyph CSS gives IBMid extra width so the
+		// letters are not squashed.
+		return ibmLogoSVG
+	case "redhat":
+		return `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>`
+	case "microsoft":
+		// Microsoft's four-square logo (official brand colors).
+		return `<svg viewBox="0 0 23 23" aria-hidden="true"><path fill="#F25022" d="M0 0h11v11H0z"/><path fill="#7FBA00" d="M12 0h11v11H12z"/><path fill="#00A4EF" d="M0 12h11v11H0z"/><path fill="#FFB900" d="M12 12h11v11H12z"/></svg>`
+	case "custom":
+		// Generic OIDC provider (operator-configured): a neutral key mark, since
+		// we can't ship a third party's brand logo we don't know in advance.
+		return `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M14 6a5 5 0 1 0-4.9 6L7 14v2H5v2H2v-3l6.1-6.1A5 5 0 0 0 14 6zm-4-1a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"/></svg>`
+	default:
+		return "&#x2022;"
+	}
+}
+
+// writeProviderPicker renders the multi-provider sign-in page. Shown only when
+// more than one provider is enabled; a single-provider hub never reaches here.
+// The redirect target is preserved by threading it through each button's link.
+func (s *HubServer) writeProviderPicker(w http.ResponseWriter, providers []*auth.Provider, redirect string) {
+	rd := ""
+	if redirect != "" {
+		rd = "?redirect=" + url.QueryEscape(redirect)
+	}
+	var buttons strings.Builder
+	for _, p := range providers {
+		// Each button is a plain link to /login/{provider}; startProviderLogin
+		// mints the nonces there. Provider name/display are from our closed set,
+		// not user input, so they are safe to embed.
+		buttons.WriteString(fmt.Sprintf(
+			`<a class="prov prov-%s" href="/login/%s%s"><span class="glyph">%s</span><span>Continue with %s</span></a>`+"\n",
+			html.EscapeString(p.Name), html.EscapeString(p.Name), rd, providerGlyph(p.Name), html.EscapeString(p.DisplayName)))
+	}
+	page := `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sign in — Hive</title>
+<style>
+:root{color-scheme:light dark}
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0d1117;color:#e6edf3}
+.card{width:min(440px,94vw);padding:44px 40px;border:1px solid #30363d;border-radius:18px;background:#161b22;text-align:center}
+h1{font-size:26px;margin:0 0 6px;letter-spacing:-.01em}
+p.sub{color:#8b949e;font-size:15px;margin:0 0 32px}
+.prov{display:flex;align-items:center;gap:16px;width:100%;box-sizing:border-box;
+padding:16px 22px;margin:12px 0;border:1px solid #30363d;border-radius:12px;background:#21262d;color:#e6edf3;
+text-decoration:none;font-size:16px;font-weight:600;transition:background .12s,border-color .12s,transform .05s}
+.prov:hover{background:#30363d;border-color:#8b949e}
+.prov:active{transform:translateY(1px)}
+.glyph{display:inline-flex;align-items:center;justify-content:center;min-width:32px;height:32px;flex:none}
+.glyph svg{display:block;height:24px;width:auto;max-width:48px}
+.foot{margin-top:28px;color:#6e7681;font-size:12px;line-height:1.5}
+</style></head><body>
+<div class="card">
+<h1>Sign in to Hive</h1>
+<p class="sub">Choose how you'd like to continue.</p>
+` + buttons.String() + `<div class="foot">Your login provider controls access only. Hive's GitHub work runs through its own app.</div>
+</div></body></html>`
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(page))
 }
 
 func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
@@ -255,6 +439,162 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// Single-use: clear it now so a captured callback URL cannot be replayed.
 	s.clearOAuthStateCookie(w)
 
+	// state = nonce : provider : redirect. The provider name tells us which flow
+	// to complete; it defaults to github so a stale two-part state (from a login
+	// begun on the pre-multi-provider hub, mid-deploy) still completes as GitHub.
+	providerName, redirect := s.parseCallbackState(r)
+	p := s.resolveProvider(providerName)
+	if p == nil {
+		s.logger.Warn("OAuth: callback for unconfigured provider", "provider", providerName)
+		http.Error(w, "unknown login provider", http.StatusBadRequest)
+		return
+	}
+
+	// Resolve the login into a canonical identity (+ optional avatar/email and, for
+	// GitHub, the user access token to store). Each branch fully validates its own
+	// response; a failure returns an HTTP error and no session is minted.
+	var (
+		canonicalID string
+		avatarURL   string
+		email       string
+		ghToken     string // GitHub user access token, if any (stored encrypted)
+	)
+	if p.IsOIDC {
+		claims, err := p.Exchange(r.Context(), code, oauthRedirectURI, s.oidcNonceFromCookie(r))
+		s.clearOIDCNonceCookie(w)
+		if err != nil {
+			s.logger.Warn("OIDC: callback verification failed", "provider", p.Name, "error", err)
+			http.Error(w, "login failed — could not verify your identity", http.StatusBadGateway)
+			return
+		}
+		id, err := makeCanonical(p.Name, claims.Subject)
+		if err != nil {
+			s.logger.Warn("OIDC: subject not usable as identity", "provider", p.Name, "error", err)
+			http.Error(w, "login failed — invalid identity", http.StatusBadGateway)
+			return
+		}
+		canonicalID = id
+		avatarURL = claims.AvatarURL
+		email = claims.Email
+		s.logger.Info("audit: hub OIDC login", "provider", p.Name, "user", canonicalID)
+	} else {
+		login, avatar, token, ok := s.exchangeGitHubLogin(w, code)
+		if !ok {
+			return // exchangeGitHubLogin already wrote the error
+		}
+		// GitHub primary identity is the bare login (the shim reads it as
+		// github:<login>); keep it bare so legacy files/grants/cookies are
+		// byte-identical to the pre-multi-provider hub.
+		canonicalID = login
+		avatarURL = avatar
+		ghToken = token
+		s.logger.Info("audit: hub OAuth login", "user", login)
+	}
+
+	// From here the two paths converge: mint the session cookie over the
+	// canonical id (the Ed25519 signing machinery signs an opaque string, so
+	// this is provider-agnostic) and persist the user record.
+	if !s.mintSessionCookies(w, canonicalID) {
+		return // mintSessionCookies wrote the error
+	}
+
+	saasUser := ensureSaaSUser(canonicalID)
+	// Stamp the provider fields so the Users-table badge and dual-read storage
+	// have an explicit canonical identity (Phase 1d fields). For a legacy GitHub
+	// user these are derivable, but writing them makes the record self-describing.
+	provider, _, _ := parseCanonical(canonicalizeLegacy(canonicalID))
+	saasUser.CanonicalID = canonicalizeLegacy(canonicalID)
+	saasUser.Provider = provider
+	if avatarURL != "" {
+		saasUser.AvatarURL = avatarURL
+	}
+	if email != "" {
+		saasUser.Email = email
+	}
+	// A completed callback IS a login — count it here and nowhere else.
+	// ensureSaaSUser already refreshed LastLogin; the count is the engagement
+	// signal the admin Users card reads. Persist unconditionally below so a login
+	// is recorded even when there is no token to encrypt (the token branch used to
+	// be the only save path, so a token-encrypt failure silently dropped the whole
+	// record update).
+	saasUser.LoginCount++
+	if ghToken != "" {
+		if encrypted, err := encryptToken(ghToken); err == nil {
+			saasUser.EncryptedToken = encrypted
+		}
+	}
+	saveSaaSUser(saasUser)
+
+	if redirect == "" {
+		redirect = "/dashboard"
+	}
+	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
+}
+
+// resolveProvider returns the auth.Provider to complete a callback against. It
+// reads the built registry, but falls back to synthesizing a GitHub provider
+// from the current env/endpoint vars when the registry is absent (a HubServer
+// constructed without registerOAuth — the unit-test path) or does not carry
+// GitHub. This keeps the GitHub callback working exactly as before regardless of
+// whether the registry was built, while OIDC always requires the registry.
+func (s *HubServer) resolveProvider(name string) *auth.Provider {
+	if p := s.authProviders.Get(name); p != nil {
+		return p
+	}
+	// GitHub is always resolvable by synthesizing it from the current env/endpoint
+	// vars: the registry may not carry it (a HubServer built without registerOAuth
+	// — the unit-test path — or one where the GitHub client id was unset). An empty
+	// client id is a production-config concern, not a handler concern; the pre-
+	// multi-provider hub also redirected to GitHub's authorize with whatever client
+	// id was in env. OIDC providers, by contrast, MUST come from the built registry.
+	if name == legacyProvider || name == "" {
+		return &auth.Provider{
+			Name:         "github",
+			DisplayName:  "GitHub",
+			IsOIDC:       false,
+			AuthorizeURL: defaultGHAuthorizeURL,
+			TokenURL:     defaultGHTokenURL,
+			ClientID:     os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID"),
+			Scopes:       []string{""},
+		}
+	}
+	return nil
+}
+
+// parseCallbackState extracts the provider name and validated redirect target
+// from the (already nonce-verified) state parameter. State is
+// "nonce:provider:redirect". A two-part legacy state (nonce:redirect, from a
+// login begun before this deploy) yields provider "github" and treats the second
+// half as the redirect.
+func (s *HubServer) parseCallbackState(r *http.Request) (provider, redirect string) {
+	provider = "github"
+	redirect = "/dashboard"
+	decoded, err := url.QueryUnescape(r.URL.Query().Get("state"))
+	if err != nil || decoded == "" {
+		return provider, redirect
+	}
+	// Strip the already-verified nonce.
+	_, rest, ok := strings.Cut(decoded, oauthStateSeparator)
+	if !ok {
+		return provider, redirect
+	}
+	// rest is "provider:redirect" (new) or just "redirect" (legacy two-part).
+	maybeProvider, maybeRedirect, ok := strings.Cut(rest, oauthStateSeparator)
+	if ok && s.authProviders.Get(maybeProvider) != nil {
+		provider = maybeProvider
+		rest = maybeRedirect
+	}
+	if rest != "" && ((strings.HasPrefix(rest, "/") && !strings.HasPrefix(rest, "//")) || isTrustedRedirectTarget(rest)) {
+		redirect = rest
+	}
+	return provider, redirect
+}
+
+// exchangeGitHubLogin runs the GitHub OAuth code→token→/user flow and returns the
+// login, avatar, and user access token. On any failure it writes the HTTP error
+// and returns ok=false. This is the original callback logic, factored out so the
+// dispatcher can share the surrounding cookie/persistence code with OIDC.
+func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (login, avatar, token string, ok bool) {
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
 	clientSecret := os.Getenv("HIVE_HUB_OAUTH_CLIENT_SECRET")
 
@@ -271,7 +611,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		s.logger.Warn("OAuth token exchange failed", "error", err)
 		http.Error(w, "token exchange failed", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
 	defer resp.Body.Close()
 
@@ -285,13 +625,12 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		s.logger.Warn("OAuth: failed to parse token response", "error", err)
 		http.Error(w, "invalid token response", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
-
 	if tokenResp.AccessToken == "" {
 		s.logger.Warn("OAuth: no access token in response")
 		http.Error(w, "no access token", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
 
 	userReq, _ := http.NewRequest("GET", defaultGHUserURL, nil)
@@ -299,7 +638,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	userResp, err := client.Do(userReq)
 	if err != nil {
 		http.Error(w, "user fetch failed", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
 	defer userResp.Body.Close()
 
@@ -311,28 +650,33 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	if err := json.Unmarshal(userBody, &user); err != nil {
 		s.logger.Warn("OAuth: failed to parse user response", "error", err)
 		http.Error(w, "invalid user response", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
-
 	if user.Login == "" || !isValidName(user.Login) {
 		s.logger.Warn("OAuth: invalid or empty login", "login", user.Login)
 		http.Error(w, "invalid user login", http.StatusBadGateway)
-		return
+		return "", "", "", false
 	}
+	return user.Login, user.AvatarURL, tokenResp.AccessToken, true
+}
 
-	s.logger.Info("audit: hub OAuth login", "user", user.Login)
-
-	// Set the session cookie to a signed, tamper-evident value so it cannot be
-	// forged. If the hub has no secret to sign with, fail the login rather than
-	// emit an unsigned (trusted-by-default) cookie.
-	// N2: mint ASYMMETRICALLY. The hub holds the Ed25519 private seed; spokes
-	// receive only the public key, so a spoke operator can verify this cookie but
-	// can no longer forge one (notably an admin cookie).
-	cookieValue := mintHubUserCookieValueV2(s.sessionSigningSeed(), user.Login)
+// mintSessionCookies sets the hub session cookie over the given canonical
+// identity. Returns false (after writing an HTTP error) if the hub has no
+// secret to sign with — an unsigned cookie would be trusted by default and
+// must never be emitted.
+//
+// The value is a signed, tamper-evident token so it cannot be forged.
+// N2: minted ASYMMETRICALLY (mintHubUserCookieValueV2). The hub holds the
+// Ed25519 private seed; spokes receive only the public key, so a spoke
+// operator can verify this cookie but can no longer forge one (notably an
+// admin cookie). The signer signs an opaque string, so a canonical
+// "provider:subject" identity rides through with no format change.
+func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
+	cookieValue := mintHubUserCookieValueV2(s.sessionSigningSeed(), canonicalID)
 	if cookieValue == "" {
-		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", user.Login)
+		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", canonicalID)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
-		return
+		return false
 	}
 	// AUDIT F4, DELIBERATELY NOT CHANGED — read before "fixing" this.
 	//
@@ -376,31 +720,56 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, cookie)
+	return true
+}
 
-	saasUser := ensureSaaSUser(user.Login)
-	// A completed OAuth callback IS a login — count it here and nowhere else.
-	// ensureSaaSUser already refreshed LastLogin; the count is the engagement
-	// signal the admin Users card reads. Persist unconditionally below so a login
-	// is recorded even when there is no token to encrypt (the token branch used to
-	// be the only save path, so a token-encrypt failure silently dropped the whole
-	// record update).
-	saasUser.LoginCount++
-	if encrypted, err := encryptToken(tokenResp.AccessToken); err == nil {
-		saasUser.EncryptedToken = encrypted
+// oidcNonceFromCookie returns the OIDC replay nonce this browser was issued at
+// login start, or "" if absent. The id_token must echo it back.
+func (s *HubServer) oidcNonceFromCookie(r *http.Request) string {
+	c, err := r.Cookie(oidcNonceCookieName)
+	if err != nil || c.Value == "" {
+		return ""
 	}
-	saveSaaSUser(saasUser)
+	return c.Value
+}
 
-	redirect := "/dashboard"
-	if decoded, err := url.QueryUnescape(r.URL.Query().Get("state")); err == nil && decoded != "" {
-		// The nonce was already verified above; take only the redirect half.
-		if _, target, ok := strings.Cut(decoded, oauthStateSeparator); ok {
-			decoded = target
-		}
-		if decoded != "" && ((strings.HasPrefix(decoded, "/") && !strings.HasPrefix(decoded, "//")) || isTrustedRedirectTarget(decoded)) {
-			redirect = decoded
-		}
+// clearOIDCNonceCookie expires the OIDC nonce, making it single-use.
+func (s *HubServer) clearOIDCNonceCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oidcNonceCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// displayIdentity returns the human-facing login label and avatar URL for a
+// canonical (or legacy bare) identity. For a GitHub user this is the bare login
+// and the derived github.com/<login>.png avatar — byte-identical to the
+// pre-multi-provider behavior. For an OIDC user it prefers the STORED avatar
+// (Google/IBMid provide a picture) and a friendly display label (email, else
+// the canonical id), never nothing.
+func (s *HubServer) displayIdentity(identity string) (login, avatarURL string) {
+	provider, subject, ok := parseCanonical(canonicalizeLegacy(identity))
+	if !ok {
+		return identity, ""
 	}
-	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
+	if provider == legacyProvider {
+		// GitHub: unchanged. subject is the bare login.
+		return subject, fmt.Sprintf("https://github.com/%s.png", subject)
+	}
+	// Non-GitHub: use the stored record for a good label + avatar.
+	login = identity
+	if u := loadSaaSUser(canonicalizeLegacy(identity)); u != nil {
+		if u.Email != "" {
+			login = u.Email
+		}
+		avatarURL = u.AvatarURL
+	}
+	return login, avatarURL
 }
 
 func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
@@ -421,6 +790,7 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	isAdmin := isHubAdmin(username)
+	displayLogin, avatar := s.displayIdentity(username)
 	// Fold impersonation status into the auth payload the dashboard already
 	// fetches, so the "Viewing as … read-only" banner renders without a second
 	// round-trip. When an admin is impersonating, report the effective identity
@@ -429,17 +799,18 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	// user, so admin-only affordances hide via the existing role checks.
 	payload := map[string]any{
 		"authenticated": true,
-		"login":         username,
-		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", username),
+		"login":         displayLogin,
+		"avatar_url":    avatar,
 		"hub_admin":     isAdmin,
 	}
 	if grant, ok := s.activeImpersonationGrant(r); ok {
-		payload["login"] = grant.Target
-		payload["avatar_url"] = fmt.Sprintf("https://github.com/%s.png", grant.Target)
+		targetLogin, targetAvatar := s.displayIdentity(grant.Target)
+		payload["login"] = targetLogin
+		payload["avatar_url"] = targetAvatar
 		payload["hub_admin"] = false
 		payload["impersonating"] = true
-		payload["viewing_as"] = grant.Target
-		payload["real_user"] = username
+		payload["viewing_as"] = targetLogin
+		payload["real_user"] = displayLogin
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/v2/pkg/hub/oidc_login_test.go
+++ b/v2/pkg/hub/oidc_login_test.go
@@ -1,0 +1,215 @@
+package hub
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/kubestellar/hive/v2/pkg/auth"
+)
+
+// fakeOIDCProvider is a minimal OIDC server (discovery + JWKS + token endpoint)
+// returning one signed id_token, used to drive the hub's OIDC callback end to end.
+type fakeOIDCProvider struct {
+	srv     *httptest.Server
+	key     *rsa.PrivateKey
+	kid     string
+	issuer  string
+	idToken string
+}
+
+func newFakeOIDCProvider(t *testing.T) *fakeOIDCProvider {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeOIDCProvider{key: key, kid: "hub-test-kid"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 f.issuer,
+			"authorization_endpoint": f.issuer + "/authorize",
+			"token_endpoint":         f.issuer + "/token",
+			"jwks_uri":               f.issuer + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		pub := key.Public().(*rsa.PublicKey)
+		n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+		json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{{"kty": "RSA", "kid": f.kid, "use": "sig", "alg": "RS256", "n": n, "e": e}},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"id_token": f.idToken})
+	})
+	f.srv = httptest.NewServer(mux)
+	f.issuer = f.srv.URL
+	return f
+}
+
+func (f *fakeOIDCProvider) close() { f.srv.Close() }
+
+func (f *fakeOIDCProvider) sign(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = f.kid
+	s, err := tok.SignedString(f.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// TestOIDCCallback_CreatesCanonicalUser drives a full Google login through the
+// hub callback: the id_token verifies, a canonical google:<sub> user is created
+// with provider/avatar/email stamped, and the Ed25519 session cookie is minted
+// over the canonical id (v4 mints ONLY the asymmetric format —
+// mintHubUserCookieValueV2 — so a spoke can verify but never forge it).
+func TestOIDCCallback_CreatesCanonicalUser(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	f := newFakeOIDCProvider(t)
+	defer f.close()
+
+	const clientID = "hub-oidc-client"
+	const nonce = "oidc-nonce-123"
+	const sub = "108877665544332211"
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss":     f.issuer,
+		"aud":     clientID,
+		"sub":     sub,
+		"exp":     time.Now().Add(time.Hour).Unix(),
+		"iat":     time.Now().Unix(),
+		"nonce":   nonce,
+		"email":   "person@example.com",
+		"name":    "A Person",
+		"picture": "https://example.com/p.png",
+	})
+
+	// A hub with a real secret (mints signed cookies) and a registry carrying our
+	// fake Google provider.
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	s.authProviders = auth.NewRegistry(&auth.Provider{
+		Name:        "google",
+		DisplayName: "Google",
+		IsOIDC:      true,
+		Issuer:      f.issuer,
+		ClientID:    clientID,
+		Scopes:      []string{"openid", "email", "profile"},
+	})
+
+	// state = nonce : google : /dashboard, with matching state + OIDC nonce cookies.
+	stateNonce, _ := oauthStateNonce()
+	state := url.QueryEscape(stateNonce + oauthStateSeparator + "google" + oauthStateSeparator + "/dashboard")
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=xyz&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: stateNonce})
+	req.AddCookie(&http.Cookie{Name: oidcNonceCookieName, Value: nonce})
+
+	rec := httptest.NewRecorder()
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want 307 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/dashboard" {
+		t.Errorf("redirect = %q, want /dashboard", loc)
+	}
+
+	// A canonical google user must exist with the provider fields stamped.
+	u := loadSaaSUser("google:" + sub)
+	if u == nil {
+		t.Fatalf("expected google:%s user to be created", sub)
+	}
+	if u.Provider != "google" {
+		t.Errorf("Provider = %q, want google", u.Provider)
+	}
+	if u.CanonicalID != "google:"+sub {
+		t.Errorf("CanonicalID = %q, want google:%s", u.CanonicalID, sub)
+	}
+	if u.AvatarURL != "https://example.com/p.png" {
+		t.Errorf("AvatarURL = %q", u.AvatarURL)
+	}
+	if u.Email != "person@example.com" {
+		t.Errorf("Email = %q", u.Email)
+	}
+	if u.EncryptedToken != "" {
+		t.Error("a Google user must NOT carry a GitHub EncryptedToken")
+	}
+
+	// The session cookie is minted over the canonical id and verifies through
+	// the hub's own verifier (Ed25519 v2 format).
+	var gotSession bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			gotSession = true
+			if !hubCookieIsV2(c.Value) {
+				t.Errorf("hive_hub_user is not the Ed25519 v2 format: %q", c.Value)
+			}
+			if user, ok := s.verifyHubUserCookie(c.Value); !ok || user != "google:"+sub {
+				t.Errorf("hive_hub_user verifies to %q (ok=%v), want google:%s", user, ok, sub)
+			}
+		}
+	}
+	if !gotSession {
+		t.Error("expected an hive_hub_user session cookie to be minted")
+	}
+}
+
+// TestOIDCCallback_RejectsBadNonce confirms the hub callback fails closed when
+// the id_token's nonce does not match the browser's OIDC nonce cookie (replay /
+// injection), minting NO session.
+func TestOIDCCallback_RejectsBadNonce(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	f := newFakeOIDCProvider(t)
+	defer f.close()
+
+	const clientID = "hub-oidc-client"
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss": f.issuer, "aud": clientID, "sub": "s1",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": "the-real-nonce",
+	})
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	s.authProviders = auth.NewRegistry(&auth.Provider{
+		Name: "google", DisplayName: "Google", IsOIDC: true,
+		Issuer: f.issuer, ClientID: clientID, Scopes: []string{"openid"},
+	})
+
+	stateNonce, _ := oauthStateNonce()
+	state := url.QueryEscape(stateNonce + oauthStateSeparator + "google" + oauthStateSeparator + "/dashboard")
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=xyz&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: stateNonce})
+	// The browser's cookie carries a DIFFERENT nonce than the token.
+	req.AddCookie(&http.Cookie{Name: oidcNonceCookieName, Value: "a-different-nonce"})
+
+	rec := httptest.NewRecorder()
+	s.handleOAuthCallback(rec, req)
+
+	if rec.Code == http.StatusTemporaryRedirect {
+		t.Fatal("callback must not succeed on nonce mismatch")
+	}
+	if loadSaaSUser("google:s1") != nil {
+		t.Error("no user should be created on a rejected login")
+	}
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			t.Errorf("a session cookie %q was minted on a rejected login", c.Name)
+		}
+	}
+}

--- a/v2/pkg/hub/openrouter.go
+++ b/v2/pkg/hub/openrouter.go
@@ -65,7 +65,7 @@ func (s *HubServer) openRouterState() *openrouter.StateStore {
 // read-write grantee, or the hub admin). Funding stores a spend-capable key on
 // the hive, so it is restricted to those who administer the hive.
 func (s *HubServer) ownsHiveForFunding(username, hiveID string) bool {
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		return true
 	}
 	h := loadSaaSHive(hiveID)

--- a/v2/pkg/hub/openrouter.go
+++ b/v2/pkg/hub/openrouter.go
@@ -69,7 +69,7 @@ func (s *HubServer) ownsHiveForFunding(username, hiveID string) bool {
 		return true
 	}
 	h := loadSaaSHive(hiveID)
-	if h != nil && strings.EqualFold(h.Owner, username) {
+	if h != nil && canonicalEqual(h.Owner, username) {
 		return true
 	}
 	if u := loadSaaSUser(username); u != nil {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -828,12 +828,73 @@ func (s *HubServer) validateGitHubToken(token string) string {
 	return user.Login
 }
 
+// saaSUserFilePaths returns the candidate on-disk paths for an identity, in
+// read/try order: the canonical filename first, then the legacy "<login>.json"
+// fallback for a bare or github: identity. The caller has already rejected
+// path-traversal characters in the raw username.
+func saaSUserFilePaths(username string) []string {
+	var paths []string
+	if stem, err := encodeUserFilename(username); err == nil {
+		paths = append(paths, filepath.Join(saasUsersDir, stem+".json"))
+	}
+	provider, subject, ok := parseCanonical(username)
+	if ok && provider == legacyProvider {
+		legacy := filepath.Join(saasUsersDir, subject+".json")
+		if len(paths) == 0 || paths[0] != legacy {
+			paths = append(paths, legacy)
+		}
+	}
+	return paths
+}
+
+// readSaaSUserFile reads a user's JSON, trying the canonical filename then the
+// legacy fallback (see saaSUserFilePaths). Returns the first file that reads.
+func readSaaSUserFile(username string) ([]byte, error) {
+	var firstErr error
+	for _, p := range saaSUserFilePaths(username) {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return data, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr == nil {
+		firstErr = os.ErrNotExist
+	}
+	return nil, firstErr
+}
+
+// saveSaaSUserPath returns the file path a user record is written to. A GitHub
+// (or bare-legacy) primary keeps its legacy "<login>.json" so existing records
+// are updated in place with no rename; a non-GitHub primary writes the canonical
+// "<provider>.<subject>.json".
+func saveSaaSUserPath(u *SaaSUser) (string, error) {
+	// The record's primary identity. Today this is GitHubUsername (a bare login
+	// for GitHub users, or a canonical id once non-GitHub records exist in 1d+).
+	id := u.GitHubUsername
+	provider, subject, ok := parseCanonical(id)
+	if !ok {
+		return "", fmt.Errorf("invalid identity for save: %q", id)
+	}
+	if provider == legacyProvider {
+		return filepath.Join(saasUsersDir, subject+".json"), nil
+	}
+	stem, err := encodeUserFilename(id)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(saasUsersDir, stem+".json"), nil
+}
+
 func loadSaaSUser(username string) *SaaSUser {
 	if strings.Contains(username, "..") || strings.Contains(username, "/") || strings.Contains(username, "\\") {
 		return nil
 	}
-	path := filepath.Join(saasUsersDir, username+".json")
-	data, err := os.ReadFile(path)
+	// Dual-read: try the canonical filename ("google.1078.json") then the legacy
+	// "<login>.json". No file is rewritten — existing users resolve via legacy.
+	data, err := readSaaSUserFile(username)
 	if err != nil {
 		return nil
 	}
@@ -866,7 +927,10 @@ func saveSaaSUser(u *SaaSUser) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(saasUsersDir, u.GitHubUsername+".json")
+	path, err := saveSaaSUserPath(u)
+	if err != nil {
+		return err
+	}
 	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		return err
@@ -910,7 +974,14 @@ func listAllSaaSUsers() []SaaSUser {
 		if !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
-		u := loadSaaSUser(strings.TrimSuffix(e.Name(), ".json"))
+		stem := strings.TrimSuffix(e.Name(), ".json")
+		// A canonical filename ("google.1078", "github.foo") decodes to its wire
+		// id; a legacy filename ("foo") does not — load it as the bare login.
+		key := stem
+		if id, ok := decodeUserFilename(stem); ok {
+			key = id
+		}
+		u := loadSaaSUser(key)
 		if u != nil {
 			users = append(users, *u)
 		}
@@ -2590,7 +2661,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			result = append(result, entry)
 			continue
 		}
-		if strings.EqualFold(h.Owner, username) {
+		if canonicalEqual(h.Owner, username) {
 			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID], AutoUpgradeMode: autoUpgradeModeMap[h.ID]}
 			enrichFromSaaSMeta(&entry)
 			result = append(result, entry)
@@ -2638,7 +2709,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, sh := range listSaaSHives() {
-		if (sh.Owner == username || isAdmin) && !seen[sh.ID] {
+		if (canonicalEqual(sh.Owner, username) || isAdmin) && !seen[sh.ID] {
 			user.Hives[sh.ID] = "owner"
 			entry := MyHiveEntry{
 				RegistryEntry: RegistryEntry{
@@ -2889,7 +2960,7 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 			hiveAccess[h.ID] = hiveAccessInfo{Role: role, Status: "accepted"}
 			continue
 		}
-		if strings.EqualFold(h.Owner, username) {
+		if canonicalEqual(h.Owner, username) {
 			hiveAccess[h.ID] = hiveAccessInfo{Role: "owner", Status: "accepted"}
 			continue
 		}
@@ -3141,7 +3212,7 @@ func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		if _, hasAccess := user.Hives[id]; !hasAccess {
 			http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 			return
@@ -3228,7 +3299,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 			return
 		}
-		if h := loadSaaSHive(id); h != nil && h.Owner == username {
+		if h := loadSaaSHive(id); h != nil && canonicalEqual(h.Owner, username) {
 			role = saasRoleOwner
 		} else if r, ok := user.Hives[id]; ok {
 			role = r
@@ -3276,7 +3347,7 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can delete this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -3347,7 +3418,7 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can migrate this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -3692,7 +3763,7 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can upgrade"}`, http.StatusForbidden)
 		return
 	}
@@ -3781,7 +3852,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can switch branches"}`, http.StatusForbidden)
 		return
 	}
@@ -3916,7 +3987,7 @@ func (s *HubServer) handleToggleVisibility(w http.ResponseWriter, r *http.Reques
 		http.Error(w, `{"error":"hive not found — only hosted hives can be toggled from here"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can change visibility"}`, http.StatusForbidden)
 		return
 	}
@@ -4003,7 +4074,7 @@ func (s *HubServer) handleRenameHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found — only hosted hives can be renamed from here"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can rename this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -4126,7 +4197,7 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			Repos: regEntry.Repos,
 		}
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprint(w, `{"error":"only the owner can change auto-upgrade"}`)
@@ -5454,7 +5525,7 @@ func (s *HubServer) handleProxyHiveConfig(w http.ResponseWriter, r *http.Request
 	// hive with no owner fell through and its raw config was fetchable by ANY
 	// authenticated hub user. Fail closed: only the site admin may pull an
 	// ownerless hive's config.
-	if !isHubAdmin(caller) && (owner == "" || caller != owner) {
+	if !isHubAdmin(caller) && (owner == "" || !canonicalEqual(caller, owner)) {
 		http.Error(w, `{"error":"not authorized for this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -5600,7 +5671,7 @@ func userIsHiveOwner(username string, h *SaaSHive) bool {
 	if isHubAdmin(username) {
 		return true
 	}
-	if strings.EqualFold(h.Owner, username) {
+	if canonicalEqual(h.Owner, username) {
 		return true
 	}
 	u := loadSaaSUser(username)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -107,6 +107,37 @@ func primaryHubAdmin() string {
 	return canonicalizeLegacy(hubAdminUsername)
 }
 
+// userCanonicalID returns a user's canonical wire-form identity: the explicit
+// CanonicalID when present, else the legacy-shimmed GitHubUsername (a bare login
+// becomes github:<login>). This is the single source of truth for "who is this
+// record" across the dual-read storage path and the provider badge.
+func userCanonicalID(u *SaaSUser) string {
+	if u == nil {
+		return ""
+	}
+	if u.CanonicalID != "" {
+		return canonicalizeLegacy(u.CanonicalID)
+	}
+	return canonicalizeLegacy(u.GitHubUsername)
+}
+
+// userProvider returns a user's login provider ("github"/"google"/"ibmid"/
+// "redhat"/"microsoft"/"custom"), from the stored Provider field when set, else
+// parsed from the canonical identity. Legacy records with neither resolve to
+// "github" via the shim. Drives the admin Users-table auth-method badge.
+func userProvider(u *SaaSUser) string {
+	if u == nil {
+		return ""
+	}
+	if u.Provider != "" {
+		return strings.ToLower(u.Provider)
+	}
+	if p, _, ok := parseCanonical(userCanonicalID(u)); ok {
+		return p
+	}
+	return legacyProvider
+}
+
 func splitCSV(s string) []string {
 	parts := strings.Split(s, ",")
 	out := make([]string, 0, len(parts))
@@ -228,6 +259,34 @@ type SaaSUser struct {
 	SaaSQuota      int               `json:"saas_quota"`
 	Blocked        bool              `json:"blocked"`
 	EncryptedToken string            `json:"encrypted_token,omitempty"`
+
+	// Multi-provider identity (phase 1d). All omitempty so the thousands of
+	// existing GitHub-only records on the PVC round-trip byte-identical until a
+	// user first logs in / links after this ships.
+	//
+	//   CanonicalID  the wire-form primary identity ("google:1078", "github:foo").
+	//                Empty on a legacy record → the shim treats GitHubUsername as
+	//                the (github:) primary. saveSaaSUser/loadSaaSUser already dual-
+	//                read on GitHubUsername; CanonicalID is the explicit form used
+	//                by the badge and by Phase 2's OIDC callback when it creates a
+	//                non-GitHub user.
+	//   Provider     "github" | "google" | "ibmid" | "redhat" | "microsoft" |
+	//                "custom" — drives the admin Users-table auth-method badge.
+	//                Derivable from CanonicalID but stored so the badge needs no
+	//                parse per render.
+	//   AvatarURL    stored avatar (Google/IBMid give a picture claim); replaces
+	//                the derived github.com/<login>.png where present.
+	//   Email        the provider email claim (display only; NEVER the key — subs
+	//                are stable, emails are reassignable).
+	//   LinkedGitHubLogin  an OPTIONAL attached GitHub identity for a non-GitHub
+	//                primary who needs user-scoped GitHub calls (contributor
+	//                reissue). Never required to own a hive — the App does the
+	//                GitHub work.
+	CanonicalID       string `json:"canonical_id,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+	AvatarURL         string `json:"avatar_url,omitempty"`
+	Email             string `json:"email,omitempty"`
+	LinkedGitHubLogin string `json:"linked_github_login,omitempty"`
 
 	// Contact/CRM fields. Admin-maintained free text used to reach a hub user
 	// outside GitHub (and to remember what was said last time). All three are
@@ -871,9 +930,10 @@ func readSaaSUserFile(username string) ([]byte, error) {
 // are updated in place with no rename; a non-GitHub primary writes the canonical
 // "<provider>.<subject>.json".
 func saveSaaSUserPath(u *SaaSUser) (string, error) {
-	// The record's primary identity. Today this is GitHubUsername (a bare login
-	// for GitHub users, or a canonical id once non-GitHub records exist in 1d+).
-	id := u.GitHubUsername
+	// The record's primary identity: the explicit CanonicalID when set (a
+	// non-GitHub or newly-created user), else GitHubUsername (a bare login for
+	// legacy GitHub users). Either resolves through parseCanonical + the shim.
+	id := userCanonicalID(u)
 	provider, subject, ok := parseCanonical(id)
 	if !ok {
 		return "", fmt.Errorf("invalid identity for save: %q", id)
@@ -1062,6 +1122,11 @@ func (s *HubServer) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
 	type adminUserView struct {
 		SaaSUser
 		StatusTier string `json:"status_tier"`
+		// Provider is always populated (derived via userProvider) so the Users
+		// table's auth-method badge never has to parse — a legacy github-only
+		// record resolves to "github". This shadows SaaSUser.Provider's
+		// omitempty, so the field is present on every row.
+		Provider string `json:"provider"`
 	}
 	views := make([]adminUserView, 0, len(users))
 	for i := range users {
@@ -1070,6 +1135,7 @@ func (s *HubServer) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
 		views = append(views, adminUserView{
 			SaaSUser:   users[i],
 			StatusTier: userStatusTier(&users[i], live[name], engaged[name], now),
+			Provider:   userProvider(&users[i]),
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -15637,6 +15703,48 @@ const dashboardHTML = `<!DOCTYPE html>
       return 'contact-panel-' + String(username || '').replace(/[^A-Za-z0-9_-]/g, '_');
     }
 
+    /* providerBadge renders the user's login method (auth provider) as a small
+       chip next to their name in the admin Users table, so an admin can see at a
+       glance who signed in with GitHub vs Google vs IBMid vs Red Hat vs
+       Microsoft. The provider rides the users payload as u.provider (derived
+       server-side via userProvider). A legacy record with no provider resolves
+       to github, so every existing row shows the GitHub chip — no blank. */
+    // providerLogoSVG returns a small inline brand SVG per login provider, matching
+    // the marks used on the /login picker, so the badge is recognizable at a glance.
+    function providerLogoSVG(p) {
+      var s = 'width="12" height="12" style="flex:none" aria-hidden="true"';
+      switch (p) {
+        case 'github':
+          return '<svg viewBox="0 0 16 16" fill="currentColor" ' + s + '><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>';
+        case 'google':
+          return '<svg viewBox="0 0 18 18" ' + s + '><path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/><path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"/><path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"/><path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/></svg>';
+        case 'ibmid':
+          return '<svg viewBox="0 0 24 24" fill="#1F70C1" ' + s + '><path d="M2 4h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2z"/></svg>';
+        case 'redhat':
+          return '<svg viewBox="0 0 24 24" fill="#EE0000" ' + s + '><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>';
+        case 'microsoft':
+          return '<svg viewBox="0 0 23 23" ' + s + '><path fill="#F25022" d="M0 0h11v11H0z"/><path fill="#7FBA00" d="M12 0h11v11H12z"/><path fill="#00A4EF" d="M0 12h11v11H0z"/><path fill="#FFB900" d="M12 12h11v11H12z"/></svg>';
+        default:
+          return '';
+      }
+    }
+
+    function providerBadge(u) {
+      var p = String((u && u.provider) || 'github').toLowerCase();
+      var meta = {
+        github: {label: 'GitHub', color: '#c9d1d9', bg: 'rgba(110,118,129,0.25)'},
+        google: {label: 'Google', color: '#e8eaed', bg: 'rgba(66,133,244,0.22)'},
+        ibmid:  {label: 'IBMid',  color: '#e8eaed', bg: 'rgba(15,98,254,0.22)'},
+        redhat: {label: 'Red Hat',color: '#f5c2c7', bg: 'rgba(238,0,0,0.22)'},
+        microsoft: {label: 'Microsoft', color: '#e8eaed', bg: 'rgba(0,120,215,0.22)'}
+      }[p] || {label: p || 'unknown', color: 'var(--muted)', bg: 'rgba(110,118,129,0.25)'};
+      var logo = providerLogoSVG(p);
+      return '<span title="Signed in with ' + escAttr(meta.label) + '"' +
+        ' style="display:inline-flex;align-items:center;gap:4px;padding:1px 7px;border-radius:9999px;' +
+        'font-size:0.6rem;font-weight:600;color:' + meta.color + ';background:' + meta.bg + '">' +
+        (logo ? logo : '') + esc(meta.label) + '</span>';
+    }
+
     // renderContactCell is the collapsed summary shown in the main user row.
     function renderContactCell(u) {
       var bits = [];
@@ -16289,6 +16397,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var nameCell = avatar +
           '<span class="hive-access-wrap" style="position:relative;display:inline-flex;align-items:center;gap:4px;cursor:help">' +
             '<span style="color:var(--text);font-weight:600">' + esc(u.github_username) + '</span>' +
+            providerBadge(u) +
             (hasPendingReq ? ' <span style="color:var(--accent);font-size:0.65rem">&#9679; request</span>' : '') +
             renderUserStatsCard(u, hasPendingReq) +
           '</span>';

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -52,6 +52,61 @@ func resolveHubAdminUsername() string {
 	return defaultHubAdminUsername
 }
 
+// hubAdminsEnv is the env var (comma-separated canonical ids, e.g.
+// "github:clubanderson,google:1078...") that overrides the admin SET for
+// multi-provider login. A bare login in the list is accepted and treated as
+// github: via the identity shim. When unset, the admin set is the single
+// hubAdminUsername above (itself overridable via HIVE_HUB_ADMIN_USERNAME), so
+// both existing env contracts keep working. Prefer isHubAdmin()/
+// primaryHubAdmin() over comparing against hubAdminUsername directly, so
+// multi-provider admins work and so a same-subject identity on a DIFFERENT
+// provider can never inherit admin.
+const hubAdminsEnv = "HIVE_HUB_ADMINS"
+
+// hubAdminSet returns the canonicalized set of admin identities. Sourced from
+// HIVE_HUB_ADMINS when set, else the single hubAdminUsername. Every entry is
+// run through canonicalizeLegacy so a bare login becomes github:<login>; this
+// is what stops a Google/IBMid user whose subject happens to be the admin's
+// login from matching the GitHub admin.
+func hubAdminSet() map[string]bool {
+	raw := strings.TrimSpace(os.Getenv(hubAdminsEnv))
+	entries := []string{hubAdminUsername}
+	if raw != "" {
+		entries = splitCSV(raw)
+	}
+	set := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if c := canonicalizeLegacy(e); c != "" {
+			set[strings.ToLower(c)] = true
+		}
+	}
+	return set
+}
+
+// isHubAdmin reports whether the given identity (bare-legacy or canonical) is a
+// hub admin. Both the input and the configured admin ids are canonicalized, so
+// "clubanderson", "github:clubanderson", and "GitHub:ClubAnderson" all match the
+// default admin, while "google:clubanderson" does NOT.
+func isHubAdmin(id string) bool {
+	if id == "" {
+		return false
+	}
+	return hubAdminSet()[strings.ToLower(canonicalizeLegacy(id))]
+}
+
+// primaryHubAdmin returns the canonical identity of the primary hub admin — the
+// first entry of HIVE_HUB_ADMINS, else the resolved hubAdminUsername. Used where
+// the code needs a concrete admin identity to WRITE (e.g. audit attribution).
+func primaryHubAdmin() string {
+	raw := strings.TrimSpace(os.Getenv(hubAdminsEnv))
+	if raw != "" {
+		if list := splitCSV(raw); len(list) > 0 {
+			return canonicalizeLegacy(list[0])
+		}
+	}
+	return canonicalizeLegacy(hubAdminUsername)
+}
+
 func splitCSV(s string) []string {
 	parts := strings.Split(s, ",")
 	out := make([]string, 0, len(parts))
@@ -479,7 +534,7 @@ func (s *HubServer) blockIfImpersonatingWrite(w http.ResponseWriter, r *http.Req
 // read used for messaging/audit/status; the security decisions live in
 // resolveIdentity.
 func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGrant, bool) {
-	if s.getRealAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getRealAuthUser(r)) {
 		return impersonationGrant{}, false
 	}
 	cookie, err := r.Cookie(impersonateCookieName)
@@ -487,7 +542,7 @@ func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGran
 		return impersonationGrant{}, false
 	}
 	grant, ok := verifyImpersonateCookieValue(s.impersonateKey(), cookie.Value, time.Now())
-	if !ok || grant.Admin != hubAdminUsername {
+	if !ok || !isHubAdmin(grant.Admin) {
 		return impersonationGrant{}, false
 	}
 	if loadSaaSUser(grant.Target) == nil {
@@ -672,7 +727,7 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 //   - a hive_hub_impersonate cookie is present AND its HMAC verifies AND it has
 //     not expired (verifyImpersonateCookieValue);
 //   - the grant's Admin field equals the REAL signed session user;
-//   - that real user is exactly hubAdminUsername (only the admin may impersonate
+//   - that real user is a hub admin (isHubAdmin — only an admin may impersonate
 //     — a stolen cookie replayed on a non-admin session is ignored);
 //   - the target resolves to a real registered user on disk.
 //
@@ -683,7 +738,7 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 // the target is always a normal user, and writes never run under it.
 func (s *HubServer) resolveIdentity(r *http.Request) (effective, realUser string, impersonating bool) {
 	realUser = s.getRealAuthUser(r)
-	if realUser == "" || realUser != hubAdminUsername {
+	if realUser == "" || !isHubAdmin(realUser) {
 		return realUser, realUser, false
 	}
 	cookie, err := r.Cookie(impersonateCookieName)
@@ -830,7 +885,7 @@ func ensureSaaSUser(username string) *SaaSUser {
 		return u
 	}
 	quota := 0
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		quota = -1
 	}
 	u = &SaaSUser{
@@ -886,7 +941,7 @@ func (s *HubServer) requireAdmin(next http.HandlerFunc) http.HandlerFunc {
 		// particular the impersonation exit) must still be reachable by the real
 		// admin, and no admin-only surface may leak to the impersonated target.
 		username := s.getRealAuthUser(r)
-		if username != hubAdminUsername {
+		if !isHubAdmin(username) {
 			http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 			return
 		}
@@ -1148,7 +1203,7 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 // record (login state, quota, encrypted token).
 func (s *HubServer) handleAdminDeleteUser(w http.ResponseWriter, r *http.Request) {
 	username := r.PathValue("username")
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		writeJSONError(w, http.StatusForbidden, "cannot delete the hub admin")
 		return
 	}
@@ -2524,7 +2579,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
 			if isAdmin && role != "owner" {
@@ -2828,7 +2883,7 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	hiveAccess := make(map[string]hiveAccessInfo)
 
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
 			hiveAccess[h.ID] = hiveAccessInfo{Role: role, Status: "accepted"}
@@ -3086,7 +3141,7 @@ func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		if _, hasAccess := user.Hives[id]; !hasAccess {
 			http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 			return
@@ -3165,7 +3220,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	// the spoke. The role we pass is advisory — the spoke re-checks its own
 	// allowlist and uses that role authoritatively.
 	role := saasRoleRead
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		role = saasRoleOwner
 	} else {
 		user := loadSaaSUser(username)
@@ -3221,7 +3276,7 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can delete this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -3292,7 +3347,7 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can migrate this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -3637,7 +3692,7 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can upgrade"}`, http.StatusForbidden)
 		return
 	}
@@ -3726,7 +3781,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can switch branches"}`, http.StatusForbidden)
 		return
 	}
@@ -3861,7 +3916,7 @@ func (s *HubServer) handleToggleVisibility(w http.ResponseWriter, r *http.Reques
 		http.Error(w, `{"error":"hive not found — only hosted hives can be toggled from here"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can change visibility"}`, http.StatusForbidden)
 		return
 	}
@@ -3948,7 +4003,7 @@ func (s *HubServer) handleRenameHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found — only hosted hives can be renamed from here"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can rename this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -4071,7 +4126,7 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			Repos: regEntry.Repos,
 		}
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprint(w, `{"error":"only the owner can change auto-upgrade"}`)
@@ -5399,7 +5454,7 @@ func (s *HubServer) handleProxyHiveConfig(w http.ResponseWriter, r *http.Request
 	// hive with no owner fell through and its raw config was fetchable by ANY
 	// authenticated hub user. Fail closed: only the site admin may pull an
 	// ownerless hive's config.
-	if caller != hubAdminUsername && (owner == "" || caller != owner) {
+	if !isHubAdmin(caller) && (owner == "" || caller != owner) {
 		http.Error(w, `{"error":"not authorized for this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -5542,7 +5597,7 @@ func userIsHiveOwner(username string, h *SaaSHive) bool {
 	if username == "" || h == nil {
 		return false
 	}
-	if username == hubAdminUsername {
+	if isHubAdmin(username) {
 		return true
 	}
 	if strings.EqualFold(h.Owner, username) {
@@ -5566,7 +5621,7 @@ func (s *HubServer) handleAccessList(w http.ResponseWriter, r *http.Request) {
 	}
 	// Notes is admin-only; a non-admin owner viewing their hive's access gets
 	// name+Slack but not the admin's private CRM notes.
-	access := accessForHive(hiveID, listAllSaaSUsers(), username == hubAdminUsername)
+	access := accessForHive(hiveID, listAllSaaSUsers(), isHubAdmin(username))
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"access": access})
 }
@@ -5582,7 +5637,7 @@ func (s *HubServer) handleGrantableUsers(w http.ResponseWriter, r *http.Request)
 	username := s.getAuthUser(r)
 	// Any user who owns at least one hive may see the roster; that is the same
 	// bar as being able to open Manage Access at all. Admin always qualifies.
-	owns := username == hubAdminUsername
+	owns := isHubAdmin(username)
 	if !owns {
 		for _, h := range listSaaSHives() {
 			h := h
@@ -5804,7 +5859,7 @@ func (s *HubServer) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	role := user.Hives[hiveID]
-	if !config.RoleAtLeast(role, config.RoleReadWrite) && username != hubAdminUsername {
+	if !config.RoleAtLeast(role, config.RoleReadWrite) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5838,7 +5893,7 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	approverRole := approverUser.Hives[hiveID]
-	if !config.RoleAtLeast(approverRole, config.RoleReadWrite) && approver != hubAdminUsername {
+	if !config.RoleAtLeast(approverRole, config.RoleReadWrite) && !isHubAdmin(approver) {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5855,7 +5910,7 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 		http.Error(w, `{"error":"role must be read, read-write, merger, or owner"}`, http.StatusBadRequest)
 		return
 	}
-	if approver != hubAdminUsername && config.RoleAtLeast(body.Role, approverRole) {
+	if !isHubAdmin(approver) && config.RoleAtLeast(body.Role, approverRole) {
 		http.Error(w, `{"error":"cannot grant a role equal to or higher than your own"}`, http.StatusForbidden)
 		return
 	}
@@ -5896,7 +5951,7 @@ func (s *HubServer) handleDenyRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	denierRole := denierUser.Hives[hiveID]
-	if !config.RoleAtLeast(denierRole, config.RoleReadWrite) && denier != hubAdminUsername {
+	if !config.RoleAtLeast(denierRole, config.RoleReadWrite) && !isHubAdmin(denier) {
 		http.Error(w, `{"error":"need owner or read-write access"}`, http.StatusForbidden)
 		return
 	}
@@ -5933,7 +5988,7 @@ func (s *HubServer) handleApproveAccess(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	approverRole := approverUser.Hives[hiveID]
-	if approverRole != "owner" && approver != hubAdminUsername {
+	if approverRole != "owner" && !isHubAdmin(approver) {
 		http.Error(w, `{"error":"only the owner can approve access"}`, http.StatusForbidden)
 		return
 	}
@@ -5979,7 +6034,7 @@ func (s *HubServer) handleDenyAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	denierRole := denierUser.Hives[hiveID]
-	if denierRole != "owner" && denier != hubAdminUsername {
+	if denierRole != "owner" && !isHubAdmin(denier) {
 		http.Error(w, `{"error":"only the owner can deny access"}`, http.StatusForbidden)
 		return
 	}
@@ -6477,7 +6532,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		// Admin chose a specific placeholder — validate it is an available
 		// placeholder (same check the assign path uses) before using it. The
 		// full status recheck under loadSaaSHive below still guards the race.
-		if sel := loadSaaSHive(hiveID); sel == nil || sel.Status != statusAvailable || sel.Owner != hubAdminUsername {
+		if sel := loadSaaSHive(hiveID); sel == nil || sel.Status != statusAvailable || !isHubAdmin(sel.Owner) {
 			http.Error(w, `{"error":"selected placeholder is not available"}`, http.StatusConflict)
 			return
 		}
@@ -6749,7 +6804,7 @@ func findAvailablePlaceholder(clusterID string) string {
 		if h.Status != statusAvailable {
 			continue
 		}
-		if h.Owner != hubAdminUsername {
+		if !isHubAdmin(h.Owner) {
 			continue
 		}
 		if clusterIDForHive(&h) != clusterID {
@@ -6778,7 +6833,7 @@ func listAvailablePlaceholders(pool string) []AvailablePlaceholder {
 		if h.Status != statusAvailable {
 			continue
 		}
-		if h.Owner != hubAdminUsername {
+		if !isHubAdmin(h.Owner) {
 			continue
 		}
 		cluster := clusterIDForHive(&h)
@@ -7208,7 +7263,7 @@ type AssignHiveRequest struct {
 // both reachable (hive-oke) and heartbeat-only (vllm-d) clusters: NO hub→spoke
 // push or kubectl is used, so a vllm-d claim is delivered entirely by heartbeat.
 func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 		return
 	}
@@ -7540,7 +7595,7 @@ func (s *HubServer) handleUserToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requester := s.getAuthUser(r)
-	if requester != body.Username && requester != hubAdminUsername {
+	if requester != body.Username && !isHubAdmin(requester) {
 		http.Error(w, `{"error":"can only retrieve your own token"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -107,7 +107,7 @@ func (s *HubServer) registerBulkRoutes() {
 
 // authorizeBulkHive re-derives authorization for one hive from the hub's own
 // store, mirroring the owner check every single-hive handler performs
-// (h.Owner != username && !isHubAdmin(username)). It returns the loaded
+// (!canonicalEqual(h.Owner, username) && !isHubAdmin(username)). It returns the loaded
 // hive on success, or a reason string on refusal. The client's list is never
 // trusted: an ID that does not resolve, or resolves to someone else's hive, is
 // refused here rather than acted on.
@@ -119,7 +119,7 @@ func authorizeBulkHive(id, username string) (*SaaSHive, string) {
 	if h == nil {
 		return nil, "hive not found"
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		return nil, "not authorized for this hive"
 	}
 	return h, ""

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -107,7 +107,7 @@ func (s *HubServer) registerBulkRoutes() {
 
 // authorizeBulkHive re-derives authorization for one hive from the hub's own
 // store, mirroring the owner check every single-hive handler performs
-// (h.Owner != username && username != hubAdminUsername). It returns the loaded
+// (h.Owner != username && !isHubAdmin(username)). It returns the loaded
 // hive on success, or a reason string on refusal. The client's list is never
 // trusted: an ID that does not resolve, or resolves to someone else's hive, is
 // refused here rather than acted on.
@@ -119,7 +119,7 @@ func authorizeBulkHive(id, username string) (*SaaSHive, string) {
 	if h == nil {
 		return nil, "hive not found"
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		return nil, "not authorized for this hive"
 	}
 	return h, ""

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1517,7 +1517,7 @@ func listSaaSHives() []SaaSHive {
 func countUserHives(username string) int {
 	count := 0
 	for _, h := range listSaaSHives() {
-		if h.Owner == username {
+		if canonicalEqual(h.Owner, username) {
 			count++
 		}
 	}

--- a/v2/pkg/hub/saas_user_dualread_test.go
+++ b/v2/pkg/hub/saas_user_dualread_test.go
@@ -1,0 +1,104 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempUsersDir points saasUsersDir at a fresh temp dir and restores it.
+func withTempUsersDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "users")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := saasUsersDir
+	saasUsersDir = dir
+	t.Cleanup(func() { saasUsersDir = orig })
+	return dir
+}
+
+func writeRawUser(t *testing.T, dir, filename string, u SaaSUser) {
+	t.Helper()
+	data, _ := json.MarshalIndent(&u, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, filename), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDualRead_LegacyAndCanonical: a pre-migration legacy file "<login>.json" and
+// a canonical "<provider>.<subject>.json" both resolve through loadSaaSUser, by
+// bare login, by github: canonical, and by non-github canonical.
+func TestDualRead_LegacyAndCanonical(t *testing.T) {
+	dir := withTempUsersDir(t)
+
+	// Legacy GitHub user on disk as "alice.json" (no provider prefix).
+	writeRawUser(t, dir, "alice.json", SaaSUser{GitHubUsername: "alice"})
+	// Canonical Google user on disk as "google.1078.json".
+	writeRawUser(t, dir, "google.1078.json", SaaSUser{GitHubUsername: "google:1078"})
+
+	// Legacy user resolves by bare login AND by github: canonical.
+	if u := loadSaaSUser("alice"); u == nil || u.GitHubUsername != "alice" {
+		t.Errorf("loadSaaSUser(alice) = %+v", u)
+	}
+	if u := loadSaaSUser("github:alice"); u == nil || u.GitHubUsername != "alice" {
+		t.Errorf("loadSaaSUser(github:alice) should resolve the legacy file, got %+v", u)
+	}
+	// Google user resolves by its canonical id (and NOT via a legacy path).
+	if u := loadSaaSUser("google:1078"); u == nil || u.GitHubUsername != "google:1078" {
+		t.Errorf("loadSaaSUser(google:1078) = %+v", u)
+	}
+	// A non-existent user is nil.
+	if u := loadSaaSUser("nobody"); u != nil {
+		t.Errorf("loadSaaSUser(nobody) = %+v, want nil", u)
+	}
+}
+
+// TestSave_LegacyStaysInPlace_CanonicalWritesCanonical: saving a GitHub user
+// updates the legacy "<login>.json" (no rename/migration), while a non-GitHub
+// user writes the canonical filename.
+func TestSave_LegacyStaysInPlace_CanonicalWritesCanonical(t *testing.T) {
+	dir := withTempUsersDir(t)
+
+	// GitHub user → legacy file, in place.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "bob", Hives: map[string]string{}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "bob.json")); err != nil {
+		t.Errorf("expected legacy bob.json, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "github.bob.json")); err == nil {
+		t.Error("GitHub user must NOT create a canonical github.bob.json (no migration on save)")
+	}
+
+	// Google user → canonical file.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "google:2222", Hives: map[string]string{}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "google.2222.json")); err != nil {
+		t.Errorf("expected canonical google.2222.json, got %v", err)
+	}
+	// And it round-trips through load.
+	if u := loadSaaSUser("google:2222"); u == nil || u.GitHubUsername != "google:2222" {
+		t.Errorf("round-trip loadSaaSUser(google:2222) = %+v", u)
+	}
+}
+
+// TestListAllSaaSUsers_MixedFilenames: enumeration decodes canonical filenames
+// and leaves legacy ones as-is, returning both users.
+func TestListAllSaaSUsers_MixedFilenames(t *testing.T) {
+	dir := withTempUsersDir(t)
+	writeRawUser(t, dir, "carol.json", SaaSUser{GitHubUsername: "carol"})
+	writeRawUser(t, dir, "google.3333.json", SaaSUser{GitHubUsername: "google:3333"})
+
+	users := listAllSaaSUsers()
+	got := map[string]bool{}
+	for _, u := range users {
+		got[u.GitHubUsername] = true
+	}
+	if !got["carol"] || !got["google:3333"] {
+		t.Errorf("listAllSaaSUsers missing an entry: %+v", got)
+	}
+}

--- a/v2/pkg/hub/saas_user_provider_test.go
+++ b/v2/pkg/hub/saas_user_provider_test.go
@@ -1,0 +1,45 @@
+package hub
+
+import "testing"
+
+func TestUserProviderAndCanonicalID(t *testing.T) {
+	cases := []struct {
+		u            SaaSUser
+		wantProvider string
+		wantCanon    string
+	}{
+		// Legacy github-only record: no Provider/CanonicalID → resolves to github.
+		{SaaSUser{GitHubUsername: "clubanderson"}, "github", "github:clubanderson"},
+		// Explicit Provider field wins.
+		{SaaSUser{GitHubUsername: "google:1078", Provider: "google"}, "google", "google:1078"},
+		// CanonicalID drives provider when Provider is unset.
+		{SaaSUser{GitHubUsername: "ignored", CanonicalID: "ibmid:xyz"}, "ibmid", "ibmid:xyz"},
+		// github: canonical still resolves to github.
+		{SaaSUser{GitHubUsername: "github:foo"}, "github", "github:foo"},
+	}
+	for _, c := range cases {
+		if got := userProvider(&c.u); got != c.wantProvider {
+			t.Errorf("userProvider(%+v) = %q, want %q", c.u, got, c.wantProvider)
+		}
+		if got := userCanonicalID(&c.u); got != c.wantCanon {
+			t.Errorf("userCanonicalID(%+v) = %q, want %q", c.u, got, c.wantCanon)
+		}
+	}
+	// nil-safety
+	if userProvider(nil) != "" || userCanonicalID(nil) != "" {
+		t.Error("nil user must return empty")
+	}
+}
+
+// TestSaveUsesCanonicalIDWhenSet: a record carrying an explicit CanonicalID
+// writes to that canonical file even when GitHubUsername holds something else.
+func TestSaveUsesCanonicalIDWhenSet(t *testing.T) {
+	withTempUsersDir(t)
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "legacy-ignored", CanonicalID: "google:5555", Provider: "google", Hives: map[string]string{}}); err != nil {
+		t.Fatal(err)
+	}
+	// It must land at the canonical google file, not a legacy one.
+	if u := loadSaaSUser("google:5555"); u == nil || u.CanonicalID != "google:5555" {
+		t.Errorf("loadSaaSUser(google:5555) = %+v", u)
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -2910,7 +2910,7 @@ func (s *HubServer) saveRegistryNow() error {
 }
 
 func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, "admin access required", http.StatusForbidden)
 		return
 	}
@@ -2931,7 +2931,7 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 			s.logger.Error("admin registry removal persist failed", "id", id, "error", err)
 			s.requestSave()
 		}
-		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", hubAdminUsername)
+		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", primaryHubAdmin())
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"removed": removed, "id": id})

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/v2/pkg/auth"
 	"github.com/kubestellar/hive/v2/pkg/openrouter"
 )
 
@@ -776,6 +777,13 @@ type HubServer struct {
 	mu       sync.RWMutex
 	logger   *slog.Logger
 	saveCh   chan struct{}
+
+	// authProviders is the enabled human-login provider set (GitHub OAuth plus any
+	// configured OIDC providers — Google/IBMid/Red Hat/Microsoft/custom). Built
+	// once in registerOAuth from the environment; nil until then. The login picker
+	// and the OIDC callback read it. It governs ONLY human dashboard login/access —
+	// never the GitHub App token or agent logins.
+	authProviders *auth.Registry
 	// registryPath is this server's on-disk registry file, captured from the
 	// package-level default at construction and immutable afterwards. It is a
 	// per-instance field (not a use-time read of the global) so the saveLoop

--- a/v2/pkg/hub/slack.go
+++ b/v2/pkg/hub/slack.go
@@ -441,7 +441,7 @@ func (s *HubServer) handleSlackMessageHiveOwner(w http.ResponseWriter, r *http.R
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != actor && !isHubAdmin(actor) {
+	if !canonicalEqual(h.Owner, actor) && !isHubAdmin(actor) {
 		http.Error(w, `{"error":"only the owner can message this hive's owner"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/slack.go
+++ b/v2/pkg/hub/slack.go
@@ -385,7 +385,7 @@ func (s *HubServer) handleSlackMessageUser(w http.ResponseWriter, r *http.Reques
 	}
 	actor := s.getAuthUser(r)
 	username := r.PathValue("username")
-	if actor != hubAdminUsername && !strings.EqualFold(actor, username) {
+	if !isHubAdmin(actor) && !strings.EqualFold(actor, username) {
 		http.Error(w, `{"error":"only an admin can message another user"}`, http.StatusForbidden)
 		return
 	}
@@ -441,7 +441,7 @@ func (s *HubServer) handleSlackMessageHiveOwner(w http.ResponseWriter, r *http.R
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != actor && actor != hubAdminUsername {
+	if h.Owner != actor && !isHubAdmin(actor) {
 		http.Error(w, `{"error":"only the owner can message this hive's owner"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/spoke_restart.go
+++ b/v2/pkg/hub/spoke_restart.go
@@ -152,7 +152,7 @@ func (s *HubServer) restartSpokeForHeartbeat(hiveID string) bool {
 // (RolloutRestartSelf): a stale pod is replaced and never comes back, while
 // the healthy instance suffers one rolling restart.
 func (s *HubServer) handleRestartSpoke(w http.ResponseWriter, r *http.Request) {
-	if s.getAuthUser(r) != hubAdminUsername {
+	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -601,7 +601,7 @@
     </nav>
     <div class="header-right">
       <span id="hub-version"></span>
-      <a href="/login" class="header-link" id="nav-login">Login with GitHub</a>
+      <a href="/login" class="header-link" id="nav-login">Sign in</a>
       <a href="#" class="header-link" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.reload()});return false;">Logout</a>
     </div>
   </header>

--- a/v2/pkg/hub/timeline.go
+++ b/v2/pkg/hub/timeline.go
@@ -564,7 +564,7 @@ func (s *HubServer) handleHiveTimeline(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && username != hubAdminUsername {
+	if h.Owner != username && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can view this hive's timeline"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/timeline.go
+++ b/v2/pkg/hub/timeline.go
@@ -564,7 +564,7 @@ func (s *HubServer) handleHiveTimeline(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if h.Owner != username && !isHubAdmin(username) {
+	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
 		http.Error(w, `{"error":"only the owner can view this hive's timeline"}`, http.StatusForbidden)
 		return
 	}

--- a/v2/pkg/hub/usage.go
+++ b/v2/pkg/hub/usage.go
@@ -375,7 +375,7 @@ func (s *HubServer) usageHistorySnapshot() []UsageSnapshot {
 // unauthenticated caller never reaches this handler at all.
 func (s *HubServer) handleUsage(w http.ResponseWriter, r *http.Request) {
 	username := s.getAuthUser(r)
-	isAdmin := username == hubAdminUsername
+	isAdmin := isHubAdmin(username)
 
 	s.mu.RLock()
 	scoped := make([]RegistryEntry, 0, len(s.registry.Hives))

--- a/v2/pkg/hub/usage.go
+++ b/v2/pkg/hub/usage.go
@@ -380,7 +380,7 @@ func (s *HubServer) handleUsage(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	scoped := make([]RegistryEntry, 0, len(s.registry.Hives))
 	for _, h := range s.registry.Hives {
-		if isAdmin || strings.EqualFold(strings.TrimSpace(h.Owner), strings.TrimSpace(username)) {
+		if isAdmin || canonicalEqual(h.Owner, username) {
 			scoped = append(scoped, h)
 		}
 	}


### PR DESCRIPTION
Ports the multi-provider HUMAN login feature from `v2` to `v4` — item **1** on the "v2 fix not carried; consider separate v4 port" list in the v2→v4 sync (#3642). This is a deliberate security-path PORT, not a graft: every v2 concept was re-implemented against v4's audited auth primitives, using the v2 diffs as reference.

Scope boundary: this is identity/access for humans only — it touches neither the GitHub App installation token (kubestellar-hive[bot]) nor agent/backend logins.

## Phase-by-phase (mirrors the v2 PR order, one commit each)

**Phase 1a — canonical identity foundation (v2 #3566)**
`v2/pkg/hub/identity_canonical.go`: wire form `provider:subject`, closed provider set (`github`, `google`, `ibmid`, `redhat`, `custom`, `microsoft`), legacy shim (a bare key means `github:`), `canonicalEqual` for every ownership/admin comparison, and a path-safe filename encoding that stays inside `safeNamePattern` so the storage-layer traversal guards keep working unchanged. + `identity_canonical_test.go`.

**Phase 1b — env-driven admin list + generalized admin gate (v2 #3568)**
`isHubAdmin()` / `primaryHubAdmin()` over a canonicalized `HIVE_HUB_ADMINS` set; every admin comparison site in `saas.go`, `forge.go`, `identity.go`, `oauth.go`, `openrouter.go`, `saas_bulk.go`, `server.go`, `slack.go`, `spoke_restart.go`, `timeline.go`, `usage.go` converted to the gate. **v4 adaptation:** the default admin set is v4's existing `resolveHubAdminUsername()` value, so the audit-F12 `HIVE_HUB_ADMIN_USERNAME` contract keeps working; `HIVE_HUB_ADMINS` layers the multi-provider set on top. Canonicalization on both sides is what stops a same-subject identity on a different provider from inheriting GitHub admin. + `admin_gate_test.go`.

**Phase 1c — canonical owner-match + dual-read user store (v2 #3569, tests from #3571)**
User records dual-read: canonical `<provider>.<subject>.json` first, then legacy `<login>.json` — zero migration; existing GitHub records stay byte-identical and update in place. All hive-owner comparisons go through `canonicalEqual`. + `saas_user_dualread_test.go` and the #3571 coverage set (`multilogin_coverage_gaps_test.go`: file-path order, save-path error handling, admin quota under env override, the canonicalEqual owner-match matrix incl. cross-provider spoof rejection).

**Phase 1d — SaaSUser provider fields + Users-table badge (v2 #3573)**
`CanonicalID`/`Provider`/`AvatarURL`/`Email`/`LinkedGitHubLogin` on `SaaSUser` (all `omitempty` — existing PVC records round-trip byte-identical), `userCanonicalID`/`userProvider` helpers, always-populated `provider` on the admin users payload, and a provider badge chip (inline brand SVGs) next to each name in the admin Users table. + `saas_user_provider_test.go`.

**Phase 2 + 4 + BYO + Entra — provider abstraction + OIDC login (v2 #3579, #3588, #3590, #3595; picker SVGs from #3589)**
New `v2/pkg/auth` package (`oidc_provider.go`, `registry.go`) and the hub login rework in `oauth.go`:
- `/login` renders a provider picker only when >1 provider is enabled; a single-provider hub keeps the exact pre-multi-provider redirect UX. `/login/{provider}` starts a specific provider; one shared callback dispatches on the state's provider segment (`state = nonce:provider:redirect`; a legacy two-part state from a login begun mid-deploy still completes as GitHub).
- **id_token verification rigor preserved exactly as reviewed on v2:** RS256/RS384/RS512 only (never `none`, never HS*), JWKS key resolved by `kid` with rate-limited refresh, `iss`/`aud`/`exp` enforced, **nonce required and failing CLOSED** (an empty expected nonce is a rejection, not a skip), discovery issuer REQUIRED and matched against configuration (template-matched for multi-tenant).
- Providers: **Google**, **IBMid** (`SubjectClaim: "uid"` — IBMid discovery advertises no `sub`; overridable via `HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM`), **Red Hat**, **Microsoft Entra** incl. multi-tenant (`IssuerTemplate` with `{tenantid}` + `AllowedTenants`; multi-tenant subjects namespaced `<tenant>.<sub>` so identities never collide across tenants), and **custom** (generic BYO OIDC — Okta/Auth0/Keycloak/Dex/… — subjects keyed `custom:<sub>`).
- Tests: `pkg/auth` suite (`oidc_provider_test.go`, `coverage_test.go`, `generic_provider_test.go`, `entra_multitenant_test.go`), hub-side `oidc_login_test.go` (end-to-end fake-OIDC callback: canonical user creation + Ed25519 cookie verified through v4's own verifier; nonce-mismatch fails closed with no session and no user), `identity_custom_test.go`.

**Nav wording (v2 #3589 remainder)** — landing page header link "Login with GitHub" → provider-neutral "Sign in" (the other hub static pages already carried it on v4).

## How each v4 security primitive was preserved

- **Session minting stays v4's**: the OIDC callback resolves a canonical `provider:subject` and then enters v4's existing session path — `mintHubUserCookieValueV2` (Ed25519, audit N2) remains the ONLY mint; the F4 cookie-scope decision (Domain-scoped `hive_hub_user`, with its full rationale comment) is untouched. v2's dual HMAC+Ed25519 mint and its `verifyHubUserDual` were **not** ported.
- **Verification stays v4's**: `verifyHubUserCookie` (v3/v2/legacy accept + signed expiry + revocation, audit F10) is the only verifier; logout keeps v4's `revokeHubSessionCookie` server-side revocation.
- **SSO handoff stays v4's Ed25519 mechanism** (`MintSSOToken`/`VerifySSOToken`, per-hive keys): the signer treats the identity as an opaque string, so the canonical id rides the existing handoff and the `X-Hive-User` auth-check header with no format change — hub-proxied spokes inherit every provider automatically.
- **Admin resolution stays env-driven** (audit F12): `HIVE_HUB_ADMIN_USERNAME` remains the base; `HIVE_HUB_ADMINS` extends it.
- Where v2 and v4 both define a symbol (the #3642 report's backed-out twins — hub_cookie V3 machinery, `isHubAdmin` wiring), the feature was re-implemented against v4's current files rather than applied as patches.

**Anchor verification (run at this branch head; all present):**

```
OK (5): derivePerHiveKey in v2/pkg/hub/hub_keys.go
OK (4): verifyHeartbeatBearer in v2/pkg/hub/hub_keys.go
OK (3): mintHubUserCookieValueV2 in v2/pkg/hub/hub_cookie.go
OK (1): HIVE_TERMINAL_KEY in v2/pkg/hub/saas_provision.go
OK (1): The assertion VERIFIED in v2/proxy/server.js
OK (4): gh_flag_takes_value in bin/gh-wrapper.sh
OK (6): SecretFilePathAllowed in v2/pkg/config/config.go
OK (2): audit N9 in v2/pkg/dashboard/contribute_ws.go
OK (7): writeAgentStateFile in v2/pkg/agent/manager.go
```

(Counts match the #3642 post-merge verification exactly; `oauth.go` gains one additional `mintHubUserCookieValueV2` call site, which is the port's single mint path.)

## Env-var contract (secrets via env / secretKeyRef ONLY — no defaults, nothing hardcoded)

A provider is enabled iff `HIVE_HUB_OIDC_<P>_CLIENT_ID` is set (`<P>` ∈ `GOOGLE`, `IBMID`, `REDHAT`, `MICROSOFT`, `CUSTOM`). Per provider:

| Var | Meaning |
|---|---|
| `HIVE_HUB_OIDC_<P>_CLIENT_ID` | enables the provider |
| `HIVE_HUB_OIDC_<P>_CLIENT_SECRET` | client secret |
| `HIVE_HUB_OIDC_<P>_ISSUER` | issuer override; REQUIRED for `IBMID`/`CUSTOM` (no default), optional for `GOOGLE`/`REDHAT` |
| `HIVE_HUB_OIDC_MICROSOFT_TENANT` | Entra only: directory GUID = single-tenant strict issuer; `organizations`/`common`/`consumers` = multi-tenant template validation (default `organizations`) |
| `HIVE_HUB_OIDC_MICROSOFT_ALLOWED_TENANTS` | Entra multi-tenant: optional comma/space-separated tenant allowlist |
| `HIVE_HUB_OIDC_<P>_DISPLAY` / `_SCOPES` / `_SUBJECT_CLAIM` | optional label / scope / subject-claim overrides (work for ALL providers) |

Admin gate: `HIVE_HUB_ADMINS` (comma-separated canonical ids; bare = `github:`) overrides the admin set; unset ⇒ single admin from `HIVE_HUB_ADMIN_USERNAME` (default unchanged). GitHub OAuth keeps `HIVE_HUB_OAUTH_CLIENT_ID`/`_SECRET`. A misconfigured provider (client id but no usable issuer) is skipped, never fatal.

## Deliberately NOT ported

- **v2's session-cookie machinery** (`mintHubUserCookieValue` HMAC dual-mint, `hive_hub_user_v2` second cookie, `verifyHubUserDual`) — v4's Ed25519-only mint + v3-revocation verifier is the audited superset; grafting v2's lanes would reintroduce the forgeable symmetric mint (N2).
- **v2's `primaryHubAdmin()` audit-log usage beyond `handleRegistryDelete`** — ported where v2 used it; nothing else re-attributed.
- **Other #3642 consider-port items** (migration-API removal, device-flow scope reduction, auth-probe badge, granted-owner parity, pull-only clusters, offline-dot tooltip, proxy npm test wiring) — out of scope for this PR; they remain on the consider-port list.
- **`LinkedGitHubLogin` flows** (contributor reissue for non-GitHub primaries) — field ported for record-shape parity as on v2; the linking UX was not part of the v2 PR set either.

Base: this branch was built on the #3642 sync head (incl. the `KeyName` compile fix), so the diff shows only the port.
