### PR TITLE
🔒 sec(dashboard): scope style-src into its two halves, with written rationale (#3848 part 2)

### DIFF
--- a/v2/docs/adr/0015-csp-style-src-scope.md
+++ b/v2/docs/adr/0015-csp-style-src-scope.md
@@ -1,0 +1,100 @@
+# ADR-0015: Scope `style-src` as two directives and accept inline style attributes
+
+Status: Accepted
+
+## Context
+
+The dashboard's Content-Security-Policy carried one blanket `style-src 'self'
+'unsafe-inline'` ([securityHeaders](../../pkg/dashboard/server.go)). That single
+token covered two different things with two different futures, and hid the fact
+that only one of them is closable.
+
+[kubestellar/hive#3848](https://github.com/kubestellar/hive/issues/3848) asked
+for the two to be separated and for the remaining allowance to be either removed
+or accepted **with a written rationale**. This is that rationale.
+
+Measured on `v4` at the time of writing:
+
+| Inline style form | Count | Covered by a nonce or hash? |
+| --- | --- | --- |
+| `style="…"` attributes | 2061 | **No** |
+| `<style>` elements | 7 | Yes |
+
+The asymmetry is the whole decision. CSP's nonce and hash mechanisms apply to
+*elements* — `<style>` and `<script>`. There is no nonce form and no hash form
+for an attribute-level style. `style-src-attr` accepts only `'none'`,
+`'unsafe-inline'`, or `'unsafe-hashes'` plus hashes; and `'unsafe-hashes'` would
+mean enumerating a hash for each of 2061 distinct attribute values and
+regenerating them on every UI edit, which is neither reviewable nor
+maintainable. So for the attributes there is no policy that both permits them
+and constrains them: the realistic choice is `'unsafe-inline'` or deleting every
+inline style in the UI.
+
+A second constraint shapes the timing. `script-src` still carries
+`'unsafe-inline'` — that is the other half of #3848 and is staged behind an
+event-delegation refactor (437 inline `on*=` attributes in `static/index.html`,
+plus ~145 more built as strings inside the page's own JavaScript and injected
+through 169 `innerHTML`/`insertAdjacentHTML` sites; a nonce cannot cover any of
+them). **While inline script is permitted, tightening inline style buys no real
+security**: an attacker who can inject a `<style>` element into a page can
+inject a `<script>` element into the same page, and the script is strictly the
+more capable primitive. Hardening the weaker one first would be motion, not
+protection.
+
+## Decision
+
+Split the single `style-src` into the two directives CSP Level 3 provides, and
+state a different verdict for each.
+
+```
+style-src      'self' 'unsafe-inline'   ← CSP2 fallback, unchanged
+style-src-elem 'self' 'unsafe-inline'   ← the 7 <style> elements: CLOSABLE, staged
+style-src-attr 'unsafe-inline'          ← the 2061 attributes: ACCEPTED
+```
+
+- **`style-src-attr 'unsafe-inline'` is accepted, not staged.** It is not a
+  compromise awaiting a refactor; it is the end state unless the UI stops using
+  style attributes. No tripwire test guards it, because there is nothing to
+  trip.
+
+- **`style-src-elem 'self' 'unsafe-inline'` is staged.** `<style>` elements
+  accept hashes, and the hive serves only seven of them, all with deterministic
+  content — so this one can be closed with hashes computed once at startup. It
+  is deliberately sequenced *after* `script-src`, for the reason above.
+  `TestCSPStyleSrcElemUnsafeInlineIsStaged` pins that staged state and instructs
+  whoever closes it to invert the assertion, mirroring the `script-src` tripwire
+  that #3844 established.
+
+- **The `style-src` fallback stays.** Browsers without CSP3 support ignore
+  `style-src-elem` / `style-src-attr` and fall back to it, so the effective
+  policy is identical on old and new browsers. This split therefore names the
+  decision without changing what any browser enforces today.
+
+## Consequences
+
+**Easier.** Closing the `<style>` half becomes a bounded, one-directive change
+with a test already watching it, instead of an unscoped "remove unsafe-inline
+from style-src" that would also have to answer for 2061 attributes. The two
+halves can now move independently.
+
+**Honest.** The policy states which allowance is permanent and which is
+temporary. A reader of the header — or of an external CSP audit — can no longer
+mistake the accepted attribute allowance for unfinished work, or the staged
+element allowance for a settled decision.
+
+**Residual risk, stated plainly.** With `style-src-attr 'unsafe-inline'`, an
+attacker who achieves HTML injection can style injected markup. That enables UI
+redressing (overlaying or hiding page content to mislead an operator) and, on
+some engines, CSS-based inference of page content. It does **not** enable script
+execution. This risk is accepted for as long as the UI uses inline style
+attributes.
+
+It is worth being clear that this residual is currently dominated by a larger
+one: while `script-src 'unsafe-inline'` remains, HTML injection already yields
+script execution, which subsumes everything the style allowance permits. The
+style residual only becomes the *governing* risk once #3848's `script-src` half
+lands — which is precisely why the element half is sequenced behind it rather
+than in front of it.
+
+**Harder.** Nothing meaningfully. The extra directives lengthen the header by
+about 70 bytes on every response.

--- a/v2/docs/adr/README.md
+++ b/v2/docs/adr/README.md
@@ -50,3 +50,4 @@ What becomes easier, harder, safer, or riskier because of this decision?
 - [ADR-0012: Skill registry and BYO-agent contract](0012-skill-registry.md)
 - [ADR-0013: CEL triggers over normalized forge events](0013-cel-triggers.md)
 - [ADR-0014: Hub/spoke fleet over heartbeat callbacks](0014-hub-spoke.md)
+- [ADR-0015: Scope `style-src` as two directives and accept inline style attributes](0015-csp-style-src-scope.md)

--- a/v2/pkg/dashboard/csp_style_src_test.go
+++ b/v2/pkg/dashboard/csp_style_src_test.go
@@ -1,0 +1,184 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// csp_style_src_test.go covers the style-src half of kubestellar/hive#3848.
+//
+// #3844 left ONE blanket `style-src 'self' 'unsafe-inline'` covering two things
+// with different futures, and #3848 asked for them to be separated and for the
+// remainder to be removed or accepted with a written rationale. The split and
+// the rationale are ADR-0015; these tests pin both.
+//
+// The asymmetry that drives everything here: CSP has no nonce form and no hash
+// form for an ATTRIBUTE-level style, so the 2061 inline style="" attributes
+// cannot be constrained by any policy that also permits them — that allowance is
+// ACCEPTED. Inline <style> ELEMENTS do take hashes and there are only seven, so
+// that half is CLOSABLE and merely staged.
+
+// servedCSP renders the security headers the way every response gets them.
+func servedCSP(t *testing.T) string {
+	t.Helper()
+	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
+	handler := s.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	csp := rec.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("Content-Security-Policy header missing")
+	}
+	return csp
+}
+
+// TestCSPStyleSrcScopedIntoElemAndAttr is the #3848 part-2 deliverable itself:
+// style-src is no longer one blanket token. All three directives must be
+// present — the two CSP3 halves plus the CSP2 fallback that older browsers use
+// instead of them.
+func TestCSPStyleSrcScopedIntoElemAndAttr(t *testing.T) {
+	csp := servedCSP(t)
+
+	for _, name := range []string{"style-src", "style-src-elem", "style-src-attr"} {
+		if cspDirective(csp, name) == "" {
+			t.Errorf("CSP is missing %q — the two style halves must be scoped separately (#3848, ADR-0015)\n got: %s", name, csp)
+		}
+	}
+
+	// The fallback must keep permitting what the CSP3 halves permit, or a
+	// browser without style-src-elem/-attr support enforces a STRICTER policy
+	// than the one this project reasoned about — i.e. the split would silently
+	// unstyle the UI on exactly the older browsers nobody tests.
+	fallback := cspDirective(csp, "style-src")
+	if !strings.Contains(fallback, "'self'") || !strings.Contains(fallback, "'unsafe-inline'") {
+		t.Errorf("style-src fallback must stay permissive for pre-CSP3 browsers, got %q", fallback)
+	}
+}
+
+// TestCSPStyleSrcAttrIsAcceptedNotStaged pins the half that is NOT going away.
+//
+// There is deliberately no tripwire here, unlike style-src-elem below: closing
+// this would mean deleting every inline style attribute in the UI, and CSP
+// offers nothing in between. If a future change removes 'unsafe-inline' from
+// style-src-attr, this test fails and that is CORRECT — it means the UI's inline
+// styles just stopped applying.
+func TestCSPStyleSrcAttrIsAcceptedNotStaged(t *testing.T) {
+	attr := cspDirective(servedCSP(t), "style-src-attr")
+	if attr == "" {
+		t.Fatal("CSP must declare style-src-attr explicitly (#3848, ADR-0015)")
+	}
+	if !strings.Contains(attr, "'unsafe-inline'") {
+		t.Errorf("style-src-attr lost 'unsafe-inline' (got %q).\n"+
+			"The dashboard renders ~2000 inline style=\"\" attributes and CSP has NO nonce or hash "+
+			"form for attribute styles, so this is an ACCEPTED allowance (ADR-0015), not staging. "+
+			"If the UI genuinely stopped using style attributes, update ADR-0015 in the same PR.", attr)
+	}
+	// 'unsafe-hashes' would mean enumerating a hash per distinct attribute value
+	// and regenerating them on every UI edit — unreviewable, and rejected in
+	// ADR-0015. Its appearance means someone tried to "tighten" this into a
+	// maintenance trap.
+	if strings.Contains(attr, "'unsafe-hashes'") {
+		t.Errorf("style-src-attr must not use 'unsafe-hashes' (got %q) — ADR-0015 rejects "+
+			"per-attribute hash enumeration as unmaintainable", attr)
+	}
+}
+
+// TestCSPStyleSrcElemUnsafeInlineIsStaged is the TRIPWIRE for the half that IS
+// closable, mirroring TestCSPScriptSrcUnsafeInlineIsStaged for script-src.
+//
+// The hive serves seven inline <style> elements with deterministic content, so
+// this can be closed with hashes computed once at startup. It is staged behind
+// script-src on purpose: while inline SCRIPT is permitted, tightening inline
+// STYLE buys nothing, because anyone who can inject a <style> element can inject
+// a <script> element, which is strictly more capable.
+//
+// When that ordering is satisfied and the hashes land, this test FAILS by
+// design. Do not relax it — INVERT it, so the closed state is pinned in turn.
+func TestCSPStyleSrcElemUnsafeInlineIsStaged(t *testing.T) {
+	elem := cspDirective(servedCSP(t), "style-src-elem")
+	if elem == "" {
+		t.Fatal("CSP must declare style-src-elem explicitly (#3848, ADR-0015)")
+	}
+	if !strings.Contains(elem, "'self'") {
+		t.Errorf("style-src-elem must allowlist 'self' for same-origin stylesheets, got %q", elem)
+	}
+	if !strings.Contains(elem, "'unsafe-inline'") {
+		t.Fatalf("style-src-elem no longer has 'unsafe-inline' (got %q).\n"+
+			"This is GOOD NEWS: the closable half of #3848's style-src work appears to have landed.\n"+
+			"Invert this test into an assertion that 'unsafe-inline' is ABSENT (and that the "+
+			"expected 'sha256-...' sources are present), so it can never come back, and update "+
+			"ADR-0015's status in the same PR.", elem)
+	}
+}
+
+// TestCSPStyleSrcSplitIsBehaviourNeutralToday guards the one way this change
+// could have done harm: it is meant to NAME the decision, not alter enforcement.
+// A browser that honours the CSP3 halves and one that only honours the fallback
+// must both end up permitting exactly the same thing.
+func TestCSPStyleSrcSplitIsBehaviourNeutralToday(t *testing.T) {
+	csp := servedCSP(t)
+	fallback := cspDirective(csp, "style-src")
+	elem := cspDirective(csp, "style-src-elem")
+	attr := cspDirective(csp, "style-src-attr")
+
+	// Inline styles: permitted through the fallback, and through both halves.
+	for name, directive := range map[string]string{
+		"style-src": fallback, "style-src-elem": elem, "style-src-attr": attr,
+	} {
+		if !strings.Contains(directive, "'unsafe-inline'") {
+			t.Errorf("%s does not permit inline styles (%q) while the others do — "+
+				"the split must not change what any browser enforces (ADR-0015)", name, directive)
+		}
+	}
+	// Stylesheet URLs: 'self' on the fallback and on the element half. Attribute
+	// styles have no URL source, so style-src-attr correctly carries none.
+	if !strings.Contains(elem, "'self'") || !strings.Contains(fallback, "'self'") {
+		t.Errorf("style-src/style-src-elem must both allowlist 'self'\n fallback=%q elem=%q", fallback, elem)
+	}
+	if strings.Contains(attr, "'self'") {
+		t.Errorf("style-src-attr carries 'self' (%q), which is meaningless for attribute "+
+			"styles — they have no URL source", attr)
+	}
+}
+
+// TestCSPStyleSrcRationaleIsWritten pins the DELIVERABLE, not just the header.
+//
+// #3848 accepts "keep 'unsafe-inline' with written rationale" as a legitimate
+// outcome for the attribute half — which makes the written rationale part of the
+// fix, not documentation of it. An undocumented 'unsafe-inline' is precisely the
+// state the issue was filed about, so a future edit that deletes or unlinks the
+// ADR while keeping the allowance must fail.
+func TestCSPStyleSrcRationaleIsWritten(t *testing.T) {
+	const adr = "../../docs/adr/0015-csp-style-src-scope.md"
+	body, err := os.ReadFile(adr)
+	if err != nil {
+		t.Fatalf("ADR-0015 is missing (%v).\nstyle-src-attr 'unsafe-inline' is ACCEPTED only because "+
+			"a written rationale exists (#3848); without it the allowance is undocumented again.", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"style-src-attr",   // the accepted half is named
+		"style-src-elem",   // and distinguished from the staged half
+		"Status: Accepted", // it is a decision, not a proposal
+		"Residual risk",    // what we are accepting is stated
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("ADR-0015 does not mention %q — the rationale must state what is accepted and why", want)
+		}
+	}
+
+	index, err := os.ReadFile("../../docs/adr/README.md")
+	if err != nil {
+		t.Fatalf("reading ADR index: %v", err)
+	}
+	if !strings.Contains(string(index), "0015-csp-style-src-scope.md") {
+		t.Error("ADR-0015 is not linked from the ADR index — an unlinked ADR is one nobody finds")
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -865,10 +865,17 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 		// SECURITY (#3315): script-src still carries 'unsafe-inline' because the
-		// dashboard is server-rendered HTML with ~400 inline on*= handlers and
+		// dashboard is server-rendered HTML with inline on*= handlers and
 		// several inline <script> blocks (static/index.html, api_contribute.go,
 		// the device-flow login page below). Dropping it today would blank the
-		// UI, so it is staged behind a nonce/handler refactor — see #3315.
+		// UI, so it is staged behind a nonce/handler refactor — see #3315/#3848.
+		// Measured on v4 for #3848: 437 inline on*= attributes in
+		// static/index.html plus ~145 more BUILT AS STRINGS inside the page's
+		// own JavaScript and injected through 169 innerHTML/insertAdjacentHTML
+		// sites. A nonce cannot cover ANY of them — nonces apply to <script>
+		// elements, never to event-handler attributes — so completing script-src
+		// is an event-delegation refactor of the SPA, not a nonce threading
+		// exercise. TestCSPScriptSrcUnsafeInlineIsStaged stays as the tripwire.
 		//
 		// What IS enforced here: the secret that 'unsafe-inline' used to expose
 		// is gone. The dashboard token is never rendered into the page (see
@@ -876,8 +883,30 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		// inline-script XSS has no token to steal from the served HTML.
 		// form-action 'self' is added to stop an injected <form> from posting
 		// credentials off-origin, which does NOT depend on inline scripts.
+		//
+		// style-src (#3848 part 2) is scoped as TWO directives rather than one
+		// blanket allowance, because the two halves have different futures:
+		//
+		//   style-src-attr 'unsafe-inline'  — the 2061 inline style="" attributes.
+		//     ACCEPTED, permanently, and not a staging compromise: CSP has no
+		//     nonce or hash form for attribute-level styles, so there is no
+		//     policy that both allows them and constrains them. Closing this
+		//     would mean deleting every style attribute in the UI. See
+		//     ADR-0015 for the rationale and the residual risk.
+		//
+		//   style-src-elem 'self' 'unsafe-inline' — the 7 inline <style> elements.
+		//     CLOSABLE, unlike the attributes: <style> elements do take hashes.
+		//     Left open today because tightening it while script-src still
+		//     allows inline script buys nothing — anyone who can inject <style>
+		//     can inject <script> — so it is sequenced AFTER script-src, where
+		//     it starts to matter. TestCSPStyleSrcElemUnsafeInlineIsStaged is
+		//     its tripwire, mirroring the script-src one.
+		//
+		// Both are listed AFTER the style-src fallback, which browsers without
+		// CSP3 support use instead; the effective policy is identical either way,
+		// so this split names the decision without changing behaviour.
 		w.Header().Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors "+frameAncestors)
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors "+frameAncestors)
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
## What

Closes **part 2** of #3848 — `style-src` is scoped into its two halves, with the written rationale the issue asked for.

**Part 1 (`script-src`) is not attempted here, and the tripwire stays armed.** I did measure it, and the measurement corrects the issue's own estimate — details at the bottom, because I think it changes how the work should be planned.

Refs #3848 — no `Fixes`.

## Part 2 — the asymmetry that decides it

One blanket `style-src 'self' 'unsafe-inline'` was covering two things with different futures. Measured on `v4`:

| form | count | nonce or hash possible? |
|---|---|---|
| `style="…"` attributes | **2061** | **no** |
| `<style>` elements | **7** | yes |

CSP's nonce and hash mechanisms apply to *elements*. There is no nonce form and no hash form for an attribute-level style — `style-src-attr` accepts only `'none'`, `'unsafe-inline'`, or `'unsafe-hashes'` plus hashes, and `'unsafe-hashes'` would mean enumerating a hash per distinct attribute value and regenerating them on every UI edit. So for the 2061 attributes there is no policy that both permits them and constrains them. The real choice is `'unsafe-inline'` or deleting every inline style in the UI.

The header now says that out loud:

```
style-src      'self' 'unsafe-inline'   ← CSP2 fallback, unchanged
style-src-elem 'self' 'unsafe-inline'   ← the 7 elements: CLOSABLE, staged
style-src-attr 'unsafe-inline'          ← the 2061 attributes: ACCEPTED
```

**ADR-0015** records the rationale and the residual risk: styling injected markup enables UI redressing and some CSS-based inference of page content; it does **not** enable script execution.

**Behaviour is unchanged today, deliberately.** Browsers without CSP3 fall back to `style-src`, and the two CSP3 halves permit exactly what it permits — so no browser enforces anything different. The value is structural: the permanent allowance is now distinguishable from the temporary one, and closing the element half becomes a one-directive change with a test already watching it.

## Why I staged the element half instead of closing it

Seven deterministic `<style>` blocks *could* be hash-pinned now. It would buy nothing: while `script-src 'unsafe-inline'` stands, anyone who can inject a `<style>` element can inject a `<script>` element, which is strictly the more capable primitive. Hardening the weaker one first is motion, not protection.

So it is sequenced **after** `script-src`, where it starts to matter, and `TestCSPStyleSrcElemUnsafeInlineIsStaged` is its tripwire — written in the same shape as the one #3844 established, including the instruction to **invert, not relax** it.

## Part 1 — a correction to the estimate

The issue and the existing tripwire comment both say "~400 inline `on*=` handlers". Measured:

- **437** inline `on*=` attributes in `static/index.html` (299 `onclick`, 97 `onchange`, 10 `oninput`, plus a tail), **and**
- **~145 more built as strings inside the page's own JavaScript**, injected through **169** `innerHTML`/`insertAdjacentHTML` sites.

That second group changes the *shape* of the work, not just its size. A nonce covers `<script>` elements and never covers event-handler attributes, so completing `script-src` is an event-delegation refactor of a 21k-line SPA — not the nonce-threading exercise the issue describes.

There is also a collision worth flagging with **#3863**: `static/index.html` is now served as a precomputed-at-startup gzipped, ETag'd immutable document, and a **per-request nonce is fundamentally incompatible with that**. Closing `script-src` on this page has to reach for hashes or delegation rather than nonces, or it undoes the 4× transfer win.

I left the tripwire untouched and put these measurements in the comment beside the CSP, so whoever picks up part 1 starts from the real shape.

## Tests

5 new in `v2/pkg/dashboard/csp_style_src_test.go`: the split exists; the attr half is accepted and must never grow `'unsafe-hashes'`; the elem tripwire; behaviour-neutrality across CSP2 and CSP3 browsers; and that the ADR exists and is indexed — the written rationale *is* the deliverable for the accepted half, so deleting it has to fail.

### Regression replay

| # | Neutered | Caught by |
|---|---|---|
| 1 | blanket `style-src` restored | 3 tests fail |
| 2 | elem half closed without inverting | the tripwire, with its instructions |
| 3 | `'unsafe-hashes'` added to attr | `AttrIsAcceptedNotStaged` |
| 4 | ADR deleted, allowance kept | `RationaleIsWritten` |

Each confirmed failing, then restored green. `pkg/dashboard` passes.
