### PR TITLE
🔒 fix(hub): provision hosted spokes on v4, not v2 (F2 follow-up)

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -431,7 +431,10 @@ func loadClusters(logger *slog.Logger) map[string]ClusterConfig {
 			CertIssuer:   "letsencrypt-prod",
 			Domain:       "hive.kubestellar.io",
 			Arch:         "arm64",
-			ImageTag:     "v2-latest",
+			// v4 is the ONLY image a hosted spoke can run: audit F2 deleted the
+			// fleet-wide heartbeat lane, and a v2 spoke has no SpokeHeartbeatKey
+			// self-derive path, so it cannot authenticate to this hub at all.
+			ImageTag: "v4-latest",
 		}
 		return clusters
 	}
@@ -1842,10 +1845,17 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		imagePullPolicy = "Always"
 	}
 
-	// Determine image tag from cluster config, falling back to v2-latest.
+	// Determine image tag from cluster config, falling back to v4-latest.
+	//
+	// AUDIT F2 FOLLOW-UP: this fallback MUST NOT be v2. verifyHeartbeatBearer no
+	// longer accepts the fleet-wide bearer, and the per-hive bearer reaches a
+	// spoke either by injection or by SpokeHeartbeatKey() self-deriving it — a
+	// path that exists only in the v4 tree. A v2-tagged spoke therefore cannot
+	// heartbeat against this hub, so defaulting to v2-latest silently provisions
+	// a hive that is dead on arrival.
 	imageTag := cluster.ImageTag
 	if imageTag == "" {
-		imageTag = "v2-latest"
+		imageTag = "v4-latest"
 	}
 
 	data := map[string]any{

--- a/v2/pkg/hub/saas_provision_image_default_test.go
+++ b/v2/pkg/hub/saas_provision_image_default_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A hosted spoke MUST be provisioned on v4.
+//
+// AUDIT F2 FOLLOW-UP. verifyHeartbeatBearer no longer accepts the fleet-wide
+// bearer (deleted in the F2 cutover). The per-hive bearer reaches a spoke either
+// by injection at provision time, or by SpokeHeartbeatKey() self-deriving it
+// from HIVE_HUB_SECRET + HIVE_ID — and that self-derive path exists ONLY in the
+// v4 tree. A v2-tagged spoke can therefore do neither: it cannot authenticate to
+// this hub at all.
+//
+// Both image-tag defaults previously read "v2-latest", so a cluster with no
+// explicit image_tag (which is the live configuration — the hub's data carries
+// no imageTag anywhere) would provision a hive that is dead on arrival, with no
+// error at provision time. These tests assert the INVARIANT in source, because
+// the failure mode is a default quietly reverting, not a logic bug.
+
+// TestProvisioningDefaultsToV4 is the regression: no default may name a v2 tag.
+func TestProvisioningDefaultsToV4(t *testing.T) {
+	src := readProvisionSource(t)
+
+	// Every ImageTag default and every fallback assignment must be v4.
+	for _, bad := range []string{
+		`ImageTag: "v2-latest"`,
+		`ImageTag:     "v2-latest"`,
+		`imageTag = "v2-latest"`,
+	} {
+		if strings.Contains(src, bad) {
+			t.Errorf("saas_provision.go still defaults to v2 (%q) — a spoke provisioned on v2 "+
+				"cannot heartbeat since the F2 fleet-wide lane was deleted", bad)
+		}
+	}
+
+	if !strings.Contains(src, `imageTag = "v4-latest"`) {
+		t.Error("the image-tag fallback is not v4-latest")
+	}
+}
+
+// TestNoV2ImageTagAssignmentsRemain is the blunt backstop: catch any NEW v2
+// default someone adds later, in a form the exact-string checks above miss.
+func TestNoV2ImageTagAssignmentsRemain(t *testing.T) {
+	src := readProvisionSource(t)
+	re := regexp.MustCompile(`(?i)image_?tag\s*[:=]\s*"v2-latest"`)
+	if m := re.FindAllString(src, -1); len(m) > 0 {
+		t.Errorf("found %d v2-latest image-tag assignment(s): %v", len(m), m)
+	}
+}
+
+// TestV4TagIsNotHardcodedOverClusterConfig is the positive control. The fix must
+// only change the FALLBACK — an explicitly configured cluster.ImageTag has to
+// keep winning. Without this, "hardcode v4 everywhere" would satisfy both tests
+// above while removing the operator's ability to pin a tag at all.
+func TestV4TagIsNotHardcodedOverClusterConfig(t *testing.T) {
+	src := readProvisionSource(t)
+	if !strings.Contains(src, "imageTag := cluster.ImageTag") {
+		t.Error("cluster.ImageTag must still be consulted first — the fix is to the fallback only, " +
+			"not a hardcoded tag that ignores cluster configuration")
+	}
+}
+
+func readProvisionSource(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("saas_provision.go")
+	if err != nil {
+		t.Fatalf("read saas_provision.go: %v", err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
**Any hive provisioned right now would be dead on arrival.** Found while implementing the master-secret removal plan.

## The problem

Provisioning defaults the spoke image tag to `v2-latest` in two places — `saas_provision.go:434` (seed cluster) and `:1848` (fallback). Since the F2 cutover deleted the fleet-wide heartbeat lane, **a v2-tagged spoke cannot authenticate to this hub at all**:

- `verifyHeartbeatBearer` now accepts **only** the per-hive bearer
- A spoke obtains that bearer either by injection at provision time, or by `SpokeHeartbeatKey()` self-deriving it from `HIVE_HUB_SECRET` + `HIVE_ID`
- `SpokeHeartbeatKey` exists **only in the v4 tree** — `git grep -c 'func SpokeHeartbeatKey' origin/v2` returns **0**

A v2 spoke can do neither. It provisions successfully, reports no error, and simply never heartbeats.

## This is live, not hypothetical

I checked the running hub: there is **no `imageTag` anywhere in its data** — no `clusters.json`, nothing under `/data`. So `cluster.ImageTag` is empty and the hardcoded fallback is exactly what a new hive gets today.

## Scope of the fix

Only the **fallback** changes. `imageTag := cluster.ImageTag` still takes precedence, so an operator can pin a tag per cluster.

`TestV4TagIsNotHardcodedOverClusterConfig` pins that explicitly — without it, "hardcode v4 everywhere" would satisfy the other two tests while silently removing operator control.

## Verification

Tests assert the **invariant in source**, because the failure mode here is a default quietly reverting — the same way F14 and F18 regressed through merges — not a logic bug.

Positive control: putting `"v2-latest"` back **still compiles** and fails:

```
--- FAIL: TestProvisioningDefaultsToV4
--- FAIL: TestNoV2ImageTagAssignmentsRemain
```