### PR TITLE
🔒 fix(v2): restore supply-chain version pins + guard against silent revert (F18)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -45,6 +45,16 @@ jobs:
       - name: Entrypoint runtime-config migration tests
         run: bash deploy/test_entrypoint_runtime_config.sh
 
+      # Supply-chain pins regress SILENTLY. The PI_VERSION pin (#3443) landed on
+      # v2, and a sync/v2-into-v4-* merge resolved the conflict in favour of the
+      # older side and restored `ARG PI_VERSION=latest` — the fix commit is an
+      # ancestor of v4, yet the pin was gone. Audit findings F14 and F18 both
+      # died this way. This asserts the INVARIANT (nothing floats) rather than
+      # any behaviour, so a merge that drops a pin fails the PR instead of
+      # quietly shipping a build that trusts whatever npm/Docker Hub serves.
+      - name: Supply-chain pin guard
+        run: bash deploy/test_supply_chain_pins.sh
+
       # bin/gh-wrapper.sh is the merge gate standing behind the proxy hard-deny:
       # if its argument parsing is wrong, a prompt-injected agent merges
       # unvetted code. It had NO tests and matched no CI path filter. This

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -188,7 +188,7 @@ RUN npm install -g @openai/codex@${CODEX_VERSION} && npm cache clean --force || 
     echo "WARN: OpenAI Codex CLI install failed — skipping"
 
 # --- Layer 7: Claude Code (most frequent updates) ---
-ARG CLAUDE_CODE_VERSION=latest
+ARG CLAUDE_CODE_VERSION=2.1.226
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
 
 # --- Layer 8: Goose CLI (official block/goose upstream) ---
@@ -217,7 +217,7 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
 # Tolerant of failure like the copilot/codex layers: agents configured for
 # backend: pi simply won't launch if this is absent, same degradation as
 # any other missing backend binary.
-ARG PI_VERSION=latest
+ARG PI_VERSION=0.84.1
 RUN npm install -g @earendil-works/pi-coding-agent@${PI_VERSION} && npm cache clean --force || \
     echo "WARN: pi CLI install failed — skipping"
 

--- a/v2/deploy/test_supply_chain_pins.sh
+++ b/v2/deploy/test_supply_chain_pins.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Asserts that supply-chain-sensitive versions stay PINNED.
+#
+# Why this exists: the PI_VERSION pin (#3443, commit 2011739b) was landed and
+# then silently LOST. The commit is an ancestor of v4, but a sync/v2-into-v4-*
+# merge resolved the conflict in favour of the older v2 side and restored
+# `ARG PI_VERSION=latest`. Nothing failed, so nobody noticed. The same class of
+# regression hit audit findings F14 and F18.
+#
+# So this does NOT test behaviour — it tests the INVARIANT. A floating tag means
+# any malicious npm publish or image push lands automatically in the next build,
+# and for watchtower (which mounts /var/run/docker.sock) that is full host
+# control. Re-introducing `=latest`, or dropping the watchtower digest, must
+# fail the PR rather than quietly ship.
+#
+# Run: bash v2/deploy/test_supply_chain_pins.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+V2_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DOCKERFILE="$V2_DIR/Dockerfile"
+DOCKERFILE_CONTRIB="$V2_DIR/Dockerfile.contributor"
+COMPOSE="$V2_DIR/docker-compose.yaml"
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== supply-chain pin tests ==="
+
+# --- 1. No ARG *_VERSION=latest in any v2 Dockerfile -------------------------
+# Matches optional whitespace and quoting so `ARG X_VERSION = "latest"` and
+# `ARG X_VERSION=LATEST` cannot slip through the guard.
+for df in "$DOCKERFILE" "$DOCKERFILE_CONTRIB"; do
+  rel="${df#"$(dirname "$V2_DIR")"/}"
+  if [ ! -f "$df" ]; then
+    fail "$rel exists" "file not found — guard cannot verify pins"
+    continue
+  fi
+
+  floating="$(grep -inE '^[[:space:]]*ARG[[:space:]]+[A-Z0-9_]*VERSION[[:space:]]*=[[:space:]]*"?'"'"'?latest' "$df" || true)"
+  if [ -n "$floating" ]; then
+    fail "$rel has no floating ARG *_VERSION=latest" \
+         "found: $(echo "$floating" | tr '\n' ' ')"
+  else
+    pass "$rel has no floating ARG *_VERSION=latest"
+  fi
+
+  # Every ARG *_VERSION must carry a non-empty value; `ARG FOO_VERSION` with no
+  # default lets the builder inject anything via --build-arg at build time.
+  valueless="$(grep -inE '^[[:space:]]*ARG[[:space:]]+[A-Z0-9_]*VERSION[[:space:]]*$' "$df" || true)"
+  if [ -n "$valueless" ]; then
+    fail "$rel has no valueless ARG *_VERSION" \
+         "found: $(echo "$valueless" | tr '\n' ' ')"
+  else
+    pass "$rel has no valueless ARG *_VERSION"
+  fi
+done
+
+# --- 2. Specific pins that have regressed before ------------------------------
+# Named explicitly so that deleting the line (rather than setting it to
+# `latest`) also trips the guard.
+check_pinned_arg() {
+  local name="$1" file="$2"
+  local line
+  line="$(grep -E "^[[:space:]]*ARG[[:space:]]+${name}[[:space:]]*=" "$file" | head -1 || true)"
+  if [ -z "$line" ]; then
+    fail "$name is present and pinned" "no ARG $name found in $file"
+    return
+  fi
+  local value="${line#*=}"
+  value="$(echo "$value" | tr -d ' "'"'"'')"
+  if [ -z "$value" ] || [ "$value" = "latest" ]; then
+    fail "$name is pinned to a concrete version" "got: '$value'"
+  else
+    pass "$name is pinned ($value)"
+  fi
+}
+
+check_pinned_arg CLAUDE_CODE_VERSION "$DOCKERFILE"
+check_pinned_arg PI_VERSION "$DOCKERFILE"
+check_pinned_arg COPILOT_VERSION "$DOCKERFILE"
+check_pinned_arg CODEX_VERSION "$DOCKERFILE"
+
+# --- 3. watchtower must be pinned BY DIGEST ----------------------------------
+# A tag alone is mutable: containrrr could re-push 1.7.1. Since this container
+# mounts the Docker socket, the digest is the only thing that actually binds
+# the running code to what was reviewed.
+if [ ! -f "$COMPOSE" ]; then
+  fail "docker-compose.yaml exists" "file not found at $COMPOSE"
+else
+  wt_line="$(grep -E '^[[:space:]]*image:[[:space:]]*containrrr/watchtower' "$COMPOSE" | head -1 || true)"
+  if [ -z "$wt_line" ]; then
+    fail "watchtower image line found" "no containrrr/watchtower image: line in docker-compose.yaml"
+  elif echo "$wt_line" | grep -qE '@sha256:[0-9a-f]{64}'; then
+    pass "watchtower is pinned by @sha256 digest"
+  else
+    fail "watchtower is pinned by @sha256 digest" "got: $(echo "$wt_line" | xargs)"
+  fi
+fi
+
+# --- 4. No floating :latest image tags anywhere in compose -------------------
+latest_images="$(grep -inE '^[[:space:]]*image:[[:space:]]*[^#]*:latest[[:space:]]*$' "$COMPOSE" || true)"
+if [ -n "$latest_images" ]; then
+  fail "no compose service uses a :latest image tag" \
+       "found: $(echo "$latest_images" | tr '\n' ' ')"
+else
+  pass "no compose service uses a :latest image tag"
+fi
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -62,9 +62,10 @@ services:
     # The image also mounts the Docker socket, so a compromised :latest tag
     # would give an attacker full host control. Bump deliberately by
     # verifying the release at https://github.com/containrrr/watchtower/releases
-    # and updating this tag + the digest comment below.
-    # Digest: sha256:6dd50763bbd632a83cb154d5451700530d1e44200b268a4e9488fefdfcf2b038
-    image: containrrr/watchtower:1.7.1
+    # and updating BOTH the tag and the @sha256 digest below. The digest is the
+    # multi-arch manifest-list digest, so amd64/arm64 pulls both still resolve.
+    # v2/deploy/test_supply_chain_pins.sh fails the build if the digest is dropped.
+    image: containrrr/watchtower:1.7.1@sha256:6dd50763bbd632a83cb154d5451700530d1e44200b268a4e9488fefdfcf2b038
     container_name: hive-watchtower
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Audit finding **F18**. Restores three floating supply-chain references and adds a CI guard so this class of regression cannot silently recur.

## Why this is a re-fix, not a new fix

The `PI_VERSION` pin **already landed** in `2011739b` (#3443). That commit **is an ancestor of `v4`** — yet the pin was gone at HEAD. A `sync/v2-into-v4-*` merge resolved the conflict in favour of the older v2 side:

```
$ git log --first-parent -S"PI_VERSION=0.84.1" -- v2/Dockerfile   # on origin/v4
(empty)
```

The pin never survived a single first-parent commit. Nothing failed, so nobody noticed. Findings **F14 and F18 both died this way** — which is why the guard below is the important half of this PR.

## Restored pins

| What | Before | After | Source of value |
|---|---|---|---|
| `v2/Dockerfile:220` `PI_VERSION` | `latest` | `0.84.1` | Cherry-picked from `2011739b`; also matches `Dockerfile.contributor` |
| `v2/Dockerfile:191` `CLAUDE_CODE_VERSION` | `latest` | `2.1.226` | Matches the pin already in `Dockerfile.contributor`; verified published on npm |
| `v2/docker-compose.yaml:67` watchtower | tag only | `1.7.1@sha256:6dd5076…` | Digest from the adjacent comment, **re-verified against the Docker Hub registry API** |

Notes:
- `CLAUDE_CODE_VERSION` has *never* been changed since it was introduced, so there was no prior pinned value to recover. I chose `2.1.226` because `Dockerfile.contributor` already pins exactly that — this makes both build paths install the same claude-code instead of introducing a third version. npm currently resolves `latest` to `2.1.231` and `stable` to `2.1.223`; I deliberately did **not** use either, to avoid divergence.
- The watchtower digest is the **multi-arch manifest-list** digest, confirmed via `docker-content-digest`, so amd64/arm64 pulls both still resolve. This container mounts `/var/run/docker.sock`, so a re-pushed `1.7.1` tag would be full host-Docker control — the tag alone is mutable, and the digest is the only thing binding the running code to what was reviewed.

## The guard

`v2/deploy/test_supply_chain_pins.sh`, in the style of the neighbouring `test_entrypoint_runtime_config.sh` (plain bash, PASS/FAIL counters, non-zero exit). It asserts the **invariant** — nothing floats — rather than any behaviour, because behaviour tests are precisely what these merges kept passing.

It fails on:
1. any `ARG *_VERSION=latest` in `v2/Dockerfile` or `v2/Dockerfile.contributor` (tolerant of spacing/quoting/case)
2. a valueless `ARG *_VERSION` (injectable via `--build-arg`)
3. the watchtower image lacking an `@sha256:` digest
4. any compose service on a `:latest` tag
5. **a named pin going missing entirely** — checked individually, since the sync merge *deleted* the line rather than setting it to `latest`

### Proof it actually fails

Each regression was reintroduced, the guard run, then reverted:

| Injected regression | Result |
|---|---|
| `ARG PI_VERSION=latest` (the exact F18 revert) | **exit 1**, 2 checks fail |
| `ARG CLAUDE_CODE_VERSION=latest` | **exit 1**, 2 checks fail |
| watchtower digest removed | **exit 1** |
| `containrrr/watchtower:latest` | **exit 1**, 2 checks fail |
| whole `ARG PI_VERSION` line deleted | **exit 1** |
| clean tree | **exit 0**, 10/10 pass |

Wired into `.github/workflows/v2-ci.yml` next to the existing entrypoint tests. That workflow's `paths: ['v2/**', …]` filter and `branches: [v2, v4]` triggers mean a future sync merge touching these files will run it.

## Scope

Static edits plus the guard script. **No docker builds were run** and no cluster state was touched. Image builds are unaffected apart from now installing pinned versions.