### PR TITLE
🐛 fix(proxy,github): stop CLOSE_WAIT socket leak to GitHub through the MITM proxy

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3177,6 +3177,12 @@ func main() {
 				AIAuthor:          cfg.Project.AIAuthor,
 				AIAuthorEffective: cfg.EffectiveAIAuthor(),
 				StartedAt:         processStartedAt.UTC().Format(time.RFC3339),
+				// FD gauge (#3875): a socket leak reached 92,962 FDs and
+				// self-DoSed spokes with nothing surfacing it. Report the count
+				// and its rlimit every beat so the next leak is a climbing
+				// number on the hub, not a manual /proc excavation.
+				OpenFDs:     hub.OpenFDCount(),
+				FDSoftLimit: hub.FDSoftLimit(),
 				// Reporter names THIS process (the pod) so the hub can tell two
 				// instances reporting as one hive apart — the pod name is the
 				// hostname inside the container.

--- a/v2/pkg/github/proxytrust.go
+++ b/v2/pkg/github/proxytrust.go
@@ -69,6 +69,15 @@ type proxyTrustPool struct {
 	caModTime  time.Time
 	caSize     int64
 	lastReload time.Time
+
+	// transport is the process-wide shared HTTP transport for every
+	// JWT/token-mint client, rebuilt only when the RootCAs pool itself is
+	// rebuilt. transportPool records which pool the cached transport carries
+	// so a pool rebuild (CA appearing/rotating) invalidates it. See
+	// sharedTransport for why sharing (rather than a transport per call) is
+	// load-bearing and not merely an optimization (#3875).
+	transport     *http.Transport
+	transportPool *x509.CertPool
 }
 
 // certPool returns a RootCAs pool trusting the system roots plus the proxy CA
@@ -100,7 +109,15 @@ func (t *proxyTrustPool) certPool() *x509.CertPool {
 			// became briefly unreadable; do not downgrade an established trust.
 			return t.pool
 		}
-		return systemOnlyPool()
+		// Cache the system-only fallback so callers see a STABLE pool pointer
+		// while the CA is absent — sharedTransport keys transport reuse on
+		// pool identity, and a fresh clone per call would rebuild the
+		// transport (and drop its keep-alive pool) on every advisory-mode
+		// mint. The stat-succeeds path above still rebuilds the moment the CA
+		// file appears, because caModTime/caSize have never been recorded for
+		// it.
+		t.pool = systemOnlyPool()
+		return t.pool
 	}
 
 	// Rebuild only when the file actually changed since we last loaded it.
@@ -149,19 +166,37 @@ func systemOnlyPool() *x509.CertPool {
 // per call.
 var sharedProxyTrust = &proxyTrustPool{}
 
-// proxyTrustingHTTPClient returns an *http.Client whose TLS RootCAs trust the
-// system roots plus the in-process proxy CA (lazily reloaded from disk). This
-// is the client the App-JWT / installation-token mint calls use so a fresh-PVC
-// boot trusts the proxy CA from the FIRST mint attempt, independent of
-// SSL_CERT_FILE or the entrypoint's launch ordering.
+// sharedTransport returns the process-wide *http.Transport carrying the
+// current (system roots + proxy CA) pool, building a new one only when the
+// pool itself has been rebuilt (the CA appearing on first boot, or rotating).
+// The superseded transport gets CloseIdleConnections so its pooled sockets are
+// reclaimed immediately instead of lingering until the peer or the idle reaper
+// gets around to them.
 //
-// The transport clones http.DefaultTransport (preserving proxy/keep-alive/
-// timeout defaults) and installs the RootCAs pool. crypto/tls has no
-// per-handshake roots hook, so the pool is captured at client construction —
-// but a fresh client is built for each short-lived mint call, so the pool is
-// re-read (subject to certPool's own reload interval) each time, and a CA that
-// appears after process start is trusted on the next mint.
-func proxyTrustingHTTPClient(timeout time.Duration) *http.Client {
+// Sharing ONE transport across mint calls is load-bearing, not an
+// optimization (#3875): the previous shape — a freshly cloned Transport per
+// call — meant every mint/token call dialed a brand-new connection and then
+// orphaned it in a single-use idle pool that no future call could ever reuse
+// and nothing ever explicitly closed. Under a retry loop against a slow
+// GitHub, that manufactured sockets at the exact moment the process could
+// least afford them. With a shared transport, keep-alive reuse actually
+// happens, and Go's idle-pool accounting (IdleConnTimeout, per-host caps,
+// inherited from http.DefaultTransport) governs one pool instead of one pool
+// per historical call.
+//
+// crypto/tls has no per-handshake roots hook, so the pool is captured at
+// transport construction; certPool()'s own reload interval keeps it fresh, and
+// a CA that appears after process start yields a new pool pointer — which is
+// exactly the signal used here to rebuild the transport for the next mint.
+func (t *proxyTrustPool) sharedTransport() *http.Transport {
+	pool := t.certPool()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.transport != nil && t.transportPool == pool {
+		return t.transport
+	}
+
 	var transport *http.Transport
 	if base, ok := http.DefaultTransport.(*http.Transport); ok {
 		transport = base.Clone()
@@ -173,11 +208,30 @@ func proxyTrustingHTTPClient(timeout time.Duration) *http.Client {
 	} else {
 		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
 	}
-	// certPool returns (system roots + proxy CA), or a system-only pool while
-	// the CA does not yet exist. nil would also mean "system roots", so the
+	// pool is (system roots + proxy CA), or a system-only pool while the CA
+	// does not yet exist. nil also means "system roots" to crypto/tls, so the
 	// direct-HTTPS (advisory mode) path is never broken.
-	transport.TLSClientConfig.RootCAs = sharedProxyTrust.certPool()
-	return &http.Client{Transport: transport, Timeout: timeout}
+	transport.TLSClientConfig.RootCAs = pool
+
+	if old := t.transport; old != nil {
+		old.CloseIdleConnections()
+	}
+	t.transport = transport
+	t.transportPool = pool
+	return transport
+}
+
+// proxyTrustingHTTPClient returns an *http.Client whose TLS RootCAs trust the
+// system roots plus the in-process proxy CA (lazily reloaded from disk). This
+// is the client the App-JWT / installation-token mint calls use so a fresh-PVC
+// boot trusts the proxy CA from the FIRST mint attempt, independent of
+// SSL_CERT_FILE or the entrypoint's launch ordering.
+//
+// The client wrapper is per-call (it only carries the timeout); the transport
+// underneath — the part that owns sockets — is shared and reaped, see
+// sharedTransport.
+func proxyTrustingHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Transport: sharedProxyTrust.sharedTransport(), Timeout: timeout}
 }
 
 // newJWTClient builds a go-github client authenticated with an App JWT whose

--- a/v2/pkg/github/proxytrust_transport_leak_test.go
+++ b/v2/pkg/github/proxytrust_transport_leak_test.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Regressions for the client-side half of issue #3875: every JWT/token-mint
+// call built a freshly cloned http.Transport, dialed a brand-new connection,
+// and then orphaned it in a single-use idle pool nothing ever reused or
+// explicitly closed — one manufactured socket per call, at the exact moment
+// (a slow GitHub, a hot retry loop) the process could least afford them. The
+// fix shares ONE process-wide transport, rebuilt (and its predecessor's idle
+// pool reaped via CloseIdleConnections) only when the RootCAs pool changes.
+
+// TestProxyTrustingHTTPClient_SharesTransport asserts transport identity is
+// stable across mint clients while the CA is unchanged — the property that
+// makes keep-alive reuse possible at all.
+func TestProxyTrustingHTTPClient_SharesTransport(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "proxy-ca.pem")
+	writeTestCA(t, caPath)
+	withProxyCAPath(t, caPath)
+
+	c1 := proxyTrustingHTTPClient(mintClientTimeout)
+	c2 := proxyTrustingHTTPClient(mintClientTimeout)
+	if c1 == c2 {
+		t.Fatal("clients must be per-call wrappers (they carry per-call timeouts)")
+	}
+	if c1.Transport != c2.Transport {
+		t.Fatal("mint clients must share ONE transport — a transport per call orphans a socket per call (#3875)")
+	}
+}
+
+// TestProxyTrustingHTTPClient_RebuildsTransportOnCAChange asserts the shared
+// transport is invalidated when the proxy CA rotates (pool rebuild), so a
+// fresh-PVC boot still picks up the CA written after process start — the
+// guarantee the old per-call construction provided implicitly.
+func TestProxyTrustingHTTPClient_RebuildsTransportOnCAChange(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "proxy-ca.pem")
+	withProxyCAPath(t, caPath)
+
+	before := sharedProxyTrust.sharedTransport() // CA absent: system-only trust
+
+	writeTestCA(t, caPath)
+	sharedProxyTrust.mu.Lock()
+	sharedProxyTrust.lastReload = time.Now().Add(-2 * proxyCAReloadInterval)
+	sharedProxyTrust.mu.Unlock()
+
+	after := sharedProxyTrust.sharedTransport()
+	if before == after {
+		t.Fatal("transport must be rebuilt when the proxy CA appears — otherwise the mint never trusts a CA written after start")
+	}
+	if after.TLSClientConfig == nil || after.TLSClientConfig.RootCAs == nil {
+		t.Fatal("rebuilt transport must carry the (system + proxy CA) RootCAs pool")
+	}
+	// And stay stable once rebuilt.
+	if again := sharedProxyTrust.sharedTransport(); again != after {
+		t.Fatal("transport must be stable while the CA is unchanged")
+	}
+}
+
+// TestProxyTrustingHTTPClient_ReusesConnections is the leak-count regression:
+// N sequential mint-style calls (a fresh client wrapper per call, exactly as
+// newJWTClient/newTokenClient construct them) against one TLS server must
+// ride a small number of underlying connections. Pre-fix this was one NEW
+// connection per call — the per-call socket manufacturing measured live as
+// part of the #3875 FD pile.
+func TestProxyTrustingHTTPClient_ReusesConnections(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "proxy-ca.pem")
+	withProxyCAPath(t, caPath)
+
+	var connsOpened atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	srv.Config.ConnState = func(c net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			connsOpened.Add(1)
+		}
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	// Trust the test server exactly the way production trusts the MITM proxy:
+	// its cert PEM at proxyCAPath (self-signed, so it is its own root).
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	if err := os.WriteFile(caPath, certPEM, 0o644); err != nil {
+		t.Fatalf("write server cert as proxy CA: %v", err)
+	}
+	if _, err := x509.ParseCertificate(srv.Certificate().Raw); err != nil {
+		t.Fatalf("parse server cert: %v", err)
+	}
+
+	const calls = 6
+	for i := 0; i < calls; i++ {
+		client := proxyTrustingHTTPClient(mintClientTimeout) // fresh wrapper per call, like every mint
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	// Keep-alive reuse must hold: allow a little slack for a mid-run
+	// CA-pool/transport settle, but nothing close to one conn per call.
+	const maxConns = 2
+	if got := connsOpened.Load(); got > maxConns {
+		t.Fatalf("%d calls opened %d connections (want <= %d) — per-call transports are manufacturing sockets again (#3875)", calls, got, maxConns)
+	}
+}

--- a/v2/pkg/hub/fd_gauge.go
+++ b/v2/pkg/hub/fd_gauge.go
@@ -1,0 +1,36 @@
+package hub
+
+import "os"
+
+// fdDirs are the per-process file-descriptor listings tried in order:
+// /proc/self/fd on Linux (the production container target), /dev/fd as the
+// BSD/macOS dev-machine fallback.
+var fdDirs = []string{"/proc/self/fd", "/dev/fd"}
+
+// OpenFDCount returns the number of file descriptors this process currently
+// holds, or 0 when it cannot be determined. It exists for the heartbeat FD
+// gauge (see HeartbeatPayload.OpenFDs, #3875): a leak that self-DoSed spokes
+// at 92k FDs was invisible until someone hand-inspected /proc. A directory
+// read costs microseconds at healthy FD counts and is paid once per beat.
+//
+// Callers must treat 0 as UNKNOWN, not as "no descriptors": a live process
+// always holds at least the directory handle used for the read itself.
+//
+// Readdirnames, not os.ReadDir: ReadDir lstats entries whose type the
+// filesystem does not report, and on /dev/fd that stats the listing's own
+// (already-consumed) descriptor — "bad file descriptor" instead of a count.
+// Names alone are all a count needs.
+func OpenFDCount() int {
+	for _, dir := range fdDirs {
+		f, err := os.Open(dir)
+		if err != nil {
+			continue
+		}
+		names, err := f.Readdirnames(-1)
+		f.Close()
+		if err == nil {
+			return len(names)
+		}
+	}
+	return 0
+}

--- a/v2/pkg/hub/fd_gauge_other.go
+++ b/v2/pkg/hub/fd_gauge_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package hub
+
+// FDSoftLimit has no meaningful value off unix (dev/Windows builds); return 0,
+// which readers already treat as UNKNOWN. The production target is Linux.
+func FDSoftLimit() uint64 { return 0 }

--- a/v2/pkg/hub/fd_gauge_test.go
+++ b/v2/pkg/hub/fd_gauge_test.go
@@ -1,0 +1,44 @@
+package hub
+
+import (
+	"os"
+	"testing"
+)
+
+// TestOpenFDCountReportsLiveDescriptors pins the gauge to reality: it must
+// report a positive count on the platforms we build on (Linux containers in
+// production, macOS dev machines), and the count must move when descriptors
+// are opened. A gauge that silently reads 0 would report UNKNOWN forever and
+// reintroduce exactly the blindness #3875 showed (92,962 leaked FDs found
+// only by manual /proc inspection).
+func TestOpenFDCountReportsLiveDescriptors(t *testing.T) {
+	base := OpenFDCount()
+	if base <= 0 {
+		t.Fatalf("OpenFDCount() = %d, want > 0 — a live process always holds descriptors", base)
+	}
+
+	const extra = 8
+	files := make([]*os.File, 0, extra)
+	for i := 0; i < extra; i++ {
+		f, err := os.Open(os.DevNull)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		files = append(files, f)
+	}
+	grown := OpenFDCount()
+	for _, f := range files {
+		f.Close()
+	}
+	if grown < base+extra {
+		t.Fatalf("OpenFDCount() = %d after opening %d more (baseline %d) — gauge does not track real descriptors", grown, extra, base)
+	}
+}
+
+// TestFDSoftLimitPositiveOnUnix: the rlimit companion must be readable where
+// the daemon actually runs.
+func TestFDSoftLimitPositiveOnUnix(t *testing.T) {
+	if got := FDSoftLimit(); got == 0 {
+		t.Fatalf("FDSoftLimit() = 0 on a unix build — the ulimit-relative gauge would read UNKNOWN")
+	}
+}

--- a/v2/pkg/hub/fd_gauge_unix.go
+++ b/v2/pkg/hub/fd_gauge_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package hub
+
+import "syscall"
+
+// FDSoftLimit returns the RLIMIT_NOFILE soft limit for this process, or 0 when
+// it cannot be read. Reported alongside OpenFDCount in the heartbeat so the
+// gauge is ulimit-relative — 20k open FDs is an emergency under a 65k limit
+// and routine under 1M (#3875).
+func FDSoftLimit() uint64 {
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
+		return 0
+	}
+	return uint64(rl.Cur)
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -475,6 +475,16 @@ type HeartbeatPayload struct {
 	// but restarted 35 times — is visible in My Hives instead of looking
 	// healthy. A short uptime that keeps resetting is the tell.
 	StartedAt string `json:"started_at,omitempty"`
+	// OpenFDs is the spoke process's open file-descriptor count at beat time,
+	// with FDSoftLimit the RLIMIT_NOFILE soft cap it is burning toward. They
+	// exist because #3875's leak — tens of thousands of CLOSE_WAIT sockets to
+	// GitHub — reached 92,962 FDs and total self-DoS with NOTHING surfacing
+	// it; it took a manual /proc inspection to find. A gauge in the beat makes
+	// the next FD leak a visible climbing number instead of an outage
+	// forensics exercise. Zero means "could not be read / old spoke" and must
+	// be treated as UNKNOWN, never as "no descriptors open".
+	OpenFDs     int    `json:"open_fds,omitempty"`
+	FDSoftLimit uint64 `json:"fd_soft_limit,omitempty"`
 	// Reporter identifies the spoke PROCESS that sent this beat as
 	// "<pod-name>/<pid>" (hostname/PID; older spokes send the bare hostname).
 	// It exists because two spoke instances can report as the same hive_id —

--- a/v2/pkg/proxy/close_wait_leak_test.go
+++ b/v2/pkg/proxy/close_wait_leak_test.go
@@ -1,0 +1,222 @@
+package proxy
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regressions for issue #3875: the hive process leaked CLOSE_WAIT sockets to
+// GitHub through its own MITM proxy until FD exhaustion (92,962 FDs measured
+// live) self-DoSed the pod. #3872 bounded relayTunnel's half-close drains, but
+// two proxyHTTP paths kept the pre-#3872 shape:
+//
+//  1. the git smart-HTTP branch ran its OWN unbounded io.Copy pair, so an
+//     upstream FIN with a half-open client parked the handler at <-done
+//     forever — the deferred conn Closes never ran and the FIN'd upstream
+//     socket sat in CLOSE_WAIT for the life of the process;
+//  2. the API branch cleared the upstream read deadline once response HEADERS
+//     arrived, so a "reachable but slow" GitHub (TLS + headers OK, body never
+//     comes — the measured live signature) parked resp.Write in an unbounded
+//     upstream.Read holding all three sockets of the exchange, one fresh
+//     parked handler per retry (~1k FDs/min measured on a live spoke).
+//
+// The leak invariant in both: proxyHTTP MUST RETURN once the exchange can no
+// longer make progress, because the sockets are closed by the CALLERS'
+// deferred Closes — a handler that never returns is a socket that never
+// closes.
+
+func leakTestProxy() *GitHubProxy {
+	return &GitHubProxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func shortenBodyStall(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := responseBodyStallTimeout
+	responseBodyStallTimeout = d
+	t.Cleanup(func() { responseBodyStallTimeout = old })
+}
+
+func runProxyHTTP(p *GitHubProxy, client, upstream net.Conn) chan struct{} {
+	returned := make(chan struct{})
+	go func() {
+		p.proxyHTTP(client, upstream, internalCallerName, 0)
+		close(returned)
+	}()
+	return returned
+}
+
+// TestProxyHTTPGitRelayReleasesAfterUpstreamFIN is the regression for leak
+// (1): upstream sends the git response and FINs; the client keeps its side
+// half-open (keep-alive). Pre-fix the inline copy pair blocked in
+// client.Read() forever and <-done never returned; the FIN'd upstream fd was
+// CLOSE_WAIT until process death. Post-fix the git branch goes through
+// relayTunnel, whose half-close drain releases the handler.
+func TestProxyHTTPGitRelayReleasesAfterUpstreamFIN(t *testing.T) {
+	shortenTunnelDrain(t, 300*time.Millisecond)
+	p := leakTestProxy()
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runProxyHTTP(p, proxyClientSide, proxyUpstreamSide)
+
+	req := "GET /kubestellar/hive.git/info/refs?service=git-upload-pack HTTP/1.1\r\nHost: github.com\r\n\r\n"
+	if _, err := agentSide.Write([]byte(req)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4096)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := forgeSide.Read(buf); err != nil {
+		t.Fatalf("upstream did not receive relayed git request: %v", err)
+	}
+	const gitResp = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+	if _, err := forgeSide.Write([]byte(gitResp)); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+	forgeSide.Close() // remote FIN — our side must eventually close too
+
+	// Positive control: the response reached the client through the relay.
+	respBuf := make([]byte, len(gitResp))
+	agentSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(agentSide, respBuf); err != nil {
+		t.Fatalf("client did not receive relayed git response: %v", err)
+	}
+	// The client deliberately does NOT close: half-open keep-alive is the
+	// leak-triggering state.
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxyHTTP wedged after upstream FIN with a half-open client — the CLOSE_WAIT leak (#3875)")
+	}
+}
+
+// TestProxyHTTPBodyStallReleasesHandler is the regression for leak (2):
+// headers arrive promptly, the body never does, and the client gives up and
+// closes (the 10s collect budget firing). Pre-fix resp.Write sat in an
+// unbounded upstream.Read forever. Post-fix the rolling stall bound errors the
+// relay out and proxyHTTP returns.
+func TestProxyHTTPBodyStallReleasesHandler(t *testing.T) {
+	shortenBodyStall(t, 300*time.Millisecond)
+	p := leakTestProxy()
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runProxyHTTP(p, proxyClientSide, proxyUpstreamSide)
+
+	req := "GET /app/installations/1/access_tokens HTTP/1.1\r\nHost: api.github.com\r\n\r\n"
+	if _, err := agentSide.Write([]byte(req)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4096)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := forgeSide.Read(buf); err != nil {
+		t.Fatalf("upstream did not receive relayed request: %v", err)
+	}
+	// Headers promptly; the 1000-byte body NEVER — GitHub's measured
+	// "reachable but slow" signature (TLS in 0.03–2.2s, 0 body bytes in 12s).
+	if _, err := forgeSide.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\n")); err != nil {
+		t.Fatalf("upstream header write: %v", err)
+	}
+	// The minting client's context deadline fires; it hangs up.
+	time.Sleep(100 * time.Millisecond)
+	agentSide.Close()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxyHTTP wedged on a stalled response body — the parked-handler FD leak (#3875)")
+	}
+}
+
+// TestProxyHTTPBodyRelayToleratesSlowButFlowingBody is the positive control
+// against over-fixing: the stall bound must be a rolling PER-READ bound, not a
+// cap on total transfer time. A body that keeps trickling — each gap well
+// under the stall bound, total time well over it — must arrive intact.
+func TestProxyHTTPBodyRelayToleratesSlowButFlowingBody(t *testing.T) {
+	shortenBodyStall(t, 500*time.Millisecond)
+	p := leakTestProxy()
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runProxyHTTP(p, proxyClientSide, proxyUpstreamSide)
+
+	req := "GET /repos/kubestellar/hive/issues HTTP/1.1\r\nHost: api.github.com\r\n\r\n"
+	if _, err := agentSide.Write([]byte(req)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4096)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := forgeSide.Read(buf); err != nil {
+		t.Fatalf("upstream did not receive relayed request: %v", err)
+	}
+	const chunks = 6
+	body := strings.Repeat("x", chunks)
+	if _, err := forgeSide.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\n")); err != nil {
+		t.Fatalf("upstream header write: %v", err)
+	}
+	// 6 bytes over ~900ms: every inter-byte gap (150ms) is far inside the
+	// 500ms stall bound, but the TOTAL exceeds it. An absolute deadline would
+	// cut this transfer; the rolling bound must not.
+	for i := 0; i < chunks; i++ {
+		time.Sleep(150 * time.Millisecond)
+		if _, err := forgeSide.Write([]byte{body[i]}); err != nil {
+			t.Fatalf("upstream body write %d: %v", i, err)
+		}
+	}
+
+	respBuf := make([]byte, 512)
+	agentSide.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := ""
+	for !strings.HasSuffix(got, body) {
+		n, err := agentSide.Read(respBuf)
+		if err != nil {
+			t.Fatalf("client read: %v (got so far: %q)", err, got)
+		}
+		got += string(respBuf[:n])
+	}
+
+	agentSide.Close()
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxyHTTP did not return after the client closed")
+	}
+}
+
+// TestProxyHTTPHasNoInlineCopyPairs asserts the source-level invariant behind
+// leak (1): every opaque byte-shuttling path in github_proxy.go must go
+// through relayTunnel (whose half-close drains are the #3872 guarantee), never
+// a hand-rolled io.Copy pair. The pre-fix git branch was exactly such a pair
+// that #3872 missed. relayTunnel's own two copies are the only sanctioned
+// ones.
+func TestProxyHTTPHasNoInlineCopyPairs(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "github_proxy.go"))
+	if err != nil {
+		t.Fatalf("read github_proxy.go: %v", err)
+	}
+	text := string(body)
+	const wantRelayTunnelCalls = 3 // transparent passthrough, CONNECT tunnelDirect, git branch
+	if got := strings.Count(text, "relayTunnel(") - strings.Count(text, "func relayTunnel("); got != wantRelayTunnelCalls {
+		t.Fatalf("relayTunnel call sites = %d, want %d — opaque relays must use relayTunnel, not inline io.Copy pairs", got, wantRelayTunnelCalls)
+	}
+	// relayTunnel's own two directional copies are the only raw conn-to-conn
+	// io.Copy allowed in this file.
+	if got := strings.Count(text, "io.Copy(upstream, client)"); got != 0 {
+		t.Fatalf("found %d inline io.Copy(upstream, client) — the unbounded copy-pair shape that leaked CLOSE_WAIT sockets (#3875)", got)
+	}
+	// And the API branch must bound its body relay.
+	if !strings.Contains(text, "resp.Body = &stallBoundedBody{") {
+		t.Fatal("proxyHTTP response body relay must be wrapped in stallBoundedBody — an unbounded body read parks the handler and leaks its sockets (#3875)")
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -927,13 +927,16 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			}
 			upstream.SetWriteDeadline(time.Time{})
 			client.SetReadDeadline(time.Time{})
-			done := make(chan struct{})
-			go func() {
-				io.Copy(upstream, client)
-				close(done)
-			}()
-			io.Copy(client, upstream)
-			<-done
+			// Use relayTunnel, NOT an inline copy pair: this branch used to run
+			// its own unbounded io.Copy pair, which was the same wedge #3872
+			// fixed in relayTunnel but left here. When GitHub FIN'd after the
+			// response while the client kept its side open (keep-alive), the
+			// client→upstream copy stayed blocked in client.Read() forever and
+			// `<-done` never returned — the handler's deferred Closes never ran,
+			// parking the upstream socket in CLOSE_WAIT for the life of the
+			// process (issue #3875's FD pile). relayTunnel bounds each direction
+			// once the other finishes.
+			relayTunnel(client, upstream)
 			return
 		}
 
@@ -957,6 +960,20 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			p.logTimeout("proxy upstream response read timed out", err, "agent", agentName, "path", req.URL.Path)
 			return
 		}
+
+		// Bound the BODY relay too, not just the header read above. The
+		// deadline was cleared once headers arrived, so a "reachable but slow"
+		// GitHub — TLS and headers complete, body never arrives (the measured
+		// #3875 signature: time_total=12s, 0 body bytes) — parked resp.Write
+		// in upstream.Read() with no deadline. The client had long since given
+		// up (10s collect budget) and FIN'd its side, but this goroutine never
+		// noticed: it holds all three sockets of the exchange forever, and the
+		// retry loop stacks a fresh parked handler on every attempt (~1k
+		// FDs/min measured live). The wrapper re-arms a rolling per-Read
+		// deadline, so a body that keeps flowing is never cut while a stall
+		// longer than responseBodyStallTimeout errors out and lets the
+		// handler's deferred Closes reclaim the sockets.
+		resp.Body = &stallBoundedBody{body: resp.Body, conn: upstream, idle: responseBodyStallTimeout}
 
 		client.SetWriteDeadline(time.Now().Add(httpWriteTimeout))
 		if err := resp.Write(client); err != nil {
@@ -1059,6 +1076,44 @@ func (p *GitHubProxy) tunnelDirect(conn net.Conn, r *http.Request) {
 	fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n")
 
 	relayTunnel(conn, upstream)
+}
+
+// responseBodyStallTimeout bounds how long the MITM'd response-BODY relay may
+// go without a single byte of progress from the upstream. It is a rolling
+// per-Read bound (re-armed on every read by stallBoundedBody), not a cap on
+// total transfer time, so a large-but-flowing response is never cut while an
+// upstream that goes silent mid-body releases the handler — and with it the
+// three sockets of the exchange — within one stall window. A var, not a
+// const, so tests can shorten it (same pattern as tunnelHalfCloseDrain).
+// Matches httpReadTimeout: the same patience already extended to the header
+// phase.
+var responseBodyStallTimeout = httpReadTimeout
+
+// stallBoundedBody wraps a proxied response body so every underlying Read is
+// preceded by re-arming a read deadline on the upstream conn. Close clears the
+// deadline (for the next keep-alive exchange on the same conn) and closes the
+// wrapped body. See responseBodyStallTimeout for why this exists (#3875).
+type stallBoundedBody struct {
+	body io.ReadCloser
+	conn net.Conn
+	idle time.Duration
+}
+
+func (b *stallBoundedBody) Read(p []byte) (int, error) {
+	b.conn.SetReadDeadline(time.Now().Add(b.idle))
+	return b.body.Read(p)
+}
+
+func (b *stallBoundedBody) Close() error {
+	// Close the wrapped body while a stall deadline is armed: net/http body
+	// Close paths may still read from the conn (drain-to-EOF), and an unarmed
+	// read there would reintroduce the very stall this type exists to bound.
+	// The deadline is cleared afterwards so the next keep-alive exchange on
+	// this conn starts unencumbered.
+	b.conn.SetReadDeadline(time.Now().Add(b.idle))
+	err := b.body.Close()
+	b.conn.SetReadDeadline(time.Time{})
+	return err
 }
 
 // tunnelHalfCloseDrain bounds how long one direction of an opaque tunnel may


### PR DESCRIPTION
Fixes #3875

## The variant #3872 did not cover

#3872 bounded `relayTunnel`'s half-close drains — the *parked-read* variant, where an upstream that never sends a byte wedged an opaque tunnel. The CLOSE_WAIT pile that kept growing on the fixed build (fresh pod on `ca6aa8a`: 19,466 FDs in ~20 min, ~1k/min) is a different shape: **our read got the FIN, but the fd's owner never returned, so the deferred `Close`s never ran**. Three sites, all with the same signature:

### 1. `proxyHTTP` git branch ran its own unbounded copy pair (`v2/pkg/proxy/github_proxy.go`)
The git smart-HTTP branch had a hand-rolled `io.Copy` pair — the exact pre-#3872 shape, missed because #3872 only fixed `relayTunnel`. When GitHub FIN'd after the response while the client kept its side half-open (keep-alive), `io.Copy(upstream, client)` stayed blocked in `client.Read()` forever, `<-done` never returned, and the FIN'd upstream socket sat in **CLOSE_WAIT for the life of the process**. Reproduced deterministically. Fix: route the branch through `relayTunnel`.

### 2. `proxyHTTP` response-body relay had no deadline (`v2/pkg/proxy/github_proxy.go`)
The upstream read deadline was cleared once response *headers* arrived; `resp.Write(client)` then streamed the body with **no deadline at all**. "Reachable but slow" GitHub — TLS + headers OK, body never arrives (the exact live signature: `time_total=12s, 0 bytes`) — parked the handler in an unbounded `upstream.Read()` holding all three sockets of the exchange. The minting client gave up at its 10s budget and FIN'd, but the parked handler never noticed; the retry loop stacked one fresh parked handler per attempt. Fix: `stallBoundedBody`, a rolling per-Read stall bound (`responseBodyStallTimeout`, 30s like the header phase) — a body that keeps flowing is never cut; a stall releases the handler so its deferred `Close`s reclaim the sockets. The close path keeps a deadline armed too, since body `Close` can itself read (drain-to-EOF).

### 3. A fresh `http.Transport` per mint call (`v2/pkg/github/proxytrust.go`)
`proxyTrustingHTTPClient` cloned `http.DefaultTransport` on **every** JWT/token call; there was not a single `CloseIdleConnections` in the tree. Every call dialed a new connection and orphaned it in a single-use idle pool nothing could ever reuse — one manufactured socket per call, at the exact moment (slow GitHub + hot retry loop) the process could least afford it. Fix: one shared process-wide transport, rebuilt only when the RootCAs pool changes (CA appearing on fresh-PVC boot / rotating), with the superseded transport's idle pool reaped via `CloseIdleConnections`. Keep-alive reuse now actually happens: 6 sequential mint-style calls ride 1 connection (was 6).

### Belt and braces: FD gauge in the heartbeat
92,962 FDs accumulated with *nothing* surfacing it. The beat now carries `open_fds` + `fd_soft_limit` (`hub.OpenFDCount` / `hub.FDSoftLimit`, `/proc/self/fd` + `RLIMIT_NOFILE`), so the next leak is a climbing number on the hub, not an outage forensics exercise. Zero = UNKNOWN.

## Repro / verification
Local repro (15 stalled-body + 15 git-FIN exchanges through `proxyHTTP`, then settle):
- **pre-fix**: handlers never return — leaked sockets held until process death (delta includes every wedged exchange, grows without bound at retry rate)
- **post-fix**: every handler releases within the stall/drain bounds; only the deliberately held test-side conns remain

## Tests
- `TestProxyHTTPGitRelayReleasesAfterUpstreamFIN` — regression for (1), fails on pre-fix code by wedging
- `TestProxyHTTPBodyStallReleasesHandler` — regression for (2), fails on pre-fix code by wedging
- `TestProxyHTTPBodyRelayToleratesSlowButFlowingBody` — positive control: rolling bound, not an absolute cap
- `TestProxyHTTPHasNoInlineCopyPairs` — source invariant: opaque relays must use `relayTunnel`; body relay must be stall-bounded
- `TestProxyTrustingHTTPClient_SharesTransport` / `_RebuildsTransportOnCAChange` / `_ReusesConnections` — leak-count regression for (3): 6 calls ≤ 2 conns (was 6), CA rotation still picked up
- `TestOpenFDCountReportsLiveDescriptors` / `TestFDSoftLimitPositiveOnUnix` — gauge reads reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)
