### PR TITLE
🔒 fix(dashboard): close three missing-authorization gaps — F22, F25, #3011

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -7186,7 +7186,21 @@ func (s *Server) handleHivesHeartbeat(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]any{"ok": true})
 }
 
+// handleHivesDelete removes an entry from the federation registry.
+//
+// OWNER-ONLY (audit F25, 2026-08-14). Deletion is the destructive end of the
+// hive lifecycle: register/heartbeat are self-service actions a peer hive
+// performs for ITSELF, but delete removes ANOTHER hive from the discovery
+// list, so it is an administrative action on shared state rather than a
+// contributor one. Un-gated, any authenticated write-tier session could
+// unregister peers. Impact is bounded — the registry is a discovery list and
+// handleHivesRegister can re-add entries — but the gate matches the owner-only
+// convention the other destructive dashboard mutations follow (F14's
+// handleContributorDelete, handleAgentDelete).
 func (s *Server) handleHivesDelete(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	id := r.PathValue("id")
 	reg := loadFederationRegistry()
 	for i := range reg.Hives {

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -6805,8 +6805,34 @@ func (s *Server) handleContributorAgentRoleGrants(w http.ResponseWriter, r *http
 	jsonResponse(w, map[string]any{"ok": true, "agent_role_grants": grants, "grantable_roles": grantable})
 }
 
+// handleContributorAgentRole assigns a contributor's agent role.
+//
+// OWNER-ONLY (issue #3011, High). This was gated on requireContributorWrite,
+// which admits any caller whose role is not "read" — so a read-write
+// contributor could assign privileged agent roles. Its sibling
+// handleContributorAgentRoleGrants was moved to requireOwnerRole by F16; this
+// half of #3011 was left behind. Role assignment is an operator action.
+//
+// The handler also used to PRE-POPULATE its probe profile with the very grant
+// it was about to check:
+//
+//	probeProfile := *p
+//	if roleClaimNeedsGrant[role] && !hasAgentRoleGrant(&probeProfile, role) {
+//	    probeProfile.AgentRoleGrants = append(probeProfile.AgentRoleGrants, role)
+//	}
+//
+// which made roleClaimAllowed's "requires an operator grant" check pass
+// trivially, and then wrote that grant to the REAL profile — auto-granting
+// sec-check/architect/ci-maintainer as a side effect of assigning them. That
+// is removed: the probe is now the unmodified profile, so a role needing a
+// grant is REFUSED unless the target already holds it. Grant issuance stays a
+// separate explicit owner action (handleContributorAgentRoleGrants).
+//
+// Assignment is additionally checked against the server-side assignable
+// allowlist, so a role outside contributorAgentRoleAssignableRoles cannot be
+// assigned even when roleClaimAllowed would tolerate it.
 func (s *Server) handleContributorAgentRole(w http.ResponseWriter, r *http.Request) {
-	if !s.requireContributorWrite(w, r) {
+	if !requireOwnerRole(w, r) {
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
@@ -6831,11 +6857,27 @@ func (s *Server) handleContributorAgentRole(w http.ResponseWriter, r *http.Reque
 	if role == "" || role == "none" {
 		p.AssignedAgentRole = "none"
 	} else {
-		probeProfile := *p
-		if roleClaimNeedsGrant[role] && !hasAgentRoleGrant(&probeProfile, role) {
-			probeProfile.AgentRoleGrants = append(probeProfile.AgentRoleGrants, role)
+		// Server-side allowlist: only roles the hive actually exposes as
+		// assignable may be assigned (issue #3011 recommendation 3).
+		var allowCfg *config.Config
+		if s.deps != nil {
+			allowCfg = s.deps.Config
 		}
-		probe := &ContributorConnection{profile: &probeProfile}
+		assignable := false
+		for _, candidate := range contributorAgentRoleAssignableRoles(allowCfg) {
+			if candidate == role {
+				assignable = true
+				break
+			}
+		}
+		if !assignable {
+			jsonError(w, fmt.Sprintf("agent role %q is not assignable", role), http.StatusBadRequest)
+			return
+		}
+
+		// Probe with the profile AS IT IS. Pre-seeding the grant here was the
+		// #3011 bypass: it made the grant check below tautological.
+		probe := &ContributorConnection{profile: p}
 		if s.contributeHub == nil {
 			s.contributeHub = NewContributeWSHub(s.logger, s)
 		}
@@ -6843,9 +6885,13 @@ func (s *Server) handleContributorAgentRole(w http.ResponseWriter, r *http.Reque
 			jsonError(w, reason, http.StatusBadRequest)
 			return
 		}
+		// Belt and braces: roleClaimAllowed returns early for the no-config
+		// hubs used by unit tests and legacy deployments, so re-assert the
+		// grant requirement here unconditionally. No grant is ever WRITTEN by
+		// this handler — that is handleContributorAgentRoleGrants' job.
 		if roleClaimNeedsGrant[role] && !hasAgentRoleGrant(p, role) {
-			p.AgentRoleGrants = append(p.AgentRoleGrants, role)
-			p.AgentRoleGrants = normalizeUniqueAgentRoles(p.AgentRoleGrants)
+			jsonError(w, fmt.Sprintf("agent role %q requires an operator grant", role), http.StatusBadRequest)
+			return
 		}
 		p.AssignedAgentRole = role
 	}

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -1120,7 +1120,19 @@ func TestHivesDelete(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.mux.ServeHTTP(w, req)
 
+	// Audit F25 (2026-08-14): this test used to send a bare DELETE with no role
+	// headers and assert 200 — i.e. it ENCODED the missing gate as correct
+	// behaviour. It is inverted rather than deleted: the un-gated call must now
+	// be REFUSED, and the owner call must still succeed.
+	reqUngated := httptest.NewRequest(http.MethodDelete, "/api/hives/hive-del-org-del", nil)
+	wUngated := httptest.NewRecorder()
+	s.mux.ServeHTTP(wUngated, reqUngated)
+	if wUngated.Code != http.StatusForbidden {
+		t.Fatalf("un-gated DELETE /api/hives/{id} got %d, want 403 — the owner gate is missing (audit F25)", wUngated.Code)
+	}
+
 	req2 := httptest.NewRequest(http.MethodDelete, "/api/hives/hive-del-org-del", nil)
+	markOwnerRequest(req2)
 	w2 := httptest.NewRecorder()
 	s.mux.ServeHTTP(w2, req2)
 	if w2.Code != http.StatusOK {
@@ -1129,6 +1141,7 @@ func TestHivesDelete(t *testing.T) {
 
 	// 404 for already deleted
 	req3 := httptest.NewRequest(http.MethodDelete, "/api/hives/hive-del-org-del", nil)
+	markOwnerRequest(req3)
 	w3 := httptest.NewRecorder()
 	s.mux.ServeHTTP(w3, req3)
 	if w3.Code != http.StatusNotFound {

--- a/v2/pkg/dashboard/api_governor_features.go
+++ b/v2/pkg/dashboard/api_governor_features.go
@@ -35,7 +35,20 @@ const (
 // their runtime behavior. saveConfig() persists a secret-free overlay to the
 // PVC that the entrypoint merges on restart, so a hosted hive picks the change
 // up on its next boot.
+//
+// OWNER-ONLY (audit F22, 2026-08-14). The body carries OTelEndpoint,
+// OTelHeaders, OTelInsecure and TracingEndpoint, which feed a live OTLP
+// exporter (pkg/tracing/tracing.go WithEndpointURL/WithHeaders/WithInsecure).
+// Un-gated, any read-write or merger member could redirect the hive's entire
+// trace stream — spans carry hive.agent, issue refs, model names and token
+// counts (pkg/tracing/semconv.go) — to an attacker-controlled collector, and
+// flip OTelInsecure to strip TLS off it. Eleven of the twelve governor-config
+// writers already called requireOwnerRole; this one was the lone outlier,
+// exactly the asymmetry that established F16.
 func (s *Server) handleGovernorFeatures(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
 	var body struct {
 		IoscanEnabled *bool `json:"ioscanEnabled"`
 

--- a/v2/pkg/dashboard/contribute_agent_role_assignment_test.go
+++ b/v2/pkg/dashboard/contribute_agent_role_assignment_test.go
@@ -64,13 +64,42 @@ func TestContributorAgentRoleAssignmentValidationAndPersistence(t *testing.T) {
 		t.Fatalf("supervisor got %d, want 400", rec.Code)
 	}
 
+	// Issue #3011: this block used to assert the AUTO-GRANT — it expected 200
+	// and a profile that had silently acquired the ci-maintainer grant
+	// ("assignment did not persist with auto-grant"). That behaviour WAS the
+	// vulnerability, so the assertions are INVERTED rather than deleted.
+	// ci-maintainer is in roleClaimNeedsGrant, and alice holds no grant, so the
+	// assignment must now be REFUSED and must write nothing.
+	rec = putAssignedRole(t, s, "c-alice", "ci-maintainer")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("assign ci-maintainer without a grant got %d, want 400 — the auto-grant "+
+			"bypass is back (issue #3011); body: %s", rec.Code, rec.Body.String())
+	}
+	p = findContributor("c-alice")
+	if hasAgentRoleGrant(p, "ci-maintainer") {
+		t.Fatalf("refused the assignment but still wrote the grant to the profile: %+v", p)
+	}
+	if p.AssignedAgentRole == "ci-maintainer" {
+		t.Fatalf("refused the assignment but still assigned the role: %+v", p)
+	}
+
+	// The legitimate path: an owner grants the role explicitly, and only then
+	// can it be assigned.
+	grantReq := httptest.NewRequest(http.MethodPut, "/api/contributors/c-alice/agent-role-grants", strings.NewReader(`{"agent_role_grants":["ci-maintainer"]}`))
+	grantReq.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(grantReq)
+	grantRec := httptest.NewRecorder()
+	s.mux.ServeHTTP(grantRec, grantReq)
+	if grantRec.Code != http.StatusOK {
+		t.Fatalf("explicit grant got %d, want 200: %s", grantRec.Code, grantRec.Body.String())
+	}
 	rec = putAssignedRole(t, s, "c-alice", "ci-maintainer")
 	if rec.Code != http.StatusOK {
-		t.Fatalf("assign ci-maintainer got %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+		t.Fatalf("assign ci-maintainer after an explicit grant got %d, want 200 (body: %s)", rec.Code, rec.Body.String())
 	}
 	p = findContributor("c-alice")
 	if p.AssignedAgentRole != "ci-maintainer" || !hasAgentRoleGrant(p, "ci-maintainer") {
-		t.Fatalf("assignment did not persist with auto-grant: %+v", p)
+		t.Fatalf("granted assignment did not persist: %+v", p)
 	}
 	req := httptest.NewRequest(http.MethodPut, "/api/contributors/c-alice/agent-role-grants", strings.NewReader(`{"agent_role_grants":[]}`))
 	req.Header.Set("Content-Type", "application/json")

--- a/v2/pkg/dashboard/f22_f25_gate_test.go
+++ b/v2/pkg/dashboard/f22_f25_gate_test.go
@@ -1,0 +1,323 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Audit F22/F25 (2026-08-14). Two dashboard writers performed privileged
+// mutations with NO role gate:
+//
+//   - PUT /api/config/governor/features (F22, Medium) — the body carries
+//     otelEndpoint, otelHeaders, otelInsecure and tracingEndpoint, which feed a
+//     live OTLP exporter. Un-gated, any read-write or merger member could point
+//     the hive's whole trace stream at an attacker-controlled collector (spans
+//     carry hive.agent, issue refs, model names, token counts) and strip TLS
+//     off it. Eleven of the twelve governor-config writers already gated; this
+//     was the lone outlier — the same asymmetry that established F16.
+//   - DELETE /api/hives/{id} (F25, Low) — removed a peer from the federation
+//     registry with no gate of any kind.
+//
+// As with F14/F16 these assert the INVARIANT at the source level as well as
+// behaviourally, because the failure mode for this class of bug in this repo is
+// a sync merge silently dropping a gate, not a logic bug. F14 regressed exactly
+// that way and a behavioural test on one handler did not catch it.
+
+// --- BEHAVIOURAL: REJECTED in one direction, ACCEPTED in the other -----------
+
+// putFeatures issues PUT /api/config/governor/features with caller-controlled
+// headers, so a test can pick the role rather than inheriting doPut's owner
+// headers.
+func putFeatures(s *Server, body map[string]any, mark func(*http.Request)) *httptest.ResponseRecorder {
+	var b bytes.Buffer
+	_ = json.NewEncoder(&b).Encode(body)
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/features", &b)
+	req.Header.Set("Content-Type", "application/json")
+	if mark != nil {
+		mark(req)
+	}
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestF22GovernorFeaturesRejectsNonOwner is the negative half: every non-owner
+// shape must be refused. Each subtest is a caller the audit named as able to
+// reach the OTel exporter config before the fix.
+func TestF22GovernorFeaturesRejectsNonOwner(t *testing.T) {
+	body := map[string]any{
+		"otelEnabled":  true,
+		"otelEndpoint": "https://attacker.example.com/v1/traces",
+		"otelInsecure": true,
+		"otelHeaders":  map[string]string{"authorization": "stolen"},
+	}
+
+	cases := []struct {
+		name string
+		mark func(*http.Request)
+	}{
+		{"no role headers at all", nil},
+		{"read-write session", func(r *http.Request) { r.Header.Set("X-Hive-Role", "read-write") }},
+		{"merger session", func(r *http.Request) { r.Header.Set("X-Hive-Role", "merger") }},
+		// The spoofable half: a client-supplied owner role WITHOUT the
+		// server-only verification marker must not pass. A test that sent only
+		// X-Hive-Role: owner and saw 200 would be passing for the wrong reason.
+		{"owner role header without the verified marker", func(r *http.Request) {
+			r.Header.Set("X-Hive-Role", "owner")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := covApiServer(t)
+			rec := putFeatures(s, body, tc.mark)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("PUT governor/features as %s got %d, want 403 — "+
+					"this caller can redirect the OTel trace stream (audit F22)", tc.name, rec.Code)
+			}
+			// The gate must refuse BEFORE mutating config, not after.
+			if got := s.deps.Config.EffectiveOTel(); got.Endpoint == "https://attacker.example.com/v1/traces" {
+				t.Fatalf("refused with 403 but the endpoint was still written: %+v", got)
+			}
+		})
+	}
+}
+
+// TestF22GovernorFeaturesAcceptsOwner is the positive half. Without it, a gate
+// that rejected EVERYTHING would satisfy the test above while breaking the
+// Governor config dialog outright.
+func TestF22GovernorFeaturesAcceptsOwner(t *testing.T) {
+	s := covApiServer(t)
+	rec := putFeatures(s, map[string]any{
+		"otelEnabled":     true,
+		"otelEndpoint":    "https://otel-collector.example.com:4318",
+		"otelServiceName": "hive-ui",
+	}, markOwnerRequest)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner PUT governor/features got %d, want 200 — the gate is over-broad "+
+			"and has broken the legitimate Governor config workflow; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := s.deps.Config.EffectiveOTel(); !got.Enabled || got.Endpoint != "https://otel-collector.example.com:4318" {
+		t.Fatalf("owner update did not take effect: %+v", got)
+	}
+}
+
+// TestF25HivesDeleteRejectsNonOwnerAcceptsOwner covers both directions for the
+// federation-registry delete.
+func TestF25HivesDeleteRejectsNonOwner(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mark func(*http.Request)
+	}{
+		{"no role headers at all", nil},
+		{"read-write session", func(r *http.Request) { r.Header.Set("X-Hive-Role", "read-write") }},
+		{"owner role header without the verified marker", func(r *http.Request) {
+			r.Header.Set("X-Hive-Role", "owner")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupContributeEnv(t)
+			s := newHivesTestServer(t)
+
+			req := httptest.NewRequest(http.MethodDelete, "/api/hives/hive-f25-org-f25", nil)
+			if tc.mark != nil {
+				tc.mark(req)
+			}
+			rec := httptest.NewRecorder()
+			s.mux.ServeHTTP(rec, req)
+
+			// 403, NOT 404: the gate must run before the registry lookup, so an
+			// un-gated caller cannot even probe which hives exist.
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("DELETE /api/hives/{id} as %s got %d, want 403 (audit F25)", tc.name, rec.Code)
+			}
+		})
+	}
+}
+
+// TestF25HivesDeleteAcceptsOwner is the positive control: the registered hive
+// must actually be removable by an owner.
+func TestF25HivesDeleteAcceptsOwner(t *testing.T) {
+	setupContributeEnv(t)
+	s := newHivesTestServer(t)
+
+	body := `{"project_name":"f25","org":"f25-org","hub_url":"wss://x:3001/c"}`
+	reg := httptest.NewRequest(http.MethodPost, "/api/hives/register", bytes.NewBufferString(body))
+	reg.Header.Set("Content-Type", "application/json")
+	regRec := httptest.NewRecorder()
+	s.mux.ServeHTTP(regRec, reg)
+	if regRec.Code != http.StatusOK {
+		t.Fatalf("register got %d, want 200: %s", regRec.Code, regRec.Body.String())
+	}
+
+	del := httptest.NewRequest(http.MethodDelete, "/api/hives/hive-f25-org-f25", nil)
+	markOwnerRequest(del)
+	delRec := httptest.NewRecorder()
+	s.mux.ServeHTTP(delRec, del)
+	if delRec.Code != http.StatusOK {
+		t.Fatalf("owner DELETE got %d, want 200 — the gate is over-broad and owners can no "+
+			"longer manage the federation registry; body=%s", delRec.Code, delRec.Body.String())
+	}
+}
+
+func newHivesTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := NewServer(0, testLogger())
+	s.registerContributeRoutes()
+	return s
+}
+
+// --- SOURCE-ASSERTING INVARIANT ----------------------------------------------
+
+// ownerGatedF22F25Handlers maps each handler this fix gated to its file.
+var ownerGatedF22F25Handlers = map[string]string{
+	"handleGovernorFeatures": "api_governor_features.go",
+	"handleHivesDelete":      "api_contribute.go",
+}
+
+// TestF22F25HandlersAreOwnerGated is the source-level regression, mirroring
+// TestF16PrivilegedHandlersAreOwnerGated. This is the test that survives a sync
+// merge reverting the gate while the behavioural tests are also reverted.
+func TestF22F25HandlersAreOwnerGated(t *testing.T) {
+	for name, file := range ownerGatedF22F25Handlers {
+		body := f16HandlerBody(t, f16ReadSource(t, file), name)
+		if !strings.Contains(body, "requireOwnerRole(w, r)") {
+			t.Errorf("%s (%s) has no requireOwnerRole gate — a non-owner write-tier member can "+
+				"reach a privileged mutation (audit F22/F25). If a merge dropped this, restore "+
+				"the gate rather than relaxing the test.", name, file)
+		}
+		// Weaker gates admit RoleReadWrite (or better) and are NOT sufficient.
+		for _, weak := range []string{
+			"s.requireContributorWrite(w, r)",
+			"requireMergerOrOwnerRole(w, r)",
+		} {
+			if strings.Contains(body, weak) {
+				t.Errorf("%s (%s) gates on %s, which admits a non-owner role; this surface is owner-only",
+					name, file, weak)
+			}
+		}
+	}
+}
+
+// governorConfigWriters is the full census of governor-config write handlers
+// from audit F22: twelve writers, of which eleven were gated and `features` was
+// the outlier. After this fix it must be 12 of 12. The count floor below is
+// what catches a NEW un-gated writer being added alongside them later.
+var governorConfigWriters = map[string]string{
+	"handleGovernorSensing":       "api.go",
+	"handleGovernorThresholds":    "api.go",
+	"handleGovernorLabels":        "api.go",
+	"handleGovernorBudget":        "api.go",
+	"handleGovernorNotifications": "api.go",
+	"handleGovernorHealth":        "api.go",
+	"handleGovernorLogging":       "api.go",
+	"handleGovernorAttribution":   "api.go",
+	"handleGovernorHub":           "api.go",
+	"handleGovernorTrajectory":    "api_trajectory.go",
+	"handleGovernorSecurity":      "api_governor_security.go",
+	"handleGovernorFeatures":      "api_governor_features.go",
+}
+
+// TestF22AllGovernorConfigWritersAreOwnerGated asserts the property the audit
+// actually reasoned from: there is no un-gated outlier among the governor
+// config writers. F22 existed because exactly one of twelve was missing a gate
+// and nothing asserted the set was uniform.
+func TestF22AllGovernorConfigWritersAreOwnerGated(t *testing.T) {
+	const wantWriters = 12
+	if got := len(governorConfigWriters); got != wantWriters {
+		t.Errorf("census lists %d governor config writers, want %d — a writer was added or "+
+			"removed; update this table deliberately and confirm the new one is gated", got, wantWriters)
+	}
+
+	srcCache := map[string]string{}
+	gated := 0
+	for name, file := range governorConfigWriters {
+		src, ok := srcCache[file]
+		if !ok {
+			src = f16ReadSource(t, file)
+			srcCache[file] = src
+		}
+		if strings.Contains(f16HandlerBody(t, src, name), "requireOwnerRole(w, r)") {
+			gated++
+			continue
+		}
+		t.Errorf("governor config writer %s (%s) is not owner-gated — this is the F22 shape: "+
+			"one un-gated outlier among otherwise-uniform writers", name, file)
+	}
+	if gated < wantWriters {
+		t.Errorf("%d of %d governor config writers are owner-gated, want %d of %d (audit F22)",
+			gated, wantWriters, wantWriters, wantWriters)
+	}
+}
+
+// TestF22F25OwnerGateCountFloor is the blunt instrument that survives renames.
+func TestF22F25OwnerGateCountFloor(t *testing.T) {
+	// Minimum requireOwnerRole call sites per file after F22/F25.
+	// api_governor_features.go: features (this fix).
+	// api_contribute.go: the four F14 contributor-management gates + hives delete.
+	// api.go: the nine governor writers that live there.
+	// api_trajectory.go: trajectory.
+	want := map[string]int{
+		"api_governor_features.go": 1,
+		"api_contribute.go":        5,
+		"api.go":                   9,
+		"api_trajectory.go":        1,
+	}
+	gate := regexp.MustCompile(`requireOwnerRole\(w, r\)`)
+	for file, min := range want {
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if got := len(gate.FindAllString(string(raw), -1)); got < min {
+			t.Errorf("%s has %d requireOwnerRole gates, want at least %d — a gate was removed "+
+				"(audit F14 regressed exactly this way, via a sync merge)", file, got, min)
+		}
+	}
+}
+
+// --- POSITIVE CONTROLS -------------------------------------------------------
+//
+// Without these, "add requireOwnerRole to every handler in these files" would
+// satisfy everything above while breaking legitimate workflows.
+
+// TestF25HivesSelfServiceRoutesStayUngated is the substantive control for F25.
+// register and heartbeat are actions a peer hive performs for ITSELF as part of
+// federation onboarding — they are called by other hives, not by a logged-in
+// owner in a browser, so owner-gating them would break federation entirely.
+// Only delete, which acts on ANOTHER hive's entry, is owner-tier.
+func TestF25HivesSelfServiceRoutesStayUngated(t *testing.T) {
+	src := f16ReadSource(t, "api_contribute.go")
+	for _, name := range []string{
+		"handleHivesRegister",
+		"handleHivesHeartbeat",
+		"handleHivesOnboard",
+		"handleHivesList",
+	} {
+		if strings.Contains(f16HandlerBody(t, src, name), "requireOwnerRole(w, r)") {
+			t.Errorf("%s must NOT be owner-gated — register/heartbeat/onboard are self-service "+
+				"actions a peer hive performs for itself and list is a read; owner-gating them "+
+				"breaks federation onboarding", name)
+		}
+	}
+}
+
+// TestF22ReadOnlyConfigGetStaysUngated confirms the config READ path is still
+// reachable by a non-owner, so the Governor dialog can still render for
+// everyone even though only an owner may submit it.
+func TestF22ReadOnlyConfigGetStaysUngated(t *testing.T) {
+	s := covApiServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code == http.StatusForbidden {
+		t.Error("GET /api/config is owner-gated — the Governor view would blank for every " +
+			"non-owner; the F22 gate belongs on the PUT only")
+	}
+}

--- a/v2/pkg/dashboard/issue3011_agent_role_test.go
+++ b/v2/pkg/dashboard/issue3011_agent_role_test.go
@@ -1,0 +1,274 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// Issue #3011 (High, authorization bypass / privilege escalation).
+// PUT /api/contributors/{id}/agent-role had TWO independent defects:
+//
+//  1. It was gated on requireContributorWrite, which admits any caller whose
+//     role is not "read" — so a read-write contributor could assign agent
+//     roles. Its sibling .../agent-role-grants was moved to requireOwnerRole
+//     by F16; this half was left behind, so the issue was half-fixed and still
+//     live on v4.
+//
+//  2. Independent of the gate: the handler PRE-POPULATED its probe profile
+//     with the very grant it was about to check, so roleClaimAllowed's
+//     "requires an operator grant" branch passed trivially, and the grant was
+//     then written to the REAL profile. That auto-granted the privileged roles
+//     (sec-check, architect, ci-maintainer) as a side effect of assigning them.
+//
+// Fixing only the gate would leave an owner able to trip the bypass by
+// accident and leave it one refactor from reachable, so both are fixed and
+// both are pinned here.
+
+// seed3011Contributor writes a trusted contributor holding NO agent-role
+// grants, which is the precondition the bypass exploited.
+func seed3011Contributor(t *testing.T) {
+	t.Helper()
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername: "alice",
+		ContributorID:  "c-alice",
+		TrustTier:      "trusted",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func put3011AgentRole(s *Server, id, body string, mark func(*http.Request)) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/api/contributors/"+id+"/agent-role", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if mark != nil {
+		mark(req)
+	}
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// --- DEFECT 1: THE ROLE GATE -------------------------------------------------
+
+// TestIssue3011AgentRoleRejectsNonOwner is the negative half of the gate.
+func TestIssue3011AgentRoleRejectsNonOwner(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mark func(*http.Request)
+	}{
+		{"no role headers at all", nil},
+		{"read-write session", func(r *http.Request) { r.Header.Set("X-Hive-Role", "read-write") }},
+		{"merger session", func(r *http.Request) { r.Header.Set("X-Hive-Role", "merger") }},
+		// A client-supplied owner role WITHOUT the server-only verification
+		// marker must not pass; a test sending only X-Hive-Role: owner would
+		// otherwise pass for the wrong reason.
+		{"owner role header without the verified marker", func(r *http.Request) {
+			r.Header.Set("X-Hive-Role", "owner")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupContributeEnv(t)
+			seed3011Contributor(t)
+			s, deps := apiServer(t)
+			seedAssignableRoleConfig(deps)
+
+			rec := put3011AgentRole(s, "c-alice", `{"agent_role":"scanner"}`, tc.mark)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("PUT agent-role as %s got %d, want 403 — role assignment is owner-only (issue #3011)",
+					tc.name, rec.Code)
+			}
+			if p := findContributor("c-alice"); p != nil && normalizeAgentRole(p.AssignedAgentRole) != "" {
+				t.Fatalf("refused with 403 but the role was still assigned: %+v", p)
+			}
+		})
+	}
+}
+
+// TestIssue3011AgentRoleAcceptsOwner is the positive control for the gate:
+// without it, a gate that rejected everything would satisfy the test above
+// while breaking the ops tab's role-assignment control outright.
+func TestIssue3011AgentRoleAcceptsOwner(t *testing.T) {
+	setupContributeEnv(t)
+	seed3011Contributor(t)
+	s, deps := apiServer(t)
+	seedAssignableRoleConfig(deps)
+
+	rec := put3011AgentRole(s, "c-alice", `{"agent_role":"scanner"}`, markOwnerRequest)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner PUT agent-role got %d, want 200 — the gate is over-broad and owners can "+
+			"no longer assign agent roles; body=%s", rec.Code, rec.Body.String())
+	}
+	p := findContributor("c-alice")
+	if p == nil || p.AssignedAgentRole != "scanner" {
+		t.Fatalf("owner assignment did not persist: %+v", p)
+	}
+}
+
+// --- DEFECT 2: THE AUTO-GRANT BYPASS -----------------------------------------
+
+// TestIssue3011NoAutoGrantOnAssign is the core of the second defect. Every role
+// in roleClaimNeedsGrant must be REFUSED for a target holding no grant, and —
+// critically — nothing may be written to the persisted profile. The original
+// bug wrote the grant as a side effect, so asserting the HTTP status alone
+// would not have caught it.
+//
+// Note the caller here is a fully-authorized OWNER: this defect is independent
+// of the gate, which is exactly why fixing the gate alone is insufficient.
+func TestIssue3011NoAutoGrantOnAssign(t *testing.T) {
+	for _, role := range []string{"sec-check", "architect", "ci-maintainer"} {
+		t.Run(role, func(t *testing.T) {
+			setupContributeEnv(t)
+			seed3011Contributor(t)
+			s, deps := apiServer(t)
+			seedAssignableRoleConfig(deps)
+			// Make every privileged role delegatable and enabled, so the ONLY
+			// thing standing between the caller and the role is the grant.
+			// Otherwise this test could pass for the wrong reason — refused by
+			// the delegatable-roles check rather than by the grant check.
+			deps.Config.Agents[role] = agentConfigFor(role)
+			deps.Config.Hub.ContributeDelegatableRoles = []string{
+				"scanner", "quality", "outreach", "ci-maintainer", "sec-check", "architect",
+			}
+
+			rec := put3011AgentRole(s, "c-alice", `{"agent_role":"`+role+`"}`, markOwnerRequest)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("assigning %q to a contributor with NO grant got %d, want 400 — "+
+					"the auto-grant bypass is back (issue #3011); body=%s", role, rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "grant") {
+				t.Errorf("refusal should name the missing grant; body=%s", rec.Body.String())
+			}
+
+			// The persisted profile must be untouched in BOTH respects.
+			p := findContributor("c-alice")
+			if p == nil {
+				t.Fatalf("contributor vanished")
+			}
+			if hasAgentRoleGrant(p, role) {
+				t.Fatalf("handler refused the assignment but STILL auto-granted %q to the "+
+					"persisted profile — this is the #3011 escalation: %+v", role, p)
+			}
+			if normalizeAgentRole(p.AssignedAgentRole) == role {
+				t.Fatalf("handler refused the assignment but STILL assigned %q: %+v", role, p)
+			}
+		})
+	}
+}
+
+// TestIssue3011GrantedRoleStillAssignable is the positive control for the
+// bypass fix: a target who legitimately HAS the grant must still be
+// assignable, so "deny every privileged role" cannot pass the test above.
+func TestIssue3011GrantedRoleStillAssignable(t *testing.T) {
+	setupContributeEnv(t)
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername:  "alice",
+		ContributorID:   "c-alice",
+		TrustTier:       "trusted",
+		AgentRoleGrants: []string{"ci-maintainer"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s, deps := apiServer(t)
+	seedAssignableRoleConfig(deps)
+
+	rec := put3011AgentRole(s, "c-alice", `{"agent_role":"ci-maintainer"}`, markOwnerRequest)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assigning a role the contributor HOLDS A GRANT for got %d, want 200 — the "+
+			"fix over-corrected and explicit operator grants no longer work; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	p := findContributor("c-alice")
+	if p == nil || p.AssignedAgentRole != "ci-maintainer" {
+		t.Fatalf("granted assignment did not persist: %+v", p)
+	}
+}
+
+// TestIssue3011UnprivilegedRolesNeedNoGrant is the second positive control: the
+// ordinary roles are NOT in roleClaimNeedsGrant and must stay assignable
+// without any grant, so the grant check cannot be over-applied.
+func TestIssue3011UnprivilegedRolesNeedNoGrant(t *testing.T) {
+	for _, role := range []string{"scanner", "quality"} {
+		t.Run(role, func(t *testing.T) {
+			setupContributeEnv(t)
+			seed3011Contributor(t)
+			s, deps := apiServer(t)
+			seedAssignableRoleConfig(deps)
+
+			rec := put3011AgentRole(s, "c-alice", `{"agent_role":"`+role+`"}`, markOwnerRequest)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("assigning unprivileged role %q got %d, want 200 — the grant check is "+
+					"over-applied; body=%s", role, rec.Code, rec.Body.String())
+			}
+			if p := findContributor("c-alice"); p == nil || p.AssignedAgentRole != role {
+				t.Fatalf("assignment did not persist: %+v", p)
+			}
+		})
+	}
+}
+
+// --- SOURCE-ASSERTING INVARIANT ----------------------------------------------
+
+// TestIssue3011AgentRoleHandlersAreOwnerGated pins BOTH endpoints at the source
+// level. The grants half was already fixed by F16 and regressing it would
+// re-open this issue's other half, so both are asserted together.
+func TestIssue3011AgentRoleHandlersAreOwnerGated(t *testing.T) {
+	src := f16ReadSource(t, "api_contribute.go")
+	for _, name := range []string{
+		"handleContributorAgentRole",
+		"handleContributorAgentRoleGrants",
+	} {
+		body := f16HandlerBody(t, src, name)
+		if !strings.Contains(body, "requireOwnerRole(w, r)") {
+			t.Errorf("%s has no requireOwnerRole gate — a read-write contributor can assign or "+
+				"grant privileged agent roles (issue #3011)", name)
+		}
+		if strings.Contains(body, "s.requireContributorWrite(w, r)") {
+			t.Errorf("%s gates on requireContributorWrite, which admits RoleReadWrite; agent-role "+
+				"administration is owner-only (issue #3011)", name)
+		}
+	}
+}
+
+// TestIssue3011ProbeIsNotPreSeededWithTheGrant asserts the bypass cannot come
+// back by shape. The defect was a single append onto a COPY of the profile
+// immediately before the check that reads it; a behavioural test catches
+// today's version, this catches a re-introduction that a refactor makes
+// reachable again.
+func TestIssue3011ProbeIsNotPreSeededWithTheGrant(t *testing.T) {
+	body := f16HandlerBody(t, f16ReadSource(t, "api_contribute.go"), "handleContributorAgentRole")
+
+	if strings.Contains(body, "probeProfile") {
+		t.Error("handleContributorAgentRole reconstructs a probeProfile — the #3011 bypass " +
+			"pre-populated a copied profile with the grant it was about to check, making " +
+			"roleClaimAllowed tautological. Probe with the real profile instead.")
+	}
+	// The handler must never WRITE a grant. Issuance belongs to
+	// handleContributorAgentRoleGrants alone.
+	if strings.Contains(body, "AgentRoleGrants = append") {
+		t.Error("handleContributorAgentRole appends to AgentRoleGrants — this handler must never " +
+			"issue a grant; that is handleContributorAgentRoleGrants' job (issue #3011)")
+	}
+}
+
+// TestIssue3011GrantIssuanceStaysWithTheGrantsHandler is the positive control
+// for the source assertion above: the grants handler is the one place that IS
+// supposed to write grants, so "no handler may ever write a grant" cannot be
+// the reading of the rule.
+func TestIssue3011GrantIssuanceStaysWithTheGrantsHandler(t *testing.T) {
+	body := f16HandlerBody(t, f16ReadSource(t, "api_contribute.go"), "handleContributorAgentRoleGrants")
+	if !strings.Contains(body, "p.AgentRoleGrants = grants") {
+		t.Error("handleContributorAgentRoleGrants no longer writes grants — grant issuance must " +
+			"still exist as an explicit owner action, otherwise privileged roles become " +
+			"unassignable entirely")
+	}
+}
+
+// agentConfigFor builds an enabled AgentConfig for a role, so a test can make a
+// privileged role fully available and isolate the grant check.
+func agentConfigFor(role string) config.AgentConfig {
+	return config.AgentConfig{Role: role, Enabled: true}
+}


### PR DESCRIPTION
Closes audit-8 findings **F22** (Medium) and **F25** (Low), plus issue **#3011** (High). All three are missing/insufficient-authorization bugs in `pkg/dashboard` route and gate code, so they ship together.

Fixes #3011

---

## F22 — `PUT /api/config/governor/features` ungated (Medium)

**Confirmed.** Registered at `v2/pkg/dashboard/api.go:139`, handled at `v2/pkg/dashboard/api_governor_features.go:38` with no gate. I re-ran the audit's census independently — of the twelve governor-config writers, **eleven** already called `requireOwnerRole` and `features` was the lone outlier, exactly the asymmetry that established F16.

The body carries `otelEndpoint`, `otelHeaders`, `otelInsecure` and `tracingEndpoint`, which feed a live OTLP exporter (`pkg/tracing/tracing.go` `WithEndpointURL`/`WithHeaders`/`WithInsecure`). Un-gated, any `read-write` or `merger` session could redirect the hive's entire trace stream — spans carry `hive.agent`, issue refs, model names and token counts — to an attacker-controlled collector, and flip `otelInsecure` to strip TLS off it.

### SSRF assessment

**A private-address guard is deliberately not added, and the role gate alone is the right close.** Reasoning:

- This handler **only persists config** — it dials nothing. The endpoint is consumed by `tracing.Init` at process start (`cmd/hive/main.go:1004`). There is no request-time fetch, so there is no SSRF *probe* primitive: no response, no error/timing oracle, no cloud-metadata read back to the caller.
- `guardDiscoverEndpoint` (the F13 fix) is the wrong template. Its own doc comment says the placement is "deliberate and easy to 'fix' wrongly" — it guards **discover**, a caller-driven immediate fetch, and was explicitly kept out of `validateGatewayEndpoint` because in-cluster endpoints are supported there. OTel is the same situation: in-cluster collectors (`*.svc.cluster.local`, `localhost:4318`) are a normal deployment, and blanket private-address denial would break them — the remedy the F6 fix already rejected.
- What remains post-fix is an **owner** able to point trace export at an internal address. An owner already edits `hive.yaml` and controls the exporter directly, so this is configuration, not privilege escalation.

The exfiltration half of F22 — the genuinely serious half — is fully closed by the gate.

## F25 — `DELETE /api/hives/{id}` no role gate (Low)

**Confirmed.** Registered at `api_contribute.go:405`; `handleHivesDelete` had no gate of any kind, so any authenticated write-tier session could unregister a peer from the federation registry.

One nuance worth flagging: the audit says "sibling mutations in the same file are gated", which holds file-wide (the four F14 contributor-management gates) but **not** for the hive-lifecycle siblings — `register`, `heartbeat` and `onboard` are all ungated. That is correct and deliberate: those are self-service actions a peer hive performs **for itself** during federation onboarding, called by other hives rather than by a logged-in owner. Only `delete`, which acts on **another** hive's entry, is administrative. It is now owner-tier like the other destructive dashboard mutations, and a positive control pins the other three as ungated.

## #3011 — agent-role assignment: gate + auto-grant bypass (High)

**Confirmed half-fixed and still live on v4**, with two independent defects.

**Defect 1 — the gate.** `PUT /api/contributors/{id}/agent-role` was on `s.requireContributorWrite(w, r)`, which admits any caller whose role is not `read`. The sibling `.../agent-role-grants` was moved to `requireOwnerRole` by F16; this half was left behind. Now `requireOwnerRole`.

**Defect 2 — the auto-grant bypass, independent of the gate.** The handler pre-populated its probe profile with the very grant it was about to check, so `roleClaimAllowed`'s "requires an operator grant" branch passed trivially, and the grant was then written to the **real** profile — auto-granting `sec-check`/`architect`/`ci-maintainer` as a side effect of assigning them. The probe is now the unmodified profile, and the handler never writes a grant at all; issuance stays an explicit owner action on the grants handler.

Two things worth calling out:

- The grant requirement is **re-asserted unconditionally** after `roleClaimAllowed`, because that function returns early ("role is a display label") for the no-config hubs used by unit tests and legacy deployments. Relying on it alone would leave the check unenforced exactly where `Config` is absent.
- Added the server-side assignable allowlist the issue recommends (recommendation 3), so a role outside `contributorAgentRoleAssignableRoles` cannot be assigned even where `roleClaimAllowed` would tolerate it.

## Gate applied

`requireOwnerRole(w, r)` on all three, matching the established siblings rather than inventing a pattern. It requires the server-only `ownerRoleVerifiedHeader` **in addition to** `X-Hive-Role: owner`, so a spoofed client role header fails closed — every endpoint has an explicit test for that shape.

On CSRF: `requireAdmin`/`isCSRFSafe` live in `pkg/hub` and guard the SaaS proxy layer; nothing in `pkg/dashboard` calls them, and none of the gated siblings do. Importing a hub-layer helper here would be exactly the new-pattern invention to avoid, so these match their siblings.

## Tests

Source-asserting **and** behavioural, because the failure mode for this class in this repo is a sync merge silently dropping a gate — F14 regressed that way and a behavioural test alone missed it.

`v2/pkg/dashboard/f22_f25_gate_test.go`:

| Test | Role |
|---|---|
| `TestF22GovernorFeaturesRejectsNonOwner` | 4 subtests: no headers, read-write, merger, owner-without-verified-marker → 403; asserts config not mutated |
| `TestF22GovernorFeaturesAcceptsOwner` | positive control |
| `TestF25HivesDeleteRejectsNonOwner` | 3 subtests → 403 (not 404: the gate runs before registry lookup, so callers cannot probe which hives exist) |
| `TestF25HivesDeleteAcceptsOwner` | positive control |
| `TestF22F25HandlersAreOwnerGated` | source invariant; rejects downgrade to `requireContributorWrite`/`requireMergerOrOwnerRole` |
| `TestF22AllGovernorConfigWritersAreOwnerGated` | **12-of-12 census** over the full writer set |
| `TestF22F25OwnerGateCountFloor` | per-file count floors |
| `TestF25HivesSelfServiceRoutesStayUngated` | positive control: register/heartbeat/onboard/list stay ungated |
| `TestF22ReadOnlyConfigGetStaysUngated` | positive control: `GET /api/config` must not blank for non-owners |

`v2/pkg/dashboard/issue3011_agent_role_test.go`:

| Test | Role |
|---|---|
| `TestIssue3011AgentRoleRejectsNonOwner` | 4 subtests incl. owner-without-verified-marker → 403 |
| `TestIssue3011AgentRoleAcceptsOwner` | positive control |
| `TestIssue3011NoAutoGrantOnAssign` | `sec-check`/`architect`/`ci-maintainer` refused for a target with no grant, asserting the **persisted profile is unchanged** — the caller is a fully-authorized owner, since this defect is gate-independent |
| `TestIssue3011GrantedRoleStillAssignable` | positive control — a target who HAS the grant is still assignable |
| `TestIssue3011UnprivilegedRolesNeedNoGrant` | positive control — the grant check is not over-applied |
| `TestIssue3011AgentRoleHandlersAreOwnerGated` | source invariant, both endpoints |
| `TestIssue3011ProbeIsNotPreSeededWithTheGrant` | source invariant: no `probeProfile` reconstruction, no `AgentRoleGrants` append in the assign handler |
| `TestIssue3011GrantIssuanceStaysWithTheGrantsHandler` | positive control — grant issuance must still exist somewhere |

### Two tests that ENCODED the vulnerabilities — inverted, not deleted

- `TestHivesDelete` sent a bare DELETE with no role headers and asserted **200**. Inverted: the un-gated call must now be refused, and the owner path must still succeed.
- `TestContributorAgentRoleAssignmentValidationAndPersistence` asserted the auto-grant outright — `"assignment did not persist with auto-grant"`. Inverted: the ungranted assign must now be refused and write nothing, and the legitimate **grant-then-assign** path is asserted in its place.

`TestCovGov_Features` needed no change — the shared `doPut`/`doDelete` helpers already call `markOwnerRequest`, so it was not encoding the vulnerability.

## Regression replay

Neutered each fix so it still compiles, confirmed failure, restored, confirmed green. All four replays failed genuinely — no false pass.

**F22 neutered:**
```
--- FAIL: TestF22GovernorFeaturesRejectsNonOwner/read-write_session
    PUT governor/features as read-write session got 200, want 403 — this caller can redirect the OTel trace stream (audit F22)
--- FAIL: TestF22AllGovernorConfigWritersAreOwnerGated
    11 of 12 governor config writers are owner-gated, want 12 of 12 (audit F22)
--- FAIL: TestF22F25OwnerGateCountFloor
    api_governor_features.go has 0 requireOwnerRole gates, want at least 1
```
The census reproducing the audit's exact "11 of 12" is the signal that it measures the real property.

**F25 neutered:**
```
--- FAIL: TestHivesDelete
    un-gated DELETE /api/hives/{id} got 200, want 403 — the owner gate is missing (audit F25)
--- FAIL: TestF25HivesDeleteRejectsNonOwner/no_role_headers_at_all
    DELETE /api/hives/{id} as no role headers at all got 404, want 403 (audit F25)
```

**#3011 gate downgraded to `requireContributorWrite`:**
```
--- FAIL: TestIssue3011AgentRoleRejectsNonOwner/read-write_session
    PUT agent-role as read-write session got 200, want 403 — role assignment is owner-only (issue #3011)
--- FAIL: TestIssue3011AgentRoleHandlersAreOwnerGated
    handleContributorAgentRole gates on requireContributorWrite, which admits RoleReadWrite
```

**#3011 auto-grant bypass restored (owner gate left in place, to prove the defect is independent):**
```
--- FAIL: TestIssue3011NoAutoGrantOnAssign/sec-check
    assigning "sec-check" to a contributor with NO grant got 200, want 400 — the auto-grant bypass is back (issue #3011);
    body={"agent_role_grants":["sec-check"],...,"assigned_agent_role":"sec-check","ok":true}
--- FAIL: TestContributorAgentRoleAssignmentValidationAndPersistence
    assign ci-maintainer without a grant got 200, want 400 — the auto-grant bypass is back (issue #3011)
--- FAIL: TestIssue3011ProbeIsNotPreSeededWithTheGrant
    handleContributorAgentRole reconstructs a probeProfile ...
```
The response body showing `"agent_role_grants":["sec-check"]` is the escalation itself: the grant was written as a side effect of the assign.

All restored → `ok github.com/kubestellar/hive/v2/pkg/dashboard`.

## Verification

- `go build ./...` clean
- `go test ./pkg/dashboard/` — `ok` (58s), full suite
- `go test ./pkg/hub/` — `ok` (125s), full suite
- `gofmt -l` clean on every touched file (the 8 pre-existing hits in `pkg/dashboard` are untouched)

Diff is confined to `pkg/dashboard` route/gate code — no overlap with the concurrent F19/F20/F21 work in `pkg/hub`.

Not merging — leaving that to the operator on green.
