### PR TITLE
🔒 fix(proxy): attribute the hive's own egress so v4 stops blocking App-token mints

### DIFF
--- a/v2/pkg/agent/uidmap.go
+++ b/v2/pkg/agent/uidmap.go
@@ -83,6 +83,42 @@ func (u *UIDMap) LookupByUID(uid int) string {
 	return ""
 }
 
+// IsInternalUID reports whether uid belongs to the hive's OWN control plane
+// rather than to a sandboxed agent — the hive process itself (which runs as
+// root) or the MITM proxy user.
+//
+// WHY THIS EXISTS (proxy request blocked / github_auth 403). v4 forces ALL
+// egress through the MITM proxy, including the hive's own control-plane calls.
+// The proxy attributes a connection to an agent by looking its UID up in
+// Agents; the hive process is not an agent, so the lookup missed, agentName
+// came back "", and identifyAgentFromConn's caller fell back to ADVISORY and
+// blocked the write. That silently broke every App installation-token mint
+// (POST /app/installations/{id}/access_tokens) on v4 spokes — surfacing as a
+// bogus GitHub "403" and paused agents fleet-wide.
+//
+// SECURITY. This must NEVER match an agent UID. Agents are >= BaseUID (2001)
+// and are dynamically allocated upward, so the internal set is exactly {0, the
+// proxy UID} and is checked against Agents as a belt-and-braces guard: if an
+// agent were ever provisioned at 0 or at ProxyUID, this returns false rather
+// than handing that agent an exemption. Verified on a live v4 spoke that an
+// agent UID cannot reach 0: su-exec is 4750 root:hive-launch and agents are not
+// in hive-launch (Permission denied), /usr/bin/su fails (root is password
+// locked, "*"), and mount is refused (no CAP_SYS_ADMIN, CapBnd 15fb).
+func (u *UIDMap) IsInternalUID(uid int) bool {
+	if uid != 0 && uid != u.ProxyUID {
+		return false
+	}
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	for _, agentUID := range u.Agents {
+		if agentUID == uid {
+			// An agent occupies this UID — never treat it as internal.
+			return false
+		}
+	}
+	return true
+}
+
 // LookupByName returns the UID for a given agent name, or 0 if not found.
 func (u *UIDMap) LookupByName(name string) int {
 	u.mu.RLock()

--- a/v2/pkg/agent/uidmap_internal_test.go
+++ b/v2/pkg/agent/uidmap_internal_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import "testing"
+
+// IsInternalUID decides whether a caller bypasses the proxy's agent-mode gate.
+// A false positive hands a sandboxed agent an un-gated egress path, so the
+// negative cases below matter more than the positive one.
+
+// TestIsInternalUID_HiveProcess is the regression for the outage: the hive runs
+// as root, is not in the agent map, and must be recognised as internal.
+func TestIsInternalUID_HiveProcess(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"scanner": 2007, "quality": 2006}
+	if !u.IsInternalUID(0) {
+		t.Error("uid 0 (the hive process) must be internal — otherwise its App-token mint is blocked")
+	}
+}
+
+// TestIsInternalUID_ProxyUser: the MITM proxy's own upstream dials are internal
+// too, mirroring the existing proxy_uid exemption in the iptables chain.
+func TestIsInternalUID_ProxyUser(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"scanner": 2007}
+	if !u.IsInternalUID(u.ProxyUID) {
+		t.Errorf("proxy uid %d must be internal", u.ProxyUID)
+	}
+}
+
+// TestIsInternalUID_AgentsAreNeverInternal is the positive control. Without it,
+// a function that simply returned true would satisfy both tests above while
+// handing every agent an exemption.
+func TestIsInternalUID_AgentsAreNeverInternal(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{
+		"architect": 2001, "brainstorm": 2002, "ci-maintainer": 2003,
+		"guide": 2004, "outreach": 2005, "quality": 2006,
+		"scanner": 2007, "sec-check": 2008, "strategist": 2009, "supervisor": 2010,
+	}
+	for name, uid := range u.Agents {
+		if u.IsInternalUID(uid) {
+			t.Errorf("agent %q (uid %d) must NOT be internal — that would bypass the mode gate", name, uid)
+		}
+	}
+}
+
+// TestIsInternalUID_AgentSquattingOnInternalUID is the belt-and-braces case: if
+// an agent were ever provisioned at uid 0 or at the proxy uid, it must lose the
+// exemption rather than inherit it. This is what keeps the fix safe on a spoke
+// where the C6 setuid hole is still open (v2), even though it is closed on v4.
+func TestIsInternalUID_AgentSquattingOnInternalUID(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"rogue": 0}
+	if u.IsInternalUID(0) {
+		t.Error("an agent occupying uid 0 must not be treated as internal")
+	}
+
+	u2 := NewUIDMap()
+	u2.Agents = map[string]int{"rogue": u2.ProxyUID}
+	if u2.IsInternalUID(u2.ProxyUID) {
+		t.Error("an agent occupying the proxy uid must not be treated as internal")
+	}
+}
+
+// TestIsInternalUID_UnknownUID: an unattributable UID stays non-internal, so a
+// genuine UID-attribution failure still fails closed and still logs loudly.
+func TestIsInternalUID_UnknownUID(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"scanner": 2007}
+	for _, uid := range []int{1, 999, 1002, 5000} {
+		if u.IsInternalUID(uid) {
+			t.Errorf("uid %d is neither the hive nor the proxy and must not be internal", uid)
+		}
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -402,6 +402,15 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 			uid, lookupErr := LookupUIDByLocalPort(port)
 			if lookupErr == nil {
 				agentName = p.uidMap.LookupByUID(uid)
+				// The hive's own control plane is not an agent, so the lookup
+				// above returns "". Under v4's forced-proxy egress that made
+				// every hive-originated write — notably the App installation
+				// token mint — look like an unattributable agent, which the
+				// mode gate blocks. Name it explicitly so it is attributed
+				// rather than mistaken for a UID-attribution failure.
+				if agentName == "" && p.uidMap.IsInternalUID(uid) {
+					agentName = internalCallerName
+				}
 			}
 		}
 	}
@@ -843,6 +852,11 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			}
 			req.Body = io.NopCloser(strings.NewReader(string(body)))
 			req.ContentLength = int64(len(body))
+		} else if agentName == internalCallerName {
+			// The hive itself has no ACMM mode to enforce — ACMM governs AGENT
+			// autonomy. Its control-plane calls (App token mint, heartbeat)
+			// must not be gated as if they were agent writes. Repo-filter and
+			// canary-egress checks below still apply.
 		} else if !AllowedByMode(mode, req.Method, req.URL.Path) {
 			blocked = true
 			// An unidentified agent is silently treated as ADVISORY, which turns
@@ -1012,6 +1026,14 @@ func githubWriteBodyMayLeak(method, path string) bool {
 func isGitReceivePack(path string) bool {
 	return strings.HasSuffix(path, "/git-receive-pack")
 }
+
+// internalCallerName attributes a connection that originated from the hive's
+// OWN control plane rather than from a sandboxed agent. It is deliberately not
+// a valid agent name (agents come from the UID map) so it can never collide
+// with one, and it is what distinguishes "the hive called GitHub" from the
+// genuine failure mode the mode gate warns about: "an agent's UID could not be
+// attributed". See UIDMap.IsInternalUID for the security argument.
+const internalCallerName = "hive-internal"
 
 func (p *GitHubProxy) recordViolation(agentName, method, path string) {
 	p.logger.Warn("proxy request blocked", "agent", agentName, "method", method, "path", path)


### PR DESCRIPTION
## Symptom

On v4 spokes, **every GitHub App installation-token mint was blocked**, surfacing to operators as a bogus GitHub **403** and paused agents. The proxy logged this ~80 times in 10 minutes:

```
"proxy request blocked" agent="" method=POST path=/app/installations/<id>/access_tokens
"proxy: agent could not be identified — defaulting to ADVISORY and blocking a write;
 UID attribution failed ... this is NOT an agent-mode misconfiguration"
```

**Nine spokes affected:** torch-spyre, llm-d-wva, llm-d-fma, laredo-cuga-agent, kellyaa, inf-sim, ibm-alchemy, certus, kalantar-msb.

## Root cause

The proxy attributes a connection to an agent by looking the connection's UID up in the UID map. The hive process runs as **uid 0** and is not an agent, so `LookupByUID` returned `""`, the caller fell back to **ADVISORY**, and the write was blocked.

The log line was accidentally self-describing: it insisted the attribution failure was *not* a misconfiguration. It wasn't — it was the hive failing to recognise **itself**.

### Why this is v4-only

v4 forces **all** egress through the MITM proxy, including the hive's own control-plane calls. On v2 those calls never traversed the proxy, so they were never subjected to the agent-mode gate.

## Fix

- `UIDMap.IsInternalUID` recognises the hive's own control plane (uid 0 / proxy uid).
- The proxy attributes such connections as `hive-internal` rather than `""`, and skips the agent-mode gate for them.

## Why this is safe

`IsInternalUID` matches **only** uid 0 and the proxy UID, and cross-checks against the agent map so an agent squatting on either UID never inherits the exemption.

I verified **dynamically on a live v4 spoke** that an agent cannot reach uid 0:

| Attempt | Result |
|---|---|
| `su-exec hive-scanner sh -c 'su-exec root id'` | **Permission denied** |
| `su-exec 2007 sh -c '/usr/local/bin/su-exec 0 id'` | **Permission denied** |
| `/usr/bin/su root -c id` | **Authentication failure** (root is `*`, password-locked) |
| `mount -t tmpfs` | **must be superuser** (CapBnd `15fb`, no CAP_SYS_ADMIN) |

Additionally:
- `su-exec` is `4750 root:hive-launch`; agents are in `node`(1000) + their own group, **not** `hive-launch`.
- Agents **cannot write** `/var/run/hive/uid-map.json` (Permission denied), so they cannot forge their own attribution.

### Scope of the exemption

It skips **only the agent-mode gate** — ACMM governs *agent* autonomy, and the hive itself has no mode to enforce. **Repo-filter and canary-egress checks still apply** to internal callers.

## Tests

Five tests in `v2/pkg/agent/uidmap_internal_test.go` cover the hive process, the proxy user, all ten agent UIDs, an agent squatting on uid 0 / the proxy uid, and unknown UIDs.

**Positive control:** deleting the agent-map cross-check loop still **compiles**, but `TestIsInternalUID_AgentSquattingOnInternalUID` then **FAILS** on both assertions:

```
--- FAIL: TestIsInternalUID_AgentSquattingOnInternalUID (0.00s)
    uidmap_internal_test.go:54: an agent occupying uid 0 must not be treated as internal
    uidmap_internal_test.go:60: an agent occupying the proxy uid must not be treated as internal
```

Restored, the suite is green. `go build ./...`, `go vet ./pkg/proxy/ ./pkg/agent/`, and `go test ./pkg/agent/ ./pkg/proxy/ -count=1` all pass with no pre-existing failures.

No existing tests were modified.
