### PR TITLE
✨ feat(hub): admin-only upgrade kill switch — pause hub and fleet-wide spoke upgrades

### DIFF
--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -31,12 +31,14 @@ func helperSetupTempDirs(t *testing.T) func() {
 	oldHMAC := hmacKeyPath
 	oldProv := provisionRequestsDir
 	oldAutoUpgrade := hubAutoUpgradePath
+	oldUpgradePause := upgradePausePath
 
 	saasUsersDir = filepath.Join(dir, "users")
 	saasHivesDir = filepath.Join(dir, "hives")
 	hmacKeyPath = filepath.Join(dir, "hmac.key")
 	provisionRequestsDir = filepath.Join(dir, "provision-requests")
 	hubAutoUpgradePath = filepath.Join(dir, "hub-auto-upgrade")
+	upgradePausePath = filepath.Join(dir, "upgrade-pause.json")
 
 	os.MkdirAll(saasUsersDir, 0o755)
 	os.MkdirAll(saasHivesDir, 0o755)
@@ -49,6 +51,7 @@ func helperSetupTempDirs(t *testing.T) func() {
 		hmacKeyPath = oldHMAC
 		provisionRequestsDir = oldProv
 		hubAutoUpgradePath = oldAutoUpgrade
+		upgradePausePath = oldUpgradePause
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -477,6 +477,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("POST /api/saas/hub/upgrade", s.requireAdmin(s.handleHubSelfUpgrade))
 	s.mux.HandleFunc("PUT /api/saas/hub/auto-upgrade", s.requireAdmin(s.handleHubAutoUpgrade))
+	// Admin upgrade kill switch (upgrade_pause.go): pause hub self-upgrades
+	// and/or ALL automatic spoke image changes, fleet-wide.
+	s.mux.HandleFunc("GET /api/saas/upgrade-pause", s.requireAdmin(s.handleGetUpgradePause))
+	s.mux.HandleFunc("POST /api/saas/upgrade-pause", s.requireAdmin(s.handleSetUpgradePause))
 	s.mux.HandleFunc("GET /api/saas/auth-check", s.handleSaaSAuthCheck)
 	s.mux.HandleFunc("POST /api/saas/user-token", s.requireAuth(s.handleUserToken))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/access", s.requireAuth(s.handleAccessList))
@@ -3057,6 +3061,10 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		"channel_targets":          getChannelTargets(getDisplaySHAs(), s.logger),
 		"hub_auto_upgrade":         isHubAutoUpgrade(),
 		"hub_upgrade_state":        s.hubUpgradeState(),
+		// Kill-switch state rides the top-level payload (NOT the hive-row
+		// shape, so no HIVES_CACHE_VERSION bump): the dashboard shows a
+		// prominent banner while anything is paused, and admins get toggles.
+		"upgrade_pause": s.upgradePauseSnapshot(),
 		"show_my_hives":            true,
 		// Fleet alerts ship WITH the hive list so the "Attention needed" panel
 		// renders in the same paint as the rows it summarises — a second
@@ -3626,8 +3634,18 @@ func (s *HubServer) handleHubAutoUpgrade(w http.ResponseWriter, r *http.Request)
 	os.WriteFile(hubAutoUpgradePath, []byte(val), 0644)
 	s.logger.Info("audit: hub auto-upgrade toggled", "enabled", body.AutoUpgrade, "by", s.getAuthUser(r))
 
-	// If enabling and hub is behind, trigger immediately
+	// If enabling and hub is behind, trigger immediately. The kill switch does
+	// NOT block saving the preference — only the immediate rollout: with hub
+	// upgrades paused the poller stays suppressed too, and the preference takes
+	// effect when an admin resumes.
 	if body.AutoUpgrade {
+		if sw, paused := s.hubUpgradesPaused(); paused {
+			s.logger.Info("hub auto-upgrade initial trigger suppressed — hub upgrades are paused",
+				"paused_by", sw.By, "paused_at", sw.At)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"ok":true,"auto_upgrade":%t}`, body.AutoUpgrade)
+			return
+		}
 		latestSHA := getLatestHubSHAForBranch(s.hubGitBranch)
 		if latestSHA != "" && !sameCommit(latestSHA, s.hubGitHash) {
 			s.logger.Info("audit: hub auto-upgrade initial trigger", "from", s.hubGitHash, "to", latestSHA)
@@ -3826,6 +3844,15 @@ func (s *HubServer) hubUpgradeState() string {
 
 func (s *HubServer) handleHubSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 	username := s.getAuthUser(r)
+	// Admin kill switch: while hub upgrades are paused, a manual trigger is
+	// refused loudly — never queued — so the operator learns the state and who
+	// set it instead of waiting on a rollout that will not come.
+	if sw, paused := s.hubUpgradesPaused(); paused {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": upgradePauseRefusal("hub", sw)})
+		return
+	}
 	target := getLatestHubSHAForBranch(s.hubGitBranch)
 	s.logger.Info("audit: hub self-upgrade triggered", "by", username, "to", target)
 	if err := s.rolloutHubToSHA(target); err != nil {
@@ -3858,6 +3885,15 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	}
 	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can upgrade"}`, http.StatusForbidden)
+		return
+	}
+	// Admin kill switch: refuse loudly rather than arm anything — a request
+	// accepted here would either restart the pod now or sit silently in
+	// heartbeatUpgrade, both of which the pause exists to prevent.
+	if sw, paused := s.spokeUpgradesPaused(); paused {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": upgradePauseRefusal("spoke", sw)})
 		return
 	}
 	cluster := s.clusterForHive(h)
@@ -3947,6 +3983,15 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	}
 	if !userIsHiveOwner(username, h) {
 		http.Error(w, `{"error":"only the owner can switch branches"}`, http.StatusForbidden)
+		return
+	}
+	// Admin kill switch: a branch/channel switch while spoke upgrades are
+	// paused gets an explicit 409 naming who paused and when — never a silent
+	// queue into heartbeatSwitchTag.
+	if sw, paused := s.spokeUpgradesPaused(); paused {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": upgradePauseRefusal("spoke", sw)})
 		return
 	}
 	var body struct {
@@ -4369,7 +4414,16 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 	// (autoUpgradeDailyHour, currently 13:00 / 1pm ET). The
 	// operator who wants it now still has the explicit Upgrade button, which
 	// goes through handleUpgradeHive and is never gated by mode.
-	if body.AutoUpgrade && normalizeAutoUpgradeMode(body.Mode) == AutoUpgradeModeInstant {
+	// The kill switch does not block saving the PREFERENCE (auto-upgrade
+	// on/off is configuration, not delivery) — only the immediate trigger
+	// below. While paused, triggerAutoUpgrades stays suppressed anyway, and
+	// the hive upgrades after an admin resumes.
+	spokePauseSw, spokesPaused := s.spokeUpgradesPaused()
+	if body.AutoUpgrade && spokesPaused {
+		s.logger.Info("auto-upgrade initial trigger suppressed — spoke upgrades are paused",
+			"hive_id", id, "paused_by", spokePauseSw.By, "paused_at", spokePauseSw.At)
+	}
+	if body.AutoUpgrade && !spokesPaused && normalizeAutoUpgradeMode(body.Mode) == AutoUpgradeModeInstant {
 		s.mu.RLock()
 		var currentSHA, branch string
 		for _, reg := range s.registry.Hives {
@@ -5088,7 +5142,16 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		s.hubUpgradeMu.Lock()
 		debounced := time.Since(s.lastHubUpgradeTrigger) > hubUpgradeDebounce
 		s.hubUpgradeMu.Unlock()
-		if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) && debounced {
+		// Admin kill switch: while hub upgrades are paused the hub stays on its
+		// current build regardless of new tags — the auto-trigger below never
+		// fires. Checked every cycle (like the trigger itself), so flipping the
+		// switch takes effect on the next poll without a restart.
+		if hubPauseSw, hubPaused := s.hubUpgradesPaused(); hubPaused {
+			if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) {
+				s.logger.Debug("hub auto-upgrade suppressed — hub upgrades are paused",
+					"behind", hubBranchSHA, "paused_by", hubPauseSw.By, "paused_at", hubPauseSw.At)
+			}
+		} else if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) && debounced {
 			s.logger.Info("audit: hub auto-upgrade triggered", "from", s.hubGitHash, "to", hubBranchSHA)
 			// rolloutHubToSHA verifies the hub image exists (skips a doomed roll
 			// when the hive-hub build for this SHA failed) and pins the SHA so a
@@ -5178,6 +5241,17 @@ func (s *HubServer) rolloutRestartHive(cluster *ClusterConfig, hiveID string) bo
 }
 
 func (s *HubServer) triggerAutoUpgrades() {
+	// Admin kill switch: while spoke upgrades are paused this entire reconciler
+	// is a no-op — it must start no new upgrades, issue no kubectl restarts,
+	// and (critically) not re-arm heartbeatUpgrade through its stale-recovery
+	// path, which otherwise re-delivers in-flight targets every cycle. The
+	// registry latches and armed targets are left untouched so resuming picks
+	// up exactly where the fleet paused.
+	if sw, paused := s.spokeUpgradesPaused(); paused {
+		s.logger.Debug("auto-upgrade reconciler suppressed — spoke upgrades are paused",
+			"paused_by", sw.By, "paused_at", sw.At)
+		return
+	}
 	hives := listSaaSHives()
 	for _, h := range hives {
 		s.mu.RLock()
@@ -12883,6 +12957,7 @@ const dashboardHTML = `<!DOCTYPE html>
         _latestBuildStarted = data.latest_sha_build_started || {};
         if (data.commit_messages) _commitMessages = data.commit_messages;
         if (data.hub_auto_upgrade !== undefined) _hubAutoUpgrade = data.hub_auto_upgrade;
+        if (data.upgrade_pause) _upgradePause = data.upgrade_pause;
         var shaEl = document.getElementById('latest-image-sha');
         if (shaEl) {
           var lines = '';
@@ -12996,6 +13071,12 @@ const dashboardHTML = `<!DOCTYPE html>
             var hubAutoCheck = '';
             if (_isAdmin) {
               hubAutoCheck = ' <label style="margin-left:6px;font-size:0.6rem;color:var(--muted);cursor:pointer;white-space:nowrap" title="Auto-upgrade hub when a new image is available"><input type="checkbox" ' + (_hubAutoUpgrade ? 'checked' : '') + ' onchange="toggleHubAutoUpgrade(this.checked)" style="vertical-align:middle;margin-right:2px;cursor:pointer">auto</label>';
+              /* Upgrade kill switches (admin-only): checked = paused. Titles
+                 carry who/when; the dashboard banner repeats it prominently. */
+              hubAutoCheck += upgradePauseToggleHTML('hub', 'pause hub upgrades',
+                'Kill switch: freeze the hub on its current build — no self-upgrades (auto or manual) until resumed') +
+                upgradePauseToggleHTML('spokes', 'pause spoke upgrades',
+                'Kill switch: freeze ALL automatic image changes to spokes, fleet-wide, until resumed');
             }
             var hubStatusIcon = hubLatestUnknown
               ? ' <span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-left:3px" title="Resolving latest version…"></span>'
@@ -13030,6 +13111,7 @@ const dashboardHTML = `<!DOCTYPE html>
            never be cached, or the next page load would replay the same crash
            from localStorage before the network could correct it. */
         writeHivesCache(data.hives || []);
+        renderUpgradePauseBanner();
         renderPendingBanner(data.hives || []);
         renderUserAccessBanner();
         renderProvisionRequestBanner(data.my_provision_request || null);
@@ -14462,6 +14544,59 @@ const dashboardHTML = `<!DOCTYPE html>
         _hubUpgrading = true;
         hiveToast('Hub upgrade started — page will refresh when ready', 'success');
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
+    }
+
+    /* Admin upgrade kill switch. _upgradePause mirrors the server's persisted
+       state ({hub:{paused,by,at}, spokes:{...}}); it rides the my-hives
+       top-level payload. Checked = PAUSED. */
+    var _upgradePause = {hub: {paused: false}, spokes: {paused: false}};
+    function upgradePauseToggleHTML(target, label, title) {
+      var sw = (_upgradePause && _upgradePause[target]) || {paused: false};
+      var t = title + (sw.paused ? ' — paused by ' + (sw.by || '?') + ' since ' + (sw.at || '?') : '');
+      return ' <label style="margin-left:6px;font-size:0.6rem;color:' + (sw.paused ? 'var(--red)' : 'var(--muted)') + ';cursor:pointer;white-space:nowrap;font-weight:' + (sw.paused ? '700' : '400') + '" title="' + escAttr(t) + '"><input type="checkbox" ' + (sw.paused ? 'checked' : '') + ' onchange="toggleUpgradePause(\'' + target + '\', this.checked)" style="vertical-align:middle;margin-right:2px;cursor:pointer">' + esc(label) + '</label>';
+    }
+    async function toggleUpgradePause(target, paused) {
+      try {
+        var resp = await fetch('/api/saas/upgrade-pause', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({target: target, paused: paused})
+        });
+        var data = await resp.json();
+        if (!resp.ok) { hiveToast(data.error || 'Failed to update upgrade pause', 'error'); loadHives(); return; }
+        if (data.state) _upgradePause = data.state;
+        hiveToast((target === 'hub' ? 'Hub' : 'Spoke') + ' upgrades ' + (paused ? 'PAUSED' : 'resumed'), 'success');
+        renderUpgradePauseBanner();
+        loadHives();
+      } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
+    }
+    /* renderUpgradePauseBanner paints a prominent banner above the hive list
+       while EITHER kill switch is engaged, so a paused fleet is impossible to
+       miss. Same placement/styling family as renderPendingBanner. */
+    function renderUpgradePauseBanner() {
+      var existing = document.getElementById('upgrade-pause-banner');
+      if (existing) existing.remove();
+      var hubSw = (_upgradePause && _upgradePause.hub) || {};
+      var spokeSw = (_upgradePause && _upgradePause.spokes) || {};
+      if (!hubSw.paused && !spokeSw.paused) return;
+      var container = document.getElementById('hives-container');
+      if (!container || !container.parentNode) return;
+      var line = function(sw, label, detail) {
+        return '<div style="display:flex;align-items:center;gap:10px">' +
+          '<span style="font-size:1.1rem">&#x23F8;&#xFE0F;</span>' +
+          '<span style="font-size:0.85rem;color:var(--text)"><strong>' + label + '</strong> ' + detail +
+          ' — paused by <strong>' + esc(sw.by || 'an admin') + '</strong>' +
+          (sw.at ? ' since <span style="font-family:monospace;font-size:0.8rem">' + esc(sw.at) + '</span>' : '') +
+          '</span></div>';
+      };
+      var html = '';
+      if (hubSw.paused) html += line(hubSw, 'Hub upgrades are PAUSED', '(the hub stays on its current build)');
+      if (spokeSw.paused) html += line(spokeSw, 'Spoke upgrades are PAUSED fleet-wide', '(no automatic image changes reach any hive)');
+      var banner = document.createElement('div');
+      banner.id = 'upgrade-pause-banner';
+      banner.style.cssText = 'background:rgba(239,68,68,0.12);border:1px solid rgba(239,68,68,0.4);border-radius:8px;padding:12px 16px;margin-bottom:16px;display:flex;flex-direction:column;gap:6px';
+      banner.innerHTML = html;
+      container.parentNode.insertBefore(banner, container);
     }
 
     var _upgradingHives = {};

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -159,6 +159,18 @@ func (s *HubServer) handleBulkHiveAction(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Admin kill switch: bulk upgrade / branch-switch are the same image-change
+	// deliveries the single-hive handlers refuse while spoke upgrades are
+	// paused, so they get the same explicit 409 — for the whole batch, before
+	// any hive is touched. Auto-upgrade preference changes and plain restarts
+	// (no image target) pass through.
+	if body.Action == bulkActionUpgrade || body.Action == bulkActionSwitchBranch {
+		if sw, paused := s.spokeUpgradesPaused(); paused {
+			writeBulkError(w, http.StatusConflict, upgradePauseRefusal("spoke", sw))
+			return
+		}
+	}
+
 	// De-duplicate while preserving the client's order: a repeated ID would
 	// otherwise restart the same hive twice within one request.
 	ids := make([]string, 0, len(body.HiveIDs))

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -827,6 +827,13 @@ type HubServer struct {
 	// left the hub serving stale code for ~20 minutes with nothing surfaced.
 	hubUpgradeFault string
 	hubUpgradeMu    sync.Mutex // guards lastHubUpgradeTrigger + hubUpgradeTarget + hubUpgradeFault
+	// Admin upgrade kill switch (upgrade_pause.go). Lazily loaded from its
+	// durable JSON file on first use so the state survives the hub's own
+	// frequent auto-rolls; guarded by its own mutex because it is consulted on
+	// every heartbeat and every upgrade-poll cycle, never under s.mu.
+	upgradePause       UpgradePauseState
+	upgradePauseLoaded bool
+	upgradePauseMu     sync.Mutex // guards upgradePause + upgradePauseLoaded
 	httpServer      *http.Server
 	httpMu          sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
 	clusters        map[string]ClusterConfig
@@ -2115,6 +2122,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		spokeManaged = false
 	}
 
+	// Admin kill switch (upgrade_pause.go): while spoke upgrades are paused,
+	// this handler must not DELIVER any image change — no UpgradeTo, no
+	// SwitchToTag, no tracked-channel re-arm. Completion CLEARING below still
+	// runs (a spoke that already landed somewhere must not stay latched), and
+	// armed targets are left in place so resuming delivers them again.
+	spokePauseSw, spokeUpgradesPausedNow := s.spokeUpgradesPaused()
+
 	// Pending branch switch (image-tag change) delivered via heartbeat for
 	// clusters the hub can't kubectl-reach. Takes precedence over a plain
 	// SHA upgrade. Cleared when the spoke reports running that tag's build.
@@ -2133,7 +2147,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// re-arming would stamp a fresh restart-at annotation and re-roll the
 	// pod every beat). Also self-heals the delivered-upgrade-overwrote-the-
 	// channel-tag drift, not just hub restarts.
-	if switchTag == "" && saasHive != nil && isReleaseChannel(saasHive.TrackedChannel) &&
+	// The pause guard leads: a re-arm IS a delivery decision (the very next
+	// branch would put the tag on the wire), and the aggressive self-healing
+	// here is exactly what an admin reaching for the kill switch needs stopped.
+	if !spokeUpgradesPausedNow && switchTag == "" && saasHive != nil && isReleaseChannel(saasHive.TrackedChannel) &&
 		!payload.Upgrading && payload.ImageRef != "" &&
 		imageTagOf(sanitizeImageRef(payload.ImageRef)) != saasHive.TrackedChannel {
 		switchTag = saasHive.TrackedChannel
@@ -2167,6 +2184,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			s.logger.Info("heartbeat: spoke branch switch complete",
 				"hive_id", payload.HiveID, "branch", payload.GitBranch)
 			switchTag = ""
+		} else if spokeUpgradesPausedNow {
+			// Kill switch: keep the armed tag but do not put it on the wire.
+			s.logger.Debug("heartbeat: switch instruction withheld — spoke upgrades are paused",
+				"hive_id", payload.HiveID, "tag", switchTag,
+				"paused_by", spokePauseSw.By, "paused_at", spokePauseSw.At)
 		} else {
 			resp.SwitchToTag = switchTag
 			s.logger.Info("heartbeat: instructing spoke to switch branch image",
@@ -2190,7 +2212,16 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		hbTarget = ""
 	}
 
-	if spokeManaged && latestSHA != "" && payload.GitHash != "" && !sameCommit(payload.GitHash, latestSHA) {
+	if spokeUpgradesPausedNow {
+		// Kill switch: no UpgradeTo of any flavour — spoke-managed chase-latest
+		// or the armed kubectl fallback. Heartbeat is otherwise answered
+		// normally; the armed target survives for resume.
+		if hbTarget != "" || spokeManaged {
+			s.logger.Debug("heartbeat: upgrade instruction withheld — spoke upgrades are paused",
+				"hive_id", payload.HiveID,
+				"paused_by", spokePauseSw.By, "paused_at", spokePauseSw.At)
+		}
+	} else if spokeManaged && latestSHA != "" && payload.GitHash != "" && !sameCommit(payload.GitHash, latestSHA) {
 		resp.UpgradeTo = latestSHA
 		s.logger.Info("heartbeat: instructing spoke-managed hive to upgrade",
 			"hive_id", payload.HiveID,

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -217,6 +217,17 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time, latestSHA stri
 // mid-upgrade. UpgradeTarget is preserved for observability, and the event is
 // logged and written to the hive's timeline.
 func (s *HubServer) sweepOrphanedUpgrades() {
+	// Admin kill switch: while spoke upgrades are paused nothing is being
+	// delivered, so this sweep must not run — it re-arms heartbeatUpgrade
+	// (a delivery the pause forbids) and burns OrphanedUpgradeSweeps retry
+	// budget against hives that CANNOT land their target while paused, which
+	// would tip healthy hives into a false permanent UpgradeFailed. Latches
+	// simply wait; the sweep resumes with the rest of the machinery.
+	if sw, paused := s.spokeUpgradesPaused(); paused {
+		s.logger.Debug("orphaned-upgrade sweep suppressed — spoke upgrades are paused",
+			"paused_by", sw.By, "paused_at", sw.At)
+		return
+	}
 	now := time.Now()
 
 	type cleared struct {

--- a/v2/pkg/hub/upgrade_pause.go
+++ b/v2/pkg/hub/upgrade_pause.go
@@ -1,0 +1,189 @@
+package hub
+
+// Admin-only upgrade kill switch.
+//
+// Two independent pauses, both admin-only and both DURABLE across hub restarts
+// (the hub auto-rolls itself frequently, so any in-memory-only flag would be
+// silently wiped by the very machinery it is meant to stop):
+//
+//   - hub:    freezes the hub's own self-upgrade machinery. While set, the
+//     poll-loop auto-upgrade never triggers and the manual
+//     /api/saas/hub/upgrade endpoint refuses with 409. The hub stays on its
+//     current build regardless of new tags.
+//
+//   - spokes: freezes EVERY automatic image-change delivery path to spokes,
+//     fleet-wide. The pause must be honoured by ALL of them or it is a lie:
+//     triggerAutoUpgrades (kubectl restarts + arming heartbeatUpgrade), the
+//     heartbeat handler's UpgradeTo / SwitchToTag sends, the tracked-channel
+//     re-arm inside the heartbeat handler, and the orphaned-upgrade sweep's
+//     heartbeatUpgrade re-arm. Heartbeats are otherwise answered normally, and
+//     armed in-memory targets are left in place — pause suppresses DELIVERY,
+//     it does not destroy state, so resuming picks up exactly where the fleet
+//     left off. Manual upgrade/switch API requests while paused get an
+//     explicit 409 naming who paused and when, never a silent queue.
+//
+// State is one small JSON file on the hub's durable data dir, next to the
+// other hub-owned SaaS state (hub-auto-upgrade, hub-generations.json), loaded
+// lazily on first use so a fresh post-restart process starts from the
+// persisted truth.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// upgradePausePath is the durable home of the kill-switch state. A var (not a
+// const) so tests can redirect it at a temp path, exactly like
+// hubAutoUpgradePath and hubGenerationsPath.
+var upgradePausePath = "/data/saas/upgrade-pause.json"
+
+// upgradePauseFileMode matches the other non-secret /data/saas JSON files
+// (registry, hive records): the state is operational, not key material.
+const upgradePauseFileMode = 0o644
+
+// Pause targets accepted by the API and used as the audit-log discriminator.
+const (
+	upgradePauseTargetHub    = "hub"
+	upgradePauseTargetSpokes = "spokes"
+)
+
+// UpgradePauseSwitch is one of the two toggles: whether it is engaged, and who
+// flipped it last, when (RFC3339). By/At record the LAST flip in either
+// direction so a resume is attributable too.
+type UpgradePauseSwitch struct {
+	Paused bool   `json:"paused"`
+	By     string `json:"by,omitempty"`
+	At     string `json:"at,omitempty"`
+}
+
+// UpgradePauseState is the full persisted kill-switch state.
+type UpgradePauseState struct {
+	Hub    UpgradePauseSwitch `json:"hub"`
+	Spokes UpgradePauseSwitch `json:"spokes"`
+}
+
+// ensureUpgradePauseLoadedLocked loads the persisted state exactly once per
+// process. Callers must hold s.upgradePauseMu. A missing file means "nothing
+// paused" — the safe default and the pre-feature behaviour. An unreadable or
+// corrupt file is logged and treated the same way rather than wedging the hub.
+func (s *HubServer) ensureUpgradePauseLoadedLocked() {
+	if s.upgradePauseLoaded {
+		return
+	}
+	s.upgradePauseLoaded = true
+	data, err := os.ReadFile(upgradePausePath)
+	if err != nil {
+		return
+	}
+	var st UpgradePauseState
+	if err := json.Unmarshal(data, &st); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("upgrade-pause state file is corrupt — treating as not paused",
+				"path", upgradePausePath, "error", err)
+		}
+		return
+	}
+	s.upgradePause = st
+}
+
+// upgradePauseSnapshot returns a copy of the current kill-switch state.
+func (s *HubServer) upgradePauseSnapshot() UpgradePauseState {
+	s.upgradePauseMu.Lock()
+	defer s.upgradePauseMu.Unlock()
+	s.ensureUpgradePauseLoadedLocked()
+	return s.upgradePause
+}
+
+// hubUpgradesPaused reports whether the hub self-upgrade kill switch is on,
+// with the switch metadata for messages/logs.
+func (s *HubServer) hubUpgradesPaused() (UpgradePauseSwitch, bool) {
+	st := s.upgradePauseSnapshot()
+	return st.Hub, st.Hub.Paused
+}
+
+// spokeUpgradesPaused reports whether the fleet-wide spoke kill switch is on,
+// with the switch metadata for messages/logs.
+func (s *HubServer) spokeUpgradesPaused() (UpgradePauseSwitch, bool) {
+	st := s.upgradePauseSnapshot()
+	return st.Spokes, st.Spokes.Paused
+}
+
+// upgradePauseRefusal is the human-readable 409 message for a manual request
+// refused by an engaged kill switch: "<kind> upgrades are paused by <who>
+// since <when>".
+func upgradePauseRefusal(kind string, sw UpgradePauseSwitch) string {
+	msg := kind + " upgrades are paused"
+	if sw.By != "" {
+		msg += " by " + sw.By
+	}
+	if sw.At != "" {
+		msg += " since " + sw.At
+	}
+	return msg
+}
+
+// setUpgradePause flips one switch, stamps who/when, persists, and returns the
+// new full state. The write happens under the mutex so two admins flipping
+// different switches concurrently cannot lose each other's update.
+func (s *HubServer) setUpgradePause(target string, paused bool, by string) (UpgradePauseState, error) {
+	s.upgradePauseMu.Lock()
+	defer s.upgradePauseMu.Unlock()
+	s.ensureUpgradePauseLoadedLocked()
+	sw := UpgradePauseSwitch{Paused: paused, By: by, At: time.Now().UTC().Format(time.RFC3339)}
+	switch target {
+	case upgradePauseTargetHub:
+		s.upgradePause.Hub = sw
+	case upgradePauseTargetSpokes:
+		s.upgradePause.Spokes = sw
+	}
+	data, err := json.MarshalIndent(s.upgradePause, "", "  ")
+	if err != nil {
+		return s.upgradePause, err
+	}
+	if err := os.MkdirAll(filepath.Dir(upgradePausePath), 0o755); err != nil {
+		return s.upgradePause, err
+	}
+	if err := os.WriteFile(upgradePausePath, data, upgradePauseFileMode); err != nil {
+		return s.upgradePause, err
+	}
+	return s.upgradePause, nil
+}
+
+// handleGetUpgradePause returns the current kill-switch state. Admin-only
+// (wrapped in requireAdmin at registration) — the same gate as the toggles it
+// describes, and the who/when metadata names admins.
+func (s *HubServer) handleGetUpgradePause(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(s.upgradePauseSnapshot())
+}
+
+// handleSetUpgradePause flips one switch. Admin-only (requireAdmin). Every
+// flip — pause AND resume — is audit-logged with the acting admin.
+func (s *HubServer) handleSetUpgradePause(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Target string `json:"target"`
+		Paused bool   `json:"paused"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid body"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Target != upgradePauseTargetHub && body.Target != upgradePauseTargetSpokes {
+		http.Error(w, `{"error":"target must be \"hub\" or \"spokes\""}`, http.StatusBadRequest)
+		return
+	}
+	username := s.getAuthUser(r)
+	state, err := s.setUpgradePause(body.Target, body.Paused, username)
+	if err != nil {
+		s.logger.Error("failed to persist upgrade-pause state", "target", body.Target, "error", err)
+		http.Error(w, `{"error":"failed to persist upgrade-pause state"}`, http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("audit: upgrade pause toggled",
+		"target", body.Target, "paused", body.Paused, "by", username)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "state": state})
+}

--- a/v2/pkg/hub/upgrade_pause_test.go
+++ b/v2/pkg/hub/upgrade_pause_test.go
@@ -1,0 +1,581 @@
+package hub
+
+// Tests for the admin upgrade kill switch (upgrade_pause.go).
+//
+// Every "pause blocks X" test carries a POSITIVE CONTROL — the same scenario
+// with the switch off must behave normally. A pause gate that blocks
+// everything forever is exactly the failure mode these switches must not have,
+// and a suppression test without a control passes for the wrong reason the
+// moment the underlying delivery path breaks (see the F14/F18 lesson).
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// pauseSpokes / pauseHub flip the switch through the same code path the API
+// uses, so By/At stamping and persistence are exercised in every test.
+func pauseSpokes(t *testing.T, s *HubServer, paused bool) {
+	t.Helper()
+	if _, err := s.setUpgradePause(upgradePauseTargetSpokes, paused, "clubanderson"); err != nil {
+		t.Fatalf("setUpgradePause(spokes, %v): %v", paused, err)
+	}
+}
+
+func pauseHub(t *testing.T, s *HubServer, paused bool) {
+	t.Helper()
+	if _, err := s.setUpgradePause(upgradePauseTargetHub, paused, "clubanderson"); err != nil {
+		t.Fatalf("setUpgradePause(hub, %v): %v", paused, err)
+	}
+}
+
+// ============================================================
+// Persistence: the state file must survive a hub restart
+// ============================================================
+
+func TestUpgradePausePersistenceRoundTrip(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default()}
+	state, err := s.setUpgradePause(upgradePauseTargetSpokes, true, "clubanderson")
+	if err != nil {
+		t.Fatalf("setUpgradePause: %v", err)
+	}
+	if !state.Spokes.Paused || state.Spokes.By != "clubanderson" {
+		t.Fatalf("in-memory state after pause = %+v", state.Spokes)
+	}
+	if _, err := time.Parse(time.RFC3339, state.Spokes.At); err != nil {
+		t.Fatalf("At %q is not RFC3339: %v", state.Spokes.At, err)
+	}
+
+	// A FRESH HubServer models the hub restarting (the hub auto-rolls itself
+	// frequently — in-memory-only pause state was the incident mode).
+	s2 := &HubServer{logger: slog.Default()}
+	sw, paused := s2.spokeUpgradesPaused()
+	if !paused || sw.By != "clubanderson" || sw.At != state.Spokes.At {
+		t.Fatalf("reloaded spoke switch = %+v paused=%v, want persisted pause by clubanderson", sw, paused)
+	}
+	// The two switches are independent: pausing spokes must not pause the hub.
+	if _, hubPaused := s2.hubUpgradesPaused(); hubPaused {
+		t.Fatal("hub switch reads paused after only the spoke switch was set")
+	}
+
+	// Resume is persisted too, with fresh who/when.
+	if _, err := s2.setUpgradePause(upgradePauseTargetSpokes, false, "otheradmin"); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	s3 := &HubServer{logger: slog.Default()}
+	sw3, paused3 := s3.spokeUpgradesPaused()
+	if paused3 {
+		t.Fatal("spoke switch still paused after persisted resume")
+	}
+	if sw3.By != "otheradmin" {
+		t.Fatalf("resume attribution = %q, want otheradmin", sw3.By)
+	}
+}
+
+// ============================================================
+// Delivery path 1: triggerAutoUpgrades (incl. stale-recovery re-arm)
+// ============================================================
+
+// TestSpokePauseBlocksTriggerAutoUpgradesReArm: the non-stale re-populate path
+// (heartbeatUpgrade re-armed after a hub restart) must be suppressed while
+// paused and work normally when resumed.
+func TestSpokePauseBlocksTriggerAutoUpgradesReArm(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetCommitOrderState(t)
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "behind", nil
+	})
+
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "remote"})
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitBranch: "v2", GitHash: "old", Upgrading: true,
+		UpgradeTarget: "keepTarget", UpgradeStartedAt: time.Now(),
+	}}
+
+	pauseSpokes(t, s, true)
+	s.triggerAutoUpgrades()
+	s.mu.RLock()
+	got := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if got != "" {
+		t.Fatalf("paused: heartbeatUpgrade re-armed to %q, want nothing delivered", got)
+	}
+	// The durable latch must be untouched — pause freezes, it does not cancel.
+	s.mu.RLock()
+	entry := s.registry.Hives[0]
+	s.mu.RUnlock()
+	if !entry.Upgrading || entry.UpgradeTarget != "keepTarget" {
+		t.Fatalf("paused: registry latch mutated: %+v", entry)
+	}
+
+	// POSITIVE CONTROL: resumed, the same cycle re-arms the target.
+	pauseSpokes(t, s, false)
+	s.triggerAutoUpgrades()
+	s.mu.RLock()
+	got = s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if got != "keepTarget" {
+		t.Fatalf("resumed: heartbeatUpgrade = %q, want keepTarget (control failed — the pause test proves nothing)", got)
+	}
+}
+
+// TestSpokePauseBlocksStaleRecovery: the stale-upgrade recovery reconciler
+// (beginUpgrade + heartbeatUpgrade[...] = recoverTarget + rolloutRestartHive)
+// re-arms in-memory state aggressively — the exact machinery the kill switch
+// exists to stop.
+func TestSpokePauseBlocksStaleRecovery(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	installScriptedKubectl(t)
+	resetCommitOrderState(t)
+	// Pin the ancestry answer to "behind" so the at-or-ahead clearing path
+	// cannot swallow the latch before the stale-recovery branch runs.
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "behind", nil
+	})
+
+	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx", Domain: "r.example.com"}
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "remote"})
+	resetSHACaches(t)
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newsha7"}
+	latestSHAMu.Unlock()
+
+	started := time.Now().Add(-2 * time.Hour)
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	// SHAs deliberately share no prefix: sameCommit matches short-vs-full by
+	// prefix, so "old"/"oldtarget" would read as already-at-target and clear
+	// the latch before the recovery branch this test exercises.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitBranch: "v2", GitHash: "aaa1111", Upgrading: true,
+		UpgradeTarget: "bbb2222", UpgradeStartedAt: started,
+	}}
+
+	pauseSpokes(t, s, true)
+	s.triggerAutoUpgrades()
+	s.mu.RLock()
+	got := s.heartbeatUpgrade["h1"]
+	target := s.registry.Hives[0].UpgradeTarget
+	s.mu.RUnlock()
+	if got != "" {
+		t.Fatalf("paused: stale recovery armed heartbeatUpgrade=%q, want no re-arm", got)
+	}
+	if target != "bbb2222" {
+		t.Fatalf("paused: stale recovery advanced the target to %q, want bbb2222 untouched", target)
+	}
+
+	// POSITIVE CONTROL: resumed, recovery advances the target and re-arms.
+	pauseSpokes(t, s, false)
+	s.triggerAutoUpgrades()
+	s.mu.RLock()
+	got = s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if got != "newsha7" {
+		t.Fatalf("resumed: heartbeatUpgrade = %q, want newsha7 (control failed)", got)
+	}
+}
+
+// ============================================================
+// Delivery path 2: heartbeat handler (UpgradeTo, SwitchToTag, channel re-arm)
+// ============================================================
+
+func TestSpokePauseBlocksHeartbeatUpgradeTo(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+	s.registry.Hives = []RegistryEntry{{ID: "h1"}}
+	s.heartbeatUpgrade["h1"] = "newtarget"
+
+	pauseSpokes(t, s, true)
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"oldhash"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("paused heartbeat status = %d, want 200 (heartbeats stay normal)", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "newtarget") {
+		t.Fatalf("paused: heartbeat delivered upgrade_to: %s", rec.Body.String())
+	}
+	// The armed target survives the pause so resuming delivers it again.
+	s.mu.RLock()
+	armed := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if armed != "newtarget" {
+		t.Fatalf("paused: armed target = %q, want newtarget preserved", armed)
+	}
+
+	// POSITIVE CONTROL: resumed, the very next beat carries the instruction.
+	pauseSpokes(t, s, false)
+	rec = postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"oldhash"}`)
+	if !strings.Contains(rec.Body.String(), "newtarget") {
+		t.Fatalf("resumed: expected upgrade_to newtarget, got %s (control failed)", rec.Body.String())
+	}
+}
+
+func TestSpokePauseBlocksSpokeManagedUpgradeTo(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+	resetSHACaches(t)
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newsha7"}
+	latestSHAMu.Unlock()
+
+	// Spoke-managed hive (ConfigMap auto_upgrade=true, no SaaS record):
+	// normally chases latest on every beat.
+	// Assert on the upgrade_to KEY, not the SHA — the heartbeat response always
+	// echoes latest_sha, so the SHA string alone appears even when nothing is
+	// instructed.
+	pauseSpokes(t, s, true)
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"old","git_branch":"v2","auto_upgrade":true}`)
+	if strings.Contains(rec.Body.String(), `"upgrade_to"`) {
+		t.Fatalf("paused: spoke-managed upgrade_to delivered: %s", rec.Body.String())
+	}
+
+	// POSITIVE CONTROL.
+	pauseSpokes(t, s, false)
+	rec = postHeartbeat(t, s, `{"hive_id":"h1","git_hash":"old","git_branch":"v2","auto_upgrade":true}`)
+	if !strings.Contains(rec.Body.String(), `"upgrade_to":"newsha7"`) {
+		t.Fatalf("resumed: expected upgrade_to newsha7, got %s (control failed)", rec.Body.String())
+	}
+}
+
+func TestSpokePauseBlocksSwitchToTag(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+	s.registry.Hives = []RegistryEntry{{ID: "h1"}}
+	s.heartbeatSwitchTag["h1"] = "dev-latest"
+
+	pauseSpokes(t, s, true)
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","git_branch":"v2"}`)
+	if strings.Contains(rec.Body.String(), "dev-latest") {
+		t.Fatalf("paused: switch_to_tag delivered: %s", rec.Body.String())
+	}
+	// The armed tag survives for resume.
+	s.mu.RLock()
+	armed := s.heartbeatSwitchTag["h1"]
+	s.mu.RUnlock()
+	if armed != "dev-latest" {
+		t.Fatalf("paused: armed switch tag = %q, want dev-latest preserved", armed)
+	}
+
+	// POSITIVE CONTROL.
+	pauseSpokes(t, s, false)
+	rec = postHeartbeat(t, s, `{"hive_id":"h1","git_branch":"v2"}`)
+	if !strings.Contains(rec.Body.String(), "dev-latest") {
+		t.Fatalf("resumed: expected switch_to_tag dev-latest, got %s (control failed)", rec.Body.String())
+	}
+}
+
+// TestSpokePauseBlocksTrackedChannelReArm: the durable-channel self-heal
+// (#3771) re-arms heartbeatSwitchTag from SaaSHive.TrackedChannel whenever the
+// reported image tag disagrees — a delivery decision that must respect the
+// pause.
+func TestSpokePauseBlocksTrackedChannelReArm(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", TrackedChannel: ReleaseChannelStable})
+	s.registry.Hives = []RegistryEntry{{ID: "h1"}}
+
+	pauseSpokes(t, s, true)
+	rec := postHeartbeat(t, s, `{"hive_id":"h1","image_ref":"ghcr.io/kubestellar/hive:v4-latest"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	s.mu.RLock()
+	armed := s.heartbeatSwitchTag["h1"]
+	s.mu.RUnlock()
+	if armed != "" {
+		t.Fatalf("paused: tracked-channel re-armed heartbeatSwitchTag=%q, want no re-arm", armed)
+	}
+	if strings.Contains(rec.Body.String(), "switch_to_tag") {
+		t.Fatalf("paused: switch instruction delivered: %s", rec.Body.String())
+	}
+
+	// POSITIVE CONTROL: resumed, the drift re-arms and instructs the channel.
+	pauseSpokes(t, s, false)
+	rec = postHeartbeat(t, s, `{"hive_id":"h1","image_ref":"ghcr.io/kubestellar/hive:v4-latest"}`)
+	s.mu.RLock()
+	armed = s.heartbeatSwitchTag["h1"]
+	s.mu.RUnlock()
+	if armed != ReleaseChannelStable {
+		t.Fatalf("resumed: re-armed tag = %q, want %q (control failed)", armed, ReleaseChannelStable)
+	}
+	if !strings.Contains(rec.Body.String(), ReleaseChannelStable) {
+		t.Fatalf("resumed: expected switch_to_tag %q, got %s", ReleaseChannelStable, rec.Body.String())
+	}
+}
+
+// ============================================================
+// Delivery path 3: orphaned-upgrade sweep re-arm
+// ============================================================
+
+func TestSpokePauseBlocksOrphanSweep(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetSHACaches(t)
+	resetCommitOrderState(t)
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "behind", nil
+	})
+
+	mkOrphan := func() *HubServer {
+		s := &HubServer{logger: slog.Default(), saveCh: make(chan struct{}, 1), heartbeatUpgrade: make(map[string]string)}
+		s.registry.Hives = []RegistryEntry{{
+			ID: "h1", Upgrading: true, UpgradeTarget: "tgt7777", GitHash: "old7777",
+			UpgradeStartedAt: time.Now().Add(-3 * staleUpgradeTimeout),
+			LastHeartbeat:    time.Now().Format(time.RFC3339),
+		}}
+		return s
+	}
+
+	s := mkOrphan()
+	pauseSpokes(t, s, true)
+	s.sweepOrphanedUpgrades()
+	s.mu.RLock()
+	entry := s.registry.Hives[0]
+	armed := s.heartbeatUpgrade["h1"]
+	s.mu.RUnlock()
+	if !entry.Upgrading || entry.OrphanedUpgradeSweeps != 0 {
+		t.Fatalf("paused: sweep mutated the latch (%+v) — must be a no-op; retry budget burned while paused would fake UpgradeFailed", entry)
+	}
+	if armed != "" {
+		t.Fatalf("paused: sweep re-armed heartbeatUpgrade=%q", armed)
+	}
+
+	// POSITIVE CONTROL on a fresh, unpaused server: same orphan is swept and
+	// the target is re-armed for delivery.
+	s2 := mkOrphan()
+	pauseSpokes(t, s2, false)
+	s2.sweepOrphanedUpgrades()
+	s2.mu.RLock()
+	entry = s2.registry.Hives[0]
+	armed = s2.heartbeatUpgrade["h1"]
+	s2.mu.RUnlock()
+	if entry.Upgrading || entry.OrphanedUpgradeSweeps != 1 {
+		t.Fatalf("unpaused control: sweep did not clear the orphan (%+v) — the pause test proves nothing", entry)
+	}
+	if armed != "tgt7777" {
+		t.Fatalf("unpaused control: re-armed target = %q, want tgt7777", armed)
+	}
+}
+
+// ============================================================
+// Hub self-upgrade kill switch
+// ============================================================
+
+func TestHubPauseRefusesManualHubUpgrade(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetSHACaches(t)
+	mkUser(t, hubAdminUsername)
+	s := newHandlerHub()
+
+	pauseHub(t, s, true)
+	rec := httptest.NewRecorder()
+	s.handleHubSelfUpgrade(rec, reqWithUser(http.MethodPost, "/api/saas/hub/upgrade", "", hubAdminUsername))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("paused: hub self-upgrade status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "hub upgrades are paused by clubanderson since ") {
+		t.Fatalf("paused: refusal must name who/when, got %s", rec.Body.String())
+	}
+
+	// POSITIVE CONTROL: resumed, the request passes the gate. With no latest
+	// hub SHA cached, rolloutHubToSHA fails -> 500, which proves the handler
+	// advanced PAST the 409 pause gate.
+	pauseHub(t, s, false)
+	rec = httptest.NewRecorder()
+	s.handleHubSelfUpgrade(rec, reqWithUser(http.MethodPost, "/api/saas/hub/upgrade", "", hubAdminUsername))
+	if rec.Code == http.StatusConflict {
+		t.Fatalf("resumed: still 409 — the kill switch is stuck on; body=%s", rec.Body.String())
+	}
+}
+
+// ============================================================
+// Manual spoke upgrade / branch switch refusals (409, never a silent queue)
+// ============================================================
+
+func TestSpokePauseRefusesManualUpgradeHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	installScriptedKubectl(t)
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
+	s := newHandlerHub()
+	s.clusters = map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}
+	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2", GitHash: "old"}}
+	resetSHACaches(t)
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newsha7"}
+	latestSHAMu.Unlock()
+
+	pauseSpokes(t, s, true)
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/h1/upgrade", "", "alice"), "id", "h1")
+	s.handleUpgradeHive(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("paused: upgrade status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "spoke upgrades are paused by clubanderson since ") {
+		t.Fatalf("paused: refusal must name who/when, got %s", rec.Body.String())
+	}
+	// Refused means NOTHING was armed or latched — no silent queue.
+	s.mu.RLock()
+	armed := s.heartbeatUpgrade["h1"]
+	upgrading := s.registry.Hives[0].Upgrading
+	s.mu.RUnlock()
+	if armed != "" || upgrading {
+		t.Fatalf("paused: refused request still armed state (armed=%q upgrading=%v)", armed, upgrading)
+	}
+
+	// POSITIVE CONTROL: resumed, the same request upgrades (scripted kubectl
+	// delivers the restart).
+	pauseSpokes(t, s, false)
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/h1/upgrade", "", "alice"), "id", "h1")
+	s.handleUpgradeHive(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resumed: upgrade status = %d, want 200 (control failed); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSpokePauseRefusesManualSwitchBranch(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
+	// GitHub returns 404 for every branch, so the unpaused control below stops
+	// at "unknown branch" (400) without touching a cluster — far enough to
+	// prove the request advanced past the pause gate.
+	fakeGitHubGHCR(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	resetSHACaches(t)
+	s := newHandlerHub()
+	s.clusters = map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}
+
+	pauseSpokes(t, s, true)
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/h1/switch-branch", `{"branch":"v4"}`, "alice"), "id", "h1")
+	s.handleSwitchBranch(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("paused: switch status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "spoke upgrades are paused by clubanderson since ") {
+		t.Fatalf("paused: refusal must name who/when, got %s", rec.Body.String())
+	}
+	s.mu.RLock()
+	armed := s.heartbeatSwitchTag["h1"]
+	s.mu.RUnlock()
+	if armed != "" {
+		t.Fatalf("paused: refused switch still queued heartbeatSwitchTag=%q", armed)
+	}
+
+	// POSITIVE CONTROL: resumed, the handler reaches branch validation (400
+	// here, because the faked GitHub knows no branches) instead of 409.
+	pauseSpokes(t, s, false)
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/h1/switch-branch", `{"branch":"no-such-branch"}`, "alice"), "id", "h1")
+	s.handleSwitchBranch(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("resumed: switch status = %d, want 400 unknown-branch (control failed); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSpokePauseRefusesBulkUpgradeAndSwitch(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: hubAdminUsername, ClusterID: "hive-oke"})
+	s := newHandlerHub()
+
+	pauseSpokes(t, s, true)
+	for _, action := range []string{bulkActionUpgrade, bulkActionSwitchBranch} {
+		body := `{"action":"` + action + `","hive_ids":["h1"],"branch":"v4"}`
+		rec := httptest.NewRecorder()
+		s.handleBulkHiveAction(rec, reqWithUser(http.MethodPost, "/api/saas/hives/bulk", body, hubAdminUsername))
+		if rec.Code != http.StatusConflict {
+			t.Errorf("paused bulk %s: status = %d, want 409; body=%s", action, rec.Code, rec.Body.String())
+		}
+	}
+	// Preference-only bulk actions are configuration, not delivery — allowed.
+	rec := httptest.NewRecorder()
+	s.handleBulkHiveAction(rec, reqWithUser(http.MethodPost, "/api/saas/hives/bulk",
+		`{"action":"disable-auto-upgrade","hive_ids":["h1"]}`, hubAdminUsername))
+	if rec.Code != http.StatusOK {
+		t.Errorf("paused bulk disable-auto-upgrade: status = %d, want 200 (preference changes stay allowed); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ============================================================
+// API: admin-only enforcement + state shape
+// ============================================================
+
+func TestUpgradePauseEndpointsAdminOnly(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+	mkUser(t, hubAdminUsername)
+	s := newHandlerHub()
+
+	getH := s.requireAdmin(s.handleGetUpgradePause)
+	postH := s.requireAdmin(s.handleSetUpgradePause)
+
+	// Non-admin: both verbs 403.
+	rec := httptest.NewRecorder()
+	getH(rec, reqWithUser(http.MethodGet, "/api/saas/upgrade-pause", "", "alice"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin GET status = %d, want 403", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	req := reqWithUser(http.MethodPost, "/api/saas/upgrade-pause", `{"target":"spokes","paused":true}`, "alice")
+	req.Header.Set("Origin", "https://"+hubCanonicalHost)
+	postH(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin POST status = %d, want 403", rec.Code)
+	}
+	// The refused flip must not have engaged the switch.
+	if _, paused := s.spokeUpgradesPaused(); paused {
+		t.Fatal("non-admin POST engaged the kill switch")
+	}
+
+	// POSITIVE CONTROL: admin flips it (same-origin, so the CSRF gate passes),
+	// and GET reflects the persisted state with who/when.
+	rec = httptest.NewRecorder()
+	req = reqWithUser(http.MethodPost, "/api/saas/upgrade-pause", `{"target":"spokes","paused":true}`, hubAdminUsername)
+	req.Header.Set("Origin", "https://"+hubCanonicalHost)
+	postH(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin POST status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	rec = httptest.NewRecorder()
+	getH(rec, reqWithUser(http.MethodGet, "/api/saas/upgrade-pause", "", hubAdminUsername))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin GET status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"paused":true`) || !strings.Contains(body, hubAdminUsername) {
+		t.Fatalf("GET state missing paused/by fields: %s", body)
+	}
+
+	// Unknown target is rejected.
+	rec = httptest.NewRecorder()
+	req = reqWithUser(http.MethodPost, "/api/saas/upgrade-pause", `{"target":"everything","paused":true}`, hubAdminUsername)
+	req.Header.Set("Origin", "https://"+hubCanonicalHost)
+	postH(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad target status = %d, want 400", rec.Code)
+	}
+}


### PR DESCRIPTION
## What

Two independent, admin-only, **durable** kill switches on the hub dashboard (My Hives admin area):

1. **Pause hub upgrades** — freezes the hub's own self-upgrade machinery. The poll-loop auto-trigger is suppressed every cycle and the manual `POST /api/saas/hub/upgrade` refuses with **409** naming who paused and when. The hub stays on its current build regardless of new tags.
2. **Pause spoke upgrades** — freezes ALL automatic image changes to spokes, fleet-wide.

## Why every path is gated

A pause that misses one delivery path is a lie — the reconcilers re-arm in-memory state aggressively. All of these honour the spoke pause:

- `triggerAutoUpgrades()` (saas.go): early no-op — no new upgrades, no kubectl restarts, no stale-recovery re-arm (`beginUpgrade` + `heartbeatUpgrade[...] = recoverTarget` + `rolloutRestartHive`), no restart re-populate.
- Heartbeat handler (server.go): no `resp.UpgradeTo` (spoke-managed **and** kubectl-fallback lanes), no `resp.SwitchToTag`, and the #3771 tracked-channel re-arm from `SaaSHive.TrackedChannel` is suppressed. Completion **clearing** still runs; heartbeats are otherwise answered normally.
- `sweepOrphanedUpgrades()` (stale_upgrade.go): no-op while paused — it re-arms `heartbeatUpgrade` and would burn `OrphanedUpgradeSweeps` retry budget against hives that cannot land targets while paused, faking a permanent `UpgradeFailed`.
- Manual API: single-hive upgrade, single-hive branch/channel switch, and bulk `upgrade` / `switch-branch` all return **409** `"spoke upgrades are paused by <who> since <when>"` — never a silent queue. Auto-upgrade *preference* changes stay allowed; only their immediate trigger is suppressed.

Armed targets are preserved (pause suppresses delivery, not state), so resuming picks up exactly where the fleet paused.

## Persistence

`/data/saas/upgrade-pause.json` (sibling of `hub-auto-upgrade` / `hub-generations.json`), recording `paused` / `by` / `at` (RFC3339) per switch, lazily loaded on first use. The hub auto-rolls itself frequently — in-memory-only pause state being wiped by restarts is a known live-incident mode. Every flip is audit-logged (`audit: upgrade pause toggled`).

## API

- `GET /api/saas/upgrade-pause` — state (admin-only, `requireAdmin`)
- `POST /api/saas/upgrade-pause` `{"target":"hub"|"spokes","paused":bool}` (admin-only)

## UI

Two labeled admin-only toggles next to the hub version pill (checked = paused, red when engaged, titles carry who/when) and a prominent red banner above the hive list while either switch is on, naming the switch, who, and since when. Pause state rides the my-hives **top-level** payload — not the hive-row shape — so no `HIVES_CACHE_VERSION` bump.

## Tests

Each delivery path has a suppression test **with a positive control** (unpaused = normal behaviour — a pause that blocks everything forever is the failure mode to guard):

- `TestUpgradePausePersistenceRoundTrip` — survives a simulated hub restart; switches independent; resume attribution persisted
- `TestSpokePauseBlocksTriggerAutoUpgradesReArm`, `TestSpokePauseBlocksStaleRecovery`
- `TestSpokePauseBlocksHeartbeatUpgradeTo`, `TestSpokePauseBlocksSpokeManagedUpgradeTo`, `TestSpokePauseBlocksSwitchToTag`, `TestSpokePauseBlocksTrackedChannelReArm`
- `TestSpokePauseBlocksOrphanSweep`
- `TestHubPauseRefusesManualHubUpgrade`, `TestSpokePauseRefusesManualUpgradeHive`, `TestSpokePauseRefusesManualSwitchBranch`, `TestSpokePauseRefusesBulkUpgradeAndSwitch`
- `TestUpgradePauseEndpointsAdminOnly` (non-admin 403, CSRF-safe admin flip, bad target 400)

All 13 pass locally alongside the existing Heartbeat/Upgrade/Switch/Sweep/Bulk/Dashboard test groups.