### PR TITLE
fix(agent): symlink-check the inference-home anchor directory (audit F12)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -5206,8 +5207,9 @@ func (m *Manager) seedJSONFile(agentName, path string, seed map[string]any) {
 // ensureClaudeSettings creates a per-agent writable HOME directory for inference
 // agents with pre-populated .claude/settings.json. Each agent gets its own dir
 // to avoid cross-agent permission conflicts when Claude Code creates session
-// files. Directories use 0o777 so the agent UID can create subdirs freely
-// (hive runs as dev, not root, so chown is not available).
+// files. Directories are created 0o700 and chowned to the agent UID where the
+// deployment permits it (the hosted container runs as root), falling back to
+// 0o777 only where chown is refused — see tightenInferenceHome.
 //
 // The .claude.json and settings.json seeds are repaired on every call
 // (missing keys merged in, corrupt files rewritten) so agents launched by
@@ -5218,7 +5220,11 @@ func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 	settingsDir := filepath.Join(homePath, ".claude")
 	settingsFile := filepath.Join(settingsDir, "settings.json")
 
-	if err := os.MkdirAll(settingsDir, inferenceHomeDirMode); err != nil {
+	// SECURITY (audit F12): os.MkdirAll stats components with a
+	// symlink-FOLLOWING stat, so a pre-planted link at the predictable anchor
+	// redirected everything below — including the root-privileged Chown/Chmod
+	// in tightenInferenceHome. mkdirAllNoFollow Lstats every component instead.
+	if err := mkdirAllNoFollow(inferenceHomeRoot(), settingsDir, inferenceHomeDirMode); err != nil {
 		m.logger.Warn("failed to create claude inference home", "agent", agentName, "error", err)
 		return
 	}
@@ -5387,11 +5393,110 @@ const (
 	inferenceHomeSharedDirMode = 0o777
 )
 
+// errInferenceHomeSymlink reports that a path component of an inference HOME is
+// a symlink, so the caller must not act on it (audit F12).
+var errInferenceHomeSymlink = errors.New("inference home path component is a symlink")
+
+// lstatNoFollow reports whether path exists and is a real directory, refusing a
+// symlink (audit F12).
+//
+// Returns (false, nil) when the path does not exist yet — the normal first-run
+// case, which the callers create. Any symlink, at any component, is
+// errInferenceHomeSymlink: acting on it is exactly the redirection this guard
+// exists to stop.
+func lstatNoFollow(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("%w: %s", errInferenceHomeSymlink, path)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("inference home path is not a directory: %s", path)
+	}
+	return true, nil
+}
+
+// mkdirAllNoFollow creates dir and any missing parents BELOW root, refusing to
+// traverse or create through a symlink (audit F12).
+//
+// SECURITY: os.MkdirAll stats each component with a symlink-FOLLOWING stat and
+// is happy to treat a link-to-directory as an existing component, so a
+// pre-planted link at the predictable anchor
+// (/tmp/.claude-inference-home-<agent>) silently redirects the whole subtree —
+// and with it the path-based Chown/Chmod in tightenInferenceHome, which run as
+// root in the hosted container. Lstat-ing every component below root closes
+// that: a planted link fails loudly instead of redirecting.
+//
+// root is RESOLVED rather than Lstat-refused: it is the operator-controlled
+// container path (/tmp, or a test temp dir), and on macOS /tmp is itself a
+// symlink to private/tmp — refusing it would break every real launch. The
+// threat model is a link planted at the AGENT-controlled anchor below root, so
+// resolving root and then Lstat-ing every component beneath it is what matters.
+// root always already exists and is never created here.
+func mkdirAllNoFollow(root, dir string, perm os.FileMode) error {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	// Re-anchor dir onto the resolved root so Rel compares like with like.
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return err
+	}
+	root = resolvedRoot
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("inference home %s escapes root %s", dir, root)
+	}
+	current := root
+	if rel == "." {
+		return nil
+	}
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+		exists, err := lstatNoFollow(current)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if err := os.Mkdir(current, perm); err != nil && !os.IsExist(err) {
+			return err
+		}
+		// Re-check: os.Mkdir returning EEXIST means something raced us into
+		// place, and that something may be a symlink.
+		if _, err := lstatNoFollow(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// inferenceHomeRoot returns the directory the per-agent inference HOMEs are
+// created in — /tmp in production, the override's parent under test.
+func inferenceHomeRoot() string {
+	if inferenceHomePrefixOverride != "" {
+		return filepath.Dir(inferenceHomePrefixOverride)
+	}
+	return filepath.Dir(claudeInferenceHomePrefix)
+}
+
 // tightenInferenceHome tries to give the agent UID sole ownership of its
 // inference HOME, falling back to the historical world-writable mode when the
 // hive lacks the privilege to chown. Best-effort by design: every failure path
-// leaves a WORKING home, because the O_NOFOLLOW writers — not this — are what
-// close audit F12.
+// leaves a WORKING home.
+//
+// SECURITY (audit F12): os.Chown and os.Chmod both FOLLOW symlinks, and this
+// runs as root in the hosted container, so each directory is Lstat-verified as
+// a real directory immediately before it is acted on. A planted link is skipped
+// loudly rather than having the hive's own privilege redirected onto whatever
+// it points at. The leaf O_NOFOLLOW writers do NOT cover this: they protect
+// files, and these are the ANCHOR DIRECTORIES.
 func (m *Manager) tightenInferenceHome(agentName, homePath, settingsDir string, uid int) {
 	if uid <= 0 {
 		// No per-agent UID: the hive itself is the only writer, so 0700 owned
@@ -5399,6 +5504,11 @@ func (m *Manager) tightenInferenceHome(agentName, homePath, settingsDir string, 
 		return
 	}
 	for _, dir := range []string{homePath, settingsDir} {
+		if exists, err := lstatNoFollow(dir); err != nil || !exists {
+			m.logger.Warn("refusing to tighten inference home (not a real directory)",
+				"agent", agentName, "dir", dir, "error", err)
+			continue
+		}
 		if err := os.Chown(dir, uid, -1); err != nil {
 			// Unprivileged deployment. Restore the shared mode so the agent can
 			// still use its HOME, and say so once at debug level rather than

--- a/v2/pkg/agent/manager_inference_home_anchor_test.go
+++ b/v2/pkg/agent/manager_inference_home_anchor_test.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Audit F12 residual: the inference-home ANCHOR directory was never
+// symlink-checked. ensureClaudeSettings called os.MkdirAll on a path derived
+// from the predictable /tmp/.claude-inference-home-<agent>, and
+// tightenInferenceHome then ran path-based os.Chown/os.Chmod over it. All three
+// syscalls follow symlinks, so a local UID that pre-planted that name
+// redirected the hive's own (root, in the hosted container) privilege onto an
+// arbitrary directory. The leaf-file O_NOFOLLOW writers do not cover this —
+// they guard files, not the anchor directory.
+//
+// These tests use the inferenceHomePrefixOverride seam so nothing touches the
+// real /tmp.
+
+// inferenceHomeTestPrefix points the per-agent inference HOME at a fresh temp
+// dir and returns the root those homes are created in.
+func inferenceHomeTestPrefix(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	claudeInferenceHomePrefixForTest(t, filepath.Join(root, "home-"))
+	return root
+}
+
+// TestF12_EnsureClaudeSettingsRefusesSymlinkedAnchor is the core regression:
+// a symlink pre-planted at the anchor must NOT be followed.
+func TestF12_EnsureClaudeSettingsRefusesSymlinkedAnchor(t *testing.T) {
+	root := inferenceHomeTestPrefix(t)
+
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+
+	anchor := inferenceHomePath("scanner")
+	if err := os.Symlink(victim, anchor); err != nil {
+		t.Fatalf("symlink anchor: %v", err)
+	}
+
+	quietManager().ensureClaudeSettings("scanner", 0)
+
+	// The hive must not have created anything through the link.
+	if _, err := os.Stat(filepath.Join(victim, ".claude")); err == nil {
+		t.Fatal("ensureClaudeSettings created .claude inside the symlink target: anchor symlink was followed (CWE-59 regression)")
+	}
+	if got := statMode(t, victim); got != 0o700 {
+		t.Fatalf("victim mode = %v, want 0700: anchor symlink was followed", got)
+	}
+	// The anchor itself must still be the planted link, not a replaced dir.
+	info, err := os.Lstat(anchor)
+	if err != nil {
+		t.Fatalf("lstat anchor: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("anchor is no longer a symlink; the guard must refuse, not silently replace")
+	}
+}
+
+// TestF12_TightenInferenceHomeRefusesSymlinkedAnchor covers the chown/chmod
+// half directly: tightenInferenceHome must not act on a linked directory.
+func TestF12_TightenInferenceHomeRefusesSymlinkedAnchor(t *testing.T) {
+	root := inferenceHomeTestPrefix(t)
+
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	anchor := filepath.Join(root, "linked-home")
+	if err := os.Symlink(victim, anchor); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// uid>0 so the chown/chmod loop is actually entered. The chown itself is
+	// expected to be refused by the OS for an unprivileged test runner; the
+	// assertion is on the CHMOD fallback, which would otherwise widen the
+	// victim to 0777 through the link.
+	quietManager().tightenInferenceHome("scanner", anchor, filepath.Join(anchor, ".claude"), 12345)
+
+	if got := statMode(t, victim); got != 0o700 {
+		t.Fatalf("victim mode = %v, want 0700: tightenInferenceHome followed the anchor symlink (CWE-59 regression)", got)
+	}
+}
+
+// TestF12_MkdirAllNoFollowRefusesSymlinkedIntermediate ensures the guard covers
+// every component, not just the final anchor.
+func TestF12_MkdirAllNoFollowRefusesSymlinkedIntermediate(t *testing.T) {
+	root := t.TempDir()
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	if err := os.Symlink(victim, filepath.Join(root, "anchor")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := mkdirAllNoFollow(root, filepath.Join(root, "anchor", ".claude"), inferenceHomeDirMode)
+	if !errors.Is(err, errInferenceHomeSymlink) {
+		t.Fatalf("mkdirAllNoFollow error = %v, want errInferenceHomeSymlink", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(victim, ".claude")); statErr == nil {
+		t.Fatal("created a directory through a symlinked intermediate component")
+	}
+}
+
+// TestF12_EnsureClaudeSettingsCreatesRealHome is the POSITIVE CONTROL: with no
+// symlink planted, the normal path must still create the home, the settings
+// directory and the seeded files. A guard that broke this would be worthless.
+func TestF12_EnsureClaudeSettingsCreatesRealHome(t *testing.T) {
+	inferenceHomeTestPrefix(t)
+
+	quietManager().ensureClaudeSettings("scanner", 0)
+
+	home := inferenceHomePath("scanner")
+	info, err := os.Lstat(home)
+	if err != nil {
+		t.Fatalf("inference home was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("inference home is not a directory: mode %v", info.Mode())
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err != nil {
+		t.Fatalf("settings.json was not seeded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude.json")); err != nil {
+		t.Fatalf(".claude.json was not seeded: %v", err)
+	}
+}
+
+// TestF12_TightenInferenceHomeTightensRealDirectory is the second POSITIVE
+// CONTROL: permissions must still actually be applied to a real directory.
+func TestF12_TightenInferenceHomeTightensRealDirectory(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	settings := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settings, 0o777); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Defeat umask so the starting mode is unambiguously the wide one.
+	if err := os.Chmod(home, 0o777); err != nil {
+		t.Fatalf("chmod home: %v", err)
+	}
+
+	// uid>0 with an unprivileged runner: chown fails, so the loop takes the
+	// documented fallback and restores the shared mode. Either way it must
+	// have ACTED on the real directory rather than skipping it.
+	quietManager().tightenInferenceHome("scanner", home, settings, 12345)
+
+	got := statMode(t, home)
+	if got != inferenceHomeSharedDirMode && got != inferenceHomeDirMode {
+		t.Fatalf("home mode = %v, want %v or %v: tightenInferenceHome skipped a real directory",
+			got, os.FileMode(inferenceHomeSharedDirMode), os.FileMode(inferenceHomeDirMode))
+	}
+}


### PR DESCRIPTION
## Finding

Audit **F12** (High, root/multi-UID). The leaf-file `O_NOFOLLOW` guards from the earlier F12 work hold — but they protect **files**. The **anchor directory** was never symlink-checked.

Two sinks in `v2/pkg/agent/manager.go`:

1. **`ensureClaudeSettings`** called `os.MkdirAll(settingsDir, …)` on a path derived from the predictable `/tmp/.claude-inference-home-<agent>`, with no `Lstat`. `MkdirAll` stats each component with a symlink-**following** stat and happily treats a link-to-directory as an already-existing component, so a pre-planted link silently redirected the entire subtree.
2. **`tightenInferenceHome`** then ran path-based `os.Chown` / `os.Chmod` in a loop over `{homePath, settingsDir}`. Both follow symlinks.

Severity is High specifically because **the hosted container runs the hive process as root**: any local UID able to pre-plant that predictable `/tmp` name had the hive's own root privilege redirected onto a directory of its choosing.

The surrounding comments asserted this was already covered — *"the O_NOFOLLOW writers — not this — are what close audit F12"* and *"The audit named three sinks; all three are now covered."* That reasoning only holds for files, which is why the directory-level gap survived.

## Fix

- `mkdirAllNoFollow` — `Lstat`s **every** path component beneath the root before creating it; a symlink at any component is refused with `errInferenceHomeSymlink` rather than traversed. Re-checks after `Mkdir` returns `EEXIST` so a race cannot plant a link underneath us.
- `tightenInferenceHome` — `Lstat`-verifies each directory is a real directory immediately before `Chown`/`Chmod`, skipping (loudly) rather than acting through a link.

Follows this repo's existing idiom (`os.Lstat` + `ModeSymlink`, as in `permissions_watcher.go`) rather than introducing `golang.org/x/sys/unix`, which is currently only an **indirect** dependency.

**One subtlety worth review:** the root is *resolved* (`EvalSymlinks`), not `Lstat`-refused. On macOS `/tmp` is itself a symlink to `private/tmp`, so refusing a symlinked root broke every real launch — my first iteration did exactly that and failed two pre-existing tests. The threat model is a link planted at the **agent-controlled anchor below** the operator-controlled root.

Also corrects a stale doc comment that still claimed *"hive runs as dev, not root, so chown is not available"*, contradicted 15 lines below it.

## Tests

Regression-replayed: with the guard neutered back to symlink-following (`os.Lstat` → `os.Stat`, check disabled) the code still compiles and **all three security tests fail**:

```
--- FAIL: TestF12_EnsureClaudeSettingsRefusesSymlinkedAnchor
    ensureClaudeSettings created .claude inside the symlink target: anchor symlink was followed (CWE-59 regression)
--- FAIL: TestF12_TightenInferenceHomeRefusesSymlinkedAnchor
    victim mode = -rwxrwxrwx, want 0700: tightenInferenceHome followed the anchor symlink (CWE-59 regression)
--- FAIL: TestF12_MkdirAllNoFollowRefusesSymlinkedIntermediate
    mkdirAllNoFollow error = <nil>, want errInferenceHomeSymlink
```

`victim mode = -rwxrwxrwx` is the exploit reproduced concretely: an arbitrary outside directory widened to 0777 through the planted link.

**Positive controls** (pass in *both* states, so they verify the happy path rather than the guard):
- `TestF12_EnsureClaudeSettingsCreatesRealHome`
- `TestF12_TightenInferenceHomeTightensRealDirectory`

Tests use the existing `inferenceHomePrefixOverride` seam with `t.TempDir()`, so nothing touches the real `/tmp`.

**No existing test was modified** — no test in this package asserted that a symlink is followed.

Full `./pkg/agent/` suite green (351s).