### PR TITLE
fix(hub): reconcile F19 generation-set wiring tests with per-hive HIVE_SESSION_KEY derivation (#3858/#3860)

### DIFF
--- a/v2/pkg/hub/hub_generations_f19_wiring_test.go
+++ b/v2/pkg/hub/hub_generations_f19_wiring_test.go
@@ -106,7 +106,12 @@ func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
 		EnvHeartbeatKey:     derivePerHiveKey(newSecret, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(newSecret, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(newSecret, infoInviteKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(newSecret, infoSessionKey),
+		// PER-HIVE since audit RESIDUAL-2 (#3858): HIVE_SESSION_KEY was
+		// deriveDomainKey(secret, infoSessionKey) — fleet-uniform — and is now
+		// derivePerHiveKey(secret, infoSessionKey, hiveID). Reconciled through
+		// provisionSessionKey exactly like its heartbeat/terminal/invite
+		// neighbours, so it must be pinned the same per-hive way here.
+		EnvSessionKey:       derivePerHiveKey(newSecret, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSessionEd25519Seed)),
 	}
@@ -157,15 +162,21 @@ func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
 	}
 }
 
-// rawMasterDerivation reproduces the PRE-generation expressions literally, the
-// same way TestPerHiveEnvGenerationIsAReadPathChangeToday does. Used as the
-// byte-identity reference in both directions.
+// rawMasterDerivation reproduces the derivation expressions literally, the same
+// way TestPerHiveEnvGenerationIsAReadPathChangeToday does, so it can serve as
+// the byte-identity reference in both directions independently of the code under
+// test. HIVE_SESSION_KEY is per-hive here since audit RESIDUAL-2 (#3858); every
+// mandatory var except the two Ed25519 public keys is now identity-bound.
 func rawMasterDerivation(master, hiveID string) map[string]string {
 	return map[string]string{
 		EnvHeartbeatKey:     derivePerHiveKey(master, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(master, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(master, infoInviteKey, hiveID),
-		EnvSessionKey:       deriveDomainKey(master, infoSessionKey),
+		// PER-HIVE since audit RESIDUAL-2 (#3858) — see wantAfter above. This is
+		// the byte-identity reference in BOTH directions (un-rotated positive
+		// control and post-rotation), so it must track the production formula in
+		// desiredPerHiveEnv, which now derives HIVE_SESSION_KEY per-hive.
+		EnvSessionKey:       derivePerHiveKey(master, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(master, infoSessionEd25519Seed)),
 	}


### PR DESCRIPTION
## What this unblocks

The v4 mainline `test` / `build-and-test` job is RED on **every** open PR (confirmed independently on two unrelated PRs — an HTML-only change and a dd sync), blocking the whole v4 merge queue. This is a test-only fix that turns it green.

## Root cause

Two security commits landed close together on v4 and collided in test expectations:

- **#3860** (`af28a116`) added `v2/pkg/hub/hub_generations_f19_wiring_test.go`, which pins the byte-identity of the spoke-bound derivation before/after a rotation (F19 wiring).
- **#3858** (`f3048410`, RESIDUAL-2) changed `HIVE_SESSION_KEY` from the fleet-uniform `deriveDomainKey(secret, infoSessionKey)` to the **per-hive** `derivePerHiveKey(secret, infoSessionKey, hiveID)`, reconciled through `provisionSessionKey` exactly like its heartbeat/terminal/invite neighbours.

`#3858` updated its **own** tests (`perhive_env_generation_test.go`, `perhive_env_reconcile_test.go`, `residual2_session_key_per_hive_test.go`) to the new per-hive expression, but did **not** touch the newer `#3860` file. So that file's `rawMasterDerivation` reference and `wantAfter` map still asserted the old fleet-uniform value while production (`desiredPerHiveEnv`) already derives per-hive.

**Verdict per failing case — STALE TEST, not a production regression:**
- `TestRotationReachesDesiredPerHiveEnv`
- `TestUnrotatedHubDerivesByteIdenticallyAfterWiring/no_hub_constructed:_falls_back_to_the_legacy_set`
- `TestUnrotatedHubDerivesByteIdenticallyAfterWiring/never-rotated_hub:_live_set_installed,_still_byte-identical`

Production (`provisionSessionKey` → `desiredPerHiveEnv`) is the sanctioned RESIDUAL-2 behaviour and is correct; the two `EnvSessionKey` expressions in the `#3860` test file were the stale half.

## The fix

Update the two `EnvSessionKey` expressions in `hub_generations_f19_wiring_test.go` (`wantAfter` and the shared `rawMasterDerivation` reference) from `deriveDomainKey(secret, infoSessionKey)` to `derivePerHiveKey(secret, infoSessionKey, hiveID)`, with comments pointing at RESIDUAL-2 (#3858).

## Safety property is NOT weakened

`rawMasterDerivation` remains the independent byte-identity reference used in **both** directions. The never-rotated and no-hub-constructed paths still assert byte-identity against the *correct* derivation (nothing was loosened to `_ = got`), rotation still moves every mandatory var, and the existing positive control still proves an installed rotated set changes the output. The change only corrects *which* correct value is expected.

## Local verification (`-count=1 -short`, macOS)

- `TestRotationReachesDesiredPerHiveEnv` — PASS
- `TestUnrotatedHubDerivesByteIdenticallyAfterWiring` (+2 sub-cases) — PASS
- `go test ./pkg/hub/ -run 'Generation|Rotat|SessionKey|Wiring'` — PASS
- `go test ./pkg/hub/ -run 'Residual2|PerHiveEnv'` — PASS
- full `go test ./pkg/hub/ -short` — PASS

Refs #3858, #3860.