### PR TITLE
✨ feature(contribute): let both sides detect an incompatible protocol peer (#2547 compatibility criterion)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -123,9 +123,16 @@ const TASK_UNAVAILABLE_RETRY_MS = 30000;
 // RELAY_PROTOCOL_VERSION is the contributor-protocol version this relay speaks
 // (kubestellar/hive#2567). It is DECLARED to the hub in auth_response (additive,
 // optional — an older hub simply ignores it) and the hub advertises its own
-// version + capability set back on auth_ok. Keep in step with
-// contributorProtocolVersion in v2/pkg/dashboard/contribute_protocol.go.
-const RELAY_PROTOCOL_VERSION = '1.1';
+// version + capability set back on auth_ok.
+//
+// MUST equal contributorProtocolVersion in v2/pkg/dashboard/contribute_protocol.go:
+// the hub and this relay ship from the same tree, so they speak the same version
+// by construction. That was previously only a comment, and it drifted — #2600
+// shipped both at 1.1, #2671 bumped the hub to 1.2 for credential_after_accept
+// (handled by the token_refresh case below) and left this at 1.1, so the relay
+// under-declared itself for months with nothing to notice. It is now pinned by
+// TestRelayProtocolVersionMatchesHub, which fails the build on the next drift.
+const RELAY_PROTOCOL_VERSION = '1.2';
 
 // Per-task CLI-crash retry budget. Issue #2203: a task whose CLI kept dying was
 // reassigned by the hub and failed identically forever (5+ times in ~20min),
@@ -161,6 +168,9 @@ const hubs = rawHubList.map((url, i) => ({
   reconnectTimer: null,
   authenticated: false,
   authFailed: false,
+  // #2547: set once we have reported a contributor-protocol difference with
+  // this hub, so a reconnect loop does not repeat the same advisory line.
+  protocolDriftReported: false,
 }));
 // Index into hubs[] of the hub we are currently soliciting work from (sent it
 // the last 'ready'), or that owns currentTask. Round-robins forward on an
@@ -332,6 +342,59 @@ function sanitizeDeclaredValue(raw) {
   return points.length > CLI_VERSION_MAX_LEN
     ? points.slice(0, CLI_VERSION_MAX_LEN).join('').trim()
     : clean;
+}
+
+// parseProtocolVersion mirrors the hub's parser (contribute_protocol_compat.go):
+// strict "MAJOR.MINOR", both non-negative integers, nothing after the minor.
+// Anything else returns null so an unrecognised shape is reported as unparseable
+// rather than coerced into a confident, wrong comparison.
+function parseProtocolVersion(v) {
+  var m = /^\s*(\d+)\.(\d+)\s*$/.exec(String(v == null ? '' : v));
+  if (!m) return null;
+  return { major: parseInt(m[1], 10), minor: parseInt(m[2], 10) };
+}
+
+// classifyPeerProtocol compares a peer's declared version against ours and
+// returns the same verdict vocabulary the hub uses, so the two sides describe a
+// mismatch identically: 'unknown' | 'current' | 'older' | 'newer' |
+// 'incompatible' | 'malformed'. 'unknown' (peer stated nothing) is the
+// backward-compatible default and is never treated as a fault.
+//
+// The verdict always describes THE PEER, so the same 'older' means "the hub is
+// older" here and "the client is older" on the hub side. That is deliberate —
+// one vocabulary, each side reading it about the other — and every message
+// built from it names both versions explicitly so it cannot be misread.
+function classifyPeerProtocol(peer, self) {
+  if (!peer || !String(peer).trim()) return 'unknown';
+  var p = parseProtocolVersion(peer);
+  if (!p) return 'malformed';
+  var s = parseProtocolVersion(self);
+  if (!s) return 'unknown';
+  if (p.major !== s.major) return 'incompatible';
+  if (p.minor < s.minor) return 'older';
+  if (p.minor > s.minor) return 'newer';
+  return 'current';
+}
+
+// warnOnProtocolDrift reports, once per hub for the life of this process, that
+// the hub speaks a
+// different contributor-protocol version than this relay (kubestellar/hive#2547).
+// Purely informational: nothing below changes what we send, what we ask for, or
+// whether we stay connected — a version is not a gate on either side. Silent when
+// the versions agree or the hub is unversioned, so a healthy connection logs
+// nothing extra and an old hub is not nagged about a field it never had.
+function warnOnProtocolDrift(hub, hubVersion) {
+  if (hub.protocolDriftReported) return;
+  var verdict = classifyPeerProtocol(hubVersion, RELAY_PROTOCOL_VERSION);
+  if (verdict === 'current' || verdict === 'unknown') return;
+  hub.protocolDriftReported = true;
+  var detail = {
+    older: `hub ${hubVersion} is behind this relay ${RELAY_PROTOCOL_VERSION} — features this relay knows about may not be deployed there`,
+    newer: `hub ${hubVersion} is ahead of this relay ${RELAY_PROTOCOL_VERSION} — the hub may support features this relay does not use yet`,
+    incompatible: `hub ${hubVersion} differs from this relay ${RELAY_PROTOCOL_VERSION} in MAJOR version — the wire contract differs and behaviour is undefined; consider updating the relay`,
+    malformed: `hub announced an unparseable protocol version; expected MAJOR.MINOR`,
+  }[verdict];
+  console.warn(`Protocol ${verdict}: ${detail}. Continuing normally — this is advisory and nothing is gated on it.`);
 }
 
 // Backends that must NOT be given --model, mirroring contributor-agent.sh.
@@ -1371,6 +1434,18 @@ function handleMessage(data, hub) {
       if (msg.protocol_version || (msg.server_capabilities && msg.server_capabilities.length)) {
         console.log(`Hub protocol ${msg.protocol_version || 'unversioned'}; capabilities: ${(msg.server_capabilities || []).join(', ') || 'none'}`);
       }
+      // #2547 (peer-compatibility): both sides have STATED a version since #2567,
+      // but neither COMPARED them, so "an old relay against a new hub" was still
+      // only detectable by watching it misbehave. Say it once, plainly, on the
+      // contributor's own terminal — this is the half of the detection the hub
+      // log cannot deliver, because the person running the relay is usually not
+      // the person reading the hub.
+      //
+      // Advisory in BOTH directions: we never refuse to connect, never stop
+      // asking for work, and never change what we send. A relay that downgraded
+      // itself on a version mismatch would strand its own contributor for a
+      // difference that is, by the additive-versioning rule, usually harmless.
+      warnOnProtocolDrift(hub, msg.protocol_version);
       hub.authenticated = true;
       hub.authFailed = false;
       hub.reconnectDelay = BASE_RECONNECT_DELAY_MS;
@@ -1655,6 +1730,13 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     getCLIState,
     setWs: (w) => { hubs[0].ws = w; },
     getHubs: () => hubs,
+    // Peer-protocol compatibility (kubestellar/hive#2547). Exported so the
+    // relay-side half of "both sides can detect an incompatible peer" is tested
+    // behaviourally here, not just asserted to exist from the Go side.
+    RELAY_PROTOCOL_VERSION,
+    parseProtocolVersion,
+    classifyPeerProtocol,
+    warnOnProtocolDrift,
     // Headless (non-interactive) mode surface (kubestellar/hive#2538).
     CONTRIBUTOR_MODE,
     MODE_INTERACTIVE,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1716,6 +1716,102 @@ test('capabilities are probed once and cached, not re-probed per hub handshake',
 });
 
 // ---------------------------------------------------------------------------
+// Peer-protocol compatibility (kubestellar/hive#2547).
+//
+// #2567 gave both sides a version to STATE; neither side COMPARED them, so the
+// issue's original complaint stood: "the only way to learn that an old relay is
+// talking to a new hub is to watch it misbehave." These cover the relay half of
+// the detection, and — more importantly — that detecting a mismatch NEVER
+// changes what the relay does.
+// ---------------------------------------------------------------------------
+
+test('protocol verdicts: peer version is classified against our own', () => {
+  const relay = loadRelay();
+  try {
+    const self = relay.RELAY_PROTOCOL_VERSION;
+    const [maj, min] = self.split('.').map(Number);
+    const c = (peer) => relay.classifyPeerProtocol(peer, self);
+
+    // An unversioned hub is 'unknown', NEVER a fault: that is what every
+    // deployment predating the versioned handshake answers with.
+    assert.strictEqual(c(undefined), 'unknown');
+    assert.strictEqual(c(''), 'unknown');
+    assert.strictEqual(c('   '), 'unknown');
+
+    assert.strictEqual(c(self), 'current');
+    assert.strictEqual(c(`${maj}.${min + 1}`), 'newer');
+    assert.strictEqual(c(`${maj + 1}.${min}`), 'incompatible');
+    if (min > 0) assert.strictEqual(c(`${maj}.${min - 1}`), 'older');
+
+    // Strict MAJOR.MINOR — an unrecognised shape is reported as unparseable
+    // rather than coerced into a confident, wrong comparison.
+    for (const bad of ['1', '1.2.3', 'v1.2', '1.x', 'nonsense']) {
+      assert.strictEqual(c(bad), 'malformed', `${bad} should be malformed`);
+    }
+  } finally { teardown(relay); }
+});
+
+test('protocol drift is reported once per hub and never changes relay behaviour', () => {
+  const relay = loadRelay();
+  const origWarn = console.warn;
+  const warnings = [];
+  console.warn = (m) => warnings.push(String(m));
+  try {
+    const hub = relay.getHubs()[0];
+    const self = relay.RELAY_PROTOCOL_VERSION;
+    const [maj, min] = self.split('.').map(Number);
+    const wsBefore = hub.ws;
+    const authBefore = hub.authenticated;
+
+    // Matching and unversioned hubs are SILENT: a healthy connection and an old
+    // hub both stay quiet, so the warning means something when it does appear.
+    relay.warnOnProtocolDrift(hub, self);
+    relay.warnOnProtocolDrift(hub, undefined);
+    assert.strictEqual(warnings.length, 0, `expected silence, got: ${warnings.join(' | ')}`);
+
+    // A real mismatch is reported once, names BOTH versions (the verdict alone
+    // is ambiguous about which side is behind), and says it is advisory.
+    relay.warnOnProtocolDrift(hub, `${maj + 1}.${min}`);
+    assert.strictEqual(warnings.length, 1, 'expected exactly one warning');
+    assert.ok(/incompatible/.test(warnings[0]), warnings[0]);
+    assert.ok(warnings[0].includes(`${maj + 1}.${min}`) && warnings[0].includes(self),
+      `warning must name both versions: ${warnings[0]}`);
+    assert.ok(/advisory/.test(warnings[0]), `warning must say it is advisory: ${warnings[0]}`);
+
+    // Reconnect loops must not repeat it.
+    relay.warnOnProtocolDrift(hub, `${maj + 1}.${min}`);
+    assert.strictEqual(warnings.length, 1, 'drift warning repeated on a second call');
+
+    // And nothing about the connection changed: a mismatched peer keeps working
+    // exactly as before. #2547 is explicit that compatibility is carried by the
+    // defaults, because there is no negotiation to carry it.
+    assert.strictEqual(hub.authFailed, false, 'a protocol mismatch must not fail auth');
+    assert.strictEqual(hub.authenticated, authBefore, 'a protocol mismatch must not change auth state');
+    assert.strictEqual(hub.ws, wsBefore, 'a protocol mismatch must not drop the socket');
+  } finally {
+    console.warn = origWarn;
+    teardown(relay);
+  }
+});
+
+test('the relay declares the same protocol version the hub speaks', () => {
+  // The hub and this relay ship from the same tree. That was previously only a
+  // comment, and it drifted (#2600 shipped both at 1.1; #2671 bumped the hub to
+  // 1.2 and left the relay at 1.1). Pinned from both sides — the Go half is
+  // TestRelayProtocolVersionMatchesHub.
+  const goSrc = fs.readFileSync(
+    path.join(__dirname, '..', 'v2', 'pkg', 'dashboard', 'contribute_protocol.go'), 'utf8');
+  const m = /const contributorProtocolVersion = "([^"]*)"/.exec(goSrc);
+  assert.ok(m, 'could not find contributorProtocolVersion in contribute_protocol.go');
+  const relay = loadRelay();
+  try {
+    assert.strictEqual(relay.RELAY_PROTOCOL_VERSION, m[1],
+      'bin/contributor-relay.sh and the hub must declare the same contributor-protocol version; ' +
+      'bump both in the same PR');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
 
 let failed = 0;
 // RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.

--- a/v2/docs/contributor-relay.md
+++ b/v2/docs/contributor-relay.md
@@ -101,3 +101,18 @@ This is **display-only and untrusted**: the hub never routes, gates, or trusts w
 **How each fact is obtained.** All of it is probed once at relay startup, before the first hub connection, and cached for the life of the process — nothing here runs during the handshake. The container runtime is a `command -v docker || command -v podman` presence check. The agent CLI version comes from running the resolved backend binary with `--version` (the same binary `backends.conf` maps your `AGENT_BACKEND` to, so `litellm` reports the `claude` CLI's version), with stdin closed and a short timeout. Every probe is best-effort: if the binary is missing, the flag is unsupported, or the call times out, that one field is simply **omitted**, which reads as unknown. Declaring nothing is always a valid answer and never costs you work.
 
 **Both sides bound it.** The relay reduces a CLI's output to one short printable line — CLIs append update nudges and colour escapes — and the hub independently truncates every declared field to 64 characters and strips control characters when it stores them. A declaration is unverified client text, so the hub does not rely on the client having limited it. Sanitizing never rejects: an over-long or messy declaration still authenticates and still receives work, it just cannot spill past its field on the Operations row.
+
+## Protocol compatibility
+
+Both sides state a contributor-protocol version: the hub advertises its own on `auth_ok`, and the relay declares `relay_protocol_version` in `auth_response`. Since [#2547](https://github.com/kubestellar/hive/issues/2547) both sides also **compare** them, so an old relay against a new hub is something you are told about rather than something you infer from misbehaviour:
+
+- **On the relay** — a mismatch prints one line on the contributor's own terminal (`Protocol older: hub 1.3 is behind this relay 1.2 …`), once per hub.
+- **On the hub** — the Operations tab shows a `protocol: client 1.1 · hub 1.2 · older than this hub` line under the clanker row, and the hub log records the verdict at connect.
+
+Versions are `MAJOR.MINOR`. A MINOR difference is purely additive — the older side simply doesn't know about features added since. A MAJOR difference means the wire contract changed and behaviour is undefined; update the relay.
+
+**Nothing is gated on this, in either direction.** A drifted or even majorly-incompatible relay authenticates, is admitted, and receives exactly the work it received before; a relay that sees a hub version it doesn't recognise keeps working normally. A version is self-reported client text, so acting on it would mean routing on a value the client controls. The comparison is a diagnostic, not a control — if you need to keep a client away from work, use the server-side controls (trust tiers, `contribute_allow_models`, the allow/deny filters), which are enforced rather than declared.
+
+A relay that declares no version at all reads as `unknown` and is **not** treated as incompatible — that is what every relay written before the versioned handshake sends.
+
+Both surfaces render nothing when the versions agree, so a healthy fleet stays quiet. The in-tree relay and hub always match (a test fails the build if they drift); the comparison exists for third-party relays and for deployments running a hub and relay from different releases.

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1443,6 +1443,12 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 .clanker-interests{display:flex;flex-wrap:wrap;align-items:center;gap:4px;margin-top:3px;font-size:.68rem;color:#6e7681}
 .clanker-interests-label{color:#6e7681}
 .clanker-interest-chip{display:inline-flex;padding:1px 7px;border-radius:999px;font-size:.68rem;background:rgba(46,160,67,.12);color:#3fb950;border:1px solid rgba(46,160,67,.3)}
+/* #2547 peer compatibility: the hub-vs-client protocol comparison, rendered ONLY
+   when the versions actually differ so a healthy fleet stays quiet. Amber (not
+   red) on purpose — a drifted peer is still fully served; this is a notice, not
+   an error state, and must not read as "this clanker is broken/blocked". */
+.clanker-proto{margin-top:3px;font-size:.68rem;color:#d29922}
+.clanker-proto.incompatible{color:#f85149}
 /* #2637 owner roster: an OWNER-facing aggregate of which labels connected
    contributors subscribe to, and who — so the owner can label matching issues to
    route work. Reuses the green .cc-interest-chip affinity color. Read-only. */
@@ -4278,6 +4284,33 @@ function capabilityLine(caps){
   if(!parts.length)return '';
   return '<div class="clanker-sub clanker-declares" title="Self-declared by the client. Advisory only — the hub records and shows it but never routes, gates, or trusts work on it.">declares: '+parts.join(' &middot; ')+'</div>';
 }
+// protocolLine (#2547 peer-compatibility criterion) renders the hub-vs-client
+// contributor-protocol comparison the fleet snapshot derives. Until now the ops
+// row showed the client's declared "proto 1.1" with NOTHING to compare it
+// against, so an operator could not tell a current relay from one three minors
+// behind — the issue's "the only way to learn that an old relay is talking to a
+// new hub is to watch it misbehave", still true after both sides gained a version.
+//
+// It returns '' unless there is genuinely something to say: an exact match and an
+// undeclared version (every relay predating the versioned handshake) both render
+// nothing, so this adds no noise to a healthy fleet and no shaming of an old
+// client that works fine. The mismatch flag is the server's own boolean, so the
+// UI does not re-derive the verdict set.
+//
+// Advisory ONLY. A drifted or even majorly-incompatible peer is admitted and
+// assigned work exactly as before — the title text says so explicitly, because a
+// warning-coloured line an operator cannot act on invites them to invent a
+// remedy (disabling the contributor) that the hub never asked for.
+function protocolLine(p){
+  if(!p||!p.mismatch)return '';
+  var label={older:'older than this hub',newer:'newer than this hub',
+    incompatible:'INCOMPATIBLE with this hub',malformed:'unparseable'}[p.verdict];
+  if(!label)return '';
+  var cls='clanker-proto'+(p.verdict==='incompatible'?' incompatible':'');
+  var shown=p.peer?esc(p.peer):'(none)';
+  return '<div class="'+cls+'" title="'+esc(p.detail||'')+' The hub does not gate on this — the client is served exactly as before.">'+
+    'protocol: client '+shown+' &middot; hub '+esc(p.hub||'')+' &middot; '+label+'</div>';
+}
 // #2546: human-readable label for the machine reason a clanker is idle. Keeps the
 // raw reason as a fallback so a new server-side reason still renders legibly.
 function idleReasonLabel(r){
@@ -4394,6 +4427,10 @@ function renderClankers(list){
     // used to route or gate work — see capabilityLine() for the "self-declared" note
     // that keeps that visible at the point of use (per the issue's risk section).
     var capsLine=capabilityLine(c.capabilities);
+    // #2547 (peer-compatibility): the declared protocol version above is only
+    // meaningful next to the hub's own. Renders nothing when they agree or when
+    // the client declared none, so this is silent for a healthy fleet.
+    var protoLine=protocolLine(c.protocol);
     // #2677: this contributor's own label interests, read-only, so the operator
     // gets a fleet-wide view of who prefers what without cross-referencing each
     // profile separately (the data already travels in this same fleet snapshot).
@@ -4445,7 +4482,7 @@ function renderClankers(list){
     var rowTitle=c.role_mismatch?(' title="'+esc(c.role_mismatch)+'"'):'';
     return '<div class="'+rowCls+'" data-clanker="'+esc(key)+'"'+rowTitle+'><span class="clanker-dot'+(c.stale?' stale':'')+'"></span>'+av+
       '<div class="clanker-main"><div class="clanker-user">'+esc(user)+statusPill+tierPill+'</div>'+
-      '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+capsLine+interestsLine+'</div>'+
+      '<div class="clanker-sub">'+(sub||'&mdash;')+'</div>'+task+capsLine+protoLine+interestsLine+'</div>'+
       (actions||('<span class="feed-time">'+esc(rel(c.connected_at))+'</span>'))+'</div>';
   }).join('');
 }

--- a/v2/pkg/dashboard/contribute_protocol_compat.go
+++ b/v2/pkg/dashboard/contribute_protocol_compat.go
@@ -1,0 +1,204 @@
+// Peer-protocol compatibility detection for the contributor WebSocket protocol.
+//
+// This closes the one kubestellar/hive#2547 acceptance criterion that DECLARE
+// (#2659/#2600) left open:
+//
+//	"Either the protocol gains a way for both sides to detect an incompatible
+//	 peer, or it is documented that compatibility is managed out of band and how."
+//
+// #2567 gave both sides a version to STATE — the hub advertises
+// contributorProtocolVersion on auth_ok, and a relay may declare
+// capabilities.relay_protocol_version in auth_response. Neither side ever
+// COMPARED them, so the issue's original complaint survived the fix: the only
+// way to learn that an old relay is talking to a new hub was still to watch it
+// misbehave. The declared version was rendered on the ops row as a bare
+// "proto 1.1" chip with nothing to compare it against.
+//
+// That is not hypothetical. #2600 shipped both sides at "1.1"; #2671 bumped the
+// hub to "1.2" (adding capCredentialAfterAccept) and left bin/contributor-relay.sh
+// at "1.1", against an explicit "Keep in step with contributorProtocolVersion"
+// comment that nothing enforced. The in-tree relay has been under-declaring its
+// own protocol level ever since, and no surface said so.
+//
+// What this file adds, and the line it holds:
+//
+//   - A comparison, and a legible operator-facing verdict for it. Nothing else.
+//
+//   - It NEVER gates. A mismatched — even a majorly incompatible — peer
+//     authenticates, is admitted, and receives exactly the work it receives
+//     today. #2547 is emphatic that compatibility must be carried by the
+//     DEFAULTS because there is no negotiation to carry it, and that an existing
+//     relay must never lose assignments because it was written before a change.
+//     A version is self-reported client text; rejecting on it would be routing
+//     on a value the client controls, which is the failure mode the issue names.
+//     TestProtocolCompat_NeverGates and TestProtocolCompatIsNotReadBySelection
+//     pin this, mirroring the #3815 DECLARE/ROUTE source-level guard.
+//
+//   - The verdict is DERIVED, not stored: FleetSnapshot computes it from the
+//     capability the client already declared. No new connection state, and no
+//     new field on the wire in either direction.
+package dashboard
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Peer-compatibility verdicts. Stable identifiers (an operator UI maps them to
+// prose); add new ones rather than repurposing these.
+const (
+	// protoPeerUnknown: the peer declared no version at all — an unversioned
+	// relay predating #2567. Compatibility is UNVERIFIABLE, not bad: this is the
+	// backward-compatible default and every such client keeps working.
+	protoPeerUnknown = "unknown"
+	// protoPeerCurrent: peer and hub speak the same MAJOR.MINOR.
+	protoPeerCurrent = "current"
+	// protoPeerOlder: same major, lower minor. Purely additive drift — the peer
+	// simply does not know about features added since its minor.
+	protoPeerOlder = "older"
+	// protoPeerNewer: same major, higher minor. The peer knows about features
+	// this hub has not deployed; it should degrade using server_capabilities.
+	protoPeerNewer = "newer"
+	// protoPeerIncompatible: MAJOR mismatch. By the versioning rule in
+	// contribute_protocol.go a major bump is a breaking wire change, so peer
+	// behaviour is undefined. Reported LOUDLY, still not enforced.
+	protoPeerIncompatible = "incompatible"
+	// protoPeerMalformed: the peer declared something that is not MAJOR.MINOR.
+	// Treated as unverifiable, exactly like unknown, never as a rejection.
+	protoPeerMalformed = "malformed"
+)
+
+// maxDeclaredVersionRunes bounds the client-declared version string before it is
+// echoed into an operator-visible payload. relay_protocol_version is
+// client-controlled free text and nothing obliges a relay to keep it short.
+const maxDeclaredVersionRunes = 32
+
+// parseProtocolVersion parses a "MAJOR.MINOR" contributor-protocol version.
+// Both components must be non-negative integers and nothing may follow the
+// minor — "1.2.3", "v1.2", "1", and "" are all rejected, so an unrecognised
+// shape lands on protoPeerMalformed rather than being silently coerced into a
+// comparison that would report a confident and wrong verdict.
+func parseProtocolVersion(v string) (major, minor int, ok bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, 0, false
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil || major < 0 {
+		return 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil || minor < 0 {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+// classifyPeerProtocol compares a peer's declared contributor-protocol version
+// against the version this hub speaks and returns one of the protoPeer*
+// verdicts. An empty declaration is protoPeerUnknown — NEVER an error and never
+// a rejection: that is what every relay written before #2567 sends.
+func classifyPeerProtocol(peer string) string {
+	if strings.TrimSpace(peer) == "" {
+		return protoPeerUnknown
+	}
+	peerMajor, peerMinor, ok := parseProtocolVersion(peer)
+	if !ok {
+		return protoPeerMalformed
+	}
+	// The hub's own constant is compile-time ours; if it ever stops parsing we
+	// cannot make a meaningful comparison, so we report unknown rather than
+	// accusing the client of a mismatch we caused.
+	hubMajor, hubMinor, ok := parseProtocolVersion(contributorProtocolVersion)
+	if !ok {
+		return protoPeerUnknown
+	}
+	switch {
+	case peerMajor != hubMajor:
+		return protoPeerIncompatible
+	case peerMinor < hubMinor:
+		return protoPeerOlder
+	case peerMinor > hubMinor:
+		return protoPeerNewer
+	default:
+		return protoPeerCurrent
+	}
+}
+
+// protocolVerdictDetail is the operator-facing sentence for a verdict.
+//
+// It deliberately interpolates NO client-supplied text. The hub's own version is
+// a server constant and safe to name; the peer's is client-controlled and is
+// carried separately in ProtocolCompat.Peer (bounded, and escaped at render).
+// Keeping the two apart means a hostile version string cannot dress itself up as
+// hub prose on an operator's screen.
+func protocolVerdictDetail(verdict string) string {
+	switch verdict {
+	case protoPeerCurrent:
+		return "Client speaks the same protocol version as this hub."
+	case protoPeerOlder:
+		return "Client speaks an older protocol minor than this hub (" + contributorProtocolVersion +
+			"). Additive-only: features added since the client's version are unavailable to it, but nothing breaks."
+	case protoPeerNewer:
+		return "Client speaks a newer protocol minor than this hub (" + contributorProtocolVersion +
+			"). It should degrade using the capability set advertised on auth_ok."
+	case protoPeerIncompatible:
+		return "Client declares a different protocol MAJOR than this hub (" + contributorProtocolVersion +
+			"). A major bump is a breaking wire change, so behaviour is undefined — but the client is still served."
+	case protoPeerMalformed:
+		return "Client declared a protocol version this hub cannot parse (expected MAJOR.MINOR). Treated as undeclared."
+	default:
+		return "Client declared no protocol version (a relay predating the versioned handshake). Compatibility is unverifiable and assumed good."
+	}
+}
+
+// ProtocolCompat is the read-only comparison between the contributor-protocol
+// version this hub speaks and the one a connected client declared. It is DERIVED
+// per snapshot from the client's existing declaration — it stores nothing new
+// and adds nothing to the wire in either direction.
+//
+// It is observability, not enforcement: no field here is consulted when
+// admitting a client or selecting work for one. Every verdict, including
+// protoPeerIncompatible, describes a client that is fully served.
+type ProtocolCompat struct {
+	// Hub is the contributor-protocol version this hub speaks. Always set — the
+	// operator complaint this answers is that a bare "proto 1.1" on a fleet row
+	// had nothing to compare against.
+	Hub string `json:"hub"`
+	// Peer is the version the CLIENT declared, verbatim but length-bounded.
+	// Empty for an unversioned relay. Client-controlled: escape at render.
+	Peer string `json:"peer,omitempty"`
+	// Verdict is one of the protoPeer* constants.
+	Verdict string `json:"verdict"`
+	// Detail is the operator-facing explanation. Server-authored; never contains
+	// client text.
+	Detail string `json:"detail,omitempty"`
+	// Mismatch is true when the operator has something to look at — the peer
+	// declared a version and it is not this hub's. It is false for both
+	// protoPeerCurrent and protoPeerUnknown, so a healthy fleet and a fleet of
+	// pre-#2567 relays are equally quiet. A UI can key its warning off this one
+	// boolean rather than re-deriving the verdict set.
+	Mismatch bool `json:"mismatch,omitempty"`
+}
+
+// peerProtocolCompat builds the comparison for a client-declared version.
+// peer may be empty (unversioned relay) — that is a supported, non-exceptional
+// input and yields a quiet protoPeerUnknown.
+func peerProtocolCompat(peer string) ProtocolCompat {
+	peer = strings.TrimSpace(peer)
+	if r := []rune(peer); len(r) > maxDeclaredVersionRunes {
+		peer = string(r[:maxDeclaredVersionRunes])
+	}
+	verdict := classifyPeerProtocol(peer)
+	return ProtocolCompat{
+		Hub:      contributorProtocolVersion,
+		Peer:     peer,
+		Verdict:  verdict,
+		Detail:   protocolVerdictDetail(verdict),
+		Mismatch: verdict == protoPeerOlder || verdict == protoPeerNewer || verdict == protoPeerIncompatible || verdict == protoPeerMalformed,
+	}
+}

--- a/v2/pkg/dashboard/contribute_protocol_compat_test.go
+++ b/v2/pkg/dashboard/contribute_protocol_compat_test.go
@@ -1,0 +1,406 @@
+package dashboard
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_protocol_compat_test.go covers the peer-compatibility half of
+// kubestellar/hive#2547:
+//
+//	"Either the protocol gains a way for both sides to detect an incompatible
+//	 peer, or it is documented that compatibility is managed out of band and how."
+//
+// Two properties are load-bearing and are tested as such:
+//
+//  1. The comparison EXISTS and is legible (verdicts, the fleet surface, the
+//     operator line).
+//  2. The comparison NEVER GATES. Every verdict, including the worst one,
+//     describes a client that authenticates and is served exactly as before.
+//     This mirrors the #3815 DECLARE/ROUTE guard: the risk is not that the code
+//     is wrong today, it is that a later change quietly makes a self-reported
+//     version load-bearing.
+
+func TestParseProtocolVersion(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		in               string
+		wantOK           bool
+		wantMaj, wantMin int
+	}{
+		{in: "1.2", wantOK: true, wantMaj: 1, wantMin: 2},
+		{in: "0.0", wantOK: true},
+		{in: "10.34", wantOK: true, wantMaj: 10, wantMin: 34},
+		{in: " 1.2 ", wantOK: true, wantMaj: 1, wantMin: 2}, // surrounding space tolerated
+		{in: ""},        // undeclared
+		{in: "1"},       // no minor
+		{in: "1.2.3"},   // semver-ish, not this scheme
+		{in: "v1.2"},    // prefixed
+		{in: "1.x"},     // non-numeric minor
+		{in: "-1.2"},    // negative
+		{in: "1.2-rc1"}, // suffixed
+		{in: "abc"},
+	} {
+		maj, min, ok := parseProtocolVersion(tc.in)
+		if ok != tc.wantOK {
+			t.Errorf("parseProtocolVersion(%q) ok = %v, want %v", tc.in, ok, tc.wantOK)
+			continue
+		}
+		if ok && (maj != tc.wantMaj || min != tc.wantMin) {
+			t.Errorf("parseProtocolVersion(%q) = %d.%d, want %d.%d", tc.in, maj, min, tc.wantMaj, tc.wantMin)
+		}
+	}
+}
+
+// TestClassifyPeerProtocol pins the verdict for each shape of declared version,
+// stated RELATIVE to the hub's own constant so the table does not silently rot
+// the next time contributorProtocolVersion is bumped.
+func TestClassifyPeerProtocol(t *testing.T) {
+	t.Parallel()
+	hubMaj, hubMin, ok := parseProtocolVersion(contributorProtocolVersion)
+	if !ok {
+		t.Fatalf("contributorProtocolVersion %q does not parse as MAJOR.MINOR — the hub's own version must be well-formed", contributorProtocolVersion)
+	}
+	ver := func(maj, min int) string {
+		return strconv.Itoa(maj) + "." + strconv.Itoa(min)
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"undeclared is unknown, never a fault", "", protoPeerUnknown},
+		{"blank is unknown", "   ", protoPeerUnknown},
+		{"same version is current", contributorProtocolVersion, protoPeerCurrent},
+		{"lower minor is older", ver(hubMaj, hubMin-1), protoPeerOlder},
+		{"higher minor is newer", ver(hubMaj, hubMin+1), protoPeerNewer},
+		{"lower major is incompatible", ver(hubMaj-1, hubMin), protoPeerIncompatible},
+		{"higher major is incompatible", ver(hubMaj+1, hubMin), protoPeerIncompatible},
+		{"garbage is malformed", "not-a-version", protoPeerMalformed},
+		{"semver is malformed", "1.2.3", protoPeerMalformed},
+	} {
+		if hubMin == 0 && tc.want == protoPeerOlder {
+			continue // no representable lower minor at hub minor 0
+		}
+		if hubMaj == 0 && tc.name == "lower major is incompatible" {
+			continue // no representable lower major at hub major 0
+		}
+		if got := classifyPeerProtocol(tc.in); got != tc.want {
+			t.Errorf("%s: classifyPeerProtocol(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestPeerProtocolCompat_MismatchFlag asserts the boolean the UI keys off: it is
+// true only when the operator has something to look at. A healthy fleet and a
+// fleet of pre-#2567 relays must be EQUALLY quiet — the issue is explicit that a
+// client which declares nothing must never be treated as declaring something bad.
+func TestPeerProtocolCompat_MismatchFlag(t *testing.T) {
+	t.Parallel()
+	if c := peerProtocolCompat(""); c.Mismatch {
+		t.Error("an undeclared version must not be flagged as a mismatch — every relay predating #2567 sends nothing")
+	}
+	if c := peerProtocolCompat(contributorProtocolVersion); c.Mismatch {
+		t.Error("a matching version must not be flagged as a mismatch")
+	}
+	for _, in := range []string{"99.0", "0.0", "nonsense"} {
+		if c := peerProtocolCompat(in); !c.Mismatch {
+			t.Errorf("peerProtocolCompat(%q).Mismatch = false, want true (verdict %q)", in, c.Verdict)
+		}
+	}
+	// The hub's own version is always reported, even for an undeclared peer —
+	// that is the actual gap: a bare "proto 1.1" chip with nothing to compare it to.
+	if c := peerProtocolCompat(""); c.Hub != contributorProtocolVersion {
+		t.Errorf("Hub = %q, want %q — the comparison is useless without the hub's own version", c.Hub, contributorProtocolVersion)
+	}
+}
+
+// TestPeerProtocolCompat_HandlesHostileDeclaredVersion covers the one
+// client-controlled string in this payload. It must be bounded (nothing obliges
+// a relay to keep it short) and it must never be interpolated into the
+// server-authored Detail prose, where it could dress itself up as a hub
+// statement on an operator's screen.
+func TestPeerProtocolCompat_HandlesHostileDeclaredVersion(t *testing.T) {
+	t.Parallel()
+	hostile := strings.Repeat("A", 500) + " <script>alert(1)</script> hub says everything is fine"
+	c := peerProtocolCompat(hostile)
+
+	if got := len([]rune(c.Peer)); got > maxDeclaredVersionRunes {
+		t.Errorf("Peer kept %d runes, want <= %d — the declared version is unbounded client text", got, maxDeclaredVersionRunes)
+	}
+	if strings.Contains(c.Detail, "hub says everything is fine") || strings.Contains(c.Detail, "<script>") {
+		t.Errorf("Detail echoed client text (%q) — operator prose must be server-authored only", c.Detail)
+	}
+	if c.Verdict != protoPeerMalformed {
+		t.Errorf("Verdict = %q, want %q", c.Verdict, protoPeerMalformed)
+	}
+	// A malformed declaration is still a served client, not an error.
+	if c.Hub != contributorProtocolVersion {
+		t.Errorf("Hub = %q, want %q", c.Hub, contributorProtocolVersion)
+	}
+}
+
+// TestRelayProtocolVersionMatchesHub is the drift guard, and the reason this
+// test file exists at all.
+//
+// The hub and bin/contributor-relay.sh ship from the same tree, so they speak
+// the same contributor-protocol version by construction — but that was only ever
+// a comment ("Keep in step with contributorProtocolVersion"), and it drifted:
+// #2600 shipped both at 1.1, #2671 bumped the hub to 1.2 and left the relay at
+// 1.1. The in-tree relay under-declared itself, and because nothing compared the
+// two versions, no surface said so. A comment cannot enforce this; this can.
+func TestRelayProtocolVersionMatchesHub(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("../../../bin/contributor-relay.sh")
+	if err != nil {
+		t.Fatalf("read bin/contributor-relay.sh: %v (if the relay moved, re-point this test rather than deleting it)", err)
+	}
+	m := regexp.MustCompile(`(?m)^const RELAY_PROTOCOL_VERSION = '([^']*)';`).FindSubmatch(raw)
+	if m == nil {
+		t.Fatal("could not find RELAY_PROTOCOL_VERSION in bin/contributor-relay.sh — if it was renamed, re-point this test in the same PR")
+	}
+	if got := string(m[1]); got != contributorProtocolVersion {
+		t.Errorf("bin/contributor-relay.sh declares protocol %q but the hub speaks %q.\n"+
+			"They ship from the same tree and must match. Bumping contributorProtocolVersion "+
+			"means bumping RELAY_PROTOCOL_VERSION in the same PR (kubestellar/hive#2547 / #2567).", got, contributorProtocolVersion)
+	}
+}
+
+// TestRelayComparesHubProtocolVersion asserts the client half of the criterion:
+// "BOTH sides" must be able to detect an incompatible peer. The hub-side
+// comparison is covered above; this one pins that the relay does not merely log
+// the hub's version but actually compares it — and that it does so advisorily.
+func TestRelayComparesHubProtocolVersion(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("../../../bin/contributor-relay.sh")
+	if err != nil {
+		t.Fatalf("read bin/contributor-relay.sh: %v", err)
+	}
+	src := string(raw)
+	for _, want := range []string{
+		"function classifyPeerProtocol",                  // the relay-side mirror of the hub verdict vocabulary
+		"function warnOnProtocolDrift",                   // the operator-facing report
+		"warnOnProtocolDrift(hub, msg.protocol_version)", // actually wired into auth_ok
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("bin/contributor-relay.sh missing %q — the client half of peer detection (#2547) is not wired", want)
+		}
+	}
+	// The relay must keep working through a mismatch: no exit, no refusal to ask
+	// for work. If a future change makes drift fatal, this fails and the author
+	// has to justify stranding contributors on an advisory signal.
+	drift := funcSourceJS(t, src, "warnOnProtocolDrift")
+	for _, forbidden := range []string{"process.exit", "return false", "throw "} {
+		if strings.Contains(drift, forbidden) {
+			t.Errorf("warnOnProtocolDrift contains %q — a protocol mismatch is ADVISORY on both sides; "+
+				"a relay that stops on a version difference strands its contributor (#2547 backward-compat criterion)", forbidden)
+		}
+	}
+}
+
+// funcSourceJS extracts a brace-balanced JS function body from the relay source
+// so a test can assert on one function rather than the whole 4k-line file.
+func funcSourceJS(t *testing.T, src, name string) string {
+	t.Helper()
+	start := strings.Index(src, "function "+name+"(")
+	if start < 0 {
+		t.Fatalf("function %s not found in relay source", name)
+	}
+	open := strings.Index(src[start:], "{")
+	if open < 0 {
+		t.Fatalf("no body for %s", name)
+	}
+	depth := 0
+	for i := start + open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("unbalanced braces extracting %s", name)
+	return ""
+}
+
+// TestProtocolCompatIsNotReadBySelection is the source-level no-routing guard,
+// mirroring TestSelectionPathsDoNotReadDeclaredCapabilities (#3815). A declared
+// protocol version is client-controlled text; if selection ever consults it, a
+// contributor loses work for a self-reported string, which is precisely the
+// failure #2547 names ("routing on a value the client controls").
+func TestProtocolCompatIsNotReadBySelection(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("contribute_ws.go")
+	if err != nil {
+		t.Fatalf("read contribute_ws.go: %v", err)
+	}
+	src := string(raw)
+	// Positive control: the comparison genuinely lives in this file, so a read
+	// inside a selection body would be visible to the scan below.
+	if !strings.Contains(src, "peerProtocolCompat(") {
+		t.Fatal("contribute_ws.go no longer derives the protocol comparison — if it moved, re-point this test rather than deleting it")
+	}
+	for _, name := range []string{"selectTask", "RequeueContributorTask"} {
+		body := selectionFuncBody(t, src, name)
+		if name == "selectTask" && !strings.Contains(body, "candidates") {
+			t.Fatal("extracted selectTask body has no candidate collection — extraction is wrong; fix the test")
+		}
+		for _, forbidden := range []string{"peerProtocolCompat", "classifyPeerProtocol", "ProtocolCompat", "RelayProtocolVersion", "protoPeer"} {
+			if strings.Contains(body, forbidden) {
+				t.Errorf("%s references %s — the peer-protocol comparison is OBSERVABILITY, not routing "+
+					"(kubestellar/hive#2547 DECLARE/ROUTE split). If routing has now been decided and recorded "+
+					"by a maintainer, update this test in that same PR; otherwise remove the read.", name, forbidden)
+			}
+		}
+	}
+}
+
+// TestWS_IncompatiblePeerIsReportedNotRejected is the behavioural half of the
+// same guard, and the acceptance criterion that matters most here: "a client
+// that declares nothing keeps receiving exactly the work it receives today. No
+// existing relay loses assignments because it was written before the change."
+//
+// A client declaring a MAJOR-incompatible version — the worst verdict — must
+// still authenticate, and the mismatch must be VISIBLE to the operator rather
+// than enforced against the client.
+func TestWS_IncompatiblePeerIsReportedNotRejected(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, cid := registerWSUser(t, s, "proto-mismatch-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: token,
+		CLIBackend:        "claude",
+		// A major-version mismatch: the loudest verdict the hub can reach.
+		Capabilities: &ContributorCapabilities{RelayProtocolVersion: "99.0"},
+	})
+	authOK := readMsg(t, conn)
+	if authOK.Type != "auth_ok" {
+		t.Fatalf("a protocol-incompatible client MUST still be admitted (#2547: compatibility is carried by the "+
+			"defaults, not by rejection) — got %s: %s", authOK.Type, authOK.Reason)
+	}
+
+	fc := waitForClanker(t, s, cid)
+	if fc.Protocol == nil {
+		t.Fatal("FleetClanker.Protocol is nil — the operator has no way to see the mismatch")
+	}
+	if fc.Protocol.Verdict != protoPeerIncompatible {
+		t.Errorf("Verdict = %q, want %q", fc.Protocol.Verdict, protoPeerIncompatible)
+	}
+	if !fc.Protocol.Mismatch {
+		t.Error("Mismatch = false for a major-version difference")
+	}
+	if fc.Protocol.Hub != contributorProtocolVersion || fc.Protocol.Peer != "99.0" {
+		t.Errorf("Protocol = %+v, want hub=%q peer=%q", fc.Protocol, contributorProtocolVersion, "99.0")
+	}
+}
+
+// TestWS_UnversionedPeerIsQuiet asserts the backward-compatible default: an
+// existing relay that declares no version is surfaced as "unknown" with no
+// mismatch, and is otherwise untouched. This is the case that must never
+// regress — it is every relay written before #2567, including downstream ones
+// the project does not know about.
+func TestWS_UnversionedPeerIsQuiet(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, cid := registerWSUser(t, s, "proto-legacy-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	// Exactly today's wire: no capabilities, no protocol_version.
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: token, CLIBackend: "claude"})
+	if authOK := readMsg(t, conn); authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+	}
+
+	fc := waitForClanker(t, s, cid)
+	if fc.Capabilities != nil {
+		t.Errorf("an unversioned client must still surface nil capabilities, got %+v", fc.Capabilities)
+	}
+	if fc.Protocol == nil {
+		t.Fatal("Protocol is nil — the hub's own version should be reported even when the client declared none")
+	}
+	if fc.Protocol.Verdict != protoPeerUnknown {
+		t.Errorf("Verdict = %q, want %q", fc.Protocol.Verdict, protoPeerUnknown)
+	}
+	if fc.Protocol.Mismatch {
+		t.Error("an unversioned client must NOT be flagged as a mismatch — silence is not a claim of incompatibility (#2547)")
+	}
+	if fc.Protocol.Peer != "" {
+		t.Errorf("Peer = %q, want empty for an unversioned client", fc.Protocol.Peer)
+	}
+}
+
+// TestWS_TopLevelProtocolVersionIsCompared covers the version-only client: a
+// relay that sends protocol_version at the top level but no capabilities object
+// (the shape #2567 documents). The hub folds it into the declaration, so the
+// comparison must see it too.
+func TestWS_TopLevelProtocolVersionIsCompared(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	token, cid := registerWSUser(t, s, "proto-toplevel-user")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: token,
+		CLIBackend:        "claude",
+		ProtocolVersion:   "99.0",
+	})
+	if authOK := readMsg(t, conn); authOK.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOK.Type, authOK.Reason)
+	}
+
+	fc := waitForClanker(t, s, cid)
+	if fc.Protocol == nil || fc.Protocol.Verdict != protoPeerIncompatible {
+		t.Fatalf("top-level protocol_version was not compared: %+v", fc.Protocol)
+	}
+}
+
+// TestOpsPage_ProtocolMismatchIsVisibleAndAdvisory asserts the operator surface.
+// The comparison is worthless if it only exists in a struct — the criterion is
+// that an operator can SEE an incompatible peer. It must also stay labelled
+// advisory at the point of use, for the same reason DECLARE is: a
+// warning-coloured line an operator cannot act on invites them to invent a
+// remedy the hub never asked for.
+func TestOpsPage_ProtocolMismatchIsVisibleAndAdvisory(t *testing.T) {
+	body := renderContributePage(t)
+	for _, want := range []string{
+		"function protocolLine",                  // the renderer exists
+		"clanker-proto",                          // stable hook class
+		"protocolLine(c.protocol)",               // wired into the clanker row
+		"the client is served exactly as before", // advisory framing at the point of use
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("ops page missing %q — an incompatible peer must be visible to the operator, and visibly advisory (#2547)", want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1614,6 +1614,13 @@ type FleetClanker struct {
 	// agent roles. It is shown to owner/read-write viewers in the fleet row; the
 	// server-side mutation endpoint remains the enforcement boundary.
 	AgentRoleGrants []string `json:"agent_role_grants,omitempty"`
+	// Protocol compares the contributor-protocol version this client DECLARED
+	// against the one this hub speaks (#2547 peer-compatibility criterion,
+	// building on the versions #2567 put on the wire). Always set — an
+	// unversioned relay reports verdict "unknown", which is a supported state,
+	// not a fault. Derived per snapshot from Capabilities.RelayProtocolVersion;
+	// it stores nothing new and, like Capabilities, is never routed or gated on.
+	Protocol *ProtocolCompat `json:"protocol,omitempty"`
 }
 
 // FleetWorkItem is a read-only view of one in-flight task the fleet is working,
@@ -1683,6 +1690,16 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 			capsCopy := *c.capabilities
 			fc.Capabilities = &capsCopy
 		}
+		// #2547 peer-compatibility: derive the hub-vs-client protocol comparison
+		// from the version already declared above. Always present so the operator
+		// row can show the hub's own version even when the client declared none —
+		// a bare "proto 1.1" chip with nothing to compare it against was the gap.
+		declaredVersion := ""
+		if c.capabilities != nil {
+			declaredVersion = c.capabilities.RelayProtocolVersion
+		}
+		compat := peerProtocolCompat(declaredVersion)
+		fc.Protocol = &compat
 		if c.profile != nil {
 			fc.ContributorID = c.profile.ContributorID
 			fc.GitHubUsername = c.profile.GitHubUsername
@@ -2080,6 +2097,25 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if !declared.IsZero() {
 				c := declared
 				caps = &c
+			}
+
+			// #2547 (peer-compatibility criterion): compare the declared version
+			// with ours and say so ONCE, at the log level the verdict deserves, so
+			// "an old relay against a new hub" is legible in the hub log instead of
+			// only discoverable by watching it misbehave. This is a REPORT, not a
+			// gate — admission continues unchanged for every verdict, including
+			// protoPeerIncompatible, because compatibility here has to be carried by
+			// the defaults (there is no negotiation to carry it) and rejecting on a
+			// client-declared string would strand relays written before any change.
+			switch verdict := classifyPeerProtocol(declared.RelayProtocolVersion); verdict {
+			case protoPeerIncompatible, protoPeerMalformed:
+				h.logger.Warn("[contribute-ws] contributor protocol mismatch (advisory; client still served)",
+					"contributor", profile.ContributorID, "verdict", verdict,
+					"client_version", declared.RelayProtocolVersion, "hub_version", contributorProtocolVersion)
+			case protoPeerOlder, protoPeerNewer:
+				h.logger.Info("[contribute-ws] contributor protocol drift (advisory; client still served)",
+					"contributor", profile.ContributorID, "verdict", verdict,
+					"client_version", declared.RelayProtocolVersion, "hub_version", contributorProtocolVersion)
 			}
 
 			contributor = &ContributorConnection{


### PR DESCRIPTION
## What

Makes an incompatible contributor-protocol peer **detectable from both sides**, instead of only discoverable by watching it misbehave.

Refs #2547 — **no `Fixes`.** This is the peer-compatibility acceptance criterion, not ROUTE. ROUTE stays open and untouched.

## The criterion this closes

> Either the protocol gains a way for both sides to detect an incompatible peer, or it is documented that compatibility is managed out of band and how.

DECLARE (#2659/#2600, pinned by #3815, documented by #3830) shipped the *declaration*. #2567 gave each side a version to **state**. Neither side ever **compared** them, so the sentence from the issue body is still literally true today:

> with no version on either side, the only way to learn that an old relay is talking to a new hub is to watch it misbehave

The ops row renders the client's declared `proto 1.1` — with nothing to compare it against.

## The drift already happened

This is the part that convinced me it was worth doing:

| | hub | relay |
|---|---|---|
| #2600 | `1.1` | `1.1` |
| #2671 (`credential_after_accept`) | **`1.2`** | `1.1` |

`bin/contributor-relay.sh` carried an explicit `Keep in step with contributorProtocolVersion` comment. Nothing enforced it, and the in-tree relay has under-declared itself ever since — while `v2/docs/contributor-relay.md` said "Since protocol 1.2 the relay self-reports…". A comment cannot hold that invariant.

## What changed

**One comparison, one vocabulary, both sides.** `MAJOR.MINOR` → `unknown` / `current` / `older` / `newer` / `incompatible` / `malformed`. The verdict always describes *the peer*, so the same `older` means "the hub is older" on the relay and "the client is older" on the hub; every message names both versions explicitly so it cannot be misread.

**Hub.** `FleetClanker.Protocol` carries hub version, peer version, verdict and operator prose. The ops row shows `protocol: client 1.1 · hub 1.2 · older than this hub`; the hub log records the verdict at connect. Derived per snapshot from the capability the client already declares — no new connection state, and no new field on the wire in either direction.

**Relay.** Compares the hub's advertised version instead of only logging it, and prints one advisory line per hub on the contributor's own terminal. That is the half a hub log cannot deliver: whoever runs the relay is usually not whoever reads the hub.

```
Protocol incompatible: hub 2.0 differs from this relay 1.2 in MAJOR version — the wire
contract differs and behaviour is undefined; consider updating the relay. Continuing
normally — this is advisory and nothing is gated on it.
```

**The drift, fixed and pinned.** The relay moves to `1.2` — it already handles the `token_refresh` credential delivery that version denotes — and the two constants are now pinned in step from *both* sides (`TestRelayProtocolVersionMatchesHub` in Go, and a Go-source-reading test in `contributor-relay.test.js`), so the next bump either happens on both sides or fails the build.

## The line this holds

**Nothing is gated, in either direction.** A drifted or even majorly-incompatible relay authenticates, is admitted, and receives exactly the work it received before. A relay that sees a hub version it does not recognise keeps working normally.

A declared version is self-reported client text. Acting on it would be *routing on a value the client controls* — the failure mode the issue names, where a mis-declaring client produces a fleet-level symptom that presents as a hub bug. So this stays on the same side of the #3815 line as DECLARE, and is pinned the same way:

- `TestProtocolCompatIsNotReadBySelection` — `selectTask` / `RequeueContributorTask` may not even mention the comparison. Carries the same instruction as the capability guard: *if routing has now been decided and recorded by a maintainer, update this test in that same PR.*
- `TestWS_IncompatiblePeerIsReportedNotRejected` — a client declaring a **major** mismatch, the loudest verdict reachable, still gets `auth_ok` and is served.
- Relay side: `warnOnProtocolDrift` may not contain `process.exit` / `throw`, and a behavioural test asserts a mismatch leaves `authFailed`, `authenticated` and the socket untouched. A relay that stopped on a version difference would strand its own contributor over an advisory signal.

## Backward compatibility

A client that declares nothing reads as `unknown`, is **not** flagged as a mismatch, and renders nothing. The issue is emphatic that silence must never be read as a claim of incompatibility, and that compatibility has to be carried by the defaults since there is no negotiation to carry it. `TestWS_UnversionedPeerIsQuiet` pins the whole shape: nil capabilities, verdict `unknown`, `mismatch` false, empty peer.

Matching versions also render nothing, so a healthy fleet stays exactly as quiet as it is today — and the warning means something when it does appear.

## Handling of client-controlled data

`relay_protocol_version` is the one client-controlled string reaching this payload:

- **Bounded** to 32 runes, rune-safe. Nothing obliges a relay to keep it short.
- **Never interpolated into the operator prose.** `Detail` is server-authored and names only the hub's own constant; the client's value travels separately in `Peer` and is escaped at render. A hostile version string cannot dress itself up as a hub statement on an operator's screen.
- **Strictly parsed.** `1.2.3`, `v1.2`, `1`, `1.x` land on `malformed` rather than being coerced into a comparison that would report a confident, wrong verdict.

## Docs

`v2/docs/contributor-relay.md` gains a **Protocol compatibility** section: what is compared, what each side shows, what MAJOR vs MINOR means, and — stated plainly — that nothing is gated on it, with a pointer to the server-side controls that *are* enforced if an operator actually needs to shape the queue.

## Tests

`v2/pkg/dashboard/contribute_protocol_compat_test.go` (11 tests) and 3 new tests in `bin/contributor-relay.test.js`. Full `pkg/dashboard` suite green (51s); `node bin/contributor-relay.test.js` 69/69.

### Regression replay

Each change neutered, the named test confirmed failing, then restored green.

| # | Neutered | Test that caught it |
|---|---|---|
| 1 | relay back to `1.1` | `TestRelayProtocolVersionMatchesHub` |
| 2 | `Detail` built from raw client text | `TestPeerProtocolCompat_HandlesHostileDeclaredVersion` |
| 3 | length bound removed (554 runes through) | same |
| 4 | `unknown` counted as a mismatch | `TestWS_UnversionedPeerIsQuiet`, `TestPeerProtocolCompat_MismatchFlag` |
| 5 | hub sends `auth_failed` on incompatible | `TestWS_IncompatiblePeerIsReportedNotRejected` |
| 6 | `classifyPeerProtocol` read inside `selectTask` | `TestProtocolCompatIsNotReadBySelection` |
| 7 | ops row stops rendering the line | `TestOpsPage_ProtocolMismatchIsVisibleAndAdvisory` |
| 8 | relay `process.exit(1)` on incompatible | `TestRelayComparesHubProtocolVersion` |
| 9 | relay drops socket / fails auth on drift | relay: "never changes relay behaviour" |
| 10 | relay warns on every reconnect | same (dedupe assertion) |
| 11 | relay version drifts (JS half) | relay: "declares the same protocol version" |

## What this deliberately does not do

No task-side requirements vocabulary, no dispatch change, no capability read anywhere in selection. The three ROUTE design questions in #2547 are still open for the maintainer and the downstream reporter; nothing here presumes an answer to any of them.

Separately open from me and independent of this: #3901 (failure attribution), which touches `contribute_protocol.go` and `contribute_ws.go` in different places. Either can merge first; I'll rebase the other.
