### PR TITLE
🔒 fix(scheduler): stop handing every agent a live GitHub token in its kick prompt (#1861)

### DIFF
--- a/v2/pkg/scheduler/gh_auth_instructions_test.go
+++ b/v2/pkg/scheduler/gh_auth_instructions_test.go
@@ -1,0 +1,113 @@
+package scheduler
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// kubestellar/hive#1861 asks that agents hold no GitHub token material at all.
+// The proxy-side injection half of that issue is deferred (it needs attested
+// identity first — #3841/N7, and the #3833 keypair), but the container path
+// already reaches the goal without it: the image installs bin/gh-wrapper.sh AS
+// `gh` (v2/Dockerfile: COPY bin/gh-wrapper.sh /usr/local/bin/gh) and the wrapper
+// exports the agent's tier-scoped token from HIVE_AGENT_TOKEN_CACHE itself,
+// before the agent's command runs.
+//
+// So the kick prompt has no reason to hand the agent a token, and every reason
+// not to. These pin that it does not — the container-path twin of the
+// native-path guard in bin/test_gh_auth_native_no_cat.sh (#3842/#3889).
+
+func ghAuthBlock(t *testing.T) string {
+	t.Helper()
+	s := New(&config.Config{
+		Project: config.ProjectConfig{Org: "org", Repos: []string{"r"}},
+	}, testLogger())
+	block := s.ghAuthInstructions()
+	// Positive control: we are looking at the real authentication block, so a
+	// silent rename/emptying cannot make the assertions below vacuously pass.
+	if !strings.Contains(block, "## Project Authentication") {
+		t.Fatalf("ghAuthInstructions no longer returns the authentication block; got %q", block)
+	}
+	return block
+}
+
+// The load-bearing one. A token on a command line the agent types is a token in
+// the agent's transcript and in whatever it echoes back — one prompt injection
+// from exfiltration. This is the same exposure #3889 removed from the
+// native-install prompt; it differs only in blast radius (tier-scoped here,
+// fleet-wide there), not in kind.
+func TestGHAuthInstructions_NeverHandsTheAgentAToken(t *testing.T) {
+	block := ghAuthBlock(t)
+
+	// No token cache path of any kind, per-agent or shared — not even inside a
+	// prohibition. Naming the shared cache in order to forbid it still tells an
+	// agent where it lives, and #1861's "Why now" is precisely an agent
+	// DISCOVERING that path under pressure when its push failed. The prohibition
+	// below works without a map to the thing being prohibited.
+	for _, forbidden := range []string{
+		"/var/run/hive-metrics/agent-tokens",
+		"gh-app-token.cache",
+		"gh-token-",
+		"HIVE_AGENT_TOKEN_CACHE",
+	} {
+		if strings.Contains(block, forbidden) {
+			t.Errorf("the kick prompt names a token path (%q). Agents must not be told where credentials live "+
+				"(kubestellar/hive#1861): gh-wrapper.sh already applies the scoped token per invocation, so this "+
+				"instruction is redundant AND puts a live credential in the agent's transcript.", forbidden)
+		}
+	}
+
+	// No instruction to read a secret, whatever the path. Catches a reworded
+	// reintroduction that the literal list above would miss.
+	readsASecret := regexp.MustCompile(`(?i)\$\(\s*cat\b|\bcat\s+/var/run|\bexport\s+GH_TOKEN\s*=`)
+	if m := readsASecret.FindString(block); m != "" {
+		t.Errorf("the kick prompt tells the agent to read or export a credential (matched %q). "+
+			"The hive authenticates gh and git on the agent's behalf; nothing here should ask the agent to "+
+			"fetch, echo, or export one (kubestellar/hive#1861).", m)
+	}
+}
+
+// The instruction must still SAY something about gh, or "no token handling"
+// silently becomes "no guidance" and an agent invents its own auth — which is
+// how the shared-cache read was discovered in the field (#1861's "Why now").
+func TestGHAuthInstructions_StillTellsTheAgentGHIsAuthenticated(t *testing.T) {
+	block := ghAuthBlock(t)
+
+	for _, want := range []string{
+		"gh CLI",                 // the tool is still addressed
+		"already handled",        // and stated to be authenticated for them
+		"do NOT export GH_TOKEN", // with the trap named explicitly
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("gh auth instructions missing %q — the agent needs to know gh works WITHOUT setup, "+
+				"or it will improvise a credential", want)
+		}
+	}
+
+	// git's half is unchanged and must stay: it is the same promise for the
+	// other tool class, served by the credential helper.
+	if !strings.Contains(block, "credential helper") {
+		t.Error("the git bullet lost its credential-helper promise — both tool classes must state that auth is automatic")
+	}
+}
+
+// A Copilot-backed agent that exports GH_TOKEN can lose its MODEL auth:
+// bin/agent-launch.sh leaves GH_TOKEN unset precisely because "Copilot CLI uses
+// GH_TOKEN for its own Copilot API auth, which rejects GitHub App
+// server-to-server tokens". The old block told agents to export it four lines
+// above admitting the Copilot CLI owns it. Keep the two consistent.
+func TestGHAuthInstructions_DoesNotContradictItselfOnGHTOKEN(t *testing.T) {
+	block := ghAuthBlock(t)
+
+	if strings.Contains(block, "export GH_TOKEN=") {
+		t.Fatal("the prompt sets GH_TOKEN while also telling the agent the Copilot CLI owns it — " +
+			"agent-launch.sh deliberately leaves it unset for that reason")
+	}
+	if !strings.Contains(block, "missing GH_TOKEN") {
+		t.Error("the prompt no longer reassures the agent that a missing GH_TOKEN is expected; " +
+			"without it an agent reads the empty variable as a broken session and starts hunting for a token")
+	}
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -260,7 +260,7 @@ func (s *Scheduler) substituteTemplateWithPolicy(template string, actionable *gi
 		"ISSUE_LIST":            lit(issueList),
 		"PR_LIST":               lit(prList),
 		"AUTHORIZED_REPOS":      lit(s.buildReposSection()),
-		"GH_AUTH":               lit(s.ghAuthInstructions(agentName)),
+		"GH_AUTH":               lit(s.ghAuthInstructions()),
 		"PROJECT_ORG":           lit(s.cfg.Project.Org),
 		"PROJECT_NAME":          lit(s.cfg.Project.Name),
 		"PROJECT_PRIMARY_REPO":  lit(fullPrimaryRepo),
@@ -645,7 +645,7 @@ func (s *Scheduler) buildSupervisorMessage(actionable *github.ActionableResult) 
 	b.WriteString("[agent:supervisor]\n")
 	b.WriteString(fmt.Sprintf("MONITORING PASS %s\n\n", now.Format("1/2 3:04 PM MST")))
 
-	b.WriteString(s.ghAuthInstructions("supervisor"))
+	b.WriteString(s.ghAuthInstructions())
 	b.WriteString(s.reposSection())
 
 	b.WriteString("ROLE: You are the SUPERVISOR. Your job is to MONITOR other agents, NOT to fix issues yourself.\n")
@@ -728,13 +728,40 @@ func (s *Scheduler) buildCIFailingList() string {
 }
 
 // ghAuthInstructions tells the agent how to authenticate each tool class.
-// The per-agent token file is 0600, owned by the agent's UID, and scoped to
-// the agent's trust tier — pointing gh at it preserves both enforcement
-// layers (tier-scoped token + proxy mode inspection). Never point agents at
-// the shared gh-app-token.cache: reading it skips the credential helper's
-// UID/mode gate and hands every agent an unscoped token.
-func (s *Scheduler) ghAuthInstructions(agentName string) string {
-	return fmt.Sprintf(`## Project Authentication
+//
+// The answer for every class is THE AGENT DOES NOTHING (#1861): git is served
+// by the credential helper, and gh by the wrapper the image installs AS `+"`gh`"+`
+// (v2/Dockerfile: COPY bin/gh-wrapper.sh /usr/local/bin/gh), which reads
+// HIVE_AGENT_TOKEN_CACHE and exports the agent's tier-scoped App token itself,
+// per invocation. No token material has to reach the agent for either tool.
+//
+// This block used to instruct every agent to run
+// `+"`export GH_TOKEN=$(cat .../agent-tokens/gh-token-<agent>.cache)`"+`, which was
+// wrong three ways:
+//
+//   - It put a live App installation token into the agent's OWN reasoning and
+//     transcript — the exact exposure #3842/#3889 removed from the native-install
+//     prompt, differing only in blast radius (tier-scoped here, fleet-wide there).
+//     A token in the transcript is one prompt injection from exfiltration, and
+//     #1861's whole goal is that agents hold no token material.
+//   - It was redundant. The wrapper had already injected the same token before
+//     the agent's command ran.
+//   - It could BREAK the session. bin/agent-launch.sh deliberately leaves
+//     GH_TOKEN unset because "Copilot CLI uses GH_TOKEN for its own Copilot API
+//     auth, which rejects GitHub App server-to-server tokens" — so a Copilot-
+//     backed agent following this instruction could lose model auth. The final
+//     bullet below already said the Copilot CLI owns that variable, contradicting
+//     the instruction four lines above it.
+//
+// Keep this block free of any token path or GH_TOKEN assignment. Both hive
+// tools authenticate the agent without its participation; anything that tells
+// an agent to fetch, read, echo or export a credential is a regression, and
+// TestGHAuthInstructions_NeverHandsTheAgentAToken pins that.
+// The agent name is no longer a parameter: nothing in this block is per-agent
+// any more, which is the point — there is no per-agent path for the agent to
+// read, because the hive applies the per-agent token on its behalf.
+func (s *Scheduler) ghAuthInstructions() string {
+	return `## Project Authentication
 
 - The GitHub App is the WRITE GATE. Every write to GitHub — opening or updating
   an issue or PR, commenting, and merging — goes through this hive's GitHub App
@@ -745,7 +772,7 @@ func (s *Scheduler) ghAuthInstructions(agentName string) string {
 - Writes are authored by the App bot identity, not a personal account. Do not
   set git user.name/user.email to a human, and do not pass 'gh pr create' or
   'git commit' an explicit --author: let the App identity stand.
-- To OPEN A PULL REQUEST, use `+"`hive-open-pr`"+` — the hive opens it with the
+- To OPEN A PULL REQUEST, use ` + "`hive-open-pr`" + ` — the hive opens it with the
   App token so it is authored by the App bot ("<slug>[bot]"), never the login user:
     hive-open-pr --repo <org>/<repo> --head <your-branch> --title "<title>" --body "<body with Fixes #N>"
   Do NOT open PRs with the GitHub MCP (create_pull_request / create_pull_request_with_copilot)
@@ -755,15 +782,19 @@ func (s *Scheduler) ghAuthInstructions(agentName string) string {
 - git push / git fetch: run them normally. A credential helper supplies the
   App-scoped push token automatically. Do NOT export GH_TOKEN for git and do
   NOT use HIVE_GITHUB_TOKEN (it is read-only; overriding breaks pushes).
-- gh CLI: export your per-agent token first:
-    export GH_TOKEN=$(cat /var/run/hive-metrics/agent-tokens/gh-token-%s.cache)
-  It is scoped to YOUR tier and is an App installation token. Never read another
-  agent's token file or the shared gh-app-token.cache.
-- A missing GH_TOKEN at session start is expected (the Copilot CLI owns that
-  variable) — it is never a blocker. All GitHub traffic flows through the
-  hive proxy either way.
+- gh CLI: just run ` + "`gh`" + `. Authentication is already handled for you — the hive
+  wraps every gh call and applies YOUR tier-scoped App token to it. You do not
+  need, and must not set up, any credential of your own: do NOT export GH_TOKEN,
+  and do NOT go looking for, read, or echo a token file — not one of your own,
+  not another agent's, not a shared one. There is no token file you are meant
+  to open. A token you put on a command line is a token in your transcript, and
+  exporting GH_TOKEN can break the Copilot CLI's own auth, which owns that
+  variable. If gh reports an auth problem, report it — do not go find a token.
+- A missing GH_TOKEN at session start is therefore expected and is never a
+  blocker — it is what "already handled for you" looks like from inside the
+  session. All GitHub traffic flows through the hive proxy either way.
 
-`, agentName)
+`
 }
 
 func (s *Scheduler) reposSection() string {
@@ -868,7 +899,7 @@ func (s *Scheduler) buildArchitectMessage(issues []github.Issue, actionable *git
 	b.WriteString("[agent:architect]\n")
 	b.WriteString("Full architect pass — refactor/perf scan across all repos.\n\n")
 
-	b.WriteString(s.ghAuthInstructions("architect"))
+	b.WriteString(s.ghAuthInstructions())
 
 	architectIssues := filterByLane(issues, "architect")
 	if len(architectIssues) > 0 {
@@ -922,7 +953,7 @@ func (s *Scheduler) buildOutreachMessage(actionable *github.ActionableResult) st
 	b.WriteString("[agent:outreach]\n")
 	b.WriteString(fmt.Sprintf("Full outreach pass. Time: %s\n\n", now.Format("1/2 3:04 PM MST")))
 
-	b.WriteString(s.ghAuthInstructions("outreach"))
+	b.WriteString(s.ghAuthInstructions())
 
 	b.WriteString("YOUR RESPONSIBILITIES:\n")
 	b.WriteString("  1. Open PRs on external repos to promote adoption (awesome-lists, adopters files, install guides)\n")
@@ -947,7 +978,7 @@ func (s *Scheduler) buildSecCheckMessage(actionable *github.ActionableResult) st
 	b.WriteString("[agent:sec-check]\n")
 	b.WriteString(fmt.Sprintf("Security review pass. Time: %s\n\n", now.Format("1/2 3:04 PM MST")))
 
-	b.WriteString(s.ghAuthInstructions("sec-check"))
+	b.WriteString(s.ghAuthInstructions())
 
 	b.WriteString("YOUR RESPONSIBILITIES:\n")
 	b.WriteString("  1. Scan repos for security vulnerabilities (OWASP top 10, dependency CVEs)\n")


### PR DESCRIPTION
## What

Stops the kick prompt handing every container-hosted agent a live GitHub App token. This is the **container-path twin of #3889**, and the part of #1861 that reaches the issue's stated goal — *"agents then need no token material at all"* — without waiting on proxy-side injection.

Refs #1861 — **no `Fixes`.** Item 1 (injection) stays deferred exactly as the 2026-08-14 triage recorded.

## The instruction

Every kick prompt (`${GH_AUTH}`, rendered for supervisor / architect / outreach / sec-check and every templated agent) said, verbatim:

```
- gh CLI: export your per-agent token first:
    export GH_TOKEN=$(cat /var/run/hive-metrics/agent-tokens/gh-token-<agent>.cache)
```

That is wrong three separate ways.

**1. It leaks a credential into the agent's own context.** A token the agent types is a token in its transcript and in anything it echoes — one prompt injection from exfiltration. This is precisely the exposure #3842/#3889 removed from the *native-install* prompt. It differs only in blast radius (tier-scoped here, fleet-wide there), not in kind. #1861 exists because agents should hold no token material, and the container path was still handing them some.

**2. It was redundant.** `v2/Dockerfile` installs the wrapper **as** `gh`:

```
COPY bin/gh-wrapper.sh /usr/local/bin/gh
```

and `bin/gh-wrapper.sh:76` already does `export GH_TOKEN="$(cat "$HIVE_AGENT_TOKEN_CACHE")"` before the agent's command runs. `HIVE_AGENT_TOKEN_CACHE` is set per agent by the manager (`v2/pkg/agent/manager.go:6209`). The token was applied whether or not the agent did anything.

**3. It could break the session.** `bin/agent-launch.sh:25-26` deliberately leaves `GH_TOKEN` unset:

> Do NOT export GH_TOKEN here — Copilot CLI uses GH_TOKEN for its own Copilot API auth, which rejects GitHub App server-to-server tokens.

So a Copilot-backed agent that followed this instruction could lose **model** auth. The prompt's very next bullet already said *"the Copilot CLI owns that variable"* — contradicting the instruction four lines above it.

## What changed

The block now states the truth for both tool classes — git via the credential helper, gh via the wrapper, nothing to set up — and names the traps **without naming any path**.

That last part is deliberate, and it's a correction to my own first draft. I initially kept the shared cache in the prohibition ("do NOT read … not the shared `gh-app-token.cache`"), and the new guard rejected it. It's right to reject: #1861's *"Why now"* is an agent **discovering** that path under pressure when its push failed, so a prohibition that cites the path still hands over the map. The prohibition works fine generically — *"There is no token file you are meant to open"* — plus a positive instruction for the failure case: *"If gh reports an auth problem, report it — do not go find a token."*

`ghAuthInstructions` also loses its `agentName` parameter. Nothing in the block is per-agent any more, and that absence is the point.

## Guards

`v2/pkg/scheduler/gh_auth_instructions_test.go`, mirroring `bin/test_gh_auth_native_no_cat.sh` on the native side:

- **No token path of any kind** — plus a regex for `$(cat`, `cat /var/run` and `export GH_TOKEN=`, so a *reworded* reintroduction is caught, not just a literal revert.
- **The gh guidance must still exist.** "No token handling" must not decay into "no guidance" — an agent with no instruction improvises its own auth, which is exactly how the shared-cache read was found in the field.
- **The prompt must not set `GH_TOKEN`** while also telling the agent Copilot owns it.
- **Positive control:** an emptied block fails loudly rather than passing vacuously.

### Regression replay

| # | Neutered | Caught by |
|---|---|---|
| 1 | old `export GH_TOKEN=$(cat …)` restored | `NeverHandsTheAgentAToken` (3 assertions) + `DoesNotContradictItselfOnGHTOKEN` |
| 2 | reworded as `GH_TOKEN=$(cat /opt/creds/tok)` | the `$(cat` regex |
| 3 | gh bullet silently dropped | `StillTellsTheAgentGHIsAuthenticated` |
| 4 | block emptied | positive control in the helper |

Each confirmed failing, then restored green.

## Scope

`pkg/scheduler` passes. I swept the tree for the same pattern: the only other hits are `v2/deploy/entrypoint.sh:691` (root-side *creation* of the token file — correct) and my own comment recording what was removed. No docs asserted the old flow.

`pkg/agent`'s `TestRestartWithBootstrap` fails identically on clean `upstream/v4` in my environment (tmux socket path length from a deep workspace path) — pre-existing, and `pkg/agent` is untouched here.

## What this deliberately does not do

No proxy-side auth injection, no `Authorization` stripping/rewriting, no minting layer. Item 1 still needs attested identity first (#3841/N7, and the #3833 Option D keypair) exactly as triaged — this neither implements nor presumes it. It just removes the reason an agent had to touch a token on the path where the hive already authenticates it.

Related open on this issue's actionable slice: #3888 (N7), #3889 (native prompt), #3926 (relay cache path). All three re-verified against current `v4` today while working on this — they still build and pass.
