### PR TITLE
🔒 Fail closed on /metrics when HIVE_METRICS_TOKEN is unset

### DIFF
--- a/v2/pkg/dashboard/history_endpoints_coverage_test.go
+++ b/v2/pkg/dashboard/history_endpoints_coverage_test.go
@@ -52,8 +52,12 @@ func TestHandleMetricsWithCollector(t *testing.T) {
 	deps.Tokens = tokens.NewCollector(t.TempDir(),
 		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
 
+	// A bearer token is mandatory (#3785) — handleMetrics fails closed without it.
+	t.Setenv("HIVE_METRICS_TOKEN", "cov-metrics-token")
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer cov-metrics-token")
 	rec := httptest.NewRecorder()
-	s.handleMetrics(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	s.handleMetrics(rec, req)
 	if rec.Code != http.StatusOK && rec.Code != 0 {
 		t.Fatalf("metrics status = %d", rec.Code)
 	}

--- a/v2/pkg/dashboard/metrics_prometheus.go
+++ b/v2/pkg/dashboard/metrics_prometheus.go
@@ -20,11 +20,12 @@ func metricsEnabled() bool {
 	return false
 }
 
-// metricsToken returns the optional bearer token that guards /metrics. When set
+// metricsToken returns the bearer token that guards /metrics. When set
 // (HIVE_METRICS_TOKEN), the endpoint requires "Authorization: Bearer <token>";
-// when empty, /metrics stays open (backward-compatible — existing scrapers keep
-// working). Configure a token AND point Prometheus at it via bearer_token to
-// stop the endpoint from leaking cost/agent data to anyone on the pod network.
+// point Prometheus at it via bearer_token. The token is REQUIRED whenever
+// metrics are enabled: with HIVE_METRICS_ENABLED set but no token configured,
+// handleMetrics fails closed (403) instead of serving the cost/agent series to
+// anyone on the pod network (#3785).
 func metricsToken() string {
 	return strings.TrimSpace(os.Getenv("HIVE_METRICS_TOKEN"))
 }
@@ -49,16 +50,21 @@ func metricsToken() string {
 //	hive_model_input_tokens_total{hive_id,model}    — per-model input tokens
 //	hive_model_output_tokens_total{hive_id,model}   — per-model output tokens
 func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
-	// Optional bearer auth (#3399): when HIVE_METRICS_TOKEN is set, /metrics
-	// requires "Authorization: Bearer <token>" so the cost/agent series aren't
-	// readable by anyone on the pod network. Empty token = open, as before.
-	if want := metricsToken(); want != "" {
-		got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-		if !secureCompare(got, want) {
-			w.Header().Set("WWW-Authenticate", `Bearer realm="hive-metrics"`)
-			http.Error(w, "metrics require a bearer token", http.StatusUnauthorized)
-			return
-		}
+	// Mandatory bearer auth (#3399, hardened in #3785): the cost/agent series
+	// are business-sensitive, so /metrics FAILS CLOSED when metrics are enabled
+	// without a token — enabling HIVE_METRICS_ENABLED alone no longer exposes
+	// the data unauthenticated. Operators must also set HIVE_METRICS_TOKEN and
+	// configure the scraper's bearer_token to match.
+	want := metricsToken()
+	if want == "" {
+		http.Error(w, "metrics are enabled (HIVE_METRICS_ENABLED) but no HIVE_METRICS_TOKEN is configured; refusing to serve cost/agent metrics unauthenticated", http.StatusForbidden)
+		return
+	}
+	got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !secureCompare(got, want) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="hive-metrics"`)
+		http.Error(w, "metrics require a bearer token", http.StatusUnauthorized)
+		return
 	}
 
 	est := s.estimatedCost()

--- a/v2/pkg/dashboard/metrics_prometheus_test.go
+++ b/v2/pkg/dashboard/metrics_prometheus_test.go
@@ -26,9 +26,13 @@ func TestHandleMetricsExposition(t *testing.T) {
 	s := covApiServer(t)
 	s.deps.Config.HiveID = "test-hive"
 	// The route is only registered when metrics are enabled, so exercise the
-	// handler directly — the exposition format is what's under test.
+	// handler directly — the exposition format is what's under test. A token is
+	// mandatory (#3785), so authenticate.
+	t.Setenv("HIVE_METRICS_TOKEN", "sk-metrics")
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer sk-metrics")
 	rec := httptest.NewRecorder()
-	s.handleMetrics(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	s.handleMetrics(rec, req)
 	body := rec.Body.String()
 	for _, want := range []string{
 		"# TYPE hive_estimated_cost_usd_total counter",
@@ -44,9 +48,9 @@ func TestHandleMetricsExposition(t *testing.T) {
 	}
 }
 
-// TestHandleMetricsBearerToken covers the optional HIVE_METRICS_TOKEN gate
-// (#3399): open when unset (backward-compatible), and requires a matching
-// Bearer token when set.
+// TestHandleMetricsBearerToken covers the mandatory HIVE_METRICS_TOKEN gate
+// (#3399, hardened in #3785): fails closed (403) when no token is configured,
+// and requires a matching Bearer token when set.
 func TestHandleMetricsBearerToken(t *testing.T) {
 	newRec := func(auth string) *httptest.ResponseRecorder {
 		s := covApiServer(t)
@@ -60,10 +64,19 @@ func TestHandleMetricsBearerToken(t *testing.T) {
 		return rec
 	}
 
-	t.Run("no token configured stays open", func(t *testing.T) {
+	t.Run("no token configured fails closed", func(t *testing.T) {
+		// SECURITY (#3785): enabling metrics without HIVE_METRICS_TOKEN must
+		// NOT expose the cost/agent series — the handler refuses to serve.
 		t.Setenv("HIVE_METRICS_TOKEN", "")
-		if rec := newRec(""); rec.Code != http.StatusOK {
-			t.Errorf("unauthenticated /metrics with no token = %d, want 200", rec.Code)
+		rec := newRec("")
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("unauthenticated /metrics with no token = %d, want 403", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "hive_estimated_cost_usd") {
+			t.Error("fail-closed response must not include the cost exposition")
+		}
+		if !strings.Contains(rec.Body.String(), "HIVE_METRICS_TOKEN") {
+			t.Error("fail-closed response should name HIVE_METRICS_TOKEN so the operator knows the fix")
 		}
 	})
 
@@ -93,6 +106,57 @@ func TestHandleMetricsBearerToken(t *testing.T) {
 		}
 		if !strings.Contains(rec.Body.String(), "hive_estimated_cost_usd_total") {
 			t.Error("authenticated /metrics should return the exposition")
+		}
+	})
+}
+
+// TestMetricsRouteRegistration exercises /metrics end-to-end through the mux:
+// the route only exists when HIVE_METRICS_ENABLED is set at server
+// construction (404 otherwise), and the registered route enforces the
+// mandatory HIVE_METRICS_TOKEN gate (#3785).
+func TestMetricsRouteRegistration(t *testing.T) {
+	serve := func(t *testing.T, auth string) *httptest.ResponseRecorder {
+		t.Helper()
+		s := covApiServer(t) // registerCoreRoutes runs here, reading the env
+		s.deps.Config.HiveID = "test-hive"
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		if auth != "" {
+			req.Header.Set("Authorization", auth)
+		}
+		rec := httptest.NewRecorder()
+		s.mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("disabled means no route", func(t *testing.T) {
+		t.Setenv("HIVE_METRICS_ENABLED", "")
+		t.Setenv("HIVE_METRICS_TOKEN", "")
+		if rec := serve(t, ""); rec.Code != http.StatusNotFound {
+			t.Errorf("/metrics while disabled = %d, want 404", rec.Code)
+		}
+	})
+
+	t.Run("enabled without token fails closed", func(t *testing.T) {
+		t.Setenv("HIVE_METRICS_ENABLED", "1")
+		t.Setenv("HIVE_METRICS_TOKEN", "")
+		rec := serve(t, "")
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("/metrics enabled w/o token = %d, want 403", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "hive_estimated_cost_usd") {
+			t.Error("fail-closed route must not leak the cost exposition")
+		}
+	})
+
+	t.Run("enabled with token serves authenticated scrape", func(t *testing.T) {
+		t.Setenv("HIVE_METRICS_ENABLED", "1")
+		t.Setenv("HIVE_METRICS_TOKEN", "sk-route")
+		rec := serve(t, "Bearer sk-route")
+		if rec.Code != http.StatusOK {
+			t.Errorf("authenticated scrape = %d, want 200", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "hive_estimated_cost_usd_total") {
+			t.Error("authenticated scrape should return the exposition")
 		}
 	})
 }

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -779,11 +779,15 @@ func (s *Server) registerCoreRoutes() {
 	s.mux.HandleFunc("GET /api/health", s.handleHealth)
 	s.mux.HandleFunc("GET /api/health/deep", s.handleHealthDeep)
 	s.mux.HandleFunc("GET /api/livez", s.handleLivez)
-	// Prometheus scrape endpoint for estimated LLM cost — opt-in, since it
-	// exposes cost data unauthenticated (Prometheus can't do device-flow auth).
-	// Enabled only when HIVE_METRICS_ENABLED is truthy; see isPublicPath.
+	// Prometheus scrape endpoint for estimated LLM cost — opt-in via
+	// HIVE_METRICS_ENABLED, and the handler additionally requires the
+	// HIVE_METRICS_TOKEN bearer token (fails closed with 403 when the token is
+	// unset, #3785) since the series expose cost/agent data. See isPublicPath.
 	if metricsEnabled() {
 		s.mux.HandleFunc("GET /metrics", s.handleMetrics)
+		if metricsToken() == "" && s.logger != nil {
+			s.logger.Warn("HIVE_METRICS_ENABLED is set but HIVE_METRICS_TOKEN is not; /metrics will refuse every request (403) until a token is configured — set HIVE_METRICS_TOKEN and the scraper's bearer_token to match")
+		}
 	}
 	s.mux.HandleFunc("GET /api/status", s.handleStatus)
 	s.mux.HandleFunc("GET /api/events", s.handleSSE)
@@ -1092,8 +1096,11 @@ func isPublicPath(path string) bool {
 	case path == "/api/auth/token":
 		return true
 	case path == "/metrics" && metricsEnabled():
-		// Prometheus scrape target — public only when explicitly enabled via
-		// HIVE_METRICS_ENABLED. Prometheus cannot authenticate via device flow.
+		// Prometheus scrape target — bypasses dashboard auth only when
+		// explicitly enabled via HIVE_METRICS_ENABLED (Prometheus cannot
+		// authenticate via device flow). NOT actually open: handleMetrics
+		// requires the HIVE_METRICS_TOKEN bearer token and fails closed (403)
+		// when no token is configured (#3785).
 		return true
 	case path == "/snapshot" || strings.HasPrefix(path, "/snapshot/"):
 		return true


### PR DESCRIPTION
## Summary

`/metrics` (opt-in via `HIVE_METRICS_ENABLED`) exposes business-sensitive series — `hive_estimated_cost_usd` per model/agent, token totals, agent identifiers — and the `HIVE_METRICS_TOKEN` bearer guard was optional. An operator who enabled metrics without setting the token served all of that unauthenticated to anyone who could reach the endpoint.

This PR makes the token mandatory whenever metrics are enabled (fail closed):

- `handleMetrics` now returns **403** when `HIVE_METRICS_ENABLED` is set but `HIVE_METRICS_TOKEN` is not, with an error body naming both env vars so the operator knows the fix. The cost/agent exposition is never served without a valid `Authorization: Bearer` token.
- `registerCoreRoutes` logs a **startup warning** naming both env vars when metrics are enabled token-less, so the misconfiguration is visible immediately rather than only at scrape time.
- `isPublicPath` comment updated — the dashboard-auth bypass for `/metrics` is no longer an open door; the handler enforces its own bearer gate.
- Disabled remains 404 (route never registered); enabled+token behavior is unchanged for correctly configured scrapers.

## Why fail-closed rather than serving redacted process metrics

The endpoint's entire surface is the cost/agent estimate — there are no non-sensitive series to fall back to, so a redacted mode would serve an empty exposition while implying the scrape works. Refusing with a self-describing 403 (plus the startup warning) surfaces the misconfiguration instead of hiding it.

## Tests

- enabled + no token → 403, no `hive_estimated_cost_usd` leak, body names `HIVE_METRICS_TOKEN` (positive control on the invariant)
- enabled + wrong/missing bearer → 401 with `WWW-Authenticate` challenge (unchanged)
- enabled + correct bearer → 200 with full exposition (unchanged)
- disabled → 404 through the mux
- new `TestMetricsRouteRegistration` exercises all three states end-to-end through `s.mux`, not just the bare handler

Fixes #3785