### PR TITLE
fix(knowledge): register /api/knowledge/channels routes on v4

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -189,6 +189,11 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/knowledge/fact-history", s.handleFactHistory)
 	s.mux.HandleFunc("POST /api/knowledge/create", s.handleKnowledgeCreate)
 	s.mux.HandleFunc("POST /api/knowledge/import", s.handleKnowledgeImport)
+	// Channels (user-writable local vaults). Registered under /channels rather
+	// than /vaults so they don't collide with the GET /api/knowledge/{layer}
+	// wildcard below. This is the import-target surface fixed in #3581.
+	s.mux.HandleFunc("GET /api/knowledge/channels", s.handleKnowledgeChannelsList)
+	s.mux.HandleFunc("POST /api/knowledge/channels", s.handleKnowledgeChannelCreate)
 	s.mux.HandleFunc("POST /api/knowledge/promote", s.handleKnowledgePromote)
 	s.mux.HandleFunc("GET /api/knowledge/subscriptions", s.handleKnowledgeSubsList)
 	s.mux.HandleFunc("POST /api/knowledge/subscriptions", s.handleKnowledgeSubsAdd)
@@ -7144,6 +7149,38 @@ func (s *Server) handleKnowledgeImport(w http.ResponseWriter, r *http.Request) {
 	}
 	s.auditFromRequest(r, "knowledge_import", auditDetail("layer", req.Layer, "format", req.Format), "")
 	jsonResponse(w, map[string]interface{}{"ok": true, "imported": count, "layer": req.Layer, "format": req.Format})
+}
+
+// handleKnowledgeChannelsList returns the user-writable channels (vaults) that
+// facts can be imported into. The reserved automation vault is excluded (#3581).
+func (s *Server) handleKnowledgeChannelsList(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, []interface{}{})
+		return
+	}
+	jsonResponse(w, s.deps.Knowledge.WritableVaults())
+}
+
+// handleKnowledgeChannelCreate creates a new local channel (vault) to import into.
+func (s *Server) handleKnowledgeChannelCreate(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := decodeBody(r, &req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	info, err := s.deps.Knowledge.CreateVault(req.Name)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.auditFromRequest(r, "knowledge_channel_create", auditDetail("channel", info.Name), "")
+	jsonResponse(w, map[string]interface{}{"ok": true, "channel": info})
 }
 
 func (s *Server) handleKnowledgeSubsList(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_knowledge_channels_test.go
+++ b/v2/pkg/dashboard/api_knowledge_channels_test.go
@@ -1,0 +1,87 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestKnowledgeChannelsListRoute asserts GET /api/knowledge/channels is
+// actually registered on the mux (not a 404) and returns a JSON array — the
+// v2-parity gap where the dashboard SPA called this route but v4 never wired
+// it up.
+func TestKnowledgeChannelsListRoute(t *testing.T) {
+	s, _, wiki := apiServerWithKnowledge(t)
+	defer wiki.Close()
+
+	rec := doGet(s, "/api/knowledge/channels")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/knowledge/channels status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var out []interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("response is not a JSON array: %v (body: %s)", err, rec.Body.String())
+	}
+}
+
+// TestKnowledgeChannelsListNoKnowledge asserts the handler degrades to an
+// empty list rather than erroring when knowledge is disabled, mirroring the
+// other knowledge list handlers.
+func TestKnowledgeChannelsListNoKnowledge(t *testing.T) {
+	s, _ := apiServer(t)
+
+	rec := doGet(s, "/api/knowledge/channels")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != "[]\n" && got != "[]" {
+		t.Fatalf("body = %q, want empty JSON array", got)
+	}
+}
+
+// TestKnowledgeChannelCreateRoute asserts POST /api/knowledge/channels is
+// registered and validates its input, mirroring v2's handleKnowledgeChannelCreate.
+func TestKnowledgeChannelCreateRoute(t *testing.T) {
+	s, _, wiki := apiServerWithKnowledge(t)
+	defer wiki.Close()
+
+	rec := doOwnerPost(s, "/api/knowledge/channels", map[string]interface{}{"name": ""})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty channel name status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestKnowledgeChannelCreateNoKnowledge asserts the handler reports knowledge
+// as unavailable rather than 404ing when knowledge is disabled.
+func TestKnowledgeChannelCreateNoKnowledge(t *testing.T) {
+	s, _ := apiServer(t)
+
+	rec := doOwnerPost(s, "/api/knowledge/channels", map[string]interface{}{"name": "test-channel"})
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestKnowledgeChannelCreateBadJSON asserts malformed bodies are rejected
+// with 400 rather than panicking or falling through to a 404 (route absent).
+func TestKnowledgeChannelCreateBadJSON(t *testing.T) {
+	s, _, wiki := apiServerWithKnowledge(t)
+	defer wiki.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/knowledge/channels", nil)
+	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
+	req.Body = http.NoBody
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty body status = %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Problem
The dashboard SPA calls `POST /api/knowledge/channels` (create) and `GET /api/knowledge/channels` (list) — see `v2/pkg/dashboard/static/index.html:10665` and `:10711`. On v4 these routes were never registered, so both calls 404 live.

v2 registers both (`v2/pkg/dashboard/api.go` route table) with thin handlers `handleKnowledgeChannelsList` / `handleKnowledgeChannelCreate`. Only `/api/knowledge/vaults*` survived the v2→v4 sync; the channels routes and their handlers were dropped.

The underlying backend methods were never lost — `WritableVaults()` and `CreateVault()` are present on v4's `pkg/knowledge/api.go` (KnowledgeAPI) unchanged. This is purely a routing/handler gap.

## Fix
Ports v2's two route registrations and handlers verbatim into v4's `v2/pkg/dashboard/api.go`, in the same position (before the `GET /api/knowledge/{layer}` wildcard, so `/channels` doesn't collide with it) and with the same explanatory comment.

## Tests
Adds `v2/pkg/dashboard/api_knowledge_channels_test.go`, exercised through the real mux (`s.mux.ServeHTTP`) so it catches the exact failure mode (404 from a missing route), not just a direct handler call:
- `GET /api/knowledge/channels` returns 200 with a JSON array shape, both with knowledge enabled and disabled
- `POST /api/knowledge/channels` validates input (empty name → 400, malformed body → 400) and reports 503 when knowledge is disabled