### PR TITLE
🔒 fix(dashboard): restore owner-only gates on contributor management (F14)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -6682,7 +6682,7 @@ func (s *Server) handleContributorGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) {
-	if !s.requireContributorWrite(w, r) {
+	if !requireOwnerRole(w, r) {
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
@@ -6723,7 +6723,7 @@ func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleContributorAgentRoleGrants(w http.ResponseWriter, r *http.Request) {
-	if !s.requireContributorWrite(w, r) {
+	if !requireOwnerRole(w, r) {
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
@@ -6858,7 +6858,7 @@ func normalizeUniqueAgentRoles(in []string) []string {
 }
 
 func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request) {
-	if !s.requireContributorWrite(w, r) {
+	if !requireOwnerRole(w, r) {
 		return
 	}
 	id := r.PathValue("id")
@@ -6959,7 +6959,7 @@ func (s *Server) handleContributorRequeue(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleContributorDelete(w http.ResponseWriter, r *http.Request) {
-	if !s.requireContributorWrite(w, r) {
+	if !requireOwnerRole(w, r) {
 		return
 	}
 	id := r.PathValue("id")

--- a/v2/pkg/dashboard/api_contribute_admin_controls_test.go
+++ b/v2/pkg/dashboard/api_contribute_admin_controls_test.go
@@ -283,12 +283,17 @@ func TestContributorWrite_ReadViewerForbidden(t *testing.T) {
 	}
 }
 
-// TestContributorWrite_OwnerAndRWAllowed proves owner and read-write pass the gate
-// (they are not blocked). SECURITY (C5): an absent/empty role is NO LONGER allowed
-// here — the gate now fails closed on a missing role (see
-// TestContributorWrite_MissingRoleForbidden), because an absent header is exactly
-// what an unauthenticated caller reaching the pod directly presents.
-func TestContributorWrite_OwnerAndRWAllowed(t *testing.T) {
+// TestContributorTrustIsOwnerOnly: contributor trust is OWNER-ONLY (audit F14).
+//
+// This test previously asserted that read-write ALSO passed the gate — it encoded
+// the vulnerability. #3460 gated these handlers with requireOwnerRole; a v2->v4
+// sync merge reverted that, and F14 (2026-08-13) re-reproduced it. Setting a
+// contributor's trust tier is an owner action, so read-write must now be denied.
+//
+// The owner case also needs ownerRoleVerifiedHeader: requireOwnerRole demands
+// BOTH the role header and the verified marker, so that a caller who can spoof
+// X-Hive-Role alone cannot mint owner authority.
+func TestContributorTrustIsOwnerOnly(t *testing.T) {
 	for _, role := range []string{"owner", "read-write"} {
 		t.Run("trust_"+role, func(t *testing.T) {
 			setupContributeEnv(t)
@@ -302,14 +307,23 @@ func TestContributorWrite_OwnerAndRWAllowed(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPut, "/api/contributors/alice/trust", strings.NewReader(`{"tier":"trusted"}`))
 			req.SetPathValue("id", "alice")
-			if role != "" {
+			if role == "owner" {
+				markOwnerRequest(req)
+			} else if role != "" {
 				req.Header.Set("X-Hive-Role", role)
 			}
 			w := httptest.NewRecorder()
 			s.handleContributorTrust(w, req)
 
-			if w.Code != http.StatusOK {
-				t.Fatalf("role %q got %d, want 200 (body: %s)", role, w.Code, w.Body.String())
+			wantCode := http.StatusOK
+			if role != "owner" {
+				wantCode = http.StatusForbidden
+			}
+			if w.Code != wantCode {
+				t.Fatalf("role %q got %d, want %d (body: %s)", role, w.Code, wantCode, w.Body.String())
+			}
+			if role != "owner" {
+				return // denied as intended; nothing further to assert
 			}
 			if p := findContributor("alice"); p == nil || p.TrustTier != "trusted" {
 				t.Errorf("role %q: tier not promoted: %+v", role, p)
@@ -448,6 +462,7 @@ func TestContributorAgentRoleGrantsAuthzAndRoundTrip(t *testing.T) {
 	ownerReq := httptest.NewRequest(http.MethodPut, "/api/contributors/c-alice/agent-role-grants", strings.NewReader(`{"agent_role_grants":["sec-check","ci-maintainer","ci-maintainer"]}`))
 	ownerReq.Header.Set("Content-Type", "application/json")
 	ownerReq.Header.Set("X-Hive-Role", "owner")
+	ownerReq.Header.Set(ownerRoleVerifiedHeader, "true")
 	ownerRec := httptest.NewRecorder()
 	s.mux.ServeHTTP(ownerRec, ownerReq)
 	if ownerRec.Code != http.StatusOK {
@@ -464,6 +479,7 @@ func TestContributorAgentRoleGrantsAuthzAndRoundTrip(t *testing.T) {
 	badReq := httptest.NewRequest(http.MethodPut, "/api/contributors/c-alice/agent-role-grants", strings.NewReader(`{"agent_role_grants":["scanner"]}`))
 	badReq.Header.Set("Content-Type", "application/json")
 	badReq.Header.Set("X-Hive-Role", "owner")
+	badReq.Header.Set(ownerRoleVerifiedHeader, "true")
 	badRec := httptest.NewRecorder()
 	s.mux.ServeHTTP(badRec, badReq)
 	if badRec.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/api_contribute_coverage_test.go
+++ b/v2/pkg/dashboard/api_contribute_coverage_test.go
@@ -31,6 +31,7 @@ func doPutOwner(s *Server, path string, body interface{}) *httptest.ResponseReco
 	req := httptest.NewRequest(http.MethodPut, path, &b)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }
@@ -42,6 +43,7 @@ func doPostOwner(s *Server, path string, body interface{}) *httptest.ResponseRec
 	req := httptest.NewRequest(http.MethodPost, path, &b)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }
@@ -55,6 +57,7 @@ func doDeleteOwner(s *Server, path string, body interface{}) *httptest.ResponseR
 	req := httptest.NewRequest(http.MethodDelete, path, &b)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	s.mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/v2/pkg/dashboard/api_contribute_owner_gate_test.go
+++ b/v2/pkg/dashboard/api_contribute_owner_gate_test.go
@@ -1,0 +1,99 @@
+package dashboard
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Contributor trust, agent-role grants, revoke and delete are OWNER-only. They
+// were gated by #3460 (f575b06c) and then silently REVERTED: that commit is an
+// ancestor of v4, yet every gate was back to requireContributorWrite at HEAD —
+// a v2->v4 sync merge resolved the conflict in favour of the older side.
+// Audit F14 (2026-08-13) re-reproduced it.
+//
+// requireContributorWrite admits RoleOwner OR RoleReadWrite, so the regression
+// let any read-write member grant trust, hand out agent roles, and delete other
+// contributors.
+//
+// This test asserts the INVARIANT rather than the behaviour of one handler,
+// because the failure mode is a merge dropping the gate, not a logic bug. A
+// behavioural test on a single handler would not have caught the revert.
+
+var ownerGatedContributorHandlers = []string{
+	"handleContributorTrust",
+	"handleContributorAgentRoleGrants",
+	"handleContributorRevoke",
+	"handleContributorDelete",
+}
+
+// handlerBody returns the source of the named handler, from its func line to
+// the first line that is exactly "}".
+func handlerBody(t *testing.T, src, name string) string {
+	t.Helper()
+	i := strings.Index(src, "func (s *Server) "+name+"(")
+	if i < 0 {
+		t.Fatalf("handler %s not found — it was renamed or removed; update this test deliberately, do not delete the case", name)
+	}
+	j := strings.Index(src[i:], "\n}\n")
+	if j < 0 {
+		t.Fatalf("could not find the end of %s", name)
+	}
+	return src[i : i+j]
+}
+
+// TestContributorManagementHandlersAreOwnerGated is the F14 regression.
+func TestContributorManagementHandlersAreOwnerGated(t *testing.T) {
+	raw, err := os.ReadFile("api_contribute.go")
+	if err != nil {
+		t.Fatalf("read api_contribute.go: %v", err)
+	}
+	src := string(raw)
+
+	for _, name := range ownerGatedContributorHandlers {
+		body := handlerBody(t, src, name)
+		if !strings.Contains(body, "requireOwnerRole(w, r)") {
+			t.Errorf("%s has no requireOwnerRole gate — a read-write member can reach it (audit F14). "+
+				"If a merge dropped this, restore it rather than relaxing the test.", name)
+		}
+		if strings.Contains(body, "s.requireContributorWrite(w, r)") {
+			t.Errorf("%s still gates on requireContributorWrite, which admits RoleReadWrite; "+
+				"contributor management is owner-only", name)
+		}
+	}
+}
+
+// TestContributorRequeueStaysContributorWrite is the positive control. #3460
+// deliberately did NOT gate requeue — it is a normal contributor action. Without
+// this case, "add requireOwnerRole everywhere in the file" would satisfy the
+// test above while breaking a legitimate workflow.
+func TestContributorRequeueStaysContributorWrite(t *testing.T) {
+	raw, err := os.ReadFile("api_contribute.go")
+	if err != nil {
+		t.Fatalf("read api_contribute.go: %v", err)
+	}
+	body := handlerBody(t, string(raw), "handleContributorRequeue")
+	if !strings.Contains(body, "s.requireContributorWrite(w, r)") {
+		t.Error("handleContributorRequeue must stay on requireContributorWrite — " +
+			"requeue is a contributor action, not an owner action")
+	}
+	if strings.Contains(body, "requireOwnerRole(w, r)") {
+		t.Error("handleContributorRequeue must NOT be owner-gated")
+	}
+}
+
+// TestOwnerGateCountFloor is the blunt instrument that survives renames: if the
+// count ever drops below the number of owner-gated handlers, something removed
+// a gate. Cheap, and it is exactly the signal a sync merge would trip.
+func TestOwnerGateCountFloor(t *testing.T) {
+	raw, err := os.ReadFile("api_contribute.go")
+	if err != nil {
+		t.Fatalf("read api_contribute.go: %v", err)
+	}
+	got := len(regexp.MustCompile(`requireOwnerRole\(w, r\)`).FindAllString(string(raw), -1))
+	if want := len(ownerGatedContributorHandlers); got < want {
+		t.Errorf("api_contribute.go has %d requireOwnerRole gates, want at least %d — "+
+			"a gate was removed (audit F14 regressed exactly this way)", got, want)
+	}
+}

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -986,6 +986,7 @@ func TestContributorTrust(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/api/contributors/"+cid+"/trust", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -997,6 +998,7 @@ func TestContributorTrust(t *testing.T) {
 	req2 := httptest.NewRequest(http.MethodPut, "/api/contributors/"+cid+"/trust", bytes.NewBufferString(body2))
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("X-Hive-Role", "owner")
+	req2.Header.Set(ownerRoleVerifiedHeader, "true")
 	w2 := httptest.NewRecorder()
 	s.mux.ServeHTTP(w2, req2)
 	if w2.Code != http.StatusBadRequest {
@@ -1013,6 +1015,7 @@ func TestContributorDelete(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/contributors/"+cid, nil)
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -1037,6 +1040,7 @@ func TestContributorRevoke(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/contributors/"+cid+"/revoke", nil)
 	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(ownerRoleVerifiedHeader, "true")
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {

--- a/v2/pkg/dashboard/contribute_ws_sec_c4_h2_test.go
+++ b/v2/pkg/dashboard/contribute_ws_sec_c4_h2_test.go
@@ -326,6 +326,7 @@ func TestH2_RevokeDisconnectsLiveSessionAndDeniesReconnect(t *testing.T) {
 	// Admin revokes via the real endpoint.
 	revReq := httptest.NewRequest(http.MethodPost, "/api/contributors/"+reg["contributor_id"]+"/revoke", nil)
 	revReq.Header.Set("X-Hive-Role", "owner")
+	revReq.Header.Set(ownerRoleVerifiedHeader, "true")
 	revW := httptest.NewRecorder()
 	s.mux.ServeHTTP(revW, revReq)
 	if revW.Code != http.StatusOK {

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -156,6 +156,7 @@ func TestWSAuthRevoked(t *testing.T) {
 	// missing role, see requireContributorWrite / C5 fix).
 	revokeReq := httptest.NewRequest(http.MethodPost, "/api/contributors/"+reg["contributor_id"]+"/revoke", nil)
 	revokeReq.Header.Set("X-Hive-Role", "owner")
+	revokeReq.Header.Set(ownerRoleVerifiedHeader, "true")
 	revokeW := httptest.NewRecorder()
 	s.mux.ServeHTTP(revokeW, revokeReq)
 

--- a/v2/pkg/dashboard/coverage_boost4_test.go
+++ b/v2/pkg/dashboard/coverage_boost4_test.go
@@ -706,6 +706,7 @@ func TestHandleContributorTrust_UserNotFound(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/api/contribute/trust", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Hive-Role", "owner") // mutation gate fails closed on a missing role (C5)
+	req.Header.Set(ownerRoleVerifiedHeader, "true") // requireOwnerRole needs the verified marker too (F14)
 	w := httptest.NewRecorder()
 	srv.handleContributorTrust(w, req)
 


### PR DESCRIPTION
**Audit F14 (2026-08-13) — a shipped security fix was silently reverted by a merge.**

Contributor trust, agent-role grants, revoke and delete were owner-gated by #3460 (`f575b06c`). That commit **is an ancestor of `v4`** — yet at HEAD all four handlers were back on `s.requireContributorWrite`. A `sync/v2-into-v4-*` merge resolved the conflict in favour of the older side.

`requireContributorWrite` admits `RoleOwner` **or** `RoleReadWrite`, so any read-write member could grant trust, hand out agent roles, revoke, and delete other contributors.

## Change

Restores `requireOwnerRole` on exactly the four handlers #3460 gated:

| Handler | Gate |
|---|---|
| `handleContributorTrust` | `requireOwnerRole` |
| `handleContributorAgentRoleGrants` | `requireOwnerRole` |
| `handleContributorRevoke` | `requireOwnerRole` |
| `handleContributorDelete` | `requireOwnerRole` |
| `handleContributorRequeue` | **unchanged** — `requireContributorWrite` |

`handleContributorRequeue` is deliberately left alone; #3460 excluded it because requeue is a normal contributor action.

## The tests assert an invariant, not a behaviour

This is the important part. The failure mode here is **a merge dropping a gate**, not a logic bug — a behavioural test on one handler would not have caught the revert. So the tests read the source and assert the property:

- `TestContributorManagementHandlersAreOwnerGated` — each of the four contains `requireOwnerRole` and does *not* contain `requireContributorWrite`
- `TestContributorRequeueStaysContributorWrite` — **positive control**: without it, "add `requireOwnerRole` everywhere in the file" would satisfy the test above while breaking a legitimate workflow
- `TestOwnerGateCountFloor` — gate count never drops below 4; survives renames

## Verification — I replayed the actual regression

Reverting all four gates back to `requireContributorWrite` **still compiles** (exactly as it did in production) and fails two of the three tests:

```
--- FAIL: TestContributorManagementHandlersAreOwnerGated
--- FAIL: TestOwnerGateCountFloor
```

This would have caught the original revert at merge time.