### PR TITLE
Revert #3774 — restore intentional cap_net_admin file capability on hive binary

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -153,20 +153,11 @@ jobs:
             docker rm -f -v "$name" >/dev/null 2>&1 || true
           }
           trap cleanup EXIT
-          # REGRESSION GUARD for #3760: the hive binary MUST exec under docker's
-          # DEFAULT capability set — i.e. WITHOUT --cap-add NET_ADMIN — because
-          # that is what every self-hosted / rootless spoke runs. A file
-          # capability on the binary (removed in the #3760 fix) made the kernel
-          # refuse execve with EPERM whenever NET_ADMIN was not in the bounding
-          # set, crash-looping the fleet. NET_ADMIN is now granted at runtime as
-          # an ambient cap by the entrypoint only where the platform allows it,
-          # and the proxy SO_MARK path degrades gracefully otherwise. So this
-          # must pass with NO added capabilities.
-          timeout --signal=TERM --kill-after=10s 60s \
-            docker run --rm --name "$name" --network none hive:test --version
-          # And it must ALSO exec on platforms that DO grant NET_ADMIN (managed
-          # OKE/OpenShift spokes), where the entrypoint raises the ambient cap.
-          name="${name}-netadmin"
+          # --cap-add NET_ADMIN mirrors the production contract: the pod spec
+          # grants it (SCC hive-netadmin) and the image binary carries
+          # cap_net_admin+ep file caps (SO_MARK egress attribution), so exec
+          # under docker's default cap set fails EPERM by design, not by bug.
+          # The old `--help || true` form could not fail and asserted nothing.
           timeout --signal=TERM --kill-after=10s 60s \
             docker run --rm --name "$name" --network none --cap-add NET_ADMIN hive:test --version
 

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -43,17 +43,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM node:26-slim
 
 # --- Layer 1: system packages (rarely changes) ---
-# setpriv (util-linux-extra on Debian) is used by the entrypoint to drop to the
-# non-root `dev` user WHILE raising CAP_NET_ADMIN into the ambient set on
-# platforms that grant it, so the proxy's SO_MARK egress exemption works without
-# a file capability on the binary (issue #3760). If the package is unavailable
-# the entrypoint falls back to gosu (no ambient cap, best-effort SO_MARK).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates bash curl bzip2 gosu iptables inotify-tools libevent-core-2.1-7 \
     gcc libc6-dev \
- && (apt-get install -y --no-install-recommends util-linux-extra || \
-     apt-get install -y --no-install-recommends util-linux || \
-     echo "WARN: setpriv unavailable — entrypoint will fall back to gosu (no ambient CAP_NET_ADMIN)") \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tmux-builder /usr/local/bin/tmux /usr/local/bin/tmux
@@ -310,33 +302,41 @@ RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bi
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
     /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-merge
 
-# SECURITY (audit F5-egress / refs #2674, #2678, #3574): the MITM proxy's own
-# upstream :443 dials must be exempted from the forced-egress iptables REDIRECT.
-# On OpenShift/OVN (no xt_owner) the only exemption is the SO_MARK packet mark,
-# and setsockopt(SO_MARK) needs CAP_NET_ADMIN in the hive process's EFFECTIVE
-# set. The hive process runs as non-root `dev` (the entrypoint drops from root
-# via gosu, which strips all capabilities).
+# SECURITY (audit F5-egress / refs #2674, #2678): give the hive binary
+# CAP_NET_ADMIN as a FILE capability so the MITM proxy's own upstream dials can
+# be exempted from the forced-egress iptables REDIRECT.
 #
-# We DO NOT set CAP_NET_ADMIN as a FILE capability on /usr/local/bin/hive.
-# Doing so (PR #3574) crash-looped every self-hosted spoke: the kernel refuses
-# to execve() a binary whose file capabilities it cannot fully grant, and
-# NET_ADMIN is NOT in the default container bounding set for docker/podman/
-# containerd. The result was a bare "Operation not permitted" (EPERM) at exec
-# for anyone who did not run with `--cap-add NET_ADMIN` / an SCC granting it —
-# i.e. the entire self-hosted / rootless population (issue #3760). Copying the
-# binary elsewhere "fixed" it only because `cp` drops the security.capability
-# xattr; it did not actually grant the cap.
+# WHY THIS IS NEEDED
+# The entrypoint installs `-p tcp --dport 443 -j REDIRECT` so every agent's
+# egress is forced through the proxy, then exempts the proxy's OWN traffic three
+# ways. On OKE the `-m owner --uid-owner` matches work. On OpenShift/OVN xt_owner
+# is ABSENT, so those rules silently fail to load (`|| true`) and the only
+# remaining exemption is the SO_MARK packet mark — but setsockopt(SO_MARK)
+# requires CAP_NET_ADMIN in the calling process's EFFECTIVE set. The entrypoint
+# runs as root only long enough to build the chain; the hive process itself is
+# dropped to `dev` via gosu, so without a file capability it loses NET_ADMIN and
+# the mark silently fails ("operation not permitted").
 #
-# Instead, NET_ADMIN is granted at RUNTIME as an AMBIENT capability by the
-# entrypoint (see v2/deploy/entrypoint.sh, at the gosu privilege-drop): the
-# entrypoint already runs as root and already needs NET_ADMIN to build the
-# iptables chain, so where the platform grants NET_ADMIN in the bounding set
-# (managed OKE/OpenShift spokes via SCC/PSA) it raises the cap into the ambient
-# set so it survives the drop to `dev`, and where it is absent (self-hosted /
-# rootless) it simply skips the raise. The Go proxy's SO_MARK path is already
-# best-effort (v2/pkg/proxy/github_proxy.go: setSockMark failure is logged once
-# and the dial proceeds unmarked), so a missing NET_ADMIN degrades gracefully
-# to the existing owner-UID exemption instead of failing to exec at all.
+# Observed live on vllm-d: with neither exemption active the proxy's own :443
+# dials hit the REDIRECT and looped back into itself, returning 502 for every
+# forge request and cutting a live tenant's agents off from their repository.
+#
+# WHY A FILE CAPABILITY IS SAFE HERE
+# File caps are recomputed AT EXEC from the binary being exec'd. Agents are
+# launched via su-exec into their OWN binaries (claude/goose/bob), which carry
+# no file capability, so NET_ADMIN does NOT propagate to any agent process.
+# Agent UIDs (2001+) also cannot exec su-exec itself — it is 4750
+# root:hive-launch and only `dev` is in that group (audit C6) — so there is no
+# path from an agent to a process holding this capability.
+#
+# +ep = permitted AND effective: the hive process needs the cap live at
+# setsockopt time, not merely inheritable.
+RUN apt-get update && apt-get install -y --no-install-recommends libcap2-bin \
+ && setcap cap_net_admin+ep /usr/local/bin/hive \
+ && [ "$(getcap /usr/local/bin/hive)" != "" ] \
+ && getcap /usr/local/bin/hive | grep -q "cap_net_admin" \
+ && apt-get purge -y libcap2-bin \
+ && rm -rf /var/lib/apt/lists/*
 
 # --- Nous framework (strategist experiment engine) ---
 RUN (apt-get update && apt-get install -y --no-install-recommends \

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -844,54 +844,9 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
 
   # Drop to non-root user for all runtime processes.
   # Claude Code refuses --dangerously-skip-permissions as root.
-  #
-  # CAP_NET_ADMIN (issue #3760): the Go hive process needs NET_ADMIN in its
-  # EFFECTIVE set so the MITM proxy can setsockopt(SO_MARK) its own upstream
-  # dials for the forced-egress exemption. Dropping via gosu strips all caps, so
-  # where the platform grants NET_ADMIN (managed OKE/OpenShift spokes via
-  # SCC/PSA — it is already in our bounding set because the iptables chain above
-  # succeeded) we drop with `setpriv`, which can raise NET_ADMIN into the
-  # inheritable + AMBIENT sets so it survives the UID transition. We deliberately
-  # do NOT put NET_ADMIN as a file capability on the binary: the kernel refuses
-  # to execve a binary carrying a file cap absent from the container bounding
-  # set, which crash-looped every self-hosted/rootless spoke (issue #3760).
-  #
-  # setpriv --init-groups replicates gosu's supplementary-group setup from
-  # /etc/group (preserving the `dev`-only `hive-launch` membership, audit C6).
-  # If setpriv is missing, NET_ADMIN is not in the bounding set, or setpriv
-  # fails, we fall back to gosu: hive still execs, and the proxy's SO_MARK path
-  # is best-effort (it logs once and dials unmarked), so egress still works via
-  # the owner-UID exemption on OKE.
-  # setpriv resolves `dev`'s UID and supplementary groups via --reuid/--init-groups;
-  # only the primary GID must be named explicitly.
-  DEV_GID="$(id -g dev 2>/dev/null || echo node)"
-  # NET_ADMIN is bit 12; the process bounding set is the CapBnd field in
-  # /proc/self/status (a hex bitmask). Only attempt the ambient-cap drop when
-  # NET_ADMIN is actually in the bounding set — otherwise setpriv would fail.
-  _capbnd="$(awk '/^CapBnd:/ {print $2}' /proc/self/status 2>/dev/null || echo 0)"
-  # Guard the arithmetic: only feed a pure-hex value into $(( )) so a malformed
-  # or missing CapBnd never aborts the entrypoint with a shell arithmetic error.
-  case "$_capbnd" in
-    ''|*[!0-9A-Fa-f]*) _capbnd=0 ;;
-  esac
-  _net_admin_in_bnd=false
-  if [ "$(( 0x${_capbnd} >> 12 & 1 ))" = "1" ]; then
-    _net_admin_in_bnd=true
-  fi
-  if [ "$_net_admin_in_bnd" = "true" ] && command -v setpriv >/dev/null 2>&1 \
-     && setpriv --reuid dev --regid "$DEV_GID" --init-groups \
-        --inh-caps +net_admin --ambient-caps +net_admin true 2>/dev/null; then
-    echo "[entrypoint] Dropping to dev user (setpriv, ambient CAP_NET_ADMIN)"
-    exec setpriv --reuid dev --regid "$DEV_GID" --init-groups \
-      --inh-caps +net_admin --ambient-caps +net_admin "$0" "$@"
-  fi
-  # Test gosu — on some NFS/container combos it fails with EPERM.
+  # Test gosu first — on some NFS/container combos it fails with EPERM.
   if command -v gosu >/dev/null 2>&1 && gosu dev true 2>/dev/null; then
-    if [ "$_net_admin_in_bnd" = "true" ]; then
-      echo "[entrypoint] Dropping to dev user (gosu; NET_ADMIN present but setpriv unavailable — proxy SO_MARK will be best-effort)"
-    else
-      echo "[entrypoint] Dropping to dev user (gosu; no NET_ADMIN in bounding set — proxy SO_MARK best-effort, owner-UID exemption applies)"
-    fi
+    echo "[entrypoint] Dropping to dev user"
     exec gosu dev "$0" "$@"
   else
     echo "[entrypoint] WARN: gosu unavailable or failed, continuing as root"

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -40,16 +40,7 @@ fail=0
 # checks run against CODE so that an explanatory comment mentioning e.g.
 # `chmod u+s` (describing the OLD insecure build) is not itself flagged — only a
 # real instruction would be. The positive checks run against the raw file.
-#
-# CODE is materialized to a temp file so every forbidden-pattern check greps a
-# FILE, never `printf | grep -q`. Under `set -o pipefail` a `grep -q` that
-# matches exits and closes the pipe before the writer finishes, giving the
-# writer EPIPE ("write error: Broken pipe") and making the pipeline exit
-# non-zero — which previously flipped a passing check to FAIL (issue #3760 fix).
 CODE="$(grep -vE '^[[:space:]]*#' "$DOCKERFILE")"
-CODE_TMP="$(mktemp)"
-trap 'rm -f "$CODE_TMP"' EXIT
-printf '%s\n' "$CODE" > "$CODE_TMP"
 
 check() {
   local desc="$1" pattern="$2"
@@ -63,7 +54,7 @@ check() {
 
 check_absent() {
   local desc="$1" pattern="$2"
-  if grep -qE "$pattern" "$CODE_TMP"; then
+  if printf '%s\n' "$CODE" | grep -qE "$pattern"; then
     echo "  FAIL: ${desc} (found forbidden pattern in a build instruction: ${pattern})"
     fail=1
   else
@@ -115,44 +106,32 @@ check "hive-launch launcher group is created" \
 check "dev is a member of hive-launch" \
   'useradd.*-G[[:space:]]+hive-launch'
 
-# ── File-capability contract (audit F5-egress, refs #2674/#2678, #3574, #3760) ─
+# ── File-capability contract (audit F5-egress, refs #2674/#2678) ──────────────
 #
-# The MITM proxy needs CAP_NET_ADMIN in the hive process's EFFECTIVE set so it
-# can stamp SO_MARK on its own upstream dials and be exempted from the forced-
-# egress iptables REDIRECT (on OpenShift, where xt_owner is absent, the packet
-# mark is the only exemption).
+# The hive binary carries cap_net_admin+ep so the MITM proxy can stamp SO_MARK
+# on its own upstream dials and be exempted from the forced-egress iptables
+# REDIRECT. Without it, on OpenShift (no xt_owner, so the owner-UID exemptions
+# silently fail to load) the proxy redirects its OWN traffic into itself and
+# every forge request 502s — observed live on vllm-d.
 #
-# It must NOT be granted as a FILE capability on the binary. A file capability
-# absent from the container bounding set makes the kernel refuse execve() with
-# EPERM, which crash-looped every self-hosted/rootless spoke (issue #3760).
-# Instead the entrypoint grants NET_ADMIN as an AMBIENT capability at the
-# non-root privilege drop (setpriv --ambient-caps), where the platform bounding
-# set allows it, and degrades gracefully (best-effort SO_MARK) where it does not.
-#
-# CONTRACT: NO binary in the image may carry a file capability. `setcap` must
-# not appear in a build instruction. CODE_TMP has comment lines stripped, so a
-# `setcap` mentioned in a comment is not flagged — only a real instruction.
-if grep -qE '(^|[^[:alnum:]_])setcap[[:space:]]' "$CODE_TMP"; then
-  echo "  FAIL: the Dockerfile runs setcap — no binary may carry a file capability (issue #3760: a file cap absent from the container bounding set makes execve fail with EPERM). Grant NET_ADMIN as an ambient cap in the entrypoint instead."
-  fail=1
-else
-  echo "  ok: no file capability is granted to any binary (setcap absent)"
-fi
+# The capability is SAFE only because it cannot reach an agent:
+#   - file caps are recomputed at exec, and agents exec their own binaries
+#   - agents cannot exec su-exec (4750 root:hive-launch, asserted above)
+# If either invariant breaks, this capability becomes an escalation path — hence
+# both are asserted in the same contract.
+check "hive binary carries cap_net_admin" \
+  'setcap[[:space:]]+cap_net_admin\+ep[[:space:]]+/usr/local/bin/hive'
+check "the capability is verified at build time" \
+  'getcap[[:space:]]+/usr/local/bin/hive'
 
-# The runtime ambient-capability grant must be present in the entrypoint so the
-# proxy egress exemption still works on platforms that grant NET_ADMIN. Grep the
-# entrypoint file directly (no pipe). The entrypoint builds the setpriv drop
-# across two physical lines and may use either `--ambient-caps +net_admin` or
-# `--ambient-caps=+net_admin`, so match `ambient-caps`, `net_admin`, and
-# `setpriv` independently rather than pinning one exact flag spelling.
-ENTRYPOINT_FILE="$(dirname "$0")/../deploy/entrypoint.sh"
-if [[ -f "$ENTRYPOINT_FILE" ]] \
-   && grep -qE -- 'ambient-caps[=[:space:]]+\+?net_admin' "$ENTRYPOINT_FILE" \
-   && grep -qE -- '(^|[^[:alnum:]_])setpriv([^[:alnum:]_]|$)' "$ENTRYPOINT_FILE"; then
-  echo "  ok: entrypoint grants CAP_NET_ADMIN as an ambient capability (setpriv --ambient-caps +net_admin)"
-else
-  echo "  FAIL: entrypoint does not grant CAP_NET_ADMIN via setpriv --ambient-caps +net_admin — the proxy SO_MARK egress exemption will never work"
+# No OTHER binary may be given a capability. Agents run their own binaries; a
+# capability on any of them would hand NET_ADMIN straight to an agent process.
+if printf '%s\n' "$CODE" | grep -oE 'setcap[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+' \
+   | grep -qvE 'setcap[[:space:]]+cap_net_admin\+ep[[:space:]]+/usr/local/bin/hive'; then
+  echo "  FAIL: a setcap targets something other than /usr/local/bin/hive"
   fail=1
+else
+  echo "  ok: no capability is granted to any binary except /usr/local/bin/hive"
 fi
 
 if [[ "$fail" -ne 0 ]]; then


### PR DESCRIPTION
Reverts #3774.

Per the maintainer's authoritative ruling on #3760, the `setcap cap_net_admin+ep /usr/local/bin/hive` file capability is **intentional and required**: the non-root hive process needs `CAP_NET_ADMIN` to `setsockopt(SO_MARK)` its own proxy upstream dials for the forced-proxy-egress security gate (on OpenShift, where `xt_owner` is absent, the packet mark is the only self-exemption). #3774 removed that file cap and substituted a runtime ambient-cap grant in the entrypoint, which weakens the egress gate on the managed fleet. This restores the file cap and the original contract-check / CI smoke exactly as they were before #3774.

The actual #3760 fix — self-hosted install docs stating the `NET_ADMIN` requirement, plus a cap-less entrypoint preflight that turns the bare `exec ... Operation not permitted` into an actionable message — is a **separate follow-up PR**. The issue stays open for that, so this revert intentionally does **not** `Fixes #3760`.

## What this restores
- `v2/Dockerfile`: `setcap cap_net_admin+ep /usr/local/bin/hive` (+ build-time `getcap` verification).
- `v2/deploy/entrypoint.sh`: removes the `setpriv --ambient-caps` grant #3774 added; back to the plain `gosu dev` drop.
- `v2/scripts/check-suid-contract.sh`: back to asserting the file cap is present (rather than forbidding `setcap`).
- `.github/workflows/v2-ci.yml`: smoke test back to `--cap-add NET_ADMIN`.

## Open question for the maintainer (not acted on in this revert)
I verified the currently published image directly (`ghcr.io/kubestellar/hive:v4-latest` @ `b688dca5`, commit `f4ba07a`) and found evidence that complicates the file-cap explanation:

- `getcap /usr/local/bin/hive` → empty; `getfattr -n security.capability /usr/local/bin/hive` → **"No such attribute"** — the shipped binary carries **no** `security.capability` xattr. (Tooling validated with a positive control: `setcap cap_net_admin+ep` on a copy reads back `cap_net_admin=ep`.)
- The binary is **ET_EXEC** (`e_type=0x0002`), not PIE.
- It **EPERMs under containerd/k3s** but **execs fine under docker/runc even with `--cap-drop ALL`**.

That combination is consistent with the reporter's overlayfs / BuildKit metacopy-layer hypothesis (the restriction tracks the file's position in the image rootfs, and a copy to any other path execs) and suggests `COPY --from=builder /hive` may be dropping the file-cap xattr from the shipped layer regardless of the `setcap`. Restoring the `setcap` is the correct **design intent**, but on its own it may not resolve the container-runtime EPERM. The follow-up should confirm the cap actually lands on the shipped binary (e.g. verify `getcap` on the final image in CI), and evaluate the overlayfs/metacopy angle.

Refs #3760