### PR TITLE
🔒 fix(security): CSRF fails closed (F4), mint revocable v3 sessions (F10), bound the revocation store (F15)

### DIFF
--- a/v2/pkg/hub/csrf_f4_fail_closed_test.go
+++ b/v2/pkg/hub/csrf_f4_fail_closed_test.go
@@ -1,0 +1,235 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// AUDIT F4 (replay half): isCSRFSafe used to fail OPEN.
+//
+// The old final line was `return strings.Contains(ct, "application/json")`, so a
+// mutation with NO Origin and NO Referer was accepted as long as it claimed a
+// JSON Content-Type. Content-Type is attacker-controlled and proves nothing
+// about the caller, and a missing Origin/Referer is not evidence of a
+// non-browser client — Referrer-Policy: no-referrer, privacy extensions and
+// corporate proxies strip these routinely. The check now fails CLOSED.
+//
+// The tests below come in matched pairs. Each "must be refused" case is paired
+// with a "must still succeed" positive control, because a check that simply
+// returned false for every mutation would satisfy every regression here while
+// breaking the entire dashboard.
+//
+// NOTE on the existing suite: TestIsCSRFSafe in hub_test.go carried a case
+// asserting `{"POST with JSON content-type", "POST", "", "application/json",
+// true}`. That was the vulnerability written down as an expectation, so it was
+// INVERTED to `false` rather than deleted or relaxed.
+
+const f4TrustedOrigin = "https://hive.kubestellar.io"
+
+// TestF4HeaderlessJSONMutationIsRefused is the core regression.
+func TestF4HeaderlessJSONMutationIsRefused(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			if isCSRFSafe(req) {
+				t.Errorf("%s with a JSON Content-Type and no Origin/Referer was accepted; "+
+					"CSRF must fail closed (F4)", method)
+			}
+		})
+	}
+}
+
+// TestF4ContentTypeAloneNeverRescues: no Content-Type value is a substitute for
+// origin information. Pinned across the shapes an attacker would reach for,
+// including the ones a cross-site form POST can natively produce.
+func TestF4ContentTypeAloneNeverRescues(t *testing.T) {
+	for _, ct := range []string{
+		"application/json",
+		"application/json; charset=utf-8",
+		"APPLICATION/JSON",
+		"text/plain",
+		"application/x-www-form-urlencoded",
+		"multipart/form-data",
+		"",
+	} {
+		req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+		if ct != "" {
+			req.Header.Set("Content-Type", ct)
+		}
+		if isCSRFSafe(req) {
+			t.Errorf("POST with Content-Type %q and no Origin/Referer was accepted (F4)", ct)
+		}
+	}
+}
+
+// TestF4SameOriginMutationStillSucceeds is the POSITIVE CONTROL for the whole
+// finding. A legitimate dashboard mutation — the exact request the real UI
+// sends — must still pass. Without this, "reject every mutation" would satisfy
+// every regression above.
+func TestF4SameOriginMutationStillSucceeds(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		t.Run(method+"/Origin", func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Origin", f4TrustedOrigin)
+			if !isCSRFSafe(req) {
+				t.Errorf("legitimate same-origin %s was REFUSED — the fix is too strict "+
+					"and would break the dashboard", method)
+			}
+		})
+		t.Run(method+"/Referer", func(t *testing.T) {
+			// Origin absent but Referer present is a real browser shape.
+			req := httptest.NewRequest(method, "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Referer", f4TrustedOrigin+"/dashboard")
+			if !isCSRFSafe(req) {
+				t.Errorf("legitimate same-origin %s via Referer was REFUSED", method)
+			}
+		})
+	}
+	// Safe methods are untouched.
+	for _, method := range []string{"GET", "HEAD", "OPTIONS"} {
+		req := httptest.NewRequest(method, "/api/saas/my-hives", nil)
+		if !isCSRFSafe(req) {
+			t.Errorf("%s must remain safe", method)
+		}
+	}
+}
+
+// TestF4HostileOriginStillRefused: the exact-origin half of F4 (already fixed)
+// must not regress. A sibling tenant receives the parent-domain session cookie
+// and is therefore the most important hostile origin here.
+func TestF4HostileOriginStillRefused(t *testing.T) {
+	for _, origin := range []string{
+		"https://evil.com",
+		"https://hive.kubestellar.io.evil.com",
+		"https://attacker-hive.hive.kubestellar.io", // sibling tenant
+		"https://evil-hive.kubestellar.io",
+		"://invalid",
+		// NOT asserted here: "http://hive.kubestellar.io". isSameOriginAsHub
+		// matches on HOST only and deliberately accepts localhost/127.0.0.1 for
+		// local development, so it is scheme-agnostic by design. A scheme
+		// downgrade on the real hub host is unreachable in practice (HSTS + the
+		// Secure cookie), and tightening it is a separate change with its own
+		// dev-flow blast radius — deliberately out of scope for F4 rather than
+		// bundled in silently.
+	} {
+		req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Origin", origin)
+		if isCSRFSafe(req) {
+			t.Errorf("hostile Origin %q was accepted", origin)
+		}
+	}
+}
+
+// TestF4BearerLaneIsTheExplicitNonBrowserPath: a non-browser API client
+// authenticating with a bearer token and NO session cookie is allowed through,
+// because it carries no ambient credential and so cannot be cross-site forged.
+// This is the escape hatch that makes failing closed viable.
+func TestF4BearerLaneIsTheExplicitNonBrowserPath(t *testing.T) {
+	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer gho_sometoken")
+	if !isCSRFSafe(req) {
+		t.Error("a bearer-authenticated request with no session cookie must be allowed; " +
+			"it carries no ambient credential and cannot be CSRF'd")
+	}
+}
+
+// TestF4BearerDoesNotBypassWhenCookiePresent is the important half of the bearer
+// lane, and the one that would be easy to get wrong. If merely ADDING a header
+// let a cookie-bearing request skip the CSRF check, the fix would be worthless:
+// the ambient credential is still in play and is still what the server would
+// authenticate with.
+func TestF4BearerDoesNotBypassWhenCookiePresent(t *testing.T) {
+	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer gho_sometoken")
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "some-session-value"})
+	if isCSRFSafe(req) {
+		t.Error("a request carrying the ambient session cookie must prove its Origin " +
+			"even when it also sends a bearer token (F4)")
+	}
+
+	// Even a junk cookie value counts — "browser sent a cookie" is the signal,
+	// not "the cookie is valid". Otherwise the bypass condition is trivially
+	// satisfiable by sending a garbage cookie.
+	req2 := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req2.Header.Set("Authorization", "Bearer gho_sometoken")
+	req2.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "not-a-valid-cookie"})
+	if isCSRFSafe(req2) {
+		t.Error("an invalid session cookie must not re-enable the bearer bypass")
+	}
+
+	// A non-bearer Authorization scheme is not the API lane either.
+	req3 := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req3.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	if isCSRFSafe(req3) {
+		t.Error("a non-Bearer Authorization header must not pass the CSRF gate")
+	}
+}
+
+// TestF4RequireAuthAndRequireAdminBothEnforce pins that the check is actually
+// WIRED — a correct isCSRFSafe that no middleware calls protects nothing. An
+// earlier audit found ~21 admin routes with no CSRF check at all; both
+// middlewares must enforce it, and both must enforce it BEFORE resolving
+// identity so a forged request never reaches the impersonation logic.
+func TestF4RequireAuthAndRequireAdminBothEnforce(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+
+	for _, tc := range []struct {
+		name string
+		wrap func(http.HandlerFunc) http.HandlerFunc
+		user string
+	}{
+		{"requireAuth", s.requireAuth, "alice"},
+		{"requireAdmin", s.requireAdmin, hubAdminUsername},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			h := tc.wrap(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Headerless JSON mutation with a VALID session cookie — the CSRF
+			// scenario exactly. Must be refused, handler never reached.
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(testAuthCookie(tc.user))
+			h(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("headerless mutation status = %d, want 403", rec.Code)
+			}
+			if called {
+				t.Error("handler ran on a request that failed the CSRF check")
+			}
+			if !strings.Contains(rec.Body.String(), "CSRF") {
+				t.Errorf("body = %q, want a CSRF refusal", rec.Body.String())
+			}
+
+			// POSITIVE CONTROL: same request, same user, WITH a legitimate
+			// same-origin header — must reach the handler.
+			called = false
+			rec = httptest.NewRecorder()
+			ok := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+			ok.Header.Set("Content-Type", "application/json")
+			ok.Header.Set("Origin", f4TrustedOrigin)
+			ok.AddCookie(testAuthCookie(tc.user))
+			h(rec, ok)
+			if rec.Code != http.StatusOK || !called {
+				t.Errorf("legitimate same-origin mutation: status=%d called=%v; want 200 + handler run",
+					rec.Code, called)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/hub_cookie_v3_test.go
+++ b/v2/pkg/hub/hub_cookie_v3_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"encoding/json"
 	"log/slog"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,18 +269,44 @@ func TestF10_EitherLaneIsAdditive(t *testing.T) {
 	}
 }
 
-// TestF10_MintingHasNotFlipped is the anti-outage assertion. This PR ships the
-// VERIFIER only. If someone flips the minter to v3 before the whole fleet
-// verifies v3, /terminal breaks fleet-wide (incident #2773). This test is the
-// tripwire — when minting legitimately flips, this test is updated in the SAME
-// PR, which forces the change to be seen.
-func TestF10_MintingHasNotFlipped(t *testing.T) {
-	value := mintHubUserCookieValueV2(f10TestSeed, "alice")
-	if hubCookieIsV3(value) {
-		t.Fatal("the production minter now emits v3 — do not land this until every spoke verifies v3")
+// TestF10_MintingHasFlippedToV3 — INVERTED, by this test's own instructions.
+//
+// It was TestF10_MintingHasNotFlipped, the anti-outage tripwire for the PR that
+// shipped the v3 VERIFIER only: flipping the minter before the whole fleet
+// verified v3 would have broken /terminal fleet-wide (incident #2773). Its
+// comment said "when minting legitimately flips, this test is updated in the
+// SAME PR, which forces the change to be seen." This is that PR. The fleet is
+// v4 and v2/proxy/server.js verifies v3 → v2 → legacy, so the precondition is
+// met and the tripwire becomes its opposite: a guard that minting does not
+// silently fall BACK to the non-revocable format.
+//
+// Note it also had a real defect worth not reproducing: it called
+// mintHubUserCookieValueV2 directly, so it asserted what that function does,
+// not what PRODUCTION mints — it could never have detected the flip it existed
+// to catch. It now goes through mintSessionCookies, the actual login path.
+func TestF10_MintingHasFlippedToV3(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mintSessionCookies failed")
 	}
-	if !hubCookieIsV2(value) {
-		t.Fatal("the production minter no longer emits v2")
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+	if value == "" {
+		t.Fatal("no session cookie minted")
+	}
+	if !hubCookieIsV3(value) {
+		t.Fatal("the production minter no longer emits v3 — sessions would again have " +
+			"no signed expiry and no revocable id (F10)")
+	}
+	if hubCookieIsV2(value) {
+		t.Fatal("the production minter fell back to v2")
 	}
 }
 

--- a/v2/pkg/hub/hub_session_revocation.go
+++ b/v2/pkg/hub/hub_session_revocation.go
@@ -98,17 +98,61 @@ func (r *revokedSessions) isRevoked(sid string, now time.Time) bool {
 // A non-positive exp is ignored rather than stored: an entry that is already
 // expired would be evicted on the next prune without ever having rejected
 // anything, and storing it would let a caller grow the file with dead keys.
+// AUDIT F15: two hard bounds on the persisted store, both of which hold even if
+// the verify-before-revoke check in handleLogout is ever weakened or bypassed.
+// Defence in depth: the store's own invariants must not depend on its caller.
+const (
+	// maxRevokedSessionExpiry clamps how far in the future a stored entry may
+	// sit. An entry's expiry comes from the cookie's SIGNED claims, so it is not
+	// attacker-chosen once signatures are verified — but a bug that let an
+	// unverified value through, or a future minting change with a longer TTL,
+	// would otherwise pin entries indefinitely. Sized off the longest session the
+	// hub will ever mint (cookieSessionTTL) with slack for clock skew: nothing
+	// legitimate can exceed it, and anything that claims to is lying.
+	maxRevokedSessionExpiry = cookieSessionTTL + 24*time.Hour
+
+	// maxRevokedSessions hard-caps the entry count so the file, the startup parse
+	// and the memory footprint stay bounded no matter what. The natural bound is
+	// "sessions revoked within one cookie lifetime", which for this fleet is
+	// orders of magnitude below this number; reaching it means something is
+	// wrong, so it is logged rather than silently absorbed.
+	maxRevokedSessions = 100_000
+)
+
 func (r *revokedSessions) revoke(sid string, exp int64, now time.Time) bool {
 	if r == nil || sid == "" || exp <= now.Unix() {
 		return false
+	}
+	// Clamp to the mint horizon. An entry is only useful until the cookie it
+	// names fails its own expiry check; anything beyond that is dead weight that
+	// merely occupies the store for longer.
+	if maxExp := now.Add(maxRevokedSessionExpiry).Unix(); exp > maxExp {
+		exp = maxExp
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if existing, ok := r.sid[sid]; ok && existing >= exp {
 		return false
 	}
+	// The cap applies only to NEW session IDs — extending an entry that already
+	// exists adds nothing to the store's size, and refusing it would be the
+	// unsafe direction (it would leave a session un-revoked).
+	if _, exists := r.sid[sid]; !exists && len(r.sid) >= maxRevokedSessions {
+		return false
+	}
 	r.sid[sid] = exp
 	return true
+}
+
+// atCapacity reports whether the store has hit its hard cap, so the caller can
+// log it. Separate from revoke so the lock discipline stays simple.
+func (r *revokedSessions) atCapacity() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.sid) >= maxRevokedSessions
 }
 
 // pruneExpired drops entries whose expiry has passed, reporting whether anything
@@ -286,12 +330,71 @@ func (s *HubServer) revokeHubSessionCookieAt(value string, now time.Time) bool {
 		return false
 	}
 	if !s.revokedSessions.revoke(sid, exp, now) {
+		if s.revokedSessions.atCapacity() {
+			// AUDIT F15: the hard cap refused an entry. This should be
+			// unreachable in normal operation, so it is an operational signal,
+			// not a routine outcome — a session the user asked to revoke has NOT
+			// been revoked.
+			s.logger.Error("revocation store at capacity — session NOT revoked",
+				"cap", maxRevokedSessions)
+		}
 		return false
 	}
 	s.revokedSessions.pruneExpired(now)
-	s.saveRevokedSessions()
+	// AUDIT F15: coalesce the disk write, but stay DURABLE.
+	//
+	// The tempting version of this is "mark dirty, flush on a timer, return" —
+	// which is wrong here, and the F10 restart test is what says so. Revocation's
+	// entire value proposition is that it survives a roll: the hub restarts
+	// several times a day, so a revocation that is only in memory un-revokes
+	// itself on a schedule an attacker can simply wait for. A purely deferred
+	// flush reintroduces exactly the bug F10 was filed for, just with a 2-second
+	// window instead of an unbounded one.
+	//
+	// So the write still happens before this returns. What coalescing buys is
+	// that CONCURRENT revocations collapse into one write rather than one each:
+	// the flush is idempotent and drains whatever is pending, so a burst of N
+	// logouts costs far fewer than N full-file rewrites without any of them
+	// returning before their own entry is on disk.
+	s.markRevokedSessionsDirty()
+	s.flushRevokedSessions()
 	s.logger.Info("audit: hub session revoked", "sid", sid)
 	return true
+}
+
+// markRevokedSessionsDirty records that the in-memory set has changes not yet on
+// disk. Separate from the flush so several revocations can accumulate into one
+// pending write.
+func (s *HubServer) markRevokedSessionsDirty() {
+	if s == nil {
+		return
+	}
+	s.revokedSaveMu.Lock()
+	s.revokedSaveDirty = true
+	s.revokedSaveMu.Unlock()
+}
+
+// flushRevokedSessions persists the set if anything is pending, and is a no-op
+// otherwise. Safe to call unconditionally and from any goroutine.
+//
+// The dirty flag is cleared BEFORE the write, under the lock, and the write
+// snapshots the whole set. That ordering is what makes concurrent revocations
+// coalesce: a revocation that lands while a flush is in progress re-marks the
+// set dirty, and either it was already captured by the in-flight snapshot
+// (harmless — the next flush is a cheap no-op re-write) or it is picked up by
+// the next flush. The one thing that must never happen is a change being
+// dropped, and clearing-before-writing cannot drop one; clearing after could.
+func (s *HubServer) flushRevokedSessions() {
+	if s == nil || s.revokedSessions == nil {
+		return
+	}
+	s.revokedSaveMu.Lock()
+	dirty := s.revokedSaveDirty
+	s.revokedSaveDirty = false
+	s.revokedSaveMu.Unlock()
+	if dirty {
+		s.saveRevokedSessions()
+	}
 }
 
 // hubSessionRevokedLookup adapts the store to the hubSessionRevokedFunc the

--- a/v2/pkg/hub/hub_test.go
+++ b/v2/pkg/hub/hub_test.go
@@ -88,7 +88,15 @@ func TestIsCSRFSafe(t *testing.T) {
 		// though the browser hands it the parent-domain session cookie.
 		{"POST from sibling tenant origin", "POST", "https://attacker-hive.hive.kubestellar.io", "", false},
 		{"POST from sibling tenant origin with JSON ct", "POST", "https://attacker-hive.hive.kubestellar.io", "application/json", false},
-		{"POST with JSON content-type", "POST", "", "application/json", true},
+		// AUDIT F4 — THIS CASE IS INVERTED, NOT RELAXED. It previously asserted
+		// `true`: a POST with no Origin, no Referer and Content-Type
+		// application/json was treated as CSRF-safe. That WAS the vulnerability,
+		// written down as an expectation. Content-Type is attacker-controlled and
+		// proves nothing, and "no Origin/Referer" is not evidence of a
+		// non-browser caller — Referrer-Policy: no-referrer, privacy extensions
+		// and corporate proxies strip these routinely. Failing closed is the
+		// whole fix, so the expectation flips to `false`.
+		{"POST with JSON content-type and no origin is NOT safe", "POST", "", "application/json", false},
 		{"POST with no origin or ct", "POST", "", "", false},
 		{"POST with evil origin suffix", "POST", "https://hive.kubestellar.io.evil.com", "", false},
 		{"DELETE with trusted referer", "DELETE", "", "", false},

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -153,6 +153,12 @@ func TestWriteBlockedDuringImpersonation(t *testing.T) {
 	rec := httptest.NewRecorder()
 	post := httptest.NewRequest(http.MethodPost, "/api/saas/hives", strings.NewReader("{}"))
 	post.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: without an Origin this now stops at the CSRF gate with 403. The
+	// status would still be 403, so the test would keep passing while no longer
+	// exercising the IMPERSONATION write-block it is named for — the "read-only"
+	// body assertion below is what catches the difference. Send the same-origin
+	// header a real browser would so the request reaches the block under test.
+	post.Header.Set("Origin", "https://hive.kubestellar.io")
 	post.AddCookie(testAuthCookie(hubAdminUsername))
 	post.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guardedAuth(rec, post)
@@ -171,6 +177,7 @@ func TestWriteBlockedDuringImpersonation(t *testing.T) {
 	guardedAdmin := s.requireAdmin(next)
 	rec = httptest.NewRecorder()
 	del := httptest.NewRequest(http.MethodDelete, "/api/saas/admin/users/alice", nil)
+	del.Header.Set("Origin", "https://hive.kubestellar.io") // see the note on `post` above (F4)
 	del.AddCookie(testAuthCookie(hubAdminUsername))
 	del.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guardedAdmin(rec, del)

--- a/v2/pkg/hub/lite_enrollment_test.go
+++ b/v2/pkg/hub/lite_enrollment_test.go
@@ -228,9 +228,34 @@ func TestLiteEnrollRouteRequiresAuth(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/saas/lite/enroll", strings.NewReader(`{"owner":"o","repo":"r","installation_id":1}`))
 	req.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: a JSON Content-Type with no Origin no longer passes the CSRF
+	// gate (it fails closed), and requireAuth checks CSRF before identity — so
+	// without an Origin this returns 403 and stops proving anything about AUTH,
+	// which is what the test is named for. Supplying a legitimate same-origin
+	// header keeps the request past the CSRF gate so the 401 assertion still
+	// tests the thing it was written to test.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d body=%s, want 401", rec.Code, rec.Body.String())
+	}
+}
+
+// TestLiteEnrollRouteRefusesHeaderlessMutation is the F4 companion: the same
+// route, same unauthenticated caller, but with NO Origin/Referer. Before the fix
+// the JSON Content-Type alone carried it past the CSRF gate. It must now be
+// refused at that gate, BEFORE any identity resolution.
+func TestLiteEnrollRouteRefusesHeaderlessMutation(t *testing.T) {
+	s, cleanup := newLiteTestHub(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/saas/lite/enroll", s.requireAuth(s.handleLiteEnroll))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/lite/enroll", strings.NewReader(`{"owner":"o","repo":"r","installation_id":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s, want 403 (CSRF fails closed)", rec.Code, rec.Body.String())
 	}
 }
 

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -21,6 +21,16 @@ const (
 	oauthTimeout     = 10 * time.Second
 	cookieMaxAgeDays = 7 // login session cookie lifetime
 
+	// cookieSessionTTL is the SIGNED lifetime baked into a v3 session cookie
+	// (audit F10). Derived from cookieMaxAgeDays so the enforced expiry and the
+	// browser's MaxAge hint can never drift apart — the two must agree, or a
+	// session either dies early in the browser or outlives its signature.
+	//
+	// This is the value that actually bounds a stolen cookie: MaxAge is advisory
+	// and an attacker replaying a captured value ignores it entirely, whereas exp
+	// is inside the signature and checked by every verifier.
+	cookieSessionTTL = time.Duration(cookieMaxAgeDays) * 24 * time.Hour
+
 	// oauthRedirectURI is the single OAuth/OIDC callback registered on every
 	// provider's side. All providers share one callback path; the state parameter
 	// carries which provider to complete against.
@@ -666,13 +676,44 @@ func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (log
 // must never be emitted.
 //
 // The value is a signed, tamper-evident token so it cannot be forged.
-// N2: minted ASYMMETRICALLY (mintHubUserCookieValueV2). The hub holds the
-// Ed25519 private seed; spokes receive only the public key, so a spoke
-// operator can verify this cookie but can no longer forge one (notably an
-// admin cookie). The signer signs an opaque string, so a canonical
-// "provider:subject" identity rides through with no format change.
+// N2: minted ASYMMETRICALLY. The hub holds the Ed25519 private seed; spokes
+// receive only the public key, so a spoke operator can verify this cookie but
+// can no longer forge one (notably an admin cookie). The signer signs an opaque
+// string, so a canonical "provider:subject" identity rides through with no
+// format change.
+//
+// AUDIT F10: production now mints V3, not V2.
+//
+// V2 carries only the username. Its lifetime lives entirely in the cookie's
+// MaxAge attribute — a CLIENT-side hint the browser is free to ignore and an
+// attacker who captured the value simply discards — and it has no session ID, so
+// there is nothing for logout to revoke. Concretely: a stolen V2 cookie is valid
+// forever, and /api/auth/logout was a no-op against it.
+//
+// V3 moves both facts inside the signature: a signed `exp` the verifier enforces
+// regardless of what the client claims, and a random `sid` the hub records at
+// logout so the verifier rejects it on demand (hub_session_revocation.go).
+//
+// WHY IT IS SAFE TO FLIP NOW. The V3 minting function has carried a comment
+// saying nothing calls it in production, deliberately, because a spoke that
+// cannot parse the shape breaks /terminal fleet-wide — incident #2773, the
+// v2-hub/v4-spoke split. That condition no longer holds: the fleet is v4, and
+// the spoke-side verifier in v2/proxy/server.js tries lanes v3 → v2 → legacy
+// (verifyHubUserCookieEither), so a spoke accepts a V3 cookie today. This is
+// therefore the verify-both/mint-new cutover the N2 change already rehearsed,
+// with the verifier side shipped well ahead of the minter — not a flag day.
+//
+// The TTL matches the cookie's MaxAge, so the signed expiry and the browser hint
+// agree and nothing changes about how long a session lasts. The difference is
+// only that the signed one is now the ENFORCED one.
+//
+// Note the residual on spokes: the proxy enforces signature and signed expiry
+// but has no revocation store, so a revoked session can still reach a spoke
+// until its expiry. Closing that requires the spoke to ask the hub on the
+// terminal path; it is tracked separately and called out in hub_session_revocation.go.
 func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
-	cookieValue := mintHubUserCookieValueV2(s.sessionSigningSeed(), canonicalID)
+	cookieValue, _ := mintHubUserCookieValueV3(
+		s.sessionSigningSeed(), canonicalID, time.Now(), cookieSessionTTL)
 	if cookieValue == "" {
 		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", canonicalID)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
@@ -825,13 +866,38 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// AUDIT F10: deleting the browser's copy is not logging out. Anyone who
 	// captured the cookie value keeps a working session until its own expiry.
 	// Record the session ID server-side so the verifier rejects it from now on.
+	// Now load-bearing: minting emits v3 (see mintSessionCookies).
 	//
-	// This is a no-op today because minting still emits v2, which carries no
-	// session ID — that is the point of this PR being verifier-only. It becomes
-	// load-bearing the moment minting flips to v3, with no further change to
-	// this handler.
+	// AUDIT F15: this route is deliberately unauthenticated — logout must work
+	// even when the session is already broken, and requiring auth to log out is
+	// its own denial of service. But it used to pass the RAW cookie value
+	// straight to revokeHubSessionCookie, and revocation writes to a persisted
+	// store. An anonymous attacker could POST arbitrary attacker-chosen values
+	// and grow that store without bound: every entry lands on the PVC, is
+	// rewritten in full on each revocation, and is loaded on every hub start. The
+	// entries were also stored until the *cookie's own claimed* expiry, which is
+	// attacker-supplied, so a forged far-future exp pinned an entry for as long
+	// as the attacker liked.
+	//
+	// The fix is to verify BEFORE revoking. verifyHubUserCookie checks the
+	// Ed25519 signature, so a session ID can only enter the store if the hub
+	// itself minted the cookie — the store is now bounded by sessions the hub
+	// actually issued, not by requests an attacker can send. A caller presenting
+	// a real cookie is not an attacker; they are the owner of that session,
+	// logging out.
+	//
+	// The browser's copy is cleared unconditionally regardless, below: a client
+	// with a corrupt or expired cookie must still be able to clear it.
 	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
-		s.revokeHubSessionCookie(c.Value)
+		if _, ok := s.verifyHubUserCookie(c.Value); ok {
+			s.revokeHubSessionCookie(c.Value)
+		} else {
+			// Not an error path worth surfacing to the client — an expired or
+			// already-revoked cookie logging out is entirely normal — but it is
+			// worth counting, because a spike is what an enumeration attempt
+			// against this route looks like.
+			s.logger.Debug("logout: unverifiable session cookie, nothing to revoke")
+		}
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     "hive_hub_user",

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -122,11 +122,21 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	if user, ok := verifyHubUserCookieEither(pub, legacy, sessionCookie.Value); !ok || user != "octocat" {
 		t.Errorf("minted cookie did not verify: (%q, %v)", user, ok)
 	}
-	// And it must be the v2 format, not a legacy HMAC cookie that merely still
-	// verifies — otherwise the hub is silently minting the forgeable format.
-	if !hubCookieIsV2(sessionCookie.Value) {
-		t.Errorf("hub minted a LEGACY (symmetric) session cookie %q — any spoke could forge one",
+	// AUDIT F10 — updated from hubCookieIsV2 to hubCookieIsV3. This is a
+	// TIGHTENING, not a relaxation: the original intent was "must not be the
+	// forgeable symmetric format", and v3 is Ed25519-signed exactly as v2 is,
+	// PLUS it carries a signed expiry and a revocable session id. Asserting v2
+	// here after the mint flip would demand the hub keep issuing the
+	// non-revocable format, i.e. the test would pin the finding open.
+	if !hubCookieIsV3(sessionCookie.Value) {
+		t.Errorf("hub did not mint a v3 session cookie %q — a v2/legacy cookie has "+
+			"no signed expiry and no session id, so logout cannot revoke it (F10)",
 			sessionCookie.Value)
+	}
+	// The forgeable-format guarantee the original assertion existed for, stated
+	// directly rather than implied by the version marker.
+	if hubCookieIsV2(sessionCookie.Value) {
+		t.Error("hub minted a v2 cookie — expected v3")
 	}
 }
 

--- a/v2/pkg/hub/oidc_login_test.go
+++ b/v2/pkg/hub/oidc_login_test.go
@@ -150,13 +150,18 @@ func TestOIDCCallback_CreatesCanonicalUser(t *testing.T) {
 	}
 
 	// The session cookie is minted over the canonical id and verifies through
-	// the hub's own verifier (Ed25519 v2 format).
+	// the hub's own verifier.
+	//
+	// AUDIT F10 — updated from hubCookieIsV2 to hubCookieIsV3, a tightening
+	// rather than a relaxation: v3 is Ed25519-signed like v2 and additionally
+	// carries a signed expiry and a revocable session id. See the same change in
+	// oauth_provision_coverage_test.go.
 	var gotSession bool
 	for _, c := range rec.Result().Cookies() {
 		if c.Name == "hive_hub_user" && c.Value != "" {
 			gotSession = true
-			if !hubCookieIsV2(c.Value) {
-				t.Errorf("hive_hub_user is not the Ed25519 v2 format: %q", c.Value)
+			if !hubCookieIsV3(c.Value) {
+				t.Errorf("hive_hub_user is not the Ed25519 v3 format: %q", c.Value)
 			}
 			if user, ok := s.verifyHubUserCookie(c.Value); !ok || user != "google:"+sub {
 				t.Errorf("hive_hub_user verifies to %q (ok=%v), want google:%s", user, ok, sub)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -653,20 +653,82 @@ func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// isCSRFSafe reports whether a request may be allowed to MUTATE state.
+//
+// AUDIT F4 (replay half). This used to end with
+//
+//	return strings.Contains(ct, "application/json")
+//
+// which meant a mutation carrying NEITHER Origin NOR Referer was treated as
+// safe as long as it said `Content-Type: application/json`. That fails OPEN, and
+// the Content-Type is not a defence: it is fully attacker-controlled, and — the
+// part that actually matters — Origin is absent in exactly the cases CSRF cares
+// about. A browser omits Origin on plenty of navigations and redirect-issued
+// requests, and Referer is routinely stripped by
+// `Referrer-Policy: no-referrer`, privacy extensions, and corporate proxies. So
+// "no headers" was never a reliable signal of "not a browser"; it was a signal
+// of "we cannot tell", and the old code resolved that ambiguity in the
+// attacker's favour on every requireAuth and requireAdmin write.
+//
+// It now fails CLOSED: a mutation must positively demonstrate it is either
+// same-origin or not-a-browser. There are exactly two ways to do that.
+//
+//  1. Origin (preferred) or Referer matches the hub. Browsers attach Origin to
+//     every cross-origin mutation and cannot forge it from script, which is what
+//     makes it load-bearing.
+//
+//  2. The request authenticates with `Authorization: Bearer …` and sends NO
+//     session cookie. This is the explicit non-browser lane, and it is safe for
+//     a structural reason rather than a stylistic one: CSRF is an AMBIENT
+//     credential attack. A cross-site request rides the cookie the browser
+//     attaches automatically; it cannot attach an Authorization header, because
+//     setting one from script requires CORS permission the hub never grants. A
+//     request whose ONLY credential is a bearer token therefore cannot be
+//     cross-site forged — the attacker would need the token itself, at which
+//     point CSRF is irrelevant.
+//
+//     The "no session cookie" half is not optional. If a request carrying the
+//     ambient cookie could opt out of the CSRF check merely by ALSO presenting a
+//     header, then an attacker who can get any header set (or a stale token
+//     lying in a client) re-opens the hole. Cookie present ⇒ ambient credential
+//     ⇒ Origin must be proven.
+//
+// See getRealAuthUser: Bearer is already a first-class authentication path here,
+// so this is not a new trust surface, only an explicit statement of which lane a
+// caller is using.
 func isCSRFSafe(r *http.Request) bool {
 	if r.Method == "GET" || r.Method == "HEAD" || r.Method == "OPTIONS" {
 		return true
 	}
-	origin := r.Header.Get("Origin")
-	if origin != "" {
+	// Origin first: it is present on cross-origin browser mutations and cannot
+	// be spoofed by page script.
+	if origin := r.Header.Get("Origin"); origin != "" {
 		return isSameOriginAsHub(origin)
 	}
-	referer := r.Header.Get("Referer")
-	if referer != "" {
+	if referer := r.Header.Get("Referer"); referer != "" {
 		return isSameOriginAsHub(referer)
 	}
-	ct := r.Header.Get("Content-Type")
-	return strings.Contains(ct, "application/json")
+	// No origin information. The ONLY remaining way to be safe is to prove this
+	// is not an ambient-credential browser request.
+	return isNonBrowserAPIRequest(r)
+}
+
+// isNonBrowserAPIRequest reports whether a request authenticates purely with a
+// bearer token and carries no ambient session cookie — the one shape that is
+// structurally immune to CSRF. See isCSRFSafe for why both halves are required.
+func isNonBrowserAPIRequest(r *http.Request) bool {
+	if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+		return false
+	}
+	// Any hub session cookie means an ambient credential is in play, and the
+	// request must prove its origin like any other browser mutation. Checked by
+	// presence, not by validity: an INVALID cookie still means a browser sent
+	// one, and letting a bogus cookie value re-enable the bearer bypass would be
+	// a trivially attacker-satisfiable condition.
+	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
+		return false
+	}
+	return true
 }
 
 // hubCanonicalHost is the ONE host that serves the hub's own dashboard and API.

--- a/v2/pkg/hub/saas_bulk_test.go
+++ b/v2/pkg/hub/saas_bulk_test.go
@@ -50,6 +50,12 @@ func bulkPost(t *testing.T, srv *HubServer, user string, body any) (*httptest.Re
 	}
 	req := httptest.NewRequest("POST", "/api/saas/hives/bulk", bytes.NewReader(raw))
 	req.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: mutations now fail CLOSED without Origin/Referer, so this helper
+	// must send the header a real browser would. These tests are about bulk
+	// action semantics (caps, dedup, per-hive ownership), not about CSRF — the
+	// CSRF behaviour is asserted directly in csrf_f4_fail_closed_test.go. Without
+	// this every case here would stop at 403 and silently test nothing.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	if user != "" {
 		req.AddCookie(testAuthCookie(user))
 	}

--- a/v2/pkg/hub/saas_user_contact_test.go
+++ b/v2/pkg/hub/saas_user_contact_test.go
@@ -23,6 +23,11 @@ func contactUpdateHandler(srv *HubServer) http.Handler {
 func contactPutRequest(username, body, asUser string) *http.Request {
 	req := httptest.NewRequest("PUT", "/api/saas/admin/users/"+username, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: mutations fail closed without Origin/Referer. These tests cover
+	// admin contact-field authorization and caps; the same-origin header keeps
+	// them past the CSRF gate so they still exercise that. CSRF itself is
+	// asserted in csrf_f4_fail_closed_test.go.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	if asUser != "" {
 		req.AddCookie(testAuthCookie(asUser))
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -979,6 +979,15 @@ type HubServer struct {
 	// never touched while s.mu is held — see hub_session_revocation.go.
 	revokedSessions *revokedSessions
 
+	// revokedSave* coalesce the revocation set's disk writes (audit F15) without
+	// giving up durability: concurrent revocations collapse into one full-file
+	// rewrite instead of one each, but every revocation is still on disk before
+	// its call returns — a deferred-only flush would un-revoke sessions across a
+	// hub roll, which is the F10 bug. Leaf mutex like the store's own, never
+	// touched while s.mu is held — see flushRevokedSessions.
+	revokedSaveMu    sync.Mutex
+	revokedSaveDirty bool
+
 	// urlHealth remembers how many consecutive times each hive's PUBLIC
 	// dashboard URL failed to serve, so a transient blip can be told apart from
 	// a link that has been dead for hours. Populated by the auth-audit loop,

--- a/v2/pkg/hub/session_f10_f15_test.go
+++ b/v2/pkg/hub/session_f10_f15_test.go
@@ -1,0 +1,292 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// AUDIT F10 (mint flip) and F15 (unauthenticated logout grows the revocation
+// store without bound).
+//
+// F10: production minted V2 cookies, which carry only a username. Their lifetime
+// lives entirely in the client-side MaxAge attribute — which a replaying
+// attacker simply ignores — and they carry no session id, so /api/auth/logout
+// had nothing to revoke and was a no-op against a captured cookie. V3 puts a
+// signed exp and a random sid inside the signature. The spoke-side verifier
+// (v2/proxy/server.js, verifyHubUserCookieEither) already tries v3 → v2 →
+// legacy, so the verifier shipped ahead of the minter and this is a cutover, not
+// a flag day.
+//
+// F15: the logout route is deliberately unauthenticated (logging out must work
+// when the session is already broken). It passed the RAW cookie value to
+// revokeHubSessionCookie, so an anonymous attacker could POST arbitrary values
+// and grow a PERSISTED store without bound, pinning entries with a forged
+// far-future expiry.
+
+// f10f15Server builds a hub whose revocation store points at a temp path.
+func f10f15Server(t *testing.T) *HubServer {
+	t.Helper()
+	cleanup := helperSetupTempDirs(t)
+	t.Cleanup(cleanup)
+	s := newHandlerHub()
+	if s.revokedSessions == nil {
+		s.revokedSessions = newRevokedSessions()
+	}
+	prev := revokedSessionsPath
+	revokedSessionsPath = filepath.Join(t.TempDir(), "revoked.json")
+	t.Cleanup(func() { revokedSessionsPath = prev })
+	return s
+}
+
+// TestF10ProductionMintsV3 is the regression: the cookie the login path actually
+// sets must be v3, i.e. must carry a signed expiry and a revocable session id.
+func TestF10ProductionMintsV3(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mintSessionCookies failed")
+	}
+
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+	if value == "" {
+		t.Fatal("no session cookie minted")
+	}
+
+	if !hubCookieIsV3(value) {
+		t.Errorf("production minted a non-v3 session cookie %q — no signed expiry and "+
+			"no session id, so logout cannot revoke it (F10)", value)
+	}
+	// The two properties that make v3 worth minting, asserted directly rather
+	// than inferred from the version marker.
+	if sid := hubCookieSessionID(value); sid == "" {
+		t.Error("minted cookie carries no session id — nothing for logout to revoke")
+	}
+	if exp := hubCookieExpiry(value); exp <= time.Now().Unix() {
+		t.Errorf("minted cookie has no future signed expiry (exp=%d)", exp)
+	}
+
+	// POSITIVE CONTROL: it must still be a WORKING session. A mint that produced
+	// an unverifiable cookie would satisfy every assertion above while locking
+	// everyone out.
+	if user, ok := s.verifyHubUserCookie(value); !ok || user != "github:alice" {
+		t.Errorf("minted v3 cookie does not verify: (%q, %v)", user, ok)
+	}
+}
+
+// TestF10SignedExpiryIsEnforcedNotAdvisory: the whole point of v3's exp is that
+// it is checked by the verifier, unlike MaxAge which only the browser honours.
+func TestF10SignedExpiryIsEnforcedNotAdvisory(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mint failed")
+	}
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+
+	pub := s.sessionPublicKey()
+	// Valid now (positive control)...
+	if _, ok := verifyHubUserCookieEitherAt(pub, s.sessionKey(), value, time.Now(), nil); !ok {
+		t.Fatal("freshly minted cookie did not verify")
+	}
+	// ...and refused past its signed expiry, even though the value is byte
+	// identical and its signature is still perfectly valid. This is what a
+	// replaying attacker cannot get around.
+	future := time.Now().Add(cookieSessionTTL + time.Hour)
+	if _, ok := verifyHubUserCookieEitherAt(pub, s.sessionKey(), value, future, nil); ok {
+		t.Error("cookie still verified past its signed expiry — exp is not enforced (F10)")
+	}
+}
+
+// TestF10LogoutActuallyRevokes ties the flip to the outcome F10 is about: after
+// logout, the SAME cookie value stops working. Under v2 this was a no-op.
+func TestF10LogoutActuallyRevokes(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mint failed")
+	}
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+
+	// POSITIVE CONTROL: live before logout.
+	if _, ok := s.verifyHubUserCookie(value); !ok {
+		t.Fatal("cookie not valid before logout — setup is wrong")
+	}
+
+	out := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+	req.Header.Set("Origin", f4TrustedOrigin)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: value})
+	s.handleLogout(out, req)
+
+	if _, ok := s.verifyHubUserCookie(value); ok {
+		t.Error("the captured cookie value STILL works after logout — logout is a no-op (F10)")
+	}
+}
+
+// TestF15UnauthenticatedLogoutCannotGrowTheStore is the F15 regression. An
+// anonymous attacker POSTing garbage (or forged) cookie values must not add a
+// single entry to the persisted revocation store.
+func TestF15UnauthenticatedLogoutCannotGrowTheStore(t *testing.T) {
+	s := f10f15Server(t)
+
+	before := len(s.revokedSessions.snapshot())
+
+	// A spread of attacker-controlled shapes: junk, a well-formed-but-unsigned
+	// v3 body, and a v3 cookie signed with the WRONG key.
+	forged, _ := mintHubUserCookieValueV3(
+		"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+		"attacker", time.Now(), 100000*time.Hour)
+
+	for i, value := range []string{
+		"garbage",
+		"not.a.cookie",
+		"eyJ1IjoiYXR0YWNrZXIifQ.v3.bm90YXNpZw",
+		forged,
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+		req.Header.Set("Origin", f4TrustedOrigin)
+		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: value})
+		s.handleLogout(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("case %d: logout status = %d, want 200 (logout must always clear the browser copy)", i, rec.Code)
+		}
+	}
+
+	if got := len(s.revokedSessions.snapshot()); got != before {
+		t.Errorf("revocation store grew from %d to %d entries on UNVERIFIED cookies — "+
+			"an anonymous attacker can grow the persisted store without bound (F15)", before, got)
+	}
+
+	// And nothing was persisted either.
+	if data, err := os.ReadFile(revokedSessionsPath); err == nil && len(data) > 0 {
+		var stored map[string]int64
+		_ = json.Unmarshal(data, &stored)
+		if len(stored) != 0 {
+			t.Errorf("forged logouts wrote %d entries to the PVC (F15)", len(stored))
+		}
+	}
+}
+
+// TestF15LegitimateLogoutStillRevokes is the POSITIVE CONTROL for F15. Verifying
+// before revoking must not break real logout — otherwise "revoke nothing" would
+// pass the regression above and silently re-open F10.
+func TestF15LegitimateLogoutStillRevokes(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mint failed")
+	}
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+	sid := hubCookieSessionID(value)
+
+	out := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+	req.Header.Set("Origin", f4TrustedOrigin)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: value})
+	s.handleLogout(out, req)
+
+	if !s.revokedSessions.isRevoked(sid, time.Now()) {
+		t.Fatal("a LEGITIMATE logout did not revoke the session — verify-before-revoke " +
+			"is too strict and has re-opened F10")
+	}
+	// Durability: the revocation must survive a hub roll, which is the entire
+	// reason the store is on disk. A deferred-only flush would fail here.
+	restarted := &HubServer{logger: s.logger, revokedSessions: newRevokedSessions()}
+	restarted.loadRevokedSessions()
+	if !restarted.revokedSessions.isRevoked(sid, time.Now()) {
+		t.Error("revocation did not survive restart — write coalescing dropped durability")
+	}
+}
+
+// TestF15ExpiryIsClampedToTheMintHorizon: an entry may not be stored further out
+// than the longest session the hub will ever mint. Defence in depth behind
+// verify-before-revoke, so the store's bound does not depend on its caller.
+func TestF15ExpiryIsClampedToTheMintHorizon(t *testing.T) {
+	r := newRevokedSessions()
+	now := time.Now()
+
+	absurd := now.Add(1000 * 24 * time.Hour).Unix()
+	if !r.revoke("sid-far-future", absurd, now) {
+		t.Fatal("revoke refused a new entry")
+	}
+	got := r.snapshot()["sid-far-future"]
+	maxAllowed := now.Add(maxRevokedSessionExpiry).Unix()
+	if got > maxAllowed {
+		t.Errorf("stored expiry %d exceeds the mint horizon %d — a forged far-future exp "+
+			"pins an entry for as long as the attacker likes (F15)", got, maxAllowed)
+	}
+
+	// POSITIVE CONTROL: a NORMAL expiry is stored unchanged, not clamped down to
+	// something uselessly short (which would silently un-revoke sessions early).
+	normal := now.Add(cookieSessionTTL / 2).Unix()
+	if !r.revoke("sid-normal", normal, now) {
+		t.Fatal("revoke refused a normal entry")
+	}
+	if got := r.snapshot()["sid-normal"]; got != normal {
+		t.Errorf("normal expiry was altered: stored %d, want %d", got, normal)
+	}
+}
+
+// TestF15StoreIsHardCapped: the entry count is bounded no matter what.
+func TestF15StoreIsHardCapped(t *testing.T) {
+	r := newRevokedSessions()
+	now := time.Now()
+	exp := now.Add(time.Hour).Unix()
+
+	// Fill to the cap directly (cheaper than driving maxRevokedSessions HTTP
+	// requests, and it is the store's invariant under test).
+	r.mu.Lock()
+	for i := 0; i < maxRevokedSessions; i++ {
+		r.sid["sid-"+strconv.Itoa(i)] = exp
+	}
+	r.mu.Unlock()
+
+	if r.revoke("one-too-many", exp, now) {
+		t.Error("store accepted an entry beyond its hard cap (F15)")
+	}
+	if got := len(r.snapshot()); got > maxRevokedSessions {
+		t.Errorf("store holds %d entries, cap is %d", got, maxRevokedSessions)
+	}
+
+	// POSITIVE CONTROL: at capacity, EXTENDING an existing entry must still
+	// work. Refusing it would leave a session un-revoked, which is the unsafe
+	// direction and exactly the wrong way to enforce a cap.
+	if !r.revoke("sid-0", exp+3600, now) {
+		t.Error("at capacity, extending an EXISTING revocation was refused — that leaves " +
+			"a session live and is the unsafe direction")
+	}
+}


### PR DESCRIPTION
Three Medium-severity session findings that compound: a CSRF gate that let forged mutations through, sessions that could not be revoked once stolen, and a revocation store an anonymous attacker could grow at will.

## F4 (replay half) — CSRF failed OPEN with no Origin and no Referer

`isCSRFSafe` ended with `return strings.Contains(ct, "application/json")`, so a mutation carrying **neither** header was accepted if it merely claimed a JSON Content-Type. Content-Type is attacker-controlled and proves nothing, and missing Origin/Referer is not evidence of a non-browser caller — `Referrer-Policy: no-referrer`, privacy extensions and corporate proxies strip them routinely. It now **fails closed**.

Non-browser clients get an explicit lane: `Authorization: Bearer` with **no session cookie**. That is safe structurally, not stylistically — CSRF is an *ambient credential* attack, and a request whose only credential is a bearer token cannot be cross-site forged (script cannot set that header without CORS permission the hub never grants). The "no cookie" half is required: letting a cookie-bearing request opt out by *also* sending a header would re-open the hole. Bearer is already a first-class auth path in `getRealAuthUser`, so this is not a new trust surface.

**On the ~21 unprotected admin routes:** checked as instructed — that gap (N6) is already closed on v4. Both `requireAuth` and `requireAdmin` call `isCSRFSafe` before resolving identity. `TestF4RequireAuthAndRequireAdminBothEnforce` pins the wiring so a correct-but-uncalled check cannot regress silently.

### NOT changed: the cookie `Domain` attribute

Left alone deliberately, as instructed. The code carries an `AUDIT F4, DELIBERATELY NOT CHANGED` comment and it is right: spokes verify this cookie **independently** in `v2/proxy/server.js`, and the browser only delivers it to `<id>.hive.kubestellar.io` *because* of `Domain=.hive.kubestellar.io`. Dropping it (which `__Host-` additionally forbids) means no spoke ever receives the cookie, logging every hosted tenant out of their dashboard and terminal — a fleet-wide outage, and precisely the flag-day auth change behind incident #2773. The verify-both/mint-new trick does not rescue it, because the change is to *delivery scope*, not to a format a verifier can learn. This needs a spoke-scoped session redesign and stays tracked as follow-up.

## F10 — production minted non-revocable v2 cookies; logout was a no-op

v2 carries only a username. Its lifetime lives entirely in the **client-side** `MaxAge` attribute, which a replaying attacker simply ignores, and it has no session id — so `/api/auth/logout` had nothing to revoke. A captured cookie was good forever.

Minting now emits **v3** (signed `exp` + revocable `sid`). The `NOTHING CALLS THIS IN PRODUCTION YET` guard existed for incident #2773, the v2-hub/v4-spoke split. Verified before flipping, as instructed: the fleet is v4 and `v2/proxy/server.js` `verifyHubUserCookieEither` already tries **v3 → v2 → legacy**, so the spoke-side verifier shipped well ahead of the minter. This is the same verify-both/mint-new cutover the N2 Ed25519 change already rehearsed, not a flag day. TTL derives from `cookieMaxAgeDays` so the signed expiry and the browser hint cannot drift apart.

Residual, unchanged and called out in code: spokes enforce signature and signed expiry but have no revocation store, so a revoked session can still reach a spoke until its expiry. Closing that puts a hub round-trip on the terminal path — out of scope here.

## F15 — unauthenticated logout grew a persistent store without bound

The handler passed the **raw** cookie to `revokeHubSessionCookie`, and revocation writes to a PVC-backed store. An anonymous attacker could POST arbitrary values, grow the file without bound, and pin entries with a forged far-future expiry.

- **Verify before revoking** — a `sid` can only enter the store if the hub itself minted the cookie. The store is now bounded by sessions actually issued, not by requests an attacker can send.
- **Clamp** stored expiry to the mint horizon.
- **Hard-cap** the entry count.
- **Coalesce** writes.

The route stays unauthenticated and still always clears the browser's copy — requiring auth to log out is its own denial of service, and a client with a corrupt cookie must still be able to clear it.

### Two design calls, both driven by a test that failed

- **Write coalescing is not deferred-only.** A timer-based flush broke `TestF10_RevocationSurvivesRestart`, *correctly*: the hub rolls several times a day, so a revocation living only in memory un-revokes itself on a schedule an attacker can wait for — the F10 bug with a smaller window. Concurrent revocations now collapse into one write, but every revocation is on disk before its call returns.
- **The hard cap refuses new sids only.** Refusing to *extend* an existing entry would leave a session live, which is the unsafe direction.

## Testing

Every fix has a regression test **and** a positive control, and each was regression-replayed (neuter so it still compiles → confirm the specific test fails → restore → confirm green). Full `pkg/hub` suite green on fresh `v4`.

| Finding | Regression | Positive control |
|---|---|---|
| F4 | `TestF4HeaderlessJSONMutationIsRefused`, `TestF4ContentTypeAloneNeverRescues`, `TestF4BearerDoesNotBypassWhenCookiePresent` | `TestF4SameOriginMutationStillSucceeds` — a legitimate same-origin mutation must still 200, so "reject everything" cannot pass |
| F4 wiring | `TestF4RequireAuthAndRequireAdminBothEnforce` | same test, second half: same user + Origin reaches the handler |
| F10 | `TestF10ProductionMintsV3`, `TestF10SignedExpiryIsEnforcedNotAdvisory`, `TestF10LogoutActuallyRevokes` | the minted cookie must still **verify** — a mint producing junk would satisfy the rest while locking everyone out |
| F15 | `TestF15UnauthenticatedLogoutCannotGrowTheStore`, `TestF15ExpiryIsClampedToTheMintHorizon`, `TestF15StoreIsHardCapped` | `TestF15LegitimateLogoutStillRevokes` (incl. survives-restart); cap must still allow *extending* an existing entry |

## ⚠️ Existing tests edited — flagged as required

**Inverted, not relaxed** (they encoded the vulnerable behaviour):

1. `hub_test.go` `TestIsCSRFSafe` — the case `{"POST with JSON content-type", "POST", "", "application/json", true}` was F4 written down as an expectation. Flipped to `false`.
2. `hub_cookie_v3_test.go` `TestF10_MintingHasNotFlipped` → `TestF10_MintingHasFlippedToV3`. Its own comment instructed that it be updated in the same PR as the flip; this is that PR. It also had a **real defect**: it called `mintHubUserCookieValueV2` directly, so it asserted what that function does rather than what production mints — it could never have detected the flip it existed to catch. It now goes through `mintSessionCookies`, the actual login path.

**Tightened v2 → v3** (`oauth_provision_coverage_test.go`, `oidc_login_test.go`): their intent was "must not be the forgeable symmetric format". v3 is Ed25519 like v2 *plus* a signed expiry and revocable id, so this is strictly stronger — asserting v2 after the flip would have pinned the finding open.

**Header-only** (`saas_bulk_test.go`, `saas_user_contact_test.go`, `impersonation_test.go`, `lite_enrollment_test.go`): these test bulk semantics, field caps and the impersonation write-block, and only needed the same-origin `Origin` header a real browser sends. Without it they stop at 403 and silently assert nothing. `TestWriteBlockedDuringImpersonation` is the clearest case — it would have stayed **green on the wrong 403**. `TestLiteEnrollRouteRequiresAuth` keeps its 401 assertion and gains a companion asserting the headerless 403.

## Coordination with #3725 (F1)

No conflict. #3725 has since **merged**; this branch is rebased on current `v4` and F1's deletion of the legacy symmetric lane is intact — I did not touch `verifyHubUserCookieEitherAt`. The only shared file is `hub_cookie_v3_test.go`, where #3725 edits `TestF10_EitherLaneIsAdditive` and this PR edits a different test plus the import block. Rebase was clean and the full suite passes on top of it.

## Scope note

`isSameOriginAsHub` matches on **host only** and deliberately accepts `localhost`/`127.0.0.1` for local development, so it is scheme-agnostic — `http://hive.kubestellar.io` passes. Unreachable in practice (HSTS + `Secure` cookie), and tightening it has its own dev-flow blast radius, so it is left out of F4 rather than bundled in silently. Called out in a comment in the test file.

`go build ./...` + targeted `go test`. No kubectl, no cluster changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)