### PR TITLE
🔒 fix(dashboard): add noRedirectToPrivate to customStyleClient (SSRF)

### DIFF
--- a/v2/pkg/dashboard/api_leaderboard_style.go
+++ b/v2/pkg/dashboard/api_leaderboard_style.go
@@ -52,7 +52,15 @@ type customStyleSanitizeReport struct {
 var (
 	customStyleCacheMu sync.Mutex
 	customStyleCache   = map[string]customStyleCacheEntry{}
-	customStyleClient  = &http.Client{Timeout: customStyleFetchTTL}
+	// customStyleClient serves the unauthenticated /api/style endpoint. The
+	// fetch URL is always constructed against raw.githubusercontent.com, but
+	// noRedirectToPrivate is applied like every other outbound fetch so a
+	// redirect (or DNS rebinding) can never walk the request to a
+	// private/internal address (SSRF defence-in-depth, #3759).
+	customStyleClient = &http.Client{
+		Timeout:       customStyleFetchTTL,
+		CheckRedirect: noRedirectToPrivate,
+	}
 )
 
 var (

--- a/v2/pkg/dashboard/api_leaderboard_style_test.go
+++ b/v2/pkg/dashboard/api_leaderboard_style_test.go
@@ -22,6 +22,28 @@ func resetLeaderboardStyleTestState(t *testing.T) {
 	})
 }
 
+// TestCustomStyleClient_RefusesRedirectToInternal pins #3759: /api/style is a
+// public endpoint, and customStyleClient was the one outbound client without
+// noRedirectToPrivate — a redirect from the (normally trusted) upstream to a
+// private/internal address would have been followed. Mirrors
+// TestImportClient_RefusesRedirectToInternal.
+func TestCustomStyleClient_RefusesRedirectToInternal(t *testing.T) {
+	stubImportResolver(t, map[string][]string{
+		"metadata.attacker.example": {"169.254.169.254"},
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://metadata.attacker.example/latest/meta-data/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	resp, err := customStyleClient.Get(srv.URL)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("customStyleClient followed a redirect to an internal host (SSRF); " +
+			"it must carry noRedirectToPrivate like every other outbound client")
+	}
+}
+
 func TestValidateLeaderboardCustomStyleSource(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

`customStyleClient` (v2/pkg/dashboard/api_leaderboard_style.go), which serves the unauthenticated public `/api/style` endpoint, was the only outbound HTTP client in the dashboard defined without the `noRedirectToPrivate` `CheckRedirect` guard. Every other user-influenced fetch (`importFetchURL`, gateway model probes, agent endpoint clients) applies it uniformly.

While the fetch URL is always constructed against `raw.githubusercontent.com` (owner/repo/ref/path validated and escaped), an upstream redirect — or DNS rebinding aliasing the domain — would have been followed to a private/internal address without the guard.

## Changes

- Apply `CheckRedirect: noRedirectToPrivate` to `customStyleClient`, the exact idiom used by the other clients, with a comment explaining the defense-in-depth rationale.
- Add `TestCustomStyleClient_RefusesRedirectToInternal`, mirroring `TestImportClient_RefusesRedirectToInternal`: a live `httptest` server 302s to a hostname stub-resolved to `169.254.169.254` and the client must refuse to follow.

## Testing

- `go vet ./pkg/dashboard/` clean; `gofmt` clean on touched files
- `go test -run 'TestCustomStyleClient_RefusesRedirectToInternal|TestImportClient_RefusesRedirectToInternal' ./pkg/dashboard/` — pass

Fixes #3759