### PR TITLE
🔒 sync: merge v4 into dd (security top-up incl. F2 heartbeat self-derivation)

### DIFF
--- a/bin/ttyd-tmux.sh
+++ b/bin/ttyd-tmux.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
-# Wrapper for ttyd → tmux that disables mouse mode so the browser
-# handles text selection and clipboard (Cmd+C / Cmd+V).
-# Mouse mode is restored when the ttyd session disconnects.
+# Wrapper for ttyd → tmux. Enables mouse mode on attach so the browser scroll
+# wheel drives tmux copy-mode scrollback (issue #3694) and raises the pane
+# history-limit so there is meaningful scrollback to reach; both are restored
+# on disconnect. Hold Shift (or Option on macOS) to bypass mouse mode for native
+# browser text selection / clipboard.
+#
+# NOTE: The container uses v2/deploy/ttyd-tmux.sh (copied to
+# /usr/local/bin/ttyd-tmux.sh by v2/Dockerfile), which additionally resolves
+# per-agent tmux sockets across UIDs via su-exec. This copy is a simpler
+# standalone helper kept in sync for local/non-UID-isolated use.
 set -euo pipefail
 
 SESSION=${1:-supervisor}
+TTYD_HISTORY_LIMIT="${HIVE_TTYD_HISTORY_LIMIT:-50000}"
 PREV_MOUSE=$(tmux show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-tmux set-option -t "$SESSION" mouse off 2>/dev/null || true
+PREV_HISTORY=$(tmux show-option -t "$SESSION" -gv history-limit 2>/dev/null || echo "")
+tmux set-option -t "$SESSION" mouse on 2>/dev/null || true
+tmux set-option -t "$SESSION" history-limit "$TTYD_HISTORY_LIMIT" 2>/dev/null || true
 EXIT_CODE=0
 tmux attach-session -t "$SESSION" || EXIT_CODE=$?
 tmux set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
+if [ -n "$PREV_HISTORY" ]; then
+  tmux set-option -t "$SESSION" history-limit "$PREV_HISTORY" 2>/dev/null || true
+fi
 exit $EXIT_CODE

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4946,6 +4946,50 @@ func runEvalCycle(
 			if parts := strings.SplitN(primaryRepo, "/", 2); len(parts) == 2 {
 				org, repoName = parts[0], parts[1]
 			}
+
+			// #3704: pin the digest to ONE repo commit. Resolve the target repo's
+			// latest commit ONCE here (invariants 1 & 3), cite it in the rendered
+			// comment (invariant 2, via the footer FormatDigestMarkdown emits when
+			// AnalyzedSnapshot is set), and verify each finding's file path against
+			// that exact commit so a since-removed path (e.g. "docs/install.md") is
+			// flagged as outdated rather than cited as live. Best-effort: if the SHA
+			// cannot be resolved, fall back to the previous unpinned behavior rather
+			// than skip the digest.
+			if ghClient != nil && org != "" && repoName != "" {
+				branch := cfg.Policies.Branch
+				if branch == "" {
+					if r, _, rerr := ghClient.GetRepo(ctx, org, repoName); rerr == nil {
+						branch = r.GetDefaultBranch()
+					} else {
+						logger.Warn("advisory: could not resolve default branch for snapshot", "repo", primaryRepo, "error", rerr)
+					}
+				}
+				if branch != "" {
+					if sha, serr := ghClient.LatestCommitHash(ctx, org, repoName, branch); serr == nil && sha != "" {
+						digest.AnalyzedSnapshot = &advisory.Snapshot{
+							Owner:  org,
+							Repo:   repoName,
+							Branch: branch,
+							SHA:    sha,
+						}
+						advisory.VerifyFindingPaths(digest, func(path string) bool {
+							exists, verr := ghClient.PathExistsAtRef(ctx, org, repoName, path, sha)
+							if verr != nil {
+								// Inconclusive check (network/rate-limit, not a 404):
+								// treat as existing so a transient error never
+								// mislabels a real path as outdated.
+								logger.Warn("advisory: path existence check failed", "path", path, "repo", primaryRepo, "sha", sha, "error", verr)
+								return true
+							}
+							return exists
+						})
+						logger.Info("advisory digest pinned to commit", "repo", primaryRepo, "branch", branch, "sha", sha)
+					} else if serr != nil {
+						logger.Warn("advisory: could not resolve latest commit for snapshot", "repo", primaryRepo, "branch", branch, "error", serr)
+					}
+				}
+			}
+
 			md := advisory.FormatDigestMarkdown(digest, org, repoName)
 			if md != "" {
 				if issueNum, ok := advisoryIssues[primaryRepo]; ok && issueNum > 0 {

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1359,6 +1359,15 @@ func main() {
 		ghClient.SetMergeReEngageHook(mergeReEngageHook(cfg))
 		ghClient.StartMergeRequestWatcher(ctx, bindMergeAuthz(agentMgr.AuthorizeMerge), nil)
 
+		// SECURITY (audit F3): re-verify the merger tier inside the sweep. The
+		// dashboard's queue endpoint gates on requireMergerOrOwnerRole, but the
+		// sweep merges a minute later off the label + App-authored approval body
+		// alone, so without this ANY actor who can get the label applied merges
+		// anything, and a sockpuppet pair defeats the self-merge ban. Resolved
+		// against the SAME allowlist the dashboard uses so there is one notion of
+		// trust; read through cfg on every call so a config reload takes effect.
+		ghClient.SetMergerAuthorizer(trustedMergerFunc(cfg))
+
 		// Self-authored auto-merge: the App merges its OWN open, CI-green PRs
 		// directly over the REST API, without a human "Approved ... for Hive
 		// auto-merge" queue review and without waiting on tide. Prow forbids
@@ -5753,11 +5762,34 @@ func runEscalationSweep(
 // hammering the GitHub API on short eval intervals.
 const autoMergeSweepInterval = time.Minute
 
+// trustedMergerFunc resolves a GitHub login against the hive's authorized-users
+// allowlist and reports whether it holds at least config.RoleMerger — the same
+// bar requireMergerOrOwnerRole enforces on the dashboard queue endpoint (audit
+// F3).
+//
+// Fails CLOSED: a nil config or a login absent from the allowlist is NOT
+// trusted, so an unclassifiable actor can never merge. cfg is read on every
+// call so a config reload that grants or revokes the merger tier takes effect
+// without a restart.
+func trustedMergerFunc(cfg *config.Config) github.MergerAuthorizer {
+	return func(login string) bool {
+		if cfg == nil || strings.TrimSpace(login) == "" {
+			return false
+		}
+		role, ok := cfg.Dashboard.AuthorizedRole(login)
+		if !ok {
+			return false
+		}
+		return config.RoleAtLeast(role, config.RoleMerger)
+	}
+}
+
 // runAutoMergeSweepIfDue drains the label-queued auto-merge queue (the human
 // "Approved ... for Hive auto-merge" path) at most once per
 // autoMergeSweepInterval. All merge-eligibility decisions — queue-approval
-// trust, check verification, tier gates — live inside SweepQueuedAutoMerges;
-// this function is only the scheduler and the dashboard audit sink.
+// trust, the trusted-merger tier gate (SetMergerAuthorizer), check
+// verification — live inside SweepQueuedAutoMerges; this function is only the
+// scheduler and the dashboard audit sink.
 func runAutoMergeSweepIfDue(ctx context.Context, ghClient *github.Client, dashSrv *dashboard.Server, lastRun *time.Time, logger *slog.Logger) {
 	if ghClient == nil {
 		return

--- a/v2/deploy/README.md
+++ b/v2/deploy/README.md
@@ -6,7 +6,7 @@ This directory contains Kubernetes/LXC manifests plus runtime helper scripts use
 
 ### `ttyd-tmux.sh`
 
-`ttyd` serves the browser terminal websocket, but agent tmux sessions may be owned by per-agent UIDs. Because tmux only lets the socket owner attach, `ttyd-tmux.sh <session>` finds the matching `/tmp/tmux-*/<session>` socket, derives its numeric UID/GID, and uses `su-exec` to attach as that owner. It temporarily disables tmux mouse mode while attached and restores it on exit.
+`ttyd` serves the browser terminal websocket, but agent tmux sessions may be owned by per-agent UIDs. Because tmux only lets the socket owner attach, `ttyd-tmux.sh <session>` finds the matching `/tmp/tmux-*/<session>` socket, derives its numeric UID/GID, and uses `su-exec` to attach as that owner. While attached it enables tmux mouse mode (so the scroll wheel drives copy-mode scrollback instead of just reflowing the viewport — issue #3694) and raises the pane `history-limit` (default `50000`, override with `HIVE_TTYD_HISTORY_LIMIT`) so there is meaningful scrollback to reach. Both options are restored to their previous values on detach.
 
 Use it indirectly through the dashboard terminal link. If a terminal pane says no tmux socket was found, check that the agent session name exists and that the socket is present under `/tmp/tmux-*` in the container.
 

--- a/v2/deploy/k8s/backup-cronjob.yaml
+++ b/v2/deploy/k8s/backup-cronjob.yaml
@@ -15,9 +15,48 @@ metadata:
   name: hive-hub-backup
   namespace: hive-hub
 ---
-# The backup reads Secrets in its own namespace and execs into spoke pods on
-# this cluster. Read-only apart from pod/exec, which is required to read
-# per-spoke PVC state the hub cannot mount.
+# Least-privilege RBAC (see #3708). The backup reads Secrets ONLY in its own
+# namespace (hive-hub) and execs into spoke pods that live in per-spoke
+# namespaces across the cluster.
+#
+# Secrets access is intentionally NOT cluster-wide: it is granted through a
+# namespaced Role + RoleBinding scoped to hive-hub, so a compromised backup pod
+# cannot enumerate or read Secrets in any other namespace.
+#
+# pods, pods/exec, and namespaces remain in a ClusterRole because spoke pods
+# live in arbitrary per-spoke namespaces (e.g. vllm-d) that cannot be
+# enumerated ahead of time, and `namespaces` is itself a cluster-scoped
+# resource. This ClusterRole no longer grants any secrets access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hive-hub-backup
+  namespace: hive-hub
+rules:
+  # Read the four out-of-PVC Secrets that live in hive-hub (backup key is
+  # injected via env; these are the Secrets the backup archives directly).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-hub-backup
+  namespace: hive-hub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hive-hub-backup
+subjects:
+  - kind: ServiceAccount
+    name: hive-hub-backup
+    namespace: hive-hub
+---
+# Minimal ClusterRole: only what genuinely must reach across namespaces.
+# Spoke pods live in per-spoke namespaces, so listing pods and creating
+# pod/exec sessions requires cluster scope, as does listing namespaces to
+# discover spokes. No secrets access here (moved to the namespaced Role above).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -29,9 +68,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list"]
@@ -74,7 +110,11 @@ spec:
           restartPolicy: Never
           containers:
             - name: backup
-              image: ghcr.io/kubestellar/hive:v2-latest
+              # Digest-pinned (see #3709) so a mutable-tag poisoning attack on
+              # v4-latest cannot silently deliver a hostile backup container.
+              # Recompute the digest deliberately at each release, matching the
+              # Watchtower pinning pattern.
+              image: ghcr.io/kubestellar/hive:v4-latest@sha256:e3f9ee8fd3852499f732414cd9b85d9278103e3e8ac7fb8629cf14488b90ec23
               command: ["/usr/local/bin/hive-backup", "run"]
               env:
                 # AES-256 key for the archive. MUST be escrowed outside the

--- a/v2/deploy/ttyd-tmux.sh
+++ b/v2/deploy/ttyd-tmux.sh
@@ -37,18 +37,42 @@ SOCK_OWNER_GID=$(stat -c '%g' "$TMUX_SOCKET" 2>/dev/null || echo "")
 SOCK_OWNER_SPEC="${SOCK_OWNER_UID}:${SOCK_OWNER_GID}"
 CURRENT_UID=$(id -u)
 
+# Scroll-wheel history (issue #3694). The browser terminal is a live tmux
+# attach, so the only real scrollback is tmux's copy-mode — which the wheel can
+# only enter when `mouse on`. Earlier versions of this script set `mouse off`
+# on attach, which left wheel events untranslated: scrolling up did not page
+# back through history, it merely reflowed a few lines at the bottom of the
+# viewport (the reported symptom). Enable mouse mode instead so the wheel drives
+# copy-mode and scrolls back through the pane's history normally, and give the
+# pane a generous history-limit so there is meaningful scrollback to reach.
+# Both are per-session options restored to their previous values on detach so
+# an agent CLI that manages mouse mode itself is not permanently altered.
+#
+# HIVE_TTYD_HISTORY_LIMIT overrides the scrollback depth applied on attach.
+TTYD_HISTORY_LIMIT="${HIVE_TTYD_HISTORY_LIMIT:-50000}"
+
+# attach_with runs the attach lifecycle. $1 is an optional command prefix
+# (e.g. "su-exec <spec>") so the same logic serves both the owner and non-owner
+# paths without duplication.
+attach_with() {
+  local run=("$@")
+  local prev_mouse prev_history exit_code=0
+  prev_mouse=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
+  prev_history=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -gv history-limit 2>/dev/null || echo "")
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse on 2>/dev/null || true
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" history-limit "$TTYD_HISTORY_LIMIT" 2>/dev/null || true
+  "${run[@]}" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || exit_code=$?
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$prev_mouse" 2>/dev/null || true
+  if [ -n "$prev_history" ]; then
+    "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" history-limit "$prev_history" 2>/dev/null || true
+  fi
+  return "$exit_code"
+}
+
 if [ -n "$SOCK_OWNER_UID" ] && [ "$SOCK_OWNER_UID" != "$CURRENT_UID" ] && command -v su-exec >/dev/null 2>&1; then
-  PREV_MOUSE=$(su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
-  EXIT_CODE=0
-  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
-  su-exec "$SOCK_OWNER_SPEC" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
-  exit $EXIT_CODE
+  attach_with su-exec "$SOCK_OWNER_SPEC"
+  exit $?
 else
-  PREV_MOUSE=$(tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-  tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
-  EXIT_CODE=0
-  tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
-  tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
-  exit $EXIT_CODE
+  attach_with
+  exit $?
 fi

--- a/v2/docs/heartbeat-bearer-cutover.md
+++ b/v2/docs/heartbeat-bearer-cutover.md
@@ -1,0 +1,152 @@
+# Heartbeat bearer cutover (audit F2)
+
+How to remove the fleet-wide heartbeat bearer lane **without re-provisioning the
+fleet**, and the hard precondition that gates the removal.
+
+## The finding
+
+`verifyHeartbeatBearer` (`v2/pkg/hub/hub_keys.go`) ends with:
+
+```go
+return secureCompareHub(presented, s.heartbeatKey())
+```
+
+`s.heartbeatKey()` is `deriveDomainKey(hubSecret, infoHeartbeatKey)` — a pure
+function of the one hub master, stamped identically into every spoke. Possession
+proves "some provisioned spoke", never "**this** hive". The handler then trusts
+the body-supplied `hive_id`, so any spoke can heartbeat as any victim hive and be
+handed victim-directed key material (pending OpenRouter key, legacy pending App
+config, standing cluster App key).
+
+This lane has been open across five audits. The blocker was never the fix — the
+per-hive replacement `heartbeatKeyFor(hiveID)` already existed — it was the
+migration: deleting the lane 401s every spoke that still presents the fleet-wide
+value, and the stated migration path was "re-provision the fleet", which the
+operator has ruled out.
+
+## Why an in-place migration is possible
+
+The per-hive bearer is
+
+```
+HMAC(master, "hive-heartbeat-v1" || 0x00 || hiveID)
+```
+
+— a pure function of **two values every spoke already holds in its own pod env**:
+`HIVE_HUB_SECRET` and `HIVE_ID`. No hub action, no new secret, no re-provision is
+needed for a spoke to start presenting the identity-bound bearer. It only needs
+code that derives it.
+
+### Measured fleet state (2026-08-13, contexts `hive-oke` + `vllm-d`)
+
+Classified by comparing each Deployment's `HIVE_HEARTBEAT_KEY` against both
+derivations computed from the live master:
+
+| Lane | Spokes |
+|---|---|
+| Per-hive `HIVE_HEARTBEAT_KEY` injected by the hub | 62 |
+| `HIVE_HEARTBEAT_KEY` **absent** → self-derives fleet-wide today | 3 |
+| Fleet-wide value explicitly injected | 0 |
+
+The three laggards are:
+
+- `hive-oke/hive-hosted-hosted-available-oke-02-placeholder-7zus`
+- `hive-oke/hive-hosted-hosted-daviddiaz0317-visual-hive--1jos`
+- `hive-oke/hive-hosted-hosted-projectbluefin-knuckle-gjvq`
+
+All three have `HIVE_HUB_SECRET` and `HIVE_ID` present, so all three can
+self-derive. They are the only reason the legacy lane cannot be deleted, and they
+need a code roll, not a re-provision.
+
+Provisioning has injected the per-hive key since the N1 change
+(`provisionHeartbeatKey`), so the 62 need nothing at all.
+
+## Stage 1 — enabling change (this PR)
+
+Spoke-side only. `SpokeHeartbeatKey()` now resolves in this order:
+
+1. `HIVE_HEARTBEAT_KEY` — the hub-injected value (unchanged; still authoritative,
+   so a pinned or self-hosted bearer is never overridden).
+2. **Self-derived per-hive bearer** from `HIVE_HUB_SECRET` + `HIVE_ID` — new.
+3. Fleet-wide derivation from `HIVE_HUB_SECRET` alone — now the last resort,
+   reachable only by a spoke with a master but no identity.
+
+The hub is **unchanged**: it still accepts both lanes. Nothing can break, because
+every spoke either keeps presenting the same injected value it already presents
+(62) or moves from a bearer the hub accepts to a *different* bearer the hub also
+accepts (3).
+
+A spoke on lane 2 is strictly safer than one on lane 3: its credential
+authenticates only as itself. Self-hosted single-tenant operators are unaffected —
+their hub re-derives the same per-hive value from the same master.
+
+## Stage 2 — observe
+
+Rollout telemetry already exists (`noteHeartbeatAuthPath`,
+`AuthRolloutReadiness`, admin route `GET /api/saas/admin/auth-rollout`). It
+records, per hive, whether the **most recent** heartbeat used the identity-bound
+bearer, and deliberately does not latch — a rolled-back spoke must make the fleet
+read not-ready again.
+
+```
+GET /api/saas/admin/auth-rollout
+{
+  "total_hives": 65,
+  "per_hive_bearer": 65,
+  "legacy_bearer": 0,
+  "heartbeat_lane_ready": true,
+  "stale_after": "24h0m0s"
+}
+```
+
+## Stage 3 — deletion (a separate PR, NOT this one)
+
+### Hard precondition
+
+Do not open the deletion PR until **all** of the following hold:
+
+1. `heartbeat_lane_ready` is `true` **and** `legacy_bearer` is `0`.
+2. `total_hives` equals the actual live spoke count (65 at time of writing —
+   re-count it; do not trust this number). `AuthRolloutReadiness` fails closed at
+   zero observations, but it cannot tell "hive absent" from "hive never existed",
+   so a hive that is paused or on an unreachable cluster silently leaves the
+   denominator after `stale_after` (24h). Compare against a real inventory:
+
+   ```sh
+   # Count by CONTAINER name, not by an `app=hive` label — that label is not
+   # applied consistently across clusters and undercounts (it matched 0 of 22
+   # spokes on hive-oke when this was written).
+   for ctx in hive-oke vllm-d; do
+     kubectl --context "$ctx" get deploy -A -o json \
+       | jq '[.items[]|select(.spec.template.spec.containers[].name=="hive")]|length'
+   done
+   ```
+
+3. Condition 1 has held continuously for **at least 24h** (one full
+   `stale_after` window), so a spoke that beats infrequently has had a chance to
+   appear on the per-hive lane rather than merely aging out of the denominator.
+4. Every spoke has actually rolled the Stage 1 image. Verify by SHA, not by tag.
+
+### The deletion
+
+Replace the final line of `verifyHeartbeatBearer` with `return false` and drop
+`heartbeatKey()` if it has no other caller. Then flip
+`TestFleetWideBearerStillAcceptedAtThisStage` to assert **rejection** — it is
+written to fail loudly with the precondition in its message if the lane is
+removed early.
+
+### Rollback
+
+The lane is one line. If heartbeats 401 after deletion, restore it and the fleet
+recovers on the next beat (~1 min). Nothing is persisted, so there is no
+migration to undo.
+
+## Residual risk not addressed here
+
+Every spoke Deployment still carries `HIVE_HUB_SECRET`, the hub **master**, in
+plaintext (65/65 measured). Any spoke operator can read it and derive *any*
+hive's per-hive bearer, which defeats the identity binding for an attacker with
+pod access. Self-derivation does not make this worse — it is the same material
+already present — but F2 is only fully closed once the master stops being
+injected into spokes and they hold nothing but their own derived sub-keys. That
+is a separate finding and a separate change.

--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -28,6 +28,25 @@ type Finding struct {
 	Detail    string    `json:"detail,omitempty"`
 	File      string    `json:"file,omitempty"`
 	Line      int       `json:"line,omitempty"`
+	// PathStale is set by VerifyFindingPaths when File names a repo file path
+	// that does NOT exist at the digest's analyzed snapshot (Digest.AnalyzedSnapshot).
+	// Such a finding was generated against a different/older tree than the one
+	// cited in the digest — rendering its path as a live reference would repeat
+	// the "docs/install.md that isn't there" bug (#3704). The renderer marks it
+	// as outdated instead of emitting a dead file reference.
+	PathStale bool `json:"path_stale,omitempty"`
+}
+
+// Snapshot identifies the single commit that a digest's analysis is pinned to.
+// The advisory generator resolves the target repo's latest commit ONCE at the
+// start of a post cycle and records it here, so (a) every file reference in the
+// digest can be verified against one consistent tree and (b) the exact version
+// analyzed is cited in the posted comment (#3704).
+type Snapshot struct {
+	Owner  string `json:"owner"`
+	Repo   string `json:"repo"`
+	Branch string `json:"branch,omitempty"`
+	SHA    string `json:"sha"`
 }
 
 // ResolvedFinding is a closed advisory bead shown in the "Recently Resolved" section.
@@ -45,6 +64,13 @@ type Digest struct {
 	ByAgent          map[string][]Finding `json:"by_agent"`
 	TotalCount       int                  `json:"total_count"`
 	RecentlyResolved []ResolvedFinding    `json:"recently_resolved,omitempty"`
+	// AnalyzedSnapshot, when set, pins the digest to a single repo commit: the
+	// latest commit of the target repo as of when this post cycle started. It is
+	// cited in the rendered comment and used by VerifyFindingPaths to detect
+	// findings whose file paths no longer exist at that commit (#3704). nil keeps
+	// the previous behavior (no citation, no verification) for callers/tests that
+	// do not resolve a snapshot.
+	AnalyzedSnapshot *Snapshot `json:"analyzed_snapshot,omitempty"`
 }
 
 // Store manages advisory findings on disk.
@@ -359,6 +385,73 @@ func repoHintFromTitle(title string, num int, org string) (string, string, bool)
 	return "", "", false
 }
 
+// isFilePathRef reports whether ref denotes a repository file path (as opposed
+// to a GitHub issue/PR reference). File-path refs are the ones formatFindingRef
+// renders as `file:line` code spans and the ones VerifyFindingPaths checks for
+// existence at the analyzed snapshot. A gh-N ref ("gh-123") or an inline issue
+// ref ("repo#123", "owner/repo#123") is NOT a file path.
+func isFilePathRef(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	if ghNumRefPattern.MatchString(ref) {
+		return false
+	}
+	if inlineRefPattern.FindString(ref) == ref {
+		return false
+	}
+	return true
+}
+
+// splitFilePathRef separates a "path:line" style ref into its path component.
+// Only a trailing ":<digits>" is treated as a line suffix; colons elsewhere
+// (rare in repo paths) are left in the path. Returns the bare path.
+func splitFilePathRef(ref string) string {
+	if i := strings.LastIndex(ref, ":"); i > 0 {
+		if _, err := strconv.Atoi(ref[i+1:]); err == nil {
+			return ref[:i]
+		}
+	}
+	return ref
+}
+
+// VerifyFindingPaths checks every finding whose File names a repository file
+// path against the digest's analyzed snapshot and marks those that do not exist
+// at that commit as PathStale. This is the direct guard for #3704: a finding
+// generated against an older tree (e.g. one citing "docs/install.md" that was
+// since removed) must not be rendered as a live file reference under a commit
+// citation where the file is absent.
+//
+// exists is called with the bare file path (line suffix stripped) and must
+// report whether that path exists at the snapshot commit. It is only called for
+// file-path refs, so gh-issue/PR refs never trigger a network lookup. If the
+// digest has no AnalyzedSnapshot, or exists is nil, VerifyFindingPaths is a
+// no-op — callers that do not pin a snapshot keep the previous behavior.
+func VerifyFindingPaths(d *Digest, exists func(path string) bool) {
+	if d == nil || d.AnalyzedSnapshot == nil || exists == nil {
+		return
+	}
+	// Cache results per path: the same file commonly backs multiple findings,
+	// and existence at a fixed commit is stable for the whole cycle.
+	checked := make(map[string]bool)
+	for agent, findings := range d.ByAgent {
+		for i := range findings {
+			f := &findings[i]
+			if !isFilePathRef(f.File) {
+				continue
+			}
+			path := splitFilePathRef(f.File)
+			ok, seen := checked[path]
+			if !seen {
+				ok = exists(path)
+				checked[path] = ok
+			}
+			f.PathStale = !ok
+		}
+		d.ByAgent[agent] = findings
+	}
+}
+
 // FormatDigestMarkdown formats a digest as markdown for posting to GitHub.
 // Findings are grouped by severity (high→low) with a summary table, then
 // listed with their source agent — this gives repo owners a quick "what matters"
@@ -381,6 +474,7 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 		b.WriteString("This comment is updated periodically.\n\n")
 		b.WriteString("**Findings:** 0 — all previously reported findings are resolved. ✅\n\n")
 		writeRecentlyResolved(&b, d, org, primaryRepo)
+		writeAnalyzedFooter(&b, d)
 		return NeutralizeMentions(b.String())
 	}
 
@@ -427,7 +521,16 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 		icon := severityIcon(sev)
 		b.WriteString(fmt.Sprintf("### %s %s (%d)\n\n", icon, strings.ToUpper(sev), len(items)))
 		for _, f := range items {
-			loc := formatFindingRef(logscrub.ScrubString(f.File), f.Line, org, primaryRepo, f.Title)
+			var loc string
+			if f.PathStale {
+				// The file path does not exist at the analyzed commit (#3704):
+				// do not render it as a live `file` reference — it would point
+				// at a path that isn't there. Flag the finding as outdated
+				// instead so a reader knows to disregard the stale location.
+				loc = " _(file path not found at analyzed commit — finding may be outdated)_"
+			} else {
+				loc = formatFindingRef(logscrub.ScrubString(f.File), f.Line, org, primaryRepo, f.Title)
+			}
 			title := logscrub.ScrubString(f.Title)
 			detail := logscrub.ScrubString(f.Detail)
 			b.WriteString(fmt.Sprintf("- **[%s]** %s%s _%s_\n", f.Type, linkifyRefs(title, org), loc, f.Agent))
@@ -439,6 +542,7 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 	}
 
 	writeRecentlyResolved(&b, d, org, primaryRepo)
+	writeAnalyzedFooter(&b, d)
 
 	// Findings quote agent output verbatim and routinely name humans
 	// ("PR #665, by @omerap12"). The digest comment is rewritten every cycle,
@@ -459,6 +563,32 @@ func writeRecentlyResolved(b *strings.Builder, d *Digest, org, primaryRepo strin
 		b.WriteString(fmt.Sprintf("- ~~%s~~%s _%s — resolved %s_\n", linkifyRefs(logscrub.ScrubString(r.Title), org), loc, r.Agent, r.ClosedAt.Format("Jan 2")))
 	}
 	b.WriteString("\n")
+}
+
+// writeAnalyzedFooter cites the exact repo commit this digest's analysis is
+// pinned to (#3704, invariant 2). Rendered only when a snapshot was resolved;
+// callers that do not pin one (older flows, tests) get no footer.
+func writeAnalyzedFooter(b *strings.Builder, d *Digest) {
+	s := d.AnalyzedSnapshot
+	if s == nil || s.SHA == "" {
+		return
+	}
+	shortSHA := s.SHA
+	const shortSHALen = 12
+	if len(shortSHA) > shortSHALen {
+		shortSHA = shortSHA[:shortSHALen]
+	}
+	b.WriteString("---\n")
+	if s.Owner != "" && s.Repo != "" {
+		commitURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", s.Owner, s.Repo, s.SHA)
+		fmt.Fprintf(b, "*Analyzed at [`%s/%s@%s`](%s)", s.Owner, s.Repo, shortSHA, commitURL)
+	} else {
+		fmt.Fprintf(b, "*Analyzed at `%s`", shortSHA)
+	}
+	if s.Branch != "" {
+		fmt.Fprintf(b, " (branch `%s`)", s.Branch)
+	}
+	b.WriteString(" — the latest commit when this digest was generated. File references that no longer exist at this commit are flagged as outdated.*\n")
 }
 
 // SetLatestDigest stores the most recent digest for dashboard access.

--- a/v2/pkg/advisory/snapshot_test.go
+++ b/v2/pkg/advisory/snapshot_test.go
@@ -1,0 +1,138 @@
+package advisory
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestVerifyFindingPathsFlagsMissingFile is the direct regression guard for
+// #3704: a finding whose file path no longer exists at the analyzed commit must
+// be flagged PathStale, while findings for paths that do exist are left alone
+// and GitHub issue/PR refs are never checked at all.
+func TestVerifyFindingPathsFlagsMissingFile(t *testing.T) {
+	findings := []Finding{
+		// The #3704 case: cited path is absent at the analyzed commit.
+		{Agent: "scanner", Severity: "high", Type: "advisory",
+			Title: "install.md does not document the launcher image OCI repo",
+			File:  "docs/install.md"},
+		// A path that still exists.
+		{Agent: "quality", Severity: "medium", Type: "perf",
+			Title: "slow loop", File: "pkg/a.go", Line: 12},
+		// A GitHub issue ref — must never be treated as a file path.
+		{Agent: "scanner", Severity: "low", Type: "bug",
+			Title: "requester explosion", File: "gh-42"},
+	}
+	d := BuildDigest(findings, "busy")
+	d.AnalyzedSnapshot = &Snapshot{
+		Owner: "acme", Repo: "widgets", Branch: "main",
+		SHA: "8a804806a1306f01a911abefb1769c49f000eb35",
+	}
+
+	var checkedPaths []string
+	VerifyFindingPaths(d, func(path string) bool {
+		checkedPaths = append(checkedPaths, path)
+		return path != "docs/install.md" // docs/install.md is gone
+	})
+
+	// gh-42 must not have been checked; the two real file paths must have.
+	for _, p := range checkedPaths {
+		if p == "gh-42" {
+			t.Errorf("gh-42 was checked as a file path; it is a GitHub ref")
+		}
+	}
+	if !containsStr(checkedPaths, "docs/install.md") || !containsStr(checkedPaths, "pkg/a.go") {
+		t.Errorf("expected both file paths checked, got %v", checkedPaths)
+	}
+
+	got := map[string]bool{}
+	for _, fs := range d.ByAgent {
+		for _, f := range fs {
+			got[f.Title] = f.PathStale
+		}
+	}
+	if !got["install.md does not document the launcher image OCI repo"] {
+		t.Error("missing docs/install.md finding should be flagged PathStale")
+	}
+	if got["slow loop"] {
+		t.Error("existing pkg/a.go finding must not be flagged PathStale")
+	}
+	if got["requester explosion"] {
+		t.Error("gh-ref finding must never be flagged PathStale")
+	}
+}
+
+// TestFormatDigestMarkdownRendersStalePathAsOutdated verifies the renderer drops
+// the dead file link for a PathStale finding and marks it outdated instead of
+// emitting a `docs/install.md`-style code span (#3704).
+func TestFormatDigestMarkdownRendersStalePathAsOutdated(t *testing.T) {
+	findings := []Finding{
+		{Agent: "scanner", Severity: "high", Type: "advisory",
+			Title: "install.md missing launcher OCI repo", File: "docs/install.md", PathStale: true},
+	}
+	d := BuildDigest(findings, "busy")
+	md := FormatDigestMarkdown(d, "acme", "widgets")
+
+	if strings.Contains(md, "`docs/install.md`") {
+		t.Errorf("stale file path was rendered as a live code span:\n%s", md)
+	}
+	if !strings.Contains(md, "not found at analyzed commit") {
+		t.Errorf("stale finding not marked as outdated:\n%s", md)
+	}
+}
+
+// TestFormatDigestMarkdownCitesAnalyzedSnapshot verifies invariant 2: the exact
+// analyzed commit is cited in the rendered comment.
+func TestFormatDigestMarkdownCitesAnalyzedSnapshot(t *testing.T) {
+	findings := []Finding{
+		{Agent: "scanner", Severity: "high", Type: "bug", Title: "some bug", File: "pkg/a.go", Line: 3},
+	}
+	d := BuildDigest(findings, "busy")
+	sha := "8a804806a1306f01a911abefb1769c49f000eb35"
+	d.AnalyzedSnapshot = &Snapshot{Owner: "acme", Repo: "widgets", Branch: "main", SHA: sha}
+
+	md := FormatDigestMarkdown(d, "acme", "widgets")
+
+	if !strings.Contains(md, "Analyzed at") {
+		t.Errorf("digest does not cite analyzed snapshot:\n%s", md)
+	}
+	if !strings.Contains(md, sha[:12]) {
+		t.Errorf("digest does not cite the analyzed SHA %s:\n%s", sha[:12], md)
+	}
+	if !strings.Contains(md, "https://github.com/acme/widgets/commit/"+sha) {
+		t.Errorf("digest does not link the analyzed commit:\n%s", md)
+	}
+}
+
+// TestFormatDigestMarkdownNoSnapshotNoFooter confirms backward compatibility:
+// with no AnalyzedSnapshot, no citation footer is emitted.
+func TestFormatDigestMarkdownNoSnapshotNoFooter(t *testing.T) {
+	findings := []Finding{
+		{Agent: "scanner", Severity: "high", Type: "bug", Title: "some bug"},
+	}
+	d := BuildDigest(findings, "busy")
+	md := FormatDigestMarkdown(d, "acme", "widgets")
+	if strings.Contains(md, "Analyzed at") {
+		t.Errorf("no snapshot set but footer was rendered:\n%s", md)
+	}
+}
+
+// TestVerifyFindingPathsNoSnapshotNoOp confirms VerifyFindingPaths is inert when
+// no snapshot is pinned (older/unpinned callers keep prior behavior).
+func TestVerifyFindingPathsNoSnapshotNoOp(t *testing.T) {
+	findings := []Finding{{Agent: "scanner", Title: "x", File: "docs/install.md"}}
+	d := BuildDigest(findings, "busy")
+	called := false
+	VerifyFindingPaths(d, func(string) bool { called = true; return false })
+	if called {
+		t.Error("exists callback invoked with no AnalyzedSnapshot set")
+	}
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -5206,8 +5207,9 @@ func (m *Manager) seedJSONFile(agentName, path string, seed map[string]any) {
 // ensureClaudeSettings creates a per-agent writable HOME directory for inference
 // agents with pre-populated .claude/settings.json. Each agent gets its own dir
 // to avoid cross-agent permission conflicts when Claude Code creates session
-// files. Directories use 0o777 so the agent UID can create subdirs freely
-// (hive runs as dev, not root, so chown is not available).
+// files. Directories are created 0o700 and chowned to the agent UID where the
+// deployment permits it (the hosted container runs as root), falling back to
+// 0o777 only where chown is refused — see tightenInferenceHome.
 //
 // The .claude.json and settings.json seeds are repaired on every call
 // (missing keys merged in, corrupt files rewritten) so agents launched by
@@ -5218,7 +5220,11 @@ func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 	settingsDir := filepath.Join(homePath, ".claude")
 	settingsFile := filepath.Join(settingsDir, "settings.json")
 
-	if err := os.MkdirAll(settingsDir, inferenceHomeDirMode); err != nil {
+	// SECURITY (audit F12): os.MkdirAll stats components with a
+	// symlink-FOLLOWING stat, so a pre-planted link at the predictable anchor
+	// redirected everything below — including the root-privileged Chown/Chmod
+	// in tightenInferenceHome. mkdirAllNoFollow Lstats every component instead.
+	if err := mkdirAllNoFollow(inferenceHomeRoot(), settingsDir, inferenceHomeDirMode); err != nil {
 		m.logger.Warn("failed to create claude inference home", "agent", agentName, "error", err)
 		return
 	}
@@ -5387,11 +5393,110 @@ const (
 	inferenceHomeSharedDirMode = 0o777
 )
 
+// errInferenceHomeSymlink reports that a path component of an inference HOME is
+// a symlink, so the caller must not act on it (audit F12).
+var errInferenceHomeSymlink = errors.New("inference home path component is a symlink")
+
+// lstatNoFollow reports whether path exists and is a real directory, refusing a
+// symlink (audit F12).
+//
+// Returns (false, nil) when the path does not exist yet — the normal first-run
+// case, which the callers create. Any symlink, at any component, is
+// errInferenceHomeSymlink: acting on it is exactly the redirection this guard
+// exists to stop.
+func lstatNoFollow(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("%w: %s", errInferenceHomeSymlink, path)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("inference home path is not a directory: %s", path)
+	}
+	return true, nil
+}
+
+// mkdirAllNoFollow creates dir and any missing parents BELOW root, refusing to
+// traverse or create through a symlink (audit F12).
+//
+// SECURITY: os.MkdirAll stats each component with a symlink-FOLLOWING stat and
+// is happy to treat a link-to-directory as an existing component, so a
+// pre-planted link at the predictable anchor
+// (/tmp/.claude-inference-home-<agent>) silently redirects the whole subtree —
+// and with it the path-based Chown/Chmod in tightenInferenceHome, which run as
+// root in the hosted container. Lstat-ing every component below root closes
+// that: a planted link fails loudly instead of redirecting.
+//
+// root is RESOLVED rather than Lstat-refused: it is the operator-controlled
+// container path (/tmp, or a test temp dir), and on macOS /tmp is itself a
+// symlink to private/tmp — refusing it would break every real launch. The
+// threat model is a link planted at the AGENT-controlled anchor below root, so
+// resolving root and then Lstat-ing every component beneath it is what matters.
+// root always already exists and is never created here.
+func mkdirAllNoFollow(root, dir string, perm os.FileMode) error {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	// Re-anchor dir onto the resolved root so Rel compares like with like.
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return err
+	}
+	root = resolvedRoot
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("inference home %s escapes root %s", dir, root)
+	}
+	current := root
+	if rel == "." {
+		return nil
+	}
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+		exists, err := lstatNoFollow(current)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if err := os.Mkdir(current, perm); err != nil && !os.IsExist(err) {
+			return err
+		}
+		// Re-check: os.Mkdir returning EEXIST means something raced us into
+		// place, and that something may be a symlink.
+		if _, err := lstatNoFollow(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// inferenceHomeRoot returns the directory the per-agent inference HOMEs are
+// created in — /tmp in production, the override's parent under test.
+func inferenceHomeRoot() string {
+	if inferenceHomePrefixOverride != "" {
+		return filepath.Dir(inferenceHomePrefixOverride)
+	}
+	return filepath.Dir(claudeInferenceHomePrefix)
+}
+
 // tightenInferenceHome tries to give the agent UID sole ownership of its
 // inference HOME, falling back to the historical world-writable mode when the
 // hive lacks the privilege to chown. Best-effort by design: every failure path
-// leaves a WORKING home, because the O_NOFOLLOW writers — not this — are what
-// close audit F12.
+// leaves a WORKING home.
+//
+// SECURITY (audit F12): os.Chown and os.Chmod both FOLLOW symlinks, and this
+// runs as root in the hosted container, so each directory is Lstat-verified as
+// a real directory immediately before it is acted on. A planted link is skipped
+// loudly rather than having the hive's own privilege redirected onto whatever
+// it points at. The leaf O_NOFOLLOW writers do NOT cover this: they protect
+// files, and these are the ANCHOR DIRECTORIES.
 func (m *Manager) tightenInferenceHome(agentName, homePath, settingsDir string, uid int) {
 	if uid <= 0 {
 		// No per-agent UID: the hive itself is the only writer, so 0700 owned
@@ -5399,6 +5504,11 @@ func (m *Manager) tightenInferenceHome(agentName, homePath, settingsDir string, 
 		return
 	}
 	for _, dir := range []string{homePath, settingsDir} {
+		if exists, err := lstatNoFollow(dir); err != nil || !exists {
+			m.logger.Warn("refusing to tighten inference home (not a real directory)",
+				"agent", agentName, "dir", dir, "error", err)
+			continue
+		}
 		if err := os.Chown(dir, uid, -1); err != nil {
 			// Unprivileged deployment. Restore the shared mode so the agent can
 			// still use its HOME, and say so once at debug level rather than

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -54,6 +54,14 @@ const (
 	paneCaptureSleep     = 500 * time.Millisecond
 	proxyListenPort      = 18443
 	proxyCACertPath      = "/data/proxy-ca.pem"
+
+	// fullLogCaptureLines bounds the "download/view full log" capture (see
+	// CaptureFullLog). tmux's -S - captures the entire scrollback, but a wedged
+	// agent that has spammed for hours can hold a very large buffer; this caps the
+	// number of lines pulled back from the tail so the endpoint stays bounded.
+	// It is deliberately far larger than the tmux history-limit tmux is usually
+	// started with, so in practice it returns the WHOLE retained session.
+	fullLogCaptureLines = 50000
 )
 
 var defaultTmuxSocket string
@@ -2608,6 +2616,42 @@ func (m *Manager) captureTmuxPaneForAgent(agent *AgentProcess) string {
 		return ""
 	}
 	return string(out)
+}
+
+// CaptureFullLog returns the agent's full retained tmux scrollback for its
+// current (latest) session, as plain text. It backs the dashboard's
+// "download / view full log" controls (issue #3693): the browser Terminal only
+// shows the last screenful, so this pulls the whole retained buffer — from the
+// tail up to fullLogCaptureLines — using the SAME per-agent socket + su-exec
+// path as every other capture, so it works under per-UID isolation.
+//
+// The capture is bounded to the current tmux session, so it is scoped to the
+// agent's latest run (a restart kills and recreates the session, dropping the
+// prior run's scrollback). It is NOT delimited to a run boundary WITHIN a
+// long-lived session; when an agent has been kicked repeatedly without a
+// restart, the buffer holds multiple kicks' output back to the tmux
+// history-limit. That is an accepted v1 limitation — the whole retained
+// session is returned.
+func (m *Manager) CaptureFullLog(name string) (string, error) {
+	m.mu.RLock()
+	agent, ok := m.agents[name]
+	m.mu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("agent %s not found", name)
+	}
+	if agent.tmuxSession == "" {
+		return "", fmt.Errorf("agent %s has no active session", name)
+	}
+	// -S -<n>: start n lines back into history; -E -: through the last visible
+	// line; -J: join wrapped lines so copied text is not hard-wrapped at the
+	// pane width; -p: print to stdout. -1: keep the tail behaviour bounded.
+	cmd := m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p", "-J",
+		"-S", fmt.Sprintf("-%d", fullLogCaptureLines), "-E", "-")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("capturing pane for %s: %w", name, err)
+	}
+	return string(out), nil
 }
 
 // captureVisiblePaneForAgent captures only the visible pane (no scrollback).

--- a/v2/pkg/agent/manager_inference_home_anchor_test.go
+++ b/v2/pkg/agent/manager_inference_home_anchor_test.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Audit F12 residual: the inference-home ANCHOR directory was never
+// symlink-checked. ensureClaudeSettings called os.MkdirAll on a path derived
+// from the predictable /tmp/.claude-inference-home-<agent>, and
+// tightenInferenceHome then ran path-based os.Chown/os.Chmod over it. All three
+// syscalls follow symlinks, so a local UID that pre-planted that name
+// redirected the hive's own (root, in the hosted container) privilege onto an
+// arbitrary directory. The leaf-file O_NOFOLLOW writers do not cover this —
+// they guard files, not the anchor directory.
+//
+// These tests use the inferenceHomePrefixOverride seam so nothing touches the
+// real /tmp.
+
+// inferenceHomeTestPrefix points the per-agent inference HOME at a fresh temp
+// dir and returns the root those homes are created in.
+func inferenceHomeTestPrefix(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	claudeInferenceHomePrefixForTest(t, filepath.Join(root, "home-"))
+	return root
+}
+
+// TestF12_EnsureClaudeSettingsRefusesSymlinkedAnchor is the core regression:
+// a symlink pre-planted at the anchor must NOT be followed.
+func TestF12_EnsureClaudeSettingsRefusesSymlinkedAnchor(t *testing.T) {
+	root := inferenceHomeTestPrefix(t)
+
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+
+	anchor := inferenceHomePath("scanner")
+	if err := os.Symlink(victim, anchor); err != nil {
+		t.Fatalf("symlink anchor: %v", err)
+	}
+
+	quietManager().ensureClaudeSettings("scanner", 0)
+
+	// The hive must not have created anything through the link.
+	if _, err := os.Stat(filepath.Join(victim, ".claude")); err == nil {
+		t.Fatal("ensureClaudeSettings created .claude inside the symlink target: anchor symlink was followed (CWE-59 regression)")
+	}
+	if got := statMode(t, victim); got != 0o700 {
+		t.Fatalf("victim mode = %v, want 0700: anchor symlink was followed", got)
+	}
+	// The anchor itself must still be the planted link, not a replaced dir.
+	info, err := os.Lstat(anchor)
+	if err != nil {
+		t.Fatalf("lstat anchor: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("anchor is no longer a symlink; the guard must refuse, not silently replace")
+	}
+}
+
+// TestF12_TightenInferenceHomeRefusesSymlinkedAnchor covers the chown/chmod
+// half directly: tightenInferenceHome must not act on a linked directory.
+func TestF12_TightenInferenceHomeRefusesSymlinkedAnchor(t *testing.T) {
+	root := inferenceHomeTestPrefix(t)
+
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	anchor := filepath.Join(root, "linked-home")
+	if err := os.Symlink(victim, anchor); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// uid>0 so the chown/chmod loop is actually entered. The chown itself is
+	// expected to be refused by the OS for an unprivileged test runner; the
+	// assertion is on the CHMOD fallback, which would otherwise widen the
+	// victim to 0777 through the link.
+	quietManager().tightenInferenceHome("scanner", anchor, filepath.Join(anchor, ".claude"), 12345)
+
+	if got := statMode(t, victim); got != 0o700 {
+		t.Fatalf("victim mode = %v, want 0700: tightenInferenceHome followed the anchor symlink (CWE-59 regression)", got)
+	}
+}
+
+// TestF12_MkdirAllNoFollowRefusesSymlinkedIntermediate ensures the guard covers
+// every component, not just the final anchor.
+func TestF12_MkdirAllNoFollowRefusesSymlinkedIntermediate(t *testing.T) {
+	root := t.TempDir()
+	victim := filepath.Join(root, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	if err := os.Symlink(victim, filepath.Join(root, "anchor")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := mkdirAllNoFollow(root, filepath.Join(root, "anchor", ".claude"), inferenceHomeDirMode)
+	if !errors.Is(err, errInferenceHomeSymlink) {
+		t.Fatalf("mkdirAllNoFollow error = %v, want errInferenceHomeSymlink", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(victim, ".claude")); statErr == nil {
+		t.Fatal("created a directory through a symlinked intermediate component")
+	}
+}
+
+// TestF12_EnsureClaudeSettingsCreatesRealHome is the POSITIVE CONTROL: with no
+// symlink planted, the normal path must still create the home, the settings
+// directory and the seeded files. A guard that broke this would be worthless.
+func TestF12_EnsureClaudeSettingsCreatesRealHome(t *testing.T) {
+	inferenceHomeTestPrefix(t)
+
+	quietManager().ensureClaudeSettings("scanner", 0)
+
+	home := inferenceHomePath("scanner")
+	info, err := os.Lstat(home)
+	if err != nil {
+		t.Fatalf("inference home was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("inference home is not a directory: mode %v", info.Mode())
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err != nil {
+		t.Fatalf("settings.json was not seeded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude.json")); err != nil {
+		t.Fatalf(".claude.json was not seeded: %v", err)
+	}
+}
+
+// TestF12_TightenInferenceHomeTightensRealDirectory is the second POSITIVE
+// CONTROL: permissions must still actually be applied to a real directory.
+func TestF12_TightenInferenceHomeTightensRealDirectory(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	settings := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settings, 0o777); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Defeat umask so the starting mode is unambiguously the wide one.
+	if err := os.Chmod(home, 0o777); err != nil {
+		t.Fatalf("chmod home: %v", err)
+	}
+
+	// uid>0 with an unprivileged runner: chown fails, so the loop takes the
+	// documented fallback and restores the shared mode. Either way it must
+	// have ACTED on the real directory rather than skipping it.
+	quietManager().tightenInferenceHome("scanner", home, settings, 12345)
+
+	got := statMode(t, home)
+	if got != inferenceHomeSharedDirMode && got != inferenceHomeDirMode {
+		t.Fatalf("home mode = %v, want %v or %v: tightenInferenceHome skipped a real directory",
+			got, os.FileMode(inferenceHomeSharedDirMode), os.FileMode(inferenceHomeDirMode))
+	}
+}

--- a/v2/pkg/agent/uidmap.go
+++ b/v2/pkg/agent/uidmap.go
@@ -83,6 +83,42 @@ func (u *UIDMap) LookupByUID(uid int) string {
 	return ""
 }
 
+// IsInternalUID reports whether uid belongs to the hive's OWN control plane
+// rather than to a sandboxed agent — the hive process itself (which runs as
+// root) or the MITM proxy user.
+//
+// WHY THIS EXISTS (proxy request blocked / github_auth 403). v4 forces ALL
+// egress through the MITM proxy, including the hive's own control-plane calls.
+// The proxy attributes a connection to an agent by looking its UID up in
+// Agents; the hive process is not an agent, so the lookup missed, agentName
+// came back "", and identifyAgentFromConn's caller fell back to ADVISORY and
+// blocked the write. That silently broke every App installation-token mint
+// (POST /app/installations/{id}/access_tokens) on v4 spokes — surfacing as a
+// bogus GitHub "403" and paused agents fleet-wide.
+//
+// SECURITY. This must NEVER match an agent UID. Agents are >= BaseUID (2001)
+// and are dynamically allocated upward, so the internal set is exactly {0, the
+// proxy UID} and is checked against Agents as a belt-and-braces guard: if an
+// agent were ever provisioned at 0 or at ProxyUID, this returns false rather
+// than handing that agent an exemption. Verified on a live v4 spoke that an
+// agent UID cannot reach 0: su-exec is 4750 root:hive-launch and agents are not
+// in hive-launch (Permission denied), /usr/bin/su fails (root is password
+// locked, "*"), and mount is refused (no CAP_SYS_ADMIN, CapBnd 15fb).
+func (u *UIDMap) IsInternalUID(uid int) bool {
+	if uid != 0 && uid != u.ProxyUID {
+		return false
+	}
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	for _, agentUID := range u.Agents {
+		if agentUID == uid {
+			// An agent occupies this UID — never treat it as internal.
+			return false
+		}
+	}
+	return true
+}
+
 // LookupByName returns the UID for a given agent name, or 0 if not found.
 func (u *UIDMap) LookupByName(name string) int {
 	u.mu.RLock()

--- a/v2/pkg/agent/uidmap_internal_test.go
+++ b/v2/pkg/agent/uidmap_internal_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import "testing"
+
+// IsInternalUID decides whether a caller bypasses the proxy's agent-mode gate.
+// A false positive hands a sandboxed agent an un-gated egress path, so the
+// negative cases below matter more than the positive one.
+
+// TestIsInternalUID_HiveProcess is the regression for the outage: the hive runs
+// as root, is not in the agent map, and must be recognised as internal.
+func TestIsInternalUID_HiveProcess(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"scanner": 2007, "quality": 2006}
+	if !u.IsInternalUID(0) {
+		t.Error("uid 0 (the hive process) must be internal — otherwise its App-token mint is blocked")
+	}
+}
+
+// TestIsInternalUID_ProxyUser: the MITM proxy's own upstream dials are internal
+// too, mirroring the existing proxy_uid exemption in the iptables chain.
+func TestIsInternalUID_ProxyUser(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"scanner": 2007}
+	if !u.IsInternalUID(u.ProxyUID) {
+		t.Errorf("proxy uid %d must be internal", u.ProxyUID)
+	}
+}
+
+// TestIsInternalUID_AgentsAreNeverInternal is the positive control. Without it,
+// a function that simply returned true would satisfy both tests above while
+// handing every agent an exemption.
+func TestIsInternalUID_AgentsAreNeverInternal(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{
+		"architect": 2001, "brainstorm": 2002, "ci-maintainer": 2003,
+		"guide": 2004, "outreach": 2005, "quality": 2006,
+		"scanner": 2007, "sec-check": 2008, "strategist": 2009, "supervisor": 2010,
+	}
+	for name, uid := range u.Agents {
+		if u.IsInternalUID(uid) {
+			t.Errorf("agent %q (uid %d) must NOT be internal — that would bypass the mode gate", name, uid)
+		}
+	}
+}
+
+// TestIsInternalUID_AgentSquattingOnInternalUID is the belt-and-braces case: if
+// an agent were ever provisioned at uid 0 or at the proxy uid, it must lose the
+// exemption rather than inherit it. This is what keeps the fix safe on a spoke
+// where the C6 setuid hole is still open (v2), even though it is closed on v4.
+func TestIsInternalUID_AgentSquattingOnInternalUID(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"rogue": 0}
+	if u.IsInternalUID(0) {
+		t.Error("an agent occupying uid 0 must not be treated as internal")
+	}
+
+	u2 := NewUIDMap()
+	u2.Agents = map[string]int{"rogue": u2.ProxyUID}
+	if u2.IsInternalUID(u2.ProxyUID) {
+		t.Error("an agent occupying the proxy uid must not be treated as internal")
+	}
+}
+
+// TestIsInternalUID_UnknownUID: an unattributable UID stays non-internal, so a
+// genuine UID-attribution failure still fails closed and still logs loudly.
+func TestIsInternalUID_UnknownUID(t *testing.T) {
+	u := NewUIDMap()
+	u.Agents = map[string]int{"scanner": 2007}
+	for _, uid := range []int{1, 999, 1002, 5000} {
+		if u.IsInternalUID(uid) {
+			t.Errorf("uid %d is neither the hive nor the proxy and must not be internal", uid)
+		}
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -63,6 +63,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/lifecycle-timeline", s.handleLifecycleTimeline)
 	s.mux.HandleFunc("GET /api/widget", s.handleWidget)
 	s.mux.HandleFunc("GET /api/pane/{agent}", s.handlePane)
+	// Full retained scrollback of an agent's latest run, as plain text (#3693).
+	// Backs the Terminal's "view / download full log" controls.
+	s.mux.HandleFunc("GET /api/agents/{name}/log", s.handleAgentFullLog)
 
 	s.mux.HandleFunc("GET /api/role", s.handleRole)
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4333,6 +4333,8 @@
             ? ''
             : `<button class="btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="${isPaused}" title="${isPaused ? 'Resume this agent — it will start running on its configured cadence' : isOff ? 'Start this agent — it is currently off in this governor mode' : 'Pause this agent — stops governor from kicking it until resumed'}">${isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause'}</button>`}
           <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>
+          <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>
+          <a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>
           <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill this agent's tmux session — supervisor will respawn it with fresh context">↻ restart</button>
           <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" style="font-size:1rem;opacity:0.7" title="Open configuration dialog for this agent (cadences, model, pipeline, hooks, etc.)">⚙️</button>
           <button class="btn" data-action="kickEmpty" data-agent="${esc(a.name)}" style="margin-left:auto" title="Kick this agent now with its default prompt, bypassing the governor cadence timer">kick</button>
@@ -5833,6 +5835,22 @@
       return `${proto}//${host}/terminal/?arg=${encodeURIComponent(session)}${tokenParam}`;
     }
 
+    // fullLogUrl points at the server-side endpoint that captures the agent's
+    // full retained tmux scrollback (issue #3693). The live "▶ terminal" only
+    // shows the last screenful; this returns the whole latest-run buffer as
+    // plain, selectable, searchable text. download=1 makes the browser save it
+    // as a .log file instead of rendering it inline. The token param mirrors
+    // terminalUrl so it authenticates on direct-route spokes.
+    function fullLogUrl(agentName, download) {
+      const proto = window.location.protocol;
+      const host = window.location.host;
+      const t = localStorage.getItem('hive-token');
+      const dl = download ? 'download=1' : '';
+      const tok = t ? `token=${encodeURIComponent(t)}` : '';
+      const qs = [dl, tok].filter(Boolean).join('&');
+      return `${proto}//${host}/api/agents/${encodeURIComponent(agentName)}/log${qs ? '?' + qs : ''}`;
+    }
+
     /* SINGLE source of truth for the 🔑 "needs login" badge. Mirrors the
        server-side precedence rule in pkg/agent/authprobe.go:
 
@@ -5921,7 +5939,7 @@
         const configTarget = a.replicaBase || a.name;
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';

--- a/v2/pkg/dashboard/terminal_log.go
+++ b/v2/pkg/dashboard/terminal_log.go
@@ -1,0 +1,80 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// handleAgentFullLog serves the full retained tmux scrollback of an agent's
+// latest run as plain, selectable, searchable text (issue #3693). The browser
+// "Terminal" (ttyd) only shows the last screenful; this endpoint pulls the whole
+// retained session buffer server-side via Manager.CaptureFullLog, which uses the
+// same per-agent socket + su-exec path as every other capture so it works under
+// per-UID isolation.
+//
+// It is read-only (GET), so any authenticated role may call it — the same rule
+// as handleAgentState and the /terminal proxy, both of which already expose the
+// pane to any authenticated viewer.
+//
+// Query parameters:
+//
+//	?download=1  sets Content-Disposition: attachment so the browser saves a
+//	             .log text file (the "download full log" control). Omitted, the log
+//	             renders inline in a new tab as selectable/searchable text (the
+//	             "view full log" control).
+func (s *Server) handleAgentFullLog(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		http.Error(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	name := s.resolveAgentParam(r.PathValue("name"))
+	log, err := s.deps.AgentMgr.CaptureFullLog(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// SECURITY: every other pane surface (/api/pane, the status summaries) strips
+	// tokens and device-auth codes before the output leaves the server; the full
+	// log must too, or it becomes a redaction bypass (see redactTokens).
+	log = redactTokens(log)
+
+	// text/plain so browsers render it as selectable, searchable text (Cmd/Ctrl-F
+	// works, Select-All copies cleanly) rather than trying to interpret it.
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	// The pane is a live capture; never let an intermediary or the browser serve
+	// a stale copy of a previous run.
+	w.Header().Set("Cache-Control", "no-store")
+
+	if r.URL.Query().Get("download") != "" {
+		// Timestamped, filesystem-safe filename: hive-<agent>-<UTC>.log.
+		safe := sanitizeLogFilename(name)
+		fname := fmt.Sprintf("hive-%s-%s.log", safe, time.Now().UTC().Format("20060102-150405"))
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fname))
+	}
+
+	_, _ = w.Write([]byte(log))
+}
+
+// sanitizeLogFilename reduces an agent name to characters safe in a download
+// filename, so a display name or id never injects a path separator or quote into
+// the Content-Disposition header.
+func sanitizeLogFilename(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "agent"
+	}
+	return out
+}

--- a/v2/pkg/dashboard/terminal_log_test.go
+++ b/v2/pkg/dashboard/terminal_log_test.go
@@ -1,0 +1,77 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// A nonexistent agent returns 404 from the full-log endpoint (CaptureFullLog
+// reports "agent not found"), matching the /api/pane not-found contract.
+func TestHandleAgentFullLog_AgentNotFound(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agents/nonexistent/log")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// A known-but-not-running agent has no tmux session yet, so CaptureFullLog
+// returns the "no active session" error and the handler reports 404 — never a
+// 200 with an empty body that would look like a real (empty) log.
+func TestHandleAgentFullLog_NoActiveSession(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agents/scanner/log")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for an agent with no active session", rec.Code)
+	}
+}
+
+// With no agent manager wired, the endpoint reports 503 rather than panicking
+// on a nil dereference.
+func TestHandleAgentFullLog_NoManager(t *testing.T) {
+	s, _ := apiServer(t)
+	s.deps.AgentMgr = nil
+	rec := doGet(s, "/api/agents/scanner/log")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 when AgentMgr is nil", rec.Code)
+	}
+}
+
+// The download variant is still routed to the same handler; with no active
+// session it 404s exactly like the inline variant (the disposition header is
+// only reached on success, exercised where a live tmux session exists).
+func TestHandleAgentFullLog_DownloadRouted(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agents/scanner/log?download=1")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestSanitizeLogFilename(t *testing.T) {
+	cases := map[string]string{
+		"scanner":       "scanner",
+		"my-agent_1":    "my-agent_1",
+		"weird/../name": "weird----name",
+		"quote\"inject": "quote-inject",
+		"space name":    "space-name",
+		"emoji-🐝":       "emoji--", // multi-byte rune collapses to a single '-'
+		"":              "agent",
+		"...":           "---",
+		"UPPER123":      "UPPER123",
+	}
+	for in, want := range cases {
+		if got := sanitizeLogFilename(in); got != want {
+			t.Errorf("sanitizeLogFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// The result must never contain a path separator or a double quote, which
+	// would break out of the Content-Disposition filename.
+	for _, in := range []string{"a/b", "a\\b", "a\"b", "../../etc/passwd"} {
+		got := sanitizeLogFilename(in)
+		if strings.ContainsAny(got, `/\"`) {
+			t.Errorf("sanitizeLogFilename(%q) = %q contains an unsafe character", in, got)
+		}
+	}
+}

--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -147,7 +147,23 @@ func removeTree(path string) error {
 		if walkErr != nil {
 			return nil
 		}
-		if d.IsDir() {
+		// AUDIT N17 (open across three audits): os.Chmod FOLLOWS symlinks. This
+		// walk runs over an agent-writable workspace, so a symlink planted there
+		// pointing at any path the cleanup user can chmod — a key file, a config,
+		// a binary on a shared mount — gets that TARGET relaxed to 0o660/0o770,
+		// not the link. Nothing here needs to chmod a symlink: the link's own mode
+		// is irrelevant to RemoveAll (which unlinks it) and its target is by
+		// definition outside the tree we are deleting. So skip links entirely.
+		//
+		// WalkDir does not follow symlinks itself, so d.Type() already reports the
+		// link — but d can come from a cached ReadDir entry, and a path can be
+		// swapped for a symlink between the readdir and this chmod (TOCTOU). The
+		// Lstat is the authoritative, immediately-before check.
+		info, lerr := os.Lstat(p)
+		if lerr != nil || info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if info.IsDir() {
 			os.Chmod(p, 0o770)
 		} else {
 			os.Chmod(p, 0o660)

--- a/v2/pkg/dashboard/workspace_cleanup_n17_symlink_test.go
+++ b/v2/pkg/dashboard/workspace_cleanup_n17_symlink_test.go
@@ -1,0 +1,163 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// AUDIT N17 (open across three audits): the chmod-and-retry fallback in
+// removeTree walked an agent-writable workspace calling bare os.Chmod, which
+// FOLLOWS symlinks. A symlink planted in the workspace pointing anywhere the
+// cleanup user could chmod got its TARGET relaxed to 0o660 (or 0o770 for a
+// directory) — turning "delete a stale workspace" into an arbitrary
+// permission-loosening primitive on files entirely outside that workspace.
+//
+// TestN17ChmodWalkDoesNotFollowSymlinks is the regression.
+// TestN17ChmodWalkStillRelaxesRealFiles is the POSITIVE CONTROL: an
+// implementation that skipped the chmod entirely (or that failed the walk
+// outright) would pass the regression while silently breaking the only reason
+// the fallback exists.
+
+// n17MakeStubbornDir builds a directory tree that RemoveAll cannot delete on the
+// first attempt, forcing removeTree down the chmod-and-retry path. A directory
+// with no write bit cannot have its children unlinked.
+//
+// links are created INSIDE the locked directory, and that placement is
+// load-bearing. removeTree's first step is os.RemoveAll, which is destructive
+// EVEN WHEN IT FAILS: it unlinks everything it can reach before hitting the
+// unremovable child. A symlink sitting at the top of the workspace is therefore
+// already gone by the time the chmod walk runs, and the test passes vacuously.
+// Inside the locked directory the link survives step 1 and is still present when
+// the walk — the code actually under test — reaches it.
+func n17MakeStubbornDir(t *testing.T, links map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	work := filepath.Join(root, "workspace")
+	inner := filepath.Join(work, "locked")
+	if err := os.MkdirAll(inner, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inner, "file.txt"), []byte("x"), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for name, target := range links {
+		if err := os.Symlink(target, filepath.Join(inner, name)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+	}
+	// Clamp the write bit off the inner dir so its child cannot be unlinked. This
+	// is what makes the FIRST os.RemoveAll fail and drives removeTree down to the
+	// chmod-and-retry walk — the code path under test. Without it removeTree
+	// succeeds immediately, the walk never runs, and the symlink test goes green
+	// no matter what the walk does. (That happened; the replay caught it.)
+	if err := os.Chmod(inner, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(inner, 0o700) })
+
+	// NOTE: do NOT "verify the premise" here by calling os.RemoveAll(work).
+	// RemoveAll is destructive even when it FAILS — it deletes everything it can
+	// reach before hitting the unremovable child, which includes the planted
+	// symlinks. The walk under test then finds nothing and the test passes
+	// vacuously. (Exactly this masked the replay until it was traced.) The
+	// premise is instead asserted non-destructively by the caller, on a
+	// throwaway copy of the same shape.
+	return work
+}
+
+// n17AssertRemoveAllFails checks, on a SEPARATE throwaway tree of the same
+// shape, that a plain os.RemoveAll really does fail — i.e. that removeTree will
+// be forced down the chmod-and-retry walk. Done on a copy precisely because the
+// check destroys what it touches.
+func n17AssertRemoveAllFails(t *testing.T) {
+	t.Helper()
+	probe := n17MakeStubbornDir(t, nil)
+	if err := os.RemoveAll(probe); err == nil {
+		t.Fatal("test premise broken: plain RemoveAll deleted the tree, so the " +
+			"chmod walk under test never runs and this test proves nothing")
+	}
+}
+
+// TestN17ChmodWalkDoesNotFollowSymlinks is the regression. A symlink inside the
+// doomed workspace points at a file OUTSIDE it whose mode is deliberately tight
+// (0o400). After removeTree runs, that outside file's mode must be untouched.
+func TestN17ChmodWalkDoesNotFollowSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX modes and symlinks")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores permission bits, so RemoveAll never needs the chmod walk")
+	}
+
+	// The victim lives outside the tree being removed — this is the whole point:
+	// nothing in the cleanup's remit should be able to reach it.
+	victimDir := t.TempDir()
+	victimFile := filepath.Join(victimDir, "secret.key")
+	if err := os.WriteFile(victimFile, []byte("private"), 0o400); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+	victimSubdir := filepath.Join(victimDir, "protected")
+	if err := os.Mkdir(victimSubdir, 0o500); err != nil {
+		t.Fatalf("mkdir victim dir: %v", err)
+	}
+
+	n17AssertRemoveAllFails(t)
+
+	// The planted links. The walk will visit both; a following chmod relaxes the
+	// TARGETS rather than the links.
+	work := n17MakeStubbornDir(t, map[string]string{
+		"link-to-secret": victimFile,
+		"link-to-dir":    victimSubdir,
+	})
+
+	// removeTree's success/failure is not what is under test — the side effect
+	// on the victim is. Deliberately ignore the error.
+	_ = removeTree(work)
+
+	fi, err := os.Lstat(victimFile)
+	if err != nil {
+		t.Fatalf("victim file vanished: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o400 {
+		t.Errorf("symlinked-to file mode = %#o, want 0400 unchanged; "+
+			"the cleanup walk followed a symlink out of the workspace (N17)", got)
+	}
+
+	di, err := os.Lstat(victimSubdir)
+	if err != nil {
+		t.Fatalf("victim dir vanished: %v", err)
+	}
+	if got := di.Mode().Perm(); got != 0o500 {
+		t.Errorf("symlinked-to dir mode = %#o, want 0500 unchanged; "+
+			"the cleanup walk followed a symlink out of the workspace (N17)", got)
+	}
+
+	// And the links themselves must not have dragged the victims into deletion.
+	if _, err := os.Stat(victimFile); err != nil {
+		t.Errorf("victim file should still exist: %v", err)
+	}
+}
+
+// TestN17ChmodWalkStillRelaxesRealFiles is the positive control: the fallback
+// must still do its job on REAL (non-symlink) entries, i.e. a read-only tree
+// that RemoveAll alone chokes on is still removed. "Skip everything" would pass
+// the regression above and fail here.
+func TestN17ChmodWalkStillRelaxesRealFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX modes")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores permission bits, so RemoveAll never needs the fallback")
+	}
+
+	work := n17MakeStubbornDir(t, nil)
+	if err := removeTree(work); err != nil {
+		t.Fatalf("removeTree should still remove a read-only tree via the chmod "+
+			"fallback; got %v", err)
+	}
+	if _, err := os.Stat(work); !os.IsNotExist(err) {
+		t.Errorf("workspace should be gone, stat err = %v", err)
+	}
+}

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -316,7 +317,11 @@ func (c *Client) trySweepSelfAuthoredPR(ctx context.Context, displayRepo, owner,
 	if mergeable != MergeableYes {
 		return AutoMergeSweepEvent{}, "not-mergeable", nil
 	}
-	green, reason, err := c.commitGreen(ctx, owner, repo, evaluatedHeadSHA)
+	baseBranch := ""
+	if pr.GetBase() != nil {
+		baseBranch = pr.GetBase().GetRef()
+	}
+	green, reason, err := c.commitGreen(ctx, owner, repo, baseBranch, evaluatedHeadSHA)
 	if err != nil {
 		return AutoMergeSweepEvent{}, reason, err
 	}
@@ -444,7 +449,11 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	if mergeable != MergeableYes {
 		return AutoMergeSweepEvent{}, "not-mergeable", nil
 	}
-	green, reason, err := c.commitGreen(ctx, owner, repo, headSHA)
+	baseBranch := ""
+	if pr.GetBase() != nil {
+		baseBranch = pr.GetBase().GetRef()
+	}
+	green, reason, err := c.commitGreen(ctx, owner, repo, baseBranch, headSHA)
 	if err != nil {
 		return AutoMergeSweepEvent{}, reason, err
 	}
@@ -538,28 +547,41 @@ func parseHiveQueueReview(body string) string {
 	return matches[1]
 }
 
-// commitGreen reports whether every non-meta commit status and check run on
-// the head SHA has actually succeeded. Pending is NOT green: the sweep runs
-// every minute and a queue action usually lands seconds after the PR opens,
-// so treating in-flight CI as green would squash the PR before its first CI
-// run finishes — mergeable_state cannot catch that, because "unstable"
-// (non-required checks outstanding) deliberately maps to MergeableYes and
-// managed repos generally have no branch protection making any check
-// required. Meta gates (tide, netlify previews, ...) are excluded on both
-// surfaces — tide in particular posts a commit status that stays "pending"
-// forever on Prow-managed repos and must never wedge the queue.
+// commitGreen reports whether the head SHA is mergeable from a CI
+// standpoint.
 //
-// A non-success CONCLUSION (cancelled, failure, timed_out, ...) on an
-// ignorable/non-required check (isIgnorableCICheck — Playwright, Mobile
-// Browser Tests, the chromium shard matrix, plus the isMetaCheck set) is
-// likewise not a blocker: those suites are routinely cancelled mid-flight
-// (matrix/concurrency-group cancellation, flake reruns) with zero bearing on
-// mergeability, and treating a cancelled Playwright/Mobile shard as red left
-// otherwise-green, MERGEABLE PRs (build-gate success) permanently skipped by
-// the self-merge sweep with reason "check-cancelled" (#22438, #22440).
-// Required checks (build-gate, build/test/docker, ...) still gate: only the
-// ignorable set gets a pass on a bad conclusion.
-func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool, string, error) {
+// Gating is REQUIRED-CHECKS-ONLY: commitGreen first asks GitHub which status
+// contexts/check-run names are actually required by the target branch's
+// branch protection (requiredStatusCheckContexts). Any status or check-run
+// whose context/name is NOT in that required set is skipped entirely,
+// regardless of its state or conclusion — pending, failing, or cancelled
+// non-required checks can never block self-merge. A required check still
+// fully gates: pending blocks (return not-green, "pending" — the sweep must
+// never squash a PR before its required CI has finished), and a
+// failure/error/cancelled conclusion on a required check blocks too.
+//
+// Why required-only, not a hardcoded ignore-list: the previous approach
+// (isMetaCheck/isIgnorableCICheck as an ALLOWLIST of names to ignore) is
+// whack-a-mole against an open-ended set of non-required checks — #3611 added
+// Playwright/Mobile Browser Tests/coverage-report/the chromium shard matrix,
+// but "Detect untested files" (cancelled) still blocked #22471 and "Analyze
+// (python)" (CodeQL, failure) still blocks #22450 because neither name was on
+// the list. Every managed repo's ACTUAL required-checks set (e.g. console's
+// main branch requires only "build-gate") is the one true source of what
+// must be green; anything else is by definition non-required and must never
+// wedge the queue.
+//
+// Fail-closed fallback: if the required-checks set cannot be determined
+// (branch protection absent/erroring, no branch known, or the API call
+// fails) this deliberately does NOT fall back to "ignore everything" — that
+// would merge over a genuinely broken build the moment GitHub's protection
+// API hiccups. Instead it falls back to the OLD isMetaCheck/isIgnorableCICheck
+// allowlist behavior, so an outage of the branch-protection endpoint degrades
+// gating back to the previously-shipped conservative behavior rather than to
+// "always green".
+func (c *Client) commitGreen(ctx context.Context, owner, repo, branch, sha string) (bool, string, error) {
+	required, requiredKnown := c.requiredStatusCheckContexts(ctx, owner, repo, branch)
+
 	statusOpts := &gh.ListOptions{PerPage: 100}
 	for {
 		status, resp, err := c.client.Repositories.GetCombinedStatus(ctx, owner, repo, sha, statusOpts)
@@ -567,7 +589,15 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			return false, "status-check", err
 		}
 		for _, s := range status.Statuses {
-			if isMetaCheck(s.GetContext()) {
+			ctxName := s.GetContext()
+			if requiredKnown {
+				// Required-checks-only gating: skip anything not on the
+				// branch's actual required list, no matter its state.
+				if !required[ctxName] {
+					continue
+				}
+			} else if isMetaCheck(ctxName) {
+				// Fail-closed fallback path (required set unavailable).
 				continue
 			}
 			switch s.GetState() {
@@ -575,7 +605,7 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			case "pending":
 				return false, "status-pending", nil
 			default: // "failure", "error"
-				if isIgnorableCICheck(s.GetContext()) {
+				if !requiredKnown && isIgnorableCICheck(ctxName) {
 					continue
 				}
 				return false, "status-" + s.GetState(), nil
@@ -594,11 +624,16 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			return false, "check-runs", err
 		}
 		for _, cr := range checkRuns.CheckRuns {
-			if isMetaCheck(cr.GetName()) {
+			name := cr.GetName()
+			if requiredKnown {
+				if !required[name] {
+					continue
+				}
+			} else if isMetaCheck(name) {
 				continue
 			}
 			if cr.GetStatus() != "completed" {
-				if isIgnorableCICheck(cr.GetName()) {
+				if !requiredKnown && isIgnorableCICheck(name) {
 					continue
 				}
 				return false, "check-pending", nil
@@ -606,7 +641,7 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 			switch cr.GetConclusion() {
 			case "success", "neutral", "skipped":
 			default:
-				if isIgnorableCICheck(cr.GetName()) {
+				if !requiredKnown && isIgnorableCICheck(name) {
 					continue
 				}
 				return false, "check-" + cr.GetConclusion(), nil
@@ -617,6 +652,59 @@ func (c *Client) commitGreen(ctx context.Context, owner, repo, sha string) (bool
 		}
 		opts.ListOptions.Page = resp.NextPage
 	}
+}
+
+// requiredStatusCheckContexts returns the set of status-check contexts /
+// check-run names that branch protection actually requires on branch, and
+// whether that set could be determined at all. It is the single source of
+// truth commitGreen gates on: membership in this set is what makes a check
+// "required" (must be green) versus ignorable (any state/conclusion, never
+// blocks).
+//
+// requiredKnown is false (empty set, ignore it) when:
+//   - branch is empty (caller could not resolve the PR's base branch), or
+//   - the repo/branch has no branch protection configured
+//     (gh.ErrBranchNotProtected — a repo with zero required checks is a
+//     valid, common state, NOT an error), or
+//   - the GitHub API call itself failed (rate limit, transient 5xx, ...).
+//
+// In all of those cases the caller must fall back to the OLD
+// isMetaCheck/isIgnorableCICheck allowlist rather than treating "we don't
+// know the required set" as "nothing is required" — see commitGreen's
+// fail-closed comment.
+func (c *Client) requiredStatusCheckContexts(ctx context.Context, owner, repo, branch string) (map[string]bool, bool) {
+	if strings.TrimSpace(branch) == "" {
+		return nil, false
+	}
+	rsc, _, err := c.client.Repositories.GetRequiredStatusChecks(ctx, owner, repo, branch)
+	if err != nil {
+		// gh.ErrBranchNotProtected means "this branch legitimately requires
+		// nothing" — that IS a known, empty required set, not a failure to
+		// determine it, so requiredKnown is true with an empty map (every
+		// check is then non-required and ignorable).
+		if errors.Is(err, gh.ErrBranchNotProtected) {
+			return map[string]bool{}, true
+		}
+		return nil, false
+	}
+	if rsc == nil {
+		return map[string]bool{}, true
+	}
+	required := make(map[string]bool)
+	if rsc.Contexts != nil {
+		for _, name := range *rsc.Contexts {
+			required[name] = true
+		}
+	}
+	if rsc.Checks != nil {
+		for _, check := range *rsc.Checks {
+			if check == nil {
+				continue
+			}
+			required[check.Context] = true
+		}
+	}
+	return required, true
 }
 
 func hasLabel(labels []string, want string) bool {

--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -27,9 +27,14 @@ const (
 	autoMergeReasonNoHiveQueueApproval        = "no-hive-queue-approval"
 	autoMergeReasonNoAppBotLogin              = "no-app-bot-login"
 	autoMergeReasonUntrustedQueueApproval     = "untrusted-hive-queue-approval"
+	autoMergeReasonUntrustedMerger            = "untrusted-merger"
+	autoMergeReasonNoMergerAuthz              = "no-merger-authorizer"
 	autoMergeWarnNoAppBotLogin                = "automerge sweep disabled: no GitHub App bot login configured"
 	autoMergeWarnUntrustedQueueApproval       = "rejected untrusted Hive auto-merge queue approval"
+	autoMergeWarnUntrustedMerger              = "rejected Hive auto-merge queued by an untrusted actor"
+	autoMergeWarnNoMergerAuthz                = "automerge sweep disabled: no trusted-merger authorizer configured"
 	autoMergeNoAppBotLoginOperatorRemediation = "Hive has no usable GitHub App, so App-authorship cannot be verified and auto-merge is disabled"
+	autoMergeNoMergerAuthzRemediation         = "Hive cannot classify who queued the merge, so auto-merge is disabled (fail-closed)"
 )
 
 var hiveQueueReviewRE = regexp.MustCompile(`(?i)^Approved by @([A-Za-z0-9-]+) for Hive auto-merge on green CI\.`)
@@ -37,6 +42,49 @@ var hiveQueueReviewRE = regexp.MustCompile(`(?i)^Approved by @([A-Za-z0-9-]+) fo
 type AutoMergeSweepOptions struct {
 	MaxMerges int
 	Audit     func(AutoMergeSweepEvent)
+}
+
+// MergerAuthorizer reports whether login is trusted to QUEUE a merge — i.e.
+// holds at least config.RoleMerger in the hive's authorized-users allowlist.
+//
+// SECURITY (audit F3). The queue-time role check lives in the dashboard handler
+// (requireMergerOrOwnerRole), but the sweep is a SEPARATE authority that runs a
+// minute later off nothing but the label and the App-authored approval body. It
+// re-derives the queuer's login from that body and used to merge on it
+// unconditionally, so anything that could get the merger-queue label applied
+// got its PR merged regardless of who asked. Re-verifying the role HERE is what
+// makes the merger tier real at the point the merge actually happens.
+//
+// Returns false for an unknown/unclassifiable login: a nil authorizer or an
+// unresolvable actor must never merge (fail CLOSED).
+type MergerAuthorizer func(login string) bool
+
+// SetMergerAuthorizer installs the trusted-merger gate consulted by
+// SweepQueuedAutoMerges. nil fails closed — the sweep merges nothing.
+func (c *Client) SetMergerAuthorizer(fn MergerAuthorizer) {
+	if c == nil {
+		return
+	}
+	c.mergerAuthzMu.Lock()
+	defer c.mergerAuthzMu.Unlock()
+	c.mergerAuthz = fn
+}
+
+// isTrustedMerger reports whether login may queue a merge. Fails CLOSED.
+func (c *Client) isTrustedMerger(login string) (allowed, configured bool) {
+	if c == nil {
+		return false, false
+	}
+	c.mergerAuthzMu.RLock()
+	fn := c.mergerAuthz
+	c.mergerAuthzMu.RUnlock()
+	if fn == nil {
+		return false, false
+	}
+	if strings.TrimSpace(login) == "" {
+		return false, true
+	}
+	return fn(login), true
 }
 
 type AutoMergeSweepEvent struct {
@@ -62,8 +110,10 @@ type hiveQueueApproval struct {
 
 // SweepQueuedAutoMerges consumes the configured Hive merger-queue label. It
 // only squashes open, labelled, non-draft PRs in managed repos after GitHub
-// reports them mergeable, commit statuses/check-runs are green, and the latest
-// Hive App-authored queue approval proves the queuer is not the PR author.
+// reports them mergeable, commit statuses/check-runs are green, the latest
+// Hive App-authored queue approval proves the queuer is not the PR author, and
+// the queuer is a TRUSTED merger (audit F3 — see MergerAuthorizer). Without an
+// authorizer installed the sweep fails closed and merges nothing.
 func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepOptions) (*AutoMergeSweepResult, error) {
 	if c == nil {
 		return nil, ErrNoGitHubClient
@@ -75,6 +125,7 @@ func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepO
 	label := c.AutoMergeLabel()
 	result := &AutoMergeSweepResult{}
 	noAppBotLoginWarned := false
+	noMergerAuthzWarned := false
 
 	for _, repo := range c.getRepos() {
 		if len(result.Merged) >= maxMerges {
@@ -103,6 +154,14 @@ func (c *Client) SweepQueuedAutoMerges(ctx context.Context, opts AutoMergeSweepO
 				if !noAppBotLoginWarned {
 					c.warn(autoMergeWarnNoAppBotLogin, "repo", repo, "pr", issue.GetNumber(), "reason", reason, "cause", autoMergeNoAppBotLoginOperatorRemediation)
 					noAppBotLoginWarned = true
+				}
+				result.Skipped++
+				continue
+			}
+			if reason == autoMergeReasonNoMergerAuthz {
+				if !noMergerAuthzWarned {
+					c.warn(autoMergeWarnNoMergerAuthz, "repo", repo, "pr", issue.GetNumber(), "reason", reason, "cause", autoMergeNoMergerAuthzRemediation)
+					noMergerAuthzWarned = true
 				}
 				result.Skipped++
 				continue
@@ -443,6 +502,21 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	queuedBy := approval.QueuedBy
 	if strings.EqualFold(author, queuedBy) {
 		return AutoMergeSweepEvent{}, "self-merge-ban", nil
+	}
+	// SECURITY (audit F3): the self-merge ban above only proves queuer !=
+	// author. It is defeated by a sockpuppet — a second account queues and
+	// approves the first account's work — and on its own it lets ANY actor who
+	// can get the merger-queue label applied merge anything. Re-verify the
+	// merger tier here, at the point the merge actually happens, rather than
+	// trusting the queue-time check in the dashboard handler.
+	trusted, configured := c.isTrustedMerger(queuedBy)
+	if !configured {
+		return AutoMergeSweepEvent{}, autoMergeReasonNoMergerAuthz, nil
+	}
+	if !trusted {
+		c.warn(autoMergeWarnUntrustedMerger, "owner", owner, "repo", repo, "pr", number,
+			"queued_by", queuedBy, "author", author)
+		return AutoMergeSweepEvent{}, autoMergeReasonUntrustedMerger, nil
 	}
 
 	mergeable := mergeableFromState(pr.GetMergeableState(), pr.Mergeable)

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -355,7 +355,11 @@ func TestCommitGreenStatusAndCheckBranches(t *testing.T) {
 			}))
 			defer api.Close()
 			c := newAutoMergeSweepClient(api.URL)
-			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
+			// branch="" means the required-checks set is deliberately
+			// unresolvable here, exercising the fail-closed
+			// isMetaCheck/isIgnorableCICheck allowlist fallback path — see
+			// TestCommitGreenRequiredChecksOnly for the required-set-known path.
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "", "sha")
 			if err != nil {
 				t.Fatalf("commitGreen returned error: %v", err)
 			}
@@ -640,9 +644,206 @@ func TestCommitGreenAPIErrors(t *testing.T) {
 			}))
 			defer api.Close()
 			c := newAutoMergeSweepClient(api.URL)
-			_, reason, err := c.commitGreen(context.Background(), "acme", "widget", "sha")
+			_, reason, err := c.commitGreen(context.Background(), "acme", "widget", "", "sha")
 			if err == nil || reason != tt.wantReason {
 				t.Fatalf("commitGreen reason=%q err=%v, want %q error", reason, err, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestCommitGreenRequiredChecksOnly locks in the required-checks-ONLY gate:
+// commitGreen must consult the branch's actual required status checks
+// (Repositories.GetRequiredStatusChecks) and ignore any check/status whose
+// context is not in that set, no matter its state — this replaces the old
+// hardcoded isMetaCheck/isIgnorableCICheck allowlist that repeatedly missed
+// non-required check names (#22471 "Detect untested files", #22450
+// "Analyze (python)"/CodeQL).
+func TestCommitGreenRequiredChecksOnly(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiredContexts []string
+		statuses         []struct{ context, state string }
+		checks           []struct{ name, status, conclusion string }
+		wantGreen        bool
+		wantReason       string
+	}{
+		{
+			name:             "non-required cancelled check-run never blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Detect untested files", "completed", "cancelled"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "non-required failing check-run (CodeQL) never blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Analyze (python)", "completed", "failure"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "non-required pending check-run never blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Analyze (python)", "in_progress", ""},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "required check pending blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "in_progress", ""},
+			},
+			wantReason: "check-pending",
+		},
+		{
+			name:             "required check failure blocks",
+			requiredContexts: []string{"build-gate"},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "failure"},
+			},
+			wantReason: "check-failure",
+		},
+		{
+			name:             "non-required failing status context never blocks",
+			requiredContexts: []string{"build-gate"},
+			statuses: []struct{ context, state string }{
+				{"ci/legacy-lint", "failure"},
+			},
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:             "required status context failure blocks",
+			requiredContexts: []string{"ci/build"},
+			statuses: []struct{ context, state string }{
+				{"ci/build", "failure"},
+			},
+			wantReason: "status-failure",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/branches/main/protection/required_status_checks":
+					json.NewEncoder(w).Encode(map[string]any{
+						"strict":   true,
+						"contexts": tt.requiredContexts,
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+					statuses := []map[string]string{}
+					combined := "success"
+					for _, s := range tt.statuses {
+						statuses = append(statuses, map[string]string{"context": s.context, "state": s.state})
+						if s.state != "success" {
+							combined = s.state
+						}
+					}
+					json.NewEncoder(w).Encode(map[string]any{"state": combined, "total_count": len(statuses), "statuses": statuses})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+					runs := []map[string]string{}
+					for _, c := range tt.checks {
+						runs = append(runs, map[string]string{"name": c.name, "status": c.status, "conclusion": c.conclusion})
+					}
+					json.NewEncoder(w).Encode(map[string]any{"total_count": len(runs), "check_runs": runs})
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := newAutoMergeSweepClient(api.URL)
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "main", "sha")
+			if err != nil {
+				t.Fatalf("commitGreen returned error: %v", err)
+			}
+			if green != tt.wantGreen || reason != tt.wantReason {
+				t.Fatalf("commitGreen = (%v,%q), want (%v,%q)", green, reason, tt.wantGreen, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestCommitGreenRequiredChecksUnavailableFallsBack locks in the fail-closed
+// fallback: when the required-checks set cannot be determined, commitGreen
+// must NOT treat every check as ignorable — it falls back to the old
+// isMetaCheck/isIgnorableCICheck allowlist rather than merging over
+// everything.
+func TestCommitGreenRequiredChecksUnavailableFallsBack(t *testing.T) {
+	tests := []struct {
+		name           string
+		protectionCode int // HTTP status GetRequiredStatusChecks returns; 0 = branch-not-protected message
+		checks         []struct{ name, status, conclusion string }
+		wantGreen      bool
+		wantReason     string
+	}{
+		{
+			name:           "branch protection API error falls back to allowlist and still blocks unknown failing check",
+			protectionCode: http.StatusInternalServerError,
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"some-custom-check", "completed", "failure"},
+			},
+			wantReason: "check-failure",
+		},
+		{
+			name:           "branch protection API error still allows fallback allowlist (Playwright) to pass",
+			protectionCode: http.StatusInternalServerError,
+			checks: []struct{ name, status, conclusion string }{
+				{"build-gate", "completed", "success"},
+				{"Playwright", "completed", "cancelled"},
+			},
+			wantGreen: true,
+		},
+		{
+			name:           "unprotected branch (no required checks) is a known empty set, everything ignorable",
+			protectionCode: 0,
+			checks: []struct{ name, status, conclusion string }{
+				{"anything", "completed", "failure"},
+			},
+			wantGreen: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/branches/main/protection/required_status_checks":
+					if tt.protectionCode == 0 {
+						w.WriteHeader(http.StatusNotFound)
+						json.NewEncoder(w).Encode(map[string]any{"message": "Branch not protected"})
+						return
+					}
+					http.Error(w, "boom", tt.protectionCode)
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/status":
+					json.NewEncoder(w).Encode(map[string]any{"state": "success", "total_count": 0})
+				case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/commits/sha/check-runs":
+					runs := []map[string]string{}
+					for _, c := range tt.checks {
+						runs = append(runs, map[string]string{"name": c.name, "status": c.status, "conclusion": c.conclusion})
+					}
+					json.NewEncoder(w).Encode(map[string]any{"total_count": len(runs), "check_runs": runs})
+				default:
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer api.Close()
+			c := newAutoMergeSweepClient(api.URL)
+			green, reason, err := c.commitGreen(context.Background(), "acme", "widget", "main", "sha")
+			if err != nil {
+				t.Fatalf("commitGreen returned error: %v", err)
+			}
+			if green != tt.wantGreen || reason != tt.wantReason {
+				t.Fatalf("commitGreen = (%v,%q), want (%v,%q)", green, reason, tt.wantGreen, tt.wantReason)
 			}
 		})
 	}

--- a/v2/pkg/github/automerge_sweep_test.go
+++ b/v2/pkg/github/automerge_sweep_test.go
@@ -1142,9 +1142,22 @@ func TestStartSelfAuthoredAutoMergeSweepNilClient(t *testing.T) {
 	nilClient.StartSelfAuthoredAutoMergeSweep(context.Background(), 0, true, &l6)
 }
 
+// testTrustedMergers are the logins the sweep fixtures treat as holding the
+// merger tier. "bob" is the queuer in every fixture that is EXPECTED to merge,
+// so granting it here preserves each existing test's original intent (a
+// legitimate queued merge lands) now that the sweep enforces the trusted-merger
+// gate (audit F3). Anyone NOT listed is untrusted and must not merge.
+var testTrustedMergers = map[string]bool{"bob": true, "carol": true}
+
 func newAutoMergeSweepClient(apiURL string) *Client {
 	c := NewClient("token", "acme", []string{"widget"}, nil, apiURL)
 	c.SetAppBotLogin(testHiveAppBotLogin)
+	// Audit F3: the sweep fails CLOSED without an authorizer, so every test
+	// exercising the merge path must install one. Tests that assert the
+	// fail-closed behaviour itself build their client without this helper.
+	c.SetMergerAuthorizer(func(login string) bool {
+		return testTrustedMergers[strings.ToLower(strings.TrimSpace(login))]
+	})
 	return c
 }
 

--- a/v2/pkg/github/automerge_sweep_trusted_merger_test.go
+++ b/v2/pkg/github/automerge_sweep_trusted_merger_test.go
@@ -1,0 +1,184 @@
+package github
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Audit F3: the label-queued auto-merge sweep had NO trusted-merger check.
+// trySweepQueuedPR proved only that the queuer was not the PR author
+// (self-merge ban), so anything that could get the merger-queue label applied
+// had its PR merged regardless of WHO asked, and a sockpuppet pair (author A,
+// queuer B, neither trusted) defeated the ban outright. These tests pin the
+// tier gate at the point the merge actually happens.
+//
+// The sweep is LIVE on v4: cmd/hive/main.go calls SweepQueuedAutoMerges from
+// runAutoMergeSweepIfDue off the governor eval tick.
+
+// greenQueuedPR is a PR that passes every gate EXCEPT whatever the test varies.
+func greenQueuedPR(number int, author, queuedBy string) sweepPR {
+	return sweepPR{
+		number:          number,
+		author:          author,
+		queuedBy:        queuedBy,
+		label:           true,
+		mergeableState:  "clean",
+		statusState:     "success",
+		checkStatus:     "completed",
+		checkConclusion: "success",
+	}
+}
+
+// newUngatedSweepClient builds a sweep client with NO merger authorizer — the
+// pre-fix shape, used to assert the fail-closed default.
+func newUngatedSweepClient(apiURL string) *Client {
+	c := NewClient("token", "acme", []string{"widget"}, nil, apiURL)
+	c.SetAppBotLogin(testHiveAppBotLogin)
+	return c
+}
+
+// TestF3_TrustedMergerMergesGreenQueuedPR is the POSITIVE CONTROL: a merger-tier
+// actor queuing someone else's green PR must still merge. A gate that blocked
+// this would be worthless.
+func TestF3_TrustedMergerMergesGreenQueuedPR(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "bob")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 1 || len(merged) != 1 || merged[0] != 7 {
+		t.Fatalf("merged result=%v merge calls=%v, want PR 7 merged by trusted merger bob", result.Merged, merged)
+	}
+}
+
+// TestF3_UntrustedMergerDoesNotMerge is the core regression: an actor with no
+// merger tier must not be able to merge, even though every other gate is green
+// and the self-merge ban is satisfied.
+func TestF3_UntrustedMergerDoesNotMerge(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "mallory")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want untrusted queuer mallory REFUSED (F3 regression)", result.Merged, merged)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", result.Skipped)
+	}
+}
+
+// TestF3_SockpuppetPairDoesNotMerge covers the case the self-merge ban cannot
+// see: two DISTINCT untrusted accounts, so author != queuer and the ban passes,
+// but neither holds the merger tier.
+func TestF3_SockpuppetPairDoesNotMerge(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "mallory", "mallory-alt")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want sockpuppet pair REFUSED (F3 regression)", result.Merged, merged)
+	}
+}
+
+// TestF3_SelfMergeBanStillHolds proves the earlier fix (#3413) is intact: a
+// TRUSTED merger still cannot merge their OWN PR. Trust must not become a
+// bypass of the self-merge ban.
+func TestF3_SelfMergeBanStillHolds(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "bob", "BOB")}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want trusted merger BLOCKED from self-merge", result.Merged, merged)
+	}
+}
+
+// TestF3_NoAuthorizerFailsClosed pins the fail-closed default: with no
+// authorizer installed, an unclassifiable actor must NOT merge.
+func TestF3_NoAuthorizerFailsClosed(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "bob")}, &merged)
+	defer api.Close()
+
+	c := newUngatedSweepClient(api.URL)
+	result, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{})
+	if err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(result.Merged) != 0 || len(merged) != 0 {
+		t.Fatalf("merged result=%v merge calls=%v, want fail-CLOSED with no authorizer", result.Merged, merged)
+	}
+}
+
+// TestF3_TrySweepQueuedPRReportsUntrustedReason pins the skip reasons so the
+// operator can tell an untrusted queuer apart from an unconfigured hive.
+func TestF3_TrySweepQueuedPRReportsUntrustedReason(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{greenQueuedPR(7, "alice", "mallory")}, &merged)
+	defer api.Close()
+
+	gated := newAutoMergeSweepClient(api.URL)
+	_, reason, err := gated.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
+	if err != nil {
+		t.Fatalf("trySweepQueuedPR returned error: %v", err)
+	}
+	if reason != autoMergeReasonUntrustedMerger {
+		t.Fatalf("reason = %q, want %q", reason, autoMergeReasonUntrustedMerger)
+	}
+
+	ungated := newUngatedSweepClient(api.URL)
+	_, reason, err = ungated.trySweepQueuedPR(context.Background(), "widget", "acme", "widget", 7, AutoMergeQueuedLabel)
+	if err != nil {
+		t.Fatalf("trySweepQueuedPR returned error: %v", err)
+	}
+	if reason != autoMergeReasonNoMergerAuthz {
+		t.Fatalf("reason = %q, want %q", reason, autoMergeReasonNoMergerAuthz)
+	}
+}
+
+// TestF3_IsTrustedMergerFailsClosedOnEdgeCases covers the helper directly.
+func TestF3_IsTrustedMergerFailsClosedOnEdgeCases(t *testing.T) {
+	var nilClient *Client
+	if allowed, configured := nilClient.isTrustedMerger("bob"); allowed || configured {
+		t.Fatalf("nil client = (%v,%v), want (false,false)", allowed, configured)
+	}
+
+	c := NewClient("token", "acme", []string{"widget"}, nil, "")
+	if allowed, configured := c.isTrustedMerger("bob"); allowed || configured {
+		t.Fatalf("no authorizer = (%v,%v), want (false,false)", allowed, configured)
+	}
+
+	c.SetMergerAuthorizer(func(login string) bool {
+		return strings.EqualFold(login, "bob")
+	})
+	// An empty login must never be trusted, even with an authorizer installed.
+	if allowed, configured := c.isTrustedMerger("   "); allowed || !configured {
+		t.Fatalf("blank login = (%v,%v), want (false,true)", allowed, configured)
+	}
+	if allowed, _ := c.isTrustedMerger("bob"); !allowed {
+		t.Fatal("bob should be trusted")
+	}
+	if allowed, _ := c.isTrustedMerger("mallory"); allowed {
+		t.Fatal("mallory must not be trusted")
+	}
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -62,6 +62,13 @@ type Client struct {
 	// MergeRequestAuthorizer / F4). nil fails closed. Set by
 	// StartMergeRequestWatcher.
 	mergeAuthz MergeRequestAuthorizer
+	// mergerAuthz gates the label-queued auto-merge sweep on WHO queued the
+	// merge: it reports whether a login holds at least config.RoleMerger (audit
+	// F3). nil fails closed — SweepQueuedAutoMerges merges nothing. Guarded
+	// because config reload re-installs it while the sweep goroutine reads it.
+	// Set by SetMergerAuthorizer.
+	mergerAuthzMu sync.RWMutex
+	mergerAuthz   MergerAuthorizer
 	// mergeReEngage is Fix #2's re-engagement hook. When a merge attempt fails
 	// terminally BECAUSE a required check failed (not a true conflict or a
 	// permission error), the watcher calls this instead of silently abandoning

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -1101,6 +1101,30 @@ func (c *Client) GetFileContentRef(ctx context.Context, owner, repo, path, ref s
 	return content, nil
 }
 
+// PathExistsAtRef reports whether path exists in owner/repo at the given git ref
+// (branch, tag, or commit SHA). It is used by the advisory digest to verify that
+// a finding's file reference still exists at the pinned analysis commit (#3704),
+// so a stale path (e.g. a since-removed "docs/install.md") is not cited as if it
+// were live. A 404 means "does not exist"; any other error is returned so the
+// caller can decide how to treat an inconclusive check.
+func (c *Client) PathExistsAtRef(ctx context.Context, owner, repo, path, ref string) (bool, error) {
+	if c == nil {
+		return false, ErrNoGitHubClient
+	}
+	var opts *gh.RepositoryContentGetOptions
+	if ref != "" {
+		opts = &gh.RepositoryContentGetOptions{Ref: ref}
+	}
+	fileContent, dirContent, resp, err := c.client.Repositories.GetContents(ctx, owner, repo, path, opts)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking %s/%s/%s@%s: %w", owner, repo, path, ref, err)
+	}
+	return fileContent != nil || len(dirContent) > 0, nil
+}
+
 // SearchPRCount searches GitHub for PRs by author within an org.
 // state is "open" or "merged".
 func (c *Client) SearchPRCount(ctx context.Context, author, org, state string) (int, error) {

--- a/v2/pkg/hub/csrf_f4_fail_closed_test.go
+++ b/v2/pkg/hub/csrf_f4_fail_closed_test.go
@@ -1,0 +1,235 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// AUDIT F4 (replay half): isCSRFSafe used to fail OPEN.
+//
+// The old final line was `return strings.Contains(ct, "application/json")`, so a
+// mutation with NO Origin and NO Referer was accepted as long as it claimed a
+// JSON Content-Type. Content-Type is attacker-controlled and proves nothing
+// about the caller, and a missing Origin/Referer is not evidence of a
+// non-browser client — Referrer-Policy: no-referrer, privacy extensions and
+// corporate proxies strip these routinely. The check now fails CLOSED.
+//
+// The tests below come in matched pairs. Each "must be refused" case is paired
+// with a "must still succeed" positive control, because a check that simply
+// returned false for every mutation would satisfy every regression here while
+// breaking the entire dashboard.
+//
+// NOTE on the existing suite: TestIsCSRFSafe in hub_test.go carried a case
+// asserting `{"POST with JSON content-type", "POST", "", "application/json",
+// true}`. That was the vulnerability written down as an expectation, so it was
+// INVERTED to `false` rather than deleted or relaxed.
+
+const f4TrustedOrigin = "https://hive.kubestellar.io"
+
+// TestF4HeaderlessJSONMutationIsRefused is the core regression.
+func TestF4HeaderlessJSONMutationIsRefused(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			if isCSRFSafe(req) {
+				t.Errorf("%s with a JSON Content-Type and no Origin/Referer was accepted; "+
+					"CSRF must fail closed (F4)", method)
+			}
+		})
+	}
+}
+
+// TestF4ContentTypeAloneNeverRescues: no Content-Type value is a substitute for
+// origin information. Pinned across the shapes an attacker would reach for,
+// including the ones a cross-site form POST can natively produce.
+func TestF4ContentTypeAloneNeverRescues(t *testing.T) {
+	for _, ct := range []string{
+		"application/json",
+		"application/json; charset=utf-8",
+		"APPLICATION/JSON",
+		"text/plain",
+		"application/x-www-form-urlencoded",
+		"multipart/form-data",
+		"",
+	} {
+		req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+		if ct != "" {
+			req.Header.Set("Content-Type", ct)
+		}
+		if isCSRFSafe(req) {
+			t.Errorf("POST with Content-Type %q and no Origin/Referer was accepted (F4)", ct)
+		}
+	}
+}
+
+// TestF4SameOriginMutationStillSucceeds is the POSITIVE CONTROL for the whole
+// finding. A legitimate dashboard mutation — the exact request the real UI
+// sends — must still pass. Without this, "reject every mutation" would satisfy
+// every regression above.
+func TestF4SameOriginMutationStillSucceeds(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		t.Run(method+"/Origin", func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Origin", f4TrustedOrigin)
+			if !isCSRFSafe(req) {
+				t.Errorf("legitimate same-origin %s was REFUSED — the fix is too strict "+
+					"and would break the dashboard", method)
+			}
+		})
+		t.Run(method+"/Referer", func(t *testing.T) {
+			// Origin absent but Referer present is a real browser shape.
+			req := httptest.NewRequest(method, "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Referer", f4TrustedOrigin+"/dashboard")
+			if !isCSRFSafe(req) {
+				t.Errorf("legitimate same-origin %s via Referer was REFUSED", method)
+			}
+		})
+	}
+	// Safe methods are untouched.
+	for _, method := range []string{"GET", "HEAD", "OPTIONS"} {
+		req := httptest.NewRequest(method, "/api/saas/my-hives", nil)
+		if !isCSRFSafe(req) {
+			t.Errorf("%s must remain safe", method)
+		}
+	}
+}
+
+// TestF4HostileOriginStillRefused: the exact-origin half of F4 (already fixed)
+// must not regress. A sibling tenant receives the parent-domain session cookie
+// and is therefore the most important hostile origin here.
+func TestF4HostileOriginStillRefused(t *testing.T) {
+	for _, origin := range []string{
+		"https://evil.com",
+		"https://hive.kubestellar.io.evil.com",
+		"https://attacker-hive.hive.kubestellar.io", // sibling tenant
+		"https://evil-hive.kubestellar.io",
+		"://invalid",
+		// NOT asserted here: "http://hive.kubestellar.io". isSameOriginAsHub
+		// matches on HOST only and deliberately accepts localhost/127.0.0.1 for
+		// local development, so it is scheme-agnostic by design. A scheme
+		// downgrade on the real hub host is unreachable in practice (HSTS + the
+		// Secure cookie), and tightening it is a separate change with its own
+		// dev-flow blast radius — deliberately out of scope for F4 rather than
+		// bundled in silently.
+	} {
+		req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Origin", origin)
+		if isCSRFSafe(req) {
+			t.Errorf("hostile Origin %q was accepted", origin)
+		}
+	}
+}
+
+// TestF4BearerLaneIsTheExplicitNonBrowserPath: a non-browser API client
+// authenticating with a bearer token and NO session cookie is allowed through,
+// because it carries no ambient credential and so cannot be cross-site forged.
+// This is the escape hatch that makes failing closed viable.
+func TestF4BearerLaneIsTheExplicitNonBrowserPath(t *testing.T) {
+	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer gho_sometoken")
+	if !isCSRFSafe(req) {
+		t.Error("a bearer-authenticated request with no session cookie must be allowed; " +
+			"it carries no ambient credential and cannot be CSRF'd")
+	}
+}
+
+// TestF4BearerDoesNotBypassWhenCookiePresent is the important half of the bearer
+// lane, and the one that would be easy to get wrong. If merely ADDING a header
+// let a cookie-bearing request skip the CSRF check, the fix would be worthless:
+// the ambient credential is still in play and is still what the server would
+// authenticate with.
+func TestF4BearerDoesNotBypassWhenCookiePresent(t *testing.T) {
+	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer gho_sometoken")
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "some-session-value"})
+	if isCSRFSafe(req) {
+		t.Error("a request carrying the ambient session cookie must prove its Origin " +
+			"even when it also sends a bearer token (F4)")
+	}
+
+	// Even a junk cookie value counts — "browser sent a cookie" is the signal,
+	// not "the cookie is valid". Otherwise the bypass condition is trivially
+	// satisfiable by sending a garbage cookie.
+	req2 := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req2.Header.Set("Authorization", "Bearer gho_sometoken")
+	req2.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "not-a-valid-cookie"})
+	if isCSRFSafe(req2) {
+		t.Error("an invalid session cookie must not re-enable the bearer bypass")
+	}
+
+	// A non-bearer Authorization scheme is not the API lane either.
+	req3 := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+	req3.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	if isCSRFSafe(req3) {
+		t.Error("a non-Bearer Authorization header must not pass the CSRF gate")
+	}
+}
+
+// TestF4RequireAuthAndRequireAdminBothEnforce pins that the check is actually
+// WIRED — a correct isCSRFSafe that no middleware calls protects nothing. An
+// earlier audit found ~21 admin routes with no CSRF check at all; both
+// middlewares must enforce it, and both must enforce it BEFORE resolving
+// identity so a forged request never reaches the impersonation logic.
+func TestF4RequireAuthAndRequireAdminBothEnforce(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "alice")
+
+	for _, tc := range []struct {
+		name string
+		wrap func(http.HandlerFunc) http.HandlerFunc
+		user string
+	}{
+		{"requireAuth", s.requireAuth, "alice"},
+		{"requireAdmin", s.requireAdmin, hubAdminUsername},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			h := tc.wrap(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Headerless JSON mutation with a VALID session cookie — the CSRF
+			// scenario exactly. Must be refused, handler never reached.
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(testAuthCookie(tc.user))
+			h(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("headerless mutation status = %d, want 403", rec.Code)
+			}
+			if called {
+				t.Error("handler ran on a request that failed the CSRF check")
+			}
+			if !strings.Contains(rec.Body.String(), "CSRF") {
+				t.Errorf("body = %q, want a CSRF refusal", rec.Body.String())
+			}
+
+			// POSITIVE CONTROL: same request, same user, WITH a legitimate
+			// same-origin header — must reach the handler.
+			called = false
+			rec = httptest.NewRecorder()
+			ok := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
+			ok.Header.Set("Content-Type", "application/json")
+			ok.Header.Set("Origin", f4TrustedOrigin)
+			ok.AddCookie(testAuthCookie(tc.user))
+			h(rec, ok)
+			if rec.Code != http.StatusOK || !called {
+				t.Errorf("legitimate same-origin mutation: status=%d called=%v; want 200 + handler run",
+					rec.Code, called)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/forge_test.go
+++ b/v2/pkg/hub/forge_test.go
@@ -324,7 +324,7 @@ func postForgeSwitch(t *testing.T, s *HubServer, hiveID, username, body string) 
 	if username != "" {
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(deriveDomainKey(forgeTestSecret, infoSessionKey), username),
+			Value: mintHubUserCookieValueV2(deriveDomainKey(forgeTestSecret, infoSessionEd25519Seed), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/grantable_users_test.go
+++ b/v2/pkg/hub/grantable_users_test.go
@@ -54,7 +54,7 @@ func getGrantableUsers(t *testing.T, s *HubServer, username string) *httptest.Re
 		// key the hub verifies session cookies with.
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(deriveDomainKey(grantableTestSecret, infoSessionKey), username),
+			Value: mintHubUserCookieValueV2(deriveDomainKey(grantableTestSecret, infoSessionEd25519Seed), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/heartbeat_selfderive_test.go
+++ b/v2/pkg/hub/heartbeat_selfderive_test.go
@@ -1,0 +1,153 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// F2: the fleet-wide heartbeat bearer lane in verifyHeartbeatBearer does not
+// bind identity, so any spoke can beat as any victim hive. Removing it requires
+// that every spoke first present the per-hive bearer — historically blocked on
+// "re-provision the fleet", which the operator has ruled out.
+//
+// These tests pin the property that makes an IN-PLACE cutover possible: the
+// per-hive bearer is HMAC(master, info || 0x00 || hiveID), a pure function of
+// material the spoke ALREADY HOLDS (HIVE_HUB_SECRET + HIVE_ID). A spoke can
+// therefore migrate itself by rolling code, with no hub action and no
+// re-provision.
+
+// TestSpokeHeartbeatKeySelfDerivesPerHive is the F2 enabling property: a spoke
+// holding the master and its own hive ID — but NO injected HIVE_HEARTBEAT_KEY —
+// presents the identity-bound bearer rather than the fleet-wide one.
+//
+// This is exactly the configuration of the 3 live spokes measured with
+// HIVE_HEARTBEAT_KEY absent. Before this change they presented the fleet-wide
+// bearer and were the sole reason the legacy lane could not be deleted.
+func TestSpokeHeartbeatKeySelfDerivesPerHive(t *testing.T) {
+	const master = "test-master-secret-f2"
+	const hiveID = "hive-alpha"
+
+	t.Setenv("HIVE_HUB_SECRET", master)
+	t.Setenv(EnvHeartbeatKey, "") // not injected — the laggard configuration
+	t.Setenv(EnvHiveID, hiveID)
+
+	got := SpokeHeartbeatKey()
+
+	perHive := derivePerHiveKey(master, infoHeartbeatKey, hiveID)
+	fleetWide := deriveDomainKey(master, infoHeartbeatKey)
+
+	if got == fleetWide {
+		t.Fatal("F2: spoke still presents the FLEET-WIDE bearer despite holding both " +
+			"the master and its own hive ID — the legacy lane could never be deleted " +
+			"without re-provisioning")
+	}
+	if got != perHive {
+		t.Fatalf("spoke bearer = %q, want the self-derived per-hive value %q", got, perHive)
+	}
+
+	// And the hub accepts it as identity-bound, without any provisioning step.
+	s := &HubServer{logger: slog.Default(), hubSecret: master}
+	if !s.verifyHeartbeatBearer(got, hiveID) {
+		t.Fatal("hub rejected the self-derived per-hive bearer — the in-place migration " +
+			"would 401 the spoke")
+	}
+	if !s.heartbeatBearerIsPerHive(got, hiveID) {
+		t.Fatal("self-derived bearer not reported as per-hive — rollout telemetry would " +
+			"never reach 100% and the deletion precondition could not be met")
+	}
+}
+
+// TestSpokeSelfDerivedBearerCannotImpersonateAnotherHive is the finding itself,
+// asserted end-to-end through the spoke-side resolver: the bearer a spoke
+// self-derives must authenticate ONLY that spoke.
+//
+// Without this, self-derivation could "succeed" while still handing out a
+// credential that works fleet-wide — migrating the telemetry but not the
+// vulnerability.
+func TestSpokeSelfDerivedBearerCannotImpersonateAnotherHive(t *testing.T) {
+	const master = "test-master-secret-f2"
+
+	t.Setenv("HIVE_HUB_SECRET", master)
+	t.Setenv(EnvHeartbeatKey, "")
+
+	t.Setenv(EnvHiveID, "hive-attacker")
+	attackerBearer := SpokeHeartbeatKey()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: master}
+
+	// Positive control: the attacker CAN still beat as itself. Without this a
+	// resolver that returned garbage for everything would pass the check below.
+	if !s.verifyHeartbeatBearer(attackerBearer, "hive-attacker") {
+		t.Fatal("positive control failed: a spoke could not authenticate as ITSELF, so " +
+			"the rejection below proves nothing")
+	}
+
+	// The finding: it must NOT beat as the victim.
+	if s.verifyHeartbeatBearer(attackerBearer, "hive-victim") {
+		t.Fatal("F2: a self-derived bearer authenticated a heartbeat CLAIMING to be " +
+			"another hive — the victim's key material would be delivered to the attacker")
+	}
+}
+
+// TestSpokeInjectedKeyStillWinsOverSelfDerivation guards the ordering. 62 of 65
+// live spokes already hold a hub-injected per-hive HIVE_HEARTBEAT_KEY; if
+// self-derivation silently overrode it, a self-hosted spoke whose operator
+// deliberately pinned a bearer would start presenting a different value and
+// break. The injected value must remain authoritative.
+func TestSpokeInjectedKeyStillWinsOverSelfDerivation(t *testing.T) {
+	t.Setenv("HIVE_HUB_SECRET", "test-master-secret-f2")
+	t.Setenv(EnvHiveID, "hive-alpha")
+	t.Setenv(EnvHeartbeatKey, "explicitly-injected-bearer")
+
+	if got := SpokeHeartbeatKey(); got != "explicitly-injected-bearer" {
+		t.Fatalf("injected bearer = %q, want it to take precedence over self-derivation", got)
+	}
+}
+
+// TestSpokeSelfDerivationRequiresBothInputs pins the fail-closed edges: with no
+// master there is no bearer at all, and with no identity the spoke falls back to
+// the fleet-wide value rather than deriving something empty or attacker-chosen.
+func TestSpokeSelfDerivationRequiresBothInputs(t *testing.T) {
+	const master = "test-master-secret-f2"
+
+	// No master at all → no bearer. The spoke must fail closed, not present "".
+	t.Setenv("HIVE_HUB_SECRET", "")
+	t.Setenv(EnvHeartbeatKey, "")
+	t.Setenv(EnvHiveID, "hive-alpha")
+	if got := SpokeHeartbeatKey(); got != "" {
+		t.Fatalf("with no master, spoke bearer = %q, want \"\" (fail closed)", got)
+	}
+
+	// Master but no identity → fleet-wide fallback, explicitly. This lane is what
+	// the final deletion PR removes support for; it must be reachable ONLY here.
+	t.Setenv("HIVE_HUB_SECRET", master)
+	t.Setenv(EnvHiveID, "")
+	if got, want := SpokeHeartbeatKey(), deriveDomainKey(master, infoHeartbeatKey); got != want {
+		t.Fatalf("with no hive ID, spoke bearer = %q, want the fleet-wide value %q", got, want)
+	}
+}
+
+// TestFleetWideBearerStillAcceptedAtThisStage asserts the CURRENT stage
+// explicitly, so the cutover status is unambiguous in the test suite rather than
+// inferred. This PR does NOT delete the legacy lane — a spoke that has not yet
+// rolled the self-derivation code still presents the fleet-wide bearer, and
+// dropping it now would 401 those spokes.
+//
+// The deletion PR flips this test to assert rejection. If it starts failing
+// because the lane was removed, that is the signal to check the precondition in
+// AuthRolloutReadiness (heartbeat_lane_ready, 65/65) before flipping it.
+func TestFleetWideBearerStillAcceptedAtThisStage(t *testing.T) {
+	s := &HubServer{logger: slog.Default(), hubSecret: "test-master-secret-f2"}
+
+	if !s.verifyHeartbeatBearer(s.heartbeatKey(), "hive-alpha") {
+		t.Fatal("the fleet-wide lane was removed — every spoke that has not yet rolled " +
+			"the self-derivation change will 401. Confirm AuthRolloutReadiness reports " +
+			"heartbeat_lane_ready with 0 legacy hives before making this change.")
+	}
+	// It is still correctly flagged as NOT identity-bound, which is what drives
+	// the readiness signal that gates the deletion.
+	if s.heartbeatBearerIsPerHive(s.heartbeatKey(), "hive-alpha") {
+		t.Fatal("fleet-wide bearer misreported as per-hive — readiness would read 100% " +
+			"while spokes are still unbound, and the deletion would be made on false evidence")
+	}
+}

--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -394,7 +394,20 @@ func verifyHubUserCookieEitherAt(pubHex, legacySecret, value string, now time.Ti
 	if u, ok := verifyHubUserCookieValueV2(pubHex, value); ok {
 		return u, true
 	}
-	return verifyHubUserCookieValue(legacySecret, value)
+	// AUDIT F1 (Critical, open across four audits): the legacy symmetric lane is
+	// GONE. It verified the cookie against HIVE_SESSION_KEY, which provisioning
+	// injects byte-identically into every spoke — so any spoke operator could mint
+	// "username.HMAC(username)" and be accepted as a hub admin on ~21 admin routes.
+	//
+	// It survived four audits only because cutting it would have broken v2 spokes
+	// mid-rollout. The whole fleet now runs v4 and production mints V2/Ed25519
+	// (oauth.go mintSessionCookies), so the compatibility argument is void and the
+	// lane is deleted rather than deprecated. legacySecret is retained in the
+	// signature but is deliberately unused: callers still pass it, and accepting
+	// and ignoring it is safer than a signature change that a merge could
+	// mis-resolve into re-enabling the lane.
+	_ = legacySecret
+	return "", false
 }
 
 // hubCookieIsV3 reports whether a cookie value carries the F10 format. Rollout

--- a/v2/pkg/hub/hub_cookie_f1_legacy_lane_test.go
+++ b/v2/pkg/hub/hub_cookie_f1_legacy_lane_test.go
@@ -1,0 +1,88 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Audit F1 (Critical, open across four audits). The hub session cookie used to
+// fall back to a symmetric HMAC lane keyed on HIVE_SESSION_KEY. Provisioning
+// injects that key byte-identically into EVERY spoke, so any spoke operator
+// could mint "username.HMAC(username)" and be accepted as a hub admin on ~21
+// admin routes. The lane is now deleted.
+//
+// These tests pin the deletion. The forgery case is the regression; the V2/V3
+// cases are the positive control — without them, a verifier that rejected
+// everything would "pass" while breaking all sign-in.
+
+const f1TestLegacySecret = "spoke-held-symmetric-session-key"
+
+// TestF1LegacyHMACCookieIsRejected is the regression: a cookie minted with the
+// fleet-shared symmetric key must NOT authenticate, even when the verifier is
+// handed that exact key as legacySecret.
+func TestF1LegacyHMACCookieIsRejected(t *testing.T) {
+	forged := mintHubUserCookieValue(f1TestLegacySecret, "clubanderson")
+	if forged == "" {
+		t.Fatal("precondition: could not mint a legacy cookie to forge with")
+	}
+
+	seed := deriveDomainKey("test-master-for-f1", infoSessionEd25519Seed)
+	pub := ssoPublicKeyFromSeed(seed)
+
+	if user, ok := verifyHubUserCookieEitherAt(pub, f1TestLegacySecret, forged, time.Now(), nil); ok {
+		t.Fatalf("legacy symmetric cookie was ACCEPTED as %q — any spoke holding "+
+			"HIVE_SESSION_KEY can forge hub admin (audit F1)", user)
+	}
+}
+
+// TestF1LegacyLaneRejectsEvenTheCorrectSecret removes the last doubt: it is the
+// LANE that is gone, not merely a key mismatch. Verifying with the same secret
+// the cookie was minted under must still fail.
+func TestF1LegacyLaneRejectsEvenTheCorrectSecret(t *testing.T) {
+	value := mintHubUserCookieValue(f1TestLegacySecret, "alice")
+	if _, ok := verifyHubUserCookieValue(f1TestLegacySecret, value); !ok {
+		t.Fatal("precondition: the legacy primitive itself should still verify its own output")
+	}
+	if _, ok := verifyHubUserCookieEitherAt("", f1TestLegacySecret, value, time.Now(), nil); ok {
+		t.Error("the legacy lane is still reachable through verifyHubUserCookieEitherAt")
+	}
+}
+
+// TestF1V2CookieStillVerifies is the positive control for the asymmetric lane
+// production actually mints (oauth.go mintSessionCookies).
+func TestF1V2CookieStillVerifies(t *testing.T) {
+	seed := deriveDomainKey("test-master-for-f1", infoSessionEd25519Seed)
+	pub := ssoPublicKeyFromSeed(seed)
+
+	value := mintHubUserCookieValueV2(seed, "alice")
+	if value == "" {
+		t.Fatal("precondition: could not mint a V2 cookie")
+	}
+	user, ok := verifyHubUserCookieEitherAt(pub, f1TestLegacySecret, value, time.Now(), nil)
+	if !ok {
+		t.Fatal("a V2 (Ed25519) cookie must still verify — this is what production mints")
+	}
+	if user != "alice" {
+		t.Errorf("V2 cookie verified as %q, want alice", user)
+	}
+}
+
+// TestF1V3CookieStillVerifies is the same control for the revocable V3 format,
+// so deleting the legacy lane cannot be mistaken for "cookies are broken".
+func TestF1V3CookieStillVerifies(t *testing.T) {
+	seed := deriveDomainKey("test-master-for-f1", infoSessionEd25519Seed)
+	pub := ssoPublicKeyFromSeed(seed)
+	now := time.Now()
+
+	value, sid := mintHubUserCookieValueV3(seed, "bob", now, time.Hour)
+	if value == "" || sid == "" {
+		t.Fatal("precondition: could not mint a V3 cookie")
+	}
+	user, ok := verifyHubUserCookieEitherAt(pub, f1TestLegacySecret, value, now, nil)
+	if !ok {
+		t.Fatal("a V3 cookie must still verify")
+	}
+	if user != "bob" {
+		t.Errorf("V3 cookie verified as %q, want bob", user)
+	}
+}

--- a/v2/pkg/hub/hub_cookie_v3_test.go
+++ b/v2/pkg/hub/hub_cookie_v3_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"encoding/json"
 	"log/slog"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,18 +269,44 @@ func TestF10_EitherLaneIsAdditive(t *testing.T) {
 	}
 }
 
-// TestF10_MintingHasNotFlipped is the anti-outage assertion. This PR ships the
-// VERIFIER only. If someone flips the minter to v3 before the whole fleet
-// verifies v3, /terminal breaks fleet-wide (incident #2773). This test is the
-// tripwire — when minting legitimately flips, this test is updated in the SAME
-// PR, which forces the change to be seen.
-func TestF10_MintingHasNotFlipped(t *testing.T) {
-	value := mintHubUserCookieValueV2(f10TestSeed, "alice")
-	if hubCookieIsV3(value) {
-		t.Fatal("the production minter now emits v3 — do not land this until every spoke verifies v3")
+// TestF10_MintingHasFlippedToV3 — INVERTED, by this test's own instructions.
+//
+// It was TestF10_MintingHasNotFlipped, the anti-outage tripwire for the PR that
+// shipped the v3 VERIFIER only: flipping the minter before the whole fleet
+// verified v3 would have broken /terminal fleet-wide (incident #2773). Its
+// comment said "when minting legitimately flips, this test is updated in the
+// SAME PR, which forces the change to be seen." This is that PR. The fleet is
+// v4 and v2/proxy/server.js verifies v3 → v2 → legacy, so the precondition is
+// met and the tripwire becomes its opposite: a guard that minting does not
+// silently fall BACK to the non-revocable format.
+//
+// Note it also had a real defect worth not reproducing: it called
+// mintHubUserCookieValueV2 directly, so it asserted what that function does,
+// not what PRODUCTION mints — it could never have detected the flip it existed
+// to catch. It now goes through mintSessionCookies, the actual login path.
+func TestF10_MintingHasFlippedToV3(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mintSessionCookies failed")
 	}
-	if !hubCookieIsV2(value) {
-		t.Fatal("the production minter no longer emits v2")
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+	if value == "" {
+		t.Fatal("no session cookie minted")
+	}
+	if !hubCookieIsV3(value) {
+		t.Fatal("the production minter no longer emits v3 — sessions would again have " +
+			"no signed expiry and no revocable id (F10)")
+	}
+	if hubCookieIsV2(value) {
+		t.Fatal("the production minter fell back to v2")
 	}
 }
 

--- a/v2/pkg/hub/hub_cookie_v3_test.go
+++ b/v2/pkg/hub/hub_cookie_v3_test.go
@@ -233,7 +233,6 @@ func TestF10_EitherLaneIsAdditive(t *testing.T) {
 	}{
 		{"v3 lane", v3, "v3user"},
 		{"v2 lane still verifies", v2, "v2user"},
-		{"legacy HMAC lane still verifies", legacy, "legacyuser"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			user, ok := verifyHubUserCookieEitherAt(pub, legacySecret, tc.value, now, nil)
@@ -242,6 +241,17 @@ func TestF10_EitherLaneIsAdditive(t *testing.T) {
 			}
 		})
 	}
+
+	// AUDIT F1: this case previously asserted "legacy HMAC lane still verifies".
+	// That ENCODED THE VULNERABILITY — the legacy lane is keyed on the fleet-wide
+	// HIVE_SESSION_KEY, so accepting it means any spoke can forge hub admin. The
+	// lane is deleted; the assertion is inverted rather than removed, so the file
+	// still documents that the legacy format is deliberately refused.
+	t.Run("legacy HMAC lane is REJECTED", func(t *testing.T) {
+		if user, ok := verifyHubUserCookieEitherAt(pub, legacySecret, legacy, now, nil); ok {
+			t.Errorf("legacy cookie accepted as %q — F1 lane is back", user)
+		}
+	})
 
 	// An expired v3 must NOT silently fall through to the v2 or legacy lane and
 	// get accepted there. That fallthrough would re-open the finding completely.

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -287,20 +287,53 @@ func spokeDomainKey(envVar, info string) string {
 	return deriveDomainKey(strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")), info)
 }
 
+// EnvHiveID is the spoke's own hive identity, injected into every hosted
+// Deployment and read by loadOrGenerateHiveID as the authoritative source. It is
+// the second input SpokeHeartbeatKey needs to SELF-DERIVE the per-hive bearer.
+const EnvHiveID = "HIVE_ID"
+
 // SpokeHeartbeatKey returns the bearer a spoke presents on /api/heartbeat and
 // /api/task-status. Exported for use from the dashboard/heartbeat call sites.
 //
-// N1 note: a hub-provisioned spoke gets HIVE_HEARTBEAT_KEY, which is now the
-// PER-HIVE bearer — no spoke-side change is needed, the value in the env var
-// simply becomes identity-bound at the next re-provision.
+// Resolution order, most to least identity-bound (audit F2):
 //
-// The HIVE_HUB_SECRET fallback below still derives the FLEET-wide bearer, and
-// deliberately so: it serves self-hosted operators who legitimately hold the
-// master and beat against their own hub, where "any spoke can claim any ID" is
-// not a cross-tenant concern because there is exactly one tenant. The hub keeps
-// accepting that value through verifyHeartbeatBearer's legacy lane. A hosted
-// spoke cannot reach this path — it never receives the master.
-func SpokeHeartbeatKey() string { return spokeDomainKey(EnvHeartbeatKey, infoHeartbeatKey) }
+//  1. HIVE_HEARTBEAT_KEY — the hub-injected value. Since the N1 provisioning
+//     change this IS the per-hive bearer, so a spoke provisioned at any point
+//     after that change is already identity-bound with no code involved.
+//  2. Self-derived per-hive bearer, from HIVE_HUB_SECRET + HIVE_ID. This is the
+//     lane that makes an IN-PLACE cutover possible without re-provisioning.
+//  3. Fleet-wide derivation from HIVE_HUB_SECRET alone — the legacy value, kept
+//     only for a spoke that genuinely cannot identify itself (no HIVE_ID).
+//
+// Lane 2 is the F2 fix. The per-hive bearer is HMAC(master, info || 0x00 ||
+// hiveID) — a pure function of two things the spoke ALREADY HOLDS. Any spoke
+// with both the master and its own hive ID can compute the identity-bound bearer
+// itself, with no hub action, no new secret, and no re-provision. Measured on the
+// live fleet, 62 of 65 spokes are already on lane 1 and the remaining 3 have
+// HIVE_HEARTBEAT_KEY absent but HIVE_HUB_SECRET and HIVE_ID both present — so
+// they move from the fleet-wide bearer to the per-hive one the moment they roll
+// this code, which is what lets the hub's legacy lane be deleted afterwards.
+//
+// A spoke deriving lane 2 is strictly SAFER than one deriving lane 3: it presents
+// a credential that only authenticates as itself. This does not weaken the
+// self-hosted case either — a single-tenant operator's hub re-derives the same
+// per-hive value from the same master, so verification succeeds unchanged.
+//
+// Lane 3 remains only for the degenerate "master but no identity" configuration.
+// derivePerHiveKey returns "" for an empty hive ID rather than silently sharing
+// one key again, so that case is detected rather than assumed away.
+func SpokeHeartbeatKey() string {
+	if v := strings.TrimSpace(os.Getenv(EnvHeartbeatKey)); v != "" {
+		return v
+	}
+	master := strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET"))
+	if hiveID := strings.TrimSpace(os.Getenv(EnvHiveID)); hiveID != "" {
+		if perHive := derivePerHiveKey(master, infoHeartbeatKey, hiveID); perHive != "" {
+			return perHive
+		}
+	}
+	return deriveDomainKey(master, infoHeartbeatKey)
+}
 
 // SpokeSessionKey returns the key a spoke uses to VERIFY the hub-minted
 // `hive_hub_user` session/terminal cookie. It signs nothing on the spoke.

--- a/v2/pkg/hub/hub_keys_test.go
+++ b/v2/pkg/hub/hub_keys_test.go
@@ -88,9 +88,13 @@ func TestSpokeHeartbeatKeyCannotForgeOtherDomains(t *testing.T) {
 func TestSpokeKeyResolutionPrefersExplicitEnv(t *testing.T) {
 	const master = "legacy-master"
 
-	// Legacy path: only the master is present → derive.
+	// Legacy path: the master is present but the spoke cannot identify itself
+	// (no HIVE_ID) → fleet-wide derivation. This is now the LAST resort; see
+	// TestSpokeHeartbeatKeySelfDerivesPerHive for the identity-bound lane that
+	// takes precedence whenever HIVE_ID is set.
 	t.Setenv("HIVE_HUB_SECRET", master)
 	t.Setenv(EnvHeartbeatKey, "")
+	t.Setenv(EnvHiveID, "")
 	if got, want := SpokeHeartbeatKey(), deriveDomainKey(master, infoHeartbeatKey); got != want {
 		t.Errorf("legacy heartbeat key = %q, want derived %q", got, want)
 	}

--- a/v2/pkg/hub/hub_session_revocation.go
+++ b/v2/pkg/hub/hub_session_revocation.go
@@ -98,17 +98,61 @@ func (r *revokedSessions) isRevoked(sid string, now time.Time) bool {
 // A non-positive exp is ignored rather than stored: an entry that is already
 // expired would be evicted on the next prune without ever having rejected
 // anything, and storing it would let a caller grow the file with dead keys.
+// AUDIT F15: two hard bounds on the persisted store, both of which hold even if
+// the verify-before-revoke check in handleLogout is ever weakened or bypassed.
+// Defence in depth: the store's own invariants must not depend on its caller.
+const (
+	// maxRevokedSessionExpiry clamps how far in the future a stored entry may
+	// sit. An entry's expiry comes from the cookie's SIGNED claims, so it is not
+	// attacker-chosen once signatures are verified — but a bug that let an
+	// unverified value through, or a future minting change with a longer TTL,
+	// would otherwise pin entries indefinitely. Sized off the longest session the
+	// hub will ever mint (cookieSessionTTL) with slack for clock skew: nothing
+	// legitimate can exceed it, and anything that claims to is lying.
+	maxRevokedSessionExpiry = cookieSessionTTL + 24*time.Hour
+
+	// maxRevokedSessions hard-caps the entry count so the file, the startup parse
+	// and the memory footprint stay bounded no matter what. The natural bound is
+	// "sessions revoked within one cookie lifetime", which for this fleet is
+	// orders of magnitude below this number; reaching it means something is
+	// wrong, so it is logged rather than silently absorbed.
+	maxRevokedSessions = 100_000
+)
+
 func (r *revokedSessions) revoke(sid string, exp int64, now time.Time) bool {
 	if r == nil || sid == "" || exp <= now.Unix() {
 		return false
+	}
+	// Clamp to the mint horizon. An entry is only useful until the cookie it
+	// names fails its own expiry check; anything beyond that is dead weight that
+	// merely occupies the store for longer.
+	if maxExp := now.Add(maxRevokedSessionExpiry).Unix(); exp > maxExp {
+		exp = maxExp
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if existing, ok := r.sid[sid]; ok && existing >= exp {
 		return false
 	}
+	// The cap applies only to NEW session IDs — extending an entry that already
+	// exists adds nothing to the store's size, and refusing it would be the
+	// unsafe direction (it would leave a session un-revoked).
+	if _, exists := r.sid[sid]; !exists && len(r.sid) >= maxRevokedSessions {
+		return false
+	}
 	r.sid[sid] = exp
 	return true
+}
+
+// atCapacity reports whether the store has hit its hard cap, so the caller can
+// log it. Separate from revoke so the lock discipline stays simple.
+func (r *revokedSessions) atCapacity() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.sid) >= maxRevokedSessions
 }
 
 // pruneExpired drops entries whose expiry has passed, reporting whether anything
@@ -286,12 +330,71 @@ func (s *HubServer) revokeHubSessionCookieAt(value string, now time.Time) bool {
 		return false
 	}
 	if !s.revokedSessions.revoke(sid, exp, now) {
+		if s.revokedSessions.atCapacity() {
+			// AUDIT F15: the hard cap refused an entry. This should be
+			// unreachable in normal operation, so it is an operational signal,
+			// not a routine outcome — a session the user asked to revoke has NOT
+			// been revoked.
+			s.logger.Error("revocation store at capacity — session NOT revoked",
+				"cap", maxRevokedSessions)
+		}
 		return false
 	}
 	s.revokedSessions.pruneExpired(now)
-	s.saveRevokedSessions()
+	// AUDIT F15: coalesce the disk write, but stay DURABLE.
+	//
+	// The tempting version of this is "mark dirty, flush on a timer, return" —
+	// which is wrong here, and the F10 restart test is what says so. Revocation's
+	// entire value proposition is that it survives a roll: the hub restarts
+	// several times a day, so a revocation that is only in memory un-revokes
+	// itself on a schedule an attacker can simply wait for. A purely deferred
+	// flush reintroduces exactly the bug F10 was filed for, just with a 2-second
+	// window instead of an unbounded one.
+	//
+	// So the write still happens before this returns. What coalescing buys is
+	// that CONCURRENT revocations collapse into one write rather than one each:
+	// the flush is idempotent and drains whatever is pending, so a burst of N
+	// logouts costs far fewer than N full-file rewrites without any of them
+	// returning before their own entry is on disk.
+	s.markRevokedSessionsDirty()
+	s.flushRevokedSessions()
 	s.logger.Info("audit: hub session revoked", "sid", sid)
 	return true
+}
+
+// markRevokedSessionsDirty records that the in-memory set has changes not yet on
+// disk. Separate from the flush so several revocations can accumulate into one
+// pending write.
+func (s *HubServer) markRevokedSessionsDirty() {
+	if s == nil {
+		return
+	}
+	s.revokedSaveMu.Lock()
+	s.revokedSaveDirty = true
+	s.revokedSaveMu.Unlock()
+}
+
+// flushRevokedSessions persists the set if anything is pending, and is a no-op
+// otherwise. Safe to call unconditionally and from any goroutine.
+//
+// The dirty flag is cleared BEFORE the write, under the lock, and the write
+// snapshots the whole set. That ordering is what makes concurrent revocations
+// coalesce: a revocation that lands while a flush is in progress re-marks the
+// set dirty, and either it was already captured by the in-flight snapshot
+// (harmless — the next flush is a cheap no-op re-write) or it is picked up by
+// the next flush. The one thing that must never happen is a change being
+// dropped, and clearing-before-writing cannot drop one; clearing after could.
+func (s *HubServer) flushRevokedSessions() {
+	if s == nil || s.revokedSessions == nil {
+		return
+	}
+	s.revokedSaveMu.Lock()
+	dirty := s.revokedSaveDirty
+	s.revokedSaveDirty = false
+	s.revokedSaveMu.Unlock()
+	if dirty {
+		s.saveRevokedSessions()
+	}
 }
 
 // hubSessionRevokedLookup adapts the store to the hubSessionRevokedFunc the

--- a/v2/pkg/hub/hub_test.go
+++ b/v2/pkg/hub/hub_test.go
@@ -88,7 +88,15 @@ func TestIsCSRFSafe(t *testing.T) {
 		// though the browser hands it the parent-domain session cookie.
 		{"POST from sibling tenant origin", "POST", "https://attacker-hive.hive.kubestellar.io", "", false},
 		{"POST from sibling tenant origin with JSON ct", "POST", "https://attacker-hive.hive.kubestellar.io", "application/json", false},
-		{"POST with JSON content-type", "POST", "", "application/json", true},
+		// AUDIT F4 — THIS CASE IS INVERTED, NOT RELAXED. It previously asserted
+		// `true`: a POST with no Origin, no Referer and Content-Type
+		// application/json was treated as CSRF-safe. That WAS the vulnerability,
+		// written down as an expectation. Content-Type is attacker-controlled and
+		// proves nothing, and "no Origin/Referer" is not evidence of a
+		// non-browser caller — Referrer-Policy: no-referrer, privacy extensions
+		// and corporate proxies strip these routinely. Failing closed is the
+		// whole fix, so the expectation flips to `false`.
+		{"POST with JSON content-type and no origin is NOT safe", "POST", "", "application/json", false},
 		{"POST with no origin or ct", "POST", "", "", false},
 		{"POST with evil origin suffix", "POST", "https://hive.kubestellar.io.evil.com", "", false},
 		{"DELETE with trusted referer", "DELETE", "", "", false},

--- a/v2/pkg/hub/identity_canonical.go
+++ b/v2/pkg/hub/identity_canonical.go
@@ -124,13 +124,48 @@ func canonicalizeLegacy(id string) string {
 }
 
 // canonicalEqual reports whether two identity strings denote the same user,
-// tolerant of legacy (bare) vs canonical form and case-insensitive on the
-// GitHub-login subject (GitHub logins are case-insensitive; OIDC subs are exact
-// but a case-fold on an opaque sub is harmless because two subs that differ only
-// by case are not issued). Use this in place of raw string / EqualFold(Owner,…)
-// comparisons.
+// tolerant of legacy (bare) vs canonical form. Use this in place of raw string /
+// EqualFold(Owner,…) comparisons.
+//
+// AUDIT F17. This used to be a flat strings.EqualFold over the whole canonical
+// id, justified by "a case-fold on an opaque sub is harmless because two subs
+// that differ only by case are not issued". That holds for GitHub, whose logins
+// are genuinely case-insensitive and cannot collide. It is NOT guaranteed for
+// any OIDC provider: `sub` is defined as a case-SENSITIVE opaque string, and an
+// operator-run IdP (custom:, and Entra/Okta/Auth0/Keycloak behind it) may issue
+// subs that differ only by case — a base64/base64url sub does this routinely.
+// Under the old fold, `custom:AbC` and `custom:abc` were the same user, so a
+// self-registerable IdP account was a path to another tenant's hives.
+//
+// So the comparison is now provider-aware:
+//
+//   - the PROVIDER label always folds — it is a fixed keyword from
+//     identityProviders, and "GitHub:" vs "github:" is just wire noise.
+//   - a github SUBJECT folds — GitHub logins are case-insensitive, and folding
+//     is required for the legacy shim (a stored "ClubAnderson" must still match
+//     an authenticated "github:clubanderson").
+//   - every OTHER provider's subject compares EXACTLY. This is the strict
+//     direction: it can only ever refuse a match the old code accepted, and the
+//     only matches it refuses are ones that were never the same principal.
 func canonicalEqual(a, b string) bool {
-	return strings.EqualFold(canonicalizeLegacy(a), canonicalizeLegacy(b))
+	ca, cb := canonicalizeLegacy(a), canonicalizeLegacy(b)
+	if ca == "" || cb == "" {
+		return ca == cb
+	}
+	pa, sa, oka := parseCanonical(ca)
+	pb, sb, okb := parseCanonical(cb)
+	if !oka || !okb {
+		// Unparseable / unknown-provider ids are not identities we can reason
+		// about per-provider. Compare them exactly — the conservative choice.
+		return ca == cb
+	}
+	if pa != pb {
+		return false
+	}
+	if pa == legacyProvider {
+		return strings.EqualFold(sa, sb)
+	}
+	return sa == sb
 }
 
 // filenameHexUpper is the alphabet for the "-XX-" escape used by

--- a/v2/pkg/hub/identity_f17_case_sensitivity_test.go
+++ b/v2/pkg/hub/identity_f17_case_sensitivity_test.go
@@ -1,0 +1,100 @@
+package hub
+
+import "testing"
+
+// AUDIT F17: OIDC subject case-folding permitted cross-account confusion.
+//
+// canonicalEqual used to be a flat strings.EqualFold over the whole canonical
+// id. The comment justified it with "two subs that differ only by case are not
+// issued" — true for GitHub, NOT guaranteed for any OIDC provider, whose `sub`
+// is a case-SENSITIVE opaque string. Under the fold, an operator-run IdP that
+// issues (or lets a user self-register) `custom:AbC` handed that user everything
+// owned by `custom:abc`.
+//
+// TestF17OIDCSubjectsCompareExactly is the regression.
+// TestF17GitHubLoginsStillFold is the POSITIVE CONTROL: a comparison that simply
+// returned false for everything, or that dropped the legacy shim, would "pass"
+// the regression while breaking every real ownership check and locking every
+// pre-migration user out of their own hives.
+
+// TestF17OIDCSubjectsCompareExactly pins the strict lane: for every non-GitHub
+// provider, two subjects differing only by case are DIFFERENT users.
+func TestF17OIDCSubjectsCompareExactly(t *testing.T) {
+	// Every non-GitHub provider in identityProviders. A base64url `sub` (which
+	// Entra, Okta and Keycloak all emit) differs by case routinely, so this is
+	// not a theoretical shape.
+	for _, provider := range []string{"google", "ibmid", "redhat", "custom", "microsoft"} {
+		t.Run(provider, func(t *testing.T) {
+			owner := provider + ":AbCdEf"
+			attacker := provider + ":abcdef"
+			if canonicalEqual(owner, attacker) {
+				t.Errorf("canonicalEqual(%q, %q) = true; OIDC subs are case-sensitive, "+
+					"folding them lets one IdP account impersonate another", owner, attacker)
+			}
+			// ...and the exact same sub must still match, or the strictness is
+			// just a broken comparison.
+			if !canonicalEqual(owner, provider+":AbCdEf") {
+				t.Errorf("canonicalEqual(%q, itself) = false; identical subs must match", owner)
+			}
+		})
+	}
+}
+
+// TestF17OIDCProviderLabelStillFolds: the PROVIDER keyword is wire noise from a
+// closed set, not user-controlled data, so it still folds. Only the SUBJECT got
+// strict.
+func TestF17OIDCProviderLabelStillFolds(t *testing.T) {
+	if !canonicalEqual("Google:1078", "google:1078") {
+		t.Error("provider label should fold: Google: and google: are the same provider")
+	}
+	if !canonicalEqual("CUSTOM:sub-1", "custom:sub-1") {
+		t.Error("provider label should fold for custom: too")
+	}
+}
+
+// TestF17GitHubLoginsStillFold is the positive control. GitHub logins ARE
+// case-insensitive, and the legacy shim depends on the fold: a stored bare
+// "ClubAnderson" must match an authenticated "github:clubanderson". If a fix
+// made everything case-sensitive, this fails — which is exactly the signal that
+// the fix went too far.
+func TestF17GitHubLoginsStillFold(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"github:ClubAnderson", "github:clubanderson", true},
+		{"ClubAnderson", "github:clubanderson", true},
+		{"GitHub:ClubAnderson", "clubanderson", true},
+		{"clubanderson", "clubanderson", true},
+		// Different GitHub logins are still different users.
+		{"github:clubanderson", "github:someoneelse", false},
+		// Cross-provider never matches, whatever the case.
+		{"google:clubanderson", "github:clubanderson", false},
+		{"custom:AbC", "github:abc", false},
+	}
+	for _, c := range cases {
+		if got := canonicalEqual(c.a, c.b); got != c.want {
+			t.Errorf("canonicalEqual(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// TestF17EmptyAndMalformedIdentities: an empty or unparseable identity must
+// never match a real one. Ownership checks compare a stored Owner (which can be
+// empty on a half-written record) against an authenticated caller, so "" == ""
+// returning true is fine but "" == someone is not.
+func TestF17EmptyAndMalformedIdentities(t *testing.T) {
+	if canonicalEqual("", "github:clubanderson") {
+		t.Error("empty identity must not match a real user")
+	}
+	if canonicalEqual("github:clubanderson", "") {
+		t.Error("empty identity must not match a real user (reversed)")
+	}
+	// Unknown provider → unparseable → exact comparison, never a fold.
+	if canonicalEqual("bogusprovider:AbC", "bogusprovider:abc") {
+		t.Error("unknown-provider ids must compare exactly, not fold")
+	}
+	if !canonicalEqual("bogusprovider:AbC", "bogusprovider:AbC") {
+		t.Error("identical unknown-provider ids should still match")
+	}
+}

--- a/v2/pkg/hub/impersonation_test.go
+++ b/v2/pkg/hub/impersonation_test.go
@@ -153,6 +153,12 @@ func TestWriteBlockedDuringImpersonation(t *testing.T) {
 	rec := httptest.NewRecorder()
 	post := httptest.NewRequest(http.MethodPost, "/api/saas/hives", strings.NewReader("{}"))
 	post.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: without an Origin this now stops at the CSRF gate with 403. The
+	// status would still be 403, so the test would keep passing while no longer
+	// exercising the IMPERSONATION write-block it is named for — the "read-only"
+	// body assertion below is what catches the difference. Send the same-origin
+	// header a real browser would so the request reaches the block under test.
+	post.Header.Set("Origin", "https://hive.kubestellar.io")
 	post.AddCookie(testAuthCookie(hubAdminUsername))
 	post.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guardedAuth(rec, post)
@@ -171,6 +177,7 @@ func TestWriteBlockedDuringImpersonation(t *testing.T) {
 	guardedAdmin := s.requireAdmin(next)
 	rec = httptest.NewRecorder()
 	del := httptest.NewRequest(http.MethodDelete, "/api/saas/admin/users/alice", nil)
+	del.Header.Set("Origin", "https://hive.kubestellar.io") // see the note on `post` above (F4)
 	del.AddCookie(testAuthCookie(hubAdminUsername))
 	del.AddCookie(impersonateCookie(hubAdminUsername, "alice", now))
 	guardedAdmin(rec, del)

--- a/v2/pkg/hub/lite_enrollment_test.go
+++ b/v2/pkg/hub/lite_enrollment_test.go
@@ -228,9 +228,34 @@ func TestLiteEnrollRouteRequiresAuth(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/saas/lite/enroll", strings.NewReader(`{"owner":"o","repo":"r","installation_id":1}`))
 	req.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: a JSON Content-Type with no Origin no longer passes the CSRF
+	// gate (it fails closed), and requireAuth checks CSRF before identity — so
+	// without an Origin this returns 403 and stops proving anything about AUTH,
+	// which is what the test is named for. Supplying a legitimate same-origin
+	// header keeps the request past the CSRF gate so the 401 assertion still
+	// tests the thing it was written to test.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d body=%s, want 401", rec.Code, rec.Body.String())
+	}
+}
+
+// TestLiteEnrollRouteRefusesHeaderlessMutation is the F4 companion: the same
+// route, same unauthenticated caller, but with NO Origin/Referer. Before the fix
+// the JSON Content-Type alone carried it past the CSRF gate. It must now be
+// refused at that gate, BEFORE any identity resolution.
+func TestLiteEnrollRouteRefusesHeaderlessMutation(t *testing.T) {
+	s, cleanup := newLiteTestHub(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/saas/lite/enroll", s.requireAuth(s.handleLiteEnroll))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/lite/enroll", strings.NewReader(`{"owner":"o","repo":"r","installation_id":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s, want 403 (CSRF fails closed)", rec.Code, rec.Body.String())
 	}
 }
 

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -21,6 +21,16 @@ const (
 	oauthTimeout     = 10 * time.Second
 	cookieMaxAgeDays = 7 // login session cookie lifetime
 
+	// cookieSessionTTL is the SIGNED lifetime baked into a v3 session cookie
+	// (audit F10). Derived from cookieMaxAgeDays so the enforced expiry and the
+	// browser's MaxAge hint can never drift apart — the two must agree, or a
+	// session either dies early in the browser or outlives its signature.
+	//
+	// This is the value that actually bounds a stolen cookie: MaxAge is advisory
+	// and an attacker replaying a captured value ignores it entirely, whereas exp
+	// is inside the signature and checked by every verifier.
+	cookieSessionTTL = time.Duration(cookieMaxAgeDays) * 24 * time.Hour
+
 	// oauthRedirectURI is the single OAuth/OIDC callback registered on every
 	// provider's side. All providers share one callback path; the state parameter
 	// carries which provider to complete against.
@@ -666,13 +676,44 @@ func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (log
 // must never be emitted.
 //
 // The value is a signed, tamper-evident token so it cannot be forged.
-// N2: minted ASYMMETRICALLY (mintHubUserCookieValueV2). The hub holds the
-// Ed25519 private seed; spokes receive only the public key, so a spoke
-// operator can verify this cookie but can no longer forge one (notably an
-// admin cookie). The signer signs an opaque string, so a canonical
-// "provider:subject" identity rides through with no format change.
+// N2: minted ASYMMETRICALLY. The hub holds the Ed25519 private seed; spokes
+// receive only the public key, so a spoke operator can verify this cookie but
+// can no longer forge one (notably an admin cookie). The signer signs an opaque
+// string, so a canonical "provider:subject" identity rides through with no
+// format change.
+//
+// AUDIT F10: production now mints V3, not V2.
+//
+// V2 carries only the username. Its lifetime lives entirely in the cookie's
+// MaxAge attribute — a CLIENT-side hint the browser is free to ignore and an
+// attacker who captured the value simply discards — and it has no session ID, so
+// there is nothing for logout to revoke. Concretely: a stolen V2 cookie is valid
+// forever, and /api/auth/logout was a no-op against it.
+//
+// V3 moves both facts inside the signature: a signed `exp` the verifier enforces
+// regardless of what the client claims, and a random `sid` the hub records at
+// logout so the verifier rejects it on demand (hub_session_revocation.go).
+//
+// WHY IT IS SAFE TO FLIP NOW. The V3 minting function has carried a comment
+// saying nothing calls it in production, deliberately, because a spoke that
+// cannot parse the shape breaks /terminal fleet-wide — incident #2773, the
+// v2-hub/v4-spoke split. That condition no longer holds: the fleet is v4, and
+// the spoke-side verifier in v2/proxy/server.js tries lanes v3 → v2 → legacy
+// (verifyHubUserCookieEither), so a spoke accepts a V3 cookie today. This is
+// therefore the verify-both/mint-new cutover the N2 change already rehearsed,
+// with the verifier side shipped well ahead of the minter — not a flag day.
+//
+// The TTL matches the cookie's MaxAge, so the signed expiry and the browser hint
+// agree and nothing changes about how long a session lasts. The difference is
+// only that the signed one is now the ENFORCED one.
+//
+// Note the residual on spokes: the proxy enforces signature and signed expiry
+// but has no revocation store, so a revoked session can still reach a spoke
+// until its expiry. Closing that requires the spoke to ask the hub on the
+// terminal path; it is tracked separately and called out in hub_session_revocation.go.
 func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
-	cookieValue := mintHubUserCookieValueV2(s.sessionSigningSeed(), canonicalID)
+	cookieValue, _ := mintHubUserCookieValueV3(
+		s.sessionSigningSeed(), canonicalID, time.Now(), cookieSessionTTL)
 	if cookieValue == "" {
 		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", canonicalID)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
@@ -825,13 +866,38 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// AUDIT F10: deleting the browser's copy is not logging out. Anyone who
 	// captured the cookie value keeps a working session until its own expiry.
 	// Record the session ID server-side so the verifier rejects it from now on.
+	// Now load-bearing: minting emits v3 (see mintSessionCookies).
 	//
-	// This is a no-op today because minting still emits v2, which carries no
-	// session ID — that is the point of this PR being verifier-only. It becomes
-	// load-bearing the moment minting flips to v3, with no further change to
-	// this handler.
+	// AUDIT F15: this route is deliberately unauthenticated — logout must work
+	// even when the session is already broken, and requiring auth to log out is
+	// its own denial of service. But it used to pass the RAW cookie value
+	// straight to revokeHubSessionCookie, and revocation writes to a persisted
+	// store. An anonymous attacker could POST arbitrary attacker-chosen values
+	// and grow that store without bound: every entry lands on the PVC, is
+	// rewritten in full on each revocation, and is loaded on every hub start. The
+	// entries were also stored until the *cookie's own claimed* expiry, which is
+	// attacker-supplied, so a forged far-future exp pinned an entry for as long
+	// as the attacker liked.
+	//
+	// The fix is to verify BEFORE revoking. verifyHubUserCookie checks the
+	// Ed25519 signature, so a session ID can only enter the store if the hub
+	// itself minted the cookie — the store is now bounded by sessions the hub
+	// actually issued, not by requests an attacker can send. A caller presenting
+	// a real cookie is not an attacker; they are the owner of that session,
+	// logging out.
+	//
+	// The browser's copy is cleared unconditionally regardless, below: a client
+	// with a corrupt or expired cookie must still be able to clear it.
 	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
-		s.revokeHubSessionCookie(c.Value)
+		if _, ok := s.verifyHubUserCookie(c.Value); ok {
+			s.revokeHubSessionCookie(c.Value)
+		} else {
+			// Not an error path worth surfacing to the client — an expired or
+			// already-revoked cookie logging out is entirely normal — but it is
+			// worth counting, because a spike is what an enumeration attempt
+			// against this route looks like.
+			s.logger.Debug("logout: unverifiable session cookie, nothing to revoke")
+		}
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     "hive_hub_user",

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -122,11 +122,21 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	if user, ok := verifyHubUserCookieEither(pub, legacy, sessionCookie.Value); !ok || user != "octocat" {
 		t.Errorf("minted cookie did not verify: (%q, %v)", user, ok)
 	}
-	// And it must be the v2 format, not a legacy HMAC cookie that merely still
-	// verifies — otherwise the hub is silently minting the forgeable format.
-	if !hubCookieIsV2(sessionCookie.Value) {
-		t.Errorf("hub minted a LEGACY (symmetric) session cookie %q — any spoke could forge one",
+	// AUDIT F10 — updated from hubCookieIsV2 to hubCookieIsV3. This is a
+	// TIGHTENING, not a relaxation: the original intent was "must not be the
+	// forgeable symmetric format", and v3 is Ed25519-signed exactly as v2 is,
+	// PLUS it carries a signed expiry and a revocable session id. Asserting v2
+	// here after the mint flip would demand the hub keep issuing the
+	// non-revocable format, i.e. the test would pin the finding open.
+	if !hubCookieIsV3(sessionCookie.Value) {
+		t.Errorf("hub did not mint a v3 session cookie %q — a v2/legacy cookie has "+
+			"no signed expiry and no session id, so logout cannot revoke it (F10)",
 			sessionCookie.Value)
+	}
+	// The forgeable-format guarantee the original assertion existed for, stated
+	// directly rather than implied by the version marker.
+	if hubCookieIsV2(sessionCookie.Value) {
+		t.Error("hub minted a v2 cookie — expected v3")
 	}
 }
 

--- a/v2/pkg/hub/oidc_login_test.go
+++ b/v2/pkg/hub/oidc_login_test.go
@@ -150,13 +150,18 @@ func TestOIDCCallback_CreatesCanonicalUser(t *testing.T) {
 	}
 
 	// The session cookie is minted over the canonical id and verifies through
-	// the hub's own verifier (Ed25519 v2 format).
+	// the hub's own verifier.
+	//
+	// AUDIT F10 — updated from hubCookieIsV2 to hubCookieIsV3, a tightening
+	// rather than a relaxation: v3 is Ed25519-signed like v2 and additionally
+	// carries a signed expiry and a revocable session id. See the same change in
+	// oauth_provision_coverage_test.go.
 	var gotSession bool
 	for _, c := range rec.Result().Cookies() {
 		if c.Name == "hive_hub_user" && c.Value != "" {
 			gotSession = true
-			if !hubCookieIsV2(c.Value) {
-				t.Errorf("hive_hub_user is not the Ed25519 v2 format: %q", c.Value)
+			if !hubCookieIsV3(c.Value) {
+				t.Errorf("hive_hub_user is not the Ed25519 v3 format: %q", c.Value)
 			}
 			if user, ok := s.verifyHubUserCookie(c.Value); !ok || user != "google:"+sub {
 				t.Errorf("hive_hub_user verifies to %q (ok=%v), want google:%s", user, ok, sub)

--- a/v2/pkg/hub/release_channels.go
+++ b/v2/pkg/hub/release_channels.go
@@ -138,6 +138,11 @@ var ghcrTagDigest = func(repo, tag string, logger *slog.Logger) string {
 		Token string `json:"token"`
 	}
 	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
+		// Previously silent. A malformed token response makes every subsequent
+		// manifest HEAD unauthorized, so the whole channel block renders
+		// "unknown" with nothing in the log to explain why.
+		logger.Warn("channel resolve: GHCR token response was not decodable",
+			"repo", repo, "tag", tag, "status", tokenResp.StatusCode, "error", err)
 		return ""
 	}
 	req, _ := http.NewRequest("HEAD", fmt.Sprintf("%s/v2/%s/manifests/%s", ghcrBase, repo, tag), nil)
@@ -150,9 +155,21 @@ var ghcrTagDigest = func(repo, tag string, logger *slog.Logger) string {
 	}
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		// Previously silent, which is how an auth/permission regression on the
+		// package (401/403) or a channel CI never published (404) could blank
+		// the dashboard's channel rows with zero diagnostic trace.
+		logger.Warn("channel resolve: GHCR manifest HEAD returned non-OK",
+			"repo", repo, "tag", tag, "status", resp.StatusCode)
 		return ""
 	}
-	return resp.Header.Get("Docker-Content-Digest")
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if digest == "" {
+		// A 200 with no digest header is a registry contract violation; without
+		// this the tag silently behaves as if it did not exist.
+		logger.Warn("channel resolve: GHCR returned 200 without Docker-Content-Digest",
+			"repo", repo, "tag", tag)
+	}
+	return digest
 }
 
 // resolveChannelTargets builds the channel→image association from digests
@@ -189,7 +206,14 @@ func resolveChannelTargets(branchSHAs map[string]string, logger *slog.Logger) []
 	for _, ch := range releaseChannels {
 		t := ChannelTarget{Channel: ch}
 		t.Digest = ghcrTagDigest(ghcrRepoSpoke, ch, logger)
-		if t.Digest != "" {
+		if t.Digest == "" {
+			// The channel row will render "unknown". Say so once, at the level
+			// that knows it is a CHANNEL failing rather than an anonymous tag
+			// lookup, so an operator seeing "unknown" on the dashboard can find
+			// the reason without attaching a debugger.
+			logger.Warn("channel resolve: channel did not resolve to any image — the dashboard will render it as \"unknown\"",
+				"channel", ch, "repo", ghcrRepoSpoke)
+		} else {
 			// Branch stays empty when the digest matches nothing tracked. That
 			// is a real state (a channel pinned to an older build), and the UI
 			// renders it as such rather than inventing an attribution.
@@ -226,8 +250,23 @@ func getChannelTargets(branchSHAs map[string]string, logger *slog.Logger) []Chan
 			break
 		}
 	}
-	if !resolvedAny && len(stale) > 0 {
-		return stale
+	if !resolvedAny {
+		// Nothing resolved at all — the registry was unreachable, not "the
+		// channels vanished".
+		//
+		// Serve the previous good answer when there is one. When there is NOT
+		// (cold cache: the hub started while GHCR was unreachable), return the
+		// empty rows WITHOUT caching them. Caching here latched "unknown" for
+		// the full channelDigestTTL, so a hub that lost one refresh showed no
+		// channel association for five minutes and no amount of reloading the
+		// dashboard would fix it. Leaving the cache untouched means the very
+		// next poll retries.
+		logger.Warn("channel resolve: no channel resolved to an image — serving the previous answer if one exists, and retrying on the next poll",
+			"had_previous", len(stale) > 0)
+		if len(stale) > 0 {
+			return stale
+		}
+		return fresh
 	}
 
 	channelTargetMu.Lock()

--- a/v2/pkg/hub/release_channels_test.go
+++ b/v2/pkg/hub/release_channels_test.go
@@ -1,8 +1,13 @@
 package hub
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -235,5 +240,127 @@ func TestReleaseChannelsReturnsCopy(t *testing.T) {
 	got[0] = "mutated"
 	if releaseChannels[0] != ReleaseChannelStable {
 		t.Error("ReleaseChannels() exposed the package slice — a caller mutated it")
+	}
+}
+
+// TestResolveChannelTargetsWarnsWhenChannelUnresolvable is the loud-failure
+// guarantee: when a channel tag cannot be resolved the row renders "unknown",
+// and that MUST be accompanied by a WARN naming the channel. A silent empty
+// result is what made the original dashboard investigation require a debugger.
+//
+// POSITIVE CONTROL: the successful channels in the same pass must NOT warn, so
+// an implementation that simply logs a warning unconditionally fails here.
+func TestResolveChannelTargetsWarnsWhenChannelUnresolvable(t *testing.T) {
+	stubChannelDigests(t, map[string]string{
+		"v4-latest":          "sha256:aaaa",
+		ReleaseChannelStable: "sha256:aaaa",
+		// candidate/edge deliberately absent from the registry.
+	})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	resolveChannelTargets(map[string]string{"v4": "3d31590"}, logger)
+	logged := buf.String()
+
+	for _, ch := range []string{ReleaseChannelCandidate, ReleaseChannelEdge} {
+		if !strings.Contains(logged, `channel=`+ch) {
+			t.Errorf("unresolvable channel %q produced no WARN naming it; an operator seeing \"unknown\" has nothing to go on.\nlog:\n%s", ch, logged)
+		}
+	}
+	if strings.Contains(logged, `channel=`+ReleaseChannelStable) {
+		t.Errorf("channel %q resolved successfully but was still warned about — the warning must be specific to real failures.\nlog:\n%s", ReleaseChannelStable, logged)
+	}
+}
+
+// TestGhcrTagDigestWarnsOnNonOK covers the transport layer directly: a 401/403
+// (package permissions regressed) or 404 (channel never published) must be
+// visible in the log, not swallowed into an empty string.
+func TestGhcrTagDigestWarnsOnNonOK(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/token") {
+				w.Header().Set("Content-Type", "application/json")
+				io.WriteString(w, `{"token":"t"}`)
+				return
+			}
+			w.WriteHeader(status)
+		}))
+
+		oldBase := ghcrBase
+		ghcrBase = srv.URL
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		got := ghcrTagDigest(ghcrRepoSpoke, ReleaseChannelStable, logger)
+		ghcrBase = oldBase
+		srv.Close()
+
+		if got != "" {
+			t.Errorf("status %d: digest = %q, want empty", status, got)
+		}
+		if !strings.Contains(buf.String(), fmt.Sprintf("status=%d", status)) {
+			t.Errorf("status %d was swallowed without a WARN carrying the status.\nlog:\n%s", status, buf.String())
+		}
+	}
+}
+
+// TestGhcrTagDigestSucceedsAndStaysQuiet is the POSITIVE CONTROL for the two
+// tests above: the happy path must return the digest and log NOTHING at WARN.
+// Without this, "warn on every call" would satisfy the failure tests.
+func TestGhcrTagDigestSucceedsAndStaysQuiet(t *testing.T) {
+	const want = "sha256:abc123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/token") {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"token":"t"}`)
+			return
+		}
+		w.Header().Set("Docker-Content-Digest", want)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	oldBase := ghcrBase
+	ghcrBase = srv.URL
+	defer func() { ghcrBase = oldBase }()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	got := ghcrTagDigest(ghcrRepoSpoke, ReleaseChannelStable, logger)
+
+	if got != want {
+		t.Errorf("digest = %q, want %q", got, want)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("a successful resolve logged at WARN: %s", buf.String())
+	}
+}
+
+// TestGetChannelTargetsEmptyResolveDoesNotPoisonCache: a first refresh that
+// resolves NOTHING (cold cache + registry down) must not be latched for the
+// full TTL — once the registry recovers the next call must resolve for real.
+// This is the "empty result poisons the 5-minute cache" failure mode.
+func TestGetChannelTargetsEmptyResolveDoesNotPoisonCache(t *testing.T) {
+	resetChannelTargetCache()
+	orig := ghcrTagDigest
+	t.Cleanup(func() { ghcrTagDigest = orig; resetChannelTargetCache() })
+
+	// Cold cache, registry dark.
+	ghcrTagDigest = func(string, string, *slog.Logger) string { return "" }
+	shas := map[string]string{"v4": "3d31590"}
+	if got := getChannelTargets(shas, testChannelLogger()); targetFor(got, ReleaseChannelStable).Digest != "" {
+		t.Fatalf("expected an empty first resolve, got %+v", got)
+	}
+
+	// Registry recovers. No TTL manipulation: an empty result must not have
+	// been cached as if it were a good answer.
+	ghcrTagDigest = func(_, tag string, _ *slog.Logger) string {
+		if tag == "v4-latest" || tag == ReleaseChannelStable {
+			return "sha256:aaaa"
+		}
+		return ""
+	}
+	got := getChannelTargets(shas, testChannelLogger())
+	if targetFor(got, ReleaseChannelStable).Branch != "v4" {
+		t.Errorf("an empty resolve poisoned the cache: stable = %+v, want branch v4 once the registry recovered", targetFor(got, ReleaseChannelStable))
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -653,20 +653,82 @@ func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// isCSRFSafe reports whether a request may be allowed to MUTATE state.
+//
+// AUDIT F4 (replay half). This used to end with
+//
+//	return strings.Contains(ct, "application/json")
+//
+// which meant a mutation carrying NEITHER Origin NOR Referer was treated as
+// safe as long as it said `Content-Type: application/json`. That fails OPEN, and
+// the Content-Type is not a defence: it is fully attacker-controlled, and — the
+// part that actually matters — Origin is absent in exactly the cases CSRF cares
+// about. A browser omits Origin on plenty of navigations and redirect-issued
+// requests, and Referer is routinely stripped by
+// `Referrer-Policy: no-referrer`, privacy extensions, and corporate proxies. So
+// "no headers" was never a reliable signal of "not a browser"; it was a signal
+// of "we cannot tell", and the old code resolved that ambiguity in the
+// attacker's favour on every requireAuth and requireAdmin write.
+//
+// It now fails CLOSED: a mutation must positively demonstrate it is either
+// same-origin or not-a-browser. There are exactly two ways to do that.
+//
+//  1. Origin (preferred) or Referer matches the hub. Browsers attach Origin to
+//     every cross-origin mutation and cannot forge it from script, which is what
+//     makes it load-bearing.
+//
+//  2. The request authenticates with `Authorization: Bearer …` and sends NO
+//     session cookie. This is the explicit non-browser lane, and it is safe for
+//     a structural reason rather than a stylistic one: CSRF is an AMBIENT
+//     credential attack. A cross-site request rides the cookie the browser
+//     attaches automatically; it cannot attach an Authorization header, because
+//     setting one from script requires CORS permission the hub never grants. A
+//     request whose ONLY credential is a bearer token therefore cannot be
+//     cross-site forged — the attacker would need the token itself, at which
+//     point CSRF is irrelevant.
+//
+//     The "no session cookie" half is not optional. If a request carrying the
+//     ambient cookie could opt out of the CSRF check merely by ALSO presenting a
+//     header, then an attacker who can get any header set (or a stale token
+//     lying in a client) re-opens the hole. Cookie present ⇒ ambient credential
+//     ⇒ Origin must be proven.
+//
+// See getRealAuthUser: Bearer is already a first-class authentication path here,
+// so this is not a new trust surface, only an explicit statement of which lane a
+// caller is using.
 func isCSRFSafe(r *http.Request) bool {
 	if r.Method == "GET" || r.Method == "HEAD" || r.Method == "OPTIONS" {
 		return true
 	}
-	origin := r.Header.Get("Origin")
-	if origin != "" {
+	// Origin first: it is present on cross-origin browser mutations and cannot
+	// be spoofed by page script.
+	if origin := r.Header.Get("Origin"); origin != "" {
 		return isSameOriginAsHub(origin)
 	}
-	referer := r.Header.Get("Referer")
-	if referer != "" {
+	if referer := r.Header.Get("Referer"); referer != "" {
 		return isSameOriginAsHub(referer)
 	}
-	ct := r.Header.Get("Content-Type")
-	return strings.Contains(ct, "application/json")
+	// No origin information. The ONLY remaining way to be safe is to prove this
+	// is not an ambient-credential browser request.
+	return isNonBrowserAPIRequest(r)
+}
+
+// isNonBrowserAPIRequest reports whether a request authenticates purely with a
+// bearer token and carries no ambient session cookie — the one shape that is
+// structurally immune to CSRF. See isCSRFSafe for why both halves are required.
+func isNonBrowserAPIRequest(r *http.Request) bool {
+	if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+		return false
+	}
+	// Any hub session cookie means an ambient credential is in play, and the
+	// request must prove its origin like any other browser mutation. Checked by
+	// presence, not by validity: an INVALID cookie still means a browser sent
+	// one, and letting a bogus cookie value re-enable the bearer bypass would be
+	// a trivially attacker-satisfiable condition.
+	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
+		return false
+	}
+	return true
 }
 
 // hubCanonicalHost is the ONE host that serves the hub's own dashboard and API.

--- a/v2/pkg/hub/saas_bulk_test.go
+++ b/v2/pkg/hub/saas_bulk_test.go
@@ -50,6 +50,12 @@ func bulkPost(t *testing.T, srv *HubServer, user string, body any) (*httptest.Re
 	}
 	req := httptest.NewRequest("POST", "/api/saas/hives/bulk", bytes.NewReader(raw))
 	req.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: mutations now fail CLOSED without Origin/Referer, so this helper
+	// must send the header a real browser would. These tests are about bulk
+	// action semantics (caps, dedup, per-hive ownership), not about CSRF — the
+	// CSRF behaviour is asserted directly in csrf_f4_fail_closed_test.go. Without
+	// this every case here would stop at 403 and silently test nothing.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	if user != "" {
 		req.AddCookie(testAuthCookie(user))
 	}

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -28,9 +28,15 @@ const testHubSecret = "test-hub-secret-f4"
 // the hub now verifies session cookies with. A cookie signed with the raw master
 // no longer verifies (that is the whole point of the fix), so tests must sign
 // with the session sub-key to match getAuthUser / handleAuthUser.
+// testAuthCookie mints the cookie production mints: V2 / Ed25519.
+//
+// AUDIT F1: this helper used to mint the LEGACY symmetric format keyed on the
+// derived session key. That lane is deleted (any spoke holds the same key, so
+// accepting it means any spoke can forge hub admin), and a test helper that
+// keeps minting it would silently exercise a path production no longer has.
 func testAuthCookie(username string) *http.Cookie {
-	sessionKey := deriveDomainKey(testHubSecret, infoSessionKey)
-	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValue(sessionKey, username)}
+	seed := deriveDomainKey(testHubSecret, infoSessionEd25519Seed)
+	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValueV2(seed, username)}
 }
 
 // heartbeatBearer returns the derived HEARTBEAT-domain bearer for a given master

--- a/v2/pkg/hub/saas_user_contact_test.go
+++ b/v2/pkg/hub/saas_user_contact_test.go
@@ -23,6 +23,11 @@ func contactUpdateHandler(srv *HubServer) http.Handler {
 func contactPutRequest(username, body, asUser string) *http.Request {
 	req := httptest.NewRequest("PUT", "/api/saas/admin/users/"+username, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: mutations fail closed without Origin/Referer. These tests cover
+	// admin contact-field authorization and caps; the same-origin header keeps
+	// them past the CSRF gate so they still exercise that. CSRF itself is
+	// asserted in csrf_f4_fail_closed_test.go.
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
 	if asUser != "" {
 		req.AddCookie(testAuthCookie(asUser))
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -979,6 +979,15 @@ type HubServer struct {
 	// never touched while s.mu is held — see hub_session_revocation.go.
 	revokedSessions *revokedSessions
 
+	// revokedSave* coalesce the revocation set's disk writes (audit F15) without
+	// giving up durability: concurrent revocations collapse into one full-file
+	// rewrite instead of one each, but every revocation is still on disk before
+	// its call returns — a deferred-only flush would un-revoke sessions across a
+	// hub roll, which is the F10 bug. Leaf mutex like the store's own, never
+	// touched while s.mu is held — see flushRevokedSessions.
+	revokedSaveMu    sync.Mutex
+	revokedSaveDirty bool
+
 	// urlHealth remembers how many consecutive times each hive's PUBLIC
 	// dashboard URL failed to serve, so a transient blip can be told apart from
 	// a link that has been dead for hours. Populated by the auth-audit loop,

--- a/v2/pkg/hub/session_cookie_asym_test.go
+++ b/v2/pkg/hub/session_cookie_asym_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // N2 (CWE-321/798): the hub session cookie must be ASYMMETRICALLY signed.
@@ -108,11 +109,8 @@ func TestSessionCookieDualVerifyDuringRollout(t *testing.T) {
 	v2Cookie := mintHubUserCookieValueV2(s.sessionSigningSeed(), "alice")
 	legacyCookie := mintHubUserCookieValue(legacySecret, "bob")
 
-	if u, ok := verifyHubUserCookieEither(pub, legacySecret, v2Cookie); !ok || u != "alice" {
-		t.Errorf("v2 cookie failed dual-verify: (%q,%v)", u, ok)
-	}
-	if u, ok := verifyHubUserCookieEither(pub, legacySecret, legacyCookie); !ok || u != "bob" {
-		t.Errorf("legacy cookie failed dual-verify: (%q,%v) — live sessions would break at deploy", u, ok)
+	if _, ok := verifyHubUserCookieEitherAt(pub, legacySecret, legacyCookie, time.Now(), nil); ok {
+		t.Error("AUDIT F1: the legacy symmetric cookie must NOT verify — that lane is deleted")
 	}
 
 	// And once the legacy secret is withdrawn (the follow-up removal PR), the

--- a/v2/pkg/hub/session_f10_f15_test.go
+++ b/v2/pkg/hub/session_f10_f15_test.go
@@ -1,0 +1,292 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// AUDIT F10 (mint flip) and F15 (unauthenticated logout grows the revocation
+// store without bound).
+//
+// F10: production minted V2 cookies, which carry only a username. Their lifetime
+// lives entirely in the client-side MaxAge attribute — which a replaying
+// attacker simply ignores — and they carry no session id, so /api/auth/logout
+// had nothing to revoke and was a no-op against a captured cookie. V3 puts a
+// signed exp and a random sid inside the signature. The spoke-side verifier
+// (v2/proxy/server.js, verifyHubUserCookieEither) already tries v3 → v2 →
+// legacy, so the verifier shipped ahead of the minter and this is a cutover, not
+// a flag day.
+//
+// F15: the logout route is deliberately unauthenticated (logging out must work
+// when the session is already broken). It passed the RAW cookie value to
+// revokeHubSessionCookie, so an anonymous attacker could POST arbitrary values
+// and grow a PERSISTED store without bound, pinning entries with a forged
+// far-future expiry.
+
+// f10f15Server builds a hub whose revocation store points at a temp path.
+func f10f15Server(t *testing.T) *HubServer {
+	t.Helper()
+	cleanup := helperSetupTempDirs(t)
+	t.Cleanup(cleanup)
+	s := newHandlerHub()
+	if s.revokedSessions == nil {
+		s.revokedSessions = newRevokedSessions()
+	}
+	prev := revokedSessionsPath
+	revokedSessionsPath = filepath.Join(t.TempDir(), "revoked.json")
+	t.Cleanup(func() { revokedSessionsPath = prev })
+	return s
+}
+
+// TestF10ProductionMintsV3 is the regression: the cookie the login path actually
+// sets must be v3, i.e. must carry a signed expiry and a revocable session id.
+func TestF10ProductionMintsV3(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mintSessionCookies failed")
+	}
+
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+	if value == "" {
+		t.Fatal("no session cookie minted")
+	}
+
+	if !hubCookieIsV3(value) {
+		t.Errorf("production minted a non-v3 session cookie %q — no signed expiry and "+
+			"no session id, so logout cannot revoke it (F10)", value)
+	}
+	// The two properties that make v3 worth minting, asserted directly rather
+	// than inferred from the version marker.
+	if sid := hubCookieSessionID(value); sid == "" {
+		t.Error("minted cookie carries no session id — nothing for logout to revoke")
+	}
+	if exp := hubCookieExpiry(value); exp <= time.Now().Unix() {
+		t.Errorf("minted cookie has no future signed expiry (exp=%d)", exp)
+	}
+
+	// POSITIVE CONTROL: it must still be a WORKING session. A mint that produced
+	// an unverifiable cookie would satisfy every assertion above while locking
+	// everyone out.
+	if user, ok := s.verifyHubUserCookie(value); !ok || user != "github:alice" {
+		t.Errorf("minted v3 cookie does not verify: (%q, %v)", user, ok)
+	}
+}
+
+// TestF10SignedExpiryIsEnforcedNotAdvisory: the whole point of v3's exp is that
+// it is checked by the verifier, unlike MaxAge which only the browser honours.
+func TestF10SignedExpiryIsEnforcedNotAdvisory(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mint failed")
+	}
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+
+	pub := s.sessionPublicKey()
+	// Valid now (positive control)...
+	if _, ok := verifyHubUserCookieEitherAt(pub, s.sessionKey(), value, time.Now(), nil); !ok {
+		t.Fatal("freshly minted cookie did not verify")
+	}
+	// ...and refused past its signed expiry, even though the value is byte
+	// identical and its signature is still perfectly valid. This is what a
+	// replaying attacker cannot get around.
+	future := time.Now().Add(cookieSessionTTL + time.Hour)
+	if _, ok := verifyHubUserCookieEitherAt(pub, s.sessionKey(), value, future, nil); ok {
+		t.Error("cookie still verified past its signed expiry — exp is not enforced (F10)")
+	}
+}
+
+// TestF10LogoutActuallyRevokes ties the flip to the outcome F10 is about: after
+// logout, the SAME cookie value stops working. Under v2 this was a no-op.
+func TestF10LogoutActuallyRevokes(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mint failed")
+	}
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+
+	// POSITIVE CONTROL: live before logout.
+	if _, ok := s.verifyHubUserCookie(value); !ok {
+		t.Fatal("cookie not valid before logout — setup is wrong")
+	}
+
+	out := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+	req.Header.Set("Origin", f4TrustedOrigin)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: value})
+	s.handleLogout(out, req)
+
+	if _, ok := s.verifyHubUserCookie(value); ok {
+		t.Error("the captured cookie value STILL works after logout — logout is a no-op (F10)")
+	}
+}
+
+// TestF15UnauthenticatedLogoutCannotGrowTheStore is the F15 regression. An
+// anonymous attacker POSTing garbage (or forged) cookie values must not add a
+// single entry to the persisted revocation store.
+func TestF15UnauthenticatedLogoutCannotGrowTheStore(t *testing.T) {
+	s := f10f15Server(t)
+
+	before := len(s.revokedSessions.snapshot())
+
+	// A spread of attacker-controlled shapes: junk, a well-formed-but-unsigned
+	// v3 body, and a v3 cookie signed with the WRONG key.
+	forged, _ := mintHubUserCookieValueV3(
+		"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+		"attacker", time.Now(), 100000*time.Hour)
+
+	for i, value := range []string{
+		"garbage",
+		"not.a.cookie",
+		"eyJ1IjoiYXR0YWNrZXIifQ.v3.bm90YXNpZw",
+		forged,
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+		req.Header.Set("Origin", f4TrustedOrigin)
+		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: value})
+		s.handleLogout(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("case %d: logout status = %d, want 200 (logout must always clear the browser copy)", i, rec.Code)
+		}
+	}
+
+	if got := len(s.revokedSessions.snapshot()); got != before {
+		t.Errorf("revocation store grew from %d to %d entries on UNVERIFIED cookies — "+
+			"an anonymous attacker can grow the persisted store without bound (F15)", before, got)
+	}
+
+	// And nothing was persisted either.
+	if data, err := os.ReadFile(revokedSessionsPath); err == nil && len(data) > 0 {
+		var stored map[string]int64
+		_ = json.Unmarshal(data, &stored)
+		if len(stored) != 0 {
+			t.Errorf("forged logouts wrote %d entries to the PVC (F15)", len(stored))
+		}
+	}
+}
+
+// TestF15LegitimateLogoutStillRevokes is the POSITIVE CONTROL for F15. Verifying
+// before revoking must not break real logout — otherwise "revoke nothing" would
+// pass the regression above and silently re-open F10.
+func TestF15LegitimateLogoutStillRevokes(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mint failed")
+	}
+	var value string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			value = c.Value
+		}
+	}
+	sid := hubCookieSessionID(value)
+
+	out := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+	req.Header.Set("Origin", f4TrustedOrigin)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: value})
+	s.handleLogout(out, req)
+
+	if !s.revokedSessions.isRevoked(sid, time.Now()) {
+		t.Fatal("a LEGITIMATE logout did not revoke the session — verify-before-revoke " +
+			"is too strict and has re-opened F10")
+	}
+	// Durability: the revocation must survive a hub roll, which is the entire
+	// reason the store is on disk. A deferred-only flush would fail here.
+	restarted := &HubServer{logger: s.logger, revokedSessions: newRevokedSessions()}
+	restarted.loadRevokedSessions()
+	if !restarted.revokedSessions.isRevoked(sid, time.Now()) {
+		t.Error("revocation did not survive restart — write coalescing dropped durability")
+	}
+}
+
+// TestF15ExpiryIsClampedToTheMintHorizon: an entry may not be stored further out
+// than the longest session the hub will ever mint. Defence in depth behind
+// verify-before-revoke, so the store's bound does not depend on its caller.
+func TestF15ExpiryIsClampedToTheMintHorizon(t *testing.T) {
+	r := newRevokedSessions()
+	now := time.Now()
+
+	absurd := now.Add(1000 * 24 * time.Hour).Unix()
+	if !r.revoke("sid-far-future", absurd, now) {
+		t.Fatal("revoke refused a new entry")
+	}
+	got := r.snapshot()["sid-far-future"]
+	maxAllowed := now.Add(maxRevokedSessionExpiry).Unix()
+	if got > maxAllowed {
+		t.Errorf("stored expiry %d exceeds the mint horizon %d — a forged far-future exp "+
+			"pins an entry for as long as the attacker likes (F15)", got, maxAllowed)
+	}
+
+	// POSITIVE CONTROL: a NORMAL expiry is stored unchanged, not clamped down to
+	// something uselessly short (which would silently un-revoke sessions early).
+	normal := now.Add(cookieSessionTTL / 2).Unix()
+	if !r.revoke("sid-normal", normal, now) {
+		t.Fatal("revoke refused a normal entry")
+	}
+	if got := r.snapshot()["sid-normal"]; got != normal {
+		t.Errorf("normal expiry was altered: stored %d, want %d", got, normal)
+	}
+}
+
+// TestF15StoreIsHardCapped: the entry count is bounded no matter what.
+func TestF15StoreIsHardCapped(t *testing.T) {
+	r := newRevokedSessions()
+	now := time.Now()
+	exp := now.Add(time.Hour).Unix()
+
+	// Fill to the cap directly (cheaper than driving maxRevokedSessions HTTP
+	// requests, and it is the store's invariant under test).
+	r.mu.Lock()
+	for i := 0; i < maxRevokedSessions; i++ {
+		r.sid["sid-"+strconv.Itoa(i)] = exp
+	}
+	r.mu.Unlock()
+
+	if r.revoke("one-too-many", exp, now) {
+		t.Error("store accepted an entry beyond its hard cap (F15)")
+	}
+	if got := len(r.snapshot()); got > maxRevokedSessions {
+		t.Errorf("store holds %d entries, cap is %d", got, maxRevokedSessions)
+	}
+
+	// POSITIVE CONTROL: at capacity, EXTENDING an existing entry must still
+	// work. Refusing it would leave a session un-revoked, which is the unsafe
+	// direction and exactly the wrong way to enforce a cap.
+	if !r.revoke("sid-0", exp+3600, now) {
+		t.Error("at capacity, extending an EXISTING revocation was refused — that leaves " +
+			"a session live and is the unsafe direction")
+	}
+}

--- a/v2/pkg/hub/slack_test.go
+++ b/v2/pkg/hub/slack_test.go
@@ -21,7 +21,7 @@ func postSlack(t *testing.T, username, body string, path string, pathVals map[st
 	if username != "" {
 		req.AddCookie(&http.Cookie{
 			Name:  "hive_hub_user",
-			Value: mintHubUserCookieValue(deriveDomainKey(slackTestSecret, infoSessionKey), username),
+			Value: mintHubUserCookieValueV2(deriveDomainKey(slackTestSecret, infoSessionEd25519Seed), username),
 		})
 	}
 	rec := httptest.NewRecorder()

--- a/v2/pkg/knowledge/gitsource.go
+++ b/v2/pkg/knowledge/gitsource.go
@@ -204,7 +204,7 @@ func (g *GitSource) ensureCloned(ctx context.Context) error {
 
 	args = append(args, "--", g.config.URL, g.cloneDir)
 
-	cmd := exec.CommandContext(cloneCtx, "git", args...)
+	cmd := exec.CommandContext(cloneCtx, "git", gitCmdArgs(args...)...)
 	cmd.Env = gitSourceEnv()
 
 	output, err := cmd.CombinedOutput()
@@ -474,6 +474,30 @@ func isSCPStyleGitURL(raw string) bool {
 	at := strings.Index(raw, "@")
 	colon := strings.Index(raw, ":")
 	return at > 0 && colon > at+1
+}
+
+// gitNoRedirectArgs are the leading `git -c …` overrides that forbid a remote
+// from bouncing a fetch to a different host AFTER the URL has passed validation.
+//
+// AUDIT F8 (residual). The DNS-pinning fix closed the "resolve the validated
+// hostname to 127.0.0.1" hole, but validation still only inspects the URL the
+// operator configured. git follows HTTP 3xx by default, so a public, allow-listed
+// remote can answer the very first request with `302 Location:
+// http://169.254.169.254/…` (or any in-cluster service) and git will happily
+// re-issue the request there — with credentials, and with every URL/DNS check
+// already behind it. `http.followRedirects=false` makes git treat a redirect as
+// an error instead of a destination, so a validated URL is the ONLY URL fetched.
+//
+// This is passed as `-c` args rather than an env var because there is no
+// GIT_HTTP_FOLLOW_REDIRECTS; http.followRedirects is config-only, and repo-local
+// config is attacker-influenced on a re-used clone dir whereas `-c` on the
+// command line wins over every config file.
+var gitNoRedirectArgs = []string{"-c", "http.followRedirects=false"}
+
+// gitCmdArgs prefixes a git argument list with the redirect suppression above.
+// Every git invocation that talks to a REMOTE must go through this.
+func gitCmdArgs(args ...string) []string {
+	return append(append([]string{}, gitNoRedirectArgs...), args...)
 }
 
 func gitSourceEnv() []string {

--- a/v2/pkg/knowledge/gitsource_f8_redirect_test.go
+++ b/v2/pkg/knowledge/gitsource_f8_redirect_test.go
@@ -1,0 +1,241 @@
+package knowledge
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// AUDIT F8 (residual): redirect SSRF after validation.
+//
+// GitSource validates the configured URL (scheme, host allow-list, and since the
+// DNS-pinning fix, the resolved address too). git then follows HTTP 3xx by
+// DEFAULT, so a public, fully-validated remote can answer the first request with
+// `302 Location: http://169.254.169.254/…` — or any in-cluster Service — and git
+// re-issues the request there with every check already behind it. Validating a
+// URL is worthless if the fetch is allowed to end up somewhere else.
+//
+// TestF8GitCloneRefusesRedirect / TestF8GitPullRefusesRedirect are the
+// regressions, driven against a real local HTTP server that redirects.
+// TestF8GitCloneStillWorksWithoutRedirect is the POSITIVE CONTROL: `git -c
+// http.followRedirects=false` must still clone a normal, non-redirecting remote,
+// or "block all git" would pass the regressions.
+
+func f8RequireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+}
+
+// f8RedirectServer models the F8 scenario with TWO servers.
+//
+// CRITICAL TEST-DESIGN NOTE. The obvious version of this test redirects at
+// 169.254.169.254 and asserts the clone fails. That test passes WITH OR WITHOUT
+// the fix — the clone fails either way, because link-local is simply
+// unroutable. It proves nothing. (Verified: with the fix neutered it still went
+// green.)
+//
+// So the "internal" target here is a REACHABLE local server that counts its
+// requests. The assertion is therefore not "did the clone fail" but "was the
+// internal target contacted AT ALL" — which is exactly the SSRF property, and
+// which flips the moment redirects are followed.
+//
+// front = the validated, allow-listed remote the operator configured.
+// internal = the address it tries to pivot the fetch to.
+func f8RedirectServer(t *testing.T) (remoteURL string, frontHits, internalHits *int) {
+	t.Helper()
+	nFront, nInternal := 0, 0
+
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nInternal++
+		// Answer plausibly so that, if git DOES follow, it keeps going and the
+		// hit is unambiguous rather than an instant transport error.
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(internal.Close)
+
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nFront++
+		http.Redirect(w, r, internal.URL+r.URL.Path, http.StatusFound)
+	}))
+	t.Cleanup(front.Close)
+
+	return front.URL + "/repo.git", &nFront, &nInternal
+}
+
+// f8LocalOriginRepo builds a real git repo on disk and serves it over HTTP via
+// git's dumb protocol, giving the positive control a remote that actually
+// clones without any redirect involved.
+func f8LocalOriginRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "origin")
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	run("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	run("add", "README.md")
+	run("commit", "-q", "-m", "init")
+	// Dumb HTTP needs the server info + a bare-visible layout; simplest reliable
+	// remote for a unit test is the local path itself, which exercises the same
+	// argument plumbing. The redirect cases below are the ones that need HTTP.
+	return repo
+}
+
+// TestF8GitCloneRefusesRedirect: a clone against a remote that 302s must FAIL,
+// and must not have issued a request to the redirect target.
+func TestF8GitCloneRefusesRedirect(t *testing.T) {
+	f8RequireGit(t)
+	remote, frontHits, internalHits := f8RedirectServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dest := filepath.Join(t.TempDir(), "clone")
+	args := gitCmdArgs("clone", "--depth", "1", "--", remote, dest)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, _ := cmd.CombinedOutput()
+
+	// Guard against the test passing for the wrong reason: the front server must
+	// actually have been reached, or nothing about redirects was exercised.
+	if *frontHits == 0 {
+		t.Fatalf("test never reached the validated remote — no redirect was "+
+			"exercised. output: %s", out)
+	}
+	// THE assertion. Following the redirect means issuing a request to the
+	// internal target; suppressing it means never touching that host.
+	if *internalHits != 0 {
+		t.Errorf("git issued %d request(s) to the redirect target after cloning a "+
+			"validated URL — redirect SSRF is live (F8). output: %s", *internalHits, out)
+	}
+	if _, statErr := os.Stat(filepath.Join(dest, ".git")); statErr == nil {
+		t.Error("clone dir was populated despite the redirect")
+	}
+}
+
+// TestF8GitPullRefusesRedirect: same for the sync path. A repo whose origin is
+// a redirecting remote must not follow it on pull.
+func TestF8GitPullRefusesRedirect(t *testing.T) {
+	f8RequireGit(t)
+	remote, frontHits, internalHits := f8RedirectServer(t)
+
+	// gitSourceEnv sets GIT_ALLOW_PROTOCOL=https unless the private opt-in is on,
+	// and httptest only speaks plain HTTP. Without this the pull fails on the
+	// PROTOCOL filter and never reaches the redirect at all — a green test that
+	// proves nothing. (The *hits assertion below is what surfaced this.) The
+	// opt-in is exactly the configuration in which F8 still bites: an operator
+	// who has allowed private/HTTP sources still must not be redirect-pivoted.
+	t.Setenv("HIVE_ALLOW_PRIVATE_GIT_SOURCE", "true")
+
+	// A local repo pointed at the hostile remote — the state after a source has
+	// been cloned once and is now being refreshed.
+	repo := t.TempDir()
+	//
+	// NOTE the branch/upstream wiring: without it `git pull` fails LOCALLY
+	// ("no tracking information") before it ever opens a socket, and the test
+	// would pass whether or not redirects are suppressed. The *hits assertion
+	// below is what catches that — it caught exactly this while writing the test.
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"remote", "add", "origin", remote},
+		{"config", "branch.main.remote", "origin"},
+		{"config", "branch.main.merge", "refs/heads/main"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup git %v: %v: %s", args, err, out)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// The pull is expected to fail; what matters is WHERE it did not go.
+	_ = gitSourcePull(ctx, repo)
+
+	if *frontHits == 0 {
+		t.Fatal("test never reached the validated remote — no redirect was exercised")
+	}
+	if *internalHits != 0 {
+		t.Errorf("git pull issued %d request(s) to the redirect target — redirect "+
+			"SSRF is live on the sync path (F8)", *internalHits)
+	}
+}
+
+// TestF8GitCloneStillWorksWithoutRedirect is the POSITIVE CONTROL. With redirect
+// suppression on, an ordinary remote must still clone. Without this, a change
+// that simply broke every git invocation would pass both regressions above.
+func TestF8GitCloneStillWorksWithoutRedirect(t *testing.T) {
+	f8RequireGit(t)
+	origin := f8LocalOriginRepo(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dest := filepath.Join(t.TempDir(), "clone")
+	args := gitCmdArgs("clone", "--depth", "1", "--branch", "main", "--", origin, dest)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone of a normal remote must still succeed with redirect "+
+			"suppression on; got %v: %s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "README.md")); err != nil {
+		t.Errorf("cloned repo missing content: %v", err)
+	}
+
+	// And the positive control extends to pull: a fast-forward from the same
+	// non-redirecting origin still works.
+	if err := gitPull(ctx, dest); err != nil {
+		t.Errorf("pull from a normal remote must still succeed; got %v", err)
+	}
+}
+
+// TestF8RedirectArgsArePrefixed pins the ARGUMENT SHAPE. `-c` overrides are only
+// honoured before the subcommand; if a refactor ever appends them after
+// "clone", git treats them as a path and the protection silently evaporates
+// with no test failure anywhere else.
+func TestF8RedirectArgsArePrefixed(t *testing.T) {
+	got := gitCmdArgs("clone", "--depth", "1")
+	want := []string{"-c", "http.followRedirects=false", "clone", "--depth", "1"}
+	if len(got) != len(want) {
+		t.Fatalf("gitCmdArgs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("gitCmdArgs = %v, want %v", got, want)
+		}
+	}
+	// gitCmdArgs must not alias or mutate a shared backing array — two calls
+	// must be independent.
+	a := gitCmdArgs("pull")
+	b := gitCmdArgs("fetch")
+	if a[len(a)-1] != "pull" || b[len(b)-1] != "fetch" {
+		t.Errorf("gitCmdArgs calls interfere: a=%v b=%v", a, b)
+	}
+}

--- a/v2/pkg/knowledge/gitsync.go
+++ b/v2/pkg/knowledge/gitsync.go
@@ -112,7 +112,10 @@ func gitPullWithEnv(ctx context.Context, dir string, env []string) error {
 	pullCtx, cancel := context.WithTimeout(ctx, gitPullTimeoutSeconds*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(pullCtx, "git", "pull", "--ff-only")
+	// AUDIT F8 (residual): `--ff-only` bounds what git will MERGE, not where it
+	// will FETCH FROM. Without redirect suppression the remote can 302 this pull
+	// at an internal address after the URL passed validation. See gitNoRedirectArgs.
+	cmd := exec.CommandContext(pullCtx, "git", gitCmdArgs("pull", "--ff-only")...)
 	cmd.Dir = dir
 	cmd.Env = env
 

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -402,6 +402,15 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 			uid, lookupErr := LookupUIDByLocalPort(port)
 			if lookupErr == nil {
 				agentName = p.uidMap.LookupByUID(uid)
+				// The hive's own control plane is not an agent, so the lookup
+				// above returns "". Under v4's forced-proxy egress that made
+				// every hive-originated write — notably the App installation
+				// token mint — look like an unattributable agent, which the
+				// mode gate blocks. Name it explicitly so it is attributed
+				// rather than mistaken for a UID-attribution failure.
+				if agentName == "" && p.uidMap.IsInternalUID(uid) {
+					agentName = internalCallerName
+				}
 			}
 		}
 	}
@@ -843,6 +852,11 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			}
 			req.Body = io.NopCloser(strings.NewReader(string(body)))
 			req.ContentLength = int64(len(body))
+		} else if agentName == internalCallerName {
+			// The hive itself has no ACMM mode to enforce — ACMM governs AGENT
+			// autonomy. Its control-plane calls (App token mint, heartbeat)
+			// must not be gated as if they were agent writes. Repo-filter and
+			// canary-egress checks below still apply.
 		} else if !AllowedByMode(mode, req.Method, req.URL.Path) {
 			blocked = true
 			// An unidentified agent is silently treated as ADVISORY, which turns
@@ -1012,6 +1026,14 @@ func githubWriteBodyMayLeak(method, path string) bool {
 func isGitReceivePack(path string) bool {
 	return strings.HasSuffix(path, "/git-receive-pack")
 }
+
+// internalCallerName attributes a connection that originated from the hive's
+// OWN control plane rather than from a sandboxed agent. It is deliberately not
+// a valid agent name (agents come from the UID map) so it can never collide
+// with one, and it is what distinguishes "the hive called GitHub" from the
+// genuine failure mode the mode gate warns about: "an agent's UID could not be
+// attributed". See UIDMap.IsInternalUID for the security argument.
+const internalCallerName = "hive-internal"
 
 func (p *GitHubProxy) recordViolation(agentName, method, path string) {
 	p.logger.Warn("proxy request blocked", "agent", agentName, "method", method, "path", path)

--- a/v2/pkg/retro/analysis_test.go
+++ b/v2/pkg/retro/analysis_test.go
@@ -1,0 +1,389 @@
+package retro
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestParseAnalysisValid covers the happy path and confirms whitespace is
+// trimmed on every string field.
+func TestParseAnalysisValid(t *testing.T) {
+	content := `some preamble text {"root_cause_hypothesis":"  CI failed late  ","process_improvement":" add pre-submit checks ","generalizable":true,"generalizable_lesson":"Run the same validation locally before opening PRs to catch failures earlier."} trailing`
+	got, err := ParseAnalysis(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.RootCauseHypothesis != "CI failed late" {
+		t.Fatalf("RootCauseHypothesis = %q, want trimmed value", got.RootCauseHypothesis)
+	}
+	if got.ProcessImprovement != "add pre-submit checks" {
+		t.Fatalf("ProcessImprovement = %q, want trimmed value", got.ProcessImprovement)
+	}
+	if !got.Generalizable {
+		t.Fatal("Generalizable = false, want true")
+	}
+	if got.GeneralizableLesson == "" {
+		t.Fatal("GeneralizableLesson should be preserved when generalizable is true")
+	}
+}
+
+// TestParseAnalysisMalformed exercises the edge cases and boundary
+// conditions the issue calls out: empty input, malformed JSON, missing
+// required fields, over-length fields, and lesson-length boundaries.
+func TestParseAnalysisMalformed(t *testing.T) {
+	longField := strings.Repeat("x", MaxAnalysisFieldChars+1)
+	shortLesson := strings.Repeat("y", MinLessonChars-1)
+	longLesson := strings.Repeat("z", MaxLessonChars+1)
+	exactLesson := strings.Repeat("a", MinLessonChars)
+
+	cases := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{"empty input", "", true},
+		{"no braces at all", "just some text with no json", true},
+		{"unbalanced braces end before start", "} nonsense {", true},
+		{"not valid json inside braces", `{not: valid json}`, true},
+		{"two json objects concatenated", `{"root_cause_hypothesis":"a","process_improvement":"b","generalizable":false,"generalizable_lesson":""}{"root_cause_hypothesis":"c","process_improvement":"d","generalizable":false,"generalizable_lesson":""}`, true},
+		{"unknown field rejected", `{"root_cause_hypothesis":"a","process_improvement":"b","generalizable":false,"generalizable_lesson":"","extra_field":"nope"}`, true},
+		{"missing root cause", `{"root_cause_hypothesis":"","process_improvement":"b","generalizable":false,"generalizable_lesson":""}`, true},
+		{"missing process improvement", `{"root_cause_hypothesis":"a","process_improvement":"","generalizable":false,"generalizable_lesson":""}`, true},
+		{"root cause too long", `{"root_cause_hypothesis":"` + longField + `","process_improvement":"b","generalizable":false,"generalizable_lesson":""}`, true},
+		{"process improvement too long", `{"root_cause_hypothesis":"a","process_improvement":"` + longField + `","generalizable":false,"generalizable_lesson":""}`, true},
+		{"generalizable true but lesson too short", `{"root_cause_hypothesis":"a","process_improvement":"b","generalizable":true,"generalizable_lesson":"` + shortLesson + `"}`, true},
+		{"generalizable true but lesson too long", `{"root_cause_hypothesis":"a","process_improvement":"b","generalizable":true,"generalizable_lesson":"` + longLesson + `"}`, true},
+		{"generalizable true with lesson exactly at minimum", `{"root_cause_hypothesis":"a","process_improvement":"b","generalizable":true,"generalizable_lesson":"` + exactLesson + `"}`, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseAnalysis(tt.content)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ParseAnalysis(%q) = nil error, want error", tt.content)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ParseAnalysis(%q) = %v, want no error", tt.content, err)
+			}
+		})
+	}
+}
+
+// TestParseAnalysisNonGeneralizableClearsLesson confirms the lesson is
+// discarded (not merely left alone) when generalizable is false, even if
+// the model supplied lesson text.
+func TestParseAnalysisNonGeneralizableClearsLesson(t *testing.T) {
+	content := `{"root_cause_hypothesis":"a","process_improvement":"b","generalizable":false,"generalizable_lesson":"this text should be dropped because generalizable is false"}`
+	got, err := ParseAnalysis(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.GeneralizableLesson != "" {
+		t.Fatalf("GeneralizableLesson = %q, want empty when not generalizable", got.GeneralizableLesson)
+	}
+}
+
+// TestExtractJSONObject is a positive control on the brace-scanning helper:
+// wrong extraction would break every downstream ParseAnalysis case above.
+func TestExtractJSONObject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no braces", "hello world", ""},
+		{"only open brace", "hello { world", ""},
+		{"only close brace", "hello } world", ""},
+		{"close before open", "} { ", ""},
+		{"simple object", `noise {"a":1} noise`, `{"a":1}`},
+		{"nested object takes outermost span", `pre {"a":{"b":1}} post`, `{"a":{"b":1}}`},
+		{"empty object", "{}", "{}"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractJSONObject(tt.input)
+			if got != tt.want {
+				t.Fatalf("extractJSONObject(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTruncate is a positive control: an off-by-one or missing rune-vs-byte
+// handling would corrupt every prompt built from record/finding text.
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		name string
+		s    string
+		max  int
+		want string
+	}{
+		{"empty string", "", 10, ""},
+		{"shorter than max unchanged", "hello", 10, "hello"},
+		{"exactly at max unchanged", "hello", 5, "hello"},
+		{"longer than max truncated", "hello world", 5, "hello"},
+		{"max zero returns trimmed input unchanged", "hello world", 0, "hello world"},
+		{"negative max returns trimmed input unchanged", "hello world", -1, "hello world"},
+		{"leading and trailing whitespace trimmed first", "  hello  ", 10, "hello"},
+		{"multi-byte runes truncate by rune not byte", "日本語のテスト", 3, "日本語"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncate(tt.s, tt.max)
+			if got != tt.want {
+				t.Fatalf("truncate(%q, %d) = %q, want %q", tt.s, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRuneLen is a positive control for the length checks ParseAnalysis
+// relies on: byte-counting instead of rune-counting would let multi-byte
+// content silently bypass the documented character bounds.
+func TestRuneLen(t *testing.T) {
+	cases := []struct {
+		name string
+		s    string
+		want int
+	}{
+		{"empty", "", 0},
+		{"ascii", "hello", 5},
+		{"trims whitespace before counting", "  hello  ", 5},
+		{"multi-byte runes count as one each", "日本語", 3},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runeLen(tt.s); got != tt.want {
+				t.Fatalf("runeLen(%q) = %d, want %d", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCorrectiveAnalysisPromptIncludesError confirms the retry-guidance
+// prompt actually surfaces the validation error, otherwise the model would
+// retry blind.
+func TestCorrectiveAnalysisPromptIncludesError(t *testing.T) {
+	err := &testErr{"root_cause_hypothesis is required"}
+	got := correctiveAnalysisPrompt(err)
+	if !strings.Contains(got, "root_cause_hypothesis is required") {
+		t.Fatalf("corrective prompt = %q, want it to contain underlying error text", got)
+	}
+	if !strings.Contains(got, "generalizable_lesson") {
+		t.Fatal("corrective prompt should restate the required schema")
+	}
+}
+
+type testErr struct{ msg string }
+
+func (e *testErr) Error() string { return e.msg }
+
+// TestNewAnalyzer covers the exported constructor's branches: blank model
+// (intentional no-op analyzer), blank endpoint (error), and success.
+func TestNewAnalyzer(t *testing.T) {
+	t.Run("blank model returns nil analyzer and nil error", func(t *testing.T) {
+		a, err := NewAnalyzer("http://example.com", "key", "  ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a != nil {
+			t.Fatalf("analyzer = %+v, want nil", a)
+		}
+	})
+	t.Run("blank endpoint with non-blank model errors", func(t *testing.T) {
+		a, err := NewAnalyzer("   ", "key", "gpt-x")
+		if err == nil {
+			t.Fatal("expected error for blank endpoint")
+		}
+		if a != nil {
+			t.Fatalf("analyzer = %+v, want nil on error", a)
+		}
+	})
+	t.Run("valid endpoint and model construct an analyzer", func(t *testing.T) {
+		a, err := NewAnalyzer("http://example.com/", "key", " gpt-x ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a == nil {
+			t.Fatal("analyzer = nil, want non-nil")
+		}
+		if a.model != "gpt-x" {
+			t.Fatalf("model = %q, want trimmed %q", a.model, "gpt-x")
+		}
+		if a.client == nil {
+			t.Fatal("client should be constructed")
+		}
+	})
+}
+
+// TestAnalyzeNilReceiverAndEmptyConfig is a positive control on the
+// fail-open guard at the top of Analyze: a nil analyzer, nil client, or
+// blank model must all return a zero-value Analysis with no error rather
+// than panicking or attempting a network call.
+func TestAnalyzeNilReceiverAndEmptyConfig(t *testing.T) {
+	var nilAnalyzer *Analyzer
+	got, err := nilAnalyzer.Analyze(context.Background(), RetroRecord{}, nil)
+	if err != nil {
+		t.Fatalf("nil analyzer: unexpected error: %v", err)
+	}
+	if got != (Analysis{}) {
+		t.Fatalf("nil analyzer: got %#v, want zero value", got)
+	}
+
+	blankModel := newAnalyzerWithClient("   ", &fakeAnalysisClient{replies: []string{"should never be called"}})
+	got, err = blankModel.Analyze(context.Background(), RetroRecord{}, nil)
+	if err != nil {
+		t.Fatalf("blank model: unexpected error: %v", err)
+	}
+	if got != (Analysis{}) {
+		t.Fatalf("blank model: got %#v, want zero value", got)
+	}
+}
+
+// TestAnalyzeExhaustsRetries is a positive control: if Analyze looped
+// forever or swallowed the terminal error, this would hang or return nil
+// error incorrectly.
+func TestAnalyzeExhaustsRetries(t *testing.T) {
+	client := &fakeAnalysisClient{replies: []string{
+		`not json at all`,
+		`not json at all`,
+		`not json at all`,
+		`not json at all`,
+		`not json at all`,
+	}}
+	analyzer := newAnalyzerWithClient("m", client)
+	_, err := analyzer.Analyze(context.Background(), RetroRecord{BeadID: "b"}, nil)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries on persistently invalid JSON")
+	}
+	if client.calls < 1 {
+		t.Fatal("client should have been called at least once")
+	}
+}
+
+// TestAnalyzePropagatesClientError confirms a transport-level error from the
+// client short-circuits immediately without retrying.
+func TestAnalyzePropagatesClientError(t *testing.T) {
+	client := &fakeAnalysisClient{err: &testErr{"connection refused"}}
+	analyzer := newAnalyzerWithClient("m", client)
+	_, err := analyzer.Analyze(context.Background(), RetroRecord{BeadID: "b"}, nil)
+	if err == nil {
+		t.Fatal("expected error to propagate from client")
+	}
+	if client.calls != 1 {
+		t.Fatalf("calls = %d, want exactly 1 (no retry on transport error)", client.calls)
+	}
+}
+
+// TestOpenAIChatClientComplete exercises the HTTP request/response handling
+// in openAIChatClient.Complete against a local httptest server: success,
+// non-200 status, empty choices, and malformed response bodies.
+func TestOpenAIChatClientComplete(t *testing.T) {
+	t.Run("success returns message content", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer secret-key" {
+				t.Errorf("missing/incorrect Authorization header: %q", r.Header.Get("Authorization"))
+			}
+			if r.URL.Path != "/v1/chat/completions" {
+				t.Errorf("path = %q, want /v1/chat/completions", r.URL.Path)
+			}
+			var req chatRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("failed to decode request body: %v", err)
+			}
+			if req.Model != "gpt-x" {
+				t.Errorf("request model = %q, want gpt-x", req.Model)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello analysis"}}]}`))
+		}))
+		defer srv.Close()
+
+		c := &openAIChatClient{endpoint: srv.URL, apiKey: "secret-key", model: "gpt-x", http: srv.Client()}
+		got, err := c.Complete(context.Background(), []chatMessage{{Role: "user", Content: "hi"}}, 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "hello analysis" {
+			t.Fatalf("content = %q, want %q", got, "hello analysis")
+		}
+	})
+
+	t.Run("no api key omits authorization header", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "" {
+				t.Errorf("Authorization header = %q, want empty", r.Header.Get("Authorization"))
+			}
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+		}))
+		defer srv.Close()
+
+		c := &openAIChatClient{endpoint: srv.URL, apiKey: "", model: "gpt-x", http: srv.Client()}
+		if _, err := c.Complete(context.Background(), nil, 10); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("non-200 status returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		c := &openAIChatClient{endpoint: srv.URL, model: "gpt-x", http: srv.Client()}
+		_, err := c.Complete(context.Background(), nil, 10)
+		if err == nil {
+			t.Fatal("expected error on non-200 status")
+		}
+		if !strings.Contains(err.Error(), strconv.Itoa(http.StatusInternalServerError)) {
+			t.Fatalf("error = %v, want it to mention status %d", err, http.StatusInternalServerError)
+		}
+	})
+
+	t.Run("empty choices returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"choices":[]}`))
+		}))
+		defer srv.Close()
+
+		c := &openAIChatClient{endpoint: srv.URL, model: "gpt-x", http: srv.Client()}
+		_, err := c.Complete(context.Background(), nil, 10)
+		if err == nil {
+			t.Fatal("expected error on empty choices")
+		}
+	})
+
+	t.Run("malformed json body returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{not valid json`))
+		}))
+		defer srv.Close()
+
+		c := &openAIChatClient{endpoint: srv.URL, model: "gpt-x", http: srv.Client()}
+		_, err := c.Complete(context.Background(), nil, 10)
+		if err == nil {
+			t.Fatal("expected error on malformed response body")
+		}
+	})
+}
+
+// TestBuildAnalysisPromptEmptyInput is a boundary case not covered by the
+// existing TestBuildAnalysisPromptBounds in retro_test.go: a record and
+// findings slice that are both entirely empty must still produce a
+// well-formed two-message prompt rather than panicking.
+func TestBuildAnalysisPromptEmptyInput(t *testing.T) {
+	msgs := buildAnalysisPrompt(RetroRecord{}, nil)
+	if len(msgs) != 2 {
+		t.Fatalf("messages = %d, want 2", len(msgs))
+	}
+	if msgs[0].Role != "system" || msgs[1].Role != "user" {
+		t.Fatalf("roles = (%q, %q), want (system, user)", msgs[0].Role, msgs[1].Role)
+	}
+	if !strings.Contains(msgs[1].Content, "DETERMINISTIC_FINDINGS") {
+		t.Fatal("prompt should include the findings section header even with no findings")
+	}
+}


### PR DESCRIPTION
Brings `dd` up to date with `v4` so spokes pinned to `dd-latest` receive today's security fixes.

## Why — this is the recovery path for `daviddiaz0317-visual-hive--1jos`
A pending PR deletes the fleet-wide heartbeat bearer lane ("lane 2") from the hub. Any spoke without the F2 per-hive heartbeat self-derivation change (`c2286f45`) will fail heartbeat auth (401) and go dark.

`daviddiaz0317-visual-hive--1jos` runs `dd-latest` and did **not** have `c2286f45`. The operator accepted that breakage on the understanding that topping up the fork restores the tenant. This PR is that top-up.

## What
Real merge of `origin/v4` into `dd` (not squash, not rebase — long-lived fork, shared history preserved). `dd` carries **27 unique commits** (the `pkg/visualhive` subsystem, governed Visual Hive lifecycle, PRs #1940–#2526). All preserved.

## Conflicts
**None.** Zero conflict hunks — no security-relevant resolution was required, so there was no opportunity to regress a fix the way F14/F18 were previously reverted by reverse-direction syncs.

## Verification
- `go build ./...` — clean
- `git merge-base --is-ancestor c2286f45 HEAD` — **YES** (F2 present)
- **dd's fork survived intact**: `v2/pkg/visualhive/` present with 28 files; `git rev-list --count --no-merges --cherry-pick --right-only origin/v4...HEAD` = **27** (unchanged from pre-merge)
- F14: `requireOwnerRole` present in `v2/pkg/dashboard/api_contribute.go` (4 occurrences)
- F18: `ARG PI_VERSION=0.84.1` pinned in `v2/Dockerfile` (not `latest`); no `*_VERSION=latest` ARGs remain
- `go test ./pkg/hub/ ./pkg/dashboard/ -count=1` — both **ok**
- `pkg/agent` tests skipped (~7 min runtime)