### PR TITLE
🔒 v4: harden codex and claude-code npm installs with --ignore-scripts

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -192,12 +192,12 @@ RUN npm install -g @github/copilot-sdk@${COPILOT_SDK_VERSION} && npm cache clean
 # local stdio, no network, unaffected by the proxy CA) falls back to the
 # static list, and non-codex backends are unaffected.
 ARG CODEX_VERSION=0.146.0
-RUN npm install -g @openai/codex@${CODEX_VERSION} && npm cache clean --force || \
+RUN npm install -g --ignore-scripts --no-fund --no-audit @openai/codex@${CODEX_VERSION} && npm cache clean --force || \
     echo "WARN: OpenAI Codex CLI install failed — skipping"
 
 # --- Layer 7: Claude Code (most frequent updates) ---
 ARG CLAUDE_CODE_VERSION=2.1.226
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
+RUN npm install -g --ignore-scripts --no-fund --no-audit @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
 
 # --- Layer 8: Goose CLI (official block/goose upstream) ---
 # Installs from the OFFICIAL block/goose repo, pinned to a fixed release and

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -34,7 +34,7 @@ RUN mkdir -p /etc/apt/keyrings \
 # diff, mirroring the cleanup already done for the bobshell install below.
 ARG CLAUDE_CODE_VERSION=2.1.226
 ARG COPILOT_VERSION=1.0.59
-RUN npm install -g \
+RUN npm install -g --ignore-scripts --no-fund --no-audit \
     @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
     @github/copilot@${COPILOT_VERSION} \
     @openai/codex@0.146.0 \


### PR DESCRIPTION
## Security Fix

PR #3756 added `--ignore-scripts --no-fund --no-audit` to the copilot, copilot-sdk, and pluk npm install layers in `v2/Dockerfile`, but left `@openai/codex` and `@anthropic-ai/claude-code` unprotected. The single combined install block in `v2/Dockerfile.contributor` (claude-code, copilot, codex) was also missed.

Without `--ignore-scripts`, npm executes preinstall/install/postinstall lifecycle scripts from the package and its full transitive dependency tree during `docker build`. A compromised or backdoored package version can run arbitrary code inside the build environment with access to ARG values and the partially-built filesystem.

### Changes
- `v2/Dockerfile`: added `--ignore-scripts --no-fund --no-audit` to the `@openai/codex` and `@anthropic-ai/claude-code` `npm install -g` layers
- `v2/Dockerfile.contributor`: added `--ignore-scripts --no-fund --no-audit` to the combined `npm install -g` block (claude-code, copilot, codex)

`v2/Dockerfile.hub` has no npm install layers — nothing to change there.

Fixes #3772

This supersedes #3773, which applied the same fix but targeted the retired v2 branch.