### PR TITLE
🔒 fix(dashboard): owner-gate governor security, agent create/import and plan review (F16)

### DIFF
--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -46,7 +46,13 @@ func (s *Server) handleAgentsList(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, agents)
 }
 
+// handleAgentCreate serves POST /api/agents. OWNER-ONLY, matching
+// handleAgentDelete below: creating an agent writes an agent file, lifts any
+// deletion tombstone, and starts a live process. Audit F16 (2026-08-13).
 func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	var body struct {
 		Name  string             `json:"name"`
 		Agent config.AgentConfig `json:"agent"`
@@ -245,7 +251,13 @@ func agentConfigFromDefinition(def *agentDefinition) config.AgentConfig {
 	}
 }
 
+// handleAgentImport serves POST /api/agents/import. OWNER-ONLY for the same
+// reason as handleAgentCreate — it is a create path that additionally fetches a
+// caller-supplied remote definition. Audit F16 (2026-08-13).
 func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	var body struct {
 		Source  string `json:"source"`
 		URL     string `json:"url"`

--- a/v2/pkg/dashboard/api_agents_test.go
+++ b/v2/pkg/dashboard/api_agents_test.go
@@ -354,6 +354,9 @@ func TestHandleAgentImport_InvalidBody(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/agents/import",
 		strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	// Import is owner-only (audit F16). This test is about body validation, not
+	// authorization, so give it credentials and keep asserting 400.
+	markOwnerRequest(req)
 	s.mux.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusBadRequest {

--- a/v2/pkg/dashboard/api_governor_security.go
+++ b/v2/pkg/dashboard/api_governor_security.go
@@ -7,7 +7,16 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
+// handleGovernorSecurity serves PUT /api/config/governor/security. It is
+// OWNER-ONLY: the body carries agentSandboxEnabled, ioscanFailMode and
+// intentEnforce, so an un-gated version let any read-write member turn the
+// agent sandbox off outright. Every sibling governor-config handler
+// (health/logging/hub/trajectory/thresholds/...) already calls requireOwnerRole;
+// this one was the outlier. Audit F16 (2026-08-13).
 func (s *Server) handleGovernorSecurity(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	var body struct {
 		IoscanEnabled        *bool     `json:"ioscanEnabled"`
 		IoscanFailMode       *string   `json:"ioscanFailMode"`

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -686,6 +686,9 @@ func TestHandleAgentImport_InvalidBody_Boost(t *testing.T) {
 	srv := newFullServer(t)
 	req := httptest.NewRequest("POST", "/api/agents/import", strings.NewReader("not yaml"))
 	req.Header.Set("Content-Type", "application/json")
+	// Import is owner-only (audit F16). This test asserts body validation, not
+	// authorization, so give it credentials and keep asserting 400.
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleAgentImport(w, req)
 

--- a/v2/pkg/dashboard/f16_owner_gate_test.go
+++ b/v2/pkg/dashboard/f16_owner_gate_test.go
@@ -1,0 +1,166 @@
+package dashboard
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Audit F16 (2026-08-13). Three dashboard surfaces performed privileged
+// mutations with NO owner gate, so any authenticated read-write member could
+// reach them:
+//
+//   - PUT /api/config/governor/security — the body carries agentSandboxEnabled,
+//     so a read-write member could TURN OFF THE AGENT SANDBOX. Every sibling
+//     governor-config handler was already owner-gated; this one was the outlier.
+//   - POST /api/agents and POST /api/agents/import — create paths that write an
+//     agent file and start a live process. The asymmetry proved the intent:
+//     handleAgentDelete in the same file WAS gated.
+//   - POST /api/plan/{epicID}/{approve,reject,child} — the plan-review gate that
+//     decompose.go relies on to withhold an epic's children "until a human
+//     approves the plan".
+//
+// These tests assert the INVARIANT at the source level rather than one
+// handler's behaviour, because the failure mode for this class of bug in this
+// repo is a merge silently dropping a gate, not a logic bug. Finding F14
+// regressed exactly that way: the fix commit is an ancestor of v4, yet the gate
+// was gone at HEAD because a v2->v4 sync merge resolved the conflict in favour
+// of the older side. A behavioural test on a single handler does not catch that.
+//
+// Shape follows api_contribute_owner_gate_test.go (#3713).
+
+// ownerGatedF16Handlers maps each handler this fix gated to the file it lives
+// in. Adding a handler here without gating it fails the test, and vice versa.
+var ownerGatedF16Handlers = map[string]string{
+	"handleGovernorSecurity": "api_governor_security.go",
+	"handleAgentCreate":      "api_agents.go",
+	"handleAgentImport":      "api_agents.go",
+	"handlePlanApprove":      "plan_handlers.go",
+	"handlePlanReject":       "plan_handlers.go",
+	"handlePlanChild":        "plan_handlers.go",
+}
+
+// f16HandlerBody returns the source of the named handler, from its func line to
+// the first line that is exactly "}".
+func f16HandlerBody(t *testing.T, src, name string) string {
+	t.Helper()
+	i := strings.Index(src, "func (s *Server) "+name+"(")
+	if i < 0 {
+		t.Fatalf("handler %s not found — it was renamed or removed; update this test deliberately, do not delete the case", name)
+	}
+	j := strings.Index(src[i:], "\n}\n")
+	if j < 0 {
+		t.Fatalf("could not find the end of %s", name)
+	}
+	return src[i : i+j]
+}
+
+func f16ReadSource(t *testing.T, file string) string {
+	t.Helper()
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	return string(raw)
+}
+
+// TestF16PrivilegedHandlersAreOwnerGated is the F16 regression.
+func TestF16PrivilegedHandlersAreOwnerGated(t *testing.T) {
+	for name, file := range ownerGatedF16Handlers {
+		body := f16HandlerBody(t, f16ReadSource(t, file), name)
+		if !strings.Contains(body, "requireOwnerRole(w, r)") {
+			t.Errorf("%s (%s) has no requireOwnerRole gate — a read-write member can reach a privileged mutation (audit F16). "+
+				"If a merge dropped this, restore the gate rather than relaxing the test.", name, file)
+		}
+		// Weaker gates admit RoleReadWrite (or better) and are NOT sufficient
+		// for these surfaces. Catch a downgrade as well as an outright removal.
+		for _, weak := range []string{
+			"s.requireContributorWrite(w, r)",
+			"requireMergerOrOwnerRole(w, r)",
+		} {
+			if strings.Contains(body, weak) {
+				t.Errorf("%s (%s) gates on %s, which admits a non-owner role; this surface is owner-only", name, file, weak)
+			}
+		}
+	}
+}
+
+// TestF16AgentSandboxToggleIsOwnerOnly pins the single highest-impact item
+// explicitly, so the reason this fix exists survives even if someone prunes the
+// table above. handleGovernorSecurity is the only handler that writes
+// cfg.AgentSandbox.Enabled from request input.
+func TestF16AgentSandboxToggleIsOwnerOnly(t *testing.T) {
+	body := f16HandlerBody(t, f16ReadSource(t, "api_governor_security.go"), "handleGovernorSecurity")
+	if !strings.Contains(body, "AgentSandboxEnabled") {
+		t.Skip("handleGovernorSecurity no longer accepts agentSandboxEnabled; the sandbox toggle moved — re-point this test")
+	}
+	if !strings.Contains(body, "requireOwnerRole(w, r)") {
+		t.Error("handleGovernorSecurity accepts agentSandboxEnabled but is not owner-gated — " +
+			"a read-write member can disable the agent sandbox (audit F16)")
+	}
+}
+
+// --- POSITIVE CONTROLS -------------------------------------------------------
+//
+// Without these, a blanket "add requireOwnerRole to every handler in these
+// files" would satisfy the tests above while breaking legitimate workflows.
+// Over-gating is a real cost, not a safe default — #3713 deliberately left
+// handleContributorRequeue un-gated for exactly this reason.
+
+// TestF16ReadOnlyPlanAndAgentReadsStayUngated asserts the GET handlers that sit
+// beside the gated mutations are still reachable by a read-only member.
+func TestF16ReadOnlyPlanAndAgentReadsStayUngated(t *testing.T) {
+	for name, file := range map[string]string{
+		"handlePlanTree":   "plan_handlers.go",
+		"handleAgentsList": "api_agents.go",
+	} {
+		body := f16HandlerBody(t, f16ReadSource(t, file), name)
+		if strings.Contains(body, "requireOwnerRole(w, r)") {
+			t.Errorf("%s (%s) must NOT be owner-gated — it is a read-only GET that the "+
+				"review UI calls for every viewer; owner-gating it blanks the plan/agent views "+
+				"for non-owners", name, file)
+		}
+	}
+}
+
+// TestF16PlanFromIssueStaysUngated is the substantive control: a mutating
+// handler in a file this fix touched that must stay reachable by a normal
+// contributor. handlePlanFromIssue mints a DRAFT epic — decompose.go withholds
+// a draft epic's children from Ready(), so proposing a plan releases no work on
+// its own. It is the "ask for a plan" action, and the owner gate belongs on
+// approve (which releases the children), not here.
+func TestF16PlanFromIssueStaysUngated(t *testing.T) {
+	body := f16HandlerBody(t, f16ReadSource(t, "plan_handlers.go"), "handlePlanFromIssue")
+	if strings.Contains(body, "requireOwnerRole(w, r)") {
+		t.Error("handlePlanFromIssue must NOT be owner-gated — proposing a plan creates a " +
+			"draft epic whose children stay gated until approve; gating it here would make " +
+			"planning owner-only end to end and break the contributor workflow")
+	}
+}
+
+// --- COUNT FLOORS ------------------------------------------------------------
+
+// TestF16OwnerGateCountFloor is the blunt instrument that survives renames: if
+// a file's gate count drops below what this fix established, something removed
+// a gate even if the handler names changed. Cheap, and exactly the signal a
+// sync merge would trip.
+func TestF16OwnerGateCountFloor(t *testing.T) {
+	// Minimum requireOwnerRole call sites per file after F16.
+	// api_agents.go: create + import + delete (delete predates this fix).
+	// plan_handlers.go: approve + reject + child.
+	// api_governor_security.go: security.
+	want := map[string]int{
+		"api_governor_security.go": 1,
+		"api_agents.go":            3,
+		"plan_handlers.go":         3,
+	}
+	gate := regexp.MustCompile(`requireOwnerRole\(w, r\)`)
+	for file, min := range want {
+		got := len(gate.FindAllString(f16ReadSource(t, file), -1))
+		if got < min {
+			t.Errorf("%s has %d requireOwnerRole gates, want at least %d — a gate was removed "+
+				"(audit F14 regressed exactly this way, via a sync merge)", file, got, min)
+		}
+	}
+}

--- a/v2/pkg/dashboard/plan_handlers.go
+++ b/v2/pkg/dashboard/plan_handlers.go
@@ -230,7 +230,15 @@ func (s *Server) handlePlanTree(w http.ResponseWriter, r *http.Request) {
 
 // handlePlanApprove serves POST /api/plan/{epicID}/approve: approve the plan,
 // releasing its children through Ready().
+//
+// OWNER-ONLY. Approval is the whole point of the plan-review gate: decompose.go
+// withholds a draft epic's children from Ready() "until a human approves the
+// plan", and ApprovePlan is what releases them into agent execution. An
+// un-gated approve makes the gate decorative. Audit F16 (2026-08-13).
 func (s *Server) handlePlanApprove(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	epicID := r.PathValue("epicID")
 	store, agentName := s.findEpicStore(epicID)
 	if store == nil {
@@ -249,7 +257,16 @@ func (s *Server) handlePlanApprove(w http.ResponseWriter, r *http.Request) {
 
 // handlePlanReject serves POST /api/plan/{epicID}/reject: return an approved (or
 // draft) plan to draft state, re-gating its children.
+//
+// OWNER-ONLY. RejectPlan is documented as "the inverse of ApprovePlan". If
+// approve is owner-only and reject is not, a read-write member can undo an
+// owner's approval at will — the gate is bypassed from the other side, and the
+// two ends of one state machine must sit at the same trust level.
+// Audit F16 (2026-08-13).
 func (s *Server) handlePlanReject(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	epicID := r.PathValue("epicID")
 	store, agentName := s.findEpicStore(epicID)
 	if store == nil {
@@ -269,7 +286,16 @@ func (s *Server) handlePlanReject(w http.ResponseWriter, r *http.Request) {
 // handlePlanChild serves POST /api/plan/{epicID}/child/{childID}: edit a child
 // before approval. Body {"action":"retag","execution":"agent_suitable"} retags;
 // {"action":"remove"} removes (closes) the child.
+//
+// OWNER-ONLY. This edits the plan that approval will release: "remove" closes a
+// child bead outright and "retag" flips a child between human_required and
+// agent_suitable — i.e. it can hand work the planner marked as needing a human
+// to an agent. That is the same decision approve makes, taken one bead at a
+// time, so it sits behind the same gate. Audit F16 (2026-08-13).
 func (s *Server) handlePlanChild(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	epicID := r.PathValue("epicID")
 	childID := r.PathValue("childID")
 	store, agentName := s.findEpicStore(epicID)

--- a/v2/pkg/dashboard/plan_handlers_test.go
+++ b/v2/pkg/dashboard/plan_handlers_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/planning"
 )
 
+// The plan MUTATION routes (approve/reject/child) are owner-only as of audit
+// F16 — approval is what releases a draft epic's children into agent execution.
+// The tests below exercise happy paths, not-found and input validation, so they
+// call markOwnerRequest to supply credentials and keep their original
+// assertions. Authorization itself is covered by f16_owner_gate_test.go.
+//
+// The read-only GET route (handlePlanTree) is deliberately NOT owner-gated, so
+// its tests intentionally send no credentials — do not "fix" them by adding
+// markOwnerRequest; that would hide a regression if the GET were ever gated.
+
 // planServer builds a Server with a single "architect" bead store and an epic
 // decomposed into children. It returns the server, store, and epic.
 func planServer(t *testing.T) (*Server, *beads.Store, *beads.Bead) {
@@ -82,6 +92,7 @@ func TestHandlePlanApprove(t *testing.T) {
 	srv, store, epic := planServer(t)
 
 	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/approve", nil)
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -94,7 +105,9 @@ func TestHandlePlanApprove(t *testing.T) {
 
 	// Double-approve → 400.
 	w2 := httptest.NewRecorder()
-	srv.mux.ServeHTTP(w2, httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/approve", nil))
+	req2 := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/approve", nil)
+	markOwnerRequest(req2)
+	srv.mux.ServeHTTP(w2, req2)
 	if w2.Code != http.StatusBadRequest {
 		t.Fatalf("double approve want 400, got %d", w2.Code)
 	}
@@ -103,7 +116,9 @@ func TestHandlePlanApprove(t *testing.T) {
 func TestHandlePlanApprove_NotFound(t *testing.T) {
 	srv, _, _ := planServer(t)
 	w := httptest.NewRecorder()
-	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/missing/approve", nil))
+	req := httptest.NewRequest("POST", "/api/plan/missing/approve", nil)
+	markOwnerRequest(req)
+	srv.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", w.Code)
 	}
@@ -115,7 +130,9 @@ func TestHandlePlanReject(t *testing.T) {
 		t.Fatalf("approve: %v", err)
 	}
 	w := httptest.NewRecorder()
-	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/reject", nil))
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/reject", nil)
+	markOwnerRequest(req)
+	srv.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -141,6 +158,7 @@ func TestHandlePlanChild_Retag(t *testing.T) {
 
 	body := strings.NewReader(`{"action":"retag","execution":"human_required"}`)
 	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	markOwnerRequest(req)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -164,6 +182,7 @@ func TestHandlePlanChild_Remove(t *testing.T) {
 	}
 	body := strings.NewReader(`{"action":"remove"}`)
 	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	markOwnerRequest(req)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -187,6 +206,7 @@ func TestHandlePlanChild_BadAction(t *testing.T) {
 	}
 	body := strings.NewReader(`{"action":"bogus"}`)
 	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	markOwnerRequest(req)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -208,7 +228,9 @@ func TestHandlePlanReject_BadState(t *testing.T) {
 	}
 	srv.RegisterAPI(srv.deps)
 	w := httptest.NewRecorder()
-	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/reject", nil))
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/reject", nil)
+	markOwnerRequest(req)
+	srv.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
 	}
@@ -217,7 +239,9 @@ func TestHandlePlanReject_BadState(t *testing.T) {
 func TestHandlePlanReject_NotFound(t *testing.T) {
 	srv, _, _ := planServer(t)
 	w := httptest.NewRecorder()
-	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/missing/reject", nil))
+	req := httptest.NewRequest("POST", "/api/plan/missing/reject", nil)
+	markOwnerRequest(req)
+	srv.mux.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", w.Code)
 	}
@@ -227,6 +251,7 @@ func TestHandlePlanChild_NotFound(t *testing.T) {
 	srv, _, _ := planServer(t)
 	body := strings.NewReader(`{"action":"remove"}`)
 	req := httptest.NewRequest("POST", "/api/plan/missing/child/x", body)
+	markOwnerRequest(req)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -238,6 +263,7 @@ func TestHandlePlanChild_NotFound(t *testing.T) {
 func TestHandlePlanChild_BadBody(t *testing.T) {
 	srv, _, epic := planServer(t)
 	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/x", strings.NewReader("{not json"))
+	markOwnerRequest(req)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -258,6 +284,7 @@ func TestHandlePlanChild_RetagError(t *testing.T) {
 	// Invalid execution value → RetagChild errors → 400.
 	body := strings.NewReader(`{"action":"retag","execution":"bogus"}`)
 	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	markOwnerRequest(req)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)


### PR DESCRIPTION
Audit finding **F16** (High, 2026-08-13). Three dashboard surfaces performed privileged mutations with **no owner gate**, so any authenticated read-write member could reach them.

## What was open

| Surface | Handler | Impact |
|---|---|---|
| `PUT /api/config/governor/security` | `handleGovernorSecurity` | body accepts `agentSandboxEnabled` — **a read-write member could turn off the agent sandbox** — plus `ioscanFailMode` and `intentEnforce` |
| `POST /api/agents`, `POST /api/agents/import` | `handleAgentCreate`, `handleAgentImport` | writes an agent file, lifts any deletion tombstone, starts a live process; import additionally fetches a caller-supplied remote definition |
| `POST /api/plan/{epicID}/{approve,reject,child}` | `handlePlanApprove`, `handlePlanReject`, `handlePlanChild` | releases a decomposed epic's children into agent execution |

Two asymmetries showed the intent rather than a design choice: every sibling governor-config handler (`health`/`logging`/`hub`/`trajectory`/`thresholds`/…) already called `requireOwnerRole`, and `handleAgentDelete` — in the same file as create/import — was already gated.

## Judgement calls on the plan handlers

- **`handlePlanApprove` — gated.** `decompose.go` withholds a draft epic's children from `Ready()` "until a human approves the plan"; `ApprovePlan` is what releases them. An un-gated approve makes the whole review gate decorative.
- **`handlePlanReject` — gated.** `RejectPlan` is documented as "the inverse of `ApprovePlan`". If approve is owner-only and reject is not, a read-write member can undo an owner's approval at will — the gate is bypassed from the other side. Two ends of one state machine must sit at the same trust level.
- **`handlePlanChild` — gated.** `remove` closes a child bead outright, and `retag` flips a child between `human_required` and `agent_suitable` — i.e. it can hand work the planner marked as needing a human to an agent. That is the same decision approve makes, taken one bead at a time.

**Deliberately left un-gated** (over-gating breaks legitimate workflows and is a real cost, not a safe default — precedent: #3713 left `handleContributorRequeue` alone):

- **`handlePlanFromIssue`** — mints a **draft** epic. Its children stay gated until approve, so proposing a plan releases no work. This is the "ask for a plan" contributor action; the gate belongs on approve.
- **`handlePlanTree`, `handleAgentsList`** — read-only GETs the review UI calls for every viewer.

## Tests assert the invariant, not one handler's behaviour

The failure mode for this class of bug in this repo is **a merge silently dropping a gate**. F14 regressed exactly that way: its fix commit is an ancestor of `v4`, yet the gate was gone at HEAD because a v2→v4 sync merge resolved the conflict in favour of the older side. A behavioural test on a single handler would not have caught that. Shape follows `api_contribute_owner_gate_test.go` (#3713).

- `TestF16PrivilegedHandlersAreOwnerGated` — each gated handler's body contains `requireOwnerRole` and no weaker gate (`requireContributorWrite`, `requireMergerOrOwnerRole`), so a downgrade is caught as well as a removal.
- `TestF16AgentSandboxToggleIsOwnerOnly` — pins the highest-impact item explicitly so the reason this fix exists survives a pruned table.
- `TestF16ReadOnlyPlanAndAgentReadsStayUngated` and `TestF16PlanFromIssueStaysUngated` — **positive controls**. Without them, "add `requireOwnerRole` everywhere" would satisfy the tests above while breaking the contributor planning workflow.
- `TestF16OwnerGateCountFloor` — per-file floors so a rename cannot silently reduce coverage.

## Regression replay

Gates removed, code still compiling:

```
--- FAIL: TestF16PrivilegedHandlersAreOwnerGated (0.00s)
    handlePlanReject / handlePlanChild / handleGovernorSecurity /
    handleAgentCreate / handleAgentImport / handlePlanApprove
      has no requireOwnerRole gate — a read-write member can reach a
      privileged mutation (audit F16).
--- FAIL: TestF16AgentSandboxToggleIsOwnerOnly (0.00s)
    handleGovernorSecurity accepts agentSandboxEnabled but is not owner-gated
--- FAIL: TestF16OwnerGateCountFloor (0.00s)
    api_governor_security.go has 0 gates, want at least 1
    api_agents.go has 1 gates, want at least 3
    plan_handlers.go has 0 gates, want at least 3
--- PASS: TestF16ReadOnlyPlanAndAgentReadsStayUngated
--- PASS: TestF16PlanFromIssueStaysUngated
```

Both controls still passed there — they are not just failing along with everything else. Separately, over-gating `handlePlanTree` and `handlePlanFromIssue` fails **both** controls, so every test in the file is capable of failing. Gates restored: all 5 pass, and the existing `TestPlan*`/`TestAgent*`/`TestOwner*` suites stay green.