### PR TITLE
🐛 fix(hub+spoke): report the host the spoke's Route actually serves

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3273,6 +3273,21 @@ func main() {
 					if cfg.Hub.DashboardURL != "" {
 						return cfg.Hub.DashboardURL
 					}
+					// Prefer the host our OWN Route/Ingress actually serves.
+					//
+					// The synthesised "<hiveID>.<hub host>" below is only
+					// correct when this spoke is fronted by the hub's wildcard
+					// domain, i.e. co-located with the hub. On any other
+					// cluster that name resolves — via that same wildcard — to
+					// the HUB's router, which has no backend for it and returns
+					// 503, so the hub linked users at a hostname that could
+					// never work while our real Route served fine. Reading the
+					// live object is the only source that is right on every
+					// cluster, and on a pull-only cluster the hub cannot read
+					// it, so the spoke must report it.
+					if host := hub.SpokeServedHost(ctx); host != "" {
+						return "https://" + host
+					}
 					if cfg.HiveID != "" && cfg.Hub.URL != "" {
 						if u, err := url.Parse(cfg.Hub.URL); err == nil && u.Host != "" {
 							return fmt.Sprintf("https://%s.%s", cfg.HiveID, u.Host)

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -833,6 +833,17 @@ var (
 		nextProbe time.Time
 		result    *RouteExistenceCheck
 	}{}
+
+	// servedHostProbeCache memoises the spoke's own served-host discovery on
+	// the same cadence as the route-existence probe. The answer changes only
+	// when an operator recreates the spoke's Route/Ingress, so re-listing the
+	// namespace on every beat would be pure overhead against the API server.
+	servedHostProbeCache = struct {
+		sync.Mutex
+		nextProbe time.Time
+		host      string
+		probed    bool
+	}{}
 )
 
 func waitForReady(ctx context.Context, logger *slog.Logger) {
@@ -1352,6 +1363,132 @@ func ingressHostExists(ctx context.Context, client *http.Client, cfg *inClusterC
 		}
 	}
 	return false, false, ""
+}
+
+// spokeServedHost returns the external hostname the spoke's OWN Route or
+// Ingress actually serves, read from the in-cluster Kubernetes API, or "" when
+// it cannot be determined.
+//
+// This exists because the DashboardURL fallback used to synthesise
+// "<hiveID>.<hub's host>", which silently assumes every spoke is fronted by the
+// hub's own wildcard domain. That holds only for spokes co-located with the hub
+// (hive-oke, where *.hive.kubestellar.io IS the router). On any other cluster —
+// an OpenShift pool on *.apps.<cluster>, an IKS pool — the synthesised host
+// resolves, via the hub's wildcard, to the HUB's router, which has no backend
+// for that name and answers 503. The hub then linked users at a hostname that
+// could never work, while the spoke's real Route was serving fine all along.
+//
+// The spoke is the only party that can answer this on a pull-only cluster: the
+// hub has no kubectl path there by design, so it cannot read the Route. The
+// spoke reads its own namespace, which it can always do.
+//
+// Ingress is consulted before Route so a cluster carrying both resolves to the
+// same object the traffic path uses. Ordering matches routeExistenceProbe.
+//
+// Returns "" on any error, on an unknown/unsupported API, or when no host is
+// found — every caller must treat that as "no answer" and fall back, never as
+// an assertion that no route exists.
+func spokeServedHost(ctx context.Context) string {
+	now := time.Now()
+	servedHostProbeCache.Lock()
+	defer servedHostProbeCache.Unlock()
+	if servedHostProbeCache.probed && now.Before(servedHostProbeCache.nextProbe) {
+		return servedHostProbeCache.host
+	}
+
+	host := discoverSpokeServedHost(ctx)
+	servedHostProbeCache.probed = true
+	servedHostProbeCache.nextProbe = now.Add(routeExistenceProbeInterval)
+	servedHostProbeCache.host = host
+	return host
+}
+
+// SpokeServedHost is the exported entry point to spokeServedHost, used by the
+// spoke binary (cmd/hive) to resolve the dashboard URL it advertises to the hub
+// when no dashboard_url is configured. Returns "" when the host cannot be
+// determined; the caller must fall back rather than treat that as an answer.
+func SpokeServedHost(ctx context.Context) string { return spokeServedHost(ctx) }
+
+// discoverSpokeServedHost performs the uncached read behind spokeServedHost.
+func discoverSpokeServedHost(ctx context.Context) string {
+	cfg, err := inClusterAPIConfig()
+	if err != nil {
+		return ""
+	}
+	client, err := inClusterHTTPClient(cfg)
+	if err != nil {
+		return ""
+	}
+	if host := ingressServedHost(ctx, client, cfg); host != "" {
+		return host
+	}
+	return routeServedHost(ctx, client, cfg)
+}
+
+// ingressServedHost returns the first non-empty host on any Ingress rule in the
+// spoke's namespace.
+func ingressServedHost(ctx context.Context, client *http.Client, cfg *inClusterConfig) string {
+	var list struct {
+		Items []struct {
+			Spec struct {
+				Rules []struct {
+					Host string `json:"host"`
+				} `json:"rules"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if unknown, _ := listKubernetesResource(ctx, client, cfg,
+		"/apis/networking.k8s.io/v1/namespaces/"+url.PathEscape(cfg.Namespace)+"/ingresses", &list); unknown {
+		return ""
+	}
+	for _, item := range list.Items {
+		for _, rule := range item.Spec.Rules {
+			if host := strings.ToLower(strings.TrimSpace(rule.Host)); host != "" {
+				return host
+			}
+		}
+	}
+	return ""
+}
+
+// routeServedHost returns the host of the spoke's dashboard Route.
+//
+// The dashboard Route is selected BY NAME (routeBaseDashboard) rather than by
+// taking the first Route in the namespace, because the namespace also carries
+// the terminal Route and any "<base>-vanity" mirrors. Picking arbitrarily would
+// make the reported URL depend on list order and could advertise the terminal
+// host as the dashboard. Only if no Route bears that name does this fall back
+// to the first Route with a host, so a spoke provisioned under a different
+// naming convention still reports something reachable rather than nothing.
+func routeServedHost(ctx context.Context, client *http.Client, cfg *inClusterConfig) string {
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Host string `json:"host"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if unknown, _ := listKubernetesResource(ctx, client, cfg,
+		"/apis/route.openshift.io/v1/namespaces/"+url.PathEscape(cfg.Namespace)+"/routes", &list); unknown {
+		return ""
+	}
+	fallback := ""
+	for _, item := range list.Items {
+		host := strings.ToLower(strings.TrimSpace(item.Spec.Host))
+		if host == "" {
+			continue
+		}
+		if strings.TrimSpace(item.Metadata.Name) == routeBaseDashboard {
+			return host
+		}
+		if fallback == "" {
+			fallback = host
+		}
+	}
+	return fallback
 }
 
 func routeHostExists(ctx context.Context, client *http.Client, cfg *inClusterConfig, host string) (found, unknown bool, errText string) {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3452,7 +3452,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 		base = v
 	}
 	if base == "" && (strings.HasPrefix(id, "hosted-") || strings.HasPrefix(id, "saas-")) {
-		base = "https://" + id + ".hive.kubestellar.io"
+		base = s.placeholderHostURL(id)
 	}
 	if base == "" {
 		http.Error(w, `{"error":"hive has no reachable dashboard URL yet"}`, http.StatusConflict)
@@ -7292,6 +7292,35 @@ func claimedVanityURL(h *SaaSHive) string {
 		return ""
 	}
 	return h.VanityURL
+}
+
+// placeholderHostURL builds the "<hiveID>.<domain>" placeholder URL for a hive
+// that has not yet reported a dashboard URL, using the domain of the cluster
+// the hive actually lives on.
+//
+// The domain MUST come from the hive's own cluster rather than the hub's
+// hardcoded hive.kubestellar.io. That constant is the wildcard fronting the
+// HUB's router, so using it for a spoke on any other cluster produces a name
+// that resolves to the hub and 503s — the exact defect this path exhibited on
+// the OpenShift pool. Deriving it per-cluster is also what keeps this correct
+// for clusters added in future, without naming any of them here.
+//
+// Returns "" when the cluster (or its domain) is unknown, so the caller reports
+// "no reachable dashboard URL yet" instead of inventing an unreachable host.
+func (s *HubServer) placeholderHostURL(hiveID string) string {
+	// A hive with no meta record yet (mid-provision, or a registry-only entry)
+	// still resolves through clusterForHive, which falls back to the default
+	// cluster. That is the correct answer for it: with nothing recorded about
+	// where it lives, the hub's own pool is the only defensible guess, and it
+	// is the pool such a hive is in fact provisioned into.
+	cluster := s.clusterForHive(&SaaSHive{ID: hiveID})
+	if h := loadSaaSHive(hiveID); h != nil {
+		cluster = s.clusterForHive(h)
+	}
+	if cluster == nil || cluster.Domain == "" {
+		return ""
+	}
+	return "https://" + hiveID + "." + strings.Trim(strings.TrimSpace(cluster.Domain), ".")
 }
 
 // curAPIURL is the GitHub API base URL the spoke reports it is CURRENTLY using

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -90,7 +90,13 @@ func newHandlerHub() *HubServer {
 		hubBanners:         make(map[string]*HubBannerEntry),
 		heartbeatSwitchTag: make(map[string]string),
 		heartbeatUpgrade:   make(map[string]string),
-		clusters:           map[string]ClusterConfig{"hive-oke": {ID: "hive-oke"}},
+		// Domain is load-bearing, not decoration: the placeholder URL a hive
+		// with no reported dashboard URL falls back to is now derived from ITS
+		// OWN cluster's domain (placeholderHostURL) instead of a hardcoded
+		// hive.kubestellar.io. A cluster with no domain therefore yields no
+		// URL at all — which is the correct fail-closed answer, and is why this
+		// fixture must name the domain it is standing in for.
+		clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", Domain: "hive.kubestellar.io"}},
 	}
 }
 
@@ -174,6 +180,13 @@ func TestHandleOpenHive(t *testing.T) {
 	s.handleOpenHive(rec, req)
 	if rec.Code != http.StatusSeeOther || !strings.Contains(rec.Header().Get("Location"), "/sso?token=") {
 		t.Errorf("admin open: status=%d loc=%q", rec.Code, rec.Header().Get("Location"))
+	}
+	// INVERTED (not relaxed): this used to assert only that SOME /sso?token=
+	// redirect happened, which passed just as happily when the host was
+	// unreachable — the 503 bug. Assert the HOST too: it must be the one this
+	// hive's own cluster serves.
+	if loc := rec.Header().Get("Location"); !strings.HasPrefix(loc, "https://hosted-abc.hive.kubestellar.io/sso?token=") {
+		t.Errorf("admin open must hand off to the host the hive's cluster serves, got %q", loc)
 	}
 
 	// Non-owner, non-authorized -> access denied.

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -2324,6 +2324,51 @@ subjects:
 {{- end}}
   namespace: {{.Namespace}}
 ---
+# hive-route-reader lets the spoke discover the external hostname its OWN
+# Route/Ingress serves, which it reports to the hub as dashboard_url (see
+# SpokeServedHost). Without it the spoke falls back to synthesising
+# "<hiveID>.<hub host>" — correct only for spokes fronted by the hub's wildcard
+# domain, and a guaranteed 503 anywhere else, because that wildcard sends the
+# name to the HUB's router which has no backend for it.
+#
+# The spoke is the only party that CAN read this on a pull-only cluster, where
+# the hub has no kubectl path by design. Strictly read-only and namespace-scoped:
+# list/get, no write verbs, so a compromised spoke learns only its own hostname
+# — which it already advertises — and can neither create nor retarget routing.
+# Routes are included unconditionally rather than under RequiresSCC: a cluster
+# can serve Routes without requiring an SCC, and a Role naming a CRD-backed
+# resource is inert on clusters where that API is absent.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hive-route-reader
+  namespace: {{.Namespace}}
+rules:
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get", "list"]
+- apiGroups: ["route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-route-reader
+  namespace: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hive-route-reader
+subjects:
+- kind: ServiceAccount
+{{- if .RequiresSCC}}
+  name: hive-sa
+{{- else}}
+  name: default
+{{- end}}
+  namespace: {{.Namespace}}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/v2/pkg/hub/spoke_served_host_test.go
+++ b/v2/pkg/hub/spoke_served_host_test.go
@@ -1,0 +1,252 @@
+package hub
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ============================================================
+// Unreachable spoke URL: the hub linked a host no Route serves.
+//
+// The spoke's dashboard_url fallback synthesised "<hiveID>.<hub host>". That is
+// only correct when the spoke is fronted by the hub's OWN wildcard domain
+// (hive-oke, where *.hive.kubestellar.io IS the router). On the OpenShift pool
+// the spoke's real Route serves
+// hosted-available-vllmd-260806-5q6l.apps.fmaas-vllm-d.fmaas.res.ibm.com, but
+// the hub linked hosted-available-vllmd-260806-5q6l.hive.kubestellar.io — a
+// name the shared wildcard resolves to the HUB's router, which has no backend
+// for it and answers 503.
+//
+// Measured live 2026-08-14 and the reason the fix reads the live object:
+//   - dig random-nonexistent-xyz.hive.kubestellar.io -> 157.151.252.29 (the hub
+//     router). The wildcard answers for ANY name, so DNS resolving proves
+//     nothing about reachability.
+//   - curl https://hosted-available-vllmd-260806-5q6l.hive.kubestellar.io/ -> 000
+//   - curl https://hosted-available-vllmd-260806-5q6l.apps.fmaas-vllm-d...   -> 401
+//
+// Both directions are asserted here. A spoke whose Ingress genuinely carries a
+// hub-domain host must still report it (the hive-oke positive control, 67/67
+// working ingresses that must not regress), and a spoke on a foreign cluster
+// must report its own router's host.
+// ============================================================
+
+const (
+	// servedHostOKEDomain is the hub's own wildcard domain — the ONLY domain
+	// for which the old synthesised host was ever correct.
+	servedHostOKEDomain = "hive.kubestellar.io"
+	// servedHostOpenShiftDomain is the OpenShift pool's wildcard apps domain.
+	servedHostOpenShiftDomain = "apps.fmaas-vllm-d.fmaas.res.ibm.com"
+)
+
+// fakeKubeAPI stands in for the in-cluster Kubernetes API. It serves the two
+// list endpoints the served-host discovery reads and 404s everything else, so a
+// test cannot pass by way of a request the real code would never make.
+type fakeKubeAPI struct {
+	ingressHosts []string
+	routes       []fakeRoute
+	// ingressStatus/routeStatus override the response code, used to simulate a
+	// cluster with no Route API (404) or an RBAC denial (403).
+	ingressStatus int
+	routeStatus   int
+}
+
+type fakeRoute struct {
+	name string
+	host string
+}
+
+func (f *fakeKubeAPI) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/ingresses"):
+			if f.ingressStatus != 0 {
+				w.WriteHeader(f.ingressStatus)
+				return
+			}
+			type rule struct {
+				Host string `json:"host"`
+			}
+			out := map[string]any{"items": []any{}}
+			items := []any{}
+			for _, h := range f.ingressHosts {
+				items = append(items, map[string]any{
+					"spec": map[string]any{"rules": []rule{{Host: h}}},
+				})
+			}
+			out["items"] = items
+			_ = json.NewEncoder(w).Encode(out)
+		case strings.HasSuffix(r.URL.Path, "/routes"):
+			if f.routeStatus != 0 {
+				w.WriteHeader(f.routeStatus)
+				return
+			}
+			items := []any{}
+			for _, rt := range f.routes {
+				items = append(items, map[string]any{
+					"metadata": map[string]any{"name": rt.name},
+					"spec":     map[string]any{"host": rt.host},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+// newFakeKubeConfig points the discovery helpers at a test server.
+func newFakeKubeConfig(t *testing.T, api *fakeKubeAPI) (*http.Client, *inClusterConfig) {
+	t.Helper()
+	srv := httptest.NewServer(api.handler())
+	t.Cleanup(srv.Close)
+	return srv.Client(), &inClusterConfig{
+		BaseURL:   srv.URL,
+		Token:     "test-token",
+		Namespace: "hive-hosted-test",
+	}
+}
+
+// POSITIVE CONTROL A (must keep working): a spoke on the hub's own cluster
+// carries a hub-domain host on its Ingress, and that is exactly what it must
+// report. This is the 67/67 hive-oke case; if this test ever fails, the fix has
+// broken the working fleet.
+func TestSpokeServedHost_HubDomainIngressIsReported(t *testing.T) {
+	wantHost := "hosted-aslom-hive-agent-ua5i." + servedHostOKEDomain
+	client, cfg := newFakeKubeConfig(t, &fakeKubeAPI{
+		ingressHosts: []string{wantHost},
+	})
+	got := ingressServedHost(t.Context(), client, cfg)
+	if got != wantHost {
+		t.Errorf("hive-oke spoke must report its own Ingress host %q, got %q", wantHost, got)
+	}
+	if !strings.HasSuffix(got, servedHostOKEDomain) {
+		t.Errorf("expected a host on the hub domain %q, got %q", servedHostOKEDomain, got)
+	}
+}
+
+// POSITIVE CONTROL B (the regression): a spoke on a foreign OpenShift cluster
+// must report the host its own Route serves, NOT a hub-domain name.
+func TestSpokeServedHost_OpenShiftRouteHostIsReported(t *testing.T) {
+	wantHost := "hosted-available-vllmd-260806-5q6l." + servedHostOpenShiftDomain
+	client, cfg := newFakeKubeConfig(t, &fakeKubeAPI{
+		// No Ingress on this cluster; the dashboard Route is the source.
+		routes: []fakeRoute{
+			{name: routeBaseDashboard, host: wantHost},
+			{name: "hive-terminal", host: wantHost},
+		},
+	})
+	got := routeServedHost(t.Context(), client, cfg)
+	if got != wantHost {
+		t.Errorf("OpenShift spoke must report its Route host %q, got %q", wantHost, got)
+	}
+	// The heart of the bug: the reported host must NOT be on the hub's wildcard,
+	// which would resolve to the hub's router and 503.
+	if strings.HasSuffix(got, servedHostOKEDomain) {
+		t.Errorf("reported host %q is on the hub wildcard %q — this is the 503 regression",
+			got, servedHostOKEDomain)
+	}
+}
+
+// The dashboard Route must be selected BY NAME. A namespace carries the
+// terminal Route and "-vanity" mirrors too, so picking the first item would
+// make the advertised URL depend on list order and could advertise the terminal
+// host as the dashboard.
+func TestSpokeServedHost_PrefersDashboardRouteByName(t *testing.T) {
+	dashboard := "hosted-available-vllmd-01." + servedHostOpenShiftDomain
+	client, cfg := newFakeKubeConfig(t, &fakeKubeAPI{
+		routes: []fakeRoute{
+			// Deliberately ordered so a naive "first item" read picks wrong.
+			{name: "hive-terminal", host: "terminal-host." + servedHostOpenShiftDomain},
+			{name: "hive-dashboard-vanity", host: "vanity-host." + servedHostOpenShiftDomain},
+			{name: routeBaseDashboard, host: dashboard},
+		},
+	})
+	if got := routeServedHost(t.Context(), client, cfg); got != dashboard {
+		t.Errorf("expected the %s Route host %q, got %q", routeBaseDashboard, dashboard, got)
+	}
+}
+
+// An RBAC denial or a cluster with no Route API must yield "" — "no answer" —
+// so the caller falls back, rather than an assertion that no route exists.
+func TestSpokeServedHost_UnknownAPIYieldsEmpty(t *testing.T) {
+	client, cfg := newFakeKubeConfig(t, &fakeKubeAPI{
+		ingressStatus: http.StatusForbidden,
+		routeStatus:   http.StatusNotFound,
+	})
+	if got := ingressServedHost(t.Context(), client, cfg); got != "" {
+		t.Errorf("an RBAC denial must yield \"\", got %q", got)
+	}
+	if got := routeServedHost(t.Context(), client, cfg); got != "" {
+		t.Errorf("a missing Route API must yield \"\", got %q", got)
+	}
+}
+
+// placeholderHostURL must derive the domain from the hive's OWN cluster. The
+// hardcoded hive.kubestellar.io it replaced is the hub's wildcard, so using it
+// for a spoke elsewhere mints a host that resolves to the hub and 503s.
+func TestPlaceholderHostURL_UsesTheHivesOwnClusterDomain(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	s := &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {ID: defaultClusterID, Domain: servedHostOKEDomain, IngressType: "nginx"},
+			"openshift-pool": {ID: "openshift-pool", Domain: servedHostOpenShiftDomain, IngressType: ingressTypeOpenShiftRoute, PullOnly: true},
+		},
+	}
+
+	// Positive control A: a hive on the hub's own cluster keeps the hub domain.
+	okeHive := &SaaSHive{ID: "hosted-oke-spoke-aaaa", Status: "running", ClusterID: defaultClusterID}
+	if err := saveSaaSHive(okeHive); err != nil {
+		t.Fatal(err)
+	}
+	wantOKE := "https://hosted-oke-spoke-aaaa." + servedHostOKEDomain
+	if got := s.placeholderHostURL(okeHive.ID); got != wantOKE {
+		t.Errorf("hub-cluster hive: expected %q, got %q", wantOKE, got)
+	}
+
+	// Positive control B: a hive on the pull-only OpenShift pool must get that
+	// pool's domain, never the hub's.
+	osHive := &SaaSHive{ID: "hosted-available-vllmd-260806-5q6l", Status: "running", ClusterID: "openshift-pool"}
+	if err := saveSaaSHive(osHive); err != nil {
+		t.Fatal(err)
+	}
+	wantOS := "https://hosted-available-vllmd-260806-5q6l." + servedHostOpenShiftDomain
+	got := s.placeholderHostURL(osHive.ID)
+	if got != wantOS {
+		t.Errorf("openshift-pool hive: expected %q, got %q", wantOS, got)
+	}
+	if strings.HasSuffix(strings.TrimPrefix(got, "https://"), servedHostOKEDomain) {
+		t.Errorf("openshift-pool hive got a hub-wildcard host %q — this is the 503 regression", got)
+	}
+}
+
+// A hive whose cluster (or cluster domain) is unknown must yield "" so the
+// caller reports "no reachable dashboard URL yet" instead of inventing an
+// unreachable host.
+func TestPlaceholderHostURL_UnknownClusterYieldsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	s := &HubServer{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{},
+	}
+	h := &SaaSHive{ID: "hosted-orphan-spoke-bbbb", Status: "running", ClusterID: "gone"}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.placeholderHostURL(h.ID); got != "" {
+		t.Errorf("expected \"\" for a hive with no known cluster, got %q", got)
+	}
+}


### PR DESCRIPTION
## Symptom

Clicking through to a spoke on the OpenShift pool returned a branded 503 "Hive Restarting" page. The hub minted SSO links at `hosted-available-vllmd-260806-5q6l.hive.kubestellar.io` while the spoke's Route served `hosted-available-vllmd-260806-5q6l.apps.fmaas-vllm-d.fmaas.res.ibm.com`.

## Measured live (2026-08-14, read-only)

```
dig random-nonexistent-xyz.hive.kubestellar.io            -> 157.151.252.29
curl https://...-5q6l.hive.kubestellar.io/                -> 000
curl https://...-5q6l.apps.fmaas-vllm-d.fmaas.res.ibm.com -> 401   (healthy: OAuth proxy)
```

`*.hive.kubestellar.io` is a **wildcard onto the hub's own router**. It answers for *any* name, so the bad host resolved fine and simply had no backend there — the spoke it named lives on a different cluster. DNS resolving proves nothing here.

Cluster state (read-only): vllm-d has 101 hive Routes, **0** on the vanity domain; hive-oke has 67 hive Ingresses, all on it.

## Regression point

`f4e0aa6a` (#1623, 2026-06-18) — the spoke's `dashboard_url` fallback synthesises `"<hiveID>.<hub host>"`, correct only for spokes fronted by the hub's wildcard. #1623 was itself fixing OpenShift routes and fixed the *hub* half (prefer the reported `dashboardUrl`); the *spoke* half it added re-introduced the same assumption on the other side. Deliberate change, unforeseen consequence.

**Not #3778 / `1b4c8a23`** — that commit touches only Ed25519 verification (`hub_pubkey_generations.go`, `proxy/server.js`) and contains zero URL/host construction.

## Option chosen: emit the reachable host

The other options are not available:

- **Hub creates the `-vanity` Route** — infeasible; pull-only clusters have no hub kubectl path by design (`makeVanityHostServable` already fails closed on `PullOnly`).
- **Spoke creates its own `-vanity` Route** — impossible *even with RBAC*: DNS for `*.hive.kubestellar.io` points at the hub's router, so a Route serving that host on another cluster would never receive traffic. This needs a DNS change, not a code change.

So the spoke reads its **own** Route/Ingress in-cluster and reports the host it actually serves. The spoke is the only party that can answer on a pull-only cluster.

## How the hub learns the reachable host

Over the existing heartbeat `dashboard_url` field — no new transport. `SpokeServedHost` reuses the in-cluster API client already backing `routeExistenceProbe`, cached on the same 5-minute cadence. The dashboard Route is selected **by name** (`hive-dashboard`), not first-item, so the terminal Route or a `-vanity` mirror can't be advertised by list order.

Hub side additionally derives its placeholder fallback from the hive's own `cluster.Domain` instead of hardcoded `hive.kubestellar.io`. **No cluster names are hardcoded** — this works for any pull-only or OpenShift cluster, present or future.

Adds namespace-scoped **read-only** RBAC (`hive-route-reader`: `get`/`list` on ingresses + routes). Verified live that spokes currently lack it. No write verbs — a compromised spoke learns only its own hostname, which it already advertises.

## `sso_hop` — not a regression

`?sso_hop=1` is the spoke's post-handoff **landing** redirect (`e716e468`, #2222, 2026-07-29); `/sso?token=` is the hub's **handoff** link (`d7f3158d`, #1976, 2026-07-24). They are consecutive stages of one flow, not competing formats. The operator saw the two ends of the same working handoff. The 90s `iat`/`exp` window is untouched.

## Tests

Both-direction positive controls:

- `TestSpokeServedHost_HubDomainIngressIsReported` — hive-oke keeps working (the 67/67 case)
- `TestSpokeServedHost_OpenShiftRouteHostIsReported` — foreign cluster reports its own host
- `TestSpokeServedHost_PrefersDashboardRouteByName`
- `TestSpokeServedHost_UnknownAPIYieldsEmpty` — RBAC denial = "no answer", falls back
- `TestPlaceholderHostURL_UsesTheHivesOwnClusterDomain` — asserts **both** clusters
- `TestPlaceholderHostURL_UnknownClusterYieldsEmpty` — fail closed

`TestHandleOpenHive` is **INVERTED, not relaxed**: it asserted only that *some* `/sso?token=` redirect happened, which passed just as happily when the host was unreachable — it encoded the bug. It now asserts the host.

## Regression replay

Neutered (still compiles), the failure reproduces the exact production string:

```
--- FAIL: TestSpokeServedHost_PrefersDashboardRouteByName
    expected the hive-dashboard Route host "hosted-available-vllmd-01.apps..."
    got "terminal-host.apps.fmaas-vllm-d.fmaas.res.ibm.com"
--- FAIL: TestPlaceholderHostURL_UsesTheHivesOwnClusterDomain
    openshift-pool hive: expected "https://hosted-available-vllmd-260806-5q6l.apps.fmaas-vllm-d.fmaas.res.ibm.com",
    got "https://hosted-available-vllmd-260806-5q6l.hive.kubestellar.io"
    openshift-pool hive got a hub-wildcard host ... — this is the 503 regression
```

Restored: all pass. `pkg/hub` and `pkg/dashboard` suites both green.

Reported honestly: the hive-oke controls **stay PASS while neutered**, which is correct — on that cluster the hardcoded value coincides with the right answer. That is what makes them controls rather than tests that fail at everything.

## Rollout note

Spokes must roll to pick up the new reporting, and existing namespaces need the new RoleBinding. No cluster writes were made here — all kubectl was read-only.