### PR TITLE
fix(dashboard): authenticate snapshot builder so live data is baked in

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -876,13 +876,33 @@ func (s *Server) buildSnapshot(outputFile, mode string) {
 		"--base-path", "/snapshot",
 		"--html", htmlSource,
 		dashURL, outputFile)
-	cmd.Env = append(os.Environ(), "NODE_TLS_REJECT_UNAUTHORIZED=0")
+	// The builder fetches /api/status (and siblings) from localhost. Those
+	// endpoints require auth, so without a token the builder gets 401 and
+	// bakes an empty snapshot (blank Governor/Tokens/Cost/Repos/Beads/Agents
+	// panels, ACMM "--"). Pass s.authToken as DASHBOARD_AUTH_TOKEN so the
+	// builder authenticates via the trusted X-Hive-Internal header path. The
+	// token is used ONLY as a request header for the localhost fetch; the
+	// builder never writes it into the snapshot HTML output.
+	cmd.Env = snapshotBuilderEnv(os.Environ(), s.authToken)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		s.logger.Warn("snapshot build failed", "error", err, "output", string(out))
 	} else {
 		s.logger.Info("snapshot built", "file", outputFile)
 	}
+}
+
+// snapshotBuilderEnv returns the environment for the Node snapshot builder.
+// NODE_TLS_REJECT_UNAUTHORIZED=0 is always set for the localhost fetch. When
+// authToken is non-empty it is exposed as DASHBOARD_AUTH_TOKEN so the builder
+// can send the trusted X-Hive-Internal header and receive live data instead of
+// a 401. Open/no-auth spokes (empty token) get the prior behavior unchanged.
+func snapshotBuilderEnv(baseEnv []string, authToken string) []string {
+	env := append(baseEnv, "NODE_TLS_REJECT_UNAUTHORIZED=0")
+	if authToken != "" {
+		env = append(env, "DASHBOARD_AUTH_TOKEN="+authToken)
+	}
+	return env
 }
 
 func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/snapshot_test.go
+++ b/v2/pkg/dashboard/snapshot_test.go
@@ -277,6 +277,43 @@ func TestSnapshotAPINoSecretsEmbedded(t *testing.T) {
 	}
 }
 
+// TestSnapshotBuilderEnvPassesAuthToken is the regression test for the empty
+// /snapshot page: the Node snapshot builder fetches /api/status unauthenticated
+// and gets 401 unless DASHBOARD_AUTH_TOKEN is supplied. When the server has an
+// auth token it MUST be exposed to the builder (as the trusted X-Hive-Internal
+// credential); when there is no token the env must be left unchanged so open
+// spokes keep working.
+func TestSnapshotBuilderEnvPassesAuthToken(t *testing.T) {
+	const token = "test-internal-token-1234"
+
+	// With a token: DASHBOARD_AUTH_TOKEN must be present with that value.
+	env := snapshotBuilderEnv([]string{"PATH=/usr/bin"}, token)
+	var gotToken string
+	var haveTLS bool
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, "DASHBOARD_AUTH_TOKEN="); ok {
+			gotToken = v
+		}
+		if kv == "NODE_TLS_REJECT_UNAUTHORIZED=0" {
+			haveTLS = true
+		}
+	}
+	if !haveTLS {
+		t.Error("snapshotBuilderEnv must always set NODE_TLS_REJECT_UNAUTHORIZED=0")
+	}
+	if gotToken != token {
+		t.Errorf("DASHBOARD_AUTH_TOKEN = %q, want %q — builder would fetch /api/status unauthenticated and bake an empty snapshot", gotToken, token)
+	}
+
+	// Without a token: DASHBOARD_AUTH_TOKEN must NOT be added (open spokes).
+	env = snapshotBuilderEnv([]string{"PATH=/usr/bin"}, "")
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "DASHBOARD_AUTH_TOKEN=") {
+			t.Errorf("snapshotBuilderEnv added %q for an empty token — must leave no-auth spokes unchanged", kv)
+		}
+	}
+}
+
 func TestSnapshotFrameAncestorsEndpoint(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.Dashboard.SnapshotFrameAncestors = []string{"https://docs.projectbluefin.io"}


### PR DESCRIPTION
## Problem

The read-only `/snapshot` page renders with **no live data** — empty Governor / Tokens / Cost / Repos / Beads / Agents panels, and ACMM stats showing `--`. This is especially visible on mobile, where the informational sidebar is hidden and the page looks barren.

## Root cause

`buildSnapshot` (in `v2/pkg/dashboard/api.go`) spawns the Node snapshot builder (`dashboard/build-snapshot.mjs`), which fetches `/api/status` (and siblings) from localhost to bake live data into the static snapshot.

The builder authenticates by sending the `X-Hive-Internal` header **only when** `DASHBOARD_AUTH_TOKEN` is set in its environment. `buildSnapshot` never set that env var, so the builder fetched `/api/status` **unauthenticated** → the endpoint returned `{"error":"unauthorized"}` (401) → the snapshot baked in **no live data**.

## Fix

When `s.authToken` is non-empty, pass it to the builder child process as `DASHBOARD_AUTH_TOKEN`, so the builder uses the already-trusted server-to-server `X-Hive-Internal` path recognized by the auth middleware (`server.go`: `internalTrusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)`).

The env construction is extracted into a tiny pure helper, `snapshotBuilderEnv`, so the behavior is unit-testable without executing Node.

### Safety
- The token is passed **only** as an env var to a trusted local child process (the snapshot builder running in the same pod) and is used **solely as a request header** for the localhost fetch. It is **never written into the snapshot HTML output** — `build-snapshot.mjs` already only uses it as the fetch header and is unchanged here. The token is never logged.
- Guarded on `s.authToken != ""`, so open/no-auth spokes are entirely unaffected (identical behavior to before).

## Tests

Added `TestSnapshotBuilderEnvPassesAuthToken` in `snapshot_test.go`, asserting:
- with a token set, the builder env contains `DASHBOARD_AUTH_TOKEN=<token>` (and still `NODE_TLS_REJECT_UNAUTHORIZED=0`);
- with an empty token, `DASHBOARD_AUTH_TOKEN` is **not** added (open spokes unchanged).

## Scope
Only `v2/pkg/dashboard/api.go` (fix) and `v2/pkg/dashboard/snapshot_test.go` (test) changed. `build-snapshot.mjs`, CSS, and everything else are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)