### PR TITLE
feat(governor): auto-scale mode thresholds by configured repo count (#3498)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -956,6 +956,11 @@ func main() {
 	// Dashboard login now requests no scope and no user write-token is persisted.
 
 	gov := governor.New(cfg.Governor, cfg.EnabledAgents(), logger)
+	// Repo count feeds the default mode thresholds' auto-scaling (#3498) — set
+	// separately from New's fixed signature so config-reload can re-sync it
+	// alongside UpdateConfig below without every governor.New call site (tests
+	// included) needing a new parameter.
+	gov.SetRepoCount(len(cfg.Project.Repos))
 	sched := scheduler.New(cfg, logger)
 
 	// Wire the GitHub prompt-source resolver so agents may source their kick
@@ -2341,6 +2346,10 @@ func main() {
 		// Re-sync subsystems that cache config values
 		ghClient.SetRepos(cfg.Project.Repos)
 		gov.UpdateConfig(cfg.Governor)
+		// Re-tune auto-scaled mode thresholds (#3498) for the post-reload repo
+		// count — a hive that adds or archives repos gets a re-tuned ladder on
+		// the next reload rather than only at process start.
+		gov.SetRepoCount(len(cfg.Project.Repos))
 
 		// Re-apply live agent definitions (definition_source) on reload so an
 		// operator's edit to a linked repo propagates. Merges only operator-safe

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -621,6 +621,16 @@ type GovernorConfig struct {
 	// so turning this off never removes the operator's ability to answer "which
 	// backend/model produced this PR?".
 	AttributionTrailer *bool `yaml:"attribution_trailer,omitempty"`
+	// AutoScaleThresholds controls whether a mode's DEFAULT threshold (one with
+	// no explicit governor.modes.<mode>.threshold set) is scaled by the
+	// configured repo count (len(project.repos)) instead of used as a flat
+	// absolute number. Default ON: a hive that says nothing gets scaled
+	// defaults. Set `governor.auto_scale_thresholds: false` to keep the flat
+	// historical defaults (surge=20, busy=10, quiet=2) regardless of repo
+	// count. An explicit threshold always wins over both the scaled and the
+	// flat default, so a hive that hand-tunes its thresholds is unaffected
+	// either way. See Governor.thresholdFor in pkg/governor.
+	AutoScaleThresholds *bool `yaml:"auto_scale_thresholds,omitempty"`
 }
 
 // AttributionTrailerEnabled reports whether the visible attribution trailer on
@@ -630,6 +640,13 @@ type GovernorConfig struct {
 // by this.
 func (g *GovernorConfig) AttributionTrailerEnabled() bool {
 	return g.AttributionTrailer == nil || *g.AttributionTrailer
+}
+
+// AutoScaleThresholdsEnabled reports whether DEFAULT (unset) mode thresholds
+// should be scaled by the hive's configured repo count. Default ON — see
+// AutoScaleThresholds's doc comment.
+func (g *GovernorConfig) AutoScaleThresholdsEnabled() bool {
+	return g.AutoScaleThresholds == nil || *g.AutoScaleThresholds
 }
 
 // GatewayConfig is one named, OpenAI-compatible model gateway. A hive may

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -377,6 +377,10 @@ func (s *Server) saveConfig() error {
 	}
 	if s.deps.Governor != nil {
 		s.deps.Governor.UpdateConfig(s.deps.Config.Governor)
+		// Re-tune auto-scaled mode thresholds (#3498) whenever config is saved
+		// from the dashboard — covers the repo list changing via this path, not
+		// just a file-level reload.
+		s.deps.Governor.SetRepoCount(len(s.deps.Config.Project.Repos))
 	}
 	return nil
 }
@@ -3804,7 +3808,10 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		agents = append(agents, name)
 	}
 
-	// Extract thresholds from modes (exclude idle which is always 0)
+	// Extract thresholds from modes (exclude idle which is always 0). These
+	// are the RAW configured values (0 = unset, using the default) — the edit
+	// form's source of truth. See effectiveThresholds below for what the
+	// governor is actually evaluating against right now.
 	thresholds := map[string]int{}
 	for modeName, mode := range cfg.Governor.Modes {
 		if modeName != "idle" {
@@ -3846,13 +3853,26 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		primaryRepo = org + "/" + primaryRepo
 	}
 
+	// effectiveThresholds (#3498) is what the governor is ACTUALLY evaluating
+	// the queue against right now: an explicit threshold above where set,
+	// otherwise the repo-count-scaled (or flat, if opted out) default. Falls
+	// back to the raw configured/default values (repo-count-unaware) when no
+	// live Governor is wired — e.g. in tests that build the dashboard server
+	// standalone.
+	effectiveThresholds := thresholds
+	if s.deps.Governor != nil {
+		effectiveThresholds = s.deps.Governor.EffectiveThresholds()
+	}
+
 	jsonResponse(w, map[string]interface{}{
-		"agents":      agents,
-		"thresholds":  thresholds,
-		"labels":      cfg.Governor.Labels.Exempt,
-		"holdLabels":  github.HoldLabels,
-		"repos":       repos,
-		"primaryRepo": primaryRepo,
+		"agents":              agents,
+		"thresholds":          thresholds,
+		"effectiveThresholds": effectiveThresholds,
+		"autoScaleThresholds": cfg.Governor.AutoScaleThresholdsEnabled(),
+		"labels":              cfg.Governor.Labels.Exempt,
+		"holdLabels":          github.HoldLabels,
+		"repos":               repos,
+		"primaryRepo":         primaryRepo,
 		"budget": map[string]interface{}{
 			"totalTokens": cfg.Governor.Budget.TotalTokens,
 			"periodDays":  cfg.Governor.Budget.PeriodDays,

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -187,6 +187,16 @@ type Governor struct {
 	mu     sync.RWMutex
 	logger *slog.Logger
 
+	// repoCount is the configured project repo count (len(config.Project.Repos)),
+	// set at construction and re-synced on every config reload via
+	// SetRepoCount. thresholdFor uses it to scale a mode's DEFAULT threshold
+	// (see AutoScaleThresholds's doc comment in pkg/config) — it never affects
+	// an explicit governor.modes.<mode>.threshold. Zero until the first
+	// SetRepoCount call, which thresholdFor treats the same as "1 repo" (no
+	// scaling), so a Governor built without it (e.g. most unit tests) keeps
+	// the flat historical defaults.
+	repoCount int
+
 	modeHistory []ModeChange
 	evalHistory []EvalSnapshot
 	kickHistory []KickRecord
@@ -239,6 +249,17 @@ func (g *Governor) UpdateConfig(cfg config.GovernorConfig) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.cfg = cfg
+}
+
+// SetRepoCount updates the repo count thresholdFor scales default mode
+// thresholds by (see AutoScaleThresholds in pkg/config). Callers should invoke
+// it alongside UpdateConfig — at construction and on every config reload —
+// with len(config.Project.Repos), so a hive that adds or archives repos gets
+// re-tuned thresholds without an operator having to hand-edit them.
+func (g *Governor) SetRepoCount(n int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.repoCount = n
 }
 
 func (g *Governor) UpdateAgents(agents map[string]config.AgentConfig) {
@@ -357,6 +378,17 @@ func (g *Governor) thresholdFor(modeName string) int {
 	if mode, ok := g.cfg.Modes[modeName]; ok && mode.Threshold > 0 {
 		return mode.Threshold
 	}
+	base := baseThreshold(modeName)
+	if !g.cfg.AutoScaleThresholdsEnabled() {
+		return base
+	}
+	return scaledThreshold(base, g.repoCount)
+}
+
+// baseThreshold is the flat, pre-scaling default for a mode — the value
+// thresholdFor returned before #3498, and still what it returns for a hive
+// that opts out of auto-scaling (governor.auto_scale_thresholds: false).
+func baseThreshold(modeName string) int {
 	switch modeName {
 	case "surge":
 		return 20
@@ -367,6 +399,37 @@ func (g *Governor) thresholdFor(modeName string) int {
 	default:
 		return 0
 	}
+}
+
+// scaledThreshold scales a mode's base threshold by the hive's configured
+// repo count (#3498). The queue depth a mode ladder gates on scales with how
+// many repos a hive watches — a 39-repo hive naturally carries a queue in the
+// hundreds — so a flat threshold sized for a handful of repos leaves a
+// large-fleet hive stuck in SURGE almost permanently, running the most
+// aggressive (and most expensive) cadences even when its PER-REPO backlog is
+// small.
+//
+// The scaling is linear and floored at the base value: max(base, base *
+// repoCount). repoCount <= 1 (including the zero value a Governor has before
+// its first SetRepoCount call) is a deliberate no-op, not "scale by zero" —
+// base*0 would be a NEGATIVE change (every non-empty queue would surge,
+// exactly the failure mode thresholdFor's zero-threshold guard above already
+// exists to prevent), and base*1 is base, so short-circuiting is only an
+// optimization there, not a correctness requirement.
+//
+// A "surge" queue-depth positive control: at 39 repos, base=20 scales to 780,
+// so the ~210-deep queue observed live in #3498 (which sat in SURGE against
+// the flat default) now clears SURGE and BUSY (both scaled well above it) and
+// lands in QUIET — proportionate to a per-repo backlog of ~5, not the
+// absolute number.
+func scaledThreshold(base, repoCount int) int {
+	if repoCount <= 1 {
+		return base
+	}
+	if scaled := base * repoCount; scaled > base {
+		return scaled
+	}
+	return base
 }
 
 // updateCadences recomputes every agent's effective cadence for the current
@@ -599,6 +662,23 @@ func (g *Governor) RecordKick(agentName string) {
 	now := g.now()
 	g.state.LastKick[agentName] = now
 	g.appendKickHistory(KickRecord{Timestamp: now, Agent: agentName})
+}
+
+// EffectiveThresholds returns the surge/busy/quiet thresholds computeMode is
+// actually evaluating the queue against right now: an explicit
+// governor.modes.<mode>.threshold where set, otherwise the repo-count-scaled
+// (or flat, if opted out) default (#3498). For dashboard display only —
+// computeMode/thresholdFor remain the single source of truth for mode
+// selection; this just exposes their result so a hive with many repos isn't
+// left guessing why a small configured surge=20 is behaving like 780.
+func (g *Governor) EffectiveThresholds() map[string]int {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return map[string]int{
+		"surge": g.thresholdFor("surge"),
+		"busy":  g.thresholdFor("busy"),
+		"quiet": g.thresholdFor("quiet"),
+	}
 }
 
 func (g *Governor) GetState() State {

--- a/v2/pkg/governor/governor_threshold_test.go
+++ b/v2/pkg/governor/governor_threshold_test.go
@@ -33,7 +33,7 @@ func TestThresholdForDefaults(t *testing.T) {
 func TestThresholdForConfigured(t *testing.T) {
 	cfg := config.GovernorConfig{
 		Modes: map[string]config.ModeConfig{
-			"surge": {Threshold: 50},
+			"surge":  {Threshold: 50},
 			"custom": {Threshold: 7},
 		},
 	}
@@ -49,4 +49,175 @@ func TestThresholdForConfigured(t *testing.T) {
 	if got := g.thresholdFor("busy"); got != 10 {
 		t.Errorf("unconfigured busy = %d, want 10", got)
 	}
+}
+
+// --- #3498: auto-scale default thresholds by configured repo count --------
+
+// TestScaledThreshold pins the pure scaling function directly: max(base,
+// base*repoCount), with repoCount<=1 a deliberate no-op.
+func TestScaledThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		base      int
+		repoCount int
+		want      int
+	}{
+		{"zero repo count is a no-op", 20, 0, 20},
+		{"one repo is a no-op", 20, 1, 20},
+		{"three repos scales linearly", 20, 3, 60},
+		{"the #3498 live example: 39 repos", 20, 39, 780},
+		{"busy base at 39 repos", 10, 39, 390},
+		{"quiet base at 39 repos", 2, 39, 78},
+		{"zero base never scales above zero", 0, 39, 0},
+		{"negative repo count floors at base, never goes negative", 20, -5, 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scaledThreshold(tt.base, tt.repoCount); got != tt.want {
+				t.Errorf("scaledThreshold(%d, %d) = %d, want %d", tt.base, tt.repoCount, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestThresholdForAutoScalesByDefault is the end-to-end proof through
+// thresholdFor: a hive that sets nothing but a repo count gets the scaled
+// default, with no config beyond what SetRepoCount (wired at construction and
+// on every reload) already provides.
+func TestThresholdForAutoScalesByDefault(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	tests := []struct {
+		mode     string
+		expected int
+	}{
+		{"surge", 780},
+		{"busy", 390},
+		{"quiet", 78},
+	}
+	for _, tt := range tests {
+		if got := g.thresholdFor(tt.mode); got != tt.expected {
+			t.Errorf("thresholdFor(%q) with repoCount=39 = %d, want %d", tt.mode, got, tt.expected)
+		}
+	}
+}
+
+// TestThresholdForExplicitConfigWinsOverAutoScale is the "no behavior change
+// for hives that hand-tune" guarantee #3498 requires: an explicit threshold
+// must never be overridden by the repo-count scaling, no matter the repo
+// count.
+func TestThresholdForExplicitConfigWinsOverAutoScale(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"surge": {Threshold: 50},
+		},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	if got := g.thresholdFor("surge"); got != 50 {
+		t.Errorf("explicit surge threshold with repoCount=39 = %d, want 50 (explicit config must win)", got)
+	}
+	// The UNCONFIGURED neighbour in the same call still scales — proves the
+	// explicit win is per-mode, not an all-or-nothing switch on the Governor.
+	if got := g.thresholdFor("busy"); got != 390 {
+		t.Errorf("unconfigured busy threshold with repoCount=39 = %d, want 390 (auto-scale still applies)", got)
+	}
+}
+
+// TestThresholdForAutoScaleOptOut covers governor.auto_scale_thresholds:
+// false — the escape hatch for hives that want the flat historical defaults
+// regardless of repo count.
+func TestThresholdForAutoScaleOptOut(t *testing.T) {
+	optOut := false
+	cfg := config.GovernorConfig{AutoScaleThresholds: &optOut}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	tests := []struct {
+		mode     string
+		expected int
+	}{
+		{"surge", 20},
+		{"busy", 10},
+		{"quiet", 2},
+	}
+	for _, tt := range tests {
+		if got := g.thresholdFor(tt.mode); got != tt.expected {
+			t.Errorf("thresholdFor(%q) opted out with repoCount=39 = %d, want flat default %d", tt.mode, got, tt.expected)
+		}
+	}
+}
+
+// TestThresholdForAutoScaleDefaultIsOn asserts AutoScaleThresholds's zero
+// value (nil *bool, i.e. a hive that never mentions the setting) means ON —
+// matching AttributionTrailer's established default-true convention in this
+// same config struct.
+func TestThresholdForAutoScaleDefaultIsOn(t *testing.T) {
+	cfg := config.GovernorConfig{} // AutoScaleThresholds left nil
+	if !cfg.AutoScaleThresholdsEnabled() {
+		t.Error("AutoScaleThresholdsEnabled() = false for a nil AutoScaleThresholds field, want true (default ON)")
+	}
+}
+
+// TestComputeModeUsesAutoScaledThresholds proves the scaling actually reaches
+// mode selection, not just thresholdFor in isolation — the #3498 queue=~210,
+// 39-repo scenario that sat in SURGE against the flat default now lands in
+// QUIET (surge=780, busy=390, quiet=78; 210 clears quiet but not busy).
+func TestComputeModeUsesAutoScaledThresholds(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	if got := g.computeMode(210); got != ModeSurge {
+		t.Fatalf("fixture: computeMode(210) with no repo count set = %s, want %s (flat default surge=20)", got, ModeSurge)
+	}
+
+	g.SetRepoCount(39)
+	if got := g.computeMode(210); got != ModeQuiet {
+		t.Errorf("computeMode(210) with repoCount=39 = %s, want %s — auto-scaling did not reach mode selection", got, ModeQuiet)
+	}
+}
+
+// TestEffectiveThresholds covers the dashboard-facing accessor: it must
+// report the SAME resolved values thresholdFor uses for mode selection, not
+// the raw config.
+func TestEffectiveThresholds(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"surge": {Threshold: 50},
+		},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	got := g.EffectiveThresholds()
+	want := map[string]int{"surge": 50, "busy": 390, "quiet": 78}
+	for mode, wantVal := range want {
+		if got[mode] != wantVal {
+			t.Errorf("EffectiveThresholds()[%q] = %d, want %d", mode, got[mode], wantVal)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("EffectiveThresholds() returned %d entries, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// TestSetRepoCountIsConcurrencySafe exercises SetRepoCount and thresholdFor
+// (via Evaluate, which holds the same mutex) concurrently — SetRepoCount is
+// called from a config-reload goroutine independent of the eval loop, so it
+// must not race with it.
+func TestSetRepoCountIsConcurrencySafe(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			g.SetRepoCount(i)
+		}
+	}()
+	for i := 0; i < 100; i++ {
+		g.Evaluate(i, 0, 0, 0)
+	}
+	<-done
 }


### PR DESCRIPTION
Closes #3498.

## Problem

The governor's mode thresholds gate an absolute queue depth (`surge=20`, `busy=10`, `quiet=2` defaults, or explicit `governor.modes.*.threshold`), but the queue depth a hive carries scales with how many repos it watches. A 39-repo hive naturally sits at a queue in the hundreds and stays in **SURGE** almost permanently — running the most aggressive (and most expensive) cadences — even though its per-repo backlog is small. Every hive with a different repo count has to hand-tune the thresholds, and re-tune whenever repos are added or removed.

## What changed

`v2/pkg/governor/governor.go`:
- `thresholdFor` now scales a mode's **default** threshold (one with no explicit `governor.modes.<mode>.threshold`) by `max(base, base * repoCount)` — pulled out into a pure `scaledThreshold(base, repoCount int) int` helper for direct unit testing.
- An explicit threshold still always wins — checked first, unchanged from before.
- `repoCount` is a new field on `Governor`, set via a new `SetRepoCount(n int)` method rather than by changing `New`/`UpdateConfig`'s signatures. That keeps every existing call site (and the ~30 test files across the repo that construct a `Governor` directly) compiling unchanged; a `Governor` that never gets `SetRepoCount` called on it keeps the flat historical defaults (`repoCount` defaults to 0, which `scaledThreshold` treats as "no scaling," same as 1).
- Added `EffectiveThresholds() map[string]int` — the resolved surge/busy/quiet values `computeMode` is actually evaluating against right now, for dashboard display.

`v2/pkg/config/config.go`:
- `GovernorConfig.AutoScaleThresholds *bool` + `AutoScaleThresholdsEnabled()` accessor — the opt-out (`governor.auto_scale_thresholds: false`), default on, following the exact same `*bool`/accessor pattern already used for `AttributionTrailer`.

Wiring `SetRepoCount` alongside every existing `UpdateConfig` call site, with `len(config.Project.Repos))`:
- `cmd/hive/main.go`: at construction, and in the config-reload path (so adding/archiving repos re-tunes the ladder on the next reload, not just at process start).
- `pkg/dashboard/api.go` `saveConfig()`: the dashboard-save path, which also covers the repo list changing.

`pkg/dashboard/api.go` `handleGovernorConfigGet`:
- Added `effectiveThresholds` and `autoScaleThresholds` as new, additive fields in the existing `GET /api/config/governor` response, alongside the unchanged raw `thresholds` field. This is read-only visibility (no new mutation endpoint) — an operator can now see what the governor is actually evaluating against instead of just the configured absolute number. I didn't wire up frontend display for these; that's a reasonable frontend follow-up but out of scope for what's otherwise a backend defaults fix.

## Why linear scaling, not the sub-linear alternative

The issue offered two options — linear `max(base, base*repos)` or a gentler `base*ceil(sqrt(repos))` — since queue depth doesn't grow strictly linearly with repo count. I went with linear because it's presented first as "a simple, predictable scaling," it's simpler to reason about and test, and the issue doesn't mandate matching the specific manually-tuned values from its own live example (which were explicitly called out as static and expected to drift). Nothing here would make it hard to swap in a sub-linear curve later if linear proves too aggressive in practice — `scaledThreshold` is the single, isolated place that formula lives.

## Tests

New tests in `pkg/governor/governor_threshold_test.go`:
- `TestScaledThreshold` — the pure scaling function, including the #3498 live example (39 repos: 20→780, 10→390, 2→78), zero/negative repo counts, and zero base.
- `TestThresholdForAutoScalesByDefault` — end-to-end through `thresholdFor`.
- `TestThresholdForExplicitConfigWinsOverAutoScale` — explicit config wins per-mode, with an unconfigured neighbour in the same call still scaling.
- `TestThresholdForAutoScaleOptOut` / `TestThresholdForAutoScaleDefaultIsOn` — the opt-out flag and its default.
- `TestComputeModeUsesAutoScaledThresholds` — proves the scaling reaches mode selection: `computeMode(210)` at 39 repos moves from SURGE (flat default) to QUIET (scaled), the exact shift described in the issue.
- `TestEffectiveThresholds` — the dashboard-facing accessor matches what `thresholdFor` actually resolves.
- `TestSetRepoCountIsConcurrencySafe` — `SetRepoCount` runs from a reload path independent of the eval loop; raced against `Evaluate` under `-race`.

All pre-existing `thresholdFor`/`computeMode` tests pass unmodified, confirming the change is backward compatible for any `Governor` that never calls `SetRepoCount`.

```
go build ./...
go vet ./...
go test ./pkg/governor/... -race   # includes the new tests above
go test ./pkg/config/...
go test ./pkg/dashboard/...
go test ./cmd/hive/...
```
all clean; `gofmt -l` clean on every touched file.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/governor/... -race` (full package, no failures)
- [x] `go test ./pkg/config/...`
- [x] `go test ./pkg/dashboard/...`
- [x] `go test ./cmd/hive/...`
- [x] `gofmt -l` on every touched Go file
- [ ] Live verification against a real multi-repo hive (no cluster access from this environment)
