### PR TITLE
🔒 v4: complete npm supply-chain hardening port from v2 #3756

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -167,7 +167,8 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
 # 1.0.78 npm wrapper only spawns the platform binary — deleting it now
 # breaks the CLI outright instead of triggering a fallback.
 ARG COPILOT_VERSION=1.0.78
-RUN npm install -g @github/copilot@${COPILOT_VERSION} && npm cache clean --force || \
+RUN npm install -g --ignore-scripts --no-fund --no-audit \
+    "@github/copilot@${COPILOT_VERSION}" && npm cache clean --force || \
     echo "WARN: GitHub Copilot CLI install failed — skipping"
 
 # --- Layer 3b: GitHub Copilot SDK (pinned; powers SDK-based model discovery) ---
@@ -179,7 +180,8 @@ RUN npm install -g @github/copilot@${COPILOT_VERSION} && npm cache clean --force
 # reject the proxy CA). Tolerant of failure like the copilot layer: discovery
 # falls back to the raw HTTP probe when the SDK is absent.
 ARG COPILOT_SDK_VERSION=1.0.8
-RUN npm install -g @github/copilot-sdk@${COPILOT_SDK_VERSION} && npm cache clean --force || \
+RUN npm install -g --ignore-scripts --no-fund --no-audit \
+    "@github/copilot-sdk@${COPILOT_SDK_VERSION}" && npm cache clean --force || \
     echo "WARN: GitHub Copilot SDK install failed — skipping"
 
 # --- Layer 4: OpenAI Codex CLI (pinned; backend: codex + live model discovery) ---
@@ -226,7 +228,8 @@ RUN ARCH="${TARGETARCH:-$(dpkg --print-architecture)}" && \
 # backend: pi simply won't launch if this is absent, same degradation as
 # any other missing backend binary.
 ARG PI_VERSION=0.84.1
-RUN npm install -g @earendil-works/pi-coding-agent@${PI_VERSION} && npm cache clean --force || \
+RUN npm install -g --ignore-scripts --no-fund --no-audit \
+    "@earendil-works/pi-coding-agent@${PI_VERSION}" && npm cache clean --force || \
     echo "WARN: pi CLI install failed — skipping"
 
 # --- Layer 9: Bob CLI (IBM bobshell — backend: bob) ---
@@ -354,7 +357,7 @@ RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null 
     echo "WARN: spec-kit (specify-cli) install failed — inception will generate facts without it"
 # pluk (TypeScript): structured event streaming for AI agent tmux sessions
 ARG PLUK_VERSION=0.8.0
-RUN npm install -g @kubestellar/pluk@${PLUK_VERSION} && npm cache clean --force
+RUN npm install -g --ignore-scripts --no-fund --no-audit "@kubestellar/pluk@${PLUK_VERSION}" && npm cache clean --force
 RUN mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
     chown dev:node /var/run/pluk/logs /var/run/pluk/commands && \
     chmod 2770 /var/run/pluk/logs /var/run/pluk/commands


### PR DESCRIPTION
## Summary
Completes the v4 port of v2's #3756 (npm supply-chain hardening), following the same style already applied by #3787 and #3772 for `@openai/codex` and `@anthropic-ai/claude-code`.

v2 #3756 added `--ignore-scripts --no-fund --no-audit` to the `@github/copilot`, `@github/copilot-sdk`, and `@kubestellar/pluk`/pi-coding-agent npm install layers, but this was never ported to v4. This PR hardens the remaining unhardened `npm install -g` layers in `v2/Dockerfile` on the v4 branch:

- `@github/copilot` (Layer 3)
- `@github/copilot-sdk` (Layer 3b)
- `@earendil-works/pi-coding-agent` (Layer 8.5, the v4 equivalent of v2's pi/pluk layer)
- `@kubestellar/pluk`

## Not touched (out of scope, matches v2 #3756)
- `@openai/codex` / `@anthropic-ai/claude-code` (already hardened by #3787/#3772)
- `Dockerfile.contributor`'s combined claude/copilot/codex block and its pi-coding-agent layer (already hardened by #3787)
- bobshell install (tarball, not a registry package — already SHA-256 verified)
- the internal `/opt/hive/proxy` `npm install --omit=dev` (local package, not a public registry install)

## Testing
Dockerfile-only change; relying on CI's docker/build checks to validate.