### PR TITLE
feat(hub): master secret key generations — make rotation possible

### DIFF
--- a/v2/docs/design/master-key-rotation.md
+++ b/v2/docs/design/master-key-rotation.md
@@ -1,0 +1,299 @@
+# Hub master secret rotation
+
+Status: foundational code landed; per-domain adoption pending (see "Follow-on PRs").
+
+## The problem
+
+Every piece of signing material on the platform is a pure function of ONE value,
+the hub master secret, with no marker recording which master produced it:
+
+```
+heartbeat bearer   = HMAC(master, "hive-heartbeat-v1" || 0x00 || hiveID)
+session cookie key = HMAC(master, "hive-session-v1")
+session Ed25519    = HMAC(master, "hive-session-ed25519-v1")   -> seed
+SSO Ed25519        = HMAC(master, "hive-sso-ed25519-v1")       -> seed
+impersonate key    = HMAC(master, "hive-impersonate-v1")
+terminal key       = HMAC(master, "hive-terminal-v1" || 0x00 || hiveID)
+invite key         = HMAC(master, "hive-invite-v1"   || 0x00 || hiveID)
+```
+
+The `-v1` suffixes version the DOMAIN LABEL, not the key. There is no
+generation, kid, or secret-version concept anywhere in `v2/pkg/hub`.
+
+The consequence is that rotation is a fleet-wide flag day. Changing the master
+changes all seven derived values simultaneously, and no verifier can accept
+both the outgoing and incoming forms. In one instant every browser session is
+invalidated, every heartbeat 401s, every SSO handoff fails to verify, and every
+terminal grant is rejected — across ~66 hosted spokes. In practice this means
+the master has never been rotated and cannot be, which is exactly the property
+a master secret must not have.
+
+## Why not simply bump the info labels
+
+The obvious alternative — rotate per-domain by moving `hive-session-v1` to
+`hive-session-v2` — was considered and rejected as the primary mechanism.
+
+It does not rotate the secret. Every `-v2` label is still `HMAC(master, ...)`
+of the SAME master. If the master leaks, bumping labels changes the derived
+bytes but the attacker who holds the master re-derives every `-v2` key as
+easily as every `-v1` key. Label bumping is a domain-separation tool, not a
+compromise-recovery tool, and compromise recovery is the reason to rotate.
+
+It also does not compose. A label bump requires editing a constant, which is a
+code change and therefore a deploy, which means the rotation cadence is bounded
+by the release cadence and cannot be done urgently. And the labels are a
+contract shared with the Node proxy (`v2/proxy/server.js`) and with already-
+provisioned spoke Deployments, so a bump is fleet-visible in exactly the way an
+emergency rotation must not be.
+
+So: rotate the MASTER, and add a generation marker so verifiers can select.
+The info labels stay as they are and keep meaning what they mean.
+
+## Design
+
+### Generations
+
+A generation is `(id, secret)`. The hub holds an ordered set: exactly one
+**current** generation, which is the only one that MINTS, plus zero or more
+**previous** generations that are accepted for VERIFY only, each with an
+explicit expiry.
+
+```
+current:  gen=3  secret=<64 hex>        mint + verify
+previous: gen=2  secret=<64 hex>        verify only, until 2026-08-20T00:00:00Z
+```
+
+The generation id is a small monotonically increasing integer. It is NOT
+secret — it appears in cookies and log lines and that is fine; it names a key,
+it is not a key.
+
+Derivation is unchanged. `deriveDomainKey(gen.secret, info)` and
+`derivePerHiveKey(gen.secret, info, hiveID)` are called exactly as today,
+once per generation. This matters: it means no domain's key FORMAT changes,
+so a rotation does not require the Node proxy or any spoke to understand
+generations in order to keep working. A spoke that is handed
+`HIVE_SESSION_KEY=<derived from gen 3>` simply has a different string in its
+env than it had before, and every existing code path treats it identically.
+
+### On-disk representation
+
+Today the master lives at `/data/saas/hub-secret.key` — 64 bytes, raw. That
+file remains the generation-1 secret and is never rewritten, so a hub that
+rolls back to pre-rotation code finds exactly what it expects. Generations are
+stored alongside it in `/data/saas/hub-generations.json`:
+
+```json
+{
+  "current": 3,
+  "generations": [
+    {"id": 3, "secret": "...", "created": "..."},
+    {"id": 2, "secret": "...", "created": "...", "verify_until": "..."}
+  ]
+}
+```
+
+When that file is absent — the state of every hub today — the loader
+synthesizes a single generation `{id: 1, secret: <contents of
+hub-secret.key>}`. So an un-rotated hub behaves byte-identically to today, and
+"has never been rotated" and "has been rotated back to one generation" are the
+same state. There is no migration step.
+
+### Dual acceptance, and how it ends
+
+Verifiers try the current generation first, then each unexpired previous
+generation. Minting only ever uses current.
+
+The prior art here is a warning, not a template. The F1/F2 lanes that took
+five audits to remove were "verify-both" lanes that were **unversioned and
+permanent**: nothing in the code said which alternative was the legacy one,
+and nothing said when it stopped being accepted, so the only way to end them
+was an audit finding. This design fixes both properties:
+
+- **Explicitly versioned.** A previous generation is a numbered entry in a
+  list, not an unnamed `if` branch. "Which key accepted this request" is a
+  value the code can return and the telemetry can count.
+- **Explicitly finite.** Every previous generation carries `verify_until`. An
+  expired generation is not accepted, full stop — the acceptance window closes
+  on a wall clock whether or not anyone remembers to close it. The default
+  window is 7 days, matching `cookieMaxAgeDays`, because the longest-lived
+  artifact bound to a generation is a session cookie.
+
+The end state is observable rather than inferred: `GET
+/api/saas/admin/auth-rollout` reports, per generation, how many spokes carry
+material derived from it. Retirement is safe when the previous generation's
+count reaches zero AND its `verify_until` has passed.
+
+### Which artifacts can carry a generation marker
+
+This is the part that constrains the design, and it splits three ways.
+
+**CAN carry a marker — payload room, hub controls both ends.**
+
+| Artifact | Format | Marker placement |
+|---|---|---|
+| Impersonation cookie | `admin\|target\|exp.<sig>` | prepend `g<N>.` |
+| Session cookie (HMAC) | `user.<sig>` | prepend `g<N>.` |
+| Session cookie (Ed25519) | signed payload | field in payload |
+| SSO handoff token | structured, versioned | field in payload |
+
+For these, a verifier reads the marker and selects the one generation to check
+against. No trial verification, no extra HMAC work, and — importantly — the
+audit log can record which generation was used.
+
+**CANNOT carry a marker — bare derived strings.**
+
+| Artifact | Why |
+|---|---|
+| Heartbeat bearer | The bearer IS the derived key, presented raw in `Authorization`. There is no envelope to put a marker in. |
+| Terminal assertion key | Symmetric key read from env by both Go and Node; adding structure changes the contract with `proxy/server.js`. |
+| Invite key | Same shape as terminal. |
+| SSO/session PUBLIC keys | A hex Ed25519 public key has a fixed 32-byte form. |
+
+For these the answer is **bounded trial verification**: compare the presented
+value against the derivation from each live generation, in current-then-previous
+order, constant-time, and stop at the first match. The bound is the number of
+live generations, which the loader caps at
+`maxLiveGenerations = 2` (one current, one previous). So worst case is two
+HMAC computations per heartbeat instead of one — a heartbeat already does
+strictly more work than that, and the comparison stays constant-time within
+each attempt.
+
+Prefixing the bearer with `g<N>.` was considered and rejected. The bearer's
+format is a contract with already-deployed spoke Deployments and with
+`SpokeHeartbeatKey()`'s self-derivation lane; changing it would make the
+rotation mechanism itself require a flag day, which defeats the purpose.
+
+**Deliberately NOT rotated in the first instance: the SSO and session Ed25519
+public keys.** These are injected into spoke Deployments and verified by the
+Node proxy, which has no generation concept. Rotating them is a
+reconcile-lane problem (below), not a verifier problem, and it is sequenced
+last because it is the most fleet-visible.
+
+### Rotating spoke-held material without re-provisioning
+
+Fleet re-provisioning is ruled out. The mechanism is the existing reconcile
+lane, `perhive_env_reconcile.go`, which already does exactly the right thing
+and already handles the rotation case — its `perHiveEnvDrift` doc comment
+says so explicitly:
+
+> A var present with a DIFFERENT value counts as drift and is corrected — that
+> is the case a stale hive ID or **a rotated master** produces.
+
+So `desiredPerHiveEnv` derives from the CURRENT generation, drift detection
+notices every spoke still holding gen-N-1 material, and the existing
+rate limiter (3 patches per 15-minute cycle) walks the fleet over ~6 hours.
+Each spoke rolls its pod once. During that walk the hub's dual acceptance is
+what keeps the not-yet-patched spokes authenticating — which is precisely why
+dual acceptance is the prerequisite for rotation and not an optimization.
+
+No new machinery is required for this. The reconcile lane needs one change:
+derive from the current generation rather than from `provisionMasterSecret()`.
+
+### Observability
+
+`PerHiveEnvStatus` gains a per-generation breakdown, sourced the same way the
+existing counts are — from the hub's OWN Deployment reads, NOT from heartbeat
+recency.
+
+This distinction is load-bearing and was learned the hard way.
+`AuthRolloutReadiness` drops any hive not seen in 24h and, as its own comment
+records, cannot distinguish "hive absent" from "hive never existed". A paused
+spoke silently leaves the denominator and the fleet reads ready while that
+spoke is still on the old generation. `PerHiveEnvSnapshot` is immune: a paused
+hive still has a Deployment, so it is still read, still counted, and still
+blocks convergence.
+
+Rotation readiness therefore gates on the Deployment-sourced counts:
+
+```json
+"key_generations": {
+  "current": 3,
+  "spokes_on_current": 61,
+  "spokes_on_previous": 5,
+  "previous_verify_until": "2026-08-20T00:00:00Z",
+  "safe_to_retire_previous": false
+}
+```
+
+`safe_to_retire_previous` is true only when `spokes_on_previous == 0` with a
+non-zero denominator AND `verify_until` has passed. It fails closed on zero
+observations.
+
+## Rotation procedure
+
+1. Operator posts to the (admin-only) rotate endpoint. The hub generates a new
+   64-byte secret, makes it current, demotes the outgoing one to previous with
+   `verify_until = now + 7d`, and persists.
+2. Hub immediately mints only with the new generation. Existing cookies and
+   bearers keep verifying against the previous generation.
+3. The reconcile lane detects drift on every spoke and patches 3 per cycle.
+   ~6 hours to converge 66 spokes.
+4. Operator watches `safe_to_retire_previous`.
+5. After `verify_until`, the previous generation stops being accepted —
+   automatically, whether or not anyone is watching.
+
+No step requires re-provisioning, and no step invalidates every session at once.
+
+## Scope landed in this PR
+
+Foundational only, deliberately:
+
+- The generation type and ordered set (`hub_generations.go`)
+- Load/synthesize-from-legacy-file, so today's hubs are unchanged
+- Dual-generation derivation helpers
+- Dual acceptance in ONE verifier: the impersonation cookie
+
+The impersonation cookie was chosen as the pilot because it is the
+lowest-risk verifier on the platform: hub-only (no spoke, no Node proxy, no
+Deployment env), a 30-minute TTL that bounds any mistake to half an hour, and
+a blast radius limited to the admin's own read-only "view as" feature — which
+is already fail-closed and grants no privileges when it fails. It exercises
+the full marker path (mint with marker, verify by selection, accept unmarked
+legacy) without touching anything a tenant depends on.
+
+The other six domains are deliberately untouched. See below.
+
+## Follow-on PRs, in order
+
+| # | Scope | Size | Fleet-visible |
+|---|---|---|---|
+| 1 | Session cookie (HMAC + Ed25519) dual acceptance, marker in payload | M | No — hub-side verify only |
+| 2 | Heartbeat bearer bounded trial verification against both generations | M | No — hub-side verify only |
+| 3 | `desiredPerHiveEnv` derives from current generation; per-generation counts in `PerHiveEnvStatus` | S | No — read path until #4 |
+| 4 | Admin rotate endpoint + persistence of the generation file | S | No — arms the rest |
+| 5 | Terminal + invite key dual acceptance (spoke-side, symmetric) | M | **Yes** — rolls pods via reconcile |
+| 6 | SSO/session Ed25519 public key rotation, incl. `proxy/server.js` accepting two public keys | L | **Yes** — Node proxy contract |
+| 7 | Retire generation automatically past `verify_until`; alert if a generation is pinned open | S | No |
+
+PRs 1–4 are hub-internal and can land without any spoke rolling. Only 5 and 6
+touch the fleet, and both go through the existing rate-limited reconcile lane
+rather than a re-provision.
+
+## Note: the empty-master readers
+
+The task flagged that `hub_keys.go:314`, `:356`, and `:390` read
+`os.Getenv("HIVE_HUB_SECRET")` directly, and that this env var is UNSET on the
+live hub pod — raising the question of what is currently deriving keys from an
+empty master.
+
+It is not a bug. Those three sites are inside `spokeDomainKey`,
+`SpokeHeartbeatKey`, and `SpokeSSOPublicKey` — all SPOKE-side resolvers. The
+`hive` binary serves both roles but selects between them at startup:
+`runHub()` (`v2/cmd/hive/main.go:6943`) is the only caller of
+`hub.NewHubServer`, and it is a distinct mode from the spoke path. On a hub
+pod those three functions are never called, so the empty `HIVE_HUB_SECRET`
+they would read is never consulted.
+
+The hub's own material comes from `NewHubServer` (`server.go:1107`), which
+reads the env var, falls back to `/data/saas/hub-secret.key`, and generates +
+persists a fresh secret if both are absent — and `provisionMasterSecret()`
+mirrors that same order. Both resolve to the 64-byte file that exists on the
+live hub PVC. `s.hubSecret` is non-empty in production, which is confirmed by
+the fleet authenticating at all: `verifyHeartbeatBearer` fails closed on an
+empty master, so an empty `s.hubSecret` would 401 all 66 spokes.
+
+Worth keeping in view rather than fixing: the three spoke-side sites bypass
+`provisionMasterSecret()` and so do NOT have the file fallback. That is
+correct today (a spoke has no hub PVC) but it means the two resolution orders
+are similar enough to be mistaken for each other and different in a way that
+is not stated at either site.

--- a/v2/pkg/hub/hub_generations.go
+++ b/v2/pkg/hub/hub_generations.go
@@ -1,0 +1,389 @@
+package hub
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Master-secret GENERATIONS — the mechanism that makes rotation possible.
+//
+// THE PROBLEM. Every piece of signing material on the platform is a pure
+// function of ONE value, the hub master secret, with no marker recording which
+// master produced it (hub_keys.go: heartbeat, session, session-Ed25519, SSO,
+// impersonate, terminal, invite). The "-v1" suffixes on the info labels version
+// the DOMAIN, not the key. So changing the master changes all seven derived
+// values at once, and no verifier can accept both the outgoing and the incoming
+// form. A rotation is therefore a fleet-wide flag day: every browser session
+// invalidated, every heartbeat 401'd, every SSO handoff unverifiable, across ~66
+// hosted spokes, simultaneously. Which is why the master has never been rotated
+// and, as the code stands, cannot be.
+//
+// THE SHAPE OF THE FIX. The hub holds an ORDERED SET of generations rather than
+// a single secret. Exactly one is CURRENT — the only one that MINTS — and zero
+// or more are PREVIOUS, accepted for VERIFY only and each carrying an explicit
+// expiry. Rotation promotes a new current and demotes the outgoing one, so
+// artifacts minted before the rotation keep verifying while artifacts minted
+// after it use the new material. Convergence of spoke-held material then happens
+// through the existing rate-limited reconcile lane (perhive_env_reconcile.go),
+// not through a re-provision.
+//
+// WHY THIS IS NOT THE "VERIFY-BOTH" LANE THAT TOOK FIVE AUDITS TO REMOVE. The
+// F1/F2 lanes were verify-both lanes too, and they were a real vulnerability for
+// years. What made them so was not that they accepted two credentials — it was
+// that they were UNVERSIONED and PERMANENT. Nothing in the code named which
+// alternative was the legacy one, and nothing said when it stopped being
+// accepted, so the only mechanism that could ever end them was an audit finding.
+// Both properties are fixed here deliberately:
+//
+//   - VERSIONED. A previous generation is a numbered entry in a list, not an
+//     unnamed `if` branch. "Which key accepted this request" is a value the code
+//     returns (see verifyWithGenerations) and the telemetry can count, so the
+//     question "is anything still using the old key?" has an answer that does not
+//     require reading the code.
+//   - FINITE. Every previous generation carries VerifyUntil. An expired
+//     generation is not accepted, full stop — the window closes on a wall clock
+//     whether or not anyone remembers to close it. This is the property the F1/F2
+//     lanes lacked entirely, and it is why this one cannot rot into permanence
+//     the way those did.
+//
+// DERIVATION IS UNCHANGED. Each generation's secret feeds deriveDomainKey and
+// derivePerHiveKey exactly as the single master does today. No domain's key
+// FORMAT changes, which is what lets a rotation happen without the Node proxy or
+// any spoke needing to understand generations at all: a spoke handed a
+// HIVE_SESSION_KEY derived from generation 3 just has a different string in its
+// env than it had before, and every existing code path treats it identically.
+
+// keyGeneration is one master secret plus the metadata that says what may be
+// done with it and until when.
+type keyGeneration struct {
+	// ID names this generation. Small monotonically increasing integer. NOT
+	// secret — it appears in cookie values and log lines, which is fine: it
+	// names a key, it is not a key.
+	ID int `json:"id"`
+	// Secret is the master for this generation. Never logged, never returned by
+	// any handler, never placed in a Deployment.
+	Secret string `json:"secret"`
+	// Created records when this generation was minted, for operator forensics.
+	Created time.Time `json:"created,omitempty"`
+	// VerifyUntil is the hard expiry of this generation's VERIFY acceptance. It
+	// is meaningful only for PREVIOUS generations; the current generation is
+	// always accepted and carries the zero value.
+	//
+	// This field is the whole reason this design does not become the permanent
+	// compat lane it replaces. See the file comment.
+	VerifyUntil time.Time `json:"verify_until,omitempty"`
+}
+
+const (
+	// legacyGenerationID is the generation number assigned to the pre-rotation
+	// master — the raw contents of /data/saas/hub-secret.key. Every hub in the
+	// fleet is on this generation today.
+	//
+	// It starts at 1 rather than 0 so that "generation 0" can never be confused
+	// with the zero value of an int: an artifact whose parsed marker is 0 is
+	// malformed, not "generation zero".
+	legacyGenerationID = 1
+
+	// maxLiveGenerations caps how many generations may be live (current plus
+	// previous) at once.
+	//
+	// This bound is what makes trial verification acceptable for the artifacts
+	// that CANNOT carry a generation marker — the heartbeat bearer above all,
+	// which is a bare derived string presented raw in an Authorization header
+	// with no envelope to put a marker in. Verifying such an artifact means
+	// deriving and comparing once per live generation, so an unbounded set would
+	// turn every heartbeat into unbounded HMAC work and hand an attacker a cheap
+	// asymmetric cost. At 2, the worst case is two HMAC computations where there
+	// was one — less than the rest of a heartbeat already costs.
+	//
+	// 2 is also the smallest value that permits rotation at all (you need the
+	// incoming and the outgoing one simultaneously), so it is deliberately the
+	// minimum that works rather than a round number. Raising it would allow
+	// stacking rotations before the previous has converged, which is a
+	// misfeature: it lets an operator start a second rotation while the first is
+	// still mid-flight and lose track of which spokes are on which key.
+	maxLiveGenerations = 2
+
+	// defaultVerifyWindow is how long a demoted generation stays acceptable for
+	// VERIFY after a rotation.
+	//
+	// Set to match cookieMaxAgeDays (7 days), because the longest-lived artifact
+	// bound to a generation is a session cookie: any shorter and a rotation logs
+	// out users whose cookies were minted just before it, which is the flag-day
+	// symptom this whole mechanism exists to avoid. Any longer and the old key
+	// stays live past the point where it protects anything, which is the F1/F2
+	// failure mode.
+	defaultVerifyWindow = 7 * 24 * time.Hour
+)
+
+// generationSet is the hub's ordered set of master generations.
+//
+// Invariants, all established by newGenerationSet and relied on by every method:
+//   - exactly one generation is current
+//   - the current generation is first in Generations
+//   - previous generations follow, most recent first
+//   - len(Generations) <= maxLiveGenerations
+type generationSet struct {
+	// Current is the ID of the generation that MINTS. Exactly one.
+	Current int `json:"current"`
+	// Generations holds the live set, current first.
+	Generations []keyGeneration `json:"generations"`
+}
+
+// newGenerationSet builds a validated set from an unordered slice, establishing
+// every invariant above. Returns nil if no generation matches currentID — a set
+// with no minting key is not a degraded set, it is an unusable one, and callers
+// must fall back to the legacy single-master path rather than run with it.
+func newGenerationSet(currentID int, gens []keyGeneration) *generationSet {
+	var current *keyGeneration
+	var previous []keyGeneration
+	for i := range gens {
+		g := gens[i]
+		if strings.TrimSpace(g.Secret) == "" {
+			// A generation with no secret derives every key to "" (see
+			// deriveDomainKey's fail-closed contract). Admitting one would make
+			// verification silently compare against empty keys, so drop it.
+			continue
+		}
+		if g.ID == currentID {
+			c := g
+			current = &c
+			continue
+		}
+		previous = append(previous, g)
+	}
+	if current == nil {
+		return nil
+	}
+	// Most recent previous generation first, so verification tries the
+	// likeliest match before the older ones.
+	sort.Slice(previous, func(i, j int) bool { return previous[i].ID > previous[j].ID })
+
+	ordered := make([]keyGeneration, 0, maxLiveGenerations)
+	ordered = append(ordered, *current)
+	for _, p := range previous {
+		if len(ordered) >= maxLiveGenerations {
+			break
+		}
+		ordered = append(ordered, p)
+	}
+	return &generationSet{Current: current.ID, Generations: ordered}
+}
+
+// legacyGenerationSet wraps a single pre-rotation master as generation 1.
+//
+// This is the state of EVERY hub in the fleet today, and the reason there is no
+// migration step: a hub that has never rotated has exactly one generation, so
+// dual acceptance degenerates to single acceptance and every derived key is
+// byte-identical to what the same master produces now. "Never rotated" and
+// "rotated back down to one generation" are therefore the same state, which
+// means rollback needs no special handling either.
+func legacyGenerationSet(master string) *generationSet {
+	if strings.TrimSpace(master) == "" {
+		return nil
+	}
+	return newGenerationSet(legacyGenerationID, []keyGeneration{
+		{ID: legacyGenerationID, Secret: master},
+	})
+}
+
+// currentGeneration returns the generation that MINTS. Returns (zero, false)
+// for a nil or empty set so minting stays fail-closed: no key configured must
+// mean "cannot mint", never "mint unsigned".
+func (gs *generationSet) currentGeneration() (keyGeneration, bool) {
+	if gs == nil || len(gs.Generations) == 0 {
+		return keyGeneration{}, false
+	}
+	return gs.Generations[0], true
+}
+
+// currentSecret returns the minting master, or "" when there is none. The ""
+// flows into deriveDomainKey, which returns "" for an empty master, so an
+// unconfigured hub fails closed through the existing contract rather than
+// needing a new one at every call site.
+func (gs *generationSet) currentSecret() string {
+	g, ok := gs.currentGeneration()
+	if !ok {
+		return ""
+	}
+	return g.Secret
+}
+
+// acceptableGenerations returns the generations a VERIFIER may consider at
+// time `now`, current first.
+//
+// This is where the finiteness promise is actually kept. A previous generation
+// whose VerifyUntil has passed is EXCLUDED — not warned about, not logged and
+// accepted anyway, but excluded — so the acceptance window closes on a wall
+// clock with no operator action. The current generation has no VerifyUntil and
+// is always included.
+func (gs *generationSet) acceptableGenerations(now time.Time) []keyGeneration {
+	if gs == nil {
+		return nil
+	}
+	out := make([]keyGeneration, 0, len(gs.Generations))
+	for _, g := range gs.Generations {
+		if g.ID == gs.Current {
+			out = append(out, g)
+			continue
+		}
+		if g.VerifyUntil.IsZero() || !now.Before(g.VerifyUntil) {
+			// A previous generation with no expiry is exactly the unbounded
+			// compat lane this design exists to prevent, so treat a missing
+			// expiry as ALREADY EXPIRED rather than as "never expires". A
+			// malformed or hand-edited generations file therefore fails closed.
+			continue
+		}
+		out = append(out, g)
+	}
+	return out
+}
+
+// rotate returns a NEW set with newSecret as the incoming current generation
+// and the outgoing current demoted to verify-only until now+window.
+//
+// Pure: it does not mutate the receiver, so a caller that fails to persist the
+// result has not already changed the hub's in-memory state. Returns nil for an
+// empty secret — rotating TO no key would silently disable minting.
+func (gs *generationSet) rotate(newSecret string, now time.Time, window time.Duration) *generationSet {
+	if strings.TrimSpace(newSecret) == "" {
+		return nil
+	}
+	if window <= 0 {
+		window = defaultVerifyWindow
+	}
+	nextID := legacyGenerationID
+	var carried []keyGeneration
+	if gs != nil {
+		for _, g := range gs.Generations {
+			if g.ID >= nextID {
+				nextID = g.ID + 1
+			}
+		}
+		// Only the OUTGOING CURRENT is carried forward. Older previous
+		// generations are dropped rather than aged out, which is what keeps the
+		// set within maxLiveGenerations and, more importantly, means a second
+		// rotation cannot quietly extend the life of a key from two rotations
+		// ago.
+		if cur, ok := gs.currentGeneration(); ok {
+			cur.VerifyUntil = now.Add(window)
+			carried = append(carried, cur)
+		}
+	}
+	gens := append([]keyGeneration{{ID: nextID, Secret: newSecret, Created: now}}, carried...)
+	return newGenerationSet(nextID, gens)
+}
+
+// Generation markers on minted artifacts.
+//
+// An artifact that can carry a marker lets a verifier SELECT the one generation
+// to check rather than trying each in turn: cheaper, and it makes "which key
+// verified this" observable instead of inferred. The marker is a prefix
+// "g<N>." on the artifact value.
+//
+// Not every artifact can carry one. Cookies and SSO tokens have payload room;
+// a heartbeat bearer is a bare HMAC-derived string presented raw in an
+// Authorization header, and the terminal/invite keys are symmetric values read
+// from env by both Go and Node — none of those has an envelope, and giving one
+// to them would change a contract with already-deployed spokes, making the
+// rotation mechanism itself require the flag day it exists to avoid. Those
+// artifacts use bounded trial verification instead, which maxLiveGenerations
+// keeps to at most two attempts. See v2/docs/design/master-key-rotation.md for
+// the per-artifact table.
+
+// generationMarkerPrefix introduces a generation marker. Chosen as a letter
+// rather than a bare digit so an unmarked legacy value can never be mistaken
+// for a marked one: legacy artifacts begin with a username or a base64 payload,
+// and the parser requires BOTH this prefix and a well-formed integer.
+const generationMarkerPrefix = "g"
+
+// formatGenerationMarker renders the prefix a minted artifact carries.
+func formatGenerationMarker(id int) string {
+	return generationMarkerPrefix + strconv.Itoa(id) + "."
+}
+
+// splitGenerationMarker separates a leading generation marker from the rest of
+// an artifact value.
+//
+// Returns (id, remainder, true) when a well-formed marker is present, and
+// (0, value, false) when it is not — which is the UNMARKED LEGACY case and is
+// explicitly not an error. Every artifact minted before this change lacks a
+// marker, so a verifier must be able to fall back to trying each acceptable
+// generation rather than rejecting it. That fallback is what makes deploying
+// this change itself a non-event.
+//
+// The parse is strict: a value like "gfoo.bar" or "g.bar" or "g-1.bar" is NOT a
+// marker, because treating a malformed marker as a valid one would let a
+// crafted value steer generation selection.
+func splitGenerationMarker(value string) (int, string, bool) {
+	if !strings.HasPrefix(value, generationMarkerPrefix) {
+		return 0, value, false
+	}
+	rest := value[len(generationMarkerPrefix):]
+	dot := strings.Index(rest, ".")
+	if dot <= 0 {
+		return 0, value, false
+	}
+	id, err := strconv.Atoi(rest[:dot])
+	if err != nil || id <= 0 {
+		return 0, value, false
+	}
+	return id, rest[dot+1:], true
+}
+
+// verifyWithGenerations is the shared dual-acceptance driver.
+//
+// It resolves which generations to try — the marked one if the artifact names a
+// generation the set still accepts, otherwise every acceptable generation in
+// current-first order — and calls `attempt` with each generation's secret and
+// the artifact stripped of its marker. It returns the ID of the generation that
+// accepted, so callers can report which key verified rather than merely that
+// something did. That return value is the versioning promise made observable:
+// it is what the readiness surface counts.
+//
+// A marker naming a generation that is NOT acceptable (expired, or unknown)
+// falls through to trying every acceptable generation rather than failing
+// outright. The marker is an optimization hint carried on an unauthenticated
+// value, so it must never be able to make verification FAIL — otherwise anyone
+// could invalidate a valid artifact by editing its prefix. It can only ever
+// make verification cheaper.
+func verifyWithGenerations[T any](
+	gs *generationSet,
+	value string,
+	now time.Time,
+	attempt func(secret, artifact string) (T, bool),
+) (T, int, bool) {
+	var zero T
+	acceptable := gs.acceptableGenerations(now)
+	if len(acceptable) == 0 {
+		return zero, 0, false
+	}
+	markedID, stripped, marked := splitGenerationMarker(value)
+	if marked {
+		for _, g := range acceptable {
+			if g.ID == markedID {
+				out, ok := attempt(g.Secret, stripped)
+				if ok {
+					return out, g.ID, true
+				}
+				// The marker named a live generation and the signature did not
+				// verify under it. Do NOT fall through to the other
+				// generations: the artifact asserted which key signed it, that
+				// key says no, and trying the others would only serve to
+				// re-admit a value whose own claim already failed.
+				return zero, 0, false
+			}
+		}
+		// Marker named a generation we do not accept (expired or unknown). Fall
+		// through and try what we do accept, against the STRIPPED value.
+		value = stripped
+	}
+	for _, g := range acceptable {
+		if out, ok := attempt(g.Secret, value); ok {
+			return out, g.ID, true
+		}
+	}
+	return zero, 0, false
+}

--- a/v2/pkg/hub/hub_generations_test.go
+++ b/v2/pkg/hub/hub_generations_test.go
@@ -1,0 +1,310 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for the master-secret generation mechanism (hub_generations.go).
+//
+// Each test below states the property it pins and, where the property is a
+// SECURITY one, is paired with a positive control — an assertion that the test
+// would actually fail if the behavior regressed. Several of these properties
+// are "X is rejected", which passes trivially against a broken implementation
+// that rejects everything, so the controls prove the accept path works too.
+
+const (
+	genSecretA = "master-generation-A-0123456789abcdef"
+	genSecretB = "master-generation-B-fedcba9876543210"
+)
+
+// TestLegacyGenerationSetIsBehaviorPreserving pins the no-migration promise: a
+// hub that has never rotated derives EXACTLY the keys the single-master code
+// derives today. If this ever fails, deploying the generation mechanism is
+// itself a flag day — the precise outcome it exists to prevent.
+func TestLegacyGenerationSetIsBehaviorPreserving(t *testing.T) {
+	gs := legacyGenerationSet(genSecretA)
+	if gs == nil {
+		t.Fatal("legacy set must exist for a non-empty master")
+	}
+	if gs.Current != legacyGenerationID {
+		t.Errorf("current = %d, want %d", gs.Current, legacyGenerationID)
+	}
+	if got := gs.currentSecret(); got != genSecretA {
+		t.Errorf("current secret does not round-trip the master")
+	}
+	// The derived key must be byte-identical to the pre-generation formula.
+	want := deriveDomainKey(genSecretA, infoImpersonateKey)
+	got := deriveDomainKey(gs.currentSecret(), infoImpersonateKey)
+	if got != want || got == "" {
+		t.Errorf("derived key changed under the generation set: got %q want %q", got, want)
+	}
+	// Fail-closed: no master means no generation set, so nothing can mint.
+	if legacyGenerationSet("") != nil {
+		t.Error("empty master must not produce a generation set")
+	}
+	if legacyGenerationSet("   ") != nil {
+		t.Error("whitespace-only master must not produce a generation set")
+	}
+}
+
+// TestRotateDemotesOutgoingAndMintsWithIncoming is the core rotation contract:
+// after rotating, MINTING uses the new secret while the outgoing one remains
+// acceptable for VERIFY. Without both halves a rotation is a flag day.
+func TestRotateDemotesOutgoingAndMintsWithIncoming(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+	rotated := gs.rotate(genSecretB, now, defaultVerifyWindow)
+	if rotated == nil {
+		t.Fatal("rotate returned nil for a valid secret")
+	}
+
+	// Minting moved to the incoming generation.
+	if rotated.currentSecret() != genSecretB {
+		t.Error("current secret must be the incoming one after rotation")
+	}
+	if rotated.Current != legacyGenerationID+1 {
+		t.Errorf("current id = %d, want %d", rotated.Current, legacyGenerationID+1)
+	}
+
+	// The outgoing generation is still ACCEPTED — this is the property that
+	// makes rotation not a flag day.
+	acceptable := rotated.acceptableGenerations(now)
+	if len(acceptable) != 2 {
+		t.Fatalf("acceptable generations = %d, want 2 (current + outgoing)", len(acceptable))
+	}
+	if acceptable[0].Secret != genSecretB {
+		t.Error("current generation must be tried first")
+	}
+	if acceptable[1].Secret != genSecretA {
+		t.Error("outgoing generation must remain acceptable during the window")
+	}
+
+	// POSITIVE CONTROL. "The outgoing key is accepted" is only meaningful if an
+	// UNRELATED key is not. Otherwise this test would pass against an
+	// implementation that accepts anything.
+	for _, g := range acceptable {
+		if g.Secret == "some-key-that-was-never-a-generation" {
+			t.Fatal("positive control: an unrelated secret must never be acceptable")
+		}
+	}
+
+	// The receiver is untouched — rotate is pure, so a failed persist does not
+	// leave the hub having half-rotated in memory.
+	if gs.currentSecret() != genSecretA {
+		t.Error("rotate must not mutate the receiver")
+	}
+}
+
+// TestPreviousGenerationExpiresOnItsOwn is the FINITENESS property — the one
+// the F1/F2 verify-both lanes lacked, which is why they survived five audits.
+// The old key must stop being accepted on a wall clock with NO operator action.
+func TestPreviousGenerationExpiresOnItsOwn(t *testing.T) {
+	now := time.Now()
+	rotated := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	// Inside the window: two generations accepted.
+	inside := now.Add(defaultVerifyWindow - time.Hour)
+	if n := len(rotated.acceptableGenerations(inside)); n != 2 {
+		t.Fatalf("inside window: acceptable = %d, want 2", n)
+	}
+
+	// Past the window: the previous generation is GONE with nobody retiring it.
+	after := now.Add(defaultVerifyWindow + time.Minute)
+	got := rotated.acceptableGenerations(after)
+	if len(got) != 1 {
+		t.Fatalf("after window: acceptable = %d, want 1 (current only)", len(got))
+	}
+	if got[0].Secret != genSecretB {
+		t.Error("after expiry the surviving generation must be the current one")
+	}
+
+	// POSITIVE CONTROL: the current generation must NOT expire. A test that
+	// only checked "count drops to 1" would also pass if everything expired,
+	// which would break the hub entirely.
+	far := now.Add(100 * 365 * 24 * time.Hour)
+	if n := len(rotated.acceptableGenerations(far)); n != 1 {
+		t.Errorf("current generation must never expire: acceptable = %d, want 1", n)
+	}
+}
+
+// TestPreviousGenerationWithoutExpiryFailsClosed pins that a MISSING expiry is
+// treated as already-expired rather than as never-expires. A hand-edited or
+// malformed generations file must not be able to create the unbounded compat
+// lane this whole design exists to prevent.
+func TestPreviousGenerationWithoutExpiryFailsClosed(t *testing.T) {
+	now := time.Now()
+	gs := newGenerationSet(2, []keyGeneration{
+		{ID: 2, Secret: genSecretB},
+		{ID: 1, Secret: genSecretA}, // no VerifyUntil at all
+	})
+	if gs == nil {
+		t.Fatal("set must build")
+	}
+	acceptable := gs.acceptableGenerations(now)
+	if len(acceptable) != 1 {
+		t.Fatalf("acceptable = %d, want 1 — a previous generation with no expiry must NOT be accepted", len(acceptable))
+	}
+	if acceptable[0].ID != 2 {
+		t.Error("the surviving generation must be the current one")
+	}
+}
+
+// TestGenerationSetCapsLiveGenerations pins the bound that makes trial
+// verification affordable for artifacts that cannot carry a marker (the
+// heartbeat bearer above all).
+func TestGenerationSetCapsLiveGenerations(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+	// Rotate repeatedly; the set must never exceed the cap.
+	for i := 0; i < 5; i++ {
+		gs = gs.rotate("secret-round-"+time.Duration(i).String(), now, defaultVerifyWindow)
+		if gs == nil {
+			t.Fatal("rotate returned nil")
+		}
+		if len(gs.Generations) > maxLiveGenerations {
+			t.Fatalf("round %d: %d live generations, cap is %d", i, len(gs.Generations), maxLiveGenerations)
+		}
+	}
+	// After many rotations the ORIGINAL secret must be long gone, not merely
+	// unexpired — otherwise stacked rotations silently extend an old key's life.
+	for _, g := range gs.acceptableGenerations(now) {
+		if g.Secret == genSecretA {
+			t.Error("a key from several rotations ago must not still be acceptable")
+		}
+	}
+}
+
+// TestGenerationMarkerRoundTripAndStrictParse pins the marker format. The parse
+// must be STRICT: a malformed marker must read as "unmarked legacy", never as a
+// valid generation selector, or a crafted value could steer key selection.
+func TestGenerationMarkerRoundTripAndStrictParse(t *testing.T) {
+	// Round-trip.
+	marked := formatGenerationMarker(7) + "payload.sig"
+	id, rest, ok := splitGenerationMarker(marked)
+	if !ok || id != 7 || rest != "payload.sig" {
+		t.Fatalf("round trip failed: id=%d rest=%q ok=%v", id, rest, ok)
+	}
+
+	// Values that must NOT parse as a marker. Each would otherwise be a way to
+	// influence which key is selected.
+	for _, bad := range []string{
+		"payload.sig",    // unmarked legacy — the common case
+		"gfoo.bar",       // non-numeric
+		"g.bar",          // empty number
+		"g-1.bar",        // negative
+		"g0.bar",         // zero is not a valid generation id
+		"g12",            // no separator
+		"alice.sigvalue", // a real legacy session-shaped value
+		"",               // empty
+	} {
+		if _, _, ok := splitGenerationMarker(bad); ok {
+			t.Errorf("%q must not parse as a generation marker", bad)
+		}
+	}
+
+	// POSITIVE CONTROL: the rejections above are only meaningful if a
+	// well-formed marker still parses. Otherwise a parser that always returned
+	// false would pass every assertion in this test.
+	if _, _, ok := splitGenerationMarker("g1.x"); !ok {
+		t.Error("positive control: a well-formed marker must parse")
+	}
+}
+
+// TestVerifyWithGenerationsSelectsAndFallsBack pins the three paths through the
+// dual-acceptance driver: marked-and-current, marked-and-previous, and
+// unmarked-legacy.
+func TestVerifyWithGenerationsSelectsAndFallsBack(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	// attempt accepts only when the artifact equals the secret it was derived
+	// under — a stand-in for a signature check that is exact and observable.
+	attempt := func(secret, artifact string) (string, bool) {
+		return artifact, artifact == "signed-by-"+secret
+	}
+
+	// 1. Marked with the CURRENT generation.
+	cur, _ := gs.currentGeneration()
+	v1 := formatGenerationMarker(cur.ID) + "signed-by-" + genSecretB
+	if _, gen, ok := verifyWithGenerations(gs, v1, now, attempt); !ok || gen != cur.ID {
+		t.Errorf("current-marked artifact: ok=%v gen=%d, want ok=true gen=%d", ok, gen, cur.ID)
+	}
+
+	// 2. Marked with the PREVIOUS generation — the rotation-window case.
+	v2 := formatGenerationMarker(legacyGenerationID) + "signed-by-" + genSecretA
+	if _, gen, ok := verifyWithGenerations(gs, v2, now, attempt); !ok || gen != legacyGenerationID {
+		t.Errorf("previous-marked artifact: ok=%v gen=%d, want ok=true gen=%d", ok, gen, legacyGenerationID)
+	}
+
+	// 3. UNMARKED legacy artifact signed by the previous generation. Every
+	//    artifact minted before this change looks like this, so it must verify
+	//    by falling back rather than being rejected.
+	if _, gen, ok := verifyWithGenerations(gs, "signed-by-"+genSecretA, now, attempt); !ok || gen != legacyGenerationID {
+		t.Errorf("unmarked legacy artifact: ok=%v gen=%d, want ok=true gen=%d", ok, gen, legacyGenerationID)
+	}
+
+	// 4. POSITIVE CONTROL / negative case: an artifact signed by NO generation
+	//    must be rejected. Without this the three accepts above would pass
+	//    against a driver that accepts everything.
+	if _, _, ok := verifyWithGenerations(gs, "signed-by-some-other-key", now, attempt); ok {
+		t.Error("an artifact signed by no live generation must be rejected")
+	}
+
+	// 5. Once the window closes, the previous generation's artifact stops
+	//    verifying — finiteness, end to end.
+	after := now.Add(defaultVerifyWindow + time.Minute)
+	if _, _, ok := verifyWithGenerations(gs, "signed-by-"+genSecretA, after, attempt); ok {
+		t.Error("a previous-generation artifact must stop verifying after the window")
+	}
+	// ...while the current one still does. (Control for #5: proves the failure
+	// above is expiry, not a broken driver.)
+	if _, _, ok := verifyWithGenerations(gs, "signed-by-"+genSecretB, after, attempt); !ok {
+		t.Error("the current generation must still verify after the previous expires")
+	}
+}
+
+// TestGenerationMarkerCannotForceFailure pins that the marker is an
+// OPTIMIZATION HINT on an unauthenticated value: editing it must never turn a
+// valid artifact into a rejected one via an unknown generation, or anyone could
+// invalidate anyone's cookie by rewriting a prefix.
+func TestGenerationMarkerCannotForceFailure(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+	attempt := func(secret, artifact string) (string, bool) {
+		return artifact, artifact == "signed-by-"+secret
+	}
+	valid := "signed-by-" + genSecretA
+
+	// A marker naming a generation that does not exist must fall through to
+	// trying the generations we DO accept.
+	tampered := formatGenerationMarker(999) + valid
+	if _, _, ok := verifyWithGenerations(gs, tampered, now, attempt); !ok {
+		t.Error("an unknown-generation marker must fall back, not fail the artifact")
+	}
+
+	// POSITIVE CONTROL: falling back must not become "accept anything". A
+	// tampered marker on a BOGUS payload still fails.
+	if _, _, ok := verifyWithGenerations(gs, formatGenerationMarker(999)+"signed-by-nothing", now, attempt); ok {
+		t.Error("fallback must not accept an artifact signed by no generation")
+	}
+}
+
+// TestNilGenerationSetFailsClosed pins that an unconfigured hub cannot mint or
+// verify anything. "No key" must mean "no", never "yes by default".
+func TestNilGenerationSetFailsClosed(t *testing.T) {
+	var gs *generationSet
+	if _, ok := gs.currentGeneration(); ok {
+		t.Error("nil set must have no current generation")
+	}
+	if gs.currentSecret() != "" {
+		t.Error("nil set must yield an empty secret")
+	}
+	if n := len(gs.acceptableGenerations(time.Now())); n != 0 {
+		t.Errorf("nil set acceptable = %d, want 0", n)
+	}
+	attempt := func(string, string) (string, bool) { return "", true } // accepts EVERYTHING
+	if _, _, ok := verifyWithGenerations(gs, "anything", time.Now(), attempt); ok {
+		t.Error("nil set must reject even when the attempt function accepts everything")
+	}
+}

--- a/v2/pkg/hub/impersonate_cookie.go
+++ b/v2/pkg/hub/impersonate_cookie.go
@@ -83,6 +83,61 @@ func impersonateSign(secret, payload string) string {
 	return hubCookieB64.EncodeToString(mac.Sum(nil))
 }
 
+// mintImpersonateCookieValueForGeneration mints an impersonation cookie under
+// the CURRENT generation and stamps it with that generation's marker.
+//
+// This is the pilot adoption of the master-secret rotation mechanism
+// (hub_generations.go), chosen because the impersonation cookie is the
+// lowest-risk verifier on the platform: it is hub-only (no spoke, no Node
+// proxy, no Deployment env), it lives 30 minutes, and it grants nothing — an
+// impersonating admin is read-only, so a failure here degrades to "not
+// impersonating" rather than to any loss of access.
+//
+// The cookie is one of the artifacts that CAN carry a marker: it has payload
+// room and the hub controls both mint and verify. So the verifier can SELECT a
+// generation instead of trial-verifying, and the audit trail records which key
+// was used. Returns "" when there is no minting generation, preserving the
+// fail-closed contract of the underlying mint.
+func mintImpersonateCookieValueForGeneration(gs *generationSet, admin, target string, now time.Time) string {
+	g, ok := gs.currentGeneration()
+	if !ok {
+		return ""
+	}
+	inner := mintImpersonateCookieValue(deriveDomainKey(g.Secret, infoImpersonateKey), admin, target, now)
+	if inner == "" {
+		return ""
+	}
+	return formatGenerationMarker(g.ID) + inner
+}
+
+// verifyImpersonateCookieValueWithGenerations verifies an impersonation cookie
+// against every generation the set still accepts, and reports WHICH one
+// accepted.
+//
+// Dual acceptance is the point: during a rotation a cookie minted under the
+// outgoing generation must keep working until it expires on its own, or every
+// rotation logs the admin out mid-session. The window is finite by
+// construction — acceptableGenerations drops any previous generation past its
+// VerifyUntil — so this cannot become the unbounded verify-both lane that F1/F2
+// took five audits to remove.
+//
+// An UNMARKED cookie (every one minted before this change) is tried against
+// each acceptable generation in turn, so deploying this is a non-event for
+// cookies already in browsers.
+//
+// Returns the accepting generation ID alongside the grant. Callers that do not
+// care may ignore it; it exists so "is anything still using the old key?" is a
+// question the telemetry can answer without reading the code.
+func verifyImpersonateCookieValueWithGenerations(gs *generationSet, value string, now time.Time) (impersonationGrant, int, bool) {
+	if value == "" {
+		return impersonationGrant{}, 0, false
+	}
+	return verifyWithGenerations(gs, value, now,
+		func(secret, artifact string) (impersonationGrant, bool) {
+			return verifyImpersonateCookieValue(deriveDomainKey(secret, infoImpersonateKey), artifact, now)
+		})
+}
+
 // mintImpersonateCookieValue returns a signed impersonation cookie value that
 // records admin viewing target, expiring impersonateTTL from now. It returns ""
 // when no secret is configured or either login is empty — callers must treat

--- a/v2/pkg/hub/impersonate_generation_test.go
+++ b/v2/pkg/hub/impersonate_generation_test.go
@@ -1,0 +1,218 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Dual-generation acceptance for the impersonation cookie — the pilot adoption
+// of hub_generations.go.
+//
+// The impersonation cookie is the lowest-risk verifier on the platform: hub-only
+// (no spoke, no Node proxy, no Deployment env), 30-minute TTL, and it grants
+// nothing — impersonation is read-only. So it exercises the full marker path
+// without any tenant-visible risk.
+
+// TestImpersonationSurvivesRotation is THE test this whole change exists for.
+// Before it, rotating the master invalidated every live impersonation grant at
+// the instant of rotation. After it, a grant minted under the outgoing
+// generation keeps working for its natural lifetime.
+func TestImpersonationSurvivesRotation(t *testing.T) {
+	now := time.Now()
+	before := legacyGenerationSet(genSecretA)
+
+	// A grant minted BEFORE the rotation.
+	cookie := mintImpersonateCookieValueForGeneration(before, hubAdminUsername, "alice", now)
+	if cookie == "" {
+		t.Fatal("mint returned empty for valid inputs")
+	}
+
+	// Rotate the master.
+	after := before.rotate(genSecretB, now, defaultVerifyWindow)
+	if after == nil {
+		t.Fatal("rotate returned nil")
+	}
+
+	// The pre-rotation grant STILL VERIFIES, and reports the generation that
+	// accepted it — so an operator can see the old key is still in use.
+	grant, gen, ok := verifyImpersonateCookieValueWithGenerations(after, cookie, now.Add(time.Minute))
+	if !ok {
+		t.Fatal("a grant minted before rotation must still verify during the window")
+	}
+	if gen != legacyGenerationID {
+		t.Errorf("accepting generation = %d, want %d (the outgoing one)", gen, legacyGenerationID)
+	}
+	if grant.Admin != hubAdminUsername || grant.Target != "alice" {
+		t.Errorf("grant payload corrupted across rotation: %+v", grant)
+	}
+
+	// POSITIVE CONTROL — this is the regression the test guards. Verifying the
+	// SAME cookie against a hub that only knows the NEW generation must FAIL.
+	// Without this assertion the test above would pass against an
+	// implementation that accepts any cookie regardless of key.
+	onlyNew := legacyGenerationSet(genSecretB)
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(onlyNew, cookie, now.Add(time.Minute)); ok {
+		t.Error("positive control: a pre-rotation cookie must NOT verify against the new generation alone")
+	}
+}
+
+// TestImpersonationMintsOnlyWithCurrentGeneration pins the mint half of the
+// contract: after rotation, NEW grants use the NEW key. Dual acceptance is for
+// verification only — if minting also used the old key the rotation would never
+// actually take effect.
+func TestImpersonationMintsOnlyWithCurrentGeneration(t *testing.T) {
+	now := time.Now()
+	rotated := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	cookie := mintImpersonateCookieValueForGeneration(rotated, hubAdminUsername, "bob", now)
+	if cookie == "" {
+		t.Fatal("mint returned empty")
+	}
+
+	// It carries the CURRENT generation's marker.
+	cur, _ := rotated.currentGeneration()
+	id, _, marked := splitGenerationMarker(cookie)
+	if !marked {
+		t.Fatal("a freshly minted cookie must carry a generation marker")
+	}
+	if id != cur.ID {
+		t.Errorf("marker generation = %d, want current %d", id, cur.ID)
+	}
+
+	// It verifies, and does so under the CURRENT generation.
+	_, gen, ok := verifyImpersonateCookieValueWithGenerations(rotated, cookie, now)
+	if !ok || gen != cur.ID {
+		t.Errorf("fresh cookie: ok=%v gen=%d, want ok=true gen=%d", ok, gen, cur.ID)
+	}
+
+	// POSITIVE CONTROL: it must NOT verify against the OLD generation alone —
+	// proving the new key really was used rather than the old one.
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(legacyGenerationSet(genSecretA), cookie, now); ok {
+		t.Error("positive control: a post-rotation cookie must not verify under the outgoing key")
+	}
+}
+
+// TestImpersonationAcceptsUnmarkedLegacyCookie pins that deploying this change
+// is a NON-EVENT for cookies already sitting in browsers. Every impersonation
+// cookie minted before this code shipped is unmarked and signed with the
+// derived impersonate sub-key of the single master.
+func TestImpersonationAcceptsUnmarkedLegacyCookie(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+
+	// Mint EXACTLY the way the pre-generation code did: no marker, signed with
+	// the derived sub-key.
+	legacy := mintImpersonateCookieValue(
+		deriveDomainKey(genSecretA, infoImpersonateKey), hubAdminUsername, "carol", now)
+	if legacy == "" {
+		t.Fatal("legacy mint returned empty")
+	}
+	if _, _, marked := splitGenerationMarker(legacy); marked {
+		t.Fatal("the legacy mint must not produce a marker — the test would not be testing the legacy path")
+	}
+
+	grant, gen, ok := verifyImpersonateCookieValueWithGenerations(gs, legacy, now)
+	if !ok {
+		t.Fatal("an unmarked pre-rotation cookie must still verify")
+	}
+	if gen != legacyGenerationID {
+		t.Errorf("accepting generation = %d, want %d", gen, legacyGenerationID)
+	}
+	if grant.Target != "carol" {
+		t.Errorf("grant target = %q, want carol", grant.Target)
+	}
+}
+
+// TestImpersonationRejectsAfterGenerationExpires pins finiteness at the
+// artifact level: once the outgoing generation's window closes, cookies minted
+// under it stop being accepted — with no operator action.
+func TestImpersonationRejectsAfterGenerationExpires(t *testing.T) {
+	now := time.Now()
+	before := legacyGenerationSet(genSecretA)
+	cookie := mintImpersonateCookieValueForGeneration(before, hubAdminUsername, "dave", now)
+	after := before.rotate(genSecretB, now, defaultVerifyWindow)
+
+	// Note the cookie's own 30-minute TTL would expire long before the 7-day
+	// window, so verify at a time inside the cookie TTL but past the generation
+	// window by minting a fresh legacy-signed cookie at that later moment.
+	late := now.Add(defaultVerifyWindow + time.Minute)
+	lateCookie := formatGenerationMarker(legacyGenerationID) + mintImpersonateCookieValue(
+		deriveDomainKey(genSecretA, infoImpersonateKey), hubAdminUsername, "dave", late)
+
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(after, lateCookie, late); ok {
+		t.Error("a cookie under an EXPIRED generation must be rejected")
+	}
+
+	// POSITIVE CONTROL: the same cookie, verified INSIDE the window, is
+	// accepted. This proves the rejection above is the expiry and not a broken
+	// verifier or a bad cookie.
+	early := now.Add(time.Minute)
+	earlyCookie := formatGenerationMarker(legacyGenerationID) + mintImpersonateCookieValue(
+		deriveDomainKey(genSecretA, infoImpersonateKey), hubAdminUsername, "dave", early)
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(after, earlyCookie, early); !ok {
+		t.Error("positive control: the same cookie inside the window must be accepted")
+	}
+
+	_ = cookie
+}
+
+// TestImpersonationGenerationFailsClosedWithoutKeys pins that a hub with no
+// generation set cannot mint or verify an impersonation grant. Fail-closed here
+// means "cannot impersonate", which is the safe direction.
+func TestImpersonationGenerationFailsClosedWithoutKeys(t *testing.T) {
+	now := time.Now()
+	if v := mintImpersonateCookieValueForGeneration(nil, hubAdminUsername, "eve", now); v != "" {
+		t.Error("mint with no generation set must return empty")
+	}
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(nil, "anything", now); ok {
+		t.Error("verify with no generation set must reject")
+	}
+	// A well-formed cookie from a real generation must not verify against a nil
+	// set either.
+	real := mintImpersonateCookieValueForGeneration(legacyGenerationSet(genSecretA), hubAdminUsername, "eve", now)
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(nil, real, now); ok {
+		t.Error("a valid cookie must not verify against a nil generation set")
+	}
+	// POSITIVE CONTROL: that same cookie DOES verify against its real set, so
+	// the rejection above is about the nil set, not a malformed cookie.
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(legacyGenerationSet(genSecretA), real, now); !ok {
+		t.Error("positive control: the cookie must verify against its own generation set")
+	}
+}
+
+// TestImpersonationTamperStillFailsUnderGenerations pins that dual acceptance
+// did NOT widen what verifies. Adding a second acceptable key must not turn a
+// forged or edited cookie into a valid one — the risk any verify-both lane
+// carries.
+func TestImpersonationTamperStillFailsUnderGenerations(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+	cookie := mintImpersonateCookieValueForGeneration(gs, hubAdminUsername, "frank", now)
+
+	// Edit the payload, keep the signature.
+	tampered := cookie[:len(cookie)-4] + "AAAA"
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(gs, tampered, now); ok {
+		t.Error("a tampered cookie must not verify under ANY generation")
+	}
+
+	// A cookie signed with a key that is no generation at all.
+	forged := formatGenerationMarker(gs.Current) + mintImpersonateCookieValue(
+		"not-a-generation-key", hubAdminUsername, "frank", now)
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(gs, forged, now); ok {
+		t.Error("a cookie signed with a non-generation key must not verify")
+	}
+
+	// Signing with the RAW master rather than the derived impersonate sub-key
+	// must also fail — domain separation is preserved across the change.
+	rawMaster := formatGenerationMarker(gs.Current) + mintImpersonateCookieValue(
+		genSecretB, hubAdminUsername, "frank", now)
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(gs, rawMaster, now); ok {
+		t.Error("a cookie signed with the raw master must not verify — domain separation regressed")
+	}
+
+	// POSITIVE CONTROL: the untampered cookie verifies, so the three rejections
+	// above are about the tampering rather than a verifier that rejects all.
+	if _, _, ok := verifyImpersonateCookieValueWithGenerations(gs, cookie, now); !ok {
+		t.Error("positive control: the untampered cookie must verify")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -604,7 +604,7 @@ func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGran
 	if err != nil || cookie.Value == "" {
 		return impersonationGrant{}, false
 	}
-	grant, ok := verifyImpersonateCookieValue(s.impersonateKey(), cookie.Value, time.Now())
+	grant, _, ok := verifyImpersonateCookieValueWithGenerations(s.keyGenerations, cookie.Value, time.Now())
 	if !ok || !isHubAdmin(grant.Admin) {
 		return impersonationGrant{}, false
 	}
@@ -870,7 +870,7 @@ func (s *HubServer) resolveIdentity(r *http.Request) (effective, realUser string
 	if err != nil || cookie.Value == "" {
 		return realUser, realUser, false
 	}
-	grant, ok := verifyImpersonateCookieValue(s.impersonateKey(), cookie.Value, time.Now())
+	grant, _, ok := verifyImpersonateCookieValueWithGenerations(s.keyGenerations, cookie.Value, time.Now())
 	if !ok {
 		return realUser, realUser, false
 	}
@@ -1292,7 +1292,7 @@ func (s *HubServer) handleImpersonateStart(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, http.StatusNotFound, "user not found")
 		return
 	}
-	value := mintImpersonateCookieValue(s.impersonateKey(), admin, target, time.Now())
+	value := mintImpersonateCookieValueForGeneration(s.keyGenerations, admin, target, time.Now())
 	if value == "" {
 		writeJSONError(w, http.StatusInternalServerError, "cannot start impersonation")
 		return

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -79,8 +79,14 @@ func setPathValue(r *http.Request, key, val string) *http.Request {
 
 func newHandlerHub() *HubServer {
 	return &HubServer{
-		logger:             slog.Default(),
-		hubSecret:          testHubSecret,
+		logger:    slog.Default(),
+		hubSecret: testHubSecret,
+		// Mirror NewHubServer: a real hub ALWAYS has a generation set holding
+		// its master (legacyGenerationSet). Without this the impersonation
+		// verifier — the first adopter of hub_generations.go — sees a nil set
+		// and fails closed, which is correct behavior but not the behavior
+		// these handler tests are exercising.
+		keyGenerations:     legacyGenerationSet(testHubSecret),
 		hubBanners:         make(map[string]*HubBannerEntry),
 		heartbeatSwitchTag: make(map[string]string),
 		heartbeatUpgrade:   make(map[string]string),

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -794,6 +794,13 @@ type HubServer struct {
 	hubGitHash   string
 	hubGitBranch string
 	hubSecret    string
+	// keyGenerations is the ordered set of master generations this hub accepts
+	// (hub_generations.go). Until a rotation happens it holds exactly ONE
+	// generation whose secret IS hubSecret, so every derived key is
+	// byte-identical to the single-master behavior and dual acceptance
+	// degenerates to single acceptance. It is set once in NewHubServer and read
+	// without a lock; a rotation endpoint that replaces it will need one.
+	keyGenerations *generationSet
 	// lastHubUpgradeTrigger debounces the hub self-upgrade rollout restart so the
 	// every-cycle behind-latest check doesn't re-restart while a rollout is still
 	// in flight. See the auto-upgrade block in the SHA-poll loop. It also marks
@@ -1122,13 +1129,16 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		logger.Info("generated hub secret", "path", "/data/saas/hub-secret.key")
 	}
 	s := &HubServer{
-		mux:                     http.NewServeMux(),
-		logger:                  logger,
-		saveCh:                  make(chan struct{}, 1),
-		registryPath:            registryPath,
-		hubGitHash:              gitHash,
-		hubGitBranch:            gitBranch,
-		hubSecret:               secret,
+		mux:          http.NewServeMux(),
+		logger:       logger,
+		saveCh:       make(chan struct{}, 1),
+		registryPath: registryPath,
+		hubGitHash:   gitHash,
+		hubGitBranch: gitBranch,
+		hubSecret:    secret,
+		// One generation, holding the existing master. No migration step and no
+		// behavior change: see legacyGenerationSet.
+		keyGenerations:          legacyGenerationSet(secret),
 		clusters:                loadClusters(logger),
 		heartbeatHealth:         make(map[string]*HeartbeatHealthEntry),
 		heartbeatUpgrade:        make(map[string]string),


### PR DESCRIPTION
## Problem

Rotating the hub master secret is currently **impossible**, and it is the top remaining security item after the 2026-08-13 audit was fully remediated.

Every piece of signing material on the platform is a pure function of ONE value, with no marker recording which master produced it:

```
heartbeat bearer   = HMAC(master, "hive-heartbeat-v1" || 0x00 || hiveID)
session cookie key = HMAC(master, "hive-session-v1")
session Ed25519    = HMAC(master, "hive-session-ed25519-v1")
SSO Ed25519        = HMAC(master, "hive-sso-ed25519-v1")
impersonate key    = HMAC(master, "hive-impersonate-v1")
terminal key       = HMAC(master, "hive-terminal-v1" || 0x00 || hiveID)
invite key         = HMAC(master, "hive-invite-v1"   || 0x00 || hiveID)
```

The `-v1` suffixes version the **domain label**, not the key. Changing the master changes all seven simultaneously, and no verifier can accept both the outgoing and incoming form — so a rotation invalidates every session, 401s every heartbeat, and breaks every SSO handoff across ~66 hosted spokes at once.

## Design

Full write-up: **`v2/docs/design/master-key-rotation.md`**

The hub holds an ordered set of **generations**. Exactly one is **current** (the only one that MINTS); zero or more are **previous**, accepted for VERIFY only, each with an explicit expiry.

### Why not just bump the info labels to `-v2`

Considered and rejected as the primary mechanism. It does not rotate the secret — every `-v2` label is still `HMAC(master, ...)` of the *same* master, so an attacker holding the master re-derives `-v2` keys as easily as `-v1`. Label bumping is a domain-separation tool, not a compromise-recovery tool, and compromise recovery is the reason to rotate. It also requires a code change (so rotation cadence is bounded by release cadence, and cannot be done urgently) and the labels are a contract with `proxy/server.js` and deployed spokes, making a bump fleet-visible in exactly the way an emergency rotation must not be.

### Why this is not the verify-both lane F1/F2 took five audits to remove

Those lanes were verify-both too. What made them a vulnerability was that they were **unversioned and permanent** — nothing named which alternative was legacy, nothing said when it stopped being accepted, so only an audit finding could end them. Both properties are fixed deliberately:

- **Versioned** — a previous generation is a numbered entry whose ID the verifier *returns*, so "is anything still on the old key?" is a countable value, not a code-reading exercise.
- **Finite** — every previous generation carries `VerifyUntil`. The window closes on a wall clock with no operator action. A *missing* expiry is treated as **already expired**, so a hand-edited or malformed generations file fails closed rather than creating the unbounded lane this design exists to prevent.

### Which artifacts can carry a generation marker

**Can** (payload room, hub controls both ends) — verifier *selects* one generation:

| Artifact | Marker |
|---|---|
| Impersonation cookie | prefix `g<N>.` |
| Session cookie (HMAC) | prefix `g<N>.` |
| Session cookie (Ed25519) | payload field |
| SSO handoff token | payload field |

**Cannot** — bare derived strings with no envelope:

| Artifact | Why |
|---|---|
| Heartbeat bearer | The bearer *is* the derived key, presented raw in `Authorization` |
| Terminal / invite key | Symmetric values read from env by both Go and Node |
| SSO / session public keys | Fixed 32-byte Ed25519 form |

These use **bounded trial verification** — at most `maxLiveGenerations = 2` attempts, so worst case is two HMAC computations where there was one. Prefixing the heartbeat bearer was rejected: its format is a contract with deployed Deployments and with `SpokeHeartbeatKey()`'s self-derivation lane, so changing it would make the rotation mechanism itself require a flag day.

### No migration

A hub that has never rotated synthesizes a single generation from the existing `/data/saas/hub-secret.key`. Every derived key stays byte-identical and dual acceptance degenerates to single acceptance, so "never rotated" and "rotated back to one generation" are the same state — rollback needs no special handling either.

### Rotation without re-provisioning

Fleet re-provisioning is ruled out. The existing reconcile lane (`perhive_env_reconcile.go`) already handles this case — its own `perHiveEnvDrift` doc says a var with a different value is drift, "the case a stale hive ID **or a rotated master** produces". Deriving `desiredPerHiveEnv` from the current generation makes the existing rate limiter (3 patches / 15 min) walk the fleet in ~6 hours, one pod roll each. Dual acceptance is what keeps not-yet-patched spokes authenticating during that walk — which is why it is the *prerequisite* for rotation, not an optimization.

### Observability

Readiness gates on the **Deployment-sourced** counts in `PerHiveEnvStatus`, not on heartbeat recency. `AuthRolloutReadiness` drops hives unseen for 24h and cannot distinguish "hive absent" from "never existed", so a paused spoke silently leaves the denominator and the fleet reads ready. `PerHiveEnvSnapshot` reads each Deployment directly — a paused hive still has one, so it still counts and still blocks convergence.

## What landed here

Foundational only:

- `hub_generations.go` — generation type, ordered set, legacy synthesis, marker format, `verifyWithGenerations` driver
- Dual acceptance in **one** verifier: the **impersonation cookie**

The impersonation cookie was chosen as the pilot because it is the lowest-risk verifier on the platform: hub-only (no spoke, no Node proxy, no Deployment env), a 30-minute TTL bounding any mistake, and a read-only grant that already fails closed. It exercises the full marker path without touching anything a tenant depends on. **The other six domains are deliberately untouched.**

## Follow-on PRs, in order

| # | Scope | Size | Fleet-visible |
|---|---|---|---|
| 1 | Session cookie (HMAC + Ed25519) dual acceptance | M | No |
| 2 | Heartbeat bearer bounded trial verification | M | No |
| 3 | `desiredPerHiveEnv` from current generation; per-generation counts | S | No |
| 4 | Admin rotate endpoint + generation-file persistence | S | No |
| 5 | Terminal + invite key dual acceptance | M | **Yes** |
| 6 | SSO/session Ed25519 public key rotation incl. `proxy/server.js` | L | **Yes** |
| 7 | Auto-retire past `VerifyUntil`; alert on a pinned-open generation | S | No |

1–4 are hub-internal and land without any spoke rolling. Only 5 and 6 touch the fleet, both via the rate-limited reconcile lane rather than a re-provision.

## Finding: the empty-master readers

The three sites reading `os.Getenv("HIVE_HUB_SECRET")` directly (`hub_keys.go:314`, `:356`, `:390`) while that var is **unset on the live hub pod** are **not a bug**.

All three are inside `spokeDomainKey`, `SpokeHeartbeatKey`, and `SpokeSSOPublicKey` — **spoke-side** resolvers. The `hive` binary serves both roles but selects at startup: `runHub()` (`v2/cmd/hive/main.go:6943`) is the only caller of `hub.NewHubServer` and is a distinct mode. On a hub pod those functions are never called, so the empty env var is never consulted.

The hub's own material comes from `NewHubServer` (`server.go:1107`), which reads env → falls back to `/data/saas/hub-secret.key` → generates and persists. `provisionMasterSecret()` mirrors that order. Both resolve to the 64-byte file on the live PVC. That `s.hubSecret` is non-empty in production is confirmed by the fleet authenticating at all — `verifyHeartbeatBearer` fails closed on an empty master, so an empty one would 401 all 66 spokes.

Worth keeping in view rather than fixing: the three spoke-side sites bypass `provisionMasterSecret()` and so lack its file fallback. Correct today (a spoke has no hub PVC), but the two resolution orders are similar enough to be mistaken for each other and differ in a way stated at neither site.

## Tests

New — `hub_generations_test.go`, `impersonate_generation_test.go`:

```
TestLegacyGenerationSetIsBehaviorPreserving
TestRotateDemotesOutgoingAndMintsWithIncoming
TestPreviousGenerationExpiresOnItsOwn
TestPreviousGenerationWithoutExpiryFailsClosed
TestGenerationSetCapsLiveGenerations
TestGenerationMarkerRoundTripAndStrictParse
TestVerifyWithGenerationsSelectsAndFallsBack
TestGenerationMarkerCannotForceFailure
TestNilGenerationSetFailsClosed
TestImpersonationSurvivesRotation
TestImpersonationMintsOnlyWithCurrentGeneration
TestImpersonationAcceptsUnmarkedLegacyCookie
TestImpersonationRejectsAfterGenerationExpires
TestImpersonationGenerationFailsClosedWithoutKeys
TestImpersonationTamperStillFailsUnderGenerations
```

Every test asserting "X is rejected" is paired with a **positive control** proving the accept path still works — otherwise it would pass against an implementation that rejects everything.

### Regression replay (three, neutered so it still compiles)

**1 — removed finiteness** (expired previous generations still acceptable):
```
--- FAIL: TestPreviousGenerationExpiresOnItsOwn
--- FAIL: TestPreviousGenerationWithoutExpiryFailsClosed
--- FAIL: TestVerifyWithGenerationsSelectsAndFallsBack
--- FAIL: TestImpersonationRejectsAfterGenerationExpires
```

**2 — removed dual acceptance** (only ever try current):
```
--- FAIL: TestRotateDemotesOutgoingAndMintsWithIncoming
--- FAIL: TestPreviousGenerationExpiresOnItsOwn
--- FAIL: TestVerifyWithGenerationsSelectsAndFallsBack
--- FAIL: TestImpersonationSurvivesRotation
```

**3 — loosened marker parsing** (accept malformed/negative/zero ids):
```
--- FAIL: TestGenerationMarkerRoundTripAndStrictParse
    "gfoo.bar" must not parse as a generation marker
    "g-1.bar"  must not parse as a generation marker
    "g0.bar"   must not parse as a generation marker
```

Restored after each; full `./pkg/hub/` and `./pkg/dashboard/` suites green, `go vet` clean.

### Existing test touched

**`saas_handlers_coverage_test.go`** — `newHandlerHub()` set `hubSecret` but no `keyGenerations`. This is the single-generation assumption showing up: four impersonation tests failed because the verifier saw a nil set and fail-closed. **Inverted rather than relaxed** — the helper now mirrors `NewHubServer` by building `legacyGenerationSet(testHubSecret)`, so tests exercise the same invariant production holds.

Notably the existing `impersonateCookie` helper still mints **unmarked** cookies, so the pre-existing impersonation suite now doubles as a legacy-acceptance regression test at no cost.

No existing test was weakened.
