### PR TITLE
🔒 hub: per-hive terminal + invite keys, close N3 fallthrough (rotation PR #5)

### DIFF
--- a/v2/docs/design/master-key-rotation.md
+++ b/v2/docs/design/master-key-rotation.md
@@ -261,7 +261,7 @@ The other six domains are deliberately untouched. See below.
 | 2 | Heartbeat bearer bounded trial verification against both generations | M | No — hub-side verify only |
 | 3 | `desiredPerHiveEnv` derives from current generation; per-generation counts in `PerHiveEnvStatus` | S | No — read path until #4 |
 | 4 | Admin rotate endpoint + persistence of the generation file | S | No — arms the rest | ✅ landed
-| 5 | Terminal + invite key dual acceptance (spoke-side, symmetric) | M | **Yes** — rolls pods via reconcile |
+| 5 | ~~Terminal + invite key dual acceptance (spoke-side, symmetric)~~ → **per-hive terminal + invite keys; no dual acceptance (see as-built)** | M | **Yes** — rolls pods via reconcile |
 | 6 | SSO/session Ed25519 public key rotation, incl. `proxy/server.js` accepting two public keys | L | **Yes** — Node proxy contract |
 | 7 | Retire generation automatically past `verify_until`; alert if a generation is pinned open | S | No |
 
@@ -357,3 +357,92 @@ Worth keeping in view rather than fixing: the three spoke-side sites bypass
 correct today (a spoke has no hub PVC) but it means the two resolution orders
 are similar enough to be mistaken for each other and different in a way that
 is not stated at either site.
+
+## As-built notes for PR #5
+
+The design filed the terminal and invite keys under "CANNOT carry a marker →
+use bounded trial verification". Implementing it established that **the first
+half is right and the second half does not apply**, so PR #5 is smaller and
+differently shaped than this document anticipated. The row above should be read
+with this section.
+
+**A spoke has no generation set, and cannot be given one.** Trial verification
+means "derive from each live generation and compare". A spoke holds exactly ONE
+master (`HIVE_HUB_SECRET`) and ONE injected value per key; nothing in
+`saas_provision.go` puts generation material into a Deployment, and nothing
+should — shipping the generation set to 66 spokes would hand every tenant
+operator the previous master as well as the current one. So on the spoke there
+is nothing to trial against, and the machinery the row implies cannot be built
+there.
+
+**Nor is it needed, because these two keys are mint-and-verify on the SAME
+spoke.** The terminal assertion is minted by `dashboard/session.go` and verified
+by `proxy/server.js` in the same pod; the invite token is minted and verified by
+the same process. Both sides resolve the key from the same env at the same
+instant, so minter and verifier can never disagree about which generation is in
+force. Dual acceptance exists to bridge a gap between two parties that rotate at
+different times — for these keys there is no such gap. Contrast the heartbeat
+bearer (PR #2), where the spoke mints and the HUB verifies: there the two rotate
+hours apart and trial verification is exactly right.
+
+What rotation costs here is therefore bounded and self-healing: when the
+reconcile lane patches a spoke's `HIVE_TERMINAL_KEY`, in-flight terminal
+assertions become invalid and users re-acquire one at their next login — the
+assertion's TTL is 15 minutes. In-flight invite links break once; an invalid
+invite already degrades to "no attribution", never to an error.
+
+**What PR #5 actually had to fix.** Auditing the two resolvers for rotation
+readiness surfaced two live defects, both of which would have made a rotation
+incorrect rather than merely inconvenient:
+
+- `TerminalSigningKey()` still carried both FLEET-UNIFORM fallback lanes that
+  audit N3 was believed to have closed. N3 closed the gap in PROVISIONING (by
+  injecting a per-hive `HIVE_TERMINAL_KEY` so lane 1 wins) but left the lanes in
+  the resolver: `HIVE_SESSION_KEY` (measured live: 65/65 spokes, ONE distinct
+  value) and `deriveTerminalKeyFrom(master)` (the master is likewise fleet-
+  uniform, and that derivation takes no hive ID). Either one resolving means an
+  assertion minted on one tenant's spoke verifies on every other — the exact N3
+  forgery lane, one absent env var away from being live, which is precisely the
+  state a re-provision or manifest reapply produces (see
+  `perhive_env_reconcile.go`'s header on the fleet's out-of-band posture). Both
+  are deleted; the fallback now SELF-DERIVES the per-hive key from the master
+  plus `HIVE_ID`, mirroring `SpokeHeartbeatKey`'s lane 2 (audit F2) so no
+  re-provision is required for a spoke to become correct.
+- `inviteSigningSecret()` used the RAW MASTER as its HMAC key, and measured live
+  that was the lane in force on 65/65 spokes: `HIVE_INVITE_KEY` is emitted by
+  the provisioning template but was NOT carried by the reconcile sweep, so no
+  live spoke has ever received it. Every spoke signed invites with an identical
+  key, and the per-hive binding `provisionInviteKey` exists to provide was in
+  force nowhere. Now routed through `hub.SpokeInviteKey()`, which is per-hive in
+  both lanes.
+
+**The reconcile lane gained a sixth var.** `EnvInviteKey` was missing from
+`desiredPerHiveEnv`/`perHiveEnvNames`, which is why the fleet never got it and
+also means a rotation would never have converged the invite key. Adding it is
+what makes the invite key rotate at all.
+
+**Fleet effect when this merges.** One pod roll per spoke, rate-limited by the
+existing lane at 3 per 15-minute cycle (~6h for the fleet), caused by the newly
+reconciled `HIVE_INVITE_KEY`. `HIVE_TERMINAL_KEY` is already present and correct
+on 65/65 spokes, so the terminal key is NOT re-keyed by this PR — the resolver
+change only alters which key a spoke would compute if that var were ever absent.
+
+**`proxy/server.js`'s terminal lane IS in scope, and is changed here.** PR #6
+landed first and explicitly deferred it ("The terminal key path in server.js is
+untouched (PR #5's scope)"), which is correct: `TERMINAL_SIGNING_KEY` mirrors
+`hub.TerminalSigningKey` and the two must stay in lockstep, so deleting the
+fleet-uniform lanes on the Go side while leaving them in Node would leave the
+N3 forgery lane live in the verifier — the half that actually decides whether a
+shell opens. Both fallbacks are removed there too and replaced with the same
+per-hive self-derivation, using `HIVE_ID`, which the proxy already read.
+
+The two derivations are asserted equal byte-for-byte (`HMAC(master, info || 0x00
+|| hiveID)`; the 0x00 separator must match exactly, since hive IDs are
+attacker-influenced and plain concatenation would be ambiguous).
+
+Note this strengthens the wrong-hive tests in a way worth recording: with a
+per-hive key, an assertion minted for hive X and presented on hive Y now fails
+on the SIGNATURE rather than only on the payload's `h` claim. The tests that
+specifically exercise the `h`-claim check therefore pin the signing hive
+explicitly, so they keep testing the claim check rather than silently becoming
+duplicates of the signature test.

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -67,29 +67,38 @@ var (
 //
 // Resolution order, most to least identity-bound:
 //
-//  1. HIVE_INVITE_KEY — the hub-injected PER-HIVE key (hub.provisionInviteKey,
-//     HMAC(master, "hive-invite-v1" || 0x00 || hiveID)). Preferred, and the reason
-//     this var exists: it lets a hosted spoke sign invites without ever holding
-//     the master.
-//  2. HIVE_HUB_SECRET — the raw master, the historical lane. Kept for spokes on an
-//     older Deployment that predates HIVE_INVITE_KEY, and for self-hosted hives
-//     whose operator legitimately holds the master. Using the master AS the HMAC
-//     key is exactly what we are moving away from; this fallback is transitional
-//     and is removed once the fleet has re-provisioned.
-//  3. A lazily generated, persisted per-instance random secret beside the
-//     contributor store, when neither var is set.
+//  1. hub.SpokeInviteKey() — the PER-HIVE invite key, either hub-injected as
+//     HIVE_INVITE_KEY or self-derived from HIVE_HUB_SECRET + HIVE_ID as
+//     HMAC(master, "hive-invite-v1" || 0x00 || hiveID). Both lanes are per-hive,
+//     so an invite link minted on one tenant is meaningless on another.
+//  2. A lazily generated, persisted per-instance random secret beside the
+//     contributor store, when the hive cannot identify itself at all.
+//
+// !! The RAW MASTER lane is DELETED. !!
+//
+// It read HIVE_HUB_SECRET and used the master ITSELF as the HMAC key. Measured on
+// the live fleet, that was the lane actually in use on 65/65 spokes —
+// HIVE_INVITE_KEY is emitted by the provisioning template but is not carried by
+// the perhive_env_reconcile sweep, so no live spoke has ever been handed it.
+// Since the master is fleet-uniform (65/65 spokes, one distinct value), every
+// spoke signed invites with an identical key and the per-hive binding that
+// provisionInviteKey exists to provide was not in force anywhere.
+//
+// Self-deriving in lane 1 is what makes deleting the master lane safe WITHOUT
+// waiting for a re-provision: the per-hive invite key is a pure function of the
+// master and the HIVE_ID a spoke already holds, so every spoke computes the
+// correct value the moment it rolls this code — the same in-place cutover
+// SpokeHeartbeatKey's lane 2 uses for the bearer (audit F2).
 //
 // Either way the secret never leaves the server — the token the client sees is
 // opaque. NOTE: invite tokens are signed with this key, so a hive whose key
-// CHANGES invalidates in-flight invite links (see the PR body); a spoke that
-// gains HIVE_INVITE_KEY re-keys exactly once.
+// CHANGES invalidates in-flight invite links; this change re-keys each spoke
+// exactly once, and an invalid invite degrades to "no attribution" (a plain
+// self-registration), never to an error. That is why the invite key is safe to
+// cut over in place while the terminal key is not re-keyed here at all.
 func inviteSigningSecret() []byte {
 	inviteSecretOnce.Do(func() {
-		if v := strings.TrimSpace(os.Getenv(hub.EnvInviteKey)); v != "" {
-			inviteSecretCache = []byte(v)
-			return
-		}
-		if v := strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")); v != "" {
+		if v := strings.TrimSpace(hub.SpokeInviteKey()); v != "" {
 			inviteSecretCache = []byte(v)
 			return
 		}

--- a/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -228,8 +228,13 @@ func TestCovDF_GHUserAuthPoll_EmptyAuthTokenStillMintsSession(t *testing.T) {
 	s.authToken = ""
 	// Give the terminal-assertion mint a signing key and a hive identity so the
 	// C3 cookie is observable (it is a no-op without both).
+	//
+	// HIVE_ID is required as well as the master: TerminalSigningKey's fallback
+	// lane now SELF-DERIVES the PER-HIVE key (audit N3) rather than deriving a
+	// fleet-uniform one, so a master alone no longer resolves to any key.
 	deps.Config.HiveID = testHiveID
 	t.Setenv("HIVE_HUB_SECRET", testHubSecret)
+	t.Setenv("HIVE_ID", testHiveID)
 
 	doPost(s, "/api/gh-user-auth/start", nil)
 

--- a/v2/pkg/dashboard/invite_signing_key_test.go
+++ b/v2/pkg/dashboard/invite_signing_key_test.go
@@ -3,18 +3,26 @@ package dashboard
 import (
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hub"
 )
 
 // Invite tokens are HMAC-signed with inviteSigningSecret(). Historically that key
-// was the RAW master HIVE_HUB_SECRET, which made the invite lane the last
-// spoke-side consumer that actually needed the master to function. These tests
-// pin the new resolution order — HIVE_INVITE_KEY, then HIVE_HUB_SECRET, then a
-// persisted per-instance random file — and pin that the lanes are cryptographically
-// distinct, so a token signed under one does not verify under another.
+// was the RAW master HIVE_HUB_SECRET — used directly AS the HMAC key — which made
+// the invite lane the last spoke-side consumer that actually needed the master,
+// and which (because the master is fleet-uniform) meant every spoke signed
+// invites with an identical key.
+//
+// That lane is now DELETED. These tests pin the new resolution order —
+// HIVE_INVITE_KEY, then the SELF-DERIVED per-hive key from HIVE_HUB_SECRET +
+// HIVE_ID, then a persisted per-instance random file — and pin that the lanes are
+// cryptographically distinct, so a token signed under one does not verify under
+// another.
 
 const (
 	testInviteKey    = "per-hive-invite-key-aaaaaaaaaaaaaaaa"
 	testInviteMaster = "master-hub-secret-bbbbbbbbbbbbbbbb"
+	testInviteHiveID = "hive-under-test"
 )
 
 // inviteTestNow is a fixed instant well inside inviteTokenTTL, so expiry never
@@ -35,17 +43,51 @@ func TestInviteSigningSecretPrefersInviteKey(t *testing.T) {
 	}
 }
 
-// TestInviteSigningSecretFallsBackToMaster pins the transitional lane: a spoke on
-// an older Deployment that has no HIVE_INVITE_KEY must keep signing with the
-// master, so existing hives are not broken by this change.
-func TestInviteSigningSecretFallsBackToMaster(t *testing.T) {
+// TestInviteSigningSecretSelfDerivesPerHive pins the in-place cutover lane: a
+// spoke with no HIVE_INVITE_KEY but holding the master and its own HIVE_ID
+// derives the CORRECT per-hive invite key itself, with no hub action and no
+// re-provision. This is what makes deleting the raw-master lane safe.
+func TestInviteSigningSecretSelfDerivesPerHive(t *testing.T) {
 	t.Setenv("HIVE_INVITE_KEY", "")
 	t.Setenv("HIVE_HUB_SECRET", testInviteMaster)
+	t.Setenv("HIVE_ID", testInviteHiveID)
 	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
 	resetInviteSecretForTest(t)
 
-	if got := string(inviteSigningSecret()); got != testInviteMaster {
-		t.Fatalf("inviteSigningSecret() = %q, want the HIVE_HUB_SECRET fallback %q", got, testInviteMaster)
+	got := string(inviteSigningSecret())
+	want := hub.SpokeInviteKey()
+	if got != want {
+		t.Fatalf("inviteSigningSecret() = %q, want the self-derived per-hive key %q", got, want)
+	}
+	// The RAW MASTER must never be the signing key.
+	if got == testInviteMaster {
+		t.Fatal("REGRESSION: the raw master is being used directly as the invite HMAC key")
+	}
+	// Per-hive: a different HIVE_ID under the same master yields a different key.
+	t.Setenv("HIVE_ID", testInviteHiveID+"-other")
+	resetInviteSecretForTest(t)
+	if other := string(inviteSigningSecret()); other == got {
+		t.Fatal("invite key must differ per hive under the same master")
+	}
+}
+
+// TestInviteSigningSecretNoIdentityFallsToFile pins that a spoke holding the
+// master but UNABLE to identify itself does not fall back to any shared key: it
+// gets the per-instance generated secret instead. derivePerHiveKey returns "" for
+// an empty hive ID precisely so this case is detected rather than assumed away.
+func TestInviteSigningSecretNoIdentityFallsToFile(t *testing.T) {
+	t.Setenv("HIVE_INVITE_KEY", "")
+	t.Setenv("HIVE_HUB_SECRET", testInviteMaster)
+	t.Setenv("HIVE_ID", "")
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
+	resetInviteSecretForTest(t)
+
+	got := string(inviteSigningSecret())
+	if got == "" {
+		t.Fatal("expected a generated secret")
+	}
+	if got == testInviteMaster {
+		t.Fatal("REGRESSION: fell back to the raw fleet-uniform master with no hive identity")
 	}
 }
 
@@ -84,14 +126,16 @@ func TestInviteTokenRoundTripUnderEachLane(t *testing.T) {
 		name      string
 		inviteKey string
 		master    string
+		hiveID    string
 	}{
-		{name: "invite key lane", inviteKey: testInviteKey, master: ""},
-		{name: "master fallback lane", inviteKey: "", master: testInviteMaster},
-		{name: "generated file lane", inviteKey: "", master: ""},
+		{name: "invite key lane", inviteKey: testInviteKey, master: "", hiveID: ""},
+		{name: "self-derive per-hive lane", inviteKey: "", master: testInviteMaster, hiveID: testInviteHiveID},
+		{name: "generated file lane", inviteKey: "", master: "", hiveID: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("HIVE_INVITE_KEY", tc.inviteKey)
 			t.Setenv("HIVE_HUB_SECRET", tc.master)
+			t.Setenv("HIVE_ID", tc.hiveID)
 			t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
 			resetInviteSecretForTest(t)
 
@@ -112,9 +156,10 @@ func TestInviteTokenRoundTripUnderEachLane(t *testing.T) {
 func TestInviteTokenDoesNotVerifyAcrossKeys(t *testing.T) {
 	const inviter = "octocat"
 
-	// Sign under the master lane.
+	// Sign under the self-derived per-hive lane.
 	t.Setenv("HIVE_INVITE_KEY", "")
 	t.Setenv("HIVE_HUB_SECRET", testInviteMaster)
+	t.Setenv("HIVE_ID", testInviteHiveID)
 	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
 	resetInviteSecretForTest(t)
 	masterToken := mintInviteToken(inviter, inviteTestNow)

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -499,6 +499,50 @@ func SpokeHeartbeatKey() string {
 // `hive_hub_user` session/terminal cookie. It signs nothing on the spoke.
 func SpokeSessionKey() string { return spokeDomainKey(EnvSessionKey, infoSessionKey) }
 
+// SpokeInviteKey returns the PER-HIVE key a spoke both mints and verifies
+// contributor invite tokens with (dashboard.inviteSigningSecret).
+//
+// Resolution order mirrors TerminalSigningKey exactly, because the two keys have
+// exactly the same shape — symmetric, spoke-local, minted and verified by the
+// same process:
+//
+//  1. HIVE_INVITE_KEY — the hub-injected per-hive key (provisionInviteKey).
+//  2. Self-derived per-hive key from HIVE_HUB_SECRET + HIVE_ID.
+//
+// Returns "" when neither resolves, so the caller keeps its existing fail-closed
+// fallback (a persisted per-instance random secret) rather than signing with an
+// empty key.
+//
+// WHY THIS EXISTS. inviteSigningSecret's lane 2 used the RAW MASTER as the HMAC
+// key — not a key derived from it, the master itself. Measured on the live fleet
+// that is the lane in use on 65/65 spokes, because HIVE_INVITE_KEY is emitted by
+// the provisioning template but is NOT carried by the reconcile sweep, so no live
+// spoke has ever received it. Two consequences, both fixed by routing through
+// here:
+//
+//   - The master is fleet-uniform, so every spoke signed invites with the SAME
+//     key: an invite minted on one tenant verified on every other, defeating the
+//     per-hive binding provisionInviteKey was introduced to provide.
+//   - Using the master directly as an HMAC key gives the invite lane no domain
+//     separation at all — a signing oracle over attacker-influenced input keyed
+//     by the master that also protects heartbeats, sessions and SSO.
+//
+// ROTATION (master-key-rotation.md PR #5): as with the terminal key there is no
+// trial verification and none is possible — a spoke holds one master, never a
+// generation set. Rotation re-keys invites once; in-flight invite links become
+// invalid, which the invite flow already tolerates (verifyInviteToken returning
+// "" means "no attribution", never an error).
+func SpokeInviteKey() string {
+	if v := strings.TrimSpace(os.Getenv(EnvInviteKey)); v != "" {
+		return v
+	}
+	return derivePerHiveKey(
+		strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")),
+		infoInviteKey,
+		strings.TrimSpace(os.Getenv(EnvHiveID)),
+	)
+}
+
 // SpokeSSOPublicKey returns the Ed25519 PUBLIC key a spoke uses to VERIFY a
 // hub-minted SSO handoff token (C2 follow-up: SSO is asymmetric). It signs nothing
 // on the spoke and — unlike the old symmetric key — cannot be used to mint a token

--- a/v2/pkg/hub/hub_keys_test.go
+++ b/v2/pkg/hub/hub_keys_test.go
@@ -111,3 +111,74 @@ func TestSpokeKeyResolutionPrefersExplicitEnv(t *testing.T) {
 		t.Error("spoke bearer must never equal the raw master secret")
 	}
 }
+
+// SpokeInviteKey resolution: HIVE_INVITE_KEY, then the SELF-DERIVED per-hive key
+// from HIVE_HUB_SECRET + HIVE_ID. Both lanes are per-hive; the RAW MASTER is
+// never returned.
+//
+// The raw-master lane it replaces was not a theoretical concern: measured on the
+// live fleet, HIVE_INVITE_KEY is absent on 65/65 spokes (the provisioning
+// template emits it but the reconcile sweep did not carry it), so every spoke
+// was signing invites with the fleet-uniform master itself.
+func TestSpokeInviteKeyResolution(t *testing.T) {
+	const master = "fleet-uniform-master"
+
+	t.Setenv(EnvInviteKey, "")
+	t.Setenv("HIVE_HUB_SECRET", "")
+	t.Setenv(EnvHiveID, "")
+	if got := SpokeInviteKey(); got != "" {
+		t.Fatalf("no sources → empty (fail closed), got %q", got)
+	}
+
+	// Master but no identity: must NOT resolve to anything shared.
+	t.Setenv("HIVE_HUB_SECRET", master)
+	if got := SpokeInviteKey(); got != "" {
+		t.Fatalf("master without HIVE_ID must not resolve a key, got %q", got)
+	}
+
+	// Self-derive lane.
+	t.Setenv(EnvHiveID, "hive-a")
+	got := SpokeInviteKey()
+	if want := derivePerHiveKey(master, infoInviteKey, "hive-a"); got != want {
+		t.Fatalf("self-derive lane = %q, want per-hive %q", got, want)
+	}
+	if got == master {
+		t.Fatal("REGRESSION: the raw master must never be the invite key")
+	}
+
+	// Per-hive isolation: hive B under the SAME master gets a different key.
+	t.Setenv(EnvHiveID, "hive-b")
+	if other := SpokeInviteKey(); other == got {
+		t.Fatal("invite key must differ per hive — an invite must not travel between tenants")
+	}
+
+	// Injected key wins over the derivation.
+	t.Setenv(EnvInviteKey, "injected-invite-key")
+	if SpokeInviteKey() != "injected-invite-key" {
+		t.Fatal("injected HIVE_INVITE_KEY must win")
+	}
+}
+
+// The invite key must be domain-separated from every other spoke-side key
+// derived from the same master and hive ID. If it collided with the terminal or
+// heartbeat key, holding one would grant the other.
+func TestSpokeInviteKeyIsDomainSeparated(t *testing.T) {
+	const master = "master-under-test"
+	const hiveID = "hive-1"
+
+	invite := derivePerHiveKey(master, infoInviteKey, hiveID)
+	terminal := derivePerHiveKey(master, infoTerminalKey, hiveID)
+	heartbeat := derivePerHiveKey(master, infoHeartbeatKey, hiveID)
+
+	for name, v := range map[string]string{"invite": invite, "terminal": terminal, "heartbeat": heartbeat} {
+		if v == "" {
+			t.Fatalf("%s key derived empty", name)
+		}
+		if v == master {
+			t.Fatalf("%s key equals the raw master", name)
+		}
+	}
+	if invite == terminal || invite == heartbeat || terminal == heartbeat {
+		t.Fatal("per-hive sub-keys must be pairwise distinct under one master+hive")
+	}
+}

--- a/v2/pkg/hub/perhive_env_generation_test.go
+++ b/v2/pkg/hub/perhive_env_generation_test.go
@@ -64,6 +64,7 @@ func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
 	fromCurrent := map[string]string{
 		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretB, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretB, infoTerminalKey, hiveID),
+		EnvInviteKey:        derivePerHiveKey(perHiveGenSecretB, infoInviteKey, hiveID),
 		EnvSessionKey:       deriveDomainKey(perHiveGenSecretB, infoSessionKey),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSessionEd25519Seed)),
@@ -71,9 +72,26 @@ func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
 	fromPrevious := map[string]string{
 		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretA, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretA, infoTerminalKey, hiveID),
+		EnvInviteKey:        derivePerHiveKey(perHiveGenSecretA, infoInviteKey, hiveID),
 		EnvSessionKey:       deriveDomainKey(perHiveGenSecretA, infoSessionKey),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSessionEd25519Seed)),
+	}
+
+	// COUNT FLOOR. The loop below iterates perHiveEnvNames(), so a change that
+	// DROPS a var from that list would also drop it from every assertion and
+	// this test would pass while the var silently stopped being rotated. Pin the
+	// expected set explicitly against the fixture so narrowing the list is a
+	// failure rather than a no-op. (Observed: removing EnvInviteKey from the
+	// reconcile made this test pass until this guard was added.)
+	if len(fromCurrent) != len(perHiveEnvNames()) {
+		t.Fatalf("perHiveEnvNames() has %d vars but the fixture covers %d — a reconciled var is unasserted",
+			len(perHiveEnvNames()), len(fromCurrent))
+	}
+	for name := range fromCurrent {
+		if _, ok := got[name]; !ok {
+			t.Errorf("%s: absent from desiredPerHiveEnv — it would never converge after a rotation", name)
+		}
 	}
 
 	for _, name := range perHiveEnvNames() {
@@ -93,6 +111,9 @@ func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
 	}
 	if provisionTerminalKey(hiveID) != fromCurrent[EnvTerminalKey] {
 		t.Error("provisionTerminalKey did not follow the current generation")
+	}
+	if provisionInviteKey(hiveID) != fromCurrent[EnvInviteKey] {
+		t.Error("provisionInviteKey did not follow the current generation")
 	}
 	if provisionSessionPublicKey() != fromCurrent[envSessionPublicKey] {
 		t.Error("provisionSessionPublicKey did not follow the current generation")

--- a/v2/pkg/hub/perhive_env_reconcile.go
+++ b/v2/pkg/hub/perhive_env_reconcile.go
@@ -12,7 +12,7 @@ import (
 //
 // THE GAP THIS CLOSES. The C2/N1/N2/N3 work moved every spoke off the shared
 // master onto derived, per-hive sub-keys, and the provisioning template
-// (saas_provision.go) renders all five vars. But that template is `kubectl
+// (saas_provision.go) renders all six vars. But that template is `kubectl
 // apply`ed ONLY inside provisionHive — at provision/assign time. Hives
 // provisioned BEFORE those vars entered the template never received them, and
 // nothing re-asserts them afterwards.
@@ -107,13 +107,13 @@ const (
 // container env list. Only name/value matter here: a var sourced from a
 // secretKeyRef/fieldRef has no literal .value, and we deliberately treat that
 // as "not the value we expect" rather than trying to chase the reference —
-// none of the five vars is ever provisioned as a reference.
+// none of the six vars is ever provisioned as a reference.
 type deploymentEnvVar struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
-// desiredPerHiveEnv returns the five security env vars a spoke for hiveID must
+// desiredPerHiveEnv returns the six security env vars a spoke for hiveID must
 // carry, derived EXACTLY as the v4 provisioning template derives them
 // (saas_provision.go, the HeartbeatKey/SessionKey/SSOPublicKey/
 // SessionPublicKey/TerminalKey block). Provision-time and reconcile-time
@@ -161,8 +161,16 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 		return nil
 	}
 	want := map[string]string{
-		EnvHeartbeatKey:     provisionHeartbeatKey(hiveID),
-		EnvTerminalKey:      provisionTerminalKey(hiveID),
+		EnvHeartbeatKey: provisionHeartbeatKey(hiveID),
+		EnvTerminalKey:  provisionTerminalKey(hiveID),
+		// EnvInviteKey is reconciled for the same reason as EnvTerminalKey, and
+		// its absence here is why no live spoke has ever held it: the
+		// provisioning template emits HIVE_INVITE_KEY, but this sweep is what
+		// actually puts vars on the fleet, and it did not carry this one. So
+		// inviteSigningSecret fell through to the raw master on every spoke.
+		// Without it in this list a rotation would also never converge the
+		// invite key, leaving it derived from a generation the hub has retired.
+		EnvInviteKey:        provisionInviteKey(hiveID),
 		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: provisionSessionPublicKey(),
@@ -181,7 +189,7 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 	// PREVIOUS-GENERATION PUBLIC KEYS (rotation follow-on #6).
 	//
 	// Added AFTER the empty-value guard above, deliberately, because these two
-	// are the only reconciled vars that are legitimately ABSENT. The five vars
+	// are the only reconciled vars that are legitimately ABSENT. The six vars
 	// above must always be present and non-empty; these two exist only while a
 	// previous generation is live, so "" here means "omit", not "fail".
 	//
@@ -204,12 +212,13 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 	return want
 }
 
-// perHiveEnvNames lists the five ALWAYS-PRESENT reconciled vars in a stable
+// perHiveEnvNames lists the six ALWAYS-PRESENT reconciled vars in a stable
 // order, for deterministic patches and log lines.
 func perHiveEnvNames() []string {
 	return []string{
 		EnvHeartbeatKey,
 		EnvTerminalKey,
+		EnvInviteKey,
 		EnvSessionKey,
 		EnvSSOPublicKey,
 		envSessionPublicKey,
@@ -224,7 +233,7 @@ func perHiveEnvNames() []string {
 // They are kept OUT of perHiveEnvNames because that list encodes "must be
 // present and non-empty", and these two must not be. Separating them is what
 // lets perHiveEnvDrift express the third state these vars can be in, which the
-// mandatory five never are: PRESENT WHEN IT SHOULD BE ABSENT. That state is
+// mandatory six never are: PRESENT WHEN IT SHOULD BE ABSENT. That state is
 // reached the moment a previous generation expires, and if the sweep could not
 // see it the retired generation's public key would stay on all 65 spokes
 // forever — the exact "unversioned, permanent compat lane" failure the
@@ -309,7 +318,7 @@ func perHiveEnvDrift(live []deploymentEnvVar, want map[string]string) []string {
 func perHiveEnvPatchJSON(live []deploymentEnvVar, want map[string]string) (string, error) {
 	// Vars this lane is allowed to REMOVE: only the optional previous-generation
 	// keys, and only when they are not wanted. Every other live var — including
-	// the mandatory five and every var this lane knows nothing about — is
+	// the mandatory six and every var this lane knows nothing about — is
 	// preserved untouched, which is the property that keeps a whole-array
 	// replace safe.
 	removable := make(map[string]bool, len(perHiveEnvOptionalNames()))
@@ -339,7 +348,7 @@ func perHiveEnvPatchJSON(live []deploymentEnvVar, want map[string]string) (strin
 			merged = append(merged, deploymentEnvVar{Name: name, Value: want[name]})
 		}
 	}
-	// Optional vars are appended only when wanted, after the mandatory five, so
+	// Optional vars are appended only when wanted, after the mandatory six, so
 	// a converged Deployment still produces a byte-identical array on the next
 	// sweep and the no-patch-loop property holds in both the rotated and the
 	// un-rotated state.
@@ -411,7 +420,7 @@ func perHiveEnvPatchAllowed(patchedThisCycle int) bool {
 //
 // Only "provisioning" is excluded: the namespace and Deployment are still
 // being applied, so a read would fail anyway and the provisioning template
-// renders all five vars correctly at creation. This is a cheap-cycle
+// renders all six vars correctly at creation. This is a cheap-cycle
 // optimisation, not a safety gate — the sweep already handles a missing
 // Deployment safely (a failed `kubectl get` logs Debug and continues WITHOUT
 // recording an observation, so an unread hive can never count as converged).
@@ -423,7 +432,7 @@ func perHiveEnvSweepEligible(status string) bool {
 // was derived from, by re-deriving the per-hive heartbeat key under each
 // acceptable generation and comparing.
 //
-// WHY THE HEARTBEAT KEY IS THE PROBE. Of the five reconciled vars it is the one
+// WHY THE HEARTBEAT KEY IS THE PROBE. Of the six reconciled vars it is the one
 // that is BOTH per-hive and a direct HMAC of the master, so a match identifies
 // the generation AND the hive — two spokes on the same generation produce
 // different values, so a stale-hive-ID drift can never be misread as a
@@ -516,7 +525,7 @@ type PerHiveEnvStatus struct {
 	// unreachable cluster is not evidence of anything either way.
 	ObservedHives int `json:"observed_hives"`
 	// MissingPerHiveEnv is how many observed hives are missing (or carry a
-	// wrong value for) at least one of the five reconciled security vars.
+	// wrong value for) at least one of the six reconciled security vars.
 	// Convergence means this reaches zero and STAYS zero across a full sweep.
 	MissingPerHiveEnv int `json:"missing_per_hive_env"`
 	// MissingHives names those laggards so an operator can go look at them
@@ -586,7 +595,7 @@ type KeyGenerationStatus struct {
 	SafeToRetirePrevious bool `json:"safe_to_retire_previous"`
 }
 
-// PerHiveEnvSnapshot reports fleet convergence for the five per-hive security
+// PerHiveEnvSnapshot reports fleet convergence for the six per-hive security
 // env vars.
 //
 // WHY THIS IS NOT SOURCED FROM HEARTBEAT RECENCY. The sibling signal in this
@@ -712,7 +721,7 @@ func (s *HubServer) reconcilePerHiveEnvIfDue() {
 }
 
 // reconcilePerHiveEnv sweeps every hub-managed hosted hive, records its live
-// env posture, and patches in the five security vars where they are absent or
+// env posture, and patches in the six security vars where they are absent or
 // wrong — at most perHiveEnvMaxPatchesPerCycle per cycle.
 //
 // Idempotent: a converged hive produces no patch and therefore no rollout.

--- a/v2/pkg/hub/perhive_env_reconcile_test.go
+++ b/v2/pkg/hub/perhive_env_reconcile_test.go
@@ -65,6 +65,7 @@ func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSSOEd25519Seed)),
 		envSessionPublicKey: provisionSessionPublicKey(),
 		EnvTerminalKey:      provisionTerminalKey(hiveID),
+		EnvInviteKey:        provisionInviteKey(hiveID),
 	}
 	for name, v := range expect {
 		if v == "" {
@@ -78,7 +79,7 @@ func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
 		t.Errorf("desiredPerHiveEnv returned %d vars, want %d", len(want), len(expect))
 	}
 
-	// The two PER-HIVE keys must actually differ between hives — otherwise the
+	// The PER-HIVE keys must actually differ between hives — otherwise the
 	// reconcile would be re-installing the fleet-uniform sharing N1/N3 removed.
 	other := desiredPerHiveEnv("hive-bravo")
 	if other[EnvHeartbeatKey] == want[EnvHeartbeatKey] {
@@ -87,11 +88,14 @@ func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
 	if other[EnvTerminalKey] == want[EnvTerminalKey] {
 		t.Error("terminal key is identical across hives — not per-hive")
 	}
+	if other[EnvInviteKey] == want[EnvInviteKey] {
+		t.Error("invite key is identical across hives — not per-hive")
+	}
 }
 
 // TestPerHiveEnvDriftMissingAll covers the four spokes found running purely on
 // master fallbacks: a Deployment with the pre-cutover env shape and none of the
-// five reconciled vars. All five must be reported as drift.
+// six reconciled vars. All six must be reported as drift.
 func TestPerHiveEnvDriftMissingAll(t *testing.T) {
 	withTestMaster(t, perHiveEnvTestMaster)
 	want := desiredPerHiveEnv("hive-alpha")
@@ -106,8 +110,8 @@ func TestPerHiveEnvDriftMissingAll(t *testing.T) {
 	)
 
 	drift := perHiveEnvDrift(live, want)
-	if len(drift) != 5 {
-		t.Fatalf("drift = %v (%d), want all 5 vars reported missing", drift, len(drift))
+	if len(drift) != len(perHiveEnvNames()) {
+		t.Fatalf("drift = %v (%d), want all %d vars reported missing", drift, len(drift), len(perHiveEnvNames()))
 	}
 	for _, name := range perHiveEnvNames() {
 		found := false

--- a/v2/pkg/hub/terminal_assertion.go
+++ b/v2/pkg/hub/terminal_assertion.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -60,18 +59,18 @@ const (
 	// terminal key can only ever sign/verify terminal assertions.
 	infoTerminalKey = "hive-terminal-v1"
 
-	// EnvTerminalKey is the dedicated spoke-side env var a least-privilege
-	// provisioning path may inject (mirrors C2's EnvSessionKey / EnvHeartbeatKey).
-	// When unset, terminalSigningKey falls back to the session sub-key the spoke
-	// already holds, then to deriving from HIVE_HUB_SECRET — see terminalSigningKey.
+	// EnvTerminalKey is the dedicated spoke-side env var carrying the PER-HIVE
+	// terminal signing key (provisionTerminalKey). It is the preferred lane and,
+	// measured on the live fleet, the one every spoke actually uses. When unset,
+	// TerminalSigningKey SELF-DERIVES the same per-hive value from the master
+	// plus HIVE_ID — it never falls back to a fleet-uniform key. See
+	// TerminalSigningKey for why both former fallbacks were deleted (audit N3).
 	EnvTerminalKey = "HIVE_TERMINAL_KEY"
 
-	// envSessionKey / envHubSecret are the fallbacks terminalSigningKey resolves
-	// against. Named as string literals here (not imported from hub_keys.go, which
-	// lives only on the C2 branch) so this file compiles on its own base and after
-	// the C2 merge alike.
-	envSessionKey = "HIVE_SESSION_KEY"
-	envHubSecret  = "HIVE_HUB_SECRET"
+	// envHubSecret is the raw master, still present on every spoke today. It is
+	// read ONLY as the input to the per-hive self-derivation lane, never as a
+	// terminal key in its own right.
+	envHubSecret = "HIVE_HUB_SECRET"
 )
 
 // terminalSign returns the URL-safe base64 HMAC-SHA256 of body under key. This is
@@ -84,44 +83,88 @@ func terminalSign(key, body string) string {
 	return ssoB64.EncodeToString(mac.Sum(nil))
 }
 
-// deriveTerminalKeyFrom returns the domain-separated terminal sub-key of master,
-// as lowercase hex — HMAC-SHA256(master, infoTerminalKey). Same formula as C2's
-// deriveDomainKey, kept local (under a distinct name) so it neither depends on
-// nor collides with hub_keys.go's deriveDomainKey when both land. Returns "" for
-// an empty master so an unset secret can never derive a usable key (fail closed).
-func deriveTerminalKeyFrom(master string) string {
-	if master == "" {
-		return ""
-	}
-	mac := hmac.New(sha256.New, []byte(master))
-	mac.Write([]byte(infoTerminalKey))
-	return hex.EncodeToString(mac.Sum(nil))
-}
+// deriveTerminalKeyFrom is DELETED (audit N3).
+//
+// It returned HMAC-SHA256(master, infoTerminalKey) with NO hive ID. Because the
+// master is fleet-uniform — measured live: present on 65/65 spokes with exactly
+// ONE distinct value — that expression derived a single terminal key for the
+// entire fleet, so an assertion minted on any spoke verified on every other.
+// Domain separation does not help when the keying input is shared by every
+// tenant; only binding the hive ID does.
+//
+// The replacement is derivePerHiveKey(master, infoTerminalKey, hiveID), used
+// inline by TerminalSigningKey's self-derive lane. Nothing may reintroduce a
+// hiveID-less terminal derivation: a helper that exists is a helper that gets
+// called, which is how this lane survived the original N3 fix.
 
 // TerminalSigningKey resolves the symmetric key the spoke mints — and the proxy
-// verifies — terminal assertions with. Resolution order (most-to-least specific),
-// matching the spoke-side least-privilege story and surviving the C2 cutover:
+// verifies — terminal assertions with.
 //
-//  1. HIVE_TERMINAL_KEY — a dedicated derived sub-key, if a future provisioning
-//     path injects one (most privilege-minimal).
-//  2. HIVE_SESSION_KEY — the session sub-key a C2-provisioned spoke ALREADY holds
-//     (the spoke both mints and verifies terminal grants, so reusing the
-//     spoke-local session key is a legitimate symmetric use). This is the normal
-//     post-#2761 hosted path: the spoke no longer receives the master.
-//  3. deriveTerminalKeyFrom(HIVE_HUB_SECRET) — self-hosted / pre-#2761 hosted
-//     spokes still hold the master; derive the terminal sub-key from it.
+// Resolution order, most-to-least specific. EVERY lane is PER-HIVE:
 //
-// Returns "" only when none is configured, preserving fail-closed behavior (no
-// key → no assertion minted → proxy falls back to the #2756 static allowlist).
-// The Node proxy's terminalSigningKey() mirrors this order EXACTLY.
+//  1. HIVE_TERMINAL_KEY — the hub-injected per-hive sub-key
+//     (provisionTerminalKey: HMAC(master, infoTerminalKey || 0x00 || hiveID)).
+//     This is the normal hosted path; measured on the live fleet it is present
+//     and 65-distinct on every spoke.
+//  2. Self-derived per-hive key, from HIVE_HUB_SECRET + HIVE_ID. This mirrors
+//     SpokeHeartbeatKey's lane 2 (audit F2) and exists for the same reason: the
+//     per-hive key is a pure function of two things the spoke ALREADY HOLDS, so
+//     a spoke can become identity-bound with no hub action and no re-provision.
+//
+// !! AUDIT N3 MUST NOT REGRESS: there is deliberately NO lane that resolves to a
+// FLEET-UNIFORM value. !!
+//
+// Two such lanes used to sit here and both are DELETED by this change:
+//
+//   - HIVE_SESSION_KEY. Measured live: present on 65/65 spokes and byte-IDENTICAL
+//     across all of them. An assertion minted on spoke A verified on spoke B, so
+//     any tenant operator could forge a shell grant for an arbitrary user on an
+//     arbitrary hive. N3 closed this in PROVISIONING (by injecting
+//     HIVE_TERMINAL_KEY so lane 1 wins), but the lane itself was left in the
+//     resolver — so it was one absent env var away from being live again, which
+//     is exactly the state of a re-provisioned or manifest-reapplied spoke (see
+//     perhive_env_reconcile.go's header: the fleet's posture is held by an
+//     out-of-band patch no controller maintained).
+//   - deriveTerminalKeyFrom(HIVE_HUB_SECRET), i.e. deriveDomainKey with NO hiveID.
+//     The master is fleet-uniform (measured: 65/65 spokes, 1 distinct value), so
+//     this derived exactly ONE key for the entire fleet. It was the same forgery
+//     lane wearing domain separation: separating the DOMAIN does nothing when the
+//     input is shared by every tenant.
+//
+// Lane 2 replaces the second of those in place: same inputs, same no-hub-action
+// property, but binding the hive ID makes the result unforgeable across tenants.
+// derivePerHiveKey returns "" for an empty hive ID rather than silently falling
+// back to a shared key, so a spoke that cannot identify itself mints nothing.
+//
+// Returns "" when nothing resolves, preserving fail-closed behavior (no key → no
+// assertion minted → the proxy falls back to the #2756 static allowlist, which
+// is a degradation in convenience, not in safety).
+//
+// ROTATION (master-key-rotation.md, follow-on PR #5). There is deliberately NO
+// trial verification here, and none is possible: a spoke holds ONE master and
+// ONE injected key, never a generation set — the hub never provisions generation
+// material to a spoke. Terminal assertions are also minted AND verified on the
+// same spoke from this same resolver, so minter and verifier hold an identical
+// value at every instant and dual acceptance has nothing to reconcile. Rotation
+// converges here through the reconcile lane re-patching HIVE_TERMINAL_KEY, at
+// the cost of invalidating in-flight assertions — which self-heal within their
+// 15-minute TTL. See the design doc's PR #5 note for why that is the whole job.
+//
+// The Node proxy's TERMINAL_SIGNING_KEY mirrors this order EXACTLY
+// (v2/proxy/server.js) — the two MUST stay in lockstep, and PR #6 carries the
+// matching proxy change.
 func TerminalSigningKey() string {
 	if v := strings.TrimSpace(os.Getenv(EnvTerminalKey)); v != "" {
 		return v
 	}
-	if v := strings.TrimSpace(os.Getenv(envSessionKey)); v != "" {
-		return v
-	}
-	return deriveTerminalKeyFrom(strings.TrimSpace(os.Getenv(envHubSecret)))
+	// Lane 2: self-derive the PER-HIVE key from the master the spoke already
+	// holds plus its own identity. Never deriveTerminalKeyFrom(master) — that is
+	// fleet-uniform and is the N3 forgery lane.
+	return derivePerHiveKey(
+		strings.TrimSpace(os.Getenv(envHubSecret)),
+		infoTerminalKey,
+		strings.TrimSpace(os.Getenv(EnvHiveID)),
+	)
 }
 
 // MintTerminalAssertion creates a short-lived, HMAC-signed assertion binding

--- a/v2/pkg/hub/terminal_assertion_test.go
+++ b/v2/pkg/hub/terminal_assertion_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -129,52 +131,165 @@ func TestTerminalAssertionRejectsForeignVersion(t *testing.T) {
 	}
 }
 
-// The terminal signing key is a DEDICATED symmetric sub-key, distinct from the
-// master and from the SSO material.
-func TestDeriveTerminalKeyIsDomainSeparated(t *testing.T) {
+// The terminal signing key is a DEDICATED, PER-HIVE symmetric sub-key: distinct
+// from the master, from the SSO material, and — the N3 property — from every
+// other hive's terminal key.
+func TestDeriveTerminalKeyIsDomainSeparatedAndPerHive(t *testing.T) {
 	master := "master-secret"
-	got := deriveTerminalKeyFrom(master)
+	got := derivePerHiveKey(master, infoTerminalKey, "hive-1")
 	if got == "" {
 		t.Fatal("expected a derived key")
 	}
 	if got == master {
 		t.Fatal("derived key must not equal the master")
 	}
-	// Deterministic and equal to the documented formula: HMAC-SHA256(master, info) hex.
+	// Deterministic and equal to the documented formula:
+	// HMAC-SHA256(master, info || 0x00 || hiveID) hex.
 	mac := hmac.New(sha256.New, []byte(master))
 	mac.Write([]byte(infoTerminalKey))
+	mac.Write([]byte{0})
+	mac.Write([]byte("hive-1"))
 	if want := hex.EncodeToString(mac.Sum(nil)); got != want {
 		t.Fatalf("derived key = %q, want %q", got, want)
 	}
-	if deriveTerminalKeyFrom("") != "" {
+	// N3: a DIFFERENT hive under the SAME master must get a different key.
+	if other := derivePerHiveKey(master, infoTerminalKey, "hive-2"); other == got {
+		t.Fatal("terminal key must differ per hive — this is audit N3")
+	}
+	// Fail closed on either missing input.
+	if derivePerHiveKey("", infoTerminalKey, "hive-1") != "" {
 		t.Fatal("empty master must derive to empty (fail closed)")
+	}
+	if derivePerHiveKey(master, infoTerminalKey, "") != "" {
+		t.Fatal("empty hive ID must derive to empty (fail closed) — never a shared key")
 	}
 }
 
-// TerminalSigningKey resolution order: HIVE_TERMINAL_KEY > HIVE_SESSION_KEY >
-// derive(HIVE_HUB_SECRET). Ensures the spoke picks the least-privilege key
-// available and still works pre-#2761 (master only) and post-#2761 (session key).
+// TerminalSigningKey resolution order: HIVE_TERMINAL_KEY > self-derived per-hive
+// key from HIVE_HUB_SECRET + HIVE_ID. Every lane is per-hive; there is no lane
+// that yields a fleet-uniform value.
 func TestTerminalSigningKeyResolutionOrder(t *testing.T) {
 	t.Setenv(EnvTerminalKey, "")
-	t.Setenv(envSessionKey, "")
 	t.Setenv(envHubSecret, "")
+	t.Setenv(EnvHiveID, "")
 	if TerminalSigningKey() != "" {
 		t.Fatal("no key sources → empty (fail closed)")
 	}
 
+	// Master present but NO identity: must stay empty rather than fall back to
+	// any shared value.
 	t.Setenv(envHubSecret, "master")
-	if got, want := TerminalSigningKey(), deriveTerminalKeyFrom("master"); got != want {
-		t.Fatalf("hub-secret fallback: got %q want derived %q", got, want)
+	if got := TerminalSigningKey(); got != "" {
+		t.Fatalf("master without HIVE_ID must not resolve a key, got %q", got)
 	}
 
-	t.Setenv(envSessionKey, "session-subkey")
-	if TerminalSigningKey() != "session-subkey" {
-		t.Fatal("session key must win over hub-secret derivation")
+	t.Setenv(EnvHiveID, "hive-1")
+	if got, want := TerminalSigningKey(), derivePerHiveKey("master", infoTerminalKey, "hive-1"); got != want {
+		t.Fatalf("self-derive lane: got %q want per-hive %q", got, want)
 	}
 
 	t.Setenv(EnvTerminalKey, "dedicated-terminal-key")
 	if TerminalSigningKey() != "dedicated-terminal-key" {
 		t.Fatal("dedicated terminal key must win over all")
+	}
+}
+
+// !! AUDIT N3 REGRESSION GATE !!
+//
+// The terminal key must NEVER resolve to HIVE_SESSION_KEY. That var is
+// byte-identical across all 65 spokes (verified live), so any lane that returns
+// it re-creates a fleet-wide forgery lane: an assertion minted on one tenant's
+// spoke would verify on every other tenant's spoke.
+//
+// This asserts the invariant TWICE — behaviourally (the resolver ignores the var
+// entirely) and structurally (the source does not mention it) — because a
+// behavioural test alone passes if some future refactor reads the var under a
+// condition this test does not happen to hit.
+func TestN3_TerminalKeyNeverFallsThroughToSessionKey(t *testing.T) {
+	const fleetUniform = "fleet-uniform-session-key"
+
+	// Behavioural: HIVE_SESSION_KEY set and nothing else — must NOT be adopted.
+	t.Setenv(EnvTerminalKey, "")
+	t.Setenv(envHubSecret, "")
+	t.Setenv(EnvHiveID, "")
+	t.Setenv("HIVE_SESSION_KEY", fleetUniform)
+	if got := TerminalSigningKey(); got != "" {
+		t.Fatalf("N3 REGRESSION: HIVE_SESSION_KEY was adopted as the terminal key (got %q)", got)
+	}
+
+	// Behavioural: even alongside a valid self-derive, the session key must not win.
+	t.Setenv(envHubSecret, "master")
+	t.Setenv(EnvHiveID, "hive-1")
+	got := TerminalSigningKey()
+	if got == fleetUniform {
+		t.Fatal("N3 REGRESSION: HIVE_SESSION_KEY won over the per-hive derivation")
+	}
+	if want := derivePerHiveKey("master", infoTerminalKey, "hive-1"); got != want {
+		t.Fatalf("expected per-hive key %q, got %q", want, got)
+	}
+
+	// Structural: the resolver's source must not reference the session key at
+	// all. Positive control below proves this assertion can fail.
+	src, err := os.ReadFile("terminal_assertion.go")
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	fn := terminalSigningKeyFuncBody(t, string(src))
+	if strings.Contains(fn, "HIVE_SESSION_KEY") || strings.Contains(fn, "envSessionKey") {
+		t.Fatal("N3 REGRESSION: TerminalSigningKey's body references the fleet-uniform session key")
+	}
+	// Positive control: the extracted body is really the function we think it
+	// is, so the check above is not vacuously passing on an empty string.
+	if !strings.Contains(fn, "EnvTerminalKey") || !strings.Contains(fn, "derivePerHiveKey") {
+		t.Fatalf("positive control failed: extracted body is not TerminalSigningKey:\n%s", fn)
+	}
+}
+
+// terminalSigningKeyFuncBody extracts the source text of TerminalSigningKey so
+// the structural assertion above inspects the RESOLVER rather than the whole
+// file (whose comments legitimately discuss the deleted lane by name).
+func terminalSigningKeyFuncBody(t *testing.T, src string) string {
+	t.Helper()
+	const sig = "func TerminalSigningKey() string {"
+	i := strings.Index(src, sig)
+	if i < 0 {
+		t.Fatal("TerminalSigningKey not found in source")
+	}
+	rest := src[i:]
+	end := strings.Index(rest, "\n}")
+	if end < 0 {
+		t.Fatal("could not find end of TerminalSigningKey")
+	}
+	return rest[:end]
+}
+
+// N3 identity isolation (the F2-style property): a terminal assertion minted by
+// hive A must NOT verify on hive B, under any key-resolution lane. This is the
+// property that the fleet-uniform lanes destroyed.
+func TestN3_TerminalAssertionDoesNotCrossHives(t *testing.T) {
+	const master = "shared-fleet-master"
+	now := time.Now()
+
+	keyA := derivePerHiveKey(master, infoTerminalKey, "hive-a")
+	keyB := derivePerHiveKey(master, infoTerminalKey, "hive-b")
+	if keyA == "" || keyB == "" {
+		t.Fatal("expected derived keys")
+	}
+	if keyA == keyB {
+		t.Fatal("N3: two hives under one master must not share a terminal key")
+	}
+
+	tok := MintTerminalAssertion(keyA, "alice", "admin", "hive-a", now)
+	if tok == "" {
+		t.Fatal("expected a minted assertion")
+	}
+	// Positive control: it DOES verify on its own hive with its own key.
+	if _, _, err := VerifyTerminalAssertion(keyA, tok, "hive-a", now); err != nil {
+		t.Fatalf("positive control failed: assertion must verify on its own hive: %v", err)
+	}
+	// The property: hive B's key rejects it.
+	if _, _, err := VerifyTerminalAssertion(keyB, tok, "hive-b", now); err == nil {
+		t.Fatal("N3 REGRESSION: hive A's assertion verified under hive B's key")
 	}
 }
 

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -293,27 +293,51 @@ const TERMINAL_ASSERTION_VERSION = 'hive-terminal-v1';
 // convention (HMAC-SHA256(master, info) as lowercase hex).
 const INFO_TERMINAL_KEY = 'hive-terminal-v1';
 
-// deriveTerminalKeyFrom mirrors the Go deriveTerminalKeyFrom: the hex
-// HMAC-SHA256(master, INFO_TERMINAL_KEY), or '' for an empty master.
-function deriveTerminalKeyFrom(master) {
-  if (!master) return '';
-  return crypto.createHmac('sha256', master).update(INFO_TERMINAL_KEY).digest('hex');
+// derivePerHiveTerminalKey mirrors the Go derivePerHiveKey(master,
+// INFO_TERMINAL_KEY, hiveID): hex HMAC-SHA256 over info || 0x00 || hiveID.
+//
+// The 0x00 separator is load-bearing and must match Go byte for byte. Plain
+// concatenation would be ambiguous — ("hive-terminal-v1", "a|b") and
+// ("hive-terminal-v1|a", "b") would hash identically — and hive IDs are
+// attacker-influenced.
+//
+// Returns '' when EITHER input is missing, so a spoke that cannot identify
+// itself derives nothing rather than silently sharing a key.
+function derivePerHiveTerminalKey(master, hiveID) {
+  if (!master || !hiveID) return '';
+  return crypto
+    .createHmac('sha256', master)
+    .update(INFO_TERMINAL_KEY)
+    .update(Buffer.from([0]))
+    .update(hiveID)
+    .digest('hex');
 }
 
 // TERMINAL_SIGNING_KEY resolves the symmetric key the proxy verifies terminal
-// assertions with, mirroring Go hub.TerminalSigningKey's order EXACTLY:
-//   1. HIVE_TERMINAL_KEY   — a dedicated derived sub-key, if provisioned.
-//   2. HIVE_SESSION_KEY    — the session sub-key a C2-provisioned spoke already
-//                            holds (normal post-#2761 hosted path; the spoke no
-//                            longer receives the master).
-//   3. derive from HIVE_HUB_SECRET — self-hosted / pre-#2761 hosted spokes that
-//                            still hold the master.
+// assertions with, mirroring Go hub.TerminalSigningKey's order EXACTLY.
+// EVERY lane is PER-HIVE:
+//   1. HIVE_TERMINAL_KEY — the hub-injected per-hive sub-key. Present on every
+//      spoke in the fleet today, so this is the lane in force in production.
+//   2. Self-derived per-hive key from HIVE_HUB_SECRET + HIVE_ID.
+//
+// !! AUDIT N3 MUST NOT REGRESS: no lane may resolve to a FLEET-UNIFORM value. !!
+//
+// Two lanes used to sit here and both are DELETED in lockstep with the Go side:
+//   - HIVE_SESSION_KEY, which is byte-identical across all 65 spokes. An
+//     assertion minted on one tenant's spoke verified on every other, so any
+//     tenant operator could forge a shell grant for an arbitrary user on an
+//     arbitrary hive.
+//   - deriveTerminalKeyFrom(HIVE_HUB_SECRET), which took no hive ID and so
+//     derived ONE key for the whole fleet from a fleet-uniform master.
+//
 // Empty when none is configured → no assertion ever verifies → the terminal gate
 // falls back to the #2756 static allowlist. Computed ONCE at startup like HUB_SECRET.
 const TERMINAL_SIGNING_KEY =
   (process.env.HIVE_TERMINAL_KEY || '').trim() ||
-  (process.env.HIVE_SESSION_KEY || '').trim() ||
-  deriveTerminalKeyFrom((process.env.HIVE_HUB_SECRET || '').trim());
+  derivePerHiveTerminalKey(
+    (process.env.HIVE_HUB_SECRET || '').trim(),
+    (process.env.HIVE_ID || '').trim(),
+  );
 
 // TERMINAL_ASSERTION_COOKIE is where the spoke deposits the assertion (see
 // dashboard setTerminalAssertionCookie). Path=/terminal-scoped, HttpOnly.

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -267,19 +267,34 @@ function mintCookie(secret, username) {
 
 // mintTerminalAssertion mirrors Go hub.MintTerminalAssertion / the proxy's
 // verifyTerminalAssertion: `<base64url(json{v,u,r,h,iat,exp})>.<base64url(HMAC)>`.
-// It signs with the DERIVED terminal sub-key (deriveTerminalKey), not the raw
-// master — matching the proxy's TERMINAL_SIGNING_KEY resolution for a spoke
-// provisioned with only HIVE_HUB_SECRET (its default in these tests). ttlSec and
-// version are overridable so tests can forge expired / wrong-version / wrong-hive
+// It signs with the PER-HIVE terminal sub-key (deriveTerminalKey), not the raw
+// master and not a fleet-wide derivation — matching the proxy's
+// TERMINAL_SIGNING_KEY self-derive lane for a spoke provisioned with
+// HIVE_HUB_SECRET + HIVE_ID (its default in these tests). ttlSec and version are
+// overridable so tests can forge expired / wrong-version / wrong-hive
 // assertions. Default: this hive, 15-min TTL, current version.
 const TERMINAL_ASSERTION_VERSION = 'hive-terminal-v1';
 const INFO_TERMINAL_KEY = 'hive-terminal-v1';
-// deriveTerminalKey mirrors the Go deriveTerminalKeyFrom / proxy deriveTerminalKeyFrom.
-function deriveTerminalKey(master) {
-  return crypto.createHmac('sha256', master).update(INFO_TERMINAL_KEY).digest('hex');
+// deriveTerminalKey mirrors the Go derivePerHiveKey / proxy
+// derivePerHiveTerminalKey: HMAC over info || 0x00 || hiveID (audit N3).
+//
+// The key is now bound to the hive, so signing for hive X and presenting on hive
+// Y fails on the SIGNATURE rather than only on the payload's h-claim check —
+// which is exactly the cross-tenant forgery N3 closed.
+function deriveTerminalKey(master, hiveID) {
+  return crypto
+    .createHmac('sha256', master)
+    .update(INFO_TERMINAL_KEY)
+    .update(Buffer.from([0]))
+    .update(hiveID)
+    .digest('hex');
 }
-function mintTerminalAssertion(secret, { username, role, hiveID, ttlSec = 900, version = TERMINAL_ASSERTION_VERSION, iatOffsetSec = 0 } = {}) {
-  const key = deriveTerminalKey(secret);
+function mintTerminalAssertion(secret, { username, role, hiveID, signingHiveID, ttlSec = 900, version = TERMINAL_ASSERTION_VERSION, iatOffsetSec = 0 } = {}) {
+  // signingHiveID defaults to the hive the assertion CLAIMS, so a normal mint is
+  // self-consistent. A test that wants a wrong-hive CLAIM signed by the LOCAL
+  // hive's key (i.e. probing the h-claim check specifically, not the signature)
+  // passes signingHiveID explicitly.
+  const key = deriveTerminalKey(secret, signingHiveID || hiveID);
   const now = Math.floor(Date.now() / 1000) + iatOffsetSec;
   const claims = { v: version, u: username, r: role, h: hiveID, iat: now, exp: now + ttlSec };
   const body = Buffer.from(JSON.stringify(claims)).toString('base64url');
@@ -490,7 +505,10 @@ async function testC3F_ExpiredAssertionDenied() {
 // WRONG-HIVE assertion (minted for another hive id) → not usable → denied.
 async function testC3F_WrongHiveAssertionDenied() {
   const cookie = mintCookie(HIVE_B_SECRET, 'dave');
-  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: 'some-other-hive' });
+  // Signed by THIS hive's key but claiming another hive id, so the h-claim
+  // check is what must reject it (the signature is valid here). Since N3 the
+  // key is per-hive, so signingHiveID is pinned to keep this probing the CLAIM.
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: 'some-other-hive', signingHiveID: HIVE_B_ID });
   const resp = await terminalHTTP(cookie, HOSTED_HOST, assertion);
   assert.equal(resp.status, 403, `dave with a WRONG-HIVE assertion must be 403, got ${resp.status}`);
   const { opened } = await terminalWS(cookie, HOSTED_HOST, assertion);
@@ -631,8 +649,10 @@ async function testF4_ExpiredAssertionAloneDenied() {
 }
 
 async function testF4_WrongHiveAssertionAloneDenied() {
-  // Signed by hive B's key but claiming a different hive id.
-  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: 'hosted-some-other-hive' });
+  // Signed by hive B's key but claiming a different hive id — signingHiveID is
+  // pinned so this still exercises the h-claim check rather than failing on the
+  // signature (the terminal key is per-hive since N3).
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, { username: 'dave', role: 'owner', hiveID: 'hosted-some-other-hive', signingHiveID: HIVE_B_ID });
   const resp = await terminalHTTP(null, HOSTED_HOST, assertion);
   assert.notEqual(resp.status, 200, 'an assertion for ANOTHER hive must not authenticate here');
   console.log('  ✓ F4: wrong-hive assertion alone → denied');
@@ -646,6 +666,40 @@ async function testF4_ForgedAssertionAloneDenied() {
   const { opened } = await terminalWS(null, HOSTED_HOST, assertion);
   assert.ok(!opened, 'a forged assertion must not open a WS');
   console.log('  ✓ F4: forged-signature assertion alone → denied, HTTP + WS');
+}
+
+// !! AUDIT N3: a sibling tenant's spoke must not be able to forge a shell grant
+// here, even though every spoke shares the SAME master. !!
+//
+// This is the property that the deleted fleet-uniform lanes destroyed. Hive C
+// holds the identical HIVE_HUB_SECRET (the master is fleet-wide, verified live:
+// 65/65 spokes, one distinct value) and honestly claims THIS hive's id. Before
+// N3, TERMINAL_SIGNING_KEY resolved to a value derived without any hive id — so
+// hive C's key WAS this hive's key and this assertion would have verified.
+//
+// It must now fail on the SIGNATURE, because the key is bound to the hive id.
+async function testN3_SiblingTenantCannotForgeAcrossHives() {
+  const SIBLING_HIVE_ID = 'hosted-hive-c';
+  // Same master, different hive identity — exactly a co-tenant's spoke.
+  const assertion = mintTerminalAssertion(HIVE_B_SECRET, {
+    username: 'dave', role: 'owner', hiveID: HIVE_B_ID, signingHiveID: SIBLING_HIVE_ID,
+  });
+  const resp = await terminalHTTP(null, HOSTED_HOST, assertion);
+  assert.notEqual(resp.status, 200,
+    'N3 REGRESSION: an assertion signed with a SIBLING hive key authenticated here');
+  const { opened } = await terminalWS(null, HOSTED_HOST, assertion);
+  assert.ok(!opened, 'N3 REGRESSION: sibling-hive-signed assertion opened a WS');
+
+  // POSITIVE CONTROL: the same claims signed with THIS hive's key DO open a
+  // terminal. Without this the assertions above could pass because the terminal
+  // gate is broken outright rather than because the key binding works.
+  const good = mintTerminalAssertion(HIVE_B_SECRET, {
+    username: 'dave', role: 'owner', hiveID: HIVE_B_ID,
+  });
+  const okResp = await terminalHTTP(null, HOSTED_HOST, good);
+  assert.equal(okResp.status, 200,
+    `positive control failed: a correctly-signed assertion must open (got ${okResp.status})`);
+  console.log('  \u2713 N3: sibling-tenant assertion denied; own-hive assertion still opens');
 }
 
 async function testF4_InsufficientRoleAloneDenied() {
@@ -863,6 +917,7 @@ try {
   await testF4_ExpiredAssertionAloneDenied();
   await testF4_WrongHiveAssertionAloneDenied();
   await testF4_ForgedAssertionAloneDenied();
+  await testN3_SiblingTenantCannotForgeAcrossHives();
   await testF4_InsufficientRoleAloneDenied();
   await testC3F_StaticAllowlistFallbackPreserved();
 


### PR DESCRIPTION
Follow-on PR #5 of `v2/docs/design/master-key-rotation.md`. Base `v4`.

## The design's premise for this PR was wrong, and the honest answer is smaller

The design filed terminal/invite under *"CANNOT carry a marker → bounded trial verification"*. The first half holds. **The second does not apply**, for two independent reasons:

- **A spoke has no generation set, and must not be given one.** Trial verification means "derive from each live generation and compare". A spoke holds exactly ONE master (`HIVE_HUB_SECRET`) and ONE injected value per key. Nothing in `saas_provision.go` puts generation material into a Deployment — and nothing should, since shipping the set to 66 spokes would hand every tenant operator the *previous* master as well as the current one. There is nothing to trial against.
- **Nor is it needed.** Both keys are mint-and-verify **on the same spoke** (terminal: `dashboard/session.go` mints, `proxy/server.js` verifies, same pod; invite: same process). Minter and verifier read the same env at the same instant and cannot disagree about which generation is in force. Dual acceptance bridges a gap between parties that rotate at different times; here there is no gap. Contrast the heartbeat bearer (PR #2), where the spoke mints and the **hub** verifies — hours apart — which is exactly why trial verification fits there.

So this PR adds **no trial-verification machinery**. I would rather ship an accurate small PR than a speculative large one. Auditing the two resolvers for rotation readiness instead surfaced two **live defects** that would have made a rotation incorrect rather than merely inconvenient.

## Defect 1 — audit N3 was not actually closed in the resolver

`TerminalSigningKey()` still carried **both** fleet-uniform fallback lanes. N3 closed the gap in *provisioning* (inject a per-hive `HIVE_TERMINAL_KEY` so lane 1 wins) but left the lanes in the resolver:

| Lane | Value | Measured live |
|---|---|---|
| `HIVE_SESSION_KEY` | fleet-uniform | present 65/65 spokes, **1 distinct value** |
| `deriveTerminalKeyFrom(master)` | no hive ID | master is fleet-uniform, 65/65, **1 distinct value** |

Either lane resolving means an assertion minted on one tenant's spoke verifies on **every** other — the exact N3 forgery lane, one absent env var away from being live. That is precisely the state a re-provision or manifest reapply produces (see `perhive_env_reconcile.go`'s header on the fleet's out-of-band posture).

Both are **deleted**. The fallback now **self-derives** the per-hive key from the master plus `HIVE_ID`, mirroring `SpokeHeartbeatKey`'s lane 2 (audit F2), so a spoke becomes correct **in place** with no re-provision. `deriveTerminalKeyFrom` is removed outright — a helper that exists is a helper that gets called, which is how this lane survived the original N3 fix.

## Defect 2 — invite still used the RAW master, fleet-wide

`inviteSigningSecret()` used the master **itself** as the HMAC key. Measured live, that was the lane in force on **65/65 spokes**: `HIVE_INVITE_KEY` is emitted by the provisioning template but was **not carried by the reconcile sweep**, so no live spoke has ever received it. Every spoke signed invites with an identical key, and the per-hive binding `provisionInviteKey` exists to provide was in force nowhere.

Now routed through a new `hub.SpokeInviteKey()` — per-hive in both lanes, raw-master lane deleted.

## The reconcile lane was missing a var

`EnvInviteKey` was absent from `desiredPerHiveEnv`/`perHiveEnvNames`. That is *why* the fleet never got it, and it also means a rotation would never have converged the invite key. The lane now carries **six** vars, not five.

## What rolls on the fleet

One pod roll per spoke, rate-limited by the existing lane at **3 per 15-minute cycle (~6h)**, caused by the newly reconciled `HIVE_INVITE_KEY`.

`HIVE_TERMINAL_KEY` is already present and correct on 65/65 spokes, so **the terminal key is not re-keyed by this PR** — the resolver change only alters what a spoke would compute if that var were ever absent.

Rotation costs here are bounded and self-healing: terminal assertions carry a 15-minute TTL, and an invalid invite degrades to "no attribution", never to an error.

## `proxy/server.js`'s terminal lane IS in scope (changed after rebasing onto #6)

PR #6 landed while this was in review and explicitly deferred this lane — *"The terminal key path in server.js is untouched (PR #5's scope)"*. That is correct, and it means the proxy change belongs **here**.

`TERMINAL_SIGNING_KEY` mirrors `hub.TerminalSigningKey`, and the two must stay in lockstep. Deleting the fleet-uniform lanes on the Go side alone would leave the N3 forgery lane live in the **verifier** — the half that actually decides whether a shell opens. So both fallbacks are removed there too, replaced with the same per-hive self-derivation from `HIVE_HUB_SECRET` + `HIVE_ID` (which the proxy already read at `server.js:96`).

The two derivations are asserted **equal byte-for-byte**: `HMAC(master, info || 0x00 || hiveID)`. The `0x00` separator must match exactly — hive IDs are attacker-influenced and plain concatenation would be ambiguous.

```
node: c15a09abd8debf0dd09e250cdfd45753b725f96bdc5f8550ab7f9ac124700dbc
go:   c15a09abd8debf0dd09e250cdfd45753b725f96bdc5f8550ab7f9ac124700dbc
```

**A subtlety worth flagging for review.** With a per-hive key, an assertion minted for hive X and presented on hive Y now fails on the **signature**, not only on the payload's `h` claim. The two tests that specifically exercise the `h`-claim check therefore pin `signingHiveID` explicitly, so they keep testing the claim rather than silently becoming duplicates of the signature test.

New: `testN3_SiblingTenantCannotForgeAcrossHives` — a co-tenant holding the **same fleet-wide master** cannot forge a grant here, with a positive control that a correctly-signed assertion still opens a terminal.

## Tests

- `TestN3_TerminalKeyNeverFallsThroughToSessionKey` — asserts the invariant **behaviourally** (resolver ignores the var) **and structurally** (the resolver's source must not name it), with a **positive control** proving the extracted function body is really the function.
- `TestN3_TerminalAssertionDoesNotCrossHives` — hive A's assertion rejected under hive B's key, with a positive control that it verifies under its own.
- `TestDeriveTerminalKeyIsDomainSeparatedAndPerHive`, `TestTerminalSigningKeyResolutionOrder`
- `TestSpokeInviteKeyResolution`, `TestSpokeInviteKeyIsDomainSeparated`
- `TestInviteSigningSecretSelfDerivesPerHive`, `TestInviteSigningSecretNoIdentityFallsToFile` — the no-identity case must reach the generated file, never a shared key.

**Hardened `TestDesiredPerHiveEnvUsesCurrentNotPrevious` with a count floor.** It iterates `perHiveEnvNames()`, so dropping a var from that list also drops it from every assertion — **it passed while `EnvInviteKey` was neutered out.** It now fails. This came directly from a replay that initially passed while neutered, which is exactly the failure mode this repo has hit before.

### Regression replay

Four neuters, each compiled, each confirmed failing, each restored green:

| # | Neuter | Caught by |
|---|---|---|
| 1 | reopen `HIVE_SESSION_KEY` fallthrough | `TestN3_TerminalKeyNeverFallsThroughToSessionKey` |
| 2 | terminal key back to fleet-wide derivation | `TestTerminalSigningKeyResolutionOrder` + `TestN3_...SessionKey` |
| 3 | restore raw-master invite lane | `TestInviteSigningSecretSelfDerivesPerHive` + `...NoIdentityFallsToFile` |
| 4 | drop `EnvInviteKey` from reconcile | `TestDesiredPerHiveEnvMatchesProvisioningTemplate`; `...UsesCurrentNotPrevious` **only after** the count-floor guard |
| 5 | proxy `TERMINAL_SIGNING_KEY` back to fleet-wide lanes | positive control fails loudly: *"dave with a valid owner assertion should reach terminal, got 403"* |

## Verification

- `go build ./...`, `go vet ./...` clean
- `./pkg/hub/` and `./pkg/dashboard/` fully green
- `gofmt`: zero hits on touched files (16 pre-existing hits on clean `v4`, none mine)
- Rebased onto #7 (`a2ee877e`, auto-retire) and then #6 (`1b4c8a23`, pubkey rotation). The #6 rebase had one comment-only conflict in `perHiveEnvNames`; #6's "mandatory five" prose is updated to six, since this PR adds a sixth always-present var
- `cd v2/proxy && npm ci && npm test` → exit 0, zero failures
- One pre-existing test needed a fix, not a workaround: `TestCovDF_GHUserAuthPoll_EmptyAuthTokenStillMintsSession` set only the master and relied on the deleted fleet-wide lane. Its own comment already said it needs "a signing key and a hive identity"; it now sets `HIVE_ID` too.

Fleet numbers above are from read-only `kubectl` across the live spoke Deployments; no secret values were printed or written.
