### PR TITLE
✨ feature(contribute): record and surface why a contributor task failed (DECLARE, not ROUTE)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -480,7 +480,9 @@ function runHeadlessTask(task) {
     const reason = `backend '${BACKEND}' has no headless (non-interactive) mode; supported: ${Object.keys(HEADLESS_BACKENDS).join(', ')}`;
     console.error(`Headless dispatch refused: ${reason}`);
     writeHeadlessStatus(HEADLESS_STATE_FAILED, { task_id: task.task_id, reason });
-    failCurrentTask(reason, { permanent: true });
+    // environment: this relay's configured backend has no headless entry point;
+    // the work item itself is unjudged.
+    failCurrentTask(reason, { permanent: true, kind: 'environment' });
     return;
   }
 
@@ -746,7 +748,8 @@ function armCLIReadyWait() {
     // contributor silently working on someone else's issue.
     pendingTask = null;
     if (currentTask) {
-      failCurrentTask(`CLI never became ready: ${e.message}`, { skipReady: true });
+      // environment: the agent CLI never reached its prompt on this host.
+      failCurrentTask(`CLI never became ready: ${e.message}`, { skipReady: true, kind: 'environment' });
     }
     // Keep waiting. The CLI may still come up (a slow login, an operator
     // attaching to clear a prompt we don't recognize), and when it does the
@@ -1178,14 +1181,26 @@ function restartBackoffMs(attempt) {
   return Math.min(TASK_RESTART_BASE_BACKOFF_MS * Math.pow(2, attempt - 1), TASK_RESTART_MAX_BACKOFF_MS);
 }
 
+// failCurrentTask reports the active task as failed.
+//
+// opts.kind (kubestellar/hive#2547) optionally states WHY: 'environment' when
+// this client's own runtime could not run the work (the CLI never started, it
+// crashed, the backend has no headless mode) versus 'task' when the work was
+// attempted and failed on its merits. Omit it when the cause is genuinely
+// ambiguous — the hub normalizes absent to 'unspecified', and guessing would be
+// worse than saying nothing, since an operator reads this to attribute failures.
+//
+// It is advisory: the hub records and displays it and does not route, gate, or
+// change the work item's failure cooldown on it. Older hubs ignore the field.
 function failCurrentTask(reason, opts) {
   if (!currentTask) return;
   const permanent = !!(opts && opts.permanent);
+  const kind = (opts && opts.kind) || undefined;
   const taskId = currentTask.task_id;
   const taskGen = currentTask.task_gen;
   const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
-  console.error(`Task ${taskId} failed${permanent ? ' permanently' : ''}: ${reason}`);
-  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, task_gen: taskGen, reason, permanent, tmux_output: tmuxLines });
+  console.error(`Task ${taskId} failed${permanent ? ' permanently' : ''}${kind ? ` [${kind}]` : ''}: ${reason}`);
+  send({ type: 'task_failed', seq: nextSeq(), task_id: taskId, task_gen: taskGen, reason, permanent, failure_kind: kind, tmux_output: tmuxLines });
   currentTask = null;
   taskAssignedAt = 0;
   if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
@@ -1268,7 +1283,8 @@ function progressTick() {
       } catch (e) {
         console.error('Failed to restart CLI:', e.message);
       }
-      failCurrentTask('CLI process exited — restarted');
+      // environment: the agent CLI process died; nothing was judged about the work.
+      failCurrentTask('CLI process exited — restarted', { kind: 'environment' });
       return;
     }
   } catch (_) {}

--- a/v2/docs/contributor-relay.md
+++ b/v2/docs/contributor-relay.md
@@ -101,3 +101,21 @@ This is **display-only and untrusted**: the hub never routes, gates, or trusts w
 **How each fact is obtained.** All of it is probed once at relay startup, before the first hub connection, and cached for the life of the process — nothing here runs during the handshake. The container runtime is a `command -v docker || command -v podman` presence check. The agent CLI version comes from running the resolved backend binary with `--version` (the same binary `backends.conf` maps your `AGENT_BACKEND` to, so `litellm` reports the `claude` CLI's version), with stdin closed and a short timeout. Every probe is best-effort: if the binary is missing, the flag is unsupported, or the call times out, that one field is simply **omitted**, which reads as unknown. Declaring nothing is always a valid answer and never costs you work.
 
 **Both sides bound it.** The relay reduces a CLI's output to one short printable line — CLIs append update nudges and colour escapes — and the hub independently truncates every declared field to 64 characters and strips control characters when it stores them. A declaration is unverified client text, so the hub does not rely on the client having limited it. Sanitizing never rejects: an over-long or messy declaration still authenticates and still receives work, it just cannot spill past its field on the Operations row.
+
+### Failure attribution
+
+The same DECLARE rule applies to failures. A `task_failed` may carry an optional `failure_kind`:
+
+| `failure_kind` | Meaning |
+|---|---|
+| `environment` | This client's own runtime could not run the work — the agent CLI never started or crashed, the backend has no headless mode. The work item itself is unjudged. |
+| `task` | The work was attempted and failed on its merits. |
+| *(absent)* | Normalized to `unspecified`. This is what every relay written before protocol 1.2 sends, and it is treated exactly as it is today. |
+
+The hub records the reason and kind on the connection and shows the most recent one on the Operations tab, so an operator can tell "this client cannot run the work" from "the agent got the work wrong" instead of inferring it from a tmux tail.
+
+The shipped relay declares `environment` only where the cause is unambiguous (CLI never became ready, CLI process died, backend has no headless mode) and omits the field everywhere else — an honest `unspecified` is better than a guess, because operators read this to attribute failures.
+
+**It changes nothing about dispatch.** The kind is self-reported, so acting on it would be routing on a value the client controls: a relay could keep an issue permanently hot by tagging every failure `environment`. The work item's failure cooldown and quarantine weight (#2435) are computed exactly as before, from the repo, number and `permanent` flag alone — never from the declared kind. That separation is pinned by tests (`TestSelectionPathsDoNotReadFailureKind`, `TestRecordTaskFailure_IgnoresFailureKind`).
+
+Whether the hub should ever *act* on client declarations — the ROUTE half of [#2547](https://github.com/kubestellar/hive/issues/2547) — remains an open maintainer decision, and needs task-side requirements metadata that does not exist yet.

--- a/v2/pkg/dashboard/contribute_failure_kind_test.go
+++ b/v2/pkg/dashboard/contribute_failure_kind_test.go
@@ -1,0 +1,277 @@
+package dashboard
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Task-failure attribution (#2547).
+//
+// The issue's operational complaint: "a task that failed because the client
+// couldn't run it and a task that failed because the agent got it wrong are,
+// from the hub's side, the same event with different terminal scrollback." The
+// hub logged task_failed's reason and dropped it, so an operator had backend,
+// model, role and a tmux tail and had to infer the rest.
+//
+// This records the reason and an OPTIONAL self-declared kind, and surfaces both
+// read-only. It is the DECLARE half applied to failures. The tests below exist
+// mostly to hold the ROUTE line: nothing may act on the kind, and no relay that
+// omits it may behave differently than it does today.
+
+func TestNormalizeTaskFailureKind(t *testing.T) {
+	known := map[string]string{
+		"environment": TaskFailureKindEnvironment,
+		"task":        TaskFailureKindTask,
+		// Case and surrounding space must not demote a real declaration to
+		// unspecified over a cosmetic difference.
+		"Environment": TaskFailureKindEnvironment,
+		"  TASK  ":    TaskFailureKindTask,
+	}
+	for in, want := range known {
+		if got := NormalizeTaskFailureKind(in); got != want {
+			t.Errorf("NormalizeTaskFailureKind(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	// Absent is the case EVERY relay written before this hits. It must land on
+	// unspecified — never on either real kind, which would be the hub inferring
+	// a cause no client stated.
+	for _, in := range []string{"", "   ", "env", "environmental", "TASK_FAILED", "hardware", "1"} {
+		if got := NormalizeTaskFailureKind(in); got != TaskFailureKindUnspecified {
+			t.Errorf("NormalizeTaskFailureKind(%q) = %q, want unspecified", in, got)
+		}
+	}
+}
+
+// An unknown kind must not be echoed back verbatim: the value is rendered to
+// operators, so preserving arbitrary client text would let a relay write free
+// text into the operator's view through a field that reads like an enum.
+func TestNormalizeTaskFailureKind_DoesNotEchoClientText(t *testing.T) {
+	hostile := "environment<script>alert(1)</script>"
+	if got := NormalizeTaskFailureKind(hostile); got != TaskFailureKindUnspecified {
+		t.Errorf("NormalizeTaskFailureKind(%q) = %q — unknown kinds must collapse, not pass through", hostile, got)
+	}
+}
+
+func TestTruncateFailureReason(t *testing.T) {
+	short := "CLI never became ready: spawn podman ENOENT"
+	if got := truncateFailureReason(short); got != short {
+		t.Errorf("a short reason was altered: %q", got)
+	}
+
+	long := strings.Repeat("x", maxFailureReasonLen+50)
+	got := truncateFailureReason(long)
+	if len([]rune(got)) > maxFailureReasonLen+len([]rune("… (truncated)")) {
+		t.Errorf("truncated reason is %d runes, still unbounded", len([]rune(got)))
+	}
+	if !strings.HasSuffix(got, "… (truncated)") {
+		t.Error("truncation is not marked — an operator cannot tell a cut-off message from a terse one")
+	}
+
+	// Rune safety: cutting mid-rune would put invalid UTF-8 into a JSON response.
+	multibyte := strings.Repeat("é", maxFailureReasonLen+10)
+	if !utf8Valid(truncateFailureReason(multibyte)) {
+		t.Error("truncation produced invalid UTF-8 on multi-byte input")
+	}
+}
+
+func utf8Valid(s string) bool {
+	for _, r := range s {
+		if r == '�' {
+			return false
+		}
+	}
+	return true
+}
+
+// --- surfacing -------------------------------------------------------------
+
+func failureTestHub(t *testing.T) (*ContributeWSHub, *ContributorConnection) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	hub := &ContributeWSHub{
+		connections:    make(map[string]*ContributorConnection),
+		completedTasks: make(map[string]time.Time),
+		logger:         logger,
+	}
+	conn := &ContributorConnection{
+		profile:  &ContributorProfile{ContributorID: "cid-1", GitHubUsername: "testuser"},
+		lastPong: time.Now(),
+	}
+	hub.connections["conn-1"] = conn
+	return hub, conn
+}
+
+func TestFleetSnapshot_SurfacesLastFailure(t *testing.T) {
+	hub, conn := failureTestHub(t)
+	conn.lastFailure = &ContributorFailure{
+		TaskID: "task-1", Repo: "org/repo", Number: 42,
+		Kind: TaskFailureKindEnvironment, Reason: "CLI never became ready",
+		At: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	fleet := hub.FleetSnapshot().Clankers
+	if len(fleet) != 1 {
+		t.Fatalf("expected 1 clanker, got %d", len(fleet))
+	}
+	got := fleet[0].LastFailure
+	if got == nil {
+		t.Fatal("LastFailure not surfaced — the failure is recorded but invisible to an operator")
+	}
+	if got.Kind != TaskFailureKindEnvironment {
+		t.Errorf("Kind = %q, want environment", got.Kind)
+	}
+	if got.Repo != "org/repo" || got.Number != 42 {
+		t.Errorf("failure lost its work item: %+v", got)
+	}
+}
+
+// A connection that has never failed must not sprout an empty failure record —
+// omitempty keeps the fleet payload identical to today for healthy clankers.
+func TestFleetSnapshot_NoFailureIsNil(t *testing.T) {
+	hub, _ := failureTestHub(t)
+	fleet := hub.FleetSnapshot().Clankers
+	if len(fleet) != 1 {
+		t.Fatalf("expected 1 clanker, got %d", len(fleet))
+	}
+	if fleet[0].LastFailure != nil {
+		t.Errorf("LastFailure = %+v on a clanker that never failed, want nil", fleet[0].LastFailure)
+	}
+}
+
+// The snapshot must be a COPY: aliasing live connection state would let a
+// reader of the fleet view observe (or mutate) a connection's record.
+func TestFleetSnapshot_LastFailureIsACopy(t *testing.T) {
+	hub, conn := failureTestHub(t)
+	conn.lastFailure = &ContributorFailure{TaskID: "task-1", Kind: TaskFailureKindTask, Reason: "original"}
+
+	fleet := hub.FleetSnapshot().Clankers
+	if fleet[0].LastFailure == conn.lastFailure {
+		t.Fatal("fleet snapshot aliases the live connection's failure record")
+	}
+	fleet[0].LastFailure.Reason = "mutated"
+	if conn.lastFailure.Reason != "original" {
+		t.Error("mutating the snapshot changed live connection state")
+	}
+}
+
+// SECURITY: the reason is the only CLIENT-CONTROLLED free text on this
+// snapshot. It is an error string the relay chose, so it can carry a token it
+// happened to print, and it has no length the client is obliged to respect.
+func TestFleetSnapshot_FailureReasonRedactedAndBounded(t *testing.T) {
+	hub, conn := failureTestHub(t)
+	conn.lastFailure = &ContributorFailure{
+		TaskID: "task-1",
+		Reason: "push failed: ANTHROPIC_API_KEY='sk-hive-scanner' " + strings.Repeat("y", maxFailureReasonLen),
+	}
+
+	got := hub.FleetSnapshot().Clankers[0].LastFailure
+	if strings.Contains(got.Reason, "sk-hive-scanner") {
+		t.Errorf("secret survived into the fleet view: %q", got.Reason)
+	}
+	if len([]rune(got.Reason)) > maxFailureReasonLen+len([]rune("… (truncated)")) {
+		t.Errorf("reason is %d runes — unbounded client text reached the operator view", len([]rune(got.Reason)))
+	}
+	// And the redaction must not destroy the surrounding diagnostic.
+	if !strings.Contains(got.Reason, "push failed") {
+		t.Error("redaction removed the useful part of the reason")
+	}
+}
+
+// --- the ROUTE line --------------------------------------------------------
+
+// The source-level guard, mirroring TestSelectionPathsDoNotReadDeclaredCapabilities.
+// A behavioural test alone could pass while a routing read hid behind config
+// that is off in tests; a merge that wires failure kind into selection trips
+// this immediately.
+func TestSelectionPathsDoNotReadFailureKind(t *testing.T) {
+	raw, err := os.ReadFile("contribute_ws.go")
+	if err != nil {
+		t.Fatalf("read contribute_ws.go: %v", err)
+	}
+	src := string(raw)
+
+	// Positive control: the plumbing genuinely lives in this file, so a read
+	// inside the selection bodies would be visible to this scan.
+	if !strings.Contains(src, "lastFailure *ContributorFailure") {
+		t.Fatal("contribute_ws.go no longer stores the last failure — storage moved; re-point this test deliberately")
+	}
+
+	for _, name := range []string{"selectTask", "RequeueContributorTask"} {
+		body := selectionFuncBody(t, src, name)
+		lower := strings.ToLower(body)
+		for _, forbidden := range []string{"lastfailure", "failurekind", "failure_kind"} {
+			if strings.Contains(lower, forbidden) {
+				t.Errorf("%s references %q — ROUTE is intentionally NOT implemented "+
+					"(kubestellar/hive#2547 DECLARE/ROUTE split). Acting on a self-declared "+
+					"failure kind is routing on a client-controlled value. If routing has now "+
+					"been decided and recorded by a maintainer, update this test in that same PR.",
+					name, forbidden)
+			}
+		}
+	}
+}
+
+// The work item's failure cooldown must not depend on the client's declaration.
+// If it did, a relay could keep an issue permanently hot by tagging every
+// failure "environment" — a fleet-level symptom that presents as a hub bug.
+func TestRecordTaskFailure_IgnoresFailureKind(t *testing.T) {
+	raw, err := os.ReadFile("contribute_ws.go")
+	if err != nil {
+		t.Fatalf("read contribute_ws.go: %v", err)
+	}
+	body := selectionFuncBody(t, string(raw), "recordTaskFailure")
+	lower := strings.ToLower(body)
+	for _, forbidden := range []string{"failurekind", "failure_kind", "lastfailure", "environment"} {
+		if strings.Contains(lower, forbidden) {
+			t.Errorf("recordTaskFailure references %q — the cooldown must not depend on a "+
+				"client-declared value (#2547: routing on a value the client controls)", forbidden)
+		}
+	}
+}
+
+// Backward compatibility, stated as a behaviour: two identical failures, one
+// tagged and one not, must book the SAME cooldown and quarantine weight. A
+// relay written before this change must not lose or gain anything.
+func TestRecordTaskFailure_SameForTaggedAndUntagged(t *testing.T) {
+	newHub := func() *ContributeWSHub {
+		return &ContributeWSHub{
+			connections:         make(map[string]*ContributorConnection),
+			completedTasks:      make(map[string]time.Time),
+			failedTasks:         make(map[string]time.Time),
+			consecutiveFailures: make(map[string]int),
+			logger:              slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		}
+	}
+
+	// recordTaskFailure takes no kind by construction — that IS the guarantee.
+	// Exercise it the way both paths reach it and compare the ledger.
+	a := newHub()
+	a.recordTaskFailure("org/repo", 42, false)
+	b := newHub()
+	b.recordTaskFailure("org/repo", 42, false)
+
+	if a.consecutiveFailures["org/repo#42"] != b.consecutiveFailures["org/repo#42"] {
+		t.Errorf("quarantine weight differs between paths: %d vs %d",
+			a.consecutiveFailures["org/repo#42"], b.consecutiveFailures["org/repo#42"])
+	}
+	if !a.isTaskInFailureCooldown("org/repo", 42) || !b.isTaskInFailureCooldown("org/repo", 42) {
+		t.Error("a failure stopped booking a cooldown — existing #2435 behaviour regressed")
+	}
+}
+
+// The wire field must stay optional. A relay that omits failure_kind is the
+// default case, not a degraded one.
+func TestWSMessage_FailureKindIsOptional(t *testing.T) {
+	raw, err := os.ReadFile("contribute_ws.go")
+	if err != nil {
+		t.Fatalf("read contribute_ws.go: %v", err)
+	}
+	if !strings.Contains(string(raw), "`json:\"failure_kind,omitempty\"`") {
+		t.Error("failure_kind is not omitempty — it would appear on every wire message and " +
+			"imply a declaration no client made")
+	}
+}

--- a/v2/pkg/dashboard/contribute_protocol.go
+++ b/v2/pkg/dashboard/contribute_protocol.go
@@ -209,3 +209,96 @@ func sanitizeCapabilityField(s string) string {
 	}
 	return strings.TrimSpace(out)
 }
+
+// Task failure kinds (#2547). A relay MAY tag a task_failed with the kind of
+// failure it observed, so an operator can tell a work item that failed on its
+// merits from one that was fine and simply landed on a client whose environment
+// could not run it.
+//
+// The issue's own framing: "a task that failed because the client couldn't run
+// it and a task that failed because the agent got it wrong are, from the hub's
+// side, the same event with different terminal scrollback." Today the hub logs
+// task_failed's reason and discards it, so that inference is left to whoever
+// reads a tmux tail.
+//
+// Like ContributorCapabilities, this is SELF-REPORTED and advisory. It is
+// stored and surfaced read-only; it does NOT influence selection, admission, or
+// the failure cooldown. That separation is the DECLARE/ROUTE split this issue
+// exists to keep: acting on it is ROUTE, which is intentionally undecided, and
+// making a work item's cooldown depend on a client-controlled value would be
+// exactly the "routing on a value the client controls" hazard the issue names.
+const (
+	// TaskFailureKindEnvironment: the client's own runtime could not run the
+	// work (no container runtime, agent CLI never started or crashed, missing
+	// toolchain). The work item itself is unjudged.
+	TaskFailureKindEnvironment = "environment"
+	// TaskFailureKindTask: the work was attempted and failed on its merits.
+	TaskFailureKindTask = "task"
+	// TaskFailureKindUnspecified is the value for a relay that sent no kind, or
+	// sent one this hub does not recognize. It is deliberately the default for
+	// EVERY older relay: absent must never be read as either of the above, or a
+	// hub would be inferring a cause no client stated.
+	TaskFailureKindUnspecified = "unspecified"
+)
+
+// NormalizeTaskFailureKind maps a client-supplied failure kind onto the known
+// set, collapsing absent/unknown values to TaskFailureKindUnspecified.
+//
+// Unknown values are NOT preserved verbatim: the field is rendered to
+// operators, and echoing an arbitrary client string into that surface would let
+// a client write free text into the operator's view. Matching is
+// case-insensitive and space-trimmed so a relay's "Environment" is not silently
+// demoted to unspecified on a cosmetic difference.
+func NormalizeTaskFailureKind(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case TaskFailureKindEnvironment:
+		return TaskFailureKindEnvironment
+	case TaskFailureKindTask:
+		return TaskFailureKindTask
+	default:
+		return TaskFailureKindUnspecified
+	}
+}
+
+// ContributorFailure is a read-only record of the most recent task failure a
+// connection reported (#2547). It is stored on the connection and surfaced on
+// FleetClanker, mirroring how lastIdleReason/IdleReason (#2546) made "why is
+// this clanker idle" answerable instead of an indistinguishable silence.
+//
+// Metadata only — never a credential. Reason is client-supplied free text and
+// is scrubbed before it is surfaced.
+type ContributorFailure struct {
+	TaskID string `json:"task_id,omitempty"`
+	Repo   string `json:"repo,omitempty"`
+	Number int    `json:"number,omitempty"`
+	// Kind is the normalized, self-reported cause (see NormalizeTaskFailureKind).
+	Kind string `json:"kind,omitempty"`
+	// Reason is the client's free-text explanation, as already carried on
+	// task_failed today and, until now, only written to the hub log.
+	Reason string `json:"reason,omitempty"`
+	// Permanent mirrors the task_failed flag: the client does not expect a retry
+	// to succeed.
+	Permanent bool `json:"permanent,omitempty"`
+	// At is when the hub recorded the failure (RFC3339, UTC).
+	At string `json:"at,omitempty"`
+}
+
+// maxFailureReasonLen bounds the client-supplied task_failed reason surfaced on
+// the fleet view (#2547). The reason is free text a relay chose — an error
+// string, or whatever a future relay decides to put there — so it is bounded at
+// the point it becomes operator-visible rather than trusted to be short. 512
+// characters comfortably holds a real error line while keeping one clanker's
+// row from dominating a fleet snapshot.
+const maxFailureReasonLen = 512
+
+// truncateFailureReason bounds a failure reason for display, marking any
+// truncation so an operator can tell a cut-off message from a terse one.
+// Truncation is rune-safe: cutting mid-rune would emit invalid UTF-8 into a
+// JSON response.
+func truncateFailureReason(s string) string {
+	r := []rune(s)
+	if len(r) <= maxFailureReasonLen {
+		return s
+	}
+	return string(r[:maxFailureReasonLen]) + "… (truncated)"
+}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -126,6 +126,17 @@ type ContributorConnection struct {
 	// client). Stored read-only and surfaced on FleetClanker; NEVER used to route
 	// or gate work.
 	capabilities *ContributorCapabilities
+	// lastFailure is the most recent task_failed this connection reported
+	// (#2547): the reason it sent, the self-declared failure kind, and which
+	// task. Nil until the connection has failed a task.
+	//
+	// Until now task_failed's reason was written to the hub log and dropped, so
+	// "this client cannot run the work" and "the agent got the work wrong"
+	// reached an operator as the same event distinguished only by terminal
+	// scrollback. Stored read-only and surfaced on FleetClanker exactly like
+	// lastIdleReason (#2546); NEVER used to route, gate, or adjust a work item's
+	// failure cooldown.
+	lastFailure *ContributorFailure
 	// pendingToken is the scoped, expiring GitHub credential minted for currentTask
 	// but NOT yet delivered to the relay (kubestellar/hive#2537). The credential no
 	// longer travels inside task_assign; it is held here until the task's acceptance
@@ -170,18 +181,28 @@ func (c *ContributorConnection) send(msg WSMessage) error {
 }
 
 type WSMessage struct {
-	Type              string   `json:"type"`
-	Seq               int      `json:"seq,omitempty"`
-	Nonce             string   `json:"nonce,omitempty"`
-	ContributorID     string   `json:"contributor_id,omitempty"`
-	TrustTier         string   `json:"trust_tier,omitempty"`
-	Permissions       []string `json:"permissions,omitempty"`
-	Reason            string   `json:"reason,omitempty"`
-	Message           string   `json:"message,omitempty"`
-	RegistrationToken string   `json:"registration_token,omitempty"`
-	CLIBackend        string   `json:"cli_backend,omitempty"`
-	Model             string   `json:"model,omitempty"`
-	TaskID            string   `json:"task_id,omitempty"`
+	Type          string   `json:"type"`
+	Seq           int      `json:"seq,omitempty"`
+	Nonce         string   `json:"nonce,omitempty"`
+	ContributorID string   `json:"contributor_id,omitempty"`
+	TrustTier     string   `json:"trust_tier,omitempty"`
+	Permissions   []string `json:"permissions,omitempty"`
+	Reason        string   `json:"reason,omitempty"`
+	// FailureKind is the OPTIONAL, client-declared cause of a task_failed
+	// (#2547): "environment" (the client's runtime could not run the work) or
+	// "task" (the work was attempted and failed on its merits). Absent — which
+	// is what every relay written before this sends — normalizes to
+	// "unspecified" and is treated exactly as today.
+	//
+	// Self-reported and advisory, like Capabilities below. It is recorded and
+	// shown to operators; it does NOT affect selection, admission, or the
+	// failure cooldown. See NormalizeTaskFailureKind.
+	FailureKind       string `json:"failure_kind,omitempty"`
+	Message           string `json:"message,omitempty"`
+	RegistrationToken string `json:"registration_token,omitempty"`
+	CLIBackend        string `json:"cli_backend,omitempty"`
+	Model             string `json:"model,omitempty"`
+	TaskID            string `json:"task_id,omitempty"`
 	// TaskGen is the assignment GENERATION / lease token for this task (kubestellar/
 	// hive#2568, the Gate). The hub stamps it on task_assign; the relay echoes it back
 	// on task_progress / task_complete / task_failed. The hub rejects any completion or
@@ -300,7 +321,7 @@ type ContributeWSHub struct {
 	// mu-guarded to match taskGen's reasoning above: it is touched from the
 	// upgrade path and from deferred cleanup, and must never contend with or
 	// re-enter h.mu.
-	pendingConns atomic.Int64
+	pendingConns   atomic.Int64
 	activityMu     sync.RWMutex
 	activity       []ActivityEntry
 	server         *Server
@@ -1602,6 +1623,13 @@ type FleetClanker struct {
 	// Surfaced read-only exactly like CLIBackend/Model/Role so the Operations tab
 	// COULD display it; it is NEVER used to route or gate work.
 	Capabilities *ContributorCapabilities `json:"capabilities,omitempty"`
+	// LastFailure is the most recent task failure this clanker reported (#2547),
+	// surfaced read-only so an operator can attribute a run of failures instead
+	// of inferring the cause from a tmux tail. Its Kind is SELF-REPORTED by the
+	// client and advisory — the hub records and displays it, and never routes,
+	// gates, or adjusts a work item's failure cooldown on it. Nil until this
+	// connection has failed a task.
+	LastFailure *ContributorFailure `json:"last_failure,omitempty"`
 	// LabelInterests (#2677) mirrors the contributor's own OPT-IN label-affinity
 	// list (#2637, ContributorProfile.LabelInterests) so an operator can see
 	// fleet-wide who prefers what without cross-referencing each profile
@@ -1682,6 +1710,17 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 		if c.capabilities != nil {
 			capsCopy := *c.capabilities
 			fc.Capabilities = &capsCopy
+		}
+		// #2547: same treatment for the last reported failure — a copy, with the
+		// client's free-text reason redacted and bounded. Reason is the only
+		// CLIENT-CONTROLLED free text on this snapshot: it is an error string the
+		// relay chose, so it can carry a token it happened to print, and it has no
+		// length the client is obliged to respect. Both are handled here, at the
+		// boundary where it becomes operator-visible.
+		if c.lastFailure != nil {
+			failCopy := *c.lastFailure
+			failCopy.Reason = truncateFailureReason(redactTokens(failCopy.Reason))
+			fc.LastFailure = &failCopy
 		}
 		if c.profile != nil {
 			fc.ContributorID = c.profile.ContributorID
@@ -2578,11 +2617,34 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						// counts more toward the quarantine threshold.
 						h.recordTaskFailure(failedTask.Repo, failedTask.Number, msg.Permanent)
 					}
+					// #2547: keep the failure reason instead of only logging it, so an
+					// operator can tell a work item that failed on its merits from one
+					// that landed on a client whose environment could not run it. The
+					// kind is self-reported and advisory — recorded and displayed, never
+					// acted on. Note this is stored AFTER recordTaskFailure above and
+					// deliberately does not influence it: the cooldown must not depend
+					// on a client-controlled value (that is ROUTE, still undecided).
+					failureKind := NormalizeTaskFailureKind(msg.FailureKind)
+					contributor.mu.Lock()
+					contributor.lastFailure = &ContributorFailure{
+						TaskID:    msg.TaskID,
+						Kind:      failureKind,
+						Reason:    msg.Reason,
+						Permanent: msg.Permanent,
+						At:        time.Now().UTC().Format(time.RFC3339),
+					}
+					if failedTask != nil {
+						contributor.lastFailure.Repo = failedTask.Repo
+						contributor.lastFailure.Number = failedTask.Number
+					}
+					contributor.mu.Unlock()
+
 					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task failed",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
 						"reason", msg.Reason,
+						"failure_kind", failureKind,
 						"permanent", msg.Permanent,
 					)
 					contributor.mu.Lock()


### PR DESCRIPTION
## What

Makes a contributor task failure **attributable**: the hub now records *why* a task failed and shows it, instead of logging the reason and dropping it.

Refs #2547 — **no `Fixes`.** This is deliberately **not** ROUTE. The issue stays open for that decision.

## Scope — why this is not ROUTE

Reading the issue and its comments, the state is unambiguous:

- **DECLARE shipped** (#2659, pinned by #3815, documented by #3830).
- **ROUTE is intentionally open.** The maintainer asked the reporter three design questions (requirement axes, where task requirements come from, hard vs soft) and said: *"we'd rather design the requirements schema around real fleet needs than guess."*

So ROUTE is blocked on a maintainer decision plus downstream field input. Implementing it here would be guessing at a schema someone explicitly asked not to have guessed, and would trip `TestSelectionPathsDoNotReadDeclaredCapabilities` — a test that exists precisely to stop a PR like that landing quietly.

What I built instead is the one operational cost in the issue body that is **independent of ROUTE**:

> "a task that failed because the client couldn't run it and a task that failed because the agent got it wrong are, from the hub's side, the same event with different terminal scrollback."

That needs no task-side requirements vocabulary, makes no dispatch decision, and produces exactly the fleet evidence the maintainer said they want *before* designing ROUTE.

## The gap

`task_failed` carries a `reason`. The handler uses it in one place — the log line — and nowhere else:

```go
h.logger.Info("[contribute-ws] task failed", …, "reason", msg.Reason, …)
```

It is never stored on the connection, the profile, or the failure ledger. Meanwhile `lastIdleReason` (#2546) already solved the identical problem for idleness and is surfaced as `FleetClanker.IdleReason`, explicitly so an operator can see *"why is this clanker idle"* rather than *"an indistinguishable silence."* Failures had no equivalent.

## What changed

**Wire (additive):** `task_failed` may carry `failure_kind`:

| value | meaning |
|---|---|
| `environment` | this client's runtime could not run the work (CLI never started, CLI crashed, backend has no headless mode) — the work item is unjudged |
| `task` | the work was attempted and failed on its merits |
| *absent* | normalizes to `unspecified` — what every existing relay sends, treated exactly as today |

**Hub:** stores reason + normalized kind + work item on the connection; surfaces the most recent one read-only as `FleetClanker.LastFailure`, mirroring `IdleReason`.

**Relay:** `failCurrentTask` takes an optional `kind`, and declares `environment` at the three sites where the cause is unambiguous — CLI never became ready, CLI process died, backend has no headless entry point. The ambiguous sites (headless non-zero exit, max-duration timeout) deliberately send **nothing**: an honest `unspecified` beats a guess when an operator reads this to attribute blame.

## The line this holds

Nothing acts on the declaration. That is the whole design constraint, and it is where the risk lives.

**The cooldown must not depend on it.** The obvious next step — "skip the failure cooldown for an `environment` failure, since the issue was fine" — is exactly the hazard the issue names: *routing on a value the client controls*. A relay could keep an issue permanently hot by tagging every failure `environment`, producing a fleet-level symptom that presents as a hub bug. So `recordTaskFailure` still computes cooldown and quarantine weight from repo, number and `permanent` alone. I did not take that step even though the issue's acceptance criteria gesture at it, because that criterion is conditioned on *"if any routing ships"* — and routing is not shipping here.

Two tests pin it, mirroring the existing #3815 source-level guard:

- `TestSelectionPathsDoNotReadFailureKind` — `selectTask` / `RequeueContributorTask` may not even mention the field.
- `TestRecordTaskFailure_IgnoresFailureKind` — the cooldown path may not mention it either.

Both carry the same instruction as the capability guard: *if routing has now been decided and recorded by a maintainer, update this test in that same PR.*

## Backward compatibility

Absent → `unspecified`, **never** either real kind. The issue is emphatic that *"a client that declares nothing must never be treated as declaring 'no'"*, and that compatibility has to be carried by the defaults since there is no negotiation to carry it. `TestNormalizeTaskFailureKind` asserts absent/blank/unknown all land on `unspecified`; `TestRecordTaskFailure_SameForTaggedAndUntagged` asserts identical ledger outcomes; `TestFleetSnapshot_NoFailureIsNil` keeps the payload identical for a clanker that never failed.

## Handling of client-controlled data

Two properties, because `reason` is the **only** client-controlled free text reaching this snapshot:

- **Redacted.** It is an error string the relay chose, so it can carry a token the relay happened to print. Run through the package's existing `redactTokens` at the boundary where it becomes operator-visible.
- **Bounded** to 512 runes with a visible `… (truncated)` marker, rune-safe so a cut cannot emit invalid UTF-8 into a JSON response. Nothing obliges a client to keep it short.

And `failure_kind` itself is normalized rather than echoed: an unknown value collapses to `unspecified` instead of passing arbitrary client text into a field that reads like an enum on an operator's screen.

## Tests

`v2/pkg/dashboard/contribute_failure_kind_test.go` — normalization (incl. case/space tolerance, and that hostile text does not pass through), truncation (bound, marker, rune safety), fleet surfacing, snapshot-is-a-copy, redaction+bounding, the two ROUTE guards, tagged-vs-untagged equivalence, and that the wire field stays `omitempty`.

### Regression replay

Each change neutered, the specific test confirmed failing, then restored green.

**1. Unknown client kind echoed verbatim** — client writes free text into the operator view:
```
--- FAIL: TestNormalizeTaskFailureKind
    NormalizeTaskFailureKind("hardware") = "hardware", want unspecified
    NormalizeTaskFailureKind("environmental") = "environmental", want unspecified
```

**2. Reason surfaced without redaction/bounding:**
```
--- FAIL: TestFleetSnapshot_FailureReasonRedactedAndBounded
    secret survived into the fleet view: "push failed: ANTHROPIC_API_KEY='sk-hive-scanner' …"
    reason is 561 runes — unbounded client text reached the operator view
```

**3. Cooldown made to depend on the declared kind** — the ROUTE hazard:
```
--- FAIL: TestRecordTaskFailure_IgnoresFailureKind
    recordTaskFailure references "failure_kind" — the cooldown must not depend on a
    client-declared value (#2547: routing on a value the client controls)
```

**4. Failure kind wired into `selectTask`:**
```
--- FAIL: TestSelectionPathsDoNotReadFailureKind
    selectTask references "lastfailure" — ROUTE is intentionally NOT implemented
```

My first attempt at replay 4 failed to *compile*, so the compiler caught it rather than the test. I redid it with a clean-compiling read so the test is demonstrably what fires — otherwise I'd have been claiming coverage the test hadn't shown.

### Local verification

```
go build ./...              clean
gofmt -l <changed files>    clean
go vet ./pkg/dashboard      clean
go test ./pkg/dashboard/    ok  51.6s  (full suite, incl. the existing DECLARE/ROUTE guards)
node --check contributor-relay.sh   clean
```

## What this does and does not give you

**Does:** an operator seeing a run of failures can tell environment from merit, per connection, with the reason preserved. That is the diagnostic cost in the issue's "Why this matters operationally", and it is the data needed to answer the maintainer's own question — *is the fit problem real and recurring on this fleet?* — before a routing schema is designed around a guess.

**Does not:** prevent the wasted assignment, or stop a work item accruing failure history for an environment problem. Both need ROUTE, and ROUTE needs the task-side vocabulary and the maintainer decision. This is Option B applied to failures, and it is offered on the same reasoning the reporter used for preferring B first: get the data before designing policy on top of it.
