### PR TITLE
fix(github): gate the auto-merge sweep on a trusted-merger check (audit F3)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1359,6 +1359,15 @@ func main() {
 		ghClient.SetMergeReEngageHook(mergeReEngageHook(cfg))
 		ghClient.StartMergeRequestWatcher(ctx, bindMergeAuthz(agentMgr.AuthorizeMerge), nil)
 
+		// SECURITY (audit F3): re-verify the merger tier inside the sweep. The
+		// dashboard's queue endpoint gates on requireMergerOrOwnerRole, but the
+		// sweep merges a minute later off the label + App-authored approval body
+		// alone, so without this ANY actor who can get the label applied merges
+		// anything, and a sockpuppet pair defeats the self-merge ban. Resolved
+		// against the SAME allowlist the dashboard uses so there is one notion of
+		// trust; read through cfg on every call so a config reload takes effect.
+		ghClient.SetMergerAuthorizer(trustedMergerFunc(cfg))
+
 		// Self-authored auto-merge: the App merges its OWN open, CI-green PRs
 		// directly over the REST API, without a human "Approved ... for Hive
 		// auto-merge" queue review and without waiting on tide. Prow forbids
@@ -5709,11 +5718,34 @@ func runEscalationSweep(
 // hammering the GitHub API on short eval intervals.
 const autoMergeSweepInterval = time.Minute
 
+// trustedMergerFunc resolves a GitHub login against the hive's authorized-users
+// allowlist and reports whether it holds at least config.RoleMerger — the same
+// bar requireMergerOrOwnerRole enforces on the dashboard queue endpoint (audit
+// F3).
+//
+// Fails CLOSED: a nil config or a login absent from the allowlist is NOT
+// trusted, so an unclassifiable actor can never merge. cfg is read on every
+// call so a config reload that grants or revokes the merger tier takes effect
+// without a restart.
+func trustedMergerFunc(cfg *config.Config) github.MergerAuthorizer {
+	return func(login string) bool {
+		if cfg == nil || strings.TrimSpace(login) == "" {
+			return false
+		}
+		role, ok := cfg.Dashboard.AuthorizedRole(login)
+		if !ok {
+			return false
+		}
+		return config.RoleAtLeast(role, config.RoleMerger)
+	}
+}
+
 // runAutoMergeSweepIfDue drains the label-queued auto-merge queue (the human
 // "Approved ... for Hive auto-merge" path) at most once per
 // autoMergeSweepInterval. All merge-eligibility decisions — queue-approval
-// trust, check verification, tier gates — live inside SweepQueuedAutoMerges;
-// this function is only the scheduler and the dashboard audit sink.
+// trust, the trusted-merger tier gate (SetMergerAuthorizer), check
+// verification — live inside SweepQueuedAutoMerges; this function is only the
+// scheduler and the dashboard audit sink.
 func runAutoMergeSweepIfDue(ctx context.Context, ghClient *github.Client, dashSrv *dashboard.Server, lastRun *time.Time, logger *slog.Logger) {
 	if ghClient == nil {
 		return

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -26,9 +26,14 @@ const (
 	autoMergeReasonNoHiveQueueApproval        = "no-hive-queue-approval"
 	autoMergeReasonNoAppBotLogin              = "no-app-bot-login"
 	autoMergeReasonUntrustedQueueApproval     = "untrusted-hive-queue-approval"
+	autoMergeReasonUntrustedMerger            = "untrusted-merger"
+	autoMergeReasonNoMergerAuthz              = "no-merger-authorizer"
 	autoMergeWarnNoAppBotLogin                = "automerge sweep disabled: no GitHub App bot login configured"
 	autoMergeWarnUntrustedQueueApproval       = "rejected untrusted Hive auto-merge queue approval"
+	autoMergeWarnUntrustedMerger              = "rejected Hive auto-merge queued by an untrusted actor"
+	autoMergeWarnNoMergerAuthz                = "automerge sweep disabled: no trusted-merger authorizer configured"
 	autoMergeNoAppBotLoginOperatorRemediation = "Hive has no usable GitHub App, so App-authorship cannot be verified and auto-merge is disabled"
+	autoMergeNoMergerAuthzRemediation         = "Hive cannot classify who queued the merge, so auto-merge is disabled (fail-closed)"
 )
 
 var hiveQueueReviewRE = regexp.MustCompile(`(?i)^Approved by @([A-Za-z0-9-]+) for Hive auto-merge on green CI\.`)
@@ -36,6 +41,49 @@ var hiveQueueReviewRE = regexp.MustCompile(`(?i)^Approved by @([A-Za-z0-9-]+) fo
 type AutoMergeSweepOptions struct {
 	MaxMerges int
 	Audit     func(AutoMergeSweepEvent)
+}
+
+// MergerAuthorizer reports whether login is trusted to QUEUE a merge — i.e.
+// holds at least config.RoleMerger in the hive's authorized-users allowlist.
+//
+// SECURITY (audit F3). The queue-time role check lives in the dashboard handler
+// (requireMergerOrOwnerRole), but the sweep is a SEPARATE authority that runs a
+// minute later off nothing but the label and the App-authored approval body. It
+// re-derives the queuer's login from that body and used to merge on it
+// unconditionally, so anything that could get the merger-queue label applied
+// got its PR merged regardless of who asked. Re-verifying the role HERE is what
+// makes the merger tier real at the point the merge actually happens.
+//
+// Returns false for an unknown/unclassifiable login: a nil authorizer or an
+// unresolvable actor must never merge (fail CLOSED).
+type MergerAuthorizer func(login string) bool
+
+// SetMergerAuthorizer installs the trusted-merger gate consulted by
+// SweepQueuedAutoMerges. nil fails closed — the sweep merges nothing.
+func (c *Client) SetMergerAuthorizer(fn MergerAuthorizer) {
+	if c == nil {
+		return
+	}
+	c.mergerAuthzMu.Lock()
+	defer c.mergerAuthzMu.Unlock()
+	c.mergerAuthz = fn
+}
+
+// isTrustedMerger reports whether login may queue a merge. Fails CLOSED.
+func (c *Client) isTrustedMerger(login string) (allowed, configured bool) {
+	if c == nil {
+		return false, false
+	}
+	c.mergerAuthzMu.RLock()
+	fn := c.mergerAuthz
+	c.mergerAuthzMu.RUnlock()
+	if fn == nil {
+		return false, false
+	}
+	if strings.TrimSpace(login) == "" {
+		return false, true
+	}
+	return fn(login), true
 }
 
 type AutoMergeSweepEvent struct {
@@ -61,8 +109,10 @@ type hiveQueueApproval struct {
 
 // SweepQueuedAutoMerges consumes the configured Hive merger-queue label. It
 // only squashes open, labelled, non-draft PRs in managed repos after GitHub
-// reports them mergeable, commit statuses/check-runs are green, and the latest
-// Hive App-authored queue approval proves the queuer is not the PR author.
+// reports them mergeable, commit statuses/check-runs are green, the latest
+// Hive App-authored queue approval proves the queuer is not the PR author, and
+// the queuer is a TRUSTED merger (audit F3 — see MergerAuthorizer). Without an
+// authorizer installed the sweep fails closed and merges nothing.
 func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepOptions) (*AutoMergeSweepResult, error) {
 	if c == nil {
 		return nil, ErrNoGitHubClient
@@ -74,6 +124,7 @@ func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepO
 	label := c.AutoMergeLabel()
 	result := &AutoMergeSweepResult{}
 	noAppBotLoginWarned := false
+	noMergerAuthzWarned := false
 
 	for _, repo := range c.getRepos() {
 		if len(result.Merged) >= maxMerges {
@@ -102,6 +153,14 @@ func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepO
 				if !noAppBotLoginWarned {
 					c.warn(autoMergeWarnNoAppBotLogin, "repo", repo, "pr", issue.GetNumber(), "reason", reason, "cause", autoMergeNoAppBotLoginOperatorRemediation)
 					noAppBotLoginWarned = true
+				}
+				result.Skipped++
+				continue
+			}
+			if reason == autoMergeReasonNoMergerAuthz {
+				if !noMergerAuthzWarned {
+					c.warn(autoMergeWarnNoMergerAuthz, "repo", repo, "pr", issue.GetNumber(), "reason", reason, "cause", autoMergeNoMergerAuthzRemediation)
+					noMergerAuthzWarned = true
 				}
 				result.Skipped++
 				continue
@@ -438,6 +497,21 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	queuedBy := approval.QueuedBy
 	if strings.EqualFold(author, queuedBy) {
 		return AutoMergeSweepEvent{}, "self-merge-ban", nil
+	}
+	// SECURITY (audit F3): the self-merge ban above only proves queuer !=
+	// author. It is defeated by a sockpuppet — a second account queues and
+	// approves the first account's work — and on its own it lets ANY actor who
+	// can get the merger-queue label applied merge anything. Re-verify the
+	// merger tier here, at the point the merge actually happens, rather than
+	// trusting the queue-time check in the dashboard handler.
+	trusted, configured := c.isTrustedMerger(queuedBy)
+	if !configured {
+		return AutoMergeSweepEvent{}, autoMergeReasonNoMergerAuthz, nil
+	}
+	if !trusted {
+		c.warn(autoMergeWarnUntrustedMerger, "owner", owner, "repo", repo, "pr", number,
+			"queued_by", queuedBy, "author", author)
+		return AutoMergeSweepEvent{}, autoMergeReasonUntrustedMerger, nil
 	}
 
 	mergeable := mergeableFromState(pr.GetMergeableState(), pr.Mergeable)

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -941,9 +941,22 @@ func TestStartSelfAuthoredAutoMergeSweepNilClient(t *testing.T) {
 	nilClient.StartSelfAuthoredAutoMergeSweep(context.Background(), 0, true, &l6)
 }
 
+// testTrustedMergers are the logins the sweep fixtures treat as holding the
+// merger tier. "bob" is the queuer in every fixture that is EXPECTED to merge,
+// so granting it here preserves each existing test's original intent (a
+// legitimate queued merge lands) now that the sweep enforces the trusted-merger
+// gate (audit F3). Anyone NOT listed is untrusted and must not merge.
+var testTrustedMergers = map[string]bool{"bob": true, "carol": true}
+
 func newAutoMergeSweepClient(apiURL string) *Client {
 	c := NewClient("token", "acme", []string{"widget"}, nil, apiURL)
 	c.SetAppBotLogin(testHiveAppBotLogin)
+	// Audit F3: the sweep fails CLOSED without an authorizer, so every test
+	// exercising the merge path must install one. Tests that assert the
+	// fail-closed behaviour itself build their client without this helper.
+	c.SetMergerAuthorizer(func(login string) bool {
+		return testTrustedMergers[strings.ToLower(strings.TrimSpace(login))]
+	})
 	return c
 }
 

--- a/v2/pkg/github/automerge_sweep_trusted_merger_test.go
+++ b/v2/pkg/github/automerge_sweep_trusted_merger_test.go
@@ -1,0 +1,184 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Audit F3: the label-queued auto-merge sweep had NO trusted-merger check.
+// trySweepQueuedPR proved only that the queuer was not the PR author
+// (self-merge ban), so anything that could get the merger-queue label applied
+// had its PR merged regardless of WHO asked, and a sockpuppet pair (author A,
+// queuer B, neither trusted) defeated the ban outright. These tests pin the
+// tier gate at the point the merge actually happens.
+//
+// The sweep is LIVE on v4: cmd/hive/main.go calls SweepQueuedAutoMerges from
+// runAutoMergeSweepIfDue off the governor eval tick.
+
+// greenQueuedPR is a PR that passes every gate EXCEPT whatever the test varies.
+func greenQueuedPR(number int, author, queuedBy string) sweepPR {
+	return sweepPR{
+		number:          number,
+		author:          author,
+		queuedBy:        queuedBy,
+		label:           true,
+		mergeableState:  "clean",
+		statusState:     "success",
+		checkStatus:     "completed",
+		checkConclusion: "success",
+	}
+}
+
+// newUngatedSweepClient builds a sweep client with NO merger authorizer — the
+// pre-fix shape, used to assert the fail-closed default.
+func newUngatedSweepClient(apiURL string) *Client {
+	c := NewClient("token", "acme", []string{"widget"}, nil, apiURL)
+	c.SetAppBotLogin(testHiveAppBotLogin)
+	return c
+}
+
+// TestF3_TrustedMergerMergesGreenQueuedPR is the POSITIVE CONTROL: a merger-tier
+// actor queuing someone else's green PR must still merge. A gate that blocked
+// this would be worthless.
+func TestF3_TrustedMergerMergesGreenQueuedPR(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "bob")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 1 || len(merged) != 1 || merged[0] != 7 {
+		t.Fatalf("merged result=%v merge calls=%v, want PR 7 merged by trusted merger bob", result.Merged, merged)
+	}
+}
+
+// TestF3_UntrustedMergerDoesNotMerge is the core regression: an actor with no
+// merger tier must not be able to merge, even though every other gate is green
+// and the self-merge ban is satisfied.
+func TestF3_UntrustedMergerDoesNotMerge(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "mallory")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want untrusted queuer mallory REFUSED (F3 regression)", result.Merged, merged)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", result.Skipped)
+	}
+}
+
+// TestF3_SockpuppetPairDoesNotMerge covers the case the self-merge ban cannot
+// see: two DISTINCT untrusted accounts, so author != queuer and the ban passes,
+// but neither holds the merger tier.
+func TestF3_SockpuppetPairDoesNotMerge(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "mallory", "mallory-alt")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want sockpuppet pair REFUSED (F3 regression)", result.Merged, merged)
+	}
+}
+
+// TestF3_SelfMergeBanStillHolds proves the earlier fix (#3413) is intact: a
+// TRUSTED merger still cannot merge their OWN PR. Trust must not become a
+// bypass of the self-merge ban.
+func TestF3_SelfMergeBanStillHolds(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "bob", "BOB")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want trusted merger BLOCKED from self-merge", result.Merged, merged)
+	}
+}
+
+// TestF3_NoAuthorizerFailsClosed pins the fail-closed default: with no
+// authorizer installed, an unclassifiable actor must NOT merge.
+func TestF3_NoAuthorizerFailsClosed(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "bob")}, &merged)
+	defer api.Close()
+
+	c := newUngatedSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want fail-CLOSED with no authorizer", result.Merged, merged)
+	}
+}
+
+// TestF3_TrySweepQueuedPRReportsUntrustedReason pins the skip reasons so the
+// operator can tell an untrusted queuer apart from an unconfigured hive.
+func TestF3_TrySweepQueuedPRReportsUntrustedReason(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "mallory")}, &merged)
+	defer api.Close()
+
+	gated := newAutoMergeSweepClient(api.URL)
+	_, reason, err := gated.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
+	if err != nil {
+		t.Fatalf("trySweepQueuedPR returned error: %v", err)
+	}
+	if reason != autoMergeReasonUntrustedMerger {
+		t.Fatalf("reason = %q, want %q", reason, autoMergeReasonUntrustedMerger)
+	}
+
+	ungated := newUngatedSweepClient(api.URL)
+	_, reason, err = ungated.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
+	if err != nil {
+		t.Fatalf("trySweepQueuedPR returned error: %v", err)
+	}
+	if reason != autoMergeReasonNoMergerAuthz {
+		t.Fatalf("reason = %q, want %q", reason, autoMergeReasonNoMergerAuthz)
+	}
+}
+
+// TestF3_IsTrustedMergerFailsClosedOnEdgeCases covers the helper directly.
+func TestF3_IsTrustedMergerFailsClosedOnEdgeCases(t *testing.T) {
+	var nilClient *Client
+	if allowed, configured := nilClient.isTrustedMerger("bob"); allowed || configured {
+		t.Fatalf("nil client = (%v,%v), want (false,false)", allowed, configured)
+	}
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, "")
+	if allowed, configured := c.isTrustedMerger("bob"); allowed || configured {
+		t.Fatalf("no authorizer = (%v,%v), want (false,false)", allowed, configured)
+	}
+
+	c.SetMergerAuthorizer(func(login string) bool {
+		return strings.EqualFold(login, "bob")
+	})
+	// An empty login must never be trusted, even with an authorizer installed.
+	if allowed, configured := c.isTrustedMerger("   "); allowed || !configured {
+		t.Fatalf("blank login = (%v,%v), want (false,true)", allowed, configured)
+	}
+	if allowed, _ := c.isTrustedMerger("bob"); !allowed {
+		t.Fatal("bob should be trusted")
+	}
+	if allowed, _ := c.isTrustedMerger("mallory"); allowed {
+		t.Fatal("mallory must not be trusted")
+	}
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -62,6 +62,13 @@ type Client struct {
 	// MergeRequestAuthorizer / F4). nil fails closed. Set by
 	// StartMergeRequestWatcher.
 	mergeAuthz MergeRequestAuthorizer
+	// mergerAuthz gates the label-queued auto-merge sweep on WHO queued the
+	// merge: it reports whether a login holds at least config.RoleMerger (audit
+	// F3). nil fails closed — SweepQueuedAutoMerges merges nothing. Guarded
+	// because config reload re-installs it while the sweep goroutine reads it.
+	// Set by SetMergerAuthorizer.
+	mergerAuthzMu sync.RWMutex
+	mergerAuthz   MergerAuthorizer
 	// mergeReEngage is Fix #2's re-engagement hook. When a merge attempt fails
 	// terminally BECAUSE a required check failed (not a true conflict or a
 	// permission error), the watcher calls this instead of silently abandoning


### PR DESCRIPTION
## Finding

Audit **F3**. Rated Medium, treated here as **High: the sweep is LIVE on v4.**

> ⚠️ **Correction to the audit.** The 2026-08-13 report claims the sweep is *"latent on v4 — `SweepQueuedAutoMerges` has no caller at HEAD"*. That is **wrong**. It is wired: `cmd/hive/main.go:5728` calls it from `runAutoMergeSweepIfDue`, driven off the governor eval tick with an `autoMergeSweepInterval` floor, invoked from two sites (`:4031`, `:4072`). A second ticker loop drives `SweepSelfAuthoredAutoMerges`. The residuals are **active on the operator's fleet**, not dormant.

`trySweepQueuedPR` proved only that the queuer was not the PR author (the self-merge ban from #3413). It never checked **who** queued the merge:

- **No trusted-merger check.** Anything that could get the merger-queue label applied had its PR merged, regardless of who asked.
- **The self-merge ban is defeatable by a sockpuppet.** Author A, queuer B, neither trusted → the ban is satisfied and the merge proceeds.

The existing `untrusted-hive-queue-approval` reason is **orthogonal**: it verifies the *review* was authored by the App bot (anti-forgery). Because the App posts that review on behalf of whoever applied the label, a genuine App-bot review sails straight through.

### Why this survived review

The merger tier already existed — but was enforced only at the **dashboard door** (`requireMergerOrOwnerRole`), never at the **sweep**, which is the actual merge authority running a minute later off nothing but the label and the approval body. Two comments assert the gate that was not there:

- `config.go` on `RoleMerger`: *"Both the dashboard queue endpoint **and the sweep** enforce the … rule server-side."*
- `main.go` on the scheduler: *"All merge-eligibility decisions — queue-approval trust, check verification, **tier gates** — live inside `SweepQueuedAutoMerges`."*

Both are now accurate.

## Fix

A `MergerAuthorizer` hook on `Client`, following the established **nil-fails-closed** pattern already used by `prAuthz` / `mergeAuthz`. `main.go` installs it from `cfg.Dashboard.AuthorizedRole` + `config.RoleAtLeast(role, config.RoleMerger)` — the **same allowlist and the same bar the dashboard uses**, reusing the repo's existing trust primitives rather than inventing a parallel notion of trust. `cfg` is read on each call so a config reload granting/revoking the tier takes effect without a restart.

**Fails CLOSED**: no authorizer, an unresolvable login, or a blank login merges nothing — surfaced as a distinct `no-merger-authorizer` reason with a one-time operator warning, so a misconfigured hive is diagnosable rather than silently dead.

## Tests

Regression-replayed: with the gate neutered (`trusted, configured = true, true`) the code still compiles and untrusted actors merge again:

```
--- FAIL: TestF3_UntrustedMergerDoesNotMerge
    merged result=[{widget 7 alice mallory sha7 merge7 lgtm}] merge calls=[7]
--- FAIL: TestF3_SockpuppetPairDoesNotMerge
    merged result=[{widget 7 mallory mallory-alt sha7 merge7 lgtm}] merge calls=[7]
--- FAIL: TestF3_NoAuthorizerFailsClosed
    merged result=[{widget 7 alice bob sha7 merge7 lgtm}] merge calls=[7]
--- FAIL: TestF3_TrySweepQueuedPRReportsUntrustedReason
    reason = "", want "untrusted-merger"
```

The sockpuppet line is the money shot: `mallory` and `mallory-alt` are distinct, so the self-merge ban passes and the merge lands.

**Positive controls** (pass in *both* states):
- `TestF3_TrustedMergerMergesGreenQueuedPR` — a legitimate merger-tier merge still succeeds
- `TestF3_SelfMergeBanStillHolds` — trust is **not** a bypass of the self-merge ban

Full `./pkg/github/` suite green (43s).

## ⚠️ Existing test changed — please review this deliberately

`newAutoMergeSweepClient` now installs an authorizer granting the merger tier to `"bob"`, the queuer in every fixture expected to merge.

**These tests encoded the vulnerability.** `TestSweepQueuedAutoMergesMergesLabelledGreenPRAudits`, `TestSweepQueuedAutoMergesHonorsConfiguredLabel`, and `TestSweepQueuedAutoMergesRespectsCap` all asserted that an actor with **no trust classification whatsoever** successfully merges. `TestTrySweepQueuedPRSkipBranches` enumerates every rejection reason the sweep knows and has **no case** for an untrusted queuer — negative-space evidence the check never existed.

The safe fix is to give the fixture actor **real trust**, preserving each test's original intent as a genuine positive control. Relaxing the new gate to admit unclassified logins would have preserved the hole. No assertion was weakened, and no test was deleted.