### PR TITLE
fix(sec): derive a per-hive HIVE_INVITE_KEY so spokes stop using the raw master

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/hub"
 )
 
 const (
@@ -63,13 +64,31 @@ var (
 )
 
 // inviteSigningSecret returns the HMAC key used to sign/verify invite tokens.
-// It prefers the operator-configured HIVE_HUB_SECRET (already the cross-hive
-// shared secret) so invites are consistent across a federated deployment; if
-// that is unset it lazily generates and persists a per-instance random secret
-// beside the contributor store. Either way the secret never leaves the server —
-// the token the client sees is opaque.
+//
+// Resolution order, most to least identity-bound:
+//
+//  1. HIVE_INVITE_KEY — the hub-injected PER-HIVE key (hub.provisionInviteKey,
+//     HMAC(master, "hive-invite-v1" || 0x00 || hiveID)). Preferred, and the reason
+//     this var exists: it lets a hosted spoke sign invites without ever holding
+//     the master.
+//  2. HIVE_HUB_SECRET — the raw master, the historical lane. Kept for spokes on an
+//     older Deployment that predates HIVE_INVITE_KEY, and for self-hosted hives
+//     whose operator legitimately holds the master. Using the master AS the HMAC
+//     key is exactly what we are moving away from; this fallback is transitional
+//     and is removed once the fleet has re-provisioned.
+//  3. A lazily generated, persisted per-instance random secret beside the
+//     contributor store, when neither var is set.
+//
+// Either way the secret never leaves the server — the token the client sees is
+// opaque. NOTE: invite tokens are signed with this key, so a hive whose key
+// CHANGES invalidates in-flight invite links (see the PR body); a spoke that
+// gains HIVE_INVITE_KEY re-keys exactly once.
 func inviteSigningSecret() []byte {
 	inviteSecretOnce.Do(func() {
+		if v := strings.TrimSpace(os.Getenv(hub.EnvInviteKey)); v != "" {
+			inviteSecretCache = []byte(v)
+			return
+		}
 		if v := strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")); v != "" {
 			inviteSecretCache = []byte(v)
 			return

--- a/v2/pkg/dashboard/invite_signing_key_test.go
+++ b/v2/pkg/dashboard/invite_signing_key_test.go
@@ -1,0 +1,136 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+)
+
+// Invite tokens are HMAC-signed with inviteSigningSecret(). Historically that key
+// was the RAW master HIVE_HUB_SECRET, which made the invite lane the last
+// spoke-side consumer that actually needed the master to function. These tests
+// pin the new resolution order — HIVE_INVITE_KEY, then HIVE_HUB_SECRET, then a
+// persisted per-instance random file — and pin that the lanes are cryptographically
+// distinct, so a token signed under one does not verify under another.
+
+const (
+	testInviteKey    = "per-hive-invite-key-aaaaaaaaaaaaaaaa"
+	testInviteMaster = "master-hub-secret-bbbbbbbbbbbbbbbb"
+)
+
+// inviteTestNow is a fixed instant well inside inviteTokenTTL, so expiry never
+// confounds a signature assertion.
+var inviteTestNow = time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+// TestInviteSigningSecretPrefersInviteKey pins that the dedicated per-hive key
+// wins over the master when BOTH are set. This is the whole point of the change:
+// a re-provisioned spoke stops using the master even if it still carries one.
+func TestInviteSigningSecretPrefersInviteKey(t *testing.T) {
+	t.Setenv("HIVE_INVITE_KEY", testInviteKey)
+	t.Setenv("HIVE_HUB_SECRET", testInviteMaster)
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
+	resetInviteSecretForTest(t)
+
+	if got := string(inviteSigningSecret()); got != testInviteKey {
+		t.Fatalf("inviteSigningSecret() = %q, want the dedicated HIVE_INVITE_KEY %q", got, testInviteKey)
+	}
+}
+
+// TestInviteSigningSecretFallsBackToMaster pins the transitional lane: a spoke on
+// an older Deployment that has no HIVE_INVITE_KEY must keep signing with the
+// master, so existing hives are not broken by this change.
+func TestInviteSigningSecretFallsBackToMaster(t *testing.T) {
+	t.Setenv("HIVE_INVITE_KEY", "")
+	t.Setenv("HIVE_HUB_SECRET", testInviteMaster)
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
+	resetInviteSecretForTest(t)
+
+	if got := string(inviteSigningSecret()); got != testInviteMaster {
+		t.Fatalf("inviteSigningSecret() = %q, want the HIVE_HUB_SECRET fallback %q", got, testInviteMaster)
+	}
+}
+
+// TestInviteSigningSecretFallsBackToRandomFile pins the self-hosted lane where no
+// key material is configured at all: a random secret is generated and PERSISTED,
+// so invite links survive a restart.
+func TestInviteSigningSecretFallsBackToRandomFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HIVE_INVITE_KEY", "")
+	t.Setenv("HIVE_HUB_SECRET", "")
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", dir)
+	resetInviteSecretForTest(t)
+
+	first := string(inviteSigningSecret())
+	if first == "" {
+		t.Fatal("inviteSigningSecret() returned empty with no env key configured; want a generated secret")
+	}
+	if first == testInviteKey || first == testInviteMaster {
+		t.Fatalf("inviteSigningSecret() = %q, want a generated secret, not an env value", first)
+	}
+
+	// Persisted: a fresh process (simulated by resetting the once) reads the same
+	// secret back off disk rather than minting a new one.
+	resetInviteSecretForTest(t)
+	if second := string(inviteSigningSecret()); second != first {
+		t.Fatalf("generated invite secret not persisted: got %q on reload, want %q", second, first)
+	}
+}
+
+// TestInviteTokenRoundTripUnderEachLane is the POSITIVE CONTROL for the
+// cross-lane test below. If sign/verify were broken outright — or if
+// verifyInviteToken always returned "" — the cross-lane assertions would pass
+// for entirely the wrong reason. This proves each lane genuinely works.
+func TestInviteTokenRoundTripUnderEachLane(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		inviteKey string
+		master    string
+	}{
+		{name: "invite key lane", inviteKey: testInviteKey, master: ""},
+		{name: "master fallback lane", inviteKey: "", master: testInviteMaster},
+		{name: "generated file lane", inviteKey: "", master: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HIVE_INVITE_KEY", tc.inviteKey)
+			t.Setenv("HIVE_HUB_SECRET", tc.master)
+			t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
+			resetInviteSecretForTest(t)
+
+			const inviter = "octocat"
+			token := mintInviteToken(inviter, inviteTestNow)
+			if got := verifyInviteToken(token, inviteTestNow); got != inviter {
+				t.Fatalf("round trip failed: verifyInviteToken = %q, want %q", got, inviter)
+			}
+		})
+	}
+}
+
+// TestInviteTokenDoesNotVerifyAcrossKeys pins the security property: the lanes are
+// cryptographically distinct. A token signed while the spoke used the master must
+// NOT verify once the spoke is re-provisioned with a per-hive HIVE_INVITE_KEY, and
+// a token from one hive's invite key must not verify under another's. This is the
+// documented one-time re-key, asserted rather than assumed.
+func TestInviteTokenDoesNotVerifyAcrossKeys(t *testing.T) {
+	const inviter = "octocat"
+
+	// Sign under the master lane.
+	t.Setenv("HIVE_INVITE_KEY", "")
+	t.Setenv("HIVE_HUB_SECRET", testInviteMaster)
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
+	resetInviteSecretForTest(t)
+	masterToken := mintInviteToken(inviter, inviteTestNow)
+
+	// Verify under the per-hive invite lane: must fail.
+	t.Setenv("HIVE_INVITE_KEY", testInviteKey)
+	resetInviteSecretForTest(t)
+	if got := verifyInviteToken(masterToken, inviteTestNow); got != "" {
+		t.Fatalf("master-signed token verified under HIVE_INVITE_KEY as %q, want rejection", got)
+	}
+
+	// And a token minted under hive A's invite key must not verify under hive B's.
+	aToken := mintInviteToken(inviter, inviteTestNow)
+	t.Setenv("HIVE_INVITE_KEY", testInviteKey+"-different-hive")
+	resetInviteSecretForTest(t)
+	if got := verifyInviteToken(aToken, inviteTestNow); got != "" {
+		t.Fatalf("hive A invite token verified under hive B's key as %q, want rejection", got)
+	}
+}

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -44,6 +44,14 @@ const (
 	infoSSOKey         = "hive-sso-v1"
 	infoImpersonateKey = "hive-impersonate-v1"
 
+	// infoInviteKey derives the PER-HIVE HMAC key that signs contributor invite
+	// tokens (dashboard.inviteSigningSecret). Invite tokens carry attribution, not
+	// access, so this is the lowest-value key in the set — but it was the LAST
+	// spoke-side consumer of the raw master HIVE_HUB_SECRET, which is why it gets
+	// its own derived lane. Per-hive rather than fleet-wide because an invite
+	// minted on one tenant's hive has no business verifying on another's.
+	infoInviteKey = "hive-invite-v1"
+
 	// infoSSOEd25519Seed derives the SSO signing SEED for the C2 follow-up: SSO is
 	// now ASYMMETRIC. deriveDomainKey(master, infoSSOEd25519Seed) yields a 32-byte
 	// (hex) value used verbatim as the Ed25519 seed (ed25519.SeedSize == 32, and a
@@ -188,6 +196,22 @@ func provisionHeartbeatKey(hiveID string) string {
 	return derivePerHiveKey(provisionMasterSecret(), infoHeartbeatKey, hiveID)
 }
 
+// provisionInviteKey returns the PER-HIVE contributor-invite signing key injected
+// into a spoke as HIVE_INVITE_KEY.
+//
+// Mirrors provisionTerminalKey exactly: the token is both minted and verified on
+// the same spoke (dashboard/api_contribute.go), so a symmetric key is the right
+// shape, and binding it to the hive ID means an invite link from one tenant is
+// meaningless on another.
+//
+// The point of this var is removing the last spoke-side READER of the raw master:
+// inviteSigningSecret() used HIVE_HUB_SECRET itself as the HMAC key, so the invite
+// lane was the one place a spoke still needed the master to function. With this
+// injected it does not.
+func provisionInviteKey(hiveID string) string {
+	return derivePerHiveKey(provisionMasterSecret(), infoInviteKey, hiveID)
+}
+
 // heartbeatKeyFor returns the per-hive heartbeat bearer the hub EXPECTS from
 // hiveID. Mirror of provisionHeartbeatKey, resolved against the running hub's
 // own master rather than the provisioning-time lookup.
@@ -268,6 +292,10 @@ const (
 	// re-provisions them with the public key.
 	EnvSSOPublicKey = "HIVE_SSO_PUBLIC_KEY"
 	EnvSSOKeyLegacy = "HIVE_SSO_KEY"
+	// EnvInviteKey carries the per-hive contributor-invite signing key. The spoke
+	// both mints and verifies invite tokens with it, so it is symmetric; it exists
+	// so inviteSigningSecret() no longer has to read the raw master.
+	EnvInviteKey = "HIVE_INVITE_KEY"
 )
 
 // spokeDomainKey resolves a domain sub-key for spoke-side code. It prefers the

--- a/v2/pkg/hub/invite_key_test.go
+++ b/v2/pkg/hub/invite_key_test.go
@@ -1,0 +1,77 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// provisionInviteKey is the hub side of HIVE_INVITE_KEY: it derives the per-hive
+// contributor-invite signing key that lets a spoke sign invites WITHOUT holding
+// the raw master. These tests pin that it is genuinely per-hive, genuinely
+// domain-separated from the other sub-keys, and never the master itself.
+
+const testInviteMasterSecret = "test-master-secret-invite"
+
+// TestProvisionInviteKeyIsPerHive pins that two hives get different invite keys,
+// so an invite token minted on one tenant cannot verify on another.
+func TestProvisionInviteKeyIsPerHive(t *testing.T) {
+	t.Setenv("HIVE_HUB_SECRET", testInviteMasterSecret)
+
+	a := provisionInviteKey("hive-alpha")
+	b := provisionInviteKey("hive-beta")
+
+	// Positive control: derivation actually produced key material. Without this a
+	// bug returning "" for everything would satisfy the inequality below.
+	if a == "" || b == "" {
+		t.Fatalf("provisionInviteKey returned empty: alpha=%q beta=%q", a, b)
+	}
+	if a == b {
+		t.Fatalf("invite key is fleet-uniform: alpha and beta both = %q, want per-hive keys", a)
+	}
+	// Deterministic: the hub must re-derive the same value on every provision.
+	if again := provisionInviteKey("hive-alpha"); again != a {
+		t.Fatalf("provisionInviteKey not deterministic: got %q then %q", a, again)
+	}
+}
+
+// TestProvisionInviteKeyIsNotTheMaster pins the security property that motivated
+// the change: the injected value must not be the master, nor equal to any other
+// derived sub-key for the same hive (domain separation).
+func TestProvisionInviteKeyIsNotTheMaster(t *testing.T) {
+	t.Setenv("HIVE_HUB_SECRET", testInviteMasterSecret)
+
+	const hiveID = "hive-alpha"
+	invite := provisionInviteKey(hiveID)
+	if invite == "" {
+		t.Fatal("provisionInviteKey returned empty; want derived key material")
+	}
+	if invite == testInviteMasterSecret {
+		t.Fatalf("invite key IS the raw master %q — the whole point is that it is not", invite)
+	}
+	if strings.Contains(invite, testInviteMasterSecret) {
+		t.Fatalf("invite key %q leaks the master verbatim", invite)
+	}
+
+	for name, other := range map[string]string{
+		"heartbeat": provisionHeartbeatKey(hiveID),
+		"terminal":  provisionTerminalKey(hiveID),
+	} {
+		if other == "" {
+			t.Fatalf("%s key empty; positive control failed", name)
+		}
+		if invite == other {
+			t.Fatalf("invite key collides with the %s key (%q): domain separation broken", name, invite)
+		}
+	}
+}
+
+// TestProvisionInviteKeyEmptyWithoutMaster pins fail-closed behaviour: with no
+// master configured there is nothing to derive from, and the provisioner must
+// emit an empty value rather than a guessable constant. The spoke then falls
+// through to its own generated secret.
+func TestProvisionInviteKeyEmptyWithoutMaster(t *testing.T) {
+	t.Setenv("HIVE_HUB_SECRET", "")
+	if got := provisionInviteKey("hive-alpha"); got != "" {
+		t.Fatalf("provisionInviteKey with no master = %q, want empty", got)
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1942,6 +1942,12 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// both mints and verifies this key locally, so symmetric is correct;
 		// only the sharing was wrong.
 		"TerminalKey": provisionTerminalKey(h.ID),
+		// The per-hive contributor-invite signing key. inviteSigningSecret() used
+		// the raw master as its HMAC key, making invites the LAST spoke-side
+		// consumer that actually needed HIVE_HUB_SECRET to function. With this
+		// injected it no longer does. Minted and verified on the same spoke, so
+		// symmetric; per-hive so an invite link cannot travel between tenants.
+		"InviteKey": provisionInviteKey(h.ID),
 		// Cluster-aware fields.
 		"DashboardHost":      dashboardHost,
 		"DashboardURL":       dashboardURL,
@@ -2669,6 +2675,16 @@ spec:
         # on an arbitrary hive. Both resolvers already prefer this var.
         - name: HIVE_TERMINAL_KEY
           value: "{{.TerminalKey}}"
+        # The per-hive contributor-invite signing key. inviteSigningSecret() on
+        # the spoke used the raw master HIVE_HUB_SECRET as its HMAC key — the
+        # last spoke-side code that USED the master rather than merely falling
+        # back to it. Injecting this removes that need. Invite tokens carry
+        # attribution, not access, so the blast radius is small; the point is
+        # that the master no longer has to be present for invites to work.
+        # NOTE: a hive that gains this var re-keys once, invalidating any
+        # in-flight invite links. Nothing else is affected.
+        - name: HIVE_INVITE_KEY
+          value: "{{.InviteKey}}"
 {{- if .IsNginxIngress}}
         # HIVE_INGRESS_AUTHZ tells the Node proxy that an nginx ingress
         # auth-proxy sits IN FRONT of this pod and per-hive-authorizes every


### PR DESCRIPTION
## What

`inviteSigningSecret()` in `v2/pkg/dashboard/api_contribute.go` used the **raw master `HIVE_HUB_SECRET`** as its HMAC key for signing and verifying contributor invite tokens. It was the **last spoke-side code that USED the master** rather than merely falling back to it.

Every other spoke-side consumer already prefers a dedicated per-hive env var — `SpokeHeartbeatKey()` → `HIVE_HEARTBEAT_KEY`, `SpokeSessionKey()` → `HIVE_SESSION_KEY`, `SpokeSSOPublicKey()` → `HIVE_SSO_PUBLIC_KEY`, `TerminalSigningKey()` → `HIVE_TERMINAL_KEY` — and `v2/proxy/server.js` mirrors the same order. The invite lane was the gap.

## Changes

- **`v2/pkg/hub/hub_keys.go`** — `infoInviteKey = "hive-invite-v1"` domain separator, `provisionInviteKey(hiveID)` using `derivePerHiveKey(master, infoInviteKey, hiveID)` (mirrors `provisionHeartbeatKey` / `provisionTerminalKey` exactly), and `EnvInviteKey = "HIVE_INVITE_KEY"`.
- **`v2/pkg/dashboard/api_contribute.go`** — resolution order is now `HIVE_INVITE_KEY` → `HIVE_HUB_SECRET` → persisted per-instance random file.
- **`v2/pkg/hub/saas_provision.go`** — emit `HIVE_INVITE_KEY` in the v4 provisioning template alongside the four existing per-hive vars.

Per-hive rather than fleet-wide because an invite minted on one tenant's hive has no business verifying on another's.

## What this PR deliberately does NOT do

**The master lane stays as a fallback**, both in `inviteSigningSecret()` and in every template. Stripping `HIVE_HUB_SECRET` from spoke Deployments is a later, fleet-visible step with its own hard preconditions. This PR is the safe precursor: it removes the last *functional need* for the master on a spoke, so that later step becomes possible.

The fallback also keeps self-hosted hives working, where the operator legitimately holds the master and points heartbeats at their own hub.

## Behavioural note — one-time re-key of in-flight invite links

Invite tokens are signed with this key, so **a hive whose key changes invalidates in-flight invite links.** With the fallback order (invite key → master), a spoke that gains `HIVE_INVITE_KEY` re-keys exactly **once**, at the roll that injects it. Any invite link minted before that roll and not yet redeemed stops working; the invitee sees a plain self-registration with no attribution, which `verifyInviteToken` already handles as a normal case rather than an error.

Blast radius is small — invite tokens carry **attribution, not access** — but stating it plainly rather than discovering it in support. Nothing else breaks.

## Tests

`v2/pkg/dashboard/invite_signing_key_test.go`:
- `TestInviteSigningSecretPrefersInviteKey` — dedicated key wins when both are set
- `TestInviteSigningSecretFallsBackToMaster` — master used when invite key absent
- `TestInviteSigningSecretFallsBackToRandomFile` — generated *and persisted* when both absent
- `TestInviteTokenRoundTripUnderEachLane` — **positive control**: sign/verify succeeds under each of the three lanes, so an "always fails" regression cannot make the cross-lane test below pass for the wrong reason
- `TestInviteTokenDoesNotVerifyAcrossKeys` — a master-signed token does not verify under `HIVE_INVITE_KEY`; hive A's token does not verify under hive B's key

`v2/pkg/hub/invite_key_test.go`:
- `TestProvisionInviteKeyIsPerHive` — two hives derive different keys; deterministic across calls
- `TestProvisionInviteKeyIsNotTheMaster` — derived value is not the master and does not collide with the heartbeat or terminal key for the same hive (domain separation)
- `TestProvisionInviteKeyEmptyWithoutMaster` — fail-closed with no master configured

### Regression replay

Each fix was neutered so it still compiled, and the tests were confirmed to fail:

1. Neutered the `HIVE_INVITE_KEY` preference in `inviteSigningSecret()` (kept the branch, forced it never to win):
   - `FAIL TestInviteSigningSecretPrefersInviteKey` — `got "master-hub-secret-…", want the dedicated key`
   - `FAIL TestInviteTokenDoesNotVerifyAcrossKeys` — `master-signed token verified under HIVE_INVITE_KEY as "octocat", want rejection`
   - `TestInviteTokenRoundTripUnderEachLane` still **passed**, confirming the two failures were real signal.
2. Neutered `provisionInviteKey` to `deriveDomainKey` (dropping the hive binding, making it fleet-uniform):
   - `FAIL TestProvisionInviteKeyIsPerHive` — `invite key is fleet-uniform: alpha and beta both = "874fc165…"`

Restored; `go build ./...` clean and all targeted tests green.

### Existing tests

Checked for tests encoding the current master-based behaviour before editing. `contribute_security_test.go:11` sets `HIVE_HUB_SECRET` but only to make the signing lane deterministic for a reserved-username assertion — it does not assert the master *must* be used, so it needed no change and still passes. The other 10 pre-existing invite tests pass unchanged. **No existing test was relaxed, inverted, or deleted.**