### PR TITLE
🔒 fix(hub): enable in-place cutover to the per-hive heartbeat bearer (F2)

### DIFF
--- a/v2/docs/heartbeat-bearer-cutover.md
+++ b/v2/docs/heartbeat-bearer-cutover.md
@@ -1,0 +1,152 @@
+# Heartbeat bearer cutover (audit F2)
+
+How to remove the fleet-wide heartbeat bearer lane **without re-provisioning the
+fleet**, and the hard precondition that gates the removal.
+
+## The finding
+
+`verifyHeartbeatBearer` (`v2/pkg/hub/hub_keys.go`) ends with:
+
+```go
+return secureCompareHub(presented, s.heartbeatKey())
+```
+
+`s.heartbeatKey()` is `deriveDomainKey(hubSecret, infoHeartbeatKey)` — a pure
+function of the one hub master, stamped identically into every spoke. Possession
+proves "some provisioned spoke", never "**this** hive". The handler then trusts
+the body-supplied `hive_id`, so any spoke can heartbeat as any victim hive and be
+handed victim-directed key material (pending OpenRouter key, legacy pending App
+config, standing cluster App key).
+
+This lane has been open across five audits. The blocker was never the fix — the
+per-hive replacement `heartbeatKeyFor(hiveID)` already existed — it was the
+migration: deleting the lane 401s every spoke that still presents the fleet-wide
+value, and the stated migration path was "re-provision the fleet", which the
+operator has ruled out.
+
+## Why an in-place migration is possible
+
+The per-hive bearer is
+
+```
+HMAC(master, "hive-heartbeat-v1" || 0x00 || hiveID)
+```
+
+— a pure function of **two values every spoke already holds in its own pod env**:
+`HIVE_HUB_SECRET` and `HIVE_ID`. No hub action, no new secret, no re-provision is
+needed for a spoke to start presenting the identity-bound bearer. It only needs
+code that derives it.
+
+### Measured fleet state (2026-08-13, contexts `hive-oke` + `vllm-d`)
+
+Classified by comparing each Deployment's `HIVE_HEARTBEAT_KEY` against both
+derivations computed from the live master:
+
+| Lane | Spokes |
+|---|---|
+| Per-hive `HIVE_HEARTBEAT_KEY` injected by the hub | 62 |
+| `HIVE_HEARTBEAT_KEY` **absent** → self-derives fleet-wide today | 3 |
+| Fleet-wide value explicitly injected | 0 |
+
+The three laggards are:
+
+- `hive-oke/hive-hosted-hosted-available-oke-02-placeholder-7zus`
+- `hive-oke/hive-hosted-hosted-daviddiaz0317-visual-hive--1jos`
+- `hive-oke/hive-hosted-hosted-projectbluefin-knuckle-gjvq`
+
+All three have `HIVE_HUB_SECRET` and `HIVE_ID` present, so all three can
+self-derive. They are the only reason the legacy lane cannot be deleted, and they
+need a code roll, not a re-provision.
+
+Provisioning has injected the per-hive key since the N1 change
+(`provisionHeartbeatKey`), so the 62 need nothing at all.
+
+## Stage 1 — enabling change (this PR)
+
+Spoke-side only. `SpokeHeartbeatKey()` now resolves in this order:
+
+1. `HIVE_HEARTBEAT_KEY` — the hub-injected value (unchanged; still authoritative,
+   so a pinned or self-hosted bearer is never overridden).
+2. **Self-derived per-hive bearer** from `HIVE_HUB_SECRET` + `HIVE_ID` — new.
+3. Fleet-wide derivation from `HIVE_HUB_SECRET` alone — now the last resort,
+   reachable only by a spoke with a master but no identity.
+
+The hub is **unchanged**: it still accepts both lanes. Nothing can break, because
+every spoke either keeps presenting the same injected value it already presents
+(62) or moves from a bearer the hub accepts to a *different* bearer the hub also
+accepts (3).
+
+A spoke on lane 2 is strictly safer than one on lane 3: its credential
+authenticates only as itself. Self-hosted single-tenant operators are unaffected —
+their hub re-derives the same per-hive value from the same master.
+
+## Stage 2 — observe
+
+Rollout telemetry already exists (`noteHeartbeatAuthPath`,
+`AuthRolloutReadiness`, admin route `GET /api/saas/admin/auth-rollout`). It
+records, per hive, whether the **most recent** heartbeat used the identity-bound
+bearer, and deliberately does not latch — a rolled-back spoke must make the fleet
+read not-ready again.
+
+```
+GET /api/saas/admin/auth-rollout
+{
+  "total_hives": 65,
+  "per_hive_bearer": 65,
+  "legacy_bearer": 0,
+  "heartbeat_lane_ready": true,
+  "stale_after": "24h0m0s"
+}
+```
+
+## Stage 3 — deletion (a separate PR, NOT this one)
+
+### Hard precondition
+
+Do not open the deletion PR until **all** of the following hold:
+
+1. `heartbeat_lane_ready` is `true` **and** `legacy_bearer` is `0`.
+2. `total_hives` equals the actual live spoke count (65 at time of writing —
+   re-count it; do not trust this number). `AuthRolloutReadiness` fails closed at
+   zero observations, but it cannot tell "hive absent" from "hive never existed",
+   so a hive that is paused or on an unreachable cluster silently leaves the
+   denominator after `stale_after` (24h). Compare against a real inventory:
+
+   ```sh
+   # Count by CONTAINER name, not by an `app=hive` label — that label is not
+   # applied consistently across clusters and undercounts (it matched 0 of 22
+   # spokes on hive-oke when this was written).
+   for ctx in hive-oke vllm-d; do
+     kubectl --context "$ctx" get deploy -A -o json \
+       | jq '[.items[]|select(.spec.template.spec.containers[].name=="hive")]|length'
+   done
+   ```
+
+3. Condition 1 has held continuously for **at least 24h** (one full
+   `stale_after` window), so a spoke that beats infrequently has had a chance to
+   appear on the per-hive lane rather than merely aging out of the denominator.
+4. Every spoke has actually rolled the Stage 1 image. Verify by SHA, not by tag.
+
+### The deletion
+
+Replace the final line of `verifyHeartbeatBearer` with `return false` and drop
+`heartbeatKey()` if it has no other caller. Then flip
+`TestFleetWideBearerStillAcceptedAtThisStage` to assert **rejection** — it is
+written to fail loudly with the precondition in its message if the lane is
+removed early.
+
+### Rollback
+
+The lane is one line. If heartbeats 401 after deletion, restore it and the fleet
+recovers on the next beat (~1 min). Nothing is persisted, so there is no
+migration to undo.
+
+## Residual risk not addressed here
+
+Every spoke Deployment still carries `HIVE_HUB_SECRET`, the hub **master**, in
+plaintext (65/65 measured). Any spoke operator can read it and derive *any*
+hive's per-hive bearer, which defeats the identity binding for an attacker with
+pod access. Self-derivation does not make this worse — it is the same material
+already present — but F2 is only fully closed once the master stops being
+injected into spokes and they hold nothing but their own derived sub-keys. That
+is a separate finding and a separate change.

--- a/v2/pkg/hub/heartbeat_selfderive_test.go
+++ b/v2/pkg/hub/heartbeat_selfderive_test.go
@@ -1,0 +1,153 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// F2: the fleet-wide heartbeat bearer lane in verifyHeartbeatBearer does not
+// bind identity, so any spoke can beat as any victim hive. Removing it requires
+// that every spoke first present the per-hive bearer — historically blocked on
+// "re-provision the fleet", which the operator has ruled out.
+//
+// These tests pin the property that makes an IN-PLACE cutover possible: the
+// per-hive bearer is HMAC(master, info || 0x00 || hiveID), a pure function of
+// material the spoke ALREADY HOLDS (HIVE_HUB_SECRET + HIVE_ID). A spoke can
+// therefore migrate itself by rolling code, with no hub action and no
+// re-provision.
+
+// TestSpokeHeartbeatKeySelfDerivesPerHive is the F2 enabling property: a spoke
+// holding the master and its own hive ID — but NO injected HIVE_HEARTBEAT_KEY —
+// presents the identity-bound bearer rather than the fleet-wide one.
+//
+// This is exactly the configuration of the 3 live spokes measured with
+// HIVE_HEARTBEAT_KEY absent. Before this change they presented the fleet-wide
+// bearer and were the sole reason the legacy lane could not be deleted.
+func TestSpokeHeartbeatKeySelfDerivesPerHive(t *testing.T) {
+	const master = "test-master-secret-f2"
+	const hiveID = "hive-alpha"
+
+	t.Setenv("HIVE_HUB_SECRET", master)
+	t.Setenv(EnvHeartbeatKey, "") // not injected — the laggard configuration
+	t.Setenv(EnvHiveID, hiveID)
+
+	got := SpokeHeartbeatKey()
+
+	perHive := derivePerHiveKey(master, infoHeartbeatKey, hiveID)
+	fleetWide := deriveDomainKey(master, infoHeartbeatKey)
+
+	if got == fleetWide {
+		t.Fatal("F2: spoke still presents the FLEET-WIDE bearer despite holding both " +
+			"the master and its own hive ID — the legacy lane could never be deleted " +
+			"without re-provisioning")
+	}
+	if got != perHive {
+		t.Fatalf("spoke bearer = %q, want the self-derived per-hive value %q", got, perHive)
+	}
+
+	// And the hub accepts it as identity-bound, without any provisioning step.
+	s := &HubServer{logger: slog.Default(), hubSecret: master}
+	if !s.verifyHeartbeatBearer(got, hiveID) {
+		t.Fatal("hub rejected the self-derived per-hive bearer — the in-place migration " +
+			"would 401 the spoke")
+	}
+	if !s.heartbeatBearerIsPerHive(got, hiveID) {
+		t.Fatal("self-derived bearer not reported as per-hive — rollout telemetry would " +
+			"never reach 100% and the deletion precondition could not be met")
+	}
+}
+
+// TestSpokeSelfDerivedBearerCannotImpersonateAnotherHive is the finding itself,
+// asserted end-to-end through the spoke-side resolver: the bearer a spoke
+// self-derives must authenticate ONLY that spoke.
+//
+// Without this, self-derivation could "succeed" while still handing out a
+// credential that works fleet-wide — migrating the telemetry but not the
+// vulnerability.
+func TestSpokeSelfDerivedBearerCannotImpersonateAnotherHive(t *testing.T) {
+	const master = "test-master-secret-f2"
+
+	t.Setenv("HIVE_HUB_SECRET", master)
+	t.Setenv(EnvHeartbeatKey, "")
+
+	t.Setenv(EnvHiveID, "hive-attacker")
+	attackerBearer := SpokeHeartbeatKey()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: master}
+
+	// Positive control: the attacker CAN still beat as itself. Without this a
+	// resolver that returned garbage for everything would pass the check below.
+	if !s.verifyHeartbeatBearer(attackerBearer, "hive-attacker") {
+		t.Fatal("positive control failed: a spoke could not authenticate as ITSELF, so " +
+			"the rejection below proves nothing")
+	}
+
+	// The finding: it must NOT beat as the victim.
+	if s.verifyHeartbeatBearer(attackerBearer, "hive-victim") {
+		t.Fatal("F2: a self-derived bearer authenticated a heartbeat CLAIMING to be " +
+			"another hive — the victim's key material would be delivered to the attacker")
+	}
+}
+
+// TestSpokeInjectedKeyStillWinsOverSelfDerivation guards the ordering. 62 of 65
+// live spokes already hold a hub-injected per-hive HIVE_HEARTBEAT_KEY; if
+// self-derivation silently overrode it, a self-hosted spoke whose operator
+// deliberately pinned a bearer would start presenting a different value and
+// break. The injected value must remain authoritative.
+func TestSpokeInjectedKeyStillWinsOverSelfDerivation(t *testing.T) {
+	t.Setenv("HIVE_HUB_SECRET", "test-master-secret-f2")
+	t.Setenv(EnvHiveID, "hive-alpha")
+	t.Setenv(EnvHeartbeatKey, "explicitly-injected-bearer")
+
+	if got := SpokeHeartbeatKey(); got != "explicitly-injected-bearer" {
+		t.Fatalf("injected bearer = %q, want it to take precedence over self-derivation", got)
+	}
+}
+
+// TestSpokeSelfDerivationRequiresBothInputs pins the fail-closed edges: with no
+// master there is no bearer at all, and with no identity the spoke falls back to
+// the fleet-wide value rather than deriving something empty or attacker-chosen.
+func TestSpokeSelfDerivationRequiresBothInputs(t *testing.T) {
+	const master = "test-master-secret-f2"
+
+	// No master at all → no bearer. The spoke must fail closed, not present "".
+	t.Setenv("HIVE_HUB_SECRET", "")
+	t.Setenv(EnvHeartbeatKey, "")
+	t.Setenv(EnvHiveID, "hive-alpha")
+	if got := SpokeHeartbeatKey(); got != "" {
+		t.Fatalf("with no master, spoke bearer = %q, want \"\" (fail closed)", got)
+	}
+
+	// Master but no identity → fleet-wide fallback, explicitly. This lane is what
+	// the final deletion PR removes support for; it must be reachable ONLY here.
+	t.Setenv("HIVE_HUB_SECRET", master)
+	t.Setenv(EnvHiveID, "")
+	if got, want := SpokeHeartbeatKey(), deriveDomainKey(master, infoHeartbeatKey); got != want {
+		t.Fatalf("with no hive ID, spoke bearer = %q, want the fleet-wide value %q", got, want)
+	}
+}
+
+// TestFleetWideBearerStillAcceptedAtThisStage asserts the CURRENT stage
+// explicitly, so the cutover status is unambiguous in the test suite rather than
+// inferred. This PR does NOT delete the legacy lane — a spoke that has not yet
+// rolled the self-derivation code still presents the fleet-wide bearer, and
+// dropping it now would 401 those spokes.
+//
+// The deletion PR flips this test to assert rejection. If it starts failing
+// because the lane was removed, that is the signal to check the precondition in
+// AuthRolloutReadiness (heartbeat_lane_ready, 65/65) before flipping it.
+func TestFleetWideBearerStillAcceptedAtThisStage(t *testing.T) {
+	s := &HubServer{logger: slog.Default(), hubSecret: "test-master-secret-f2"}
+
+	if !s.verifyHeartbeatBearer(s.heartbeatKey(), "hive-alpha") {
+		t.Fatal("the fleet-wide lane was removed — every spoke that has not yet rolled " +
+			"the self-derivation change will 401. Confirm AuthRolloutReadiness reports " +
+			"heartbeat_lane_ready with 0 legacy hives before making this change.")
+	}
+	// It is still correctly flagged as NOT identity-bound, which is what drives
+	// the readiness signal that gates the deletion.
+	if s.heartbeatBearerIsPerHive(s.heartbeatKey(), "hive-alpha") {
+		t.Fatal("fleet-wide bearer misreported as per-hive — readiness would read 100% " +
+			"while spokes are still unbound, and the deletion would be made on false evidence")
+	}
+}

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -287,20 +287,53 @@ func spokeDomainKey(envVar, info string) string {
 	return deriveDomainKey(strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")), info)
 }
 
+// EnvHiveID is the spoke's own hive identity, injected into every hosted
+// Deployment and read by loadOrGenerateHiveID as the authoritative source. It is
+// the second input SpokeHeartbeatKey needs to SELF-DERIVE the per-hive bearer.
+const EnvHiveID = "HIVE_ID"
+
 // SpokeHeartbeatKey returns the bearer a spoke presents on /api/heartbeat and
 // /api/task-status. Exported for use from the dashboard/heartbeat call sites.
 //
-// N1 note: a hub-provisioned spoke gets HIVE_HEARTBEAT_KEY, which is now the
-// PER-HIVE bearer — no spoke-side change is needed, the value in the env var
-// simply becomes identity-bound at the next re-provision.
+// Resolution order, most to least identity-bound (audit F2):
 //
-// The HIVE_HUB_SECRET fallback below still derives the FLEET-wide bearer, and
-// deliberately so: it serves self-hosted operators who legitimately hold the
-// master and beat against their own hub, where "any spoke can claim any ID" is
-// not a cross-tenant concern because there is exactly one tenant. The hub keeps
-// accepting that value through verifyHeartbeatBearer's legacy lane. A hosted
-// spoke cannot reach this path — it never receives the master.
-func SpokeHeartbeatKey() string { return spokeDomainKey(EnvHeartbeatKey, infoHeartbeatKey) }
+//  1. HIVE_HEARTBEAT_KEY — the hub-injected value. Since the N1 provisioning
+//     change this IS the per-hive bearer, so a spoke provisioned at any point
+//     after that change is already identity-bound with no code involved.
+//  2. Self-derived per-hive bearer, from HIVE_HUB_SECRET + HIVE_ID. This is the
+//     lane that makes an IN-PLACE cutover possible without re-provisioning.
+//  3. Fleet-wide derivation from HIVE_HUB_SECRET alone — the legacy value, kept
+//     only for a spoke that genuinely cannot identify itself (no HIVE_ID).
+//
+// Lane 2 is the F2 fix. The per-hive bearer is HMAC(master, info || 0x00 ||
+// hiveID) — a pure function of two things the spoke ALREADY HOLDS. Any spoke
+// with both the master and its own hive ID can compute the identity-bound bearer
+// itself, with no hub action, no new secret, and no re-provision. Measured on the
+// live fleet, 62 of 65 spokes are already on lane 1 and the remaining 3 have
+// HIVE_HEARTBEAT_KEY absent but HIVE_HUB_SECRET and HIVE_ID both present — so
+// they move from the fleet-wide bearer to the per-hive one the moment they roll
+// this code, which is what lets the hub's legacy lane be deleted afterwards.
+//
+// A spoke deriving lane 2 is strictly SAFER than one deriving lane 3: it presents
+// a credential that only authenticates as itself. This does not weaken the
+// self-hosted case either — a single-tenant operator's hub re-derives the same
+// per-hive value from the same master, so verification succeeds unchanged.
+//
+// Lane 3 remains only for the degenerate "master but no identity" configuration.
+// derivePerHiveKey returns "" for an empty hive ID rather than silently sharing
+// one key again, so that case is detected rather than assumed away.
+func SpokeHeartbeatKey() string {
+	if v := strings.TrimSpace(os.Getenv(EnvHeartbeatKey)); v != "" {
+		return v
+	}
+	master := strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET"))
+	if hiveID := strings.TrimSpace(os.Getenv(EnvHiveID)); hiveID != "" {
+		if perHive := derivePerHiveKey(master, infoHeartbeatKey, hiveID); perHive != "" {
+			return perHive
+		}
+	}
+	return deriveDomainKey(master, infoHeartbeatKey)
+}
 
 // SpokeSessionKey returns the key a spoke uses to VERIFY the hub-minted
 // `hive_hub_user` session/terminal cookie. It signs nothing on the spoke.

--- a/v2/pkg/hub/hub_keys_test.go
+++ b/v2/pkg/hub/hub_keys_test.go
@@ -88,9 +88,13 @@ func TestSpokeHeartbeatKeyCannotForgeOtherDomains(t *testing.T) {
 func TestSpokeKeyResolutionPrefersExplicitEnv(t *testing.T) {
 	const master = "legacy-master"
 
-	// Legacy path: only the master is present → derive.
+	// Legacy path: the master is present but the spoke cannot identify itself
+	// (no HIVE_ID) → fleet-wide derivation. This is now the LAST resort; see
+	// TestSpokeHeartbeatKeySelfDerivesPerHive for the identity-bound lane that
+	// takes precedence whenever HIVE_ID is set.
 	t.Setenv("HIVE_HUB_SECRET", master)
 	t.Setenv(EnvHeartbeatKey, "")
+	t.Setenv(EnvHiveID, "")
 	if got, want := SpokeHeartbeatKey(), deriveDomainKey(master, infoHeartbeatKey); got != want {
 		t.Errorf("legacy heartbeat key = %q, want derived %q", got, want)
 	}


### PR DESCRIPTION
## Finding

**F2 (Critical)** — open across five audits, the longest-lived Critical in the corpus.

`verifyHeartbeatBearer` (`v2/pkg/hub/hub_keys.go`) ends with a fleet-wide lane:

```go
return secureCompareHub(presented, s.heartbeatKey())
```

`s.heartbeatKey()` is a pure function of the one hub master, stamped identically into every spoke. Possession proves *"some provisioned spoke"*, never *"THIS hive"*. The handler then trusts the body-supplied `hive_id`, so any spoke can heartbeat as any victim hive and be handed victim-directed key material.

The per-hive replacement (`heartbeatKeyFor`) already existed and worked. **The blocker was never the fix — it was the migration.** The documented path was "re-provision the fleet", which the operator has ruled out, and a flag-day deletion would 401 every un-rolled spoke at once (#2773's failure mode).

## Why an in-place migration works

The per-hive bearer is `HMAC(master, "hive-heartbeat-v1" || 0x00 || hiveID)` — a pure function of **two values every spoke already holds in its own pod env**: `HIVE_HUB_SECRET` and `HIVE_ID`. A spoke can migrate itself with a code roll. No hub action, no new secret, no re-provision.

### Measured fleet state (`hive-oke` + `vllm-d`, read-only)

Each Deployment's `HIVE_HEARTBEAT_KEY` compared against both derivations computed from the live master:

| Lane | Spokes |
|---|---|
| Per-hive key injected by the hub | **62** |
| `HIVE_HEARTBEAT_KEY` **absent** → self-derives fleet-wide today | **3** |
| Fleet-wide value explicitly injected | 0 |

The 3 laggards (`...oke-02-placeholder-7zus`, `...daviddiaz0317-visual-hive--1jos`, `...projectbluefin-knuckle-gjvq`) all have `HIVE_HUB_SECRET` **and** `HIVE_ID` present, so all three can self-derive. They are the *only* reason the legacy lane cannot be deleted.

## What this PR does

Spoke-side only. `SpokeHeartbeatKey()` now resolves:

1. `HIVE_HEARTBEAT_KEY` — hub-injected (unchanged, still authoritative)
2. **Self-derived per-hive bearer** from `HIVE_HUB_SECRET` + `HIVE_ID` — new
3. Fleet-wide derivation — now last resort, only for a spoke with a master but no identity

**The hub is deliberately unchanged.** It still accepts both lanes, so nothing can break: each spoke either presents the same value it already presents (62), or moves from one accepted bearer to another accepted bearer (3). Keeping the injected value authoritative means a pinned or self-hosted bearer is never overridden, and self-hosted operators are unaffected because their hub re-derives the same per-hive value from the same master.

## What is deferred

**Lane 2 is NOT deleted here.** Deleting it today would 401 the three laggards. `v2/docs/heartbeat-bearer-cutover.md` documents the hard precondition for the deletion PR:

- `auth-rollout` reports `legacy_bearer: 0` / `heartbeat_lane_ready: true`
- `total_hives` matches a **real inventory** (the readiness signal cannot distinguish "hive absent" from "hive never existed" — a paused spoke silently leaves the denominator after the 24h stale window)
- held continuously for a full 24h window
- every spoke verified rolled **by SHA, not tag**

The runbook's inventory command counts by *container name*, not an `app=hive` label — that label matched 0 of 22 spokes on `hive-oke` and would have undercounted by 25.

## Residual risk (not closed here)

Every spoke still carries `HIVE_HUB_SECRET`, the hub **master**, in plaintext (65/65). Any spoke operator can read it and derive *any* hive's bearer. Self-derivation doesn't make this worse — same material, already present — but F2 is only fully closed once the master stops being injected into spokes. Separate finding, separate change.

## Tests

- `TestSpokeHeartbeatKeySelfDerivesPerHive` — the enabling property
- `TestSpokeSelfDerivedBearerCannotImpersonateAnotherHive` — **the finding**; includes a positive control that the spoke can still beat as itself, so the rejection proves something
- `TestSpokeInjectedKeyStillWinsOverSelfDerivation` — ordering guard
- `TestSpokeSelfDerivationRequiresBothInputs` — fail-closed edges
- `TestFleetWideBearerStillAcceptedAtThisStage` — asserts the current stage explicitly; written to fail with the precondition in its message if the lane is removed early

**Regression replay:** removing the self-derivation lane (still compiling) fails `TestSpokeHeartbeatKeySelfDerivesPerHive` and `TestSpokeSelfDerivedBearerCannotImpersonateAnotherHive` on the exact F2 property; restored, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)