### PR TITLE
fix(dashboard): make [hidden] win over display:flex for gh-app banners

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -763,6 +763,7 @@
     /* .gh-auth-btn — primary button (system recipe at end of style block) */
     .gh-auth-banner .gh-auth-user { color: var(--blue); font-weight: 600; }
     .gh-app-install-banner { background: color-mix(in srgb, var(--red) 12%, var(--panel)); border: 1px solid var(--red); border-radius: 8px; padding: 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
+    .gh-app-install-banner[hidden] { display: none !important; }
     .gh-app-install-banner .gh-app-title { font-weight: 600; margin-bottom: 4px; color: var(--text); }
     .gh-app-install-banner .gh-app-desc { font-size: 0.85rem; color: var(--text); }
     /* .gh-app-btn — primary button (system recipe); banner tint carries severity */


### PR DESCRIPTION
## Problem

On the read-only \`/snapshot\` dashboard page, the **"GitHub App Not Installed"** and **"Repo Target Misconfigured"** banners always render, regardless of the hive's actual state — producing false alarms.

## Root cause (CSS specificity defeats \`[hidden]\`)

Both banner elements ship in the HTML with the \`hidden\` attribute:

- \`<div id="gh-app-install-banner" class="gh-app-install-banner" hidden>\`
- \`<div id="repo-target-banner" class="gh-app-install-banner perm-issue" hidden>\`

But the base CSS rule sets \`display: flex\` unconditionally:

\`\`\`css
.gh-app-install-banner { ...; display: flex; ...; }
\`\`\`

A class selector carrying \`display: flex\` has **higher specificity** than the user-agent \`[hidden] { display: none }\` rule, so the \`hidden\` attribute is defeated and both banners are forced visible.

On the live dashboard the client \`render()\` toggles these banners correctly, but on the read-only snapshot \`render()\` is neutralized and never activates them — so the CSS override is the sole thing making them appear. Verified live: computed \`display\` is \`flex\` even with the \`hidden\` attribute present; an inline \`display:none\` hides it.

## Fix (one line)

Add a \`[hidden]\` guard immediately after the base rule so the attribute wins for this banner class:

\`\`\`css
.gh-app-install-banner[hidden] { display: none !important; }
\`\`\`

## Why this is safe on the live dashboard

When \`render()\` decides a banner **should** show, it calls \`banner.removeAttribute('hidden')\` (see \`renderGitHubAppBanner\`). With \`hidden\` removed, the new \`[hidden]\` rule no longer matches and the banner displays normally via the base \`display: flex\` rule. When a banner should stay hidden, the \`hidden\` attribute remains and now correctly suppresses it. This preserves — and corrects — live behavior.

## Scope

- Changes **only** \`v2/pkg/dashboard/static/index.html\` (+1 line).
- No JS, no markup, no \`render()\`, no \`build-snapshot.mjs\` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)