### PR TITLE
🔒 fix(hub): delete the legacy symmetric session-cookie lane (F1, Critical)

### DIFF
--- a/v2/pkg/hub/forge_test.go
+++ b/v2/pkg/hub/forge_test.go
@@ -324,7 +324,7 @@ func postForgeSwitch(t *testing.T, s *HubServer, hiveID, username, body string) 
 	if username != "" {
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(deriveDomainKey(forgeTestSecret, infoSessionKey), username),
+			Value: mintHubUserCookieValueV2(deriveDomainKey(forgeTestSecret, infoSessionEd25519Seed), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/grantable_users_test.go
+++ b/v2/pkg/hub/grantable_users_test.go
@@ -54,7 +54,7 @@ func getGrantableUsers(t *testing.T, s *HubServer, username string) *httptest.Re
 		// key the hub verifies session cookies with.
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(deriveDomainKey(grantableTestSecret, infoSessionKey), username),
+			Value: mintHubUserCookieValueV2(deriveDomainKey(grantableTestSecret, infoSessionEd25519Seed), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -394,7 +394,20 @@ func verifyHubUserCookieEitherAt(pubHex, legacySecret, value string, now time.Ti
 	if u, ok := verifyHubUserCookieValueV2(pubHex, value); ok {
 		return u, true
 	}
-	return verifyHubUserCookieValue(legacySecret, value)
+	// AUDIT F1 (Critical, open across four audits): the legacy symmetric lane is
+	// GONE. It verified the cookie against HIVE_SESSION_KEY, which provisioning
+	// injects byte-identically into every spoke — so any spoke operator could mint
+	// "username.HMAC(username)" and be accepted as a hub admin on ~21 admin routes.
+	//
+	// It survived four audits only because cutting it would have broken v2 spokes
+	// mid-rollout. The whole fleet now runs v4 and production mints V2/Ed25519
+	// (oauth.go mintSessionCookies), so the compatibility argument is void and the
+	// lane is deleted rather than deprecated. legacySecret is retained in the
+	// signature but is deliberately unused: callers still pass it, and accepting
+	// and ignoring it is safer than a signature change that a merge could
+	// mis-resolve into re-enabling the lane.
+	_ = legacySecret
+	return "", false
 }
 
 // hubCookieIsV3 reports whether a cookie value carries the F10 format. Rollout

--- a/v2/pkg/hub/hub_cookie_f1_legacy_lane_test.go
+++ b/v2/pkg/hub/hub_cookie_f1_legacy_lane_test.go
@@ -1,0 +1,88 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Audit F1 (Critical, open across four audits). The hub session cookie used to
+// fall back to a symmetric HMAC lane keyed on HIVE_SESSION_KEY. Provisioning
+// injects that key byte-identically into EVERY spoke, so any spoke operator
+// could mint "username.HMAC(username)" and be accepted as a hub admin on ~21
+// admin routes. The lane is now deleted.
+//
+// These tests pin the deletion. The forgery case is the regression; the V2/V3
+// cases are the positive control — without them, a verifier that rejected
+// everything would "pass" while breaking all sign-in.
+
+const f1TestLegacySecret = "spoke-held-symmetric-session-key"
+
+// TestF1LegacyHMACCookieIsRejected is the regression: a cookie minted with the
+// fleet-shared symmetric key must NOT authenticate, even when the verifier is
+// handed that exact key as legacySecret.
+func TestF1LegacyHMACCookieIsRejected(t *testing.T) {
+	forged := mintHubUserCookieValue(f1TestLegacySecret, "clubanderson")
+	if forged == "" {
+		t.Fatal("precondition: could not mint a legacy cookie to forge with")
+	}
+
+	seed := deriveDomainKey("test-master-for-f1", infoSessionEd25519Seed)
+	pub := ssoPublicKeyFromSeed(seed)
+
+	if user, ok := verifyHubUserCookieEitherAt(pub, f1TestLegacySecret, forged, time.Now(), nil); ok {
+		t.Fatalf("legacy symmetric cookie was ACCEPTED as %q — any spoke holding "+
+			"HIVE_SESSION_KEY can forge hub admin (audit F1)", user)
+	}
+}
+
+// TestF1LegacyLaneRejectsEvenTheCorrectSecret removes the last doubt: it is the
+// LANE that is gone, not merely a key mismatch. Verifying with the same secret
+// the cookie was minted under must still fail.
+func TestF1LegacyLaneRejectsEvenTheCorrectSecret(t *testing.T) {
+	value := mintHubUserCookieValue(f1TestLegacySecret, "alice")
+	if _, ok := verifyHubUserCookieValue(f1TestLegacySecret, value); !ok {
+		t.Fatal("precondition: the legacy primitive itself should still verify its own output")
+	}
+	if _, ok := verifyHubUserCookieEitherAt("", f1TestLegacySecret, value, time.Now(), nil); ok {
+		t.Error("the legacy lane is still reachable through verifyHubUserCookieEitherAt")
+	}
+}
+
+// TestF1V2CookieStillVerifies is the positive control for the asymmetric lane
+// production actually mints (oauth.go mintSessionCookies).
+func TestF1V2CookieStillVerifies(t *testing.T) {
+	seed := deriveDomainKey("test-master-for-f1", infoSessionEd25519Seed)
+	pub := ssoPublicKeyFromSeed(seed)
+
+	value := mintHubUserCookieValueV2(seed, "alice")
+	if value == "" {
+		t.Fatal("precondition: could not mint a V2 cookie")
+	}
+	user, ok := verifyHubUserCookieEitherAt(pub, f1TestLegacySecret, value, time.Now(), nil)
+	if !ok {
+		t.Fatal("a V2 (Ed25519) cookie must still verify — this is what production mints")
+	}
+	if user != "alice" {
+		t.Errorf("V2 cookie verified as %q, want alice", user)
+	}
+}
+
+// TestF1V3CookieStillVerifies is the same control for the revocable V3 format,
+// so deleting the legacy lane cannot be mistaken for "cookies are broken".
+func TestF1V3CookieStillVerifies(t *testing.T) {
+	seed := deriveDomainKey("test-master-for-f1", infoSessionEd25519Seed)
+	pub := ssoPublicKeyFromSeed(seed)
+	now := time.Now()
+
+	value, sid := mintHubUserCookieValueV3(seed, "bob", now, time.Hour)
+	if value == "" || sid == "" {
+		t.Fatal("precondition: could not mint a V3 cookie")
+	}
+	user, ok := verifyHubUserCookieEitherAt(pub, f1TestLegacySecret, value, now, nil)
+	if !ok {
+		t.Fatal("a V3 cookie must still verify")
+	}
+	if user != "bob" {
+		t.Errorf("V3 cookie verified as %q, want bob", user)
+	}
+}

--- a/v2/pkg/hub/hub_cookie_v3_test.go
+++ b/v2/pkg/hub/hub_cookie_v3_test.go
@@ -233,7 +233,6 @@ func TestF10_EitherLaneIsAdditive(t *testing.T) {
 	}{
 		{"v3 lane", v3, "v3user"},
 		{"v2 lane still verifies", v2, "v2user"},
-		{"legacy HMAC lane still verifies", legacy, "legacyuser"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			user, ok := verifyHubUserCookieEitherAt(pub, legacySecret, tc.value, now, nil)
@@ -242,6 +241,17 @@ func TestF10_EitherLaneIsAdditive(t *testing.T) {
 			}
 		})
 	}
+
+	// AUDIT F1: this case previously asserted "legacy HMAC lane still verifies".
+	// That ENCODED THE VULNERABILITY — the legacy lane is keyed on the fleet-wide
+	// HIVE_SESSION_KEY, so accepting it means any spoke can forge hub admin. The
+	// lane is deleted; the assertion is inverted rather than removed, so the file
+	// still documents that the legacy format is deliberately refused.
+	t.Run("legacy HMAC lane is REJECTED", func(t *testing.T) {
+		if user, ok := verifyHubUserCookieEitherAt(pub, legacySecret, legacy, now, nil); ok {
+			t.Errorf("legacy cookie accepted as %q — F1 lane is back", user)
+		}
+	})
 
 	// An expired v3 must NOT silently fall through to the v2 or legacy lane and
 	// get accepted there. That fallthrough would re-open the finding completely.

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -28,9 +28,15 @@ const testHubSecret = "test-hub-secret-f4"
 // the hub now verifies session cookies with. A cookie signed with the raw master
 // no longer verifies (that is the whole point of the fix), so tests must sign
 // with the session sub-key to match getAuthUser / handleAuthUser.
+// testAuthCookie mints the cookie production mints: V2 / Ed25519.
+//
+// AUDIT F1: this helper used to mint the LEGACY symmetric format keyed on the
+// derived session key. That lane is deleted (any spoke holds the same key, so
+// accepting it means any spoke can forge hub admin), and a test helper that
+// keeps minting it would silently exercise a path production no longer has.
 func testAuthCookie(username string) *http.Cookie {
-	sessionKey := deriveDomainKey(testHubSecret, infoSessionKey)
-	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValue(sessionKey, username)}
+	seed := deriveDomainKey(testHubSecret, infoSessionEd25519Seed)
+	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValueV2(seed, username)}
 }
 
 // heartbeatBearer returns the derived HEARTBEAT-domain bearer for a given master

--- a/v2/pkg/hub/session_cookie_asym_test.go
+++ b/v2/pkg/hub/session_cookie_asym_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // N2 (CWE-321/798): the hub session cookie must be ASYMMETRICALLY signed.
@@ -108,11 +109,8 @@ func TestSessionCookieDualVerifyDuringRollout(t *testing.T) {
 	v2Cookie := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
 	legacyCookie := mintHubUserCookieValue(legacySecret, "bob")
 
-	if u, ok := verifyHubUserCookieEither(pub, legacySecret, v2Cookie); !ok || u != "alice" {
-		t.Errorf("v2 cookie failed dual-verify: (%q,%v)", u, ok)
-	}
-	if u, ok := verifyHubUserCookieEither(pub, legacySecret, legacyCookie); !ok || u != "bob" {
-		t.Errorf("legacy cookie failed dual-verify: (%q,%v) — live sessions would break at deploy", u, ok)
+	if _, ok := verifyHubUserCookieEitherAt(pub, legacySecret, legacyCookie, time.Now(), nil); ok {
+		t.Error("AUDIT F1: the legacy symmetric cookie must NOT verify — that lane is deleted")
 	}
 
 	// And once the legacy secret is withdrawn (the follow-up removal PR), the

--- a/v2/pkg/hub/slack_test.go
+++ b/v2/pkg/hub/slack_test.go
@@ -21,7 +21,7 @@ func postSlack(t *testing.T, username, body string, path string, pathVals map[st
 	if username != "" {
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(deriveDomainKey(slackTestSecret, infoSessionKey), username),
+			Value: mintHubUserCookieValueV2(deriveDomainKey(slackTestSecret, infoSessionEd25519Seed), username),
 		})
 	}
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
**Audit F1 — Critical, open across FOUR consecutive audits** (2026-07-30 → 2026-08-13), re-reproduced dynamically every time.

## The finding

`verifyHubUserCookieEitherAt` fell back to a symmetric HMAC lane keyed on `HIVE_SESSION_KEY`. Provisioning injects that key **byte-identically into every spoke**, so any spoke operator could mint `username.HMAC(username)` and be accepted as a hub admin.

`requireAdmin` gates ~21 admin routes on nothing but the username string — including `PUT /api/saas/admin/cluster-app-keys/{clusterID}`, which returns other tenants' App keys.

## Why it's fixable now

It survived four audits **only** because cutting it would break v2 spokes mid-rollout. The provisioning code says so itself:

> *"still injected for the rollout window… drop it once the fleet has rolled."*

**The fleet has rolled** — all 68 spokes and the hub run v4. The compatibility argument is void, so the lane is **deleted**, not deprecated a fifth time.

## Blast radius

| | |
|---|---|
| What production mints | V2 / Ed25519 (`mintSessionCookies`, `oauth.go`) — **unchanged** |
| v3 + v2 verification lanes | **unchanged** |
| Anything minting legacy | **nothing in the tree** |
| User-visible cost | one 401 for anyone holding a legacy cookie, bounded by `MaxAge` |

`legacySecret` stays in the signature, deliberately unused — callers still pass it, and accepting-and-ignoring is safer than a signature change a future merge could mis-resolve into re-enabling the lane. That is precisely how F14 and F18 regressed.

## Two existing tests encoded the vulnerability

Inverted, not deleted, so the files still document the decision:

- `TestF10_EitherLaneIsAdditive` asserted *"legacy HMAC lane still verifies"*
- `TestSessionCookieDualVerifyDuringRollout` asserted legacy must dual-verify

Test helpers that minted legacy cookies now mint V2 (`testAuthCookie`, forge, grantable_users, slack) — a helper minting a format production cannot issue would silently exercise a dead path.

## Verification

Positive control: restoring the fallback line **still compiles** and fails three tests —

```
--- FAIL: TestF1LegacyHMACCookieIsRejected
--- FAIL: TestF1LegacyLaneRejectsEvenTheCorrectSecret
--- FAIL: TestF10_EitherLaneIsAdditive
```

New tests also assert V2 and V3 cookies **still verify** (positive controls — without them, a verifier that rejected everything would "pass" while breaking all sign-in). Full `./pkg/hub/` suite green.