### PR TITLE
⚡ perf(dashboard): gzip + ETag/304 for the 1.3 MB SPA document

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -816,6 +816,19 @@ func (s *Server) Start() error {
 	if err != nil {
 		return fmt.Errorf("loading embedded static files: %w", err)
 	}
+	// The SPA document gets a dedicated handler with startup-precomputed gzip
+	// and a strong ETag (see static_index.go): http.FileServer would serve the
+	// ~1.3 MB inline document uncompressed with no cache validators (embed.FS
+	// has a zero ModTime, so not even Last-Modified), forcing a full re-download
+	// on every visit. "/{$}" matches the root path exactly; every other static
+	// path falls through to the plain file server below.
+	if rawIndex, err := fs.ReadFile(staticContent, "index.html"); err == nil {
+		idx := newIndexDocument(rawIndex)
+		s.mux.Handle("GET /{$}", idx)
+		s.mux.Handle("GET /index.html", idx)
+	} else {
+		s.logger.Warn("embedded index.html unavailable; falling back to plain file serving", "error", err)
+	}
 	s.mux.Handle("GET /", http.FileServer(http.FS(staticContent)))
 
 	// authenticate is outermost so the identity headers it injects from a

--- a/v2/pkg/dashboard/static_index.go
+++ b/v2/pkg/dashboard/static_index.go
@@ -1,0 +1,133 @@
+package dashboard
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// indexDocument serves the embedded SPA document (static/index.html) with
+// compression and revalidation, replacing the bare http.FileServer for the
+// root document only.
+//
+// WHY THIS EXISTS (perf, measured 2026-08-14): the SPA is a single ~1.3 MB
+// inline HTML document. http.FileServer over embed.FS served it with
+//   - no Content-Encoding (Go's file server never compresses),
+//   - no ETag, and
+//   - no Last-Modified (embed.FS files have a zero ModTime),
+// so every dashboard visit re-downloaded the full 1.3 MB uncompressed. None of
+// the fleet's edges compress on our behalf (ingress-nginx ships with gzip off,
+// the OpenShift HAProxy router never compresses), so the spoke process is the
+// only place this can be fixed for every cluster at once. Gzip cuts the
+// transfer to ~330 KB (≈4x), and the strong ETag turns repeat visits into a
+// 304 with no body at all.
+//
+// The document is embedded in the binary, so both the gzipped form and the
+// ETag are computed exactly once at startup and are immutable for the life of
+// the process. A new image ⇒ new bytes ⇒ new ETag, which is precisely the
+// invalidation we want; Cache-Control: no-cache forces revalidation on every
+// load, so a rolled spoke can never serve a stale UI from browser cache.
+type indexDocument struct {
+	raw     []byte
+	gzipped []byte // nil when gzip compression failed; raw is then always served
+	etag    string
+}
+
+func newIndexDocument(raw []byte) *indexDocument {
+	sum := sha256.Sum256(raw)
+	// 16 hex bytes of the digest is plenty for cache validation and keeps the
+	// header short; the quotes are part of the ETag grammar (RFC 9110 §8.8.3).
+	d := &indexDocument{
+		raw:  raw,
+		etag: `"` + hex.EncodeToString(sum[:])[:16] + `"`,
+	}
+	var buf bytes.Buffer
+	// BestCompression: this runs once per process for a highly compressible
+	// document — spend the extra CPU at startup, not per request.
+	zw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err == nil {
+		if _, err = zw.Write(raw); err == nil {
+			if err = zw.Close(); err == nil {
+				d.gzipped = buf.Bytes()
+			}
+		}
+	}
+	return d
+}
+
+// acceptsGzip reports whether the request's Accept-Encoding allows gzip.
+// A bare substring check would treat "gzip;q=0" (an explicit refusal) as
+// acceptance, so each listed coding is inspected for a zero q-value.
+func acceptsGzip(acceptEncoding string) bool {
+	for _, part := range strings.Split(acceptEncoding, ",") {
+		fields := strings.Split(strings.TrimSpace(part), ";")
+		coding := strings.ToLower(strings.TrimSpace(fields[0]))
+		if coding != "gzip" && coding != "*" {
+			continue
+		}
+		for _, p := range fields[1:] {
+			p = strings.TrimSpace(p)
+			if q, ok := strings.CutPrefix(p, "q="); ok {
+				if f, err := strconv.ParseFloat(q, 64); err == nil && f == 0 {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// ifNoneMatchHits reports whether the request's If-None-Match header matches
+// etag. A weak validator prefix on the client's copy still matches: byte-range
+// requests are not served here, so weak comparison (RFC 9110 §8.8.3.2) is the
+// correct and safe interpretation for a full-document 304.
+func ifNoneMatchHits(header, etag string) bool {
+	if header == "" {
+		return false
+	}
+	if strings.TrimSpace(header) == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		candidate = strings.TrimPrefix(candidate, "W/")
+		if candidate == etag {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *indexDocument) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h := w.Header()
+	h.Set("Content-Type", "text/html; charset=utf-8")
+	h.Set("ETag", d.etag)
+	// no-cache = "store it, but revalidate before every use". Combined with the
+	// strong ETag this makes repeat loads a 304 (no body) while guaranteeing a
+	// freshly rolled spoke's new UI is picked up immediately.
+	h.Set("Cache-Control", "no-cache")
+	// The body varies with Accept-Encoding, so any intermediary cache must key
+	// on it or it could hand gzip bytes to a client that cannot decode them.
+	h.Set("Vary", "Accept-Encoding")
+
+	if ifNoneMatchHits(r.Header.Get("If-None-Match"), d.etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	body := d.raw
+	if d.gzipped != nil && acceptsGzip(r.Header.Get("Accept-Encoding")) {
+		h.Set("Content-Encoding", "gzip")
+		body = d.gzipped
+	}
+	h.Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusOK)
+	if r.Method != http.MethodHead {
+		_, _ = w.Write(body)
+	}
+}

--- a/v2/pkg/dashboard/static_index_test.go
+++ b/v2/pkg/dashboard/static_index_test.go
@@ -1,0 +1,154 @@
+package dashboard
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// testIndexBody is intentionally repetitive so the gzipped form is measurably
+// smaller than the raw form — a positive control that compression actually
+// happened rather than the raw bytes being relabeled.
+var testIndexBody = []byte("<!DOCTYPE html><html>" + strings.Repeat("<div>hive dashboard</div>", 200) + "</html>")
+
+func newTestIndex(t *testing.T) *indexDocument {
+	t.Helper()
+	d := newIndexDocument(testIndexBody)
+	if d.gzipped == nil {
+		t.Fatal("gzip precompression failed for test body")
+	}
+	if len(d.gzipped) >= len(d.raw) {
+		t.Fatalf("gzipped form (%d bytes) not smaller than raw (%d bytes)", len(d.gzipped), len(d.raw))
+	}
+	return d
+}
+
+func TestIndexDocumentServesGzipWhenAccepted(t *testing.T) {
+	d := newTestIndex(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	rec := httptest.NewRecorder()
+	d.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if got := rec.Header().Get("Vary"); got != "Accept-Encoding" {
+		t.Fatalf("Vary = %q, want Accept-Encoding", got)
+	}
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("body is not valid gzip: %v", err)
+	}
+	decoded, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("decompressing body: %v", err)
+	}
+	if string(decoded) != string(testIndexBody) {
+		t.Fatal("decompressed body does not round-trip to the raw document")
+	}
+}
+
+func TestIndexDocumentServesIdentityWithoutAcceptEncoding(t *testing.T) {
+	d := newTestIndex(t)
+	for _, ae := range []string{"", "identity", "gzip;q=0", "br"} {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		if ae != "" {
+			req.Header.Set("Accept-Encoding", ae)
+		}
+		rec := httptest.NewRecorder()
+		d.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("Accept-Encoding=%q: status = %d, want 200", ae, rec.Code)
+		}
+		if got := rec.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("Accept-Encoding=%q: unexpected Content-Encoding %q", ae, got)
+		}
+		if rec.Body.String() != string(testIndexBody) {
+			t.Fatalf("Accept-Encoding=%q: body is not the raw document", ae)
+		}
+	}
+}
+
+func TestIndexDocumentRevalidation(t *testing.T) {
+	d := newTestIndex(t)
+
+	// First load discovers the ETag.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	d.ServeHTTP(rec, req)
+	etag := rec.Header().Get("ETag")
+	if etag == "" || !strings.HasPrefix(etag, `"`) {
+		t.Fatalf("ETag = %q, want a quoted validator", etag)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("Cache-Control = %q, want no-cache", got)
+	}
+
+	// Revalidation with the same ETag — including a weak-prefixed or listed
+	// form — must produce an empty-body 304.
+	for _, inm := range []string{etag, "W/" + etag, `"stale-etag", ` + etag, "*"} {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("If-None-Match", inm)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rec := httptest.NewRecorder()
+		d.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotModified {
+			t.Fatalf("If-None-Match=%q: status = %d, want 304", inm, rec.Code)
+		}
+		if rec.Body.Len() != 0 {
+			t.Fatalf("If-None-Match=%q: 304 carried a %d-byte body", inm, rec.Body.Len())
+		}
+	}
+
+	// A mismatched validator serves the full document.
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("If-None-Match", `"something-else"`)
+	rec = httptest.NewRecorder()
+	d.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Body.Len() == 0 {
+		t.Fatalf("mismatched If-None-Match: status = %d, body = %d bytes; want 200 with body", rec.Code, rec.Body.Len())
+	}
+}
+
+func TestIndexDocumentHeadHasNoBody(t *testing.T) {
+	d := newTestIndex(t)
+	req := httptest.NewRequest(http.MethodHead, "/", nil)
+	rec := httptest.NewRecorder()
+	d.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("HEAD carried a %d-byte body", rec.Body.Len())
+	}
+}
+
+func TestAcceptsGzip(t *testing.T) {
+	cases := []struct {
+		header string
+		want   bool
+	}{
+		{"gzip", true},
+		{"gzip, deflate, br", true},
+		{"br;q=1.0, gzip;q=0.8", true},
+		{"*", true},
+		{"GZIP", true},
+		{"", false},
+		{"identity", false},
+		{"gzip;q=0", false},
+		{"gzip;q=0.0", false},
+		{"br, deflate", false},
+	}
+	for _, c := range cases {
+		if got := acceptsGzip(c.header); got != c.want {
+			t.Errorf("acceptsGzip(%q) = %v, want %v", c.header, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Live-fleet investigation of slow spoke-dashboard loads (2026-08-14). Every hosted route on every cluster (ingress-nginx on hive-oke, HAProxy router on vllm-d, IBM ALB on a-ks-wec2) targets port 3002 — the Go dashboard server — whose `http.FileServer` over `embed.FS` serves the ~1.3 MB inline `static/index.html` with:

- **no Content-Encoding** (Go's file server never compresses; measured live: `Accept-Encoding: gzip, br` still returns 1,305,906 identity bytes on the public `/snapshot` sibling document),
- **no ETag**, and
- **no Last-Modified** (embed.FS files have a zero ModTime),

so every visit re-downloads the full 1.3 MB uncompressed. No edge compresses on our behalf (ingress-nginx ships with gzip off; the OpenShift router never compresses), making the spoke process the only place a fix covers all clusters at once.

## What

A dedicated handler for `GET /{$}` and `GET /index.html` (everything else still falls through to the plain file server):

- pre-gzips the embedded document **once at startup**: 1,299,973 → ~326 KB (~4x),
- strong content-hash ETag + `Cache-Control: no-cache` → repeat visits are an **empty-body 304**, while a freshly rolled spoke's new binary ⇒ new ETag ⇒ immediate UI pickup (no staleness window),
- correct `Accept-Encoding` handling (`gzip;q=0` refusal honored), `Vary: Accept-Encoding`, HEAD without body.

Unit tests cover gzip round-trip (with a positive control that compression actually shrank the body), identity fallback, 304 revalidation incl. weak/listed validators, HEAD, and Accept-Encoding parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)