### PR TITLE
🔒 fix(knowledge): restore v2's doc-source file_path confinement

### DIFF
--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -45,6 +45,7 @@ type DocumentSource struct {
 	config         DocSourceConfig
 	metadata       DocMetadata
 	storageDir     string
+	knowledgeDir   string
 	vaultDir       string
 	graphStore     *GraphStore
 	logger         *slog.Logger
@@ -58,6 +59,7 @@ func NewDocumentSource(config DocSourceConfig, baseDir, vaultDir string, graphSt
 		slug:           slug,
 		config:         config,
 		storageDir:     filepath.Join(baseDir, docStorageDir, slug),
+		knowledgeDir:   baseDir,
 		vaultDir:       vaultDir,
 		graphStore:     graphStore,
 		logger:         logger,
@@ -127,6 +129,9 @@ func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {
 			return nil, fmt.Errorf("fetching URL: %w", err)
 		}
 	} else if ds.config.FilePath != "" {
+		if err := ds.validateFilePath(ds.config.FilePath); err != nil {
+			return nil, err
+		}
 		content, err = os.ReadFile(ds.config.FilePath)
 		if err != nil {
 			return nil, fmt.Errorf("reading file: %w", err)
@@ -337,6 +342,43 @@ func (ds *DocumentSource) fetchURL(ctx context.Context, url string) ([]byte, str
 		ct = detectContentType(url)
 	}
 	return body, normalizeContentType(ct), nil
+}
+
+// allowedFilePrefixes is the list of directory prefixes from which the hive
+// may read local documents. Restricting to /data/knowledge prevents an
+// authenticated caller from using file_path to read arbitrary server files
+// (e.g. /data/hive.yaml, /secrets/*, /etc/passwd).
+// Tests that use a DocumentSource with a file outside the knowledge dir must
+// override this variable for the duration of the test.
+var allowedFilePrefixes = []string{localKnowledgeDir + "/"}
+
+// validateLocalFilePath rejects any file_path that falls outside the
+// allowed knowledge directory. The path is cleaned before comparison to
+// block ../ traversal.
+func validateLocalFilePath(path string) error {
+	clean := filepath.Clean(path)
+	for _, prefix := range allowedFilePrefixes {
+		if strings.HasPrefix(clean, prefix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("file_path %q is outside the allowed knowledge directory (%s)", path, localKnowledgeDir)
+}
+
+// validateFilePath checks the file_path on this DocumentSource. Uses the
+// instance's knowledgeDir (set at construction time) when available, so that
+// unit tests constructing a DocumentSource with a temporary baseDir get their
+// correct prefix automatically. Falls back to the global allowedFilePrefixes.
+func (ds *DocumentSource) validateFilePath(path string) error {
+	if ds.knowledgeDir != "" {
+		clean := filepath.Clean(path)
+		prefix := ds.knowledgeDir + string(filepath.Separator)
+		if strings.HasPrefix(clean, prefix) {
+			return nil
+		}
+		return fmt.Errorf("file_path %q is outside the allowed knowledge directory (%s)", path, ds.knowledgeDir)
+	}
+	return validateLocalFilePath(path)
 }
 
 func (ds *DocumentSource) parseContent(content []byte, contentType string) ([]DocChunk, string) {

--- a/v2/pkg/knowledge/docsource_test.go
+++ b/v2/pkg/knowledge/docsource_test.go
@@ -69,6 +69,74 @@ func TestDocumentSource_ImportFile(t *testing.T) {
 	}
 }
 
+// TestDocumentSource_ImportFile_OutsideKnowledgeDirRejected is the positive
+// control for the file_path confinement guard: it points a doc source at a
+// real, readable file OUTSIDE the knowledge directory (simulating an
+// authenticated caller using file_path to exfiltrate e.g. /data/hive.yaml or
+// /secrets/*). If the validateFilePath check at the read site is removed,
+// Import succeeds reading the file and this test FAILS.
+func TestDocumentSource_ImportFile_OutsideKnowledgeDirRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultDir := filepath.Join(tmpDir, "vault")
+	baseDir := filepath.Join(tmpDir, "knowledge")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Readable file outside the knowledge dir (sibling of baseDir).
+	secretFile := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("super secret credentials"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Absolute path outside the knowledge dir must be rejected.
+	ds := NewDocumentSource(DocSourceConfig{
+		Name:     "evil-abs",
+		FilePath: secretFile,
+		Layer:    LayerProject,
+	}, baseDir, vaultDir, nil, logger, "")
+	if _, err := ds.Import(context.Background()); err == nil {
+		t.Fatal("expected Import to reject absolute file_path outside knowledge dir")
+	} else if !strings.Contains(err.Error(), "outside the allowed knowledge directory") {
+		t.Fatalf("expected confinement error, got: %v", err)
+	}
+
+	// ../ traversal escaping the knowledge dir must be rejected.
+	ds = NewDocumentSource(DocSourceConfig{
+		Name:     "evil-traversal",
+		FilePath: filepath.Join(baseDir, "..", "secret.txt"),
+		Layer:    LayerProject,
+	}, baseDir, vaultDir, nil, logger, "")
+	if _, err := ds.Import(context.Background()); err == nil {
+		t.Fatal("expected Import to reject ../ traversal escaping knowledge dir")
+	} else if !strings.Contains(err.Error(), "outside the allowed knowledge directory") {
+		t.Fatalf("expected confinement error, got: %v", err)
+	}
+
+	// No artifact may have been written for the rejected sources.
+	for _, slug := range []string{"evil-abs", "evil-traversal"} {
+		if _, err := os.Stat(filepath.Join(baseDir, docStorageDir, slug, docSourceFile+".txt")); !os.IsNotExist(err) {
+			t.Errorf("artifact for %s should not exist after rejected import", slug)
+		}
+	}
+
+	// A file inside the knowledge dir imports fine (guard is not over-broad).
+	okFile := filepath.Join(baseDir, "doc.txt")
+	if err := os.WriteFile(okFile, []byte("Legitimate knowledge content."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ds = NewDocumentSource(DocSourceConfig{
+		Name:     "ok-doc",
+		FilePath: okFile,
+		Layer:    LayerProject,
+	}, baseDir, vaultDir, nil, logger, "")
+	if _, err := ds.Import(context.Background()); err != nil {
+		t.Fatalf("expected in-dir import to succeed: %v", err)
+	}
+}
+
 func TestDocumentSource_ImportURL(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")

--- a/v2/pkg/knowledge/knowledge_coverage_test.go
+++ b/v2/pkg/knowledge/knowledge_coverage_test.go
@@ -146,6 +146,29 @@ func TestSplitAtParagraphs_SingleShort(t *testing.T) {
 	}
 }
 
+func TestValidateLocalFilePath(t *testing.T) {
+	orig := allowedFilePrefixes
+	t.Cleanup(func() { allowedFilePrefixes = orig })
+
+	base := t.TempDir()
+	allowedFilePrefixes = []string{base + string(filepath.Separator)}
+
+	if err := validateLocalFilePath(filepath.Join(base, "doc.md")); err != nil {
+		t.Fatalf("expected allowed local document path: %v", err)
+	}
+	if err := validateLocalFilePath(filepath.Join(base, "..", "secret.md")); err == nil {
+		t.Fatal("expected path outside allowed prefix to be rejected")
+	}
+
+	ds := &DocumentSource{knowledgeDir: base}
+	if err := ds.validateFilePath(filepath.Join(base, "nested", "doc.md")); err != nil {
+		t.Fatalf("expected DocumentSource path under knowledge dir: %v", err)
+	}
+	if err := ds.validateFilePath(filepath.Join(base, "..", "secret.md")); err == nil {
+		t.Fatal("expected DocumentSource path outside knowledge dir to be rejected")
+	}
+}
+
 // --- Context7 coverage (context7Get and wrappers) ---
 
 func TestContext7Get_Success(t *testing.T) {
@@ -393,8 +416,11 @@ func TestDocumentSource_ImportWithGraph(t *testing.T) {
 	baseDir := filepath.Join(tmpDir, "knowledge")
 	gs := newTestGraphStore(t)
 
-	srcFile := filepath.Join(tmpDir, "test.txt")
+	srcFile := filepath.Join(baseDir, "test.txt")
 	content := "First para about one thing.\n\nSecond para about another thing.\n\nThird para wraps up."
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(srcFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Security parity regression (v4 vs v2)

On v4, `DocumentSource.Import` reads a doc-source `file_path` with `os.ReadFile(ds.config.FilePath)` directly (`v2/pkg/knowledge/docsource.go:129-130`). v2 gates the same read with `ds.validateFilePath` → `validateLocalFilePath`, which confines local document reads to the knowledge directory (`/data/knowledge`) and blocks `../` traversal — its comment explicitly names `/data/hive.yaml` and `/secrets/*` as the targets it defends against.

**Impact on v4:** an authenticated caller creating a `file_path` doc source could read arbitrary in-container files (e.g. `/data/hive.yaml`, `/secrets/*`, `/etc/passwd`) and have their contents imported into the knowledge vault.

## Fix

Ports v2's guard verbatim, adapting only for v4's structural drift:

- `allowedFilePrefixes` / `validateLocalFilePath` / `(*DocumentSource).validateFilePath` restored in `v2/pkg/knowledge/docsource.go`, placed as in v2 (paths are `filepath.Clean`ed before prefix comparison to block `../` traversal)
- `knowledgeDir` field restored on `DocumentSource` and set from `baseDir` in `NewDocumentSource`, so unit tests with temporary base dirs get their correct prefix automatically (falls back to the global `localKnowledgeDir`-based prefix list otherwise, e.g. for sources restored via `LoadDocumentSource`)
- Guard wired at the read site in `Import`, before `os.ReadFile`

## Tests

- Ports v2's `TestValidateLocalFilePath` (traversal rejected; knowledge-dir read allowed; path outside the dir rejected — both the global helper and the instance method)
- Adds `TestDocumentSource_ImportFile_OutsideKnowledgeDirRejected` as a **positive control**: it points a doc source at a real, readable file outside the knowledge dir (absolute path and `../` traversal), asserts `Import` fails with the confinement error and writes no artifact, and asserts an in-dir read still succeeds. If the guard wiring at the read site is removed, `Import` succeeds and this test fails.
- `TestDocumentSource_ImportWithGraph` updated to match v2 (source file moved inside the knowledge dir), since the guard now correctly rejects its previous outside-the-dir fixture path.