### PR TITLE
🐛 fix(dashboard): always mint the device-flow session (parity with v2 and handleSSO)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1865,19 +1865,24 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 	// Issue a per-user session (opaque random id → username+role) instead of a
 	// single shared cookie. Each authenticated user gets their own session so
 	// requests resolve to the user that owns their cookie — never a shared one.
-	if s.authToken != "" {
-		sid := s.createUserSession(username, role)
-		if sid == "" {
-			jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to create session"})
-			return
-		}
-		setSessionCookie(w, r, sid)
-		// Mint the short-lived per-hive terminal assertion cookie the Node proxy
-		// verifies as its PRIMARY per-hive gate (finding C3 follow-up). Same
-		// {user,hive,role} just authorized for this session, bound to THIS hive
-		// with an expiry. No-op on non-hosted hives.
-		s.setTerminalAssertionCookie(w, r, username, role)
+	//
+	// Always mint the session. This used to be gated on s.authToken != "", which
+	// meant a spoke with no dashboard token logged "authenticated via device
+	// flow", returned {status:"complete"}, and set NO cookie at all — so "/"
+	// rejected the request and the login page bounced forever (same failure
+	// handleSSO fixed). The session store is the authority on identity here and
+	// does not depend on a shared token existing.
+	sid := s.createUserSession(username, role)
+	if sid == "" {
+		jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to create session"})
+		return
 	}
+	setSessionCookie(w, r, sid)
+	// Mint the short-lived per-hive terminal assertion cookie the Node proxy
+	// verifies as its PRIMARY per-hive gate (finding C3 follow-up). Same
+	// {user,hive,role} just authorized for this session, bound to THIS hive
+	// with an expiry. No-op on non-hosted hives.
+	s.setTerminalAssertionCookie(w, r, username, role)
 
 	// Audit the successful login with the authenticated GitHub username as the
 	// actor (not the request's X-Hive-User, which has no session yet at this

--- a/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -215,6 +215,86 @@ func TestCovDF_GHUserAuthPoll_DirectRouteViewer(t *testing.T) {
 	}
 }
 
+// TestCovDF_GHUserAuthPoll_EmptyAuthTokenStillMintsSession is the device-flow
+// twin of the SSO regression test: minting the session used to be gated on
+// s.authToken != "", so a spoke provisioned without a dashboard token returned
+// {status:"complete"} having set NO cookie at all — "/" rejected the very next
+// request and the login page bounced forever. The session store is the
+// authority on identity and does not depend on a shared token existing, so the
+// cookie must be set even when authToken is empty. The C3 terminal-assertion
+// cookie is minted in the same path and must not be lost either.
+func TestCovDF_GHUserAuthPoll_EmptyAuthTokenStillMintsSession(t *testing.T) {
+	s, deps, _ := dfServer(t, "complete", "octocat")
+	s.authToken = ""
+	// Give the terminal-assertion mint a signing key and a hive identity so the
+	// C3 cookie is observable (it is a no-op without both).
+	deps.Config.HiveID = testHiveID
+	t.Setenv("HIVE_HUB_SECRET", testHubSecret)
+
+	doPost(s, "/api/gh-user-auth/start", nil)
+
+	// Drive the poll with X-Forwarded-Proto set, mirroring production traffic
+	// behind the TLS-terminating proxy, so Secure cookie attributes are asserted.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/gh-user-auth/poll", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	s.mux.ServeHTTP(rec, req)
+
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["status"] != "complete" {
+		t.Fatalf("want complete, got %v (%s)", body["status"], rec.Body.String())
+	}
+
+	c := sessionCookie(rec)
+	if c == nil {
+		t.Fatal("no hive_session cookie set with empty authToken — the login page would bounce forever")
+	}
+	if c.Value == "" {
+		t.Fatal("hive_session cookie set to an empty value")
+	}
+	if !c.HttpOnly {
+		t.Error("session cookie must be HttpOnly")
+	}
+	if !c.Secure {
+		t.Error("session cookie must be Secure behind TLS-terminating nginx")
+	}
+	if c.Path != "/" {
+		t.Errorf("cookie Path = %q, want / so it is returned on the root request", c.Path)
+	}
+	if c.SameSite != http.SameSiteLaxMode {
+		t.Errorf("cookie SameSite = %v, want Lax", c.SameSite)
+	}
+
+	// The minted session must resolve to the authenticated identity, otherwise
+	// "/" rejects the very next request.
+	sess := s.lookupSession(c.Value)
+	if sess == nil {
+		t.Fatal("session cookie does not resolve to a session")
+	}
+	if sess.Username != "octocat" {
+		t.Errorf("session username = %q, want octocat", sess.Username)
+	}
+	if sess.Role != config.RoleOwner {
+		t.Errorf("session role = %q, want %q", sess.Role, config.RoleOwner)
+	}
+
+	// The C3 terminal-assertion mint lives in the same (formerly gated) path and
+	// must survive the un-nesting.
+	var terminal *http.Cookie
+	for _, ck := range (&http.Response{Header: rec.Header()}).Cookies() {
+		if ck.Name == terminalAssertionCookieName {
+			terminal = ck
+		}
+	}
+	if terminal == nil {
+		t.Fatal("no terminal assertion cookie set — the C3 mint was lost from the device-flow path")
+	}
+	if terminal.Value == "" {
+		t.Fatal("terminal assertion cookie set to an empty value")
+	}
+}
+
 func TestCovDF_GHUserAuthStatus_Session(t *testing.T) {
 	s, _, _ := dfServer(t, "complete", "octocat")
 	sid := s.createUserSession("alice", config.RoleOwner)


### PR DESCRIPTION
## Problem

On v4, the device-flow completion path in `v2/pkg/dashboard/api.go` wraps `createUserSession` + `setSessionCookie` + the C3 terminal-assertion mint in `if s.authToken != ""` (was line 1868). On a spoke provisioned with an **empty dashboard authToken**, a successful device-flow login returns `{status:"complete"}` having set **no cookie at all** — so `/` rejects the very next request and the login page bounces forever.

This is a v2-parity gap: v2's device-flow path (api.go:1799) mints unconditionally. It is also the exact failure v4's own `handleSSO` (api.go:1982) already fixed, whose comment explains it:

> Always mint the session. This used to be gated on `s.authToken != ""`, which meant a spoke with no dashboard token logged "authenticated via SSO", redirected to "/", and set NO cookie at all — so "/" rejected the request and the browser bounced forever. The session store is the authority on identity here and does not depend on a shared token existing.

## Fix

Drop the `authToken` gate in the device-flow completion path exactly as `handleSSO` did — always mint the session. The C3 terminal-assertion mint stays in the same path (not lost when un-nesting).

**Only the gating changes.** The mint functions, cookie format, and terminal-assertion machinery are untouched. All pre-mint authorization (identity verification before persisting anything, the direct-route allowlist denial) is unchanged and still runs before the mint.

## Test

Adds `TestCovDF_GHUserAuthPoll_EmptyAuthTokenStillMintsSession` — the device-flow twin of the SSO regression case in `sso_handoff_test.go` ("hub-proxied spoke with EMPTY dashboard token still sets a cookie"). With `authToken == ""`:

- device-flow completion returns `status: complete` **and** sets the `hive_session` cookie (HttpOnly, Secure behind the TLS-terminating proxy, `Path=/`, SameSite Lax)
- the cookie resolves via the session store to the authenticated identity (`octocat`, role `owner`)
- the C3 `hive_terminal_assertion` cookie is still minted in the same path