### PR TITLE
🐛 fix(hub): clear stale "Upgrading" latch on convergence + unify the Upgrading filter pill with the row badge

### DIFF
--- a/v2/pkg/hub/commit_order_test.go
+++ b/v2/pkg/hub/commit_order_test.go
@@ -259,10 +259,17 @@ func TestHandleHeartbeatKeepsLatchWhileAncestryUnresolved(t *testing.T) {
 	}
 }
 
-// The orphan sweep must treat a spoke at-or-ahead of its target as NOT
-// orphaned — pre-fix it swept, re-armed and (after maxOrphanedUpgradeSweeps)
-// reported a false permanent UpgradeFailed for an upgrade that had landed.
-func TestEvaluateOrphanedUpgradeAheadOfTargetNotOrphaned(t *testing.T) {
+// The orphan sweep must treat a spoke at-or-ahead of its target as CONVERGED:
+// the latch is cleared, but as a completed upgrade — never re-armed, never
+// charged against maxOrphanedUpgradeSweeps, and never escalated to a false
+// permanent UpgradeFailed (the fault this test originally guarded).
+//
+// It formerly asserted orphaned=false, i.e. "leave it to the heartbeat path".
+// That deferral wedged z-mlz-manager: once the entry records the target SHA,
+// later beats carry no transition for the completion chain to act on, so the
+// latch survived forever. Clearing is now correct; `converged` is what keeps
+// the abandoned-attempt handling from firing on a success.
+func TestEvaluateOrphanedUpgradeAheadOfTargetIsConverged(t *testing.T) {
 	resetCommitOrderState(t)
 	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
 		return "", errors.New("stubbed offline")
@@ -274,15 +281,25 @@ func TestEvaluateOrphanedUpgradeAheadOfTargetNotOrphaned(t *testing.T) {
 		LastHeartbeat:    now.Add(-time.Minute).UTC().Format(time.RFC3339),
 	}
 
-	// Unresolved ancestry: liveness + wrong SHA still reads as orphaned.
-	if ev := evaluateOrphanedUpgrade(entry, now, "ccccccc"); !ev.orphaned {
+	// Unresolved ancestry: liveness + wrong SHA reads as an ABANDONED orphan —
+	// we cannot yet prove the spoke surpassed the target.
+	ev := evaluateOrphanedUpgrade(entry, now, "ccccccc")
+	if !ev.orphaned {
 		t.Fatal("sanity: unresolved ancestry should still evaluate as orphaned")
 	}
+	if ev.converged {
+		t.Errorf("unresolved ancestry cannot prove convergence: %+v", ev)
+	}
 
-	// Resolved ahead: converged, not orphaned.
+	// Resolved ahead: cleared, and marked converged so the sweep records a
+	// completion rather than re-arming a stale pin.
 	seedCommitOrder("bbbbbbb", "aaaaaaa", true)
-	if ev := evaluateOrphanedUpgrade(entry, now, "ccccccc"); ev.orphaned {
-		t.Errorf("a spoke ahead of its target is converged, not orphaned: %+v", ev)
+	ev = evaluateOrphanedUpgrade(entry, now, "ccccccc")
+	if !ev.orphaned {
+		t.Errorf("a spoke ahead of its target must have its stale latch cleared: %+v", ev)
+	}
+	if !ev.converged {
+		t.Errorf("a spoke ahead of its target is a COMPLETED upgrade: %+v", ev)
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10306,9 +10306,55 @@ const dashboardHTML = `<!DOCTYPE html>
                      elapsed counter must not claim to know one.
        'upgrading' is tested FIRST because an in-flight upgrade outranks a
        queued one; without that ordering a hive would be double-counted. */
+    /* hiveIsUpgradingNow is THE predicate for "this hive's row shows the
+       Upgrading/Switching spinner". Both the row badge and the filter pill call
+       it, so the pill can never disagree with what the operator sees in the
+       list.
+
+       It previously did not exist: the pill tested only h.upgrading while the
+       row OR'd together three sources, so the pill under-reported. A hive
+       mid-branch-switch, or one carrying a just-clicked client-side sentinel,
+       rendered a spinner the pill could not match; and the row's own
+       "isCurrent -> not really upgrading" suppression was invisible to the
+       pill, which counted such a hive as upgrading with no badge to show for
+       it. Three sources, one of them purely client-side, mean the answer cannot
+       be derived from the hub JSON alone — hence a shared function rather than
+       a shared field.
+
+       branchName / branchLatest are the row's already-resolved values; when the
+       caller has not resolved them (the facet counter iterating raw hives) they
+       are recomputed here from the same globals the row uses, so both paths
+       reach the identical answer. */
+    function hiveIsUpgradingNow(h, branchName, branchLatest) {
+      if (!h) return false;
+      if (branchName === undefined || branchName === null || branchName === '') {
+        branchName = h.gitBranch || 'v2';
+      }
+      if (branchLatest === undefined || branchLatest === null) {
+        branchLatest = _latestSHAs[branchName] || _latestSHA || '';
+      }
+      /* A branch switch is an upgrade in flight even though h.upgrading may
+         still be false — the spoke keeps reporting the OLD branch until the new
+         pod heartbeats. */
+      if (hiveSwitchState(h, branchName).isSwitching) return true;
+      /* Client-side sentinel: the operator clicked Upgrade and the hive still
+         reports the pre-click SHA. The hub has not yet flipped h.upgrading, but
+         the row is already spinning. */
+      var sentinel = _upgradingHives[h.id];
+      var sha = h.gitHash || '';
+      if (sentinel && sha === sentinel) return true;
+      /* Hub-reported. Suppressed when the hive is ALREADY at latest (the latch
+         is stale — exactly the server-side bug this pairs with) or when latest
+         is unresolved, because the row suppresses the spinner in both cases and
+         the pill must match. */
+      var latestUnknown = !branchLatest;
+      var isCurrent = !!branchLatest && sameShaJS(sha, branchLatest);
+      return !!(h.upgrading && !isCurrent && !latestUnknown);
+    }
+
     function hiveUpgradeState(h) {
       if (!h) return '';
-      if (h.upgrading) return UPGRADE_FILTER_UPGRADING;
+      if (hiveIsUpgradingNow(h)) return UPGRADE_FILTER_UPGRADING;
       if (h.autoUpgrade && h.upgradeTarget) return UPGRADE_FILTER_QUEUED;
       return '';
     }
@@ -13515,8 +13561,10 @@ const dashboardHTML = `<!DOCTYPE html>
              stops forcing the upgrading state on later auto-upgrades. */
           if (upgradeState.switchSentinelStale) delete _upgradingHives[h.id];
           var sentinel = _upgradingHives[h.id];
-          var isUpgrading = isSwitching ||
-            (sentinel && sha === sentinel) || (h.upgrading && !isCurrent && !latestUnknown);
+          /* ONE predicate, shared with the filter pill (hiveUpgradeState ->
+             hiveIsUpgradingNow), so a spinning row is always matched by the
+             "Upgrading" facet and vice versa. */
+          var isUpgrading = hiveIsUpgradingNow(h, branchName, branchLatest);
           if (sentinel && sha !== sentinel && !isSwitching) { delete _upgradingHives[h.id]; delete _switchStartedAt[h.id]; }
           if (isCurrent && h.upgrading && !isSwitching) { h.upgrading = false; }
           var imageBuilding = (_latestImageStatus[branchName] || '') === 'building';

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -49,6 +49,17 @@ const maxOrphanedUpgradeSweeps = 3
 type upgradeAttemptEvidence struct {
 	// orphaned is true when the flag should be cleared.
 	orphaned bool
+	// converged marks the clear as a COMPLETED upgrade rather than an abandoned
+	// one: the spoke is demonstrably at (or ahead of) the target it was asked
+	// for, so the rollout succeeded and only the latch was left behind.
+	//
+	// The sweep must treat the two differently. An abandoned attempt is re-armed
+	// and counts against maxOrphanedUpgradeSweeps, because the hive is still on
+	// its old build and the instruction has to be re-delivered. A converged one
+	// must do NEITHER: re-arming would re-instruct an upgrade that has already
+	// happened (rolling a healthy pod), and burning retry budget would let three
+	// successful upgrades tip the hive into a permanent, false UpgradeFailed.
+	converged bool
 	// reason is a short human-readable justification, logged and surfaced.
 	reason string
 	// elapsed is the time since the upgrade was instructed.
@@ -136,15 +147,45 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time, latestSHA stri
 		return ev
 	}
 
-	// The spoke is alive and post-dates the instruction. If it is already on the
+	// The spoke is alive, post-dates the instruction, and is already ON the
 	// target — or AHEAD of it (a floating-tag re-pull lands on whatever CI last
 	// published, which can surpass a stale target; only ancestry can prove
-	// that) — the flag is merely lagging and the heartbeat path clears it; only
-	// a spoke still on a SHA behind the target is genuinely un-upgraded.
+	// that). The upgrade CONVERGED. Clear the latch here.
+	//
+	// This used to `return ev` (orphaned=false) on the reasoning that "the flag
+	// is merely lagging and the heartbeat path clears it". That deferral is the
+	// z-mlz-manager wedge: it is only true when a heartbeat actually arrives
+	// carrying a state TRANSITION the completion chain in server.go recognises.
+	// When the spoke's entry already records the target SHA — because the hub
+	// asked for X, the spoke rolled onto X (or onto a newer Y that the entry has
+	// since recorded), and every later beat therefore reports the SAME hash the
+	// entry already holds — the completion chain sees no change to act on, so it
+	// never fires. Both sides then defer to each other and the "Upgrading"
+	// spinner, its elapsed counter and the stale SHA it was armed with survive
+	// forever. Live case: z-mlz-manager sat Upgrading=true with
+	// GitHash == UpgradeTarget == 815d7e4 for 35m+ while its pod was ready and
+	// healthy on v4-latest.
+	//
+	// Deciding it HERE is safe precisely because we have already proven all
+	// three of: the flag is latched, orphanedUpgradeClearAfter has elapsed (or
+	// the start clock is corrupt), and the spoke has heartbeated SINCE the
+	// instruction. A genuine in-flight rollout fails the last test — a
+	// restarting pod is not heartbeating — so this can never cancel a live
+	// upgrade.
+	//
+	// converged is reported distinctly from the un-upgraded orphan below so the
+	// timeline and logs do not accuse a hive that in fact upgraded successfully
+	// of having "never completed".
+	//
 	// commitAtOrAheadOfTarget is cache-only (the sweep holds s.mu), so an
 	// unresolved pair is treated as "behind" this cycle and re-evaluated next.
 	if entry.UpgradeTarget != "" && (sameCommit(entry.GitHash, entry.UpgradeTarget) ||
 		commitAtOrAheadOfTarget(entry.GitHash, entry.UpgradeTarget, nil)) {
+		ev.orphaned = true
+		ev.converged = true
+		ev.reason = "spoke is running " + orDash(entry.GitHash) +
+			", at or ahead of the requested target " + orDash(entry.UpgradeTarget) +
+			" — upgrade completed but the latch was never cleared"
 		return ev
 	}
 
@@ -187,6 +228,9 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		// retrying — reported as a fault rather than re-armed.
 		exhausted bool
 		sweeps    int
+		// converged marks a clear that completed successfully — logged and
+		// timelined as a completion, never as an abandonment.
+		converged bool
 	}
 	var swept []cleared
 
@@ -202,6 +246,26 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		}
 		ev := evaluateOrphanedUpgrade(h, now, getLatestSHAForBranch(branch))
 		if !ev.orphaned {
+			continue
+		}
+		if ev.converged {
+			// The upgrade LANDED; only the latch was stale. Clear it outright:
+			// no retry-budget spend, no re-arm, and reset the counter so a hive
+			// that needed one sweep on each of three separate upgrades is never
+			// declared permanently faulty. Drop any armed instruction too, or
+			// the next beat re-delivers an upgrade that already happened.
+			swept = append(swept, cleared{
+				id: h.ID, from: h.GitHash, to: h.UpgradeTarget,
+				elapsed: ev.elapsed, reason: ev.reason, converged: true,
+			})
+			h.Upgrading = false
+			h.UpgradeTarget = ""
+			h.UpgradeStartedAt = time.Time{}
+			h.OrphanedUpgradeSweeps = 0
+			h.UpgradeFailed = false
+			h.UpgradeError = ""
+			h.UpgradeFailedAt = time.Time{}
+			delete(s.heartbeatUpgrade, h.ID)
 			continue
 		}
 		h.OrphanedUpgradeSweeps++
@@ -259,6 +323,20 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 	s.mu.Unlock()
 
 	for _, c := range swept {
+		if c.converged {
+			s.logger.Info("cleared stale upgrade latch — upgrade had already completed",
+				"hive_id", c.id,
+				"elapsed", roundedDuration(c.elapsed),
+				"sha", orDash(c.from),
+				"target", orDash(c.to),
+				"reason", c.reason,
+			)
+			s.recordTimeline(c.id, TimelineUpgradeStale,
+				"upgrade to "+orDash(c.to)+" had already completed (hive is on "+
+					orDash(c.from)+") — cleared a stale in-flight latch",
+				"stale-upgrade-sweep")
+			continue
+		}
 		if c.exhausted {
 			s.logger.Error("upgrade repeatedly failed to land — giving up and reporting a fault",
 				"hive_id", c.id,

--- a/v2/pkg/hub/stale_upgrade_test.go
+++ b/v2/pkg/hub/stale_upgrade_test.go
@@ -23,6 +23,10 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 		entry     RegistryEntry
 		latestSHA string
 		orphaned  bool
+		// converged distinguishes a clear that means "the upgrade LANDED, only
+		// the latch was stale" from one that means "the attempt was abandoned".
+		// The sweep re-arms and spends retry budget only on the latter.
+		converged bool
 	}{
 		{
 			// The floating-tag loop this fix closes: a hive tracking a mutable
@@ -110,7 +114,12 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 			orphaned: false,
 		},
 		{
-			name: "not orphaned: spoke already reports the target, heartbeat path clears it",
+			// The z-mlz-manager fixture: latched past the clear threshold, spoke
+			// alive and heartbeating, and already ON the SHA it was asked for.
+			// The upgrade completed; only the latch is stale, so it is cleared as
+			// converged. Waiting for the heartbeat path here is what left the
+			// spinner and the old SHA on screen for 35m+ with nothing in flight.
+			name: "converged: spoke already reports the target and the latch is stale",
 			entry: RegistryEntry{
 				Upgrading:        true,
 				UpgradeStartedAt: started,
@@ -118,7 +127,8 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 				UpgradeTarget:    "fc32ae4",
 				LastHeartbeat:    rfc3339(fixedSweepNow.Add(-30 * time.Second)),
 			},
-			orphaned: false,
+			orphaned:  true,
+			converged: true,
 		},
 		{
 			name: "not orphaned: an explicitly reported failure keeps its known cause",
@@ -170,16 +180,26 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 			orphaned: false,
 		},
 		{
-			// Zero start, alive, but the spoke already reports the target SHA: the
-			// heartbeat path clears it, this sweep must not race ahead.
-			name: "not orphaned: zero start time but the spoke already reports the target",
+			// Zero start, alive, and the spoke already reports the target SHA: the
+			// upgrade CONVERGED and only the latch is stale, so the sweep clears it.
+			//
+			// This case used to expect orphaned=false, deferring to "the heartbeat
+			// path clears it". That deferral is the z-mlz-manager wedge: the
+			// completion chain in server.go fires on a state TRANSITION, and once
+			// the entry already records the target SHA no later beat carries one.
+			// Both sides waited for the other and the spinner ran forever. Clearing
+			// here is safe because liveness is already proven — a mid-restart pod is
+			// not heartbeating — and `converged` keeps it out of the re-arm and
+			// retry-budget paths that a genuine abandoned attempt takes.
+			name: "converged: zero start time and the spoke already reports the target",
 			entry: RegistryEntry{
 				Upgrading:     true,
 				GitHash:       "fc32ae4",
 				UpgradeTarget: "fc32ae4",
 				LastHeartbeat: rfc3339(fixedSweepNow.Add(-30 * time.Second)),
 			},
-			orphaned: false,
+			orphaned:  true,
+			converged: true,
 		},
 		{
 			name:     "not upgrading at all",
@@ -196,6 +216,9 @@ func TestEvaluateOrphanedUpgrade(t *testing.T) {
 			}
 			if got.orphaned && got.reason == "" {
 				t.Fatal("an orphaned verdict must carry a reason for the log")
+			}
+			if got.converged != tc.converged {
+				t.Fatalf("converged = %v, want %v (reason %q)", got.converged, tc.converged, got.reason)
 			}
 		})
 	}

--- a/v2/pkg/hub/upgrade_latch_clear_test.go
+++ b/v2/pkg/hub/upgrade_latch_clear_test.go
@@ -1,0 +1,220 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================================================
+// Stale "Upgrading" latch — every SET must have a CLEAR.
+// ============================================================================
+//
+// The live wedge these cover (z-mlz-manager, 2026-08-13): the hub armed an
+// upgrade to 815d7e4, the spoke rolled onto ghcr.io/kubestellar/hive:v4-latest
+// and came back ready and heartbeating, and the hub still showed the spinner,
+// "Starting up after upgrade" and the OLD sha 35+ minutes later. Nothing on the
+// fleet was actually mid-upgrade.
+//
+// The deadlock was in evaluateOrphanedUpgrade: a spoke proven alive and proven
+// AT-OR-AHEAD of its target returned orphaned=false on the reasoning that "the
+// heartbeat path clears it" — while the heartbeat completion chain only fires
+// on a state TRANSITION it recognises. When the entry already records the
+// target sha, later beats carry no transition, so both sides deferred to each
+// other forever.
+
+// liveWedgeEntry builds the z-mlz-manager fixture: latched-upgrading well past
+// the clear threshold, with a spoke that has heartbeated SINCE the instruction.
+func liveWedgeEntry(now time.Time, gitHash, target string) *RegistryEntry {
+	return &RegistryEntry{
+		ID:               "z-mlz-manager",
+		Upgrading:        true,
+		UpgradeTarget:    target,
+		GitHash:          gitHash,
+		UpgradeStartedAt: now.Add(-35 * time.Minute),
+		LastHeartbeat:    now.Add(-2 * time.Minute).Format(time.RFC3339),
+		ImageRef:         "ghcr.io/kubestellar/hive:v4-latest",
+		GitBranch:        "v4",
+	}
+}
+
+// Case 1: the spoke reports the EXACT sha the hub asked for -> latch clears.
+//
+// This is the live z-mlz-manager state (GitHash == UpgradeTarget == 815d7e4)
+// and is precisely what the old code refused to clear.
+func TestOrphanSweepClearsWhenSpokeReportsExactRequestedSHA(t *testing.T) {
+	now := time.Now()
+	ev := evaluateOrphanedUpgrade(liveWedgeEntry(now, "815d7e4", "815d7e4"), now, "")
+	if !ev.orphaned {
+		t.Fatalf("spoke is alive and running the exact requested sha, but the latch was not cleared (reason=%q)", ev.reason)
+	}
+	if !ev.converged {
+		t.Errorf("reaching the requested sha is a COMPLETED upgrade; converged = false, reason=%q", ev.reason)
+	}
+	if !strings.Contains(ev.reason, "815d7e4") {
+		t.Errorf("reason should name the sha, got %q", ev.reason)
+	}
+}
+
+// Case 2: the spoke reports a DIFFERENT, NEWER sha than the one requested ->
+// the latch STILL clears. The hub asked for X, a newer merge landed first, the
+// floating v4-latest tag delivered Y, and a latch keyed on X will never see X.
+func TestOrphanSweepClearsWhenSpokeRolledToNewerSHAThanRequested(t *testing.T) {
+	now := time.Now()
+	target, reported := "815d7e4", "a2b2c2c"
+
+	// Seed the ancestry cache so the cache-only check can answer "ahead"
+	// without any network call (commit_order.go resolves in the background).
+	commitOrderMu.Lock()
+	commitOrderCache[commitOrderKey{target: target, reported: reported}] = true
+	commitOrderMu.Unlock()
+	defer func() {
+		commitOrderMu.Lock()
+		delete(commitOrderCache, commitOrderKey{target: target, reported: reported})
+		commitOrderMu.Unlock()
+	}()
+
+	ev := evaluateOrphanedUpgrade(liveWedgeEntry(now, reported, target), now, "")
+	if !ev.orphaned {
+		t.Fatalf("spoke rolled to %s, ahead of the requested %s, but the latch was not cleared (reason=%q)",
+			reported, target, ev.reason)
+	}
+	if !ev.converged {
+		t.Errorf("landing ahead of the target is a COMPLETED upgrade; converged = false, reason=%q", ev.reason)
+	}
+}
+
+// Case 3 (POSITIVE CONTROL): the spoke is still on the OLD sha, strictly BEHIND
+// the target -> the latch REMAINS an un-upgraded orphan, never "converged".
+//
+// Without this, an "always clear" implementation would satisfy cases 1 and 2
+// while destroying the distinction the sweep exists to draw.
+func TestOrphanSweepDoesNotReportConvergedWhenSpokeStillOnOldSHA(t *testing.T) {
+	now := time.Now()
+	target, reported := "aaaaaaa", "815d7e4"
+
+	// Explicitly cache "not ahead" so the result cannot depend on an
+	// unresolved pair happening to default to false.
+	commitOrderMu.Lock()
+	commitOrderCache[commitOrderKey{target: target, reported: reported}] = false
+	commitOrderMu.Unlock()
+	defer func() {
+		commitOrderMu.Lock()
+		delete(commitOrderCache, commitOrderKey{target: target, reported: reported})
+		commitOrderMu.Unlock()
+	}()
+
+	ev := evaluateOrphanedUpgrade(liveWedgeEntry(now, reported, target), now, "")
+	if ev.converged {
+		t.Fatalf("spoke is BEHIND the target (%s < %s); this is an abandoned attempt, not a converged one (reason=%q)",
+			reported, target, ev.reason)
+	}
+	if !ev.orphaned {
+		t.Fatalf("an alive spoke still on the old sha long past the threshold is an orphan, got orphaned=false")
+	}
+	if !strings.Contains(ev.reason, "no upgrade attempt in flight") {
+		t.Errorf("expected the abandoned-attempt reason, got %q", ev.reason)
+	}
+}
+
+// A genuinely in-flight upgrade must never be cancelled: a restarting pod is
+// not heartbeating, so a spoke silent since the instruction stays latched even
+// though it is nominally "at" the target.
+func TestOrphanSweepLeavesGenuineInFlightUpgradeAlone(t *testing.T) {
+	now := time.Now()
+	e := liveWedgeEntry(now, "815d7e4", "815d7e4")
+	// Silent since the upgrade was instructed — the pod is rolling.
+	e.LastHeartbeat = now.Add(-40 * time.Minute).Format(time.RFC3339)
+	ev := evaluateOrphanedUpgrade(e, now, "")
+	if ev.orphaned {
+		t.Errorf("a spoke silent since the instruction is mid-restart and must not be cleared (reason=%q)", ev.reason)
+	}
+}
+
+// A converged clear must not burn orphan-sweep retry budget, must not re-arm
+// the instruction, and must wipe the latch fields — otherwise three successful
+// upgrades would tip a healthy hive into a permanent false UpgradeFailed.
+func TestSweepConvergedClearsLatchWithoutRearmingOrBurningBudget(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	now := time.Now()
+	e := liveWedgeEntry(now, "815d7e4", "815d7e4")
+	e.OrphanedUpgradeSweeps = 2 // one short of maxOrphanedUpgradeSweeps
+	s.registry.Hives = []RegistryEntry{*e}
+	s.heartbeatUpgrade["z-mlz-manager"] = "815d7e4"
+
+	s.sweepOrphanedUpgrades()
+
+	s.mu.RLock()
+	got := s.registry.Hives[0]
+	_, stillArmed := s.heartbeatUpgrade["z-mlz-manager"]
+	s.mu.RUnlock()
+
+	if got.Upgrading {
+		t.Error("Upgrading latch should be cleared")
+	}
+	if got.UpgradeTarget != "" {
+		t.Errorf("UpgradeTarget should be cleared, got %q", got.UpgradeTarget)
+	}
+	if !got.UpgradeStartedAt.IsZero() {
+		t.Error("UpgradeStartedAt should be zeroed so the next upgrade times from zero")
+	}
+	if got.UpgradeFailed {
+		t.Errorf("a converged upgrade must never be reported as failed: %q", got.UpgradeError)
+	}
+	if got.OrphanedUpgradeSweeps != 0 {
+		t.Errorf("converged clear must reset the retry budget, got %d", got.OrphanedUpgradeSweeps)
+	}
+	if stillArmed {
+		t.Error("converged clear must drop the armed instruction; re-delivering would roll a healthy pod")
+	}
+}
+
+// ============================================================================
+// Filter pill vs row badge — ONE predicate.
+// ============================================================================
+
+// The "Upgrading" facet under-reported because the pill tested only
+// h.upgrading while the row OR'd three sources. Assert from the embedded JS
+// that both call sites route through the single shared helper.
+func TestUpgradingFilterAndRowBadgeShareOnePredicate(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "function hiveIsUpgradingNow(") {
+		t.Fatal("shared predicate hiveIsUpgradingNow is missing")
+	}
+
+	// The pill's classifier must delegate, not re-derive from h.upgrading.
+	stateFn := jsFunctionBody(t, "hiveUpgradeState")
+	if !strings.Contains(stateFn, "hiveIsUpgradingNow(h)") {
+		t.Errorf("hiveUpgradeState must delegate to hiveIsUpgradingNow, body:\n%s", stateFn)
+	}
+	if strings.Contains(stateFn, "if (h.upgrading)") {
+		t.Errorf("hiveUpgradeState still tests h.upgrading directly — that is the under-reporting bug:\n%s", stateFn)
+	}
+
+	// The row badge must assign isUpgrading from the same helper rather than
+	// rebuilding the OR chain inline.
+	if !strings.Contains(dashboardHTML, "var isUpgrading = hiveIsUpgradingNow(h, branchName, branchLatest);") {
+		t.Error("the row badge must compute isUpgrading via hiveIsUpgradingNow")
+	}
+	if strings.Contains(dashboardHTML, "var isUpgrading = isSwitching ||") {
+		t.Error("the row badge still rebuilds its own OR chain; the pill cannot match it")
+	}
+
+	// The shared helper must actually cover all three sources the row showed,
+	// or unifying on it would fix the disagreement by dropping badges.
+	body := jsFunctionBody(t, "hiveIsUpgradingNow")
+	for _, want := range []string{"isSwitching", "_upgradingHives", "h.upgrading"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("shared predicate drops the %q source:\n%s", want, body)
+		}
+	}
+	// And it must keep the row's own suppressions, or the pill would now
+	// over-report where the row shows nothing.
+	for _, want := range []string{"isCurrent", "latestUnknown"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("shared predicate drops the %q suppression:\n%s", want, body)
+		}
+	}
+}


### PR DESCRIPTION
## Bug 1 — the "Upgrading" filter pill under-reports

The pill's classifier `hiveUpgradeState` tested only `h.upgrading`. The row badge OR'd **three** sources — an in-flight branch switch, a client-side `_upgradingHives` sentinel from a just-clicked upgrade, and `h.upgrading` — and additionally *suppressed* the last one when the hive is already at latest or latest is unresolved.

So the two disagreed in both directions: a visibly spinning row (mid-switch, or just-clicked) was not matched by the pill, and a hive with `h.upgrading && isCurrent` was counted by the pill while showing no badge at all.

**Fix:** extract the row's real predicate into one shared `hiveIsUpgradingNow(h, branchName, branchLatest)`. Both `hiveUpgradeState` (pill/facet) and the row's `isUpgrading` now call it, so the facet count and the list can no longer disagree. When a caller has not resolved `branchName`/`branchLatest` (the facet counter iterating raw hives) the helper recomputes them from the same globals the row uses.

## Bug 2 — "Upgrading" goes stale and never clears

`evaluateOrphanedUpgrade` returned `orphaned=false` whenever a **live** spoke was already at — or ahead of — its armed target, reasoning that "the heartbeat path clears it".

That deferral only holds when a beat carries a state **transition** the completion chain in `server.go` recognises. Once the registry entry already records the target SHA, every later beat reports the same hash the entry already holds — the chain sees nothing to act on and never fires. Both sides wait for each other, and the spinner, its elapsed counter and the stale SHA survive forever.

**Verified live:** `z-mlz-manager` (ns `hive-hosted-hosted-available-vllmd-04`, ctx `vllm-d`) showed SHA `815d7e4`, a spinner and "Starting up after upgrade" for 35m+, with `Upgrading=true` and `GitHash == UpgradeTarget == 815d7e4`, while its only pod (`hive-7d548db987-wg56b`) was **ready** on `ghcr.io/kubestellar/hive:v4-latest`. A scan of all hives across hive-oke / vllm-d / c116-e for spec-image != live-pod-image found **zero** drift — nothing was actually mid-upgrade anywhere.

**Fix:** the sweep now clears that latch and marks the evidence `converged`. This is safe in the sweep precisely because liveness is already proven — a mid-restart pod is not heartbeating — so a genuine in-flight rollout can never be cancelled.

A `converged` clear is deliberately **not** handled like an abandoned attempt. It does **not**:
- re-arm the instruction (which would re-roll a healthy pod),
- spend orphan-sweep retry budget (three successful upgrades would otherwise tip a hive into a permanent, false `UpgradeFailed`),
- log/timeline as "never completed".

This also covers the case called out in the report: the hub asks for SHA **X**, a newer merge lands first, the floating `…-latest` tag delivers **Y**. A latch keyed on X will never see X; commit **ancestry** is what proves convergence.

## Tests

New — `v2/pkg/hub/upgrade_latch_clear_test.go`:
- `TestOrphanSweepClearsWhenSpokeReportsExactRequestedSHA` — case 1, the exact live fixture
- `TestOrphanSweepClearsWhenSpokeRolledToNewerSHAThanRequested` — case 2, ahead-of-target via seeded ancestry
- `TestOrphanSweepDoesNotReportConvergedWhenSpokeStillOnOldSHA` — **case 3, positive control**: a spoke still behind stays an abandoned orphan and is never reported converged, so an "always clear" implementation cannot pass
- `TestOrphanSweepLeavesGenuineInFlightUpgradeAlone` — a spoke silent since the instruction is mid-restart and must not be cleared
- `TestSweepConvergedClearsLatchWithoutRearmingOrBurningBudget` — no re-arm, no budget spend, no false `UpgradeFailed`
- `TestUpgradingFilterAndRowBadgeShareOnePredicate` — case 4: asserts from the embedded JS that both call sites route through the one helper, that it retains all three badge sources, and that it retains the row's suppressions (so unification cannot "agree" by silently dropping badges)

### Positive control (run and confirmed)

Neutered the clear logic (`ev.orphaned = false; ev.converged = false`, still compiling) → cases **1 and 2 both FAILED**, along with the sweep test; case 3 kept passing, proving the suite is not trivially satisfiable. Restored → all green. Same exercise for Bug 1: reverting `hiveUpgradeState` to `if (h.upgrading)` → `TestUpgradingFilterAndRowBadgeShareOnePredicate` FAILED. Restored → green.

Full `go test ./pkg/hub/` passes (114s). All four embedded dashboard script blocks pass `node --check`.

### Updated existing tests

Two cases encoded the old deferral (at-or-ahead ⇒ not orphaned) and were updated to the corrected contract. The fault they originally guarded — a false permanent `UpgradeFailed` — is exactly what `converged` now prevents structurally.

## Notes

- No `kubectl` write operations were performed; cluster inspection was read-only.
- `v2/pkg/hub/saas.go` is unformatted per `gofmt` on the **baseline** (pre-existing); not reformatted here to keep the diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)