### PR TITLE
🐛 hub: detect channel-switch completion via reported image ref

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -2013,9 +2013,16 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	hbTarget := s.heartbeatUpgrade[payload.HiveID]
 	s.mu.RUnlock()
 	if switchTag != "" {
-		// Clear once the spoke reports it's on the target branch — its tag is
-		// branchToTag(GitBranch)+"-latest". Otherwise keep instructing.
-		if payload.GitBranch != "" && branchToTag(payload.GitBranch)+"-latest" == switchTag {
+		// Clear once the spoke reports it runs the target tag. The reported
+		// deployment ImageRef is the authoritative signal and works for every
+		// switch shape — "<branch>-latest" AND bare channel tags ("stable"),
+		// whose completion the branch inference below can never detect: a
+		// channel image heartbeats its baked-in branch ("v4"), which maps to
+		// "v4-latest", not "stable", so a completed channel switch would be
+		// re-instructed forever. The branch inference stays as the fallback
+		// for older spokes whose heartbeat omits image_ref.
+		switchDone := payload.ImageRef != "" && imageTagOf(payload.ImageRef) == switchTag
+		if switchDone || (payload.GitBranch != "" && branchToTag(payload.GitBranch)+"-latest" == switchTag) {
 			s.mu.Lock()
 			delete(s.heartbeatSwitchTag, payload.HiveID)
 			for i := range s.registry.Hives {


### PR DESCRIPTION
Third member of the pre-channels-assumption class (#3757 fixed the hub validator, but two more surfaced live tonight when 7 hives were switched v4 → stable):

1. **Spoke-side refusal (no code change possible here):** `SwitchImageSelf` runs the same `validateImageTag` inside the spoke binary. Spokes running pre-#3757 builds refuse the delivered `stable` tag every beat (`self image switch REFUSED: invalid image reference`). Self-resolves once spokes run a post-#3757 build; the currently-stuck fleet is being bridged operationally by patching their deployments to `:stable` directly.

2. **This PR — completion never detected:** the heartbeat switch latch cleared only when `branchToTag(GitBranch)+"-latest"` matched the target — a shape a channel switch can never produce (a `stable` image heartbeats its baked-in branch `v4` → `v4-latest` ≠ `stable`). So even a COMPLETED channel switch was re-instructed forever and the pill stayed "Switching to stable" indefinitely. Fix: clear when the spoke-reported deployment `ImageRef` tag equals the switch target (authoritative, uniform for `-latest` and channel tags); keep the branch inference as fallback for older spokes that omit `image_ref`.

Observed live: hub log loops of `heartbeat: instructing spoke to switch branch image tag=stable` every beat for all 7 switched hives.