### PR TITLE
🐛 fix(hub): stop arming auto-upgrades the hub cannot deliver (pull-only wedge)

### DIFF
--- a/v2/pkg/hub/pullonly_upgrade.go
+++ b/v2/pkg/hub/pullonly_upgrade.go
@@ -1,0 +1,205 @@
+package hub
+
+import (
+	"sync"
+)
+
+// Auto-upgrade on a cluster the hub cannot write to.
+//
+// THE WEDGE THIS FILE EXISTS TO PREVENT. `vllm-d` and `a-ks-wec2` are declared
+// `pull_only` in clusters.json: the hub has no network path to one and no
+// `deployments.apps` RBAC on the other, and — per audit-8 F21 — is not MEANT to
+// have either. Giving the hub write access is explicitly out of scope. But
+// triggerAutoUpgrades() did not consult that declaration before ARMING an
+// upgrade. The resulting loop, measured live on 2026-08-14:
+//
+//  1. triggerAutoUpgrades() sees a hive behind latest with AutoUpgrade=true and
+//     calls beginUpgrade(): Upgrading=true, UpgradeStartedAt=now.
+//  2. rolloutRestartHive() returns false IMMEDIATELY — clusterRecentlyUnreachable()
+//     short-circuits on PullOnly by declaration, so not even a dial is attempted.
+//  3. The heartbeat fallback is armed instead. For the 26 hives actually seen
+//     wedged — unassigned placeholders that have never heartbeated — there is no
+//     spoke on the other end to consume it, so nothing ever converges.
+//  4. staleUpgradeTimeout (10m) passes. The stale-recovery branch re-arms. Because
+//     the target is unchanged, beginUpgrade() deliberately PRESERVES the original
+//     UpgradeStartedAt (so a thrashing retry still crosses the stuck threshold),
+//     so upgradeAge keeps growing rather than resetting.
+//  5. Nothing bounds this. sweepOrphanedUpgrades()'s retry budget
+//     (maxOrphanedUpgradeSweeps) is the mechanism that is SUPPOSED to convert a
+//     structurally-undeliverable upgrade into a visible UpgradeFailed, but
+//     evaluateOrphanedUpgrade() returns early on an unparseable LastHeartbeat —
+//     a hive that never heartbeated cannot prove its attempt is gone. So the
+//     budget is never spent, exhaustion never fires, and step 4 repeats forever.
+//
+// Measured result: 208 re-arms in 15 minutes, stale_minutes 90–104, hives reading
+// "offline" on the dashboard while showing "Upgrading 1h39m". The overlap was
+// exact — 26 hives stale, 26 hives with auto_upgrade on a pull-only cluster,
+// intersection 26, and zero stale hives outside that set.
+//
+// WHY REFUSING TO ARM IS THE RIGHT BEHAVIOUR, not tracking it by heartbeat.
+// A correct v4 target would have been equally undeliverable, so the wedge is not
+// about WHICH commit was chosen — it is about the hub instructing work it has no
+// mechanism to perform. Of the three candidate fixes, "track it by what the spoke
+// self-reports" still requires a spoke to be reporting, which is exactly what an
+// unassigned placeholder is not doing; it would fix the 3 assigned cases and leave
+// the 26 measured ones wedged. "Clear the flag on delivery failure" treats the
+// symptom one cycle later and still burns an arm/re-arm every 10 minutes forever.
+// Refusing at the ARM is the only one that makes the wedge unreachable rather than
+// merely self-healing, and it is honest: the spokes are NOT broken. They run
+// current code and self-derive every per-hive key from HIVE_HUB_SECRET + HIVE_ID.
+// A hub-pushed upgrade is an optimisation for them, never a dependency.
+//
+// AND IT MUST NOT BE SILENT. Silently skipping is how this went unnoticed for as
+// long as it did — a hive with auto_upgrade=true that simply never upgrades is
+// indistinguishable from one that is up to date. So the refusal is recorded on the
+// hive's timeline and surfaced through the same F21 reachability vocabulary the
+// per-hive env sweep already established (UnreachableHives / UnreachableClusters /
+// FleetFullyObserved on PerHiveEnvStatus): "the hub cannot reach this spoke" is a
+// state an operator must be able to SEE, never one that renders as "fine".
+//
+// This deliberately reuses clusterRecentlyUnreachable() rather than testing
+// PullOnly directly, so it is one notion of reachability, not a second one. That
+// predicate already returns true by DECLARATION for a pull-only cluster (no dial,
+// no timeout) and also covers a cluster inside the learned unreachable-breaker
+// window — an upgrade armed at a cluster the hub just failed to dial is just as
+// undeliverable as one aimed at a declared pull-only cluster, and wedges the same
+// way.
+
+// upgradeDeliverable reports whether the hub has any mechanism to DELIVER an
+// upgrade it arms for a hive on this cluster.
+//
+// The hub's only write path to a spoke is `kubectl rollout restart` against the
+// hive's Deployment. When the cluster is unreachable — declared pull_only, or
+// inside the learned unreachable window — that path does not exist, and the
+// heartbeat fallback is not a substitute the hub can rely on: it requires a spoke
+// that is already checking in, which an unassigned placeholder is not.
+//
+// A nil cluster is NOT deliverable. The caller already treats "no cluster config"
+// as a skip, and answering "deliverable" for a hive whose cluster cannot even be
+// resolved would arm an upgrade aimed at nothing.
+//
+// The caller must NOT hold s.mu: clusterRecentlyUnreachable takes
+// s.clusterUnreachableMu and reads s.clusters.
+func (s *HubServer) upgradeDeliverable(cluster *ClusterConfig) bool {
+	if cluster == nil {
+		return false
+	}
+	// An in-cluster hive is reachable through the hub's own API server; the
+	// unreachable breaker is about REMOTE clusters and is not consulted for it.
+	if cluster.InCluster {
+		return true
+	}
+	return !s.clusterRecentlyUnreachable(cluster.ID)
+}
+
+// undeliverableUpgradeReason explains, in operator-facing terms, why an upgrade
+// for a hive on this cluster cannot be armed. It names the cluster and the
+// declaration responsible so the log/timeline entry is actionable rather than a
+// bare "skipped". It never includes kubeconfig paths or credentials — cluster IDs
+// only, matching the UnreachableClusters convention.
+func (s *HubServer) undeliverableUpgradeReason(cluster *ClusterConfig) string {
+	if cluster == nil {
+		return "no cluster config resolved for this hive"
+	}
+	if cluster.PullOnly {
+		return "cluster " + cluster.ID + " is pull-only: the hub has no write path to this spoke, " +
+			"so an armed upgrade could never be delivered. The spoke is not broken — it self-derives " +
+			"its configuration and upgrades independently of the hub."
+	}
+	return "cluster " + cluster.ID + " is currently unreachable from the hub, " +
+		"so an armed upgrade could not be delivered"
+}
+
+// undeliverableUpgradeNoted remembers the (hive, target) pairs already written to
+// a timeline, so the refusal is recorded ONCE per target rather than on every
+// poll.
+//
+// This matters for the same reason the bug it fixes matters. StartLatestSHAPoller
+// ticks every latestSHAPollInterval (2m) and calls triggerAutoUpgrades() each
+// time, so an un-deduplicated timeline write would append an identical entry ~720
+// times a day per hive — trading an unbounded re-arm loop for an unbounded
+// timeline, and burying the genuine events a timeline exists to show. Keying on
+// the TARGET (not just the hive) means a genuinely new upgrade opportunity — the
+// branch advanced, so there is a new SHA the hive is now behind — is reported
+// again, while the same refusal is not repeated.
+//
+// Unbounded growth is not a concern at fleet scale: one entry per hive per
+// distinct target, and the entry is dropped as soon as the hive becomes
+// deliverable (forgetUndeliverableUpgrade), which is the transition that makes
+// the memory stale.
+var (
+	undeliverableUpgradeMu    sync.Mutex
+	undeliverableUpgradeNoted = map[string]string{}
+)
+
+// noteUndeliverableUpgrade records — once per (hive, target) — that the hub
+// declined to arm an upgrade it could not deliver, and why.
+//
+// The timeline is the durable, operator-visible surface: it is what makes this
+// refusal auditable after the fact, rather than a log line that ages out. Being
+// able to SEE that a hive is deliberately not being upgraded is the whole point;
+// silence here is what let the original wedge run unnoticed.
+func (s *HubServer) noteUndeliverableUpgrade(hiveID, target, reason string) {
+	undeliverableUpgradeMu.Lock()
+	if prev, ok := undeliverableUpgradeNoted[hiveID]; ok && prev == target {
+		undeliverableUpgradeMu.Unlock()
+		return
+	}
+	undeliverableUpgradeNoted[hiveID] = target
+	undeliverableUpgradeMu.Unlock()
+
+	s.recordTimeline(hiveID, TimelineUpgradeStale,
+		"auto-upgrade to "+orDash(target)+" not armed — "+reason, "auto-upgrade")
+}
+
+// upgradeBranchOrDefault resolves the branch whose latest SHA should be used as
+// an upgrade target for a hive reporting gitBranch.
+//
+// WHY THE OLD `if branch == "" { branch = "v2" }` WAS WRONG. That default was
+// written when v2 was the only branch. It is now a CROSS-BRANCH bug: a hive whose
+// GitBranch is unset — which is every unassigned placeholder, since
+// RegistryEntry.GitBranch is only ever populated from a heartbeat payload and a
+// placeholder has never heartbeated — had its upgrade target resolved against v2
+// while running on a v4 hub. That is exactly what was observed live: the target
+// issued was 0b78dc0, a commit that is on v2 and NOT on v4, while the hub's own
+// latest-shas.json correctly recorded v4=7cd059b. The hub was instructing spokes
+// to move to a commit that does not exist on their branch.
+//
+// It is a genuinely separate bug from the pull-only wedge and neither causes the
+// other: a CORRECT v4 target would have been equally undeliverable to a pull-only
+// cluster, so fixing this alone would not have unwedged anything. But it would
+// have made the wedge much easier to diagnose, and on a REACHABLE cluster it is
+// the more dangerous of the two — there, delivery succeeds, and the hub would be
+// rolling a v4 spoke onto a v2 build.
+//
+// The hub's OWN branch is the right fallback. It is what the hub is built from,
+// so it is the only branch the hub can honestly assume when the hive has not said
+// otherwise, and it makes the default self-correcting as the fleet moves between
+// branches instead of pinning a constant that silently rots. This mirrors the
+// existing precedent in StartLatestSHAPoller, which already stopped hardcoding
+// "v2" for the hub's own upgrade target for the same reason: "hardcoding here
+// made the badge and the poller disagree the moment a hub ran on v3".
+//
+// Falls back to "v2" only when the hub's own branch is somehow unset, preserving
+// the historical behaviour for a hub that cannot identify itself rather than
+// resolving against an empty branch (which returns no SHA and silently disables
+// upgrades).
+func (s *HubServer) upgradeBranchOrDefault(gitBranch string) string {
+	if gitBranch != "" {
+		return gitBranch
+	}
+	if s.hubGitBranch != "" {
+		return s.hubGitBranch
+	}
+	return "v2"
+}
+
+// forgetUndeliverableUpgrade drops the de-duplication memory for a hive, so that
+// if it later becomes undeliverable again the refusal is reported afresh rather
+// than suppressed by a stale entry from a previous episode. Called when a hive is
+// successfully armed — i.e. the condition has genuinely cleared.
+func forgetUndeliverableUpgrade(hiveID string) {
+	undeliverableUpgradeMu.Lock()
+	delete(undeliverableUpgradeNoted, hiveID)
+	undeliverableUpgradeMu.Unlock()
+}

--- a/v2/pkg/hub/pullonly_upgrade_test.go
+++ b/v2/pkg/hub/pullonly_upgrade_test.go
@@ -1,0 +1,387 @@
+package hub
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// These tests come in matched PAIRS. Every assertion that a pull-only hive must
+// NOT be armed/re-armed is accompanied by a positive control on a REACHABLE
+// cluster asserting the normal auto-upgrade still happens. Without that control,
+// a change that simply disabled auto-upgrade everywhere would pass the whole
+// file — which is the failure mode this repo has repeatedly shipped (a test that
+// passes for the wrong reason). The controls are what make the pull-only
+// assertions mean "refused BECAUSE undeliverable" rather than "nothing works".
+
+// pullOnlyTestServer builds a hub with one reachable remote cluster and one
+// declared pull-only cluster, plus a known latest SHA for branch v4.
+func pullOnlyTestServer(t *testing.T) *HubServer {
+	t.Helper()
+	resetSHACaches(t)
+	latestSHAMu.Lock()
+	latestSHAByBranch["v4"] = branchSHAInfo{SHA: "7cd059b"}
+	latestSHAMu.Unlock()
+
+	return &HubServer{
+		logger:       slog.Default(),
+		hubSecret:    testHubSecret,
+		hubGitBranch: "v4",
+		// A real store, so the surfacing assertions read the same path
+		// production writes rather than a stub that cannot fail.
+		timeline:         newTimelineStore(),
+		heartbeatUpgrade: make(map[string]string),
+		clusters: map[string]ClusterConfig{
+			// Reachable: a normal remote cluster with a kubeconfig.
+			"hive-oke": {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
+			// Undeliverable BY DECLARATION — audit-8 F21. The hub has no write
+			// path here and is not meant to have one.
+			"vllm-d": {ID: "vllm-d", PullOnly: true, Domain: "vllmd.example.cloud"},
+		},
+	}
+}
+
+// TestAutoUpgradeNotArmedForPullOnlyCluster is the primary assertion: the hub
+// must not ARM an upgrade it structurally cannot deliver. Arming one is what
+// latches Upgrading=true with no mechanism to ever clear it.
+func TestAutoUpgradeNotArmedForPullOnlyCluster(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ph-1")
+	saveSaaSHive(&SaaSHive{
+		ID: "ph-1", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	// Behind latest, so absent the pull-only check this WOULD be armed.
+	s.registry.Hives = []RegistryEntry{{ID: "ph-1", GitBranch: "v4", GitHash: "old1234"}}
+
+	s.triggerAutoUpgrades()
+
+	h := s.registry.Hives[0]
+	if h.Upgrading {
+		t.Error("armed an upgrade for a hive on a pull-only cluster: the hub has no write " +
+			"path to deliver it, so Upgrading=true can never be cleared and the hive " +
+			"wedges as perpetually 'Upgrading' while reading offline")
+	}
+	if h.UpgradeTarget != "" {
+		t.Errorf("UpgradeTarget = %q, want empty — nothing should be targeted", h.UpgradeTarget)
+	}
+	if got := s.heartbeatUpgrade["ph-1"]; got != "" {
+		t.Errorf("heartbeatUpgrade[ph-1] = %q, want empty — the heartbeat fallback must not "+
+			"be armed either; an unassigned placeholder has no spoke to consume it", got)
+	}
+}
+
+// TestAutoUpgradeStillArmedForReachableCluster is the POSITIVE CONTROL for the
+// test above. If this fails, the fix has disabled auto-upgrade generally rather
+// than refusing only the undeliverable case, and every other assertion in this
+// file is worthless.
+func TestAutoUpgradeStillArmedForReachableCluster(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	installScriptedKubectl(t)
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ok-1")
+	saveSaaSHive(&SaaSHive{
+		ID: "ok-1", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "hive-oke",
+	})
+	s.registry.Hives = []RegistryEntry{{ID: "ok-1", GitBranch: "v4", GitHash: "old1234"}}
+
+	s.triggerAutoUpgrades()
+
+	h := s.registry.Hives[0]
+	if !h.Upgrading {
+		t.Fatal("a hive on a REACHABLE cluster must still auto-upgrade normally — " +
+			"the pull-only refusal must be narrow, not a blanket disable")
+	}
+	if h.UpgradeTarget != "7cd059b" {
+		t.Errorf("UpgradeTarget = %q, want 7cd059b (latest for v4)", h.UpgradeTarget)
+	}
+}
+
+// TestStaleUpgradeNotReArmedForPullOnlyCluster covers the branch that actually
+// produced the measured damage: 208 re-arms in 15 minutes. A stale upgrade on a
+// cluster the hub cannot reach must be ABANDONED, not re-armed — re-arming
+// reproduces the identical no-op every staleUpgradeTimeout forever.
+func TestStaleUpgradeNotReArmedForPullOnlyCluster(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ph-2")
+	saveSaaSHive(&SaaSHive{
+		ID: "ph-2", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	// Already latched and long past staleUpgradeTimeout — the live shape, where
+	// stale_minutes was observed between 90 and 104.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "ph-2", GitBranch: "v4", GitHash: "old1234",
+		Upgrading: true, UpgradeTarget: "7cd059b",
+		UpgradeStartedAt: time.Now().Add(-99 * time.Minute),
+	}}
+	s.heartbeatUpgrade["ph-2"] = "7cd059b"
+
+	s.triggerAutoUpgrades()
+
+	h := s.registry.Hives[0]
+	if h.Upgrading {
+		t.Error("stale undeliverable upgrade was re-armed instead of abandoned — " +
+			"this is the 208-re-arms-in-15-minutes loop")
+	}
+	if !h.UpgradeStartedAt.IsZero() {
+		t.Error("UpgradeStartedAt must be zeroed when the latch is cleared, or the " +
+			"next cycle reads a stale elapsed and reports the hive stuck again")
+	}
+	if got := s.heartbeatUpgrade["ph-2"]; got != "" {
+		t.Errorf("heartbeatUpgrade[ph-2] = %q, want empty — the armed instruction must "+
+			"be dropped so no path keeps re-delivering it", got)
+	}
+}
+
+// TestStaleUpgradeStillRecoveredForReachableCluster is the POSITIVE CONTROL for
+// the abandonment above. Stale-upgrade recovery on a reachable cluster is a real
+// and valuable behaviour (#2476) and must survive.
+func TestStaleUpgradeStillRecoveredForReachableCluster(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	installScriptedKubectl(t)
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ok-2")
+	saveSaaSHive(&SaaSHive{
+		ID: "ok-2", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "hive-oke",
+	})
+	s.registry.Hives = []RegistryEntry{{
+		ID: "ok-2", GitBranch: "v4", GitHash: "old1234",
+		Upgrading: true, UpgradeTarget: "7cd059b",
+		UpgradeStartedAt: time.Now().Add(-99 * time.Minute),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	if !s.registry.Hives[0].Upgrading {
+		t.Fatal("a stale upgrade on a REACHABLE cluster must still be recovered/re-armed — " +
+			"abandonment must apply only where delivery is impossible")
+	}
+	if got := s.heartbeatUpgrade["ok-2"]; got != "7cd059b" {
+		t.Errorf("heartbeatUpgrade[ok-2] = %q, want 7cd059b — recovery must keep the "+
+			"instruction alive for a reachable hive", got)
+	}
+}
+
+// TestUndeliverableUpgradeCannotAccumulateStaleness is the invariant the whole
+// fix exists to establish, asserted the way the bug actually presented: over
+// REPEATED poll cycles.
+//
+// The original loop survived every individual-cycle check — each cycle looked
+// like a reasonable recovery. Only the accumulation was pathological: elapsed
+// climbing past 90 minutes while the hub re-armed 208 times. So this replays
+// many cycles and asserts the hive never latches at all, which is the only
+// formulation that would have caught the live behaviour.
+func TestUndeliverableUpgradeCannotAccumulateStaleness(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ph-3")
+	saveSaaSHive(&SaaSHive{
+		ID: "ph-3", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{{ID: "ph-3", GitBranch: "v4", GitHash: "old1234"}}
+
+	for cycle := 1; cycle <= 25; cycle++ {
+		s.triggerAutoUpgrades()
+		h := s.registry.Hives[0]
+		if h.Upgrading {
+			t.Fatalf("cycle %d: hive latched Upgrading — staleness is accumulating for an "+
+				"upgrade that can never be delivered", cycle)
+		}
+		if !h.UpgradeStartedAt.IsZero() {
+			t.Fatalf("cycle %d: UpgradeStartedAt is non-zero (%v) — the elapsed counter that "+
+				"reached 104 minutes live is being started again", cycle, h.UpgradeStartedAt)
+		}
+		if got := s.heartbeatUpgrade["ph-3"]; got != "" {
+			t.Fatalf("cycle %d: heartbeatUpgrade re-armed to %q — this is the re-arm loop",
+				cycle, got)
+		}
+	}
+}
+
+// TestUndeliverableUpgradeIsSurfacedNotSilent guards the second half of the fix.
+// Silently skipping is how the original wedge went unnoticed: a hive with
+// auto_upgrade=true that never upgrades looks exactly like one already at latest.
+// The refusal must leave an operator-visible record.
+func TestUndeliverableUpgradeIsSurfacedNotSilent(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ph-4")
+	saveSaaSHive(&SaaSHive{
+		ID: "ph-4", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{{ID: "ph-4", GitBranch: "v4", GitHash: "old1234"}}
+
+	s.triggerAutoUpgrades()
+
+	events := s.timeline.recent("ph-4", 100)
+	var found bool
+	for _, e := range events {
+		if e.Kind == TimelineUpgradeStale {
+			found = true
+			// The reason must NAME the cluster, or an operator reading it cannot
+			// act on it.
+			if !contains(e.Detail, "vllm-d") {
+				t.Errorf("timeline detail %q does not name the responsible cluster", e.Detail)
+			}
+			if !contains(e.Detail, "pull-only") {
+				t.Errorf("timeline detail %q does not explain WHY it was refused", e.Detail)
+			}
+		}
+	}
+	if !found {
+		t.Error("the refusal left NO timeline record — an operator cannot distinguish " +
+			"'deliberately not upgraded' from 'silently broken', which is exactly how " +
+			"this bug survived")
+	}
+}
+
+// TestUndeliverableRefusalIsDeduplicated stops the fix from trading an unbounded
+// re-arm loop for an unbounded timeline. StartLatestSHAPoller ticks every 2
+// minutes, so an un-deduplicated write would append ~720 identical entries per
+// hive per day and bury the genuine events.
+func TestUndeliverableRefusalIsDeduplicated(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ph-5")
+	saveSaaSHive(&SaaSHive{
+		ID: "ph-5", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{{ID: "ph-5", GitBranch: "v4", GitHash: "old1234"}}
+
+	for i := 0; i < 10; i++ {
+		s.triggerAutoUpgrades()
+	}
+
+	var stale int
+	for _, e := range s.timeline.recent("ph-5", 100) {
+		if e.Kind == TimelineUpgradeStale {
+			stale++
+		}
+	}
+	if stale != 1 {
+		t.Errorf("timeline recorded %d refusal entries across 10 identical cycles, want 1 — "+
+			"the refusal must be reported once per target, not once per poll", stale)
+	}
+}
+
+// TestUpgradeDeliverablePredicate pins the reachability predicate itself, and in
+// particular that it reuses the EXISTING clusterRecentlyUnreachable notion (the
+// F21 vocabulary) rather than introducing a second, divergent one.
+func TestUpgradeDeliverablePredicate(t *testing.T) {
+	s := &HubServer{
+		logger: slog.Default(),
+		clusters: map[string]ClusterConfig{
+			"in":   {ID: "in", InCluster: true},
+			"pull": {ID: "pull", PullOnly: true, Domain: "d"},
+			"rem":  {ID: "rem", KubeconfigPath: "/tmp/kc", Domain: "d"},
+		},
+		clusterUnreachableUntil: map[string]time.Time{},
+	}
+
+	cases := []struct {
+		name    string
+		cluster *ClusterConfig
+		want    bool
+	}{
+		{"nil cluster is not deliverable", nil, false},
+		{"in-cluster is deliverable", &ClusterConfig{ID: "in", InCluster: true}, true},
+		{"pull-only is never deliverable", &ClusterConfig{ID: "pull", PullOnly: true}, false},
+		{"reachable remote is deliverable", &ClusterConfig{ID: "rem", KubeconfigPath: "/tmp/kc"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.upgradeDeliverable(tc.cluster); got != tc.want {
+				t.Errorf("upgradeDeliverable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// A cluster inside the LEARNED unreachable window must also be undeliverable:
+	// an upgrade armed at a cluster the hub just failed to dial wedges exactly
+	// like one aimed at a declared pull-only cluster. This is the assertion that
+	// proves the predicate is the shared F21 notion, not a bare PullOnly test.
+	s.markClusterUnreachable("rem")
+	if s.upgradeDeliverable(&ClusterConfig{ID: "rem", KubeconfigPath: "/tmp/kc"}) {
+		t.Error("a cluster inside the unreachable breaker window must not be deliverable — " +
+			"upgradeDeliverable must reuse clusterRecentlyUnreachable, not re-test PullOnly")
+	}
+}
+
+// TestUpgradeBranchDefaultsToHubBranchNotV2 is the 0b78dc0 regression. A
+// placeholder that has never heartbeated has an empty GitBranch; the old
+// hardcoded `branch = "v2"` then resolved its target against v2 while running on
+// a v4 hub, which is how a v2-only commit was issued as a v4 hive's target.
+func TestUpgradeBranchDefaultsToHubBranchNotV2(t *testing.T) {
+	s := &HubServer{logger: slog.Default(), hubGitBranch: "v4"}
+
+	if got := s.upgradeBranchOrDefault(""); got != "v4" {
+		t.Errorf("upgradeBranchOrDefault(\"\") = %q, want v4 — an unset branch must resolve "+
+			"against the HUB's branch; defaulting to v2 on a v4 hub is what armed 0b78dc0, "+
+			"a commit that does not exist on v4", got)
+	}
+	// An explicitly reported branch always wins — the default must never override
+	// a hive that has told us what it runs.
+	if got := s.upgradeBranchOrDefault("v2"); got != "v2" {
+		t.Errorf("upgradeBranchOrDefault(\"v2\") = %q, want v2", got)
+	}
+	// A hub that cannot identify its own branch falls back to the historical
+	// constant rather than resolving against "" (which yields no SHA at all).
+	s2 := &HubServer{logger: slog.Default()}
+	if got := s2.upgradeBranchOrDefault(""); got != "v2" {
+		t.Errorf("with no hub branch, upgradeBranchOrDefault(\"\") = %q, want v2", got)
+	}
+}
+
+// TestPullOnlyHiveNeverTargetedWithForeignBranchSHA joins the two fixes at the
+// surface where they were both observed: a placeholder on a pull-only cluster
+// with no reported branch. It must be neither armed nor aimed at a v2 commit.
+func TestPullOnlyHiveNeverTargetedWithForeignBranchSHA(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUndeliverableUpgrade("ph-6")
+	// The v2 SHA that was actually being issued live.
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "0b78dc0"}
+	latestSHAMu.Unlock()
+
+	saveSaaSHive(&SaaSHive{
+		ID: "ph-6", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	// GitBranch deliberately EMPTY — the unassigned-placeholder shape.
+	s.registry.Hives = []RegistryEntry{{ID: "ph-6", GitHash: "old1234"}}
+
+	s.triggerAutoUpgrades()
+
+	h := s.registry.Hives[0]
+	if h.UpgradeTarget == "0b78dc0" {
+		t.Error("hive was targeted at 0b78dc0, a v2-only commit, from a v4 hub")
+	}
+	if h.Upgrading {
+		t.Error("hive on a pull-only cluster must not be latched Upgrading at all")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3877,10 +3877,7 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	var latestSHA string
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
-			branch := s.registry.Hives[i].GitBranch
-			if branch == "" {
-				branch = "v2"
-			}
+			branch := s.upgradeBranchOrDefault(s.registry.Hives[i].GitBranch)
 			latestSHA = getLatestSHAForBranch(branch)
 			s.beginUpgrade(i, latestSHA)
 			break
@@ -4380,9 +4377,7 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			}
 		}
 		s.mu.RUnlock()
-		if branch == "" {
-			branch = "v2"
-		}
+		branch = s.upgradeBranchOrDefault(branch)
 		latestSHA := getLatestSHAForBranch(branch)
 		if latestSHA != "" && currentSHA != "" && !sameCommit(currentSHA, latestSHA) {
 			s.logger.Info("audit: auto-upgrade initial trigger", "hive_id", id, "from", currentSHA, "to", latestSHA)
@@ -5196,9 +5191,11 @@ func (s *HubServer) triggerAutoUpgrades() {
 			}
 		}
 		s.mu.RUnlock()
-		if branch == "" {
-			branch = "v2"
-		}
+		// Resolve against the hub's own branch when the hive has not reported
+		// one, never a hardcoded "v2" — see upgradeBranchOrDefault. A hardcoded
+		// v2 is what armed 0b78dc0 (a v2-only commit) at placeholders on a v4
+		// hub.
+		branch = s.upgradeBranchOrDefault(branch)
 		if alreadyUpgrading {
 			// Floating-tag convergence. A hive whose Deployment tracks a MUTABLE
 			// tag (…-latest) has no stable target commit: a restart re-pulls the
@@ -5269,6 +5266,41 @@ func (s *HubServer) triggerAutoUpgrades() {
 			isStale := upgradeStartedAt.IsZero() || upgradeAge > staleUpgradeTimeout
 
 			if isStale {
+				// STRUCTURALLY UNDELIVERABLE: abandon, do not re-arm. This is
+				// the branch that produced the measured wedge — 208 re-arms in
+				// 15 minutes across 26 hives, stale_minutes climbing to 104 —
+				// because re-arming an upgrade the hub cannot deliver reproduces
+				// the identical no-op every staleUpgradeTimeout, forever, while
+				// beginUpgrade() preserves the original start clock so the
+				// elapsed only ever grows. The retry budget in
+				// sweepOrphanedUpgrades() cannot bound it: these hives never
+				// heartbeated, so evaluateOrphanedUpgrade() bails on the
+				// liveness test and the budget is never spent.
+				//
+				// Clearing the latch outright is what stops staleness
+				// accumulating. The hive stays on its old SHA — which is
+				// truthful and visible — instead of misreporting as
+				// perpetually "Upgrading" while reading offline. Nothing is
+				// lost: the spoke self-derives its configuration and upgrades
+				// independently of the hub, so the hub was never the thing
+				// keeping it current.
+				if !s.upgradeDeliverable(s.clusterForHive(&h)) {
+					reason := s.undeliverableUpgradeReason(s.clusterForHive(&h))
+					s.logger.Warn("abandoning stale upgrade — undeliverable, not re-arming",
+						"hive", h.ID, "stale_minutes", int(upgradeAge.Minutes()),
+						"target", upgradeTarget, "reason", reason)
+					s.mu.Lock()
+					for i := range s.registry.Hives {
+						if s.registry.Hives[i].ID == h.ID {
+							s.clearUpgradeLatch(i)
+							break
+						}
+					}
+					delete(s.heartbeatUpgrade, h.ID)
+					s.mu.Unlock()
+					s.noteUndeliverableUpgrade(h.ID, upgradeTarget, reason)
+					continue
+				}
 				// Upgrade has been stuck longer than staleUpgradeTimeout.
 				// Recover it. Two things can be wrong: (a) the target SHA
 				// contains a crashing bug a newer commit fixes — advance the
@@ -5401,6 +5433,30 @@ func (s *HubServer) triggerAutoUpgrades() {
 			s.logger.Warn("auto-upgrade skipped — no cluster config", "hive_id", h.ID, "cluster_id", h.ClusterID)
 			continue
 		}
+		// Do not ARM an upgrade the hub has no mechanism to deliver. Arming one
+		// latches Upgrading=true, and because rolloutRestartHive() cannot reach a
+		// pull-only cluster and the heartbeat fallback needs a spoke that is
+		// already checking in, nothing ever clears that latch: the stale-recovery
+		// branch above re-arms every staleUpgradeTimeout while beginUpgrade()
+		// preserves the original start clock, so the elapsed grows without bound
+		// and the hive reads "offline" while claiming to be upgrading. The
+		// orphan sweep's retry budget cannot rescue it either — a hive that never
+		// heartbeated fails evaluateOrphanedUpgrade()'s liveness test, so the
+		// budget is never spent and exhaustion never converts it to a visible
+		// failure. See pullonly_upgrade.go for the full measured loop.
+		//
+		// Refused LOUDLY, never silently: a hive with auto_upgrade=true that
+		// simply never upgrades is indistinguishable from one already at latest,
+		// which is how this stayed unnoticed. The timeline entry is the durable
+		// operator-visible record.
+		if !s.upgradeDeliverable(hiveCluster) {
+			reason := s.undeliverableUpgradeReason(hiveCluster)
+			s.logger.Warn("auto-upgrade not armed — undeliverable",
+				"hive_id", h.ID, "cluster", hiveCluster.ID, "branch", branch,
+				"from", currentSHA, "would_have_targeted", latestSHA, "reason", reason)
+			s.noteUndeliverableUpgrade(h.ID, latestSHA, reason)
+			continue
+		}
 		// Record the day's fire BEFORE kicking the rollout. Persisting first
 		// means a hub crash between here and the restart cannot cause a second
 		// upgrade for the same ET day; at worst the hive waits for tomorrow's
@@ -5419,6 +5475,9 @@ func (s *HubServer) triggerAutoUpgrades() {
 					"hive_id", h.ID, "date", decision.FireDate, "error", err)
 			}
 		}
+		// The hive is deliverable again — drop any suppressed-refusal memory so a
+		// future undeliverable episode is reported afresh rather than swallowed.
+		forgetUndeliverableUpgrade(h.ID)
 		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID, "mode", normalizeAutoUpgradeMode(h.AutoUpgradeMode))
 		s.recordTimeline(h.ID, TimelineUpgradeStarted,
 			fmt.Sprintf("auto-upgrade triggered on %s: %s → %s", branch, orDash(currentSHA), latestSHA), "auto-upgrade")

--- a/v2/pkg/hub/stale_upgrade.go
+++ b/v2/pkg/hub/stale_upgrade.go
@@ -240,10 +240,7 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		// Resolve the image-verified latest for this hive's branch so the
 		// evaluation can recognise a floating-tag hive that is already at latest
 		// (and must not be swept/re-rolled toward a specific historical target).
-		branch := h.GitBranch
-		if branch == "" {
-			branch = "v2"
-		}
+		branch := s.upgradeBranchOrDefault(h.GitBranch)
 		ev := evaluateOrphanedUpgrade(h, now, getLatestSHAForBranch(branch))
 		if !ev.orphaned {
 			continue


### PR DESCRIPTION
## The bug

Enabling auto-upgrade on a spoke whose cluster the hub cannot write to **wedges that spoke permanently**. It reads `offline` on the dashboard while showing `Upgrading 1h39m`, and the hub re-arms the same undeliverable instruction forever.

Measured live 2026-08-14, and **re-verified against the running hub** while preparing this PR:

| signal | value |
|---|---|
| distinct hives re-arming | **26** |
| hives with `auto_upgrade` on a pull-only cluster | **26** |
| overlap | **26** |
| stale hives *outside* that set | **0** |
| `stale_minutes` at re-verification | **146** (up from 90–104 — unbounded, not converging) |

The 26 are 21 `vllmd-*`, 3 `akswec2-*`, plus `kalantar-msb` and `osscar` (both also on `vllm-d`). `clusters.json` confirms only `vllm-d` and `a-ks-wec2` carry `pull_only: true`.

## The loop

1. `triggerAutoUpgrades()` arms an upgrade — `Upgrading=true`, start stamped.
2. `rolloutRestartHive()` returns false **immediately**: `clusterRecentlyUnreachable()` short-circuits on `PullOnly` by declaration, so no dial is even attempted.
3. The heartbeat fallback is armed instead — but the wedged hives are unassigned placeholders that have **never heartbeated**, so nothing consumes it.
4. `staleUpgradeTimeout` passes; stale-recovery re-arms. The target is unchanged, so `beginUpgrade()` deliberately *preserves* the original `UpgradeStartedAt` (correct for a thrashing retry) and the elapsed only ever **grows**.
5. `sweepOrphanedUpgrades()`'s retry budget — the mechanism meant to turn a structurally-undeliverable upgrade into a visible `UpgradeFailed` — **cannot bound it**: `evaluateOrphanedUpgrade()` returns early on an unparseable `LastHeartbeat`, so the budget is never spent and exhaustion never fires.

Confirmed on the live registry — the wedged entries carry no `git_branch`, no `last_heartbeat`, no `orphaned_upgrade_sweeps`, while `upgrading=true`.

## The behaviour chosen, and why

**Refuse to ARM what cannot be delivered**, rather than clearing the flag a cycle later.

Of the three options in play, refusing at the arm is the only one that makes the wedge *unreachable* rather than merely self-healing — and it is the honest one. **The spokes are not broken.** They self-derive every per-hive key from `HIVE_HUB_SECRET` + `HIVE_ID`, so a hub-pushed upgrade is an optimisation, never a dependency.

Tracking delivery by heartbeat instead would still require a spoke that is *reporting*, which an unassigned placeholder is not — it would have fixed the assigned cases and left the 26 measured ones wedged. Clearing on delivery failure treats the symptom and still burns an arm/re-arm every 10 minutes forever.

The refusal is **recorded on the timeline**, deduplicated per `(hive, target)`. Silence is exactly how this went unnoticed: a hive with `auto_upgrade=true` that never upgrades is indistinguishable from one already at latest. The dedup stops the fix trading an unbounded re-arm loop for an unbounded timeline (the poller ticks every 2 min).

**No hub write access is added or implied** — this strictly *reduces* what the hub attempts against pull-only clusters (audit-8 F21).

## Reuse of the F21 reachability signal

`upgradeDeliverable()` delegates to the existing `clusterRecentlyUnreachable()` predicate rather than re-testing `PullOnly`, so there is **one** notion of "can the hub reach this", not two. A cluster inside the *learned* unreachable-breaker window is therefore covered for free — it wedges identically. `TestUpgradeDeliverablePredicate` asserts exactly that, so a future refactor to a bare `PullOnly` check fails the test.

## Secondary finding: the `0b78dc0` v2 target — a real, separate bug

The target being issued was `0b78dc0`, **a commit on v2 that is not on v4**, while `latest-shas.json` correctly recorded `v4=7cd059b`.

Cause: `if branch == "" { branch = "v2" }`, a default from when v2 was the only branch. `RegistryEntry.GitBranch` is only ever populated from a heartbeat payload, so **every unassigned placeholder has an empty branch** and resolved its target against v2. Confirmed live — the issued target is byte-identical to the `v2` entry in `latest-shas.json`.

It is genuinely separate and neither bug causes the other: **a correct v4 target would have been equally undeliverable.** But on a *reachable* cluster it is the more dangerous of the two, because there delivery succeeds and the hub would roll a v4 spoke onto a v2 build. Cheap and clearly wrong, so fixed: upgrade-arming sites now resolve against the hub's own branch, mirroring the existing precedent in `StartLatestSHAPoller` ("hardcoding here made the badge and the poller disagree the moment a hub ran on v3"). The heartbeat path is untouched — there the spoke supplies its own branch.

## Tests

Matched **pairs**, so a "disable everything" change cannot pass:

| test | role |
|---|---|
| `TestAutoUpgradeNotArmedForPullOnlyCluster` | primary |
| `TestAutoUpgradeStillArmedForReachableCluster` | **positive control** |
| `TestStaleUpgradeNotReArmedForPullOnlyCluster` | the 208-re-arms branch |
| `TestStaleUpgradeStillRecoveredForReachableCluster` | **positive control** |
| `TestUndeliverableUpgradeCannotAccumulateStaleness` | 25 cycles — the accumulation invariant |
| `TestUndeliverableUpgradeIsSurfacedNotSilent` | not-silent |
| `TestUndeliverableRefusalIsDeduplicated` | timeline bounded |
| `TestUpgradeDeliverablePredicate` | pins F21 reuse |
| `TestUpgradeBranchDefaultsToHubBranchNotV2` | `0b78dc0` regression |
| `TestPullOnlyHiveNeverTargetedWithForeignBranchSHA` | both fixes joined |

The accumulation test replays **25 poll cycles**, because the original loop survived every single-cycle check — each cycle looked like a reasonable recovery, and only the accumulation was pathological. That is the only formulation that would have caught the live behaviour.

### Regression replay

Neutered `upgradeDeliverable()` to `return true` and restored the hardcoded v2 default — **still compiles** (`NEUTERED BUILD OK`). 8 of 10 fail:

```
--- FAIL: TestAutoUpgradeNotArmedForPullOnlyCluster (0.00s)
--- FAIL: TestStaleUpgradeNotReArmedForPullOnlyCluster (0.00s)
--- FAIL: TestUndeliverableUpgradeCannotAccumulateStaleness (0.00s)
--- FAIL: TestUndeliverableUpgradeIsSurfacedNotSilent (0.00s)
--- FAIL: TestUndeliverableRefusalIsDeduplicated (0.00s)
--- FAIL: TestUpgradeDeliverablePredicate (0.00s)
    --- FAIL: TestUpgradeDeliverablePredicate/pull-only_is_never_deliverable (0.00s)
--- FAIL: TestUpgradeBranchDefaultsToHubBranchNotV2 (0.00s)
--- FAIL: TestPullOnlyHiveNeverTargetedWithForeignBranchSHA (0.00s)
FAIL	github.com/kubestellar/hive/v2/pkg/hub	1.250s
```

The neutered run **reproduces the live log line verbatim**:

```
WARN re-arming heartbeat fallback for stale upgrade hive=ph-2 stale_minutes=99 target=7cd059b
    pullonly_upgrade_test.go:133: stale undeliverable upgrade was re-armed instead of abandoned — this is the 208-re-arms-in-15-minutes loop
    pullonly_upgrade_test.go:203: cycle 1: hive latched Upgrading — staleness is accumulating for an upgrade that can never be delivered
    pullonly_upgrade_test.go:340: upgradeBranchOrDefault("") = "v2", want v4 — an unset branch must resolve against the HUB's branch; defaulting to v2 on a v4 hub is what armed 0b78dc0, a commit that does not exist on v4
```

**The two positive controls still PASS while neutered** — they are absent from the failure list above. That is the check that matters: it proves they exercise the reachable path independently and are not passing merely because the pull-only path is broken.

Restored — all 10 green, and the full `pkg/hub` suite green (`ok ... 107.315s`, exit 0).

### On inverted tests

**No existing test asserted the wedging behaviour was acceptable**, so none needed inverting. Notably, *no* upgrade test referenced `PullOnly` at all — the two concerns had never been tested together, which is itself why this shipped.

## Notes

- `v2/pkg/hub/saas.go` is flagged by `gofmt` at line ~3053 (a map alignment) **on clean `origin/v4`**, before any change here. Pre-existing and unrelated; left untouched rather than mixing an unrelated reformat into this diff.
- Verification was **read-only kubectl throughout**; no cluster writes.
