### PR TITLE
🔒 v2/Dockerfile.contributor: pin debian:bookworm-slim base image by digest

### DIFF
--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -1,6 +1,16 @@
 # Contributor image for ClankeR, the contributor relay: a CLI agent plus the
 # WebSocket client that pulls tasks from a Hive hub.
-FROM debian:bookworm-slim
+#
+# Base image is pinned by digest (multi-arch index, covers amd64+arm64) for
+# supply-chain safety (issue #3746) so a compromised/republished bookworm-slim
+# tag cannot silently change what CI builds. To refresh after a legitimate
+# Debian security update, resolve the current index digest with:
+#   TOK=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/debian:pull" | jq -r .token)
+#   curl -sI -H "Authorization: Bearer $TOK" \
+#     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+#     https://registry-1.docker.io/v2/library/debian/manifests/bookworm-slim | grep -i docker-content-digest
+# and swap it in below, keeping the tag for readability.
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 ARG NODE_MAJOR=24
 


### PR DESCRIPTION
Fixes #3746

Pins `v2/Dockerfile.contributor`'s `FROM debian:bookworm-slim` to the current multi-arch index digest so a republished or compromised tag can't silently change what CI builds for amd64/arm64.

- Resolved via anonymous Docker Hub auth against `registry-1.docker.io`, requesting both OCI index and Docker manifest-list media types, and using the `docker-content-digest` response header — confirmed to be the multi-arch index digest (not a per-arch manifest digest).
- Digest: `sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241`
- Tag kept alongside the digest for readability, plus a comment documenting how to resolve a fresh digest when the base image needs a refresh.
- Checked the rest of the file for other unpinned `FROM` lines — there are none; this file has a single base image.
- Scoped to `v2/Dockerfile.contributor` only. `v2/Dockerfile` and `Dockerfile.hub` are intentionally untouched (tracked separately by #3734).

No local build performed; CI's build-contributor checks (amd64 + arm64) validate the pin.