### PR TITLE
🐛 hub: make channel switches durable across hub restarts

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -14584,6 +14584,13 @@ const dashboardHTML = `<!DOCTYPE html>
       var targetBranch = '';
       if (isBranchTarget) {
         targetBranch = upgradeTarget.slice(0, -BRANCH_TARGET_SUFFIX.length);
+      } else if (upgradeTarget && (_releaseChannels || []).indexOf(upgradeTarget) !== -1) {
+        /* A channel switch arms the CHANNEL NAME as the target ("stable"),
+           not a "-latest" tag, so the suffix parse above never sees it —
+           after a page refresh (client sentinel gone) the "Switching to
+           stable" indicator silently vanished while the switch was still
+           running server-side. */
+        targetBranch = upgradeTarget;
       } else if (hasSwitchSentinel) {
         targetBranch = sentinel.slice(SWITCH_SENTINEL_PREFIX.length);
       }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1701,7 +1701,16 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			// re-rolls its pod every staleUpgradeTimeout forever. Commit-pinned
 			// hives keep the exact-SHA test below — their tag resolves to one
 			// build, so "did it reach the target" is a meaningful question.
-			floatingAtLatest := h.Upgrading && !payload.Upgrading && imageTagIsMutable(payload.ImageRef)
+			// A CHANNEL-switch latch ("stable") is only satisfied by the
+			// reported image actually running that tag. Without this guard, a
+			// spoke still on v4-latest (mutable) sending one quiet beat
+			// cleared the latch — the switch evaporated from the dashboard
+			// while the hive never moved (observed live 2026-08-13 when the
+			// hub auto-rolled mid-switch).
+			channelTarget := isReleaseChannel(h.UpgradeTarget)
+			channelSatisfied := imageTagOf(sanitizeImageRef(payload.ImageRef)) == h.UpgradeTarget
+			floatingAtLatest := h.Upgrading && !payload.Upgrading && imageTagIsMutable(payload.ImageRef) &&
+				(!channelTarget || channelSatisfied)
 			if floatingAtLatest {
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
@@ -2009,7 +2018,8 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	//      kubectl failed. triggerAutoUpgrades() adds hive to
 	//      s.heartbeatUpgrade; the next heartbeat sends UpgradeTo as fallback.
 	spokeManaged := payload.AutoUpgrade
-	if sh := loadSaaSHive(payload.HiveID); sh != nil && sh.AutoUpgrade {
+	saasHive := loadSaaSHive(payload.HiveID)
+	if saasHive != nil && saasHive.AutoUpgrade {
 		spokeManaged = false
 	}
 
@@ -2020,6 +2030,28 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	switchTag := s.heartbeatSwitchTag[payload.HiveID]
 	hbTarget := s.heartbeatUpgrade[payload.HiveID]
 	s.mu.RUnlock()
+	// Durable channel tracking: heartbeatSwitchTag is in-memory, so a hub
+	// restart mid-switch silently dropped the delivery and stranded the hive
+	// on its old tag while the pill kept promising the channel (the persisted
+	// tracked_channel survives; the directive did not). Re-arm from the
+	// hive record whenever the spoke's REPORTED image tag disagrees with its
+	// tracked channel. Guards: a reported ImageRef (unknown means we cannot
+	// tell drift from a stale cache — do not roll pods on a guess) and a
+	// non-upgrading spoke (mid-roll, the old pod still reports the old tag;
+	// re-arming would stamp a fresh restart-at annotation and re-roll the
+	// pod every beat). Also self-heals the delivered-upgrade-overwrote-the-
+	// channel-tag drift, not just hub restarts.
+	if switchTag == "" && saasHive != nil && isReleaseChannel(saasHive.TrackedChannel) &&
+		!payload.Upgrading && payload.ImageRef != "" &&
+		imageTagOf(sanitizeImageRef(payload.ImageRef)) != saasHive.TrackedChannel {
+		switchTag = saasHive.TrackedChannel
+		s.mu.Lock()
+		s.heartbeatSwitchTag[payload.HiveID] = switchTag
+		s.mu.Unlock()
+		s.logger.Info("heartbeat: re-armed channel switch from tracked_channel",
+			"hive_id", payload.HiveID, "channel", switchTag,
+			"reported_image", payload.ImageRef)
+	}
 	if switchTag != "" {
 		// Clear once the spoke reports it runs the target tag. The reported
 		// deployment ImageRef is the authoritative signal and works for every


### PR DESCRIPTION
Completes the channel-switch series (#3757 validator, #3761 completion detection, #3762 spoke badge, #3764 dropdown). Three holes observed live while moving the fleet to `stable`:

1. **Hub restart drops in-flight switches** — `heartbeatSwitchTag` is in-memory; the hub auto-rolling mid-switch stranded ~14 hives with pills promising `stable` while their deployments stayed on `v4-latest`. Fix: re-arm from the persisted `tracked_channel` on heartbeat whenever the spoke's reported image tag disagrees. Guards: non-empty `ImageRef` only (never roll on a guess), non-upgrading spoke only (a mid-roll old pod reporting the old tag must not trigger a fresh `restart-at` stamp and re-roll every beat). This also self-heals the delivered-upgrade-overwrites-channel-tag drift class.
2. **`floatingAtLatest` cleared channel latches prematurely** — one quiet beat from a mutable-tag spoke evaporated the switch from the dashboard while the hive never moved. A channel target is only satisfied when the reported image runs that tag.
3. **Indicator lost on page refresh** — the SPA's `hiveSwitchState` only parsed `-latest` targets; channel targets (`stable`) fell through once the client-side click sentinel was gone. Recognize channel names from the payload's `release_channels`.

Known residual (documented in code): a pre-#3757 spoke refuses the re-armed channel tag each beat (log noise, no rolls) until it lands on a post-#3757 build — the fleet was bridged tonight, so this only affects future stragglers.