### PR TITLE
🔒 fix(dashboard): encode JS-context values at the sink and pin CSP (#3315)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -624,6 +624,43 @@ func (s *Server) handleContributorDossierPage(w http.ResponseWriter, r *http.Req
 	s.handleContributeLanding(w, r)
 }
 
+// jsStringLiteral renders v as a complete, self-quoting JavaScript string
+// literal that is safe to emit inside an inline <script> element (#3315).
+//
+// Two distinct escapes are required and neither alone is sufficient:
+//
+//   - json.Marshal handles the JavaScript string grammar — quotes, backslashes,
+//     newlines and other control characters — so the value cannot terminate the
+//     literal. HTML escaping does NOT do this job: inside <script> the parser is
+//     in script data state, so "&#39;" is NOT decoded back to a quote and an
+//     html.EscapeString'd value is not protected at all.
+//   - JSON does not escape "/", so a value containing "</script>" would close
+//     the enclosing element before the JS parser ever sees the string. Breaking
+//     that byte sequence with "<\/" keeps the HTML tokenizer inside the script
+//     element while remaining the identical string value to JavaScript.
+//
+// The result INCLUDES its surrounding quotes, so callers must interpolate it
+// bare (var x=%s), never inside quotes of their own (var x='%s').
+func jsStringLiteral(v string) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		// json.Marshal only fails here for un-encodable types; a string is
+		// always encodable. Fail closed with an empty literal rather than
+		// emitting anything unescaped.
+		return `""`
+	}
+	out := string(b)
+	// Case-insensitively neutralize any "</script" and the HTML comment opener,
+	// both of which end script data state regardless of JS quoting.
+	out = scriptCloseRe.ReplaceAllString(out, `<\/$1`)
+	out = strings.ReplaceAll(out, "<!--", `<\!--`)
+	return out
+}
+
+// scriptCloseRe matches the "</" that begins a script-element end tag, in any
+// letter case, so it can be neutralized inside a JS string literal.
+var scriptCloseRe = regexp.MustCompile(`(?i)</(script)`)
+
 func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request) {
 	profiles := listContributorProfiles()
 	projectName := ""
@@ -737,6 +774,15 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 			customStyleNoticeHTML = `<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status">Custom style could not be loaded — using default <button type="button" onclick="this.parentElement.remove()">Dismiss</button></div>`
 		}
 	}
+
+	// SECURITY (#3315): encode the two values that land in a JS string context
+	// AT THE SINK. json.Marshal yields a complete, quoted JS string literal with
+	// quotes, backslashes, newlines and control characters escaped, so neither a
+	// hostile Host header nor a hostile project name can terminate the literal.
+	// Additionally neutralize "</script" (JSON does not escape "/"), which would
+	// otherwise close the enclosing <script> element regardless of JS quoting.
+	hubURLJS := jsStringLiteral(hubURL)
+	projectNameJS := jsStringLiteral(projectName)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>
@@ -1849,8 +1895,15 @@ var modeSel=document.getElementById('mode-select');
 var runtimeSel=document.getElementById('runtime-select');
 var runtimeGroup=document.getElementById('runtime-group');
 var cmds=document.getElementById('copy-cmds');
-var hubURL='%s';
-var ccProjectName='%s';
+// SECURITY (#3315): both values are JSON-encoded at the sink (they arrive as
+// complete JS string literals, quotes included) rather than being dropped raw
+// into '...' quotes. hubURL derives from X-Forwarded-Host/r.Host and
+// ccProjectName from operator config; both were previously kept safe only by
+// sanitizers ~1200 lines away (a charset filter and html.EscapeString), so a
+// change to either of those would silently have opened a script-literal
+// break-out here. HTML escaping is NOT sufficient in a script data context.
+var hubURL=%s;
+var ccProjectName=%s;
 // Shared with the second script block's IIFE (the dossier renderer lives there
 // and needs the project name for its masthead). Without this the bare reference
 // in renderMeCard resolves to nothing and every dossier render throws.
@@ -5834,7 +5887,7 @@ fetch('/api/version').then(function(r){return r.json()}).then(function(d){
   el.innerHTML=dot+' Hive v'+d.version+' ('+d.short+')' + (d.behind?' · <span style="color:#d29922">update available</span>':' · up to date');
 }).catch(function(){});
 </script>
-</body></html>`, projectName, michromaFontFaceCSS, customStyleHeadHTML, projectName, len(profiles), tierBoxes.String(), hubURL, hubURL, projectName, tierTableRows, customStyleNoticeHTML)
+</body></html>`, projectName, michromaFontFaceCSS, customStyleHeadHTML, projectName, len(profiles), tierBoxes.String(), hubURL, hubURLJS, projectNameJS, tierTableRows, customStyleNoticeHTML)
 }
 
 // ── Registration ───────────────────────────────────────────────────────────

--- a/v2/pkg/dashboard/csp_token_test.go
+++ b/v2/pkg/dashboard/csp_token_test.go
@@ -1,0 +1,371 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// cspDirective returns the named directive from a CSP header value, or "".
+func cspDirective(csp, name string) string {
+	for _, part := range strings.Split(csp, ";") {
+		part = strings.TrimSpace(part)
+		if part == name || strings.HasPrefix(part, name+" ") {
+			return part
+		}
+	}
+	return ""
+}
+
+// TestCSPDirectivesPinned locks the shape of the dashboard CSP (#3315).
+//
+// The finding paired script-src 'unsafe-inline' with a DASHBOARD_TOKEN written
+// into an inline <script>. The token half is fixed (the token is never rendered
+// into any response -- see TestDashboardTokenNeverRenderedIntoHTML below), so
+// what remains here is pinning the directives that DO NOT depend on inline
+// scripts, and making sure the rest cannot silently loosen further.
+func TestCSPDirectivesPinned(t *testing.T) {
+	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
+	handler := s.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("Content-Security-Policy header missing")
+	}
+
+	for _, want := range []string{
+		"default-src 'self'",
+		"object-src 'none'",
+		"base-uri 'self'",
+		// form-action was absent before #3315: without it an injected <form>
+		// could post operator input to an attacker origin. It does NOT depend
+		// on inline scripts, so it is enforced now rather than staged.
+		"form-action 'self'",
+		"frame-ancestors 'none'",
+	} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("CSP missing %q\n got: %s", want, csp)
+		}
+	}
+
+	// 'unsafe-eval' has never been needed and must never appear.
+	if strings.Contains(csp, "'unsafe-eval'") {
+		t.Errorf("CSP must never permit 'unsafe-eval'\n got: %s", csp)
+	}
+}
+
+// TestCSPScriptSrcUnsafeInlineIsStaged documents the REMAINING half of #3315.
+//
+// script-src still carries 'unsafe-inline' because the dashboard is
+// server-rendered HTML with roughly 400 inline on*= handlers plus several
+// inline <script> blocks (static/index.html, api_contribute.go, and the
+// device-flow login page in server.go). Removing the directive today blanks
+// the UI, so it is staged behind a nonce/handler-extraction refactor.
+//
+// This test is deliberately written as a TRIPWIRE, not an endorsement: when the
+// refactor lands, script-src loses 'unsafe-inline', this test FAILS, and whoever
+// does that work must invert it into the "must be absent" assertion below --
+// which is already written and enabled for the directives that are safe today.
+func TestCSPScriptSrcUnsafeInlineIsStaged(t *testing.T) {
+	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
+	handler := s.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	scriptSrc := cspDirective(rec.Header().Get("Content-Security-Policy"), "script-src")
+	if scriptSrc == "" {
+		t.Fatal("CSP must declare an explicit script-src directive")
+	}
+	if !strings.Contains(scriptSrc, "'self'") {
+		t.Errorf("script-src must allowlist 'self', got %q", scriptSrc)
+	}
+	if strings.Contains(scriptSrc, "'unsafe-eval'") {
+		t.Errorf("script-src must never permit 'unsafe-eval', got %q", scriptSrc)
+	}
+	if !strings.Contains(scriptSrc, "'unsafe-inline'") {
+		t.Fatalf("script-src no longer has 'unsafe-inline' (got %q).\n"+
+			"This is GOOD NEWS: the #3315 follow-up appears to have landed.\n"+
+			"Invert this test into an assertion that 'unsafe-inline' is ABSENT, "+
+			"so it can never come back.", scriptSrc)
+	}
+}
+
+// TestJSStringLiteralEscapesScriptContext covers the encode-at-the-sink helper
+// used for the values injected into the /contribute inline <script> (#3315),
+// in BOTH directions.
+func TestJSStringLiteralEscapesScriptContext(t *testing.T) {
+	// --- NEGATIVE: hostile inputs must not escape the script/string context ---
+	hostile := []struct {
+		name string
+		in   string
+	}{
+		{"closing script tag", `</script><script>alert(1)</script>`},
+		{"uppercase closing tag", `</SCRIPT><SCRIPT>alert(1)</SCRIPT>`},
+		{"mixed case closing tag", `</ScRiPt>`},
+		{"single quote", `it's`},
+		{"double quote", `say "hi"`},
+		{"backslash", `back\slash`},
+		{"backslash before quote", `trailing\`},
+		{"newline", "line1\nline2"},
+		{"carriage return", "line1\r\nline2"},
+		{"html comment opener", `<!--<script>`},
+		{"line separator", "a b"},
+		{"null byte", "a\x00b"},
+	}
+	for _, tc := range hostile {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jsStringLiteral(tc.in)
+
+			// Must be a quoted literal.
+			if len(got) < 2 || got[0] != '"' || got[len(got)-1] != '"' {
+				t.Fatalf("jsStringLiteral(%q) = %s, want a quoted JS string literal", tc.in, got)
+			}
+			// Must not contain a raw script end tag in ANY case, which would
+			// close the enclosing <script> element regardless of JS quoting.
+			if strings.Contains(strings.ToLower(got), "</script") {
+				t.Errorf("jsStringLiteral(%q) = %s, leaks a raw </script", tc.in, got)
+			}
+			if strings.Contains(got, "<!--") {
+				t.Errorf("jsStringLiteral(%q) = %s, leaks a raw <!-- comment opener", tc.in, got)
+			}
+			// Must not contain a literal newline/CR, which would terminate a JS
+			// string literal outright.
+			if strings.ContainsAny(got, "\n\r") {
+				t.Errorf("jsStringLiteral(%q) = %s, contains a raw newline", tc.in, got)
+			}
+			// The literal must round-trip back to EXACTLY the input: escaping
+			// must not silently corrupt or drop characters. This is what stops
+			// "mangle everything" from passing.
+			var back string
+			unescaped := strings.ReplaceAll(got, `<\/`, `</`)
+			unescaped = strings.ReplaceAll(unescaped, `<\!--`, `<!--`)
+			if err := json.Unmarshal([]byte(unescaped), &back); err != nil {
+				t.Fatalf("jsStringLiteral(%q) = %s, not valid JSON: %v", tc.in, got, err)
+			}
+			if back != tc.in {
+				t.Errorf("round-trip mismatch: got %q, want %q", back, tc.in)
+			}
+		})
+	}
+
+	// --- POSITIVE CONTROL: ordinary values survive intact and readable ---
+	benign := []struct {
+		in   string
+		want string
+	}{
+		{"kubestellar", `"kubestellar"`},
+		{"https://hub.example.com:8443", `"https://hub.example.com:8443"`},
+		{"", `""`},
+		{"my-project_1", `"my-project_1"`},
+	}
+	for _, tc := range benign {
+		got := jsStringLiteral(tc.in)
+		if got != tc.want {
+			t.Errorf("jsStringLiteral(%q) = %s, want %s (benign values must not be mangled)", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestContributeLandingEscapesInjectedJSValues is the end-to-end control: a
+// hostile Host header must not break out of the inline <script>, while a normal
+// request must still produce a working page.
+func TestContributeLandingEscapesInjectedJSValues(t *testing.T) {
+	srv := newFullServer(t)
+
+	// POSITIVE CONTROL FIRST: a normal request renders a usable page.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	req.Host = "hub.example.com"
+	srv.handleContributeLanding(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("contribute landing status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "var hubURL=") {
+		t.Error("contribute page must still declare hubURL")
+	}
+	if !strings.Contains(body, "var ccProjectName=") {
+		t.Error("contribute page must still declare ccProjectName")
+	}
+	if !strings.Contains(body, "hub.example.com") {
+		t.Error("contribute page must still carry the real hub URL (positive control)")
+	}
+	// Balanced script elements: the page must not have a stray unclosed block.
+	if opens, closes := countScriptElements(body); opens != closes {
+		t.Errorf("unbalanced script tags: %d open, %d close", opens, closes)
+	}
+
+	// The two JS-context values must be emitted as ENCODED literals (produced by
+	// jsStringLiteral, hence double-quoted), never dropped into hand-written
+	// single quotes. Both are additionally defended upstream -- hubURL by a
+	// charset filter (handleContributeLanding) and ccProjectName by
+	// html.EscapeString -- so a break-out is not reachable through them TODAY.
+	// That is exactly why this asserts on the encoding at the sink rather than
+	// on a payload: it is the invariant that survives someone relaxing either
+	// remote sanitizer, which is how this class of bug comes back.
+	if strings.Contains(body, `var hubURL='`) {
+		t.Error("hubURL must be JSON-encoded at the sink, not wrapped in hand-written quotes")
+	}
+	if strings.Contains(body, `var ccProjectName='`) {
+		t.Error("ccProjectName must be JSON-encoded at the sink, not wrapped in hand-written quotes")
+	}
+	if !strings.Contains(body, `var hubURL="`) {
+		t.Error("hubURL must be emitted as a JSON-encoded string literal")
+	}
+	if !strings.Contains(body, `var ccProjectName="`) {
+		t.Error("ccProjectName must be emitted as a JSON-encoded string literal")
+	}
+
+	// NEGATIVE: a hostile Host must not inject a script or break the literal.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	req2.Host = `evil.com'</script><script>alert(1)</script>`
+	req2.Header.Set("X-Forwarded-Host", `evil.com'</script><script>alert(1)</script>`)
+	srv.handleContributeLanding(rec2, req2)
+
+	body2 := rec2.Body.String()
+	if strings.Contains(body2, "alert(1)") {
+		t.Error("hostile Host header injected an executable payload into the page")
+	}
+	if strings.Contains(body2, `'</script><script>`) {
+		t.Error("hostile Host header broke out of the inline script context")
+	}
+	if opens, closes := countScriptElements(body2); opens != closes {
+		t.Errorf("hostile Host unbalanced script tags: %d open, %d close", opens, closes)
+	}
+
+	// The hostile page must have exactly as many script elements as the benign
+	// one: no more (nothing injected), no fewer (nothing swallowed).
+	benignOpens, _ := countScriptElements(body)
+	hostileOpens, _ := countScriptElements(body2)
+	if hostileOpens != benignOpens {
+		t.Errorf("hostile Host changed the script-element count: %d vs benign %d",
+			hostileOpens, benignOpens)
+	}
+}
+
+// countScriptElements counts real <script> start and end tags in HTML, ignoring
+// the sequence when it appears inside a JS line comment (the page's own source
+// comments mention "<script>" in prose, which is not a tag).
+func countScriptElements(body string) (opens, closes int) {
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "<!--") {
+			continue
+		}
+		opens += strings.Count(line, "<script>") + strings.Count(line, "<script ")
+		closes += strings.Count(line, "</script>")
+	}
+	return opens, closes
+}
+
+// TestDashboardTokenNeverRenderedIntoHTML is the Go-side half of the #3315
+// regression guard, with both-direction positive controls.
+//
+// NEGATIVE: a token full of script-breaking characters must not appear in a
+// response body in any form. POSITIVE CONTROL: the handler must still produce
+// a real, useful response -- otherwise "return nothing" would pass.
+func TestDashboardTokenNeverRenderedIntoHTML(t *testing.T) {
+	// SYNTHETIC token designed to escape an inline <script> string context.
+	// Never the real HIVE_DASHBOARD_TOKEN.
+	const hostile = "abc</script><script>alert('xss')</script>'\"\\\ndef"
+
+	t.Setenv("HIVE_DASHBOARD_TOKEN", hostile)
+
+	srv := newFullServer(t)
+	srv.authToken = hostile
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/token", nil)
+	srv.handleAuthToken(rec, req)
+
+	body := rec.Body.String()
+
+	// POSITIVE CONTROL: the endpoint must still answer usefully. On a plain
+	// self-hosted hive it reports WHETHER a token is configured. If it 404s
+	// (direct-route/hub-proxied), that is also a valid non-leaking answer --
+	// but it must do one of the two, not return an empty 200.
+	switch rec.Code {
+	case http.StatusOK:
+		if !strings.Contains(body, "configured") {
+			t.Errorf("auth/token must still report configured-ness, got %q", body)
+		}
+		if !strings.Contains(body, "true") {
+			t.Errorf("auth/token must report configured=true when a token is set, got %q", body)
+		}
+	case http.StatusNotFound:
+		// Fine: the token is not exposed on this deployment shape at all.
+	default:
+		t.Fatalf("unexpected status %d body %q", rec.Code, body)
+	}
+
+	// NEGATIVE: the token value must never come back, in any encoding.
+	if strings.Contains(body, hostile) {
+		t.Error("auth/token leaked the token verbatim")
+	}
+	if strings.Contains(body, "alert('xss')") {
+		t.Error("auth/token leaked attacker-controlled payload from the token")
+	}
+	// The distinctive core must not survive in any partial/escaped rendering.
+	if strings.Contains(body, "abc") && strings.Contains(body, "def") {
+		t.Errorf("auth/token appears to leak token material: %q", body)
+	}
+	// A leak via header would be just as bad.
+	for name, vals := range rec.Header() {
+		for _, v := range vals {
+			if strings.Contains(v, "abc") && strings.Contains(v, "def") {
+				t.Errorf("token material leaked via header %s: %q", name, v)
+			}
+		}
+	}
+}
+
+// TestDashboardTokenEndpointPositiveControl is the other direction: with an
+// ordinary token the endpoint must still work, so that a fix which simply
+// disabled the endpoint cannot pass the leak tests above.
+func TestDashboardTokenEndpointPositiveControl(t *testing.T) {
+	const normal = "plain-operator-token-1234"
+
+	t.Setenv("HIVE_DASHBOARD_TOKEN", normal)
+	srv := newFullServer(t)
+	srv.authToken = normal
+
+	rec := httptest.NewRecorder()
+	srv.handleAuthToken(rec, httptest.NewRequest(http.MethodGet, "/api/auth/token", nil))
+	body := rec.Body.String()
+
+	if rec.Code == http.StatusOK {
+		if !strings.Contains(body, "configured") {
+			t.Errorf("endpoint must report configured-ness, got %q", body)
+		}
+	} else if rec.Code != http.StatusNotFound {
+		t.Fatalf("unexpected status %d body %q", rec.Code, body)
+	}
+	// Still must not hand back the value.
+	if strings.Contains(body, normal) {
+		t.Errorf("endpoint must never return the token VALUE, got %q", body)
+	}
+
+	// And the unset case must report configured=false rather than erroring,
+	// proving the endpoint really is reading the token, not hard-coding a reply.
+	os.Unsetenv("HIVE_DASHBOARD_TOKEN")
+	srv2 := newFullServer(t)
+	srv2.authToken = ""
+	rec2 := httptest.NewRecorder()
+	srv2.handleAuthToken(rec2, httptest.NewRequest(http.MethodGet, "/api/auth/token", nil))
+	if rec2.Code == http.StatusOK && !strings.Contains(rec2.Body.String(), "false") {
+		t.Errorf("with no token configured the endpoint must report false, got %q", rec2.Body.String())
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -851,8 +851,20 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		}
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
+		// SECURITY (#3315): script-src still carries 'unsafe-inline' because the
+		// dashboard is server-rendered HTML with ~400 inline on*= handlers and
+		// several inline <script> blocks (static/index.html, api_contribute.go,
+		// the device-flow login page below). Dropping it today would blank the
+		// UI, so it is staged behind a nonce/handler refactor — see #3315.
+		//
+		// What IS enforced here: the secret that 'unsafe-inline' used to expose
+		// is gone. The dashboard token is never rendered into the page (see
+		// serveIndex in proxy/server.js and handleAuthToken in api.go), so an
+		// inline-script XSS has no token to steal from the served HTML.
+		// form-action 'self' is added to stop an injected <form> from posting
+		// credentials off-origin, which does NOT depend on inline scripts.
 		w.Header().Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors "+frameAncestors)
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors "+frameAncestors)
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		next.ServeHTTP(w, r)
 	})

--- a/v2/proxy/csp_token_injection.test.js
+++ b/v2/proxy/csp_token_injection.test.js
@@ -1,0 +1,253 @@
+import { createServer, request as httpRequest } from 'http';
+import { strict as assert } from 'assert';
+import { spawn } from 'child_process';
+import { writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import path from 'path';
+
+// Regression guard for #3315 — "CSP unsafe-inline + DASHBOARD_TOKEN inline
+// script injection".
+//
+// The historical bug: serveIndex rewrote the served index.html to append
+//   <script>if(!localStorage.getItem('hive-token'))
+//           localStorage.setItem('hive-token',<TOKEN>);</script>
+// so every visitor who could reach the port was handed the only API credential.
+// script-src 'unsafe-inline' is what let that inline block execute.
+//
+// These tests lock BOTH directions, so that neither "the token leaks" nor
+// "everything got escaped into uselessness" can pass:
+//   1. NEGATIVE: a token containing script-breaking characters must never
+//      appear in the served HTML, in any encoding, and must not be able to
+//      close the <script> context.
+//   2. POSITIVE CONTROL: with a perfectly ordinary token configured, the
+//      dashboard must STILL render its real content and still serve the CSP
+//      header. Without this control, a serveIndex that returned an empty body
+//      would satisfy every leak assertion.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROXY_PORT = 19051;
+const GO_PORT = 19052;
+const TTYD_PORT = 19053;
+
+// A token built to break out of an inline <script> string context: it carries a
+// closing script tag, both quote styles, a backslash and newlines. SYNTHETIC —
+// never the real HIVE_DASHBOARD_TOKEN.
+const HOSTILE_TOKEN = `abc</script><script>alert('xss')</script>'"\\\ndef`;
+const NORMAL_TOKEN = 'plain-operator-token-1234';
+
+// A recognisable marker so the positive control proves real page content came
+// back rather than an empty or error body.
+const INDEX_MARKER = 'hive-dashboard-index-marker';
+const INDEX_HTML = `<!doctype html><html><head><title>Hive</title></head>` +
+  `<body><div id="${INDEX_MARKER}">dashboard</div></body></html>`;
+
+let staticDir;
+let goServer;
+
+function setupMockGoBackend() {
+  const server = createServer((req, res) => {
+    if (req.url === '/api/snapshot/frame-ancestors') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ origins: [] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end('not found');
+  });
+  return new Promise((resolve) => server.listen(GO_PORT, () => resolve(server)));
+}
+
+function startProxy(extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        HIVE_PROXY_PORT: String(PROXY_PORT),
+        HIVE_API_PORT: String(GO_PORT),
+        HIVE_TTYD_PORT: String(TTYD_PORT),
+        HIVE_STATIC_DIR: staticDir,
+        NODE_ENV: 'test',
+        ...extraEnv,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', (d) => {
+      if (!started && d.toString().includes('hive-proxy')) {
+        started = true;
+        resolve(proc);
+      }
+    });
+    proc.stderr.on('data', (d) => { if (!started) console.error('proxy stderr:', d.toString()); });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('proxy start timeout')); }, 10000);
+  });
+}
+
+function get(pathname, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port: PROXY_PORT, path: pathname, method: 'GET', headers },
+      (res) => {
+        let body = '';
+        res.on('data', (c) => { body += c; });
+        res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function stop(proc) {
+  if (!proc) return;
+  proc.kill('SIGKILL');
+  await new Promise((r) => proc.once('exit', r));
+}
+
+async function main() {
+  staticDir = mkdtempSync(path.join(tmpdir(), 'hive-csp-test-'));
+  writeFileSync(path.join(staticDir, 'index.html'), INDEX_HTML);
+  goServer = await setupMockGoBackend();
+
+  // ---------------------------------------------------------------------
+  // 1. NEGATIVE: a script-breaking token must never reach the served HTML.
+  // ---------------------------------------------------------------------
+  let proxy = await startProxy({ HIVE_DASHBOARD_TOKEN: HOSTILE_TOKEN });
+  try {
+    const res = await get('/');
+    assert.equal(res.status, 200, 'dashboard index must be served');
+
+    // The token must not appear raw...
+    assert.ok(
+      !res.body.includes(HOSTILE_TOKEN),
+      'served HTML must not contain the dashboard token verbatim',
+    );
+    // ...nor in any of the encodings an "escaping" fix might have produced.
+    // A fix that merely escaped the token would still be leaking it.
+    assert.ok(
+      !res.body.includes(JSON.stringify(HOSTILE_TOKEN)),
+      'served HTML must not contain the dashboard token JSON-encoded',
+    );
+    assert.ok(
+      !res.body.includes(encodeURIComponent(HOSTILE_TOKEN)),
+      'served HTML must not contain the dashboard token URL-encoded',
+    );
+    // The distinctive secret core must not survive in ANY form. This catches
+    // partial/HTML-escaped renderings that the exact-match checks above miss.
+    assert.ok(
+      !/abc[\s\S]{0,80}def/.test(res.body),
+      'served HTML must not contain the dashboard token in any encoding',
+    );
+
+    // The historical injection sink itself must be gone.
+    assert.ok(
+      !/localStorage\s*\.\s*setItem\(\s*['"]hive-token['"]/.test(res.body),
+      "served HTML must not write 'hive-token' into localStorage",
+    );
+
+    // The hostile token must not have closed the <script> context: the page
+    // must carry no more script-open tags than it was authored with (zero).
+    const scriptOpens = (res.body.match(/<script/gi) || []).length;
+    assert.equal(scriptOpens, 0, 'no <script> tag may be injected into the served index');
+    assert.ok(!/alert\(/.test(res.body), 'no attacker payload may appear in the served HTML');
+    console.log('  ok: script-breaking token never reaches the served HTML');
+  } finally {
+    await stop(proxy);
+  }
+
+  // ---------------------------------------------------------------------
+  // 2. POSITIVE CONTROL: with a normal token the dashboard still works.
+  //    This is what stops "escape/blank everything" from passing test 1.
+  // ---------------------------------------------------------------------
+  proxy = await startProxy({ HIVE_DASHBOARD_TOKEN: NORMAL_TOKEN });
+  try {
+    const res = await get('/');
+    assert.equal(res.status, 200, 'dashboard index must still be served with a normal token');
+    assert.ok(
+      res.body.includes(INDEX_MARKER),
+      'dashboard must still render its real content (positive control)',
+    );
+    assert.ok(
+      res.body.includes('<title>Hive</title>'),
+      'dashboard HTML must be served intact, not stripped',
+    );
+    // ...and it still must not leak the token.
+    assert.ok(
+      !res.body.includes(NORMAL_TOKEN),
+      'an ordinary token must not be embedded in the served HTML either',
+    );
+
+    // A deep link (SPA fallback route) must render too, not just "/".
+    const deep = await get('/agents');
+    assert.equal(deep.status, 200, 'SPA fallback route must render');
+    assert.ok(deep.body.includes(INDEX_MARKER), 'SPA fallback must serve the dashboard');
+    assert.ok(!deep.body.includes(NORMAL_TOKEN), 'SPA fallback must not leak the token');
+    console.log('  ok: dashboard still renders normally and leaks nothing (positive control)');
+
+    // -------------------------------------------------------------------
+    // 3. CSP is still emitted, and its shape is pinned.
+    // -------------------------------------------------------------------
+    const csp = res.headers['content-security-policy'];
+    assert.ok(csp, 'Content-Security-Policy header must be present');
+    assert.match(csp, /default-src 'self'/, "CSP must set default-src 'self'");
+    assert.match(csp, /object-src 'none'/, "CSP must set object-src 'none'");
+    assert.match(csp, /base-uri 'self'/, "CSP must set base-uri 'self'");
+    assert.match(csp, /form-action 'self'/, "CSP must set form-action 'self'");
+    assert.match(csp, /frame-ancestors 'none'/, 'CSP must deny framing by default');
+
+    // #3315 STAGED: script-src still carries 'unsafe-inline' because the
+    // dashboard is server-rendered with ~400 inline on*= handlers and several
+    // inline <script> blocks. This assertion documents the remaining exposure
+    // and MUST be inverted to a "does not contain" check by the follow-up that
+    // moves those handlers out of the markup. Failing here means the refactor
+    // landed and this guard needs flipping -- see #3315.
+    const scriptSrc = csp.split(';').map(s => s.trim()).find(s => s.startsWith('script-src'));
+    assert.ok(scriptSrc, 'CSP must declare an explicit script-src');
+    assert.ok(
+      scriptSrc.includes("'self'"),
+      "script-src must allowlist 'self'",
+    );
+    assert.ok(
+      !scriptSrc.includes("'unsafe-eval'"),
+      "script-src must never permit 'unsafe-eval'",
+    );
+    // The token is no longer in the page, so 'unsafe-inline' no longer exposes
+    // it -- but object-src/base-uri/form-action must not regress either.
+    console.log('  ok: CSP present and pinned (script-src unsafe-inline staged, see #3315)');
+  } finally {
+    await stop(proxy);
+  }
+
+  // ---------------------------------------------------------------------
+  // 4. SOURCE GUARD: the injection sink must not come back.
+  // ---------------------------------------------------------------------
+  const { readFileSync } = await import('fs');
+  const src = readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+  assert.ok(
+    !/indexHtml\s*\.\s*replace\s*\(/.test(src),
+    'server.js must not rewrite the index HTML to inject anything',
+  );
+  assert.ok(
+    !/setItem\(\s*['"]hive-token['"]\s*,\s*\$\{/.test(src),
+    'server.js must not interpolate the token into an inline script',
+  );
+  console.log('  ok: token-injection sink absent from server.js');
+}
+
+main()
+  .then(() => {
+    goServer?.close();
+    if (staticDir) rmSync(staticDir, { recursive: true, force: true });
+    console.log('csp_token_injection.test.js: OK');
+    process.exit(0);
+  })
+  .catch((err) => {
+    goServer?.close();
+    if (staticDir) rmSync(staticDir, { recursive: true, force: true });
+    console.error('csp_token_injection.test.js: FAIL');
+    console.error(err);
+    process.exit(1);
+  });

--- a/v2/proxy/package.json
+++ b/v2/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js"
+    "test": "node server.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node csp_token_injection.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",


### PR DESCRIPTION
Fixes #3315

## What the finding claimed vs. what is on `v4`

The issue reports two coupled problems. They are in very different states, so this PR treats them separately.

### 1. `DASHBOARD_TOKEN` inline script injection — **REFUTED (already fixed), now locked**

The reported sink no longer exists on `v4`.

- `v2/proxy/server.js:928-937` — `serveIndex` sends `index.html` untouched. The `indexHtml.replace('</head>', injection + '</head>')` rewrite is gone (removed by `8ef94e33`).
- `v2/pkg/dashboard/api.go:8227-8252` — `handleAuthToken` returns only `{"configured": true|false}`, never the token value, and 404s entirely on direct-route / hub-proxied hives.

The token now reaches `localStorage` only when an operator pastes it (`static/index.html:3584`). **No test covered any of this**, so a revert would have been silent. This PR adds that coverage.

### 2. CSP `script-src 'unsafe-inline'` — **CONFIRMED, deliberately staged**

- `v2/pkg/dashboard/server.go:855` (Go dashboard)
- `v2/proxy/server.js:784` (Node proxy)

I did **not** remove it, and I want to be explicit about why rather than shipping a cosmetic change.

| Blocker | Count |
|---|---|
| Inline `on*=` handlers in `static/index.html` | 424 |
| Inline `on*=` handlers in `dashboard/index.html` | 105 |
| Inline `on*=` in Go-emitted HTML | 9 |
| Inline `<script>` blocks (static + Go) | 8 (largest ~17.6k lines) |
| CSP nonce plumbing in the repo | **none** |

The SPA is served by `http.FileServer` (`server.go:819`) from `//go:embed`, which cannot inject a per-request nonce. Removing `'unsafe-inline'` today blanks the dashboard. Per the "correct partial fix that ships beats a complete one that gets reverted" principle, it is staged behind a nonce/handler-extraction refactor.

Note `style-src 'unsafe-inline'` is a substantially larger lift (~2,055 inline `style=` attributes, which nonces do **not** cover) and should be decoupled from the `script-src` work.

## What this PR actually changes

**A real defect found while enumerating the CSP surface.** `hubURL` and `ccProjectName` were interpolated raw into *single-quoted JS string literals* inside the `/contribute` inline `<script>`:

```go
var hubURL='%s';
var ccProjectName='%s';
```

Neither was exploitable *today*, but only because of sanitizers ~1,200 lines away — a charset filter for `hubURL` and `html.EscapeString` for `ccProjectName`. That is safety-by-coincidence: relaxing either remote sanitizer silently reopens a script-literal break-out, and **HTML escaping is not sufficient in a script data context** regardless (`&#39;` is not decoded there). Both now encode **at the sink** via a new `jsStringLiteral` helper — `json.Marshal`, plus neutralizing `</script` and `<!--`, which JSON does not escape.

**CSP:** added `form-action 'self'` to the Go dashboard CSP. It was missing (the proxy CSP already had it), it stops an injected `<form>` posting credentials off-origin, and it does **not** depend on inline scripts.

## Tests

Go (`v2/pkg/dashboard/csp_token_test.go`):
- `TestCSPDirectivesPinned`
- `TestCSPScriptSrcUnsafeInlineIsStaged`
- `TestJSStringLiteralEscapesScriptContext` (12 subtests)
- `TestContributeLandingEscapesInjectedJSValues`
- `TestDashboardTokenNeverRenderedIntoHTML`
- `TestDashboardTokenEndpointPositiveControl`

Node (`v2/proxy/csp_token_injection.test.js`, wired into `npm test`) — boots the real proxy and asserts over live HTTP.

**Both-direction positive controls** are the point: the negative half feeds a token containing `</script>`, quotes, backslashes and newlines and asserts it never appears in any encoding; the positive half asserts the dashboard still renders real content, still serves its CSP, and still resolves SPA deep links with an ordinary token. Without that second half, "escape everything into uselessness" would pass.

`TestCSPScriptSrcUnsafeInlineIsStaged` is a **tripwire, not an endorsement**: it fails the moment the refactor lands, with instructions to invert it into a "must be absent" assertion so `unsafe-inline` can never silently return.

### Regression replay

Each fix was neutered so it still compiled and rendered, the specific test confirmed failing, then restored and confirmed green.

<details><summary>Replay 1 — naive quoting instead of <code>jsStringLiteral</code></summary>

```
--- FAIL: TestJSStringLiteralEscapesScriptContext/closing_script_tag
    jsStringLiteral("</script><script>alert(1)</script>") = "</script><script>alert(1)</script>", leaks a raw </script
--- FAIL: TestJSStringLiteralEscapesScriptContext/backslash
    jsStringLiteral("back\\slash") = "back\slash", not valid JSON: invalid character 's' in string escape code
--- FAIL: TestJSStringLiteralEscapesScriptContext/newline
    contains a raw newline
--- FAIL: TestJSStringLiteralEscapesScriptContext/html_comment_opener
    jsStringLiteral("<!--<script>") = "<!--<script>", leaks a raw <!-- comment opener
```
</details>

<details><summary>Replay 2 — revert the sink to <code>var hubURL='%s'</code></summary>

```
--- FAIL: TestContributeLandingEscapesInjectedJSValues (0.01s)
    csp_token_test.go:219: hubURL must be JSON-encoded at the sink, not wrapped in hand-written quotes
    csp_token_test.go:222: ccProjectName must be JSON-encoded at the sink, not wrapped in hand-written quotes
    csp_token_test.go:225: hubURL must be emitted as a JSON-encoded string literal
    csp_token_test.go:228: ccProjectName must be emitted as a JSON-encoded string literal
```
</details>

<details><summary>Replay 3 — drop <code>form-action</code></summary>

```
--- FAIL: TestCSPDirectivesPinned (0.00s)
    csp_token_test.go:56: CSP missing "form-action 'self'"
```
</details>

<details><summary>Replay 4 — tripwire fires when <code>unsafe-inline</code> is removed</summary>

```
--- FAIL: TestCSPScriptSrcUnsafeInlineIsStaged (0.00s)
    csp_token_test.go:97: script-src no longer has 'unsafe-inline' (got "script-src 'self'").
        This is GOOD NEWS: the #3315 follow-up appears to have landed.
        Invert this test into an assertion that 'unsafe-inline' is ABSENT, so it can never come back.
```
</details>

### Existing tests

No existing test asserted `unsafe-inline` or `script-src` at all, so nothing here relaxes a security assertion — none needed inverting. Six test files are structurally coupled to the inline `<script>` blocks (`contribute_ops_init_order_test.go`, `dossier_split_test.go`, `contribute_devlog_rail_test.go`, `api_leaderboard_style_test.go`, others); all still pass, and they will need updating by whoever does the nonce refactor.

## What remains for #3315

1. Extract the inline `<script>` blocks to external `.js` and convert ~530 `on*=` handlers to `addEventListener` (including those generated at runtime inside `innerHTML` template literals).
2. Replace the SPA `http.FileServer` with a handler that can thread a per-request nonce, or externalize both static blocks.
3. Drop `'unsafe-inline'` from `script-src` in **both** `server.go:855` and `proxy/server.js:784` in lockstep, and invert the tripwire test.
4. Separately, `style-src 'unsafe-inline'`.

## Scope / coordination

Kept strictly to the dashboard/CSP path. **No `nginx.conf` changes** — CSP there belongs to #3822, which is in flight. No `pkg/hub` changes.

`go build ./...` clean; `go test ./pkg/dashboard/` and the full `proxy` suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)