### PR TITLE
🐛 fix(hub): stamp GIT_BRANCH into the hub image so it stops self-reverting to v2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -347,6 +347,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             GIT_HASH=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
           outputs: type=image,name=ghcr.io/kubestellar/hive-hub,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }}
           cache-from: type=gha,scope=hub-${{ steps.slug.outputs.slug }}
           cache-to: type=gha,scope=hub-${{ steps.slug.outputs.slug }},mode=max

--- a/v2/Dockerfile.hub
+++ b/v2/Dockerfile.hub
@@ -4,9 +4,19 @@ WORKDIR /src
 
 COPY .git /repo/.git
 COPY v2/ .
+# GIT_BRANCH must be stamped in, exactly as v2/Dockerfile does for the spoke.
+# The hub SELF-UPGRADES by polling GHCR for the head SHA of its OWN branch
+# (s.hubGitBranch, from main.gitBranch). Without this ldflag the binary carries
+# the "unknown" default, NewHubServer coerces it to "v2", and a hub built from
+# ANY other branch pins itself back to v2's SHA every poll — silently reverting
+# a v4 deployment ~60s after it rolls out. Deriving it from the checkout is the
+# fallback for local builds; CI passes GIT_BRANCH explicitly because the .git
+# copy is often in a detached HEAD state.
+ARG GIT_BRANCH=unknown
 RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     GIT_SHORT=$(git -C /repo rev-parse --short=7 HEAD 2>/dev/null || echo "unknown") && \
-    CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT}" -o /hive ./cmd/hive
+    if [ "$GIT_BRANCH" = "unknown" ] || [ -z "$GIT_BRANCH" ]; then GIT_BRANCH=$(git -C /repo rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"); fi && \
+    CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive
 
 FROM alpine:3.24
 ARG TARGETARCH


### PR DESCRIPTION
**A hub deployed on v4 reverts itself to the v2 image ~60 seconds later, every time.** This is what made the hub cutover appear to "not take" — twice.

## Root cause

The hub **self-upgrades** by polling GHCR for the head SHA of its *own* branch (`s.hubGitBranch` ← `main.gitBranch`).

`v2/Dockerfile.hub` stamped only `main.gitHash` and `main.gitShort` — **never `main.gitBranch`**. So every hub binary, regardless of which branch built it, carried the `"unknown"` default. `NewHubServer` then coerces that:

```go
if gitBranch == "" || gitBranch == "unknown" {
    gitBranch = "v2"
}
```

…so the hub resolved **v2's** head SHA and "corrected" itself back onto it, undoing the v4 deployment. Its own logs show both polls side by side:

```
SHA poll: hub image verified on GHCR  branch=v2  sha=9a87c53   ← pinned itself here
SHA poll: hub image verified on GHCR  branch=v4  sha=815d7e4
```

This was **not** Keel (last touched the hub 2026-06-08) and not CI/CD.

## Fix — mirror what the spoke build already does

| File | Change |
|---|---|
| `v2/Dockerfile.hub` | Add `ARG GIT_BRANCH`, derive from the checkout as a fallback, pass `-X main.gitBranch` |
| `.github/workflows/docker.yml` | Pass `GIT_BRANCH=${{ github.ref_name }}` to the hub build step |

`v2/Dockerfile` (spoke) and the spoke workflow step already do exactly this — the hub step passed `GIT_HASH` only. CI must pass the branch explicitly because the copied `.git` is often in a detached-HEAD state, where the in-container fallback would yield `HEAD`.

## Verification

Not assumed — measured:

```
build with -X main.gitBranch=<sentinel>   → sentinel present in binary: 3
control build, no ldflag                  → sentinel present in binary: 0
```

`v2/cmd/hive/main.go:6834` confirms `gitBranch` is the value passed to `hub.NewHubServer(port, logger, gitShort, gitBranch)`, which is what drives the self-upgrade poller.

## Operational note

Until a hub image built **with** this change is published, a v4 hub must run with auto-upgrade disabled (`/data/saas/hub-auto-upgrade` = `false`) or it will revert. That is the current state of the production hub.