### PR TITLE
🔐 hub: auto-retire master generations past verify_until + pinned-open alert (#7)

### DIFF
--- a/v2/pkg/hub/hub_generations_retire.go
+++ b/v2/pkg/hub/hub_generations_retire.go
@@ -1,0 +1,399 @@
+package hub
+
+import (
+	"errors"
+	"sort"
+	"time"
+)
+
+// Automatic retirement of expired master generations, and the alert that fires
+// when one is about to strand spokes (follow-on PR #7 of
+// v2/docs/design/master-key-rotation.md).
+//
+// WHAT WAS ALREADY TRUE BEFORE THIS FILE, AND WHY THAT MATTERS. The security
+// guarantee — step 5 of the rotation procedure, "after verify_until the
+// previous generation stops being accepted, automatically, whether or not
+// anyone is watching" — was ALREADY kept by acceptableGenerations(now) in
+// hub_generations.go. That function excludes any non-current generation whose
+// VerifyUntil has passed, and treats a ZERO VerifyUntil as ALREADY EXPIRED
+// rather than as "never expires", so a hand-edited or malformed generations
+// file fails closed. Every verifier on the platform goes through it. Nothing in
+// this file weakens, duplicates, or re-implements that filter, and nothing in
+// this file is load-bearing for the guarantee: if this whole lane never ran,
+// an expired generation would still stop verifying on the wall clock.
+//
+// SO WHAT IS THIS FOR. Two things the read-path filter cannot do by itself:
+//
+//  1. PERSIST the drop. acceptableGenerations is a pure read-path predicate; it
+//     leaves the dead entry sitting in the set on disk forever. A generation
+//     that is no longer accepted but is still recorded is a plaintext master
+//     secret retained on the hub PVC past the point where it protects anything
+//     — the F1/F2 residue in a different form. Retirement rewrites
+//     hub-generations.json without it, so the secret stops existing rather than
+//     merely stopping being honoured.
+//
+//  2. ALERT. Retirement on the wall clock is unconditional, which means it can
+//     and will strand spokes that have not converged. That is the CORRECT
+//     behaviour — the alternative, waiting for convergence, is what lets one
+//     unreachable spoke pin the old master open forever — but it is not a
+//     silent one. The operator gets a warning as the window closes with spokes
+//     still on the old key, and a louder one after it closes.
+//
+// THE TWO CONDITIONS ARE DELIBERATELY NOT THE SAME CONDITION. The design states
+// both, and collapsing them would be the bug:
+//
+//   - RETIREMENT (here) is a WALL-CLOCK SECURITY GUARANTEE. It fires when
+//     VerifyUntil has passed, FULL STOP — never gated on spokes_on_previous,
+//     never gated on spokes_unattributed, never gated on whether anything was
+//     observed at all. Gating it on convergence would mean a single spoke on an
+//     unreachable cluster keeps a superseded master secret live indefinitely,
+//     which is precisely the "unversioned and permanent compat lane" failure
+//     mode the explicit-finiteness property exists to prevent.
+//
+//   - SafeToRetirePrevious (perhive_env_reconcile.go, unchanged by this file)
+//     is an OPERATOR-FACING READINESS SIGNAL meaning "retiring right now costs
+//     nothing". It fails closed on zero observations and on any unattributed
+//     spoke, deliberately. It answers "is this free?", not "will this happen?".
+//
+// Retirement does not read SafeToRetirePrevious and must never learn to. The
+// counts feed the ALERT only — they change how loudly retirement is announced,
+// never whether it occurs.
+
+const (
+	// generationRetireInterval is how often the retirement sweep runs, matching
+	// netAdminReconcileInterval and perHiveEnvReconcileInterval so the one
+	// frequent SHA poller drives every periodic hub-internal lane on the same
+	// cadence rather than acquiring a scheduler per lane.
+	//
+	// The interval bounds how long a dead entry LINGERS ON DISK, not how long
+	// it is ACCEPTED — acceptance already ended on the wall clock at
+	// VerifyUntil, via acceptableGenerations, with no reference to this value.
+	// So a coarse interval costs cleanup latency, never acceptance.
+	generationRetireInterval = 15 * time.Minute
+
+	// generationPinWarnWindow is how long BEFORE VerifyUntil the pinned-open
+	// alert starts firing when spokes are still on the outgoing generation.
+	//
+	// Sized to exceed one full reconcile sweep. The lane converges the fleet at
+	// perHiveEnvMaxPatchesPerCycle per perHiveEnvReconcileInterval, so ~66
+	// spokes take roughly 5.5 hours; 24 hours gives an operator time to notice
+	// a stalled convergence and act (unpause a spoke, fix an unreachable
+	// cluster) BEFORE the window closes on it, rather than reading about it
+	// afterwards. Warning only at expiry would make the alert a post-mortem.
+	generationPinWarnWindow = 24 * time.Hour
+)
+
+// generationPinSeverity ranks how urgent a pinned-open generation is.
+type generationPinSeverity int
+
+const (
+	// pinSeverityNone means nothing to report: no expiring generation, or one
+	// whose window is closing with no spoke left on it.
+	pinSeverityNone generationPinSeverity = iota
+	// pinSeverityWarn means the window is closing within
+	// generationPinWarnWindow and spokes still carry the generation. Still
+	// actionable — convergence can finish before expiry.
+	pinSeverityWarn
+	// pinSeverityStranded means the window has ALREADY closed while spokes
+	// still carry the generation. Those spokes are now failing verification.
+	// Not actionable by waiting; the operator must converge or re-provision
+	// them.
+	pinSeverityStranded
+)
+
+func (p generationPinSeverity) String() string {
+	switch p {
+	case pinSeverityWarn:
+		return "warn"
+	case pinSeverityStranded:
+		return "stranded"
+	default:
+		return "none"
+	}
+}
+
+// generationPinAlert is the pure, testable description of a pinned-open
+// generation. It carries IDs, counts, and times — never key material.
+type generationPinAlert struct {
+	// Severity is what to do about it. pinSeverityNone means do not alert.
+	Severity generationPinSeverity
+	// GenerationID names the generation spokes are stuck on. An ID names a key;
+	// it is not a key.
+	GenerationID int
+	// VerifyUntil is when that generation stops (or stopped) being accepted.
+	VerifyUntil time.Time
+	// SpokesOnPrevious is how many observed spokes carry material from a live
+	// but non-current generation.
+	SpokesOnPrevious int
+	// SpokesUnattributed is how many observed spokes carry material matching NO
+	// live generation.
+	//
+	// Counted into the alert exactly as PerHiveEnvSnapshot counts it into
+	// SafeToRetirePrevious, and for the same reason: an unattributed spoke is
+	// BROKEN NOW, not merely lagging, and must never be silently folded into
+	// "converged". #3766 made it block retirement readiness deliberately;
+	// letting it read as clean here would re-open that hole from the alerting
+	// side.
+	SpokesUnattributed int
+	// ObservedHives is the denominator. Zero means the hub has read nothing, in
+	// which case the counts above are evidence of nothing.
+	ObservedHives int
+}
+
+// evaluateGenerationPin decides whether to alert about a generation whose
+// verify window is closing while spokes still carry it.
+//
+// PURE. No clock, no locks, no I/O — `now` and the counts are arguments, so the
+// policy is testable at any point on the timeline without sleeping.
+//
+// IT DOES NOT DECIDE WHETHER TO RETIRE. Retirement is the wall clock's call
+// alone (see retireExpiredGenerations). This function only decides how loudly
+// to say so. That separation is the whole point of the PR: a pinned-open
+// generation produces an ALERT, never a stay of execution.
+//
+// FAILS CLOSED ON ZERO OBSERVATIONS, in the alerting direction. With
+// observedHives == 0 the hub has read nothing, so "0 spokes on previous" is not
+// evidence of convergence — but it is equally not evidence of stranding, and
+// crying stranded from no data would train operators to ignore the alert. The
+// readiness signal (SafeToRetirePrevious) is the surface that refuses to call
+// zero observations safe; this one simply declines to claim knowledge it lacks.
+func evaluateGenerationPin(
+	gen keyGeneration,
+	isCurrent bool,
+	now time.Time,
+	spokesOnPrevious int,
+	spokesUnattributed int,
+	observedHives int,
+) generationPinAlert {
+	alert := generationPinAlert{
+		GenerationID:       gen.ID,
+		VerifyUntil:        gen.VerifyUntil,
+		SpokesOnPrevious:   spokesOnPrevious,
+		SpokesUnattributed: spokesUnattributed,
+		ObservedHives:      observedHives,
+	}
+	if isCurrent {
+		// The current generation never expires and is never pinned open. It is
+		// the thing spokes are converging TOWARD.
+		return alert
+	}
+	// A spoke is "still carrying the old key" if it is on a previous generation
+	// OR unattributed. Both are un-converged; only the second is also broken.
+	stuck := spokesOnPrevious + spokesUnattributed
+	if stuck == 0 || observedHives == 0 {
+		return alert
+	}
+	// A ZERO VerifyUntil is ALREADY EXPIRED, matching acceptableGenerations
+	// exactly. Reading it as "never expires" here would suppress the alert on
+	// precisely the malformed file that most needs one.
+	if gen.VerifyUntil.IsZero() || !now.Before(gen.VerifyUntil) {
+		alert.Severity = pinSeverityStranded
+		return alert
+	}
+	if !gen.VerifyUntil.After(now.Add(generationPinWarnWindow)) {
+		alert.Severity = pinSeverityWarn
+	}
+	return alert
+}
+
+// retirableGenerations splits a set into the entries that survive retirement at
+// `now` and the entries that must be dropped.
+//
+// PURE, and it does not mutate the receiver — the same discipline
+// generationSet.rotate follows, so a caller that fails to persist has not
+// already changed the hub's in-memory state.
+//
+// The keep/drop rule is acceptableGenerations' rule, applied to the STORED set
+// rather than to a verification attempt: the current generation always stays,
+// and a previous generation stays only while now is strictly before its
+// VerifyUntil. A zero VerifyUntil drops. Deriving both from the same predicate
+// is deliberate — if these two rules could drift, the hub could retire a
+// generation it still accepts (breaking live artifacts) or keep one it does not
+// (retaining a dead secret), and only the second failure would be visible.
+func retirableGenerations(gs *generationSet, now time.Time) (keep []keyGeneration, drop []keyGeneration) {
+	if gs == nil {
+		return nil, nil
+	}
+	acceptable := make(map[int]bool, len(gs.Generations))
+	for _, g := range gs.acceptableGenerations(now) {
+		acceptable[g.ID] = true
+	}
+	for _, g := range gs.Generations {
+		if g.ID == gs.Current || acceptable[g.ID] {
+			keep = append(keep, g)
+			continue
+		}
+		drop = append(drop, g)
+	}
+	return keep, drop
+}
+
+// errRetireWouldEmptySet guards against retiring the minting key.
+var errRetireWouldEmptySet = errors.New("refusing to retire the current generation")
+
+// retireExpiredGenerations drops every expired generation from the live set,
+// persisting the result, and returns the IDs retired.
+//
+// UNCONDITIONAL ON CONVERGENCE, BY DESIGN. It never reads spoke counts and
+// never consults SafeToRetirePrevious. A generation past VerifyUntil is retired
+// even when every spoke in the fleet is still on it. This is the anti-pin
+// property: making retirement wait for convergence would hand any single
+// unconverged spoke — paused, unreachable, forgotten — the power to keep a
+// superseded master secret on disk indefinitely, which is the exact failure the
+// "explicitly finite" property exists to prevent. The stranding is instead made
+// LOUD by the caller's alert, not prevented.
+//
+// PERSIST BEFORE INSTALL, matching rotateMasterSecret's ordering and for the
+// same reason inverted: if the write fails, the hub keeps the old set in memory
+// and returns an error, so the sweep retries next cycle. A retirement applied
+// in memory but not on disk would come back at the next hub roll — several
+// times a day — and an operator watching the surface would see a generation
+// retire, vanish, and reappear. Persist-then-install makes a failed retirement
+// a CLEAN NO-OP rather than a half-applied state.
+//
+// Returns (nil, nil) when there is nothing to retire, which is the overwhelming
+// common case: the fleet is on one generation and no hub has ever rotated.
+func (s *HubServer) retireExpiredGenerations(now time.Time) ([]int, error) {
+	if s == nil {
+		return nil, nil
+	}
+	// Hold the write lock across evaluate-persist-install for the reason
+	// rotateMasterSecret documents: a rotation landing between our read and our
+	// write would otherwise be silently discarded by our persist, dropping a
+	// generation that is live material by then.
+	s.keyGenerationsMu.Lock()
+	defer s.keyGenerationsMu.Unlock()
+
+	gs := s.keyGenerations
+	keep, drop := retirableGenerations(gs, now)
+	if len(drop) == 0 {
+		return nil, nil
+	}
+	// keep always contains the current generation (retirableGenerations keeps
+	// gs.Current unconditionally), so this cannot fire — but a set with no
+	// minting key is unusable, not degraded, and installing one would silently
+	// disable minting. Refuse rather than trust the invariant.
+	if len(keep) == 0 {
+		return nil, errRetireWouldEmptySet
+	}
+	next := newGenerationSet(gs.Current, keep)
+	if next == nil {
+		return nil, errRetireWouldEmptySet
+	}
+
+	retired := make([]int, 0, len(drop))
+	for _, g := range drop {
+		retired = append(retired, g.ID)
+	}
+	sort.Ints(retired)
+
+	// PERSIST FIRST. lastKeyRotation is carried through unchanged: retirement
+	// is not a rotation and must not reset the double-rotation cooldown, or an
+	// operator could bypass the cooldown by waiting for a retirement instead of
+	// for the fleet to converge.
+	if err := saveGenerations(next, s.lastKeyRotation); err != nil {
+		return nil, err
+	}
+	s.keyGenerations = next
+	return retired, nil
+}
+
+// retireExpiredGenerationsIfDue runs the retirement sweep and the pinned-open
+// alert, throttled to generationRetireInterval so the frequent SHA poller can
+// call it every tick. Mirrors reconcileNetAdminIfDue and
+// reconcilePerHiveEnvIfDue — this lane deliberately reuses the existing poller
+// rather than adding a scheduler.
+//
+// THE THROTTLE IS A CLEANUP THROTTLE, NOT AN ACCEPTANCE THROTTLE. Acceptance
+// already ends at VerifyUntil for every verifier via acceptableGenerations,
+// independent of whether this ever runs. Skipping a tick delays only the
+// rewrite of hub-generations.json and the alert.
+func (s *HubServer) retireExpiredGenerationsIfDue() {
+	if s == nil {
+		return
+	}
+	s.clusterUnreachableMu.Lock()
+	due := s.lastGenerationRetire.IsZero() ||
+		time.Since(s.lastGenerationRetire) >= generationRetireInterval
+	if due {
+		s.lastGenerationRetire = time.Now()
+	}
+	s.clusterUnreachableMu.Unlock()
+	if !due {
+		return
+	}
+	s.sweepGenerationRetirement(time.Now())
+}
+
+// sweepGenerationRetirement alerts on pinned-open generations and then retires
+// the expired ones.
+//
+// ORDER MATTERS: alert BEFORE retire. The alert describes generations that are
+// still in the set, and the counts that make it meaningful are keyed to those
+// IDs. Retiring first would drop the entry and leave the operator with a
+// retirement notice and no way to see what it stranded.
+func (s *HubServer) sweepGenerationRetirement(now time.Time) {
+	if s == nil {
+		return
+	}
+	gs := s.currentGenerations()
+	if gs == nil {
+		return
+	}
+
+	// Counts come from the Deployment-sourced snapshot, NOT from heartbeat
+	// recency — the distinction PerHiveEnvSnapshot documents at length. A
+	// paused spoke still has a Deployment, so it is still counted and still
+	// shows up in this alert; it cannot fall out of the denominator by going
+	// quiet and make a stranding look like a convergence.
+	snap := s.PerHiveEnvSnapshot()
+
+	for _, g := range gs.Generations {
+		alert := evaluateGenerationPin(
+			g,
+			g.ID == gs.Current,
+			now,
+			snap.KeyGenerations.SpokesOnPrevious,
+			snap.KeyGenerations.SpokesUnattributed,
+			snap.ObservedHives,
+		)
+		if alert.Severity == pinSeverityNone {
+			continue
+		}
+		if s.logger == nil {
+			continue
+		}
+		// IDs, counts, and timestamps only. Never the secret, and never a
+		// prefix or length of it either.
+		args := []any{
+			"generation", alert.GenerationID,
+			"verify_until", alert.VerifyUntil.UTC().Format(time.RFC3339),
+			"spokes_on_previous", alert.SpokesOnPrevious,
+			"spokes_unattributed", alert.SpokesUnattributed,
+			"observed_hives", alert.ObservedHives,
+			"severity", alert.Severity.String(),
+		}
+		if alert.Severity == pinSeverityStranded {
+			s.logger.Warn("master generation verify window has CLOSED while spokes still carry it — "+
+				"those spokes are failing verification now; retirement is unconditional by design and "+
+				"will not wait for them. Converge or re-provision them.", args...)
+			continue
+		}
+		s.logger.Warn("master generation verify window is closing while spokes still carry it — "+
+			"retirement is on the wall clock and will NOT wait for convergence. "+
+			"Converge these spokes before verify_until or they will be stranded.", args...)
+	}
+
+	retired, err := s.retireExpiredGenerations(now)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("could not retire expired master generations; leaving the set unchanged and retrying next sweep",
+				"path", hubGenerationsPath, "error", err)
+		}
+		return
+	}
+	if len(retired) > 0 && s.logger != nil {
+		s.logger.Info("retired expired master generations",
+			"retired", retired, "current", gs.Current, "path", hubGenerationsPath)
+	}
+}

--- a/v2/pkg/hub/hub_generations_retire_test.go
+++ b/v2/pkg/hub/hub_generations_retire_test.go
@@ -1,0 +1,562 @@
+package hub
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+)
+
+// Tests for follow-on PR #7: automatic retirement past verify_until, and the
+// alert that fires when a generation is pinned open.
+//
+// The properties under test, in order of how badly they hurt if broken:
+//
+//  1. RETIREMENT IS UNCONDITIONAL ON CONVERGENCE. A generation past
+//     VerifyUntil is retired EVEN WITH SPOKES STILL ON IT. Gating retirement on
+//     spokes_on_previous would let one unconverged spoke pin a superseded
+//     master live forever — the "unversioned and permanent compat lane" failure
+//     that took five audits to remove. This is the point of the PR.
+//  2. VerifyUntil.IsZero() STILL MEANS ALREADY EXPIRED, on every path this PR
+//     adds. A hand-edited file must fail closed, not pin a key open.
+//  3. THE WALL-CLOCK GUARANTEE AND THE READINESS SIGNAL STAY SEPARATE.
+//     SafeToRetirePrevious still fails closed on zero observations and on
+//     non-zero spokes_unattributed; retirement ignores both.
+//  4. RETIREMENT SURVIVES A RESTART, and a failed persist is a clean no-op.
+//  5. THE FOUR MERGED READERS reject — not error — against a just-retired
+//     generation.
+
+const (
+	retSecretA = "retire-test-master-alpha"
+	retSecretB = "retire-test-master-bravo"
+)
+
+// newRetireTestHub builds a hub with an explicit two-generation set.
+//
+// It goes through setHubSecret rather than assigning hubSecret directly. That
+// is the trap #2 (2234750a) left behind: 97 test sites assigned srv.hubSecret
+// after NewHubServer, leaving keyGenerations derived from a DISCARDED secret,
+// so a generation-set reader silently tested against the wrong material.
+// retireExpiredGenerations is a new generation-set reader, so it would be
+// exposed to exactly that. setHubSecret sets both in lockstep; the explicit set
+// below then REPLACES the derived one, which is the only assignment this file
+// makes and it assigns the field the readers actually consult.
+func newRetireTestHub(t *testing.T, gens []keyGeneration, current int) *HubServer {
+	t.Helper()
+	s := &HubServer{logger: quietLogger()}
+	s.setHubSecret(retSecretA)
+	gs := newGenerationSet(current, gens)
+	if gs == nil {
+		t.Fatalf("fixture: newGenerationSet(%d, %d gens) returned nil", current, len(gens))
+	}
+	s.keyGenerations = gs
+	return s
+}
+
+// seedObservations installs Deployment-sourced spoke observations, which is
+// what PerHiveEnvSnapshot counts. Deliberately NOT heartbeat-sourced: a paused
+// spoke still has a Deployment and must still block readiness.
+func seedObservations(s *HubServer, onGeneration map[string]int) {
+	s.perHiveEnvMu.Lock()
+	defer s.perHiveEnvMu.Unlock()
+	s.perHiveEnvSeen = map[string]perHiveEnvObservation{}
+	for id, gen := range onGeneration {
+		s.perHiveEnvSeen[id] = perHiveEnvObservation{Generation: gen}
+	}
+}
+
+// TestRetireExpiredGenerationsIsPositiveControl is the two-directional positive
+// control. A retirement lane can fail two opposite ways — never firing, or
+// firing on everything — and a test that only asserts one direction passes
+// under the other. Both are asserted here, against the SAME hub.
+func TestRetireExpiredGenerationsIsPositiveControl(t *testing.T) {
+	withTempGenerationsPath(t)
+	now := time.Now().UTC()
+
+	// Direction 1: an UNEXPIRED previous generation must NOT be retired. Fails
+	// an implementation that retires unconditionally.
+	t.Run("unexpired generation is kept", func(t *testing.T) {
+		s := newRetireTestHub(t, []keyGeneration{
+			{ID: 2, Secret: retSecretB, Created: now},
+			{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(time.Hour)},
+		}, 2)
+		retired, err := s.retireExpiredGenerations(now)
+		if err != nil {
+			t.Fatalf("retire: %v", err)
+		}
+		if len(retired) != 0 {
+			t.Errorf("retired %v, want none — an unexpired generation must survive", retired)
+		}
+		if got := len(s.currentGenerations().Generations); got != 2 {
+			t.Errorf("live generations = %d, want 2", got)
+		}
+	})
+
+	// Direction 2: an EXPIRED previous generation MUST be retired. Fails an
+	// implementation that never retires.
+	t.Run("expired generation is retired", func(t *testing.T) {
+		s := newRetireTestHub(t, []keyGeneration{
+			{ID: 2, Secret: retSecretB, Created: now},
+			{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(-time.Hour)},
+		}, 2)
+		retired, err := s.retireExpiredGenerations(now)
+		if err != nil {
+			t.Fatalf("retire: %v", err)
+		}
+		if len(retired) != 1 || retired[0] != 1 {
+			t.Fatalf("retired %v, want [1] — an expired generation must be dropped", retired)
+		}
+		gs := s.currentGenerations()
+		if len(gs.Generations) != 1 {
+			t.Fatalf("live generations = %d, want 1", len(gs.Generations))
+		}
+		if gs.Current != 2 {
+			t.Errorf("current = %d, want 2 — retirement must never move the minting key", gs.Current)
+		}
+	})
+
+	// Direction 3: the CURRENT generation is never retired, however the clock
+	// reads. Fails an implementation that applies the expiry rule to current.
+	t.Run("current generation is never retired", func(t *testing.T) {
+		s := newRetireTestHub(t, []keyGeneration{
+			{ID: 2, Secret: retSecretB, Created: now.Add(-100 * 24 * time.Hour)},
+		}, 2)
+		retired, err := s.retireExpiredGenerations(now)
+		if err != nil {
+			t.Fatalf("retire: %v", err)
+		}
+		if len(retired) != 0 {
+			t.Fatalf("retired %v, want none — the minting key must never be retired", retired)
+		}
+	})
+}
+
+// TestRetireTreatsZeroVerifyUntilAsExpired pins the invariant this whole design
+// rests on, on the code path THIS PR adds.
+//
+// A zero VerifyUntil means ALREADY EXPIRED, not "never expires". Reading it the
+// other way would make a hand-edited or malformed generations file pin the old
+// master open permanently — which is the F1/F2 failure mode restated.
+func TestRetireTreatsZeroVerifyUntilAsExpired(t *testing.T) {
+	withTempGenerationsPath(t)
+	now := time.Now().UTC()
+	s := newRetireTestHub(t, []keyGeneration{
+		{ID: 2, Secret: retSecretB, Created: now},
+		// No VerifyUntil at all — the hand-edited-file case.
+		{ID: 1, Secret: retSecretA},
+	}, 2)
+
+	// The read path already refuses it...
+	if got := len(s.currentGenerations().acceptableGenerations(now)); got != 1 {
+		t.Fatalf("acceptableGenerations = %d, want 1 — a zero VerifyUntil must not be accepted", got)
+	}
+	// ...and the retirement path must agree, or the dead secret stays on disk.
+	retired, err := s.retireExpiredGenerations(now)
+	if err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	if len(retired) != 1 || retired[0] != 1 {
+		t.Fatalf("retired %v, want [1] — a zero VerifyUntil is ALREADY EXPIRED, not never-expires", retired)
+	}
+}
+
+// TestRetireHappensEvenWithSpokesStillOnGeneration is the ANTI-PIN TEST and the
+// reason this PR exists.
+//
+// Every spoke in the fleet is on the outgoing generation and none has
+// converged. Retirement must fire ANYWAY, and the alert must say so. An
+// implementation that waits for spokes_on_previous == 0 passes every other test
+// in this file and fails this one.
+func TestRetireHappensEvenWithSpokesStillOnGeneration(t *testing.T) {
+	withTempGenerationsPath(t)
+	now := time.Now().UTC()
+	s := newRetireTestHub(t, []keyGeneration{
+		{ID: 2, Secret: retSecretB, Created: now},
+		{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(-time.Minute)},
+	}, 2)
+	// The entire fleet is still on generation 1. Nothing has converged.
+	seedObservations(s, map[string]int{"hive-a": 1, "hive-b": 1, "hive-c": 1})
+
+	snap := s.PerHiveEnvSnapshot()
+	if snap.KeyGenerations.SpokesOnPrevious != 3 {
+		t.Fatalf("fixture: spokes_on_previous = %d, want 3", snap.KeyGenerations.SpokesOnPrevious)
+	}
+
+	// The alert must fire, at STRANDED severity: the window has closed and
+	// spokes are still on it.
+	alert := evaluateGenerationPin(
+		keyGeneration{ID: 1, VerifyUntil: now.Add(-time.Minute)}, false, now,
+		snap.KeyGenerations.SpokesOnPrevious, snap.KeyGenerations.SpokesUnattributed, snap.ObservedHives)
+	if alert.Severity != pinSeverityStranded {
+		t.Errorf("severity = %v, want stranded — a closed window with spokes on it must alert loudly",
+			alert.Severity)
+	}
+
+	// And retirement must happen regardless. This is the assertion that fails
+	// if retirement is ever made conditional on convergence.
+	retired, err := s.retireExpiredGenerations(now)
+	if err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	if len(retired) != 1 || retired[0] != 1 {
+		t.Fatalf("retired %v, want [1] — retirement is a WALL-CLOCK guarantee and must NOT wait for "+
+			"convergence; one unconverged spoke must never pin the old master open", retired)
+	}
+	if got := len(s.currentGenerations().acceptableGenerations(now)); got != 1 {
+		t.Errorf("acceptable after retire = %d, want 1", got)
+	}
+}
+
+// TestGenerationPinAlertSeverities covers the alert policy across the timeline.
+func TestGenerationPinAlertSeverities(t *testing.T) {
+	now := time.Now().UTC()
+	prev := func(until time.Duration) keyGeneration {
+		return keyGeneration{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(until)}
+	}
+
+	cases := []struct {
+		name         string
+		gen          keyGeneration
+		isCurrent    bool
+		onPrevious   int
+		unattributed int
+		observed     int
+		wantSeverity generationPinSeverity
+	}{
+		{
+			name: "converged fleet well before expiry is silent",
+			gen:  prev(72 * time.Hour), onPrevious: 0, observed: 5,
+			wantSeverity: pinSeverityNone,
+		},
+		{
+			name: "spokes on previous but expiry far away is silent",
+			gen:  prev(72 * time.Hour), onPrevious: 3, observed: 5,
+			wantSeverity: pinSeverityNone,
+		},
+		{
+			name: "spokes on previous inside the warn window warns",
+			gen:  prev(2 * time.Hour), onPrevious: 3, observed: 5,
+			wantSeverity: pinSeverityWarn,
+		},
+		{
+			name: "window closed with spokes still on it is stranded",
+			gen:  prev(-time.Minute), onPrevious: 3, observed: 5,
+			wantSeverity: pinSeverityStranded,
+		},
+		{
+			// spokes_unattributed must count as "still carrying the old key".
+			// #3766 made it block retirement readiness deliberately; folding it
+			// into "converged" here would reopen that hole from the alerting
+			// side.
+			name: "unattributed spokes alone still raise the alert",
+			gen:  prev(-time.Minute), onPrevious: 0, unattributed: 2, observed: 5,
+			wantSeverity: pinSeverityStranded,
+		},
+		{
+			// Zero observations means the hub has read nothing, so the counts
+			// are evidence of nothing. Do not claim stranding from no data.
+			name: "zero observations does not manufacture an alert",
+			gen:  prev(-time.Minute), onPrevious: 0, unattributed: 0, observed: 0,
+			wantSeverity: pinSeverityNone,
+		},
+		{
+			// A zero VerifyUntil is ALREADY EXPIRED, so it is stranded, not
+			// silent. Suppressing here would hide the malformed-file case.
+			name: "zero VerifyUntil with spokes on it is stranded",
+			gen:  keyGeneration{ID: 1, Secret: retSecretA}, onPrevious: 1, observed: 5,
+			wantSeverity: pinSeverityStranded,
+		},
+		{
+			name: "current generation is never pinned open",
+			gen:  keyGeneration{ID: 2, Secret: retSecretB}, isCurrent: true, onPrevious: 3, observed: 5,
+			wantSeverity: pinSeverityNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evaluateGenerationPin(tc.gen, tc.isCurrent, now, tc.onPrevious, tc.unattributed, tc.observed)
+			if got.Severity != tc.wantSeverity {
+				t.Errorf("severity = %v, want %v", got.Severity, tc.wantSeverity)
+			}
+		})
+	}
+}
+
+// TestSafeToRetirePreviousStillFailsClosed pins the READINESS signal, which is
+// a different condition from retirement and must stay that way.
+//
+// Retirement is the wall clock's call. SafeToRetirePrevious answers a narrower
+// question — "does retiring right now cost nothing?" — and fails closed on zero
+// observations and on any unattributed spoke. This PR must not have relaxed it.
+func TestSafeToRetirePreviousStillFailsClosed(t *testing.T) {
+	withTempGenerationsPath(t)
+	now := time.Now().UTC()
+	build := func(t *testing.T, obs map[string]int) PerHiveEnvStatus {
+		t.Helper()
+		s := newRetireTestHub(t, []keyGeneration{
+			{ID: 2, Secret: retSecretB, Created: now},
+			{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(-time.Hour)},
+		}, 2)
+		seedObservations(s, obs)
+		return s.PerHiveEnvSnapshot()
+	}
+
+	t.Run("zero observations is never safe", func(t *testing.T) {
+		snap := build(t, map[string]int{})
+		if snap.KeyGenerations.SafeToRetirePrevious {
+			t.Error("safe_to_retire_previous = true from ZERO observations — must fail closed")
+		}
+	})
+
+	t.Run("unattributed spokes are never safe", func(t *testing.T) {
+		// Generation 0 == matches no live generation == unattributed.
+		snap := build(t, map[string]int{"hive-a": 2, "hive-b": 0})
+		if snap.KeyGenerations.SpokesUnattributed != 1 {
+			t.Fatalf("fixture: spokes_unattributed = %d, want 1", snap.KeyGenerations.SpokesUnattributed)
+		}
+		if snap.KeyGenerations.SafeToRetirePrevious {
+			t.Error("safe_to_retire_previous = true with an UNATTRIBUTED spoke — #3766 made this block " +
+				"readiness deliberately; an unattributed spoke is broken now, not converged")
+		}
+	})
+
+	t.Run("spokes on previous are never safe", func(t *testing.T) {
+		snap := build(t, map[string]int{"hive-a": 2, "hive-b": 1})
+		if snap.KeyGenerations.SafeToRetirePrevious {
+			t.Error("safe_to_retire_previous = true with a spoke still on previous")
+		}
+	})
+
+	t.Run("converged fleet past the window is safe", func(t *testing.T) {
+		snap := build(t, map[string]int{"hive-a": 2, "hive-b": 2})
+		if !snap.KeyGenerations.SafeToRetirePrevious {
+			t.Error("safe_to_retire_previous = false for a fully converged fleet past verify_until — " +
+				"the readiness signal must still be able to say yes, or it is not a signal")
+		}
+	})
+}
+
+// TestRetirementSurvivesRestart asserts persistence: a retirement must not come
+// back at the next hub roll, which happens several times a day.
+func TestRetirementSurvivesRestart(t *testing.T) {
+	path := withTempGenerationsPath(t)
+	now := time.Now().UTC()
+
+	// Seed a persisted two-generation set, one of them expired.
+	seed := &generationSet{Current: 2, Generations: []keyGeneration{
+		{ID: 2, Secret: retSecretB, Created: now},
+		{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(-time.Hour)},
+	}}
+	if err := saveGenerations(seed, now.Add(-8*24*time.Hour)); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	s := newRetireTestHub(t, seed.Generations, 2)
+	s.lastKeyRotation = now.Add(-8 * 24 * time.Hour)
+	retired, err := s.retireExpiredGenerations(now)
+	if err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	if len(retired) != 1 {
+		t.Fatalf("retired %v, want [1]", retired)
+	}
+
+	// Simulate the restart: read the file back the way loadGenerations does.
+	reloaded, rotatedAt := loadGenerations(retSecretA, quietLogger())
+	if reloaded == nil {
+		t.Fatal("reload returned nil set")
+	}
+	if len(reloaded.Generations) != 1 {
+		t.Errorf("after restart, live generations = %d, want 1 — the retirement did not persist",
+			len(reloaded.Generations))
+	}
+	if reloaded.Current != 2 {
+		t.Errorf("after restart, current = %d, want 2", reloaded.Current)
+	}
+	for _, g := range reloaded.Generations {
+		if g.ID == 1 {
+			t.Error("retired generation 1 is still on disk after restart — its master secret is " +
+				"retained in plaintext past the point where it protects anything")
+		}
+	}
+	// Retirement is not a rotation and must not reset the cooldown, or an
+	// operator could bypass it by waiting for a retirement.
+	if rotatedAt.IsZero() {
+		t.Error("rotated_at was cleared by retirement — the double-rotation cooldown would reset")
+	}
+
+	// And the file must still be 0600: it holds master secrets.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != hubGenerationsFileMode {
+		t.Errorf("file mode = %o, want %o", perm, hubGenerationsFileMode)
+	}
+}
+
+// TestFailedPersistLeavesRetirementUnapplied asserts the persist-before-install
+// ordering #4 established: a failed write must be a clean NO-OP, never a
+// half-applied state where memory and disk disagree.
+func TestFailedPersistLeavesRetirementUnapplied(t *testing.T) {
+	withTempGenerationsPath(t)
+	now := time.Now().UTC()
+	s := newRetireTestHub(t, []keyGeneration{
+		{ID: 2, Secret: retSecretB, Created: now},
+		{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(-time.Hour)},
+	}, 2)
+
+	// Make the write fail by pointing the path at a location that cannot be
+	// created: a directory component that is actually a file.
+	blocker := hubGenerationsPath + ".blocker"
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("blocker: %v", err)
+	}
+	prev := hubGenerationsPath
+	hubGenerationsPath = blocker + "/hub-generations.json"
+	t.Cleanup(func() { hubGenerationsPath = prev })
+
+	retired, err := s.retireExpiredGenerations(now)
+	if err == nil {
+		t.Fatal("retire returned no error despite an unwritable path")
+	}
+	if len(retired) != 0 {
+		t.Errorf("retired %v on a failed persist, want none", retired)
+	}
+	// The in-memory set must be UNCHANGED — a retirement applied in memory only
+	// would come back at the next roll.
+	if got := len(s.currentGenerations().Generations); got != 2 {
+		t.Errorf("in-memory generations = %d, want 2 — a failed persist must be a clean no-op", got)
+	}
+}
+
+// TestMergedReadersRejectRetiredGeneration covers the four merged follow-ons
+// that read the generation set. An artifact minted under a generation that has
+// just been retired must be REJECTED — cleanly, not with an error or a panic —
+// by every one of them.
+func TestMergedReadersRejectRetiredGeneration(t *testing.T) {
+	withTempGenerationsPath(t)
+	now := time.Now().UTC()
+
+	// Build the pre-retirement set and mint artifacts under generation 1.
+	before := newGenerationSet(2, []keyGeneration{
+		{ID: 2, Secret: retSecretB, Created: now},
+		{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(time.Hour)},
+	})
+	gen1 := keyGeneration{ID: 1, Secret: retSecretA}
+	cookie, _ := mintHubUserCookieValueV3Gen(sessionSeedForGeneration(gen1), "alice", now, time.Hour, 1)
+	bearer := derivePerHiveKey(retSecretA, infoHeartbeatKey, "hive-a")
+	if cookie == "" || bearer == "" {
+		t.Fatal("fixture: could not mint generation-1 artifacts")
+	}
+
+	// #1 session cookie and #2 heartbeat bearer both verify BEFORE retirement.
+	if _, id, ok := verifyHubUserCookieAcrossGenerations(before, cookie, now, nil); !ok || id != 1 {
+		t.Fatalf("fixture: cookie did not verify under generation 1 (ok=%v id=%d)", ok, id)
+	}
+	if id, ok := verifyHeartbeatBearerAcrossGenerations(before, bearer, "hive-a", now); !ok || id != 1 {
+		t.Fatalf("fixture: bearer did not verify under generation 1 (ok=%v id=%d)", ok, id)
+	}
+
+	// Retire generation 1.
+	s := newRetireTestHub(t, before.Generations, 2)
+	retiredNow := now.Add(2 * time.Hour)
+	if _, err := s.retireExpiredGenerations(retiredNow); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	after := s.currentGenerations()
+	if len(after.Generations) != 1 {
+		t.Fatalf("fixture: generation 1 was not retired (%d live)", len(after.Generations))
+	}
+
+	// #1 SESSION COOKIE — rejected, not errored. The cookie carries a `g:1`
+	// claim naming a generation that no longer exists; that must fall through
+	// to trial verification and simply fail, since only generation 2's key
+	// remains and it did not sign this cookie.
+	t.Run("session cookie is rejected", func(t *testing.T) {
+		u, id, ok := verifyHubUserCookieAcrossGenerations(after, cookie, retiredNow, nil)
+		if ok {
+			t.Errorf("cookie minted under a RETIRED generation verified (user=%q id=%d)", u, id)
+		}
+		if u != "" || id != 0 {
+			t.Errorf("rejected cookie leaked user=%q id=%d, want empty", u, id)
+		}
+	})
+
+	// #2 HEARTBEAT BEARER — rejected. A bare derived string with no envelope,
+	// so this is trial verification against the remaining generation only.
+	t.Run("heartbeat bearer is rejected", func(t *testing.T) {
+		id, ok := verifyHeartbeatBearerAcrossGenerations(after, bearer, "hive-a", retiredNow)
+		if ok {
+			t.Errorf("bearer derived from a RETIRED generation verified (id=%d)", id)
+		}
+		if id != 0 {
+			t.Errorf("rejected bearer reported generation %d, want 0", id)
+		}
+	})
+
+	// #3 PER-HIVE ENV — a spoke still carrying generation-1 material must
+	// classify as UNATTRIBUTED, not as "on previous" and not as converged. It
+	// is broken now, not lagging.
+	t.Run("per-hive env classifies retired material as unattributed", func(t *testing.T) {
+		live := []deploymentEnvVar{{Name: "HIVE_HEARTBEAT_KEY", Value: bearer}}
+		gen, ok := perHiveEnvGeneration(after.acceptableGenerations(retiredNow), live, "hive-a")
+		if ok || gen != 0 {
+			t.Errorf("retired-generation material classified as generation %d (ok=%v), want unattributed",
+				gen, ok)
+		}
+	})
+
+	// #4 ROTATE ENDPOINT — the persisted file must no longer contain the
+	// retired generation's secret, and the set must still be usable for a
+	// subsequent rotation.
+	t.Run("persisted set no longer holds the retired secret", func(t *testing.T) {
+		data, err := os.ReadFile(hubGenerationsPath)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		var p persistedGenerations
+		if err := json.Unmarshal(data, &p); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(p.Generations) != 1 {
+			t.Fatalf("persisted generations = %d, want 1", len(p.Generations))
+		}
+		for _, g := range p.Generations {
+			if g.ID == 1 {
+				t.Error("retired generation 1 remains in the persisted file")
+			}
+		}
+		// A rotation must still work off the retired-down set.
+		s.lastKeyRotation = time.Time{}
+		next, _, err := s.rotateMasterSecret(retiredNow, false)
+		if err != nil {
+			t.Fatalf("rotate after retirement: %v", err)
+		}
+		if next.Current != 3 {
+			t.Errorf("post-retirement rotation produced current = %d, want 3", next.Current)
+		}
+	})
+}
+
+// TestSweepGenerationRetirementIsIdempotent asserts the poller-facing entry
+// point is safe to call every tick: the second sweep finds nothing to do.
+func TestSweepGenerationRetirementIsIdempotent(t *testing.T) {
+	withTempGenerationsPath(t)
+	now := time.Now().UTC()
+	s := newRetireTestHub(t, []keyGeneration{
+		{ID: 2, Secret: retSecretB, Created: now},
+		{ID: 1, Secret: retSecretA, VerifyUntil: now.Add(-time.Hour)},
+	}, 2)
+	seedObservations(s, map[string]int{"hive-a": 1})
+
+	s.sweepGenerationRetirement(now)
+	if got := len(s.currentGenerations().Generations); got != 1 {
+		t.Fatalf("after first sweep, generations = %d, want 1", got)
+	}
+	s.sweepGenerationRetirement(now)
+	if got := len(s.currentGenerations().Generations); got != 1 {
+		t.Errorf("after second sweep, generations = %d, want 1 — the sweep must be idempotent", got)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5027,6 +5027,13 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// rate-limited to perHiveEnvMaxPatchesPerCycle patches per cycle, because
 	// each patch rolls that hive's pod. See perhive_env_reconcile.go.
 	s.reconcilePerHiveEnvIfDue()
+	// Drop master generations whose verify window has closed, and warn when one
+	// is closing while spokes still carry it. Throttled internally to
+	// generationRetireInterval. This lane PERSISTS the drop and ALERTS; it is
+	// not what enforces expiry — acceptableGenerations already refuses an
+	// expired generation at every verify, on the wall clock, whether or not
+	// this ever runs. See hub_generations_retire.go.
+	s.retireExpiredGenerationsIfDue()
 	// Record the per-release image-pulls snapshot (external-adoption chart). The
 	// call is internally guarded to snapshot only when the v2 release SHA advances,
 	// so ticking it alongside the frequent SHA poll is cheap — no separate
@@ -5055,6 +5062,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		s.sweepStuckAssignments()
 		s.reconcileNetAdminIfDue()
 		s.reconcilePerHiveEnvIfDue()
+		s.retireExpiredGenerationsIfDue()
 		s.maybeSnapshotImagePulls(ctx, time.Now())
 		changed := false
 		for branch, sha := range newSHAs {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -910,6 +910,15 @@ type HubServer struct {
 	// Same rationale and same guarding mutex as lastNetAdminReconcile above:
 	// both are poller-loop-only state.
 	lastPerHiveEnvReconcile time.Time
+	// lastGenerationRetire throttles the expired-master-generation retirement
+	// sweep (hub_generations_retire.go). Same rationale and same guarding mutex
+	// as the two above: poller-loop-only state.
+	//
+	// NOTE this throttles CLEANUP AND ALERTING ONLY. A generation stops being
+	// ACCEPTED at its VerifyUntil via acceptableGenerations, on the wall clock,
+	// whether or not this sweep ever runs — so a missed tick delays rewriting
+	// hub-generations.json, never extends the acceptance window.
+	lastGenerationRetire time.Time
 	// perHiveEnvSeen is the Deployment-SOURCED convergence view backing
 	// PerHiveEnvSnapshot: hive ID → what the hub last actually read off that
 	// hive's Deployment. Deliberately NOT derived from heartbeat recency (see


### PR DESCRIPTION
Follow-on PR #7 of the hub master-key rotation design
(v2/docs/design/master-key-rotation.md). Hub-internal — no spoke rolls.

WHAT WAS ALREADY TRUE. acceptableGenerations(now) in hub_generations.go
ALREADY filters on the wall clock: it excludes any non-current generation
whose VerifyUntil has passed, and treats a ZERO VerifyUntil as ALREADY
EXPIRED rather than "never expires". Every verifier goes through it. So
step 5's security guarantee — "after verify_until the previous generation
stops being accepted, automatically, whether or not anyone is watching" —
was already kept, and this PR does not duplicate, re-implement, or weaken
it. If this entire lane never ran, an expired generation would still stop
verifying on time.

WHAT WAS MISSING, and what this adds:

1. PERSISTING THE DROP. acceptableGenerations is a pure read-path
   predicate; it leaves the dead entry in the set on disk forever. A
   generation that is no longer accepted but is still recorded is a
   plaintext master secret retained on the hub PVC past the point where it
   protects anything — the F1/F2 residue in another form. Retirement
   rewrites hub-generations.json without it, so the secret stops existing
   rather than merely stopping being honoured.

2. THE PINNED-OPEN ALERT. Unconditional wall-clock retirement can and will
   strand unconverged spokes. That is correct, but it must not be silent.

THE TWO CONDITIONS ARE KEPT SEPARATE, DELIBERATELY.

  - RETIREMENT is a WALL-CLOCK SECURITY GUARANTEE. It fires when
    VerifyUntil has passed, full stop — never gated on spokes_on_previous,
    never on spokes_unattributed, never on whether anything was observed.
    Gating it on convergence would let one paused or unreachable spoke keep
    a superseded master live indefinitely, which is exactly the unversioned,
    permanent compat lane the "explicitly finite" property exists to
    prevent.

  - safe_to_retire_previous stays an OPERATOR-FACING READINESS SIGNAL
    meaning "retiring now costs nothing". Unchanged by this PR: it still
    fails closed on zero observations and on any unattributed spoke (#3766
    made the latter block readiness deliberately).

Retirement never reads the readiness signal. The counts feed the ALERT
only — they change how loudly retirement is announced, never whether it
happens.

WHERE IT RUNS. retireExpiredGenerationsIfDue() on the existing SHA poller
in saas.go, alongside reconcileNetAdminIfDue / reconcilePerHiveEnvIfDue,
throttled to 15m — no new scheduler. The throttle bounds how long a dead
entry LINGERS ON DISK, never how long it is ACCEPTED.

PERSIST BEFORE INSTALL, matching rotateMasterSecret: a failed write leaves
the in-memory set untouched and retries next sweep, so a failed retirement
is a clean no-op rather than a half-applied state that reappears at the
next hub roll. lastKeyRotation is carried through unchanged — retirement is
not a rotation and must not reset the double-rotation cooldown.

Alert severity: warn when the window closes within 24h with spokes still on
the generation (sized to exceed a full ~5.5h reconcile sweep, so it is
actionable rather than a post-mortem), stranded once it has closed.
spokes_unattributed counts as "still carrying the old key" — broken now,
not lagging. IDs, counts and timestamps only; never key material.

TESTS

  TestRetireExpiredGenerationsIsPositiveControl — fails in BOTH directions
    (never retires / retires unconditionally / retires current).
  TestRetireTreatsZeroVerifyUntilAsExpired — the invariant, on the new path.
  TestRetireHappensEvenWithSpokesStillOnGeneration — the ANTI-PIN test: the
    whole fleet is on the old generation, retirement fires anyway and the
    alert reads stranded.
  TestGenerationPinAlertSeverities — alert policy across the timeline,
    including unattributed-only and zero-observation cases.
  TestSafeToRetirePreviousStillFailsClosed — readiness unchanged.
  TestRetirementSurvivesRestart — persist, reload, still retired; 0600 held.
  TestFailedPersistLeavesRetirementUnapplied — failed write is a no-op.
  TestMergedReadersRejectRetiredGeneration — all four merged readers (#1
    cookie, #2 bearer, #3 per-hive env, #4 rotate) REJECT rather than error
    against a just-retired generation.
  TestSweepGenerationRetirementIsIdempotent — safe on every poller tick.

Regression replay: gating retirement on spokes_on_previous > 0 still
compiles and fails TestRetireHappensEvenWithSpokesStillOnGeneration with
"retired [], want [1]"; restored, all nine pass. Full ./pkg/hub/ suite green.

The #2 (2234750a) trap is avoided: the new test helper goes through
setHubSecret rather than assigning hubSecret directly, so the new
generation-set reader is never tested against a discarded secret.

Signed-off-by: Andrew Anderson <andy@clubanderson.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)