### PR TITLE
feat(backends): support agy (Antigravity CLI) — Gemini CLI is retired for subscription accounts

### DIFF
--- a/v2/pkg/agent/backend_coverage_test.go
+++ b/v2/pkg/agent/backend_coverage_test.go
@@ -303,6 +303,28 @@ func TestBackendBinaryName_EverySupportedBackendResolves(t *testing.T) {
 	}
 }
 
+// TestBackendBinaryName_AgyLaunchesAntigravityCLI pins agy to its own binary.
+//
+// agy is the Antigravity CLI, Google's replacement for the Gemini CLI: Google
+// stopped serving Gemini CLI for personal and AI Pro accounts on 2026-06-18, so
+// for any hive whose Google access is a subscription rather than metered API
+// credits, agy is the ONLY reachable Google backend. It is emphatically not an
+// alias for gemini — different binary, different auth, different flags — so a
+// future tidy-up that folds it into the gemini derivation would silently break
+// every subscription-backed Google agent. This catches that.
+func TestBackendBinaryName_AgyLaunchesAntigravityCLI(t *testing.T) {
+	if !config.IsCLIBackend("agy") {
+		t.Fatal("precondition failed: \"agy\" is not a config.CLIBackends member")
+	}
+	got, err := backendBinaryName("agy")
+	if err != nil {
+		t.Fatalf("backendBinaryName(\"agy\") err = %v, want nil", err)
+	}
+	if got != "agy" {
+		t.Errorf("backendBinaryName(\"agy\") = %q, want \"agy\"", got)
+	}
+}
+
 // TestBackendBinaryName_CodexAndAiderLaunchTheirOwnBinaries pins the specific
 // regression: codex and aider are agentic CLIs of their own, not aliases and not
 // gateway backends, so each must exec a binary of its own name. If either were

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1693,6 +1693,22 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 				binary, model, copilotGitHubWriteDenyFlags)
 		case "gemini":
 			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
+		case "agy":
+			// Antigravity CLI (Google's Gemini CLI replacement). Needs
+			// --dangerously-skip-permissions or it blocks on a per-tool
+			// approval prompt that no one is attached to answer — the same
+			// contract as claude's bypass flag, and the value already used for
+			// agy in config/backends.conf.
+			//
+			// An unrecognised --model is NOT fatal here: agy warns
+			// ("model X is not recognized ... Using \"Gemini 3.6 Flash\"
+			// instead") and continues on its default, so a stale model carried
+			// over from another provider degrades to a warning rather than a
+			// dead agent.
+			launchCmd = fmt.Sprintf("%s --dangerously-skip-permissions", binary)
+			if model != "" {
+				launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
+			}
 		case "pi":
 			// pi takes the model as a CLI flag, not a subcommand. Without
 			// this case the launch command never receives the configured

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1705,9 +1705,16 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			// instead") and continues on its default, so a stale model carried
 			// over from another provider degrades to a warning rather than a
 			// dead agent.
+			//
+			// --effort is REQUIRED whenever --model is given. Without it agy
+			// warns "--model <m> requires --effort (available: low, medium,
+			// high)" and silently ignores the model, so the configured model
+			// would never actually take effect. "low" matches the effort agy
+			// itself falls back to, keeping behaviour unchanged while making
+			// the model selection real.
 			launchCmd = fmt.Sprintf("%s --dangerously-skip-permissions", binary)
 			if model != "" {
-				launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
+				launchCmd = fmt.Sprintf("%s --model %s --effort %s", launchCmd, model, agyDefaultEffort)
 			}
 		case "pi":
 			// pi takes the model as a CLI flag, not a subcommand. Without
@@ -4660,6 +4667,14 @@ var (
 
 const (
 	sharedConfigDesiredMode    = 0o660
+	// agyDefaultEffort is the reasoning effort passed alongside agy's --model.
+	// agy requires --effort whenever --model is given and otherwise ignores the
+	// model entirely; "low" is the effort agy defaults to on its own, so this
+	// makes the configured model take effect without changing behaviour. Hive
+	// has no per-agent reasoning-effort setting yet — when it grows one, this
+	// is the constant it should replace.
+	agyDefaultEffort = "low"
+
 	tokenRestartCooldownSec    = 60  // minimum seconds between token-triggered restarts per agent
 	expiredTokenHangTimeoutSec = 180 // blank pane after this many seconds triggers token purge + restart
 	tlsErrorRestartCooldownSec = 120 // minimum seconds between TLS-error-triggered restarts per agent

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -3720,7 +3720,18 @@ func IsInferenceBackend(backend string) bool {
 // `backend: watsonx` be accepted at config-set time and then fail at kick time
 // with "unknown backend: watsonx". Adding a backend in one place only is now a
 // visible omission rather than a silent accept-then-fail.
-var CLIBackends = []string{"claude", "copilot", "goose", "codex", "pi", "bob", "aider", "gemini"}
+//
+// `agy` is the Antigravity CLI, Google's replacement for the Gemini CLI. Google
+// consolidated its CLI tooling under Antigravity at I/O 2026 and Gemini CLI
+// STOPPED SERVING personal and Google AI Pro accounts on 2026-06-18; only
+// customers holding paid Gemini Code Assist licences can still invoke it. The
+// `gemini` entry is therefore retained for those licence holders, but a hive
+// whose Google access is a Gemini/AI Pro subscription can only reach Google
+// through `agy`. It was already listed in config/backends.conf's
+// KNOWN_BACKENDS, so omitting it here reproduced exactly the accept-in-one-
+// place drift this list exists to prevent — except inverted: valid in the
+// shell config, rejected by the hub.
+var CLIBackends = []string{"claude", "copilot", "goose", "codex", "pi", "bob", "aider", "gemini", "agy"}
 
 // IsCLIBackend returns true if the backend launches an agentic CLI binary.
 func IsCLIBackend(backend string) bool {


### PR DESCRIPTION
## Problem

`agy` is listed in `config/backends.conf`'s `KNOWN_BACKENDS` but missing from `config.CLIBackends`, so the hub rejects it:

```
unsupported backend "agy" (supported: claude, copilot, goose, codex, pi, bob, aider, gemini; ...)
```

That is the same accept-in-one-place drift `CLIBackends` exists to prevent, just inverted — valid in the shell config, unknown to the hub.

It is not cosmetic, because **the Google backend hive does accept has been retired.** Google consolidated its CLI tooling under Antigravity at I/O 2026, and [Gemini CLI stopped serving personal and Google AI Pro accounts on 2026-06-18](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/); only paid Gemini Code Assist licence holders can still invoke it. Antigravity CLI — invoked as `agy` — is the replacement.

So for any hive whose Google access is a Gemini/AI Pro **subscription** rather than metered API credits, the situation is:

- `gemini` — accepted by the hub, but retired and needs API credits a subscription does not provide
- `agy` — has the working credentials, but is refused

The backend that is paid for is rejected; the one that is accepted cannot pay. Google is effectively unavailable as a backend.

## Change

- Add `agy` to `config.CLIBackends`. Validation and binary resolution both derive from that list, so this is all that is needed for the hub to accept it and for `backendBinaryName` to resolve it.
- Add the launcher case. `agy` needs `--dangerously-skip-permissions` or it blocks on a per-tool approval prompt with nobody attached — the same contract as claude's bypass flag, and the value already used for agy in `backends.conf`.
- Pass `--effort` alongside `--model`. agy **requires** it and otherwise ignores the model entirely:

  ```
  --model gemini-3.6-flash requires --effort (available: low, medium, high).
  Using "Gemini 3.6 Flash (Low)" instead.
  ```

  `low` is the effort agy falls back to on its own, so behaviour is unchanged while the configured model actually takes effect. Hive has no per-agent reasoning-effort setting yet; `agyDefaultEffort` is the constant to replace when it grows one.

`gemini` is deliberately **kept** — Gemini Code Assist licence holders can still use it.

## Verification

Built and deployed to a live single-node hive (v4, 9 agents), then switched an agent onto agy through the normal API. Hive launched it itself:

```
/usr/local/bin/agy --dangerously-skip-permissions --model gemini-3.6-flash --effort low
```

```
      ▄▀▀▄        Antigravity CLI 1.1.11
     ▀▀▀▀▀▀       <account> (Google AI Pro)
    ▀▀▀▀▀▀▀▀      Gemini 3.6 Flash (Low)
   ▄▀▀    ▀▀▄     /data/agents/guide
? for shortcuts
```

Authenticated against a Google AI Pro subscription and reaching the ready signature, with no effort warning once `--effort` was passed.

Note agy has no known one-shot/headless entry point (it drives an interactive TUI), consistent with how it is already described in `api_contribute_test.go`.

## Tests

`TestBackendBinaryName_EverySupportedBackendResolves` already covers agy automatically, since it derives its cases from `config.SupportedBackends()` — which is exactly the property that guard was added for. Added `TestBackendBinaryName_AgyLaunchesAntigravityCLI` to pin agy to its own binary, mirroring the existing codex/aider test, so a future tidy-up cannot fold it into the gemini derivation.

`go build ./...`, `go vet`, and the `pkg/config` + `pkg/agent` backend tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)