### PR TITLE
🔒 fix(supply-chain): digest-pin the hub alpine base and assert the nous commit pin

### DIFF
--- a/v2/Dockerfile.hub
+++ b/v2/Dockerfile.hub
@@ -27,7 +27,13 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
 # alongside `builder`. Busting only `builder` rebuilt a fresh /hive but let
 # BuildKit serve the final-stage `COPY --from=builder /hive` layer from the
 # branch-scoped GHA cache, shipping the OLD binary. See docker.yml.
-FROM alpine:3.24 AS runtime
+# Digest-pinned (#3843): a bare `alpine:3.24` tag is mutable — Alpine re-pushes
+# the patch tag on every CVE respin, so the trusted computing base of the hub
+# image could change with no diff in this repo. Every other FROM here was
+# already digest-pinned; this was the last tag-only one. Digest resolved from
+# docker.io/library/alpine:3.24 (an OCI index, so it stays multi-arch — the
+# amd64/arm64 hub builds both still work).
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS runtime
 ARG TARGETARCH
 ARG KUBECTL_VERSION=v1.36.3
 ARG KUBECTL_SHA256_AMD64=ebbd080e7c2e275093b55915722043257eb24004363e20acb3c4d71919f88336

--- a/v2/deploy/test_supply_chain_pins.sh
+++ b/v2/deploy/test_supply_chain_pins.sh
@@ -143,6 +143,84 @@ else
        "expected an 'echo \"\$NODESOURCE_KEY_SHA256  /tmp/nodesource.key\" | sha256sum -c -' step in $DOCKERFILE_CONTRIB"
 fi
 
+# --- 6. Every FROM must be digest-pinned (#3843) ------------------------------
+# A tag is mutable. `alpine:3.24` was the last tag-only base here, and Alpine
+# re-pushes patch tags on every CVE respin — so the hub image's whole trusted
+# computing base could change with no diff in this repo.
+#
+# This is written as a SWEEP over every FROM in every v2 Dockerfile rather than
+# a named check for alpine, deliberately: a named check would pass forever while
+# a NEW tag-pinned base was added next to it. The failure mode being guarded is
+# "someone adds an unpinned FROM", which only a sweep catches.
+#
+# `FROM x AS y` and `COPY --from=<stage>` refer to build STAGES, not registry
+# images, and have no digest — so stage names defined earlier in the same file
+# are excluded from the requirement.
+for df in "$DOCKERFILE" "$DOCKERFILE_CONTRIB" "$V2_DIR/Dockerfile.hub"; do
+  rel="${df#"$(dirname "$V2_DIR")"/}"
+  if [ ! -f "$df" ]; then
+    fail "$rel exists for FROM digest sweep" "file not found"
+    continue
+  fi
+
+  # Collect stage aliases (the `AS <name>` on each FROM) so intra-file stage
+  # references are not mistaken for unpinned registry images.
+  stages="$(grep -iE '^[[:space:]]*FROM[[:space:]]' "$df" \
+            | sed -nE 's/.*[[:space:]][aA][sS][[:space:]]+([A-Za-z0-9_.-]+).*/\1/p')"
+
+  unpinned=""
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Image reference is the first token after FROM, skipping --platform=... flags.
+    img="$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*[fF][rR][oO][mA-Za-z]*[[:space:]]+//; s/^(--[a-z-]+(=[^ ]+)?[[:space:]]+)*//' | awk '{print $1}')"
+    [ -z "$img" ] && continue
+    # Skip references to a stage declared in this same file.
+    if printf '%s\n' "$stages" | grep -qxF "$img"; then continue; fi
+    # Skip scratch, which has no digest by definition.
+    [ "$img" = "scratch" ] && continue
+    if ! printf '%s\n' "$img" | grep -qE '@sha256:[0-9a-f]{64}$'; then
+      unpinned="${unpinned}${img} "
+    fi
+  done <<EOF
+$(grep -iE '^[[:space:]]*FROM[[:space:]]' "$df")
+EOF
+
+  if [ -n "$unpinned" ]; then
+    fail "$rel: every FROM is digest-pinned" "tag-pinned (mutable): $unpinned"
+  else
+    pass "$rel: every FROM is digest-pinned"
+  fi
+done
+
+# --- 7. Nous must install from a pinned COMMIT, not a branch (#3843) ---------
+# The Nous framework is `git clone`d and pip-installed with `-e`. Cloning
+# without a checkout would track the default branch, so the content behind a
+# fixed Dockerfile line could change on any upstream push — a supply-chain
+# injection with no diff here. Guard BOTH halves: the ARG must be a full 40-hex
+# commit SHA (a branch name or short SHA is not good enough — a short SHA is
+# ambiguous and a branch moves), AND the RUN must actually `git checkout` it.
+# Pinning the ARG without wiring the checkout would regress silently to
+# "whatever the default branch says", which is exactly the shape of the
+# PI_VERSION regression this file was written for.
+nous_arg="$(grep -E '^[[:space:]]*ARG[[:space:]]+NOUS_COMMIT[[:space:]]*=' "$DOCKERFILE" | head -1 || true)"
+if [ -z "$nous_arg" ]; then
+  fail "NOUS_COMMIT is present and pinned" "no ARG NOUS_COMMIT found in $DOCKERFILE"
+else
+  nous_value="$(echo "${nous_arg#*=}" | tr -d ' "'"'"'')"
+  if echo "$nous_value" | grep -qE '^[0-9a-f]{40}$'; then
+    pass "NOUS_COMMIT is pinned to a full 40-hex commit SHA"
+  else
+    fail "NOUS_COMMIT is pinned to a full 40-hex commit SHA" "got: '$nous_value'"
+  fi
+fi
+
+if grep -qE 'git -C /opt/nous checkout "\$\{NOUS_COMMIT\}"' "$DOCKERFILE"; then
+  pass "nous clone is checked out at the pinned NOUS_COMMIT"
+else
+  fail "nous clone is checked out at the pinned NOUS_COMMIT" \
+       "expected a 'git -C /opt/nous checkout \"\${NOUS_COMMIT}\"' step in $DOCKERFILE"
+fi
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Fixes #3843

The issue flagged three inputs and noted it was **not verified** in the #2172 triage pass. Verified each against `origin/v4` @ `c9ea2cc8`: **two were already fixed, one was a real gap.** The larger finding is that two of the three pins had *no CI assertion*, which is exactly how the `PI_VERSION` pin was silently lost.

## 1. su-exec — already done, no change needed

`v2/Dockerfile:110-114` pins `SU_EXEC_COMMIT=89c016e6` and verifies `SU_EXEC_SHA256` with `sha256sum -c` before compiling. `v2/scripts/check-suid-contract.sh:98-107` already asserts the commit ARG, the SHA256 ARG, that the URL interpolates the commit, and that `sha256sum -c` runs — CI-gated by `.github/workflows/suid-contract.yml`. Given C6's history this was the item I most expected to find open; it is closed. **Stale finding.**

## 2. Base images — one real gap

Every `FROM` across the three v2 Dockerfiles was digest-pinned **except**:

```
v2/Dockerfile.hub:30:FROM alpine:3.24 AS runtime
```

Alpine re-pushes patch tags on every CVE respin, so the hub's entire trusted computing base could change with no diff in this repo. Pinned to `sha256:28bd5fe8...`. Confirmed via `docker buildx imagetools inspect` that this is an **OCI index** carrying both `linux/amd64` and `linux/arm64/v8`, so the multi-arch hub build is unaffected.

## 3. pip feature-branch install — content pinned, assertion missing

`ARG NOUS_COMMIT=8de28905` with `git checkout "${NOUS_COMMIT}"` after the clone, so the branch ref is *not* actually floating — the issue's concern was already addressed in the Dockerfile. But **nothing asserted it**, so a future edit could drop the checkout and silently return to tracking the default branch.

## Pattern followed

The #3838 nodesource model, as directed: guard **the pin AND the step that uses it**, since pinning an ARG without wiring the check regresses silently to trust-on-first-use. Assertions live in `v2/deploy/test_supply_chain_pins.sh`, already gated by `v2-ci.yml`.

One deliberate design choice: the base-image check is a **sweep over every `FROM` in all three Dockerfiles**, not a named check for alpine. A named check would pass forever while a new tag-pinned base was added beside it — and "someone adds an unpinned FROM" is the failure mode actually being guarded. The sweep skips intra-file stage aliases (`FROM x AS y` / `COPY --from=`) and `scratch`, which have no digests.

## Deliberate-break replay

Each break restored to green (`17 passed, 0 failed`) afterward:

```
### BREAK 1: revert alpine to a bare tag ###
  FAIL: v2/Dockerfile.hub: every FROM is digest-pinned
=== 16 passed, 1 failed ===

### BREAK 2: NOUS_COMMIT set to a branch name ###
  FAIL: NOUS_COMMIT is pinned to a full 40-hex commit SHA
  PASS: nous clone is checked out at the pinned NOUS_COMMIT
=== 16 passed, 1 failed ===

### BREAK 3: ARG stays pinned but the checkout is dropped ###
  FAIL: nous clone is checked out at the pinned NOUS_COMMIT
=== 16 passed, 1 failed ===

### RESTORED ###
=== 17 passed, 0 failed ===
```

Breaks 2 and 3 confirm the two halves of the nous guard fail **independently** — a pinned ARG whose checkout was deleted is still caught, which is the regression the #3838 pattern exists to prevent.

## Tests

**12 → 17.** No existing assertion was modified or relaxed.

## Not verified

A full image build — too slow to run locally, so I am not claiming it. The alpine digest was resolved and its platform list confirmed via `docker buildx imagetools inspect`; CI will exercise the actual build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)