### PR TITLE
fix(ci): bust final-stage cache so published hive binary matches source — stale-binary bug

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,7 +102,18 @@ jobs:
           build-args: |
             GIT_HASH=${{ github.sha }}
             GIT_BRANCH=${{ github.ref_name }}
-          no-cache-filters: builder
+          # STALE-BINARY FIX (unblocks the #3760 fix in the SHIPPED image).
+          # The GHA cache scope below is keyed on the platform slug only
+          # (linux-amd64 / linux-arm64), NOT the commit — so it persists across
+          # every commit on the branch. `no-cache-filters: builder` alone rebuilt
+          # a fresh /hive in the `builder` stage but let BuildKit serve the FINAL
+          # (`runtime`) stage's `COPY --from=builder /hive` layer AND the
+          # subsequent fresh-inode rewrite RUN from that persistent cache — so the
+          # rebuilt binary was thrown away and the OLD binary (e.g. commit
+          # 4d9c11c) shipped even though the manifest digest advanced. Listing the
+          # `runtime` stage too forces those binary-bearing layers to re-run every
+          # build, so the published /usr/local/bin/hive always matches HEAD.
+          no-cache-filters: builder,runtime
           # #3760: DO NOT attach provenance/SBOM attestations. build-push-action
           # adds them by DEFAULT, and an attestation can only be carried by an
           # OCI image *index* — so the per-arch digest we push becomes
@@ -393,6 +404,12 @@ jobs:
           build-args: |
             GIT_HASH=${{ github.sha }}
             GIT_BRANCH=${{ github.ref_name }}
+          # STALE-BINARY FIX (see the main build step). The hub image also does
+          # `COPY --from=builder /hive` into a `runtime` final stage, and its GHA
+          # cache scope (hub-<slug>) is likewise branch-persistent — so without
+          # busting `runtime` the hub could ship an old hive that self-upgrades
+          # against the wrong SHA. Bust both binary-bearing stages.
+          no-cache-filters: builder,runtime
           # #3760: no default provenance/SBOM attestations → plain image
           # manifests, not an OCI index. See the note on the main build above.
           provenance: false

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -259,7 +259,29 @@ jobs:
               echo "::error::#3760 regression: hive execve returned Operation not permitted at its image path under containerd/overlayfs." >&2
               exit 1 ;;
           esac
-          echo "OK: hive execs in-place under containerd/overlayfs (no copy, no NET_ADMIN)."
+
+          # STALE-BINARY GUARD. The exec check above passes even for an OLD hive
+          # binary — a stale binary works fine, it just reports the WRONG commit.
+          # A branch-persistent GHA cache once let BuildKit serve a cached
+          # final-stage `COPY --from=builder /hive` layer, so the manifest digest
+          # advanced but /usr/local/bin/hive was an old build (reported commit
+          # 4d9c11c while HEAD had the #3760 fix). Assert the built binary's
+          # embedded commit matches THIS build's commit so a stale-layer cache hit
+          # is caught directly, not just an exec failure. `hive --version` prints
+          # `hive 3.0.0 (commit <short7>, branch <branch>)`; main.gitShort is the
+          # 7-char short SHA stamped from GIT_HASH=${{ github.sha }} at build.
+          EXPECTED_SHORT="${GITHUB_SHA::7}"
+          REPORTED_COMMIT=$(printf '%s\n' "$out" | sed -n 's/.*commit \([0-9a-f][0-9a-f]*\).*/\1/p' | head -n1)
+          echo "expected commit=$EXPECTED_SHORT reported commit=$REPORTED_COMMIT"
+          if [ -z "$REPORTED_COMMIT" ]; then
+            echo "::error::stale-binary guard: could not parse commit from 'hive --version' output — version stamping is broken or the output format changed." >&2
+            exit 1
+          fi
+          if [ "$REPORTED_COMMIT" != "$EXPECTED_SHORT" ]; then
+            echo "::error::stale-binary guard: shipped hive reports commit '$REPORTED_COMMIT' but this build is '$EXPECTED_SHORT'. The binary is STALE — a cached final-stage COPY --from=builder layer shipped an old /usr/local/bin/hive (the bug that let #3760's fix miss the published image). Check no-cache-filters covers the runtime stage in docker.yml." >&2
+            exit 1
+          fi
+          echo "OK: hive execs in-place under containerd/overlayfs (no copy, no NET_ADMIN) AND reports the current commit ($REPORTED_COMMIT)."
 
   nightly-release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/v2'

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -53,7 +53,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Pinned to the same node:26-slim digest as the tmux-builder stage above —
 # refresh both FROM lines together.
-FROM node:26-slim@sha256:4ebb5ace66f15a24c14c492e01a8beeed4fddf970a856109f5126e703e5fe503
+#
+# The final stage is NAMED `runtime` so the CI build steps can list it in
+# `no-cache-filters` alongside `builder`. Busting ONLY `builder` rebuilt a fresh
+# /hive but let BuildKit serve the final-stage `COPY --from=builder /hive` layer
+# (and the rewrite RUN below) from the branch-scoped GHA cache — so a fresh
+# binary was rebuilt and then discarded, and the OLD binary shipped. See the
+# stale-binary note in .github/workflows/docker.yml.
+FROM node:26-slim@sha256:4ebb5ace66f15a24c14c492e01a8beeed4fddf970a856109f5126e703e5fe503 AS runtime
 
 # --- Layer 1: system packages (rarely changes) ---
 # util-linux provides `setpriv`, used by the entrypoint to drop to `dev` with an

--- a/v2/Dockerfile.hub
+++ b/v2/Dockerfile.hub
@@ -23,7 +23,11 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     if [ "$GIT_BRANCH" = "unknown" ] || [ -z "$GIT_BRANCH" ]; then GIT_BRANCH=$(git -C /repo rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"); fi && \
     CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive
 
-FROM alpine:3.24
+# Named `runtime` so the CI hub build step can list it in `no-cache-filters`
+# alongside `builder`. Busting only `builder` rebuilt a fresh /hive but let
+# BuildKit serve the final-stage `COPY --from=builder /hive` layer from the
+# branch-scoped GHA cache, shipping the OLD binary. See docker.yml.
+FROM alpine:3.24 AS runtime
 ARG TARGETARCH
 ARG KUBECTL_VERSION=v1.36.3
 ARG KUBECTL_SHA256_AMD64=ebbd080e7c2e275093b55915722043257eb24004363e20acb3c4d71919f88336


### PR DESCRIPTION
## Problem

The just-merged #3760 fix (remove the hive file-cap, add the fresh-inode rewrite) is **correct in source but was not reaching the published image**. `ghcr.io/kubestellar/hive:v4-latest` / `:stable` shipped an **old** `/usr/local/bin/hive` — reports `commit 4d9c11c`, file mtime "Aug 14 02:32", exits 126 / EPERM — even though HEAD (`8303d29e`) had removed the setcap and added the rewrite, and the **manifest digest advanced** on each build.

## Root cause: a cached final-stage binary layer

`.github/workflows/docker.yml` builds the main and hub images with:

```yaml
cache-from: type=gha,scope=${{ steps.slug.outputs.slug }}
cache-to:   type=gha,scope=${{ steps.slug.outputs.slug }},mode=max
no-cache-filters: builder
```

`steps.slug.outputs.slug` is the **platform** slug (`linux-amd64` / `linux-arm64`, from `${PLATFORM//\//-}`) — **never the commit** — so the GHA cache persists across every commit on the branch.

`no-cache-filters: builder` busts only the Go-build stage. But the binary that actually **ships** lives in the **final image stage**:

```dockerfile
COPY --from=builder /hive /usr/local/bin/hive   # then the #3794 fresh-inode rewrite RUN
```

Those final-stage layers were **not** in `no-cache-filters`, so BuildKit served them from the persistent GHA cache. The `builder` stage rebuilt a fresh binary — which was then **discarded** — and the **cached final-stage `COPY --from` layer (embedding the OLD binary) shipped**. The manifest digest still advanced because other final-stage layers change per build (re-declared `ARG GIT_HASH`, labels, `provenance:false`), which masked the stale binary. That is exactly the observed signature: *digest-changed-but-binary-is-old* (`4d9c11c`, mtime 02:32) while HEAD source has the fix.

## Fix

- **Name the final stage `AS runtime`** in `v2/Dockerfile` and `v2/Dockerfile.hub`.
- **Extend `no-cache-filters` to `builder,runtime`** on the **main** and **hub** build steps in `docker.yml`, forcing the `COPY --from=builder` + rewrite layers to re-run every build, so the published `/usr/local/bin/hive` always matches HEAD. (The hub step had **no** `no-cache-filters` at all, and the hub self-upgrades against its own branch SHA — a stale hub binary is equally hazardous.)
- The **contributor image ships no hive binary** (no builder stage, no `COPY --from=builder /hive`), so it is intentionally left unchanged.

I chose `no-cache-filters` over per-SHA cache scoping deliberately: a pure per-SHA scope would kill *all* cache reuse (module downloads, apt/npm layers). Busting only the two binary-bearing stages keeps the expensive dependency layers cached while guaranteeing the binary is fresh — correctness without throwing away cache efficiency.

## Guard strengthened to catch this class

The #3760 `overlayfs-exec-guard` (in `v2-ci.yml`, which runs on **v4** too) previously only asserted that `/usr/local/bin/hive` **execs**. A stale binary execs fine — it just reports the **wrong commit**. The guard now also asserts that `hive --version` reports the **current** commit (`${GITHUB_SHA::7}`); `hive --version` prints `hive 3.0.0 (commit <short7>, branch <branch>)` where `main.gitShort` is stamped from `GIT_HASH=${{ github.sha }}` at build time. This positive control catches cache-staleness directly, not just an exec failure.

## Why this matters

`provenance:false` / `sbom:false` (#3791) and the in-stage rewrite (#3794) are untouched — they remain correct. But none of them help if the **cached final-stage layer** ships the old binary in the first place. This PR is what actually gets **#3760**'s fix into the shipped `:v4-latest` / `:stable` image.

Do not merge on my behalf — hive-org policy.