### PR TITLE
fix(agents): stop instructing native-install agents to cat the shared App token (N14, #3842)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -73,6 +73,18 @@ jobs:
         working-directory: .
         run: bash bin/test_gh_wrapper_gates.sh
 
+      # N14 (#3842): kick-agents.sh (the native/systemd-install path — no Go
+      # AgentManager, no per-agent scoped token) used to instruct every kicked
+      # agent to `cat` the shared, fleet-wide, full-privilege App token cache
+      # and prefix gh calls with it — putting a live credential into
+      # agent-controlled text, one prompt injection from exfiltration. Source-
+      # asserts the instruction is gone and agent-launch.sh authenticates gh's
+      # own credential store instead, so a future edit can't reintroduce it
+      # quietly.
+      - name: gh-auth native-install guard (#3842)
+        working-directory: .
+        run: bash bin/test_gh_auth_native_no_cat.sh
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'

--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -38,6 +38,44 @@ if [[ -f "$HIVE_CONFIG" ]]; then
 elif [[ -f /usr/local/bin/hive-config.sh ]]; then
   source /usr/local/bin/hive-config.sh
 fi
+
+# N14 (#3842) follow-up: a native/systemd install (kick-agents.sh, no Go
+# AgentManager) never sets HIVE_AGENT_TOKEN_CACHE — that per-agent scoped
+# cache is minted only by the container-hosted model (v2/pkg/agent/manager.go).
+# Without it, neither of this codebase's two SAFE gh-auth mechanisms apply:
+# gh-wrapper.sh isn't installed as `gh` for native installs (install.sh ships
+# it under its own name), and git-credential-hive.sh refuses without a
+# per-agent cache by design (audit H3). The only way a native agent could
+# authenticate `gh` at all was kick-agents.sh's prompt instruction to `cat`
+# the shared cache and prefix every gh call with it — putting the raw,
+# fleet-wide, full-privilege token into the AGENT'S OWN reasoning/output,
+# one prompt injection away from exfiltration (the exact anti-pattern H3
+# removed from the wrapper, just reintroduced at the prompt-text layer).
+#
+# Fix: authenticate `gh`'s OWN persistent credential store here, ONCE, from a
+# value this launcher script reads directly — never typed by the agent. `gh
+# auth login --with-token` writes to ~/.config/gh/hosts.yml; every later `gh`
+# call the agent runs authenticates from that stored config with no env var
+# and no explicit token handling. GH_TOKEN itself stays unset in the agent's
+# environment exactly as before (Copilot CLI overloads that name for its own
+# API auth — see above), so this changes what `gh` can do, not what the agent
+# can see.
+#
+# Gated on HIVE_AGENT_TOKEN_CACHE being ABSENT so this never fires for the
+# container-hosted model, where gh-wrapper.sh already handles auth correctly
+# per invocation and an additional `gh auth login` here would be redundant.
+# Same privilege boundary as before for native installs (the whole fleet
+# already shared this one token via the prompt instruction) — this closes the
+# "raw secret text reaches the agent's own context" exposure without changing
+# who is trusted with what.
+if [[ -z "${HIVE_AGENT_TOKEN_CACHE:-}" && -n "${HIVE_GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
+  if printf '%s' "$HIVE_GITHUB_TOKEN" | gh auth login --with-token >/dev/null 2>&1; then
+    echo "[agent-launch] gh CLI pre-authenticated from the shared token cache (native install, no per-agent scope available — N14/#3842)"
+  else
+    echo "[agent-launch] WARN: gh auth login --with-token failed — gh calls in this session may be unauthenticated" >&2
+  fi
+fi
+
 unset GH_TOKEN
 unset HIVE_GITHUB_TOKEN
 

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -831,7 +831,16 @@ if policy_changed "scanner"; then
 else
   _SCANNER_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
 fi
-_GH_AUTH_INSTR="⚙ GH AUTH: ALWAYS prefix gh commands with: GH_TOKEN=\$(cat /var/run/hive-metrics/gh-app-token.cache) gh ... — this uses the GitHub App token (15k/hr). NEVER use a PAT or hardcode tokens. NEVER set GH_TOKEN from env vars or hosts.yml. The App token file is refreshed automatically."
+# N14 (#3842): this used to tell the agent to `cat` the shared App-token
+# cache and prefix every gh call with it — putting the raw, fleet-wide,
+# full-privilege token into the agent's OWN reasoning/output, one prompt
+# injection (a crafted issue/PR body asking it to "print" or "debug" its
+# token) away from exfiltration. agent-launch.sh now authenticates gh's own
+# persistent credential store (gh auth login --with-token) once at agent
+# startup, using a value it reads directly — never typed by the agent — so
+# every `gh` call the agent runs is already authenticated with NO env var and
+# NO token handling required. Do not reintroduce the cat/prefix pattern.
+_GH_AUTH_INSTR="⚙ GH AUTH: gh is already authenticated — just run gh commands directly (e.g. gh issue list, gh pr create). Do NOT read, cat, echo, or set GH_TOKEN yourself; do NOT hardcode a token or use a PAT. If a gh command fails with an auth error, report it — do not try to work around it by fetching a token."
 
 _CLUSTER_SECTION=""
 if [ -n "$_CLUSTERS_INLINE" ]; then

--- a/bin/test_gh_auth_native_no_cat.sh
+++ b/bin/test_gh_auth_native_no_cat.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Asserts the N14 (#3842) fix: a native/systemd-install agent (kicked via
+# kick-agents.sh, no Go AgentManager, no per-agent HIVE_AGENT_TOKEN_CACHE)
+# must never be instructed to read the shared, fleet-wide, full-privilege
+# GitHub App token cache into its own reasoning/output.
+#
+# Before this fix, kick-agents.sh's _GH_AUTH_INSTR told every kicked agent to
+# `cat /var/run/hive-metrics/gh-app-token.cache` and prefix gh calls with the
+# result — the exact anti-pattern audit H3 already removed from gh-wrapper.sh
+# (a shared credential reaching agent-controlled text is one prompt injection
+# from exfiltration), just reintroduced at the prompt-text layer instead of
+# in code.
+#
+# This is source-asserting rather than executing (the fix's actual effect —
+# `gh` working without env-var handling — needs a real `gh` auth state and a
+# native install to observe directly), matching the style of
+# check-suid-contract.sh and test_supply_chain_pins.sh: it tests the
+# INVARIANT text is present/absent, so a future edit that reintroduces the
+# cat/prefix instruction (or silently drops the gh-auth-login replacement)
+# fails CI instead of shipping quietly.
+#
+# Run: bash bin/test_gh_auth_native_no_cat.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+KICK_AGENTS="$BIN_DIR/kick-agents.sh"
+AGENT_LAUNCH="$BIN_DIR/agent-launch.sh"
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== N14 (#3842): no shared-token-cat instruction to agents ==="
+
+# --- 1. kick-agents.sh must not instruct agents to cat the shared cache -----
+if [ ! -f "$KICK_AGENTS" ]; then
+  fail "kick-agents.sh exists" "not found at $KICK_AGENTS"
+else
+  if grep -qE 'cat[[:space:]]+/var/run/hive-metrics/gh-app-token\.cache' "$KICK_AGENTS"; then
+    fail "kick-agents.sh does not instruct agents to cat the shared token cache" \
+         "found a 'cat /var/run/hive-metrics/gh-app-token.cache' reference — this puts the raw fleet-wide token in agent-visible text"
+  else
+    pass "kick-agents.sh does not instruct agents to cat the shared token cache"
+  fi
+
+  if grep -qE 'GH_TOKEN=\\\$\(cat' "$KICK_AGENTS"; then
+    fail "kick-agents.sh does not build a GH_TOKEN=\$(cat ...) prefix instruction" \
+         "found the literal prefix pattern the agent would be told to type"
+  else
+    pass "kick-agents.sh does not build a GH_TOKEN=\$(cat ...) prefix instruction"
+  fi
+
+  if grep -qE '_GH_AUTH_INSTR=' "$KICK_AGENTS"; then
+    pass "_GH_AUTH_INSTR is still defined (instruction exists, just not the cat pattern)"
+  else
+    fail "_GH_AUTH_INSTR is still defined" "the gh-auth instruction variable was removed entirely, not just fixed"
+  fi
+fi
+
+# --- 2. agent-launch.sh must authenticate gh itself instead ------------------
+if [ ! -f "$AGENT_LAUNCH" ]; then
+  fail "agent-launch.sh exists" "not found at $AGENT_LAUNCH"
+else
+  if grep -qE "gh auth login --with-token" "$AGENT_LAUNCH"; then
+    pass "agent-launch.sh authenticates gh's own credential store (gh auth login --with-token)"
+  else
+    fail "agent-launch.sh authenticates gh's own credential store" \
+         "expected a 'gh auth login --with-token' step so native agents never handle the raw token themselves"
+  fi
+
+  # The fallback must be gated on the ABSENCE of the per-agent scoped cache —
+  # otherwise it would also fire (redundantly, or worse, in a way that could
+  # conflict) for the container-hosted model, where gh-wrapper.sh already
+  # authenticates every gh call per-invocation from the per-agent cache.
+  if grep -qE '\-z[[:space:]]+"\$\{HIVE_AGENT_TOKEN_CACHE:-\}"' "$AGENT_LAUNCH"; then
+    pass "the gh-auth-login fallback is gated on HIVE_AGENT_TOKEN_CACHE being absent"
+  else
+    fail "the gh-auth-login fallback is gated on HIVE_AGENT_TOKEN_CACHE being absent" \
+         "without this gate the step could run redundantly (or conflict) on the container-hosted model, which already has per-agent auth via gh-wrapper.sh"
+  fi
+
+  # The unset lines are the OTHER half of the H3 follow-up (GH_TOKEN/
+  # HIVE_GITHUB_TOKEN must never reach the agent CLI's own environment,
+  # partly because Copilot CLI overloads GH_TOKEN for its own API auth) and
+  # must survive this change untouched.
+  if grep -qE '^unset GH_TOKEN$' "$AGENT_LAUNCH" && grep -qE '^unset HIVE_GITHUB_TOKEN$' "$AGENT_LAUNCH"; then
+    pass "GH_TOKEN and HIVE_GITHUB_TOKEN are still unset before the agent CLI launches"
+  else
+    fail "GH_TOKEN and HIVE_GITHUB_TOKEN are still unset before the agent CLI launches" \
+         "the N14 fix must not reintroduce the full token into the agent's own environment"
+  fi
+fi
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #3842.

## Re-verifying the moved citation

The issue's original N14 target (`contribute_ws.go` falling back to an unscoped token when `GHAppAuth == nil`) does not exist on `v4`. I traced the current path: `mintScopedToken` (`v2/pkg/dashboard/contribute_ws.go`) mints a **tier + single-repo-scoped** (via C4's `ScopedTokenForRepos`), expiring credential for a contributor task, or returns `("", nil)` — "mint nothing rather than leak a full credential," per its own comment. **This half is already fixed**, and doesn't need a code change.

## Answering the issue's three questions (for `bin/contributor-relay.sh:47`, the new citation)

1. **When is the fallback taken, and what token does it yield?** It isn't a security fallback at all — `GH_TOKEN_CACHE`'s `fs.existsSync('/var/run/hive-metrics') ? ... : '/tmp/...'` ternary only picks *where to write* the file, not *what* gets written. The relay writes whatever `github_token` the hub sends via `task_assign`/`token_refresh` — the scoped credential from (1). Turns out this cache is currently **write-only**: nothing in the contributor flow reads it back (`contributor-agent.sh` authenticates git with the contributor's own personal PAT instead).
2. **Who can read the cache? Is 0600 still enforced?** Yes — confirmed in both the Go writer (`tokenCachePerms`) and the relay's own `{mode: 0o600}`. In `Dockerfile.contributor`, `/var/run/hive-metrics` is `chown dev:dev` and both the relay and the agent CLI run as `dev` — the same UID, by design (one container per contributor task, nothing else on that host to isolate from).
3. **Is the fallback reachable by an agent, or only hive-internal code?** N/A for this specific path — see (1).

## The issue's "Related" pointer was the real, live gap

> `bin/kick-agents.sh:834` still instructs agents verbatim to `cat` the shared token cache — the exact anti-pattern H3 removed from the wrapper.

Confirmed, and traced it through: `kick-agents.sh` kicks the **native/systemd install** path (scanner, ci-maintainer, architect, outreach — no Go `AgentManager`, no per-agent token scoping infrastructure at all). Its `_GH_AUTH_INSTR` told every kicked agent to `cat /var/run/hive-metrics/gh-app-token.cache` and prefix every `gh` call with the result. In that deployment model every agent runs as the same OS user (`User=dev` in `systemd/hive.service`) that owns the 0600 cache — so the `cat` **succeeds**, putting the shared, fleet-wide, full-privilege App token into the agent's own reasoning/output. One prompt injection (a crafted issue/PR body asking it to "print" or "debug" its token) away from exfiltration — exactly the anti-pattern H3 already removed from `gh-wrapper.sh`, just reintroduced at the prompt-text layer.

Neither of this codebase's two existing safe `gh`-auth mechanisms cover native installs, which is why the instruction existed in the first place:
- `gh-wrapper.sh` isn't installed as `gh` for native installs — `install.sh` ships it under its own filename (`$BIN_DIR/gh-wrapper.sh`), so it never intercepts real `gh` calls there (unlike the container image, which does `COPY bin/gh-wrapper.sh /usr/local/bin/gh`).
- `git-credential-hive.sh` refuses without `HIVE_AGENT_TOKEN_CACHE` by design (the same H3 fail-loud guard) — and that var is set only by the Go `AgentManager` (`v2/pkg/agent/manager.go`), which native installs don't run at all.

## The fix

`agent-launch.sh` already sources `hive-config.sh` (which sets `HIVE_GITHUB_TOKEN`) and immediately unsets it — an H3 follow-up assuming a per-agent scoped replacement exists, which is simply false for native installs. I added one step **before** that unset: if there's no per-agent scoped cache (`HIVE_AGENT_TOKEN_CACHE` absent — true only for native installs, never for the container-hosted model), authenticate `gh`'s own persistent credential store once (`gh auth login --with-token`, fed the value directly by this script — never typed by the agent). Every later `gh` call the agent runs authenticates from that stored config (`~/.config/gh/hosts.yml`) with **no env var and no token handling required**.

`GH_TOKEN`/`HIVE_GITHUB_TOKEN` stay unset in the agent's own environment exactly as before — that's load-bearing for an independent reason (Copilot CLI overloads `GH_TOKEN` for its own API auth and rejects a GitHub App token there), so I could not just leave the token sitting in env as a simpler fix.

`kick-agents.sh`'s instruction now just says `gh` is already authenticated — call it directly, don't read/set `GH_TOKEN` yourself.

**What this does not change:** native installs still share one token across the whole fleet — the same privilege boundary that existed before (via the prompt instruction). This fix closes the "raw secret text reaches the agent's own context" exposure, not the "one agent could theoretically do what another agent can" question — bringing real per-agent scoping to the native/systemd model would mean running some form of token-minting infrastructure there, which doesn't exist today and is a materially larger undertaking than this issue asked for. Flagging it here rather than silently leaving it unaddressed or scope-creeping this PR to attempt it.

## Tests

New `bin/test_gh_auth_native_no_cat.sh` (wired into `.github/workflows/v2-ci.yml` alongside the existing `bin/test_gh_wrapper_gates.sh`):
- Asserts the `cat .../gh-app-token.cache` and `GH_TOKEN=$(cat ...)` patterns are gone from `kick-agents.sh`.
- Asserts `agent-launch.sh` has the `gh auth login --with-token` step, gated on `HIVE_AGENT_TOKEN_CACHE` being absent (so it can't fire redundantly on the container-hosted model).
- Asserts `GH_TOKEN`/`HIVE_GITHUB_TOKEN` are still unset before the agent CLI launches.

Deliberate-break replay (both breaks caught, restore clean):
```
### BREAK 1: reintroduce the cat instruction ###
  FAIL: kick-agents.sh does not instruct agents to cat the shared token cache
  FAIL: kick-agents.sh does not build a GH_TOKEN=$(cat ...) prefix instruction
=== 4 passed, 2 failed ===

### BREAK 2: remove the gh auth login step ###
  FAIL: agent-launch.sh authenticates gh's own credential store
=== 5 passed, 1 failed ===

### RESTORED ###
=== 6 passed, 0 failed ===
```

Also ran: `bin/test_gh_wrapper_gates.sh` (46/46), `v2/deploy/test_supply_chain_pins.sh` (17/17), `v2/deploy/test_entrypoint_symlinks.sh` (8/8) — all still pass, confirming no regression to adjacent scripts. `shellcheck` warning count unchanged on both modified files (no new warnings vs. the unmodified originals).

## Test plan

- [x] `bash -n` on both modified shell scripts
- [x] `shellcheck` — no new warnings vs. unmodified originals
- [x] New `bin/test_gh_auth_native_no_cat.sh` — 6/6, deliberate-break replay confirms it catches regressions
- [x] `bin/test_gh_wrapper_gates.sh`, `v2/deploy/test_supply_chain_pins.sh`, `v2/deploy/test_entrypoint_symlinks.sh` — unaffected, all still pass
- [x] `go build ./...`, `go test ./pkg/config/...` (has `entrypoint_boot_test.go`, which reads these scripts) — clean
- [ ] Live verification against a real native/systemd install with `gh` installed (no such environment available here)
