### PR TITLE
fix: wire label-queued auto-merge sweep into the governor loop (v2 parity)

### DIFF
--- a/v2/cmd/hive/automerge_label_test.go
+++ b/v2/cmd/hive/automerge_label_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+func TestNormalizedAutoMergeLabel(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		label string
+		want  string
+	}{
+		{name: "configured", label: "ship-it", want: "ship-it"},
+		{name: "trims", label: "  ship-it  ", want: "ship-it"},
+		{name: "blank falls back", label: " \t\n ", want: github.AutoMergeQueuedLabel},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizedAutoMergeLabel(tt.label); got != tt.want {
+				t.Fatalf("normalizedAutoMergeLabel(%q) = %q, want %q", tt.label, got, tt.want)
+			}
+		})
+	}
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1019,7 +1019,7 @@ func main() {
 	appAuthState := ghAuth.State
 	if ghClient != nil && len(cfg.Governor.Labels.Exempt) > 0 {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
-		ghClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
+		ghClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 	}
 	// The user write-token client (userGHClient) was removed: every GitHub write
 	// — issues, PRs, comments, merges, and the advisory digest — now goes through
@@ -1539,7 +1539,7 @@ func main() {
 			ghClient.SetRepos(cfg.Project.Repos)
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
-				ghClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
+				ghClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 			}
 			logger.Info("migrated config overrides from state to hive.yaml",
 				"repos", cfg.Project.Repos)
@@ -2196,7 +2196,7 @@ func main() {
 			newClient := github.NewClientFromAppWithBotLogin(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.BotLogin())
 			if len(cfg.Governor.Labels.Exempt) > 0 {
 				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
-				newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
+				newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 			}
 
 			ghClient = newClient
@@ -2597,7 +2597,7 @@ func main() {
 					newClient := github.NewClientFromAppWithBotLogin(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.BotLogin())
 					if len(cfg.Governor.Labels.Exempt) > 0 {
 						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
-						newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
+						newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 					}
 					ghClient = newClient
 					appAuth = newAppAuth
@@ -3704,7 +3704,7 @@ func main() {
 				newClient := github.NewClientFromAppWithBotLogin(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.BotLogin())
 				if len(cfg.Governor.Labels.Exempt) > 0 {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
-					newClient.SetAutoMergeLabel(cfg.Governor.Labels.AutoMerge)
+					newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 				}
 				ghClient = newClient
 				appAuth = newAppAuth
@@ -4002,6 +4002,7 @@ func main() {
 	lastEvalInterval := cfg.Governor.EvalIntervalS
 	ticker := time.NewTicker(time.Duration(cfg.Governor.EvalIntervalS) * time.Second)
 	defer ticker.Stop()
+	var lastAutoMergeSweep time.Time
 
 	var agentTicker *time.Ticker
 	if cfg.Dashboard.AgentPollIntervalS > 0 {
@@ -4027,6 +4028,7 @@ func main() {
 	gov.ClearLastKicks()
 	logger.Info("cleared last kicks for startup — all eligible agents will be kicked on first eval")
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
+	runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 
 	agentTickCh := func() <-chan time.Time {
@@ -4067,6 +4069,7 @@ func main() {
 				}
 			}
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, restarted, logger)
+			runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 			// Trajectory review runs after the eval cycle (so kicks/intents are
 			// current) on its own cadence, gated by Due().
 			if trajLane != nil && trajLane.Due(time.Now()) {
@@ -5700,6 +5703,48 @@ func runEscalationSweep(
 	return escalated
 }
 
+// autoMergeSweepInterval is the minimum spacing between label-queued
+// auto-merge sweeps. The sweep piggybacks on the governor eval tick, which can
+// fire much more often than once a minute; this floor keeps the sweep from
+// hammering the GitHub API on short eval intervals.
+const autoMergeSweepInterval = time.Minute
+
+// runAutoMergeSweepIfDue drains the label-queued auto-merge queue (the human
+// "Approved ... for Hive auto-merge" path) at most once per
+// autoMergeSweepInterval. All merge-eligibility decisions — queue-approval
+// trust, check verification, tier gates — live inside SweepQueuedAutoMerges;
+// this function is only the scheduler and the dashboard audit sink.
+func runAutoMergeSweepIfDue(ctx context.Context, ghClient *github.Client, dashSrv *dashboard.Server, lastRun *time.Time, logger *slog.Logger) {
+	if ghClient == nil {
+		return
+	}
+	now := time.Now()
+	if lastRun != nil && !lastRun.IsZero() && now.Sub(*lastRun) < autoMergeSweepInterval {
+		return
+	}
+	if lastRun != nil {
+		*lastRun = now
+	}
+	result, err := ghClient.SweepQueuedAutoMerges(ctx, github.AutoMergeSweepOptions{
+		MaxMerges: github.DefaultAutoMergeSweepMaxMerges,
+		Audit: func(event github.AutoMergeSweepEvent) {
+			if dashSrv == nil {
+				return
+			}
+			detail := fmt.Sprintf("repo=%s, pr=%d, author=%s, queued_by=%s, label=%s, head_sha=%s, merge_sha=%s",
+				event.Repo, event.Number, event.Author, event.QueuedBy, event.Label, event.HeadSHA, event.MergeSHA)
+			dashSrv.AuditLog("system", "automerge-sweep-merged", detail, "")
+		},
+	})
+	if err != nil {
+		logger.Warn("automerge sweep failed", "error", err)
+		return
+	}
+	if len(result.Merged) > 0 || result.Seen > 0 {
+		logger.Info("automerge sweep complete", "seen", result.Seen, "merged", len(result.Merged), "skipped", result.Skipped)
+	}
+}
+
 // mergeEligiblePath is a var (not a const) only so tests can point
 // mergeTargetEligible at a temp file; production never reassigns it.
 var mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
@@ -6469,6 +6514,19 @@ func persistReviewDispatchState(plan review.DispatchPlan, delivered []review.Dis
 	if err := review.WriteDispatchState("", state); err != nil {
 		logger.Warn("failed to persist review dispatch state", "error", err)
 	}
+}
+
+// normalizedAutoMergeLabel resolves the configured queue label, falling back
+// to the shared default when the value is blank. Client.SetAutoMergeLabel
+// ignores blank input (keeping whatever was set before) and
+// Client.AutoMergeLabel falls back on read, but the cmd layer normalizes
+// eagerly too so a partially-populated config can never propagate an unnamed
+// label to a fresh client.
+func normalizedAutoMergeLabel(label string) string {
+	if label = strings.TrimSpace(label); label != "" {
+		return label
+	}
+	return github.AutoMergeQueuedLabel
 }
 
 func atomicWrite(path string, data []byte) {


### PR DESCRIPTION
## Problem

`SweepQueuedAutoMerges` exists on v4 (`v2/pkg/github/automerge_sweep.go`, tests intact) but has **no caller** — the label-queued merge queue silently never runs. v2 drains it every minute from the governor eval loop via `runAutoMergeSweepIfDue` and emits the `automerge-sweep-merged` dashboard audit event; that string is absent from all of v4. v4 only starts the separate `StartSelfAuthoredAutoMergeSweep`, so PRs queued by a human "Approved ... for Hive auto-merge" review + queue label are approved but never landed by the hive.

## Fix (port from v2)

- Add `autoMergeSweepInterval` (1 minute floor) + `runAutoMergeSweepIfDue` to `cmd/hive/main.go` and call it after both `runEvalCycle` sites in the governor loop (startup eval and the ticker tick), matching v2's placement.
- Restore the `automerge-sweep-merged` dashboard audit event emitted for every merge the sweep lands (repo, pr, author, queued_by, label, head_sha, merge_sha).
- Restore `normalizedAutoMergeLabel` and the `cmd/hive/automerge_label_test.go` test deleted in the sync: a blank configured label now resolves eagerly to `github.AutoMergeQueuedLabel` at the `SetAutoMergeLabel` call sites, belt-and-suspenders over the existing config normalization and the `Client.AutoMergeLabel` read-side fallback (which are unchanged), so a partially-populated config can never propagate an unnamed label to a fresh client.

## Security scope

v4's merge-eligibility gating inside the sweep — queue-approval trust (App-authored review, forged-approval rejection, head-SHA binding), check verification, and tier gates — is **untouched**. `pkg/github` has zero edits; this PR only adds the scheduler call and the label normalization in `cmd/hive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)