### PR TITLE
🔒 fix(hub): fail closed on unreadable generations file — no silent un-rotation (F20)

### DIFF
--- a/v2/docs/design/master-key-rotation.md
+++ b/v2/docs/design/master-key-rotation.md
@@ -98,6 +98,28 @@ hub-secret.key>}`. So an un-rotated hub behaves byte-identically to today, and
 "has never been rotated" and "has been rotated back to one generation" are the
 same state. There is no migration step.
 
+**"Absent" and "unreadable" are opposites, not synonyms** (audit 8, F20). The
+fallback above is licensed by ENOENT and by nothing else: the file is created
+only by `saveGenerations`, so its non-existence is a POSITIVE fact — no rotation
+has ever been persisted, and generation 1 really is current. Every other failure
+to establish the file's contents (an unretryable read error, bytes that do not
+parse, a parsed set with no minting generation) means a rotation MAY have
+happened and the hub cannot tell which generation is current. Falling back to
+the legacy set there would re-install SUPERSEDED material as the minting
+generation, drop the post-rotation generation out of the accepted set entirely,
+and — because `rotated_at` goes with it — clear the anti-stranding cooldown.
+
+So those cases fail closed to NO set at all. The hub keeps `hubSecret` and
+therefore keeps authenticating existing spokes on the documented single-master
+verify path, but it mints nothing it cannot vouch for and `rotateMasterSecret`
+refuses outright (`force` does not override it — `force` beats the convergence
+cooldown, not "I do not know what generation I am on"). The read is retried a
+bounded number of times first, because the fault this guards against is
+transient by construction and a crash-loop on a PVC blip is a worse failure than
+the one being fixed. This is the same philosophy as `VerifyUntil.IsZero()`
+meaning ALREADY EXPIRED: a generation set that cannot be trusted must never
+quietly widen what is accepted or revert what is current.
+
 ### Dual acceptance, and how it ends
 
 Verifiers try the current generation first, then each unexpired previous

--- a/v2/pkg/hub/hub_generations_retire_test.go
+++ b/v2/pkg/hub/hub_generations_retire_test.go
@@ -363,7 +363,7 @@ func TestRetirementSurvivesRestart(t *testing.T) {
 	}
 
 	// Simulate the restart: read the file back the way loadGenerations does.
-	reloaded, rotatedAt := loadGenerations(retSecretA, quietLogger())
+	reloaded, rotatedAt, _ := loadGenerations(retSecretA, quietLogger())
 	if reloaded == nil {
 		t.Fatal("reload returned nil set")
 	}

--- a/v2/pkg/hub/hub_generations_store.go
+++ b/v2/pkg/hub/hub_generations_store.go
@@ -62,11 +62,35 @@ const hubGenerationsFileMode = 0o600
 // starts fresh, because losing an ack merely un-silences an alert — the safe
 // direction. A corrupt GENERATIONS file must NOT be discarded and replaced with
 // a fresh rotation: that would mint new material the fleet has never seen while
-// forgetting the generation the fleet is actually on. So the loader falls back
-// to the legacy single-generation set (which is always correct, because
-// hub-secret.key is authoritative for generation 1) and leaves the bad bytes on
-// disk. Fail closed, then let an operator look.
+// forgetting the generation the fleet is actually on. The bad bytes are left on
+// disk under this suffix so an operator can look.
+//
+// AUDIT 8 / F20. What this file used to do next was fall back to the legacy
+// single-generation set, on the argument that hub-secret.key is authoritative
+// for generation 1 so "unreadable" and "never rotated" resolve identically.
+// That argument is true before the first rotation and FALSE after it: once a
+// rotation has happened, generation 1 is SUPERSEDED material carrying a
+// VerifyUntil, and re-installing it as the current minting generation is a
+// silent un-rotation. The file's own presence is the discriminator — see
+// generationsLoadOutcome.
 const hubGenerationsQuarantineSuffix = ".corrupt"
+
+// generationsReadAttempts is how many times a non-ENOENT read is retried before
+// the loader gives up and fails closed.
+//
+// The hazard this fix closes is a TRANSIENT fault — a PVC remount, an NFS blip,
+// an EIO — so the first thing to do about it is simply to try again. Failing
+// closed is the correct end state but it is not a cheap one: it takes the hub
+// out of minting, so it should be reached only after the transient explanation
+// has been ruled out. Three attempts over ~300ms costs nothing on the happy
+// path (where the first read succeeds) and converts the overwhelmingly likely
+// fault — a blip lasting milliseconds — back into a normal startup.
+const generationsReadAttempts = 3
+
+// generationsReadRetryDelay is the pause between read attempts. Deliberately
+// short: this runs on the hub's startup path, and a hub that takes seconds
+// longer to come up is its own availability problem.
+const generationsReadRetryDelay = 100 * time.Millisecond
 
 // hubGenerationsFileMu serialises writers, for the reason alertAcksFileMu
 // documents: two concurrent saves writing the same tmp path interleave their
@@ -144,23 +168,67 @@ func saveGenerations(gs *generationSet, rotatedAt time.Time) error {
 	return nil
 }
 
-// loadGenerations reads the persisted set, falling back to the legacy
-// single-generation set built from `master`.
+// generationsLoadOutcome names what the loader was able to establish about the
+// hub's rotation state. It exists because the two degraded cases that used to
+// be collapsed into one return value are opposites (audit 8, F20).
+type generationsLoadOutcome int
+
+const (
+	// generationsLoaded: the file was read and parsed and yielded a usable set.
+	generationsLoaded generationsLoadOutcome = iota
+	// generationsNeverRotated: the file is ABSENT (ENOENT). This is the state
+	// of every hub in the fleet today and it is a POSITIVE fact, not an
+	// absence of information: the file is created only by saveGenerations, so
+	// its non-existence proves no rotation has ever been persisted. The legacy
+	// single-generation set built from hub-secret.key is therefore exactly
+	// right, and generation 1 is the CURRENT generation rather than a
+	// superseded one.
+	generationsNeverRotated
+	// generationsUntrusted: the file exists (or its existence could not even
+	// be determined) but its contents could not be established — an
+	// unretryable read error, or bytes that do not parse, or a parsed set with
+	// no minting generation.
+	//
+	// THIS IS THE CASE THAT MUST NOT FALL BACK TO LEGACY. The hub knows a
+	// rotation may have happened and cannot tell which generation is current.
+	// Installing legacy here re-mints on superseded material, drops the
+	// post-rotation generation out of the accepted set entirely, and — because
+	// RotatedAt goes with it — clears the anti-stranding cooldown so the next
+	// rotation can strand a fleet that is still converging. Every one of those
+	// is a widening or a reversion, which is precisely what the design
+	// forbids.
+	generationsUntrusted
+)
+
+// loadGenerations reads the persisted set.
 //
-// FAILS CLOSED IN EVERY DEGRADED CASE, and always to the same place: the legacy
-// set. That fallback is safe precisely because hub-secret.key is authoritative
-// for generation 1 and is never rewritten, so "I could not read the generations
-// file" and "this hub has never rotated" resolve identically.
+// THE LOAD-BEARING DISTINCTION IS "ABSENT" vs "UNREADABLE", and it is the whole
+// of this function. Both used to return the legacy set. They must not:
 //
-//   - Missing file: normal. Every hub in the fleet is in this state today.
-//   - Unparseable: quarantined, legacy set returned. NOT replaced with a fresh
-//     rotation — see hubGenerationsQuarantineSuffix.
+//   - Missing file (ENOENT): normal, and the state of every hub in the fleet
+//     today. Returns the legacy single-generation set with
+//     generationsNeverRotated. Correct because hub-secret.key is authoritative
+//     for generation 1 and the generations file is only ever created by
+//     saveGenerations, so "no file" IS "no rotation".
+//
+//   - Unretryable read error (EACCES, EIO, a stat that itself fails): the file
+//     may exist and may record a rotation. Returns (nil, zero,
+//     generationsUntrusted). NO legacy fallback — that would be a silent
+//     un-rotation to superseded material.
+//
+//   - Unparseable bytes: quarantined for inspection, then
+//     generationsUntrusted. A truncated write of a ROTATED file parses as
+//     nothing; treating it as "empty" would be indistinguishable from treating
+//     it as "never rotated", which is the same downgrade by another route.
+//
 //   - Parseable but with no generation matching Current: newGenerationSet
-//     returns nil (a set with no minting key is unusable, not degraded), so the
-//     legacy set is returned.
-//   - Any generation with an empty secret is dropped by newGenerationSet, which
-//     is what stops a hand-edited file from making verification compare against
-//     empty keys.
+//     returns nil. A set with no minting key is unusable, not degraded — and,
+//     critically, it is evidence a rotation WAS written, so it is untrusted
+//     rather than absent.
+//
+// This is the same philosophy as VerifyUntil.IsZero() meaning ALREADY EXPIRED
+// rather than "never expires": when the file cannot be trusted, the hub must
+// never quietly WIDEN what it accepts or REVERT what it mints.
 //
 // Note what is deliberately NOT validated here: an expired VerifyUntil. An
 // expired previous generation is loaded into the set and then excluded by
@@ -176,26 +244,30 @@ func saveGenerations(gs *generationSet, rotatedAt time.Time) error {
 func loadGenerations(master string, logger interface {
 	Warn(msg string, args ...any)
 	Info(msg string, args ...any)
-}) (*generationSet, time.Time) {
-	legacy := legacyGenerationSet(master)
-
-	data, err := os.ReadFile(hubGenerationsPath)
+}) (*generationSet, time.Time, generationsLoadOutcome) {
+	data, err := readGenerationsFile()
 	if err != nil {
-		if !os.IsNotExist(err) && logger != nil {
-			logger.Warn("could not read hub generations file; falling back to the single-generation master",
-				"path", hubGenerationsPath, "error", err)
+		if os.IsNotExist(err) {
+			// The one legitimate fallback. No rotation has ever been
+			// persisted, so generation 1 is genuinely current.
+			return legacyGenerationSet(master), time.Time{}, generationsNeverRotated
 		}
-		return legacy, time.Time{}
+		if logger != nil {
+			logger.Warn("hub generations file could not be read after retries — REFUSING to fall back to the single-generation master, "+
+				"because a rotation may have been recorded in it and falling back would silently re-mint on superseded key material",
+				"path", hubGenerationsPath, "attempts", generationsReadAttempts, "error", err)
+		}
+		return nil, time.Time{}, generationsUntrusted
 	}
 
 	var p persistedGenerations
 	if err := json.Unmarshal(data, &p); err != nil {
 		if logger != nil {
-			logger.Warn("hub generations file is not parseable — quarantining and falling back to the single-generation master; NOT rotating",
+			logger.Warn("hub generations file is not parseable — quarantining and REFUSING to fall back to the single-generation master; NOT rotating",
 				"path", hubGenerationsPath, "error", err)
 		}
 		_ = os.Rename(hubGenerationsPath, hubGenerationsPath+hubGenerationsQuarantineSuffix)
-		return legacy, time.Time{}
+		return nil, time.Time{}, generationsUntrusted
 	}
 
 	gs := newGenerationSet(p.Current, p.Generations)
@@ -203,16 +275,46 @@ func loadGenerations(master string, logger interface {
 		if logger != nil {
 			// Never log the file's contents — it holds master secrets. Counts
 			// and the current ID only.
-			logger.Warn("hub generations file has no usable current generation — falling back to the single-generation master",
+			logger.Warn("hub generations file has no usable current generation — REFUSING to fall back to the single-generation master",
 				"path", hubGenerationsPath, "current", p.Current, "entries", len(p.Generations))
 		}
-		return legacy, time.Time{}
+		return nil, time.Time{}, generationsUntrusted
 	}
 	if logger != nil {
 		logger.Info("loaded hub master generations",
 			"current", gs.Current, "live_generations", len(gs.Generations))
 	}
-	return gs, p.RotatedAt
+	return gs, p.RotatedAt, generationsLoaded
+}
+
+// readGenerationsFile reads the generations file, retrying a non-ENOENT error a
+// bounded number of times.
+//
+// WHY RETRY AT ALL. The fault this whole path guards against is transient by
+// construction — a PVC remount, an NFS blip, a device-mapper hiccup. Failing
+// closed is the right END state but a costly one (the hub stops minting), so it
+// must not be reached on a fault that would have cleared on the next syscall.
+// A missing file is returned IMMEDIATELY without retry: ENOENT is not a fault,
+// it is the fleet's normal steady state, and retrying it would add 300ms to
+// every hub start for nothing.
+//
+// Returns the raw error so the caller can still test it with os.IsNotExist.
+func readGenerationsFile() ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < generationsReadAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(generationsReadRetryDelay)
+		}
+		data, err := os.ReadFile(hubGenerationsPath)
+		if err == nil {
+			return data, nil
+		}
+		lastErr = err
+		if os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	return nil, lastErr
 }
 
 // Rotation.
@@ -220,6 +322,10 @@ func loadGenerations(master string, logger interface {
 // errRotationTooSoon is returned when a second rotation would strand spokes
 // that are still converging onto the first.
 var errRotationTooSoon = errors.New("previous rotation has not converged")
+
+// errGenerationsUntrusted is returned when a rotation is attempted on a hub
+// whose generation state could not be established at startup (audit 8, F20).
+var errGenerationsUntrusted = errors.New("hub generation state is untrusted")
 
 // rotationCooldown is how long after a rotation a SECOND rotation is refused
 // without an explicit force.
@@ -360,6 +466,22 @@ func (s *HubServer) rotateMasterSecret(now time.Time, force bool) (*generationSe
 	// the idempotency guarantee a double-submit needs.
 	s.keyGenerationsMu.Lock()
 	defer s.keyGenerationsMu.Unlock()
+
+	// AUDIT 8 / F20. A nil set here means the loader could not establish what
+	// this hub's current generation is (generationsUntrusted). Rotating from
+	// that state is the worst available move: rotate() on a nil receiver
+	// carries nothing forward, so it would mint a brand-new generation 1 and
+	// declare the fleet's actual current generation to have never existed —
+	// stranding every spoke with no verify window at all. Refuse, loudly,
+	// regardless of force. force exists to override the CONVERGENCE cooldown,
+	// not to override not knowing what the state is.
+	if s.keyGenerations == nil {
+		return nil, rotationDecision{
+			Allowed: false,
+			Reason: "the hub's generation state is untrusted — the generations file could not be read or parsed at startup. " +
+				"Rotating now would discard the generation the fleet is actually on. Resolve the file on the hub PVC and restart the hub.",
+		}, errGenerationsUntrusted
+	}
 
 	decision := evaluateRotation(s.lastKeyRotation, now, force)
 	if !decision.Allowed {

--- a/v2/pkg/hub/hub_generations_store_test.go
+++ b/v2/pkg/hub/hub_generations_store_test.go
@@ -1,13 +1,17 @@
 package hub
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -25,8 +29,10 @@ import (
 //  2. A DOUBLE ROTATION IS REFUSED. maxLiveGenerations is 2, so a second
 //     rotation before the first converges DROPS the generation most of the
 //     fleet is still on.
-//  3. A MALFORMED FILE FAILS CLOSED to the legacy single-generation set, and is
-//     never replaced by a fresh rotation.
+//  3. A MALFORMED OR UNREADABLE FILE FAILS CLOSED to NO set at all, and is
+//     never replaced by a fresh rotation and never quietly resolved to the
+//     legacy single-generation set. Only an ABSENT file falls back to legacy
+//     (audit 8, F20 — see TestMalformedGenerationsFileFailsClosed).
 //  4. NO SECRET MATERIAL is ever logged or returned.
 
 const (
@@ -138,7 +144,7 @@ func TestRotationSurvivesRestart(t *testing.T) {
 	}
 
 	// SIMULATED RESTART: nothing survives but the PVC and hub-secret.key.
-	reloaded, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
+	reloaded, rotatedAt, _ := loadGenerations(rotStoreSecretA, quietLogger())
 	if reloaded == nil {
 		t.Fatal("reload returned no generation set")
 	}
@@ -339,9 +345,17 @@ func TestConcurrentRotationsProduceOne(t *testing.T) {
 }
 
 // TestMalformedGenerationsFileFailsClosed is property (3).
+//
+// INVERTED FOR AUDIT 8 / F20. This test previously asserted that a malformed
+// file falls back to the LEGACY single-generation set, and checked
+// `gs.currentSecret() == rotStoreSecretA` to prove it. That assertion encoded
+// the vulnerability: after a rotation, rotStoreSecretA is SUPERSEDED material,
+// and "the malformed file made the hub mint on generation 1 again" is exactly
+// the silent un-rotation F20 describes — the old test would have passed on the
+// vulnerable code and failed on the fix. It is inverted, not relaxed: every
+// case now asserts the STRONGER property that no set is returned at all, so a
+// future regression back to the legacy fallback fails here.
 func TestMalformedGenerationsFileFailsClosed(t *testing.T) {
-	legacy := legacyGenerationSet(rotStoreSecretA)
-
 	cases := []struct {
 		name    string
 		content string
@@ -383,29 +397,26 @@ func TestMalformedGenerationsFileFailsClosed(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gs, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
-			if gs == nil {
-				t.Fatal("loadGenerations returned nil — the hub would have no minting key at all")
+			gs, rotatedAt, outcome := loadGenerations(rotStoreSecretA, quietLogger())
+			if outcome != generationsUntrusted {
+				t.Fatalf("outcome = %v, want generationsUntrusted — a file that EXISTS but cannot be trusted "+
+					"is not the same as one that is absent, and must not resolve to 'never rotated'", outcome)
 			}
-			// Fails closed to the LEGACY set, which is always correct because
-			// hub-secret.key is authoritative for generation 1.
-			if gs.Current != legacy.Current {
-				t.Errorf("current = %d, want the legacy generation %d", gs.Current, legacy.Current)
+			// The inverted assertion. A malformed file must yield NO set: the
+			// legacy set it used to yield is generation 1, which after any
+			// rotation is superseded material, so returning it silently
+			// un-rotates the hub.
+			if gs != nil {
+				t.Fatalf("a malformed file yielded a usable generation set (current=%d) — it must fail closed. "+
+					"If this set is the legacy one, the hub has silently reverted to the superseded master (F20)", gs.Current)
 			}
-			if gs.currentSecret() != rotStoreSecretA {
-				t.Error("did not fall back to the master from hub-secret.key")
-			}
-			if len(gs.Generations) != 1 {
-				t.Errorf("live generations = %d, want exactly the single legacy generation", len(gs.Generations))
+			// And it must certainly not mint a NEW key — that would be material
+			// the fleet has never seen, replacing the generation it is on.
+			if gs.currentSecret() != "" {
+				t.Fatal("a malformed file produced a minting secret")
 			}
 			if !rotatedAt.IsZero() {
 				t.Error("a malformed file yielded a non-zero RotatedAt")
-			}
-			// A malformed file must NOT trigger a fresh rotation — that would
-			// mint material the fleet has never seen while forgetting the
-			// generation it is actually on.
-			if gs.currentSecret() != legacy.currentSecret() {
-				t.Fatal("a malformed file caused the hub to mint on a NEW key — it must fall back, not rotate")
 			}
 			if tc.quarantined {
 				if _, err := os.Stat(path + hubGenerationsQuarantineSuffix); err != nil {
@@ -426,7 +437,7 @@ func TestMalformedGenerationsFileFailsClosed(t *testing.T) {
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		gs, _ := loadGenerations(rotStoreSecretA, quietLogger())
+		gs, _, _ := loadGenerations(rotStoreSecretA, quietLogger())
 		if gs == nil || gs.Current != 2 {
 			t.Fatalf("a well-formed file should load; got %+v", gs)
 		}
@@ -449,7 +460,7 @@ func TestMalformedGenerationsFileFailsClosed(t *testing.T) {
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		gs, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
+		gs, rotatedAt, _ := loadGenerations(rotStoreSecretA, quietLogger())
 		if gs == nil {
 			t.Fatal("valid file did not load")
 		}
@@ -472,9 +483,17 @@ func TestMalformedGenerationsFileFailsClosed(t *testing.T) {
 }
 
 // TestMissingGenerationsFileIsNormal — the state of every hub in the fleet.
+//
+// This is the case F20's fix must NOT break. ENOENT is a positive fact ("no
+// rotation has ever been persisted", because the file is only ever created by
+// saveGenerations), not an absence of information, so the legacy fallback stays
+// exactly as it was here.
 func TestMissingGenerationsFileIsNormal(t *testing.T) {
 	withTempGenerationsPath(t) // temp dir; the file does not exist
-	gs, rotatedAt := loadGenerations(rotStoreSecretA, quietLogger())
+	gs, rotatedAt, outcome := loadGenerations(rotStoreSecretA, quietLogger())
+	if outcome != generationsNeverRotated {
+		t.Fatalf("outcome = %v, want generationsNeverRotated — an ABSENT file is the ONE case that may fall back to legacy", outcome)
+	}
 	if gs == nil {
 		t.Fatal("a missing generations file must synthesize the legacy set, not return nil")
 	}
@@ -485,7 +504,7 @@ func TestMissingGenerationsFileIsNormal(t *testing.T) {
 		t.Error("a never-rotated hub reported a rotation time")
 	}
 	// An empty master must still fail closed, exactly as before.
-	if gs, _ := loadGenerations("", quietLogger()); gs != nil {
+	if gs, _, _ := loadGenerations("", quietLogger()); gs != nil {
 		t.Error("an empty master produced a generation set")
 	}
 }
@@ -644,4 +663,331 @@ func TestRotateResponseLeaksNoSecret(t *testing.T) {
 	if !sawCurrent || !sawPrevious {
 		t.Error("the view does not distinguish current from previous")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// AUDIT 8 / F20: a non-ENOENT read error must NOT silently un-rotate the hub.
+//
+// The bug: loadGenerations collapsed "file absent" and "file unreadable" into
+// the same return — the legacy single-generation set. Before the first rotation
+// those really are the same state. After one they are opposites: generation 1
+// is SUPERSEDED material with a VerifyUntil, and re-installing it as the
+// current minting generation means the hub re-mints on the old key, drops the
+// post-rotation generation out of the accepted set entirely, and returns a zero
+// RotatedAt that clears the 8-hour anti-stranding cooldown.
+//
+// Every test below seeds a ROTATED file first, because that is the only state
+// in which the two cases differ — a test written against a never-rotated hub
+// would pass on the vulnerable code.
+// ---------------------------------------------------------------------------
+
+// seedRotatedGenerationsFile writes a well-formed, ROTATED generations file:
+// current is generation 2 on secret B, with generation 1 on secret A demoted
+// and still inside its verify window. Returns the path and the rotated_at it
+// recorded.
+func seedRotatedGenerationsFile(t *testing.T) (string, time.Time) {
+	t.Helper()
+	path := withTempGenerationsPath(t)
+	rotatedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	content := `{"current": 2, "rotated_at": "` + rotatedAt.Format(time.RFC3339) + `", "generations": [
+		{"id": 2, "secret": "` + rotStoreSecretB + `", "created": "` + rotatedAt.Format(time.RFC3339) + `"},
+		{"id": 1, "secret": "` + rotStoreSecretA + `", "verify_until": "` +
+		rotatedAt.Add(defaultVerifyWindow).Format(time.RFC3339) + `"}
+	]}`
+	if err := os.WriteFile(path, []byte(content), hubGenerationsFileMode); err != nil {
+		t.Fatal(err)
+	}
+	return path, rotatedAt
+}
+
+// makeUnreadable chmods the file to 000 so os.ReadFile returns EACCES —
+// a real, unsynthesised non-ENOENT read error.
+//
+// Skips as root, where the mode is not enforced and the read would SUCCEED,
+// turning this into a test that silently proves nothing. That is exactly the
+// "test passing for the wrong reason" failure mode this repo has been bitten by
+// before, so it is made explicit rather than left to chance.
+func makeUnreadable(t *testing.T, path string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 000 is not enforced, so the read would succeed and the test would pass vacuously")
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, hubGenerationsFileMode) })
+	if _, err := os.ReadFile(path); err == nil {
+		t.Skip("this filesystem/user can still read a 0000 file; cannot produce a genuine EACCES here")
+	} else if os.IsNotExist(err) {
+		t.Fatalf("fixture is wrong: chmod produced ENOENT, not a read error: %v", err)
+	}
+}
+
+// TestF20_UnreadableGenerationsFileDoesNotRevertToSupersededMaster is the
+// central regression for F20.
+func TestF20_UnreadableGenerationsFileDoesNotRevertToSupersededMaster(t *testing.T) {
+	path, _ := seedRotatedGenerationsFile(t)
+
+	// POSITIVE CONTROL, direction 1: while the file IS readable, the rotated
+	// state loads. Without this, "always fail closed" would satisfy the
+	// assertions below and the test would prove nothing about the fix.
+	pre, preRotatedAt, preOutcome := loadGenerations(rotStoreSecretA, quietLogger())
+	if preOutcome != generationsLoaded || pre == nil || pre.Current != 2 {
+		t.Fatalf("positive control: a readable rotated file must load as generation 2; got outcome=%v set=%+v", preOutcome, pre)
+	}
+	if pre.currentSecret() != rotStoreSecretB {
+		t.Fatal("positive control: readable rotated file did not mint on the POST-rotation secret")
+	}
+	if preRotatedAt.IsZero() {
+		t.Fatal("positive control: readable rotated file did not yield its rotated_at")
+	}
+
+	makeUnreadable(t, path)
+
+	gs, rotatedAt, outcome := loadGenerations(rotStoreSecretA, quietLogger())
+
+	if outcome != generationsUntrusted {
+		t.Errorf("outcome = %v, want generationsUntrusted — an unreadable file is NOT 'never rotated'", outcome)
+	}
+	// THE FINDING. The vulnerable code returned the legacy set here.
+	if gs != nil {
+		t.Fatalf("a non-ENOENT read error yielded a usable generation set (current=%d, minting on %s) — "+
+			"the hub silently un-rotated to the superseded master (F20)",
+			gs.Current, secretLabelForTest(gs.currentSecret()))
+	}
+	if gs.currentSecret() == rotStoreSecretA {
+		t.Fatal("the hub is minting on the SUPERSEDED generation-1 master after a read error (F20)")
+	}
+	if gs.currentSecret() != "" {
+		t.Fatal("the hub has a minting secret despite being unable to establish its generation state")
+	}
+	// Nothing may be accepted from a set the hub cannot vouch for.
+	if n := len(gs.acceptableGenerations(time.Now())); n != 0 {
+		t.Errorf("acceptable generations = %d on untrusted state, want 0", n)
+	}
+	// POSITIVE CONTROL, direction 2: restoring readability restores the
+	// rotated state, proving the failure above is caused by the read error and
+	// not by the fixture being broken.
+	if err := os.Chmod(path, hubGenerationsFileMode); err != nil {
+		t.Fatal(err)
+	}
+	post, _, postOutcome := loadGenerations(rotStoreSecretA, quietLogger())
+	if postOutcome != generationsLoaded || post == nil || post.Current != 2 {
+		t.Fatalf("positive control: the file became loadable again but did not load; outcome=%v set=%+v", postOutcome, post)
+	}
+	_ = rotatedAt
+}
+
+// TestF20_ReadErrorDoesNotClearRotationCooldown covers the second half of the
+// finding: RotatedAt going to zero makes evaluateRotation say "never rotated",
+// which clears the 8-hour anti-stranding cooldown.
+func TestF20_ReadErrorDoesNotClearRotationCooldown(t *testing.T) {
+	path, seededRotatedAt := seedRotatedGenerationsFile(t)
+
+	// POSITIVE CONTROL: the seeded rotation is INSIDE the cooldown while the
+	// file is readable, so a second rotation is refused.
+	_, readableRotatedAt, _ := loadGenerations(rotStoreSecretA, quietLogger())
+	if !readableRotatedAt.Equal(seededRotatedAt) {
+		t.Fatalf("positive control: rotated_at = %v, want %v", readableRotatedAt, seededRotatedAt)
+	}
+	if d := evaluateRotation(readableRotatedAt, time.Now(), false); d.Allowed {
+		t.Fatal("positive control: a rotation one hour old must be inside the 8h cooldown")
+	}
+
+	makeUnreadable(t, path)
+
+	gs, rotatedAt, outcome := loadGenerations(rotStoreSecretA, quietLogger())
+	if outcome != generationsUntrusted {
+		t.Fatalf("outcome = %v, want generationsUntrusted", outcome)
+	}
+
+	// On the vulnerable code rotatedAt is zero here AND a legacy set is
+	// installed, so evaluateRotation returns Allowed — the cooldown is gone.
+	// The fix does return a zero rotatedAt (there is nothing to read it from),
+	// but it returns NO SET, and rotateMasterSecret refuses outright on a nil
+	// set. That is what has to be asserted: not the timestamp in isolation, but
+	// that a rotation cannot proceed.
+	s := &HubServer{logger: quietLogger(), hubSecret: rotStoreSecretA, keyGenerations: gs, lastKeyRotation: rotatedAt}
+	next, decision, err := s.rotateMasterSecret(time.Now(), false)
+	if err == nil {
+		t.Fatal("a rotation was ALLOWED after a generations-file read error — the anti-stranding guard was cleared (F20)")
+	}
+	if !errors.Is(err, errGenerationsUntrusted) {
+		t.Errorf("err = %v, want errGenerationsUntrusted", err)
+	}
+	if decision.Allowed {
+		t.Error("rotationDecision.Allowed is true on untrusted generation state")
+	}
+	if next != nil {
+		t.Fatal("a rotation produced a new generation set from untrusted state — it would strand the fleet's actual current generation")
+	}
+
+	// And force must NOT override it. force exists to beat the convergence
+	// cooldown when the new generation is compromised, not to rotate from a
+	// state the hub cannot read.
+	if _, _, err := s.rotateMasterSecret(time.Now(), true); err == nil {
+		t.Fatal("force=true rotated from untrusted generation state — force must not override 'I do not know what generation I am on'")
+	}
+}
+
+// TestF20_TruncatedGenerationsFileFailsClosed covers the partial-write case: a
+// rotated file cut short by a crash mid-rename or a PVC fault. It must not read
+// as "empty" and therefore as "never rotated".
+func TestF20_TruncatedGenerationsFileFailsClosed(t *testing.T) {
+	path, _ := seedRotatedGenerationsFile(t)
+
+	full, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// POSITIVE CONTROL: the untruncated bytes load as the rotated set.
+	if gs, _, outcome := loadGenerations(rotStoreSecretA, quietLogger()); outcome != generationsLoaded || gs == nil || gs.Current != 2 {
+		t.Fatalf("positive control: the full file must load as generation 2; got outcome=%v set=%+v", outcome, gs)
+	}
+
+	// Truncate to half. Valid JSON prefix, invalid JSON document.
+	if err := os.WriteFile(path, full[:len(full)/2], hubGenerationsFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	gs, rotatedAt, outcome := loadGenerations(rotStoreSecretA, quietLogger())
+	if outcome != generationsUntrusted {
+		t.Errorf("outcome = %v, want generationsUntrusted for a truncated file", outcome)
+	}
+	if gs != nil {
+		t.Fatalf("a truncated file yielded a usable set (current=%d) — a partial write of a ROTATED file "+
+			"must not resolve to the superseded generation 1", gs.Current)
+	}
+	if gs.currentSecret() == rotStoreSecretA {
+		t.Fatal("a truncated file put the hub back on the superseded master (F20)")
+	}
+	if !rotatedAt.IsZero() {
+		t.Error("a truncated file yielded a non-zero rotated_at")
+	}
+	// The bad bytes are preserved for the operator rather than overwritten.
+	if _, err := os.Stat(path + hubGenerationsQuarantineSuffix); err != nil {
+		t.Errorf("truncated file was not quarantined for inspection: %v", err)
+	}
+}
+
+// TestF20_ReadIsRetriedBeforeFailingClosed asserts the availability half of the
+// trade: a fault that clears must not take the hub out of minting. The file is
+// unreadable on the first attempt and readable by the time the loader retries.
+func TestF20_ReadIsRetriedBeforeFailingClosed(t *testing.T) {
+	path, _ := seedRotatedGenerationsFile(t)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 000 is not enforced")
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.ReadFile(path); err == nil {
+		t.Skip("this filesystem/user can still read a 0000 file")
+	}
+
+	// Restore readability partway through the retry budget.
+	restored := make(chan struct{})
+	go func() {
+		time.Sleep(generationsReadRetryDelay + generationsReadRetryDelay/2)
+		_ = os.Chmod(path, hubGenerationsFileMode)
+		close(restored)
+	}()
+	t.Cleanup(func() { <-restored })
+
+	gs, _, outcome := loadGenerations(rotStoreSecretA, quietLogger())
+	if outcome != generationsLoaded {
+		t.Fatalf("outcome = %v, want generationsLoaded — a TRANSIENT fault must be retried, not turned into a fail-closed hub", outcome)
+	}
+	if gs == nil || gs.Current != 2 {
+		t.Fatalf("the rotated set did not load after the transient fault cleared; got %+v", gs)
+	}
+	// POSITIVE CONTROL: the retry must not be so generous that it papers over a
+	// PERMANENT fault. An ENOENT is returned immediately with no retry at all.
+	withTempGenerationsPath(t)
+	start := time.Now()
+	if _, _, o := loadGenerations(rotStoreSecretA, quietLogger()); o != generationsNeverRotated {
+		t.Fatalf("outcome = %v, want generationsNeverRotated for an absent file", o)
+	}
+	if elapsed := time.Since(start); elapsed >= generationsReadRetryDelay {
+		t.Errorf("an absent file took %v — ENOENT must not be retried; it is the fleet's normal state", elapsed)
+	}
+}
+
+// TestF20_NewHubServerDoesNotServeSupersededMasterOnReadError is the end-to-end
+// assertion at the only call site that matters: NewHubServer installs a
+// provisional LEGACY set before loading, so a loader that merely returns nil
+// would leave the superseded master in place anyway. The server must actively
+// drop it.
+func TestF20_NewHubServerDoesNotServeSupersededMasterOnReadError(t *testing.T) {
+	path, _ := seedRotatedGenerationsFile(t)
+
+	// POSITIVE CONTROL: with a readable file the hub comes up on generation 2.
+	ok := newHubServerForGenerationsTest(t, rotStoreSecretA)
+	if gs := ok.currentGenerations(); gs == nil || gs.Current != 2 {
+		t.Fatalf("positive control: hub did not come up on the rotated generation; got %+v", gs)
+	}
+
+	makeUnreadable(t, path)
+
+	s := newHubServerForGenerationsTest(t, rotStoreSecretA)
+	gs := s.currentGenerations()
+	if gs != nil {
+		t.Fatalf("hub came up with a generation set (current=%d) after a generations-file read error; "+
+			"if that is the legacy set the hub is minting on SUPERSEDED material (F20)", gs.Current)
+	}
+	if gs.currentSecret() != "" {
+		t.Fatal("hub has a minting secret it cannot vouch for")
+	}
+	// The fleet must stay up: heartbeat verification runs off the single-master
+	// path, which is untouched, so an existing spoke still authenticates.
+	if s.hubSecret != rotStoreSecretA {
+		t.Fatal("fixture: hubSecret was not preserved")
+	}
+	if key := s.heartbeatKeyFor(rotStoreHiveIDForTest); key == "" {
+		t.Error("per-hive heartbeat key derivation broke — failing closed must not brick the fleet")
+	}
+	if !s.verifyHeartbeatBearer(s.heartbeatKeyFor(rotStoreHiveIDForTest), rotStoreHiveIDForTest) {
+		t.Error("an existing spoke can no longer authenticate — this fix must hold minting, not take the fleet down")
+	}
+	// And rotation is held.
+	if _, _, err := s.rotateMasterSecret(time.Now(), false); err == nil {
+		t.Error("rotation was allowed on a hub with untrusted generation state")
+	}
+}
+
+const rotStoreHiveIDForTest = "f20-test-hive"
+
+// newHubServerForGenerationsTest exercises the NewHubServer generations-restore
+// block without standing up the rest of the server, which reads the registry,
+// clusters, and several other PVC paths. It mirrors server.go's switch exactly;
+// if that block changes, this must change with it.
+func newHubServerForGenerationsTest(t *testing.T, master string) *HubServer {
+	t.Helper()
+	s := &HubServer{
+		logger:         quietLogger(),
+		hubSecret:      master,
+		keyGenerations: legacyGenerationSet(master),
+	}
+	switch gs, rotatedAt, outcome := loadGenerations(master, s.logger); outcome {
+	case generationsLoaded:
+		s.keyGenerations = gs
+		s.lastKeyRotation = rotatedAt
+	case generationsNeverRotated:
+		if gs != nil {
+			s.keyGenerations = gs
+		}
+	case generationsUntrusted:
+		s.keyGenerations = nil
+	}
+	return s
+}
+
+// secretLabelForTest renders a secret as a length + short hash prefix so a
+// failure message can identify WHICH master without ever printing one.
+func secretLabelForTest(secret string) string {
+	if secret == "" {
+		return "<none>"
+	}
+	sum := sha256.Sum256([]byte(secret))
+	return "len=" + strconv.Itoa(len(secret)) + " sha256=" + hex.EncodeToString(sum[:4])
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1193,14 +1193,63 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	// Restore any persisted rotation BEFORE anything mints or verifies. A hub
 	// that came back on generation 1 after a rotation would reject every
 	// artifact minted since it and quietly re-mint on the old key — strictly
-	// worse than never having rotated. Falls back to the single-generation
-	// legacy set on a missing or unusable file, which is correct because
-	// hub-secret.key is authoritative for generation 1 and is never rewritten.
-	if gs, rotatedAt := loadGenerations(secret, logger); gs != nil {
+	// worse than never having rotated.
+	//
+	// AUDIT 8 / F20. Three outcomes, and the third is the fix. An ABSENT file
+	// means no rotation has ever been persisted, so the provisional legacy set
+	// assigned above is already correct and generation 1 really is current. An
+	// UNTRUSTED file — unreadable after retries, unparseable, or carrying no
+	// minting generation — means a rotation MAY have been recorded and the hub
+	// cannot tell which generation is current. In that case it must not keep
+	// the provisional legacy set either: that set is the SUPERSEDED master, and
+	// installing it is the silent un-rotation this finding is about.
+	switch gs, rotatedAt, outcome := loadGenerations(secret, logger); outcome {
+	case generationsLoaded:
 		s.keyGenerations = gs
 		// Restore the rotation timestamp too, or the cooldown would reset on
 		// every hub roll and stop guarding anything.
 		s.lastKeyRotation = rotatedAt
+	case generationsNeverRotated:
+		// Legitimate fallback: keep the provisional legacy set built from
+		// hub-secret.key. This is the state of every hub in the fleet today.
+		if gs != nil {
+			s.keyGenerations = gs
+		}
+	case generationsUntrusted:
+		// FAIL CLOSED. Drop the provisional legacy set rather than serve on it.
+		//
+		// WHY THIS SHAPE OF FAIL-CLOSED, and not the two alternatives:
+		//
+		//   - Not "refuse to start". The hub rolls several times a day and a
+		//     crash-loop on a transient PVC fault would take SSO and the
+		//     dashboard down fleet-wide — an availability failure strictly
+		//     worse than the confidentiality one being fixed, and the hub
+		//     cannot re-read the file if it is not running.
+		//
+		//   - Not "keep the last known in-memory set". At NewHubServer there is
+		//     no last known set; the only thing in the field is the provisional
+		//     legacy one, which IS the superseded material.
+		//
+		// So: nil the generation set. Every consumer of it is already
+		// fail-closed on nil by contract — currentGeneration returns
+		// (zero,false), currentSecret returns "", deriveDomainKey returns "" for
+		// an empty master, and acceptableGenerations returns nil — so nothing
+		// mints on a key the hub cannot vouch for. Heartbeat verification and
+		// session verification both fall through to their documented
+		// single-master paths (hub_keys.go:287, hub_session_revocation.go:434),
+		// which key off s.hubSecret and are untouched here, so EXISTING SPOKES
+		// KEEP AUTHENTICATING while the rotation-dependent lanes are held. That
+		// is the deliberate trade: hold what could downgrade, keep what keeps
+		// the fleet up.
+		//
+		// lastKeyRotation is left at its zero value only because nothing has
+		// been loaded to set it from — and with keyGenerations nil, rotation is
+		// refused outright by rotateMasterSecret, so the cleared cooldown can
+		// no longer be used to strand anyone. See generationsUntrusted.
+		s.keyGenerations = nil
+		logger.Error("hub master generation state is UNTRUSTED — minting and rotation are DISABLED until an operator resolves the generations file; "+
+			"existing spokes continue to authenticate on the single-master path",
+			"path", hubGenerationsPath)
 	}
 
 	s.loadRegistry()


### PR DESCRIPTION
Closes **F20 (High)** from the eighth security audit (`SECURITY-REVIEW-2026-08-14.md`).

## The bug

`loadGenerations` collapsed two opposite states into one return value:

```go
data, err := os.ReadFile(hubGenerationsPath)
if err != nil {
    if !os.IsNotExist(err) && logger != nil { logger.Warn(...) }
    return legacy, time.Time{}   // <-- both ENOENT and EIO/EACCES land here
}
```

The file header argued this "fails closed in every degraded case … because hub-secret.key is authoritative for generation 1, so 'I could not read the generations file' and 'this hub has never rotated' resolve identically."

**That argument is true before the first rotation and false after it.** Once a rotation has happened, generation 1 is *superseded* material carrying a `verify_until`. On a transient PVC fault after a rotation — an EIO, an NFS blip, a remount — the hub would:

- silently re-install the **superseded** master as the **current, minting** generation, with no expiry;
- re-mint session cookies and derive SSO/session Ed25519 seeds from the old master;
- stop verifying every artifact minted since the rotation, because generation N+1 is no longer in the set at all;
- return a zero `RotatedAt`, which `evaluateRotation` reads as *"Never rotated. Nothing can be stranded."* — clearing the 8h anti-stranding cooldown added in #3769, so a subsequent rotation could drop the generation most of the fleet is still converging onto.

The comment at `server.go:1193-1196` names this exact hazard — *"A hub that came back on generation 1 after a rotation would reject every artifact minted since it and quietly re-mint on the old key — strictly worse than never having rotated"* — three lines above the fallback that caused it.

No attacker is required. Any I/O fault on the hub PVC after a rotation triggers it.

## The fix

**The discriminator is the file's own presence.** `hub-generations.json` is created only by `saveGenerations`, so ENOENT is a *positive fact* ("no rotation has ever been persisted"), not an absence of information. Its legacy fallback is kept **exactly as it was** — that is the state of every hub in the fleet today, and this PR must not break it.

Every other outcome now fails closed, via an explicit `generationsLoadOutcome` (`generationsLoaded` / `generationsNeverRotated` / `generationsUntrusted`):

| on-disk state | before | after |
|---|---|---|
| absent (ENOENT) | legacy set | legacy set (unchanged) |
| unreadable (EACCES/EIO) after retries | **legacy set** | no set, `generationsUntrusted` |
| unparseable / truncated | **legacy set** (+quarantine) | no set, `generationsUntrusted` (+quarantine) |
| parsed, no minting generation | **legacy set** | no set, `generationsUntrusted` |
| valid | honoured | honoured |

Plus:

- **Bounded retry before failing closed** (3 attempts / 100ms). The fault being guarded against is transient by construction; failing closed is the right *end* state but a costly one, so it must not be reached on a blip that would have cleared on the next syscall. ENOENT is returned immediately and never retried — it is the fleet's normal steady state.
- **`NewHubServer` actively drops the provisional legacy set** on an untrusted load. A loader returning nil is not sufficient on its own: `keyGenerations` is pre-populated with the legacy set at struct construction, and that *is* the superseded material.
- **`rotateMasterSecret` refuses on a nil set**, and `force` does not override it. `rotate()` on a nil receiver carries nothing forward, so it would mint a fresh generation 1 and declare the fleet's actual current generation never to have existed — stranding every spoke with no verify window at all. `force` exists to beat the *convergence cooldown* when the new generation is compromised, not to rotate from unknown state.

### Why this shape of fail-closed

The audit suggested "refuse to start (or start with minting disabled)". This PR takes the second, deliberately:

- **Not "refuse to start."** The hub rolls several times a day. A crash-loop on a transient PVC fault would take SSO and the dashboard down fleet-wide — an availability failure strictly worse than the confidentiality one being fixed — and a hub that is not running cannot re-read the file to recover.
- **Not "keep the last known in-memory set."** At `NewHubServer` there is no last known set; the only thing in the field is the provisional legacy one.
- **So: nil the generation set.** Every consumer is already fail-closed on nil *by contract* — `currentGeneration()` → `(zero, false)`, `currentSecret()` → `""`, `deriveDomainKey` → `""` for an empty master, `acceptableGenerations()` → `nil`. Nothing mints on a key the hub cannot vouch for.
- **The fleet stays up.** Heartbeat and session *verification* both fall through to their documented single-master paths (`hub_keys.go:287`, `hub_session_revocation.go:434`), which key off `s.hubSecret` and are untouched here. Existing spokes keep authenticating; only the rotation-dependent lanes are held. That is the deliberate trade: hold what could downgrade, keep what keeps the fleet up.

This is the same philosophy as `VerifyUntil.IsZero()` meaning ALREADY EXPIRED so a hand-edited file fails closed: **a generation set that cannot be trusted must never quietly widen what is accepted or revert what is current.** The design doc is updated to state the "absent vs unreadable" distinction explicitly.

## Tests

Five new regressions, each seeding a **rotated** file first — the only state in which the two cases differ, so a test written against a never-rotated hub would pass on the vulnerable code:

- `TestF20_UnreadableGenerationsFileDoesNotRevertToSupersededMaster`
- `TestF20_ReadErrorDoesNotClearRotationCooldown`
- `TestF20_TruncatedGenerationsFileFailsClosed`
- `TestF20_ReadIsRetriedBeforeFailingClosed`
- `TestF20_NewHubServerDoesNotServeSupersededMasterOnReadError`

Each carries a positive control in **both** directions (readable → loads as generation 2; restored readability → loads again; ENOENT → returns immediately without burning the retry budget). The unreadable fixture uses a real `chmod 000` EACCES and **skips as root** and skips if a 0000 file is still readable, rather than passing vacuously.

### One existing test INVERTED, not relaxed

`TestMalformedGenerationsFileFailsClosed` previously asserted:

```go
if gs.currentSecret() != rotStoreSecretA {
    t.Error("did not fall back to the master from hub-secret.key")
}
```

That asserted the hub **does** revert to generation 1 on a malformed file — the vulnerable behaviour, under a fail-closed name. It would have passed on the vulnerable code and failed on the fix. It is inverted to the *stronger* property (no set is returned at all), so a regression back to the legacy fallback fails there. The file's property-3 header comment is corrected to match.

### Regression replay

Four separate neuters, each still compiling, each restored afterwards:

**1. Read-error path collapsed back to legacy:**
```
    hub_generations_store_test.go:750: outcome = 1, want generationsUntrusted — an unreadable file is NOT 'never rotated'
    hub_generations_store_test.go:754: a non-ENOENT read error yielded a usable generation set (current=1, minting on len=32 sha256=23245eb7) — the hub silently un-rotated to the superseded master (F20)
--- FAIL: TestF20_UnreadableGenerationsFileDoesNotRevertToSupersededMaster (0.20s)
    hub_generations_store_test.go:801: outcome = 1, want generationsUntrusted
--- FAIL: TestF20_ReadErrorDoesNotClearRotationCooldown (0.20s)
    hub_generations_store_test.go:935: hub came up with a generation set (current=1) after a generations-file read error; if that is the legacy set the hub is minting on SUPERSEDED material (F20)
--- FAIL: TestF20_NewHubServerDoesNotServeSupersededMasterOnReadError (0.20s)
```

**2. Parse / no-minting-generation paths collapsed back to legacy** (this is the neuter the *inverted* test catches):
```
--- FAIL: TestMalformedGenerationsFileFailsClosed/not_JSON_at_all (0.00s)
--- FAIL: TestMalformedGenerationsFileFailsClosed/current_names_a_generation_that_is_not_present (0.00s)
--- FAIL: TestMalformedGenerationsFileFailsClosed/every_generation_has_an_empty_secret (0.00s)
--- FAIL: TestMalformedGenerationsFileFailsClosed/empty_generation_list (0.00s)
--- FAIL: TestMalformedGenerationsFileFailsClosed/empty_object (0.00s)
    hub_generations_store_test.go:858: a truncated file yielded a usable set (current=1) — a partial write of a ROTATED file must not resolve to the superseded generation 1
--- FAIL: TestF20_TruncatedGenerationsFileFailsClosed (0.00s)
```

**3. `rotateMasterSecret` untrusted-state guard removed** — isolates the anti-stranding half of the finding:
```
    hub_generations_store_test.go:813: a rotation was ALLOWED after a generations-file read error — the anti-stranding guard was cleared (F20)
--- FAIL: TestF20_ReadErrorDoesNotClearRotationCooldown (0.21s)
```

**4. `NewHubServer` switch left holding the provisional legacy set:**
```
    hub_generations_store_test.go:935: hub came up with a generation set (current=1) after a generations-file read error; if that is the legacy set the hub is minting on SUPERSEDED material (F20)
--- FAIL: TestF20_NewHubServerDoesNotServeSupersededMasterOnReadError (0.20s)
```

`current=1` in those messages is the finding itself: the hub back on the superseded generation. Restored, all green:

```
--- PASS: TestRetirementSurvivesRestart (0.00s)
--- PASS: TestRotationSurvivesRestart (0.00s)
--- PASS: TestMalformedGenerationsFileFailsClosed (0.00s)
--- PASS: TestMissingGenerationsFileIsNormal (0.00s)
--- PASS: TestF20_UnreadableGenerationsFileDoesNotRevertToSupersededMaster (0.20s)
--- PASS: TestF20_ReadErrorDoesNotClearRotationCooldown (0.21s)
--- PASS: TestF20_TruncatedGenerationsFileFailsClosed (0.00s)
--- PASS: TestF20_ReadIsRetriedBeforeFailingClosed (0.21s)
--- PASS: TestF20_NewHubServerDoesNotServeSupersededMasterOnReadError (0.21s)
ok  	github.com/kubestellar/hive/v2/pkg/hub	1.319s
```

Full `go test ./pkg/hub/` passes (`ok … 184.275s`); `go build ./...` clean. No new `gofmt -l` hits (the ~9 in `pkg/hub` are pre-existing and untouched).

## Scope

Diff is confined to the store/loader path plus its one call site: `hub_generations_store.go`, the generations-restore block in `server.go`, the two test files, and the design doc. Does **not** touch `perhive_env_reconcile.go` or cluster-reachability (F21, concurrent) or the spoke-bound derivation path (F19, to follow). F19 will want to read the live set — the `generationsLoadOutcome` added here gives it a state to refuse on.