### PR TITLE
🔒 fix(dashboard): stop gateway discover leaking stored API keys (audit F13)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -6512,7 +6512,17 @@ func fetchModelsFromEndpoint(baseURL, apiKey string) ([]string, error) {
 // the Bearer; for watsonx the caller passes the minted IAM token as apiKey.
 func fetchModelsWithHeaders(baseURL, apiKey string, extraHeaders map[string]string) ([]string, error) {
 	modelsURL := strings.TrimRight(baseURL, "/") + "/v1/models"
-	client := &http.Client{Timeout: inferenceModelQueryTimeout}
+	client := &http.Client{
+		Timeout: inferenceModelQueryTimeout,
+		// SECURITY (audit F13): Go's default redirect policy PRESERVES the
+		// Authorization header across same-host hops and follows up to 10
+		// redirects. An upstream that answers /v1/models with a 302 could
+		// therefore walk the gateway key onward. Strip credentials on any hop
+		// that changes host, so a redirect can never carry the key somewhere the
+		// original request was not authorized to reach. probeModelsWithHeaders
+		// already used this policy; this sibling was simply missed.
+		CheckRedirect: noRedirectToPrivate,
+	}
 	req, err := http.NewRequest("GET", modelsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -7488,11 +7488,29 @@ func defaultHostResolver(ctx context.Context, host string) ([]string, error) {
 	return (&net.Resolver{}).LookupHost(resolveCtx, host)
 }
 
+// privateURLTestExemptHostPorts lets tests treat specific loopback host:port
+// pairs (httptest servers, which always bind 127.0.0.1) as public, so SSRF
+// behaviour can be exercised end-to-end without weakening the guard.
+//
+// It is EMPTY in production and only ever populated by test helpers, so real
+// traffic sees the unmodified check. Entries are host:port, never a bare host,
+// so an exemption cannot widen to all of loopback.
+var privateURLTestExemptHostPorts map[string]struct{}
+
 func isPrivateURL(ctx context.Context, rawURL string) bool {
 	for _, scheme := range []string{"https://", "http://", "wss://", "ws://"} {
 		if strings.HasPrefix(rawURL, scheme) {
 			rawURL = strings.TrimPrefix(rawURL, scheme)
 			break
+		}
+	}
+	if len(privateURLTestExemptHostPorts) > 0 {
+		hostPort := rawURL
+		if idx := strings.IndexAny(hostPort, "/"); idx >= 0 {
+			hostPort = hostPort[:idx]
+		}
+		if _, ok := privateURLTestExemptHostPorts[strings.ToLower(hostPort)]; ok {
+			return false
 		}
 	}
 	host := rawURL

--- a/v2/pkg/dashboard/gateways.go
+++ b/v2/pkg/dashboard/gateways.go
@@ -15,7 +15,9 @@ package dashboard
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -487,6 +489,13 @@ func (s *Server) handleGovernorGatewaysDelete(w http.ResponseWriter, r *http.Req
 // re-opening an existing gateway populates its models without re-entering the
 // key. Returns {ok, models:[...]} or {ok:false, error}.
 func (s *Server) handleGovernorGatewaysDiscover(w http.ResponseWriter, r *http.Request) {
+	// SECURITY (audit F13): discover mutates nothing, but it drives an outbound
+	// request to a caller-named endpoint and can attach a stored credential, so
+	// it is gated like the other gateway routes rather than left open.
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
 	var body struct {
 		Name      string `json:"name"`
 		Endpoint  string `json:"endpoint"`
@@ -507,6 +516,10 @@ func (s *Server) handleGovernorGatewaysDiscover(w http.ResponseWriter, r *http.R
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if err := guardDiscoverEndpoint(r.Context(), endpoint); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	key := strings.TrimSpace(body.APIKey)
 	kind := strings.ToLower(strings.TrimSpace(body.Kind))
 	projectID := strings.TrimSpace(body.ProjectID)
@@ -515,7 +528,23 @@ func (s *Server) handleGovernorGatewaysDiscover(w http.ResponseWriter, r *http.R
 	// stored gateway of this name.
 	if key == "" || kind == "" || projectID == "" {
 		if gw := s.deps.Config.Governor.ResolveGateway(strings.TrimSpace(body.Name)); gw != nil {
-			if key == "" {
+			// SECURITY (audit F13, CWE-200): this is the same defect as N8 and F6,
+			// which were fixed on the UPSERT handler but never here. A credential
+			// the caller did not supply must never be sent to an endpoint the
+			// caller chose. Falling back to the stored key while taking the
+			// endpoint from the request body made one POST — naming an existing
+			// gateway and any attacker-controlled endpoint — walk the stored key
+			// straight out. The caller never had to know the key.
+			//
+			// The stored key is therefore usable only when the caller names the
+			// gateway's OWN persisted endpoint: that address already receives this
+			// key on every agent request, so probing it discloses nothing new. Any
+			// other endpoint requires the caller to supply their own key, which
+			// they already possess.
+			//
+			// kind/project_id are NOT secrets, so they still fall back freely —
+			// only the key is endpoint-bound.
+			if key == "" && sameGatewayEndpoint(endpoint, gw.Endpoint) {
 				key = gw.ResolveAPIKey()
 			}
 			if kind == "" {
@@ -617,12 +646,97 @@ func (s *Server) registerGatewayEndpoints() {
 // validateGatewayEndpoint checks the endpoint parses as an absolute http(s)
 // URL, mirroring LiteLLMConfig.Validate.
 func validateGatewayEndpoint(endpoint string) error {
+	_, err := parseGatewayEndpoint(endpoint)
+	return err
+}
+
+// parseGatewayEndpoint is validateGatewayEndpoint's shared parse step, returning
+// the parsed URL so callers that need the host do not re-parse (and cannot drift
+// from what validation accepted).
+func parseGatewayEndpoint(endpoint string) (*url.URL, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return fmt.Errorf("endpoint %q is not a valid URL: %w", endpoint, err)
+		return nil, fmt.Errorf("endpoint %q is not a valid URL: %w", endpoint, err)
 	}
 	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-		return fmt.Errorf("endpoint %q must be an absolute http(s) URL", endpoint)
+		return nil, fmt.Errorf("endpoint %q must be an absolute http(s) URL", endpoint)
+	}
+	return u, nil
+}
+
+// sameGatewayEndpoint reports whether a caller-supplied endpoint addresses the
+// SAME upstream as a gateway's persisted endpoint. It is the gate on reusing a
+// stored credential (audit F13), so it compares canonically and is deliberately
+// strict: anything it cannot prove identical returns false, which merely costs
+// the caller a re-typed key.
+//
+// Canonicalisation covers the ways two spellings of one address differ
+// innocently — scheme/host case, the implicit :80/:443 port, a trailing slash —
+// and nothing else. In particular userinfo must match, so
+// "https://evil@gw.example" is NOT the same upstream as "https://gw.example":
+// Go sends userinfo as Basic credentials and the host itself can differ under
+// some parsers, both of which are exactly the confusion an attacker wants.
+func sameGatewayEndpoint(supplied, stored string) bool {
+	a, errA := parseGatewayEndpoint(strings.TrimSpace(supplied))
+	b, errB := parseGatewayEndpoint(strings.TrimSpace(stored))
+	if errA != nil || errB != nil {
+		return false
+	}
+	return canonicalGatewayEndpoint(a) == canonicalGatewayEndpoint(b)
+}
+
+// canonicalGatewayEndpoint renders a URL in a normalized form for equality
+// comparison: lowercased scheme and host, the default port made explicit, and a
+// trailing slash trimmed from the path.
+func canonicalGatewayEndpoint(u *url.URL) string {
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	user := ""
+	if u.User != nil {
+		user = u.User.String() + "@"
+	}
+	path := strings.TrimRight(u.Path, "/")
+	return scheme + "://" + user + net.JoinHostPort(host, port) + path
+}
+
+// errGatewayEndpointPrivate is returned when a caller-supplied discover target
+// resolves into private/loopback/link-local space.
+var errGatewayEndpointPrivate = errors.New("endpoint resolves to a private, loopback or link-local address and cannot be probed from the discover form; save the gateway and use its test action instead")
+
+// guardDiscoverEndpoint is the SSRF gate on the DISCOVER path (audit F13).
+//
+// Scope note, because the placement is deliberate and easy to "fix" wrongly:
+// this check is NOT in validateGatewayEndpoint. That helper also validates the
+// UPSERT path, where in-cluster gateways are a supported, documented
+// configuration — the bundled local litellm proxy is http://127.0.0.1:18445 and
+// vllm/llm-d default to *.svc.cluster.local (see HIVE_VLLM_ENDPOINT). Blanket
+// private-address denial there would break real deployments, which is why the
+// F6 fix explicitly rejected it as the remedy.
+//
+// Discover is different: it is an unauthenticated-shaped, caller-driven fetch
+// whose only job is populating a dropdown. Refusing to aim it at internal
+// addresses removes the SSRF probe primitive (cloud metadata at 169.254.169.254,
+// port-scanning localhost via error/timing differences) while leaving every
+// legitimate in-cluster gateway configurable through upsert + the test action,
+// which probe a PERSISTED endpoint an owner already committed to.
+//
+// Resolution is done via DNS, not string matching, so "evil.example" pointing at
+// 169.254.169.254 is caught; it fails CLOSED on resolution error.
+func guardDiscoverEndpoint(ctx context.Context, endpoint string) error {
+	u, err := parseGatewayEndpoint(endpoint)
+	if err != nil {
+		return err
+	}
+	if isPrivateURL(ctx, u.Scheme+"://"+u.Host) {
+		return errGatewayEndpointPrivate
 	}
 	return nil
 }

--- a/v2/pkg/dashboard/gateways_discover_ssrf_test.go
+++ b/v2/pkg/dashboard/gateways_discover_ssrf_test.go
@@ -1,0 +1,379 @@
+package dashboard
+
+// Regression tests for audit F13: the gateway DISCOVER endpoint exfiltrated a
+// stored API key to a caller-supplied endpoint and was a full SSRF.
+//
+// F13 is the same defect as N8 (2026-08-07) and F6 (2026-08-11). Those were
+// fixed on the gateway UPSERT handler and missed on this sibling, so it survived
+// three audits. These tests pin the invariant on the discover path specifically:
+//
+//	a credential the caller did not supply must never be sent to an endpoint the
+//	caller chose.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// storedKeyGateway registers a gateway named "stored" whose key lives in a file
+// (the production shape — hive.yaml records the PATH, never the value) pointing
+// at endpoint. Returns the key value the test should never see leave.
+func storedKeyGateway(t *testing.T, deps *Dependencies, endpoint string) string {
+	t.Helper()
+	dir := t.TempDir()
+	restore := setGatewaySecretsDirForTest(dir)
+	t.Cleanup(restore)
+
+	const secret = "sk-stored-must-not-leak"
+	path := filepath.Join(dir, "gateway_stored_api_key")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	deps.Config.Governor.Gateways = []config.GatewayConfig{{
+		Name:       "stored",
+		Kind:       config.GatewayKindCustom,
+		Endpoint:   endpoint,
+		APIKeyFile: path,
+	}}
+	// Positive control on the fixture itself: if resolution silently returned ""
+	// every "the key did not leak" assertion below would pass for the wrong
+	// reason.
+	if got := deps.Config.Governor.Gateways[0].ResolveAPIKey(); got != secret {
+		t.Fatalf("fixture: stored key resolved to %q, want %q — the leak assertions "+
+			"would be vacuous", got, secret)
+	}
+	return secret
+}
+
+// treatAsPublic exempts the given httptest server URLs' host:port from the
+// private-address guard for the duration of the test. httptest always binds
+// 127.0.0.1, which the guard correctly rejects; without this seam the SSRF
+// tests below would pass because the request was blocked as loopback rather
+// than because the credential logic is right — passing for the wrong reason.
+func treatAsPublic(t *testing.T, urls ...string) {
+	t.Helper()
+	prev := privateURLTestExemptHostPorts
+	exempt := make(map[string]struct{}, len(urls))
+	for _, raw := range urls {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("parse %q: %v", raw, err)
+		}
+		exempt[strings.ToLower(u.Host)] = struct{}{}
+	}
+	privateURLTestExemptHostPorts = exempt
+	t.Cleanup(func() { privateURLTestExemptHostPorts = prev })
+}
+
+// captureAuthServer records the Authorization header of every request it
+// receives and answers with an empty OpenAI-style model list.
+func captureAuthServer(t *testing.T, got *[]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*got = append(*got, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestF13_DiscoverRequiresOwnerRole pins sub-fix 1: discover drives an outbound
+// request with a stored credential attached, so it must be owner-gated like the
+// other gateway routes. Before the fix it had no gate at all, so a read-write
+// member — or an unauthenticated caller on an open spoke — could reach it.
+func TestF13_DiscoverRequiresOwnerRole(t *testing.T) {
+	s, _ := apiServer(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/config/governor/gateways/discover",
+		strings.NewReader(`{"endpoint":"https://public.example/v1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	// Deliberately NOT markOwnerRequest: a non-owner caller.
+	req.Header.Set("X-Hive-Role", "member")
+	s.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("discover as non-owner = %d, want 403 — the endpoint is ungated: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestF13_DiscoverDoesNotSendStoredKeyToCallerEndpoint is the core exfiltration
+// regression. The caller names an existing gateway but points the endpoint at a
+// server they control and supplies no key. The stored key must NOT be attached.
+//
+// This asserts on what the outbound request actually CARRIED, not on the handler
+// response — the leak happens on the wire, and a handler that returns an error
+// after already sending the key has still lost it.
+func TestF13_DiscoverDoesNotSendStoredKeyToCallerEndpoint(t *testing.T) {
+	s, deps := apiServer(t)
+
+	var attackerSaw []string
+	attacker := captureAuthServer(t, &attackerSaw)
+
+	// The gateway's real endpoint is somewhere else entirely.
+	secret := storedKeyGateway(t, deps, "https://real-gateway.example/v1")
+
+	treatAsPublic(t, attacker.URL)
+
+	rec := doPost(s, "/api/config/governor/gateways/discover", map[string]interface{}{
+		"name":     "stored", // an EXISTING gateway with a stored key
+		"endpoint": attacker.URL,
+		// no api_key: this is the whole attack — make the server supply one.
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	for _, auth := range attackerSaw {
+		if strings.Contains(auth, secret) {
+			t.Fatalf("F13 EXFILTRATION: the stored gateway key was sent to a "+
+				"caller-supplied endpoint (Authorization: %q)", auth)
+		}
+		if auth != "" {
+			t.Errorf("unexpected credential sent to caller endpoint: %q", auth)
+		}
+	}
+}
+
+// TestF13_DiscoverUsesStoredKeyForOwnEndpoint is the POSITIVE CONTROL for the
+// test above. "Never send the stored key" is trivially satisfiable by never
+// sending it at all, which would silently break the legitimate feature (
+// re-opening an existing gateway populates its model dropdown without retyping
+// the key). When the caller names the gateway's OWN persisted endpoint — an
+// address that already receives this key on every agent request — the stored key
+// SHOULD still be used.
+func TestF13_DiscoverUsesStoredKeyForOwnEndpoint(t *testing.T) {
+	s, deps := apiServer(t)
+
+	var upstreamSaw []string
+	upstream := captureAuthServer(t, &upstreamSaw)
+
+	// The gateway's persisted endpoint IS the server we probe.
+	secret := storedKeyGateway(t, deps, upstream.URL)
+	treatAsPublic(t, upstream.URL)
+
+	rec := doPost(s, "/api/config/governor/gateways/discover", map[string]interface{}{
+		"name":     "stored",
+		"endpoint": upstream.URL,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	found := false
+	for _, auth := range upstreamSaw {
+		if auth == "Bearer "+secret {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("stored key was NOT used for the gateway's own endpoint (saw %q) — "+
+			"the fix over-blocked and broke model discovery for saved gateways", upstreamSaw)
+	}
+}
+
+// TestF13_SameGatewayEndpoint covers the canonicalisation that decides whether
+// the stored key may be reused. Innocent spelling differences must match;
+// anything else must not.
+func TestF13_SameGatewayEndpoint(t *testing.T) {
+	same := []struct{ a, b, why string }{
+		{"https://gw.example/v1", "https://gw.example/v1", "identical"},
+		{"https://gw.example/v1/", "https://gw.example/v1", "trailing slash"},
+		{"https://GW.Example/v1", "https://gw.example/v1", "host case"},
+		{"HTTPS://gw.example/v1", "https://gw.example/v1", "scheme case"},
+		{"https://gw.example:443/v1", "https://gw.example/v1", "explicit default port"},
+		{"http://gw.example:80/v1", "http://gw.example/v1", "explicit default port (http)"},
+	}
+	for _, c := range same {
+		if !sameGatewayEndpoint(c.a, c.b) {
+			t.Errorf("sameGatewayEndpoint(%q,%q) = false, want true (%s)", c.a, c.b, c.why)
+		}
+	}
+
+	diff := []struct{ a, b, why string }{
+		{"https://evil.example/v1", "https://gw.example/v1", "different host"},
+		{"http://gw.example/v1", "https://gw.example/v1", "different scheme"},
+		{"https://gw.example:8443/v1", "https://gw.example/v1", "different port"},
+		{"https://gw.example/other", "https://gw.example/v1", "different path"},
+		{"https://gw.example.evil.com/v1", "https://gw.example/v1", "suffix-extended host"},
+		{"https://evil@gw.example/v1", "https://gw.example/v1", "injected userinfo"},
+		{"notaurl", "https://gw.example/v1", "unparseable supplied"},
+		{"", "https://gw.example/v1", "empty supplied"},
+		{"https://gw.example/v1", "", "empty stored (unconfigured gateway)"},
+	}
+	for _, c := range diff {
+		if sameGatewayEndpoint(c.a, c.b) {
+			t.Errorf("sameGatewayEndpoint(%q,%q) = true, want false (%s)", c.a, c.b, c.why)
+		}
+	}
+}
+
+// TestF13_DiscoverRejectsInternalEndpoints pins sub-fix 3: the discover probe
+// must refuse internal address space so it cannot be used to reach cloud
+// metadata or port-scan the pod's own loopback.
+//
+// Note this guard is on DISCOVER only, not on validateGatewayEndpoint — upsert
+// must keep accepting in-cluster gateways (the bundled litellm proxy listens on
+// 127.0.0.1:18445 and vllm/llm-d default to *.svc.cluster.local).
+func TestF13_DiscoverRejectsInternalEndpoints(t *testing.T) {
+	s, _ := apiServer(t)
+
+	blocked := []struct{ endpoint, why string }{
+		{"http://127.0.0.1/v1", "loopback"},
+		{"http://127.0.0.1:18445/v1", "loopback, bundled litellm proxy port"},
+		{"http://localhost/v1", "loopback by name"},
+		{"http://169.254.169.254/v1", "cloud metadata endpoint"},
+		{"http://10.0.0.5/v1", "RFC1918 10/8"},
+		{"http://192.168.1.1/v1", "RFC1918 192.168/16"},
+		{"http://172.16.0.1/v1", "RFC1918 172.16/12"},
+		{"http://[::1]/v1", "IPv6 loopback"},
+		{"http://0.0.0.0/v1", "unspecified address"},
+	}
+	for _, c := range blocked {
+		rec := doPost(s, "/api/config/governor/gateways/discover", map[string]interface{}{
+			"endpoint": c.endpoint,
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("discover %s (%s) = %d, want 400 — SSRF target reachable",
+				c.endpoint, c.why, rec.Code)
+		}
+	}
+}
+
+// TestF13_DiscoverAcceptsPublicEndpoint is the POSITIVE CONTROL for the table
+// above: without it, a guard that rejected EVERY endpoint would pass.
+func TestF13_DiscoverAcceptsPublicEndpoint(t *testing.T) {
+	s, _ := apiServer(t)
+	allowPrivateURLHostsForTest(t, "public.example")
+
+	rec := doPost(s, "/api/config/governor/gateways/discover", map[string]interface{}{
+		"endpoint": "https://public.example/v1",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("discover public endpoint = %d, want 200 — the guard over-blocks "+
+			"and no gateway can be discovered at all: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestF13_UpsertStillAcceptsInClusterEndpoint guards the scope decision above.
+// If someone later "hardens" validateGatewayEndpoint itself, in-cluster gateway
+// configuration breaks — this test says so explicitly rather than letting a
+// real deployment discover it.
+func TestF13_UpsertStillAcceptsInClusterEndpoint(t *testing.T) {
+	for _, ep := range []string{
+		"http://127.0.0.1:18445",                                     // bundled local litellm proxy
+		"http://hive-vllm-svc.hive-inference.svc.cluster.local:8000", // HIVE_VLLM_ENDPOINT default
+		"http://10.0.0.5:4000",                                       // in-cluster LiteLLM
+	} {
+		if err := validateGatewayEndpoint(ep); err != nil {
+			t.Errorf("validateGatewayEndpoint(%q) = %v, want nil — in-cluster gateways "+
+				"are a supported configuration and must stay configurable", ep, err)
+		}
+	}
+}
+
+// TestF13_RedirectDropsAuthorizationCrossHost pins sub-fix 4. Go's default
+// redirect policy preserves Authorization across hops it considers same-host and
+// follows up to 10 of them, so an upstream answering /v1/models with a 302 could
+// walk the gateway key onward. fetchModelsWithHeaders had no CheckRedirect at
+// all.
+func TestF13_RedirectDropsAuthorizationCrossHost(t *testing.T) {
+	var finalSaw []string
+	final := captureAuthServer(t, &finalSaw)
+
+	// The first hop redirects to a DIFFERENT host.
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL+"/v1/models", http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	treatAsPublic(t, redirector.URL, final.URL)
+
+	const secret = "sk-redirect-must-not-follow"
+	if _, err := fetchModelsWithHeaders(redirector.URL, secret, nil); err != nil {
+		// A refusal to follow is an equally acceptable outcome; the assertion
+		// that matters is that the key never reached the second host.
+		t.Logf("fetch returned error (redirect refused): %v", err)
+	}
+
+	for _, auth := range finalSaw {
+		if strings.Contains(auth, secret) {
+			t.Fatalf("F13: Authorization survived a cross-host redirect and leaked "+
+				"the key to another host (got %q)", auth)
+		}
+	}
+}
+
+// TestF13_RedirectKeepsAuthorizationSameHost is the POSITIVE CONTROL for the
+// redirect fix: stripping credentials on EVERY redirect would pass the test
+// above while breaking upstreams that legitimately redirect in-place (trailing
+// slash, path normalization).
+func TestF13_RedirectKeepsAuthorizationSameHost(t *testing.T) {
+	var saw []string
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		saw = append(saw, r.Header.Get("Authorization"))
+		if r.URL.Path == "/v1/models" {
+			// Same-host redirect to a normalized path.
+			http.Redirect(w, r, "/models-final", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m1"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	treatAsPublic(t, srv.URL)
+
+	const secret = "sk-same-host-ok"
+	models, err := fetchModelsWithHeaders(srv.URL, secret, nil)
+	if err != nil {
+		t.Fatalf("same-host redirect should still succeed: %v", err)
+	}
+	if len(models) != 1 || models[0] != "m1" {
+		t.Errorf("models = %v, want [m1]", models)
+	}
+	if len(saw) < 2 || saw[len(saw)-1] != "Bearer "+secret {
+		t.Errorf("Authorization was dropped on a SAME-host redirect (saw %q) — "+
+			"legitimate in-place redirects would break", saw)
+	}
+}
+
+// TestF13_DiscoverErrorDoesNotEchoStoredKey checks the error path does not turn
+// into a slower oracle for the same secret.
+func TestF13_DiscoverErrorDoesNotEchoStoredKey(t *testing.T) {
+	s, deps := apiServer(t)
+
+	failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized: "+r.Header.Get("Authorization"), http.StatusUnauthorized)
+	}))
+	t.Cleanup(failing.Close)
+
+	secret := storedKeyGateway(t, deps, failing.URL)
+	treatAsPublic(t, failing.URL)
+
+	rec := doPost(s, "/api/config/governor/gateways/discover", map[string]interface{}{
+		"name":     "stored",
+		"endpoint": failing.URL,
+	})
+	body := rec.Body.String()
+	if strings.Contains(body, secret) {
+		t.Fatalf("discover error response echoed the stored key: %s", body)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &parsed); err == nil {
+		if ok, _ := parsed["ok"].(bool); ok {
+			t.Logf("discover reported ok on an upstream 401 (informational)")
+		}
+	}
+}

--- a/v2/pkg/dashboard/ssrf_guard.go
+++ b/v2/pkg/dashboard/ssrf_guard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 const ssrfMaxRedirects = 3
@@ -27,5 +28,31 @@ func noRedirectToPrivate(req *http.Request, via []*http.Request) error {
 	if isPrivateURL(context.Background(), req.URL.String()) {
 		return fmt.Errorf("redirect to private/internal host blocked: %s", req.URL.Host)
 	}
+	stripAuthOnCrossHostRedirect(req, via)
 	return nil
+}
+
+// stripAuthOnCrossHostRedirect removes credential headers from a redirect hop
+// that changes host (audit F13).
+//
+// Blocking private redirect targets is not sufficient on its own: Go PRESERVES
+// the Authorization header across hops it considers same-host, and a redirect
+// from one PUBLIC host to another public host it does not. Without this, an
+// upstream answering /v1/models with "302 → attacker.example" walks the gateway
+// API key straight to the attacker — the credential leaves with the request
+// before any response is inspected.
+//
+// Comparing Host (not the full URL) keeps legitimate same-host redirects —
+// http→https upgrades, path normalization, trailing-slash fixes — working with
+// credentials intact, which is what upstreams actually do.
+func stripAuthOnCrossHostRedirect(req *http.Request, via []*http.Request) {
+	if len(via) == 0 {
+		return
+	}
+	if strings.EqualFold(req.URL.Host, via[0].URL.Host) {
+		return
+	}
+	for _, h := range []string{"Authorization", "Proxy-Authorization", "Cookie", "X-IBM-Project-ID"} {
+		req.Header.Del(h)
+	}
 }

--- a/v2/pkg/dashboard/watsonx_gateway_test.go
+++ b/v2/pkg/dashboard/watsonx_gateway_test.go
@@ -270,6 +270,10 @@ func TestWatsonxDiscover_InvalidKeyReturnsNoModels(t *testing.T) {
 	body := `{"name":"watsonx","kind":"watsonx","endpoint":"https://public.example/ml/gateway","project_id":"p","api_key":"bad-key-1234567890"}`
 	req := httptest.NewRequest("POST", "/api/config/governor/gateways/discover", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	// Discover is owner-gated (audit F13); these tests exercise the watsonx
+	// verdict logic BEHIND that gate, so they authenticate like the upsert tests
+	// in this file already do.
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleGovernorGatewaysDiscover(w, req)
 	if w.Code != http.StatusOK {
@@ -318,6 +322,10 @@ func TestWatsonxDiscover_ValidKeyListingFailureFallsBack(t *testing.T) {
 	body := `{"name":"watsonx","kind":"watsonx","endpoint":"https://public.example/ml/gateway","project_id":"p","api_key":"good-key-1234567890"}`
 	req := httptest.NewRequest("POST", "/api/config/governor/gateways/discover", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	// Discover is owner-gated (audit F13); these tests exercise the watsonx
+	// verdict logic BEHIND that gate, so they authenticate like the upsert tests
+	// in this file already do.
+	markOwnerRequest(req)
 	w := httptest.NewRecorder()
 	srv.handleGovernorGatewaysDiscover(w, req)
 	var out struct {


### PR DESCRIPTION
## Summary

The gateway **discover** endpoint exfiltrated a stored API key to any endpoint the caller named, and doubled as a full SSRF primitive.

`handleGovernorGatewaysDiscover` had **no role gate**; when the request body's `api_key` was empty it loaded the **stored** key via `ResolveAPIKey()` and sent it as a bearer to an endpoint taken from **the same request body**. A read-write member — or an unauthenticated caller on an open spoke — could name any gateway plus any endpoint they controlled and receive the stored key.

## This is a three-audit survivor, not a new finding

The 2026-08-13 audit labels F13 "NEW". It is the **same defect** as **N8** (2026-08-07) and **F6** (2026-08-11). Both were fixed on the gateway **upsert** handler and never on this sibling call site. The fix was applied to one call site and missed the other.

To stop a fourth recurrence I grepped every `ResolveAPIKey` call site in `pkg/dashboard`. All the others — gateways test/probe, `cost.go`, `openrouter.go`, `api.go` (litellm section + backend model discovery) — use the gateway's **own stored** `Endpoint`, never a caller-supplied one. **Discover was the only exfiltration primitive.**

## The four fixes

**1. Gate it** — `requireOwnerRole` on discover, matching every other gateway route.

**2. Stop the exfil** — the stored key is used **only** when the caller-supplied endpoint matches the gateway's **own persisted endpoint** (canonicalised for scheme/host case, default ports, trailing slash; userinfo must match, so `https://evil@gw.example` is not `https://gw.example`). That address already receives this key on every agent request, so probing it discloses nothing new. Any other endpoint requires the caller's own key. `kind`/`project_id` aren't secrets and still fall back freely.

**3. Harden the discover target** — `guardDiscoverEndpoint` rejects loopback, RFC1918, link-local (incl. `169.254.169.254`) and unresolvable hosts, **resolved via DNS** rather than string-matched, **failing closed** on resolution error. Reuses the package's existing `isPrivateURL` helper (the same approach as `gitsource.go`'s `ValidateGitSourceURLContext`, already mirrored into this package).

> **Scope note — deliberate, and easy to "fix" wrongly.** This guard is **not** in `validateGatewayEndpoint`, which also guards **upsert**. In-cluster gateways are a supported, documented configuration: the bundled litellm proxy is `http://127.0.0.1:18445` and vllm/llm-d default to `*.svc.cluster.local` (`HIVE_VLLM_ENDPOINT`). Blanket private-address denial there would break real deployments — which is exactly why the F6 fix explicitly rejected it as the remedy. Discover is a caller-driven fetch that only populates a dropdown, so it can afford to be strict; in-cluster gateways stay configurable through upsert + the test action, which probe a **persisted** endpoint an owner already committed to. `TestF13_UpsertStillAcceptsInClusterEndpoint` pins this so a later "hardening" can't silently break it.

**4. Kill redirect credential leakage** — `fetchModelsWithHeaders` built a bare `&http.Client{}` with **no `CheckRedirect`**, so Go followed up to 10 redirects and preserved `Authorization`. It now uses `noRedirectToPrivate` — which the sibling `probeModelsWithHeaders` already used and this one simply missed. `noRedirectToPrivate` additionally strips `Authorization`/`Proxy-Authorization`/`Cookie`/`X-IBM-Project-ID` on any **host-changing** hop, because blocking private targets alone still let a public→public redirect walk the key onward.

## Tests

`v2/pkg/dashboard/gateways_discover_ssrf_test.go` — all assert on **what the outbound request actually carried** (via `httptest`, no real network), not on the handler's response, since the leak happens on the wire.

| Test | Pins |
|---|---|
| `TestF13_DiscoverRequiresOwnerRole` | fix 1 |
| `TestF13_DiscoverDoesNotSendStoredKeyToCallerEndpoint` | fix 2 (core regression) |
| `TestF13_DiscoverUsesStoredKeyForOwnEndpoint` | fix 2 **positive control** |
| `TestF13_SameGatewayEndpoint` | canonicalisation, match + no-match tables |
| `TestF13_DiscoverRejectsInternalEndpoints` | fix 3 (loopback, metadata, all RFC1918, `::1`, `0.0.0.0`) |
| `TestF13_DiscoverAcceptsPublicEndpoint` | fix 3 **positive control** |
| `TestF13_UpsertStillAcceptsInClusterEndpoint` | scope guard for the note above |
| `TestF13_RedirectDropsAuthorizationCrossHost` | fix 4 |
| `TestF13_RedirectKeepsAuthorizationSameHost` | fix 4 **positive control** |
| `TestF13_DiscoverErrorDoesNotEchoStoredKey` | error path isn't a slower oracle |

Every guard has a positive control, so "reject everything" cannot pass.

A test-only seam (`privateURLTestExemptHostPorts`, empty in production, host:port entries only) lets `httptest` servers — which always bind `127.0.0.1` — be treated as public. Without it these tests would have passed because the request was blocked as loopback rather than because the credential logic is correct: **passing for the wrong reason.** `TestF13_RedirectDropsAuthorizationCrossHost` initially did exactly that, and the seam is what exposed it.

## Regression replay

Each protection was neutered one at a time (still compiling) and the corresponding test confirmed failing, then restored green:

| Neutered | Failing test |
|---|---|
| `requireOwnerRole` removed | `TestF13_DiscoverRequiresOwnerRole` |
| endpoint-match dropped (exact pre-fix behaviour) | `TestF13_DiscoverDoesNotSendStoredKeyToCallerEndpoint` |
| private-address check removed | `TestF13_DiscoverRejectsInternalEndpoints` |
| cross-host auth strip removed | `TestF13_RedirectDropsAuthorizationCrossHost` |
| `CheckRedirect` removed entirely (pre-fix state) | `TestF13_RedirectDropsAuthorizationCrossHost` |

Restored: `go build ./...` clean, full `./pkg/dashboard/` package green (50s).

## Note on two pre-existing tests

`TestWatsonxDiscover_InvalidKeyReturnsNoModels` and `TestWatsonxDiscover_ValidKeyListingFailureFallsBack` called the discover handler directly without owner headers, so they 403'd once the gate landed. They exercise watsonx **verdict** logic behind the gate, so they now call `markOwnerRequest` — as the upsert tests in that same file already did. No behaviour under test changed.