### PR TITLE
🐛 fix(agent,dashboard): stop clipping tool calls in agent logs; redact API keys

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -75,6 +75,37 @@ const (
 	// fullLogCaptureLines so the full-log endpoint can return the entire
 	// retained buffer.
 	defaultTmuxHistoryLimit = fullLogCaptureLines
+
+	// tmuxPaneWidthEnv overrides the column count agent tmux sessions are
+	// created with (see newSessionCommands).
+	tmuxPaneWidthEnv = "HIVE_TMUX_PANE_WIDTH"
+
+	// defaultTmuxPaneWidth is the column count agent tmux panes are created
+	// with (#3878). tmux gives a DETACHED session (new-session -d, which is how
+	// every agent session is created) a default pane of 80x24, because there is
+	// no attached client whose terminal size it could adopt. The agent CLI
+	// renders its tool-call lines — "Bash(git log --oneline …)" — to fit the
+	// pane it sees, TRUNCATING with an ellipsis rather than wrapping. That
+	// truncation happens at render time, inside the CLI, before any byte
+	// reaches the scrollback: capture-pane -J rejoins wrapped lines but cannot
+	// recover characters the CLI never emitted. So an 80-column pane means long
+	// bash commands are permanently unrecoverable from the log, which is
+	// exactly the debugging wall reported in #3878.
+	//
+	// 500 columns is chosen to sit well beyond the longest tool invocations
+	// observed in practice (multi-flag kubectl/gh/git pipelines run 200-300
+	// columns) while staying a bounded, sane terminal geometry. It costs
+	// nothing at rest: tmux allocates scrollback per line by actual content
+	// length, not by pane width, so a wide pane does not inflate memory for
+	// short lines.
+	defaultTmuxPaneWidth = 500
+
+	// defaultTmuxPaneHeight is the row count agent tmux panes are created with.
+	// It only needs to exceed a normal terminal screenful — scrollback depth is
+	// governed by history-limit, not by pane height — but tmux requires -y
+	// whenever -x is given, so it is pinned here rather than left to the 24-row
+	// default.
+	defaultTmuxPaneHeight = 50
 )
 
 var defaultTmuxSocket string
@@ -1036,6 +1067,20 @@ func tmuxHistoryLimit() int {
 	return defaultTmuxHistoryLimit
 }
 
+// tmuxPaneWidth returns the column count agent tmux panes are created with:
+// HIVE_TMUX_PANE_WIDTH when set to a positive integer, defaultTmuxPaneWidth
+// otherwise. Operators who need even wider panes (or who want to reproduce the
+// old 80-column rendering) can set the env var; see defaultTmuxPaneWidth for
+// why the default is wide.
+func tmuxPaneWidth() int {
+	if v := os.Getenv(tmuxPaneWidthEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultTmuxPaneWidth
+}
+
 // newSessionCommands returns the tmux command sequence (after the base
 // socket args) that creates a detached agent session with a deep scrollback
 // buffer.
@@ -1050,10 +1095,17 @@ func tmuxHistoryLimit() int {
 // auto-starts the server if needed, applies the global option, then creates
 // the session — before the server's exit-empty logic could tear down a
 // sessionless server and discard the option.
+//
+// The same creation-time reasoning applies to pane GEOMETRY (#3878): a
+// detached session has no attached client to size itself from, so tmux would
+// default the pane to 80x24 and the agent CLI would truncate every long tool
+// invocation to fit. -x/-y must therefore be passed to new-session itself —
+// resizing later cannot restore text the CLI already elided.
 func newSessionCommands(session, dir string) []string {
 	return []string{
 		"set-option", "-g", "history-limit", strconv.Itoa(tmuxHistoryLimit()), ";",
 		"new-session", "-d", "-s", session, "-c", dir,
+		"-x", strconv.Itoa(tmuxPaneWidth()), "-y", strconv.Itoa(defaultTmuxPaneHeight),
 	}
 }
 

--- a/v2/pkg/agent/tmux_history_limit_test.go
+++ b/v2/pkg/agent/tmux_history_limit_test.go
@@ -42,9 +42,13 @@ func TestNewSessionCommandsRaisesHistoryBeforePaneCreation(t *testing.T) {
 		t.Fatalf("history-limit value = %q, want %q", got, want)
 	}
 
-	// new-session still carries the detached session + working dir arguments.
+	// new-session still carries the detached session + working dir arguments,
+	// now followed by the explicit pane geometry (#3878).
 	rest := cmds[newIdx:]
-	want := []string{"new-session", "-d", "-s", "hive-scanner", "-c", "/data/workdir/scanner"}
+	want := []string{
+		"new-session", "-d", "-s", "hive-scanner", "-c", "/data/workdir/scanner",
+		"-x", strconv.Itoa(defaultTmuxPaneWidth), "-y", strconv.Itoa(defaultTmuxPaneHeight),
+	}
 	if len(rest) != len(want) {
 		t.Fatalf("new-session args = %v, want %v", rest, want)
 	}
@@ -52,6 +56,99 @@ func TestNewSessionCommandsRaisesHistoryBeforePaneCreation(t *testing.T) {
 		if rest[i] != want[i] {
 			t.Fatalf("new-session args = %v, want %v", rest, want)
 		}
+	}
+}
+
+// TestNewSessionCreatesWidePane is the #3878 guard. A detached tmux session
+// with no -x defaults to 80 columns, and the agent CLI truncates its tool-call
+// lines to the pane width at RENDER time — before anything reaches the
+// scrollback, so no capture flag can recover it. This asserts the pane is
+// created explicitly wide, and that the width is carried on new-session itself
+// (a later resize cannot un-elide already-rendered text).
+func TestNewSessionCreatesWidePane(t *testing.T) {
+	cmds := newSessionCommands("hive-scanner", "/data/workdir/scanner")
+
+	idx := func(want string) int {
+		for i, a := range cmds {
+			if a == want {
+				return i
+			}
+		}
+		t.Fatalf("args %v missing %q", cmds, want)
+		return -1
+	}
+
+	newIdx := idx("new-session")
+	xIdx := idx("-x")
+	yIdx := idx("-y")
+
+	// Geometry must belong to new-session, not to the set-option before it.
+	if xIdx < newIdx || yIdx < newIdx {
+		t.Fatalf("-x/-y must follow new-session so the pane is CREATED wide, got %v", cmds)
+	}
+	if got, want := cmds[xIdx+1], strconv.Itoa(defaultTmuxPaneWidth); got != want {
+		t.Fatalf("pane width = %q, want %q", got, want)
+	}
+	if got, want := cmds[yIdx+1], strconv.Itoa(defaultTmuxPaneHeight); got != want {
+		t.Fatalf("pane height = %q, want %q", got, want)
+	}
+
+	// Boundary: the whole point is being clear of tmux's 80-column default.
+	// A regression to 80 (or anything near it) re-clips tool calls.
+	if defaultTmuxPaneWidth <= tmuxDefaultPaneWidthForTest {
+		t.Fatalf("defaultTmuxPaneWidth (%d) must exceed tmux's %d-column default, or long tool calls are clipped again",
+			defaultTmuxPaneWidth, tmuxDefaultPaneWidthForTest)
+	}
+}
+
+// tmuxDefaultPaneWidthForTest is tmux's own default pane width for a detached
+// session — the value #3878 was clipping at. Named so the boundary assertion
+// above does not hard-code a bare 80.
+const tmuxDefaultPaneWidthForTest = 80
+
+// TestTmuxPaneWidthEnvOverride covers the HIVE_TMUX_PANE_WIDTH knob, mirroring
+// the history-limit knob: positive integers win, anything else falls back.
+func TestTmuxPaneWidthEnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset", "", defaultTmuxPaneWidth},
+		{"positive", "1000", 1000},
+		{"zero", "0", defaultTmuxPaneWidth},
+		{"negative", "-5", defaultTmuxPaneWidth},
+		{"garbage", "wide", defaultTmuxPaneWidth},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tmuxPaneWidthEnv, tc.env)
+			if got := tmuxPaneWidth(); got != tc.want {
+				t.Fatalf("tmuxPaneWidth() with %q = %d, want %d", tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPaneWidthAccommodatesRealisticToolCalls is the positive control in BOTH
+// directions required by #3878: a long, realistic tool invocation must fit the
+// pane in full, and a short one must be unaffected (no padding, no mangling).
+// It asserts against the width the session is actually created with, so it
+// fails if the constant is ever lowered back toward 80.
+func TestPaneWidthAccommodatesRealisticToolCalls(t *testing.T) {
+	long := "kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{\"/\"}" +
+		"{.metadata.name}{\"\\t\"}{.status.phase}{\"\\n\"}{end}' | grep -v Running | sort -u | head -50"
+	short := "git status"
+
+	if len(long) <= tmuxDefaultPaneWidthForTest {
+		t.Fatalf("test fixture is not long enough (%d cols) to exercise the 80-column clip", len(long))
+	}
+	if len(long) > tmuxPaneWidth() {
+		t.Fatalf("realistic tool call is %d columns but pane is only %d: it would still be clipped",
+			len(long), tmuxPaneWidth())
+	}
+	if len(short) > tmuxPaneWidth() {
+		t.Fatalf("short tool call %q unexpectedly exceeds pane width %d", short, tmuxPaneWidth())
 	}
 }
 

--- a/v2/pkg/dashboard/redact_api_key_test.go
+++ b/v2/pkg/dashboard/redact_api_key_test.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRedactTokensRedactsAPIKeysRegardlessOfLength is the security guard tied
+// to #3878. Widening agent tmux panes means a full command line — including
+// one carrying ANTHROPIC_API_KEY='sk-hive-…' as seen in the #3852 report — now
+// reliably reaches the pane and full-log endpoints instead of being clipped
+// off the end of an 80-column line by accident.
+//
+// Truncation was never a security control, so the redaction has to be real.
+// The key assertion is "regardless of length": a secret must be scrubbed
+// whether it sits at column 10 or column 400, because the fix removes the
+// length-based accident that used to hide it.
+func TestRedactTokensRedactsAPIKeysRegardlessOfLength(t *testing.T) {
+	const secret = "sk-hive-quality"
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"bare_key", secret},
+		{"reported_form_3852", "Bash(ANTHROPIC_API_KEY='" + secret + "' gh pr list)"},
+		{"anthropic_real_key", "export ANTHROPIC_API_KEY=sk-ant-api03-AbCdEf0123456789xyz"},
+		{"double_quoted", `ANTHROPIC_API_KEY="` + secret + `" claude -p run`},
+		{"exported_inline", "env ANTHROPIC_API_KEY=" + secret + " node index.js"},
+		{
+			// The whole point of the #3878 change: long lines are no longer
+			// clipped, so a secret far past column 80 is now retained and must
+			// be redacted rather than accidentally cut off.
+			"key_beyond_old_80_column_clip",
+			"kubectl get pods -A -o wide --sort-by=.metadata.creationTimestamp " +
+				strings.Repeat("# padding ", 40) + " ANTHROPIC_API_KEY=" + secret,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactTokens(tc.in)
+			if strings.Contains(got, secret) {
+				t.Fatalf("secret survived redaction in %s", tc.name)
+			}
+			if strings.Contains(got, "sk-ant-api03-AbCdEf0123456789xyz") {
+				t.Fatalf("anthropic key survived redaction in %s", tc.name)
+			}
+			if !strings.Contains(got, "REDACTED") {
+				t.Fatalf("expected a redaction marker in output for %s, got %q", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestRedactTokensPreservesNonSecretText is the negative control: the new
+// api-key pattern must not eat ordinary log text. Without this, a pattern
+// broad enough to pass the test above could silently gut the very tool-call
+// output #3878 is trying to make readable.
+func TestRedactTokensPreservesNonSecretText(t *testing.T) {
+	cases := []string{
+		"git commit -s -m 'sk- prefix discussed in docs'",
+		"installing package sk",
+		"Bash(kubectl get pods -n kube-system)",
+		"the task-sk-flow module was refactored",
+	}
+	for _, in := range cases {
+		if got := redactTokens(in); got != in {
+			t.Fatalf("non-secret text was altered:\n in: %q\nout: %q", in, got)
+		}
+	}
+}
+
+// TestFullLogRedactionIsAppliedNotImpliedByTruncation pins the ordering
+// invariant. handleAgentFullLog redacts the WHOLE captured buffer, so a secret
+// must be scrubbed even when it appears in a line far longer than any pane
+// width — i.e. redaction must not depend on something else having clipped it
+// first.
+func TestFullLogRedactionIsAppliedNotImpliedByTruncation(t *testing.T) {
+	const secret = "sk-hive-scanner"
+	// A single line far wider than even the widened pane.
+	line := strings.Repeat("x", 5000) + " ANTHROPIC_API_KEY=" + secret + " " + strings.Repeat("y", 5000)
+
+	got := redactTokens(line)
+	if strings.Contains(got, secret) {
+		t.Fatal("secret survived redaction on an over-wide log line")
+	}
+	if len(got) < 5000 {
+		t.Fatalf("redaction unexpectedly truncated the line to %d bytes; the fix must not reintroduce clipping", len(got))
+	}
+}

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -1739,6 +1739,29 @@ var statusTokenRedactor = regexp.MustCompile(`(ghp_|gho_|ghs_|ghu_|ghr_|github_p
 var deviceCodeRedactor = regexp.MustCompile(`(?i)(one-time code:\s*)[A-Z0-9]{4}-[A-Z0-9]{4}`)
 var deviceCodeLineRedactor = regexp.MustCompile(`(?m)^.*(?:login/device|Waiting for authorization|one-time code:|Press any key to copy).*$`)
 
+// apiKeyRedactor matches sk-prefixed API keys: real Anthropic keys (sk-ant-…),
+// the per-agent LiteLLM virtual keys hive itself mints (sk-hive-<agent>, see
+// Manager.agentEnv), and the generic OpenAI-style sk-… form.
+//
+// This surface previously redacted only GitHub tokens, so an agent command line
+// carrying ANTHROPIC_API_KEY='sk-hive-…' reached the pane/full-log endpoints in
+// clear text (observed in the #3852 report). That was survivable only by
+// accident: an 80-column pane frequently clipped the key off the end of the
+// line before it was ever captured. Widening the pane for #3878 removes that
+// accidental cover and makes the exposure reliable, so the redaction has to
+// become real. Truncation is not a security control.
+//
+// The {6,} floor keeps the pattern off ordinary prose ("sk-" alone) while still
+// catching short virtual keys such as sk-hive-qa.
+//
+// The leading (^|[^A-Za-z0-9._-]) guard anchors the match to a real token
+// start. Without it the pattern fires INSIDE ordinary identifiers — a module
+// named "task-sk-flow" was rewritten to "task-[redacted]", which would corrupt
+// the very tool-call text this change exists to make readable. A redactor that
+// eats legitimate output is its own bug, so the boundary is asserted by
+// TestRedactTokensPreservesNonSecretText.
+var apiKeyRedactor = regexp.MustCompile(`(^|[^A-Za-z0-9._-])(sk-[A-Za-z0-9._\-]{6,})`)
+
 func redactTokens(s string) string {
 	s = statusTokenRedactor.ReplaceAllStringFunc(s, func(m string) string {
 		if len(m) > 7 {
@@ -1746,6 +1769,8 @@ func redactTokens(s string) string {
 		}
 		return "***"
 	})
+	// ${1} preserves the boundary character the pattern had to consume.
+	s = apiKeyRedactor.ReplaceAllString(s, "${1}sk-***REDACTED***")
 	s = deviceCodeRedactor.ReplaceAllString(s, "${1}****-****")
 	s = deviceCodeLineRedactor.ReplaceAllString(s, "[auth flow redacted]")
 	return s


### PR DESCRIPTION
## What

Implements **one half** of #3878: tool invocations in agent logs are no longer clipped.

Refs #3878 — deliberately **no `Fixes` keyword**. The issue's second ask (an option for agents to explain themselves) requires agent prompt changes and is **not** addressed here, so #3878 must stay open. See "What remains" below.

## Where the clipping was

`v2/pkg/agent/manager.go:1053` — `newSessionCommands` created every agent session with `new-session -d` and **no `-x`/`-y`**:

```go
"new-session", "-d", "-s", session, "-c", dir,
```

A *detached* tmux session has no attached client whose terminal size it could adopt, so tmux applies its **80x24** default. The agent CLI renders its tool-call lines — `Bash(git log --oneline …)` — to fit the pane it sees, **truncating with an ellipsis rather than wrapping**.

That truncation happens at render time, *inside the CLI*, before a single byte reaches the scrollback. This is why the existing mitigations did not help: `CaptureFullLog` already passes `-J` (`manager.go:2792`) to rejoin wrapped lines, but `-J` cannot recover characters the CLI never emitted.

**There is no Go-side truncation on the tool-call log path.** Agent "logs" are tmux pane *screen scrapes*; every `truncateStr` site in `manager.go` is on kick/prompt/signal paths, and the dashboard display path (`terminal_log.go:43`, `api.go:1147`) only redacts, never clips. The pane geometry was the entire cause.

## Why the limit existed

It wasn't a deliberate limit at all — it was tmux's default inherited by omission, not a guard against log volume, payload size, or a UI column width. Notably `bin/contributor-agent.sh:456` **already** creates its session with `-x 200 -y 50`, so widening is established practice in this repo; the agent manager simply never got the same treatment.

So rather than deleting a protective limit, this **sets a geometry that was never chosen**. Capture remains bounded where it actually matters — by line *count* (`fullLogCaptureLines = 50000`), untouched here.

## What changed

- **`v2/pkg/agent/manager.go`** — new named constants `defaultTmuxPaneWidth = 500` and `defaultTmuxPaneHeight = 50`, each commented with the reasoning (no magic numbers), plus a `tmuxPaneWidth()` helper honouring `HIVE_TMUX_PANE_WIDTH`, mirroring the existing `HIVE_TMUX_HISTORY_LIMIT` knob. `newSessionCommands` now passes `-x`/`-y` **on `new-session` itself** — a later resize cannot un-elide already-rendered text.
- **`v2/pkg/dashboard/status_builder.go`** — added an `sk-` API-key pattern to `redactTokens` (see below).

500 columns clears the longest tool invocations seen in practice (multi-flag kubectl/gh/git pipelines run 200–300 columns) and costs nothing at rest: tmux allocates scrollback per line by actual content length, not pane width.

## ⚠️ Secret-exposure assessment — a real gap was found and closed

**Un-clipping would have been a secret-exposure regression on its own.** `redactTokens` (`status_builder.go:1742`) is the *sole* redactor on both pane surfaces — `handleAgentFullLog` (`terminal_log.go:43`) and the status summaries — and it covered **only** GitHub tokens and device codes. It had **no pattern for `sk-` API keys**.

Agents run with `ANTHROPIC_API_KEY` set to `sk-hive-<agent>` (`manager.go:6080`), exactly the form pasted in the #3852 report. Probed against the unmodified code:

```
redactTokens("Bash(ANTHROPIC_API_KEY='sk-hive-quality' gh pr list)")
  => "Bash(ANTHROPIC_API_KEY='sk-hive-quality' gh pr list)"   // unchanged
```

At 80 columns that key was frequently clipped off the end of the line *by luck*. A 500-column pane retains it reliably. **Redaction here was partly relying on truncation, which is not a security control** — so this change adds real redaction as part of the fix, covering `sk-ant-*`, hive's own `sk-hive-*` virtual keys, and the generic `sk-` form.

The pattern is **boundary-anchored**. An unanchored `sk-[A-Za-z0-9._-]{6,}` rewrote the ordinary identifier `task-sk-flow` to `task-[redacted]` — a redactor that eats legitimate output would corrupt the very tool-call text this PR exists to make readable. My negative control caught this before commit.

Out of scope, worth a follow-up: `v2/pkg/logscrub/handler.go` (the global slog handler) likewise has no `sk-` pattern. Different surface, not on the un-clipped path.

## Tests

New in `v2/pkg/agent/tmux_history_limit_test.go`:
- `TestNewSessionCreatesWidePane` — geometry rides on `new-session`; **explicit boundary assertion** that the width exceeds tmux's 80-column default.
- `TestPaneWidthAccommodatesRealisticToolCalls` — **positive control in both directions**: a 164-column kubectl pipeline fits in full, a short `git status` is unaffected.
- `TestTmuxPaneWidthEnvOverride` — the `HIVE_TMUX_PANE_WIDTH` knob.

New in `v2/pkg/dashboard/redact_api_key_test.go`:
- `TestRedactTokensRedactsAPIKeysRegardlessOfLength` — a token-shaped value is redacted **at any length/position**, including one placed far past the old 80-column cut, plus the verbatim #3852 form.
- `TestRedactTokensPreservesNonSecretText` — negative control; caught the `task-sk-flow` over-match.
- `TestFullLogRedactionIsAppliedNotImpliedByTruncation` — pins that redaction does **not** depend on clipping, and that redaction itself introduces no truncation.

**Existing test INVERTED, not relaxed:** `TestNewSessionCommandsRaisesHistoryBeforePaneCreation` compares `new-session`'s exact arg list. Rather than loosening the length check to tolerate the new args, it now **requires** `-x 500 -y 50` — so removing the geometry fails it.

### Regression replay

Each fix neutered (still compiling), specific test confirmed failing, then restored green.

**1. Width reverted to tmux's 80 default:**
```
=== RUN   TestNewSessionCreatesWidePane
    tmux_history_limit_test.go:99: defaultTmuxPaneWidth (80) must exceed tmux's 80-column default, or long tool calls are clipped again
--- FAIL: TestNewSessionCreatesWidePane (0.00s)
=== RUN   TestPaneWidthAccommodatesRealisticToolCalls
    tmux_history_limit_test.go:147: realistic tool call is 164 columns but pane is only 80: it would still be clipped
--- FAIL: TestPaneWidthAccommodatesRealisticToolCalls (0.00s)
FAIL
```

**2. `-x`/`-y` args removed from `new-session`:**
```
=== RUN   TestNewSessionCommandsRaisesHistoryBeforePaneCreation
    tmux_history_limit_test.go:53: new-session args = [new-session -d -s hive-scanner -c /data/workdir/scanner], want [new-session -d -s hive-scanner -c /data/workdir/scanner -x 500 -y 50]
--- FAIL: TestNewSessionCommandsRaisesHistoryBeforePaneCreation (0.00s)
=== RUN   TestNewSessionCreatesWidePane
    tmux_history_limit_test.go:77: args [set-option -g history-limit 50000 ; new-session -d -s hive-scanner -c /data/workdir/scanner] missing "-x"
--- FAIL: TestNewSessionCreatesWidePane (0.00s)
FAIL
```

**3. `sk-` redaction line removed (security replay):**
```
--- FAIL: TestRedactTokensRedactsAPIKeysRegardlessOfLength (0.00s)
    --- FAIL: TestRedactTokensRedactsAPIKeysRegardlessOfLength/bare_key (0.00s)
    --- FAIL: TestRedactTokensRedactsAPIKeysRegardlessOfLength/reported_form_3852 (0.00s)
    --- FAIL: TestRedactTokensRedactsAPIKeysRegardlessOfLength/anthropic_real_key (0.00s)
    --- FAIL: TestRedactTokensRedactsAPIKeysRegardlessOfLength/double_quoted (0.00s)
    --- FAIL: TestRedactTokensRedactsAPIKeysRegardlessOfLength/exported_inline (0.00s)
    --- FAIL: TestRedactTokensRedactsAPIKeysRegardlessOfLength/key_beyond_old_80_column_clip (0.00s)
=== RUN   TestFullLogRedactionIsAppliedNotImpliedByTruncation
    redact_api_key_test.go:86: secret survived redaction on an over-wide log line
--- FAIL: TestFullLogRedactionIsAppliedNotImpliedByTruncation (0.00s)
FAIL
```

All restored. Local verification: `go build ./...` clean, `gofmt` clean, full `pkg/agent` (458s) and full `pkg/dashboard` (39s) suites pass.

## What remains for #3878

The issue's second request — *"the agents are adamantly told to not explain themselves, removing the primary avenue for debugging"* → **add an option for an agent to explain itself**. That needs agent prompt/policy changes, which are intentionally untouched in this PR. **#3878 should stay open** for that half.

## Compatibility

Takes effect for sessions created *after* rollout; existing sessions keep their current geometry until the agent restarts. Operators can set `HIVE_TMUX_PANE_WIDTH` to tune, or to restore the old 80-column rendering. No cluster or config changes required.
