### PR TITLE
fix(image): link claude's native binary — the claude backend is unusable in images built from v4

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -215,7 +215,21 @@ RUN npm install -g --ignore-scripts --no-fund --no-audit @openai/codex@${CODEX_V
 
 # --- Layer 7: Claude Code (most frequent updates) ---
 ARG CLAUDE_CODE_VERSION=2.1.226
-RUN npm install -g --ignore-scripts --no-fund --no-audit @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
+# --ignore-scripts (kept, deliberately: no arbitrary postinstall runs during the
+# build) skips claude-code's install.cjs, which is what LINKS the platform
+# native binary into the package's bin/. The binary itself ships in the
+# platform sub-package, so nothing is downloaded here — but without the link
+# every invocation dies with:
+#
+#     Error: claude native binary not installed.
+#
+# i.e. the `claude` backend is unusable in the image. Run the vendor's own
+# install step explicitly: still auditable (one named script, not "whatever any
+# dependency wants"), and it writes into the global package dir, so the fix
+# applies to every agent UID rather than one $HOME.
+RUN npm install -g --ignore-scripts --no-fund --no-audit @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force && \
+    node /usr/local/lib/node_modules/@anthropic-ai/claude-code/install.cjs && \
+    claude --version
 
 # --- Layer 8: Goose CLI (official block/goose upstream) ---
 # Installs from the OFFICIAL block/goose repo, pinned to a fixed release and


### PR DESCRIPTION
## Problem

An image built from current `v4` has a **completely unusable `claude` backend**:

```
$ claude --version
Error: claude native binary not installed.
```

Every agent configured for `backend: claude` launches into that error and never reaches a prompt.

## Cause

The Claude Code layer installs with `--ignore-scripts`:

```dockerfile
RUN npm install -g --ignore-scripts --no-fund --no-audit @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache clean --force
```

That skips the package's `install.cjs`, which is what **links** the platform native binary into the package's `bin/`. The binary itself ships inside the platform sub-package — nothing is downloaded — so the failure is purely a missing link:

```
/usr/local/lib/node_modules/@anthropic-ai/claude-code/
├── bin/claude.exe          285M   (present, from the platform sub-package)
├── cli-wrapper.cjs                (resolves join(pkgDir, info.bin) -> fails)
└── install.cjs                    (skipped by --ignore-scripts)
```

Running `node install.cjs` in a built image fixes it immediately and permanently:

```
$ node /usr/local/lib/node_modules/@anthropic-ai/claude-code/install.cjs
$ claude --version
2.1.226 (Claude Code)
```

This is presumably why it went unnoticed: a **previously built** image keeps working, and `/data/home` is a persistent volume, so an existing deployment shows no symptom. It only appears when the image is rebuilt.

## Fix

Keep `--ignore-scripts` — the point of it is that no *arbitrary* dependency postinstall runs during the build — and invoke the vendor's own install step explicitly. That is still auditable: one named script, not "whatever any package in the tree wants to run". It writes into the global package directory, so it fixes **every** agent UID rather than a single `$HOME`.

`claude --version` is asserted in the same layer, so the build fails loudly if this ever regresses instead of shipping an image whose flagship backend is dead.

## Verification

Built the image with this change through the fork's CI (all platforms green — the assertion is part of the build, so a green build *is* the verification), deployed it to a live single-node hive, and switched an agent onto claude:

```
$ claude --version          # as the agent UID, no manual step
2.1.226 (Claude Code)
```

Before the change, the same agent on the same freshly-built image produced `Error: claude native binary not installed.`

## Note

The same `--ignore-scripts` pattern is used for copilot, codex and pi in neighbouring layers. Those are fine today — their npm packages resolve platform binaries through `optionalDependencies` rather than a postinstall link step — so this change is deliberately scoped to the claude layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)