### PR TITLE
🐛 hub: fix per-hive env reconcile selecting zero hives

### DIFF
--- a/v2/pkg/hub/perhive_env_reconcile.go
+++ b/v2/pkg/hub/perhive_env_reconcile.go
@@ -252,6 +252,56 @@ func perHiveEnvPatchAllowed(patchedThisCycle int) bool {
 	return patchedThisCycle < perHiveEnvMaxPatchesPerCycle
 }
 
+// perHiveEnvSweepEligible reports whether a hive with this lifecycle status
+// should be examined by the sweep. Extracted as a named predicate — the same
+// shape as perHiveEnvPatchAllowed — so the selection rule is a single testable
+// decision the sweep and its test share, rather than an inline comparison a
+// test could only re-implement (and therefore keep passing after the sweep's
+// own check broke).
+//
+// WHY THIS EXISTS. The original guard was `h.Status != "running"`, copied from
+// reconcileNetAdmin. It selected NOTHING: across the live 66-hive registry the
+// status distribution is 30 "available", 28 "", 8 "assigned" — zero "running".
+// The two code paths that do write "running" (the provision watcher in
+// saas_provision.go, and the stale-"error" clear on heartbeat in server.go)
+// only fire from the transient "provisioning"/"error" states, so a hive in
+// steady state never reaches or holds it. The sweep therefore `continue`d on
+// every hive of every cycle and had never patched a spoke; the fleet's key
+// posture was still held in place by the out-of-band `kubectl patch` this lane
+// exists to replace, and the four known-drifted spokes never converged.
+//
+// WHAT IT SHOULD HAVE EXPRESSED. Not "is running" but "is deployed" — does
+// this hive plausibly have a hive Deployment to reconcile? The sibling sweeps
+// over the same listSaaSHives() (triggerAutoUpgrades, sweepOrphanedUpgrades,
+// sweepStuckAssignments) apply NO status filter at all and gate instead on the
+// resources they actually need. This predicate follows that convention, only
+// naming the one status that is genuinely premature.
+//
+//   - "" (28 live) — the common steady state; a provisioned hive that has
+//     simply never had a status written. Must be swept: two of the four
+//     drifted spokes sit here.
+//   - "available" (30 live) — an unclaimed pre-provisioned placeholder. It is
+//     genuinely deployed, its Deployment is live, and it must carry correct
+//     per-hive keys BEFORE it is claimed — a placeholder that is assigned to a
+//     user while running on master-derived fallbacks hands that user a spoke
+//     with fleet-shared keys, exactly what N1/N3 removed.
+//   - "assigned" (8 live) — claimed and deployed. Obviously swept.
+//   - "running" — kept so the pre-existing intent still selects, not because
+//     anything reaches it.
+//   - "error" — SWEPT. The status is frequently stale (only a heartbeat clears
+//     it), the Deployment usually still exists, and an unconverged key is a
+//     plausible CAUSE of the error rather than a reason to leave it drifted.
+//
+// Only "provisioning" is excluded: the namespace and Deployment are still
+// being applied, so a read would fail anyway and the provisioning template
+// renders all five vars correctly at creation. This is a cheap-cycle
+// optimisation, not a safety gate — the sweep already handles a missing
+// Deployment safely (a failed `kubectl get` logs Debug and continues WITHOUT
+// recording an observation, so an unread hive can never count as converged).
+func perHiveEnvSweepEligible(status string) bool {
+	return strings.TrimSpace(status) != "provisioning"
+}
+
 // perHiveEnvObservation is one hive's live posture, recorded by the sweep from
 // its OWN Deployment read. See perHiveEnvSnapshot for why this is not sourced
 // from heartbeat recency.
@@ -313,6 +363,15 @@ type PerHiveEnvStatus struct {
 	// none is missing a var. Fails CLOSED on zero observations: "no evidence"
 	// must never read as "safe to proceed".
 	PerHiveEnvConverged bool `json:"per_hive_env_converged"`
+	// ConsideredHives is how many hives the LAST sweep's status filter
+	// admitted, and SkippedByStatus how many it rejected. These make the
+	// sweep's own selection auditable: ConsideredHives == 0 on a non-empty
+	// fleet means the sweep is patching nobody regardless of how healthy the
+	// counts above look. That is precisely the state this lane shipped in —
+	// the filter matched no hive, so ObservedHives stayed 0 and the surface
+	// was indistinguishable from "nothing to do".
+	ConsideredHives int `json:"considered_hives"`
+	SkippedByStatus int `json:"skipped_by_status"`
 }
 
 // PerHiveEnvSnapshot reports fleet convergence for the five per-hive security
@@ -342,6 +401,8 @@ func (s *HubServer) PerHiveEnvSnapshot() PerHiveEnvStatus {
 	}
 	s.perHiveEnvMu.RLock()
 	defer s.perHiveEnvMu.RUnlock()
+	out.ConsideredHives = s.perHiveEnvConsidered
+	out.SkippedByStatus = s.perHiveEnvSkippedByStatus
 	for id, obs := range s.perHiveEnvSeen {
 		out.ObservedHives++
 		if len(obs.MissingVars) > 0 {
@@ -386,11 +447,21 @@ func (s *HubServer) reconcilePerHiveEnv() {
 	live := make(map[string]bool, len(hives))
 	patched := 0
 	deferredByRateLimit := 0
+	// Selection accounting, published to the readiness surface. A sweep that
+	// selects NOBODY is the exact failure this lane shipped with and nothing
+	// made it visible: every counter downstream of the filter stayed at zero,
+	// which is indistinguishable from a converged fleet. Recording the
+	// considered/skipped split makes "the filter matches nothing" readable
+	// instead of silent.
+	consideredHives := 0
+	skippedByStatus := 0
 
 	for _, h := range hives {
-		if h.Status != "running" {
+		if !perHiveEnvSweepEligible(h.Status) {
+			skippedByStatus++
 			continue
 		}
+		consideredHives++
 		cluster := s.clusterForHive(&h)
 		if cluster == nil {
 			continue
@@ -501,7 +572,18 @@ func (s *HubServer) reconcilePerHiveEnv() {
 			delete(s.perHiveEnvSeen, id)
 		}
 	}
+	s.perHiveEnvConsidered = consideredHives
+	s.perHiveEnvSkippedByStatus = skippedByStatus
 	s.perHiveEnvMu.Unlock()
+
+	// A sweep that admitted no hives at all is a BUG signal, not a quiet
+	// no-op: the registry is never legitimately empty on a hub that hosts
+	// spokes. Log it at Warn so the condition that made this lane dead code
+	// for its whole production life cannot recur silently.
+	if consideredHives == 0 && len(hives) > 0 {
+		s.logger.Warn("per-hive env reconcile: status filter selected NO hives — sweep is a no-op, key drift will not be repaired",
+			"hives_in_registry", len(hives), "skipped_by_status", skippedByStatus)
+	}
 
 	if deferredByRateLimit > 0 {
 		s.logger.Info("per-hive env reconcile: rate limit reached, remaining hives deferred to next cycle",

--- a/v2/pkg/hub/perhive_env_reconcile_test.go
+++ b/v2/pkg/hub/perhive_env_reconcile_test.go
@@ -524,3 +524,155 @@ func hasString(hay []string, needle string) bool {
 	}
 	return false
 }
+
+// realRegistryStatuses are the hive lifecycle statuses that actually occur,
+// with the LIVE distribution measured across all 66 /data/saas/hives/*/meta.json
+// records on the production hub at the time this test was written:
+//
+//	30 "available"   28 ""   8 "assigned"   0 "running"
+//
+// The zero is the whole point. The sweep originally guarded on
+// `h.Status != "running"`, so it selected no hive on any cycle and had never
+// patched a spoke in production. These fixtures are stated as real data, not
+// invented values, so that a future change to the status vocabulary that
+// invalidates them is a test failure rather than a silent regression.
+var realRegistryStatuses = []struct {
+	status string
+	live   int
+	want   bool
+	why    string
+}{
+	{"", 28, true, "the common steady state: provisioned, deployed, no status ever written"},
+	{"available", 30, true, "unclaimed placeholder; deployed, and must hold correct keys BEFORE it is claimed"},
+	{"assigned", 8, true, "claimed and deployed"},
+	{"running", 0, true, "never observed live, but the pre-existing intent must still select"},
+	{"error", 0, true, "status is often stale and the Deployment usually still exists; drift may be the CAUSE"},
+	{"provisioning", 0, false, "namespace/Deployment still being applied; the template renders all five vars at creation"},
+}
+
+// TestPerHiveEnvSweepEligibleOverRealStatuses pins the sweep's hive-selection
+// predicate against the REAL status vocabulary. This is the test layer that was
+// missing: the original suite exercised desiredPerHiveEnv, perHiveEnvDrift,
+// perHiveEnvPatchJSON and the rate limiter directly, but nothing covered the
+// filter that decides which hives reach any of them — so a filter matching
+// NOTHING left every one of those tests green.
+func TestPerHiveEnvSweepEligibleOverRealStatuses(t *testing.T) {
+	for _, tc := range realRegistryStatuses {
+		if got := perHiveEnvSweepEligible(tc.status); got != tc.want {
+			t.Errorf("perHiveEnvSweepEligible(%q) = %v, want %v — %s", tc.status, got, tc.want, tc.why)
+		}
+	}
+}
+
+// TestPerHiveEnvSweepSelectsTheLiveFleet replays the predicate over a fixture
+// with the exact live status distribution and asserts the sweep would examine
+// the whole 66-hive fleet.
+//
+// POSITIVE CONTROL, BOTH DIRECTIONS. The bug being fixed is "selects nothing",
+// so a test that can only fail when the predicate becomes too permissive is
+// insufficient — and the converse is equally true. This asserts a exact
+// selected count, which is the only assertion that fails in BOTH directions:
+//
+//   - Neuter the predicate to `return false` (the shipped bug, and the
+//     `!= "running"` guard is behaviourally identical against this fixture):
+//     selected becomes 0, and the count assertion fails.
+//   - Neuter it to `return true` (select everything unconditionally):
+//     selected becomes 66, "provisioning" is no longer excluded, and both the
+//     count assertion and the explicit skipped-bucket assertion fail.
+//
+// Neither direction can be satisfied by a predicate that ignores its argument.
+func TestPerHiveEnvSweepSelectsTheLiveFleet(t *testing.T) {
+	// The live registry: 66 hives, none "running".
+	type hive struct{ id, status string }
+	var fleet []hive
+	for _, tc := range realRegistryStatuses {
+		for i := 0; i < tc.live; i++ {
+			fleet = append(fleet, hive{id: "hosted-" + tc.status + itoa(i), status: tc.status})
+		}
+	}
+	// Add one hive in each status that has no live instances today, so the
+	// predicate is exercised over the full vocabulary rather than only the
+	// three statuses that happen to be populated right now.
+	for _, tc := range realRegistryStatuses {
+		if tc.live == 0 {
+			fleet = append(fleet, hive{id: "hosted-synth-" + tc.status, status: tc.status})
+		}
+	}
+
+	const liveFleetSize = 66 // 30 available + 28 "" + 8 assigned
+	if got := len(fleet) - 3; got != liveFleetSize {
+		t.Fatalf("fixture models %d live hives, want %d — update the measured distribution", got, liveFleetSize)
+	}
+
+	var selected, skipped int
+	var selectedProvisioning int
+	for _, h := range fleet {
+		if !perHiveEnvSweepEligible(h.status) {
+			skipped++
+			continue
+		}
+		selected++
+		if h.status == "provisioning" {
+			selectedProvisioning++
+		}
+	}
+
+	// Direction 1 — the shipped bug. A predicate that selects nobody (or that
+	// keys off "running", which no live hive has) drives this to 0.
+	if selected == 0 {
+		t.Fatal("sweep selected NO hives from a 66-hive fleet — this is the production bug: " +
+			"the lane runs every cycle and patches nothing, and drifted spokes never converge")
+	}
+	// The 66 live hives + the synthetic "running" and "error" rows are all
+	// eligible; only the synthetic "provisioning" row is not.
+	const wantSelected = liveFleetSize + 2
+	if selected != wantSelected {
+		t.Errorf("selected %d hives, want %d", selected, wantSelected)
+	}
+	// Direction 2 — over-selection. `return true` makes this 0 and trips here.
+	if skipped != 1 {
+		t.Errorf("skipped %d hives, want exactly 1 (the provisioning row) — "+
+			"a predicate that selects everything unconditionally skips 0", skipped)
+	}
+	if selectedProvisioning != 0 {
+		t.Error("a hive still provisioning was selected; its Deployment may not exist yet")
+	}
+
+	// The four spokes measured as drifted on the live fleet sit in "" and
+	// "available". If either status were excluded, the spokes this lane exists
+	// to repair would still never converge. Assert that explicitly rather than
+	// relying on the aggregate count.
+	for _, s := range []string{"", "available"} {
+		if !perHiveEnvSweepEligible(s) {
+			t.Errorf("status %q is not selected, but known-drifted production spokes carry it", s)
+		}
+	}
+}
+
+// TestPerHiveEnvSweepEligibleRejectsTheOldGuard is the regression replay,
+// pinned as a permanent test. It reconstructs the exact predicate that shipped
+// and asserts it selects nothing over the real distribution — so if anyone
+// reintroduces a "running"-based filter, the reasoning is already written down
+// next to the failure.
+func TestPerHiveEnvSweepEligibleRejectsTheOldGuard(t *testing.T) {
+	oldGuard := func(status string) bool { return status == "running" }
+
+	var oldSelected, newSelected int
+	for _, tc := range realRegistryStatuses {
+		if oldGuard(tc.status) {
+			oldSelected += tc.live
+		}
+		if perHiveEnvSweepEligible(tc.status) {
+			newSelected += tc.live
+		}
+	}
+	if oldSelected != 0 {
+		t.Fatalf("fixture no longer reproduces the bug: old guard selected %d hives, expected 0", oldSelected)
+	}
+	if newSelected == 0 {
+		t.Fatal("fixed predicate ALSO selects nothing — the bug is not fixed")
+	}
+	if newSelected != 66 {
+		t.Errorf("fixed predicate selects %d of 66 live hives, want all 66", newSelected)
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -902,7 +902,15 @@ type HubServer struct {
 	// the long note on PerHiveEnvSnapshot) so a paused spoke cannot drop out of
 	// the denominator and make the fleet read converged while it is not.
 	perHiveEnvSeen map[string]perHiveEnvObservation
-	perHiveEnvMu   sync.RWMutex
+	// perHiveEnvConsidered / perHiveEnvSkippedByStatus record the LAST sweep's
+	// hive-selection split: how many hives the status filter admitted versus
+	// rejected. Published on the readiness surface so "the sweep is selecting
+	// nobody" is visible rather than silent — the failure this lane shipped
+	// with, where every downstream counter sat at zero and read exactly like a
+	// converged fleet. Guarded by perHiveEnvMu with perHiveEnvSeen.
+	perHiveEnvConsidered      int
+	perHiveEnvSkippedByStatus int
+	perHiveEnvMu              sync.RWMutex
 	// reporterSeen tracks which spoke instance (payload.Reporter, the pod
 	// name) last reported as each hive, to catch two instances alternating
 	// under one hive_id. Guarded by reporterMu, not s.mu — it is touched on


### PR DESCRIPTION
The per-hive security env reconcile lane (`v2/pkg/hub/perhive_env_reconcile.go`, merged as `736de935`) has **never patched a single spoke in production**. Its first filter is:

```go
if h.Status != "running" { continue }
```

**No hive in the live registry holds that status.** Across all 66 `/data/saas/hives/*/meta.json` records on the hub PVC the distribution is exactly:

```
30 "status": "available"
28 "status": ""
 8 "status": "assigned"
```

Zero `"running"`. The sweep `continue`s on every hive of every cycle — dead code in production.

`"running"` *is* written in two places (`saas_provision.go:2246` provision watcher, `server.go:1788` stale-`"error"` clear on heartbeat), but both only fire out of the transient `"provisioning"`/`"error"` states, so a steady-state hive never reaches or holds it.

### Impact

The fleet's key posture is still held in place by the out-of-band `kubectl patch` this lane exists to replace. Measured live on `hive-oke`: 22 hosted deployments, 18 converged at 5/5, and these four still drifted —

| namespace | vars present |
|---|---|
| `hive-hosted-hosted-available-oke-02-placeholder-7zus` | 0/5 |
| `hive-hosted-hosted-daviddiaz0317-visual-hive--1jos` | 0/5 |
| `hive-hosted-hosted-projectbluefin-knuckle-gjvq` | 0/5 |
| `hive-hosted-hosted-kubestellar-console-4vkt` | 2/5 |

Two of the four sit in status `""` and two in `"available"` — both excluded by the old guard. The 61 converged spokes were converged by the manual patch, not by this lane.

### The predicate

Replaced with a named `perHiveEnvSweepEligible()` that excludes only `"provisioning"`.

The guard was copied from `reconcileNetAdmin`, but the sweeps it claims to mirror do not filter on status at all: `triggerAutoUpgrades`, `sweepOrphanedUpgrades` and `sweepStuckAssignments` all iterate the same `listSaaSHives()` and gate on the resources they actually need. This follows that established convention while naming the one status that is genuinely premature.

- `""` / `"available"` / `"assigned"` — all genuinely deployed, all swept. `"available"` placeholders deliberately included: a placeholder claimed while running on master-derived fallbacks hands its new owner a spoke with fleet-shared keys, exactly what N1/N3 removed.
- `"error"` — swept. The status is often stale (only a heartbeat clears it), the Deployment usually still exists, and unconverged keys are a plausible *cause* of the error.
- `"provisioning"` — excluded. A cheap-cycle optimisation, not a safety gate: the sweep already handles a missing Deployment safely (a failed `kubectl get` logs Debug and `continue`s **without** recording an observation, so an unread hive can never count as converged).

### Fail-safes — all untouched

- `want == nil` empty-value refusal
- `clusterRecentlyUnreachable` skip
- `len(drift) == 0` converged branch (no fleet-wide restart storm)
- `perHiveEnvPatchAllowed` — still **3** patches/cycle, not raised

### Tests

Nothing previously covered the selection filter — the existing suite exercises `desiredPerHiveEnv`, `perHiveEnvDrift`, `perHiveEnvPatchJSON` and the rate limiter directly, which is why a filter matching *no hive* left every test green. This is the repo's recurring "passes for the wrong reason" pattern.

Three new tests, driven by the real measured status distribution:

- `TestPerHiveEnvSweepEligibleOverRealStatuses`
- `TestPerHiveEnvSweepSelectsTheLiveFleet`
- `TestPerHiveEnvSweepEligibleRejectsTheOldGuard`

**Positive controls in both directions.** The bug is "selects nothing", so a test that can only fail on over-selection is insufficient. Verified by regression replay:

Predicate reverted to `status == "running"` (the shipped bug):

```
--- FAIL: TestPerHiveEnvSweepEligibleOverRealStatuses (0.00s)
    perHiveEnvSweepEligible("") = false, want true
    perHiveEnvSweepEligible("available") = false, want true
    perHiveEnvSweepEligible("assigned") = false, want true
    perHiveEnvSweepEligible("error") = false, want true
--- FAIL: TestPerHiveEnvSweepSelectsTheLiveFleet (0.00s)
    selected 1 hives, want 68
    skipped 68 hives, want exactly 1 (the provisioning row)
    status "" is not selected, but known-drifted production spokes carry it
    status "available" is not selected, but known-drifted production spokes carry it
--- FAIL: TestPerHiveEnvSweepEligibleRejectsTheOldGuard (0.00s)
    fixed predicate ALSO selects nothing — the bug is not fixed
FAIL
```

Predicate neutered to `return true` (selects everything):

```
--- FAIL: TestPerHiveEnvSweepEligibleOverRealStatuses (0.00s)
    perHiveEnvSweepEligible("provisioning") = true, want false
--- FAIL: TestPerHiveEnvSweepSelectsTheLiveFleet (0.00s)
    selected 69 hives, want 68
    skipped 0 hives, want exactly 1 (the provisioning row)
    a hive still provisioning was selected; its Deployment may not exist yet
FAIL
```

Fix restored — all three pass.

### Observability

`PerHiveEnvStatus` now carries `considered_hives` / `skipped_by_status`, and the sweep logs a `Warn` when it admits zero hives from a non-empty registry. `ConsideredHives == 0` on a non-empty fleet is now readable on `GET /api/saas/admin/auth-rollout` — previously every counter downstream of the filter sat at zero, indistinguishable from a converged fleet. This is what would have caught the bug.

### Notes

- Diff kept minimal and surgical (predicate + counters) to avoid conflicting with the concurrent rotation follow-ons on `sec/rotation-perhive-generation` and `sec/rotation-admin-endpoint`. No restructuring of `desiredPerHiveEnv`.
- `reconcileNetAdmin` (`netadmin_reconcile.go:140`) carries the **same `!= "running"` guard** and is therefore also selecting zero hives. Left untouched here to keep this diff scoped — worth a follow-up.
- Diagnosis used read-only kubectl. No cluster writes. No secret values printed or logged (the lane logs var names only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)