### PR TITLE
✨ feat(hub): pull-only cluster registration (v4 port)

### DIFF
--- a/v2/docs/cross-cluster-migration.md
+++ b/v2/docs/cross-cluster-migration.md
@@ -57,6 +57,12 @@ Use it when all of these hold:
    an entry in `/data/saas/clusters.json` on the hub PVC. The entry carries
    a `kubeconfig_path` and a `context` for the hub to use. The hub runs
    plain `kubectl` for the in-cluster entry.
+
+   A cluster marked `"pull_only": true` is excluded. Its spokes connect
+   outbound over the heartbeat and the hub cannot `kubectl` into them, so
+   it can be neither the source nor the target of a migrate call — the API
+   rejects both with a 400 before any migration state is recorded. Move
+   those hives by hand using the manual procedure below.
 2. **No hive data must be preserved.** The API does not copy volume data.
 3. **You are the hive owner or the hub admin.** The hub rejects any other
    caller with a 403.

--- a/v2/pkg/hub/hosted_namespace_identity.go
+++ b/v2/pkg/hub/hosted_namespace_identity.go
@@ -187,6 +187,16 @@ func stampHostedNamespaceIdentity(cluster *ClusterConfig, namespace, name, org, 
 	if cluster == nil || strings.TrimSpace(namespace) == "" {
 		return
 	}
+	if cluster.PullOnly {
+		// A pull-only cluster's namespaces are not ours to label. Before
+		// clusters like this could be registered, clusterForHive fell back to
+		// the DEFAULT cluster and this ran against the hub's own cluster,
+		// stamping (or failing to find) a namespace that lives on another
+		// cluster entirely.
+		logger.Info("skipping hosted namespace identity stamp: cluster is not reachable from the hub",
+			"cluster", cluster.ID, "namespace", namespace, "hive_id", hiveID)
+		return
+	}
 	labels, annotations := hiveNamespaceIdentityLabels(name, org, hiveID)
 	if len(labels) == 0 && len(annotations) == 0 {
 		return

--- a/v2/pkg/hub/pull_only_cluster_test.go
+++ b/v2/pkg/hub/pull_only_cluster_test.go
@@ -1,0 +1,221 @@
+package hub
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// TestPullOnlyClusterRegisters is the point of the field: a cluster the hub
+// cannot reach must still be REGISTRABLE, so everything keyed off the cluster
+// registry works for its hives.
+//
+// Before this, the loader dropped such an entry entirely ("skipping remote
+// cluster with no kubeconfig_path"), which is how five a-ks-wec2 spokes ended
+// up with no resolvable App identity while the hub held their App key.
+func TestPullOnlyClusterRegisters(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clusters.json")
+	body := `[
+	  {"id":"hive-oke","name":"OKE","in_cluster":true,"domain":"hive.kubestellar.io"},
+	  {"id":"a-ks-wec2","name":"IKS wec2","pull_only":true,"domain":"wec2.example.cloud",
+	   "github_app_id":5686,"github_app_slug":"kubestellar-hive-ghe",
+	   "github_base_url":"https://github.ibm.com","github_api_url":"https://github.ibm.com/api/v3"}
+	]`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	clusters := loadClusterConfigsFrom(t, path)
+
+	c, ok := clusters["a-ks-wec2"]
+	if !ok {
+		t.Fatal("pull-only cluster was dropped at load: its hives get no identity, " +
+			"and clusterForHive falls back to the DEFAULT cluster")
+	}
+	if !c.PullOnly {
+		t.Error("PullOnly did not survive the round trip")
+	}
+	if c.GitHubAppID != 5686 {
+		t.Errorf("GitHubAppID = %d, want 5686", c.GitHubAppID)
+	}
+}
+
+// TestRemoteClusterWithoutKubeconfigStillDropped is the guard: pull_only must be
+// a DELIBERATE declaration, not a way for a misconfigured entry to slip in. An
+// entry that simply forgot kubeconfig_path is still an error.
+func TestRemoteClusterWithoutKubeconfigStillDropped(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clusters.json")
+	body := `[{"id":"oops","name":"typo","domain":"x.example"}]`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := loadClusterConfigsFrom(t, path)["oops"]; ok {
+		t.Error("a remote cluster with no kubeconfig_path and no pull_only must still be dropped")
+	}
+}
+
+// TestPullOnlyClusterIsNotKubectlReachable pins the predicate every kubectl call
+// site is expected to consult.
+func TestPullOnlyClusterIsNotKubectlReachable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cluster ClusterConfig
+		want    bool
+	}{
+		{"pull-only", ClusterConfig{ID: "a", PullOnly: true, Domain: "d"}, false},
+		{"pull-only wins over a stale kubeconfig", ClusterConfig{ID: "a", PullOnly: true, KubeconfigPath: "/etc/hive/kubeconfigs/a.yaml"}, false},
+		{"remote with kubeconfig", ClusterConfig{ID: "b", KubeconfigPath: "/etc/hive/kubeconfigs/b.yaml"}, true},
+		{"in-cluster", ClusterConfig{ID: "c", InCluster: true}, true},
+		{"remote with nothing", ClusterConfig{ID: "d"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cluster.KubectlReachable(); got != tc.want {
+				t.Errorf("KubectlReachable() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKubectlNeverFallsBackToAmbientClusterForPullOnly is the safety property
+// that matters most.
+//
+// kubectl given an EMPTY --kubeconfig falls back to its ambient configuration,
+// which inside the hub pod is the hub's OWN cluster. A command intended for a
+// pull-only pool would then execute against the hub's cluster and report
+// success for work that never happened there — the silent-wrong-cluster
+// failure, which is far worse than an error.
+func TestKubectlNeverFallsBackToAmbientClusterForPullOnly(t *testing.T) {
+	c := &ClusterConfig{ID: "a-ks-wec2", PullOnly: true, Domain: "wec2.example.cloud"}
+
+	args := kubectlArgsForCluster(c, "get", "pods")
+
+	i := slices.Index(args, "--kubeconfig")
+	if i < 0 || i+1 >= len(args) {
+		t.Fatalf("no --kubeconfig in %v", args)
+	}
+	got := args[i+1]
+	if got == "" {
+		t.Fatal("empty --kubeconfig: kubectl would silently use the hub's OWN cluster")
+	}
+	if got != unreachableKubeconfigSentinel {
+		t.Errorf("--kubeconfig = %q, want the unreachable sentinel", got)
+	}
+	if _, err := os.Stat(got); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("the sentinel path must not exist, stat gave %v", err)
+	}
+}
+
+// TestPullOnlyClusterCountsAsUnreachableWithoutDialing checks the declarative
+// short-circuit of the reactive breaker: unreachability is known from config, so
+// the hub never pays the dial timeout that made a pool of hives serialise into
+// tens of minutes of blocking.
+func TestPullOnlyClusterCountsAsUnreachableWithoutDialing(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.clusters = map[string]ClusterConfig{
+		"a-ks-wec2": {ID: "a-ks-wec2", PullOnly: true, Domain: "wec2.example.cloud"},
+		"hive-oke":  {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
+	}
+
+	if !srv.clusterRecentlyUnreachable("a-ks-wec2") {
+		t.Error("a pull-only cluster must count as unreachable before any dial is attempted")
+	}
+	if srv.clusterRecentlyUnreachable("hive-oke") {
+		t.Error("a reachable cluster must not be suppressed")
+	}
+}
+
+// TestPullOnlyClusterHealthUsesHeartbeat asserts the health query routes to the
+// sentinel rather than a generic failure, so the caller uses the health the
+// spokes report over the heartbeat instead of rendering the pool as broken.
+func TestPullOnlyClusterHealthUsesHeartbeat(t *testing.T) {
+	c := &ClusterConfig{ID: "a-ks-wec2", PullOnly: true, Domain: "wec2.example.cloud"}
+
+	_, err := buildSingleClusterHealth(c, 5, slog.Default())
+	if err == nil {
+		t.Fatal("expected the pull-only sentinel, got nil")
+	}
+	if !errors.Is(err, errClusterPullOnly) {
+		t.Errorf("error %v does not wrap errClusterPullOnly, so it would be logged as a query failure", err)
+	}
+}
+
+// TestPullOnlyVanityHostIsNotSilentlyAttempted covers the concrete misfire seen
+// live: vanity repair for an a-ks-wec2 hive ran kubectl against hive-oke and
+// reported "no ingress found" for a namespace on another cluster.
+func TestPullOnlyVanityHostIsNotSilentlyAttempted(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	called := false
+	srv.vanityHostServable = func(hiveID, vanityHost string, cluster *ClusterConfig) error {
+		called = true
+		return nil
+	}
+
+	c := &ClusterConfig{ID: "a-ks-wec2", PullOnly: true, Domain: "wec2.example.cloud"}
+	err := srv.makeVanityHostServable("hosted-x", "hosted-x.wec2.example.cloud", c)
+	if err == nil {
+		t.Error("expected an explicit error so the caller reports the host as not served")
+	}
+	if called {
+		t.Error("the ingress path must not run for a cluster the hub cannot reach")
+	}
+}
+
+// migrateHive is provision-on-target plus deprovision-of-source, and both
+// halves are kubectl. A pull-only cluster cannot serve either half, so the
+// handler must refuse BEFORE it flips the hive into the migrating state —
+// otherwise a hive is left marked migrating for work that can never run.
+func TestMigrateRejectsPullOnlyCluster(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		sourcePullOnly bool
+		targetPullOnly bool
+	}{
+		{"target is pull-only", false, true},
+		{"source is pull-only", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(helperSetupTempDirs(t))
+			mkUser(t, "po-user")
+
+			srv := newHandlerHub2()
+			srv.clusters = map[string]ClusterConfig{
+				defaultClusterID: {ID: defaultClusterID, KubeconfigPath: "/tmp/kc", PullOnly: tc.sourcePullOnly},
+				"pool-b":         {ID: "pool-b", KubeconfigPath: "/tmp/kc", PullOnly: tc.targetPullOnly},
+			}
+			if err := saveSaaSHive(&SaaSHive{ID: "hosted-po", Owner: "po-user"}); err != nil {
+				t.Fatalf("seed hive: %v", err)
+			}
+
+			w := httptest.NewRecorder()
+			req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/hosted-po/migrate",
+				`{"target_cluster_id":"pool-b"}`, "po-user"), "id", "hosted-po")
+			srv.handleMigrateHive(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("migration involving a pull-only cluster must be refused with 400, got %d: %s", w.Code, w.Body.String())
+			}
+			// The refusal must leave no migration state behind.
+			if h := loadSaaSHive("hosted-po"); h != nil && h.MigrationStatus != "" {
+				t.Errorf("hive was flipped into migration state %q despite the migration being refused", h.MigrationStatus)
+			}
+		})
+	}
+}
+
+// loadClusterConfigsFrom parses a clusters.json at an arbitrary path using the
+// same loader production uses.
+func loadClusterConfigsFrom(t *testing.T, path string) map[string]ClusterConfig {
+	t.Helper()
+	orig := clustersConfigPath
+	clustersConfigPath = path
+	t.Cleanup(func() { clustersConfigPath = orig })
+	return loadClusters(slog.Default())
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1566,7 +1567,11 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 		select {
 		case res := <-query.ch:
 			if res.err != nil {
-				s.logger.Warn("cluster health query failed", "cluster", cID, "error", res.err)
+				if errors.Is(res.err, errClusterPullOnly) {
+					s.logger.Info("cluster health: pull-only cluster, using the health its spokes report over the heartbeat", "cluster", cID)
+				} else {
+					s.logger.Warn("cluster health query failed", "cluster", cID, "error", res.err)
+				}
 				// Fall back to heartbeat-reported health if available.
 				if hbHealth := s.getHeartbeatHealthForCluster(cID); hbHealth != nil {
 					pch := convertHeartbeatToPerClusterHealth(cID, s.clusterNameForID(cID), hbHealth, hiveCounts[cID])
@@ -1701,8 +1706,21 @@ func clusterHealthQueryTimeoutFor(cluster *ClusterConfig) time.Duration {
 	return defaultClusterHealthQueryTimeout
 }
 
+// errClusterPullOnly marks a health query skipped because the hub cannot reach
+// the cluster at all. It is an EXPECTED outcome, not a fault, so callers report
+// it as such and use the spokes' own heartbeat-reported health instead.
+var errClusterPullOnly = errors.New("cluster is pull-only: not reachable from the hub")
+
 // buildSingleClusterHealth queries a single cluster for node health data.
 func buildSingleClusterHealth(cluster *ClusterConfig, hiveCount int, logger *slog.Logger) (PerClusterHealth, error) {
+	if cluster.PullOnly {
+		// Node-level health comes from kubectl, which cannot run here. This is
+		// not a new failure mode: the caller already falls back to the health
+		// the spokes THEMSELVES report over the heartbeat, which is exactly the
+		// right source for a pull-only pool. Returning the sentinel routes into
+		// that path and keeps it out of the "query failed" warning.
+		return PerClusterHealth{}, fmt.Errorf("%w: %s", errClusterPullOnly, cluster.ID)
+	}
 	timeout := clusterHealthQueryTimeoutFor(cluster)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -3331,6 +3349,21 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Migration is provision-on-target plus deprovision-of-source, and BOTH
+	// halves are kubectl. A pull-only cluster cannot be reached from the hub
+	// at all, so neither half can run against it. Reject up front: accepting
+	// the call would mark the hive migrating, then fail (or, worse, aim the
+	// kubectl at whatever cluster is reachable) after the state was already
+	// flipped. Hives on a pull-only cluster must be moved by hand.
+	if toCluster.PullOnly {
+		http.Error(w, `{"error":"target cluster is pull-only: the hub cannot kubectl into it, so a hive cannot be migrated there"}`, http.StatusBadRequest)
+		return
+	}
+	if fromCluster.PullOnly {
+		http.Error(w, `{"error":"current cluster is pull-only: the hub cannot kubectl into it, so a hive cannot be migrated off it"}`, http.StatusBadRequest)
+		return
+	}
+
 	// Set migration status and launch background goroutine.
 	h.MigrationStatus = "migrating"
 	h.MigrationFrom = currentClusterID
@@ -4800,6 +4833,16 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 func (s *HubServer) clusterRecentlyUnreachable(clusterID string) bool {
 	if clusterID == "" {
 		return false
+	}
+	// A pull-only cluster is unreachable BY DECLARATION and permanently, so it
+	// never has to be learned the expensive way. This breaker exists because
+	// discovering unreachability costs a full dial timeout per hive per cycle —
+	// ~90s a call, with a pool of hives serialising into tens of minutes of
+	// blocking. Saying so in clusters.json means that price is never paid even
+	// once, and every caller that already consults this breaker is covered
+	// without needing its own pull-only check.
+	if c, ok := s.clusters[clusterID]; ok && c.PullOnly {
+		return true
 	}
 	s.clusterUnreachableMu.Lock()
 	defer s.clusterUnreachableMu.Unlock()

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -203,7 +203,25 @@ type ClusterConfig struct {
 	//
 	// Zero means "this cluster has no hub-managed App identity" — the hub then
 	// changes nothing about its spokes' credentials.
-	GitHubAppID   int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
+	GitHubAppID int64 `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
+	// PullOnly marks a cluster the hub CANNOT reach: its spokes connect
+	// outbound over the heartbeat and nothing here can kubectl into them.
+	//
+	// WHY THIS FIELD EXISTS. Registration used to require a kubeconfig_path,
+	// so a pull-only pool could not be registered AT ALL — the loader dropped
+	// the entry ("skipping remote cluster with no kubeconfig_path"). Everything
+	// keyed off the cluster registry then silently misfired for its hives:
+	// appIdentityForHive returned nil, so spokes sat on the placeholder app_id
+	// logging "cluster names no github app — cannot repair", naming a remedy
+	// for a cluster entry that could not exist; and clusterForHive fell back
+	// to the DEFAULT cluster, so vanity repair ran kubectl against the hub's
+	// own cluster looking for a namespace that lives elsewhere.
+	//
+	// Registering such a cluster makes its identity (App, forge URLs, domain)
+	// available to the heartbeat paths that do work, while every kubectl path
+	// must first ask KubectlReachable and skip rather than aim at the wrong
+	// cluster.
+	PullOnly      bool   `json:"pull_only,omitempty" yaml:"pull_only,omitempty"`
 	OAuthClientID string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
 	// Forges carries App identity for EVERY forge this cluster can serve, keyed
 	// by bare forge host ("github.com", "github.ibm.com").
@@ -332,10 +350,42 @@ func kubectlForClusterContext(ctx context.Context, cluster *ClusterConfig, args 
 	return exec.CommandContext(ctx, "kubectl", kubectlArgsForCluster(cluster, args...)...)
 }
 
+// unreachableKubeconfigSentinel is aimed at instead of a real kubeconfig when a
+// caller builds a kubectl command for a cluster the hub cannot reach.
+//
+// It must never exist. An empty --kubeconfig makes kubectl fall back to its
+// AMBIENT configuration, which inside the hub pod is the hub's OWN cluster — so
+// a command meant for a pull-only pool would quietly execute against the hub's
+// cluster and report success for work that never happened there. Naming a path
+// that cannot resolve turns that silent misfire into a loud failure.
+const unreachableKubeconfigSentinel = "/nonexistent/pull-only-cluster-is-not-reachable-from-the-hub"
+
+// KubectlReachable reports whether the hub can run kubectl against this cluster.
+//
+// Callers that are about to touch a cluster with kubectl must check this and
+// skip with a clear message: a pull-only cluster's spokes are reached ONLY by
+// answering their outbound heartbeat.
+func (c *ClusterConfig) KubectlReachable() bool {
+	if c == nil {
+		return false
+	}
+	if c.PullOnly {
+		return false
+	}
+	return c.InCluster || c.KubeconfigPath != ""
+}
+
 func kubectlArgsForCluster(cluster *ClusterConfig, args ...string) []string {
 	fullArgs := []string{}
 	if !cluster.InCluster {
-		fullArgs = append(fullArgs, "--kubeconfig", cluster.KubeconfigPath, "--context", cluster.Context)
+		kubeconfig := cluster.KubeconfigPath
+		if !cluster.KubectlReachable() || kubeconfig == "" {
+			// Defence in depth: the call sites guard on KubectlReachable, and
+			// this makes a missed guard fail loudly rather than execute against
+			// whatever ambient cluster kubectl would otherwise choose.
+			kubeconfig = unreachableKubeconfigSentinel
+		}
+		fullArgs = append(fullArgs, "--kubeconfig", kubeconfig, "--context", cluster.Context)
 	} else {
 		// Explicitly pass in-cluster credentials so kubectl does not fall back
 		// to localhost:8080 when exec.Command inherits an empty KUBECONFIG path.
@@ -397,8 +447,10 @@ func loadClusters(logger *slog.Logger) map[string]ClusterConfig {
 			logger.Warn("skipping cluster config with empty ID")
 			continue
 		}
-		if !c.InCluster && c.KubeconfigPath == "" {
-			logger.Warn("skipping remote cluster with no kubeconfig_path", "cluster", c.ID)
+		if !c.InCluster && c.KubeconfigPath == "" && !c.PullOnly {
+			logger.Warn("skipping remote cluster with no kubeconfig_path",
+				"cluster", c.ID,
+				"remedy", "set kubeconfig_path, or pull_only: true if the hub cannot reach this cluster and its spokes connect outbound over the heartbeat")
 			continue
 		}
 		if c.Domain == "" {
@@ -1377,6 +1429,14 @@ func (s *HubServer) existingVanityHost(hiveID string, cluster *ClusterConfig) st
 // tests substitute it to exercise the adopt path without a live cluster (kubectl
 // is unavailable under test, so the real call always fails there).
 func (s *HubServer) makeVanityHostServable(hiveID, vanityHost string, cluster *ClusterConfig) error {
+	if cluster != nil && cluster.PullOnly {
+		// The spoke's ingress lives on a cluster the hub cannot touch, so the
+		// host cannot be added here. Returning an explicit error keeps the
+		// caller's "vanity host is not served" reporting truthful instead of
+		// letting kubectl aim at the hub's own cluster and report a missing
+		// ingress for a namespace that was never there.
+		return fmt.Errorf("cluster %s is pull-only: the hub cannot add %s to the spoke's ingress", cluster.ID, vanityHost)
+	}
 	if s.vanityHostServable != nil {
 		return s.vanityHostServable(hiveID, vanityHost, cluster)
 	}


### PR DESCRIPTION
Fixes #3655. Registration mode for clusters the hub cannot reach inbound: PullOnly ClusterConfig field, KubectlReachable predicate, health falls back to heartbeat (Info not Warn), vanity-host + namespace-stamp + migration guards, 8 tests adapted to v4 helpers, docs. Rides v4's heartbeat credential model untouched. NOTE: merge BEFORE the migration-API-removal PR (both touch handleMigrateHive).