### PR TITLE
🔒 fix(hub): device-flow login requests empty scopes; drop dead user-client plumbing (v4 port)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1021,22 +1021,12 @@ func main() {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 		ghClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
 	}
-	// Load user token for advisory posting (comments on issues as the logged-in user)
-	var userGHClient atomic.Pointer[github.Client]
-	if tokenData, err := os.ReadFile("/data/gh-user-token"); err == nil {
-		userToken := strings.TrimSpace(string(tokenData))
-		if userToken != "" {
-			// Identity check goes to github.com (the user token is a github.com
-			// OAuth token); the repo client stays on the per-hive host.
-			if username, err := github.ValidateToken(userToken, cfg.GitHub.OAuthAPIURL()); err == nil {
-				uc := github.NewClient(userToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
-				userGHClient.Store(uc)
-				logger.Info("user GitHub token loaded for advisory posting", "username", username)
-			} else {
-				logger.Warn("persisted user token is invalid or expired", "error", err)
-			}
-		}
-	}
+	// The user write-token client (userGHClient) was removed: every GitHub write
+	// — issues, PRs, comments, merges, and the advisory digest — now goes through
+	// the hive's App installation token (ghClient / kubestellar-hive[bot]). The
+	// user token only ever served as an advisory-digest fallback writer, which is
+	// no longer wanted (and forced the excessive "repo" login scope, issue #1927).
+	// Dashboard login now requests no scope and no user write-token is persisted.
 
 	gov := governor.New(cfg.Governor, cfg.EnabledAgents(), logger)
 	sched := scheduler.New(cfg, logger)
@@ -1550,9 +1540,6 @@ func main() {
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				ghClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
-			}
-			if uc := userGHClient.Load(); uc != nil {
-				uc.SetRepos(cfg.Project.Repos)
 			}
 			logger.Info("migrated config overrides from state to hive.yaml",
 				"repos", cfg.Project.Repos)
@@ -2163,13 +2150,8 @@ func main() {
 		ReInitFunc: func() {
 			initAgentConfigDrivenSystems(cfg)
 		},
-		SetUserClient: func(token string) {
-			uc := github.NewClient(token, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
-			userGHClient.Store(uc)
-			logger.Info("user GitHub client updated via device flow")
-		},
 		EnumerateFunc: func() {
-			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, &userGHClient, nil, logger)
+			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
 		},
 		AdvisoryResetFunc: func(newPrimaryRepo string) {
 			logger.Info("advisory reset: primary repo changed, creating new advisory issue", "repo", newPrimaryRepo)
@@ -2573,9 +2555,6 @@ func main() {
 
 		// Re-sync subsystems that cache config values
 		ghClient.SetRepos(cfg.Project.Repos)
-		if uc := userGHClient.Load(); uc != nil {
-			uc.SetRepos(cfg.Project.Repos)
-		}
 		gov.UpdateConfig(cfg.Governor)
 		agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 
@@ -3878,12 +3857,9 @@ func main() {
 			level := pc.ACMMLevel
 			cfg.ACMMLevel = &level
 
-			// Re-sync the GitHub clients that cache the repo list (mirrors the
+			// Re-sync the GitHub client that caches the repo list (mirrors the
 			// config-watcher reload path).
 			ghClient.SetRepos(cfg.Project.Repos)
-			if uc := userGHClient.Load(); uc != nil {
-				uc.SetRepos(cfg.Project.Repos)
-			}
 
 			// Persist to the PVC overlay so the claim survives a pod restart
 			// (config save writes the overlay hive.yaml, same as level switches).
@@ -4050,7 +4026,7 @@ func main() {
 
 	gov.ClearLastKicks()
 	logger.Info("cleared last kicks for startup — all eligible agents will be kicked on first eval")
-	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, &userGHClient, nil, logger)
+	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 
 	agentTickCh := func() <-chan time.Time {
@@ -4090,7 +4066,7 @@ func main() {
 					}
 				}
 			}
-			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, &userGHClient, restarted, logger)
+			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, restarted, logger)
 			// Trajectory review runs after the eval cycle (so kicks/intents are
 			// current) on its own cadence, gated by Due().
 			if trajLane != nil && trajLane.Due(time.Now()) {
@@ -4558,7 +4534,6 @@ func runEvalCycle(
 	lastActionable *atomic.Pointer[github.ActionableResult],
 	advisoryStore *advisory.Store,
 	advisoryIssues map[string]int,
-	userGHClient *atomic.Pointer[github.Client],
 	restartedAgents []string,
 	logger *slog.Logger,
 ) {
@@ -4981,28 +4956,16 @@ func runEvalCycle(
 					// the bot's own comment) would false-flag the App as "Not
 					// Installed" even though the App itself works fine.
 					if err := ghClient.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); err != nil {
-						// App failed. Try the user client as a FALLBACK ONLY so
-						// the digest still gets posted. A user-fallback success
-						// does NOT clear the App banner — the App error below is
-						// what decides the banner state.
-						postedViaFallback := false
-						if uc := userGHClient.Load(); uc != nil {
-							if uerr := uc.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); uerr == nil {
-								logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "user-fallback")
-								postedViaFallback = true
-							}
-						}
-						// Record the outcome for the heartbeat's advisory-staleness
-						// signal. A user-fallback success still counts as a fresh
-						// digest post (the issue DID get updated); otherwise record the
-						// App error so the hub can flag the digest as stale with its
-						// specific cause. err.Error() is the same string logged just
-						// below — log-safe, never key material.
-						if postedViaFallback {
-							dashSrv.RecordAdvisoryPost(digest.TotalCount)
-						} else {
-							dashSrv.RecordAdvisoryError(err.Error())
-						}
+						// The App is the sole advisory-digest writer. The former
+						// user-token fallback was removed (issue #1927): it only
+						// existed to post the digest under the logged-in user's
+						// identity when the App failed, which is exactly the
+						// owner-attributed write path we no longer want — and it
+						// forced every dashboard login through the excessive "repo"
+						// scope. Record the App error so the hub flags the digest
+						// as stale with its specific cause. err.Error() is the same
+						// string logged just below — log-safe, never key material.
+						dashSrv.RecordAdvisoryError(err.Error())
 						logger.Warn("failed to post advisory digest via app", "repo", primaryRepo, "issue", issueNum, "error", err)
 						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
 							// App is installed (we found the issue) but a real

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -34,7 +34,6 @@ import (
 func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.deps = deps
 	s.loadSidebarFromDisk()
-	s.restoreGHUserSession()
 	s.registerContributeRoutes()
 
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
@@ -1853,25 +1852,13 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 		role = resolvedRole
 	}
 
-	// The persisted token and the hive's shared user GitHub client represent the
-	// hive's WRITE identity (advisory posting, autonomous actions). Only the
-	// owner (read-write) may set them; a read-only viewer logging in must never
-	// clobber the owner's token/client with their own identity. Viewers still
-	// get a per-user session below, they just don't become the hive's actor.
-	if role == config.RoleOwner {
-		tmpTokenPath := userTokenPath + ".tmp"
-		if err := os.WriteFile(tmpTokenPath, []byte(token), 0o600); err != nil {
-			jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to save token: " + err.Error()})
-			return
-		}
-		if err := os.Rename(tmpTokenPath, userTokenPath); err != nil {
-			jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to persist token: " + err.Error()})
-			return
-		}
-		if s.deps.SetUserClient != nil {
-			s.deps.SetUserClient(token)
-		}
-	}
+	// The login token is used ONLY to prove identity (username + role, above).
+	// It is deliberately NOT persisted and NOT installed as a hive write
+	// identity: every GitHub write goes through the App installation token, so
+	// there is nothing for a user token to do. This is what lets the device flow
+	// request no scope at all (issue #1927) — an owner logging in no longer has
+	// to grant "read and write all repositories" just to administer their hive.
+	// Both owners and viewers get an identity-only per-user session below.
 
 	s.deps.Logger.Info("GitHub user authenticated via device flow", "username", username, "role", role)
 
@@ -2132,35 +2119,6 @@ func (s *Server) handleGHUserAuthSession(w http.ResponseWriter, r *http.Request)
 	// handler; we never mint a session here (doing so from a shared secret or a
 	// disk token file would grant any caller a valid session).
 	http.Redirect(w, r, "/", http.StatusFound)
-}
-
-// restoreGHUserSession loads a previously-saved GitHub user OAuth token from
-// disk and calls SetUserClient so that advisory posting works immediately
-// after a container restart, without requiring re-login via Device Flow.
-func (s *Server) restoreGHUserSession() {
-	if s.deps == nil || s.deps.SetUserClient == nil {
-		return
-	}
-
-	tokenData, err := os.ReadFile(userTokenPath)
-	if err != nil {
-		return // no saved token — nothing to restore
-	}
-
-	token := strings.TrimSpace(string(tokenData))
-	if token == "" {
-		return
-	}
-
-	user, err := github.ValidateToken(token, s.deps.Config.GitHub.OAuthAPIURL())
-	if err != nil {
-		s.deps.Logger.Warn("saved GitHub user token is invalid, removing", "error", err)
-		os.Remove(userTokenPath)
-		return
-	}
-
-	s.deps.SetUserClient(token)
-	s.deps.Logger.Info("restored GitHub user session from disk", "username", user.Login)
 }
 
 func (s *Server) handleGHRateLimits(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_helpers_coverage_test.go
+++ b/v2/pkg/dashboard/api_helpers_coverage_test.go
@@ -218,11 +218,3 @@ func TestCovJ_DefaultStatsConfig(t *testing.T) {
 	// exercise the lookup path.
 	_ = defaultStatsConfig("totally-unknown-agent")
 }
-
-// --- restoreGHUserSession reads a fixed token path (absent) → early return ---
-
-func TestCovJ_RestoreGHUserSession(t *testing.T) {
-	s := covHelperServer(t)
-	// userTokenPath is absent in the sandbox → the no-token branch runs.
-	s.restoreGHUserSession()
-}

--- a/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -153,11 +153,9 @@ func TestCovDF_GHUserAuthPoll_Error(t *testing.T) {
 }
 
 func TestCovDF_GHUserAuthPoll_CompleteOwner(t *testing.T) {
-	s, deps, _ := dfServer(t, "complete", "octocat")
+	s, _, _ := dfServer(t, "complete", "octocat")
 	// Not direct-route (no allowlist) → role owner, token persisted only if
-	// userTokenPath is writable; SetUserClient captures the token.
-	var gotToken string
-	deps.SetUserClient = func(tok string) { gotToken = tok }
+	// userTokenPath is writable.
 	doPost(s, "/api/gh-user-auth/start", nil)
 	rec := doPost(s, "/api/gh-user-auth/poll", nil)
 	var body map[string]any
@@ -168,7 +166,6 @@ func TestCovDF_GHUserAuthPoll_CompleteOwner(t *testing.T) {
 	if body["status"] != "complete" && body["status"] != "error" {
 		t.Fatalf("unexpected status %v (body=%s)", body["status"], rec.Body.String())
 	}
-	_ = gotToken
 }
 
 func TestCovDF_GHUserAuthPoll_UnverifiableIdentity(t *testing.T) {
@@ -367,20 +364,4 @@ func TestCovDF_SSO_NotAuthorized(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("unauthorized sso: want 403, got %d", rec.Code)
 	}
-}
-
-// ---- restoreGHUserSession ----
-
-func TestCovDF_RestoreGHUserSession_NoSetUserClient(t *testing.T) {
-	s, deps, _ := dfServer(t, "complete", "octocat")
-	deps.SetUserClient = nil
-	// Should return early without panicking (no token file present anyway).
-	s.restoreGHUserSession()
-}
-
-func TestCovDF_RestoreGHUserSession_NoToken(t *testing.T) {
-	s, deps, _ := dfServer(t, "complete", "octocat")
-	deps.SetUserClient = func(string) {}
-	// userTokenPath absent in tests → early return.
-	s.restoreGHUserSession()
 }

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -495,22 +495,6 @@ func TestHandleGHUserAuthPoll_ActiveFlow(t *testing.T) {
 	}
 }
 
-// --- restoreGHUserSession with saved token ---
-
-func TestRestoreGHUserSession_WithToken(t *testing.T) {
-	srv := newFullServer(t)
-	srv.deps.SetUserClient = func(token string) {}
-
-	// Write a fake token to disk
-	dir := t.TempDir()
-	tokenFile := dir + "/gh-user-token"
-	os.WriteFile(tokenFile, []byte("ghp_faketoken12345678\n"), 0o600)
-
-	// restoreGHUserSession reads from hardcoded path, can't test directly.
-	// Just verify the function doesn't panic.
-	srv.restoreGHUserSession()
-}
-
 // --- loadSidebarFromDisk / saveSidebarToDisk ---
 
 func TestSaveSidebarToDisk(t *testing.T) {

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -1588,19 +1588,6 @@ func TestHandleGHUserAuthStatus_NoToken(t *testing.T) {
 	}
 }
 
-// --- restoreGHUserSession ---
-
-func TestRestoreGHUserSession_NilDeps(t *testing.T) {
-	srv := &Server{}
-	srv.restoreGHUserSession() // should not panic
-}
-
-func TestRestoreGHUserSession_NoSetUserClient(t *testing.T) {
-	srv := newFullServer(t)
-	srv.deps.SetUserClient = nil
-	srv.restoreGHUserSession() // should not panic
-}
-
 // --- checkModelAllowed ---
 
 func TestCheckModelAllowed_NoConfig(t *testing.T) {

--- a/v2/pkg/dashboard/dashboard_inception_handlers_test.go
+++ b/v2/pkg/dashboard/dashboard_inception_handlers_test.go
@@ -382,14 +382,3 @@ func TestHandleKnowledgeExportNilKnowledge(t *testing.T) {
 	// Should handle nil knowledge gracefully — either 503 or creates fallback
 	_ = w.Code
 }
-
-func TestRestoreGHUserSessionNilDeps(t *testing.T) {
-	srv := NewServer(0, slog.Default())
-	srv.restoreGHUserSession()
-}
-
-func TestRestoreGHUserSessionNoToken(t *testing.T) {
-	srv := newMinimalServer(t)
-	srv.deps.SetUserClient = func(token string) {}
-	srv.restoreGHUserSession()
-}

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -39,7 +39,6 @@ type Dependencies struct {
 	PersistFunc       func()
 	SkipReloadFunc    func()
 	ReInitFunc        func()
-	SetUserClient     func(token string)
 	EnumerateFunc     func()
 	AdvisoryResetFunc func(newPrimaryRepo string)
 	ReinitGitHubFunc  func(appID, installationID int64, keyFile string) error

--- a/v2/pkg/github/deviceflow.go
+++ b/v2/pkg/github/deviceflow.go
@@ -21,7 +21,16 @@ const (
 	defaultTokenURL = "https://github.com/login/oauth/access_token"
 	// defaultUserURL is the GitHub.com API user endpoint.
 	defaultUserURL = "https://api.github.com/user"
-	deviceScope    = "repo"
+	// deviceScope is empty: dashboard login only proves the user's identity
+	// (ValidateToken → GET /user, which works with a no-scope token). It never
+	// needs repository access, because ALL GitHub writes — issues, PRs,
+	// comments, merges, the advisory digest — go through the hive's App
+	// installation token (kubestellar-hive[bot]), not the user token. Requesting
+	// "repo" here forced every viewer/owner through GitHub's "read and write all
+	// public and private repository data" authorization just to look at a
+	// dashboard (issue #1927). This mirrors the hub browser-OAuth path, which
+	// has used an empty scope for the same reason.
+	deviceScope = ""
 )
 
 // deviceFlowURLs derives the device flow endpoints from a custom base URL.
@@ -56,7 +65,12 @@ func StartDeviceFlow(clientID, baseURL, apiURL string) (*DeviceFlowState, error)
 	codeURL, _, _ := deviceFlowURLs(baseURL, apiURL)
 	data := url.Values{
 		"client_id": {clientID},
-		"scope":     {deviceScope},
+	}
+	// Only request a scope when one is configured. deviceScope is empty by
+	// default (identity-only login, issue #1927); omitting the field entirely
+	// yields a no-scope token rather than sending scope="".
+	if deviceScope != "" {
+		data.Set("scope", deviceScope)
 	}
 	req, err := http.NewRequest("POST", codeURL, strings.NewReader(data.Encode()))
 	if err != nil {


### PR DESCRIPTION
Fixes #3652. Port item 3: least-privilege device-flow (identity only, no repo grant) + SetUserClient removal, mirroring v2 minus UI/403-messaging hunks. Security anchors verified intact (derivePerHiveKey/verifyHeartbeatBearer/mintHubUserCookieValueV2/SecretFilePathAllowed). HOLD for coordinator review before merge.