### PR TITLE
🔒 fix(hub): granted owners get hive-management parity (v4 port)

### DIFF
--- a/v2/pkg/hub/granted_owner_parity_test.go
+++ b/v2/pkg/hub/granted_owner_parity_test.go
@@ -1,0 +1,206 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGrantedOwnerParityForHiveManagementHandlers proves that every hive
+// management handler resolves ownership through userIsHiveOwner: the registry
+// creator and any user GRANTED the owner role pass, while granted read,
+// granted read-write, and unrelated users are rejected. The creator case is
+// the positive control that the port did not break original owners, and the
+// rejected cases are the positive control that the gate still exists at all.
+//
+// Ported from v2 (#3567) and re-expressed against v4's role gating: the
+// authorization change here only EXTENDS who passes the owner checks.
+func TestGrantedOwnerParityForHiveManagementHandlers(t *testing.T) {
+	type parityCase struct {
+		name    string
+		method  string
+		target  string
+		body    string
+		prepare func(t *testing.T, s *HubServer, hiveID string)
+		handler func(*HubServer, http.ResponseWriter, *http.Request)
+	}
+
+	cases := []parityCase{
+		{
+			name:   "delete hive",
+			method: http.MethodDelete,
+			target: "/delete",
+			prepare: func(t *testing.T, s *HubServer, hiveID string) {
+				t.Helper()
+				h := loadSaaSHive(hiveID)
+				h.ClusterID = "missing-cluster"
+				if err := saveSaaSHive(h); err != nil {
+					t.Fatalf("save hive: %v", err)
+				}
+			},
+			handler: (*HubServer).handleDeleteHive,
+		},
+		{
+			name:    "migrate hive",
+			method:  http.MethodPost,
+			target:  "/migrate",
+			body:    `{"target_cluster_id":"hive-oke"}`,
+			handler: (*HubServer).handleMigrateHive,
+		},
+		{
+			name:   "upgrade hive",
+			method: http.MethodPost,
+			target: "/upgrade",
+			prepare: func(t *testing.T, s *HubServer, hiveID string) {
+				t.Helper()
+				h := loadSaaSHive(hiveID)
+				h.ClusterID = "missing-cluster"
+				if err := saveSaaSHive(h); err != nil {
+					t.Fatalf("save hive: %v", err)
+				}
+			},
+			handler: (*HubServer).handleUpgradeHive,
+		},
+		{
+			name:    "switch branch",
+			method:  http.MethodPost,
+			target:  "/switch",
+			body:    `{"branch":""}`,
+			handler: (*HubServer).handleSwitchBranch,
+		},
+		{
+			name:    "toggle visibility",
+			method:  http.MethodPut,
+			target:  "/visibility",
+			body:    `{"is_public":true}`,
+			handler: (*HubServer).handleToggleVisibility,
+		},
+		{
+			name:    "rename hive",
+			method:  http.MethodPut,
+			target:  "/rename",
+			body:    `{"project_name":"Granted Owner Rename"}`,
+			handler: (*HubServer).handleRenameHive,
+		},
+		{
+			name:    "toggle auto-upgrade",
+			method:  http.MethodPut,
+			target:  "/auto-upgrade",
+			body:    `{"auto_upgrade":true,"auto_upgrade_mode":"daily"}`,
+			handler: (*HubServer).handleToggleAutoUpgrade,
+		},
+	}
+
+	actors := []struct {
+		name       string
+		username   string
+		role       string
+		wantStatus int
+	}{
+		{name: "creator is allowed", username: "creator"},
+		{name: "granted owner is allowed", username: "granted-owner", role: "owner"},
+		{name: "granted read is rejected", username: "reader", role: "read", wantStatus: http.StatusForbidden},
+		{name: "granted read-write is rejected", username: "writer", role: "read-write", wantStatus: http.StatusForbidden},
+		{name: "unrelated user is rejected", username: "stranger", wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, actor := range actors {
+				t.Run(actor.name, func(t *testing.T) {
+					cleanup := helperSetupTempDirs(t)
+					defer cleanup()
+
+					s := newHandlerHub()
+					hiveID := "hosted-parity"
+					if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "creator", ClusterID: "hive-oke", Org: "org", PrimaryRepo: "repo"}); err != nil {
+						t.Fatalf("save hive: %v", err)
+					}
+					if err := saveSaaSUser(&SaaSUser{GitHubUsername: "creator", Hives: map[string]string{}}); err != nil {
+						t.Fatalf("save creator: %v", err)
+					}
+					if actor.username != "creator" {
+						user := &SaaSUser{GitHubUsername: actor.username, Hives: map[string]string{}}
+						if actor.role != "" {
+							user.Hives[hiveID] = actor.role
+						}
+						if err := saveSaaSUser(user); err != nil {
+							t.Fatalf("save actor: %v", err)
+						}
+					}
+					if tc.prepare != nil {
+						tc.prepare(t, s, hiveID)
+					}
+
+					req := setPathValue(reqWithUser(tc.method, tc.target, tc.body, actor.username), "id", hiveID)
+					rec := httptest.NewRecorder()
+					tc.handler(s, rec, req)
+
+					if actor.wantStatus == http.StatusForbidden {
+						if rec.Code != http.StatusForbidden {
+							t.Fatalf("%s got status %d, want 403 (body=%s)", actor.name, rec.Code, rec.Body.String())
+						}
+						return
+					}
+					if rec.Code == http.StatusForbidden {
+						t.Fatalf("%s got 403, want authorization to pass (body=%s)", actor.name, rec.Body.String())
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestHiveStatusAccessSemantics pins handleHiveStatus's v4 semantics after the
+// granted-owner parity port: effective owners (creator and granted owner) pass
+// via userIsHiveOwner, granted read/read-write users KEEP their existing status
+// access via the access fallback (a deliberate deviation from v2, which
+// tightened status to owner-only), and unrelated users remain rejected — the
+// positive control that the gate is still enforced.
+func TestHiveStatusAccessSemantics(t *testing.T) {
+	actors := []struct {
+		name       string
+		username   string
+		role       string
+		wantStatus int
+	}{
+		{name: "creator is allowed", username: "creator", wantStatus: http.StatusOK},
+		{name: "granted owner is allowed", username: "granted-owner", role: "owner", wantStatus: http.StatusOK},
+		{name: "granted read keeps status access", username: "reader", role: "read", wantStatus: http.StatusOK},
+		{name: "granted read-write keeps status access", username: "writer", role: "read-write", wantStatus: http.StatusOK},
+		{name: "unrelated user is rejected", username: "stranger", wantStatus: http.StatusForbidden},
+	}
+
+	for _, actor := range actors {
+		t.Run(actor.name, func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+
+			s := newHandlerHub()
+			hiveID := "hosted-parity-status"
+			if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "creator", ClusterID: "hive-oke", Org: "org", PrimaryRepo: "repo"}); err != nil {
+				t.Fatalf("save hive: %v", err)
+			}
+			if err := saveSaaSUser(&SaaSUser{GitHubUsername: "creator", Hives: map[string]string{}}); err != nil {
+				t.Fatalf("save creator: %v", err)
+			}
+			if actor.username != "creator" {
+				user := &SaaSUser{GitHubUsername: actor.username, Hives: map[string]string{}}
+				if actor.role != "" {
+					user.Hives[hiveID] = actor.role
+				}
+				if err := saveSaaSUser(user); err != nil {
+					t.Fatalf("save actor: %v", err)
+				}
+			}
+
+			req := setPathValue(reqWithUser(http.MethodGet, "/status", "", actor.username), "id", hiveID)
+			rec := httptest.NewRecorder()
+			s.handleHiveStatus(rec, req)
+
+			if rec.Code != actor.wantStatus {
+				t.Fatalf("%s got status %d, want %d (body=%s)", actor.name, rec.Code, actor.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3278,7 +3278,12 @@ func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 		return
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	// Effective owners (creator, granted owner, hub admin — userIsHiveOwner)
+	// always pass; other granted roles keep read access to status. This is a
+	// deliberate v4 deviation from v2, which tightened status to owner-only:
+	// restricting existing read/read-write access is out of scope for the
+	// granted-owner parity port (which only EXTENDS who passes owner checks).
+	if !userIsHiveOwner(username, h) {
 		if _, hasAccess := user.Hives[id]; !hasAccess {
 			http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 			return
@@ -3413,7 +3418,7 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 		return
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can delete this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -3484,7 +3489,7 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can migrate this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -3829,7 +3834,7 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can upgrade"}`, http.StatusForbidden)
 		return
 	}
@@ -3918,7 +3923,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
 		return
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can switch branches"}`, http.StatusForbidden)
 		return
 	}
@@ -4053,7 +4058,7 @@ func (s *HubServer) handleToggleVisibility(w http.ResponseWriter, r *http.Reques
 		http.Error(w, `{"error":"hive not found — only hosted hives can be toggled from here"}`, http.StatusNotFound)
 		return
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can change visibility"}`, http.StatusForbidden)
 		return
 	}
@@ -4140,7 +4145,7 @@ func (s *HubServer) handleRenameHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"hive not found — only hosted hives can be renamed from here"}`, http.StatusNotFound)
 		return
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can rename this hive"}`, http.StatusForbidden)
 		return
 	}
@@ -4263,7 +4268,7 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			Repos: regEntry.Repos,
 		}
 	}
-	if !canonicalEqual(h.Owner, username) && !isHubAdmin(username) {
+	if !userIsHiveOwner(username, h) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprint(w, `{"error":"only the owner can change auto-upgrade"}`)


### PR DESCRIPTION
Fixes #3654. Eight management-handler gates in saas.go route through a shared userIsHiveOwner; creator and granted owners pass, read-only/stranger 403 (positive controls in tests). Deliberate deviation documented: handleHiveStatus keeps its read-access fallback. Anchors verified. HOLD for coordinator review before merge.