### PR TITLE
🌱 sync: merge v4 into dd (top-up — CapAmb entrypoint outage fix)

### DIFF
--- a/.github/workflows/suid-contract.yml
+++ b/.github/workflows/suid-contract.yml
@@ -40,3 +40,17 @@ jobs:
 
       - name: Run SUID + NET_ADMIN static contract check
         run: bash v2/scripts/check-suid-contract.sh v2/Dockerfile v2/deploy/entrypoint.sh
+
+  # RUNTIME assertion (#3874). The static check above cannot catch the bug that
+  # caused the fleet-wide outage: `setpriv --ambient-caps +net_admin` EXITS 0 but
+  # leaves CapAmb=0x0 unless --inh-caps is raised in the same call. Only actually
+  # performing the privilege drop and reading /proc/self/status proves it.
+  # This runs the real setpriv from the real base image, with NET_ADMIN in the
+  # bounding set (--cap-add), and asserts bit 12 survives the drop to dev.
+  ambient-cap-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Assert ambient CAP_NET_ADMIN survives the privilege drop
+        run: bash v2/deploy/test_ambient_cap_runtime.sh

--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -47,7 +47,30 @@ async function fetchJson(endpoint, fallback = '{}') {
     }
     const res = await fetch(`${dashboardUrl}${endpoint}`, { signal: controller.signal, headers });
     clearTimeout(timer);
-    return await res.text();
+    const body = await res.text();
+    // Every payload here is interpolated RAW into the snapshot's inline script
+    // (var _snapAudit = BODY;). A non-JSON body therefore becomes invalid
+    // JavaScript that throws a PARSE-time SyntaxError — which aborts the ENTIRE
+    // <script>, leaving render() and all render functions undefined and every
+    // panel (Governor/Repos/Beads/Agents/Tokens/Cost/ACMM) blank. This is not
+    // hypothetical: a privilege-gated endpoint such as /api/audit answers a 401/
+    // 403 with a plaintext body like "insufficient access", not JSON, so
+    // `var _snapAudit = insufficient access;` broke the whole page. The
+    // try/catch around each baked block cannot save it — a SyntaxError is raised
+    // at parse time, before any try runs. Validate here: only return a body we
+    // have confirmed parses as JSON; on anything else fall back to the safe JSON
+    // literal so the script stays well-formed and the rest of the page renders.
+    try {
+      JSON.parse(body);
+      return body;
+    } catch {
+      if (res.status >= 400 || body.trim() === '') {
+        console.warn(`WARNING: ${endpoint} returned non-JSON (status ${res.status}); using fallback so the snapshot script stays valid.`);
+      } else {
+        console.warn(`WARNING: ${endpoint} returned a non-JSON 2xx body; using fallback so the snapshot script stays valid.`);
+      }
+      return fallback;
+    }
   } catch {
     return fallback;
   }

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3111,6 +3111,20 @@ func main() {
 		// fixed interval comfortably under that 5-min threshold so every hive,
 		// regardless of ACMM level, stays fresh on the hub.
 		const heartbeatSendInterval = 2 * time.Minute
+		// Publish the collect-independent identity BEFORE the loop starts, so
+		// this spoke can report liveness even if its very first collects time
+		// out. collect() below reaches api.github.com (owner-token validation,
+		// and it shares the pass that enumerates issues/PRs for MTTR), which on
+		// a hive with real repos routinely exceeds the collect budget right
+		// after a restart. Without this, such a spoke sent NOTHING and read
+		// OFFLINE on the hub while being perfectly healthy.
+		hub.PublishHeartbeatIdentity(
+			cfg.HiveID,
+			cfg.Project.Org,
+			reporterName,
+			processStartedAt.UTC().Format(time.RFC3339),
+			gitShort,
+		)
 		go hub.StartHeartbeat(ctx, hubURL, func() *hub.HeartbeatPayload {
 			if !cfg.Hub.Enabled {
 				return nil

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -3177,6 +3177,12 @@ func main() {
 				AIAuthor:          cfg.Project.AIAuthor,
 				AIAuthorEffective: cfg.EffectiveAIAuthor(),
 				StartedAt:         processStartedAt.UTC().Format(time.RFC3339),
+				// FD gauge (#3875): a socket leak reached 92,962 FDs and
+				// self-DoSed spokes with nothing surfacing it. Report the count
+				// and its rlimit every beat so the next leak is a climbing
+				// number on the hub, not a manual /proc excavation.
+				OpenFDs:     hub.OpenFDCount(),
+				FDSoftLimit: hub.FDSoftLimit(),
 				// Reporter names THIS process (the pod) so the hub can tell two
 				// instances reporting as one hive apart — the pod name is the
 				// hostname inside the container.

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -880,29 +880,74 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
   # regid of a nonexistent `dev` group would make setpriv fail and silently drop
   # us to the gosu fallback (losing the ambient cap on managed spokes).
   _SETPRIV_ID="--reuid dev --regid node --init-groups"
+
+  # ── The ambient set CANNOT be raised without the INHERITABLE set (#3874) ──
+  # An ambient capability is only permitted to hold a bit that is in BOTH the
+  # permitted and the inheritable set (kernel: cap_ambient_raise → PR_CAP_AMBIENT
+  # requires the cap in pP *and* pI, capability.c). setpriv applies --ambient-caps
+  # AFTER the UID change, at which point a setuid transition has already zeroed
+  # pI. So `--ambient-caps +net_admin` ALONE is a silent no-op: setpriv exits 0,
+  # the entrypoint prints its success line, and the process lands with
+  # CapAmb=0x0 — exactly the signature seen fleet-wide (CapBnd=...a80435fb with
+  # CapInh/CapPrm/CapEff/CapAmb all zero). The proxy then cannot setsockopt
+  # (SO_MARK) its own upstream dial, that dial is REDIRECTed back into the proxy
+  # itself, and every outbound :443 hangs until timeout while inbound is fine.
+  #
+  # Raising --inh-caps in the SAME setpriv call fixes it: pI keeps NET_ADMIN
+  # across the credential change, so the ambient raise is legal and sticks
+  # (verified live: CapInh/CapPrm/CapEff/CapAmb all become 0x1000).
+  #
+  # This grants net_admin and NOTHING else — no file capability, no SUID, and the
+  # bounding set is still the gate above, so self-hosted spokes are unaffected.
+  _SETPRIV_CAPS="--inh-caps +net_admin --ambient-caps +net_admin"
+
   # Probe the full invocation once (as root) so a bad flag/identity falls through
   # to the gosu fallback instead of exec-failing after the point of no return.
+  #
+  # The probe VERIFIES THE OUTCOME rather than trusting the exit status: it reads
+  # CapAmb back out of /proc/self/status in the dropped child and requires bit 12
+  # to actually be set. A setpriv that "succeeds" while producing CapAmb=0x0 (the
+  # bug above, and any future kernel/util-linux regression of the same shape) is
+  # therefore treated as a FAILURE and falls through to the honest gosu path,
+  # instead of silently claiming an egress exemption the proxy does not have.
+  _setpriv_grants_ambient_net_admin() {
+    _probe_amb="$(setpriv $_SETPRIV_CAPS $_SETPRIV_ID \
+      sh -c 'grep -m1 "^CapAmb:" /proc/self/status' 2>/dev/null | awk '{print $2}')"
+    [ -n "$_probe_amb" ] && [ $(( 0x${_probe_amb} & 0x1000 )) -ne 0 ]
+  }
+
   if [ "$_cap_net_admin_in_bset" = "true" ] \
      && command -v setpriv >/dev/null 2>&1 \
-     && setpriv --ambient-caps +net_admin $_SETPRIV_ID true 2>/dev/null; then
+     && _setpriv_grants_ambient_net_admin; then
     # Managed spoke: bounding set HAS NET_ADMIN and setpriv can raise it into the
     # ambient set. Drop to dev WITH ambient+effective NET_ADMIN so the Go hive
     # process can SO_MARK its proxy dials.
     echo "[entrypoint] Dropping to dev user (ambient CAP_NET_ADMIN granted for proxy SO_MARK egress-gate)"
-    exec setpriv --ambient-caps +net_admin $_SETPRIV_ID "$0" "$@"
+    exec setpriv $_SETPRIV_CAPS $_SETPRIV_ID "$0" "$@"
   elif command -v gosu >/dev/null 2>&1 && gosu dev true 2>/dev/null; then
     if [ "$_cap_net_admin_in_bset" != "true" ]; then
       # Self-hosted / rootless spoke: no NET_ADMIN in the bounding set. Do NOT
       # attempt the ambient raise (setpriv would error). The binary execs fine
-      # (no file cap), but the proxy's SO_MARK egress exemption is unavailable —
-      # the forced-proxy egress-gate degrades to the owner-UID exemption only
-      # (works on OKE, not on OpenShift/OVN). The Go proxy logs this once and
-      # dials unmarked (v2/pkg/proxy/github_proxy.go warnSockMarkOnce).
-      echo "[entrypoint] NOTICE: CAP_NET_ADMIN is not in the bounding set — the forced-proxy egress exemption (SO_MARK) is unavailable. hive will run without it; grant NET_ADMIN (securityContext capabilities.add / --cap-add NET_ADMIN) for full egress attribution."
+      # (no file cap), but the proxy's SO_MARK egress exemption is unavailable.
+      # The only remaining self-exemption is the owner-UID RETURN appended above
+      # — and that one is CONDITIONAL: it is appended with `|| true` and silently
+      # does not exist on kernels without the xt_owner module (OpenShift/OVN and
+      # some IKS/OKE node images: "Extension owner revision 0 not supported").
+      # So do NOT promise it here. Report what is actually in the chain, which is
+      # verifiable, instead of asserting a backstop that may not be loaded.
+      # The Go proxy logs the unmarked dial once
+      # (v2/pkg/proxy/github_proxy.go warnSockMarkOnce).
+      if iptables -t nat -C HIVE_PROXY -m owner --uid-owner "$PROXY_UID" -j RETURN 2>/dev/null; then
+        _owner_backstop="present (xt_owner loaded) — proxy dials still exempt via owner-UID"
+      else
+        _owner_backstop="ABSENT (no xt_owner on this kernel) — the proxy has NO self-exemption; outbound :443 from the proxy will loop back into the redirect"
+      fi
+      echo "[entrypoint] NOTICE: CAP_NET_ADMIN is not in the bounding set — the forced-proxy egress exemption (SO_MARK) is unavailable. Owner-UID backstop: ${_owner_backstop}. Grant NET_ADMIN (securityContext capabilities.add / --cap-add NET_ADMIN) for full egress attribution."
     else
-      # Bounding set HAD NET_ADMIN but setpriv was missing or failed — fall back
-      # to gosu (no ambient cap). Same SO_MARK degradation as the no-cap case.
-      echo "[entrypoint] WARN: setpriv unavailable or ambient-cap raise failed despite NET_ADMIN in bounding set — falling back to gosu (SO_MARK egress exemption unavailable)."
+      # Bounding set HAD NET_ADMIN but setpriv was missing, or the probe proved
+      # the ambient bit did NOT survive the drop (the #3874 silent no-op). Fall
+      # back to gosu with an honest warning: this path has no SO_MARK exemption.
+      echo "[entrypoint] WARN: setpriv unavailable, or the ambient CAP_NET_ADMIN raise did not survive the privilege drop (verified CapAmb bit 12 unset), despite NET_ADMIN in the bounding set — falling back to gosu (SO_MARK egress exemption unavailable)."
     fi
     echo "[entrypoint] Dropping to dev user"
     exec gosu dev "$0" "$@"

--- a/v2/deploy/test_ambient_cap_runtime.sh
+++ b/v2/deploy/test_ambient_cap_runtime.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# test_ambient_cap_runtime.sh — RUNTIME regression test for #3874.
+#
+# THE BUG THIS CATCHES
+# --------------------
+# `setpriv --ambient-caps +net_admin --reuid dev ...` exits 0 but silently
+# produces CapAmb=0x0. The kernel only permits an ambient bit that is present in
+# BOTH the permitted and the INHERITABLE set (cap_ambient_raise / PR_CAP_AMBIENT,
+# kernel/capability.c), and setpriv applies --ambient-caps after the UID change,
+# by which point the setuid transition has zeroed pI. The entrypoint therefore
+# printed its success line while the hive process ran with NO NET_ADMIN, so the
+# proxy could not SO_MARK its own upstream dial, that dial was REDIRECTed back
+# into the proxy, and every outbound :443 hung — a fleet-wide outage.
+#
+# The fix raises --inh-caps in the SAME setpriv call.
+#
+# WHY THIS TEST IS RUNTIME AND NOT A grep
+# ---------------------------------------
+# The shipped bug was 100% invisible to static inspection: the flag was present,
+# the exit status was 0, the log line claimed success. Only executing the drop
+# and reading CapAmb back proves the capability actually survived. A static
+# assertion here would be exactly the "test that passes for the wrong reason"
+# this repo already has too many of.
+#
+# CONTROLS (both directions, all executed for real):
+#   POSITIVE : the fixed invocation           -> CapAmb bit 12 MUST be set
+#   NEGATIVE : the buggy invocation (no --inh) -> CapAmb bit 12 MUST be unset
+#              (this is the regression replay: it reproduces the outage in-test,
+#              so if a future change makes the buggy form "work", we learn it)
+#   NEGATIVE : no NET_ADMIN in the bounding set -> raise must NOT be attempted
+#   SOURCE   : the entrypoint must actually use the fixed form
+#
+# Run: bash v2/deploy/test_ambient_cap_runtime.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ENTRYPOINT="$(cd "$(dirname "$0")" && pwd)/entrypoint.sh"
+
+# CAP_NET_ADMIN is capability 12 -> mask 0x1000.
+CAP_NET_ADMIN_MASK=0x1000
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Image with setpriv (util-linux) and a non-root user to drop to.
+IMAGE="debian:bookworm-slim"
+
+# Run a shell snippet inside a container that HAS NET_ADMIN in its bounding set,
+# with an unprivileged target user created, and echo the resulting CapAmb.
+# $1 = the setpriv capability flags under test (may be empty).
+capamb_after_drop() {
+  local capflags="$1" caps_arg="$2"
+  docker run --rm $caps_arg "$IMAGE" sh -c "
+    set -e
+    apt-get update -qq >/dev/null 2>&1
+    apt-get install -y -qq util-linux >/dev/null 2>&1
+    useradd -u 1001 -m dev >/dev/null 2>&1 || true
+    setpriv $capflags --reuid dev --regid dev --init-groups \
+      sh -c 'grep -m1 \"^CapAmb:\" /proc/self/status' 2>/dev/null \
+      | awk '{print \$2}'
+  " 2>/dev/null | tr -d '[:space:]'
+}
+
+bit_set() {
+  local hex="$1"
+  [ -n "$hex" ] || return 1
+  [ $(( 0x${hex} & ${CAP_NET_ADMIN_MASK} )) -ne 0 ]
+}
+
+echo "=== #3874 ambient CAP_NET_ADMIN runtime tests ==="
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  echo "  SKIP: docker unavailable — runtime capability assertions require it"
+  echo "  (CI runs this on ubuntu-latest where docker is present)"
+  exit 0
+fi
+
+echo "-- runtime: POSITIVE control (the ENTRYPOINT'S OWN flags) --"
+# CRITICAL: these flags are EXTRACTED FROM THE ENTRYPOINT, not hardcoded here.
+# A hardcoded copy would keep passing even after the entrypoint regressed — the
+# exact "passes for the wrong reason" failure mode this repo keeps hitting. By
+# driving the container with whatever the entrypoint actually sets, a regression
+# in the entrypoint turns this runtime assertion RED.
+ENTRY_CAPS="$(sed -n 's/^[[:space:]]*_SETPRIV_CAPS="\(.*\)"[[:space:]]*$/\1/p' "$ENTRYPOINT" | head -1)"
+echo "     flags extracted from entrypoint = '${ENTRY_CAPS:-<none>}'"
+if [ -z "$ENTRY_CAPS" ]; then
+  bad "could not extract _SETPRIV_CAPS from the entrypoint — test cannot verify the real invocation"
+fi
+FIXED="$(capamb_after_drop "$ENTRY_CAPS" '--cap-add=NET_ADMIN')"
+echo "     CapAmb after entrypoint drop = ${FIXED:-<empty>}"
+if bit_set "$FIXED"; then
+  ok "ambient CAP_NET_ADMIN SURVIVES the privilege drop using the entrypoint's own flags"
+else
+  bad "ambient CAP_NET_ADMIN LOST across the privilege drop using the entrypoint's own flags — the #3874 outage condition"
+fi
+
+echo "-- runtime: NEGATIVE control (regression replay of the shipped bug) --"
+BUGGY="$(capamb_after_drop '--ambient-caps +net_admin' '--cap-add=NET_ADMIN')"
+echo "     CapAmb after buggy drop   = ${BUGGY:-<empty>}"
+if bit_set "$BUGGY"; then
+  bad "the buggy form (--ambient-caps WITHOUT --inh-caps) now yields a live ambient cap — this test can no longer distinguish fixed from broken; re-derive the control"
+else
+  ok "the buggy form still silently yields CapAmb=0 (proves the positive control above is meaningful, not vacuous)"
+fi
+
+echo "-- runtime: NEGATIVE control (no NET_ADMIN in bounding set) --"
+NOCAP="$(capamb_after_drop '--inh-caps +net_admin --ambient-caps +net_admin' '')"
+echo "     CapAmb without --cap-add  = ${NOCAP:-<empty/failed>}"
+if bit_set "$NOCAP"; then
+  bad "ambient NET_ADMIN raised despite it being absent from the bounding set"
+else
+  ok "no ambient NET_ADMIN when the bounding set lacks it (self-hosted spokes unaffected)"
+fi
+
+echo "-- source: the entrypoint uses the fixed form --"
+# Both flags must appear, and they must be in the SAME setpriv invocation.
+if grep -qE '\-\-inh-caps[[:space:]]+\+net_admin[[:space:]]+--ambient-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"; then
+  ok "entrypoint raises --inh-caps alongside --ambient-caps in one setpriv call"
+else
+  bad "entrypoint does not raise --inh-caps with --ambient-caps (#3874 would recur)"
+fi
+
+# The entrypoint must VERIFY the outcome, not trust setpriv's exit status.
+if grep -qE 'CapAmb' "$ENTRYPOINT"; then
+  ok "entrypoint verifies CapAmb after the drop rather than trusting exit status"
+else
+  bad "entrypoint does not read CapAmb back — a silent no-op would go unnoticed again"
+fi
+
+# Guard the blast radius: net_admin and nothing more.
+if grep -qE '\-\-(inh|ambient)-caps[[:space:]]+\+(?!net_admin)' "$ENTRYPOINT" 2>/dev/null \
+   || grep -qE '\-\-(inh|ambient)-caps[[:space:]]+\+all' "$ENTRYPOINT"; then
+  bad "entrypoint raises more than net_admin"
+else
+  ok "entrypoint raises net_admin only (no capability-posture widening)"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/v2/deploy/test_entrypoint_netadmin_ambient.sh
+++ b/v2/deploy/test_entrypoint_netadmin_ambient.sh
@@ -75,8 +75,19 @@ else
   echo "  PASS: entrypoint does not mask the wrong bit (0x2000 / NET_RAW)"
   PASS=$((PASS + 1))
 fi
-assert_contains 'setpriv[[:space:]]+--ambient-caps[[:space:]]+\+net_admin' \
-  "entrypoint raises an ambient NET_ADMIN cap via setpriv"
+# INVERTED (not relaxed) for #3874. The old pattern was
+#   'setpriv[[:space:]]+--ambient-caps[[:space:]]+\+net_admin'
+# which required EXACTLY the silently-broken invocation and would have gone RED
+# on the correct fix — it ENCODED the bug. `--ambient-caps` alone exits 0 but
+# leaves CapAmb=0x0: the kernel only permits an ambient bit that is also in the
+# inheritable set, and the setuid transition zeroes pI first. The contract is now
+# STRONGER — both flags are required.
+assert_contains '--inh-caps[[:space:]]+\+net_admin' \
+  "entrypoint raises NET_ADMIN into the inheritable set (required for ambient to stick — #3874)"
+assert_contains '--ambient-caps[[:space:]]+\+net_admin' \
+  "entrypoint raises an ambient NET_ADMIN cap"
+assert_contains 'setpriv' \
+  "entrypoint still performs the drop via setpriv"
 assert_contains '--reuid[[:space:]]+dev' \
   "entrypoint drops the ambient-cap path to the dev user (--reuid dev)"
 assert_contains 'exec[[:space:]]+gosu[[:space:]]+dev' \

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -876,13 +876,33 @@ func (s *Server) buildSnapshot(outputFile, mode string) {
 		"--base-path", "/snapshot",
 		"--html", htmlSource,
 		dashURL, outputFile)
-	cmd.Env = append(os.Environ(), "NODE_TLS_REJECT_UNAUTHORIZED=0")
+	// The builder fetches /api/status (and siblings) from localhost. Those
+	// endpoints require auth, so without a token the builder gets 401 and
+	// bakes an empty snapshot (blank Governor/Tokens/Cost/Repos/Beads/Agents
+	// panels, ACMM "--"). Pass s.authToken as DASHBOARD_AUTH_TOKEN so the
+	// builder authenticates via the trusted X-Hive-Internal header path. The
+	// token is used ONLY as a request header for the localhost fetch; the
+	// builder never writes it into the snapshot HTML output.
+	cmd.Env = snapshotBuilderEnv(os.Environ(), s.authToken)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		s.logger.Warn("snapshot build failed", "error", err, "output", string(out))
 	} else {
 		s.logger.Info("snapshot built", "file", outputFile)
 	}
+}
+
+// snapshotBuilderEnv returns the environment for the Node snapshot builder.
+// NODE_TLS_REJECT_UNAUTHORIZED=0 is always set for the localhost fetch. When
+// authToken is non-empty it is exposed as DASHBOARD_AUTH_TOKEN so the builder
+// can send the trusted X-Hive-Internal header and receive live data instead of
+// a 401. Open/no-auth spokes (empty token) get the prior behavior unchanged.
+func snapshotBuilderEnv(baseEnv []string, authToken string) []string {
+	env := append(baseEnv, "NODE_TLS_REJECT_UNAUTHORIZED=0")
+	if authToken != "" {
+		env = append(env, "DASHBOARD_AUTH_TOKEN="+authToken)
+	}
+	return env
 }
 
 func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/contribute_admission.go
+++ b/v2/pkg/dashboard/contribute_admission.go
@@ -1,0 +1,60 @@
+package dashboard
+
+import ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+
+type contributorAdmissionCandidate struct {
+	repoFull string
+	repoName string
+	number   int
+}
+
+type contributorAdmissionDecision struct {
+	admitted bool
+	reason   string
+	claim    ghpkg.IssueClaim
+}
+
+const contributorAdmissionReasonOpenPRClaim = "open_pr_claim"
+
+// evaluateContributorNeutralAdmission applies repository-global admission
+// decisions shared by ReadyQueue and selectTask. Contributor-specific policy,
+// ranking, cooldowns, rate limits, role matching, and routing remain in their
+// existing downstream paths.
+func (h *ContributeWSHub) evaluateContributorNeutralAdmission(candidate contributorAdmissionCandidate) contributorAdmissionDecision {
+	claim, claimed := h.issueClaimedByOpenPR(candidate.repoFull, candidate.repoName, candidate.number)
+	if claimed {
+		return contributorAdmissionDecision{
+			reason: contributorAdmissionReasonOpenPRClaim,
+			claim:  claim,
+		}
+	}
+	return contributorAdmissionDecision{admitted: true}
+}
+
+// issueClaimedByOpenPR reports whether ANY open PR already claims to fix the
+// given issue (kubestellar/hive#3768), via the Dependencies.IssueClaimed hook
+// into the governor's duplicate-PR claim ledger. Unlike the agent-side
+// FilterClaimedIssues — which deliberately honours only hive-authored claims —
+// the contribute queue must honour EVERY claim: a human contributor's open PR
+// is exactly the "someone is already on it" signal whose absence let the same
+// issue be handed to contributor after contributor.
+//
+// The ledger keys claims by the repo spelling used in the hive config, which
+// FrontendRepo.Name preserves; repo.Full is the org-qualified form and is tried
+// first since cross-repo `owner/repo#N` closing references key on it. A hub
+// with no hook wired (tests, or a hive booted without GitHub credentials)
+// reports no claims and selection proceeds exactly as before.
+func (h *ContributeWSHub) issueClaimedByOpenPR(repoFull, repoName string, number int) (ghpkg.IssueClaim, bool) {
+	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.IssueClaimed == nil {
+		return ghpkg.IssueClaim{}, false
+	}
+	if claim, ok := h.server.deps.IssueClaimed(repoFull, number); ok {
+		return claim, true
+	}
+	if repoName != "" && repoName != repoFull {
+		if claim, ok := h.server.deps.IssueClaimed(repoName, number); ok {
+			return claim, true
+		}
+	}
+	return ghpkg.IssueClaim{}, false
+}

--- a/v2/pkg/dashboard/contribute_sse.go
+++ b/v2/pkg/dashboard/contribute_sse.go
@@ -275,6 +275,14 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 			if active[fmt.Sprintf("%s#%d", repo.Full, number)] {
 				continue
 			}
+			decision := h.evaluateContributorNeutralAdmission(contributorAdmissionCandidate{
+				repoFull: repo.Full,
+				repoName: repo.Name,
+				number:   number,
+			})
+			if !decision.admitted {
+				continue
+			}
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
 			author, _ := issue["author"].(string)

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/kubestellar/hive/v2/pkg/config"
-	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
 
 const (
@@ -3319,34 +3318,6 @@ func (h *ContributeWSHub) resumeGateReason(c *ContributorConnection) string {
 	return ""
 }
 
-// issueClaimedByOpenPR reports whether ANY open PR already claims to fix the
-// given issue (kubestellar/hive#3768), via the Dependencies.IssueClaimed hook
-// into the governor's duplicate-PR claim ledger. Unlike the agent-side
-// FilterClaimedIssues — which deliberately honours only hive-authored claims —
-// the contribute queue must honour EVERY claim: a human contributor's open PR
-// is exactly the "someone is already on it" signal whose absence let the same
-// issue be handed to contributor after contributor.
-//
-// The ledger keys claims by the repo spelling used in the hive config, which
-// FrontendRepo.Name preserves; repo.Full is the org-qualified form and is tried
-// first since cross-repo `owner/repo#N` closing references key on it. A hub
-// with no hook wired (tests, or a hive booted without GitHub credentials)
-// reports no claims and selection proceeds exactly as before.
-func (h *ContributeWSHub) issueClaimedByOpenPR(repoFull, repoName string, number int) (ghpkg.IssueClaim, bool) {
-	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.IssueClaimed == nil {
-		return ghpkg.IssueClaim{}, false
-	}
-	if claim, ok := h.server.deps.IssueClaimed(repoFull, number); ok {
-		return claim, true
-	}
-	if repoName != "" && repoName != repoFull {
-		if claim, ok := h.server.deps.IssueClaimed(repoName, number); ok {
-			return claim, true
-		}
-	}
-	return ghpkg.IssueClaim{}, false
-}
-
 func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	h.selectMu.Lock()
 	defer h.selectMu.Unlock()
@@ -3631,10 +3602,17 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			// PR per window. The claim ledger sees the open PR itself on the
 			// next eval cycle, which closes that hole regardless of what the
 			// relay managed to report.
-			if claim, claimed := h.issueClaimedByOpenPR(repo.Full, repo.Name, number); claimed {
-				h.logger.Info("[contribute-ws] skip: issue already claimed by an open PR",
-					"repo", repo.Full, "number", number,
-					"pr_url", claim.PRURL, "pr_author", claim.PRAuthor)
+			decision := h.evaluateContributorNeutralAdmission(contributorAdmissionCandidate{
+				repoFull: repo.Full,
+				repoName: repo.Name,
+				number:   number,
+			})
+			if !decision.admitted {
+				if decision.reason == contributorAdmissionReasonOpenPRClaim {
+					h.logger.Info("[contribute-ws] skip: issue already claimed by an open PR",
+						"repo", repo.Full, "number", number,
+						"pr_url", decision.claim.PRURL, "pr_author", decision.claim.PRAuthor)
+				}
 				continue
 			}
 			// Yank self-exclusion: an issue this SAME clanker was just yanked off is

--- a/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
+++ b/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
@@ -89,6 +89,45 @@ func TestClaimedIssue_SkippedAndNextOffered(t *testing.T) {
 	}
 }
 
+// TestClaimedIssue_ReadyQueueMatchesSelectTaskAdmission pins the contributor
+// queue contract: repository-global admission decisions must agree between the
+// read-only ReadyQueue projection and live selectTask assignment. An open PR
+// claims #353, so both paths must withhold it while leaving #360 offerable.
+func TestClaimedIssue_ReadyQueueMatchesSelectTaskAdmission(t *testing.T) {
+	for _, claimRepo := range []string{"projectbluefin/dakota", "dakota"} {
+		t.Run(claimRepo, func(t *testing.T) {
+			hub, s := covK2Hub(t)
+			claimedIssueStatus(s)
+			s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+				if repo == claimRepo && number == 353 {
+					return externalClaim(repo, number), true
+				}
+				return ghpkg.IssueClaim{}, false
+			}
+
+			queue := hub.ReadyQueue(readyQueueDefaultLimit)
+			if len(queue) != 1 || queue[0].Number != 360 {
+				t.Fatalf("ReadyQueue should initially offer only unclaimed #360, got %+v", queue)
+			}
+
+			conn := claimedIssueConn()
+			hub.mu.Lock()
+			hub.connections["conn-a"] = conn
+			hub.mu.Unlock()
+
+			msg := hub.selectTask(conn)
+			if msg == nil || msg.Type != "task_assign" || msg.Number != 360 {
+				t.Fatalf("selectTask should skip claimed #353 and assign #360, got %+v", msg)
+			}
+
+			queue = hub.ReadyQueue(readyQueueDefaultLimit)
+			if len(queue) != 0 {
+				t.Fatalf("ReadyQueue should be empty while #360 is active, got %+v", queue)
+			}
+		})
+	}
+}
+
 // TestClaimedIssue_AllClaimedYieldsNoMatchingWork: when every admissible issue
 // is claimed by an open PR, the contributor gets an explicit no_matching_work
 // negative-ack — never a duplicate assignment.

--- a/v2/pkg/dashboard/snapshot_test.go
+++ b/v2/pkg/dashboard/snapshot_test.go
@@ -277,6 +277,43 @@ func TestSnapshotAPINoSecretsEmbedded(t *testing.T) {
 	}
 }
 
+// TestSnapshotBuilderEnvPassesAuthToken is the regression test for the empty
+// /snapshot page: the Node snapshot builder fetches /api/status unauthenticated
+// and gets 401 unless DASHBOARD_AUTH_TOKEN is supplied. When the server has an
+// auth token it MUST be exposed to the builder (as the trusted X-Hive-Internal
+// credential); when there is no token the env must be left unchanged so open
+// spokes keep working.
+func TestSnapshotBuilderEnvPassesAuthToken(t *testing.T) {
+	const token = "test-internal-token-1234"
+
+	// With a token: DASHBOARD_AUTH_TOKEN must be present with that value.
+	env := snapshotBuilderEnv([]string{"PATH=/usr/bin"}, token)
+	var gotToken string
+	var haveTLS bool
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, "DASHBOARD_AUTH_TOKEN="); ok {
+			gotToken = v
+		}
+		if kv == "NODE_TLS_REJECT_UNAUTHORIZED=0" {
+			haveTLS = true
+		}
+	}
+	if !haveTLS {
+		t.Error("snapshotBuilderEnv must always set NODE_TLS_REJECT_UNAUTHORIZED=0")
+	}
+	if gotToken != token {
+		t.Errorf("DASHBOARD_AUTH_TOKEN = %q, want %q — builder would fetch /api/status unauthenticated and bake an empty snapshot", gotToken, token)
+	}
+
+	// Without a token: DASHBOARD_AUTH_TOKEN must NOT be added (open spokes).
+	env = snapshotBuilderEnv([]string{"PATH=/usr/bin"}, "")
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "DASHBOARD_AUTH_TOKEN=") {
+			t.Errorf("snapshotBuilderEnv added %q for an empty token — must leave no-auth spokes unchanged", kv)
+		}
+	}
+}
+
 func TestSnapshotFrameAncestorsEndpoint(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.Dashboard.SnapshotFrameAncestors = []string{"https://docs.projectbluefin.io"}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1384,6 +1384,22 @@
     /* Cost panel — mirrors token-panel styling */
     .cost-panel { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
     .cost-title { font-size: var(--fs-lg); font-weight: 700; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; }
+    /* Collapsible cost panel — reuses the .section-chevron / max-height idiom (#1533). */
+    .cost-title.cost-toggle { cursor: pointer; user-select: none; width: 100%; }
+    .cost-title.cost-toggle:hover { opacity: 0.85; }
+    .cost-chevron {
+      display: inline-block; font-size: 0.7em; transition: transform 200ms ease;
+      color: var(--muted); flex-shrink: 0;
+    }
+    .cost-chevron.collapsed { transform: rotate(-90deg); }
+    /* Compact total shown only while collapsed, so the header still carries the headline number. */
+    .cost-collapsed-total { display: none; font-size: 0.75rem; font-weight: 600; color: var(--muted); margin-left: auto; }
+    .cost-panel.collapsed .cost-collapsed-total { display: inline; }
+    .cost-body {
+      overflow: hidden; transition: max-height 200ms ease, opacity 200ms ease;
+      max-height: 8000px; opacity: 1;
+    }
+    .cost-body.collapsed { max-height: 0 !important; opacity: 0; pointer-events: none; }
     .cost-subtitle { font-size: 0.7rem; color: var(--muted); margin-bottom: 12px; }
     .cost-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; margin-bottom: 14px; }
     .cost-stat { text-align: left; }
@@ -8142,6 +8158,47 @@ function burnAreaChart() {
     // Last cost payload, so the range pills can re-render the trend chart
     // instantly (client-only bucketing) without waiting for the next poll.
     let _lastCost = null;
+    // ── Collapsible cost panel (mirrors the toggleSection idiom, #1533) ──
+    // The cost panel is fully rebuilt via innerHTML on every /api/cost poll, so
+    // the collapsed state cannot live only in the DOM — it is persisted in
+    // localStorage and re-applied after each render so a poll never re-expands it.
+    const COST_COLLAPSED_LS_KEY = 'hive-cost-collapsed';
+    function isCostCollapsed() {
+      return localStorage.getItem(COST_COLLAPSED_LS_KEY) === '1';
+    }
+    function setCostCollapsed(collapsed) {
+      if (collapsed) localStorage.setItem(COST_COLLAPSED_LS_KEY, '1');
+      else localStorage.removeItem(COST_COLLAPSED_LS_KEY);
+    }
+    /** Reflect the persisted collapsed state onto the current cost-panel DOM. */
+    function applyCostCollapse() {
+      const panel = document.querySelector('#cost-panel .cost-panel');
+      if (!panel) return;
+      const collapsed = isCostCollapsed();
+      const body = panel.querySelector('.cost-body');
+      const chevron = panel.querySelector('.cost-chevron');
+      const header = panel.querySelector('.cost-title');
+      panel.classList.toggle('collapsed', collapsed);
+      if (body) body.classList.toggle('collapsed', collapsed);
+      if (chevron) {
+        chevron.classList.toggle('collapsed', collapsed);
+        chevron.textContent = '▼';
+      }
+      if (header) header.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    }
+    /** Toggle collapsed state on click / keyboard, persist, and animate. */
+    function toggleCostPanel() {
+      setCostCollapsed(!isCostCollapsed());
+      applyCostCollapse();
+    }
+    /** Enter/Space activate the header like a button. */
+    function costHeaderKey(ev) {
+      if (ev.key === 'Enter' || ev.key === ' ' || ev.key === 'Spacebar') {
+        ev.preventDefault();
+        toggleCostPanel();
+      }
+    }
+
     function renderCost(cost) {
       const el = document.getElementById('cost-panel');
       if (!el) return;
@@ -8295,22 +8352,30 @@ function burnAreaChart() {
         </table>`;
 
       el.innerHTML = `<div class="cost-panel">
-        <div class="cost-title">Cost <span class="cost-badge est" title="Estimated from token counts × list prices; subscription/self-hosted billing may differ">est.</span></div>
-        <div class="cost-subtitle">Estimated from token counts × list prices (as of ${esc(cost.price_table_date || '')}); models without an exact price use a coarse tier estimate (~). Where a metered gateway reports actual spend it refines the estimate, but the figure is always an estimate.</div>
-        <div class="cost-grid">
-          <div class="cost-stat"><div class="cval">${fmtUSD(est.total_usd)}<span class="cost-badge est">est.</span></div><div class="clabel">estimated total — all-time cumulative (token × list price)</div>${costSparkSvg()}</div>
+        <div class="cost-title cost-toggle" role="button" tabindex="0" aria-expanded="true" aria-controls="cost-panel-body" onclick="toggleCostPanel()" onkeydown="costHeaderKey(event)" title="Collapse / expand the cost panel">
+          <span class="cost-chevron" aria-hidden="true">▼</span>
+          Cost <span class="cost-badge est" title="Estimated from token counts × list prices; subscription/self-hosted billing may differ">est.</span>
+          <span class="cost-collapsed-total" title="Estimated all-time total">${fmtUSD(est.total_usd)}</span>
         </div>
-        ${costTrendHtml()}
-        ${gwCards ? `<div class="cost-gateways">${gwCards}</div>` : ''}
-        <table class="cost-table">
-          <thead><tr><th>model</th><th style="text-align:center" title="Running agents on this model right now — hover the count for names">running agents</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
-          <tbody>${modelRows || '<tr><td colspan="5" style="color:var(--muted)">no usage yet</td></tr>'}</tbody>
-        </table>
-        ${sandboxTable}
-        ${sessionTable}
-        ${unpricedNote}
-        <div class="cost-disclaimer">${esc(cost.disclaimer || '')} vLLM / self-hosted figures are estimated (reflect list price, not your infra cost).</div>
+        <div class="cost-body" id="cost-panel-body">
+          <div class="cost-subtitle">Estimated from token counts × list prices (as of ${esc(cost.price_table_date || '')}); models without an exact price use a coarse tier estimate (~). Where a metered gateway reports actual spend it refines the estimate, but the figure is always an estimate.</div>
+          <div class="cost-grid">
+            <div class="cost-stat"><div class="cval">${fmtUSD(est.total_usd)}<span class="cost-badge est">est.</span></div><div class="clabel">estimated total — all-time cumulative (token × list price)</div>${costSparkSvg()}</div>
+          </div>
+          ${costTrendHtml()}
+          ${gwCards ? `<div class="cost-gateways">${gwCards}</div>` : ''}
+          <table class="cost-table">
+            <thead><tr><th>model</th><th style="text-align:center" title="Running agents on this model right now — hover the count for names">running agents</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
+            <tbody>${modelRows || '<tr><td colspan="5" style="color:var(--muted)">no usage yet</td></tr>'}</tbody>
+          </table>
+          ${sandboxTable}
+          ${sessionTable}
+          ${unpricedNote}
+          <div class="cost-disclaimer">${esc(cost.disclaimer || '')} vLLM / self-hosted figures are estimated (reflect list price, not your infra cost).</div>
+        </div>
       </div>`;
+      // Re-apply the persisted collapsed state so a poll re-render never resets it.
+      applyCostCollapse();
     }
 
     async function fetchCost() {

--- a/v2/pkg/github/proxytrust.go
+++ b/v2/pkg/github/proxytrust.go
@@ -69,6 +69,15 @@ type proxyTrustPool struct {
 	caModTime  time.Time
 	caSize     int64
 	lastReload time.Time
+
+	// transport is the process-wide shared HTTP transport for every
+	// JWT/token-mint client, rebuilt only when the RootCAs pool itself is
+	// rebuilt. transportPool records which pool the cached transport carries
+	// so a pool rebuild (CA appearing/rotating) invalidates it. See
+	// sharedTransport for why sharing (rather than a transport per call) is
+	// load-bearing and not merely an optimization (#3875).
+	transport     *http.Transport
+	transportPool *x509.CertPool
 }
 
 // certPool returns a RootCAs pool trusting the system roots plus the proxy CA
@@ -100,7 +109,15 @@ func (t *proxyTrustPool) certPool() *x509.CertPool {
 			// became briefly unreadable; do not downgrade an established trust.
 			return t.pool
 		}
-		return systemOnlyPool()
+		// Cache the system-only fallback so callers see a STABLE pool pointer
+		// while the CA is absent — sharedTransport keys transport reuse on
+		// pool identity, and a fresh clone per call would rebuild the
+		// transport (and drop its keep-alive pool) on every advisory-mode
+		// mint. The stat-succeeds path above still rebuilds the moment the CA
+		// file appears, because caModTime/caSize have never been recorded for
+		// it.
+		t.pool = systemOnlyPool()
+		return t.pool
 	}
 
 	// Rebuild only when the file actually changed since we last loaded it.
@@ -149,19 +166,37 @@ func systemOnlyPool() *x509.CertPool {
 // per call.
 var sharedProxyTrust = &proxyTrustPool{}
 
-// proxyTrustingHTTPClient returns an *http.Client whose TLS RootCAs trust the
-// system roots plus the in-process proxy CA (lazily reloaded from disk). This
-// is the client the App-JWT / installation-token mint calls use so a fresh-PVC
-// boot trusts the proxy CA from the FIRST mint attempt, independent of
-// SSL_CERT_FILE or the entrypoint's launch ordering.
+// sharedTransport returns the process-wide *http.Transport carrying the
+// current (system roots + proxy CA) pool, building a new one only when the
+// pool itself has been rebuilt (the CA appearing on first boot, or rotating).
+// The superseded transport gets CloseIdleConnections so its pooled sockets are
+// reclaimed immediately instead of lingering until the peer or the idle reaper
+// gets around to them.
 //
-// The transport clones http.DefaultTransport (preserving proxy/keep-alive/
-// timeout defaults) and installs the RootCAs pool. crypto/tls has no
-// per-handshake roots hook, so the pool is captured at client construction —
-// but a fresh client is built for each short-lived mint call, so the pool is
-// re-read (subject to certPool's own reload interval) each time, and a CA that
-// appears after process start is trusted on the next mint.
-func proxyTrustingHTTPClient(timeout time.Duration) *http.Client {
+// Sharing ONE transport across mint calls is load-bearing, not an
+// optimization (#3875): the previous shape — a freshly cloned Transport per
+// call — meant every mint/token call dialed a brand-new connection and then
+// orphaned it in a single-use idle pool that no future call could ever reuse
+// and nothing ever explicitly closed. Under a retry loop against a slow
+// GitHub, that manufactured sockets at the exact moment the process could
+// least afford them. With a shared transport, keep-alive reuse actually
+// happens, and Go's idle-pool accounting (IdleConnTimeout, per-host caps,
+// inherited from http.DefaultTransport) governs one pool instead of one pool
+// per historical call.
+//
+// crypto/tls has no per-handshake roots hook, so the pool is captured at
+// transport construction; certPool()'s own reload interval keeps it fresh, and
+// a CA that appears after process start yields a new pool pointer — which is
+// exactly the signal used here to rebuild the transport for the next mint.
+func (t *proxyTrustPool) sharedTransport() *http.Transport {
+	pool := t.certPool()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.transport != nil && t.transportPool == pool {
+		return t.transport
+	}
+
 	var transport *http.Transport
 	if base, ok := http.DefaultTransport.(*http.Transport); ok {
 		transport = base.Clone()
@@ -173,11 +208,30 @@ func proxyTrustingHTTPClient(timeout time.Duration) *http.Client {
 	} else {
 		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
 	}
-	// certPool returns (system roots + proxy CA), or a system-only pool while
-	// the CA does not yet exist. nil would also mean "system roots", so the
+	// pool is (system roots + proxy CA), or a system-only pool while the CA
+	// does not yet exist. nil also means "system roots" to crypto/tls, so the
 	// direct-HTTPS (advisory mode) path is never broken.
-	transport.TLSClientConfig.RootCAs = sharedProxyTrust.certPool()
-	return &http.Client{Transport: transport, Timeout: timeout}
+	transport.TLSClientConfig.RootCAs = pool
+
+	if old := t.transport; old != nil {
+		old.CloseIdleConnections()
+	}
+	t.transport = transport
+	t.transportPool = pool
+	return transport
+}
+
+// proxyTrustingHTTPClient returns an *http.Client whose TLS RootCAs trust the
+// system roots plus the in-process proxy CA (lazily reloaded from disk). This
+// is the client the App-JWT / installation-token mint calls use so a fresh-PVC
+// boot trusts the proxy CA from the FIRST mint attempt, independent of
+// SSL_CERT_FILE or the entrypoint's launch ordering.
+//
+// The client wrapper is per-call (it only carries the timeout); the transport
+// underneath — the part that owns sockets — is shared and reaped, see
+// sharedTransport.
+func proxyTrustingHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Transport: sharedProxyTrust.sharedTransport(), Timeout: timeout}
 }
 
 // newJWTClient builds a go-github client authenticated with an App JWT whose

--- a/v2/pkg/github/proxytrust_transport_leak_test.go
+++ b/v2/pkg/github/proxytrust_transport_leak_test.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Regressions for the client-side half of issue #3875: every JWT/token-mint
+// call built a freshly cloned http.Transport, dialed a brand-new connection,
+// and then orphaned it in a single-use idle pool nothing ever reused or
+// explicitly closed — one manufactured socket per call, at the exact moment
+// (a slow GitHub, a hot retry loop) the process could least afford them. The
+// fix shares ONE process-wide transport, rebuilt (and its predecessor's idle
+// pool reaped via CloseIdleConnections) only when the RootCAs pool changes.
+
+// TestProxyTrustingHTTPClient_SharesTransport asserts transport identity is
+// stable across mint clients while the CA is unchanged — the property that
+// makes keep-alive reuse possible at all.
+func TestProxyTrustingHTTPClient_SharesTransport(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "proxy-ca.pem")
+	writeTestCA(t, caPath)
+	withProxyCAPath(t, caPath)
+
+	c1 := proxyTrustingHTTPClient(mintClientTimeout)
+	c2 := proxyTrustingHTTPClient(mintClientTimeout)
+	if c1 == c2 {
+		t.Fatal("clients must be per-call wrappers (they carry per-call timeouts)")
+	}
+	if c1.Transport != c2.Transport {
+		t.Fatal("mint clients must share ONE transport — a transport per call orphans a socket per call (#3875)")
+	}
+}
+
+// TestProxyTrustingHTTPClient_RebuildsTransportOnCAChange asserts the shared
+// transport is invalidated when the proxy CA rotates (pool rebuild), so a
+// fresh-PVC boot still picks up the CA written after process start — the
+// guarantee the old per-call construction provided implicitly.
+func TestProxyTrustingHTTPClient_RebuildsTransportOnCAChange(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "proxy-ca.pem")
+	withProxyCAPath(t, caPath)
+
+	before := sharedProxyTrust.sharedTransport() // CA absent: system-only trust
+
+	writeTestCA(t, caPath)
+	sharedProxyTrust.mu.Lock()
+	sharedProxyTrust.lastReload = time.Now().Add(-2 * proxyCAReloadInterval)
+	sharedProxyTrust.mu.Unlock()
+
+	after := sharedProxyTrust.sharedTransport()
+	if before == after {
+		t.Fatal("transport must be rebuilt when the proxy CA appears — otherwise the mint never trusts a CA written after start")
+	}
+	if after.TLSClientConfig == nil || after.TLSClientConfig.RootCAs == nil {
+		t.Fatal("rebuilt transport must carry the (system + proxy CA) RootCAs pool")
+	}
+	// And stay stable once rebuilt.
+	if again := sharedProxyTrust.sharedTransport(); again != after {
+		t.Fatal("transport must be stable while the CA is unchanged")
+	}
+}
+
+// TestProxyTrustingHTTPClient_ReusesConnections is the leak-count regression:
+// N sequential mint-style calls (a fresh client wrapper per call, exactly as
+// newJWTClient/newTokenClient construct them) against one TLS server must
+// ride a small number of underlying connections. Pre-fix this was one NEW
+// connection per call — the per-call socket manufacturing measured live as
+// part of the #3875 FD pile.
+func TestProxyTrustingHTTPClient_ReusesConnections(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "proxy-ca.pem")
+	withProxyCAPath(t, caPath)
+
+	var connsOpened atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	srv.Config.ConnState = func(c net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			connsOpened.Add(1)
+		}
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	// Trust the test server exactly the way production trusts the MITM proxy:
+	// its cert PEM at proxyCAPath (self-signed, so it is its own root).
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	if err := os.WriteFile(caPath, certPEM, 0o644); err != nil {
+		t.Fatalf("write server cert as proxy CA: %v", err)
+	}
+	if _, err := x509.ParseCertificate(srv.Certificate().Raw); err != nil {
+		t.Fatalf("parse server cert: %v", err)
+	}
+
+	const calls = 6
+	for i := 0; i < calls; i++ {
+		client := proxyTrustingHTTPClient(mintClientTimeout) // fresh wrapper per call, like every mint
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	// Keep-alive reuse must hold: allow a little slack for a mid-run
+	// CA-pool/transport settle, but nothing close to one conn per call.
+	const maxConns = 2
+	if got := connsOpened.Load(); got > maxConns {
+		t.Fatalf("%d calls opened %d connections (want <= %d) — per-call transports are manufacturing sockets again (#3875)", calls, got, maxConns)
+	}
+}

--- a/v2/pkg/hub/fd_gauge.go
+++ b/v2/pkg/hub/fd_gauge.go
@@ -1,0 +1,36 @@
+package hub
+
+import "os"
+
+// fdDirs are the per-process file-descriptor listings tried in order:
+// /proc/self/fd on Linux (the production container target), /dev/fd as the
+// BSD/macOS dev-machine fallback.
+var fdDirs = []string{"/proc/self/fd", "/dev/fd"}
+
+// OpenFDCount returns the number of file descriptors this process currently
+// holds, or 0 when it cannot be determined. It exists for the heartbeat FD
+// gauge (see HeartbeatPayload.OpenFDs, #3875): a leak that self-DoSed spokes
+// at 92k FDs was invisible until someone hand-inspected /proc. A directory
+// read costs microseconds at healthy FD counts and is paid once per beat.
+//
+// Callers must treat 0 as UNKNOWN, not as "no descriptors": a live process
+// always holds at least the directory handle used for the read itself.
+//
+// Readdirnames, not os.ReadDir: ReadDir lstats entries whose type the
+// filesystem does not report, and on /dev/fd that stats the listing's own
+// (already-consumed) descriptor — "bad file descriptor" instead of a count.
+// Names alone are all a count needs.
+func OpenFDCount() int {
+	for _, dir := range fdDirs {
+		f, err := os.Open(dir)
+		if err != nil {
+			continue
+		}
+		names, err := f.Readdirnames(-1)
+		f.Close()
+		if err == nil {
+			return len(names)
+		}
+	}
+	return 0
+}

--- a/v2/pkg/hub/fd_gauge_other.go
+++ b/v2/pkg/hub/fd_gauge_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package hub
+
+// FDSoftLimit has no meaningful value off unix (dev/Windows builds); return 0,
+// which readers already treat as UNKNOWN. The production target is Linux.
+func FDSoftLimit() uint64 { return 0 }

--- a/v2/pkg/hub/fd_gauge_test.go
+++ b/v2/pkg/hub/fd_gauge_test.go
@@ -1,0 +1,44 @@
+package hub
+
+import (
+	"os"
+	"testing"
+)
+
+// TestOpenFDCountReportsLiveDescriptors pins the gauge to reality: it must
+// report a positive count on the platforms we build on (Linux containers in
+// production, macOS dev machines), and the count must move when descriptors
+// are opened. A gauge that silently reads 0 would report UNKNOWN forever and
+// reintroduce exactly the blindness #3875 showed (92,962 leaked FDs found
+// only by manual /proc inspection).
+func TestOpenFDCountReportsLiveDescriptors(t *testing.T) {
+	base := OpenFDCount()
+	if base <= 0 {
+		t.Fatalf("OpenFDCount() = %d, want > 0 — a live process always holds descriptors", base)
+	}
+
+	const extra = 8
+	files := make([]*os.File, 0, extra)
+	for i := 0; i < extra; i++ {
+		f, err := os.Open(os.DevNull)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		files = append(files, f)
+	}
+	grown := OpenFDCount()
+	for _, f := range files {
+		f.Close()
+	}
+	if grown < base+extra {
+		t.Fatalf("OpenFDCount() = %d after opening %d more (baseline %d) — gauge does not track real descriptors", grown, extra, base)
+	}
+}
+
+// TestFDSoftLimitPositiveOnUnix: the rlimit companion must be readable where
+// the daemon actually runs.
+func TestFDSoftLimitPositiveOnUnix(t *testing.T) {
+	if got := FDSoftLimit(); got == 0 {
+		t.Fatalf("FDSoftLimit() = 0 on a unix build — the ulimit-relative gauge would read UNKNOWN")
+	}
+}

--- a/v2/pkg/hub/fd_gauge_unix.go
+++ b/v2/pkg/hub/fd_gauge_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package hub
+
+import "syscall"
+
+// FDSoftLimit returns the RLIMIT_NOFILE soft limit for this process, or 0 when
+// it cannot be read. Reported alongside OpenFDCount in the heartbeat so the
+// gauge is ulimit-relative — 20k open FDs is an emergency under a 65k limit
+// and routine under 1M (#3875).
+func FDSoftLimit() uint64 {
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
+		return 0
+	}
+	return uint64(rl.Cur)
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -475,6 +475,16 @@ type HeartbeatPayload struct {
 	// but restarted 35 times — is visible in My Hives instead of looking
 	// healthy. A short uptime that keeps resetting is the tell.
 	StartedAt string `json:"started_at,omitempty"`
+	// OpenFDs is the spoke process's open file-descriptor count at beat time,
+	// with FDSoftLimit the RLIMIT_NOFILE soft cap it is burning toward. They
+	// exist because #3875's leak — tens of thousands of CLOSE_WAIT sockets to
+	// GitHub — reached 92,962 FDs and total self-DoS with NOTHING surfacing
+	// it; it took a manual /proc inspection to find. A gauge in the beat makes
+	// the next FD leak a visible climbing number instead of an outage
+	// forensics exercise. Zero means "could not be read / old spoke" and must
+	// be treated as UNKNOWN, never as "no descriptors open".
+	OpenFDs     int    `json:"open_fds,omitempty"`
+	FDSoftLimit uint64 `json:"fd_soft_limit,omitempty"`
 	// Reporter identifies the spoke PROCESS that sent this beat as
 	// "<pod-name>/<pid>" (hostname/PID; older spokes send the bare hostname).
 	// It exists because two spoke instances can report as the same hive_id —

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -24,6 +24,15 @@ import (
 )
 
 const (
+	// heartbeatTimeout bounds BOTH the collect() budget and the POST to the hub.
+	//
+	// DELIBERATELY NOT RAISED. A longer budget does not decouple liveness from
+	// third-party availability — it only moves the threshold at which a slow or
+	// rate-limited api.github.com starts making healthy spokes look dead, at the
+	// cost of a slower heartbeat loop for everyone. The fix for that coupling is
+	// structural (send an identity-only beat when no stats are available; see
+	// minimalLivenessPayload), so 10s stays: long enough for a healthy collect,
+	// short enough that the loop keeps ticking well inside staleThreshold.
 	heartbeatTimeout = 10 * time.Second
 	staleThreshold   = 15 * time.Minute
 )
@@ -114,6 +123,81 @@ var lastGoodPayload = struct {
 	sync.Mutex
 	payload *HeartbeatPayload
 }{}
+
+// heartbeatIdentity holds the CHEAP, purely-local identity of this spoke — the
+// fields that come straight from config and never require a network call.
+//
+// WHY (the GitHub-dependent-liveness outage): the last-good cache above can
+// only help a spoke that has completed at least one collect. A spoke that has
+// just restarted has no cache, and collect() reaches api.github.com (owner
+// token validation, plus MTTR/actionable-item enumeration feeding the same
+// pass). On a hive with real repos that enumeration exceeds the 10s collect
+// budget on EVERY early cycle, so `cached == nil` skipped every beat and a
+// perfectly healthy spoke read OFFLINE until it happened to get one fast
+// collect. Observed exactly this: placeholder hives (nothing to enumerate)
+// recovered instantly while named tenants with real repos stayed offline.
+//
+// Liveness is a property of THIS process, not of GitHub's availability. So we
+// publish identity as soon as it is known (before any collect runs) and use it
+// to send a minimal beat when there is nothing else to send. A third-party API
+// being slow, rate-limited or down must never make the fleet look dead.
+//
+// Guarded by a mutex for the same reason as lastGoodPayload: written once at
+// loop start, read by the sender goroutine on every timed-out beat.
+var heartbeatIdentity = struct {
+	sync.Mutex
+	payload *HeartbeatPayload
+}{}
+
+// publishHeartbeatIdentity records the collect-independent identity of this
+// spoke so a beat can always be addressed to the right hive, even when no
+// collect has ever succeeded. Only non-empty identities are stored.
+func publishHeartbeatIdentity(p *HeartbeatPayload) {
+	if p == nil || p.HiveID == "" {
+		return
+	}
+	c := *p
+	heartbeatIdentity.Lock()
+	heartbeatIdentity.payload = &c
+	heartbeatIdentity.Unlock()
+}
+
+// PublishHeartbeatIdentity registers this spoke's collect-independent identity
+// (hive id, org, reporter, started-at, git hash) so the heartbeat loop can send
+// a liveness beat before — or without ever — completing a stats collect.
+//
+// Call this as soon as config is loaded, BEFORE StartHeartbeat. It is the piece
+// that makes liveness independent of GitHub: without it, a spoke that restarts
+// while GitHub is slow has nothing it can legitimately address to the hub.
+func PublishHeartbeatIdentity(hiveID, org, reporter, startedAt, gitHash string) {
+	publishHeartbeatIdentity(&HeartbeatPayload{
+		HiveID:    hiveID,
+		Org:       org,
+		Reporter:  reporter,
+		StartedAt: startedAt,
+		GitHash:   gitHash,
+	})
+}
+
+// minimalLivenessPayload builds a beat that asserts ONLY "this spoke process is
+// alive and its loop is ticking", with no collected stats at all.
+//
+// It is marked StatsStale so the hub keeps the hive online and advances
+// lastHeartbeat (the documented contract of that field) without treating the
+// absent agent/fleet numbers as freshly-observed zeros. Returns nil when the
+// identity is not yet known, which is the only genuinely unsendable case.
+func minimalLivenessPayload() *HeartbeatPayload {
+	heartbeatIdentity.Lock()
+	id := heartbeatIdentity.payload
+	heartbeatIdentity.Unlock()
+	if id == nil {
+		return nil
+	}
+	c := *id
+	// No stats were collected this cycle. Carry identity only, and say so.
+	c.StatsStale = true
+	return &c
+}
 
 // storeUnixOrZero stores t as unix seconds, or 0 for the zero time so it
 // reads back as "never happened" through the Last* accessors.
@@ -916,10 +1000,28 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	if payload == nil {
 		cached := loadLastGoodPayload()
 		if cached == nil {
-			// No successful collect yet — genuinely nothing to send. Rare: only
-			// the first beats before any collect has ever finished in time.
-			logger.Warn("hub heartbeat collect timed out and no cached payload yet — skipping this beat; loop keeps ticking so liveness stays green")
-			return nil
+			// No successful collect yet. This is NOT a reason to stay silent:
+			// liveness is a property of this process, and collect() depends on
+			// api.github.com (owner-token validation, MTTR/actionable-item
+			// enumeration), which on a hive with real repos routinely exceeds
+			// the collect budget on every early cycle after a restart. Skipping
+			// here made healthy spokes read OFFLINE whenever GitHub was slow or
+			// rate-limited — the fleet looking dead because a third party was.
+			//
+			// Send a minimal identity-only beat instead: no stats, marked
+			// StatsStale, which the hub already treats as "keep this hive
+			// online, don't trust the numbers".
+			minimal := minimalLivenessPayload()
+			if minimal == nil {
+				// Identity genuinely unknown (loop started before config was
+				// published). Nothing can be addressed to a hive yet.
+				logger.Warn("hub heartbeat collect timed out and hive identity not yet known — skipping this beat; loop keeps ticking so liveness stays green")
+				return nil
+			}
+			logger.Warn("hub heartbeat collect timed out with no cached payload — sending MINIMAL liveness beat (identity only, no stats) so the hub keeps this hive online; loop keeps ticking so liveness stays green")
+			payload = minimal
+			payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
+			return postHeartbeatToHub(ctx, hubURL, payload, logger)
 		}
 		// Send the cached stats so the hub keeps the hive online through the
 		// stall. Mark them stale so the hub does not treat the agent/fleet
@@ -931,6 +1033,10 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		// Fresh collect: remember it (a clone, so the in-place filtering below
 		// never mutates the cache) for the next time collect() times out.
 		storeLastGoodPayload(payload)
+		// Keep the collect-independent identity current from the authoritative
+		// source, so a LATER restart-free identity change (e.g. git hash after
+		// an upgrade) is reflected in any minimal beat we may need to send.
+		publishHeartbeatIdentity(payload)
 	}
 	payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	payload.PublicURLSelfCheck = publicURLSelfCheckFor(ctx, payload.DashboardURL, logger)
@@ -952,6 +1058,19 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	}
 	payload.Agents = filteredAgents
 
+	return postHeartbeatToHub(ctx, hubURL, payload, logger)
+}
+
+// postHeartbeat marshals and POSTs a beat to the hub, records success on
+// acceptance, and decodes the hub's response.
+//
+// Named ...ToHub to avoid colliding with the pkg-local test helper postHeartbeat.
+// Extracted from sendHeartbeat so the MINIMAL liveness beat (no cached payload,
+// collect timed out) travels the EXACT same path as a normal beat: same auth
+// header, same timeout, same recordHeartbeatSuccess accounting, same response
+// handling — including hub-instructed upgrades. A separate ad-hoc POST would
+// drift from this one over time and silently lose those behaviours.
+func postHeartbeatToHub(ctx context.Context, hubURL string, payload *HeartbeatPayload, logger *slog.Logger) *HeartbeatResponse {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		logger.Warn("hub heartbeat marshal failed", "error", err)

--- a/v2/pkg/hub/heartbeat_send_on_collect_timeout_test.go
+++ b/v2/pkg/hub/heartbeat_send_on_collect_timeout_test.go
@@ -150,17 +150,35 @@ func TestSendHeartbeat_TimedOutCollectStillAdvancesAttempt(t *testing.T) {
 	}
 }
 
-// TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips proves the one case that
-// still skips: a collect() that times out before ANY collect has ever
-// succeeded has no cached identity to send, so it skips the beat (but the loop
-// still ticks — attempt advanced, no success).
-func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips(t *testing.T) {
+// TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness is the
+// INVERSION of the former TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips.
+//
+// WHY IT WAS INVERTED, NOT RELAXED: that test asserted `posts == 0` — it
+// ENCODED the outage. Skipping the beat is exactly what made healthy spokes
+// read OFFLINE: collect() reaches api.github.com, and on a hive with real repos
+// the issue/PR/MTTR enumeration exceeds the collect budget on every early cycle
+// after a restart, so a just-restarted spoke had no cache, POSTed nothing, and
+// went offline while being perfectly alive. Placeholder hives (nothing to
+// enumerate) recovered instantly, which is the fingerprint of a GitHub-coupled
+// liveness path.
+//
+// The corrected contract: with an identity published, a spoke that has NEVER
+// completed a collect MUST still report liveness — identity only, no stats,
+// marked StatsStale.
+func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness(t *testing.T) {
 	t.Cleanup(ResetHeartbeatStateForTest)
 	ResetHeartbeatStateForTest()
 
+	// Identity is known (published at startup) but NO collect has ever run.
+	PublishHeartbeatIdentity("fresh-hive", "org", "pod-1", "2026-01-01T00:00:00Z", "abc1234")
+
 	var posts atomic.Int32
+	got := make(chan HeartbeatPayload, 8)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		posts.Add(1)
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		got <- p
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -182,15 +200,109 @@ func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheSkips(t *testing.T) {
 		t.Fatal("sendHeartbeat did not return on a first-beat wedged collect — the loop would freeze")
 	}
 
-	if got := posts.Load(); got != 0 {
-		t.Fatalf("first-beat timeout with no cache should POST nothing, got %d POSTs", got)
+	if n := posts.Load(); n != 1 {
+		t.Fatalf("first-beat timeout with no cache POSTed %d beats, want 1 — a healthy spoke that cannot reach GitHub must still report liveness or the hub marks it OFFLINE", n)
+	}
+	p := <-got
+	if p.HiveID != "fresh-hive" {
+		t.Errorf("minimal beat carried hive_id %q, want fresh-hive — the hub could not attribute the beat", p.HiveID)
+	}
+	if !p.StatsStale {
+		t.Error("minimal beat was not marked StatsStale — the hub would treat absent stats as freshly-observed zeros")
 	}
 	att, ok := LastHeartbeatAttempt()
 	if !ok || att.Before(before) {
-		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt even on a skipped first beat", att, ok)
+		t.Errorf("LastHeartbeatAttempt() = (%v, %v), want a fresh attempt", att, ok)
+	}
+	// The beat WAS delivered, so success must advance — this is what keeps the
+	// hub's lastHeartbeat moving and the hive online.
+	suc, ok := LastHeartbeatSuccess()
+	if !ok || suc.Before(before) {
+		t.Errorf("LastHeartbeatSuccess() = (%v, %v), want a fresh success — the minimal beat was accepted by the hub", suc, ok)
+	}
+}
+
+// TestSendHeartbeat_NoCacheAndNoIdentityStillSkips is the NEGATIVE control for
+// the test above. The minimal-beat path must not invent a beat out of nothing:
+// with no cache AND no published identity there is no hive the beat could be
+// attributed to, so skipping remains correct. Without this control, the
+// inverted test above could be satisfied by unconditionally POSTing garbage.
+func TestSendHeartbeat_NoCacheAndNoIdentityStillSkips(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest() // clears identity too
+
+	var posts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	done := make(chan struct{})
+	go func() {
+		sendHeartbeat(context.Background(), server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(heartbeatTimeout + 5*time.Second):
+		t.Fatal("sendHeartbeat did not return on a wedged collect — the loop would freeze")
+	}
+
+	if n := posts.Load(); n != 0 {
+		t.Fatalf("with no cache and no identity, sendHeartbeat POSTed %d beats, want 0 — a beat with no hive_id cannot be attributed", n)
 	}
 	if _, ok := LastHeartbeatSuccess(); ok {
-		t.Error("LastHeartbeatSuccess() ok = true, want false: the first beat was skipped, nothing was delivered")
+		t.Error("LastHeartbeatSuccess() ok = true, want false: nothing was delivered")
+	}
+}
+
+// TestSendHeartbeat_CachedPayloadPreferredOverMinimal proves the pre-existing
+// behaviour did NOT regress: when a last-good cache EXISTS, a timed-out beat
+// must still send the cached STATS, not the stats-less minimal beat. The
+// minimal beat is strictly a last resort.
+func TestSendHeartbeat_CachedPayloadPreferredOverMinimal(t *testing.T) {
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
+
+	PublishHeartbeatIdentity("hive", "org", "pod-1", "2026-01-01T00:00:00Z", "abc1234")
+
+	got := make(chan HeartbeatPayload, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var p HeartbeatPayload
+		_ = json.NewDecoder(r.Body).Decode(&p)
+		got <- p
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+
+	// One good collect with real stats populates the cache.
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{
+			HiveID:      "hive",
+			Org:         "org",
+			PrimaryRepo: "repo",
+			Agents:      []AgentSummary{{Name: "scanner", State: "running"}},
+		}
+	}, nil2Logger())
+	<-got
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	sendHeartbeat(ctx, server.URL, blockUntilClosed(release, &HeartbeatPayload{HiveID: "late"}), nil2Logger())
+
+	p := <-got
+	if len(p.Agents) != 1 || p.Agents[0].Name != "scanner" {
+		t.Fatalf("timed-out beat carried Agents=%v, want the CACHED stats (scanner) — the minimal beat must not displace a usable cache", p.Agents)
+	}
+	if !p.StatsStale {
+		t.Error("cached beat was not marked StatsStale")
 	}
 }
 

--- a/v2/pkg/hub/heartbeat_testhooks.go
+++ b/v2/pkg/hub/heartbeat_testhooks.go
@@ -32,4 +32,10 @@ func ResetHeartbeatStateForTest() {
 	lastGoodPayload.Lock()
 	lastGoodPayload.payload = nil
 	lastGoodPayload.Unlock()
+	// The collect-independent identity is process-global too. Clearing it keeps
+	// each test's starting state honest: a test asserting the "no identity yet"
+	// path must not silently inherit an identity published by an earlier test.
+	heartbeatIdentity.Lock()
+	heartbeatIdentity.payload = nil
+	heartbeatIdentity.Unlock()
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -13163,11 +13163,17 @@ const dashboardHTML = `<!DOCTYPE html>
             if (_isAdmin) {
               hubAutoCheck = ' <label style="margin-left:6px;font-size:0.6rem;color:var(--muted);cursor:pointer;white-space:nowrap" title="Auto-upgrade hub when a new image is available"><input type="checkbox" ' + (_hubAutoUpgrade ? 'checked' : '') + ' onchange="toggleHubAutoUpgrade(this.checked)" style="vertical-align:middle;margin-right:2px;cursor:pointer">auto</label>';
               /* Upgrade kill switches (admin-only): checked = paused. Titles
-                 carry who/when; the dashboard banner repeats it prominently. */
-              hubAutoCheck += upgradePauseToggleHTML('hub', 'pause hub upgrades',
+                 carry who/when; the dashboard banner repeats it prominently.
+                 Rendered as ONE compact bordered column so the pair reads as a
+                 control cluster, stays vertically aligned with the header row,
+                 and wraps as a unit instead of the second toggle dangling onto
+                 its own line. */
+              hubAutoCheck += ' <span style="display:inline-flex;flex-direction:column;align-items:flex-start;gap:2px;margin-left:8px;padding:3px 8px;border:1px solid var(--border);border-radius:6px;background:var(--surface);vertical-align:middle;line-height:1.2">' +
+                upgradePauseToggleHTML('hub', 'hub upgrades',
                 'Kill switch: freeze the hub on its current build — no self-upgrades (auto or manual) until resumed') +
-                upgradePauseToggleHTML('spokes', 'pause spoke upgrades',
-                'Kill switch: freeze ALL automatic image changes to spokes, fleet-wide, until resumed');
+                upgradePauseToggleHTML('spokes', 'spoke upgrades',
+                'Kill switch: freeze ALL automatic image changes to spokes, fleet-wide, until resumed') +
+                '</span>';
             }
             var hubStatusIcon = hubLatestUnknown
               ? ' <span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-left:3px" title="Resolving latest version…"></span>'
@@ -14644,7 +14650,21 @@ const dashboardHTML = `<!DOCTYPE html>
     function upgradePauseToggleHTML(target, label, title) {
       var sw = (_upgradePause && _upgradePause[target]) || {paused: false};
       var t = title + (sw.paused ? ' — paused by ' + (sw.by || '?') + ' since ' + (sw.at || '?') : '');
-      return ' <label style="margin-left:6px;font-size:0.6rem;color:' + (sw.paused ? 'var(--red)' : 'var(--muted)') + ';cursor:pointer;white-space:nowrap;font-weight:' + (sw.paused ? '700' : '400') + '" title="' + escAttr(t) + '"><input type="checkbox" ' + (sw.paused ? 'checked' : '') + ' onchange="toggleUpgradePause(\'' + target + '\', this.checked)" style="vertical-align:middle;margin-right:2px;cursor:pointer">' + esc(label) + '</label>';
+      /* Pause/play ICON button with the plain-text label beside it. The icon
+         shows the ACTION a click performs: running → ⏸ (pause), paused → ▶
+         (resume, red). Text-variation selector (\uFE0E) keeps the glyphs
+         monochrome instead of emoji. The bordered flex-column wrapper at the
+         call site owns spacing/alignment for the pair. */
+      var icon = sw.paused ? '\u25B6\uFE0E' : '\u23F8\uFE0E';
+      var btnStyle = 'width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;' +
+        'padding:0;font-size:0.62rem;line-height:1;border-radius:4px;cursor:pointer;' +
+        (sw.paused
+          ? 'background:color-mix(in srgb, var(--red) 18%, transparent);border:1px solid var(--red);color:var(--red)'
+          : 'background:var(--surface);border:1px solid var(--border);color:var(--muted)');
+      return '<span style="display:inline-flex;align-items:center;gap:5px;white-space:nowrap" title="' + escAttr(t) + '">' +
+        '<button onclick="toggleUpgradePause(\'' + target + '\', ' + (sw.paused ? 'false' : 'true') + ')" style="' + btnStyle + '" aria-label="' + escAttr((sw.paused ? 'Resume ' : 'Pause ') + label) + '">' + icon + '</button>' +
+        '<span style="font-size:0.6rem;color:' + (sw.paused ? 'var(--red)' : 'var(--muted)') + ';font-weight:' + (sw.paused ? '700' : '400') + '">' + esc(label) + '</span>' +
+        '</span>';
     }
     async function toggleUpgradePause(target, paused) {
       try {

--- a/v2/pkg/hub/wrapkey.go
+++ b/v2/pkg/hub/wrapkey.go
@@ -1,0 +1,423 @@
+package hub
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Wrapped master delivery to pull-only spokes — the sealing primitive.
+//
+// WHY THIS EXISTS. The master (HIVE_HUB_SECRET) is the ONE value a spoke cannot
+// self-derive; every other per-hive value is a pure function of it plus HIVE_ID
+// (SpokeHeartbeatKey, SpokeInviteKey, spokeDomainKey, SpokeSSOPublicKey — see
+// hub_keys.go). 44 of 66 spokes sit on pull_only clusters the hub cannot write
+// to BY DESIGN (saas_provision.go KubectlReachable), so rotation cannot deliver
+// a new master to them and RESIDUAL-1 (strip the plaintext master) is blocked
+// behind the same boundary.
+//
+// Option D closes it without weakening pull_only: the spoke generates a
+// keypair, keeps the private half on its PVC, publishes the public half over
+// its own OUTBOUND heartbeat, and the hub seals each new master to that key.
+// The delivery channel need not be confidential, because the payload is already
+// sealed to a key only the recipient holds. Nothing here asks the hub to
+// initiate a connection to a spoke.
+//
+// WHY X25519 AND NOT Ed25519. The repo's existing asymmetric material is
+// Ed25519 (sso.go, hub_cookie.go, hub_pubkey_generations.go). Ed25519 is a
+// SIGNING key and CANNOT encrypt. Reusing it here would require either the
+// Ed25519->X25519 birational map — sharp-edged, easy to get wrong, and it
+// creates one key used under two algorithms — or an ad-hoc scheme. Neither is
+// acceptable for the one payload whose compromise is fleet-wide. This is a new
+// key type, deliberately. See TestWrapKeyNeverAcceptsEd25519Material, which
+// asserts no Ed25519-sized-or-shaped material can enter this path, because
+// "unify the key types" is exactly the plausible future refactor and a
+// behavioural test would not notice the crypto silently weakening.
+//
+// WHY NO HKDF. hub_keys.go:31-33 records the deliberate choice to avoid
+// x/crypto/hkdf as a direct module dependency and to use single-block
+// HMAC-SHA256 expansion instead. That reasoning holds identically here — fixed,
+// unique context labels and one 32-byte output — and OQ-3 was decided to follow
+// the precedent rather than reverse it. Adding a module to the one payload
+// whose compromise is fleet-wide is the wrong place for new supply-chain
+// surface.
+
+const (
+	// wrapKeyLen is the X25519 key size in bytes, for both halves. Named rather
+	// than inlined so a reader does not have to know that 32 here means "an
+	// X25519 scalar" and 32 elsewhere in this file means "an AES-256 key".
+	wrapKeyLen = 32
+
+	// wrapAEADKeyLen is the AES-256 key size. AES-256-GCM has precedent in this
+	// repo (pkg/hubbackup) — precedent, not novelty.
+	wrapAEADKeyLen = 32
+
+	// wrapNonceLen is the GCM standard nonce size (96 bits). Every seal draws a
+	// fresh random nonce; nonces are never derived or counted, so there is no
+	// reuse hazard to reason about across restarts.
+	wrapNonceLen = 12
+
+	// infoWrapSharedSecret is the domain-separation label for the single-block
+	// HMAC-SHA256 expansion of the X25519 shared secret into the AEAD key.
+	// Versioned ("-v1") for the same reason every info string in hub_keys.go is:
+	// so the format can evolve without a verifier ever silently accepting a
+	// foreign-domain key.
+	infoWrapSharedSecret = "hive-wrap-master-v1"
+
+	// infoWrapFingerprint is the domain-separation label for the public-key
+	// fingerprint. A fingerprint is a PUBLIC identifier that names a pinned key
+	// in logs, alerts and operator re-pin commands; it is separated from the
+	// AEAD-key label so a fingerprint can never collide with key material.
+	infoWrapFingerprint = "hive-wrap-fingerprint-v1"
+)
+
+// wrapKeyMaxAge and wrapKeyOverlap are POLICY CHOICES, not derived values.
+//
+// There is no calculation behind either number and a future reader must not
+// assume there is. They are recorded here with what they trade off so they can
+// be changed DELIBERATELY rather than either treated as sacred or adjusted
+// blindly. (OQ-4, decided by the operator 2026-08-14.)
+//
+//   - wrapKeyMaxAge = 90 days bounds how long any single wrapping key is
+//     exposed. Shorter is more conservative but generates more republication
+//     churn; the constraint on the upper end of churn is the reconcile lane's
+//     perHiveEnvMaxPatchesPerCycle = 3 budget, since each patch rolls a tenant
+//     pod. 90 days is comfortably clear of making that a bottleneck.
+//   - wrapKeyOverlap = 24 hours is how long a spoke retains its PREVIOUS
+//     private key after rotating, so a master sealed to the old key and still
+//     in flight can be opened. It must exceed the time a full fleet
+//     convergence takes (~6 hours), with margin for a spoke that misses a
+//     cycle. 24 hours gives roughly 4x that.
+//
+// Safe to change deliberately. Not safe to change because a number "looked
+// arbitrary".
+const (
+	wrapKeyMaxAge  = 90 * 24 * time.Hour
+	wrapKeyOverlap = 24 * time.Hour
+)
+
+var (
+	// errWrapKeyMalformed is returned for any public or private key that is not
+	// exactly wrapKeyLen bytes of valid X25519 material. Callers must treat this
+	// as "no usable key", never as "accept something else" — an unparseable key
+	// must not silently unpin a good one (§8 row 1).
+	errWrapKeyMalformed = errors.New("wrap key: malformed X25519 key material")
+
+	// errWrapOpenFailed is returned for every unseal failure — bad AAD, wrong
+	// recipient, tampered ciphertext, wrong generation. Deliberately ONE error
+	// with no detail: distinguishing "wrong hive" from "bad tag" would hand an
+	// attacker an oracle, and the caller's correct response is identical in
+	// every case (do not apply, do not ack, keep the current master).
+	errWrapOpenFailed = errors.New("wrap key: sealed payload did not open")
+)
+
+// wrapPublicKey is a spoke's published X25519 public half. It is a PUBLIC
+// value: it appears on the heartbeat, in the pin store, and in alerts.
+type wrapPublicKey struct {
+	raw []byte
+}
+
+// wrapPrivateKey is a spoke's X25519 private half. It NEVER leaves the pod and
+// is never logged, never serialised into a heartbeat, and never returned by any
+// hub API. Only the spoke holds one.
+type wrapPrivateKey struct {
+	key *ecdh.PrivateKey
+}
+
+// generateWrapKeypair produces a fresh X25519 keypair from crypto/rand.
+//
+// Spoke-side only. The hub never generates a wrapping keypair — if it did, it
+// would hold the private half and the entire point of Option D (the hub cannot
+// read what it seals) would be lost.
+func generateWrapKeypair() (wrapPrivateKey, wrapPublicKey, error) {
+	priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return wrapPrivateKey{}, wrapPublicKey{}, fmt.Errorf("wrap key: generate: %w", err)
+	}
+	return wrapPrivateKey{key: priv}, wrapPublicKey{raw: priv.PublicKey().Bytes()}, nil
+}
+
+// parseWrapPublicKey decodes a hex-encoded published public key.
+//
+// FAILS CLOSED. Anything that is not exactly wrapKeyLen bytes of valid X25519
+// material returns errWrapKeyMalformed and NO key. There is deliberately no
+// lenient path, no truncation, and no padding: a caller that cannot parse a
+// publication must count the hive as NOT having a usable key (which blocks
+// retirement) rather than falling back to any other key.
+func parseWrapPublicKey(hexEncoded string) (wrapPublicKey, error) {
+	raw, err := hex.DecodeString(hexEncoded)
+	if err != nil {
+		return wrapPublicKey{}, errWrapKeyMalformed
+	}
+	if len(raw) != wrapKeyLen {
+		return wrapPublicKey{}, errWrapKeyMalformed
+	}
+	// Round-trip through crypto/ecdh so the point is actually validated rather
+	// than merely length-checked. A 32-byte string is not necessarily a valid
+	// X25519 public key.
+	if _, err := ecdh.X25519().NewPublicKey(raw); err != nil {
+		return wrapPublicKey{}, errWrapKeyMalformed
+	}
+	return wrapPublicKey{raw: raw}, nil
+}
+
+// parseWrapPrivateKey decodes a hex-encoded private key read from the spoke's
+// PVC. Same fail-closed discipline as parseWrapPublicKey: a malformed key file
+// yields no key, and the caller's correct response is to generate a fresh
+// keypair (which then requires an operator re-pin — §8 row 7, deliberate).
+func parseWrapPrivateKey(hexEncoded string) (wrapPrivateKey, error) {
+	raw, err := hex.DecodeString(hexEncoded)
+	if err != nil {
+		return wrapPrivateKey{}, errWrapKeyMalformed
+	}
+	if len(raw) != wrapKeyLen {
+		return wrapPrivateKey{}, errWrapKeyMalformed
+	}
+	k, err := ecdh.X25519().NewPrivateKey(raw)
+	if err != nil {
+		return wrapPrivateKey{}, errWrapKeyMalformed
+	}
+	return wrapPrivateKey{key: k}, nil
+}
+
+// Hex renders the public key for publication on the heartbeat and for storage
+// in the pin store. Hex for the same reason every derived key in hub_keys.go is
+// hex: it is a safe ASCII value for an env var, a JSON field and a log line.
+func (p wrapPublicKey) Hex() string {
+	if len(p.raw) != wrapKeyLen {
+		return ""
+	}
+	return hex.EncodeToString(p.raw)
+}
+
+// hex renders the private key for persistence to the spoke PVC at 0600.
+// Unexported and lowercase on purpose: this must be impossible to reach from
+// any package that could serialise it outward.
+func (p wrapPrivateKey) hex() string {
+	if p.key == nil {
+		return ""
+	}
+	return hex.EncodeToString(p.key.Bytes())
+}
+
+// publicKey returns the public half of a private key, so a spoke that loaded a
+// key from disk can publish without storing the public half separately.
+func (p wrapPrivateKey) publicKey() wrapPublicKey {
+	if p.key == nil {
+		return wrapPublicKey{}
+	}
+	return wrapPublicKey{raw: p.key.PublicKey().Bytes()}
+}
+
+func (p wrapPublicKey) valid() bool  { return len(p.raw) == wrapKeyLen }
+func (p wrapPrivateKey) valid() bool { return p.key != nil }
+
+// wrapKeyFingerprint is the short PUBLIC identifier for a pinned key. It names
+// a key in alerts, in the pin store, and in the operator's re-pin command —
+// which is why it must be domain-separated from the AEAD key derivation: a
+// value an operator reads off a dashboard must never be usable as key material.
+func wrapKeyFingerprint(pub wrapPublicKey) string {
+	if !pub.valid() {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(infoWrapFingerprint))
+	mac.Write(pub.raw)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// wrapAAD builds the additional authenticated data that binds a sealed payload
+// to exactly one recipient and one generation.
+//
+//	hiveID || 0x00 || generationID || 0x00 || fingerprint
+//
+// The 0x00 separators match derivePerHiveKey's convention (hub_keys.go:118-122)
+// and exist for the same stated reason: hive IDs are attacker-influenced and
+// plain concatenation is ambiguous, so ("ab","c") and ("a","bc") must not
+// produce the same bytes.
+//
+// Each component closes a specific attack:
+//   - hiveID: a ciphertext sealed for X cannot be opened as Y even if misrouted
+//     or deliberately replayed cross-hive.
+//   - generationID: an attacker who captured a generation-N ciphertext cannot
+//     roll a spoke back to a retired master after N+1 has shipped. The channel
+//     is assumed NON-confidential, so replay resistance cannot come from it.
+//   - fingerprint: binds to the specific pinned key, so a payload sealed under
+//     a superseded wrapping key cannot be presented as current.
+func wrapAAD(hiveID string, generationID int, fingerprint string) []byte {
+	aad := make([]byte, 0, len(hiveID)+len(fingerprint)+16)
+	aad = append(aad, []byte(hiveID)...)
+	aad = append(aad, 0)
+	aad = append(aad, []byte(fmt.Sprintf("%d", generationID))...)
+	aad = append(aad, 0)
+	aad = append(aad, []byte(fingerprint)...)
+	return aad
+}
+
+// deriveWrapAEADKey expands an X25519 shared secret into the AES-256 key.
+//
+// Single-block HMAC-SHA256, following hub_keys.go's deliberate no-HKDF
+// precedent (OQ-3). Both public keys are mixed in so the derived key is bound
+// to BOTH parties — without that, a shared secret alone would not distinguish
+// which ephemeral produced it.
+func deriveWrapAEADKey(shared []byte, ephemeralPub, recipientPub wrapPublicKey) []byte {
+	mac := hmac.New(sha256.New, shared)
+	mac.Write([]byte(infoWrapSharedSecret))
+	mac.Write([]byte{0})
+	mac.Write(ephemeralPub.raw)
+	mac.Write([]byte{0})
+	mac.Write(recipientPub.raw)
+	return mac.Sum(nil)[:wrapAEADKeyLen]
+}
+
+// sealedPayload is the wire form of a wrapped master.
+//
+// Everything here is PUBLIC except by construction: the ephemeral public key is
+// public, and the ciphertext is opaque to anyone without the recipient's
+// private key. There is deliberately NO field carrying a plaintext secret —
+// that would be Option B, which was rejected because it makes the heartbeat
+// bearer a master-exfiltration primitive.
+type sealedPayload struct {
+	// EphemeralPub is the hex X25519 public half of the fresh sender keypair
+	// generated for THIS seal. Fresh per wrap, which gives forward secrecy
+	// against later compromise of hub state and makes every ciphertext
+	// independently sealed.
+	EphemeralPub string `json:"ephemeral_pub"`
+	// Nonce is the hex 96-bit GCM nonce, fresh random per seal.
+	Nonce string `json:"nonce"`
+	// Ciphertext is the hex AES-256-GCM output (with tag).
+	Ciphertext string `json:"ciphertext"`
+	// GenerationID names the master generation sealed inside. It is REPEATED in
+	// the AAD; this copy exists only so the spoke can decide whether to attempt
+	// the open at all (refuse generation <= current) without first decrypting.
+	// The AAD copy is the authoritative one — a tampered GenerationID here fails
+	// the AEAD tag rather than being trusted.
+	GenerationID int `json:"generation_id"`
+	// Fingerprint names the wrapping key this was sealed to, so a spoke holding
+	// both a current and an overlap key knows which private half to try first.
+	// Also repeated in the AAD, and authoritative there for the same reason.
+	Fingerprint string `json:"fingerprint"`
+}
+
+// sealForSpoke encrypts payload to a spoke's pinned wrapping key.
+//
+// HUB-SIDE. The hub holds no private half, generates a fresh ephemeral keypair
+// per call, and discards it immediately — so the hub cannot re-open what it
+// sealed, which is the property that makes a non-confidential delivery channel
+// acceptable.
+//
+// payload is the caller's plaintext. Under OQ-2(c) it carries BOTH the new
+// master AND the spoke's freshly derived heartbeat key for the incoming
+// generation, sealed together — never as separate plaintext fields on the
+// heartbeat response, which is what would turn Option D into the rejected
+// Option B.
+func sealForSpoke(recipient wrapPublicKey, hiveID string, generationID int, payload []byte) (sealedPayload, error) {
+	if !recipient.valid() {
+		return sealedPayload{}, errWrapKeyMalformed
+	}
+	if hiveID == "" {
+		// No identity means no AAD binding means a ciphertext openable by
+		// anyone holding any wrapping key. Refuse rather than seal something
+		// unbound. Mirrors derivePerHiveKey's refusal to derive without a hive
+		// ID (hub_keys.go:115-117), which the F2 banner names as the invariant
+		// that must never regain a bypass.
+		return sealedPayload{}, errors.New("wrap key: refusing to seal without a hive ID")
+	}
+	recipientPub, err := ecdh.X25519().NewPublicKey(recipient.raw)
+	if err != nil {
+		return sealedPayload{}, errWrapKeyMalformed
+	}
+	ephPriv, ephPub, err := generateWrapKeypair()
+	if err != nil {
+		return sealedPayload{}, err
+	}
+	shared, err := ephPriv.key.ECDH(recipientPub)
+	if err != nil {
+		return sealedPayload{}, fmt.Errorf("wrap key: ecdh: %w", err)
+	}
+	aeadKey := deriveWrapAEADKey(shared, ephPub, recipient)
+	block, err := aes.NewCipher(aeadKey)
+	if err != nil {
+		return sealedPayload{}, fmt.Errorf("wrap key: aes: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return sealedPayload{}, fmt.Errorf("wrap key: gcm: %w", err)
+	}
+	nonce := make([]byte, wrapNonceLen)
+	if _, err := rand.Read(nonce); err != nil {
+		return sealedPayload{}, fmt.Errorf("wrap key: nonce: %w", err)
+	}
+	fp := wrapKeyFingerprint(recipient)
+	ct := gcm.Seal(nil, nonce, payload, wrapAAD(hiveID, generationID, fp))
+	return sealedPayload{
+		EphemeralPub: ephPub.Hex(),
+		Nonce:        hex.EncodeToString(nonce),
+		Ciphertext:   hex.EncodeToString(ct),
+		GenerationID: generationID,
+		Fingerprint:  fp,
+	}, nil
+}
+
+// openFromHub decrypts a sealed payload with the spoke's private wrapping key.
+//
+// SPOKE-SIDE. hiveID is supplied by the CALLER from its own local identity
+// (/data/hive-id), never from the payload — taking it from the payload would
+// let an attacker choose the AAD and defeat the cross-hive binding entirely.
+//
+// Every failure returns errWrapOpenFailed with no detail. On failure the spoke
+// keeps its current master, does NOT apply, and does NOT ack, which is what
+// makes the hub retry (§8 row 3). Applying a partially decoded master would
+// brick the spoke.
+func openFromHub(priv wrapPrivateKey, hiveID string, sp sealedPayload) ([]byte, error) {
+	if !priv.valid() || hiveID == "" {
+		return nil, errWrapOpenFailed
+	}
+	ephRaw, err := hex.DecodeString(sp.EphemeralPub)
+	if err != nil || len(ephRaw) != wrapKeyLen {
+		return nil, errWrapOpenFailed
+	}
+	ephPub, err := ecdh.X25519().NewPublicKey(ephRaw)
+	if err != nil {
+		return nil, errWrapOpenFailed
+	}
+	nonce, err := hex.DecodeString(sp.Nonce)
+	if err != nil || len(nonce) != wrapNonceLen {
+		return nil, errWrapOpenFailed
+	}
+	ct, err := hex.DecodeString(sp.Ciphertext)
+	if err != nil {
+		return nil, errWrapOpenFailed
+	}
+	shared, err := priv.key.ECDH(ephPub)
+	if err != nil {
+		return nil, errWrapOpenFailed
+	}
+	ownPub := priv.publicKey()
+	aeadKey := deriveWrapAEADKey(shared, wrapPublicKey{raw: ephRaw}, ownPub)
+	block, err := aes.NewCipher(aeadKey)
+	if err != nil {
+		return nil, errWrapOpenFailed
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, errWrapOpenFailed
+	}
+	// The AAD is rebuilt from the SPOKE's own identity and its OWN key's
+	// fingerprint — not from sp.Fingerprint. If the hub sealed to a different
+	// key, or to a different hive, the tag fails here. This is the line that
+	// makes cross-hive misdelivery and stale-key replay fail closed, so it must
+	// never be "fixed" to read the fingerprint off the payload.
+	aad := wrapAAD(hiveID, sp.GenerationID, wrapKeyFingerprint(ownPub))
+	pt, err := gcm.Open(nil, nonce, ct, aad)
+	if err != nil {
+		return nil, errWrapOpenFailed
+	}
+	return pt, nil
+}

--- a/v2/pkg/hub/wrapkey_store.go
+++ b/v2/pkg/hub/wrapkey_store.go
@@ -1,0 +1,309 @@
+package hub
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Spoke-side wrapping-key lifecycle: generate, persist, load, rotate.
+//
+// STORAGE MIRRORS AN ESTABLISHED PATTERN rather than inventing one. The spoke
+// already persists private key material on the same PVC at the same mode:
+// spokeAppKeyPath = "/data/gh-app-key.pem" with spokeAppKeyFileMode = 0o600 and
+// the comment "signing material must never be readable by anything else sharing
+// the PVC or the pod" (v2/cmd/hive/main.go:99,114-116). /data is the PVC mount
+// in the spoke template, and /data/hive-id already establishes that
+// identity-critical state persists there across restarts.
+//
+// PERSIST BEFORE USE. Step 2 of the lifecycle writes the key to disk BEFORE
+// returning it to any caller, mirroring rotateMasterSecret's persist-before-
+// install ordering and its stated rationale: never act on key material you
+// might forget at the next roll. A key used but not persisted would be
+// republished as a DIFFERENT key after the next pod roll, which the hub would
+// correctly refuse as a pin mismatch — turning a write failure into an
+// operator-intervention event on a cluster the hub cannot reach into.
+
+// spokeWrapKeyPath is where the spoke's X25519 private wrapping key lives on
+// the PVC. A var rather than a const so tests can redirect it and exercise the
+// real resolution order — the reason given at v2/cmd/hive/main.go:95-97.
+// Production never reassigns it.
+var spokeWrapKeyPath = "/data/hive-wrap-key"
+
+// spokeWrapKeyFileMode is rw------- , identical to spokeAppKeyFileMode and for
+// the identical reason: the wrapping private key is the ONLY thing standing
+// between a sealed master and anything else sharing the PVC or the pod.
+const spokeWrapKeyFileMode = 0o600
+
+// spokeWrapKeyDirMode is rwx------ for the containing directory when it must be
+// created. /data normally exists as the PVC mount; this covers the test and
+// first-boot-before-mount cases without ever widening the directory.
+const spokeWrapKeyDirMode = 0o700
+
+// wrapKeyFile is the on-disk form. It is versioned and carries explicit
+// timestamps because the overlap window is a SECOND dual-acceptance window and
+// inherits the discipline the master generations carry: explicitly versioned
+// (the previous key is a numbered entry with a fingerprint, not an unnamed `if`
+// branch) and explicitly finite (it carries an expiry, and an expired key is
+// EXCLUDED, not warned about).
+type wrapKeyFile struct {
+	// Version guards the format. An unrecognised version is MALFORMED, not
+	// "probably fine" — see loadSpokeWrapKeys.
+	Version int `json:"version"`
+	// Current is the hex private key currently published and sealed to.
+	Current string `json:"current"`
+	// CurrentCreated is when Current was generated. Drives wrapKeyMaxAge.
+	CurrentCreated time.Time `json:"current_created"`
+	// Previous is the hex private key retained across a rotation so a master
+	// sealed to the old key and still in flight can be opened. Empty when there
+	// is no overlap in progress.
+	//
+	// NOTE THE ASYMMETRY THAT MAKES THIS SAFE, AND DO NOT REMOVE IT: retaining
+	// the old PRIVATE key spoke-side is what lets the spoke rotate WITHOUT
+	// asking the hub to accept a new public key. The hub-side pin is untouched
+	// by spoke-side rotation. If a future change instead makes the hub accept
+	// the new public key automatically, that is an auto-re-pin path and it
+	// silently degrades Option D into the rejected Option B. The adversarial
+	// review hunted specifically for such a path and found none; keep it that
+	// way. Spoke-side wrap-key rotation still requires a hub-side OPERATOR
+	// re-pin before the new key is sealed to.
+	Previous string `json:"previous,omitempty"`
+	// PreviousExpires is the hard expiry of Previous's acceptance. A ZERO value
+	// means ALREADY EXPIRED, never "never expires" — the same reading
+	// acceptableGenerations gives VerifyUntil (hub_generations.go:232-238).
+	// Reading it the other way would pin a superseded key live forever, which is
+	// the F1/F2 failure mode this project has spent five audits removing.
+	PreviousExpires time.Time `json:"previous_expires,omitempty"`
+}
+
+const wrapKeyFileVersion = 1
+
+// spokeWrapKeys is the in-memory view a spoke uses.
+type spokeWrapKeys struct {
+	current         wrapPrivateKey
+	currentCreated  time.Time
+	previous        wrapPrivateKey
+	previousExpires time.Time
+}
+
+// errWrapKeyFileMalformed is returned when the on-disk key file cannot be
+// trusted. Callers must treat it EXACTLY as they treat an absent file: generate
+// fresh. There is deliberately no partial-recovery path — a half-readable key
+// file is not evidence of anything.
+var errWrapKeyFileMalformed = errors.New("wrap key file: malformed")
+
+// loadSpokeWrapKeys reads and validates the spoke's key file.
+//
+// Returns (keys, nil) on success, (zero, os.ErrNotExist) when absent, and
+// (zero, errWrapKeyFileMalformed) for anything unparseable. The caller
+// distinguishes absent from unreadable only for LOGGING — both lead to
+// generate-fresh, because a spoke with no usable private key cannot open a
+// sealed master either way.
+//
+// AN EXPIRED PREVIOUS KEY IS DROPPED, NOT WARNED ABOUT. That is the finiteness
+// promise made real: the overlap window closes on its own without operator
+// action, and a spoke cannot extend its own acceptance window.
+func loadSpokeWrapKeys(path string, now time.Time) (spokeWrapKeys, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return spokeWrapKeys{}, os.ErrNotExist
+		}
+		// Present but unreadable. NOT the same as absent, and it must not be
+		// silently treated as "no key, all good" — this is the same
+		// absent-versus-unreadable distinction hub_generations_store.go makes.
+		// It still routes to generate-fresh, but the caller logs it loudly.
+		return spokeWrapKeys{}, fmt.Errorf("wrap key file: read: %w", err)
+	}
+	var f wrapKeyFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return spokeWrapKeys{}, errWrapKeyFileMalformed
+	}
+	if f.Version != wrapKeyFileVersion {
+		return spokeWrapKeys{}, errWrapKeyFileMalformed
+	}
+	cur, err := parseWrapPrivateKey(strings.TrimSpace(f.Current))
+	if err != nil {
+		return spokeWrapKeys{}, errWrapKeyFileMalformed
+	}
+	out := spokeWrapKeys{current: cur, currentCreated: f.CurrentCreated}
+	if strings.TrimSpace(f.Previous) != "" {
+		// A ZERO PreviousExpires means ALREADY EXPIRED. Same rule as
+		// acceptableGenerations. Dropping the key here rather than accepting it
+		// is what stops a hand-edited file with the field stripped from keeping
+		// a superseded wrapping key acceptable forever.
+		if !f.PreviousExpires.IsZero() && now.Before(f.PreviousExpires) {
+			prev, perr := parseWrapPrivateKey(strings.TrimSpace(f.Previous))
+			if perr == nil {
+				out.previous = prev
+				out.previousExpires = f.PreviousExpires
+			}
+			// A malformed PREVIOUS key is dropped without failing the load: the
+			// current key is independently valid and the spoke can still
+			// publish and receive. Failing the whole load here would discard a
+			// good current key over a stale overlap entry.
+		}
+	}
+	return out, nil
+}
+
+// persistSpokeWrapKeys writes the key file at 0600.
+//
+// Writes to a temp file in the same directory and renames, so a crash mid-write
+// never leaves a truncated key file that the next boot would read as malformed
+// and replace — which would produce a new public key, a pin mismatch, and an
+// operator-intervention event on an unreachable cluster.
+func persistSpokeWrapKeys(path string, keys spokeWrapKeys) error {
+	if !keys.current.valid() {
+		return errWrapKeyMalformed
+	}
+	f := wrapKeyFile{
+		Version:        wrapKeyFileVersion,
+		Current:        keys.current.hex(),
+		CurrentCreated: keys.currentCreated.UTC(),
+	}
+	if keys.previous.valid() && !keys.previousExpires.IsZero() {
+		f.Previous = keys.previous.hex()
+		f.PreviousExpires = keys.previousExpires.UTC()
+	}
+	blob, err := json.Marshal(f)
+	if err != nil {
+		return fmt.Errorf("wrap key file: marshal: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, spokeWrapKeyDirMode); err != nil {
+		return fmt.Errorf("wrap key file: mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".hive-wrap-key-*")
+	if err != nil {
+		return fmt.Errorf("wrap key file: temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Chmod BEFORE writing: the key bytes must never exist on disk at a wider
+	// mode, not even for the microseconds between write and chmod.
+	if err := tmp.Chmod(spokeWrapKeyFileMode); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("wrap key file: chmod: %w", err)
+	}
+	if _, err := tmp.Write(blob); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("wrap key file: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("wrap key file: close: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("wrap key file: rename: %w", err)
+	}
+	return nil
+}
+
+// ensureSpokeWrapKeys is the ONE mechanism covering first boot, pod roll and
+// PVC loss — they are one mechanism because they must be.
+//
+//  1. Read the file. If present and well-formed, use it.
+//  2. If absent or malformed, generate a fresh keypair and PERSIST IT BEFORE
+//     returning it.
+//
+// A pod roll with the PVC intact is therefore a no-op: same key, same
+// publication. PVC LOSS IS INDISTINGUISHABLE FROM FIRST BOOT by construction —
+// the spoke generates a new keypair and publishes it. Whether the HUB should
+// accept that new key is not decided here and must not be: it is refused as a
+// pin mismatch and requires an operator re-pin. That availability cost is
+// accepted DELIBERATELY, because the alternative is a design where losing a PVC
+// and being attacked are indistinguishable and both silently succeed.
+//
+// Returns the keys and whether a fresh keypair was generated, so the caller can
+// log the (operationally significant) difference.
+func ensureSpokeWrapKeys(path string, now time.Time) (spokeWrapKeys, bool, error) {
+	keys, err := loadSpokeWrapKeys(path, now)
+	if err == nil && keys.current.valid() {
+		return keys, false, nil
+	}
+	priv, _, gerr := generateWrapKeypair()
+	if gerr != nil {
+		return spokeWrapKeys{}, false, gerr
+	}
+	fresh := spokeWrapKeys{current: priv, currentCreated: now}
+	if perr := persistSpokeWrapKeys(path, fresh); perr != nil {
+		// Persist-before-use: refuse to return a key we could not durably
+		// record. Returning it anyway would mean publishing a key that
+		// disappears at the next roll, producing a pin mismatch the operator
+		// then has to resolve on an unreachable cluster.
+		return spokeWrapKeys{}, false, perr
+	}
+	return fresh, true, nil
+}
+
+// wrapKeyNeedsRotation reports whether the current key has exceeded
+// wrapKeyMaxAge.
+//
+// A ZERO currentCreated reads as NEEDS ROTATION, not as "brand new". Same
+// fail-closed direction as VerifyUntil.IsZero(): an unknown age must not read
+// as a safe age. A hand-edited or migrated file missing the timestamp gets
+// rotated rather than kept indefinitely.
+func wrapKeyNeedsRotation(keys spokeWrapKeys, now time.Time) bool {
+	if !keys.current.valid() {
+		return true
+	}
+	if keys.currentCreated.IsZero() {
+		return true
+	}
+	return !now.Before(keys.currentCreated.Add(wrapKeyMaxAge))
+}
+
+// rotateSpokeWrapKeys generates a new current key and retains the OLD PRIVATE
+// key for wrapKeyOverlap, so a master sealed to the old key and still in flight
+// can be opened.
+//
+// SPOKE-LOCAL ONLY. This does not, and must not, cause the hub to accept the
+// new public key. The hub keeps sealing to the PINNED key until an operator
+// re-pins. That is why the overlap retains the old private half rather than
+// asking for acceptance of a new public half — it is the construction that
+// keeps the never-auto-re-pin guarantee intact through the one place the design
+// itself introduces a legitimate key change.
+func rotateSpokeWrapKeys(path string, keys spokeWrapKeys, now time.Time) (spokeWrapKeys, error) {
+	priv, _, err := generateWrapKeypair()
+	if err != nil {
+		return keys, err
+	}
+	next := spokeWrapKeys{
+		current:         priv,
+		currentCreated:  now,
+		previous:        keys.current,
+		previousExpires: now.Add(wrapKeyOverlap),
+	}
+	if perr := persistSpokeWrapKeys(path, next); perr != nil {
+		// Keep the existing keys on a persist failure. Rotating in memory only
+		// would publish a key that vanishes at the next roll.
+		return keys, perr
+	}
+	return next, nil
+}
+
+// openWithSpokeKeys tries the current key, then the unexpired previous key.
+//
+// Order matters only for efficiency; correctness comes from the AEAD tag, which
+// fails for the wrong key regardless of order. An EXPIRED previous key is not
+// tried at all — loadSpokeWrapKeys never puts one in the struct.
+func openWithSpokeKeys(keys spokeWrapKeys, hiveID string, sp sealedPayload) ([]byte, error) {
+	if keys.current.valid() {
+		if pt, err := openFromHub(keys.current, hiveID, sp); err == nil {
+			return pt, nil
+		}
+	}
+	if keys.previous.valid() {
+		if pt, err := openFromHub(keys.previous, hiveID, sp); err == nil {
+			return pt, nil
+		}
+	}
+	return nil, errWrapOpenFailed
+}

--- a/v2/pkg/hub/wrapkey_test.go
+++ b/v2/pkg/hub/wrapkey_test.go
@@ -1,0 +1,841 @@
+package hub
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for the Option D sealing primitive and the spoke-side wrapping-key
+// lifecycle (v2/docs/design/master-delivery-wrapped.md, PR #3833).
+//
+// THE HOUSE STANDARD THIS FILE IS WRITTEN TO. Fifteen tests in this repo have
+// been found ENCODING vulnerabilities or passing for the wrong reason —
+// heartbeatBearerOK's test literally asserting the hub "must accept raw master
+// secret" (F24) is the canonical example, and F19's
+// TestDesiredPerHiveEnvUsesCurrentNotPrevious passed while validating a code
+// path production never takes. So:
+//
+//   - Every negative assertion carries a POSITIVE CONTROL in the same test. A
+//     test asserting "decryption fails" passes trivially when decryption is
+//     broken outright; without the paired success case it asserts nothing.
+//   - Properties where a behavioural test would pass for the wrong reason get a
+//     SOURCE-ASSERTING test as well — with the subject chosen carefully, since
+//     the design's own §10 spec was found to assert a true property of the
+//     WRONG variable.
+
+// --- helpers -----------------------------------------------------------------
+
+func mustWrapKeypair(t *testing.T) (wrapPrivateKey, wrapPublicKey) {
+	t.Helper()
+	priv, pub, err := generateWrapKeypair()
+	if err != nil {
+		t.Fatalf("generateWrapKeypair: %v", err)
+	}
+	return priv, pub
+}
+
+// --- AAD BINDING: cross-hive, cross-generation, cross-key ---------------------
+
+// TestSealOpenRoundTrip is the POSITIVE CONTROL for every negative test below.
+// Without it, an implementation whose Open always fails would pass the entire
+// rest of this file.
+func TestSealOpenRoundTrip(t *testing.T) {
+	priv, pub := mustWrapKeypair(t)
+	payload := []byte("master-generation-7-plus-heartbeat-key")
+
+	sp, err := sealForSpoke(pub, "hive-alpha", 7, payload)
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+	got, err := openFromHub(priv, "hive-alpha", sp)
+	if err != nil {
+		t.Fatalf("openFromHub on the correctly-bound case failed: %v — every "+
+			"negative assertion in this file is meaningless without this passing", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("round trip corrupted the payload: got %d bytes, want %d", len(got), len(payload))
+	}
+	if sp.Ciphertext == hex.EncodeToString(payload) {
+		t.Fatal("ciphertext equals hex(plaintext) — the payload was not encrypted at all")
+	}
+	if strings.Contains(sp.Ciphertext, hex.EncodeToString(payload)) {
+		t.Fatal("plaintext appears inside the ciphertext")
+	}
+}
+
+// TestAADBindsHiveID: a ciphertext sealed for hive X must not open as hive Y,
+// even with the correct private key. This is what makes cross-hive
+// misdelivery — accidental or deliberate — fail closed.
+func TestAADBindsHiveID(t *testing.T) {
+	priv, pub := mustWrapKeypair(t)
+	sp, err := sealForSpoke(pub, "hive-alpha", 3, []byte("secret"))
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+
+	// Positive control FIRST, so a broken-open implementation cannot pass.
+	if _, err := openFromHub(priv, "hive-alpha", sp); err != nil {
+		t.Fatalf("positive control failed: correctly-bound open errored: %v", err)
+	}
+
+	if _, err := openFromHub(priv, "hive-beta", sp); err == nil {
+		t.Error("a ciphertext sealed for hive-alpha opened as hive-beta — the AAD hiveID " +
+			"binding is not in force, so a misrouted or replayed payload crosses hives")
+	}
+}
+
+// TestAADBindsGeneration: an attacker who captured a generation-N ciphertext
+// must not be able to present it as any other generation. The channel is
+// assumed NON-confidential, so replay resistance cannot come from the channel.
+func TestAADBindsGeneration(t *testing.T) {
+	priv, pub := mustWrapKeypair(t)
+	sp, err := sealForSpoke(pub, "hive-alpha", 5, []byte("master-5"))
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+
+	if _, err := openFromHub(priv, "hive-alpha", sp); err != nil {
+		t.Fatalf("positive control failed: correctly-bound open errored: %v", err)
+	}
+
+	// Rewrite the advertised generation, as a replaying attacker would.
+	replayed := sp
+	replayed.GenerationID = 4
+	if _, err := openFromHub(priv, "hive-alpha", replayed); err == nil {
+		t.Error("a generation-5 ciphertext opened when presented as generation 4 — an attacker " +
+			"who captured an old ciphertext could roll a spoke back to a retired master")
+	}
+	forward := sp
+	forward.GenerationID = 6
+	if _, err := openFromHub(priv, "hive-alpha", forward); err == nil {
+		t.Error("a generation-5 ciphertext opened when presented as generation 6")
+	}
+}
+
+// TestAADBindsWrappingKey: a payload sealed to key A must not open with key B,
+// and — critically — the AAD is rebuilt from the SPOKE's own key fingerprint,
+// not from the fingerprint field on the payload. If openFromHub ever reads
+// sp.Fingerprint into the AAD, an attacker chooses the AAD and the binding is
+// gone.
+func TestAADBindsWrappingKey(t *testing.T) {
+	privA, pubA := mustWrapKeypair(t)
+	privB, _ := mustWrapKeypair(t)
+
+	sp, err := sealForSpoke(pubA, "hive-alpha", 2, []byte("secret"))
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+	if _, err := openFromHub(privA, "hive-alpha", sp); err != nil {
+		t.Fatalf("positive control failed: open with the sealed-to key errored: %v", err)
+	}
+	if _, err := openFromHub(privB, "hive-alpha", sp); err == nil {
+		t.Error("a payload sealed to key A opened with key B's private half")
+	}
+
+	// THE FINGERPRINT-TRUST CASE, AND WHY IT IS SHAPED LIKE THIS.
+	//
+	// The obvious construction — rewrite sp.Fingerprint to key B's and open with
+	// B — does NOT isolate the property. It fails whether or not openFromHub
+	// trusts sp.Fingerprint, because opening with a different key also changes
+	// the ECDH shared secret and therefore the AEAD key. The tag fails for an
+	// unrelated reason and the test passes for the wrong reason. (Verified: the
+	// regression replay for this property PASSED while neutered when written
+	// that way.)
+	//
+	// The isolating construction keeps the recipient key FIXED, so the ECDH
+	// shared secret is unchanged and the ONLY varying input is the fingerprint
+	// that goes into the AAD.
+	spoofed := sp
+	spoofed.Fingerprint = wrapKeyFingerprint(privB.publicKey())
+	if _, err := openFromHub(privA, "hive-alpha", spoofed); err != nil {
+		t.Error("rewriting sp.Fingerprint broke the open for the CORRECT recipient — openFromHub " +
+			"is reading the fingerprint off the payload instead of rebuilding it from the " +
+			"spoke's own key, so an attacker who controls the payload controls the AAD")
+	}
+}
+
+// TestOpenRebuildsAADFromOwnKeyNotPayload is the source-asserting half of the
+// fingerprint-trust property, because the behavioural test above can only prove
+// the negative direction (a rewritten fingerprint does not BREAK a good open).
+// It cannot prove the positive one — that a payload whose fingerprint names a
+// key the spoke does not hold is still rejected on the fingerprint's account —
+// since any such payload also fails on the ECDH secret.
+//
+// The subject is chosen deliberately, per §10's worked example that a
+// source-assertion is only as good as its choice of subject: assert that the
+// AAD construction inside openFromHub passes wrapKeyFingerprint(ownPub) and NOT
+// sp.Fingerprint. That is the property actually needed.
+func TestOpenRebuildsAADFromOwnKeyNotPayload(t *testing.T) {
+	raw, err := os.ReadFile("wrapkey.go")
+	if err != nil {
+		t.Fatalf("read wrapkey.go: %v", err)
+	}
+	src := stripGoComments(string(raw))
+	i := strings.Index(src, "func openFromHub(")
+	if i < 0 {
+		t.Fatal("openFromHub not found — this test is not reading the implementation it thinks it is")
+	}
+	body := src[i:]
+	if j := strings.Index(body[1:], "\nfunc "); j >= 0 {
+		body = body[:j+1]
+	}
+	if !strings.Contains(body, "wrapAAD(hiveID, sp.GenerationID, wrapKeyFingerprint(ownPub))") {
+		t.Error("openFromHub does not rebuild the AAD from the spoke's OWN key fingerprint. " +
+			"The AAD must be wrapAAD(hiveID, sp.GenerationID, wrapKeyFingerprint(ownPub)) — " +
+			"reading sp.Fingerprint instead lets an attacker who controls the payload choose " +
+			"the AAD, and cross-key replay stops failing closed")
+	}
+	if regexp.MustCompile(`wrapAAD\([^)]*sp\.Fingerprint`).MatchString(body) {
+		t.Error("openFromHub passes sp.Fingerprint into wrapAAD — the payload's own copy is " +
+			"attacker-controlled and must never be an AAD input")
+	}
+	// Positive control on the subject: hiveID IS supposed to come from the
+	// caller, so confirm the matcher can see real content and is not matching an
+	// empty body.
+	if !strings.Contains(body, "priv.key.ECDH(ephPub)") {
+		t.Fatal("the extracted openFromHub body does not contain its ECDH call — the extraction " +
+			"is wrong and every assertion above is vacuous")
+	}
+}
+
+// TestSealRefusesWithoutHiveID mirrors derivePerHiveKey's refusal to derive
+// without a hive ID (hub_keys.go:115-117). An unbound ciphertext is openable by
+// anyone holding any wrapping key, so sealing one must be impossible.
+func TestSealRefusesWithoutHiveID(t *testing.T) {
+	_, pub := mustWrapKeypair(t)
+	if _, err := sealForSpoke(pub, "", 1, []byte("secret")); err == nil {
+		t.Error("sealForSpoke produced a ciphertext with no hive ID in the AAD — F2's " +
+			"identity-binding invariant is re-opened through a new door")
+	}
+	// Positive control: with an ID it succeeds.
+	if _, err := sealForSpoke(pub, "hive-alpha", 1, []byte("secret")); err != nil {
+		t.Fatalf("positive control failed: sealForSpoke with a hive ID errored: %v", err)
+	}
+}
+
+// TestOpenRefusesWithoutHiveID: the spoke supplies the hive ID from its own
+// local identity, never from the payload. An empty one must fail closed.
+func TestOpenRefusesWithoutHiveID(t *testing.T) {
+	priv, pub := mustWrapKeypair(t)
+	sp, err := sealForSpoke(pub, "hive-alpha", 1, []byte("secret"))
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+	if _, err := openFromHub(priv, "", sp); err == nil {
+		t.Error("openFromHub opened a payload with an empty hive ID")
+	}
+	if _, err := openFromHub(priv, "hive-alpha", sp); err != nil {
+		t.Fatalf("positive control failed: %v", err)
+	}
+}
+
+// TestCiphertextTamperingFailsClosed covers the ordinary AEAD property, with a
+// positive control, so "GCM is wired up at all" is actually asserted.
+func TestCiphertextTamperingFailsClosed(t *testing.T) {
+	priv, pub := mustWrapKeypair(t)
+	sp, err := sealForSpoke(pub, "hive-alpha", 1, []byte("a-master-secret-value"))
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+	if _, err := openFromHub(priv, "hive-alpha", sp); err != nil {
+		t.Fatalf("positive control failed: %v", err)
+	}
+
+	raw, err := hex.DecodeString(sp.Ciphertext)
+	if err != nil || len(raw) == 0 {
+		t.Fatalf("ciphertext not hex-decodable: %v", err)
+	}
+	raw[0] ^= 0xFF
+	tampered := sp
+	tampered.Ciphertext = hex.EncodeToString(raw)
+	if _, err := openFromHub(priv, "hive-alpha", tampered); err == nil {
+		t.Error("a tampered ciphertext opened — the GCM tag is not being verified")
+	}
+}
+
+// TestEphemeralIsFreshPerSeal: sealing the same payload to the same key twice
+// must produce different ciphertexts. Otherwise the "fresh sender keypair per
+// wrap" forward-secrecy claim is false and an observer can correlate deliveries.
+func TestEphemeralIsFreshPerSeal(t *testing.T) {
+	_, pub := mustWrapKeypair(t)
+	a, err := sealForSpoke(pub, "hive-alpha", 1, []byte("same"))
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+	b, err := sealForSpoke(pub, "hive-alpha", 1, []byte("same"))
+	if err != nil {
+		t.Fatalf("sealForSpoke: %v", err)
+	}
+	if a.EphemeralPub == b.EphemeralPub {
+		t.Error("two seals reused the same ephemeral public key — forward secrecy claim is false")
+	}
+	if a.Ciphertext == b.Ciphertext {
+		t.Error("two seals of the same payload produced identical ciphertext")
+	}
+	if a.Nonce == b.Nonce {
+		t.Error("two seals reused the same GCM nonce")
+	}
+}
+
+// --- MALFORMED KEY HANDLING: fail closed, never fall back ---------------------
+
+func TestParseWrapPublicKeyFailsClosed(t *testing.T) {
+	_, pub := mustWrapKeypair(t)
+	// Positive control first.
+	if _, err := parseWrapPublicKey(pub.Hex()); err != nil {
+		t.Fatalf("positive control failed: a valid key did not parse: %v", err)
+	}
+	for _, bad := range []struct{ name, in string }{
+		{"empty", ""},
+		{"not hex", "zzzz"},
+		{"too short", hex.EncodeToString(make([]byte, wrapKeyLen-1))},
+		{"too long", hex.EncodeToString(make([]byte, wrapKeyLen+1))},
+		{"ed25519 public key length", hex.EncodeToString(make([]byte, ed25519.PublicKeySize+1))},
+	} {
+		if _, err := parseWrapPublicKey(bad.in); err == nil {
+			t.Errorf("parseWrapPublicKey accepted %s — a malformed publication must count as "+
+				"NO usable key, never as something to fall back on", bad.name)
+		}
+	}
+}
+
+// TestWrapKeyNeverAcceptsEd25519Material is the source+behaviour assertion for
+// the Ed25519-is-not-an-encryption-key invariant.
+//
+// WHY THIS IS SOURCE-ASSERTING. "Unify the key types" is exactly the plausible
+// future refactor, and a behavioural test would not notice the crypto silently
+// weakening: an Ed25519 seed is 32 bytes, the same as an X25519 scalar, so a
+// refactor feeding Ed25519 material into this path would still produce
+// working-looking round trips. The subject is chosen deliberately: assert that
+// wrapkey.go imports no ed25519 and names no ed25519 symbol, because that is
+// the property actually needed — not the weaker "the happy path still works".
+func TestWrapKeyNeverAcceptsEd25519Material(t *testing.T) {
+	for _, file := range []string{"wrapkey.go", "wrapkey_store.go"} {
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		src := string(raw)
+		// Strip comments before matching, so the explanatory prose in these
+		// files (which necessarily says "Ed25519") does not trip the assertion.
+		src = stripGoComments(src)
+		if strings.Contains(src, "crypto/ed25519") {
+			t.Errorf("%s imports crypto/ed25519 — Ed25519 is a SIGNING key and cannot encrypt; "+
+				"routing it into the wrapping path is the refactor this test exists to block", file)
+		}
+		if regexp.MustCompile(`\bed25519\.`).MatchString(src) {
+			t.Errorf("%s references an ed25519 symbol in code", file)
+		}
+	}
+	// Positive control on the subject choice: the file DOES use crypto/ecdh, so
+	// this test is reading the file it thinks it is reading and a typo'd
+	// filename would not silently pass.
+	raw, err := os.ReadFile("wrapkey.go")
+	if err != nil {
+		t.Fatalf("read wrapkey.go: %v", err)
+	}
+	if !strings.Contains(string(raw), "crypto/ecdh") {
+		t.Fatal("wrapkey.go does not import crypto/ecdh — this test is not reading the wrapping " +
+			"implementation, so its negative assertions above prove nothing")
+	}
+}
+
+// TestNoHKDFModuleDependency asserts OQ-3: single-block HMAC-SHA256 expansion,
+// following hub_keys.go:31-33's deliberate choice, not x/crypto/hkdf.
+func TestNoHKDFModuleDependency(t *testing.T) {
+	raw, err := os.ReadFile("wrapkey.go")
+	if err != nil {
+		t.Fatalf("read wrapkey.go: %v", err)
+	}
+	src := stripGoComments(string(raw))
+	if strings.Contains(src, "hkdf") {
+		t.Error("wrapkey.go references hkdf — OQ-3 decided to follow hub_keys.go's no-HKDF " +
+			"precedent; adding a module to the one payload whose compromise is fleet-wide " +
+			"is a deliberate operator decision, not a side effect")
+	}
+	if !strings.Contains(src, "hmac.New(sha256.New") {
+		t.Error("wrapkey.go does not use hmac.New(sha256.New) — the expansion is not the " +
+			"single-block HMAC-SHA256 shape OQ-3 selected")
+	}
+}
+
+// --- POLICY CONSTANTS: recorded as policy, not derivation --------------------
+
+// TestWrapKeyPolicyConstants asserts OQ-4's decided values AND that they carry
+// the rationale comment the operator required. "A bare 90 is how the next
+// reader assumes it was computed."
+func TestWrapKeyPolicyConstants(t *testing.T) {
+	if wrapKeyMaxAge != 90*24*time.Hour {
+		t.Errorf("wrapKeyMaxAge = %v, want 90 days (OQ-4)", wrapKeyMaxAge)
+	}
+	if wrapKeyOverlap != 24*time.Hour {
+		t.Errorf("wrapKeyOverlap = %v, want 24h (OQ-4)", wrapKeyOverlap)
+	}
+	if wrapKeyOverlap >= wrapKeyMaxAge {
+		t.Error("the overlap window is not shorter than the key max age — a key would be " +
+			"retained past the life of its successor")
+	}
+	raw, err := os.ReadFile("wrapkey.go")
+	if err != nil {
+		t.Fatalf("read wrapkey.go: %v", err)
+	}
+	src := string(raw)
+	idx := strings.Index(src, "wrapKeyMaxAge  = 90")
+	if idx < 0 {
+		t.Fatal("could not locate the wrapKeyMaxAge declaration — this test is not reading " +
+			"what it thinks it is")
+	}
+	preamble := src[:idx]
+	for _, want := range []string{"POLICY CHOICES", "not derived", "changed"} {
+		if !strings.Contains(preamble, want) {
+			t.Errorf("the comment above wrapKeyMaxAge does not record %q — OQ-4 requires these "+
+				"constants carry a comment saying they are policy choices with no derivation "+
+				"behind them, what they trade off, and that they are safe to change deliberately", want)
+		}
+	}
+}
+
+// --- SPOKE KEY LIFECYCLE ------------------------------------------------------
+
+// TestEnsureWrapKeysPersistsBeforeUse: the key returned on first boot must
+// already be on disk. A key used but not persisted republishes as a DIFFERENT
+// key after the next pod roll, which the hub correctly refuses as a pin
+// mismatch — turning a write failure into an operator-intervention event on a
+// cluster the hub cannot reach into.
+func TestEnsureWrapKeysPersistsBeforeUse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hive-wrap-key")
+	now := time.Now()
+
+	keys, fresh, err := ensureSpokeWrapKeys(path, now)
+	if err != nil {
+		t.Fatalf("ensureSpokeWrapKeys: %v", err)
+	}
+	if !fresh {
+		t.Error("first boot did not report generating a fresh keypair")
+	}
+	if !keys.current.valid() {
+		t.Fatal("no current key returned")
+	}
+
+	reloaded, err := loadSpokeWrapKeys(path, now)
+	if err != nil {
+		t.Fatalf("the key ensure() returned was not on disk: %v", err)
+	}
+	if reloaded.current.publicKey().Hex() != keys.current.publicKey().Hex() {
+		t.Error("the persisted key differs from the one returned — the spoke would publish one " +
+			"key and republish a different one after a roll")
+	}
+}
+
+// TestWrapKeyFileMode: the private key must be 0600, matching spokeAppKeyPath's
+// stated rationale.
+func TestWrapKeyFileMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hive-wrap-key")
+	if _, _, err := ensureSpokeWrapKeys(path, time.Now()); err != nil {
+		t.Fatalf("ensureSpokeWrapKeys: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// ASSERT THE LITERAL, NOT THE CONSTANT. Comparing fi.Mode() against
+	// spokeWrapKeyFileMode is a tautology: widening the constant to 0644 moves
+	// both sides of the comparison and the test passes. (Verified: the
+	// regression replay for this property PASSED while neutered when written
+	// that way.) The invariant is 0600 specifically, so 0600 is what is written
+	// here.
+	const wantMode os.FileMode = 0o600
+	if got := fi.Mode().Perm(); got != wantMode {
+		t.Errorf("wrap key file mode = %04o, want %04o — the wrapping private key must never be "+
+			"readable by anything else sharing the PVC or the pod", got, wantMode)
+	}
+	if spokeWrapKeyFileMode != wantMode {
+		t.Errorf("spokeWrapKeyFileMode = %04o, want %04o — the constant itself was widened",
+			spokeWrapKeyFileMode, wantMode)
+	}
+	// NOT ASSERTED HERE: the mode of the containing directory. In production
+	// that is /data, the PVC mount, whose mode the spoke does not own — and in
+	// this test it is t.TempDir(), which pre-exists at 0755 so MkdirAll's mode
+	// never applies. Asserting on it would test the harness, not the code. The
+	// 0600 file mode is what actually protects the key from anything else
+	// sharing the PVC or the pod, exactly as for spokeAppKeyPath.
+}
+
+// TestPodRollWithIntactPVCIsNoOp: same key, same publication. This is the
+// property that makes ordinary restarts invisible to the hub-side pin.
+func TestPodRollWithIntactPVCIsNoOp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hive-wrap-key")
+	now := time.Now()
+	first, _, err := ensureSpokeWrapKeys(path, now)
+	if err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+	second, fresh, err := ensureSpokeWrapKeys(path, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("after roll: %v", err)
+	}
+	if fresh {
+		t.Error("a pod roll with the PVC intact regenerated the keypair — every restart would " +
+			"then require an operator re-pin")
+	}
+	if first.current.publicKey().Hex() != second.current.publicKey().Hex() {
+		t.Error("the published public key changed across a pod roll")
+	}
+}
+
+// TestPVCLossGeneratesFreshKey: PVC loss is indistinguishable from first boot BY
+// CONSTRUCTION. The spoke generates and publishes a new key; whether the hub
+// accepts it is emphatically not decided here.
+func TestPVCLossGeneratesFreshKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive-wrap-key")
+	now := time.Now()
+	first, _, err := ensureSpokeWrapKeys(path, now)
+	if err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("simulating PVC loss: %v", err)
+	}
+	second, fresh, err := ensureSpokeWrapKeys(path, now)
+	if err != nil {
+		t.Fatalf("after PVC loss: %v", err)
+	}
+	if !fresh {
+		t.Error("PVC loss did not produce a fresh keypair")
+	}
+	if first.current.publicKey().Hex() == second.current.publicKey().Hex() {
+		t.Error("PVC loss reproduced the same key — impossible unless generation is deterministic, " +
+			"which would mean the keypair is derived rather than random")
+	}
+}
+
+// TestMalformedKeyFileIsReplacedNotTrusted: a malformed file must route to
+// generate-fresh, never to a partial-recovery path. A half-readable key file is
+// not evidence of anything.
+func TestMalformedKeyFileIsReplacedNotTrusted(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"not json", "definitely not json"},
+		{"wrong version", `{"version":99,"current":"` + hex.EncodeToString(make([]byte, wrapKeyLen)) + `"}`},
+		{"truncated key", `{"version":1,"current":"abcd"}`},
+		{"empty object", `{}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "hive-wrap-key")
+			if err := os.WriteFile(path, []byte(tc.body), spokeWrapKeyFileMode); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if _, err := loadSpokeWrapKeys(path, time.Now()); err == nil {
+				t.Fatal("loadSpokeWrapKeys accepted a malformed file")
+			}
+			keys, fresh, err := ensureSpokeWrapKeys(path, time.Now())
+			if err != nil {
+				t.Fatalf("ensureSpokeWrapKeys: %v", err)
+			}
+			if !fresh || !keys.current.valid() {
+				t.Error("a malformed key file did not route to generate-fresh")
+			}
+		})
+	}
+}
+
+// --- ROTATION OVERLAP: versioned, finite, and NOT an auto-re-pin -------------
+
+// TestRotationRetainsOldPrivateKeyForOverlap is the behavioural half of
+// non-weakenable property 1. The wrap-key rotation path retains the old PRIVATE
+// key spoke-side rather than asking the hub to accept a new PUBLIC key — that
+// construction is what keeps "a different key is never accepted on bearer
+// authority" intact through the one place the design itself introduces a
+// legitimate key change.
+func TestRotationRetainsOldPrivateKeyForOverlap(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hive-wrap-key")
+	now := time.Now()
+	keys, _, err := ensureSpokeWrapKeys(path, now)
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	oldPub := keys.current.publicKey()
+
+	// The hub sealed to the OLD (still pinned) key while this was in flight.
+	inFlight, err := sealForSpoke(oldPub, "hive-alpha", 4, []byte("master-4"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	rotated, err := rotateSpokeWrapKeys(path, keys, now)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if rotated.current.publicKey().Hex() == oldPub.Hex() {
+		t.Fatal("rotation did not produce a new current key")
+	}
+	if !rotated.previous.valid() {
+		t.Fatal("rotation discarded the old private key — a master sealed to the pinned key and " +
+			"still in flight becomes unopenable, stranding the spoke")
+	}
+	if got, err := openWithSpokeKeys(rotated, "hive-alpha", inFlight); err != nil {
+		t.Errorf("an in-flight payload sealed to the pinned key did not open after rotation: %v", err)
+	} else if string(got) != "master-4" {
+		t.Errorf("overlap open returned %q", got)
+	}
+}
+
+// TestOverlapKeyIsFiniteAndZeroMeansExpired: a ZERO PreviousExpires reads as
+// ALREADY EXPIRED, never "never expires" — the same rule acceptableGenerations
+// gives VerifyUntil. Reading it the other way would keep a superseded wrapping
+// key acceptable forever, which is the F1/F2 failure mode.
+func TestOverlapKeyIsFiniteAndZeroMeansExpired(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	privCur, _ := mustWrapKeypair(t)
+	privPrev, prevPub := mustWrapKeypair(t)
+
+	write := func(t *testing.T, expires time.Time) string {
+		t.Helper()
+		path := filepath.Join(dir, "k-"+strings.ReplaceAll(t.Name(), "/", "_"))
+		f := wrapKeyFile{
+			Version:         wrapKeyFileVersion,
+			Current:         privCur.hex(),
+			CurrentCreated:  now,
+			Previous:        privPrev.hex(),
+			PreviousExpires: expires,
+		}
+		blob, err := json.Marshal(f)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(path, blob, spokeWrapKeyFileMode); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		return path
+	}
+
+	sealed, err := sealForSpoke(prevPub, "hive-alpha", 1, []byte("old-gen"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	// POSITIVE CONTROL: an unexpired overlap key IS retained and DOES open.
+	t.Run("unexpired overlap opens", func(t *testing.T) {
+		path := write(t, now.Add(time.Hour))
+		keys, err := loadSpokeWrapKeys(path, now)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if !keys.previous.valid() {
+			t.Fatal("an unexpired previous key was dropped")
+		}
+		if _, err := openWithSpokeKeys(keys, "hive-alpha", sealed); err != nil {
+			t.Errorf("unexpired overlap key did not open an in-flight payload: %v", err)
+		}
+	})
+
+	t.Run("zero expiry means already expired", func(t *testing.T) {
+		path := write(t, time.Time{})
+		keys, err := loadSpokeWrapKeys(path, now)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if keys.previous.valid() {
+			t.Error("a previous key with a ZERO expiry was retained — a hand-edited file with " +
+				"the field stripped would keep a superseded wrapping key acceptable forever")
+		}
+		if _, err := openWithSpokeKeys(keys, "hive-alpha", sealed); err == nil {
+			t.Error("a payload sealed to a zero-expiry previous key still opened")
+		}
+	})
+
+	t.Run("past expiry is excluded not warned about", func(t *testing.T) {
+		path := write(t, now.Add(-time.Minute))
+		keys, err := loadSpokeWrapKeys(path, now)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if keys.previous.valid() {
+			t.Error("an EXPIRED previous key was retained")
+		}
+		if _, err := openWithSpokeKeys(keys, "hive-alpha", sealed); err == nil {
+			t.Error("a payload sealed to an expired previous key still opened")
+		}
+	})
+}
+
+// TestWrapKeyRotationDueOnUnknownAge: a ZERO currentCreated reads as NEEDS
+// ROTATION, not "brand new" — the same fail-closed direction as
+// VerifyUntil.IsZero().
+func TestWrapKeyRotationDueOnUnknownAge(t *testing.T) {
+	priv, _ := mustWrapKeypair(t)
+	now := time.Now()
+
+	if wrapKeyNeedsRotation(spokeWrapKeys{current: priv, currentCreated: now}, now) {
+		t.Error("positive control failed: a brand-new key was reported as needing rotation")
+	}
+	if !wrapKeyNeedsRotation(spokeWrapKeys{current: priv}, now) {
+		t.Error("a key with a ZERO creation time was NOT reported as needing rotation — an " +
+			"unknown age must not read as a safe age")
+	}
+	old := now.Add(-wrapKeyMaxAge - time.Minute)
+	if !wrapKeyNeedsRotation(spokeWrapKeys{current: priv, currentCreated: old}, now) {
+		t.Error("a key past wrapKeyMaxAge was not reported as needing rotation")
+	}
+	if !wrapKeyNeedsRotation(spokeWrapKeys{}, now) {
+		t.Error("an absent key was not reported as needing rotation")
+	}
+}
+
+// --- OPTION B REPLAY ----------------------------------------------------------
+
+// TestSealedPayloadCarriesNoPlaintextSecret is the Option B replay for this
+// stage. The invariant separating D from the rejected B is that no plaintext
+// secret ever rides the delivery structure. sealedPayload must have no field
+// that could carry one.
+//
+// This is checked against the STRUCT rather than an instance, because an
+// instance test would pass simply by not populating the field. The failure mode
+// being blocked is a future field being ADDED — e.g. a heartbeat key delivered
+// alongside the master as a separate plaintext field, which OQ-2's
+// implementation note calls out by name as the way (c) becomes Option B by the
+// back door.
+func TestSealedPayloadCarriesNoPlaintextSecret(t *testing.T) {
+	// REFLECT OVER THE STRUCT, DO NOT MARSHAL AN INSTANCE. Marshalling a
+	// zero-valued instance hides any field tagged `omitempty` — and a new
+	// plaintext secret field would almost certainly be tagged that way, since
+	// every optional field on HeartbeatResponse is. (Verified: the regression
+	// replay for this property PASSED while neutered when written as a marshal
+	// of an instance.) reflect.Type sees the field regardless of its tag.
+	rt := reflect.TypeOf(sealedPayload{})
+	allowed := map[string]bool{
+		"EphemeralPub": true, "Nonce": true, "Ciphertext": true,
+		"GenerationID": true, "Fingerprint": true,
+	}
+	seen := map[string]bool{}
+	for i := 0; i < rt.NumField(); i++ {
+		name := rt.Field(i).Name
+		seen[name] = true
+		if !allowed[name] {
+			t.Errorf("sealedPayload gained an unreviewed field %q (json tag %q). Under OQ-2(c) "+
+				"the new heartbeat key ships SEALED INSIDE the ciphertext, never as a separate "+
+				"plaintext field on the delivery structure — a plaintext secret field here is "+
+				"Option B by the back door, and Option B was rejected because it makes the "+
+				"heartbeat bearer a master-exfiltration primitive",
+				name, rt.Field(i).Tag.Get("json"))
+		}
+	}
+	// Positive control on the subject: the fields this test knows about are
+	// actually present, so a renamed or emptied struct would not silently pass.
+	for k := range allowed {
+		if !seen[k] {
+			t.Errorf("expected field %q missing — this test is not inspecting the payload it "+
+				"thinks it is, so its negative assertions above prove nothing", k)
+		}
+	}
+	// And the marshalled form must carry no unexpected key either, which catches
+	// a field renamed only at the json-tag level.
+	blob, err := json.Marshal(sealedPayload{
+		EphemeralPub: "aa", Nonce: "bb", Ciphertext: "cc", GenerationID: 1, Fingerprint: "dd",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(blob, &fields); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	allowedJSON := map[string]bool{
+		"ephemeral_pub": true, "nonce": true, "ciphertext": true,
+		"generation_id": true, "fingerprint": true,
+	}
+	for k := range fields {
+		if !allowedJSON[k] {
+			t.Errorf("sealedPayload marshals an unreviewed json key %q", k)
+		}
+	}
+}
+
+// TestHubCannotReopenWhatItSealed: the hub generates a fresh ephemeral per seal
+// and discards it. If the hub retained any means of reopening, the entire
+// premise (a non-confidential delivery channel is acceptable because only the
+// recipient can open) would be false.
+func TestHubCannotReopenWhatItSealed(t *testing.T) {
+	priv, pub := mustWrapKeypair(t)
+	sp, err := sealForSpoke(pub, "hive-alpha", 1, []byte("master"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	// The only public material the hub retains is the ephemeral public key and
+	// the recipient public key. Neither yields the shared secret.
+	ephPub, err := parseWrapPublicKey(sp.EphemeralPub)
+	if err != nil {
+		t.Fatalf("ephemeral pub did not parse: %v", err)
+	}
+	if ephPub.Hex() == pub.Hex() {
+		t.Error("the ephemeral public key equals the recipient's — no ephemeral was generated")
+	}
+	// Positive control: the recipient CAN open.
+	if _, err := openFromHub(priv, "hive-alpha", sp); err != nil {
+		t.Fatalf("positive control failed: the recipient could not open: %v", err)
+	}
+}
+
+// --- fingerprint --------------------------------------------------------------
+
+// TestFingerprintIsStableDistinctAndNotKeyMaterial. A fingerprint is a PUBLIC
+// identifier that appears on dashboards and in operator re-pin commands, so it
+// must be domain-separated from the AEAD key derivation: a value an operator
+// reads off a screen must never be usable as key material.
+func TestFingerprintIsStableDistinctAndNotKeyMaterial(t *testing.T) {
+	privA, pubA := mustWrapKeypair(t)
+	_, pubB := mustWrapKeypair(t)
+
+	if wrapKeyFingerprint(pubA) == "" {
+		t.Fatal("fingerprint of a valid key was empty")
+	}
+	if wrapKeyFingerprint(pubA) != wrapKeyFingerprint(pubA) {
+		t.Error("fingerprint is not stable")
+	}
+	if wrapKeyFingerprint(pubA) == wrapKeyFingerprint(pubB) {
+		t.Error("two distinct keys share a fingerprint")
+	}
+	if wrapKeyFingerprint(wrapPublicKey{}) != "" {
+		t.Error("an invalid key produced a non-empty fingerprint")
+	}
+	if strings.Contains(wrapKeyFingerprint(pubA), pubA.Hex()) {
+		t.Error("the fingerprint contains the raw public key")
+	}
+	// It must not equal the AEAD key derived from any shared secret involving
+	// this key. Different info labels guarantee this; assert it so a future
+	// "simplify the labels" change is caught.
+	_, ephPub := mustWrapKeypair(t)
+	shared := make([]byte, wrapKeyLen)
+	aeadKey := hex.EncodeToString(deriveWrapAEADKey(shared, ephPub, pubA))
+	if wrapKeyFingerprint(pubA) == aeadKey {
+		t.Error("the fingerprint collides with a derived AEAD key — the domain separation " +
+			"between a public identifier and key material has been lost")
+	}
+	_ = privA
+}
+
+// stripGoComments removes // and /* */ comments so source assertions match on
+// CODE rather than on the explanatory prose that necessarily names the very
+// things being forbidden.
+func stripGoComments(src string) string {
+	src = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(src, "")
+	var b strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/v2/pkg/proxy/close_wait_leak_test.go
+++ b/v2/pkg/proxy/close_wait_leak_test.go
@@ -1,0 +1,222 @@
+package proxy
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regressions for issue #3875: the hive process leaked CLOSE_WAIT sockets to
+// GitHub through its own MITM proxy until FD exhaustion (92,962 FDs measured
+// live) self-DoSed the pod. #3872 bounded relayTunnel's half-close drains, but
+// two proxyHTTP paths kept the pre-#3872 shape:
+//
+//  1. the git smart-HTTP branch ran its OWN unbounded io.Copy pair, so an
+//     upstream FIN with a half-open client parked the handler at <-done
+//     forever — the deferred conn Closes never ran and the FIN'd upstream
+//     socket sat in CLOSE_WAIT for the life of the process;
+//  2. the API branch cleared the upstream read deadline once response HEADERS
+//     arrived, so a "reachable but slow" GitHub (TLS + headers OK, body never
+//     comes — the measured live signature) parked resp.Write in an unbounded
+//     upstream.Read holding all three sockets of the exchange, one fresh
+//     parked handler per retry (~1k FDs/min measured on a live spoke).
+//
+// The leak invariant in both: proxyHTTP MUST RETURN once the exchange can no
+// longer make progress, because the sockets are closed by the CALLERS'
+// deferred Closes — a handler that never returns is a socket that never
+// closes.
+
+func leakTestProxy() *GitHubProxy {
+	return &GitHubProxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func shortenBodyStall(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := responseBodyStallTimeout
+	responseBodyStallTimeout = d
+	t.Cleanup(func() { responseBodyStallTimeout = old })
+}
+
+func runProxyHTTP(p *GitHubProxy, client, upstream net.Conn) chan struct{} {
+	returned := make(chan struct{})
+	go func() {
+		p.proxyHTTP(client, upstream, internalCallerName, 0)
+		close(returned)
+	}()
+	return returned
+}
+
+// TestProxyHTTPGitRelayReleasesAfterUpstreamFIN is the regression for leak
+// (1): upstream sends the git response and FINs; the client keeps its side
+// half-open (keep-alive). Pre-fix the inline copy pair blocked in
+// client.Read() forever and <-done never returned; the FIN'd upstream fd was
+// CLOSE_WAIT until process death. Post-fix the git branch goes through
+// relayTunnel, whose half-close drain releases the handler.
+func TestProxyHTTPGitRelayReleasesAfterUpstreamFIN(t *testing.T) {
+	shortenTunnelDrain(t, 300*time.Millisecond)
+	p := leakTestProxy()
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runProxyHTTP(p, proxyClientSide, proxyUpstreamSide)
+
+	req := "GET /kubestellar/hive.git/info/refs?service=git-upload-pack HTTP/1.1\r\nHost: github.com\r\n\r\n"
+	if _, err := agentSide.Write([]byte(req)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4096)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := forgeSide.Read(buf); err != nil {
+		t.Fatalf("upstream did not receive relayed git request: %v", err)
+	}
+	const gitResp = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+	if _, err := forgeSide.Write([]byte(gitResp)); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+	forgeSide.Close() // remote FIN — our side must eventually close too
+
+	// Positive control: the response reached the client through the relay.
+	respBuf := make([]byte, len(gitResp))
+	agentSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(agentSide, respBuf); err != nil {
+		t.Fatalf("client did not receive relayed git response: %v", err)
+	}
+	// The client deliberately does NOT close: half-open keep-alive is the
+	// leak-triggering state.
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxyHTTP wedged after upstream FIN with a half-open client — the CLOSE_WAIT leak (#3875)")
+	}
+}
+
+// TestProxyHTTPBodyStallReleasesHandler is the regression for leak (2):
+// headers arrive promptly, the body never does, and the client gives up and
+// closes (the 10s collect budget firing). Pre-fix resp.Write sat in an
+// unbounded upstream.Read forever. Post-fix the rolling stall bound errors the
+// relay out and proxyHTTP returns.
+func TestProxyHTTPBodyStallReleasesHandler(t *testing.T) {
+	shortenBodyStall(t, 300*time.Millisecond)
+	p := leakTestProxy()
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runProxyHTTP(p, proxyClientSide, proxyUpstreamSide)
+
+	req := "GET /app/installations/1/access_tokens HTTP/1.1\r\nHost: api.github.com\r\n\r\n"
+	if _, err := agentSide.Write([]byte(req)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4096)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := forgeSide.Read(buf); err != nil {
+		t.Fatalf("upstream did not receive relayed request: %v", err)
+	}
+	// Headers promptly; the 1000-byte body NEVER — GitHub's measured
+	// "reachable but slow" signature (TLS in 0.03–2.2s, 0 body bytes in 12s).
+	if _, err := forgeSide.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\n")); err != nil {
+		t.Fatalf("upstream header write: %v", err)
+	}
+	// The minting client's context deadline fires; it hangs up.
+	time.Sleep(100 * time.Millisecond)
+	agentSide.Close()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxyHTTP wedged on a stalled response body — the parked-handler FD leak (#3875)")
+	}
+}
+
+// TestProxyHTTPBodyRelayToleratesSlowButFlowingBody is the positive control
+// against over-fixing: the stall bound must be a rolling PER-READ bound, not a
+// cap on total transfer time. A body that keeps trickling — each gap well
+// under the stall bound, total time well over it — must arrive intact.
+func TestProxyHTTPBodyRelayToleratesSlowButFlowingBody(t *testing.T) {
+	shortenBodyStall(t, 500*time.Millisecond)
+	p := leakTestProxy()
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runProxyHTTP(p, proxyClientSide, proxyUpstreamSide)
+
+	req := "GET /repos/kubestellar/hive/issues HTTP/1.1\r\nHost: api.github.com\r\n\r\n"
+	if _, err := agentSide.Write([]byte(req)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4096)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := forgeSide.Read(buf); err != nil {
+		t.Fatalf("upstream did not receive relayed request: %v", err)
+	}
+	const chunks = 6
+	body := strings.Repeat("x", chunks)
+	if _, err := forgeSide.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\n")); err != nil {
+		t.Fatalf("upstream header write: %v", err)
+	}
+	// 6 bytes over ~900ms: every inter-byte gap (150ms) is far inside the
+	// 500ms stall bound, but the TOTAL exceeds it. An absolute deadline would
+	// cut this transfer; the rolling bound must not.
+	for i := 0; i < chunks; i++ {
+		time.Sleep(150 * time.Millisecond)
+		if _, err := forgeSide.Write([]byte{body[i]}); err != nil {
+			t.Fatalf("upstream body write %d: %v", i, err)
+		}
+	}
+
+	respBuf := make([]byte, 512)
+	agentSide.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := ""
+	for !strings.HasSuffix(got, body) {
+		n, err := agentSide.Read(respBuf)
+		if err != nil {
+			t.Fatalf("client read: %v (got so far: %q)", err, got)
+		}
+		got += string(respBuf[:n])
+	}
+
+	agentSide.Close()
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxyHTTP did not return after the client closed")
+	}
+}
+
+// TestProxyHTTPHasNoInlineCopyPairs asserts the source-level invariant behind
+// leak (1): every opaque byte-shuttling path in github_proxy.go must go
+// through relayTunnel (whose half-close drains are the #3872 guarantee), never
+// a hand-rolled io.Copy pair. The pre-fix git branch was exactly such a pair
+// that #3872 missed. relayTunnel's own two copies are the only sanctioned
+// ones.
+func TestProxyHTTPHasNoInlineCopyPairs(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(file), "github_proxy.go"))
+	if err != nil {
+		t.Fatalf("read github_proxy.go: %v", err)
+	}
+	text := string(body)
+	const wantRelayTunnelCalls = 3 // transparent passthrough, CONNECT tunnelDirect, git branch
+	if got := strings.Count(text, "relayTunnel(") - strings.Count(text, "func relayTunnel("); got != wantRelayTunnelCalls {
+		t.Fatalf("relayTunnel call sites = %d, want %d — opaque relays must use relayTunnel, not inline io.Copy pairs", got, wantRelayTunnelCalls)
+	}
+	// relayTunnel's own two directional copies are the only raw conn-to-conn
+	// io.Copy allowed in this file.
+	if got := strings.Count(text, "io.Copy(upstream, client)"); got != 0 {
+		t.Fatalf("found %d inline io.Copy(upstream, client) — the unbounded copy-pair shape that leaked CLOSE_WAIT sockets (#3875)", got)
+	}
+	// And the API branch must bound its body relay.
+	if !strings.Contains(text, "resp.Body = &stallBoundedBody{") {
+		t.Fatal("proxyHTTP response body relay must be wrapped in stallBoundedBody — an unbounded body read parks the handler and leaks its sockets (#3875)")
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -435,14 +435,7 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 		if _, err := upstream.Write(fullBuf); err != nil {
 			return
 		}
-		done := make(chan struct{})
-		go func() {
-			io.Copy(upstream, conn)
-			upstream.(*net.TCPConn).CloseWrite()
-			close(done)
-		}()
-		io.Copy(conn, upstream)
-		<-done
+		relayTunnel(conn, upstream)
 		return
 	}
 
@@ -1065,15 +1058,58 @@ func (p *GitHubProxy) tunnelDirect(conn net.Conn, r *http.Request) {
 
 	fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n")
 
+	relayTunnel(conn, upstream)
+}
+
+// tunnelHalfCloseDrain bounds how long one direction of an opaque tunnel may
+// keep waiting for bytes AFTER the other direction has already finished. It is
+// a var, not a const, for the same reason as waitForReadyPollInterval in
+// pkg/hub: tests need a relay that unwedges in milliseconds. Production keeps
+// the default.
+//
+// 30s is deliberately generous: the only legitimate traffic still in flight
+// once one side has hung up is a response tail already on the wire, which
+// arrives in RTTs, not tens of seconds.
+var tunnelHalfCloseDrain = 30 * time.Second
+
+// relayTunnel shuttles bytes both ways between the proxied client conn and the
+// upstream until BOTH directions have finished, bounding each direction once
+// the other has ended.
+//
+// WHY THE BOUNDS EXIST (measured live, 2026-08-14): the previous inline copies
+// waited on each other unboundedly. On spokes whose forge host
+// (github.ibm.com) sits behind a SYN-accepting firewall, the upstream TCP
+// connect succeeds but no byte ever comes back and no FIN is ever sent. The
+// client (the daemon's own JWT mints, agents' CLIs) gives up at its TLS
+// handshake timeout and closes — the client→upstream copy finishes and
+// half-closes the upstream — but io.Copy(conn, upstream) stayed blocked in
+// upstream.Read() FOREVER. Every attempt leaked two sockets (the FIN_WAIT2 /
+// CLOSE_WAIT piles), the goroutine, and the splice pipe pair io.Copy holds for
+// a TCP↔TCP copy on Linux: ~300k fds and ~11 burned cores per affected spoke.
+//
+// SetReadDeadline is documented to interrupt Reads that are ALREADY blocked,
+// which is exactly what arms the escape hatch here: each side arms the OTHER
+// side's deadline only at the moment its own direction completes, so a
+// healthy long-lived tunnel (git smart HTTP, device-flow polling) is never
+// cut while both directions are still live.
+func relayTunnel(conn, upstream net.Conn) {
 	done := make(chan struct{})
 	go func() {
 		io.Copy(upstream, conn)
 		if tc, ok := upstream.(*net.TCPConn); ok {
 			tc.CloseWrite()
 		}
+		// Client side is done (EOF or error — a dead client looks the same).
+		// A live upstream answers or closes within RTTs; a blackholed one
+		// never would, so bound the remaining upstream→client read.
+		upstream.SetReadDeadline(time.Now().Add(tunnelHalfCloseDrain))
 		close(done)
 	}()
 	io.Copy(conn, upstream)
+	// Mirror image: upstream finished (or errored) but the client may sit
+	// half-open without ever sending EOF; bound the client-side read so
+	// <-done cannot wedge this handler.
+	conn.SetReadDeadline(time.Now().Add(tunnelHalfCloseDrain))
 	<-done
 }
 

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -927,13 +927,16 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			}
 			upstream.SetWriteDeadline(time.Time{})
 			client.SetReadDeadline(time.Time{})
-			done := make(chan struct{})
-			go func() {
-				io.Copy(upstream, client)
-				close(done)
-			}()
-			io.Copy(client, upstream)
-			<-done
+			// Use relayTunnel, NOT an inline copy pair: this branch used to run
+			// its own unbounded io.Copy pair, which was the same wedge #3872
+			// fixed in relayTunnel but left here. When GitHub FIN'd after the
+			// response while the client kept its side open (keep-alive), the
+			// client→upstream copy stayed blocked in client.Read() forever and
+			// `<-done` never returned — the handler's deferred Closes never ran,
+			// parking the upstream socket in CLOSE_WAIT for the life of the
+			// process (issue #3875's FD pile). relayTunnel bounds each direction
+			// once the other finishes.
+			relayTunnel(client, upstream)
 			return
 		}
 
@@ -957,6 +960,20 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			p.logTimeout("proxy upstream response read timed out", err, "agent", agentName, "path", req.URL.Path)
 			return
 		}
+
+		// Bound the BODY relay too, not just the header read above. The
+		// deadline was cleared once headers arrived, so a "reachable but slow"
+		// GitHub — TLS and headers complete, body never arrives (the measured
+		// #3875 signature: time_total=12s, 0 body bytes) — parked resp.Write
+		// in upstream.Read() with no deadline. The client had long since given
+		// up (10s collect budget) and FIN'd its side, but this goroutine never
+		// noticed: it holds all three sockets of the exchange forever, and the
+		// retry loop stacks a fresh parked handler on every attempt (~1k
+		// FDs/min measured live). The wrapper re-arms a rolling per-Read
+		// deadline, so a body that keeps flowing is never cut while a stall
+		// longer than responseBodyStallTimeout errors out and lets the
+		// handler's deferred Closes reclaim the sockets.
+		resp.Body = &stallBoundedBody{body: resp.Body, conn: upstream, idle: responseBodyStallTimeout}
 
 		client.SetWriteDeadline(time.Now().Add(httpWriteTimeout))
 		if err := resp.Write(client); err != nil {
@@ -1059,6 +1076,44 @@ func (p *GitHubProxy) tunnelDirect(conn net.Conn, r *http.Request) {
 	fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n")
 
 	relayTunnel(conn, upstream)
+}
+
+// responseBodyStallTimeout bounds how long the MITM'd response-BODY relay may
+// go without a single byte of progress from the upstream. It is a rolling
+// per-Read bound (re-armed on every read by stallBoundedBody), not a cap on
+// total transfer time, so a large-but-flowing response is never cut while an
+// upstream that goes silent mid-body releases the handler — and with it the
+// three sockets of the exchange — within one stall window. A var, not a
+// const, so tests can shorten it (same pattern as tunnelHalfCloseDrain).
+// Matches httpReadTimeout: the same patience already extended to the header
+// phase.
+var responseBodyStallTimeout = httpReadTimeout
+
+// stallBoundedBody wraps a proxied response body so every underlying Read is
+// preceded by re-arming a read deadline on the upstream conn. Close clears the
+// deadline (for the next keep-alive exchange on the same conn) and closes the
+// wrapped body. See responseBodyStallTimeout for why this exists (#3875).
+type stallBoundedBody struct {
+	body io.ReadCloser
+	conn net.Conn
+	idle time.Duration
+}
+
+func (b *stallBoundedBody) Read(p []byte) (int, error) {
+	b.conn.SetReadDeadline(time.Now().Add(b.idle))
+	return b.body.Read(p)
+}
+
+func (b *stallBoundedBody) Close() error {
+	// Close the wrapped body while a stall deadline is armed: net/http body
+	// Close paths may still read from the conn (drain-to-EOF), and an unarmed
+	// read there would reintroduce the very stall this type exists to bound.
+	// The deadline is cleared afterwards so the next keep-alive exchange on
+	// this conn starts unencumbered.
+	b.conn.SetReadDeadline(time.Now().Add(b.idle))
+	err := b.body.Close()
+	b.conn.SetReadDeadline(time.Time{})
+	return err
 }
 
 // tunnelHalfCloseDrain bounds how long one direction of an opaque tunnel may

--- a/v2/pkg/proxy/tunnel_drain_test.go
+++ b/v2/pkg/proxy/tunnel_drain_test.go
@@ -1,0 +1,140 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// tcpPair returns two ends of a real localhost TCP connection. relayTunnel's
+// escape hatch relies on net.Conn deadline semantics interrupting an
+// in-flight blocked Read, so the test must use real sockets, not net.Pipe.
+func tcpPair(t *testing.T) (client, server net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	ch := make(chan acceptResult, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		ch <- acceptResult{c, aerr}
+	}()
+	client, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	res := <-ch
+	if res.err != nil {
+		t.Fatalf("accept: %v", res.err)
+	}
+	t.Cleanup(func() { client.Close(); res.conn.Close() })
+	return client, res.conn
+}
+
+func shortenTunnelDrain(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := tunnelHalfCloseDrain
+	tunnelHalfCloseDrain = d
+	t.Cleanup(func() { tunnelHalfCloseDrain = old })
+}
+
+func runRelay(conn, upstream net.Conn) chan struct{} {
+	returned := make(chan struct{})
+	go func() {
+		relayTunnel(conn, upstream)
+		close(returned)
+	}()
+	return returned
+}
+
+// TestRelayTunnelDataFlowsBothWays is the positive control: the drain bounds
+// must not have broken the relay itself. Bytes written on either side while
+// both directions are live must arrive intact on the other.
+func TestRelayTunnelDataFlowsBothWays(t *testing.T) {
+	shortenTunnelDrain(t, 2*time.Second)
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+
+	returned := runRelay(proxyClientSide, proxyUpstreamSide)
+
+	if _, err := agentSide.Write([]byte("ping")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 4)
+	forgeSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(forgeSide, buf); err != nil || string(buf) != "ping" {
+		t.Fatalf("client→upstream relay: got %q err %v", buf, err)
+	}
+	if _, err := forgeSide.Write([]byte("pong")); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+	agentSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(agentSide, buf); err != nil || string(buf) != "pong" {
+		t.Fatalf("upstream→client relay: got %q err %v", buf, err)
+	}
+
+	// Orderly shutdown from both ends releases the relay.
+	agentSide.Close()
+	forgeSide.Close()
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relayTunnel did not return after both ends closed")
+	}
+}
+
+// TestRelayTunnelUnwedgesFromSilentUpstream is the regression for the live
+// incident: the upstream TCP-connects (SYN-accepting firewall in front of an
+// unreachable forge) but never sends a byte and never FINs. The client gives
+// up and closes. Before the drain bound, io.Copy(conn, upstream) stayed
+// blocked in upstream.Read() forever, leaking both sockets, the goroutine and
+// io.Copy's splice pipe pair on every attempt.
+func TestRelayTunnelUnwedgesFromSilentUpstream(t *testing.T) {
+	shortenTunnelDrain(t, 300*time.Millisecond)
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+	_ = forgeSide // held open, silent: never reads, never writes, never closes
+
+	returned := runRelay(proxyClientSide, proxyUpstreamSide)
+
+	if _, err := agentSide.Write([]byte("client-hello")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	agentSide.Close() // client-side TLS timeout fires; the client is gone
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relayTunnel wedged on a silent upstream after the client closed — the leak this fix exists for")
+	}
+}
+
+// TestRelayTunnelUnwedgesFromSilentClient is the mirror image: the upstream
+// closes but the client sits half-open forever without sending EOF. <-done
+// must not wedge the handler.
+func TestRelayTunnelUnwedgesFromSilentClient(t *testing.T) {
+	shortenTunnelDrain(t, 300*time.Millisecond)
+	agentSide, proxyClientSide := tcpPair(t)
+	proxyUpstreamSide, forgeSide := tcpPair(t)
+	_ = agentSide // held open, silent
+
+	returned := runRelay(proxyClientSide, proxyUpstreamSide)
+
+	if _, err := forgeSide.Write([]byte("gone")); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+	forgeSide.Close()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("relayTunnel wedged on a silent client after the upstream closed")
+	}
+}

--- a/v2/scripts/check-suid-contract.sh
+++ b/v2/scripts/check-suid-contract.sh
@@ -28,8 +28,12 @@
 #   - NO `setcap` file capability on the hive binary (a file cap EPERMs on exec
 #     wherever the runtime bounding set lacks the cap — the #3760 crash-loop).
 #   - the entrypoint instead raises NET_ADMIN as an AMBIENT capability, gated on
-#     the CAP_NET_ADMIN bounding-set bit, via `setpriv --ambient-caps +net_admin`,
+#     the CAP_NET_ADMIN bounding-set bit, via
+#     `setpriv --inh-caps +net_admin --ambient-caps +net_admin`,
 #     with a `gosu dev` fallback when the cap is unavailable.
+#     BOTH flags are required (#3874): --ambient-caps alone exits 0 but yields
+#     CapAmb=0x0, because the kernel only allows an ambient bit that is also in
+#     the inheritable set, which the setuid transition has already zeroed.
 #
 # Usage: v2/scripts/check-suid-contract.sh [path-to-Dockerfile] [path-to-entrypoint]
 set -euo pipefail
@@ -166,8 +170,17 @@ check "entrypoint reads the bounding set (CapBnd)" \
   'CapBnd' "$ENTRYPOINT"
 check "entrypoint tests the CAP_NET_ADMIN bounding-set bit (bit 12 / 0x1000)" \
   '0x1000' "$ENTRYPOINT"
-check "entrypoint raises NET_ADMIN as an ambient capability via setpriv" \
-  'setpriv[[:space:]]+--ambient-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"
+# INVERTED (not relaxed) for #3874. This assertion previously required the
+# literal `setpriv --ambient-caps +net_admin` — i.e. it demanded EXACTLY the
+# form that is silently broken, and would have gone RED on the correct fix. It
+# ENCODED the bug: an ambient bit cannot be raised unless the same setpriv call
+# also raises the INHERITABLE set (the kernel requires the cap in pP *and* pI;
+# setpriv applies --ambient-caps after the UID change, when pI is already zero).
+# The contract is now the stronger one: --inh-caps must accompany --ambient-caps.
+check "entrypoint raises NET_ADMIN into the INHERITABLE set (required for the ambient raise to stick — #3874)" \
+  '--inh-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"
+check "entrypoint raises NET_ADMIN as an ambient capability" \
+  '--ambient-caps[[:space:]]+\+net_admin' "$ENTRYPOINT"
 # The setpriv identity (--reuid dev) may live in a shell variable reused by both
 # the probe and the exec, so assert it appears in the file rather than adjacent
 # to --ambient-caps. A missing --reuid dev would leave the drop-to-dev broken.


### PR DESCRIPTION
Top-up merge of `v4` into `dd`, carrying today's fleet-wide outage fix. Visual Hive work preserved.

## Why

`dd` was on the **broken** entrypoint form. Before this merge:

```sh
exec setpriv --ambient-caps +net_admin $_SETPRIV_ID "$0" "$@"
```

`setpriv --ambient-caps +net_admin` **exits 0 while doing nothing**: the kernel only permits an ambient bit that is also in the *inheritable* set, and `setpriv` applies ambient caps *after* the UID change, when `pI` has already been zeroed. Spokes land with `CapAmb: 0000000000000000`; the MITM proxy cannot `setsockopt(SO_MARK)` its upstream dial, fails its own `-m mark --mark 0x1112 -j RETURN` bypass, and is REDIRECTed back into itself — every outbound :443 returns `000`. Verified live on `kalantar-msb-soft-reflect-jsro` (`mk-latest`, `f304841`).

## Commits carried

| Commit | Change |
| --- | --- |
| `e6c769ff` | entrypoint `--inh-caps` — **the outage fix** |
| `1dab71b4` | heartbeat liveness decoupled from GitHub availability |
| `ca6aa8ad` | proxy tunnel half-close drain (fd/goroutine leak) |
| `7a783d05` | Option D stage 1 (X25519 sealed box; inert) |

## Verification

Merged `v2/deploy/entrypoint.sh` line 978:

```sh
_SETPRIV_CAPS="--inh-caps +net_admin --ambient-caps +net_admin"
```

The entrypoint also verifies the *outcome* — it reads `CapAmb` back from `/proc/self/status` in the dropped child and requires bit 12, so a `setpriv` that "succeeds" with `CapAmb=0x0` falls through to the honest gosu path rather than silently claiming an exemption it lacks.

`git merge-base --is-ancestor` — all ANCESTOR: `e6c769ff`, `1dab71b4`, `ca6aa8ad`, `7a783d05`.

Security greps: `TerminalSigningKey` has no `HIVE_SESSION_KEY`/`EnvSessionKey` fallthrough (N3 closed); `inviteSigningSecret` calls `hub.SpokeInviteKey()` and never reads the raw master; `perHiveEnvMaxPatchesPerCycle = 3`.

The two tests that were inverted in #3874 arrived asserting the **fixed** shape, not the broken one — `test_entrypoint_netadmin_ambient.sh` requires `--inh-caps`, and `check-suid-contract.sh` documents that demanding the literal `--ambient-caps`-only string previously *encoded* the bug. No re-inversion needed.

## Conflicts

**None.** The merge touched 30 files, all of them shared v4 surface (`pkg/hub`, `pkg/proxy`, `pkg/github`, `pkg/dashboard`, `deploy/`, `scripts/`).

## Fork-specific work confirmed intact

`git diff origin/dd HEAD` shows the merge modified **zero** dd-owned files:

- `v2/pkg/visualhive/` — 28 files, untouched
- `v2/pkg/internal/visualhivepr/` — untouched
- `v2/cmd/hive/integrated_test.go` — untouched
- dd's signed integrated README — unchanged (no diff under `*README*`), so the `98f609a8` restoration is not re-clobbered
- `v2/cmd/hive/main.go` still uses the explicit no-op-logger form, **not** the blank import, so the `automaxprocs` banner cannot corrupt parsed git output again:

```go
_, _ = maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
```

All 33 dd-unique commits remain ancestors, including the four `fix(sync): ...` repair commits.

## Tests

`go build ./...` clean. `go test ./pkg/hub/ ./pkg/dashboard/ ./pkg/visualhive/` — all three ok.

Merge commit (not squashed) so `merge-base --is-ancestor` checks keep working.
