### PR TITLE
🔐 hub: per-hive env derives from the CURRENT master generation

### DIFF
--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -160,9 +160,11 @@ func (s *HubServer) sessionPublicKey() string {
 }
 
 // provisionSessionPublicKey is the provisioning-time mirror of
-// sessionPublicKey, resolved against provisionMasterSecret().
+// sessionPublicKey, resolved against the CURRENT generation's secret
+// (provisionCurrentSecret). Before any rotation exists that is byte-identical
+// to provisionMasterSecret().
 func provisionSessionPublicKey() string {
-	return ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSessionEd25519Seed))
+	return ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSessionEd25519Seed))
 }
 
 // provisionTerminalKey returns the PER-HIVE terminal signing key injected into a
@@ -179,7 +181,7 @@ func provisionSessionPublicKey() string {
 // code on either side — TerminalSigningKey() and the proxy's mirror already
 // prefer HIVE_TERMINAL_KEY; provisioning simply never set it.
 func provisionTerminalKey(hiveID string) string {
-	return derivePerHiveKey(provisionMasterSecret(), infoTerminalKey, hiveID)
+	return derivePerHiveKey(provisionCurrentSecret(), infoTerminalKey, hiveID)
 }
 
 // provisionHeartbeatKey returns the PER-HIVE heartbeat bearer injected into a
@@ -193,7 +195,7 @@ func provisionTerminalKey(hiveID string) string {
 // handleHeartbeat trusted body-supplied hive_id and three key-delivery lanes
 // became IDOR.
 func provisionHeartbeatKey(hiveID string) string {
-	return derivePerHiveKey(provisionMasterSecret(), infoHeartbeatKey, hiveID)
+	return derivePerHiveKey(provisionCurrentSecret(), infoHeartbeatKey, hiveID)
 }
 
 // provisionInviteKey returns the PER-HIVE contributor-invite signing key injected
@@ -209,7 +211,7 @@ func provisionHeartbeatKey(hiveID string) string {
 // lane was the one place a spoke still needed the master to function. With this
 // injected it does not.
 func provisionInviteKey(hiveID string) string {
-	return derivePerHiveKey(provisionMasterSecret(), infoInviteKey, hiveID)
+	return derivePerHiveKey(provisionCurrentSecret(), infoInviteKey, hiveID)
 }
 
 // heartbeatKeyFor returns the per-hive heartbeat bearer the hub EXPECTS from
@@ -412,4 +414,59 @@ func provisionMasterSecret() string {
 		return strings.TrimSpace(string(data))
 	}
 	return ""
+}
+
+// provisionGenerationSet resolves the generation set that provision-time and
+// reconcile-time derivation share.
+//
+// WHY THIS EXISTS AS ONE FUNCTION. saas_provision.go's template data map and
+// perhive_env_reconcile.go's desiredPerHiveEnv must derive the five per-hive
+// env vars byte-identically — desiredPerHiveEnv's own doc comment says so, and
+// the consequence of divergence is not subtle: the sweep would see "drift" on
+// every freshly provisioned hive, patch it, and roll its pod every cycle
+// forever. Making them both resolve their master through THIS function means a
+// rotation cannot move one side without the other.
+//
+// TODAY THIS IS EXACTLY legacyGenerationSet(provisionMasterSecret()). There is
+// no persisted generations file yet and no endpoint that can create a second
+// generation (that is follow-on PR #4), so currentSecret() is always the same
+// string provisionMasterSecret() returns and every derived value is
+// byte-identical to what this code produced before generations existed. This
+// change is a READ-PATH change in effect: it re-expresses where the master
+// comes from without changing which master it is.
+//
+// Returns nil for an empty master, and currentSecret() on a nil set returns ""
+// — so the fail-closed contract every caller already relies on (deriveDomainKey
+// and derivePerHiveKey both return "" for an empty master) is preserved through
+// the nil case rather than needing a new one.
+func provisionGenerationSet() *generationSet {
+	if gs := provisionGenerationsOverride; gs != nil {
+		return gs
+	}
+	return legacyGenerationSet(provisionMasterSecret())
+}
+
+// provisionGenerationsOverride replaces the resolved generation set.
+//
+// It exists so a test can drive the ROTATED case, which is otherwise
+// unreachable: there is no persisted generations file and no endpoint that can
+// create a second generation until follow-on PR #4, so without this seam
+// "derives from the current generation" and "derives from the raw master" are
+// indistinguishable and no test could tell them apart. That is precisely the
+// kind of test-that-passes-for-the-wrong-reason this seam prevents.
+//
+// nil in production, set only via withProvisionGenerations in tests. Read
+// without a lock because it is only ever written before the code under test
+// runs, from that test's own goroutine — the same discipline as
+// HubServer.keyGenerations, which is set once in NewHubServer.
+var provisionGenerationsOverride *generationSet
+
+// provisionCurrentSecret is the MINTING master at provision/reconcile time: the
+// secret of the current generation. Every spoke-bound derivation goes through
+// this rather than provisionMasterSecret() directly, so that after a rotation
+// newly provisioned and newly reconciled spokes both receive material from the
+// new current generation while the hub's dual acceptance keeps the not-yet-
+// converged spokes authenticating against the demoted previous one.
+func provisionCurrentSecret() string {
+	return provisionGenerationSet().currentSecret()
 }

--- a/v2/pkg/hub/perhive_env_generation_test.go
+++ b/v2/pkg/hub/perhive_env_generation_test.go
@@ -1,0 +1,512 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for follow-on PR #3: the per-hive env reconcile derives from the
+// CURRENT generation, and PerHiveEnvStatus reports a per-generation breakdown.
+//
+// Two properties are load-bearing across this file:
+//
+//   - Provision-time and reconcile-time derivation must agree EXACTLY. They now
+//     both resolve their master through provisionGenerationSet(), so a rotation
+//     cannot move one without the other. Divergence would make the sweep fight
+//     provisioning and roll a pod every cycle forever.
+//   - A ZERO VerifyUntil means ALREADY EXPIRED, never "never expires". This is
+//     the property that stops a previous generation being pinned live forever
+//     by a hand-edited file, and it is asserted here on the retirement surface
+//     as well as in hub_generations_test.go on the acceptance surface.
+
+// genTestSecretA / B are fixed non-production masters. Only ever compared to
+// each other, never to any real value.
+const (
+	perHiveGenSecretA = "perhive-generation-test-master-alpha"
+	perHiveGenSecretB = "perhive-generation-test-master-bravo"
+)
+
+// withProvisionGenerations points provisionGenerationSet() at an explicit set
+// for the duration of a test, and restores it afterwards. Without this the
+// rotated case is untestable — see provisionGenerationsOverride.
+func withProvisionGenerations(t *testing.T, gs *generationSet) {
+	t.Helper()
+	prev := provisionGenerationsOverride
+	provisionGenerationsOverride = gs
+	t.Cleanup(func() { provisionGenerationsOverride = prev })
+}
+
+// TestDesiredPerHiveEnvUsesCurrentNotPrevious is the test that can actually
+// FAIL if desiredPerHiveEnv reverts to the raw master.
+//
+// It is the only one that can. With a single generation — the state of every
+// hub today — provisionCurrentSecret() and provisionMasterSecret() return the
+// same string, so swapping one for the other changes nothing observable. This
+// test therefore installs a ROTATED set whose current secret differs from the
+// raw master, and asserts the derived material follows the CURRENT generation
+// and specifically is NOT the previous generation's.
+func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
+	// The raw master stays on generation A. The rotated set's current is B.
+	withTestMaster(t, perHiveGenSecretA)
+	now := time.Now()
+	rotated := legacyGenerationSet(perHiveGenSecretA).rotate(perHiveGenSecretB, now, defaultVerifyWindow)
+	if rotated == nil || rotated.currentSecret() != perHiveGenSecretB {
+		t.Fatal("fixture: rotate did not make secret B current")
+	}
+	withProvisionGenerations(t, rotated)
+
+	const hiveID = "hive-alpha"
+	got := desiredPerHiveEnv(hiveID)
+	if got == nil {
+		t.Fatal("desiredPerHiveEnv returned nil")
+	}
+
+	fromCurrent := map[string]string{
+		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretB, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretB, infoTerminalKey, hiveID),
+		EnvSessionKey:       deriveDomainKey(perHiveGenSecretB, infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSSOEd25519Seed)),
+		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSessionEd25519Seed)),
+	}
+	fromPrevious := map[string]string{
+		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretA, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretA, infoTerminalKey, hiveID),
+		EnvSessionKey:       deriveDomainKey(perHiveGenSecretA, infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSSOEd25519Seed)),
+		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSessionEd25519Seed)),
+	}
+
+	for _, name := range perHiveEnvNames() {
+		if got[name] != fromCurrent[name] {
+			t.Errorf("%s: not derived from the CURRENT generation", name)
+		}
+		if got[name] == fromPrevious[name] {
+			t.Errorf("%s: still derived from the PREVIOUS generation — rotation would never converge", name)
+		}
+	}
+
+	// The provisioning template must move in lockstep. If provisioning stayed
+	// on the old master while the reconcile moved, the sweep would see drift on
+	// every freshly provisioned hive and roll its pod every cycle forever.
+	if provisionHeartbeatKey(hiveID) != fromCurrent[EnvHeartbeatKey] {
+		t.Error("provisionHeartbeatKey did not follow the current generation — provision/reconcile would fight")
+	}
+	if provisionTerminalKey(hiveID) != fromCurrent[EnvTerminalKey] {
+		t.Error("provisionTerminalKey did not follow the current generation")
+	}
+	if provisionSessionPublicKey() != fromCurrent[envSessionPublicKey] {
+		t.Error("provisionSessionPublicKey did not follow the current generation")
+	}
+
+	// POSITIVE CONTROL: the fixture is only meaningful if the two generations
+	// actually derive different material. If A and B collided every assertion
+	// above would be vacuous.
+	for _, name := range perHiveEnvNames() {
+		if fromCurrent[name] == fromPrevious[name] {
+			t.Fatalf("fixture is degenerate: %s derives identically from both generations", name)
+		}
+	}
+}
+
+// TestDesiredPerHiveEnvDerivesFromCurrentGeneration is the core PR #3
+// assertion: the reconcile's desired values are a function of the CURRENT
+// generation's secret, not of the raw master file.
+//
+// Today there is only ever one generation (nothing can create a second until
+// PR #4), so this test does the derivation by hand rather than by rotating the
+// hub: it asserts that desiredPerHiveEnv's output equals what the generation
+// set's currentSecret() produces, which is the invariant PR #4 will start
+// exercising for real.
+func TestDesiredPerHiveEnvDerivesFromCurrentGeneration(t *testing.T) {
+	withTestMaster(t, perHiveGenSecretA)
+	const hiveID = "hive-alpha"
+
+	gs := provisionGenerationSet()
+	if gs == nil {
+		t.Fatal("provisionGenerationSet returned nil for a configured master")
+	}
+	if gs.currentSecret() != perHiveGenSecretA {
+		t.Fatalf("current generation secret does not match the configured master")
+	}
+
+	want := desiredPerHiveEnv(hiveID)
+	if want == nil {
+		t.Fatal("desiredPerHiveEnv returned nil for a valid master + hive ID")
+	}
+
+	cur := gs.currentSecret()
+	expect := map[string]string{
+		EnvHeartbeatKey:     derivePerHiveKey(cur, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:      derivePerHiveKey(cur, infoTerminalKey, hiveID),
+		EnvSessionKey:       deriveDomainKey(cur, infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(cur, infoSSOEd25519Seed)),
+		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(cur, infoSessionEd25519Seed)),
+	}
+	for name, v := range expect {
+		if v == "" {
+			t.Fatalf("generation-side derivation for %s is empty; test setup is wrong", name)
+		}
+		if want[name] != v {
+			t.Errorf("%s: desiredPerHiveEnv does not derive from the current generation", name)
+		}
+	}
+}
+
+// TestPerHiveEnvGenerationIsAReadPathChangeToday is the "no behaviour change"
+// proof the task asks for explicitly.
+//
+// Until PR #4 lands there is no way to create a second generation, so the
+// generation set is always legacyGenerationSet(provisionMasterSecret()) and
+// every derived value must be BYTE-IDENTICAL to what the pre-generation code
+// produced. The pre-generation expressions are reproduced literally on the
+// right-hand side.
+func TestPerHiveEnvGenerationIsAReadPathChangeToday(t *testing.T) {
+	withTestMaster(t, perHiveGenSecretA)
+	const hiveID = "hive-alpha"
+
+	if got, want := provisionCurrentSecret(), provisionMasterSecret(); got != want {
+		t.Fatalf("current-generation secret differs from the raw master before any rotation exists")
+	}
+
+	master := provisionMasterSecret() // the PRE-generation expression
+	preGeneration := map[string]string{
+		EnvHeartbeatKey:     derivePerHiveKey(master, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:      derivePerHiveKey(master, infoTerminalKey, hiveID),
+		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
+		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(master, infoSessionEd25519Seed)),
+	}
+
+	got := desiredPerHiveEnv(hiveID)
+	if got == nil {
+		t.Fatal("desiredPerHiveEnv returned nil")
+	}
+	for name, v := range preGeneration {
+		if got[name] != v {
+			t.Errorf("%s changed value: this PR must be a read-path change with no fleet-visible effect", name)
+		}
+	}
+}
+
+// TestPerHiveEnvEmptyGuardStillFailsSafe re-asserts the guard the task singles
+// out, against the NEW master expression.
+//
+// The reason it matters is not obvious from the code: HIVE_HEARTBEAT_KEY=""
+// falls back to the master exactly like an ABSENT var, so the spoke keeps
+// working — while making the readiness count report that hive as CONVERGED. A
+// silently-wrong "converged" is worse than a visible drift, which is why
+// desiredPerHiveEnv must return nil rather than a map with an empty value in
+// it.
+func TestPerHiveEnvEmptyGuardStillFailsSafe(t *testing.T) {
+	t.Run("nil generation set derives nothing", func(t *testing.T) {
+		var gs *generationSet
+		if gs.currentSecret() != "" {
+			t.Fatal("nil generation set must yield an empty current secret")
+		}
+		if deriveDomainKey(gs.currentSecret(), infoSessionKey) != "" {
+			t.Fatal("an empty current secret must derive to \"\" (fail closed)")
+		}
+	})
+
+	t.Run("empty master short-circuits before deriving", func(t *testing.T) {
+		withTestMaster(t, "")
+		if provisionGenerationSet() != nil {
+			t.Fatal("provisionGenerationSet with no master must be nil, not an empty-secret set")
+		}
+		if got := desiredPerHiveEnv("hive-alpha"); got != nil {
+			t.Fatalf("desiredPerHiveEnv with no master = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty hive ID short-circuits", func(t *testing.T) {
+		withTestMaster(t, perHiveGenSecretA)
+		if got := desiredPerHiveEnv(""); got != nil {
+			t.Fatalf("desiredPerHiveEnv(\"\") = %v, want nil", got)
+		}
+	})
+
+	// POSITIVE CONTROL for the three sub-tests above. "always return nil" would
+	// satisfy every one of them, so assert the opposite direction: a valid
+	// master and hive ID DO produce a complete map with no empty value in it.
+	t.Run("positive control: valid inputs produce all five non-empty", func(t *testing.T) {
+		withTestMaster(t, perHiveGenSecretA)
+		got := desiredPerHiveEnv("hive-alpha")
+		if got == nil {
+			t.Fatal("valid master + hive ID returned nil — the guard is too aggressive")
+		}
+		if len(got) != len(perHiveEnvNames()) {
+			t.Fatalf("got %d vars, want %d", len(got), len(perHiveEnvNames()))
+		}
+		for _, name := range perHiveEnvNames() {
+			if got[name] == "" {
+				t.Errorf("%s is empty — exactly the value that must never reach a Deployment", name)
+			}
+		}
+	})
+}
+
+// perHiveEnvForGeneration builds a live Deployment env list for hiveID as it
+// would look if provisioned from the given generation's secret.
+func perHiveEnvForGeneration(secret, hiveID string) []deploymentEnvVar {
+	return []deploymentEnvVar{
+		{Name: "HIVE_ID", Value: hiveID},
+		{Name: EnvHeartbeatKey, Value: derivePerHiveKey(secret, infoHeartbeatKey, hiveID)},
+		{Name: EnvTerminalKey, Value: derivePerHiveKey(secret, infoTerminalKey, hiveID)},
+		{Name: EnvSessionKey, Value: deriveDomainKey(secret, infoSessionKey)},
+		{Name: EnvSSOPublicKey, Value: ssoPublicKeyFromSeed(deriveDomainKey(secret, infoSSOEd25519Seed))},
+		{Name: envSessionPublicKey, Value: ssoPublicKeyFromSeed(deriveDomainKey(secret, infoSessionEd25519Seed))},
+	}
+}
+
+// TestPerHiveEnvGenerationAttribution covers the classifier that decides which
+// generation a spoke is on.
+func TestPerHiveEnvGenerationAttribution(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(perHiveGenSecretA).rotate(perHiveGenSecretB, now, defaultVerifyWindow)
+	if gs == nil {
+		t.Fatal("rotate returned nil")
+	}
+	acceptable := gs.acceptableGenerations(now)
+	if len(acceptable) != 2 {
+		t.Fatalf("expected current + previous acceptable, got %d", len(acceptable))
+	}
+	// Deliberately NOT the "hive-alpha" used elsewhere in this file. The probe
+	// must depend on the hiveID ARGUMENT; a classifier that ignored it (or
+	// substituted any fixed ID) would still pass if every fixture in the test
+	// shared one hive name, which is exactly the test-passing-for-the-wrong-
+	// reason this avoids.
+	const hiveID = "hive-classifier-subject"
+
+	t.Run("spoke on the new current", func(t *testing.T) {
+		live := perHiveEnvForGeneration(perHiveGenSecretB, hiveID)
+		id, ok := perHiveEnvGeneration(acceptable, live, hiveID)
+		if !ok || id != gs.Current {
+			t.Fatalf("got (%d,%v), want current generation %d", id, ok, gs.Current)
+		}
+	})
+
+	t.Run("spoke still on the previous", func(t *testing.T) {
+		live := perHiveEnvForGeneration(perHiveGenSecretA, hiveID)
+		id, ok := perHiveEnvGeneration(acceptable, live, hiveID)
+		if !ok || id != legacyGenerationID {
+			t.Fatalf("got (%d,%v), want previous generation %d", id, ok, legacyGenerationID)
+		}
+	})
+
+	t.Run("spoke on a key from no live generation is UNATTRIBUTED", func(t *testing.T) {
+		live := perHiveEnvForGeneration("some-third-retired-master", hiveID)
+		if id, ok := perHiveEnvGeneration(acceptable, live, hiveID); ok {
+			t.Fatalf("attributed a retired key to generation %d — must fail closed", id)
+		}
+	})
+
+	t.Run("stale hive ID is not mistaken for a generation match", func(t *testing.T) {
+		// Correct generation, WRONG hive: the heartbeat key is per-hive, so
+		// this must not attribute. If it did, a stale-hive-ID drift would read
+		// as converged.
+		live := perHiveEnvForGeneration(perHiveGenSecretB, "hive-bravo")
+		if id, ok := perHiveEnvGeneration(acceptable, live, hiveID); ok {
+			t.Fatalf("attributed another hive's key to generation %d", id)
+		}
+	})
+
+	t.Run("absent heartbeat key is unattributed", func(t *testing.T) {
+		live := []deploymentEnvVar{{Name: "HIVE_ID", Value: hiveID}}
+		if _, ok := perHiveEnvGeneration(acceptable, live, hiveID); ok {
+			t.Fatal("attributed a hive with no heartbeat key")
+		}
+	})
+
+	t.Run("classification is a function of the hiveID argument", func(t *testing.T) {
+		// Same live env, two different subject hive IDs: at most one can match.
+		// This is the positive control for the stale-hive-ID case above — that
+		// one only proves a NEGATIVE, which "never attribute anything" would
+		// also satisfy.
+		live := perHiveEnvForGeneration(perHiveGenSecretB, hiveID)
+		if id, ok := perHiveEnvGeneration(acceptable, live, hiveID); !ok || id != gs.Current {
+			t.Fatalf("subject hive did not attribute: (%d,%v)", id, ok)
+		}
+		if id, ok := perHiveEnvGeneration(acceptable, live, "hive-some-other"); ok {
+			t.Fatalf("a DIFFERENT hive attributed to generation %d from the same env — "+
+				"the classifier ignores its hiveID argument", id)
+		}
+	})
+
+	t.Run("no live generations attributes nothing", func(t *testing.T) {
+		live := perHiveEnvForGeneration(perHiveGenSecretB, hiveID)
+		if _, ok := perHiveEnvGeneration(nil, live, hiveID); ok {
+			t.Fatal("attributed with an empty generation set")
+		}
+	})
+}
+
+// TestPerHiveEnvStatusMixedFleetCounts is the observability assertion: a fleet
+// split across generations must be counted correctly, and the counts must come
+// from Deployment-sourced observations so a PAUSED spoke still blocks
+// retirement rather than dropping out of the denominator.
+func TestPerHiveEnvStatusMixedFleetCounts(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(perHiveGenSecretA).rotate(perHiveGenSecretB, now, defaultVerifyWindow)
+	s := &HubServer{keyGenerations: gs, perHiveEnvSeen: map[string]perHiveEnvObservation{}}
+
+	// 3 on the new current, 2 still on the previous, 1 on neither.
+	for _, id := range []string{"c1", "c2", "c3"} {
+		s.perHiveEnvSeen[id] = perHiveEnvObservation{Generation: gs.Current, Observed: now}
+	}
+	for _, id := range []string{"p1", "p2"} {
+		s.perHiveEnvSeen[id] = perHiveEnvObservation{Generation: legacyGenerationID, Observed: now}
+	}
+	s.perHiveEnvSeen["x1"] = perHiveEnvObservation{Generation: 0, Observed: now}
+
+	got := s.PerHiveEnvSnapshot().KeyGenerations
+	if got.Current != gs.Current {
+		t.Errorf("Current = %d, want %d", got.Current, gs.Current)
+	}
+	if got.SpokesOnCurrent != 3 {
+		t.Errorf("SpokesOnCurrent = %d, want 3", got.SpokesOnCurrent)
+	}
+	if got.SpokesOnPrevious != 2 {
+		t.Errorf("SpokesOnPrevious = %d, want 2", got.SpokesOnPrevious)
+	}
+	if got.SpokesUnattributed != 1 {
+		t.Errorf("SpokesUnattributed = %d, want 1", got.SpokesUnattributed)
+	}
+	if len(got.LiveGenerations) != 2 {
+		t.Errorf("LiveGenerations = %v, want two entries", got.LiveGenerations)
+	}
+	if got.PreviousVerifyUntil == "" {
+		t.Error("PreviousVerifyUntil is empty; a demoted generation must publish its expiry")
+	}
+	// Still converging AND the window is still open: not retirable.
+	if got.SafeToRetirePrevious {
+		t.Error("SafeToRetirePrevious with 2 spokes still on the previous generation")
+	}
+
+	// The counts must NEVER expose secret material. LiveGenerations holds IDs.
+	for _, id := range got.LiveGenerations {
+		if id <= 0 {
+			t.Errorf("live generation id %d is not a valid generation number", id)
+		}
+	}
+}
+
+// TestPerHiveEnvSafeToRetireIsGated walks every clause of
+// SafeToRetirePrevious. Each sub-test flips exactly one input, so a clause
+// deleted from the predicate turns exactly one sub-test red.
+func TestPerHiveEnvSafeToRetireIsGated(t *testing.T) {
+	now := time.Now()
+	// A rotation whose verify window has ALREADY closed.
+	expired := legacyGenerationSet(perHiveGenSecretA).
+		rotate(perHiveGenSecretB, now.Add(-2*defaultVerifyWindow), defaultVerifyWindow)
+
+	newHub := func(gs *generationSet, seen map[string]perHiveEnvObservation) *HubServer {
+		return &HubServer{keyGenerations: gs, perHiveEnvSeen: seen}
+	}
+	allOnCurrent := map[string]perHiveEnvObservation{
+		"c1": {Generation: expired.Current, Observed: now},
+	}
+
+	t.Run("retirable: window closed, everything on current", func(t *testing.T) {
+		got := newHub(expired, allOnCurrent).PerHiveEnvSnapshot().KeyGenerations
+		if !got.SafeToRetirePrevious {
+			t.Fatalf("want retirable; got %+v", got)
+		}
+	})
+
+	t.Run("not retirable with zero observations (fails closed)", func(t *testing.T) {
+		got := newHub(expired, map[string]perHiveEnvObservation{}).PerHiveEnvSnapshot().KeyGenerations
+		if got.SafeToRetirePrevious {
+			t.Fatal("reported retirable from zero evidence")
+		}
+	})
+
+	t.Run("not retirable while a spoke is still on the previous", func(t *testing.T) {
+		seen := map[string]perHiveEnvObservation{
+			"c1": {Generation: expired.Current, Observed: now},
+			"p1": {Generation: legacyGenerationID, Observed: now},
+		}
+		if newHub(expired, seen).PerHiveEnvSnapshot().KeyGenerations.SafeToRetirePrevious {
+			t.Fatal("reported retirable with a spoke still on the previous generation")
+		}
+	})
+
+	t.Run("not retirable while a spoke is unattributed", func(t *testing.T) {
+		seen := map[string]perHiveEnvObservation{
+			"c1": {Generation: expired.Current, Observed: now},
+			"x1": {Generation: 0, Observed: now},
+		}
+		if newHub(expired, seen).PerHiveEnvSnapshot().KeyGenerations.SafeToRetirePrevious {
+			t.Fatal("reported retirable with an unattributed spoke")
+		}
+	})
+
+	t.Run("not retirable while the verify window is still open", func(t *testing.T) {
+		open := legacyGenerationSet(perHiveGenSecretA).rotate(perHiveGenSecretB, now, defaultVerifyWindow)
+		seen := map[string]perHiveEnvObservation{"c1": {Generation: open.Current, Observed: now}}
+		if newHub(open, seen).PerHiveEnvSnapshot().KeyGenerations.SafeToRetirePrevious {
+			t.Fatal("reported retirable before verify_until passed")
+		}
+	})
+
+	t.Run("never-rotated hub has no previous to retire", func(t *testing.T) {
+		single := legacyGenerationSet(perHiveGenSecretA)
+		seen := map[string]perHiveEnvObservation{"c1": {Generation: legacyGenerationID, Observed: now}}
+		got := newHub(single, seen).PerHiveEnvSnapshot().KeyGenerations
+		if got.SafeToRetirePrevious {
+			t.Fatal("a never-rotated hub reported a previous generation as retirable")
+		}
+		if got.PreviousVerifyUntil != "" {
+			t.Errorf("PreviousVerifyUntil = %q on a never-rotated hub", got.PreviousVerifyUntil)
+		}
+		if got.SpokesOnCurrent != 1 {
+			t.Errorf("SpokesOnCurrent = %d, want 1", got.SpokesOnCurrent)
+		}
+	})
+
+	// THE ZERO-VerifyUntil CASE. A hand-edited generations file that strips
+	// verify_until must read as ALREADY EXPIRED, never as "never expires".
+	// Reading it the other way would pin the previous generation live forever —
+	// the exact F1/F2 failure mode. acceptableGenerations already refuses to
+	// ACCEPT such a generation; this asserts the retirement surface agrees.
+	t.Run("zero verify_until reads as already expired, not never-expires", func(t *testing.T) {
+		hand := &generationSet{
+			Current: 2,
+			Generations: []keyGeneration{
+				{ID: 2, Secret: perHiveGenSecretB},
+				{ID: 1, Secret: perHiveGenSecretA}, // VerifyUntil deliberately zero
+			},
+		}
+		seen := map[string]perHiveEnvObservation{"c1": {Generation: 2, Observed: now}}
+		got := newHub(hand, seen).PerHiveEnvSnapshot().KeyGenerations
+		if !got.SafeToRetirePrevious {
+			t.Fatal("a zero verify_until must read as already expired (retirable), not as never-expires")
+		}
+		// And it must not be advertised as live, since it is not accepted.
+		for _, id := range got.LiveGenerations {
+			if id == 1 {
+				t.Fatal("an expired generation is advertised as live")
+			}
+		}
+	})
+}
+
+// TestPerHiveEnvGenerationSnapshotNilSafe: the snapshot must not panic on a hub
+// with no generation set, and must fail closed.
+func TestPerHiveEnvGenerationSnapshotNilSafe(t *testing.T) {
+	s := &HubServer{perHiveEnvSeen: map[string]perHiveEnvObservation{
+		"c1": {Generation: 0, Observed: time.Now()},
+	}}
+	got := s.PerHiveEnvSnapshot().KeyGenerations
+	if got.Current != 0 {
+		t.Errorf("Current = %d on a hub with no generation set", got.Current)
+	}
+	if got.SpokesOnCurrent != 0 || got.SpokesOnPrevious != 0 {
+		t.Errorf("counted spokes onto generations with no generation set: %+v", got)
+	}
+	if got.SpokesUnattributed != 1 {
+		t.Errorf("SpokesUnattributed = %d, want 1", got.SpokesUnattributed)
+	}
+	if got.SafeToRetirePrevious {
+		t.Error("reported retirable with no generation set")
+	}
+}

--- a/v2/pkg/hub/perhive_env_reconcile.go
+++ b/v2/pkg/hub/perhive_env_reconcile.go
@@ -121,6 +121,22 @@ type deploymentEnvVar struct {
 // and roll a pod every cycle forever — so both sides call the same helpers in
 // hub_keys.go rather than re-implementing the formulas.
 //
+// GENERATIONS. The master used here is the CURRENT generation's secret
+// (provisionCurrentSecret), not the raw file/env master. That single change is
+// the whole of "rotate spoke-held material without re-provisioning": after a
+// rotation every spoke still carries generation-N material, perHiveEnvDrift
+// sees a var present with a DIFFERENT value — the case its own doc comment
+// names as "a rotated master" — and the existing rate limiter walks the fleet
+// onto the new generation at 3 patches per 15-minute cycle. Nothing about the
+// sweep's cadence or aggressiveness changes; the drift detector was already
+// correct for this case.
+//
+// Until a rotation can actually happen (follow-on PR #4 adds the persistence
+// and the admin endpoint) there is exactly one generation, so
+// provisionCurrentSecret() == provisionMasterSecret() and every value below is
+// byte-identical to what this function returned before. This is a read-path
+// change in effect.
+//
 // FAIL-SAFE: returns nil when any derived value is empty. derivePerHiveKey
 // returns "" for an empty master OR an empty hiveID, and deriveDomainKey
 // returns "" for an empty master, by design (a keyless caller must fail closed).
@@ -136,7 +152,11 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 	if hiveID == "" {
 		return nil
 	}
-	master := provisionMasterSecret()
+	// The CURRENT generation's secret. Empty when no generation is configured —
+	// including the nil-set case, since currentSecret() on a nil *generationSet
+	// returns "". The guard below is unchanged: an empty master must still
+	// short-circuit before anything is derived.
+	master := provisionCurrentSecret()
 	if master == "" {
 		return nil
 	}
@@ -302,6 +322,52 @@ func perHiveEnvSweepEligible(status string) bool {
 	return strings.TrimSpace(status) != "provisioning"
 }
 
+// perHiveEnvGeneration classifies which live generation a spoke's Deployment env
+// was derived from, by re-deriving the per-hive heartbeat key under each
+// acceptable generation and comparing.
+//
+// WHY THE HEARTBEAT KEY IS THE PROBE. Of the five reconciled vars it is the one
+// that is BOTH per-hive and a direct HMAC of the master, so a match identifies
+// the generation AND the hive — two spokes on the same generation produce
+// different values, so a stale-hive-ID drift can never be misread as a
+// generation match. The session/SSO public keys are fleet-uniform and would
+// answer a weaker question.
+//
+// Returns (id, true) for the generation that produced the live value, and
+// (0, false) when NO live generation explains it. That second case is
+// deliberately not folded into "previous": a value derived from a generation
+// the hub has already retired, or from a stale hive ID, is UNATTRIBUTED and
+// must not be counted as being on any generation — otherwise a spoke stuck on
+// a retired key would silently inflate a "converged" count. It fails closed.
+//
+// gens is the acceptable set in current-first order, so the common case (a
+// converged spoke) matches on the first attempt.
+func perHiveEnvGeneration(gens []keyGeneration, live []deploymentEnvVar, hiveID string) (int, bool) {
+	hiveID = strings.TrimSpace(hiveID)
+	if hiveID == "" || len(gens) == 0 {
+		return 0, false
+	}
+	var presented string
+	for _, e := range live {
+		if e.Name == EnvHeartbeatKey {
+			presented = e.Value
+			break
+		}
+	}
+	if presented == "" {
+		// Absent or blank. An absent heartbeat key is drift, already reported
+		// by perHiveEnvDrift; it is not evidence of any generation.
+		return 0, false
+	}
+	for _, g := range gens {
+		expect := derivePerHiveKey(g.Secret, infoHeartbeatKey, hiveID)
+		if expect != "" && secureCompareHub(presented, expect) {
+			return g.ID, true
+		}
+	}
+	return 0, false
+}
+
 // perHiveEnvObservation is one hive's live posture, recorded by the sweep from
 // its OWN Deployment read. See perHiveEnvSnapshot for why this is not sourced
 // from heartbeat recency.
@@ -311,6 +377,11 @@ type perHiveEnvObservation struct {
 	// HasMasterSecret is true when the Deployment still injects
 	// HIVE_HUB_SECRET, the master this whole line of work exists to remove.
 	HasMasterSecret bool
+	// Generation is the live generation ID whose material this hive carries, or
+	// 0 when the hub could not attribute the hive's key to any acceptable
+	// generation. Zero is the fail-closed value: it is counted as neither
+	// current nor previous.
+	Generation int
 	// Observed is when the Deployment was last successfully read.
 	Observed time.Time
 }
@@ -372,6 +443,50 @@ type PerHiveEnvStatus struct {
 	// was indistinguishable from "nothing to do".
 	ConsideredHives int `json:"considered_hives"`
 	SkippedByStatus int `json:"skipped_by_status"`
+	// KeyGenerations is the per-generation breakdown of the observed fleet. It
+	// is the surface an operator watches during a rotation to decide when the
+	// previous generation can be retired.
+	KeyGenerations KeyGenerationStatus `json:"key_generations"`
+}
+
+// KeyGenerationStatus is the rotation-readiness view: how many observed spokes
+// carry material from which master generation.
+//
+// SOURCED FROM DEPLOYMENT READS, NOT HEARTBEATS — for the reason spelled out at
+// length on PerHiveEnvSnapshot. A paused spoke still has a Deployment, so it is
+// still counted and still blocks retirement; it cannot fall out of the
+// denominator by going quiet. Gating retirement on a heartbeat-sourced count
+// would let a paused spoke sit on a key the hub has stopped accepting.
+type KeyGenerationStatus struct {
+	// Current is the ID of the generation that MINTS. 0 when the hub has no
+	// generation set configured at all.
+	Current int `json:"current"`
+	// LiveGenerations lists the IDs the hub currently accepts for VERIFY,
+	// current first. Never includes secret material — an ID names a key, it is
+	// not a key.
+	LiveGenerations []int `json:"live_generations,omitempty"`
+	// SpokesOnCurrent is how many observed hives carry material derived from
+	// the current generation.
+	SpokesOnCurrent int `json:"spokes_on_current"`
+	// SpokesOnPrevious is how many observed hives carry material from a live
+	// but non-current generation — the ones a rotation is still walking.
+	SpokesOnPrevious int `json:"spokes_on_previous"`
+	// SpokesUnattributed is how many observed hives carry a heartbeat key that
+	// matches NO live generation. These are not on "previous"; they are on
+	// something the hub no longer accepts, or their hive ID has drifted. They
+	// are broken now, not merely lagging, and they are counted separately so
+	// they can never be mistaken for either converged or converging.
+	SpokesUnattributed int `json:"spokes_unattributed"`
+	// PreviousVerifyUntil is when the most recent previous generation stops
+	// being accepted, RFC3339. Empty when there is no previous generation.
+	PreviousVerifyUntil string `json:"previous_verify_until,omitempty"`
+	// SafeToRetirePrevious is true only when a previous generation exists, at
+	// least one hive was observed, NO observed hive is on a previous generation
+	// or unattributed, and the previous generation's VerifyUntil has passed.
+	//
+	// Fails CLOSED on zero observations, exactly like PerHiveEnvConverged: "the
+	// hub has read nothing" must never render as "safe to retire".
+	SafeToRetirePrevious bool `json:"safe_to_retire_previous"`
 }
 
 // PerHiveEnvSnapshot reports fleet convergence for the five per-hive security
@@ -403,6 +518,40 @@ func (s *HubServer) PerHiveEnvSnapshot() PerHiveEnvStatus {
 	defer s.perHiveEnvMu.RUnlock()
 	out.ConsideredHives = s.perHiveEnvConsidered
 	out.SkippedByStatus = s.perHiveEnvSkippedByStatus
+	gs := s.keyGenerations
+	now := time.Now()
+	current, hasCurrent := gs.currentGeneration()
+	if hasCurrent {
+		out.KeyGenerations.Current = current.ID
+	}
+	// LiveGenerations reports what the hub currently ACCEPTS, so it comes from
+	// acceptableGenerations — an expired previous generation is already gone
+	// from it, which is the finiteness promise made visible.
+	acceptable := gs.acceptableGenerations(now)
+	for _, g := range acceptable {
+		out.KeyGenerations.LiveGenerations = append(out.KeyGenerations.LiveGenerations, g.ID)
+	}
+
+	// previousVerifyUntil, by contrast, comes from the RAW set. It must not be
+	// sourced from `acceptable`: retirement is precisely the state where the
+	// window has already closed, so an acceptable-sourced read would drop the
+	// previous generation from view at the exact moment it becomes retirable
+	// and SafeToRetirePrevious could never be true. The entry still sits in the
+	// set until something removes it; this surface is what says it may be.
+	var previousVerifyUntil time.Time
+	hasPrevious := false
+	if gs != nil {
+		for _, g := range gs.Generations {
+			if g.ID == gs.Current {
+				continue
+			}
+			hasPrevious = true
+			if previousVerifyUntil.IsZero() || g.VerifyUntil.After(previousVerifyUntil) {
+				previousVerifyUntil = g.VerifyUntil
+			}
+		}
+	}
+
 	for id, obs := range s.perHiveEnvSeen {
 		out.ObservedHives++
 		if len(obs.MissingVars) > 0 {
@@ -412,9 +561,39 @@ func (s *HubServer) PerHiveEnvSnapshot() PerHiveEnvStatus {
 		if obs.HasMasterSecret {
 			out.StillCarryingMaster++
 		}
+		switch {
+		case hasCurrent && obs.Generation == out.KeyGenerations.Current:
+			out.KeyGenerations.SpokesOnCurrent++
+		case obs.Generation > 0:
+			out.KeyGenerations.SpokesOnPrevious++
+		default:
+			out.KeyGenerations.SpokesUnattributed++
+		}
 	}
 	sort.Strings(out.MissingHives)
 	out.PerHiveEnvConverged = out.ObservedHives > 0 && out.MissingPerHiveEnv == 0
+
+	if !previousVerifyUntil.IsZero() {
+		out.KeyGenerations.PreviousVerifyUntil = previousVerifyUntil.UTC().Format(time.RFC3339)
+	}
+	// windowClosed follows acceptableGenerations' rule exactly: a ZERO
+	// VerifyUntil means ALREADY EXPIRED, not "never expires". Reading it the
+	// other way here would be worse than inconsistent — a hand-edited
+	// generations file with the field stripped would report the window as
+	// permanently open and pin the previous generation live forever, which is
+	// the F1/F2 failure mode this design exists to make impossible.
+	windowClosed := previousVerifyUntil.IsZero() || !now.Before(previousVerifyUntil)
+
+	// Every clause is required. Dropping "hasPrevious" would report a fresh,
+	// never-rotated hub as safe to retire a generation it does not have;
+	// dropping the observation floor would report safety from zero evidence;
+	// and counting SpokesUnattributed here (rather than ignoring it) is what
+	// stops a spoke on an ALREADY-retired key from reading as retirable.
+	out.KeyGenerations.SafeToRetirePrevious = hasPrevious &&
+		out.ObservedHives > 0 &&
+		out.KeyGenerations.SpokesOnPrevious == 0 &&
+		out.KeyGenerations.SpokesUnattributed == 0 &&
+		windowClosed
 	return out
 }
 
@@ -513,12 +692,16 @@ func (s *HubServer) reconcilePerHiveEnv() {
 				break
 			}
 		}
+		// Attribute this hive to a generation from the SAME read that produced
+		// the drift list, so the two can never describe different moments.
+		gen, _ := perHiveEnvGeneration(s.keyGenerations.acceptableGenerations(time.Now()), liveEnv, h.ID)
 		// Record the observation from THIS read regardless of whether we go on
 		// to patch — the readiness surface must reflect the whole fleet even
 		// while remediation is rate-limited.
 		s.recordPerHiveEnvObservation(h.ID, perHiveEnvObservation{
 			MissingVars:     drift,
 			HasMasterSecret: hasMaster,
+			Generation:      gen,
 			Observed:        time.Now(),
 		})
 

--- a/v2/pkg/hub/perhive_env_reconcile_test.go
+++ b/v2/pkg/hub/perhive_env_reconcile_test.go
@@ -54,11 +54,15 @@ func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
 
 	// These right-hand sides are copied verbatim from the template's data map
 	// (saas_provision.go: HeartbeatKey / SessionKey / SSOPublicKey /
-	// SessionPublicKey / TerminalKey).
+	// SessionPublicKey / TerminalKey), INCLUDING their master expression. The
+	// template derives from provisionCurrentSecret() — the current generation —
+	// so this test pins the generation-aware expression, not the old
+	// provisionMasterSecret() one. If provisioning and the reconcile ever
+	// resolved different generations, this fails.
 	expect := map[string]string{
 		EnvHeartbeatKey:     provisionHeartbeatKey(hiveID),
-		EnvSessionKey:       deriveDomainKey(provisionMasterSecret(), infoSessionKey),
-		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
+		EnvSessionKey:       deriveDomainKey(provisionCurrentSecret(), infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSSOEd25519Seed)),
 		envSessionPublicKey: provisionSessionPublicKey(),
 		EnvTerminalKey:      provisionTerminalKey(hiveID),
 	}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1955,9 +1955,16 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// "some provisioned spoke", so the hub had to trust body-supplied
 		// hive_id — and three key-delivery lanes read off that claimed ID.
 		// Binding the bearer to the hive makes the claim self-authenticating.
+		//
+		// All five resolve against provisionCurrentSecret() — the CURRENT
+		// generation's master (hub_keys.go). Provisioning and the
+		// perhive_env_reconcile sweep MUST derive identically or they would
+		// fight and roll a pod every cycle forever, so both sides read the
+		// generation set through the same helper. Before any rotation exists
+		// this is byte-identical to the old provisionMasterSecret() reads.
 		"HeartbeatKey": provisionHeartbeatKey(h.ID),
-		"SessionKey":   deriveDomainKey(provisionMasterSecret(), infoSessionKey),
-		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionMasterSecret(), infoSSOEd25519Seed)),
+		"SessionKey":   deriveDomainKey(provisionCurrentSecret(), infoSessionKey),
+		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSSOEd25519Seed)),
 		// N2: the Ed25519 PUBLIC key for hub session cookies. A spoke verifies
 		// hive_hub_user with this and cannot mint one — unlike SessionKey below,
 		// which is symmetric and therefore let any spoke forge a hub ADMIN cookie.


### PR DESCRIPTION
Follow-on **PR #3** of the hub master-key rotation design (`v2/docs/design/master-key-rotation.md`), building on the foundation in `58c15549`. **Hub-internal — no spoke rolls as a result of this change.**

## What changes

`desiredPerHiveEnv` (`perhive_env_reconcile.go`) now resolves its master through the **current generation** rather than the raw `provisionMasterSecret()`. The provisioning template (`saas_provision.go`) and the four provision-time key helpers move with it, through one shared resolver — `provisionGenerationSet` / `provisionCurrentSecret` in `hub_keys.go`.

Routing both sides through one resolver is the point. `desiredPerHiveEnv`'s own doc comment already required provision-time and reconcile-time derivation to agree, and the consequence of divergence is not cosmetic: the sweep would see "drift" on every freshly provisioned hive, patch it, and roll its pod every cycle forever.

That single substitution is the whole of "rotate spoke-held material without re-provisioning". `perHiveEnvDrift`'s comment already names the case — *"a stale hive ID or a **rotated master**"* — so after a rotation the existing sweep walks the fleet onto the new generation at its **existing** rate limit.

**The rate limit is deliberately untouched**: still 3 patches per 15-minute cycle, ~6h for 66 spokes.

## This is a read-path change today

Nothing can create a second generation until follow-on PR #4 adds persistence and the admin endpoint, so `provisionCurrentSecret() == provisionMasterSecret()` and every derived value is byte-identical to what this code produced before. `TestPerHiveEnvGenerationIsAReadPathChangeToday` asserts exactly that, against the literal pre-generation expressions.

## Observability

`PerHiveEnvStatus` gains `KeyGenerations`, surfaced on the existing `GET /api/saas/admin/auth-rollout`:

```json
"key_generations": {
  "current": 3,
  "live_generations": [3, 2],
  "spokes_on_current": 61,
  "spokes_on_previous": 5,
  "spokes_unattributed": 0,
  "previous_verify_until": "2026-08-20T00:00:00Z",
  "safe_to_retire_previous": false
}
```

Counts come from the hub's **own Deployment reads**, never heartbeat recency — a paused spoke still has a Deployment, so it stays in the denominator and blocks retirement instead of silently dropping out the way `AuthRolloutReadiness`'s 24h staleness window lets it.

Attribution probes the **per-hive heartbeat key**, the only reconciled var that is both per-hive and a direct HMAC of the master: a match identifies the generation *and* the hive, so a stale-hive-ID drift can never be misread as a generation match. A key matching **no** live generation is counted as `spokes_unattributed` rather than folded into "previous" — it is broken now, not merely lagging, and it blocks retirement.

## Fail-closed properties preserved

- **The empty-value guard is unchanged, comment included.** An empty master still short-circuits before anything is derived, and every derived value is still re-checked for `""`. The reason is load-bearing: `HIVE_HEARTBEAT_KEY=""` falls back to the master exactly like an **absent** var, while making the readiness count report that hive as **converged**. A silently-wrong "converged" is worse than a visible drift.
- **A zero `VerifyUntil` reads as ALREADY EXPIRED** on the retirement surface, matching `acceptableGenerations`. Reading it as "never expires" would let a hand-edited generations file pin a previous generation live forever — the F1/F2 failure mode this design exists to make impossible.
- `safe_to_retire_previous` fails closed on zero observations, and additionally requires a previous generation to exist, zero spokes on it, zero unattributed, and the window closed.

## Tests

New `pkg/hub/perhive_env_generation_test.go`.

**On the test seam:** `provisionGenerationsOverride` exists because the rotated case is otherwise unreachable — with one generation, "derives from current" and "derives from the raw master" are indistinguishable and no test could tell them apart. `TestDesiredPerHiveEnvUsesCurrentNotPrevious` is the only test that can catch a revert of the core change; it asserts in both directions (matches current **and** differs from previous), with a positive control that the two fixture generations do not derive identical material.

Regression replay (neuter → compile → confirm fail → restore → confirm green), three neuters:

| Neuter | Failing test |
|---|---|
| `desiredPerHiveEnv` + provision helpers revert to `provisionMasterSecret()` | `TestDesiredPerHiveEnvUsesCurrentNotPrevious` (all 5 vars, both directions, + all 3 provision-lockstep assertions) |
| zero `VerifyUntil` treated as never-expires | `TestPerHiveEnvSafeToRetireIsGated/zero_verify_until_reads_as_already_expired,_not_never-expires` |
| attribution drops the per-hive binding | `TestPerHiveEnvGenerationAttribution` (3 subtests) |

The third neuter **initially passed while neutered** — every fixture in the file used `hive-alpha`, so hardcoding that ID was a no-op. Fixed by giving the classifier test a distinct subject hive ID and adding an explicit "classification is a function of the hiveID argument" positive control; it then failed correctly.

Full `pkg/hub` suite green.

## Existing test touched

`TestDesiredPerHiveEnvMatchesProvisioningTemplate` had the provisioning template's master expression copied verbatim into it. Updated to the generation-aware expression rather than **relaxed** — it still pins provision/reconcile agreement exactly, now at the generation level.