### PR TITLE
fix(hub): port v2 delete-flow parity fixes to v4 — record purge + delete-in-flight UI

### DIFF
--- a/v2/pkg/hub/delete_hive_registry_test.go
+++ b/v2/pkg/hub/delete_hive_registry_test.go
@@ -25,15 +25,20 @@ func helperDeleteHiveEnv(t *testing.T) (*HubServer, *http.ServeMux) {
 	oldHives := saasHivesDir
 	oldUsers := saasUsersDir
 	oldRegistry := registryPath
+	oldTimeline := timelineDir
 
 	saasHivesDir = filepath.Join(dir, "hives")
 	saasUsersDir = filepath.Join(dir, "users")
 	registryPath = filepath.Join(dir, "hub-registry.json")
+	timelineDir = filepath.Join(dir, "timeline")
 	if err := os.MkdirAll(saasHivesDir, 0o755); err != nil {
 		t.Fatalf("mkdir hives: %v", err)
 	}
 	if err := os.MkdirAll(saasUsersDir, 0o755); err != nil {
 		t.Fatalf("mkdir users: %v", err)
+	}
+	if err := os.MkdirAll(timelineDir, 0o755); err != nil {
+		t.Fatalf("mkdir timeline: %v", err)
 	}
 
 	t.Cleanup(func() {
@@ -41,12 +46,37 @@ func helperDeleteHiveEnv(t *testing.T) (*HubServer, *http.ServeMux) {
 		saasHivesDir = oldHives
 		saasUsersDir = oldUsers
 		registryPath = oldRegistry
+		timelineDir = oldTimeline
 	})
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
 	return srv, mux
+}
+
+// helperHiveRecordExists reports whether the on-disk SaaS hive record dir
+// (hives/<id>/) still exists. This husk is what resurrected the hive: a delete
+// that left it behind — with status:"available" — kept the hive in the
+// unassigned/available listing across a hub restart.
+func helperHiveRecordExists(id string) bool {
+	if _, err := os.Stat(filepath.Join(saasHivesDir, id)); err == nil {
+		return true
+	}
+	return false
+}
+
+// helperTimelineFileExists reports whether the hive's timeline file
+// (timelineDir/<id>.json) still exists on disk.
+func helperTimelineFileExists(id string) bool {
+	tp := timelinePath(id)
+	if tp == "" {
+		return false
+	}
+	if _, err := os.Stat(tp); err == nil {
+		return true
+	}
+	return false
 }
 
 // helperRegistryHasHive reports whether the in-memory registry holds an entry.
@@ -119,6 +149,138 @@ func TestDeleteHiveRemovesRegistryEntryFromMemoryAndDisk(t *testing.T) {
 	}
 	if helperPersistedRegistryHasHive(t, hiveID) {
 		t.Error("hive still present in the persisted registry after delete (would resurrect on hub restart)")
+	}
+}
+
+// TestDeleteHiveWithNoClusterConfigPurgesOnDiskRecord is the direct regression
+// for the resurrection bug. When clusterForHive returns nil, deprovisionHive is
+// skipped — and deprovisionHive was the ONLY code that removed the hives/<id>/
+// dir. A slot record with status:"available" therefore survived on disk and the
+// hive reappeared in the unassigned/available listing after a hub restart, still
+// pointing at a namespace that no longer existed. After the fix the delete must
+// purge the on-disk record (and the timeline file) even with no cluster config.
+func TestDeleteHiveWithNoClusterConfigPurgesOnDiskRecord(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_purge", "del-purge-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+	// No cluster config → clusterForHive returns nil → deprovision is skipped.
+	srv.clusters = map[string]ClusterConfig{}
+
+	const hiveID = "hosted-del-purge-hive"
+	// The exact husk that resurrects: an available-looking slot record on disk.
+	if err := saveSaaSHive(&SaaSHive{
+		ID:        hiveID,
+		Owner:     "del-purge-owner",
+		ClusterID: "cluster-that-was-removed",
+		Status:    statusAvailable,
+	}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	// A timeline file that nothing else in the delete path ever removed.
+	srv.recordTimeline(hiveID, TimelineOwnership, "seeded", "tester")
+
+	if !helperHiveRecordExists(hiveID) {
+		t.Fatal("precondition: seeded hive record dir should exist on disk")
+	}
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-purge-owner"}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_purge")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	if helperRegistryHasHive(srv, hiveID) || helperPersistedRegistryHasHive(t, hiveID) {
+		t.Error("registry entry survived a no-cluster delete")
+	}
+	if helperHiveRecordExists(hiveID) {
+		t.Error("resurrection bug: on-disk hive record dir survived delete with no cluster config")
+	}
+	if helperTimelineFileExists(hiveID) {
+		t.Error("resurrection bug: timeline file survived delete")
+	}
+}
+
+// TestDeleteHivePurgesTimelineFile pins that the timeline file is removed on a
+// normal delete too. deprovisionHive removes the hive dir but never touched the
+// timeline; removeHiveRecord closes that gap.
+func TestDeleteHivePurgesTimelineFile(t *testing.T) {
+	cleanup := helperSetupAuthUser(t, "ghp_del_tl", "del-tl-owner")
+	defer cleanup()
+
+	srv, mux := helperDeleteHiveEnv(t)
+
+	const hiveID = "hosted-del-tl-hive"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "del-tl-owner", ClusterID: defaultClusterID}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	srv.recordTimeline(hiveID, TimelineOwnership, "seeded", "tester")
+	if !helperTimelineFileExists(hiveID) {
+		t.Fatal("precondition: seeded timeline file should exist on disk")
+	}
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "del-tl-owner"}}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/"+hiveID, nil)
+	req.Header.Set("Authorization", "Bearer ghp_del_tl")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if helperHiveRecordExists(hiveID) {
+		t.Error("on-disk hive record dir survived delete")
+	}
+	if helperTimelineFileExists(hiveID) {
+		t.Error("timeline file survived delete")
+	}
+}
+
+// TestRemoveHiveRecordRefusesTraversal pins the path-traversal guard:
+// removeHiveRecord takes an id that (in the handler's h == nil path) may not
+// have been round-tripped through loadSaaSHive, so the function itself must
+// refuse any id that could escape saasHivesDir / timelineDir. A hostile id
+// containing "..", "/" or "\" must remove NOTHING outside the record dirs.
+func TestRemoveHiveRecordRefusesTraversal(t *testing.T) {
+	_, _ = helperDeleteHiveEnv(t)
+
+	// A sibling of saasHivesDir that a "../victim" id would resolve to.
+	victim := filepath.Join(filepath.Dir(saasHivesDir), "victim")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	sentinel := filepath.Join(victim, "keep.txt")
+	if err := os.WriteFile(sentinel, []byte("do not delete"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	for _, id := range []string{"../victim", "..", "a/../../victim", `..\victim`, "/victim"} {
+		removeHiveRecord(id, slog.Default())
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("traversal escape: removeHiveRecord deleted a file outside the record dirs: %v", err)
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Fatalf("traversal escape: removeHiveRecord deleted a directory outside the record dirs: %v", err)
+	}
+
+	// A safe id still purges its own record dir + timeline file.
+	const safeID = "hosted-traversal-safe-hive"
+	if err := saveSaaSHive(&SaaSHive{ID: safeID, Owner: "trav-owner", ClusterID: defaultClusterID}); err != nil {
+		t.Fatalf("seed hive: %v", err)
+	}
+	removeHiveRecord(safeID, slog.Default())
+	if helperHiveRecordExists(safeID) {
+		t.Error("removeHiveRecord left a safe id's record dir behind")
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3420,9 +3420,12 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 
 	h := loadSaaSHive(id)
 	if h == nil {
-		// SaaS entry already gone — still clean up the in-memory registry
-		// so the hive disappears from the listing immediately.
+		// SaaS meta.json already gone — still clean up the in-memory registry so
+		// the hive disappears from the listing immediately, and best-effort purge
+		// any leftover record dir / timeline file so a partial prior delete cannot
+		// leave a status:"available" husk that resurrects in the listing.
 		s.removeRegistryEntry(id, username)
+		removeHiveRecord(id, s.logger)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": deleteStatusDeleted})
 		return
@@ -3450,6 +3453,21 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("no cluster config for deprovision; removing registry entry anyway",
 			"hive_id", id, "cluster_id", h.ClusterID)
 	}
+	// Durably purge the hub-side record. This is what stops the "resurrection":
+	// deprovisionHive removes the hive directory only when a cluster config is
+	// available (the else branch above skips it), and NEITHER path removes the
+	// timeline file. Without this, a delete with no cluster config left the
+	// hives/<id>/ dir — status:"available" — behind, so the hive reappeared in
+	// the unassigned/available list forever. removeHiveRecord is idempotent, so
+	// calling it after a successful deprovision (which already removed the dir)
+	// is harmless and still cleans up the timeline file deprovision never touched.
+	//
+	// NOTE: this is the genuine, user-initiated delete path. It is deliberately
+	// NOT the placeholder-recycle path — resetting a slot to status:"available"
+	// (handleResetAssignment / sweepStuckAssignments in saas_reset_assignment.go)
+	// rewrites meta.json in place and KEEPS the record, and never reaches this
+	// handler. So purging the record here cannot break placeholder recycling.
+	removeHiveRecord(id, s.logger)
 	s.removeRegistryEntry(id, username)
 
 	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username,
@@ -9485,7 +9503,9 @@ const dashboardHTML = `<!DOCTYPE html>
       var c = colors[st] || colors.unknown;
       var ic = icons[st] || '?';
       var isUpgrading = _upgradingHives[h.id];
-      var statusLabel = isUpgrading ? 'Starting up after upgrade' : st.charAt(0).toUpperCase() + st.slice(1);
+      var isDeleting = _deletingHives[h.id];
+      if (isDeleting) { c = colors.warning; ic = '⏳'; }
+      var statusLabel = isDeleting ? 'Deleting…' : (isUpgrading ? 'Starting up after upgrade' : st.charAt(0).toUpperCase() + st.slice(1));
       /* Checks, failures first, so the reason for a bad status reads before the
          wall of passing checks. Stable within each group (spoke report order). */
       var checks = healthChecks(h).slice().sort(function(a, b) {
@@ -13830,6 +13850,10 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     var _upgradingHives = {};
+    // _deletingHives[id] = true while a hive delete is in flight, so the hub
+    // table shows a "Deleting…" status on that row instead of the row just
+    // silently vanishing (or looking normal) mid-teardown.
+    var _deletingHives = {};
     var _switchStartedAt = {}; // hiveId → ms timestamp the switch was initiated
     var SWITCH_STALE_MS = 8 * 60 * 1000; // warn if a switch hasn't landed in 8 min
 
@@ -16450,6 +16474,9 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!await hiveConfirm('Delete ' + id + '? This removes the namespace, PV, OCI storage, and all data.')) return;
       var btns = document.querySelectorAll('button[onclick*="deleteHive"]');
       btns.forEach(function(b) { b.disabled = true; b.textContent = 'Deleting...'; b.style.opacity = '0.6'; });
+      // Mark the row as deleting so its status shows "Deleting…" until the next
+      // refresh removes it (or clears the flag on failure).
+      _deletingHives[id] = true;
       try {
         gtag('event','hive_deleted',{hive_id:id});
         hiveToast('Deleting ' + id + '...', 'info');
@@ -16457,6 +16484,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!resp.ok) {
           var d = await resp.json().catch(function(){ return {}; });
           hiveToast(d.error || 'Delete failed', 'error');
+          delete _deletingHives[id];
           // Refresh regardless: the hub removes the registry entry even when
           // teardown fails, so the listing may already be correct.
           loadHives();
@@ -16475,7 +16503,7 @@ const dashboardHTML = `<!DOCTYPE html>
           hiveToast('Deleted ' + id, 'success');
         }
         loadHives();
-      } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
+      } catch(e) { hiveToast('Error: ' + e.message, 'error'); delete _deletingHives[id]; }
       finally { btns.forEach(function(b) { b.disabled = false; b.textContent = 'Delete'; b.style.opacity = '1'; }); }
     }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1550,6 +1550,40 @@ func saveSaaSHive(h *SaaSHive) error {
 	return os.Rename(tmpPath, path)
 }
 
+// removeHiveRecord durably purges the hub-side, on-disk record for a deleted
+// hive: the per-hive directory under saasHivesDir/<id>/ (meta.json + manifests +
+// requests.json) and the hive's timeline file under timelineDir/<id>.json.
+//
+// This is the counterpart to saveSaaSHive and closes the "resurrection" bug:
+// deprovisionHive removes the hive directory only when a cluster config is
+// available, and NOTHING removed the timeline file. A delete that could not run
+// deprovision (no cluster config) therefore left the hive/<id>/ directory —
+// with status:"available" — on disk, so the hive reappeared in the
+// unassigned/available listing forever, pointing at a namespace that no longer
+// existed. Removing the record here makes the delete stick across a hub restart.
+//
+// Best-effort by design: a delete must never be blocked by a leftover file, and
+// the registry entry is the row the user actually sees. Failures are logged, not
+// returned. The path-traversal guard mirrors loadSaaSHive/saveSaaSHive so a
+// hostile id can never escape the record dirs.
+func removeHiveRecord(id string, logger *slog.Logger) {
+	if strings.Contains(id, "..") || strings.Contains(id, "/") || strings.Contains(id, "\\") {
+		logger.Warn("removeHiveRecord: refusing unsafe hive id", "hive_id", id)
+		return
+	}
+	hiveDir := filepath.Join(saasHivesDir, id)
+	if err := os.RemoveAll(hiveDir); err != nil {
+		logger.Warn("removeHiveRecord: failed to remove hive directory", "path", hiveDir, "error", err)
+	}
+	// timelinePath applies its own traversal guard and returns "" if the id is
+	// not a safe filename; skip the removal in that case.
+	if tp := timelinePath(id); tp != "" {
+		if err := os.Remove(tp); err != nil && !os.IsNotExist(err) {
+			logger.Warn("removeHiveRecord: failed to remove timeline file", "path", tp, "error", err)
+		}
+	}
+}
+
 func listSaaSHives() []SaaSHive {
 	entries, err := os.ReadDir(saasHivesDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

Ports two v2-parity fixes into v4's hive-delete flow.

### Gap 1 — husk resurrection (hub)

v4's `handleDeleteHive` only called `removeRegistryEntry` on both of its paths. `deprovisionHive` removes the `hives/<id>/` record dir only when a cluster config is available, and nothing removed the timeline file — so a delete that could not run deprovision left a `status:"available"` husk on disk that resurrected in the unassigned/available listing across hub restarts (the exact bug v2 already fixed and documented).

- Port `removeHiveRecord` into `v2/pkg/hub/saas_provision.go`: `RemoveAll` of the hive record dir + removal of the timeline file, best-effort (logged, never blocking the delete), with the path-traversal guard intact (`..`, `/`, `\` refused; `timelinePath` applies its own guard).
- Call it on **both** delete paths in `handleDeleteHive`, mirroring v2: the `h == nil` early-return path (so a partial prior delete cannot leave a husk) and the main path after deprovision (idempotent; also cleans the timeline file deprovision never touched).

### Gap 2 — SPA delete-in-flight guard (hub SPA)

v4's `deleteHive` had no in-flight tracking, so a row being deleted looked normal (or silently vanished) mid-teardown. Port v2's `_deletingHives` map:

- declaration next to `_upgradingHives`
- set on delete start, cleared on the failure and error paths
- `healthBadge` renders the row as `Deleting…` (warning colour, hourglass icon) while the flag is set

### Tests

- Port v2's `TestDeleteHiveWithNoClusterConfigPurgesOnDiskRecord` and `TestDeleteHivePurgesTimelineFile`, plus the `helperHiveRecordExists` / `helperTimelineFileExists` helpers and `timelineDir` isolation in `helperDeleteHiveEnv`.
- Add `TestRemoveHiveRecordRefusesTraversal`: hostile ids (`../victim`, `..`, `a/../../victim`, `..\victim`, `/victim`) must remove nothing outside the record dirs, and a safe id still purges its own record.

Note: `gofmt` drift flagged in `saas_provision.go` is pre-existing on clean v4 (const block alignment) and deliberately left untouched.