### PR TITLE
🔒 fix(docker): remove hive binary file-cap that crash-loops non-NET_ADMIN spokes (EPERM on exec) (#3760)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -153,11 +153,20 @@ jobs:
             docker rm -f -v "$name" >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
-          # --cap-add NET_ADMIN mirrors the production contract: the pod spec
-          # grants it (SCC hive-netadmin) and the image binary carries
-          # cap_net_admin+ep file caps (SO_MARK egress attribution), so exec
-          # under docker's default cap set fails EPERM by design, not by bug.
-          # The old `--help || true` form could not fail and asserted nothing.
+          # REGRESSION GUARD for #3760: the hive binary MUST exec under docker's
+          # DEFAULT capability set — i.e. WITHOUT --cap-add NET_ADMIN — because
+          # that is what every self-hosted / rootless spoke runs. A file
+          # capability on the binary (removed in the #3760 fix) made the kernel
+          # refuse execve with EPERM whenever NET_ADMIN was not in the bounding
+          # set, crash-looping the fleet. NET_ADMIN is now granted at runtime as
+          # an ambient cap by the entrypoint only where the platform allows it,
+          # and the proxy SO_MARK path degrades gracefully otherwise. So this
+          # must pass with NO added capabilities.
+          timeout --signal=TERM --kill-after=10s 60s \
+            docker run --rm --name "$name" --network none hive:test --version
+          # And it must ALSO exec on platforms that DO grant NET_ADMIN (managed
+          # OKE/OpenShift spokes), where the entrypoint raises the ambient cap.
+          name="${name}-netadmin"
           timeout --signal=TERM --kill-after=10s 60s \
             docker run --rm --name "$name" --network none --cap-add NET_ADMIN hive:test --version
 

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -43,9 +43,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM node:26-slim
 
 # --- Layer 1: system packages (rarely changes) ---
+# setpriv (util-linux-extra on Debian) is used by the entrypoint to drop to the
+# non-root `dev` user WHILE raising CAP_NET_ADMIN into the ambient set on
+# platforms that grant it, so the proxy's SO_MARK egress exemption works without
+# a file capability on the binary (issue #3760). If the package is unavailable
+# the entrypoint falls back to gosu (no ambient cap, best-effort SO_MARK).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates bash curl bzip2 gosu iptables inotify-tools libevent-core-2.1-7 \
     gcc libc6-dev \
+ && (apt-get install -y --no-install-recommends util-linux-extra || \
+     apt-get install -y --no-install-recommends util-linux || \
+     echo "WARN: setpriv unavailable — entrypoint will fall back to gosu (no ambient CAP_NET_ADMIN)") \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tmux-builder /usr/local/bin/tmux /usr/local/bin/tmux
@@ -302,41 +310,33 @@ RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bi
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
     /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-merge
 
-# SECURITY (audit F5-egress / refs #2674, #2678): give the hive binary
-# CAP_NET_ADMIN as a FILE capability so the MITM proxy's own upstream dials can
-# be exempted from the forced-egress iptables REDIRECT.
+# SECURITY (audit F5-egress / refs #2674, #2678, #3574): the MITM proxy's own
+# upstream :443 dials must be exempted from the forced-egress iptables REDIRECT.
+# On OpenShift/OVN (no xt_owner) the only exemption is the SO_MARK packet mark,
+# and setsockopt(SO_MARK) needs CAP_NET_ADMIN in the hive process's EFFECTIVE
+# set. The hive process runs as non-root `dev` (the entrypoint drops from root
+# via gosu, which strips all capabilities).
 #
-# WHY THIS IS NEEDED
-# The entrypoint installs `-p tcp --dport 443 -j REDIRECT` so every agent's
-# egress is forced through the proxy, then exempts the proxy's OWN traffic three
-# ways. On OKE the `-m owner --uid-owner` matches work. On OpenShift/OVN xt_owner
-# is ABSENT, so those rules silently fail to load (`|| true`) and the only
-# remaining exemption is the SO_MARK packet mark — but setsockopt(SO_MARK)
-# requires CAP_NET_ADMIN in the calling process's EFFECTIVE set. The entrypoint
-# runs as root only long enough to build the chain; the hive process itself is
-# dropped to `dev` via gosu, so without a file capability it loses NET_ADMIN and
-# the mark silently fails ("operation not permitted").
+# We DO NOT set CAP_NET_ADMIN as a FILE capability on /usr/local/bin/hive.
+# Doing so (PR #3574) crash-looped every self-hosted spoke: the kernel refuses
+# to execve() a binary whose file capabilities it cannot fully grant, and
+# NET_ADMIN is NOT in the default container bounding set for docker/podman/
+# containerd. The result was a bare "Operation not permitted" (EPERM) at exec
+# for anyone who did not run with `--cap-add NET_ADMIN` / an SCC granting it —
+# i.e. the entire self-hosted / rootless population (issue #3760). Copying the
+# binary elsewhere "fixed" it only because `cp` drops the security.capability
+# xattr; it did not actually grant the cap.
 #
-# Observed live on vllm-d: with neither exemption active the proxy's own :443
-# dials hit the REDIRECT and looped back into itself, returning 502 for every
-# forge request and cutting a live tenant's agents off from their repository.
-#
-# WHY A FILE CAPABILITY IS SAFE HERE
-# File caps are recomputed AT EXEC from the binary being exec'd. Agents are
-# launched via su-exec into their OWN binaries (claude/goose/bob), which carry
-# no file capability, so NET_ADMIN does NOT propagate to any agent process.
-# Agent UIDs (2001+) also cannot exec su-exec itself — it is 4750
-# root:hive-launch and only `dev` is in that group (audit C6) — so there is no
-# path from an agent to a process holding this capability.
-#
-# +ep = permitted AND effective: the hive process needs the cap live at
-# setsockopt time, not merely inheritable.
-RUN apt-get update && apt-get install -y --no-install-recommends libcap2-bin \
- && setcap cap_net_admin+ep /usr/local/bin/hive \
- && [ "$(getcap /usr/local/bin/hive)" != "" ] \
- && getcap /usr/local/bin/hive | grep -q "cap_net_admin" \
- && apt-get purge -y libcap2-bin \
- && rm -rf /var/lib/apt/lists/*
+# Instead, NET_ADMIN is granted at RUNTIME as an AMBIENT capability by the
+# entrypoint (see v2/deploy/entrypoint.sh, at the gosu privilege-drop): the
+# entrypoint already runs as root and already needs NET_ADMIN to build the
+# iptables chain, so where the platform grants NET_ADMIN in the bounding set
+# (managed OKE/OpenShift spokes via SCC/PSA) it raises the cap into the ambient
+# set so it survives the drop to `dev`, and where it is absent (self-hosted /
+# rootless) it simply skips the raise. The Go proxy's SO_MARK path is already
+# best-effort (v2/pkg/proxy/github_proxy.go: setSockMark failure is logged once
+# and the dial proceeds unmarked), so a missing NET_ADMIN degrades gracefully
+# to the existing owner-UID exemption instead of failing to exec at all.
 
 # --- Nous framework (strategist experiment engine) ---
 RUN (apt-get update && apt-get install -y --no-install-recommends \

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -844,9 +844,54 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
 
   # Drop to non-root user for all runtime processes.
   # Claude Code refuses --dangerously-skip-permissions as root.
-  # Test gosu first — on some NFS/container combos it fails with EPERM.
+  #
+  # CAP_NET_ADMIN (issue #3760): the Go hive process needs NET_ADMIN in its
+  # EFFECTIVE set so the MITM proxy can setsockopt(SO_MARK) its own upstream
+  # dials for the forced-egress exemption. Dropping via gosu strips all caps, so
+  # where the platform grants NET_ADMIN (managed OKE/OpenShift spokes via
+  # SCC/PSA — it is already in our bounding set because the iptables chain above
+  # succeeded) we drop with `setpriv`, which can raise NET_ADMIN into the
+  # inheritable + AMBIENT sets so it survives the UID transition. We deliberately
+  # do NOT put NET_ADMIN as a file capability on the binary: the kernel refuses
+  # to execve a binary carrying a file cap absent from the container bounding
+  # set, which crash-looped every self-hosted/rootless spoke (issue #3760).
+  #
+  # setpriv --init-groups replicates gosu's supplementary-group setup from
+  # /etc/group (preserving the `dev`-only `hive-launch` membership, audit C6).
+  # If setpriv is missing, NET_ADMIN is not in the bounding set, or setpriv
+  # fails, we fall back to gosu: hive still execs, and the proxy's SO_MARK path
+  # is best-effort (it logs once and dials unmarked), so egress still works via
+  # the owner-UID exemption on OKE.
+  # setpriv resolves `dev`'s UID and supplementary groups via --reuid/--init-groups;
+  # only the primary GID must be named explicitly.
+  DEV_GID="$(id -g dev 2>/dev/null || echo node)"
+  # NET_ADMIN is bit 12; the process bounding set is the CapBnd field in
+  # /proc/self/status (a hex bitmask). Only attempt the ambient-cap drop when
+  # NET_ADMIN is actually in the bounding set — otherwise setpriv would fail.
+  _capbnd="$(awk '/^CapBnd:/ {print $2}' /proc/self/status 2>/dev/null || echo 0)"
+  # Guard the arithmetic: only feed a pure-hex value into $(( )) so a malformed
+  # or missing CapBnd never aborts the entrypoint with a shell arithmetic error.
+  case "$_capbnd" in
+    ''|*[!0-9A-Fa-f]*) _capbnd=0 ;;
+  esac
+  _net_admin_in_bnd=false
+  if [ "$(( 0x${_capbnd} >> 12 & 1 ))" = "1" ]; then
+    _net_admin_in_bnd=true
+  fi
+  if [ "$_net_admin_in_bnd" = "true" ] && command -v setpriv >/dev/null 2>&1 \
+     && setpriv --reuid dev --regid "$DEV_GID" --init-groups \
+        --inh-caps +net_admin --ambient-caps +net_admin true 2>/dev/null; then
+    echo "[entrypoint] Dropping to dev user (setpriv, ambient CAP_NET_ADMIN)"
+    exec setpriv --reuid dev --regid "$DEV_GID" --init-groups \
+      --inh-caps +net_admin --ambient-caps +net_admin "$0" "$@"
+  fi
+  # Test gosu — on some NFS/container combos it fails with EPERM.
   if command -v gosu >/dev/null 2>&1 && gosu dev true 2>/dev/null; then
-    echo "[entrypoint] Dropping to dev user"
+    if [ "$_net_admin_in_bnd" = "true" ]; then
+      echo "[entrypoint] Dropping to dev user (gosu; NET_ADMIN present but setpriv unavailable — proxy SO_MARK will be best-effort)"
+    else
+      echo "[entrypoint] Dropping to dev user (gosu; no NET_ADMIN in bounding set — proxy SO_MARK best-effort, owner-UID exemption applies)"
+    fi
     exec gosu dev "$0" "$@"
   else
     echo "[entrypoint] WARN: gosu unavailable or failed, continuing as root"

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -106,32 +106,38 @@ check "hive-launch launcher group is created" \
 check "dev is a member of hive-launch" \
   'useradd.*-G[[:space:]]+hive-launch'
 
-# ── File-capability contract (audit F5-egress, refs #2674/#2678) ──────────────
+# ── File-capability contract (audit F5-egress, refs #2674/#2678, #3574, #3760) ─
 #
-# The hive binary carries cap_net_admin+ep so the MITM proxy can stamp SO_MARK
-# on its own upstream dials and be exempted from the forced-egress iptables
-# REDIRECT. Without it, on OpenShift (no xt_owner, so the owner-UID exemptions
-# silently fail to load) the proxy redirects its OWN traffic into itself and
-# every forge request 502s — observed live on vllm-d.
+# The MITM proxy needs CAP_NET_ADMIN in the hive process's EFFECTIVE set so it
+# can stamp SO_MARK on its own upstream dials and be exempted from the forced-
+# egress iptables REDIRECT (on OpenShift, where xt_owner is absent, the packet
+# mark is the only exemption).
 #
-# The capability is SAFE only because it cannot reach an agent:
-#   - file caps are recomputed at exec, and agents exec their own binaries
-#   - agents cannot exec su-exec (4750 root:hive-launch, asserted above)
-# If either invariant breaks, this capability becomes an escalation path — hence
-# both are asserted in the same contract.
-check "hive binary carries cap_net_admin" \
-  'setcap[[:space:]]+cap_net_admin\+ep[[:space:]]+/usr/local/bin/hive'
-check "the capability is verified at build time" \
-  'getcap[[:space:]]+/usr/local/bin/hive'
-
-# No OTHER binary may be given a capability. Agents run their own binaries; a
-# capability on any of them would hand NET_ADMIN straight to an agent process.
-if printf '%s\n' "$CODE" | grep -oE 'setcap[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+' \
-   | grep -qvE 'setcap[[:space:]]+cap_net_admin\+ep[[:space:]]+/usr/local/bin/hive'; then
-  echo "  FAIL: a setcap targets something other than /usr/local/bin/hive"
+# It must NOT be granted as a FILE capability on the binary. A file capability
+# absent from the container bounding set makes the kernel refuse execve() with
+# EPERM, which crash-looped every self-hosted/rootless spoke (issue #3760).
+# Instead the entrypoint grants NET_ADMIN as an AMBIENT capability at the
+# non-root privilege drop (setpriv --ambient-caps), where the platform bounding
+# set allows it, and degrades gracefully (best-effort SO_MARK) where it does not.
+#
+# CONTRACT: NO binary in the image may carry a file capability. `setcap` must
+# not appear in the Dockerfile at all.
+if printf '%s\n' "$CODE" | grep -qE '(^|[^[:alnum:]_])setcap[[:space:]]'; then
+  echo "  FAIL: the Dockerfile runs setcap — no binary may carry a file capability (issue #3760: a file cap absent from the container bounding set makes execve fail with EPERM). Grant NET_ADMIN as an ambient cap in the entrypoint instead."
   fail=1
 else
-  echo "  ok: no capability is granted to any binary except /usr/local/bin/hive"
+  echo "  ok: no file capability is granted to any binary (setcap absent)"
+fi
+
+# The runtime ambient-capability grant must be present in the entrypoint so the
+# proxy egress exemption still works on platforms that grant NET_ADMIN.
+ENTRYPOINT_SRC="$(cat "$(dirname "$0")/../deploy/entrypoint.sh" 2>/dev/null || true)"
+if printf '%s\n' "$ENTRYPOINT_SRC" | grep -qE -- '--ambient-caps[[:space:]]+\+net_admin' \
+   && printf '%s\n' "$ENTRYPOINT_SRC" | grep -qE -- 'setpriv'; then
+  echo "  ok: entrypoint grants CAP_NET_ADMIN as an ambient capability (setpriv --ambient-caps +net_admin)"
+else
+  echo "  FAIL: entrypoint does not grant CAP_NET_ADMIN via setpriv --ambient-caps +net_admin — the proxy SO_MARK egress exemption will never work"
+  fail=1
 fi
 
 if [[ "$fail" -ne 0 ]]; then

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -40,7 +40,16 @@ fail=0
 # checks run against CODE so that an explanatory comment mentioning e.g.
 # `chmod u+s` (describing the OLD insecure build) is not itself flagged — only a
 # real instruction would be. The positive checks run against the raw file.
+#
+# CODE is materialized to a temp file so every forbidden-pattern check greps a
+# FILE, never `printf | grep -q`. Under `set -o pipefail` a `grep -q` that
+# matches exits and closes the pipe before the writer finishes, giving the
+# writer EPIPE ("write error: Broken pipe") and making the pipeline exit
+# non-zero — which previously flipped a passing check to FAIL (issue #3760 fix).
 CODE="$(grep -vE '^[[:space:]]*#' "$DOCKERFILE")"
+CODE_TMP="$(mktemp)"
+trap 'rm -f "$CODE_TMP"' EXIT
+printf '%s\n' "$CODE" > "$CODE_TMP"
 
 check() {
   local desc="$1" pattern="$2"
@@ -54,7 +63,7 @@ check() {
 
 check_absent() {
   local desc="$1" pattern="$2"
-  if printf '%s\n' "$CODE" | grep -qE "$pattern"; then
+  if grep -qE "$pattern" "$CODE_TMP"; then
     echo "  FAIL: ${desc} (found forbidden pattern in a build instruction: ${pattern})"
     fail=1
   else
@@ -121,8 +130,9 @@ check "dev is a member of hive-launch" \
 # set allows it, and degrades gracefully (best-effort SO_MARK) where it does not.
 #
 # CONTRACT: NO binary in the image may carry a file capability. `setcap` must
-# not appear in the Dockerfile at all.
-if printf '%s\n' "$CODE" | grep -qE '(^|[^[:alnum:]_])setcap[[:space:]]'; then
+# not appear in a build instruction. CODE_TMP has comment lines stripped, so a
+# `setcap` mentioned in a comment is not flagged — only a real instruction.
+if grep -qE '(^|[^[:alnum:]_])setcap[[:space:]]' "$CODE_TMP"; then
   echo "  FAIL: the Dockerfile runs setcap — no binary may carry a file capability (issue #3760: a file cap absent from the container bounding set makes execve fail with EPERM). Grant NET_ADMIN as an ambient cap in the entrypoint instead."
   fail=1
 else
@@ -130,10 +140,15 @@ else
 fi
 
 # The runtime ambient-capability grant must be present in the entrypoint so the
-# proxy egress exemption still works on platforms that grant NET_ADMIN.
-ENTRYPOINT_SRC="$(cat "$(dirname "$0")/../deploy/entrypoint.sh" 2>/dev/null || true)"
-if printf '%s\n' "$ENTRYPOINT_SRC" | grep -qE -- '--ambient-caps[[:space:]]+\+net_admin' \
-   && printf '%s\n' "$ENTRYPOINT_SRC" | grep -qE -- 'setpriv'; then
+# proxy egress exemption still works on platforms that grant NET_ADMIN. Grep the
+# entrypoint file directly (no pipe). The entrypoint builds the setpriv drop
+# across two physical lines and may use either `--ambient-caps +net_admin` or
+# `--ambient-caps=+net_admin`, so match `ambient-caps`, `net_admin`, and
+# `setpriv` independently rather than pinning one exact flag spelling.
+ENTRYPOINT_FILE="$(dirname "$0")/../deploy/entrypoint.sh"
+if [[ -f "$ENTRYPOINT_FILE" ]] \
+   && grep -qE -- 'ambient-caps[=[:space:]]+\+?net_admin' "$ENTRYPOINT_FILE" \
+   && grep -qE -- '(^|[^[:alnum:]_])setpriv([^[:alnum:]_]|$)' "$ENTRYPOINT_FILE"; then
   echo "  ok: entrypoint grants CAP_NET_ADMIN as an ambient capability (setpriv --ambient-caps +net_admin)"
 else
   echo "  FAIL: entrypoint does not grant CAP_NET_ADMIN via setpriv --ambient-caps +net_admin — the proxy SO_MARK egress exemption will never work"


### PR DESCRIPTION
Fixes #3760

## Symptom
Today's channel images (`stable`/`candidate`/`edge`, all currently retags of the v4 build) ship `/usr/local/bin/hive` in a state where **every `execve()` of that path inside a container returns EPERM (`Operation not permitted`)**. The entrypoint's `hive "$@"` fails and the container crash-loops at boot. Any hive pulling these images is down.

## Root cause: a FILE capability the kernel can't grant, not a toolchain/packaging bug

`v2/Dockerfile` (the Dockerfile that builds the v4-family images) ran:

```dockerfile
setcap cap_net_admin+ep /usr/local/bin/hive
```

(added in #3574, merged 2026-08-12 — exactly the regression window).

The kernel **refuses to `execve()` a binary whose file capabilities it cannot fully grant**, and `CAP_NET_ADMIN` is **not** in the default container bounding set for docker / podman (rootless) / containerd / k3s. So on any runtime that doesn't add `NET_ADMIN`, exec fails with EPERM before the process even starts.

This matches every piece of the reporter's evidence:

| Observation | Explanation |
|---|---|
| In-place `hive --version` → EPERM | binary carries the `security.capability` xattr the kernel can't grant |
| `cp hive /tmp/hx && /tmp/hx --version` works | `cp` does **not** preserve the `security.capability` xattr → no cap to grant |
| Works run directly on the host | root already holds `NET_ADMIN` in its bounding set |
| Fails even with `seccomp=unconfined` / `apparmor=unconfined` | it's a **capability bounding-set** check, not an LSM/seccomp filter |
| In-cluster managed spokes are fine | the pod securityContext / SCC puts `NET_ADMIN` in the bounding set |

### It is *not* the Go 1.26 / PIE theory
Static `CGO_ENABLED=0` Go binaries are `ET_DYN` regardless of toolchain, and `ET_DYN` alone does not cause exec EPERM. The file capability does. The Go 1.26 bump (#3126, 2026-08-10) is a red herring; the reporter's known-good fork predates the `setcap` (#3574), not the Go bump.

## Why the cap existed, and why removing it is safe
The cap was for the MITM proxy to `setsockopt(SO_MARK)` its own upstream :443 dials so the forced-egress iptables REDIRECT can exempt them (on OpenShift, where `xt_owner` is absent, the packet mark is the only exemption). But **the Go proxy's SO_MARK path is already best-effort** — see `v2/pkg/proxy/github_proxy.go`: a `setSockMark` failure is logged once and the dial proceeds unmarked (the owner-UID exemption still covers OKE). So the file cap was strictly harmful on non-NET_ADMIN runtimes: it converted a graceful "log once and continue" into a hard crash-loop *at execve*, before the process runs.

## The fix (least behavioral change; preserves the exemption where it's usable)
1. **Remove the `setcap`** from `v2/Dockerfile` — no binary carries a file capability.
2. **Grant `CAP_NET_ADMIN` at runtime as an AMBIENT capability** in the entrypoint's non-root privilege drop, via `setpriv --ambient-caps +net_admin`, **gated on `NET_ADMIN` actually being in the process bounding set** (parsed from `/proc/self/status` `CapBnd`). `setpriv --init-groups` replicates gosu's supplementary-group setup, preserving the `dev`-only `hive-launch` membership (audit C6).
   - **Managed OKE/OpenShift spokes** (NET_ADMIN granted via SCC/PSA): the ambient cap survives the drop to `dev`, so SO_MARK works exactly as before.
   - **Self-hosted / rootless** (no NET_ADMIN): the raise is skipped, the drop falls back to `gosu`, the binary execs fine, and SO_MARK degrades to the existing best-effort/owner-UID behavior instead of crash-looping.
3. Install `util-linux-extra` (provides `setpriv`) with a graceful fallback to `gosu` if unavailable.
4. Update `v2/scripts/check-suid-contract.sh`: forbid **any** `setcap`, and require the ambient-cap grant in the entrypoint.
5. Turn the CI smoke test into a **#3760 regression guard**: `hive --version` must exec under docker's **default** cap set (no `--cap-add`) — the exact self-hosted condition #3760 broke — and also with `--cap-add NET_ADMIN`.

## Verification
- `bash v2/scripts/check-suid-contract.sh v2/Dockerfile` passes with the new invariants.
- Entrypoint passes `dash -n` / `sh -n`; the `CapBnd` bit-12 arithmetic is validated against full/empty/default-docker/garbage masks.
- (Container exec cannot be fully reproduced locally; the Docker build + smoke test gate this in CI.)

## Scope
This PR targets **v4** only. The same defect exists on any branch that carries the #3574 `setcap` — the reporter flagged `v2-latest` specifically. v2/mk/dd/v3 likely need the identical fix, tracked separately so this urgent v4 fix isn't blocked.