### PR TITLE
🔒 Pin actions/checkout SHA + add npm dependabot for v2/proxy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,13 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/v2/proxy"
+    target-branch: "v4"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10

--- a/.github/workflows/suid-contract.yml
+++ b/.github/workflows/suid-contract.yml
@@ -36,7 +36,7 @@ jobs:
   contract-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Run SUID + NET_ADMIN static contract check
         run: bash v2/scripts/check-suid-contract.sh v2/Dockerfile v2/deploy/entrypoint.sh


### PR DESCRIPTION
## Summary

- **#3639**: `.github/workflows/suid-contract.yml` used mutable `actions/checkout@v4`. Pinned to the full commit SHA of the current `v4` tag (`11d5960a326750d5838078e36cf38b85af677262`) with the standard `# v4` comment. No other mutable action refs exist in this file.
- **#3663**: `v2/proxy` npm packages (express, http-proxy-middleware) were not monitored by Dependabot. Added an `npm` ecosystem entry to `.github/dependabot.yml` for directory `/v2/proxy`, `target-branch: v4`, weekly schedule, matching the file's existing style.

## Scope

Only `.github/workflows/suid-contract.yml` and `.github/dependabot.yml` were touched. No other workflow files were modified.

Fixes #3639
Fixes #3663
