### PR TITLE
🐛 fix(test): expect v4 contributor image tag after #3777 Justfile default bump

### DIFF
--- a/v2/deploy/test_contribute_k8s_workload.sh
+++ b/v2/deploy/test_contribute_k8s_workload.sh
@@ -69,7 +69,7 @@ OUT="$(cd "$REPO_ROOT" && HOME="$FAKE_HOME" just contribute-k8s hive-contributor
 contains "emits a Deployment"                 "$OUT" "kind: Deployment"
 contains "workload runs headless (#2660)"     "$OUT" "CONTRIBUTOR_MODE: \"headless\""
 contains "status file env for the probe"      "$OUT" "HIVE_HEADLESS_STATUS_FILE:"
-contains "uses the published contributor image" "$OUT" "image: ghcr.io/kubestellar/hive-contributor:v2"
+contains "uses the published contributor image" "$OUT" "image: ghcr.io/kubestellar/hive-contributor:v4"
 contains "wires the ConfigMap via envFrom"    "$OUT" "configMapRef:"
 contains "wires the Secret via secretRef"     "$OUT" "secretRef:"
 contains "has a readiness probe"              "$OUT" "readinessProbe:"


### PR DESCRIPTION
#3777 correctly changed the `contribute-k8s` default `image_tag` from `v2` to `v4` (v2 is unsupported). The generated Deployment now references `ghcr.io/kubestellar/hive-contributor:v4`, but `v2/deploy/test_contribute_k8s_workload.sh:72` still asserted `:v2`, which reddened `build-and-test` on v4 tip (and blocked the #3774 revert PR that branched off it).

One-line fix: assertion now expects `hive-contributor:v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)