### PR TITLE
fix: share contributor claim admission

### DIFF
--- a/v2/pkg/dashboard/contribute_admission.go
+++ b/v2/pkg/dashboard/contribute_admission.go
@@ -1,0 +1,60 @@
+package dashboard
+
+import ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+
+type contributorAdmissionCandidate struct {
+	repoFull string
+	repoName string
+	number   int
+}
+
+type contributorAdmissionDecision struct {
+	admitted bool
+	reason   string
+	claim    ghpkg.IssueClaim
+}
+
+const contributorAdmissionReasonOpenPRClaim = "open_pr_claim"
+
+// evaluateContributorNeutralAdmission applies repository-global admission
+// decisions shared by ReadyQueue and selectTask. Contributor-specific policy,
+// ranking, cooldowns, rate limits, role matching, and routing remain in their
+// existing downstream paths.
+func (h *ContributeWSHub) evaluateContributorNeutralAdmission(candidate contributorAdmissionCandidate) contributorAdmissionDecision {
+	claim, claimed := h.issueClaimedByOpenPR(candidate.repoFull, candidate.repoName, candidate.number)
+	if claimed {
+		return contributorAdmissionDecision{
+			reason: contributorAdmissionReasonOpenPRClaim,
+			claim:  claim,
+		}
+	}
+	return contributorAdmissionDecision{admitted: true}
+}
+
+// issueClaimedByOpenPR reports whether ANY open PR already claims to fix the
+// given issue (kubestellar/hive#3768), via the Dependencies.IssueClaimed hook
+// into the governor's duplicate-PR claim ledger. Unlike the agent-side
+// FilterClaimedIssues — which deliberately honours only hive-authored claims —
+// the contribute queue must honour EVERY claim: a human contributor's open PR
+// is exactly the "someone is already on it" signal whose absence let the same
+// issue be handed to contributor after contributor.
+//
+// The ledger keys claims by the repo spelling used in the hive config, which
+// FrontendRepo.Name preserves; repo.Full is the org-qualified form and is tried
+// first since cross-repo `owner/repo#N` closing references key on it. A hub
+// with no hook wired (tests, or a hive booted without GitHub credentials)
+// reports no claims and selection proceeds exactly as before.
+func (h *ContributeWSHub) issueClaimedByOpenPR(repoFull, repoName string, number int) (ghpkg.IssueClaim, bool) {
+	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.IssueClaimed == nil {
+		return ghpkg.IssueClaim{}, false
+	}
+	if claim, ok := h.server.deps.IssueClaimed(repoFull, number); ok {
+		return claim, true
+	}
+	if repoName != "" && repoName != repoFull {
+		if claim, ok := h.server.deps.IssueClaimed(repoName, number); ok {
+			return claim, true
+		}
+	}
+	return ghpkg.IssueClaim{}, false
+}

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -275,6 +275,14 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 			if active[fmt.Sprintf("%s#%d", repo.Full, number)] {
 				continue
 			}
+			decision := h.evaluateContributorNeutralAdmission(contributorAdmissionCandidate{
+				repoFull: repo.Full,
+				repoName: repo.Name,
+				number:   number,
+			})
+			if !decision.admitted {
+				continue
+			}
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
 			author, _ := issue["author"].(string)

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/kubestellar/hive/v2/pkg/config"
-	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
 
 const (
@@ -3319,34 +3318,6 @@ func (h *ContributeWSHub) resumeGateReason(c *ContributorConnection) string {
 	return ""
 }
 
-// issueClaimedByOpenPR reports whether ANY open PR already claims to fix the
-// given issue (kubestellar/hive#3768), via the Dependencies.IssueClaimed hook
-// into the governor's duplicate-PR claim ledger. Unlike the agent-side
-// FilterClaimedIssues — which deliberately honours only hive-authored claims —
-// the contribute queue must honour EVERY claim: a human contributor's open PR
-// is exactly the "someone is already on it" signal whose absence let the same
-// issue be handed to contributor after contributor.
-//
-// The ledger keys claims by the repo spelling used in the hive config, which
-// FrontendRepo.Name preserves; repo.Full is the org-qualified form and is tried
-// first since cross-repo `owner/repo#N` closing references key on it. A hub
-// with no hook wired (tests, or a hive booted without GitHub credentials)
-// reports no claims and selection proceeds exactly as before.
-func (h *ContributeWSHub) issueClaimedByOpenPR(repoFull, repoName string, number int) (ghpkg.IssueClaim, bool) {
-	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.IssueClaimed == nil {
-		return ghpkg.IssueClaim{}, false
-	}
-	if claim, ok := h.server.deps.IssueClaimed(repoFull, number); ok {
-		return claim, true
-	}
-	if repoName != "" && repoName != repoFull {
-		if claim, ok := h.server.deps.IssueClaimed(repoName, number); ok {
-			return claim, true
-		}
-	}
-	return ghpkg.IssueClaim{}, false
-}
-
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.selectMu.Lock()
 	defer h.selectMu.Unlock()
@@ -3631,10 +3602,17 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			// PR per window. The claim ledger sees the open PR itself on the
 			// next eval cycle, which closes that hole regardless of what the
 			// relay managed to report.
-			if claim, claimed := h.issueClaimedByOpenPR(repo.Full, repo.Name, number); claimed {
-				h.logger.Info("[contribute-ws] skip: issue already claimed by an open PR",
-					"repo", repo.Full, "number", number,
-					"pr_url", claim.PRURL, "pr_author", claim.PRAuthor)
+			decision := h.evaluateContributorNeutralAdmission(contributorAdmissionCandidate{
+				repoFull: repo.Full,
+				repoName: repo.Name,
+				number:   number,
+			})
+			if !decision.admitted {
+				if decision.reason == contributorAdmissionReasonOpenPRClaim {
+					h.logger.Info("[contribute-ws] skip: issue already claimed by an open PR",
+						"repo", repo.Full, "number", number,
+						"pr_url", decision.claim.PRURL, "pr_author", decision.claim.PRAuthor)
+				}
 				continue
 			}
 			// Yank self-exclusion: an issue this SAME clanker was just yanked off is

--- a/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
+++ b/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
@@ -89,6 +89,45 @@ func TestClaimedIssue_SkippedAndNextOffered(t *testing.T) {
 	}
 }
 
+// TestClaimedIssue_ReadyQueueMatchesSelectTaskAdmission pins the contributor
+// queue contract: repository-global admission decisions must agree between the
+// read-only ReadyQueue projection and live selectTask assignment. An open PR
+// claims #353, so both paths must withhold it while leaving #360 offerable.
+func TestClaimedIssue_ReadyQueueMatchesSelectTaskAdmission(t *testing.T) {
+	for _, claimRepo := range []string{"projectbluefin/dakota", "dakota"} {
+		t.Run(claimRepo, func(t *testing.T) {
+			hub, s := covK2Hub(t)
+			claimedIssueStatus(s)
+			s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+				if repo == claimRepo && number == 353 {
+					return externalClaim(repo, number), true
+				}
+				return ghpkg.IssueClaim{}, false
+			}
+
+			queue := hub.ReadyQueue(readyQueueDefaultLimit)
+			if len(queue) != 1 || queue[0].Number != 360 {
+				t.Fatalf("ReadyQueue should initially offer only unclaimed #360, got %+v", queue)
+			}
+
+			conn := claimedIssueConn()
+			hub.mu.Lock()
+			hub.connections["conn-a"] = conn
+			hub.mu.Unlock()
+
+			msg := hub.selectTask(conn)
+			if msg == nil || msg.Type != "task_assign" || msg.Number != 360 {
+				t.Fatalf("selectTask should skip claimed #353 and assign #360, got %+v", msg)
+			}
+
+			queue = hub.ReadyQueue(readyQueueDefaultLimit)
+			if len(queue) != 0 {
+				t.Fatalf("ReadyQueue should be empty while #360 is active, got %+v", queue)
+			}
+		})
+	}
+}
+
 // TestClaimedIssue_AllClaimedYieldsNoMatchingWork: when every admissible issue
 // is claimed by an open PR, the contributor gets an explicit no_matching_work
 // negative-ack — never a duplicate assignment.


### PR DESCRIPTION
## Summary

- reproduce the contributor queue drift where `selectTask` suppresses an issue claimed by an open PR while `ReadyQueue` still advertises it
- extract a deterministic contributor-neutral admission decision shared by both live projections
- preserve contributor-specific cooldown, role, trust, rate, ranking, and routing behavior downstream

## Behavioral change

Before, an open-PR claim prevented live assignment but the same issue remained visible as ready/offerable. After this change, both `ReadyQueue` and `selectTask` consume the same claim-admission decision, including canonical and bare repository-key lookup, while unrelated work remains offerable.

## Scope

This PR establishes and proves the shared admission contract only. It does **not** implement `DependsOn`, desired-state persistence, proofs, CRDs, or scheduler behavior.

## Verification

- `go test ./pkg/dashboard -run '^TestClaimedIssue_ReadyQueueMatchesSelectTaskAdmission$' -count=1`
- `go test ./pkg/dashboard -run '^TestClaimedIssue_' -count=1`
- `go test ./pkg/dashboard -count=1`

Progresses #3845
