### PR TITLE
🐛 fix: guard mode file reads in git-credential-hive.sh and gh-wrapper.sh so an unreadable file cannot kill them

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -366,10 +366,15 @@ fi
 
 # ── Mode-based enforcement (hot-reloadable via mode file) ──
 # Read mode from file first (updated by Manager on mode change), fallback to env var.
+# -r as well as -f: this script runs under `set -e`, so a mode file that exists
+# but is unreadable by the agent UID (owner-only perms, #3679) would kill the
+# wrapper before any mode gate or repo restriction ran, failing every gh call
+# with exit 1 and no output. Fall back to the env var instead — the same mode
+# value the Manager exported.
 AGENT_NAME_GW="${HIVE_AGENT:-${HIVE_AGENT_ID:-unknown}}"
 MODE_FILE="/tmp/.hive-mode-${AGENT_NAME_GW}"
-if [ -f "$MODE_FILE" ]; then
-  AGENT_MODE="$(cat "$MODE_FILE")"
+if [ -f "$MODE_FILE" ] && [ -r "$MODE_FILE" ]; then
+  AGENT_MODE="$(cat "$MODE_FILE" 2>/dev/null || true)"
 else
   AGENT_MODE="${HIVE_AGENT_MODE:-}"
 fi

--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -68,10 +68,14 @@ fi
 
 # ── Mode-based enforcement: block git push for agents without push capability ──
 
-# Read mode from file first (hot-reloadable), fallback to env var
+# Read mode from file first (hot-reloadable), fallback to env var.
+# -r as well as -f: this script runs under `set -e`, so a mode file that exists
+# but is unreadable by the agent UID (owner-only perms, #3679/#3881) would kill
+# the helper mid-script and block every push with no credential and no error.
+# Fall back to the env var instead — the same mode value the Manager exported.
 MODE_FILE="/tmp/.hive-mode-${AGENT}"
-if [ -f "$MODE_FILE" ]; then
-  AGENT_MODE="$(cat "$MODE_FILE")"
+if [ -f "$MODE_FILE" ] && [ -r "$MODE_FILE" ]; then
+  AGENT_MODE="$(cat "$MODE_FILE" 2>/dev/null || true)"
 else
   AGENT_MODE="${HIVE_AGENT_MODE:-}"
 fi


### PR DESCRIPTION
## Summary

Port of #3883 / #3884 (and #3681) from `v2` to `v4` — neither reader-side guard ever landed on `v4`.

- Both enforcement scripts run under `set -euo pipefail` and read the per-agent mode file `/tmp/.hive-mode-<agent>` guarded only by `-f`. On `v4` the Manager writes that file owner-only (`agentStateFileMode = 0600`, #3172) while the scripts run as the per-agent UID, so `cat` fails with `EACCES`, `set -e` kills the script mid-flight, and:
  - `bin/git-credential-hive.sh` returns no credential → with `GIT_TERMINAL_PROMPT=0` every push from every push-capable agent fails (#3881);
  - `bin/gh-wrapper.sh` exits 1 before any mode gate, repo restriction, or `exec "$REAL_GH"` runs → every agent `gh` call fails with no output (#3679 — closed by the `v2`-only #3681, so still live on `v4`).
- Guard both reads with `-r` in addition to `-f` and tolerate a failing `cat`, falling back to the `HIVE_AGENT_MODE` env var the Manager exported. Mode enforcement is unchanged: the same mode value is enforced, just sourced from the session env when the file cannot be read.
- Scope note: my original #3883 touched only `git-credential-hive.sh` because `gh-wrapper.sh` had already been fixed on `v2` by #3681. That fix is also missing on `v4`, so this PR carries the identical one-line guard for both scripts rather than leaving `gh` broken while fixing `git push`.
- Writer-side companion (make the files readable by the agent UID and self-heal running pods — port of #3885): opened separately.

## Related issues

Fixes #3881
Fixes #3679

## Testing

- [ ] `cd v2 && go build ./...`
- [ ] `cd v2 && go test ./...`
- [x] Other / not run (explain): shell-only change, no Go code touched. `bash -n` passes on both scripts. Behavioural check of the extracted mode-read block under `set -euo pipefail` with a `chmod 000` mode file and `HIVE_AGENT_MODE=ISSUES_AND_PRS`:

  ```
  --- BEFORE (origin/v4) ---
  cat: .../modefile-test: Permission denied
  cred: exit=1 (helper died, no AGENT_MODE)
  cat: .../modefile-test: Permission denied
  gh: exit=1 (helper died, no AGENT_MODE)
  --- AFTER ---
  cred: exit=ok AGENT_MODE=ISSUES_AND_PRS
  gh: exit=ok AGENT_MODE=ISSUES_AND_PRS
  --- AFTER, readable file (mode file still wins) ---
  cred: exit=ok AGENT_MODE=ISSUES_ONLY
  gh: exit=ok AGENT_MODE=ISSUES_ONLY
  ```

## Contributor checklist

- [x] PR targets `v4` — `v2` is no longer the maintained line for this work; CONTRIBUTING.md on `v4` still says `v2` and may want an update.
- [x] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes. (No behavior change beyond the fallback; rationale is in the script comments.)
- [x] No secrets, credentials, or local runtime state are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
