### PR TITLE
fix(hive): stop automaxprocs banner from polluting merged child output

### DIFF
--- a/v2/cmd/hive/automaxprocs_banner_test.go
+++ b/v2/cmd/hive/automaxprocs_banner_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// automaxprocsBannerPattern matches the line go.uber.org/automaxprocs's
+// default logger writes to stderr at init when imported blank, e.g.
+// "2026/08/14 08:03:25 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined".
+var automaxprocsBannerPattern = regexp.MustCompile(`maxprocs:`)
+
+// TestNoBlankAutomaxprocsImport is the source-asserting half of the
+// regression: it fails if anyone reinstates
+// `_ "go.uber.org/automaxprocs"` in this file. That import's init writes an
+// unconditional banner to the default logger (stderr) with no way to
+// silence it, which is exactly the defect TestChildProcessOutputHasNoAutomaxprocsBanner
+// below exercises at runtime. Asserting the source shape catches the
+// regression even before a test binary is built, and pins down *why* the
+// runtime test would start failing again.
+func TestNoBlankAutomaxprocsImport(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("reading main.go: %v", err)
+	}
+	if strings.Contains(string(src), `_ "go.uber.org/automaxprocs"`) {
+		t.Fatal(`main.go must not blank-import "go.uber.org/automaxprocs": its init ` +
+			`writes an unconditional banner to stderr that corrupts any caller ` +
+			`merging this process's stdout and stderr (e.g. the pushbroker git ` +
+			`shim's CombinedOutput()). Use "go.uber.org/automaxprocs/maxprocs" ` +
+			`with an explicit maxprocs.Set(maxprocs.Logger(...noop...)) call instead.`)
+	}
+}
+
+// TestChildProcessOutputHasNoAutomaxprocsBanner is the runtime half of the
+// regression. `hive` re-execs itself as a Git transport shim, and
+// pkg/pushbroker's ExecRunner captures a child's stdout AND stderr into one
+// buffer via cmd.CombinedOutput() (see pkg/pushbroker/pushbroker.go). This
+// test builds the real hive binary and inspects exactly that combined
+// stream from a real child process spawn — the same code path a blank
+// automaxprocs import would corrupt with a stray
+// "maxprocs: Leaving GOMAXPROCS=... " line ahead of (or interleaved with)
+// the caller's expected output, which is what broke branch parsing (see
+// PR #3820 on branch dd: a `git symbolic-ref` answer got the banner
+// prepended and the resulting "branch name" made `git reset --hard` fail
+// with "fatal: invalid object name").
+//
+// `hive --version` is used as the child invocation because it returns
+// before any config/flag parsing, but init() — where automaxprocs runs —
+// always executes first regardless of arguments, so it faithfully exercises
+// the banner-at-init behaviour without needing a hive.yaml or network access.
+func TestChildProcessOutputHasNoAutomaxprocsBanner(t *testing.T) {
+	bin := buildHiveBinaryForTest(t)
+
+	cmd := exec.Command(bin, "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("hive --version failed: %v\noutput: %s", err, out)
+	}
+
+	if automaxprocsBannerPattern.Match(out) {
+		t.Fatalf("child hive process's combined stdout+stderr contains an "+
+			"automaxprocs banner line, which corrupts any caller parsing this "+
+			"output as if it were the expected answer (e.g. a git shim reading "+
+			"a ref name):\n%s", out)
+	}
+
+	if !strings.Contains(string(out), "hive 3.0.0") {
+		t.Fatalf("expected combined output to contain the --version banner, got: %s", out)
+	}
+}
+
+// buildHiveBinaryForTest compiles the cmd/hive package under test into a
+// temp binary and returns its path. Building (rather than `go run`) ensures
+// the test observes the real init() ordering and stderr behaviour of the
+// actual shipped binary, matching how the pushbroker git shim invokes a
+// real child hive process.
+func buildHiveBinaryForTest(t *testing.T) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "hive-under-test")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = "."
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building hive test binary: %v\n%s", err, out)
+	}
+	return bin
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -32,9 +32,17 @@ import (
 	// that answers the :3002 liveness probe and the heartbeat loop — is
 	// throttled until the next CFS period, which stacks on top of the NFS
 	// stalls to push probe latency past the kubelet timeout. Matching GOMAXPROCS
-	// to the quota removes that self-inflicted throttling. Blank import: its
-	// only job is the init-time side effect.
-	_ "go.uber.org/automaxprocs"
+	// to the quota removes that self-inflicted throttling.
+	//
+	// This is called explicitly rather than via the package's blank import
+	// because that import's init writes a line to the default logger (stderr)
+	// unconditionally. `hive` re-execs itself as a Git transport shim, and the
+	// setup path captures a child's stdout and stderr into a single buffer to
+	// parse (e.g. `symbolic-ref --short origin/HEAD`), so an init-time banner
+	// is indistinguishable from Git's answer and corrupts the parsed branch
+	// name. Setting it with a no-op logger keeps the GOMAXPROCS behaviour and
+	// drops the banner.
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -828,6 +836,15 @@ func singletonLockPath() string {
 // multi-minute window so all instances hear it; without this guard the
 // restarted process would come back inside the same window and restart again.
 const spokeRestartMinUptime = 10 * time.Minute
+
+// init applies the container CPU quota to GOMAXPROCS with a silent logger. See
+// the go.uber.org/automaxprocs/maxprocs import comment for why the banner the
+// blank import would print is not acceptable in this binary. A failure here is
+// deliberately ignored: it only means GOMAXPROCS keeps the Go default, which is
+// the pre-existing behaviour and must never block startup.
+func init() {
+	_, _ = maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
+}
 
 func main() {
 	// --version fast path, before any flag parsing or startup work: the CI


### PR DESCRIPTION
## Problem

`v2/cmd/hive/main.go` blank-imports `go.uber.org/automaxprocs`. That package's `init` writes a banner line to **stderr unconditionally**, e.g.:

```
2026/08/14 08:03:25 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
```

`hive` re-execs itself as a Git transport shim. `pkg/pushbroker.ExecRunner.Run` captures a child process's stdout **and** stderr into a single buffer via `cmd.CombinedOutput()`. An init-time banner on stderr is therefore indistinguishable from the child's real stdout answer (e.g. a parsed git ref name), corrupting anything downstream that parses it.

This exact defect was caught on branch `dd` by `TestSetupPlanCLIResolvesAndEmitsInstalledVisualHiveDependency` (PR #3820, merged as `2de5c35b`): a `git symbolic-ref --short origin/HEAD` answer got the banner prepended, was parsed as a branch name, and the follow-on `git reset --hard origin/<garbage>` failed with `fatal: invalid object name`.

`v4` has the identical blank import and the identical `CombinedOutput()`-based capture pattern (`pkg/pushbroker.ExecRunner.Run`), but nothing tests this path here — `dd` is the only branch that happened to exercise it.

## Fix

Ported from `dd` (already proven there): replace the blank import with an explicit `maxprocs.Set(maxprocs.Logger(noop))` call in `init()`. This keeps the GOMAXPROCS-matches-CPU-quota behaviour but suppresses the banner.

Verified in a standalone scratch program that `maxprocs.Set` with a no-op logger yields the **identical** GOMAXPROCS value as the blank import (12 on this host), confirming behaviour is unchanged — only the stderr banner is suppressed.

## Tests added (`v2/cmd/hive/automaxprocs_banner_test.go`)

- `TestNoBlankAutomaxprocsImport` — source-asserting invariant: fails if the blank import is ever reinstated in `main.go`.
- `TestChildProcessOutputHasNoAutomaxprocsBanner` — builds the real `hive` binary, runs `hive --version` (init() always runs first regardless of args), and asserts the combined stdout+stderr output — the same stream `pkg/pushbroker.ExecRunner` captures from a real child spawn — contains no `maxprocs:` banner line.

**Positive control (both directions) — verbatim**

Neutered (blank import restored, no `maxprocs.Set` call):
```
2026/08/14 08:39:47 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
=== RUN   TestNoBlankAutomaxprocsImport
    automaxprocs_banner_test.go:31: main.go must not blank-import "go.uber.org/automaxprocs": ...
--- FAIL: TestNoBlankAutomaxprocsImport (0.00s)
=== RUN   TestChildProcessOutputHasNoAutomaxprocsBanner
    automaxprocs_banner_test.go:66: child hive process's combined stdout+stderr contains an automaxprocs banner line, which corrupts any caller parsing this output as if it were the expected answer (e.g. a git shim reading a ref name):
        2026/08/14 08:39:49 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
        hive 3.0.0 (commit unknown, branch unknown)
--- FAIL: TestChildProcessOutputHasNoAutomaxprocsBanner (1.83s)
FAIL
```

Fix restored:
```
=== RUN   TestNoBlankAutomaxprocsImport
--- PASS: TestNoBlankAutomaxprocsImport (0.00s)
=== RUN   TestChildProcessOutputHasNoAutomaxprocsBanner
--- PASS: TestChildProcessOutputHasNoAutomaxprocsBanner (6.30s)
PASS
ok  	github.com/kubestellar/hive/v2/cmd/hive	10.809s
```

## Scope

Minimal diff — one-line import swap, one `init()` function carrying dd's explanatory comment, plus the new test file. No other changes to `main.go`.

## Testing

- `go build ./...` — clean
- `go test ./cmd/hive/... ./pkg/pushbroker/...` — all pass
- `gofmt -l`, `go vet ./cmd/hive/...` — clean