### PR TITLE
🐛 fix: make /tmp/.hive-mode-* world-readable and self-heal existing pods

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4872,6 +4872,11 @@ func (m *Manager) SyncModeFiles(level int) {
 		modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", name)
 		if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
 			m.logger.Warn("SyncModeFiles: write failed", "file", modeFile, "error", err)
+		} else if err := os.Chmod(modeFile, 0o644); err != nil {
+			// WriteFile's mode is umask-filtered at creation and ignored for an
+			// existing file, but the enforcement readers (gh-wrapper.sh,
+			// git-credential-hive.sh) run as per-agent UIDs and need world-read.
+			m.logger.Warn("SyncModeFiles: chmod failed", "file", modeFile, "error", err)
 		}
 	}
 }
@@ -5093,6 +5098,11 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", agent.Name)
 	if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
 		m.logger.Warn("agentBootstrapEnv: mode file write failed", "file", modeFile, "error", err)
+	} else if err := os.Chmod(modeFile, 0o644); err != nil {
+		// WriteFile's mode is umask-filtered at creation and ignored for an
+		// existing file, but the enforcement readers (gh-wrapper.sh,
+		// git-credential-hive.sh) run as per-agent UIDs and need world-read.
+		m.logger.Warn("agentBootstrapEnv: mode file chmod failed", "file", modeFile, "error", err)
 	}
 	// Plain proxy URL without userinfo — Claude Code's native binary fails
 	// to open a socket when the URL contains username:password@ (FailedToOpenSocket).

--- a/v2/pkg/agent/permissions_modefile_test.go
+++ b/v2/pkg/agent/permissions_modefile_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// modeFileStartMode is the exact production-observed broken mode: a mode file
+// created through a umask-filtered os.WriteFile came out 0600, so the per-agent
+// UIDs that run gh-wrapper.sh / git-credential-hive.sh could not read it and
+// every push was blocked (#3881/#3882).
+const modeFileStartMode os.FileMode = 0o600
+
+// withModeFileGlob points the watcher's mode-file scan at a temp pattern for
+// the duration of the test, restoring the production value afterwards.
+func withModeFileGlob(t *testing.T, glob string) {
+	t.Helper()
+	orig := ModeFileGlob
+	ModeFileGlob = glob
+	t.Cleanup(func() { ModeFileGlob = orig })
+}
+
+// mkModeFile creates a .hive-mode-<agent> file pinned to a given mode
+// (os.WriteFile is umask-filtered, so the mode is re-applied explicitly —
+// which is precisely the production bug this test file exists for).
+func mkModeFile(t *testing.T, dir, agent string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, ".hive-mode-"+agent)
+	if err := os.WriteFile(path, []byte("ISSUES_AND_PRS"), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+	return path
+}
+
+// TestFixModeFilesWidensUnreadableFile is the core fail-before/pass-after: a
+// mode file created 0600 must come back world-readable so the enforcement
+// scripts running as per-agent UIDs can read it.
+func TestFixModeFilesWidensUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	path := mkModeFile(t, dir, "quality", modeFileStartMode)
+	withModeFileGlob(t, filepath.Join(dir, ".hive-mode-*"))
+
+	fixModeFiles(quietLogger())
+
+	got := statMode(t, path)
+	if got&modeFileReadBits != modeFileReadBits {
+		t.Errorf("mode = %v, want a+r (%v) so agent UIDs can read their GitHub mode", got, modeFileReadBits)
+	}
+	if got != modeFileStartMode|modeFileReadBits {
+		t.Errorf("mode = %v, want exactly %v (only read bits added, write bits preserved)", got, modeFileStartMode|modeFileReadBits)
+	}
+}
+
+// TestFixModeFilesLeavesCorrectFileUntouched: an already world-readable 0644
+// file must stay byte-identical so the scan is idempotent.
+func TestFixModeFilesLeavesCorrectFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := mkModeFile(t, dir, "guide", 0o644)
+	withModeFileGlob(t, filepath.Join(dir, ".hive-mode-*"))
+
+	fixModeFiles(quietLogger())
+
+	if got := statMode(t, path); got != 0o644 {
+		t.Errorf("mode = %v, want 0644 unchanged", got)
+	}
+}
+
+// TestFixModeFilesSkipsSymlink: /tmp is sticky and world-writable, so an agent
+// can plant a symlink matching the glob; os.Chmod follows symlinks (CWE-59),
+// so the scan must never act on one. The link target must keep its mode.
+func TestFixModeFilesSkipsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "victim")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", target, err)
+	}
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatalf("chmod %s: %v", target, err)
+	}
+	link := filepath.Join(dir, ".hive-mode-evil")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	withModeFileGlob(t, filepath.Join(dir, ".hive-mode-*"))
+
+	fixModeFiles(quietLogger())
+
+	if got := statMode(t, target); got != 0o600 {
+		t.Errorf("symlink target mode = %v, want 0600 untouched (watcher must not follow planted links)", got)
+	}
+}

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -38,6 +38,24 @@ const (
 	bobStateDirGroupRWX os.FileMode = 0o070
 )
 
+// ModeFileGlob matches the per-agent GitHub-mode files the Manager writes
+// (/tmp/.hive-mode-<agent>) and the enforcement layer reads: gh-wrapper.sh,
+// git-credential-hive.sh, and the MITM proxy. The Manager writes them as the
+// hive uid but the shell readers run as per-agent UIDs, so the files must be
+// world-readable; a restrictive umask at write time leaves them 0600, which
+// blocks every push (an unreadable mode file killed git-credential-hive.sh
+// under set -e — #3881/#3882). The watcher re-widens them each tick so a
+// running pod self-heals without operator intervention.
+//
+// A var (not const) so tests can point the scan at a writable temp pattern,
+// matching WatchedHomeDirs/SharedRepoParent. Production value is unchanged.
+var ModeFileGlob = "/tmp/.hive-mode-*"
+
+// modeFileReadBits is `a+r` — the read access every mode-file consumer needs.
+// ORed into the existing perms, never narrowing owner bits, so an
+// already-correct 0644 file is left byte-identical and the scan idempotent.
+const modeFileReadBits os.FileMode = 0o444
+
 // bobStateDirBase is the directory name bob uses for both its shared-HOME state
 // (/data/home/.bob) and its per-agent workdir state (/data/agents/<name>/.bob).
 // The watcher recognizes an entry as a bob state dir by this basename so it can
@@ -200,6 +218,8 @@ func fixPermissions(logger *slog.Logger) {
 	// write/commit/push and therefore open PRs. fixEntry already brings each
 	// dir to >=0770 and each file to >=0660 for the node group (and skips
 	// symlinks), which is exactly what the clone (created 0755 dev:node) needs.
+	fixModeFiles(logger)
+
 	roots := append([]string{}, WatchedHomeDirs...)
 	roots = append(roots, sharedRepoClones()...)
 	for _, root := range roots {
@@ -228,6 +248,52 @@ func fixPermissions(logger *slog.Logger) {
 				"error", err,
 			)
 		}
+	}
+}
+
+// fixModeFiles re-widens the per-agent mode files (ModeFileGlob) to be
+// world-readable. This is the running-pod remediation for #3882: the Manager's
+// WriteFile mode is umask-filtered at creation and ignored for existing files,
+// so a pod whose mode files came out 0600 stays broken across restarts;
+// this scan repairs them within one tick.
+//
+// SECURITY: /tmp is sticky and world-writable, so an agent can pre-create a
+// name matching the glob. Only regular, non-symlink files owned by the hive
+// uid are touched (os.Chmod follows symlinks — CWE-59, same guard as
+// fixEntry), and the only change ever made is adding read bits.
+func fixModeFiles(logger *slog.Logger) {
+	paths, err := filepath.Glob(ModeFileGlob)
+	if err != nil {
+		return
+	}
+	for _, path := range paths {
+		fi, err := os.Lstat(path)
+		if err != nil || fi.Mode()&os.ModeSymlink != 0 || !fi.Mode().IsRegular() {
+			continue
+		}
+		stat, ok := fi.Sys().(*syscall.Stat_t)
+		if !ok || stat.Uid != uint32(os.Getuid()) {
+			continue
+		}
+		perm := fi.Mode().Perm()
+		if perm&modeFileReadBits == modeFileReadBits {
+			continue
+		}
+		newPerm := perm | modeFileReadBits
+		if err := os.Chmod(path, newPerm); err != nil {
+			logger.Warn("permissions watcher: chmod mode file failed; agents cannot read their GitHub mode and pushes will be blocked",
+				"path", path,
+				"old_mode", perm.String(),
+				"want_mode", newPerm.String(),
+				"error", err,
+			)
+			continue
+		}
+		logger.Info("permissions watcher: fixed mode file permissions",
+			"path", path,
+			"old_mode", perm.String(),
+			"new_mode", newPerm.String(),
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The Manager writes the per-agent GitHub-mode files with `os.WriteFile(modeFile, ..., 0o644)` in `SyncModeFiles` and `agentEnvPairs`. That mode is umask-filtered at creation and ignored entirely for an existing file, so under a restrictive umask the files came out 0600 — unreadable by the per-agent UIDs that run the enforcement scripts (`gh-wrapper.sh`, `git-credential-hive.sh`). Combined with the `set -e` helper bug (#3881 / #3883) this blocked every agent push, and a pod restart recreated the files broken the same way. Observed live on a hosted hive at ACMM L5: `cat /tmp/.hive-mode-quality` → `Permission denied` from the agent's shell.
- Writer side: `os.Chmod(modeFile, 0o644)` after each successful write in both call sites, making the perms explicit regardless of umask and repairing existing files on every level change and kick.
- Running-pod self-heal: the permissions watcher now re-widens mode files on its 10-second tick (`fixModeFiles`), so an already-broken running pod repairs itself with no operator intervention — same remediation pattern as the `.bob` state-dir fix. Because `/tmp` is sticky and world-writable, the scan skips symlinks (`os.Chmod` follows them — CWE-59, same guard as `fixEntry`) and any file not owned by the hive uid, and only ever adds read bits.

## Related issues

Fixes #3882

Reader-side companion (guard in `git-credential-hive.sh`): #3883.

## Testing

- [x] `cd v2 && go build ./...`
- [x] `cd v2 && go test ./...` — `./pkg/agent` suite passes, including new `permissions_modefile_test.go`: fail-before/pass-after widening of a 0600 file, idempotence on an already-correct 0644 file, and the planted-symlink skip.
- [ ] Other / not run (explain):

## Contributor checklist

- [x] PR targets `v2` unless a maintainer requested another branch.
- [x] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes. (Behavior change is self-healing perms only; documented in code comments on `ModeFileGlob`/`fixModeFiles`.)
- [x] No secrets, credentials, or local runtime state are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)