### PR TITLE
🐛 fix(governor): stop boot-kick cadence bypass — honor persisted LastKick across pod rolls

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4088,8 +4088,20 @@ func main() {
 		return
 	}
 
-	gov.ClearLastKicks()
-	logger.Info("cleared last kicks for startup — all eligible agents will be kicked on first eval")
+	// #2573: startup must NOT clear persisted last-kick timestamps. It used to
+	// (gov.ClearLastKicks) so that every eligible agent was kicked on the first
+	// eval — "one kick per agent per pod boot, by design". But on hosted hives
+	// the hub rolls the Deployment for every auto-upgrade, and each roll is a
+	// brand-new pod with container restart count 0, so agents on 4h/6h cadences
+	// were re-kicked at roll frequency — burning backend tokens ("Bob coins")
+	// far beyond any configured cadence, while "next run" (recomputed from the
+	// wiped timestamps) showed sooner than the cadence implied. LastKick state
+	// is persisted to /data (PVC) after every eval and restored above via
+	// SeedLastKicks, so this first eval kicks exactly the agents whose cadence
+	// has actually elapsed — including everything after downtime longer than an
+	// interval. A hive with no persisted state (fresh install) has no LastKick
+	// entries, and every cadenced agent is still kicked here, unchanged.
+	logger.Info("startup honors persisted cadence state — first eval kicks only agents whose cadence has elapsed")
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
 	runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -850,21 +850,28 @@ func (g *Governor) SeedQueueState(issues, prs, hold, slaViolations int) {
 	g.state.SLAViolations = slaViolations
 }
 
+// SeedLastKicks restores persisted last-kick timestamps from the state
+// snapshot. Restored values gate the first eval after a pod boot exactly
+// like live values gate any other eval — #2573: a pod boot must NOT bypass
+// cadence (startup used to wipe these via a ClearLastKicks call so every
+// eligible agent was kicked on the first eval; on hosted hives, where hub-
+// managed auto-upgrades roll the Deployment into a NEW pod, that re-kicked
+// 4h/6h-cadence agents at roll frequency and burned backend tokens far
+// beyond any configured cadence).
+//
+// A timestamp in the future — node clock skew or a corrupt snapshot —
+// is clamped to now, so a bad value can never hold an agent past one full
+// cadence interval from the current wall clock.
 func (g *Governor) SeedLastKicks(kicks map[string]time.Time) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	now := g.now()
 	for k, v := range kicks {
+		if v.After(now) {
+			v = now
+		}
 		g.state.LastKick[k] = v
 	}
-}
-
-// ClearLastKicks resets all LastKick timestamps so every agent is "due"
-// on the next eval cycle. Paused and on-demand agents are still skipped
-// by agentsDueForKick() — this just clears the timing gate.
-func (g *Governor) ClearLastKicks() {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.state.LastKick = make(map[string]time.Time)
 }
 
 func (g *Governor) SeedKickHistory(records []KickRecord) {

--- a/v2/pkg/governor/governor_boot_kick_test.go
+++ b/v2/pkg/governor/governor_boot_kick_test.go
@@ -1,0 +1,142 @@
+package governor
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// Regression tests for #2573 (boot-kick cadence bypass): startup used to call
+// a ClearLastKicks method that wiped the persisted last-kick timestamps right
+// after they were restored, so EVERY eligible agent was kicked on the first
+// eval of every pod boot. On hosted hives, hub-managed auto-upgrades roll the
+// Deployment into a brand-new pod (container restart count 0), so agents on
+// 4h/6h cadences were re-kicked at roll frequency — burning backend tokens
+// ("Bob coins") far beyond any configured cadence. The fix removes the wipe:
+// restored timestamps gate the first eval exactly like any other eval.
+
+// bootTestGovernor mirrors the reporter's setup: bob-backed agents on long
+// cadences plus a paused supervisor, pinned to a fixed clock.
+func bootTestGovernor(base time.Time) *Governor {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"idle": {Threshold: 0, Cadences: map[string]config.Cadence{
+				"scanner":    "6h",
+				"outreach":   "4h",
+				"supervisor": "pause",
+			}},
+		},
+	}
+	agents := map[string]config.AgentConfig{
+		"scanner":    {Backend: "bob", Enabled: true},
+		"outreach":   {Backend: "bob", Enabled: true},
+		"supervisor": {Backend: "bob", Enabled: true},
+	}
+	g := New(cfg, agents, testLogger())
+	g.now = func() time.Time { return base }
+	return g
+}
+
+// TestBootSeededLastKick_WithinCadence_NotDue is the core #2573 boot
+// regression: an agent whose persisted last kick is INSIDE its cadence
+// interval must NOT be kicked on the first eval after a pod boot.
+func TestBootSeededLastKick_WithinCadence_NotDue(t *testing.T) {
+	base := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	g := bootTestGovernor(base)
+
+	// The pod rolled 1h after the last kick — 6h/4h cadences have NOT elapsed.
+	g.SeedLastKicks(map[string]time.Time{
+		"scanner":  base.Add(-1 * time.Hour),
+		"outreach": base.Add(-1 * time.Hour),
+	})
+
+	due := dueSet(g)
+	if due["scanner"] || due["outreach"] {
+		t.Errorf("boot must not bypass cadence: agents kicked 1h ago on 6h/4h cadences came up due = %v", due)
+	}
+	if due["supervisor"] {
+		t.Error("paused supervisor must never be due")
+	}
+}
+
+// TestBootSeededLastKick_CadenceElapsed_Due is the positive control against
+// over-blocking (the paused-blocks-everything failure mode): an agent whose
+// cadence HAS elapsed — including across downtime longer than the interval —
+// is kicked on the first eval.
+func TestBootSeededLastKick_CadenceElapsed_Due(t *testing.T) {
+	base := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	g := bootTestGovernor(base)
+
+	g.SeedLastKicks(map[string]time.Time{
+		"scanner":  base.Add(-7 * time.Hour), // 6h cadence elapsed
+		"outreach": base.Add(-3 * time.Hour), // 4h cadence NOT elapsed
+	})
+
+	due := dueSet(g)
+	if !due["scanner"] {
+		t.Error("scanner's 6h cadence elapsed while the pod was down — it must be due on first eval")
+	}
+	if due["outreach"] {
+		t.Error("outreach's 4h cadence has not elapsed — it must not be due")
+	}
+}
+
+// TestBootNoSeededKicks_AllCadencedAgentsDue: a fresh hive (no persisted
+// state, nothing seeded) keeps the original behavior — every cadenced,
+// unpaused agent is kicked on the first eval.
+func TestBootNoSeededKicks_AllCadencedAgentsDue(t *testing.T) {
+	base := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	g := bootTestGovernor(base)
+
+	due := dueSet(g)
+	if !due["scanner"] || !due["outreach"] {
+		t.Errorf("fresh hive with no persisted kicks must kick all cadenced agents on first eval, got %v", due)
+	}
+	if due["supervisor"] {
+		t.Error("paused supervisor must never be due, even on a fresh hive")
+	}
+}
+
+// TestSeedLastKicks_ClampsFutureTimestamps: a future-dated snapshot value
+// (node clock skew, corrupt state) is clamped to now, so it can delay an
+// agent by at most one full cadence interval from the current wall clock.
+func TestSeedLastKicks_ClampsFutureTimestamps(t *testing.T) {
+	base := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	g := bootTestGovernor(base)
+
+	g.SeedLastKicks(map[string]time.Time{"scanner": base.Add(3 * time.Hour)})
+
+	if lk := g.GetState().LastKick["scanner"]; !lk.Equal(base) {
+		t.Fatalf("future timestamp must be clamped to now: got %v, want %v", lk, base)
+	}
+
+	// Not due immediately (clamped to "just kicked")...
+	if due := dueSet(g); due["scanner"] {
+		t.Error("scanner should not be due immediately after the clamp")
+	}
+	// ...but due once one full interval passes — never blocked past that.
+	g.now = func() time.Time { return base.Add(6*time.Hour + time.Minute) }
+	if due := dueSet(g); !due["scanner"] {
+		t.Error("scanner must be due one cadence interval after the clamped timestamp")
+	}
+}
+
+// TestStartup_NoClearLastKicksWipe asserts the fix is present in SOURCE: the
+// startup path must not wipe restored last-kick state, and the governor must
+// not offer a wipe primitive for it to call. Sync/port merges have silently
+// reverted shipped fixes before — this fails loudly if the wipe comes back.
+func TestStartup_NoClearLastKicksWipe(t *testing.T) {
+	for _, path := range []string{"governor.go", "../../cmd/hive/main.go"} {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		if strings.Contains(string(src), "ClearLastKicks()") {
+			t.Errorf("%s references ClearLastKicks() — the #2573 boot-kick cadence bypass has been reintroduced: "+
+				"startup must honor persisted LastKick state instead of wiping it", path)
+		}
+	}
+}

--- a/v2/pkg/governor/governor_gap_coverage_test.go
+++ b/v2/pkg/governor/governor_gap_coverage_test.go
@@ -184,39 +184,6 @@ func TestSetBudgetIgnoreAll_BypassesKickSuppression(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ClearLastKicks
-// ---------------------------------------------------------------------------
-
-// TestClearLastKicks_MakesAgentsDueAgain: clearing the timing gate makes every
-// cadenced agent due on the next eval, while paused agents stay excluded (the
-// reset clears timing only, not the operator's pause).
-func TestClearLastKicks_MakesAgentsDueAgain(t *testing.T) {
-	// testGovernor: idle cadences scanner=15m, supervisor=pause.
-	g := testGovernor()
-
-	g.Evaluate(0, 0, 0, 0)
-	g.RecordKick("scanner")
-
-	// Positive control: freshly kicked, scanner is not due.
-	if due := dueSet(g); due["scanner"] {
-		t.Fatal("precondition: scanner should not be due right after a kick")
-	}
-
-	g.ClearLastKicks()
-
-	due := dueSet(g)
-	if !due["scanner"] {
-		t.Error("scanner should be due immediately after ClearLastKicks")
-	}
-	if due["supervisor"] {
-		t.Error("paused supervisor must stay excluded even after ClearLastKicks")
-	}
-	if lk := g.GetState().LastKick; len(lk) != 0 {
-		t.Errorf("LastKick map should be empty after clear, got %v", lk)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // Kick-channel gate in scheduled kicks
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause (#2573)

The reporter had the supervisor paused and every other agent on 4h/6h cadences, yet Bob coin usage kept climbing and "next run" implied runs more frequent than the cadences. The earlier live-pod diagnostic ruled out the scheduler bugs fixed in #2627 (single IDLE mode entry, pause working, container restart count 0) — but that diagnostic could not see the actual bypass, because it isn't a *restart*:

**Startup unconditionally wiped restored cadence state.** Boot restored the persisted per-agent `LastKick` timestamps from `/data/hive-state.json` (`SeedLastKicks`) — and then immediately wiped them (`gov.ClearLastKicks()`, "all eligible agents will be kicked on first eval"). The first eval therefore kicked **every** unpaused cadenced agent, regardless of when it last ran.

On hosted hives the hub rolls the Deployment for every auto-upgrade. Each roll is a **brand-new pod with container restart count 0** — invisible to a "0 restarts" check — and every roll re-kicked every agent. Agents on 4h/6h cadences ran at roll frequency instead:

- Bob coins burned far beyond any configured cadence, matching the report;
- "next run", recomputed from the wiped timestamps, showed sooner than the configured cadence implied — the reporter's second symptom;
- hive-side token accounting could still read zero: bob frequently cannot persist its chat recordings (`EACCES` on `$HOME/.bob`, the exact failure the permissions watcher now self-heals), and hive's bob token scanner reads those recordings — so real spend left no hive-side ledger.

This is the row #2627's consumer map surfaced as "Startup `ClearLastKicks` — one kick per agent per pod restart, by design — unchanged". Under the cadence contract that same PR established ("a user-set 6h being run more often is always a bug"), and with hosted rolls being routine, that design is the remaining cadence bypass.

## Fix

- Remove the startup wipe. `LastKick` is persisted after every eval (5 min) and restored at boot, so the first eval kicks exactly the agents whose cadence has actually elapsed — including everything after downtime longer than an interval.
- Fresh installs (no persisted state) have no `LastKick` entries, so every cadenced agent is still kicked on first eval — behavior unchanged.
- `SeedLastKicks` clamps future-dated snapshot values (node clock skew, corrupt state) to now, so a bad value can never hold an agent past one full cadence interval.
- The `ClearLastKicks` primitive is **deleted**, and a source-assertion test fails if the wipe is reintroduced (sync/port merges have silently reverted shipped fixes before).

Deliberately untouched (no governor redesign): the per-launch bootstrap prompt (`deliverStartupKick`) still delivers each agent its mission once per pod boot — that is one bounded prompt per agent per roll, and removing it would leave freshly launched CLIs missionless. The multiplicative burn (bootstrap + unconditional first-eval kick, every roll) is what this PR removes.

## Tests (`v2/pkg/governor/governor_boot_kick_test.go`)

- `TestBootSeededLastKick_WithinCadence_NotDue` — the regression: kicked 1h ago on 6h/4h cadences, pod rolls, first eval must NOT kick.
- `TestBootSeededLastKick_CadenceElapsed_Due` — positive control against over-blocking: elapsed cadence (including downtime > interval) IS kicked on first eval.
- `TestBootNoSeededKicks_AllCadencedAgentsDue` — fresh hive keeps today's behavior; paused supervisor stays excluded.
- `TestSeedLastKicks_ClampsFutureTimestamps` — skewed snapshot delays an agent at most one interval.
- `TestStartup_NoClearLastKicksWipe` — source-level invariant: neither `main.go` nor `governor.go` may reference `ClearLastKicks()` again.

`go vet` and the governor test suite pass on the touched packages.

Fixes #2573
