### PR TITLE
fix(github): recover from a stale rate-limit cache after installation-token rotation

### DIFF
--- a/v2/pkg/github/automerge_sweep.go
+++ b/v2/pkg/github/automerge_sweep.go
@@ -303,6 +303,51 @@ func (c *Client) SweepSelfAuthoredAutoMerges(ctx context.Context, opts AutoMerge
 // started at all: an ACMM L4/L5 hive (l4.md/l5.md both forbid the App
 // merging its own PRs) must not self-merge, matching console's L6 hive which
 // is unaffected and keeps self-merging as before.
+// refreshRateLimitCache re-reads GitHub's real rate limits and writes them back
+// into the go-github client's cache.
+//
+// WHY THIS IS NEEDED. go-github refuses requests PRE-EMPTIVELY: once it has seen
+// Remaining==0 it returns a synthetic 403 ("not making remote request") for
+// every call until the cached Reset time passes, without contacting GitHub.
+// That cache lives on the Client and is only updated by responses the Client
+// itself receives.
+//
+// Hive's App client is created ONCE (NewClientFromApp) while appTransport
+// injects a freshly minted INSTALLATION TOKEN per request, and installation
+// tokens rotate roughly hourly. A new token gets a new allowance — but the
+// Client's cache still says Remaining==0 with the old token's reset, so
+// go-github keeps refusing requests the new token could happily serve.
+//
+// Observed live: the dashboard reported core remaining=6613 of 6900 while every
+// sweep tick failed with "API rate limit of 6900 still exceeded", and the fleet
+// consumed ZERO requests over six minutes — not rate-limited, just refusing.
+// Merges stalled for the remainder of the window each time.
+//
+// GET /rate_limit does not count against any limit, and RateLimitService.Get
+// writes the result back into the client's cache, so this is a cheap, exact
+// correction rather than a guess.
+func (c *Client) refreshRateLimitCache(ctx context.Context) {
+	if c == nil || c.client == nil {
+		return
+	}
+	if _, _, err := c.client.RateLimit.Get(ctx); err != nil {
+		c.warn("could not refresh rate-limit cache", "error", err)
+		return
+	}
+	c.info("refreshed rate-limit cache after a pre-emptive rate-limit refusal")
+}
+
+// isRateLimited reports whether err is a primary/secondary rate-limit error,
+// including go-github's pre-emptive synthetic one.
+func isRateLimited(err error) bool {
+	var rl *gh.RateLimitError
+	if errors.As(err, &rl) {
+		return true
+	}
+	var ab *gh.AbuseRateLimitError
+	return errors.As(err, &ab)
+}
+
 func (c *Client) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges int, acmmAllowed bool, acmmLevel *int) {
 	if c == nil {
 		return
@@ -326,6 +371,14 @@ func (c *Client) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 			case <-t.C:
 				if _, err := c.SweepSelfAuthoredAutoMerges(ctx, AutoMergeSweepOptions{MaxMerges: maxMerges}); err != nil {
 					c.warn("self-authored automerge sweep failed", "error", err)
+					// A rate-limit refusal may be go-github's cached verdict
+					// from a token that has since rotated. Re-read the real
+					// limits (free, and it updates that cache) so the next tick
+					// is decided on current truth instead of repeating a stale
+					// refusal for the rest of the window.
+					if isRateLimited(err) {
+						c.refreshRateLimitCache(ctx)
+					}
 				}
 			}
 		}

--- a/v2/pkg/github/rate_limit_cache_test.go
+++ b/v2/pkg/github/rate_limit_cache_test.go
@@ -1,0 +1,66 @@
+package github
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// TestIsRateLimited_RecognisesPreEmptiveRefusal is the guard for the stall this
+// fixes. go-github does not only surface rate limits GitHub reports — once it
+// has cached Remaining==0 it SYNTHESISES a 403 locally and returns it without
+// contacting GitHub ("not making remote request"). Both shapes must be
+// recognised, or the self-heal never runs for the case that actually stalls.
+func TestIsRateLimited_RecognisesPreEmptiveRefusal(t *testing.T) {
+	preEmptive := &gh.RateLimitError{
+		Rate:     gh.Rate{Limit: 6900, Remaining: 0, Reset: gh.Timestamp{Time: time.Now().Add(30 * time.Minute)}},
+		Response: &http.Response{StatusCode: http.StatusForbidden},
+		Message:  "API rate limit of 6900 still exceeded until 2026-08-16 02:34:57 -0400 EDT, not making remote request.",
+	}
+	if !isRateLimited(preEmptive) {
+		t.Error("go-github's pre-emptive rate-limit refusal was not recognised")
+	}
+
+	abuse := &gh.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}}
+	if !isRateLimited(abuse) {
+		t.Error("secondary (abuse) rate limit was not recognised")
+	}
+
+	// Wrapped errors must still match — callers wrap with context like
+	// "listing open PRs for owner/repo: %w".
+	if !isRateLimited(wrap(preEmptive)) {
+		t.Error("a wrapped rate-limit error was not recognised")
+	}
+}
+
+func wrap(err error) error { return &wrapped{err} }
+
+type wrapped struct{ err error }
+
+func (w *wrapped) Error() string { return "listing open PRs for o/r: " + w.err.Error() }
+func (w *wrapped) Unwrap() error { return w.err }
+
+// TestIsRateLimited_IgnoresOtherErrors: the self-heal costs an API call, so it
+// must not fire on unrelated failures.
+func TestIsRateLimited_IgnoresOtherErrors(t *testing.T) {
+	for _, err := range []error{
+		errors.New("connection refused"),
+		&gh.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}},
+		&gh.ErrorResponse{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+	} {
+		if isRateLimited(err) {
+			t.Errorf("non-rate-limit error treated as rate limited: %v", err)
+		}
+	}
+}
+
+// TestRefreshRateLimitCache_NilSafe: the sweep calls this from an error path, so
+// it must never panic on a half-constructed client.
+func TestRefreshRateLimitCache_NilSafe(t *testing.T) {
+	var c *Client
+	c.refreshRateLimitCache(t.Context()) // nil receiver
+	(&Client{}).refreshRateLimitCache(t.Context())
+}


### PR DESCRIPTION
## Symptom

Auto-merge stalls with a rate-limit error while the App has almost its entire allowance free:

```
WARN self-authored automerge sweep failed
  error="listing open PRs for tuna-os/tunaos: GET .../pulls: 403
         API rate limit of 6900 still exceeded until 2026-08-16 02:34:57 -0400 EDT,
         not making remote request."
```

…measured at the same moment on the same hive:

```
core: {"limit":6900,"remaining":6613,"reset":"…"}
```

**6613 of 6900 remaining, and zero requests consumed across six minutes.** The hive was not rate limited. It was refusing to ask.

MTTR collection and the queued auto-merge sweep fail as collateral, because the refusal is client-wide rather than per-caller.

## Cause

`checkRateLimitBeforeDo` short-circuits locally:

```go
if !rate.Reset.Time.IsZero() && rate.Remaining == 0 && time.Now().Before(rate.Reset.Time) {
    // Create a fake response.  →  synthetic 403, no request made
```

That cache is per-`Client`, and is only updated by responses the `Client` receives.

Hive's App client is constructed **once**:

```go
func NewClientFromAppWithBotLogin(...) *Client {
    transport := &appTransport{auth: auth, base: http.DefaultTransport}
    client := gh.NewClient(&http.Client{Transport: transport, ...})
```

…while `appTransport.RoundTrip` injects a **freshly minted installation token per request**, and installation tokens rotate roughly hourly.

So the two halves disagree: the credential is new and has a full allowance, but the client's cached verdict belongs to the *previous* token. go-github then refuses every call until the old token's reset time — potentially most of an hour of self-inflicted downtime, during which the real budget sits unused.

This is not a go-github bug. Its cache is correct for the usual one-client-one-credential shape; it simply cannot know the credential underneath was swapped.

## Fix

On a rate-limit error, re-read `GET /rate_limit`. `RateLimitService.Get` writes the response straight back into the client's cache:

```go
s.client.rateMu.Lock()
if response.Resources.Core != nil {
    s.client.rateLimits[CoreCategory] = *response.Resources.Core
}
```

So one call replaces the stale verdict with current truth, and the next tick is decided on that. `GET /rate_limit` **does not count against any limit**, so this is an exact correction rather than a guess or a backoff.

If the limit really is exhausted, the refreshed cache says so and the pre-emptive check keeps doing its job — the behaviour only changes when the cache was wrong.

Scoped to the self-authored sweep's error path: that is where the stall was observed, and its ticker makes a stuck cache most expensive. Worth extending to other long-lived callers if this proves out, but I would rather land the narrow, demonstrated case first.

## Tests

`rate_limit_cache_test.go`:

- **RecognisesPreEmptiveRefusal** — the synthetic local 403 is the shape that actually stalls, so it must match, including when wrapped in caller context (`listing open PRs for o/r: %w`). Also covers `AbuseRateLimitError`.
- **IgnoresOtherErrors** — the refresh costs an API call; it must not fire on 404/401/network errors.
- **NilSafe** — called from an error path, so it must not panic on a half-constructed client.

`go build ./...`, `go vet ./pkg/github/` and the package tests pass.

## Relationship to #3921

Independent, and both are needed. #3921 stops the sweep *causing* exhaustion (it was issuing 16,200 req/hour against a 6,900 limit by ticking every 10s per repo). This one stops the hive staying stuck after any exhaustion, whatever the cause. With only #3921 the fleet still froze for the remainder of a window whenever the cache went stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)