### PR TITLE
feat(dashboard): full-log download/view for an agent's latest run (#3693)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -54,6 +54,14 @@ const (
 	paneCaptureSleep     = 500 * time.Millisecond
 	proxyListenPort      = 18443
 	proxyCACertPath      = "/data/proxy-ca.pem"
+
+	// fullLogCaptureLines bounds the "download/view full log" capture (see
+	// CaptureFullLog). tmux's -S - captures the entire scrollback, but a wedged
+	// agent that has spammed for hours can hold a very large buffer; this caps the
+	// number of lines pulled back from the tail so the endpoint stays bounded.
+	// It is deliberately far larger than the tmux history-limit tmux is usually
+	// started with, so in practice it returns the WHOLE retained session.
+	fullLogCaptureLines = 50000
 )
 
 var defaultTmuxSocket string
@@ -2608,6 +2616,42 @@ func (m *Manager) captureTmuxPaneForAgent(agent *AgentProcess) string {
 		return ""
 	}
 	return string(out)
+}
+
+// CaptureFullLog returns the agent's full retained tmux scrollback for its
+// current (latest) session, as plain text. It backs the dashboard's
+// "download / view full log" controls (issue #3693): the browser Terminal only
+// shows the last screenful, so this pulls the whole retained buffer — from the
+// tail up to fullLogCaptureLines — using the SAME per-agent socket + su-exec
+// path as every other capture, so it works under per-UID isolation.
+//
+// The capture is bounded to the current tmux session, so it is scoped to the
+// agent's latest run (a restart kills and recreates the session, dropping the
+// prior run's scrollback). It is NOT delimited to a run boundary WITHIN a
+// long-lived session; when an agent has been kicked repeatedly without a
+// restart, the buffer holds multiple kicks' output back to the tmux
+// history-limit. That is an accepted v1 limitation — the whole retained
+// session is returned.
+func (m *Manager) CaptureFullLog(name string) (string, error) {
+	m.mu.RLock()
+	agent, ok := m.agents[name]
+	m.mu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("agent %s not found", name)
+	}
+	if agent.tmuxSession == "" {
+		return "", fmt.Errorf("agent %s has no active session", name)
+	}
+	// -S -<n>: start n lines back into history; -E -: through the last visible
+	// line; -J: join wrapped lines so copied text is not hard-wrapped at the
+	// pane width; -p: print to stdout. -1: keep the tail behaviour bounded.
+	cmd := m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p", "-J",
+		"-S", fmt.Sprintf("-%d", fullLogCaptureLines), "-E", "-")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("capturing pane for %s: %w", name, err)
+	}
+	return string(out), nil
 }
 
 // captureVisiblePaneForAgent captures only the visible pane (no scrollback).

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -63,6 +63,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/lifecycle-timeline", s.handleLifecycleTimeline)
 	s.mux.HandleFunc("GET /api/widget", s.handleWidget)
 	s.mux.HandleFunc("GET /api/pane/{agent}", s.handlePane)
+	// Full retained scrollback of an agent's latest run, as plain text (#3693).
+	// Backs the Terminal's "view / download full log" controls.
+	s.mux.HandleFunc("GET /api/agents/{name}/log", s.handleAgentFullLog)
 
 	s.mux.HandleFunc("GET /api/role", s.handleRole)
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4333,6 +4333,8 @@
             ? ''
             : `<button class="btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="${isPaused}" title="${isPaused ? 'Resume this agent — it will start running on its configured cadence' : isOff ? 'Start this agent — it is currently off in this governor mode' : 'Pause this agent — stops governor from kicking it until resumed'}">${isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause'}</button>`}
           <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>
+          <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>
+          <a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>
           <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill this agent's tmux session — supervisor will respawn it with fresh context">↻ restart</button>
           <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" style="font-size:1rem;opacity:0.7" title="Open configuration dialog for this agent (cadences, model, pipeline, hooks, etc.)">⚙️</button>
           <button class="btn" data-action="kickEmpty" data-agent="${esc(a.name)}" style="margin-left:auto" title="Kick this agent now with its default prompt, bypassing the governor cadence timer">kick</button>
@@ -5833,6 +5835,22 @@
       return `${proto}//${host}/terminal/?arg=${encodeURIComponent(session)}${tokenParam}`;
     }
 
+    // fullLogUrl points at the server-side endpoint that captures the agent's
+    // full retained tmux scrollback (issue #3693). The live "▶ terminal" only
+    // shows the last screenful; this returns the whole latest-run buffer as
+    // plain, selectable, searchable text. download=1 makes the browser save it
+    // as a .log file instead of rendering it inline. The token param mirrors
+    // terminalUrl so it authenticates on direct-route spokes.
+    function fullLogUrl(agentName, download) {
+      const proto = window.location.protocol;
+      const host = window.location.host;
+      const t = localStorage.getItem('hive-token');
+      const dl = download ? 'download=1' : '';
+      const tok = t ? `token=${encodeURIComponent(t)}` : '';
+      const qs = [dl, tok].filter(Boolean).join('&');
+      return `${proto}//${host}/api/agents/${encodeURIComponent(agentName)}/log${qs ? '?' + qs : ''}`;
+    }
+
     /* SINGLE source of truth for the 🔑 "needs login" badge. Mirrors the
        server-side precedence rule in pkg/agent/authprobe.go:
 
@@ -5921,7 +5939,7 @@
         const configTarget = a.replicaBase || a.name;
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';

--- a/v2/pkg/dashboard/terminal_log.go
+++ b/v2/pkg/dashboard/terminal_log.go
@@ -1,0 +1,80 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// handleAgentFullLog serves the full retained tmux scrollback of an agent's
+// latest run as plain, selectable, searchable text (issue #3693). The browser
+// "Terminal" (ttyd) only shows the last screenful; this endpoint pulls the whole
+// retained session buffer server-side via Manager.CaptureFullLog, which uses the
+// same per-agent socket + su-exec path as every other capture so it works under
+// per-UID isolation.
+//
+// It is read-only (GET), so any authenticated role may call it — the same rule
+// as handleAgentState and the /terminal proxy, both of which already expose the
+// pane to any authenticated viewer.
+//
+// Query parameters:
+//
+//	?download=1  sets Content-Disposition: attachment so the browser saves a
+//	             .log text file (the "download full log" control). Omitted, the log
+//	             renders inline in a new tab as selectable/searchable text (the
+//	             "view full log" control).
+func (s *Server) handleAgentFullLog(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		http.Error(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	name := s.resolveAgentParam(r.PathValue("name"))
+	log, err := s.deps.AgentMgr.CaptureFullLog(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// SECURITY: every other pane surface (/api/pane, the status summaries) strips
+	// tokens and device-auth codes before the output leaves the server; the full
+	// log must too, or it becomes a redaction bypass (see redactTokens).
+	log = redactTokens(log)
+
+	// text/plain so browsers render it as selectable, searchable text (Cmd/Ctrl-F
+	// works, Select-All copies cleanly) rather than trying to interpret it.
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	// The pane is a live capture; never let an intermediary or the browser serve
+	// a stale copy of a previous run.
+	w.Header().Set("Cache-Control", "no-store")
+
+	if r.URL.Query().Get("download") != "" {
+		// Timestamped, filesystem-safe filename: hive-<agent>-<UTC>.log.
+		safe := sanitizeLogFilename(name)
+		fname := fmt.Sprintf("hive-%s-%s.log", safe, time.Now().UTC().Format("20060102-150405"))
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fname))
+	}
+
+	_, _ = w.Write([]byte(log))
+}
+
+// sanitizeLogFilename reduces an agent name to characters safe in a download
+// filename, so a display name or id never injects a path separator or quote into
+// the Content-Disposition header.
+func sanitizeLogFilename(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "agent"
+	}
+	return out
+}

--- a/v2/pkg/dashboard/terminal_log_test.go
+++ b/v2/pkg/dashboard/terminal_log_test.go
@@ -1,0 +1,77 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// A nonexistent agent returns 404 from the full-log endpoint (CaptureFullLog
+// reports "agent not found"), matching the /api/pane not-found contract.
+func TestHandleAgentFullLog_AgentNotFound(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agents/nonexistent/log")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// A known-but-not-running agent has no tmux session yet, so CaptureFullLog
+// returns the "no active session" error and the handler reports 404 — never a
+// 200 with an empty body that would look like a real (empty) log.
+func TestHandleAgentFullLog_NoActiveSession(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agents/scanner/log")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for an agent with no active session", rec.Code)
+	}
+}
+
+// With no agent manager wired, the endpoint reports 503 rather than panicking
+// on a nil dereference.
+func TestHandleAgentFullLog_NoManager(t *testing.T) {
+	s, _ := apiServer(t)
+	s.deps.AgentMgr = nil
+	rec := doGet(s, "/api/agents/scanner/log")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 when AgentMgr is nil", rec.Code)
+	}
+}
+
+// The download variant is still routed to the same handler; with no active
+// session it 404s exactly like the inline variant (the disposition header is
+// only reached on success, exercised where a live tmux session exists).
+func TestHandleAgentFullLog_DownloadRouted(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agents/scanner/log?download=1")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestSanitizeLogFilename(t *testing.T) {
+	cases := map[string]string{
+		"scanner":       "scanner",
+		"my-agent_1":    "my-agent_1",
+		"weird/../name": "weird----name",
+		"quote\"inject": "quote-inject",
+		"space name":    "space-name",
+		"emoji-🐝":       "emoji--", // multi-byte rune collapses to a single '-'
+		"":              "agent",
+		"...":           "---",
+		"UPPER123":      "UPPER123",
+	}
+	for in, want := range cases {
+		if got := sanitizeLogFilename(in); got != want {
+			t.Errorf("sanitizeLogFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// The result must never contain a path separator or a double quote, which
+	// would break out of the Content-Disposition filename.
+	for _, in := range []string{"a/b", "a\\b", "a\"b", "../../etc/passwd"} {
+		got := sanitizeLogFilename(in)
+		if strings.ContainsAny(got, `/\"`) {
+			t.Errorf("sanitizeLogFilename(%q) = %q contains an unsafe character", in, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3693

## What

The browser **Terminal** (ttyd, reverse-proxied at `/terminal`) only shows the last screenful of an agent's tmux session, and its scrollback is awkward to select and copy elsewhere. This adds the ability to see and copy the **full retained log of an agent's latest run** as selectable, searchable, copyable text.

Two new controls sit next to the existing `▶ terminal` link on each agent card:

- **📄 full log** — opens the latest run inline in a new browser tab as plain text (Cmd/Ctrl-F search works, Select-All copies cleanly).
- **⬇ log** — downloads the same content as a timestamped `.log` file (expanded card only).

## Which of the 3 proposed solutions

Implements the issue's **Option 2 (download the latest run as a text file)** and **Option 3 (pop up the latest run's log as selectable, searchable text)** together. Both are far more robust than fighting the tmux scrollback UI (Option 1), because they pull the complete captured log **server-side** rather than being limited to the visible pane — and the issue notes a separate tmux-scroll issue that this deliberately does not depend on.

## How the full-log content is sourced server-side

- New `agent.Manager.CaptureFullLog(name)` runs `tmux capture-pane -t <session> -p -J -S -<n> -E -` on the agent's **current** session, reusing the existing per-agent socket + `su-exec` path (`tmuxCmd`) so it works under per-UID isolation exactly like every other capture in the manager. `-J` joins wrapped lines so copied text isn't hard-wrapped at the pane width.
- New endpoint `GET /api/agents/{name}/log` serves it as `text/plain; charset=utf-8` with `Cache-Control: no-store`. `?download=1` adds `Content-Disposition: attachment` with a sanitized, timestamped filename (`hive-<agent>-<UTC>.log`).
- **Security:** output is passed through `redactTokens`, the same redaction every other pane surface (`/api/pane`, the status summaries) already applies, so the full log is not a token/device-code redaction bypass. The download filename is sanitized to prevent header injection. The endpoint is read-only (GET), so any authenticated role may call it — the same rule as `/api/agent-state` and the `/terminal` proxy, which already expose the pane to any authenticated viewer.

## Limitation (v1)

The capture is bounded to the agent's **current tmux session**, so it is scoped to the latest run — a restart kills and recreates the session, dropping the prior run's scrollback. It is **not** delimited to a single run *within* a long-lived session: an agent kicked many times without a restart holds all retained kicks back to tmux's history-limit. Returning the whole retained session is the accepted v1 behavior; a true per-run delimiter would need run-boundary markers the pane does not currently emit.

There is no persistent per-agent run-log file on the spoke today (only the live tmux pane and a 500-line in-memory ring buffer), so the retained tmux scrollback is the fullest available source without adding new persistence.

## Files changed

- `v2/pkg/agent/manager.go` — `CaptureFullLog` + `fullLogCaptureLines` const.
- `v2/pkg/dashboard/terminal_log.go` — `handleAgentFullLog` + filename sanitizer (new).
- `v2/pkg/dashboard/terminal_log_test.go` — handler + sanitizer tests (new).
- `v2/pkg/dashboard/api.go` — route registration.
- `v2/pkg/dashboard/static/index.html` — `fullLogUrl()` helper + the two controls on the expanded and compact agent cards.

## Testing

Unit tests cover the not-found (404), no-active-session (404), no-manager (503), and download-routing paths, plus the filename sanitizer (path-separator / quote injection). The live-session happy path requires a running tmux session and is exercised on the spoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)