### PR TITLE
security: pin nodesource GPG key, add nginx defence-in-depth headers

### DIFF
--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -25,9 +25,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl git jq tmux python3 ca-certificates gnupg openssh-client \
   && rm -rf /var/lib/apt/lists/*
 
+# The NodeSource GPG key is downloaded to a file and its SHA-256 verified
+# BEFORE being dearmored/trusted (issue #3821), mirroring the
+# download-then-sha256sum-c-then-use pattern already used below for bobshell,
+# Goose, and the Go toolchain. Without this, a compromised deb.nodesource.com,
+# a DNS hijack, or a build-network MITM could swap in a malicious signing key
+# that apt would then trust for every nodejs package pulled into the image.
+# NODESOURCE_KEY_SHA256 is the digest of the raw ASCII-armored key as
+# published at the URL below; re-verify against NodeSource's documented
+# fingerprint (6F71F5252828 41EEDAF851B4 2F59B5F99B1B E0B4) before bumping.
+ARG NODESOURCE_KEY_SHA256=b42e0321dabdc24e892115da705cf061167eac12a317f23d329862d0aa0a271d
 RUN mkdir -p /etc/apt/keyrings \
-  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && curl -fsSL -o /tmp/nodesource.key https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+  && echo "${NODESOURCE_KEY_SHA256}  /tmp/nodesource.key" | sha256sum -c - \
+  && gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg /tmp/nodesource.key \
+  && rm -f /tmp/nodesource.key \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update && apt-get install -y nodejs \

--- a/v2/deploy/nginx.conf
+++ b/v2/deploy/nginx.conf
@@ -45,6 +45,16 @@ http {
             add_header Cache-Control "no-store, no-cache, must-revalidate" always;
             add_header Pragma "no-cache" always;
 
+            # Defence-in-depth headers (issue #3822). X-Frame-Options is
+            # deliberately NOT set here: the Go dashboard (server.go) already
+            # sets it per-route (DENY, or omitted in favour of a CSP
+            # frame-ancestors allowlist for /api/snapshot/frame-ancestors), and
+            # a blanket nginx XFO would collide with that per-document logic.
+            # CSP is out of scope here too -- tracked separately as #3315.
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
+
             proxy_intercept_errors on;
             error_page 502 503 504 =503 @api_error;
         }
@@ -67,6 +77,12 @@ http {
             proxy_hide_header Pragma;
             add_header Cache-Control "no-store, no-cache, must-revalidate" always;
             add_header Pragma "no-cache" always;
+
+            # Defence-in-depth headers (issue #3822). See the /api/ location
+            # above for why X-Frame-Options and CSP are intentionally absent.
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
         }
     }
 }

--- a/v2/deploy/test_supply_chain_pins.sh
+++ b/v2/deploy/test_supply_chain_pins.sh
@@ -117,6 +117,32 @@ else
   pass "no compose service uses a :latest image tag"
 fi
 
+# --- 5. NodeSource GPG key must be pinned by SHA-256 before use --------------
+# issue #3821: the key used to be curl | gpg --dearmor with no verification, so
+# a compromised deb.nodesource.com or a build-network MITM could swap in a
+# trusted signing key silently. Guard both that the ARG is a real 64-hex-char
+# digest (not blank/placeholder) and that the RUN step actually verifies it
+# with sha256sum -c before dearmoring -- pinning the ARG alone without wiring
+# the check into the RUN would regress silently back to "trust on first use".
+nodesource_arg="$(grep -E '^[[:space:]]*ARG[[:space:]]+NODESOURCE_KEY_SHA256[[:space:]]*=' "$DOCKERFILE_CONTRIB" | head -1 || true)"
+if [ -z "$nodesource_arg" ]; then
+  fail "NODESOURCE_KEY_SHA256 is present and pinned" "no ARG NODESOURCE_KEY_SHA256 found in $DOCKERFILE_CONTRIB"
+else
+  nodesource_value="$(echo "${nodesource_arg#*=}" | tr -d ' "'"'"'')"
+  if echo "$nodesource_value" | grep -qE '^[0-9a-f]{64}$'; then
+    pass "NODESOURCE_KEY_SHA256 is pinned to a 64-hex-char digest"
+  else
+    fail "NODESOURCE_KEY_SHA256 is pinned to a 64-hex-char digest" "got: '$nodesource_value'"
+  fi
+fi
+
+if grep -A2 'NODESOURCE_KEY_SHA256}  /tmp/nodesource.key' "$DOCKERFILE_CONTRIB" | grep -q 'sha256sum -c'; then
+  pass "nodesource key fetch is verified with sha256sum -c before dearmoring"
+else
+  fail "nodesource key fetch is verified with sha256sum -c before dearmoring" \
+       "expected an 'echo \"\$NODESOURCE_KEY_SHA256  /tmp/nodesource.key\" | sha256sum -c -' step in $DOCKERFILE_CONTRIB"
+fi
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1

--- a/v2/pkg/config/gateway_nginx_dualstack_test.go
+++ b/v2/pkg/config/gateway_nginx_dualstack_test.go
@@ -72,3 +72,83 @@ func TestGatewayConfDoesNotRelyOnConfD(t *testing.T) {
 			"and the dual-stack rationale in TestGatewayListensDualStack needs review")
 	}
 }
+
+// gatewaySecurityHeaders pins the defence-in-depth headers added for issue
+// #3822. Each entry is a directive regex (must appear at least once per
+// `location` block, i.e. at least twice total in this file's two proxied
+// locations) paired with a human label for failure messages.
+//
+// X-Frame-Options and Content-Security-Policy are deliberately NOT included
+// here: the Go dashboard (pkg/dashboard/server.go) already sets XFO per-route
+// (DENY, or omits it in favour of a CSP frame-ancestors allowlist for
+// /api/snapshot/frame-ancestors), and a blanket nginx XFO would collide with
+// that per-document logic. CSP is tracked separately as issue #3315.
+// Strict-Transport-Security is also excluded: this file has no `ssl`/`443`
+// directive, so nginx never terminates TLS here, and asserting HSTS would
+// pin a header that describes a connection this config doesn't make.
+var gatewaySecurityHeaders = []struct {
+	label     string
+	directive *regexp.Regexp
+}{
+	{
+		label:     `X-Content-Type-Options: nosniff`,
+		directive: regexp.MustCompile(`(?m)^\s*add_header\s+X-Content-Type-Options\s+"nosniff"\s+always;`),
+	},
+	{
+		label:     `Referrer-Policy: strict-origin-when-cross-origin`,
+		directive: regexp.MustCompile(`(?m)^\s*add_header\s+Referrer-Policy\s+"strict-origin-when-cross-origin"\s+always;`),
+	},
+	{
+		label:     `Permissions-Policy`,
+		directive: regexp.MustCompile(`(?m)^\s*add_header\s+Permissions-Policy\s+"[^"]+"\s+always;`),
+	},
+}
+
+// gatewayProxiedLocationCount is the number of `location` blocks in
+// nginx.conf that proxy to hive_api and therefore must carry the
+// defence-in-depth headers (/api/ and /). The @api_error location returns a
+// static JSON body directly, not a proxied response, so it is not counted.
+const gatewayProxiedLocationCount = 2
+
+// TestGatewaySecurityHeadersPresent pins the fix for issue #3822: nginx.conf
+// must add defence-in-depth headers on every proxied response, not just
+// Cache-Control/Pragma. Requiring gatewayProxiedLocationCount occurrences
+// (not just >=1) ensures a future edit that trims the header from one
+// location while leaving it in another still fails loudly instead of passing
+// on a technicality.
+func TestGatewaySecurityHeadersPresent(t *testing.T) {
+	conf := readNginxConf(t)
+
+	for _, h := range gatewaySecurityHeaders {
+		t.Run(h.label, func(t *testing.T) {
+			matches := h.directive.FindAllString(conf, -1)
+			if len(matches) < gatewayProxiedLocationCount {
+				t.Errorf("nginx.conf has %d occurrence(s) of `%s`, want at least %d "+
+					"(one per proxied location) -- issue #3822 regressed",
+					len(matches), h.label, gatewayProxiedLocationCount)
+			}
+		})
+	}
+}
+
+// TestGatewayDoesNotSetFrameOptionsOrHSTS documents and guards a deliberate
+// omission from TestGatewaySecurityHeadersPresent: X-Frame-Options/CSP belong
+// to the Go dashboard's per-route logic (server.go) and HSTS is inapplicable
+// because this file never terminates TLS. If either shows up here, that's a
+// signal the rationale in the comment above gatewaySecurityHeaders needs a
+// fresh look (e.g. TLS termination moved into this file), not a silent green.
+func TestGatewayDoesNotSetFrameOptionsOrHSTS(t *testing.T) {
+	conf := readNginxConf(t)
+
+	if regexp.MustCompile(`(?m)^\s*add_header\s+X-Frame-Options\b`).MatchString(conf) {
+		t.Error("nginx.conf now sets X-Frame-Options -- this would collide with " +
+			"the Go dashboard's per-route XFO/CSP logic in pkg/dashboard/server.go; " +
+			"revisit the rationale in gatewaySecurityHeaders before allowing this")
+	}
+	if regexp.MustCompile(`(?m)^\s*add_header\s+Strict-Transport-Security\b`).MatchString(conf) {
+		t.Error("nginx.conf now sets Strict-Transport-Security but has no TLS " +
+			"(ssl/443) directive -- HSTS from a plaintext listener is misleading; " +
+			"if TLS termination moved into this file, HSTS is now appropriate and " +
+			"this guard should be updated instead of just deleted")
+	}
+}


### PR DESCRIPTION
Two unrelated low/medium sec-check hardening items, same class of change (supply-chain / defence-in-depth), landed together per the filing agent's grouping.

## #3822 — nginx.conf missing defence-in-depth headers

**Confirmed as filed.** `v2/deploy/nginx.conf` set only `Cache-Control`/`Pragma` on proxied responses (lines 43-46, 66-69 pre-fix). Added to both proxied `location` blocks:

- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: geolocation=(), camera=(), microphone=()`

**Deliberately NOT added:**
- **X-Frame-Options** — checked `pkg/dashboard/server.go`: it already sets XFO per-route (`DENY`, or omitted in favour of a CSP `frame-ancestors` allowlist for the `/api/snapshot/frame-ancestors` document — see `security_headers_test.go`). A blanket nginx XFO would collide with that per-document logic and could break whatever legitimately needs the allowlist path.
- **CSP** — out of scope per the task; tracked separately as #3315 (`unsafe-inline` / `DASHBOARD_TOKEN` inline-script injection needs its own change and testing).
- **HSTS** — this file has no `ssl`/`443` directive (verified via grep), so nginx never terminates TLS here. An HSTS header from a plaintext listener would misdescribe the connection, so it's omitted per the issue's own caveat ("when TLS terminates at nginx").

**Test:** added `TestGatewaySecurityHeadersPresent` (+ a companion `TestGatewayDoesNotSetFrameOptionsOrHSTS` guard that documents/enforces the omissions above) to `pkg/config/gateway_nginx_dualstack_test.go`, which already parses `nginx.conf` as text for the existing dual-stack listen test — same pattern. Verified it fails without the fix and passes with it (see PR description / commit message for verbatim output).

## #3821 — Dockerfile.contributor nodesource GPG key unpinned

**Confirmed as filed**, `v2/Dockerfile.contributor` line ~28-30: `curl -fsSL ... | gpg --dearmor -o ...` piped directly with zero verification.

**Fix:** download to a temp file, verify SHA-256 via `sha256sum -c` before dearmoring, remove the temp file. This mirrors the **existing** download-then-`sha256sum -c`-then-use pattern already in this same file for bobshell, Goose, and the Go toolchain (not invented for this PR). `NODESOURCE_KEY_SHA256` is pinned to the digest of the key currently published at the NodeSource URL, which matches NodeSource's documented fingerprint `6F71F525282841EEDAF851B42F59B5F99B1BE0B4`.

**Test:** extended `test_supply_chain_pins.sh` (the existing convention for guarding pins against silent regression, per its own header referencing #3443) to assert `NODESOURCE_KEY_SHA256` is a real 64-hex digest and that the RUN step actually wires `sha256sum -c` into the chain, not just declares the ARG. Fails without the fix (2/12), passes with it (12/12).

Also directly verified the runtime failure mode: ran the exact `sha256sum -c` command Docker's `RUN` would execute, once with the correct digest and once with a deliberately wrong one:

```
=== 1) Correct digest: should succeed ===
/tmp/nodesource.key: OK
VERIFICATION PASSED (as expected)
exit code: 0

=== 2) Deliberately WRONG digest: should fail loudly ===
sha256sum: WARNING: 1 computed checksum did NOT match
/tmp/nodesource.key: FAILED
exit code: 1
```

Under Docker's `RUN` (single shell, `&&`-chained), that non-zero exit aborts the layer before `gpg --dearmor` or `apt-get install nodejs` ever runs.

**Not verified:** a full Docker image build (no local daemon available in this environment — starting one plus a full multi-layer build was judged too slow for this change's scope, per task guidance to report honestly rather than claim it). The static Dockerfile syntax was reviewed by hand against the file's existing style and `go build ./...` / package tests pass; the RUN chain logic itself was verified standalone as above.

## Both

- `go build ./...` — passes.
- `go test ./pkg/config/...` — full package passes (all pre-existing tests + new ones).
- No `.go` files touched other than the new test additions.
- Rebased on latest `origin/v4` before push.

Fixes #3822
Fixes #3821