### PR TITLE
fix(automerge): learn required status checks from config, not admin API

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1368,6 +1368,18 @@ func main() {
 		// trust; read through cfg on every call so a config reload takes effect.
 		ghClient.SetMergerAuthorizer(trustedMergerFunc(cfg))
 
+		// commitGreen's required-checks gate (self-merge sweep, see
+		// automerge_sweep.go): install the operator-declared
+		// auto_merge.required_checks list, if any, so gating does not depend
+		// on GitHub's branch-protection API — the Hive App token lacks
+		// administration:read, so that API call reliably errors and would
+		// otherwise fail closed to the coarser isMetaCheck/isIgnorableCICheck
+		// allowlist. Unset/empty leaves the API/allowlist fallback chain
+		// intact (SetRequiredChecks(nil) is a safe no-op).
+		if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
+			ghClient.SetRequiredChecks(set)
+		}
+
 		// Self-authored auto-merge: the App merges its OWN open, CI-green PRs
 		// directly over the REST API, without a human "Approved ... for Hive
 		// auto-merge" queue review and without waiting on tide. Prow forbids
@@ -2207,6 +2219,9 @@ func main() {
 				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 			}
+			if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
+				newClient.SetRequiredChecks(set)
+			}
 
 			ghClient = newClient
 			appAuth = newAppAuth
@@ -2607,6 +2622,9 @@ func main() {
 					if len(cfg.Governor.Labels.Exempt) > 0 {
 						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 						newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
+					}
+					if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
+						newClient.SetRequiredChecks(set)
 					}
 					ghClient = newClient
 					appAuth = newAppAuth
@@ -3714,6 +3732,9 @@ func main() {
 				if len(cfg.Governor.Labels.Exempt) > 0 {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 					newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
+				}
+				if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
+					newClient.SetRequiredChecks(set)
 				}
 				ghClient = newClient
 				appAuth = newAppAuth

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -4585,6 +4585,51 @@ type AutoMergeConfig struct {
 	// AutoMergeSweepOptions.MaxMerges for the human queue sweep. Zero means
 	// DefaultAutoMergeSweepMaxMerges.
 	MaxMerges int `yaml:"max_merges,omitempty" json:"max_merges,omitempty"`
+	// RequiredChecks is the operator-declared list of status-check
+	// contexts/check-run names that the self-merge sweep's commitGreen must
+	// gate on, e.g. ["build-gate"]. This is the scope-free alternative to
+	// asking GitHub's branch-protection API (Repositories.GetRequiredStatusChecks)
+	// which one, and only one, of these checks are actually required: that
+	// API needs administration:read, a scope the Hive GitHub App does not
+	// hold, so the call errors and the sweep used to fail closed to the old
+	// isMetaCheck/isIgnorableCICheck allowlist — which still blocked on
+	// non-required checks like "Detect untested files" (cancelled) or
+	// "Analyze (python)" (CodeQL failure). Declaring the branch's actual
+	// required set here removes the dependency on that scope entirely.
+	//
+	// Unset/empty means "not config-declared" (RequiredCheckSet returns
+	// requiredKnown=false) — callers then fall back to the branch-protection
+	// API, and if that also cannot determine the set, to the allowlist. There
+	// is deliberately no hardcoded default here: the required-checks set is
+	// per-repo (e.g. console's main branch requires only "build-gate"), so
+	// the operator must declare it per-hive in `auto_merge.required_checks`.
+	RequiredChecks []string `yaml:"required_checks,omitempty" json:"required_checks,omitempty"`
+}
+
+// RequiredCheckSet returns the config-declared required-status-check set as a
+// membership map, and whether the config actually declared one. An
+// empty/unset RequiredChecks list returns (nil, false) — "not config-declared"
+// — so callers can distinguish that from a genuinely empty required set (e.g.
+// an unprotected branch) and fall through to their next source (the
+// branch-protection API, then the allowlist fallback). A non-empty list
+// always returns requiredKnown=true; entries are matched by exact string
+// equality against status-context / check-run names.
+func (a AutoMergeConfig) RequiredCheckSet() (map[string]bool, bool) {
+	if len(a.RequiredChecks) == 0 {
+		return nil, false
+	}
+	set := make(map[string]bool, len(a.RequiredChecks))
+	for _, name := range a.RequiredChecks {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		set[name] = true
+	}
+	if len(set) == 0 {
+		return nil, false
+	}
+	return set, true
 }
 
 // SelfAuthoredEnabled reports whether the App-self-merge sweep is on for this

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -1174,3 +1174,41 @@ func TestSelfAuthoredAutoMergeAllowed(t *testing.T) {
 		})
 	}
 }
+
+func TestAutoMergeConfigRequiredCheckSet(t *testing.T) {
+	cases := []struct {
+		name     string
+		checks   []string
+		wantSet  map[string]bool
+		wantKnow bool
+	}{
+		{"unset returns not-declared", nil, nil, false},
+		{"empty slice returns not-declared", []string{}, nil, false},
+		{"all-blank entries return not-declared", []string{"  ", ""}, nil, false},
+		{"single entry", []string{"build-gate"}, map[string]bool{"build-gate": true}, true},
+		{"multiple entries, whitespace trimmed", []string{" build-gate ", "lint"}, map[string]bool{"build-gate": true, "lint": true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := AutoMergeConfig{RequiredChecks: tc.checks}
+			got, know := cfg.RequiredCheckSet()
+			if know != tc.wantKnow {
+				t.Fatalf("RequiredCheckSet() requiredKnown = %v, want %v", know, tc.wantKnow)
+			}
+			if !know {
+				if got != nil {
+					t.Fatalf("RequiredCheckSet() set = %v, want nil when not declared", got)
+				}
+				return
+			}
+			if len(got) != len(tc.wantSet) {
+				t.Fatalf("RequiredCheckSet() set = %v, want %v", got, tc.wantSet)
+			}
+			for k, v := range tc.wantSet {
+				if got[k] != v {
+					t.Errorf("RequiredCheckSet()[%q] = %v, want %v", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -70,6 +70,37 @@ func (c *Client) SetMergerAuthorizer(fn MergerAuthorizer) {
 	c.mergerAuthz = fn
 }
 
+// SetRequiredChecks installs the config-declared required-status-check set
+// (config.AutoMergeConfig.RequiredCheckSet) consulted by commitGreen before
+// it ever calls GitHub's branch-protection API. nil/empty clears it, meaning
+// "not config-declared" — commitGreen then falls back to the API and, if that
+// also fails, to the isMetaCheck/isIgnorableCICheck allowlist. Safe to call
+// repeatedly (e.g. on every config reload); the sweep goroutine reads the
+// installed value through requiredChecksMu.
+func (c *Client) SetRequiredChecks(set map[string]bool) {
+	if c == nil {
+		return
+	}
+	c.requiredChecksMu.Lock()
+	defer c.requiredChecksMu.Unlock()
+	c.requiredChecks = set
+}
+
+// configRequiredChecks returns the currently installed config-declared
+// required-check set and whether one is installed. Mirrors isTrustedMerger's
+// nil-safe read pattern for c.mergerAuthz.
+func (c *Client) configRequiredChecks() (map[string]bool, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.requiredChecksMu.RLock()
+	defer c.requiredChecksMu.RUnlock()
+	if len(c.requiredChecks) == 0 {
+		return nil, false
+	}
+	return c.requiredChecks, true
+}
+
 // isTrustedMerger reports whether login may queue a merge. Fails CLOSED.
 func (c *Client) isTrustedMerger(login string) (allowed, configured bool) {
 	if c == nil {
@@ -624,15 +655,15 @@ func parseHiveQueueReview(body string) string {
 // commitGreen reports whether the head SHA is mergeable from a CI
 // standpoint.
 //
-// Gating is REQUIRED-CHECKS-ONLY: commitGreen first asks GitHub which status
-// contexts/check-run names are actually required by the target branch's
-// branch protection (requiredStatusCheckContexts). Any status or check-run
-// whose context/name is NOT in that required set is skipped entirely,
-// regardless of its state or conclusion — pending, failing, or cancelled
-// non-required checks can never block self-merge. A required check still
-// fully gates: pending blocks (return not-green, "pending" — the sweep must
-// never squash a PR before its required CI has finished), and a
-// failure/error/cancelled conclusion on a required check blocks too.
+// Gating is REQUIRED-CHECKS-ONLY: commitGreen first asks which status
+// contexts/check-run names are actually required for the target branch
+// (requiredStatusCheckContexts). Any status or check-run whose context/name
+// is NOT in that required set is skipped entirely, regardless of its state or
+// conclusion — pending, failing, or cancelled non-required checks can never
+// block self-merge. A required check still fully gates: pending blocks
+// (return not-green, "pending" — the sweep must never squash a PR before its
+// required CI has finished), and a failure/error/cancelled conclusion on a
+// required check blocks too.
 //
 // Why required-only, not a hardcoded ignore-list: the previous approach
 // (isMetaCheck/isIgnorableCICheck as an ALLOWLIST of names to ignore) is
@@ -645,13 +676,21 @@ func parseHiveQueueReview(body string) string {
 // must be green; anything else is by definition non-required and must never
 // wedge the queue.
 //
-// Fail-closed fallback: if the required-checks set cannot be determined
-// (branch protection absent/erroring, no branch known, or the API call
-// fails) this deliberately does NOT fall back to "ignore everything" — that
-// would merge over a genuinely broken build the moment GitHub's protection
-// API hiccups. Instead it falls back to the OLD isMetaCheck/isIgnorableCICheck
-// allowlist behavior, so an outage of the branch-protection endpoint degrades
-// gating back to the previously-shipped conservative behavior rather than to
+// Where that required set comes from (see requiredStatusCheckContexts for
+// the full precedence): config (auto_merge.required_checks) FIRST — the Hive
+// App token lacks administration:read, so GitHub's branch-protection API
+// (Repositories.GetRequiredStatusChecks, #3723) reliably errors in practice;
+// the operator-declared config list needs no such scope. The API is tried
+// only as a secondary source (in case the App ever does have that scope, or
+// the branch is legitimately unprotected).
+//
+// Fail-closed fallback: if the required-checks set cannot be determined by
+// EITHER config or the API (no config list, branch protection absent/erroring,
+// no branch known, or the API call fails) this deliberately does NOT fall
+// back to "ignore everything" — that would merge over a genuinely broken
+// build the moment both sources are unavailable. Instead it falls back to the
+// OLD isMetaCheck/isIgnorableCICheck allowlist behavior, so the previously-
+// shipped conservative behavior is preserved rather than degrading to
 // "always green".
 func (c *Client) commitGreen(ctx context.Context, owner, repo, branch, sha string) (bool, string, error) {
 	required, requiredKnown := c.requiredStatusCheckContexts(ctx, owner, repo, branch)
@@ -729,24 +768,32 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, branch, sha strin
 }
 
 // requiredStatusCheckContexts returns the set of status-check contexts /
-// check-run names that branch protection actually requires on branch, and
-// whether that set could be determined at all. It is the single source of
-// truth commitGreen gates on: membership in this set is what makes a check
+// check-run names that are actually required for branch, and whether that
+// set could be determined at all. It is the single source of truth
+// commitGreen gates on: membership in this set is what makes a check
 // "required" (must be green) versus ignorable (any state/conclusion, never
 // blocks).
 //
-// requiredKnown is false (empty set, ignore it) when:
-//   - branch is empty (caller could not resolve the PR's base branch), or
-//   - the repo/branch has no branch protection configured
-//     (gh.ErrBranchNotProtected — a repo with zero required checks is a
-//     valid, common state, NOT an error), or
-//   - the GitHub API call itself failed (rate limit, transient 5xx, ...).
-//
-// In all of those cases the caller must fall back to the OLD
-// isMetaCheck/isIgnorableCICheck allowlist rather than treating "we don't
-// know the required set" as "nothing is required" — see commitGreen's
-// fail-closed comment.
+// Precedence (first available source wins):
+//  1. Config: c.configRequiredChecks(), i.e. the operator-declared
+//     auto_merge.required_checks list (config.AutoMergeConfig.RequiredCheckSet).
+//     This needs NO GitHub API call and NO administration:read scope, so it
+//     is checked first and is the primary path in practice — the Hive App's
+//     token does not hold that scope, so path 2 below reliably errors.
+//  2. GitHub's branch-protection API (Repositories.GetRequiredStatusChecks).
+//     Kept as a fallback in case the App ever does have admin-read scope, or
+//     the branch is legitimately unprotected (gh.ErrBranchNotProtected — a
+//     repo with zero required checks is a valid, common state, NOT an
+//     error, so that case returns requiredKnown=true with an empty set).
+//  3. Neither available (no config list AND branch empty / API call failed
+//     for a reason other than "not protected") → requiredKnown=false. The
+//     caller must fall back to the OLD isMetaCheck/isIgnorableCICheck
+//     allowlist rather than treating "we don't know the required set" as
+//     "nothing is required" — see commitGreen's fail-closed comment.
 func (c *Client) requiredStatusCheckContexts(ctx context.Context, owner, repo, branch string) (map[string]bool, bool) {
+	if set, ok := c.configRequiredChecks(); ok {
+		return set, true
+	}
 	if strings.TrimSpace(branch) == "" {
 		return nil, false
 	}

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -849,6 +849,134 @@ func TestCommitGreenRequiredChecksUnavailableFallsBack(t *testing.T) {
 	}
 }
 
+// TestCommitGreenConfigRequiredChecksTakesPrecedence locks in that a
+// config-declared required-checks set (SetRequiredChecks, mirroring
+// config.AutoMergeConfig.RequiredCheckSet) is consulted BEFORE the
+// branch-protection API — the primary path now that the Hive App token
+// lacks administration:read. The mock server's protection endpoint is left
+// unregistered (any request to it fails the test) to prove commitGreen never
+// even calls it when a config set is installed.
+func TestCommitGreenConfigRequiredChecksTakesPrecedence(t *testing.T) {
+	tests := []struct {
+		name           string
+		requiredChecks map[string]bool
+		checks         []struct{ name, status, conclusion string }
+		wantGreen      bool
+		wantReason     string
+	}{
+		{
+			name:           "build-gate success + non-required cancelled check is green",
+			requiredChecks: map[string]bool{"build-gate": true},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Detect untested files", "completed", "cancelled"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:           "build-gate failure blocks even though it's the only required check",
+			requiredChecks: map[string]bool{"build-gate": true},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "failure"},
+			},
+			wantReason: "check-failure",
+		},
+		{
+			name:           "non-required CodeQL failure never blocks",
+			requiredChecks: map[string]bool{"build-gate": true},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Analyze (python)", "completed", "failure"},
+			},
+			wantGreen: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/branches/main/protection/required_status_checks":
+					t.Fatalf("commitGreen must not call the branch-protection API when a config required-checks set is installed")
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 0})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+					runs := []map[string]string{}
+					for _, c := range tt.checks {
+						runs = append(runs, map[string]string{"name": c.name, "status": c.status, "conclusion": c.conclusion})
+					}
+					json.NewEncoder(w).Encode(map[string]any{"total_count": len(runs), "check_runs": runs})
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := newAutoMergeSweepClient(api.URL)
+			c.SetRequiredChecks(tt.requiredChecks)
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "main", "sha")
+			if err != nil {
+				t.Fatalf("commitGreen returned error: %v", err)
+			}
+			if green != tt.wantGreen || reason != tt.wantReason {
+				t.Fatalf("commitGreen = (%v,%q), want (%v,%q)", green, reason, tt.wantGreen, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestCommitGreenNoConfigRequiredChecksFallsBackToAPIThenAllowlist confirms
+// the full precedence chain when no config set is installed
+// (SetRequiredChecks never called / installed with an empty map): commitGreen
+// falls through to the branch-protection API exactly as before #this-change,
+// and if that is also unavailable, to the isMetaCheck/isIgnorableCICheck
+// allowlist.
+func TestCommitGreenNoConfigRequiredChecksFallsBackToAPIThenAllowlist(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/branches/main/protection/required_status_checks":
+			w.WriteHeader(http.StatusInternalServerError)
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+			json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 0})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+			json.NewEncoder(w).Encode(map[string]any{"total_count": 2, "check_runs": []map[string]string{
+				{"name": "build-gate", "status": "completed", "conclusion": "success"},
+				{"name": "Playwright", "status": "completed", "conclusion": "cancelled"},
+			}})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer api.Close()
+	c := newAutoMergeSweepClient(api.URL)
+	// Deliberately do NOT call SetRequiredChecks: config did not declare a
+	// list, so this must fall through to the API (which errors here) and
+	// then to the allowlist fallback (Playwright is on it, so this stays
+	// green).
+	green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "main", "sha")
+	if err != nil {
+		t.Fatalf("commitGreen returned error: %v", err)
+	}
+	if !green || reason != "" {
+		t.Fatalf("commitGreen = (%v,%q), want (true,\"\")", green, reason)
+	}
+}
+
+func TestSetRequiredChecksEmptyMapIsNotDeclared(t *testing.T) {
+	c := newAutoMergeSweepClient("http://unused.invalid")
+	c.SetRequiredChecks(map[string]bool{})
+	if set, ok := c.configRequiredChecks(); ok || set != nil {
+		t.Fatalf("configRequiredChecks() after SetRequiredChecks(empty) = (%v,%v), want (nil,false)", set, ok)
+	}
+	c.SetRequiredChecks(map[string]bool{"build-gate": true})
+	if set, ok := c.configRequiredChecks(); !ok || !set["build-gate"] {
+		t.Fatalf("configRequiredChecks() after SetRequiredChecks(build-gate) = (%v,%v), want ({build-gate:true},true)", set, ok)
+	}
+	c.SetRequiredChecks(nil)
+	if set, ok := c.configRequiredChecks(); ok || set != nil {
+		t.Fatalf("configRequiredChecks() after SetRequiredChecks(nil) = (%v,%v), want (nil,false)", set, ok)
+	}
+}
+
 func TestListQueuedPullRequestIssuesPaginates(t *testing.T) {
 	var base string
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -69,6 +69,17 @@ type Client struct {
 	// Set by SetMergerAuthorizer.
 	mergerAuthzMu sync.RWMutex
 	mergerAuthz   MergerAuthorizer
+	// requiredChecks is the operator-declared config.AutoMergeConfig.RequiredChecks
+	// set (see config.AutoMergeConfig.RequiredCheckSet), consulted by
+	// commitGreen/requiredStatusCheckContexts BEFORE the branch-protection
+	// API — the Hive App token lacks administration:read, so that API call
+	// always errors, and this config-declared set is the scope-free source
+	// of truth for which status checks actually gate self-merge. nil means
+	// "not config-declared", so callers fall through to the API, then the
+	// allowlist. Guarded because config reload re-installs it while the
+	// sweep goroutine reads it. Set by SetRequiredChecks.
+	requiredChecksMu sync.RWMutex
+	requiredChecks   map[string]bool
 	// mergeReEngage is Fix #2's re-engagement hook. When a merge attempt fails
 	// terminally BECAUSE a required check failed (not a true conflict or a
 	// permission error), the watcher calls this instead of silently abandoning


### PR DESCRIPTION
## Problem

#3723 changed `commitGreen` to gate the self-merge sweep only on the target branch's actual required status checks, fetched via `Repositories.GetRequiredStatusChecks` in `requiredStatusCheckContexts`. That API needs `administration:read` on the branch-protection endpoint — a scope the Hive GitHub App does not hold — so the call reliably errors in practice. When it errors, `requiredStatusCheckContexts` returns `requiredKnown=false` and `commitGreen` falls back to the old `isMetaCheck`/`isIgnorableCICheck` allowlist, which still blocks PRs on non-required checks that aren't on that allowlist — e.g. console #22471 stuck on `Detect untested files` (cancelled) and #22450 stuck on `Analyze (python)` (CodeQL failure), even though the only real required check (`build-gate`) is green.

## Fix

Add a config-declared alternative that needs no GitHub API call and no admin scope:

- `AutoMergeConfig.RequiredChecks []string` (`auto_merge.required_checks` in hive.yaml) — the operator declares the branch's actual required check names, e.g. `["build-gate"]`.
- `AutoMergeConfig.RequiredCheckSet()` returns `(set, true)` when the list is non-empty, `(nil, false)` when unset/empty, so callers can distinguish "not config-declared" from a genuinely empty set.
- `Client.SetRequiredChecks` / `Client.configRequiredChecks` install and read the config-declared set on the `Client`, mirroring the existing `mergerAuthz` mutex-guarded-field pattern.
- `requiredStatusCheckContexts` now checks three sources in order:
  1. **Config** (`Client.configRequiredChecks()`) — primary path, no API call, no admin scope needed.
  2. **Branch-protection API** (`GetRequiredStatusChecks`) — kept as a fallback for hives where the App does have that scope, or for legitimately unprotected branches.
  3. **Neither available** → `requiredKnown=false` → the old `isMetaCheck`/`isIgnorableCICheck` allowlist, unchanged.

No default required-checks list is hardcoded; the field comment documents `[build-gate]` purely as an example. `SetRequiredChecks` is reinstalled at every GitHub-client reinit site (config reload, App-identity rebuild) alongside the existing `SetExemptLabels`/`SetAutoMergeLabel` calls so it isn't silently dropped.

Operators set `auto_merge.required_checks: [build-gate]` per hive to opt in.

## Tests

- `config_test.go`: `RequiredCheckSet` declared/not-declared cases (nil, empty slice, blank entries, single/multiple entries).
- `automerge_sweep_test.go`: config-required-checks taking precedence over the branch-protection API (asserts the API is never even called once a config set is installed), the full fallback chain when no config set is installed, and `SetRequiredChecks` empty-map/nil semantics.

Not built or tested locally — CI validates.