### PR TITLE
🐛 fix(hub): decouple heartbeat liveness from GitHub availability

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3111,6 +3111,20 @@ func main() {
 		// fixed interval comfortably under that 5-min threshold so every hive,
 		// regardless of ACMM level, stays fresh on the hub.
 		const heartbeatSendInterval = 2 * time.Minute
+		// Publish the collect-independent identity BEFORE the loop starts, so
+		// this spoke can report liveness even if its very first collects time
+		// out. collect() below reaches api.github.com (owner-token validation,
+		// and it shares the pass that enumerates issues/PRs for MTTR), which on
+		// a hive with real repos routinely exceeds the collect budget right
+		// after a restart. Without this, such a spoke sent NOTHING and read
+		// OFFLINE on the hub while being perfectly healthy.
+		hub.PublishHeartbeatIdentity(
+			cfg.HiveID,
+			cfg.Project.Org,
+			reporterName,
+			processStartedAt.UTC().Format(time.RFC3339),
+			gitShort,
+		)
 		go hub.StartHeartbeat(ctx, hubURL, func() *hub.HeartbeatPayload {
 			if !cfg.Hub.Enabled {
 				return nil

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -24,6 +24,15 @@ import (
 )
 
 const (
+	// heartbeatTimeout bounds BOTH the collect() budget and the POST to the hub.
+	//
+	// DELIBERATELY NOT RAISED. A longer budget does not decouple liveness from
+	// third-party availability — it only moves the threshold at which a slow or
+	// rate-limited api.github.com starts making healthy spokes look dead, at the
+	// cost of a slower heartbeat loop for everyone. The fix for that coupling is
+	// structural (send an identity-only beat when no stats are available; see
+	// minimalLivenessPayload), so 10s stays: long enough for a healthy collect,
+	// short enough that the loop keeps ticking well inside staleThreshold.
 	heartbeatTimeout = 10 * time.Second
 	staleThreshold   = 15 * time.Minute
 )
@@ -114,6 +123,81 @@ var lastGoodPayload = struct {
 	sync.Mutex
 	payload *HeartbeatPayload
 }{}
+
+// heartbeatIdentity holds the CHEAP, purely-local identity of this spoke — the
+// fields that come straight from config and never require a network call.
+//
+// WHY (the GitHub-dependent-liveness outage): the last-good cache above can
+// only help a spoke that has completed at least one collect. A spoke that has
+// just restarted has no cache, and collect() reaches api.github.com (owner
+// token validation, plus MTTR/actionable-item enumeration feeding the same
+// pass). On a hive with real repos that enumeration exceeds the 10s collect
+// budget on EVERY early cycle, so `cached == nil` skipped every beat and a
+// perfectly healthy spoke read OFFLINE until it happened to get one fast
+// collect. Observed exactly this: placeholder hives (nothing to enumerate)
+// recovered instantly while named tenants with real repos stayed offline.
+//
+// Liveness is a property of THIS process, not of GitHub's availability. So we
+// publish identity as soon as it is known (before any collect runs) and use it
+// to send a minimal beat when there is nothing else to send. A third-party API
+// being slow, rate-limited or down must never make the fleet look dead.
+//
+// Guarded by a mutex for the same reason as lastGoodPayload: written once at
+// loop start, read by the sender goroutine on every timed-out beat.
+var heartbeatIdentity = struct {
+	sync.Mutex
+	payload *HeartbeatPayload
+}{}
+
+// publishHeartbeatIdentity records the collect-independent identity of this
+// spoke so a beat can always be addressed to the right hive, even when no
+// collect has ever succeeded. Only non-empty identities are stored.
+func publishHeartbeatIdentity(p *HeartbeatPayload) {
+	if p == nil || p.HiveID == "" {
+		return
+	}
+	c := *p
+	heartbeatIdentity.Lock()
+	heartbeatIdentity.payload = &c
+	heartbeatIdentity.Unlock()
+}
+
+// PublishHeartbeatIdentity registers this spoke's collect-independent identity
+// (hive id, org, reporter, started-at, git hash) so the heartbeat loop can send
+// a liveness beat before — or without ever — completing a stats collect.
+//
+// Call this as soon as config is loaded, BEFORE StartHeartbeat. It is the piece
+// that makes liveness independent of GitHub: without it, a spoke that restarts
+// while GitHub is slow has nothing it can legitimately address to the hub.
+func PublishHeartbeatIdentity(hiveID, org, reporter, startedAt, gitHash string) {
+	publishHeartbeatIdentity(&HeartbeatPayload{
+		HiveID:    hiveID,
+		Org:       org,
+		Reporter:  reporter,
+		StartedAt: startedAt,
+		GitHash:   gitHash,
+	})
+}
+
+// minimalLivenessPayload builds a beat that asserts ONLY "this spoke process is
+// alive and its loop is ticking", with no collected stats at all.
+//
+// It is marked StatsStale so the hub keeps the hive online and advances
+// lastHeartbeat (the documented contract of that field) without treating the
+// absent agent/fleet numbers as freshly-observed zeros. Returns nil when the
+// identity is not yet known, which is the only genuinely unsendable case.
+func minimalLivenessPayload() *HeartbeatPayload {
+	heartbeatIdentity.Lock()
+	id := heartbeatIdentity.payload
+	heartbeatIdentity.Unlock()
+	if id == nil {
+		return nil
+	}
+	c := *id
+	// No stats were collected this cycle. Carry identity only, and say so.
+	c.StatsStale = true
+	return &c
+}
 
 // storeUnixOrZero stores t as unix seconds, or 0 for the zero time so it
 // reads back as "never happened" through the Last* accessors.
@@ -916,10 +1000,28 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	if payload == nil {
 		cached := loadLastGoodPayload()
 		if cached == nil {
-			// No successful collect yet — genuinely nothing to send. Rare: only
-			// the first beats before any collect has ever finished in time.
-			logger.Warn("hub heartbeat collect timed out and no cached payload yet — skipping this beat; loop keeps ticking so liveness stays green")
-			return nil
+			// No successful collect yet. This is NOT a reason to stay silent:
+			// liveness is a property of this process, and collect() depends on
+			// api.github.com (owner-token validation, MTTR/actionable-item
+			// enumeration), which on a hive with real repos routinely exceeds
+			// the collect budget on every early cycle after a restart. Skipping
+			// here made healthy spokes read OFFLINE whenever GitHub was slow or
+			// rate-limited — the fleet looking dead because a third party was.
+			//
+			// Send a minimal identity-only beat instead: no stats, marked
+			// StatsStale, which the hub already treats as "keep this hive
+			// online, don't trust the numbers".
+			minimal := minimalLivenessPayload()
+			if minimal == nil {
+				// Identity genuinely unknown (loop started before config was
+				// published). Nothing can be addressed to a hive yet.
+				logger.Warn("hub heartbeat collect timed out and hive identity not yet known — skipping this beat; loop keeps ticking so liveness stays green")
+				return nil
+			}
+			logger.Warn("hub heartbeat collect timed out with no cached payload — sending MINIMAL liveness beat (identity only, no stats) so the hub keeps this hive online; loop keeps ticking so liveness stays green")
+			payload = minimal
+			payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
+			return postHeartbeatToHub(ctx, hubURL, payload, logger)
 		}
 		// Send the cached stats so the hub keeps the hive online through the
 		// stall. Mark them stale so the hub does not treat the agent/fleet
@@ -931,6 +1033,10 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		// Fresh collect: remember it (a clone, so the in-place filtering below
 		// never mutates the cache) for the next time collect() times out.
 		storeLastGoodPayload(payload)
+		// Keep the collect-independent identity current from the authoritative
+		// source, so a LATER restart-free identity change (e.g. git hash after
+		// an upgrade) is reflected in any minimal beat we may need to send.
+		publishHeartbeatIdentity(payload)
 	}
 	payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	payload.PublicURLSelfCheck = publicURLSelfCheckFor(ctx, payload.DashboardURL, logger)
@@ -952,6 +1058,19 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	}
 	payload.Agents = filteredAgents
 
+	return postHeartbeatToHub(ctx, hubURL, payload, logger)
+}
+
+// postHeartbeat marshals and POSTs a beat to the hub, records success on
+// acceptance, and decodes the hub's response.
+//
+// Named ...ToHub to avoid colliding with the pkg-local test helper postHeartbeat.
+// Extracted from sendHeartbeat so the MINIMAL liveness beat (no cached payload,
+// collect timed out) travels the EXACT same path as a normal beat: same auth
+// header, same timeout, same recordHeartbeatSuccess accounting, same response
+// handling — including hub-instructed upgrades. A separate ad-hoc POST would
+// drift from this one over time and silently lose those behaviours.
+func postHeartbeatToHub(ctx context.Context, hubURL string, payload *HeartbeatPayload, logger *slog.Logger) *HeartbeatResponse {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		logger.Warn("hub heartbeat marshal failed", "error", err)

--- a/v2/pkg/hub/heartbeat_send_on_collect_timeout_test.go
+++ b/v2/pkg/hub/heartbeat_send_on_collect_timeout_test.go
@@ -150,17 +150,35 @@ func TestSendHeartbeat_TimedOutCollectStillAdvancesAttempt(t *testing.T) {
 	}
 }
 
-// TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips proves the one case that
-// still skips: a collect() that times out before ANY collect has ever
-// succeeded has no cached identity to send, so it skips the beat (but the loop
-// still ticks — attempt advanced, no success).
-func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips(t *testing.T) {
+// TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness is the
+// INVERSION of the former TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips.
+//
+// WHY IT WAS INVERTED, NOT RELAXED: that test asserted `posts == 0` — it
+// ENCODED the outage. Skipping the beat is exactly what made healthy spokes
+// read OFFLINE: collect() reaches api.github.com, and on a hive with real repos
+// the issue/PR/MTTR enumeration exceeds the collect budget on every early cycle
+// after a restart, so a just-restarted spoke had no cache, POSTed nothing, and
+// went offline while being perfectly alive. Placeholder hives (nothing to
+// enumerate) recovered instantly, which is the fingerprint of a GitHub-coupled
+// liveness path.
+//
+// The corrected contract: with an identity published, a spoke that has NEVER
+// completed a collect MUST still report liveness — identity only, no stats,
+// marked StatsStale.
+func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness(t *testing.T) {
 	t.Cleanup(ResetHeartbeatStateForTest)
 	ResetHeartbeatStateForTest()
 
+	// Identity is known (published at startup) but NO collect has ever run.
+	PublishHeartbeatIdentity("fresh-hive", "org", "pod-1", "2026-01-01T00:00:00Z", "abc1234")
+
 	var posts atomic.Int32
+	got := make(chan HeartbeatPayload, 8)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		posts.Add(1)
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		got <- p
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -182,15 +200,109 @@ func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips(t *testing.T) {
 		t.Fatal("sendHeartbeat did not return on a first-beat wedged collect — the loop would freeze")
 	}
 
-	if got := posts.Load(); got != 0 {
-		t.Fatalf("first-beat timeout with no cache should POST nothing, got %d POSTs", got)
+	if n := posts.Load(); n != 1 {
+		t.Fatalf("first-beat timeout with no cache POSTed %d beats, want 1 — a healthy spoke that cannot reach GitHub must still report liveness or the hub marks it OFFLINE", n)
+	}
+	p := <-got
+	if p.HiveID != "fresh-hive" {
+		t.Errorf("minimal beat carried hive_id %q, want fresh-hive — the hub could not attribute the beat", p.HiveID)
+	}
+	if !p.StatsStale {
+		t.Error("minimal beat was not marked StatsStale — the hub would treat absent stats as freshly-observed zeros")
 	}
 	att, ok := LastHeartbeatAttempt()
 	if !ok || att.Before(before) {
-		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt even on a skipped first beat", att, ok)
+		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt", att, ok)
+	}
+	// The beat WAS delivered, so success must advance — this is what keeps the
+	// hub's lastHeartbeat moving and the hive online.
+	suc, ok := LastHeartbeatSuccess()
+	if !ok || suc.Before(before) {
+		t.Errorf("LastHeartbeatSuccess() = (%v, %v), want a fresh success — the minimal beat was accepted by the hub", suc, ok)
+	}
+}
+
+// TestSendHeartbeat_NoCacheAndNoIdentityStillSkips is the NEGATIVE control for
+// the test above. The minimal-beat path must not invent a beat out of nothing:
+// with no cache AND no published identity there is no hive the beat could be
+// attributed to, so skipping remains correct. Without this control, the
+// inverted test above could be satisfied by unconditionally POSTing garbage.
+func TestSendHeartbeat_NoCacheAndNoIdentityStillSkips(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest() // clears identity too
+
+	var posts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	done := make(chan struct{})
+	go func() {
+		sendHeartbeat(context.Background(), server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(heartbeatTimeout + 5*time.Second):
+		t.Fatal("sendHeartbeat did not return on a wedged collect — the loop would freeze")
+	}
+
+	if n := posts.Load(); n != 0 {
+		t.Fatalf("with no cache and no identity, sendHeartbeat POSTed %d beats, want 0 — a beat with no hive_id cannot be attributed", n)
 	}
 	if _, ok := LastHeartbeatSuccess(); ok {
-		t.Error("LastHeartbeatSuccess() ok = true, want false: the first beat was skipped, nothing was delivered")
+		t.Error("LastHeartbeatSuccess() ok = true, want false: nothing was delivered")
+	}
+}
+
+// TestSendHeartbeat_CachedPayloadPreferredOverMinimal proves the pre-existing
+// behaviour did NOT regress: when a last-good cache EXISTS, a timed-out beat
+// must still send the cached STATS, not the stats-less minimal beat. The
+// minimal beat is strictly a last resort.
+func TestSendHeartbeat_CachedPayloadPreferredOverMinimal(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	PublishHeartbeatIdentity("hive", "org", "pod-1", "2026-01-01T00:00:00Z", "abc1234")
+
+	got := make(chan HeartbeatPayload, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		got <- p
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	// One good collect with real stats populates the cache.
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{
+			HiveID:      "hive",
+			Org:         "org",
+			PrimaryRepo: "repo",
+			Agents:      []AgentSummary{{Name: "scanner", State: "running"}},
+		}
+	}, nil2Logger())
+	<-got
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	sendHeartbeat(ctx, server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+
+	p := <-got
+	if len(p.Agents) != 1 || p.Agents[0].Name != "scanner" {
+		t.Fatalf("timed-out beat carried Agents=%v, want the CACHED stats (scanner) — the minimal beat must not displace a usable cache", p.Agents)
+	}
+	if !p.StatsStale {
+		t.Error("cached beat was not marked StatsStale")
 	}
 }
 

--- a/v2/pkg/hub/heartbeat_testhooks.go
+++ b/v2/pkg/hub/heartbeat_testhooks.go
@@ -32,4 +32,10 @@ func ResetHeartbeatStateForTest() {
 	lastGoodPayload.Lock()
 	lastGoodPayload.payload = nil
 	lastGoodPayload.Unlock()
+	// The collect-independent identity is process-global too. Clearing it keeps
+	// each test's starting state honest: a test asserting the "no identity yet"
+	// path must not silently inherit an identity published by an earlier test.
+	heartbeatIdentity.Lock()
+	heartbeatIdentity.payload = nil
+	heartbeatIdentity.Unlock()
 }


### PR DESCRIPTION
## The bug

A spoke whose stats collect could not finish within the 10s budget **and** had no cached payload sent **nothing** to the hub — so a perfectly healthy hive read **OFFLINE**.

```
fleet stats collect failed; retrying ... api.github.com
hub heartbeat collect timed out; timeout=10s
hub heartbeat collect timed out and no cached payload yet — skipping this beat
```

`collect()` reaches `api.github.com`: owner-token validation (`github.ValidateToken` on `/data/gh-user-token`), plus the pass feeding MTTR and actionable-item enumeration. On a hive with real repos that enumeration routinely exceeds the budget on every early cycle after a restart, so a just-restarted spoke never populates the last-good cache and skips every beat.

**This is a permanent stall, not slow recovery** — the spoke can never build a cache because it can never complete a collect.

The fingerprint matches exactly: placeholder hives (nothing to enumerate) recovered instantly, while named tenants with real repos (`kellyaa`, `torch-spyre`, `llm-d-*`) stayed offline.

**Liveness is a property of this process, not of GitHub's availability.**

## What changed

- Publish the spoke's **collect-independent identity** (hive id, org, reporter, started-at, git hash — all straight from config, no network) at startup **before** the heartbeat loop runs, and refresh it from each successful collect.
- When collect times out and there is **no cached payload**, send a **minimal liveness beat**: identity only, no stats, marked `StatsStale` — which the hub already treats as "keep this hive online, do not trust the numbers".
- Extracted `postHeartbeatToHub` so the minimal beat travels the **exact same path** as a normal beat (same auth header, timeout, success accounting, and response handling — including hub-instructed upgrades) rather than drifting via an ad-hoc POST.

## Decisions requested in the brief

**Minimal beat on collect failure, or non-blocking collect with out-of-band stats?**
Chose the **minimal beat**. Out-of-band stats is a strictly larger change (a second delivery path plus its own staleness accounting) for the same outcome. The payload already carries `StatsStale` and the hub already honours it, so reusing that contract keeps **one** delivery path and **one** definition of stale.

**Is 10s the right timeout?**
Left at 10s, deliberately, with a comment recording why. Raising it does not decouple liveness from a third party — it only moves the threshold at which slow or rate-limited GitHub makes the fleet look dead, and slows the loop for everyone. As the brief put it, a longer timeout is not a fix.

## Preserved

The existing stale-cache behaviour is untouched and now explicitly regression-tested: when a last-good cache exists, a timed-out beat still sends the **cached stats**, not the stats-less minimal beat. The minimal beat is strictly a last resort.

## Tests

### Inverted (not relaxed) a test that ENCODED the outage

`TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips` asserted `posts == 0` — it encoded the outage as the intended contract and would have gone RED on the correct fix. It is now `TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness`, asserting the corrected contract.

### New controls

- `TestSendHeartbeat_NoCacheAndNoIdentityStillSkips` — **negative control**, so the inversion cannot be satisfied by POSTing unconditionally: with no cache *and* no identity there is no hive to attribute a beat to, so skipping stays correct.
- `TestSendHeartbeat_CachedPayloadPreferredOverMinimal` — proves the already-working cached path cannot silently regress.
- `ResetHeartbeatStateForTest` now clears identity too, so a test asserting the "no identity" path cannot inherit one from another test.

### Regression replay

Neutered the fix (forced `minimal = nil`; still compiles):

```
--- FAIL: TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness (10.00s)
    heartbeat_send_on_collect_timeout_test.go:204: first-beat timeout with no cache POSTed 0 beats, want 1 — a healthy spoke that cannot reach GitHub must still report liveness or the hub marks it OFFLINE
FAIL
FAIL	github.com/kubestellar/hive/v2/pkg/hub	70.840s
```

Note the other heartbeat tests stayed **green** while neutered — the failure is specific to the behaviour being fixed, not a blanket break. Restored -> `ok github.com/kubestellar/hive/v2/pkg/hub`.

## MITM proxy

Untouched. This PR changes no iptables rule and no egress path — it only changes what the spoke reports when its collect cannot finish. It does not reduce what the proxy sees.

## Verification

- `go build ./...` clean
- `go test ./pkg/hub/ ./pkg/dashboard/` -> both `ok` (incl. the known-flaky `TestF9_UnauthenticatedConnectionsCountTowardCap`)
- `gofmt -l` clean on every file touched
- Rebased on latest `origin/v4`
- No cluster writes; all `kubectl` was read-only. Does not depend on the temporary hub-IP NAT stopgap.