### PR TITLE
v2-parity + cleanup batch: build timer, tooltip test, stale comments, shared parseCookies

### DIFF
--- a/v2/pkg/dashboard/session.go
+++ b/v2/pkg/dashboard/session.go
@@ -19,8 +19,8 @@ import (
 // that owns ITS cookie — never a single shared identity.
 //
 // The GitHub OAuth token is intentionally NOT stored on the session; the token
-// lives only where it is needed (SetUserClient / userTokenPath) and is never
-// exposed through the session. The session carries only identity + role.
+// lives only in the persisted userTokenPath file and is never exposed through
+// the session. The session carries only identity + role.
 type userSession struct {
 	Username  string
 	Role      string

--- a/v2/pkg/hub/offline_dot_tooltip_test.go
+++ b/v2/pkg/hub/offline_dot_tooltip_test.go
@@ -1,0 +1,45 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOfflineStatusDotCarriesTooltip pins the native `title` tooltip on the
+// My Hives status dot in its OFFLINE state. The online dot has always carried a
+// rich hover via healthBadge() (status + ns: + heartbeat age), but the grey
+// offline dot rendered as a bare '<span class="online-dot off"></span>' with no
+// title at all — so an operator hovering a dead row could not even see which
+// Kubernetes namespace the hive runs in without cross-referencing the registry
+// by hand. This asserts the offline dot now builds a defensive title from the
+// same facts an operator needs to go find the hive on the cluster.
+//
+// String-anchored on the raw dashboardHTML, same as the other JS structure
+// tests (see TestDashboardHeartbeatHeartFlashesOnReceipt).
+func TestOfflineStatusDotCarriesTooltip(t *testing.T) {
+	// The offline dot span must now carry a title attribute (and a help cursor),
+	// no longer the bare untitled span.
+	if strings.Contains(dashboardHTML, `: '<span class="online-dot off"></span>');`) {
+		t.Error("offline status dot is still the bare untitled '<span class=\"online-dot off\"></span>' — it must carry a title tooltip")
+	}
+	if !strings.Contains(dashboardHTML, `'<span class="online-dot off" title="' + escAttr(offlineDotTitle) + '" style="cursor:help"></span>'`) {
+		t.Error("offline status dot lost its escAttr(offlineDotTitle) title attribute")
+	}
+
+	// The tooltip is built defensively: a status word, then the namespace,
+	// cluster and last-seen lines, each skipped when its field is empty.
+	for _, part := range []string{
+		`var offlineDotTitle = (function() {`,
+		`var parts = ['Offline'];`,
+		`var ns = hiveNamespace(h);`,
+		`if (ns) parts.push('ns: ' + ns);`,
+		`var cluster = h.clusterName || h.clusterId || '';`,
+		`if (cluster) parts.push('cluster: ' + cluster);`,
+		`if (h.lastHeartbeat) parts.push('last seen: ' + fmtUserTS(h.lastHeartbeat));`,
+		`return parts.join('\n');`,
+	} {
+		if !strings.Contains(dashboardHTML, part) {
+			t.Errorf("offline status dot tooltip is missing its %q builder line", part)
+		}
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3392,15 +3392,11 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	// Mint the handoff token. Without a hub secret we can't sign one, so fall
 	// back to a plain dashboard redirect (spoke will prompt for login).
 	//
-	// Dual-mint (transitional v2→v4 backport): a v4 spoke verifies SSO with an
-	// Ed25519 PUBLIC key and CANNOT verify a legacy symmetric HMAC token; the 33
-	// old spokes verify symmetric and CANNOT verify Ed25519. So the hub must mint
-	// the scheme THIS consuming hive can verify. We branch per-hive on a positive
-	// v4 signal (hiveWantsEd25519SSO: the console-hive allowlist plus a
-	// heartbeat-reported v4 commit/image), and DEFAULT to the legacy symmetric
-	// mint for every hive not positively identified as v4 — so the old fleet is
-	// never broken. Once all hives report a v4 version this becomes version-driven
-	// and the allowlist can be retired.
+	// Ed25519-only: every v4 spoke verifies SSO handoff tokens with an Ed25519
+	// PUBLIC key (see MintSSOToken/VerifySSOToken in sso.go). There is no
+	// per-hive branching or legacy symmetric fallback here — the hub always
+	// mints with its Ed25519 signing seed, and a spoke that cannot verify
+	// Ed25519 tokens simply falls through to the plain dashboard redirect below.
 	if s.hubSecret != "" {
 		if tok := MintSSOToken(s.ssoSigningSeed(), username, role, id, time.Now()); tok != "" {
 			http.Redirect(w, r, base+"/sso?token="+url.QueryEscape(tok), http.StatusSeeOther)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2948,21 +2948,22 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
-		"hives":                   result,
-		"saas_quota":              user.SaaSQuota,
-		"saas_used":               saasCount,
-		"is_admin":                isAdmin,
-		"latest_sha":              getLatestSHA(),
-		"latest_shas":             getDisplaySHAs(),
-		"latest_sha_messages":     getDisplaySHAMessages(),
-		"latest_sha_image_status": getImageStatuses(),
-		"commit_messages":         getCommitMessages(),
-		"hub_git_hash":            s.hubGitHash,
-		"hub_git_branch":          s.hubGitBranch,
-		"tracked_branches":        s.trackedBranchList(),
-		"hub_auto_upgrade":        isHubAutoUpgrade(),
-		"hub_upgrade_state":       s.hubUpgradeState(),
-		"show_my_hives":           true,
+		"hives":                    result,
+		"saas_quota":               user.SaaSQuota,
+		"saas_used":                saasCount,
+		"is_admin":                 isAdmin,
+		"latest_sha":               getLatestSHA(),
+		"latest_shas":              getDisplaySHAs(),
+		"latest_sha_messages":      getDisplaySHAMessages(),
+		"latest_sha_image_status":  getImageStatuses(),
+		"latest_sha_build_started": getImageBuildStartTimes(),
+		"commit_messages":          getCommitMessages(),
+		"hub_git_hash":             s.hubGitHash,
+		"hub_git_branch":           s.hubGitBranch,
+		"tracked_branches":         s.trackedBranchList(),
+		"hub_auto_upgrade":         isHubAutoUpgrade(),
+		"hub_upgrade_state":        s.hubUpgradeState(),
+		"show_my_hives":            true,
 		// Fleet alerts ship WITH the hive list so the "Attention needed" panel
 		// renders in the same paint as the rows it summarises — a second
 		// round-trip would make the panel pop in after the list and shift it.
@@ -3054,14 +3055,15 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"authenticated":           true,
-		"show_my_hives":           true,
-		"hives":                   hiveAccess,
-		"latest_sha":              getLatestSHA(),
-		"latest_shas":             getDisplaySHAs(),
-		"latest_sha_messages":     getDisplaySHAMessages(),
-		"latest_sha_image_status": getImageStatuses(),
-		"commit_messages":         getCommitMessages(),
+		"authenticated":            true,
+		"show_my_hives":            true,
+		"hives":                    hiveAccess,
+		"latest_sha":               getLatestSHA(),
+		"latest_shas":              getDisplaySHAs(),
+		"latest_sha_messages":      getDisplaySHAMessages(),
+		"latest_sha_image_status":  getImageStatuses(),
+		"latest_sha_build_started": getImageBuildStartTimes(),
+		"commit_messages":          getCommitMessages(),
 	})
 }
 
@@ -4292,6 +4294,12 @@ type branchHeadInfo struct {
 	SHA         string
 	Message     string
 	ImageStatus string
+	// BuildStartedAt is when THIS SHA first entered the "building" status, so the
+	// dashboard can show an elapsed build timer. It is stamped once on the
+	// ready→building (or new-SHA→building) transition and preserved across polls
+	// while the same SHA keeps building; it is zeroed when the image finishes
+	// (ready/failed) or a new SHA takes over. Zero means "not building / unknown".
+	BuildStartedAt time.Time
 }
 
 // githubAPIBase and ghcrBase are the GitHub/GHCR origins used by the SHA-poll
@@ -4682,10 +4690,24 @@ func getBranchHead(branch string) branchHeadInfo {
 func setBranchHead(branch, sha, msg, status string) {
 	latestSHAMu.Lock()
 	defer latestSHAMu.Unlock()
-	if msg == "" && headSHAByBranch[branch].SHA == sha {
-		msg = headSHAByBranch[branch].Message
+	prev := headSHAByBranch[branch]
+	if msg == "" && prev.SHA == sha {
+		msg = prev.Message
 	}
-	headSHAByBranch[branch] = branchHeadInfo{SHA: sha, Message: msg, ImageStatus: status}
+	// Stamp the build-start time on the first poll that sees this SHA building,
+	// and carry it forward on every subsequent poll while the same SHA is still
+	// building — so the dashboard's elapsed timer counts from when the build
+	// actually started, not from each poll. Clear it once the image is
+	// ready/failed or a different SHA takes over.
+	var buildStartedAt time.Time
+	if status == imageStatusBuilding {
+		if prev.SHA == sha && !prev.BuildStartedAt.IsZero() {
+			buildStartedAt = prev.BuildStartedAt // same build, keep the original start
+		} else {
+			buildStartedAt = time.Now() // newly observed building SHA
+		}
+	}
+	headSHAByBranch[branch] = branchHeadInfo{SHA: sha, Message: msg, ImageStatus: status, BuildStartedAt: buildStartedAt}
 	if msg != "" {
 		commitMsgBySHA[sha] = msg
 	}
@@ -4740,6 +4762,22 @@ func getImageStatuses() map[string]string {
 	for k, v := range headSHAByBranch {
 		if v.SHA != "" && v.ImageStatus != "" {
 			cp[k] = v.ImageStatus
+		}
+	}
+	return cp
+}
+
+// getImageBuildStartTimes returns branch→unix-millis of when each currently
+// "building" head first started building, for the dashboard's elapsed build
+// timer. Only branches that are actively building have an entry; ready/failed/
+// unknown branches are omitted. Millis match the JS side (Date.now()).
+func getImageBuildStartTimes() map[string]int64 {
+	latestSHAMu.RLock()
+	defer latestSHAMu.RUnlock()
+	cp := make(map[string]int64, len(headSHAByBranch))
+	for k, v := range headSHAByBranch {
+		if v.SHA != "" && v.ImageStatus == imageStatusBuilding && !v.BuildStartedAt.IsZero() {
+			cp[k] = v.BuildStartedAt.UnixMilli()
 		}
 	}
 	return cp
@@ -9979,6 +10017,32 @@ const dashboardHTML = `<!DOCTYPE html>
     var _latestSHAs = {};
     var _latestSHAMessages = {};
     var _latestImageStatus = {};
+    /* branch -> unix-millis when the currently-building image started building,
+       from the hub (getImageBuildStartTimes). Drives the elapsed build timer. */
+    var _latestBuildStarted = {};
+
+    /* Format elapsed build time from an epoch-ms start as "Mm Ss" (or "Ss" under
+       a minute). Clamps negatives (clock skew) to 0. */
+    function fmtBuildElapsed(startMs) {
+      var s = Math.max(0, Math.floor((Date.now() - Number(startMs)) / 1000));
+      var m = Math.floor(s / 60);
+      var rem = s % 60;
+      return m > 0 ? (m + 'm ' + rem + 's') : (rem + 's');
+    }
+
+    /* Live-update every rendered build timer once a second, in place, so the
+       count climbs without re-rendering the whole image panel or hitting the
+       hub. Runs off a single shared interval started once below. */
+    function _tickBuildTimers() {
+      var els = document.querySelectorAll('.build-timer');
+      for (var i = 0; i < els.length; i++) {
+        var start = els[i].getAttribute('data-build-start');
+        if (start) els[i].textContent = fmtBuildElapsed(start);
+      }
+    }
+    if (typeof window !== 'undefined' && !window._buildTimerInterval) {
+      window._buildTimerInterval = setInterval(_tickBuildTimers, 1000);
+    }
     var _trackedBranchesList = [];
     var _clusterList = [];
     var _commitMessages = {};
@@ -12440,6 +12504,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (data.tracked_branches) _trackedBranchesList = data.tracked_branches;
         if (data.latest_sha_messages) _latestSHAMessages = data.latest_sha_messages;
         if (data.latest_sha_image_status) _latestImageStatus = data.latest_sha_image_status;
+        _latestBuildStarted = data.latest_sha_build_started || {};
         if (data.commit_messages) _commitMessages = data.commit_messages;
         if (data.hub_auto_upgrade !== undefined) _hubAutoUpgrade = data.hub_auto_upgrade;
         var shaEl = document.getElementById('latest-image-sha');
@@ -12453,7 +12518,15 @@ const dashboardHTML = `<!DOCTYPE html>
               var brStatus = _latestImageStatus[br] || 'ready';
               var brStatusHTML = '';
               if (brStatus === 'building') {
-                brStatusHTML = '<span style="display:inline-block;flex:none;width:10px;height:10px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite" title="Container image for this commit is still building"></span><span style="font-size:0.65rem;color:var(--muted);opacity:0.7;white-space:nowrap">building image…</span>';
+                var _bStart = _latestBuildStarted[br];
+                /* Elapsed build timer: a span the live ticker (_tickBuildTimers)
+                   refreshes each second. data-build-start carries the epoch-ms
+                   start so the ticker can recompute without a server round-trip.
+                   Omitted when the hub hasn't reported a start time yet. */
+                var _timerHTML = _bStart
+                  ? '<span class="build-timer" data-build-start="' + _bStart + '" style="font-size:0.65rem;color:var(--muted);opacity:0.7;white-space:nowrap;font-variant-numeric:tabular-nums">' + fmtBuildElapsed(_bStart) + '</span>'
+                  : '';
+                brStatusHTML = '<span style="display:inline-block;flex:none;width:10px;height:10px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite" title="Container image for this commit is still building"></span><span style="font-size:0.65rem;color:var(--muted);opacity:0.7;white-space:nowrap">building image…</span>' + _timerHTML;
               } else if (brStatus === 'failed') {
                 brStatusHTML = '<span style="color:var(--red);font-size:0.7rem;cursor:help" title="Image build failed for this commit — upgrades keep using the previous image">✗</span>';
               }

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -322,6 +322,16 @@ function verifyTerminalAssertion(key, token, expectedHiveID, nowSec) {
 // authorizeTerminal — this only changes whether the hub cookie must ALSO be
 // present.
 //
+// parseCookies is shared by the HTTP and WebSocket terminal gates so the two
+// cannot drift — they are equally exploitable and must stay in lockstep.
+function parseCookies(header) {
+  return (header || '').split(';').reduce((acc, c) => {
+    const [k, ...v] = c.trim().split('=');
+    if (k) acc[k] = v.join('=');
+    return acc;
+  }, {});
+}
+
 // Returns the identity to authorize as, or null if neither credential is usable.
 // Fails closed: an absent, expired, wrong-hive or badly-signed assertion with no
 // valid hub cookie yields null and the caller denies.
@@ -729,11 +739,7 @@ app.use('/terminal', (req, res, next) => {
   const host = req.headers.host || '';
   const isHosted = isHostedHost(host);
   if (isHosted) {
-    const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
-      const [k, ...v] = c.trim().split('=');
-      if (k) acc[k] = v.join('=');
-      return acc;
-    }, {});
+    const cookies = parseCookies(req.headers.cookie);
     // SECURITY (CWE-345): the cookie is HMAC-signed by the hub. Verify the
     // signature — a non-empty value is NOT proof of authentication.
     const user = resolveTerminalIdentity(cookies);
@@ -832,11 +838,7 @@ server.on('upgrade', (req, socket, head) => {
     const host = req.headers.host || '';
     const isHosted = isHostedHost(host);
     if (isHosted) {
-      const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
-        const [k, ...v] = c.trim().split('=');
-        if (k) acc[k] = v.join('=');
-        return acc;
-      }, {});
+      const cookies = parseCookies(req.headers.cookie);
       // SECURITY (CWE-345): verify the hub's HMAC signature, not mere existence.
       const wsUser = resolveTerminalIdentity(cookies);
       if (!wsUser) {


### PR DESCRIPTION
Batch of five small v2-parity + cleanup items on v4. Each item is a separate commit.

## 1. Build timer parity (feat)

v2 tracked per-branch-head `BuildStartedAt`, reported it as `latest_sha_build_started` in two hub payloads, and rendered a live per-second elapsed-build ticker in My Hives. v4's `branchHeadInfo` had no such field.

Ported all three layers:
- `branchHeadInfo.BuildStartedAt`, stamped on the ready→building (or new-SHA→building) transition and carried forward across polls of the same SHA in `setBranchHead`, cleared on ready/failed/new-SHA.
- `getImageBuildStartTimes()` (branch → unix-millis), wired into `latest_sha_build_started` in both hub payloads that already send `latest_sha_image_status` (`handleMyHives` and `handleAccessStatus`).
- SPA ticker: `_latestBuildStarted` intake, `fmtBuildElapsed`, `_tickBuildTimers` on a shared 1s interval, rendering a `data-build-start`-carrying `.build-timer` span next to the "building image…" indicator so the elapsed time climbs live.

v4's code at this location matched v2's structure closely enough that this was a direct, faithful port — no architectural adaptation needed beyond current line numbers.

## 2. Tooltip test coverage parity (test)

Re-added `offline_dot_tooltip_test.go` (`TestOfflineStatusDotCarriesTooltip`), lost when the offline-dot-tooltip feature was ported to v4 in #3671. Verified first that v4's `offlineDotTitle` markup is byte-identical to v2's — it is — so the test was copied verbatim with no adaptation.

## 3. Stale dual-mint comment cleanup (docs)

The comment above the SSO handoff mint in `handleHiveSSO` (saas.go, ~3392-3403) described a transitional dual-mint scheme branching on a `hiveWantsEd25519SSO` signal between Ed25519 and legacy symmetric HMAC tokens. That symbol doesn't exist on v4, and the code only ever calls `MintSSOToken` with the hub's Ed25519 seed. Rewrote the comment to describe the actual Ed25519-only behavior (see `sso.go` for the full design rationale, which was already accurate).

## 4. Stale SetUserClient comment cleanup (docs)

`session.go`'s `userSession` doc comment referenced a `SetUserClient` abstraction that no longer exists (removed by the empty-scope port). `userTokenPath` is still real (`api.go:1724`, a flat file at `/data/gh-user-token`). Updated the comment to describe the current single-file token persistence instead of the removed abstraction.

## 5. Extract shared parseCookies helper in proxy/server.js (refactor)

**Security-relevant — pure refactor, read carefully.**

v4's `proxy/server.js` inlined the same cookie-parsing block twice: once in the HTTP `/terminal` gate, once in the WebSocket upgrade `/terminal` gate. v2 has a shared `parseCookies` helper specifically so the two gates can't drift apart.

Extracted the identical logic into one helper (byte-identical body to v2's):

```js
// parseCookies is shared by the HTTP and WebSocket terminal gates so the two
// cannot drift — they are equally exploitable and must stay in lockstep.
function parseCookies(header) {
  return (header || '').split(';').reduce((acc, c) => {
    const [k, ...v] = c.trim().split('=');
    if (k) acc[k] = v.join('=');
    return acc;
  }, {});
}
```

Both call sites now read:

```js
// HTTP /terminal gate
const cookies = parseCookies(req.headers.cookie);

// WebSocket /terminal upgrade gate
const cookies = parseCookies(req.headers.cookie);
```

Each previously had its own copy of exactly this `(req.headers.cookie || '').split(';').reduce(...)` block — same delimiter split, same `trim()`, same `=`-rejoin for values containing `=`, same empty-key skip. No verification/signature-check logic touched; only the duplicated parsing was collapsed into one function both gates call.
