### PR TITLE
docs: self-hosted CAP_NET_ADMIN — full egress gate vs degraded mode (#3760)

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -42,7 +42,8 @@ For tag provenance, digest pinning, and the release/tagging flow, see [docs/oper
 ### Troubleshooting
 
 - **Rancher Desktop / Lima**: Volume mounts from `/tmp` may fail silently (file appears as directory inside container). Clone the repo under your home directory instead.
-- **Gateway won't start**: The gateway depends on the hive health check (120s start period). If it times out, run the hive container directly: `docker run -d --name hive -p 3001:3001 -v ./hive.yaml:/etc/hive/hive.yaml -e HIVE_GITHUB_TOKEN=$HIVE_GITHUB_TOKEN ghcr.io/kubestellar/hive:v2-latest`
+- **Gateway won't start**: The gateway depends on the hive health check (120s start period). If it times out, run the hive container directly: `docker run -d --name hive --cap-add NET_ADMIN -p 3001:3001 -v ./hive.yaml:/etc/hive/hive.yaml -e HIVE_GITHUB_TOKEN=$HIVE_GITHUB_TOKEN ghcr.io/kubestellar/hive:v2-latest` (the `--cap-add NET_ADMIN` enables the full forced-proxy-egress gate — see below).
+- **Forced-proxy-egress gate is degraded / `SO_MARK unavailable` in logs**: the container runs fine without `NET_ADMIN`, but the proxy's SO_MARK self-exemption needs it. Grant `NET_ADMIN` (`--cap-add NET_ADMIN` for docker/podman, `securityContext.capabilities.add: ["NET_ADMIN"]` for Kubernetes) for the full egress gate; without it the spoke stays in best-effort/degraded egress mode. See [docs/net-admin-requirement.md](docs/net-admin-requirement.md).
 - **Policy clone errors in logs**: The example config has a placeholder policy repo. Comment out the `policies:` section in `hive.yaml` if you don't have a custom policy repo.
 
 ## Command-line client

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -6,6 +6,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 
 - [Manual provisioning](manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
 - [Self-hosted hub deployment](hub-deployment.md) — `HIVE_MODE=hub`, hub storage, heartbeat secrets, and SaaS spoke registration.
+- [`CAP_NET_ADMIN` and self-hosted spokes](net-admin-requirement.md) — the container runs with or without `NET_ADMIN`; granting it (`--cap-add NET_ADMIN` / `securityContext.capabilities.add`) enables the full forced-proxy-egress gate, and what the degraded best-effort mode means without it.
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, GitHub token scopes, and image provenance.
 - [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.

--- a/v2/docs/net-admin-requirement.md
+++ b/v2/docs/net-admin-requirement.md
@@ -1,0 +1,90 @@
+# Self-Hosted Hive and `CAP_NET_ADMIN`
+
+A self-hosted / unmanaged Hive spoke **runs without** the `NET_ADMIN` Linux
+capability — the container starts normally either way. But `NET_ADMIN` is what
+activates the **full forced-proxy-egress security gate**. Grant it to get the
+complete gate; without it the spoke runs in a **degraded (best-effort) egress
+mode** described below.
+
+> Historical note: earlier builds shipped `/usr/local/bin/hive` with a
+> `cap_net_admin+ep` **file capability**. The kernel refuses to `execve()` a
+> binary whose file capabilities it cannot grant from the container's bounding
+> set, and `NET_ADMIN` is not in the default bounding set for docker / podman /
+> containerd / k3s — so those builds **crash-looped** on self-hosted spokes with
+> a bare `exec ... Operation not permitted` (EPERM). That file capability has
+> been **removed** (see #3760/#3794): the binary now carries no
+> `security.capability` xattr and execs everywhere. `NET_ADMIN` is instead raised
+> at runtime as an **ambient** capability by the entrypoint, gated on the
+> bounding set actually having it. The crash-loop is gone; what remains is the
+> choice between the full gate and the degraded mode.
+
+## Why `NET_ADMIN` matters
+
+The hive process runs as a **non-root** user (`dev`). The MITM proxy uses
+`CAP_NET_ADMIN` to `setsockopt(SO_MARK)` on its **own** upstream dials, which is
+how the proxy's traffic is exempted from the **forced-proxy-egress** gate: the
+entrypoint installs an iptables `REDIRECT` of all outbound `:443` through the
+proxy, and on OpenShift/OVN — where the `-m owner` UID match is unavailable —
+the `SO_MARK` packet mark is the **only** self-exemption. `setsockopt(SO_MARK)`
+requires `CAP_NET_ADMIN` in the calling process's **effective** set.
+
+The entrypoint delivers that capability by reading its own capability bounding
+set (`CapBnd` in `/proc/self/status`) at the privilege drop and, **only when
+`CAP_NET_ADMIN` (capability number 12) is present**, dropping to `dev` via
+`setpriv --ambient-caps +net_admin …` so the hive process inherits `NET_ADMIN`
+in its effective + ambient set. When the bounding set lacks it, the entrypoint
+does **not** attempt the raise (it would error) and drops to `dev` via plain
+`gosu`, printing a one-line notice that the SO_MARK egress exemption is
+unavailable.
+
+> This is a **capability bounding-set** distinction, not a seccomp or AppArmor
+> filter — `--security-opt seccomp=unconfined` / `apparmor=unconfined` do not
+> change it.
+
+The **managed fleet** always gets the full gate: its pods are granted
+`NET_ADMIN` via an SCC / PodSecurity grant (see
+`v2/deploy/k8s/deployment.yaml`), so the entrypoint's ambient raise fires.
+
+## Full gate vs. degraded mode
+
+| Deployment | `NET_ADMIN`? | Behavior |
+|---|---|---|
+| Managed k8s / OpenShift (SCC or `securityContext`) | yes | Entrypoint raises it ambiently → SO_MARK works → **full forced-proxy-egress gate**. |
+| Self-hosted docker / podman **with** `--cap-add NET_ADMIN` | yes | Same as above → **full gate**. |
+| Self-hosted docker / podman **without** the cap | no | Container **runs** (no crash). SO_MARK exemption unavailable → egress gate is **degraded / best-effort**: on OKE the owner-UID exemption still applies, but on OpenShift/OVN the proxy's own dials are not mark-exempted. |
+| Rootless podman | effectively no | Rootless cannot grant `NET_ADMIN` meaningfully, so it runs in the **degraded mode** above. |
+
+"Degraded" means the proxy's own upstream dials rely solely on the owner-UID
+iptables exemption; where that match is unavailable the proxy dials **unmarked**
+(the Go proxy logs this once and continues — it does not fail). Agents' forced
+egress through the proxy is still installed; only the proxy's *self*-exemption is
+best-effort.
+
+## How to get the full gate
+
+### Docker / Podman (rootful)
+
+```bash
+docker run --cap-add NET_ADMIN ... ghcr.io/kubestellar/hive:<tag>
+# or
+podman run --cap-add NET_ADMIN ... ghcr.io/kubestellar/hive:<tag>
+```
+
+### Kubernetes / k3s
+
+Add `NET_ADMIN` to the hive container's `securityContext`:
+
+```yaml
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+```
+
+(The bundled `v2/deploy/k8s/deployment.yaml` already declares this.)
+
+### Rootless Podman
+
+Rootless Podman cannot grant `NET_ADMIN` in a way the kernel will honor, so a
+rootless self-hosted spoke runs in the **degraded egress mode** above. The
+container still starts and operates; it simply lacks the SO_MARK self-exemption.


### PR DESCRIPTION
## Self-hosted `CAP_NET_ADMIN` docs, reconciled onto the post-#3794 model

This PR was originally written on the assumption that the `cap_net_admin+ep`
**file capability** stays and that self-hosted spokes **crash-loop** with a bare
`exec: Operation not permitted` until you grant `NET_ADMIN`. That premise is now
**obsolete**: **#3794** (merged to `v4`) **removed** the file capability and
instead raises `NET_ADMIN` as a **bounding-set-gated ambient capability** in the
entrypoint. The binary now execs everywhere; there is no crash-loop.

Rebased onto current `v4` (includes #3794) and rewritten accordingly.

### Dropped — entrypoint preflight (now redundant)
#3794's entrypoint already reads `CapBnd` at the privilege drop, raises the
ambient `NET_ADMIN` cap when the bounding set has it, and prints a clear notice
on the fallback (no-cap) path. This PR therefore **drops its own preflight
block entirely** — keeping it would produce two competing `CapBnd` checks and a
now-false "crash-loop" message. **This PR touches no code; it is docs-only.**

### Kept + corrected — the docs (the real remaining value)
- **`v2/docs/net-admin-requirement.md`** rewritten to the ambient-cap model:
  - **No file capability** on the binary (removed by #3794), with a short
    historical note explaining the old crash-loop and that it is fixed.
  - **Managed k8s / OpenShift**: `NET_ADMIN` via SCC / `securityContext` → the
    entrypoint raises it ambiently → **full forced-proxy-egress gate**.
  - **Self-hosted docker / podman**: pass `--cap-add NET_ADMIN` for the full
    gate. **Without it the spoke still RUNS** (no crash) but in a **degraded /
    best-effort egress mode** — the proxy's `SO_MARK` self-exemption is
    unavailable, so on OpenShift/OVN the proxy dials unmarked (logged once, not
    a failure). Rootless podman can't grant `NET_ADMIN` meaningfully → degraded
    mode.
  - A **full-gate-vs-degraded** comparison table.
- **`v2/README.md`** + **`v2/docs/README.md`**: wording reframed as "how to get
  the full egress gate + what degraded mode means", not "how to avoid a
  crash-loop".

### CI
- Docs-only change; `v2/scripts/check-suid-contract.sh` (updated by #3794) still
  passes — this PR reintroduces nothing the contract now forbids (no `setcap`,
  no competing ambient pattern; the entrypoint is byte-for-byte `v4`).

Supersedes the stale premise of #3774/#3779 framing. Complements the merged
**#3794** (which owns the runtime behavior); this PR documents it.

Refs #3760