### PR TITLE
🌱 sync: merge v4 into mk (top-up — CapAmb entrypoint outage fix)

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -47,7 +47,30 @@ async function fetchJson(endpoint, fallback = '{}') {
     }
     const res = await fetch(`${dashboardUrl}${endpoint}`, { signal: controller.signal, headers });
     clearTimeout(timer);
-    return await res.text();
+    const body = await res.text();
+    // Every payload here is interpolated RAW into the snapshot's inline script
+    // (var _snapAudit = BODY;). A non-JSON body therefore becomes invalid
+    // JavaScript that throws a PARSE-time SyntaxError — which aborts the ENTIRE
+    // <script>, leaving render() and all render functions undefined and every
+    // panel (Governor/Repos/Beads/Agents/Tokens/Cost/ACMM) blank. This is not
+    // hypothetical: a privilege-gated endpoint such as /api/audit answers a 401/
+    // 403 with a plaintext body like "insufficient access", not JSON, so
+    // `var _snapAudit = insufficient access;` broke the whole page. The
+    // try/catch around each baked block cannot save it — a SyntaxError is raised
+    // at parse time, before any try runs. Validate here: only return a body we
+    // have confirmed parses as JSON; on anything else fall back to the safe JSON
+    // literal so the script stays well-formed and the rest of the page renders.
+    try {
+      JSON.parse(body);
+      return body;
+    } catch {
+      if (res.status >= 400 || body.trim() === '') {
+        console.warn(`WARNING: ${endpoint} returned non-JSON (status ${res.status}); using fallback so the snapshot script stays valid.`);
+      } else {
+        console.warn(`WARNING: ${endpoint} returned a non-JSON 2xx body; using fallback so the snapshot script stays valid.`);
+      }
+      return fallback;
+    }
   } catch {
     return fallback;
   }


### PR DESCRIPTION
Top-up merge of `v4` into `mk`, carrying today's fleet-wide outage fix.

## Why

Spokes running the pre-fix entrypoint land with `CapAmb: 0000000000000000`. `setpriv --ambient-caps +net_admin` **exits 0 while doing nothing**: the kernel only permits an ambient bit that is also in the *inheritable* set, and `setpriv` applies ambient caps *after* the UID change, when `pI` has already been zeroed. Without `CAP_NET_ADMIN` the MITM proxy cannot `setsockopt(SO_MARK)` its own upstream dial, so it fails its `-m mark --mark 0x1112 -j RETURN` bypass and gets REDIRECTed back into itself — every outbound :443 returns `000`.

## Commits carried

| Commit | Change |
| --- | --- |
| `e6c769ff` | entrypoint `--inh-caps` — **the outage fix** |
| `1dab71b4` | heartbeat liveness decoupled from GitHub availability |
| `ca6aa8ad` | proxy tunnel half-close drain (fd/goroutine leak) |
| `7a783d05` | Option D stage 1 (X25519 sealed box; inert) |

## Verification

Merged `v2/deploy/entrypoint.sh` line 902:

```sh
_SETPRIV_CAPS="--inh-caps +net_admin --ambient-caps +net_admin"
```

The entrypoint additionally verifies the *outcome* — it reads `CapAmb` back out of `/proc/self/status` in the dropped child and requires bit 12, so a `setpriv` that "succeeds" with `CapAmb=0x0` falls through to the honest gosu path instead of silently claiming an exemption it does not have.

`git merge-base --is-ancestor` — all ANCESTOR: `e6c769ff`, `1dab71b4`, `ca6aa8ad`, `7a783d05`.

Security greps: `TerminalSigningKey` has no `HIVE_SESSION_KEY`/`EnvSessionKey` fallthrough (N3 closed); `inviteSigningSecret` calls `hub.SpokeInviteKey()` and never reads the raw master; `perHiveEnvMaxPatchesPerCycle = 3`.

## Conflicts

None. `mk` had zero unique non-merge commits against `v4`, so this is mechanical — the only delta was `dashboard/build-snapshot.mjs` from `af4c6a8f`.

## Tests

`go build ./...` clean. `go test ./pkg/hub/ ./pkg/dashboard/` — both ok.

Merge commit (not squashed) so `merge-base --is-ancestor` checks keep working.
