### PR TITLE
fix(hub): give TestSpokePauseBlocksStaleRecovery a heartbeating fixture

### DIFF
--- a/v2/pkg/hub/upgrade_pause_test.go
+++ b/v2/pkg/hub/upgrade_pause_test.go
@@ -157,9 +157,18 @@ func TestSpokePauseBlocksStaleRecovery(t *testing.T) {
 	// SHAs deliberately share no prefix: sameCommit matches short-vs-full by
 	// prefix, so "old"/"oldtarget" would read as already-at-target and clear
 	// the latch before the recovery branch this test exercises.
+	//
+	// LastHeartbeat must be fresh (#3851): stale-recovery only re-arms a hive
+	// that can actually COLLECT the instruction on its next heartbeat. A hive
+	// with no LastHeartbeat is an unassigned placeholder that never checked
+	// in — triggerAutoUpgrades correctly abandons its latch instead of
+	// re-arming forever (see pullonly_upgrade.go:upgradeCollectible). This
+	// test exercises the pause switch on a LIVE, recoverable hive, so the
+	// fixture must model one: a hive that recently heartbeated.
 	s.registry.Hives = []RegistryEntry{{
 		ID: "h1", GitBranch: "v2", GitHash: "aaa1111", Upgrading: true,
 		UpgradeTarget: "bbb2222", UpgradeStartedAt: started,
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
 	}}
 
 	pauseSpokes(t, s, true)


### PR DESCRIPTION
## Problem

`TestSpokePauseBlocksStaleRecovery` fails on v4 HEAD, blocking the merge queue (#3855, #3858, #3859):

```
--- FAIL: TestSpokePauseBlocksStaleRecovery (0.00s)
    upgrade_pause_test.go:185: resumed: heartbeatUpgrade = "", want newsha7 (control failed)
```

## Root cause — stale test fixture, NOT a kill-switch regression

The failure is in the test's own **positive control**, so it needed to be taken seriously as a possible real bug in the admin upgrade kill switch (#3836 / `c9ea2cc8`). It is not.

`#3851` (`23a12d5b`), which landed **on top of** `#3836`, deliberately changed `triggerAutoUpgrades`'s stale-recovery branch to gate re-arming on `upgradeCollectible(LastHeartbeat)`: a hive that has never heartbeated is treated as an unassigned placeholder that can never collect an upgrade instruction, so recovery now **abandons** its latch instead of re-arming it forever (see `pullonly_upgrade.go`). That PR's own description says it updated five other assignment/recovery test fixtures to carry a fresh `LastHeartbeat` for exactly this reason — but it did not touch `upgrade_pause_test.go` (added by the sibling PR #3836), whose `h1` fixture has no `LastHeartbeat` at all.

With no `LastHeartbeat`, the resumed control in `TestSpokePauseBlocksStaleRecovery` hits the (correct, new) uncollectible-abandon branch and leaves `heartbeatUpgrade` empty — not because the pause switch stayed stuck on, but because the fixture models a spoke that can never collect anything, paused or not.

## Fix

Give the fixture a fresh `LastHeartbeat`, matching the pattern already used by `TestStaleUpgradeStillRecoveredForLiveHive` and the other recovery tests `#3851` updated. This models a live, heartbeating hive — which is what the test's own comments and paused-side assertions already intend.

## Verification

**Reproduced on v4 HEAD:**
```
=== RUN   TestSpokePauseBlocksStaleRecovery
2026/08/14 11:16:49 WARN abandoning stale upgrade — hive cannot collect it, not re-arming ...
    upgrade_pause_test.go:185: resumed: heartbeatUpgrade = "", want newsha7 (control failed)
--- FAIL: TestSpokePauseBlocksStaleRecovery (0.00s)
```

**Neuter replay** (proves the updated control still catches a real kill-switch regression — simulated by forcing `spokeUpgradesPaused()` to always report paused):
```
=== RUN   TestSpokePauseBlocksStaleRecovery
    upgrade_pause_test.go:194: resumed: heartbeatUpgrade = "", want newsha7 (control failed)
--- FAIL: TestSpokePauseBlocksStaleRecovery (0.00s)
```
Restored: green again.

**Fixed, with production behavior now correctly exercised:**
```
=== RUN   TestSpokePauseBlocksStaleRecovery
2026/08/14 11:17:53 WARN advancing upgrade target for stale upgrade hive=h1 stale_minutes=120 old_target=bbb2222 new_target=newsha7
--- PASS: TestSpokePauseBlocksStaleRecovery (0.00s)
```

**Full `pkg/hub` suite:**
```
ok  	github.com/kubestellar/hive/v2/pkg/hub	107.376s
```

No production code changed — this is a test-fixture-only fix.