### PR TITLE
fix(config): normalize org-qualified repos entries instead of failing the hive

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -3328,11 +3328,19 @@ const (
 )
 
 func (c *Config) applyDefaults() {
+	// Repo targets are built as org + "/" + repo, so an entry that already
+	// carries the org resolves to "org/org/repo" and every agent fails. Strip a
+	// matching org prefix off both primary_repo and every repos entry on load.
+	// primary_repo has been normalized here for a long time; repos was not,
+	// which is why live configs are seen with a correct bare primary_repo next
+	// to an org-qualified repos list. A mismatched org is deliberately left
+	// alone so ValidateRepoTargets still rejects it rather than silently
+	// retargeting the hive at a repository the owner never named.
 	if c.Project.PrimaryRepo != "" && c.Project.Org != "" {
-		prefix := c.Project.Org + "/"
-		if strings.HasPrefix(c.Project.PrimaryRepo, prefix) {
-			c.Project.PrimaryRepo = strings.TrimPrefix(c.Project.PrimaryRepo, prefix)
-		}
+		c.Project.PrimaryRepo, _ = NormalizeRepoForOrg(c.Project.Org, c.Project.PrimaryRepo)
+	}
+	if len(c.Project.Repos) > 0 && c.Project.Org != "" {
+		c.Project.Repos, _ = NormalizeProjectRepos(c.Project.Org, c.Project.Repos)
 	}
 	if c.Dashboard.Port == 0 {
 		c.Dashboard.Port = defaultDashboardPort

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -632,8 +632,40 @@ func TestLoadWithOverrides_ConfigEnvOverridesRepos(t *testing.T) {
 	if len(cfg.Project.Repos) != 2 {
 		t.Fatalf("len(Project.Repos) = %d, want 2", len(cfg.Project.Repos))
 	}
-	if cfg.Project.Repos[0] != "my-org/alpha" {
-		t.Errorf("Project.Repos[0] = %q, want %q", cfg.Project.Repos[0], "my-org/alpha")
+	// PROJECT_REPOS still overrides the YAML; the org-qualified entries are
+	// normalized to bare repo names on load, because repo targets are built as
+	// org + "/" + repo and "my-org/alpha" would otherwise resolve to
+	// "my-org/my-org/alpha".
+	want := []string{"alpha", "beta"}
+	for i := range want {
+		if cfg.Project.Repos[i] != want[i] {
+			t.Errorf("Project.Repos[%d] = %q, want %q", i, cfg.Project.Repos[i], want[i])
+		}
+	}
+}
+
+// Positive control for the normalization above: config.env values that are
+// already bare must survive the override path untouched.
+func TestLoadWithOverrides_ConfigEnvBareReposUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "hive.yaml")
+	os.WriteFile(yamlPath, []byte(minimalValidYAML("my-org", "ghp_tok")), 0o600)
+
+	envPath := filepath.Join(dir, "config.env")
+	os.WriteFile(envPath, []byte("PROJECT_REPOS=alpha beta\n"), 0o600)
+
+	cfg, err := LoadWithOverrides(yamlPath, envPath)
+	if err != nil {
+		t.Fatalf("LoadWithOverrides() error = %v", err)
+	}
+	want := []string{"alpha", "beta"}
+	if len(cfg.Project.Repos) != len(want) {
+		t.Fatalf("Project.Repos = %v, want %v", cfg.Project.Repos, want)
+	}
+	for i := range want {
+		if cfg.Project.Repos[i] != want[i] {
+			t.Errorf("Project.Repos[%d] = %q, want %q", i, cfg.Project.Repos[i], want[i])
+		}
 	}
 }
 

--- a/v2/pkg/config/repo_target.go
+++ b/v2/pkg/config/repo_target.go
@@ -26,8 +26,74 @@ func ValidateRepoTargets(cfg *Config) *RepoTargetIssue {
 	return ValidateProjectRepoTargets(cfg.Project.Org, cfg.Project.Repos, cfg.Project.PrimaryRepo, cfg.GitHub.HostLabel())
 }
 
+// NormalizeRepoForOrg accepts a repos-list entry and returns the bare repo name
+// the org/repo target is built from.
+//
+// A repo entry is combined with project.org to form "org/repo", so an entry that
+// already carries its own org ("zacburns/mlz-manager" under org "zacburns")
+// resolves to "zacburns/zacburns/mlz-manager" and every agent targeting it
+// fails. Owners paste the org-qualified form routinely — it is the shape GitHub
+// shows everywhere — so accept it when the prefix matches the configured org and
+// strip it back to the bare name.
+//
+// Only an exact, case-insensitive match on the configured org is stripped.
+// An entry qualified with a DIFFERENT org ("other/hive" under org "kubestellar")
+// is left untouched so validateRepoName still rejects it: silently dropping a
+// mismatched org would retarget the hive at a repository the owner did not name.
+// The second return reports whether a prefix was stripped.
+func NormalizeRepoForOrg(org, repo string) (string, bool) {
+	org = strings.TrimSpace(org)
+	repo = strings.TrimSpace(repo)
+	if org == "" || repo == "" || strings.Contains(org, "/") {
+		return repo, false
+	}
+	// A URL is a different misconfiguration with its own error message; leave it
+	// for validateRepoName rather than half-parsing it here.
+	if looksLikeURL(repo) {
+		return repo, false
+	}
+	prefix := org + "/"
+	if len(repo) <= len(prefix) || !strings.EqualFold(repo[:len(prefix)], prefix) {
+		return repo, false
+	}
+	rest := repo[len(prefix):]
+	// "org/a/b" is not an org-qualified repo name — it is some deeper path we
+	// must not guess at. Leave it to be rejected.
+	if rest == "" || strings.Contains(rest, "/") {
+		return repo, false
+	}
+	return rest, true
+}
+
+// NormalizeProjectRepos returns repos with any entry qualified by the configured
+// org rewritten to its bare repo name. Entries that need no change are returned
+// as-is. The second return reports whether anything changed, so callers can log
+// or persist the repair.
+func NormalizeProjectRepos(org string, repos []string) ([]string, bool) {
+	if len(repos) == 0 {
+		return repos, false
+	}
+	out := make([]string, len(repos))
+	changed := false
+	for i, repo := range repos {
+		normalized, stripped := NormalizeRepoForOrg(org, repo)
+		out[i] = normalized
+		if stripped {
+			changed = true
+		}
+	}
+	if !changed {
+		return repos, false
+	}
+	return out, true
+}
+
 // ValidateProjectRepoTargets is the testable core used by provisioning and
 // config-save paths before they have a full Config object.
+//
+// Org-qualified entries that match org are normalized before validation, so
+// "zacburns/mlz-manager" under org "zacburns" is accepted; anything else that
+// still contains '/' keeps failing with the same operator-facing message.
 func ValidateProjectRepoTargets(org string, repos []string, primaryRepo, forgeHost string) *RepoTargetIssue {
 	org = strings.TrimSpace(org)
 	if org == "" {
@@ -43,12 +109,14 @@ func ValidateProjectRepoTargets(org string, repos []string, primaryRepo, forgeHo
 		return issue("project.repos", "repo is empty — expected org/repo")
 	}
 	for _, repo := range repos {
-		if repoIssue := validateRepoName("project.repos", repo); repoIssue != nil {
+		normalized, _ := NormalizeRepoForOrg(org, repo)
+		if repoIssue := validateRepoName("project.repos", normalized); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	if strings.TrimSpace(primaryRepo) != "" {
-		if repoIssue := validateRepoName("project.primary_repo", primaryRepo); repoIssue != nil {
+		normalizedPrimary, _ := NormalizeRepoForOrg(org, primaryRepo)
+		if repoIssue := validateRepoName("project.primary_repo", normalizedPrimary); repoIssue != nil {
 			return repoIssue
 		}
 	}

--- a/v2/pkg/config/repo_target_test.go
+++ b/v2/pkg/config/repo_target_test.go
@@ -70,12 +70,36 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
-			name:    "primary contains slash",
+			name:    "primary qualified with a different org",
+			org:     "kubestellar",
+			repos:   []string{"hive"},
+			primary: "other/hive",
+			forge:   "github.com",
+			want:    "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+		},
+		// The live regression: an owner pastes the org/repo form GitHub shows.
+		// Accepted, because it normalizes to the bare repo under the same org.
+		{
+			name:    "primary qualified with the configured org",
 			org:     "kubestellar",
 			repos:   []string{"hive"},
 			primary: "kubestellar/hive",
 			forge:   "github.com",
-			want:    "Repo target misconfigured: repo 'kubestellar/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
+		},
+		{
+			name:    "repos entry qualified with the configured org",
+			org:     "zacburns",
+			repos:   []string{"zacburns/mlz-manager"},
+			primary: "mlz-manager",
+			forge:   "github.com",
+		},
+		{
+			name:    "repos entry qualified with a deeper path",
+			org:     "kubestellar",
+			repos:   []string{"kubestellar/hive/tree/main"},
+			primary: "hive",
+			forge:   "github.com",
+			want:    "Repo target misconfigured: repo 'kubestellar/hive/tree/main' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Governor Config → Repos.",
 		},
 		{
 			name:  "full url pasted into org",
@@ -101,5 +125,128 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 				t.Fatalf("message = %q, want %q", got.Message, tt.want)
 			}
 		})
+	}
+}
+
+// TestNormalizeRepoForOrg pins the normalizer directly. The bare-name and
+// different-org cases are positive controls: an implementation that simply
+// stripped everything before the last '/' would pass the org-qualified case
+// alone, but must fail these.
+func TestNormalizeRepoForOrg(t *testing.T) {
+	tests := []struct {
+		name         string
+		org          string
+		repo         string
+		want         string
+		wantStripped bool
+	}{
+		// The live regression from hive-hosted-hosted-available-vllmd-04.
+		{name: "org qualified matching org", org: "zacburns", repo: "zacburns/mlz-manager", want: "mlz-manager", wantStripped: true},
+		{name: "org qualified case insensitive", org: "zacburns", repo: "ZacBurns/mlz-manager", want: "mlz-manager", wantStripped: true},
+		{name: "org qualified with surrounding space", org: "zacburns", repo: "  zacburns/mlz-manager  ", want: "mlz-manager", wantStripped: true},
+
+		// Positive controls: nothing may be stripped from these.
+		{name: "bare repo unchanged", org: "zacburns", repo: "mlz-manager", want: "mlz-manager"},
+		{name: "bare repo containing org as substring", org: "zac", repo: "zacburns", want: "zacburns"},
+		{name: "different org not stripped", org: "kubestellar", repo: "other/hive", want: "other/hive"},
+		{name: "deeper path not stripped", org: "kubestellar", repo: "kubestellar/hive/tree/main", want: "kubestellar/hive/tree/main"},
+		{name: "org prefix with empty repo not stripped", org: "kubestellar", repo: "kubestellar/", want: "kubestellar/"},
+		{name: "url left for the url error", org: "kubestellar", repo: "https://github.com/kubestellar/hive", want: "https://github.com/kubestellar/hive"},
+		{name: "empty org is a no-op", org: "", repo: "kubestellar/hive", want: "kubestellar/hive"},
+		{name: "empty repo is a no-op", org: "kubestellar", repo: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, stripped := NormalizeRepoForOrg(tt.org, tt.repo)
+			if got != tt.want || stripped != tt.wantStripped {
+				t.Fatalf("NormalizeRepoForOrg(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.org, tt.repo, got, stripped, tt.want, tt.wantStripped)
+			}
+		})
+	}
+}
+
+func TestNormalizeProjectRepos(t *testing.T) {
+	t.Run("mixed list normalizes only the qualified entries", func(t *testing.T) {
+		got, changed := NormalizeProjectRepos("zacburns", []string{"zacburns/mlz-manager", "other-repo"})
+		if !changed {
+			t.Fatalf("changed = false, want true")
+		}
+		want := []string{"mlz-manager", "other-repo"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		}
+	})
+
+	// Positive control: an already-correct list must report no change so callers
+	// do not log or persist a spurious repair.
+	t.Run("bare list unchanged", func(t *testing.T) {
+		in := []string{"mlz-manager", "other-repo"}
+		got, changed := NormalizeProjectRepos("zacburns", in)
+		if changed {
+			t.Fatalf("changed = true for an already-bare list %v", in)
+		}
+		for i := range in {
+			if got[i] != in[i] {
+				t.Fatalf("got %v, want %v", got, in)
+			}
+		}
+	})
+
+	t.Run("different org left for validation to reject", func(t *testing.T) {
+		got, changed := NormalizeProjectRepos("kubestellar", []string{"other/hive"})
+		if changed || got[0] != "other/hive" {
+			t.Fatalf("got (%v, %v), want ([other/hive], false)", got, changed)
+		}
+		if issue := ValidateProjectRepoTargets("kubestellar", got, "hive", "github.com"); issue == nil {
+			t.Fatalf("a repo qualified with a different org must still be rejected")
+		}
+	})
+}
+
+// TestApplyDefaultsNormalizesRepos covers the load path: the exact live config
+// shape from the degraded hive must come out of applyDefaults with a bare repos
+// list, and ValidateRepoTargets must then report no issue.
+func TestApplyDefaultsNormalizesRepos(t *testing.T) {
+	cfg := &Config{}
+	cfg.Project.Org = "zacburns"
+	cfg.Project.Repos = []string{"zacburns/mlz-manager"}
+	cfg.Project.PrimaryRepo = "mlz-manager"
+	cfg.applyDefaults()
+
+	if len(cfg.Project.Repos) != 1 || cfg.Project.Repos[0] != "mlz-manager" {
+		t.Fatalf("Project.Repos = %v, want [mlz-manager]", cfg.Project.Repos)
+	}
+	if issue := ValidateRepoTargets(cfg); issue != nil {
+		t.Fatalf("ValidateRepoTargets = %q, want nil", issue.Message)
+	}
+
+	// Positive control: a already-bare config must survive applyDefaults intact.
+	bare := &Config{}
+	bare.Project.Org = "zacburns"
+	bare.Project.Repos = []string{"mlz-manager"}
+	bare.Project.PrimaryRepo = "mlz-manager"
+	bare.applyDefaults()
+	if len(bare.Project.Repos) != 1 || bare.Project.Repos[0] != "mlz-manager" {
+		t.Fatalf("bare Project.Repos = %v, want [mlz-manager]", bare.Project.Repos)
+	}
+
+	// A mismatched org must NOT be normalized away on load — it stays broken and
+	// visibly reported rather than silently retargeting the hive.
+	mismatch := &Config{}
+	mismatch.Project.Org = "zacburns"
+	mismatch.Project.Repos = []string{"someoneelse/mlz-manager"}
+	mismatch.Project.PrimaryRepo = "mlz-manager"
+	mismatch.applyDefaults()
+	if mismatch.Project.Repos[0] != "someoneelse/mlz-manager" {
+		t.Fatalf("mismatched org was rewritten to %v", mismatch.Project.Repos)
+	}
+	if issue := ValidateRepoTargets(mismatch); issue == nil {
+		t.Fatalf("ValidateRepoTargets = nil, want a repo_target issue for a mismatched org")
 	}
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -5484,9 +5484,26 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	if body.PrimaryRepo != nil {
 		validatePrimary = *body.PrimaryRepo
 	}
+	// Normalize org-qualified entries ("myorg/myrepo" under org "myorg") to the
+	// bare repo name BEFORE validating, so the accepted value and the persisted
+	// value are the same shape. Without this an owner pasting the org/repo form
+	// GitHub shows everywhere is rejected with a 400 here, or — worse, on paths
+	// that skip this handler — persisted org-qualified and then resolved as
+	// "org/org/repo", which fails every agent. An entry qualified with a
+	// different org is left untouched and still 400s below.
+	validateRepos, _ = config.NormalizeProjectRepos(org, validateRepos)
+	validatePrimary, _ = config.NormalizeRepoForOrg(org, validatePrimary)
 	if issue := config.ValidateProjectRepoTargets(org, validateRepos, validatePrimary, spokeHost); issue != nil {
 		jsonError(w, issue.Message, http.StatusBadRequest)
 		return
+	}
+	// Feed the normalized values back into the body so the persistence code
+	// below stores bare names even when its own url-parse branch does not fire.
+	if len(body.Repos) > 0 {
+		body.Repos = validateRepos
+	}
+	if body.PrimaryRepo != nil {
+		body.PrimaryRepo = &validatePrimary
 	}
 	for _, ref := range body.Repos {
 		if h := repoRefHostLabel(ref); h != "" && !sameForgeHost(h, spokeHost) {

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1485,14 +1485,34 @@ func TestHandleGovernorRepos_Success(t *testing.T) {
 	}
 }
 
+// The fixture's org is "myorg", so "myorg/new-repo" is the hive's own org
+// spelled out — the form GitHub shows everywhere. Accept it and store the bare
+// repo name, because repo targets are built as org + "/" + repo and the
+// qualified form would otherwise resolve to "myorg/myorg/new-repo".
 func TestHandleGovernorRepos_StripOrg(t *testing.T) {
 	s, deps := apiServer(t)
 	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"myorg/new-repo"}, "primaryRepo": "myorg/new-repo"})
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want 400", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
-	if len(deps.Config.Project.Repos) == 1 && deps.Config.Project.Repos[0] == "new-repo" {
-		t.Errorf("repos mutated to stripped value %v despite rejection", deps.Config.Project.Repos)
+	if len(deps.Config.Project.Repos) != 1 || deps.Config.Project.Repos[0] != "new-repo" {
+		t.Errorf("repos = %v, want [new-repo]", deps.Config.Project.Repos)
+	}
+	if deps.Config.Project.PrimaryRepo != "new-repo" {
+		t.Errorf("primaryRepo = %q, want %q", deps.Config.Project.PrimaryRepo, "new-repo")
+	}
+}
+
+// A repo qualified with someone else's org must still be rejected outright and
+// must not mutate the stored config.
+func TestHandleGovernorRepos_ForeignOrgRejected(t *testing.T) {
+	s, deps := apiServer(t)
+	rec := doPut(s, "/api/config/governor/repos", map[string]interface{}{"repos": []string{"notmyorg/new-repo"}, "primaryRepo": "repo1"})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if len(deps.Config.Project.Repos) != 1 || deps.Config.Project.Repos[0] != "repo1" {
+		t.Errorf("repos = %v, want the pre-request [repo1]", deps.Config.Project.Repos)
 	}
 }
 

--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -348,6 +348,11 @@ func TestHandleSnapshotPage_CustomHubURL(t *testing.T) {
 
 // --- handleGovernorRepos with path-stripping ---
 
+// An entry qualified with THIS hive's own org is the shape GitHub shows
+// everywhere, so the save is accepted and stored as the bare repo name. It must
+// never be persisted org-qualified: repo targets are built as org + "/" + repo,
+// so "testorg/repo1" under org "testorg" would resolve to
+// "testorg/testorg/repo1" and fail every agent.
 func TestHandleGovernorRepos_StripOrgPrefix(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.Project.Org = "testorg"
@@ -358,14 +363,83 @@ func TestHandleGovernorRepos_StripOrgPrefix(t *testing.T) {
 	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("code = %d, want 400", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200: %s", w.Code, w.Body.String())
 	}
 	repos := srv.deps.Config.Project.Repos
-	for _, r := range repos {
-		if strings.Contains(r, "testorg/") {
-			t.Errorf("repo %q should not contain org prefix", r)
-		}
+	if len(repos) != 1 || repos[0] != "repo1" {
+		t.Fatalf("Project.Repos = %v, want [repo1]", repos)
+	}
+}
+
+// The org-qualified form is accepted in primaryRepo too, and both fields land
+// bare so the always-exactly-one-default guard still matches them up.
+func TestHandleGovernorRepos_StripOrgPrefixFromPrimary(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = "zacburns"
+	body := `{"repos":["zacburns/mlz-manager"],"primaryRepo":"zacburns/mlz-manager"}`
+	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := srv.deps.Config.Project.Repos; len(got) != 1 || got[0] != "mlz-manager" {
+		t.Fatalf("Project.Repos = %v, want [mlz-manager]", got)
+	}
+	if got := srv.deps.Config.Project.PrimaryRepo; got != "mlz-manager" {
+		t.Fatalf("Project.PrimaryRepo = %q, want %q", got, "mlz-manager")
+	}
+}
+
+// Positive control for the two tests above: a bare repo name must pass through
+// the write path untouched. Without this a handler that stripped everything
+// before the first '/' would still look correct.
+func TestHandleGovernorRepos_BareRepoUnchanged(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = "testorg"
+	body := `{"repos":["repo1"],"primaryRepo":"repo1"}`
+	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := srv.deps.Config.Project.Repos; len(got) != 1 || got[0] != "repo1" {
+		t.Fatalf("Project.Repos = %v, want [repo1]", got)
+	}
+}
+
+// A repo qualified with a DIFFERENT org must still be rejected with the clear
+// repo_target message — normalizing it away would silently retarget the hive at
+// a repository the owner never named.
+func TestHandleGovernorRepos_ForeignOrgPrefixRejected(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = "testorg"
+	srv.deps.Config.Project.Repos = []string{"repo1"}
+	srv.deps.Config.Project.PrimaryRepo = "repo1"
+	body := `{"repos":["someoneelse/repo1"],"primaryRepo":"repo1"}`
+	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "contains '/'") {
+		t.Fatalf("body = %q, want the repo_target contains-'/' message", w.Body.String())
+	}
+	// The rejected value must not have been persisted.
+	if got := srv.deps.Config.Project.Repos; len(got) != 1 || got[0] != "repo1" {
+		t.Fatalf("Project.Repos = %v, want the pre-request [repo1]", got)
 	}
 }
 

--- a/v2/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/v2/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -702,6 +702,10 @@ func TestHandleGovernorReposSpecialChars(t *testing.T) {
 	}
 }
 
+// A mixed list: the entry qualified with this hive's own org ("testorg") is
+// normalized to its bare name, and the already-bare entry is left exactly as it
+// was. The bare entry is the positive control — it proves the handler strips an
+// org prefix rather than everything up to a '/'.
 func TestHandleGovernorReposStripOrgPrefix(t *testing.T) {
 	srv := newFullServer(t)
 	body := `{"repos":["testorg/my-repo","other-repo"],"primaryRepo":"my-repo"}`
@@ -711,14 +715,17 @@ func TestHandleGovernorReposStripOrgPrefix(t *testing.T) {
 	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
 	}
-	// Verify org prefix was not silently stripped
 	repos := srv.deps.Config.Project.Repos
-	for _, r := range repos {
-		if strings.HasPrefix(r, "testorg/") {
-			t.Errorf("org prefix should be stripped: %q", r)
+	want := []string{"my-repo", "other-repo"}
+	if len(repos) != len(want) {
+		t.Fatalf("repos = %v, want %v", repos, want)
+	}
+	for i := range want {
+		if repos[i] != want[i] {
+			t.Fatalf("repos = %v, want %v", repos, want)
 		}
 	}
 }

--- a/v2/pkg/hub/provision_coverage_test.go
+++ b/v2/pkg/hub/provision_coverage_test.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"log/slog"
 	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // ============================================================
@@ -103,5 +105,63 @@ func TestExtractYAMLValue_ProvCov(t *testing.T) {
 	}
 	if got := extractYAMLValue(yaml, "missing"); got != "" {
 		t.Errorf("missing = %q, want empty", got)
+	}
+}
+
+// The provisioner bakes project.repos straight into the spoke's hive.yaml, so an
+// org-qualified entry that reaches it becomes a permanently broken hive: the
+// spoke resolves targets as org + "/" + repo, yielding "org/org/repo". This pins
+// the normalization the provisioner applies to h.Repos/h.PrimaryRepo.
+func TestProvisionRepoNormalization(t *testing.T) {
+	tests := []struct {
+		name        string
+		org         string
+		repos       []string
+		primary     string
+		wantRepos   []string
+		wantPrimary string
+	}{
+		{
+			name:        "org qualified entry is stripped",
+			org:         "zacburns",
+			repos:       []string{"zacburns/mlz-manager"},
+			primary:     "zacburns/mlz-manager",
+			wantRepos:   []string{"mlz-manager"},
+			wantPrimary: "mlz-manager",
+		},
+		// Positive control: an already-correct project must pass through intact.
+		{
+			name:        "bare entry unchanged",
+			org:         "zacburns",
+			repos:       []string{"mlz-manager"},
+			primary:     "mlz-manager",
+			wantRepos:   []string{"mlz-manager"},
+			wantPrimary: "mlz-manager",
+		},
+		{
+			name:        "foreign org left for the spoke to reject",
+			org:         "zacburns",
+			repos:       []string{"someoneelse/mlz-manager"},
+			primary:     "mlz-manager",
+			wantRepos:   []string{"someoneelse/mlz-manager"},
+			wantPrimary: "mlz-manager",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRepos, _ := config.NormalizeProjectRepos(tt.org, tt.repos)
+			if len(gotRepos) != len(tt.wantRepos) {
+				t.Fatalf("repos = %v, want %v", gotRepos, tt.wantRepos)
+			}
+			for i := range tt.wantRepos {
+				if gotRepos[i] != tt.wantRepos[i] {
+					t.Fatalf("repos = %v, want %v", gotRepos, tt.wantRepos)
+				}
+			}
+			gotPrimary, _ := config.NormalizeRepoForOrg(tt.org, tt.primary)
+			if gotPrimary != tt.wantPrimary {
+				t.Fatalf("primary = %q, want %q", gotPrimary, tt.wantPrimary)
+			}
+		})
 	}
 }

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -24,11 +24,11 @@ import (
 var saasHivesDir = "/data/saas/hives"
 
 const (
-	maxHivesPerUser       = 3
-	maxSaaSHivesTotal     = 0 // 0 = unlimited
-	provisionTimeout      = 5 * time.Minute
-	cpuRequest            = "500m"
-	cpuLimit              = "2000m"
+	maxHivesPerUser   = 3
+	maxSaaSHivesTotal = 0 // 0 = unlimited
+	provisionTimeout  = 5 * time.Minute
+	cpuRequest        = "500m"
+	cpuLimit          = "2000m"
 	// memRequest/memLimit size the spoke pod for the WHOLE agent fleet, not just
 	// the Go hive process. Each active coding agent (Copilot/Claude CLI) grows to
 	// ~2GB RSS, and an L6 hive runs 5-6 concurrently plus the hive process, so an
@@ -1719,7 +1719,16 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 	dir := filepath.Join(saasHivesDir, h.ID, "manifests")
 	os.MkdirAll(dir, 0o755)
 
-	repos := h.Repos
+	// Strip a leading "<org>/" off each repo before it is baked into the spoke's
+	// hive.yaml. The spoke builds every repo target as org + "/" + repo, so an
+	// org-qualified entry here resolves to "org/org/repo" and every agent on that
+	// hive fails with a repo_target misconfiguration. primary_repo below is
+	// normalized on the spoke at config load; repos was not, which is how a hive
+	// ends up with a correct bare primary_repo next to a broken repos list.
+	// A repo qualified with a DIFFERENT org is left alone so the spoke still
+	// reports it rather than silently targeting a repository nobody named.
+	repos, _ := config.NormalizeProjectRepos(h.Org, h.Repos)
+	normalizedPrimaryRepo, _ := config.NormalizeRepoForOrg(h.Org, h.PrimaryRepo)
 	reposYAML := "[]"
 	if len(repos) > 0 {
 		parts := make([]string, 0, len(repos))
@@ -1759,7 +1768,7 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		"Namespace":       "hive-hosted-" + h.ID,
 		"Org":             sanitize(h.Org),
 		"Repos":           reposYAML,
-		"PrimaryRepo":     sanitize(h.PrimaryRepo),
+		"PrimaryRepo":     sanitize(normalizedPrimaryRepo),
 		"AuthorizedUsers": authorizedUsersForHive(h),
 		"ACMMLevel":       h.ACMMLevel,
 		"Token":           req.GitHubToken,
@@ -1801,7 +1810,7 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// Kept as an empty list rather than deleting the template block, so a
 		// spoke rolling on an older manifest sees the field disappear cleanly
 		// instead of failing to render.
-		"AdditionalAppKeys": []provisionAppKey{},
+		"AdditionalAppKeys":     []provisionAppKey{},
 		"CPURequest":            cpuRequest,
 		"CPULimit":              cpuLimit,
 		"MemRequest":            memRequest,


### PR DESCRIPTION
## Problem

A hive shows **Degraded** with:

```
repo_target: Repo target misconfigured: repo 'zacburns/mlz-manager' contains '/' —
expected repo name only so the target resolves to org/repo. Fix in Governor Config -> Repos.
```

and `agents: 0 running, 1 paused, 4 need login`.

A repo target is built as `project.org + "/" + repo`, so a `repos` entry that already carries its own org resolves to `zacburns/zacburns/mlz-manager`. Every agent on that hive fails.

## Root cause

`applyDefaults` has stripped a matching `org/` prefix off `primary_repo` for a long time, but the identical normalization was never applied to the `repos` slice. That asymmetry is visible in the live config on `hive-hosted-hosted-available-vllmd-04`, which has a correct bare `primary_repo: mlz-manager` sitting next to `repos: [zacburns/mlz-manager]`.

The bad value originates in `provisionHive`, which baked `h.Repos` into the spoke's `hive.yaml` verbatim (only `sanitize`d), while `PrimaryRepo` got normalized downstream on the spoke.

## Fix

New `NormalizeRepoForOrg` / `NormalizeProjectRepos` in `pkg/config`, applied on three paths:

| Path | Change |
| --- | --- |
| **Load** (`applyDefaults`) | Normalizes `repos` as well as `primary_repo`, so existing broken hives self-heal on the next config load — no re-provision needed. |
| **Write** (`handleGovernorRepos`) | Normalizes before validating and persists the normalized values, so the `org/repo` form GitHub shows everywhere is accepted rather than 400'd, and can never be stored org-qualified again. |
| **Provision** (`provisionHive`) | Normalizes before templating the spoke's `hive.yaml`, fixing the origin of the bad data. |

Only an **exact, case-insensitive match on the configured org** is stripped. An entry qualified with a **different** org, a deeper path (`org/repo/tree/main`), or a URL still fails with the existing operator-facing message — silently dropping a mismatched org would retarget the hive at a repository the owner never named.

## Tests

- `TestNormalizeRepoForOrg` — org-qualified stripped (incl. case/whitespace variants); bare name unchanged; `zac` vs `zacburns` substring not stripped; different org, deeper path, URL, empty org/repo all untouched.
- `TestNormalizeProjectRepos` — mixed list normalizes only the qualified entries; already-bare list reports no change; different-org entry still rejected by validation.
- `TestApplyDefaultsNormalizesRepos` — the exact live config shape comes out bare and validates clean; bare config survives intact; mismatched org stays broken and still reports an issue.
- `TestValidateProjectRepoTargets` — added same-org accept cases and a deeper-path reject case.
- `TestHandleGovernorRepos_StripOrgPrefix` / `_StripOrgPrefixFromPrimary` / `_BareRepoUnchanged` / `_ForeignOrgPrefixRejected`, `TestHandleGovernorRepos_StripOrg`, `TestHandleGovernorRepos_ForeignOrgRejected`, `TestHandleGovernorReposStripOrgPrefix` — write path stores bare names, leaves bare input alone, and still 400s a foreign org without mutating stored config.
- `TestProvisionRepoNormalization` — provisioning-path normalization incl. bare and foreign-org controls.
- `TestLoadWithOverrides_ConfigEnvOverridesRepos` / `_ConfigEnvBareReposUnchanged` — `PROJECT_REPOS` override normalizes, bare values pass through.

Four pre-existing tests asserted the old behavior (400 on the hive's *own* org prefix) and were updated to assert the corrected behavior; each fixture's org was checked first to confirm it was genuinely a same-org case.

### Positive control

Neutered `NormalizeRepoForOrg` to return its input unchanged (still compiles). The regression cases failed as expected:

```
--- FAIL: TestValidateProjectRepoTargets/repos_entry_qualified_with_the_configured_org
--- FAIL: TestNormalizeRepoForOrg/org_qualified_matching_org
--- FAIL: TestApplyDefaultsNormalizesRepos
--- FAIL: TestHandleGovernorRepos_StripOrgPrefix
--- FAIL: TestHandleGovernorRepos_StripOrgPrefixFromPrimary
--- FAIL: TestHandleGovernorReposStripOrgPrefix
--- FAIL: TestHandleGovernorRepos_StripOrg
```

while every negative/control case (bare unchanged, different-org rejected, deeper path, URL) kept passing — confirming the tests discriminate on the normalization itself rather than on something incidental. Implementation restored; `go build ./...` clean and `pkg/config`, `pkg/dashboard`, `pkg/hub` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)