### PR TITLE
fix(snapshot): validate fetched payloads are JSON before baking (fixes blank /snapshot panels)

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -47,7 +47,30 @@ async function fetchJson(endpoint, fallback = '{}') {
     }
     const res = await fetch(`${dashboardUrl}${endpoint}`, { signal: controller.signal, headers });
     clearTimeout(timer);
-    return await res.text();
+    const body = await res.text();
+    // Every payload here is interpolated RAW into the snapshot's inline script
+    // (var _snapAudit = BODY;). A non-JSON body therefore becomes invalid
+    // JavaScript that throws a PARSE-time SyntaxError — which aborts the ENTIRE
+    // <script>, leaving render() and all render functions undefined and every
+    // panel (Governor/Repos/Beads/Agents/Tokens/Cost/ACMM) blank. This is not
+    // hypothetical: a privilege-gated endpoint such as /api/audit answers a 401/
+    // 403 with a plaintext body like "insufficient access", not JSON, so
+    // `var _snapAudit = insufficient access;` broke the whole page. The
+    // try/catch around each baked block cannot save it — a SyntaxError is raised
+    // at parse time, before any try runs. Validate here: only return a body we
+    // have confirmed parses as JSON; on anything else fall back to the safe JSON
+    // literal so the script stays well-formed and the rest of the page renders.
+    try {
+      JSON.parse(body);
+      return body;
+    } catch {
+      if (res.status >= 400 || body.trim() === '') {
+        console.warn(`WARNING: ${endpoint} returned non-JSON (status ${res.status}); using fallback so the snapshot script stays valid.`);
+      } else {
+        console.warn(`WARNING: ${endpoint} returned a non-JSON 2xx body; using fallback so the snapshot script stays valid.`);
+      }
+      return fallback;
+    }
   } catch {
     return fallback;
   }


### PR DESCRIPTION
## Problem

The read-only `/snapshot` page renders **every core data panel blank** — Governor, Repositories, Beads, Agents, Tokens, Cost, ACMM — even though the auth fix (#3856) is in place and the data is available at build time.

## Root cause (verified against the live broken page)

Inspecting the live snapshot at `.../snapshot` via the browser showed **`render` is not defined, `_snapStatus` is not defined, and every render function is undefined** — the entire main `<script>` failed to execute. Extracting that script and syntax-checking it pinpointed the exact defect:

```js
var _snapAudit = insufficient access;
                              ^^^^^^
SyntaxError: Unexpected identifier 'access'
```

`/api/audit` is privilege-gated. For the snapshot builder's token it answers **403 with a plaintext body `insufficient access`**, not JSON. `build-snapshot.mjs` interpolates every fetched payload **raw** into the inline init script (`var _snapAudit = ${auditRaw};`), so a non-JSON body becomes invalid JavaScript. That is a **parse-time SyntaxError**, which aborts the whole `<script>` — so `render()` and all render functions are never defined and `_snapStatus` is never assigned, leaving all panels blank. The `try/catch` around each baked block cannot help, because a SyntaxError is raised before any `try` runs.

This was **not** a `render()` logic bug — with a well-formed `_snapStatus` the existing `render()` populates every panel correctly (confirmed in a jsdom harness).

## Fix

Make `fetchJson` return only a body it has **confirmed parses as JSON**; on any non-JSON response, fall back to the safe JSON literal and log a warning. This protects **every** interpolated payload (status, config, history, audit, inception, nous, knowledge, contributors, leaderboard, …) at the source, so a single misbehaving endpoint can never again break the whole page.

## Verification (end-to-end, with `/api/audit` → 403 `insufficient access`)

| | main script parses | `render` | `_snapStatus.agents` | panels |
|---|---|---|---|---|
| **before** (origin/v4 builder) | ✗ `SyntaxError: Unexpected identifier 'access'` | undefined | 0 | all blank |
| **after** (this PR) | ✓ | function | 10 | Governor 715 / Repos 716 / Agents 8154 / Tokens 240 chars |

After the fix the audit block bakes `var _snapAudit = {"entries":[]}` and the page renders fully.

## Safety

- Change is confined to `dashboard/build-snapshot.mjs` `fetchJson` (build-time fetch only).
- **Neutralization preserved** — no live connections re-enabled (`connect()` no-op, `checkGhAuth`/`checkGHAuth` stubs, stripped init calls all unchanged). The page stays static/read-only.
- No secrets baked. Auth path and banner CSS untouched.
- No backtick/template-literal hazard: the edit is in normal module code, not inside the `initScript` template literal.