### PR TITLE
fix(automerge): gate self-merge sweep only on branch required checks

### DIFF
--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -316,7 +317,11 @@ func (c *Client) trySweepSelfAuthoredPR(ctx context.Context, displayRepo, owner,
 	if mergeable != MergeableYes {
 		return AutoMergeSweepEvent{}, "not-mergeable", nil
 	}
-	green, reason, err := c.commitGreen(ctx, owner, repo, evaluatedHeadSHA)
+	baseBranch := ""
+	if pr.GetBase() != nil {
+		baseBranch = pr.GetBase().GetRef()
+	}
+	green, reason, err := c.commitGreen(ctx, owner, repo, baseBranch, evaluatedHeadSHA)
 	if err != nil {
 		return AutoMergeSweepEvent{}, reason, err
 	}
@@ -444,7 +449,11 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	if mergeable != MergeableYes {
 		return AutoMergeSweepEvent{}, "not-mergeable", nil
 	}
-	green, reason, err := c.commitGreen(ctx, owner, repo, headSHA)
+	baseBranch := ""
+	if pr.GetBase() != nil {
+		baseBranch = pr.GetBase().GetRef()
+	}
+	green, reason, err := c.commitGreen(ctx, owner, repo, baseBranch, headSHA)
 	if err != nil {
 		return AutoMergeSweepEvent{}, reason, err
 	}
@@ -538,28 +547,41 @@ func parseHiveQueueReview(body string) string {
 	return matches[1]
 }
 
-// commitGreen reports whether every non-meta commit status and check run on
-// the head SHA has actually succeeded. Pending is NOT green: the sweep runs
-// every minute and a queue action usually lands seconds after the PR opens,
-// so treating in-flight CI as green would squash the PR before its first CI
-// run finishes — mergeable_state cannot catch that, because "unstable"
-// (non-required checks outstanding) deliberately maps to MergeableYes and
-// managed repos generally have no branch protection making any check
-// required. Meta gates (tide, netlify previews, ...) are excluded on both
-// surfaces — tide in particular posts a commit status that stays "pending"
-// forever on Prow-managed repos and must never wedge the queue.
+// commitGreen reports whether the head SHA is mergeable from a CI
+// standpoint.
 //
-// A non-success CONCLUSION (cancelled, failure, timed_out, ...) on an
-// ignorable/non-required check (isIgnorableCICheck — Playwright, Mobile
-// Browser Tests, the chromium shard matrix, plus the isMetaCheck set) is
-// likewise not a blocker: those suites are routinely cancelled mid-flight
-// (matrix/concurrency-group cancellation, flake reruns) with zero bearing on
-// mergeability, and treating a cancelled Playwright/Mobile shard as red left
-// otherwise-green, MERGEABLE PRs (build-gate success) permanently skipped by
-// the self-merge sweep with reason "check-cancelled" (#22438, #22440).
-// Required checks (build-gate, build/test/docker, ...) still gate: only the
-// ignorable set gets a pass on a bad conclusion.
-func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool, string, error) {
+// Gating is REQUIRED-CHECKS-ONLY: commitGreen first asks GitHub which status
+// contexts/check-run names are actually required by the target branch's
+// branch protection (requiredStatusCheckContexts). Any status or check-run
+// whose context/name is NOT in that required set is skipped entirely,
+// regardless of its state or conclusion — pending, failing, or cancelled
+// non-required checks can never block self-merge. A required check still
+// fully gates: pending blocks (return not-green, "pending" — the sweep must
+// never squash a PR before its required CI has finished), and a
+// failure/error/cancelled conclusion on a required check blocks too.
+//
+// Why required-only, not a hardcoded ignore-list: the previous approach
+// (isMetaCheck/isIgnorableCICheck as an ALLOWLIST of names to ignore) is
+// whack-a-mole against an open-ended set of non-required checks — #3611 added
+// Playwright/Mobile Browser Tests/coverage-report/the chromium shard matrix,
+// but "Detect untested files" (cancelled) still blocked #22471 and "Analyze
+// (python)" (CodeQL, failure) still blocks #22450 because neither name was on
+// the list. Every managed repo's ACTUAL required-checks set (e.g. console's
+// main branch requires only "build-gate") is the one true source of what
+// must be green; anything else is by definition non-required and must never
+// wedge the queue.
+//
+// Fail-closed fallback: if the required-checks set cannot be determined
+// (branch protection absent/erroring, no branch known, or the API call
+// fails) this deliberately does NOT fall back to "ignore everything" — that
+// would merge over a genuinely broken build the moment GitHub's protection
+// API hiccups. Instead it falls back to the OLD isMetaCheck/isIgnorableCICheck
+// allowlist behavior, so an outage of the branch-protection endpoint degrades
+// gating back to the previously-shipped conservative behavior rather than to
+// "always green".
+func (c *Client) commitGreen(ctx context.Context, owner, repo, branch, sha string) (bool, string, error) {
+	required, requiredKnown := c.requiredStatusCheckContexts(ctx, owner, repo, branch)
+
 	statusOpts := &gh.ListOptions{PerPage: 100}
 	for {
 		status, resp, err := c.client.Repositories.GetCombinedStatus(ctx, owner, repo, sha, statusOpts)
@@ -567,7 +589,15 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			return false, "status-check", err
 		}
 		for _, s := range status.Statuses {
-			if isMetaCheck(s.GetContext()) {
+			ctxName := s.GetContext()
+			if requiredKnown {
+				// Required-checks-only gating: skip anything not on the
+				// branch's actual required list, no matter its state.
+				if !required[ctxName] {
+					continue
+				}
+			} else if isMetaCheck(ctxName) {
+				// Fail-closed fallback path (required set unavailable).
 				continue
 			}
 			switch s.GetState() {
@@ -575,7 +605,7 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			case "pending":
 				return false, "status-pending", nil
 			default: // "failure", "error"
-				if isIgnorableCICheck(s.GetContext()) {
+				if !requiredKnown && isIgnorableCICheck(ctxName) {
 					continue
 				}
 				return false, "status-" + s.GetState(), nil
@@ -594,11 +624,16 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			return false, "check-runs", err
 		}
 		for _, cr := range checkRuns.CheckRuns {
-			if isMetaCheck(cr.GetName()) {
+			name := cr.GetName()
+			if requiredKnown {
+				if !required[name] {
+					continue
+				}
+			} else if isMetaCheck(name) {
 				continue
 			}
 			if cr.GetStatus() != "completed" {
-				if isIgnorableCICheck(cr.GetName()) {
+				if !requiredKnown && isIgnorableCICheck(name) {
 					continue
 				}
 				return false, "check-pending", nil
@@ -606,7 +641,7 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			switch cr.GetConclusion() {
 			case "success", "neutral", "skipped":
 			default:
-				if isIgnorableCICheck(cr.GetName()) {
+				if !requiredKnown && isIgnorableCICheck(name) {
 					continue
 				}
 				return false, "check-" + cr.GetConclusion(), nil
@@ -617,6 +652,59 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 		}
 		opts.ListOptions.Page = resp.NextPage
 	}
+}
+
+// requiredStatusCheckContexts returns the set of status-check contexts /
+// check-run names that branch protection actually requires on branch, and
+// whether that set could be determined at all. It is the single source of
+// truth commitGreen gates on: membership in this set is what makes a check
+// "required" (must be green) versus ignorable (any state/conclusion, never
+// blocks).
+//
+// requiredKnown is false (empty set, ignore it) when:
+//   - branch is empty (caller could not resolve the PR's base branch), or
+//   - the repo/branch has no branch protection configured
+//     (gh.ErrBranchNotProtected — a repo with zero required checks is a
+//     valid, common state, NOT an error), or
+//   - the GitHub API call itself failed (rate limit, transient 5xx, ...).
+//
+// In all of those cases the caller must fall back to the OLD
+// isMetaCheck/isIgnorableCICheck allowlist rather than treating "we don't
+// know the required set" as "nothing is required" — see commitGreen's
+// fail-closed comment.
+func (c *Client) requiredStatusCheckContexts(ctx context.Context, owner, repo, branch string) (map[string]bool, bool) {
+	if strings.TrimSpace(branch) == "" {
+		return nil, false
+	}
+	rsc, _, err := c.client.Repositories.GetRequiredStatusChecks(ctx, owner, repo, branch)
+	if err != nil {
+		// gh.ErrBranchNotProtected means "this branch legitimately requires
+		// nothing" — that IS a known, empty required set, not a failure to
+		// determine it, so requiredKnown is true with an empty map (every
+		// check is then non-required and ignorable).
+		if errors.Is(err, gh.ErrBranchNotProtected) {
+			return map[string]bool{}, true
+		}
+		return nil, false
+	}
+	if rsc == nil {
+		return map[string]bool{}, true
+	}
+	required := make(map[string]bool)
+	if rsc.Contexts != nil {
+		for _, name := range *rsc.Contexts {
+			required[name] = true
+		}
+	}
+	if rsc.Checks != nil {
+		for _, check := range *rsc.Checks {
+			if check == nil {
+				continue
+			}
+			required[check.Context] = true
+		}
+	}
+	return required, true
 }
 
 func hasLabel(labels []string, want string) bool {

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -355,7 +355,11 @@ func TestCommitGreenStatusAndCheckBranches(t *testing.T) {
 			}))
 			defer api.Close()
 			c := newAutoMergeSweepClient(api.URL)
-			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
+			// branch="" means the required-checks set is deliberately
+			// unresolvable here, exercising the fail-closed
+			// isMetaCheck/isIgnorableCICheck allowlist fallback path — see
+			// TestCommitGreenRequiredChecksOnly for the required-set-known path.
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "", "sha")
 			if err != nil {
 				t.Fatalf("commitGreen returned error: %v", err)
 			}
@@ -640,9 +644,206 @@ func TestCommitGreenAPIErrors(t *testing.T) {
 			}))
 			defer api.Close()
 			c := newAutoMergeSweepClient(api.URL)
-			_, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
+			_, reason, err := c.commitGreen(context.Background(), "acme", "widget", "", "sha")
 			if err == nil || reason != tt.wantReason {
 				t.Fatalf("commitGreen reason=%q err=%v, want %q error", reason, err, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestCommitGreenRequiredChecksOnly locks in the required-checks-ONLY gate:
+// commitGreen must consult the branch's actual required status checks
+// (Repositories.GetRequiredStatusChecks) and ignore any check/status whose
+// context is not in that set, no matter its state — this replaces the old
+// hardcoded isMetaCheck/isIgnorableCICheck allowlist that repeatedly missed
+// non-required check names (#22471 "Detect untested files", #22450
+// "Analyze (python)"/CodeQL).
+func TestCommitGreenRequiredChecksOnly(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiredContexts []string
+		statuses         []struct{ context, state string }
+		checks           []struct{ name, status, conclusion string }
+		wantGreen        bool
+		wantReason       string
+	}{
+		{
+			name:             "non-required cancelled check-run never blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Detect untested files", "completed", "cancelled"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "non-required failing check-run (CodeQL) never blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Analyze (python)", "completed", "failure"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "non-required pending check-run never blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Analyze (python)", "in_progress", ""},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "required check pending blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "in_progress", ""},
+			},
+			wantReason: "check-pending",
+		},
+		{
+			name:             "required check failure blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "failure"},
+			},
+			wantReason: "check-failure",
+		},
+		{
+			name:             "non-required failing status context never blocks",
+			requiredContexts: []string{"build-gate"},
+			statuses: []struct{ context, state string }{
+				{"ci/legacy-lint", "failure"},
+			},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "required status context failure blocks",
+			requiredContexts: []string{"ci/build"},
+			statuses: []struct{ context, state string }{
+				{"ci/build", "failure"},
+			},
+			wantReason: "status-failure",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/branches/main/protection/required_status_checks":
+					json.NewEncoder(w).Encode(map[string]any{
+						"strict":   true,
+						"contexts": tt.requiredContexts,
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+					statuses := []map[string]string{}
+					combined := "success"
+					for _, s := range tt.statuses {
+						statuses = append(statuses, map[string]string{"context": s.context, "state": s.state})
+						if s.state != "success" {
+							combined = s.state
+						}
+					}
+					json.NewEncoder(w).Encode(map[string]any{"state": combined, "total_count": len(statuses), "statuses": statuses})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+					runs := []map[string]string{}
+					for _, c := range tt.checks {
+						runs = append(runs, map[string]string{"name": c.name, "status": c.status, "conclusion": c.conclusion})
+					}
+					json.NewEncoder(w).Encode(map[string]any{"total_count": len(runs), "check_runs": runs})
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := newAutoMergeSweepClient(api.URL)
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "main", "sha")
+			if err != nil {
+				t.Fatalf("commitGreen returned error: %v", err)
+			}
+			if green != tt.wantGreen || reason != tt.wantReason {
+				t.Fatalf("commitGreen = (%v,%q), want (%v,%q)", green, reason, tt.wantGreen, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestCommitGreenRequiredChecksUnavailableFallsBack locks in the fail-closed
+// fallback: when the required-checks set cannot be determined, commitGreen
+// must NOT treat every check as ignorable — it falls back to the old
+// isMetaCheck/isIgnorableCICheck allowlist rather than merging over
+// everything.
+func TestCommitGreenRequiredChecksUnavailableFallsBack(t *testing.T) {
+	tests := []struct {
+		name           string
+		protectionCode int // HTTP status GetRequiredStatusChecks returns; 0 = branch-not-protected message
+		checks         []struct{ name, status, conclusion string }
+		wantGreen      bool
+		wantReason     string
+	}{
+		{
+			name:           "branch protection API error falls back to allowlist and still blocks unknown failing check",
+			protectionCode: http.StatusInternalServerError,
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"some-custom-check", "completed", "failure"},
+			},
+			wantReason: "check-failure",
+		},
+		{
+			name:           "branch protection API error still allows fallback allowlist (Playwright) to pass",
+			protectionCode: http.StatusInternalServerError,
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Playwright", "completed", "cancelled"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:           "unprotected branch (no required checks) is a known empty set, everything ignorable",
+			protectionCode: 0,
+			checks: []struct{ name, status, conclusion string }{
+				{"anything", "completed", "failure"},
+			},
+			wantGreen: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/branches/main/protection/required_status_checks":
+					if tt.protectionCode == 0 {
+						w.WriteHeader(http.StatusNotFound)
+						json.NewEncoder(w).Encode(map[string]any{"message": "Branch not protected"})
+						return
+					}
+					http.Error(w, "boom", tt.protectionCode)
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 0})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+					runs := []map[string]string{}
+					for _, c := range tt.checks {
+						runs = append(runs, map[string]string{"name": c.name, "status": c.status, "conclusion": c.conclusion})
+					}
+					json.NewEncoder(w).Encode(map[string]any{"total_count": len(runs), "check_runs": runs})
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := newAutoMergeSweepClient(api.URL)
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "main", "sha")
+			if err != nil {
+				t.Fatalf("commitGreen returned error: %v", err)
+			}
+			if green != tt.wantGreen || reason != tt.wantReason {
+				t.Fatalf("commitGreen = (%v,%q), want (%v,%q)", green, reason, tt.wantGreen, tt.wantReason)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

The self-merge sweep's `commitGreen` gated on a hardcoded
`isMetaCheck`/`isIgnorableCICheck` allowlist of non-required check names to
ignore. That allowlist is whack-a-mole against an open-ended set of checks:

- #3611 added Playwright / Mobile Browser Tests / coverage-report / the
  chromium shard matrix to the ignore list.
- "Detect untested files" (cancelled, non-required) still blocked #22471.
- "Analyze (python)" (CodeQL, non-required, `failure`) still blocks #22450.

On console, the only required check on `main` is `build-gate`. The operator
wants the sweep to gate only on the repo/branch's actual required status
checks — any non-required check, in any state or conclusion, must never
block self-merge.

## Fix

`commitGreen` now asks GitHub for the target branch's actual required
status-check contexts (`Repositories.GetRequiredStatusChecks`) and gates
**only** on membership in that set:

- A check/status **not** in the required set is skipped entirely, regardless
  of state/conclusion (pending, failure, cancelled — none of it blocks).
- A check/status **in** the required set still fully gates: pending returns
  not-green, and failure/error/cancelled blocks the merge.

**Safety preserved**: required checks (e.g. `build-gate`) still gate exactly
as before. This does not weaken required-check enforcement — it only stops
non-required checks from blocking self-merge.

**Fail-closed fallback**: when the required-checks set cannot be determined
(no base branch known, or the branch-protection API errors), `commitGreen`
falls back to the previous `isMetaCheck`/`isIgnorableCICheck` allowlist
behavior instead of treating "unknown" as "ignore everything." An outage of
the branch-protection endpoint degrades gating to the prior conservative
behavior, never to an unconditional merge.

## Changes

- `v2/pkg/github/automerge_sweep.go`: `commitGreen` gains a `branch`
  parameter; adds `requiredStatusCheckContexts` to fetch the branch's
  required check set (`gh.ErrBranchNotProtected` is treated as a known,
  empty required set). Both call sites (`trySweepSelfAuthoredPR`,
  `trySweepQueuedPR`) now pass `pr.GetBase().GetRef()`.
- `v2/pkg/github/automerge_sweep_test.go`: updates existing `commitGreen`
  callers to exercise the fallback path explicitly, plus new tests:
  - required check (`build-gate`) failing/pending ⇒ not green
  - non-required checks (`Detect untested files`, `Analyze (python)`)
    cancelled/failed while `build-gate` is green ⇒ GREEN
  - required-checks-unavailable ⇒ falls back to allowlist behavior
