### PR TITLE
✨ ci: publish stable/candidate/edge release channels from v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -174,6 +174,18 @@ jobs:
           # sanitize '/' -> '-' so feat/x becomes tag feat-x-latest.
           REF_NAME='${{ github.ref_name }}'
           echo "branch_tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+          # RELEASE CHANNELS. stable/candidate/edge are moving pointers that must
+          # always resolve to the newest good build of the RELEASE branch (v4).
+          # They are emitted here, in the same imagetools create that publishes
+          # <branch>-latest, so a channel is a RETAG of the digest we just built —
+          # never a rebuild, and never a manual promotion step that can be
+          # forgotten. Empty on every other branch, so a feature branch can never
+          # move a channel out from under production.
+          if [ "$REF_NAME" = "v4" ]; then
+            echo "release_channels=stable candidate edge" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_channels=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create manifest list and push
         if: steps.head-check.outputs.stale != 'true'
@@ -187,6 +199,7 @@ jobs:
           fi
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive:${{ steps.meta.outputs.branch_tag }}-latest \
+            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive:%s ' "$c"; done) \\
             -t ghcr.io/kubestellar/hive:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive@sha256:%s ' "${digests[@]}")
 
@@ -291,6 +304,18 @@ jobs:
           # sanitize '/' -> '-' so feat/x becomes tag feat-x-latest.
           REF_NAME='${{ github.ref_name }}'
           echo "branch_tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+          # RELEASE CHANNELS. stable/candidate/edge are moving pointers that must
+          # always resolve to the newest good build of the RELEASE branch (v4).
+          # They are emitted here, in the same imagetools create that publishes
+          # <branch>-latest, so a channel is a RETAG of the digest we just built —
+          # never a rebuild, and never a manual promotion step that can be
+          # forgotten. Empty on every other branch, so a feature branch can never
+          # move a channel out from under production.
+          if [ "$REF_NAME" = "v4" ]; then
+            echo "release_channels=stable candidate edge" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_channels=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create contributor manifest list and push
         if: steps.head-check.outputs.stale != 'true'
@@ -305,6 +330,7 @@ jobs:
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive-contributor:latest \
             -t ghcr.io/kubestellar/hive-contributor:${{ steps.meta.outputs.branch_tag }}-latest \
+            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive-contributor:%s ' "$c"; done) \\
             -t ghcr.io/kubestellar/hive-contributor:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive-contributor@sha256:%s ' "${digests[@]}")
 
@@ -412,6 +438,18 @@ jobs:
           # sanitize '/' -> '-' so feat/x becomes tag feat-x-latest.
           REF_NAME='${{ github.ref_name }}'
           echo "branch_tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+          # RELEASE CHANNELS. stable/candidate/edge are moving pointers that must
+          # always resolve to the newest good build of the RELEASE branch (v4).
+          # They are emitted here, in the same imagetools create that publishes
+          # <branch>-latest, so a channel is a RETAG of the digest we just built —
+          # never a rebuild, and never a manual promotion step that can be
+          # forgotten. Empty on every other branch, so a feature branch can never
+          # move a channel out from under production.
+          if [ "$REF_NAME" = "v4" ]; then
+            echo "release_channels=stable candidate edge" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_channels=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create hub manifest list and push
         if: steps.head-check.outputs.stale != 'true'
@@ -426,5 +464,6 @@ jobs:
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive-hub:latest \
             -t ghcr.io/kubestellar/hive-hub:${{ steps.meta.outputs.branch_tag }}-latest \
+            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive-hub:%s ' "$c"; done) \\
             -t ghcr.io/kubestellar/hive-hub:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive-hub@sha256:%s ' "${digests[@]}")


### PR DESCRIPTION
Adds three moving channel tags — **`stable`**, **`candidate`**, **`edge`** — that always resolve to the newest good build of the release branch (`v4`), for all three images (`hive`, `hive-contributor`, `hive-hub`).

## Why

Today the only mutable pointers are `<branch>-latest`, which *is* an edge channel by definition — it moves on every merge. There was no constant pointer a consumer could track, which is why the v4 fleet cutover put 68 spokes on whatever `v4` HEAD happened to be at that minute.

This follows the OpenShift channel model (`candidate` → `fast`/`stable`), minus the version axis: hive tracks branches, not semver releases, so `stable` is simpler and correct here.

## How

The channels are emitted inside the **same `docker buildx imagetools create`** that already publishes `<branch>-latest` and the immutable `git_short` tag:

```yaml
-t ghcr.io/kubestellar/hive:${{ steps.meta.outputs.branch_tag }}-latest \
$(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive:%s ' "$c"; done) \
```

So a channel is a **retag of the digest just built** — never a rebuild, and never a separate promotion job that can be forgotten or that could publish an artifact nobody tested. Multi-arch indexes are preserved because the retag is by digest.

**No manual step: channels advance automatically on every v4 build.**

## Safety

`release_channels` is computed per-branch and is **empty on anything but `v4`**, so a feature branch can never move a production channel out from under the fleet. Verified by simulating the shell expansion both ways:

| `release_channels` | expands to |
|---|---|
| `stable candidate edge` | `-t …:stable -t …:candidate -t …:edge` |
| `` (any other branch) | *(nothing)* |

YAML validated with `yaml.safe_load`.

## Current state

All three channels already point at the v4 digest (created by hand ahead of this PR). Verified — for both `hive` and `hive-hub`, `stable`/`candidate`/`edge`/`v4-latest` all resolve to the same digest.

## Follow-up, deliberately not in this PR

The self-upgrade poller resolves **branches** to SHAs (`getLatestHubSHAForBranch`). Pointing hives at a *channel* rather than a branch is a code change in that same path. Until then `stable` and `candidate` track `edge` exactly — they gain distinct soak policy only once that lands, and the gate for promotion (time-based soak vs. manual vs. green nightly E2E) is still an open product decision.