### PR TITLE
fix(terminal): enable tmux mouse mode + history for browser scrollback

### DIFF
--- a/bin/ttyd-tmux.sh
+++ b/bin/ttyd-tmux.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
-# Wrapper for ttyd → tmux that disables mouse mode so the browser
-# handles text selection and clipboard (Cmd+C / Cmd+V).
-# Mouse mode is restored when the ttyd session disconnects.
+# Wrapper for ttyd → tmux. Enables mouse mode on attach so the browser scroll
+# wheel drives tmux copy-mode scrollback (issue #3694) and raises the pane
+# history-limit so there is meaningful scrollback to reach; both are restored
+# on disconnect. Hold Shift (or Option on macOS) to bypass mouse mode for native
+# browser text selection / clipboard.
+#
+# NOTE: The container uses v2/deploy/ttyd-tmux.sh (copied to
+# /usr/local/bin/ttyd-tmux.sh by v2/Dockerfile), which additionally resolves
+# per-agent tmux sockets across UIDs via su-exec. This copy is a simpler
+# standalone helper kept in sync for local/non-UID-isolated use.
 set -euo pipefail
 
 SESSION=${1:-supervisor}
+TTYD_HISTORY_LIMIT="${HIVE_TTYD_HISTORY_LIMIT:-50000}"
 PREV_MOUSE=$(tmux show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-tmux set-option -t "$SESSION" mouse off 2>/dev/null || true
+PREV_HISTORY=$(tmux show-option -t "$SESSION" -gv history-limit 2>/dev/null || echo "")
+tmux set-option -t "$SESSION" mouse on 2>/dev/null || true
+tmux set-option -t "$SESSION" history-limit "$TTYD_HISTORY_LIMIT" 2>/dev/null || true
 EXIT_CODE=0
 tmux attach-session -t "$SESSION" || EXIT_CODE=$?
 tmux set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
+if [ -n "$PREV_HISTORY" ]; then
+  tmux set-option -t "$SESSION" history-limit "$PREV_HISTORY" 2>/dev/null || true
+fi
 exit $EXIT_CODE

--- a/v2/deploy/README.md
+++ b/v2/deploy/README.md
@@ -6,7 +6,7 @@ This directory contains Kubernetes/LXC manifests plus runtime helper scripts use
 
 ### `ttyd-tmux.sh`
 
-`ttyd` serves the browser terminal websocket, but agent tmux sessions may be owned by per-agent UIDs. Because tmux only lets the socket owner attach, `ttyd-tmux.sh <session>` finds the matching `/tmp/tmux-*/<session>` socket, derives its numeric UID/GID, and uses `su-exec` to attach as that owner. It temporarily disables tmux mouse mode while attached and restores it on exit.
+`ttyd` serves the browser terminal websocket, but agent tmux sessions may be owned by per-agent UIDs. Because tmux only lets the socket owner attach, `ttyd-tmux.sh <session>` finds the matching `/tmp/tmux-*/<session>` socket, derives its numeric UID/GID, and uses `su-exec` to attach as that owner. While attached it enables tmux mouse mode (so the scroll wheel drives copy-mode scrollback instead of just reflowing the viewport — issue #3694) and raises the pane `history-limit` (default `50000`, override with `HIVE_TTYD_HISTORY_LIMIT`) so there is meaningful scrollback to reach. Both options are restored to their previous values on detach.
 
 Use it indirectly through the dashboard terminal link. If a terminal pane says no tmux socket was found, check that the agent session name exists and that the socket is present under `/tmp/tmux-*` in the container.
 

--- a/v2/deploy/ttyd-tmux.sh
+++ b/v2/deploy/ttyd-tmux.sh
@@ -37,18 +37,42 @@ SOCK_OWNER_GID=$(stat -c '%g' "$TMUX_SOCKET" 2>/dev/null || echo "")
 SOCK_OWNER_SPEC="${SOCK_OWNER_UID}:${SOCK_OWNER_GID}"
 CURRENT_UID=$(id -u)
 
+# Scroll-wheel history (issue #3694). The browser terminal is a live tmux
+# attach, so the only real scrollback is tmux's copy-mode — which the wheel can
+# only enter when `mouse on`. Earlier versions of this script set `mouse off`
+# on attach, which left wheel events untranslated: scrolling up did not page
+# back through history, it merely reflowed a few lines at the bottom of the
+# viewport (the reported symptom). Enable mouse mode instead so the wheel drives
+# copy-mode and scrolls back through the pane's history normally, and give the
+# pane a generous history-limit so there is meaningful scrollback to reach.
+# Both are per-session options restored to their previous values on detach so
+# an agent CLI that manages mouse mode itself is not permanently altered.
+#
+# HIVE_TTYD_HISTORY_LIMIT overrides the scrollback depth applied on attach.
+TTYD_HISTORY_LIMIT="${HIVE_TTYD_HISTORY_LIMIT:-50000}"
+
+# attach_with runs the attach lifecycle. $1 is an optional command prefix
+# (e.g. "su-exec <spec>") so the same logic serves both the owner and non-owner
+# paths without duplication.
+attach_with() {
+  local run=("$@")
+  local prev_mouse prev_history exit_code=0
+  prev_mouse=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
+  prev_history=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -gv history-limit 2>/dev/null || echo "")
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse on 2>/dev/null || true
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" history-limit "$TTYD_HISTORY_LIMIT" 2>/dev/null || true
+  "${run[@]}" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || exit_code=$?
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$prev_mouse" 2>/dev/null || true
+  if [ -n "$prev_history" ]; then
+    "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" history-limit "$prev_history" 2>/dev/null || true
+  fi
+  return "$exit_code"
+}
+
 if [ -n "$SOCK_OWNER_UID" ] && [ "$SOCK_OWNER_UID" != "$CURRENT_UID" ] && command -v su-exec >/dev/null 2>&1; then
-  PREV_MOUSE=$(su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
-  EXIT_CODE=0
-  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
-  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
-  exit $EXIT_CODE
+  attach_with su-exec "$SOCK_OWNER_SPEC"
+  exit $?
 else
-  PREV_MOUSE=$(tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-  tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
-  EXIT_CODE=0
-  tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
-  tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
-  exit $EXIT_CODE
+  attach_with
+  exit $?
 fi


### PR DESCRIPTION
## Problem

Fixes #3694. In the spoke dashboard's agent **Terminal**, scrolling up does not reveal earlier output — it only makes "a little more temporally-earlier material appear at the bottom" and the viewport cannot scroll down again. Normal terminal scrollback (scroll up = older lines at top, viewport pages back through history) is broken. Reported on v4 commit `7e892978`.

## Root cause

The Terminal is not xterm.js scrollback — it is a **live tmux attach** served by `ttyd`, wrapped by `v2/deploy/ttyd-tmux.sh`. On attach the script set **`mouse off`** (`v2/deploy/ttyd-tmux.sh:42,49`). With mouse mode off, tmux never translates browser scroll-wheel events into **copy-mode**, so the wheel never pages back through the pane's history. Because the agent CLI runs on tmux's **alternate screen** (which has no xterm.js scrollback of its own), copy-mode is the *only* real scrollback — disabling mouse mode removed scrollback entirely, producing exactly the reported reflow-at-the-bottom symptom.

The original rationale (visible in the stale `bin/ttyd-tmux.sh` comment) was to let the browser handle native text selection / clipboard. That tradeoff broke the more important interactive function.

## Fix

In `ttyd-tmux.sh`, on attach:
- Set **`mouse on`** so the scroll wheel drives tmux copy-mode and scrolls back through history normally.
- Raise the pane **`history-limit`** (default `50000`, overridable via `HIVE_TTYD_HISTORY_LIMIT`) so there is meaningful scrollback to reach (tmux's default is only 2000).

Both are per-session options **captured and restored to their previous values on detach**, so an agent CLI that manages mouse mode itself is not permanently altered. The owner (`su-exec`) and non-owner paths are refactored into a shared `attach_with` helper to avoid duplication.

Users can still hold **Shift** (or **Option** on macOS) for native browser text selection while mouse mode is on.

## Notes
- This is complementary to #3711 (full-log download endpoint), not overlapping — that PR avoids the scroll problem; this one fixes the interactive scroll behavior itself. #3711 is untouched.
- Also updated the stale, unreferenced `bin/ttyd-tmux.sh` copy (the container uses `v2/deploy/ttyd-tmux.sh` per `v2/Dockerfile`) and the `v2/deploy/README.md` description to match.

## Testing
Shell-script change only; verified with `bash -n`. No Go code touched.