### PR TITLE
🔒 fix(gh-wrapper): deny-by-default allowlist for the general command surface

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -193,6 +193,94 @@ for arg in "${args[@]}"; do
   esac
 done
 
+# ── GENERAL COMMAND-SURFACE ALLOWLIST (#3840, F6/F7 residual) ────────────────
+#
+# Everything below this point is a DENYLIST: each gate names a specific thing an
+# agent must not do (`pr merge`, `issue create`, mutating `gh api`, ...) and the
+# script ends in a bare `exec "$REAL_GH" "$@"`. So any subcommand nobody thought
+# to enumerate reached real GitHub with the App token attached. That is the same
+# failure shape as the mode `case` with no default arm (fixed in ce9d19aa):
+# unenumerated input takes the permissive branch.
+#
+# This was not theoretical. Against the stub harness, on v4 @ c9ea2cc8, EVERY
+# one of these reached gh with rc=0 — including in NO_GITHUB mode, the most
+# restrictive mode there is, because the mode gates only ever inspect
+# `subcmd = issue|pr`:
+#
+#   NO_GITHUB     gh auth token                 → reached gh  (exfiltrates the token)
+#   NO_GITHUB     gh secret set FOO --body bar  → reached gh  (writes Actions secrets)
+#   NO_GITHUB     gh ssh-key add /tmp/k.pub     → reached gh  (persistent account access)
+#   NO_GITHUB     gh variable set X --body y    → reached gh
+#   ISSUES_ONLY   gh repo delete owner/repo     → reached gh  (destroys the repo)
+#   ISSUES_ONLY   gh release create v9.9.9      → reached gh  (publishes artifacts)
+#   ISSUES_ONLY   gh gist create /etc/passwd    → reached gh  (exfiltrates file content)
+#   ADVISORY      gh workflow run deploy.yml    → reached gh  (arbitrary CI execution)
+#
+# So we deny by default and enumerate what agents legitimately do. The permitted
+# set below was derived from actual usage in this repo — the agent policies
+# (v2/policies/*.md, examples/kubestellar/agents/**) and bin/*.sh — NOT invented,
+# so the allowlist cannot quietly break the fleet. Ordering matters: this runs
+# BEFORE the mode/ACMM gates, so it only decides whether a verb is on the map at
+# all. Everything it admits is still subject to every gate below — `pr merge`
+# passes here and is then held by the merge-eligibility allowlist.
+#
+# Adding a verb here is a deliberate security decision: it must be something an
+# agent genuinely needs, and it must be safe for a prompt-injected agent to run.
+_gh_surface_allowed() {
+  local s="$1" a="$2"
+  case "$s" in
+    # Core work surface. Per-action so a new destructive action on an existing
+    # subcommand (e.g. a future `gh pr delete`) is denied until reviewed, rather
+    # than inherited for free by allowing the whole subcommand.
+    issue)
+      case "$a" in
+        list|view|create|edit|comment|close|reopen|status|develop) return 0 ;;
+      esac ;;
+    pr)
+      case "$a" in
+        list|view|create|edit|comment|close|reopen|status|diff|checks| \
+        merge|review|ready|checkout) return 0 ;;
+      esac ;;
+    # Read-only discovery.
+    search)
+      case "$a" in issues|prs|repos|code|commits) return 0 ;; esac ;;
+    run)
+      case "$a" in list|view|watch) return 0 ;; esac ;;
+    release)
+      case "$a" in list|view) return 0 ;; esac ;;
+    cache)
+      case "$a" in list) return 0 ;; esac ;;
+    label)
+      # The wrapper itself calls `gh label create` to ensure agent/hive labels
+      # exist before tagging (see _ensure_labels below).
+      case "$a" in list|create) return 0 ;; esac ;;
+    repo)
+      # fork/clone/view are the contributor flow (contribute_ws.go:3207 issues
+      # `gh repo fork <r> --clone=true`). `delete`, `archive`, `rename`,
+      # `edit` and `deploy-key` are deliberately NOT here.
+      case "$a" in view|list|fork|clone) return 0 ;; esac ;;
+    # `gh api` has its own read/write split gate further down, which is finer
+    # grained than anything expressible here (it distinguishes GET from an
+    # implicit POST). Admit the subcommand and let that gate do the work.
+    api) return 0 ;;
+    # No-network local helpers.
+    help|version|--version|--help|status) return 0 ;;
+  esac
+  return 1
+}
+
+# `gh` with no arguments prints help — harmless, and denying it produces a
+# confusing error for an agent that is just probing.
+if [ -n "$subcmd" ] && ! _gh_surface_allowed "$subcmd" "$action"; then
+  echo "⛔ BLOCKED: 'gh ${subcmd}${action:+ $action}' is not on the hive's allowlist of permitted gh commands." >&2
+  echo "The wrapper denies by default: only commands agents are known to need are permitted," >&2
+  echo "so a subcommand nobody reviewed cannot reach GitHub with the App token attached (#3840)." >&2
+  echo "Permitted: issue/pr (list view create edit comment close reopen ...), search, run list|view|watch," >&2
+  echo "           release list|view, label list|create, repo view|list|fork|clone, api, help, version." >&2
+  echo "If this command is genuinely needed, ask the operator to add it to _gh_surface_allowed in bin/gh-wrapper.sh." >&2
+  exit 1
+fi
+
 # ── Helpers: author validation for the list gate ──
 
 # Extract the --author value from the args array. Returns the value on stdout

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -81,6 +81,7 @@ run_wrapper() {
   [[ "$out" == *"unrecognized agent mode"* ]] && gate=mode-default
   [[ "$out" == *"NOT in merge-eligible.json"* || "$out" == *"cannot verify merge eligibility"* ]] && gate=eligibility
   [[ "$out" == *"needs an explicit PR number or URL"* ]] && gate=no-identifier
+  [[ "$out" == *"is not on the hive's allowlist"* ]] && gate=surface
 
   echo "exit=${rc} stub=${reached} gate=${gate}"
   # Surface wrapper output only when debugging a failure.
@@ -197,6 +198,82 @@ assert_blocked "PR URL is normalized and reaches the eligibility gate" \
   "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge https://github.com/owner/repo/pull/123)" eligibility
 assert_blocked "-R form reaches the eligibility gate (not a parse denial)" \
   "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123 -R owner/repo)" eligibility
+
+# ── #3840: general command surface is an ALLOWLIST, not a denylist ───────────
+# Before the fix the script ended in a bare `exec "$REAL_GH" "$@"`, so any
+# subcommand no gate named reached GitHub with the App token attached. Each of
+# these was verified reaching gh with rc=0 on v4 @ c9ea2cc8 — several in
+# NO_GITHUB mode, because the mode gates only ever inspect `issue`/`pr`.
+#
+# These assert on `gate=surface` specifically. Without that pin a test could go
+# green off some unrelated gate (NO_GITHUB blocks pr/issue, ADVISORY blocks
+# creates) and keep passing even if the allowlist were deleted entirely.
+echo "-- general surface denies by default (#3840) --"
+assert_blocked "gh auth token cannot exfiltrate the App token (NO_GITHUB)" \
+  "$(run_wrapper "NO_GITHUB" 5 -- auth token)" surface
+assert_blocked "gh secret set is denied (NO_GITHUB)" \
+  "$(run_wrapper "NO_GITHUB" 5 -- secret set FOO --body bar)" surface
+assert_blocked "gh ssh-key add is denied (NO_GITHUB)" \
+  "$(run_wrapper "NO_GITHUB" 5 -- ssh-key add /tmp/k.pub)" surface
+assert_blocked "gh variable set is denied (NO_GITHUB)" \
+  "$(run_wrapper "NO_GITHUB" 5 -- variable set X --body y)" surface
+assert_blocked "gh repo delete is denied (ISSUES_ONLY)" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- repo delete owner/repo --yes)" surface
+assert_blocked "gh release create is denied (ISSUES_ONLY)" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- release create v9.9.9)" surface
+assert_blocked "gh gist create is denied (ISSUES_ONLY)" \
+  "$(run_wrapper "ISSUES_ONLY" 5 -- gist create /etc/passwd)" surface
+assert_blocked "gh workflow run is denied (ADVISORY)" \
+  "$(run_wrapper "ADVISORY" 5 -- workflow run deploy.yml)" surface
+# Denial is per-ACTION, not per-subcommand: an allowed subcommand must not carry
+# a destructive action through with it.
+assert_blocked "an unlisted action on an allowed subcommand is denied (repo archive)" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- repo archive owner/repo)" surface
+assert_blocked "an unlisted action on an allowed subcommand is denied (release delete)" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- release delete v1)" surface
+# The N7 flag parser feeds this gate, so the reorder trick must not smuggle a
+# denied verb past it either.
+assert_blocked "flag-reordered denied verb is still denied" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- secret --repo owner/repo set FOO)" surface
+
+# ── POSITIVE CONTROL: the allowlist must not be "deny everything" ────────────
+# This is the control that makes the block-assertions above meaningful. If these
+# fail, the fix has broken real agent workflows — which is a worse outcome than
+# the vulnerability, and exactly how a "security fix" gets reverted wholesale.
+# Every command here is one agents actually run per v2/policies/*.md,
+# examples/kubestellar/agents/** and bin/*.sh.
+echo "-- allowlist preserves the operations agents actually perform --"
+assert_reached "issue view reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- issue view 1 --repo owner/repo)"
+assert_reached "pr view reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr view 1 --repo owner/repo)"
+assert_reached "pr diff reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr diff 1 --repo owner/repo)"
+assert_reached "pr checks reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr checks 1 --repo owner/repo)"
+assert_reached "search issues reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- search issues --repo owner/repo)"
+assert_reached "search prs reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- search prs --repo owner/repo)"
+assert_reached "run list reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- run list --repo owner/repo)"
+assert_reached "run view reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- run view 123 --repo owner/repo)"
+assert_reached "release list reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- release list --repo owner/repo)"
+assert_reached "repo view reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- repo view owner/repo)"
+assert_reached "repo fork (contributor flow) reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- repo fork owner/repo --clone=false)"
+assert_reached "read-only gh api reaches gh" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- api repos/owner/repo/pulls)"
+
+# The allowlist admits `pr merge` as a VERB; the merge-eligibility allowlist is
+# what actually decides it. Asserting gate=eligibility here proves the surface
+# gate did not swallow the merge path — if it had, the eligibility gate would
+# never run and this would report gate=surface.
+assert_blocked "pr merge passes the surface gate and is held by eligibility" \
+  "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123)" eligibility
 
 echo
 echo "=== $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
Fixes #3840

## What the issue claimed vs what I found

The issue said the general command surface is denylist-shaped and fails open. **Confirmed, and worse than described.** The mode gates only ever inspect `subcmd = issue|pr`, and the script ends in a bare `exec "$REAL_GH" "$@"` — so the *most restrictive* mode still let an agent write secrets and exfiltrate the App token.

Verified by executing the wrapper against a stub `REAL_GH` on `origin/v4` @ `c9ea2cc8`. Every one of these reached gh with `rc=0`:

```
mode=NO_GITHUB        rc=0 reached_gh=yes :: gh auth token
mode=NO_GITHUB        rc=0 reached_gh=yes :: gh secret set FOO --body bar
mode=ISSUES_ONLY      rc=0 reached_gh=yes :: gh release create v9.9.9
mode=ISSUES_ONLY      rc=0 reached_gh=yes :: gh repo delete owner/repo --yes
mode=ADVISORY         rc=0 reached_gh=yes :: gh workflow run deploy.yml
mode=NO_GITHUB        rc=0 reached_gh=yes :: gh ssh-key add /tmp/k.pub
mode=ISSUES_ONLY      rc=0 reached_gh=yes :: gh gist create /etc/passwd
mode=NO_GITHUB        rc=0 reached_gh=yes :: gh variable set X --body y
```

`gh auth token` prints the injected per-agent App token to stdout. `gh secret set` / `ssh-key add` are persistent write access. `gh repo delete` is destructive. None were reachable through any gate because no gate named them.

## Pattern followed

The merge-eligibility allowlist already in this file (`bin/gh-wrapper.sh:451-553` + `merge-eligible.json`), as the issue directed — deny by default, fail loudly, no silent skip. Not invented.

`_gh_surface_allowed` runs **before** the mode/ACMM gates and only decides whether a verb is on the map at all. Everything it admits is still subject to every gate below: `pr merge` passes the surface gate and is then held by merge-eligibility. Matching is **per-action**, so a future destructive action on an already-allowed subcommand (e.g. a new `gh pr delete`) is denied until reviewed rather than inherited for free.

## Preserving legitimate operations

This is the control that stops "deny everything" from passing. The permitted set was derived from **actual usage** in this repo — `v2/policies/*.md`, `examples/kubestellar/agents/**`, and `bin/*.sh` — not guessed. Notably preserved: `gh repo fork` (the contributor flow in `contribute_ws.go:3207`), `gh label create` (the wrapper's own `_ensure_labels`), and read-only `gh api` (which keeps its own finer-grained GET/POST split gate).

## Tests

`bin/test_gh_wrapper_gates.sh`, **22 → 46**. Already CI-gated by `v2-ci.yml`. It executes the wrapper against a stub and asserts on exit codes — not `grep` against script text, per the issue's guidance.

**No existing assertion was modified or relaxed.** New denial assertions pin `gate=surface` so they cannot go green off an unrelated gate (`NO_GITHUB` blocks pr/issue anyway, `ADVISORY` blocks creates — without the tag these would pass even with the allowlist deleted).

Positive control, both directions: 12 assertions that the operations agents genuinely perform still reach gh, plus one asserting `pr merge` reports `gate=eligibility` — proving the surface gate did not swallow the merge path.

## Regression replay

Neutering the gate to `if false` (restoring the pre-fix fail-open):

```
### NEUTERED — expecting the #3840 surface tests to FAIL ###
  FAIL: gh auth token cannot exfiltrate the App token (NO_GITHUB)
  FAIL: gh secret set is denied (NO_GITHUB)
  FAIL: gh ssh-key add is denied (NO_GITHUB)
  FAIL: gh variable set is denied (NO_GITHUB)
  FAIL: gh repo delete is denied (ISSUES_ONLY)
  FAIL: gh release create is denied (ISSUES_ONLY)
  FAIL: gh gist create is denied (ISSUES_ONLY)
  FAIL: gh workflow run is denied (ADVISORY)
  FAIL: an unlisted action on an allowed subcommand is denied (repo archive)
  FAIL: an unlisted action on an allowed subcommand is denied (release delete)
  FAIL: flag-reordered denied verb is still denied
=== 35 passed, 11 failed ===
```

Exactly the 11 new denial assertions fail and no others — the 12 positive controls stay green, confirming they test availability rather than the gate. Restored:

```
=== 46 passed, 0 failed ===
```

`shellcheck -S error` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)