### PR TITLE
✅ ci: adopt the strict docker smoke test (the old one could not fail)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -145,7 +145,21 @@ jobs:
         run: docker build -f v2/Dockerfile -t hive:test .
 
       - name: Smoke test
-        run: docker run --rm hive:test --help || true
+        shell: bash
+        run: |
+          set -euo pipefail
+          name="hive-v2-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker rm -f -v "$name" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          # --cap-add NET_ADMIN mirrors the production contract: the pod spec
+          # grants it (SCC hive-netadmin) and the image binary carries
+          # cap_net_admin+ep file caps (SO_MARK egress attribution), so exec
+          # under docker's default cap set fails EPERM by design, not by bug.
+          # The old `--help || true` form could not fail and asserted nothing.
+          timeout --signal=TERM --kill-after=10s 60s \
+            docker run --rm --name "$name" --network none --cap-add NET_ADMIN hive:test --version
 
   nightly-release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/v2'

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -830,6 +830,15 @@ func singletonLockPath() string {
 const spokeRestartMinUptime = 10 * time.Minute
 
 func main() {
+	// --version fast path, before any flag parsing or startup work: the CI
+	// smoke test (and operators) probe the binary with `hive --version`; the
+	// standard flag set would reject it ("flag provided but not defined").
+	// dd's full CLI dispatcher handles this via a version subcommand; this is
+	// the minimal equivalent for the v4 line.
+	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "version") {
+		fmt.Printf("hive 3.0.0 (commit %s, branch %s)\n", gitShort, gitBranch)
+		return
+	}
 	startTime := time.Now()
 	defaultConfig := "/etc/hive/hive.yaml"
 	if envCfg := os.Getenv("HIVE_CONFIG"); envCfg != "" {


### PR DESCRIPTION
Follow-up from the #3691 endgame: v4's smoke was `docker run --rm hive:test --help || true` — structurally unable to fail, which is how the image's cap_net_admin+ep exec-EPERM under docker's default capability set stayed invisible for weeks until dd's strict smoke surfaced it. This adopts dd's proven version verbatim: named container + cleanup trap, --network none, 60s timeout, --cap-add NET_ADMIN (the production pod contract via the hive-netadmin SCC), asserting `--version` genuinely executes.