### PR TITLE
🔐 hub: admin rotate endpoint + generation-file persistence

### DIFF
--- a/v2/docs/design/master-key-rotation.md
+++ b/v2/docs/design/master-key-rotation.md
@@ -260,7 +260,7 @@ The other six domains are deliberately untouched. See below.
 | 1 | Session cookie (HMAC + Ed25519) dual acceptance, marker in payload | M | No — hub-side verify only |
 | 2 | Heartbeat bearer bounded trial verification against both generations | M | No — hub-side verify only |
 | 3 | `desiredPerHiveEnv` derives from current generation; per-generation counts in `PerHiveEnvStatus` | S | No — read path until #4 |
-| 4 | Admin rotate endpoint + persistence of the generation file | S | No — arms the rest |
+| 4 | Admin rotate endpoint + persistence of the generation file | S | No — arms the rest | ✅ landed
 | 5 | Terminal + invite key dual acceptance (spoke-side, symmetric) | M | **Yes** — rolls pods via reconcile |
 | 6 | SSO/session Ed25519 public key rotation, incl. `proxy/server.js` accepting two public keys | L | **Yes** — Node proxy contract |
 | 7 | Retire generation automatically past `verify_until`; alert if a generation is pinned open | S | No |
@@ -268,6 +268,66 @@ The other six domains are deliberately untouched. See below.
 PRs 1–4 are hub-internal and can land without any spoke rolling. Only 5 and 6
 touch the fleet, and both go through the existing rate-limited reconcile lane
 rather than a re-provision.
+
+## As-built notes for PR #4
+
+Two decisions were made during implementation that the design above did not
+pin down.
+
+**Double rotation is REFUSED, not warned about, with `force` as the override.**
+`maxLiveGenerations` is 2 and `rotate()` carries forward only the outgoing
+current, so a second rotation DROPS the generation from two rotations ago —
+which is the one most of the fleet is still on, because the reconcile lane
+walks spokes at 3 patches per 15-minute cycle. A second rotation an hour into
+the first would leave ~54 of 66 spokes holding material the hub no longer
+accepts: heartbeat 401s until the sweep reaches them, hours later. That is the
+flag day this design exists to prevent, reintroduced through the front door.
+
+A warning on a response body is not a control. The operator most likely to
+double-rotate is the one who did not realise the first rotation was still in
+flight — precisely the operator who will not read it. So the endpoint returns
+409 with a `retry_after_seconds`, and `force: true` is required to override.
+
+`force` is honoured rather than omitted because there is a real case for it: if
+the NEW generation is itself compromised, rotating again immediately is correct
+even at the cost of stranding spokes for a few hours. A guard with no override
+would turn the cooldown into a window of known-compromised material.
+
+`rotationCooldown` is 8 hours — sized to CONVERGENCE (66 spokes at 3 per
+15-minute cycle is ~5.5h, plus margin for cycles lost to unreachable clusters),
+deliberately NOT to `defaultVerifyWindow`. Waiting for the previous generation
+to expire before permitting another rotation would block emergency re-rotation
+for a week, and the hazard being guarded is unconverged spokes, not the old key
+still being accepted. A test asserts `rotationCooldown < defaultVerifyWindow`.
+
+**Double-submit is guarded by the same mechanism, not a separate one.**
+`rotateMasterSecret` holds the generation write lock across
+evaluate-generate-persist-install, so two concurrent POSTs cannot both observe a
+pre-rotation `lastKeyRotation`; the second is refused by the cooldown. The
+cooldown IS the idempotency guard.
+
+**Persistence.** `/data/saas/hub-generations.json`, a sibling of
+`hub-secret.key` on the hub PVC, at mode 0600 (not the 0644 its JSON neighbours
+use — this file holds master secrets in plaintext). `hub-secret.key` is never
+rewritten, so a hub that rolls back to pre-rotation code finds exactly what it
+expects. `rotated_at` is persisted alongside the set, because otherwise the
+cooldown would reset on every hub roll — several times a day — and stop
+guarding anything.
+
+The set is persisted BEFORE it is installed in memory: a failed write leaves
+the hub on the old set and returns an error, rather than minting on a key it
+forgets at its next roll.
+
+A corrupt generations file is quarantined and the loader falls back to the
+legacy single-generation set — it is NOT discarded and replaced with a fresh
+rotation, which would mint material the fleet has never seen while forgetting
+the generation the fleet is actually on. This differs deliberately from the
+alert-acks precedent, where starting fresh is the safe direction.
+
+Expiry is NOT filtered at load time. An expired previous generation is loaded
+and then excluded by `acceptableGenerations` at every verify, so the wall clock
+is the only thing that closes the window — filtering at load would make expiry
+depend on when the hub last restarted.
 
 ## Note: the empty-master readers
 

--- a/v2/pkg/hub/hub_generations_handler.go
+++ b/v2/pkg/hub/hub_generations_handler.go
@@ -1,0 +1,239 @@
+package hub
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Admin-facing rotation endpoints (follow-on PR #4).
+//
+// AUTHORISATION. Both routes are wrapped in requireAdmin (saas.go), which:
+//   - calls isCSRFSafe FIRST, before any identity resolution, so a cross-site
+//     POST never reaches the rotation logic. Verified during the F4 work: BOTH
+//     requireAuth and requireAdmin enforce it. Without that, an ambient hub
+//     session cookie would make a cross-origin form POST rotate the fleet's
+//     master secret — which is the single most destructive unauthenticated
+//     action available on the platform.
+//   - gates on the REAL logged-in user (getRealAuthUser), not the effective
+//     one, and refuses every admin route while an impersonation grant is
+//     active.
+//
+// SECRET HYGIENE. Nothing in this file logs, returns, or renders any secret
+// material. The responses carry generation IDs, counts, and timestamps — an ID
+// names a key, it is not a key. This is asserted by test, not just by review.
+
+// rotateResponse is what the rotate endpoint returns. Deliberately contains no
+// field that could hold key material.
+type rotateResponse struct {
+	OK bool `json:"ok"`
+	// Current is the new minting generation's ID.
+	Current int `json:"current"`
+	// Previous is the demoted generation's ID, 0 if there was none.
+	Previous int `json:"previous,omitempty"`
+	// PreviousVerifyUntil is when the demoted generation stops being accepted.
+	PreviousVerifyUntil string `json:"previous_verify_until,omitempty"`
+	// LiveGenerations is every ID the hub now accepts for VERIFY, current
+	// first.
+	LiveGenerations []int `json:"live_generations"`
+	// RotatedAt is when this rotation happened.
+	RotatedAt string `json:"rotated_at"`
+	// Forced records that the cooldown was overridden.
+	Forced bool `json:"forced,omitempty"`
+	// Note tells the operator what happens next, because the rotation is not
+	// finished when this returns — the fleet converges over hours.
+	Note string `json:"note"`
+}
+
+// rotateRefusedResponse is the 409 body for a refused double-rotation.
+type rotateRefusedResponse struct {
+	Error string `json:"error"`
+	// RetryAfterSeconds is when the cooldown lapses.
+	RetryAfterSeconds int `json:"retry_after_seconds"`
+	// Current is the generation currently minting — unchanged by the refusal.
+	Current int `json:"current"`
+}
+
+// rotationConvergenceNote explains the part an operator most needs to know and
+// is most likely to get wrong: the rotation is NOT complete when the endpoint
+// returns 200.
+const rotationConvergenceNote = "rotation applied. The hub now mints only with the new generation; " +
+	"artifacts minted under the previous one keep verifying until previous_verify_until. " +
+	"Spoke-held material converges through the existing reconcile sweep at 3 patches per " +
+	"15-minute cycle (~6h for the full fleet), rolling each pod once. Watch " +
+	"GET /api/saas/admin/auth-rollout for per-generation counts and safe_to_retire_previous."
+
+// handleRotateMasterKey performs a master-secret rotation.
+//
+// POST /api/saas/admin/rotate-master-key   body: {"force": bool}
+//
+// IDEMPOTENCY / DOUBLE-SUBMIT. A double-submitted POST does NOT produce two
+// rotations. rotateMasterSecret holds the generation write lock across
+// evaluate-generate-persist-install, so the second request observes the first
+// one's lastKeyRotation and evaluateRotation refuses it with 409 — the cooldown
+// IS the double-submit guard, not merely a policy on top of one. The two
+// requests cannot interleave inside the critical section, so there is no window
+// in which both read a pre-rotation lastKeyRotation.
+//
+// This is why the guard is a refusal rather than a warning: a warning would let
+// a double-click strand the fleet, and a double-click is the single likeliest
+// way this endpoint is called twice.
+func (s *HubServer) handleRotateMasterKey(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		// Force overrides the cooldown. See evaluateRotation for when this is
+		// legitimate (the new generation is itself compromised) and what it
+		// costs (spokes still on the dropped generation 401 until the sweep
+		// reaches them).
+		Force bool `json:"force"`
+	}
+	// An absent or empty body is fine — force defaults to false, the safe
+	// value. Only MALFORMED JSON is an error, so a plain POST with no body
+	// performs an unforced rotation.
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+			return
+		}
+	}
+
+	now := time.Now().UTC()
+	next, decision, err := s.rotateMasterSecret(now, body.Force)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if errors.Is(err, errRotationTooSoon) {
+		retry := int(decision.RetryAfter.Seconds())
+		if retry < 0 {
+			retry = 0
+		}
+		s.logger.Warn("master key rotation REFUSED — previous rotation still converging",
+			"by", s.getRealAuthUser(r),
+			"retry_after_seconds", retry,
+			"current", s.currentGenerations().Current)
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(rotateRefusedResponse{
+			Error:             decision.Reason,
+			RetryAfterSeconds: retry,
+			Current:           s.currentGenerations().Current,
+		})
+		return
+	}
+	if err != nil {
+		// Includes a failed PERSIST. The in-memory set is untouched in that
+		// case (rotateMasterSecret persists before installing), so this is a
+		// clean no-op and the operator can retry.
+		s.logger.Error("master key rotation FAILED — no rotation applied",
+			"by", s.getRealAuthUser(r), "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "rotation failed; no rotation was applied — see hub logs",
+		})
+		return
+	}
+
+	resp := rotateResponse{
+		OK:        true,
+		Current:   next.Current,
+		RotatedAt: now.Format(time.RFC3339),
+		Forced:    decision.RetryAfter > 0,
+		Note:      rotationConvergenceNote,
+	}
+	for _, g := range next.Generations {
+		resp.LiveGenerations = append(resp.LiveGenerations, g.ID)
+		if g.ID != next.Current {
+			resp.Previous = g.ID
+			if !g.VerifyUntil.IsZero() {
+				resp.PreviousVerifyUntil = g.VerifyUntil.UTC().Format(time.RFC3339)
+			}
+		}
+	}
+
+	// IDs and timestamps only — never the secret, and never a prefix or length
+	// of it either. A generation ID names a key; it is not a key.
+	s.logger.Info("master key ROTATED",
+		"by", s.getRealAuthUser(r),
+		"current", resp.Current,
+		"previous", resp.Previous,
+		"previous_verify_until", resp.PreviousVerifyUntil,
+		"forced", resp.Forced,
+		"path", hubGenerationsPath)
+
+	json.NewEncoder(w).Encode(resp)
+}
+
+// keyGenerationsResponse is the read-only view of the generation set.
+type keyGenerationsResponse struct {
+	Current int `json:"current"`
+	// Generations describes each live generation. No secrets.
+	Generations []keyGenerationInfo `json:"generations"`
+	// LastRotation is when the current generation was minted, empty on a hub
+	// that has never rotated.
+	LastRotation string `json:"last_rotation,omitempty"`
+	// RotateAvailableIn is how long until the cooldown lapses, 0 when a
+	// rotation may proceed now.
+	RotateAvailableInSeconds int `json:"rotate_available_in_seconds"`
+	// PersistPath is where the set is stored, so an operator can find it
+	// without reading the source.
+	PersistPath string `json:"persist_path"`
+}
+
+// keyGenerationInfo describes ONE generation without its secret.
+type keyGenerationInfo struct {
+	ID      int    `json:"id"`
+	Created string `json:"created,omitempty"`
+	// VerifyUntil is empty for the current generation, which never expires.
+	VerifyUntil string `json:"verify_until,omitempty"`
+	// Acceptable is whether this generation is accepted for VERIFY right now.
+	// Computed from the wall clock, so a generation whose window has closed
+	// reads false here even though it is still listed.
+	Acceptable bool `json:"acceptable"`
+	// Current marks the one generation that MINTS.
+	Current bool `json:"current"`
+}
+
+// handleKeyGenerations serves the read-only generation view.
+//
+// GET /api/saas/admin/key-generations
+//
+// Admin-gated like its siblings. It is strictly less sensitive than the
+// rotate endpoint — it returns no secret material at all — but it describes the
+// hub's key posture, which is fleet-shaped information with no reason to be
+// public.
+func (s *HubServer) handleKeyGenerations(w http.ResponseWriter, r *http.Request) {
+	now := time.Now()
+	gs := s.currentGenerations()
+
+	out := keyGenerationsResponse{PersistPath: hubGenerationsPath}
+	if gs != nil {
+		out.Current = gs.Current
+		acceptable := make(map[int]bool, len(gs.Generations))
+		for _, g := range gs.acceptableGenerations(now) {
+			acceptable[g.ID] = true
+		}
+		for _, g := range gs.Generations {
+			info := keyGenerationInfo{
+				ID:         g.ID,
+				Acceptable: acceptable[g.ID],
+				Current:    g.ID == gs.Current,
+			}
+			if !g.Created.IsZero() {
+				info.Created = g.Created.UTC().Format(time.RFC3339)
+			}
+			if !g.VerifyUntil.IsZero() {
+				info.VerifyUntil = g.VerifyUntil.UTC().Format(time.RFC3339)
+			}
+			out.Generations = append(out.Generations, info)
+		}
+	}
+	if last := s.lastRotationAt(); !last.IsZero() {
+		out.LastRotation = last.UTC().Format(time.RFC3339)
+		if d := evaluateRotation(last, now, false); !d.Allowed {
+			out.RotateAvailableInSeconds = int(d.RetryAfter.Seconds())
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(out)
+}

--- a/v2/pkg/hub/hub_generations_store.go
+++ b/v2/pkg/hub/hub_generations_store.go
@@ -1,0 +1,386 @@
+package hub
+
+import (
+	cryptoRand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Persistence and the operator-facing rotate mechanism for master-secret
+// generations (follow-on PR #4 of v2/docs/design/master-key-rotation.md).
+//
+// The foundation (hub_generations.go) can already REPRESENT a rotation:
+// generationSet.rotate is pure, maxLiveGenerations bounds the set, and every
+// previous generation carries VerifyUntil. What it cannot do is CREATE one, or
+// remember one. Both gaps are closed here, and they are closed together
+// deliberately: an endpoint that rotates without persisting would produce a
+// rotation that survives until the next hub roll — which happens several times
+// a day — and a hub that came back holding only generation 1 would reject every
+// artifact minted since the rotation while quietly re-minting on the old key.
+// That is strictly worse than never having rotated.
+//
+// WHY A SEPARATE FILE FROM hub-secret.key. /data/saas/hub-secret.key stays
+// exactly as it is — 64 hex bytes, raw, never rewritten by this code. It is
+// generation 1's secret and nothing else, so a hub that rolls BACK to
+// pre-rotation code finds precisely the file it expects and keeps working on
+// generation 1. Rewriting it in place would make rollback a data-loss event.
+// The generations live alongside it in hub-generations.json, and when that file
+// is absent — the state of every hub in the fleet today — the loader synthesizes
+// legacyGenerationSet from hub-secret.key. So there is no migration step and no
+// flag day: "never rotated" and "rotated back down to one generation" are the
+// same on-disk state.
+
+// hubGenerationsPath is where the generation set is persisted.
+//
+// A SIBLING of /data/saas/hub-secret.key on the hub PVC, which is the volume
+// that survives a pod roll — and the hub rolls several times a day, so anything
+// held only in memory is effectively not held at all. Verified live: the hub's
+// HIVE_HUB_SECRET env is UNSET and hub-secret.key exists on the PVC at 64
+// bytes, so the file is the live source of the master and this file sits in the
+// same durable place.
+//
+// A var, not a const, so tests can redirect it — the same convention as
+// alertAcksPath, journeyStatePath, and revokedSessionsPath.
+var hubGenerationsPath = "/data/saas/hub-generations.json"
+
+// hubGenerationsFileMode is 0600, NOT the 0644 the other /data/saas JSON files
+// use. Those hold acks, banners, and journey state; this one holds MASTER
+// SECRETS in plaintext, so it matches hub-secret.key's own 0600 rather than its
+// neighbours' mode.
+const hubGenerationsFileMode = 0o600
+
+// hubGenerationsQuarantineSuffix preserves an unparseable file for inspection
+// instead of overwriting it.
+//
+// The recovery differs sharply from the alert-acks precedent, and the
+// difference is the point. A corrupt acks file is discarded and the system
+// starts fresh, because losing an ack merely un-silences an alert — the safe
+// direction. A corrupt GENERATIONS file must NOT be discarded and replaced with
+// a fresh rotation: that would mint new material the fleet has never seen while
+// forgetting the generation the fleet is actually on. So the loader falls back
+// to the legacy single-generation set (which is always correct, because
+// hub-secret.key is authoritative for generation 1) and leaves the bad bytes on
+// disk. Fail closed, then let an operator look.
+const hubGenerationsQuarantineSuffix = ".corrupt"
+
+// hubGenerationsFileMu serialises writers, for the reason alertAcksFileMu
+// documents: two concurrent saves writing the same tmp path interleave their
+// bytes and rename non-JSON into place. Here the consequence is worse than a
+// lost ack — an unparseable generations file means the hub falls back to
+// generation 1 on its next restart.
+var hubGenerationsFileMu sync.Mutex
+
+// persistedGenerations is the on-disk shape. It is exactly generationSet's
+// JSON, named separately so the file format is a deliberate, reviewable
+// artifact rather than an incidental consequence of a struct definition.
+type persistedGenerations struct {
+	Current     int             `json:"current"`
+	Generations []keyGeneration `json:"generations"`
+	// RotatedAt records the most recent rotation, for operator forensics and —
+	// more importantly — for the double-rotation guard. Never used to decide
+	// whether a key is ACCEPTABLE; that is VerifyUntil's job alone.
+	RotatedAt time.Time `json:"rotated_at,omitempty"`
+}
+
+// masterSecretBytes is the length of a generated master, matching the 32 bytes
+// NewHubServer generates for hub-secret.key (rendered as 64 hex chars).
+const masterSecretBytes = 32
+
+// generateMasterSecret returns a fresh hex master secret from crypto/rand.
+//
+// Returns an error rather than a short read: a partially-filled buffer would
+// produce a low-entropy master that every subsequent derivation inherits, and
+// silently rotating TO a weak key is worse than refusing to rotate at all.
+func generateMasterSecret() (string, error) {
+	b := make([]byte, masterSecretBytes)
+	if _, err := cryptoRand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// saveGenerations writes the set atomically (tmp + rename) at 0600.
+//
+// Returns an error rather than only logging, unlike its neighbours. The
+// rotate handler MUST fail loudly if this fails: a rotation that is applied in
+// memory but not on disk is a rotation the hub forgets on its next roll, and
+// the operator would have no signal that the fleet is now converging onto a key
+// the hub is about to lose.
+func saveGenerations(gs *generationSet, rotatedAt time.Time) error {
+	if gs == nil || len(gs.Generations) == 0 {
+		return errors.New("refusing to persist an empty generation set")
+	}
+	hubGenerationsFileMu.Lock()
+	defer hubGenerationsFileMu.Unlock()
+
+	data, err := json.MarshalIndent(persistedGenerations{
+		Current:     gs.Current,
+		Generations: gs.Generations,
+		RotatedAt:   rotatedAt,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(hubGenerationsPath), 0o755); err != nil {
+		return err
+	}
+	tmpPath := hubGenerationsPath + ".tmp"
+	// WriteFile's mode applies only on create, so an existing tmp file left by
+	// a crashed write could keep a laxer mode. Remove it first so 0600 is
+	// guaranteed for a file that contains master secrets.
+	_ = os.Remove(tmpPath)
+	if err := os.WriteFile(tmpPath, data, hubGenerationsFileMode); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, hubGenerationsPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// loadGenerations reads the persisted set, falling back to the legacy
+// single-generation set built from `master`.
+//
+// FAILS CLOSED IN EVERY DEGRADED CASE, and always to the same place: the legacy
+// set. That fallback is safe precisely because hub-secret.key is authoritative
+// for generation 1 and is never rewritten, so "I could not read the generations
+// file" and "this hub has never rotated" resolve identically.
+//
+//   - Missing file: normal. Every hub in the fleet is in this state today.
+//   - Unparseable: quarantined, legacy set returned. NOT replaced with a fresh
+//     rotation — see hubGenerationsQuarantineSuffix.
+//   - Parseable but with no generation matching Current: newGenerationSet
+//     returns nil (a set with no minting key is unusable, not degraded), so the
+//     legacy set is returned.
+//   - Any generation with an empty secret is dropped by newGenerationSet, which
+//     is what stops a hand-edited file from making verification compare against
+//     empty keys.
+//
+// Note what is deliberately NOT validated here: an expired VerifyUntil. An
+// expired previous generation is loaded into the set and then excluded by
+// acceptableGenerations at every VERIFY. Filtering at load time instead would
+// make expiry depend on when the hub last restarted — a generation would stay
+// live across a long-running process and vanish on a roll. The wall clock must
+// be the only thing that closes the window.
+//
+// Returns the set AND the persisted RotatedAt. The timestamp must survive a
+// restart or the double-rotation cooldown would reset on every hub roll —
+// several times a day — which would make the guard trivially bypassable by
+// waiting for the next deploy rather than for the fleet to converge.
+func loadGenerations(master string, logger interface {
+	Warn(msg string, args ...any)
+	Info(msg string, args ...any)
+}) (*generationSet, time.Time) {
+	legacy := legacyGenerationSet(master)
+
+	data, err := os.ReadFile(hubGenerationsPath)
+	if err != nil {
+		if !os.IsNotExist(err) && logger != nil {
+			logger.Warn("could not read hub generations file; falling back to the single-generation master",
+				"path", hubGenerationsPath, "error", err)
+		}
+		return legacy, time.Time{}
+	}
+
+	var p persistedGenerations
+	if err := json.Unmarshal(data, &p); err != nil {
+		if logger != nil {
+			logger.Warn("hub generations file is not parseable — quarantining and falling back to the single-generation master; NOT rotating",
+				"path", hubGenerationsPath, "error", err)
+		}
+		_ = os.Rename(hubGenerationsPath, hubGenerationsPath+hubGenerationsQuarantineSuffix)
+		return legacy, time.Time{}
+	}
+
+	gs := newGenerationSet(p.Current, p.Generations)
+	if gs == nil {
+		if logger != nil {
+			// Never log the file's contents — it holds master secrets. Counts
+			// and the current ID only.
+			logger.Warn("hub generations file has no usable current generation — falling back to the single-generation master",
+				"path", hubGenerationsPath, "current", p.Current, "entries", len(p.Generations))
+		}
+		return legacy, time.Time{}
+	}
+	if logger != nil {
+		logger.Info("loaded hub master generations",
+			"current", gs.Current, "live_generations", len(gs.Generations))
+	}
+	return gs, p.RotatedAt
+}
+
+// Rotation.
+
+// errRotationTooSoon is returned when a second rotation would strand spokes
+// that are still converging onto the first.
+var errRotationTooSoon = errors.New("previous rotation has not converged")
+
+// rotationCooldown is how long after a rotation a SECOND rotation is refused
+// without an explicit force.
+//
+// WHY REFUSE RATHER THAN QUEUE OR SILENTLY ALLOW. maxLiveGenerations is 2, and
+// deliberately so (see its comment). rotate() carries forward ONLY the outgoing
+// current, so rotating twice in quick succession DROPS the generation from two
+// rotations ago — and that dropped generation is exactly the one most of the
+// fleet is still on, because the reconcile lane walks spokes at 3 patches per
+// 15-minute cycle. A second rotation an hour into the first would leave ~54 of
+// 66 spokes holding material the hub no longer accepts: they would 401 on every
+// heartbeat until the sweep reached them, hours later. That is the fleet-wide
+// flag day this entire design exists to prevent, reintroduced through the front
+// door.
+//
+// The cooldown is sized to the CONVERGENCE time, not to the verify window. 66
+// spokes at 3 per 15-minute cycle is ~5.5 hours, so 8 hours covers a full sweep
+// with margin for cycles lost to unreachable clusters. It is deliberately much
+// shorter than defaultVerifyWindow (7 days): waiting for the previous
+// generation to EXPIRE before allowing another rotation would make emergency
+// re-rotation impossible for a week, and the actual hazard is unconverged
+// spokes, not the old key still being accepted.
+const rotationCooldown = 8 * time.Hour
+
+// rotationDecision is the pure, testable answer to "may this rotation proceed?"
+// — separated from the handler so the guard has no HTTP in it and the handler
+// has no policy in it.
+type rotationDecision struct {
+	// Allowed is whether the rotation may proceed.
+	Allowed bool
+	// Reason explains a refusal, for the operator. Never contains key material.
+	Reason string
+	// RetryAfter is how long until the cooldown lapses. Zero when allowed.
+	RetryAfter time.Duration
+}
+
+// evaluateRotation decides whether a rotation may proceed.
+//
+// THE CHOICE MADE HERE: REFUSE, with an explicit force flag as the override,
+// rather than allowing it and warning. A warning on a response body is not a
+// control — the operator most likely to double-rotate is one who did not
+// realise the first rotation was still in flight, which is precisely the
+// operator who will not read it. Requiring `force` makes stranding the fleet a
+// thing you have to TYPE, and the endpoint tells you what you would be doing.
+//
+// force is honoured because there is a real case for it: if the new generation
+// itself is compromised (a leaked rotate response, a bad deploy), rotating
+// again immediately is the correct emergency action even at the cost of
+// stranding spokes for a few hours. A guard with no override would turn an
+// 8-hour cooldown into an 8-hour window of known-compromised material.
+func evaluateRotation(lastRotation time.Time, now time.Time, force bool) rotationDecision {
+	if lastRotation.IsZero() {
+		// Never rotated. Nothing can be stranded.
+		return rotationDecision{Allowed: true}
+	}
+	elapsed := now.Sub(lastRotation)
+	if elapsed >= rotationCooldown {
+		return rotationDecision{Allowed: true}
+	}
+	// A negative elapsed means lastRotation is in the FUTURE — a clock skew or
+	// a hand-edited file. Treat it as "inside the cooldown" rather than
+	// computing a nonsense RetryAfter: fail closed.
+	remaining := rotationCooldown - elapsed
+	if remaining > rotationCooldown {
+		remaining = rotationCooldown
+	}
+	if force {
+		return rotationDecision{Allowed: true, Reason: "forced within cooldown", RetryAfter: remaining}
+	}
+	return rotationDecision{
+		Allowed: false,
+		Reason: "a rotation is still converging; with at most two live generations a second rotation " +
+			"would drop the generation most spokes are still on and 401 them until the reconcile sweep " +
+			"catches up. Wait for the cooldown, or pass force=true if the current generation is itself compromised.",
+		RetryAfter: remaining,
+	}
+}
+
+// currentGenerations returns an immutable snapshot of the hub's generation set.
+//
+// The set is only ever REPLACED, never mutated, so the returned pointer stays
+// valid and self-consistent for as long as the caller holds it — a verifier
+// that reads just before a rotation verifies against the pre-rotation set,
+// which is exactly right because the outgoing generation remains acceptable.
+func (s *HubServer) currentGenerations() *generationSet {
+	if s == nil {
+		return nil
+	}
+	s.keyGenerationsMu.RLock()
+	defer s.keyGenerationsMu.RUnlock()
+	return s.keyGenerations
+}
+
+// setGenerations installs a new set and records when it happened.
+func (s *HubServer) setGenerations(gs *generationSet, rotatedAt time.Time) {
+	if s == nil || gs == nil {
+		return
+	}
+	s.keyGenerationsMu.Lock()
+	defer s.keyGenerationsMu.Unlock()
+	s.keyGenerations = gs
+	s.lastKeyRotation = rotatedAt
+}
+
+// lastRotationAt reports when the current generation was minted, or the zero
+// time on a hub that has never rotated.
+func (s *HubServer) lastRotationAt() time.Time {
+	if s == nil {
+		return time.Time{}
+	}
+	s.keyGenerationsMu.RLock()
+	defer s.keyGenerationsMu.RUnlock()
+	return s.lastKeyRotation
+}
+
+// rotateMasterSecret performs a rotation: generate, demote, persist, install.
+//
+// ORDER MATTERS AND IS DELIBERATE. The new set is persisted BEFORE it is
+// installed in memory. If the write fails the hub keeps running on the old set
+// and the caller gets an error — a hub that rotated in memory only would mint
+// on a key it forgets at its next roll (several times a day), and every
+// artifact minted in between would become unverifiable. Persist-then-install
+// makes a failed rotation a no-op rather than a time bomb.
+//
+// Returns the NEW set on success. Never returns, logs, or otherwise exposes any
+// secret material — the caller gets generation IDs and timestamps only.
+func (s *HubServer) rotateMasterSecret(now time.Time, force bool) (*generationSet, rotationDecision, error) {
+	if s == nil {
+		return nil, rotationDecision{}, errors.New("no hub server")
+	}
+	// Serialise the whole rotation, not just the field write. Two concurrent
+	// POSTs that both read the set, both built a rotation from it, and both
+	// persisted would race: the second write would carry forward the FIRST
+	// rotation's outgoing generation, silently discarding the first rotation's
+	// new current — which is live material by then. Holding the write lock
+	// across evaluate-generate-persist-install makes the second POST observe
+	// the first one's lastKeyRotation and be refused by the cooldown, which is
+	// the idempotency guarantee a double-submit needs.
+	s.keyGenerationsMu.Lock()
+	defer s.keyGenerationsMu.Unlock()
+
+	decision := evaluateRotation(s.lastKeyRotation, now, force)
+	if !decision.Allowed {
+		return nil, decision, errRotationTooSoon
+	}
+
+	secret, err := generateMasterSecret()
+	if err != nil {
+		return nil, decision, err
+	}
+	next := s.keyGenerations.rotate(secret, now, defaultVerifyWindow)
+	if next == nil {
+		// rotate returns nil only for an empty new secret, which
+		// generateMasterSecret cannot produce — but rotating to no key would
+		// silently disable minting, so refuse rather than install it.
+		return nil, decision, errors.New("rotation produced no usable generation set")
+	}
+	if err := saveGenerations(next, now); err != nil {
+		return nil, decision, err
+	}
+	s.keyGenerations = next
+	s.lastKeyRotation = now
+	return next, decision, nil
+}

--- a/v2/pkg/hub/hub_generations_store_test.go
+++ b/v2/pkg/hub/hub_generations_store_test.go
@@ -1,0 +1,647 @@
+package hub
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Tests for follow-on PR #4: generation persistence and the admin rotate
+// endpoint.
+//
+// The properties under test, in order of how badly they hurt if broken:
+//
+//  1. A rotation SURVIVES A RESTART. The hub rolls several times a day; a
+//     rotation held only in memory means the hub comes back on the old
+//     generation and rejects everything minted since.
+//  2. A DOUBLE ROTATION IS REFUSED. maxLiveGenerations is 2, so a second
+//     rotation before the first converges DROPS the generation most of the
+//     fleet is still on.
+//  3. A MALFORMED FILE FAILS CLOSED to the legacy single-generation set, and is
+//     never replaced by a fresh rotation.
+//  4. NO SECRET MATERIAL is ever logged or returned.
+
+const (
+	rotStoreSecretA = "rotation-store-test-master-alpha"
+	rotStoreSecretB = "rotation-store-test-master-bravo"
+)
+
+// withTempGenerationsPath redirects hubGenerationsPath into a temp dir so tests
+// never read or write the real PVC path.
+func withTempGenerationsPath(t *testing.T) string {
+	t.Helper()
+	prev := hubGenerationsPath
+	dir := t.TempDir()
+	hubGenerationsPath = filepath.Join(dir, "hub-generations.json")
+	t.Cleanup(func() { hubGenerationsPath = prev })
+	return hubGenerationsPath
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newRotationTestHub(t *testing.T, master string) *HubServer {
+	t.Helper()
+	return &HubServer{
+		logger:          quietLogger(),
+		hubSecret:       master,
+		keyGenerations:  legacyGenerationSet(master),
+		lastKeyRotation: time.Time{},
+	}
+}
+
+// TestRotateDemotesAndSetsVerifyUntil is the core mechanism assertion.
+func TestRotateDemotesAndSetsVerifyUntil(t *testing.T) {
+	withTempGenerationsPath(t)
+	s := newRotationTestHub(t, rotStoreSecretA)
+	before := s.currentGenerations()
+	if before.Current != legacyGenerationID {
+		t.Fatalf("fixture: current = %d, want %d", before.Current, legacyGenerationID)
+	}
+	beforeSecret := before.currentSecret()
+
+	now := time.Now().UTC()
+	next, _, err := s.rotateMasterSecret(now, false)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+
+	if next.Current != legacyGenerationID+1 {
+		t.Errorf("new current = %d, want %d", next.Current, legacyGenerationID+1)
+	}
+	if len(next.Generations) != 2 {
+		t.Fatalf("live generations = %d, want current + one previous", len(next.Generations))
+	}
+	if next.currentSecret() == beforeSecret {
+		t.Error("rotation did not change the minting secret")
+	}
+	if len(next.Generations) > maxLiveGenerations {
+		t.Errorf("live generations %d exceeds maxLiveGenerations %d", len(next.Generations), maxLiveGenerations)
+	}
+
+	// The demoted generation must be the OLD current, carry the old secret, and
+	// carry a NON-ZERO VerifyUntil — the whole finiteness promise.
+	prev := next.Generations[1]
+	if prev.ID != legacyGenerationID {
+		t.Errorf("previous id = %d, want %d", prev.ID, legacyGenerationID)
+	}
+	if prev.Secret != beforeSecret {
+		t.Error("previous generation does not carry the outgoing master — pre-rotation artifacts would not verify")
+	}
+	if prev.VerifyUntil.IsZero() {
+		t.Fatal("demoted generation has a ZERO VerifyUntil, which means ALREADY EXPIRED — " +
+			"every pre-rotation artifact would be rejected immediately")
+	}
+	if want := now.Add(defaultVerifyWindow); !prev.VerifyUntil.Equal(want) {
+		t.Errorf("VerifyUntil = %v, want %v (now + defaultVerifyWindow)", prev.VerifyUntil, want)
+	}
+
+	// Both generations must be acceptable right now — that is what keeps
+	// unconverged spokes authenticating during the walk.
+	if got := len(next.acceptableGenerations(now)); got != 2 {
+		t.Errorf("acceptable generations = %d immediately after rotation, want 2", got)
+	}
+	// And the previous one must STOP being acceptable once its window closes,
+	// with no operator action.
+	if got := len(next.acceptableGenerations(now.Add(defaultVerifyWindow + time.Minute))); got != 1 {
+		t.Errorf("acceptable generations = %d after verify_until, want 1 — the window must close on the wall clock", got)
+	}
+
+	// The generated secret must be a full-length hex master, not a short read.
+	if len(next.currentSecret()) != masterSecretBytes*2 {
+		t.Errorf("new master is %d chars, want %d hex chars", len(next.currentSecret()), masterSecretBytes*2)
+	}
+}
+
+// TestRotationSurvivesRestart is property (1): persist, then reload from disk
+// exactly as NewHubServer does, and confirm the rotated state came back.
+func TestRotationSurvivesRestart(t *testing.T) {
+	path := withTempGenerationsPath(t)
+	s := newRotationTestHub(t, rotStoreSecretA)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rotated, _, err := s.rotateMasterSecret(now, false)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("rotation did not persist a generations file: %v", err)
+	}
+
+	// SIMULATED RESTART: nothing survives but the PVC and hub-secret.key.
+	reloaded, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
+	if reloaded == nil {
+		t.Fatal("reload returned no generation set")
+	}
+	if reloaded.Current != rotated.Current {
+		t.Errorf("after restart current = %d, want %d — the hub forgot the rotation", reloaded.Current, rotated.Current)
+	}
+	if reloaded.currentSecret() != rotated.currentSecret() {
+		t.Error("after restart the minting secret differs — artifacts minted before the roll would not verify")
+	}
+	if len(reloaded.Generations) != 2 {
+		t.Fatalf("after restart live generations = %d, want 2", len(reloaded.Generations))
+	}
+	if reloaded.Generations[1].Secret != rotStoreSecretA {
+		t.Error("after restart the previous generation lost the outgoing master")
+	}
+	if reloaded.Generations[1].VerifyUntil.IsZero() {
+		t.Fatal("after restart the previous generation has a ZERO VerifyUntil — it would be treated as expired")
+	}
+	// The cooldown timestamp must survive too, or a hub roll would reset the
+	// double-rotation guard.
+	if rotatedAt.IsZero() {
+		t.Fatal("RotatedAt did not survive the restart — the cooldown would reset on every hub roll")
+	}
+	if !rotatedAt.Equal(now) {
+		t.Errorf("RotatedAt = %v, want %v", rotatedAt, now)
+	}
+
+	// The file must be 0600: it holds master secrets in plaintext.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != hubGenerationsFileMode {
+		t.Errorf("generations file mode = %o, want %o — it contains master secrets", perm, hubGenerationsFileMode)
+	}
+
+	// POSITIVE CONTROL for this test. "reload always returns the legacy set"
+	// would pass every assertion above if the legacy set happened to match, so
+	// assert the reloaded state is NOT the pre-rotation state.
+	legacy := legacyGenerationSet(rotStoreSecretA)
+	if reloaded.Current == legacy.Current {
+		t.Error("reloaded set is the pre-rotation legacy set — the rotation was not actually persisted")
+	}
+	if reloaded.currentSecret() == legacy.currentSecret() {
+		t.Error("reloaded minting secret is the pre-rotation master")
+	}
+}
+
+// TestSecondRotationIsRefused is property (2).
+func TestSecondRotationIsRefused(t *testing.T) {
+	withTempGenerationsPath(t)
+	s := newRotationTestHub(t, rotStoreSecretA)
+	now := time.Now().UTC()
+
+	first, _, err := s.rotateMasterSecret(now, false)
+	if err != nil {
+		t.Fatalf("first rotate: %v", err)
+	}
+
+	t.Run("immediate second rotation refused", func(t *testing.T) {
+		_, decision, err := s.rotateMasterSecret(now.Add(time.Minute), false)
+		if err == nil {
+			t.Fatal("second rotation was allowed — it would drop the generation most spokes are still on")
+		}
+		if decision.Allowed {
+			t.Error("decision reports Allowed on a refusal")
+		}
+		if decision.RetryAfter <= 0 {
+			t.Error("refusal did not report a RetryAfter")
+		}
+		// The refusal must be a NO-OP: the set is unchanged.
+		if s.currentGenerations().Current != first.Current {
+			t.Error("a refused rotation still changed the current generation")
+		}
+		if s.currentGenerations().currentSecret() != first.currentSecret() {
+			t.Error("a refused rotation still changed the minting secret")
+		}
+	})
+
+	t.Run("force overrides", func(t *testing.T) {
+		forced, decision, err := s.rotateMasterSecret(now.Add(time.Minute), true)
+		if err != nil {
+			t.Fatalf("forced rotation refused: %v", err)
+		}
+		if !decision.Allowed {
+			t.Error("forced decision reports not Allowed")
+		}
+		if decision.RetryAfter <= 0 {
+			t.Error("a forced-within-cooldown rotation should still report the remaining cooldown")
+		}
+		if forced.Current != first.Current+1 {
+			t.Errorf("forced current = %d, want %d", forced.Current, first.Current+1)
+		}
+		// maxLiveGenerations still holds, and the generation from two rotations
+		// ago is GONE — which is exactly the hazard the cooldown guards.
+		if len(forced.Generations) != maxLiveGenerations {
+			t.Errorf("live generations = %d, want %d", len(forced.Generations), maxLiveGenerations)
+		}
+		for _, g := range forced.Generations {
+			if g.Secret == rotStoreSecretA {
+				t.Error("the original master is still live after two rotations — maxLiveGenerations is not holding")
+			}
+		}
+	})
+
+	t.Run("allowed again after the cooldown lapses", func(t *testing.T) {
+		s2 := newRotationTestHub(t, rotStoreSecretA)
+		base := time.Now().UTC()
+		if _, _, err := s2.rotateMasterSecret(base, false); err != nil {
+			t.Fatalf("first rotate: %v", err)
+		}
+		if _, _, err := s2.rotateMasterSecret(base.Add(rotationCooldown+time.Minute), false); err != nil {
+			t.Fatalf("rotation after the cooldown was refused: %v", err)
+		}
+	})
+}
+
+// TestEvaluateRotationGuard walks the pure decision function directly.
+func TestEvaluateRotationGuard(t *testing.T) {
+	now := time.Now()
+
+	t.Run("never rotated is allowed", func(t *testing.T) {
+		if d := evaluateRotation(time.Time{}, now, false); !d.Allowed {
+			t.Fatalf("a hub that has never rotated was refused: %+v", d)
+		}
+	})
+	t.Run("inside the cooldown is refused", func(t *testing.T) {
+		d := evaluateRotation(now.Add(-time.Hour), now, false)
+		if d.Allowed {
+			t.Fatal("allowed one hour after a rotation")
+		}
+		if d.Reason == "" {
+			t.Error("refusal carries no reason for the operator")
+		}
+	})
+	t.Run("exactly at the cooldown is allowed", func(t *testing.T) {
+		if d := evaluateRotation(now.Add(-rotationCooldown), now, false); !d.Allowed {
+			t.Fatal("refused exactly at the cooldown boundary")
+		}
+	})
+	t.Run("force allows inside the cooldown", func(t *testing.T) {
+		if d := evaluateRotation(now.Add(-time.Hour), now, true); !d.Allowed {
+			t.Fatal("force did not override the cooldown")
+		}
+	})
+	// A lastRotation in the FUTURE — clock skew or a hand-edited file — must
+	// fail closed rather than compute a nonsense RetryAfter.
+	t.Run("future lastRotation fails closed", func(t *testing.T) {
+		d := evaluateRotation(now.Add(24*time.Hour), now, false)
+		if d.Allowed {
+			t.Fatal("allowed with a lastRotation in the future")
+		}
+		if d.RetryAfter > rotationCooldown {
+			t.Errorf("RetryAfter = %v exceeds the cooldown %v", d.RetryAfter, rotationCooldown)
+		}
+	})
+	// The cooldown must be sized to CONVERGENCE, not to the verify window. If
+	// it were >= defaultVerifyWindow an emergency re-rotation would be
+	// impossible for a week.
+	t.Run("cooldown is shorter than the verify window", func(t *testing.T) {
+		if rotationCooldown >= defaultVerifyWindow {
+			t.Fatalf("rotationCooldown %v >= defaultVerifyWindow %v — emergency re-rotation would be blocked for the whole window",
+				rotationCooldown, defaultVerifyWindow)
+		}
+	})
+}
+
+// TestConcurrentRotationsProduceOne is the double-submit guarantee, exercised
+// concurrently rather than argued for in a comment.
+func TestConcurrentRotationsProduceOne(t *testing.T) {
+	withTempGenerationsPath(t)
+	s := newRotationTestHub(t, rotStoreSecretA)
+	now := time.Now().UTC()
+
+	const attempts = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	succeeded := 0
+	wg.Add(attempts)
+	for i := 0; i < attempts; i++ {
+		go func() {
+			defer wg.Done()
+			if _, _, err := s.rotateMasterSecret(now, false); err == nil {
+				mu.Lock()
+				succeeded++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if succeeded != 1 {
+		t.Fatalf("%d of %d concurrent rotations succeeded, want exactly 1 — a double-submit must not rotate twice", succeeded, attempts)
+	}
+	if got := s.currentGenerations().Current; got != legacyGenerationID+1 {
+		t.Errorf("current = %d after %d concurrent attempts, want %d", got, attempts, legacyGenerationID+1)
+	}
+}
+
+// TestMalformedGenerationsFileFailsClosed is property (3).
+func TestMalformedGenerationsFileFailsClosed(t *testing.T) {
+	legacy := legacyGenerationSet(rotStoreSecretA)
+
+	cases := []struct {
+		name    string
+		content string
+		// quarantined is whether the bad file should be moved aside.
+		quarantined bool
+	}{
+		{
+			name:        "not JSON at all",
+			content:     "this is not json {{{",
+			quarantined: true,
+		},
+		{
+			name: "current names a generation that is not present",
+			content: `{"current": 99, "generations": [
+				{"id": 1, "secret": "` + rotStoreSecretA + `"}
+			]}`,
+		},
+		{
+			name: "every generation has an empty secret",
+			content: `{"current": 2, "generations": [
+				{"id": 2, "secret": ""},
+				{"id": 1, "secret": "   "}
+			]}`,
+		},
+		{
+			name:    "empty generation list",
+			content: `{"current": 1, "generations": []}`,
+		},
+		{
+			name:    "empty object",
+			content: `{}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := withTempGenerationsPath(t)
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			gs, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
+			if gs == nil {
+				t.Fatal("loadGenerations returned nil — the hub would have no minting key at all")
+			}
+			// Fails closed to the LEGACY set, which is always correct because
+			// hub-secret.key is authoritative for generation 1.
+			if gs.Current != legacy.Current {
+				t.Errorf("current = %d, want the legacy generation %d", gs.Current, legacy.Current)
+			}
+			if gs.currentSecret() != rotStoreSecretA {
+				t.Error("did not fall back to the master from hub-secret.key")
+			}
+			if len(gs.Generations) != 1 {
+				t.Errorf("live generations = %d, want exactly the single legacy generation", len(gs.Generations))
+			}
+			if !rotatedAt.IsZero() {
+				t.Error("a malformed file yielded a non-zero RotatedAt")
+			}
+			// A malformed file must NOT trigger a fresh rotation — that would
+			// mint material the fleet has never seen while forgetting the
+			// generation it is actually on.
+			if gs.currentSecret() != legacy.currentSecret() {
+				t.Fatal("a malformed file caused the hub to mint on a NEW key — it must fall back, not rotate")
+			}
+			if tc.quarantined {
+				if _, err := os.Stat(path + hubGenerationsQuarantineSuffix); err != nil {
+					t.Errorf("unparseable file was not quarantined for inspection: %v", err)
+				}
+			}
+		})
+	}
+
+	// A generation whose VerifyUntil is absent must load, and then be REFUSED
+	// at verify time — zero means ALREADY EXPIRED, never "never expires".
+	t.Run("previous generation with no verify_until is loaded but not accepted", func(t *testing.T) {
+		path := withTempGenerationsPath(t)
+		content := `{"current": 2, "generations": [
+			{"id": 2, "secret": "` + rotStoreSecretB + `"},
+			{"id": 1, "secret": "` + rotStoreSecretA + `"}
+		]}`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		gs, _ := loadGenerations(rotStoreSecretA, quietLogger())
+		if gs == nil || gs.Current != 2 {
+			t.Fatalf("a well-formed file should load; got %+v", gs)
+		}
+		acceptable := gs.acceptableGenerations(time.Now())
+		if len(acceptable) != 1 || acceptable[0].ID != 2 {
+			t.Fatalf("acceptable = %+v, want only the current generation — a missing verify_until must read as ALREADY EXPIRED", acceptable)
+		}
+	})
+
+	// POSITIVE CONTROL for the whole block. Every case above asserts a
+	// FALLBACK, and "always fall back to legacy" would satisfy all of them. So
+	// assert that a VALID file is honoured and does NOT fall back.
+	t.Run("positive control: a valid file is honoured", func(t *testing.T) {
+		path := withTempGenerationsPath(t)
+		until := time.Now().Add(defaultVerifyWindow).UTC().Format(time.RFC3339)
+		content := `{"current": 2, "rotated_at": "` + time.Now().UTC().Format(time.RFC3339) + `", "generations": [
+			{"id": 2, "secret": "` + rotStoreSecretB + `"},
+			{"id": 1, "secret": "` + rotStoreSecretA + `", "verify_until": "` + until + `"}
+		]}`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		gs, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
+		if gs == nil {
+			t.Fatal("valid file did not load")
+		}
+		if gs.Current != 2 {
+			t.Fatalf("current = %d, want 2 — a VALID file must be honoured, not discarded", gs.Current)
+		}
+		if gs.currentSecret() != rotStoreSecretB {
+			t.Error("valid file did not install its current secret")
+		}
+		if len(gs.acceptableGenerations(time.Now())) != 2 {
+			t.Error("valid file did not yield two acceptable generations")
+		}
+		if rotatedAt.IsZero() {
+			t.Error("valid file did not yield its rotated_at")
+		}
+		if _, err := os.Stat(path + hubGenerationsQuarantineSuffix); err == nil {
+			t.Error("a VALID file was quarantined")
+		}
+	})
+}
+
+// TestMissingGenerationsFileIsNormal — the state of every hub in the fleet.
+func TestMissingGenerationsFileIsNormal(t *testing.T) {
+	withTempGenerationsPath(t) // temp dir; the file does not exist
+	gs, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
+	if gs == nil {
+		t.Fatal("a missing generations file must synthesize the legacy set, not return nil")
+	}
+	if gs.Current != legacyGenerationID || gs.currentSecret() != rotStoreSecretA {
+		t.Errorf("got current=%d, want the single legacy generation from hub-secret.key", gs.Current)
+	}
+	if !rotatedAt.IsZero() {
+		t.Error("a never-rotated hub reported a rotation time")
+	}
+	// An empty master must still fail closed, exactly as before.
+	if gs, _ := loadGenerations("", quietLogger()); gs != nil {
+		t.Error("an empty master produced a generation set")
+	}
+}
+
+// TestSaveGenerationsRefusesEmpty — never persist a set with no minting key.
+func TestSaveGenerationsRefusesEmpty(t *testing.T) {
+	path := withTempGenerationsPath(t)
+	if err := saveGenerations(nil, time.Now()); err == nil {
+		t.Error("saveGenerations(nil) succeeded")
+	}
+	if err := saveGenerations(&generationSet{Current: 1}, time.Now()); err == nil {
+		t.Error("saveGenerations with no generations succeeded")
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("a refused save still wrote a file")
+	}
+	// POSITIVE CONTROL: a real set DOES persist.
+	if err := saveGenerations(legacyGenerationSet(rotStoreSecretA), time.Now()); err != nil {
+		t.Fatalf("saveGenerations refused a valid set: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("a valid save wrote nothing: %v", err)
+	}
+}
+
+// --- Handler tests -------------------------------------------------------
+
+// newRotationHandlerHub builds a hub with a real mux so the requireAdmin
+// wrapper — and therefore isCSRFSafe — is actually exercised, rather than
+// calling the handler directly and testing nothing about authorisation.
+func newRotationHandlerHub(t *testing.T) *HubServer {
+	t.Helper()
+	withTempGenerationsPath(t)
+	s := newRotationTestHub(t, rotStoreSecretA)
+	s.mux = http.NewServeMux()
+	s.mux.HandleFunc("GET /api/saas/admin/key-generations", s.requireAdmin(s.handleKeyGenerations))
+	s.mux.HandleFunc("POST /api/saas/admin/rotate-master-key", s.requireAdmin(s.handleRotateMasterKey))
+	return s
+}
+
+// TestRotateEndpointRejectsNonAdmin: the endpoint must be unreachable without
+// admin, and unreachable cross-site even WITH a session.
+func TestRotateEndpointRejectsNonAdmin(t *testing.T) {
+	s := newRotationHandlerHub(t)
+	beforeCurrent := s.currentGenerations().Current
+	beforeSecret := s.currentGenerations().currentSecret()
+
+	post := func(t *testing.T, mutate func(*http.Request)) *httptest.ResponseRecorder {
+		t.Helper()
+		r := httptest.NewRequest(http.MethodPost, "/api/saas/admin/rotate-master-key", strings.NewReader(`{}`))
+		r.Header.Set("Content-Type", "application/json")
+		if mutate != nil {
+			mutate(r)
+		}
+		w := httptest.NewRecorder()
+		s.mux.ServeHTTP(w, r)
+		return w
+	}
+
+	t.Run("unauthenticated is refused", func(t *testing.T) {
+		if code := post(t, nil).Code; code == http.StatusOK {
+			t.Fatal("an unauthenticated POST rotated the master key")
+		}
+	})
+
+	t.Run("cross-site is refused by isCSRFSafe", func(t *testing.T) {
+		w := post(t, func(r *http.Request) {
+			r.Header.Set("Origin", "https://evil.example.com")
+		})
+		if w.Code != http.StatusForbidden {
+			t.Errorf("cross-origin POST got %d, want 403 — requireAdmin must call isCSRFSafe", w.Code)
+		}
+	})
+
+	// Nothing above may have changed the key material.
+	if s.currentGenerations().Current != beforeCurrent {
+		t.Error("a rejected request still rotated the current generation")
+	}
+	if s.currentGenerations().currentSecret() != beforeSecret {
+		t.Error("a rejected request still changed the minting secret")
+	}
+	if _, err := os.Stat(hubGenerationsPath); err == nil {
+		t.Error("a rejected request still persisted a generations file")
+	}
+}
+
+// TestRotateResponseLeaksNoSecret is the secret-hygiene assertion, made by test
+// rather than by review: no response body and no persisted-file-adjacent
+// surface may contain any master secret.
+func TestRotateResponseLeaksNoSecret(t *testing.T) {
+	withTempGenerationsPath(t)
+	s := newRotationTestHub(t, rotStoreSecretA)
+	now := time.Now().UTC()
+	next, _, err := s.rotateMasterSecret(now, false)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	newSecret := next.currentSecret()
+
+	// Build the exact response the handler builds.
+	w := httptest.NewRecorder()
+	s.handleKeyGenerations(w, httptest.NewRequest(http.MethodGet, "/api/saas/admin/key-generations", nil))
+	bodies := []string{w.Body.String()}
+
+	rw := httptest.NewRecorder()
+	rr := httptest.NewRequest(http.MethodPost, "/api/saas/admin/rotate-master-key", strings.NewReader(`{}`))
+	s.handleRotateMasterKey(rw, rr) // refused by the cooldown; still a response body
+	bodies = append(bodies, rw.Body.String())
+
+	for i, body := range bodies {
+		for _, secret := range []string{newSecret, rotStoreSecretA} {
+			if strings.Contains(body, secret) {
+				t.Fatalf("response %d contains master secret material", i)
+			}
+		}
+	}
+
+	// The read endpoint must still be USEFUL — a handler that returned nothing
+	// would trivially leak nothing. Positive control.
+	var view keyGenerationsResponse
+	if err := json.Unmarshal([]byte(bodies[0]), &view); err != nil {
+		t.Fatalf("key-generations response is not JSON: %v", err)
+	}
+	if view.Current != next.Current {
+		t.Errorf("view current = %d, want %d", view.Current, next.Current)
+	}
+	if len(view.Generations) != 2 {
+		t.Fatalf("view lists %d generations, want 2", len(view.Generations))
+	}
+	if view.PersistPath == "" {
+		t.Error("view does not report where generations are persisted")
+	}
+	if view.LastRotation == "" {
+		t.Error("view does not report the last rotation")
+	}
+	if view.RotateAvailableInSeconds <= 0 {
+		t.Error("view does not report the remaining cooldown right after a rotation")
+	}
+	var sawCurrent, sawPrevious bool
+	for _, g := range view.Generations {
+		if g.Current {
+			sawCurrent = true
+			if !g.Acceptable {
+				t.Error("the current generation is reported as not acceptable")
+			}
+			if g.VerifyUntil != "" {
+				t.Error("the current generation carries a verify_until; it never expires")
+			}
+		} else {
+			sawPrevious = true
+			if g.VerifyUntil == "" {
+				t.Error("the previous generation does not publish its verify_until")
+			}
+		}
+	}
+	if !sawCurrent || !sawPrevious {
+		t.Error("the view does not distinguish current from previous")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -505,6 +505,13 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
 	// #3234: fleet readiness for removing the N1/N2 legacy compatibility lanes.
 	s.mux.HandleFunc("GET /api/saas/admin/auth-rollout", s.requireAdmin(s.handleAuthRollout))
+	// Master-secret rotation (v2/docs/design/master-key-rotation.md). Both are
+	// requireAdmin, which enforces isCSRFSafe BEFORE resolving identity — an
+	// ambient hub session cookie would otherwise make a cross-site POST able to
+	// rotate the fleet's master key. The rotate route is a POST for that reason
+	// too: isCSRFSafe exempts safe methods.
+	s.mux.HandleFunc("GET /api/saas/admin/key-generations", s.requireAdmin(s.handleKeyGenerations))
+	s.mux.HandleFunc("POST /api/saas/admin/rotate-master-key", s.requireAdmin(s.handleRotateMasterKey))
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
 	s.mux.HandleFunc("DELETE /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminDeleteUser))
 	// Admin read-only "View as user" impersonation. Enter is admin-only and
@@ -604,7 +611,7 @@ func (s *HubServer) activeImpersonationGrant(r *http.Request) (impersonationGran
 	if err != nil || cookie.Value == "" {
 		return impersonationGrant{}, false
 	}
-	grant, _, ok := verifyImpersonateCookieValueWithGenerations(s.keyGenerations, cookie.Value, time.Now())
+	grant, _, ok := verifyImpersonateCookieValueWithGenerations(s.currentGenerations(), cookie.Value, time.Now())
 	if !ok || !isHubAdmin(grant.Admin) {
 		return impersonationGrant{}, false
 	}
@@ -870,7 +877,7 @@ func (s *HubServer) resolveIdentity(r *http.Request) (effective, realUser string
 	if err != nil || cookie.Value == "" {
 		return realUser, realUser, false
 	}
-	grant, _, ok := verifyImpersonateCookieValueWithGenerations(s.keyGenerations, cookie.Value, time.Now())
+	grant, _, ok := verifyImpersonateCookieValueWithGenerations(s.currentGenerations(), cookie.Value, time.Now())
 	if !ok {
 		return realUser, realUser, false
 	}
@@ -1292,7 +1299,7 @@ func (s *HubServer) handleImpersonateStart(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, http.StatusNotFound, "user not found")
 		return
 	}
-	value := mintImpersonateCookieValueForGeneration(s.keyGenerations, admin, target, time.Now())
+	value := mintImpersonateCookieValueForGeneration(s.currentGenerations(), admin, target, time.Now())
 	if value == "" {
 		writeJSONError(w, http.StatusInternalServerError, "cannot start impersonation")
 		return

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -798,9 +798,23 @@ type HubServer struct {
 	// (hub_generations.go). Until a rotation happens it holds exactly ONE
 	// generation whose secret IS hubSecret, so every derived key is
 	// byte-identical to the single-master behavior and dual acceptance
-	// degenerates to single acceptance. It is set once in NewHubServer and read
-	// without a lock; a rotation endpoint that replaces it will need one.
-	keyGenerations *generationSet
+	// degenerates to single acceptance.
+	//
+	// GUARDED BY keyGenerationsMu. The admin rotate endpoint replaces this
+	// pointer while heartbeat and cookie verifiers are concurrently reading it,
+	// so every access goes through currentGenerations() / setGenerations()
+	// rather than touching the field. The field itself is only ever REPLACED,
+	// never mutated in place — generationSet.rotate is pure and returns a new
+	// set — so a reader that grabbed the old pointer keeps a consistent,
+	// immutable snapshot and simply verifies against the pre-rotation set for
+	// the remainder of its request. That is correct, not a race: the outgoing
+	// generation is still acceptable.
+	keyGenerationsMu sync.RWMutex
+	keyGenerations   *generationSet
+	// lastKeyRotation is when the current generation was minted, used ONLY by
+	// the double-rotation cooldown (evaluateRotation). It is never consulted to
+	// decide whether a key is acceptable — VerifyUntil alone does that.
+	lastKeyRotation time.Time
 	// lastHubUpgradeTrigger debounces the hub self-upgrade rollout restart so the
 	// every-cycle behind-latest check doesn't re-restart while a rollout is still
 	// in flight. See the auto-upgrade block in the SHA-poll loop. It also marks
@@ -1136,8 +1150,10 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		hubGitHash:   gitHash,
 		hubGitBranch: gitBranch,
 		hubSecret:    secret,
-		// One generation, holding the existing master. No migration step and no
-		// behavior change: see legacyGenerationSet.
+		// Provisional single generation holding the existing master. Replaced
+		// immediately below by loadGenerations, which reads any persisted
+		// rotation off the PVC. It is set here too so the field is never nil
+		// between struct construction and that load.
 		keyGenerations:          legacyGenerationSet(secret),
 		clusters:                loadClusters(logger),
 		heartbeatHealth:         make(map[string]*HeartbeatHealthEntry),
@@ -1155,6 +1171,19 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		alerts:                  newAlertState(),
 		revokedSessions:         newRevokedSessions(),
 		urlHealth:               newURLHealthState(),
+	}
+
+	// Restore any persisted rotation BEFORE anything mints or verifies. A hub
+	// that came back on generation 1 after a rotation would reject every
+	// artifact minted since it and quietly re-mint on the old key — strictly
+	// worse than never having rotated. Falls back to the single-generation
+	// legacy set on a missing or unusable file, which is correct because
+	// hub-secret.key is authoritative for generation 1 and is never rewritten.
+	if gs, rotatedAt := loadGenerations(secret, logger); gs != nil {
+		s.keyGenerations = gs
+		// Restore the rotation timestamp too, or the cooldown would reset on
+		// every hub roll and stop guarding anything.
+		s.lastKeyRotation = rotatedAt
 	}
 
 	s.loadRegistry()


### PR DESCRIPTION
Follow-on **PR #4** of the hub master-key rotation design (`v2/docs/design/master-key-rotation.md`). This is the PR that **arms** the rest: the foundation in `58c15549` could *represent* a rotation but could neither create one nor remember one. **Hub-internal — no spoke rolls as a result of this change.**

## Persistence — `/data/saas/hub-generations.json`

A sibling of `hub-secret.key` on the hub PVC, at mode **0600** rather than the 0644 its JSON neighbours use — this file holds master secrets in plaintext.

`hub-secret.key` is **never rewritten**, so it remains generation 1 and a hub that rolls back to pre-rotation code finds exactly what it expects. When the generations file is absent — the state of every hub in the fleet today — the loader synthesizes the legacy single-generation set. No migration step.

Two ordering decisions:

- **Persist before install.** A failed write leaves the hub on the old set and returns an error, rather than minting on a key it forgets at its next roll — and the hub rolls several times a day.
- **`rotated_at` is persisted alongside the set.** Without it the cooldown below would reset on every hub roll and stop guarding anything.

## Double-rotation guard: REFUSE, with an explicit `force` override

`maxLiveGenerations` is 2 and `rotate()` carries forward only the outgoing current, so a second rotation **drops the generation from two rotations ago** — the one most of the fleet is still on, because the reconcile lane walks spokes at 3 patches per 15-minute cycle. A second rotation an hour into the first would leave ~54 of 66 spokes holding material the hub no longer accepts: heartbeat 401s until the sweep reaches them, hours later. That is the flag day this design exists to prevent, reintroduced through the front door.

**Chosen: 409 with `retry_after_seconds`; `force: true` to override.** A warning on a response body is not a control — the operator most likely to double-rotate is the one who did not realise the first rotation was still in flight, which is precisely the operator who will not read it.

`force` is honoured rather than omitted because there is a real case for it: if the **new** generation is itself compromised, rotating again immediately is correct even at the cost of stranding spokes for a few hours. A guard with no override would turn the cooldown into a window of known-compromised material.

`rotationCooldown` is **8 hours** — sized to *convergence* (~5.5h for 66 spokes at 3 per 15-min cycle, plus margin for cycles lost to unreachable clusters), deliberately **not** to `defaultVerifyWindow`. Waiting for the previous generation to expire would block emergency re-rotation for a week, and the hazard is unconverged spokes, not the old key still being accepted. A test asserts `rotationCooldown < defaultVerifyWindow`.

### Idempotency

`rotateMasterSecret` holds the generation write lock across evaluate→generate→persist→install, so two concurrent POSTs cannot both observe a pre-rotation `lastKeyRotation`. **The cooldown *is* the double-submit guard**, not a policy layered on top of one. `TestConcurrentRotationsProduceOne` fires 8 simultaneous rotations and asserts exactly one succeeds.

## Endpoints

```
POST /api/saas/admin/rotate-master-key   {"force": bool}
GET  /api/saas/admin/key-generations
```

Both `requireAdmin`, following the ~21 existing `/api/saas/admin/*` routes. `requireAdmin` calls **`isCSRFSafe` first**, before any identity resolution (verified during F4 — both `requireAuth` and `requireAdmin` enforce it). Without that, the ambient hub session cookie would let a cross-site form POST rotate the fleet's master secret.

**No secret material is logged or returned anywhere** — IDs, counts, and timestamps only. A generation ID names a key; it is not a key. Asserted by test against both response bodies, not just by review.

## Fail-closed loading

- **Corrupt file** → quarantined to `.corrupt`, loader falls back to the legacy set. It is **not** discarded and replaced with a fresh rotation, which would mint material the fleet has never seen while forgetting the generation it is actually on. This differs deliberately from the alert-acks precedent, where starting fresh is the safe direction.
- **`current` names a missing generation / all secrets empty / empty list** → legacy set.
- **Expiry is NOT filtered at load time.** An expired previous generation loads and is then excluded by `acceptableGenerations` at every verify, so the wall clock alone closes the window — filtering at load would make expiry depend on when the hub last restarted.
- A previous generation with **no** `verify_until` loads but is **not accepted**: zero means ALREADY EXPIRED, never "never expires".

## Concurrency

`keyGenerations` is now guarded by `keyGenerationsMu` and reached through `currentGenerations()` / `setGenerations()`. The field is only ever **replaced**, never mutated (`rotate` is pure), so a verifier holding the old pointer keeps a consistent snapshot and verifies against the pre-rotation set — correct, not a race, because the outgoing generation is still acceptable. This resolves the *"a rotation endpoint that replaces it will need one"* note left on the field in `58c15549`.

## Tests

New `pkg/hub/hub_generations_store_test.go`. Regression replay (neuter → compile → confirm fail → restore → confirm green), five neuters:

| Neuter | Failing test |
|---|---|
| rotation never persisted | `TestRotationSurvivesRestart` |
| double-rotation guard removed | `TestSecondRotationIsRefused` (2 subtests) + `TestConcurrentRotationsProduceOne` (8/8 succeeded) |
| malformed file mints a fresh key instead of failing closed | `TestMalformedGenerationsFileFailsClosed/not_JSON_at_all` |
| demotion sets no `VerifyUntil` | `TestRotateDemotesAndSetsVerifyUntil`, `TestRotationSurvivesRestart`, `TestRotateResponseLeaksNoSecret` — plus 4 pre-existing foundation/impersonation tests |
| `requireAdmin` removed from the rotate route | `TestRotateEndpointRejectsNonAdmin` (both subtests + all 3 no-op assertions) |

Positive controls throughout: the malformed-file block asserts a **valid** file is honoured and not quarantined (otherwise "always fall back" would pass every case); `TestSaveGenerationsRefusesEmpty` asserts a real set does persist; `TestRotateResponseLeaksNoSecret` asserts the read endpoint is still **useful** (a handler returning nothing would trivially leak nothing).

Full `pkg/hub` suite green (127s). `gofmt` clean on all new/modified files — the `gofmt -l` hits in `pkg/hub` are pre-existing on clean `v4`.

**No existing test was modified.**

## Design doc

Updated with an "As-built notes for PR #4" section recording the two decisions the design did not pin down: the refuse-with-force choice and its cooldown sizing, and the persistence/ordering details.