### PR TITLE
🔒 fix(hub): wire provisionGenerationSet to the live generation set (F19), gated on full fleet observation

### DIFF
--- a/v2/docs/design/master-key-rotation.md
+++ b/v2/docs/design/master-key-rotation.md
@@ -468,3 +468,108 @@ on the SIGNATURE rather than only on the payload's `h` claim. The tests that
 specifically exercise the `h`-claim check therefore pin the signing hive
 explicitly, so they keep testing the claim check rather than silently becoming
 duplicates of the signature test.
+
+## As-built notes for F19 (audit 8): wiring the derivation path
+
+The eighth security audit found that the entire rotation wave was **inert**, and
+this note records why, because the shape of the mistake is more instructive than
+the fix.
+
+`provisionGenerationSet()` — the single function every spoke-bound derivation
+flows through — resolved to `legacyGenerationSet(provisionMasterSecret())` in
+production. Its only other branch read a package-level override that **nothing
+but a test helper ever wrote**. So:
+
+- the hub's MINTING and VERIFYING side used the real persisted set
+  (`s.keyGenerations`), which `rotateMasterSecret` correctly advanced;
+- the hub's SPOKE-BOUND side rebuilt generation 1 from `/data/saas/hub-secret.key`,
+  a file rotation never rewrites.
+
+The two were disjoint. After a rotation the hub minted under generation N+1 while
+the reconcile sweep computed "desired" per-hive env from generation 1, compared it
+against what the spokes already held, found no drift, and patched nothing. Step 3
+of the rotation procedure above silently did not happen.
+
+**Why no test caught it.** Coverage existed on both halves and was split across two
+files that never referenced each other: `hub_generations_store_test.go` drove
+`rotateMasterSecret`, `perhive_env_generation_test.go` drove `desiredPerHiveEnv`
+through the test-only seam. Each half passed. The join — "a real rotation changes
+what a spoke would be handed" — was the only thing that was false, and it was the
+one thing nobody asserted. `TestRotationReachesDesiredPerHiveEnv` is that test,
+and it deliberately asserts `provisionGenerationsOverride == nil` so it can never
+decay back into testing the seam instead of the wiring.
+
+### What the fix is
+
+A package-level `liveGenerations` pointer, installed by `NewHubServer` from the
+same `loadGenerations` call that populates `s.keyGenerations`, and replaced by
+`rotateMasterSecret` and `retireExpiredGenerations` inside their existing
+critical sections. Package-level rather than threaded through a receiver because
+every caller in the chain (`desiredPerHiveEnv`, the four `provision*Key`
+helpers, the provisioning template map) is a free function, several invoked from
+template expansion with no `HubServer` in scope.
+
+Three states, not two:
+
+| State | Meaning | Behaviour |
+|---|---|---|
+| installed | a hub is running | derive from the live set |
+| nil, not untrusted | no hub in this process | fall back to legacy — byte-identical to pre-F19 |
+| untrusted | F20's `generationsUntrusted` | **refuse**; return nil, derive nothing |
+
+The third is the handoff F20 left open. When the loader cannot establish which
+generation is current, the derivation path must not re-derive its own notion from
+the raw master file — after a rotation that file holds SUPERSEDED generation-1
+material, and writing keys from it onto live Deployments would drag the fleet
+backwards onto a retired generation. That is F20's silent un-rotation reappearing
+on the side F20 did not cover. "Untrusted" is a separate flag rather than a
+sentinel nil because nil must keep meaning "no hub constructed".
+
+### Staleness: the installed set is not unconditionally authoritative
+
+`liveGenerations` is process-global but `provisionMasterSecret()` is re-read from
+the environment or the file on every call, so the two can disagree — a second
+`NewHubServer`, or an operator changing `HIVE_HUB_SECRET` without the generations
+file following. `generationSetDescendsFrom` requires the ambient master to still
+be present in the installed set before trusting it. That is sound because rotation
+only ever ADDS a generation and demotes the outgoing one, so on a correctly
+installed hub the ambient master is still there as current or previous.
+
+### The stranding interlock, and why rotation is gated shut today
+
+F21 measured that **44 of 70 hosted spokes** sit on `pull_only` clusters
+(`vllm-d`, `a-ks-wec2`) that the reconcile sweep structurally cannot read or
+patch. That is by design and is not changing until the Option D wrapped-master
+delivery path lands.
+
+Wiring F19 without addressing that would be actively worse than leaving it inert:
+a rotation would converge the 26 reachable spokes, leave 44 on the outgoing
+generation, and strand them when retirement fires **unconditionally** at
+`verify_until` seven days later. The audit's phrase is "converts a silent no-op
+into a 7-day-delayed outage".
+
+So `rotateMasterSecret` now refuses unless `FleetFullyObserved` — the last sweep
+saw every admitted hive with none unreachable. A pull-only cluster increments
+`UnreachableHives` for every hive on it, so this is **false on the production hub
+today and stays false** until every spoke is reachable. The wiring lands now; the
+ability to fire it unlocks only when the thing that makes it safe exists.
+
+Three deliberate choices:
+
+- **In `rotateMasterSecret`, not the handler.** It is the single choke point every
+  rotation passes through; a handler gate could be bypassed by a future internal
+  caller.
+- **`force` does not override it.** `force` exists to override the convergence
+  COOLDOWN — "the current generation is compromised, accept the cost". With 44
+  spokes structurally unreachable the cost is not lag, it is a guaranteed outage
+  with no in-band way to avert it. An operator who must rotate a compromised
+  master ahead of Option D has to make the fleet observable first.
+- **Retirement is NOT gated the same way, and must never be.** Gating retirement
+  on convergence would let one unreachable spoke pin a superseded master live
+  forever — the failure mode explicit finiteness exists to prevent. Gating the
+  START of a rotation strands nobody, because nothing has been demoted yet. The
+  two gates correctly point in opposite directions.
+
+Step 4 of the rotation procedure above ("operator watches `safe_to_retire_previous`")
+is therefore now enforced at the front of the procedure rather than being advisory
+at the back.

--- a/v2/pkg/hub/hub_generations_f19_wiring_test.go
+++ b/v2/pkg/hub/hub_generations_f19_wiring_test.go
@@ -1,0 +1,520 @@
+package hub
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// AUDIT 8 / F19 — the spoke-bound derivation path reads the hub's LIVE
+// generation set.
+//
+// WHAT WENT WRONG, AND WHY NO TEST CAUGHT IT. provisionGenerationSet() used to
+// consult a package-level override that only a test helper ever wrote, then fall
+// through to legacyGenerationSet(provisionMasterSecret()) — generation 1 rebuilt
+// from a file rotateMasterSecret never rewrites. The hub's MINTING side used the
+// real persisted set; the SPOKE-BOUND side used that frozen one. A rotation
+// changed what the hub minted and nothing about what the fleet held.
+//
+// The existing coverage could not see it because it was split across two test
+// files that never referenced each other: hub_generations_store_test.go drove
+// rotateMasterSecret, perhive_env_generation_test.go drove desiredPerHiveEnv
+// through the test-only seam. Each half passed. The join — "a real rotation
+// changes what a spoke would be given" — was the thing nobody asserted, and it
+// was the only thing that was false.
+//
+// So the load-bearing test in this file is TestRotationReachesDesiredPerHiveEnv:
+// it spans rotateMasterSecret -> desiredPerHiveEnv with NO seam in between.
+
+const (
+	f19SecretA = "f19-wiring-test-master-alpha"
+	f19SecretB = "f19-wiring-test-master-bravo"
+)
+
+// withCleanLiveGenerations isolates the package-level live-generation pointer
+// for a test and restores it afterwards.
+//
+// Every test in this file must take it. The pointer is process-global by
+// design (see liveGenerations), so a test that installed a set and did not
+// restore it would silently change what every LATER test in the package
+// derives — the kind of cross-test bleed that makes a suite pass for the wrong
+// reason. Restoring rather than nil-ing keeps that honest under -count=N.
+func withCleanLiveGenerations(t *testing.T) {
+	t.Helper()
+	prevSet, prevUntrusted := liveGenerations, liveGenerationsUntrusted
+	setLiveGenerations(nil, false)
+	t.Cleanup(func() { setLiveGenerations(prevSet, prevUntrusted) })
+}
+
+// TestRotationReachesDesiredPerHiveEnv is THE test whose absence let F19 ship.
+//
+// It spans rotateMasterSecret -> desiredPerHiveEnv with no test seam in the
+// middle: provisionGenerationsOverride is explicitly left nil, so the only way
+// desiredPerHiveEnv can see the new generation is if the production wiring
+// actually connects them. Against the pre-fix code every assertion in the
+// "after" block fails, because desiredPerHiveEnv keeps deriving from the raw
+// master file that rotation never touches.
+func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
+	withTempGenerationsPath(t)
+	withCleanLiveGenerations(t)
+	// The raw master file stays on A forever — rotateMasterSecret never rewrites
+	// hub-secret.key, which is exactly why reading it is wrong after a rotation.
+	withTestMaster(t, f19SecretA)
+	// Assert the seam is NOT in play. If a future edit made this file rely on
+	// it, this test would silently go back to proving only what the old one did.
+	if provisionGenerationsOverride != nil {
+		t.Fatal("provisionGenerationsOverride must be nil here: this test exists to prove the PRODUCTION path is wired")
+	}
+
+	const hiveID = "hive-f19"
+	s := newRotationTestHub(t, f19SecretA)
+	// Install the pre-rotation set the way NewHubServer does.
+	setLiveGenerations(s.keyGenerations, false)
+
+	before := desiredPerHiveEnv(hiveID)
+	if before == nil {
+		t.Fatal("desiredPerHiveEnv returned nil before rotation")
+	}
+	// PRECONDITION / POSITIVE CONTROL for the un-rotated direction: before any
+	// rotation the wiring must be byte-identical to the raw-master derivation.
+	// Without this the test could pass by breaking the un-rotated case.
+	for _, name := range perHiveEnvNames() {
+		if before[name] != rawMasterDerivation(f19SecretA, hiveID)[name] {
+			t.Fatalf("%s: pre-rotation derivation already differs from the raw master — "+
+				"this change must be invisible on a never-rotated hub", name)
+		}
+	}
+
+	next, _, err := s.rotateMasterSecret(time.Now(), false)
+	if err != nil {
+		t.Fatalf("rotateMasterSecret: %v", err)
+	}
+	newSecret := next.currentSecret()
+	if newSecret == "" || newSecret == f19SecretA {
+		t.Fatal("fixture: rotation did not produce a new current secret")
+	}
+
+	after := desiredPerHiveEnv(hiveID)
+	if after == nil {
+		t.Fatal("desiredPerHiveEnv returned nil after rotation")
+	}
+
+	// THE ASSERTION. Every mandatory var must now be derived from the NEW
+	// generation's secret, computed here independently of the code under test.
+	wantAfter := map[string]string{
+		EnvHeartbeatKey:     derivePerHiveKey(newSecret, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:      derivePerHiveKey(newSecret, infoTerminalKey, hiveID),
+		EnvInviteKey:        derivePerHiveKey(newSecret, infoInviteKey, hiveID),
+		EnvSessionKey:       deriveDomainKey(newSecret, infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSSOEd25519Seed)),
+		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSessionEd25519Seed)),
+	}
+	// COUNT FLOOR, same discipline as TestDesiredPerHiveEnvUsesCurrentNotPrevious:
+	// a var dropped from perHiveEnvNames() must fail here rather than silently
+	// stop being asserted.
+	if len(wantAfter) != len(perHiveEnvNames()) {
+		t.Fatalf("perHiveEnvNames() has %d vars but this test covers %d — a reconciled var is unasserted after rotation",
+			len(perHiveEnvNames()), len(wantAfter))
+	}
+	for _, name := range perHiveEnvNames() {
+		if after[name] != wantAfter[name] {
+			t.Errorf("%s: NOT derived from the new generation after rotation — "+
+				"the reconcile sweep would see no drift and patch nothing (F19)", name)
+		}
+		if after[name] == before[name] {
+			t.Errorf("%s: unchanged by rotation — rotation is inert on the spoke-bound path (F19)", name)
+		}
+	}
+
+	// And specifically NOT the raw master file's derivation, which is the exact
+	// value the pre-fix code returned.
+	stale := rawMasterDerivation(provisionMasterSecret(), hiveID)
+	for _, name := range perHiveEnvNames() {
+		if after[name] == stale[name] {
+			t.Errorf("%s: still derived from the raw hub-secret.key master after a rotation — "+
+				"this is the F19 inertness verbatim", name)
+		}
+	}
+
+	// The provisioning template must move in lockstep with the reconcile, or the
+	// sweep would fight provisioning and roll a freshly created pod every cycle.
+	if provisionHeartbeatKey(hiveID) != wantAfter[EnvHeartbeatKey] {
+		t.Error("provisionHeartbeatKey did not follow the rotation — provision and reconcile would fight")
+	}
+	if provisionTerminalKey(hiveID) != wantAfter[EnvTerminalKey] {
+		t.Error("provisionTerminalKey did not follow the rotation")
+	}
+	if provisionInviteKey(hiveID) != wantAfter[EnvInviteKey] {
+		t.Error("provisionInviteKey did not follow the rotation")
+	}
+
+	// The hub's own minting set and the spoke-bound set must be the SAME object
+	// after a rotation. Two equal-but-separate sets would pass every assertion
+	// above and still drift on the next rotation.
+	if provisionGenerationSet() != s.currentGenerations() {
+		t.Error("the derivation set and the hub's minting set are different objects — they can drift")
+	}
+}
+
+// rawMasterDerivation reproduces the PRE-generation expressions literally, the
+// same way TestPerHiveEnvGenerationIsAReadPathChangeToday does. Used as the
+// byte-identity reference in both directions.
+func rawMasterDerivation(master, hiveID string) map[string]string {
+	return map[string]string{
+		EnvHeartbeatKey:     derivePerHiveKey(master, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:      derivePerHiveKey(master, infoTerminalKey, hiveID),
+		EnvInviteKey:        derivePerHiveKey(master, infoInviteKey, hiveID),
+		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
+		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
+		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(master, infoSessionEd25519Seed)),
+	}
+}
+
+// TestUnrotatedHubDerivesByteIdenticallyAfterWiring is the positive control in
+// the OTHER direction, and the reason this change is safe to ship to a fleet
+// that has never rotated.
+//
+// The whole fleet is on generationsNeverRotated today. If wiring the live set
+// changed ANY derived byte on such a hub, the next reconcile sweep would see
+// drift on all 70 spokes and roll every tenant pod. So: with a single
+// generation installed, every var must equal the literal pre-generation
+// expression, exactly as TestPerHiveEnvGenerationIsAReadPathChangeToday pins it.
+func TestUnrotatedHubDerivesByteIdenticallyAfterWiring(t *testing.T) {
+	withCleanLiveGenerations(t)
+	withTestMaster(t, f19SecretA)
+	const hiveID = "hive-f19"
+
+	want := rawMasterDerivation(f19SecretA, hiveID)
+
+	t.Run("no hub constructed: falls back to the legacy set", func(t *testing.T) {
+		// liveGenerations is nil here — the state of every unit test that
+		// derives keys without building a HubServer.
+		got := desiredPerHiveEnv(hiveID)
+		if got == nil {
+			t.Fatal("desiredPerHiveEnv returned nil with no live set installed")
+		}
+		for _, name := range perHiveEnvNames() {
+			if got[name] != want[name] {
+				t.Errorf("%s changed with no live set installed — the fallback is not byte-identical", name)
+			}
+		}
+	})
+
+	t.Run("never-rotated hub: live set installed, still byte-identical", func(t *testing.T) {
+		setLiveGenerations(legacyGenerationSet(f19SecretA), false)
+		got := desiredPerHiveEnv(hiveID)
+		if got == nil {
+			t.Fatal("desiredPerHiveEnv returned nil on a never-rotated hub")
+		}
+		for _, name := range perHiveEnvNames() {
+			if got[name] != want[name] {
+				t.Errorf("%s changed on a never-rotated hub — this would roll all 70 tenant pods on the next sweep", name)
+			}
+		}
+		// No _PREV vars on a hub with one generation: emitting them would add a
+		// var to every Deployment in the fleet.
+		for _, name := range perHiveEnvOptionalNames() {
+			if _, present := got[name]; present {
+				t.Errorf("%s present on a never-rotated hub — there is no previous generation", name)
+			}
+		}
+	})
+
+	// POSITIVE CONTROL. Everything above is an equality check, which "always
+	// return the raw-master derivation" would also satisfy — that is precisely
+	// the pre-fix behaviour. Prove the installed set is actually consulted.
+	t.Run("positive control: an installed ROTATED set does change the output", func(t *testing.T) {
+		rotated := legacyGenerationSet(f19SecretA).rotate(f19SecretB, time.Now(), defaultVerifyWindow)
+		setLiveGenerations(rotated, false)
+		got := desiredPerHiveEnv(hiveID)
+		if got == nil {
+			t.Fatal("desiredPerHiveEnv returned nil with a rotated set installed")
+		}
+		for _, name := range perHiveEnvNames() {
+			if got[name] == want[name] {
+				t.Fatalf("%s is unchanged by an installed ROTATED set — the live set is being ignored, "+
+					"which means the byte-identity assertions above are vacuous", name)
+			}
+		}
+	})
+}
+
+// TestUntrustedGenerationsRefusesDerivation is the F20 handoff.
+//
+// When the loader cannot establish which generation is current, the derivation
+// path must REFUSE rather than re-derive its own notion from the raw master
+// file. That file holds SUPERSEDED generation-1 material once a rotation has
+// happened, so falling back would write keys from a retired generation onto
+// live Deployments and drag the whole fleet backwards — F20's silent
+// un-rotation, reintroduced on the side F20 did not cover.
+func TestUntrustedGenerationsRefusesDerivation(t *testing.T) {
+	withCleanLiveGenerations(t)
+	withTestMaster(t, f19SecretA)
+	const hiveID = "hive-f19"
+
+	// PRECONDITION: with a trusted set this hive derives fine. Without this the
+	// test could pass because desiredPerHiveEnv is broken for some other reason.
+	setLiveGenerations(legacyGenerationSet(f19SecretA), false)
+	if desiredPerHiveEnv(hiveID) == nil {
+		t.Fatal("precondition: desiredPerHiveEnv returned nil for a TRUSTED set")
+	}
+
+	setLiveGenerations(nil, true)
+
+	if gs := provisionGenerationSet(); gs != nil {
+		t.Error("provisionGenerationSet returned a set while the generation state is UNTRUSTED — " +
+			"it re-derived from the raw master, which is superseded material after a rotation")
+	}
+	if got := provisionCurrentSecret(); got != "" {
+		t.Error("provisionCurrentSecret returned a non-empty secret while UNTRUSTED (value withheld)")
+	}
+	if got := desiredPerHiveEnv(hiveID); got != nil {
+		t.Errorf("desiredPerHiveEnv returned %d vars while UNTRUSTED — the sweep would patch spokes "+
+			"with keys derived from a generation the hub cannot vouch for", len(got))
+	}
+	// The per-hive provisioning helpers must fail closed the same way, or a hive
+	// created during the untrusted window would be handed stale keys.
+	if provisionHeartbeatKey(hiveID) != "" {
+		t.Error("provisionHeartbeatKey derived a key while UNTRUSTED")
+	}
+	if provisionTerminalKey(hiveID) != "" {
+		t.Error("provisionTerminalKey derived a key while UNTRUSTED")
+	}
+	if provisionInviteKey(hiveID) != "" {
+		t.Error("provisionInviteKey derived a key while UNTRUSTED")
+	}
+
+	// NOT-nil control: untrusted must be distinguishable from "no hub in this
+	// process". Same nil set, untrusted cleared — derivation resumes. If these
+	// two collapsed into one state, every unit test that never builds a hub
+	// would take the refuse path.
+	setLiveGenerations(nil, false)
+	if desiredPerHiveEnv(hiveID) == nil {
+		t.Error("clearing the untrusted flag did not restore derivation — " +
+			"\"untrusted\" and \"no hub constructed\" have been collapsed into one state")
+	}
+}
+
+// TestRotationRefusedWhileFleetNotFullyObserved is the F19/F21 stranding
+// interlock: the guarantee that wiring F19 today cannot strand the 44 spokes on
+// pull-only clusters.
+//
+// Retirement at verify_until is UNCONDITIONAL by design, so a spoke the sweep
+// never converged is a spoke that hard-fails heartbeat 7 days after a rotation.
+// The only safe place to stop that is before the rotation starts.
+func TestRotationRefusedWhileFleetNotFullyObserved(t *testing.T) {
+	withTempGenerationsPath(t)
+	withCleanLiveGenerations(t)
+	withTestMaster(t, f19SecretA)
+
+	// The shape of the production hub: hives on a pull-only cluster the sweep
+	// counted but could not read. 26 reachable, 44 not — the F21 census.
+	unobservedHub := func() *HubServer {
+		s := newRotationTestHub(t, f19SecretA)
+		s.perHiveEnvConsidered = 70
+		s.perHiveEnvUnreachable = 44
+		s.perHiveEnvUnreachableClusters = []string{"a-ks-wec2", "vllm-d"}
+		return s
+	}
+
+	t.Run("refused with unreachable spokes", func(t *testing.T) {
+		s := unobservedHub()
+		next, decision, err := s.rotateMasterSecret(time.Now(), false)
+		if !errors.Is(err, errRotationWouldStrandSpokes) {
+			t.Fatalf("err = %v, want errRotationWouldStrandSpokes", err)
+		}
+		if next != nil {
+			t.Error("a refused rotation returned a new generation set")
+		}
+		if decision.Allowed {
+			t.Error("decision.Allowed = true on a refused rotation")
+		}
+		// Nothing may have changed: not the in-memory set, not the file.
+		if s.currentGenerations().Current != legacyGenerationID {
+			t.Error("the refused rotation still advanced the current generation")
+		}
+		if _, statErr := os.Stat(hubGenerationsPath); statErr == nil {
+			t.Error("the refused rotation persisted a generations file")
+		}
+	})
+
+	// force must NOT override this. It exists to override the convergence
+	// COOLDOWN — "the current generation is compromised, accept the cost". With
+	// 44 spokes structurally unreachable the cost is not lag, it is a
+	// guaranteed outage with no in-band way to avert it.
+	t.Run("force does NOT override the stranding interlock", func(t *testing.T) {
+		s := unobservedHub()
+		if _, _, err := s.rotateMasterSecret(time.Now(), true); !errors.Is(err, errRotationWouldStrandSpokes) {
+			t.Fatalf("force bypassed the stranding interlock: err = %v", err)
+		}
+	})
+
+	// A sweep that observed NOTHING is not a fully observed fleet. This is the
+	// fail-closed direction: a hub that has not run a sweep yet must not be
+	// treated as having a clean bill of health.
+	// Built inline rather than via newRotationTestHub, which now DECLARES a
+	// fully observed fleet so the rotation-mechanics tests can run. This case
+	// needs the opposite: a hub whose sweep has never populated anything.
+	t.Run("a hub that has never swept is refused", func(t *testing.T) {
+		s := &HubServer{
+			logger:          quietLogger(),
+			hubSecret:       f19SecretA,
+			keyGenerations:  legacyGenerationSet(f19SecretA),
+			lastKeyRotation: time.Time{},
+			// perHiveEnvConsidered and perHiveEnvUnreachable both zero: no sweep
+			// has run. "Nothing observed" is not "everything observed".
+		}
+		if _, _, err := s.rotateMasterSecret(time.Now(), false); !errors.Is(err, errRotationWouldStrandSpokes) {
+			t.Fatalf("a never-swept hub was allowed to rotate: err = %v", err)
+		}
+	})
+
+	// POSITIVE CONTROL. Every case above asserts a REFUSAL, and "always refuse"
+	// would satisfy all of them — which would make F19's wiring permanently
+	// unreachable and this whole change a no-op. Prove a fully observed fleet
+	// still rotates, and that the rotation reaches the derivation path.
+	t.Run("positive control: a fully observed fleet DOES rotate", func(t *testing.T) {
+		withCleanLiveGenerations(t)
+		s := newRotationTestHub(t, f19SecretA)
+		setLiveGenerations(s.keyGenerations, false)
+		next, _, err := s.rotateMasterSecret(time.Now(), false)
+		if err != nil {
+			t.Fatalf("a fully observed fleet was refused: %v", err)
+		}
+		if next.Current == legacyGenerationID {
+			t.Fatal("rotation did not advance the generation")
+		}
+		if provisionCurrentSecret() != next.currentSecret() {
+			t.Error("the rotation did not reach the derivation path even though it was allowed")
+		}
+	})
+}
+
+// TestRotationInterlockMatchesFleetFullyObserved pins fleetObservation()'s
+// predicate to PerHiveEnvSnapshot().FleetFullyObserved.
+//
+// There are now two expressions of "did the sweep see everything" — the
+// operator-facing one on the readiness surface and the enforcing one in the
+// rotate path. Two copies of one predicate is exactly the drift hazard the four
+// VerifyUntil readers are held against, so assert them equal across the cases
+// that distinguish them rather than trusting the copies to stay in step.
+func TestRotationInterlockMatchesFleetFullyObserved(t *testing.T) {
+	cases := []struct {
+		name        string
+		considered  int
+		unreachable int
+	}{
+		{"nothing swept", 0, 0},
+		{"fully observed", 22, 0},
+		{"one unreachable", 70, 44},
+		{"all unreachable", 44, 44},
+		{"unreachable with nothing considered", 0, 3},
+	}
+	sawTrue, sawFalse := false, false
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &HubServer{
+				keyGenerations:        legacyGenerationSet(f19SecretA),
+				perHiveEnvSeen:        map[string]perHiveEnvObservation{},
+				perHiveEnvConsidered:  tc.considered,
+				perHiveEnvUnreachable: tc.unreachable,
+			}
+			want := s.PerHiveEnvSnapshot().FleetFullyObserved
+			got := s.fleetObservation().FullyObserved
+			if got != want {
+				t.Errorf("fleetObservation().FullyObserved = %v but PerHiveEnvSnapshot().FleetFullyObserved = %v — "+
+					"the rotate interlock and the readiness surface disagree about what a fully observed fleet is",
+					got, want)
+			}
+			if got {
+				sawTrue = true
+			} else {
+				sawFalse = true
+			}
+		})
+	}
+	// POSITIVE CONTROL: the table must exercise both outcomes, or "always equal"
+	// would be proven by a table that only ever produces one of them.
+	if !sawTrue || !sawFalse {
+		t.Fatalf("degenerate table: sawTrue=%v sawFalse=%v — the equality is only meaningful across both outcomes",
+			sawTrue, sawFalse)
+	}
+}
+
+// TestRetirementKeepsDerivationSetInLockstep. Retirement replaces the
+// generation set without changing the CURRENT generation, so the six mandatory
+// vars are unaffected — but it does drop PREVIOUS generations, and those are
+// what the two _PREV public-key vars are derived from. If the derivation set
+// were not updated, the sweep would keep advertising a _PREV public key for a
+// generation the hub has just stopped accepting.
+func TestRetirementKeepsDerivationSetInLockstep(t *testing.T) {
+	withTempGenerationsPath(t)
+	withCleanLiveGenerations(t)
+	// The ambient master is B, the generation that SURVIVES the retirement.
+	//
+	// This mirrors the real post-rotation hub rather than the fixture's
+	// convenience: generationSetDescendsFrom requires the installed set to still
+	// contain the ambient master, and retirement drops generation A. Pinning the
+	// ambient master to A would make the set legitimately stale the instant A is
+	// retired, and the test would be asserting the staleness fallback rather than
+	// the lockstep it is named for.
+	withTestMaster(t, f19SecretB)
+	const hiveID = "hive-f19"
+
+	now := time.Now()
+	// A rotation whose verify window has already closed: the previous
+	// generation is retirable right now.
+	expired := legacyGenerationSet(f19SecretA).
+		rotate(f19SecretB, now.Add(-2*defaultVerifyWindow), defaultVerifyWindow)
+	s := newRotationTestHub(t, f19SecretB)
+	s.keyGenerations = expired
+	setLiveGenerations(expired, false)
+
+	// PRECONDITION: while the previous generation is still in the set, the
+	// _PREV vars are absent because the window has closed (they track
+	// ACCEPTANCE, not mere presence). Assert the current-generation vars are
+	// present so the post-retirement comparison is meaningful.
+	beforeEnv := desiredPerHiveEnv(hiveID)
+	if beforeEnv == nil {
+		t.Fatal("precondition: desiredPerHiveEnv returned nil before retirement")
+	}
+
+	retired, err := s.retireExpiredGenerations(now)
+	if err != nil {
+		t.Fatalf("retireExpiredGenerations: %v", err)
+	}
+	if len(retired) == 0 {
+		t.Fatal("fixture: nothing was retired, so this test asserts nothing")
+	}
+
+	// The derivation set must be the retired-from set, not the stale one.
+	if provisionGenerationSet() != s.currentGenerations() {
+		t.Error("retirement left the derivation set pointing at the pre-retirement object")
+	}
+	for _, g := range provisionGenerationSet().Generations {
+		for _, id := range retired {
+			if g.ID == id {
+				t.Errorf("generation %d was retired but is still in the derivation set — "+
+					"the hub would keep handing spokes a public key it no longer accepts", id)
+			}
+		}
+	}
+	// The CURRENT generation did not move, so the mandatory vars must not have.
+	afterEnv := desiredPerHiveEnv(hiveID)
+	if afterEnv == nil {
+		t.Fatal("desiredPerHiveEnv returned nil after retirement")
+	}
+	for _, name := range perHiveEnvNames() {
+		if afterEnv[name] != beforeEnv[name] {
+			t.Errorf("%s changed on RETIREMENT — retirement does not move the current generation "+
+				"and must not roll a single tenant pod", name)
+		}
+	}
+	// And no _PREV var may survive the retirement of its generation.
+	for _, name := range perHiveEnvOptionalNames() {
+		if _, present := afterEnv[name]; present {
+			t.Errorf("%s still emitted after the previous generation was retired", name)
+		}
+	}
+}

--- a/v2/pkg/hub/hub_generations_handler.go
+++ b/v2/pkg/hub/hub_generations_handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -117,6 +118,28 @@ func (s *HubServer) handleRotateMasterKey(w http.ResponseWriter, r *http.Request
 			Error:             decision.Reason,
 			RetryAfterSeconds: retry,
 			Current:           s.currentGenerations().Current,
+		})
+		return
+	}
+	// AUDIT 8 / F19 + F21. The fleet is not fully observed, so a rotation would
+	// converge the reachable spokes and strand the rest at verify_until. This is
+	// a 409 like the cooldown — the request is well-formed and the hub is
+	// healthy, the FLEET is not in a state where rotating is safe — but it
+	// carries no RetryAfter, because unlike the cooldown it does not clear on
+	// its own. It clears when every spoke becomes reachable by the convergence
+	// lane.
+	if errors.Is(err, errRotationWouldStrandSpokes) {
+		obs := s.fleetObservation()
+		s.logger.Warn("master key rotation REFUSED — fleet not fully observed, rotating would strand spokes",
+			"by", s.getRealAuthUser(r),
+			"considered_hives", obs.Considered,
+			"unreachable_hives", obs.Unreachable,
+			"unreachable_clusters", strings.Join(obs.UnreachableClusters, ","),
+			"current", s.currentGenerations().Current)
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(rotateRefusedResponse{
+			Error:   decision.Reason,
+			Current: s.currentGenerations().Current,
 		})
 		return
 	}

--- a/v2/pkg/hub/hub_generations_retire.go
+++ b/v2/pkg/hub/hub_generations_retire.go
@@ -296,6 +296,16 @@ func (s *HubServer) retireExpiredGenerations(now time.Time) ([]int, error) {
 		return nil, err
 	}
 	s.keyGenerations = next
+	// AUDIT 8 / F19. Keep the spoke-bound derivation set in lockstep with the
+	// minting set here too. Retirement does not change the CURRENT generation —
+	// retirableGenerations always keeps gs.Current — so the six mandatory
+	// per-hive vars are unaffected. What it does change is the set of PREVIOUS
+	// generations, which is what provisionSSOPublicKeyPrevious and
+	// provisionSessionPublicKeyPrevious read to emit the two _PREV public keys.
+	// Without this line the sweep would keep advertising a _PREV public key for
+	// a generation the hub has just stopped accepting, and the removal path in
+	// perHiveEnvPatchJSON would never fire.
+	setLiveGenerations(next, false)
 	return retired, nil
 }
 

--- a/v2/pkg/hub/hub_generations_retire_test.go
+++ b/v2/pkg/hub/hub_generations_retire_test.go
@@ -50,6 +50,16 @@ func newRetireTestHub(t *testing.T, gens []keyGeneration, current int) *HubServe
 		t.Fatalf("fixture: newGenerationSet(%d, %d gens) returned nil", current, len(gens))
 	}
 	s.keyGenerations = gs
+	// AUDIT 8 / F19+F21. Declare a fully observed fleet so tests that go on to
+	// ROTATE off this fixture are not refused by the stranding interlock.
+	//
+	// This does NOT weaken anything these tests assert. Retirement is
+	// deliberately unconditional on convergence (see the file header rationale)
+	// and never reads these fields, so every retirement assertion is unaffected;
+	// only rotateMasterSecret consults them. The tests that seed real
+	// observation state call seedObservations, which overwrites these.
+	s.perHiveEnvConsidered = 1
+	s.perHiveEnvUnreachable = 0
 	return s
 }
 

--- a/v2/pkg/hub/hub_generations_store.go
+++ b/v2/pkg/hub/hub_generations_store.go
@@ -5,8 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -327,6 +330,61 @@ var errRotationTooSoon = errors.New("previous rotation has not converged")
 // whose generation state could not be established at startup (audit 8, F20).
 var errGenerationsUntrusted = errors.New("hub generation state is untrusted")
 
+// errRotationWouldStrandSpokes is returned when the last reconcile sweep did
+// not observe the entire fleet (audit 8, F19/F21). Distinct from
+// errRotationTooSoon because the remedy is different: the cooldown clears on its
+// own with time, this one does not clear until the fleet becomes observable.
+var errRotationWouldStrandSpokes = errors.New("rotation would strand unobserved spokes")
+
+// fleetObservationSummary is the evidence-completeness slice of the reconcile
+// sweep's state — the only part the rotation interlock needs.
+type fleetObservationSummary struct {
+	Considered          int
+	Unreachable         int
+	UnreachableClusters []string
+	// FullyObserved mirrors PerHiveEnvStatus.FleetFullyObserved EXACTLY, and is
+	// asserted equal to it by TestRotationInterlockMatchesFleetFullyObserved.
+	// Two expressions of one predicate is one more than ideal; the test exists
+	// so they cannot drift, which is the same discipline the four VerifyUntil
+	// readers are held to.
+	FullyObserved bool
+}
+
+// fleetObservation reports what the last per-hive env sweep managed to observe.
+//
+// It reads the same four fields PerHiveEnvSnapshot does, under the same
+// perHiveEnvMu, but deliberately does NOT call PerHiveEnvSnapshot: that function
+// also reads s.keyGenerations, and rotateMasterSecret calls this while holding
+// keyGenerationsMu for write. Snapshotting only the observation counters keeps
+// the interlock free of any second lock order and avoids an unsynchronised read
+// of the very field the caller is about to replace.
+func (s *HubServer) fleetObservation() fleetObservationSummary {
+	out := fleetObservationSummary{}
+	if s == nil {
+		// A nil hub has observed nothing, and "nothing observed" is not
+		// "everything observed" — fail closed, same as a zero-hive sweep.
+		return out
+	}
+	s.perHiveEnvMu.RLock()
+	defer s.perHiveEnvMu.RUnlock()
+	out.Considered = s.perHiveEnvConsidered
+	out.Unreachable = s.perHiveEnvUnreachable
+	out.UnreachableClusters = append([]string(nil), s.perHiveEnvUnreachableClusters...)
+	sort.Strings(out.UnreachableClusters)
+	out.FullyObserved = out.Considered > 0 && out.Unreachable == 0
+	return out
+}
+
+// unreachableClusterSuffix renders cluster IDs for an operator-facing message.
+// Cluster IDs are non-secret registry identifiers (e.g. "vllm-d"); no key
+// material, hive name, or env value passes through here.
+func unreachableClusterSuffix(clusters []string) string {
+	if len(clusters) == 0 {
+		return ""
+	}
+	return ", unreachable clusters: " + strings.Join(clusters, ",")
+}
+
 // rotationCooldown is how long after a rotation a SECOND rotation is refused
 // without an explicit force.
 //
@@ -483,6 +541,57 @@ func (s *HubServer) rotateMasterSecret(now time.Time, force bool) (*generationSe
 		}, errGenerationsUntrusted
 	}
 
+	// AUDIT 8 / F19 + F21. THE STRANDING INTERLOCK.
+	//
+	// F19 wires the derivation path to the live set, which means a rotation now
+	// actually reaches the fleet. F21 measured that 44 of the 70 hosted spokes
+	// sit on pull_only clusters (vllm-d, a-ks-wec2) that the reconcile sweep
+	// structurally cannot read or patch — by design, and that is not changing
+	// until the Option D wrapped-master delivery path lands. Those two facts
+	// together are dangerous in a way neither is alone: before F19 a rotation
+	// was a silent no-op, and after F19 without this gate it would converge the
+	// 26 reachable spokes, leave 44 on the outgoing generation, and strand them
+	// when retirement fires unconditionally at verify_until seven days later.
+	// The audit's phrase for it is "converts a silent no-op into a 7-day-delayed
+	// outage", and it is the reason F21 was named a precondition of F19.
+	//
+	// So: refuse to rotate unless the last sweep OBSERVED THE ENTIRE FLEET.
+	// FleetFullyObserved is (ConsideredHives > 0 && UnreachableHives == 0), and
+	// a pull-only cluster increments UnreachableHives for every hive on it, so
+	// this is false on the production hub today and will stay false until every
+	// spoke is reachable by whatever delivery mechanism ships. That is the
+	// intended effect: the wiring lands now, and the ability to fire it unlocks
+	// only when the thing that makes it safe exists.
+	//
+	// WHY HERE AND NOT IN THE HANDLER. This is the single choke point every
+	// rotation passes through; a gate in handleRotateMasterKey could be bypassed
+	// by any future internal caller. It sits BEFORE evaluateRotation so an
+	// operator sees the stranding reason rather than a cooldown message.
+	//
+	// WHY NOT force. force overrides the convergence COOLDOWN — a "the current
+	// generation is compromised, accept the cost" switch. This is not that: with
+	// 44 spokes structurally unreachable the cost is not "some spokes lag", it
+	// is "44 spokes hard-fail heartbeat in 7 days with no path to converge
+	// them". There is no in-band way to accept that responsibly, so force does
+	// not reach it. An operator who genuinely must rotate a compromised master
+	// ahead of Option D has to make the fleet observable first.
+	//
+	// NOTE the deliberate asymmetry with retirement, which is unconditional and
+	// must stay that way (hub_generations_retire.go:42-60): gating RETIREMENT on
+	// convergence would let one unreachable spoke pin a superseded secret live
+	// forever. Gating the START of a rotation strands nobody — nothing has been
+	// demoted yet — so the two gates point in opposite directions correctly.
+	if obs := s.fleetObservation(); !obs.FullyObserved {
+		return nil, rotationDecision{
+			Allowed: false,
+			Reason: fmt.Sprintf("refusing to rotate: the last reconcile sweep did not observe the whole fleet "+
+				"(%d hives considered, %d unreachable%s). Rotating now would converge only the reachable spokes and "+
+				"strand the rest when the previous generation retires at verify_until. Make every spoke reachable "+
+				"by the convergence lane first; force does not override this.",
+				obs.Considered, obs.Unreachable, unreachableClusterSuffix(obs.UnreachableClusters)),
+		}, errRotationWouldStrandSpokes
+	}
+
 	decision := evaluateRotation(s.lastKeyRotation, now, force)
 	if !decision.Allowed {
 		return nil, decision, errRotationTooSoon
@@ -504,5 +613,17 @@ func (s *HubServer) rotateMasterSecret(now time.Time, force bool) (*generationSe
 	}
 	s.keyGenerations = next
 	s.lastKeyRotation = now
+	// AUDIT 8 / F19. Install into the package-level pointer the SPOKE-BOUND
+	// derivation path reads, in the same critical section that installs the
+	// minting set. This single line is what makes a rotation observable to
+	// desiredPerHiveEnv and therefore to the reconcile sweep; without it the
+	// sweep keeps computing "desired" from the pre-rotation generation, sees no
+	// drift, and patches nothing — the inertness this finding is about.
+	//
+	// Deliberately inside the keyGenerationsMu critical section so the two can
+	// never disagree, even transiently. setLiveGenerations takes a DIFFERENT
+	// mutex (liveGenerationsMu) and nothing that holds liveGenerationsMu ever
+	// reaches for keyGenerationsMu, so this cannot deadlock.
+	setLiveGenerations(next, false)
 	return next, decision, nil
 }

--- a/v2/pkg/hub/hub_generations_store_test.go
+++ b/v2/pkg/hub/hub_generations_store_test.go
@@ -55,6 +55,20 @@ func quietLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// newRotationTestHub builds a hub that is ALLOWED to rotate.
+//
+// AUDIT 8 / F19+F21. rotateMasterSecret now refuses unless the last reconcile
+// sweep observed the ENTIRE fleet, because with 44 of 70 spokes on pull-only
+// clusters a rotation would converge the reachable ones and strand the rest
+// when the previous generation retires. So a hub with no sweep state — which is
+// what this fixture used to be — is refused with errRotationWouldStrandSpokes.
+//
+// This fixture therefore declares a fully observed fleet: one hive considered,
+// none unreachable. That is the PRECONDITION under test elsewhere, not the
+// subject of the tests using this helper; they assert rotation mechanics
+// (demotion, persistence, cooldown, double-submit) and would otherwise all fail
+// for one unrelated reason. The interlock itself is asserted directly, in both
+// directions, by TestRotationRefusedWhileFleetNotFullyObserved.
 func newRotationTestHub(t *testing.T, master string) *HubServer {
 	t.Helper()
 	return &HubServer{
@@ -62,6 +76,12 @@ func newRotationTestHub(t *testing.T, master string) *HubServer {
 		hubSecret:       master,
 		keyGenerations:  legacyGenerationSet(master),
 		lastKeyRotation: time.Time{},
+		// A fully observed fleet: considered > 0 and unreachable == 0.
+		perHiveEnvConsidered:  1,
+		perHiveEnvUnreachable: 0,
+		perHiveEnvSeen: map[string]perHiveEnvObservation{
+			"hive-observed": {Generation: legacyGenerationID, Observed: time.Now()},
+		},
 	}
 }
 

--- a/v2/pkg/hub/hub_keys.go
+++ b/v2/pkg/hub/hub_keys.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -602,38 +603,167 @@ func provisionMasterSecret() string {
 // forever. Making them both resolve their master through THIS function means a
 // rotation cannot move one side without the other.
 //
-// TODAY THIS IS EXACTLY legacyGenerationSet(provisionMasterSecret()). There is
-// no persisted generations file yet and no endpoint that can create a second
-// generation (that is follow-on PR #4), so currentSecret() is always the same
-// string provisionMasterSecret() returns and every derived value is
-// byte-identical to what this code produced before generations existed. This
-// change is a READ-PATH change in effect: it re-expresses where the master
-// comes from without changing which master it is.
+// AUDIT 8 / F19 — THIS FUNCTION USED TO BE INERT.
+//
+// It previously read:
+//
+//	if gs := provisionGenerationsOverride; gs != nil { return gs }
+//	return legacyGenerationSet(provisionMasterSecret())
+//
+// and provisionGenerationsOverride was written by NOTHING but a test helper. So
+// in production it unconditionally returned generation 1 built from the raw
+// /data/saas/hub-secret.key — a file rotateMasterSecret never rewrites. The
+// hub's MINTING and VERIFYING side used the real persisted set
+// (s.keyGenerations); this, the entire SPOKE-BOUND derivation side, used a set
+// nothing could ever advance. The two were disjoint, so a rotation changed what
+// the hub minted but never what the fleet held: the sweep computed "desired"
+// from generation 1, saw no drift against what spokes already had, and patched
+// nothing. Every one of the seven rotation PRs was dead on arrival.
+//
+// THE FIX is the package-level pointer below, installed by NewHubServer from
+// the same load that populates s.keyGenerations. Now one set feeds both sides
+// and a rotation moves them together.
+//
+// THREE STATES, and the third is the F20 handoff:
+//
+//   - INSTALLED (liveGenerations non-nil): return the hub's live set. After a
+//     rotation this is the new current generation, which is the whole point.
+//
+//   - NOT INSTALLED (liveGenerations nil, liveGenerationsUntrusted false): no
+//     HubServer has been constructed in this process. This is the state of
+//     every unit test that derives keys without building a hub, and of any
+//     provisioning helper invoked before NewHubServer runs. Fall back to
+//     legacyGenerationSet(provisionMasterSecret()) — byte-identical to the
+//     pre-F19 behaviour, which is what keeps this a no-op on an un-rotated hub.
+//
+//   - UNTRUSTED (liveGenerationsUntrusted true): NewHubServer could not
+//     establish which generation is current (F20's generationsUntrusted). REFUSE
+//     — return nil, do not re-derive our own notion from the raw master file.
+//     Falling back here would be the exact silent un-rotation F20 fixed on the
+//     minting side, reintroduced on the derivation side: the master file holds
+//     SUPERSEDED generation-1 material once a rotation has happened, and writing
+//     keys derived from it onto live Deployments would push the whole fleet
+//     BACKWARDS onto a retired generation. nil propagates as "" through
+//     currentSecret(), which desiredPerHiveEnv's empty-master guard already
+//     turns into "skip this hive, patch nothing".
 //
 // Returns nil for an empty master, and currentSecret() on a nil set returns ""
 // — so the fail-closed contract every caller already relies on (deriveDomainKey
 // and derivePerHiveKey both return "" for an empty master) is preserved through
 // the nil case rather than needing a new one.
 func provisionGenerationSet() *generationSet {
+	// The test seam still wins, so the ROTATED case stays drivable without
+	// standing up a HubServer. See provisionGenerationsOverride.
 	if gs := provisionGenerationsOverride; gs != nil {
+		return gs
+	}
+	liveGenerationsMu.RLock()
+	gs, untrusted := liveGenerations, liveGenerationsUntrusted
+	liveGenerationsMu.RUnlock()
+	if untrusted {
+		// FAIL CLOSED. Never re-derive from the raw master here — see above.
+		return nil
+	}
+	if gs != nil && generationSetDescendsFrom(gs, provisionMasterSecret()) {
 		return gs
 	}
 	return legacyGenerationSet(provisionMasterSecret())
 }
 
+// generationSetDescendsFrom reports whether gs is a set this process's ambient
+// master could legitimately have produced — i.e. whether SOME generation in it
+// holds that master.
+//
+// WHY THE INSTALLED SET IS NOT UNCONDITIONALLY AUTHORITATIVE. liveGenerations is
+// process-global, but provisionMasterSecret() is re-read from the environment
+// (HIVE_HUB_SECRET) or the file on every call. Those can disagree, and when they
+// do the installed set is STALE — it descends from a master this process is no
+// longer configured with. Deriving from a stale set would hand spokes keys that
+// verify against nothing.
+//
+// The invariant that makes the check sound: rotation only ever ADDS a
+// generation and demotes the outgoing one (generationSet.rotate carries the
+// previous current forward), so on a correctly-installed hub the ambient master
+// is still present in the set as either the current or the previous generation.
+// A set that contains it is therefore a legitimate descendant; one that does not
+// belongs to a different master entirely.
+//
+// This is what keeps the un-rotated fallback honest and is load-bearing for
+// TestPerHiveEnvGenerationIsAReadPathChangeToday and friends: a test that builds
+// a HubServer pins the global to that hub's master, and a LATER test using a
+// different master must not silently derive from the earlier one. In production
+// it covers the same shape — a second NewHubServer, or an operator changing
+// HIVE_HUB_SECRET without the generations file following.
+//
+// Returns false for a nil set or an empty master so both fall through to the
+// legacy path, which is itself nil-for-empty. Comparison is a plain string
+// equality on secrets already held in memory by this process; it is not a
+// verification of attacker-supplied input, so constant time is not required.
+func generationSetDescendsFrom(gs *generationSet, master string) bool {
+	if gs == nil || master == "" {
+		return false
+	}
+	for _, g := range gs.Generations {
+		if g.Secret == master {
+			return true
+		}
+	}
+	return false
+}
+
+// liveGenerations is the hub's live generation set as seen by the spoke-bound
+// derivation path, installed by NewHubServer and replaced by rotateMasterSecret.
+//
+// WHY A PACKAGE-LEVEL POINTER AND NOT A RECEIVER. Every caller in the
+// derivation chain — desiredPerHiveEnv, provisionHeartbeatKey,
+// provisionTerminalKey, provisionInviteKey, provisionSessionPublicKey, and
+// saas_provision.go's template map — is a free function, and several are called
+// from template expansion that has no HubServer in scope. Threading a receiver
+// through all of them is the larger refactor; the audit explicitly sanctions
+// either shape. This is the smaller change and it makes the two sides share one
+// object rather than two copies that can drift.
+//
+// A generation set is only ever REPLACED, never mutated (see
+// currentGenerations), so a reader that takes this pointer holds a
+// self-consistent snapshot for as long as it needs it.
+var (
+	liveGenerationsMu sync.RWMutex
+	liveGenerations   *generationSet
+	// liveGenerationsUntrusted latches the F20 generationsUntrusted outcome.
+	//
+	// It is a SEPARATE flag rather than a sentinel value of liveGenerations
+	// because nil has to keep meaning "no hub in this process" for the unit
+	// tests that never build one. Collapsing "untrusted" into "nil" would make
+	// every such test take the refuse path and derive nothing.
+	liveGenerationsUntrusted bool
+)
+
+// setLiveGenerations installs the set the spoke-bound derivation path reads.
+//
+// Called by NewHubServer with the loaded set, and by rotateMasterSecret with
+// the newly rotated one — the latter is what makes a rotation actually reach
+// the fleet, which is the F19 fix. untrusted latches the fail-closed state and
+// is only ever set from the generationsUntrusted branch.
+func setLiveGenerations(gs *generationSet, untrusted bool) {
+	liveGenerationsMu.Lock()
+	defer liveGenerationsMu.Unlock()
+	liveGenerations = gs
+	liveGenerationsUntrusted = untrusted
+}
+
 // provisionGenerationsOverride replaces the resolved generation set.
 //
-// It exists so a test can drive the ROTATED case, which is otherwise
-// unreachable: there is no persisted generations file and no endpoint that can
-// create a second generation until follow-on PR #4, so without this seam
-// "derives from the current generation" and "derives from the raw master" are
-// indistinguishable and no test could tell them apart. That is precisely the
-// kind of test-that-passes-for-the-wrong-reason this seam prevents.
+// RETAINED DELIBERATELY after F19 wired provisionGenerationSet() to the live
+// set. It is still the only way to drive the derivation path from an explicit
+// set without constructing a whole HubServer, and the tests that use it
+// (perhive_env_generation_test.go) are the ones that distinguish "derives from
+// the CURRENT generation" from "derives from the raw master" — the exact
+// test-that-passes-for-the-wrong-reason this seam prevents. Removing it would
+// delete that coverage, so it stays.
 //
 // nil in production, set only via withProvisionGenerations in tests. Read
 // without a lock because it is only ever written before the code under test
-// runs, from that test's own goroutine — the same discipline as
-// HubServer.keyGenerations, which is set once in NewHubServer.
+// runs, from that test's own goroutine.
 var provisionGenerationsOverride *generationSet
 
 // provisionCurrentSecret is the MINTING master at provision/reconcile time: the

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1215,18 +1215,30 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	// cannot tell which generation is current. In that case it must not keep
 	// the provisional legacy set either: that set is the SUPERSEDED master, and
 	// installing it is the silent un-rotation this finding is about.
+	// AUDIT 8 / F19. Each arm below ALSO installs the set into the package-level
+	// pointer the spoke-bound derivation path reads (setLiveGenerations). Before
+	// this, provisionGenerationSet() ignored everything decided here and
+	// unconditionally rebuilt generation 1 from the raw hub-secret.key, so the
+	// hub minted on one set and provisioned the fleet from another. The two must
+	// come from the same load or a rotation never reaches a spoke.
 	switch gs, rotatedAt, outcome := loadGenerations(secret, logger); outcome {
 	case generationsLoaded:
 		s.keyGenerations = gs
 		// Restore the rotation timestamp too, or the cooldown would reset on
 		// every hub roll and stop guarding anything.
 		s.lastKeyRotation = rotatedAt
+		setLiveGenerations(gs, false)
 	case generationsNeverRotated:
 		// Legitimate fallback: keep the provisional legacy set built from
 		// hub-secret.key. This is the state of every hub in the fleet today.
 		if gs != nil {
 			s.keyGenerations = gs
 		}
+		// Install it on the derivation side too. On a never-rotated hub this is
+		// byte-identical to the pre-F19 legacyGenerationSet(provisionMasterSecret())
+		// whenever HIVE_HUB_SECRET and hub-secret.key agree, which is the whole
+		// fleet today — so this arm is a no-op in effect, by construction.
+		setLiveGenerations(gs, false)
 	case generationsUntrusted:
 		// FAIL CLOSED. Drop the provisional legacy set rather than serve on it.
 		//
@@ -1259,6 +1271,15 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		// refused outright by rotateMasterSecret, so the cleared cooldown can
 		// no longer be used to strand anyone. See generationsUntrusted.
 		s.keyGenerations = nil
+		// AUDIT 8 / F19 + F20. Latch the untrusted state on the derivation side
+		// too, and note this is NOT the same as installing nil there: nil means
+		// "no hub in this process" and falls back to the legacy set, which is
+		// exactly the re-derivation from superseded material that must not
+		// happen here. The explicit flag makes provisionGenerationSet() return
+		// nil, so desiredPerHiveEnv's empty-master guard skips every hive and the
+		// sweep patches nothing rather than pushing the fleet backwards onto
+		// generation 1.
+		setLiveGenerations(nil, true)
 		logger.Error("hub master generation state is UNTRUSTED — minting and rotation are DISABLED until an operator resolves the generations file; "+
 			"existing spokes continue to authenticate on the single-master path",
 			"path", hubGenerationsPath)


### PR DESCRIPTION
Audit 8 / **F19** (§6 item 1). The entire seven-PR master-key rotation wave was **inert**.

## The bug

`provisionGenerationSet()` — the one function every spoke-bound derivation flows through — returned `legacyGenerationSet(provisionMasterSecret())` in production. Its only other branch read `provisionGenerationsOverride`, which **nothing but a test helper ever wrote**.

So the hub's minting/verifying side used the real persisted set (`s.keyGenerations`), while the spoke-bound side rebuilt generation 1 from `/data/saas/hub-secret.key` — a file `rotateMasterSecret` never rewrites. After a rotation the hub minted under generation N+1 while the reconcile sweep computed "desired" per-hive env from generation 1, found no drift, and patched nothing.

**Why no test caught it.** Coverage existed on both halves, split across two files that never referenced each other. Each half passed. The join — "a real rotation changes what a spoke is handed" — was the only thing that was false, and the one thing nobody asserted.

## The wiring

A package-level `liveGenerations` pointer installed by `NewHubServer` from the same `loadGenerations` call that populates `s.keyGenerations`, and replaced by `rotateMasterSecret` and `retireExpiredGenerations` inside their existing critical sections. Package-level rather than threaded through a receiver because every caller in the chain is a free function, several invoked from template expansion with no `HubServer` in scope (the audit sanctions either shape).

Three states, not two — the third is the handoff **F20** (`7f6bf9c1`) explicitly left open:

| State | Meaning | Behaviour |
|---|---|---|
| installed | a hub is running | derive from the live set |
| nil, not untrusted | no hub in this process | fall back to legacy — byte-identical to pre-F19 |
| **untrusted** | F20's `generationsUntrusted` | **refuse**; return nil, derive nothing |

Re-deriving from the raw master on `untrusted` would be F20's silent un-rotation reappearing on the side F20 did not cover: after a rotation that file holds **superseded** generation-1 material, and writing keys from it onto live Deployments would drag the fleet backwards onto a retired generation. "Untrusted" is a separate flag rather than a sentinel nil because nil must keep meaning "no hub constructed", or every unit test that never builds one would take the refuse path.

`generationSetDescendsFrom` guards staleness: `liveGenerations` is process-global but `provisionMasterSecret()` is re-read per call, so the installed set is trusted only while the ambient master is still in it. Sound because rotation only ever ADDS a generation and demotes the outgoing one.

## ⚠️ What prevents a stranding rotation today

**F21's reachability half is not closed and will not be** — `vllm-d` (39) and `a-ks-wec2` (5) are `pull_only` by design until Option D (#3833) lands. Wiring F19 without a gate would be **worse than inertness**: a rotation would converge the reachable spokes and strand 44 when retirement fires unconditionally at `verify_until`, seven days later.

`rotateMasterSecret` now refuses unless `FleetFullyObserved` (`ConsideredHives > 0 && UnreachableHives == 0`). A pull-only cluster increments `UnreachableHives` for every hive on it, so **this is false on the production hub today and stays false** until every spoke is reachable. The wiring lands now; the ability to fire it unlocks only when the thing that makes it safe exists.

- **In `rotateMasterSecret`, not the handler** — the single choke point every rotation passes through; a handler gate could be bypassed by a future internal caller.
- **`force` does NOT override it.** `force` overrides the convergence *cooldown* ("this generation is compromised, accept the cost"). With 44 spokes structurally unreachable the cost is not lag, it is a guaranteed outage with no in-band way to avert it.
- **Retirement is NOT gated the same way, and must never be.** Gating retirement on convergence would let one unreachable spoke pin a superseded master live forever — the failure mode explicit finiteness exists to prevent. Gating the *start* of a rotation strands nobody; nothing has been demoted yet. The two gates correctly point in opposite directions.

This is the "deliver the wiring behind an explicit guard" outcome: F19 is wired and correct, and cannot be fired until Option D (or equivalent) makes the fleet observable.

## Invariants verified

- `VerifyUntil.IsZero()` = ALREADY EXPIRED — **no fourth reader added**; the interlock routes through the existing `FleetFullyObserved` accounting.
- F20 fail-closed preserved; `lastKeyRotation` untouched on the fallback path.
- F2 identity binding — every generation still derives via `derivePerHiveKey(master_g, infoHeartbeatKey, hiveID)`.
- `maxLiveGenerations = 2`, `perHiveEnvMaxPatchesPerCycle = 3` unchanged.
- `desiredPerHiveEnv`'s empty-value guard intact — the untrusted path routes through it rather than around it.
- No secret material logged; the refusal message carries cluster IDs and counts only.

## Tests

| Test | Asserts |
|---|---|
| `TestRotationReachesDesiredPerHiveEnv` | **the end-to-end test the audit asked for** — `rotateMasterSecret` → `desiredPerHiveEnv`, NO seam; asserts `provisionGenerationsOverride == nil` so it cannot decay back into testing the seam |
| `TestUnrotatedHubDerivesByteIdenticallyAfterWiring` | byte-identity on a never-rotated hub, + positive control that an installed rotated set DOES change output |
| `TestUntrustedGenerationsRefusesDerivation` | untrusted → refuses, with a not-nil control that untrusted ≠ "no hub" |
| `TestRotationRefusedWhileFleetNotFullyObserved` | interlock; `force` cannot bypass; never-swept refused; **positive control that a fully observed fleet still rotates** |
| `TestRotationInterlockMatchesFleetFullyObserved` | pins the interlock predicate to `PerHiveEnvSnapshot().FleetFullyObserved` across a table exercising both outcomes |
| `TestRetirementKeepsDerivationSetInLockstep` | retirement drops `_PREV` public keys without moving the mandatory six |

`provisionGenerationsOverride` is **retained** — still the only way to drive the derivation path without building a `HubServer`, and removing it would delete the coverage distinguishing "current generation" from "raw master".

Two existing fixtures (`newRotationTestHub`, `newRetireTestHub`) now declare a fully observed fleet. This **relaxes no assertion**: rotation gained a precondition, and the interlock is asserted directly elsewhere. Retirement never reads those fields.

## Regression replay

Neutering the wiring (still compiling) fails the four wiring tests:

```
--- FAIL: TestRotationReachesDesiredPerHiveEnv (0.00s)
    HIVE_HEARTBEAT_KEY: NOT derived from the new generation after rotation — the reconcile sweep would see no drift and patch nothing (F19)
    HIVE_HEARTBEAT_KEY: unchanged by rotation — rotation is inert on the spoke-bound path (F19)
    ... (all six vars)
    HIVE_HEARTBEAT_KEY: still derived from the raw hub-secret.key master after a rotation — this is the F19 inertness verbatim
    the derivation set and the hub's minting set are different objects — they can drift
--- FAIL: TestUnrotatedHubDerivesByteIdenticallyAfterWiring/positive_control:_an_installed_ROTATED_set_does_change_the_output
    HIVE_HEARTBEAT_KEY is unchanged by an installed ROTATED set — the live set is being ignored, which means the byte-identity assertions above are vacuous
--- FAIL: TestUntrustedGenerationsRefusesDerivation (0.00s)
    provisionGenerationSet returned a set while the generation state is UNTRUSTED — it re-derived from the raw master, which is superseded material after a rotation
--- FAIL: TestRetirementKeepsDerivationSetInLockstep (0.00s)
    generation 1 was retired but is still in the derivation set — the hub would keep handing spokes a public key it no longer accepts
```

Neutering the interlock fails all three refusal subtests:

```
--- FAIL: TestRotationRefusedWhileFleetNotFullyObserved/refused_with_unreachable_spokes
    err = <nil>, want errRotationWouldStrandSpokes
--- FAIL: TestRotationRefusedWhileFleetNotFullyObserved/force_does_NOT_override_the_stranding_interlock
    force bypassed the stranding interlock: err = <nil>
--- FAIL: TestRotationRefusedWhileFleetNotFullyObserved/a_hub_that_has_never_swept_is_refused
    a never-swept hub was allowed to rotate: err = <nil>
```

Restored → `go build ./...` clean, all six green.

## Local verification

- `go build ./...` clean.
- `go test ./pkg/hub/` — only `TestSpokePauseBlocksStaleRecovery` fails, **verified identical on clean `origin/v4`** (pre-existing).
- `gofmt -l` on changed files: only `server.go`, pre-existing (unrelated struct alignment at ~L834); 10 pre-existing hits in `pkg/hub`.
- Read-only kubectl; no cluster writes; no secret values printed.

## Follow-ups (not this PR)

- **Option D (#3833)** is the precondition for ever firing a rotation. Until it lands the interlock holds rotation shut by design.
- `PerHiveEnvSnapshot` reads `s.keyGenerations` without `keyGenerationsMu` (`perhive_env_reconcile.go:674`) — pre-existing race, deliberately not touched here; `fleetObservation()` avoids it by reading only the observation counters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
