### PR TITLE
🔒 hub: session cookie dual-generation acceptance (rotation PR #1)

### DIFF
--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -147,6 +147,30 @@ type hubCookieClaims struct {
 	// what makes logout mean something for a value that has already left the
 	// browser.
 	SID string `json:"sid"`
+	// G names the master GENERATION whose derived seed signed this cookie
+	// (hub_generations.go). It is a SELECTION HINT, not a claim of authority:
+	// it lets the verifier check one generation instead of trying each, and it
+	// lets telemetry answer "is anything still using the old key?" without
+	// reading the code. It names a key; it is not a key, so carrying it in the
+	// clear costs nothing.
+	//
+	// `omitempty` is load-bearing in BOTH directions:
+	//
+	//   - Omitted on the wire when zero, so a hub that has never rotated mints
+	//     byte-identical cookies to the ones it mints today. Deploying this is
+	//     therefore not observable at the cookie level.
+	//   - Absent on every cookie already sitting in a browser, which is all of
+	//     them. Verification treats a zero G as UNMARKED and falls back to
+	//     trying each acceptable generation, so no live session is logged out.
+	//
+	// The Node proxy (v2/proxy/server.js verifyHubUserCookieV3) parses u/iat/
+	// exp/sid and ignores unrecognized fields, so adding this one is additive
+	// and needs no spoke roll — which is the whole reason the marker lives in
+	// the payload rather than as a "g<N>." prefix on the cookie value. A prefix
+	// would sit in front of the base64url body and break the proxy's parse for
+	// every hosted tenant, which is the flag day this mechanism exists to
+	// avoid.
+	G int `json:"g,omitempty"`
 }
 
 // hubCookieSessionIDBytes is the entropy behind a session ID. Matches
@@ -176,6 +200,25 @@ func newHubCookieSessionID() string {
 // Returns "" on empty inputs, a bad seed, a non-positive ttl, or a CSPRNG
 // failure — fail closed rather than sign junk, matching mintHubUserCookieValueV2.
 func mintHubUserCookieValueV3(seedHex, username string, now time.Time, ttl time.Duration) (value, sid string) {
+	// gen 0 => the G claim is omitted, so this mints exactly the bytes it
+	// minted before generations existed.
+	return mintHubUserCookieValueV3Gen(seedHex, username, now, ttl, 0)
+}
+
+// mintHubUserCookieValueV3Gen is mintHubUserCookieValueV3 with the master
+// GENERATION that produced seedHex stamped into the signed claims.
+//
+// gen <= 0 omits the marker entirely and produces byte-identical output to the
+// pre-generations mint, which is what makes the unmarked-legacy path testable
+// against the real minter rather than against a hand-built fixture.
+//
+// The marker is INSIDE the signature, so it cannot be edited to steer generation
+// selection: a value whose G was altered fails the Ed25519 check before the
+// payload is ever parsed. That is a stronger property than the impersonation
+// cookie's "g<N>." prefix has (the prefix is unauthenticated, which is why
+// verifyWithGenerations treats a bad prefix as a hint that can only make
+// verification cheaper, never make it fail).
+func mintHubUserCookieValueV3Gen(seedHex, username string, now time.Time, ttl time.Duration, gen int) (value, sid string) {
 	if seedHex == "" || username == "" || ttl <= 0 {
 		return "", ""
 	}
@@ -187,12 +230,16 @@ func mintHubUserCookieValueV3(seedHex, username string, now time.Time, ttl time.
 	if sid == "" {
 		return "", ""
 	}
-	payload, err := json.Marshal(hubCookieClaims{
+	claims := hubCookieClaims{
 		U:   username,
 		IAT: now.Unix(),
 		EXP: now.Add(ttl).Unix(),
 		SID: sid,
-	})
+	}
+	if gen > 0 {
+		claims.G = gen
+	}
+	payload, err := json.Marshal(claims)
 	if err != nil {
 		return "", ""
 	}
@@ -200,6 +247,33 @@ func mintHubUserCookieValueV3(seedHex, username string, now time.Time, ttl time.
 	priv := ed25519.NewKeyFromSeed(seed)
 	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(body)))
 	return body + hubCookieV3Marker + sig, sid
+}
+
+// hubCookieClaimedGeneration reads the G marker off a v3 cookie WITHOUT
+// verifying its signature, returning 0 for any other shape or an unmarked
+// cookie.
+//
+// Reading an unauthenticated field is safe here for the same reason
+// hubCookieSessionID's identical shortcut is: the result is used only to pick
+// WHICH generation to verify against, and every candidate then has to pass a
+// real Ed25519 check. The worst a forged G achieves is pointing the verifier at
+// a key that will reject it — and the verifier falls back to trying every
+// acceptable generation in that case, so a forged marker cannot even deny
+// service to a legitimate cookie.
+func hubCookieClaimedGeneration(value string) int {
+	idx := strings.LastIndex(value, hubCookieV3Marker)
+	if idx <= 0 {
+		return 0
+	}
+	raw, err := hubCookieB64.DecodeString(value[:idx])
+	if err != nil {
+		return 0
+	}
+	var claims hubCookieClaims
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return 0
+	}
+	return claims.G
 }
 
 // hubSessionRevokedFunc reports whether a session ID has been revoked. Passed in

--- a/v2/pkg/hub/hub_cookie_generations.go
+++ b/v2/pkg/hub/hub_cookie_generations.go
@@ -1,0 +1,149 @@
+package hub
+
+import (
+	"time"
+)
+
+// Dual-generation acceptance for the HUB SESSION COOKIE — follow-on PR #1 of
+// the master-key rotation design (v2/docs/design/master-key-rotation.md).
+//
+// WHY THE SESSION COOKIE IS THE ONE THAT MATTERS. It is the longest-lived
+// artifact bound to a generation (cookieMaxAgeDays == 7, which is exactly why
+// defaultVerifyWindow is 7 days). Without dual acceptance, the instant an
+// operator rotates the master every browser session on the platform is
+// invalidated at once — the single most visible symptom of the flag day this
+// whole mechanism exists to remove.
+//
+// WHERE THE MARKER LIVES, AND WHY IT DIFFERS PER FORMAT. The session cookie
+// exists in two live shapes and they do NOT have the same amount of room:
+//
+//	v3  base64url(JSON{u,iat,exp,sid[,g]}) .v3. base64url(sig)
+//	v2  <username> .v2. base64url(sig)
+//
+//   - v3 CAN carry a marker, as the `g` claim (hub_cookie.go hubCookieClaims).
+//     It rides INSIDE the signature, so it is tamper-evident, and the Node proxy
+//     ignores JSON fields it does not recognize, so adding it needs no spoke
+//     roll. This is the design doc's "field in payload" row.
+//
+//   - v2 CANNOT. Its username sits in the clear at the head of the value with no
+//     envelope around it, and prefixing the VALUE with "g<N>." — the impersonation
+//     cookie's scheme — is not available to either shape here, because the same
+//     value is parsed independently by v2/proxy/server.js. A prefix would sit in
+//     front of the username (v2) or in front of the base64url body (v3) and break
+//     the proxy's parse for every hosted tenant. Making the rotation mechanism
+//     require a fleet-wide proxy roll would defeat its entire purpose.
+//
+// So v2 gets bounded TRIAL verification instead — the same treatment the
+// heartbeat bearer gets, and bounded by the same maxLiveGenerations == 2. Two
+// Ed25519 verifications worst case, on a path that already does one.
+//
+// MINTING IS ALWAYS CURRENT-ONLY. Dual acceptance is a property of the VERIFIER.
+// If minting also used a previous generation the rotation would never converge,
+// which is the failure mode that makes a compat lane permanent.
+
+// mintHubUserCookieValueV3ForGeneration mints a v3 session cookie under the
+// CURRENT generation and stamps that generation into the signed claims.
+//
+// Returns ("", "") when the set has no minting generation, preserving the
+// fail-closed contract of the underlying mint: no key configured must mean
+// "cannot establish a session", never "emit an unsigned cookie".
+func mintHubUserCookieValueV3ForGeneration(gs *generationSet, username string, now time.Time, ttl time.Duration) (value, sid string) {
+	g, ok := gs.currentGeneration()
+	if !ok {
+		return "", ""
+	}
+	return mintHubUserCookieValueV3Gen(
+		deriveDomainKey(g.Secret, infoSessionEd25519Seed), username, now, ttl, g.ID)
+}
+
+// sessionSeedForGeneration returns the Ed25519 signing SEED for one generation.
+// Private key material — hub-only, never injected into a spoke.
+func sessionSeedForGeneration(g keyGeneration) string {
+	return deriveDomainKey(g.Secret, infoSessionEd25519Seed)
+}
+
+// sessionPublicKeyForGeneration returns the hex Ed25519 PUBLIC key a verifier
+// checks one generation's session cookies against.
+func sessionPublicKeyForGeneration(g keyGeneration) string {
+	return ssoPublicKeyFromSeed(sessionSeedForGeneration(g))
+}
+
+// verifyHubUserCookieAcrossGenerations verifies a session cookie against every
+// generation the set still accepts, and reports WHICH one accepted.
+//
+// Resolution, in order:
+//
+//  1. If the cookie is v3 AND carries a `g` claim naming a generation the set
+//     still accepts, verify against THAT generation only. One Ed25519 check, and
+//     the accepting generation is recorded rather than inferred.
+//  2. Otherwise — unmarked (every cookie in a browser today), v2, or a `g`
+//     naming a generation we no longer accept — try each acceptable generation
+//     in current-first order.
+//
+// Case 2 is what makes deploying this a non-event: every already-issued cookie
+// lacks a marker, and an unmarked cookie must VERIFY against the current
+// generation, not be rejected for want of a field that did not exist when it was
+// minted.
+//
+// A marker naming a generation we do not accept must never make verification
+// FAIL where trial verification would have succeeded. The `g` claim is inside
+// the signature so it cannot be forged on a valid cookie, but it CAN name an
+// expired generation on a cookie that is otherwise fine — in which case falling
+// through is correct, and the expiry still binds because the expired generation
+// is not in the acceptable set to be tried.
+//
+// Every lane below is the existing verifyHubUserCookieEitherAt, called once per
+// generation with that generation's derived material. Nothing new verifies:
+// this adds a second KEY, not a second FORMAT and not a second LANE. In
+// particular the F1 legacy symmetric lane stays deleted — legacySecret is passed
+// as "" on every attempt, so there is no path by which a rotation could
+// resurrect it.
+//
+// Returns (username, generationID, true) on success.
+func verifyHubUserCookieAcrossGenerations(gs *generationSet, value string, now time.Time, revoked hubSessionRevokedFunc) (string, int, bool) {
+	if value == "" {
+		return "", 0, false
+	}
+	acceptable := gs.acceptableGenerations(now)
+	if len(acceptable) == 0 {
+		return "", 0, false
+	}
+
+	attempt := func(g keyGeneration) (string, bool) {
+		// legacySecret is deliberately "" — see AUDIT F1 in
+		// verifyHubUserCookieEitherAt. The lane is gone and must stay gone; a
+		// rotation adds generations, never lanes.
+		return verifyHubUserCookieEitherAt(sessionPublicKeyForGeneration(g), "", value, now, revoked)
+	}
+
+	if claimed := hubCookieClaimedGeneration(value); claimed > 0 {
+		for _, g := range acceptable {
+			if g.ID != claimed {
+				continue
+			}
+			if u, ok := attempt(g); ok {
+				return u, g.ID, true
+			}
+			// The cookie NAMED this generation and this generation's key says
+			// no. Do not fall through: the marker is inside the signature, so a
+			// cookie that carries it and fails under it is not a cookie some
+			// other generation signed — it is forged, tampered, expired, or
+			// revoked. Trying the others could only re-admit a value whose own
+			// signed claim already failed.
+			return "", 0, false
+		}
+		// Claimed a generation we no longer accept (expired or unknown). Fall
+		// through to trial verification: the marker is an optimization, and an
+		// artifact must never be rejected merely for naming a key we retired.
+		// If it really was signed by that retired key, every remaining attempt
+		// fails anyway — which IS the finiteness guarantee, enforced by the key
+		// rather than by the marker.
+	}
+
+	for _, g := range acceptable {
+		if u, ok := attempt(g); ok {
+			return u, g.ID, true
+		}
+	}
+	return "", 0, false
+}

--- a/v2/pkg/hub/hub_cookie_generations_test.go
+++ b/v2/pkg/hub/hub_cookie_generations_test.go
@@ -1,0 +1,360 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Dual-generation acceptance for the HUB SESSION COOKIE — follow-on PR #1 of
+// the master-key rotation design.
+//
+// The session cookie is the artifact that makes rotation visible to users: it
+// is the longest-lived thing bound to a generation, so without dual acceptance
+// a rotation logs every browser out at the instant it happens. These tests pin
+// the four properties the design demands — accepted under current, accepted
+// under an unexpired previous, REJECTED under an expired previous, and unmarked
+// legacy cookies still accepted — each with a positive control so that a
+// verifier which rejected everything could not pass.
+
+// sessionSeedFor is the derived Ed25519 session seed for a raw master, i.e.
+// exactly what the pre-generations code signed with.
+func sessionSeedFor(master string) string {
+	return deriveDomainKey(master, infoSessionEd25519Seed)
+}
+
+// TestSessionCookieSurvivesRotation is THE test this change exists for. A
+// cookie minted before a rotation must keep working for its natural lifetime
+// rather than dying at the instant the master changes.
+func TestSessionCookieSurvivesRotation(t *testing.T) {
+	now := time.Now()
+	before := legacyGenerationSet(genSecretA)
+
+	cookie, sid := mintHubUserCookieValueV3ForGeneration(before, "alice", now, time.Hour)
+	if cookie == "" || sid == "" {
+		t.Fatal("mint returned empty for valid inputs")
+	}
+
+	after := before.rotate(genSecretB, now, defaultVerifyWindow)
+	if after == nil {
+		t.Fatal("rotate returned nil")
+	}
+
+	user, gen, ok := verifyHubUserCookieAcrossGenerations(after, cookie, now.Add(time.Minute), nil)
+	if !ok {
+		t.Fatal("a session minted before rotation must still verify during the window")
+	}
+	if user != "alice" {
+		t.Errorf("verified user = %q, want alice", user)
+	}
+	if gen != legacyGenerationID {
+		t.Errorf("accepting generation = %d, want %d (the outgoing one)", gen, legacyGenerationID)
+	}
+
+	// POSITIVE CONTROL. The same cookie against a hub that knows ONLY the new
+	// generation must FAIL. Without this, an implementation that accepted any
+	// cookie regardless of key would pass the assertion above.
+	onlyNew := legacyGenerationSet(genSecretB)
+	if u, _, ok := verifyHubUserCookieAcrossGenerations(onlyNew, cookie, now.Add(time.Minute), nil); ok {
+		t.Errorf("positive control: a pre-rotation cookie verified as %q against the new generation alone", u)
+	}
+}
+
+// TestSessionCookieAcceptedUnderCurrentGeneration is the base case: a freshly
+// minted cookie verifies, under the CURRENT generation, and carries that
+// generation's marker inside its signed claims.
+func TestSessionCookieAcceptedUnderCurrentGeneration(t *testing.T) {
+	now := time.Now()
+	rotated := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+	cur, _ := rotated.currentGeneration()
+
+	cookie, _ := mintHubUserCookieValueV3ForGeneration(rotated, "bob", now, time.Hour)
+	if cookie == "" {
+		t.Fatal("mint returned empty")
+	}
+
+	if got := hubCookieClaimedGeneration(cookie); got != cur.ID {
+		t.Errorf("claimed generation = %d, want current %d", got, cur.ID)
+	}
+
+	user, gen, ok := verifyHubUserCookieAcrossGenerations(rotated, cookie, now, nil)
+	if !ok || user != "bob" || gen != cur.ID {
+		t.Errorf("fresh cookie: user=%q gen=%d ok=%v; want bob/%d/true", user, gen, ok, cur.ID)
+	}
+
+	// POSITIVE CONTROL for the mint half of the contract: minting is
+	// current-ONLY, so this must NOT verify under the outgoing key alone. If it
+	// did, the rotation would never actually take effect.
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(legacyGenerationSet(genSecretA), cookie, now, nil); ok {
+		t.Error("positive control: a post-rotation cookie must not verify under the outgoing key")
+	}
+}
+
+// TestSessionCookieRejectedAfterGenerationExpires pins FINITENESS — the single
+// property that keeps dual acceptance from rotting into the permanent compat
+// lane F1/F2 took five audits to remove. Past verify_until the old key stops
+// being accepted with no operator action.
+func TestSessionCookieRejectedAfterGenerationExpires(t *testing.T) {
+	now := time.Now()
+	before := legacyGenerationSet(genSecretA)
+	after := before.rotate(genSecretB, now, defaultVerifyWindow)
+
+	// Mint under the OUTGOING generation at a moment past its verify window, so
+	// the cookie's own signed expiry is not what rejects it — the generation
+	// expiry is.
+	late := now.Add(defaultVerifyWindow + time.Minute)
+	lateCookie, _ := mintHubUserCookieValueV3Gen(
+		sessionSeedFor(genSecretA), "dave", late, time.Hour, legacyGenerationID)
+	if lateCookie == "" {
+		t.Fatal("could not mint the late cookie")
+	}
+
+	if u, _, ok := verifyHubUserCookieAcrossGenerations(after, lateCookie, late, nil); ok {
+		t.Errorf("a cookie under an EXPIRED generation was accepted as %q", u)
+	}
+
+	// POSITIVE CONTROL. The same construction verified INSIDE the window is
+	// accepted, proving the rejection above is the generation expiry and not a
+	// broken verifier or a malformed cookie.
+	early := now.Add(time.Minute)
+	earlyCookie, _ := mintHubUserCookieValueV3Gen(
+		sessionSeedFor(genSecretA), "dave", early, time.Hour, legacyGenerationID)
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(after, earlyCookie, early, nil); !ok {
+		t.Error("positive control: the same cookie inside the window must be accepted")
+	}
+}
+
+// TestSessionCookieAcceptsUnmarkedLegacyV3 pins that deploying this is a
+// NON-EVENT for cookies already in browsers. Every session cookie live today is
+// v3 with NO `g` claim, and it must verify against the current generation
+// rather than be rejected for lacking a field that did not exist when it was
+// minted.
+func TestSessionCookieAcceptsUnmarkedLegacyV3(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+
+	// Mint EXACTLY the way production did before this change: the plain
+	// three-argument minter, no generation involved.
+	legacy, sid := mintHubUserCookieValueV3(sessionSeedFor(genSecretA), "carol", now, time.Hour)
+	if legacy == "" || sid == "" {
+		t.Fatal("legacy mint returned empty")
+	}
+	if got := hubCookieClaimedGeneration(legacy); got != 0 {
+		t.Fatalf("the legacy mint carried generation %d — the test would not be testing the unmarked path", got)
+	}
+
+	user, gen, ok := verifyHubUserCookieAcrossGenerations(gs, legacy, now, nil)
+	if !ok {
+		t.Fatal("an UNMARKED pre-rotation session cookie must still verify")
+	}
+	if user != "carol" {
+		t.Errorf("verified user = %q, want carol", user)
+	}
+	if gen != legacyGenerationID {
+		t.Errorf("accepting generation = %d, want %d", gen, legacyGenerationID)
+	}
+
+	// And it survives a rotation too — the unmarked cookies in browsers at the
+	// moment an operator rotates are precisely the population at risk.
+	after := gs.rotate(genSecretB, now, defaultVerifyWindow)
+	if u, g2, ok := verifyHubUserCookieAcrossGenerations(after, legacy, now.Add(time.Minute), nil); !ok || u != "carol" {
+		t.Errorf("unmarked cookie across rotation: user=%q gen=%d ok=%v; want carol/true", u, g2, ok)
+	}
+}
+
+// TestSessionCookieAcceptsUnmarkedLegacyV2 covers the OTHER live shape. A v2
+// cookie has no payload to put a marker in, so it can only ever be verified by
+// bounded trial across generations — this pins that the trial lane exists and
+// is itself bounded by the generation expiry.
+func TestSessionCookieAcceptsUnmarkedLegacyV2(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+
+	v2 := mintHubUserCookieValueV2(sessionSeedFor(genSecretA), "erin")
+	if v2 == "" {
+		t.Fatal("v2 mint returned empty")
+	}
+	if !hubCookieIsV2(v2) {
+		t.Fatal("precondition: minted value is not v2")
+	}
+
+	if u, gen, ok := verifyHubUserCookieAcrossGenerations(gs, v2, now, nil); !ok || u != "erin" || gen != legacyGenerationID {
+		t.Errorf("v2 under current generation: user=%q gen=%d ok=%v; want erin/%d/true", u, gen, ok, legacyGenerationID)
+	}
+
+	// Survives rotation (trial verification finds the previous generation)...
+	after := gs.rotate(genSecretB, now, defaultVerifyWindow)
+	if u, _, ok := verifyHubUserCookieAcrossGenerations(after, v2, now.Add(time.Minute), nil); !ok || u != "erin" {
+		t.Errorf("v2 across rotation: user=%q ok=%v; want erin/true", u, ok)
+	}
+
+	// ...and stops being accepted once that generation expires. A v2 cookie
+	// cannot carry a marker, so this is the ONLY thing that bounds it.
+	late := now.Add(defaultVerifyWindow + time.Minute)
+	if u, _, ok := verifyHubUserCookieAcrossGenerations(after, v2, late, nil); ok {
+		t.Errorf("a v2 cookie under an EXPIRED generation was accepted as %q", u)
+	}
+}
+
+// TestSessionCookieGenerationsPreserveRevocation pins that adding generations
+// did not route around F10 revocation. A revoked session must stay revoked
+// under EVERY generation — otherwise a rotation would silently un-revoke every
+// logged-out session, which is worse than the bug F10 fixed.
+func TestSessionCookieGenerationsPreserveRevocation(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	cookie, sid := mintHubUserCookieValueV3ForGeneration(gs, "frank", now, time.Hour)
+	if cookie == "" || sid == "" {
+		t.Fatal("mint returned empty")
+	}
+
+	revoked := func(s string) bool { return s == sid }
+	if u, _, ok := verifyHubUserCookieAcrossGenerations(gs, cookie, now, revoked); ok {
+		t.Errorf("a REVOKED session verified as %q under generations", u)
+	}
+
+	// Also revoked when it is the PREVIOUS generation doing the accepting: the
+	// pre-rotation cookie is the one an attacker would replay across a
+	// rotation hoping the new code forgot to check.
+	old, oldSID := mintHubUserCookieValueV3ForGeneration(legacyGenerationSet(genSecretA), "frank", now, time.Hour)
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(gs, old, now, func(s string) bool { return s == oldSID }); ok {
+		t.Error("a revoked PRE-ROTATION session verified under the previous generation")
+	}
+
+	// POSITIVE CONTROL: with nothing revoked, both cookies verify — so the two
+	// rejections above are revocation and not a verifier that rejects all.
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(gs, cookie, now, nil); !ok {
+		t.Error("positive control: the current-generation cookie must verify when not revoked")
+	}
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(gs, old, now, nil); !ok {
+		t.Error("positive control: the previous-generation cookie must verify when not revoked")
+	}
+}
+
+// TestSessionCookieGenerationsDoNotWidenAcceptance is the risk any verify-both
+// lane carries: adding a second acceptable key must not turn a forged or edited
+// cookie into a valid one, and must not resurrect the deleted F1 symmetric lane.
+func TestSessionCookieGenerationsDoNotWidenAcceptance(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	cookie, _ := mintHubUserCookieValueV3ForGeneration(gs, "grace", now, time.Hour)
+
+	// Edited payload, original signature.
+	tampered := cookie[:len(cookie)-4] + "AAAA"
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(gs, tampered, now, nil); ok {
+		t.Error("a tampered cookie must not verify under ANY generation")
+	}
+
+	// AUDIT F1 must stay closed. A cookie minted with the SYMMETRIC session
+	// sub-key — the value provisioned byte-identically into every spoke — must
+	// not verify, under any generation. If it does, a rotation has re-opened a
+	// Critical finding that took four audits to close.
+	for _, master := range []string{genSecretA, genSecretB} {
+		forged := mintHubUserCookieValue(deriveDomainKey(master, infoSessionKey), hubAdminUsername)
+		if u, _, ok := verifyHubUserCookieAcrossGenerations(gs, forged, now, nil); ok {
+			t.Errorf("F1 REGRESSION: a spoke-forgeable symmetric cookie verified as %q", u)
+		}
+	}
+
+	// Signed with the RAW master rather than the derived session seed — domain
+	// separation must survive the change.
+	rawSeed := genSecretB
+	if v := mintHubUserCookieValueV2(rawSeed, "grace"); v != "" {
+		if _, _, ok := verifyHubUserCookieAcrossGenerations(gs, v, now, nil); ok {
+			t.Error("a cookie signed with the raw master must not verify — domain separation regressed")
+		}
+	}
+
+	// A cookie signed by a key that is NO generation at all, but which CLAIMS
+	// the current generation. The marker is a hint, never an authorization.
+	cur, _ := gs.currentGeneration()
+	alien, _ := mintHubUserCookieValueV3Gen(
+		sessionSeedFor("some-master-that-is-not-a-generation"), "grace", now, time.Hour, cur.ID)
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(gs, alien, now, nil); ok {
+		t.Error("a cookie signed by a non-generation key must not verify however it is marked")
+	}
+
+	// POSITIVE CONTROL: the untampered cookie verifies, so the rejections above
+	// are about the forgeries rather than a verifier that rejects everything.
+	if u, _, ok := verifyHubUserCookieAcrossGenerations(gs, cookie, now, nil); !ok || u != "grace" {
+		t.Errorf("positive control: the untampered cookie must verify; got %q ok=%v", u, ok)
+	}
+}
+
+// TestSessionCookieStaleMarkerFallsThrough pins that the `g` claim can only
+// ever make verification CHEAPER, never make it fail. A cookie naming a
+// generation the hub no longer accepts must still be tried against the ones it
+// does — otherwise retiring a generation would reject cookies that a live key
+// can perfectly well verify.
+func TestSessionCookieStaleMarkerFallsThrough(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+
+	// Signed by the CURRENT generation's seed but marked with a generation ID
+	// that does not exist in the set.
+	const unknownGeneration = 99
+	cookie, _ := mintHubUserCookieValueV3Gen(
+		sessionSeedFor(genSecretA), "heidi", now, time.Hour, unknownGeneration)
+	if cookie == "" {
+		t.Fatal("mint returned empty")
+	}
+	if got := hubCookieClaimedGeneration(cookie); got != unknownGeneration {
+		t.Fatalf("claimed generation = %d, want %d", got, unknownGeneration)
+	}
+
+	u, gen, ok := verifyHubUserCookieAcrossGenerations(gs, cookie, now, nil)
+	if !ok || u != "heidi" {
+		t.Errorf("a cookie with an unknown marker but a valid signature must verify; got %q ok=%v", u, ok)
+	}
+	if gen != legacyGenerationID {
+		t.Errorf("accepting generation = %d, want %d", gen, legacyGenerationID)
+	}
+}
+
+// TestSessionCookieGenerationsFailClosed pins that a hub with no usable
+// generation set cannot mint or verify a session. Fail-closed here means
+// "cannot establish a session", which is the safe direction.
+func TestSessionCookieGenerationsFailClosed(t *testing.T) {
+	now := time.Now()
+
+	if v, sid := mintHubUserCookieValueV3ForGeneration(nil, "alice", now, time.Hour); v != "" || sid != "" {
+		t.Error("mint with no generation set must return empty")
+	}
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(nil, "anything", now, nil); ok {
+		t.Error("verify with no generation set must reject")
+	}
+
+	real, _ := mintHubUserCookieValueV3ForGeneration(legacyGenerationSet(genSecretA), "alice", now, time.Hour)
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(nil, real, now, nil); ok {
+		t.Error("a valid cookie must not verify against a nil generation set")
+	}
+	// POSITIVE CONTROL: the same cookie verifies against its real set.
+	if _, _, ok := verifyHubUserCookieAcrossGenerations(legacyGenerationSet(genSecretA), real, now, nil); !ok {
+		t.Error("positive control: the cookie must verify against its own generation set")
+	}
+}
+
+// TestSessionCookieUnrotatedHubIsByteIdentical pins the no-migration promise at
+// the wire level: on a hub that has never rotated, the generation-aware minter
+// stamps g=1 and the resulting cookie is still verifiable by the plain
+// single-key verifier the spokes and the Node proxy run. The `g` claim is
+// additive, not a format change.
+func TestSessionCookieUnrotatedHubIsByteIdentical(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+
+	cookie, _ := mintHubUserCookieValueV3ForGeneration(gs, "ivan", now, time.Hour)
+	if cookie == "" {
+		t.Fatal("mint returned empty")
+	}
+
+	// The SPOKE-side verifier — which knows nothing about generations and only
+	// has the one public key — must still accept it. This is the assertion that
+	// says no spoke roll is required.
+	pub := ssoPublicKeyFromSeed(sessionSeedFor(genSecretA))
+	if u, ok := verifyHubUserCookieEitherAt(pub, "", cookie, now, nil); !ok || u != "ivan" {
+		t.Errorf("a generation-marked cookie must verify with the plain single-key verifier "+
+			"(this is what every spoke's Node proxy does); got %q ok=%v", u, ok)
+	}
+}

--- a/v2/pkg/hub/hub_session_revocation.go
+++ b/v2/pkg/hub/hub_session_revocation.go
@@ -406,17 +406,34 @@ func (s *HubServer) hubSessionRevokedLookup(now time.Time) hubSessionRevokedFunc
 	return func(sid string) bool { return s.revokedSessions.isRevoked(sid, now) }
 }
 
-// verifyHubUserCookie is the hub-side entry point: it accepts v3, v2 or legacy
-// cookies and, for v3, additionally enforces signed expiry AND revocation.
+// verifyHubUserCookie is the hub-side entry point: it accepts v3 or v2 cookies
+// and, for v3, additionally enforces signed expiry AND revocation.
 //
 // Spokes deliberately get less: their proxy enforces the signature and the
 // signed expiry, but has no revocation store, so a revoked session can still
 // reach a spoke until its expiry. Closing that needs the spoke to ask the hub,
 // which is a network dependency on the terminal path and out of scope here.
+//
+// ROTATION (master-key-rotation.md, follow-on PR #1): the cookie is checked
+// against every master GENERATION the hub still accepts, not just the current
+// one. Without this, rotating the master logs every user out at the instant of
+// rotation — the session cookie is the longest-lived artifact bound to a
+// generation, which is why defaultVerifyWindow matches cookieMaxAgeDays.
+//
+// On a hub that has never rotated the set holds exactly one generation whose
+// secret IS s.hubSecret, so this is byte-identical to the single-master call it
+// replaces. keyGenerations is nil only in hand-built test servers; the fallback
+// below keeps those on the old path rather than failing them closed, which
+// would be an authentication change disguised as a nil check.
 func (s *HubServer) verifyHubUserCookie(value string) (string, bool) {
 	if s == nil {
 		return "", false
 	}
 	now := time.Now()
-	return verifyHubUserCookieEitherAt(s.sessionPublicKey(), s.sessionKey(), value, now, s.hubSessionRevokedLookup(now))
+	revoked := s.hubSessionRevokedLookup(now)
+	if s.keyGenerations != nil {
+		u, _, ok := verifyHubUserCookieAcrossGenerations(s.keyGenerations, value, now, revoked)
+		return u, ok
+	}
+	return verifyHubUserCookieEitherAt(s.sessionPublicKey(), s.sessionKey(), value, now, revoked)
 }

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -712,8 +712,24 @@ func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (log
 // until its expiry. Closing that requires the spoke to ask the hub on the
 // terminal path; it is tracked separately and called out in hub_session_revocation.go.
 func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
-	cookieValue, _ := mintHubUserCookieValueV3(
-		s.sessionSigningSeed(), canonicalID, time.Now(), cookieSessionTTL)
+	// ROTATION (master-key-rotation.md, follow-on PR #1): mint under the CURRENT
+	// generation and stamp its ID into the signed claims, so the verifier can
+	// select one key instead of trying each and so telemetry can see which key
+	// a live session is on. Minting is current-ONLY — dual acceptance is a
+	// property of the verifier alone, and a minter that also used a previous
+	// generation would mean a rotation never converged.
+	//
+	// On a hub that has never rotated this is the same seed and the same bytes
+	// as before, minus a `g:1` claim the Node proxy ignores. keyGenerations is
+	// nil only in hand-built test servers, which stay on the unmarked mint.
+	var cookieValue string
+	if s.keyGenerations != nil {
+		cookieValue, _ = mintHubUserCookieValueV3ForGeneration(
+			s.keyGenerations, canonicalID, time.Now(), cookieSessionTTL)
+	} else {
+		cookieValue, _ = mintHubUserCookieValueV3(
+			s.sessionSigningSeed(), canonicalID, time.Now(), cookieSessionTTL)
+	}
 	if cookieValue == "" {
 		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", canonicalID)
 		http.Error(w, "session unavailable", http.StatusInternalServerError)


### PR DESCRIPTION
Follow-on PR **#1** of [`v2/docs/design/master-key-rotation.md`](https://github.com/kubestellar/hive/blob/v4/v2/docs/design/master-key-rotation.md). Hub-internal verify-path change only — **no spoke rolls, nothing fleet-visible**.

## Why the session cookie

It is the artifact that makes a master rotation visible to users: the longest-lived thing bound to a generation (`cookieMaxAgeDays` is 7, which is exactly why `defaultVerifyWindow` is 7 days). Without dual acceptance, the instant an operator rotates the master every browser session on the platform dies at once — the single most visible symptom of the flag day this mechanism exists to remove.

## What changed

Verification tries every generation the hub still accepts, current first. **Minting stays current-ONLY** — a minter that also used a previous generation would mean a rotation never converged, which is the failure mode that makes a compat lane permanent.

- `hubCookieClaims` gains `G int json:"g,omitempty"` — the generation marker.
- `mintHubUserCookieValueV3Gen` / `mintHubUserCookieValueV3ForGeneration` mint under the current generation and stamp it.
- `verifyHubUserCookieAcrossGenerations` selects by marker when present, else trial-verifies.
- Wired at both production call sites: `HubServer.verifyHubUserCookie` and `mintSessionCookies`.

## Where the marker lives, and why it is not a prefix

The design's table says "field in payload" for the Ed25519 session cookie, and the reason is load-bearing. The same cookie value is parsed **independently by `v2/proxy/server.js`** on every spoke. A `g<N>.` prefix on the VALUE — the impersonation cookie's scheme — would sit in front of the base64url body (v3) or in front of the username (v2) and break the proxy's parse for every hosted tenant. Making the rotation mechanism require a fleet-wide proxy roll defeats its entire purpose.

Inside the payload it is strictly better: the marker rides **inside the signature**, so it is tamper-evident (unlike the impersonation cookie's unauthenticated prefix), and the proxy's `verifyHubUserCookieV3` checks `u`/`sid`/`iat`/`exp` and ignores fields it does not recognize — so the field is additive and needs no spoke roll. `TestSessionCookieUnrotatedHubIsByteIdentical` pins that a generation-marked cookie still verifies with the plain single-key verifier every spoke runs.

**v2 cookies have no payload room at all** (username in the clear at the head), so they get bounded trial verification instead — capped by `maxLiveGenerations == 2`, same as the heartbeat bearer in PR #2.

## Backward compatibility

`g` is `omitempty`, and **every session cookie in a browser today lacks it**. An unmarked cookie is tried against each acceptable generation rather than rejected, so deploying this is a non-event. A marker naming a generation the hub no longer accepts falls THROUGH to trial verification — the marker can only ever make verification cheaper, never make it fail. On an un-rotated hub the set holds one generation whose secret IS `hubSecret`, so this is byte-identical to the single-master path minus a `g:1` claim.

`keyGenerations` is nil only in hand-built test servers; those keep the old path rather than failing closed, so this is not an authentication change disguised as a nil check.

## Audit F1 stays closed

Every per-generation attempt passes `legacySecret` as `""`, so there is no path by which adding a generation could resurrect the deleted symmetric lane. `TestSessionCookieGenerationsDoNotWidenAcceptance` asserts a cookie minted with `deriveDomainKey(master, infoSessionKey)` — the value provisioned byte-identically into every spoke — is rejected under **both** generations.

## Finiteness

Unchanged and still enforced by `acceptableGenerations`: a previous generation past its `VerifyUntil`, or carrying a zero `VerifyUntil` as a hand-edited file would, is excluded. This cannot rot into the permanent compat lane F1/F2 were.

## Tests

Every test carries a positive control, so a verifier that rejected everything could not pass.

| Test | Property |
|---|---|
| `TestSessionCookieSurvivesRotation` | accepted under an unexpired **previous** generation |
| `TestSessionCookieAcceptedUnderCurrentGeneration` | accepted under **current**; mint is current-only |
| `TestSessionCookieRejectedAfterGenerationExpires` | **rejected** under an expired previous generation |
| `TestSessionCookieAcceptsUnmarkedLegacyV3` | unmarked legacy cookie still verifies, incl. across a rotation |
| `TestSessionCookieAcceptsUnmarkedLegacyV2` | v2 trial lane works and is bounded by the same expiry |
| `TestSessionCookieGenerationsPreserveRevocation` | F10 revocation holds under **every** generation |
| `TestSessionCookieGenerationsDoNotWidenAcceptance` | tamper/forgery/**F1** rejected under every generation |
| `TestSessionCookieStaleMarkerFallsThrough` | a stale marker cannot deny service to a valid cookie |
| `TestSessionCookieGenerationsFailClosed` | nil/empty set cannot mint or verify |
| `TestSessionCookieUnrotatedHubIsByteIdentical` | **no spoke roll needed** — plain verifier still accepts |

## Regression replay

Neutered `verifyHubUserCookieAcrossGenerations` to try only `acceptable[:1]` (current generation only) on both the marked and trial paths. Still compiles (`BUILD OK`); five tests fail, and the four that legitimately do not depend on dual acceptance still pass:

```
=== RUN   TestSessionCookieSurvivesRotation
    hub_cookie_generations_test.go:44: a session minted before rotation must still verify during the window
--- FAIL: TestSessionCookieSurvivesRotation (0.00s)
=== RUN   TestSessionCookieAcceptedUnderCurrentGeneration
--- PASS: TestSessionCookieAcceptedUnderCurrentGeneration (0.00s)
=== RUN   TestSessionCookieRejectedAfterGenerationExpires
    hub_cookie_generations_test.go:122: positive control: the same cookie inside the window must be accepted
--- FAIL: TestSessionCookieRejectedAfterGenerationExpires (0.00s)
=== RUN   TestSessionCookieAcceptsUnmarkedLegacyV3
    hub_cookie_generations_test.go:160: unmarked cookie across rotation: user="" gen=0 ok=false; want carol/true
--- FAIL: TestSessionCookieAcceptsUnmarkedLegacyV3 (0.00s)
=== RUN   TestSessionCookieAcceptsUnmarkedLegacyV2
    hub_cookie_generations_test.go:187: v2 across rotation: user="" ok=false; want erin/true
--- FAIL: TestSessionCookieAcceptsUnmarkedLegacyV2 (0.00s)
=== RUN   TestSessionCookieGenerationsPreserveRevocation
    hub_cookie_generations_test.go:230: positive control: the previous-generation cookie must verify when not revoked
--- FAIL: TestSessionCookieGenerationsPreserveRevocation (0.00s)
=== RUN   TestSessionCookieGenerationsDoNotWidenAcceptance
--- PASS: TestSessionCookieGenerationsDoNotWidenAcceptance (0.00s)
=== RUN   TestSessionCookieStaleMarkerFallsThrough
--- PASS: TestSessionCookieStaleMarkerFallsThrough (0.00s)
=== RUN   TestSessionCookieGenerationsFailClosed
--- PASS: TestSessionCookieGenerationsFailClosed (0.00s)
=== RUN   TestSessionCookieUnrotatedHubIsByteIdentical
--- PASS: TestSessionCookieUnrotatedHubIsByteIdentical (0.00s)
FAIL
FAIL	github.com/kubestellar/hive/v2/pkg/hub	1.094s
```

Restored, re-ran, green: `ok github.com/kubestellar/hive/v2/pkg/hub 4.873s`. Full `go test ./pkg/hub/` also green (`ok ... 173.399s`).

## Existing tests touched

**None.** The full `pkg/hub` suite passes unmodified — no existing test encoded a single-generation assumption for the session cookie, because `mintHubUserCookieValueV3` kept its original signature and mints unmarked (`gen 0` omits the claim), so every existing caller's expectations hold byte-for-byte.