### PR TITLE
fix: stop NFS-induced :3002 liveness flap (bound heartbeat collect, de-lock Start, automaxprocs)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -24,6 +24,18 @@ import (
 	"syscall"
 	"time"
 
+	// automaxprocs sets GOMAXPROCS to match the container's CPU quota (Linux
+	// CFS) at init. Without it the Go runtime sizes its P count to the whole
+	// NODE's core count, so on a many-core IKS worker a pod limited to a few
+	// CPUs spawns far more runnable Ps than its CFS quota can service; when the
+	// quota is exhausted mid-period EVERY goroutine — including the netpoller
+	// that answers the :3002 liveness probe and the heartbeat loop — is
+	// throttled until the next CFS period, which stacks on top of the NFS
+	// stalls to push probe latency past the kubelet timeout. Matching GOMAXPROCS
+	// to the quota removes that self-inflicted throttling. Blank import: its
+	// only job is the init-time side effect.
+	_ "go.uber.org/automaxprocs"
+
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	gh "github.com/google/go-github/v72/github"

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -39,6 +39,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/automaxprocs v1.6.0
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -83,6 +83,8 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -106,6 +106,15 @@ type AgentProcess struct {
 	tmuxSocket        string
 	cancel            context.CancelFunc
 	forceRelaunch     bool
+	// launching is set true under m.mu while Start runs this agent's launch
+	// with m.mu RELEASED (so a slow /data NFS write or a hung MITM-proxy token
+	// mint during launch cannot block AllStatuses()/the heartbeat collect() and
+	// flap /api/livez). It is cleared under m.mu when the launch finishes on
+	// every path (success, error, or panic — via a deferred clear). It exists
+	// solely to serialize concurrent Start(sameName): with m.mu no longer held
+	// across the launch, a second Start would otherwise race the first one's
+	// tmux launch and its guarded-field writes. Guarded by m.mu.
+	launching         bool
 	BootstrapOverride string    // when set, replaces buildBootstrapPrompt output
 	LastError         string    // captured from bare copilot diagnostic launch
 	lastTokenRestart  time.Time // cooldown for auto-restart after token detection
@@ -812,22 +821,31 @@ func (m *Manager) ResolveAgent(nameOrID string) string {
 }
 
 func (m *Manager) Start(ctx context.Context, name string) error {
+	// PHASE 1 — brief critical section: map lookup, the pure in-memory
+	// decisions (running/sandbox), and claiming the per-agent launch guard.
+	// Nothing here does /data NFS I/O or a subprocess/outbound call, so m.mu is
+	// held only for microseconds.
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	agent, ok := m.agents[name]
 	if !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("agent %s not found", name)
 	}
 
 	if agent.State == StateRunning {
+		m.mu.Unlock()
 		return fmt.Errorf("agent %s already running", name)
 	}
 
 	if m.agentSandboxEnabledLocked(agent) {
+		// Sandbox agents never launch a CLI here — this branch only sets
+		// in-memory state and does no I/O, so it completes entirely inside the
+		// Phase-1 lock and never claims the launch guard.
 		if agent.Paused {
 			agent.State = StatePaused
 			m.logger.Info("sandbox agent starting paused", "name", agent.Name, "trigger", agent.PausedTrigger, "persisted", agent.Config.Paused)
+			m.mu.Unlock()
 			return nil
 		}
 		now := time.Now()
@@ -836,9 +854,39 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		agent.HasLaunched = true
 		agent.LaunchedMode = m.agentMode(agent)
 		m.logger.Info("audit: sandbox agent ready", "name", name)
+		m.mu.Unlock()
 		return nil
 	}
 
+	// Serialize concurrent Start(sameName). Once we release m.mu for the
+	// out-of-lock launch below, this guard is the only thing preventing a
+	// second Start from racing this one's tmux launch and guarded-field writes
+	// (m.mu no longer covers the whole method). Refuse the second caller fast.
+	if agent.launching {
+		m.mu.Unlock()
+		return fmt.Errorf("agent %s launch already in progress", name)
+	}
+	agent.launching = true
+	m.mu.Unlock()
+
+	// Clear the guard on EVERY exit from here down (error, park-and-return,
+	// success, or panic). Phase 1's returns above happen before the guard is
+	// set, so they neither set nor need to clear it.
+	defer func() {
+		m.mu.Lock()
+		agent.launching = false
+		m.mu.Unlock()
+	}()
+
+	// PHASE 2 — launch preparation with m.mu RELEASED. sanitizeGitRemotes walks
+	// /data/agents/<name> and runs git subprocesses; ensureTmuxSession does
+	// os.MkdirAll("/data/agents/<name>") + a tmux subprocess. On the NFS RWX
+	// PVC these can block in uninterruptible D-state when the server has stale
+	// locks — but no longer WHILE HOLDING m.mu, so AllStatuses()/the heartbeat
+	// collect() keep taking the RLock, the heartbeat-attempt clock keeps
+	// advancing, and /api/livez stays 200. Neither call mutates m.mu-guarded
+	// AgentProcess fields (they read only immutable Name/UID/tmuxSession/
+	// tmuxSocket and Config), so running them lock-free is race-free.
 	m.sanitizeGitRemotes(agent)
 
 	if err := m.ensureTmuxSession(agent); err != nil {
@@ -877,16 +925,27 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		// strategist stayed paused, which is what exposed this).
 		operatorPaused := agent.Config.Paused || agent.PausedTrigger == "dashboard-api"
 		if IsInferenceBackend(backend) && !operatorPaused {
+			// agent.Paused is an m.mu-guarded field; brief re-lock around the
+			// write so it stays atomic against AllStatuses()/setters.
+			m.mu.Lock()
 			agent.Paused = false
+			m.mu.Unlock()
 			m.logger.Info("auto-unpaused inference agent (transient pause, not operator)", "name", agent.Name, "backend", backend, "trigger", agent.PausedTrigger)
 		} else {
+			m.mu.Lock()
 			agent.State = StatePaused
+			m.mu.Unlock()
 			m.logger.Info("agent starting paused", "name", agent.Name, "backend", backend, "trigger", agent.PausedTrigger, "persisted", agent.Config.Paused)
 			return nil
 		}
 	}
 
 	if m.appAuth != nil && agent.UID > 0 {
+		// Runs with m.mu RELEASED: WriteAgentToken mints a scoped token via an
+		// outbound GitHub API call (through the MITM egress proxy, which the
+		// production incident showed can hang), and issueAgentMintToken can do
+		// the same. Neither writes an m.mu-guarded AgentProcess field, so a hang
+		// here no longer stalls AllStatuses()/the heartbeat while holding m.mu.
 		tier := m.agentMode(agent).TokenTier()
 		if err := m.appAuth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
 			// Be precise about the blast radius. Since audit H3 the shared-cache
@@ -905,6 +964,38 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		m.issueAgentMintToken(agent.Name, tier, agent.UID)
 	}
 
+	// PHASE 3 — launchInTmux. It was written to be called WITH m.mu held: it
+	// mutates m.mu-guarded AgentProcess fields (State, StartedAt, HasLaunched,
+	// LaunchedMode, LastKick/LastKickMessage/KickHistory, LastError, cancel,
+	// launchGen, forceRelaunch, awaitingBobKey, ...) directly with no internal
+	// locking. Re-acquire m.mu for the duration so those writes stay race-free
+	// against AllStatuses()/snapshot() and the model/backend/pause setters —
+	// preserving its original contract exactly (the function is unchanged).
+	//
+	// The launch's own /data reads/writes (ensureTmuxSession has already run
+	// lock-free above; the remaining /data touch is ensureBobAuthSettings on
+	// /data/home for bob agents) are NOT hoisted here — pulling launchInTmux's
+	// deeply interleaved guarded-field writes and NFS I/O apart is a larger,
+	// riskier refactor left for a separate maintainer decision. The three
+	// biggest and most common NFS/proxy blockers (sanitizeGitRemotes,
+	// ensureTmuxSession, WriteAgentToken/mint) are already off the lock above,
+	// which is what breaks the observed fleet-wide liveness flap; a bob-only
+	// /data/home stall under the lock remains a narrower residual.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Re-verify under the re-acquired lock: while m.mu was released for Phase 2,
+	// a concurrent Stop/Remove could have deleted this agent from the map or a
+	// racing path could have started it. The launching guard prevents a second
+	// concurrent Start of THIS agent, but not a Stop/delete, so re-check both
+	// before mutating launch state. (agent still points at the same struct; the
+	// map re-lookup is what detects a delete.)
+	if cur, ok := m.agents[name]; !ok || cur != agent {
+		return fmt.Errorf("agent %s removed during launch", name)
+	}
+	if agent.State == StateRunning {
+		// Another path won the launch race while we were unlocked; nothing to do.
+		return nil
+	}
 	return m.launchInTmux(ctx, agent)
 }
 
@@ -1398,8 +1489,15 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		// auth block BEFORE bob starts. A persisted selectedType beats
 		// BOBSHELL_DEFAULT_AUTH_TYPE, so without this one agent that ever picked
 		// SSO leaves every bob agent on the hive stuck at the auth prompt.
-		// Pure filesystem work on locals only — takes no locks, so it is safe on
-		// this m.mu-holding path.
+		//
+		// NOTE: this writes /data/home/.bob/settings.json, which is on the NFS
+		// RWX PVC — NOT "locals" as an earlier comment claimed. It takes no
+		// Manager lock of its own, but Start still calls launchInTmux with m.mu
+		// held (Phase 3), so an NFS stall here CAN block AllStatuses() for the
+		// NFS timeout. This is the narrower residual left after the Phase-2
+		// hoist (ensureTmuxSession/sanitizeGitRemotes/token writes are already
+		// off the lock); moving bob's /data/home pre-flight off the lock too is
+		// a follow-up for a separate maintainer decision.
 		m.ensureBobAuthSettings(agent.Name, bobSharedHome)
 		// The key resolved above was read by the HIVE process as dev. bob will
 		// read it as the AGENT UID, which is a different question — and the one

--- a/v2/pkg/agent/start_launch_guard_test.go
+++ b/v2/pkg/agent/start_launch_guard_test.go
@@ -72,9 +72,10 @@ func TestStart_RunningAgentStillRejectedBeforeGuard(t *testing.T) {
 	}
 }
 
-// TestStart_UnknownAgentReturnsError keeps the not-found path covered under the
-// restructured Phase-1 critical section (it now unlocks explicitly).
-func TestStart_UnknownAgentReturnsError(t *testing.T) {
+// TestStart_LaunchGuard_UnknownAgentReturnsError keeps the not-found path
+// covered under the restructured Phase-1 critical section (it now unlocks
+// explicitly). Named distinctly from manager_test.go's TestStart_UnknownAgentReturnsError.
+func TestStart_LaunchGuard_UnknownAgentReturnsError(t *testing.T) {
 	t.Setenv("HIVE_WORK_DIR", t.TempDir())
 	m := NewManager(map[string]config.AgentConfig{
 		"cxa": {Backend: "claude"},

--- a/v2/pkg/agent/start_launch_guard_test.go
+++ b/v2/pkg/agent/start_launch_guard_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// These tests cover the per-agent launch guard that lets Manager.Start run its
+// NFS/exec launch work with m.mu RELEASED (so a stalled /data write or a hung
+// MITM-proxy token mint during launch cannot block AllStatuses()/the heartbeat
+// collect() and flap /api/livez). The guard serializes concurrent
+// Start(sameName) that m.mu used to serialize implicitly.
+
+// TestStart_LaunchGuardRejectsConcurrentSameAgent proves a second Start of an
+// agent whose launch is already in progress is refused fast rather than racing
+// the first launch's tmux setup and guarded-field writes.
+func TestStart_LaunchGuardRejectsConcurrentSameAgent(t *testing.T) {
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	m := NewManager(map[string]config.AgentConfig{
+		"cxa": {Backend: "claude"},
+	}, discardLogger(), ProjectContext{})
+
+	// Simulate a launch already in flight (as if another goroutine is in
+	// Phase 2/3 with m.mu released).
+	m.mu.Lock()
+	m.agents["cxa"].launching = true
+	m.mu.Unlock()
+
+	err := m.Start(context.Background(), "cxa")
+	if err == nil {
+		t.Fatal("expected an error when a launch is already in progress, got nil")
+	}
+	if got := err.Error(); got != "agent cxa launch already in progress" {
+		t.Fatalf("unexpected error: %q, want the launch-already-in-progress guard error", got)
+	}
+
+	// The guard flag must be untouched by the rejected call (still owned by the
+	// in-flight launch), not cleared by the loser's deferred clear.
+	m.mu.RLock()
+	stillLaunching := m.agents["cxa"].launching
+	m.mu.RUnlock()
+	if !stillLaunching {
+		t.Error("rejected Start cleared the launching guard — it must leave the in-flight launch's guard intact")
+	}
+}
+
+// TestStart_RunningAgentStillRejectedBeforeGuard proves the StateRunning check
+// still precedes the guard (an already-running agent is rejected without ever
+// touching launching), so the guard governs only genuine launch attempts.
+func TestStart_RunningAgentStillRejectedBeforeGuard(t *testing.T) {
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	m := NewManager(map[string]config.AgentConfig{
+		"cxa": {Backend: "claude"},
+	}, discardLogger(), ProjectContext{})
+
+	m.mu.Lock()
+	m.agents["cxa"].State = StateRunning
+	m.mu.Unlock()
+
+	err := m.Start(context.Background(), "cxa")
+	if err == nil || err.Error() != "agent cxa already running" {
+		t.Fatalf("expected already-running error, got %v", err)
+	}
+
+	m.mu.RLock()
+	launching := m.agents["cxa"].launching
+	m.mu.RUnlock()
+	if launching {
+		t.Error("already-running Start set the launching guard — it must return before claiming it")
+	}
+}
+
+// TestStart_UnknownAgentReturnsError keeps the not-found path covered under the
+// restructured Phase-1 critical section (it now unlocks explicitly).
+func TestStart_UnknownAgentReturnsError(t *testing.T) {
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	m := NewManager(map[string]config.AgentConfig{
+		"cxa": {Backend: "claude"},
+	}, discardLogger(), ProjectContext{})
+
+	if err := m.Start(context.Background(), "nope"); err == nil {
+		t.Fatal("expected an error for an unknown agent, got nil")
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -840,7 +840,22 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	// know. Success is tracked separately, further down, on hub acceptance.
 	recordHeartbeatAttempt()
 
-	payload := collect()
+	// Bound collect() so a wedged collector cannot freeze the loop. collect()
+	// reads the agent manager and governor state, and those reads take locks
+	// (e.g. Manager.AllStatuses -> m.mu.RLock). If some other goroutine holds
+	// m.mu.Lock() while blocked in an uninterruptible NFS write to the RWX
+	// /data PVC (stale locks: "no locks available"), collect() blocks with no
+	// timeout of its own. Because the heartbeat loop runs sendHeartbeat
+	// synchronously in its for-select, a stuck collect() means sendHeartbeat
+	// never returns, the loop never reaches its next tick, and
+	// recordHeartbeatAttempt() stops advancing — after livezHeartbeatStallMax
+	// (6 min) /api/livez reports the loop as stalled and kubelet kills a pod
+	// that is actually alive (the NFS server is stuck, which a restart cannot
+	// fix), producing a fleet-wide liveness crash-loop. The attempt above is
+	// already recorded, so timing collect() out lets the loop keep ticking and
+	// keeps liveness green while the process is genuinely alive; the beat is
+	// simply skipped this cycle and retried on the next tick.
+	payload := collectWithTimeout(ctx, collect, heartbeatTimeout, logger)
 	if payload == nil {
 		return nil
 	}
@@ -918,6 +933,54 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		return &hbResp
 	}
 	return nil
+}
+
+// collectWithTimeout runs collect() with an upper bound so a collector wedged
+// on a lock held by a blocked NFS write (see the call site in sendHeartbeat)
+// cannot stall the heartbeat loop. It returns the payload if collect finishes
+// within timeout, or nil (skip this beat) if it does not.
+//
+// A Go goroutine blocked in an uninterruptible syscall or on a held mutex
+// cannot be cancelled, so a timed-out collect goroutine necessarily keeps
+// running until its blocker clears — this cannot be avoided, only contained.
+// It is contained here: the goroutine sends on a buffered (cap 1) channel, so
+// the eventual send never blocks even though sendHeartbeat has already
+// returned, and the late payload is simply dropped (GC'd with the channel).
+// No double-record occurs: recordHeartbeatAttempt already ran in the caller,
+// and this helper never records anything itself. If collect panics, the panic
+// is recovered and reported as a nil (skipped) payload rather than crashing
+// the heartbeat goroutine.
+func collectWithTimeout(ctx context.Context, collect StatusCollector, timeout time.Duration, logger *slog.Logger) *HeartbeatPayload {
+	// Buffered so the collect goroutine can always complete its send and exit
+	// even after we have stopped waiting — prevents a permanent goroutine leak
+	// once the blocker (NFS) finally releases.
+	done := make(chan *HeartbeatPayload, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if logger != nil {
+					logger.Warn("hub heartbeat collect panicked", "recover", r)
+				}
+				done <- nil
+			}
+		}()
+		done <- collect()
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case payload := <-done:
+		return payload
+	case <-timer.C:
+		if logger != nil {
+			logger.Warn("hub heartbeat collect timed out — skipping this beat; loop keeps ticking so liveness stays green",
+				"timeout", timeout.String())
+		}
+		return nil
+	case <-ctx.Done():
+		return nil
+	}
 }
 
 func publicURLSelfCheckFor(ctx context.Context, rawURL string, logger *slog.Logger) *PublicURLSelfCheck {

--- a/v2/pkg/hub/heartbeat_collect_timeout_test.go
+++ b/v2/pkg/hub/heartbeat_collect_timeout_test.go
@@ -1,0 +1,161 @@
+package hub
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// These tests are the positive control for the NFS -> m.mu -> collect() ->
+// frozen-liveness stall fix. collect() reads the agent manager under m.mu.RLock
+// (Manager.AllStatuses); if another goroutine holds m.mu.Lock() while blocked
+// in an uninterruptible NFS write to /data, collect() blocks with no timeout of
+// its own. Because sendHeartbeat runs synchronously in the heartbeat loop's
+// for-select, a stuck collect() means sendHeartbeat never returns, the loop
+// never ticks again, and recordHeartbeatAttempt() stops advancing — after
+// livezHeartbeatStallMax /api/livez reports the loop as stalled and kubelet
+// kills an otherwise-alive pod. collectWithTimeout bounds collect() so the loop
+// keeps ticking and liveness stays green.
+
+// TestCollectWithTimeout_BlockedCollectReturnsAndDoesNotBlock is the core
+// positive control: a collect() that never returns must NOT hang
+// collectWithTimeout — it returns nil (skip this beat) at the timeout, well
+// before the test's own deadline.
+func TestCollectWithTimeout_BlockedCollectReturnsAndDoesNotBlock(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) }) // unblock the leaked goroutine at test end
+
+	blocked := func() *HeartbeatPayload {
+		<-release // simulate an NFS-wedged AllStatuses() that never returns in time
+		return &HeartbeatPayload{HiveID: "late"}
+	}
+
+	const timeout = 50 * time.Millisecond
+	done := make(chan *HeartbeatPayload, 1)
+	go func() {
+		done <- collectWithTimeout(context.Background(), blocked, timeout, nil2Logger())
+	}()
+
+	select {
+	case payload := <-done:
+		if payload != nil {
+			t.Fatalf("expected nil (skipped beat) from a blocked collect, got %+v", payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("collectWithTimeout did NOT return on a blocked collect — the heartbeat loop would freeze and liveness would 503")
+	}
+}
+
+// TestCollectWithTimeout_FastCollectReturnsPayload proves the happy path is
+// unchanged: a collect() that finishes within the timeout returns its payload.
+func TestCollectWithTimeout_FastCollectReturnsPayload(t *testing.T) {
+	want := &HeartbeatPayload{HiveID: "hive-1"}
+	got := collectWithTimeout(context.Background(), func() *HeartbeatPayload {
+		return want
+	}, time.Second, nil2Logger())
+	if got != want {
+		t.Fatalf("collectWithTimeout returned %+v, want %+v", got, want)
+	}
+}
+
+// TestCollectWithTimeout_PanicRecovered proves a panicking collect() does not
+// crash the heartbeat goroutine — it is reported as a skipped (nil) beat.
+func TestCollectWithTimeout_PanicRecovered(t *testing.T) {
+	got := collectWithTimeout(context.Background(), func() *HeartbeatPayload {
+		panic("boom")
+	}, time.Second, nil2Logger())
+	if got != nil {
+		t.Fatalf("expected nil after a panicking collect, got %+v", got)
+	}
+}
+
+// TestCollectWithTimeout_LateGoroutineDoesNotLeakPermanently proves the timed-
+// out collect goroutine can still complete its send after collectWithTimeout
+// has returned (the channel is buffered), so once the NFS blocker clears the
+// goroutine exits rather than leaking forever.
+func TestCollectWithTimeout_LateGoroutineDoesNotLeakPermanently(t *testing.T) {
+	release := make(chan struct{})
+	var once sync.Once
+	exited := make(chan struct{})
+
+	blocked := func() *HeartbeatPayload {
+		<-release
+		once.Do(func() { close(exited) })
+		return &HeartbeatPayload{HiveID: "late"}
+	}
+
+	got := collectWithTimeout(context.Background(), blocked, 20*time.Millisecond, nil2Logger())
+	if got != nil {
+		t.Fatalf("expected nil (timed out), got %+v", got)
+	}
+
+	// Now let the wedged collect finish, as a real NFS server eventually would.
+	close(release)
+	select {
+	case <-exited:
+		// Goroutine completed its buffered send and returned — no permanent leak.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed-out collect goroutine never completed after its blocker cleared — permanent goroutine leak")
+	}
+}
+
+// TestCollectWithTimeout_ContextCancelReturns proves a cancelled context short-
+// circuits the wait (loop shutdown must not block on a wedged collect).
+func TestCollectWithTimeout_ContextCancelReturns(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := collectWithTimeout(ctx, func() *HeartbeatPayload {
+		<-release
+		return &HeartbeatPayload{}
+	}, time.Hour, nil2Logger())
+	if got != nil {
+		t.Fatalf("expected nil on a cancelled context, got %+v", got)
+	}
+}
+
+// TestSendHeartbeat_BlockedCollectStillAdvancesAttemptAndReturns is the end-to-
+// end positive control at the sendHeartbeat level: even when collect() is
+// wedged, recordHeartbeatAttempt has run (attempt clock advanced) AND
+// sendHeartbeat returns (the loop keeps ticking) — the exact combination that
+// keeps /api/livez green through an NFS stall.
+func TestSendHeartbeat_BlockedCollectStillAdvancesAttemptAndReturns(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	blocked := func() *HeartbeatPayload {
+		<-release
+		return &HeartbeatPayload{HiveID: "late"}
+	}
+
+	before := time.Now().Truncate(time.Second)
+
+	done := make(chan *HeartbeatResponse, 1)
+	go func() {
+		done <- sendHeartbeat(context.Background(), "http://127.0.0.1:1", blocked, nil2Logger())
+	}()
+
+	select {
+	case resp := <-done:
+		if resp != nil {
+			t.Fatalf("expected nil response when collect() is wedged, got %+v", resp)
+		}
+	case <-time.After(heartbeatTimeout + 5*time.Second):
+		t.Fatal("sendHeartbeat did not return with a wedged collect — the heartbeat loop would freeze and liveness would 503")
+	}
+
+	got, ok := LastHeartbeatAttempt()
+	if !ok || got.Before(before) {
+		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt at/after %v even though collect() was wedged", got, ok, before)
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Error("LastHeartbeatSuccess() ok = true, want false: the beat was skipped, not delivered")
+	}
+}


### PR DESCRIPTION
## Problem: fleet-wide `:3002` liveness flap on NFS-backed spokes

On clusters whose `/data` is an **NFS RWX PVC** (observed on a-ks-wec2 / IKS, all 5 hive spokes, `v4-latest`), the spoke dashboard's `/api/livez` probe periodically returns **503** and kubelet crash-loops otherwise-healthy pods (~every 20-30 min). It affects even near-idle placeholder hives, and `kubectl exec` also hangs during the window — the tell-tale of a node/NFS-level stall, not agent CPU load.

### Root cause — a lock+NFS coupling that freezes the liveness signal

`/api/livez` is (correctly) gated on the heartbeat loop's **attempt** timestamp: if `LastHeartbeatAttempt()` goes stale for `livezHeartbeatStallMax` (6 min) the loop is judged wedged and the pod is restarted (`v2/pkg/dashboard/server.go:1731`, `:1761-1770`). The attempt timestamp is recorded at the **top** of every `sendHeartbeat` (`v2/pkg/hub/heartbeat.go:841`), so it only advances if `sendHeartbeat` returns and the loop reaches its next tick. The loop runs `sendHeartbeat` **synchronously** in a `for-select`.

The freeze happens like this:

```
agent op holds Manager.mu.Lock()  ──(blocked in uninterruptible NFS write to /data)──►
   heartbeat collect() → AllStatuses() blocks on m.mu.RLock()  (no timeout)
   → sendHeartbeat never returns → loop never ticks
   → recordHeartbeatAttempt() stops advancing
   → after 6 min /api/livez → 503 → pod killed
   → new pod re-stalls on the same stuck NFS server → fleet-wide flap
```

Two things make an agent op hold `m.mu` across a blocking NFS write:
- `Manager.Start` held `m.mu.Lock()` across its **entire** body, including `sanitizeGitRemotes` (walks `/data/agents/<name>` + git subprocesses), `ensureTmuxSession` (`os.MkdirAll("/data/agents/<name>")` + tmux subprocess), and `WriteAgentToken`/`issueAgentMintToken` (mint a scoped token via an outbound GitHub call through the MITM egress proxy, which the incident showed can hang).
- `collect()` (the hub heartbeat's `StatusCollector`) calls `AllStatuses()` → `m.mu.RLock()`, and `collect()` had **no timeout of its own**.

The readiness `/api/health` `context deadline exceeded` and the hanging `kubectl exec` are the node-level face of the same NFS stall (D-state processes), compounded by the Go runtime sizing `GOMAXPROCS` to the whole node's core count and getting CFS-throttled.

## The fix — break every link of that chain (v4-only)

### 1. Bound `collect()` in the heartbeat loop — `v2/pkg/hub/heartbeat.go`
`sendHeartbeat` now calls `collectWithTimeout(ctx, collect, heartbeatTimeout, logger)` (10s). The attempt is already recorded before this runs, so a wedged `collect()` is **timed out** and the beat skipped — the loop keeps ticking, `recordHeartbeatAttempt()` keeps advancing, and `/api/livez` stays 200 while the process is genuinely alive. The timed-out collect goroutine sends on a **buffered (cap 1)** channel so it exits (no permanent leak) once the NFS blocker clears; a panicking collect is recovered rather than crashing the loop; a cancelled context short-circuits the wait.

### 2. Run `Manager.Start` launch prep off `m.mu` — `v2/pkg/agent/manager.go`
`Start` is restructured into three phases:
- **Phase 1** (m.mu held, microseconds): map lookup, running/sandbox decisions, and claim a new per-agent `launching` guard (`AgentProcess.launching`, m.mu-guarded).
- **Phase 2** (m.mu **released**): `sanitizeGitRemotes`, `ensureTmuxSession`, and the token writes — the heavy NFS/proxy work no longer holds `m.mu`, so `AllStatuses()`/`collect()` keep taking the RLock. The paused-decision's guarded-field writes take a brief re-lock.
- **Phase 3** (m.mu re-acquired): re-verify the agent still exists and isn't already running (a Stop/delete or racing Start could have landed while unlocked), then call `launchInTmux` **unchanged** — it mutates m.mu-guarded fields directly and was written to be called with the lock held, so its contract is preserved exactly.

The `launching` guard replaces the serialization `m.mu` used to provide implicitly: a second concurrent `Start(sameName)` is refused fast (`launch already in progress`). A single deferred clear releases it on every exit (error, park-and-return, success, panic).

**Residual (documented, not fixed here):** `launchInTmux`'s bob-only `/data/home` pre-flight (`ensureBobAuthSettings`) still runs under the re-acquired lock — pulling its deeply interleaved guarded-field writes and NFS I/O apart is a larger refactor left for a separate maintainer decision. The three biggest and most common blockers are already off the lock, which is what breaks the observed flap. The stale "locals only" comment on that path is corrected to name the residual.

### 3. `go.uber.org/automaxprocs` — `v2/cmd/hive/main.go`
Blank import so the Go runtime sizes `GOMAXPROCS` to the pod's CFS CPU quota instead of the node's core count, removing the CFS-throttling that stacks on the NFS stalls to push probe latency past the kubelet timeout. **Resolved cleanly via `go get go.uber.org/automaxprocs@v1.6.0`** (go.mod/go.sum updated; its only non-test deps are already-present modules).

## Tests (positive controls)
- `v2/pkg/hub/heartbeat_collect_timeout_test.go` — a `collect()` that **never returns** must NOT hang `sendHeartbeat` and must still leave the attempt clock advanced (the exact freeze this fixes); plus fast-path, panic-recovery, no-permanent-leak, and context-cancel cases.
- `v2/pkg/agent/start_launch_guard_test.go` — a concurrent same-agent `Start` is rejected with `launch already in progress` and leaves the in-flight guard intact; running/unknown agents are rejected before the guard is claimed.

## Scope
**v4-only.** No v2 / mk / dd / v3 counterpart is intended. Do not merge automatically — for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
