### PR TITLE
🔒 Pin vllm inference image digest and verify model checksum

### DIFF
--- a/v2/deploy/inference/vllm-deployment.yaml
+++ b/v2/deploy/inference/vllm-deployment.yaml
@@ -42,16 +42,34 @@ spec:
             - -c
             - |
               echo "[model-download] Downloading Qwen2.5-0.5B-Instruct GGUF..."
+              # URL is pinned to a specific HF repo revision (commit 9217f5d) rather than
+              # "main" so the artifact cannot change out from under the checksum below.
               curl -L -o /models/qwen2.5-0.5b-instruct-q4_k_m.gguf \
-                "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf"
+                "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/9217f5db79a29953eb74d5343926648285ec7e67/qwen2.5-0.5b-instruct-q4_k_m.gguf"
               ls -lh /models/
+              echo "[model-download] Verifying checksum..."
+              # Expected SHA-256 sourced from the HF LFS metadata (lfs.oid) for this file
+              # at the pinned revision above. To refresh: bump the revision commit and
+              # update this hash from
+              #   curl -s https://huggingface.co/api/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/tree/main
+              echo "74a4da8c9fdbcd15bd1f6d01d621410d31c6fc00986f5eb687824e7b93d7a9db  /models/qwen2.5-0.5b-instruct-q4_k_m.gguf" | sha256sum -c - || {
+                echo "[model-download] Checksum verification FAILED, deleting corrupted file." >&2
+                rm -f /models/qwen2.5-0.5b-instruct-q4_k_m.gguf
+                exit 1
+              }
               echo "[model-download] Done."
           volumeMounts:
             - name: models
               mountPath: /models
       containers:
         - name: llama-server
-          image: ghcr.io/ggml-org/llama.cpp:server
+          # Pinned by digest for supply-chain integrity (the "server" tag is mutable
+          # and moves on every llama.cpp release). To refresh after a deliberate bump:
+          #   TOK=$(curl -s "https://ghcr.io/token?scope=repository:ggml-org/llama.cpp:pull" | jq -r .token)
+          #   curl -sI -H "Authorization: Bearer $TOK" \
+          #     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+          #     "https://ghcr.io/v2/ggml-org/llama.cpp/manifests/server" | grep -i docker-content-digest
+          image: ghcr.io/ggml-org/llama.cpp:server@sha256:c88223e4bd7b7791aac2bb6945dd9b6d6dccdf191b5cabc3a73cee67ffc966ff
           args:
             - "--model"
             - "/models/qwen2.5-0.5b-instruct-q4_k_m.gguf"


### PR DESCRIPTION
## Summary

Hardens `v2/deploy/inference/vllm-deployment.yaml` (v2 directory, v4 branch — v2 base is retired) against two supply-chain integrity gaps:

- **#3799**: The `llama-server` container used the mutable `ghcr.io/ggml-org/llama.cpp:server` tag, which can silently change the running image on any upstream push. Pinned to the current amd64 manifest digest (`sha256:c88223e4bd7b7791aac2bb6945dd9b6d6dccdf191b5cabc3a73cee67ffc966ff`), keeping the tag in the ref for readability. A comment documents how to refresh the pin via the GHCR anonymous token + manifest HEAD flow.
- **#3800**: The init container downloaded the Qwen2.5-0.5B-Instruct GGUF model from HuggingFace with no integrity check. Added SHA-256 verification (`sha256sum -c -`) after download; on mismatch the corrupted file is deleted and the container exits non-zero so a retry re-downloads cleanly. The download URL is also pinned to a specific HF repo revision commit (`9217f5d`) instead of `main`, so the artifact can't drift out from under the embedded checksum. The checksum was sourced from HuggingFace's LFS metadata (`lfs.oid`) for this file at the pinned revision.

## Verification

- GHCR digest resolved via anonymous token + `docker-content-digest` response header for the `server` tag manifest (OCI index).
- Model checksum cross-checked against the HuggingFace Hub API LFS metadata (`tree/main` → `lfs.oid`), which for HF is the file's SHA-256.
- Manifest-only YAML change; no application code touched.

Fixes #3799
Fixes #3800
