### PR TITLE
🐛 fix(hub): unbreak upgrade-pill/badge agreement tests (_releaseChannels harness stub, #3771 regression)

### DIFF
--- a/v2/pkg/hub/upgrade_filter_agreement_test.go
+++ b/v2/pkg/hub/upgrade_filter_agreement_test.go
@@ -89,6 +89,15 @@ func upgradeHarness(t *testing.T) string {
 		"var _latestSHAs = {};",
 		"var _upgradingHives = {};",
 		"var _switchStartedAt = {};",
+		// hiveSwitchState reads the release-channel list to recognize a
+		// channel-name target ("stable") as a switch that survives a page
+		// refresh (added in #3771 for durable channel switches). In the
+		// browser _releaseChannels is declared at page scope and seeded from
+		// the dashboard poll; here the extracted function closes over it too,
+		// so the harness must declare it or node throws ReferenceError before
+		// any predicate runs. None of these fixtures targets a channel, so the
+		// empty list is the correct default — the switch branch is not taken.
+		"var _releaseChannels = [];",
 		jsFunc(t, "sameShaJS"),
 		jsFunc(t, "hiveSwitchState"),
 		jsFunc(t, "hiveIsUpgradingNow"),


### PR DESCRIPTION
## Problem

On `v4`, two hub tests fail — pre-existing, unrelated to the #3760 image work, but blocking the urgent #3794 whose CI-file changes re-trigger the path-gated `test` workflow:

- `TestUpgradingPredicateCases` — sub-cases `armed_latch_in_flight`, `behind_branch_tip_with_an_armed_target,_no_latch_yet`, `behind_with_auto-upgrade_on_and_a_target:_queued,_not_upgrading`, `latest_unresolved`
- `TestPillAndBadgeAgree` — same four sub-cases

Each failed with:

```
ReferenceError: _releaseChannels is not defined
    at hiveSwitchState ([eval]:24:36)
    at normalizeUpgradeState ...
```

## Root cause — stale test, not a production bug

These tests deliberately execute the **real shipped** `hiveSwitchState` / `hiveIsUpgradingNow` / `normalizeUpgradeState` JS out of `dashboardHTML` under node (rather than re-implementing them in Go), against a hand-built global scope (`upgradeHarness`).

Commit **`4d9c11c1` (#3771)** — *"make channel switches durable across hub restarts"* — added a `_releaseChannels` read to `hiveSwitchState` so a channel-name target (e.g. `"stable"`) is still recognized as an in-flight switch after a page refresh (client sentinel gone). In the browser `_releaseChannels` is declared at page scope (`saas.go:10219`) and seeded from the dashboard poll, so the production code is correct and the pill/badge agreement invariant is intact.

The **test harness** was not updated to declare that global, so node threw `ReferenceError` before any predicate could run — failing exactly the four fixtures whose code paths reach `hiveSwitchState`. The source's `(_releaseChannels || [])` guard protects against a null/undefined *value*; it cannot protect against an *undeclared identifier* under node's `-e`.

## Per-case verdict

| Case | Verdict | Fix |
|------|---------|-----|
| `armed_latch_in_flight` | Stale harness (ReferenceError) | Declare `_releaseChannels` global |
| `behind_branch_tip_with_an_armed_target,_no_latch_yet` | Stale harness | same |
| `behind_with_auto-upgrade_on_and_a_target:_queued,_not_upgrading` | Stale harness | same |
| `latest_unresolved` | Stale harness | same |

No production logic was wrong; **no case was a genuine pill-vs-badge disagreement**. The four passing cases (positive control `at_latest,_nothing_armed`, `branch_switch_in_flight`, `just-clicked_sentinel`) never reach the missing global and were unaffected.

## Fix

Add `var _releaseChannels = [];` to the harness globals with a comment explaining the dependency. None of the fixtures targets a channel, so the empty list is the correct default and the switch branch is not taken — the fix restores the harness's simulated page scope without loosening any assertion.

## Verification (ran locally — targeted `go test`, not a build/lint/docker gate)

```
go test ./pkg/hub/ -run 'TestUpgradingPredicateCases|TestPillAndBadgeAgree|TestSentinelExpiryIsOrderIndependent|TestRowLoopDoesNotMutateUpgradeSentinels' -count=1
ok  github.com/kubestellar/hive/v2/pkg/hub
```

All seven sub-cases in each test pass; the sibling harness-sharing tests still pass; `gofmt` clean.

Unblocks the urgent #3760 fix (#3794).