### PR TITLE
🔒 test(hub): reconcile F19 wiring tests with RESIDUAL-2 per-hive session key

### DIFF
--- a/v2/pkg/hub/hub_generations_f19_wiring_test.go
+++ b/v2/pkg/hub/hub_generations_f19_wiring_test.go
@@ -103,10 +103,14 @@ func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
 	// THE ASSERTION. Every mandatory var must now be derived from the NEW
 	// generation's secret, computed here independently of the code under test.
 	wantAfter := map[string]string{
-		EnvHeartbeatKey:     derivePerHiveKey(newSecret, infoHeartbeatKey, hiveID),
-		EnvTerminalKey:      derivePerHiveKey(newSecret, infoTerminalKey, hiveID),
-		EnvInviteKey:        derivePerHiveKey(newSecret, infoInviteKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(newSecret, infoSessionKey),
+		EnvHeartbeatKey: derivePerHiveKey(newSecret, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:  derivePerHiveKey(newSecret, infoTerminalKey, hiveID),
+		EnvInviteKey:    derivePerHiveKey(newSecret, infoInviteKey, hiveID),
+		// PER-HIVE since RESIDUAL-2 (#3858): this file was written against the
+		// fleet-wide deriveDomainKey expression, which #3858 deliberately
+		// retired. The negative assertion below keeps a merge that resolves
+		// back to the fleet-wide formula from passing silently.
+		EnvSessionKey:       derivePerHiveKey(newSecret, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSessionEd25519Seed)),
 	}
@@ -125,6 +129,13 @@ func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
 		if after[name] == before[name] {
 			t.Errorf("%s: unchanged by rotation — rotation is inert on the spoke-bound path (F19)", name)
 		}
+	}
+	// RESIDUAL-2 guard: the session key must be per-hive, never the fleet-wide
+	// derivation, even after a rotation. Without this, reverting BOTH the
+	// fixture above and desiredPerHiveEnv to deriveDomainKey would satisfy
+	// every equality check in this test.
+	if after[EnvSessionKey] == deriveDomainKey(newSecret, infoSessionKey) {
+		t.Errorf("HIVE_SESSION_KEY is byte-identical to the fleet-wide derivation after rotation — RESIDUAL-2 regressed")
 	}
 
 	// And specifically NOT the raw master file's derivation, which is the exact
@@ -157,15 +168,21 @@ func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
 	}
 }
 
-// rawMasterDerivation reproduces the PRE-generation expressions literally, the
-// same way TestPerHiveEnvGenerationIsAReadPathChangeToday does. Used as the
-// byte-identity reference in both directions.
+// rawMasterDerivation reproduces the current single-generation expressions
+// literally, the same way TestPerHiveEnvGenerationIsAReadPathChangeToday does.
+// Used as the byte-identity reference in both directions.
+//
+// HIVE_SESSION_KEY is the PER-HIVE expression, not the original fleet-wide
+// deriveDomainKey one: RESIDUAL-2 (#3858) retired the fleet-wide formula, so
+// "byte-identical on an unrotated hub" now means identical to the per-hive
+// derivation from the raw master. Keeping the old expression here would make
+// this reference assert the vulnerability rather than the invariant.
 func rawMasterDerivation(master, hiveID string) map[string]string {
 	return map[string]string{
 		EnvHeartbeatKey:     derivePerHiveKey(master, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(master, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(master, infoInviteKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
+		EnvSessionKey:       derivePerHiveKey(master, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(master, infoSessionEd25519Seed)),
 	}
@@ -198,6 +215,12 @@ func TestUnrotatedHubDerivesByteIdenticallyAfterWiring(t *testing.T) {
 			if got[name] != want[name] {
 				t.Errorf("%s changed with no live set installed — the fallback is not byte-identical", name)
 			}
+		}
+		// RESIDUAL-2 guard: pin the per-hive property itself, not just the
+		// fixture. If rawMasterDerivation and desiredPerHiveEnv both regressed
+		// to the fleet-wide formula, every equality above would still hold.
+		if got[EnvSessionKey] == deriveDomainKey(f19SecretA, infoSessionKey) {
+			t.Errorf("HIVE_SESSION_KEY is byte-identical to the fleet-wide derivation — RESIDUAL-2 regressed")
 		}
 	})
 


### PR DESCRIPTION
## Branch-wide regression — blocks every open v4 PR

`TestRotationReachesDesiredPerHiveEnv` and `TestUnrotatedHubDerivesByteIdenticallyAfterWiring` (subtests "no hub constructed" and "never-rotated hub") fail on clean v4 HEAD and therefore on every open PR's merge ref. Reproduced locally on a fresh clone of `origin/v4`.

## The semantic conflict

A textbook semantic merge conflict between two individually green PRs:

- **#3860** (F19 wiring, merged first, `af28a116`) added `hub_generations_f19_wiring_test.go`, whose reference fixtures (`rawMasterDerivation`, `wantAfter`) pin `HIVE_SESSION_KEY` to the **fleet-wide** expression `deriveDomainKey(master, infoSessionKey)` — the formula in force when the file was written.
- **#3858** (RESIDUAL-2, merged second, `f3048410`) deliberately **retired** that fleet-wide formula: `desiredPerHiveEnv` and provisioning now use `provisionSessionKey(hiveID) = derivePerHiveKey(provisionCurrentSecret(), infoSessionKey, hiveID)`.

Each PR's CI ran before the other landed, so neither merge ref contained the union. The union breaks only the wiring tests' expectations — the production code already carries the correct combined semantics: the session key is **per-hive** (RESIDUAL-2) *and* **generation-aware** (F19, via `provisionCurrentSecret`).

## Which semantics won, and why

**#3858's per-hive semantics.** RESIDUAL-2 established that a fleet-uniform `HIVE_SESSION_KEY` was the intended output of the old formula and no rotation could ever fix it; the per-hive derivation is v4's security direction. The stale side is the test fixtures, so the fix is test-only — no production code changes.

## What changed (one file: `v2/pkg/hub/hub_generations_f19_wiring_test.go`)

Following #3858's own "inverted, not relaxed" discipline (as it already applied to `TestPerHiveEnvGenerationIsAReadPathChangeToday`):

- `rawMasterDerivation` and `wantAfter` flip `EnvSessionKey` to `derivePerHiveKey(..., infoSessionKey, hiveID)`, with comments explaining why.
- Two new **negative assertions** pin the property itself: the derived session key must never equal the fleet-wide derivation (post-rotation in `TestRotationReachesDesiredPerHiveEnv`, and in the fallback subtest of the byte-identity test). Without these, a future merge resolving both fixture and production back to `deriveDomainKey` would satisfy every equality check silently.

## What is NOT weakened

- **Byte-identity for unrotated hubs is intact.** The guarantee is "wiring the live generation set changes no derived byte on a never-rotated hub"; the reference is now the *current* production expression (per-hive from the raw master), exactly as `TestPerHiveEnvGenerationIsAReadPathChangeToday` pins it since #3858. `provisionCurrentSecret()` on a never-rotated hub resolves to the same raw master in all three states, so no key material moves without a rotation.
- All positive controls stay: the "installed ROTATED set does change the output" control, the count floors, and the untrusted-refusal tests are untouched.

## Verification

- Failing tests reproduce on clean `origin/v4` HEAD (`c379bcf8`) before the fix.
- After: `go test ./pkg/hub/ -run 'Rotation|Derive|SessionKey|Residual2|Generation|PerHiveEnv|Retire' -count=1` green; full `go test ./pkg/hub/` green (112s).
- `gofmt -l` clean on the touched file.