### PR TITLE
🐛 fix: guard mode file read with readability check in git-credential-hive.sh

### DIFF
--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -70,7 +70,7 @@ fi
 
 # Read mode from file first (hot-reloadable), fallback to env var
 MODE_FILE="/tmp/.hive-mode-${AGENT}"
-if [ -f "$MODE_FILE" ]; then
+if [ -f "$MODE_FILE" ] && [ -r "$MODE_FILE" ]; then
   AGENT_MODE="$(cat "$MODE_FILE")"
 else
   AGENT_MODE="${HIVE_AGENT_MODE:-}"


### PR DESCRIPTION
## Problem

`bin/git-credential-hive.sh` runs with `set -euo pipefail` and reads the hot-reloadable mode file without checking readability:

```sh
MODE_FILE="/tmp/.hive-mode-${AGENT}"
if [ -f "$MODE_FILE" ]; then
  AGENT_MODE="$(cat "$MODE_FILE")"
```

When the file exists but is not readable by the agent's UID, `cat` fails and `set -e` kills the helper mid-script. Git receives no credential, blocking all agent pushes with `GIT_TERMINAL_PROMPT=0`.

## Solution

Mirror the fix from #3681 (a244990e): check `[-r]` in addition to `[-f]` when reading the mode file, allowing graceful fallback to the `HIVE_AGENT_MODE` env var instead of dying.

```sh
MODE_FILE="/tmp/.hive-mode-${AGENT}"
if [ -f "$MODE_FILE" ] && [ -r "$MODE_FILE" ]; then
  AGENT_MODE="$(cat "$MODE_FILE")"
else
  AGENT_MODE="${HIVE_AGENT_MODE:-}"
fi
```

Mode enforcement is unchanged—the same mode value is enforced, just sourced from the env fallback when the file is unreadable.

Fixes #3881