### PR TITLE
fix(contributor): stop the relay defaulting its token write to the hub's full-privilege cache path

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -43,8 +43,19 @@ const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
 const REASONING_EFFORT = process.env.AGENT_REASONING_EFFORT || '';
 const AGENT_ROLE = (process.env.HIVE_AGENT_ROLE || '').trim();
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
+// Where the hub-delivered, task-scoped token is written (injectGhToken). This
+// deliberately does NOT default to /var/run/hive-metrics/gh-app-token.cache:
+// that filename is the hub's FULL-privilege installation-token cache
+// (bin/gh-app-token.sh, root-owned 0600 since audit H3). A relay started on a
+// host that also runs hive-hub components (native install) would either
+// clobber that cache with a short-lived repo-scoped token (relay running as
+// root) or die on EACCES trying (any other uid — the write was uncaught), and
+// detectCapabilities() would misreport the hub's own cache as this relay's
+// credential. Distinct filename, same directory, so the contributor container
+// (which owns /var/run/hive-metrics — v2/Dockerfile.contributor) behaves as
+// before. See kubestellar/hive#1861 / #3842 (audit N14).
 const GH_TOKEN_CACHE = process.env.HIVE_GH_TOKEN_CACHE || (fs.existsSync('/var/run/hive-metrics')
-  ? '/var/run/hive-metrics/gh-app-token.cache'
+  ? '/var/run/hive-metrics/contributor-gh-token.cache'
   : '/tmp/hive-gh-token.cache');
 const TASK_FILE = process.env.HIVE_TASK_FILE || '/tmp/contributor-task.json';
 
@@ -222,7 +233,17 @@ function advanceActiveHub(fromHub) {
 function injectGhToken(token) {
   const dir = path.dirname(GH_TOKEN_CACHE);
   try { fs.mkdirSync(dir, { recursive: true }); } catch (_) {}
-  fs.writeFileSync(GH_TOKEN_CACHE, token, { mode: 0o600 });
+  // A failed write must never throw out of handleMessage: task_assign calls
+  // this before task_accepted is sent, so an unwritable cache path (EACCES on
+  // a root-owned directory, HIVE_GH_TOKEN_CACHE pointing somewhere bad) would
+  // crash the relay on every assignment that carries a token — a crash loop,
+  // not a degraded mode. The agent can still work with its own GH_TOKEN, so
+  // log loudly and carry on.
+  try {
+    fs.writeFileSync(GH_TOKEN_CACHE, token, { mode: 0o600 });
+  } catch (e) {
+    console.error(`Failed to write GitHub token cache ${GH_TOKEN_CACHE}: ${e.message} — continuing without it`);
+  }
 }
 
 const CLI_READY_POLL_MS = 2000;
@@ -1621,6 +1642,8 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     detectAgentCLIVersion,
     sanitizeDeclaredValue,
     handleMessage,
+    injectGhToken,
+    GH_TOKEN_CACHE,
     tmuxSendKeys,
     flushPendingTask,
     relaunchCLI,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1716,6 +1716,54 @@ test('capabilities are probed once and cached, not re-probed per hub handshake',
 });
 
 // ---------------------------------------------------------------------------
+// kubestellar/hive#1861 / #3842 (audit N14) — the relay must never target the
+// hub's full-privilege installation-token cache, and a failed token write must
+// degrade, not crash the relay mid-assignment.
+// ---------------------------------------------------------------------------
+
+test('default token cache path is never the hub shared gh-app-token.cache', () => {
+  // Empty override forces the relay's built-in default (|| is falsy on '').
+  const relay = loadRelay({ env: { HIVE_GH_TOKEN_CACHE: '' } });
+  try {
+    assert.ok(relay.GH_TOKEN_CACHE, 'expected GH_TOKEN_CACHE exported in test mode');
+    assert.notStrictEqual(path.basename(relay.GH_TOKEN_CACHE), 'gh-app-token.cache',
+      'the relay defaulted its token write path to the hub\'s full-privilege ' +
+      `installation-token cache: ${relay.GH_TOKEN_CACHE} — a relay on a hive ` +
+      'host would clobber it (as root) or crash on EACCES (as anyone else)');
+  } finally { teardown(relay); }
+});
+
+test('task_assign with an unwritable token cache path does not crash the relay', () => {
+  // Parent "directory" is a regular file, so mkdirSync and writeFileSync both
+  // fail no matter what uid the test runs as.
+  const scratchRoot = path.join(__dirname, '..', '.relay-test-tmp');
+  fs.mkdirSync(scratchRoot, { recursive: true });
+  const tmp = fs.mkdtempSync(path.join(scratchRoot, 'relay-badcache-'));
+  const fileAsDir = path.join(tmp, 'blocker');
+  fs.writeFileSync(fileAsDir, 'not a directory');
+  const relay = loadRelay({ env: { HIVE_GH_TOKEN_CACHE: path.join(fileAsDir, 'token.cache') } });
+  try {
+    relay.setCliReady(true);
+    relay.handleMessage(JSON.stringify({
+      type: 'task_assign',
+      task_id: 'tok-1',
+      kind: 'issue',
+      repo: 'foo/bar',
+      number: 7,
+      title: 'token write failure must degrade',
+      prompt: 'do the thing',
+      github_token: 'scoped-task-token',
+    }));
+    const accepted = relay.__sent.find(m => m.type === 'task_accepted');
+    assert.ok(accepted,
+      'task_assign must survive an unwritable token cache and still accept the task');
+  } finally {
+    teardown(relay);
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+  }
+});
+
+// ---------------------------------------------------------------------------
 
 let failed = 0;
 // RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.


### PR DESCRIPTION
## What

The contributor relay writes the hub-delivered, **task-scoped** GitHub token to `GH_TOKEN_CACHE` (`injectGhToken`, fed by `task_assign.github_token` / `token_refresh`). Whenever `/var/run/hive-metrics` exists, that path defaulted to `/var/run/hive-metrics/gh-app-token.cache` — the exact filename of the hub's **full-privilege** installation-token cache (`bin/gh-app-token.sh`, root-owned `0600` since audit H3 / `69256ecf`).

On a host running both hive-hub components and a contributor relay (native install), that collision means:

- **relay as root** → silently overwrites the hub's installation-token cache with a short-TTL repo-scoped contributor token, corrupting every hub-side consumer (`bin/hive-merge.sh:90`, entrypoint's `HIVE_GITHUB_TOKEN` at `v2/deploy/entrypoint.sh:1039`) until the next refresh;
- **relay as any other uid** → `fs.writeFileSync` throws `EACCES`, uncaught in the ws `'message'` handler (`injectGhToken` only try/caught the `mkdir`), crashing the relay on **every** `task_assign` that carries a token — a crash loop on assignment, before `task_accepted` is even sent;
- either way, `detectCapabilities()` misreported the hub's own cache as this relay's credential (`credential_type: 'app'`).

## Fix

1. Default to a **relay-owned filename** (`contributor-gh-token.cache`) in the same directory. The contributor container behaviour is unchanged — it owns `/var/run/hive-metrics` (`v2/Dockerfile.contributor:170-171`) and, verified by repo-wide search, **nothing reads the relay-written file by path** (the wrapper in contributor mode injects no token; the inline cred helper bakes `GH_TOKEN` at container start), so no consumer needed updating. The `HIVE_GH_TOKEN_CACHE` override is preserved.
2. `injectGhToken` now degrades loudly instead of throwing — a failed token write logs and continues (the agent can still work with its own `GH_TOKEN`); it must never kill the relay mid-assignment.

Two regression tests added (`bin/contributor-relay.test.js`, 68/68 passing): the default path must never be the hub's shared cache filename, and a `task_assign` with an unwritable cache path must still produce `task_accepted`.

## Context

Part of the #1861 constellation and the concrete contributor-relay half of the **N14 re-verification** asked for in #3842 (full verification writeup posted there). Complements #3888 (N7) and #3889 (kick-agents N14 instruction fix) — no overlap with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
