### PR TITLE
fix(hub): reconcile stale vanity URLs against the live Route

### DIFF
--- a/v2/pkg/hub/heartbeat_vanity_async_test.go
+++ b/v2/pkg/hub/heartbeat_vanity_async_test.go
@@ -173,11 +173,12 @@ func TestVanityRepairKickInlineGuards(t *testing.T) {
 	cases := []*SaaSHive{
 		nil, // no record at all
 		{ID: "hosted-unclaimed", Status: statusAvailable, Org: "available-x", ClusterID: "vllm-d"},
-		func() *SaaSHive { // already has a vanity URL
-			h := assignedVllmdHive("hosted-has-vanity")
-			h.VanityURL = "https://already.example.com"
-			return h
-		}(),
+		// NOTE: "already has a vanity URL" is deliberately NOT in this list any
+		// more. It used to be, and that short-circuit is exactly why a stale
+		// vanity host could never be corrected — the only code that reads the
+		// live Route sat behind it. Such a hive must now reach the repair so it
+		// can reconcile against reality; see
+		// TestVanityRepairKickRunsForHiveWithExistingVanityURL below.
 		func() *SaaSHive { // incomplete claim — nothing to derive a host from
 			h := assignedVllmdHive("hosted-no-primary")
 			h.PrimaryRepo = ""
@@ -201,6 +202,34 @@ func TestVanityRepairKickInlineGuards(t *testing.T) {
 	if got := entered.Load(); got != 0 {
 		t.Errorf("no-op kicks reached the servability seam %d times, want 0", got)
 	}
+}
+
+// A claimed hive that ALREADY has a vanity URL must still be kicked, because
+// the stored host is not self-validating: it can drift from the live Route
+// (the suffix is random, so any re-mint changes it) and the reconcile inside
+// the repair is the only thing that compares the two. This is the inverse of
+// the guard list above, and it fails against the pre-fix short-circuit.
+func TestVanityRepairKickRunsForHiveWithExistingVanityURL(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s, _, _ := newBlockedVanityHub(t)
+
+	h := assignedVllmdHive("hosted-has-vanity")
+	h.VanityURL = "https://already.example.com"
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	s.kickVanityURLRepairAsync(h.ID)
+
+	deadline := time.Now().Add(waitTimeout)
+	for time.Now().Before(deadline) {
+		if _, inFlight := s.vanityRepairInFlight.Load(h.ID); inFlight {
+			return // the reconcile pass was spawned, which is the contract here
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("kick spawned no repair for a hive with a vanity URL, so a stale host could never be reconciled")
 }
 
 // A successful repair must not write through a record loaded before its slow

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1172,9 +1172,6 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 	if h.Status == statusAvailable {
 		return false // unclaimed placeholder — assign mints it at claim time
 	}
-	if h.VanityURL != "" {
-		return false // already has one — never re-mint (idempotency + stable host)
-	}
 	// An incomplete claim has nothing to derive a friendly host from.
 	if h.Org == "" || h.PrimaryRepo == "" {
 		return false
@@ -1182,6 +1179,12 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 	cluster := s.clusterForHive(h)
 	if cluster == nil || cluster.Domain == "" {
 		return false
+	}
+	if h.VanityURL != "" {
+		// Already has one. Do NOT re-mint (that would churn the host every
+		// beat, since the suffix is random) — but DO reconcile it against the
+		// live route, because a stored host is not self-validating.
+		return s.reconcileStaleVanityURL(hiveID, h, cluster)
 	}
 	// Reuse the host an EXISTING vanity route already serves before minting a
 	// new one. generateHiveID appends a fresh random suffix on every call, so a
@@ -1227,6 +1230,81 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 	return true
 }
 
+// reconcileStaleVanityURL corrects a STORED vanity URL that no longer matches
+// the host the hive's live vanity Route/Ingress actually serves, reporting
+// whether it changed anything.
+//
+// This closes the drift half of the vanity bug. The mint paths
+// (mintClaimVanityURL, repairVanityURLForHive) write h.VanityURL exactly once
+// and every later call returns early on `h.VanityURL != ""`, so the stored
+// value was treated as permanently authoritative. But the host it names is not
+// stable: hiveNameVanityHost appends randomHostSuffix() on every call, so any
+// path that re-mints — a re-provision, a reset+re-assign, an operator
+// recreating the spoke's routes — produces a DIFFERENT hostname. When the new
+// Route is created but the registry write is missed (or a re-provision recreates
+// the Route from the hive's name while meta.json keeps the older record), the
+// hub links a hostname no Route serves. The live symptom is the OpenShift
+// "Application is not available" page: the registry advertised
+// hosted-<name>-ph31.apps... while the spoke's hive-vanity Route served
+// hosted-<name>-qcd0.apps... — same hive, same display name, different random
+// suffix, and nothing in the hub ever compared the two.
+//
+// Reality wins. The Route is what actually serves traffic, so when the live host
+// disagrees with the stored one the stored one is what is wrong, and we adopt
+// the live host rather than trying to make the cluster match the registry.
+//
+// Conservative by design, mirroring the mint paths it sits beside:
+//   - A cluster that cannot be read (unreachable, kubectl error, no vanity
+//     route) yields "" from existingVanityHost, which is NOT evidence of drift.
+//     We return early and keep the stored value; a heartbeat-only cluster must
+//     never have its working URL blanked by an inability to look.
+//   - A live host that already matches the stored one is the overwhelmingly
+//     common case and writes nothing.
+//   - No makeVanityHostServable call: the host we are adopting is, by
+//     construction, the one an existing Route already serves, so it needs no
+//     ingress work. That also keeps this path free of any cluster WRITE.
+//   - The record is RE-LOADED before writing, for the same reason every other
+//     path in this file does it: existingVanityHost can block for minutes in
+//     kubectl while the heartbeat path keeps load-modify-writing this hive
+//     (ClaimDelivered/ACMMDelivered latches, forge handshakes), and saving
+//     through a pre-window copy would silently revert them.
+func (s *HubServer) reconcileStaleVanityURL(hiveID string, h *SaaSHive, cluster *ClusterConfig) bool {
+	stored := h.VanityURL
+	if stored == "" {
+		return false
+	}
+	liveHost := s.existingVanityHost(hiveID, cluster)
+	if liveHost == "" {
+		// Could not read the cluster, or there is no vanity route to compare
+		// against. Absence of evidence is not evidence of drift — keep what we
+		// have, since it is the only link the dashboard can offer.
+		return false
+	}
+	liveURL := "https://" + liveHost
+	if stored == liveURL {
+		return false // already tracking the live route
+	}
+	// Re-load before writing so we do not clobber fields written while the
+	// kubectl read above was blocked.
+	h = loadSaaSHive(hiveID)
+	if h == nil {
+		return false
+	}
+	if h.VanityURL != stored {
+		// Another path rewrote it while we were reading the cluster; that write
+		// is newer than our observation, so leave it and re-check next beat.
+		return false
+	}
+	h.VanityURL = liveURL
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("vanity url reconcile: failed to save hive", "hive", hiveID, "error", err)
+		return false
+	}
+	s.logger.Info("vanity url reconcile: stored vanity host did not match the live route, adopted the live host",
+		"hive", hiveID, "stored", stored, "live", liveURL, "cluster", cluster.ID)
+	return true
+}
+
 // kickVanityURLRepairAsync runs repairVanityURLForHive in the background, at
 // most one attempt per hive at a time, registered with provisionWG so tests can
 // drain it before swapping the package-level saas*Dir vars.
@@ -1247,7 +1325,14 @@ func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 // placeholder, incomplete claim, no cluster domain) spawns no goroutine at all.
 func (s *HubServer) kickVanityURLRepairAsync(hiveID string) {
 	h := loadSaaSHive(hiveID)
-	if h == nil || h.Status == statusAvailable || h.VanityURL != "" ||
+	// NOTE: a non-empty VanityURL is deliberately NOT a short-circuit here.
+	// It used to be, which is precisely why a stale vanity host could never be
+	// corrected: the only path that reads the live route was gated behind
+	// "has no vanity URL yet". repairVanityURLForHive now reconciles a stored
+	// host against the live one, so hives WITH a vanity URL must still reach it.
+	// The remaining guards below (unclaimed, incomplete claim, no cluster
+	// domain) still keep every truly-inapplicable hive off the goroutine path.
+	if h == nil || h.Status == statusAvailable ||
 		h.Org == "" || h.PrimaryRepo == "" {
 		return
 	}

--- a/v2/pkg/hub/vanity_url_drift_test.go
+++ b/v2/pkg/hub/vanity_url_drift_test.go
@@ -1,0 +1,153 @@
+package hub
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// ============================================================
+// Stale vanity-URL drift (the "Application is not available" bug)
+//
+// The hub stored a hive's vanity host once, at claim/repair time, and every
+// later pass returned early on `h.VanityURL != ""`. Because the host carries a
+// random suffix (hiveNameVanityHost -> randomHostSuffix), a re-provision or a
+// route recreation produces a DIFFERENT hostname, and nothing ever compared the
+// stored value to the live Route. Live symptom: the dashboard linked
+// hosted-katamari-ibm-aiops-or-ph31.apps... while the spoke's hive-vanity Route
+// served hosted-katamari-ibm-aiops-or-qcd0.apps..., so the link hit the
+// OpenShift "Application is not available" page.
+// ============================================================
+
+const (
+	// driftDomain mirrors the live cluster's wildcard apps domain.
+	driftDomain = "apps.fmaas-vllm-d.fmaas.res.ibm.com"
+	// driftStaleHost is the host the registry had persisted (no Route serves it).
+	driftStaleHost = "hosted-katamari-ibm-aiops-or-ph31." + driftDomain
+	// driftLiveHost is the host the spoke's hive-vanity Route actually serves.
+	driftLiveHost = "hosted-katamari-ibm-aiops-or-qcd0." + driftDomain
+)
+
+// newVanityDriftTestHub builds a hub whose single cluster is an OpenShift-route
+// cluster, matching the vllm-d spoke where the drift was observed.
+func newVanityDriftTestHub() *HubServer {
+	return &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {
+				ID:          defaultClusterID,
+				Name:        "vllm-d",
+				Domain:      driftDomain,
+				IngressType: ingressTypeOpenShiftRoute,
+			},
+		},
+	}
+}
+
+// installVanityRouteKubectl scripts a kubectl that answers the ONE read
+// existingVanityHost makes — `get route hive-dashboard-vanity -o
+// jsonpath={.spec.host}` — with the supplied host. Any other invocation exits
+// non-zero, so a test cannot accidentally pass by way of some other command
+// succeeding.
+func installVanityRouteKubectl(t *testing.T, host string) {
+	t.Helper()
+	installKubectlScript(t, `#!/bin/sh
+case "$*" in
+  *"get route "*"-vanity"*) printf '`+host+`' ;;
+  *) exit 1 ;;
+esac
+`)
+}
+
+// saveDriftHive persists a claimed hive carrying the stale vanity URL.
+func saveDriftHive(t *testing.T, id string) {
+	t.Helper()
+	h := &SaaSHive{
+		ID: id, Status: "running", Owner: "katamari", Org: "katamari",
+		ProjectName: "katamari ibm aiops or",
+		Repos:       []string{"aiops"}, PrimaryRepo: "aiops", ACMMLevel: 3,
+		ClusterID: defaultClusterID, ClaimDelivered: true,
+		VanityURL: "https://" + driftStaleHost,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestVanityURLDriftReconciledToLiveRoute is the regression test for the bug.
+//
+// POSITIVE CONTROL: before the fix, repairVanityURLForHive returned false at
+// its `h.VanityURL != ""` guard without ever running kubectl, so the stored
+// host stayed at ...-ph31 and the assertion below fails. It is not merely
+// exercising the code path: the scripted kubectl reports a host that DIFFERS
+// from the stored one, and the test asserts the stored value actually changes
+// to the live host — so a no-op implementation cannot pass it.
+func TestVanityURLDriftReconciledToLiveRoute(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityDriftTestHub()
+	installVanityRouteKubectl(t, driftLiveHost)
+
+	const id = "hosted-available-vllmd-01"
+	saveDriftHive(t, id)
+
+	// Precondition: the hub links the stale host that no Route serves.
+	if got := claimedVanityURL(loadSaaSHive(id)); got != "https://"+driftStaleHost {
+		t.Fatalf("precondition: stored vanity URL = %q, want the stale host", got)
+	}
+
+	if !s.repairVanityURLForHive(id) {
+		t.Fatal("repair reported no change, but the stored vanity host differs from the live Route " +
+			"(this is the bug: a stale vanity URL was never reconciled)")
+	}
+
+	want := "https://" + driftLiveHost
+	if got := loadSaaSHive(id).VanityURL; got != want {
+		t.Errorf("stored vanity URL = %q, want the live route host %q", got, want)
+	}
+	// The link the dashboard renders must now be the live one.
+	if got := claimedVanityURL(loadSaaSHive(id)); got != want {
+		t.Errorf("claimedVanityURL = %q, want %q", got, want)
+	}
+}
+
+// TestVanityURLReconcileNoOpWhenLiveHostMatches proves the reconcile is
+// idempotent: the overwhelmingly common case (stored == live) must report no
+// change, so heartbeats do not rewrite meta.json every beat.
+func TestVanityURLReconcileNoOpWhenLiveHostMatches(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityDriftTestHub()
+	// The live Route serves exactly what is stored.
+	installVanityRouteKubectl(t, driftStaleHost)
+
+	const id = "hosted-available-vllmd-02"
+	saveDriftHive(t, id)
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair reported a change when the stored host already matches the live Route")
+	}
+	if got := loadSaaSHive(id).VanityURL; got != "https://"+driftStaleHost {
+		t.Errorf("stored vanity URL = %q, want it left untouched", got)
+	}
+}
+
+// TestVanityURLReconcileKeepsStoredHostWhenClusterUnreadable is the guard that
+// keeps this fix from making things WORSE than the bug it closes. vllm-d is
+// heartbeat-only, so kubectl fails outright; an unreadable cluster is not
+// evidence of drift, and blanking or rewriting the URL there would break the
+// one working link the dashboard has.
+func TestVanityURLReconcileKeepsStoredHostWhenClusterUnreadable(t *testing.T) {
+	useTempHiveDir(t)
+	s := newVanityDriftTestHub()
+	// Every kubectl invocation fails, as on an unreachable cluster.
+	installKubectlScript(t, "#!/bin/sh\nexit 1\n")
+
+	const id = "hosted-available-vllmd-03"
+	saveDriftHive(t, id)
+
+	if s.repairVanityURLForHive(id) {
+		t.Error("repair reported a change though the cluster could not be read")
+	}
+	if got := loadSaaSHive(id).VanityURL; got != "https://"+driftStaleHost {
+		t.Errorf("stored vanity URL = %q, want it preserved when the cluster is unreadable", got)
+	}
+}


### PR DESCRIPTION
## Symptom

Clicking a hive's link from the hub dashboard opened
`https://hosted-katamari-ibm-aiops-or-ph31.apps.fmaas-vllm-d.fmaas.res.ibm.com`,
which returned the OpenShift **"Application is not available"** page.

The hive itself was healthy. Its live `hive-vanity` Route served
`hosted-katamari-ibm-aiops-or-**qcd0**.apps...` — same hive, same display name,
**different random suffix**. No Route for `ph31` existed on any cluster.

## Root cause

`h.VanityURL` was written exactly once — at claim time (`mintClaimVanityURL`) or
by the retroactive backfill (`repairVanityURLForHive`) — and every later pass
returned early on `h.VanityURL != ""`. The stored value was treated as
permanently authoritative.

But the host it names is **not stable**: `hiveNameVanityHost` appends
`randomHostSuffix()` on every call, so any re-mint (a re-provision, a
reset+re-assign, an operator recreating the spoke's routes) yields a different
hostname. When the new Route was created but the registry write was missed, the
hub kept linking a hostname no Route serves.

`existingVanityHost` already reads the live Route — but it was reachable *only*
from the "has no vanity URL yet" branch, so nothing ever compared a **stored**
host to the live one.

## Fix

- `repairVanityURLForHive` now **reconciles** a stored vanity URL against the
  live Route instead of returning early.
- `kickVanityURLRepairAsync` no longer short-circuits on a non-empty
  `VanityURL`, so those hives actually reach the reconcile on each beat.

Reality wins: the Route is what serves traffic, so a disagreement means the
*stored* value is wrong.

Conservative by design, matching the mint paths it sits beside:

- An **unreadable cluster** (vllm-d is heartbeat-only) yields `""` from
  `existingVanityHost`, which is **not** evidence of drift — the stored URL is
  kept, never blanked.
- A **matching** live host writes nothing, so beats do not churn `meta.json`.
- **No cluster writes**: no `makeVanityHostServable` call, since the adopted host
  is by construction one an existing Route already serves.
- The record is **re-loaded before the write**, so fields latched during the slow
  kubectl window are not reverted.

## Tests

Both new assertions were verified to **FAIL before the fix** (positive controls,
not just path coverage):

- **`TestVanityURLDriftReconciledToLiveRoute`** — stores the `...-ph31` host,
  scripts kubectl to report the `...-qcd0` Route, and asserts the stored value
  *actually changes* to the live host. A no-op implementation cannot pass it.
  Pre-fix: `repair reported no change...`.
- **`TestVanityRepairKickRunsForHiveWithExistingVanityURL`** — the inverse of the
  kick guard list; asserts a hive *with* a vanity URL is still kicked.

Plus guards for the no-op (stored == live) and unreadable-cluster cases, which
keep this fix from being worse than the bug.

The "already has a vanity URL" case was removed from
`TestVanityRepairKickInlineGuards` — it encoded the very short-circuit that
caused this bug.

`go build ./pkg/hub/` clean; full `go test ./pkg/hub/` passes. No cluster state
was changed while diagnosing this.