### PR TITLE
🐛 hub: NET_ADMIN reconcile selected no hives — sweep was dead code

### DIFF
--- a/v2/pkg/hub/netadmin_reconcile.go
+++ b/v2/pkg/hub/netadmin_reconcile.go
@@ -56,6 +56,59 @@ const (
 	hiveContainerSecurityContextPath = "/spec/template/spec/containers/0/securityContext"
 )
 
+// netAdminSweepEligible reports whether a hive with this lifecycle status
+// should be examined by the NET_ADMIN drift sweep. Extracted as a named
+// predicate — the same shape as securityContextHasNetAdmin — so the selection
+// rule is a single testable decision that the sweep and its test share, rather
+// than an inline comparison a test could only re-implement (and therefore keep
+// passing after the sweep's own check broke).
+//
+// WHY THIS EXISTS. The original guard was `h.Status != "running"`. It selected
+// NOTHING: across the live 66-hive registry the status distribution is 30
+// "available", 28 "", 8 "assigned" — zero "running". Only two sites write
+// "running": the provision watcher in saas_provision.go, which sets it on the
+// transition OUT of "provisioning", and the stale-"error" clear on heartbeat in
+// server.go, which is gated on Status == "error" and so only rescues a hive out
+// of error. Neither puts or holds a steady-state hive at "running", and nothing
+// re-asserts it, so a hive in steady state never carries it. This sweep
+// therefore `continue`d on every hive of every cycle and has never patched a
+// Deployment in production — the pre-#1222 drift it exists to close was only
+// ever repaired by the out-of-band `kubectl patch` recorded in issue #2674.
+//
+// WHAT IT SHOULD HAVE EXPRESSED. Not "is running" but "is deployed" — does this
+// hive plausibly have a hive Deployment to reconcile? The sibling sweeps over
+// the same listSaaSHives() (triggerAutoUpgrades, sweepOrphanedUpgrades,
+// sweepStuckAssignments) apply NO status filter at all and gate instead on the
+// resources they actually need. This predicate follows that convention, naming
+// only the one status that is genuinely premature.
+//
+//   - "" (28 live) — the common steady state: provisioned and deployed, with a
+//     status that was simply never written. Must be swept.
+//   - "available" (30 live) — an unclaimed pre-provisioned placeholder. Its
+//     Deployment is live, and it must carry NET_ADMIN BEFORE it is claimed: a
+//     placeholder handed to a user while drifted crash-loops the moment the F5
+//     fatal-egress image rolls onto it, which is the exact failure this sweep
+//     exists to prevent.
+//   - "assigned" (8 live) — claimed and deployed. Obviously swept.
+//   - "running" — kept so the pre-existing intent still selects, not because
+//     anything reaches it.
+//   - "error" — SWEPT. The status is frequently stale (only a heartbeat clears
+//     it), the Deployment usually still exists, and missing NET_ADMIN is a
+//     plausible CAUSE of the error (an F5 fatal-egress crash-loop presents
+//     exactly this way) rather than a reason to leave it drifted.
+//
+// Only "provisioning" is excluded: the namespace and Deployment are still being
+// applied, and the provisioning template has requested NET_ADMIN since #1222, so
+// a hive created now is born correct. This is a cheap-cycle optimisation, NOT a
+// safety gate. The sweep is safe on an unreadable hive for a stronger reason
+// than its per-hive-env sibling: a failed `kubectl get` logs at Debug and
+// `continue`s, and this sweep records NO observations of any kind — it has no
+// seen-map and publishes no convergence surface, so there is no state in which
+// an unread hive could ever be counted as healthy.
+func netAdminSweepEligible(status string) bool {
+	return strings.TrimSpace(status) != "provisioning"
+}
+
 // securityContextHasNetAdmin reports whether the jsonpath-extracted list of
 // added capabilities already contains NET_ADMIN. This is the PURE decision
 // function — no kubectl, fully unit-testable. `raw` is the trimmed stdout of:
@@ -131,15 +184,25 @@ func (s *HubServer) reconcileNetAdminIfDue() {
 // retried on the next sweep).
 func (s *HubServer) reconcileNetAdmin() {
 	hives := listSaaSHives()
+	// Selection accounting. A sweep that selects NOBODY is the exact failure
+	// this lane shipped with, and nothing made it visible: every counter
+	// downstream of the filter stayed at zero, which is indistinguishable from
+	// a fleet with no drift. Recording the considered/skipped split makes "the
+	// filter matches nothing" readable instead of silent.
+	consideredHives := 0
+	skippedByStatus := 0
 	for _, h := range hives {
-		// Only hives with a live Deployment on a resolvable cluster. A hive
-		// still provisioning has no stable deployment to reconcile yet, and one
-		// in error/deprovisioned state may have none at all — both are picked up
-		// on a later sweep once running. This mirrors how triggerAutoUpgrades
-		// resolves the cluster before touching a hive.
-		if h.Status != "running" {
+		// Only hives that plausibly have a live Deployment on a resolvable
+		// cluster. A hive still provisioning has no stable deployment to
+		// reconcile yet and is born with NET_ADMIN from the template; every
+		// other status is swept. See netAdminSweepEligible for why this is not
+		// a "running" check. This mirrors how triggerAutoUpgrades resolves the
+		// cluster before touching a hive.
+		if !netAdminSweepEligible(h.Status) {
+			skippedByStatus++
 			continue
 		}
+		consideredHives++
 		cluster := s.clusterForHive(&h)
 		if cluster == nil {
 			continue
@@ -198,5 +261,15 @@ func (s *HubServer) reconcileNetAdmin() {
 		s.markClusterReachable(cluster.ID)
 		s.logger.Info("reconciled NET_ADMIN onto hive deployment",
 			"hive_id", h.ID, "cluster", cluster.ID)
+	}
+
+	// A sweep that admitted no hives at all is a BUG signal, not a quiet no-op:
+	// the registry is never legitimately empty on a hub that hosts spokes. Log
+	// it at Warn so the condition that made this lane dead code for its whole
+	// production life cannot recur silently. Unlike its per-hive-env sibling
+	// this sweep keeps no observation state, so the log IS the surface.
+	if consideredHives == 0 && len(hives) > 0 {
+		s.logger.Warn("netadmin reconcile: status filter selected NO hives — sweep is a no-op, NET_ADMIN drift will not be repaired",
+			"hives_in_registry", len(hives), "skipped_by_status", skippedByStatus)
 	}
 }

--- a/v2/pkg/hub/netadmin_reconcile_test.go
+++ b/v2/pkg/hub/netadmin_reconcile_test.go
@@ -100,3 +100,164 @@ func TestReconcileNetAdminThrottle(t *testing.T) {
 		t.Fatal("reconcile should be due again after the interval elapses")
 	}
 }
+
+// netAdminRealRegistryStatuses are the hive lifecycle statuses that actually
+// occur, with the LIVE distribution measured across all 66
+// /data/saas/hives/*/meta.json records on the production hub at the time this
+// test was written:
+//
+//	30 "available"   28 ""   8 "assigned"   0 "running"
+//
+// The zero is the whole point. The sweep originally guarded on
+// `h.Status != "running"`, so it selected no hive on any cycle and had never
+// patched a Deployment in production. These fixtures are stated as real
+// measured data, not invented values, so that a future change to the status
+// vocabulary which invalidates them is a test failure rather than a silent
+// regression.
+var netAdminRealRegistryStatuses = []struct {
+	status string
+	live   int
+	want   bool
+	why    string
+}{
+	{"", 28, true, "the common steady state: provisioned, deployed, no status ever written"},
+	{"available", 30, true, "unclaimed placeholder; deployed, and must hold NET_ADMIN BEFORE it is claimed or it crash-loops on the F5 image"},
+	{"assigned", 8, true, "claimed and deployed"},
+	{"running", 0, true, "never observed live, but the pre-existing intent must still select"},
+	{"error", 0, true, "status is often stale and the Deployment usually still exists; missing NET_ADMIN may be the CAUSE of the error"},
+	{"provisioning", 0, false, "namespace/Deployment still being applied; the template has requested NET_ADMIN since #1222"},
+}
+
+// netAdminLiveFleetSize is the measured size of the production registry, and
+// the sum of the `live` counts above. Pinned so the two cannot drift apart.
+const netAdminLiveFleetSize = 66
+
+// TestNetAdminSweepEligibleOverRealStatuses pins the sweep's hive-selection
+// predicate against the REAL status vocabulary. This is the test layer that was
+// missing: the existing suite exercised securityContextHasNetAdmin,
+// netAdminPatchJSON and the throttle directly, but nothing covered the filter
+// that decides which hives ever reach any of them — so a filter matching
+// NOTHING left every one of those tests green while the sweep was dead code.
+func TestNetAdminSweepEligibleOverRealStatuses(t *testing.T) {
+	var sum int
+	for _, tc := range netAdminRealRegistryStatuses {
+		sum += tc.live
+		if got := netAdminSweepEligible(tc.status); got != tc.want {
+			t.Errorf("netAdminSweepEligible(%q) = %v, want %v — %s", tc.status, got, tc.want, tc.why)
+		}
+	}
+	if sum != netAdminLiveFleetSize {
+		t.Errorf("fixture live counts sum to %d, want %d — the measured fleet distribution and the pinned size have drifted apart", sum, netAdminLiveFleetSize)
+	}
+}
+
+// TestNetAdminSweepSelectsTheLiveFleet replays the predicate over a fixture
+// with the exact live status distribution and asserts the sweep would examine
+// the whole 66-hive fleet.
+//
+// POSITIVE CONTROL, BOTH DIRECTIONS. The bug being fixed is "selects nothing",
+// so a test that can only fail when the predicate becomes too permissive is
+// insufficient — and the converse is equally true. This asserts an EXACT
+// selected count AND an EXACT skipped count, which together fail in BOTH
+// directions and cannot be satisfied by any predicate that ignores its
+// argument:
+//
+//   - Neuter to `return false` (or restore the shipped `== "running"` guard,
+//     which is behaviourally identical against this fixture since no live hive
+//     is "running"): selected drops to 0 and skipped rises to the full fleet —
+//     both assertions fail.
+//   - Neuter to `return true` (select everything unconditionally): the
+//     "provisioning" row is no longer excluded, so skipped drops to 0 and
+//     selectedProvisioning rises — those assertions fail.
+func TestNetAdminSweepSelectsTheLiveFleet(t *testing.T) {
+	type hive struct{ id, status string }
+	var fleet []hive
+	for _, tc := range netAdminRealRegistryStatuses {
+		for i := 0; i < tc.live; i++ {
+			fleet = append(fleet, hive{id: tc.status + "-" + string(rune('a'+i%26)), status: tc.status})
+		}
+	}
+	if len(fleet) != netAdminLiveFleetSize {
+		t.Fatalf("fixture fleet is %d hives, want the measured %d", len(fleet), netAdminLiveFleetSize)
+	}
+	// Add one synthetic hive for each status that does not occur live, so the
+	// predicate's handling of "running", "error" and "provisioning" is exercised
+	// by the count assertions too rather than only by the table test above.
+	fleet = append(fleet,
+		hive{id: "synthetic-running", status: "running"},
+		hive{id: "synthetic-error", status: "error"},
+		hive{id: "synthetic-provisioning", status: "provisioning"},
+	)
+
+	selected, skipped, selectedProvisioning := 0, 0, 0
+	for _, h := range fleet {
+		if netAdminSweepEligible(h.status) {
+			selected++
+			if h.status == "provisioning" {
+				selectedProvisioning++
+			}
+			continue
+		}
+		skipped++
+	}
+
+	// Direction 1 — the shipped bug. A predicate that selects nobody (or that
+	// keys off "running", which no live hive has) drives this to 0.
+	if selected == 0 {
+		t.Fatal("sweep selected NO hives from a 66-hive fleet — this is the production bug: " +
+			"the lane runs every cycle and patches nothing, so pre-#1222 NET_ADMIN drift is never repaired")
+	}
+	// The 66 live hives + the synthetic "running" and "error" rows are eligible;
+	// only the synthetic "provisioning" row is not.
+	const wantSelected = netAdminLiveFleetSize + 2
+	if selected != wantSelected {
+		t.Errorf("selected %d hives, want %d", selected, wantSelected)
+	}
+	// Direction 2 — over-selection. `return true` makes this 0 and trips here.
+	if skipped != 1 {
+		t.Errorf("skipped %d hives, want exactly 1 (the provisioning row) — "+
+			"a predicate that selects everything unconditionally skips 0", skipped)
+	}
+	if selectedProvisioning != 0 {
+		t.Error("a hive still provisioning was selected; its Deployment may not exist yet")
+	}
+
+	// The two spokes historically measured as drifted on the live fleet
+	// (kubestellar-console-4vkt and projectbluefin-knuckle-gjvq, issue #2674)
+	// sit in "" and "available". If either status were excluded, the spokes
+	// this sweep exists to repair would still never converge. Assert that
+	// explicitly rather than relying on the aggregate count.
+	for _, s := range []string{"", "available"} {
+		if !netAdminSweepEligible(s) {
+			t.Errorf("status %q is not selected, but known-drifted production spokes carry it", s)
+		}
+	}
+}
+
+// TestNetAdminSweepEligibleRejectsTheOldGuard is the regression replay, pinned
+// as a permanent test. It reconstructs the exact predicate that shipped and
+// asserts it selects nothing over the real distribution — so if anyone
+// reintroduces a "running"-based filter, the reasoning is already written down
+// next to the failure.
+func TestNetAdminSweepEligibleRejectsTheOldGuard(t *testing.T) {
+	oldGuard := func(status string) bool { return status == "running" }
+
+	var oldSelected, newSelected int
+	for _, tc := range netAdminRealRegistryStatuses {
+		if oldGuard(tc.status) {
+			oldSelected += tc.live
+		}
+		if netAdminSweepEligible(tc.status) {
+			newSelected += tc.live
+		}
+	}
+	if oldSelected != 0 {
+		t.Fatalf("fixture no longer reproduces the bug: old guard selected %d hives, expected 0", oldSelected)
+	}
+	if newSelected == 0 {
+		t.Fatal("fixed predicate ALSO selects nothing — the bug is not fixed")
+	}
+	if newSelected != netAdminLiveFleetSize {
+		t.Errorf("fixed predicate selects %d of %d live hives, want all of them", newSelected, netAdminLiveFleetSize)
+	}
+}


### PR DESCRIPTION
The NET_ADMIN drift sweep guarded on `h.Status != "running"`, so it skipped every hive on every cycle and **has never patched a Deployment in production**.

This is the *original* of the bug fixed in #3765 — `reconcilePerHiveEnv` was copied from this function and inherited the same guard.

## Verification (independent, re-derived)

**Live registry** — all 66 `/data/saas/hives/*/meta.json` on the hub PVC (`hive-oke` / ns `hive-hub`):

| status | count |
|---|---|
| `"available"` | 30 |
| `""` | 28 |
| `"assigned"` | 8 |
| **`"running"`** | **0** |

**Source** — only two sites write `"running"`:
- `saas_provision.go:2246` (provision watcher) — sets it on the transition **out of** `"provisioning"`, inside a loop gated on `h.Status != "provisioning" { continue }`.
- `server.go:1788` (heartbeat) — gated on `sh.Status == "error"`, so it only rescues a hive **out of** error.

Neither puts or holds a steady-state hive at `"running"`, and nothing re-asserts it. Diagnosis confirmed.

## The failed-read path — checked, and it differs *favourably*

#3765 noted its exclusion of `"provisioning"` was safe because a failed `kubectl get` continues **without recording an observation**. This sweep has a **stronger** property: it records no observations *at all*. There is no seen-map, no convergence surface, no `PerHiveEnvStatus` equivalent — `reconcileNetAdmin` is purely imperative (read → compare → patch). A failed read logs Debug and `continue`s, and there is no state in which an unread hive could ever be counted as healthy. Confirmed by grep: no `netAdmin*` state exists outside this file except the `lastNetAdminReconcile` throttle timestamp.

The predicate therefore lands in the same place as #3765's, for a reason that is independently sound rather than inherited.

## Predicate

```go
func netAdminSweepEligible(status string) bool {
	return strings.TrimSpace(status) != "provisioning"
}
```

Not "is running" but **"is deployed"**. The sibling sweeps over the same `listSaaSHives()` — `triggerAutoUpgrades`, `sweepOrphanedUpgrades`, `sweepStuckAssignments` — apply **no** status filter at all and gate instead on the resources they actually need. This follows that convention, naming only the one status that is genuinely premature.

`"available"` matters especially here: a placeholder must carry NET_ADMIN **before** it is claimed, or it crash-loops the moment the F5 fatal-egress image rolls onto it — the exact failure this sweep exists to prevent.

`"error"` is **swept**: the status is often stale, the Deployment usually still exists, and missing NET_ADMIN is a plausible *cause* of the error rather than a reason to leave it drifted.

## Blast radius: zero

Enabling a sweep that patches Deployments (and therefore **rolls pods**) after it has been dead its whole life is itself a risk, so drift was measured read-only across **all 66 hives on all three clusters**:

| cluster | hives | drifted |
|---|---|---|
| `hive-oke` | 22 | **0** |
| `vllm-d` | 39 | **0** |
| `a-ks-wec2` | 5 | **0** |

**The fleet is fully converged — no hive rolls when this lands.** Provisioning has rendered NET_ADMIN correctly since #1222, and the two historically-drifted spokes (`kubestellar-console-4vkt`, `projectbluefin-knuckle-gjvq`, issue #2674) were repaired out-of-band. This is the ideal condition under which to enable it.

## Throttles preserved exactly

No fail-safe touched, nothing made more aggressive: the 15-min `netAdminReconcileInterval`, the 15s per-hive `netAdminKubectlTimeout`, `clusterRecentlyUnreachable` suppression, `markClusterUnreachable`/`markClusterReachable`, the idempotent has-NET_ADMIN check that guarantees **at most one patch per hive**, and non-fatal error handling.

## Missing test layer

The existing tests exercised `securityContextHasNetAdmin`, `netAdminPatchJSON` and the throttle **directly, and never the hive-selection filter** — which is exactly why this survived. A filter matching *nothing* left every one of them green.

- `TestNetAdminSweepEligibleOverRealStatuses` — pins the predicate over the real vocabulary (`""`, `"assigned"`, `"available"`, `"error"`, `"provisioning"`, `"running"`), with the measured live counts, and cross-checks they sum to 66.
- `TestNetAdminSweepSelectsTheLiveFleet` — **positive control in both directions**: exact selected count *and* exact skipped count over a fixture fleet, which no argument-ignoring predicate can satisfy either way.
- `TestNetAdminSweepEligibleRejectsTheOldGuard` — permanent regression pin against a `"running"`-based filter.

### Regression replay — verbatim

**Direction 1 — restore `== "running"` (the shipped bug):**
```
--- FAIL: TestNetAdminSweepEligibleOverRealStatuses (0.00s)
    netadmin_reconcile_test.go:146: netAdminSweepEligible("") = false, want true
    netadmin_reconcile_test.go:146: netAdminSweepEligible("available") = false, want true
    netadmin_reconcile_test.go:146: netAdminSweepEligible("assigned") = false, want true
    netadmin_reconcile_test.go:146: netAdminSweepEligible("error") = false, want true
--- FAIL: TestNetAdminSweepSelectsTheLiveFleet (0.00s)
    netadmin_reconcile_test.go:214: selected 1 hives, want 68
    netadmin_reconcile_test.go:218: skipped 68 hives, want exactly 1 (the provisioning row)
--- FAIL: TestNetAdminSweepEligibleRejectsTheOldGuard (0.00s)
    netadmin_reconcile_test.go:258: fixed predicate ALSO selects nothing — the bug is not fixed
FAIL
```

**Direction 2 — neuter to `return true`:**
```
--- FAIL: TestNetAdminSweepEligibleOverRealStatuses (0.00s)
    netadmin_reconcile_test.go:146: netAdminSweepEligible("provisioning") = true, want false
--- FAIL: TestNetAdminSweepSelectsTheLiveFleet (0.00s)
    netadmin_reconcile_test.go:214: selected 69 hives, want 68
    netadmin_reconcile_test.go:218: skipped 0 hives, want exactly 1 (the provisioning row)
    netadmin_reconcile_test.go:222: a hive still provisioning was selected
--- PASS: TestNetAdminSweepEligibleRejectsTheOldGuard (0.00s)
FAIL
```

**Honest note:** `TestNetAdminSweepEligibleRejectsTheOldGuard` **passes** under `return true`. That is by design — it is a one-directional pin asserting only that a `"running"` filter is never reinstated. Two-directional coverage is carried by the other two tests, which both fail in *both* replays. Reported rather than papered over.

**Fixed:**
```
--- PASS: TestSecurityContextHasNetAdmin (0.00s)
--- PASS: TestNetAdminPatchJSON (0.00s)
--- PASS: TestReconcileNetAdminThrottle (0.00s)
--- PASS: TestNetAdminSweepEligibleOverRealStatuses (0.00s)
--- PASS: TestNetAdminSweepSelectsTheLiveFleet (0.00s)
--- PASS: TestNetAdminSweepEligibleRejectsTheOldGuard (0.00s)
ok  	github.com/kubestellar/hive/v2/pkg/hub	0.412s
```

## Observability (mirrors #3765)

Counts considered vs skipped hives and logs at **Warn** when a sweep admits zero hives from a non-empty registry — the signal that would have surfaced both bugs on day one. Unlike its sibling this sweep keeps no observation state, so the log *is* the surface; no struct fields added, keeping the diff off `server.go` where other agents are working.

## Scope

Diff is confined to `netadmin_reconcile.go` + its test (2 files). `perhive_env_reconcile.go` deliberately untouched. `go build ./...` passes.