### PR TITLE
🔒 fix(security): add CODEOWNERS for v4 security-sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# CODEOWNERS — mandatory review for security-sensitive files on v4.
+#
+# NOTE: This file is inert until "Require review from Code Owners" is
+# enabled in the v4 branch protection rule. That is deliberately NOT
+# enabled as part of this change — the repo's automation currently merges
+# green PRs without human review, and turning on enforcement here would
+# block that automation. Enabling enforcement is a separate operator
+# decision with workflow implications and should be made explicitly.
+
+# Security-sensitive build and image files
+v2/Dockerfile                       @clubanderson
+v2/Dockerfile.contributor           @clubanderson
+v2/Dockerfile.hub                   @clubanderson
+
+# CI/CD workflows (GITHUB_TOKEN write access, security gates)
+.github/workflows/                  @clubanderson
+
+# Kubernetes deployment, RBAC, and secret manifests
+v2/deploy/                          @clubanderson
+
+# Token-handling and agent launch scripts
+bin/agent-launch.sh                 @clubanderson
+bin/contributor-agent.sh            @clubanderson
+
+# gh CLI wrapper — enforces REAL_GH security-mode gating
+bin/gh-wrapper.sh                   @clubanderson
+
+# Core agent manager (exec construction, su-exec SUID invocation)
+v2/pkg/agent/                       @clubanderson
+
+# Hub key and session/cookie machinery
+v2/pkg/hub/hub_keys.go              @clubanderson
+v2/pkg/hub/hub_cookie.go            @clubanderson


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` on `v4`, mapping security-sensitive paths to the maintainer.

v2 is retired; all code now lives under the `v2/` directory on the `v4` branch, so this file targets the actual v4 tree rather than the old top-level layout.

## Paths covered

- `v2/Dockerfile`, `v2/Dockerfile.contributor`, `v2/Dockerfile.hub` — build/image files
- `.github/workflows/` — CI/CD workflows (GITHUB_TOKEN write access, security gates)
- `v2/deploy/` — Kubernetes deployment, RBAC, and secret manifests
- `bin/agent-launch.sh`, `bin/contributor-agent.sh` — agent launch scripts
- `bin/gh-wrapper.sh` — gh CLI wrapper enforcing `REAL_GH` security-mode gating
- `v2/pkg/agent/` — core agent manager, including `su-exec`/`exec` construction
- `v2/pkg/hub/hub_keys.go`, `v2/pkg/hub/hub_cookie.go` — hub key and session/cookie machinery

All paths were verified to exist on `v4` before inclusion.

## Important caveats

- **This file is inert until "Require review from Code Owners" is enabled in branch protection for `v4`.** Enabling that enforcement is deliberately **not** part of this change: the repo's current automation merges green PRs without human review, and flipping enforcement on here would block that automation. Enabling it is a separate operator decision with workflow implications and should be made explicitly, outside this PR.
- **Supersedes #3797**, which added an equivalent CODEOWNERS file targeting the now-retired `v2` branch.

Fixes #3796
