### PR TITLE
🔒 fix(hub): derive HIVE_SESSION_KEY per-hive (audit RESIDUAL-2)

### DIFF
--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -168,6 +168,54 @@ func provisionSessionPublicKey() string {
 	return ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSessionEd25519Seed))
 }
 
+// provisionSessionKey returns the PER-HIVE value injected into a spoke as
+// HIVE_SESSION_KEY (audit RESIDUAL-2).
+//
+// Measured live before this change: 1 distinct value across all 70 spokes,
+// 0 converged — not sweep drift, but derivation by design. desiredPerHiveEnv
+// derived this var with deriveDomainKey, which takes no hiveID, while its
+// neighbours two lines away used derivePerHiveKey. Uniformity was the intended
+// output of the old formula, so no rotation could ever have made these
+// per-hive: a rotation moves all 70 in lockstep. That is why this is a code
+// change and not a convergence problem.
+//
+// WHY THIS IS SAFE TO MAKE PER-HIVE — the value is no longer a comparand.
+// Every lane that once VERIFIED against this key is already deleted:
+//
+//   - F1 removed the Go legacy symmetric cookie lane
+//     (hub_cookie.go verifyHubUserCookieEitherAt, `_ = legacySecret`).
+//   - N3 stopped the terminal key falling through to it (terminal_assertion.go).
+//   - F23 removed the Node proxy's copy (proxy/server.js
+//     verifyHubUserCookieAcrossKeys, `void legacySecret`).
+//
+// What remains on the spoke reads this var for its PRESENCE, never its value:
+// the proxy's IS_HOSTED boot signal is `SESSION_KEY !== ”`. SpokeSessionKey()
+// has zero non-test Go callers. So no party compares a value derived here
+// against a value derived anywhere else, and changing the formula cannot make
+// two honest parties disagree.
+//
+// THE SELF-DERIVE FALLBACK IS THEREFORE HARMLESS, and this is the one thing
+// worth being explicit about, because it is the obvious way a change like this
+// breaks a fleet. A spoke that lacks the env var self-derives it, and both
+// spoke-side resolvers — Go spokeDomainKey(EnvSessionKey, infoSessionKey) and
+// the proxy's deriveSessionKey() — self-derive the FLEET-WIDE value from
+// HIVE_HUB_SECRET, because neither mixes in the hive ID. Once the hub injects a
+// per-hive value the two disagree by construction, and during the roll the
+// fleet holds a mix of both. That is fine here, and only here, precisely
+// because nothing verifies with it: a disagreement over a value no one compares
+// has no observable effect. Both surviving readers are emptiness checks, and a
+// per-hive value is exactly as non-empty as a fleet-wide one, so IS_HOSTED is
+// unchanged for every spoke in every state.
+//
+// Deliberately NOT changing the self-derive fallbacks to match. Making them
+// per-hive would be dead code on both sides today, and on the spoke it would
+// hand a wrong answer to a spoke that has no HIVE_ID — flipping IS_HOSTED to
+// false and silently converting a hosted hive to the self-hosted identity
+// model. The fallbacks stay as they are until the var is dropped outright.
+func provisionSessionKey(hiveID string) string {
+	return derivePerHiveKey(provisionCurrentSecret(), infoSessionKey, hiveID)
+}
+
 // provisionTerminalKey returns the PER-HIVE terminal signing key injected into a
 // spoke as HIVE_TERMINAL_KEY (audit N3).
 //

--- a/v2/pkg/hub/perhive_env_generation_test.go
+++ b/v2/pkg/hub/perhive_env_generation_test.go
@@ -65,7 +65,7 @@ func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
 		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretB, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretB, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(perHiveGenSecretB, infoInviteKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(perHiveGenSecretB, infoSessionKey),
+		EnvSessionKey:       derivePerHiveKey(perHiveGenSecretB, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSessionEd25519Seed)),
 	}
@@ -73,7 +73,7 @@ func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
 		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretA, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretA, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(perHiveGenSecretA, infoInviteKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(perHiveGenSecretA, infoSessionKey),
+		EnvSessionKey:       derivePerHiveKey(perHiveGenSecretA, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSessionEd25519Seed)),
 	}
@@ -159,7 +159,7 @@ func TestDesiredPerHiveEnvDerivesFromCurrentGeneration(t *testing.T) {
 	expect := map[string]string{
 		EnvHeartbeatKey:     derivePerHiveKey(cur, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(cur, infoTerminalKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(cur, infoSessionKey),
+		EnvSessionKey:       derivePerHiveKey(cur, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(cur, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(cur, infoSessionEd25519Seed)),
 	}
@@ -191,9 +191,21 @@ func TestPerHiveEnvGenerationIsAReadPathChangeToday(t *testing.T) {
 
 	master := provisionMasterSecret() // the PRE-generation expression
 	preGeneration := map[string]string{
-		EnvHeartbeatKey:     derivePerHiveKey(master, infoHeartbeatKey, hiveID),
-		EnvTerminalKey:      derivePerHiveKey(master, infoTerminalKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
+		EnvHeartbeatKey: derivePerHiveKey(master, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:  derivePerHiveKey(master, infoTerminalKey, hiveID),
+		// AUDIT RESIDUAL-2. This entry is deliberately INVERTED rather than
+		// relaxed. It used to read deriveDomainKey(master, infoSessionKey) —
+		// the fleet-uniform expression — and it was correct to do so: this test
+		// proves the GENERATION work was a pure read-path change. Making the
+		// session key per-hive is a genuinely fleet-VISIBLE change, so leaving
+		// the old right-hand side here would have been a real failure, and
+		// simply deleting the entry would have silently dropped HIVE_SESSION_KEY
+		// from this test's coverage.
+		//
+		// The invariant this test exists to protect is unchanged for every other
+		// var; for this one the claim is now the opposite and is asserted
+		// explicitly below, so a revert to the fleet-wide formula FAILS here.
+		EnvSessionKey:       derivePerHiveKey(master, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(master, infoSessionEd25519Seed)),
 	}
@@ -206,6 +218,18 @@ func TestPerHiveEnvGenerationIsAReadPathChangeToday(t *testing.T) {
 		if got[name] != v {
 			t.Errorf("%s changed value: this PR must be a read-path change with no fleet-visible effect", name)
 		}
+	}
+
+	// AUDIT RESIDUAL-2, the inverted half. HIVE_SESSION_KEY must NOT equal the
+	// fleet-uniform value any more. Without this, restoring
+	// deriveDomainKey(master, infoSessionKey) in desiredPerHiveEnv would be
+	// caught only by the loop above — and only for as long as the fixture keeps
+	// the per-hive expression, which a merge resolving in favour of the older
+	// side would quietly undo. Asserting the negative pins the property itself
+	// rather than the fixture.
+	if fleetWide := deriveDomainKey(master, infoSessionKey); got[EnvSessionKey] == fleetWide {
+		t.Errorf("HIVE_SESSION_KEY is byte-identical to the fleet-wide derivation — RESIDUAL-2 regressed; " +
+			"desiredPerHiveEnv must use provisionSessionKey(hiveID), not deriveDomainKey(master, infoSessionKey)")
 	}
 }
 
@@ -273,7 +297,7 @@ func perHiveEnvForGeneration(secret, hiveID string) []deploymentEnvVar {
 		{Name: "HIVE_ID", Value: hiveID},
 		{Name: EnvHeartbeatKey, Value: derivePerHiveKey(secret, infoHeartbeatKey, hiveID)},
 		{Name: EnvTerminalKey, Value: derivePerHiveKey(secret, infoTerminalKey, hiveID)},
-		{Name: EnvSessionKey, Value: deriveDomainKey(secret, infoSessionKey)},
+		{Name: EnvSessionKey, Value: derivePerHiveKey(secret, infoSessionKey, hiveID)},
 		{Name: EnvSSOPublicKey, Value: ssoPublicKeyFromSeed(deriveDomainKey(secret, infoSSOEd25519Seed))},
 		{Name: envSessionPublicKey, Value: ssoPublicKeyFromSeed(deriveDomainKey(secret, infoSessionEd25519Seed))},
 	}

--- a/v2/pkg/hub/perhive_env_reconcile.go
+++ b/v2/pkg/hub/perhive_env_reconcile.go
@@ -170,8 +170,14 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 		// inviteSigningSecret fell through to the raw master on every spoke.
 		// Without it in this list a rotation would also never converge the
 		// invite key, leaving it derived from a generation the hub has retired.
-		EnvInviteKey:        provisionInviteKey(hiveID),
-		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
+		EnvInviteKey: provisionInviteKey(hiveID),
+		// AUDIT RESIDUAL-2: per-hive, was deriveDomainKey(master,
+		// infoSessionKey) — fleet-uniform by construction, measured as 1
+		// distinct value across all 70 spokes. Nothing verifies with this key
+		// any more (F1/N3/F23 deleted every lane), so the change is
+		// defence-in-depth; see provisionSessionKey for why the spoke-side
+		// self-derive fallback disagreeing during the roll is harmless.
+		EnvSessionKey:       provisionSessionKey(hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: provisionSessionPublicKey(),
 	}

--- a/v2/pkg/hub/perhive_env_reconcile_test.go
+++ b/v2/pkg/hub/perhive_env_reconcile_test.go
@@ -61,7 +61,7 @@ func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
 	// resolved different generations, this fails.
 	expect := map[string]string{
 		EnvHeartbeatKey:     provisionHeartbeatKey(hiveID),
-		EnvSessionKey:       deriveDomainKey(provisionCurrentSecret(), infoSessionKey),
+		EnvSessionKey:       provisionSessionKey(hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSSOEd25519Seed)),
 		envSessionPublicKey: provisionSessionPublicKey(),
 		EnvTerminalKey:      provisionTerminalKey(hiveID),

--- a/v2/pkg/hub/residual2_session_key_per_hive_test.go
+++ b/v2/pkg/hub/residual2_session_key_per_hive_test.go
@@ -1,0 +1,247 @@
+package hub
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Audit RESIDUAL-2 (2026-08-14). HIVE_SESSION_KEY was derived with
+// deriveDomainKey, which takes no hiveID, so every spoke in the fleet held a
+// byte-identical value: measured live as 1 distinct value across all 70 spokes,
+// 0 converged, while HIVE_TERMINAL_KEY next to it was 70 distinct values.
+//
+// That was not sweep drift. Uniformity was the intended output of the formula,
+// which is why no rotation could ever have fixed it — a rotation moves all 70
+// in lockstep. It required a code change: provisionSessionKey(hiveID).
+//
+// These tests are source-asserting as well as behavioural because the failure
+// mode for this class in this repo is a sync merge resolving a conflict in
+// favour of the older side (F3, F14 and F18 were all lost that way), and the
+// old expression differs from the new one by a single call.
+
+const residual2Master = "residual2-test-master-secret"
+
+// --- THE INVARIANT -----------------------------------------------------------
+
+// TestResidual2SessionKeyIsPerHive is the core regression: two hives must not
+// receive the same HIVE_SESSION_KEY.
+func TestResidual2SessionKeyIsPerHive(t *testing.T) {
+	withTestMaster(t, residual2Master)
+
+	a := desiredPerHiveEnv("hive-alpha")
+	b := desiredPerHiveEnv("hive-beta")
+	if a == nil || b == nil {
+		t.Fatal("desiredPerHiveEnv returned nil for a valid master + hive ID")
+	}
+
+	if a[EnvSessionKey] == "" || b[EnvSessionKey] == "" {
+		t.Fatal("HIVE_SESSION_KEY derived empty — an empty var is WORSE than absent: it makes the " +
+			"readiness count report the hive as converged when it is not")
+	}
+	if a[EnvSessionKey] == b[EnvSessionKey] {
+		t.Error("two hives received a byte-identical HIVE_SESSION_KEY — RESIDUAL-2 regressed; " +
+			"this is the fleet-uniform symmetric-key shape that keeps reappearing in these audits")
+	}
+
+	// Pin it against the exact pre-fix expression, so a revert is named rather
+	// than merely differing from a fixture.
+	if a[EnvSessionKey] == deriveDomainKey(provisionCurrentSecret(), infoSessionKey) {
+		t.Error("HIVE_SESSION_KEY equals deriveDomainKey(master, infoSessionKey) — the pre-fix " +
+			"fleet-wide derivation is back (RESIDUAL-2)")
+	}
+	if want := derivePerHiveKey(provisionCurrentSecret(), infoSessionKey, "hive-alpha"); a[EnvSessionKey] != want {
+		t.Error("HIVE_SESSION_KEY is not HMAC(master, infoSessionKey || 0x00 || hiveID); the " +
+			"derivation no longer matches derivePerHiveKey")
+	}
+}
+
+// TestResidual2SessionKeyStaysReconciled guards the other half: being per-hive
+// is worthless if the sweep stops shipping the var. perHiveEnvNames() is what
+// the reconcile actually walks.
+func TestResidual2SessionKeyStaysReconciled(t *testing.T) {
+	found := false
+	for _, n := range perHiveEnvNames() {
+		if n == EnvSessionKey {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("EnvSessionKey is absent from perHiveEnvNames() — the sweep would never converge it, " +
+			"so the fleet would keep the fleet-uniform value it already holds (RESIDUAL-2)")
+	}
+}
+
+// TestResidual2ProvisioningAndReconcileAgree pins the constraint that makes
+// this change safe to ship. If provisioning emitted the fleet-wide value while
+// the sweep wanted the per-hive one, perHiveEnvDrift would see drift on every
+// pass and roll every pod every cycle, forever.
+func TestResidual2ProvisioningAndReconcileAgree(t *testing.T) {
+	withTestMaster(t, residual2Master)
+	const hiveID = "hive-alpha"
+
+	got := desiredPerHiveEnv(hiveID)
+	if got == nil {
+		t.Fatal("desiredPerHiveEnv returned nil")
+	}
+	// provisionSessionKey is the single helper both sides call.
+	if got[EnvSessionKey] != provisionSessionKey(hiveID) {
+		t.Error("the reconcile sweep and provisionSessionKey disagree — provisioning and reconcile " +
+			"MUST derive identically or they fight and roll a pod every cycle forever")
+	}
+
+	// The provisioning template must call the same helper, not re-implement the
+	// formula. Asserted in source because the template data map is built in a
+	// function too large to exercise here.
+	src := residual2ReadSource(t, "saas_provision.go")
+	if !strings.Contains(src, `"SessionKey":   provisionSessionKey(h.ID)`) {
+		t.Error(`saas_provision.go no longer sets "SessionKey" from provisionSessionKey(h.ID) — if it ` +
+			`reverted to deriveDomainKey, provisioning emits the fleet-wide value while the sweep ` +
+			`wants the per-hive one, and every newly provisioned spoke rolls forever (RESIDUAL-2)`)
+	}
+}
+
+// --- SOURCE INVARIANT --------------------------------------------------------
+
+func residual2ReadSource(t *testing.T, file string) string {
+	t.Helper()
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	return string(raw)
+}
+
+// TestResidual2NoFleetWideSessionDerivationInReconcile asserts the shape at the
+// source level. The behavioural tests above would catch a revert today, but
+// they depend on fixtures that a merge could rewrite in the same commit that
+// reverts the fix; this does not.
+func TestResidual2NoFleetWideSessionDerivationInReconcile(t *testing.T) {
+	src := residual2ReadSource(t, "perhive_env_reconcile.go")
+
+	if regexp.MustCompile(`EnvSessionKey:\s*deriveDomainKey\(`).MatchString(src) {
+		t.Error("perhive_env_reconcile.go derives EnvSessionKey with deriveDomainKey — that takes no " +
+			"hiveID and is fleet-uniform by construction (RESIDUAL-2). Use provisionSessionKey(hiveID).")
+	}
+	if !regexp.MustCompile(`EnvSessionKey:\s*provisionSessionKey\(hiveID\)`).MatchString(src) {
+		t.Error("perhive_env_reconcile.go no longer derives EnvSessionKey with provisionSessionKey(hiveID) " +
+			"(RESIDUAL-2)")
+	}
+}
+
+// TestResidual2PerHiveVarsCountFloor is the blunt instrument that survives
+// renames: if the number of per-hive derivations in the desired-env map drops,
+// something went back to a fleet-wide formula even if the names still look
+// right. Exactly the signal a sync merge trips.
+func TestResidual2PerHiveVarsCountFloor(t *testing.T) {
+	src := residual2ReadSource(t, "perhive_env_reconcile.go")
+
+	// After RESIDUAL-2 the desired-env map has four hive-bound derivations:
+	// heartbeat, terminal, invite (each provision*Key(hiveID)) and session.
+	// The two public keys are legitimately fleet-wide — they are PUBLIC halves
+	// of hub-held Ed25519 seeds, so binding them per-hive would be meaningless.
+	perHive := regexp.MustCompile(`provision(?:Heartbeat|Terminal|Invite|Session)Key\(hiveID\)`)
+	if got := len(perHive.FindAllString(src, -1)); got < 4 {
+		t.Errorf("perhive_env_reconcile.go has %d per-hive key derivations, want at least 4 "+
+			"(heartbeat, terminal, invite, session) — one reverted to a fleet-wide formula (RESIDUAL-2)", got)
+	}
+}
+
+// --- POSITIVE CONTROLS -------------------------------------------------------
+//
+// Without these, "make everything per-hive" would satisfy every assertion above
+// while breaking the fleet in two distinct ways.
+
+// TestResidual2PublicKeysStayFleetWide is the substantive control. The two
+// Ed25519 PUBLIC keys must NOT become per-hive: the hub holds ONE private seed
+// and mints ONE cookie for a user, so a spoke handed a per-hive "public key"
+// would verify nothing the hub ever signed and every hosted login would break.
+func TestResidual2PublicKeysStayFleetWide(t *testing.T) {
+	withTestMaster(t, residual2Master)
+
+	a := desiredPerHiveEnv("hive-alpha")
+	b := desiredPerHiveEnv("hive-beta")
+	if a == nil || b == nil {
+		t.Fatal("desiredPerHiveEnv returned nil")
+	}
+	for _, name := range []string{EnvSSOPublicKey, envSessionPublicKey} {
+		if a[name] == "" {
+			t.Fatalf("%s derived empty; test setup is wrong", name)
+		}
+		if a[name] != b[name] {
+			t.Errorf("%s differs between hives — it is the PUBLIC half of a key the HUB alone holds "+
+				"the seed for. Per-hive public keys verify nothing the hub signed and would break "+
+				"every hosted login. Fleet-wide is CORRECT here.", name)
+		}
+	}
+}
+
+// TestResidual2FailsClosedWithoutIdentity asserts the guard that makes the
+// per-hive formula safe. derivePerHiveKey returns "" for an empty hiveID, and
+// desiredPerHiveEnv must SKIP such a hive rather than ship HIVE_SESSION_KEY=""
+// — an empty var falls back exactly like an absent one on the spoke, but it
+// also makes the readiness counter report the hive as converged when it is not.
+func TestResidual2FailsClosedWithoutIdentity(t *testing.T) {
+	withTestMaster(t, residual2Master)
+
+	if got := desiredPerHiveEnv(""); got != nil {
+		t.Errorf("desiredPerHiveEnv(\"\") returned %v, want nil — a hive whose ID does not resolve must "+
+			"be SKIPPED, never patched with empty values", got)
+	}
+	if derivePerHiveKey(residual2Master, infoSessionKey, "") != "" {
+		t.Error("derivePerHiveKey must return \"\" for an empty hiveID (fail closed)")
+	}
+}
+
+// --- THE SELF-DERIVE FALLBACK ------------------------------------------------
+
+// TestResidual2SelfDeriveDisagreementIsHarmless documents, as an executable
+// claim, the single most likely way a change like this breaks a fleet.
+//
+// Spokes self-derive HIVE_SESSION_KEY when the env var is absent, and both
+// spoke-side resolvers — Go spokeDomainKey and the proxy's deriveSessionKey —
+// derive the FLEET-WIDE value from HIVE_HUB_SECRET, because neither mixes in
+// the hive ID. So once the hub injects a per-hive value the two DISAGREE by
+// construction, and during the 66-spoke roll the fleet holds a mix of both.
+//
+// That is safe here, and only here, because nothing verifies with this key:
+// F1 deleted the Go legacy symmetric cookie lane, N3 stopped the terminal key
+// falling through to it, and F23 deleted the Node proxy's copy. A disagreement
+// over a value that no party ever compares has no observable effect.
+//
+// This test pins the premise, not the conclusion: it asserts the value is not
+// used as a comparand. If some future change makes it one again, the
+// disagreement becomes a live fleet-breaking bug and this test fails first.
+func TestResidual2SessionKeyIsNotAVerificationComparand(t *testing.T) {
+	// Go side: the legacy symmetric lane must stay deleted.
+	cookieSrc := residual2ReadSource(t, "hub_cookie.go")
+	if !strings.Contains(cookieSrc, "_ = legacySecret") {
+		t.Error("hub_cookie.go no longer discards legacySecret — if the symmetric session lane came " +
+			"back, spokes self-deriving the fleet-wide key would disagree with the hub's per-hive " +
+			"value and hosted auth would break during the roll (RESIDUAL-2 / F1)")
+	}
+
+	// SpokeSessionKey must remain callable-but-unused on the Go side. A new
+	// caller is the tripwire: it would be verifying with a value the hub now
+	// derives differently.
+	for _, f := range []string{"hub_cookie.go", "hub_session_revocation.go", "terminal_assertion.go"} {
+		src := residual2ReadSource(t, f)
+		if strings.Contains(src, "SpokeSessionKey()") {
+			t.Errorf("%s calls SpokeSessionKey() — it had zero Go callers when HIVE_SESSION_KEY became "+
+				"per-hive, and a spoke self-deriving the fleet-wide value would not match the hub "+
+				"(RESIDUAL-2)", f)
+		}
+	}
+
+	// The spoke-side resolver is deliberately left fleet-wide. Making it
+	// per-hive would be dead code today and would hand a WRONG answer to a
+	// spoke with no HIVE_ID, flipping the proxy's IS_HOSTED signal to false and
+	// silently converting a hosted hive to the self-hosted identity model.
+	keysSrc := residual2ReadSource(t, "hub_keys.go")
+	if !strings.Contains(keysSrc, "func SpokeSessionKey() string { return spokeDomainKey(EnvSessionKey, infoSessionKey) }") {
+		t.Error("SpokeSessionKey changed shape — it must keep reading the injected var first and " +
+			"self-deriving the fleet-wide value only as a fallback; see provisionSessionKey for why " +
+			"(RESIDUAL-2)")
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1948,7 +1948,11 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// generation set through the same helper. Before any rotation exists
 		// this is byte-identical to the old provisionMasterSecret() reads.
 		"HeartbeatKey": provisionHeartbeatKey(h.ID),
-		"SessionKey":   deriveDomainKey(provisionCurrentSecret(), infoSessionKey),
+		// RESIDUAL-2: PER-HIVE, matching desiredPerHiveEnv. This MUST move in
+		// lockstep with the reconcile sweep — the two derivations fighting is
+		// exactly the "roll a pod every cycle forever" failure the comment
+		// above warns about.
+		"SessionKey":   provisionSessionKey(h.ID),
 		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSSOEd25519Seed)),
 		// N2: the Ed25519 PUBLIC key for hub session cookies. A spoke verifies
 		// hive_hub_user with this and cannot mint one — unlike SessionKey below,


### PR DESCRIPTION
Closes audit item §6.7 (RESIDUAL-2) from `SECURITY-REVIEW-2026-08-14.md`.

## The problem

`HIVE_SESSION_KEY` was **byte-identical across the whole hosted fleet** — measured live as **1 distinct value on all 70 spokes, 0 converged**, while `HIVE_TERMINAL_KEY` beside it was 70 distinct values.

This was **not sweep drift**. `desiredPerHiveEnv` derived this one var with `deriveDomainKey`, which takes no `hiveID`, while its neighbours two lines away used `derivePerHiveKey`. Uniformity was the *intended output of the formula*, so **no rotation could ever have fixed it** — a rotation moves all 70 in lockstep. It needed a code change.

## What changed

Adds `provisionSessionKey(hiveID)` alongside the existing `provisionTerminalKey` / `provisionHeartbeatKey` / `provisionInviteKey` helpers, and uses it from **both** `desiredPerHiveEnv` and the provisioning template.

Both sides must move together: if provisioning emitted the fleet-wide value while the sweep wanted the per-hive one, `perHiveEnvDrift` would see drift on every pass and **roll every pod every cycle forever**.

## Defence in depth, not a live hole

Every lane that verified against this key is already deleted — **F1** (Go legacy symmetric cookie lane), **N3** (terminal key fall-through), **F23** (Node proxy copy). But a fleet-uniform symmetric key is exactly the shape that keeps reappearing in these audits, so the formula is fixed rather than left as a hygiene note.

## The self-derive fallback — the way this could have broken the fleet

Spokes self-derive this var when it is absent, and **both** spoke-side resolvers (Go `spokeDomainKey`, proxy `deriveSessionKey`) derive the **fleet-wide** value from `HIVE_HUB_SECRET`, because neither mixes in the hive ID. So the hub's per-hive value and a self-deriving spoke now **disagree by construction**, and during the roll the fleet holds a mix of both.

That is harmless **here, and only here, because nothing compares the value.** Verified rather than assumed:

- `SpokeSessionKey()` has **zero non-test Go callers**.
- `hub_cookie.go` discards `legacySecret` (`_ = legacySecret`).
- In `proxy/server.js` there are **exactly three** non-comment uses of `SESSION_KEY`: its definition, `IS_HOSTED = SESSION_KEY !== ''`, and the argument to `verifyHubUserCookieAcrossKeys`, which discards it (`void legacySecret`).

Both survivors test **presence, never value**, and a per-hive value is exactly as non-empty as a fleet-wide one — so `IS_HOSTED` is unchanged for every spoke in every state.

The self-derive fallbacks are **deliberately not changed** to match. Per-hive there would be dead code today, and on a spoke with no `HIVE_ID` it would return `""` — flipping `IS_HOSTED` to false and silently converting a hosted hive to the self-hosted identity model. They stay until the var is dropped outright.

## Fleet impact

66 spokes each get a new value and roll **once**, at the existing 3 patches per 15-minute cycle. **`perHiveEnvMaxPatchesPerCycle` is NOT raised.** No cluster writes were made in preparing this PR.

## Tests

New `residual2_session_key_per_hive_test.go`:

| Test | Asserts |
|---|---|
| `TestResidual2SessionKeyIsPerHive` | two hives differ; not the pre-fix expression |
| `TestResidual2SessionKeyStaysReconciled` | still in `perHiveEnvNames()` |
| `TestResidual2ProvisioningAndReconcileAgree` | no roll-forever |
| `TestResidual2NoFleetWideSessionDerivationInReconcile` | source invariant |
| `TestResidual2PerHiveVarsCountFloor` | count floor ≥ 4 |
| `TestResidual2PublicKeysStayFleetWide` | **positive control** |
| `TestResidual2FailsClosedWithoutIdentity` | **positive control** |
| `TestResidual2SessionKeyIsNotAVerificationComparand` | pins the premise |

`TestResidual2PublicKeysStayFleetWide` is load-bearing: the two Ed25519 **public** keys must NOT become per-hive. The hub holds one private seed, so a per-hive "public key" would verify nothing the hub signed and would break every hosted login. Without this control, "make everything per-hive" would satisfy every other assertion.

`TestResidual2SessionKeyIsNotAVerificationComparand` pins the *premise* of the safety argument rather than its conclusion: if a future change makes this value a comparand again, the self-derive disagreement becomes a live fleet-breaking bug and that test fails first.

### Inverted, not relaxed

`TestPerHiveEnvGenerationIsAReadPathChangeToday` asserted every per-hive var was byte-identical to the pre-generation expression. That claim was correct for the generation work and is now **deliberately false for this one var**, so its `HIVE_SESSION_KEY` entry is flipped to the per-hive expression **and** a new explicit assertion demands the value NOT equal the fleet-wide derivation. Deleting the entry would have silently dropped the var from that test's coverage.

## Regression replay

Reverted `desiredPerHiveEnv` to `deriveDomainKey(master, infoSessionKey)`, still compiling:

```
BUILD OK
--- FAIL: TestPerHiveEnvGenerationIsAReadPathChangeToday
    HIVE_SESSION_KEY is byte-identical to the fleet-wide derivation — RESIDUAL-2 regressed
--- FAIL: TestDesiredPerHiveEnvMatchesProvisioningTemplate
    HIVE_SESSION_KEY: reconcile derivation diverges from the provisioning template
--- FAIL: TestResidual2SessionKeyIsPerHive
    two hives received a byte-identical HIVE_SESSION_KEY — RESIDUAL-2 regressed
--- FAIL: TestResidual2ProvisioningAndReconcileAgree
    the reconcile sweep and provisionSessionKey disagree
--- FAIL: TestResidual2NoFleetWideSessionDerivationInReconcile
    perhive_env_reconcile.go derives EnvSessionKey with deriveDomainKey
--- FAIL: TestResidual2PerHiveVarsCountFloor
    has 3 per-hive key derivations, want at least 4
```

Restored → `ok github.com/kubestellar/hive/v2/pkg/hub`. The replay did **not** pass while neutered.

## Local verification

- `go build ./...` clean
- `go test ./pkg/hub/` — one failure, `TestSpokePauseBlocksStaleRecovery`, confirmed **pre-existing**: it fails identically on a clean `origin/v4` worktree with no `pkg/hub` changes
- `gofmt -l` clean on every touched file
- `proxy/server.js` not modified

Coordination note: diff kept minimal in `desiredPerHiveEnv` (one map entry + comment) to stay clear of concurrent F19 work in the generation-set plumbing.