### PR TITLE
fix(dashboard): remove stray backticks breaking snapshot build parse

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -407,8 +407,8 @@ async function main() {
     // a static page:
     //   1. /api/gh-auth is not on the dashboard's public-path allowlist, so
     //      an anonymous snapshot visitor's fetch gets a 401 JSON error body
-    //      with no "ok" field. checkGhAuth()'s `if (data.ok) {...} else
-    //      {mark #gh-auth-alert active}` then reads that 401 as "GitHub API
+    //      with no "ok" field. checkGhAuth()'s if (data.ok) {...} else
+    //      {mark #gh-auth-alert active} then reads that 401 as "GitHub API
     //      authentication failed" even when the hive's real GitHub auth
     //      (already captured correctly in the baked status above) is fine.
     //   2. checkGHAuth() correctly reports the anonymous viewer as not


### PR DESCRIPTION
PR #3832's comment backticks broke `build-snapshot.mjs` parse — snapshot build failed on every timer run (log: `SyntaxError: Unexpected token 'if'` at line 410) — so /snapshot went stale. This removes the stray backticks so the build succeeds.

## Root cause

The neutralization comment #3832 added (explaining why `checkGhAuth()`/`checkGHAuth()` are stubbed in snapshot mode) lives inside the `initScript` template literal in `dashboard/build-snapshot.mjs` (opens line 253, closes line 445 — this literal's contents are injected as JS into the generated snapshot HTML page). Two backticks used for inline code-quoting in that comment (```if (data.ok) {...} else``` / ```{mark #gh-auth-alert active}```) closed and reopened the surrounding backtick-delimited literal, exposing `if (data.ok) {...} else` as raw module-level code. Node's parser then hit `Unexpected token 'if'`, the whole .mjs failed to load, and the snapshot build failed on every run.

## Fix

Removed the two stray backticks from the comment text (rephrased as plain words, no code-quoting) — no other content changed. Verified no other stray backticks or unintended `${...}` interpolations exist anywhere in the `initScript` literal (253–445): backtick count across the file is even (32), and every `${...}` in that block is a legitimate build-time interpolation (historyRaw, trendsRaw, configRaw, layoutInit, etc.).

Did not run `node`/build locally per repo convention — reasoned through the parse manually (mentally `node --check`); the fix is a minimal 2-character-class removal isolated to comment text, so it does not affect runtime behavior.

## Verification pending

The `checkGhAuth()`/`checkGHAuth()` neutralization behavior from #3832 is preserved unchanged (the stub functions and their logic are untouched). Because the build has been failing since #3832 deployed, the currently-served /snapshot is a stale pre-#3832 capture, so whether #3832's auth/login banner fix actually works cannot be confirmed yet. Once this PR merges and a fresh snapshot builds successfully, that should be re-checked — if the "App Not Installed"/"Repo Misconfigured" banners persist after a successful rebuild, that's a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)