### PR TITLE
🐛 fix(kick,docs): stop instructing agents to read the shared full-privilege App token cache

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -83,3 +83,4 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `contributor-agent.test.sh` | Contributor-agent regression for knowledge export handling. |
 | `contributor-relay.test.js` | Contributor relay task/restart/headless behavior; loads `contributor-relay.sh` as JavaScript with stubs. |
 | `gh-wrapper.test.sh` | `gh-wrapper.sh` author-gate and restriction regressions using a mock `gh` binary. |
+| `kick-agents-gh-auth.test.sh` | `kick-agents.sh` GH AUTH instruction (#1861): kicks must point each agent at its own tier-scoped token file, never the shared full-privilege App token cache. |

--- a/bin/kick-agents-gh-auth.test.sh
+++ b/bin/kick-agents-gh-auth.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Regression tests for kubestellar/hive#1861: the kick messages must never
+# instruct an agent to read the shared GitHub App token cache.
+#
+# /var/run/hive-metrics/gh-app-token.cache holds the FULL, unscoped
+# installation token. Reading it skips the credential helper's UID/mode gate
+# and hands any agent full privilege — the escalation #1861 exists to close
+# (audit H3, CWE-522/732). The file is 0600 today, so the old instruction can
+# no longer succeed for a non-root agent, but an agent TOLD to reach for it
+# will try the same path with curl or git, where no wrapper intervenes.
+#
+# bin/gh-wrapper.sh already refuses that fallback and fails loud, and the v2
+# scheduler (v2/pkg/scheduler/scheduler.go ghAuthInstructions) already tells
+# agents the right thing. These tests hold the v1 kick lane to the same rule so
+# the two lanes cannot drift apart again.
+#
+# Run: bash bin/kick-agents-gh-auth.test.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KICK="${ROOT_DIR}/bin/kick-agents.sh"
+SHARED_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+PASSED=0
+FAILED=0
+
+pass() { printf '  ✓ %s\n' "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf '  ✗ %s\n' "$1"; printf '    %s\n' "${2:-}"; FAILED=$((FAILED + 1)); }
+
+# The agents whose kick messages carry a GH AUTH line. Kept explicit rather
+# than derived, so ADDING an agent without an auth line is a visible diff here.
+AGENTS=(scanner ci-maintainer architect outreach supervisor)
+
+printf '\n=== kick-agents.sh GH AUTH instruction (#1861) ===\n\n'
+
+# --- 1. the script is valid bash -------------------------------------------
+if bash -n "$KICK" 2>/dev/null; then
+  pass "kick-agents.sh parses"
+else
+  fail "kick-agents.sh parses" "$(bash -n "$KICK" 2>&1 | head -3)"
+fi
+
+# --- 2. no agent-facing instruction names the shared cache ------------------
+# Scoped to the auth helper and the kick message bodies. The script may still
+# reference the shared cache in hive-side plumbing that runs as the hive, which
+# is legitimate; what must never happen is TELLING AN AGENT to read it.
+if grep -n "cat ${SHARED_CACHE}" "$KICK" >/dev/null 2>&1; then
+  fail "no kick instruction tells an agent to cat the shared App token cache" \
+    "found: $(grep -n "cat ${SHARED_CACHE}" "$KICK" | head -3)"
+else
+  pass "no kick instruction tells an agent to cat the shared App token cache"
+fi
+
+if grep -n "GH_TOKEN=\\\$(cat ${SHARED_CACHE}" "$KICK" >/dev/null 2>&1; then
+  fail "no kick instruction exports GH_TOKEN from the shared cache" \
+    "found: $(grep -n "GH_TOKEN=\\\$(cat ${SHARED_CACHE}" "$KICK" | head -3)"
+else
+  pass "no kick instruction exports GH_TOKEN from the shared cache"
+fi
+
+# --- 3. the auth helper renders a per-agent path ----------------------------
+# Extract just _gh_auth_instr rather than sourcing kick-agents.sh, which does
+# real work (reads metrics, talks to tmux) at load time.
+HELPER="$(mktemp)"
+# shellcheck disable=SC2329 # invoked via EXIT trap
+cleanup() { rm -f "$HELPER"; }
+trap cleanup EXIT
+sed -n '/^_gh_auth_instr() {$/,/^}$/p' "$KICK" >"$HELPER"
+
+if [ -s "$HELPER" ]; then
+  pass "_gh_auth_instr helper found in kick-agents.sh"
+else
+  fail "_gh_auth_instr helper found in kick-agents.sh" "extraction produced nothing"
+  printf '\nResult: %d passed, %d failed\n' "$PASSED" "$FAILED"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$HELPER"
+
+for agent in "${AGENTS[@]}"; do
+  rendered="$(_gh_auth_instr "$agent")"
+
+  # The agent's OWN token file, and no other agent's.
+  want="/var/run/hive-metrics/agent-tokens/gh-token-${agent}.cache"
+  if [[ "$rendered" == *"$want"* ]]; then
+    pass "${agent}: instruction names its own token file"
+  else
+    fail "${agent}: instruction names its own token file" "want substring: $want"
+  fi
+
+  # The shared cache may be NAMED in a prohibition ("NEVER read ..."), but must
+  # never appear as a path the agent is told to read.
+  if [[ "$rendered" == *"cat ${SHARED_CACHE}"* || "$rendered" == *"cat \$(${SHARED_CACHE}"* ]]; then
+    fail "${agent}: instruction does not tell the agent to read the shared cache" \
+      "rendered: $rendered"
+  else
+    pass "${agent}: instruction does not tell the agent to read the shared cache"
+  fi
+
+  # And it must actively warn against it — silence would let an agent that
+  # remembers the old prompt keep using it.
+  if [[ "$rendered" == *"NEVER read"*"gh-app-token.cache"* ]]; then
+    pass "${agent}: instruction explicitly forbids the shared cache"
+  else
+    fail "${agent}: instruction explicitly forbids the shared cache" "rendered: $rendered"
+  fi
+done
+
+# --- 4. the emitted token path is a literal for the agent, not expanded here -
+# The kick builder must hand the agent the command text `$(cat ...)`. If the
+# substitution ran while BUILDING the kick, the hive would read the file as
+# root and paste a live token into a tmux pane and the kick audit log.
+rendered_scanner="$(_gh_auth_instr scanner)"
+if [[ "$rendered_scanner" == *'$(cat /var/run/hive-metrics/agent-tokens/gh-token-scanner.cache)'* ]]; then
+  pass "token path stays a literal command for the agent (no token pasted into the kick)"
+else
+  fail "token path stays a literal command for the agent (no token pasted into the kick)" \
+    "rendered: $rendered_scanner"
+fi
+
+# --- 5. every call site passes an agent name --------------------------------
+# A bare ${_GH_AUTH_INSTR} left behind would expand to the empty string under
+# `set -u`-less bash, silently dropping the auth line from that agent's kick.
+if grep -n '_GH_AUTH_INSTR' "$KICK" >/dev/null 2>&1; then
+  fail "no stale _GH_AUTH_INSTR references remain" \
+    "found: $(grep -n '_GH_AUTH_INSTR' "$KICK" | head -3)"
+else
+  pass "no stale _GH_AUTH_INSTR references remain"
+fi
+
+call_sites="$(grep -c '\$(_gh_auth_instr ' "$KICK" || true)"
+if [ "$call_sites" -eq "${#AGENTS[@]}" ]; then
+  pass "all ${#AGENTS[@]} kick messages carry a GH AUTH line"
+else
+  fail "all ${#AGENTS[@]} kick messages carry a GH AUTH line" \
+    "found ${call_sites} call sites, expected ${#AGENTS[@]}"
+fi
+
+# --- 6. each kick passes ITS OWN agent name ---------------------------------
+# The call sites are hand-maintained, one per message, so the natural error is a
+# copy-paste that leaves an agent pointing at ANOTHER agent's token file. That
+# is a cross-agent credential leak — the agent is handed a path it must never
+# read (and, if tiers differ, one that escalates it) — and every check above
+# still passes, because the helper itself renders correctly for whatever name
+# it is given. Tie each call site back to the [agent:NAME] tag of the message
+# it sits inside.
+mismatches=""
+while IFS=: read -r lineno _; do
+  [ -n "$lineno" ] || continue
+  passed_agent="$(sed -n "${lineno}p" "$KICK" | sed -n 's/.*_gh_auth_instr \([a-z0-9-]*\)).*/\1/p')"
+  # The owning message's tag is the nearest [agent:NAME] at or above this line.
+  owning_agent="$(head -n "$lineno" "$KICK" | grep -o '\[agent:[a-z0-9-]*\]' | tail -1 | sed 's/\[agent:\(.*\)\]/\1/')"
+  if [ -z "$owning_agent" ]; then
+    mismatches="${mismatches}line ${lineno}: no [agent:...] tag found above the call site; "
+  elif [ "$passed_agent" != "$owning_agent" ]; then
+    mismatches="${mismatches}line ${lineno}: [agent:${owning_agent}] kick passes '${passed_agent}'; "
+  fi
+done < <(grep -n '\$(_gh_auth_instr ' "$KICK")
+
+if [ -z "$mismatches" ]; then
+  pass "every kick passes its own agent name (no cross-agent token path)"
+else
+  fail "every kick passes its own agent name (no cross-agent token path)" "$mismatches"
+fi
+
+printf '\nResult: %d passed, %d failed\n' "$PASSED" "$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -831,7 +831,26 @@ if policy_changed "scanner"; then
 else
   _SCANNER_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
 fi
-_GH_AUTH_INSTR="⚙ GH AUTH: ALWAYS prefix gh commands with: GH_TOKEN=\$(cat /var/run/hive-metrics/gh-app-token.cache) gh ... — this uses the GitHub App token (15k/hr). NEVER use a PAT or hardcode tokens. NEVER set GH_TOKEN from env vars or hosts.yml. The App token file is refreshed automatically."
+# _gh_auth_instr <agent> — the GH AUTH line embedded in that agent's kick.
+#
+# SECURITY (kubestellar/hive#1861, audit H3 / CWE-522,732): this deliberately
+# does NOT name /var/run/hive-metrics/gh-app-token.cache. That file holds the
+# FULL, unscoped installation token; reading it skips the credential helper's
+# UID/mode gate and hands any agent full privilege, which is the exact
+# escalation #1861 exists to close. It is now 0600, so the old instruction can
+# no longer succeed for a non-root agent — but telling agents to reach for it
+# still teaches the anti-pattern, and an agent that learns the path will try it
+# on other tools (curl, git) where no wrapper is in the way.
+#
+# The per-agent file named here is 0600, owned by the agent's own UID, and
+# scoped to the agent's trust tier, so it preserves both enforcement layers
+# (tier-scoped token + proxy mode inspection). This wording is kept in step with
+# the v2 scheduler's ghAuthInstructions (v2/pkg/scheduler/scheduler.go), which
+# has told agents the right thing since per-agent tokens landed in #1860 — the
+# two kick lanes were contradicting each other until now.
+_gh_auth_instr() {
+  printf '%s' "⚙ GH AUTH: run gh normally — where the hive's gh wrapper is installed it injects your per-agent token automatically. If a command reports no token, export it yourself first: export GH_TOKEN=\$(cat /var/run/hive-metrics/agent-tokens/gh-token-$1.cache) — that file is YOUR tier-scoped App token (15k/hr) and is refreshed automatically. NEVER read another agent's token file, and NEVER read the shared gh-app-token.cache: it holds an unscoped full-privilege token and using it defeats per-agent scoping. NEVER use a PAT or hardcode tokens. NEVER set GH_TOKEN from HIVE_GITHUB_TOKEN or hosts.yml."
+}
 
 _CLUSTER_SECTION=""
 if [ -n "$_CLUSTERS_INLINE" ]; then
@@ -840,7 +859,7 @@ CLUSTERS (bundle into 1 agent each):
 ${_CLUSTERS_INLINE}"
 fi
 SCANNER_MSG="[agent:scanner] [KICK] git pull /tmp/hive. ${_SCANNER_POLICY_INSTR}
-${_GH_AUTH_INSTR}
+$(_gh_auth_instr scanner)
 YOUR WORK LIST (pre-filtered — hold/ADOPTERS/drafts excluded, classified):
 ${_WORK_LIST}${_CLUSTER_SECTION}${_MERGE_INLINE}$([ -n "$_FAILING_INLINE" ] && printf '\nCI-FAILING PRs (fix these — the ERROR lines are the RAW CI evidence, start from them, do NOT guess):\n%s' "$_FAILING_INLINE")$([ -n "$_ESCALATED_INLINE" ] && printf '\n🛑 ESCALATED (fix loop breaker tripped — do NOT open or push more fix PRs for these; a human owns them until the needs-human label is removed):\n%s' "$_ESCALATED_INLINE")
 ⛔ NEVER run gh issue list, gh pr list, gh search issues, or gh search prs — the work list above is your ONLY source. You may use gh issue view, gh pr view, gh pr merge, gh pr create on individual items.
@@ -910,7 +929,7 @@ GA4: ${_GA4_SUMMARY}"
   fi
 fi
 CI_MAINTAINER_MSG="[agent:ci-maintainer] [KICK] ${_HEALTH_PREAMBLE}git pull /tmp/hive. ${_REVIEWER_POLICY_INSTR}${_GA4_PREAMBLE}${_COPILOT_PREAMBLE}
-${_GH_AUTH_INSTR}
+$(_gh_auth_instr ci-maintainer)
 Fix REDs (NOT Playwright — file issues only, scanner owns Playwright fixes), merge green PRs. Copilot comments and GA4 data above are pre-computed — do NOT re-query. Read /var/run/hive-metrics/copilot-comments.json and /var/run/hive-metrics/ga4-anomalies.json for full details. Beads: ~/ci-maintainer-beads"
 
 if policy_changed "architect"; then
@@ -919,7 +938,7 @@ else
   _ARCHITECT_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
 fi
 ARCHITECT_MSG="[agent:architect] [KICK] git pull /tmp/hive. ${_ARCHITECT_POLICY_INSTR}
-${_GH_AUTH_INSTR}
+$(_gh_auth_instr architect)
 Full architect pass — refactor/perf scan. Beads: ~/architect-beads"
 
 if policy_changed "outreach"; then
@@ -950,7 +969,7 @@ _OUTREACH_SECTION=""
 [ -n "$_OUTREACH_PREAMBLE" ] && _OUTREACH_SECTION="
 ${_OUTREACH_PREAMBLE}"
 OUTREACH_MSG="[agent:outreach] [KICK] git pull /tmp/hive. ${_OUTREACH_POLICY_INSTR}${_OUTREACH_SECTION}
-${_GH_AUTH_INSTR}
+$(_gh_auth_instr outreach)
 Full outreach pass. PR counts above are pre-computed — do NOT re-query with gh search. Read /var/run/hive-metrics/outreach-prs.json for full details. Check blocked_orgs before opening new PRs. Beads: ~/outreach-beads"
 
 # ── Governor model integration ──────────────────────────────────────
@@ -1135,7 +1154,7 @@ else
   _SUPERVISOR_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
 fi
 SUPERVISOR_MSG="[agent:supervisor] [KICK] MONITORING PASS ${_now_et}. ${_SUPERVISOR_POLICY_INSTR}
-${_GH_AUTH_INSTR}
+$(_gh_auth_instr supervisor)
 Check all agent panes, merge green PRs, unstick idle agents. Beads: ~/supervisor-beads"
 
 case "$TARGET" in

--- a/v2/docs/security-threat-model.md
+++ b/v2/docs/security-threat-model.md
@@ -96,6 +96,24 @@ the threats they reduce.
   by the proxy, but agents still have network paths for allowed GitHub reads,
   model backends, and opaque `github.com` tunneling. #2804 proposes a stricter
   no-network sandbox with the MITM proxy retained as an outer layer.
+- **Proxy agent identity is not yet authoritative.** The MITM proxy resolves the
+  calling agent by reading the socket owner's UID from `/proc/net/tcp`
+  (unforgeable), but falls back to the client-supplied `Proxy-Authorization`
+  header when that lookup returns nothing — which is every request when no UID
+  map is present, since agents then share the `dev` UID
+  (`pkg/proxy/github_proxy.go`, `identifyAgentFromReq` / `extractAgentName`).
+  An agent that sets that header can therefore present another agent's name to
+  the proxy. Impact today is bounded to the proxy's *mode* decision: tokens are
+  per-agent files at `0600` owned by the agent's own UID, so a spoofed name does
+  not yield another agent's credential, and an unidentified caller fails closed
+  to `ADVISORY`. This gap is the stated reason the proxy-side token **injection**
+  in [#1861](https://github.com/kubestellar/hive/issues/1861) is deferred:
+  minting a tier-scoped token for whoever the proxy believes is calling would
+  promote a name-spoofing weakness into a token-minting one. Closing it is
+  tracked as N7 of [#2172](https://github.com/kubestellar/hive/issues/2172), and
+  is expected to reuse the per-spoke keypair/attestation from the master-delivery
+  work ([#3833](https://github.com/kubestellar/hive/issues/3833)) rather than
+  inventing a second identity story.
 - **ioscan semantic classification is optional and fail-open.** Deterministic
   rules, Unicode normalization, base64 rescans, canaries, output redaction, and
   fail-closed semantics are the dependable floor. The model-based classifier


### PR DESCRIPTION
## What

Removes the last place in the repo that **instructs agents to read the shared, full-privilege GitHub App token cache**, and records the blocker that gates the rest of #1861.

Refs #1861 — **no `Fixes` keyword.** This is the small independent fix the issue's own triage carved out; the architectural item (proxy-side token injection) is deliberately **not** implemented, for the reason in the last section. The issue should stay open.

## Scope, per the issue's triage

The maintainer triage on #1861 re-scoped it to three outcomes. I verified each against `origin/v4` before touching anything:

| Item | Triage claim | My verification | Action |
|---|---|---|---|
| 2 — tighten shared cache to `0600` | ✅ already shipped | Confirmed: `bin/gh-app-token.sh:60` `chmod 600`; `pkg/github/app.go:31,56` `0o600`; `pkg/agent/manager.go:630` `0o600` | Dropped from scope |
| 1 — proxy-side injection | ⛔ blocked on identity (N7), sequence after #3833 | Confirmed, and I agree — see below | **Not implemented** |
| 🔨 carve-out — `kick-agents.sh:834` | "Safe, self-contained, no design needed" | Confirmed still present, reaching **5** kick messages | **This PR** |

## The bug

`bin/kick-agents.sh:834` built one `_GH_AUTH_INSTR` string embedded in the scanner, ci-maintainer, architect, outreach, and supervisor kicks:

```
⚙ GH AUTH: ALWAYS prefix gh commands with:
  GH_TOKEN=$(cat /var/run/hive-metrics/gh-app-token.cache) gh ...
```

That file holds the **full, unscoped installation token**. Reading it skips the credential helper's UID/mode gate and hands any agent full privilege — precisely the escalation #1861 exists to close, and precisely the fallback `bin/gh-wrapper.sh:59-81` already refuses, with a comment citing audit H3 / CWE-522,732:

> there is deliberately NO fallback to the shared full-privilege installation-token cache … falling back to either would silently escalate every agent to full privilege

Meanwhile `pkg/scheduler/scheduler.go:734` has told agents the opposite since #1860:

> Never point agents at the shared `gh-app-token.cache`: reading it skips the credential helper's UID/mode gate and hands every agent an unscoped token.

**The two kick lanes were instructing agents to do opposite things.** `install.sh:93` installs `kick-agents.sh`, so the v1 lane is live, not dead code.

### Why it still matters at `0600`

Item 2 already landed, so this `cat` now fails for a non-root agent rather than escalating. It is still worth fixing:

1. **It teaches the path.** An agent told to read that file will try it with `curl` or `git`, where no wrapper intervenes — and #1861's "Why now" is literally an agent discovering this read under pressure when its push failed.
2. **It fails confusingly.** `GH_TOKEN=$(cat …)` on an unreadable file yields an *empty* `GH_TOKEN` prefix, not an error the agent can act on.
3. **It contradicts the other lane**, which is how instructions drift back.

## The fix

`_GH_AUTH_INSTR` (a single string) becomes `_gh_auth_instr <agent>` (a function). Each of the five call sites passes its own agent name, so each kick names **that agent's** `0600`, UID-owned, tier-scoped token file — and names the shared cache only to forbid it. Wording tracks `ghAuthInstructions` so the lanes now agree.

It leads with "run `gh` normally": `v2/Dockerfile:348` and `Dockerfile.contributor:177` both `COPY bin/gh-wrapper.sh /usr/local/bin/gh`, and `hive-deploy.sh:105` syncs it there, so on those hosts the wrapper already injects the scoped token and the agent needs no token material at all — #1861's actual goal, reachable today for `gh`. The explicit `export` is kept as the fallback because `install.sh:98` installs the wrapper as `gh-wrapper.sh` **only**, not as `gh`; on an `install.sh`-provisioned host "just run gh" would leave agents unauthenticated.

## Tests

New `bin/kick-agents-gh-auth.test.sh` (23 assertions), following the `bin/gh-wrapper.test.sh` convention. It extracts just the helper rather than sourcing `kick-agents.sh`, which reads metrics and talks to tmux at load time.

Beyond the obvious "no shared-cache instruction", it pins two things worth calling out:

- **The token path must stay a literal for the agent.** If `$(cat …)` were expanded while *building* the kick, the hive would read the file as root and paste a live token into a tmux pane and the kick audit log — turning a prompt fix into a credential leak.
- **Each kick must pass its own agent name**, tied back to the `[agent:NAME]` tag of the message it sits inside.

### Regression replay

**Replay 2 initially did not fail, and that was a real gap in my test.** I reverted `outreach`'s call site to `scanner` — a plausible copy-paste across five hand-edited sites, and a cross-agent credential path — and the suite passed 22/22, because the helper renders correctly for whatever name it is handed. Added check 6 to tie each call site to its message's `[agent:…]` tag; it now fails. Recording it because the gap was in the test I wrote to guard the change I made.

**1. Original instruction restored verbatim:**
```
✗ no kick instruction tells an agent to cat the shared App token cache
✗ scanner: instruction names its own token file
✗ scanner: instruction explicitly forbids the shared cache
   … Result: 5 passed, 17 failed
```

**2. Cross-agent leak — outreach handed scanner's token file** (after adding check 6):
```
✗ every kick passes its own agent name (no cross-agent token path)
    line 972: [agent:outreach] kick passes 'scanner'
   Result: 22 passed, 1 failed
```

**3. Builder expands the token at build time** (`\$(cat` → `$(cat`):
```
✗ scanner: instruction names its own token file
✗ token path stays a literal command for the agent (no token pasted into the kick)
   Result: 16 passed, 6 failed
```

### Local verification

```
bash bin/kick-agents-gh-auth.test.sh    23 passed, 0 failed
bash -n bin/kick-agents.sh              clean
shellcheck -S warning <new test>        clean
bash bin/test_gh_wrapper_gates.sh       46 passed, 0 failed
cd v2 && go build ./...                 clean (no Go changed)
```

`bin/gh-wrapper.test.sh` fails (`FAIL: issue list --author test-bot[bot]`) — **identically on a clean checkout**, verified by stashing every change. Pre-existing, unrelated.

## ⛔ Why proxy-side injection (item 1) is not in this PR

I verified the blocker rather than taking the triage on faith, and it holds.

`identifyAgentFromReq` (`pkg/proxy/github_proxy.go:648`) tries unforgeable UID lookup first, then falls back to `extractAgentName(r)` — which reads the **client-supplied `Proxy-Authorization` header** (`:1197`). The fallback is not an edge case:

```go
if p.uidMap != nil {
    if name := p.identifyAgentByUID(r.RemoteAddr); name != "" { return name }
}
return extractAgentName(r)   // Proxy-Authorization — agent-controlled
```

When no UID map exists, `manager.go:805` logs *"no UID map found, agents will share dev UID"* — so UID lookup **cannot** distinguish agents and the forgeable header is the only signal for every request.

Injecting there would mint a tier-scoped token for whoever the proxy *believes* is calling. Today spoofing the header misstates the **mode** used for a request; with injection it would yield **another tier's token**. That converts a name-spoofing weakness into a token-minting one — strictly worse than the shared-cache read this issue set out to eliminate. Per-agent token files are `0600` owned by the agent's UID, so no credential crosses over today; injection is what would change that.

Building it now would also mean inventing a second, weaker identity story that the master-delivery per-spoke keypair (#3833) would supersede — the triage's sequencing point, which I think is right.

So instead of code, item 1 gets **documentation**: a new residual-risk entry in `v2/docs/security-threat-model.md` recording the fallback, its bounded impact today, why #1861's injection is deferred, and the N7 (#2172) / #3833 dependency. That analysis lived only in an issue comment; the threat model is where the next person will look.

## One further finding, deliberately not fixed here

`bin/contributor-relay.sh:46-48` defaults its token cache to the **hive's** shared App-token path when `/var/run/hive-metrics` exists, and `injectGhToken` (`:222-226`) *writes* to it. Inside the contributor container that directory is created deliberately (`Dockerfile.contributor:170`, `contributor-agent.sh:323`) so it is intended there — but a relay run natively (`just contribute-hive … local`) on a host that is also a hive spoke would **overwrite the hive's App token** with a hub-delivered task token, and every hive-side reader (`hive-config.sh:202`, `dashboard/*.sh`) would then use the wrong credential.

I left it alone: the triage attributes it to **N14 of #2172**, not this issue, and while tracing consumers I found `gh-wrapper.sh` skips token injection entirely in contributor mode (`if ! _contributor_mode`), so it is unclear what reads that file in the container. Changing the path blind could break the contributor flow. It needs the contributor-flow owner, not a drive-by.
