### PR TITLE
fix(hub): drop HIVE_SESSION_KEY from spoke provisioning (issue #3234)

### DIFF
--- a/src/docs/security-model.md
+++ b/src/docs/security-model.md
@@ -104,11 +104,13 @@ What that looks like when misconfigured:
 
 ### Per-hive derived keys
 
-Every spoke uses keys derived per hive from the hub master secret. The hub reconciles six env vars onto **hosted** spoke Deployments automatically (a 15-minute sweep):
+Every spoke uses keys derived per hive from the hub master secret. The hub reconciles five env vars onto **hosted** spoke Deployments automatically (a 15-minute sweep):
 
-`HIVE_HEARTBEAT_KEY`, `HIVE_SESSION_KEY`, `HIVE_SSO_PUBLIC_KEY`, `HIVE_SESSION_PUBLIC_KEY`, `HIVE_TERMINAL_KEY`, `HIVE_INVITE_KEY`
+`HIVE_HEARTBEAT_KEY`, `HIVE_SSO_PUBLIC_KEY`, `HIVE_SESSION_PUBLIC_KEY`, `HIVE_TERMINAL_KEY`, `HIVE_INVITE_KEY`
 
-**Self-hosted spokes are never touched by that sweep** — and do not need to be. Every resolver falls back to deriving the same domain-separated key from `HIVE_HUB_SECRET` + `HIVE_ID`, so a self-hosted spoke that sets those two is byte-identical to a hub-injected one. Setting the six vars explicitly is the least-privilege alternative (the spoke then never holds the master).
+**Self-hosted spokes are never touched by that sweep** — and do not need to be. Every resolver falls back to deriving the same domain-separated key from `HIVE_HUB_SECRET` + `HIVE_ID`, so a self-hosted spoke that sets those two is byte-identical to a hub-injected one. Setting the five vars explicitly is the least-privilege alternative (the spoke then never holds the master).
+
+The symmetric `HIVE_SESSION_KEY` that used to sit alongside `HIVE_SESSION_PUBLIC_KEY` is gone (issue [#3234](https://github.com/kubestellar/hive/issues/3234)): every lane that ever verified against it — the legacy HMAC cookie lane ([#3725](https://github.com/kubestellar/hive/pull/3725)), the terminal-key fall-through, and the Node proxy's copy — was already deleted, so shipping it at all was unjustified secret exposure. The sweep now actively **strips** it from any Deployment still carrying one, rather than merely no longer adding it.
 
 Two gotchas:
 

--- a/src/pkg/hub/hub_generations_f19_wiring_test.go
+++ b/src/pkg/hub/hub_generations_f19_wiring_test.go
@@ -106,12 +106,6 @@ func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
 		EnvHeartbeatKey:     derivePerHiveKey(newSecret, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(newSecret, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(newSecret, infoInviteKey, hiveID),
-		// PER-HIVE since audit RESIDUAL-2 (#3858): HIVE_SESSION_KEY was
-		// deriveDomainKey(secret, infoSessionKey) — fleet-uniform — and is now
-		// derivePerHiveKey(secret, infoSessionKey, hiveID). Reconciled through
-		// provisionSessionKey exactly like its heartbeat/terminal/invite
-		// neighbours, so it must be pinned the same per-hive way here.
-		EnvSessionKey:       derivePerHiveKey(newSecret, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(newSecret, infoSessionEd25519Seed)),
 	}
@@ -165,18 +159,14 @@ func TestRotationReachesDesiredPerHiveEnv(t *testing.T) {
 // rawMasterDerivation reproduces the derivation expressions literally, the same
 // way TestPerHiveEnvGenerationIsAReadPathChangeToday does, so it can serve as
 // the byte-identity reference in both directions independently of the code under
-// test. HIVE_SESSION_KEY is per-hive here since audit RESIDUAL-2 (#3858); every
-// mandatory var except the two Ed25519 public keys is now identity-bound.
+// test. HIVE_SESSION_KEY is deliberately absent (issue #3234): it is no longer
+// injected at all, so it has no expression to pin here. Every remaining
+// mandatory var except the two Ed25519 public keys is identity-bound.
 func rawMasterDerivation(master, hiveID string) map[string]string {
 	return map[string]string{
 		EnvHeartbeatKey:     derivePerHiveKey(master, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(master, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(master, infoInviteKey, hiveID),
-		// PER-HIVE since audit RESIDUAL-2 (#3858) — see wantAfter above. This is
-		// the byte-identity reference in BOTH directions (un-rotated positive
-		// control and post-rotation), so it must track the production formula in
-		// desiredPerHiveEnv, which now derives HIVE_SESSION_KEY per-hive.
-		EnvSessionKey:       derivePerHiveKey(master, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(master, infoSessionEd25519Seed)),
 	}

--- a/src/pkg/hub/hub_keys.go
+++ b/src/pkg/hub/hub_keys.go
@@ -169,53 +169,28 @@ func provisionSessionPublicKey() string {
 	return ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSessionEd25519Seed))
 }
 
-// provisionSessionKey returns the PER-HIVE value injected into a spoke as
-// HIVE_SESSION_KEY (audit RESIDUAL-2).
+// provisionSessionKey is REMOVED (issue #3234, the N2 compatibility-lane
+// follow-up). It used to return the value injected into a spoke as
+// HIVE_SESSION_KEY; the hub no longer injects that var at all —
+// desiredPerHiveEnv (perhive_env_reconcile.go) omits it from `want` and lists
+// it in perHiveEnvRemovedNames so the sweep actively strips it from any
+// Deployment still carrying one, and the saas_provision.go template no longer
+// renders the env block.
 //
-// Measured live before this change: 1 distinct value across all 70 spokes,
-// 0 converged — not sweep drift, but derivation by design. desiredPerHiveEnv
-// derived this var with deriveDomainKey, which takes no hiveID, while its
-// neighbours two lines away used derivePerHiveKey. Uniformity was the intended
-// output of the old formula, so no rotation could ever have made these
-// per-hive: a rotation moves all 70 in lockstep. That is why this is a code
-// change and not a convergence problem.
+// Safe because nothing has verified against this key since F1 (Go legacy
+// cookie lane), N3 (terminal key fall-through) and F23 (Node proxy copy) were
+// deleted — RESIDUAL-2 made it per-hive as defence-in-depth while that was
+// still being confirmed, but per-hive-and-injected was always meant to be a
+// stop on the way to not-injected-at-all, not the destination.
 //
-// WHY THIS IS SAFE TO MAKE PER-HIVE — the value is no longer a comparand.
-// Every lane that once VERIFIED against this key is already deleted:
-//
-//   - F1 removed the Go legacy symmetric cookie lane
-//     (hub_cookie.go verifyHubUserCookieEitherAt, `_ = legacySecret`).
-//   - N3 stopped the terminal key falling through to it (terminal_assertion.go).
-//   - F23 removed the Node proxy's copy (proxy/server.js
-//     verifyHubUserCookieAcrossKeys, `void legacySecret`).
-//
-// What remains on the spoke reads this var for its PRESENCE, never its value:
-// the proxy's IS_HOSTED boot signal is `SESSION_KEY !== ”`. SpokeSessionKey()
-// has zero non-test Go callers. So no party compares a value derived here
-// against a value derived anywhere else, and changing the formula cannot make
-// two honest parties disagree.
-//
-// THE SELF-DERIVE FALLBACK IS THEREFORE HARMLESS, and this is the one thing
-// worth being explicit about, because it is the obvious way a change like this
-// breaks a fleet. A spoke that lacks the env var self-derives it, and both
-// spoke-side resolvers — Go spokeDomainKey(EnvSessionKey, infoSessionKey) and
-// the proxy's deriveSessionKey() — self-derive the FLEET-WIDE value from
-// HIVE_HUB_SECRET, because neither mixes in the hive ID. Once the hub injects a
-// per-hive value the two disagree by construction, and during the roll the
-// fleet holds a mix of both. That is fine here, and only here, precisely
-// because nothing verifies with it: a disagreement over a value no one compares
-// has no observable effect. Both surviving readers are emptiness checks, and a
-// per-hive value is exactly as non-empty as a fleet-wide one, so IS_HOSTED is
-// unchanged for every spoke in every state.
-//
-// Deliberately NOT changing the self-derive fallbacks to match. Making them
-// per-hive would be dead code on both sides today, and on the spoke it would
-// hand a wrong answer to a spoke that has no HIVE_ID — flipping IS_HOSTED to
-// false and silently converting a hosted hive to the self-hosted identity
-// model. The fallbacks stay as they are until the var is dropped outright.
-func provisionSessionKey(hiveID string) string {
-	return derivePerHiveKey(provisionCurrentSecret(), infoSessionKey, hiveID)
-}
+// The spoke-side self-derive fallback (spokeDomainKey/SpokeSessionKey in this
+// file, and the proxy's deriveSessionKey()) is UNCHANGED by this removal and
+// must stay that way: a self-hosted operator who never received this var to
+// begin with legitimately depends on deriving it from HIVE_HUB_SECRET, and
+// both surviving readers of the value — the proxy's IS_HOSTED boot signal and
+// SpokeSessionKey's own (test-only) verification path — are presence checks,
+// never comparands. See TestResidual2SessionKeyIsNotAVerificationComparand,
+// which pins that invariant independently of this removal.
 
 // provisionTerminalKey returns the PER-HIVE terminal signing key injected into a
 // spoke as HIVE_TERMINAL_KEY (audit N3).

--- a/src/pkg/hub/perhive_env_generation_test.go
+++ b/src/pkg/hub/perhive_env_generation_test.go
@@ -65,7 +65,6 @@ func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
 		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretB, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretB, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(perHiveGenSecretB, infoInviteKey, hiveID),
-		EnvSessionKey:       derivePerHiveKey(perHiveGenSecretB, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretB, infoSessionEd25519Seed)),
 	}
@@ -73,7 +72,6 @@ func TestDesiredPerHiveEnvUsesCurrentNotPrevious(t *testing.T) {
 		EnvHeartbeatKey:     derivePerHiveKey(perHiveGenSecretA, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(perHiveGenSecretA, infoTerminalKey, hiveID),
 		EnvInviteKey:        derivePerHiveKey(perHiveGenSecretA, infoInviteKey, hiveID),
-		EnvSessionKey:       derivePerHiveKey(perHiveGenSecretA, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(perHiveGenSecretA, infoSessionEd25519Seed)),
 	}
@@ -159,7 +157,6 @@ func TestDesiredPerHiveEnvDerivesFromCurrentGeneration(t *testing.T) {
 	expect := map[string]string{
 		EnvHeartbeatKey:     derivePerHiveKey(cur, infoHeartbeatKey, hiveID),
 		EnvTerminalKey:      derivePerHiveKey(cur, infoTerminalKey, hiveID),
-		EnvSessionKey:       derivePerHiveKey(cur, infoSessionKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(cur, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(cur, infoSessionEd25519Seed)),
 	}
@@ -191,21 +188,8 @@ func TestPerHiveEnvGenerationIsAReadPathChangeToday(t *testing.T) {
 
 	master := provisionMasterSecret() // the PRE-generation expression
 	preGeneration := map[string]string{
-		EnvHeartbeatKey: derivePerHiveKey(master, infoHeartbeatKey, hiveID),
-		EnvTerminalKey:  derivePerHiveKey(master, infoTerminalKey, hiveID),
-		// AUDIT RESIDUAL-2. This entry is deliberately INVERTED rather than
-		// relaxed. It used to read deriveDomainKey(master, infoSessionKey) —
-		// the fleet-uniform expression — and it was correct to do so: this test
-		// proves the GENERATION work was a pure read-path change. Making the
-		// session key per-hive is a genuinely fleet-VISIBLE change, so leaving
-		// the old right-hand side here would have been a real failure, and
-		// simply deleting the entry would have silently dropped HIVE_SESSION_KEY
-		// from this test's coverage.
-		//
-		// The invariant this test exists to protect is unchanged for every other
-		// var; for this one the claim is now the opposite and is asserted
-		// explicitly below, so a revert to the fleet-wide formula FAILS here.
-		EnvSessionKey:       derivePerHiveKey(master, infoSessionKey, hiveID),
+		EnvHeartbeatKey:     derivePerHiveKey(master, infoHeartbeatKey, hiveID),
+		EnvTerminalKey:      derivePerHiveKey(master, infoTerminalKey, hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: ssoPublicKeyFromSeed(deriveDomainKey(master, infoSessionEd25519Seed)),
 	}
@@ -220,16 +204,12 @@ func TestPerHiveEnvGenerationIsAReadPathChangeToday(t *testing.T) {
 		}
 	}
 
-	// AUDIT RESIDUAL-2, the inverted half. HIVE_SESSION_KEY must NOT equal the
-	// fleet-uniform value any more. Without this, restoring
-	// deriveDomainKey(master, infoSessionKey) in desiredPerHiveEnv would be
-	// caught only by the loop above — and only for as long as the fixture keeps
-	// the per-hive expression, which a merge resolving in favour of the older
-	// side would quietly undo. Asserting the negative pins the property itself
-	// rather than the fixture.
-	if fleetWide := deriveDomainKey(master, infoSessionKey); got[EnvSessionKey] == fleetWide {
-		t.Errorf("HIVE_SESSION_KEY is byte-identical to the fleet-wide derivation — RESIDUAL-2 regressed; " +
-			"desiredPerHiveEnv must use provisionSessionKey(hiveID), not deriveDomainKey(master, infoSessionKey)")
+	// Issue #3234: HIVE_SESSION_KEY must be ABSENT, not merely re-derived.
+	// TestSessionKeyIsPermanentlyRemoved (perhive_env_reconcile_test.go) covers
+	// the removal itself; this only guards against it silently reappearing in
+	// the generation-aware map this test exercises.
+	if _, present := got[EnvSessionKey]; present {
+		t.Error("desiredPerHiveEnv wants HIVE_SESSION_KEY under a rotated generation — issue #3234 removal regressed")
 	}
 }
 

--- a/src/pkg/hub/perhive_env_reconcile.go
+++ b/src/pkg/hub/perhive_env_reconcile.go
@@ -12,7 +12,7 @@ import (
 //
 // THE GAP THIS CLOSES. The C2/N1/N2/N3 work moved every spoke off the shared
 // master onto derived, per-hive sub-keys, and the provisioning template
-// (saas_provision.go) renders all six vars. But that template is `kubectl
+// (saas_provision.go) renders all five vars. But that template is `kubectl
 // apply`ed ONLY inside provisionHive — at provision/assign time. Hives
 // provisioned BEFORE those vars entered the template never received them, and
 // nothing re-asserts them afterwards.
@@ -107,16 +107,16 @@ const (
 // container env list. Only name/value matter here: a var sourced from a
 // secretKeyRef/fieldRef has no literal .value, and we deliberately treat that
 // as "not the value we expect" rather than trying to chase the reference —
-// none of the six vars is ever provisioned as a reference.
+// none of the five vars is ever provisioned as a reference.
 type deploymentEnvVar struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
-// desiredPerHiveEnv returns the six security env vars a spoke for hiveID must
+// desiredPerHiveEnv returns the five security env vars a spoke for hiveID must
 // carry, derived EXACTLY as the v4 provisioning template derives them
-// (saas_provision.go, the HeartbeatKey/SessionKey/SSOPublicKey/
-// SessionPublicKey/TerminalKey block). Provision-time and reconcile-time
+// (saas_provision.go, the HeartbeatKey/SSOPublicKey/SessionPublicKey/
+// TerminalKey/InviteKey block). Provision-time and reconcile-time
 // derivation MUST agree — if they drifted, this sweep would fight provisioning
 // and roll a pod every cycle forever — so both sides call the same helpers in
 // hub_keys.go rather than re-implementing the formulas.
@@ -171,13 +171,15 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 		// Without it in this list a rotation would also never converge the
 		// invite key, leaving it derived from a generation the hub has retired.
 		EnvInviteKey: provisionInviteKey(hiveID),
-		// AUDIT RESIDUAL-2: per-hive, was deriveDomainKey(master,
-		// infoSessionKey) — fleet-uniform by construction, measured as 1
-		// distinct value across all 70 spokes. Nothing verifies with this key
-		// any more (F1/N3/F23 deleted every lane), so the change is
-		// defence-in-depth; see provisionSessionKey for why the spoke-side
-		// self-derive fallback disagreeing during the roll is harmless.
-		EnvSessionKey:       provisionSessionKey(hiveID),
+		// HIVE_SESSION_KEY is deliberately ABSENT (audit #3234 N2 follow-up).
+		// RESIDUAL-2 made it per-hive as defence-in-depth, but every lane that
+		// ever verified against it — F1 (Go legacy cookie lane), N3 (terminal
+		// key fall-through), F23 (Node proxy copy) — was already deleted, so
+		// shipping any value here is unjustified secret exposure with no
+		// verification purpose. See perHiveEnvRemovedNames: leaving it out of
+		// `want` is what makes the sweep actively strip it from every
+		// Deployment that still carries one, not just stop adding it to new
+		// ones.
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(master, infoSSOEd25519Seed)),
 		envSessionPublicKey: provisionSessionPublicKey(),
 	}
@@ -195,7 +197,7 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 	// PREVIOUS-GENERATION PUBLIC KEYS (rotation follow-on #6).
 	//
 	// Added AFTER the empty-value guard above, deliberately, because these two
-	// are the only reconciled vars that are legitimately ABSENT. The six vars
+	// are the only reconciled vars that are legitimately ABSENT. The five vars
 	// above must always be present and non-empty; these two exist only while a
 	// previous generation is live, so "" here means "omit", not "fail".
 	//
@@ -218,14 +220,13 @@ func desiredPerHiveEnv(hiveID string) map[string]string {
 	return want
 }
 
-// perHiveEnvNames lists the six ALWAYS-PRESENT reconciled vars in a stable
+// perHiveEnvNames lists the five ALWAYS-PRESENT reconciled vars in a stable
 // order, for deterministic patches and log lines.
 func perHiveEnvNames() []string {
 	return []string{
 		EnvHeartbeatKey,
 		EnvTerminalKey,
 		EnvInviteKey,
-		EnvSessionKey,
 		EnvSSOPublicKey,
 		envSessionPublicKey,
 	}
@@ -239,7 +240,7 @@ func perHiveEnvNames() []string {
 // They are kept OUT of perHiveEnvNames because that list encodes "must be
 // present and non-empty", and these two must not be. Separating them is what
 // lets perHiveEnvDrift express the third state these vars can be in, which the
-// mandatory six never are: PRESENT WHEN IT SHOULD BE ABSENT. That state is
+// mandatory five never are: PRESENT WHEN IT SHOULD BE ABSENT. That state is
 // reached the moment a previous generation expires, and if the sweep could not
 // see it the retired generation's public key would stay on all 65 spokes
 // forever — the exact "unversioned, permanent compat lane" failure the
@@ -249,6 +250,33 @@ func perHiveEnvOptionalNames() []string {
 	return []string{
 		EnvSSOPublicKeyPrevious,
 		envSessionPublicKeyPrevious,
+	}
+}
+
+// perHiveEnvRemovedNames lists reconciled vars that used to live in
+// perHiveEnvNames and have been permanently retired: desiredPerHiveEnv never
+// wants them again, under any master generation, so the sweep must actively
+// strip any that are still present rather than merely stop adding them.
+//
+// This is distinct from perHiveEnvOptionalNames, where "not wanted" is a
+// TRANSIENT state a rotation window can flip back to "wanted". A name here is
+// never wanted — if a future change needs the var back, it belongs in
+// perHiveEnvNames, not this list.
+//
+// EnvSessionKey (audit #3234, the N2 follow-up): RESIDUAL-2 made it per-hive
+// as defence-in-depth, but every lane that ever verified against it was
+// already deleted (F1 the Go legacy cookie lane, N3 the terminal key
+// fall-through, F23 the Node proxy copy), so shipping it at all is unjustified
+// secret exposure with no remaining verification purpose. The spoke-side
+// self-derive fallback (spokeDomainKey / SpokeSessionKey, proxy
+// deriveSessionKey) is UNCHANGED and deliberately so: a self-hosted operator
+// who never receives this var at all legitimately depends on deriving it from
+// HIVE_HUB_SECRET, and both surviving readers of the value are presence
+// checks (IS_HOSTED), never comparands — see provisionSessionKey's removal
+// note in hub_keys.go.
+func perHiveEnvRemovedNames() []string {
+	return []string{
+		EnvSessionKey,
 	}
 }
 
@@ -304,6 +332,14 @@ func perHiveEnvDrift(live []deploymentEnvVar, want map[string]string) []string {
 			drift = append(drift, name)
 		}
 	}
+	// Permanently retired vars: never wanted, so the only drift direction is
+	// "still present" — a Deployment that has already been stripped, or never
+	// carried one, is converged.
+	for _, name := range perHiveEnvRemovedNames() {
+		if _, present := have[name]; present {
+			drift = append(drift, name)
+		}
+	}
 	return drift
 }
 
@@ -322,25 +358,29 @@ func perHiveEnvDrift(live []deploymentEnvVar, want map[string]string) []string {
 // perHiveEnvNames order, so a converged Deployment produces a byte-identical
 // array on the next sweep and perHiveEnvDrift stays empty — no patch loop.
 func perHiveEnvPatchJSON(live []deploymentEnvVar, want map[string]string) (string, error) {
-	// Vars this lane is allowed to REMOVE: only the optional previous-generation
-	// keys, and only when they are not wanted. Every other live var — including
-	// the mandatory six and every var this lane knows nothing about — is
-	// preserved untouched, which is the property that keeps a whole-array
-	// replace safe.
-	removable := make(map[string]bool, len(perHiveEnvOptionalNames()))
+	// Vars this lane is allowed to REMOVE: the optional previous-generation
+	// keys when they are not wanted, and the permanently retired vars
+	// unconditionally. Every other live var — including the mandatory five and
+	// every var this lane knows nothing about — is preserved untouched, which
+	// is the property that keeps a whole-array replace safe.
+	removable := make(map[string]bool, len(perHiveEnvOptionalNames())+len(perHiveEnvRemovedNames()))
 	for _, name := range perHiveEnvOptionalNames() {
 		if _, wanted := want[name]; !wanted {
 			removable[name] = true
 		}
+	}
+	for _, name := range perHiveEnvRemovedNames() {
+		removable[name] = true
 	}
 
 	merged := make([]deploymentEnvVar, 0, len(live)+len(want))
 	seen := make(map[string]bool, len(want))
 	for _, e := range live {
 		if removable[e.Name] {
-			// Drop it: the generation it verified for has expired out of the
-			// hub's acceptable set, so leaving it would strand a retired public
-			// key on the spoke indefinitely.
+			// Drop it: either the generation it verified for has expired out of
+			// the hub's acceptable set (perHiveEnvOptionalNames), or the var is
+			// permanently retired (perHiveEnvRemovedNames) — either way leaving
+			// it would strand dead key material on the spoke indefinitely.
 			continue
 		}
 		if v, ok := want[e.Name]; ok {
@@ -354,7 +394,7 @@ func perHiveEnvPatchJSON(live []deploymentEnvVar, want map[string]string) (strin
 			merged = append(merged, deploymentEnvVar{Name: name, Value: want[name]})
 		}
 	}
-	// Optional vars are appended only when wanted, after the mandatory six, so
+	// Optional vars are appended only when wanted, after the mandatory five, so
 	// a converged Deployment still produces a byte-identical array on the next
 	// sweep and the no-patch-loop property holds in both the rotated and the
 	// un-rotated state.
@@ -426,7 +466,7 @@ func perHiveEnvPatchAllowed(patchedThisCycle int) bool {
 //
 // Only "provisioning" is excluded: the namespace and Deployment are still
 // being applied, so a read would fail anyway and the provisioning template
-// renders all six vars correctly at creation. This is a cheap-cycle
+// renders all five vars correctly at creation. This is a cheap-cycle
 // optimisation, not a safety gate — the sweep already handles a missing
 // Deployment safely (a failed `kubectl get` logs Debug and continues WITHOUT
 // recording an observation, so an unread hive can never count as converged).
@@ -438,7 +478,7 @@ func perHiveEnvSweepEligible(status string) bool {
 // was derived from, by re-deriving the per-hive heartbeat key under each
 // acceptable generation and comparing.
 //
-// WHY THE HEARTBEAT KEY IS THE PROBE. Of the six reconciled vars it is the one
+// WHY THE HEARTBEAT KEY IS THE PROBE. Of the five reconciled vars it is the one
 // that is BOTH per-hive and a direct HMAC of the master, so a match identifies
 // the generation AND the hive — two spokes on the same generation produce
 // different values, so a stale-hive-ID drift can never be misread as a
@@ -531,7 +571,7 @@ type PerHiveEnvStatus struct {
 	// unreachable cluster is not evidence of anything either way.
 	ObservedHives int `json:"observed_hives"`
 	// MissingPerHiveEnv is how many observed hives are missing (or carry a
-	// wrong value for) at least one of the six reconciled security vars.
+	// wrong value for) at least one of the five reconciled security vars.
 	// Convergence means this reaches zero and STAYS zero across a full sweep.
 	MissingPerHiveEnv int `json:"missing_per_hive_env"`
 	// MissingHives names those laggards so an operator can go look at them
@@ -641,7 +681,7 @@ type KeyGenerationStatus struct {
 	SafeToRetirePrevious bool `json:"safe_to_retire_previous"`
 }
 
-// PerHiveEnvSnapshot reports fleet convergence for the six per-hive security
+// PerHiveEnvSnapshot reports fleet convergence for the five per-hive security
 // env vars.
 //
 // WHY THIS IS NOT SOURCED FROM HEARTBEAT RECENCY. The sibling signal in this
@@ -782,7 +822,7 @@ func (s *HubServer) reconcilePerHiveEnvIfDue() {
 }
 
 // reconcilePerHiveEnv sweeps every hub-managed hosted hive, records its live
-// env posture, and patches in the six security vars where they are absent or
+// env posture, and patches in the five security vars where they are absent or
 // wrong — at most perHiveEnvMaxPatchesPerCycle per cycle.
 //
 // Idempotent: a converged hive produces no patch and therefore no rollout.

--- a/src/pkg/hub/perhive_env_reconcile_test.go
+++ b/src/pkg/hub/perhive_env_reconcile_test.go
@@ -53,15 +53,17 @@ func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
 	}
 
 	// These right-hand sides are copied verbatim from the template's data map
-	// (saas_provision.go: HeartbeatKey / SessionKey / SSOPublicKey /
-	// SessionPublicKey / TerminalKey), INCLUDING their master expression. The
+	// (saas_provision.go: HeartbeatKey / SSOPublicKey / SessionPublicKey /
+	// TerminalKey / InviteKey), INCLUDING their master expression. The
 	// template derives from provisionCurrentSecret() — the current generation —
 	// so this test pins the generation-aware expression, not the old
 	// provisionMasterSecret() one. If provisioning and the reconcile ever
 	// resolved different generations, this fails.
+	//
+	// HIVE_SESSION_KEY is deliberately NOT in this map (issue #3234) — see
+	// TestSessionKeyIsPermanentlyRemoved below.
 	expect := map[string]string{
 		EnvHeartbeatKey:     provisionHeartbeatKey(hiveID),
-		EnvSessionKey:       provisionSessionKey(hiveID),
 		EnvSSOPublicKey:     ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSSOEd25519Seed)),
 		envSessionPublicKey: provisionSessionPublicKey(),
 		EnvTerminalKey:      provisionTerminalKey(hiveID),
@@ -93,9 +95,79 @@ func TestDesiredPerHiveEnvMatchesProvisioningTemplate(t *testing.T) {
 	}
 }
 
+// TestSessionKeyIsPermanentlyRemoved covers the issue #3234 removal: unlike
+// the mandatory five and the rotation-transient optional two,
+// HIVE_SESSION_KEY is a var the sweep must now actively STRIP wherever it
+// finds it, and must never re-add.
+func TestSessionKeyIsPermanentlyRemoved(t *testing.T) {
+	withTestMaster(t, perHiveEnvTestMaster)
+	const hiveID = "hive-alpha"
+
+	want := desiredPerHiveEnv(hiveID)
+	if want == nil {
+		t.Fatal("desiredPerHiveEnv returned nil for a valid master + hive ID")
+	}
+	if _, present := want[EnvSessionKey]; present {
+		t.Error("desiredPerHiveEnv still wants HIVE_SESSION_KEY — issue #3234 removal regressed")
+	}
+	for _, name := range perHiveEnvNames() {
+		if name == EnvSessionKey {
+			t.Error("EnvSessionKey is still in perHiveEnvNames() — it must not be re-asserted as mandatory")
+		}
+	}
+	found := false
+	for _, name := range perHiveEnvRemovedNames() {
+		if name == EnvSessionKey {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("EnvSessionKey is absent from perHiveEnvRemovedNames() — the sweep would never strip a " +
+			"live Deployment that still carries it")
+	}
+
+	// A Deployment that still carries the retired var — exactly what every
+	// spoke provisioned before this change looks like — must be reported as
+	// drifted, and the patch must remove it while leaving everything else
+	// alone.
+	live := envList("HIVE_ID", hiveID, "HIVE_SESSION_KEY", "stale-fleet-wide-value")
+	for _, name := range perHiveEnvNames() {
+		live = append(live, deploymentEnvVar{Name: name, Value: want[name]})
+	}
+
+	drift := perHiveEnvDrift(live, want)
+	if len(drift) != 1 || drift[0] != EnvSessionKey {
+		t.Fatalf("drift = %v, want exactly [%s] for a Deployment that is otherwise converged but still "+
+			"carries the retired var", drift, EnvSessionKey)
+	}
+
+	patchBody, err := perHiveEnvPatchJSON(live, want)
+	if err != nil {
+		t.Fatalf("perHiveEnvPatchJSON: %v", err)
+	}
+	merged := decodePatchEnv(t, patchBody)
+	if _, present := merged[EnvSessionKey]; present {
+		t.Error("patch left HIVE_SESSION_KEY in place — it must be stripped from the live Deployment")
+	}
+	if _, present := merged["HIVE_ID"]; !present {
+		t.Error("patch dropped an untouched pre-existing var while removing HIVE_SESSION_KEY")
+	}
+
+	// And a Deployment that never carried it (every spoke provisioned AFTER
+	// this change) must report no drift for it — the removal is idempotent.
+	converged := envList("HIVE_ID", hiveID)
+	for _, name := range perHiveEnvNames() {
+		converged = append(converged, deploymentEnvVar{Name: name, Value: want[name]})
+	}
+	if drift := perHiveEnvDrift(converged, want); len(drift) != 0 {
+		t.Errorf("a Deployment that never carried HIVE_SESSION_KEY reported drift %v — the sweep would "+
+			"patch (and roll the pod) for nothing", drift)
+	}
+}
+
 // TestPerHiveEnvDriftMissingAll covers the four spokes found running purely on
 // master fallbacks: a Deployment with the pre-cutover env shape and none of the
-// six reconciled vars. All six must be reported as drift.
+// five reconciled vars. All five must be reported as drift.
 func TestPerHiveEnvDriftMissingAll(t *testing.T) {
 	withTestMaster(t, perHiveEnvTestMaster)
 	want := desiredPerHiveEnv("hive-alpha")

--- a/src/pkg/hub/residual2_session_key_per_hive_test.go
+++ b/src/pkg/hub/residual2_session_key_per_hive_test.go
@@ -7,102 +7,33 @@ import (
 	"testing"
 )
 
-// Audit RESIDUAL-2 (2026-08-14). HIVE_SESSION_KEY was derived with
-// deriveDomainKey, which takes no hiveID, so every spoke in the fleet held a
-// byte-identical value: measured live as 1 distinct value across all 70 spokes,
-// 0 converged, while HIVE_TERMINAL_KEY next to it was 70 distinct values.
+// HIVE_SESSION_KEY, in two stages.
 //
-// That was not sweep drift. Uniformity was the intended output of the formula,
-// which is why no rotation could ever have fixed it — a rotation moves all 70
-// in lockstep. It required a code change: provisionSessionKey(hiveID).
+// RESIDUAL-2 (2026-08-14) found it derived with deriveDomainKey, which takes
+// no hiveID, so every spoke in the fleet held a byte-identical value:
+// measured live as 1 distinct value across all 70 spokes, 0 converged, while
+// HIVE_TERMINAL_KEY next to it was 70 distinct values. That was not sweep
+// drift — uniformity was the intended output of the formula — so it took a
+// code change (provisionSessionKey(hiveID)) to make it per-hive, shipped as
+// defence-in-depth: nothing verified against the key any more, but a
+// fleet-uniform symmetric key is exactly the shape that keeps reappearing in
+// these audits.
 //
-// These tests are source-asserting as well as behavioural because the failure
-// mode for this class in this repo is a sync merge resolving a conflict in
-// favour of the older side (F3, F14 and F18 were all lost that way), and the
-// old expression differs from the new one by a single call.
+// Issue #3234 (the N2 compatibility-lane follow-up) finishes the job:
+// per-hive-and-injected was always a stop on the way to not-injected-at-all,
+// not the destination. provisionSessionKey is gone, desiredPerHiveEnv never
+// wants HIVE_SESSION_KEY, and it is listed in perHiveEnvRemovedNames so the
+// sweep actively strips it from any Deployment that still carries one — see
+// TestSessionKeyIsPermanentlyRemoved in perhive_env_reconcile_test.go for the
+// behavioural coverage of that removal.
+//
+// What remains here are the tests specific to THIS var's history: the source
+// invariant that guards against a sync merge quietly reintroducing it (the
+// failure mode that lost F3, F14 and F18 in this repo), and the positive
+// controls that pin why the self-derive fallback staying unchanged is safe
+// rather than merely convenient.
 
 const residual2Master = "residual2-test-master-secret"
-
-// --- THE INVARIANT -----------------------------------------------------------
-
-// TestResidual2SessionKeyIsPerHive is the core regression: two hives must not
-// receive the same HIVE_SESSION_KEY.
-func TestResidual2SessionKeyIsPerHive(t *testing.T) {
-	withTestMaster(t, residual2Master)
-
-	a := desiredPerHiveEnv("hive-alpha")
-	b := desiredPerHiveEnv("hive-beta")
-	if a == nil || b == nil {
-		t.Fatal("desiredPerHiveEnv returned nil for a valid master + hive ID")
-	}
-
-	if a[EnvSessionKey] == "" || b[EnvSessionKey] == "" {
-		t.Fatal("HIVE_SESSION_KEY derived empty — an empty var is WORSE than absent: it makes the " +
-			"readiness count report the hive as converged when it is not")
-	}
-	if a[EnvSessionKey] == b[EnvSessionKey] {
-		t.Error("two hives received a byte-identical HIVE_SESSION_KEY — RESIDUAL-2 regressed; " +
-			"this is the fleet-uniform symmetric-key shape that keeps reappearing in these audits")
-	}
-
-	// Pin it against the exact pre-fix expression, so a revert is named rather
-	// than merely differing from a fixture.
-	if a[EnvSessionKey] == deriveDomainKey(provisionCurrentSecret(), infoSessionKey) {
-		t.Error("HIVE_SESSION_KEY equals deriveDomainKey(master, infoSessionKey) — the pre-fix " +
-			"fleet-wide derivation is back (RESIDUAL-2)")
-	}
-	if want := derivePerHiveKey(provisionCurrentSecret(), infoSessionKey, "hive-alpha"); a[EnvSessionKey] != want {
-		t.Error("HIVE_SESSION_KEY is not HMAC(master, infoSessionKey || 0x00 || hiveID); the " +
-			"derivation no longer matches derivePerHiveKey")
-	}
-}
-
-// TestResidual2SessionKeyStaysReconciled guards the other half: being per-hive
-// is worthless if the sweep stops shipping the var. perHiveEnvNames() is what
-// the reconcile actually walks.
-func TestResidual2SessionKeyStaysReconciled(t *testing.T) {
-	found := false
-	for _, n := range perHiveEnvNames() {
-		if n == EnvSessionKey {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("EnvSessionKey is absent from perHiveEnvNames() — the sweep would never converge it, " +
-			"so the fleet would keep the fleet-uniform value it already holds (RESIDUAL-2)")
-	}
-}
-
-// TestResidual2ProvisioningAndReconcileAgree pins the constraint that makes
-// this change safe to ship. If provisioning emitted the fleet-wide value while
-// the sweep wanted the per-hive one, perHiveEnvDrift would see drift on every
-// pass and roll every pod every cycle, forever.
-func TestResidual2ProvisioningAndReconcileAgree(t *testing.T) {
-	withTestMaster(t, residual2Master)
-	const hiveID = "hive-alpha"
-
-	got := desiredPerHiveEnv(hiveID)
-	if got == nil {
-		t.Fatal("desiredPerHiveEnv returned nil")
-	}
-	// provisionSessionKey is the single helper both sides call.
-	if got[EnvSessionKey] != provisionSessionKey(hiveID) {
-		t.Error("the reconcile sweep and provisionSessionKey disagree — provisioning and reconcile " +
-			"MUST derive identically or they fight and roll a pod every cycle forever")
-	}
-
-	// The provisioning template must call the same helper, not re-implement the
-	// formula. Asserted in source because the template data map is built in a
-	// function too large to exercise here.
-	src := residual2ReadSource(t, "saas_provision.go")
-	if !strings.Contains(src, `"SessionKey":   provisionSessionKey(h.ID)`) {
-		t.Error(`saas_provision.go no longer sets "SessionKey" from provisionSessionKey(h.ID) — if it ` +
-			`reverted to deriveDomainKey, provisioning emits the fleet-wide value while the sweep ` +
-			`wants the per-hive one, and every newly provisioned spoke rolls forever (RESIDUAL-2)`)
-	}
-}
-
-// --- SOURCE INVARIANT --------------------------------------------------------
 
 func residual2ReadSource(t *testing.T, file string) string {
 	t.Helper()
@@ -113,45 +44,62 @@ func residual2ReadSource(t *testing.T, file string) string {
 	return string(raw)
 }
 
-// TestResidual2NoFleetWideSessionDerivationInReconcile asserts the shape at the
-// source level. The behavioural tests above would catch a revert today, but
-// they depend on fixtures that a merge could rewrite in the same commit that
-// reverts the fix; this does not.
-func TestResidual2NoFleetWideSessionDerivationInReconcile(t *testing.T) {
+// --- SOURCE INVARIANT --------------------------------------------------------
+
+// TestSessionKeyNeverDerivedInDesiredEnv is source-asserting, not just
+// behavioural, for the same reason the rest of this file is: a sync merge
+// resolving a conflict in favour of the older side re-adds a line rather than
+// changing a value, and a behavioural test alone depends on a fixture a merge
+// could rewrite in the same commit.
+func TestSessionKeyNeverDerivedInDesiredEnv(t *testing.T) {
 	src := residual2ReadSource(t, "perhive_env_reconcile.go")
 
-	if regexp.MustCompile(`EnvSessionKey:\s*deriveDomainKey\(`).MatchString(src) {
-		t.Error("perhive_env_reconcile.go derives EnvSessionKey with deriveDomainKey — that takes no " +
-			"hiveID and is fleet-uniform by construction (RESIDUAL-2). Use provisionSessionKey(hiveID).")
+	if regexp.MustCompile(`want\s*:=\s*map\[string\]string\{[^}]*EnvSessionKey`).MatchString(src) {
+		t.Error("desiredPerHiveEnv's `want` map derives EnvSessionKey again — issue #3234 removal regressed; " +
+			"it must stay out of `want` and be listed only in perHiveEnvRemovedNames")
 	}
-	if !regexp.MustCompile(`EnvSessionKey:\s*provisionSessionKey\(hiveID\)`).MatchString(src) {
-		t.Error("perhive_env_reconcile.go no longer derives EnvSessionKey with provisionSessionKey(hiveID) " +
-			"(RESIDUAL-2)")
+	if !regexp.MustCompile(`func perHiveEnvRemovedNames\(\) \[\]string \{[^}]*EnvSessionKey`).MatchString(src) {
+		t.Error("perHiveEnvRemovedNames() no longer lists EnvSessionKey — the sweep would stop stripping " +
+			"HIVE_SESSION_KEY from Deployments that still carry it (issue #3234)")
+	}
+	if strings.Contains(src, "provisionSessionKey(") {
+		t.Error("perhive_env_reconcile.go still calls provisionSessionKey — that function was removed by " +
+			"issue #3234; a caller here means the var is being derived again")
+	}
+
+	// Only the LIVE template line is banned — historical prose in comments
+	// (explaining what used to be injected here and why) is expected and
+	// welcome; strings.Contains on the bare env var name would flag those too.
+	provisionSrc := residual2ReadSource(t, "saas_provision.go")
+	if regexp.MustCompile(`(?m)^\s*- name: HIVE_SESSION_KEY\s*$`).MatchString(provisionSrc) {
+		t.Error("saas_provision.go still renders a HIVE_SESSION_KEY env entry in the Deployment template " +
+			"(issue #3234)")
+	}
+	if strings.Contains(provisionSrc, `"SessionKey"`) {
+		t.Error(`saas_provision.go still sets a "SessionKey" template field — the Deployment template no ` +
+			"longer has an env entry to consume it (issue #3234)")
+	}
+	if strings.Contains(provisionSrc, "provisionSessionKey(") {
+		t.Error("saas_provision.go still calls provisionSessionKey — that function was removed by issue #3234")
 	}
 }
 
-// TestResidual2PerHiveVarsCountFloor is the blunt instrument that survives
-// renames: if the number of per-hive derivations in the desired-env map drops,
-// something went back to a fleet-wide formula even if the names still look
-// right. Exactly the signal a sync merge trips.
-func TestResidual2PerHiveVarsCountFloor(t *testing.T) {
-	src := residual2ReadSource(t, "perhive_env_reconcile.go")
-
-	// After RESIDUAL-2 the desired-env map has four hive-bound derivations:
-	// heartbeat, terminal, invite (each provision*Key(hiveID)) and session.
-	// The two public keys are legitimately fleet-wide — they are PUBLIC halves
-	// of hub-held Ed25519 seeds, so binding them per-hive would be meaningless.
-	perHive := regexp.MustCompile(`provision(?:Heartbeat|Terminal|Invite|Session)Key\(hiveID\)`)
-	if got := len(perHive.FindAllString(src, -1)); got < 4 {
-		t.Errorf("perhive_env_reconcile.go has %d per-hive key derivations, want at least 4 "+
-			"(heartbeat, terminal, invite, session) — one reverted to a fleet-wide formula (RESIDUAL-2)", got)
+// TestSessionKeyPerHiveDerivationRemoved pins that provisionSessionKey itself
+// is gone, not merely unreferenced. A stray definition with no callers is the
+// kind of dead code that gets called again by a future "helpful" refactor.
+func TestSessionKeyPerHiveDerivationRemoved(t *testing.T) {
+	src := residual2ReadSource(t, "hub_keys.go")
+	if regexp.MustCompile(`func provisionSessionKey\(`).MatchString(src) {
+		t.Error("provisionSessionKey still exists in hub_keys.go — issue #3234 removed the last caller; " +
+			"a defined-but-unused per-hive derivation for a var the hub no longer injects is a re-introduction " +
+			"waiting to happen")
 	}
 }
 
 // --- POSITIVE CONTROLS -------------------------------------------------------
 //
-// Without these, "make everything per-hive" would satisfy every assertion above
-// while breaking the fleet in two distinct ways.
+// Without these, "remove everything from desiredPerHiveEnv" would satisfy the
+// source invariant above while breaking the fleet in two distinct ways.
 
 // TestResidual2PublicKeysStayFleetWide is the substantive control. The two
 // Ed25519 PUBLIC keys must NOT become per-hive: the hub holds ONE private seed
@@ -177,11 +125,11 @@ func TestResidual2PublicKeysStayFleetWide(t *testing.T) {
 	}
 }
 
-// TestResidual2FailsClosedWithoutIdentity asserts the guard that makes the
-// per-hive formula safe. derivePerHiveKey returns "" for an empty hiveID, and
-// desiredPerHiveEnv must SKIP such a hive rather than ship HIVE_SESSION_KEY=""
-// — an empty var falls back exactly like an absent one on the spoke, but it
-// also makes the readiness counter report the hive as converged when it is not.
+// TestResidual2FailsClosedWithoutIdentity asserts derivePerHiveKey's fail-closed
+// guard on the empty-hiveID case, using infoSessionKey as the probe — the same
+// primitive heartbeat/terminal/invite derivation shares, so this still exercises
+// live production code even though HIVE_SESSION_KEY itself is no longer
+// derived through desiredPerHiveEnv.
 func TestResidual2FailsClosedWithoutIdentity(t *testing.T) {
 	withTestMaster(t, residual2Master)
 
@@ -196,52 +144,52 @@ func TestResidual2FailsClosedWithoutIdentity(t *testing.T) {
 
 // --- THE SELF-DERIVE FALLBACK ------------------------------------------------
 
-// TestResidual2SelfDeriveDisagreementIsHarmless documents, as an executable
-// claim, the single most likely way a change like this breaks a fleet.
+// TestResidual2SessionKeyIsNotAVerificationComparand documents, as an
+// executable claim, why removing HIVE_SESSION_KEY from provisioning outright
+// does not break a fleet.
 //
-// Spokes self-derive HIVE_SESSION_KEY when the env var is absent, and both
-// spoke-side resolvers — Go spokeDomainKey and the proxy's deriveSessionKey —
+// Every spoke self-derives HIVE_SESSION_KEY when the env var is absent — after
+// issue #3234, that is EVERY spoke, permanently, not just those mid-roll — and
+// both spoke-side resolvers (Go spokeDomainKey, the proxy's deriveSessionKey)
 // derive the FLEET-WIDE value from HIVE_HUB_SECRET, because neither mixes in
-// the hive ID. So once the hub injects a per-hive value the two DISAGREE by
-// construction, and during the 66-spoke roll the fleet holds a mix of both.
-//
-// That is safe here, and only here, because nothing verifies with this key:
-// F1 deleted the Go legacy symmetric cookie lane, N3 stopped the terminal key
-// falling through to it, and F23 deleted the Node proxy's copy. A disagreement
-// over a value that no party ever compares has no observable effect.
+// the hive ID. That is safe only because nothing verifies with this key: F1
+// deleted the Go legacy symmetric cookie lane, N3 stopped the terminal key
+// falling through to it, and F23 deleted the Node proxy's copy. A value no
+// party ever compares has no observable effect no matter how many spokes
+// disagree about it.
 //
 // This test pins the premise, not the conclusion: it asserts the value is not
 // used as a comparand. If some future change makes it one again, the
-// disagreement becomes a live fleet-breaking bug and this test fails first.
+// self-derive disagreement becomes a live fleet-breaking bug and this test
+// fails first.
 func TestResidual2SessionKeyIsNotAVerificationComparand(t *testing.T) {
 	// Go side: the legacy symmetric lane must stay deleted.
 	cookieSrc := residual2ReadSource(t, "hub_cookie.go")
 	if !strings.Contains(cookieSrc, "_ = legacySecret") {
 		t.Error("hub_cookie.go no longer discards legacySecret — if the symmetric session lane came " +
-			"back, spokes self-deriving the fleet-wide key would disagree with the hub's per-hive " +
-			"value and hosted auth would break during the roll (RESIDUAL-2 / F1)")
+			"back, spokes self-deriving the fleet-wide key would disagree with the hub and hosted auth " +
+			"would break (RESIDUAL-2 / F1 / #3234)")
 	}
 
 	// SpokeSessionKey must remain callable-but-unused on the Go side. A new
-	// caller is the tripwire: it would be verifying with a value the hub now
-	// derives differently.
+	// caller is the tripwire: it would be verifying with a value the hub no
+	// longer ever ships.
 	for _, f := range []string{"hub_cookie.go", "hub_session_revocation.go", "terminal_assertion.go"} {
 		src := residual2ReadSource(t, f)
 		if strings.Contains(src, "SpokeSessionKey()") {
-			t.Errorf("%s calls SpokeSessionKey() — it had zero Go callers when HIVE_SESSION_KEY became "+
-				"per-hive, and a spoke self-deriving the fleet-wide value would not match the hub "+
-				"(RESIDUAL-2)", f)
+			t.Errorf("%s calls SpokeSessionKey() — the hub no longer injects HIVE_SESSION_KEY at all, so "+
+				"a caller here would verify with the fleet-wide self-derived fallback (#3234)", f)
 		}
 	}
 
 	// The spoke-side resolver is deliberately left fleet-wide. Making it
-	// per-hive would be dead code today and would hand a WRONG answer to a
-	// spoke with no HIVE_ID, flipping the proxy's IS_HOSTED signal to false and
-	// silently converting a hosted hive to the self-hosted identity model.
+	// per-hive would be dead code (the hub never ships a per-hive value to
+	// disagree with) and would hand a WRONG answer to a spoke with no
+	// HIVE_ID, flipping the proxy's IS_HOSTED signal to false and silently
+	// converting a hosted hive to the self-hosted identity model.
 	keysSrc := residual2ReadSource(t, "hub_keys.go")
 	if !strings.Contains(keysSrc, "func SpokeSessionKey() string { return spokeDomainKey(EnvSessionKey, infoSessionKey) }") {
-		t.Error("SpokeSessionKey changed shape — it must keep reading the injected var first and " +
-			"self-deriving the fleet-wide value only as a fallback; see provisionSessionKey for why " +
-			"(RESIDUAL-2)")
+		t.Error("SpokeSessionKey changed shape — it must keep self-deriving the fleet-wide value; a " +
+			"self-hosted operator who never receives HIVE_SESSION_KEY at all legitimately depends on this (#3234)")
 	}
 }

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -1947,31 +1947,27 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// hive_id — and three key-delivery lanes read off that claimed ID.
 		// Binding the bearer to the hive makes the claim self-authenticating.
 		//
-		// All five resolve against provisionCurrentSecret() — the CURRENT
+		// All four resolve against provisionCurrentSecret() — the CURRENT
 		// generation's master (hub_keys.go). Provisioning and the
 		// perhive_env_reconcile sweep MUST derive identically or they would
 		// fight and roll a pod every cycle forever, so both sides read the
 		// generation set through the same helper. Before any rotation exists
 		// this is byte-identical to the old provisionMasterSecret() reads.
 		"HeartbeatKey": provisionHeartbeatKey(h.ID),
-		// RESIDUAL-2: PER-HIVE, matching desiredPerHiveEnv. This MUST move in
-		// lockstep with the reconcile sweep — the two derivations fighting is
-		// exactly the "roll a pod every cycle forever" failure the comment
-		// above warns about.
-		"SessionKey":   provisionSessionKey(h.ID),
 		"SSOPublicKey": ssoPublicKeyFromSeed(deriveDomainKey(provisionCurrentSecret(), infoSSOEd25519Seed)),
 		// N2: the Ed25519 PUBLIC key for hub session cookies. A spoke verifies
-		// hive_hub_user with this and cannot mint one — unlike SessionKey below,
-		// which is symmetric and therefore let any spoke forge a hub ADMIN cookie.
-		// SessionKey is still shipped for the rollout window so a spoke on an older
-		// image keeps verifying legacy cookies; remove it once the fleet has rolled.
+		// hive_hub_user with this and cannot mint one. The old symmetric
+		// SessionKey that used to sit here — which could ALSO mint, letting any
+		// spoke forge a hub ADMIN cookie — is gone (issue #3234): every lane
+		// that ever verified against it (F1, N3, F23) was already deleted, so
+		// it is no longer injected at all rather than shipped-but-unused.
 		"SessionPublicKey": provisionSessionPublicKey(),
 		// N3: the terminal key is PER-HIVE, not fleet-wide. Without it
-		// TerminalSigningKey() falls through to the fleet-uniform SessionKey
-		// above, so an assertion minted on one spoke verifies on every other —
-		// any tenant could forge a shell grant on any other tenant. The spoke
-		// both mints and verifies this key locally, so symmetric is correct;
-		// only the sharing was wrong.
+		// TerminalSigningKey() falls through to the self-derived fleet-wide
+		// session key, so an assertion minted on one spoke verifies on every
+		// other — any tenant could forge a shell grant on any other tenant. The
+		// spoke both mints and verifies this key locally, so symmetric is
+		// correct; only the sharing was wrong.
 		"TerminalKey": provisionTerminalKey(h.ID),
 		// The per-hive contributor-invite signing key. inviteSigningSecret() used
 		// the raw master as its HMAC key, making invites the LAST spoke-side
@@ -2725,30 +2721,34 @@ spec:
         # session, an SSO-as-any-owner token, or an impersonation grant.
         - name: HIVE_HEARTBEAT_KEY
           value: "{{.HeartbeatKey}}"
-        - name: HIVE_SESSION_KEY
-          value: "{{.SessionKey}}"
         # C2 asymmetric SSO: spokes receive only the Ed25519 PUBLIC key and
         # therefore cannot mint SSO tokens (only the hub, holding the private
         # seed, can). Replaces the earlier symmetric HIVE_SSO_KEY.
         - name: HIVE_SSO_PUBLIC_KEY
           value: "{{.SSOPublicKey}}"
-        # N2 (CWE-321/798): the Ed25519 PUBLIC key for hub SESSION cookies.
-        # HIVE_SESSION_KEY above is symmetric, so every spoke that could VERIFY
-        # hive_hub_user could also MINT it — including "clubanderson.<sig>",
-        # which requireAdmin accepts on ~21 admin routes. With this the spoke
-        # verifies and cannot forge. HIVE_SESSION_KEY is still injected for the
-        # rollout window (a spoke on an older image only knows the legacy
-        # format); drop it once the fleet has rolled.
+        # N2 (CWE-321/798): the Ed25519 PUBLIC key for hub SESSION cookies. A
+        # spoke can only VERIFY hive_hub_user with this, never mint it. The
+        # symmetric HIVE_SESSION_KEY that used to sit here let any spoke that
+        # could verify also MINT — including "clubanderson.<sig>", which
+        # requireAdmin accepts on ~21 admin routes. It is no longer injected
+        # (issue #3234): every lane that verified against it — F1 (Go legacy
+        # cookie lane), N3 (terminal key fall-through), F23 (Node proxy copy)
+        # — was already deleted, so shipping it at all was unjustified secret
+        # exposure with no remaining purpose. A spoke that lacks it self-derives
+        # a fleet-wide fallback value from HIVE_HUB_SECRET for its IS_HOSTED
+        # boot signal only (proxy/server.js deriveSessionKey) — never as a
+        # verification comparand, so the disagreement with any spoke that still
+        # holds the old per-hive value is harmless.
         - name: HIVE_SESSION_PUBLIC_KEY
           value: "{{.SessionPublicKey}}"
         # N3 (CWE-862): the terminal signing key is PER-HIVE. This spoke both
         # mints the assertion (dashboard/session.go, at login) and verifies it
         # (proxy/server.js, on /terminal), so a symmetric key is the right shape
         # — but it must not be shared. Without this var TerminalSigningKey()
-        # fell through to HIVE_SESSION_KEY, which is byte-identical fleet-wide,
-        # so an assertion minted here verified on EVERY other tenant's spoke:
-        # one hostile operator could forge a shell grant for an arbitrary user
-        # on an arbitrary hive. Both resolvers already prefer this var.
+        # falls through to the self-derived fleet-wide session key, so an
+        # assertion minted here would verify on EVERY other tenant's spoke: one
+        # hostile operator could forge a shell grant for an arbitrary user on an
+        # arbitrary hive. Both resolvers already prefer this var.
         - name: HIVE_TERMINAL_KEY
           value: "{{.TerminalKey}}"
         # The per-hive contributor-invite signing key. inviteSigningSecret() on

--- a/src/proxy/server.js
+++ b/src/proxy/server.js
@@ -151,8 +151,9 @@ const SESSION_PUBLIC_KEYS = sessionPublicKeys();
 // Boot-time "am I hub-hosted?" signal. Either the injected session key (modern)
 // or a master secret (legacy) proves hosted mode, where identity comes from the
 // hub cookie rather than a shared dashboard token.
-// N2: either key proves hosted mode. A freshly provisioned spoke may hold only
-// the public key once HIVE_SESSION_KEY is dropped after the rollout.
+// N2: either key proves hosted mode. Hosted provisioning no longer injects
+// HIVE_SESSION_KEY at all (issue #3234), so a spoke provisioned or reconciled
+// after that change holds only the public key — hence checking both.
 //
 // ROTATION: this deliberately keys off SESSION_PUBLIC_KEY — the PRIMARY key —
 // exactly as before, NOT off SESSION_PUBLIC_KEYS. Two reasons, both about not


### PR DESCRIPTION
Closes part of #3234 — the N2 compatibility-lane follow-up.

## Where this leaves off

`v4` already deleted every lane that *verified* against the N1/N2 compatibility material:

| Lane | PR | Status |
|---|---|---|
| N1 heartbeat fleet-wide bearer | #3744 | deleted |
| N2 Go cookie legacy HMAC lane | #3725 | deleted |
| N2 Node proxy legacy HMAC lane | #3831 (F23) | deleted |

What was still live: the symmetric `HIVE_SESSION_KEY` itself kept being **injected into every hosted spoke Deployment**. RESIDUAL-2 (#3858, merged today) made it per-hive as defence-in-depth while the removal above was still being confirmed safe, but explicitly documented that as a stop, not the destination:

> The fallbacks stay as they are until the var is dropped outright.

Since nothing verifies against this key any more (confirmed by RESIDUAL-2's own investigation), shipping it at all is unjustified secret exposure with no remaining purpose. This PR drops it outright.

## What changed

- `saas_provision.go`: the spoke Deployment template no longer renders a `HIVE_SESSION_KEY` env entry. Newly-provisioned/reassigned spokes get only `HIVE_SESSION_PUBLIC_KEY`.
- `perhive_env_reconcile.go`: `desiredPerHiveEnv` no longer derives or wants `HIVE_SESSION_KEY`. It's removed from the mandatory `perHiveEnvNames()` and added to a new `perHiveEnvRemovedNames()` set, which `perHiveEnvDrift`/`perHiveEnvPatchJSON` treat as "must be actively stripped if seen live" — so the existing 15-minute reconcile sweep converges the **whole fleet** onto not carrying this var, at the existing 3-patches-per-cycle rate limit (no change to blast radius per cycle).
- `provisionSessionKey` (hub_keys.go) removed — its only two callers are gone.
- Doc/comment updates in `security-model.md` and `proxy/server.js` to stop describing this as "still shipped for the rollout window."

## What I deliberately did *not* change

The issue's text also says to "remove the `SESSION_KEY` fallback from `proxy/server.js`." I didn't do that part, and I think the current code is right not to:

- `SESSION_KEY` in the proxy is read for exactly one purpose now — the `IS_HOSTED` boot signal (`SESSION_KEY !== '' || SESSION_PUBLIC_KEY !== ''`) — and it self-derives from `HIVE_HUB_SECRET` when the explicit var is absent.
- That self-derive path is how **self-hosted** spokes (which never receive `HIVE_SESSION_KEY` from this hub-only provisioning path at all) get correctly detected as hosted when their operator sets `HIVE_HUB_SECRET` directly. Removing the fallback would silently flip those deployments to the self-hosted/dashboard-token identity model.
- It's provably not a security hole: `TestResidual2SessionKeyIsNotAVerificationComparand` (updated in this PR) pins that the value is read only as a presence check on both the Go and proxy side, never as a verification comparand, on both sides of this change.

So `spokeDomainKey`/`SpokeSessionKey()` (Go) and `deriveSessionKey()` (proxy) are untouched.

## Safety / rollout

Unlike the N1/N2 verification-lane removals (which would 401 real traffic mid-roll), this is safe to ship immediately and unconditionally:

- No party has verified against this value since F1/N3/F23 were deleted (upstream of this PR).
- The only two remaining readers of the value anywhere are presence checks, not comparands (pinned by test, see above).
- The reconcile sweep's existing rate limit (3 patches/15 min) means this converges the fleet at the same pace and pod-roll cadence as any other reconciled-var fix — nothing new to plan around operationally.

## Tests

- `TestSessionKeyIsPermanentlyRemoved` (new, `perhive_env_reconcile_test.go`): a Deployment still carrying `HIVE_SESSION_KEY` is reported as drifted and the patch strips it while preserving every other var; a Deployment that never carried it reports no drift (idempotent).
- `TestSessionKeyNeverDerivedInDesiredEnv` / `TestSessionKeyPerHiveDerivationRemoved` (new, `residual2_session_key_per_hive_test.go`): source-level regression guards against a sync-merge silently reintroducing the derivation — the failure mode called out in that file's own history (F3/F14/F18 were all lost that way).
- `TestResidual2SessionKeyIsNotAVerificationComparand` (updated): still passes, now documenting the *permanent* steady state rather than a mid-roll one.
- Existing generation/rotation tests (`perhive_env_generation_test.go`, `hub_generations_f19_wiring_test.go`) updated to stop asserting `HIVE_SESSION_KEY` as one of the reconciled/rotated vars.

```
go build ./... && go vet ./pkg/hub/... && go test ./pkg/hub/...
```
all clean; `gofmt -l` clean on every touched file.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/hub/...`
- [x] `go test ./pkg/hub/...` (full package, no failures)
- [x] `gofmt -l` on every touched Go file
- [x] `node --check proxy/server.js`
- [ ] Live cluster verification (no cluster access from this environment — the reconcile sweep's own tests exercise the drift/patch logic against fixtures instead)
