### PR TITLE
🔒 sec(compose): put watchtower behind a filtered Docker socket proxy (#3865)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -63,6 +63,17 @@ jobs:
       - name: Supply-chain pin guard
         run: bash deploy/test_supply_chain_pins.sh
 
+      # #3865: watchtower bind-mounted /var/run/docker.sock — the full daemon
+      # API, including /exec, which reads the GitHub App private key out of the
+      # hive container with no escalation at all. The socket now sits behind a
+      # deny-by-default docker-socket-proxy on an internal-only network. Every
+      # property of that containment is one plausible edit from reverting (a
+      # bind mount added "to debug", a published 2375, EXEC=1 to unblock some
+      # other tool, the proxy attached to the network the hive runs on) and none
+      # of those break anything at runtime — so they need a gate, not a review.
+      - name: Docker-socket containment guard (#3865)
+        run: bash deploy/test_watchtower_socket_contract.sh
+
       # bin/gh-wrapper.sh is the merge gate standing behind the proxy hard-deny:
       # if its argument parsing is wrong, a prompt-injected agent merges
       # unvetted code. It had NO tests and matched no CI path filter. This

--- a/v2/deploy/test_watchtower_socket_contract.sh
+++ b/v2/deploy/test_watchtower_socket_contract.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Asserts the Docker-socket containment contract for the auto-update profile.
+#
+# kubestellar/hive#3865: watchtower bind-mounted /var/run/docker.sock, which is
+# the full daemon API — including /exec, which reads the GitHub App private key
+# out of the hive container with no escalation at all. The socket now sits
+# behind a deny-by-default docker-socket-proxy on an internal-only network.
+#
+# This tests the INVARIANT, not behaviour. Every property below is one edit away
+# from silently reverting: re-adding the bind mount "to debug something",
+# publishing 2375, adding EXEC=1 to make some other tool work, or attaching the
+# proxy to the default network where the hive container runs semi-trusted agent
+# code. None of those break anything at runtime, which is exactly why they need
+# a guard rather than a code review.
+#
+# What this canNOT assert, and the docs say so plainly: the proxy does not make
+# auto-update safe. CONTAINERS+POST is host-root-equivalent on its own
+# (POST /containers/create with HostConfig.Privileged, and
+# GET /containers/{id}/archive to read /secrets). See
+# v2/docs/auto-update-profile.md.
+#
+# Run: bash v2/deploy/test_watchtower_socket_contract.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+V2_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE="$V2_DIR/docker-compose.yaml"
+DOC="$V2_DIR/docs/auto-update-profile.md"
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== watchtower / docker-socket containment contract (#3865) ==="
+
+if [ ! -f "$COMPOSE" ]; then
+  echo "  FAIL: docker-compose.yaml exists — not found at $COMPOSE"
+  exit 1
+fi
+
+# Prefer a real compose render so the checks run against the RESOLVED config
+# (implicit `default` network membership included) rather than against text that
+# merely looks right. Fall back to a YAML parse when the docker CLI is absent,
+# so this still guards on a machine without Docker.
+RENDER=""
+if command -v docker >/dev/null 2>&1 && docker compose -f "$COMPOSE" --profile auto-update config >/dev/null 2>&1; then
+  RENDER="$(docker compose -f "$COMPOSE" --profile auto-update config 2>/dev/null)"
+  pass "compose file renders (docker compose config)"
+else
+  echo "  note: docker CLI unavailable — falling back to raw YAML parse"
+fi
+
+# python3 with PyYAML does the structural assertions; a raw grep would pass on a
+# commented-out line and fail on a reordered key.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  SKIP: python3 unavailable — cannot make structural assertions"
+  exit 0
+fi
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "  SKIP: PyYAML unavailable — cannot make structural assertions"
+  exit 0
+fi
+
+RESULTS="$(RENDER="$RENDER" COMPOSE="$COMPOSE" python3 <<'PY'
+import os, sys, yaml
+
+render = os.environ.get("RENDER") or ""
+if render.strip():
+    doc = yaml.safe_load(render)
+    resolved = True
+else:
+    doc = yaml.safe_load(open(os.environ["COMPOSE"]))
+    resolved = False
+
+services = doc.get("services") or {}
+out = []
+def ok(msg):   out.append(("PASS", msg, ""))
+def bad(msg, detail=""): out.append(("FAIL", msg, detail))
+
+def nets(svc):
+    n = services.get(svc, {}).get("networks")
+    if n is None:
+        # Unrendered compose: a service with no `networks:` key is implicitly on
+        # `default`. Say so rather than reporting "no networks".
+        return ["default"] if not resolved else []
+    return sorted(n.keys()) if isinstance(n, dict) else sorted(n)
+
+def env(svc):
+    e = services.get(svc, {}).get("environment") or []
+    if isinstance(e, dict):
+        return {k: ("" if v is None else str(v)) for k, v in e.items()}
+    d = {}
+    for item in e:
+        k, _, v = str(item).partition("=")
+        d[k] = v
+    return d
+
+# 1. Both services must exist and stay behind the opt-in profile.
+for svc in ("watchtower", "docker-socket-proxy"):
+    if svc not in services:
+        bad(f"{svc} service exists", "not found in docker-compose.yaml")
+        continue
+    profiles = services[svc].get("profiles") or []
+    if "auto-update" in profiles:
+        ok(f"{svc} stays behind the opt-in auto-update profile")
+    else:
+        bad(f"{svc} stays behind the auto-update profile",
+            f"profiles={profiles!r} — this must never run by default")
+
+# 2. THE finding: watchtower must not hold the socket.
+wt_vols = services.get("watchtower", {}).get("volumes") or []
+sock = [v for v in wt_vols if "docker.sock" in str(v)]
+if sock:
+    bad("watchtower does NOT bind the Docker socket",
+        f"found {sock!r} — this is #3865 itself; watchtower must reach the daemon "
+        f"only through docker-socket-proxy")
+else:
+    ok("watchtower does NOT bind the Docker socket")
+
+# 3. ...and it must actually be pointed at the proxy, or it silently falls back
+#    to the default /var/run/docker.sock and the mount removal means nothing.
+host = env("watchtower").get("DOCKER_HOST", "")
+if "docker-socket-proxy" in host:
+    ok(f"watchtower targets the proxy (DOCKER_HOST={host})")
+else:
+    bad("watchtower targets the proxy via DOCKER_HOST",
+        f"got {host!r} — without this watchtower falls back to the local socket")
+
+# 4. Exactly one service may hold the socket, and it is the proxy.
+holders = sorted(s for s, v in services.items()
+                 if any("docker.sock" in str(x) for x in (v.get("volumes") or [])))
+if holders == ["docker-socket-proxy"]:
+    ok("docker-socket-proxy is the ONLY service mounting the socket")
+else:
+    bad("docker-socket-proxy is the only service mounting the socket",
+        f"socket holders: {holders!r}")
+
+# 5. The proxy speaks an unauthenticated Docker API — it must never be published.
+ports = services.get("docker-socket-proxy", {}).get("ports") or []
+if ports:
+    bad("docker-socket-proxy publishes NO ports",
+        f"ports={ports!r} — publishing 2375 exposes an unauthenticated Docker API")
+else:
+    ok("docker-socket-proxy publishes no ports")
+
+# 6. Network isolation: the proxy must not be reachable from the hive container,
+#    which runs semi-trusted agent code.
+proxy_nets = set(nets("docker-socket-proxy"))
+hive_nets = set(nets("hive"))
+shared = proxy_nets & hive_nets
+if shared:
+    bad("the hive container cannot reach the Docker API",
+        f"hive and docker-socket-proxy share network(s) {sorted(shared)!r} — "
+        f"agent code could then create privileged containers")
+else:
+    ok("hive shares no network with docker-socket-proxy")
+
+if "default" in proxy_nets:
+    bad("docker-socket-proxy is off the default network",
+        "the default network carries the hive and gateway containers")
+else:
+    ok("docker-socket-proxy is off the default network")
+
+# 7. The isolating network must actually be internal.
+netdefs = doc.get("networks") or {}
+proxy_only = [n for n in proxy_nets if n != "default"]
+for n in proxy_only:
+    spec = netdefs.get(n) or {}
+    if spec.get("internal") is True:
+        ok(f"network {n!r} is internal")
+    else:
+        bad(f"network {n!r} is internal",
+            f"got {spec!r} — a non-internal network gives the proxy outbound reach")
+
+# 8. The allowlist: EXEC and friends must stay off.
+pe = env("docker-socket-proxy")
+DENY = ["EXEC", "AUTH", "BUILD", "COMMIT", "CONFIGS", "DISTRIBUTION", "INFO",
+        "NETWORKS", "NODES", "PLUGINS", "SECRETS", "SERVICES", "SESSION",
+        "SWARM", "SYSTEM", "TASKS", "VOLUMES"]
+enabled = [k for k in DENY if pe.get(k, "0") not in ("0", "", "false", "False")]
+if enabled:
+    bad("no dangerous Docker API section is enabled on the proxy",
+        f"enabled: {enabled!r} — EXEC in particular reads /secrets out of the hive container")
+else:
+    ok("no dangerous Docker API section is enabled on the proxy")
+
+# The four watchtower genuinely needs. Asserted so a "tightening" that breaks
+# updates fails here instead of silently in production at 03:00.
+for k in ("CONTAINERS", "IMAGES", "POST", "DELETE"):
+    if pe.get(k) == "1":
+        ok(f"proxy grants {k}=1 (required by watchtower)")
+    else:
+        bad(f"proxy grants {k}=1", f"got {pe.get(k)!r} — watchtower cannot update containers without it")
+
+# 9. Digest pins. The proxy is now the socket holder, so its pin matters at
+#    least as much as watchtower's.
+for svc, repo in (("docker-socket-proxy", "tecnativa/docker-socket-proxy"),
+                  ("watchtower", "containrrr/watchtower")):
+    img = services.get(svc, {}).get("image", "")
+    if not img.startswith(repo):
+        bad(f"{svc} uses the expected image", f"got {img!r}")
+    elif "@sha256:" in img and len(img.split("@sha256:")[1]) >= 64:
+        ok(f"{svc} is pinned by @sha256 digest")
+    else:
+        bad(f"{svc} is pinned by @sha256 digest", f"got {img!r} — a tag is mutable")
+
+for status, msg, detail in out:
+    print(f"{status}\t{msg}\t{detail}")
+PY
+)"
+
+while IFS=$'\t' read -r status msg detail; do
+  [ -z "$status" ] && continue
+  if [ "$status" = "PASS" ]; then pass "$msg"; else fail "$msg" "$detail"; fi
+done <<< "$RESULTS"
+
+# 10. The residual risk must stay documented. #3865 asked for the risk to be
+#     documented prominently, and the proxy does NOT close the finding — a
+#     future reader who believes it does will enable the profile on a
+#     credential-holding host. Deleting the doc must fail.
+if [ ! -f "$DOC" ]; then
+  fail "v2/docs/auto-update-profile.md exists" \
+       "the residual risk is only acceptable while it is written down (#3865)"
+else
+  pass "v2/docs/auto-update-profile.md exists"
+  for needle in "What the proxy does NOT fix" "host root" "not a mitigation"; do
+    if grep -qF "$needle" "$DOC"; then
+      pass "auto-update doc still states: '$needle'"
+    else
+      fail "auto-update doc still states: '$needle'" \
+           "the doc must keep naming the residual, not just the mitigation"
+    fi
+  done
+fi
+
+echo
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -64,25 +64,112 @@ services:
       retries: 3
       start_period: 120s
 
+  # Filtered Docker API in front of watchtower (#3865).
+  #
+  # Watchtower used to bind /var/run/docker.sock straight into its own
+  # container. That is the full daemon API — including /exec, which reads the
+  # GitHub App private key out of the hive container without needing an
+  # escalation at all. This service is the ONLY thing holding the socket now,
+  # and it exposes a deny-by-default subset of the API over TCP.
+  #
+  # READ v2/docs/auto-update-profile.md BEFORE ENABLING THIS PROFILE. The proxy
+  # narrows the surface; it does NOT make auto-update safe. Watchtower must be
+  # able to create and start containers to do its job, and that permission is
+  # itself host-root-equivalent. The doc states exactly what survives.
+  docker-socket-proxy:
+    # Pinned by digest for the same reason watchtower is, and more so: this is
+    # now the container holding the socket. The digest is the multi-arch OCI
+    # index (linux/amd64 + linux/arm64 both resolve). Bump deliberately by
+    # verifying the release at
+    # https://github.com/Tecnativa/docker-socket-proxy/releases and updating
+    # BOTH the tag and the @sha256 digest together.
+    image: tecnativa/docker-socket-proxy:0.3.0@sha256:9e4b9e7517a6b660f2cc903a19b257b1852d5b3344794e3ea334ff00ae677ac2
+    container_name: hive-docker-socket-proxy
+    restart: unless-stopped
+    volumes:
+      # :ro is deliberate but is NOT the control here — a unix socket mounted
+      # read-only still accepts writes, because the restriction applies to the
+      # inode, not to the API spoken over it. The control is the allowlist
+      # below. Do not "harden" this by adding :ro to watchtower and calling it
+      # done; see v2/docs/auto-update-profile.md.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      # ── ALLOWED: the minimum Watchtower needs ──────────────────────────────
+      - CONTAINERS=1 # list/inspect the containers it manages
+      - IMAGES=1 # inspect and pull replacement images
+      - POST=1 # create/start/stop — without this it can only look
+      - DELETE=1 # required by WATCHTOWER_CLEANUP=true (old images)
+      - PING=1 # daemon liveness
+      - VERSION=1 # API version negotiation on connect
+      # ── DENIED: set to 0 explicitly, not left to the image's defaults ──────
+      # These are already the upstream defaults. They are written out so that a
+      # future image whose defaults change cannot silently widen this, and so a
+      # reviewer sees the boundary rather than having to infer it.
+      # EXEC is the important one: it is the direct path to the App private key
+      # and every agent credential inside the hive container.
+      - EXEC=0
+      - AUTH=0
+      - BUILD=0
+      - COMMIT=0
+      - CONFIGS=0
+      - DISTRIBUTION=0
+      - INFO=0
+      - NETWORKS=0
+      - NODES=0
+      - PLUGINS=0
+      - SECRETS=0
+      - SERVICES=0
+      - SESSION=0
+      - SWARM=0
+      - SYSTEM=0
+      - TASKS=0
+      - VOLUMES=0
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      # ONLY the internal network. The proxy speaks an unauthenticated Docker
+      # API on :2375 — anything that can route to it inherits that API. It must
+      # never be published to the host, and it must never be reachable from the
+      # default network, where the hive container runs semi-trusted agent code.
+      - docker-proxy
+    profiles:
+      - auto-update
+
   watchtower:
     # Pinned to v1.7.1 to prevent floating-tag supply-chain risk.
-    # The image also mounts the Docker socket, so a compromised :latest tag
-    # would give an attacker full host control. Bump deliberately by
-    # verifying the release at https://github.com/containrrr/watchtower/releases
-    # and updating BOTH the tag and the @sha256 digest below. The digest is the
-    # multi-arch manifest-list digest, so amd64/arm64 pulls both still resolve.
+    # Bump deliberately by verifying the release at
+    # https://github.com/containrrr/watchtower/releases and updating BOTH the
+    # tag and the @sha256 digest below. The digest is the multi-arch
+    # manifest-list digest, so amd64/arm64 pulls both still resolve.
     # v2/deploy/test_supply_chain_pins.sh fails the build if the digest is dropped.
     image: containrrr/watchtower:1.7.1@sha256:6dd50763bbd632a83cb154d5451700530d1e44200b268a4e9488fefdfcf2b038
     container_name: hive-watchtower
     restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    # NO docker.sock bind (#3865). Watchtower reaches the daemon only through
+    # the filtered proxy above. v2/deploy/test_watchtower_socket_contract.sh
+    # fails the build if the raw socket comes back.
     environment:
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_POLL_INTERVAL=60
       - WATCHTOWER_LABEL_ENABLE=true
+    depends_on:
+      - docker-socket-proxy
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      # default: reach registries. docker-proxy: reach the filtered daemon.
+      - default
+      - docker-proxy
     profiles:
       - auto-update
+
+networks:
+  # internal: true keeps this network off the host and unroutable to the
+  # outside — it exists only so watchtower can reach the socket proxy. Every
+  # other service stays on `default` and cannot see the Docker API at all.
+  docker-proxy:
+    internal: true
 
 volumes:
   hive-data:

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -12,6 +12,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, GitHub token scopes, and image provenance.
 - [Release channels](release-channels.md) — `stable`/`candidate`/`edge` moving image tags, switching a hive to a channel, and the `stable (v4)` version pill.
+- [The `auto-update` Compose profile](auto-update-profile.md) — what unattended Watchtower updates cost you, what the Docker socket proxy does and does **not** fix, and why Kubernetes should not use this profile at all.
 - [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
 - [Troubleshooting](troubleshooting.md) — container logs, config validation, agent tmux sessions, dashboard auth, and GitHub credential checks.
 - [Cross-cluster migration](cross-cluster-migration.md) — the manual procedure for moving a hive between clusters.

--- a/v2/docs/auto-update-profile.md
+++ b/v2/docs/auto-update-profile.md
@@ -1,0 +1,128 @@
+# The `auto-update` Compose profile
+
+The `auto-update` profile runs [Watchtower](https://github.com/containrrr/watchtower)
+alongside the hive so that containers labelled
+`com.centurylinklabs.watchtower.enable=true` are replaced automatically when a
+new image is published.
+
+It is **opt-in** and off by default:
+
+```bash
+docker compose --profile auto-update up -d
+```
+
+**Read this whole page before enabling it in production.** The profile trades a
+real, permanent increase in blast radius for the convenience of unattended
+updates, and the trade is worse on a hive host than on most hosts, because this
+host holds the GitHub App private key and every agent credential.
+
+## Why unattended updates need the Docker daemon
+
+Replacing a running container is a daemon operation: pull the new image, stop
+the old container, create and start a new one with the same configuration.
+There is no way to do that without an API that can create and start containers,
+and an API that can create and start containers can create a *privileged*
+container that mounts the host filesystem. That is the irreducible core of the
+risk, and no proxy in front of it changes that fact.
+
+## What changed in [#3865](https://github.com/kubestellar/hive/issues/3865)
+
+Watchtower used to bind-mount `/var/run/docker.sock` directly into its own
+container. That is the **entire** daemon API, including:
+
+- `POST /containers/{id}/exec` — run a command inside any container. Against the
+  hive container that reads `/secrets` directly. No escalation required, no
+  privileged container needed, nothing to detect at the host level.
+- `/volumes`, `/networks`, `/secrets`, `/configs`, `/swarm`, `/build`, `/info`.
+
+Now the socket is held by a single `docker-socket-proxy` service that speaks a
+deny-by-default subset of the API over an internal-only network, and Watchtower
+reaches the daemon only through it (`DOCKER_HOST=tcp://docker-socket-proxy:2375`).
+
+| | Before | After |
+| --- | --- | --- |
+| Raw socket in Watchtower's filesystem | yes | no |
+| `/exec` into the hive container | **allowed** | **blocked** |
+| `/volumes`, `/networks`, `/secrets`, `/configs`, `/swarm` | allowed | blocked |
+| `/build`, `/commit`, `/info`, `/system` | allowed | blocked |
+| Docker API reachable from the `hive` container | on the shared network | **no** — proxy is on an `internal:` network Watchtower alone joins |
+| Docker API published to the host | no | no |
+
+## What the proxy does NOT fix
+
+This section is the point of the page. The proxy is defence in depth, not a fix,
+and a deployment that treats it as a fix is worse off than one that understands
+the residual — because it will enable the profile believing the finding is
+closed.
+
+Watchtower cannot do its job without `CONTAINERS=1` and `POST=1`. With those two
+flags, a compromised Watchtower can still:
+
+1. **Create a privileged container that mounts the host root.**
+   `POST /containers/create` is permitted, and the proxy filters *paths and
+   methods*, not request bodies — it does not and cannot inspect
+   `HostConfig.Privileged` or `HostConfig.Binds`. This is host root.
+2. **Copy files out of any container.** `GET /containers/{id}/archive` falls
+   under `CONTAINERS`, and reads are permitted for enabled sections. That is the
+   hive container's `/secrets` — the App private key — without needing step 1.
+
+So the honest summary is: the proxy removes the *easiest* path (`/exec`) and a
+broad set of unrelated API surface, and it stops the Docker API from being
+reachable by the semi-trusted agent code running in the hive container. It does
+not make a compromised Watchtower harmless. **If Watchtower is compromised, treat
+the host and every credential on it as compromised.**
+
+### A trap: `:ro` on the socket is not a mitigation
+
+Mounting `/var/run/docker.sock:ro` looks like a fix and is not one. The
+read-only flag applies to the *inode*; the Docker API is a protocol spoken over
+the socket, and writes over that connection are unaffected. A container with a
+read-only socket mount has exactly the same daemon access as one without.
+
+The `:ro` on the proxy's mount in `docker-compose.yaml` is there for hygiene and
+is explicitly *not* the control. The control is the environment allowlist.
+
+## Recommended posture
+
+In rough order of preference:
+
+1. **Do not enable `auto-update` on a hive host that holds production
+   credentials.** Update deliberately: `docker compose pull && docker compose up -d`
+   on your own schedule. This is the only option that removes the risk rather
+   than narrowing it.
+2. **On Kubernetes, do not use this profile at all.** Use a rolling update of the
+   Deployment (`kubectl set image` / a GitOps controller reconciling the image
+   digest). Kubernetes already owns container lifecycle there, so nothing needs
+   the Docker socket, and the whole class of finding disappears.
+3. **If you enable it anyway**, then at minimum:
+   - keep both images pinned by digest (`v2/deploy/test_supply_chain_pins.sh`
+     enforces this in CI);
+   - keep the proxy on the internal network and never publish `2375`;
+   - do not add `EXEC=1` — see the deny list in `docker-compose.yaml`;
+   - treat a Watchtower CVE as a host-compromise event, not a container one.
+
+## Private registries
+
+`AUTH=0` is set, so the proxy does not expose `POST /auth`. Pulling from a
+private registry needs the daemon's own credentials (`~/.docker/config.json` on
+the host) rather than Watchtower-supplied ones. If you must pass registry
+credentials to Watchtower, review whether the profile is the right mechanism at
+all before enabling `AUTH`.
+
+## Verifying the deployed posture
+
+```bash
+# Watchtower must NOT have the socket:
+docker inspect hive-watchtower --format '{{json .HostConfig.Binds}}'    # → null
+
+# The proxy must not be published to the host:
+docker inspect hive-docker-socket-proxy --format '{{json .HostConfig.PortBindings}}'   # → {}
+
+# The hive container must not be able to reach the Docker API:
+docker exec hive-hive sh -c 'wget -qO- http://docker-socket-proxy:2375/version'  # → fails to resolve
+```
+
+`v2/deploy/test_watchtower_socket_contract.sh` asserts the same invariants
+against `docker-compose.yaml` in CI, so a future edit cannot quietly restore the
+raw socket mount, publish the proxy, widen the allowlist, or put the proxy on a
+network the hive container can reach.


### PR DESCRIPTION
## What

Watchtower no longer holds the Docker socket. A single `docker-socket-proxy` holds it and exposes a deny-by-default subset of the API over an internal-only network; Watchtower reaches the daemon only through that.

Refs #3865 — **no `Fixes`**, deliberately. See "What this does not fix".

## The sharpest edge was not the one in the finding

The issue frames the risk as privileged-container escalation. The more direct path is `POST /containers/{id}/exec`: with the raw socket, a compromised Watchtower reads the GitHub App private key straight out of the hive container's `/secrets`. No escalation, no privileged container, nothing unusual at the host level. That path is now **blocked**.

## What landed

Removed from Watchtower's reach: `/exec`, `/volumes`, `/networks`, `/secrets`, `/configs`, `/swarm`, `/nodes`, `/services`, `/tasks`, `/plugins`, `/build`, `/commit`, `/info`, `/system`, `/auth`, `/distribution`, `/session`. Each is set to `0` **explicitly** rather than left to the image's defaults, so a future image whose defaults change can't silently widen this — and so a reviewer sees the boundary instead of inferring it.

**Network isolation is load-bearing, and is the part that would have been easiest to get wrong.** The proxy speaks an *unauthenticated* Docker API on 2375. Putting it on the default Compose network would have handed that API to the `hive` container — which runs semi-trusted agent code — leaving the deployment worse off than the finding reports. So it sits alone on an `internal: true` network that only Watchtower joins:

```
docker-socket-proxy    networks=['docker-proxy']            # internal, unpublished
hive                   networks=['default']                 # cannot route to it
gateway                networks=['default']
watchtower             networks=['default', 'docker-proxy']
```

(That's the resolved `docker compose config` output, not the source text.)

`tecnativa/docker-socket-proxy` is pinned by digest like everything else here — `0.3.0` → `sha256:9e4b9e75…`, verified against the registry as an OCI image index covering `linux/amd64` and `linux/arm64`, so both arches resolve.

## What this does NOT fix

I'd rather say this than let the finding read as closed.

Watchtower cannot do its job without `CONTAINERS=1` and `POST=1`, and with those two a compromised Watchtower can still:

1. **`POST /containers/create` a privileged container binding `/`.** The proxy filters paths and methods, never request bodies — it cannot see `HostConfig.Privileged` or `HostConfig.Binds`. That is host root.
2. **`GET /containers/{id}/archive` to copy `/secrets` out of the hive container.** Reads are permitted for enabled sections; no escalation needed.

So this removes the easiest path and a large amount of unrelated surface, and it takes the Docker API away from agent code. It does **not** make a compromised Watchtower harmless. If Watchtower is compromised, the host and every credential on it should be treated as compromised.

## Documentation (recommendations 2 and 3)

The profile had **no documentation at all** — that absence is part of the finding. `v2/docs/auto-update-profile.md` is new and leads with the residual above, plus:

- **`:ro` on a `docker.sock` mount is not a mitigation.** The flag applies to the inode; the Docker API is a protocol spoken over the socket. Written up as a trap specifically so nobody "hardens" Watchtower that way and stops there.
- **Kubernetes should not use this profile at all** — a rolling Deployment update needs no socket, and the whole class of finding disappears.
- The honest first recommendation stays: don't enable auto-update on a host holding production credentials.

## Guard

`v2/deploy/test_watchtower_socket_contract.sh` — 21 assertions, wired into `v2-ci` beside the supply-chain pin guard.

It renders the compose file with `docker compose config` when the CLI is present, so assertions run against the **resolved** topology (implicit `default` membership included) rather than text that merely looks right, and falls back to a YAML parse otherwise.

### Regression replay

| # | Neutered | Caught by |
|---|---|---|
| 1 | socket bind re-added to watchtower | `does NOT bind the Docker socket` + `only service mounting the socket` |
| 2 | proxy publishes 2375 | `publishes NO ports` |
| 3 | `EXEC=1` | `no dangerous Docker API section is enabled` |
| 4 | proxy on the default network | `hive cannot reach the Docker API` + `off the default network` |
| 5 | network made non-internal | `network 'docker-proxy' is internal` |
| 6 | proxy digest dropped | `pinned by @sha256 digest` |
| 7 | `DOCKER_HOST` removed (silent fallback to the local socket) | `targets the proxy via DOCKER_HOST` |
| 8 | residual-risk doc deleted | `auto-update-profile.md exists` |

Each confirmed failing, then restored green. #7 is the one worth calling out: without it, deleting the bind mount looks like a fix while Watchtower quietly reopens `/var/run/docker.sock` on its own.

All four deploy contract tests pass; compose renders with and without the profile.
