### PR TITLE
🔒 fix(hub): fail closed when the cluster registry cannot be established (audit 8 §6.11)

### DIFF
--- a/v2/pkg/hub/clusters_registry.go
+++ b/v2/pkg/hub/clusters_registry.go
@@ -1,0 +1,291 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+)
+
+// Validate-on-load for the hub's cluster registry, /data/saas/clusters.json
+// (audit 8, §6 item 11).
+//
+// WHAT THE AUDIT FOUND. The live file is owned 501:wheel — a macOS uid, not the
+// container's — with a clusters.json.bak-akswec2 sibling beside it: the
+// signature of an out-of-band `kubectl cp` from a workstation. Nothing
+// in-cluster re-asserts the file, so the hub's model of its own fleet topology
+// is drift-prone with nothing to correct it.
+//
+// WHY THIS FIX IS A LOADER AND NOT A RECONCILER. The registry is not derivable
+// from the fleet: two of its three clusters (vllm-d, a-ks-wec2) are pull_only
+// BY DESIGN and the hub cannot reach them to enumerate anything. There is no
+// in-cluster source that could re-generate this file, so a reconciler would
+// have to invent one — and a new source of truth for the file that gates all
+// fleet routing is precisely the change most likely to cause the outage it is
+// meant to prevent. What IS available is the ability to refuse to run on bytes
+// the hub cannot vouch for, which is the same answer audit F20 reached for
+// hub-generations.json.
+//
+// THE FAILURE MODE THIS CLOSES. loadClusters previously returned an EMPTY map
+// on a JSON parse error. An empty registry is not a degraded registry, it is an
+// inverted one: clusterForHive falls through both its lookups and returns nil
+// for EVERY hive, so a truncated write silently disables the hub's writes to
+// hive-oke — the one cluster it can reach — while logging a single line and
+// coming up otherwise healthy. A half-written file produced by an interrupted
+// `kubectl cp` (exactly the mechanism that left the .bak sibling) lands
+// squarely in this case.
+//
+// PULL_ONLY IS PRESERVED EXACTLY. Nothing here reinterprets, defaults, or
+// repairs PullOnly. The flag is what gates whether the hub attempts to write to
+// a cluster (KubectlReachable tests it first, unconditionally), so this code
+// round-trips it verbatim and the tests assert routing decisions are identical
+// before and after.
+
+// clustersQuarantineSuffix preserves an unparseable registry for inspection
+// instead of overwriting or discarding it.
+//
+// The recovery differs from the alert-acks precedent deliberately, for the same
+// reason hub-generations.json differs: a corrupt acks file can be discarded
+// because losing an ack merely un-silences an alert — the safe direction. A
+// corrupt REGISTRY must not be discarded and replaced with a synthesized
+// default, because the default names only hive-oke and would silently strand
+// every hive on the two pull-only clusters, re-routing their App and host
+// resolution to the wrong cluster. The bad bytes are left on disk under this
+// suffix so an operator can see what arrived.
+const clustersQuarantineSuffix = ".corrupt"
+
+// clustersBackupPrefix is the sibling-file pattern an out-of-band edit leaves
+// behind (clusters.json.bak-akswec2 on the live hub).
+//
+// It exists as a named constant so the "a sibling is not the live file"
+// property is asserted rather than assumed. The loader reads exactly
+// clustersConfigPath and never globs, so a .bak-* file can never be promoted
+// into the live registry by this code — but that is a property worth pinning,
+// because the failure it would cause (routing from a stale hand-edited
+// snapshot) is silent.
+const clustersBackupPrefix = ".bak-"
+
+// isClustersSidecarPath reports whether a path is one of the registry's
+// non-authoritative siblings — a hand-edit backup (clusters.json.bak-akswec2),
+// a quarantined corrupt file (.corrupt), or a partial write (.tmp).
+//
+// The loader reads exactly clustersConfigPath and never globs a directory, so
+// no sibling can be promoted into the live registry today. This predicate
+// exists so that property is ASSERTED rather than assumed: the failure it
+// guards against — routing the fleet from a stale hand-edited snapshot — is
+// completely silent, and a future convenience like "load the newest
+// clusters.json*" would introduce it without looking wrong.
+func isClustersSidecarPath(path string) bool {
+	base := clustersConfigPath
+	if path == base {
+		return false
+	}
+	if !strings.HasPrefix(path, base) {
+		return false
+	}
+	suffix := strings.TrimPrefix(path, base)
+	return strings.HasPrefix(suffix, clustersBackupPrefix) ||
+		suffix == clustersQuarantineSuffix ||
+		suffix == ".tmp"
+}
+
+// clustersReadAttempts is how many times a non-ENOENT read is retried before
+// the loader gives up and fails closed.
+//
+// The hazard is a TRANSIENT fault — a PVC remount, an NFS blip, an EIO — so the
+// first thing to do about it is try again. Failing closed is the correct end
+// state but not a cheap one, so it is reached only after the transient
+// explanation is ruled out. Mirrors generationsReadAttempts.
+const clustersReadAttempts = 3
+
+// clustersReadRetryDelay is the pause between read attempts. Deliberately
+// short: this runs on the hub's startup path.
+const clustersReadRetryDelay = 100 * time.Millisecond
+
+// clustersLoadOutcome names what the loader established about the registry. It
+// exists because the two degraded cases the old code collapsed into "empty map"
+// are opposites.
+type clustersLoadOutcome int
+
+const (
+	// clustersLoaded: the file was read, parsed, and yielded a usable registry.
+	clustersLoaded clustersLoadOutcome = iota
+	// clustersAbsent: the file is ENOENT. A POSITIVE fact, not an absence of
+	// information — a hub with no registry has never been given one, so the
+	// synthesized hive-oke default is exactly right. This is the documented
+	// backward-compatibility path for a fresh or Compose deployment and it is
+	// preserved verbatim.
+	clustersAbsent
+	// clustersUntrusted: the file EXISTS but its contents could not be
+	// established — an unretryable read error, bytes that do not parse, or a
+	// parsed array that yielded no usable cluster at all.
+	//
+	// THIS IS THE CASE THAT MUST NOT YIELD AN EMPTY MAP, and must not fall back
+	// to the default either. The hub knows a registry was placed here and
+	// cannot tell what it says. Returning empty disables writes to hive-oke;
+	// returning the default silently re-routes every pull-only hive. Both are
+	// widenings of the blast radius of a corrupt file, so the hub refuses.
+	clustersUntrusted
+)
+
+// clustersFatal aborts the process when the registry cannot be established.
+//
+// A var so tests can substitute a recorder: the behaviour under test is "the
+// hub refuses", and a test that genuinely called os.Exit would take the test
+// binary down with it. Production never reassigns it.
+//
+// os.Exit(1) rather than panic: this runs inside NewHubServer on the startup
+// path, and a panic could be recovered by a caller and turned back into the
+// silent degraded start this fix removes. Exiting is not recoverable, which is
+// the point — Kubernetes restarts the pod, the readiness gate stays closed, and
+// the failure is visible as a CrashLoopBackOff rather than as mis-routed
+// provisioning on a hub that looks healthy.
+var clustersFatal = func(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}
+
+// readClustersFile reads the registry, retrying transient faults.
+//
+// Returns (data, outcome). ENOENT is reported as clustersAbsent on the FIRST
+// attempt without retrying: a missing file is a stable answer, and retrying it
+// would add 300ms to every fresh hub's startup for no information.
+func readClustersFile(path string, logger *slog.Logger) ([]byte, clustersLoadOutcome) {
+	var lastErr error
+	for attempt := 1; attempt <= clustersReadAttempts; attempt++ {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return data, clustersLoaded
+		}
+		if os.IsNotExist(err) {
+			return nil, clustersAbsent
+		}
+		lastErr = err
+		if attempt < clustersReadAttempts {
+			logger.Warn("cluster registry read failed, retrying",
+				"path", path, "attempt", attempt, "error", err)
+			time.Sleep(clustersReadRetryDelay)
+		}
+	}
+	logger.Error("cluster registry is unreadable after retries — refusing to run on an unknown fleet topology",
+		"path", path,
+		"attempts", clustersReadAttempts,
+		"error", lastErr,
+		"remedy", "restore /data/saas/clusters.json on the hub PVC and restart the hub")
+	return nil, clustersUntrusted
+}
+
+// quarantineClustersFile renames unparseable bytes aside so an operator can
+// inspect what arrived. Best-effort: a failure to rename is logged and does not
+// change the load outcome, because the outcome is already "refuse".
+func quarantineClustersFile(path string, logger *slog.Logger) {
+	dst := path + clustersQuarantineSuffix
+	if err := os.Rename(path, dst); err != nil {
+		logger.Error("could not quarantine unparseable cluster registry",
+			"path", path, "quarantine", dst, "error", err)
+		return
+	}
+	logger.Error("quarantined unparseable cluster registry for inspection",
+		"path", path, "quarantine", dst)
+}
+
+// defaultClusterRegistry is the single-entry registry synthesized when no
+// registry file exists.
+//
+// Unchanged from the original loadClusters ENOENT branch, kept in one place so
+// the "absent" path is provably identical to what shipped before this fix.
+func defaultClusterRegistry() map[string]ClusterConfig {
+	return map[string]ClusterConfig{
+		defaultClusterID: {
+			ID:           defaultClusterID,
+			Name:         "OKE (default)",
+			InCluster:    true,
+			StorageType:  "nfs",
+			IngressType:  "nginx",
+			IngressClass: "nginx",
+			CertIssuer:   "letsencrypt-prod",
+			Domain:       "hive.kubestellar.io",
+			Arch:         "arm64",
+			// v4 is the ONLY image a hosted spoke can run: audit F2 deleted the
+			// fleet-wide heartbeat lane, and a v2 spoke has no SpokeHeartbeatKey
+			// self-derive path, so it cannot authenticate to this hub at all.
+			ImageTag: "v4-latest",
+		},
+	}
+}
+
+// validateClusterEntries filters a parsed array into the registry map, applying
+// exactly the same three admission rules the original loader applied, in the
+// same order, with the same log lines.
+//
+// The rules are UNCHANGED on purpose. This fix is about what happens when the
+// file cannot be parsed at all, not about which well-formed entries are
+// admitted — tightening admission here would change fleet routing, which is the
+// outcome the brief rules out.
+func validateClusterEntries(configs []ClusterConfig, logger *slog.Logger) map[string]ClusterConfig {
+	clusters := make(map[string]ClusterConfig, len(configs))
+	for _, c := range configs {
+		if c.ID == "" {
+			logger.Warn("skipping cluster config with empty ID")
+			continue
+		}
+		if !c.InCluster && c.KubeconfigPath == "" && !c.PullOnly {
+			logger.Warn("skipping remote cluster with no kubeconfig_path",
+				"cluster", c.ID,
+				"remedy", "set kubeconfig_path, or pull_only: true if the hub cannot reach this cluster and its spokes connect outbound over the heartbeat")
+			continue
+		}
+		if c.Domain == "" {
+			logger.Warn("skipping cluster with no domain", "cluster", c.ID)
+			continue
+		}
+		clusters[c.ID] = c
+	}
+	return clusters
+}
+
+// loadClustersChecked reads and validates the registry.
+//
+// Returns the registry and an outcome. The three outcomes are the whole point
+// of the function; see clustersLoadOutcome.
+func loadClustersChecked(logger *slog.Logger) (map[string]ClusterConfig, clustersLoadOutcome) {
+	data, outcome := readClustersFile(clustersConfigPath, logger)
+	switch outcome {
+	case clustersAbsent:
+		logger.Info("no clusters config found, using default hive-oke cluster", "path", clustersConfigPath)
+		return defaultClusterRegistry(), clustersAbsent
+	case clustersUntrusted:
+		return nil, clustersUntrusted
+	}
+
+	var configs []ClusterConfig
+	if err := json.Unmarshal(data, &configs); err != nil {
+		// A truncated or hand-mangled file lands here. Do NOT return an empty
+		// map: see clustersUntrusted.
+		logger.Error("cluster registry does not parse — refusing to run on an unknown fleet topology",
+			"path", clustersConfigPath,
+			"error", err,
+			"bytes", len(data),
+			"remedy", "restore a valid /data/saas/clusters.json on the hub PVC and restart the hub")
+		quarantineClustersFile(clustersConfigPath, logger)
+		return nil, clustersUntrusted
+	}
+
+	clusters := validateClusterEntries(configs, logger)
+	if len(clusters) == 0 {
+		// The file exists and parsed, but nothing in it is usable. Same
+		// reasoning as a parse failure: the operator placed a registry here and
+		// the hub cannot act on it. An empty registry would nil out
+		// clusterForHive for every hive.
+		logger.Error("cluster registry parsed but yielded no usable cluster — refusing to run on an unknown fleet topology",
+			"path", clustersConfigPath,
+			"entries_in_file", len(configs),
+			"remedy", "every entry needs a non-empty id, a domain, and either in_cluster, kubeconfig_path, or pull_only")
+		return nil, clustersUntrusted
+	}
+
+	logger.Info("loaded cluster configs", "count", len(clusters))
+	return clusters, clustersLoaded
+}

--- a/v2/pkg/hub/clusters_registry_test.go
+++ b/v2/pkg/hub/clusters_registry_test.go
@@ -1,0 +1,386 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for the fail-closed cluster registry loader (audit 8, §6 item 11).
+//
+// The shape of this file is deliberate. A fail-closed change is trivially
+// "passed" by a loader that rejects everything, so every rejection test here is
+// paired with a POSITIVE CONTROL that proves the same code still loads the real
+// registry and still produces the same routing decisions. The live-shaped
+// fixture below is the control that does most of that work.
+
+// clustersFatalRecorder captures the refusal instead of exiting the process.
+type clustersFatalRecorder struct {
+	fired bool
+	msg   string
+}
+
+// captureClustersFatal substitutes the process-exit hook for the duration of a
+// test and restores it afterwards.
+func captureClustersFatal(t *testing.T) *clustersFatalRecorder {
+	t.Helper()
+	rec := &clustersFatalRecorder{}
+	old := clustersFatal
+	clustersFatal = func(msg string) {
+		rec.fired = true
+		rec.msg = msg
+	}
+	t.Cleanup(func() { clustersFatal = old })
+	return rec
+}
+
+// pointClustersConfigAt redirects the registry path at a temp file.
+func pointClustersConfigAt(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "clusters.json")
+	if contents != "" {
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := clustersConfigPath
+	clustersConfigPath = path
+	t.Cleanup(func() { clustersConfigPath = old })
+	return path
+}
+
+// liveShapedRegistry mirrors the THREE entries on the production hub, including
+// the two pull_only clusters, so the positive controls exercise the real
+// topology rather than a toy one. Field values are structural only — no
+// credentials, no kubeconfig contents.
+const liveShapedRegistry = `[
+  {"id":"hive-oke","name":"OKE","in_cluster":true,"domain":"hive.kubestellar.io","arch":"arm64","image_tag":"v4-latest"},
+  {"id":"vllm-d","name":"vLLM-D","in_cluster":false,"pull_only":true,"kubeconfig_path":"/etc/hive/kubeconfigs/vllm-d.yaml","domain":"vllmd.example.com","arch":"amd64","image_tag":"v4-latest"},
+  {"id":"a-ks-wec2","name":"WEC2","in_cluster":false,"pull_only":true,"kubeconfig_path":"/etc/hive/kubeconfigs/a-ks-wec2.yaml","domain":"wec2.example.com","arch":"amd64","image_tag":"v4-latest"}
+]`
+
+// ---------------------------------------------------------------------------
+// POSITIVE CONTROL: a valid registry still loads and still routes identically.
+// ---------------------------------------------------------------------------
+
+// TestValidRegistryStillLoadsAndRoutesIdentically is THE control that stops a
+// "reject everything" loader from passing this suite. It asserts the live-shaped
+// registry loads, that the hub does NOT refuse, and — the part that matters —
+// that every pull_only routing decision is byte-for-byte what it was before.
+func TestValidRegistryStillLoadsAndRoutesIdentically(t *testing.T) {
+	pointClustersConfigAt(t, liveShapedRegistry)
+	fatal := captureClustersFatal(t)
+
+	clusters := loadClusters(slog.Default())
+
+	if fatal.fired {
+		t.Fatalf("a VALID registry made the hub refuse to start: %s", fatal.msg)
+	}
+	if len(clusters) != 3 {
+		t.Fatalf("loaded %d clusters, want 3 (ids=%v)", len(clusters), clusterIDsOf(clusters))
+	}
+
+	// PullOnly must round-trip exactly. This is the flag that gates whether the
+	// hub attempts to WRITE to a cluster; getting it wrong in either direction
+	// is the outage this fix must not cause.
+	wantPullOnly := map[string]bool{
+		"hive-oke":  false,
+		"vllm-d":    true,
+		"a-ks-wec2": true,
+	}
+	for id, want := range wantPullOnly {
+		c, ok := clusters[id]
+		if !ok {
+			t.Fatalf("cluster %q missing from the loaded registry", id)
+		}
+		if c.PullOnly != want {
+			t.Errorf("cluster %q PullOnly = %v, want %v", id, c.PullOnly, want)
+		}
+	}
+
+	// And the derived routing decision, which is what actually gates kubectl.
+	wantReachable := map[string]bool{
+		"hive-oke":  true,  // in_cluster, not pull_only — the hub MUST write here
+		"vllm-d":    false, // pull_only wins over a present kubeconfig_path
+		"a-ks-wec2": false,
+	}
+	for id, want := range wantReachable {
+		c := clusters[id]
+		if got := c.KubectlReachable(); got != want {
+			t.Errorf("cluster %q KubectlReachable() = %v, want %v", id, got, want)
+		}
+	}
+}
+
+// TestPullOnlyWithKubeconfigStaysUnreachableAfterLoad pins the specific
+// precedence the audit called out: a pull_only cluster that DOES carry a
+// kubeconfig_path (both live ones do) must still be unreachable. A loader that
+// "helpfully" cleared PullOnly because a kubeconfig exists would hand the hub
+// write access to 48 spokes it must not touch.
+func TestPullOnlyWithKubeconfigStaysUnreachableAfterLoad(t *testing.T) {
+	pointClustersConfigAt(t, liveShapedRegistry)
+	captureClustersFatal(t)
+
+	clusters := loadClusters(slog.Default())
+
+	c, ok := clusters["vllm-d"]
+	if !ok {
+		t.Fatal("vllm-d missing from the loaded registry")
+	}
+	if c.KubeconfigPath == "" {
+		t.Fatal("fixture is wrong: vllm-d should carry a kubeconfig_path")
+	}
+	if c.KubectlReachable() {
+		t.Error("pull_only cluster with a kubeconfig_path is kubectl-reachable; " +
+			"pull_only must win over a present kubeconfig")
+	}
+}
+
+// TestValidRegistryIsNotQuarantined guards the repair path from eating a good
+// file: nothing about a successful load may rename or remove it.
+func TestValidRegistryIsNotQuarantined(t *testing.T) {
+	path := pointClustersConfigAt(t, liveShapedRegistry)
+	captureClustersFatal(t)
+
+	loadClusters(slog.Default())
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("a valid clusters.json no longer exists after load: %v", err)
+	}
+	if _, err := os.Stat(path + clustersQuarantineSuffix); err == nil {
+		t.Error("a valid clusters.json was quarantined")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FAIL-CLOSED: corruption must refuse, not yield a partial/empty registry.
+// ---------------------------------------------------------------------------
+
+// TestMalformedRegistryFailsClosed is the direct regression for the audit
+// finding. The old loader returned an empty map here.
+func TestMalformedRegistryFailsClosed(t *testing.T) {
+	pointClustersConfigAt(t, `{not an array`)
+	fatal := captureClustersFatal(t)
+
+	clusters, outcome := loadClustersChecked(slog.Default())
+
+	if outcome != clustersUntrusted {
+		t.Fatalf("outcome = %v, want clustersUntrusted", outcome)
+	}
+	if len(clusters) != 0 {
+		t.Fatalf("untrusted load returned %d clusters, want none", len(clusters))
+	}
+
+	_ = fatal
+}
+
+// TestTruncatedRegistryFailsClosedAndDoesNotDisableHiveOKE is the exact failure
+// mode an interrupted `kubectl cp` produces — the mechanism that left the
+// .bak-akswec2 sibling on the live hub.
+//
+// The assertion that matters is the SECOND one: it is not enough that the load
+// fails, it must not leave a registry in which hive-oke has silently vanished.
+func TestTruncatedRegistryFailsClosedAndDoesNotDisableHiveOKE(t *testing.T) {
+	// A prefix of the real file — valid JSON right up to the cut.
+	truncated := liveShapedRegistry[:len(liveShapedRegistry)/2]
+	pointClustersConfigAt(t, truncated)
+	fatal := captureClustersFatal(t)
+
+	clusters := loadClusters(slog.Default())
+
+	if !fatal.fired {
+		t.Error("a truncated clusters.json did not make the hub refuse to start")
+	}
+	if _, ok := clusters[defaultClusterID]; ok {
+		t.Errorf("a truncated registry yielded a %q entry; the hub must refuse, "+
+			"not silently substitute a default that re-routes every pull-only hive", defaultClusterID)
+	}
+	if len(clusters) != 0 {
+		t.Errorf("a truncated registry yielded %d clusters, want none", len(clusters))
+	}
+}
+
+// TestEmptyArrayRegistryFailsClosed covers a file that parses perfectly and
+// says nothing. It must not be read as "no clusters configured" — the operator
+// placed a registry here, so the hub cannot act on it.
+func TestEmptyArrayRegistryFailsClosed(t *testing.T) {
+	pointClustersConfigAt(t, `[]`)
+	captureClustersFatal(t)
+
+	clusters, outcome := loadClustersChecked(slog.Default())
+
+	if outcome != clustersUntrusted {
+		t.Fatalf("outcome = %v, want clustersUntrusted for a registry with no usable cluster", outcome)
+	}
+	if len(clusters) != 0 {
+		t.Fatalf("got %d clusters, want none", len(clusters))
+	}
+}
+
+// TestAllEntriesInvalidFailsClosed: the file parses and has entries, but every
+// one is rejected by the admission rules. Same conclusion as an empty array.
+func TestAllEntriesInvalidFailsClosed(t *testing.T) {
+	pointClustersConfigAt(t, `[{"id":"","domain":"x"},{"id":"nodomain","in_cluster":true}]`)
+	captureClustersFatal(t)
+
+	_, outcome := loadClustersChecked(slog.Default())
+
+	if outcome != clustersUntrusted {
+		t.Fatalf("outcome = %v, want clustersUntrusted when no entry survives validation", outcome)
+	}
+}
+
+// TestMalformedRegistryIsQuarantinedNotDiscarded asserts the bad bytes are
+// preserved for an operator rather than overwritten.
+func TestMalformedRegistryIsQuarantinedNotDiscarded(t *testing.T) {
+	const bad = `{not an array`
+	path := pointClustersConfigAt(t, bad)
+	captureClustersFatal(t)
+
+	loadClustersChecked(slog.Default())
+
+	quarantine := path + clustersQuarantineSuffix
+	data, err := os.ReadFile(quarantine)
+	if err != nil {
+		t.Fatalf("unparseable registry was not quarantined to %s: %v", quarantine, err)
+	}
+	if string(data) != bad {
+		t.Errorf("quarantined bytes = %q, want the original %q", data, bad)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("the unparseable file is still at the live path; it should have been renamed aside")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ABSENT is not corrupt — the backward-compatibility path must survive.
+// ---------------------------------------------------------------------------
+
+// TestAbsentRegistryStillYieldsDefault is the other direction of the control:
+// this fix must NOT turn a fresh deployment into a refusal. A missing file is a
+// positive fact ("never configured"), not a corrupt one.
+func TestAbsentRegistryStillYieldsDefault(t *testing.T) {
+	pointClustersConfigAt(t, "") // writes nothing — path does not exist
+	fatal := captureClustersFatal(t)
+
+	clusters, outcome := loadClustersChecked(slog.Default())
+
+	if fatal.fired {
+		t.Fatalf("an ABSENT clusters.json made the hub refuse to start: %s", fatal.msg)
+	}
+	if outcome != clustersAbsent {
+		t.Fatalf("outcome = %v, want clustersAbsent", outcome)
+	}
+	c, ok := clusters[defaultClusterID]
+	if !ok {
+		t.Fatalf("absent registry did not yield the %q default", defaultClusterID)
+	}
+	// The default must be WRITABLE — it is the hub's own cluster.
+	if c.PullOnly {
+		t.Error("the synthesized default is pull_only; the hub must be able to write to its own cluster")
+	}
+	if !c.KubectlReachable() {
+		t.Error("the synthesized default is not kubectl-reachable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The .bak-* sibling must never be mistaken for the live file.
+// ---------------------------------------------------------------------------
+
+// TestBackupSiblingIsNeverLoadedAsLiveRegistry seeds a VALID .bak- sibling
+// beside a corrupt live file. If the loader ever preferred a parseable sibling,
+// it would route the fleet from a stale hand-edited snapshot — silently. The
+// hub must refuse instead.
+func TestBackupSiblingIsNeverLoadedAsLiveRegistry(t *testing.T) {
+	path := pointClustersConfigAt(t, `{not an array`)
+	sibling := path + clustersBackupPrefix + "akswec2"
+	if err := os.WriteFile(sibling, []byte(liveShapedRegistry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	captureClustersFatal(t)
+
+	clusters, outcome := loadClustersChecked(slog.Default())
+
+	if outcome != clustersUntrusted {
+		t.Fatalf("outcome = %v, want clustersUntrusted; a valid .bak- sibling must not rescue a corrupt live file", outcome)
+	}
+	if len(clusters) != 0 {
+		t.Fatalf("loaded %d clusters from a corrupt live file with a valid sibling present, want none", len(clusters))
+	}
+}
+
+// TestSidecarPathsAreNotTheLiveRegistry pins the naming property directly.
+func TestSidecarPathsAreNotTheLiveRegistry(t *testing.T) {
+	pointClustersConfigAt(t, liveShapedRegistry)
+	base := clustersConfigPath
+
+	sidecars := []string{
+		base + ".bak-akswec2",
+		base + ".bak-20260813",
+		base + ".corrupt",
+		base + ".tmp",
+	}
+	for _, p := range sidecars {
+		if !isClustersSidecarPath(p) {
+			t.Errorf("isClustersSidecarPath(%q) = false, want true", p)
+		}
+	}
+
+	// The live path itself is NOT a sidecar — the positive control that stops
+	// a predicate returning true for everything.
+	if isClustersSidecarPath(base) {
+		t.Errorf("isClustersSidecarPath(%q) = true for the LIVE path, want false", base)
+	}
+	if isClustersSidecarPath("/etc/hive/other.json") {
+		t.Error("isClustersSidecarPath matched an unrelated path")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: the struct must not lose fields it was given.
+// ---------------------------------------------------------------------------
+
+// TestClusterConfigRoundTripsPullOnly guards against a marshal/unmarshal
+// asymmetry silently clearing the flag. pull_only carries `omitempty`, so a
+// false value vanishes from the output — that is fine (absent reads as false)
+// but a TRUE value disappearing would be an outage.
+func TestClusterConfigRoundTripsPullOnly(t *testing.T) {
+	in := ClusterConfig{
+		ID:             "vllm-d",
+		Name:           "vLLM-D",
+		Domain:         "vllmd.example.com",
+		KubeconfigPath: "/etc/hive/kubeconfigs/vllm-d.yaml",
+		PullOnly:       true,
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"pull_only":true`) {
+		t.Fatalf("pull_only:true did not survive marshal: %s", data)
+	}
+	var out ClusterConfig
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.PullOnly {
+		t.Error("PullOnly was lost in the round trip")
+	}
+	if out.KubectlReachable() {
+		t.Error("round-tripped pull_only cluster became kubectl-reachable")
+	}
+}
+
+// clusterIDsOf is a small helper for failure messages.
+func clusterIDsOf(m map[string]ClusterConfig) []string {
+	ids := make([]string, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/v2/pkg/hub/heartbeat_start_coverage_test.go
+++ b/v2/pkg/hub/heartbeat_start_coverage_test.go
@@ -87,6 +87,15 @@ func TestLoadClustersFromFile(t *testing.T) {
 	}
 }
 
+// TestLoadClustersBadJSON pins that an unparseable registry makes the hub
+// REFUSE, and is deliberately the inversion of what it used to assert.
+//
+// AUDIT 8 / §6 ITEM 11. The original body asserted "bad JSON should yield empty
+// map" — it encoded the vulnerability as the expected behaviour. An empty
+// registry is not a safe degraded state: clusterForHive returns nil for every
+// hive, which silently turns off the hub's writes to hive-oke while the hub
+// reports healthy. The correct assertion is that the hub does not come up at
+// all, so this test now checks the refusal fired.
 func TestLoadClustersBadJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "clusters.json")
@@ -95,10 +104,13 @@ func TestLoadClustersBadJSON(t *testing.T) {
 	clustersConfigPath = path
 	defer func() { clustersConfigPath = old }()
 
-	// Bad JSON -> empty map (no default injected on parse error).
-	clusters := loadClusters(slog.Default())
-	if len(clusters) != 0 {
-		t.Errorf("bad JSON should yield empty map, got %+v", clusters)
+	fatal := captureClustersFatal(t)
+
+	_ = loadClusters(slog.Default())
+
+	if !fatal.fired {
+		t.Fatal("unparseable clusters.json did not make the hub refuse to start; " +
+			"an empty registry nils out clusterForHive for every hive and silently disables writes to hive-oke")
 	}
 }
 

--- a/v2/pkg/hub/pull_only_cluster_test.go
+++ b/v2/pkg/hub/pull_only_cluster_test.go
@@ -50,13 +50,26 @@ func TestPullOnlyClusterRegisters(t *testing.T) {
 func TestRemoteClusterWithoutKubeconfigStillDropped(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "clusters.json")
-	body := `[{"id":"oops","name":"typo","domain":"x.example"}]`
+	// The bad entry sits beside a GOOD one deliberately. Audit 8 §6 item 11 made
+	// a registry in which NOTHING survives validation a fail-closed refusal, so
+	// a fixture holding only the bad entry would now exercise the refusal path
+	// rather than the drop this test is about. Pairing them keeps the subject
+	// the drop, and makes it observable against a surviving entry.
+	body := `[
+		{"id":"oops","name":"typo","domain":"x.example"},
+		{"id":"good","name":"good","domain":"g.example","in_cluster":true}
+	]`
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, ok := loadClusterConfigsFrom(t, path)["oops"]; ok {
+	clusters := loadClusterConfigsFrom(t, path)
+	if _, ok := clusters["oops"]; ok {
 		t.Error("a remote cluster with no kubeconfig_path and no pull_only must still be dropped")
+	}
+	// Positive control: the drop is selective, not a wholesale rejection.
+	if _, ok := clusters["good"]; !ok {
+		t.Error("the valid sibling entry was dropped too; validation rejected more than it should")
 	}
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -415,55 +415,40 @@ func readSAToken() string {
 // loadClusters reads the clusters config file and returns a validated
 // map of cluster ID → ClusterConfig. If the file does not exist, it
 // returns a single default entry for hive-oke (backward compatibility).
+//
+// AUDIT 8 / §6 ITEM 11. This used to return an EMPTY map when the file existed
+// but did not parse. That is the most dangerous of the three possible answers:
+// clusterForHive falls through both its lookups on an empty registry and
+// returns nil for EVERY hive, so a truncated or hand-mangled file silently
+// disabled the hub's writes to hive-oke — the one cluster it can reach — while
+// the hub came up otherwise healthy. The registry now fails CLOSED: see
+// loadClustersChecked and clustersLoadOutcome in clusters_registry.go.
+//
+// The ABSENT case is unchanged and still returns the hive-oke default; a hub
+// that was never given a registry has not lost one.
 func loadClusters(logger *slog.Logger) map[string]ClusterConfig {
-	clusters := make(map[string]ClusterConfig)
-
-	data, err := os.ReadFile(clustersConfigPath)
-	if err != nil {
-		logger.Info("no clusters config found, using default hive-oke cluster", "path", clustersConfigPath)
-		clusters[defaultClusterID] = ClusterConfig{
-			ID:           defaultClusterID,
-			Name:         "OKE (default)",
-			InCluster:    true,
-			StorageType:  "nfs",
-			IngressType:  "nginx",
-			IngressClass: "nginx",
-			CertIssuer:   "letsencrypt-prod",
-			Domain:       "hive.kubestellar.io",
-			Arch:         "arm64",
-			// v4 is the ONLY image a hosted spoke can run: audit F2 deleted the
-			// fleet-wide heartbeat lane, and a v2 spoke has no SpokeHeartbeatKey
-			// self-derive path, so it cannot authenticate to this hub at all.
-			ImageTag: "v4-latest",
-		}
-		return clusters
+	clusters, outcome := loadClustersChecked(logger)
+	if outcome == clustersUntrusted {
+		// Refuse to serve on a fleet topology the hub cannot establish.
+		//
+		// WHY FATAL RATHER THAN A DEGRADED START. NewHubServer returns no error,
+		// so the only alternatives available here are the two this fix exists to
+		// remove: come up with an empty registry (writes to hive-oke silently
+		// off) or come up on the synthesized default (every pull-only hive
+		// silently re-routed to the hub's own cluster). Both present as a
+		// healthy hub. A hub that refuses to start is loud, is caught by the
+		// pod's restart loop and readiness gate, and — critically — is
+		// RECOVERABLE by restoring the file, whereas a hub that starts on a
+		// wrong registry mis-routes provisioning and App identity for as long
+		// as it runs.
+		logger.Error("FATAL: refusing to start without a trustworthy cluster registry",
+			"path", clustersConfigPath,
+			"remedy", "restore a valid /data/saas/clusters.json on the hub PVC (a quarantined copy may be beside it) and restart the hub")
+		clustersFatal("hub cluster registry at " + clustersConfigPath + " could not be established; refusing to start")
+		// clustersFatal does not return in production. Tests substitute a
+		// recorder, so fall through to an empty map for them.
+		return map[string]ClusterConfig{}
 	}
-
-	var configs []ClusterConfig
-	if err := json.Unmarshal(data, &configs); err != nil {
-		logger.Error("failed to parse clusters config", "path", clustersConfigPath, "error", err)
-		return clusters
-	}
-
-	for _, c := range configs {
-		if c.ID == "" {
-			logger.Warn("skipping cluster config with empty ID")
-			continue
-		}
-		if !c.InCluster && c.KubeconfigPath == "" && !c.PullOnly {
-			logger.Warn("skipping remote cluster with no kubeconfig_path",
-				"cluster", c.ID,
-				"remedy", "set kubeconfig_path, or pull_only: true if the hub cannot reach this cluster and its spokes connect outbound over the heartbeat")
-			continue
-		}
-		if c.Domain == "" {
-			logger.Warn("skipping cluster with no domain", "cluster", c.ID)
-			continue
-		}
-		clusters[c.ID] = c
-	}
-
-	logger.Info("loaded cluster configs", "count", len(clusters))
 	return clusters
 }
 


### PR DESCRIPTION
Closes §6 item 11 of `SECURITY-REVIEW-2026-08-14`: *"Re-assert `clusters.json` from a managed source — it is currently hand-patched (`501:wheel`, `.bak-akswec2` sibling) with nothing in-cluster reconciling it."*

## The audit claim is accurate — verified live (read-only)

```
-rw-r--r--    1 501      wheel         2355 Aug 13 02:04 clusters.json
-rw-r--r--    1 root     root          2284 Aug 13 02:04 clusters.json.bak-akswec2
```

Both stamped `Aug 13 02:04`, in a directory where every other file is `root:root`. `501` is a macOS uid; the container runs as uid 0. That is the signature of an out-of-band `kubectl cp` from a workstation.

Two things the audit did not record, which bound the severity **down**:

- The live file is currently **valid JSON** — a 3-entry array (`hive-oke`, `vllm-d`, `a-ks-wec2`).
- The `.bak-akswec2` sibling has an **identical `id`/`pull_only` set**. The hand-edit did not change routing; the 71-byte delta is in non-routing fields.

So there is no live misrouting today. What there is, is no guardrail if the next hand-edit lands badly.

## The real defect is what the loader did with bad bytes

`loadClusters` (`saas_provision.go:418`) returned an **empty map** on a JSON parse error. An empty registry is not a degraded registry, it is an inverted one:

```go
func (s *HubServer) clusterForHive(h *SaaSHive) *ClusterConfig {
    if c, ok := s.clusters[clusterID]; ok { return &c }
    if c, ok := s.clusters[defaultClusterID]; ok { return &c }
    return nil   // ← every hive, on an empty registry
}
```

`clusterForHive` returns **nil for every hive**, so a truncated write silently disables the hub's writes to `hive-oke` — the one cluster it can reach — while the hub comes up otherwise healthy and logs a single line. A half-written file from an interrupted `kubectl cp`, exactly the mechanism that left the `.bak` sibling, lands squarely in that case. This is the load-bearing dependency behind F21, the auto-upgrade wedge, and the SSO vanity 503.

## Mechanism chosen: validate-on-load, fail closed (option 1)

Mirrors `hub_generations_store.go`, the pattern audit F20 already proved here.

- **Tri-state outcome** (`loaded` / `absent` / `untrusted`) instead of collapsing "never configured" and "cannot be established" into one empty map.
- **ABSENT (ENOENT) unchanged** — still yields the `hive-oke` default. A hub never given a registry has not lost one; this keeps fresh/Compose deployments working.
- **UNTRUSTED refuses to start.** `NewHubServer` returns no error, so the only alternatives were the two this fix removes: come up empty (writes to `hive-oke` off) or come up on the synthesized default (every pull-only hive re-routed to the hub's own cluster). Both present as a healthy hub. A refusal is loud, is caught by the restart loop, and is recoverable by restoring the file.
- **Quarantine by rename** (`.corrupt`) — bad bytes preserved for the operator, not discarded.
- **Bounded retry** (3 × 100ms) so a PVC remount or NFS blip does not take the hub down; ENOENT returns immediately without retrying.

**Why not a ConfigMap/Secret reconciler (option 2/3).** The registry is not derivable from the fleet: `vllm-d` and `a-ks-wec2` are `pull_only` **by design** and the hub cannot reach them to enumerate anything. No in-cluster source could regenerate this file, so a reconciler would have to invent one — and a new source of truth for the file that gates all fleet routing is the change most likely to cause the outage it prevents.

## `pull_only` semantics preserved exactly

Nothing reinterprets, defaults, or repairs `PullOnly`. Admission rules for well-formed entries are byte-for-byte unchanged; only the all-invalid case changed. Tests assert `KubectlReachable()` is identical for all three live clusters: `hive-oke` **true** (the hub must keep writing there), `vllm-d`/`a-ks-wec2` **false** even though both carry a `kubeconfig_path`.

## Tests — both-direction positive controls

Rejection tests are worthless without a control proving the loader still accepts the real thing, so every one is paired against a live-shaped 3-cluster fixture.

Positive controls: `TestValidRegistryStillLoadsAndRoutesIdentically`, `TestPullOnlyWithKubeconfigStaysUnreachableAfterLoad`, `TestValidRegistryIsNotQuarantined`, `TestAbsentRegistryStillYieldsDefault`, `TestClusterConfigRoundTripsPullOnly`
Fail-closed: `TestMalformedRegistryFailsClosed`, `TestTruncatedRegistryFailsClosedAndDoesNotDisableHiveOKE`, `TestEmptyArrayRegistryFailsClosed`, `TestAllEntriesInvalidFailsClosed`, `TestMalformedRegistryIsQuarantinedNotDiscarded`
Sibling: `TestBackupSiblingIsNeverLoadedAsLiveRegistry` (valid `.bak-` beside a corrupt live file must **not** rescue it), `TestSidecarPathsAreNotTheLiveRegistry`

### A 15th test found encoding the vulnerability

`TestLoadClustersBadJSON` asserted `"bad JSON should yield empty map"` — it pinned the defect as expected behaviour. **Inverted, not relaxed**: it now asserts the hub refuses.

`TestRemoteClusterWithoutKubeconfigStillDropped` kept its original assertion and **gained** a positive control; its single-bad-entry fixture would otherwise have exercised the new refusal path instead of the drop it is about.

## Regression replay (verbatim)

Neutered the parse-error branch back to `return map[string]ClusterConfig{}, clustersLoaded` — still compiles (`BUILD OK (neutered)`):

```
--- PASS: TestValidRegistryStillLoadsAndRoutesIdentically (0.00s)
--- FAIL: TestMalformedRegistryFailsClosed (0.00s)
    clusters_registry_test.go:172: outcome = 0, want clustersUntrusted
--- FAIL: TestTruncatedRegistryFailsClosedAndDoesNotDisableHiveOKE (0.00s)
    clusters_registry_test.go:196: a truncated clusters.json did not make the hub refuse to start
--- FAIL: TestMalformedRegistryIsQuarantinedNotDiscarded (0.00s)
    clusters_registry_test.go:249: unparseable registry was not quarantined to [...]/clusters.json.corrupt
--- PASS: TestAbsentRegistryStillYieldsDefault (0.00s)
--- FAIL: TestBackupSiblingIsNeverLoadedAsLiveRegistry (0.00s)
    clusters_registry_test.go:310: outcome = 0, want clustersUntrusted; a valid .bak- sibling must not rescue a corrupt live file
--- FAIL: TestLoadClustersBadJSON (0.00s)
    heartbeat_start_coverage_test.go:112: unparseable clusters.json did not make the hub refuse to start; an empty registry nils out clusterForHive for every hive and silently disables writes to hive-oke
FAIL	github.com/kubestellar/hive/v2/pkg/hub	0.954s
```

5 fail. The two positive controls **stayed green while neutered** — that is the point of them: they test the valid path, not the fix. Restored, all 14 pass:

```
--- PASS: TestValidRegistryStillLoadsAndRoutesIdentically (0.00s)
--- PASS: TestPullOnlyWithKubeconfigStaysUnreachableAfterLoad (0.00s)
--- PASS: TestValidRegistryIsNotQuarantined (0.00s)
--- PASS: TestMalformedRegistryFailsClosed (0.00s)
--- PASS: TestTruncatedRegistryFailsClosedAndDoesNotDisableHiveOKE (0.00s)
--- PASS: TestEmptyArrayRegistryFailsClosed (0.00s)
--- PASS: TestAllEntriesInvalidFailsClosed (0.00s)
--- PASS: TestMalformedRegistryIsQuarantinedNotDiscarded (0.00s)
--- PASS: TestAbsentRegistryStillYieldsDefault (0.00s)
--- PASS: TestBackupSiblingIsNeverLoadedAsLiveRegistry (0.00s)
--- PASS: TestSidecarPathsAreNotTheLiveRegistry (0.00s)
--- PASS: TestClusterConfigRoundTripsPullOnly (0.00s)
--- PASS: TestLoadClustersBadJSON (0.00s)
--- PASS: TestRemoteClusterWithoutKubeconfigStillDropped (0.00s)
ok  	github.com/kubestellar/hive/v2/pkg/hub	0.580s
```

Full suite on the rebased commit: `ok github.com/kubestellar/hive/v2/pkg/hub 154.125s`. `pkg/hubbackup` (independent read-only loader, already fails closed) unaffected: `ok 5.268s`. `go build ./...`, `go vet ./pkg/hub/`, `gofmt -l` clean on all five touched files.

## Deliberately NOT changed

- **The live file.** No cluster writes — ownership and the `.bak` sibling are the operator's call. Diagnosis only. Worth noting the container runs as uid 0, so `501:wheel` is cosmetically wrong but reads fine; it is a provenance smell, not a live fault.
- **`setClusterAppID`** (`cluster_app_key.go:1259`), the only production writer. It already does tmp+rename. It does lack a mutex and a pre-write `os.Remove(tmp)` (so a stale tmp from a crashed write keeps a laxer mode), and it mutates `s.clusters` *before* the disk write, so a failed write diverges memory from disk. Real but separate, and adjacent to another agent's path.
- **Admission rules for well-formed entries** — tightening them would change fleet routing.
- **F21's `pull_only` flags.** Clearing them is the operator's decision on validated kubeconfigs, explicitly out of scope here.

Refs: `SECURITY-REVIEW-2026-08-14` §6 item 11, F21