### PR TITLE
✨ feature(governor,config,dashboard): auto-scale mode thresholds by configured repo count

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1095,6 +1095,10 @@ func main() {
 	// Dashboard login now requests no scope and no user write-token is persisted.
 
 	gov := governor.New(cfg.Governor, cfg.EnabledAgents(), logger)
+	// Default mode thresholds scale with how many repos the hive watches, so
+	// the mode ladder means the same thing on a 3-repo hive as on a 39-repo
+	// one (#3498). Explicit thresholds are unaffected.
+	gov.SetRepoCount(cfg.Project.RepoCount())
 	sched := scheduler.New(cfg, logger)
 
 	// Wire the GitHub prompt-source resolver so agents may source their kick
@@ -2618,6 +2622,9 @@ func main() {
 		// Re-sync subsystems that cache config values
 		ghClient.SetRepos(cfg.Project.Repos)
 		gov.UpdateConfig(cfg.Governor)
+		// A reload can add or archive repos, which moves every scaled default
+		// threshold — re-sync it alongside the repo list above.
+		gov.SetRepoCount(cfg.Project.RepoCount())
 		agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 
 		// Re-apply live agent definitions (definition_source) on reload so an

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -42,6 +42,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
+- [Governor mode thresholds](https://github.com/kubestellar/hive/blob/v4/src/docs/governor-thresholds.md) — how idle/quiet/busy/surge thresholds scale with repo count, the `threshold_scaling` curves, and when explicit thresholds win.
 - [Supervisor agent](https://github.com/kubestellar/hive/blob/v4/src/docs/supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
 - [Custom dashboard stylesheets](https://github.com/kubestellar/hive/blob/v4/src/docs/custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
 - [Portable AgentDefinition format](https://github.com/kubestellar/hive/blob/v4/src/AGENT-DEFINITION.md) — standalone YAML schema for importing/exporting agent definitions.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -229,7 +229,7 @@ Pin a model when reproducibility matters more than the governor's budget optimiz
 
 ## Cadences and the governor
 
-Agents don't schedule themselves. The **governor** evaluates the work queue every `eval_interval_s` (default 300s), computes a mode from queue depth — **idle → quiet → busy → surge** (default thresholds: quiet > 2, busy > 10, surge > 20; override with `threshold:`) — and kicks each agent on the cadence that mode assigns it:
+Agents don't schedule themselves. The **governor** evaluates the work queue every `eval_interval_s` (default 300s), computes a mode from queue depth — **idle → quiet → busy → surge** (default thresholds: quiet > 2, busy > 10, surge > 20 **per watched repo**; override with `threshold:`) — and kicks each agent on the cadence that mode assigns it:
 
 ```yaml
 governor:
@@ -250,6 +250,7 @@ governor:
       architect: pause     # "pause" stops kicks for this agent in this mode
 ```
 
+- **Thresholds scale with repo count.** The *default* thresholds above are per-repo bases, multiplied by `len(project.repos)` — so `surge` is 20 on a 1-repo hive and 780 on a 39-repo one, and the mode ladder means the same thing at any hive size. A `threshold:` you set yourself is used verbatim and never scaled. Tune the curve with `governor.threshold_scaling` (`linear` default, `sqrt`, `none`). See [Governor mode thresholds](governor-thresholds.md), which also covers the ACMM-pack interaction.
 - **Mutually exclusive modes.** Each per-agent, per-mode cadence is either an interval (`5m`, `2h`, `pause`) or a time-of-day schedule — never both. Config load and API writes reject mixed forms with a 400/error.
 - **Time-of-day schedules.** Use `times: ["HH:MM"]` with optional `days` (`mon` … `sun`) and a required IANA `tz`. The timezone is stored explicitly and displayed with the schedule; it does not float with the viewer.
 - **Advanced cron.** Power users can provide a constrained five-field cron expression plus `tz`. Hive evaluates these with robfig/cron and schedule-local timezone handling.

--- a/src/docs/governor-thresholds.md
+++ b/src/docs/governor-thresholds.md
@@ -1,0 +1,106 @@
+# Governor mode thresholds and repo-count scaling
+
+The governor picks a mode — **idle → quiet → busy → surge** — by comparing queue depth (actionable issues + open PRs, summed across every repo the hive watches) against three thresholds. The mode then selects each agent's kick cadence, so the thresholds are what decide how hard the hive works.
+
+## The problem the scaling solves
+
+Queue depth scales with how many repos a hive watches; the thresholds did not. A fixed `surge: 20` therefore encoded an implicit repo count:
+
+- A 39-repo hive naturally carries a queue in the low hundreds. Against absolute thresholds it sat in **SURGE permanently**, running the most aggressive cadences even though the per-repo backlog was small. Observed live: queue ~210 against a threshold of 70.
+- A 3-repo hive with the same thresholds would idle through a backlog that is genuinely deep *per repo*.
+
+Every hive with a different repo count had to hand-tune, and re-tune whenever repos were added or archived.
+
+## What happens by default
+
+The **default** thresholds are now per-repo base values, multiplied by the number of repos in `project.repos`:
+
+| | base (1 repo) | 3 repos | 39 repos |
+|---|---:|---:|---:|
+| `surge` | 20 | 60 | 780 |
+| `busy` | 10 | 30 | 390 |
+| `quiet` | 2 | 6 | 78 |
+
+A hive watching one repo (or none — `primary_repo` still counts as one) gets exactly the numbers it got before, so single-repo hives see no change at all.
+
+The effect is that the mode ladder means the same thing at any hive size: **surge is "20+ items per repo"** rather than "20 items, however many repos you watch".
+
+## Choosing a curve
+
+```yaml
+governor:
+  threshold_scaling: linear   # linear (default) | sqrt | none
+```
+
+| Value | Factor | When to use |
+|---|---|---|
+| `linear` (default) | `× repo_count` | The general case. Exactly equivalent to comparing per-repo queue pressure against the base thresholds. |
+| `sqrt` | `× ceil(√repo_count)` | Hives whose queue depth does not grow linearly with repo count — many small, quiet repos alongside a few busy ones. Reaches surge sooner than linear. |
+| `none` | `× 1` | Treat the thresholds as absolute queue depths. This is the behavior from before scaling existed. |
+
+For 39 repos, `linear` surges at 780 and `sqrt` at 140 (`ceil(√39) = 7`). Note that `sqrt` and `linear` are identical at 1 and 2 repos and only separate from 3 onward, because the ceiling cannot produce a factor below 2 until 5 repos.
+
+An unrecognized value is rejected at config load.
+
+## Explicit thresholds always win
+
+A threshold you set yourself is used **verbatim and never scaled**:
+
+```yaml
+governor:
+  modes:
+    surge:
+      threshold: 300     # used as-is on a 39-repo hive, not 300 × 39
+```
+
+So a hive that already hand-tuned its way around this problem keeps working unchanged, and dragging a handle in the dashboard's **Governor → Thresholds** tab pins that threshold to an absolute value.
+
+A threshold of `0` counts as **unset**, not as an explicit zero — mode entries often exist only to carry cadences, and a literal zero would put every non-empty queue in that mode.
+
+### Mixing explicit and scaled thresholds
+
+Because explicit values are not scaled, mixing them with scaled defaults can put the ladder out of order. On a 39-repo hive:
+
+```yaml
+governor:
+  modes:
+    surge:
+      threshold: 70      # explicit → stays 70
+    # busy and quiet unset → scaled to 390 and 78
+```
+
+`busy` (390) now sits **above** `surge` (70). The governor tests surge first and returns on the first threshold the queue exceeds, so BUSY becomes unreachable. The governor logs a warning naming all three effective values when it detects this:
+
+```
+governor mode thresholds are not in descending order — a mode is unreachable
+  surge=70 busy=390 quiet=78 repo_count=39 threshold_scaling=linear
+```
+
+It warns rather than silently reordering, because the inversion comes from a number you set. Either set all three explicitly, or remove the explicit one so all three scale together.
+
+## Known limitation: ACMM packs seed explicit thresholds
+
+ACMM level packs (`v2/pkg/config/packs/level-*.yaml`) write `surge`/`busy`/`quiet` thresholds into `governor.modes` when a level is applied — for example L4–L6 seed `surge: 10, busy: 5, quiet: 2`.
+
+Those land in config as **explicit** values, and nothing distinguishes a pack-seeded default from one an operator typed. So on a hive that has applied an ACMM level, **scaling does not engage**: rule "explicit always wins" takes precedence and the pack's absolute numbers are used.
+
+If your hive applied a pack and you want scaling, clear the thresholds you want scaled:
+
+```yaml
+governor:
+  modes:
+    surge:
+      # threshold omitted → scaled default
+      scanner: 5m
+```
+
+Resolving this properly requires tracking whether a threshold was pack-seeded or operator-set, which config does not currently record.
+
+## Where the numbers are shown
+
+The dashboard governor gauge and the **Governor → Thresholds** settings tab both display the **effective** thresholds — the same values the governor laddered on, resolved through the same code path — along with the watched repo count. The settings sliders edit the base values.
+
+## Related
+
+- [Agent configuration → Cadences and the governor](agent-configuration.md#cadences-and-the-governor)
+- Issue [#3498](https://github.com/kubestellar/hive/issues/3498)

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"math"
 	"net/netip"
 	"net/url"
 	"os"
@@ -957,6 +958,155 @@ type GovernorConfig struct {
 	// so turning this off never removes the operator's ability to answer "which
 	// backend/model produced this PR?".
 	AttributionTrailer *bool `yaml:"attribution_trailer,omitempty"`
+
+	// ThresholdScaling selects how the DEFAULT mode thresholds scale with the
+	// number of repos this hive watches (#3498). An explicit
+	// governor.modes.<mode>.threshold is never scaled — it always wins.
+	//
+	// Valid values: "" (= linear) | linear | sqrt | none.
+	// See EffectiveThreshold for the resolution rules and why linear is the
+	// default.
+	ThresholdScaling string `yaml:"threshold_scaling,omitempty" json:"threshold_scaling,omitempty"`
+}
+
+// Default governor mode thresholds, in queue items (actionable issues + open
+// PRs). These are the per-repo BASE values: a hive watching one repo surges at
+// 20 items, and EffectiveThreshold scales them for hives watching more.
+//
+// They live here rather than in pkg/governor because two callers need the same
+// answer — the governor, which decides the mode, and the dashboard gauge, which
+// tells the operator which numbers produced it. Those were independently
+// duplicated constants before #3498; scaling one and not the other would have
+// made the gauge disagree with the governor it describes.
+const (
+	DefaultThresholdSurge = 20
+	DefaultThresholdBusy  = 10
+	DefaultThresholdQuiet = 2
+)
+
+// Threshold scaling curves (GovernorConfig.ThresholdScaling).
+const (
+	// ThresholdScalingLinear multiplies the base threshold by the repo count.
+	// This is the default, and it is exactly equivalent to comparing PER-REPO
+	// queue pressure against the base thresholds — the mode ladder then means
+	// the same thing on a 3-repo hive as on a 39-repo one. The issue considered
+	// normalizing the queue instead (queue / repos) and rejected it because it
+	// changes the number the dashboard displays; scaling the thresholds reaches
+	// the same outcome while leaving the displayed queue depth alone.
+	ThresholdScalingLinear = "linear"
+	// ThresholdScalingSqrt multiplies by ceil(sqrt(repos)) instead — a gentler
+	// curve for hives whose queue depth does not grow linearly with repo count
+	// (many small, quiet repos alongside a few busy ones). It reaches SURGE
+	// sooner than linear does.
+	ThresholdScalingSqrt = "sqrt"
+	// ThresholdScalingNone disables scaling: the base thresholds are used as
+	// absolute queue depths, which is the behavior from before #3498.
+	ThresholdScalingNone = "none"
+)
+
+// ValidThresholdScalings are the accepted threshold_scaling values. "" means
+// "unset", which resolves to linear.
+var ValidThresholdScalings = map[string]bool{
+	"":                     true,
+	ThresholdScalingLinear: true,
+	ThresholdScalingSqrt:   true,
+	ThresholdScalingNone:   true,
+}
+
+// ValidateThresholdScaling reports whether v is an accepted scaling curve.
+func ValidateThresholdScaling(v string) bool { return ValidThresholdScalings[v] }
+
+// ThresholdScalingMode returns the configured scaling curve with its default
+// applied. Unset means linear: the whole point of #3498 is that a hive which
+// says nothing gets thresholds matched to its size.
+//
+// An unrecognized value also resolves to linear rather than silently disabling
+// scaling — config load rejects bad values outright, so reaching this with one
+// means the value came from a path that skipped validation, and defaulting to
+// the documented behavior beats defaulting to "off" for reasons nobody can see.
+func (g GovernorConfig) ThresholdScalingMode() string {
+	switch g.ThresholdScaling {
+	case ThresholdScalingSqrt:
+		return ThresholdScalingSqrt
+	case ThresholdScalingNone:
+		return ThresholdScalingNone
+	default:
+		return ThresholdScalingLinear
+	}
+}
+
+// ScaleThreshold applies a scaling curve to a base threshold for a hive
+// watching repoCount repos.
+//
+// repoCount is clamped to at least 1, so a hive with no repos: list — or one
+// that watches a single repo via primary_repo — gets the unscaled base rather
+// than a threshold of zero, which would put every non-empty queue in SURGE.
+func ScaleThreshold(base, repoCount int, scaling string) int {
+	if base <= 0 {
+		return base
+	}
+	if repoCount < 1 {
+		repoCount = 1
+	}
+	switch scaling {
+	case ThresholdScalingNone:
+		return base
+	case ThresholdScalingSqrt:
+		return base * int(math.Ceil(math.Sqrt(float64(repoCount))))
+	default:
+		return base * repoCount
+	}
+}
+
+// EffectiveThreshold resolves the queue depth at which modeName engages, for a
+// hive watching repoCount repos.
+//
+// Resolution, in order:
+//
+//  1. An explicit governor.modes.<mode>.threshold greater than zero wins and is
+//     returned UNSCALED. An operator who hand-tuned a number meant that number,
+//     and #3498 is explicit that hand-tuned hives see no behavior change.
+//  2. Otherwise the base default for surge/busy/quiet, scaled by repo count.
+//  3. Any other mode name has no threshold (0). computeMode only ladders over
+//     surge/busy/quiet — idle is the fallthrough — so a threshold on `idle` or
+//     on a custom mode has never been consulted.
+//
+// A threshold of exactly zero in config counts as UNSET, matching the existing
+// thresholdFor behavior: mode entries frequently exist only to carry cadences,
+// and a literal zero would put every non-empty queue in that mode.
+//
+// KNOWN LIMITATION: ACMM packs seed explicit thresholds (pkg/config/packs/
+// level-*.yaml write surge/busy/quiet), and rule 1 cannot tell a pack-seeded
+// default from a hand-tuned value. On a hive that applied a pack, scaling
+// therefore does not engage. See docs/governor-thresholds.md.
+func (g GovernorConfig) EffectiveThreshold(modeName string, repoCount int) int {
+	if mode, ok := g.Modes[modeName]; ok && mode.Threshold > 0 {
+		return mode.Threshold
+	}
+
+	var base int
+	switch modeName {
+	case "surge":
+		base = DefaultThresholdSurge
+	case "busy":
+		base = DefaultThresholdBusy
+	case "quiet":
+		base = DefaultThresholdQuiet
+	default:
+		return 0
+	}
+
+	return ScaleThreshold(base, repoCount, g.ThresholdScalingMode())
+}
+
+// RepoCount returns the number of repos this hive watches, for threshold
+// scaling. A hive with an empty repos: list still watches at least its primary
+// repo, so the floor is 1.
+func (p ProjectConfig) RepoCount() int {
+	if n := len(p.Repos); n > 0 {
+		return n
+	}
+	return 1
 }
 
 // AttributionTrailerEnabled reports whether the visible attribution trailer on
@@ -3836,6 +3986,9 @@ func (c *Config) validate() error {
 		return err
 	} else {
 		c.Dashboard.SnapshotFrameAncestors = normalized
+	}
+	if !ValidateThresholdScaling(c.Governor.ThresholdScaling) {
+		return fmt.Errorf("governor: invalid threshold_scaling %q (must be linear, sqrt, or none)", c.Governor.ThresholdScaling)
 	}
 	for modeName, mode := range c.Governor.Modes {
 		for agentName, cadence := range mode.Cadences {

--- a/src/pkg/config/threshold_scaling_test.go
+++ b/src/pkg/config/threshold_scaling_test.go
@@ -1,0 +1,289 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Governor mode thresholds gate a queue depth that grows with the number of
+// repos a hive watches, so a fixed threshold encodes an implicit repo count
+// (#3498). These tests pin the scaling curves and, more importantly, the
+// resolution order — an explicitly configured threshold must never be scaled.
+
+func TestScaleThreshold_Linear(t *testing.T) {
+	tests := []struct {
+		repos int
+		base  int
+		want  int
+	}{
+		{repos: 1, base: 20, want: 20},
+		{repos: 3, base: 20, want: 60},
+		{repos: 39, base: 20, want: 780},
+		{repos: 39, base: 10, want: 390},
+		{repos: 39, base: 2, want: 78},
+		// A hive with no repos configured still watches its primary repo.
+		{repos: 0, base: 20, want: 20},
+		{repos: -5, base: 20, want: 20},
+	}
+	for _, tt := range tests {
+		if got := ScaleThreshold(tt.base, tt.repos, ThresholdScalingLinear); got != tt.want {
+			t.Errorf("ScaleThreshold(%d, %d, linear) = %d, want %d", tt.base, tt.repos, got, tt.want)
+		}
+	}
+}
+
+func TestScaleThreshold_Sqrt(t *testing.T) {
+	tests := []struct {
+		repos int
+		base  int
+		want  int
+	}{
+		{repos: 1, base: 20, want: 20},   // ceil(sqrt(1)) = 1
+		{repos: 3, base: 20, want: 40},   // ceil(sqrt(3)) = 2
+		{repos: 4, base: 20, want: 40},   // ceil(sqrt(4)) = 2
+		{repos: 39, base: 20, want: 140}, // ceil(sqrt(39)) = 7
+	}
+	for _, tt := range tests {
+		if got := ScaleThreshold(tt.base, tt.repos, ThresholdScalingSqrt); got != tt.want {
+			t.Errorf("ScaleThreshold(%d, %d, sqrt) = %d, want %d", tt.base, tt.repos, got, tt.want)
+		}
+	}
+}
+
+// sqrt must never exceed linear, and must be strictly below it once the curves
+// separate — otherwise the option is mislabeled in the config docs and the UI.
+//
+// They TIE at 1 and 2 repos, because ceil(sqrt(2)) == 2: the ceiling cannot
+// produce a factor below 2 until 5 repos, where ceil(sqrt(5)) == 3. Asserting
+// strict inequality everywhere fails at repos=2, which is how this test found
+// the real shape of the curve rather than the one assumed when writing it.
+func TestScaleThreshold_SqrtIsNeverHarsherThanLinear(t *testing.T) {
+	for _, repos := range []int{1, 2, 3, 4, 5, 10, 39, 100} {
+		lin := ScaleThreshold(20, repos, ThresholdScalingLinear)
+		sq := ScaleThreshold(20, repos, ThresholdScalingSqrt)
+		if sq > lin {
+			t.Errorf("repos=%d: sqrt (%d) exceeds linear (%d)", repos, sq, lin)
+		}
+		if sq < 20 {
+			t.Errorf("repos=%d: sqrt (%d) fell below the base threshold", repos, sq)
+		}
+	}
+
+	// Where the curves have separated, the gap must be real and must widen —
+	// that separation is the entire reason sqrt is offered.
+	for _, repos := range []int{3, 5, 10, 39, 100} {
+		lin := ScaleThreshold(20, repos, ThresholdScalingLinear)
+		sq := ScaleThreshold(20, repos, ThresholdScalingSqrt)
+		if sq >= lin {
+			t.Errorf("repos=%d: sqrt (%d) should be strictly below linear (%d)", repos, sq, lin)
+		}
+	}
+}
+
+func TestScaleThreshold_None(t *testing.T) {
+	for _, repos := range []int{1, 3, 39, 500} {
+		if got := ScaleThreshold(20, repos, ThresholdScalingNone); got != 20 {
+			t.Errorf("repos=%d: scaling none = %d, want the base 20", repos, got)
+		}
+	}
+}
+
+// A zero or negative base has no meaningful scaling; multiplying it would still
+// be zero, but returning it untouched keeps "0 means unset" intact for callers.
+func TestScaleThreshold_NonPositiveBaseUnchanged(t *testing.T) {
+	for _, base := range []int{0, -1} {
+		if got := ScaleThreshold(base, 39, ThresholdScalingLinear); got != base {
+			t.Errorf("ScaleThreshold(%d, 39, linear) = %d, want %d", base, got, base)
+		}
+	}
+}
+
+func TestThresholdScalingMode_DefaultsToLinear(t *testing.T) {
+	tests := map[string]string{
+		"":       ThresholdScalingLinear,
+		"linear": ThresholdScalingLinear,
+		"sqrt":   ThresholdScalingSqrt,
+		"none":   ThresholdScalingNone,
+		// Config load rejects these; reaching here means validation was
+		// bypassed, and the documented default beats a silent opt-out.
+		"nonsense": ThresholdScalingLinear,
+		"LINEAR":   ThresholdScalingLinear,
+	}
+	for in, want := range tests {
+		g := GovernorConfig{ThresholdScaling: in}
+		if got := g.ThresholdScalingMode(); got != want {
+			t.Errorf("ThresholdScalingMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// THE core guarantee of #3498: a hand-tuned threshold is returned verbatim.
+// Scaling an operator's explicit 300 by a 39-repo hive would produce 11700 and
+// silently break every hive that already worked around this bug by hand.
+func TestEffectiveThreshold_ExplicitIsNeverScaled(t *testing.T) {
+	g := GovernorConfig{
+		Modes: map[string]ModeConfig{
+			"surge": {Threshold: 300},
+			"busy":  {Threshold: 200},
+			"quiet": {Threshold: 100},
+		},
+	}
+	for _, repos := range []int{1, 39, 500} {
+		if got := g.EffectiveThreshold("surge", repos); got != 300 {
+			t.Errorf("repos=%d: explicit surge = %d, want 300", repos, got)
+		}
+		if got := g.EffectiveThreshold("busy", repos); got != 200 {
+			t.Errorf("repos=%d: explicit busy = %d, want 200", repos, got)
+		}
+		if got := g.EffectiveThreshold("quiet", repos); got != 100 {
+			t.Errorf("repos=%d: explicit quiet = %d, want 100", repos, got)
+		}
+	}
+}
+
+func TestEffectiveThreshold_DefaultsScale(t *testing.T) {
+	g := GovernorConfig{}
+
+	// One repo must reproduce the pre-#3498 numbers exactly.
+	if got := g.EffectiveThreshold("surge", 1); got != 20 {
+		t.Errorf("1-repo surge = %d, want the historical 20", got)
+	}
+	if got := g.EffectiveThreshold("busy", 1); got != 10 {
+		t.Errorf("1-repo busy = %d, want the historical 10", got)
+	}
+	if got := g.EffectiveThreshold("quiet", 1); got != 2 {
+		t.Errorf("1-repo quiet = %d, want the historical 2", got)
+	}
+
+	// The reported hive: 39 repos.
+	if got := g.EffectiveThreshold("surge", 39); got != 780 {
+		t.Errorf("39-repo surge = %d, want 780", got)
+	}
+}
+
+// A one-repo hive must get the historical constants under EVERY curve — the
+// curves only diverge in how they grow, never at the identity point.
+func TestEffectiveThreshold_IdentityAtOneRepoForEveryCurve(t *testing.T) {
+	for _, scaling := range []string{"", ThresholdScalingLinear, ThresholdScalingSqrt, ThresholdScalingNone} {
+		g := GovernorConfig{ThresholdScaling: scaling}
+		if got := g.EffectiveThreshold("surge", 1); got != 20 {
+			t.Errorf("scaling=%q: 1-repo surge = %d, want 20", scaling, got)
+		}
+		if got := g.EffectiveThreshold("busy", 1); got != 10 {
+			t.Errorf("scaling=%q: 1-repo busy = %d, want 10", scaling, got)
+		}
+		if got := g.EffectiveThreshold("quiet", 1); got != 2 {
+			t.Errorf("scaling=%q: 1-repo quiet = %d, want 2", scaling, got)
+		}
+	}
+}
+
+// A mode entry that exists only to carry cadences has Threshold 0. Treating
+// that as an explicit zero would put every non-empty queue in that mode.
+func TestEffectiveThreshold_ZeroMeansUnset(t *testing.T) {
+	g := GovernorConfig{
+		Modes: map[string]ModeConfig{
+			"surge": {Threshold: 0, Cadences: map[string]Cadence{"scanner": "5m"}},
+		},
+	}
+	if got := g.EffectiveThreshold("surge", 3); got != 60 {
+		t.Errorf("threshold 0 with cadences = %d, want the scaled default 60", got)
+	}
+}
+
+// computeMode only ladders over surge/busy/quiet; idle is the fallthrough. A
+// threshold on any other mode has never been consulted and must not start
+// being invented here.
+func TestEffectiveThreshold_UnknownModesHaveNoDefault(t *testing.T) {
+	g := GovernorConfig{}
+	for _, name := range []string{"idle", "", "custom", "unknown"} {
+		if got := g.EffectiveThreshold(name, 39); got != 0 {
+			t.Errorf("EffectiveThreshold(%q) = %d, want 0", name, got)
+		}
+	}
+	// An explicit threshold on a custom mode is still returned, unscaled —
+	// pkg/governor's thresholdFor has always honored one.
+	g.Modes = map[string]ModeConfig{"custom": {Threshold: 7}}
+	if got := g.EffectiveThreshold("custom", 39); got != 7 {
+		t.Errorf("explicit custom threshold = %d, want 7", got)
+	}
+}
+
+// Mixed sources are legal and are the case most likely to surprise: the
+// explicit value stays put while the others scale around it.
+func TestEffectiveThreshold_MixedExplicitAndScaled(t *testing.T) {
+	g := GovernorConfig{Modes: map[string]ModeConfig{"surge": {Threshold: 70}}}
+
+	if got := g.EffectiveThreshold("surge", 39); got != 70 {
+		t.Errorf("explicit surge = %d, want 70", got)
+	}
+	if got := g.EffectiveThreshold("busy", 39); got != 390 {
+		t.Errorf("scaled busy = %d, want 390", got)
+	}
+	// This ladder is inverted (busy above surge); pkg/governor warns about it.
+	// Recorded here so the arithmetic behind that warning is pinned.
+	if g.EffectiveThreshold("busy", 39) <= g.EffectiveThreshold("surge", 39) {
+		t.Fatal("fixture no longer produces the inverted ladder it exists to document")
+	}
+}
+
+func TestEffectiveThreshold_ScalingNoneRestoresAbsoluteBehavior(t *testing.T) {
+	g := GovernorConfig{ThresholdScaling: ThresholdScalingNone}
+	if got := g.EffectiveThreshold("surge", 39); got != 20 {
+		t.Errorf("scaling none on a 39-repo hive = %d, want the absolute 20", got)
+	}
+}
+
+func TestRepoCount_FloorsAtOne(t *testing.T) {
+	if got := (ProjectConfig{}).RepoCount(); got != 1 {
+		t.Errorf("no repos = %d, want 1", got)
+	}
+	if got := (ProjectConfig{Repos: []string{"a", "b", "c"}}).RepoCount(); got != 3 {
+		t.Errorf("3 repos = %d, want 3", got)
+	}
+}
+
+func TestValidateThresholdScaling(t *testing.T) {
+	for _, v := range []string{"", "linear", "sqrt", "none"} {
+		if !ValidateThresholdScaling(v) {
+			t.Errorf("ValidateThresholdScaling(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"Linear", "SQRT", "log", "true", "off", "1"} {
+		if ValidateThresholdScaling(v) {
+			t.Errorf("ValidateThresholdScaling(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestValidate_RejectsBadThresholdScaling(t *testing.T) {
+	c := &Config{
+		Project:  ProjectConfig{Org: "my-org"},
+		GitHub:   GitHubConfig{Token: "t"},
+		Agents:   map[string]AgentConfig{"scanner": {Backend: "claude"}},
+		Governor: GovernorConfig{ThresholdScaling: "logarithmic"},
+	}
+	err := c.validate()
+	if err == nil {
+		t.Fatal("validate() accepted an invalid threshold_scaling")
+	}
+	for _, want := range []string{"threshold_scaling", "logarithmic"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func TestValidate_AcceptsEveryThresholdScaling(t *testing.T) {
+	for _, v := range []string{"", "linear", "sqrt", "none"} {
+		c := &Config{
+			Project:  ProjectConfig{Org: "my-org"},
+			GitHub:   GitHubConfig{Token: "t"},
+			Agents:   map[string]AgentConfig{"scanner": {Backend: "claude"}},
+			Governor: GovernorConfig{ThresholdScaling: v},
+		}
+		if err := c.validate(); err != nil {
+			t.Errorf("validate() rejected threshold_scaling %q: %v", v, err)
+		}
+	}
+}

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -126,6 +126,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/governor", s.handleGovernorConfigGet)
 	s.mux.HandleFunc("PUT /api/config/governor/sensing", s.handleGovernorSensing)
 	s.mux.HandleFunc("PUT /api/config/governor/thresholds", s.handleGovernorThresholds)
+	s.mux.HandleFunc("PUT /api/config/governor/threshold-scaling", s.handleGovernorThresholdScaling)
 	s.mux.HandleFunc("PUT /api/config/governor/labels", s.handleGovernorLabels)
 	s.mux.HandleFunc("PUT /api/config/governor/budget", s.handleGovernorBudget)
 	s.mux.HandleFunc("POST /api/config/governor/budget/reset", s.handleGovernorBudgetReset)
@@ -410,6 +411,10 @@ func (s *Server) saveConfig() error {
 	}
 	if s.deps.Governor != nil {
 		s.deps.Governor.UpdateConfig(s.deps.Config.Governor)
+		// The dashboard can add or remove repos, which moves every scaled
+		// default threshold (#3498). Without this, a repo change would not
+		// reach the governor until the next process restart.
+		s.deps.Governor.SetRepoCount(s.deps.Config.Project.RepoCount())
 	}
 	return nil
 }
@@ -4002,6 +4007,18 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	// The raw map above is what the operator SET (0 = unset). The governor
+	// ladders on the resolved values, which for an unset mode are the defaults
+	// scaled by repo count (#3498). Send both, so the settings panel can show
+	// the numbers actually in force next to the ones being edited instead of
+	// falling back to its own copy of the unscaled defaults.
+	repoCount := cfg.Project.RepoCount()
+	effectiveThresholds := map[string]int{
+		"quiet": cfg.Governor.EffectiveThreshold("quiet", repoCount),
+		"busy":  cfg.Governor.EffectiveThreshold("busy", repoCount),
+		"surge": cfg.Governor.EffectiveThreshold("surge", repoCount),
+	}
+
 	// Build full org/repo paths
 	org := cfg.Project.Org
 	repos := make([]string, 0, len(cfg.Project.Repos))
@@ -4037,12 +4054,15 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 	}
 
 	jsonResponse(w, map[string]interface{}{
-		"agents":      agents,
-		"thresholds":  thresholds,
-		"labels":      cfg.Governor.Labels.Exempt,
-		"holdLabels":  github.HoldLabels,
-		"repos":       repos,
-		"primaryRepo": primaryRepo,
+		"agents":              agents,
+		"thresholds":          thresholds,
+		"effectiveThresholds": effectiveThresholds,
+		"thresholdScaling":    cfg.Governor.ThresholdScalingMode(),
+		"repoCount":           repoCount,
+		"labels":              cfg.Governor.Labels.Exempt,
+		"holdLabels":          github.HoldLabels,
+		"repos":               repos,
+		"primaryRepo":         primaryRepo,
 		"budget": map[string]interface{}{
 			"totalTokens": cfg.Governor.Budget.TotalTokens,
 			"periodDays":  cfg.Governor.Budget.PeriodDays,
@@ -4275,6 +4295,51 @@ func (s *Server) handleGovernorThresholds(w http.ResponseWriter, r *http.Request
 	}
 
 	s.auditFromRequest(r, "config_governor_thresholds", auditDetail("section", "thresholds"), "")
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// handleGovernorThresholdScaling sets how the DEFAULT mode thresholds scale
+// with the hive's repo count (#3498).
+//
+// It is a separate route from handleGovernorThresholds because that one's body
+// is a flat map[string]int of mode name to threshold; a string curve does not
+// fit it, and widening it to map[string]any would put a parse branch on the
+// path every threshold drag already takes.
+func (s *Server) handleGovernorThresholdScaling(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
+	var body struct {
+		ThresholdScaling string `json:"thresholdScaling"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	scaling := sanitizeString(body.ThresholdScaling)
+	// Same gate as config.validate, so the write path cannot persist a value
+	// that fails the next config load.
+	if !config.ValidateThresholdScaling(scaling) {
+		jsonError(w, "thresholdScaling must be one of: linear, sqrt, none (or empty for the default)", http.StatusBadRequest)
+		return
+	}
+	s.deps.Config.Governor.ThresholdScaling = scaling
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after threshold scaling update", "error", err)
+	}
+
+	// Changing the curve moves every scaled threshold, so re-evaluate now
+	// rather than leaving the hive on the old ladder until the next eval tick —
+	// matching what a threshold drag already does.
+	if s.deps.EnumerateFunc != nil {
+		go s.deps.EnumerateFunc()
+	}
+
+	s.auditFromRequest(r, "config_governor_threshold_scaling", auditDetail("section", "thresholdScaling"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }

--- a/src/pkg/dashboard/governor_threshold_gauge_test.go
+++ b/src/pkg/dashboard/governor_threshold_gauge_test.go
@@ -1,0 +1,182 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/governor"
+)
+
+// The dashboard gauge explains the governor's current mode with a set of
+// thresholds. Before #3498 it kept its OWN copy of the defaults; once the
+// governor started scaling them by repo count, that copy would have described
+// the mode with numbers that did not produce it.
+
+func gaugeConfig(repos []string, gov config.GovernorConfig) *config.Config {
+	return &config.Config{
+		Project:  config.ProjectConfig{Org: "my-org", Repos: repos},
+		Governor: gov,
+	}
+}
+
+func TestBuildGovernor_ThresholdsScaleWithRepoCount(t *testing.T) {
+	repos := make([]string, 39)
+	for i := range repos {
+		repos[i] = "repo"
+	}
+
+	got := buildGovernor(governor.State{Mode: governor.ModeBusy}, gaugeConfig(repos, config.GovernorConfig{}))
+
+	if got.Thresholds.Surge != 780 {
+		t.Errorf("gauge surge = %d, want 780", got.Thresholds.Surge)
+	}
+	if got.Thresholds.Busy != 390 {
+		t.Errorf("gauge busy = %d, want 390", got.Thresholds.Busy)
+	}
+	if got.Thresholds.Quiet != 78 {
+		t.Errorf("gauge quiet = %d, want 78", got.Thresholds.Quiet)
+	}
+}
+
+// The property that actually matters: whatever the config, the gauge must show
+// exactly the numbers the governor laddered on. This compares the two
+// independently-reached answers rather than restating one of them.
+func TestBuildGovernor_GaugeAgreesWithGovernor(t *testing.T) {
+	cases := []struct {
+		name  string
+		repos int
+		gov   config.GovernorConfig
+	}{
+		{name: "defaults, single repo", repos: 1},
+		{name: "defaults, many repos", repos: 39},
+		{
+			name:  "hand-tuned",
+			repos: 39,
+			gov: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+				"surge": {Threshold: 300}, "busy": {Threshold: 200}, "quiet": {Threshold: 100},
+			}},
+		},
+		{
+			name:  "mixed explicit and scaled",
+			repos: 39,
+			gov:   config.GovernorConfig{Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}}},
+		},
+		{name: "scaling disabled", repos: 39, gov: config.GovernorConfig{ThresholdScaling: config.ThresholdScalingNone}},
+		{name: "sqrt scaling", repos: 39, gov: config.GovernorConfig{ThresholdScaling: config.ThresholdScalingSqrt}},
+		{
+			name:  "mode entry with cadences but no threshold",
+			repos: 12,
+			gov: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+				"busy": {Cadences: map[string]config.Cadence{"scanner": "5m"}},
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repos := make([]string, tc.repos)
+			for i := range repos {
+				repos[i] = "repo"
+			}
+			cfg := gaugeConfig(repos, tc.gov)
+
+			gauge := buildGovernor(governor.State{}, cfg)
+
+			// What the governor itself would use, via the same exported
+			// resolver pkg/governor calls.
+			wantSurge := cfg.Governor.EffectiveThreshold("surge", tc.repos)
+			wantBusy := cfg.Governor.EffectiveThreshold("busy", tc.repos)
+			wantQuiet := cfg.Governor.EffectiveThreshold("quiet", tc.repos)
+
+			if gauge.Thresholds.Surge != wantSurge {
+				t.Errorf("gauge surge = %d, governor uses %d", gauge.Thresholds.Surge, wantSurge)
+			}
+			if gauge.Thresholds.Busy != wantBusy {
+				t.Errorf("gauge busy = %d, governor uses %d", gauge.Thresholds.Busy, wantBusy)
+			}
+			if gauge.Thresholds.Quiet != wantQuiet {
+				t.Errorf("gauge quiet = %d, governor uses %d", gauge.Thresholds.Quiet, wantQuiet)
+			}
+		})
+	}
+}
+
+// A hive with no repos: list still watches its primary repo, so the gauge must
+// show the unscaled defaults rather than zeros.
+func TestBuildGovernor_NoReposShowsUnscaledDefaults(t *testing.T) {
+	got := buildGovernor(governor.State{}, gaugeConfig(nil, config.GovernorConfig{}))
+
+	if got.Thresholds.Surge != 20 || got.Thresholds.Busy != 10 || got.Thresholds.Quiet != 2 {
+		t.Errorf("no-repo gauge = %+v, want the unscaled 20/10/2", got.Thresholds)
+	}
+}
+
+// Editing the repo list from the Repos tab moves every scaled default, so the
+// repo count has to reach the governor at save time (saveConfig re-syncs it,
+// alongside Governor.UpdateConfig). Nothing covered that end to end: the
+// governor tests drive SetRepoCount directly, and the gauge tests never go
+// through a handler.
+//
+// This is asserted through the MODE rather than through a getter, because the
+// mode is what the operator actually sees change, and it only moves if the new
+// count genuinely reached thresholdFor. A save path that persisted the repos
+// but left the governor stale would keep the hive in SURGE — the exact symptom
+// #3498 is about — until the next periodic reload happened to correct it.
+func TestHandleGovernorRepos_ResyncsGovernorRepoCount(t *testing.T) {
+	srv := newFullServer(t)
+	gov := srv.deps.Governor
+
+	// Baseline: the fixture watches one repo, so surge is the unscaled 20 and a
+	// queue of 60 is a surge.
+	gov.Evaluate(60, 0, 0, 0)
+	if got := gov.GetState().Mode; got != governor.ModeSurge {
+		t.Fatalf("baseline mode = %q, want %q — the fixture should start at one repo", got, governor.ModeSurge)
+	}
+
+	body := `{"repos":["testrepo","r2","r3","r4","r5"],"primaryRepo":"testrepo"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Five repos scale surge to 100 and busy to 50, so the SAME queue depth is
+	// now BUSY. Still SURGE means the governor never saw the new count.
+	gov.Evaluate(60, 0, 0, 0)
+	if got := gov.GetState().Mode; got != governor.ModeBusy {
+		t.Errorf("mode after adding repos = %q, want %q — the save path did not re-sync the governor's repo count", got, governor.ModeBusy)
+	}
+}
+
+// The reject path restores the previous repo list and returns before saving, so
+// it must leave the repo count alone too. A governor scaled for a repo set that
+// was never persisted would ladder on thresholds no config explains.
+func TestHandleGovernorRepos_RejectedEditLeavesRepoCountAlone(t *testing.T) {
+	srv := newFullServer(t)
+	gov := srv.deps.Governor
+
+	// No primaryRepo among the submitted repos — the handler 400s and restores.
+	body := `{"repos":["r1","r2","r3","r4","r5"]}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a repo list with no default, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Still the one-repo ladder: a queue of 60 is a surge at surge=20. If the
+	// rejected list had reached the governor, surge would be 100 and this would
+	// come back BUSY.
+	gov.Evaluate(60, 0, 0, 0)
+	if got := gov.GetState().Mode; got != governor.ModeSurge {
+		t.Errorf("mode after a REJECTED repo edit = %q, want %q — a rejected edit must not move the repo count", got, governor.ModeSurge)
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -15300,7 +15300,7 @@ function burnAreaChart() {
       switch (tab) {
         case 'General': return renderGovGeneral();
         case 'Agents': return renderGovAgents(d.agents || []);
-        case 'Thresholds': return renderGovThresholds(d.thresholds || {});
+        case 'Thresholds': return renderGovThresholds(d);
         case 'Labels': return renderGovLabels(d.labels || [], d.holdLabels || []);
         case 'Repos': return renderGovRepos(d.repos || []);
         case 'Budget': return renderGovBudget(d.budget || {});
@@ -18383,14 +18383,33 @@ function burnAreaChart() {
     const THRESH_BAR_MAX = 200;
     const THRESH_COLORS = { idle: 'var(--green)', quiet: 'var(--blue)', busy: 'var(--yellow)', surge: 'var(--red)' };
 
-    function renderGovThresholds(t) {
+    function renderGovThresholds(d) {
+      const t = (d && d.thresholds) || {};
       const merged = Object.assign({}, t, _configState.dirty.thresholds || {});
       const q = merged.quiet || 2, b = merged.busy || 10, s = merged.surge || 20;
+      // The handles edit BASE thresholds; the governor ladders on the effective
+      // ones, which for an unset mode are the base scaled by repo count (#3498).
+      // Show both — a 39-repo hive surges at 780, far past this bar's range, and
+      // a slider reading 20 with no further explanation would be a lie.
+      const eff = (d && d.effectiveThresholds) || {};
+      const repoCount = (d && d.repoCount) || 1;
+      const scaling = ((d && d.thresholdScaling) || 'linear');
+      const scalingDirty = (_configState.dirty['threshold-scaling'] || {}).thresholdScaling;
+      const activeScaling = scalingDirty !== undefined ? scalingDirty : scaling;
+      const scaled = activeScaling !== 'none' && repoCount > 1;
+      const effNote = scaled && eff.surge
+        ? `<p style="font-size:0.75rem;color:var(--muted);margin:-12px 0 20px">
+             In force for <strong>${repoCount}</strong> watched repos:
+             quiet <strong>${eff.quiet}</strong> · busy <strong>${eff.busy}</strong> · surge <strong>${eff.surge}</strong>.
+             Dragging a handle pins that threshold to an absolute value and opts it out of scaling.
+           </p>`
+        : '';
       const qPct = (q / THRESH_BAR_MAX) * 100;
       const bPct = (b / THRESH_BAR_MAX) * 100;
       const sPct = (s / THRESH_BAR_MAX) * 100;
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:20px">Drag the handles to set issue-count thresholds for governor mode transitions.</p>
+        ${effNote}
         <div class="thresh-bar-wrap">
           <div class="thresh-bar-track" id="thresh-track"
                style="background:linear-gradient(to right,
@@ -18420,6 +18439,13 @@ function burnAreaChart() {
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from idle to quiet mode. Below this count, agents run at their idle cadence.">Quiet</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-quiet" value="${q}" oninput="setThreshFromInput('quiet',this.value)"></div>
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from quiet to busy mode. Agents increase their kick frequency to handle the growing workload.">Busy</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-busy" value="${b}" oninput="setThreshFromInput('busy',this.value)"></div>
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from busy to surge mode. Maximum agent activity — monitor your token budget closely at this level.">Surge</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-surge" value="${s}" oninput="setThreshFromInput('surge',this.value)"></div>
+        </div>
+        <div class="config-field" style="margin-top:20px">
+          <label title="How the thresholds above scale with the number of repos this hive watches. Queue depth grows with repo count, so a fixed threshold means a large hive sits in surge permanently while a small one idles. Linear (default) compares per-repo pressure. Sqrt is gentler for hives with many quiet repos. None uses the numbers above as absolute queue depths. A threshold you set explicitly is never scaled.">Threshold scaling <span class="config-info">i<span class="config-tooltip">Scales the thresholds above by how many repos the hive watches, so the mode ladder means the same thing on a 3-repo hive as on a 39-repo one. Linear multiplies by the repo count (equivalent to comparing per-repo queue pressure). Sqrt multiplies by ceil(sqrt(repos)) — gentler, reaches surge sooner. None uses absolute numbers, the behavior from before this option existed. Thresholds you set by hand are never scaled.</span></span></label>
+          <select id="cfg-threshold-scaling" onchange="markDirty('threshold-scaling','thresholdScaling',this.value)">
+            ${[['linear', 'linear — × repo count (default)'], ['sqrt', 'sqrt — × ceil(√repos), gentler'], ['none', 'none — absolute queue depths']]
+              .map(([v, label]) => `<option value="${v}" ${activeScaling === v ? 'selected' : ''}>${label}</option>`).join('')}
+          </select>
         </div>`;
     }
 

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -901,28 +901,17 @@ func cadenceDisplay(c config.Cadence) string {
 }
 
 func buildGovernor(state governor.State, cfg *config.Config) FrontendGovernor {
-	const (
-		defaultQuiet = 2
-		defaultBusy  = 10
-		defaultSurge = 20
-	)
-
+	// The gauge must show the thresholds the governor ACTUALLY laddered on, or
+	// it explains the current mode with numbers that did not produce it. This
+	// used to be a private copy of the defaults plus its own explicit-wins
+	// check; both now come from config.EffectiveThreshold, which is the same
+	// call pkg/governor makes. Scaling by repo count (#3498) is what made the
+	// duplication actively wrong rather than merely redundant.
+	repos := cfg.Project.RepoCount()
 	thresholds := FrontendThresholds{
-		Quiet: defaultQuiet,
-		Busy:  defaultBusy,
-		Surge: defaultSurge,
-	}
-
-	// Threshold zero means unset (mode entry present only for cadences);
-	// keep the defaults so the gauge matches the governor's evaluation.
-	if m, ok := cfg.Governor.Modes["quiet"]; ok && m.Threshold > 0 {
-		thresholds.Quiet = m.Threshold
-	}
-	if m, ok := cfg.Governor.Modes["busy"]; ok && m.Threshold > 0 {
-		thresholds.Busy = m.Threshold
-	}
-	if m, ok := cfg.Governor.Modes["surge"]; ok && m.Threshold > 0 {
-		thresholds.Surge = m.Threshold
+		Quiet: cfg.Governor.EffectiveThreshold("quiet", repos),
+		Busy:  cfg.Governor.EffectiveThreshold("busy", repos),
+		Surge: cfg.Governor.EffectiveThreshold("surge", repos),
 	}
 
 	nextKick := ""

--- a/src/pkg/governor/governor.go
+++ b/src/pkg/governor/governor.go
@@ -207,6 +207,22 @@ type Governor struct {
 	budget       BudgetInfo
 	now          func() time.Time
 
+	// repoCount is how many repos this hive watches, used to scale the DEFAULT
+	// mode thresholds (#3498). Set via SetRepoCount; defaults to 1 so a
+	// governor constructed without one behaves exactly as before scaling
+	// existed.
+	repoCount int
+
+	// lastLadderWarn is the inverted ladder most recently warned about, so the
+	// warning fires on the TRANSITION rather than on every re-check. Both
+	// callers of warnIfLadderInvertedLocked run on hot paths — UpdateConfig on
+	// the ~2-minute reload loop and on every dashboard config save — so an
+	// undeduplicated warning would emit a WARN every couple of minutes forever
+	// on a hive whose ladder is inverted. Zero value means "nothing warned
+	// about"; it is cleared when the ladder becomes healthy so a later
+	// re-inversion is reported again.
+	lastLadderWarn ladderSnapshot
+
 	// resumeKicks records the last crash-recovery resume kick granted per
 	// agent (see AllowResumeKick). In-memory only: after a process restart
 	// the startup path re-kicks every eligible agent anyway, so persisting
@@ -243,6 +259,9 @@ func New(cfg config.GovernorConfig, agents map[string]config.AgentConfig, logger
 		agentReports: make(map[string]AgentReportRecord),
 		resumeKicks:  make(map[string]time.Time),
 		now:          time.Now,
+		// 1 repo = scaling is a no-op, so a governor built without a repo count
+		// ladders on the same absolute numbers it always did.
+		repoCount: 1,
 		budget: BudgetInfo{
 			ByAgent: make(map[string]int64),
 			ByModel: make(map[string]int64),
@@ -254,6 +273,9 @@ func (g *Governor) UpdateConfig(cfg config.GovernorConfig) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.cfg = cfg
+	// New config can change both the explicit thresholds and the scaling curve,
+	// either of which can invert the ladder.
+	g.warnIfLadderInvertedLocked()
 }
 
 func (g *Governor) UpdateAgents(agents map[string]config.AgentConfig) {
@@ -365,23 +387,101 @@ func (g *Governor) computeMode(queueDepth int) Mode {
 	return ModeIdle
 }
 
+// ladderSnapshot is the set of effective thresholds an inversion warning was
+// last emitted for. Comparable by design (all scalars) so deduplication is a
+// plain equality check. warned distinguishes "warned about a ladder that
+// happens to be all zeros" from the zero value meaning "never warned".
+type ladderSnapshot struct {
+	surge     int
+	busy      int
+	quiet     int
+	repoCount int
+	warned    bool
+}
+
+// thresholdFor returns the queue depth at which modeName engages.
+//
+// The resolution — explicit config wins, otherwise a repo-count-scaled default
+// — lives in config.EffectiveThreshold so the dashboard gauge resolves the
+// identical number. A mode entry may exist only to carry cadences, with its
+// threshold unset (zero); that still falls through to the defaults, because a
+// zero threshold would put every non-empty queue in that mode.
 func (g *Governor) thresholdFor(modeName string) int {
-	// A mode entry may exist only for cadences with threshold unset
-	// (zero). Zero thresholds would make every non-empty queue surge,
-	// so fall through to the defaults in that case.
-	if mode, ok := g.cfg.Modes[modeName]; ok && mode.Threshold > 0 {
-		return mode.Threshold
+	return g.cfg.EffectiveThreshold(modeName, g.repoCount)
+}
+
+// SetRepoCount tells the governor how many repos this hive watches, so the
+// DEFAULT mode thresholds can scale with hive size (#3498).
+//
+// It is a separate setter rather than a New/UpdateConfig parameter because the
+// count comes from config.Project, not GovernorConfig, and because it changes
+// on a different schedule than the governor config does — a dashboard repo edit
+// moves it without touching governor settings. It sits beside the existing
+// ghClient.SetRepos call on the reload path for the same reason.
+//
+// A count below 1 is treated as 1: a hive with an empty repos: list still
+// watches its primary repo, and a zero would collapse every scaled threshold to
+// zero and pin the hive in SURGE.
+func (g *Governor) SetRepoCount(n int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if n < 1 {
+		n = 1
 	}
-	switch modeName {
-	case "surge":
-		return 20
-	case "busy":
-		return 10
-	case "quiet":
-		return 2
-	default:
-		return 0
+	if n == g.repoCount {
+		return
 	}
+	g.repoCount = n
+	g.warnIfLadderInvertedLocked()
+}
+
+// warnIfLadderInvertedLocked logs when the effective thresholds do not descend
+// surge > busy > quiet.
+//
+// computeMode tests surge first and returns on the first threshold the queue
+// exceeds, so a ladder out of order silently makes a mode unreachable. Mixing
+// sources is what newly makes this reachable: before #3498 the three thresholds
+// were either all defaults or all hand-set at comparable magnitudes, whereas an
+// explicit surge=70 now sits alongside a scaled busy=390 on a 39-repo hive, and
+// BUSY can never be entered.
+//
+// It warns rather than reorders. The inversion is produced by the operator's
+// own explicit value, and silently overriding a number they set would be a
+// worse surprise than telling them it is being ignored.
+//
+// The warning is DEDUPLICATED on the ladder it describes, because both callers
+// re-check on paths that run constantly: UpdateConfig fires on the ~2-minute
+// reload loop and on every dashboard config save, whether or not anything
+// changed. Warning each time would put a WARN in the log every couple of
+// minutes on a hive that is merely mis-tuned — and an explicit surge beside a
+// scaled busy is precisely the configuration #3498 was reported from, so that
+// would be the loudest on exactly the hives the change is meant to help. A
+// changed inversion is new information and warns again; a repaired ladder
+// clears the memo so a later re-inversion is not swallowed.
+//
+// Caller must hold g.mu.
+func (g *Governor) warnIfLadderInvertedLocked() {
+	surge := g.cfg.EffectiveThreshold("surge", g.repoCount)
+	busy := g.cfg.EffectiveThreshold("busy", g.repoCount)
+	quiet := g.cfg.EffectiveThreshold("quiet", g.repoCount)
+
+	if surge > busy && busy > quiet {
+		g.lastLadderWarn = ladderSnapshot{}
+		return
+	}
+	cur := ladderSnapshot{surge: surge, busy: busy, quiet: quiet, repoCount: g.repoCount, warned: true}
+	if cur == g.lastLadderWarn {
+		return
+	}
+	g.lastLadderWarn = cur
+	g.logger.Warn("governor mode thresholds are not in descending order — a mode is unreachable",
+		"surge", surge,
+		"busy", busy,
+		"quiet", quiet,
+		"repo_count", g.repoCount,
+		"threshold_scaling", g.cfg.ThresholdScalingMode(),
+		"hint", "an explicit governor.modes.<mode>.threshold is never scaled; set the others explicitly too, or remove it to let all three scale",
+	)
 }
 
 // updateCadences recomputes every agent's effective cadence for the current

--- a/src/pkg/governor/governor_threshold_scaling_test.go
+++ b/src/pkg/governor/governor_threshold_scaling_test.go
@@ -1,0 +1,293 @@
+package governor
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// #3498: the mode ladder gates a queue depth that grows with repo count, so
+// fixed thresholds put a large hive in permanent SURGE while a small one idles.
+// These tests cover the governor side — that the repo count reaches
+// thresholdFor, that the mode ladder moves with it, and that a governor which
+// was never told a repo count behaves exactly as it always did.
+
+func scalingLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+// A governor constructed without SetRepoCount must ladder on the historical
+// absolute numbers. Every existing test in this package relies on it, and so
+// does any embedder that has not been updated.
+func TestThresholdFor_DefaultsToUnscaledWhenRepoCountUnset(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	if got := g.thresholdFor("surge"); got != 20 {
+		t.Errorf("surge = %d, want the historical 20", got)
+	}
+	if got := g.thresholdFor("busy"); got != 10 {
+		t.Errorf("busy = %d, want the historical 10", got)
+	}
+	if got := g.thresholdFor("quiet"); got != 2 {
+		t.Errorf("quiet = %d, want the historical 2", got)
+	}
+}
+
+func TestSetRepoCount_ScalesDefaultThresholds(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	if got := g.thresholdFor("surge"); got != 780 {
+		t.Errorf("39-repo surge = %d, want 780", got)
+	}
+	if got := g.thresholdFor("busy"); got != 390 {
+		t.Errorf("39-repo busy = %d, want 390", got)
+	}
+	if got := g.thresholdFor("quiet"); got != 78 {
+		t.Errorf("39-repo quiet = %d, want 78", got)
+	}
+}
+
+func TestSetRepoCount_FloorsAtOne(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	for _, n := range []int{0, -1} {
+		g.SetRepoCount(n)
+		if got := g.thresholdFor("surge"); got != 20 {
+			t.Errorf("SetRepoCount(%d): surge = %d, want the unscaled 20 — a zero would pin the hive in SURGE", n, got)
+		}
+	}
+}
+
+// The reported scenario, end to end: a 39-repo hive carrying ~210 actionable
+// items sat in SURGE permanently. With scaled defaults the same queue is no
+// longer a surge, because 210 items across 39 repos is ~5 per repo.
+func TestComputeMode_LargeHiveLeavesPermanentSurge(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	g.SetRepoCount(1)
+	if got := g.computeMode(210); got != ModeSurge {
+		t.Fatalf("1-repo hive at queue 210 = %s, want SURGE (the pre-fix behavior)", got)
+	}
+
+	g.SetRepoCount(39)
+	if got := g.computeMode(210); got == ModeSurge {
+		t.Error("39-repo hive at queue 210 is still SURGE — the reported bug is not fixed")
+	}
+}
+
+// The same per-repo pressure must produce the same mode regardless of hive
+// size. That equivalence is the point of the feature: the ladder stops
+// encoding an implicit repo count.
+func TestComputeMode_SameMoodAtSamePerRepoPressure(t *testing.T) {
+	small := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+	small.SetRepoCount(3)
+	large := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+	large.SetRepoCount(39)
+
+	// 15 items per repo is comfortably into BUSY (base busy=10, surge=20).
+	if got, want := small.computeMode(15*3), large.computeMode(15*39); got != want {
+		t.Errorf("3-repo hive = %s but 39-repo hive = %s at the same per-repo pressure", got, want)
+	}
+	// 25 per repo clears the surge base on both.
+	if got := small.computeMode(25 * 3); got != ModeSurge {
+		t.Errorf("3-repo hive at 25/repo = %s, want SURGE", got)
+	}
+	if got := large.computeMode(25 * 39); got != ModeSurge {
+		t.Errorf("39-repo hive at 25/repo = %s, want SURGE", got)
+	}
+}
+
+// Hand-tuned hives must see no behavior change whatsoever — that promise is
+// what makes this a defaults-only change.
+func TestComputeMode_ExplicitThresholdsIgnoreRepoCount(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"surge": {Threshold: 300},
+			"busy":  {Threshold: 200},
+			"quiet": {Threshold: 100},
+		},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+
+	for _, repos := range []int{1, 39, 500} {
+		g.SetRepoCount(repos)
+		if got := g.computeMode(210); got != ModeBusy {
+			t.Errorf("repos=%d: hand-tuned hive at queue 210 = %s, want BUSY", repos, got)
+		}
+	}
+}
+
+func TestThresholdFor_ScalingNoneRestoresAbsoluteBehavior(t *testing.T) {
+	cfg := config.GovernorConfig{ThresholdScaling: config.ThresholdScalingNone}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	if got := g.thresholdFor("surge"); got != 20 {
+		t.Errorf("scaling none = %d, want the absolute 20", got)
+	}
+	if got := g.computeMode(210); got != ModeSurge {
+		t.Errorf("scaling none at queue 210 = %s, want SURGE (opted out)", got)
+	}
+}
+
+func TestThresholdFor_SqrtScaling(t *testing.T) {
+	cfg := config.GovernorConfig{ThresholdScaling: config.ThresholdScalingSqrt}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	if got := g.thresholdFor("surge"); got != 140 {
+		t.Errorf("sqrt surge = %d, want 140", got)
+	}
+}
+
+// An explicit threshold is never scaled, so mixing one with scaled defaults can
+// leave BUSY above SURGE — computeMode tests surge first and returns, making
+// BUSY unreachable. The governor must say so rather than let a mode silently
+// disappear.
+func TestSetRepoCount_WarnsOnInvertedLadder(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	out := buf.String()
+	if !strings.Contains(out, "not in descending order") {
+		t.Fatalf("no inversion warning logged; got %q", out)
+	}
+	// The warning has to carry the numbers, or an operator cannot act on it.
+	for _, want := range []string{"surge=70", "busy=390", "repo_count=39"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning does not include %q; got %q", want, out)
+		}
+	}
+
+	// And the inversion is real: BUSY cannot be entered.
+	if got := g.computeMode(200); got != ModeSurge {
+		t.Errorf("queue 200 with the inverted ladder = %s, want SURGE (busy unreachable)", got)
+	}
+}
+
+func TestSetRepoCount_NoWarningOnHealthyLadder(t *testing.T) {
+	var buf bytes.Buffer
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	if strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("warned about a correctly ordered ladder: %q", buf.String())
+	}
+}
+
+// UpdateConfig can introduce an inversion on its own (new explicit thresholds,
+// or a changed scaling curve), so it must run the same check.
+func TestUpdateConfig_WarnsOnInvertedLadder(t *testing.T) {
+	var buf bytes.Buffer
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+	buf.Reset()
+
+	g.UpdateConfig(config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	})
+
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("UpdateConfig did not re-check the ladder; got %q", buf.String())
+	}
+}
+
+// SetRepoCount is called on every config reload, including reloads that did not
+// touch the repo list. Re-warning on each one would spam the log.
+func TestSetRepoCount_UnchangedCountIsQuiet(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+	buf.Reset()
+
+	g.SetRepoCount(39)
+	if buf.Len() != 0 {
+		t.Errorf("re-setting the same repo count logged again: %q", buf.String())
+	}
+}
+
+// UpdateConfig runs on EVERY periodic config reload (main.go's ~2-minute loop)
+// and again on every dashboard config save, not only when something changed.
+// Re-warning each time would emit a WARN every couple of minutes forever on a
+// hive whose ladder is inverted — and an inverted ladder is exactly what the
+// #3498 reporter's hive has (explicit surge=70 beside a scaled busy). That is
+// against this codebase's own norm for the reload path, which is deliberately
+// kept quiet so a healthy hive does not spam.
+//
+// The warning must fire on the TRANSITION into an inverted ladder, then stay
+// quiet while nothing about it changes.
+func TestUpdateConfig_InvertedLadderWarnsOnceNotEveryReload(t *testing.T) {
+	var buf bytes.Buffer
+	inverted := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	buf.Reset()
+	g.UpdateConfig(inverted)
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Fatalf("first UpdateConfig did not warn; got %q", buf.String())
+	}
+
+	// Ten more reloads that change nothing at all.
+	buf.Reset()
+	for i := 0; i < 10; i++ {
+		g.UpdateConfig(inverted)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("re-warned on an unchanged inverted ladder %d times: %q",
+			strings.Count(buf.String(), "not in descending order"), buf.String())
+	}
+}
+
+// Suppression must be keyed on the ladder itself, not latched forever: a
+// DIFFERENT inversion is new information and has to be reported, or an operator
+// who edits one threshold and makes things worse hears nothing.
+func TestUpdateConfig_ChangedInversionWarnsAgain(t *testing.T) {
+	var buf bytes.Buffer
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+	g.UpdateConfig(config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	})
+
+	buf.Reset()
+	g.UpdateConfig(config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 50}},
+	})
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("a different inversion was suppressed; got %q", buf.String())
+	}
+}
+
+// And a ladder that gets FIXED and later breaks again must warn again — the
+// suppression is a dedupe, not a one-shot.
+func TestUpdateConfig_ReinversionAfterRepairWarnsAgain(t *testing.T) {
+	var buf bytes.Buffer
+	inverted := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	g.UpdateConfig(inverted)
+	g.UpdateConfig(config.GovernorConfig{}) // repaired: all three scale together
+	buf.Reset()
+
+	g.UpdateConfig(inverted)
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("re-inversion after a repair was suppressed; got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## What

Scales the **default** governor mode thresholds by the hive's configured repo count, so the mode ladder reflects per-repo pressure instead of an absolute queue size.

Refs #3498 — no `Fixes` keyword, deliberately. The issue left the scaling curve open ("linear — or a gentler sub-linear curve"), and I found a limitation that materially affects how much of the problem this actually solves on real hives (see **ACMM packs** below). Both are maintainer calls.

## The problem

`thresholdFor` returned fixed numbers (`surge=20`, `busy=10`, `quiet=2`) for a queue depth that is `actionable issues + open PRs` summed across **every watched repo**. So the thresholds encoded an implicit repo count:

- 39-repo hive, queue ~210 → permanent **SURGE**, most aggressive cadences, tiny per-repo backlog.
- 3-repo hive, same thresholds → idles through a backlog that is genuinely deep per repo.

## What changed

Default thresholds are now per-repo bases × `len(project.repos)`:

| | base (1 repo) | 3 repos | 39 repos |
|---|---:|---:|---:|
| `surge` | 20 | 60 | 780 |
| `busy` | 10 | 30 | 390 |
| `quiet` | 2 | 6 | 78 |

A one-repo hive gets **exactly** the numbers it got before. `primary_repo` with no `repos:` list counts as 1, so the floor never collapses a threshold to zero (which would pin the hive in SURGE — the opposite of the fix).

## Choosing the curve — and why linear is the default

The issue offered linear or `base * ceil(sqrt(repos))` and did not pick. I implemented both, defaulting to **linear**, for two reasons:

1. **Linear is exactly the per-repo normalization the issue's own "Alternatives considered" section describes**, without changing the queue number the dashboard displays. `queue > base * repos` ⟺ `queue/repos > base`. It is the principled reading, not just the simpler one.
2. **Sqrt does not fix the reported case.** `ceil(√39) = 7`, so surge lands at 140 and the reported hive at queue ~210 stays in **SURGE** — the exact symptom being reported. Linear puts it in QUIET (210/39 ≈ 5.4 per repo, which sits in the quiet band). The reporter hand-tuned their way to BUSY; linear lands one notch below that, which is a judgement call worth a maintainer's eye, but either is a world away from permanent surge.

Sqrt is still offered for hives with many quiet repos alongside a few busy ones:

```yaml
governor:
  threshold_scaling: linear   # linear (default) | sqrt | none
```

### On the config field name

The issue proposed `governor.auto_scale_thresholds: false` as the opt-out. I used `threshold_scaling: none` instead — the same switch, folded into the field that also picks the curve. Two separate knobs can contradict each other (`auto_scale_thresholds: false` + `threshold_scaling: sqrt` has no meaning), and one enum has no invalid combinations. Easy to rename if you'd rather have the original spelling.

Note `sqrt` and `linear` are **identical at 1 and 2 repos** and only separate from 3 onward, because the ceiling can't produce a factor below 2 until 5 repos. My first test asserted strict inequality everywhere and failed at `repos=2`; the test now pins the real shape of the curve rather than the assumed one.

## Explicit thresholds always win

A `threshold:` you set is returned **verbatim, never scaled**. Scaling an operator's hand-tuned `surge: 300` on a 39-repo hive would produce **11700** and silently break every hive that already worked around this bug by hand — that's the single most important guarantee here, and it has its own test.

A threshold of `0` still counts as **unset**, matching the existing behavior: mode entries frequently exist only to carry cadences.

### New hazard: mixed sources can invert the ladder

Because explicit values don't scale, mixing them with scaled defaults can put the ladder out of order. On a 39-repo hive with the reporter's own `surge: 70`, `busy` scales to 390 — **above** surge. `computeMode` tests surge first and returns, so BUSY becomes unreachable.

This was not reachable before: the three thresholds were previously either all defaults or all hand-set at comparable magnitudes. The governor now warns with all three effective values:

```
governor mode thresholds are not in descending order — a mode is unreachable
  surge=70 busy=390 quiet=78 repo_count=39 threshold_scaling=linear
```

It **warns rather than reorders** — the inversion comes from a number the operator set, and silently overriding it would be the worse surprise.

## ⚠️ ACMM packs seed explicit thresholds, so scaling won't engage on pack-applied hives

This is the finding most worth your attention, and it limits the feature's reach beyond what the issue anticipated.

`pkg/dashboard/api_packs.go:282` writes pack thresholds into `governor.modes.*.threshold` on apply, and `pkg/config/packs/level-*.yaml` all carry them (L4–L6: `surge: 10, busy: 5, quiet: 2`; L3: `15/10/3`).

Those land in config as **explicit** values. Nothing distinguishes a pack-seeded default from one an operator typed. So under "explicit always wins" — which the issue is emphatic about — **scaling does not engage on any hive that applied an ACMM level**, which is the normal path and plausibly includes the 39-repo hive that motivated the issue.

I did **not** work around this. The available workarounds are all worse than the gap:

- Scaling explicit values too would 39× a hand-tuner's `300` → `11700`.
- Dropping thresholds from the pack YAMLs loses real per-level tuning (L3 differs from L4–L6).
- Baking scaled values at apply time goes stale the moment repos change — the exact drift the issue exists to eliminate.

Fixing it properly means recording **provenance** (pack-seeded vs operator-set) so rule 1 can apply only to the latter. That's a config-layering decision, not something to bolt on inside this PR. Documented in `docs/governor-thresholds.md` with the manual workaround (clear the thresholds you want scaled).

The feature is fully correct and effective for hives without packs, and for anyone who clears the seeded values.

## Shared resolution — the gauge no longer keeps its own copy

`buildGovernor` (`status_builder.go`) had **private duplicates** of `2/10/20` plus its own explicit-wins check, with a comment saying "keep the defaults so the gauge matches the governor's evaluation."

Harmless while both were constant. Once the governor started scaling, that copy would have explained the current mode with numbers that did not produce it. Both now call `config.EffectiveThreshold`, and a table test asserts the gauge equals what the governor resolves across seven configurations (defaults, hand-tuned, mixed, none, sqrt, cadence-only mode entries, no repos) — comparing two independently reached answers rather than restating one.

## Wiring

`Governor.SetRepoCount` is a setter rather than a `New`/`UpdateConfig` parameter: the count comes from `config.Project`, not `GovernorConfig`, and moves on a different schedule (a dashboard repo edit doesn't touch governor settings). It also avoids churning 68 `New(...)` call sites in the existing tests. It sits beside the existing `ghClient.SetRepos` on the reload path, matching that precedent, and is called from all three places the governor learns about config: startup, config reload, and dashboard save.

`repoCount` defaults to **1** in `New`, so a governor built without one behaves exactly as before.

## Dashboard

- `GET /api/config/governor` now also returns `effectiveThresholds`, `thresholdScaling`, and `repoCount`.
- New `PUT /api/config/governor/threshold-scaling` — a separate route because the existing thresholds endpoint takes a flat `map[string]int`, which a string curve doesn't fit.
- **Governor → Thresholds** gains a scaling selector and a line showing the values actually in force. This matters: on a 39-repo hive the effective surge is 780, far past the slider's 200-column range, so a slider reading 20 with no further explanation would be a lie. The note also states that dragging a handle pins that threshold and opts it out of scaling.

## Tests

`pkg/config/threshold_scaling_test.go` — curves incl. boundaries and negative repo counts; explicit-never-scaled at 1/39/500 repos; zero-means-unset; unknown modes get no invented default; the mixed/inverted fixture; validation incl. near-misses (`Linear`, `on`, `true`).

`pkg/governor/governor_threshold_scaling_test.go` — repo count reaches `thresholdFor`; **the reported scenario end to end** (39 repos at queue 210 is SURGE before, not after); equal per-repo pressure yields the same mode at 3 and 39 repos; hand-tuned hives unaffected at any repo count; inversion warning fires from both `SetRepoCount` and `UpdateConfig`, carries the numbers, and stays quiet on an unchanged count (it runs on every reload).

`pkg/dashboard/governor_threshold_gauge_test.go` — gauge/governor agreement, described above.

### Regression replay

Each change neutered (still compiling), the specific test confirmed failing, then restored green.

**1. Explicit thresholds scaled too** — the change that would break every hand-tuned hive:
```
--- FAIL: TestEffectiveThreshold_ExplicitIsNeverScaled
    repos=39: explicit surge = 11700, want 300
    repos=500: explicit surge = 150000, want 300
```

**2. Repo-count floor removed:**
```
--- FAIL: TestScaleThreshold_Linear
    ScaleThreshold(20, 0, linear) = 0, want 20
    ScaleThreshold(20, -5, linear) = -100, want 20
```

**3. Governor ignores the repo count:**
```
--- FAIL: TestSetRepoCount_ScalesDefaultThresholds
    39-repo surge = 20, want 780
--- FAIL: TestComputeMode_LargeHiveLeavesPermanentSurge
    39-repo hive at queue 210 is still SURGE — the reported bug is not fixed
```

**4. Dashboard gauge restored to its own copy of the defaults:**
```
--- FAIL: TestBuildGovernor_GaugeAgreesWithGovernor/defaults,_many_repos
    gauge surge = 20, governor uses 780
--- FAIL: TestBuildGovernor_GaugeAgreesWithGovernor/sqrt_scaling
    gauge surge = 20, governor uses 140
```

**5. Inversion warning removed:**
```
--- FAIL: TestSetRepoCount_WarnsOnInvertedLadder
    no inversion warning logged; got ""
--- FAIL: TestUpdateConfig_WarnsOnInvertedLadder
```

**6. `threshold_scaling` validation removed:**
```
--- FAIL: TestValidate_RejectsBadThresholdScaling
    validate() accepted an invalid threshold_scaling
```

**7. sqrt curve degraded to linear** (the option becomes a lie):
```
--- FAIL: TestScaleThreshold_Sqrt
    ScaleThreshold(20, 39, sqrt) = 780, want 140
--- FAIL: TestScaleThreshold_SqrtIsNeverHarsherThanLinear
```

### Local verification

```
go build ./...                clean
gofmt -l <changed files>      clean
go vet <changed pkgs>         clean
go test ./pkg/governor/       ok  0.02s
go test ./pkg/config/         ok  2.6s
go test ./pkg/dashboard/      ok  51.1s
go test ./pkg/scheduler/      ok  0.02s
go test ./...                 4 pre-existing failures in cmd/bd
```

`cmd/bd` (`TestCmdCloseAndReopenViaUpdate`, `TestCmdUpdateMetadata`, `TestCmdUpdateClaim`, `TestCmdReset`) fails identically on a clean checkout — verified by stashing every change and re-running. It is the beads CLI, untouched here.

## Compatibility

Defaults-only, as the issue intended. Unchanged for: single-repo hives, hives with explicit thresholds (including every pack-applied hive), and anyone setting `threshold_scaling: none`.

**Changed for:** multi-repo hives running on the code defaults — which is the point. Such a hive will see its thresholds rise and its mode drop, likely on the first eval after upgrade. The dashboard shows the effective numbers and the repo count so the change is legible rather than mysterious.
