### PR TITLE
ci: run Scorecard on v4 pushes; fix nightly GHCR tag path

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v4" ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -198,8 +198,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}/hive:nightly
-            ghcr.io/${{ github.repository }}/hive:nightly-${{ github.sha }}
+            ghcr.io/${{ github.repository }}:nightly
+            ghcr.io/${{ github.repository }}:nightly-${{ github.sha }}
           build-args: |
             GIT_HASH=${{ github.sha }}
             GIT_SHORT=${{ github.sha }}


### PR DESCRIPTION
## What

Two workflow fixes on `v4`, one per security finding:

**Scorecard branch coverage (#3747)**
`.github/workflows/scorecard.yml` only triggered on `push: branches: ["main"]`, so OpenSSF Scorecard never ran on the branch where development actually happens. This PR adds `v4` to the push branch list. Note: the issue predates v2's retirement and recommended adding `v2`; the fleet and all development have since moved to `v4`, so `v4` is the branch that needs coverage.

**Nightly GHCR tag path (#3662)**
The `nightly-release` job in `.github/workflows/v2-ci.yml` tagged images as `ghcr.io/${{ github.repository }}/hive:nightly`, which expands to `ghcr.io/kubestellar/hive/hive:nightly` — a sub-package, not the canonical `ghcr.io/kubestellar/hive` package that `docker.yml` pushes to and that deployments reference. Any deployment pinned to `ghcr.io/kubestellar/hive:nightly` would never receive nightly updates. This PR drops the extra `/hive` path segment so nightly tags land on the canonical package.

Side note for reviewers: the `nightly-release` job is currently gated on `github.ref == 'refs/heads/v2'`, so with v2 retired it is dormant. This PR deliberately only corrects the tag paths (the reported bug); whether to re-point the job at `v4` or remove it is a separate decision.

Fixes #3747
Fixes #3662