### PR TITLE
🔒 hub: heartbeat bearer bounded trial verification (rotation PR #2)

### DIFF
--- a/v2/pkg/hub/heartbeat_generation_test.go
+++ b/v2/pkg/hub/heartbeat_generation_test.go
@@ -1,0 +1,316 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Bounded trial verification of the HEARTBEAT BEARER across master generations
+// — follow-on PR #2 of the master-key rotation design.
+//
+// The bearer is the class of artifact that CANNOT carry a generation marker: it
+// IS the derived key, presented raw in the Authorization header, and its format
+// is a contract with deployed spoke Deployments and with SpokeHeartbeatKey()'s
+// self-derive lane. So the hub tries each live generation instead, bounded at
+// maxLiveGenerations == 2.
+//
+// !! THE F2 TESTS BELOW ARE THE POINT OF THIS FILE. !!
+//
+// F2 (Critical, open across five audits) was closed by deleting the FLEET-WIDE
+// heartbeat lane. Adding a second generation must add a second KEY, never a
+// second LANE — so every generation's candidate must remain identity-bound, and
+// TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration asserts exactly that
+// against both generations rather than only the current one.
+
+const (
+	hbHiveA = "hive-alpha"
+	hbHiveB = "hive-bravo"
+)
+
+// hbBearerFor is the bearer a spoke presents: the per-hive derivation from a
+// given master. This mirrors SpokeHeartbeatKey()'s self-derive lane and
+// provisionHeartbeatKey exactly.
+func hbBearerFor(master, hiveID string) string {
+	return derivePerHiveKey(master, infoHeartbeatKey, hiveID)
+}
+
+// TestHeartbeatBearerSurvivesRotation is THE test this change exists for. A
+// spoke that has not yet been reconciled onto the new master still holds a
+// bearer derived from the old one. Without dual acceptance every one of ~66
+// spokes 401s at the instant of rotation.
+func TestHeartbeatBearerSurvivesRotation(t *testing.T) {
+	now := time.Now()
+	before := legacyGenerationSet(genSecretA)
+	after := before.rotate(genSecretB, now, defaultVerifyWindow)
+	if after == nil {
+		t.Fatal("rotate returned nil")
+	}
+
+	old := hbBearerFor(genSecretA, hbHiveA)
+	if old == "" {
+		t.Fatal("precondition: could not derive the pre-rotation bearer")
+	}
+
+	gen, ok := verifyHeartbeatBearerAcrossGenerations(after, old, hbHiveA, now.Add(time.Minute))
+	if !ok {
+		t.Fatal("a bearer derived from the outgoing master must still verify during the window")
+	}
+	if gen != legacyGenerationID {
+		t.Errorf("accepting generation = %d, want %d (the outgoing one)", gen, legacyGenerationID)
+	}
+
+	// POSITIVE CONTROL. Against a hub that knows ONLY the new generation the
+	// same bearer must FAIL. Without this, an implementation that accepted any
+	// bearer would pass the assertion above.
+	onlyNew := legacyGenerationSet(genSecretB)
+	if _, ok := verifyHeartbeatBearerAcrossGenerations(onlyNew, old, hbHiveA, now.Add(time.Minute)); ok {
+		t.Error("positive control: a pre-rotation bearer must NOT verify against the new generation alone")
+	}
+}
+
+// TestHeartbeatBearerAcceptedUnderCurrentGeneration is the base case, and the
+// state of every already-reconciled spoke after a rotation.
+func TestHeartbeatBearerAcceptedUnderCurrentGeneration(t *testing.T) {
+	now := time.Now()
+	rotated := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+	cur, _ := rotated.currentGeneration()
+
+	fresh := hbBearerFor(genSecretB, hbHiveA)
+	gen, ok := verifyHeartbeatBearerAcrossGenerations(rotated, fresh, hbHiveA, now)
+	if !ok || gen != cur.ID {
+		t.Errorf("current-generation bearer: gen=%d ok=%v, want %d/true", gen, ok, cur.ID)
+	}
+
+	// And on a hub that has never rotated, the single generation accepts.
+	if gen, ok := verifyHeartbeatBearerAcrossGenerations(
+		legacyGenerationSet(genSecretA), hbBearerFor(genSecretA, hbHiveA), hbHiveA, now); !ok || gen != legacyGenerationID {
+		t.Errorf("un-rotated hub: gen=%d ok=%v, want %d/true", gen, ok, legacyGenerationID)
+	}
+}
+
+// TestHeartbeatBearerRejectedAfterGenerationExpires pins FINITENESS. This is
+// the property that stops dual acceptance from becoming the permanent compat
+// lane F2 was: past verify_until the old bearer stops working with no operator
+// action, whether or not anyone remembered the reconcile lane had stalled.
+func TestHeartbeatBearerRejectedAfterGenerationExpires(t *testing.T) {
+	now := time.Now()
+	after := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+	old := hbBearerFor(genSecretA, hbHiveA)
+
+	late := now.Add(defaultVerifyWindow + time.Minute)
+	if _, ok := verifyHeartbeatBearerAcrossGenerations(after, old, hbHiveA, late); ok {
+		t.Error("a bearer under an EXPIRED generation must be rejected")
+	}
+
+	// POSITIVE CONTROL 1: the same bearer INSIDE the window is accepted, so the
+	// rejection above is the expiry and not a broken verifier.
+	if _, ok := verifyHeartbeatBearerAcrossGenerations(after, old, hbHiveA, now.Add(time.Minute)); !ok {
+		t.Error("positive control: the same bearer inside the window must be accepted")
+	}
+	// POSITIVE CONTROL 2: at that same LATE moment the CURRENT generation's
+	// bearer still works — so the verifier has not simply stopped verifying.
+	if _, ok := verifyHeartbeatBearerAcrossGenerations(after, hbBearerFor(genSecretB, hbHiveA), hbHiveA, late); !ok {
+		t.Error("positive control: the current-generation bearer must still verify past the previous generation's expiry")
+	}
+}
+
+// TestHeartbeatBearerRejectsMissingVerifyUntil pins the fail-closed reading of a
+// hand-edited generations file. A previous generation with a ZERO VerifyUntil is
+// treated as ALREADY EXPIRED, never as "never expires" — the latter is precisely
+// the unbounded compat lane this design exists to prevent.
+func TestHeartbeatBearerRejectsMissingVerifyUntil(t *testing.T) {
+	now := time.Now()
+	const currentID = 2
+	handEdited := newGenerationSet(currentID, []keyGeneration{
+		{ID: currentID, Secret: genSecretB},
+		// No VerifyUntil — as a hand-edited file might have.
+		{ID: legacyGenerationID, Secret: genSecretA},
+	})
+	if handEdited == nil {
+		t.Fatal("precondition: could not build the hand-edited set")
+	}
+
+	if _, ok := verifyHeartbeatBearerAcrossGenerations(
+		handEdited, hbBearerFor(genSecretA, hbHiveA), hbHiveA, now); ok {
+		t.Error("a previous generation with NO verify_until must be treated as expired, not as never-expires")
+	}
+
+	// POSITIVE CONTROL: the current generation of that same set still verifies,
+	// so the rejection is about the missing expiry and not about the set being
+	// unusable.
+	if _, ok := verifyHeartbeatBearerAcrossGenerations(
+		handEdited, hbBearerFor(genSecretB, hbHiveA), hbHiveA, now); !ok {
+		t.Error("positive control: the current generation of the hand-edited set must verify")
+	}
+}
+
+// TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration IS THE F2 TEST.
+//
+// F2 was closed by deleting the fleet-wide lane, whose possession proved "some
+// provisioned spoke" and never "THIS hive" — and because handleHeartbeat trusts
+// the body-supplied hive_id, that let any spoke beat as any victim. Adding a
+// generation must not re-open it by ANY route, so this asserts the binding holds
+// for EVERY generation independently, not merely for the current one.
+func TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	acceptable := gs.acceptableGenerations(now)
+	if len(acceptable) != 2 {
+		t.Fatalf("precondition: want 2 acceptable generations, got %d — the cross-generation "+
+			"case this test exists for would not be exercised", len(acceptable))
+	}
+
+	for _, g := range acceptable {
+		bearerA := hbBearerFor(g.Secret, hbHiveA)
+		if bearerA == "" {
+			t.Fatalf("gen %d: could not derive hive A's bearer", g.ID)
+		}
+
+		// Hive A's bearer, from THIS generation, must be rejected for hive B.
+		if _, ok := verifyHeartbeatBearerAcrossGenerations(gs, bearerA, hbHiveB, now); ok {
+			t.Errorf("F2 REGRESSION: hive %q's bearer from generation %d authenticated as hive %q",
+				hbHiveA, g.ID, hbHiveB)
+		}
+
+		// POSITIVE CONTROL: that same bearer IS accepted for hive A, so the
+		// rejection above is the identity binding and not a dead verifier.
+		if _, ok := verifyHeartbeatBearerAcrossGenerations(gs, bearerA, hbHiveA, now); !ok {
+			t.Errorf("positive control: generation %d's bearer for hive %q must verify for hive %q",
+				g.ID, hbHiveA, hbHiveA)
+		}
+	}
+}
+
+// TestHeartbeatFleetWideLaneStaysDeletedUnderGenerations is the second half of
+// F2. The deleted lane was deriveDomainKey(master, infoHeartbeatKey) — no hive
+// ID in the derivation, so one value worked everywhere. It must not verify under
+// ANY generation. If it does, the rotation work re-opened a Critical finding.
+func TestHeartbeatFleetWideLaneStaysDeletedUnderGenerations(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	for _, master := range []string{genSecretA, genSecretB} {
+		fleetWide := deriveDomainKey(master, infoHeartbeatKey)
+		if fleetWide == "" {
+			t.Fatal("precondition: could not derive the fleet-wide value")
+		}
+		for _, hive := range []string{hbHiveA, hbHiveB} {
+			if _, ok := verifyHeartbeatBearerAcrossGenerations(gs, fleetWide, hive, now); ok {
+				t.Errorf("F2 REGRESSION: the FLEET-WIDE bearer authenticated hive %q", hive)
+			}
+		}
+	}
+
+	// The RAW master must not authenticate either — that was the even older
+	// pre-N1 credential.
+	for _, master := range []string{genSecretA, genSecretB} {
+		if _, ok := verifyHeartbeatBearerAcrossGenerations(gs, master, hbHiveA, now); ok {
+			t.Error("the RAW master authenticated a heartbeat — pre-N1 lane resurrected")
+		}
+	}
+
+	// POSITIVE CONTROL: the per-hive bearer from each generation still verifies,
+	// so the rejections above are about the LANE and not about a verifier that
+	// rejects everything.
+	for _, master := range []string{genSecretA, genSecretB} {
+		if _, ok := verifyHeartbeatBearerAcrossGenerations(gs, hbBearerFor(master, hbHiveA), hbHiveA, now); !ok {
+			t.Error("positive control: the per-hive bearer must verify under its own generation")
+		}
+	}
+}
+
+// TestHeartbeatBearerFailsClosed pins the fail-closed edges: no bearer, no hive
+// ID, no generation set. An identity-less caller must authenticate nothing no
+// matter how many generations exist — derivePerHiveKey returns "" for an empty
+// hive ID rather than silently falling back to a shared key, and that is what
+// keeps the F2 fix load-bearing rather than incidental.
+func TestHeartbeatBearerFailsClosed(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow)
+
+	cases := []struct {
+		name           string
+		gs             *generationSet
+		bearer, hiveID string
+	}{
+		{"empty bearer", gs, "", hbHiveA},
+		{"empty hive id", gs, hbBearerFor(genSecretB, hbHiveA), ""},
+		{"both empty", gs, "", ""},
+		{"nil generation set", nil, hbBearerFor(genSecretB, hbHiveA), hbHiveA},
+	}
+	for _, tc := range cases {
+		if _, ok := verifyHeartbeatBearerAcrossGenerations(tc.gs, tc.bearer, tc.hiveID, now); ok {
+			t.Errorf("%s: must not authenticate", tc.name)
+		}
+	}
+
+	// POSITIVE CONTROL: the fully-populated call succeeds.
+	if _, ok := verifyHeartbeatBearerAcrossGenerations(gs, hbBearerFor(genSecretB, hbHiveA), hbHiveA, now); !ok {
+		t.Error("positive control: a well-formed bearer must verify")
+	}
+}
+
+// TestHeartbeatTrialIsBounded pins the cost argument. Trial verification is only
+// acceptable because maxLiveGenerations caps it — an unbounded set would turn
+// every heartbeat into unbounded HMAC work and hand an attacker a cheap
+// asymmetric cost. Stack more rotations than the cap allows and the set must
+// still never exceed it.
+func TestHeartbeatTrialIsBounded(t *testing.T) {
+	now := time.Now()
+	gs := legacyGenerationSet(genSecretA)
+	for i := 0; i < 5; i++ {
+		gs = gs.rotate(genSecretB, now, defaultVerifyWindow)
+		if gs == nil {
+			t.Fatal("rotate returned nil")
+		}
+		if n := len(gs.acceptableGenerations(now)); n > maxLiveGenerations {
+			t.Fatalf("after %d rotations the verifier would try %d generations, cap is %d",
+				i+1, n, maxLiveGenerations)
+		}
+	}
+}
+
+// TestHubServerHeartbeatBearerUsesGenerations pins the SERVER wiring, not just
+// the free function — a correct helper that nothing calls would not have fixed
+// anything. It drives HubServer.verifyHeartbeatBearer, which is what
+// handleHeartbeat actually calls.
+func TestHubServerHeartbeatBearerUsesGenerations(t *testing.T) {
+	now := time.Now()
+	s := &HubServer{
+		hubSecret:      genSecretB,
+		keyGenerations: legacyGenerationSet(genSecretA).rotate(genSecretB, now, defaultVerifyWindow),
+	}
+
+	// Current-generation bearer.
+	if !s.verifyHeartbeatBearer(hbBearerFor(genSecretB, hbHiveA), hbHiveA) {
+		t.Error("the current-generation bearer must authenticate through the server")
+	}
+	// Previous-generation bearer — the not-yet-reconciled spoke.
+	if !s.verifyHeartbeatBearer(hbBearerFor(genSecretA, hbHiveA), hbHiveA) {
+		t.Error("a pre-rotation bearer must authenticate through the server during the window")
+	}
+	// F2 through the server: cross-hive must fail under BOTH generations.
+	for _, master := range []string{genSecretA, genSecretB} {
+		if s.verifyHeartbeatBearer(hbBearerFor(master, hbHiveA), hbHiveB) {
+			t.Error("F2 REGRESSION via HubServer: hive A's bearer authenticated as hive B")
+		}
+	}
+	// The telemetry accessor agrees that both are per-hive, so the auth-rollout
+	// surface does not report a phantom regression mid-rotation.
+	for _, master := range []string{genSecretA, genSecretB} {
+		if !s.heartbeatBearerIsPerHive(hbBearerFor(master, hbHiveA), hbHiveA) {
+			t.Error("heartbeatBearerIsPerHive must recognize a per-hive bearer from EITHER generation")
+		}
+	}
+
+	// A server with NO generation set falls back to the single-master path
+	// unchanged — hand-built test servers must not start failing closed.
+	legacy := &HubServer{hubSecret: genSecretA}
+	if !legacy.verifyHeartbeatBearer(hbBearerFor(genSecretA, hbHiveA), hbHiveA) {
+		t.Error("a server with no generation set must still verify on the single-master path")
+	}
+	if legacy.verifyHeartbeatBearer(hbBearerFor(genSecretA, hbHiveA), hbHiveB) {
+		t.Error("F2 REGRESSION on the single-master fallback: cross-hive authenticated")
+	}
+}

--- a/v2/pkg/hub/heartbeat_handler_coverage_test.go
+++ b/v2/pkg/hub/heartbeat_handler_coverage_test.go
@@ -69,7 +69,7 @@ func TestHandleHeartbeatUnauthorized(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	s := newHeartbeatHub()
-	s.hubSecret = "top-secret"
+	s.setHubSecret("top-secret")
 
 	req := httptest.NewRequest(http.MethodPost, "/api/heartbeat", strings.NewReader(`{"hive_id":"h1"}`))
 	req.Header.Set("Content-Type", "application/json")

--- a/v2/pkg/hub/heartbeat_visibility_preserve_test.go
+++ b/v2/pkg/hub/heartbeat_visibility_preserve_test.go
@@ -42,7 +42,7 @@ func TestHeartbeatPreservesHubSetPrivate(t *testing.T) {
 	}
 
 	srv := NewHubServer(0, slog.Default(), "test", "v4")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// The placeholder spoke reports its provisioning default: is_public=true.
 	body := `{"hive_id":"` + hiveID + `","org":"available-oke-260812-test","is_public":true}`
@@ -111,7 +111,7 @@ func TestHeartbeatPreservesHubSetPrivateOnFirstBeat(t *testing.T) {
 	}
 
 	srv := NewHubServer(0, slog.Default(), "test", "v4")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	body := `{"hive_id":"` + hiveID + `","org":"available-oke-260812-fresh","is_public":true}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(body))

--- a/v2/pkg/hub/hive_namespace_overlay_test.go
+++ b/v2/pkg/hub/hive_namespace_overlay_test.go
@@ -36,7 +36,7 @@ func TestHeartbeatOverlaysHostedNamespace(t *testing.T) {
 
 	t.Run("hosted hive with a SaaSHive record gets hive-hosted-<id>", func(t *testing.T) {
 		srv := NewHubServer(0, slog.Default(), "test", "v2")
-		srv.hubSecret = ""
+		srv.setHubSecret("")
 
 		const hiveID = "hosted-available-oke-07-placeholder-a1b2"
 		if err := saveSaaSHive(&SaaSHive{
@@ -63,7 +63,7 @@ func TestHeartbeatOverlaysHostedNamespace(t *testing.T) {
 
 	t.Run("hive with no SaaSHive record keeps Namespace empty", func(t *testing.T) {
 		srv := NewHubServer(0, slog.Default(), "test", "v2")
-		srv.hubSecret = ""
+		srv.setHubSecret("")
 
 		// No saveSaaSHive: this is a self-hosted/BYO spoke the hub did not
 		// provision, so it does not run in a hive-hosted-<id> namespace and the

--- a/v2/pkg/hub/hub_coverage_boost_test.go
+++ b/v2/pkg/hub/hub_coverage_boost_test.go
@@ -500,7 +500,7 @@ func TestGhcrTagExistsWithMock(t *testing.T) {
 
 func TestHandleHeartbeatValidPayload(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := HeartbeatPayload{
 		HiveID:       "test-hive",
@@ -536,7 +536,7 @@ func TestHandleHeartbeatValidPayload(t *testing.T) {
 
 func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"","org":"test"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -552,7 +552,7 @@ func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
 
 func TestHandleHeartbeatInvalidHiveID(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	// sanitizeHeartbeatField strips most chars; use a string that becomes >100 chars of valid chars
 	longID := strings.Repeat("a", 101)
@@ -570,7 +570,7 @@ func TestHandleHeartbeatInvalidHiveID(t *testing.T) {
 
 func TestHandleHeartbeatInvalidOrg(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","org":"bad org name!"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -586,7 +586,7 @@ func TestHandleHeartbeatInvalidOrg(t *testing.T) {
 
 func TestHandleHeartbeatInvalidRepo(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	// Use a repo name that's >100 chars (too long for isValidName)
 	longRepo := strings.Repeat("r", 101)
@@ -604,7 +604,7 @@ func TestHandleHeartbeatInvalidRepo(t *testing.T) {
 
 func TestHandleHeartbeatInvalidRepoInList(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","repos":["good-repo","bad repo!"]}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -620,7 +620,7 @@ func TestHandleHeartbeatInvalidRepoInList(t *testing.T) {
 
 func TestHandleHeartbeatBadDashboardURL(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","dashboard_url":"ftp://bad-scheme.com"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -636,7 +636,7 @@ func TestHandleHeartbeatBadDashboardURL(t *testing.T) {
 
 func TestHandleHeartbeatBadSnapshotURL(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","snapshot_url":"ftp://bad.com"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -652,7 +652,7 @@ func TestHandleHeartbeatBadSnapshotURL(t *testing.T) {
 
 func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","agents":[{"name":"bad agent!","state":"running"}]}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -668,7 +668,7 @@ func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
 
 func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "test-secret"
+	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","leaderboard":[{"github_username":"bad user!"}]}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -684,7 +684,7 @@ func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
 
 func TestHandleHeartbeatNoSecretRequired(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	payload := `{"hive_id":"valid-id"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -699,7 +699,7 @@ func TestHandleHeartbeatNoSecretRequired(t *testing.T) {
 
 func TestHandleHeartbeatWrongSecret(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "correct-secret"
+	srv.setHubSecret("correct-secret")
 
 	payload := `{"hive_id":"valid-id"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -715,7 +715,7 @@ func TestHandleHeartbeatWrongSecret(t *testing.T) {
 
 func TestHandleHeartbeatExistingHive(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Pre-populate a hive
 	srv.mu.Lock()
@@ -795,7 +795,7 @@ func TestHandleHeartbeatHostedHiveRejectedWithoutSaaS(t *testing.T) {
 
 func TestHandleTaskStatusNoAuth(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "secret"
+	srv.setHubSecret("secret")
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
@@ -809,7 +809,7 @@ func TestHandleTaskStatusNoAuth(t *testing.T) {
 
 func TestHandleTaskStatusValid(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "secret"
+	srv.setHubSecret("secret")
 
 	// Pre-populate a hive in registry
 	srv.mu.Lock()
@@ -832,7 +832,7 @@ func TestHandleTaskStatusValid(t *testing.T) {
 
 func TestHandleTaskStatusBadJSON(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "secret"
+	srv.setHubSecret("secret")
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("not json"))
 	req.Header.Set("Authorization", heartbeatBearer("secret", "anything"))
@@ -847,7 +847,7 @@ func TestHandleTaskStatusBadJSON(t *testing.T) {
 
 func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "secret"
+	srv.setHubSecret("secret")
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(`{"hive_id":""}`))
 	req.Header.Set("Authorization", heartbeatBearer("secret", ""))
@@ -862,7 +862,7 @@ func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
 
 func TestHandleTaskStatusOfflineHive(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "secret"
+	srv.setHubSecret("secret")
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -2172,7 +2172,7 @@ func TestHandleDenyAccessNotFound(t *testing.T) {
 
 func TestHandleHeartbeatWithClusterHealth(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	payload := HeartbeatPayload{
 		HiveID: "health-hive",
@@ -2209,7 +2209,7 @@ func TestHandleHeartbeatWithClusterHealth(t *testing.T) {
 
 func TestHandleHeartbeatResponseContainsFields(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Set up a latestSHA
 	latestSHAMu.Lock()

--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -768,7 +768,7 @@ func TestHandleAuthUserKnownButNotInFile(t *testing.T) {
 
 func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Set latest SHA
 	latestSHAMu.Lock()
@@ -799,7 +799,7 @@ func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 
 func TestHandleHeartbeatAutoUpgradeNoUpgradeNeeded(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	latestSHAMu.Lock()
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "current", Message: "current"}
@@ -825,7 +825,7 @@ func TestHandleHeartbeatAutoUpgradeNoUpgradeNeeded(t *testing.T) {
 
 func TestHandleHeartbeatAutoUpgradeEmptyGitHash(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	latestSHAMu.Lock()
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "target2", Message: "latest"}
@@ -852,7 +852,7 @@ func TestHandleHeartbeatAutoUpgradeEmptyGitHash(t *testing.T) {
 
 func TestHandleHeartbeatDefaultBranch(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// No git_branch → defaults to "v2"
 	payload := `{"hive_id":"default-branch"}`

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -677,7 +677,7 @@ func TestHandleDenyRequestHiveNotFound(t *testing.T) {
 
 func TestHandleHeartbeatUpdateExistingWithSparkline(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Pre-populate a hive with sparkline data from 20 minutes ago
 	oldTime := time.Now().Add(-20 * time.Minute).Unix()
@@ -723,7 +723,7 @@ func TestHandleHeartbeatUpdateExistingWithSparkline(t *testing.T) {
 
 func TestHandleHeartbeatUpgradeCompleted(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -762,7 +762,7 @@ func TestHandleHeartbeatUpgradeCompleted(t *testing.T) {
 
 func TestHandleHeartbeatUpgradeInProgress(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -805,7 +805,7 @@ func TestHandleHeartbeatUpgradeInProgress(t *testing.T) {
 
 func TestHandleHeartbeatResponseAutoUpgrade(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Set up a latestSHA for v2
 	latestSHAMu.Lock()
@@ -848,7 +848,7 @@ func TestHandleHeartbeatResponseAutoUpgrade(t *testing.T) {
 
 func TestHandleHeartbeatStoresClusterHealth(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	payload := HeartbeatPayload{
 		HiveID:    "health-store-hive",
@@ -1048,7 +1048,7 @@ func TestDecryptTokenWithBadCiphertext(t *testing.T) {
 
 func TestHandleHeartbeatTriggersRegistrySave(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	payload := `{"hive_id":"save-trigger-hive"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -1222,7 +1222,7 @@ func TestHandleHeartbeatSaaSHivePrefix(t *testing.T) {
 
 func TestHandleHeartbeatUpgradingFlag(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	payload := `{"hive_id":"upgrading-flag-test","upgrading":true,"upgrade_target_sha":"7a41e01"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -1285,7 +1285,7 @@ func TestGetLatestSHAForBranchNotFound(t *testing.T) {
 
 func TestHandleHeartbeatHiveTypeExplicit(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	payload := `{"hive_id":"explicit-type","hive_type":"custom-type"}`
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
@@ -1310,7 +1310,7 @@ func TestHandleHeartbeatHiveTypeExplicit(t *testing.T) {
 
 func TestHandleHeartbeatMaxAgents(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Create 60 agents to test the max agents cap (50)
 	agents := make([]AgentSummary, 60)
@@ -1345,7 +1345,7 @@ func TestHandleHeartbeatMaxAgents(t *testing.T) {
 
 func TestHandleHeartbeatSnapshotURL(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// First heartbeat with snapshot
 	payload1 := `{"hive_id":"snapshot-hive","snapshot_url":"https://snap.example.com/1"}`

--- a/v2/pkg/hub/hub_heartbeat_test.go
+++ b/v2/pkg/hub/hub_heartbeat_test.go
@@ -325,7 +325,7 @@ func TestSendHeartbeatAutoUpgradeInPayload(t *testing.T) {
 
 func TestHeartbeatNoUpgradeToForHubManagedHives(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Simulate a heartbeat from a spoke with auto_upgrade=true
 	// but the hub also has AutoUpgrade on the SaaS hive — hub-managed
@@ -360,7 +360,7 @@ func TestHeartbeatNoUpgradeToForHubManagedHives(t *testing.T) {
 
 func TestHeartbeatUpgradeToForSpokeManaged(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Spoke declares auto_upgrade but no SaaS hive exists on hub
 	// (unreachable spoke) — should get UpgradeTo if SHA differs

--- a/v2/pkg/hub/hub_heartbeat_tokens_test.go
+++ b/v2/pkg/hub/hub_heartbeat_tokens_test.go
@@ -14,7 +14,7 @@ import (
 // My Hives token column.
 func TestHeartbeatStoresTokenTotal(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	const wantTokens = int64(1234567)
 	payload := `{
@@ -50,7 +50,7 @@ func TestHeartbeatStoresTokenTotal(t *testing.T) {
 // maximum so a corrupt/hostile spoke cannot inject an absurd value.
 func TestHeartbeatTokenTotalClamped(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	payload := `{
 		"hive_id":"clamphive",

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"os"
 	"strings"
+	"time"
 )
 
 // Domain-separated key derivation for the hub master secret (CWE-321/798, C2).
@@ -239,12 +240,127 @@ func (s *HubServer) heartbeatKeyFor(hiveID string) string {
 //
 // Fails closed: an empty bearer, or an empty hiveID (which makes the per-hive
 // derivation return ""), authenticates nothing. The comparison is constant-time.
+//
+// ROTATION (master-key-rotation.md, follow-on PR #2): the bearer is tried
+// against the per-hive derivation from EVERY master generation the hub still
+// accepts, current first. See verifyHeartbeatBearerAcrossGenerations for why
+// trial verification is the only option here and why it does NOT re-open F2.
 func (s *HubServer) verifyHeartbeatBearer(presented, hiveID string) bool {
-	if presented == "" {
-		return false
+	_, ok := s.verifyHeartbeatBearerGeneration(presented, hiveID)
+	return ok
+}
+
+// setHubSecret replaces the hub's master AND the generation set derived from it,
+// keeping the two in lockstep.
+//
+// These are two representations of ONE fact, and once any verifier reads the
+// generation set (this PR makes the heartbeat the second such verifier, after
+// the impersonation cookie), assigning s.hubSecret alone leaves the hub deriving
+// keys from a master it no longer believes it has. That drift is silent: the
+// build is fine, the types are fine, and the only symptom is a 401.
+//
+// Setting a fresh master necessarily DISCARDS any previous generations — there
+// is no basis on which to keep verifying against generations of a master that is
+// being replaced wholesale rather than rotated. A real rotation goes through
+// generationSet.rotate, which is what preserves the outgoing generation.
+func (s *HubServer) setHubSecret(secret string) {
+	if s == nil {
+		return
+	}
+	s.hubSecret = secret
+	s.keyGenerations = legacyGenerationSet(secret)
+}
+
+// verifyHeartbeatBearerGeneration is verifyHeartbeatBearer with the accepting
+// master generation reported, so an operator can see whether any spoke is still
+// authenticating with pre-rotation material rather than having to infer it.
+//
+// keyGenerations is nil only in hand-built test servers. Those fall back to the
+// single-master path so this stays a pure addition of a second KEY rather than
+// a change to what authenticates.
+func (s *HubServer) verifyHeartbeatBearerGeneration(presented, hiveID string) (int, bool) {
+	if s == nil || presented == "" {
+		return 0, false
+	}
+	if s.keyGenerations != nil {
+		return verifyHeartbeatBearerAcrossGenerations(s.keyGenerations, presented, hiveID, time.Now())
 	}
 	perHive := s.heartbeatKeyFor(hiveID)
-	return perHive != "" && secureCompareHub(presented, perHive)
+	if perHive != "" && secureCompareHub(presented, perHive) {
+		return legacyGenerationID, true
+	}
+	return 0, false
+}
+
+// verifyHeartbeatBearerAcrossGenerations is BOUNDED TRIAL VERIFICATION of the
+// heartbeat bearer against every live master generation.
+//
+// WHY TRIAL AND NOT A MARKER. The bearer IS the derived key, presented raw in
+// the Authorization header — there is no envelope to put a "g<N>." in. Its
+// format is also a contract with already-deployed spoke Deployments
+// (HIVE_HEARTBEAT_KEY) and with SpokeHeartbeatKey()'s self-derive lane, so
+// changing the format would make the rotation mechanism itself require the
+// fleet-wide flag day it exists to avoid. Trial verification is what the design
+// prescribes for exactly this class of artifact.
+//
+// THE BOUND IS THE WHOLE ARGUMENT. maxLiveGenerations == 2, so the worst case is
+// two HMAC computations where there was one — strictly less than the rest of a
+// heartbeat already costs, and an attacker cannot use it as an asymmetric-cost
+// lever because the count is capped by the loader rather than by anything the
+// caller supplies.
+//
+// !! AUDIT F2 (Critical, open across five audits) MUST NOT REGRESS. !!
+//
+// F2 was closed by DELETING the fleet-wide lane — deriveDomainKey(master,
+// infoHeartbeatKey), a value stamped byte-identically into every spoke, whose
+// possession proved "some provisioned spoke" and never "THIS hive". Because
+// handleHeartbeat trusts the body-supplied hive_id, that lane let any spoke beat
+// as any victim and be handed the victim's key material.
+//
+// This function adds a second GENERATION, not a second LANE. Every candidate
+// below is derivePerHiveKey(g.Secret, infoHeartbeatKey, hiveID) — identity-bound
+// under EVERY generation, and derivePerHiveKey returns "" for an empty hiveID so
+// an identity-less caller authenticates nothing no matter how many generations
+// exist. There is deliberately no code path here that derives without hiveID; if
+// one ever appears, F2 is re-opened.
+//
+// TIMING. Every attempt uses secureCompareHub (subtle.ConstantTimeCompare), and
+// the loop deliberately does NOT return early on a match: it ORs the results and
+// evaluates every acceptable generation regardless. Early return would leak,
+// through response latency, WHICH generation accepted a bearer — which is a
+// (small) oracle telling an attacker whether a given spoke has converged onto
+// the new key, and therefore which spokes are still holding material derived
+// from a master the operator is trying to retire. Two HMACs is cheap enough that
+// there is no reason to buy anything with that leak.
+//
+// Returns the accepting generation ID, which is 0 when nothing accepted.
+func verifyHeartbeatBearerAcrossGenerations(gs *generationSet, presented, hiveID string, now time.Time) (int, bool) {
+	if presented == "" || hiveID == "" {
+		return 0, false
+	}
+	acceptable := gs.acceptableGenerations(now)
+	if len(acceptable) == 0 {
+		return 0, false
+	}
+	matched := 0
+	for _, g := range acceptable {
+		// F2: identity-bound under EVERY generation. Never deriveDomainKey.
+		perHive := derivePerHiveKey(g.Secret, infoHeartbeatKey, hiveID)
+		if perHive == "" {
+			continue
+		}
+		// The compare is on its OWN line, unconditionally, so it runs for every
+		// acceptable generation. Folding it into the `if` below as
+		// `secureCompareHub(...) && matched == 0` would work today only because
+		// Go evaluates the left operand first — a reordering during some future
+		// tidy-up would silently reintroduce the early-exit timing leak. Keep
+		// them separate.
+		ok := secureCompareHub(presented, perHive)
+		if ok && matched == 0 {
+			matched = g.ID
+		}
+	}
+	return matched, matched != 0
 }
 
 // heartbeatBearerIsPerHive reports whether the presented bearer is the
@@ -255,7 +371,22 @@ func (s *HubServer) verifyHeartbeatBearer(presented, hiveID string) bool {
 // confirm none regressed. Post-F2 a bearer that is not per-hive no longer
 // verifies at all, so callers observe this only for bearers that already passed
 // verifyHeartbeatBearer.
+//
+// ROTATION: this must consider every live generation for the same reason the
+// verifier does. A spoke that has not yet been reconciled onto the new master
+// presents a bearer derived from the PREVIOUS generation — still per-hive, still
+// identity-bound, still accepted. Checking only the current generation would
+// report it as "not per-hive" and make the auth-rollout surface show a fleet-wide
+// F2 regression that has not happened, during exactly the window an operator is
+// watching that surface most closely.
 func (s *HubServer) heartbeatBearerIsPerHive(presented, hiveID string) bool {
+	if s == nil {
+		return false
+	}
+	if s.keyGenerations != nil {
+		_, ok := verifyHeartbeatBearerAcrossGenerations(s.keyGenerations, presented, hiveID, time.Now())
+		return ok
+	}
 	perHive := s.heartbeatKeyFor(hiveID)
 	return perHive != "" && secureCompareHub(presented, perHive)
 }

--- a/v2/pkg/hub/hub_saas_handlers_test.go
+++ b/v2/pkg/hub/hub_saas_handlers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestHandleLoginRedirect(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Register OAuth routes manually (won't register without env var)
 	srv.mux.HandleFunc("GET /login", srv.handleLogin)
@@ -33,7 +33,7 @@ func TestHandleLoginRedirect(t *testing.T) {
 
 func TestHandleLoginWithRedirectParam(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /login-test", srv.handleLogin)
 
 	req := httptest.NewRequest("GET", "/login-test?redirect=/dashboard", nil)
@@ -51,7 +51,7 @@ func TestHandleLoginWithRedirectParam(t *testing.T) {
 
 func TestHandleLoginRejectsOpenRedirect(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /login-redir", srv.handleLogin)
 
 	req := httptest.NewRequest("GET", "/login-redir?redirect=//evil.com", nil)
@@ -66,7 +66,7 @@ func TestHandleLoginRejectsOpenRedirect(t *testing.T) {
 
 func TestHandleLoginRdParam(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /login-rd", srv.handleLogin)
 
 	req := httptest.NewRequest("GET", "/login-rd?rd=/my-page", nil)
@@ -80,7 +80,7 @@ func TestHandleLoginRdParam(t *testing.T) {
 
 func TestHandleLogout(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("POST /logout-test", srv.handleLogout)
 
 	req := httptest.NewRequest("POST", "/logout-test", nil)
@@ -104,7 +104,7 @@ func TestHandleLogout(t *testing.T) {
 
 func TestHandleAuthUserNoCookie(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /auth-user-test", srv.handleAuthUser)
 
 	req := httptest.NewRequest("GET", "/auth-user-test", nil)
@@ -120,7 +120,7 @@ func TestHandleAuthUserNoCookie(t *testing.T) {
 
 func TestHandleAuthUserEmptyCookie(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /auth-user-empty", srv.handleAuthUser)
 
 	req := httptest.NewRequest("GET", "/auth-user-empty", nil)
@@ -137,7 +137,7 @@ func TestHandleAuthUserEmptyCookie(t *testing.T) {
 
 func TestHandleAuthUserUnknownUser(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /auth-user-unknown", srv.handleAuthUser)
 
 	req := httptest.NewRequest("GET", "/auth-user-unknown", nil)
@@ -154,7 +154,7 @@ func TestHandleAuthUserUnknownUser(t *testing.T) {
 
 func TestHandleAdminUsersAsAdmin(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Call handler directly to skip requireAdmin middleware (no /data on macOS)
 	req := httptest.NewRequest("GET", "/api/saas/admin/users", nil)
@@ -174,7 +174,7 @@ func TestHandleAdminUsersAsAdmin(t *testing.T) {
 
 func TestHandleAdminUpdateUserNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Call directly to skip requireAdmin
 	mux := http.NewServeMux()
@@ -191,7 +191,7 @@ func TestHandleAdminUpdateUserNotFound(t *testing.T) {
 
 func TestHandleAdminUpdateUserBadJSON(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/admin/users/{username}", srv.handleAdminUpdateUser)
@@ -207,7 +207,7 @@ func TestHandleAdminUpdateUserBadJSON(t *testing.T) {
 
 func TestHandleHiveStatusNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
@@ -222,7 +222,7 @@ func TestHandleHiveStatusNotFound(t *testing.T) {
 
 func TestHandleDeleteHiveNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
@@ -238,7 +238,7 @@ func TestHandleDeleteHiveNotFound(t *testing.T) {
 
 func TestHandleDeleteHivePathTraversal(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
@@ -253,7 +253,7 @@ func TestHandleDeleteHivePathTraversal(t *testing.T) {
 
 func TestHandleUpgradeHiveCORSPreflight(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Register directly to avoid requireAuth for OPTIONS
 	srv.mux.HandleFunc("OPTIONS /upgrade-test/{id}", srv.handleUpgradeHive)
@@ -273,7 +273,7 @@ func TestHandleUpgradeHiveCORSPreflight(t *testing.T) {
 
 func TestHandleUpgradeHiveNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/upgrade", srv.handleUpgradeHive)
@@ -289,7 +289,7 @@ func TestHandleUpgradeHiveNotFound(t *testing.T) {
 
 func TestHandleAccessListNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/access", srv.handleAccessList)
@@ -304,7 +304,7 @@ func TestHandleAccessListNotFound(t *testing.T) {
 
 func TestHandleAccessAddNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
@@ -321,7 +321,7 @@ func TestHandleAccessAddNotFound(t *testing.T) {
 
 func TestHandleAccessRemoveNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", srv.handleAccessRemove)
@@ -336,7 +336,7 @@ func TestHandleAccessRemoveNotFound(t *testing.T) {
 
 func TestHandleRequestAccessNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
@@ -351,7 +351,7 @@ func TestHandleRequestAccessNotFound(t *testing.T) {
 
 func TestHandleGetRequestsNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/requests", srv.handleGetRequests)
@@ -366,7 +366,7 @@ func TestHandleGetRequestsNotFound(t *testing.T) {
 
 func TestHandleApproveRequestNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", srv.handleApproveRequest)
@@ -382,7 +382,7 @@ func TestHandleApproveRequestNotFound(t *testing.T) {
 
 func TestHandleDenyRequestNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", srv.handleDenyRequest)
@@ -397,7 +397,7 @@ func TestHandleDenyRequestNotFound(t *testing.T) {
 
 func TestHandleCreateHiveNoAuth(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -412,7 +412,7 @@ func TestHandleCreateHiveNoAuth(t *testing.T) {
 
 func TestHandleCreateHiveBadJSON(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Call handler directly to skip requireAuth
 	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{invalid`))
@@ -428,7 +428,7 @@ func TestHandleCreateHiveBadJSON(t *testing.T) {
 
 func TestHandleCreateHiveValidation(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	tests := []struct {
 		name string
@@ -460,7 +460,7 @@ func TestHandleCreateHiveValidation(t *testing.T) {
 
 func TestHandleUserTokenBadBody(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("POST", "/user-token-test", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -474,7 +474,7 @@ func TestHandleUserTokenBadBody(t *testing.T) {
 
 func TestHandleUserTokenMissingFields(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("POST", "/user-token-test", strings.NewReader(`{"hive_id":"h1"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -488,7 +488,7 @@ func TestHandleUserTokenMissingFields(t *testing.T) {
 
 func TestHandleUserTokenOtherUserForbidden(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	body := `{"hive_id":"h1","username":"otheruser"}`
 	req := httptest.NewRequest("POST", "/user-token-test", strings.NewReader(body))
@@ -504,7 +504,7 @@ func TestHandleUserTokenOtherUserForbidden(t *testing.T) {
 
 func TestHandleUserTokenUserNotFound(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// getAuthUser returns "" on macOS, so requester="" != username → 403
 	// Admin can request any user's token
@@ -523,7 +523,7 @@ func TestHandleUserTokenUserNotFound(t *testing.T) {
 
 func TestHandleProxyHiveConfigNotInRegistry(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/proxy-config-test", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
@@ -543,7 +543,7 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 	defer func() { hiveConfigSSRFGuard = orig }()
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// The upstream must NOT be reached: this registry entry is ownerless, and
 	// after the F9 fix an ownerless hive's config is not world-readable. The
@@ -580,7 +580,7 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 
 func TestHandleMyHivesNoAuthDirect(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/my-hives-test", nil)
 	w := httptest.NewRecorder()
@@ -593,7 +593,7 @@ func TestHandleMyHivesNoAuthDirect(t *testing.T) {
 
 func TestHandleMyHivesWithRegistryHives(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -614,7 +614,7 @@ func TestHandleMyHivesWithRegistryHives(t *testing.T) {
 
 func TestHandleSaaSAuthCheckNoHive(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check", nil)
 	w := httptest.NewRecorder()
@@ -627,7 +627,7 @@ func TestHandleSaaSAuthCheckNoHive(t *testing.T) {
 
 func TestHandleSaaSAuthCheckNoAuthWithHive(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 	w := httptest.NewRecorder()
@@ -640,7 +640,7 @@ func TestHandleSaaSAuthCheckNoAuthWithHive(t *testing.T) {
 
 func TestHandleSaaSAuthCheckWithUserNoAccess(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "someuser"})
@@ -684,7 +684,7 @@ func TestDecryptTokenTooShort(t *testing.T) {
 
 func TestHandleDashboardUnfurlBotReturnsOG(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
 	req.Header.Set("User-Agent", "Slackbot-LinkExpanding 1.0")
@@ -701,7 +701,7 @@ func TestHandleDashboardUnfurlBotReturnsOG(t *testing.T) {
 
 func TestHandleDashboardNoCookieRedirects(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
 	w := httptest.NewRecorder()
@@ -717,7 +717,7 @@ func TestHandleDashboardNoCookieRedirects(t *testing.T) {
 
 func TestHandleDashboardWithCookieReturnsDashboard(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "testuser"})
@@ -734,7 +734,7 @@ func TestHandleDashboardWithCookieReturnsDashboard(t *testing.T) {
 
 func TestRequireAuthBlockedUser(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// On macOS, loadSaaSUser returns nil (no /data/saas/users)
 	// So requireAuth calls ensureSaaSUser which tries to create, fails, then loads again → nil → 401
@@ -755,7 +755,7 @@ func TestRequireAuthBlockedUser(t *testing.T) {
 
 func TestHandleOAuthCallbackMissingCode(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /callback-test", srv.handleOAuthCallback)
 
 	req := httptest.NewRequest("GET", "/callback-test", nil)
@@ -769,7 +769,7 @@ func TestHandleOAuthCallbackMissingCode(t *testing.T) {
 
 func TestHandleOAuthCallbackWithCode(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// With a code present, it tries to exchange with GitHub (ghTokenURL const)
 	// which will fail with network error → 502
@@ -831,7 +831,7 @@ func TestIsUnfurlBotVariants(t *testing.T) {
 
 func TestValidateGitHubTokenInvalid(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Will try to call GitHub API and fail (no real token)
 	result := srv.validateGitHubToken("ghp_faketoken12345678901234567890")
@@ -850,7 +850,7 @@ func TestSaveAccessRequestsNonexistentDir(t *testing.T) {
 
 func TestValidateGitHubTokenCacheHit(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Pre-populate the cache
 	ghTokenCacheMu.Lock()
@@ -873,7 +873,7 @@ func TestValidateGitHubTokenCacheHit(t *testing.T) {
 
 func TestValidateGitHubTokenCacheExpired(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Pre-populate with expired entry
 	ghTokenCacheMu.Lock()
@@ -897,7 +897,7 @@ func TestValidateGitHubTokenCacheExpired(t *testing.T) {
 
 func TestValidateGitHubTokenEmpty(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	result := srv.validateGitHubToken("")
 	if result != "" {
@@ -907,7 +907,7 @@ func TestValidateGitHubTokenEmpty(t *testing.T) {
 
 func TestGetAuthUserBearer(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Pre-populate cache so Bearer auth works
 	ghTokenCacheMu.Lock()
@@ -968,7 +968,7 @@ func TestRegisterOAuthEnabled(t *testing.T) {
 	t.Setenv("HIVE_HUB_OAUTH_CLIENT_ID", "test-client-id")
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// OAuth routes should be registered, test /login exists
 	req := httptest.NewRequest("GET", "/login", nil)
@@ -987,7 +987,7 @@ func TestRegisterOAuthEnabled(t *testing.T) {
 
 func TestHandleOAuthCallbackNoAccessToken(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Code is present but GitHub returns error (invalid code)
 	req := httptest.NewRequest("GET", "/callback?code=invalid_code_xyz", nil)
@@ -1002,7 +1002,7 @@ func TestHandleOAuthCallbackNoAccessToken(t *testing.T) {
 
 func TestHandleContributeProxyWithLocalHive(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	// Hive with localhost URL → private URL → rejected by findContributeHive
 	srv.mu.Lock()
@@ -1024,7 +1024,7 @@ func TestHandleContributeProxyWithLocalHive(t *testing.T) {
 
 func TestHandleContributeWSProxyWithLocalHive(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -1059,7 +1059,7 @@ func TestLoadSaaSUserValid(t *testing.T) {
 
 func TestMarkStaleHivesWithOldHeartbeat(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = ""
+	srv.setHubSecret("")
 
 	old := "2020-01-01T00:00:00Z"
 	srv.mu.Lock()

--- a/v2/pkg/hub/hub_test.go
+++ b/v2/pkg/hub/hub_test.go
@@ -229,7 +229,7 @@ func TestHandleHealthCheck(t *testing.T) {
 
 func TestHandleHeartbeatNoAuth(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	srv.hubSecret = "secret123"
+	srv.setHubSecret("secret123")
 	req := httptest.NewRequest("POST", "/api/heartbeat", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)


### PR DESCRIPTION
Follow-on PR **#2** of [`v2/docs/design/master-key-rotation.md`](https://github.com/kubestellar/hive/blob/v4/v2/docs/design/master-key-rotation.md). Hub-internal verify-path change only — **no spoke rolls, nothing fleet-visible**.

## Why trial verification and not a marker

The heartbeat bearer **cannot carry a generation marker**. The bearer IS the derived key, presented raw in the `Authorization` header — there is no envelope to put a `g<N>.` in. Its format is also a contract with already-deployed spoke Deployments (`HIVE_HEARTBEAT_KEY`) and with `SpokeHeartbeatKey()`'s self-derive lane, so changing it would make the rotation mechanism itself require the fleet-wide flag day it exists to avoid. The design doc calls this out explicitly and prescribes bounded trial verification for exactly this class of artifact.

`verifyHeartbeatBearer` now derives the per-hive bearer from each live generation, current first, and compares. **The bound is `maxLiveGenerations == 2`** — worst case two HMAC computations where there was one, strictly less than the rest of a heartbeat already costs. The count is capped by the loader rather than by anything the caller supplies, so it is not an asymmetric-cost lever.

## Audit F2 does not regress — how I verified it

F2 (Critical, open across five audits) was closed by **deleting the fleet-wide LANE**: `deriveDomainKey(master, infoHeartbeatKey)`, a value stamped byte-identically into every spoke, whose possession proved "some provisioned spoke" and never "THIS hive". Since `handleHeartbeat` trusts the body-supplied `hive_id`, that lane let any spoke beat as any victim and be handed the victim's key material.

**This change adds a second GENERATION, not a second LANE.** Every candidate in the loop is `derivePerHiveKey(g.Secret, infoHeartbeatKey, hiveID)` — identity-bound under every generation. `derivePerHiveKey` returns `""` for an empty `hiveID`, so an identity-less caller authenticates nothing however many generations exist. There is no code path in the new function that derives without `hiveID`.

Three independent checks:

1. **`TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration`** iterates the *acceptable generation set itself* (asserting first that it really holds 2, so the cross-generation case is genuinely exercised) and, for each generation, asserts hive A's bearer from that generation is **rejected** for hive B — with a positive control that the same bearer IS accepted for hive A.
2. **`TestHeartbeatFleetWideLaneStaysDeletedUnderGenerations`** asserts the deleted fleet-wide value, and the raw master, authenticate **no** hive under **either** generation.
3. **`TestHubServerHeartbeatBearerUsesGenerations`** repeats the cross-hive assertion through `HubServer.verifyHeartbeatBearer` — the function `handleHeartbeat` actually calls — including on the nil-generations fallback path.

The regression replay below confirms these are not decorative: with the fleet-wide lane re-added, check 2 is the **only** test that fails.

## Timing

Every attempt uses `secureCompareHub` (`subtle.ConstantTimeCompare`), and the loop deliberately does **not** return early on a match — it evaluates every acceptable generation and keeps the first ID that matched. Early return would leak, through response latency, WHICH generation accepted a bearer, telling an attacker which spokes have not yet converged off a master the operator is trying to retire. The compare is kept on its own line rather than folded into the `if`, with a comment, so a future tidy-up cannot silently reintroduce the early exit via operand reordering.

## Telemetry

`heartbeatBearerIsPerHive` is made generation-aware for the same reason the verifier is: a not-yet-reconciled spoke presents a previous-generation bearer that is still per-hive and still identity-bound. Checking only the current generation would make the `auth-rollout` surface report a fleet-wide F2 regression that has not happened — during exactly the window an operator is watching it most closely.

## Existing tests touched — 10 files, and why

**This is the finding of this PR.** `hubSecret` and `keyGenerations` are two representations of ONE fact. 97 test sites called `NewHubServer(...)` — which sets `keyGenerations` from the secret it generated — and then assigned `srv.hubSecret = "test-secret"` directly, leaving the generation set derived from the **discarded** secret.

That drift was invisible while only the impersonation cookie read the generation set. The heartbeat is the second such verifier, and the moment it started reading `keyGenerations` ten existing tests began returning 401:

```
--- FAIL: TestHandleHeartbeatValidPayload (0.00s)
    hub_coverage_boost_test.go:533: valid heartbeat: expected 200, got 401 (body: unauthorized)
--- FAIL: TestHandleHeartbeatInvalidOrg / InvalidRepo / InvalidRepoInList
--- FAIL: TestHandleHeartbeatBadDashboardURL / BadSnapshotURL
--- FAIL: TestHandleHeartbeatInvalidAgentName / InvalidLeaderboardUsername
--- FAIL: TestHandleTaskStatusValid / TestHandleTaskStatusOfflineHive
```

These tests were **correct**; the helper pattern was wrong. Rather than patch 97 call sites, I fixed it at the source with `HubServer.setHubSecret`, which sets both fields in lockstep, and rewrote the 97 assignments to use it. This is the same class of change `58c15549` made to `newHandlerHub()`.

**No test assertion was weakened, inverted, or removed** — the edit is purely `srv.hubSecret = X` → `srv.setHubSecret(X)`. No existing test encoded a single-generation assumption that needed deliberate inversion; the failures were a helper bug, not an assertion that had become wrong.

## Regression replay

Both replays run against the **final** committed code (the earlier run predated the `setHubSecret` fix, so it was redone).

**Neuter (a) — drop dual acceptance** (`acceptable[:1]`). Compiles (`BUILD OK`); the four tests that legitimately do not depend on dual acceptance still pass:

```
=== RUN   TestHeartbeatBearerSurvivesRotation
    heartbeat_generation_test.go:56: a bearer derived from the outgoing master must still verify during the window
--- FAIL: TestHeartbeatBearerSurvivesRotation (0.00s)
=== RUN   TestHeartbeatBearerAcceptedUnderCurrentGeneration
--- PASS: TestHeartbeatBearerAcceptedUnderCurrentGeneration (0.00s)
=== RUN   TestHeartbeatBearerRejectedAfterGenerationExpires
    heartbeat_generation_test.go:108: positive control: the same bearer inside the window must be accepted
--- FAIL: TestHeartbeatBearerRejectedAfterGenerationExpires (0.00s)
=== RUN   TestHeartbeatBearerRejectsMissingVerifyUntil
--- PASS: TestHeartbeatBearerRejectsMissingVerifyUntil (0.00s)
=== RUN   TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration
    heartbeat_generation_test.go:179: positive control: generation 1's bearer for hive "hive-alpha" must verify for hive "hive-alpha"
--- FAIL: TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration (0.00s)
=== RUN   TestHeartbeatFleetWideLaneStaysDeletedUnderGenerations
    heartbeat_generation_test.go:218: positive control: the per-hive bearer must verify under its own generation
--- FAIL: TestHeartbeatFleetWideLaneStaysDeletedUnderGenerations (0.00s)
=== RUN   TestHeartbeatBearerFailsClosed
--- PASS: TestHeartbeatBearerFailsClosed (0.00s)
=== RUN   TestHeartbeatTrialIsBounded
--- PASS: TestHeartbeatTrialIsBounded (0.00s)
=== RUN   TestHubServerHeartbeatBearerUsesGenerations
    heartbeat_generation_test.go:291: a pre-rotation bearer must authenticate through the server during the window
    heartbeat_generation_test.go:303: heartbeatBearerIsPerHive must recognize a per-hive bearer from EITHER generation
--- FAIL: TestHubServerHeartbeatBearerUsesGenerations (0.00s)
FAIL	github.com/kubestellar/hive/v2/pkg/hub	0.876s
```

**Neuter (c) — re-open F2** by adding the fleet-wide lane back *alongside* the per-hive one (the realistic regression: a second lane rather than a second generation). This is the important one — **exactly one test fails, and it is the F2 test**:

```
=== RUN   TestHeartbeatBearerSurvivesRotation
--- PASS: TestHeartbeatBearerSurvivesRotation (0.00s)
=== RUN   TestHeartbeatBearerAcceptedUnderCurrentGeneration
--- PASS: TestHeartbeatBearerAcceptedUnderCurrentGeneration (0.00s)
=== RUN   TestHeartbeatBearerRejectedAfterGenerationExpires
--- PASS: TestHeartbeatBearerRejectedAfterGenerationExpires (0.00s)
=== RUN   TestHeartbeatBearerRejectsMissingVerifyUntil
--- PASS: TestHeartbeatBearerRejectsMissingVerifyUntil (0.00s)
=== RUN   TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration
--- PASS: TestHeartbeatBearerIsIdentityBoundUnderEveryGeneration (0.00s)
=== RUN   TestHeartbeatFleetWideLaneStaysDeletedUnderGenerations
    heartbeat_generation_test.go:200: F2 REGRESSION: the FLEET-WIDE bearer authenticated hive "hive-alpha"
    heartbeat_generation_test.go:200: F2 REGRESSION: the FLEET-WIDE bearer authenticated hive "hive-bravo"
    heartbeat_generation_test.go:200: F2 REGRESSION: the FLEET-WIDE bearer authenticated hive "hive-alpha"
    heartbeat_generation_test.go:200: F2 REGRESSION: the FLEET-WIDE bearer authenticated hive "hive-bravo"
--- FAIL: TestHeartbeatFleetWideLaneStaysDeletedUnderGenerations (0.00s)
=== RUN   TestHeartbeatBearerFailsClosed
--- PASS: TestHeartbeatBearerFailsClosed (0.00s)
=== RUN   TestHeartbeatTrialIsBounded
--- PASS: TestHeartbeatTrialIsBounded (0.00s)
=== RUN   TestHubServerHeartbeatBearerUsesGenerations
--- PASS: TestHubServerHeartbeatBearerUsesGenerations (0.00s)
FAIL	github.com/kubestellar/hive/v2/pkg/hub	0.845s
```

Restored, `gofmt` clean, no `NEUTER` markers remain. Full `go test ./pkg/hub/` green: `ok github.com/kubestellar/hive/v2/pkg/hub 182.568s`.

## Finiteness

`TestHeartbeatBearerRejectedAfterGenerationExpires` pins that past `verify_until` the old bearer stops working with no operator action. `TestHeartbeatBearerRejectsMissingVerifyUntil` pins the fail-closed reading of a hand-edited generations file: a previous generation with a **zero** `VerifyUntil` is treated as ALREADY EXPIRED, never as "never expires".