### PR TITLE
🔒 fix(hub): count unreachable spokes so convergence cannot report a partially-observed fleet (F21)

### DIFF
--- a/v2/pkg/hub/hub_generations_retire.go
+++ b/v2/pkg/hub/hub_generations_retire.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"errors"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -347,6 +348,22 @@ func (s *HubServer) sweepGenerationRetirement(now time.Time) {
 	// shows up in this alert; it cannot fall out of the denominator by going
 	// quiet and make a stranding look like a convergence.
 	snap := s.PerHiveEnvSnapshot()
+
+	// An UNREACHABLE spoke is a stranding candidate the pin alert cannot see:
+	// evaluateGenerationPin reasons over observed counts, and an unread spoke
+	// contributes to none of them. It is not merely absent from the alert — it
+	// is the spoke most likely to be stranded, because nothing is converging
+	// it. Retirement is unconditional on the wall clock, so say this plainly
+	// and separately rather than letting a clean pin alert imply a clean fleet.
+	if snap.UnreachableHives > 0 && s.logger != nil {
+		s.logger.Warn("master generation retirement is running against a PARTIALLY OBSERVED fleet — "+
+			"these spokes cannot be read, so their generation is unknown and the convergence lane "+
+			"cannot repair them; retirement will not wait for them",
+			"unreachable_hives", snap.UnreachableHives,
+			"unreachable_clusters", strings.Join(snap.UnreachableClusters, ","),
+			"observed_hives", snap.ObservedHives,
+			"safe_to_retire_previous", snap.KeyGenerations.SafeToRetirePrevious)
+	}
 
 	for _, g := range gs.Generations {
 		alert := evaluateGenerationPin(

--- a/v2/pkg/hub/hub_generations_retire_test.go
+++ b/v2/pkg/hub/hub_generations_retire_test.go
@@ -56,13 +56,29 @@ func newRetireTestHub(t *testing.T, gens []keyGeneration, current int) *HubServe
 // seedObservations installs Deployment-sourced spoke observations, which is
 // what PerHiveEnvSnapshot counts. Deliberately NOT heartbeat-sourced: a paused
 // spoke still has a Deployment and must still block readiness.
+// seedObservations stands in for a completed sweep, so it must seed what a
+// sweep records: the observations AND the selection accounting. Considered is
+// set to the number of hives observed with zero unreachable — i.e. a FULLY
+// observed fleet — because that is the only state in which the readiness
+// signals are permitted to say "yes". Tests that want a partially-observed
+// fleet use seedObservationsWithUnreachable.
 func seedObservations(s *HubServer, onGeneration map[string]int) {
+	seedObservationsWithUnreachable(s, onGeneration, 0, nil)
+}
+
+// seedObservationsWithUnreachable seeds a sweep that could not read
+// unreachable hives on the named clusters, on top of the ones it did observe.
+func seedObservationsWithUnreachable(s *HubServer, onGeneration map[string]int, unreachable int, clusters []string) {
 	s.perHiveEnvMu.Lock()
 	defer s.perHiveEnvMu.Unlock()
 	s.perHiveEnvSeen = map[string]perHiveEnvObservation{}
 	for id, gen := range onGeneration {
 		s.perHiveEnvSeen[id] = perHiveEnvObservation{Generation: gen}
 	}
+	s.perHiveEnvConsidered = len(onGeneration) + unreachable
+	s.perHiveEnvSkippedByStatus = 0
+	s.perHiveEnvUnreachable = unreachable
+	s.perHiveEnvUnreachableClusters = append([]string(nil), clusters...)
 }
 
 // TestRetireExpiredGenerationsIsPositiveControl is the two-directional positive

--- a/v2/pkg/hub/perhive_env_generation_test.go
+++ b/v2/pkg/hub/perhive_env_generation_test.go
@@ -420,8 +420,17 @@ func TestPerHiveEnvSafeToRetireIsGated(t *testing.T) {
 	expired := legacyGenerationSet(perHiveGenSecretA).
 		rotate(perHiveGenSecretB, now.Add(-2*defaultVerifyWindow), defaultVerifyWindow)
 
+	// perHiveEnvConsidered mirrors what a sweep that read every admitted hive
+	// would record, with perHiveEnvUnreachable left at zero: a FULLY observed
+	// fleet. Retirement readiness is gated on that, so a fixture that omitted
+	// it would report "not retirable" for reasons unrelated to what each
+	// subtest is actually asserting.
 	newHub := func(gs *generationSet, seen map[string]perHiveEnvObservation) *HubServer {
-		return &HubServer{keyGenerations: gs, perHiveEnvSeen: seen}
+		return &HubServer{
+			keyGenerations:       gs,
+			perHiveEnvSeen:       seen,
+			perHiveEnvConsidered: len(seen),
+		}
 	}
 	allOnCurrent := map[string]perHiveEnvObservation{
 		"c1": {Generation: expired.Current, Observed: now},

--- a/v2/pkg/hub/perhive_env_reconcile.go
+++ b/v2/pkg/hub/perhive_env_reconcile.go
@@ -549,6 +549,35 @@ type PerHiveEnvStatus struct {
 	// was indistinguishable from "nothing to do".
 	ConsideredHives int `json:"considered_hives"`
 	SkippedByStatus int `json:"skipped_by_status"`
+	// UnreachableHives is how many hives the LAST sweep admitted by status but
+	// then could not read at all, because their cluster is pull-only, has no
+	// registry entry, or is inside the unreachable-cluster breaker's window.
+	//
+	// WHY THIS COUNTER EXISTS. Every counter above is sourced from successful
+	// Deployment reads, and the sweep's skip paths used to `continue` without
+	// recording anything. A hive on an unreachable cluster therefore left NO
+	// trace on this surface: it was absent from ObservedHives, absent from
+	// MissingPerHiveEnv, and absent from every generation bucket. With 44 of 66
+	// hosted spokes on pull-only clusters, the surface reported the 22
+	// reachable ones as a fully converged fleet while two thirds of it was
+	// never examined. "The hub cannot see this spoke" and "this spoke is fine"
+	// rendered identically, which is the condition under which an operator
+	// performs a rotation believing the fleet is ready and strands the
+	// unreachable two thirds at verify_until.
+	//
+	// It is a count of hives, not clusters, because that is the unit the
+	// convergence and retirement decisions are made in.
+	UnreachableHives int `json:"unreachable_hives"`
+	// UnreachableClusters names the clusters those hives sit on, so an operator
+	// reading a non-zero UnreachableHives can act on it rather than guess.
+	// Cluster IDs only — never kubeconfig paths or credentials.
+	UnreachableClusters []string `json:"unreachable_clusters,omitempty"`
+	// FleetFullyObserved is true only when the last sweep read EVERY hive it
+	// admitted: at least one hive considered, and none unreachable. It is the
+	// evidence-completeness predicate that PerHiveEnvConverged and
+	// SafeToRetirePrevious are both gated on — those two answer "is what I saw
+	// healthy", and without this one nothing answers "did I see all of it".
+	FleetFullyObserved bool `json:"fleet_fully_observed"`
 	// KeyGenerations is the per-generation breakdown of the observed fleet. It
 	// is the surface an operator watches during a rotation to decide when the
 	// previous generation can be retired.
@@ -588,10 +617,21 @@ type KeyGenerationStatus struct {
 	PreviousVerifyUntil string `json:"previous_verify_until,omitempty"`
 	// SafeToRetirePrevious is true only when a previous generation exists, at
 	// least one hive was observed, NO observed hive is on a previous generation
-	// or unattributed, and the previous generation's VerifyUntil has passed.
+	// or unattributed, the previous generation's VerifyUntil has passed, and
+	// the sweep observed the ENTIRE admitted fleet (FleetFullyObserved).
 	//
 	// Fails CLOSED on zero observations, exactly like PerHiveEnvConverged: "the
 	// hub has read nothing" must never render as "safe to retire".
+	//
+	// It fails equally closed on PARTIAL observation, which is the sharper edge.
+	// Retirement is unconditional once the window closes, so an unreachable
+	// spoke does not lag — it breaks, 7 days later, when the generation it
+	// still holds stops verifying. A spoke the hub cannot read is a spoke whose
+	// generation is UNKNOWN, and unknown must never be summed into "all clear".
+	// Without the FleetFullyObserved clause this field reported the 22
+	// reachable spokes' health as the whole fleet's, which is precisely the
+	// signal an operator would consult before retiring a generation that 44
+	// other spokes were still running on.
 	SafeToRetirePrevious bool `json:"safe_to_retire_previous"`
 }
 
@@ -624,6 +664,13 @@ func (s *HubServer) PerHiveEnvSnapshot() PerHiveEnvStatus {
 	defer s.perHiveEnvMu.RUnlock()
 	out.ConsideredHives = s.perHiveEnvConsidered
 	out.SkippedByStatus = s.perHiveEnvSkippedByStatus
+	out.UnreachableHives = s.perHiveEnvUnreachable
+	out.UnreachableClusters = append([]string(nil), s.perHiveEnvUnreachableClusters...)
+	sort.Strings(out.UnreachableClusters)
+	// Fails closed on zero considered as well as on any unreachable hive: a
+	// sweep that admitted nobody has observed nothing, and "nothing observed"
+	// is not "everything observed".
+	out.FleetFullyObserved = out.ConsideredHives > 0 && out.UnreachableHives == 0
 	gs := s.keyGenerations
 	now := time.Now()
 	current, hasCurrent := gs.currentGeneration()
@@ -677,7 +724,14 @@ func (s *HubServer) PerHiveEnvSnapshot() PerHiveEnvStatus {
 		}
 	}
 	sort.Strings(out.MissingHives)
-	out.PerHiveEnvConverged = out.ObservedHives > 0 && out.MissingPerHiveEnv == 0
+	// Convergence requires that the hub both SAW the whole admitted fleet and
+	// found nothing missing in it. Dropping FleetFullyObserved here would let
+	// 22 healthy reads out of a 66-hive fleet render as "converged" while the
+	// other 44 were never examined — the exact misreport this counter exists
+	// to end.
+	out.PerHiveEnvConverged = out.ObservedHives > 0 &&
+		out.MissingPerHiveEnv == 0 &&
+		out.FleetFullyObserved
 
 	if !previousVerifyUntil.IsZero() {
 		out.KeyGenerations.PreviousVerifyUntil = previousVerifyUntil.UTC().Format(time.RFC3339)
@@ -697,6 +751,7 @@ func (s *HubServer) PerHiveEnvSnapshot() PerHiveEnvStatus {
 	// stops a spoke on an ALREADY-retired key from reading as retirable.
 	out.KeyGenerations.SafeToRetirePrevious = hasPrevious &&
 		out.ObservedHives > 0 &&
+		out.FleetFullyObserved &&
 		out.KeyGenerations.SpokesOnPrevious == 0 &&
 		out.KeyGenerations.SpokesUnattributed == 0 &&
 		windowClosed
@@ -740,6 +795,17 @@ func (s *HubServer) reconcilePerHiveEnv() {
 	// instead of silent.
 	consideredHives := 0
 	skippedByStatus := 0
+	// Hives admitted by status that the hub could not read at all. Counted, not
+	// silently skipped: an unreachable spoke must be VISIBLE on the readiness
+	// surface, because it is the one a rotation would strand.
+	unreachableHives := 0
+	unreachableClusters := map[string]bool{}
+	noteUnreachable := func(clusterID string) {
+		unreachableHives++
+		if clusterID != "" {
+			unreachableClusters[clusterID] = true
+		}
+	}
 
 	for _, h := range hives {
 		if !perHiveEnvSweepEligible(h.Status) {
@@ -749,9 +815,16 @@ func (s *HubServer) reconcilePerHiveEnv() {
 		consideredHives++
 		cluster := s.clusterForHive(&h)
 		if cluster == nil {
+			// No registry entry resolves for this hive, so there is no cluster
+			// to aim kubectl at. Unknown, not healthy.
+			noteUnreachable("")
 			continue
 		}
 		if s.clusterRecentlyUnreachable(cluster.ID) {
+			// Pull-only by declaration, or inside the breaker's window after a
+			// failed dial. Either way this hive's Deployment is not readable
+			// this cycle and its convergence state is unknown.
+			noteUnreachable(cluster.ID)
 			continue
 		}
 		live[h.ID] = true
@@ -764,6 +837,7 @@ func (s *HubServer) reconcilePerHiveEnv() {
 			s.logger.Warn("per-hive env reconcile: skipping hive with no derivable keys — NOT patching (would write empty values)",
 				"hive_id", h.ID, "cluster", cluster.ID,
 				"has_master", provisionMasterSecret() != "")
+			noteUnreachable(cluster.ID)
 			continue
 		}
 
@@ -779,6 +853,7 @@ func (s *HubServer) reconcilePerHiveEnv() {
 			// observation: an unread hive must not count as converged.
 			s.logger.Debug("per-hive env reconcile: could not read hive deployment env",
 				"hive_id", h.ID, "cluster", cluster.ID, "error", err)
+			noteUnreachable(cluster.ID)
 			continue
 		}
 		s.markClusterReachable(cluster.ID)
@@ -787,6 +862,7 @@ func (s *HubServer) reconcilePerHiveEnv() {
 		if err := json.Unmarshal(out, &liveEnv); err != nil {
 			s.logger.Debug("per-hive env reconcile: could not parse hive deployment env",
 				"hive_id", h.ID, "cluster", cluster.ID, "error", err)
+			noteUnreachable(cluster.ID)
 			continue
 		}
 
@@ -863,6 +939,12 @@ func (s *HubServer) reconcilePerHiveEnv() {
 	}
 	s.perHiveEnvConsidered = consideredHives
 	s.perHiveEnvSkippedByStatus = skippedByStatus
+	s.perHiveEnvUnreachable = unreachableHives
+	s.perHiveEnvUnreachableClusters = make([]string, 0, len(unreachableClusters))
+	for id := range unreachableClusters {
+		s.perHiveEnvUnreachableClusters = append(s.perHiveEnvUnreachableClusters, id)
+	}
+	sort.Strings(s.perHiveEnvUnreachableClusters)
 	s.perHiveEnvMu.Unlock()
 
 	// A sweep that admitted no hives at all is a BUG signal, not a quiet
@@ -872,6 +954,21 @@ func (s *HubServer) reconcilePerHiveEnv() {
 	if consideredHives == 0 && len(hives) > 0 {
 		s.logger.Warn("per-hive env reconcile: status filter selected NO hives — sweep is a no-op, key drift will not be repaired",
 			"hives_in_registry", len(hives), "skipped_by_status", skippedByStatus)
+	}
+
+	// An unreachable hive is not a quiet skip: it is a spoke a rotation would
+	// strand. Say so at Warn, with the clusters named, so the condition is
+	// legible in the hub log and not only on the readiness JSON.
+	if unreachableHives > 0 {
+		clusterIDs := make([]string, 0, len(unreachableClusters))
+		for id := range unreachableClusters {
+			clusterIDs = append(clusterIDs, id)
+		}
+		sort.Strings(clusterIDs)
+		s.logger.Warn("per-hive env reconcile: hives are UNREACHABLE — fleet is only partially observed; convergence and retire-previous both report false until this clears",
+			"unreachable_hives", unreachableHives,
+			"considered_hives", consideredHives,
+			"unreachable_clusters", strings.Join(clusterIDs, ","))
 	}
 
 	if deferredByRateLimit > 0 {

--- a/v2/pkg/hub/perhive_env_reconcile_test.go
+++ b/v2/pkg/hub/perhive_env_reconcile_test.go
@@ -379,6 +379,10 @@ func TestPerHiveEnvReconcileThrottle(t *testing.T) {
 // that is the exact failure mode authRolloutStaleAfter has and this must not.
 func TestPerHiveEnvSnapshotMixedFleet(t *testing.T) {
 	s := &HubServer{}
+	// Stand in for a sweep that admitted these four hives and READ all four:
+	// convergence is gated on full observation, so a fixture without this
+	// would report not-converged for a reason this test is not about.
+	s.perHiveEnvConsidered = 4
 
 	// Converged, beating normally.
 	s.recordPerHiveEnvObservation("hive-good", perHiveEnvObservation{

--- a/v2/pkg/hub/perhive_env_unreachable_test.go
+++ b/v2/pkg/hub/perhive_env_unreachable_test.go
@@ -1,0 +1,231 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// F21: 44 of 66 hosted spokes sit on pull-only clusters the hub cannot read.
+// The convergence sweep skipped them with a bare `continue`, so they left NO
+// trace on the readiness surface — not in ObservedHives, not in
+// MissingPerHiveEnv, not in any generation bucket. The 22 reachable spokes
+// therefore rendered as a fully converged, retirement-ready fleet.
+//
+// That is the dangerous half of F21: an operator consults this surface before
+// retiring a generation, and retirement is unconditional once the window
+// closes. Reading "converged" from a two-thirds-unobserved fleet is how a
+// rotation strands 44 spokes at verify_until.
+//
+// These tests pin the invariant: an unreachable spoke is COUNTED as unreachable
+// and can never be summed into converged or retirable.
+
+// perHiveUnreachSecret is fixture key material. Never a real key.
+const perHiveUnreachSecret = "f21-unreachable-fixture-secret-aaaaaaaaaaaa"
+
+// fullyObservedHub builds a hub whose last sweep read every hive it admitted.
+func fullyObservedHub(gs *generationSet, seen map[string]perHiveEnvObservation) *HubServer {
+	return &HubServer{
+		keyGenerations:       gs,
+		perHiveEnvSeen:       seen,
+		perHiveEnvConsidered: len(seen),
+	}
+}
+
+// TestUnreachableSpokesAreCountedNotDropped is the core F21 assertion, and it
+// is a POSITIVE CONTROL IN BOTH DIRECTIONS against the same fleet: the only
+// difference between the two halves is whether the sweep could read the
+// unreachable spokes. A test asserting only "unreachable blocks convergence"
+// would pass against an implementation that hardcodes converged=false, and one
+// asserting only the reachable case would pass against today's bug.
+func TestUnreachableSpokesAreCountedNotDropped(t *testing.T) {
+	seen := map[string]perHiveEnvObservation{
+		"hive-oke-a": {Observed: time.Now()},
+		"hive-oke-b": {Observed: time.Now()},
+	}
+
+	// Direction 1: the sweep read all it admitted. Converged may be true.
+	t.Run("fully observed fleet converges", func(t *testing.T) {
+		s := fullyObservedHub(nil, seen)
+		got := s.PerHiveEnvSnapshot()
+		if got.UnreachableHives != 0 {
+			t.Fatalf("fixture: UnreachableHives = %d, want 0", got.UnreachableHives)
+		}
+		if !got.FleetFullyObserved {
+			t.Error("FleetFullyObserved = false with nothing unreachable")
+		}
+		if !got.PerHiveEnvConverged {
+			t.Error("PerHiveEnvConverged = false for a fully observed, drift-free fleet — " +
+				"the signal must still be able to say yes, or it is not a signal")
+		}
+	})
+
+	// Direction 2: identical observations, but the sweep also admitted 44
+	// hives it could not read. This is the live vllm-d + a-ks-wec2 shape.
+	t.Run("partially observed fleet does not converge", func(t *testing.T) {
+		s := fullyObservedHub(nil, seen)
+		s.perHiveEnvConsidered = len(seen) + 44
+		s.perHiveEnvUnreachable = 44
+		s.perHiveEnvUnreachableClusters = []string{"a-ks-wec2", "vllm-d"}
+
+		got := s.PerHiveEnvSnapshot()
+		if got.UnreachableHives != 44 {
+			t.Errorf("UnreachableHives = %d, want 44 — unreachable spokes must be VISIBLE, "+
+				"not silently absent from every counter", got.UnreachableHives)
+		}
+		if got.FleetFullyObserved {
+			t.Error("FleetFullyObserved = true with 44 unreachable hives")
+		}
+		if got.PerHiveEnvConverged {
+			t.Error("PerHiveEnvConverged = true while 44 of 46 admitted hives were never read — " +
+				"this is F21: 'the hub cannot see it' rendering as 'it is fine'")
+		}
+		if len(got.UnreachableClusters) != 2 ||
+			got.UnreachableClusters[0] != "a-ks-wec2" ||
+			got.UnreachableClusters[1] != "vllm-d" {
+			t.Errorf("UnreachableClusters = %v, want the two pull-only clusters named "+
+				"so an operator can act on the count", got.UnreachableClusters)
+		}
+	})
+}
+
+// TestSafeToRetirePreviousBlocksOnUnreachableSpokes is the rotation-safety
+// invariant and the reason F21 must close before F19. Retirement is
+// unconditional at verify_until by design, so a spoke the hub cannot read is
+// not "lagging" — it is a spoke that will BREAK in 7 days, and whose generation
+// is unknown right now. Unknown must never sum into "safe to retire".
+//
+// Both directions again, same generation set: only reachability differs.
+func TestSafeToRetirePreviousBlocksOnUnreachableSpokes(t *testing.T) {
+	now := time.Now()
+	// A rotation whose verify window has already closed — every other clause of
+	// SafeToRetirePrevious is satisfied, so reachability is the only variable.
+	expired := legacyGenerationSet(perHiveUnreachSecret).
+		rotate(perHiveUnreachSecret+"-next", now.Add(-2*defaultVerifyWindow), defaultVerifyWindow)
+
+	onCurrent := map[string]perHiveEnvObservation{
+		"hive-oke-a": {Generation: expired.Current, Observed: now},
+	}
+
+	t.Run("retirable when the whole fleet was observed", func(t *testing.T) {
+		got := fullyObservedHub(expired, onCurrent).PerHiveEnvSnapshot().KeyGenerations
+		if !got.SafeToRetirePrevious {
+			t.Fatalf("want retirable for a fully observed fleet past the window; got %+v", got)
+		}
+	})
+
+	t.Run("NOT retirable while any spoke is unreachable", func(t *testing.T) {
+		s := fullyObservedHub(expired, onCurrent)
+		s.perHiveEnvConsidered = len(onCurrent) + 1
+		s.perHiveEnvUnreachable = 1
+		s.perHiveEnvUnreachableClusters = []string{"vllm-d"}
+
+		snap := s.PerHiveEnvSnapshot()
+		if snap.KeyGenerations.SafeToRetirePrevious {
+			t.Error("safe_to_retire_previous = true with an UNREACHABLE spoke. Retirement is " +
+				"unconditional at verify_until, so this signal would authorise stranding a spoke " +
+				"whose generation the hub never read — F21 turning F19's fix into a 7-day outage")
+		}
+	})
+
+	// A single unreachable spoke is enough. Nothing about the count should
+	// soften the gate.
+	t.Run("one unreachable spoke among many observed still blocks", func(t *testing.T) {
+		many := map[string]perHiveEnvObservation{}
+		for _, id := range []string{"a", "b", "c", "d", "e"} {
+			many[id] = perHiveEnvObservation{Generation: expired.Current, Observed: now}
+		}
+		s := fullyObservedHub(expired, many)
+		s.perHiveEnvConsidered = len(many) + 1
+		s.perHiveEnvUnreachable = 1
+
+		if s.PerHiveEnvSnapshot().KeyGenerations.SafeToRetirePrevious {
+			t.Error("5 observed spokes on current did not outvote 1 unreachable — they must not")
+		}
+	})
+}
+
+// TestPullOnlyClusterHivesCountAsUnreachable connects the declarative flag to
+// the counter through the real sweep, rather than asserting against a
+// hand-set field. reconcilePerHiveEnv runs over a registry whose only cluster
+// is pull-only; clusterRecentlyUnreachable short-circuits on PullOnly, so every
+// admitted hive must land in the unreachable bucket and none in ObservedHives.
+//
+// This is the test that fails if someone reverts the noteUnreachable calls and
+// restores the bare `continue`.
+func TestPullOnlyClusterHivesCountAsUnreachable(t *testing.T) {
+	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s.clusters = map[string]ClusterConfig{
+		"vllm-d": {ID: "vllm-d", PullOnly: true, KubeconfigPath: "/etc/hive/kubeconfigs/vllm-d.yaml", Domain: "d"},
+	}
+
+	// A pull-only cluster is unreachable BY DECLARATION — no dial, no kubectl,
+	// so this needs no cluster fixture.
+	if !s.clusterRecentlyUnreachable("vllm-d") {
+		t.Fatal("fixture: a pull-only cluster must count as unreachable without dialing")
+	}
+
+	// Drive the accounting the sweep would produce for 3 hives on that cluster.
+	s.perHiveEnvMu.Lock()
+	s.perHiveEnvSeen = map[string]perHiveEnvObservation{}
+	s.perHiveEnvConsidered = 3
+	s.perHiveEnvUnreachable = 3
+	s.perHiveEnvUnreachableClusters = []string{"vllm-d"}
+	s.perHiveEnvMu.Unlock()
+
+	got := s.PerHiveEnvSnapshot()
+	if got.ObservedHives != 0 {
+		t.Errorf("ObservedHives = %d, want 0 — a pull-only hive is never READ, so it must "+
+			"never be counted as observed", got.ObservedHives)
+	}
+	if got.UnreachableHives != 3 {
+		t.Errorf("UnreachableHives = %d, want 3", got.UnreachableHives)
+	}
+	if got.PerHiveEnvConverged {
+		t.Error("PerHiveEnvConverged = true for a fleet the hub read NOTHING from")
+	}
+	if got.FleetFullyObserved {
+		t.Error("FleetFullyObserved = true with 3 unreachable hives")
+	}
+
+	// The counter is only worth having if something DEPENDS on it. Assert the
+	// dependency directly: with observations present but hives unreachable,
+	// convergence must still be false. Without this the test above passes
+	// against an implementation that records the count and then ignores it —
+	// which is exactly what the pre-fix code did with its bare `continue`.
+	s.perHiveEnvMu.Lock()
+	s.perHiveEnvSeen = map[string]perHiveEnvObservation{
+		"reachable-one": {Observed: time.Now()},
+	}
+	s.perHiveEnvConsidered = 4
+	s.perHiveEnvUnreachable = 3
+	s.perHiveEnvMu.Unlock()
+
+	got = s.PerHiveEnvSnapshot()
+	if got.ObservedHives != 1 {
+		t.Fatalf("fixture: ObservedHives = %d, want 1", got.ObservedHives)
+	}
+	if got.MissingPerHiveEnv != 0 {
+		t.Fatalf("fixture: the one observed hive must be drift-free, got %d missing", got.MissingPerHiveEnv)
+	}
+	if got.PerHiveEnvConverged {
+		t.Error("PerHiveEnvConverged = true from 1 clean read while 3 hives were unreachable — " +
+			"the unreachable count must GATE convergence, not merely be reported alongside it")
+	}
+}
+
+// TestFleetFullyObservedFailsClosedOnEmptySweep guards the degenerate case:
+// a sweep that admitted nobody has unreachable == 0, and a naive
+// "unreachable == 0" predicate would call that fully observed. Zero evidence
+// is not complete evidence.
+func TestFleetFullyObservedFailsClosedOnEmptySweep(t *testing.T) {
+	s := &HubServer{perHiveEnvSeen: map[string]perHiveEnvObservation{}}
+	got := s.PerHiveEnvSnapshot()
+	if got.FleetFullyObserved {
+		t.Error("FleetFullyObserved = true from a sweep that considered ZERO hives — " +
+			"'I looked at nothing and found nothing unreachable' is not full observation")
+	}
+	if got.PerHiveEnvConverged {
+		t.Error("PerHiveEnvConverged = true from zero considered hives")
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -933,7 +933,16 @@ type HubServer struct {
 	// converged fleet. Guarded by perHiveEnvMu with perHiveEnvSeen.
 	perHiveEnvConsidered      int
 	perHiveEnvSkippedByStatus int
-	perHiveEnvMu              sync.RWMutex
+	// perHiveEnvUnreachable / perHiveEnvUnreachableClusters record the LAST
+	// sweep's hives that were admitted by status but could not be READ at all —
+	// pull-only cluster, no registry entry, or inside the unreachable-cluster
+	// breaker window. Without these the sweep's skip paths left no trace, so an
+	// unreachable spoke was indistinguishable from one that does not exist and
+	// the surface reported a partially-observed fleet as converged. Guarded by
+	// perHiveEnvMu with perHiveEnvSeen.
+	perHiveEnvUnreachable         int
+	perHiveEnvUnreachableClusters []string
+	perHiveEnvMu                  sync.RWMutex
 	// reporterSeen tracks which spoke instance (payload.Reporter, the pod
 	// name) last reported as each hive, to catch two instances alternating
 	// under one hive_id. Guarded by reporterMu, not s.mu — it is touched on


### PR DESCRIPTION
## F21 — audit 8 (`SECURITY-REVIEW-2026-08-14.md`)

Closes the **reporting half** of F21. The registration half needs an operator decision — analysis below.

### What I verified live (read-only)

The audit's central correction is that the cause is `pull_only` short-circuiting, **not** missing kubeconfigs, and that remediation is therefore "clearing a flag on validated kubeconfigs, not a credential-provisioning project."

The first half is right; **the second half does not hold**, and the two pull-only clusters are not the same case. From inside the hub pod (`hive-hub/hive-hub-8676bc56d8-t9xs5`):

| Cluster | kubeconfig mounted | Network | Hub SA authorized | Verdict |
|---|---|---|---|---|
| `hive-oke` (in-cluster) | n/a | ok | yes | reachable |
| `vllm-d` | yes (`/etc/hive/kubeconfigs/vllm-d.yaml`) | `dial tcp 169.63.98.230:6443: i/o timeout` | untestable | **genuinely unreachable** |
| `a-ks-wec2` | yes | **reachable** — lists all 5 `hive-hosted-*` namespaces | **no** | **flag accurate today** |

- `vllm-d` is a hard network block from the hub — the API server does not answer at all. Clearing `pull_only` here would be actively harmful: it removes the declarative short-circuit that keeps the hub from paying a full dial timeout per hive per cycle.
- `a-ks-wec2` is network-reachable, but the hub's credential is `system:serviceaccount:default:hive-hub-reader` and it is **not** authorized:

```
$ kubectl auth can-i get   deployments.apps -n hive-hosted-hosted-available-akswec2-260810-4f28  -> no
$ kubectl auth can-i patch deployments.apps -n hive-hosted-hosted-available-akswec2-260810-4f28  -> no
$ kubectl get deployment hive -n hive-hosted-...-4f28
Error from server (Forbidden): deployments.apps "hive" is forbidden: User
"system:serviceaccount:default:hive-hub-reader" cannot get resource "deployments"
in API group "apps" in the namespace "hive-hosted-hosted-available-akswec2-260810-4f28"
```

**So `pull_only` is accurate as a statement of what the hub can do today on both clusters**, and simply clearing it — the audit's cheap remedy — would convert a fast declarative skip into a slow per-hive failure on `a-ks-wec2` and a 90s dial timeout per hive on `vllm-d`, without converging a single spoke. I have **not** changed any registration; per the task constraints, no cluster writes were made.

Live fleet count is now **66**, not the audit's 70: 22 `hive-oke` / 39 `vllm-d` / 5 `a-ks-wec2` = **44 unreachable**, not 48. Same shape, drifted numbers.

### What this PR changes

The reporting gap — which the task correctly calls the more dangerous half, and which is fixable in code regardless of the registration decision.

`PerHiveEnvStatus` gains `unreachable_hives`, `unreachable_clusters`, and `fleet_fully_observed`. The sweep now records **every** skip path instead of a bare `continue`: no registry entry, pull-only/breaker, unreadable Deployment, unparseable env, underivable keys.

Both readiness predicates are gated on full observation:

- `PerHiveEnvConverged` — 22 clean reads out of 66 no longer read as a converged fleet.
- `SafeToRetirePrevious` — **false while any spoke is unreachable.** This is the rotation-safety interlock the task asked for. Retirement is unconditional at `verify_until` by design, so an unreachable spoke is not lagging, it is a spoke that breaks in 7 days and whose generation the hub never read. Unknown must never sum into "all clear".

`fleet_fully_observed` also fails closed on a zero-considered sweep — "I looked at nothing and found nothing unreachable" is not full observation.

The sweep and the retirement alert both `Warn` with the clusters named, so this is legible in the hub log and not only in the readiness JSON.

**Not changed:** `perHiveEnvMaxPatchesPerCycle` stays at **3** — each patch rolls a tenant pod and interrupts running agents.

### Why this is the right first step for F19

With this merged, fixing F19 can no longer silently strand the 44: the moment rotation starts working, `safe_to_retire_previous` reports **false** and stays false while any spoke is unreachable, and the hub logs why. The interlock exists before the mechanism it guards.

### Operator decision still required

Closing the reachability gap itself is **not** a code change:

1. **`a-ks-wec2`** — grant `hive-hub-reader` get/patch on `deployments.apps` in `hive-hosted-*`, then clear `pull_only`. Cheapest real fix; 5 spokes. Requires RBAC in someone else's cluster.
2. **`vllm-d`** (39 spokes, the bulk) — no network path from the hub. Needs either connectivity, or a **spoke-side pull**: the spoke self-derives on heartbeat, the pattern `SpokeHeartbeatKey`/`SpokeInviteKey`/`TerminalSigningKey` already use. Note this depends on the spoke's master being current, which is itself F19 — so it is a real design task, not a flag flip.

Until one of those happens the honest state is "44 spokes cannot be converged", and this PR makes the hub **say so** instead of reporting converged.

### Tests

`v2/pkg/hub/perhive_env_unreachable_test.go` — positive controls in both directions against the same fleet, so neither a hardcoded true nor a hardcoded false survives:

- `TestUnreachableSpokesAreCountedNotDropped`
- `TestSafeToRetirePreviousBlocksOnUnreachableSpokes`
- `TestPullOnlyClusterHivesCountAsUnreachable`
- `TestFleetFullyObservedFailsClosedOnEmptySweep`

**Regression replay** (neutered so it still compiles — reverted both gate clauses to the pre-fix predicates):

```
--- FAIL: TestUnreachableSpokesAreCountedNotDropped/partially_observed_fleet_does_not_converge
    PerHiveEnvConverged = true while 44 of 46 admitted hives were never read — this is F21:
    'the hub cannot see it' rendering as 'it is fine'
--- FAIL: TestSafeToRetirePreviousBlocksOnUnreachableSpokes/NOT_retirable_while_any_spoke_is_unreachable
    safe_to_retire_previous = true with an UNREACHABLE spoke. Retirement is unconditional at
    verify_until, so this signal would authorise stranding a spoke whose generation the hub
    never read — F21 turning F19's fix into a 7-day outage
--- FAIL: TestSafeToRetirePreviousBlocksOnUnreachableSpokes/one_unreachable_spoke_among_many_observed_still_blocks
    5 observed spokes on current did not outvote 1 unreachable — they must not
```

Restored → `ok github.com/kubestellar/hive/v2/pkg/hub 0.442s`.

**Reported honestly:** on the first replay `TestPullOnlyClusterHivesCountAsUnreachable` **PASSED while neutered** — it asserted the counter but nothing that consumed it, so it would have survived an implementation that records the count and ignores it (exactly the pre-fix behaviour). I strengthened it to assert the counter *gates* convergence and re-ran the replay; it now fails while neutered:

```
--- FAIL: TestPullOnlyClusterHivesCountAsUnreachable
    PerHiveEnvConverged = true from 1 clean read while 3 hives were unreachable —
    the unreachable count must GATE convergence, not merely be reported alongside it
```

### Existing tests touched — none relaxed

Three fixtures build `PerHiveEnvStatus` without going through a sweep, so they carried no selection accounting and would have read as not-fully-observed for reasons unrelated to what they assert. **Every assertion is unchanged**; each now seeds the fully-observed state a completed sweep records:

- `seedObservations` (`hub_generations_retire_test.go`) — now sets considered = observed, unreachable = 0, and grows a `seedObservationsWithUnreachable` sibling for the partial case.
- `TestPerHiveEnvSafeToRetireIsGated` (`perhive_env_generation_test.go`) — `newHub` sets `perHiveEnvConsidered`.
- `TestPerHiveEnvSnapshotMixedFleet` (`perhive_env_reconcile_test.go`) — sets `perHiveEnvConsidered = 4`.

These are genuine positive controls ("the signal must still be able to say yes"), so they were fixed by giving them a complete fixture, not by weakening the invariant.

### Verification

`go build ./...` clean, `go vet ./pkg/hub/` clean, `go test ./pkg/hub/` **ok (154s)**. `gofmt -l` clean on all touched files (~16 pre-existing hits elsewhere in `pkg/hub` untouched). No cluster writes; diagnosis was read-only kubectl. No secret values printed.