### PR TITLE
fix(agents): stop the launcher answering codex's update prompt with "Update now"

### DIFF
--- a/v2/pkg/agent/blocking_prompt_test.go
+++ b/v2/pkg/agent/blocking_prompt_test.go
@@ -1,0 +1,205 @@
+package agent
+
+import "testing"
+
+// codexUpdatePane is the real codex 0.146.0 update menu, verbatim. Note the
+// PRE-SELECTED option ("›" marker) is "1. Update now" — the destructive one.
+const codexUpdatePane = `  ✨ Update available! 0.146.0 -> 0.147.0
+  Release notes: https://github.com/openai/codex/releases/latest
+› 1. Update now (runs ` + "`npm install -g @openai/codex`" + `)
+  2. Skip
+  3. Skip until next version
+  Press enter to continue`
+
+const codexTrustPane = `> You are in /data/agents/architect
+  Do you trust the contents of this directory? Working with untrusted contents
+  comes with higher risk of prompt injection.
+› 1. Yes, continue
+  2. No, quit
+  Press enter to continue`
+
+const copilotTrustPane = `Confirm folder trust
+  1. Yes
+  2. Yes, and remember for future sessions
+  3. No`
+
+// TestBlockingPromptKey_CodexUpdateSkipsInsteadOfInstalling is the whole point
+// of this mechanism.
+//
+// codex's update menu pre-selects "1. Update now", which runs
+// `npm install -g @openai/codex` as the unprivileged agent UID. That fails with
+// EACCES and kills the CLI — on EVERY launch, indefinitely. A bare Enter, or any
+// heuristic that merely avoids options containing "no"/"exit", picks exactly
+// that option. Only "3. Skip until next version" both unblocks startup and
+// persists so the prompt does not return on the next launch.
+func TestBlockingPromptKey_CodexUpdateSkipsInsteadOfInstalling(t *testing.T) {
+	key, label, ok := blockingPromptKey("codex", codexUpdatePane)
+	if !ok {
+		t.Fatal("codex update prompt was not recognised; the agent would block on it until timeout")
+	}
+	if key == "1" {
+		t.Fatal("answered \"1. Update now\" — this runs npm install -g as the agent UID and kills the CLI")
+	}
+	if key != "3" {
+		t.Errorf("key = %q, want \"3\" (Skip until next version); %q does not persist across launches", key, key)
+	}
+	if label == "" {
+		t.Error("label is empty; the audit log would not say which prompt was answered")
+	}
+}
+
+func TestBlockingPromptKey_KnownPrompts(t *testing.T) {
+	cases := []struct {
+		name    string
+		backend string
+		pane    string
+		want    string
+	}{
+		{"codex directory trust", "codex", codexTrustPane, "1"},
+		{"copilot folder trust", "copilot", copilotTrustPane, "2"},
+		{"codex update", "codex", codexUpdatePane, "3"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			key, _, ok := blockingPromptKey(c.backend, c.pane)
+			if !ok {
+				t.Fatalf("prompt not recognised")
+			}
+			if key != c.want {
+				t.Errorf("key = %q, want %q", key, c.want)
+			}
+		})
+	}
+}
+
+// TestBlockingPromptKey_IgnoresUnrelatedPanes: a prompt is only answered when
+// positively identified. Firing a numbered keystroke at an arbitrary pane would
+// type stray input into a working agent's prompt.
+func TestBlockingPromptKey_IgnoresUnrelatedPanes(t *testing.T) {
+	panes := []string{
+		"",
+		"? for shortcuts",
+		"⏵⏵ bypass permissions on (shift+tab to cycle)",
+		"› Implement {feature}\n  gpt-5.6-sol default · /data/agents/architect",
+		// Superficially similar but NOT the update menu: no options rendered,
+		// so there is nothing to answer.
+		"Update available! 0.146.0 -> 0.147.0",
+	}
+	for _, p := range panes {
+		if key, _, ok := blockingPromptKey("codex", p); ok {
+			t.Errorf("pane %q was answered with %q; want no action", p, key)
+		}
+	}
+}
+
+// TestBackendHasBlockingPrompts_GateMatchesTable is the guard for the bug that
+// made this whole mechanism inert: the watcher was gated on
+// `backend == "copilot"`, so codex agents were never rescued from their update
+// menu no matter how well the menu was understood. Deriving the gate from the
+// table means a prompt added for a new backend enables the watcher for it.
+func TestBackendHasBlockingPrompts_GateMatchesTable(t *testing.T) {
+	for _, p := range blockingPrompts {
+		if !backendHasBlockingPrompts(p.backend) {
+			t.Errorf("backend %q has a blocking prompt but the watcher gate excludes it", p.backend)
+		}
+	}
+	if !backendHasBlockingPrompts("codex") {
+		t.Error("codex must run the watcher: its update menu kills the CLI on every launch")
+	}
+	if backendHasBlockingPrompts("claude") {
+		t.Error("claude has no table entries; the watcher should not be started for it")
+	}
+}
+
+// TestBlockingPromptKey_BackendScoped: a prompt must only be answered for the
+// backend that renders it, so a stray keystroke is never typed into another
+// CLI's pane that happens to contain similar words.
+func TestBlockingPromptKey_BackendScoped(t *testing.T) {
+	if _, _, ok := blockingPromptKey("claude", codexUpdatePane); ok {
+		t.Error("codex update prompt matched while running claude")
+	}
+	if _, _, ok := blockingPromptKey("codex", copilotTrustPane); ok {
+		t.Error("copilot trust prompt matched while running codex")
+	}
+}
+
+// TestBlockingPromptKey_IgnoresScrollback is the guard for a bug seen live:
+// captureTmuxPaneForAgent returns scrollback, so a dead CLI's update menu
+// stayed in history and the watcher typed "3" into the bash shell that replaced
+// it, on every poll, indefinitely. Only the tail of the pane may be matched.
+func TestBlockingPromptKey_IgnoresScrollback(t *testing.T) {
+	deadCLIPane := codexUpdatePane + `
+npm error The operation was rejected by your operating system.
+Error: ` + "`npm install -g @openai/codex`" + ` failed with status exit status: 243
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$
+hive-ci-maintainer@pod:/data/agents/ci-maintainer$`
+	if key, _, ok := blockingPromptKey("codex", deadCLIPane); ok {
+		t.Errorf("answered %q against scrollback of a dead CLI; keystrokes would go to the shell", key)
+	}
+	// The same prompt, still live at the bottom, must still be answered.
+	if _, _, ok := blockingPromptKey("codex", "some earlier output\n"+codexUpdatePane); !ok {
+		t.Error("a live prompt at the tail was not recognised")
+	}
+}
+
+const agyTrustPane = `      ▄▀▀▄        Antigravity CLI 1.1.13
+     ▀▀▀▀▀▀       user@example.com (Google AI Pro)
+   Accessing workspace:
+   /data/agents/guide
+   Do you trust the contents of this project?
+   Antigravity CLI requires permission to read, edit, and execute files here.
+ > Yes, I trust this folder
+   No, exit
+   ↑/↓ Navigate · enter Confirm`
+
+// TestBlockingPromptKey_AgyProjectTrust: agy blocks startup on a project-trust
+// menu whose affirmative option is ALREADY selected, so the answer is a bare
+// Enter and the key must be empty — typing a digit there is stray input, not a
+// selection. Without this entry an agent rotated onto agy hangs at startup,
+// which matters now that automated rotation can move agents to Google.
+func TestBlockingPromptKey_AgyProjectTrust(t *testing.T) {
+	key, label, ok := blockingPromptKey("agy", agyTrustPane)
+	if !ok {
+		t.Fatal("agy project-trust prompt not recognised; a rotated agent would hang on it")
+	}
+	if key != "" {
+		t.Errorf("key = %q, want \"\" (Enter alone; the affirmative option is preselected)", key)
+	}
+	if label == "" {
+		t.Error("label is empty; the audit log would not say which prompt was answered")
+	}
+	if !backendHasBlockingPrompts("agy") {
+		t.Error("agy has a table entry but the watcher gate excludes it")
+	}
+}
+
+// The agy pane must not be answered while running another backend.
+func TestBlockingPromptKey_AgyScoped(t *testing.T) {
+	for _, b := range []string{"codex", "copilot", "claude"} {
+		if _, _, ok := blockingPromptKey(b, agyTrustPane); ok {
+			t.Errorf("agy trust prompt matched while running %q", b)
+		}
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1473,6 +1473,17 @@ func paneShowsConsentScreen(pane string) bool {
 	if pane == "" || strings.Contains(pane, cliWorkingMarker) {
 		return false
 	}
+	// A known startup-blocking menu is not a ready prompt either. The generic
+	// test below needs the "Enter to confirm" footer AND a "❯"-marked line;
+	// codex renders neither (its footer is "Press enter to continue" and its
+	// marker is "›" U+203A), so its update menu read as READY. Everything that
+	// gates on readiness — the startup kick, caveman activation — then typed
+	// into the menu, and the Enter confirmed its pre-selected option:
+	// "1. Update now", which runs `npm install -g` as the agent UID, fails, and
+	// kills the CLI. Blocking on these lets the prompt watcher answer them.
+	if paneHasBlockingPrompt(pane) {
+		return true
+	}
 	if strings.Contains(pane, bypassConsentTitle) && strings.Contains(pane, bypassConsentDefaultOption) {
 		return true
 	}
@@ -1778,7 +1789,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		agent.cancel = cancel
 		go m.pollTmuxOutputForAgent(agent, agentCtx)
 
-		if backend == "copilot" {
+		if backendHasBlockingPrompts(backend) {
 			go m.watchForTrustPromptForAgent(agent, agentCtx)
 		}
 		if isInference {
@@ -1869,7 +1880,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	agent.cancel = cancel
 	go m.pollTmuxOutputForAgent(agent, agentCtx)
 
-	if backend == "copilot" {
+	if backendHasBlockingPrompts(backend) {
 		go m.watchForTrustPromptForAgent(agent, agentCtx)
 	}
 
@@ -2125,8 +2136,172 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 	}
 }
 
-// watchForTrustPromptForAgent monitors a tmux session for Copilot's "Confirm folder trust"
-// prompt using the agent's tmux socket.
+// blockingPrompt is a startup-blocking modal that must be answered with a
+// SPECIFIC numbered option rather than a bare Enter or a generic
+// navigate-away-from-"No" heuristic.
+//
+// The generic heuristic in dismissInferencePrompts steers away from options
+// containing "no"/"exit" and otherwise confirms whatever is selected. That is
+// wrong for menus whose DEFAULT selection is affirmative but harmful — most
+// notably codex's update prompt, where the pre-selected option shells out to
+// `npm install -g`. Answering those needs the exact key, so each entry names
+// the one prompt it answers and nothing else is ever blind-fired at.
+//
+// This mirrors blockingPromptKey() in bin/contributor-relay.sh, which solved
+// the same problem contributor-side. The hub had no equivalent.
+type blockingPrompt struct {
+	// backend this prompt belongs to. Prompts are matched only against the
+	// backend that actually renders them, so a codex pattern can never fire at
+	// a claude pane that happens to contain similar words.
+	backend string
+	// match reports whether this prompt is the one on screen. All conditions
+	// must hold, so a prompt is only answered when positively identified.
+	match func(pane string) bool
+	key   string // the option to type before Enter
+	label string // for the audit log
+}
+
+var blockingPrompts = []blockingPrompt{
+	{
+		backend: "copilot",
+		// Copilot: "Confirm folder trust" → 2. Yes, and remember for future
+		// sessions. Remembering is what stops it recurring on every restart.
+		match: func(p string) bool {
+			return strings.Contains(p, "Confirm folder trust") || strings.Contains(p, "Do you trust the files")
+		},
+		key:   "2",
+		label: "copilot folder trust",
+	},
+	{
+		backend: "agy",
+		// agy (Antigravity CLI): "Do you trust the contents of this project?"
+		// An arrow-key menu whose affirmative option is ALREADY selected, so a
+		// bare Enter is correct and there is no numbered option to type. It
+		// blocks startup exactly like the codex/copilot trust dialogs.
+		match: func(p string) bool {
+			return strings.Contains(p, "Do you trust the contents of this project")
+		},
+		key:   "",
+		label: "agy project trust",
+	},
+	{
+		backend: "codex",
+		// codex: "Do you trust the contents of this directory?" → 1. Yes, continue.
+		match: func(p string) bool {
+			return strings.Contains(p, "Do you trust the contents of this directory")
+		},
+		key:   "1",
+		label: "codex directory trust",
+	},
+	{
+		backend: "codex",
+		// codex: "✨ Update available! x -> y" → 3. Skip until next version.
+		//
+		// Deliberately NOT "1. Update now", which is the PRE-SELECTED option:
+		// it runs `npm install -g @openai/codex` as the unprivileged agent UID,
+		// which fails with EACCES and takes the CLI down with it — on every
+		// launch, indefinitely, until a human intervenes. Even where it could
+		// succeed it is slow, needs network, can fail half-way, and drifts the
+		// CLI version out from under the image.
+		//
+		// "Skip until next version" is chosen over a plain "Skip" because it
+		// persists: a plain Skip re-prompts on the very next launch.
+		match: func(p string) bool {
+			return strings.Contains(p, "Update available!") && strings.Contains(p, "Skip until next version")
+		},
+		key:   "3",
+		label: codexUpdatePromptLabel,
+	},
+}
+
+// blockingPromptTailLines bounds how much of the pane a prompt may be matched
+// in. captureTmuxPaneForAgent returns SCROLLBACK, not just the visible screen,
+// so matching the whole capture answers prompts that have long since scrolled
+// away: after a codex CLI died, its update menu stayed in history and the
+// watcher typed "3" into the bash shell that replaced it, once every poll,
+// forever. A live modal is always at the bottom of the pane, so only the tail
+// is eligible.
+const blockingPromptTailLines = 25
+
+// paneTail returns the last n non-blank lines of a captured pane.
+func paneTail(pane string, n int) string {
+	lines := strings.Split(pane, "\n")
+	kept := make([]string, 0, n)
+	for i := len(lines) - 1; i >= 0 && len(kept) < n; i-- {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		kept = append(kept, lines[i])
+	}
+	for i, j := 0, len(kept)-1; i < j; i, j = i+1, j-1 {
+		kept[i], kept[j] = kept[j], kept[i]
+	}
+	return strings.Join(kept, "\n")
+}
+
+// blockingPromptKey returns the keystroke that dismisses whatever known
+// startup-blocking modal this backend currently has on screen, and whether one
+// was recognised. Only the tail of the pane is considered — see
+// blockingPromptTailLines.
+func blockingPromptKey(backend, pane string) (key, label string, ok bool) {
+	tail := paneTail(pane, blockingPromptTailLines)
+	for _, p := range blockingPrompts {
+		if p.backend == backend && p.match(tail) {
+			return p.key, p.label, true
+		}
+	}
+	return "", "", false
+}
+
+// paneHasBlockingPrompt reports whether ANY known blocking prompt is on the
+// pane, regardless of backend. Used by the readiness gate, which does not know
+// the backend; the patterns are specific enough that a false positive only
+// delays readiness rather than mis-firing a keystroke.
+func paneHasBlockingPrompt(pane string) bool {
+	tail := paneTail(pane, blockingPromptTailLines)
+	for _, p := range blockingPrompts {
+		if p.match(tail) {
+			return true
+		}
+	}
+	return false
+}
+
+// backendHasBlockingPrompts reports whether any known startup-blocking prompt
+// belongs to this backend, and so whether the watcher is worth running for it.
+//
+// Derived from the table rather than hardcoded: the watcher used to be gated on
+// `backend == "copilot"`, which is why codex agents were never rescued from
+// their update menu even after the menu itself was understood. Adding a prompt
+// for a new backend now enables the watcher for it automatically.
+func backendHasBlockingPrompts(backend string) bool {
+	for _, p := range blockingPrompts {
+		if p.backend == backend {
+			return true
+		}
+	}
+	return false
+}
+
+// codexUpdatePromptLabel identifies the codex update menu in blockingPrompts.
+//
+// NOTE: answering "skip until next version" is deliberate, and updating in
+// place is NOT a viable alternative here. The prompt's own "1. Update now"
+// runs `npm install -g @openai/codex`, which needs write access to
+// /usr/local/lib/node_modules (root:root). Neither the agent UID nor the hub
+// process has it — attempting the install from the hub fails with the same
+// exit status 243. "Skip until next version" persists in each agent's
+// CODEX_HOME, so the prompt is answered once per agent and does not recur.
+// Updating the CLI belongs to the image build, not to a running agent.
+const codexUpdatePromptLabel = "codex update prompt"
+
+// watchForTrustPromptForAgent monitors a tmux session for startup-blocking
+// modal prompts using the agent's tmux socket, and answers each with the
+// specific option that unblocks it (see blockingPrompts).
+//
+// Originally this handled only Copilot's folder-trust dialog. It covers codex's
+// trust and update menus too, because those block startup exactly the same way
+// and the update menu's default answer is actively destructive.
 func (m *Manager) watchForTrustPromptForAgent(agent *AgentProcess, ctx context.Context) {
 	const (
 		trustPollInterval = 2 * time.Second
@@ -2137,6 +2312,13 @@ func (m *Manager) watchForTrustPromptForAgent(agent *AgentProcess, ctx context.C
 	ticker := time.NewTicker(trustPollInterval)
 	defer ticker.Stop()
 
+	// A prompt is answered at most ONCE. The pane keeps rendering the menu for
+	// a beat after the keystroke, so a second poll matched it again and typed
+	// the option a second time — by then the CLI was at its input prompt, so
+	// "3" was submitted as a user message and answered ("Three."), burning
+	// tokens and polluting the conversation.
+	answered := make(map[string]bool, len(blockingPrompts))
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -2145,12 +2327,20 @@ func (m *Manager) watchForTrustPromptForAgent(agent *AgentProcess, ctx context.C
 			return
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)
-			if strings.Contains(output, "Confirm folder trust") || strings.Contains(output, "Do you trust the files") {
+			if key, label, ok := blockingPromptKey(agent.effectiveBackend(), output); ok && !answered[label] {
+				answered[label] = true
 				time.Sleep(paneCaptureSleep)
-				m.tmuxSendKeysForAgent(agent, "2")
-				time.Sleep(enterDelay)
+				// An empty key means the affirmative option is already selected
+				// and Enter alone answers it (agy). Typing a digit there would
+				// be stray input, not a selection.
+				if key != "" {
+					m.tmuxSendKeysForAgent(agent, key)
+					time.Sleep(enterDelay)
+				}
 				m.tmuxSendKeysForAgent(agent, "Enter")
-				m.logger.Info("auto-answered folder trust prompt", "agent", agent.Name)
+				m.logger.Info("auto-answered blocking prompt",
+					"agent", agent.Name, "prompt", label, "option", key)
+
 				time.Sleep(trustCooldown)
 			}
 		}
@@ -4217,6 +4407,22 @@ func (m *Manager) nudgeIfKickStalled(name, pane string) {
 // tmuxSendEntersForAgent sends Enter presses using the agent's tmux socket.
 func (m *Manager) tmuxSendEntersForAgent(agent *AgentProcess) {
 	for i := 0; i < enterCount; i++ {
+		// The repeat exists only to make sure a typed line actually RAN — it is
+		// insurance against a pane that swallowed the first Enter. Once
+		// something is on screen asking a question, further Enters stop being
+		// insurance and become an answer.
+		//
+		// This was not theoretical. Enter #1 runs the launch line, codex boots
+		// and renders "✨ Update available!" with "1. Update now" PRE-SELECTED,
+		// and Enters #2 and #3 confirmed it — running `npm install -g` as the
+		// agent UID, which fails with EACCES and kills the CLI. It recurred on
+		// every launch, and it happens within milliseconds, so no poll-based
+		// watcher can get there first.
+		if i > 0 && paneHasBlockingPrompt(m.captureVisiblePaneForAgent(agent)) {
+			m.logger.Info("stopping repeat Enter: a prompt is awaiting an answer",
+				"agent", agent.Name, "sent", i)
+			return
+		}
 		_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "Enter").Run()
 		if i < enterCount-1 {
 			time.Sleep(enterDelay)


### PR DESCRIPTION
## The bug

codex renders an update menu at startup with the **destructive option pre-selected**:

```
✨ Update available! 0.146.0 -> 0.147.0
› 1. Update now (runs `npm install -g @openai/codex`)
  2. Skip
  3. Skip until next version
  Press enter to continue
```

The launcher confirms it. `npm install -g` then runs as the unprivileged agent UID, fails with `EACCES`, and takes the CLI down with it — **on every launch, indefinitely**. The agent never runs a single task.

## Four defects, one fix each

1. **Repeat Enter answers prompts.** After typing the launch line, `tmuxSendEntersForAgent` sends `enterCount` (3) Enters as insurance the line ran. Enter #1 runs it, codex boots and draws the menu, Enters #2/#3 confirm the pre-selected option — within milliseconds, so no poll-based watcher can win that race. The repeats now stop once a known blocking prompt is on screen (the first Enter is always sent).

2. **The prompt watcher never ran for codex** — gated `backend == "copilot"`. The copilot folder-trust watcher is generalised into a table of positively-identified prompts, mirroring `blockingPromptKey()` in `bin/contributor-relay.sh` which solved this contributor-side. The gate derives from the table, so a prompt added for a new backend enables the watcher automatically.

   | backend | prompt | answer |
   |---|---|---|
   | copilot | `Confirm folder trust` | `2` (yes, and remember) |
   | codex | `Do you trust the contents of this directory` | `1` |
   | codex | `Update available!` + `Skip until next version` | `3` — persists; a plain Skip re-prompts next launch |
   | agy | `Do you trust the contents of this project` | Enter alone — its affirmative option is pre-selected; an empty key means exactly that |

3. **Readiness fired on the menu.** `paneShowsConsentScreen` needs an `Enter to confirm` footer and a `❯` line; codex renders `Press enter to continue` and `›` (U+203A), so its menu read as READY and everything gated on readiness (startup kick, caveman activation) typed into it. A known blocking prompt now reads as not-ready.

4. **Scrollback matched as live.** `captureTmuxPaneForAgent` returns history, so a dead CLI's menu stayed in the capture and the watcher typed `3` into the bash shell that replaced it, once per poll (observed live). Prompts now match only the pane **tail**, are scoped to the backend that renders them, and are answered at most once per watcher — the pane keeps rendering for a beat after the keystroke, and a second match used to submit the option as a chat message (codex replying "Three.").

## Deliberately not done: updating codex in place

`npm install -g` needs write access to `/usr/local/lib/node_modules` (`root:root`), which **neither the agent UID nor the hub process has** — driving the install from the hub fails with the same exit status 243 (tried, removed). The skip persists in each agent's `CODEX_HOME`, so the prompt is answered once per agent, ever; updating the CLI belongs to the image build.

## Verification

Live hive, codex 0.146.0 with 0.147.0 available:

- **before:** every launch → `Error: npm install -g @openai/codex failed with status exit status: 243`, agent never usable
- **after, first launch:** prompt answered `3` once, codex reaches its input prompt and runs tasks
- **after, subsequent launches:** no prompt at all, straight to ready

## Tests

`blocking_prompt_test.go`: the update prompt resolving to `3` and explicitly **not** `1`; each known prompt including agy's empty-key contract; backend scoping (a prompt is never answered while running another backend); unrelated panes left alone; and the scrollback case using a real dead-CLI pane. Plus a guard that the watcher gate matches the table — the defect that made the mechanism inert.

(`TestConfirmMenuOption_SelectsOption` fails on a clean `v4` checkout here as well — pre-existing, unrelated.)

*History note: this PR was developed live against the affected hive and previously carried four commits including mid-investigation corrections; squashed to one reviewable commit. The comment thread preserves the investigation trail.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)