### PR TITLE
🐛 fix(proxy): bound tunnel half-close drain — stop the fd/goroutine leak burning ~11 cores per spoke

### DIFF
--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -435,14 +435,7 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 		if _, err := upstream.Write(fullBuf); err != nil {
 			return
 		}
-		done := make(chan struct{})
-		go func() {
-			io.Copy(upstream, conn)
-			upstream.(*net.TCPConn).CloseWrite()
-			close(done)
-		}()
-		io.Copy(conn, upstream)
-		<-done
+		relayTunnel(conn, upstream)
 		return
 	}
 
@@ -1065,15 +1058,58 @@ func (p *GitHubProxy) tunnelDirect(conn net.Conn, r *http.Request) {
 
 	fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n")
 
+	relayTunnel(conn, upstream)
+}
+
+// tunnelHalfCloseDrain bounds how long one direction of an opaque tunnel may
+// keep waiting for bytes AFTER the other direction has already finished. It is
+// a var, not a const, for the same reason as waitForReadyPollInterval in
+// pkg/hub: tests need a relay that unwedges in milliseconds. Production keeps
+// the default.
+//
+// 30s is deliberately generous: the only legitimate traffic still in flight
+// once one side has hung up is a response tail already on the wire, which
+// arrives in RTTs, not tens of seconds.
+var tunnelHalfCloseDrain = 30 * time.Second
+
+// relayTunnel shuttles bytes both ways between the proxied client conn and the
+// upstream until BOTH directions have finished, bounding each direction once
+// the other has ended.
+//
+// WHY THE BOUNDS EXIST (measured live, 2026-08-14): the previous inline copies
+// waited on each other unboundedly. On spokes whose forge host
+// (github.ibm.com) sits behind a SYN-accepting firewall, the upstream TCP
+// connect succeeds but no byte ever comes back and no FIN is ever sent. The
+// client (the daemon's own JWT mints, agents' CLIs) gives up at its TLS
+// handshake timeout and closes — the client→upstream copy finishes and
+// half-closes the upstream — but io.Copy(conn, upstream) stayed blocked in
+// upstream.Read() FOREVER. Every attempt leaked two sockets (the FIN_WAIT2 /
+// CLOSE_WAIT piles), the goroutine, and the splice pipe pair io.Copy holds for
+// a TCP↔TCP copy on Linux: ~300k fds and ~11 burned cores per affected spoke.
+//
+// SetReadDeadline is documented to interrupt Reads that are ALREADY blocked,
+// which is exactly what arms the escape hatch here: each side arms the OTHER
+// side's deadline only at the moment its own direction completes, so a
+// healthy long-lived tunnel (git smart HTTP, device-flow polling) is never
+// cut while both directions are still live.
+func relayTunnel(conn, upstream net.Conn) {
 	done := make(chan struct{})
 	go func() {
 		io.Copy(upstream, conn)
 		if tc, ok := upstream.(*net.TCPConn); ok {
 			tc.CloseWrite()
 		}
+		// Client side is done (EOF or error — a dead client looks the same).
+		// A live upstream answers or closes within RTTs; a blackholed one
+		// never would, so bound the remaining upstream→client read.
+		upstream.SetReadDeadline(time.Now().Add(tunnelHalfCloseDrain))
 		close(done)
 	}()
 	io.Copy(conn, upstream)
+	// Mirror image: upstream finished (or errored) but the client may sit
+	// half-open without ever sending EOF; bound the client-side read so
+	// <-done cannot wedge this handler.
+	conn.SetReadDeadline(time.Now().Add(tunnelHalfCloseDrain))
 	<-done
 }
 

--- a/v2/pkg/proxy/tunnel_drain_test.go
+++ b/v2/pkg/proxy/tunnel_drain_test.go
@@ -1,0 +1,140 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// tcpPair returns two ends of a real localhost TCP connection. relayTunnel's
+// escape hatch relies on net.Conn deadline semantics interrupting an
+// in-flight blocked Read, so the test must use real sockets, not net.Pipe.
+func tcpPair(t *testing.T) (client, server net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	ch := make(chan acceptResult, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		ch <- acceptResult{c, aerr}
+	}()
+	client, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	res := <-ch
+	if res.err != nil {
+		t.Fatalf("accept: %v", res.err)
+	}
+	t.Cleanup(func() { client.Close(); res.conn.Close() })
+	return client, res.conn
+}
+
+func shortenTunnelDrain(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := tunnelHalfCloseDrain
+	tunnelHalfCloseDrain = d
+	t.Cleanup(func() { tunnelHalfCloseDrain = old })
+}
+
+func runRelay(conn, upstream net.Conn) chan struct{} {
+	returned := make(chan struct{})
+	go func() {
+		relayTunnel(conn, upstream)
+		close(returned)
+	}()
+	return returned
+}
+
+// TestRelayTunnelDataFlowsBothWays is the positive control: the drain bounds
+// must not have broken the relay itself. Bytes written on either side while
+// both directions are live must arrive intact on the other.
+func TestRelayTunnelDataFlowsBothWays(t *testing.T) {
+	shortenTunnelDrain(t, 2*time.Second)
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runRelay(proxyClientSide, proxyUpstreamSide)
+
+	if _, err := agentSide.Write([]byte("ping")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(forgeSide, buf); err != nil || string(buf) != "ping" {
+		t.Fatalf("client→upstream relay: got %q err %v", buf, err)
+	}
+	if _, err := forgeSide.Write([]byte("pong")); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+	agentSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(agentSide, buf); err != nil || string(buf) != "pong" {
+		t.Fatalf("upstream→client relay: got %q err %v", buf, err)
+	}
+
+	// Orderly shutdown from both ends releases the relay.
+	agentSide.Close()
+	forgeSide.Close()
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relayTunnel did not return after both ends closed")
+	}
+}
+
+// TestRelayTunnelUnwedgesFromSilentUpstream is the regression for the live
+// incident: the upstream TCP-connects (SYN-accepting firewall in front of an
+// unreachable forge) but never sends a byte and never FINs. The client gives
+// up and closes. Before the drain bound, io.Copy(conn, upstream) stayed
+// blocked in upstream.Read() forever, leaking both sockets, the goroutine and
+// io.Copy's splice pipe pair on every attempt.
+func TestRelayTunnelUnwedgesFromSilentUpstream(t *testing.T) {
+	shortenTunnelDrain(t, 300*time.Millisecond)
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+	_ = forgeSide // held open, silent: never reads, never writes, never closes
+
+	returned := runRelay(proxyClientSide, proxyUpstreamSide)
+
+	if _, err := agentSide.Write([]byte("client-hello")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	agentSide.Close() // client-side TLS timeout fires; the client is gone
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relayTunnel wedged on a silent upstream after the client closed — the leak this fix exists for")
+	}
+}
+
+// TestRelayTunnelUnwedgesFromSilentClient is the mirror image: the upstream
+// closes but the client sits half-open forever without sending EOF. <-done
+// must not wedge the handler.
+func TestRelayTunnelUnwedgesFromSilentClient(t *testing.T) {
+	shortenTunnelDrain(t, 300*time.Millisecond)
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+	_ = agentSide // held open, silent
+
+	returned := runRelay(proxyClientSide, proxyUpstreamSide)
+
+	if _, err := forgeSide.Write([]byte("gone")); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+	forgeSide.Close()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relayTunnel wedged on a silent client after the upstream closed")
+	}
+}


### PR DESCRIPTION
## Incident

Hive daemons on the vllm-d / a-ks-wec2 pools silently burning up to ~12 cores with **~300k open fds** (ESTABLISHED/CLOSE_WAIT/FIN_WAIT2 sockets + both-end pipe pairs) and zero log output; worst leak rate measured **~73 fds/s**. Hot spokes all share one trait: forge host `github.ibm.com`, whose firewall accepts the TCP connect from those clusters but never returns a byte and never FINs.

## Named via stack dump (local repro, stable image + silent-accept blackhole)

```
goroutine N [IO wait, 9 minutes]:
io.Copy(...)
proxy.(*GitHubProxy).tunnelDirect        github_proxy.go:1076
proxy.(*GitHubProxy).handleConnectDirect github_proxy.go:742
proxy.(*GitHubProxy).handleConn          github_proxy.go:338
```

Same inline pattern in `handleTransparentTLS`'s opaque-tunnel arm. The tunnel's two `io.Copy` directions wait on each other unboundedly: client gives up at its TLS timeout and closes → client→upstream copy finishes and half-closes upstream (the FIN_WAIT2 pile) → `io.Copy(conn, upstream)` stays blocked in `upstream.Read()` **forever**. Each attempt permanently leaks both sockets, the goroutine, and the splice pipe pair io.Copy holds for TCP↔TCP on Linux (the ~160k both-end pipes). The CPU burn is GC over the ever-growing pile.

Verified pre-fix: 5 blackholed CONNECT attempts leak +20 fds still held >70s after the clients exited.

## Fix

Extract the relay into `relayTunnel` and arm a read deadline on the surviving direction **only at the moment the other direction completes** (`SetReadDeadline` interrupts an already-blocked Read). Healthy long-lived tunnels are never cut. Mirrors what #3466 did for the MITM relay.

Tests: silent-upstream regression (the incident), silent-client mirror, positive control that bytes still relay both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)