### PR TITLE
🐛 fix(entrypoint): raise --inh-caps so ambient CAP_NET_ADMIN survives the privilege drop

### DIFF
--- a/.github/workflows/suid-contract.yml
+++ b/.github/workflows/suid-contract.yml
@@ -40,3 +40,17 @@ jobs:
 
       - name: Run SUID + NET_ADMIN static contract check
         run: bash v2/scripts/check-suid-contract.sh v2/Dockerfile v2/deploy/entrypoint.sh
+
+  # RUNTIME assertion (#3874). The static check above cannot catch the bug that
+  # caused the fleet-wide outage: `setpriv --ambient-caps +net_admin` EXITS 0 but
+  # leaves CapAmb=0x0 unless --inh-caps is raised in the same call. Only actually
+  # performing the privilege drop and reading /proc/self/status proves it.
+  # This runs the real setpriv from the real base image, with NET_ADMIN in the
+  # bounding set (--cap-add), and asserts bit 12 survives the drop to dev.
+  ambient-cap-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Assert ambient CAP_NET_ADMIN survives the privilege drop
+        run: bash v2/deploy/test_ambient_cap_runtime.sh

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -880,29 +880,74 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
   # regid of a nonexistent `dev` group would make setpriv fail and silently drop
   # us to the gosu fallback (losing the ambient cap on managed spokes).
   _SETPRIV_ID="--reuid dev --regid node --init-groups"
+
+  # ── The ambient set CANNOT be raised without the INHERITABLE set (#3874) ──
+  # An ambient capability is only permitted to hold a bit that is in BOTH the
+  # permitted and the inheritable set (kernel: cap_ambient_raise → PR_CAP_AMBIENT
+  # requires the cap in pP *and* pI, capability.c). setpriv applies --ambient-caps
+  # AFTER the UID change, at which point a setuid transition has already zeroed
+  # pI. So `--ambient-caps +net_admin` ALONE is a silent no-op: setpriv exits 0,
+  # the entrypoint prints its success line, and the process lands with
+  # CapAmb=0x0 — exactly the signature seen fleet-wide (CapBnd=...a80435fb with
+  # CapInh/CapPrm/CapEff/CapAmb all zero). The proxy then cannot setsockopt
+  # (SO_MARK) its own upstream dial, that dial is REDIRECTed back into the proxy
+  # itself, and every outbound :443 hangs until timeout while inbound is fine.
+  #
+  # Raising --inh-caps in the SAME setpriv call fixes it: pI keeps NET_ADMIN
+  # across the credential change, so the ambient raise is legal and sticks
+  # (verified live: CapInh/CapPrm/CapEff/CapAmb all become 0x1000).
+  #
+  # This grants net_admin and NOTHING else — no file capability, no SUID, and the
+  # bounding set is still the gate above, so self-hosted spokes are unaffected.
+  _SETPRIV_CAPS="--inh-caps +net_admin --ambient-caps +net_admin"
+
   # Probe the full invocation once (as root) so a bad flag/identity falls through
   # to the gosu fallback instead of exec-failing after the point of no return.
+  #
+  # The probe VERIFIES THE OUTCOME rather than trusting the exit status: it reads
+  # CapAmb back out of /proc/self/status in the dropped child and requires bit 12
+  # to actually be set. A setpriv that "succeeds" while producing CapAmb=0x0 (the
+  # bug above, and any future kernel/util-linux regression of the same shape) is
+  # therefore treated as a FAILURE and falls through to the honest gosu path,
+  # instead of silently claiming an egress exemption the proxy does not have.
+  _setpriv_grants_ambient_net_admin() {
+    _probe_amb="$(setpriv $_SETPRIV_CAPS $_SETPRIV_ID \
+      sh -c 'grep -m1 "^CapAmb:" /proc/self/status' 2>/dev/null | awk '{print $2}')"
+    [ -n "$_probe_amb" ] && [ $(( 0x${_probe_amb} & 0x1000 )) -ne 0 ]
+  }
+
   if [ "$_cap_net_admin_in_bset" = "true" ] \
      && command -v setpriv >/dev/null 2>&1 \
-     && setpriv --ambient-caps +net_admin $_SETPRIV_ID true 2>/dev/null; then
+     && _setpriv_grants_ambient_net_admin; then
     # Managed spoke: bounding set HAS NET_ADMIN and setpriv can raise it into the
     # ambient set. Drop to dev WITH ambient+effective NET_ADMIN so the Go hive
     # process can SO_MARK its proxy dials.
     echo "[entrypoint] Dropping to dev user (ambient CAP_NET_ADMIN granted for proxy SO_MARK egress-gate)"
-    exec setpriv --ambient-caps +net_admin $_SETPRIV_ID "$0" "$@"
+    exec setpriv $_SETPRIV_CAPS $_SETPRIV_ID "$0" "$@"
   elif command -v gosu >/dev/null 2>&1 && gosu dev true 2>/dev/null; then
     if [ "$_cap_net_admin_in_bset" != "true" ]; then
       # Self-hosted / rootless spoke: no NET_ADMIN in the bounding set. Do NOT
       # attempt the ambient raise (setpriv would error). The binary execs fine
-      # (no file cap), but the proxy's SO_MARK egress exemption is unavailable —
-      # the forced-proxy egress-gate degrades to the owner-UID exemption only
-      # (works on OKE, not on OpenShift/OVN). The Go proxy logs this once and
-      # dials unmarked (v2/pkg/proxy/github_proxy.go warnSockMarkOnce).
-      echo "[entrypoint] NOTICE: CAP_NET_ADMIN is not in the bounding set — the forced-proxy egress exemption (SO_MARK) is unavailable. hive will run without it; grant NET_ADMIN (securityContext capabilities.add / --cap-add NET_ADMIN) for full egress attribution."
+      # (no file cap), but the proxy's SO_MARK egress exemption is unavailable.
+      # The only remaining self-exemption is the owner-UID RETURN appended above
+      # — and that one is CONDITIONAL: it is appended with `|| true` and silently
+      # does not exist on kernels without the xt_owner module (OpenShift/OVN and
+      # some IKS/OKE node images: "Extension owner revision 0 not supported").
+      # So do NOT promise it here. Report what is actually in the chain, which is
+      # verifiable, instead of asserting a backstop that may not be loaded.
+      # The Go proxy logs the unmarked dial once
+      # (v2/pkg/proxy/github_proxy.go warnSockMarkOnce).
+      if iptables -t nat -C HIVE_PROXY -m owner --uid-owner "$PROXY_UID" -j RETURN 2>/dev/null; then
+        _owner_backstop="present (xt_owner loaded) — proxy dials still exempt via owner-UID"
+      else
+        _owner_backstop="ABSENT (no xt_owner on this kernel) — the proxy has NO self-exemption; outbound :443 from the proxy will loop back into the redirect"
+      fi
+      echo "[entrypoint] NOTICE: CAP_NET_ADMIN is not in the bounding set — the forced-proxy egress exemption (SO_MARK) is unavailable. Owner-UID backstop: ${_owner_backstop}. Grant NET_ADMIN (securityContext capabilities.add / --cap-add NET_ADMIN) for full egress attribution."
     else
-      # Bounding set HAD NET_ADMIN but setpriv was missing or failed — fall back
-      # to gosu (no ambient cap). Same SO_MARK degradation as the no-cap case.
-      echo "[entrypoint] WARN: setpriv unavailable or ambient-cap raise failed despite NET_ADMIN in bounding set — falling back to gosu (SO_MARK egress exemption unavailable)."
+      # Bounding set HAD NET_ADMIN but setpriv was missing, or the probe proved
+      # the ambient bit did NOT survive the drop (the #3874 silent no-op). Fall
+      # back to gosu with an honest warning: this path has no SO_MARK exemption.
+      echo "[entrypoint] WARN: setpriv unavailable, or the ambient CAP_NET_ADMIN raise did not survive the privilege drop (verified CapAmb bit 12 unset), despite NET_ADMIN in the bounding set — falling back to gosu (SO_MARK egress exemption unavailable)."
     fi
     echo "[entrypoint] Dropping to dev user"
     exec gosu dev "$0" "$@"

--- a/v2/deploy/test_ambient_cap_runtime.sh
+++ b/v2/deploy/test_ambient_cap_runtime.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# test_ambient_cap_runtime.sh — RUNTIME regression test for #3874.
+#
+# THE BUG THIS CATCHES
+# --------------------
+# `setpriv --ambient-caps +net_admin --reuid dev ...` exits 0 but silently
+# produces CapAmb=0x0. The kernel only permits an ambient bit that is present in
+# BOTH the permitted and the INHERITABLE set (cap_ambient_raise / PR_CAP_AMBIENT,
+# kernel/capability.c), and setpriv applies --ambient-caps after the UID change,
+# by which point the setuid transition has zeroed pI. The entrypoint therefore
+# printed its success line while the hive process ran with NO NET_ADMIN, so the
+# proxy could not SO_MARK its own upstream dial, that dial was REDIRECTed back
+# into the proxy, and every outbound :443 hung — a fleet-wide outage.
+#
+# The fix raises --inh-caps in the SAME setpriv call.
+#
+# WHY THIS TEST IS RUNTIME AND NOT A grep
+# ---------------------------------------
+# The shipped bug was 100% invisible to static inspection: the flag was present,
+# the exit status was 0, the log line claimed success. Only executing the drop
+# and reading CapAmb back proves the capability actually survived. A static
+# assertion here would be exactly the "test that passes for the wrong reason"
+# this repo already has too many of.
+#
+# CONTROLS (both directions, all executed for real):
+#   POSITIVE : the fixed invocation           -> CapAmb bit 12 MUST be set
+#   NEGATIVE : the buggy invocation (no --inh) -> CapAmb bit 12 MUST be unset
+#              (this is the regression replay: it reproduces the outage in-test,
+#              so if a future change makes the buggy form "work", we learn it)
+#   NEGATIVE : no NET_ADMIN in the bounding set -> raise must NOT be attempted
+#   SOURCE   : the entrypoint must actually use the fixed form
+#
+# Run: bash v2/deploy/test_ambient_cap_runtime.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ENTRYPOINT="$(cd "$(dirname "$0")" && pwd)/entrypoint.sh"
+
+# CAP_NET_ADMIN is capability 12 -> mask 0x1000.
+CAP_NET_ADMIN_MASK=0x1000
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Image with setpriv (util-linux) and a non-root user to drop to.
+IMAGE="debian:bookworm-slim"
+
+# Run a shell snippet inside a container that HAS NET_ADMIN in its bounding set,
+# with an unprivileged target user created, and echo the resulting CapAmb.
+# $1 = the setpriv capability flags under test (may be empty).
+capamb_after_drop() {
+  local capflags="$1" caps_arg="$2"
+  docker run --rm $caps_arg "$IMAGE" sh -c "
+    set -e
+    apt-get update -qq >/dev/null 2>&1
+    apt-get install -y -qq util-linux >/dev/null 2>&1
+    useradd -u 1001 -m dev >/dev/null 2>&1 || true
+    setpriv $capflags --reuid dev --regid dev --init-groups \
+      sh -c 'grep -m1 \"^CapAmb:\" /proc/self/status' 2>/dev/null \
+      | awk '{print \$2}'
+  " 2>/dev/null | tr -d '[:space:]'
+}
+
+bit_set() {
+  local hex="$1"
+  [ -n "$hex" ] || return 1
+  [ $(( 0x${hex} & ${CAP_NET_ADMIN_MASK} )) -ne 0 ]
+}
+
+echo "=== #3874 ambient CAP_NET_ADMIN runtime tests ==="
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  echo "  SKIP: docker unavailable — runtime capability assertions require it"
+  echo "  (CI runs this on ubuntu-latest where docker is present)"
+  exit 0
+fi
+
+echo "-- runtime: POSITIVE control (the ENTRYPOINT'S OWN flags) --"
+# CRITICAL: these flags are EXTRACTED FROM THE ENTRYPOINT, not hardcoded here.
+# A hardcoded copy would keep passing even after the entrypoint regressed — the
+# exact "passes for the wrong reason" failure mode this repo keeps hitting. By
+# driving the container with whatever the entrypoint actually sets, a regression
+# in the entrypoint turns this runtime assertion RED.
+ENTRY_CAPS="$(sed -n 's/^[[:space:]]*_SETPRIV_CAPS="\(.*\)"[[:space:]]*$/\1/p' "$ENTRYPOINT" | head -1)"
+echo "     flags extracted from entrypoint = '${ENTRY_CAPS:-<none>}'"
+if [ -z "$ENTRY_CAPS" ]; then
+  bad "could not extract _SETPRIV_CAPS from the entrypoint — test cannot verify the real invocation"
+fi
+FIXED="$(capamb_after_drop "$ENTRY_CAPS" '--cap-add=NET_ADMIN')"
+echo "     CapAmb after entrypoint drop = ${FIXED:-<empty>}"
+if bit_set "$FIXED"; then
+  ok "ambient CAP_NET_ADMIN SURVIVES the privilege drop using the entrypoint's own flags"
+else
+  bad "ambient CAP_NET_ADMIN LOST across the privilege drop using the entrypoint's own flags — the #3874 outage condition"
+fi
+
+echo "-- runtime: NEGATIVE control (regression replay of the shipped bug) --"
+BUGGY="$(capamb_after_drop '--ambient-caps +net_admin' '--cap-add=NET_ADMIN')"
+echo "     CapAmb after buggy drop   = ${BUGGY:-<empty>}"
+if bit_set "$BUGGY"; then
+  bad "the buggy form (--ambient-caps WITHOUT --inh-caps) now yields a live ambient cap — this test can no longer distinguish fixed from broken; re-derive the control"
+else
+  ok "the buggy form still silently yields CapAmb=0 (proves the positive control above is meaningful, not vacuous)"
+fi
+
+echo "-- runtime: NEGATIVE control (no NET_ADMIN in bounding set) --"
+NOCAP="$(capamb_after_drop '--inh-caps +net_admin --ambient-caps +net_admin' '')"
+echo "     CapAmb without --cap-add  = ${NOCAP:-<empty/failed>}"
+if bit_set "$NOCAP"; then
+  bad "ambient NET_ADMIN raised despite it being absent from the bounding set"
+else
+  ok "no ambient NET_ADMIN when the bounding set lacks it (self-hosted spokes unaffected)"
+fi
+
+echo "-- source: the entrypoint uses the fixed form --"
+# Both flags must appear, and they must be in the SAME setpriv invocation.
+if grep -qE '\-\-inh-caps[[:space:]]+\+net_admin[[:space:]]+--ambient-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"; then
+  ok "entrypoint raises --inh-caps alongside --ambient-caps in one setpriv call"
+else
+  bad "entrypoint does not raise --inh-caps with --ambient-caps (#3874 would recur)"
+fi
+
+# The entrypoint must VERIFY the outcome, not trust setpriv's exit status.
+if grep -qE 'CapAmb' "$ENTRYPOINT"; then
+  ok "entrypoint verifies CapAmb after the drop rather than trusting exit status"
+else
+  bad "entrypoint does not read CapAmb back — a silent no-op would go unnoticed again"
+fi
+
+# Guard the blast radius: net_admin and nothing more.
+if grep -qE '\-\-(inh|ambient)-caps[[:space:]]+\+(?!net_admin)' "$ENTRYPOINT" 2>/dev/null \
+   || grep -qE '\-\-(inh|ambient)-caps[[:space:]]+\+all' "$ENTRYPOINT"; then
+  bad "entrypoint raises more than net_admin"
+else
+  ok "entrypoint raises net_admin only (no capability-posture widening)"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/v2/deploy/test_entrypoint_netadmin_ambient.sh
+++ b/v2/deploy/test_entrypoint_netadmin_ambient.sh
@@ -75,8 +75,19 @@ else
   echo "  PASS: entrypoint does not mask the wrong bit (0x2000 / NET_RAW)"
   PASS=$((PASS + 1))
 fi
-assert_contains 'setpriv[[:space:]]+--ambient-caps[[:space:]]+\+net_admin' \
-  "entrypoint raises an ambient NET_ADMIN cap via setpriv"
+# INVERTED (not relaxed) for #3874. The old pattern was
+#   'setpriv[[:space:]]+--ambient-caps[[:space:]]+\+net_admin'
+# which required EXACTLY the silently-broken invocation and would have gone RED
+# on the correct fix — it ENCODED the bug. `--ambient-caps` alone exits 0 but
+# leaves CapAmb=0x0: the kernel only permits an ambient bit that is also in the
+# inheritable set, and the setuid transition zeroes pI first. The contract is now
+# STRONGER — both flags are required.
+assert_contains '--inh-caps[[:space:]]+\+net_admin' \
+  "entrypoint raises NET_ADMIN into the inheritable set (required for ambient to stick — #3874)"
+assert_contains '--ambient-caps[[:space:]]+\+net_admin' \
+  "entrypoint raises an ambient NET_ADMIN cap"
+assert_contains 'setpriv' \
+  "entrypoint still performs the drop via setpriv"
 assert_contains '--reuid[[:space:]]+dev' \
   "entrypoint drops the ambient-cap path to the dev user (--reuid dev)"
 assert_contains 'exec[[:space:]]+gosu[[:space:]]+dev' \

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -28,8 +28,12 @@
 #   - NO `setcap` file capability on the hive binary (a file cap EPERMs on exec
 #     wherever the runtime bounding set lacks the cap — the #3760 crash-loop).
 #   - the entrypoint instead raises NET_ADMIN as an AMBIENT capability, gated on
-#     the CAP_NET_ADMIN bounding-set bit, via `setpriv --ambient-caps +net_admin`,
+#     the CAP_NET_ADMIN bounding-set bit, via
+#     `setpriv --inh-caps +net_admin --ambient-caps +net_admin`,
 #     with a `gosu dev` fallback when the cap is unavailable.
+#     BOTH flags are required (#3874): --ambient-caps alone exits 0 but yields
+#     CapAmb=0x0, because the kernel only allows an ambient bit that is also in
+#     the inheritable set, which the setuid transition has already zeroed.
 #
 # Usage: v2/scripts/check-suid-contract.sh [path-to-Dockerfile] [path-to-entrypoint]
 set -euo pipefail
@@ -166,8 +170,17 @@ check "entrypoint reads the bounding set (CapBnd)" \
   'CapBnd' "$ENTRYPOINT"
 check "entrypoint tests the CAP_NET_ADMIN bounding-set bit (bit 12 / 0x1000)" \
   '0x1000' "$ENTRYPOINT"
-check "entrypoint raises NET_ADMIN as an ambient capability via setpriv" \
-  'setpriv[[:space:]]+--ambient-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"
+# INVERTED (not relaxed) for #3874. This assertion previously required the
+# literal `setpriv --ambient-caps +net_admin` — i.e. it demanded EXACTLY the
+# form that is silently broken, and would have gone RED on the correct fix. It
+# ENCODED the bug: an ambient bit cannot be raised unless the same setpriv call
+# also raises the INHERITABLE set (the kernel requires the cap in pP *and* pI;
+# setpriv applies --ambient-caps after the UID change, when pI is already zero).
+# The contract is now the stronger one: --inh-caps must accompany --ambient-caps.
+check "entrypoint raises NET_ADMIN into the INHERITABLE set (required for the ambient raise to stick — #3874)" \
+  '--inh-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"
+check "entrypoint raises NET_ADMIN as an ambient capability" \
+  '--ambient-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"
 # The setpriv identity (--reuid dev) may live in a shell variable reused by both
 # the probe and the exec, so assert it appears in the file rather than adjacent
 # to --ambient-caps. A missing --reuid dev would leave the drop-to-dev broken.


### PR DESCRIPTION
## Root cause (corrected from the original diagnosis)

`setpriv --ambient-caps +net_admin` **exits 0 but silently leaves `CapAmb=0x0`.**

The kernel only permits an ambient capability present in **both** the permitted and the **inheritable** set (`cap_ambient_raise` / `PR_CAP_AMBIENT`, `kernel/capability.c`). `setpriv` applies `--ambient-caps` **after** the UID change — by which point the setuid transition has already zeroed `pI`. So the raise is a no-op, and the entrypoint prints its success line anyway.

### What the original diagnosis said vs. what is actually true

The brief attributed this to the entrypoint dropping privileges "without `setpriv`", comparing two log lines:
- working: `Dropping to dev user (setpriv, ambient CAP_NET_ADMIN)`
- broken: `Dropping to dev user (ambient CAP_NET_ADMIN granted for proxy SO_MARK egress-gate)`

That comparison is **inverted**. The first string is from `f4ba07ac`, which was **reverted** in `74c22e74`. The second is the *current* `v4` code (`9cc4054f`, landed today). `setpriv` is not missing — it is present and running on the broken path.

Also corrected: `CapBnd=0x15fb` **passes** the bounding-set gate (bit 12 is set), so the gate is not the problem either. The bug is entirely downstream of it.

### Verified live on the fleet

```
CapBnd: 00000000a80435fb     <- NET_ADMIN present, gate correctly passes
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapAmb: 0000000000000000     <- the ambient raise silently did nothing
```
```
[entrypoint] Dropping to dev user (ambient CAP_NET_ADMIN granted for proxy SO_MARK egress-gate)
{"level":"WARN","msg":"proxy egress SO_MARK unavailable ...","mark":4370,"error":"operation not permitted"}
```

Reproduced and fixed in-cluster:

| invocation | resulting `CapAmb` |
|---|---|
| `setpriv --ambient-caps +net_admin ...` | `0x0` |
| `setpriv --inh-caps +net_admin --ambient-caps +net_admin ...` | `0x1000` |

## Why it broke egress

The proxy needs `CAP_NET_ADMIN` to `setsockopt(SO_MARK)` its **own** upstream dial. Without the mark, that dial matches the `REDIRECT` rule and is looped back into the proxy itself, hanging until timeout — `curl https://... -> 000` for everything outbound, while inbound is unaffected.

## The MITM proxy stays fully in the path

This adds **no** `RETURN`/bypass rule and removes nothing from the chain. It restores the capability the proxy needs to mark the single socket that is its own upstream dial — the exemption that already exists in the ruleset and that keeps the proxy from redirecting into itself. **Every other socket still hits the `REDIRECT`.** If anything, this *restores* what the proxy sees: right now the proxy cannot complete upstream dials at all.

## Also fixed: the false owner-UID backstop

The brief asked to either implement a working backstop or remove the false claim. **Removed the false claim** — a backstop that works on these kernels is not implementable, because `xt_owner` is absent (`Extension owner revision 0 not supported`) and cannot be loaded from the pod.

Correction to the brief: the owner-UID rules **do** exist on the spokes I inspected —
```
-A HIVE_PROXY -m owner --uid-owner 0 -j RETURN
-A HIVE_PROXY -m owner --uid-owner 1001 -j RETURN
```
— so "no owner-UID rule exists" is not universally true. But they are appended with `|| true` and are silently absent wherever `xt_owner` is missing. The NOTICE now **probes** with `iptables -C` and reports `present`/`ABSENT` instead of asserting a backstop that may never have loaded.

## Hardened, not just fixed

The probe now **verifies the outcome** — it reads `CapAmb` back in the dropped child and requires bit 12. A `setpriv` that "succeeds" while producing `CapAmb=0x0` now falls through to the honest `gosu` path instead of claiming an exemption the proxy does not have.

## Security posture

Unchanged: `net_admin` only, no file capability, no SUID change. The C6 `4750 root:hive-launch` `su-exec` contract and the rest of `check-suid-contract.sh` still pass.

## Tests

New `v2/deploy/test_ambient_cap_runtime.sh` performs the drop **for real** in a container and asserts `CapAmb` bit 12 — driven by flags **extracted from the entrypoint**, so a hardcoded copy cannot keep passing after a regression.

- **Positive control:** entrypoint's own flags -> `CapAmb=0x1000`
- **Negative control:** the buggy form -> `CapAmb=0x0` (proves the positive control is not vacuous)
- **Negative control:** no `--cap-add` -> no ambient raise (self-hosted spokes unaffected)

Wired into `suid-contract.yml` as a **runtime** job. The existing gate was static-only, which is exactly why this shipped.

### Inverted (not relaxed) two tests that ENCODED the bug

Both `check-suid-contract.sh` and `test_entrypoint_netadmin_ambient.sh` required the literal `setpriv --ambient-caps +net_admin` — i.e. they demanded **exactly the broken form** and would have gone RED on the correct fix. Both now require `--inh-caps` as well: a strictly stronger contract.

### Regression replay

Neutered `_SETPRIV_CAPS` back to the buggy form (still parses, `sh -n` OK):

```
-- runtime: POSITIVE control (the ENTRYPOINT'S OWN flags) --
     flags extracted from entrypoint = '--ambient-caps +net_admin'
     CapAmb after entrypoint drop = 0000000000000000
  FAIL: ambient CAP_NET_ADMIN LOST across the privilege drop using the entrypoint's own flags — the #3874 outage condition
  ...
  FAIL: entrypoint does not raise --inh-caps with --ambient-caps (#3874 would recur)

=== Results: 4 passed, 2 failed ===
EXIT=1
```

Restored -> `6 passed, 0 failed`, `EXIT=0`.

## Also closes #3852

`#3852` ("All my agents are crashed") is the same root cause. `claude.exe` is a launcher stub that fetches the real binary on first run; with egress dead (`000` to `api.anthropic.com` and `registry.npmjs.org`) that fetch fails and agents report `claude native binary not installed`. The install is fine — the egress path was not.

Fixes #3852

## Verification

- `go build ./...` clean
- `go test ./pkg/hub/ ./pkg/dashboard/` -> both `ok`
- `check-suid-contract.sh` passes
- `test_entrypoint_netadmin_ambient.sh` -> 17 passed, 0 failed
- `test_ambient_cap_runtime.sh` -> 6 passed, 0 failed
- Rebased on latest `origin/v4`
- No cluster writes; all `kubectl` was read-only. Does not depend on the temporary hub-IP NAT stopgap.