### PR TITLE
🔒 fix(proxy,hub): delete the legacy symmetric cookie lane (F23) and the dead raw-master heartbeat acceptor (F24)

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -734,31 +734,27 @@ func secureCompareHub(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
-// heartbeatBearerOK reports whether the Authorization header carries a valid
-// heartbeat bearer, accepting EITHER scheme so this v2 hub authenticates old and
-// new spokes at once (dual-path, additive — never one instead of the other):
+// AUDIT F24 TOMBSTONE — heartbeatBearerOK WAS HERE AND IS DELETED.
+// Do not reintroduce it, and do not "restore" it from history.
 //
-//   - the legacy RAW master s.hubSecret, presented by the 33 existing spokes; and
-//   - the DERIVED heartbeatKey() (HMAC-SHA256(master, "hive-heartbeat-v1")),
-//     presented by a v4 spoke that self-derived it from the same HIVE_HUB_SECRET.
+// It was a complete F2/N1 lane: it accepted the RAW fleet master (s.hubSecret)
+// as a bearer, and the fleet-wide heartbeatKey() = HMAC(master,
+// "hive-heartbeat-v1"). Neither comparand binds a hive identity, so any spoke
+// presenting either token could claim ANY hive_id — the original N1 IDOR. It was
+// the only place in the hub tree where the raw master was an authentication
+// comparand.
 //
-// Both comparisons are constant-time via secureCompareHub. The caller keeps its
-// outer `if s.hubSecret != ""` guard, so an unconfigured hub still authenticates
-// nothing here — this only widens WHICH bearer a configured hub accepts, and only
-// ever adds the new scheme alongside the old one.
-func (s *HubServer) heartbeatBearerOK(auth string) bool {
-	if !strings.HasPrefix(auth, "Bearer ") {
-		return false
-	}
-	tok := strings.TrimPrefix(auth, "Bearer ")
-	if secureCompareHub(tok, s.hubSecret) {
-		return true
-	}
-	if hk := s.heartbeatKey(); hk != "" && secureCompareHub(tok, hk) {
-		return true
-	}
-	return false
-}
+// It had zero non-test callers when deleted, so removal is behaviour-preserving.
+// It is removed rather than left dead because its tests ASSERTED THE VULNERABLE
+// BEHAVIOUR ("heartbeatBearerOK must accept raw master secret"), which would
+// have made a future refactor that re-wired it look verified-correct against a
+// green suite. Those tests are INVERTED, not deleted, in
+// server_handlers_coverage_test.go — they now assert the fleet-wide and
+// raw-master bearers are REJECTED, so this cannot come back silently.
+//
+// The live, correct path is verifyHeartbeatBearer (hub_keys.go), which is
+// per-hive-only: derivePerHiveKey(master_g, infoHeartbeatKey, hiveID) for every
+// live generation, with no deriveDomainKey fleet-wide branch anywhere (F2).
 
 // heartbeatHealthStaleness is the maximum age of heartbeat-reported health
 // data before it is considered stale and displayed with a warning.

--- a/v2/pkg/hub/server_handlers_coverage_test.go
+++ b/v2/pkg/hub/server_handlers_coverage_test.go
@@ -5,60 +5,185 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
-// --- heartbeatBearerOK tests ---
+// --- AUDIT F24: heartbeatBearerOK is DELETED; these tests are INVERTED ---
+//
+// These four tests previously asserted the VULNERABLE behaviour — literally
+// "heartbeatBearerOK must accept raw master secret". heartbeatBearerOK accepted
+// the raw fleet master and the fleet-wide heartbeatKey(), neither of which binds
+// a hive identity, so any spoke holding either could claim ANY hive_id (N1 IDOR).
+//
+// They are INVERTED rather than deleted on purpose. Deleting them would leave
+// nothing standing guard: a future refactor that re-introduced a fleet-wide
+// acceptor would face a green suite. Inverted, they fail the moment such a lane
+// comes back. Each now asserts REJECTION against the live verifier,
+// verifyHeartbeatBearer, which is per-hive-only (F2).
 
-func TestHeartbeatBearerOK_LegacyRawSecret(t *testing.T) {
+const f24TestHiveID = "hive-f24"
+
+// TestF24_FleetWideHeartbeatBearerIsRejected is the direct inversion of the old
+// TestHeartbeatBearerOK_LegacyRawSecret and _DerivedKey. Both tokens the deleted
+// acceptor honoured must now be refused.
+func TestF24_FleetWideHeartbeatBearerIsRejected(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	secret := srv.hubSecret
 
-	if !srv.heartbeatBearerOK("Bearer " + secret) {
-		t.Error("heartbeatBearerOK must accept raw master secret")
+	// POSITIVE CONTROL FIRST: prove the per-hive bearer DOES verify, so that a
+	// verifier which rejected everything could not pass this test. Without this
+	// the rejection assertions below would be satisfied by a broken hub that
+	// authenticates no spoke at all.
+	perHive := srv.heartbeatKeyFor(f24TestHiveID)
+	if perHive == "" {
+		t.Fatal("precondition: heartbeatKeyFor returned empty — cannot distinguish reject-all from correct")
+	}
+	if !srv.verifyHeartbeatBearer(perHive, f24TestHiveID) {
+		t.Fatal("positive control FAILED: the per-hive heartbeat bearer must still verify")
+	}
+
+	// The two tokens the deleted heartbeatBearerOK accepted.
+	if srv.verifyHeartbeatBearer(srv.hubSecret, f24TestHiveID) {
+		t.Error("F24 REGRESSION: the RAW fleet master must not authenticate a heartbeat")
+	}
+	fleetWide := deriveDomainKey(srv.hubSecret, infoHeartbeatKey)
+	if fleetWide == "" {
+		t.Fatal("precondition: fleet-wide derivation returned empty")
+	}
+	if srv.verifyHeartbeatBearer(fleetWide, f24TestHiveID) {
+		t.Error("F24 REGRESSION: the FLEET-WIDE derived heartbeat key must not authenticate a heartbeat")
 	}
 }
 
-func TestHeartbeatBearerOK_DerivedKey(t *testing.T) {
+// TestF24_PerHiveBearerDoesNotCrossHives is the F2 identity property: hive A's
+// bearer must not authenticate hive B. A fleet-wide lane of any shape breaks
+// this, so it guards the invariant rather than one deleted function.
+func TestF24_PerHiveBearerDoesNotCrossHives(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	derived := srv.heartbeatKey()
-	if derived == "" {
-		t.Fatal("heartbeatKey() returned empty — test cannot proceed")
+
+	keyA := srv.heartbeatKeyFor("hive-a")
+	keyB := srv.heartbeatKeyFor("hive-b")
+	if keyA == "" || keyB == "" {
+		t.Fatal("precondition: per-hive derivation returned empty")
+	}
+	if keyA == keyB {
+		t.Fatal("per-hive heartbeat keys for different hives must differ — derivation is not hive-bound")
 	}
 
-	if !srv.heartbeatBearerOK("Bearer " + derived) {
-		t.Error("heartbeatBearerOK must accept derived heartbeat key")
+	// Positive controls: each key works for its OWN hive.
+	if !srv.verifyHeartbeatBearer(keyA, "hive-a") {
+		t.Fatal("positive control FAILED: hive-a bearer must verify for hive-a")
+	}
+	if !srv.verifyHeartbeatBearer(keyB, "hive-b") {
+		t.Fatal("positive control FAILED: hive-b bearer must verify for hive-b")
+	}
+
+	// The identity property itself, in both directions.
+	if srv.verifyHeartbeatBearer(keyA, "hive-b") {
+		t.Error("F2 REGRESSION: hive-a's bearer must be rejected for hive-b")
+	}
+	if srv.verifyHeartbeatBearer(keyB, "hive-a") {
+		t.Error("F2 REGRESSION: hive-b's bearer must be rejected for hive-a")
 	}
 }
 
-func TestHeartbeatBearerOK_InvalidTokenRejected(t *testing.T) {
+// TestF24_CrossHiveRejectedUnderEveryLiveGeneration extends the identity
+// property across master generations. Rotation introduced trial verification
+// over every live generation; a fleet-wide lane re-added to ANY generation would
+// be invisible to a single-generation test.
+func TestF24_CrossHiveRejectedUnderEveryLiveGeneration(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	if srv.keyGenerations == nil {
+		t.Fatal("precondition: no generation set on a default hub server")
+	}
+
+	gens := srv.keyGenerations.acceptableGenerations(time.Now())
+	if len(gens) == 0 {
+		t.Fatal("precondition: no live generations to exercise")
+	}
+
+	for _, g := range gens {
+		// Positive control for THIS generation: its per-hive key verifies.
+		keyA := derivePerHiveKey(g.Secret, infoHeartbeatKey, "hive-a")
+		if keyA == "" {
+			t.Fatalf("gen %d: per-hive derivation returned empty", g.ID)
+		}
+		if !srv.verifyHeartbeatBearer(keyA, "hive-a") {
+			t.Fatalf("gen %d: positive control FAILED — per-hive bearer must verify for its own hive", g.ID)
+		}
+
+		// Cross-hive must fail under this generation.
+		if srv.verifyHeartbeatBearer(keyA, "hive-b") {
+			t.Errorf("gen %d: F2 REGRESSION — hive-a's bearer accepted for hive-b", g.ID)
+		}
+		// Fleet-wide material from this generation must fail outright.
+		if fw := deriveDomainKey(g.Secret, infoHeartbeatKey); fw != "" && srv.verifyHeartbeatBearer(fw, "hive-a") {
+			t.Errorf("gen %d: F24 REGRESSION — fleet-wide derived key accepted", g.ID)
+		}
+		if srv.verifyHeartbeatBearer(g.Secret, "hive-a") {
+			t.Errorf("gen %d: F24 REGRESSION — raw generation master accepted", g.ID)
+		}
+	}
+}
+
+// TestF24_MalformedAndEmptyBearersRejected preserves the old
+// _InvalidTokenRejected coverage against the live verifier. The old cases were
+// Authorization-header shaped because heartbeatBearerOK parsed the header;
+// verifyHeartbeatBearer takes the token itself, so the header-parsing cases
+// become token-shaped and the empty-hiveID fail-closed case is added.
+func TestF24_MalformedAndEmptyBearersRejected(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	valid := srv.heartbeatKeyFor(f24TestHiveID)
+	if valid == "" {
+		t.Fatal("precondition: heartbeatKeyFor returned empty")
+	}
+	if !srv.verifyHeartbeatBearer(valid, f24TestHiveID) {
+		t.Fatal("positive control FAILED: the valid per-hive bearer must verify")
+	}
 
 	cases := []struct {
-		name string
-		auth string
+		name      string
+		presented string
+		hiveID    string
 	}{
-		{"empty", ""},
-		{"no bearer prefix", srv.hubSecret},
-		{"wrong token", "Bearer totally-wrong-token"},
-		{"basic auth", "Basic dXNlcjpwYXNz"},
-		{"bearer prefix only", "Bearer "},
-		{"bearer with space", "Bearer  " + srv.hubSecret},
+		{"empty token", "", f24TestHiveID},
+		{"wrong token", "totally-wrong-token", f24TestHiveID},
+		{"valid token, empty hiveID", valid, ""},
+		{"valid token, unknown hive", valid, "some-other-hive"},
+		{"bearer prefix left on", "Bearer " + valid, f24TestHiveID},
+		{"leading space", " " + valid, f24TestHiveID},
+		{"truncated token", valid[:len(valid)-1], f24TestHiveID},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if srv.heartbeatBearerOK(tc.auth) {
-				t.Errorf("heartbeatBearerOK(%q) = true, want false", tc.auth)
+			if srv.verifyHeartbeatBearer(tc.presented, tc.hiveID) {
+				t.Errorf("verifyHeartbeatBearer(%q, %q) = true, want false", tc.presented, tc.hiveID)
 			}
 		})
 	}
 }
 
-func TestHeartbeatBearerOK_DerivedDiffersFromRaw(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
-	if srv.hubSecret == srv.heartbeatKey() {
-		t.Error("derived heartbeat key must differ from raw master secret")
+// TestF24_NoFleetWideHeartbeatLaneInSource is a source-level invariant guard.
+// The behavioural tests above can only catch a fleet-wide lane that is REACHED;
+// heartbeatBearerOK was dead-but-armed and therefore invisible to them. This
+// asserts the deleted acceptor has not returned to the file at all.
+func TestF24_NoFleetWideHeartbeatLaneInSource(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("read server.go: %v", err)
+	}
+	body := string(src)
+
+	// Positive control: the tombstone naming the finding must be present, so a
+	// wholesale rewrite of the file cannot make this test vacuously pass.
+	if !strings.Contains(body, "AUDIT F24 TOMBSTONE") {
+		t.Fatal("positive control FAILED: the F24 tombstone comment is missing from server.go")
+	}
+
+	if strings.Contains(body, "func (s *HubServer) heartbeatBearerOK(") {
+		t.Error("F24 REGRESSION: heartbeatBearerOK has been reintroduced in server.go")
 	}
 }
 

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -14,10 +14,14 @@ const TTYD_PORT = parseInt(process.env.HIVE_TTYD_PORT || '7681', 10);
 const TTYD_URL = `http://127.0.0.1:${TTYD_PORT}`;
 const DASHBOARD_TOKEN = process.env.HIVE_DASHBOARD_TOKEN || '';
 const STATIC_DIR = process.env.HIVE_STATIC_DIR || path.join(__dirname, 'public');
-// C2 domain separation: the proxy verifies the hub-minted `hive_hub_user`
-// session/terminal cookie, which is HMAC'd with the derived SESSION sub-key —
-// NOT the master hub secret. A hub-hosted hive is injected HIVE_SESSION_KEY and
-// never the master, so a spoke operator cannot forge a session cookie.
+// SESSION_KEY was the symmetric key the `hive_hub_user` cookie used to be
+// verified with. AUDIT F23 DELETED THAT LANE — see verifyHubUserCookieEither.
+// The cookie is now verified ONLY against the Ed25519 SESSION_PUBLIC_KEY below,
+// so this spoke can verify a hub-minted cookie but cannot mint one.
+//
+// SESSION_KEY is still resolved because it remains the IS_HOSTED boot signal
+// (a self-hosted operator legitimately holds the master). It must NOT be
+// reintroduced as a signature-verification comparand.
 //
 // SESSION_KEY resolution mirrors the Go SpokeSessionKey() helper:
 //   1. HIVE_SESSION_KEY (modern least-privilege provisioning) if set, else
@@ -42,10 +46,13 @@ const SESSION_KEY = deriveSessionKey();
 //
 // SESSION_KEY above is symmetric, so a spoke able to verify was equally able to
 // mint — any spoke operator could read it from the pod env and forge
-// `clubanderson.<sig>`, a hub ADMIN cookie honoured on ~21 admin routes. Both
-// are read during the rollout window: this spoke may be running an older image
-// than the hub, or vice versa. Once the fleet has rolled, HIVE_SESSION_KEY (and
-// the legacy branch in verifyHubUserCookieEither) go away.
+// `clubanderson.<sig>`, a hub ADMIN cookie honoured on ~21 admin routes.
+//
+// AUDIT F23: that verification lane is now DELETED. SESSION_KEY is no longer a
+// signature-verification comparand anywhere in this file; cookies verify ONLY
+// against SESSION_PUBLIC_KEY through the asymmetric v3/v2 lanes, so a spoke can
+// verify but can no longer mint. SESSION_KEY is retained solely as the IS_HOSTED
+// boot signal (see below).
 //
 // Derived from HIVE_HUB_SECRET as a fallback for self-hosted spokes whose
 // operator legitimately holds the master. The info string MUST stay byte-for-byte
@@ -574,34 +581,22 @@ function requireAuth(req, res, next) {
   next();
 }
 
-// verifyHubUserCookie mirrors verifyHubUserCookieValue in v2/pkg/hub/hub_cookie.go
-// EXACTLY. The `hive_hub_user` cookie value is `<username>.<sig>` where sig is
-// base64url-unpadded HMAC-SHA256(key=SESSION_KEY, msg=username). The proxy holds
-// no other secret and must not merely check that the cookie is non-empty (that
-// was CWE-345: any `Cookie: hive_hub_user=x` yielded a shell in a
-// credential-holding container). We recompute the HMAC and constant-time-compare
-// the signature; a forged, edited, or legacy-unsigned cookie fails closed.
+// AUDIT F23 TOMBSTONE — verifyHubUserCookie (the legacy symmetric HMAC verifier)
+// WAS HERE AND IS DELETED. Do not reintroduce it.
 //
-// Returns the verified username on success, or '' when the signature does not
-// verify / the secret is unset / the value is malformed.
-function verifyHubUserCookie(secret, value) {
-  if (!secret || !value) return '';
-  // SplitN from the right: the final segment is the signature.
-  const idx = value.lastIndexOf('.');
-  if (idx <= 0 || idx === value.length - 1) return '';
-  const username = value.slice(0, idx);
-  const sig = value.slice(idx + 1);
-  const expected = crypto
-    .createHmac('sha256', secret)
-    .update(username)
-    .digest('base64url'); // base64url is unpadded, matching Go's RawURLEncoding
-  const suppliedBuf = Buffer.from(sig);
-  const expectedBuf = Buffer.from(expected);
-  if (suppliedBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(suppliedBuf, expectedBuf)) {
-    return '';
-  }
-  return username;
-}
+// It verified `<username>.<base64url(HMAC-SHA256(SESSION_KEY, username))>`.
+// SESSION_KEY is symmetric and fleet-uniform, so any party able to VERIFY was
+// equally able to MINT. The Go hub deleted its twin in F1 (#3725); this is the
+// Node half, and with it the last consumer of SESSION_KEY as a verification
+// input.
+//
+// Only the ASYMMETRIC lanes remain — verifyHubUserCookieV3 (F10, signed expiry)
+// and verifyHubUserCookieV2 (Ed25519). A spoke holds only the PUBLIC key, so a
+// spoke operator can verify a hub-minted cookie but can no longer forge one.
+//
+// SESSION_KEY itself is intentionally still resolved above: it remains the
+// IS_HOSTED signal and the self-hosted boot check. What died is its use as a
+// signature-verification comparand, not the variable.
 
 // HUB_COOKIE_V2_MARKER separates the username from an Ed25519 signature. It must
 // stay byte-identical to hubCookieV2Marker in v2/pkg/hub/hub_cookie.go. A legacy
@@ -696,32 +691,44 @@ function verifyHubUserCookieV3(pubHex, value, nowSeconds) {
   }
 }
 
-// verifyHubUserCookieEither accepts a v3 (F10: signed lifetime), a v2 (Ed25519)
-// cookie or, during the rollout window only, a legacy HMAC one — mirroring the Go
-// helper of the same name. Lanes are tried v3 → v2 → legacy.
+// verifyHubUserCookieEither accepts a v3 (F10: signed lifetime) or a v2
+// (Ed25519) cookie — mirroring the Go helper of the same name. Lanes are tried
+// v3 → v2. Both are ASYMMETRIC: this spoke holds only the PUBLIC key, so it can
+// verify but cannot mint.
 //
-// The v2 and legacy branches are STRICTLY additive compatibility paths. Removing
-// either one 401s every part of the fleet that has not rolled. The legacy branch
-// is additionally the N2 vulnerability (verify-capable implies mint-capable) and
-// is removed once the fleet has rolled and existing cookies have aged out.
+// AUDIT F23 (Medium): the legacy symmetric HMAC lane is GONE, in lockstep with
+// the Go hub's F1 deletion (hub_cookie.go, PR #3725). It verified the cookie
+// against SESSION_KEY, which is byte-identical across the whole hosted fleet —
+// measured live at 1 distinct value across 48/48 reachable spokes. Symmetric
+// material means verify-capable implies MINT-capable, so any spoke operator who
+// could read the pod env could forge `clubanderson.<sig>` and have it accepted
+// by EVERY other tenant's proxy. That is a genuine cross-tenant forgery
+// primitive, not a theoretical one.
+//
+// legacySecret is retained in the signature but is deliberately unused: callers
+// still pass it, and accepting-and-ignoring is safer than a signature change a
+// future merge could mis-resolve into re-enabling the lane. That is precisely
+// how F14 and F18 regressed on the Go side.
 function verifyHubUserCookieEither(pubHex, legacySecret, value) {
   const v3 = verifyHubUserCookieV3(pubHex, value);
   if (v3) return v3;
   const v2 = verifyHubUserCookieV2(pubHex, value);
   if (v2) return v2;
-  return verifyHubUserCookie(legacySecret, value);
+  void legacySecret;
+  return '';
 }
 
 // verifyHubUserCookieAcrossKeys is BOUNDED TRIAL VERIFICATION of a session
 // cookie against every public key this spoke holds, current-then-previous.
 //
 // This adds a second KEY, not a second FORMAT and not a second LANE. Each
-// candidate runs the identical verifyHubUserCookieEither the single-key path
-// runs, so the v3/v2/legacy lane structure, the expiry enforcement and the
-// signature checks are unchanged. In particular the legacy symmetric HMAC lane
-// is passed `legacySecret` exactly once and is NOT multiplied across keys —
-// SESSION_KEY is symmetric material with no generation plurality here, and
-// giving it any would be re-opening a lane the hub side (F1) has deleted.
+// candidate runs the identical v3/v2 verification the single-key path runs, so
+// the lane structure, the expiry enforcement and the signature checks are
+// unchanged.
+//
+// AUDIT F23: the trailing legacy symmetric lane is DELETED (see
+// verifyHubUserCookieEither). `legacySecret` is accepted and ignored so callers
+// need no change and no merge can silently restore a symmetric fallback here.
 //
 // BOUNDED BY CONFIGURATION, NOT BY INPUT. `pubKeys` comes from
 // sessionPublicKeys(), which is at most two entries because the hub holds at
@@ -735,9 +742,10 @@ function verifyHubUserCookieEither(pubHex, legacySecret, value) {
 // aborts the loop. So a garbage HIVE_SESSION_PUBLIC_KEY_PREV costs nothing but
 // a skipped entry.
 //
-// An empty list verifies nothing through the Ed25519 lanes and falls through to
-// the legacy symmetric lane alone — which is the pre-existing behaviour for a
-// spoke with no public key at all, preserved rather than changed.
+// An empty list verifies NOTHING and returns '' — fail-closed. Before F23 it
+// fell through to the symmetric lane, so a spoke with no public key still
+// authenticated users; now such a spoke authenticates nobody through this path,
+// which is the correct posture for a spoke that holds no verification material.
 function verifyHubUserCookieAcrossKeys(pubKeys, legacySecret, value) {
   if (!value) return '';
   const keys = Array.isArray(pubKeys) ? pubKeys : [];
@@ -747,11 +755,8 @@ function verifyHubUserCookieAcrossKeys(pubKeys, legacySecret, value) {
     const v2 = verifyHubUserCookieV2(pubHex, value);
     if (v2) return v2;
   }
-  // Legacy symmetric lane, tried once and only once after every public key has
-  // been tried. Kept last so an Ed25519-signed cookie is never evaluated
-  // against symmetric material, and kept OUTSIDE the loop so the number of HMAC
-  // computations does not scale with the number of public keys.
-  return verifyHubUserCookie(legacySecret, value);
+  void legacySecret;
+  return '';
 }
 
 // snapshotFrameAncestors (v2 #3032): resolves the per-hive allowlist for framing

--- a/v2/proxy/server.test.js
+++ b/v2/proxy/server.test.js
@@ -248,21 +248,63 @@ const HOSTED_HOST = `${HIVE_B_ID}.hive.kubestellar.io`;
 
 let hiveBTtyd, hiveBProxy;
 
-// mintCookie mirrors mintHubUserCookieValue / verifyHubUserCookie:
-// `<username>.<base64url(HMAC-SHA256(key=SESSION_KEY, msg=username))>`.
+// mintCookie mints the cookie format PRODUCTION ACTUALLY ISSUES: v3 (F10),
+// Ed25519-signed with a signed expiry. It mirrors the Go hub's
+// mintHubUserCookieValueV3.
 //
-// C2 domain separation (#2758): the proxy no longer verifies the cookie with the
-// master HIVE_HUB_SECRET but with the derived SESSION sub-key —
-// HMAC-SHA256(master, "hive-session-v1"). We are started with HIVE_HUB_SECRET
-// (the legacy derivation lane), so mint through the SAME derivation the proxy's
-// deriveSessionKey() uses, keeping the info string byte-for-byte identical.
+// AUDIT F23: this helper used to mint the LEGACY SYMMETRIC format —
+// `<user>.<HMAC(SESSION_KEY, user)>`. That lane is now deleted from server.js,
+// so a helper still minting it would exercise a dead path and every test below
+// would pass or fail for the wrong reason. More importantly the symmetric key is
+// fleet-uniform, which is exactly the forgery primitive F23 removes.
+//
+// The proxy self-derives its session PUBLIC key from HIVE_HUB_SECRET via
+// deriveDomainKey(master, "hive-session-ed25519-v1"); we derive the matching
+// PRIVATE seed from the same master, so these cookies verify through the real
+// asymmetric lane.
+const INFO_SESSION_ED25519_SEED = 'hive-session-ed25519-v1';
+const COOKIE_TTL_SECONDS = 3600;
+
+function sessionSeedFromMaster(secret) {
+  return crypto.createHmac('sha256', secret).update(INFO_SESSION_ED25519_SEED).digest('hex');
+}
+
+function privFromSeed(seedHex) {
+  const pkcs8 = Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'),
+    Buffer.from(seedHex, 'hex'),
+  ]);
+  return crypto.createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+}
+
+// mintCookieV3 builds `<base64url(json{u,iat,exp,sid})>.v3.<base64url(ed25519 sig)>`.
+function mintCookieV3(secret, username, { ttlSec = COOKIE_TTL_SECONDS, iatOffsetSec = 0 } = {}) {
+  const iat = Math.floor(Date.now() / 1000) + iatOffsetSec;
+  const claims = {
+    u: username,
+    iat,
+    exp: iat + ttlSec,
+    sid: crypto.randomBytes(32).toString('hex'),
+  };
+  const body = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  const sig = crypto.sign(null, Buffer.from(body), privFromSeed(sessionSeedFromMaster(secret)));
+  return `${body}.v3.${sig.toString('base64url')}`;
+}
+
+// mintCookieLegacy mints the DELETED symmetric format. It exists only so the
+// F23 rejection tests can present a correctly-HMAC'd legacy cookie and prove it
+// is refused. Nothing else may use it.
 function deriveSessionKey(secret) {
   return crypto.createHmac('sha256', secret).update('hive-session-v1').digest('hex');
 }
-function mintCookie(secret, username) {
+function mintCookieLegacy(secret, username) {
   const sessionKey = deriveSessionKey(secret);
   const sig = crypto.createHmac('sha256', sessionKey).update(username).digest('base64url');
   return `${username}.${sig}`;
+}
+
+function mintCookie(secret, username) {
+  return mintCookieV3(secret, username);
 }
 
 // mintTerminalAssertion mirrors Go hub.MintTerminalAssertion / the proxy's
@@ -455,6 +497,73 @@ async function testC3_ForgedSigStillRejected() {
   const resp = await terminalHTTP(cookie, HOSTED_HOST);
   assert.equal(resp.status, 401, `forged-signature cookie must be 401, got ${resp.status}`);
   console.log('  ✓ forged-signature cookie (even for allowlisted name) → 401');
+}
+
+// ---------------------------------------------------------------------------
+// AUDIT F23 (Medium): the legacy symmetric session-cookie lane is DELETED.
+//
+// SESSION_KEY is derived from the master (or injected) and is BYTE-IDENTICAL
+// across the whole hosted fleet — measured live at 1 distinct value across
+// 48/48 reachable spokes. Symmetric material means verify-capable implies
+// MINT-capable, so any operator who could read one spoke's pod env could forge
+// `<user>.<HMAC>` and have EVERY other tenant's proxy accept it. The Go hub
+// deleted its half in F1 (#3725); these prove the Node half is gone too.
+//
+// These tests run against the REAL server.js over HTTP and WS — not an in-file
+// copy of the verifier — so they cannot pass while the shipped proxy still
+// honours the lane.
+//
+// NOTE ON WHY EACH FAILS FOR ITS OWN REASON: `alice` is ON hive B's static
+// allowlist. That is deliberate and is the opposite of the `dave` fixture's
+// weakness elsewhere in this file. If the legacy lane were still live, alice's
+// legacy cookie would authenticate AND authorize, giving 200. So a 401 here is
+// attributable to the cookie lane alone — authorization cannot be what denies
+// her, because authorization would have let her through.
+// ---------------------------------------------------------------------------
+
+async function testF23_LegacyCookieRejectedHTTP() {
+  // POSITIVE CONTROL FIRST: the very same allowlisted user, with the cookie
+  // format production actually mints (v3), MUST reach the terminal. Without
+  // this, a proxy that rejected every cookie would "pass" the rejection test
+  // below while breaking all sign-in.
+  const good = mintCookie(HIVE_B_SECRET, 'alice');
+  const okResp = await terminalHTTP(good, HOSTED_HOST);
+  assert.equal(okResp.status, 200,
+    `positive control FAILED: a v3 cookie for allowlisted alice must be 200, got ${okResp.status}`);
+
+  // THE ASSERTION: the same user, correctly HMAC'd with the CORRECT fleet
+  // session key, is refused. This is the exact cookie a spoke operator could
+  // mint from pod env.
+  const legacy = mintCookieLegacy(HIVE_B_SECRET, 'alice');
+  const resp = await terminalHTTP(legacy, HOSTED_HOST);
+  assert.equal(resp.status, 401,
+    `F23 REGRESSION: a correctly-signed LEGACY symmetric cookie was accepted (got ${resp.status}) — a spoke can forge cross-tenant`);
+  console.log('  ✓ F23: legacy symmetric cookie (correct secret, allowlisted user) → 401; v3 → 200');
+}
+
+async function testF23_LegacyCookieRejectedWS() {
+  // Fixing only the HTTP gate would be security theatre — the WS upgrade reaches
+  // the same ttyd. Positive control first, same reasoning as above.
+  const good = mintCookie(HIVE_B_SECRET, 'alice');
+  const { opened: goodOpened } = await terminalWS(good, HOSTED_HOST);
+  assert.ok(goodOpened, 'positive control FAILED: a v3 cookie for allowlisted alice must open the WS');
+
+  const legacy = mintCookieLegacy(HIVE_B_SECRET, 'alice');
+  const { opened } = await terminalWS(legacy, HOSTED_HOST);
+  assert.ok(!opened,
+    'F23 REGRESSION: a correctly-signed LEGACY symmetric cookie opened the WS terminal');
+  console.log('  ✓ F23: legacy symmetric cookie → WS closed; v3 → WS opens');
+}
+
+async function testF23_ForgedAdminLegacyCookieRejected() {
+  // The finding's actual attack: forge the HUB ADMIN username. `clubanderson`
+  // is not on this hive's allowlist, so this asserts the cookie lane refuses to
+  // AUTHENTICATE the forged identity at all.
+  const forgedAdmin = mintCookieLegacy(HIVE_B_SECRET, 'clubanderson');
+  const resp = await terminalHTTP(forgedAdmin, HOSTED_HOST);
+  assert.equal(resp.status, 401,
+    `F23 REGRESSION: a forged legacy ADMIN cookie was accepted (got ${resp.status})`);
+  console.log('  ✓ F23: forged legacy admin cookie (clubanderson) → 401');
 }
 
 // ---------------------------------------------------------------------------
@@ -893,11 +1002,14 @@ try {
   await testC3_ForeignUserHTTP_PortSuffixHost();
   await testC3_ForeignUserHTTP_TrailingDotHost();
   await testC3_ForgedSigStillRejected();
+  await testF23_LegacyCookieRejectedHTTP();
+  await testF23_ForgedAdminLegacyCookieRejected();
 
   console.log('\nWebSocket terminal gate:');
   await testC3_AuthorizedUserWS();
   await testC3_ForeignUserWS();
   await testC3_ForeignUserWS_PortSuffixHost();
+  await testF23_LegacyCookieRejectedWS();
 
   console.log('\nSigned terminal assertion (C3 follow-up):');
   await testC3F_ValidAssertionAdmitsNonAllowlistedUser();

--- a/v2/proxy/session_cookie_v2.test.js
+++ b/v2/proxy/session_cookie_v2.test.js
@@ -16,6 +16,7 @@
 
 import crypto from 'crypto';
 import assert from 'assert';
+import { readFileSync } from 'fs';
 
 const INFO_SESSION_ED25519_SEED = 'hive-session-ed25519-v1';
 const INFO_SESSION_KEY = 'hive-session-v1';
@@ -81,8 +82,12 @@ function verifyHubUserCookie(secret, value) {
   return username;
 }
 
+// AUDIT F23: kept in lockstep with server.js — the legacy symmetric lane is
+// GONE. legacySecret is accepted and ignored, mirroring the real function, so
+// this copy cannot drift back into verifying symmetric material.
 function verifyHubUserCookieEither(pubHex, legacySecret, value) {
-  return verifyHubUserCookieV2(pubHex, value) || verifyHubUserCookie(legacySecret, value);
+  void legacySecret;
+  return verifyHubUserCookieV2(pubHex, value);
 }
 
 // --- tests ------------------------------------------------------------------
@@ -134,15 +139,51 @@ test('garbage and malformed values fail closed', () => {
   assert.strictEqual(verifyHubUserCookieV2('abcd', mintV2(SEED, 'alice')), '', 'accepted a short public key');
 });
 
-test('ROLLOUT: legacy HMAC cookies still verify alongside v2', () => {
+// AUDIT F23 — INVERTED. This test previously asserted "legacy HMAC cookies still
+// verify alongside v2", i.e. it asserted the vulnerability. The legacy lane is
+// symmetric and fleet-uniform, so verify-capable implied mint-capable: any spoke
+// operator could forge `clubanderson.<sig>`. It is inverted rather than deleted
+// so the file keeps documenting the decision and a re-added lane fails here.
+test('F23: a correctly-HMACd legacy cookie is REJECTED even with the right secret', () => {
   const legacyCookie = 'bob.' + crypto.createHmac('sha256', LEGACY).update('bob').digest('base64url');
-  assert.strictEqual(verifyHubUserCookieEither(PUB, LEGACY, legacyCookie), 'bob',
-    'a live browser session would break at deploy');
-  assert.strictEqual(verifyHubUserCookieEither(PUB, LEGACY, mintV2(SEED, 'alice')), 'alice');
-  // With the legacy lane withdrawn (the follow-up removal), legacy stops working
-  // and v2 keeps working.
+
+  // PRECONDITION: the legacy primitive itself is still well-formed and the
+  // secret is the CORRECT one — so a rejection below is the lane being gone,
+  // not a typo'd fixture. This is the mirror of the Go-side
+  // TestF1LegacyLaneRejectsEvenTheCorrectSecret.
+  assert.strictEqual(verifyHubUserCookie(LEGACY, legacyCookie), 'bob',
+    'precondition: the legacy HMAC primitive must still compute — otherwise this test proves nothing');
+
+  // THE ASSERTION: the live verify path refuses it, even handed the correct secret.
+  assert.strictEqual(verifyHubUserCookieEither(PUB, LEGACY, legacyCookie), '',
+    'F23 REGRESSION: the legacy symmetric lane still verifies — a spoke can forge an admin cookie');
   assert.strictEqual(verifyHubUserCookieEither(PUB, '', legacyCookie), '');
+
+  // POSITIVE CONTROL: v2 must STILL verify. Without this, a verifier that
+  // rejected everything would satisfy the assertions above while breaking every
+  // hosted sign-in.
+  assert.strictEqual(verifyHubUserCookieEither(PUB, LEGACY, mintV2(SEED, 'alice')), 'alice',
+    'positive control FAILED: v2 cookies must still verify');
   assert.strictEqual(verifyHubUserCookieEither(PUB, '', mintV2(SEED, 'alice')), 'alice');
+});
+
+// AUDIT F23 SOURCE GUARD. The behavioural tests above exercise a COPY of the
+// verifier kept in this file, and the end-to-end tests in server.test.js only
+// catch a lane that is REACHED. heartbeatBearerOK (F24) showed that a
+// dead-but-armed acceptor is invisible to both. This asserts the symmetric
+// verifier has not returned to the shipped server.js at all.
+test('F23: server.js contains no symmetric cookie-verification lane', () => {
+  const src = readFileSync(new URL('./server.js', import.meta.url), 'utf8');
+
+  // Positive control: the tombstone naming the finding must be present, so a
+  // wholesale rewrite cannot make this assertion vacuously true.
+  assert.ok(src.includes('AUDIT F23 TOMBSTONE'),
+    'positive control FAILED: the F23 tombstone is missing from server.js');
+
+  assert.ok(!/function\s+verifyHubUserCookie\s*\(\s*secret\s*,\s*value\s*\)/.test(src),
+    'F23 REGRESSION: the symmetric verifier verifyHubUserCookie has been reintroduced in server.js');
+  assert.ok(!/return\s+verifyHubUserCookie\s*\(\s*legacySecret\s*,\s*value\s*\)/.test(src),
+    'F23 REGRESSION: a legacy symmetric fallback has been reintroduced in server.js');
 });
 
 test('INTEROP: the public key derived here matches the Go hub byte-for-byte', () => {

--- a/v2/proxy/session_pubkey_rotation.test.js
+++ b/v2/proxy/session_pubkey_rotation.test.js
@@ -142,6 +142,8 @@ function verifyHubUserCookieV3(pubHex, value, nowSeconds) {
   }
 }
 
+// AUDIT F23: kept in lockstep with server.js — no trailing legacy symmetric
+// lane. legacySecret is accepted and ignored.
 function verifyHubUserCookieAcrossKeys(pubKeys, legacySecret, value) {
   if (!value) return '';
   const keys = Array.isArray(pubKeys) ? pubKeys : [];
@@ -151,7 +153,8 @@ function verifyHubUserCookieAcrossKeys(pubKeys, legacySecret, value) {
     const v2 = verifyHubUserCookieV2(pubHex, value);
     if (v2) return v2;
   }
-  return verifyHubUserCookie(legacySecret, value);
+  void legacySecret;
+  return '';
 }
 
 // --- fixtures ---------------------------------------------------------------
@@ -282,8 +285,9 @@ const COOKIE_PREV_V2 = mintV2(SEED_PREV, 'erin');
     'expected the silent truncation to yield exactly the FIRST key');
 }
 
-// 4. EMPTY: no public key at all. Ed25519 verification must fail closed, and the
-//    legacy symmetric lane must be reachable exactly as before.
+// 4. EMPTY: no public key at all. Ed25519 verification must fail closed, and
+//    (audit F23) there is no longer any symmetric lane to fall through to, so
+//    such a spoke now authenticates NOBODY through this path.
 {
   assert.strictEqual(sessionPublicKeysFrom('', '').length, 0, 'no keys configured must yield no candidates');
   assert.strictEqual(sessionPublicKeysFrom(undefined, undefined).length, 0, 'undefined vars must yield no candidates');
@@ -295,21 +299,32 @@ const COOKIE_PREV_V2 = mintV2(SEED_PREV, 'erin');
     verifyHubUserCookieAcrossKeys(undefined, '', COOKIE_CUR_V3), '',
     'a non-array key set must fail closed rather than throw');
 
-  // The legacy symmetric lane is UNCHANGED by key plurality — it is tried once,
-  // after the public keys, and is not multiplied across generations.
+  // AUDIT F23 — INVERTED. These two assertions previously demanded the legacy
+  // symmetric lane "must still be reachable". That lane is the cross-tenant
+  // forgery primitive: SESSION_KEY is byte-identical fleet-wide, so any spoke
+  // operator could mint a cookie every other tenant's proxy accepted. It is now
+  // deleted, and these assert it stays deleted.
   const legacySecret = 'legacy-symmetric-session-key';
   const legacyCookie = 'frank.' + crypto.createHmac('sha256', legacySecret).update('frank').digest('base64url');
+
+  // PRECONDITION: the legacy primitive still computes and the secret is the
+  // CORRECT one, so the rejections below mean "lane gone", not "bad fixture".
   assert.strictEqual(
-    verifyHubUserCookieAcrossKeys([], legacySecret, legacyCookie), 'frank',
-    'the legacy symmetric lane must still be reachable with no public keys');
+    verifyHubUserCookie(legacySecret, legacyCookie), 'frank',
+    'precondition: the legacy HMAC primitive must still compute — otherwise this proves nothing');
+
   assert.strictEqual(
-    verifyHubUserCookieAcrossKeys(sessionPublicKeysFrom(PUB_CUR, PUB_PREV), legacySecret, legacyCookie), 'frank',
-    'the legacy symmetric lane must still be reachable after the public keys');
-  // POSITIVE CONTROL: the legacy lane must reject a wrong-secret cookie, so the
-  // two assertions above are not satisfied by a lane that accepts anything.
+    verifyHubUserCookieAcrossKeys([], legacySecret, legacyCookie), '',
+    'F23 REGRESSION: the legacy symmetric lane is reachable with no public keys');
   assert.strictEqual(
-    verifyHubUserCookieAcrossKeys([], 'a-different-secret', legacyCookie), '',
-    'positive control: the legacy lane accepted a cookie signed with another secret');
+    verifyHubUserCookieAcrossKeys(sessionPublicKeysFrom(PUB_CUR, PUB_PREV), legacySecret, legacyCookie), '',
+    'F23 REGRESSION: the legacy symmetric lane is reachable after the public keys');
+
+  // POSITIVE CONTROL: the Ed25519 lanes must STILL verify across keys, so the
+  // rejections above are not satisfied by a verifier that rejects everything.
+  assert.strictEqual(
+    verifyHubUserCookieAcrossKeys(sessionPublicKeysFrom(PUB_CUR, PUB_PREV), legacySecret, COOKIE_CUR_V3), 'alice',
+    'positive control FAILED: a current-generation v3 cookie must still verify');
 }
 
 // 5. DE-DUPLICATION: before the first rotation the hub may briefly hand out a

--- a/v2/proxy/terminal_cookie_verify.test.js
+++ b/v2/proxy/terminal_cookie_verify.test.js
@@ -42,13 +42,39 @@ const TTYD_PORT = 19103;
 const HOSTED_HOST = 'hive-f3.hive.kubestellar.io';
 const HIVE_ID = 'hive-f3';
 
-// The master this spoke is provisioned with; the proxy derives SESSION_KEY from
-// it exactly as Go's SpokeSessionKey() does.
+// The master this spoke is provisioned with; the proxy derives its session
+// PUBLIC key from it exactly as Go's provisioning does.
 const MASTER = 'f3-test-master-secret';
 const SESSION_KEY = crypto.createHmac('sha256', MASTER).update('hive-session-v1').digest('hex');
 
-// mintCookie mirrors the hub's mintHubUserCookieValue.
+// AUDIT F23: mintCookie now mints v3 (Ed25519 + signed expiry), the format
+// production actually issues. It previously minted the legacy symmetric HMAC
+// format, whose verification lane is deleted from server.js — so the "valid
+// cookie" positive control below would otherwise be minting a cookie no spoke
+// can verify, and would fail for a reason that has nothing to do with F3.
+const INFO_SESSION_ED25519_SEED = 'hive-session-ed25519-v1';
+
+function privFromSeed(seedHex) {
+  const pkcs8 = Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'),
+    Buffer.from(seedHex, 'hex'),
+  ]);
+  return crypto.createPrivateKey({ key: pkcs8, format: 'der', type: 'pkcs8' });
+}
+
+// mintCookie mirrors the hub's mintHubUserCookieValueV3.
 function mintCookie(username) {
+  const seed = crypto.createHmac('sha256', MASTER).update(INFO_SESSION_ED25519_SEED).digest('hex');
+  const iat = Math.floor(Date.now() / 1000);
+  const claims = { u: username, iat, exp: iat + 3600, sid: crypto.randomBytes(32).toString('hex') };
+  const body = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  const sig = crypto.sign(null, Buffer.from(body), privFromSeed(seed));
+  return `${body}.v3.${sig.toString('base64url')}`;
+}
+
+// mintCookieLegacy mints the DELETED symmetric format, for the F23 rejection
+// test only.
+function mintCookieLegacy(username) {
   const sig = crypto.createHmac('sha256', SESSION_KEY).update(username).digest('base64url');
   return `${username}.${sig}`;
 }
@@ -172,10 +198,31 @@ try {
   console.log('  ✓ valid hub-signed + authorized cookie still granted (HTTP + WS)');
 
   // --- Tampering: right shape, wrong signature ------------------------------
-  const tampered = 'mallory.' + good.split('.')[1];
+  // Swap the v3 CLAIMS BODY for one naming a different user while keeping
+  // alice's signature. The signature covers the body, so this must fail.
+  const goodSig = good.slice(good.lastIndexOf('.v3.') + 4);
+  const malloryIat = Math.floor(Date.now() / 1000);
+  const malloryBody = Buffer.from(JSON.stringify({
+    u: 'mallory', iat: malloryIat, exp: malloryIat + 3600,
+    sid: crypto.randomBytes(32).toString('hex'),
+  })).toString('base64url');
+  const tampered = `${malloryBody}.v3.${goodSig}`;
   assert.equal(await terminalHTTP(tampered), 401,
     'a re-labelled cookie (alice signature, different username) must be denied');
   console.log('  ✓ re-labelled cookie denied (signature covers the username)');
+
+  // --- AUDIT F23: the legacy symmetric lane is deleted -----------------------
+  // `alice` is signed with the CORRECT fleet SESSION_KEY and IS on this hive's
+  // allowlist, so if the lane were live she would get 200. A 401 is therefore
+  // attributable to the cookie lane alone, not to authorization. The v3 control
+  // for the same user passed above, so this is not a reject-everything proxy.
+  const legacyAlice = mintCookieLegacy('alice');
+  assert.equal(await terminalHTTP(legacyAlice), 401,
+    'F23 REGRESSION: a correctly-HMACd legacy symmetric cookie reached the terminal — ' +
+    'SESSION_KEY is fleet-uniform, so any spoke operator could forge this');
+  assert.ok(!(await terminalWS(legacyAlice)),
+    'F23 REGRESSION: a correctly-HMACd legacy symmetric cookie opened the WS terminal');
+  console.log('  ✓ F23: legacy symmetric cookie denied on BOTH gates (v3 for same user still 200)');
 
   console.log('\n✓ F3 terminal cookie verification tests passed\n');
 } catch (e) {


### PR DESCRIPTION
Closes the two "deleted on one side, still live on the other" findings from the eighth security audit (2026-08-14).

## F23 (Medium) — the Node proxy still honoured the fleet-uniform symmetric cookie lane

The Go hub deleted the F1 legacy session-cookie lane in #3725. The Node proxy did not, so `verifyHubUserCookieAcrossKeys` (`v2/proxy/server.js`) still ended in `verifyHubUserCookie(legacySecret, value)` — a plain HMAC check keyed on `SESSION_KEY`.

**This was a genuine cross-tenant forgery primitive, measured live, not a theoretical one.** `SESSION_KEY` is byte-identical across the hosted fleet:

| Cluster | Spokes with the var | Distinct `HIVE_SESSION_KEY` values |
|---|---|---|
| `vllm-d` | 43 | **1** (`sha256` prefix `547305a5`) |
| `a-ks-wec2` | 5 | **1** (same prefix) |
| **Total measured** | **48/48** | **1** |

(A third cluster's credentials had expired; 48/48 agreeing exactly with the audit's independent 70-spoke measurement of the same prefix is decisive. Only lengths/hash prefixes were ever read.)

Symmetric material means **verify-capable implies mint-capable**. Any operator who could read one spoke's pod env could mint `<user>.<sig>` and have *every other tenant's* proxy accept it. The lane was live on both terminal gates — HTTP and WebSocket — via `resolveTerminalIdentity`, and the proxy verifies the cookie **locally**, so the hub's F1 fix did not mitigate it at all.

### What was removed
- the trailing legacy lane in `verifyHubUserCookieAcrossKeys`
- the legacy branch in `verifyHubUserCookieEither`
- `verifyHubUserCookie` itself — the symmetric verifier, left dead by the above — replaced with a tombstone

`legacySecret` is retained in both signatures and explicitly discarded with `void legacySecret`, mirroring the Go side's `_ = legacySecret`. Callers need no change, and accepting-and-ignoring is safer than a signature change a future merge could mis-resolve into re-enabling the lane — which is exactly how F14 and F18 regressed.

### What was deliberately KEPT — the self-hosted path is unaffected
Several `HIVE_SESSION_KEY` consumers exist on purpose for single-tenant operators:

- **`SESSION_KEY` is still resolved in the proxy** — it remains the `IS_HOSTED` boot signal and backs the self-hosted "refuse to start with no auth" check.
- **Go `SpokeSessionKey()`** — untouched.
- **`perHiveEnvNames()` / `EnvSessionKey`** — untouched, correctly still included.
- **The `saas_provision.go` spoke template var** — untouched (see scope note).

**What died is the verification fallback, not the key.**

## F24 (Low) — dead but armed raw-master heartbeat acceptor

`heartbeatBearerOK` (`v2/pkg/hub/server.go`) accepted the **raw fleet master** and the fleet-wide `heartbeatKey()`, neither of which binds a hive identity — a complete F2/N1 IDOR lane, and the only place in the hub tree where the raw master was an authentication comparand. It had **zero non-test callers** (verified), so deleting it is behaviour-preserving.

What made it worth fixing rather than noting: **its tests asserted the vulnerable behaviour** — literally `t.Error("heartbeatBearerOK must accept raw master secret")`. A refactor that re-wired it would have been "verified correct" against a green suite.

**The tests are INVERTED, not deleted.** Deleting them leaves nothing standing guard. They now assert the fleet-wide and raw-master bearers are **rejected**, plus the F2 identity property (hive A's bearer refused for hive B) under **every live master generation**.

**F2 is not regressed:** `verifyHeartbeatBearer` remains per-hive-only via `derivePerHiveKey(master_g, infoHeartbeatKey, hiveID)`, with no `deriveDomainKey` fleet-wide branch anywhere.

## Scope decision on #3234, and why the template var stays

#3234 item 2 asks for three things. Two are now done, one is deliberately deferred:

| Item | Status |
|---|---|
| Pass `""` as `legacySecret`, delete the branch | ✅ done in the Go hub (#3725) |
| **Remove the `SESSION_KEY` fallback from `proxy/server.js`** | ✅ **this PR** |
| Drop `HIVE_SESSION_KEY` from the spoke Deployment template | ⏸️ **deferred — see below** |

#3234's two readiness conditions for the cookie lane, assessed rather than assumed:

1. **Every spoke re-provisioned so it can verify v2** — ✅ **HOLDS.** All 48/48 measured spokes carry `HIVE_SESSION_PUBLIC_KEY` (1 distinct value). Every spoke can verify the Ed25519 lanes, so removing the symmetric one cannot strand a spoke.

2. **Existing browser cookies aged out (bounded by `MaxAge`, 7 days)** — ❌ **DOES NOT HOLD YET.** F1 merged `2026-08-13T18:25:40Z`, about **a day ago**, against `cookieMaxAgeDays = 7`. The window has roughly six days left.

**Condition 2 does not block this PR, and here is the precise reason.** The hub deleted its half a day ago, so a legacy cookie is *already* 401'd at the hub. Production mints **v3 only** (`oauth.go` → `mintHubUserCookieValueV3`); nothing in the tree mints legacy. Removing the proxy's fallback therefore cannot break a login that still works — it can only close a forgery primitive that is still fully live on every terminal gate. The residual user-visible cost is the same bounded one #3725 already accepted.

**Why the template var is deliberately left in place.** Dropping `HIVE_SESSION_KEY` from `saas_provision.go` changes what 70 spokes are *provisioned with* and would land while the 7-day cookie window is still open, for no security benefit once the verification lane is gone — the var becomes inert the moment this merges. It is also the higher-risk edit (`TerminalSigningKey()` still documents a fallback path through `SessionKey`), and it collides with the F19/F21 provisioning work in flight.

**So #3234 should be UPDATED, not closed.** Remaining for it:
- drop `HIVE_SESSION_KEY` from the spoke Deployment template in `saas_provision.go`
- once dropped, `EnvSessionKey`'s fleet-uniform `deriveDomainKey` line in `perhive_env_reconcile.go:174` (audit RESIDUAL-2) can go with it

With this PR, RESIDUAL-2 drops to the hygiene item the audit describes: its practical severity was carried entirely by F23, and F23's consumer is now gone.

## Testing

Both suites green: full `./pkg/hub/` and the complete proxy suite (`npm ci && npm test`, exit 0).

Every new test has a **positive control**, so a "reject everything" implementation cannot pass:
- **F23:** the v3 cookie production actually mints, for the *same allowlisted user*, must still return **200** / open the WS. `alice` is deliberately **on** hive B's allowlist — the opposite of the `dave` fixture's known weakness — so the 401 is attributable to the cookie lane alone, since authorization would have let her through.
- **F23 precondition:** the legacy HMAC primitive must still *compute* with the *correct* secret, so a rejection means "lane gone", not "bad fixture" (mirroring `TestF1LegacyLaneRejectsEvenTheCorrectSecret`).
- **F24:** the per-hive bearer must still authenticate for its own hive, under every live generation.

Test helpers that minted the legacy format now mint **v3** — a helper minting a format production cannot issue would silently exercise a dead path.

**Source-level guards in both languages** (`TestF24_NoFleetWideHeartbeatLaneInSource`, `F23: server.js contains no symmetric cookie-verification lane`) catch a lane reintroduced but *not yet reachable* — the dead-but-armed shape that behavioural tests miss by construction. Each has its own tombstone positive control so a file rewrite cannot make it vacuously pass.

### Regression replay — Node

Restoring the legacy lane in `server.js` (still parses and runs):

```
✗ C3 test failed: F23 REGRESSION: a correctly-signed LEGACY symmetric cookie was accepted (got 200) — a spoke can forge cross-tenant
✗ F3 test failed: F23 REGRESSION: a correctly-HMACd legacy symmetric cookie reached the terminal — SESSION_KEY is fleet-uniform, so any spoke operator could forge this
```

```
server.test.js               rc=1
session_cookie_v2.test.js    rc=0
session_pubkey_rotation.test.js rc=0
terminal_cookie_verify.test.js  rc=1
```

**Reported honestly: two files still PASSED while neutered.** `session_cookie_v2.test.js` and `session_pubkey_rotation.test.js` verify in-file *copies* of the logic, so they cannot see a change to `server.js` — precisely the "passes for the wrong reason" trap the audit warns about. That is why the end-to-end tests against the real server, and the source-level guard, both exist. The guard was verified to fire on its own:

```
FAIL F23: server.js contains no symmetric cookie-verification lane
     F23 REGRESSION: the symmetric verifier verifyHubUserCookie has been reintroduced in server.js
7/8 passed
```

Restored → `npm test` exit 0, 8/8.

### Regression replay — Go

Restoring `heartbeatBearerOK` (compiles cleanly):

```
--- FAIL: TestF24_NoFleetWideHeartbeatLaneInSource (0.00s)
    server_handlers_coverage_test.go:186: F24 REGRESSION: heartbeatBearerOK has been reintroduced in server.go
```

**Reported honestly:** the four *behavioural* F24 tests still passed at this stage — correctly so, because a restored-but-uncalled function is dead code. That is the entire point of F24, and exactly why the source-level guard is not optional.

Simulating the refactor the audit actually fears — re-wiring the acceptor into `verifyHeartbeatBearer` — fails three tests:

```
--- FAIL: TestF24_FleetWideHeartbeatBearerIsRejected (0.00s)
    server_handlers_coverage_test.go:49: F24 REGRESSION: the RAW fleet master must not authenticate a heartbeat
    server_handlers_coverage_test.go:56: F24 REGRESSION: the FLEET-WIDE derived heartbeat key must not authenticate a heartbeat
--- FAIL: TestF24_CrossHiveRejectedUnderEveryLiveGeneration (0.00s)
    server_handlers_coverage_test.go:123: gen 1: F24 REGRESSION — fleet-wide derived key accepted
    server_handlers_coverage_test.go:126: gen 1: F24 REGRESSION — raw generation master accepted
--- FAIL: TestF24_NoFleetWideHeartbeatLaneInSource (0.00s)
    server_handlers_coverage_test.go:186: F24 REGRESSION: heartbeatBearerOK has been reintroduced in server.go
```

Under the old tests that refactor would have been green. Both files restored → `ok github.com/kubestellar/hive/v2/pkg/hub`.

## Notes

- Rebased on `origin/v4` @ `7f6bf9c1` (F20). Diff is confined to `proxy/server.js`, the heartbeat acceptor, and their tests — no overlap with the F19/F21 or F22/F25 work in flight.
- Read-only `kubectl` throughout; no cluster writes, no secret values printed.
