### PR TITLE
🐛 fix(hub): cover the behind-tip upgrade case and make the Upgrading pill order-independent

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10343,13 +10343,71 @@ const dashboardHTML = `<!DOCTYPE html>
       var sentinel = _upgradingHives[h.id];
       var sha = h.gitHash || '';
       if (sentinel && sha === sentinel) return true;
-      /* Hub-reported. Suppressed when the hive is ALREADY at latest (the latch
-         is stale — exactly the server-side bug this pairs with) or when latest
-         is unresolved, because the row suppresses the spinner in both cases and
-         the pill must match. */
+      /* Hub-reported. Suppressed when latest is unresolved, because the row
+         suppresses the spinner then too and the pill must match.
+
+         NOT suppressed merely because the hive reads as "current". The fleet
+         runs floating TAGS (v4-latest) while the hub tracks progress by git
+         SHA, so 'isCurrent' is a SHA comparison against the branch tip and a
+         spoke can sit behind the tip for many minutes with its tag unchanged
+         and zero Kubernetes-visible drift. Suppressing on isCurrent was only
+         ever a client-side patch over the stale server latch that the
+         stale_upgrade.go convergence sweep now clears at the source; keeping it
+         here would re-hide genuinely in-flight upgrades. */
       var latestUnknown = !branchLatest;
-      var isCurrent = !!branchLatest && sameShaJS(sha, branchLatest);
-      return !!(h.upgrading && !isCurrent && !latestUnknown);
+      if (latestUnknown) return false;
+      if (h.upgrading) return true;
+      /* Behind the branch tip with a target ALREADY armed by the hub. The hub
+         has instructed this SHA and is waiting for the spoke to report it, so
+         the rollout is in flight even before 'upgrading' latches — this is the
+         window that made the pill under-report against a moving tag. A hive
+         that is behind with NO armed target is not upgrading; it is "queued"
+         (auto-upgrade on) or simply out of date, and both are other states. */
+      var isCurrent = sameShaJS(sha, branchLatest);
+      if (!isCurrent && h.upgradeTarget && !h.autoUpgrade &&
+          !sameShaJS(sha, h.upgradeTarget)) {
+        return true;
+      }
+      return false;
+    }
+
+    /* normalizeUpgradeState expires the client-side sentinels for ONE hive.
+       It is the only writer of _upgradingHives during a render.
+
+       This has to run over the whole list BEFORE anything filters, counts or
+       draws, because _upgradingHives is global mutable state that
+       hiveIsUpgradingNow reads. While expiry lived inside the row loop, the
+       facet counter and applyDashFilters — both of which run first, over every
+       hive — saw a different map than the rows did, so the pill and the badge
+       could disagree even though they now call the same predicate. Sharing a
+       function only guarantees agreement if it is also given the same inputs.
+
+       Returns nothing; callers re-read _upgradingHives through the predicate. */
+    function normalizeUpgradeState(h) {
+      if (!h) return;
+      var branchName = h.gitBranch || 'v2';
+      var st = hiveSwitchState(h, branchName);
+      /* A switch sentinel that no longer resolves to a switch (the target
+         became a same-branch SHA) is stale and must not force upgrading. */
+      if (st.switchSentinelStale) {
+        delete _upgradingHives[h.id];
+        delete _switchStartedAt[h.id];
+        return;
+      }
+      if (st.isSwitching) return;
+      /* The hive has moved off the SHA it carried when Upgrade was clicked, so
+         the click has landed and the sentinel has done its job. */
+      var sentinel = _upgradingHives[h.id];
+      if (sentinel && (h.gitHash || '') !== sentinel) {
+        delete _upgradingHives[h.id];
+        delete _switchStartedAt[h.id];
+      }
+    }
+
+    /* normalizeUpgradeStates applies the above across the fleet. Called at the
+       top of renderHives, ahead of every filter, facet count and row. */
+    function normalizeUpgradeStates(hives) {
+      for (var i = 0; i < (hives || []).length; i++) normalizeUpgradeState(hives[i]);
     }
 
     function hiveUpgradeState(h) {
@@ -13320,6 +13378,11 @@ const dashboardHTML = `<!DOCTYPE html>
       for (var _si = 0; _si < allHives.length; _si++) {
         (isPlaceholderHive(allHives[_si]) ? unassignedAll : assignedAll).push(allHives[_si]);
       }
+      /* Expire client-side upgrade sentinels ONCE, before anything reads them.
+         Filtering, facet counting and row drawing are all pure readers of
+         _upgradingHives from here on, so they cannot observe each other's
+         mutations and the pill can no longer disagree with the badge. */
+      normalizeUpgradeStates(assignedAll);
       var hives = applyDashFilters(assignedAll).concat(unassignedAll);
       var filterBar = document.getElementById('hive-filter-bar');
       if (filterBar) filterBar.style.display = allHives.length ? '' : 'none';
@@ -13557,16 +13620,19 @@ const dashboardHTML = `<!DOCTYPE html>
           var upgradeState = hiveSwitchState(h, branchName);
           var isSwitching = upgradeState.isSwitching;
           var targetBranch = upgradeState.targetBranch;
-          /* Drop a stale switch sentinel (resolved to a same-branch SHA) so it
-             stops forcing the upgrading state on later auto-upgrades. */
-          if (upgradeState.switchSentinelStale) delete _upgradingHives[h.id];
-          var sentinel = _upgradingHives[h.id];
+          /* Sentinel expiry used to happen HERE, mid-render. That is what kept
+             the pill and the badge disagreeing even after they were given a
+             shared predicate: applyDashFilters (and the facet counter) run over
+             the whole list BEFORE this loop body executes for any row, so the
+             pill read the pre-expiry sentinel map while the row read the
+             post-expiry one — and on the next paint the pill read a map mutated
+             by the PREVIOUS render. Same function, different inputs, different
+             answers. Expiry now happens in normalizeUpgradeState(), once, ahead
+             of filtering; this loop is a pure reader. */
           /* ONE predicate, shared with the filter pill (hiveUpgradeState ->
              hiveIsUpgradingNow), so a spinning row is always matched by the
              "Upgrading" facet and vice versa. */
           var isUpgrading = hiveIsUpgradingNow(h, branchName, branchLatest);
-          if (sentinel && sha !== sentinel && !isSwitching) { delete _upgradingHives[h.id]; delete _switchStartedAt[h.id]; }
-          if (isCurrent && h.upgrading && !isSwitching) { h.upgrading = false; }
           var imageBuilding = (_latestImageStatus[branchName] || '') === 'building';
           var buildingHint = imageBuilding ? ' (image still building — upgrading now pulls the previous image)' : '';
           var status = latestUnknown

--- a/v2/pkg/hub/upgrade_filter_agreement_test.go
+++ b/v2/pkg/hub/upgrade_filter_agreement_test.go
@@ -1,0 +1,356 @@
+package hub
+
+import (
+	"encoding/json"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The "Upgrading" filter pill and the row's Upgrading badge are two readers of
+// one question: is this hive upgrading right now? They disagreed in production
+// — spokes visibly badged "Upgrading" were not matched when the operator
+// clicked the pill.
+//
+// These tests execute the REAL shipped predicate out of dashboardHTML under
+// node, rather than re-implementing it in Go. A Go re-implementation would be a
+// second copy of the logic and could agree with itself perfectly while the
+// shipped dashboard stayed broken — precisely the failure mode being fixed.
+//
+// Everything below drives hiveIsUpgradingNow / hiveUpgradeState /
+// normalizeUpgradeState as extracted from the source of truth.
+
+// jsFunc slices one top-level `function NAME(` ... matching-brace block out of
+// dashboardHTML. Brace matching is string- and comment-aware enough for this
+// file's style; if it ever mis-slices, node --check fails loudly in the test
+// rather than silently testing the wrong text.
+func jsFunc(t *testing.T, name string) string {
+	t.Helper()
+	re := regexp.MustCompile(`(?m)^ {4}function ` + regexp.QuoteMeta(name) + `\s*\(`)
+	loc := re.FindStringIndex(dashboardHTML)
+	if loc == nil {
+		t.Fatalf("function %s not found in dashboardHTML — the predicate under test "+
+			"was renamed or removed; update this test deliberately, do not delete it", name)
+	}
+	src := dashboardHTML[loc[0]:]
+	// Advance to the body's opening brace, then match to its close.
+	open := strings.Index(src, "{")
+	if open < 0 {
+		t.Fatalf("function %s has no body", name)
+	}
+	depth, inStr, inLine, inBlock := 0, byte(0), false, false
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		switch {
+		case inLine:
+			if c == '\n' {
+				inLine = false
+			}
+		case inBlock:
+			if c == '*' && i+1 < len(src) && src[i+1] == '/' {
+				inBlock, i = false, i+1
+			}
+		case inStr != 0:
+			if c == '\\' {
+				i++
+			} else if c == inStr {
+				inStr = 0
+			}
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			inLine, i = true, i+1
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			inBlock, i = true, i+1
+		case c == '\'' || c == '"':
+			inStr = c
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return src[:i+1]
+			}
+		}
+	}
+	t.Fatalf("unbalanced braces slicing function %s", name)
+	return ""
+}
+
+// upgradeHarness is the shipped predicate plus the exact globals it closes
+// over, with no behavioural stand-ins: every function below is the real source.
+func upgradeHarness(t *testing.T) string {
+	t.Helper()
+	return strings.Join([]string{
+		"var SWITCH_SENTINEL_PREFIX = 'switch:';",
+		"var BRANCH_TARGET_SUFFIX = '-latest';",
+		"var UPGRADE_FILTER_UPGRADING = 'upgrading';",
+		"var UPGRADE_FILTER_QUEUED = 'queued';",
+		"var _latestSHA = '';",
+		"var _latestSHAs = {};",
+		"var _upgradingHives = {};",
+		"var _switchStartedAt = {};",
+		jsFunc(t, "sameShaJS"),
+		jsFunc(t, "hiveSwitchState"),
+		jsFunc(t, "hiveIsUpgradingNow"),
+		jsFunc(t, "normalizeUpgradeState"),
+		jsFunc(t, "normalizeUpgradeStates"),
+		jsFunc(t, "hiveUpgradeState"),
+	}, "\n")
+}
+
+// runUpgradeJS evaluates body (which must assign to `result`) against the
+// harness and unmarshals the JSON it prints.
+func runUpgradeJS(t *testing.T, body string, out interface{}) {
+	t.Helper()
+	src := upgradeHarness(t) + "\nvar result;\n" + body +
+		"\nprocess.stdout.write(JSON.stringify(result));\n"
+	cmd := exec.Command("node", "-e", src)
+	stdout, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("node failed: %v\nstderr:\n%s", err, ee.Stderr)
+		}
+		t.Skipf("node unavailable: %v", err)
+	}
+	if err := json.Unmarshal(stdout, out); err != nil {
+		t.Fatalf("bad JSON from node: %v\ngot: %s", err, stdout)
+	}
+}
+
+// upgFixture is one hive as the dashboard JSON delivers it, plus the client
+// state that exists only in the browser.
+type upgFixture struct {
+	name string
+	// hive is the hive object literal (JS source).
+	hive string
+	// latestSHAs seeds _latestSHAs.
+	latestSHAs string
+	// sentinel, when non-empty, seeds _upgradingHives[id].
+	sentinel string
+	// wantUpgrading is the expected answer from the SHARED predicate, which is
+	// simultaneously the pill's classification and the row's badge.
+	wantUpgrading bool
+	// wantState is the expected hiveUpgradeState value.
+	wantState string
+	why       string
+}
+
+func upgradeFixtures() []upgFixture {
+	const latest = `{"v4":"aaaaaaa"}`
+	return []upgFixture{
+		{
+			name:          "armed latch in flight",
+			hive:          `{id:'h1',gitBranch:'v4',gitHash:'bbbbbbb',upgrading:true,upgradeTarget:'aaaaaaa'}`,
+			latestSHAs:    latest,
+			wantUpgrading: true,
+			wantState:     "upgrading",
+			why:           "the hub says a rollout is in flight; both surfaces must show it",
+		},
+		{
+			// The operator's case. Floating v4-latest tag, hub tracks git SHA.
+			name:          "behind branch tip with an armed target, no latch yet",
+			hive:          `{id:'h2',gitBranch:'v4',gitHash:'bbbbbbb',upgrading:false,upgradeTarget:'aaaaaaa'}`,
+			latestSHAs:    latest,
+			wantUpgrading: true,
+			wantState:     "upgrading",
+			why: "the hub has instructed this SHA and is waiting for the spoke to " +
+				"report it — in flight before the latch sets",
+		},
+		{
+			// POSITIVE CONTROL. Without this an always-true predicate passes
+			// every other case in this table.
+			name:          "at latest, nothing armed",
+			hive:          `{id:'h3',gitBranch:'v4',gitHash:'aaaaaaa',upgrading:false}`,
+			latestSHAs:    latest,
+			wantUpgrading: false,
+			wantState:     "",
+			why:           "settled hive: neither surface may claim an upgrade",
+		},
+		{
+			name:          "behind with auto-upgrade on and a target: queued, not upgrading",
+			hive:          `{id:'h4',gitBranch:'v4',gitHash:'bbbbbbb',upgrading:false,autoUpgrade:true,upgradeTarget:'aaaaaaa'}`,
+			latestSHAs:    latest,
+			wantUpgrading: false,
+			wantState:     "queued",
+			why:           "waiting on the auto-upgrade window is a distinct state",
+		},
+		{
+			name:          "branch switch in flight",
+			hive:          `{id:'h5',gitBranch:'v4',gitHash:'bbbbbbb',upgrading:false,upgradeTarget:'v2-latest'}`,
+			latestSHAs:    latest,
+			wantUpgrading: true,
+			wantState:     "upgrading",
+			why:           "the spoke reports the OLD branch until the new pod beats",
+		},
+		{
+			name:          "just-clicked sentinel, hive still on the pre-click SHA",
+			hive:          `{id:'h6',gitBranch:'v4',gitHash:'bbbbbbb',upgrading:false}`,
+			latestSHAs:    latest,
+			sentinel:      "bbbbbbb",
+			wantUpgrading: true,
+			wantState:     "upgrading",
+			why:           "the row spins on the click before the hub latches",
+		},
+		{
+			name:          "latest unresolved",
+			hive:          `{id:'h7',gitBranch:'v4',gitHash:'bbbbbbb',upgrading:true,upgradeTarget:'aaaaaaa'}`,
+			latestSHAs:    `{}`,
+			wantUpgrading: false,
+			wantState:     "",
+			why:           "the row suppresses the spinner while resolving; the pill must too",
+		},
+	}
+}
+
+// jsSetup renders the per-fixture globals.
+func (f upgFixture) jsSetup() string {
+	s := "_latestSHAs = " + f.latestSHAs + ";\nvar h = " + f.hive + ";\n"
+	if f.sentinel != "" {
+		s += "_upgradingHives[h.id] = " + jsStr(f.sentinel) + ";\n"
+	}
+	return s
+}
+
+func jsStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// TestUpgradingPredicateCases pins the shared predicate's answer per state,
+// including the positive control that keeps "always true" from passing.
+func TestUpgradingPredicateCases(t *testing.T) {
+	for _, f := range upgradeFixtures() {
+		t.Run(f.name, func(t *testing.T) {
+			var got struct {
+				Upgrading bool   `json:"u"`
+				State     string `json:"s"`
+			}
+			runUpgradeJS(t, f.jsSetup()+
+				"normalizeUpgradeState(h);\n"+
+				"result = {u: hiveIsUpgradingNow(h, h.gitBranch, _latestSHAs[h.gitBranch] || ''), s: hiveUpgradeState(h)};",
+				&got)
+			if got.Upgrading != f.wantUpgrading {
+				t.Errorf("hiveIsUpgradingNow = %v, want %v — %s", got.Upgrading, f.wantUpgrading, f.why)
+			}
+			if got.State != f.wantState {
+				t.Errorf("hiveUpgradeState = %q, want %q — %s", got.State, f.wantState, f.why)
+			}
+		})
+	}
+}
+
+// TestPillAndBadgeAgree is the invariant that was violated in production: for
+// the SAME fixture, what the filter pill classifies and what the row badge
+// draws must be the same answer, in every state.
+//
+// The pill path is hiveUpgradeState(h) with no resolved branch args — it
+// iterates raw hives. The row path passes the branch values it already
+// resolved. Those two call shapes are exactly where the old code diverged, so
+// the test drives both and compares.
+func TestPillAndBadgeAgree(t *testing.T) {
+	for _, f := range upgradeFixtures() {
+		t.Run(f.name, func(t *testing.T) {
+			var got struct {
+				Pill bool `json:"pill"`
+				Row  bool `json:"row"`
+			}
+			runUpgradeJS(t, f.jsSetup()+
+				"normalizeUpgradeState(h);\n"+
+				// Pill: the facet counter's call shape (no resolved args).
+				"var pill = hiveUpgradeState(h) === UPGRADE_FILTER_UPGRADING;\n"+
+				// Row: the render loop's call shape (resolved args).
+				"var bn = h.gitBranch || 'v2';\n"+
+				"var bl = _latestSHAs[bn] || _latestSHA;\n"+
+				"var row = hiveIsUpgradingNow(h, bn, bl);\n"+
+				"result = {pill: pill, row: row};",
+				&got)
+			if got.Pill != got.Row {
+				t.Errorf("pill=%v but row badge=%v for the same hive — the filter and "+
+					"the list disagree, which is the reported bug", got.Pill, got.Row)
+			}
+			if got.Row != f.wantUpgrading {
+				t.Errorf("agreed on %v but both are wrong, want %v — %s",
+					got.Row, f.wantUpgrading, f.why)
+			}
+		})
+	}
+}
+
+// TestSentinelExpiryIsOrderIndependent is the ordering fix.
+//
+// applyDashFilters and the facet counter sweep the WHOLE list before the row
+// loop draws anything. While sentinel expiry lived in the row loop, the pill
+// read the map pre-expiry and the row read it post-expiry, so a hive whose
+// sentinel had just gone stale was counted by the pill and not badged by the
+// row (and vice versa on the following paint). Normalizing first makes the
+// answer identical no matter which surface asks, and asking twice must not
+// change it either.
+func TestSentinelExpiryIsOrderIndependent(t *testing.T) {
+	var got struct {
+		PillBefore bool `json:"pb"`
+		RowAfter   bool `json:"ra"`
+		PillAgain  bool `json:"pa"`
+	}
+	// The hive has MOVED OFF the SHA the sentinel was armed with: the click has
+	// landed, so the sentinel is stale and nothing is upgrading.
+	runUpgradeJS(t,
+		"_latestSHAs = {v4:'aaaaaaa'};\n"+
+			"var h = {id:'h9',gitBranch:'v4',gitHash:'aaaaaaa',upgrading:false};\n"+
+			"_upgradingHives[h.id] = 'bbbbbbb';\n"+
+			// renderHives normalizes the whole list up front...
+			"normalizeUpgradeStates([h]);\n"+
+			// ...then the pill counts...
+			"var pb = hiveUpgradeState(h) === UPGRADE_FILTER_UPGRADING;\n"+
+			// ...then the row draws...
+			"var ra = hiveIsUpgradingNow(h, 'v4', _latestSHAs.v4);\n"+
+			// ...and a second paint must not flip anything.
+			"normalizeUpgradeStates([h]);\n"+
+			"var pa = hiveUpgradeState(h) === UPGRADE_FILTER_UPGRADING;\n"+
+			"result = {pb: pb, ra: ra, pa: pa};",
+		&got)
+	if got.PillBefore || got.RowAfter {
+		t.Errorf("stale sentinel still reads as upgrading: pill=%v row=%v — "+
+			"expiry did not run ahead of the readers", got.PillBefore, got.RowAfter)
+	}
+	if got.PillBefore != got.RowAfter {
+		t.Errorf("pill=%v row=%v — order-dependent divergence is back",
+			got.PillBefore, got.RowAfter)
+	}
+	if got.PillAgain != got.PillBefore {
+		t.Errorf("second paint changed the answer (%v -> %v) — normalization is not idempotent",
+			got.PillBefore, got.PillAgain)
+	}
+}
+
+// The row loop must not mutate the sentinel maps: that is what reintroduces the
+// order dependency. Guard the source directly, because a re-introduced
+// `delete _upgradingHives[...]` inside the render loop would pass every
+// behavioural test above (which normalizes explicitly) and still ship the bug.
+func TestRowLoopDoesNotMutateUpgradeSentinels(t *testing.T) {
+	start := strings.Index(dashboardHTML, "var isUpgrading = hiveIsUpgradingNow(")
+	if start < 0 {
+		t.Fatal("row-loop call to hiveIsUpgradingNow not found — update this guard deliberately")
+	}
+	// Look at the render block around the badge decision.
+	lo := start - 2000
+	if lo < 0 {
+		lo = 0
+	}
+	hi := start + 2000
+	if hi > len(dashboardHTML) {
+		hi = len(dashboardHTML)
+	}
+	window := dashboardHTML[lo:hi]
+	for _, bad := range []string{
+		"delete _upgradingHives[h.id]",
+		"delete _switchStartedAt[h.id]",
+		"h.upgrading = false",
+	} {
+		if strings.Contains(window, bad) {
+			t.Errorf("row render mutates shared upgrade state (%q). The filter pill and "+
+				"the facet counter run over the whole list BEFORE this loop, so mutating "+
+				"here makes them read different inputs than the rows and the pill "+
+				"under-reports again. Expire sentinels in normalizeUpgradeState instead.", bad)
+		}
+	}
+}


### PR DESCRIPTION
## Depends on #3712

Branched from `fix/upgrading-state-stale`, so this diff **contains** #3712's commit. Merge #3712 first, or merge this and close #3712 as subsumed. Reviewing only the second commit shows my changes.

## Does #3712 fix the pill?

**Partially.** It correctly identified that the pill tested only `h.upgrading` while the row OR'd three sources, and extracting `hiveIsUpgradingNow` was the right move. But the operator kept seeing misses, and there were two reasons.

### Gap 1 — the behind-tip case was never covered, by *either* surface

The fleet runs the floating `v4-latest` **tag**; the hub tracks upgrade progress by **git SHA**. So a spoke sits several SHAs behind the branch tip with its tag unchanged and **zero Kubernetes-visible drift** — `spec.image == status.image == v4-latest`. Scanning every hive for spec-vs-running image mismatch finds nothing while the hub legitimately shows hives upgrading. `hosted-available-vllmd-04` showed "Upgrading" on `815d7e4` for 35+ minutes with its pod ready on `v4-latest`.

#3712 kept the row's `isCurrent -> not really upgrading` suppression and *promoted it into the shared predicate*. Since `isCurrent` is a SHA comparison against the branch tip, that suppression hides precisely the spokes that are genuinely mid-rollout. It was only ever a client-side patch over the stale server latch — which #3712's own `stale_upgrade.go` convergence sweep now clears at the source, making it both redundant and harmful.

### Gap 2 — a shared predicate doesn't help if the callers feed it different inputs

This is the one that made #3712 incomplete on its own terms. `applyDashFilters` and the facet counter sweep the **whole list** before the row loop draws its first row. The row loop was **mutating the very globals the predicate reads**:

```js
if (upgradeState.switchSentinelStale) delete _upgradingHives[h.id];
if (sentinel && sha !== sentinel && !isSwitching) { delete _upgradingHives[h.id]; delete _switchStartedAt[h.id]; }
if (isCurrent && h.upgrading && !isSwitching) { h.upgrading = false; }
```

The pill read the map **pre**-expiry; the rows read it **post**-expiry. On the next paint the pill read a map mutated by the *previous* render. Same function, different inputs, different answers — order-dependent divergence that sharing a function cannot fix.

## The fix

- **Behind-tip coverage**: dropped the `isCurrent` suppression. A hive behind the tip with a target **already armed by the hub** now reads as upgrading.
- **Ordering**: sentinel expiry moves into `normalizeUpgradeState()`, applied fleet-wide by `normalizeUpgradeStates()` at the top of `renderHives`, ahead of every filter, count and row. The predicate is now pure; every surface is a reader.

## Decision on case 2 (behind latest, no latch armed)

**Behind + armed target + not auto-upgrade → upgrading. Behind + nothing armed → NOT upgrading.**

An armed `upgradeTarget` means the hub has *instructed* that SHA and is waiting for the spoke to report it — that is a rollout in flight, and it is the window that made the pill under-report against a moving tag. But "behind" alone is not an upgrade; that is just out-of-date, and with `autoUpgrade` on it is the existing **queued** state. Treating bare "behind" as upgrading would light up every lagging spoke permanently and make the facet's stuck-counter meaningless.

## Tests

Executing the **real shipped predicate** out of `dashboardHTML` under `node`, not a Go re-implementation — a Go copy could agree with itself perfectly while the shipped dashboard stayed broken, which is the exact failure mode here.

| Test | Covers |
|---|---|
| `TestUpgradingPredicateCases` | per-state answers, incl. the **positive control** `at latest, nothing armed` |
| `TestPillAndBadgeAgree` | the violated invariant, driven through **both** call shapes |
| `TestSentinelExpiryIsOrderIndependent` | normalization precedes readers; idempotent across paints |
| `TestRowLoopDoesNotMutateUpgradeSentinels` | source guard — a re-introduced mutation passes every behavioural test and still ships the bug |

### Regression replay

| Neutering | Failures |
|---|---|
| drop the behind-tip branch | `TestUpgradingPredicateCases/behind_branch_tip_with_an_armed_target,_no_latch_yet`, `TestPillAndBadgeAgree/behind_branch_tip_...` — *only* those |
| re-add row-loop mutation | `TestRowLoopDoesNotMutateUpgradeSentinels` — *only* that |
| force predicate `true` | `at_latest,_nothing_armed`, `behind_with_auto-upgrade_on...`, `latest_unresolved` — *only* those |

**No existing test was modified.** `go build ./...` clean, `node --check` clean on the extracted JS, full `pkg/hub` suite green (66.9s).