### PR TITLE
🔒 fix(backup): namespace-scope backup Secret access + digest-pin CronJob image

### DIFF
--- a/v2/deploy/k8s/backup-cronjob.yaml
+++ b/v2/deploy/k8s/backup-cronjob.yaml
@@ -15,9 +15,48 @@ metadata:
   name: hive-hub-backup
   namespace: hive-hub
 ---
-# The backup reads Secrets in its own namespace and execs into spoke pods on
-# this cluster. Read-only apart from pod/exec, which is required to read
-# per-spoke PVC state the hub cannot mount.
+# Least-privilege RBAC (see #3708). The backup reads Secrets ONLY in its own
+# namespace (hive-hub) and execs into spoke pods that live in per-spoke
+# namespaces across the cluster.
+#
+# Secrets access is intentionally NOT cluster-wide: it is granted through a
+# namespaced Role + RoleBinding scoped to hive-hub, so a compromised backup pod
+# cannot enumerate or read Secrets in any other namespace.
+#
+# pods, pods/exec, and namespaces remain in a ClusterRole because spoke pods
+# live in arbitrary per-spoke namespaces (e.g. vllm-d) that cannot be
+# enumerated ahead of time, and `namespaces` is itself a cluster-scoped
+# resource. This ClusterRole no longer grants any secrets access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hive-hub-backup
+  namespace: hive-hub
+rules:
+  # Read the four out-of-PVC Secrets that live in hive-hub (backup key is
+  # injected via env; these are the Secrets the backup archives directly).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-hub-backup
+  namespace: hive-hub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hive-hub-backup
+subjects:
+  - kind: ServiceAccount
+    name: hive-hub-backup
+    namespace: hive-hub
+---
+# Minimal ClusterRole: only what genuinely must reach across namespaces.
+# Spoke pods live in per-spoke namespaces, so listing pods and creating
+# pod/exec sessions requires cluster scope, as does listing namespaces to
+# discover spokes. No secrets access here (moved to the namespaced Role above).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -29,9 +68,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list"]
@@ -74,7 +110,11 @@ spec:
           restartPolicy: Never
           containers:
             - name: backup
-              image: ghcr.io/kubestellar/hive:v2-latest
+              # Digest-pinned (see #3709) so a mutable-tag poisoning attack on
+              # v4-latest cannot silently deliver a hostile backup container.
+              # Recompute the digest deliberately at each release, matching the
+              # Watchtower pinning pattern.
+              image: ghcr.io/kubestellar/hive:v4-latest@sha256:e3f9ee8fd3852499f732414cd9b85d9278103e3e8ac7fb8629cf14488b90ec23
               command: ["/usr/local/bin/hive-backup", "run"]
               env:
                 # AES-256 key for the archive. MUST be escrowed outside the


### PR DESCRIPTION
## Summary

Two related security fixes for the `hive-hub-backup` CronJob in `v2/deploy/k8s/backup-cronjob.yaml`, targeting **v4**. Both findings share this one file.

### #3708 — Least-privilege: remove cluster-wide `secrets` access

The backup ServiceAccount held `secrets: get,list` **cluster-wide** via a `ClusterRole` + `ClusterRoleBinding`. The backup only archives Secrets in the `hive-hub` namespace, so any compromised or misbehaving backup pod could enumerate/read every Secret on the cluster.

**Restructure:**
- Moved the `secrets: get,list` grant into a **namespaced `Role` + `RoleBinding`** scoped to `hive-hub`.
- Kept a **minimal `ClusterRole`** for only what genuinely must reach across namespaces:
  - `pods: get,list` and `pods/exec: create` — spoke pods live in **arbitrary per-spoke namespaces** (e.g. `vllm-d`) that cannot be enumerated ahead of time, so exec into them needs cluster reach. This is the behavior the original comment called out ("execs into spoke pods on this cluster … required to read per-spoke PVC state the hub cannot mount"). Narrowing it would break spoke capture, so it is intentionally left cluster-scoped.
  - `namespaces: get,list` — `namespaces` is itself a cluster-scoped resource; discovering spoke namespaces requires it.

**Result:** No cluster-wide `secrets` access remains. The only residual cluster-scoped grants are `pods`/`pods/exec`/`namespaces`, which are required for remote spoke capture and are noted here for reviewer awareness.

### #3709 — Supply-chain: digest-pin the CronJob image

The image was the mutable tag `ghcr.io/kubestellar/hive:v2-latest` with no digest, so a registry-poisoning / mutable-tag attack could silently deliver a hostile backup container running daily. Since this PR targets v4, pinned the **v4** image:

```
ghcr.io/kubestellar/hive:v4-latest@sha256:e3f9ee8fd3852499f732414cd9b85d9278103e3e8ac7fb8629cf14488b90ec23
```

Digest resolved and cross-checked two ways (both agree on the multi-arch index digest):
- `gh api /orgs/kubestellar/packages/container/hive/versions` filtered for tag `v4-latest`
- `docker buildx imagetools inspect ghcr.io/kubestellar/hive:v4-latest`

Recompute the digest deliberately at each release, matching the existing Watchtower pinning pattern. Please confirm this digest is the intended v4 release image at merge time.

## Testing
YAML validated locally (all documents parse). No functional/build changes — manifest-only. CI gates the rest.

Fixes #3708
Fixes #3709