### PR TITLE
✅ test(agent): persistence-callback re-entrancy (v4) 

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -245,6 +245,14 @@ type Manager struct {
 
 	// persistPauseCallback, when set, persists an agent's paused state to
 	// the on-disk config so it survives restarts. Nil in tests / bare setups.
+	//
+	// Invocation contract: Pause/Resume snapshot this under m.mu but invoke
+	// it only AFTER releasing m.mu. The callback does config disk I/O and is
+	// allowed to re-enter the manager (AllStatuses, GetStatus, ...); m.mu is
+	// a non-reentrant sync.RWMutex, so invoking it with the write lock held
+	// would deadlock the pause path and wedge every operation queued behind
+	// m.mu (heartbeat AllStatuses, SendKick, terminal ResolveAgent) — the
+	// same failure class as the mint-issuer deadlock fixed in ca5f0f00.
 	persistPauseCallback func(name string, paused bool)
 
 	// breakerEngaged and breakerPaused hold the fleet-breaker's state, guarded
@@ -5914,10 +5922,10 @@ func (m *Manager) KillSession(name string) error {
 
 func (m *Manager) Pause(name, trigger, reason string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	agent, ok := m.agents[name]
 	if !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("agent %s not found", name)
 	}
 
@@ -5936,9 +5944,11 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 	}
 	agent.State = StatePaused
 	agent.Config.Paused = true
-	if m.persistPauseCallback != nil {
-		m.persistPauseCallback(name, true)
-	}
+	// Snapshot the persistence callback under m.mu but invoke it only after
+	// the unlock below: it does config disk I/O and may re-enter the manager,
+	// and m.mu is a non-reentrant RWMutex — calling it here would deadlock
+	// (see the persistPauseCallback field docs).
+	persistPause := m.persistPauseCallback
 	m.logger.Info("audit: agent paused",
 		"name", name,
 		"trigger", trigger,
@@ -5953,6 +5963,11 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 		"trigger", trigger,
 		"reason", reason,
 	))
+	m.mu.Unlock()
+
+	if persistPause != nil {
+		persistPause(name, true)
+	}
 	return nil
 }
 
@@ -5982,8 +5997,13 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	resumeModel := agent.effectiveModel()
 	agent.Paused = false
 	agent.Config.Paused = false
-	if m.persistPauseCallback != nil {
-		m.persistPauseCallback(name, false)
+	if persistPause := m.persistPauseCallback; persistPause != nil {
+		// Deferred so it runs after this function's explicit m.mu.Unlock on
+		// every return path: the callback does config disk I/O and may
+		// re-enter the manager, and m.mu is a non-reentrant RWMutex —
+		// invoking it here with the lock held deadlocks Resume and wedges
+		// everything queued behind m.mu (see persistPauseCallback docs).
+		defer persistPause(name, false)
 	}
 	agent.PausedAt = time.Time{}
 	agent.PausedReason = ""

--- a/v2/pkg/agent/persist_pause_deadlock_test.go
+++ b/v2/pkg/agent/persist_pause_deadlock_test.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// These are the v4-idiom equivalents of v2's
+// TestResume_PersistenceCallbackCanReenterManager (added with the #1980→#1988
+// mutex re-entrancy fix). They pin the persistPauseCallback invocation
+// contract: Pause and Resume must NEVER invoke the persistence callback while
+// m.mu is held. The callback does config disk I/O and is allowed to re-enter
+// the manager (the wired production callback persists to the PVC; a re-entrant
+// callback — e.g. one that refreshes dashboard snapshots via AllStatuses — is
+// within its contract). m.mu is a non-reentrant sync.RWMutex, so a locked
+// invocation deadlocks the pause path and wedges every operation queued behind
+// m.mu (heartbeat AllStatuses, SendKick, terminal ResolveAgent) — the same
+// failure class as the mint-issuer deadlock fixed in ca5f0f00 (see
+// mint_deadlock_test.go).
+//
+// Positive control: reverting the fix — re-inlining the callback invocation
+// under m.mu in Resume (the old `m.persistPauseCallback(name, false)` between
+// the Paused-field writes) or in Pause (the old call under the deferred
+// unlock) — makes the matching test below fail at its timeout, because the
+// callback's AllStatuses blocks on m.mu.RLock while the same goroutine holds
+// m.mu.Lock.
+
+// TestResume_PersistenceCallbackCanReenterManager asserts Resume invokes the
+// persistence callback without holding m.mu: the callback re-enters the
+// manager via AllStatuses (m.mu.RLock) and Resume must still return. The
+// re-entrant call runs in a goroutine guarded by select+time.After so a
+// regression fails the test instead of hanging CI.
+func TestResume_PersistenceCallbackCanReenterManager(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+	// Paused flags set, but State stays idle so Resume takes the
+	// no-relaunch path (no tmux needed in a unit test).
+	m.agents["worker"].Paused = true
+	m.agents["worker"].Config.Paused = true
+
+	callbackCalled := make(chan struct{}, 1)
+	m.SetPersistPauseCallback(func(name string, paused bool) {
+		if name != "worker" || paused {
+			t.Errorf("persist callback = (%q, %v), want (worker, false)", name, paused)
+		}
+		_ = m.AllStatuses() // re-enter the manager: takes m.mu.RLock
+		callbackCalled <- struct{}{}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Resume(context.Background(), "worker", "test", "test resume")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Resume() error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Resume() deadlocked while persistence callback re-entered manager " +
+			"(persistPauseCallback invoked under m.mu — see its field docs)")
+	}
+
+	select {
+	case <-callbackCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("resume persistence callback was not called")
+	}
+}
+
+// TestPause_PersistenceCallbackCanReenterManager is the Pause-side twin: v4
+// invoked the callback under Pause's deferred m.mu.Unlock too, so the same
+// re-entrancy guarantee is pinned for the pause direction.
+func TestPause_PersistenceCallbackCanReenterManager(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+
+	callbackCalled := make(chan struct{}, 1)
+	m.SetPersistPauseCallback(func(name string, paused bool) {
+		if name != "worker" || !paused {
+			t.Errorf("persist callback = (%q, %v), want (worker, true)", name, paused)
+		}
+		_ = m.AllStatuses() // re-enter the manager: takes m.mu.RLock
+		callbackCalled <- struct{}{}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		// Agent is idle (not StateRunning), so Pause skips the tmux
+		// interrupt and exercises only the state flip + callback.
+		done <- m.Pause("worker", "test", "test pause")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Pause() error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Pause() deadlocked while persistence callback re-entered manager " +
+			"(persistPauseCallback invoked under m.mu — see its field docs)")
+	}
+
+	select {
+	case <-callbackCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("pause persistence callback was not called")
+	}
+}


### PR DESCRIPTION
Fixes #3659. Resolves the question left by the #3642 sync (v2 #1988's re-entrancy test not carried): analysis + v4-idiom test per the tracking issue; see branch commits for the (a)fix/(b)safety-proof determination. Timeout-guarded to never hang CI.