### PR TITLE
🔒 fix(hub): standardize upgrade delivery on pull; gate arming on heartbeat, not reachability (corrects #3839)

### DIFF
--- a/v2/pkg/hub/assignment_upgrade_latch_test.go
+++ b/v2/pkg/hub/assignment_upgrade_latch_test.go
@@ -50,8 +50,18 @@ func primeBehindLatest(t *testing.T) {
 
 // registryBehind returns a v2 registry entry parked one commit behind latest and
 // not currently upgrading — the state a fresh eligibility decision reads.
+// registryBehind builds a LIVE hive that is behind latest.
+//
+// LastHeartbeat is set because these tests are about the ASSIGNMENT latch, not
+// about whether the hive can collect an instruction. Upgrades are delivered on
+// the spoke's own outbound heartbeat, so a hive that has never heartbeated is
+// not armed at all — without a beat here every case below would be refused for
+// the wrong reason and would stop testing the latch.
 func registryBehind(id string) RegistryEntry {
-	return RegistryEntry{ID: id, GitBranch: "v2", GitHash: "oldsha95"}
+	return RegistryEntry{
+		ID: id, GitBranch: "v2", GitHash: "oldsha95",
+		LastHeartbeat: time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339),
+	}
 }
 
 // TestAutoUpgradeLatchedWhileClaimInFlight is the core guarantee: an

--- a/v2/pkg/hub/pullonly_upgrade.go
+++ b/v2/pkg/hub/pullonly_upgrade.go
@@ -2,144 +2,171 @@ package hub
 
 import (
 	"sync"
+	"time"
 )
 
-// Auto-upgrade on a cluster the hub cannot write to.
+// Auto-upgrade for a spoke that cannot COLLECT the instruction.
 //
-// THE WEDGE THIS FILE EXISTS TO PREVENT. `vllm-d` and `a-ks-wec2` are declared
-// `pull_only` in clusters.json: the hub has no network path to one and no
-// `deployments.apps` RBAC on the other, and — per audit-8 F21 — is not MEANT to
-// have either. Giving the hub write access is explicitly out of scope. But
-// triggerAutoUpgrades() did not consult that declaration before ARMING an
-// upgrade. The resulting loop, measured live on 2026-08-14:
+// DELIVERY IS PULL, NOT PUSH. This is the fact the whole file turns on, and it
+// is worth stating precisely because an earlier version of this fix got it
+// wrong. The hub never pushes an upgrade to a spoke. It records a target, and
+// the spoke collects it on its own OUTBOUND heartbeat:
 //
-//  1. triggerAutoUpgrades() sees a hive behind latest with AutoUpgrade=true and
-//     calls beginUpgrade(): Upgrading=true, UpgradeStartedAt=now.
-//  2. rolloutRestartHive() returns false IMMEDIATELY — clusterRecentlyUnreachable()
-//     short-circuits on PullOnly by declaration, so not even a dial is attempted.
-//  3. The heartbeat fallback is armed instead. For the 26 hives actually seen
-//     wedged — unassigned placeholders that have never heartbeated — there is no
-//     spoke on the other end to consume it, so nothing ever converges.
-//  4. staleUpgradeTimeout (10m) passes. The stale-recovery branch re-arms. Because
-//     the target is unchanged, beginUpgrade() deliberately PRESERVES the original
-//     UpgradeStartedAt (so a thrashing retry still crosses the stuck threshold),
-//     so upgradeAge keeps growing rather than resetting.
-//  5. Nothing bounds this. sweepOrphanedUpgrades()'s retry budget
-//     (maxOrphanedUpgradeSweeps) is the mechanism that is SUPPOSED to convert a
-//     structurally-undeliverable upgrade into a visible UpgradeFailed, but
-//     evaluateOrphanedUpgrade() returns early on an unparseable LastHeartbeat —
-//     a hive that never heartbeated cannot prove its attempt is gone. So the
-//     budget is never spent, exhaustion never fires, and step 4 repeats forever.
+//   - the hub sets resp.UpgradeTo on the heartbeat response (server.go ~2194 /
+//     ~2201, from the in-memory heartbeatUpgrade map);
+//   - the spoke reads it and invokes its UpgradeCallback (heartbeat.go ~752);
+//   - that callback runs entirely on the SPOKE (cmd/hive/main.go ~3358): it
+//     patches its own Deployment image via UpgradeSelfToSHA, or failing that
+//     restarts itself via RolloutRestartSelf (self_upgrade.go), using its OWN
+//     in-cluster ServiceAccount at
+//     /var/run/secrets/kubernetes.io/serviceaccount.
 //
-// Measured result: 208 re-arms in 15 minutes, stale_minutes 90–104, hives reading
-// "offline" on the dashboard while showing "Upgrading 1h39m". The overlap was
-// exact — 26 hives stale, 26 hives with auto_upgrade on a pull-only cluster,
-// intersection 26, and zero stale hives outside that set.
+// The hub's kubectl write path is therefore NOT the delivery mechanism.
+// rolloutRestartHive() is an OPTIMISATION — a fast-path that saves the spoke
+// waiting for its next beat — which is exactly why every caller already treats
+// its failure as benign and falls back to the heartbeat. A pull-only cluster
+// costs the fast-path and nothing else.
 //
-// WHY REFUSING TO ARM IS THE RIGHT BEHAVIOUR, not tracking it by heartbeat.
-// A correct v4 target would have been equally undeliverable, so the wedge is not
-// about WHICH commit was chosen — it is about the hub instructing work it has no
-// mechanism to perform. Of the three candidate fixes, "track it by what the spoke
-// self-reports" still requires a spoke to be reporting, which is exactly what an
-// unassigned placeholder is not doing; it would fix the 3 assigned cases and leave
-// the 26 measured ones wedged. "Clear the flag on delivery failure" treats the
-// symptom one cycle later and still burns an arm/re-arm every 10 minutes forever.
-// Refusing at the ARM is the only one that makes the wedge unreachable rather than
-// merely self-healing, and it is honest: the spokes are NOT broken. They run
-// current code and self-derive every per-hive key from HIVE_HUB_SECRET + HIVE_ID.
-// A hub-pushed upgrade is an optimisation for them, never a dependency.
+// WHY THE PREVIOUS GATE WAS WRONG. An earlier revision of this fix keyed on
+// cluster reachability (clusterRecentlyUnreachable / PullOnly). That predicate
+// answers "can the hub WRITE into this cluster", which is not the question.
+// Gating on it would have disabled auto-upgrade for every pull-only spoke that
+// heartbeats perfectly well — 40+ of them — converting a visible wedge into a
+// SILENT PERMANENT OPT-OUT. That is a worse failure than the bug: a wedge is at
+// least loud, whereas a spoke that quietly stops receiving upgrades looks
+// identical to one that is up to date. Reachability is not used here at all.
 //
-// AND IT MUST NOT BE SILENT. Silently skipping is how this went unnoticed for as
-// long as it did — a hive with auto_upgrade=true that simply never upgrades is
-// indistinguishable from one that is up to date. So the refusal is recorded on the
-// hive's timeline and surfaced through the same F21 reachability vocabulary the
-// per-hive env sweep already established (UnreachableHives / UnreachableClusters /
-// FleetFullyObserved on PerHiveEnvStatus): "the hub cannot reach this spoke" is a
-// state an operator must be able to SEE, never one that renders as "fine".
+// THE ACTUAL WEDGE. What the 26 measured hives have in common is not their
+// cluster — it is that they have NEVER HEARTBEATED. Confirmed on the live
+// registry: every wedged entry carries no last_heartbeat, no git_branch, and no
+// orphaned_upgrade_sweeps, while upgrading=true. They are unassigned
+// placeholders. Under a pull model that alone explains everything:
 //
-// This deliberately reuses clusterRecentlyUnreachable() rather than testing
-// PullOnly directly, so it is one notion of reachability, not a second one. That
-// predicate already returns true by DECLARATION for a pull-only cluster (no dial,
-// no timeout) and also covers a cluster inside the learned unreachable-breaker
-// window — an upgrade armed at a cluster the hub just failed to dial is just as
-// undeliverable as one aimed at a declared pull-only cluster, and wedges the same
-// way.
+//  1. triggerAutoUpgrades() arms a target and latches Upgrading=true.
+//  2. Nothing ever collects it, because collection happens on a heartbeat and
+//     this spoke does not send one.
+//  3. staleUpgradeTimeout passes; stale-recovery re-arms. The target is
+//     unchanged, so beginUpgrade() deliberately preserves the original
+//     UpgradeStartedAt and the elapsed only ever GROWS.
+//  4. sweepOrphanedUpgrades()'s retry budget — the mechanism meant to convert a
+//     never-landing upgrade into a visible UpgradeFailed — cannot bound it:
+//     evaluateOrphanedUpgrade() returns early on an unparseable LastHeartbeat,
+//     because a hive that never checked in cannot PROVE its attempt is gone. So
+//     the budget is never spent and step 3 repeats forever.
+//
+// Measured: 26 hives re-arming, stale_minutes climbing past 146 and still
+// rising. The pull-only clusters were a red herring — a perfect correlation
+// with the real cause, because those pools happen to be where the unassigned
+// placeholders live.
+//
+// The gate below is therefore keyed on heartbeat history, which is the correct
+// predicate on EVERY cluster: a hive that cannot collect an instruction must not
+// be handed one, whether it sits on hive-oke or vllm-d.
 
-// upgradeDeliverable reports whether the hub has any mechanism to DELIVER an
-// upgrade it arms for a hive on this cluster.
+// PUSH-PATH RETIREMENT: WHAT THIS PR DOES AND DOES NOT MAKE DROPPABLE.
 //
-// The hub's only write path to a spoke is `kubectl rollout restart` against the
-// hive's Deployment. When the cluster is unreachable — declared pull_only, or
-// inside the learned unreachable window — that path does not exist, and the
-// heartbeat fallback is not a substitute the hub can rely on: it requires a spoke
-// that is already checking in, which an unassigned placeholder is not.
+// This PR retires the UPGRADE push path only. Every upgrade/restart/branch-switch
+// delivery is now pull; rolloutRestartHive() is deleted and no upgrade path shells
+// out to kubectl against a spoke cluster.
 //
-// A nil cluster is NOT deliverable. The caller already treats "no cluster config"
-// as a skip, and answering "deliverable" for a hive whose cluster cannot even be
-// resolved would arm an upgrade aimed at nothing.
+// THE HUB'S KUBECONFIGS ARE NOT YET DROPPABLE. Two things still read them, and
+// removing the kubeconfigs before those land would degrade them SILENTLY, which
+// is worse than failing loudly:
 //
-// The caller must NOT hold s.mu: clusterRecentlyUnreachable takes
-// s.clusterUnreachableMu and reads s.clusters.
-func (s *HubServer) upgradeDeliverable(cluster *ClusterConfig) bool {
-	if cluster == nil {
+//  1. NODE STATS (saas.go ~2000: `kubectl get nodes -o json`, ~1993 `top nodes`,
+//     ~2126 node summary). The heartbeat fallback beside it fires only when the
+//     kubectl query ERRORS or times out — on a reachable cluster like hive-oke
+//     the kubectl path succeeds, so the spoke is never asked. Drop the
+//     kubeconfig and this does not fail over; it just stops reporting.
+//
+//     The spoke-side collector exists (CollectClusterHealth, cluster_metrics.go)
+//     but cannot currently answer on either cluster:
+//       - it requires the metrics API FIRST and returns nil if that fails
+//         (cluster_metrics.go ~59), and nodes.metrics.k8s.io is not granted to
+//         hive-sa on hive-oke OR vllm-d;
+//       - it is gated on HIVE_CLUSTER_ID (cmd/hive/main.go ~3310), which
+//         provisioning does not emit;
+//       - node-read RBAC is not in the provisioning template (saas_provision.go)
+//         at all — where it exists on vllm-d it was granted out-of-band.
+//     Verified live 2026-08-14: on hive-oke, `auth can-i list nodes` and
+//     `list nodes.metrics.k8s.io` as the spoke's hive-sa are both "no".
+//
+//  2. PROVISIONING itself (saas_provision.go) creates namespaces, Deployments
+//     and RBAC on spoke clusters. That is inherently a hub-side write and is not
+//     in scope for pull.
+//
+// So: this PR removes the upgrade path's need for write access. It does NOT make
+// the kubeconfigs removable. The ordering constraint is explicit — the node-stats
+// pull path and its provisioning prerequisites must land BEFORE any kubeconfig is
+// dropped or downgraded to read-only. Anything relying on hand-patched RBAC is
+// exactly the class of drift that nothing in code re-asserts.
+
+// upgradeCollectible reports whether this hive can COLLECT an upgrade
+// instruction, i.e. whether it is heartbeating.
+//
+// lastHeartbeat is RegistryEntry.LastHeartbeat (RFC3339, empty when the hive has
+// never checked in). A hive that has never heartbeated can never collect, and a
+// hive silent past staleRemoveAge is being evicted anyway.
+//
+// DELIBERATELY NOT maxHeartbeatAge (5m). That constant drives the Online pill,
+// and gating on it would refuse to arm an upgrade for a spoke that is merely one
+// beat late or mid-restart — including, self-defeatingly, a spoke that is quiet
+// precisely BECAUSE it is restarting into the upgrade we just armed. The
+// question here is "will this hive ever come back to collect", not "is it green
+// right now", so the bound is the same one the registry already uses to decide a
+// hive is gone for good. Anything fresher would re-introduce a different silent
+// opt-out.
+//
+// An unparseable timestamp is treated as NOT collectible: it is the same
+// evidence-quality rule evaluateOrphanedUpgrade() applies, and we must not arm
+// on a value we cannot read.
+func upgradeCollectible(lastHeartbeat string, now time.Time) bool {
+	if lastHeartbeat == "" {
 		return false
 	}
-	// An in-cluster hive is reachable through the hub's own API server; the
-	// unreachable breaker is about REMOTE clusters and is not consulted for it.
-	if cluster.InCluster {
-		return true
+	t, err := time.Parse(time.RFC3339, lastHeartbeat)
+	if err != nil {
+		return false
 	}
-	return !s.clusterRecentlyUnreachable(cluster.ID)
+	return now.Sub(t) <= staleRemoveAge
 }
 
-// undeliverableUpgradeReason explains, in operator-facing terms, why an upgrade
-// for a hive on this cluster cannot be armed. It names the cluster and the
-// declaration responsible so the log/timeline entry is actionable rather than a
-// bare "skipped". It never includes kubeconfig paths or credentials — cluster IDs
-// only, matching the UnreachableClusters convention.
-func (s *HubServer) undeliverableUpgradeReason(cluster *ClusterConfig) string {
-	if cluster == nil {
-		return "no cluster config resolved for this hive"
+// uncollectibleUpgradeReason explains, in operator-facing terms, why an upgrade
+// was not armed. It never includes kubeconfig paths or credentials.
+func uncollectibleUpgradeReason(lastHeartbeat string) string {
+	if lastHeartbeat == "" {
+		return "this hive has never heartbeated, so it cannot collect an upgrade " +
+			"instruction — upgrades are delivered on the spoke's own outbound heartbeat, " +
+			"not pushed by the hub. Typically an unassigned placeholder with no spoke running."
 	}
-	if cluster.PullOnly {
-		return "cluster " + cluster.ID + " is pull-only: the hub has no write path to this spoke, " +
-			"so an armed upgrade could never be delivered. The spoke is not broken — it self-derives " +
-			"its configuration and upgrades independently of the hub."
-	}
-	return "cluster " + cluster.ID + " is currently unreachable from the hub, " +
-		"so an armed upgrade could not be delivered"
+	return "this hive last heartbeated at " + lastHeartbeat +
+		", beyond the point where it is considered present, so it cannot collect " +
+		"an upgrade instruction"
 }
 
 // undeliverableUpgradeNoted remembers the (hive, target) pairs already written to
 // a timeline, so the refusal is recorded ONCE per target rather than on every
 // poll.
 //
-// This matters for the same reason the bug it fixes matters. StartLatestSHAPoller
-// ticks every latestSHAPollInterval (2m) and calls triggerAutoUpgrades() each
-// time, so an un-deduplicated timeline write would append an identical entry ~720
-// times a day per hive — trading an unbounded re-arm loop for an unbounded
-// timeline, and burying the genuine events a timeline exists to show. Keying on
-// the TARGET (not just the hive) means a genuinely new upgrade opportunity — the
-// branch advanced, so there is a new SHA the hive is now behind — is reported
-// again, while the same refusal is not repeated.
-//
-// Unbounded growth is not a concern at fleet scale: one entry per hive per
-// distinct target, and the entry is dropped as soon as the hive becomes
-// deliverable (forgetUndeliverableUpgrade), which is the transition that makes
-// the memory stale.
+// StartLatestSHAPoller ticks every latestSHAPollInterval (2m) and calls
+// triggerAutoUpgrades() each time, so an un-deduplicated timeline write would
+// append an identical entry ~720 times a day per hive — trading an unbounded
+// re-arm loop for an unbounded timeline, and burying the genuine events a
+// timeline exists to show. Keying on the TARGET means a genuinely new upgrade
+// opportunity (the branch advanced) is reported again, while the same refusal is
+// not repeated.
 var (
 	undeliverableUpgradeMu    sync.Mutex
 	undeliverableUpgradeNoted = map[string]string{}
 )
 
-// noteUndeliverableUpgrade records — once per (hive, target) — that the hub
-// declined to arm an upgrade it could not deliver, and why.
+// noteUncollectibleUpgrade records — once per (hive, target) — that the hub
+// declined to arm an upgrade the hive could not collect, and why.
 //
-// The timeline is the durable, operator-visible surface: it is what makes this
-// refusal auditable after the fact, rather than a log line that ages out. Being
-// able to SEE that a hive is deliberately not being upgraded is the whole point;
-// silence here is what let the original wedge run unnoticed.
-func (s *HubServer) noteUndeliverableUpgrade(hiveID, target, reason string) {
+// The timeline is the durable, operator-visible surface. Silence is how the
+// original wedge went unnoticed: a hive with auto_upgrade=true that never
+// upgrades is indistinguishable from one already at latest.
+func (s *HubServer) noteUncollectibleUpgrade(hiveID, target, reason string) {
 	undeliverableUpgradeMu.Lock()
 	if prev, ok := undeliverableUpgradeNoted[hiveID]; ok && prev == target {
 		undeliverableUpgradeMu.Unlock()
@@ -152,36 +179,44 @@ func (s *HubServer) noteUndeliverableUpgrade(hiveID, target, reason string) {
 		"auto-upgrade to "+orDash(target)+" not armed — "+reason, "auto-upgrade")
 }
 
+// forgetUncollectibleUpgrade drops the de-duplication memory for a hive, so that
+// if it later becomes uncollectible again the refusal is reported afresh rather
+// than suppressed by a stale entry. Called when a hive is successfully armed —
+// i.e. the condition has genuinely cleared.
+func forgetUncollectibleUpgrade(hiveID string) {
+	undeliverableUpgradeMu.Lock()
+	delete(undeliverableUpgradeNoted, hiveID)
+	undeliverableUpgradeMu.Unlock()
+}
+
 // upgradeBranchOrDefault resolves the branch whose latest SHA should be used as
 // an upgrade target for a hive reporting gitBranch.
 //
 // WHY THE OLD `if branch == "" { branch = "v2" }` WAS WRONG. That default was
 // written when v2 was the only branch. It is now a CROSS-BRANCH bug: a hive whose
 // GitBranch is unset — which is every unassigned placeholder, since
-// RegistryEntry.GitBranch is only ever populated from a heartbeat payload and a
-// placeholder has never heartbeated — had its upgrade target resolved against v2
-// while running on a v4 hub. That is exactly what was observed live: the target
-// issued was 0b78dc0, a commit that is on v2 and NOT on v4, while the hub's own
-// latest-shas.json correctly recorded v4=7cd059b. The hub was instructing spokes
-// to move to a commit that does not exist on their branch.
+// RegistryEntry.GitBranch is only ever populated from a heartbeat payload — had
+// its upgrade target resolved against v2 while running on a v4 hub. That is what
+// was observed live: the target issued was 0b78dc0, a commit that is on v2 and
+// NOT on v4, byte-identical to the v2 entry in the hub's own latest-shas.json,
+// while that file correctly recorded v4=7cd059b. v2 is no longer maintained, so
+// the default is unambiguously wrong rather than merely stale.
 //
-// It is a genuinely separate bug from the pull-only wedge and neither causes the
-// other: a CORRECT v4 target would have been equally undeliverable to a pull-only
-// cluster, so fixing this alone would not have unwedged anything. But it would
-// have made the wedge much easier to diagnose, and on a REACHABLE cluster it is
-// the more dangerous of the two — there, delivery succeeds, and the hub would be
-// rolling a v4 spoke onto a v2 build.
+// It is a genuinely separate bug from the collection wedge and neither causes the
+// other. On a hive that CAN collect, it is the more dangerous of the two: the
+// instruction is picked up and the spoke rolls itself onto a foreign branch's
+// build.
 //
-// The hub's OWN branch is the right fallback. It is what the hub is built from,
+// The hub's OWN branch is the right fallback: it is what the hub is built from,
 // so it is the only branch the hub can honestly assume when the hive has not said
-// otherwise, and it makes the default self-correcting as the fleet moves between
-// branches instead of pinning a constant that silently rots. This mirrors the
-// existing precedent in StartLatestSHAPoller, which already stopped hardcoding
-// "v2" for the hub's own upgrade target for the same reason: "hardcoding here
-// made the badge and the poller disagree the moment a hub ran on v3".
+// otherwise, and it self-corrects as the fleet moves between branches instead of
+// pinning a constant that silently rots. This mirrors the existing precedent in
+// StartLatestSHAPoller, which already stopped hardcoding "v2" for the hub's own
+// upgrade target for the same reason: "hardcoding here made the badge and the
+// poller disagree the moment a hub ran on v3".
 //
 // Falls back to "v2" only when the hub's own branch is somehow unset, preserving
-// the historical behaviour for a hub that cannot identify itself rather than
+// historical behaviour for a hub that cannot identify itself rather than
 // resolving against an empty branch (which returns no SHA and silently disables
 // upgrades).
 func (s *HubServer) upgradeBranchOrDefault(gitBranch string) string {
@@ -192,14 +227,4 @@ func (s *HubServer) upgradeBranchOrDefault(gitBranch string) string {
 		return s.hubGitBranch
 	}
 	return "v2"
-}
-
-// forgetUndeliverableUpgrade drops the de-duplication memory for a hive, so that
-// if it later becomes undeliverable again the refusal is reported afresh rather
-// than suppressed by a stale entry from a previous episode. Called when a hive is
-// successfully armed — i.e. the condition has genuinely cleared.
-func forgetUndeliverableUpgrade(hiveID string) {
-	undeliverableUpgradeMu.Lock()
-	delete(undeliverableUpgradeNoted, hiveID)
-	undeliverableUpgradeMu.Unlock()
 }

--- a/v2/pkg/hub/pullonly_upgrade_test.go
+++ b/v2/pkg/hub/pullonly_upgrade_test.go
@@ -2,20 +2,28 @@ package hub
 
 import (
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
 
-// These tests come in matched PAIRS. Every assertion that a pull-only hive must
-// NOT be armed/re-armed is accompanied by a positive control on a REACHABLE
-// cluster asserting the normal auto-upgrade still happens. Without that control,
-// a change that simply disabled auto-upgrade everywhere would pass the whole
-// file — which is the failure mode this repo has repeatedly shipped (a test that
-// passes for the wrong reason). The controls are what make the pull-only
-// assertions mean "refused BECAUSE undeliverable" rather than "nothing works".
+// These tests come in matched PAIRS. Every assertion that an uncollectible hive
+// must NOT be armed is accompanied by a positive control asserting a hive that
+// CAN collect still auto-upgrades normally. Without those controls, a change
+// that simply disabled auto-upgrade would pass the whole file.
+//
+// The most important control here is TestPullOnlyHiveThatHeartbeatsStillUpgrades.
+// An earlier revision of this fix gated on CLUSTER REACHABILITY, which would
+// have silently disabled auto-upgrade for every pull-only spoke that heartbeats
+// perfectly well — turning a loud wedge into a silent permanent opt-out. That
+// test is what makes the reachability-based gate un-reintroducible.
 
-// pullOnlyTestServer builds a hub with one reachable remote cluster and one
-// declared pull-only cluster, plus a known latest SHA for branch v4.
+func rfc3339At(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+
+// pullOnlyTestServer builds a hub with one in-cluster and one declared pull-only
+// cluster, plus a known latest SHA for branch v4.
 func pullOnlyTestServer(t *testing.T) *HubServer {
 	t.Helper()
 	resetSHACaches(t)
@@ -24,105 +32,162 @@ func pullOnlyTestServer(t *testing.T) *HubServer {
 	latestSHAMu.Unlock()
 
 	return &HubServer{
-		logger:       slog.Default(),
-		hubSecret:    testHubSecret,
-		hubGitBranch: "v4",
-		// A real store, so the surfacing assertions read the same path
-		// production writes rather than a stub that cannot fail.
+		logger:           slog.Default(),
+		hubSecret:        testHubSecret,
+		hubGitBranch:     "v4",
 		timeline:         newTimelineStore(),
 		heartbeatUpgrade: make(map[string]string),
 		clusters: map[string]ClusterConfig{
-			// Reachable: a normal remote cluster with a kubeconfig.
 			"hive-oke": {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
-			// Undeliverable BY DECLARATION — audit-8 F21. The hub has no write
-			// path here and is not meant to have one.
+			// The hub cannot WRITE here (audit-8 F21) — but its spokes pull
+			// their upgrades over their own outbound heartbeat, so this must
+			// NOT affect whether an upgrade is armed.
 			"vllm-d": {ID: "vllm-d", PullOnly: true, Domain: "vllmd.example.cloud"},
 		},
 	}
 }
 
-// TestAutoUpgradeNotArmedForPullOnlyCluster is the primary assertion: the hub
-// must not ARM an upgrade it structurally cannot deliver. Arming one is what
-// latches Upgrading=true with no mechanism to ever clear it.
-func TestAutoUpgradeNotArmedForPullOnlyCluster(t *testing.T) {
+// TestPullOnlyHiveThatHeartbeatsStillUpgrades is THE critical control.
+//
+// Delivery is pull: the spoke reads UpgradeTo off its own heartbeat response
+// (server.go) and patches its own Deployment with its own ServiceAccount
+// (cmd/hive/main.go → self_upgrade.go). The hub's inability to kubectl into the
+// cluster is irrelevant to that path. A gate keyed on cluster reachability would
+// disable auto-upgrade for 40+ healthy spokes; this test fails if anyone
+// reintroduces one.
+func TestPullOnlyHiveThatHeartbeatsStillUpgrades(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ph-1")
+	forgetUncollectibleUpgrade("pull-live")
+	saveSaaSHive(&SaaSHive{
+		ID: "pull-live", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	// On a pull-only cluster, but ALIVE and collecting instructions.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "pull-live", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	h := s.registry.Hives[0]
+	if !h.Upgrading {
+		t.Fatal("a pull-only spoke that heartbeats MUST still auto-upgrade — it collects " +
+			"the instruction over its own outbound heartbeat and patches its own " +
+			"Deployment. Gating on cluster reachability here would silently disable " +
+			"auto-upgrade for 40+ healthy spokes, which is worse than the wedge")
+	}
+	if h.UpgradeTarget != "7cd059b" {
+		t.Errorf("UpgradeTarget = %q, want 7cd059b", h.UpgradeTarget)
+	}
+	if got := s.heartbeatUpgrade["pull-live"]; got != "7cd059b" {
+		t.Errorf("heartbeatUpgrade = %q, want 7cd059b — the pull instruction must be armed", got)
+	}
+}
+
+// TestAutoUpgradeNotArmedForNeverHeartbeatedHive is the primary assertion: a hive
+// that has never checked in cannot collect an instruction, so arming one only
+// latches a flag nothing will ever clear.
+func TestAutoUpgradeNotArmedForNeverHeartbeatedHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUncollectibleUpgrade("ph-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
 	})
-	// Behind latest, so absent the pull-only check this WOULD be armed.
+	// The live wedged shape: no LastHeartbeat at all.
 	s.registry.Hives = []RegistryEntry{{ID: "ph-1", GitBranch: "v4", GitHash: "old1234"}}
 
 	s.triggerAutoUpgrades()
 
 	h := s.registry.Hives[0]
 	if h.Upgrading {
-		t.Error("armed an upgrade for a hive on a pull-only cluster: the hub has no write " +
-			"path to deliver it, so Upgrading=true can never be cleared and the hive " +
-			"wedges as perpetually 'Upgrading' while reading offline")
-	}
-	if h.UpgradeTarget != "" {
-		t.Errorf("UpgradeTarget = %q, want empty — nothing should be targeted", h.UpgradeTarget)
+		t.Error("armed an upgrade for a hive that has never heartbeated: nothing will ever " +
+			"collect it, so Upgrading=true latches forever and the hive wedges as " +
+			"perpetually 'Upgrading' while reading offline")
 	}
 	if got := s.heartbeatUpgrade["ph-1"]; got != "" {
-		t.Errorf("heartbeatUpgrade[ph-1] = %q, want empty — the heartbeat fallback must not "+
-			"be armed either; an unassigned placeholder has no spoke to consume it", got)
+		t.Errorf("heartbeatUpgrade[ph-1] = %q, want empty", got)
 	}
 }
 
-// TestAutoUpgradeStillArmedForReachableCluster is the POSITIVE CONTROL for the
-// test above. If this fails, the fix has disabled auto-upgrade generally rather
-// than refusing only the undeliverable case, and every other assertion in this
-// file is worthless.
-func TestAutoUpgradeStillArmedForReachableCluster(t *testing.T) {
+// TestAutoUpgradeNotArmedForLongDeadHive covers the other uncollectible shape: a
+// hive that once heartbeated but has been silent past the point where the
+// registry considers it present.
+func TestAutoUpgradeNotArmedForLongDeadHive(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	installScriptedKubectl(t)
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ok-1")
+	forgetUncollectibleUpgrade("dead-1")
 	saveSaaSHive(&SaaSHive{
-		ID: "ok-1", Owner: "alice", AutoUpgrade: true,
+		ID: "dead-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "hive-oke",
 	})
-	s.registry.Hives = []RegistryEntry{{ID: "ok-1", GitBranch: "v4", GitHash: "old1234"}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "dead-1", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-48 * time.Hour)),
+	}}
 
 	s.triggerAutoUpgrades()
 
-	h := s.registry.Hives[0]
-	if !h.Upgrading {
-		t.Fatal("a hive on a REACHABLE cluster must still auto-upgrade normally — " +
-			"the pull-only refusal must be narrow, not a blanket disable")
-	}
-	if h.UpgradeTarget != "7cd059b" {
-		t.Errorf("UpgradeTarget = %q, want 7cd059b (latest for v4)", h.UpgradeTarget)
+	if s.registry.Hives[0].Upgrading {
+		t.Error("armed an upgrade for a hive silent for 48h — it cannot collect it")
 	}
 }
 
-// TestStaleUpgradeNotReArmedForPullOnlyCluster covers the branch that actually
-// produced the measured damage: 208 re-arms in 15 minutes. A stale upgrade on a
-// cluster the hub cannot reach must be ABANDONED, not re-armed — re-arming
-// reproduces the identical no-op every staleUpgradeTimeout forever.
-func TestStaleUpgradeNotReArmedForPullOnlyCluster(t *testing.T) {
+// TestBrieflyQuietHiveStillUpgrades is the counter-control to the test above, and
+// guards the threshold choice. A spoke that is one beat late — or quiet BECAUSE
+// it is restarting into an upgrade — must still be armed. Gating on the 5-minute
+// Online threshold instead of staleRemoveAge would be a different silent opt-out.
+func TestBrieflyQuietHiveStillUpgrades(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ph-2")
+	forgetUncollectibleUpgrade("quiet-1")
+	saveSaaSHive(&SaaSHive{
+		ID: "quiet-1", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	// 20 minutes quiet: past maxHeartbeatAge (5m, the Online pill), well inside
+	// staleRemoveAge (24h). This hive will come back.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "quiet-1", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-20 * time.Minute)),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	if !s.registry.Hives[0].Upgrading {
+		t.Error("a briefly-quiet spoke must still be armed — it will collect the " +
+			"instruction on its next beat. Gating on the 5-minute Online threshold " +
+			"would refuse to upgrade a spoke that is merely mid-restart")
+	}
+}
+
+// TestStaleUpgradeNotReArmedForUncollectibleHive covers the branch that produced
+// the measured damage: re-arming an instruction nothing will ever pick up.
+func TestStaleUpgradeNotReArmedForUncollectibleHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUncollectibleUpgrade("ph-2")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-2", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
 	})
-	// Already latched and long past staleUpgradeTimeout — the live shape, where
-	// stale_minutes was observed between 90 and 104.
 	s.registry.Hives = []RegistryEntry{{
 		ID: "ph-2", GitBranch: "v4", GitHash: "old1234",
 		Upgrading: true, UpgradeTarget: "7cd059b",
-		UpgradeStartedAt: time.Now().Add(-99 * time.Minute),
+		UpgradeStartedAt: time.Now().Add(-146 * time.Minute),
 	}}
 	s.heartbeatUpgrade["ph-2"] = "7cd059b"
 
@@ -130,66 +195,57 @@ func TestStaleUpgradeNotReArmedForPullOnlyCluster(t *testing.T) {
 
 	h := s.registry.Hives[0]
 	if h.Upgrading {
-		t.Error("stale undeliverable upgrade was re-armed instead of abandoned — " +
-			"this is the 208-re-arms-in-15-minutes loop")
+		t.Error("stale uncollectible upgrade was re-armed instead of abandoned — " +
+			"this is the unbounded re-arm loop")
 	}
 	if !h.UpgradeStartedAt.IsZero() {
-		t.Error("UpgradeStartedAt must be zeroed when the latch is cleared, or the " +
-			"next cycle reads a stale elapsed and reports the hive stuck again")
+		t.Error("UpgradeStartedAt must be zeroed, or the next cycle reads a stale elapsed")
 	}
 	if got := s.heartbeatUpgrade["ph-2"]; got != "" {
-		t.Errorf("heartbeatUpgrade[ph-2] = %q, want empty — the armed instruction must "+
-			"be dropped so no path keeps re-delivering it", got)
+		t.Errorf("heartbeatUpgrade[ph-2] = %q, want empty", got)
 	}
 }
 
-// TestStaleUpgradeStillRecoveredForReachableCluster is the POSITIVE CONTROL for
-// the abandonment above. Stale-upgrade recovery on a reachable cluster is a real
-// and valuable behaviour (#2476) and must survive.
-func TestStaleUpgradeStillRecoveredForReachableCluster(t *testing.T) {
+// TestStaleUpgradeStillRecoveredForLiveHive is the POSITIVE CONTROL for the
+// abandonment above — including on a PULL-ONLY cluster, since recovery there is
+// exactly what the heartbeat fallback exists for.
+func TestStaleUpgradeStillRecoveredForLiveHive(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	installScriptedKubectl(t)
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ok-2")
+	forgetUncollectibleUpgrade("ok-2")
 	saveSaaSHive(&SaaSHive{
 		ID: "ok-2", Owner: "alice", AutoUpgrade: true,
-		Status: "running", ClusterID: "hive-oke",
+		Status: "running", ClusterID: "vllm-d",
 	})
 	s.registry.Hives = []RegistryEntry{{
 		ID: "ok-2", GitBranch: "v4", GitHash: "old1234",
 		Upgrading: true, UpgradeTarget: "7cd059b",
 		UpgradeStartedAt: time.Now().Add(-99 * time.Minute),
+		LastHeartbeat:    rfc3339At(time.Now().Add(-30 * time.Second)),
 	}}
 
 	s.triggerAutoUpgrades()
 
 	if !s.registry.Hives[0].Upgrading {
-		t.Fatal("a stale upgrade on a REACHABLE cluster must still be recovered/re-armed — " +
-			"abandonment must apply only where delivery is impossible")
+		t.Fatal("a stale upgrade on a LIVE hive must still be recovered/re-armed — " +
+			"abandonment must apply only where the instruction cannot be collected")
 	}
 	if got := s.heartbeatUpgrade["ok-2"]; got != "7cd059b" {
-		t.Errorf("heartbeatUpgrade[ok-2] = %q, want 7cd059b — recovery must keep the "+
-			"instruction alive for a reachable hive", got)
+		t.Errorf("heartbeatUpgrade[ok-2] = %q, want 7cd059b", got)
 	}
 }
 
-// TestUndeliverableUpgradeCannotAccumulateStaleness is the invariant the whole
-// fix exists to establish, asserted the way the bug actually presented: over
-// REPEATED poll cycles.
-//
-// The original loop survived every individual-cycle check — each cycle looked
-// like a reasonable recovery. Only the accumulation was pathological: elapsed
-// climbing past 90 minutes while the hub re-armed 208 times. So this replays
-// many cycles and asserts the hive never latches at all, which is the only
-// formulation that would have caught the live behaviour.
-func TestUndeliverableUpgradeCannotAccumulateStaleness(t *testing.T) {
+// TestUncollectibleUpgradeCannotAccumulateStaleness asserts the invariant the way
+// the bug actually presented: over REPEATED poll cycles. The original loop
+// survived every individual-cycle check; only the accumulation was pathological.
+func TestUncollectibleUpgradeCannotAccumulateStaleness(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ph-3")
+	forgetUncollectibleUpgrade("ph-3")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-3", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -201,29 +257,26 @@ func TestUndeliverableUpgradeCannotAccumulateStaleness(t *testing.T) {
 		h := s.registry.Hives[0]
 		if h.Upgrading {
 			t.Fatalf("cycle %d: hive latched Upgrading — staleness is accumulating for an "+
-				"upgrade that can never be delivered", cycle)
+				"upgrade that will never be collected", cycle)
 		}
 		if !h.UpgradeStartedAt.IsZero() {
-			t.Fatalf("cycle %d: UpgradeStartedAt is non-zero (%v) — the elapsed counter that "+
-				"reached 104 minutes live is being started again", cycle, h.UpgradeStartedAt)
+			t.Fatalf("cycle %d: UpgradeStartedAt non-zero (%v) — the elapsed counter that "+
+				"reached 146 minutes live is being started again", cycle, h.UpgradeStartedAt)
 		}
 		if got := s.heartbeatUpgrade["ph-3"]; got != "" {
-			t.Fatalf("cycle %d: heartbeatUpgrade re-armed to %q — this is the re-arm loop",
-				cycle, got)
+			t.Fatalf("cycle %d: heartbeatUpgrade re-armed to %q — the re-arm loop", cycle, got)
 		}
 	}
 }
 
-// TestUndeliverableUpgradeIsSurfacedNotSilent guards the second half of the fix.
-// Silently skipping is how the original wedge went unnoticed: a hive with
-// auto_upgrade=true that never upgrades looks exactly like one already at latest.
-// The refusal must leave an operator-visible record.
-func TestUndeliverableUpgradeIsSurfacedNotSilent(t *testing.T) {
+// TestUncollectibleUpgradeIsSurfacedNotSilent guards the second half of the fix.
+// Silence is how the original wedge went unnoticed.
+func TestUncollectibleUpgradeIsSurfacedNotSilent(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ph-4")
+	forgetUncollectibleUpgrade("ph-4")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-4", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -232,38 +285,29 @@ func TestUndeliverableUpgradeIsSurfacedNotSilent(t *testing.T) {
 
 	s.triggerAutoUpgrades()
 
-	events := s.timeline.recent("ph-4", 100)
 	var found bool
-	for _, e := range events {
+	for _, e := range s.timeline.recent("ph-4", 100) {
 		if e.Kind == TimelineUpgradeStale {
 			found = true
-			// The reason must NAME the cluster, or an operator reading it cannot
-			// act on it.
-			if !contains(e.Detail, "vllm-d") {
-				t.Errorf("timeline detail %q does not name the responsible cluster", e.Detail)
-			}
-			if !contains(e.Detail, "pull-only") {
+			if !strings.Contains(e.Detail, "heartbeat") {
 				t.Errorf("timeline detail %q does not explain WHY it was refused", e.Detail)
 			}
 		}
 	}
 	if !found {
 		t.Error("the refusal left NO timeline record — an operator cannot distinguish " +
-			"'deliberately not upgraded' from 'silently broken', which is exactly how " +
-			"this bug survived")
+			"'deliberately not upgraded' from 'silently broken'")
 	}
 }
 
-// TestUndeliverableRefusalIsDeduplicated stops the fix from trading an unbounded
-// re-arm loop for an unbounded timeline. StartLatestSHAPoller ticks every 2
-// minutes, so an un-deduplicated write would append ~720 identical entries per
-// hive per day and bury the genuine events.
-func TestUndeliverableRefusalIsDeduplicated(t *testing.T) {
+// TestUncollectibleRefusalIsDeduplicated stops the fix trading an unbounded
+// re-arm loop for an unbounded timeline (the poller ticks every 2 minutes).
+func TestUncollectibleRefusalIsDeduplicated(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ph-5")
+	forgetUncollectibleUpgrade("ph-5")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-5", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -281,107 +325,213 @@ func TestUndeliverableRefusalIsDeduplicated(t *testing.T) {
 		}
 	}
 	if stale != 1 {
-		t.Errorf("timeline recorded %d refusal entries across 10 identical cycles, want 1 — "+
-			"the refusal must be reported once per target, not once per poll", stale)
+		t.Errorf("timeline recorded %d refusal entries across 10 identical cycles, want 1", stale)
 	}
 }
 
-// TestUpgradeDeliverablePredicate pins the reachability predicate itself, and in
-// particular that it reuses the EXISTING clusterRecentlyUnreachable notion (the
-// F21 vocabulary) rather than introducing a second, divergent one.
-func TestUpgradeDeliverablePredicate(t *testing.T) {
-	s := &HubServer{
-		logger: slog.Default(),
-		clusters: map[string]ClusterConfig{
-			"in":   {ID: "in", InCluster: true},
-			"pull": {ID: "pull", PullOnly: true, Domain: "d"},
-			"rem":  {ID: "rem", KubeconfigPath: "/tmp/kc", Domain: "d"},
-		},
-		clusterUnreachableUntil: map[string]time.Time{},
-	}
-
+// TestUpgradeCollectiblePredicate pins the predicate, and in particular that it
+// is about HEARTBEAT HISTORY and nothing else — no cluster, no reachability.
+func TestUpgradeCollectiblePredicate(t *testing.T) {
+	now := time.Now()
 	cases := []struct {
-		name    string
-		cluster *ClusterConfig
-		want    bool
+		name string
+		last string
+		want bool
 	}{
-		{"nil cluster is not deliverable", nil, false},
-		{"in-cluster is deliverable", &ClusterConfig{ID: "in", InCluster: true}, true},
-		{"pull-only is never deliverable", &ClusterConfig{ID: "pull", PullOnly: true}, false},
-		{"reachable remote is deliverable", &ClusterConfig{ID: "rem", KubeconfigPath: "/tmp/kc"}, true},
+		{"never heartbeated", "", false},
+		{"unparseable timestamp", "not-a-timestamp", false},
+		{"beating right now", rfc3339At(now.Add(-10 * time.Second)), true},
+		{"quiet 20m (mid-restart)", rfc3339At(now.Add(-20 * time.Minute)), true},
+		{"quiet 23h, still present", rfc3339At(now.Add(-23 * time.Hour)), true},
+		{"silent 48h", rfc3339At(now.Add(-48 * time.Hour)), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := s.upgradeDeliverable(tc.cluster); got != tc.want {
-				t.Errorf("upgradeDeliverable = %v, want %v", got, tc.want)
+			if got := upgradeCollectible(tc.last, now); got != tc.want {
+				t.Errorf("upgradeCollectible(%q) = %v, want %v", tc.last, got, tc.want)
 			}
 		})
-	}
-
-	// A cluster inside the LEARNED unreachable window must also be undeliverable:
-	// an upgrade armed at a cluster the hub just failed to dial wedges exactly
-	// like one aimed at a declared pull-only cluster. This is the assertion that
-	// proves the predicate is the shared F21 notion, not a bare PullOnly test.
-	s.markClusterUnreachable("rem")
-	if s.upgradeDeliverable(&ClusterConfig{ID: "rem", KubeconfigPath: "/tmp/kc"}) {
-		t.Error("a cluster inside the unreachable breaker window must not be deliverable — " +
-			"upgradeDeliverable must reuse clusterRecentlyUnreachable, not re-test PullOnly")
 	}
 }
 
 // TestUpgradeBranchDefaultsToHubBranchNotV2 is the 0b78dc0 regression. A
 // placeholder that has never heartbeated has an empty GitBranch; the old
-// hardcoded `branch = "v2"` then resolved its target against v2 while running on
-// a v4 hub, which is how a v2-only commit was issued as a v4 hive's target.
+// hardcoded `branch = "v2"` resolved its target against v2 on a v4 hub — and v2
+// is no longer maintained.
 func TestUpgradeBranchDefaultsToHubBranchNotV2(t *testing.T) {
 	s := &HubServer{logger: slog.Default(), hubGitBranch: "v4"}
 
 	if got := s.upgradeBranchOrDefault(""); got != "v4" {
-		t.Errorf("upgradeBranchOrDefault(\"\") = %q, want v4 — an unset branch must resolve "+
-			"against the HUB's branch; defaulting to v2 on a v4 hub is what armed 0b78dc0, "+
-			"a commit that does not exist on v4", got)
+		t.Errorf("upgradeBranchOrDefault(\"\") = %q, want v4 — defaulting to v2 on a v4 hub "+
+			"is what armed 0b78dc0, a commit that does not exist on v4", got)
 	}
-	// An explicitly reported branch always wins — the default must never override
-	// a hive that has told us what it runs.
 	if got := s.upgradeBranchOrDefault("v2"); got != "v2" {
-		t.Errorf("upgradeBranchOrDefault(\"v2\") = %q, want v2", got)
+		t.Errorf("upgradeBranchOrDefault(\"v2\") = %q, want v2 — an explicit branch always wins", got)
 	}
-	// A hub that cannot identify its own branch falls back to the historical
-	// constant rather than resolving against "" (which yields no SHA at all).
 	s2 := &HubServer{logger: slog.Default()}
 	if got := s2.upgradeBranchOrDefault(""); got != "v2" {
 		t.Errorf("with no hub branch, upgradeBranchOrDefault(\"\") = %q, want v2", got)
 	}
 }
 
-// TestPullOnlyHiveNeverTargetedWithForeignBranchSHA joins the two fixes at the
-// surface where they were both observed: a placeholder on a pull-only cluster
-// with no reported branch. It must be neither armed nor aimed at a v2 commit.
-func TestPullOnlyHiveNeverTargetedWithForeignBranchSHA(t *testing.T) {
+// TestLiveHiveNeverTargetedWithForeignBranchSHA proves the branch fix on a hive
+// that CAN collect — which is where a foreign-branch target is actually
+// dangerous, because the spoke picks it up and rolls itself onto a v2 build.
+func TestLiveHiveNeverTargetedWithForeignBranchSHA(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUndeliverableUpgrade("ph-6")
-	// The v2 SHA that was actually being issued live.
+	forgetUncollectibleUpgrade("live-nobranch")
 	latestSHAMu.Lock()
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "0b78dc0"}
 	latestSHAMu.Unlock()
 
 	saveSaaSHive(&SaaSHive{
-		ID: "ph-6", Owner: "alice", AutoUpgrade: true,
+		ID: "live-nobranch", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
 	})
-	// GitBranch deliberately EMPTY — the unassigned-placeholder shape.
-	s.registry.Hives = []RegistryEntry{{ID: "ph-6", GitHash: "old1234"}}
+	// GitBranch empty, but heartbeating — so it WILL collect whatever we arm.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "live-nobranch", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
+	}}
 
 	s.triggerAutoUpgrades()
 
 	h := s.registry.Hives[0]
 	if h.UpgradeTarget == "0b78dc0" {
-		t.Error("hive was targeted at 0b78dc0, a v2-only commit, from a v4 hub")
+		t.Error("live hive was targeted at 0b78dc0, a v2-only commit, from a v4 hub — " +
+			"it would collect this and roll itself onto an unmaintained branch's build")
 	}
-	if h.Upgrading {
-		t.Error("hive on a pull-only cluster must not be latched Upgrading at all")
+	if h.UpgradeTarget != "7cd059b" {
+		t.Errorf("UpgradeTarget = %q, want 7cd059b (the hub's own branch)", h.UpgradeTarget)
+	}
+}
+
+// TestUpgradePathNeverShellsOutToCluster is the push-path retirement guard.
+//
+// It pins the security property the operator asked for: the hub must not need
+// write-capable kubeconfigs into spoke clusters to deliver an upgrade. If anyone
+// reintroduces a kubectl call on the auto-upgrade path, the fake kubectl
+// installed here records it and this fails.
+//
+// The positive half is that the upgrade is still DELIVERED — via the heartbeat —
+// so this cannot pass by simply breaking upgrades.
+func TestUpgradePathNeverShellsOutToCluster(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUncollectibleUpgrade("nopush")
+	// A REACHABLE remote cluster: under the old push model this is exactly the
+	// case that would have shelled out to kubectl.
+	s.clusters["remote"] = ClusterConfig{
+		ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx",
+		Domain: "r.example.com",
+	}
+	saveSaaSHive(&SaaSHive{
+		ID: "nopush", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "remote",
+	})
+	s.registry.Hives = []RegistryEntry{{
+		ID: "nopush", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	// Delivered by pull.
+	if got := s.heartbeatUpgrade["nopush"]; got != "7cd059b" {
+		t.Errorf("heartbeatUpgrade = %q, want 7cd059b — the upgrade must still be "+
+			"delivered, by arming the heartbeat", got)
+	}
+	if !s.registry.Hives[0].Upgrading {
+		t.Error("hive must be latched Upgrading so the dashboard reflects the request")
+	}
+}
+
+// TestManualUpgradeButtonWorksUnderPull is the operator's explicit constraint:
+// the manual Upgrade button must keep working with the push path retired.
+//
+// Under pull, "working" means the request records a target and arms delivery —
+// the spoke applies it on its next beat. This asserts the button's observable
+// contract end-to-end through the HTTP handler.
+func TestManualUpgradeButtonWorksUnderPull(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	s.clusters["remote"] = ClusterConfig{
+		ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Domain: "r.example.com",
+	}
+	saveSaaSHive(&SaaSHive{
+		ID: "manual-btn", Owner: "alice", Status: "running", ClusterID: "remote",
+	})
+	s.registry.Hives = []RegistryEntry{{
+		ID: "manual-btn", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
+	}}
+
+	mkUser(t, "alice")
+	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "manual-btn")
+	rec := httptest.NewRecorder()
+	s.handleUpgradeHive(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("manual upgrade returned %d, body %q — the button must keep working",
+			rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"mode":"heartbeat"`) {
+		t.Errorf("response %q should report heartbeat delivery so the UI can say "+
+			"'queued' rather than implying an immediate roll", rec.Body.String())
+	}
+	s.mu.RLock()
+	armed := s.heartbeatUpgrade["manual-btn"]
+	upgrading := s.registry.Hives[0].Upgrading
+	s.mu.RUnlock()
+	if armed != "7cd059b" {
+		t.Errorf("heartbeatUpgrade = %q, want 7cd059b — the click must arm delivery", armed)
+	}
+	if !upgrading {
+		t.Error("the hive must be latched Upgrading so the dashboard reflects the request")
+	}
+}
+
+// TestAutoUpgradeToggleWorksUnderPull is the other operator constraint. The
+// toggle only writes hub-side state, so it must be entirely unaffected — this
+// pins that, and that flipping it on makes the hive eligible for arming.
+func TestAutoUpgradeToggleWorksUnderPull(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	saveSaaSHive(&SaaSHive{
+		ID: "toggle-1", Owner: "alice", Status: "running",
+		ClusterID: "vllm-d", AutoUpgrade: false,
+	})
+	s.registry.Hives = []RegistryEntry{{
+		ID: "toggle-1", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
+	}}
+
+	mkUser(t, "alice")
+	req := setPathValue(reqWithUser("PUT", "/au", `{"auto_upgrade":true}`, "alice"), "id", "toggle-1")
+	rec := httptest.NewRecorder()
+	s.handleToggleAutoUpgrade(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("toggle returned %d, body %q", rec.Code, rec.Body.String())
+	}
+	if h := loadSaaSHive("toggle-1"); h == nil || !h.AutoUpgrade {
+		t.Fatal("the toggle must persist AutoUpgrade=true")
+	}
+
+	// And the setting must actually take effect on the next poll — on a
+	// pull-only cluster, which is the case that matters.
+	forgetUncollectibleUpgrade("toggle-1")
+	s.triggerAutoUpgrades()
+	if !s.registry.Hives[0].Upgrading {
+		t.Error("after enabling auto-upgrade, a live hive must be armed on the next cycle")
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3866,12 +3866,15 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// kubectl is attempt one; the heartbeat fallback below is the ONLY path
-	// that works for a cluster the hub cannot route to (the spoke pulls, the
-	// hub answers). rolloutRestartHive bounds the attempt and honours the
-	// unreachable-cluster cache, so a firewalled cluster costs seconds here,
-	// not a gateway timeout.
-	delivered := s.rolloutRestartHive(cluster, id)
+	// PULL ONLY — no kubectl push. The manual Upgrade button now does exactly
+	// what auto-upgrade does: record the target and arm the heartbeat. The
+	// spoke collects it on its next beat and patches its own Deployment.
+	//
+	// UX CONSEQUENCE, DELIBERATE: the click no longer produces an immediate
+	// pod roll. Delivery is bounded by the heartbeat interval, so "clicked
+	// Upgrade, nothing visible yet" is now normal and must not be mistaken for
+	// the wedge this PR fixes. The hive is latched Upgrading with a target the
+	// moment the request returns, which is what the dashboard renders.
 
 	s.mu.Lock()
 	var latestSHA string
@@ -3883,10 +3886,10 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	if !delivered && latestSHA != "" {
-		// Arm the durable fallback: the spoke self-restarts onto the target
-		// when its next heartbeat carries UpgradeTo. The stale-upgrade sweep
-		// re-arms this if the spoke misses it, so the request cannot be lost.
+	if latestSHA != "" {
+		// Arm delivery: the spoke self-restarts onto the target when its next
+		// heartbeat carries UpgradeTo. The stale-upgrade sweep re-arms this if
+		// the spoke misses it, so the request cannot be lost.
 		if s.heartbeatUpgrade == nil {
 			s.heartbeatUpgrade = make(map[string]string)
 		}
@@ -3894,20 +3897,19 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.Unlock()
 
-	if !delivered && latestSHA == "" {
-		// kubectl failed AND no build target is known for the branch — there is
-		// nothing a heartbeat could deliver. This is the only remaining
-		// hard-failure case.
-		s.logger.Warn("upgrade failed: cluster unreachable and no build target known",
+	if latestSHA == "" {
+		// No build target is known for this hive's branch, so there is nothing
+		// the heartbeat could carry. This is the only hard-failure case left.
+		s.logger.Warn("upgrade failed: no build target known for this hive's branch",
 			"hive", id, "cluster", cluster.ID)
-		http.Error(w, `{"error":"upgrade failed — cluster unreachable and no build target known"}`, http.StatusBadGateway)
+		http.Error(w, `{"error":"upgrade failed — no build target known for this hive's branch"}`, http.StatusBadGateway)
 		return
 	}
 
-	mode := "kubectl"
-	if !delivered {
-		mode = "heartbeat"
-	}
+	// Always "heartbeat" now: the push path is retired, so every upgrade is
+	// collected by the spoke on its next beat. The UI uses this to say "queued"
+	// rather than implying an immediate roll.
+	const mode = "heartbeat"
 	s.logger.Info("audit: hosted hive upgrade requested",
 		"hive_id", id, "by", username, "cluster", cluster.ID, "mode", mode)
 	s.recordTimeline(id, TimelineUpgradeStarted, "upgrade requested from the hub dashboard ("+mode+")", username)
@@ -5144,39 +5146,32 @@ func (s *HubServer) markClusterReachable(clusterID string) {
 	delete(s.clusterUnreachableUntil, clusterID)
 }
 
-// rolloutRestartHive issues the auto-upgrade `kubectl rollout restart` for one
-// hive under a bounded timeout, honouring and maintaining the unreachable-cluster
-// cache. It returns false when kubectl did not deliver the restart — the caller
-// must then arm the heartbeat fallback, which is the ONLY path that works for
-// firewalled clusters. Skipping is reported as a plain failure (not an error) so
-// callers treat "known unreachable" and "just failed" identically.
-func (s *HubServer) rolloutRestartHive(cluster *ClusterConfig, hiveID string) bool {
-	if s.clusterRecentlyUnreachable(cluster.ID) {
-		s.logger.Debug("auto-upgrade kubectl skipped — cluster known unreachable, using heartbeat",
-			"hive", hiveID, "cluster", cluster.ID)
-		return false
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), upgradeKubectlTimeout)
-	defer cancel()
-	ns := "hive-hosted-" + hiveID
-	cmd := kubectlForClusterContext(ctx, cluster, "rollout", "restart", "deployment/hive", "-n", ns)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		s.markClusterUnreachable(cluster.ID)
-		s.logger.Warn("auto-upgrade kubectl failed, falling back to heartbeat",
-			"hive", hiveID, "cluster", cluster.ID,
-			"timeout", upgradeKubectlTimeout, "output", strings.TrimSpace(string(out)))
-		return false
-	}
-	s.markClusterReachable(cluster.ID)
-	return true
-}
+// PUSH PATH RETIRED. rolloutRestartHive() used to live here and issued
+// `kubectl rollout restart deployment/hive` into a spoke's cluster. Every
+// caller has been converted to the pull model — the hub records a target and
+// the spoke collects it on its own outbound heartbeat — so the function is
+// gone rather than left dormant.
+//
+// WHY DELETED RATHER THAN FLAG-DISABLED. A disabled flag would keep the hub's
+// need for write-capable kubeconfigs alive in the code, which is precisely the
+// standing blast radius this change exists to remove: compromise the hub and
+// you inherit write access into every reachable spoke cluster. A flag also
+// leaves two live delivery models with no stated direction, and the dormant
+// one inevitably rots — it would be the untested path on the day someone
+// flipped it back. Deleting it makes the direction unambiguous and lets the
+// operator drop or downgrade those kubeconfigs to read-only.
+//
+// The cost is real and accepted: delivery is now bounded by the heartbeat
+// interval instead of being immediate. Nothing is lost in reliability — the
+// heartbeat was already the only path that worked for firewalled clusters, and
+// the spoke-side self-upgrade is mature (retry budget, per-target attempt
+// marker, terminal failure reported back to the hub).
 
 func (s *HubServer) triggerAutoUpgrades() {
 	hives := listSaaSHives()
 	for _, h := range hives {
 		s.mu.RLock()
-		var currentSHA, branch, upgradeTarget, imageRef string
+		var currentSHA, branch, upgradeTarget, imageRef, lastHeartbeat string
 		var alreadyUpgrading bool
 		var upgradeStartedAt time.Time
 		for _, reg := range s.registry.Hives {
@@ -5187,6 +5182,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 				upgradeTarget = reg.UpgradeTarget
 				upgradeStartedAt = reg.UpgradeStartedAt
 				imageRef = reg.ImageRef
+				lastHeartbeat = reg.LastHeartbeat
 				break
 			}
 		}
@@ -5266,29 +5262,29 @@ func (s *HubServer) triggerAutoUpgrades() {
 			isStale := upgradeStartedAt.IsZero() || upgradeAge > staleUpgradeTimeout
 
 			if isStale {
-				// STRUCTURALLY UNDELIVERABLE: abandon, do not re-arm. This is
-				// the branch that produced the measured wedge — 208 re-arms in
-				// 15 minutes across 26 hives, stale_minutes climbing to 104 —
-				// because re-arming an upgrade the hub cannot deliver reproduces
-				// the identical no-op every staleUpgradeTimeout, forever, while
-				// beginUpgrade() preserves the original start clock so the
-				// elapsed only ever grows. The retry budget in
-				// sweepOrphanedUpgrades() cannot bound it: these hives never
-				// heartbeated, so evaluateOrphanedUpgrade() bails on the
-				// liveness test and the budget is never spent.
+				// UNCOLLECTIBLE: abandon, do not re-arm. This is the branch that
+				// produced the measured wedge — 26 hives re-arming, stale_minutes
+				// climbing past 146 and still rising — because re-arming an
+				// instruction nothing will ever pick up reproduces the identical
+				// no-op every staleUpgradeTimeout, forever, while beginUpgrade()
+				// preserves the original start clock so the elapsed only ever
+				// grows. The retry budget in sweepOrphanedUpgrades() cannot bound
+				// it: these hives never heartbeated, so evaluateOrphanedUpgrade()
+				// bails on the liveness test and the budget is never spent.
 				//
 				// Clearing the latch outright is what stops staleness
-				// accumulating. The hive stays on its old SHA — which is
-				// truthful and visible — instead of misreporting as
-				// perpetually "Upgrading" while reading offline. Nothing is
-				// lost: the spoke self-derives its configuration and upgrades
-				// independently of the hub, so the hub was never the thing
-				// keeping it current.
-				if !s.upgradeDeliverable(s.clusterForHive(&h)) {
-					reason := s.undeliverableUpgradeReason(s.clusterForHive(&h))
-					s.logger.Warn("abandoning stale upgrade — undeliverable, not re-arming",
+				// accumulating. The hive stays on its old SHA — truthful and
+				// visible — instead of misreporting as perpetually "Upgrading"
+				// while reading offline. Nothing is lost: the instruction was
+				// never being collected, so dropping it forfeits nothing. If the
+				// spoke later starts heartbeating, the normal arming path picks
+				// it up on the next poll.
+				if !upgradeCollectible(lastHeartbeat, time.Now()) {
+					reason := uncollectibleUpgradeReason(lastHeartbeat)
+					s.logger.Warn("abandoning stale upgrade — hive cannot collect it, not re-arming",
 						"hive", h.ID, "stale_minutes", int(upgradeAge.Minutes()),
-						"target", upgradeTarget, "reason", reason)
+						"target", upgradeTarget, "last_heartbeat", orDash(lastHeartbeat),
+						"reason", reason)
 					s.mu.Lock()
 					for i := range s.registry.Hives {
 						if s.registry.Hives[i].ID == h.ID {
@@ -5298,7 +5294,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 					}
 					delete(s.heartbeatUpgrade, h.ID)
 					s.mu.Unlock()
-					s.noteUndeliverableUpgrade(h.ID, upgradeTarget, reason)
+					s.noteUncollectibleUpgrade(h.ID, upgradeTarget, reason)
 					continue
 				}
 				// Upgrade has been stuck longer than staleUpgradeTimeout.
@@ -5355,16 +5351,12 @@ func (s *HubServer) triggerAutoUpgrades() {
 					}
 					s.heartbeatUpgrade[h.ID] = recoverTarget
 					s.mu.Unlock()
-					hiveCluster := s.clusterForHive(&h)
-					if hiveCluster != nil && !hiveCluster.InCluster {
-						// Failure here is expected when the hub can't reach the
-						// hive's cluster; the heartbeat fallback armed above is
-						// what actually delivers the upgrade. rolloutRestartHive
-						// bounds the attempt and skips it entirely for clusters
-						// already known unreachable, so this recovery path can't
-						// re-introduce the per-hive timeout stall either.
-						s.rolloutRestartHive(hiveCluster, h.ID)
-					}
+					// PULL ONLY — the heartbeat armed above IS the delivery, as
+					// the previous comment here already conceded ("the heartbeat
+					// fallback armed above is what actually delivers the
+					// upgrade"). The kubectl push that followed it was pure
+					// latency optimisation and is deliberately gone; see the
+					// push-path retirement note in pullonly_upgrade.go.
 					continue
 				}
 			}
@@ -5433,28 +5425,33 @@ func (s *HubServer) triggerAutoUpgrades() {
 			s.logger.Warn("auto-upgrade skipped — no cluster config", "hive_id", h.ID, "cluster_id", h.ClusterID)
 			continue
 		}
-		// Do not ARM an upgrade the hub has no mechanism to deliver. Arming one
-		// latches Upgrading=true, and because rolloutRestartHive() cannot reach a
-		// pull-only cluster and the heartbeat fallback needs a spoke that is
-		// already checking in, nothing ever clears that latch: the stale-recovery
-		// branch above re-arms every staleUpgradeTimeout while beginUpgrade()
-		// preserves the original start clock, so the elapsed grows without bound
-		// and the hive reads "offline" while claiming to be upgrading. The
-		// orphan sweep's retry budget cannot rescue it either — a hive that never
-		// heartbeated fails evaluateOrphanedUpgrade()'s liveness test, so the
-		// budget is never spent and exhaustion never converts it to a visible
-		// failure. See pullonly_upgrade.go for the full measured loop.
+		// Do not ARM an upgrade this hive cannot COLLECT. Delivery is PULL: the
+		// spoke reads UpgradeTo off its own outbound heartbeat response and then
+		// patches its own Deployment with its own ServiceAccount. A hive that
+		// never heartbeats therefore never picks the instruction up, while
+		// Upgrading=true latches on the hub: the stale-recovery branch above
+		// re-arms every staleUpgradeTimeout, beginUpgrade() preserves the
+		// original start clock, and the elapsed grows without bound. The orphan
+		// sweep's retry budget cannot rescue it — a hive that never heartbeated
+		// fails evaluateOrphanedUpgrade()'s liveness test, so the budget is never
+		// spent and exhaustion never converts it to a visible failure. See
+		// pullonly_upgrade.go for the full measured loop.
+		//
+		// This is deliberately NOT gated on cluster reachability. The hub's
+		// kubectl path is only a fast-path optimisation, so a pull-only cluster
+		// is irrelevant here; gating on it would silently disable auto-upgrade
+		// for the 40+ pull-only spokes that heartbeat perfectly well.
 		//
 		// Refused LOUDLY, never silently: a hive with auto_upgrade=true that
 		// simply never upgrades is indistinguishable from one already at latest,
-		// which is how this stayed unnoticed. The timeline entry is the durable
-		// operator-visible record.
-		if !s.upgradeDeliverable(hiveCluster) {
-			reason := s.undeliverableUpgradeReason(hiveCluster)
-			s.logger.Warn("auto-upgrade not armed — undeliverable",
+		// which is how this stayed unnoticed.
+		if !upgradeCollectible(lastHeartbeat, time.Now()) {
+			reason := uncollectibleUpgradeReason(lastHeartbeat)
+			s.logger.Warn("auto-upgrade not armed — hive cannot collect the instruction",
 				"hive_id", h.ID, "cluster", hiveCluster.ID, "branch", branch,
-				"from", currentSHA, "would_have_targeted", latestSHA, "reason", reason)
-			s.noteUndeliverableUpgrade(h.ID, latestSHA, reason)
+				"from", currentSHA, "would_have_targeted", latestSHA,
+				"last_heartbeat", orDash(lastHeartbeat), "reason", reason)
+			s.noteUncollectibleUpgrade(h.ID, latestSHA, reason)
 			continue
 		}
 		// Record the day's fire BEFORE kicking the rollout. Persisting first
@@ -5477,7 +5474,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 		}
 		// The hive is deliverable again — drop any suppressed-refusal memory so a
 		// future undeliverable episode is reported afresh rather than swallowed.
-		forgetUndeliverableUpgrade(h.ID)
+		forgetUncollectibleUpgrade(h.ID)
 		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID, "mode", normalizeAutoUpgradeMode(h.AutoUpgradeMode))
 		s.recordTimeline(h.ID, TimelineUpgradeStarted,
 			fmt.Sprintf("auto-upgrade triggered on %s: %s → %s", branch, orDash(currentSHA), latestSHA), "auto-upgrade")
@@ -5489,15 +5486,21 @@ func (s *HubServer) triggerAutoUpgrades() {
 			}
 		}
 		s.mu.Unlock()
-		if !s.rolloutRestartHive(hiveCluster, h.ID) {
-			// kubectl can't reach the cluster — fall back to heartbeat-based
-			// upgrade (path 3). The next heartbeat from this hive will include
-			// UpgradeTo, causing the spoke to self-restart.
-			s.mu.Lock()
-			s.heartbeatUpgrade[h.ID] = latestSHA
-			// Keep Upgrading=true so the dashboard shows the correct state.
-			s.mu.Unlock()
-		}
+		// PULL ONLY — no kubectl push. Arming the heartbeat is the delivery:
+		// the spoke reads UpgradeTo off its next heartbeat response and patches
+		// its own Deployment with its own ServiceAccount (cmd/hive/main.go →
+		// self_upgrade.go). The former `rolloutRestartHive` call here was only a
+		// latency optimisation, and it is deliberately gone: keeping it would
+		// require the hub to hold write-capable kubeconfigs into every spoke
+		// cluster, which is a large standing blast radius for a few seconds of
+		// speed. See the push-path retirement note in pullonly_upgrade.go.
+		//
+		// The trade is real and accepted: delivery is now bounded by the
+		// heartbeat interval rather than being immediate.
+		s.mu.Lock()
+		s.heartbeatUpgrade[h.ID] = latestSHA
+		// Keep Upgrading=true so the dashboard shows the correct state.
+		s.mu.Unlock()
 	}
 }
 

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -12,8 +12,8 @@ import (
 // Bulk fleet operations for the hub dashboard's "My Hives" list.
 //
 // Every bulk action is a thin fan-out over the SAME logic the single-hive
-// handlers use (handleUpgradeHive, handleToggleAutoUpgrade, handleSwitchBranch,
-// rolloutRestartHive). The rules that make this safe to expose:
+// handlers use (handleUpgradeHive, handleToggleAutoUpgrade, handleSwitchBranch).
+// The rules that make this safe to expose:
 //
 //  1. Authorization is re-derived PER HIVE from the hub's own store. The
 //     client-supplied ID list is treated as untrusted input: every ID is
@@ -73,9 +73,11 @@ type BulkHiveRequest struct {
 }
 
 // BulkHiveResult is the outcome for ONE hive in a bulk request. Ok=false always
-// carries a human-readable Error; Via records the delivery path actually used
-// ("kubectl" or "heartbeat") so the UI can explain why a firewalled cluster's
-// hive reports success without an immediate rollout.
+// carries a human-readable Error; Via records the delivery path actually used.
+// Under the pull model this is "heartbeat" for every cluster action ("store" for
+// ones that only write hub-side state), which is also the honest signal to the
+// UI that success means "queued for the spoke's next check-in", not "already
+// rolled".
 type BulkHiveResult struct {
 	HiveID string `json:"hive_id"`
 	Ok     bool   `json:"ok"`
@@ -85,7 +87,8 @@ type BulkHiveResult struct {
 
 // Delivery paths reported in BulkHiveResult.Via.
 const (
-	bulkViaKubectl   = "kubectl"
+	// bulkViaKubectl was removed with the push path: no bulk action shells out
+	// to a spoke cluster any more, so no result can be delivered "via kubectl".
 	bulkViaHeartbeat = "heartbeat"
 	bulkViaStore     = "store"
 )
@@ -279,19 +282,18 @@ func (s *HubServer) applyBulkAction(action, branch, id, username string) BulkHiv
 	return BulkHiveResult{HiveID: id, Ok: false, Error: "unknown bulk action"}
 }
 
-// bulkRestartOrUpgrade restarts one hive's deployment. This is the same
-// operation handleUpgradeHive performs (`kubectl rollout restart
-// deployment/hive`), but routed through rolloutRestartHive so it inherits the
-// bounded timeout and the unreachable-cluster cache — without that, a batch
-// containing hives on a firewalled cluster (vllm-d) would stall for the full
-// kubectl timeout per hive.
+// bulkRestartOrUpgrade restarts or upgrades one hive, PULL ONLY — the hub never
+// kubectls into the spoke's cluster.
 //
-// When kubectl cannot deliver (firewalled cluster, or one already known
-// unreachable), the heartbeat fallback is armed exactly as the single-hive
-// paths do: s.heartbeatUpgrade[id] is set to the branch's latest SHA and the
-// registry is marked Upgrading, so the spoke self-restarts on its next
-// check-in. That is the ONLY delivery path for unreachable clusters, so it is
-// reported as success with Via="heartbeat", not as an error.
+// An upgrade arms s.heartbeatUpgrade[id] with the branch's latest SHA and marks
+// the registry Upgrading; a restart arms the durable RequestedRestartAt, which
+// the heartbeat path turns into resp.RestartSpoke. Either way the spoke applies
+// the change to its own Deployment on its next check-in, so this is reported as
+// success with Via="heartbeat".
+//
+// This is the same mechanism that was previously the "fallback" for firewalled
+// clusters; it is now the only path, on every cluster. Delivery is therefore
+// bounded by the heartbeat interval rather than immediate.
 func (s *HubServer) bulkRestartOrUpgrade(h *SaaSHive, id, username, action string) BulkHiveResult {
 	cluster := s.clusterForHive(h)
 	if cluster == nil {
@@ -315,7 +317,22 @@ func (s *HubServer) bulkRestartOrUpgrade(h *SaaSHive, id, username, action strin
 	}
 	latestSHA := getLatestSHAForBranch(branch)
 
-	delivered := s.rolloutRestartHive(cluster, id)
+	// PULL ONLY — no kubectl push. An upgrade is delivered by arming
+	// heartbeatUpgrade below; a plain restart is delivered by arming the
+	// durable RequestedRestartAt, which the heartbeat path turns into
+	// resp.RestartSpoke and the spoke applies to itself. Neither needs the hub
+	// to hold write access into the spoke's cluster.
+	delivered := false
+	if action == bulkActionRestart {
+		if rh := loadSaaSHive(id); rh != nil {
+			rh.RequestedRestartAt = time.Now().UTC().Format(time.RFC3339)
+			if err := saveSaaSHive(rh); err != nil {
+				s.logger.Warn("bulk restart: failed to arm spoke restart", "hive", id, "error", err)
+			} else {
+				delivered = true
+			}
+		}
+	}
 
 	s.mu.Lock()
 	for i := range s.registry.Hives {
@@ -329,17 +346,22 @@ func (s *HubServer) bulkRestartOrUpgrade(h *SaaSHive, id, username, action strin
 		}
 		break
 	}
-	if !delivered && action == bulkActionUpgrade && latestSHA != "" {
+	// Unconditional under the pull model: arming the heartbeat IS the delivery
+	// for an upgrade, not a fallback for when a push failed.
+	if action == bulkActionUpgrade && latestSHA != "" {
 		s.heartbeatUpgrade[id] = latestSHA
+		delivered = true
 	}
 	s.mu.Unlock()
 
 	if !delivered && action == bulkActionRestart {
-		// A restart has no SHA to hand the spoke, so there is nothing the
-		// heartbeat path can carry — say so instead of reporting success.
-		s.logger.Warn("bulk restart could not reach cluster", "hive", id, "cluster", cluster.ID)
+		// Arming the durable RequestedRestartAt is the only thing that can fail
+		// here now (a store write), and it is a real error rather than an
+		// unreachable-cluster report: the pull path does not depend on the hub
+		// being able to reach the cluster at all.
+		s.logger.Warn("bulk restart could not be armed", "hive", id, "cluster", cluster.ID)
 		return BulkHiveResult{HiveID: id, Ok: false,
-			Error: "cluster unreachable from the hub — restart could not be delivered"}
+			Error: "could not arm the restart for delivery over the heartbeat"}
 	}
 	if !delivered {
 		s.logger.Info("audit: bulk upgrade queued via heartbeat",
@@ -347,7 +369,8 @@ func (s *HubServer) bulkRestartOrUpgrade(h *SaaSHive, id, username, action strin
 		return BulkHiveResult{HiveID: id, Ok: true, Via: bulkViaHeartbeat}
 	}
 	s.logger.Info("audit: bulk hive "+action, "hive_id", id, "by", username, "cluster", cluster.ID)
-	return BulkHiveResult{HiveID: id, Ok: true, Via: bulkViaKubectl}
+	// Pull only — the spoke applies this on its next check-in.
+	return BulkHiveResult{HiveID: id, Ok: true, Via: bulkViaHeartbeat}
 }
 
 // bulkSetAutoUpgrade mirrors handleToggleAutoUpgrade's persistence: the SaaS
@@ -382,21 +405,14 @@ func (s *HubServer) bulkSwitchBranch(h *SaaSHive, id, username, branch string) B
 	imageTag := branchToTag(branch) + "-latest"
 	image := bulkHiveImageRepo + ":" + imageTag
 
+	// PULL ONLY — no `kubectl set image` push. heartbeatSwitchTag armed below
+	// is the delivery: the spoke holds the hive-self-upgrade RBAC to patch its
+	// own Deployment and applies the new tag on its next check-in, which the
+	// doc comment above already describes as the mechanism. Dropping the push
+	// removes the last reason for the hub to hold write-capable kubeconfigs
+	// into spoke clusters.
+	_ = image
 	delivered := false
-	if !s.clusterRecentlyUnreachable(cluster.ID) {
-		ns := hiveHostedNamespacePrefix + id
-		cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			s.markClusterUnreachable(cluster.ID)
-			s.logger.Warn("bulk branch switch kubectl failed, using heartbeat fallback",
-				"hive", id, "branch", branch, "output", string(out))
-		} else {
-			s.markClusterReachable(cluster.ID)
-			delivered = true
-			// Restart so the new image is pulled — same as the single-hive path.
-			s.rolloutRestartHive(cluster, id)
-		}
-	}
 
 	s.mu.Lock()
 	if !delivered {
@@ -410,10 +426,9 @@ func (s *HubServer) bulkSwitchBranch(h *SaaSHive, id, username, branch string) B
 	}
 	s.mu.Unlock()
 
-	via := bulkViaKubectl
-	if !delivered {
-		via = bulkViaHeartbeat
-	}
+	// Pull only: the switch is delivered by heartbeatSwitchTag, never by a push.
+	via := bulkViaHeartbeat
+	_ = delivered
 	s.logger.Info("audit: bulk hive branch switched",
 		"hive_id", id, "branch", branch, "image", image, "by", username, "via", via)
 	return BulkHiveResult{HiveID: id, Ok: true, Via: via}

--- a/v2/pkg/hub/saas_bulk_coverage_test.go
+++ b/v2/pkg/hub/saas_bulk_coverage_test.go
@@ -113,8 +113,11 @@ func TestBulkRestartViaKubectlWhenClusterReachable(t *testing.T) {
 	if !res.Ok {
 		t.Fatalf("restart on a reachable cluster must succeed, got %q", res.Error)
 	}
-	if res.Via != bulkViaKubectl {
-		t.Fatalf("want Via=%q, got %q", bulkViaKubectl, res.Via)
+	// INVERTED DELIBERATELY: the `kubectl set image` push is retired, so a
+	// branch switch is delivered by arming heartbeatSwitchTag and Via is
+	// "heartbeat" on every cluster.
+	if res.Via != bulkViaHeartbeat {
+		t.Fatalf("want Via=%q, got %q", bulkViaHeartbeat, res.Via)
 	}
 }
 
@@ -127,12 +130,17 @@ func TestBulkRestartFailsWhenClusterUnreachable(t *testing.T) {
 	bulkHiveOnCluster(t, s, "hosted-x", "alice", "v2")
 
 	res := s.applyBulkAction(bulkActionRestart, "", "hosted-x", "alice")
-	if res.Ok {
-		t.Fatal("an undeliverable restart must NOT report success — a restart has " +
-			"no heartbeat fallback")
-	}
-	if res.Error == "" {
-		t.Fatal("the failure must carry an explanation")
+	// INVERTED DELIBERATELY (push-path retirement). This test used to assert
+	// "an undeliverable restart must NOT report success — a restart has no
+	// heartbeat fallback". That premise died with the push path: a restart is
+	// now delivered by arming the durable RequestedRestartAt, which the
+	// heartbeat turns into resp.RestartSpoke and the spoke applies to itself.
+	// Cluster reachability is irrelevant, so there is no "undeliverable" case
+	// left to report — asserting the old behaviour would now be asserting that
+	// a working feature is broken.
+	if !res.Ok {
+		t.Fatalf("a restart must succeed via the heartbeat pull path regardless of "+
+			"cluster reachability, got %q", res.Error)
 	}
 	s.mu.RLock()
 	_, armed := s.heartbeatUpgrade["hosted-x"]
@@ -142,9 +150,9 @@ func TestBulkRestartFailsWhenClusterUnreachable(t *testing.T) {
 	}
 }
 
-// An upgrade that kubectl cannot deliver IS success, via the heartbeat path —
-// the only delivery route for a firewalled cluster. The spoke self-restarts on
-// its next check-in.
+// An upgrade is delivered over the heartbeat on EVERY cluster. This was
+// previously framed as a "fallback" for firewalled clusters; with the push path
+// retired it is simply the delivery mechanism, so Via is always "heartbeat".
 func TestBulkUpgradeFallsBackToHeartbeatWhenUnreachable(t *testing.T) {
 	installBulkKubectl(t, false)
 	s := bulkTestHub(t)
@@ -337,8 +345,11 @@ func TestBulkSwitchBranchViaKubectl(t *testing.T) {
 	if !res.Ok {
 		t.Fatalf("branch switch failed: %q", res.Error)
 	}
-	if res.Via != bulkViaKubectl {
-		t.Fatalf("want Via=%q, got %q", bulkViaKubectl, res.Via)
+	// INVERTED DELIBERATELY: the `kubectl set image` push is retired, so a
+	// branch switch is delivered by arming heartbeatSwitchTag and Via is
+	// "heartbeat" on every cluster.
+	if res.Via != bulkViaHeartbeat {
+		t.Fatalf("want Via=%q, got %q", bulkViaHeartbeat, res.Via)
 	}
 	reg := bulkRegistryEntry(t, s, "hosted-x")
 	if !reg.Upgrading {
@@ -348,12 +359,13 @@ func TestBulkSwitchBranchViaKubectl(t *testing.T) {
 	if reg.UpgradeTarget != branchToTag("dd")+"-latest" {
 		t.Fatalf("upgrade target = %q, want the branch's -latest tag", reg.UpgradeTarget)
 	}
-	// kubectl delivered, so no heartbeat fallback should be armed.
+	// The pull path IS the delivery, so the switch tag MUST be armed.
 	s.mu.RLock()
 	_, armed := s.heartbeatSwitchTag["hosted-x"]
 	s.mu.RUnlock()
-	if armed {
-		t.Fatal("a delivered switch must not also arm the heartbeat fallback")
+	if !armed {
+		t.Fatal("the branch switch must arm heartbeatSwitchTag — under the pull model " +
+			"that IS the delivery, not a fallback for a failed push")
 	}
 }
 

--- a/v2/pkg/hub/upgrade_recovery_test.go
+++ b/v2/pkg/hub/upgrade_recovery_test.go
@@ -110,6 +110,11 @@ func TestTriggerAutoUpgradesRecoversStaleManualUpgrade(t *testing.T) {
 	s.registry.Hives = []RegistryEntry{{
 		ID: "manual-1", GitBranch: "v2", GitHash: "old1234", Upgrading: true,
 		UpgradeTarget: "fc32ae4", UpgradeStartedAt: time.Now().Add(-30 * time.Minute),
+		// Alive: recovery re-arms delivery for a spoke that will COLLECT the
+		// instruction on its next beat. A hive that never heartbeated is
+		// abandoned instead, which is a different case (see
+		// pullonly_upgrade_test.go).
+		LastHeartbeat: time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339),
 	}}
 
 	s.triggerAutoUpgrades()
@@ -168,6 +173,9 @@ func TestTriggerAutoUpgradesRecoversStaleDailyModeHiveHeldBySchedule(t *testing.
 	s.registry.Hives = []RegistryEntry{{
 		ID: "daily-1", GitBranch: "v2", GitHash: "old1234", Upgrading: true,
 		UpgradeTarget: "fc32ae4", UpgradeStartedAt: time.Now().Add(-30 * time.Minute),
+		// Alive, so the assertion stays on the schedule-gate behaviour rather
+		// than on heartbeat collectability.
+		LastHeartbeat: time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339),
 	}}
 
 	s.triggerAutoUpgrades()


### PR DESCRIPTION
## ⚠️ This corrects a wrong gate that #3839 merged onto `v4`

**#3839 merged at 14:13:49Z while this rework was in progress.** It carried a gate keyed on **cluster reachability**, which is the wrong predicate. This PR replaces it, retires the push path, and keeps the branch fix. It should be treated as urgent: the merged gate can silently disable auto-upgrade for healthy spokes.

## What #3839 got wrong

It assumed the hub *delivers* upgrades by writing into the spoke's cluster, so it refused to arm when the hub couldn't write. **Delivery is pull.** Verified in source, both ends:

| step | location |
|---|---|
| hub sets `resp.UpgradeTo` on the heartbeat **response** | `server.go` ~2194 / ~2201 |
| spoke reads it, invokes `UpgradeCallback` | `heartbeat.go` ~752 |
| callback runs **on the spoke** — patches its own Deployment | `cmd/hive/main.go` ~3358 → `self_upgrade.go` |
| using the spoke's **own** ServiceAccount | `/var/run/secrets/kubernetes.io/serviceaccount` |

`saas.go` already said it outright — *"the heartbeat fallback armed above is what actually delivers the upgrade"*. `rolloutRestartHive` was a latency optimisation, not the mechanism.

**Consequence of the merged gate:** it would refuse to arm for every pull-only spoke that heartbeats perfectly well — 40+ of them — turning a *loud* wedge into a **silent permanent opt-out**, which is strictly worse. A spoke that quietly stops upgrading looks identical to one already at latest.

Not argued — **proven**: reintroducing the old gate fails `TestPullOnlyHiveThatHeartbeatsStillUpgrades` and `TestBrieflyQuietHiveStillUpgrades`:

```
--- FAIL: TestPullOnlyHiveThatHeartbeatsStillUpgrades (0.00s)
    pullonly_upgrade_test.go:76: a pull-only spoke that heartbeats MUST still auto-upgrade
--- FAIL: TestBrieflyQuietHiveStillUpgrades (0.00s)
    pullonly_upgrade_test.go:167: a briefly-quiet spoke must still be armed
```

## The correct gate: heartbeat history

What the 26 wedged hives share is **not their cluster** — it is that they have **never heartbeated**. Confirmed on the live registry: no `last_heartbeat`, no `git_branch`, no `orphaned_upgrade_sweeps`, while `upgrading=true`. The pull-only clusters were a red herring that correlated perfectly, because that is where the unassigned placeholders live.

A spoke that never calls home never collects its instruction → stale-recovery re-arms forever → `beginUpgrade` preserves the original start clock so elapsed only grows → and the orphan sweep's retry budget can't bound it, because `evaluateOrphanedUpgrade` bails on an unparseable `LastHeartbeat`.

Bound is `staleRemoveAge`, deliberately **not** `maxHeartbeatAge` (5m): gating on the Online threshold would refuse a spoke that is quiet *precisely because* it is restarting into the upgrade we just armed.

## Push path retired (security)

Per operator decision — *"the heartbeat works, why take a chance to compromise a spoke with kubeconfig in the hub."*

`rolloutRestartHive` is **deleted**, not flag-disabled. A dormant flag keeps the hub's need for write-capable kubeconfigs alive in code — the exact standing blast radius this removes — and leaves two delivery models with no stated direction, the dormant one rotting until someone flips it back.

Converted: auto-upgrade, stale recovery, manual button, bulk restart/upgrade, bulk branch-switch. `bulkViaKubectl` is now dead and removed. Bulk restart uses the durable `RequestedRestartAt` → `resp.RestartSpoke` pull path.

## 🚧 Kubeconfigs are NOT yet droppable

**Node stats still read them** (`saas.go` ~2000 `get nodes`, ~1993 `top nodes`, ~2126 summary). The heartbeat fallback beside them fires **only on error/timeout** — on a reachable cluster the kubectl path succeeds, so the spoke is never asked. Dropping the kubeconfig would degrade stats **silently**, the worst outcome.

The spoke-side collector cannot answer today:
- requires the **metrics API first**, returns `nil` otherwise (`cluster_metrics.go` ~59) — and `nodes.metrics.k8s.io` is granted on neither cluster;
- gated on `HIVE_CLUSTER_ID` (`cmd/hive/main.go` ~3310), which provisioning never emits;
- node-read RBAC is **absent from the provisioning template** — where it exists on `vllm-d` it was granted out-of-band.

Verified live on `hive-oke` — spoke `hive-sa`, both `no`:
```
auth can-i list nodes                 -> no
auth can-i list nodes.metrics.k8s.io  -> no
```

Provisioning also inherently writes (namespaces, Deployments, RBAC) and is not in scope for pull.

**Ordering constraint: node-stats pull + its provisioning prerequisites must land BEFORE any kubeconfig is dropped or downgraded to read-only.** Proposed split — (1) this PR, upgrades; (2) node-stats pull path + provisioning emits RBAC and `HIVE_CLUSTER_ID`; (3) operator drops kubeconfigs. Anything relying on hand-patched RBAC is exactly the drift class nothing in code re-asserts.

## Operator constraints — both verified end-to-end

`TestManualUpgradeButtonWorksUnderPull` drives the real HTTP handler and asserts 200 + target armed + `Upgrading` latched. `TestAutoUpgradeToggleWorksUnderPull` asserts the toggle persists **and** that the hive is armed on the next cycle, on a pull-only cluster.

**UX:** delivery is now bounded by the heartbeat interval. The manual button reports `"mode":"heartbeat"` so the UI can say *queued* rather than implying an immediate roll — latency made legible, not hidden by reintroducing push.

## Kept: `upgradeBranchOrDefault`

`branch = "v2"` on an empty `GitBranch` pointed every unassigned placeholder at v2 — now confirmed **unmaintained** — and armed `0b78dc0`, a v2-only commit, on a v4 hub. On a hive that *can* collect, this is the more dangerous bug: it picks the instruction up and rolls onto a dead branch's build.

## Tests

**Controls** (both directions — these stop "disable everything" passing): `TestPullOnlyHiveThatHeartbeatsStillUpgrades`, `TestBrieflyQuietHiveStillUpgrades`, `TestStaleUpgradeStillRecoveredForLiveHive`, `TestUpgradePathNeverShellsOutToCluster`, `TestManualUpgradeButtonWorksUnderPull`, `TestAutoUpgradeToggleWorksUnderPull`

**Wedge**: `TestAutoUpgradeNotArmedForNeverHeartbeatedHive`, `TestAutoUpgradeNotArmedForLongDeadHive`, `TestStaleUpgradeNotReArmedForUncollectibleHive`, `TestUncollectibleUpgradeCannotAccumulateStaleness` (25 cycles), `TestUncollectibleUpgradeIsSurfacedNotSilent`, `TestUncollectibleRefusalIsDeduplicated`, `TestUpgradeCollectiblePredicate`, `TestUpgradeBranchDefaultsToHubBranchNotV2`, `TestLiveHiveNeverTargetedWithForeignBranchSHA`

### Inverted deliberately

These **encoded the retired push model** — asserting them now would assert that a working feature is broken:

- `TestBulkRestartFailsWhenClusterUnreachable` — asserted *"a restart has no heartbeat fallback"*. `RestartSpoke` is exactly that fallback.
- `TestBulkSwitchBranchViaKubectl` — asserted `Via=kubectl` and that a delivered switch must **not** arm `heartbeatSwitchTag`. Arming it **is** the delivery now.
- `TestBulkUpgradeFallsBackToHeartbeatWhenUnreachable` — reframed: heartbeat is the mechanism, not a fallback.

Five further tests (assignment-latch, recovery) had fixtures with no `LastHeartbeat`, which under pull means "cannot collect". Given a beat so they keep testing the **latch** rather than passing for a new wrong reason.

### Replay

Neutered `upgradeCollectible` to `return true` + restored the v2 default (still compiles): **8 wedge tests fail, ALL controls pass** — the controls exercise the live path independently. Restored: green. Full `pkg/hub` suite green (`ok, 101.366s`, exit 0).
