### PR TITLE
fix(hub): send cached heartbeat when collect() times out so spokes don't show OFFLINE

### DIFF
--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -90,6 +90,31 @@ var heartbeatLoopActive atomic.Bool
 // goroutine, read by the dashboard's HTTP handler goroutine.
 var lastHeartbeatAttemptUnix atomic.Int64
 
+// lastGoodPayload caches the most recent payload a collect() actually
+// produced. It exists so a beat whose collect() TIMED OUT can still be sent —
+// carrying slightly-stale stats — instead of being dropped entirely.
+//
+// WHY (offline regression from the #3743 collect-timeout fix): when /data
+// (NFS RWX PVC) wedges, the agent-manager mutex is held across the stuck write
+// and collect() -> AllStatuses() blocks every cycle. #3743 bounded collect()
+// so the loop keeps ticking (liveness stays green), but on timeout it returned
+// nil and sendHeartbeat SKIPPED THE ENTIRE BEAT — POSTing nothing to the hub.
+// On a persistently-wedged spoke every beat's collect() times out, so every
+// beat was skipped, the hub received no heartbeats, and after the stale
+// threshold the UI marked an alive, 1/1-Ready hive OFFLINE. Caching the last
+// good payload lets the spoke keep beating (marked StatsStale) through the
+// stall so the hub keeps it online.
+//
+// Guarded by its own mutex because the collect goroutine writes it (on
+// success) while the sender reads it (on timeout); the two can overlap when a
+// late-returning wedged collect finally completes. A whole-payload clone is
+// stored so a later in-place mutation of the returned payload (name filtering,
+// timestamp stamping in sendHeartbeat) never races a reader of the cache.
+var lastGoodPayload = struct {
+	sync.Mutex
+	payload *HeartbeatPayload
+}{}
+
 // storeUnixOrZero stores t as unix seconds, or 0 for the zero time so it
 // reads back as "never happened" through the Last* accessors.
 func storeUnixOrZero(dst *atomic.Int64, t time.Time) {
@@ -598,6 +623,18 @@ type HeartbeatPayload struct {
 	// reporting it harmlessly and to describe what per-app-id files a spoke holds.
 	// It carries fingerprints ONLY — never key material.
 	GitHubAppKeysHeld map[string]string `json:"github_app_keys_held,omitempty"`
+	// StatsStale is true when this beat carries CACHED collected stats rather
+	// than fresh ones, because collect() timed out this cycle (see
+	// sendHeartbeat / collectWithTimeout). The beat is still a genuine liveness
+	// signal — the spoke process is alive and its loop is ticking — so the hub
+	// MUST keep the hive online and advance lastHeartbeat; it should simply not
+	// treat the agent/fleet/health numbers as freshly observed. Without this
+	// beat the hub would receive nothing at all while /data (NFS) is wedged and
+	// would mark an alive, 1/1-Ready hive OFFLINE after the stale threshold.
+	//
+	// omitempty so a healthy fresh beat, and every older spoke, sends nothing —
+	// which the hub reads as "stats are fresh", never as an error.
+	StatsStale bool `json:"stats_stale,omitempty"`
 }
 
 const (
@@ -853,11 +890,36 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	// that is actually alive (the NFS server is stuck, which a restart cannot
 	// fix), producing a fleet-wide liveness crash-loop. The attempt above is
 	// already recorded, so timing collect() out lets the loop keep ticking and
-	// keeps liveness green while the process is genuinely alive; the beat is
-	// simply skipped this cycle and retried on the next tick.
+	// keeps liveness green while the process is genuinely alive.
+	//
+	// But a timed-out collect must NOT skip the whole beat: on a spoke whose
+	// /data (NFS) is persistently wedged, collect() times out EVERY cycle, so
+	// skipping every beat means the hub receives no heartbeats and marks an
+	// alive, 1/1-Ready hive OFFLINE after the stale threshold (the offline
+	// regression from #3743). Instead, on timeout we fall back to the LAST-GOOD
+	// collected payload (cached below on every success), marked StatsStale, so
+	// the hub still gets a live beat and keeps the hive online — the stats are
+	// merely slightly stale, not absent. Only a spoke that has NEVER completed a
+	// collect (the first beats) has no cache to fall back on; that alone skips.
 	payload := collectWithTimeout(ctx, collect, heartbeatTimeout, logger)
 	if payload == nil {
-		return nil
+		cached := loadLastGoodPayload()
+		if cached == nil {
+			// No successful collect yet — genuinely nothing to send. Rare: only
+			// the first beats before any collect has ever finished in time.
+			logger.Warn("hub heartbeat collect timed out and no cached payload yet — skipping this beat; loop keeps ticking so liveness stays green")
+			return nil
+		}
+		// Send the cached stats so the hub keeps the hive online through the
+		// stall. Mark them stale so the hub does not treat the agent/fleet
+		// numbers as freshly observed.
+		cached.StatsStale = true
+		payload = cached
+		logger.Warn("hub heartbeat collect timed out — sending LAST-GOOD cached stats (marked stale) so the hub keeps this hive online; loop keeps ticking so liveness stays green")
+	} else {
+		// Fresh collect: remember it (a clone, so the in-place filtering below
+		// never mutates the cache) for the next time collect() times out.
+		storeLastGoodPayload(payload)
 	}
 	payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	payload.PublicURLSelfCheck = publicURLSelfCheckFor(ctx, payload.DashboardURL, logger)
@@ -974,13 +1036,61 @@ func collectWithTimeout(ctx context.Context, collect StatusCollector, timeout ti
 		return payload
 	case <-timer.C:
 		if logger != nil {
-			logger.Warn("hub heartbeat collect timed out — skipping this beat; loop keeps ticking so liveness stays green",
+			// The CALLER decides what to do with a timed-out collect (send
+			// cached last-good stats, or skip on the first beats) — it logs the
+			// outcome. Here we only note the timeout itself.
+			logger.Warn("hub heartbeat collect timed out; loop keeps ticking so liveness stays green",
 				"timeout", timeout.String())
 		}
 		return nil
 	case <-ctx.Done():
 		return nil
 	}
+}
+
+// storeLastGoodPayload caches a deep clone of a payload that collect() produced
+// successfully, for reuse when a later collect() times out. A clone is stored
+// (not the pointer) so sendHeartbeat's in-place filtering/stamping of the live
+// payload never mutates what a future timed-out beat will send.
+func storeLastGoodPayload(p *HeartbeatPayload) {
+	c := clonePayload(p)
+	if c == nil {
+		return
+	}
+	lastGoodPayload.Lock()
+	lastGoodPayload.payload = c
+	lastGoodPayload.Unlock()
+}
+
+// loadLastGoodPayload returns a deep clone of the last successfully-collected
+// payload, or nil if collect() has never yet succeeded. A clone is returned so
+// the caller can mutate it (set StatsStale, re-stamp Timestamp) without
+// touching the cached copy that the next timed-out beat will reuse.
+func loadLastGoodPayload() *HeartbeatPayload {
+	lastGoodPayload.Lock()
+	p := lastGoodPayload.payload
+	lastGoodPayload.Unlock()
+	return clonePayload(p)
+}
+
+// clonePayload deep-copies a HeartbeatPayload via JSON round-trip. JSON is the
+// exact shape that goes on the wire, so a clone through it can never share a
+// slice/map/pointer with the original — which is what makes the cache safe to
+// read from the sender while the collect goroutine writes a fresh one. Returns
+// nil for a nil input or on the (not expected in practice) marshal error.
+func clonePayload(p *HeartbeatPayload) *HeartbeatPayload {
+	if p == nil {
+		return nil
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return nil
+	}
+	var out HeartbeatPayload
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil
+	}
+	return &out
 }
 
 func publicURLSelfCheckFor(ctx context.Context, rawURL string, logger *slog.Logger) *PublicURLSelfCheck {

--- a/v2/pkg/hub/heartbeat_send_on_collect_timeout_test.go
+++ b/v2/pkg/hub/heartbeat_send_on_collect_timeout_test.go
@@ -1,0 +1,227 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests are the positive control for the OFFLINE regression fix. #3743
+// bounded collect() so a wedged collector can't freeze the heartbeat loop, but
+// on timeout sendHeartbeat returned WITHOUT POSTing anything. On a spoke whose
+// /data (NFS) is persistently wedged, collect() times out every cycle, so
+// EVERY beat was skipped, the hub received no heartbeats, and it marked an
+// alive, 1/1-Ready hive OFFLINE after the stale threshold. The fix: on a
+// timed-out collect, send the LAST-GOOD cached payload (marked StatsStale)
+// instead of skipping — so the hub still gets a live beat and keeps the hive
+// online. Only the first beats, before any collect has ever succeeded, skip.
+
+// blockUntilClosed returns a collect() that blocks until ch is closed, then
+// returns the given payload. It models an NFS-wedged AllStatuses() that never
+// returns within the heartbeat timeout.
+func blockUntilClosed(ch <-chan struct{}, p *HeartbeatPayload) StatusCollector {
+	return func() *HeartbeatPayload {
+		<-ch
+		return p
+	}
+}
+
+// TestSendHeartbeat_TimedOutCollectStillPostsCachedPayload is the core positive
+// control: after one successful collect populates the cache, a subsequent beat
+// whose collect() times out STILL POSTs to the hub (carrying the cached hive
+// identity) rather than skipping. Without the fix the second POST never
+// happens and the hub goes stale.
+func TestSendHeartbeat_TimedOutCollectStillPostsCachedPayload(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	var posts atomic.Int32
+	lastHiveID := make(chan string, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts.Add(1)
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		lastHiveID <- p.HiveID
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	// Beat 1: a fast collect populates the last-good cache and is delivered.
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "wedged-hive", Org: "org", PrimaryRepo: "repo"}
+	}, nil2Logger())
+
+	if got := posts.Load(); got != 1 {
+		t.Fatalf("expected 1 POST after the fresh beat, got %d", got)
+	}
+	if id := <-lastHiveID; id != "wedged-hive" {
+		t.Fatalf("fresh beat carried hive_id %q, want wedged-hive", id)
+	}
+
+	// Beat 2: collect() is wedged (times out). The beat MUST still POST, using
+	// the cached identity, so the hub keeps the hive online.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	sendHeartbeat(ctx, server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+
+	if got := posts.Load(); got != 2 {
+		t.Fatalf("timed-out collect did NOT POST a heartbeat (posts=%d) — the hub would receive nothing and mark the hive OFFLINE", got)
+	}
+	if id := <-lastHiveID; id != "wedged-hive" {
+		t.Fatalf("timed-out beat carried hive_id %q, want the cached wedged-hive identity", id)
+	}
+}
+
+// TestSendHeartbeat_TimedOutCollectMarksStatsStale proves the beat sent on a
+// collect timeout is flagged StatsStale, so the hub keeps the hive online but
+// does not treat the cached agent/fleet numbers as freshly observed.
+func TestSendHeartbeat_TimedOutCollectMarksStatsStale(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	stale := make(chan bool, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		stale <- p.StatsStale
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	// Fresh beat: cache populated, must NOT be marked stale.
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "hive", Org: "org", PrimaryRepo: "repo"}
+	}, nil2Logger())
+	if got := <-stale; got {
+		t.Fatalf("fresh beat was marked StatsStale=true, want false")
+	}
+
+	// Timed-out beat: cached stats, must be marked stale.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	sendHeartbeat(ctx, server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+	if got := <-stale; !got {
+		t.Fatalf("beat sent on a timed-out collect was NOT marked StatsStale — the hub would treat cached numbers as fresh")
+	}
+}
+
+// TestSendHeartbeat_TimedOutCollectStillAdvancesAttempt proves the #3743
+// liveness win is preserved: even on the cached-payload path, the attempt clock
+// advances and (because the POST now happens) success advances too — so
+// /api/livez stays green AND the hub's lastHeartbeat advances.
+func TestSendHeartbeat_TimedOutCollectStillAdvancesAttempt(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	// Prime the cache with one good beat.
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "hive", Org: "org", PrimaryRepo: "repo"}
+	}, nil2Logger())
+
+	before := time.Now().Truncate(time.Second)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	sendHeartbeat(ctx, server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+
+	att, ok := LastHeartbeatAttempt()
+	if !ok || att.Before(before) {
+		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt at/after %v even though collect() timed out", att, ok, before)
+	}
+	suc, ok := LastHeartbeatSuccess()
+	if !ok || suc.Before(before) {
+		t.Errorf("LastHeartbeatSuccess() = (%v, %v), want a fresh success — the cached beat WAS accepted by the hub, keeping the hive online", suc, ok)
+	}
+}
+
+// TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips proves the one case that
+// still skips: a collect() that times out before ANY collect has ever
+// succeeded has no cached identity to send, so it skips the beat (but the loop
+// still ticks — attempt advanced, no success).
+func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	var posts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	before := time.Now().Truncate(time.Second)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	done := make(chan struct{})
+	go func() {
+		sendHeartbeat(context.Background(), server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(heartbeatTimeout + 5*time.Second):
+		t.Fatal("sendHeartbeat did not return on a first-beat wedged collect — the loop would freeze")
+	}
+
+	if got := posts.Load(); got != 0 {
+		t.Fatalf("first-beat timeout with no cache should POST nothing, got %d POSTs", got)
+	}
+	att, ok := LastHeartbeatAttempt()
+	if !ok || att.Before(before) {
+		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt even on a skipped first beat", att, ok)
+	}
+	if _, ok := LastHeartbeatSuccess(); ok {
+		t.Error("LastHeartbeatSuccess() ok = true, want false: the first beat was skipped, nothing was delivered")
+	}
+}
+
+// TestClonePayload_DeepCopyIndependence proves the cache stores an independent
+// deep copy: mutating slices/maps on the clone must not touch the original (and
+// vice-versa), which is what makes the cache safe to read from the sender while
+// the collect goroutine writes a fresh one.
+func TestClonePayload_DeepCopyIndependence(t *testing.T) {
+	if clonePayload(nil) != nil {
+		t.Fatal("clonePayload(nil) must be nil")
+	}
+	orig := &HeartbeatPayload{
+		HiveID:             "hive",
+		Agents:             []AgentSummary{{Name: "scanner", State: "running"}},
+		ActiveSessionUsers: []string{"alice"},
+		UserLastActions:    map[string]string{"alice": "2026-01-01T00:00:00Z"},
+	}
+	c := clonePayload(orig)
+	if c == nil {
+		t.Fatal("clonePayload returned nil for a valid payload")
+	}
+	c.Agents[0].Name = "mutated"
+	c.ActiveSessionUsers[0] = "mutated"
+	c.UserLastActions["alice"] = "mutated"
+	if orig.Agents[0].Name != "scanner" {
+		t.Errorf("mutating the clone's Agents changed the original: %q", orig.Agents[0].Name)
+	}
+	if orig.ActiveSessionUsers[0] != "alice" {
+		t.Errorf("mutating the clone's ActiveSessionUsers changed the original: %q", orig.ActiveSessionUsers[0])
+	}
+	if orig.UserLastActions["alice"] != "2026-01-01T00:00:00Z" {
+		t.Errorf("mutating the clone's UserLastActions changed the original: %q", orig.UserLastActions["alice"])
+	}
+}

--- a/v2/pkg/hub/heartbeat_testhooks.go
+++ b/v2/pkg/hub/heartbeat_testhooks.go
@@ -22,8 +22,14 @@ func SetHeartbeatStateForTest(enabled bool, lastAttempt, lastSuccess time.Time) 
 }
 
 // ResetHeartbeatStateForTest returns the heartbeat atomics to their
-// process-start values (no loop, no attempts, no successes). Tests that mutate
-// this global state should defer it so they don't leak into other tests.
+// process-start values (no loop, no attempts, no successes) and clears the
+// cached last-good collect payload. Tests that mutate this global state should
+// defer it so they don't leak into other tests — in particular so one test's
+// cached payload cannot make another test's timed-out collect look like it
+// still had fresh stats to fall back on.
 func ResetHeartbeatStateForTest() {
 	SetHeartbeatStateForTest(false, time.Time{}, time.Time{})
+	lastGoodPayload.Lock()
+	lastGoodPayload.payload = nil
+	lastGoodPayload.Unlock()
 }


### PR DESCRIPTION
## The regression

Fixes the offline regression introduced by #3743 ("bound heartbeat collect with timeout").

#3743 correctly stopped a wedged `collect()` from freezing the heartbeat loop — it bounds `collect()` with `collectWithTimeout` so the loop keeps ticking and `/api/livez` liveness stays green even while `/data` (the NFS RWX PVC) is stalled.

But on a `collect()` timeout, `sendHeartbeat` returned **without POSTing any heartbeat to the hub**:

```
hub heartbeat collect timed out — skipping this beat; loop keeps ticking so liveness stays green
```

### Skip-beat → OFFLINE mechanism

On a spoke whose NFS `/data` is **persistently** stalled (the a-ks-wec2 fleet right now), the agent-manager mutex is held across the wedged NFS write, so `collect()` → `AllStatuses()` blocks and **times out on every beat**. Therefore:

- every beat's collect times out → **every beat was skipped**
- the hub receives **no** heartbeats at all
- after the stale threshold the hub UI marks the hive **offline/stale** (grey dot, "9m" since last beat) — even though the pod is `1/1` Ready and the agents are running.

We fixed the liveness-kill flap but broke heartbeat delivery.

## The fix

On a timed-out collect, **do not skip the beat**. Send a heartbeat built from the **last-known-good** collected payload (cached on every successful collect), marked `StatsStale`, so the hub still receives a live beat and keeps the hive **online** — the stats are merely slightly stale, not absent. `lastHeartbeat` on the hub advances and the UI shows online.

- **`lastGoodPayload` cache** (mutex-guarded). Stores a JSON deep clone so the in-place `Leaderboard`/`Agents` filtering never mutates the cache, and a late-returning wedged collect (the #3743 buffered-channel leak-safety pattern is untouched) can't race the sender reading the cache.
- **`StatsStale bool` `json:"stats_stale,omitempty"`** added to `HeartbeatPayload`. The hub keeps the hive online but should not treat the cached agent/fleet/health numbers as freshly observed. `omitempty` ⇒ fresh beats and older spokes send nothing, read by the hub as "fresh" — never an error.
- **First-beat fallback**: only a spoke that has *never* completed a collect (the first beats) has no cache; that case alone still skips (minimal-identity option not needed since identity itself comes from `collect()`).
- **#3743 win preserved**: `recordHeartbeatAttempt()` still advances unconditionally and the loop still ticks; no unbounded block reintroduced.
- `ResetHeartbeatStateForTest` clears the cache so it can't leak between tests.

## Tests (positive controls)

`v2/pkg/hub/heartbeat_send_on_collect_timeout_test.go`:

- `TestSendHeartbeat_TimedOutCollectStillPostsCachedPayload` — proves the POST **still happens** on a timed-out collect (2 POSTs: fresh beat + timed-out beat, carrying the cached hive identity). This is the direct positive control for the fix.
- `TestSendHeartbeat_TimedOutCollectMarksStatsStale` — fresh beat is not stale; timed-out beat is `StatsStale=true`.
- `TestSendHeartbeat_TimedOutCollectStillAdvancesAttempt` — liveness attempt **and** success both advance (the cached beat was accepted, keeping the hub's `lastHeartbeat` fresh).
- `TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips` — the one remaining skip case POSTs nothing but still advances the attempt clock.
- `TestClonePayload_DeepCopyIndependence` — the cache stores an independent deep copy.

New test names were grepped against the whole `hub` package for uniqueness (no duplicate `func Test*` — the previous vet failure will not recur).