### PR TITLE
hub: restore public read-only preview for is_public hives (new /public-status + /preview)

### DIFF
--- a/v2/pkg/hub/public_hive_status_test.go
+++ b/v2/pkg/hub/public_hive_status_test.go
@@ -1,0 +1,316 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Package-level tests for handlePublicHiveStatus (the anonymous, read-only
+// preview endpoint for is_public:true hives) and a regression test confirming
+// handleHiveStatus (the full, owner-only record) is unchanged by this fix.
+
+func newPublicStatusHub() *HubServer {
+	return &HubServer{
+		logger:         slog.Default(),
+		hubSecret:      testHubSecret,
+		keyGenerations: legacyGenerationSet(testHubSecret),
+	}
+}
+
+// TestHandlePublicHiveStatusAnonymousOnPublicHive verifies an anonymous
+// caller gets 200 with ONLY the safe allowlist fields for an is_public:true
+// hive, and that no sensitive field ever appears in the response body.
+func TestHandlePublicHiveStatusAnonymousOnPublicHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	h := &SaaSHive{
+		ID:          "hosted-available-oke-01-placeholder-bb95",
+		Owner:       "some-owner-username",
+		ProjectName: "My Public Hive",
+		Org:         "kubestellar",
+		PrimaryRepo: "kubestellar/hive",
+		ACMMLevel:   3,
+		Status:      "claimed",
+		IsPublic:    true,
+		GitHubHost:  "github.ibm.com", // sensitive: must NOT appear
+		ClusterID:   "cluster-internal-id-42",
+		Subdomain:   "internal-subdomain-secret",
+		PendingAppConfig: &PendingAppIdentity{
+			AppID:          123456,
+			AppSlug:        "some-app-slug",
+			InstallationID: 987654,
+			APIURL:         "https://api.github.ibm.com",
+			BaseURL:        "https://github.ibm.com",
+		},
+		Error:               "internal kubectl exec failed: connection refused to 10.0.0.5:6443",
+		OCIFileSystemID:     "ocid1.filesystem.internal",
+		RequestedGitHubHost: "github.internal.example.com",
+		PendingRequests: []PendingAccessRequest{
+			{Username: "some-requester", Status: "pending"},
+		},
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatalf("saveSaaSHive: %v", err)
+	}
+
+	s := newPublicStatusHub()
+	s.registry.Hives = []RegistryEntry{
+		{
+			ID:               h.ID,
+			Version:          "v4.2.1",
+			GitBranch:        "v4",
+			Online:           true,
+			AgentCount:       2,
+			ActionableIssues: 5,
+			ActionablePRs:    2,
+			ClusterID:        "cluster-internal-id-42",             // sensitive: must NOT appear
+			Namespace:        "hive-hosted-secret-namespace",       // sensitive: must NOT appear
+			Health:           map[string]any{"internal": "detail"}, // sensitive: must NOT appear
+			Agents: []AgentSummary{
+				{Name: "scanner", State: "running", Paused: false, StartedAt: "2026-08-01T00:00:00Z"},
+				{Name: "reviewer", State: "paused", Paused: true, NeedsLogin: true},
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/hives/"+h.ID+"/public-status", nil)
+	req = setPathValue(req, "id", h.ID)
+	rec := httptest.NewRecorder()
+
+	s.handlePublicHiveStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+
+	// Sensitive substrings must be absent from the raw JSON, regardless of
+	// field naming — this catches both "wrong field name" and "embedded the
+	// whole struct" regressions.
+	sensitive := []string{
+		"github.ibm.com",
+		"cluster-internal-id-42",
+		"internal-subdomain-secret",
+		"some-app-slug",
+		"987654",
+		"123456",
+		"api.github.ibm.com",
+		"connection refused",
+		"ocid1.filesystem.internal",
+		"github.internal.example.com",
+		"some-requester",
+		"hive-hosted-secret-namespace",
+		"\"internal\":\"detail\"",
+		"some-owner-username",
+		"needsLogin",
+		"startedAt",
+	}
+	for _, s := range sensitive {
+		if strings.Contains(body, s) {
+			t.Errorf("response body leaked sensitive content %q; body=%s", s, body)
+		}
+	}
+
+	var out PublicHiveStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if out.ID != h.ID {
+		t.Errorf("ID = %q, want %q", out.ID, h.ID)
+	}
+	if out.ProjectName != "My Public Hive" {
+		t.Errorf("ProjectName = %q", out.ProjectName)
+	}
+	if out.ACMMLevel != 3 {
+		t.Errorf("ACMMLevel = %d, want 3", out.ACMMLevel)
+	}
+	if !out.IsPublic {
+		t.Errorf("IsPublic = false, want true")
+	}
+	if out.Version != "v4.2.1" {
+		t.Errorf("Version = %q, want v4.2.1", out.Version)
+	}
+	if !out.Online {
+		t.Errorf("Online = false, want true")
+	}
+	if out.AgentCount != 2 {
+		t.Errorf("AgentCount = %d, want 2", out.AgentCount)
+	}
+	if len(out.Agents) != 2 {
+		t.Fatalf("Agents len = %d, want 2", len(out.Agents))
+	}
+	if out.Agents[0].Name != "scanner" || out.Agents[0].State != "running" {
+		t.Errorf("Agents[0] = %+v", out.Agents[0])
+	}
+	if out.Agents[1].Name != "reviewer" || !out.Agents[1].Paused {
+		t.Errorf("Agents[1] = %+v", out.Agents[1])
+	}
+}
+
+// TestHandlePublicHiveStatusAnonymousOnPrivateHive verifies an anonymous
+// caller (and a non-owner authenticated caller) gets 404 on a hive that is
+// NOT is_public, and that the response cannot be distinguished from a
+// genuinely missing hive.
+func TestHandlePublicHiveStatusAnonymousOnPrivateHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	h := &SaaSHive{
+		ID:          "hosted-private-hive-1",
+		Owner:       "the-owner",
+		ProjectName: "Private Hive",
+		IsPublic:    false,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatalf("saveSaaSHive: %v", err)
+	}
+
+	s := newPublicStatusHub()
+
+	cases := []struct {
+		name     string
+		username string
+	}{
+		{name: "anonymous", username: ""},
+		{name: "unrelated authenticated user", username: "some-other-user"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var req *http.Request
+			if tc.username == "" {
+				req = httptest.NewRequest(http.MethodGet, "/api/saas/hives/"+h.ID+"/public-status", nil)
+			} else {
+				req = reqWithUser(http.MethodGet, "/api/saas/hives/"+h.ID+"/public-status", "", tc.username)
+			}
+			req = setPathValue(req, "id", h.ID)
+			rec := httptest.NewRecorder()
+
+			s.handlePublicHiveStatus(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404 (body=%q)", rec.Code, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "the-owner") || strings.Contains(rec.Body.String(), "Private Hive") {
+				t.Errorf("404 body leaked private hive data: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandlePublicHiveStatusOwnerOnPrivateHive verifies the hive's owner CAN
+// still reach the safe-subset view of their own private hive through this
+// endpoint (falls through the is_public gate via userIsHiveOwner), so an
+// owner previewing a not-yet-public hive isn't blocked.
+func TestHandlePublicHiveStatusOwnerOnPrivateHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	h := &SaaSHive{
+		ID:          "hosted-private-hive-2",
+		Owner:       "the-owner",
+		ProjectName: "Private Hive 2",
+		IsPublic:    false,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatalf("saveSaaSHive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "the-owner", Hives: map[string]string{}}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	s := newPublicStatusHub()
+
+	req := reqWithUser(http.MethodGet, "/api/saas/hives/"+h.ID+"/public-status", "", "the-owner")
+	req = setPathValue(req, "id", h.ID)
+	rec := httptest.NewRecorder()
+
+	s.handlePublicHiveStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandlePublicHiveStatusNotFound verifies a genuinely nonexistent hive
+// ID 404s, same as a private hive — no information disclosure via status
+// code alone.
+func TestHandlePublicHiveStatusNotFound(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newPublicStatusHub()
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/hives/does-not-exist/public-status", nil)
+	req = setPathValue(req, "id", "does-not-exist")
+	rec := httptest.NewRecorder()
+
+	s.handlePublicHiveStatus(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleHiveStatusStillOwnerGated is a regression test confirming the
+// FULL, owner-only status route (handleHiveStatus, the raw SaaSHive record)
+// is completely unchanged by this fix: it still 403s for a non-owner and
+// still requires auth, exactly as #3692 left it.
+func TestHandleHiveStatusStillOwnerGated(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	h := &SaaSHive{
+		ID:          "hosted-owner-gated-hive",
+		Owner:       "the-owner",
+		ProjectName: "Owner Gated Hive",
+		IsPublic:    true, // even a PUBLIC hive's full record stays owner-only
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatalf("saveSaaSHive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "the-owner", Hives: map[string]string{}}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "not-the-owner", Hives: map[string]string{}}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	s := newPublicStatusHub()
+
+	t.Run("anonymous is forbidden", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/saas/hives/"+h.ID+"/status", nil)
+		req = setPathValue(req, "id", h.ID)
+		rec := httptest.NewRecorder()
+		s.handleHiveStatus(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403 (body=%q)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("non-owner is forbidden", func(t *testing.T) {
+		req := reqWithUser(http.MethodGet, "/api/saas/hives/"+h.ID+"/status", "", "not-the-owner")
+		req = setPathValue(req, "id", h.ID)
+		rec := httptest.NewRecorder()
+		s.handleHiveStatus(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403 (body=%q)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("owner gets the full record", func(t *testing.T) {
+		req := reqWithUser(http.MethodGet, "/api/saas/hives/"+h.ID+"/status", "", "the-owner")
+		req = setPathValue(req, "id", h.ID)
+		rec := httptest.NewRecorder()
+		s.handleHiveStatus(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+		}
+	})
+}

--- a/v2/pkg/hub/public_hive_status_test.go
+++ b/v2/pkg/hub/public_hive_status_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 // Package-level tests for handlePublicHiveStatus (the anonymous, read-only
-// preview endpoint for is_public:true hives) and a regression test confirming
-// handleHiveStatus (the full, owner-only record) is unchanged by this fix.
+// JSON endpoint for is_public:true hives), handlePublicHivePreview (the
+// browser-facing HTML page that fetches it client-side), and a regression
+// test confirming handleHiveStatus (the full, owner-only record) is
+// unchanged by this fix.
 
 func newPublicStatusHub() *HubServer {
 	return &HubServer{
@@ -313,4 +315,76 @@ func TestHandleHiveStatusStillOwnerGated(t *testing.T) {
 			t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
 		}
 	})
+}
+
+// TestHandlePublicHivePreviewAnonymous verifies the preview PAGE — the
+// actual browser-facing surface a shared public-hive link lands on — is
+// reachable anonymously, serves HTML, and carries NO hive data inline (it
+// fetches /public-status client-side, so the page itself cannot regress the
+// allowlist no matter what a hive's fields contain).
+func TestHandlePublicHivePreviewAnonymous(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newPublicStatusHub()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/hives/some-hive-id/preview", nil)
+	req = setPathValue(req, "id", "some-hive-id")
+	rec := httptest.NewRecorder()
+
+	s.handlePublicHivePreview(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "/public-status") {
+		t.Errorf("preview page does not reference /public-status: %s", body)
+	}
+	// The page is a static shell — no hive ID, name, or any other
+	// server-interpolated value should appear in the HTML itself.
+	if strings.Contains(body, "some-hive-id") {
+		t.Errorf("preview page leaked the hive id server-side instead of resolving it client-side: %s", body)
+	}
+}
+
+// TestPublicHiveRoutesRegisteredWithoutAuth is a route-table regression test:
+// it asserts /public-status and /preview are registered WITHOUT
+// requireAuth (same pattern as /open and /access-status), by exercising them
+// through the real mux with no auth cookie/header at all and confirming
+// neither is redirected to login or 401s outright (a 404 for an unknown
+// hive is fine and expected).
+func TestPublicHiveRoutesRegisteredWithoutAuth(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{
+		logger:         slog.Default(),
+		hubSecret:      testHubSecret,
+		keyGenerations: legacyGenerationSet(testHubSecret),
+		mux:            http.NewServeMux(),
+		hubBanners:     make(map[string]*HubBannerEntry),
+	}
+	s.registerSaaSRoutes()
+
+	for _, path := range []string{
+		"/api/saas/hives/unknown-hive/public-status",
+		"/api/saas/hives/unknown-hive/preview",
+	} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rec := httptest.NewRecorder()
+			s.mux.ServeHTTP(rec, req)
+			if rec.Code == http.StatusUnauthorized {
+				t.Fatalf("%s is auth-gated (401 with no credentials); it must be reachable anonymously", path)
+			}
+			if loc := rec.Header().Get("Location"); strings.Contains(loc, "/login") {
+				t.Fatalf("%s redirected to login (%q); it must be reachable anonymously", path, loc)
+			}
+		})
+	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -460,6 +460,13 @@ func (s *HubServer) registerSaaSRoutes() {
 	// raw SaaSHive record handleHiveStatus above serves to owners: see
 	// handlePublicHiveStatus for exactly what is and is not included and why.
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/public-status", s.handlePublicHiveStatus)
+	// /preview is the actual browser-facing page for the public read-only
+	// preview: a shared hive link should land here, not on /open (which
+	// requires the hub-authenticated caller to already have a role on the
+	// hive — see handleOpenHive — and so 401s/redirects-to-login for exactly
+	// the anonymous audience a public hive's preview is for). Public hives
+	// table (loadPublicHives) links each hive's name here.
+	s.mux.HandleFunc("GET /api/saas/hives/{id}/preview", s.handlePublicHivePreview)
 	// /open is a browser NAVIGATION endpoint (the SSO handoff), not an API call.
 	// It is registered WITHOUT requireAuth so an unauthenticated visit redirects
 	// to the hub login (and back) instead of dumping a raw {"error":...} JSON.
@@ -3578,6 +3585,98 @@ func (s *HubServer) handlePublicHiveStatus(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(out)
+}
+
+// publicHivePreviewHTML is the shell for the anonymous, read-only preview
+// page (handlePublicHivePreview). It ships NO hive data inline — everything
+// it shows is fetched client-side from /public-status and rendered with the
+// same DOM-based esc() pattern the rest of the hub SPA uses (see the `esc`
+// helper inside dashboardHTML), so a malicious ProjectName/Org/PrimaryRepo
+// can never inject markup: textContent, not string concatenation, puts it on
+// the page.
+const publicHivePreviewHTML = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hive — Public Preview</title>
+<meta name="robots" content="noindex">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;display:flex;justify-content:center;align-items:flex-start;min-height:100vh;padding:48px 16px}
+.card{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:32px;max-width:560px;width:100%}
+h1{font-size:1.4rem;margin-bottom:4px;word-break:break-word}
+.sub{color:#8b949e;font-size:0.85rem;margin-bottom:20px}
+.pill{display:inline-block;padding:2px 10px;border-radius:999px;font-size:0.72rem;font-weight:600;margin-right:6px}
+.pill-online{background:rgba(34,197,94,0.15);color:#4ade80}
+.pill-offline{background:rgba(248,113,113,0.15);color:#f87171}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin:20px 0}
+.stat{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:12px}
+.stat .n{font-size:1.3rem;font-weight:700}
+.stat .l{color:#8b949e;font-size:0.7rem;text-transform:uppercase;letter-spacing:0.04em}
+.agents{margin-top:8px}
+.agent-row{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid #21262d;font-size:0.85rem}
+.agent-row:last-child{border-bottom:none}
+.state{font-size:0.72rem;color:#8b949e}
+.err{color:#8b949e;line-height:1.6}
+.footer{margin-top:20px;font-size:0.75rem;color:#6e7681}
+.footer a{color:#58a6ff}
+</style></head>
+<body><div class="card" id="preview-card">
+<p class="err">Loading…</p>
+</div>
+<script>
+function esc(s) { var d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+(function() {
+  var parts = location.pathname.split('/');
+  // /api/saas/hives/{id}/preview
+  var id = decodeURIComponent(parts[4] || '');
+  var card = document.getElementById('preview-card');
+  if (!id) { card.innerHTML = '<p class="err">No hive specified.</p>'; return; }
+  fetch('/api/saas/hives/' + encodeURIComponent(id) + '/public-status').then(function(r) {
+    if (!r.ok) { throw new Error(r.status === 404 ? 'This hive is not public or does not exist.' : 'Could not load this hive.'); }
+    return r.json();
+  }).then(function(h) {
+    var title = h.project_name || h.id;
+    var repo = h.org && h.primary_repo ? h.org + '/' + h.primary_repo : (h.primary_repo || '');
+    var onlinePill = '<span class="pill ' + (h.online ? 'pill-online' : 'pill-offline') + '">' + (h.online ? 'Online' : 'Offline') + '</span>';
+    var verPill = h.version ? '<span class="pill" style="background:#21262d;color:#8b949e">' + esc(h.version) + '</span>' : '';
+    var agentsHTML = '';
+    if (h.agents && h.agents.length) {
+      agentsHTML = '<div class="agents">' + h.agents.map(function(a) {
+        return '<div class="agent-row"><span>' + esc(a.name) + '</span><span class="state">' + esc(a.state) + (a.paused ? ' (paused)' : '') + '</span></div>';
+      }).join('') + '</div>';
+    }
+    card.innerHTML =
+      '<h1>' + esc(title) + '</h1>' +
+      '<div class="sub">' + esc(repo) + '</div>' +
+      '<div>' + onlinePill + verPill + '</div>' +
+      '<div class="grid">' +
+        '<div class="stat"><div class="n">' + esc(String(h.acmm_level || 0)) + '</div><div class="l">ACMM Level</div></div>' +
+        '<div class="stat"><div class="n">' + esc(String(h.agent_count || 0)) + '</div><div class="l">Agents</div></div>' +
+        '<div class="stat"><div class="n">' + esc(String(h.actionable_issues || 0)) + '</div><div class="l">Open Issues</div></div>' +
+        '<div class="stat"><div class="n">' + esc(String(h.actionable_prs || 0)) + '</div><div class="l">Open PRs</div></div>' +
+      '</div>' +
+      agentsHTML +
+      '<div class="footer">Read-only public preview · <a href="/">Hive</a></div>';
+  }).catch(function(e) {
+    card.innerHTML = '<h1>Not available</h1><p class="err">' + esc(e.message) + '</p><div class="footer"><a href="/">Back to Hive</a></div>';
+  });
+})();
+</script>
+</body></html>`
+
+// handlePublicHivePreview serves the anonymous, read-only preview PAGE for a
+// public hive — the actual browser-facing surface a shared hive link should
+// land on. It is registered WITHOUT requireAuth (see registerSaaSRoutes),
+// same as /public-status below it: the page itself carries no hive data and
+// is safe to serve regardless of the hive's visibility (it 404s/renders
+// nothing sensitive either way), and its inline script fetches
+// /public-status client-side — the endpoint that actually enforces the
+// is_public gate and the safe-subset allowlist. This handler never touches
+// SaaSHive/RegistryEntry itself, so it cannot regress the allowlist even by
+// accident.
+func (s *HubServer) handlePublicHivePreview(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(publicHivePreviewHTML))
 }
 
 // handleOpenHive is the SSO handoff entry point: a hub-authenticated user hits
@@ -13404,8 +13503,15 @@ const dashboardHTML = `<!DOCTYPE html>
             accessSecondary = '<a href="#" onclick="dashRequestAccess(\'' + esc(h.id) + '\',this);return false" style="font-size:0.65rem;color:#60a5fa;text-decoration:none" title="request sign-in / manage access to this hive">Request access</a>';
           }
           actionCell = '<div style="display:flex;gap:8px;align-items:center;justify-content:flex-end">' + contributeAction + accessSecondary + '</div>';
+          // Name links to the anonymous, read-only preview page — the actual
+          // surface a shared link for a public hive should land on. NOT
+          // /open: that route requires the visitor to already be a
+          // hub-authenticated owner/grantee (handleOpenHive), which is the
+          // opposite of the audience this table's "other people's public
+          // hives" row is for.
+          var previewHref = '/api/saas/hives/' + encodeURIComponent(h.id) + '/preview';
           return '<tr>' +
-            '<td style="text-align:left">' + esc(h.name || h.id) + '</td>' +
+            '<td style="text-align:left"><a href="' + previewHref + '" style="color:inherit;text-decoration:none" title="View read-only preview">' + esc(h.name || h.id) + '</a></td>' +
             '<td>' + repoLink + '</td>' +
             '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
             '<td>' + actionCell + '</td>' +

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -453,6 +453,13 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("POST /api/saas/lite/enroll", s.requireAuth(s.handleLiteEnroll))
 	s.mux.HandleFunc("POST /api/saas/hives", s.requireAuth(s.handleCreateHive))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
+	// /public-status is the read-only preview for an is_public:true hive. It is
+	// registered WITHOUT requireAuth — like /open and /access-status below — so
+	// an anonymous visitor (or a logged-in non-owner) can render the preview
+	// card. It returns a hand-picked SAFE SUBSET (PublicHiveStatus), never the
+	// raw SaaSHive record handleHiveStatus above serves to owners: see
+	// handlePublicHiveStatus for exactly what is and is not included and why.
+	s.mux.HandleFunc("GET /api/saas/hives/{id}/public-status", s.handlePublicHiveStatus)
 	// /open is a browser NAVIGATION endpoint (the SSO handoff), not an API call.
 	// It is registered WITHOUT requireAuth so an unauthenticated visit redirects
 	// to the hub login (and back) instead of dumping a raw {"error":...} JSON.
@@ -3053,11 +3060,11 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// own "channel -> image" block above the per-branch rows, and offers
 		// them as branch-switch targets. The association is resolved from
 		// registry digests (cached), never hardcoded to a branch name.
-		"release_channels":         ReleaseChannels(),
-		"channel_targets":          getChannelTargets(getDisplaySHAs(), s.logger),
-		"hub_auto_upgrade":         isHubAutoUpgrade(),
-		"hub_upgrade_state":        s.hubUpgradeState(),
-		"show_my_hives":            true,
+		"release_channels":  ReleaseChannels(),
+		"channel_targets":   getChannelTargets(getDisplaySHAs(), s.logger),
+		"hub_auto_upgrade":  isHubAutoUpgrade(),
+		"hub_upgrade_state": s.hubUpgradeState(),
+		"show_my_hives":     true,
 		// Fleet alerts ship WITH the hive list so the "Attention needed" panel
 		// renders in the same paint as the rows it summarises — a second
 		// round-trip would make the panel pop in after the list and shift it.
@@ -3393,6 +3400,184 @@ func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(h)
+}
+
+// PublicAgentSummary is the safe subset of AgentSummary shown on the public,
+// unauthenticated hive preview: just enough to render a roster (name, run
+// state, paused flag). It deliberately drops everything else AgentSummary
+// carries (StartedAt/LastActivityAt timestamps, NeedsLogin, SessionMissing,
+// and any per-agent operational detail added later) — none of that is
+// needed to answer "what agents does this hive have and are they running",
+// and all of it is internal operational detail, not something an anonymous
+// visitor needs.
+type PublicAgentSummary struct {
+	// Name — the agent's role/handle (e.g. "scanner"). Cosmetic, already
+	// shown in hive-open-pr commit trailers and public PR authorship, so it
+	// carries no confidentiality on its own.
+	Name string `json:"name"`
+	// State — coarse run state ("running", "paused", "stopped", …). Same
+	// category of fact as "is this hive up", already implied by the hive
+	// being public at all.
+	State string `json:"state"`
+	// Paused — whether the operator deliberately parked this agent. Purely
+	// descriptive of the roster's current shape.
+	Paused bool `json:"paused,omitempty"`
+}
+
+// PublicHiveStatus is the explicit ALLOWLIST returned by the public,
+// unauthenticated /public-status endpoint for an is_public:true hive.
+//
+// SECURITY: every field below is hand-picked and commented with why it is
+// safe to hand to an anonymous caller. This type is built field-by-field
+// from the SaaSHive/RegistryEntry records — it never embeds or forwards
+// either of those structs, so a new sensitive field added to SaaSHive or
+// RegistryEntry in the future does NOT silently leak here; it has to be
+// deliberately added to this struct to ever be exposed. Do not change this
+// handler to json.Marshal(h) or similar — that is exactly the regression
+// #3692 fixed for the owner-only route, and this route must not reopen it
+// for anonymous callers.
+//
+// Excluded on purpose (present on SaaSHive/RegistryEntry but NEVER copied
+// here): Owner (username — PII), GitHubHost/GitHubBaseURL/GitHubAPIURL,
+// PendingAppConfig (GitHub App id/slug/installation id — app credentials),
+// RequestedAppReset/RequestedGitHubHost/ForgeDelivered (in-flight admin
+// operations), ClusterID/ClusterName/Namespace (hub-internal infra
+// location), OCIFileSystemID/OCIExportID (storage internals), Error
+// (may echo internal failure detail), PendingRequests (other users'
+// access requests), AutoUpgrade*/RequestedRestartAt (operational
+// scheduling), Health (raw heartbeat health blob), TotalTokens24h/cost
+// data, ConflictingReporters/StatusFlipping (fleet diagnostics), and
+// AgentSummary's StartedAt/LastActivityAt/NeedsLogin/SessionMissing.
+type PublicHiveStatus struct {
+	// ID — the hive's own identifier, already in the URL the caller used to
+	// reach this endpoint.
+	ID string `json:"id"`
+	// ProjectName — the operator-set display name. Public by definition once
+	// is_public is true; it's the label used in preview cards / link
+	// unfurls.
+	ProjectName string `json:"project_name"`
+	// Org — the GitHub org the hive's repos live under. Already visible in
+	// PrimaryRepo's "owner/repo" form and in every PR/issue the hive's
+	// agents open publicly.
+	Org string `json:"org"`
+	// PrimaryRepo — the hive's main repo ("owner/repo"). Public GitHub data.
+	PrimaryRepo string `json:"primary_repo"`
+	// ACMMLevel — the hive's current maturity level. Purely a badge/score,
+	// no operational detail.
+	ACMMLevel int `json:"acmm_level"`
+	// Status — coarse provisioning/run status ("available", "claimed",
+	// "provisioning", …), not a diagnostic error string.
+	Status string `json:"status"`
+	// IsPublic — echoes the flag that gated this response, so a client can
+	// confirm it hit the public view (always true here; the handler 404s
+	// before reaching this point otherwise).
+	IsPublic bool `json:"is_public"`
+	// Version / GitBranch — the running build's version/branch label. Same
+	// class of fact as what a GitHub release page or Docker tag shows
+	// publicly for any open-source project.
+	Version   string `json:"version,omitempty"`
+	GitBranch string `json:"git_branch,omitempty"`
+	// TrackedChannel — release channel ("stable"/"candidate"/"edge") this
+	// hive tracks, if any. Cosmetic, like Version.
+	TrackedChannel string `json:"tracked_channel,omitempty"`
+	// Online — whether the spoke is currently heartbeating. The one true
+	// "is it up" signal a preview card needs; carries no internals.
+	Online bool `json:"online"`
+	// AgentCount — roster size. A count, not a capability/quota detail.
+	AgentCount int `json:"agent_count"`
+	// Agents — the safe per-agent subset (see PublicAgentSummary).
+	Agents []PublicAgentSummary `json:"agents,omitempty"`
+	// ActionableIssues / ActionablePRs — public GitHub issue/PR counts the
+	// hive is tracking. Same data a visitor could get from the repo's own
+	// GitHub issue/PR list; included because it's the headline metric the
+	// preview card exists to show.
+	ActionableIssues int `json:"actionable_issues"`
+	ActionablePRs    int `json:"actionable_prs"`
+}
+
+// handlePublicHiveStatus is the public, read-only status preview for a hive
+// with is_public:true. It is registered WITHOUT requireAuth (see
+// registerSaaSRoutes) precisely because the audience is anonymous visitors
+// and non-owner viewers of a shared hive link — the same audience
+// handleOpenHive's SSO fallback and handleAccessStatus already serve
+// unauthenticated.
+//
+// It intentionally does NOT reuse handleHiveStatus's owner gate: that route
+// stays owner-only per #3692 (operator decision 2026-08-13) because the raw
+// SaaSHive record carries operational metadata beyond what a read grant
+// implies. This route instead returns a hand-built PublicHiveStatus
+// allowlist — see that type's doc comment for exactly what is included and
+// excluded, and why each inclusion is safe.
+//
+// Access rule: a hive must have IsPublic:true to be visible here at all,
+// UNLESS the caller is already an owner/grantee (handled by falling through
+// to the same allowlist — owners get the safe subset too if they hit this
+// route directly; they should use /status for the full record). A private
+// hive with no matching credential 404s, matching handleHiveStatus's
+// not-found response so this endpoint cannot be used to distinguish
+// "private hive" from "no such hive".
+func (s *HubServer) handlePublicHiveStatus(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	h := loadSaaSHive(id)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if !h.IsPublic {
+		// Not public: only let an authenticated owner/admin through (so an
+		// owner previewing their own not-yet-public hive still works), and
+		// give every other caller the SAME "not found" response a genuinely
+		// missing hive gets — never confirm a private hive's existence to an
+		// anonymous caller.
+		username := s.getAuthUser(r)
+		if !userIsHiveOwner(username, h) {
+			http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+			return
+		}
+	}
+
+	out := PublicHiveStatus{
+		ID:          h.ID,
+		ProjectName: h.ProjectName,
+		Org:         h.Org,
+		PrimaryRepo: h.PrimaryRepo,
+		ACMMLevel:   h.ACMMLevel,
+		Status:      h.Status,
+		IsPublic:    h.IsPublic,
+	}
+
+	// Overlay the live heartbeat-derived fields (version, online state,
+	// agent roster, issue/PR counts) from the registry entry, when present.
+	// Same safe-subset copy as above — field by field, never the whole
+	// RegistryEntry.
+	s.mu.RLock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == id {
+			reg := &s.registry.Hives[i]
+			out.Version = reg.Version
+			out.GitBranch = reg.GitBranch
+			out.TrackedChannel = h.TrackedChannel
+			out.Online = reg.Online
+			out.AgentCount = reg.AgentCount
+			out.ActionableIssues = reg.ActionableIssues
+			out.ActionablePRs = reg.ActionablePRs
+			if len(reg.Agents) > 0 {
+				out.Agents = make([]PublicAgentSummary, 0, len(reg.Agents))
+				for _, a := range reg.Agents {
+					out.Agents = append(out.Agents, PublicAgentSummary{
+						Name:   a.Name,
+						State:  a.State,
+						Paused: a.Paused,
+					})
+				}
+			}
+			break
+		}
+	}
+	s.mu.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(out)
 }
 
 // handleOpenHive is the SSO handoff entry point: a hub-authenticated user hits


### PR DESCRIPTION
## Problem

Tested against a public hive (`hosted-available-oke-01-placeholder-bb95`, `is_public: true`):

- `GET /api/saas/hives/{id}/status` on the hub → **401/403**.
- Spoke `GET /api/status` → **401** too.

Root cause: PR #3692 ("hive status is owner-only") deliberately tightened `handleHiveStatus` from read/read-write grantees to effective-owners-only (`userIsHiveOwner`), because the full `SaaSHive` record carries operational metadata beyond what a read grant implies. That's the right call for the full record — but it also broke the public, unauthenticated read-only preview that relied on this route for `is_public: true` hives.

**Where the preview actually lives, and why it was broken end-to-end (not just the API 401):**

- `/open` (`handleOpenHive`) is **not** the public preview surface — it requires the visitor to already be a hub-authenticated owner/grantee and redirects anonymous callers to `/login`. It's the SSO handoff into the spoke's own dashboard for people who already have access.
- The spoke has **no `is_public` concept locally at all** — `is_public` is a hub-side SaaS field the spoke merely reports over heartbeat (`cfg.Hub.IsPublic`, `v2/pkg/dashboard/api.go`). The spoke's `isPublicPath` allowlist (`v2/pkg/dashboard/server.go`) does not include `/api/status`, so the spoke's own data API 401s for anonymous callers regardless of `is_public` — there is no working spoke-side public read path today, and building one there would duplicate the allowlist-DTO work for no benefit.
- The hub's "public hives" table (`loadPublicHives`, in the SPA embedded in `saas.go`) already lists other operators' `is_public` hives by name — but the name was inert text with no link to any live view.

So there was no working "public preview" UI anywhere — this PR builds one, hub-side, backed by a safe allowlist DTO.

## Fix

### 1. `GET /api/saas/hives/{id}/public-status` (JSON, anonymous)

Registered without `requireAuth` (same pattern as `/open` and `/access-status`).

- Hive missing, or not `is_public: true` and caller isn't owner/admin → **404** (`{"error":"hive not found"}` — identical to "doesn't exist", so this can't be used to enumerate private hives).
- Otherwise → **200** with a hand-built allowlist DTO, `PublicHiveStatus`, populated field-by-field from `SaaSHive`/`RegistryEntry`. The raw structs are never marshaled or embedded.

**Fields exposed:** `id`, `project_name`, `org`, `primary_repo`, `acmm_level`, `status`, `is_public`, `version`, `git_branch`, `tracked_channel`, `online`, `agent_count`, `agents[].{name,state,paused}` (via `PublicAgentSummary`), `actionable_issues`, `actionable_prs`.

**Fields explicitly excluded:** `Owner` (PII), `GitHubHost`/`GitHubBaseURL`/`GitHubAPIURL`, `PendingAppConfig` (GitHub App id/slug/installation id), `RequestedAppReset`/`RequestedGitHubHost`/`ForgeDelivered`, `ClusterID`/`ClusterName`/`Namespace`, `OCIFileSystemID`/`OCIExportID`, `Error`, `PendingRequests`, `AutoUpgrade*`/`RequestedRestartAt`, `Health` blob, cost/token data, `ConflictingReporters`/`StatusFlipping`, and from `AgentSummary`: `StartedAt`/`LastActivityAt`/`NeedsLogin`/`SessionMissing`.

### 2. `GET /api/saas/hives/{id}/preview` (HTML, anonymous) — the actual browser-facing page

Also registered without `requireAuth`. Serves a small static HTML shell (`publicHivePreviewHTML`) that fetches `/public-status` **client-side** and renders it using the same DOM-based `esc()`-via-`textContent` pattern the rest of the hub SPA uses — a malicious `project_name`/`org`/`primary_repo` can never inject markup. The page handler itself never touches `SaaSHive`/`RegistryEntry`, so it can't regress the allowlist even by accident; the allowlist enforcement lives entirely in `/public-status`.

### 3. Wired the public hives table

`loadPublicHives`'s hive-name cell now links to `/api/saas/hives/{id}/preview` instead of being inert text — this is the actual entry point a shared public-hive link should use.

`handleHiveStatus` (the full owner-only record) is **completely untouched** — still requires auth, still gated by `userIsHiveOwner`.

## Tests

`v2/pkg/hub/public_hive_status_test.go`:
- Anonymous GET `/public-status` on an `is_public` hive → 200, asserts every sensitive value (GitHub App identity, cluster ID, namespace, error strings, owner username, pending requests, `NeedsLogin`/`StartedAt`, etc.) is **absent** from the raw response body.
- Anonymous / non-owner GET `/public-status` on a private hive → 404, body doesn't leak owner/name.
- Owner GET `/public-status` on their own not-yet-public hive → 200 (fallthrough via `userIsHiveOwner`).
- Nonexistent hive → 404.
- `/preview` is reachable anonymously, returns HTML referencing `/public-status`, and contains **no** server-interpolated hive data (id/name) of its own — confirms it's a pure client-side-fetch shell.
- Route-table test: drives both `/public-status` and `/preview` through the **real mux** with zero credentials and asserts neither 401s nor redirects to `/login`.
- Regression: `handleHiveStatus` (full record) still 403s for anonymous/non-owner and 200s for the owner — unchanged by this PR.

Per repo convention, `go build`/`go test`/lint were **not** run locally — CI validates.
