### PR TITLE
fix(sensing): login-detector defaults pause agents for reading about auth errors

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -3496,17 +3496,31 @@ func (c *Config) applyDefaults() {
 		}
 	}
 	if len(c.Governor.Sensing.LoginPatterns) == 0 {
+		// Each pattern must match the CLI's own login CHROME, never ordinary
+		// English. The login-detector matches these against the agent's PANE —
+		// which contains the issue bodies, PR diffs and CI logs the agent is
+		// READING — so generic phrases pause an agent for merely discussing an
+		// auth error. The previous defaults ("authentication required",
+		// "unauthorized.*401", "session expired", "login required", "please
+		// log in", "token expired") did exactly that on a live hive: a
+		// ci-maintainer reading CI logs full of 401s and a supervisor
+		// summarising issues across 39 repos were paused repeatedly, and the
+		// two HIGHEST-cadence agents are hit hardest because the detector runs
+		// at kick time, so exposure scales with kick frequency. Reproduced on
+		// demand by typing "authentication required" into a healthy agent's
+		// input box (unsubmitted — just rendered on the pane) and kicking it.
 		c.Governor.Sensing.LoginPatterns = []string{
-			"please log in",
-			"authentication required",
-			"not logged in",
-			"login required",
-			"session expired",
-			"token expired",
-			"unauthorized.*401",
+			// claude: exact prompt strings from Claude Code's login screens.
+			"Please run /login",
+			"Not logged in",
+			// gh / copilot / gemini: the commands their CLIs tell the user to run.
 			"gh auth login",
 			"claude login",
 			"copilot auth",
+			"gemini auth login",
+			// bob: its API-key entry prompts.
+			"Enter Bob-Shell API Key",
+			"Paste your API key here",
 		}
 	}
 	if c.Governor.Sensing.TTLSeconds == 0 {


### PR DESCRIPTION
## Problem

The default `governor.sensing.loginPatterns` are ordinary English:

```
please log in · authentication required · not logged in · login required
session expired · token expired · unauthorized.*401 · ...
```

The login-detector matches them against the agent's **pane** — which contains the issue bodies, PR diffs and CI logs the agent is *reading*. Any agent whose work so much as mentions an auth error pauses itself with `login required detected`.

On a live 39-repo hive this repeatedly paused:

- **ci-maintainer** — diagnoses CI logs, which are full of 401s
- **supervisor** — summarises issues fleet-wide, 680 advisory findings on its pane

…while both CLIs sat at a healthy ready prompt. And because the detector runs at kick time, exposure scales with kick frequency — **the defaults preferentially take down the highest-cadence agents**, i.e. the fleet's driver. Reproduced on demand: type `authentication required` into a healthy agent's input box (unsubmitted — merely rendered on the pane), kick it, and it pauses.

A false pause is also sticky: nothing clears it when the pane recovers, so each incident needs a human.

## Change

Replace the six generic phrases with the exact chrome each CLI prints when it genuinely needs a login (`Please run /login`, `Not logged in`, `gh auth login`, `claude login`, `copilot auth`), and add the gemini (`gemini auth login`) and bob (`Enter Bob-Shell API Key`, `Paste your API key here`) prompts that were missing entirely.

Every backend's real login state is still detected — these are the strings the CLIs actually render — but text an agent reads or writes no longer trips it. Operators who set their own `login_patterns` are unaffected; the defaults only apply to an empty list.

## Verification

Running as the configured patterns on the affected hive since 2026-08-15: zero false `login-detector` pauses since, across the same agents and workload that previously tripped several per day. Genuine login prompts (tested with Claude Code logged out) are still caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)