### PR TITLE
🔐 hub: SSO/session Ed25519 public key rotation across two generations (#6)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1944,8 +1944,17 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 	// sign. SpokeSSOPublicKey falls back to deriving the public key from
 	// HIVE_HUB_SECRET for self-hosted/legacy spokes that still hold the master, so
 	// verification succeeds against the hub-minted token either way.
-	pubKey := hub.SpokeSSOPublicKey()
-	if pubKey == "" {
+	// ROTATION (master-key-rotation.md follow-on #6): a spoke may hold TWO hub
+	// public keys during a master rotation — the current generation's and the
+	// outgoing one's — because the hub starts minting under the new generation
+	// immediately while the reconcile lane takes ~6h to walk the fleet. Trying
+	// only the primary key would 401 every SSO handoff into a not-yet-reconciled
+	// spoke for those hours. SpokeSSOPublicKeys returns current-then-previous,
+	// and returns exactly ONE key — byte-identical to SpokeSSOPublicKey — when
+	// HIVE_SSO_PUBLIC_KEY_PREV is absent, which is its state on every spoke
+	// today and on every spoke that has never seen a rotation.
+	pubKeys := hub.SpokeSSOPublicKeys()
+	if len(pubKeys) == 0 {
 		// No verification key → SSO cannot be verified. Terminate with an
 		// explanation. Redirecting to "/" here is what produced the historical
 		// infinite bounce: "/" is auth-gated, sends the user back to the hub
@@ -1969,7 +1978,7 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		hiveID = s.deps.Config.HiveID
 	}
 
-	username, tokenRole, err := hub.VerifySSOToken(pubKey, token, hiveID, time.Now())
+	username, tokenRole, _, err := hub.VerifySSOTokenAcrossKeys(pubKeys, token, hiveID, time.Now())
 	if err != nil {
 		if s.deps != nil && s.deps.Logger != nil {
 			s.deps.Logger.Warn("sso handoff rejected", "error", err.Error())

--- a/v2/pkg/hub/hub_pubkey_generations.go
+++ b/v2/pkg/hub/hub_pubkey_generations.go
@@ -1,0 +1,377 @@
+package hub
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"os"
+	"strings"
+	"time"
+)
+
+// SSO / SESSION Ed25519 PUBLIC KEY plurality — follow-on PR #6 of the
+// master-key rotation design (v2/docs/design/master-key-rotation.md).
+//
+// WHY THIS ONE IS SEQUENCED LAST, AND WHY IT IS A DIFFERENT SHAPE FROM #1-#5.
+// Every earlier follow-on made a HUB-side verifier accept two generations. The
+// hub holds the whole generation set, so "accept both" was a local change: read
+// one more entry out of a struct the hub already has.
+//
+// This one is not that. The SSO handoff token and the hub session cookie are
+// MINTED ON THE HUB and VERIFIED ON THE SPOKE — by Go in
+// pkg/dashboard/api.go (SSO) and, independently, by Node in v2/proxy/server.js
+// (session cookie). The verifying party does not hold the generation set, does
+// not hold any master, and by design holds no private material at all. It holds
+// ONE hex Ed25519 public key that the hub put in its Deployment env.
+//
+// So the failure this PR exists to prevent is not "the hub rejects an old
+// artifact". It is the mirror image: the hub, the instant it rotates, starts
+// minting under generation N, and ~65 spokes are still holding generation N-1's
+// PUBLIC key. Those spokes cannot verify anything the hub now mints. Every
+// hosted SSO handoff 401s and every hosted terminal session fails its cookie
+// check — not for the 30 minutes an impersonation cookie lives, but for the
+// ~6 hours the rate-limited reconcile lane takes to walk the fleet at 3 patches
+// per 15-minute cycle. That is the flag day, relocated from the hub to the
+// fleet.
+//
+// THE FIX IS THEREFORE PLURALITY ON THE SPOKE, NOT SELECTION ON THE HUB. A
+// spoke must hold BOTH live generations' public keys and try each. Which puts
+// this squarely in the design doc's "CANNOT carry a marker" bucket —
+//
+//	| SSO/session PUBLIC keys | A hex Ed25519 public key has a fixed 32-byte form. |
+//
+// — so the mechanism is BOUNDED TRIAL VERIFICATION against the live
+// generations, current-then-previous, bounded by maxLiveGenerations == 2. Worst
+// case is two Ed25519 verifications on a path that already does one.
+//
+// ORDERING — THE PROPERTY THE WHOLE PR TURNS ON.
+//
+// The VERIFIER must be able to accept two public keys BEFORE the hub ever hands
+// out a second one. A spoke whose proxy understands only one key, handed a
+// second, is not merely un-improved — depending on the env contract it can be
+// actively broken (see EnvSSOPublicKeyPrevious below for the delimited-list
+// analysis that ruled that encoding out). So this PR ships ONLY the verifier
+// plurality and the provisioning of the second var. It does not, and cannot,
+// cause a rotation: rotation is triggered by the admin endpoint from #4, and
+// until an operator calls it there is exactly ONE generation.
+//
+// WITH ONE GENERATION THIS IS A NO-OP, BY CONSTRUCTION. previousPublicKeys
+// returns an empty slice whenever acceptableGenerations yields only the current
+// generation, which is the state of every hub in the fleet today and the state
+// of every hub that has never been rotated. An empty previous list means:
+//   - desiredPerHiveEnv emits NO second var, so perHiveEnvDrift sees no drift,
+//     so NO spoke is patched and NO pod rolls;
+//   - the Go and Node verifiers evaluate a zero-length candidate list after the
+//     primary key and behave byte-identically to today.
+//
+// The second var appears on a spoke for the first time only after a rotation,
+// and disappears again — via the same drift-and-patch lane — once the previous
+// generation expires out of acceptableGenerations. It is self-clearing, which
+// is what stops it becoming the unversioned permanent compat lane that F1/F2
+// were.
+
+const (
+	// EnvSSOPublicKeyPrevious carries the PREVIOUS generation's Ed25519 public
+	// key for SSO handoff verification, alongside (never instead of)
+	// EnvSSOPublicKey.
+	//
+	// WHY A SECOND VAR AND NOT A DELIMITED LIST IN THE EXISTING VAR. A list was
+	// the tempting option — it touches no provisioning surface and no reconcile
+	// list. It is wrong, and the reason is measurable rather than aesthetic.
+	//
+	// The value in HIVE_SSO_PUBLIC_KEY is read by TWO independently written
+	// verifiers, and during the ~6h reconcile walk some spokes are running the
+	// OLD image. Feed "<hex>,<hex>" to each of them:
+	//
+	//   Node  Buffer.from(v,'hex')      -> 32 bytes. Silently truncates at the
+	//                                      first non-hex byte, yielding key #1.
+	//                                      Keeps working, by accident.
+	//   Go    hex.DecodeString(v)       -> error "invalid byte: U+002C ','".
+	//                                      SpokeSSOPublicKey / VerifySSOToken
+	//                                      fail closed. SSO DEAD on that spoke.
+	//
+	// The two languages disagree about what a delimited list means, and the
+	// disagreement is exactly "does hosted SSO still work on an un-rolled
+	// spoke". A list would therefore break SSO on every spoke the reconcile
+	// lane has patched but that has not yet rolled the new image — which is the
+	// entire fleet for the first cycle, and a shrinking slice of it for six
+	// hours. Backward compatibility here is mandatory, so the encoding that has
+	// a defined meaning to old readers wins: an ADDITIONAL var, which old code
+	// does not read at all and is consequently unable to misread.
+	//
+	// A separate var is also the only encoding that lets a spoke's key set
+	// SHRINK cleanly. Retirement removes a var, which both readers already
+	// handle (absent == empty == no candidate); shrinking a list would require
+	// old readers to re-parse a value they are truncating anyway.
+	EnvSSOPublicKeyPrevious = "HIVE_SSO_PUBLIC_KEY_PREV"
+
+	// envSessionPublicKeyPrevious is the session-cookie mirror of
+	// EnvSSOPublicKeyPrevious. Unexported for the same reason
+	// envSessionPublicKey is: only the Node proxy reads it, so there is no Go
+	// caller to export it for, and naming it here keeps the reconcile check and
+	// the reconcile patch from ever disagreeing about the spelling.
+	envSessionPublicKeyPrevious = "HIVE_SESSION_PUBLIC_KEY_PREV"
+)
+
+// errSSONoVerificationKey and errSSORejected are the two outcomes
+// VerifySSOTokenAcrossKeys can report.
+//
+// They are deliberately COARSE. VerifySSOToken distinguishes bad-signature from
+// wrong-version from expired from wrong-hive, which is useful in a hub-side log
+// but must not become richer here: with several keys tried, a per-key error
+// would tell an unauthenticated caller WHICH generation rejected its token and
+// therefore whether this spoke has converged. The caller in pkg/dashboard
+// already collapses the detailed error into one 401 for the user and logs the
+// detail; this returns only "no key configured" (an operator-facing
+// configuration fault, already surfaced as a distinct 503) versus "rejected".
+var (
+	errSSONoVerificationKey = ssoError("sso: no verification key configured")
+	errSSORejected          = ssoError("sso: handoff token rejected")
+)
+
+// ssoError is a constant-friendly error type, so the two sentinels above can be
+// compared with errors.Is by identity without a package-level init.
+type ssoError string
+
+func (e ssoError) Error() string { return string(e) }
+
+// ssoPublicKeyForGeneration returns the hex Ed25519 PUBLIC key a verifier checks
+// one generation's SSO handoff tokens against. Mirror of
+// sessionPublicKeyForGeneration (hub_cookie_generations.go) for the SSO domain.
+//
+// PRIVATE MATERIAL NEVER LEAVES: the seed produced here is expanded and
+// DISCARDED inside ssoPublicKeyFromSeed, which returns only the public half.
+// infoSSOEd25519Seed and infoSessionEd25519Seed derive SEEDS — hub-only signing
+// material — and hub_keys.go's ssoSigningSeed/sessionSigningSeed doc comments
+// state that those must never be injected into a spoke. Nothing in this file
+// returns a seed to a caller, and nothing in this file is reachable from a
+// provisioning path except through ssoPublicKeyFromSeed.
+func ssoPublicKeyForGeneration(g keyGeneration) string {
+	return ssoPublicKeyFromSeed(deriveDomainKey(g.Secret, infoSSOEd25519Seed))
+}
+
+// previousPublicKeys returns the PUBLIC keys of every acceptable generation
+// EXCEPT the current one, in most-recent-first order, for the domain named by
+// `info`.
+//
+// Empty for a set with one generation — which is every hub today. That empty
+// return is what makes this whole PR a no-op before the first rotation: the
+// callers below all treat an empty list as "emit nothing / try nothing".
+//
+// Expiry binds here and nowhere else: acceptableGenerations excludes a previous
+// generation whose VerifyUntil has passed (and treats a MISSING VerifyUntil as
+// already expired, so a hand-edited generations file fails closed). Once the
+// window shuts, this returns empty again and the reconcile lane removes the var
+// from the fleet — the acceptance window closes on a wall clock, with no
+// operator action, which is the finiteness property the design demands.
+func previousPublicKeys(gs *generationSet, info string, now time.Time) []string {
+	if gs == nil {
+		return nil
+	}
+	acceptable := gs.acceptableGenerations(now)
+	out := make([]string, 0, len(acceptable))
+	for _, g := range acceptable {
+		if g.ID == gs.Current {
+			continue
+		}
+		pub := ssoPublicKeyFromSeed(deriveDomainKey(g.Secret, info))
+		if pub == "" {
+			// A generation whose seed does not expand yields no candidate rather
+			// than an empty-string one. An empty key must never reach a
+			// Deployment: the spoke-side resolvers treat an empty var exactly
+			// like an absent one, so writing "" would look converged while
+			// verifying nothing.
+			continue
+		}
+		out = append(out, pub)
+	}
+	return out
+}
+
+// provisionSSOPublicKeyPrevious and provisionSessionPublicKeyPrevious are the
+// provisioning/reconcile-time values for the two _PREV vars.
+//
+// They return "" when there is no previous generation. The callers
+// (desiredPerHiveEnv) must then OMIT the var entirely rather than set it empty —
+// see desiredPerHiveEnv's own fail-safe comment for why an empty var is strictly
+// worse than an absent one.
+//
+// Only the FIRST previous generation is offered even though previousPublicKeys
+// returns a slice. maxLiveGenerations == 2 means the slice can never hold more
+// than one entry today; taking [0] rather than joining keeps the env contract
+// single-valued per var, which is the property that made a second var the right
+// encoding in the first place. If maxLiveGenerations were ever raised, this
+// would need a third var — deliberately a visible code change rather than a
+// silently-lengthening string.
+// SCOPE NOTE — the provisioning TEMPLATE is deliberately not changed.
+//
+// saas_provision.go's Deployment YAML emits the five mandatory vars from a
+// text/template with unconditional `- name: X / value: "{{.Y}}"` blocks. The
+// two _PREV vars are EMPTY in production and empty on every un-rotated hub, so
+// adding them there would mean either emitting `value: ""` on all 65 spokes —
+// the exact empty-var outcome desiredPerHiveEnv's fail-safe exists to prevent —
+// or introducing conditional blocks into a YAML template whose whitespace and
+// quoting are load-bearing, to cover a case that is unreachable today.
+//
+// The reconcile lane covers it instead, and covers it correctly: a hive
+// provisioned during a rotation window is read by the very next sweep, drifts
+// on the missing _PREV, and is patched within one 15-minute cycle. The cost is
+// bounded — a freshly provisioned spoke can fail SSO for up to one cycle if the
+// hub happens to be mid-rotation — and it is strictly smaller than the cost of
+// a template edit that ships an empty var to the whole fleet immediately.
+func provisionSSOPublicKeyPrevious() string {
+	return firstOrEmpty(previousPublicKeys(provisionGenerationSet(), infoSSOEd25519Seed, time.Now()))
+}
+
+func provisionSessionPublicKeyPrevious() string {
+	return firstOrEmpty(previousPublicKeys(provisionGenerationSet(), infoSessionEd25519Seed, time.Now()))
+}
+
+func firstOrEmpty(v []string) string {
+	if len(v) == 0 {
+		return ""
+	}
+	return v[0]
+}
+
+// SpokeSSOPublicKeys returns EVERY Ed25519 public key this spoke should try when
+// verifying a hub-minted SSO handoff token, in current-then-previous order.
+//
+// This is the spoke-side plural form of SpokeSSOPublicKey, which is retained
+// unchanged and still returns the single primary key. Retaining it matters: it
+// is the value the /sso handler reports on in its "no verification key
+// configured" branch, and callers that legitimately want "the one key the hub
+// is minting with" should not be silently handed a list.
+//
+// BACKWARD COMPATIBILITY, WHICH IS THE POINT. HIVE_SSO_PUBLIC_KEY_PREV is
+// absent on all 65 spokes today and stays absent until an operator rotates. An
+// absent var yields a one-element result that is byte-identical to what
+// SpokeSSOPublicKey returns, so a spoke running this code with today's env
+// verifies exactly what it verifies now, in exactly one Ed25519 operation. The
+// legacy single-value configuration is not a special case here; it is the
+// zero-previous case of the general one.
+//
+// The master-derived fallback (self-hosted spokes holding HIVE_HUB_SECRET) is
+// inherited from SpokeSSOPublicKey and deliberately NOT extended to the
+// previous generation: a spoke cannot know the hub's generation set, and a
+// self-hosted operator rotating their own master is rotating the thing the
+// fallback derives from, so there is nothing to derive a previous key from.
+//
+// FAIL CLOSED. Empty and malformed entries are dropped by validation, not
+// passed through. A malformed _PREV must not be able to affect the primary key
+// — see verifySSOTokenAcrossKeys.
+func SpokeSSOPublicKeys() []string {
+	return appendDistinctPublicKey(
+		validPublicKeys(SpokeSSOPublicKey()),
+		strings.TrimSpace(os.Getenv(EnvSSOPublicKeyPrevious)),
+	)
+}
+
+// validPublicKeys filters a candidate list down to well-formed hex Ed25519
+// public keys.
+//
+// A key that is empty, not hex, or not exactly ed25519.PublicKeySize bytes is
+// DROPPED rather than passed to the verifier. Dropping matters more than it
+// looks: crypto/ed25519.Verify PANICS on a public key of the wrong length, so
+// handing an unvalidated string to a verify loop turns a malformed env var into
+// a crash of the spoke's dashboard rather than a failed verification. Node's
+// crypto.createPublicKey throws for the same input, which server.js already
+// catches — the two sides are made to agree here on the stricter behaviour.
+func validPublicKeys(keys ...string) []string {
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			continue
+		}
+		raw, err := hex.DecodeString(k)
+		if err != nil || len(raw) != ed25519.PublicKeySize {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
+}
+
+// appendDistinctPublicKey adds `candidate` to `keys` when it is well-formed and
+// not already present.
+//
+// The de-duplication is not tidiness. Before the first rotation, and again
+// briefly after a var is written but before the generation actually differs, the
+// previous key can equal the current one. Appending it anyway would double the
+// verification work on the hottest hosted path for no benefit, and would make
+// "how many keys is this spoke trying" a misleading number on the readiness
+// surface. The comparison is a plain string compare on PUBLIC, non-secret
+// values, so constant-time is not required here — and deliberately so: see
+// verifySSOTokenAcrossKeys for where constant-time DOES bind.
+func appendDistinctPublicKey(keys []string, candidate string) []string {
+	valid := validPublicKeys(candidate)
+	if len(valid) == 0 {
+		return keys
+	}
+	for _, existing := range keys {
+		if existing == valid[0] {
+			return keys
+		}
+	}
+	return append(keys, valid[0])
+}
+
+// VerifySSOTokenAcrossKeys is bounded trial verification of an SSO handoff token
+// against every public key a spoke holds, current-then-previous.
+//
+// WHY THE SPOKE TRIES BOTH RATHER THAN THE HUB PICKING ONE. The hub cannot pick.
+// It mints under the current generation and has no way to know, at mint time,
+// whether the spoke the user is being handed off to has been reconciled yet —
+// the reconcile lane walks the fleet over ~6h and the hub does not gate the SSO
+// button on convergence. Minting under the PREVIOUS generation instead would be
+// worse in both directions: it would break already-converged spokes, and it
+// would mean the rotation never converges, which is precisely how a compat lane
+// becomes permanent.
+//
+// TIMING / NON-DISCLOSURE. The loop does NOT return early. It evaluates every
+// candidate key and records the first index that verified, so the number of
+// Ed25519 operations performed is a function of how many keys the spoke holds
+// and never of WHICH key matched. Returning on first success would leak, through
+// response latency, whether this spoke has been reconciled onto the new
+// generation — a (small) oracle mapping the fleet's convergence state, offered
+// on an unauthenticated endpoint, during exactly the window an operator is
+// mid-rotation. This mirrors verifyHeartbeatBearerAcrossGenerations, which
+// declines the same early exit for the same reason and documents why the compare
+// must stay on its own line.
+//
+// The signature check itself is ed25519.Verify, which is constant-time in the
+// signature and safe on attacker-controlled input; nothing here compares
+// secret-derived material with ==, because nothing here is secret — these are
+// public keys. What is protected is the CONVERGENCE STATE, and it is protected
+// by uniform work rather than by comparison discipline.
+//
+// FAIL CLOSED, AND A MALFORMED SECOND KEY CANNOT DISABLE THE FIRST. `keys` is
+// expected to have come from SpokeSSOPublicKeys / validPublicKeys, which drop
+// malformed entries; this function additionally treats an individual failed
+// verification as just that — a failed candidate — rather than an error that
+// aborts the loop. So a garbage HIVE_SSO_PUBLIC_KEY_PREV costs one wasted
+// candidate and changes nothing about whether the primary key verifies. An
+// empty list verifies nothing at all.
+//
+// Returns (username, role, index of the accepting key, nil) on success.
+func VerifySSOTokenAcrossKeys(keys []string, token, expectedHiveID string, now time.Time) (username, role string, keyIndex int, err error) {
+	valid := validPublicKeys(keys...)
+	if len(valid) == 0 {
+		return "", "", -1, errSSONoVerificationKey
+	}
+	matchedIndex := -1
+	var matchedUser, matchedRole string
+	for i, k := range valid {
+		u, r, verr := VerifySSOToken(k, token, expectedHiveID, now)
+		// Recorded unconditionally, and the loop deliberately continues. See the
+		// TIMING note above: an early return here would make the spoke's
+		// convergence state observable as latency.
+		if verr == nil && matchedIndex == -1 {
+			matchedIndex, matchedUser, matchedRole = i, u, r
+		}
+	}
+	if matchedIndex == -1 {
+		return "", "", -1, errSSORejected
+	}
+	return matchedUser, matchedRole, matchedIndex, nil
+}

--- a/v2/pkg/hub/hub_pubkey_generations_test.go
+++ b/v2/pkg/hub/hub_pubkey_generations_test.go
@@ -1,0 +1,585 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for follow-on PR #6: SSO / session Ed25519 PUBLIC key plurality.
+//
+// WHAT MAKES THESE TESTS ABLE TO FAIL. The trap this repo has hit repeatedly is
+// a test that is green because the scenario it claims to exercise never
+// actually occurs. With ONE generation — the state of every hub today —
+// "current key only" and "current plus previous key" are indistinguishable,
+// because previousPublicKeys returns nothing and the plural verifier degenerates
+// to the singular one. So a test that merely calls the new code with a
+// production-shaped set proves nothing at all.
+//
+// Every test below therefore either (a) installs a genuinely ROTATED set whose
+// two generations derive DIFFERENT public keys and asserts on the difference, or
+// (b) carries an explicit POSITIVE CONTROL asserting the opposite outcome from
+// the same fixture, so that a change which makes verification accept everything
+// is caught alongside one that makes it accept nothing.
+
+const (
+	pubGenSecretA = "pubkey-generation-test-master-alpha"
+	pubGenSecretB = "pubkey-generation-test-master-bravo"
+)
+
+// rotatedPubKeySet builds a two-generation set: B current, A previous and live.
+func rotatedPubKeySet(t *testing.T, now time.Time) *generationSet {
+	t.Helper()
+	gs := legacyGenerationSet(pubGenSecretA).rotate(pubGenSecretB, now, defaultVerifyWindow)
+	if gs == nil {
+		t.Fatal("fixture: rotate returned nil")
+	}
+	if gs.currentSecret() != pubGenSecretB {
+		t.Fatalf("fixture: current secret = %q, want B", "<redacted>")
+	}
+	if len(gs.acceptableGenerations(now)) != 2 {
+		t.Fatalf("fixture: want 2 acceptable generations, got %d", len(gs.acceptableGenerations(now)))
+	}
+	return gs
+}
+
+// TestSSOAndSessionPublicKeysDifferPerGeneration is the FIXTURE VALIDITY check
+// every other test in this file depends on.
+//
+// If generation A and generation B happened to derive the same public key, every
+// "verifies under the previous generation" assertion below would pass without
+// the previous generation ever being consulted — the classic passes-for-the-
+// wrong-reason failure. Asserting the keys are distinct up front means a later
+// change that collapses them is reported HERE, as a fixture fault, rather than
+// silently hollowing out the rest of the file.
+func TestSSOAndSessionPublicKeysDifferPerGeneration(t *testing.T) {
+	now := time.Now()
+	gs := rotatedPubKeySet(t, now)
+	gens := gs.acceptableGenerations(now)
+
+	for _, tc := range []struct {
+		name string
+		info string
+	}{
+		{"sso", infoSSOEd25519Seed},
+		{"session", infoSessionEd25519Seed},
+	} {
+		cur := ssoPublicKeyFromSeed(deriveDomainKey(gens[0].Secret, tc.info))
+		prev := ssoPublicKeyFromSeed(deriveDomainKey(gens[1].Secret, tc.info))
+		if cur == "" || prev == "" {
+			t.Fatalf("%s: derived an empty public key (cur empty=%v prev empty=%v)", tc.name, cur == "", prev == "")
+		}
+		if cur == prev {
+			t.Fatalf("%s: current and previous generations derived the SAME public key; every dual-key test in this file would pass vacuously", tc.name)
+		}
+		if len(cur) != 64 {
+			t.Fatalf("%s: public key is %d hex chars, want 64", tc.name, len(cur))
+		}
+	}
+}
+
+// TestPreviousPublicKeysEmptyWithOneGeneration is the NO-OP proof.
+//
+// This is the single most important assertion in the PR: with one generation —
+// production, today, on every hub — there is no previous key, so no _PREV var is
+// emitted, so no spoke drifts, so no pod rolls. If this fails, merging this PR
+// rolls the fleet.
+func TestPreviousPublicKeysEmptyWithOneGeneration(t *testing.T) {
+	now := time.Now()
+	single := legacyGenerationSet(pubGenSecretA)
+	if single == nil {
+		t.Fatal("fixture: legacyGenerationSet returned nil")
+	}
+
+	for _, tc := range []struct {
+		name string
+		info string
+	}{
+		{"sso", infoSSOEd25519Seed},
+		{"session", infoSessionEd25519Seed},
+	} {
+		if got := previousPublicKeys(single, tc.info, now); len(got) != 0 {
+			t.Fatalf("%s: previousPublicKeys on a single-generation set returned %d keys, want 0", tc.name, len(got))
+		}
+	}
+
+	// POSITIVE CONTROL, in the other direction: the same function on a ROTATED
+	// set must return exactly one key. Without this, deleting the body of
+	// previousPublicKeys and returning nil unconditionally would leave the
+	// assertions above green while silently disabling the entire feature.
+	rotated := rotatedPubKeySet(t, now)
+	for _, tc := range []struct {
+		name string
+		info string
+	}{
+		{"sso", infoSSOEd25519Seed},
+		{"session", infoSessionEd25519Seed},
+	} {
+		got := previousPublicKeys(rotated, tc.info, now)
+		if len(got) != 1 {
+			t.Fatalf("%s: positive control: rotated set returned %d previous keys, want 1", tc.name, len(got))
+		}
+	}
+}
+
+// TestPreviousPublicKeysExcludesExpiredGeneration asserts the finiteness
+// promise: once VerifyUntil passes, the previous public key stops being offered
+// and therefore comes off the fleet.
+//
+// It also pins the ZERO-VerifyUntil rule, which is the property that stops a
+// hand-edited generations file pinning a retired key live forever.
+func TestPreviousPublicKeysExcludesExpiredGeneration(t *testing.T) {
+	now := time.Now()
+	gs := rotatedPubKeySet(t, now)
+
+	// Live: inside the window.
+	if got := previousPublicKeys(gs, infoSSOEd25519Seed, now); len(got) != 1 {
+		t.Fatalf("inside verify window: got %d previous keys, want 1", len(got))
+	}
+	// Expired: one second past the window.
+	after := now.Add(defaultVerifyWindow).Add(time.Second)
+	if got := previousPublicKeys(gs, infoSSOEd25519Seed, after); len(got) != 0 {
+		t.Fatalf("past verify window: got %d previous keys, want 0", len(got))
+	}
+
+	// VerifyUntil.IsZero() means ALREADY EXPIRED, not "never expires".
+	zeroed := &generationSet{
+		Current: gs.Current,
+		Generations: []keyGeneration{
+			gs.Generations[0],
+			{ID: gs.Generations[1].ID, Secret: gs.Generations[1].Secret}, // no VerifyUntil
+		},
+	}
+	if got := previousPublicKeys(zeroed, infoSSOEd25519Seed, now); len(got) != 0 {
+		t.Fatalf("zero VerifyUntil: got %d previous keys, want 0 (zero must mean already expired)", len(got))
+	}
+}
+
+// TestSSOTokenVerifiesUnderPreviousGeneration is the CORE fleet-safety property.
+//
+// A spoke that has not yet been reconciled holds the previous generation's
+// public key. It must still be able to verify a token the hub minted under that
+// generation, and it must NOT accept a token minted under a generation the hub
+// has retired.
+func TestSSOTokenVerifiesUnderPreviousGeneration(t *testing.T) {
+	now := time.Now()
+	gs := rotatedPubKeySet(t, now)
+	gens := gs.acceptableGenerations(now)
+	curPub := ssoPublicKeyForGeneration(gens[0])
+	prevPub := ssoPublicKeyForGeneration(gens[1])
+
+	const hiveID = "hive-alpha"
+	// A token minted by the hub under the CURRENT generation.
+	curTok := MintSSOToken(deriveDomainKey(gens[0].Secret, infoSSOEd25519Seed), "alice", "owner", hiveID, now)
+	// A token minted under the PREVIOUS generation — i.e. minted just before the
+	// rotation, still in flight.
+	prevTok := MintSSOToken(deriveDomainKey(gens[1].Secret, infoSSOEd25519Seed), "bob", "owner", hiveID, now)
+	if curTok == "" || prevTok == "" {
+		t.Fatal("fixture: MintSSOToken returned empty")
+	}
+
+	keys := []string{curPub, prevPub}
+
+	// Both tokens verify against the two-key spoke.
+	if u, _, idx, err := VerifySSOTokenAcrossKeys(keys, curTok, hiveID, now); err != nil || u != "alice" || idx != 0 {
+		t.Fatalf("current-generation token: user=%q idx=%d err=%v; want alice/0/nil", u, idx, err)
+	}
+	if u, _, idx, err := VerifySSOTokenAcrossKeys(keys, prevTok, hiveID, now); err != nil || u != "bob" || idx != 1 {
+		t.Fatalf("previous-generation token: user=%q idx=%d err=%v; want bob/1/nil", u, idx, err)
+	}
+
+	// POSITIVE CONTROL — the failing direction. A spoke holding ONLY the current
+	// key must REJECT the previous-generation token. Without this assertion the
+	// two above would pass even if VerifySSOTokenAcrossKeys ignored `keys`
+	// entirely and accepted any well-formed token.
+	if _, _, _, err := VerifySSOTokenAcrossKeys([]string{curPub}, prevTok, hiveID, now); err == nil {
+		t.Fatal("positive control: a spoke holding ONLY the current key accepted a previous-generation token")
+	}
+	// And the mirror: current key alone still accepts the current token, so the
+	// rejection above is about the KEY and not about the token being broken.
+	if u, _, _, err := VerifySSOTokenAcrossKeys([]string{curPub}, curTok, hiveID, now); err != nil || u != "alice" {
+		t.Fatalf("positive control mirror: current key rejected the current token: user=%q err=%v", u, err)
+	}
+}
+
+// TestSSOTokenFromRetiredGenerationIsRejected asserts that expiry actually
+// binds end to end: once the previous generation ages out, the reconcile lane
+// stops offering its key, and a token signed by it verifies nowhere.
+func TestSSOTokenFromRetiredGenerationIsRejected(t *testing.T) {
+	now := time.Now()
+	gs := rotatedPubKeySet(t, now)
+	gens := gs.acceptableGenerations(now)
+
+	const hiveID = "hive-alpha"
+	retiredTok := MintSSOToken(deriveDomainKey(gens[1].Secret, infoSSOEd25519Seed), "bob", "owner", hiveID, now)
+	if retiredTok == "" {
+		t.Fatal("fixture: MintSSOToken returned empty")
+	}
+
+	// Well inside the verify window the key IS offered, so the token verifies.
+	// This is the control that proves the rejection below is caused by RETIREMENT
+	// and not by the token being malformed or expired on its own TTL.
+	liveKeys := append(
+		[]string{ssoPublicKeyForGeneration(gens[0])},
+		previousPublicKeys(gs, infoSSOEd25519Seed, now)...,
+	)
+	if _, _, _, err := VerifySSOTokenAcrossKeys(liveKeys, retiredTok, hiveID, now); err != nil {
+		t.Fatalf("control: token should verify while its generation is live, got %v", err)
+	}
+
+	// After the window the previous key is no longer offered. The token is
+	// evaluated at the SAME clock as the control above (`now`), so its own
+	// 90-second TTL is not what rejects it — the missing key is.
+	after := now.Add(defaultVerifyWindow).Add(time.Second)
+	retiredKeys := append(
+		[]string{ssoPublicKeyForGeneration(gens[0])},
+		previousPublicKeys(gs, infoSSOEd25519Seed, after)...,
+	)
+	if len(retiredKeys) != 1 {
+		t.Fatalf("fixture: after retirement want 1 key, got %d", len(retiredKeys))
+	}
+	if _, _, _, err := VerifySSOTokenAcrossKeys(retiredKeys, retiredTok, hiveID, now); err == nil {
+		t.Fatal("a token signed by a RETIRED generation was accepted")
+	}
+}
+
+// TestMalformedSecondKeyDoesNotBreakTheFirst is the fail-closed invariant.
+//
+// A garbage HIVE_SSO_PUBLIC_KEY_PREV — truncated, non-hex, or a comma-joined
+// list someone tried as an env encoding — must cost one skipped candidate and
+// must NOT prevent the primary key from verifying.
+func TestMalformedSecondKeyDoesNotBreakTheFirst(t *testing.T) {
+	now := time.Now()
+	gs := rotatedPubKeySet(t, now)
+	gens := gs.acceptableGenerations(now)
+	curPub := ssoPublicKeyForGeneration(gens[0])
+	prevPub := ssoPublicKeyForGeneration(gens[1])
+
+	const hiveID = "hive-alpha"
+	curTok := MintSSOToken(deriveDomainKey(gens[0].Secret, infoSSOEd25519Seed), "alice", "owner", hiveID, now)
+	if curTok == "" {
+		t.Fatal("fixture: MintSSOToken returned empty")
+	}
+
+	malformed := []struct {
+		name string
+		key  string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+		{"not hex", strings.Repeat("z", 64)},
+		{"too short", curPub[:62]},
+		{"too long", curPub + "ab"},
+		// The delimited-list encoding this PR rejected. Go's hex.DecodeString
+		// errors on the comma while Node's Buffer.from silently truncates — the
+		// disagreement that ruled the encoding out. It must be DROPPED here, not
+		// half-accepted.
+		{"comma-joined pair", curPub + "," + prevPub},
+	}
+
+	for _, m := range malformed {
+		t.Run(m.name, func(t *testing.T) {
+			u, _, idx, err := VerifySSOTokenAcrossKeys([]string{curPub, m.key}, curTok, hiveID, now)
+			if err != nil || u != "alice" {
+				t.Fatalf("malformed second key %q broke verification of the first: user=%q err=%v", m.name, u, err)
+			}
+			if idx != 0 {
+				t.Fatalf("expected the PRIMARY key (index 0) to verify, got index %d", idx)
+			}
+			// The malformed entry must be DROPPED, not merely out-ranked. If it
+			// survived validation it would be handed to ed25519.Verify, which
+			// PANICS on a wrong-length public key.
+			if got := validPublicKeys(curPub, m.key); len(got) != 1 || got[0] != curPub {
+				t.Fatalf("validPublicKeys kept a malformed entry: got %d keys", len(got))
+			}
+		})
+	}
+
+	// POSITIVE CONTROL: an entirely malformed key set must verify NOTHING.
+	// Without this, validPublicKeys could return everything and these tests
+	// would still pass on the strength of the primary key alone.
+	if _, _, _, err := VerifySSOTokenAcrossKeys([]string{"zzzz", ""}, curTok, hiveID, now); err == nil {
+		t.Fatal("positive control: an all-malformed key set verified a token")
+	}
+}
+
+// TestSpokeSSOPublicKeysLegacySingleValueConfig asserts the backward-compatible
+// case that describes all 65 spokes today: HIVE_SSO_PUBLIC_KEY set,
+// HIVE_SSO_PUBLIC_KEY_PREV absent.
+func TestSpokeSSOPublicKeysLegacySingleValueConfig(t *testing.T) {
+	now := time.Now()
+	gs := rotatedPubKeySet(t, now)
+	gens := gs.acceptableGenerations(now)
+	curPub := ssoPublicKeyForGeneration(gens[0])
+	prevPub := ssoPublicKeyForGeneration(gens[1])
+
+	// Legacy: primary only, no _PREV. This is production today.
+	t.Setenv(EnvSSOPublicKey, curPub)
+	t.Setenv(EnvSSOPublicKeyPrevious, "")
+	got := SpokeSSOPublicKeys()
+	if len(got) != 1 || got[0] != curPub {
+		t.Fatalf("legacy single-value config: got %d keys, want exactly the primary", len(got))
+	}
+	// It must be byte-identical to what the singular accessor returns, so a
+	// spoke on today's env verifies exactly what it verifies now.
+	if single := SpokeSSOPublicKey(); single != got[0] {
+		t.Fatal("plural accessor disagreed with SpokeSSOPublicKey on the legacy config")
+	}
+
+	// Rotated: both vars set.
+	t.Setenv(EnvSSOPublicKeyPrevious, prevPub)
+	got = SpokeSSOPublicKeys()
+	if len(got) != 2 || got[0] != curPub || got[1] != prevPub {
+		t.Fatalf("rotated config: got %d keys, want [current, previous]", len(got))
+	}
+
+	// A _PREV equal to the primary is de-duplicated rather than doubling the
+	// verification work on the hottest hosted path.
+	t.Setenv(EnvSSOPublicKeyPrevious, curPub)
+	if got = SpokeSSOPublicKeys(); len(got) != 1 {
+		t.Fatalf("duplicate _PREV: got %d keys, want 1", len(got))
+	}
+
+	// A malformed _PREV degrades to the legacy single-key config rather than
+	// disabling SSO.
+	t.Setenv(EnvSSOPublicKeyPrevious, "not-a-key")
+	if got = SpokeSSOPublicKeys(); len(got) != 1 || got[0] != curPub {
+		t.Fatalf("malformed _PREV: got %d keys, want exactly the primary", len(got))
+	}
+}
+
+// TestDesiredPerHiveEnvPrevVarsFollowGenerations ties the verifier to the
+// ROLLOUT: the _PREV vars appear only after a rotation and disappear again once
+// the previous generation expires.
+//
+// The absent case is the one that decides whether merging this PR rolls the
+// fleet, so it is asserted first and asserted by NAME rather than by count.
+func TestDesiredPerHiveEnvPrevVarsFollowGenerations(t *testing.T) {
+	withTestMaster(t, pubGenSecretA)
+	const hiveID = "hive-alpha"
+
+	// ONE GENERATION — production today. Neither _PREV var may be present.
+	withProvisionGenerations(t, legacyGenerationSet(pubGenSecretA))
+	got := desiredPerHiveEnv(hiveID)
+	if got == nil {
+		t.Fatal("desiredPerHiveEnv returned nil on a single-generation set")
+	}
+	for _, name := range perHiveEnvOptionalNames() {
+		if v, ok := got[name]; ok {
+			t.Fatalf("single generation: %s present (value len %d); merging this PR would drift and roll every spoke", name, len(v))
+		}
+	}
+	// And with no _PREV wanted, a spoke that has neither var is CONVERGED —
+	// no patch, no pod roll. This is the assertion that says "no-op".
+	live := make([]deploymentEnvVar, 0, len(got))
+	for _, name := range perHiveEnvNames() {
+		live = append(live, deploymentEnvVar{Name: name, Value: got[name]})
+	}
+	if drift := perHiveEnvDrift(live, got); len(drift) != 0 {
+		t.Fatalf("single generation: a spoke with today's env shape drifted on %v", drift)
+	}
+
+	// ROTATED — both _PREV vars must appear, carrying the PREVIOUS generation's
+	// public keys.
+	now := time.Now()
+	rotated := rotatedPubKeySet(t, now)
+	withProvisionGenerations(t, rotated)
+	got = desiredPerHiveEnv(hiveID)
+	if got == nil {
+		t.Fatal("desiredPerHiveEnv returned nil on a rotated set")
+	}
+	gens := rotated.acceptableGenerations(now)
+	wantSSOPrev := ssoPublicKeyForGeneration(gens[1])
+	wantSessPrev := ssoPublicKeyFromSeed(deriveDomainKey(gens[1].Secret, infoSessionEd25519Seed))
+	if got[EnvSSOPublicKeyPrevious] != wantSSOPrev {
+		t.Fatalf("rotated: %s is not the previous generation's SSO public key", EnvSSOPublicKeyPrevious)
+	}
+	if got[envSessionPublicKeyPrevious] != wantSessPrev {
+		t.Fatalf("rotated: %s is not the previous generation's session public key", envSessionPublicKeyPrevious)
+	}
+	// The PRIMARY vars must still carry the CURRENT generation — a _PREV that
+	// overwrote the primary would break every already-converged spoke.
+	if got[EnvSSOPublicKey] != ssoPublicKeyForGeneration(gens[0]) {
+		t.Fatal("rotated: primary SSO public key is not the CURRENT generation's")
+	}
+	if got[EnvSSOPublicKey] == got[EnvSSOPublicKeyPrevious] {
+		t.Fatal("rotated: primary and previous SSO public keys are identical")
+	}
+
+	// A spoke still carrying only the five mandatory vars must now DRIFT on the
+	// missing _PREV — this is what makes the reconcile lane roll the fleet onto
+	// the new key set.
+	stale := make([]deploymentEnvVar, 0, len(perHiveEnvNames()))
+	for _, name := range perHiveEnvNames() {
+		stale = append(stale, deploymentEnvVar{Name: name, Value: got[name]})
+	}
+	drift := perHiveEnvDrift(stale, got)
+	if len(drift) != 2 {
+		t.Fatalf("rotated: a spoke missing both _PREV vars drifted on %v, want both", drift)
+	}
+}
+
+// TestPerHiveEnvDriftRemovesRetiredPrevVars asserts the RETIREMENT direction:
+// a spoke still carrying a _PREV var after the previous generation expired must
+// drift, and the patch must actually DROP the var rather than leave it.
+//
+// Without this the retired generation's public key would sit on all 65 spokes
+// forever — the "unversioned, permanent compat lane" the generations design
+// exists to prevent, reintroduced as a stale env var.
+func TestPerHiveEnvDriftRemovesRetiredPrevVars(t *testing.T) {
+	withTestMaster(t, pubGenSecretA)
+	withProvisionGenerations(t, legacyGenerationSet(pubGenSecretA))
+	const hiveID = "hive-alpha"
+
+	want := desiredPerHiveEnv(hiveID)
+	if want == nil {
+		t.Fatal("desiredPerHiveEnv returned nil")
+	}
+	if _, ok := want[EnvSSOPublicKeyPrevious]; ok {
+		t.Fatal("fixture: single-generation set unexpectedly wants a _PREV var")
+	}
+
+	// A spoke carrying a leftover _PREV from a rotation whose window has closed.
+	live := make([]deploymentEnvVar, 0, len(perHiveEnvNames())+1)
+	for _, name := range perHiveEnvNames() {
+		live = append(live, deploymentEnvVar{Name: name, Value: want[name]})
+	}
+	const stale = "aa" + "bb" + "cc" + "dd"
+	live = append(live, deploymentEnvVar{Name: EnvSSOPublicKeyPrevious, Value: stale})
+
+	drift := perHiveEnvDrift(live, want)
+	if len(drift) != 1 || drift[0] != EnvSSOPublicKeyPrevious {
+		t.Fatalf("a leftover retired _PREV did not drift: got %v", drift)
+	}
+
+	patch, err := perHiveEnvPatchJSON(live, want)
+	if err != nil {
+		t.Fatalf("perHiveEnvPatchJSON: %v", err)
+	}
+	if strings.Contains(patch, EnvSSOPublicKeyPrevious) {
+		t.Fatal("the patch retained the retired _PREV var instead of dropping it")
+	}
+	// POSITIVE CONTROL: the patch must still carry the mandatory vars. A patch
+	// that dropped EVERYTHING would also pass the assertion above.
+	for _, name := range perHiveEnvNames() {
+		if !strings.Contains(patch, name) {
+			t.Fatalf("the patch dropped mandatory var %s", name)
+		}
+	}
+}
+
+// TestPerHiveEnvPatchIsStableWhenConverged guards the pod-roll-forever hazard:
+// once a rotated spoke has both _PREV vars, the next sweep must see NO drift.
+//
+// perHiveEnvPatchJSON appends optional vars after the mandatory ones, so a
+// converged Deployment must produce a byte-identical array. If it did not, the
+// sweep would patch every hive every cycle and roll all 65 pods every 15
+// minutes indefinitely.
+func TestPerHiveEnvPatchIsStableWhenConverged(t *testing.T) {
+	withTestMaster(t, pubGenSecretA)
+	now := time.Now()
+	withProvisionGenerations(t, rotatedPubKeySet(t, now))
+	const hiveID = "hive-alpha"
+
+	want := desiredPerHiveEnv(hiveID)
+	if want == nil {
+		t.Fatal("desiredPerHiveEnv returned nil")
+	}
+	if len(want) != len(perHiveEnvNames())+len(perHiveEnvOptionalNames()) {
+		t.Fatalf("rotated: want %d vars, got %d", len(perHiveEnvNames())+len(perHiveEnvOptionalNames()), len(want))
+	}
+
+	// Start from a drifted spoke, apply the patch shape, then re-check drift.
+	live := []deploymentEnvVar{{Name: "HIVE_ID", Value: hiveID}}
+	patched := applyPerHiveEnvPatchShape(live, want)
+	if drift := perHiveEnvDrift(patched, want); len(drift) != 0 {
+		t.Fatalf("a freshly patched spoke still drifts on %v — the sweep would roll its pod every cycle", drift)
+	}
+	// An unrelated var must survive untouched.
+	if patched[0].Name != "HIVE_ID" || patched[0].Value != hiveID {
+		t.Fatal("the patch clobbered an unrelated env var")
+	}
+}
+
+// applyPerHiveEnvPatchShape mirrors perHiveEnvPatchJSON's merge, so the test
+// above exercises the real ordering rather than assuming one. It is written as
+// a separate helper rather than by unmarshalling the patch JSON so that a
+// failure points at the merge rule rather than at JSON plumbing.
+func applyPerHiveEnvPatchShape(live []deploymentEnvVar, want map[string]string) []deploymentEnvVar {
+	removable := map[string]bool{}
+	for _, name := range perHiveEnvOptionalNames() {
+		if _, wanted := want[name]; !wanted {
+			removable[name] = true
+		}
+	}
+	out := make([]deploymentEnvVar, 0, len(live)+len(want))
+	seen := map[string]bool{}
+	for _, e := range live {
+		if removable[e.Name] {
+			continue
+		}
+		if v, ok := want[e.Name]; ok {
+			e.Value = v
+			seen[e.Name] = true
+		}
+		out = append(out, e)
+	}
+	for _, name := range perHiveEnvNames() {
+		if !seen[name] {
+			out = append(out, deploymentEnvVar{Name: name, Value: want[name]})
+		}
+	}
+	for _, name := range perHiveEnvOptionalNames() {
+		if v, wanted := want[name]; wanted && !seen[name] {
+			out = append(out, deploymentEnvVar{Name: name, Value: v})
+		}
+	}
+	return out
+}
+
+// TestPrivateSeedsNeverLeaveTheHub is the non-negotiable invariant made
+// mechanical: nothing this PR adds to a spoke's env may be private material.
+//
+// The check is not "does the code look right" but "is the value the spoke gets
+// derivable into the seed". Every _PREV value must be a PUBLIC key: equal to
+// the public half of its generation's seed, and NOT equal to the seed itself.
+func TestPrivateSeedsNeverLeaveTheHub(t *testing.T) {
+	withTestMaster(t, pubGenSecretA)
+	now := time.Now()
+	gs := rotatedPubKeySet(t, now)
+	withProvisionGenerations(t, gs)
+
+	got := desiredPerHiveEnv("hive-alpha")
+	if got == nil {
+		t.Fatal("desiredPerHiveEnv returned nil")
+	}
+
+	gens := gs.acceptableGenerations(now)
+	var seeds []string
+	for _, g := range gens {
+		seeds = append(seeds,
+			deriveDomainKey(g.Secret, infoSSOEd25519Seed),
+			deriveDomainKey(g.Secret, infoSessionEd25519Seed),
+		)
+		// The masters themselves must never appear either.
+		seeds = append(seeds, g.Secret)
+	}
+
+	for name, value := range got {
+		for _, seed := range seeds {
+			if seed != "" && value == seed {
+				t.Fatalf("env var %s carries PRIVATE material (a signing seed or a master)", name)
+			}
+		}
+	}
+
+	// And specifically: each _PREV var IS the public half of its generation's
+	// seed. This is the assertion that would fail if someone "simplified" the
+	// derivation by dropping ssoPublicKeyFromSeed and shipping the seed.
+	if got[EnvSSOPublicKeyPrevious] != ssoPublicKeyFromSeed(deriveDomainKey(gens[1].Secret, infoSSOEd25519Seed)) {
+		t.Fatalf("%s is not the public half of the previous generation's SSO seed", EnvSSOPublicKeyPrevious)
+	}
+	if got[envSessionPublicKeyPrevious] != ssoPublicKeyFromSeed(deriveDomainKey(gens[1].Secret, infoSessionEd25519Seed)) {
+		t.Fatalf("%s is not the public half of the previous generation's session seed", envSessionPublicKeyPrevious)
+	}
+}

--- a/v2/pkg/hub/perhive_env_reconcile.go
+++ b/v2/pkg/hub/perhive_env_reconcile.go
@@ -178,11 +178,34 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 			return nil
 		}
 	}
+	// PREVIOUS-GENERATION PUBLIC KEYS (rotation follow-on #6).
+	//
+	// Added AFTER the empty-value guard above, deliberately, because these two
+	// are the only reconciled vars that are legitimately ABSENT. The five vars
+	// above must always be present and non-empty; these two exist only while a
+	// previous generation is live, so "" here means "omit", not "fail".
+	//
+	// Omitting rather than emitting "" is the same distinction the guard above
+	// makes for the mandatory vars, and it matters for the same reason: the
+	// spoke-side resolvers treat an empty var exactly like an absent one, so an
+	// empty _PREV would add a var to every Deployment in the fleet that says
+	// nothing, drift-checks as present, and rolls 65 pods to deliver it.
+	//
+	// TODAY BOTH ARE EMPTY. There is one generation, so previousPublicKeys
+	// returns nothing, so this block adds no keys and `want` is byte-identical
+	// to what it was before this change — no drift, no patch, no pod roll. See
+	// hub_pubkey_generations.go for why that no-op property is load-bearing.
+	if prev := provisionSSOPublicKeyPrevious(); prev != "" {
+		want[EnvSSOPublicKeyPrevious] = prev
+	}
+	if prev := provisionSessionPublicKeyPrevious(); prev != "" {
+		want[envSessionPublicKeyPrevious] = prev
+	}
 	return want
 }
 
-// perHiveEnvNames lists the five reconciled vars in a stable order, for
-// deterministic patches and log lines.
+// perHiveEnvNames lists the five ALWAYS-PRESENT reconciled vars in a stable
+// order, for deterministic patches and log lines.
 func perHiveEnvNames() []string {
 	return []string{
 		EnvHeartbeatKey,
@@ -190,6 +213,27 @@ func perHiveEnvNames() []string {
 		EnvSessionKey,
 		EnvSSOPublicKey,
 		envSessionPublicKey,
+	}
+}
+
+// perHiveEnvOptionalNames lists the reconciled vars that are legitimately
+// ABSENT when no previous master generation is live — which is the state of
+// every hub that has never been rotated, and of every hub again once a
+// rotation's verify window closes.
+//
+// They are kept OUT of perHiveEnvNames because that list encodes "must be
+// present and non-empty", and these two must not be. Separating them is what
+// lets perHiveEnvDrift express the third state these vars can be in, which the
+// mandatory five never are: PRESENT WHEN IT SHOULD BE ABSENT. That state is
+// reached the moment a previous generation expires, and if the sweep could not
+// see it the retired generation's public key would stay on all 65 spokes
+// forever — the exact "unversioned, permanent compat lane" failure the
+// generations design exists to prevent, reintroduced as a stale env var rather
+// than as an if-branch.
+func perHiveEnvOptionalNames() []string {
+	return []string{
+		EnvSSOPublicKeyPrevious,
+		envSessionPublicKeyPrevious,
 	}
 }
 
@@ -219,6 +263,32 @@ func perHiveEnvDrift(live []deploymentEnvVar, want map[string]string) []string {
 			drift = append(drift, name)
 		}
 	}
+	// The OPTIONAL previous-generation keys drift in BOTH directions, which the
+	// loop above cannot express because it assumes every name it checks belongs
+	// in `want`.
+	//
+	//   wanted, absent or wrong  -> drift (a rotation just happened)
+	//   not wanted, present      -> drift (the previous generation expired, and
+	//                               its public key must come OFF the spoke)
+	//   not wanted, absent       -> converged; this is every spoke today
+	//
+	// The second case is the one worth being explicit about. Without it, the
+	// var would be written once at rotation and never removed, so every spoke
+	// would accumulate the public key of a generation the hub has already
+	// stopped accepting. Nothing would break — a retired key simply never
+	// verifies anything the hub now mints — but "which keys is the fleet
+	// carrying" would stop having an answer that converges, and the finiteness
+	// the design promises would hold only on the hub and not on the fleet.
+	for _, name := range perHiveEnvOptionalNames() {
+		got, present := have[name]
+		wantVal, wanted := want[name]
+		switch {
+		case wanted && (!present || got != wantVal):
+			drift = append(drift, name)
+		case !wanted && present:
+			drift = append(drift, name)
+		}
+	}
 	return drift
 }
 
@@ -237,9 +307,27 @@ func perHiveEnvDrift(live []deploymentEnvVar, want map[string]string) []string {
 // perHiveEnvNames order, so a converged Deployment produces a byte-identical
 // array on the next sweep and perHiveEnvDrift stays empty — no patch loop.
 func perHiveEnvPatchJSON(live []deploymentEnvVar, want map[string]string) (string, error) {
+	// Vars this lane is allowed to REMOVE: only the optional previous-generation
+	// keys, and only when they are not wanted. Every other live var — including
+	// the mandatory five and every var this lane knows nothing about — is
+	// preserved untouched, which is the property that keeps a whole-array
+	// replace safe.
+	removable := make(map[string]bool, len(perHiveEnvOptionalNames()))
+	for _, name := range perHiveEnvOptionalNames() {
+		if _, wanted := want[name]; !wanted {
+			removable[name] = true
+		}
+	}
+
 	merged := make([]deploymentEnvVar, 0, len(live)+len(want))
 	seen := make(map[string]bool, len(want))
 	for _, e := range live {
+		if removable[e.Name] {
+			// Drop it: the generation it verified for has expired out of the
+			// hub's acceptable set, so leaving it would strand a retired public
+			// key on the spoke indefinitely.
+			continue
+		}
 		if v, ok := want[e.Name]; ok {
 			e.Value = v
 			seen[e.Name] = true
@@ -249,6 +337,15 @@ func perHiveEnvPatchJSON(live []deploymentEnvVar, want map[string]string) (strin
 	for _, name := range perHiveEnvNames() {
 		if !seen[name] {
 			merged = append(merged, deploymentEnvVar{Name: name, Value: want[name]})
+		}
+	}
+	// Optional vars are appended only when wanted, after the mandatory five, so
+	// a converged Deployment still produces a byte-identical array on the next
+	// sweep and the no-patch-loop property holds in both the rotated and the
+	// un-rotated state.
+	for _, name := range perHiveEnvOptionalNames() {
+		if v, wanted := want[name]; wanted && !seen[name] {
+			merged = append(merged, deploymentEnvVar{Name: name, Value: v})
 		}
 	}
 	patch := []map[string]any{{

--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js"
+    "test": "node server.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -75,11 +75,88 @@ function deriveSessionPublicKey() {
   }
 }
 const SESSION_PUBLIC_KEY = deriveSessionPublicKey();
+
+// ROTATION (v2/docs/design/master-key-rotation.md, follow-on #6): during a hub
+// master rotation this spoke may hold TWO session public keys.
+//
+// The hub mints session cookies under the CURRENT generation the instant an
+// operator rotates, but the reconcile lane walks the fleet at 3 patches per
+// 15-minute cycle — about six hours for 65 spokes. For those hours a spoke that
+// knows only one public key cannot verify any cookie the hub is now minting, so
+// every hosted terminal session on that spoke fails its cookie check. Holding
+// both keys and trying each is what removes that window.
+//
+// WHY A SECOND VAR RATHER THAN A DELIMITED LIST IN HIVE_SESSION_PUBLIC_KEY.
+// Because the same value is read by an independently written Go verifier
+// (hub.SpokeSSOPublicKey / VerifySSOToken), and the two languages do NOT agree
+// on what "<hex>,<hex>" means:
+//
+//   Node  Buffer.from(v,'hex')  -> 32 bytes; silently truncates at the comma.
+//   Go    hex.DecodeString(v)   -> error; the verifier fails closed.
+//
+// A list would therefore keep working here by accident and break SSO outright
+// on any spoke still running the older Go image — which is the whole fleet for
+// the first reconcile cycle. An extra var has a defined meaning to old readers:
+// they do not read it, so they cannot misread it.
+//
+// ABSENT TODAY AND ABSENT UNTIL SOMEONE ROTATES. HIVE_SESSION_PUBLIC_KEY_PREV
+// is set on no spoke in the fleet, so SESSION_PUBLIC_KEYS below is a
+// one-element array whose single element is SESSION_PUBLIC_KEY, and every
+// verification does exactly the one Ed25519 operation it does today. The
+// legacy single-value configuration is not a compatibility branch here; it is
+// the zero-previous case of the general one.
+const SESSION_PUBLIC_KEY_PREV = (process.env.HIVE_SESSION_PUBLIC_KEY_PREV || '').trim();
+
+// isValidEd25519PublicKeyHex rejects anything that is not exactly 32 bytes of
+// hex.
+//
+// The length check cannot be skipped and cannot be done with Buffer alone:
+// Buffer.from('zz','hex') returns an EMPTY buffer rather than throwing, and
+// Buffer.from('<64 hex>,<64 hex>','hex') returns the FIRST 32 bytes rather than
+// throwing — Node truncates silently at the first non-hex character. So a
+// malformed value reaches crypto.createPublicKey looking plausible. Testing the
+// string against a strict pattern first is what makes "malformed" mean
+// malformed here and in Go alike.
+function isValidEd25519PublicKeyHex(v) {
+  return typeof v === 'string' && /^[0-9a-fA-F]{64}$/.test(v);
+}
+
+// sessionPublicKeys resolves the ordered list of public keys to try, current
+// first. Malformed and duplicate entries are DROPPED rather than passed through.
+//
+// Dropping a malformed _PREV is the invariant that makes this safe to ship: a
+// bad second key must cost one skipped candidate and must never prevent the
+// FIRST key from being tried. Filtering here — rather than letting each verify
+// call throw and be swallowed — also keeps the candidate count, and therefore
+// the work done, a property of configuration rather than of the cookie.
+function sessionPublicKeys() {
+  const out = [];
+  for (const k of [SESSION_PUBLIC_KEY, SESSION_PUBLIC_KEY_PREV]) {
+    const v = (k || '').trim();
+    if (!isValidEd25519PublicKeyHex(v)) continue;
+    if (out.includes(v)) continue; // before the first rotation both can be equal
+    out.push(v);
+  }
+  return out;
+}
+const SESSION_PUBLIC_KEYS = sessionPublicKeys();
+
 // Boot-time "am I hub-hosted?" signal. Either the injected session key (modern)
 // or a master secret (legacy) proves hosted mode, where identity comes from the
 // hub cookie rather than a shared dashboard token.
 // N2: either key proves hosted mode. A freshly provisioned spoke may hold only
 // the public key once HIVE_SESSION_KEY is dropped after the rollout.
+//
+// ROTATION: this deliberately keys off SESSION_PUBLIC_KEY — the PRIMARY key —
+// exactly as before, NOT off SESSION_PUBLIC_KEYS. Two reasons, both about not
+// moving a boundary this PR has no business moving. First, a spoke is never
+// handed a _PREV without a primary, so the plural form could not make this true
+// where the singular is false; switching to it would be a change with no effect
+// that a later reader would have to re-derive. Second, and decisively, the
+// plural form applies validation the singular does not, so keying off it would
+// flip a spoke whose HIVE_SESSION_PUBLIC_KEY is malformed from hosted to
+// SELF-HOSTED — silently swapping the whole identity model from hub cookies to
+// a shared dashboard token. Hosted/self-hosted detection stays byte-identical.
 const IS_HOSTED = SESSION_KEY !== '' || SESSION_PUBLIC_KEY !== '';
 
 // Snapshot frame-ancestors allowlist (v2 #3032). Additive to the v4 C2/session
@@ -336,8 +413,8 @@ function parseCookies(header) {
 // Fails closed: an absent, expired, wrong-hive or badly-signed assertion with no
 // valid hub cookie yields null and the caller denies.
 function resolveTerminalIdentity(cookies) {
-  const hubUser = verifyHubUserCookieEither(
-    SESSION_PUBLIC_KEY, SESSION_KEY, cookies['hive_hub_user']);
+  const hubUser = verifyHubUserCookieAcrossKeys(
+    SESSION_PUBLIC_KEYS, SESSION_KEY, cookies['hive_hub_user']);
   if (hubUser) return hubUser;
 
   const claim = verifyTerminalAssertion(
@@ -608,6 +685,48 @@ function verifyHubUserCookieEither(pubHex, legacySecret, value) {
   if (v3) return v3;
   const v2 = verifyHubUserCookieV2(pubHex, value);
   if (v2) return v2;
+  return verifyHubUserCookie(legacySecret, value);
+}
+
+// verifyHubUserCookieAcrossKeys is BOUNDED TRIAL VERIFICATION of a session
+// cookie against every public key this spoke holds, current-then-previous.
+//
+// This adds a second KEY, not a second FORMAT and not a second LANE. Each
+// candidate runs the identical verifyHubUserCookieEither the single-key path
+// runs, so the v3/v2/legacy lane structure, the expiry enforcement and the
+// signature checks are unchanged. In particular the legacy symmetric HMAC lane
+// is passed `legacySecret` exactly once and is NOT multiplied across keys —
+// SESSION_KEY is symmetric material with no generation plurality here, and
+// giving it any would be re-opening a lane the hub side (F1) has deleted.
+//
+// BOUNDED BY CONFIGURATION, NOT BY INPUT. `pubKeys` comes from
+// sessionPublicKeys(), which is at most two entries because the hub holds at
+// most maxLiveGenerations == 2 live generations and provisions at most one
+// _PREV var. A cookie cannot lengthen this list, so it cannot be used as an
+// asymmetric-cost lever.
+//
+// A MALFORMED SECOND KEY CANNOT DISABLE THE FIRST. Malformed entries never
+// reach here — sessionPublicKeys() drops them — and a candidate that simply
+// fails to verify is treated as a failed candidate, never as an error that
+// aborts the loop. So a garbage HIVE_SESSION_PUBLIC_KEY_PREV costs nothing but
+// a skipped entry.
+//
+// An empty list verifies nothing through the Ed25519 lanes and falls through to
+// the legacy symmetric lane alone — which is the pre-existing behaviour for a
+// spoke with no public key at all, preserved rather than changed.
+function verifyHubUserCookieAcrossKeys(pubKeys, legacySecret, value) {
+  if (!value) return '';
+  const keys = Array.isArray(pubKeys) ? pubKeys : [];
+  for (const pubHex of keys) {
+    const v3 = verifyHubUserCookieV3(pubHex, value);
+    if (v3) return v3;
+    const v2 = verifyHubUserCookieV2(pubHex, value);
+    if (v2) return v2;
+  }
+  // Legacy symmetric lane, tried once and only once after every public key has
+  // been tried. Kept last so an Ed25519-signed cookie is never evaluated
+  // against symmetric material, and kept OUTSIDE the loop so the number of HMAC
+  // computations does not scale with the number of public keys.
   return verifyHubUserCookie(legacySecret, value);
 }
 

--- a/v2/proxy/session_pubkey_rotation.test.js
+++ b/v2/proxy/session_pubkey_rotation.test.js
@@ -1,0 +1,346 @@
+// Rotation follow-on #6: the proxy must accept TWO hub session public keys.
+//
+// Run: node session_pubkey_rotation.test.js
+//
+// WHY THIS MATTERS ON THE PROXY SPECIFICALLY. The hub mints `hive_hub_user`
+// under the CURRENT master generation the instant an operator rotates, but the
+// reconcile lane patches spokes at 3 per 15-minute cycle — about six hours for
+// 65 spokes. A proxy that knows only one public key cannot verify anything the
+// hub mints during those hours, so every hosted terminal session on a
+// not-yet-reconciled spoke fails its cookie check. Holding both keys removes
+// that window.
+//
+// ON THE `dave` PRECEDENT, WHICH THIS FILE DELIBERATELY DOES NOT FOLLOW.
+// terminal_cookie_verify.test.js notes that its `dave` fixture is "deliberately
+// NOT on the static allowlist", which means several of its assertions would hold
+// even if the code under test did nothing — they pass for a reason other than
+// the one they name. Every test below is therefore written so that it FAILS for
+// the specific reason it claims:
+//
+//   - The two generations' public keys are asserted DISTINCT before anything
+//     else runs, so "verified under the previous key" can never be satisfied by
+//     the current key.
+//   - Every acceptance assertion is paired with a REJECTION assertion from the
+//     same fixture, so a verifier that accepted everything is caught too.
+//   - The cookies are minted from real Ed25519 seeds derived exactly as the Go
+//     hub derives them, so a Node-only encoding agreement cannot hide.
+
+import crypto from 'crypto';
+import assert from 'assert';
+
+const INFO_SESSION_ED25519_SEED = 'hive-session-ed25519-v1';
+const MARKER_V2 = '.v2.';
+const MARKER_V3 = '.v3.';
+const CLOCK_SKEW_SECONDS = 30;
+
+// --- helpers mirroring the hub (Go) side -----------------------------------
+
+function seedFromMaster(master) {
+  return crypto.createHmac('sha256', master).update(INFO_SESSION_ED25519_SEED).digest('hex');
+}
+
+function privFromSeed(seedHex) {
+  const pkcs8 = Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'),
+    Buffer.from(seedHex, 'hex'),
+  ]);
+  return crypto.createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+}
+
+function pubHexFromSeed(seedHex) {
+  const spki = crypto.createPublicKey(privFromSeed(seedHex)).export({ format: 'der', type: 'spki' });
+  return Buffer.from(spki.subarray(spki.length - 32)).toString('hex');
+}
+
+// mintV2 / mintV3 mirror the hub's minters. HUB-ONLY: they need the private seed.
+function mintV2(seedHex, username) {
+  const sig = crypto.sign(null, Buffer.from(username), privFromSeed(seedHex));
+  return username + MARKER_V2 + sig.toString('base64url');
+}
+
+function mintV3(seedHex, username, iat, exp) {
+  const body = Buffer.from(
+    JSON.stringify({ u: username, iat, exp, sid: 'a'.repeat(64) }),
+  ).toString('base64url');
+  const sig = crypto.sign(null, Buffer.from(body), privFromSeed(seedHex));
+  return body + MARKER_V3 + sig.toString('base64url');
+}
+
+// --- code under test (copied from server.js, kept in lockstep) -------------
+
+function isValidEd25519PublicKeyHex(v) {
+  return typeof v === 'string' && /^[0-9a-fA-F]{64}$/.test(v);
+}
+
+function sessionPublicKeysFrom(primary, prev) {
+  const out = [];
+  for (const k of [primary, prev]) {
+    const v = (k || '').trim();
+    if (!isValidEd25519PublicKeyHex(v)) continue;
+    if (out.includes(v)) continue;
+    out.push(v);
+  }
+  return out;
+}
+
+function verifyHubUserCookie(secret, value) {
+  if (!secret || !value) return '';
+  const idx = value.lastIndexOf('.');
+  if (idx <= 0 || idx === value.length - 1) return '';
+  const username = value.slice(0, idx);
+  const sig = value.slice(idx + 1);
+  const expected = crypto.createHmac('sha256', secret).update(username).digest('base64url');
+  const suppliedBuf = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expected);
+  if (suppliedBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(suppliedBuf, expectedBuf)) {
+    return '';
+  }
+  return username;
+}
+
+function verifyHubUserCookieV2(pubHex, value) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(MARKER_V2);
+  if (idx <= 0) return '';
+  const username = value.slice(0, idx);
+  const sigB64 = value.slice(idx + MARKER_V2.length);
+  if (!username || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    return crypto.verify(null, Buffer.from(username), pub, Buffer.from(sigB64, 'base64url')) ? username : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function verifyHubUserCookieV3(pubHex, value, nowSeconds) {
+  if (!pubHex || !value) return '';
+  const idx = value.lastIndexOf(MARKER_V3);
+  if (idx <= 0) return '';
+  const body = value.slice(0, idx);
+  const sigB64 = value.slice(idx + MARKER_V3.length);
+  if (!body || !sigB64) return '';
+  try {
+    const raw = Buffer.from(pubHex, 'hex');
+    if (raw.length !== 32) return '';
+    const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+    const pub = crypto.createPublicKey({ key: spki, format: 'der', type: 'spki' });
+    if (!crypto.verify(null, Buffer.from(body), pub, Buffer.from(sigB64, 'base64url'))) return '';
+    const claims = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'));
+    if (!claims || typeof claims.u !== 'string' || !claims.u) return '';
+    if (typeof claims.sid !== 'string' || !claims.sid) return '';
+    if (typeof claims.iat !== 'number' || typeof claims.exp !== 'number') return '';
+    const now = Number.isFinite(nowSeconds) ? nowSeconds : Math.floor(Date.now() / 1000);
+    if (claims.iat > now + CLOCK_SKEW_SECONDS) return '';
+    if (claims.exp < now - CLOCK_SKEW_SECONDS) return '';
+    return claims.u;
+  } catch (_) {
+    return '';
+  }
+}
+
+function verifyHubUserCookieAcrossKeys(pubKeys, legacySecret, value) {
+  if (!value) return '';
+  const keys = Array.isArray(pubKeys) ? pubKeys : [];
+  for (const pubHex of keys) {
+    const v3 = verifyHubUserCookieV3(pubHex, value);
+    if (v3) return v3;
+    const v2 = verifyHubUserCookieV2(pubHex, value);
+    if (v2) return v2;
+  }
+  return verifyHubUserCookie(legacySecret, value);
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+const MASTER_CUR = 'pubkey-rotation-test-master-bravo';
+const MASTER_PREV = 'pubkey-rotation-test-master-alpha';
+
+const SEED_CUR = seedFromMaster(MASTER_CUR);
+const SEED_PREV = seedFromMaster(MASTER_PREV);
+const PUB_CUR = pubHexFromSeed(SEED_CUR);
+const PUB_PREV = pubHexFromSeed(SEED_PREV);
+
+// NOW is the REAL clock, not a frozen vector, because
+// verifyHubUserCookieAcrossKeys mirrors server.js's call shape exactly — it
+// passes no `nowSeconds` through to the v3 lane, so v3 enforces its signed
+// lifetime against Date.now(). Freezing the clock here would make every v3
+// cookie in this file expired-by-decades and each assertion would then pass or
+// fail for the wrong reason. The expiry cases in test 6 call
+// verifyHubUserCookieV3 directly, where an explicit clock IS accepted.
+const NOW = Math.floor(Date.now() / 1000);
+
+// FIXTURE VALIDITY. Every "verified under the previous key" assertion below is
+// meaningless if the two generations happen to derive the same public key, so
+// assert they differ before anything else runs. This is the guard the `dave`
+// precedent lacked.
+assert.notStrictEqual(PUB_CUR, PUB_PREV, 'fixture: both generations derived the SAME public key');
+assert.strictEqual(PUB_CUR.length, 64, 'fixture: current public key is not 32 bytes of hex');
+assert.strictEqual(PUB_PREV.length, 64, 'fixture: previous public key is not 32 bytes of hex');
+
+const COOKIE_CUR_V3 = mintV3(SEED_CUR, 'alice', NOW, NOW + 3600);
+const COOKIE_PREV_V3 = mintV3(SEED_PREV, 'bob', NOW, NOW + 3600);
+const COOKIE_CUR_V2 = mintV2(SEED_CUR, 'carol');
+const COOKIE_PREV_V2 = mintV2(SEED_PREV, 'erin');
+
+// --- tests ------------------------------------------------------------------
+
+// 1. TWO KEYS: a spoke mid-rotation holds both and must verify cookies minted
+//    under either generation.
+{
+  const keys = sessionPublicKeysFrom(PUB_CUR, PUB_PREV);
+  assert.strictEqual(keys.length, 2, 'two distinct keys should yield two candidates');
+
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_CUR_V3), 'alice',
+    'two keys: a v3 cookie minted under the CURRENT generation must verify');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_PREV_V3), 'bob',
+    'two keys: a v3 cookie minted under the PREVIOUS generation must verify');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_CUR_V2), 'carol',
+    'two keys: a v2 cookie under the CURRENT generation must verify');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_PREV_V2), 'erin',
+    'two keys: a v2 cookie under the PREVIOUS generation must verify');
+
+  // POSITIVE CONTROL — the failing direction, from the SAME fixture. A cookie
+  // signed by neither generation must be rejected, so the four assertions above
+  // cannot be satisfied by a verifier that accepts anything well-formed.
+  const strangerSeed = seedFromMaster('pubkey-rotation-test-master-stranger');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', mintV3(strangerSeed, 'mallory', NOW, NOW + 3600)), '',
+    'positive control: a cookie signed by an unknown key was ACCEPTED');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', mintV2(strangerSeed, 'mallory')), '',
+    'positive control: a v2 cookie signed by an unknown key was ACCEPTED');
+}
+
+// 2. ONE KEY (legacy): every spoke today. HIVE_SESSION_PUBLIC_KEY_PREV absent.
+//    Behaviour must be byte-identical to the single-key path.
+{
+  const keys = sessionPublicKeysFrom(PUB_CUR, undefined);
+  assert.strictEqual(keys.length, 1, 'legacy config must yield exactly one candidate');
+  assert.strictEqual(keys[0], PUB_CUR, 'legacy config must yield the PRIMARY key');
+
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_CUR_V3), 'alice',
+    'legacy config: a cookie under the current generation must still verify');
+
+  // THE ASSERTION THAT MAKES THIS TEST MEAN SOMETHING. A one-key spoke must
+  // REJECT the previous generation's cookie — that rejection is exactly the
+  // ~6h outage this PR removes, and if it did not hold here, test 1 would be
+  // proving nothing about key plurality.
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_PREV_V3), '',
+    'legacy config: a one-key spoke must NOT verify a previous-generation cookie');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_PREV_V2), '',
+    'legacy config: a one-key spoke must NOT verify a previous-generation v2 cookie');
+
+  // Empty-string and empty-array _PREV are the same as absent.
+  assert.strictEqual(sessionPublicKeysFrom(PUB_CUR, '').length, 1, 'empty _PREV must be treated as absent');
+  assert.strictEqual(sessionPublicKeysFrom(PUB_CUR, '   ').length, 1, 'whitespace _PREV must be treated as absent');
+}
+
+// 3. MALFORMED SECOND KEY must not disable verification of the first.
+{
+  const malformed = [
+    ['not hex', 'z'.repeat(64)],
+    ['too short', PUB_PREV.slice(0, 62)],
+    ['too long', PUB_PREV + 'ab'],
+    // The delimited-list encoding this PR rejected. Node's Buffer.from would
+    // silently truncate it to the first 32 bytes and "work"; the strict pattern
+    // check must DROP it, so that Node and Go agree that this is malformed.
+    ['comma-joined pair', PUB_CUR + ',' + PUB_PREV],
+    ['space-joined pair', PUB_CUR + ' ' + PUB_PREV],
+    ['garbage', 'not-a-key'],
+  ];
+
+  for (const [name, bad] of malformed) {
+    const keys = sessionPublicKeysFrom(PUB_CUR, bad);
+    assert.strictEqual(keys.length, 1, `malformed _PREV (${name}) must be dropped, leaving one key`);
+    assert.strictEqual(keys[0], PUB_CUR, `malformed _PREV (${name}) must not displace the primary`);
+    assert.strictEqual(
+      verifyHubUserCookieAcrossKeys(keys, '', COOKIE_CUR_V3), 'alice',
+      `malformed _PREV (${name}) broke verification of the PRIMARY key`);
+  }
+
+  // Node's silent hex truncation, demonstrated rather than asserted from
+  // memory. This is the measurement that ruled out the delimited-list env
+  // encoding: Node reads "<hex>,<hex>" as 32 valid bytes while Go's
+  // hex.DecodeString errors, so the two verifiers would disagree about whether
+  // hosted SSO still works on an un-rolled spoke.
+  assert.strictEqual(
+    Buffer.from(PUB_CUR + ',' + PUB_PREV, 'hex').length, 32,
+    'expected Node to silently truncate a comma-joined hex pair to 32 bytes');
+  assert.strictEqual(
+    Buffer.from(PUB_CUR + ',' + PUB_PREV, 'hex').toString('hex'), PUB_CUR,
+    'expected the silent truncation to yield exactly the FIRST key');
+}
+
+// 4. EMPTY: no public key at all. Ed25519 verification must fail closed, and the
+//    legacy symmetric lane must be reachable exactly as before.
+{
+  assert.strictEqual(sessionPublicKeysFrom('', '').length, 0, 'no keys configured must yield no candidates');
+  assert.strictEqual(sessionPublicKeysFrom(undefined, undefined).length, 0, 'undefined vars must yield no candidates');
+
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys([], '', COOKIE_CUR_V3), '',
+    'an empty key set must verify NOTHING through the Ed25519 lanes');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(undefined, '', COOKIE_CUR_V3), '',
+    'a non-array key set must fail closed rather than throw');
+
+  // The legacy symmetric lane is UNCHANGED by key plurality — it is tried once,
+  // after the public keys, and is not multiplied across generations.
+  const legacySecret = 'legacy-symmetric-session-key';
+  const legacyCookie = 'frank.' + crypto.createHmac('sha256', legacySecret).update('frank').digest('base64url');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys([], legacySecret, legacyCookie), 'frank',
+    'the legacy symmetric lane must still be reachable with no public keys');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(sessionPublicKeysFrom(PUB_CUR, PUB_PREV), legacySecret, legacyCookie), 'frank',
+    'the legacy symmetric lane must still be reachable after the public keys');
+  // POSITIVE CONTROL: the legacy lane must reject a wrong-secret cookie, so the
+  // two assertions above are not satisfied by a lane that accepts anything.
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys([], 'a-different-secret', legacyCookie), '',
+    'positive control: the legacy lane accepted a cookie signed with another secret');
+}
+
+// 5. DE-DUPLICATION: before the first rotation the hub may briefly hand out a
+//    _PREV equal to the primary. It must not double the verification work.
+{
+  const keys = sessionPublicKeysFrom(PUB_CUR, PUB_CUR);
+  assert.strictEqual(keys.length, 1, 'a _PREV identical to the primary must be de-duplicated');
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(keys, '', COOKIE_CUR_V3), 'alice',
+    'de-duplication must not break verification');
+}
+
+// 6. EXPIRY STILL BINDS across both keys. Key plurality must add a second KEY,
+//    never a second LANE, and must not weaken the v3 signed-lifetime check
+//    (audit F10) under either generation.
+{
+  const keys = sessionPublicKeysFrom(PUB_CUR, PUB_PREV);
+  const expiredCur = mintV3(SEED_CUR, 'alice', NOW - 7200, NOW - 3600);
+  const expiredPrev = mintV3(SEED_PREV, 'bob', NOW - 7200, NOW - 3600);
+  assert.strictEqual(
+    verifyHubUserCookieV3(PUB_CUR, expiredCur, NOW), '',
+    'an expired v3 cookie under the current generation must be rejected');
+  assert.strictEqual(
+    verifyHubUserCookieV3(PUB_PREV, expiredPrev, NOW), '',
+    'an expired v3 cookie under the previous generation must be rejected');
+  // Control: the same minter with a live window is accepted, so the rejections
+  // above are about EXPIRY and not about the minting helper being broken.
+  assert.strictEqual(
+    verifyHubUserCookieV3(PUB_PREV, mintV3(SEED_PREV, 'bob', NOW, NOW + 3600), NOW), 'bob',
+    'control: a live v3 cookie under the previous generation must verify');
+  void keys;
+}
+
+console.log('session_pubkey_rotation.test.js: all assertions passed');


### PR DESCRIPTION
Follow-on **PR #6** of `v2/docs/design/master-key-rotation.md`. Base `v4`.

## Why this one is a different shape from #1–#5

Every earlier follow-on made a **hub-side** verifier accept two generations. The hub holds the generation set, so "accept both" was a local change.

This one is not that. The SSO handoff token and the hub session cookie are **minted on the hub and verified on the spoke** — by Go in `pkg/dashboard/api.go` and, independently, by Node in `v2/proxy/server.js`. Those verifiers hold **one** public key, no master, and no generation concept.

So the failure mode is the mirror of the earlier ones. The instant a hub rotates it mints under generation N while ~65 spokes still hold N-1's public key, and **they cannot verify anything the hub now mints** — for the ~6h the rate-limited reconcile lane takes to walk the fleet, not for the 30 minutes an impersonation cookie lives.

The fix is **plurality on the spoke**: hold both live generations' public keys and try each. Public keys are in the design's "CANNOT carry a marker" bucket, so the mechanism is bounded trial verification, bounded by `maxLiveGenerations == 2`.

## The env contract, and why

**A second var** (`HIVE_SSO_PUBLIC_KEY_PREV`, `HIVE_SESSION_PUBLIC_KEY_PREV`) — **not** a delimited list in the existing var.

The list option was **measured, not assumed**:

| | `"<hex>,<hex>"` |
|---|---|
| Node `Buffer.from(v,'hex')` | **32 bytes** — silently truncates at the comma, yielding key #1. Works by accident. |
| Go `hex.DecodeString(v)` | **error** `invalid byte: U+002C ','` → `SpokeSSOPublicKey`/`VerifySSOToken` fail closed. **SSO dead on that spoke.** |

The two languages disagree about exactly *"does hosted SSO still work on an un-rolled spoke"*. A list would kill SSO on every spoke the reconcile lane had patched but that had not yet rolled the new image — the whole fleet for the first cycle. An extra var has a defined meaning to old readers: **they do not read it, so they cannot misread it.** It is also the only encoding whose key set can *shrink* cleanly at retirement.

Both directions of this are pinned by tests (`comma-joined pair` cases in Go and Node; the Node test *demonstrates* the truncation rather than asserting it from memory).

## Backward compatibility for single-value spokes

`_PREV` is absent on all 65 spokes and stays absent until someone rotates. Absent ⇒ a **one-element** key list byte-identical to what the singular accessor returns, so a spoke on today's env verifies exactly what it verifies now, in exactly one Ed25519 operation. The legacy config is not a compat branch — it is the zero-previous case of the general one.

## Verifier-before-rollout ordering

This PR ships the **verifier** plurality and the *provisioning* of the second var. It **cannot itself cause a rotation** — that is #4's admin endpoint, operator-triggered. So verifiers learn to accept two keys strictly before the hub can ever hand out a second one.

## No-op with one generation ✅

Every hub today has one generation ⇒ `previousPublicKeys` returns empty ⇒ `desiredPerHiveEnv` emits **no** `_PREV` var ⇒ `perHiveEnvDrift` sees no drift ⇒ **no spoke is patched and no pod rolls.** Asserted **by name, not by count**, and the neuter replay confirms the assertion fires.

## What rolls on the fleet

**Nothing on merge.** On a future rotation: the existing reconcile lane, unchanged cadence — 3 patches / 15 min, ~6h for 65 spokes, one pod roll each. Rate limit **not** raised.

`_PREV` is **self-clearing**: once `VerifyUntil` passes, `acceptableGenerations` drops the generation, the var stops being wanted, and `perHiveEnvDrift` now reports the reverse direction (*present when it should be absent*) so the patch **removes** it. Without that the retired key would sit on all 65 spokes forever — the unversioned permanent compat lane the design exists to prevent, reintroduced as a stale env var.

## Invariants

- **Private seeds never leave the hub** — asserted mechanically (`TestPrivateSeedsNeverLeaveTheHub` compares every emitted var against every generation's seeds *and* masters).
- **Malformed second key cannot disable the first** — dropped by strict validation in *both* languages. This also avoids `ed25519.Verify`'s **panic** on a wrong-length public key, which an unvalidated env var would otherwise turn into a spoke crash.
- **`VerifyUntil.IsZero()` == already expired.**
- **Not an F1 regression** — no symmetric fallback added. The legacy lane is tried once, *outside* the key loop, and is not multiplied across generations.
- **`IS_HOSTED` byte-identical** (zero diff lines), deliberately keyed off the *primary* key: keying it off the validated plural form would flip a spoke with a malformed key from hosted to **self-hosted**, silently swapping the identity model.
- **Timing** — the Go verify loop does not early-return, so work is a function of how many keys are held, never of *which* matched. Early exit would leak fleet convergence state as latency. Errors are deliberately coarse for the same reason.
- The **terminal key path** in `server.js` is untouched (PR #5's scope).

## Scope deliberately left out

The provisioning **YAML template** is not changed. Its var blocks are unconditional, so adding `_PREV` would either ship `value: ""` to all 65 spokes — the exact empty-var outcome `desiredPerHiveEnv`'s fail-safe prevents — or add conditional blocks to a whitespace-sensitive template for a case unreachable today. The reconcile lane covers it within one 15-min cycle instead; documented at the call site.

## Tests

**Go** (`v2/pkg/hub/hub_pubkey_generations_test.go`)
- `TestSSOAndSessionPublicKeysDifferPerGeneration` — fixture validity; without it every dual-key test could pass vacuously
- `TestPreviousPublicKeysEmptyWithOneGeneration` (+ rotated positive control)
- `TestPreviousPublicKeysExcludesExpiredGeneration`
- `TestSSOTokenVerifiesUnderPreviousGeneration` (+ both positive controls)
- `TestSSOTokenFromRetiredGenerationIsRejected`
- `TestMalformedSecondKeyDoesNotBreakTheFirst` (6 subtests + all-malformed control)
- `TestSpokeSSOPublicKeysLegacySingleValueConfig`
- `TestDesiredPerHiveEnvPrevVarsFollowGenerations`
- `TestPerHiveEnvDriftRemovesRetiredPrevVars`
- `TestPerHiveEnvPatchIsStableWhenConverged` — guards patch-every-cycle-forever
- `TestPrivateSeedsNeverLeaveTheHub`

**Node** (`v2/proxy/session_pubkey_rotation.test.js`, wired into `npm test`) — two keys, one key (legacy), malformed second key, empty, de-duplication, expiry-still-binds. Every acceptance assertion is paired with a rejection from the **same** fixture. The file explicitly does **not** imitate the `dave` pattern and says why.

## Regression replay — verbatim

**Node — verify loop tries only the first key:**
```
AssertionError [ERR_ASSERTION]: two keys: a v3 cookie minted under the PREVIOUS generation must verify
'' !== 'bob'
```

**Node — strict hex validation removed:**
```
AssertionError [ERR_ASSERTION]: malformed _PREV (not hex) must be dropped, leaving one key
2 !== 1
```

**Go — `VerifySSOTokenAcrossKeys` tries only the primary key:**
```
--- FAIL: TestSSOTokenVerifiesUnderPreviousGeneration (0.00s)
    hub_pubkey_generations_test.go:188: previous-generation token: user="" idx=-1 err=sso: handoff token rejected; want bob/1/nil
--- FAIL: TestSSOTokenFromRetiredGenerationIsRejected (0.00s)
    hub_pubkey_generations_test.go:227: control: token should verify while its generation is live, got sso: handoff token rejected
```

**Go — `_PREV` emitted unconditionally (empty on an un-rotated hub):**
```
--- FAIL: TestDesiredPerHiveEnvPrevVarsFollowGenerations (0.00s)
    hub_pubkey_generations_test.go:369: single generation: HIVE_SSO_PUBLIC_KEY_PREV present (value len 0); merging this PR would drift and roll every spoke
--- FAIL: TestPerHiveEnvDriftRemovesRetiredPrevVars (0.00s)
    hub_pubkey_generations_test.go:439: fixture: single-generation set unexpectedly wants a _PREV var
```

All neuters restored → green. **No replay passed while neutered.**

## Local verification

```
go build ./...                                    ok
go test ./pkg/hub/         ok  120.892s
go test ./pkg/dashboard/   ok   52.550s   (known flake TestF9_… did not trip)
cd v2/proxy && npm ci && npm test                 all suites pass
gofmt -l <touched files>                          clean
```