### PR TITLE
🔒 fix(agent): chmod agent state file via fd before close (TOCTOU)

### DIFF
--- a/v2/pkg/agent/agent_state_file_test.go
+++ b/v2/pkg/agent/agent_state_file_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -99,6 +101,43 @@ func TestWriteAgentStateFileRefusesSymlink(t *testing.T) {
 	}
 	if string(b) != "ORIGINAL" {
 		t.Fatalf("symlink target was CLOBBERED (now %q) — the write followed the link", b)
+	}
+}
+
+// TestWriteAgentStateFileChmodsViaDescriptor pins the #3175 fix at source
+// level: the mode-tightening step must go through the open descriptor
+// (f.Chmod), never through the pathname after Close. O_NOFOLLOW only proves
+// the path is not a symlink at OPEN time; a path-based os.Chmod issued in the
+// close→chmod window can be redirected by swapping the pathname for a symlink
+// in shared /tmp. The runtime tests above are the positive control that the
+// tightening still happens; this asserts HOW it happens, which no runtime
+// probe can observe reliably (the race window is microseconds).
+func TestWriteAgentStateFileChmodsViaDescriptor(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "manager.go"))
+	if err != nil {
+		t.Fatalf("read manager.go: %v", err)
+	}
+	text := string(body)
+	start := strings.Index(text, "func writeAgentStateFile(")
+	if start < 0 {
+		t.Fatal("writeAgentStateFile not found in manager.go")
+	}
+	end := strings.Index(text[start:], "\n}\n")
+	if end < 0 {
+		t.Fatal("could not delimit writeAgentStateFile body")
+	}
+	fn := text[start : start+end]
+	if !strings.Contains(fn, "f.Chmod(agentStateFileMode)") {
+		t.Fatal("writeAgentStateFile must tighten the mode via the open descriptor (f.Chmod) — " +
+			"see #3175: a path-based chmod after Close can be symlink-swapped")
+	}
+	if strings.Contains(fn, "os.Chmod(") {
+		t.Fatal("writeAgentStateFile must not use path-based os.Chmod — " +
+			"the close→chmod window is symlink-swappable in shared /tmp (#3175)")
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5765,14 +5765,18 @@ func writeAgentStateFile(path string, data []byte) error {
 		f.Close()
 		return err
 	}
-	if err := f.Close(); err != nil {
-		return err
-	}
 	// O_CREATE honours the mode only when the file did not already exist, so an
 	// existing 0644 file from a previous release keeps its old mode without
-	// this. Chmod on the path is acceptable here because O_NOFOLLOW above has
-	// already established it is not a symlink.
-	return os.Chmod(path, agentStateFileMode)
+	// this. Chmod through the still-open descriptor: O_NOFOLLOW only proved the
+	// path was not a symlink at OPEN time, so a path-based os.Chmod after Close
+	// left a window in shared /tmp where the pathname could be swapped for a
+	// symlink and the mode change applied to the link target (TOCTOU, #3175).
+	// f.Chmod acts on the inode we opened, closing that window.
+	if err := f.Chmod(agentStateFileMode); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // SyncModeFiles rewrites /tmp/.hive-mode-* for all running agents to reflect the given ACMM level.


### PR DESCRIPTION
## Summary

`writeAgentStateFile` (v2/pkg/agent/manager.go) tightened permissions with a path-based `os.Chmod` **after** `f.Close()`. The `O_NOFOLLOW` on the open only proves the path was not a symlink at open time — in shared `/tmp` the pathname can be swapped for a symlink in the close→chmod window, redirecting the mode change to any file the process can reach (CWE-367).

## Changes

- Apply the mode through the still-open descriptor (`f.Chmod(agentStateFileMode)`) before `Close`, removing the path-based `os.Chmod`.
- Correct the safety comment, which claimed the path-based chmod was safe because of `O_NOFOLLOW`.
- Add `TestWriteAgentStateFileChmodsViaDescriptor`: a source-level assertion (same style as `TestPiLaunchCommandPassesModelFlag`) that the tightening goes through the descriptor and no path-based `os.Chmod` reappears — the race window itself is not reliably observable at runtime. The existing `TestWriteAgentStateFileTightensExistingMode` is the positive control that the tightening still happens.

This is the only close→path-chmod instance in the file; the sibling `writeInferenceConfigFile` performs no post-close chmod.

## Testing

- `go vet ./pkg/agent/` clean
- `go test -run TestWriteAgentStateFile ./pkg/agent/` — all pass

Fixes #3175