### PR TITLE
🐛 fix: make /tmp/.hive-mode-* readable by the agent UID and self-heal existing pods

### DIFF
--- a/v2/pkg/agent/agent_state_file_test.go
+++ b/v2/pkg/agent/agent_state_file_test.go
@@ -5,11 +5,14 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 )
 
 // N15 (CWE-367/732/20): per-agent control state in the pod-shared /tmp must be
-// owner-only and must not follow symlinks.
+// owner-WRITE-only and must not follow symlinks. It must remain world-readable,
+// because its consumers run as the per-agent UID, not the hive uid — see
+// agentStateFileMode and #3679/#3881/#3882.
 //
 // Two files matter, both at paths derived from the agent NAME (guessable):
 //
@@ -20,9 +23,14 @@ import (
 //     its first instruction, so planting it injects an attacker-chosen prompt
 //     that runs with the victim's credentials at message zero.
 //
-// Both were written with a plain os.WriteFile at 0o644: world-readable, and
-// symlink-following (os.WriteFile passes no O_NOFOLLOW), so a pre-planted link
-// redirected the hive's own write to any file the process could reach.
+// Both were written with a plain os.WriteFile at 0o644, symlink-following
+// (os.WriteFile passes no O_NOFOLLOW), so a pre-planted link redirected the
+// hive's own write to any file the process could reach. The 0644 itself was
+// not the hole: /tmp is sticky, so an agent UID cannot replace a hive-owned
+// file there, and world-read is REQUIRED — gh-wrapper.sh, git-credential-hive.sh
+// and goose's `--text "$(cat ...)"` all read these files as the agent UID. The
+// original N15 fix tightened to 0600 and locked every agent out of gh and git
+// push (#3679/#3881); the mode is now 0644 with the symlink hardening kept.
 //
 // NOTE on scope: an earlier reading of this called the bootstrap path arbitrary
 // CODE execution, on the theory that a nested $(...) inside the file would be
@@ -31,9 +39,16 @@ import (
 // content reaches goose as literal text. The finding is prompt injection, which
 // these file permissions are the correct fix for.
 
-func TestWriteAgentStateFileIsOwnerOnly(t *testing.T) {
+// TestWriteAgentStateFileIsOwnerWriteWorldRead pins the mode: only the hive uid
+// may write (no group/other write bits — that is what would let one agent steer
+// another), and everyone may read (the per-agent UID that consumes the file is
+// not the hive uid). The write must be exact regardless of the caller's umask.
+func TestWriteAgentStateFileIsOwnerWriteWorldRead(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".hive-mode-victim")
+
+	restore := syscall.Umask(0o077) // the restrictive umask that produced 0600 in prod (#3882)
+	defer syscall.Umask(restore)
 
 	if err := writeAgentStateFile(path, []byte("ISSUES_ONLY")); err != nil {
 		t.Fatalf("writeAgentStateFile: %v", err)
@@ -42,35 +57,41 @@ func TestWriteAgentStateFileIsOwnerOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if got := fi.Mode().Perm(); got != 0o600 {
-		t.Errorf("mode = %o, want 600 — a group/world-readable control file lets one agent read "+
-			"or (with a writable /tmp) steer another", got)
+	if got := fi.Mode().Perm(); got != 0o644 {
+		t.Errorf("mode = %o, want 644 — group/world WRITE lets one agent steer another, "+
+			"but the per-agent UID must be able to READ its own mode/bootstrap file", got)
 	}
 	if b, err := os.ReadFile(path); err != nil || string(b) != "ISSUES_ONLY" {
 		t.Errorf("content = %q err=%v, want ISSUES_ONLY", b, err)
 	}
 }
 
-// TestWriteAgentStateFileTightensExistingMode covers the upgrade path: a file
-// left at 0644 by a previous release must be tightened, not inherited. O_CREATE
+// TestWriteAgentStateFileRepairsExistingMode covers the upgrade path in both
+// directions: a file left 0600 by the #3172 build (agent-unreadable) must be
+// widened, and a file left group/world-writable must be tightened. O_CREATE
 // applies its mode only when creating, so without the explicit Chmod the old
-// permissive mode would survive every rewrite.
-func TestWriteAgentStateFileTightensExistingMode(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, ".hive-mode-legacy")
-	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+// mode would survive every rewrite.
+func TestWriteAgentStateFileRepairsExistingMode(t *testing.T) {
+	for _, seed := range []os.FileMode{0o600, 0o666} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".hive-mode-legacy")
+		if err := os.WriteFile(path, []byte("old"), seed); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := os.Chmod(path, seed); err != nil {
+			t.Fatalf("seed chmod: %v", err)
+		}
 
-	if err := writeAgentStateFile(path, []byte("ADVISORY")); err != nil {
-		t.Fatalf("writeAgentStateFile: %v", err)
-	}
-	fi, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if got := fi.Mode().Perm(); got != 0o600 {
-		t.Errorf("mode = %o, want 600 — a pre-existing 0644 file must be tightened on rewrite", got)
+		if err := writeAgentStateFile(path, []byte("ADVISORY")); err != nil {
+			t.Fatalf("writeAgentStateFile: %v", err)
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if got := fi.Mode().Perm(); got != 0o644 {
+			t.Errorf("seed %o: mode = %o, want 644 — a pre-existing file must be repaired on rewrite", seed, got)
+		}
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5547,11 +5547,27 @@ func (m *Manager) ClearAllModeOverrides() {
 	}
 }
 
-// agentStateFileMode is owner-only. These files sit in the pod-shared /tmp and
-// carry per-agent CONTROL state — the enforcement mode the gh wrapper reads, and
-// the bootstrap prompt goose is launched with — so anything group- or
-// world-writable lets one agent steer another.
-const agentStateFileMode = 0o600
+// agentStateFileMode is owner-write, world-read (0644). These files sit in the
+// pod-shared /tmp and carry per-agent CONTROL state — the enforcement mode the
+// gh wrapper and git credential helper read, and the bootstrap prompt goose is
+// launched with — so nothing but the hive uid may WRITE them: anything group-
+// or world-writable lets one agent steer another.
+//
+// They must stay world-READABLE, though: the readers run as the per-agent UID
+// (hive-<agent>, group node), not as the hive uid. bin/gh-wrapper.sh and
+// bin/git-credential-hive.sh `cat` the mode file, and goose is launched with
+// `--text "$(cat /tmp/.hive-bootstrap-<name>.txt)"` from the agent's tmux
+// session. When #3172 tightened this to 0600 those readers got EACCES: under
+// `set -e` both scripts died mid-flight, so every agent gh call failed and
+// every push had no credential (#3679, #3881, #3882). Owner-only can never
+// work for a file whose consumer is a different uid by design.
+//
+// 0644 does not reopen N15's write path: /tmp is sticky, so an agent UID cannot
+// unlink, rename or replace a hive-owned file there, and the write itself stays
+// O_NOFOLLOW + fchmod-via-descriptor (see writeAgentStateFile). The contents
+// were never secret — the mode is the agent's own enforcement level and the
+// bootstrap prompt is what the agent prints in its own pane.
+const agentStateFileMode = 0o644
 
 // writeAgentStateFile writes per-agent control state to a shared-/tmp path
 // without following symlinks.
@@ -5562,8 +5578,9 @@ const agentStateFileMode = 0o600
 //   - follows symlinks — os.WriteFile opens O_WRONLY|O_CREATE|O_TRUNC with no
 //     O_NOFOLLOW, so a pre-planted symlink at the (predictable) path redirects
 //     the hive's own write to any file the process can reach; and
-//   - left the result world-readable, and the containing /tmp world-writable,
-//     so any agent UID could replace another agent's file afterwards.
+//   - relied on the caller's umask and on O_CREATE for the mode, so a file left
+//     behind by a previous release (or created under a restrictive umask) kept
+//     whatever mode it already had, and nothing ever repaired it.
 //
 // Both matter because the path is derived from the agent NAME, which is
 // guessable, and because the readers treat these files as authoritative:
@@ -5817,9 +5834,12 @@ func writeAgentStateFile(path string, data []byte) error {
 		f.Close()
 		return err
 	}
-	// O_CREATE honours the mode only when the file did not already exist, so an
-	// existing 0644 file from a previous release keeps its old mode without
-	// this. Chmod through the still-open descriptor: O_NOFOLLOW only proved the
+	// O_CREATE honours the mode only when the file did not already exist (and
+	// umask-filters it even then), so an existing file from a previous release
+	// — 0600 from the #3172 build, or umask-narrowed 0600 (#3882) — keeps its
+	// old, agent-unreadable mode without this; the explicit chmod repairs it on
+	// the next mode change or kick. Chmod through the still-open descriptor:
+	// O_NOFOLLOW only proved the
 	// path was not a symlink at OPEN time, so a path-based os.Chmod after Close
 	// left a window in shared /tmp where the pathname could be swapped for a
 	// symlink and the mode change applied to the link target (TOCTOU, #3175).

--- a/v2/pkg/agent/permissions_modefile_test.go
+++ b/v2/pkg/agent/permissions_modefile_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// modeFileStartMode is the exact production-observed broken mode: a mode file
+// written owner-only (0600 — the #3172 build, or a umask-narrowed write) that
+// the per-agent UIDs running gh-wrapper.sh / git-credential-hive.sh could not
+// read, so every gh call and push was blocked (#3679/#3881/#3882).
+const modeFileStartMode os.FileMode = 0o600
+
+// withModeFileGlob points the watcher's mode-file scan at a temp pattern for
+// the duration of the test, restoring the production value afterwards.
+func withModeFileGlob(t *testing.T, glob string) {
+	t.Helper()
+	orig := ModeFileGlob
+	ModeFileGlob = glob
+	t.Cleanup(func() { ModeFileGlob = orig })
+}
+
+// mkModeFile creates a .hive-mode-<agent> file pinned to a given mode
+// (os.WriteFile is umask-filtered, so the mode is re-applied explicitly —
+// which is precisely one of the production bugs this test file exists for).
+func mkModeFile(t *testing.T, dir, agent string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, ".hive-mode-"+agent)
+	if err := os.WriteFile(path, []byte("ISSUES_AND_PRS"), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod %s: %v", path, err)
+	}
+	return path
+}
+
+// TestFixModeFilesWidensUnreadableFile is the core fail-before/pass-after: a
+// mode file created 0600 must come back world-readable so the enforcement
+// scripts running as per-agent UIDs can read it.
+func TestFixModeFilesWidensUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	path := mkModeFile(t, dir, "quality", modeFileStartMode)
+	withModeFileGlob(t, filepath.Join(dir, ".hive-mode-*"))
+
+	fixModeFiles(quietLogger())
+
+	got := statMode(t, path)
+	if got&modeFileReadBits != modeFileReadBits {
+		t.Errorf("mode = %v, want a+r (%v) so agent UIDs can read their GitHub mode", got, modeFileReadBits)
+	}
+	if got != modeFileStartMode|modeFileReadBits {
+		t.Errorf("mode = %v, want exactly %v (only read bits added, write bits preserved)", got, modeFileStartMode|modeFileReadBits)
+	}
+}
+
+// TestFixModeFilesLeavesCorrectFileUntouched: an already world-readable 0644
+// file must stay byte-identical so the scan is idempotent.
+func TestFixModeFilesLeavesCorrectFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := mkModeFile(t, dir, "guide", 0o644)
+	withModeFileGlob(t, filepath.Join(dir, ".hive-mode-*"))
+
+	fixModeFiles(quietLogger())
+
+	if got := statMode(t, path); got != 0o644 {
+		t.Errorf("mode = %v, want 0644 unchanged", got)
+	}
+}
+
+// TestFixModeFilesSkipsSymlink: /tmp is sticky and world-writable, so an agent
+// can plant a symlink matching the glob; a path-based chmod would follow it
+// (CWE-59), so the scan opens O_NOFOLLOW and must never act on one. The link
+// target must keep its mode.
+func TestFixModeFilesSkipsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "victim")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", target, err)
+	}
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatalf("chmod %s: %v", target, err)
+	}
+	link := filepath.Join(dir, ".hive-mode-evil")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	withModeFileGlob(t, filepath.Join(dir, ".hive-mode-*"))
+
+	fixModeFiles(quietLogger())
+
+	if got := statMode(t, target); got != 0o600 {
+		t.Errorf("symlink target mode = %v, want 0600 untouched (watcher must not follow planted links)", got)
+	}
+}
+
+// TestFixModeFilesSkipsNonRegular: a directory planted at a matching name is
+// not a mode file and must be left alone (only regular files are ever chmod'd).
+func TestFixModeFilesSkipsNonRegular(t *testing.T) {
+	dir := t.TempDir()
+	planted := filepath.Join(dir, ".hive-mode-dir")
+	if err := os.Mkdir(planted, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(planted, 0o700); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	withModeFileGlob(t, filepath.Join(dir, ".hive-mode-*"))
+
+	fixModeFiles(quietLogger())
+
+	if got := statMode(t, planted); got != 0o700 {
+		t.Errorf("planted dir mode = %v, want 0700 untouched", got)
+	}
+}

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -38,6 +38,25 @@ const (
 	bobStateDirGroupRWX os.FileMode = 0o070
 )
 
+// ModeFileGlob matches the per-agent GitHub-mode files the Manager writes
+// (/tmp/.hive-mode-<agent>) and the enforcement layer reads: gh-wrapper.sh,
+// git-credential-hive.sh, and the MITM proxy. The Manager writes them as the
+// hive uid but the shell readers run as per-agent UIDs, so the files must be
+// world-readable. A pod running a build that wrote them owner-only (#3172), or
+// that wrote them under a restrictive umask (#3882), has 0600 files that no
+// agent can read — which killed both `set -e` readers and blocked every gh
+// call and push (#3679/#3881). The watcher re-widens them each tick so a
+// running pod self-heals without operator intervention.
+//
+// A var (not const) so tests can point the scan at a writable temp pattern,
+// matching WatchedHomeDirs/SharedRepoParent. Production value is unchanged.
+var ModeFileGlob = "/tmp/.hive-mode-*"
+
+// modeFileReadBits is `a+r` — the read access every mode-file consumer needs.
+// ORed into the existing perms, never narrowing owner bits, so an
+// already-correct 0644 file is left byte-identical and the scan idempotent.
+const modeFileReadBits os.FileMode = 0o444
+
 // bobStateDirBase is the directory name bob uses for both its shared-HOME state
 // (/data/home/.bob) and its per-agent workdir state (/data/agents/<name>/.bob).
 // The watcher recognizes an entry as a bob state dir by this basename so it can
@@ -206,6 +225,8 @@ func fixPermissions(logger *slog.Logger) {
 	// write/commit/push and therefore open PRs. fixEntry already brings each
 	// dir to >=0770 and each file to >=0660 for the node group (and skips
 	// symlinks), which is exactly what the clone (created 0755 dev:node) needs.
+	fixModeFiles(logger)
+
 	roots := append([]string{}, WatchedHomeDirs...)
 	roots = append(roots, sharedRepoClones()...)
 	for _, root := range roots {
@@ -235,6 +256,66 @@ func fixPermissions(logger *slog.Logger) {
 			)
 		}
 	}
+}
+
+// fixModeFiles re-widens the per-agent mode files (ModeFileGlob) to be
+// world-readable. This is the running-pod remediation for #3882/#3679: the
+// Manager only rewrites a mode file on a level change or kick, so a pod whose
+// files are 0600 (written by the #3172 build, or umask-narrowed) stays broken
+// until then; this scan repairs them within one tick.
+//
+// SECURITY: /tmp is sticky and world-writable, so an agent can pre-create a
+// name matching the glob. Only regular files owned by the hive uid are
+// touched, the only change ever made is adding read bits, and the whole
+// check-then-chmod happens on one open descriptor: O_NOFOLLOW refuses a
+// planted symlink at open time, and f.Stat/f.Chmod act on that same inode, so
+// the pathname cannot be swapped between the check and the chmod (CWE-59 /
+// CWE-367 — the same descriptor discipline writeAgentStateFile follows, #3175).
+func fixModeFiles(logger *slog.Logger) {
+	paths, err := filepath.Glob(ModeFileGlob)
+	if err != nil {
+		return
+	}
+	for _, path := range paths {
+		fixModeFile(path, logger)
+	}
+}
+
+// fixModeFile applies the fixModeFiles policy to a single path.
+func fixModeFile(path string, logger *slog.Logger) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		// ELOOP for a planted symlink, EACCES for a file we do not own: skip.
+		return
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil || !fi.Mode().IsRegular() {
+		return
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != uint32(os.Getuid()) {
+		return
+	}
+	perm := fi.Mode().Perm()
+	if perm&modeFileReadBits == modeFileReadBits {
+		return
+	}
+	newPerm := perm | modeFileReadBits
+	if err := f.Chmod(newPerm); err != nil {
+		logger.Warn("permissions watcher: chmod mode file failed; agents cannot read their GitHub mode and gh/pushes will be blocked",
+			"path", path,
+			"old_mode", perm.String(),
+			"want_mode", newPerm.String(),
+			"error", err,
+		)
+		return
+	}
+	logger.Info("permissions watcher: fixed mode file permissions",
+		"path", path,
+		"old_mode", perm.String(),
+		"new_mode", newPerm.String(),
+	)
 }
 
 // fixEntry checks a single file or directory and corrects ownership/mode


### PR DESCRIPTION
## Summary

Port of #3885 (merged on `v2`) to `v4`. On `v4` the shape of the fix is different because of #3172, so this needs a careful read — @clubanderson, this touches your N15 change and I want to be explicit about why.

**The failure.** On `v4` the Manager writes the per-agent control files (`/tmp/.hive-mode-<agent>`, `/tmp/.hive-bootstrap-<agent>.txt`) through `writeAgentStateFile` at a hard-coded `agentStateFileMode = 0600` (#3172, audit N15). But their consumers do not run as the hive uid: `bin/gh-wrapper.sh` and `bin/git-credential-hive.sh` `cat` the mode file as the per-agent UID (`hive-<agent>`), and goose is launched with `--text "$(cat /tmp/.hive-bootstrap-<name>.txt)"` from the agent's own tmux session. Owner-only therefore means `EACCES` for every reader: under `set -e` both scripts die mid-flight, every agent `gh` call fails with exit 1 and every push has no credential. That is exactly what #3679 reported from a live system (`-rw------- dev node /tmp/.hive-mode-sec-check`, uid 2008 cannot read; the issue even noted the binary "may not match the source" — it was the `v4` build), and what #3881/#3882 hit again on a hosted hive at ACMM L5.

**Why 0644 does not undo N15.** The N15 hole was symlink-following on write (`os.WriteFile` without `O_NOFOLLOW`), and that fix — plus chmod through the open descriptor (#3175) — is fully retained. World-*read* was never the problem: `/tmp` is sticky, so an agent UID cannot unlink, rename or replace a hive-owned file there, and 0644 grants write to nobody but the owner. The contents are not secret either — the mode is the agent's own enforcement level, and the bootstrap prompt is what the agent prints in its own pane. Owner-only can never work for a file whose consumer is a different uid by design; it just silently degrades to "no gh, no push".

**The change**, mirroring #3885:

- `agentStateFileMode` 0600 → 0644 (owner-write, world-read). Because `writeAgentStateFile` already fchmods on every write, files left 0600 by the #3172 build (or umask-narrowed, #3882) are repaired on the next level change or kick, and group/world-writable files are still tightened. The N15 rationale comments are updated to match.
- The permissions watcher re-widens mode files on its 10-second tick (`fixModeFiles`), so an already-running pod self-heals with no operator intervention — same remediation pattern as the `.bob` state-dir fix. `/tmp` is sticky and world-writable, so the scan opens each path `O_NOFOLLOW` (a planted symlink is refused — CWE-59), stats and chmods on that same descriptor (no path-swap window — CWE-367, the same discipline `writeAgentStateFile` follows per #3175), skips anything that is not a regular file owned by the hive uid, and only ever adds read bits.

If you would rather keep the read narrower than world, 0640 with the group forced to `NodeGID` would also work for the per-agent-UID model — say so and I'll rework it; I went with 0644 to match what was merged on `v2`.

## Related issues

Fixes #3882
Fixes #3679

Reader-side companion (`-r` guards in `git-credential-hive.sh` / `gh-wrapper.sh`, port of #3883/#3884/#3681): #3924.

## Testing

- [x] `cd v2 && go build ./...`
- [x] `cd v2 && go test ./...` — full `./pkg/agent` suite passes (`ok ... 334s`); every other package passes except two that fail identically without this change and are unrelated to it (`pkg/policies` assumes a `master` default branch under a `init.defaultBranch=main` git config; `v2/test` needs a live hive at `192.168.4.85:3003`). Note for anyone reproducing: `TestStart_*`/`TestRestart*` in `tmux_coverage_test.go` fail with `File name too long` when the checkout path is deep — the tmux socket dir is created relative to the package dir — so run from a short path.
- [x] Other / not run (explain): tests are fail-before/pass-after — with only `manager.go` reverted, `TestWriteAgentStateFileIsOwnerWriteWorldRead` and `TestWriteAgentStateFileRepairsExistingMode` fail (`mode = 600, want 644`); the new `permissions_modefile_test.go` covers widening of a 0600 file, idempotence on 0644, planted-symlink skip and non-regular skip. `TestWriteAgentStateFileRefusesSymlink`, `...ChmodsViaDescriptor` and `...OverwritesRegularFile` are unchanged and still pass.

## Contributor checklist

- [x] PR targets `v4` — `v2` is no longer the maintained line for this work; CONTRIBUTING.md on `v4` still says `v2` and may want an update.
- [x] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes. (Behavior change is the file mode + self-healing perms; documented on `agentStateFileMode`, `writeAgentStateFile`, `ModeFileGlob`, `fixModeFiles`.)
- [x] No secrets, credentials, or local runtime state are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
