### PR TITLE
feat(hub): reconcile per-hive security env vars onto hosted spokes

### DIFF
--- a/v2/pkg/hub/auth_rollout.go
+++ b/v2/pkg/hub/auth_rollout.go
@@ -82,6 +82,27 @@ type AuthRolloutStatus struct {
 	// also have aged out (cookieMaxAgeDays, currently 7). Removing that lane
 	// early logs every active user out rather than breaking a spoke.
 	HeartbeatLaneReady bool `json:"heartbeat_lane_ready"`
+
+	// PerHiveEnv is the Deployment-SOURCED convergence view for the five
+	// per-hive security env vars (perhive_env_reconcile.go).
+	//
+	// It is embedded here rather than served from a new endpoint so an operator
+	// has ONE readiness page — but the two halves of this response are sourced
+	// differently on purpose, and the difference matters for the master-secret
+	// cutover this gates.
+	//
+	// Everything above comes from heartbeat observations and is subject to
+	// authRolloutStaleAfter: a hive that has not beaten in 24h simply leaves
+	// the totals, and as the constant's own comment records, this signal cannot
+	// distinguish "hive absent" from "hive never existed". A paused spoke
+	// therefore drops silently out of the denominator and the fleet reads ready
+	// while that spoke is unconverged.
+	//
+	// PerHiveEnv is immune to that: its counts come from the hub reading each
+	// spoke's Deployment itself. A paused hive still has a Deployment, so it is
+	// still read, still counted, and still blocks convergence. Gate the
+	// master-secret removal on THESE numbers, not on the heartbeat totals.
+	PerHiveEnv PerHiveEnvStatus `json:"per_hive_env"`
 }
 
 // authRolloutStaleAfter bounds how old an observation may be and still count.
@@ -115,21 +136,28 @@ func (s *HubServer) AuthRolloutReadiness() AuthRolloutStatus {
 		return out
 	}
 	cutoff := time.Now().Add(-authRolloutStaleAfter)
-	s.authRolloutMu.RLock()
-	defer s.authRolloutMu.RUnlock()
-	for id, e := range s.authRolloutSeen {
-		if e.LastSeen.Before(cutoff) {
-			continue
+	// Scoped, NOT deferred: PerHiveEnvSnapshot below takes a different mutex
+	// (perHiveEnvMu), and holding two hub locks at once — even in a consistent
+	// order today — is how a future caller acquires them the other way round
+	// and deadlocks the readiness endpoint. Release this one first.
+	func() {
+		s.authRolloutMu.RLock()
+		defer s.authRolloutMu.RUnlock()
+		for id, e := range s.authRolloutSeen {
+			if e.LastSeen.Before(cutoff) {
+				continue
+			}
+			out.TotalHives++
+			if e.PerHiveBearer {
+				out.PerHiveBearer++
+			} else {
+				out.LegacyBearer++
+				out.LegacyHives = append(out.LegacyHives, id)
+			}
 		}
-		out.TotalHives++
-		if e.PerHiveBearer {
-			out.PerHiveBearer++
-		} else {
-			out.LegacyBearer++
-			out.LegacyHives = append(out.LegacyHives, id)
-		}
-	}
+	}()
 	out.HeartbeatLaneReady = out.TotalHives > 0 && out.LegacyBearer == 0
+	out.PerHiveEnv = s.PerHiveEnvSnapshot()
 	return out
 }
 

--- a/v2/pkg/hub/perhive_env_reconcile.go
+++ b/v2/pkg/hub/perhive_env_reconcile.go
@@ -1,0 +1,512 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Per-hive security env reconcile — makes the fleet's key posture code-owned.
+//
+// THE GAP THIS CLOSES. The C2/N1/N2/N3 work moved every spoke off the shared
+// master onto derived, per-hive sub-keys, and the provisioning template
+// (saas_provision.go) renders all five vars. But that template is `kubectl
+// apply`ed ONLY inside provisionHive — at provision/assign time. Hives
+// provisioned BEFORE those vars entered the template never received them, and
+// nothing re-asserts them afterwards.
+//
+// What actually put the vars on the live fleet was an out-of-band `kubectl
+// patch`, not any code path: a live spoke's
+// kubectl.kubernetes.io/last-applied-configuration still lists only the
+// pre-cutover env shape (HIVE_GITHUB_TOKEN, DASHBOARD_AUTH_TOKEN, HIVE_ID,
+// HIVE_LEVEL, HIVE_HUB_URL, HIVE_HUB_SECRET) while the live .spec has the new
+// vars appended after HIVE_HUB_SECRET — and in a different order from the
+// template, which emits them instead of the master. So the fleet's security
+// posture is held in place by a manual edit that no controller maintains: any
+// re-provision, restore, or manifest reapply silently reverts a spoke to
+// master-derived fallbacks (spokeDomainKey / TerminalSigningKey /
+// SpokeSSOPublicKey all fall through to HIVE_HUB_SECRET when their dedicated
+// var is absent, which is precisely the fleet-uniform sharing N1/N3 removed).
+//
+// Four spokes were missed by that manual patch entirely and run on master-only
+// fallbacks today, including a real external user's hive. This sweep repairs
+// them and, more importantly, means the next drift is repaired automatically
+// instead of by hand.
+//
+// SCOPE / SAFETY. This lane is ADDITIVE ONLY. It never removes HIVE_HUB_SECRET.
+// Stripping the master from spoke Deployments is a separate, fleet-visible
+// cutover with its own hard preconditions (every spoke must be on an image that
+// reads the dedicated vars, and the readiness counts below must be zero across
+// a full sweep); doing it here would couple a silent repair to a breaking
+// change.
+//
+// This mirrors the NET_ADMIN reconcile (netadmin_reconcile.go) deliberately:
+// same cluster access path, same unreachable-cluster suppression, same
+// idempotent-check-then-patch shape. Divergence between two sweeps that both
+// mutate the hive Deployment would be its own maintenance hazard.
+
+const (
+	// envSessionPublicKey is the spoke-side env var carrying the Ed25519 PUBLIC
+	// key for hub session cookies (audit N2). Unlike the others there is no Go
+	// constant for it — only the Node proxy reads it (v2/proxy/server.js reads
+	// process.env.HIVE_SESSION_PUBLIC_KEY) — so it is named here rather than
+	// spelled as a literal at each use, so the check and the patch can never
+	// disagree.
+	envSessionPublicKey = "HIVE_SESSION_PUBLIC_KEY"
+
+	// envHubSecretMaster is the MASTER secret still present on every spoke. This
+	// lane never writes or removes it; the name exists only so the readiness
+	// surface can COUNT how many spokes still carry it, which is the gating
+	// signal for the later removal step.
+	envHubSecretMaster = "HIVE_HUB_SECRET"
+
+	// perHiveEnvReconcileInterval throttles the sweep. Like the NET_ADMIN drift
+	// this is static remediation, not a hot path: a converged hive stays
+	// converged until it is re-provisioned or restored, and a hive that IS
+	// drifted is not made worse by waiting one interval. The SHA poller ticks
+	// every 2 min; we run at most once per this window.
+	perHiveEnvReconcileInterval = 15 * time.Minute
+
+	// perHiveEnvKubectlTimeout bounds each per-hive kubectl get/patch so one
+	// unreachable cluster cannot stall the whole sweep. Matches
+	// netAdminKubectlTimeout.
+	perHiveEnvKubectlTimeout = 15 * time.Second
+
+	// perHiveEnvMaxPatchesPerCycle caps how many spokes this lane may PATCH in a
+	// single sweep.
+	//
+	// RATE LIMIT RATIONALE. Adding an env var mutates the podspec, so every
+	// patch triggers a rolling restart of that hive's pod — which kills the
+	// tmux session and interrupts whatever agents are mid-run on that spoke.
+	// The fleet is ~70 hosted spokes. Patching them all in one cycle would roll
+	// every pod at once: every running agent on the platform interrupted
+	// simultaneously, ~70 pods pulling images and re-scheduling together, and
+	// no way to notice a bad patch before it has reached the whole fleet.
+	//
+	// 3 per cycle at a 15-minute interval converges a fully-drifted 70-hive
+	// fleet in about 6 hours — fast enough that a security gap does not linger
+	// for days, slow enough that at most 3 tenants are disturbed at a time and
+	// an operator watching the logs has ~15 minutes to stop the hub between
+	// batches if a patch misbehaves. Today only 4 spokes are drifted, so the
+	// real convergence is two cycles (~15 minutes).
+	//
+	// The cap counts PATCHES, not hives examined: the sweep still READS every
+	// hive each cycle (a read is cheap and does not roll a pod), so the
+	// readiness counts below reflect the whole fleet even while remediation is
+	// rate-limited.
+	perHiveEnvMaxPatchesPerCycle = 3
+
+	// hiveContainerEnvPath is the JSON-Patch path to the hive container's env
+	// list. containers[0] is the hive container in the provisioning template.
+	hiveContainerEnvPath = "/spec/template/spec/containers/0/env"
+)
+
+// deploymentEnvVar is the minimal shape we read back from a Deployment's
+// container env list. Only name/value matter here: a var sourced from a
+// secretKeyRef/fieldRef has no literal .value, and we deliberately treat that
+// as "not the value we expect" rather than trying to chase the reference —
+// none of the five vars is ever provisioned as a reference.
+type deploymentEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// desiredPerHiveEnv returns the five security env vars a spoke for hiveID must
+// carry, derived EXACTLY as the v4 provisioning template derives them
+// (saas_provision.go, the HeartbeatKey/SessionKey/SSOPublicKey/
+// SessionPublicKey/TerminalKey block). Provision-time and reconcile-time
+// derivation MUST agree — if they drifted, this sweep would fight provisioning
+// and roll a pod every cycle forever — so both sides call the same helpers in
+// hub_keys.go rather than re-implementing the formulas.
+//
+// FAIL-SAFE: returns nil when any derived value is empty. derivePerHiveKey
+// returns "" for an empty master OR an empty hiveID, and deriveDomainKey
+// returns "" for an empty master, by design (a keyless caller must fail closed).
+// If we wrote those through, a spoke would get e.g. HIVE_HEARTBEAT_KEY="" —
+// strictly WORSE than absent, because the spoke-side resolvers
+// (spokeDomainKey, TerminalSigningKey, SpokeSSOPublicKey) test for a non-empty
+// value before falling back to the master: an empty var falls back exactly like
+// an absent one, but it also makes the readiness count below report the hive as
+// converged when it is not. So a hive whose ID does not resolve, or a hub with
+// no master secret configured, is SKIPPED and logged — never patched.
+func desiredPerHiveEnv(hiveID string) map[string]string {
+	hiveID = strings.TrimSpace(hiveID)
+	if hiveID == "" {
+		return nil
+	}
+	master := provisionMasterSecret()
+	if master == "" {
+		return nil
+	}
+	want := map[string]string{
+		EnvHeartbeatKey:     provisionHeartbeatKey(hiveID),
+		EnvTerminalKey:      provisionTerminalKey(hiveID),
+		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
+		envSessionPublicKey: provisionSessionPublicKey(),
+	}
+	for _, v := range want {
+		if v == "" {
+			// Belt and braces: master and hiveID are both non-empty above, so
+			// this should be unreachable — but an empty value is the one
+			// outcome that must never reach a Deployment, and a future
+			// derivation change (e.g. an Ed25519 expansion failing on a
+			// malformed seed, which ssoPublicKeyFromSeed reports as "") must
+			// fail closed here rather than silently blank a spoke's key.
+			return nil
+		}
+	}
+	return want
+}
+
+// perHiveEnvNames lists the five reconciled vars in a stable order, for
+// deterministic patches and log lines.
+func perHiveEnvNames() []string {
+	return []string{
+		EnvHeartbeatKey,
+		EnvTerminalKey,
+		EnvSessionKey,
+		EnvSSOPublicKey,
+		envSessionPublicKey,
+	}
+}
+
+// perHiveEnvDrift compares a Deployment's live container env list against the
+// desired values and returns the names of the vars that are absent or wrong, in
+// perHiveEnvNames order. An empty result means CONVERGED — the caller must then
+// issue no patch at all, because any patch rolls the pod.
+//
+// This is the pure decision function the sweep gates on: no kubectl, fully
+// unit-testable. `live` is the Deployment's containers[0].env as returned by
+// `kubectl get deploy hive -o jsonpath={...env}`.
+//
+// A var present with a DIFFERENT value counts as drift and is corrected — that
+// is the case a stale hive ID or a rotated master produces, and leaving it
+// would mean the hub rejects that spoke's heartbeats forever.
+func perHiveEnvDrift(live []deploymentEnvVar, want map[string]string) []string {
+	if len(want) == 0 {
+		return nil
+	}
+	have := make(map[string]string, len(live))
+	for _, e := range live {
+		have[e.Name] = e.Value
+	}
+	var drift []string
+	for _, name := range perHiveEnvNames() {
+		if got, ok := have[name]; !ok || got != want[name] {
+			drift = append(drift, name)
+		}
+	}
+	return drift
+}
+
+// perHiveEnvPatchJSON builds the JSON-Patch body that converges the env list.
+//
+// It replaces the WHOLE env array rather than emitting per-var add/replace ops.
+// A JSON-Patch `add` to `/…/env/-` appends, and `replace` needs the numeric
+// index of the existing entry — so a per-var patch would have to encode live
+// indices, which race any concurrent write to the Deployment and silently
+// clobber the wrong var if the list shifted between our read and our patch.
+// Replacing the array from the list we just read keeps the operation atomic in
+// intent and preserves every var we did not touch, in its original order, with
+// the reconciled ones appended or updated in place.
+//
+// Order is preserved for untouched vars and the appended ones follow
+// perHiveEnvNames order, so a converged Deployment produces a byte-identical
+// array on the next sweep and perHiveEnvDrift stays empty — no patch loop.
+func perHiveEnvPatchJSON(live []deploymentEnvVar, want map[string]string) (string, error) {
+	merged := make([]deploymentEnvVar, 0, len(live)+len(want))
+	seen := make(map[string]bool, len(want))
+	for _, e := range live {
+		if v, ok := want[e.Name]; ok {
+			e.Value = v
+			seen[e.Name] = true
+		}
+		merged = append(merged, e)
+	}
+	for _, name := range perHiveEnvNames() {
+		if !seen[name] {
+			merged = append(merged, deploymentEnvVar{Name: name, Value: want[name]})
+		}
+	}
+	patch := []map[string]any{{
+		"op":    "replace",
+		"path":  hiveContainerEnvPath,
+		"value": merged,
+	}}
+	b, err := json.Marshal(patch)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// perHiveEnvPatchAllowed reports whether the sweep may issue another patch this
+// cycle, given how many it has already issued. Extracted as a named predicate
+// (rather than an inline `>=`) so the rate limit is a single testable decision
+// that the sweep and its test share — a test that re-implemented the comparison
+// would keep passing if the sweep's own check were removed.
+func perHiveEnvPatchAllowed(patchedThisCycle int) bool {
+	return patchedThisCycle < perHiveEnvMaxPatchesPerCycle
+}
+
+// perHiveEnvObservation is one hive's live posture, recorded by the sweep from
+// its OWN Deployment read. See perHiveEnvSnapshot for why this is not sourced
+// from heartbeat recency.
+type perHiveEnvObservation struct {
+	// MissingVars are the reconciled vars absent or wrong on this hive.
+	MissingVars []string
+	// HasMasterSecret is true when the Deployment still injects
+	// HIVE_HUB_SECRET, the master this whole line of work exists to remove.
+	HasMasterSecret bool
+	// Observed is when the Deployment was last successfully read.
+	Observed time.Time
+}
+
+// recordPerHiveEnvObservation stores one hive's Deployment-sourced posture.
+func (s *HubServer) recordPerHiveEnvObservation(hiveID string, obs perHiveEnvObservation) {
+	if s == nil || hiveID == "" {
+		return
+	}
+	s.perHiveEnvMu.Lock()
+	defer s.perHiveEnvMu.Unlock()
+	if s.perHiveEnvSeen == nil {
+		s.perHiveEnvSeen = make(map[string]perHiveEnvObservation)
+	}
+	s.perHiveEnvSeen[hiveID] = obs
+}
+
+// forgetPerHiveEnvObservation drops a hive that no longer exists, so a
+// deprovisioned hive cannot hold the counts non-zero forever.
+func (s *HubServer) forgetPerHiveEnvObservation(hiveID string) {
+	if s == nil {
+		return
+	}
+	s.perHiveEnvMu.Lock()
+	defer s.perHiveEnvMu.Unlock()
+	delete(s.perHiveEnvSeen, hiveID)
+}
+
+// PerHiveEnvStatus is the Deployment-sourced convergence view exposed on
+// GET /api/saas/admin/auth-rollout.
+type PerHiveEnvStatus struct {
+	// ObservedHives is how many hives the hub has successfully READ a
+	// Deployment for. This is the denominator, and it is deliberately a count
+	// of successful reads rather than of hives that exist: a hive on an
+	// unreachable cluster is not evidence of anything either way.
+	ObservedHives int `json:"observed_hives"`
+	// MissingPerHiveEnv is how many observed hives are missing (or carry a
+	// wrong value for) at least one of the five reconciled security vars.
+	// Convergence means this reaches zero and STAYS zero across a full sweep.
+	MissingPerHiveEnv int `json:"missing_per_hive_env"`
+	// MissingHives names those laggards so an operator can go look at them
+	// rather than guessing.
+	MissingHives []string `json:"missing_hives,omitempty"`
+	// StillCarryingMaster is how many observed hives still inject
+	// HIVE_HUB_SECRET. This lane never removes it — the count exists to gate
+	// the LATER removal step, which must not begin while any spoke would lose
+	// its only working key.
+	StillCarryingMaster int `json:"still_carrying_master"`
+	// PerHiveEnvConverged is true only when at least one hive was observed and
+	// none is missing a var. Fails CLOSED on zero observations: "no evidence"
+	// must never read as "safe to proceed".
+	PerHiveEnvConverged bool `json:"per_hive_env_converged"`
+}
+
+// PerHiveEnvSnapshot reports fleet convergence for the five per-hive security
+// env vars.
+//
+// WHY THIS IS NOT SOURCED FROM HEARTBEAT RECENCY. The sibling signal in this
+// file's neighbour, AuthRolloutReadiness, is built from noteHeartbeatAuthPath
+// observations and drops any hive not seen within authRolloutStaleAfter (24h).
+// Its own doc comment records the consequence: it cannot distinguish "hive
+// absent" from "hive never existed", so a hive that is merely PAUSED,
+// mid-upgrade, or on a temporarily unreachable cluster silently leaves the
+// denominator — and the fleet then reads ready while that spoke is still
+// unconverged. For a signal that gates deleting a compat lane, that failure
+// mode is the whole risk.
+//
+// These counts therefore come from the hub's OWN Deployment reads in
+// reconcilePerHiveEnv, not from anything the spoke sends. A paused spoke still
+// has a Deployment, so it is still read, still counted, and still blocks
+// convergence until it is actually fixed. A spoke cannot fall out of the
+// denominator by going quiet; it falls out only when the hub can no longer read
+// it (in which case it was never counted as converged either) or when the hive
+// is deprovisioned and explicitly forgotten.
+func (s *HubServer) PerHiveEnvSnapshot() PerHiveEnvStatus {
+	out := PerHiveEnvStatus{}
+	if s == nil {
+		return out
+	}
+	s.perHiveEnvMu.RLock()
+	defer s.perHiveEnvMu.RUnlock()
+	for id, obs := range s.perHiveEnvSeen {
+		out.ObservedHives++
+		if len(obs.MissingVars) > 0 {
+			out.MissingPerHiveEnv++
+			out.MissingHives = append(out.MissingHives, id)
+		}
+		if obs.HasMasterSecret {
+			out.StillCarryingMaster++
+		}
+	}
+	sort.Strings(out.MissingHives)
+	out.PerHiveEnvConverged = out.ObservedHives > 0 && out.MissingPerHiveEnv == 0
+	return out
+}
+
+// reconcilePerHiveEnvIfDue runs the sweep only if perHiveEnvReconcileInterval
+// has elapsed, so the frequent SHA poller can call it every tick. Mirrors
+// reconcileNetAdminIfDue.
+func (s *HubServer) reconcilePerHiveEnvIfDue() {
+	s.clusterUnreachableMu.Lock()
+	due := s.lastPerHiveEnvReconcile.IsZero() ||
+		time.Since(s.lastPerHiveEnvReconcile) >= perHiveEnvReconcileInterval
+	if due {
+		s.lastPerHiveEnvReconcile = time.Now()
+	}
+	s.clusterUnreachableMu.Unlock()
+	if !due {
+		return
+	}
+	s.reconcilePerHiveEnv()
+}
+
+// reconcilePerHiveEnv sweeps every hub-managed hosted hive, records its live
+// env posture, and patches in the five security vars where they are absent or
+// wrong — at most perHiveEnvMaxPatchesPerCycle per cycle.
+//
+// Idempotent: a converged hive produces no patch and therefore no rollout.
+// Non-fatal: an unreachable cluster, an unreadable Deployment, or a hive
+// without a resolvable ID is skipped and logged, never patched.
+func (s *HubServer) reconcilePerHiveEnv() {
+	hives := listSaaSHives()
+	live := make(map[string]bool, len(hives))
+	patched := 0
+	deferredByRateLimit := 0
+
+	for _, h := range hives {
+		if h.Status != "running" {
+			continue
+		}
+		cluster := s.clusterForHive(&h)
+		if cluster == nil {
+			continue
+		}
+		if s.clusterRecentlyUnreachable(cluster.ID) {
+			continue
+		}
+		live[h.ID] = true
+
+		// FAIL-SAFE, checked BEFORE any cluster call: a hive with no resolvable
+		// ID, or a hub with no master secret, derives to empty values. Skip and
+		// log rather than write "" into a Deployment — see desiredPerHiveEnv.
+		want := desiredPerHiveEnv(h.ID)
+		if want == nil {
+			s.logger.Warn("per-hive env reconcile: skipping hive with no derivable keys — NOT patching (would write empty values)",
+				"hive_id", h.ID, "cluster", cluster.ID,
+				"has_master", provisionMasterSecret() != "")
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), perHiveEnvKubectlTimeout)
+		getCmd := kubectlForClusterContext(ctx, cluster, "get", "deployment", "hive",
+			"-n", hiveHostedNamespacePrefix+h.ID, "-o",
+			"jsonpath={.spec.template.spec.containers[0].env}")
+		out, err := getCmd.Output()
+		cancel()
+		if err != nil {
+			// Deployment missing, cluster unreachable, or transient kubectl
+			// error — all non-fatal, retried next sweep. Do NOT record an
+			// observation: an unread hive must not count as converged.
+			s.logger.Debug("per-hive env reconcile: could not read hive deployment env",
+				"hive_id", h.ID, "cluster", cluster.ID, "error", err)
+			continue
+		}
+		s.markClusterReachable(cluster.ID)
+
+		var liveEnv []deploymentEnvVar
+		if err := json.Unmarshal(out, &liveEnv); err != nil {
+			s.logger.Debug("per-hive env reconcile: could not parse hive deployment env",
+				"hive_id", h.ID, "cluster", cluster.ID, "error", err)
+			continue
+		}
+
+		drift := perHiveEnvDrift(liveEnv, want)
+		hasMaster := false
+		for _, e := range liveEnv {
+			if e.Name == envHubSecretMaster {
+				hasMaster = true
+				break
+			}
+		}
+		// Record the observation from THIS read regardless of whether we go on
+		// to patch — the readiness surface must reflect the whole fleet even
+		// while remediation is rate-limited.
+		s.recordPerHiveEnvObservation(h.ID, perHiveEnvObservation{
+			MissingVars:     drift,
+			HasMasterSecret: hasMaster,
+			Observed:        time.Now(),
+		})
+
+		if len(drift) == 0 {
+			// CONVERGED — issue no patch. This is the branch that prevents a
+			// fleet-wide rolling-restart storm on every sweep.
+			s.logger.Debug("per-hive env reconcile: hive already converged",
+				"hive_id", h.ID, "cluster", cluster.ID)
+			continue
+		}
+
+		if !perHiveEnvPatchAllowed(patched) {
+			deferredByRateLimit++
+			continue
+		}
+
+		patchBody, perr := perHiveEnvPatchJSON(liveEnv, want)
+		if perr != nil {
+			s.logger.Warn("per-hive env reconcile: could not build patch",
+				"hive_id", h.ID, "cluster", cluster.ID, "error", perr)
+			continue
+		}
+
+		pctx, pcancel := context.WithTimeout(context.Background(), perHiveEnvKubectlTimeout)
+		patchCmd := kubectlForClusterContext(pctx, cluster, "patch", "deployment", "hive",
+			"-n", hiveHostedNamespacePrefix+h.ID, "--type=json", "-p", patchBody)
+		pout, err := patchCmd.CombinedOutput()
+		pcancel()
+		if err != nil {
+			s.markClusterUnreachable(cluster.ID)
+			s.logger.Warn("per-hive env reconcile: patch failed — will retry next sweep",
+				"hive_id", h.ID, "cluster", cluster.ID,
+				"missing", strings.Join(drift, ","),
+				"output", strings.TrimSpace(string(pout)), "error", err)
+			continue
+		}
+		s.markClusterReachable(cluster.ID)
+		patched++
+		// Log the var NAMES only. Never the values — these are signing keys.
+		s.logger.Info("reconciled per-hive security env onto hive deployment (rolls the pod once)",
+			"hive_id", h.ID, "cluster", cluster.ID,
+			"reconciled", strings.Join(drift, ","),
+			"patched_this_cycle", patched)
+	}
+
+	// Drop hives that no longer exist so a deprovisioned spoke cannot pin the
+	// counts non-zero forever — the failure mode a too-long stale window has.
+	s.perHiveEnvMu.Lock()
+	for id := range s.perHiveEnvSeen {
+		if !live[id] {
+			delete(s.perHiveEnvSeen, id)
+		}
+	}
+	s.perHiveEnvMu.Unlock()
+
+	if deferredByRateLimit > 0 {
+		s.logger.Info("per-hive env reconcile: rate limit reached, remaining hives deferred to next cycle",
+			"patched", patched, "deferred", deferredByRateLimit,
+			"max_per_cycle", perHiveEnvMaxPatchesPerCycle,
+			"next_cycle_in", perHiveEnvReconcileInterval.String())
+	}
+}

--- a/v2/pkg/hub/perhive_env_reconcile_test.go
+++ b/v2/pkg/hub/perhive_env_reconcile_test.go
@@ -1,0 +1,526 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// perHiveEnvTestMaster is a fixed master secret for derivation in these tests.
+// Never a real value — the derived keys are compared to each other, never to a
+// production constant.
+const perHiveEnvTestMaster = "perhive-env-reconcile-test-master"
+
+// withTestMaster points provisionMasterSecret() at a known master for the
+// duration of a test. provisionMasterSecret prefers $HIVE_HUB_SECRET, so
+// setting it is sufficient and t.Setenv restores it automatically.
+func withTestMaster(t *testing.T, master string) {
+	t.Helper()
+	t.Setenv("HIVE_HUB_SECRET", master)
+	// Guard against the /data/saas/hub-secret.key fallback being picked up when
+	// we deliberately test the EMPTY-master case: an unset env var would fall
+	// through to that file if it happened to exist on the test machine.
+	if master == "" {
+		if _, err := os.Stat("/data/saas/hub-secret.key"); err == nil {
+			t.Skip("host has /data/saas/hub-secret.key; cannot exercise the empty-master path here")
+		}
+	}
+}
+
+// envList is a convenience for building a live Deployment env list.
+func envList(pairs ...string) []deploymentEnvVar {
+	out := make([]deploymentEnvVar, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, deploymentEnvVar{Name: pairs[i], Value: pairs[i+1]})
+	}
+	return out
+}
+
+// TestDesiredPerHiveEnvMatchesProvisioningTemplate is the anti-divergence test.
+// The reconcile MUST derive byte-identical values to the provisioning template
+// block in saas_provision.go. If they ever disagreed, provisioning and this
+// sweep would fight: every cycle would see "drift", patch, and roll the pod
+// forever. So pin each of the five to the exact expression the template uses.
+func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
+	withTestMaster(t, perHiveEnvTestMaster)
+	const hiveID = "hive-alpha"
+
+	want := desiredPerHiveEnv(hiveID)
+	if want == nil {
+		t.Fatal("desiredPerHiveEnv returned nil for a valid master + hive ID")
+	}
+
+	// These right-hand sides are copied verbatim from the template's data map
+	// (saas_provision.go: HeartbeatKey / SessionKey / SSOPublicKey /
+	// SessionPublicKey / TerminalKey).
+	expect := map[string]string{
+		EnvHeartbeatKey:     provisionHeartbeatKey(hiveID),
+		EnvSessionKey:       deriveDomainKey(provisionMasterSecret(), infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
+		envSessionPublicKey: provisionSessionPublicKey(),
+		EnvTerminalKey:      provisionTerminalKey(hiveID),
+	}
+	for name, v := range expect {
+		if v == "" {
+			t.Fatalf("template-side derivation for %s produced an empty value; test setup is wrong", name)
+		}
+		if want[name] != v {
+			t.Errorf("%s: reconcile derivation diverges from the provisioning template", name)
+		}
+	}
+	if len(want) != len(expect) {
+		t.Errorf("desiredPerHiveEnv returned %d vars, want %d", len(want), len(expect))
+	}
+
+	// The two PER-HIVE keys must actually differ between hives — otherwise the
+	// reconcile would be re-installing the fleet-uniform sharing N1/N3 removed.
+	other := desiredPerHiveEnv("hive-bravo")
+	if other[EnvHeartbeatKey] == want[EnvHeartbeatKey] {
+		t.Error("heartbeat key is identical across hives — not per-hive")
+	}
+	if other[EnvTerminalKey] == want[EnvTerminalKey] {
+		t.Error("terminal key is identical across hives — not per-hive")
+	}
+}
+
+// TestPerHiveEnvDriftMissingAll covers the four spokes found running purely on
+// master fallbacks: a Deployment with the pre-cutover env shape and none of the
+// five reconciled vars. All five must be reported as drift.
+func TestPerHiveEnvDriftMissingAll(t *testing.T) {
+	withTestMaster(t, perHiveEnvTestMaster)
+	want := desiredPerHiveEnv("hive-alpha")
+
+	live := envList(
+		"HIVE_GITHUB_TOKEN", "tok",
+		"DASHBOARD_AUTH_TOKEN", "dash",
+		"HIVE_ID", "hive-alpha",
+		"HIVE_LEVEL", "3",
+		"HIVE_HUB_URL", "https://hive.kubestellar.io",
+		envHubSecretMaster, perHiveEnvTestMaster,
+	)
+
+	drift := perHiveEnvDrift(live, want)
+	if len(drift) != 5 {
+		t.Fatalf("drift = %v (%d), want all 5 vars reported missing", drift, len(drift))
+	}
+	for _, name := range perHiveEnvNames() {
+		found := false
+		for _, d := range drift {
+			if d == name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s not reported as drift on a Deployment that lacks it", name)
+		}
+	}
+
+	// And the patch built from that drift must install all five with the
+	// CORRECT values, while preserving every pre-existing var — including the
+	// master, which this lane must never remove.
+	patchBody, err := perHiveEnvPatchJSON(live, want)
+	if err != nil {
+		t.Fatalf("perHiveEnvPatchJSON: %v", err)
+	}
+	merged := decodePatchEnv(t, patchBody)
+	for name, v := range want {
+		if merged[name] != v {
+			t.Errorf("%s: patched value does not match the desired derivation", name)
+		}
+	}
+	if _, ok := merged[envHubSecretMaster]; !ok {
+		t.Error("patch dropped HIVE_HUB_SECRET — this lane is additive only, removal is a separate step")
+	}
+	for _, keep := range []string{"HIVE_GITHUB_TOKEN", "DASHBOARD_AUTH_TOKEN", "HIVE_ID", "HIVE_LEVEL", "HIVE_HUB_URL"} {
+		if _, ok := merged[keep]; !ok {
+			t.Errorf("patch dropped pre-existing var %s", keep)
+		}
+	}
+}
+
+// TestPerHiveEnvDriftConvergedIsNoOp is the anti-rollout-storm test. A
+// Deployment that already carries all five correct values must report ZERO
+// drift, because the sweep issues a patch only when drift is non-empty and any
+// patch rolls the pod. If this regressed, every sweep would restart every pod
+// in the fleet and interrupt every running agent.
+func TestPerHiveEnvDriftConvergedIsNoOp(t *testing.T) {
+	withTestMaster(t, perHiveEnvTestMaster)
+	const hiveID = "hive-alpha"
+	want := desiredPerHiveEnv(hiveID)
+
+	live := envList("HIVE_ID", hiveID, envHubSecretMaster, perHiveEnvTestMaster)
+	for _, name := range perHiveEnvNames() {
+		live = append(live, deploymentEnvVar{Name: name, Value: want[name]})
+	}
+
+	if drift := perHiveEnvDrift(live, want); len(drift) != 0 {
+		t.Fatalf("converged Deployment reported drift %v — the sweep would patch and roll the pod", drift)
+	}
+
+	// Stability: feeding the patch output back in must ALSO report no drift, so
+	// a hive converged by this lane is never re-patched on the next cycle.
+	patchBody, err := perHiveEnvPatchJSON(live, want)
+	if err != nil {
+		t.Fatalf("perHiveEnvPatchJSON: %v", err)
+	}
+	if drift := perHiveEnvDrift(decodePatchEnvSlice(t, patchBody), want); len(drift) != 0 {
+		t.Fatalf("re-reading a patched Deployment reported drift %v — patch loop", drift)
+	}
+}
+
+// TestPerHiveEnvDriftWrongValueCorrected covers the drift shape a stale hive ID
+// or a rotated master produces: the var is PRESENT but carries the wrong value.
+// Present-but-wrong is worse than absent (the spoke does not fall back to the
+// master; it authenticates with a key the hub does not expect), so it must be
+// detected and corrected.
+func TestPerHiveEnvDriftWrongValueCorrected(t *testing.T) {
+	withTestMaster(t, perHiveEnvTestMaster)
+	const hiveID = "hive-alpha"
+	want := desiredPerHiveEnv(hiveID)
+
+	// Every var correct EXCEPT the heartbeat key, which carries another hive's
+	// value — exactly what a copied/stale Deployment looks like.
+	stale := desiredPerHiveEnv("hive-bravo")[EnvHeartbeatKey]
+	live := envList("HIVE_ID", hiveID)
+	for _, name := range perHiveEnvNames() {
+		v := want[name]
+		if name == EnvHeartbeatKey {
+			v = stale
+		}
+		live = append(live, deploymentEnvVar{Name: name, Value: v})
+	}
+
+	drift := perHiveEnvDrift(live, want)
+	if len(drift) != 1 || drift[0] != EnvHeartbeatKey {
+		t.Fatalf("drift = %v, want exactly [%s] for a present-but-wrong value", drift, EnvHeartbeatKey)
+	}
+
+	patchBody, err := perHiveEnvPatchJSON(live, want)
+	if err != nil {
+		t.Fatalf("perHiveEnvPatchJSON: %v", err)
+	}
+	merged := decodePatchEnv(t, patchBody)
+	if merged[EnvHeartbeatKey] != want[EnvHeartbeatKey] {
+		t.Error("wrong heartbeat key was not corrected by the patch")
+	}
+	if merged[EnvHeartbeatKey] == stale {
+		t.Error("patch left the stale heartbeat key in place")
+	}
+	// Correcting in place must not duplicate the var — a duplicate name in a
+	// container env list is an API-server error on apply.
+	if n := countEnvName(t, patchBody, EnvHeartbeatKey); n != 1 {
+		t.Errorf("patched env list contains %s %d times, want exactly 1", EnvHeartbeatKey, n)
+	}
+}
+
+// TestPerHiveEnvFailsSafeOnEmptyDerivation is THE fail-safe. derivePerHiveKey
+// returns "" for an empty master or an empty hive ID by design. Writing that
+// through would set e.g. HIVE_HEARTBEAT_KEY="" on a live spoke — strictly worse
+// than absent, because the spoke falls back to the master exactly as if the var
+// were missing while the readiness count reports the hive as converged.
+// desiredPerHiveEnv must return nil so the sweep SKIPS instead of patching.
+func TestPerHiveEnvFailsSafeOnEmptyDerivation(t *testing.T) {
+	t.Run("empty hive ID", func(t *testing.T) {
+		withTestMaster(t, perHiveEnvTestMaster)
+		if got := desiredPerHiveEnv(""); got != nil {
+			t.Fatalf("desiredPerHiveEnv(\"\") = %v, want nil — would patch empty values", got)
+		}
+		if got := desiredPerHiveEnv("   "); got != nil {
+			t.Fatalf("desiredPerHiveEnv(whitespace) = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty master", func(t *testing.T) {
+		withTestMaster(t, "")
+		if got := desiredPerHiveEnv("hive-alpha"); got != nil {
+			t.Fatalf("desiredPerHiveEnv with no master = %v, want nil — would patch empty values", got)
+		}
+	})
+
+	// And with a nil desired map, the drift function must report NOTHING to do
+	// rather than reporting all five as missing — otherwise a keyless hub would
+	// see the whole fleet as drifted and try to patch it with empty values.
+	t.Run("nil desired reports no drift", func(t *testing.T) {
+		live := envList("HIVE_ID", "hive-alpha")
+		if drift := perHiveEnvDrift(live, nil); len(drift) != 0 {
+			t.Fatalf("perHiveEnvDrift(_, nil) = %v, want empty", drift)
+		}
+	})
+}
+
+// TestPerHiveEnvPositiveControl is the control for the no-op test above.
+// "Never patch anything" would satisfy TestPerHiveEnvDriftConvergedIsNoOp
+// perfectly, so this asserts the opposite direction: a legitimately drifted
+// Deployment DOES produce a patch, and that patch is well-formed JSON-Patch
+// targeting the hive container's env list.
+func TestPerHiveEnvPositiveControl(t *testing.T) {
+	withTestMaster(t, perHiveEnvTestMaster)
+	want := desiredPerHiveEnv("hive-alpha")
+
+	// Missing exactly one var — the minimal legitimate reconcile.
+	live := envList("HIVE_ID", "hive-alpha", envHubSecretMaster, perHiveEnvTestMaster)
+	for _, name := range perHiveEnvNames() {
+		if name == envSessionPublicKey {
+			continue
+		}
+		live = append(live, deploymentEnvVar{Name: name, Value: want[name]})
+	}
+
+	drift := perHiveEnvDrift(live, want)
+	if len(drift) != 1 || drift[0] != envSessionPublicKey {
+		t.Fatalf("drift = %v, want exactly [%s] — the reconcile must still fire on real drift",
+			drift, envSessionPublicKey)
+	}
+
+	patchBody, err := perHiveEnvPatchJSON(live, want)
+	if err != nil {
+		t.Fatalf("perHiveEnvPatchJSON: %v", err)
+	}
+	if !strings.Contains(patchBody, hiveContainerEnvPath) {
+		t.Errorf("patch %q does not target the hive container env path %q", patchBody, hiveContainerEnvPath)
+	}
+	if !strings.Contains(patchBody, `"op":"replace"`) {
+		t.Errorf("patch %q is not a replace op", patchBody)
+	}
+	if merged := decodePatchEnv(t, patchBody); merged[envSessionPublicKey] != want[envSessionPublicKey] {
+		t.Errorf("%s was not installed by the patch", envSessionPublicKey)
+	}
+}
+
+// TestPerHiveEnvRateLimitRespected asserts the per-cycle patch cap. Each patch
+// rolls a pod and interrupts that hive's running agents, so a sweep over a
+// fully-drifted ~70-hive fleet must NOT patch them all at once. This replays
+// the sweep's cap arithmetic over a drifted fleet fixture.
+func TestPerHiveEnvRateLimitRespected(t *testing.T) {
+	withTestMaster(t, perHiveEnvTestMaster)
+
+	const fleetSize = 70
+	patched, deferredCount := 0, 0
+	for i := 0; i < fleetSize; i++ {
+		// Every hive is drifted (missing all five).
+		want := desiredPerHiveEnv("hive-" + string(rune('a'+i%26)) + itoa(i))
+		if want == nil {
+			t.Fatal("fixture hive derived to nil")
+		}
+		if drift := perHiveEnvDrift(nil, want); len(drift) == 0 {
+			t.Fatal("fixture hive should be drifted")
+		}
+		// Calls the SAME predicate reconcilePerHiveEnv gates on, so removing
+		// the sweep's rate limit fails this test rather than leaving it green.
+		if !perHiveEnvPatchAllowed(patched) {
+			deferredCount++
+			continue
+		}
+		patched++
+	}
+
+	if patched != perHiveEnvMaxPatchesPerCycle {
+		t.Errorf("patched %d hives in one cycle, want the cap of %d — a bigger batch rolls that many pods at once",
+			patched, perHiveEnvMaxPatchesPerCycle)
+	}
+	if deferredCount != fleetSize-perHiveEnvMaxPatchesPerCycle {
+		t.Errorf("deferred %d, want %d", deferredCount, fleetSize-perHiveEnvMaxPatchesPerCycle)
+	}
+	if perHiveEnvMaxPatchesPerCycle >= fleetSize {
+		t.Error("cap is not actually limiting: it would patch the whole fleet in one cycle")
+	}
+	// The cap must be a small positive number: 0 would never converge, and a
+	// large one defeats the purpose.
+	if perHiveEnvMaxPatchesPerCycle < 1 || perHiveEnvMaxPatchesPerCycle > 10 {
+		t.Errorf("perHiveEnvMaxPatchesPerCycle = %d, want a small positive batch", perHiveEnvMaxPatchesPerCycle)
+	}
+}
+
+// TestPerHiveEnvReconcileThrottle verifies the poller-loop throttle, so the
+// 2-min SHA poller can call the sweep every tick without hammering kubectl.
+func TestPerHiveEnvReconcileThrottle(t *testing.T) {
+	s := &HubServer{clusterUnreachableUntil: map[string]time.Time{}}
+
+	s.clusterUnreachableMu.Lock()
+	due := s.lastPerHiveEnvReconcile.IsZero()
+	if due {
+		s.lastPerHiveEnvReconcile = time.Now()
+	}
+	s.clusterUnreachableMu.Unlock()
+	if !due {
+		t.Fatal("first reconcile should be due (zero timestamp)")
+	}
+
+	s.clusterUnreachableMu.Lock()
+	due2 := time.Since(s.lastPerHiveEnvReconcile) >= perHiveEnvReconcileInterval
+	s.clusterUnreachableMu.Unlock()
+	if due2 {
+		t.Fatal("second reconcile immediately after should be throttled")
+	}
+
+	s.clusterUnreachableMu.Lock()
+	s.lastPerHiveEnvReconcile = time.Now().Add(-perHiveEnvReconcileInterval - time.Minute)
+	due3 := time.Since(s.lastPerHiveEnvReconcile) >= perHiveEnvReconcileInterval
+	s.clusterUnreachableMu.Unlock()
+	if !due3 {
+		t.Fatal("reconcile should be due again after the interval elapses")
+	}
+}
+
+// TestPerHiveEnvSnapshotMixedFleet asserts the readiness counts reflect reality
+// for a mixed fleet, and — critically — that they are sourced from Deployment
+// reads rather than heartbeat recency. A hive that has not heartbeated in weeks
+// (paused) must STILL appear in the denominator and still block convergence:
+// that is the exact failure mode authRolloutStaleAfter has and this must not.
+func TestPerHiveEnvSnapshotMixedFleet(t *testing.T) {
+	s := &HubServer{}
+
+	// Converged, beating normally.
+	s.recordPerHiveEnvObservation("hive-good", perHiveEnvObservation{
+		HasMasterSecret: true, Observed: time.Now(),
+	})
+	// Converged, but its Deployment no longer carries the master — the end state.
+	s.recordPerHiveEnvObservation("hive-clean", perHiveEnvObservation{
+		HasMasterSecret: false, Observed: time.Now(),
+	})
+	// Drifted: missing everything (one of the four real spokes).
+	s.recordPerHiveEnvObservation("hive-bare", perHiveEnvObservation{
+		MissingVars: perHiveEnvNames(), HasMasterSecret: true, Observed: time.Now(),
+	})
+	// PAUSED and drifted: its last Deployment read was weeks ago. A
+	// heartbeat-sourced signal would have dropped this hive from the totals and
+	// reported the fleet ready. Deployment-sourced counts must keep it.
+	s.recordPerHiveEnvObservation("hive-paused", perHiveEnvObservation{
+		MissingVars:     []string{envSessionPublicKey},
+		HasMasterSecret: true,
+		Observed:        time.Now().Add(-30 * 24 * time.Hour),
+	})
+
+	got := s.PerHiveEnvSnapshot()
+	if got.ObservedHives != 4 {
+		t.Errorf("ObservedHives = %d, want 4", got.ObservedHives)
+	}
+	if got.MissingPerHiveEnv != 2 {
+		t.Errorf("MissingPerHiveEnv = %d, want 2", got.MissingPerHiveEnv)
+	}
+	if got.StillCarryingMaster != 3 {
+		t.Errorf("StillCarryingMaster = %d, want 3", got.StillCarryingMaster)
+	}
+	if got.PerHiveEnvConverged {
+		t.Error("PerHiveEnvConverged = true with 2 drifted hives")
+	}
+	// The paused hive must be NAMED, not silently dropped.
+	if !hasString(got.MissingHives, "hive-paused") {
+		t.Errorf("MissingHives = %v, must include the long-unseen paused hive — "+
+			"dropping it by age is the authRolloutStaleAfter failure mode this signal avoids",
+			got.MissingHives)
+	}
+	if !hasString(got.MissingHives, "hive-bare") {
+		t.Errorf("MissingHives = %v, must include hive-bare", got.MissingHives)
+	}
+
+	// Fix both laggards → converged.
+	s.recordPerHiveEnvObservation("hive-bare", perHiveEnvObservation{HasMasterSecret: true, Observed: time.Now()})
+	s.recordPerHiveEnvObservation("hive-paused", perHiveEnvObservation{HasMasterSecret: true, Observed: time.Now()})
+	got = s.PerHiveEnvSnapshot()
+	if !got.PerHiveEnvConverged || got.MissingPerHiveEnv != 0 {
+		t.Errorf("after repair: converged=%v missing=%d, want true/0", got.PerHiveEnvConverged, got.MissingPerHiveEnv)
+	}
+	if got.StillCarryingMaster != 3 {
+		t.Errorf("StillCarryingMaster = %d, want 3 — env convergence must not imply the master is gone",
+			got.StillCarryingMaster)
+	}
+
+	// Deprovisioned hives are forgotten, so they cannot pin the counts forever.
+	s.forgetPerHiveEnvObservation("hive-clean")
+	if got := s.PerHiveEnvSnapshot(); got.ObservedHives != 3 {
+		t.Errorf("after forget: ObservedHives = %d, want 3", got.ObservedHives)
+	}
+}
+
+// TestPerHiveEnvSnapshotFailsClosed: with no observations at all the fleet must
+// NOT read converged. "No evidence" must never gate the master-secret removal.
+func TestPerHiveEnvSnapshotFailsClosed(t *testing.T) {
+	s := &HubServer{}
+	if got := s.PerHiveEnvSnapshot(); got.PerHiveEnvConverged {
+		t.Error("PerHiveEnvConverged = true with zero observations; must fail closed")
+	}
+	var nilServer *HubServer
+	if got := nilServer.PerHiveEnvSnapshot(); got.PerHiveEnvConverged {
+		t.Error("nil HubServer must not report converged")
+	}
+}
+
+// TestAuthRolloutIncludesPerHiveEnv asserts the readiness surface actually
+// carries the new counts, so convergence is measurable over the existing
+// endpoint without shelling out.
+func TestAuthRolloutIncludesPerHiveEnv(t *testing.T) {
+	s := &HubServer{}
+	s.recordPerHiveEnvObservation("hive-bare", perHiveEnvObservation{
+		MissingVars: perHiveEnvNames(), HasMasterSecret: true, Observed: time.Now(),
+	})
+	out := s.AuthRolloutReadiness()
+	if out.PerHiveEnv.ObservedHives != 1 || out.PerHiveEnv.MissingPerHiveEnv != 1 {
+		t.Errorf("AuthRolloutReadiness did not carry the per-hive env counts: %+v", out.PerHiveEnv)
+	}
+	if out.PerHiveEnv.StillCarryingMaster != 1 {
+		t.Errorf("StillCarryingMaster not surfaced: %+v", out.PerHiveEnv)
+	}
+	// The JSON must actually serialize the nested block for operators.
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, key := range []string{"per_hive_env", "missing_per_hive_env", "still_carrying_master", "per_hive_env_converged"} {
+		if !strings.Contains(string(b), key) {
+			t.Errorf("auth-rollout JSON missing %q", key)
+		}
+	}
+}
+
+// --- helpers ---
+
+func decodePatchEnv(t *testing.T, patchBody string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, e := range decodePatchEnvSlice(t, patchBody) {
+		out[e.Name] = e.Value
+	}
+	return out
+}
+
+func decodePatchEnvSlice(t *testing.T, patchBody string) []deploymentEnvVar {
+	t.Helper()
+	var ops []struct {
+		Op    string             `json:"op"`
+		Path  string             `json:"path"`
+		Value []deploymentEnvVar `json:"value"`
+	}
+	if err := json.Unmarshal([]byte(patchBody), &ops); err != nil {
+		t.Fatalf("patch body is not valid JSON-Patch: %v (%s)", err, patchBody)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("patch has %d ops, want exactly 1", len(ops))
+	}
+	if ops[0].Path != hiveContainerEnvPath {
+		t.Fatalf("patch path = %q, want %q", ops[0].Path, hiveContainerEnvPath)
+	}
+	return ops[0].Value
+}
+
+func countEnvName(t *testing.T, patchBody, name string) int {
+	t.Helper()
+	n := 0
+	for _, e := range decodePatchEnvSlice(t, patchBody) {
+		if e.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+func hasString(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4978,6 +4978,13 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// netAdminReconcileInterval — this poller ticks far more often than the
 	// static drift needs re-checking. See netadmin_reconcile.go / issue #2674.
 	s.reconcileNetAdminIfDue()
+	// Ensure the five per-hive security env vars are present and correct on
+	// every hosted spoke. Nothing else re-asserts them after provision time, so
+	// without this the fleet's key posture survives only as an out-of-band
+	// manual patch. Throttled internally to perHiveEnvReconcileInterval and
+	// rate-limited to perHiveEnvMaxPatchesPerCycle patches per cycle, because
+	// each patch rolls that hive's pod. See perhive_env_reconcile.go.
+	s.reconcilePerHiveEnvIfDue()
 	// Record the per-release image-pulls snapshot (external-adoption chart). The
 	// call is internally guarded to snapshot only when the v2 release SHA advances,
 	// so ticking it alongside the frequent SHA poll is cheap — no separate
@@ -5005,6 +5012,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		s.sweepOrphanedUpgrades()
 		s.sweepStuckAssignments()
 		s.reconcileNetAdminIfDue()
+		s.reconcilePerHiveEnvIfDue()
 		s.maybeSnapshotImagePulls(ctx, time.Now())
 		changed := false
 		for branch, sha := range newSHAs {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -882,6 +882,20 @@ type HubServer struct {
 	// most once per netAdminReconcileInterval. Guarded by clusterUnreachableMu
 	// (both are poller-loop-only state; no need for a separate mutex).
 	lastNetAdminReconcile time.Time
+	// lastPerHiveEnvReconcile throttles the per-hive security env reconcile
+	// (perhive_env_reconcile.go), which ensures HIVE_HEARTBEAT_KEY /
+	// HIVE_TERMINAL_KEY / HIVE_SESSION_KEY / HIVE_SSO_PUBLIC_KEY /
+	// HIVE_SESSION_PUBLIC_KEY are present and correct on every hosted spoke.
+	// Same rationale and same guarding mutex as lastNetAdminReconcile above:
+	// both are poller-loop-only state.
+	lastPerHiveEnvReconcile time.Time
+	// perHiveEnvSeen is the Deployment-SOURCED convergence view backing
+	// PerHiveEnvSnapshot: hive ID → what the hub last actually read off that
+	// hive's Deployment. Deliberately NOT derived from heartbeat recency (see
+	// the long note on PerHiveEnvSnapshot) so a paused spoke cannot drop out of
+	// the denominator and make the fleet read converged while it is not.
+	perHiveEnvSeen map[string]perHiveEnvObservation
+	perHiveEnvMu   sync.RWMutex
 	// reporterSeen tracks which spoke instance (payload.Reporter, the pod
 	// name) last reported as each hive, to catch two instances alternating
 	// under one hive_id. Guarded by reporterMu, not s.mu — it is touched on


### PR DESCRIPTION
## The gap

The five per-hive security env vars are rendered by the provisioning template in `saas_provision.go`, but that template is `kubectl apply`ed **only** inside `provisionHive` — at provision/assign time. Nothing re-asserts them afterwards.

What actually put them on the live fleet was an **out-of-band `kubectl patch`**, not any code path on any branch:

- `kubectl.kubernetes.io/last-applied-configuration` on a live spoke lists only the pre-cutover shape (`HIVE_GITHUB_TOKEN, DASHBOARD_AUTH_TOKEN, HIVE_ID, HIVE_LEVEL, HIVE_HUB_URL, HIVE_HUB_SECRET`), while the live `.spec` has the new vars **appended after** `HIVE_HUB_SECRET`.
- The v4 template emits them *instead of* the master, in a different order.
- `git grep HIVE_HEARTBEAT_KEY origin/v4 -- 'v2/pkg/hub/*.go'` returns only the template literal.

So the fleet's security posture is held in place by a manual edit that no controller maintains. Any re-provision, restore, or manifest reapply silently reverts a spoke to master-derived fallbacks — `spokeDomainKey` / `TerminalSigningKey` / `SpokeSSOPublicKey` all fall through to `HIVE_HUB_SECRET` when their dedicated var is absent, which is precisely the fleet-uniform key sharing N1/N3 removed.

**Four spokes were missed by that manual patch and run on master-only fallbacks today** (verified read-only against the live clusters):

| Spoke | State |
|---|---|
| `hive-hosted-hosted-available-oke-02-placeholder-7zus` | all five absent |
| `hive-hosted-hosted-daviddiaz0317-visual-hive--1jos` | all five absent |
| `hive-hosted-hosted-projectbluefin-knuckle-gjvq` | all five absent — **a real external user's hive** |
| `hive-hosted-hosted-kubestellar-console-4vkt` | has HEARTBEAT + TERMINAL; missing SSO_PUBLIC, SESSION_PUBLIC, SESSION_KEY |

All 66 hosted spokes still carry `HIVE_HUB_SECRET`.

## What this adds

`v2/pkg/hub/perhive_env_reconcile.go` — a hub-side reconcile lane that reads each hosted spoke's Deployment and patches in the five vars where absent or wrong.

Values are derived with the **same helpers the provisioning template calls**, so provision-time and reconcile-time derivation cannot disagree (divergence would make the two fight and roll a pod every cycle forever):

| Var | Derivation |
|---|---|
| `HIVE_HEARTBEAT_KEY` | `provisionHeartbeatKey(hiveID)` |
| `HIVE_TERMINAL_KEY` | `provisionTerminalKey(hiveID)` |
| `HIVE_SESSION_KEY` | `deriveDomainKey(provisionMasterSecret(), infoSessionKey)` |
| `HIVE_SSO_PUBLIC_KEY` | `ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed))` |
| `HIVE_SESSION_PUBLIC_KEY` | `provisionSessionPublicKey()` |

**Idempotent.** A converged hive produces zero drift and therefore no patch — no rolling restart. Feeding a patched Deployment back through the drift check must also yield zero, so the lane can never enter a patch loop; that stability property is tested.

**Additive only.** `HIVE_HUB_SECRET` is never removed. Stripping the master is a separate, fleet-visible step with hard preconditions; coupling it to a silent repair would turn this into a breaking change.

**Rate-limited: 3 patches per cycle, 15-minute interval.** Adding an env var mutates the podspec, so every patch rolls that hive's pod and kills its tmux session, interrupting whatever agents are mid-run. Patching ~70 spokes at once would interrupt every running agent on the platform simultaneously, stampede image pulls, and give no chance to notice a bad patch before it reached the whole fleet. 3/cycle converges a fully-drifted 70-hive fleet in ~6 hours — fast enough that a gap doesn't linger for days, slow enough that at most 3 tenants are disturbed at a time and an operator has ~15 minutes between batches to stop the hub. The cap counts **patches, not reads**: every hive is still read every cycle, so the readiness counts cover the whole fleet even while remediation is throttled.

**Fails safe.** `derivePerHiveKey` returns `""` for an empty master or empty hiveID by design. `desiredPerHiveEnv` returns `nil` if any derived value is empty, and the sweep **skips and logs** rather than patching. This matters more than it looks: an empty var is *worse than an absent one* — the spoke-side resolvers test for non-empty before falling back, so `HIVE_HEARTBEAT_KEY=\"\"` falls back to the master exactly like an absent var **while making the readiness count report the hive as converged**.

Wired into `StartLatestSHAPoller` alongside `reconcileNetAdminIfDue`, whose cluster access path, unreachable-cluster suppression, and check-then-patch shape it deliberately mirrors. Logs var **names** only, never values.

## Observability

Extends the existing `GET /api/saas/admin/auth-rollout` (`handleAuthRollout`) with a `per_hive_env` block: `observed_hives`, `missing_per_hive_env`, `missing_hives`, `still_carrying_master`, `per_hive_env_converged` (fails closed on zero observations).

These counts are sourced from the hub's **own Deployment reads**, not from heartbeat recency — and that distinction is documented in the code. `AuthRolloutReadiness` drops any hive not seen within `authRolloutStaleAfter` (24h) and, as its own doc comment records, **cannot distinguish \"hive absent\" from \"hive never existed\"**. A merely paused spoke therefore leaves the denominator silently and the fleet reads ready while unconverged — the exact failure mode that would matter most when gating the master-secret removal. A paused hive still has a Deployment, so it is still read, still counted, and still blocks convergence. It leaves the denominator only when deprovisioned and explicitly forgotten.

## Tests

`TestDesiredPerHiveEnvMatchesProvisioningTemplate`, `TestPerHiveEnvDriftMissingAll`, `TestPerHiveEnvDriftConvergedIsNoOp`, `TestPerHiveEnvDriftWrongValueCorrected`, `TestPerHiveEnvFailsSafeOnEmptyDerivation`, `TestPerHiveEnvPositiveControl`, `TestPerHiveEnvRateLimitRespected`, `TestPerHiveEnvReconcileThrottle`, `TestPerHiveEnvSnapshotMixedFleet`, `TestPerHiveEnvSnapshotFailsClosed`, `TestAuthRolloutIncludesPerHiveEnv`.

The rate-limit test calls the same `perHiveEnvPatchAllowed` predicate the sweep gates on, rather than re-implementing the comparison — a test that re-implemented it would stay green if the sweep's own check were deleted.

### Regression replay

Each guard was neutered so it still compiled, and the specific test confirmed failing, then restored:

| # | Neutered | Result |
|---|---|---|
| 1 | empty-value fail-safe (return derived values even when empty) | builds; `TestPerHiveEnvFailsSafeOnEmptyDerivation` + both subtests FAIL |
| 2 | rate limit (`perHiveEnvPatchAllowed` always true) | builds; `TestPerHiveEnvRateLimitRespected` FAIL — *\"patched 70 hives in one cycle, want the cap of 3\"* |
| 3 | drift check always reports drift (rollout storm) | builds; `TestPerHiveEnvDriftConvergedIsNoOp`, `TestPerHiveEnvDriftWrongValueCorrected`, `TestPerHiveEnvPositiveControl` FAIL |
| 4 | drift check never reports drift (\"never patch anything\") | builds; `TestPerHiveEnvDriftMissingAll`, `TestPerHiveEnvDriftWrongValueCorrected`, `TestPerHiveEnvPositiveControl`, `TestPerHiveEnvRateLimitRespected` FAIL |
| 5 | readiness never counts a hive as missing | builds; `TestPerHiveEnvSnapshotMixedFleet`, `TestAuthRolloutIncludesPerHiveEnv` FAIL |
| 6 | template agreement (wrong info label for session key) | builds; `TestDesiredPerHiveEnvMatchesProvisioningTemplate` FAIL |

Restored → green. Replay 4 is the one that matters for honesty: it confirms the no-op test is not satisfiable by simply never patching, because the positive control catches it.

`go build ./...` clean; `go test ./pkg/hub/` passes (3 consecutive runs on the branch, 4 on the untouched base for comparison). `gofmt` clean on all touched files — `pkg/hub/saas.go` is unformatted on the base already and was left alone.

## Does this converge the four named spokes?

**Yes, provided the hub can resolve each one's cluster and its `SaaSHive` status is `running`** — the same preconditions the NET_ADMIN reconcile operates under. All four sit on `hive-oke`, which the hub reaches routinely. They are the only drifted hives in the fleet, so at 3 patches per cycle they converge in **two cycles (~15 minutes)**: three on the first, the fourth on the next. Each will roll its pod once, which will interrupt agents running on those spokes — including `projectbluefin-knuckle-gjvq`, a real external user's hive. That is the intended one-time correction, and after it the vars are code-owned rather than dependent on someone remembering to re-patch by hand.

This PR does **not** remove `HIVE_HUB_SECRET` from any spoke; all 66 keep it. The new `still_carrying_master` count is what gates that later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)