### PR TITLE
🔒 fix(advisory): pin digest to one commit and cite it (#3704)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4946,6 +4946,50 @@ func runEvalCycle(
 			if parts := strings.SplitN(primaryRepo, "/", 2); len(parts) == 2 {
 				org, repoName = parts[0], parts[1]
 			}
+
+			// #3704: pin the digest to ONE repo commit. Resolve the target repo's
+			// latest commit ONCE here (invariants 1 & 3), cite it in the rendered
+			// comment (invariant 2, via the footer FormatDigestMarkdown emits when
+			// AnalyzedSnapshot is set), and verify each finding's file path against
+			// that exact commit so a since-removed path (e.g. "docs/install.md") is
+			// flagged as outdated rather than cited as live. Best-effort: if the SHA
+			// cannot be resolved, fall back to the previous unpinned behavior rather
+			// than skip the digest.
+			if ghClient != nil && org != "" && repoName != "" {
+				branch := cfg.Policies.Branch
+				if branch == "" {
+					if r, _, rerr := ghClient.GetRepo(ctx, org, repoName); rerr == nil {
+						branch = r.GetDefaultBranch()
+					} else {
+						logger.Warn("advisory: could not resolve default branch for snapshot", "repo", primaryRepo, "error", rerr)
+					}
+				}
+				if branch != "" {
+					if sha, serr := ghClient.LatestCommitHash(ctx, org, repoName, branch); serr == nil && sha != "" {
+						digest.AnalyzedSnapshot = &advisory.Snapshot{
+							Owner:  org,
+							Repo:   repoName,
+							Branch: branch,
+							SHA:    sha,
+						}
+						advisory.VerifyFindingPaths(digest, func(path string) bool {
+							exists, verr := ghClient.PathExistsAtRef(ctx, org, repoName, path, sha)
+							if verr != nil {
+								// Inconclusive check (network/rate-limit, not a 404):
+								// treat as existing so a transient error never
+								// mislabels a real path as outdated.
+								logger.Warn("advisory: path existence check failed", "path", path, "repo", primaryRepo, "sha", sha, "error", verr)
+								return true
+							}
+							return exists
+						})
+						logger.Info("advisory digest pinned to commit", "repo", primaryRepo, "branch", branch, "sha", sha)
+					} else if serr != nil {
+						logger.Warn("advisory: could not resolve latest commit for snapshot", "repo", primaryRepo, "branch", branch, "error", serr)
+					}
+				}
+			}
+
 			md := advisory.FormatDigestMarkdown(digest, org, repoName)
 			if md != "" {
 				if issueNum, ok := advisoryIssues[primaryRepo]; ok && issueNum > 0 {

--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -28,6 +28,25 @@ type Finding struct {
 	Detail    string    `json:"detail,omitempty"`
 	File      string    `json:"file,omitempty"`
 	Line      int       `json:"line,omitempty"`
+	// PathStale is set by VerifyFindingPaths when File names a repo file path
+	// that does NOT exist at the digest's analyzed snapshot (Digest.AnalyzedSnapshot).
+	// Such a finding was generated against a different/older tree than the one
+	// cited in the digest — rendering its path as a live reference would repeat
+	// the "docs/install.md that isn't there" bug (#3704). The renderer marks it
+	// as outdated instead of emitting a dead file reference.
+	PathStale bool `json:"path_stale,omitempty"`
+}
+
+// Snapshot identifies the single commit that a digest's analysis is pinned to.
+// The advisory generator resolves the target repo's latest commit ONCE at the
+// start of a post cycle and records it here, so (a) every file reference in the
+// digest can be verified against one consistent tree and (b) the exact version
+// analyzed is cited in the posted comment (#3704).
+type Snapshot struct {
+	Owner  string `json:"owner"`
+	Repo   string `json:"repo"`
+	Branch string `json:"branch,omitempty"`
+	SHA    string `json:"sha"`
 }
 
 // ResolvedFinding is a closed advisory bead shown in the "Recently Resolved" section.
@@ -45,6 +64,13 @@ type Digest struct {
 	ByAgent          map[string][]Finding `json:"by_agent"`
 	TotalCount       int                  `json:"total_count"`
 	RecentlyResolved []ResolvedFinding    `json:"recently_resolved,omitempty"`
+	// AnalyzedSnapshot, when set, pins the digest to a single repo commit: the
+	// latest commit of the target repo as of when this post cycle started. It is
+	// cited in the rendered comment and used by VerifyFindingPaths to detect
+	// findings whose file paths no longer exist at that commit (#3704). nil keeps
+	// the previous behavior (no citation, no verification) for callers/tests that
+	// do not resolve a snapshot.
+	AnalyzedSnapshot *Snapshot `json:"analyzed_snapshot,omitempty"`
 }
 
 // Store manages advisory findings on disk.
@@ -359,6 +385,73 @@ func repoHintFromTitle(title string, num int, org string) (string, string, bool)
 	return "", "", false
 }
 
+// isFilePathRef reports whether ref denotes a repository file path (as opposed
+// to a GitHub issue/PR reference). File-path refs are the ones formatFindingRef
+// renders as `file:line` code spans and the ones VerifyFindingPaths checks for
+// existence at the analyzed snapshot. A gh-N ref ("gh-123") or an inline issue
+// ref ("repo#123", "owner/repo#123") is NOT a file path.
+func isFilePathRef(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	if ghNumRefPattern.MatchString(ref) {
+		return false
+	}
+	if inlineRefPattern.FindString(ref) == ref {
+		return false
+	}
+	return true
+}
+
+// splitFilePathRef separates a "path:line" style ref into its path component.
+// Only a trailing ":<digits>" is treated as a line suffix; colons elsewhere
+// (rare in repo paths) are left in the path. Returns the bare path.
+func splitFilePathRef(ref string) string {
+	if i := strings.LastIndex(ref, ":"); i > 0 {
+		if _, err := strconv.Atoi(ref[i+1:]); err == nil {
+			return ref[:i]
+		}
+	}
+	return ref
+}
+
+// VerifyFindingPaths checks every finding whose File names a repository file
+// path against the digest's analyzed snapshot and marks those that do not exist
+// at that commit as PathStale. This is the direct guard for #3704: a finding
+// generated against an older tree (e.g. one citing "docs/install.md" that was
+// since removed) must not be rendered as a live file reference under a commit
+// citation where the file is absent.
+//
+// exists is called with the bare file path (line suffix stripped) and must
+// report whether that path exists at the snapshot commit. It is only called for
+// file-path refs, so gh-issue/PR refs never trigger a network lookup. If the
+// digest has no AnalyzedSnapshot, or exists is nil, VerifyFindingPaths is a
+// no-op — callers that do not pin a snapshot keep the previous behavior.
+func VerifyFindingPaths(d *Digest, exists func(path string) bool) {
+	if d == nil || d.AnalyzedSnapshot == nil || exists == nil {
+		return
+	}
+	// Cache results per path: the same file commonly backs multiple findings,
+	// and existence at a fixed commit is stable for the whole cycle.
+	checked := make(map[string]bool)
+	for agent, findings := range d.ByAgent {
+		for i := range findings {
+			f := &findings[i]
+			if !isFilePathRef(f.File) {
+				continue
+			}
+			path := splitFilePathRef(f.File)
+			ok, seen := checked[path]
+			if !seen {
+				ok = exists(path)
+				checked[path] = ok
+			}
+			f.PathStale = !ok
+		}
+		d.ByAgent[agent] = findings
+	}
+}
+
 // FormatDigestMarkdown formats a digest as markdown for posting to GitHub.
 // Findings are grouped by severity (high→low) with a summary table, then
 // listed with their source agent — this gives repo owners a quick "what matters"
@@ -381,6 +474,7 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 		b.WriteString("This comment is updated periodically.\n\n")
 		b.WriteString("**Findings:** 0 — all previously reported findings are resolved. ✅\n\n")
 		writeRecentlyResolved(&b, d, org, primaryRepo)
+		writeAnalyzedFooter(&b, d)
 		return NeutralizeMentions(b.String())
 	}
 
@@ -427,7 +521,16 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 		icon := severityIcon(sev)
 		b.WriteString(fmt.Sprintf("### %s %s (%d)\n\n", icon, strings.ToUpper(sev), len(items)))
 		for _, f := range items {
-			loc := formatFindingRef(logscrub.ScrubString(f.File), f.Line, org, primaryRepo, f.Title)
+			var loc string
+			if f.PathStale {
+				// The file path does not exist at the analyzed commit (#3704):
+				// do not render it as a live `file` reference — it would point
+				// at a path that isn't there. Flag the finding as outdated
+				// instead so a reader knows to disregard the stale location.
+				loc = " _(file path not found at analyzed commit — finding may be outdated)_"
+			} else {
+				loc = formatFindingRef(logscrub.ScrubString(f.File), f.Line, org, primaryRepo, f.Title)
+			}
 			title := logscrub.ScrubString(f.Title)
 			detail := logscrub.ScrubString(f.Detail)
 			b.WriteString(fmt.Sprintf("- **[%s]** %s%s _%s_\n", f.Type, linkifyRefs(title, org), loc, f.Agent))
@@ -439,6 +542,7 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 	}
 
 	writeRecentlyResolved(&b, d, org, primaryRepo)
+	writeAnalyzedFooter(&b, d)
 
 	// Findings quote agent output verbatim and routinely name humans
 	// ("PR #665, by @omerap12"). The digest comment is rewritten every cycle,
@@ -459,6 +563,32 @@ func writeRecentlyResolved(b *strings.Builder, d *Digest, org, primaryRepo strin
 		b.WriteString(fmt.Sprintf("- ~~%s~~%s _%s — resolved %s_\n", linkifyRefs(logscrub.ScrubString(r.Title), org), loc, r.Agent, r.ClosedAt.Format("Jan 2")))
 	}
 	b.WriteString("\n")
+}
+
+// writeAnalyzedFooter cites the exact repo commit this digest's analysis is
+// pinned to (#3704, invariant 2). Rendered only when a snapshot was resolved;
+// callers that do not pin one (older flows, tests) get no footer.
+func writeAnalyzedFooter(b *strings.Builder, d *Digest) {
+	s := d.AnalyzedSnapshot
+	if s == nil || s.SHA == "" {
+		return
+	}
+	shortSHA := s.SHA
+	const shortSHALen = 12
+	if len(shortSHA) > shortSHALen {
+		shortSHA = shortSHA[:shortSHALen]
+	}
+	b.WriteString("---\n")
+	if s.Owner != "" && s.Repo != "" {
+		commitURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", s.Owner, s.Repo, s.SHA)
+		fmt.Fprintf(b, "*Analyzed at [`%s/%s@%s`](%s)", s.Owner, s.Repo, shortSHA, commitURL)
+	} else {
+		fmt.Fprintf(b, "*Analyzed at `%s`", shortSHA)
+	}
+	if s.Branch != "" {
+		fmt.Fprintf(b, " (branch `%s`)", s.Branch)
+	}
+	b.WriteString(" — the latest commit when this digest was generated. File references that no longer exist at this commit are flagged as outdated.*\n")
 }
 
 // SetLatestDigest stores the most recent digest for dashboard access.

--- a/v2/pkg/advisory/snapshot_test.go
+++ b/v2/pkg/advisory/snapshot_test.go
@@ -1,0 +1,138 @@
+package advisory
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestVerifyFindingPathsFlagsMissingFile is the direct regression guard for
+// #3704: a finding whose file path no longer exists at the analyzed commit must
+// be flagged PathStale, while findings for paths that do exist are left alone
+// and GitHub issue/PR refs are never checked at all.
+func TestVerifyFindingPathsFlagsMissingFile(t *testing.T) {
+	findings := []Finding{
+		// The #3704 case: cited path is absent at the analyzed commit.
+		{Agent: "scanner", Severity: "high", Type: "advisory",
+			Title: "install.md does not document the launcher image OCI repo",
+			File:  "docs/install.md"},
+		// A path that still exists.
+		{Agent: "quality", Severity: "medium", Type: "perf",
+			Title: "slow loop", File: "pkg/a.go", Line: 12},
+		// A GitHub issue ref — must never be treated as a file path.
+		{Agent: "scanner", Severity: "low", Type: "bug",
+			Title: "requester explosion", File: "gh-42"},
+	}
+	d := BuildDigest(findings, "busy")
+	d.AnalyzedSnapshot = &Snapshot{
+		Owner: "acme", Repo: "widgets", Branch: "main",
+		SHA: "8a804806a1306f01a911abefb1769c49f000eb35",
+	}
+
+	var checkedPaths []string
+	VerifyFindingPaths(d, func(path string) bool {
+		checkedPaths = append(checkedPaths, path)
+		return path != "docs/install.md" // docs/install.md is gone
+	})
+
+	// gh-42 must not have been checked; the two real file paths must have.
+	for _, p := range checkedPaths {
+		if p == "gh-42" {
+			t.Errorf("gh-42 was checked as a file path; it is a GitHub ref")
+		}
+	}
+	if !containsStr(checkedPaths, "docs/install.md") || !containsStr(checkedPaths, "pkg/a.go") {
+		t.Errorf("expected both file paths checked, got %v", checkedPaths)
+	}
+
+	got := map[string]bool{}
+	for _, fs := range d.ByAgent {
+		for _, f := range fs {
+			got[f.Title] = f.PathStale
+		}
+	}
+	if !got["install.md does not document the launcher image OCI repo"] {
+		t.Error("missing docs/install.md finding should be flagged PathStale")
+	}
+	if got["slow loop"] {
+		t.Error("existing pkg/a.go finding must not be flagged PathStale")
+	}
+	if got["requester explosion"] {
+		t.Error("gh-ref finding must never be flagged PathStale")
+	}
+}
+
+// TestFormatDigestMarkdownRendersStalePathAsOutdated verifies the renderer drops
+// the dead file link for a PathStale finding and marks it outdated instead of
+// emitting a `docs/install.md`-style code span (#3704).
+func TestFormatDigestMarkdownRendersStalePathAsOutdated(t *testing.T) {
+	findings := []Finding{
+		{Agent: "scanner", Severity: "high", Type: "advisory",
+			Title: "install.md missing launcher OCI repo", File: "docs/install.md", PathStale: true},
+	}
+	d := BuildDigest(findings, "busy")
+	md := FormatDigestMarkdown(d, "acme", "widgets")
+
+	if strings.Contains(md, "`docs/install.md`") {
+		t.Errorf("stale file path was rendered as a live code span:\n%s", md)
+	}
+	if !strings.Contains(md, "not found at analyzed commit") {
+		t.Errorf("stale finding not marked as outdated:\n%s", md)
+	}
+}
+
+// TestFormatDigestMarkdownCitesAnalyzedSnapshot verifies invariant 2: the exact
+// analyzed commit is cited in the rendered comment.
+func TestFormatDigestMarkdownCitesAnalyzedSnapshot(t *testing.T) {
+	findings := []Finding{
+		{Agent: "scanner", Severity: "high", Type: "bug", Title: "some bug", File: "pkg/a.go", Line: 3},
+	}
+	d := BuildDigest(findings, "busy")
+	sha := "8a804806a1306f01a911abefb1769c49f000eb35"
+	d.AnalyzedSnapshot = &Snapshot{Owner: "acme", Repo: "widgets", Branch: "main", SHA: sha}
+
+	md := FormatDigestMarkdown(d, "acme", "widgets")
+
+	if !strings.Contains(md, "Analyzed at") {
+		t.Errorf("digest does not cite analyzed snapshot:\n%s", md)
+	}
+	if !strings.Contains(md, sha[:12]) {
+		t.Errorf("digest does not cite the analyzed SHA %s:\n%s", sha[:12], md)
+	}
+	if !strings.Contains(md, "https://github.com/acme/widgets/commit/"+sha) {
+		t.Errorf("digest does not link the analyzed commit:\n%s", md)
+	}
+}
+
+// TestFormatDigestMarkdownNoSnapshotNoFooter confirms backward compatibility:
+// with no AnalyzedSnapshot, no citation footer is emitted.
+func TestFormatDigestMarkdownNoSnapshotNoFooter(t *testing.T) {
+	findings := []Finding{
+		{Agent: "scanner", Severity: "high", Type: "bug", Title: "some bug"},
+	}
+	d := BuildDigest(findings, "busy")
+	md := FormatDigestMarkdown(d, "acme", "widgets")
+	if strings.Contains(md, "Analyzed at") {
+		t.Errorf("no snapshot set but footer was rendered:\n%s", md)
+	}
+}
+
+// TestVerifyFindingPathsNoSnapshotNoOp confirms VerifyFindingPaths is inert when
+// no snapshot is pinned (older/unpinned callers keep prior behavior).
+func TestVerifyFindingPathsNoSnapshotNoOp(t *testing.T) {
+	findings := []Finding{{Agent: "scanner", Title: "x", File: "docs/install.md"}}
+	d := BuildDigest(findings, "busy")
+	called := false
+	VerifyFindingPaths(d, func(string) bool { called = true; return false })
+	if called {
+		t.Error("exists callback invoked with no AnalyzedSnapshot set")
+	}
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -1101,6 +1101,30 @@ func (c *Client) GetFileContentRef(ctx context.Context, owner, repo, path, ref s
 	return content, nil
 }
 
+// PathExistsAtRef reports whether path exists in owner/repo at the given git ref
+// (branch, tag, or commit SHA). It is used by the advisory digest to verify that
+// a finding's file reference still exists at the pinned analysis commit (#3704),
+// so a stale path (e.g. a since-removed "docs/install.md") is not cited as if it
+// were live. A 404 means "does not exist"; any other error is returned so the
+// caller can decide how to treat an inconclusive check.
+func (c *Client) PathExistsAtRef(ctx context.Context, owner, repo, path, ref string) (bool, error) {
+	if c == nil {
+		return false, ErrNoGitHubClient
+	}
+	var opts *gh.RepositoryContentGetOptions
+	if ref != "" {
+		opts = &gh.RepositoryContentGetOptions{Ref: ref}
+	}
+	fileContent, dirContent, resp, err := c.client.Repositories.GetContents(ctx, owner, repo, path, opts)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking %s/%s/%s@%s: %w", owner, repo, path, ref, err)
+	}
+	return fileContent != nil || len(dirContent) > 0, nil
+}
+
 // SearchPRCount searches GitHub for PRs by author within an org.
 // state is "open" or "merged".
 func (c *Client) SearchPRCount(ctx context.Context, author, org, state string) (int, error) {


### PR DESCRIPTION
## Problem

The advisory digest (`🐝 Advisory Digest` comment on the pinned advisory issue) aggregated findings from agents without recording or citing **which version of the repo** they were analyzed against. As reported in #3704, a finding referenced `docs/install.md` — a path that does not exist at the repo's current HEAD — and the comment gave no way to know which commit was seen.

The reporter asked for three invariants:
1. All advice in one comment comes from looking at the same version of the code.
2. That version is cited in the comment.
3. That version is the latest as of when generation started.

## Fix

**Pin + cite the analyzed commit (invariants 2 & 3)** — `v2/cmd/hive/main.go`
At the start of each digest post cycle, resolve the target repo's latest commit **once** (`LatestCommitHash` on the default branch) and pin the digest to it via the new `Digest.AnalyzedSnapshot`. `FormatDigestMarkdown` renders an `Analyzed at owner/repo@<sha>` footer linking that commit.

**Verify file paths against the pinned commit (invariant 1)** — `v2/pkg/advisory/advisory.go`, `v2/pkg/github/client.go`
`VerifyFindingPaths` checks every finding whose `File` names a repo file path against the pinned commit using the new `Client.PathExistsAtRef`. A path that is **absent at that commit** is flagged `PathStale` and rendered as `(file path not found at analyzed commit — finding may be outdated)` instead of a live `` `docs/install.md` `` code span — directly preventing the reported case.

Details:
- GitHub issue/PR refs (`gh-42`, `repo#123`) are never path-checked.
- Inconclusive checks (non-404 errors, e.g. rate limits) **fail open** so a transient error never mislabels a live path as outdated.
- Path existence is cached per path for the cycle.
- **Backward compatible:** with no `AnalyzedSnapshot` (existing tests, unpinned callers) there is no footer and no verification.

## Residual / scope note

Findings are produced by independent agents over time and stored as beads; the digest is a rolling aggregation. This change does **not** re-run every agent's analysis against a single snapshot (that would be an architectural rewrite of the agent loop). Instead it pins the **digest render + citation** to one commit and verifies file references against it, which satisfies the reporter's three invariants for the posted comment and eliminates the stale-path class of bug. Any residual finding whose non-path content is stale will still be superseded on the next agent pass; its cited commit is now always truthful.

## Tests

`v2/pkg/advisory/snapshot_test.go` covers: stale-path flagging (the `docs/install.md` regression), gh-refs never checked, stale-path render, commit citation footer, and backward-compat no-op when unpinned.

Fixes #3704