### PR TITLE
feat(hub): surface release channels in the dashboard UI

### DIFF
--- a/v2/pkg/hub/release_channels.go
+++ b/v2/pkg/hub/release_channels.go
@@ -1,0 +1,238 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Release channels are MOVING container tags published by
+// .github/workflows/docker.yml as retags of the same digest as the release
+// branch's "<branch>-latest" tag. They exist so an operator can point a hive at
+// a promotion track ("give me whatever is currently blessed") instead of at a
+// branch name or a frozen SHA.
+//
+// IMPORTANT: nothing here hardcodes WHICH branch a channel currently tracks.
+// Today all three resolve to the same v4 digest, but promotion policy will
+// diverge them later, and a hardcoded mapping would then silently lie on the
+// dashboard. The association is derived by resolving each channel tag to its
+// registry digest and matching that digest against the digests of the tracked
+// branches' "<branch>-latest" tags. When CI re-points a channel, the badge
+// follows on the next cache refresh with no hub code change.
+const (
+	// ReleaseChannelStable is the most conservative track: the newest build
+	// that has been promoted as generally safe.
+	ReleaseChannelStable = "stable"
+
+	// ReleaseChannelCandidate is the pre-promotion track — a build believed
+	// good and awaiting soak before it becomes stable.
+	ReleaseChannelCandidate = "candidate"
+
+	// ReleaseChannelEdge is the newest good build, promoted with no soak.
+	ReleaseChannelEdge = "edge"
+)
+
+// releaseChannels is the ordered channel list, most-stable first. Order is
+// meaningful: it is the order the dashboard renders the channel rows and the
+// order the per-hive upgrade dropdown offers them, so the least surprising
+// choice reads first.
+var releaseChannels = []string{
+	ReleaseChannelStable,
+	ReleaseChannelCandidate,
+	ReleaseChannelEdge,
+}
+
+// ReleaseChannels returns the ordered release-channel names. A copy, so a
+// caller (e.g. the dashboard JSON encoder) cannot mutate the package list.
+func ReleaseChannels() []string {
+	return append([]string(nil), releaseChannels...)
+}
+
+// isReleaseChannel reports whether tag names a release channel. Used to accept
+// a channel as a branch-switch target without it having to exist as a git
+// branch — "stable" is a tag, not a ref, so the git-branch existence check
+// would reject it.
+func isReleaseChannel(tag string) bool {
+	for _, c := range releaseChannels {
+		if c == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// upgradeTargetTag maps a branch-switch target to the GHCR tag to pin. A
+// release channel is ALREADY a moving tag, so it is used verbatim; a branch's
+// moving tag is "<branch>-latest". Appending "-latest" to a channel would ask
+// for "stable-latest", which CI never publishes — the switch would be refused
+// by the publish check, or worse, land the hive on ImagePullBackOff.
+func upgradeTargetTag(target string) string {
+	if isReleaseChannel(target) {
+		return target
+	}
+	return branchToTag(target) + "-latest"
+}
+
+// ChannelTarget is one row of the dashboard's channel block: the channel, and
+// the image it CURRENTLY resolves to.
+type ChannelTarget struct {
+	// Channel is the moving tag name ("stable", "candidate", "edge").
+	Channel string `json:"channel"`
+
+	// Branch is the tracked branch whose "<branch>-latest" tag resolves to the
+	// same digest as this channel, or "" when the channel points at a digest
+	// that is not any tracked branch's latest (mid-promotion, a pinned older
+	// build, or a branch the hub does not track). An empty Branch must render
+	// honestly — the SHA alone, or "unknown" — never as a guessed branch.
+	Branch string `json:"branch,omitempty"`
+
+	// SHA is the short commit SHA displayed for this channel. It comes from the
+	// matched branch's resolved SHA when Branch is set; otherwise it is empty
+	// and the UI falls back to showing the digest.
+	SHA string `json:"sha,omitempty"`
+
+	// Digest is the registry digest the channel tag resolves to, or "" when the
+	// channel could not be resolved at all (tag absent, or GHCR unreachable).
+	Digest string `json:"digest,omitempty"`
+}
+
+// channelDigestTTL bounds how stale a channel→digest association may be. A
+// channel re-point must become visible on the dashboard without an operator
+// restarting the hub, but resolving costs one GHCR round-trip per channel plus
+// one per tracked branch, which must not ride on every dashboard poll (the
+// My Hives page polls every few seconds). Five minutes matches
+// imageBranchCacheTTL, the existing registry-derived cache next door.
+const channelDigestTTL = 5 * time.Minute
+
+// channelResolveTimeout bounds the whole refresh. GHCR being slow must degrade
+// to "serve the previous answer", never to a hung dashboard request.
+const channelResolveTimeout = 8 * time.Second
+
+var (
+	channelTargetMu       sync.RWMutex
+	channelTargetCache    []ChannelTarget
+	channelTargetCachedAt time.Time
+)
+
+// ghcrTagDigest returns the registry digest that repo:tag currently resolves
+// to, or "" if the tag does not exist or the registry could not be reached.
+//
+// A var so tests can supply digests without a network round-trip. Production
+// issues a HEAD against the manifest endpoint and reads Docker-Content-Digest,
+// which is exactly what a `docker pull` would resolve — so two tags reporting
+// the same digest ARE the same image, which is the property the channel→branch
+// match depends on.
+var ghcrTagDigest = func(repo, tag string, logger *slog.Logger) string {
+	client := &http.Client{Timeout: channelResolveTimeout}
+	tokenResp, err := client.Get(ghcrBase + "/token?scope=repository:" + repo + ":pull")
+	if err != nil {
+		logger.Warn("channel resolve: GHCR token request failed", "repo", repo, "error", err)
+		return ""
+	}
+	defer tokenResp.Body.Close()
+	var tok struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
+		return ""
+	}
+	req, _ := http.NewRequest("HEAD", fmt.Sprintf("%s/v2/%s/manifests/%s", ghcrBase, repo, tag), nil)
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Warn("channel resolve: GHCR manifest HEAD failed", "repo", repo, "tag", tag, "error", err)
+		return ""
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	return resp.Header.Get("Docker-Content-Digest")
+}
+
+// resolveChannelTargets builds the channel→image association from digests
+// alone. branchSHAs is branch→short-SHA (what the dashboard already displays,
+// i.e. getDisplaySHAs()); each branch is matched via its "<branch>-latest" tag.
+//
+// Pure with respect to the network: every registry read goes through the
+// ghcrTagDigest hook, so a test can express "channel X points at branch Y" by
+// handing back digests, and a hardcoded branch mapping cannot pass.
+func resolveChannelTargets(branchSHAs map[string]string, logger *slog.Logger) []ChannelTarget {
+	// Resolve each tracked branch's moving tag ONCE, then invert: digest →
+	// branch. Iterating branches per channel would multiply round-trips by the
+	// channel count for no extra information.
+	branchByDigest := make(map[string]string, len(branchSHAs))
+	// Deterministic branch order so a digest carrying two branch tags (two
+	// branches at the identical commit) always attributes to the same one
+	// instead of flapping between dashboard polls with Go's random map order.
+	branchNames := make([]string, 0, len(branchSHAs))
+	for b := range branchSHAs {
+		branchNames = append(branchNames, b)
+	}
+	sort.Strings(branchNames)
+	for _, b := range branchNames {
+		d := ghcrTagDigest(ghcrRepoSpoke, branchToTag(b)+"-latest", logger)
+		if d == "" {
+			continue
+		}
+		if _, taken := branchByDigest[d]; !taken {
+			branchByDigest[d] = b
+		}
+	}
+
+	out := make([]ChannelTarget, 0, len(releaseChannels))
+	for _, ch := range releaseChannels {
+		t := ChannelTarget{Channel: ch}
+		t.Digest = ghcrTagDigest(ghcrRepoSpoke, ch, logger)
+		if t.Digest != "" {
+			// Branch stays empty when the digest matches nothing tracked. That
+			// is a real state (a channel pinned to an older build), and the UI
+			// renders it as such rather than inventing an attribution.
+			if b, ok := branchByDigest[t.Digest]; ok {
+				t.Branch = b
+				t.SHA = branchSHAs[b]
+			}
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// getChannelTargets returns the cached channel→image association, refreshing it
+// when older than channelDigestTTL. On a failed refresh the previous answer is
+// kept: a transient GHCR blip must not blank the channel rows.
+func getChannelTargets(branchSHAs map[string]string, logger *slog.Logger) []ChannelTarget {
+	channelTargetMu.RLock()
+	if channelTargetCache != nil && time.Since(channelTargetCachedAt) < channelDigestTTL {
+		cp := append([]ChannelTarget(nil), channelTargetCache...)
+		channelTargetMu.RUnlock()
+		return cp
+	}
+	stale := append([]ChannelTarget(nil), channelTargetCache...)
+	channelTargetMu.RUnlock()
+
+	fresh := resolveChannelTargets(branchSHAs, logger)
+	// "Resolved nothing at all" means the registry was unreachable, not that
+	// the channels vanished — keep the last good answer in that case.
+	resolvedAny := false
+	for _, t := range fresh {
+		if t.Digest != "" {
+			resolvedAny = true
+			break
+		}
+	}
+	if !resolvedAny && len(stale) > 0 {
+		return stale
+	}
+
+	channelTargetMu.Lock()
+	channelTargetCache = fresh
+	channelTargetCachedAt = time.Now()
+	channelTargetMu.Unlock()
+	return append([]ChannelTarget(nil), fresh...)
+}

--- a/v2/pkg/hub/release_channels_test.go
+++ b/v2/pkg/hub/release_channels_test.go
@@ -1,0 +1,239 @@
+package hub
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func testChannelLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// stubChannelDigests points ghcrTagDigest at a fixed tag→digest table for the
+// duration of one test, and clears the channel cache on both sides so tests
+// cannot leak a resolved association into each other.
+func stubChannelDigests(t *testing.T, byTag map[string]string) {
+	t.Helper()
+	resetChannelTargetCache()
+	orig := ghcrTagDigest
+	ghcrTagDigest = func(repo, tag string, _ *slog.Logger) string {
+		if repo != ghcrRepoSpoke {
+			t.Errorf("channel resolution must read the SPOKE repo, got %q", repo)
+		}
+		return byTag[tag]
+	}
+	t.Cleanup(func() {
+		ghcrTagDigest = orig
+		resetChannelTargetCache()
+	})
+}
+
+func resetChannelTargetCache() {
+	channelTargetMu.Lock()
+	channelTargetCache = nil
+	channelTargetCachedAt = time.Time{}
+	channelTargetMu.Unlock()
+}
+
+func targetFor(targets []ChannelTarget, channel string) ChannelTarget {
+	for _, t := range targets {
+		if t.Channel == channel {
+			return t
+		}
+	}
+	return ChannelTarget{}
+}
+
+// TestResolveChannelTargetsMatchesByDigest is the everyday case: all three
+// channels are retags of the v4 digest, so all three attribute to v4.
+func TestResolveChannelTargetsMatchesByDigest(t *testing.T) {
+	const v4Digest = "sha256:aaaa"
+	stubChannelDigests(t, map[string]string{
+		"v2-latest":             "sha256:bbbb",
+		"v4-latest":             v4Digest,
+		ReleaseChannelStable:    v4Digest,
+		ReleaseChannelCandidate: v4Digest,
+		ReleaseChannelEdge:      v4Digest,
+	})
+
+	got := resolveChannelTargets(map[string]string{"v2": "9a87c53", "v4": "3d31590"}, testChannelLogger())
+	if len(got) != len(releaseChannels) {
+		t.Fatalf("got %d targets, want %d", len(got), len(releaseChannels))
+	}
+	for _, ch := range releaseChannels {
+		tgt := targetFor(got, ch)
+		if tgt.Branch != "v4" {
+			t.Errorf("channel %q: branch = %q, want v4", ch, tgt.Branch)
+		}
+		if tgt.SHA != "3d31590" {
+			t.Errorf("channel %q: sha = %q, want 3d31590", ch, tgt.SHA)
+		}
+	}
+}
+
+// TestResolveChannelTargetsFollowsRepoint is the POSITIVE CONTROL for the
+// live-association requirement. "stable" is re-pointed at the v2 digest while
+// candidate/edge stay on v4. An implementation that hardcodes "channels are
+// v4" — or that labels everything with a single branch — fails here.
+func TestResolveChannelTargetsFollowsRepoint(t *testing.T) {
+	const (
+		v2Digest = "sha256:bbbb"
+		v4Digest = "sha256:aaaa"
+	)
+	stubChannelDigests(t, map[string]string{
+		"v2-latest":             v2Digest,
+		"v4-latest":             v4Digest,
+		ReleaseChannelStable:    v2Digest, // re-pointed back to v2
+		ReleaseChannelCandidate: v4Digest,
+		ReleaseChannelEdge:      v4Digest,
+	})
+
+	got := resolveChannelTargets(map[string]string{"v2": "9a87c53", "v4": "3d31590"}, testChannelLogger())
+
+	if tgt := targetFor(got, ReleaseChannelStable); tgt.Branch != "v2" || tgt.SHA != "9a87c53" {
+		t.Errorf("stable = %q/%q, want v2/9a87c53 — the channel→branch association must follow the DIGEST, not a hardcoded release branch", tgt.Branch, tgt.SHA)
+	}
+	for _, ch := range []string{ReleaseChannelCandidate, ReleaseChannelEdge} {
+		if tgt := targetFor(got, ch); tgt.Branch != "v4" {
+			t.Errorf("%s = %q, want v4", ch, tgt.Branch)
+		}
+	}
+}
+
+// TestResolveChannelTargetsUnmatchedDigestGetsNoBranch is the second positive
+// control: a channel pointing at a digest no tracked branch carries must be
+// reported WITHOUT a branch, not silently attributed to one. This is what
+// stops the UI from labelling a mid-promotion build as "v4".
+func TestResolveChannelTargetsUnmatchedDigestGetsNoBranch(t *testing.T) {
+	stubChannelDigests(t, map[string]string{
+		"v4-latest":             "sha256:aaaa",
+		ReleaseChannelStable:    "sha256:cccc", // an older pinned build
+		ReleaseChannelCandidate: "sha256:aaaa",
+		ReleaseChannelEdge:      "sha256:aaaa",
+	})
+
+	got := resolveChannelTargets(map[string]string{"v4": "3d31590"}, testChannelLogger())
+
+	tgt := targetFor(got, ReleaseChannelStable)
+	if tgt.Branch != "" || tgt.SHA != "" {
+		t.Errorf("stable = branch %q sha %q, want both empty — an unmatched digest must not be attributed to a branch", tgt.Branch, tgt.SHA)
+	}
+	if tgt.Digest != "sha256:cccc" {
+		t.Errorf("stable digest = %q, want sha256:cccc so the UI can still identify the build", tgt.Digest)
+	}
+}
+
+// TestResolveChannelTargetsUnresolvableChannel: a channel tag that does not
+// exist on GHCR yields an empty row rather than a wrong one.
+func TestResolveChannelTargetsUnresolvableChannel(t *testing.T) {
+	stubChannelDigests(t, map[string]string{
+		"v4-latest":          "sha256:aaaa",
+		ReleaseChannelStable: "sha256:aaaa",
+		// candidate and edge are absent from the registry.
+	})
+
+	got := resolveChannelTargets(map[string]string{"v4": "3d31590"}, testChannelLogger())
+	for _, ch := range []string{ReleaseChannelCandidate, ReleaseChannelEdge} {
+		tgt := targetFor(got, ch)
+		if tgt.Digest != "" || tgt.Branch != "" {
+			t.Errorf("%s resolved to %q/%q though its tag does not exist", ch, tgt.Digest, tgt.Branch)
+		}
+	}
+	if tgt := targetFor(got, ReleaseChannelStable); tgt.Branch != "v4" {
+		t.Errorf("stable = %q, want v4 — one missing channel must not poison the others", tgt.Branch)
+	}
+}
+
+// TestResolveChannelTargetsDeterministicOnDigestCollision: when two branches
+// sit at the same commit, the attributed branch must be stable across calls
+// rather than flapping with Go's map iteration order.
+func TestResolveChannelTargetsDeterministicOnDigestCollision(t *testing.T) {
+	const d = "sha256:aaaa"
+	stubChannelDigests(t, map[string]string{
+		"v2-latest":             d,
+		"v4-latest":             d,
+		ReleaseChannelStable:    d,
+		ReleaseChannelCandidate: d,
+		ReleaseChannelEdge:      d,
+	})
+	shas := map[string]string{"v2": "3d31590", "v4": "3d31590"}
+
+	first := targetFor(resolveChannelTargets(shas, testChannelLogger()), ReleaseChannelStable).Branch
+	for i := 0; i < 20; i++ {
+		if got := targetFor(resolveChannelTargets(shas, testChannelLogger()), ReleaseChannelStable).Branch; got != first {
+			t.Fatalf("attribution flapped: %q then %q", first, got)
+		}
+	}
+}
+
+// TestGetChannelTargetsKeepsStaleOnRegistryOutage: a GHCR blip must not blank
+// the channel rows on the dashboard.
+func TestGetChannelTargetsKeepsStaleOnRegistryOutage(t *testing.T) {
+	stubChannelDigests(t, map[string]string{
+		"v4-latest":             "sha256:aaaa",
+		ReleaseChannelStable:    "sha256:aaaa",
+		ReleaseChannelCandidate: "sha256:aaaa",
+		ReleaseChannelEdge:      "sha256:aaaa",
+	})
+	shas := map[string]string{"v4": "3d31590"}
+
+	warm := getChannelTargets(shas, testChannelLogger())
+	if targetFor(warm, ReleaseChannelStable).Branch != "v4" {
+		t.Fatalf("warm-up failed: %+v", warm)
+	}
+
+	// Registry goes dark and the cache is expired.
+	ghcrTagDigest = func(string, string, *slog.Logger) string { return "" }
+	channelTargetMu.Lock()
+	channelTargetCachedAt = time.Now().Add(-2 * channelDigestTTL)
+	channelTargetMu.Unlock()
+
+	got := getChannelTargets(shas, testChannelLogger())
+	if targetFor(got, ReleaseChannelStable).Branch != "v4" {
+		t.Errorf("stale answer was dropped on registry outage: %+v", got)
+	}
+}
+
+// TestUpgradeTargetTag: a channel is already a moving tag and must NOT get a
+// "-latest" suffix; a branch must.
+func TestUpgradeTargetTag(t *testing.T) {
+	cases := map[string]string{
+		ReleaseChannelStable:    "stable",
+		ReleaseChannelCandidate: "candidate",
+		ReleaseChannelEdge:      "edge",
+		"v4":                    "v4-latest",
+		"v2":                    "v2-latest",
+		"feat/x":                "feat-x-latest",
+	}
+	for in, want := range cases {
+		if got := upgradeTargetTag(in); got != want {
+			t.Errorf("upgradeTargetTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsReleaseChannel(t *testing.T) {
+	for _, c := range releaseChannels {
+		if !isReleaseChannel(c) {
+			t.Errorf("isReleaseChannel(%q) = false", c)
+		}
+	}
+	for _, notCh := range []string{"v2", "v4", "", "stable-latest", "Stable"} {
+		if isReleaseChannel(notCh) {
+			t.Errorf("isReleaseChannel(%q) = true, want false", notCh)
+		}
+	}
+}
+
+func TestReleaseChannelsReturnsCopy(t *testing.T) {
+	got := ReleaseChannels()
+	if len(got) != len(releaseChannels) {
+		t.Fatalf("got %d channels, want %d", len(got), len(releaseChannels))
+	}
+	got[0] = "mutated"
+	if releaseChannels[0] != ReleaseChannelStable {
+		t.Error("ReleaseChannels() exposed the package slice — a caller mutated it")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2965,6 +2965,12 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		"hub_git_hash":             s.hubGitHash,
 		"hub_git_branch":           s.hubGitBranch,
 		"tracked_branches":         s.trackedBranchList(),
+		// Release channels are moving tags; the dashboard renders them as their
+		// own "channel -> image" block above the per-branch rows, and offers
+		// them as branch-switch targets. The association is resolved from
+		// registry digests (cached), never hardcoded to a branch name.
+		"release_channels":         ReleaseChannels(),
+		"channel_targets":          getChannelTargets(getDisplaySHAs(), s.logger),
 		"hub_auto_upgrade":         isHubAutoUpgrade(),
 		"hub_upgrade_state":        s.hubUpgradeState(),
 		"show_my_hives":            true,
@@ -3869,7 +3875,12 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"branch is required"}`, http.StatusBadRequest)
 		return
 	}
-	validBranch := false
+	// A release channel is a moving TAG, not a git ref, so the branch-existence
+	// checks below would reject it ("stable" is not a branch on the hive repo).
+	// Accept it here and let the shared publish check further down be the real
+	// gate — the tag still has to exist on GHCR before we point a hive at it.
+	isChannel := isReleaseChannel(body.Branch)
+	validBranch := isChannel
 	for _, b := range s.trackedBranchList() {
 		if b == body.Branch {
 			validBranch = true
@@ -3897,7 +3908,8 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ns := "hive-hosted-" + id
-	imageTag := branchToTag(body.Branch) + "-latest"
+	// A channel IS the tag ("stable"); a branch's moving tag is "<branch>-latest".
+	imageTag := upgradeTargetTag(body.Branch)
 	image := "ghcr.io/kubestellar/hive:" + imageTag
 	// Refuse a branch name that sanitizes into something that is not a valid
 	// channel tag, rather than stranding the spoke on ImagePullBackOff behind a
@@ -3960,7 +3972,7 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
-			s.beginUpgrade(i, branchToTag(body.Branch)+"-latest")
+			s.beginUpgrade(i, imageTag)
 			break
 		}
 	}
@@ -10082,6 +10094,26 @@ const dashboardHTML = `<!DOCTYPE html>
       window._buildTimerInterval = setInterval(_tickBuildTimers, 1000);
     }
     var _trackedBranchesList = [];
+    /* Release channels: the ordered channel names, and the server-resolved
+       channel -> image association (see release_channels.go). _channelTargets
+       entries are {channel, branch, sha, digest}; branch/sha are EMPTY when the
+       channel points at a digest that is not any tracked branch's latest, and
+       the UI must render that honestly rather than guessing a branch. */
+    var _releaseChannels = [];
+    var _channelTargets = [];
+    /* Width of the channel-name pill in the "channel -> image" block. Fixed so
+       the three arrows line up in a column; sized for the longest channel name
+       ("candidate") at 0.6rem. */
+    var CHANNEL_NAME_MIN_W_PX = 62;
+
+    /* A registry digest is "sha256:<64 hex>" — far too long for a table cell.
+       Show the same 7 hex chars a short git SHA uses, keeping the full digest
+       in the title so it is still copyable/verifiable. */
+    function shortDigest(d) {
+      if (!d) return '';
+      var hex = d.indexOf(':') >= 0 ? d.slice(d.indexOf(':') + 1) : d;
+      return hex.length > 7 ? hex.slice(0, 7) : hex;
+    }
     var _clusterList = [];
     var _commitMessages = {};
     var _allDashHives = [];
@@ -12540,6 +12572,8 @@ const dashboardHTML = `<!DOCTYPE html>
         _latestSHA = data.latest_sha || _latestSHA;
         if (data.latest_shas) _latestSHAs = data.latest_shas;
         if (data.tracked_branches) _trackedBranchesList = data.tracked_branches;
+        if (data.release_channels) _releaseChannels = data.release_channels;
+        if (data.channel_targets) _channelTargets = data.channel_targets;
         if (data.latest_sha_messages) _latestSHAMessages = data.latest_sha_messages;
         if (data.latest_sha_image_status) _latestImageStatus = data.latest_sha_image_status;
         _latestBuildStarted = data.latest_sha_build_started || {};
@@ -12573,7 +12607,40 @@ const dashboardHTML = `<!DOCTYPE html>
           } else if (_latestSHA) {
             lines = '<span style="font-family:monospace;color:var(--muted)">' + esc(_latestSHA) + '</span>';
           }
-          shaEl.innerHTML = lines ? '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:2px">Latest available images:</div>' + lines : '<div style="display:flex;align-items:center;gap:6px;font-size:0.7rem;color:var(--muted)"><span style="display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite"></span>Resolving latest available images…</div>';
+          /* Channel block, rendered ABOVE the per-branch rows as
+                 stable    ->  v4 3d31590 : <subject>
+             so the moving tags read as pointers INTO the branch list below
+             rather than as extra branches. The arrow column is fixed-width so
+             the three channel names left-align and the targets line up.
+             Nothing here assumes a channel tracks any particular branch: the
+             target comes from the server's digest match, and a channel with no
+             match renders its digest (or "unknown") instead of a branch. */
+          var chLines = '';
+          for (var ci = 0; ci < _channelTargets.length; ci++) {
+            var ct = _channelTargets[ci] || {};
+            var ctTarget;
+            if (ct.branch) {
+              var ctMsg = _latestSHAMessages[ct.branch] || '';
+              ctTarget = '<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3)">' + esc(ct.branch) + '</span><span style="font-family:monospace;color:var(--muted);margin-left:6px">' + esc(ct.sha || '') + '</span>' + (ctMsg ? '<span style="font-size:0.7rem;color:var(--muted);opacity:0.7">: ' + esc(ctMsg) + '</span>' : '');
+            } else if (ct.digest) {
+              /* Resolved, but to something no tracked branch points at — a
+                 pinned or mid-promotion build. Show the digest so the operator
+                 can still identify it; do NOT attribute it to a branch. */
+              ctTarget = '<span style="font-family:monospace;color:var(--muted)" title="' + escAttr(ct.digest) + '">' + esc(shortDigest(ct.digest)) + '</span>';
+            } else {
+              ctTarget = '<span style="color:var(--muted);opacity:0.7;font-size:0.7rem" title="Channel tag could not be resolved on GHCR">unknown</span>';
+            }
+            chLines += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px"><span style="display:inline-block;min-width:' + CHANNEL_NAME_MIN_W_PX + 'px;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);text-align:center" title="Release channel — a moving tag that follows whichever build is currently promoted to this track">' + esc(ct.channel) + '</span><span style="color:var(--muted);opacity:0.6;font-size:0.7rem">-&gt;</span>' + ctTarget + '</div>';
+          }
+          if (chLines) {
+            chLines = '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:2px">Release channels:</div>' + chLines +
+              '<div style="height:6px"></div>';
+          }
+          /* The branch rows keep their original header; the channel block gets
+             its own above it, so neither reads as a subheading of the other. */
+          if (lines) lines = '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:2px">Latest available images:</div>' + lines;
+          lines = chLines + lines;
+          shaEl.innerHTML = lines ? lines :'<div style="display:flex;align-items:center;gap:6px;font-size:0.7rem;color:var(--muted)"><span style="display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite"></span>Resolving latest available images…</div>';
         }
         var hubHash = data.hub_git_hash || '';
         var hubBranch = data.hub_git_branch || 'v2';
@@ -13395,7 +13462,14 @@ const dashboardHTML = `<!DOCTYPE html>
           var branchLatest = _latestSHAs[branchName] || _latestSHA;
           var _trackedBranches = _trackedBranchesList.length > 0 ? _trackedBranchesList : Object.keys(_latestSHAs);
           if (_trackedBranches.length === 0) _trackedBranches = ['v2'];
-          var canSwitchBranch = isHosted && h.role === 'owner' && _trackedBranches.length > 1 && !h.upgrading;
+          /* A release channel is as valid an upgrade target as a branch — the
+             hive gets pinned to the moving tag and follows promotions — so the
+             same menu offers both. Channels are listed in their own section
+             below the branches, because picking a channel is a different KIND
+             of choice (track a promotion policy vs. track a git branch) and
+             mixing them into one flat list hides that. */
+          var canSwitchBranch = isHosted && h.role === 'owner' &&
+            (_trackedBranches.length > 1 || _releaseChannels.length > 0) && !h.upgrading;
           var branchOptions = '';
           if (canSwitchBranch) {
             for (var bi = 0; bi < _trackedBranches.length; bi++) {
@@ -13403,6 +13477,26 @@ const dashboardHTML = `<!DOCTYPE html>
               if (tb !== branchName) {
                 branchOptions += '<div onclick="event.stopPropagation();switchBranch(\'' + esc(h.id) + '\',\'' + esc(tb) + '\',this)" style="padding:4px 10px;cursor:pointer;font-size:0.65rem;white-space:nowrap;color:#c9d1d9;border-radius:4px" onmouseover="this.style.background=\'rgba(59,130,246,0.2)\'" onmouseout="this.style.background=\'transparent\'">' + esc(tb) + '</div>';
               }
+            }
+            var chOpts = '';
+            for (var cbi = 0; cbi < _releaseChannels.length; cbi++) {
+              var cb = _releaseChannels[cbi];
+              if (cb === branchName) continue;
+              /* Name what the channel resolves to RIGHT NOW in the hover, so
+                 the operator is not picking a word with no visible meaning.
+                 Falls back to the channel's own description when unresolved. */
+              var cbT = null;
+              for (var cti = 0; cti < _channelTargets.length; cti++) {
+                if (_channelTargets[cti] && _channelTargets[cti].channel === cb) { cbT = _channelTargets[cti]; break; }
+              }
+              var cbTitle = cbT && cbT.branch
+                ? 'Currently ' + cbT.branch + ' ' + (cbT.sha || '') + ' — the hive follows this channel as it is re-pointed'
+                : 'Moving release channel — the hive follows it as it is re-pointed';
+              chOpts += '<div onclick="event.stopPropagation();switchBranch(\'' + esc(h.id) + '\',\'' + esc(cb) + '\',this)" title="' + escAttr(cbTitle) + '" style="padding:4px 10px;cursor:pointer;font-size:0.65rem;white-space:nowrap;color:#4ade80;border-radius:4px" onmouseover="this.style.background=\'rgba(34,197,94,0.2)\'" onmouseout="this.style.background=\'transparent\'">' + esc(cb) + '</div>';
+            }
+            if (chOpts) {
+              branchOptions += '<div style="border-top:1px solid #30363d;margin:4px 0"></div>' +
+                '<div style="padding:2px 10px;font-size:0.55rem;color:var(--muted);text-transform:uppercase;letter-spacing:0.05em">Channels</div>' + chOpts;
             }
           }
           var branch = canSwitchBranch


### PR DESCRIPTION
Follow-on to #3702 (which publishes the `stable` / `candidate` / `edge` moving tags). That PR did the tagging; nothing in the hub UI showed the channels existed. This is the **presentation + selection** half.

## Surface 1 — "Latest available images" (My Hives)

A new **Release channels** block renders above the existing per-branch rows, as a channel column, an arrow, and the image it currently resolves to:

```
Release channels:
  stable    ->  v4  3d31590 : fix(hub): reconcile stale vanity URLs ...
  candidate ->  v4  3d31590 : fix(hub): reconcile stale vanity URLs ...
  edge      ->  v4  3d31590 : fix(hub): reconcile stale vanity URLs ...

Latest available images:
  dd 5762c5b : ...
  mk 815d7e4 : ...
  ...
```

All three read identically today because they are retags of the same v4 digest. That is expected; they diverge once promotion policy exists. The per-branch rows are untouched.

## Surface 2 — per-hive upgrade control

The branch pill's switch menu gains a **Channels** section (below the branches, separated by a rule) offering `stable` / `candidate` / `edge`. Each option's hover names what it currently resolves to, e.g. *"Currently v4 3d31590 — the hive follows this channel as it is re-pointed"*, so the operator is not picking a bare word.

## How the association is derived — live, not hardcoded

No part of this maps "channels == v4". `resolveChannelTargets` resolves each channel tag **and** each tracked branch's `<branch>-latest` tag to its `Docker-Content-Digest` via a registry HEAD, inverts branch-by-digest, and matches. Consequences:

- Re-pointing a channel in CI moves its row on the dashboard with no hub code change.
- A channel pointing at a digest **no tracked branch carries** (mid-promotion, a pinned older build) renders as its short digest with the full digest on hover — never misattributed to a branch. An unresolvable tag renders `unknown`.
- Two branches at the same commit attribute deterministically (branches sorted) rather than flapping with map order.

Cost is one HEAD per channel plus one per tracked branch, cached for 5m (matching the adjacent `imageBranchCacheTTL`) so it does not ride on every My Hives poll. A refresh that resolves nothing keeps the previous answer, so a GHCR blip does not blank the block.

## Server-side plumbing (minimal, additive)

- `handleSwitchBranch` accepts a release channel as a target. A channel is a tag, not a git ref, so it would otherwise fail the branch-existence check.
- `upgradeTargetTag()` pins a channel **verbatim** instead of appending `-latest` — CI never publishes `stable-latest`, and asking for it would either be refused or strand the spoke on ImagePullBackOff. Branches still map to `<branch>-latest`.
- The existing `spokeImageExists` publish check remains the real gate on both paths.

**Out of scope by design:** the self-upgrade poller (`getLatestHubSHAForBranch` and friends) is deliberately untouched — teaching it to resolve channels is separate, deferred work. `.github/workflows/docker.yml` is not modified.

## Tests

`v2/pkg/hub/release_channels_test.go`:

| Test | Covers |
|---|---|
| `TestResolveChannelTargetsMatchesByDigest` | the everyday case — three retags of one v4 digest |
| `TestResolveChannelTargetsFollowsRepoint` | **positive control** — `stable` re-pointed at v2 while candidate/edge stay v4 |
| `TestResolveChannelTargetsUnmatchedDigestGetsNoBranch` | **positive control** — unmatched digest gets NO branch |
| `TestResolveChannelTargetsUnresolvableChannel` | a missing channel tag does not poison the others |
| `TestResolveChannelTargetsDeterministicOnDigestCollision` | no flapping when two branches share a commit |
| `TestGetChannelTargetsKeepsStaleOnRegistryOutage` | GHCR blip keeps the last good answer |
| `TestUpgradeTargetTag` / `TestIsReleaseChannel` / `TestReleaseChannelsReturnsCopy` | tag mapping and channel identity |

**Positive control verified by neutering:** replacing the digest match with a hardcoded `t.Branch = "v4"` still compiles, and `TestResolveChannelTargetsFollowsRepoint` + `TestResolveChannelTargetsUnmatchedDigestGetsNoBranch` both fail. The suite genuinely discriminates a live association from a hardcoded one; it was restored and re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)