### PR TITLE
🔒 fix(hub): hive status is owner-only, matching v2's tightening

### DIFF
--- a/v2/pkg/hub/granted_owner_parity_test.go
+++ b/v2/pkg/hub/granted_owner_parity_test.go
@@ -146,12 +146,12 @@ func TestGrantedOwnerParityForHiveManagementHandlers(t *testing.T) {
 	}
 }
 
-// TestHiveStatusAccessSemantics pins handleHiveStatus's v4 semantics after the
-// granted-owner parity port: effective owners (creator and granted owner) pass
-// via userIsHiveOwner, granted read/read-write users KEEP their existing status
-// access via the access fallback (a deliberate deviation from v2, which
-// tightened status to owner-only), and unrelated users remain rejected — the
-// positive control that the gate is still enforced.
+// TestHiveStatusAccessSemantics pins handleHiveStatus's owner-only semantics
+// (operator decision 2026-08-13, matching v2's tightening): effective owners
+// (creator and granted owner) pass via userIsHiveOwner; granted read and
+// read-write roles are rejected — the full SaaSHive record carries operational
+// metadata beyond what a read grant implies; unrelated users remain rejected
+// as the positive control that the gate is still enforced.
 func TestHiveStatusAccessSemantics(t *testing.T) {
 	actors := []struct {
 		name       string
@@ -161,8 +161,8 @@ func TestHiveStatusAccessSemantics(t *testing.T) {
 	}{
 		{name: "creator is allowed", username: "creator", wantStatus: http.StatusOK},
 		{name: "granted owner is allowed", username: "granted-owner", role: "owner", wantStatus: http.StatusOK},
-		{name: "granted read keeps status access", username: "reader", role: "read", wantStatus: http.StatusOK},
-		{name: "granted read-write keeps status access", username: "writer", role: "read-write", wantStatus: http.StatusOK},
+		{name: "granted read is rejected (owner-only)", username: "reader", role: "read", wantStatus: http.StatusForbidden},
+		{name: "granted read-write is rejected (owner-only)", username: "writer", role: "read-write", wantStatus: http.StatusForbidden},
 		{name: "unrelated user is rejected", username: "stranger", wantStatus: http.StatusForbidden},
 	}
 

--- a/v2/pkg/hub/hub_filesystem_extra_test.go
+++ b/v2/pkg/hub/hub_filesystem_extra_test.go
@@ -444,8 +444,8 @@ func TestHandleCreateHiveAppAuth(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleCreateHive(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 (status is owner-only; read grant does not suffice), got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
 
@@ -589,6 +589,8 @@ func TestHandleHiveStatusWithAccess(t *testing.T) {
 	authCleanup := helperSetupAuthUser(t, "ghp_status_acc", "accuser")
 	defer authCleanup()
 
+	// A granted READ role: since the owner-only tightening (operator
+	// decision matching v2), read access no longer grants hive status.
 	u := ensureSaaSUser("accuser")
 	u.Hives["acc-hive"] = "read"
 	saveSaaSUser(u)

--- a/v2/pkg/hub/hub_filesystem_extra_test.go
+++ b/v2/pkg/hub/hub_filesystem_extra_test.go
@@ -444,8 +444,8 @@ func TestHandleCreateHiveAppAuth(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.handleCreateHive(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Errorf("expected 403 (status is owner-only; read grant does not suffice), got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
 
@@ -606,8 +606,8 @@ func TestHandleHiveStatusWithAccess(t *testing.T) {
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 (status is owner-only; read grant does not suffice), got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3293,16 +3293,13 @@ func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 		return
 	}
-	// Effective owners (creator, granted owner, hub admin — userIsHiveOwner)
-	// always pass; other granted roles keep read access to status. This is a
-	// deliberate v4 deviation from v2, which tightened status to owner-only:
-	// restricting existing read/read-write access is out of scope for the
-	// granted-owner parity port (which only EXTENDS who passes owner checks).
+	// Owner-only, matching v2's tightening (operator decision 2026-08-13):
+	// effective owners (creator, granted owner, hub admin — userIsHiveOwner)
+	// read status; granted read/read-write roles do NOT. The full SaaSHive
+	// record includes operational metadata beyond what a read grant implies.
 	if !userIsHiveOwner(username, h) {
-		if _, hasAccess := user.Hives[id]; !hasAccess {
-			http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
-			return
-		}
+		http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(h)


### PR DESCRIPTION
Resolves the one operator-judgment item from the v2-parity analysis: handleHiveStatus drops the granted read/read-write fallback and gates on userIsHiveOwner alone (creator, granted owner, hub admin — canonical). Parity test table updated: read and read-write roles now expect 403; stranger stays 403 as the positive control.