### PR TITLE
🔒 Pin mutable base image tags (nginx, golang, node) + move hive:latest to stable channel

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,4 +1,11 @@
-FROM golang:1.26-alpine AS builder
+# Pinned to the golang:1.26-alpine multi-arch index digest to prevent
+# floating-tag supply-chain risk. Refresh deliberately:
+#   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/golang:pull" | jq -r .token)
+#   curl -sI -H "Authorization: Bearer $TOKEN" \
+#     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+#     https://registry-1.docker.io/v2/library/golang/manifests/1.26-alpine | grep -i docker-content-digest
+# and update both the tag and the @sha256 digest together.
+FROM golang:1.26-alpine@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS builder
 RUN apk add --no-cache git
 WORKDIR /src
 
@@ -21,7 +28,11 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
 
 
 # --- tmux from source (cached until TMUX_VERSION changes) ---
-FROM node:26-slim AS tmux-builder
+# Pinned to the node:26-slim multi-arch index digest to prevent floating-tag
+# supply-chain risk. Refresh deliberately (same technique as golang above,
+# repo library/node, tag 26-slim) and update both the tag and the @sha256
+# digest together in BOTH FROM node:26-slim lines in this file.
+FROM node:26-slim@sha256:4ebb5ace66f15a24c14c492e01a8beeed4fddf970a856109f5126e703e5fe503 AS tmux-builder
 ARG TARGETARCH
 ARG TMUX_VERSION=3.5a
 ARG TMUX_SHA256_AMD64=16216bd0877170dfcc64157085ba9013610b12b082548c7c9542cc0103198951
@@ -40,7 +51,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && cd /tmp/tmux-${TMUX_VERSION} && ./configure --prefix=/usr/local && make -j$(nproc) && make install \
  && rm -rf /tmp/tmux-${TMUX_VERSION} /tmp/tmux.tar.gz
 
-FROM node:26-slim
+# Pinned to the same node:26-slim digest as the tmux-builder stage above —
+# refresh both FROM lines together.
+FROM node:26-slim@sha256:4ebb5ace66f15a24c14c492e01a8beeed4fddf970a856109f5126e703e5fe503
 
 # --- Layer 1: system packages (rarely changes) ---
 # util-linux provides `setpriv`, used by the entrypoint to drop to `dev` with an

--- a/v2/Dockerfile.hub
+++ b/v2/Dockerfile.hub
@@ -1,4 +1,9 @@
-FROM golang:1.26-alpine AS builder
+# Pinned to the golang:1.26-alpine multi-arch index digest to prevent
+# floating-tag supply-chain risk. Refresh deliberately (same technique as
+# v2/Dockerfile: resolve via auth.docker.io token + HEAD manifest for repo
+# library/golang, tag 1.26-alpine) and update both the tag and the @sha256
+# digest together.
+FROM golang:1.26-alpine@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS builder
 RUN apk add --no-cache git
 WORKDIR /src
 

--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -35,7 +35,17 @@ spec:
         fsGroup: 1002
       containers:
         - name: hive
-          image: hive:latest
+          # Tracks the "stable" release channel rather than the mutable
+          # `:latest` tag. Channels (stable/canary/etc.) are hub-managed and
+          # get retagged to a new, reviewed digest as releases roll out — see
+          # v2/pkg/hub auto-upgrade logic — so pointing at the channel name is
+          # the operator-blessed default. A hard @sha256 digest here would go
+          # stale the moment the channel advances, since nothing on this
+          # manifest re-resolves it. Self-hosted users who want a harder pin
+          # than the channel tag can replace this with a specific
+          # ghcr.io/kubestellar/hive@sha256:<digest> of a release they've
+          # reviewed and are willing to manage upgrades for manually.
+          image: ghcr.io/kubestellar/hive:stable
           # SECURITY: drop the ambient root capability set down to only what the
           # runtime actually needs, and pin the default seccomp profile. This
           # container CANNOT run fully unprivileged: it starts as root to set up

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -1,6 +1,13 @@
 services:
   gateway:
-    image: nginx:alpine
+    # Pinned to the nginx:alpine multi-arch index digest to prevent floating-tag
+    # supply-chain risk (mirrors the watchtower pin below). Refresh deliberately:
+    #   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/nginx:pull" | jq -r .token)
+    #   curl -sI -H "Authorization: Bearer $TOKEN" \
+    #     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+    #     https://registry-1.docker.io/v2/library/nginx/manifests/alpine | grep -i docker-content-digest
+    # and update both the tag and the @sha256 digest together.
+    image: nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
     container_name: hive-gateway
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

Pins mutable third-party base image tags across three separate files, one fix per issue:

- **#3786** — `v2/docker-compose.yaml`: the `gateway` service's `nginx:alpine` tag is mutable. Pinned to the multi-arch index digest, resolved anonymously from Docker Hub (`auth.docker.io` token for `repository:library/nginx:pull`, then a `HEAD` manifest request for tag `alpine` with OCI-index/manifest-list Accept headers, digest read from `docker-content-digest`). Verified the manifest is an `application/vnd.oci.image.index.v1+json` covering `linux/amd64` and `linux/arm64`. Checked the rest of the compose file for other mutable third-party tags — `watchtower` was already digest-pinned, and `ghcr.io/kubestellar/hive:v2-latest` is hive's own image so it keeps its tag.
- **#3734** — `v2/Dockerfile` and `v2/Dockerfile.hub`: `golang:1.26-alpine` and `node:26-slim` (used twice in `v2/Dockerfile` — the `tmux-builder` stage and the final stage) were mutable tags. Pinned each `FROM` to its multi-arch index digest, resolved the same way as above (repos `library/golang`, `library/node`). `v2/Dockerfile.contributor` is untouched (already pinned via #3803), and `v2/Dockerfile.hub`'s `alpine:3.24` final-stage base is untouched (out of scope for this issue).
- **#3680** — `v2/deploy/k8s/deployment.yaml`: the container used mutable `hive:latest`. Changed to the `stable` release channel, `ghcr.io/kubestellar/hive:stable`. A comment explains channels are hub-managed and get retagged to a reviewed digest as releases roll out, so a hard `@sha256` digest here would go stale as soon as the channel advances; self-hosted users wanting a harder pin can swap in a specific digest themselves.

Every pin carries an inline comment with the exact refresh command so a future bump doesn't require re-deriving the technique.

## Digests pinned

| Image | Tag | Digest |
|---|---|---|
| `nginx` | `alpine` | `sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752` |
| `golang` | `1.26-alpine` | `sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816` |
| `node` | `26-slim` | `sha256:4ebb5ace66f15a24c14c492e01a8beeed4fddf970a856109f5126e703e5fe503` |

Fixes #3786
Fixes #3734
Fixes #3680
