### PR TITLE
🐛 fix(contribute): stop offering issues an open PR already claims to fix

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2190,6 +2190,14 @@ func main() {
 		Logger:           logger,
 		Ctx:              ctx,
 		RefreshFunc:      refreshDashboard,
+		// #3768: give the contribute queue read access to the duplicate-PR
+		// claim ledger, so an issue any open PR (hive-authored or a human
+		// contributor's) already claims to fix is never offered to another
+		// contributor. Lazy: the ledger loads on first use, same as the
+		// eval-cycle guard.
+		IssueClaimed: func(repo string, number int) (github.IssueClaim, bool) {
+			return getClaimLedger(logger).Lookup(repo, number)
+		},
 		PersistFunc: func() {
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 		},
@@ -6024,6 +6032,20 @@ func applyDuplicatePRGuard(
 	actionable *github.ActionableResult,
 	logger *slog.Logger,
 ) {
+	ledger := getClaimLedger(logger)
+	if ledger == nil {
+		return
+	}
+	github.ApplyDuplicatePRGuard(ctx, ghClient, ledger, hiveIdentity(cfg), actionable, claimingPRRedStale(cfg, actionable), logger)
+}
+
+// getClaimLedger lazily loads the persisted claim ledger on first use (and
+// keeps a usable empty ledger on a load failure), so a missing or corrupt
+// /data ledger can never block the hive from booting. It is shared by the
+// eval-cycle guard above and by the dashboard's IssueClaimed hook (#3768); the
+// sync.Once publication makes the pointer safe to read from either goroutine,
+// and the ledger itself is internally locked.
+func getClaimLedger(logger *slog.Logger) *github.ClaimLedger {
 	claimLedgerOnce.Do(func() {
 		ledger, err := github.LoadClaimLedger(github.ClaimLedgerPath, logger)
 		if err != nil {
@@ -6034,10 +6056,7 @@ func applyDuplicatePRGuard(
 		}
 		claimLedger = ledger
 	})
-	if claimLedger == nil {
-		return
-	}
-	github.ApplyDuplicatePRGuard(ctx, ghClient, claimLedger, hiveIdentity(cfg), actionable, claimingPRRedStale(cfg, actionable), logger)
+	return claimLedger
 }
 
 // claimingPRRedStale builds the Fix #3 release predicate: given a claiming PR

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
 
 const (
@@ -3318,6 +3319,34 @@ func (h *ContributeWSHub) resumeGateReason(c *ContributorConnection) string {
 	return ""
 }
 
+// issueClaimedByOpenPR reports whether ANY open PR already claims to fix the
+// given issue (kubestellar/hive#3768), via the Dependencies.IssueClaimed hook
+// into the governor's duplicate-PR claim ledger. Unlike the agent-side
+// FilterClaimedIssues — which deliberately honours only hive-authored claims —
+// the contribute queue must honour EVERY claim: a human contributor's open PR
+// is exactly the "someone is already on it" signal whose absence let the same
+// issue be handed to contributor after contributor.
+//
+// The ledger keys claims by the repo spelling used in the hive config, which
+// FrontendRepo.Name preserves; repo.Full is the org-qualified form and is tried
+// first since cross-repo `owner/repo#N` closing references key on it. A hub
+// with no hook wired (tests, or a hive booted without GitHub credentials)
+// reports no claims and selection proceeds exactly as before.
+func (h *ContributeWSHub) issueClaimedByOpenPR(repoFull, repoName string, number int) (ghpkg.IssueClaim, bool) {
+	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.IssueClaimed == nil {
+		return ghpkg.IssueClaim{}, false
+	}
+	if claim, ok := h.server.deps.IssueClaimed(repoFull, number); ok {
+		return claim, true
+	}
+	if repoName != "" && repoName != repoFull {
+		if claim, ok := h.server.deps.IssueClaimed(repoName, number); ok {
+			return claim, true
+		}
+	}
+	return ghpkg.IssueClaim{}, false
+}
+
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.selectMu.Lock()
 	defer h.selectMu.Unlock()
@@ -3589,6 +3618,23 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				continue
 			}
 			if activeIssues[fmt.Sprintf("%s#%d", repo.Full, number)] {
+				continue
+			}
+			// #3768: skip an issue that an open PR — from ANYONE, hive agent or
+			// human contributor — already claims to fix. The activeIssues guard
+			// above only covers tasks held by LIVE connections, and the
+			// completion cooldown only starts when the relay reports a verified
+			// task_complete; a contributor who opens a PR but whose completion
+			// report is missed (relay scrape failure, disconnect, verification
+			// downgrade) left the issue re-offerable after the short 4h no-PR
+			// cooldown, so projectbluefin/dakota#353 accumulated one duplicate
+			// PR per window. The claim ledger sees the open PR itself on the
+			// next eval cycle, which closes that hole regardless of what the
+			// relay managed to report.
+			if claim, claimed := h.issueClaimedByOpenPR(repo.Full, repo.Name, number); claimed {
+				h.logger.Info("[contribute-ws] skip: issue already claimed by an open PR",
+					"repo", repo.Full, "number", number,
+					"pr_url", claim.PRURL, "pr_author", claim.PRAuthor)
 				continue
 			}
 			// Yank self-exclusion: an issue this SAME clanker was just yanked off is

--- a/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
+++ b/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
@@ -1,0 +1,151 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// These tests are the #3768 regression suite: projectbluefin/dakota#353
+// accumulated duplicate PRs because the contribute queue kept offering an
+// issue that an earlier contributor's open PR already fixed. selectTask must
+// consult the duplicate-PR claim ledger (via Dependencies.IssueClaimed) and
+// skip ANY claimed issue — including claims from EXTERNAL (non-hive) PR
+// authors, which the agent-side FilterClaimedIssues deliberately ignores.
+
+// claimedIssueStatus seeds a status with two admissible issues in a repo whose
+// Full (owner/repo) differs from its bare Name, mirroring the projectbluefin
+// incident shape.
+func claimedIssueStatus(s *Server) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "dakota",
+				Full: "projectbluefin/dakota",
+				ActionableIssues: []any{
+					map[string]any{
+						"number": float64(353),
+						"title":  "the issue everyone kept fixing",
+						"url":    "https://github.com/projectbluefin/dakota/issues/353",
+						"author": "someone",
+					},
+					map[string]any{
+						"number": float64(360),
+						"title":  "an unclaimed issue",
+						"url":    "https://github.com/projectbluefin/dakota/issues/360",
+						"author": "someone",
+					},
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+}
+
+func claimedIssueConn() *ContributorConnection {
+	return &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct-a", ContributorID: "c-a", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+}
+
+// externalClaim is the exact incident signal: an open PR from a HUMAN
+// contributor (not the hive) claiming to fix the issue.
+func externalClaim(repo string, number int) ghpkg.IssueClaim {
+	return ghpkg.IssueClaim{
+		Repo: repo, Issue: number,
+		PRNumber: 900, PRRepo: repo,
+		PRURL:          "https://github.com/projectbluefin/dakota/pull/900",
+		PRAuthor:       "castrojo",
+		ObservedAt:     time.Now(),
+		ExternalAuthor: true,
+	}
+}
+
+// TestClaimedIssue_SkippedAndNextOffered replays #3768: issue 353 is claimed
+// by an external contributor's open PR, so selectTask must pass over it and
+// offer the next admissible issue instead of double-dispatching 353.
+func TestClaimedIssue_SkippedAndNextOffered(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+	s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+		if repo == "projectbluefin/dakota" && number == 353 {
+			return externalClaim(repo, number), true
+		}
+		return ghpkg.IssueClaim{}, false
+	}
+
+	msg := hub.selectTask(claimedIssueConn())
+	if msg == nil {
+		t.Fatal("expected a message from selectTask")
+	}
+	if msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %q (reason %q)", msg.Type, msg.Reason)
+	}
+	if msg.Number != 360 {
+		t.Fatalf("claimed issue was offered anyway: got #%d, want #360", msg.Number)
+	}
+}
+
+// TestClaimedIssue_AllClaimedYieldsNoMatchingWork: when every admissible issue
+// is claimed by an open PR, the contributor gets an explicit no_matching_work
+// negative-ack — never a duplicate assignment.
+func TestClaimedIssue_AllClaimedYieldsNoMatchingWork(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+	s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+		return externalClaim(repo, number), true
+	}
+
+	msg := hub.selectTask(claimedIssueConn())
+	if msg == nil {
+		t.Fatal("expected a message from selectTask")
+	}
+	if msg.Type != "task_unavailable" || msg.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("expected task_unavailable/no_matching_work, got %q/%q", msg.Type, msg.Reason)
+	}
+}
+
+// TestClaimedIssue_BareRepoNameKeyMatches: the claim ledger keys claims by the
+// repo spelling used in the hive config, which may be the BARE name rather
+// than owner/repo. The lookup must try FrontendRepo.Name too, or a
+// bare-configured repo would silently miss every claim (the same key-mismatch
+// class as #2644).
+func TestClaimedIssue_BareRepoNameKeyMatches(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+	s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+		if repo == "dakota" && number == 353 { // bare config-form key only
+			return externalClaim(repo, number), true
+		}
+		return ghpkg.IssueClaim{}, false
+	}
+
+	msg := hub.selectTask(claimedIssueConn())
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", msg)
+	}
+	if msg.Number != 360 {
+		t.Fatalf("bare-name claim key was not honoured: got #%d, want #360", msg.Number)
+	}
+}
+
+// TestClaimedIssue_NoHookLeavesSelectionUnchanged is the positive control: with
+// no IssueClaimed hook wired (test hubs, hives booted without GitHub
+// credentials), selection behaves exactly as before and offers the first
+// eligible issue.
+func TestClaimedIssue_NoHookLeavesSelectionUnchanged(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+	s.deps.IssueClaimed = nil
+
+	msg := hub.selectTask(claimedIssueConn())
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", msg)
+	}
+	if msg.Number != 353 {
+		t.Fatalf("expected first eligible issue #353 with no claim data, got #%d", msg.Number)
+	}
+}

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -50,6 +50,16 @@ type Dependencies struct {
 	// handler that gates on the raw config value alone dead-ends on exactly the
 	// fleet-standard hosted-spoke configuration (#2459).
 	ResolveAppKeyFileFunc func(configured string, appID int64) string
+	// IssueClaimed reports whether an open PR — hive-authored OR from an
+	// external contributor — already claims to fix the given issue
+	// (kubestellar/hive#3768). It is backed by the governor's duplicate-PR
+	// claim ledger, which parses `Fixes #N` / `Closes #N` references (and a
+	// branch-name heuristic) out of every open PR each eval cycle and persists
+	// them across restarts. The contribute selectTask consults it so an issue
+	// with a fix already in flight is never offered to another contributor.
+	// repo is tried in the same spelling the ledger keys on (the config repo
+	// form); a nil func means "no claim data" and disables the check.
+	IssueClaimed func(repo string, number int) (ghpkg.IssueClaim, bool)
 }
 
 type NousState struct {

--- a/v2/pkg/github/prclaims.go
+++ b/v2/pkg/github/prclaims.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
@@ -78,6 +79,16 @@ type IssueClaim struct {
 	// ObservedAt is when this claim was last confirmed by a live API call.
 	// It is the basis for TTL expiry.
 	ObservedAt time.Time `json:"observed_at"`
+	// ExternalAuthor marks a claim whose PR was opened by an account that is
+	// NOT this hive (kubestellar/hive#3768). External claims exist so the
+	// contribute queue can stop offering an issue that a human contributor's
+	// open PR already fixes; they deliberately do NOT suppress agent work in
+	// FilterClaimedIssues, preserving the original guard's rule that a
+	// stranger's PR can never freeze the hive's own pipeline. The field is
+	// omitempty-false so ledgers written before #3768 — which only ever
+	// recorded hive-authored claims — unmarshal as hive-authored (false),
+	// keeping their agent-side suppression intact across the upgrade.
+	ExternalAuthor bool `json:"external_author,omitempty"`
 }
 
 // Key identifies the issue a claim covers.
@@ -224,9 +235,13 @@ func (h HiveIdentity) IsZero() bool {
 	return h.AIAuthor == "" && h.AppLogin == ""
 }
 
-// FetchClaims lists open PRs authored by this hive across the client's
-// configured repos and returns the issue claims parsed from their titles and
-// bodies.
+// FetchClaims lists open PRs across the client's configured repos and returns
+// the issue claims parsed from their titles and bodies. Claims from PRs the
+// hive did not author are included and marked ExternalAuthor
+// (kubestellar/hive#3768): the contribute queue needs them to stop re-offering
+// an issue a human contributor's open PR already fixes, while
+// FilterClaimedIssues continues to honour only hive-authored claims for agent
+// work.
 //
 // A per-repo API failure is reported via err but the successfully-scanned repos
 // are still returned, so the caller can merge partial results into the ledger
@@ -265,9 +280,11 @@ func (c *Client) FetchClaims(ctx context.Context, identity HiveIdentity) ([]Issu
 					continue
 				}
 				author := safeGetLogin(pr.GetUser())
-				if !identity.Matches(author) {
-					continue
-				}
+				// #3768: claims are no longer restricted to hive-authored PRs.
+				// A human contributor's open PR claims its issue too — marked
+				// ExternalAuthor below so the agent-side filter can keep
+				// ignoring it while the contribute queue honours it.
+				external := !identity.Matches(author)
 				// Title and body are both scanned: `Fixes #N` conventionally
 				// lives in the body, but many agents put it in the title.
 				text := pr.GetTitle() + "\n" + pr.GetBody()
@@ -287,13 +304,14 @@ func (c *Client) FetchClaims(ctx context.Context, identity HiveIdentity) ([]Issu
 
 				for _, ref := range refs {
 					claims = append(claims, IssueClaim{
-						Repo:       ref.Repo,
-						Issue:      ref.Issue,
-						PRNumber:   pr.GetNumber(),
-						PRRepo:     repo,
-						PRURL:      pr.GetHTMLURL(),
-						PRAuthor:   author,
-						ObservedAt: now,
+						Repo:           ref.Repo,
+						Issue:          ref.Issue,
+						PRNumber:       pr.GetNumber(),
+						PRRepo:         repo,
+						PRURL:          pr.GetHTMLURL(),
+						PRAuthor:       author,
+						ObservedAt:     now,
+						ExternalAuthor: external,
 					})
 				}
 			}
@@ -314,6 +332,10 @@ func (c *Client) FetchClaims(ctx context.Context, identity HiveIdentity) ([]Issu
 type ClaimLedger struct {
 	path   string
 	logger *slog.Logger
+	// mu guards claims. The ledger was single-goroutine (the eval cycle) until
+	// #3768 gave the contribute WS hub a read path into it, so reads now happen
+	// concurrently with the eval cycle's Reconcile/Save writes.
+	mu sync.RWMutex
 	// claims is keyed by "repo#issue".
 	claims map[string]IssueClaim
 	// ttl bounds entry lifetime; overridable for tests.
@@ -372,9 +394,23 @@ func LoadClaimLedger(path string, logger *slog.Logger) (*ClaimLedger, error) {
 		if c.ObservedAt.Before(cutoff) {
 			continue
 		}
-		l.claims[c.Key()] = c
+		l.insertLocked(c)
 	}
 	return l, nil
+}
+
+// insertLocked adds a claim to the map, resolving key collisions with
+// hive-precedence: when the same issue is claimed by both a hive-authored PR
+// and an external one (#3768), the hive-authored claim wins, so the agent-side
+// filter — which honours only hive claims — can never be blinded by an
+// external PR racing it to the map. Callers must hold l.mu (or own the ledger
+// exclusively, as LoadClaimLedger does before publishing it).
+func (l *ClaimLedger) insertLocked(c IssueClaim) {
+	key := c.Key()
+	if existing, ok := l.claims[key]; ok && !existing.ExternalAuthor && c.ExternalAuthor {
+		return
+	}
+	l.claims[key] = c
 }
 
 // SetTTL overrides the entry lifetime. Intended for tests.
@@ -382,6 +418,8 @@ func (l *ClaimLedger) SetTTL(d time.Duration) {
 	if l == nil || d <= 0 {
 		return
 	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.ttl = d
 }
 
@@ -390,6 +428,8 @@ func (l *ClaimLedger) SetClock(fn func() time.Time) {
 	if l == nil || fn == nil {
 		return
 	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.now = fn
 }
 
@@ -398,10 +438,12 @@ func (l *ClaimLedger) Claims() []IssueClaim {
 	if l == nil {
 		return nil
 	}
+	l.mu.RLock()
 	out := make([]IssueClaim, 0, len(l.claims))
 	for _, c := range l.claims {
 		out = append(out, c)
 	}
+	l.mu.RUnlock()
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Repo != out[j].Repo {
 			return out[i].Repo < out[j].Repo
@@ -411,11 +453,23 @@ func (l *ClaimLedger) Claims() []IssueClaim {
 	return out
 }
 
+// Len reports the number of claims currently held.
+func (l *ClaimLedger) Len() int {
+	if l == nil {
+		return 0
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.claims)
+}
+
 // Lookup returns the claim covering the given issue, if any.
 func (l *ClaimLedger) Lookup(repo string, issue int) (IssueClaim, bool) {
 	if l == nil {
 		return IssueClaim{}, false
 	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	c, ok := l.claims[claimKey(repo, issue)]
 	return c, ok
 }
@@ -435,29 +489,31 @@ func (l *ClaimLedger) Reconcile(live []IssueClaim, authoritative bool) {
 	if l == nil {
 		return
 	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	if authoritative {
-		next := make(map[string]IssueClaim, len(live))
+		l.claims = make(map[string]IssueClaim, len(live))
 		for _, c := range live {
 			if c.Issue <= 0 || c.Repo == "" {
 				continue
 			}
-			next[c.Key()] = c
+			l.insertLocked(c)
 		}
-		l.claims = next
 		return
 	}
 	for _, c := range live {
 		if c.Issue <= 0 || c.Repo == "" {
 			continue
 		}
-		l.claims[c.Key()] = c
+		l.insertLocked(c)
 	}
-	l.prune()
+	l.pruneLocked()
 }
 
-// prune drops entries older than the TTL. It runs on the non-authoritative
-// path so a permanently-failing API cannot pin a stale claim forever.
-func (l *ClaimLedger) prune() {
+// pruneLocked drops entries older than the TTL. It runs on the
+// non-authoritative path so a permanently-failing API cannot pin a stale claim
+// forever. Callers must hold l.mu.
+func (l *ClaimLedger) pruneLocked() {
 	cutoff := l.now().Add(-l.ttl)
 	for k, c := range l.claims {
 		if c.ObservedAt.Before(cutoff) {
@@ -510,7 +566,7 @@ type RedStaleFunc func(prRepo string, prNumber int) bool
 // and returns the number of issues suppressed. A nil result or nil ledger is a
 // no-op, so callers need no extra guards.
 func FilterClaimedIssues(result *ActionableResult, ledger *ClaimLedger, redStale RedStaleFunc, logger *slog.Logger) int {
-	if result == nil || ledger == nil || len(ledger.claims) == 0 {
+	if result == nil || ledger == nil || ledger.Len() == 0 {
 		return 0
 	}
 	kept := make([]Issue, 0, len(result.Issues.Items))
@@ -518,6 +574,15 @@ func FilterClaimedIssues(result *ActionableResult, ledger *ClaimLedger, redStale
 	for _, issue := range result.Issues.Items {
 		claim, ok := ledger.Lookup(issue.Repo, issue.Number)
 		if !ok {
+			kept = append(kept, issue)
+			continue
+		}
+		// #3768: an EXTERNAL claim (a PR the hive did not author) never
+		// suppresses agent work — that is the guard's original rule, kept
+		// intact so a stranger's junk PR cannot freeze the hive's own
+		// pipeline. External claims exist for the contribute queue, which
+		// consults the ledger directly (dashboard selectTask).
+		if claim.ExternalAuthor {
 			kept = append(kept, issue)
 			continue
 		}
@@ -593,7 +658,7 @@ func ApplyDuplicatePRGuard(
 	if err != nil && logger != nil {
 		logger.Warn("duplicate-PR guard: claim fetch failed, falling back to persisted ledger (fail closed)",
 			"error", err,
-			"cached_claims", len(ledger.claims),
+			"cached_claims", ledger.Len(),
 		)
 	}
 	ledger.Reconcile(live, authoritative)
@@ -605,7 +670,7 @@ func ApplyDuplicatePRGuard(
 	suppressed := FilterClaimedIssues(result, ledger, redStale, logger)
 	if logger != nil {
 		logger.Info("duplicate-PR guard applied",
-			"claims", len(ledger.claims),
+			"claims", ledger.Len(),
 			"suppressed", suppressed,
 			"authoritative", authoritative,
 		)

--- a/v2/pkg/github/prclaims_test.go
+++ b/v2/pkg/github/prclaims_test.go
@@ -277,6 +277,24 @@ func TestFilterClaimedIssues(t *testing.T) {
 			wantRemaining:  []int{100},
 		},
 		{
+			// #3768 invariant preserved: an EXTERNAL claim (a contributor's PR)
+			// never suppresses agent work — only the contribute queue honours
+			// it. The hive-claim cases above are the positive control proving
+			// suppression still works when the claim IS hive-authored.
+			name:  "external claim never suppresses agent work",
+			items: []Issue{{Repo: "spyre-inference", Number: 100, AgeMinutes: 5}},
+			claims: []IssueClaim{{
+				Repo: "spyre-inference", Issue: 100,
+				PRNumber: 900, PRRepo: "spyre-inference",
+				PRURL:          "https://github.com/torch-spyre/spyre-inference/pull/900",
+				PRAuthor:       "outside-dev",
+				ObservedAt:     time.Now(),
+				ExternalAuthor: true,
+			}},
+			wantSuppressed: 0,
+			wantRemaining:  []int{100},
+		},
+		{
 			name: "SLA violations are recounted after suppression",
 			items: []Issue{
 				{Repo: "spyre-inference", Number: 100, AgeMinutes: slaThresholdMinutes + 1},
@@ -592,30 +610,40 @@ func TestFetchClaims(t *testing.T) {
 		prs        []map[string]any
 		identity   HiveIdentity
 		wantIssues []int
+		// wantExternal[i] is claim[i]'s expected ExternalAuthor flag (#3768):
+		// false for a hive-authored PR, true for anyone else's.
+		wantExternal []bool
 	}{
 		{
-			name:       "hive-authored PR with Fixes claims the issue",
-			prs:        []map[string]any{pr(423, "clubanderson", "fix the thing", "Fixes #100")},
-			identity:   HiveIdentity{AIAuthor: "clubanderson"},
-			wantIssues: []int{100},
+			name:         "hive-authored PR with Fixes claims the issue",
+			prs:          []map[string]any{pr(423, "clubanderson", "fix the thing", "Fixes #100")},
+			identity:     HiveIdentity{AIAuthor: "clubanderson"},
+			wantIssues:   []int{100},
+			wantExternal: []bool{false},
 		},
 		{
-			name:       "claim in the title is honoured",
-			prs:        []map[string]any{pr(424, "clubanderson", "Closes #101 — fix the thing", "")},
-			identity:   HiveIdentity{AIAuthor: "clubanderson"},
-			wantIssues: []int{101},
+			name:         "claim in the title is honoured",
+			prs:          []map[string]any{pr(424, "clubanderson", "Closes #101 — fix the thing", "")},
+			identity:     HiveIdentity{AIAuthor: "clubanderson"},
+			wantIssues:   []int{101},
+			wantExternal: []bool{false},
 		},
 		{
-			name:       "PR authored by the app bot claims too",
-			prs:        []map[string]any{pr(425, "kubestellar-hive[bot]", "t", "Resolves #102")},
-			identity:   HiveIdentity{AppLogin: "kubestellar-hive[bot]"},
-			wantIssues: []int{102},
+			name:         "PR authored by the app bot claims too",
+			prs:          []map[string]any{pr(425, "kubestellar-hive[bot]", "t", "Resolves #102")},
+			identity:     HiveIdentity{AppLogin: "kubestellar-hive[bot]"},
+			wantIssues:   []int{102},
+			wantExternal: []bool{false},
 		},
 		{
-			name:       "PR from a human contributor never claims",
-			prs:        []map[string]any{pr(426, "outside-dev", "t", "Fixes #103")},
-			identity:   HiveIdentity{AIAuthor: "clubanderson"},
-			wantIssues: nil,
+			// #3768: a human contributor's PR now claims its issue too — marked
+			// external so FilterClaimedIssues can keep ignoring it for agent
+			// work while the contribute queue honours it.
+			name:         "PR from a human contributor claims, marked external",
+			prs:          []map[string]any{pr(426, "outside-dev", "t", "Fixes #103")},
+			identity:     HiveIdentity{AIAuthor: "clubanderson"},
+			wantIssues:   []int{103},
+			wantExternal: []bool{true},
 		},
 		{
 			name:       "PR with no issue reference claims nothing (the #443 gap)",
@@ -630,8 +658,9 @@ func TestFetchClaims(t *testing.T) {
 				pr(426, "outside-dev", "b", "Fixes #200"),
 				pr(427, "clubanderson", "c", "Closes #101"),
 			},
-			identity:   HiveIdentity{AIAuthor: "clubanderson"},
-			wantIssues: []int{100, 101},
+			identity:     HiveIdentity{AIAuthor: "clubanderson"},
+			wantIssues:   []int{100, 200, 101},
+			wantExternal: []bool{false, true, false},
 		},
 		{
 			name:       "no open PRs at all",
@@ -659,6 +688,10 @@ func TestFetchClaims(t *testing.T) {
 				}
 				if claims[i].PRURL == "" {
 					t.Errorf("claim[%d] missing PRURL — suppression logs would be undebuggable", i)
+				}
+				if i < len(tt.wantExternal) && claims[i].ExternalAuthor != tt.wantExternal[i] {
+					t.Errorf("claim[%d].ExternalAuthor = %v, want %v (author %q)",
+						i, claims[i].ExternalAuthor, tt.wantExternal[i], claims[i].PRAuthor)
 				}
 			}
 		})
@@ -831,5 +864,93 @@ func TestFilterClaimedIssues_NilRedStalePreservesSuppression(t *testing.T) {
 	}
 	if result.Issues.Count != 0 {
 		t.Fatalf("claimed issue must be suppressed with nil predicate; got %+v", result.Issues.Items)
+	}
+}
+
+// TestClaimLedgerHivePrecedence: when the same issue is claimed by both a
+// hive-authored PR and an external contributor's PR (#3768), the hive claim
+// must win the ledger slot in EITHER arrival order — otherwise an external PR
+// racing the map insert would blind FilterClaimedIssues (which honours only
+// hive claims) and re-open the very duplicate-PR hole the guard exists for.
+func TestClaimLedgerHivePrecedence(t *testing.T) {
+	hive := IssueClaim{
+		Repo: "r", Issue: 1, PRNumber: 10, PRRepo: "r",
+		PRURL: "hive-pr", PRAuthor: "clubanderson", ObservedAt: time.Now(),
+	}
+	external := IssueClaim{
+		Repo: "r", Issue: 1, PRNumber: 20, PRRepo: "r",
+		PRURL: "ext-pr", PRAuthor: "outside-dev", ObservedAt: time.Now(),
+		ExternalAuthor: true,
+	}
+
+	t.Run("authoritative, hive first", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{hive, external}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.ExternalAuthor || got.PRNumber != 10 {
+			t.Fatalf("hive claim must win, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("authoritative, external first", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{external, hive}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.ExternalAuthor || got.PRNumber != 10 {
+			t.Fatalf("hive claim must win regardless of order, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("non-authoritative refresh cannot demote a hive claim", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{hive}, true)
+		l.Reconcile([]IssueClaim{external}, false)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.ExternalAuthor || got.PRNumber != 10 {
+			t.Fatalf("partial fetch must not replace a hive claim with an external one, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("external-only claim is still recorded", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{external}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || !got.ExternalAuthor || got.PRNumber != 20 {
+			t.Fatalf("external claim must be present for the contribute queue, got %+v (ok=%v)", got, ok)
+		}
+	})
+}
+
+// TestClaimLedgerBackCompatPreThreeSevenSixEight: a ledger written before
+// #3768 has no external_author field. Every entry it holds was by definition
+// hive-authored (the old FetchClaims recorded nothing else), so it must load
+// as hive-authored (ExternalAuthor=false) and KEEP suppressing agent work
+// across the upgrade — positive control included.
+func TestClaimLedgerBackCompatPreThreeSevenSixEight(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pr-claims.json")
+	oldFormat := fmt.Sprintf(`{
+  "saved_at": %[1]q,
+  "claims": [
+    {"repo": "r", "issue": 1, "pr_number": 10, "pr_repo": "r",
+     "pr_url": "u", "pr_author": "clubanderson", "observed_at": %[1]q}
+  ]
+}`, time.Now().Format(time.RFC3339Nano))
+	if err := os.WriteFile(path, []byte(oldFormat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := LoadClaimLedger(path, testLogger())
+	if err != nil {
+		t.Fatalf("old-format ledger must load cleanly: %v", err)
+	}
+	claim, ok := l.Lookup("r", 1)
+	if !ok {
+		t.Fatal("old-format claim must survive the load")
+	}
+	if claim.ExternalAuthor {
+		t.Fatal("pre-#3768 claim must read as hive-authored, not external")
+	}
+
+	// Positive control: it must still suppress agent work after the upgrade.
+	result := &ActionableResult{Issues: IssueResult{Count: 1, Items: []Issue{{Repo: "r", Number: 1}}}}
+	if got := FilterClaimedIssues(result, l, nil, testLogger()); got != 1 {
+		t.Fatalf("upgraded ledger stopped suppressing: got %d, want 1", got)
 	}
 }


### PR DESCRIPTION
## Problem

Hive kept assigning the same issue to multiple people: projectbluefin/dakota#353 accumulated duplicate PRs from several contributors, each dispatched to the same issue by the contribute queue.

## Root cause

Two guards exist, and the incident fell exactly between them:

1. **The duplicate-PR claim guard** (`pkg/github/prclaims.go`, wired into the eval cycle) parses `Fixes #N` / `Closes #N` out of open PRs and drops claimed issues from the actionable set — but it only recorded claims from **hive-authored** PRs (`identity.Matches` skipped everyone else by design). Contribute-portal contributors open PRs from their **own accounts**, so their open PR never suppressed the issue.
2. **The contribute path's own guards**: the live-connection scan only protects an issue while the assignee's WebSocket is connected, and the post-completion cooldown only starts when the relay reports a *verified* `task_complete` with the PR URL. When that report is missed or downgraded (relay scrape failure, disconnect, verification error), the issue falls into the short **4h no-PR cooldown** — after which it is re-offered to the next contributor even though the fix PR is sitting open on GitHub. One duplicate PR per window.

## Fix

- `FetchClaims` now records claims from **all** open PRs, marking non-hive authors with a new `ExternalAuthor` flag. When the same issue is claimed by both a hive PR and an external PR, the hive claim wins the ledger slot (either arrival order, both reconcile paths), so the agent-side filter can never be blinded.
- `FilterClaimedIssues` (agent kick path) keeps its original invariant: **external claims never suppress agent work**, so a stranger's junk PR still cannot freeze the hive's own pipeline. Test added with a positive control.
- `selectTask` (contribute queue) consults the ledger through a new `Dependencies.IssueClaimed` hook and skips **any** claimed issue — hive-authored or external — trying both the org-qualified (`owner/repo`) and bare config-form repo keys. The claim check is inside the existing `selectMu` critical section, so offer→claim stays atomic (#2644 semantics preserved).
- `ClaimLedger` gains an internal `RWMutex`: previously single-goroutine (eval cycle), it is now also read by contribute WS goroutines.
- Backward compatible: ledgers written before this change carry no `external_author` field and unmarshal as hive-authored, so existing agent-side suppression survives the upgrade (regression test included).

## Tests

- `pkg/github`: external claims recorded + flagged; mixed-authorship ordering; hive-precedence in both reconcile modes; external claim never suppresses agent work (with hive-claim positive control); pre-upgrade ledger back-compat.
- `pkg/dashboard`: #3768 replay — claimed issue skipped and next candidate offered; all-claimed yields `no_matching_work`; bare repo-name claim key honoured; nil hook leaves selection byte-for-byte unchanged.

Fixes #3768
