### PR TITLE
✨ spoke dashboard: show release channel in the version badge — 'stable (v4)'

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -855,6 +855,10 @@ func main() {
 	}
 	dashboard.SetGitVersion(gitHash, gitShort)
 	dashboard.SetGitBranch(gitBranch)
+	// Channel-delivered spokes ("stable" retag of a v4 build) label their
+	// version badge with the channel; "" outside a cluster or on branch/SHA
+	// tags, in which case the badge stays branch-only.
+	dashboard.SetReleaseChannel(hub.SelfImageReleaseChannel())
 
 	logger := slog.New(logscrub.NewHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	slog.SetDefault(logger)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -292,6 +292,9 @@ var (
 	// cmd/hive). The self-version check compares against the tip of THIS
 	// branch — a spoke running v3 must not be told it is "behind" v2.
 	versionBranch = "unknown"
+	// versionChannel is the release channel the Deployment image tracks, ""
+	// when not channel-delivered (see SetReleaseChannel).
+	versionChannel = ""
 )
 
 // defaultUpstreamBranch is the fallback branch for the self-version check
@@ -307,6 +310,15 @@ func SetGitVersion(hash, short string) {
 // version check and Upgrade affordance compare against the right upstream.
 func SetGitBranch(branch string) {
 	versionBranch = branch
+}
+
+// SetReleaseChannel records the release channel this spoke's Deployment image
+// tracks ("stable"/"candidate"/"edge"), or "" when it tracks a branch tag or
+// SHA pin. Display-only: the navbar badge shows "stable (v4)" instead of the
+// bare built-from branch. The upstream comparison logic is untouched — the
+// binary is still a build of versionBranch.
+func SetReleaseChannel(channel string) {
+	versionChannel = channel
 }
 
 // upstreamBranch returns the branch to compare against for the self-version
@@ -497,6 +509,9 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		"hash":    versionHash,
 		"short":   versionShort,
 		"branch":  upstreamBranch(),
+	}
+	if versionChannel != "" {
+		resp["channel"] = versionChannel
 	}
 	// autoUpgrade tells the dashboard whether the hub manages this spoke's
 	// upgrades. When true the manual spoke Upgrade button is hidden — the hub

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14397,7 +14397,12 @@ function burnAreaChart() {
         // (v2/v3 release, or a personal dev branch like mk). Skip only the
         // unknown placeholder so the pill is always present for real builds.
         if (v.branch && v.branch !== 'unknown') {
-          html += ` <span title="Tracking branch ${escapeHtml(v.branch)}" style="display:inline-block;padding:1px 7px;margin-left:6px;border-radius:999px;font-size:0.62rem;font-weight:600;background:color-mix(in srgb, var(--accent) 16%, transparent);border:1px solid color-mix(in srgb, var(--accent) 40%, transparent);color:var(--accent);vertical-align:middle">${escapeHtml(v.branch)}</span>`;
+          // Channel-delivered spoke: the deployment tracks a release channel
+          // tag, so show "stable (v4)" — the channel is what the operator
+          // chose; the branch is what the channel currently resolves to.
+          const pillText = v.channel ? v.channel + ' (' + v.branch + ')' : v.branch;
+          const pillTitle = v.channel ? 'Tracking release channel ' + v.channel + ' (currently a ' + v.branch + ' build)' : 'Tracking branch ' + v.branch;
+          html += ` <span title="${escapeHtml(pillTitle)}" style="display:inline-block;padding:1px 7px;margin-left:6px;border-radius:999px;font-size:0.62rem;font-weight:600;background:color-mix(in srgb, var(--accent) 16%, transparent);border:1px solid color-mix(in srgb, var(--accent) 40%, transparent);color:var(--accent);vertical-align:middle">${escapeHtml(pillText)}</span>`;
         }
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         if (_upgradeInProgress && v.hash !== _upgradeTargetHash) {

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -427,6 +427,21 @@ var (
 // detection skips the pinned-image signal rather than inventing one. A failed
 // read is cached the same as a successful one so a non-cluster process does
 // not retry an API call it can never satisfy on every heartbeat.
+// SelfImageReleaseChannel returns the release-channel name ("stable",
+// "candidate", "edge") when this pod's own Deployment image tag IS a channel
+// tag, else "". The spoke's dashboard uses it to label its version badge
+// "stable (v4)" instead of the bare baked-in branch — the binary itself has no
+// idea it was delivered via a channel (a stable retag of a v4 build is built
+// from v4), only the deployment's image tag knows. Inherits
+// SelfDeploymentImage's caching and its "" on any failure.
+func SelfImageReleaseChannel() string {
+	tag := imageTagOf(SelfDeploymentImage())
+	if isReleaseChannel(tag) {
+		return tag
+	}
+	return ""
+}
+
 func SelfDeploymentImage() string {
 	selfImageMu.RLock()
 	if selfImageAttempted && time.Since(selfImageFetched) < selfImageCacheTTL {


### PR DESCRIPTION
The hub's My Hives pill shows `stable (v4)` (#3742/#3750), but the spoke's own gateway-dashboard navbar still showed bare `v4` — the channel choice was invisible on the spoke because the binary only knows its baked-in branch.

- `hub.SelfImageReleaseChannel()`: channel name when the pod's own Deployment image tag is a release channel (reuses the cached `SelfDeploymentImage` read; "" off-cluster or on branch/SHA tags)
- wired in `main` next to `SetGitBranch`; `/api/version` gains an optional `channel` field
- SPA badge renders `stable (v4)` with a channel-aware tooltip; unchanged when `channel` is absent

Display-only — upstream comparison / upgrade affordances still key on the built-from branch.