### PR TITLE
🐛 fix(ci): repair line continuation broken by the release-channels change

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -199,7 +199,7 @@ jobs:
           fi
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive:${{ steps.meta.outputs.branch_tag }}-latest \
-            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive:%s ' "$c"; done) \\
+            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive:%s ' "$c"; done) \
             -t ghcr.io/kubestellar/hive:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive@sha256:%s ' "${digests[@]}")
 
@@ -330,7 +330,7 @@ jobs:
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive-contributor:latest \
             -t ghcr.io/kubestellar/hive-contributor:${{ steps.meta.outputs.branch_tag }}-latest \
-            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive-contributor:%s ' "$c"; done) \\
+            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive-contributor:%s ' "$c"; done) \
             -t ghcr.io/kubestellar/hive-contributor:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive-contributor@sha256:%s ' "${digests[@]}")
 
@@ -464,6 +464,6 @@ jobs:
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive-hub:latest \
             -t ghcr.io/kubestellar/hive-hub:${{ steps.meta.outputs.branch_tag }}-latest \
-            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive-hub:%s ' "$c"; done) \\
+            $(for c in ${{ steps.meta.outputs.release_channels }}; do printf -- '-t ghcr.io/kubestellar/hive-hub:%s ' "$c"; done) \
             -t ghcr.io/kubestellar/hive-hub:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive-hub@sha256:%s ' "${digests[@]}")


### PR DESCRIPTION
**All v4 image builds are currently failing.** This fixes them.

#3702 (release channels) wrote a **literal double backslash** at the end of the three new lines instead of a single shell line continuation:

```
ERROR: failed to parse source "\\", valid sources are digests, references and descriptors: invalid reference format
```

`merge`, `merge-hub`, and `merge-contributor` all failed on v4 HEAD `bf39d0c8`.

## Why this matters beyond CI being red

No image has been published since the break, so several merged fixes are **not yet in any image**:

| PR | Fix | Status |
|---|---|---|
| #3697 | hub `GIT_BRANCH` — stops the hub self-reverting to v2 | merged, not in an image |
| #3700 | repo-target normalization — spokes still show "Repo target misconfigured" | merged, not in an image |
| #3698 | vanity URL drift reconciliation | merged, not in an image |

This PR unblocks all of them.

My error, from a scripted patch that escaped the backslash twice.

## Verification

Not eyeballed — I **executed the exact command shape** that CI runs:

```
ARGS: -t ghcr.io/kubestellar/hive:v4-latest -t ghcr.io/kubestellar/hive:stable \
      -t ghcr.io/kubestellar/hive:candidate -t ghcr.io/kubestellar/hive:edge ...
stray backslash args: 0
```

Zero stray `\` arguments, and all three channel tags expand as intended.