### PR TITLE
🐛 fix: guard mode file read in git-credential-hive.sh so an unreadable file cannot kill the helper

### DIFF
--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -68,10 +68,14 @@ fi
 
 # ── Mode-based enforcement: block git push for agents without push capability ──
 
-# Read mode from file first (hot-reloadable), fallback to env var
+# Read mode from file first (hot-reloadable), fallback to env var.
+# -r as well as -f: this script runs under `set -e`, so a mode file that exists
+# but is unreadable by the agent UID (umask-filtered perms, #3882) would kill
+# the helper mid-script and block every push with no credential and no error.
+# Fall back to the env var instead — same guard as gh-wrapper.sh (#3681).
 MODE_FILE="/tmp/.hive-mode-${AGENT}"
-if [ -f "$MODE_FILE" ]; then
-  AGENT_MODE="$(cat "$MODE_FILE")"
+if [ -f "$MODE_FILE" ] && [ -r "$MODE_FILE" ]; then
+  AGENT_MODE="$(cat "$MODE_FILE" 2>/dev/null || true)"
 else
   AGENT_MODE="${HIVE_AGENT_MODE:-}"
 fi


### PR DESCRIPTION
## Summary

- `bin/git-credential-hive.sh` runs under `set -euo pipefail` and read `/tmp/.hive-mode-<agent>` guarded only by `-f`. When the file exists but is unreadable by the agent's UID (umask-filtered perms — #3882), `cat` failed, `set -e` killed the helper mid-script, git received no credential, and with `GIT_TERMINAL_PROMPT=0` every push from every push-capable agent failed. Observed live on a hosted hive at ACMM L5: agents reported the App Git credential as unavailable and could not create hold PRs.
- Guard the read with `-r` in addition to `-f` and tolerate a failing `cat`, falling back to the `HIVE_AGENT_MODE` env var — the exact guard `gh-wrapper.sh` gained in #3681 (`a244990e`), where the same pattern was non-fatal only because that script isn't `set -e`.
- Mode enforcement is unchanged: the same mode value is enforced, just sourced from the session env fallback when the file is unreadable. The writer-side fix (create the file world-readable and self-heal existing pods) is #3882 / #3885.

## Related issues

Fixes #3881

## Testing

- [ ] `cd v2 && go build ./...`
- [ ] `cd v2 && go test ./...`
- [x] Other / not run (explain): shell-only change; `bash -n bin/git-credential-hive.sh` passes. No Go code touched.

## Contributor checklist

- [x] PR targets `v2` unless a maintainer requested another branch.
- [x] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes. (No behavior change beyond the fallback; nothing to update.)
- [x] No secrets, credentials, or local runtime state are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)