### PR TITLE
🐛 fix(advisory): collapse near-duplicate findings so the advisory digest stays readable

### DIFF
--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -28,6 +28,11 @@ type Finding struct {
 	Detail    string    `json:"detail,omitempty"`
 	File      string    `json:"file,omitempty"`
 	Line      int       `json:"line,omitempty"`
+	// DuplicateCount is how many ADDITIONAL reports of the same finding were
+	// collapsed into this one by collapseNearDuplicates (0 = reported once).
+	// It is rendered as "(reported N×)" so a recurring problem still reads as
+	// recurring — the count is signal, and collapsing must not destroy it.
+	DuplicateCount int `json:"duplicate_count,omitempty"`
 	// PathStale is set by VerifyFindingPaths when File names a repo file path
 	// that does NOT exist at the digest's analyzed snapshot (Digest.AnalyzedSnapshot).
 	// Such a finding was generated against a different/older tree than the one
@@ -151,11 +156,19 @@ func BuildDigest(findings []Finding, mode string) *Digest {
 	for _, f := range findings {
 		byAgent[f.Agent] = append(byAgent[f.Agent], f)
 	}
+	// Collapse restatements of the same finding (#2364). TotalCount must be
+	// derived from what SURVIVES, not from the input, or the header count
+	// disagrees with the list beneath it.
+	total := 0
+	for agent, fs := range byAgent {
+		byAgent[agent] = collapseNearDuplicates(fs)
+		total += len(byAgent[agent])
+	}
 	return &Digest{
 		GeneratedAt: time.Now(),
 		Mode:        mode,
 		ByAgent:     byAgent,
-		TotalCount:  len(findings),
+		TotalCount:  total,
 	}
 }
 
@@ -172,6 +185,157 @@ func isAdvisoryBeadType(t beads.BeadType) bool {
 }
 
 const recentlyResolvedWindow = 48 * time.Hour
+
+// nearDuplicateThreshold is the Jaccard similarity at or above which two
+// findings from the SAME agent with the SAME finding type are treated as the
+// same finding reported twice (#2364).
+//
+// Exact-title dedup alone does not hold: an agent re-reporting a persistent
+// problem rewords the title each cycle, so the digest accumulates one entry per
+// report. Measured on the live digest of 2026-08-14 (92 findings in the pinned
+// comment of #2364), 29 were the same broken pr-verifier workflow under 29
+// different titles — 32% of the digest, all describing one already-fixed
+// problem, crowding out real findings.
+//
+// 0.5 is chosen for SAFETY MARGIN, not for maximum compression. Sweeping that
+// corpus, merges of genuinely different subjects last appear at 0.30 (a
+// "v2 Tests: N consecutive failures" summary absorbing a specific
+// "TestAlertAcksPersistRoundTrip regression"); 0.35 and above produce none.
+// At 0.5 the corpus goes 92 -> 56 findings and the pr-verifier pile 29 -> 4,
+// with a 0.20 margin over the observed boundary.
+//
+// The asymmetry is deliberate: a duplicate wastes a reader's attention, a
+// wrongly-merged finding HIDES a real defect. So the threshold errs toward
+// showing the duplicate, and is not tuned for the largest possible reduction.
+const nearDuplicateThreshold = 0.5
+
+// duplicateStopWords are words carrying no subject information in a finding
+// title. They are dropped before similarity is computed so that shared
+// boilerplate ("failing on every PR") cannot by itself make two findings look
+// alike.
+var duplicateStopWords = map[string]bool{
+	"a": true, "an": true, "the": true, "of": true, "on": true, "in": true,
+	"to": true, "for": true, "is": true, "are": true, "was": true, "were": true,
+	"and": true, "or": true, "but": true, "with": true, "by": true, "from": true,
+	"at": true, "as": true, "it": true, "its": true, "this": true, "that": true,
+	"not": true, "no": true, "failing": true, "fails": true, "failed": true,
+	"failure": true, "every": true, "all": true,
+}
+
+var (
+	dupBacktickRe = regexp.MustCompile("`[^`]*`")
+	dupMDLinkRe   = regexp.MustCompile(`\[[^\]]*\]\([^)]*\)`)
+	// Split on every non-letter, which breaks paths and qualified names into
+	// their parts: "kubestellar/infra" -> {kubestellar, infra} and
+	// "pr-verifier.yml" -> {verifier, yml}. Keeping them whole made
+	// "…missing from kubestellar/infra" and "…deleted from infra" share no
+	// token for the thing they are both about, and the two failed to merge.
+	// Sub-word splitting measured strictly better on the #2364 corpus: more
+	// collapse AND zero cross-subject merges at every threshold tried.
+	dupTokenRe = regexp.MustCompile(`[^a-z]+`)
+)
+
+// findingTokens reduces a finding title to the set of words that carry its
+// subject, for near-duplicate comparison.
+//
+// Digits disappear with every other non-letter, which is deliberate: the titles
+// that motivated this differ almost entirely in their numbers ("19 consecutive
+// failures", "2,943 runs", "100%") — exactly the parts that change on every
+// re-report of one problem and must not make those reports look distinct.
+func findingTokens(title string) map[string]bool {
+	t := dupBacktickRe.ReplaceAllString(title, " ")
+	t = dupMDLinkRe.ReplaceAllString(t, " ")
+	t = strings.ToLower(t)
+	tokens := make(map[string]bool)
+	for _, w := range dupTokenRe.Split(t, -1) {
+		// Two-letter words are dropped with the stop words: they are almost all
+		// noise here ("pr", "yml" survives at three) and short tokens inflate
+		// similarity between unrelated titles.
+		if len(w) <= 2 || duplicateStopWords[w] {
+			continue
+		}
+		tokens[w] = true
+	}
+	return tokens
+}
+
+// jaccard returns |a∩b| / |a∪b| for two token sets; 0 when either is empty.
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for w := range a {
+		if b[w] {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// collapseNearDuplicates merges findings that restate the same problem,
+// returning one representative per group in the input's original order.
+//
+// Two findings are merged only when they share an agent AND a finding type AND
+// their titles reach nearDuplicateThreshold similarity. Requiring agent+type to
+// match is the cheap structural guard: a scanner security finding can never be
+// absorbed into a ci-maintainer CI failure however the words line up.
+//
+// The representative keeps the HIGHEST severity in its group, so a critical
+// report is never hidden behind a medium-severity restatement of itself, and
+// carries DuplicateCount so the recurrence stays visible.
+func collapseNearDuplicates(findings []Finding) []Finding {
+	if len(findings) < 2 {
+		return findings
+	}
+	kept := make([]Finding, 0, len(findings))
+	keptTokens := make([]map[string]bool, 0, len(findings))
+
+	for _, f := range findings {
+		tokens := findingTokens(f.Title)
+		merged := false
+		for i := range kept {
+			if kept[i].Agent != f.Agent || kept[i].Type != f.Type {
+				continue
+			}
+			if jaccard(tokens, keptTokens[i]) < nearDuplicateThreshold {
+				continue
+			}
+			kept[i].DuplicateCount++
+			if severityRank(f.Severity) > severityRank(kept[i].Severity) {
+				kept[i].Severity = f.Severity
+			}
+			merged = true
+			break
+		}
+		if !merged {
+			kept = append(kept, f)
+			keptTokens = append(keptTokens, tokens)
+		}
+	}
+	return kept
+}
+
+// severityRank orders severities so the most serious wins a merge. Unknown and
+// empty severities rank lowest, so they can never displace a real one.
+func severityRank(sev string) int {
+	switch sev {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
 
 // BuildDigestFromBeads creates a digest by reading open advisory beads from all
 // agent bead stores. Only advisory/bug/feature beads are included — task and
@@ -233,6 +397,14 @@ func BuildDigestFromBeads(stores map[string]*beads.Store, mode string) *Digest {
 			byAgent[agentName] = append(byAgent[agentName], f)
 			total++
 		}
+	}
+	// Collapse near-duplicate findings per agent (#2364). Done after the whole
+	// store is read so every restatement is in hand, and the total recomputed
+	// from the survivors so the digest header matches the rendered list.
+	total = 0
+	for agent, fs := range byAgent {
+		byAgent[agent] = collapseNearDuplicates(fs)
+		total += len(byAgent[agent])
 	}
 	sort.Slice(resolved, func(i, j int) bool {
 		return resolved[i].ClosedAt.After(resolved[j].ClosedAt)
@@ -533,7 +705,14 @@ func FormatDigestMarkdown(d *Digest, org, primaryRepo string) string {
 			}
 			title := logscrub.ScrubString(f.Title)
 			detail := logscrub.ScrubString(f.Detail)
-			b.WriteString(fmt.Sprintf("- **[%s]** %s%s _%s_\n", f.Type, linkifyRefs(title, org), loc, f.Agent))
+			// A collapsed group keeps its recurrence visible: "reported 29×"
+			// tells the reader this is persistent, which the 29 separate
+			// entries it replaces conveyed only by being exhausting to read.
+			repeat := ""
+			if f.DuplicateCount > 0 {
+				repeat = fmt.Sprintf(" _(reported %d×)_", f.DuplicateCount+1)
+			}
+			b.WriteString(fmt.Sprintf("- **[%s]** %s%s%s _%s_\n", f.Type, linkifyRefs(title, org), loc, repeat, f.Agent))
 			if detail != "" {
 				b.WriteString(fmt.Sprintf("  > %s\n", linkifyRefs(detail, org)))
 			}

--- a/v2/pkg/advisory/dedup_test.go
+++ b/v2/pkg/advisory/dedup_test.go
@@ -1,0 +1,386 @@
+package advisory
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// titles renders a finding slice for failure messages, so a bad collapse shows
+// WHAT survived rather than just a count.
+func titles(fs []Finding) string {
+	var b strings.Builder
+	for _, f := range fs {
+		b.WriteString("  - " + f.Title + "\n")
+	}
+	return b.String()
+}
+
+// Near-duplicate collapse (#2364).
+//
+// The advisory issue is a living document that agents append to every cycle.
+// Exact-title dedup does not hold, because an agent re-reporting a persistent
+// problem rewords the title each time — so the digest accumulates one entry per
+// report rather than one per problem. The live digest that motivated this had
+// 92 findings of which 29 were one already-fixed CI workflow.
+//
+// The risk in fixing it is over-collapse: merging two findings that describe
+// DIFFERENT problems hides a real defect, which is strictly worse than showing
+// a duplicate. Most of these tests exist to hold that line.
+
+func TestCollapseNearDuplicates_MergesRewordedRestatements(t *testing.T) {
+	// Verbatim titles from the pinned digest of #2364 — the same broken
+	// workflow reported five ways.
+	findings := []Finding{
+		{Agent: "ci-maintainer", Type: "ci-failure", Severity: "high",
+			Title: "pr-verifier.yml failing on every PR — reusable workflow deleted from infra"},
+		{Agent: "ci-maintainer", Type: "ci-failure", Severity: "high",
+			Title: "pr-verifier.yml broken: reusable workflow missing from kubestellar/infra"},
+		{Agent: "ci-maintainer", Type: "ci-failure", Severity: "high",
+			Title: "pr-verifier.yml failing 100% — reusable workflow missing from kubestellar/infra"},
+		{Agent: "ci-maintainer", Type: "ci-failure", Severity: "high",
+			Title: "PR Verifier failing on all PRs — reusable-pr-verifier.yml deleted from kubestellar/infra"},
+		{Agent: "ci-maintainer", Type: "ci-failure", Severity: "high",
+			Title: "pr-verifier.yml: 100% failure rate — reusable workflow missing from kubestellar/infra"},
+	}
+
+	got := collapseNearDuplicates(findings)
+	if len(got) != 1 {
+		t.Fatalf("collapsed to %d findings, want 1:\n%s", len(got), titles(got))
+	}
+	if got[0].DuplicateCount != 4 {
+		t.Errorf("DuplicateCount = %d, want 4 (5 reports, 1 representative)", got[0].DuplicateCount)
+	}
+}
+
+// The tokenizer must see an org-qualified name and its bare form as the same
+// subject. Before sub-word splitting, "kubestellar/infra" and "infra" shared no
+// token and these two reports of one problem did not merge.
+func TestFindingTokens_SplitsQualifiedNames(t *testing.T) {
+	tokens := findingTokens("reusable workflow missing from kubestellar/infra")
+	for _, want := range []string{"kubestellar", "infra", "reusable", "workflow"} {
+		if !tokens[want] {
+			t.Errorf("token %q missing from %v", want, keys(tokens))
+		}
+	}
+	if tokens["kubestellar/infra"] {
+		t.Error("qualified name was kept whole; it must split into its parts")
+	}
+}
+
+// Numbers change on every re-report of the same problem and must not keep two
+// reports apart.
+func TestFindingTokens_DropsDigits(t *testing.T) {
+	a := findingTokens("pr-verifier failing 100% — 2,943 runs")
+	b := findingTokens("pr-verifier failing 19% — 47 runs")
+	if jaccard(a, b) != 1.0 {
+		t.Errorf("titles differing only in numbers scored %.2f, want 1.00\n a=%v\n b=%v",
+			jaccard(a, b), keys(a), keys(b))
+	}
+}
+
+// A merge must never cross agents or finding types. That structural guard is
+// what stops a security finding being absorbed into a CI failure because their
+// wording happened to overlap.
+func TestCollapseNearDuplicates_NeverMergesAcrossAgentOrType(t *testing.T) {
+	base := "database connection pool exhausted under load"
+	findings := []Finding{
+		{Agent: "scanner", Type: "security", Severity: "critical", Title: base},
+		{Agent: "quality", Type: "security", Severity: "critical", Title: base},
+		{Agent: "scanner", Type: "coverage-gap", Severity: "critical", Title: base},
+	}
+
+	got := collapseNearDuplicates(findings)
+	if len(got) != 3 {
+		t.Errorf("identical titles across agent/type collapsed to %d, want 3 kept:\n%s",
+			len(got), titles(got))
+	}
+}
+
+// The representative must carry the highest severity in its group. Keeping a
+// medium representative would demote a critical report into a lower section of
+// the digest, which is a quieter way of hiding it.
+func TestCollapseNearDuplicates_KeepsHighestSeverity(t *testing.T) {
+	// Deliberately a clear restatement pair: this test is about which severity
+	// survives a merge, so the titles must be similar enough that the merge is
+	// not itself in question.
+	findings := []Finding{
+		{Agent: "quality", Type: "coverage-gap", Severity: "medium",
+			Title: "oauth.go session cookie minting has no test coverage"},
+		{Agent: "quality", Type: "coverage-gap", Severity: "critical",
+			Title: "oauth.go session cookie minting has zero test coverage"},
+	}
+
+	got := collapseNearDuplicates(findings)
+	if len(got) != 1 {
+		t.Fatalf("collapsed to %d, want 1:\n%s", len(got), titles(got))
+	}
+	if got[0].Severity != "critical" {
+		t.Errorf("severity = %q, want critical — the more severe report must win the merge", got[0].Severity)
+	}
+}
+
+// Distinct problems that merely share vocabulary must survive. These pairs are
+// drawn from the same live digest and are genuinely different findings.
+func TestCollapseNearDuplicates_KeepsDistinctFindings(t *testing.T) {
+	cases := []struct{ name, a, b string }{
+		{
+			name: "different files, same finding type",
+			a:    "saas_provision.go: 101 uncovered stmts in hive provisioning mutation paths",
+			b:    "heartbeat.go (1658 lines, 28 functions) has zero dedicated unit tests",
+		},
+		{
+			name: "summary vs specific test regression",
+			a:    "v2 Tests: 9 consecutive failures all day 2026-08-06, regression on commit 1d89011",
+			b:    "TestAlertAcksPersistRoundTrip regression in pkg/hub — 2 consecutive failures",
+		},
+		{
+			name: "different workflows",
+			a:    "pr-verifier.yml failing on every PR — reusable workflow deleted from infra",
+			b:    "Coverage Hourly 'Check per-package coverage' failing on PR branch",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collapseNearDuplicates([]Finding{
+				{Agent: "a", Type: "t", Severity: "high", Title: tc.a},
+				{Agent: "a", Type: "t", Severity: "high", Title: tc.b},
+			})
+			if len(got) != 2 {
+				t.Errorf("distinct findings were merged (kept %d, want 2):\n  %q\n  %q", len(got), tc.a, tc.b)
+			}
+		})
+	}
+}
+
+func TestCollapseNearDuplicates_PreservesOrderAndShortInputs(t *testing.T) {
+	if got := collapseNearDuplicates(nil); got != nil {
+		t.Errorf("nil input returned %v, want nil", got)
+	}
+	one := []Finding{{Agent: "a", Type: "t", Title: "only one"}}
+	if got := collapseNearDuplicates(one); len(got) != 1 {
+		t.Errorf("single finding collapsed to %d", len(got))
+	}
+
+	// Order is the digest's reading order; collapsing must not shuffle it.
+	in := []Finding{
+		{Agent: "a", Type: "t", Title: "alpha subject one"},
+		{Agent: "a", Type: "t", Title: "beta subject two"},
+		{Agent: "a", Type: "t", Title: "gamma subject three"},
+	}
+	got := collapseNearDuplicates(in)
+	if len(got) != 3 {
+		t.Fatalf("kept %d, want 3", len(got))
+	}
+	for i := range in {
+		if got[i].Title != in[i].Title {
+			t.Errorf("position %d = %q, want %q — order changed", i, got[i].Title, in[i].Title)
+		}
+	}
+}
+
+// --- the real corpus --------------------------------------------------------
+
+type liveFinding struct {
+	Agent    string `json:"agent"`
+	Type     string `json:"type"`
+	Severity string `json:"severity"`
+	Title    string `json:"title"`
+}
+
+func loadLiveDigest(t *testing.T) []Finding {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/live_digest_2364.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var rows []liveFinding
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	out := make([]Finding, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, Finding{Agent: r.Agent, Type: r.Type, Severity: r.Severity, Title: r.Title})
+	}
+	return out
+}
+
+// End-to-end against the actual findings from the pinned comment of #2364.
+// This is the case the change exists for, so it is measured, not assumed.
+func TestCollapseNearDuplicates_LiveDigestCorpus(t *testing.T) {
+	findings := loadLiveDigest(t)
+	if len(findings) != 92 {
+		t.Fatalf("fixture has %d findings, expected the captured 92", len(findings))
+	}
+
+	byAgent := map[string][]Finding{}
+	for _, f := range findings {
+		byAgent[f.Agent] = append(byAgent[f.Agent], f)
+	}
+	kept := 0
+	var kase []Finding
+	for _, fs := range byAgent {
+		c := collapseNearDuplicates(fs)
+		kept += len(c)
+		kase = append(kase, c...)
+	}
+
+	if kept >= len(findings) {
+		t.Fatalf("collapse removed nothing: %d -> %d", len(findings), kept)
+	}
+	// Measured at 92 -> 60 when written. Assert a floor rather than the exact
+	// number so wording drift in the fixture does not make this brittle, but
+	// keep it tight enough that a regression to no-op dedup fails.
+	if reduction := len(findings) - kept; reduction < 30 {
+		t.Errorf("collapsed only %d of %d findings; expected >=25 given 29 pr-verifier restatements",
+			reduction, len(findings))
+	}
+
+	// The pr-verifier cluster is the specific thing that made the digest
+	// unreadable: 29 reports of one problem. It must end up as a handful.
+	prv := 0
+	for _, f := range kase {
+		if strings.Contains(strings.ToLower(f.Title), "pr-verifier") ||
+			strings.Contains(strings.ToLower(f.Title), "pr verifier") {
+			prv++
+		}
+	}
+	if prv > 6 {
+		t.Errorf("pr-verifier findings still %d after collapse (was 29); expected <=6", prv)
+	}
+	if prv == 0 {
+		t.Error("pr-verifier findings vanished entirely — the problem must still be reported once")
+	}
+}
+
+// The safety property, measured on the real corpus: no merge may join findings
+// about different subjects. This is what fixes the threshold at 0.5 — merges
+// across subjects first appear at 0.35.
+func TestCollapseNearDuplicates_NoCrossSubjectMergeOnLiveCorpus(t *testing.T) {
+	subject := func(title string) string {
+		tl := strings.ToLower(title)
+		for _, s := range []string{"pr-verifier", "pr verifier", "coverage hourly", "v2 tests", "v2 ci"} {
+			if strings.Contains(tl, s) {
+				if s == "pr verifier" {
+					return "pr-verifier"
+				}
+				return s
+			}
+		}
+		return ""
+	}
+
+	findings := loadLiveDigest(t)
+	byAgent := map[string][]Finding{}
+	for _, f := range findings {
+		byAgent[f.Agent] = append(byAgent[f.Agent], f)
+	}
+
+	for _, fs := range byAgent {
+		// Re-run the matching loop so each merge decision can be inspected.
+		var kept []Finding
+		var keptTokens []map[string]bool
+		for _, f := range fs {
+			tokens := findingTokens(f.Title)
+			for i := range kept {
+				if kept[i].Agent != f.Agent || kept[i].Type != f.Type {
+					continue
+				}
+				if jaccard(tokens, keptTokens[i]) < nearDuplicateThreshold {
+					continue
+				}
+				sa, sb := subject(f.Title), subject(kept[i].Title)
+				if sa != sb {
+					t.Errorf("cross-subject merge (%q vs %q):\n  %q\n  merged into %q",
+						sa, sb, f.Title, kept[i].Title)
+				}
+				goto next
+			}
+			kept = append(kept, f)
+			keptTokens = append(keptTokens, tokens)
+		next:
+		}
+	}
+}
+
+// The threshold must stay clear of the empirical over-collapse boundary. If
+// someone lowers it chasing compression, this fails before the digest starts
+// hiding findings.
+func TestNearDuplicateThreshold_HasSafetyMargin(t *testing.T) {
+	const observedOverCollapseBoundary = 0.30
+	if nearDuplicateThreshold <= observedOverCollapseBoundary {
+		t.Fatalf("threshold %.2f is at or below the measured over-collapse boundary %.2f — "+
+			"distinct findings get merged there", nearDuplicateThreshold, observedOverCollapseBoundary)
+	}
+	if margin := nearDuplicateThreshold - observedOverCollapseBoundary; margin < 0.1 {
+		t.Errorf("threshold margin %.2f is too thin; keep >=0.10 above %.2f",
+			margin, observedOverCollapseBoundary)
+	}
+}
+
+// --- rendering --------------------------------------------------------------
+
+// Collapsing must not make a recurring problem look like a one-off: the count
+// carries the "this keeps happening" signal the removed entries used to.
+func TestFormatDigestMarkdown_ShowsRepeatCount(t *testing.T) {
+	d := &Digest{
+		GeneratedAt: time.Now(),
+		TotalCount:  1,
+		ByAgent: map[string][]Finding{
+			"ci-maintainer": {{
+				Agent: "ci-maintainer", Type: "ci-failure", Severity: "high",
+				Title: "pr-verifier.yml failing on every PR", DuplicateCount: 28,
+			}},
+		},
+	}
+	out := FormatDigestMarkdown(d, "kubestellar", "hive")
+	if !strings.Contains(out, "_(reported 29×)_") {
+		t.Errorf("digest does not surface the repeat count:\n%s", out)
+	}
+}
+
+func TestFormatDigestMarkdown_NoRepeatMarkerForSingleReport(t *testing.T) {
+	d := &Digest{
+		GeneratedAt: time.Now(),
+		TotalCount:  1,
+		ByAgent: map[string][]Finding{
+			"quality": {{Agent: "quality", Type: "coverage-gap", Severity: "low", Title: "one-off finding"}},
+		},
+	}
+	out := FormatDigestMarkdown(d, "kubestellar", "hive")
+	if strings.Contains(out, "reported") {
+		t.Errorf("single-report finding was annotated with a count:\n%s", out)
+	}
+}
+
+// The header count and the rendered list must agree — a header claiming 92
+// above 60 entries is its own bug.
+func TestBuildDigest_TotalCountMatchesCollapsedFindings(t *testing.T) {
+	findings := loadLiveDigest(t)
+	d := BuildDigest(findings, "busy")
+
+	listed := 0
+	for _, fs := range d.ByAgent {
+		listed += len(fs)
+	}
+	if d.TotalCount != listed {
+		t.Errorf("TotalCount = %d but %d findings are listed", d.TotalCount, listed)
+	}
+	if d.TotalCount >= len(findings) {
+		t.Errorf("TotalCount = %d, expected fewer than the %d input findings", d.TotalCount, len(findings))
+	}
+}
+
+// keys renders a token set deterministically for failure messages.
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/v2/pkg/advisory/testdata/live_digest_2364.json
+++ b/v2/pkg/advisory/testdata/live_digest_2364.json
@@ -1,0 +1,554 @@
+[
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "critical",
+  "title": "v2 Tests: persistent test failure all day, queue backlog growing"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "critical",
+  "title": "saas_provision.go: 101 uncovered stmts (24.9% gap) in hive provisioning mutation paths"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "critical",
+  "title": "reclaimExpiredLeases missing pendingToken/credentialDelivered cleanup"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "critical",
+  "title": "noRedirectToPrivate in ssrf_guard.go has zero dedicated unit tests"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "critical",
+  "title": "hub_keys.go (252 lines, 13 funcs) had zero dedicated unit tests \u2014 crypto key derivation for auth"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "critical",
+  "title": "saas.go impersonation guard functions have zero test coverage"
+ },
+ {
+  "agent": "quality",
+  "type": "regression-risk",
+  "severity": "critical",
+  "title": "PR #3344 removes SSRF guards and deletes 869 test lines \u2014 security+coverage regression [kubestellar/hive#3344](https://github.com/kubestellar/hive/issues/3344)"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "critical",
+  "title": "Hub heartbeat.go (1658 lines, 28 functions) has zero dedicated unit tests"
+ },
+ {
+  "agent": "quality",
+  "type": "advisory",
+  "severity": "critical",
+  "title": "api_leaderboard_style.go (914 lines) untested - custom CSS sanitization"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "critical",
+  "title": "oauth.go: 14 of 23 functions have zero test coverage including security-critical auth handlers"
+ },
+ {
+  "agent": "quality",
+  "type": "regression-risk",
+  "severity": "critical",
+  "title": "heartbeatBearerOK per-hive binding removed without covering test"
+ },
+ {
+  "agent": "quality",
+  "type": "advisory",
+  "severity": "critical",
+  "title": "Hub OAuth handlers (handleProviderLogin, writeProviderPicker) have 0% test coverage"
+ },
+ {
+  "agent": "scanner",
+  "type": "security",
+  "severity": "critical",
+  "title": "[hive#2172](https://github.com/kubestellar/hive/issues/2172): Default deployment lacks hardening\u2014RBAC, network policy, secrets management [#2172](https://github.com/kubestellar/hive/issues/2172)"
+ },
+ {
+  "agent": "scanner",
+  "type": "advisory",
+  "severity": "critical",
+  "title": "K8s deployment.yaml missing securityContext \u2014 pods run as root with full privileges [#2920](https://github.com/kubestellar/hive/issues/2920)"
+ },
+ {
+  "agent": "scanner",
+  "type": "advisory",
+  "severity": "critical",
+  "title": "Missing role defaults to owner on /api/contributors write endpoints [#2975](https://github.com/kubestellar/hive/issues/2975)"
+ },
+ {
+  "agent": "scanner",
+  "type": "advisory",
+  "severity": "critical",
+  "title": "Unauthenticated /api/auth/token leaks dashboard auth token [#2997](https://github.com/kubestellar/hive/issues/2997)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on every PR \u2014 reusable workflow deleted from infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml broken: reusable workflow missing from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing 100% \u2014 reusable workflow missing from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier failing on all PRs \u2014 reusable-pr-verifier.yml deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml 100% failing \u2014 reusable-pr-verifier.yml deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier failing 100% \u2014 reusable-pr-verifier.yml missing from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR \u2014 missing reusable workflow in kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing: references deleted reusable workflow in kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml: 100% failure rate \u2014 reusable workflow missing from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on 100% of PRs \u2014 reusable workflow deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR: reusable workflow missing from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "flaky-test",
+  "severity": "high",
+  "title": "v2-tests 'Test' step failing at high rate on v2 branch"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "coverage-drop",
+  "severity": "high",
+  "title": "Coverage Hourly 'Check per-package coverage' failing on PR branch"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on all PRs: reusable workflow missing from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR \u2014 reusable workflow deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on all PRs: reusable workflow deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on every PR \u2014 reusable workflow missing"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on every PR: reusable workflow deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier broken: calls deleted reusable workflow in kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier failing on all PRs: reusable workflow deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR: reusable-pr-verifier.yml deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR: reusable workflow deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "flaky-test",
+  "severity": "high",
+  "title": "Coverage Hourly: 57% failure rate on v2 branch (612/1075 runs)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on every PR: missing reusable workflow in kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 Tests scheduled run failed: pkg/dashboard tests cannot write /data/hive.yaml.runtime"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier workflow failing on every PR: missing reusable workflow in kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing persistently on every PR (37+ failures today)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 Tests scheduled run failing \u2014 Test step failed"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "coverage-drop",
+  "severity": "high",
+  "title": "Coverage Hourly: per-package coverage check failed"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 CI docker build step failed on push to v2"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on every PR (100% failure rate)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing on all PRs: reusable workflow missing in kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml consistently failing: reusable workflow missing from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier failing on every PR \u2014 deleted reusable workflow"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR: deleted reusable workflow"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR \u2014 reusable workflow deleted upstream"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "flaky-test",
+  "severity": "high",
+  "title": "Data race in pkg/dashboard SSE tests (TestSSEStreamsAppendedActivity, TestSSEHelloReplaysRecentActivity)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pkg/agent TestBuildProjectPreamble_FormatContainsOrgAndRepos fails \u2014 should contain level name"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier failing 100% on all PRs \u2014 reusable workflow missing"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on every PR \u2014 missing reusable workflow"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "TestAlertAcksPersistRoundTrip regression in pkg/hub \u2014 2 consecutive failures"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "TestIntegration_SelectTask_PromotionRequiresPR failing in pkg/dashboard"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier failing on all PRs \u2014 reusable workflow missing in kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml failing 100% \u2014 reusable workflow deleted from kubestellar/infra (run #3279)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails 100% \u2014 reusable workflow deleted from kubestellar/infra"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "flaky-test",
+  "severity": "high",
+  "title": "v2 Tests recurring failures \u2014 35% failure rate (7/20 scheduled runs)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "flaky-test",
+  "severity": "high",
+  "title": "v2 Tests: second consecutive failure on c07557d (assign/approve fix) \u2014 pattern escalating"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 Tests: 100% failure rate \u2014 8 consecutive scheduled-run failures on v2 (1d89011)"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 Tests: 9 consecutive failures all day 2026-08-06, regression on commit 1d89011"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 Tests: 15 consecutive scheduled failures Aug 6 \u2014 100% failure all day"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "ARM64 docker runners failing to provision \u2014 ubuntu-24.04-arm 'Set up job' failure"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier: all PRs fail \u2014 calls deleted reusable workflow"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 Tests: 22+ consecutive failures on v2 branch since 2026-08-06T01:11Z"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "pr-verifier.yml fails on all PRs: kubestellar/infra reusable-pr-verifier.yml@main deleted"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "v2 Tests failing: TestHeartbeatDeliversClaimWhileVanityRepairBlocked in pkg/hub"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "coverage-drop",
+  "severity": "high",
+  "title": "Coverage gate failing: agent package at 88.0%, floor is 89%"
+ },
+ {
+  "agent": "ci-maintainer",
+  "type": "ci-failure",
+  "severity": "high",
+  "title": "PR Verifier failing on all PRs: upstream reusable workflow deleted"
+ },
+ {
+  "agent": "guide",
+  "type": "advisory",
+  "severity": "high",
+  "title": "Nous/Strategy Lab has no dedicated operator guide \u2014 README pointer to hive.yaml.example is broken"
+ },
+ {
+  "agent": "guide",
+  "type": "advisory",
+  "severity": "high",
+  "title": "Inception/Brainstorm workflow has no operator guide \u2014 14 API endpoints with no usage documentation"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "webhook.go: pushGitHubConfigToSpoke retry/error paths (17 stmts) untested \u2014 silent fleet key delivery failures"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "cluster_app_key.go: clusterAPIURLForIdentity/clusterBaseURLForIdentity (0%) \u2014 forge fallback path of identity guard untested"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "saas_provision.go: addVanityHostToIngress (25.4%) \u2014 K8s Route/Ingress patch paths almost entirely untested"
+ },
+ {
+  "agent": "quality",
+  "type": "regression-risk",
+  "severity": "high",
+  "title": "[PR#2431](https://github.com/kubestellar/PR/issues/2431): deleteSavedView uses await without async declaration \u2014 runtime error"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "TestAwaitHiveModalInAsyncFunction guard catches await in non-async functions"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "self_upgrade.go at 60.6% coverage \u2014 critical fleet upgrade logic undertested"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "maybeRefreshToken integration path untested \u2014 token refresh during long-running tasks"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "Provenance struct had zero dedicated test coverage (472-line file)"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "Invite token verification unit tests missing"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "TestNoNativeBrowserModals and await/async consistency guard"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "Cross-PR integration gap: reclaimExpiredLeases missing pendingToken cleanup"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "drift.go pure functions (driftEligibleForNorm, imageRefIsPinned, healthStatusOf, parseRFC3339) have zero unit tests"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "saas_provision.go (2542 lines) has 16 untested exported functions including reconcileGitHubHostFromSpoke"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "Hub server utility functions (firstCSV, normalizeRepoRef, sanitize*) lacked dedicated unit tests"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "hub/server.go heartbeat sanitization functions lacked dedicated tests"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "heartbeatBearerOK and handler endpoints had zero test coverage"
+ },
+ {
+  "agent": "quality",
+  "type": "coverage-gap",
+  "severity": "high",
+  "title": "sanitizePublicURLSelfCheck and sanitizeRouteExistenceCheck had zero test coverage"
+ }
+]


### PR DESCRIPTION
## What

#2364 is the pinned 🐝 Advisory Report — a living document agents append to every cycle. It has become hard to read: **317 findings**, and a large share of them are the same problems restated.

This fixes the mechanism that lets that happen. Measured on the digest comment as of 2026-08-14: **92 findings → 56**, with the largest pile collapsing into a single entry marked `(reported 32×)`.

Refs #2364 — no `Fixes`. The issue is explicitly a living document ("**Do not close this issue.**"), so it stays open; this improves what gets posted into it.

## The bug

`BuildDigestFromBeads` deduplicates on **exact title match**:

```go
if seen[b.Title] { continue }
seen[b.Title] = true
```

Agents re-report persistent problems every cycle and **reword the title each time**. Exact matching catches none of it, so the digest accumulates one entry per *report* rather than one per *problem*.

In the live digest, one already-fixed CI workflow appeared **32 times** under 32 different titles:

```
pr-verifier.yml failing on every PR — reusable workflow deleted from infra
pr-verifier.yml broken: reusable workflow missing from kubestellar/infra
pr-verifier.yml failing 100% — reusable workflow missing from kubestellar/infra
PR Verifier failing on all PRs — reusable-pr-verifier.yml deleted from kubestellar/infra
pr-verifier.yml: 100% failure rate — reusable workflow missing from kubestellar/infra
… 27 more
```

That is **35% of the digest** describing a single problem — and, as it happens, one that no longer exists: `.github/workflows/pr-verifier.yml` no longer calls the deleted reusable workflow, it runs a pinned `ghcr.io/kubestellar/pr-verifier` image. So a third of the report is noise about something already fixed, crowding out findings that are not.

## The fix

`collapseNearDuplicates` merges findings that share an **agent** AND a **finding type** AND reach **0.5 Jaccard similarity** on their title tokens.

The agent+type match is a cheap structural guard: a `scanner` security finding can never be absorbed into a `ci-maintainer` CI failure however the words line up.

### Threshold: chosen by measurement, not taste

I swept the real corpus and looked at what each threshold actually merges. Merges of genuinely **different** subjects last appear at **0.30**; 0.35 and above produce none.

| threshold | 92 findings → | cross-subject merges |
|---:|---:|---:|
| 0.25 | 45 | 2 ❌ |
| 0.30 | 46 | 1 ❌ |
| 0.35 | 49 | 0 |
| 0.40 | 53 | 0 |
| **0.50** | **56** | **0** |

0.5 keeps a **0.20 margin** over the observed boundary. The asymmetry is deliberate and is the main design decision here: a duplicate wastes a reader's attention, a wrong merge **hides a real defect**. So it is tuned for safety, not for maximum compression — 0.35 would compress more and I did not take it.

`TestNearDuplicateThreshold_HasSafetyMargin` fails if someone later lowers it chasing compression.

### Tokenizer: sub-word splitting measured strictly better

Tokens split on **every non-letter**, so `kubestellar/infra` → `{kubestellar, infra}` and digits vanish.

Both matter. Keeping path tokens whole meant `"…missing from kubestellar/infra"` and `"…deleted from infra"` shared **no token for the thing they are both about**, and failed to merge. And digits are exactly the part that changes on every re-report (`2,943 runs`, `100%`, `19 consecutive failures`) — keeping them makes reports of one problem look distinct.

Measured both ways on the corpus; sub-word splitting was better on **both** axes at every threshold:

| tokenizer | @0.50 | pr-verifier clusters | cross-subject merges @0.35 |
|---|---:|---:|---:|
| whole path tokens | 92 → 60 | 7 | 1 ❌ |
| **sub-word split** | **92 → 56** | **4** | **0** |

### Nothing is silently dropped

Two properties keep collapse from becoming concealment:

- **The representative keeps the highest severity in its group.** Otherwise a critical report could be merged into a medium restatement of itself and quietly demoted into a lower section of the digest.
- **The count is rendered**: `(reported 32×)`. A recurring problem still reads as recurring — arguably *better* than before, where recurrence was conveyed only by being exhausting to scroll past.

`TotalCount` is recomputed from the survivors in both builders, so the header count matches the list beneath it.

## Result on the real digest

```
live digest of #2364: 92 findings -> 56 after collapse (39% removed)
  reported 32×  [ci-maintainer] pr-verifier.yml failing on every PR — reusable workflow deleted from infra
```

## Tests

`v2/pkg/advisory/dedup_test.go`, plus `testdata/live_digest_2364.json` — the **actual 92 findings** parsed out of the pinned comment, so the corpus tests measure the real case rather than a fixture I invented.

Unit: reworded restatements merge; never across agent/type; highest severity wins; order preserved; nil/single-element inputs; tokenizer splits qualified names and drops digits.

Corpus: end-to-end reduction; the pr-verifier pile shrinks but **does not vanish** (the problem must still be reported once); and `TestCollapseNearDuplicates_NoCrossSubjectMergeOnLiveCorpus` re-runs the matching loop to inspect every individual merge decision against the real data.

Rendering: repeat marker appears for collapsed groups, absent for single reports, and `TotalCount` matches what is listed.

### Regression replay

Each change neutered, the specific test confirmed failing, then restored green.

**1. Collapse disabled (back to exact-title dedup):**
```
--- FAIL: TestCollapseNearDuplicates_MergesRewordedRestatements
      (all 5 pr-verifier restatements survive)
--- FAIL: TestCollapseNearDuplicates_LiveDigestCorpus
--- FAIL: TestBuildDigest_TotalCountMatchesCollapsedFindings
```

**2. Threshold lowered to 0.25 — the over-collapse this guards against, reproduced on real data:**
```
--- FAIL: TestCollapseNearDuplicates_KeepsDistinctFindings
    distinct findings were merged (kept 1, want 2):
      "v2 Tests: 9 consecutive failures all day 2026-08-06, regression on commit 1d89011"
      "TestAlertAcksPersistRoundTrip regression in pkg/hub — 2 consecutive failures"
--- FAIL: TestCollapseNearDuplicates_NoCrossSubjectMergeOnLiveCorpus
--- FAIL: TestNearDuplicateThreshold_HasSafetyMargin
```

**3. agent/type guard removed:**
```
--- FAIL: TestCollapseNearDuplicates_NeverMergesAcrossAgentOrType
--- FAIL: TestBuildDigest
```

**4. Severity not upgraded on merge:**
```
--- FAIL: TestCollapseNearDuplicates_KeepsHighestSeverity
```

### Local verification

```
go build ./...            clean
gofmt -l pkg/advisory     clean
go vet ./pkg/advisory     clean
go test ./pkg/advisory/   ok
go test ./pkg/beads/      ok
go test ./pkg/github/     ok  (41.9s — owns the digest posting path)
```

## A note on the findings themselves

While picking a target I verified several of the digest's **critical** findings against `origin/v4`, and the top ones are stale:

- *"pr-verifier.yml calls a deleted reusable workflow"* (×32) — fixed; it uses a pinned GHCR image.
- *"`noRedirectToPrivate` has zero dedicated unit tests"* — it has 7, in `ssrf_guard_test.go`.
- *"`stripAuthOnCrossHostRedirect` untested"* — I gutted the function to check; `TestF13_RedirectDropsAuthorizationCrossHost` fails, so it is genuinely covered.

That is the same disease as the duplicates: the digest reports what agents *found*, with no aging. This PR fixes the volume half, not the staleness half. A follow-up worth considering is expiring findings whose subject no longer reproduces — the existing `VerifyFindingPaths` does this for file paths (`_(file path not found at analyzed commit)_`), but a finding about a *workflow's contents* passes that check while being entirely obsolete.

## Compatibility

Additive. `Finding.DuplicateCount` is `omitempty`, so persisted digests are unchanged for single-report findings. Digests with no near-duplicates render byte-identically; `collapseNearDuplicates` returns its input untouched for fewer than two findings.
