### PR TITLE
🔒 fix(security): close F8 redirect SSRF, N17 symlink chmod, F17 OIDC case-fold

### DIFF
--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -147,7 +147,23 @@ func removeTree(path string) error {
 		if walkErr != nil {
 			return nil
 		}
-		if d.IsDir() {
+		// AUDIT N17 (open across three audits): os.Chmod FOLLOWS symlinks. This
+		// walk runs over an agent-writable workspace, so a symlink planted there
+		// pointing at any path the cleanup user can chmod — a key file, a config,
+		// a binary on a shared mount — gets that TARGET relaxed to 0o660/0o770,
+		// not the link. Nothing here needs to chmod a symlink: the link's own mode
+		// is irrelevant to RemoveAll (which unlinks it) and its target is by
+		// definition outside the tree we are deleting. So skip links entirely.
+		//
+		// WalkDir does not follow symlinks itself, so d.Type() already reports the
+		// link — but d can come from a cached ReadDir entry, and a path can be
+		// swapped for a symlink between the readdir and this chmod (TOCTOU). The
+		// Lstat is the authoritative, immediately-before check.
+		info, lerr := os.Lstat(p)
+		if lerr != nil || info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if info.IsDir() {
 			os.Chmod(p, 0o770)
 		} else {
 			os.Chmod(p, 0o660)

--- a/v2/pkg/dashboard/workspace_cleanup_n17_symlink_test.go
+++ b/v2/pkg/dashboard/workspace_cleanup_n17_symlink_test.go
@@ -1,0 +1,163 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// AUDIT N17 (open across three audits): the chmod-and-retry fallback in
+// removeTree walked an agent-writable workspace calling bare os.Chmod, which
+// FOLLOWS symlinks. A symlink planted in the workspace pointing anywhere the
+// cleanup user could chmod got its TARGET relaxed to 0o660 (or 0o770 for a
+// directory) — turning "delete a stale workspace" into an arbitrary
+// permission-loosening primitive on files entirely outside that workspace.
+//
+// TestN17ChmodWalkDoesNotFollowSymlinks is the regression.
+// TestN17ChmodWalkStillRelaxesRealFiles is the POSITIVE CONTROL: an
+// implementation that skipped the chmod entirely (or that failed the walk
+// outright) would pass the regression while silently breaking the only reason
+// the fallback exists.
+
+// n17MakeStubbornDir builds a directory tree that RemoveAll cannot delete on the
+// first attempt, forcing removeTree down the chmod-and-retry path. A directory
+// with no write bit cannot have its children unlinked.
+//
+// links are created INSIDE the locked directory, and that placement is
+// load-bearing. removeTree's first step is os.RemoveAll, which is destructive
+// EVEN WHEN IT FAILS: it unlinks everything it can reach before hitting the
+// unremovable child. A symlink sitting at the top of the workspace is therefore
+// already gone by the time the chmod walk runs, and the test passes vacuously.
+// Inside the locked directory the link survives step 1 and is still present when
+// the walk — the code actually under test — reaches it.
+func n17MakeStubbornDir(t *testing.T, links map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	work := filepath.Join(root, "workspace")
+	inner := filepath.Join(work, "locked")
+	if err := os.MkdirAll(inner, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inner, "file.txt"), []byte("x"), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for name, target := range links {
+		if err := os.Symlink(target, filepath.Join(inner, name)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+	}
+	// Clamp the write bit off the inner dir so its child cannot be unlinked. This
+	// is what makes the FIRST os.RemoveAll fail and drives removeTree down to the
+	// chmod-and-retry walk — the code path under test. Without it removeTree
+	// succeeds immediately, the walk never runs, and the symlink test goes green
+	// no matter what the walk does. (That happened; the replay caught it.)
+	if err := os.Chmod(inner, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(inner, 0o700) })
+
+	// NOTE: do NOT "verify the premise" here by calling os.RemoveAll(work).
+	// RemoveAll is destructive even when it FAILS — it deletes everything it can
+	// reach before hitting the unremovable child, which includes the planted
+	// symlinks. The walk under test then finds nothing and the test passes
+	// vacuously. (Exactly this masked the replay until it was traced.) The
+	// premise is instead asserted non-destructively by the caller, on a
+	// throwaway copy of the same shape.
+	return work
+}
+
+// n17AssertRemoveAllFails checks, on a SEPARATE throwaway tree of the same
+// shape, that a plain os.RemoveAll really does fail — i.e. that removeTree will
+// be forced down the chmod-and-retry walk. Done on a copy precisely because the
+// check destroys what it touches.
+func n17AssertRemoveAllFails(t *testing.T) {
+	t.Helper()
+	probe := n17MakeStubbornDir(t, nil)
+	if err := os.RemoveAll(probe); err == nil {
+		t.Fatal("test premise broken: plain RemoveAll deleted the tree, so the " +
+			"chmod walk under test never runs and this test proves nothing")
+	}
+}
+
+// TestN17ChmodWalkDoesNotFollowSymlinks is the regression. A symlink inside the
+// doomed workspace points at a file OUTSIDE it whose mode is deliberately tight
+// (0o400). After removeTree runs, that outside file's mode must be untouched.
+func TestN17ChmodWalkDoesNotFollowSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX modes and symlinks")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores permission bits, so RemoveAll never needs the chmod walk")
+	}
+
+	// The victim lives outside the tree being removed — this is the whole point:
+	// nothing in the cleanup's remit should be able to reach it.
+	victimDir := t.TempDir()
+	victimFile := filepath.Join(victimDir, "secret.key")
+	if err := os.WriteFile(victimFile, []byte("private"), 0o400); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+	victimSubdir := filepath.Join(victimDir, "protected")
+	if err := os.Mkdir(victimSubdir, 0o500); err != nil {
+		t.Fatalf("mkdir victim dir: %v", err)
+	}
+
+	n17AssertRemoveAllFails(t)
+
+	// The planted links. The walk will visit both; a following chmod relaxes the
+	// TARGETS rather than the links.
+	work := n17MakeStubbornDir(t, map[string]string{
+		"link-to-secret": victimFile,
+		"link-to-dir":    victimSubdir,
+	})
+
+	// removeTree's success/failure is not what is under test — the side effect
+	// on the victim is. Deliberately ignore the error.
+	_ = removeTree(work)
+
+	fi, err := os.Lstat(victimFile)
+	if err != nil {
+		t.Fatalf("victim file vanished: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o400 {
+		t.Errorf("symlinked-to file mode = %#o, want 0400 unchanged; "+
+			"the cleanup walk followed a symlink out of the workspace (N17)", got)
+	}
+
+	di, err := os.Lstat(victimSubdir)
+	if err != nil {
+		t.Fatalf("victim dir vanished: %v", err)
+	}
+	if got := di.Mode().Perm(); got != 0o500 {
+		t.Errorf("symlinked-to dir mode = %#o, want 0500 unchanged; "+
+			"the cleanup walk followed a symlink out of the workspace (N17)", got)
+	}
+
+	// And the links themselves must not have dragged the victims into deletion.
+	if _, err := os.Stat(victimFile); err != nil {
+		t.Errorf("victim file should still exist: %v", err)
+	}
+}
+
+// TestN17ChmodWalkStillRelaxesRealFiles is the positive control: the fallback
+// must still do its job on REAL (non-symlink) entries, i.e. a read-only tree
+// that RemoveAll alone chokes on is still removed. "Skip everything" would pass
+// the regression above and fail here.
+func TestN17ChmodWalkStillRelaxesRealFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX modes")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores permission bits, so RemoveAll never needs the fallback")
+	}
+
+	work := n17MakeStubbornDir(t, nil)
+	if err := removeTree(work); err != nil {
+		t.Fatalf("removeTree should still remove a read-only tree via the chmod "+
+			"fallback; got %v", err)
+	}
+	if _, err := os.Stat(work); !os.IsNotExist(err) {
+		t.Errorf("workspace should be gone, stat err = %v", err)
+	}
+}

--- a/v2/pkg/hub/identity_canonical.go
+++ b/v2/pkg/hub/identity_canonical.go
@@ -124,13 +124,48 @@ func canonicalizeLegacy(id string) string {
 }
 
 // canonicalEqual reports whether two identity strings denote the same user,
-// tolerant of legacy (bare) vs canonical form and case-insensitive on the
-// GitHub-login subject (GitHub logins are case-insensitive; OIDC subs are exact
-// but a case-fold on an opaque sub is harmless because two subs that differ only
-// by case are not issued). Use this in place of raw string / EqualFold(Owner,…)
-// comparisons.
+// tolerant of legacy (bare) vs canonical form. Use this in place of raw string /
+// EqualFold(Owner,…) comparisons.
+//
+// AUDIT F17. This used to be a flat strings.EqualFold over the whole canonical
+// id, justified by "a case-fold on an opaque sub is harmless because two subs
+// that differ only by case are not issued". That holds for GitHub, whose logins
+// are genuinely case-insensitive and cannot collide. It is NOT guaranteed for
+// any OIDC provider: `sub` is defined as a case-SENSITIVE opaque string, and an
+// operator-run IdP (custom:, and Entra/Okta/Auth0/Keycloak behind it) may issue
+// subs that differ only by case — a base64/base64url sub does this routinely.
+// Under the old fold, `custom:AbC` and `custom:abc` were the same user, so a
+// self-registerable IdP account was a path to another tenant's hives.
+//
+// So the comparison is now provider-aware:
+//
+//   - the PROVIDER label always folds — it is a fixed keyword from
+//     identityProviders, and "GitHub:" vs "github:" is just wire noise.
+//   - a github SUBJECT folds — GitHub logins are case-insensitive, and folding
+//     is required for the legacy shim (a stored "ClubAnderson" must still match
+//     an authenticated "github:clubanderson").
+//   - every OTHER provider's subject compares EXACTLY. This is the strict
+//     direction: it can only ever refuse a match the old code accepted, and the
+//     only matches it refuses are ones that were never the same principal.
 func canonicalEqual(a, b string) bool {
-	return strings.EqualFold(canonicalizeLegacy(a), canonicalizeLegacy(b))
+	ca, cb := canonicalizeLegacy(a), canonicalizeLegacy(b)
+	if ca == "" || cb == "" {
+		return ca == cb
+	}
+	pa, sa, oka := parseCanonical(ca)
+	pb, sb, okb := parseCanonical(cb)
+	if !oka || !okb {
+		// Unparseable / unknown-provider ids are not identities we can reason
+		// about per-provider. Compare them exactly — the conservative choice.
+		return ca == cb
+	}
+	if pa != pb {
+		return false
+	}
+	if pa == legacyProvider {
+		return strings.EqualFold(sa, sb)
+	}
+	return sa == sb
 }
 
 // filenameHexUpper is the alphabet for the "-XX-" escape used by

--- a/v2/pkg/hub/identity_f17_case_sensitivity_test.go
+++ b/v2/pkg/hub/identity_f17_case_sensitivity_test.go
@@ -1,0 +1,100 @@
+package hub
+
+import "testing"
+
+// AUDIT F17: OIDC subject case-folding permitted cross-account confusion.
+//
+// canonicalEqual used to be a flat strings.EqualFold over the whole canonical
+// id. The comment justified it with "two subs that differ only by case are not
+// issued" — true for GitHub, NOT guaranteed for any OIDC provider, whose `sub`
+// is a case-SENSITIVE opaque string. Under the fold, an operator-run IdP that
+// issues (or lets a user self-register) `custom:AbC` handed that user everything
+// owned by `custom:abc`.
+//
+// TestF17OIDCSubjectsCompareExactly is the regression.
+// TestF17GitHubLoginsStillFold is the POSITIVE CONTROL: a comparison that simply
+// returned false for everything, or that dropped the legacy shim, would "pass"
+// the regression while breaking every real ownership check and locking every
+// pre-migration user out of their own hives.
+
+// TestF17OIDCSubjectsCompareExactly pins the strict lane: for every non-GitHub
+// provider, two subjects differing only by case are DIFFERENT users.
+func TestF17OIDCSubjectsCompareExactly(t *testing.T) {
+	// Every non-GitHub provider in identityProviders. A base64url `sub` (which
+	// Entra, Okta and Keycloak all emit) differs by case routinely, so this is
+	// not a theoretical shape.
+	for _, provider := range []string{"google", "ibmid", "redhat", "custom", "microsoft"} {
+		t.Run(provider, func(t *testing.T) {
+			owner := provider + ":AbCdEf"
+			attacker := provider + ":abcdef"
+			if canonicalEqual(owner, attacker) {
+				t.Errorf("canonicalEqual(%q, %q) = true; OIDC subs are case-sensitive, "+
+					"folding them lets one IdP account impersonate another", owner, attacker)
+			}
+			// ...and the exact same sub must still match, or the strictness is
+			// just a broken comparison.
+			if !canonicalEqual(owner, provider+":AbCdEf") {
+				t.Errorf("canonicalEqual(%q, itself) = false; identical subs must match", owner)
+			}
+		})
+	}
+}
+
+// TestF17OIDCProviderLabelStillFolds: the PROVIDER keyword is wire noise from a
+// closed set, not user-controlled data, so it still folds. Only the SUBJECT got
+// strict.
+func TestF17OIDCProviderLabelStillFolds(t *testing.T) {
+	if !canonicalEqual("Google:1078", "google:1078") {
+		t.Error("provider label should fold: Google: and google: are the same provider")
+	}
+	if !canonicalEqual("CUSTOM:sub-1", "custom:sub-1") {
+		t.Error("provider label should fold for custom: too")
+	}
+}
+
+// TestF17GitHubLoginsStillFold is the positive control. GitHub logins ARE
+// case-insensitive, and the legacy shim depends on the fold: a stored bare
+// "ClubAnderson" must match an authenticated "github:clubanderson". If a fix
+// made everything case-sensitive, this fails — which is exactly the signal that
+// the fix went too far.
+func TestF17GitHubLoginsStillFold(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"github:ClubAnderson", "github:clubanderson", true},
+		{"ClubAnderson", "github:clubanderson", true},
+		{"GitHub:ClubAnderson", "clubanderson", true},
+		{"clubanderson", "clubanderson", true},
+		// Different GitHub logins are still different users.
+		{"github:clubanderson", "github:someoneelse", false},
+		// Cross-provider never matches, whatever the case.
+		{"google:clubanderson", "github:clubanderson", false},
+		{"custom:AbC", "github:abc", false},
+	}
+	for _, c := range cases {
+		if got := canonicalEqual(c.a, c.b); got != c.want {
+			t.Errorf("canonicalEqual(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// TestF17EmptyAndMalformedIdentities: an empty or unparseable identity must
+// never match a real one. Ownership checks compare a stored Owner (which can be
+// empty on a half-written record) against an authenticated caller, so "" == ""
+// returning true is fine but "" == someone is not.
+func TestF17EmptyAndMalformedIdentities(t *testing.T) {
+	if canonicalEqual("", "github:clubanderson") {
+		t.Error("empty identity must not match a real user")
+	}
+	if canonicalEqual("github:clubanderson", "") {
+		t.Error("empty identity must not match a real user (reversed)")
+	}
+	// Unknown provider → unparseable → exact comparison, never a fold.
+	if canonicalEqual("bogusprovider:AbC", "bogusprovider:abc") {
+		t.Error("unknown-provider ids must compare exactly, not fold")
+	}
+	if !canonicalEqual("bogusprovider:AbC", "bogusprovider:AbC") {
+		t.Error("identical unknown-provider ids should still match")
+	}
+}

--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -204,7 +204,7 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 
 	args = append(args, "--", g.config.URL, g.cloneDir)
 
-	cmd := exec.CommandContext(cloneCtx, "git", args...)
+	cmd := exec.CommandContext(cloneCtx, "git", gitCmdArgs(args...)...)
 	cmd.Env = gitSourceEnv()
 
 	output, err := cmd.CombinedOutput()
@@ -474,6 +474,30 @@ func isSCPStyleGitURL(raw string) bool {
 	at := strings.Index(raw, "@")
 	colon := strings.Index(raw, ":")
 	return at > 0 && colon > at+1
+}
+
+// gitNoRedirectArgs are the leading `git -c …` overrides that forbid a remote
+// from bouncing a fetch to a different host AFTER the URL has passed validation.
+//
+// AUDIT F8 (residual). The DNS-pinning fix closed the "resolve the validated
+// hostname to 127.0.0.1" hole, but validation still only inspects the URL the
+// operator configured. git follows HTTP 3xx by default, so a public, allow-listed
+// remote can answer the very first request with `302 Location:
+// http://169.254.169.254/…` (or any in-cluster service) and git will happily
+// re-issue the request there — with credentials, and with every URL/DNS check
+// already behind it. `http.followRedirects=false` makes git treat a redirect as
+// an error instead of a destination, so a validated URL is the ONLY URL fetched.
+//
+// This is passed as `-c` args rather than an env var because there is no
+// GIT_HTTP_FOLLOW_REDIRECTS; http.followRedirects is config-only, and repo-local
+// config is attacker-influenced on a re-used clone dir whereas `-c` on the
+// command line wins over every config file.
+var gitNoRedirectArgs = []string{"-c", "http.followRedirects=false"}
+
+// gitCmdArgs prefixes a git argument list with the redirect suppression above.
+// Every git invocation that talks to a REMOTE must go through this.
+func gitCmdArgs(args ...string) []string {
+	return append(append([]string{}, gitNoRedirectArgs...), args...)
 }
 
 func gitSourceEnv() []string {

--- a/v2/pkg/knowledge/gitsource_f8_redirect_test.go
+++ b/v2/pkg/knowledge/gitsource_f8_redirect_test.go
@@ -1,0 +1,241 @@
+package knowledge
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// AUDIT F8 (residual): redirect SSRF after validation.
+//
+// GitSource validates the configured URL (scheme, host allow-list, and since the
+// DNS-pinning fix, the resolved address too). git then follows HTTP 3xx by
+// DEFAULT, so a public, fully-validated remote can answer the first request with
+// `302 Location: http://169.254.169.254/…` — or any in-cluster Service — and git
+// re-issues the request there with every check already behind it. Validating a
+// URL is worthless if the fetch is allowed to end up somewhere else.
+//
+// TestF8GitCloneRefusesRedirect / TestF8GitPullRefusesRedirect are the
+// regressions, driven against a real local HTTP server that redirects.
+// TestF8GitCloneStillWorksWithoutRedirect is the POSITIVE CONTROL: `git -c
+// http.followRedirects=false` must still clone a normal, non-redirecting remote,
+// or "block all git" would pass the regressions.
+
+func f8RequireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+}
+
+// f8RedirectServer models the F8 scenario with TWO servers.
+//
+// CRITICAL TEST-DESIGN NOTE. The obvious version of this test redirects at
+// 169.254.169.254 and asserts the clone fails. That test passes WITH OR WITHOUT
+// the fix — the clone fails either way, because link-local is simply
+// unroutable. It proves nothing. (Verified: with the fix neutered it still went
+// green.)
+//
+// So the "internal" target here is a REACHABLE local server that counts its
+// requests. The assertion is therefore not "did the clone fail" but "was the
+// internal target contacted AT ALL" — which is exactly the SSRF property, and
+// which flips the moment redirects are followed.
+//
+// front = the validated, allow-listed remote the operator configured.
+// internal = the address it tries to pivot the fetch to.
+func f8RedirectServer(t *testing.T) (remoteURL string, frontHits, internalHits *int) {
+	t.Helper()
+	nFront, nInternal := 0, 0
+
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nInternal++
+		// Answer plausibly so that, if git DOES follow, it keeps going and the
+		// hit is unambiguous rather than an instant transport error.
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(internal.Close)
+
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nFront++
+		http.Redirect(w, r, internal.URL+r.URL.Path, http.StatusFound)
+	}))
+	t.Cleanup(front.Close)
+
+	return front.URL + "/repo.git", &nFront, &nInternal
+}
+
+// f8LocalOriginRepo builds a real git repo on disk and serves it over HTTP via
+// git's dumb protocol, giving the positive control a remote that actually
+// clones without any redirect involved.
+func f8LocalOriginRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "origin")
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	run("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	run("add", "README.md")
+	run("commit", "-q", "-m", "init")
+	// Dumb HTTP needs the server info + a bare-visible layout; simplest reliable
+	// remote for a unit test is the local path itself, which exercises the same
+	// argument plumbing. The redirect cases below are the ones that need HTTP.
+	return repo
+}
+
+// TestF8GitCloneRefusesRedirect: a clone against a remote that 302s must FAIL,
+// and must not have issued a request to the redirect target.
+func TestF8GitCloneRefusesRedirect(t *testing.T) {
+	f8RequireGit(t)
+	remote, frontHits, internalHits := f8RedirectServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dest := filepath.Join(t.TempDir(), "clone")
+	args := gitCmdArgs("clone", "--depth", "1", "--", remote, dest)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, _ := cmd.CombinedOutput()
+
+	// Guard against the test passing for the wrong reason: the front server must
+	// actually have been reached, or nothing about redirects was exercised.
+	if *frontHits == 0 {
+		t.Fatalf("test never reached the validated remote — no redirect was "+
+			"exercised. output: %s", out)
+	}
+	// THE assertion. Following the redirect means issuing a request to the
+	// internal target; suppressing it means never touching that host.
+	if *internalHits != 0 {
+		t.Errorf("git issued %d request(s) to the redirect target after cloning a "+
+			"validated URL — redirect SSRF is live (F8). output: %s", *internalHits, out)
+	}
+	if _, statErr := os.Stat(filepath.Join(dest, ".git")); statErr == nil {
+		t.Error("clone dir was populated despite the redirect")
+	}
+}
+
+// TestF8GitPullRefusesRedirect: same for the sync path. A repo whose origin is
+// a redirecting remote must not follow it on pull.
+func TestF8GitPullRefusesRedirect(t *testing.T) {
+	f8RequireGit(t)
+	remote, frontHits, internalHits := f8RedirectServer(t)
+
+	// gitSourceEnv sets GIT_ALLOW_PROTOCOL=https unless the private opt-in is on,
+	// and httptest only speaks plain HTTP. Without this the pull fails on the
+	// PROTOCOL filter and never reaches the redirect at all — a green test that
+	// proves nothing. (The *hits assertion below is what surfaced this.) The
+	// opt-in is exactly the configuration in which F8 still bites: an operator
+	// who has allowed private/HTTP sources still must not be redirect-pivoted.
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
+
+	// A local repo pointed at the hostile remote — the state after a source has
+	// been cloned once and is now being refreshed.
+	repo := t.TempDir()
+	//
+	// NOTE the branch/upstream wiring: without it `git pull` fails LOCALLY
+	// ("no tracking information") before it ever opens a socket, and the test
+	// would pass whether or not redirects are suppressed. The *hits assertion
+	// below is what catches that — it caught exactly this while writing the test.
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"remote", "add", "origin", remote},
+		{"config", "branch.main.remote", "origin"},
+		{"config", "branch.main.merge", "refs/heads/main"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup git %v: %v: %s", args, err, out)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// The pull is expected to fail; what matters is WHERE it did not go.
+	_ = gitSourcePull(ctx, repo)
+
+	if *frontHits == 0 {
+		t.Fatal("test never reached the validated remote — no redirect was exercised")
+	}
+	if *internalHits != 0 {
+		t.Errorf("git pull issued %d request(s) to the redirect target — redirect "+
+			"SSRF is live on the sync path (F8)", *internalHits)
+	}
+}
+
+// TestF8GitCloneStillWorksWithoutRedirect is the POSITIVE CONTROL. With redirect
+// suppression on, an ordinary remote must still clone. Without this, a change
+// that simply broke every git invocation would pass both regressions above.
+func TestF8GitCloneStillWorksWithoutRedirect(t *testing.T) {
+	f8RequireGit(t)
+	origin := f8LocalOriginRepo(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dest := filepath.Join(t.TempDir(), "clone")
+	args := gitCmdArgs("clone", "--depth", "1", "--branch", "main", "--", origin, dest)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone of a normal remote must still succeed with redirect "+
+			"suppression on; got %v: %s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "README.md")); err != nil {
+		t.Errorf("cloned repo missing content: %v", err)
+	}
+
+	// And the positive control extends to pull: a fast-forward from the same
+	// non-redirecting origin still works.
+	if err := gitPull(ctx, dest); err != nil {
+		t.Errorf("pull from a normal remote must still succeed; got %v", err)
+	}
+}
+
+// TestF8RedirectArgsArePrefixed pins the ARGUMENT SHAPE. `-c` overrides are only
+// honoured before the subcommand; if a refactor ever appends them after
+// "clone", git treats them as a path and the protection silently evaporates
+// with no test failure anywhere else.
+func TestF8RedirectArgsArePrefixed(t *testing.T) {
+	got := gitCmdArgs("clone", "--depth", "1")
+	want := []string{"-c", "http.followRedirects=false", "clone", "--depth", "1"}
+	if len(got) != len(want) {
+		t.Fatalf("gitCmdArgs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("gitCmdArgs = %v, want %v", got, want)
+		}
+	}
+	// gitCmdArgs must not alias or mutate a shared backing array — two calls
+	// must be independent.
+	a := gitCmdArgs("pull")
+	b := gitCmdArgs("fetch")
+	if a[len(a)-1] != "pull" || b[len(b)-1] != "fetch" {
+		t.Errorf("gitCmdArgs calls interfere: a=%v b=%v", a, b)
+	}
+}

--- a/v2/pkg/knowledge/gitsync.go
+++ b/v2/pkg/knowledge/gitsync.go
@@ -112,7 +112,10 @@ func gitPullWithEnv(ctx context.Context, dir string, env []string) error {
 	pullCtx, cancel := context.WithTimeout(ctx, gitPullTimeoutSeconds*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(pullCtx, "git", "pull", "--ff-only")
+	// AUDIT F8 (residual): `--ff-only` bounds what git will MERGE, not where it
+	// will FETCH FROM. Without redirect suppression the remote can 302 this pull
+	// at an internal address after the URL passed validation. See gitNoRedirectArgs.
+	cmd := exec.CommandContext(pullCtx, "git", gitCmdArgs("pull", "--ff-only")...)
 	cmd.Dir = dir
 	cmd.Env = env
 


### PR DESCRIPTION
Three Medium-severity audit residuals that share a theme: **a check that was correct at the moment it ran, and a later step that stepped around it.**

## F8 (residual) — GitSource redirect SSRF after validation

URL validation and DNS pinning both happen *before* the fetch. git then follows HTTP 3xx **by default**, so a validated, allow-listed remote can answer the very first request with `302 Location: http://169.254.169.254/…` (or any in-cluster Service) and git re-issues the request there — with credentials, and with every check already behind it. Validating a URL is worthless if the fetch is allowed to end up somewhere else.

Both remote-talking invocations now go through `gitCmdArgs`, which prefixes `-c http.followRedirects=false`:

- `v2/pkg/knowledge/gitsource.go` — `git clone --depth 1 --branch …`
- `v2/pkg/knowledge/gitsync.go` — `git pull --ff-only` (`--ff-only` bounds what git will *merge*, not where it will *fetch from*)

Passed as `-c` rather than an env var because there is no `GIT_HTTP_FOLLOW_REDIRECTS` — `http.followRedirects` is config-only — and `-c` on the command line outranks any repo-local config, which is attacker-influenced on a re-used clone dir. `TestF8RedirectArgsArePrefixed` pins the argument *position*, since `-c` after the subcommand is silently treated as a path and the protection would evaporate with no other test failing.

## N17 — symlink-following chmod in the cleanup walk (open across three audits)

`removeTree`'s chmod-and-retry fallback walked an agent-writable workspace calling bare `os.Chmod`, which **follows symlinks**. A link planted there relaxed its **target** to `0660`/`0770` — any path the cleanup user could reach, entirely outside the tree being deleted. That turns "delete a stale workspace" into an arbitrary permission-loosening primitive.

Now `Lstat`'d immediately before the chmod and skipped if it is a link. `WalkDir` does not follow symlinks itself, but `d` can come from a cached `ReadDir` entry and a path can be swapped between the readdir and the chmod, so the `Lstat` is the authoritative check rather than `d.Type()`. Nothing here needs to chmod a link: its own mode is irrelevant to `RemoveAll` (which unlinks it) and its target is by definition outside the tree.

## F17 — OIDC subject case-folding permitted cross-account confusion

`canonicalEqual` was a flat `strings.EqualFold` over the whole canonical id, justified in-comment by *"two subs that differ only by case are not issued"*. True for GitHub. **Not guaranteed for any OIDC provider** — `sub` is defined as a case-**sensitive** opaque string, and a base64/base64url sub (Entra, Okta, Keycloak all emit these) differs by case routinely. Under the fold, an operator-run IdP that issues or lets a user self-register `custom:AbC` handed that user everything owned by `custom:abc`.

The comparison is now provider-aware:

- **provider label** still folds — a fixed keyword from a closed set; `GitHub:` vs `github:` is wire noise
- **github subject** still folds — GitHub logins genuinely are case-insensitive, and the legacy bare-login shim depends on it (`ClubAnderson` must match `github:clubanderson`)
- **every other provider's subject compares exactly**

Strictly the safe direction: it can only refuse matches the old code accepted, and the only matches it refuses were never the same principal. Unparseable/unknown-provider ids compare exactly rather than folding.

## Testing

Each fix has a regression test **and** a positive control, and each was regression-replayed (neuter so it still compiles → confirm the specific test fails → restore → confirm green). `pkg/hub`, `pkg/dashboard`, `pkg/knowledge` all green on fresh `v4`.

| Finding | Regression | Positive control |
|---|---|---|
| F8 | `TestF8GitCloneRefusesRedirect`, `TestF8GitPullRefusesRedirect`, `TestF8RedirectArgsArePrefixed` | `TestF8GitCloneStillWorksWithoutRedirect` — a normal remote must still clone *and* pull, so "break all git" cannot pass |
| N17 | `TestN17ChmodWalkDoesNotFollowSymlinks` | `TestN17ChmodWalkStillRelaxesRealFiles` — a read-only tree must still be removed, so "skip everything" cannot pass |
| F17 | `TestF17OIDCSubjectsCompareExactly` (all 5 non-GitHub providers), `TestF17EmptyAndMalformedIdentities` | `TestF17GitHubLoginsStillFold`, `TestF17OIDCProviderLabelStillFolds` — the legacy shim must keep working, so "make everything case-sensitive" cannot pass |

### Three replays initially passed *while neutered* — worth reading

The tests were rebuilt until they genuinely failed. Each reason is documented in the test file, because each is a trap the next person will otherwise re-lay:

1. **F8** — the obvious test redirects at `169.254.169.254` and asserts the clone fails. That passes **with or without the fix**: link-local is simply unroutable, so the clone fails either way and the test proves nothing. The internal target is now a **reachable** local server that counts requests, and the assertion is *"was it contacted"*, not *"did the clone fail"*.
2. **N17** — `os.RemoveAll` is destructive **even when it fails**: it unlinks everything it can reach before hitting the unremovable child. A symlink at the top of the workspace was already gone before the walk ran. Links are now planted *inside* the locked directory, which survives step 1.
3. **N17** — the premise check ("does plain `RemoveAll` really fail here?") called `RemoveAll` on the tree under test and destroyed it. It now runs on a throwaway copy.

No existing test asserted any of the vulnerable behaviours, so **none were relaxed or inverted** in this PR.

`go build ./...` + targeted `go test`. No kubectl, no cluster changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)