### PR TITLE
🐛 fix(hub): stop a cold-cache registry blip from latching empty release channels

### DIFF
--- a/v2/pkg/hub/release_channels.go
+++ b/v2/pkg/hub/release_channels.go
@@ -138,6 +138,11 @@ var ghcrTagDigest = func(repo, tag string, logger *slog.Logger) string {
 		Token string `json:"token"`
 	}
 	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
+		// Previously silent. A malformed token response makes every subsequent
+		// manifest HEAD unauthorized, so the whole channel block renders
+		// "unknown" with nothing in the log to explain why.
+		logger.Warn("channel resolve: GHCR token response was not decodable",
+			"repo", repo, "tag", tag, "status", tokenResp.StatusCode, "error", err)
 		return ""
 	}
 	req, _ := http.NewRequest("HEAD", fmt.Sprintf("%s/v2/%s/manifests/%s", ghcrBase, repo, tag), nil)
@@ -150,9 +155,21 @@ var ghcrTagDigest = func(repo, tag string, logger *slog.Logger) string {
 	}
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		// Previously silent, which is how an auth/permission regression on the
+		// package (401/403) or a channel CI never published (404) could blank
+		// the dashboard's channel rows with zero diagnostic trace.
+		logger.Warn("channel resolve: GHCR manifest HEAD returned non-OK",
+			"repo", repo, "tag", tag, "status", resp.StatusCode)
 		return ""
 	}
-	return resp.Header.Get("Docker-Content-Digest")
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		// A 200 with no digest header is a registry contract violation; without
+		// this the tag silently behaves as if it did not exist.
+		logger.Warn("channel resolve: GHCR returned 200 without Docker-Content-Digest",
+			"repo", repo, "tag", tag)
+	}
+	return digest
 }
 
 // resolveChannelTargets builds the channel→image association from digests
@@ -189,7 +206,14 @@ func resolveChannelTargets(branchSHAs map[string]string, logger *slog.Logger) []
 	for _, ch := range releaseChannels {
 		t := ChannelTarget{Channel: ch}
 		t.Digest = ghcrTagDigest(ghcrRepoSpoke, ch, logger)
-		if t.Digest != "" {
+		if t.Digest == "" {
+			// The channel row will render "unknown". Say so once, at the level
+			// that knows it is a CHANNEL failing rather than an anonymous tag
+			// lookup, so an operator seeing "unknown" on the dashboard can find
+			// the reason without attaching a debugger.
+			logger.Warn("channel resolve: channel did not resolve to any image — the dashboard will render it as \"unknown\"",
+				"channel", ch, "repo", ghcrRepoSpoke)
+		} else {
 			// Branch stays empty when the digest matches nothing tracked. That
 			// is a real state (a channel pinned to an older build), and the UI
 			// renders it as such rather than inventing an attribution.
@@ -226,8 +250,23 @@ func getChannelTargets(branchSHAs map[string]string, logger *slog.Logger) []Chan
 			break
 		}
 	}
-	if !resolvedAny && len(stale) > 0 {
-		return stale
+	if !resolvedAny {
+		// Nothing resolved at all — the registry was unreachable, not "the
+		// channels vanished".
+		//
+		// Serve the previous good answer when there is one. When there is NOT
+		// (cold cache: the hub started while GHCR was unreachable), return the
+		// empty rows WITHOUT caching them. Caching here latched "unknown" for
+		// the full channelDigestTTL, so a hub that lost one refresh showed no
+		// channel association for five minutes and no amount of reloading the
+		// dashboard would fix it. Leaving the cache untouched means the very
+		// next poll retries.
+		logger.Warn("channel resolve: no channel resolved to an image — serving the previous answer if one exists, and retrying on the next poll",
+			"had_previous", len(stale) > 0)
+		if len(stale) > 0 {
+			return stale
+		}
+		return fresh
 	}
 
 	channelTargetMu.Lock()

--- a/v2/pkg/hub/release_channels_test.go
+++ b/v2/pkg/hub/release_channels_test.go
@@ -1,8 +1,13 @@
 package hub
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -235,5 +240,127 @@ func TestReleaseChannelsReturnsCopy(t *testing.T) {
 	got[0] = "mutated"
 	if releaseChannels[0] != ReleaseChannelStable {
 		t.Error("ReleaseChannels() exposed the package slice — a caller mutated it")
+	}
+}
+
+// TestResolveChannelTargetsWarnsWhenChannelUnresolvable is the loud-failure
+// guarantee: when a channel tag cannot be resolved the row renders "unknown",
+// and that MUST be accompanied by a WARN naming the channel. A silent empty
+// result is what made the original dashboard investigation require a debugger.
+//
+// POSITIVE CONTROL: the successful channels in the same pass must NOT warn, so
+// an implementation that simply logs a warning unconditionally fails here.
+func TestResolveChannelTargetsWarnsWhenChannelUnresolvable(t *testing.T) {
+	stubChannelDigests(t, map[string]string{
+		"v4-latest":          "sha256:aaaa",
+		ReleaseChannelStable: "sha256:aaaa",
+		// candidate/edge deliberately absent from the registry.
+	})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	resolveChannelTargets(map[string]string{"v4": "3d31590"}, logger)
+	logged := buf.String()
+
+	for _, ch := range []string{ReleaseChannelCandidate, ReleaseChannelEdge} {
+		if !strings.Contains(logged, `channel=`+ch) {
+			t.Errorf("unresolvable channel %q produced no WARN naming it; an operator seeing \"unknown\" has nothing to go on.\nlog:\n%s", ch, logged)
+		}
+	}
+	if strings.Contains(logged, `channel=`+ReleaseChannelStable) {
+		t.Errorf("channel %q resolved successfully but was still warned about — the warning must be specific to real failures.\nlog:\n%s", ReleaseChannelStable, logged)
+	}
+}
+
+// TestGhcrTagDigestWarnsOnNonOK covers the transport layer directly: a 401/403
+// (package permissions regressed) or 404 (channel never published) must be
+// visible in the log, not swallowed into an empty string.
+func TestGhcrTagDigestWarnsOnNonOK(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/token") {
+				w.Header().Set("Content-Type", "application/json")
+				io.WriteString(w, `{"token":"t"}`)
+				return
+			}
+			w.WriteHeader(status)
+		}))
+
+		oldBase := ghcrBase
+		ghcrBase = srv.URL
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		got := ghcrTagDigest(ghcrRepoSpoke, ReleaseChannelStable, logger)
+		ghcrBase = oldBase
+		srv.Close()
+
+		if got != "" {
+			t.Errorf("status %d: digest = %q, want empty", status, got)
+		}
+		if !strings.Contains(buf.String(), fmt.Sprintf("status=%d", status)) {
+			t.Errorf("status %d was swallowed without a WARN carrying the status.\nlog:\n%s", status, buf.String())
+		}
+	}
+}
+
+// TestGhcrTagDigestSucceedsAndStaysQuiet is the POSITIVE CONTROL for the two
+// tests above: the happy path must return the digest and log NOTHING at WARN.
+// Without this, "warn on every call" would satisfy the failure tests.
+func TestGhcrTagDigestSucceedsAndStaysQuiet(t *testing.T) {
+	const want = "sha256:abc123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/token") {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"token":"t"}`)
+			return
+		}
+		w.Header().Set("Docker-Content-Digest", want)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	oldBase := ghcrBase
+	ghcrBase = srv.URL
+	defer func() { ghcrBase = oldBase }()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	got := ghcrTagDigest(ghcrRepoSpoke, ReleaseChannelStable, logger)
+
+	if got != want {
+		t.Errorf("digest = %q, want %q", got, want)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("a successful resolve logged at WARN: %s", buf.String())
+	}
+}
+
+// TestGetChannelTargetsEmptyResolveDoesNotPoisonCache: a first refresh that
+// resolves NOTHING (cold cache + registry down) must not be latched for the
+// full TTL — once the registry recovers the next call must resolve for real.
+// This is the "empty result poisons the 5-minute cache" failure mode.
+func TestGetChannelTargetsEmptyResolveDoesNotPoisonCache(t *testing.T) {
+	resetChannelTargetCache()
+	orig := ghcrTagDigest
+	t.Cleanup(func() { ghcrTagDigest = orig; resetChannelTargetCache() })
+
+	// Cold cache, registry dark.
+	ghcrTagDigest = func(string, string, *slog.Logger) string { return "" }
+	shas := map[string]string{"v4": "3d31590"}
+	if got := getChannelTargets(shas, testChannelLogger()); targetFor(got, ReleaseChannelStable).Digest != "" {
+		t.Fatalf("expected an empty first resolve, got %+v", got)
+	}
+
+	// Registry recovers. No TTL manipulation: an empty result must not have
+	// been cached as if it were a good answer.
+	ghcrTagDigest = func(_, tag string, _ *slog.Logger) string {
+		if tag == "v4-latest" || tag == ReleaseChannelStable {
+			return "sha256:aaaa"
+		}
+		return ""
+	}
+	got := getChannelTargets(shas, testChannelLogger())
+	if targetFor(got, ReleaseChannelStable).Branch != "v4" {
+		t.Errorf("an empty resolve poisoned the cache: stable = %+v, want branch v4 once the registry recovered", targetFor(got, ReleaseChannelStable))
 	}
 }


### PR DESCRIPTION
## The reported symptom was a measurement error

The report was "stable/candidate/edge associations never appear in the hub dashboard". I could not reproduce it, and the evidence says the feature is live and working:

| Check | Result |
|---|---|
| Channel code in the running hub binary | **Present** — `strings /usr/local/bin/hive` in the live pod finds `release_channels`, `channel_targets`, `"Release channels:"`, `_channelTargets`, `CHANNEL_NAME_MIN_W_PX` |
| Published image contains #3703 | **Yes** — live `v4-latest` = `sha256:49e53e6…`, produced by docker.yml run `31717819447` at `cb6c5044`; `dbe9eb8b` is an ancestor |
| `resolveChannelTargets` against real GHCR | **Works** — returns stable/candidate/edge, all attributed to `v4` |
| GHCR auth from inside the pod | **Works** — token 200, manifest HEAD 200, digest returned |

The "Build is stale" guard **did** fire and skip tagging at `dbe9eb8b` (#3703). But the very next commit `cb6c5044` (#3705, which repaired the `\\` line-continuation that #3702 broke) re-published successfully, so the feature shipped anyway.

The original probe queried `GET /api/saas/hives` — registered **POST-only** (create hive). It returned `404 page not found`, and "no `channel` key in the body" was read as "the feature is missing". The dashboard payload is **`/api/saas/my-hives`**, which emits `release_channels` and `channel_targets` unconditionally.

**No fix was warranted for the reported symptom.** I am reporting that plainly rather than inventing one.

## Two real bugs found while chasing it

Both produce exactly the reported symptom under a narrow but real condition, so they are worth fixing.

### 1. An empty resolve poisoned the cache

The keep-stale guard was `!resolvedAny && len(stale) > 0` — it only protected a hub that *already had* a good answer. On a **cold cache** (hub starts while GHCR is briefly unreachable) the all-empty result was written and timestamped, latching `unknown` on every channel row for the full 5-minute TTL. No amount of reloading the dashboard would clear it.

Now an unresolved refresh is **never cached**, so the next poll retries.

### 2. Failures were silent

Four paths returned `""` with nothing logged: non-200 manifest HEAD (401/403 on a package-permission regression, 404 if CI never published the tag), an undecodable token response, and a 200 carrying no `Docker-Content-Digest`. The dashboard rendered `unknown` and the log said nothing — which is precisely why diagnosing this needed a debugger.

All four now log at WARN with the status/reason, plus one WARN per channel that fails to resolve, named as a *channel* rather than an anonymous tag lookup.

## Tests

Every test was verified by neutering the fix and watching it go red.

| Test | Purpose |
|---|---|
| `TestGetChannelTargetsEmptyResolveDoesNotPoisonCache` | **Found bug 1.** Fails against the original guard. |
| `TestResolveChannelTargetsWarnsWhenChannelUnresolvable` | Unresolvable channel must WARN naming the channel |
| `TestGhcrTagDigestWarnsOnNonOK` | 401/403/404 must surface the status |
| `TestGhcrTagDigestSucceedsAndStaysQuiet` | **POSITIVE CONTROL** |

The positive control is what makes the other two meaningful: the happy path must return the digest and log **nothing** at WARN, so a lazy "warn unconditionally" implementation cannot satisfy the failure tests. Confirmed — an always-warn version fails this test.

### Regression replay

```
NEUTER 1 (restore cache-poisoning guard)
--- FAIL: TestGetChannelTargetsEmptyResolveDoesNotPoisonCache

NEUTER 2 (silence the WARNs)
--- FAIL: TestResolveChannelTargetsWarnsWhenChannelUnresolvable
--- FAIL: TestGhcrTagDigestWarnsOnNonOK

POSITIVE CONTROL (always-warn cheat)
--- FAIL: TestGhcrTagDigestSucceedsAndStaysQuiet

RESTORED
ok  github.com/kubestellar/hive/v2/pkg/hub
```

All 13 channel tests pass. No hardcoded channel→branch mapping was introduced; association still derives from registry digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)