### PR TITLE
✨ feat(hub): add "Upgrade state" GROUP BY dimension to hive list

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10611,6 +10611,7 @@ const dashboardHTML = `<!DOCTYPE html>
     var HIVE_GROUP_OWNER = 'owner';
     var HIVE_GROUP_ACMM = 'acmm';
     var HIVE_GROUP_BRANCH = 'branch';
+    var HIVE_GROUP_UPGRADE_STATE = 'upgradeState';
 
     /* Label shown for a hive whose grouping field is empty/unreported. Kept as
        one constant so every dimension buckets blanks identically. */
@@ -10683,8 +10684,54 @@ const dashboardHTML = `<!DOCTYPE html>
         var na = _acmmGroupOrder(a), nb = _acmmGroupOrder(b);
         return na - nb;
       }},
-      {key: HIVE_GROUP_BRANCH, label: 'Branch', of: function(h) { return (h && h.gitBranch) || ''; }}
+      {key: HIVE_GROUP_BRANCH, label: 'Branch', of: function(h) { return (h && h.gitBranch) || ''; }},
+      {key: HIVE_GROUP_UPGRADE_STATE, label: 'Upgrade state', of: function(h) {
+        /* Reuse hiveUpgradeState(h) — the SAME predicate the row's Upgrading
+           pill and the upgrade-state filter facet use (it routes through
+           hiveIsUpgradingNow) — so the group a hive lands in can never disagree
+           with the badge the operator already sees. Do NOT re-derive the states
+           here or the grouping would drift from the pill.
+
+           hiveUpgradeState returns:
+             'upgrading' — a rollout is in flight (h.upgrading / armed target /
+                           branch switch / just-clicked sentinel).
+             'queued'    — behind latest, auto-upgrade ON, hub has not instructed
+                           the rollout yet (ready, not yet triggered). This is
+                           the operator's target bucket.
+             ''          — neither: up to date, or behind with auto-upgrade off
+                           and no pending action.
+           Map each to a human-readable header. '' is rendered as its own
+           "Up to date" group rather than falling through to Unspecified, since
+           for this dimension "no pending upgrade" is a meaningful, expected
+           bucket rather than missing data. */
+        var st = hiveUpgradeState(h);
+        if (st === UPGRADE_FILTER_QUEUED) return HIVE_UPGRADE_GROUP_QUEUED;
+        if (st === UPGRADE_FILTER_UPGRADING) return HIVE_UPGRADE_GROUP_UPGRADING;
+        return HIVE_UPGRADE_GROUP_UPTODATE;
+      }, sort: function(a, b) {
+        /* Queued first — it is why this dimension exists (systems READY for an
+           upgrade that have not triggered) — then Upgrading (in flight), then
+           Up to date. Any unexpected label sorts last. */
+        return _upgradeGroupOrder(a) - _upgradeGroupOrder(b);
+      }}
     ];
+
+    /* Header labels for the Upgrade-state dimension. Named constants so the
+       of() grouper and the sort comparator can never drift on a string typo. */
+    var HIVE_UPGRADE_GROUP_QUEUED = 'Queued (ready, not yet upgrading)';
+    var HIVE_UPGRADE_GROUP_UPGRADING = 'Upgrading';
+    var HIVE_UPGRADE_GROUP_UPTODATE = 'Up to date';
+
+    /* Sort weight for an upgrade-state group header. Queued (the actionable
+       "ready but not triggered" bucket) sorts first, then Upgrading, then Up to
+       date; anything else sorts last. */
+    var UPGRADE_GROUP_UNKNOWN_ORDER = Number.MAX_SAFE_INTEGER;
+    function _upgradeGroupOrder(label) {
+      if (label === HIVE_UPGRADE_GROUP_QUEUED) return 0;
+      if (label === HIVE_UPGRADE_GROUP_UPGRADING) return 1;
+      if (label === HIVE_UPGRADE_GROUP_UPTODATE) return 2;
+      return UPGRADE_GROUP_UNKNOWN_ORDER;
+    }
 
     /* Sort weight for an ACMM group label. "Level N" → N; anything else (the
        Unspecified bucket) sorts after every real level. */


### PR DESCRIPTION
## What

Adds a new **GROUP BY** dimension — **"Upgrade state"** — to the hub dashboard's hive list. It buckets hives by their upgrade lifecycle so an operator can target systems that are **READY for an upgrade but have not triggered one yet** (the **Queued** group).

## How it agrees with the pill (no drift)

The `of(h)` grouper reuses the existing **`hiveUpgradeState(h)`** function verbatim — the *same* predicate the row's **Upgrading pill** and the upgrade-state **filter facet** already use (it routes through `hiveIsUpgradingNow`). Because grouping and the badge read from the identical function, a hive shown as "queued" by the pill is guaranteed to land in the "Queued" group. No second, divergent notion of upgrade state is introduced.

`hiveUpgradeState(h)` classifies a hive as:
- `'queued'` — behind latest, **auto-upgrade ON**, hub has **not instructed the rollout yet** (ready, not triggered)
- `'upgrading'` — a rollout is in flight (`h.upgrading` / armed target / branch switch / just-clicked sentinel)
- `''` — neither (up to date, or behind with auto-upgrade off / no pending action)

## Bucket labels (group headers)

| `hiveUpgradeState` | Header |
|---|---|
| `queued` | **Queued (ready, not yet upgrading)** |
| `upgrading` | **Upgrading** |
| `` (empty) | **Up to date** |

The empty state is rendered as its own **"Up to date"** group rather than falling through to the generic *Unspecified* bucket, because for this dimension "no pending upgrade" is a meaningful, expected state rather than missing data.

## Ordering

A custom `sort` orders groups **Queued → Upgrading → Up to date** (the actionable "ready but not triggered" bucket first, since that is why the dimension exists), following the existing per-dimension `sort` pattern (cf. the ACMM dimension).

## Wiring

- `HIVE_GROUP_UPGRADE_STATE` added as a named key alongside the other dimensions.
- `isGroupByKey` and the `<select>` control both derive from `HIVE_GROUP_DIMENSIONS`, so validation and the picker pick the new dimension up automatically — no separate whitelist to update.

## Scope

- SPA JS lives as strings inside `v2/pkg/hub/saas.go`; only those strings changed (no Go outside the strings). Targets **v4** (v2 unsupported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)