### PR TITLE
fix(github): surface the App's own stale drafts — scanner's own step-2 instruction had nothing to act on

### DIFF
--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -264,6 +264,15 @@ type IssueResult struct {
 type PRResult struct {
 	Count int           `json:"count"`
 	Items []PullRequest `json:"items"`
+	// StaleDrafts are the App's OWN draft PRs older than staleDraftAfter.
+	// Ordinary drafts (someone's in-progress work, human or agent) are
+	// excluded from Items entirely and stay that way here — nobody should be
+	// nagged about work they are actively doing. This list exists because the
+	// scanner kick prompt already instructs: "Close stale drafts (>48h,
+	// needs-rebase + dco-no, or fix already merged)" — but fetchPRs drops
+	// EVERY draft before the agent ever sees it, so that instruction had
+	// nothing to act on. See kubestellar/hive#3963.
+	StaleDrafts []PullRequest `json:"stale_drafts,omitempty"`
 }
 
 type HoldResult struct {
@@ -381,6 +390,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	var allIssues []Issue
 	var allPRs []PullRequest
 	var holdItems []HoldItem
+	var allStaleDrafts []PullRequest
 	totalByRepo := make(map[string]RepoCounts)
 
 	repos := c.getRepos()
@@ -397,7 +407,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		allIssues = append(allIssues, issues...)
 		holdItems = append(holdItems, held...)
 
-		prs, heldPRs, prTotal, err := c.fetchPRs(ctx, repo)
+		prs, heldPRs, staleDrafts, prTotal, err := c.fetchPRs(ctx, repo)
 		if err != nil {
 			// Issues for this repo were already collected; a PR-only failure
 			// is partial and must not count toward the all-repos-failed guard,
@@ -407,6 +417,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		}
 		allPRs = append(allPRs, prs...)
 		holdItems = append(holdItems, heldPRs...)
+		allStaleDrafts = append(allStaleDrafts, staleDrafts...)
 
 		totalByRepo[repo] = RepoCounts{Issues: issueTotal, PRs: prTotal}
 	}
@@ -445,8 +456,9 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		SLAViolations: slaViolations,
 	}
 	result.PRs = PRResult{
-		Count: len(allPRs),
-		Items: allPRs,
+		Count:       len(allPRs),
+		Items:       allPRs,
+		StaleDrafts: allStaleDrafts,
 	}
 	result.Hold = HoldResult{
 		Issues: holdIssueCount,
@@ -529,7 +541,15 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 	return actionable, held, totalIssues, nil
 }
 
-func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, held []HoldItem, totalPRs int, err error) {
+// staleDraftAfter matches the age threshold the scanner kick prompt already
+// names ("Close stale drafts (>48h, ...)"). A draft newer than this may still
+// be someone's active work-in-progress; older than this, it is more likely an
+// agent that opened a WIP PR and moved on. Only the App's OWN drafts are aged
+// this way — a human's stale draft is their call, not ours to nag about.
+const staleDraftAfter = 48 * time.Hour
+
+func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, held []HoldItem, staleDrafts []PullRequest, totalPRs int, err error) {
+	now := time.Now()
 	owner, repoName := c.splitRepo(repo)
 	opts := &gh.PullRequestListOptions{
 		State:       "open",
@@ -540,7 +560,7 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 	for {
 		prs, resp, err := c.client.PullRequests.List(ctx, owner, repoName, opts)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
+			return nil, nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
 		}
 		allPRs = append(allPRs, prs...)
 		if resp.NextPage == 0 {
@@ -568,6 +588,19 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 		}
 
 		if pr.GetDraft() {
+			author := safeGetLogin(pr.GetUser())
+			if strings.EqualFold(author, c.appBotLogin) && now.Sub(pr.GetCreatedAt().Time) > staleDraftAfter {
+				staleDrafts = append(staleDrafts, PullRequest{
+					Repo:      repo,
+					Number:    pr.GetNumber(),
+					Title:     pr.GetTitle(),
+					Author:    author,
+					Labels:    labels,
+					Draft:     true,
+					CreatedAt: pr.GetCreatedAt().Time,
+					URL:       pr.GetHTMLURL(),
+				})
+			}
 			continue
 		}
 
@@ -594,7 +627,7 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 		})
 	}
 
-	return actionable, held, totalPRs, nil
+	return actionable, held, staleDrafts, totalPRs, nil
 }
 
 // EnrichCIStatus fetches check-run results for each PR's HEAD commit

--- a/v2/pkg/github/stale_draft_test.go
+++ b/v2/pkg/github/stale_draft_test.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// prsHandler serves a fixed list of wirePR for any /repos/{owner}/{repo}/pulls
+// request, ignoring pagination params — sufficient for these single-page tests.
+func prsHandler(t *testing.T, prs []wirePR) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(prs); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+}
+
+// TestFetchPRs_StaleAppDraftIsSurfaced is the fix under test: the scanner kick
+// prompt already instructs "Close stale drafts (>48h, ...)" but fetchPRs
+// dropped every draft before the agent could ever see one to act on that
+// instruction (kubestellar/hive#3963). An App-authored draft older than
+// staleDraftAfter must come back via the new StaleDrafts channel, while still
+// being absent from the normal actionable Items — a draft is never mergeable.
+func TestFetchPRs_StaleAppDraftIsSurfaced(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/widget/pulls", prsHandler(t, []wirePR{
+		{
+			Number:    42,
+			Title:     "feat: half-finished thing",
+			User:      wireUser{Login: "acme-bot[bot]"},
+			Draft:     true,
+			CreatedAt: hoursAgo(72), // > staleDraftAfter (48h)
+			HTMLURL:   "https://github.com/acme/widget/pull/42",
+		},
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "acme", []string{"widget"})
+	c.appBotLogin = "acme-bot[bot]"
+
+	actionable, held, staleDrafts, total, err := c.fetchPRs(t.Context(), "widget")
+	if err != nil {
+		t.Fatalf("fetchPRs: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("totalPRs = %d, want 1", total)
+	}
+	if len(held) != 0 {
+		t.Errorf("held = %v, want empty", held)
+	}
+	if len(actionable) != 0 {
+		t.Errorf("actionable = %v, want empty — a draft must never be treated as ready work", actionable)
+	}
+	if len(staleDrafts) != 1 {
+		t.Fatalf("staleDrafts = %d, want 1", len(staleDrafts))
+	}
+	if staleDrafts[0].Number != 42 || !staleDrafts[0].Draft {
+		t.Errorf("staleDrafts[0] = %+v, want number=42 draft=true", staleDrafts[0])
+	}
+}
+
+// TestFetchPRs_RecentAppDraftNotSurfaced: a draft newer than staleDraftAfter
+// may still be an agent's active work-in-progress from the current cycle —
+// only OLD drafts are worth nagging about.
+func TestFetchPRs_RecentAppDraftNotSurfaced(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/widget/pulls", prsHandler(t, []wirePR{
+		{
+			Number:    43,
+			Title:     "wip",
+			User:      wireUser{Login: "acme-bot[bot]"},
+			Draft:     true,
+			CreatedAt: hoursAgo(1),
+			HTMLURL:   "https://github.com/acme/widget/pull/43",
+		},
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "acme", []string{"widget"})
+	c.appBotLogin = "acme-bot[bot]"
+
+	_, _, staleDrafts, _, err := c.fetchPRs(t.Context(), "widget")
+	if err != nil {
+		t.Fatalf("fetchPRs: %v", err)
+	}
+	if len(staleDrafts) != 0 {
+		t.Errorf("staleDrafts = %v, want empty for a 1-hour-old draft", staleDrafts)
+	}
+}
+
+// TestFetchPRs_HumanStaleDraftNotSurfaced: nagging about a HUMAN's stale
+// draft is not this mechanism's job — they are actively doing that work, and
+// hive has no standing to close or finish it for them. Only the App's own
+// drafts age into StaleDrafts.
+func TestFetchPRs_HumanStaleDraftNotSurfaced(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/widget/pulls", prsHandler(t, []wirePR{
+		{
+			Number:    44,
+			Title:     "a human's long-running feature branch",
+			User:      wireUser{Login: "some-contributor"},
+			Draft:     true,
+			CreatedAt: hoursAgo(500),
+			HTMLURL:   "https://github.com/acme/widget/pull/44",
+		},
+	}))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "acme", []string{"widget"})
+	c.appBotLogin = "acme-bot[bot]"
+
+	_, _, staleDrafts, _, err := c.fetchPRs(t.Context(), "widget")
+	if err != nil {
+		t.Fatalf("fetchPRs: %v", err)
+	}
+	if len(staleDrafts) != 0 {
+		t.Errorf("staleDrafts = %v, want empty for a human-authored draft", staleDrafts)
+	}
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -616,6 +616,22 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 		b.WriteString(fmt.Sprintf("\n⚠️ %d SLA VIOLATIONS (>30 min)\n", actionable.Issues.SLAViolations))
 	}
 
+	// Surfaces exactly the work step 2 already asks for ("Close stale drafts
+	// (>48h, needs-rebase + dco-no, or fix already merged)") — which had
+	// nothing to act on before, since fetchPRs drops every draft before this
+	// prompt is ever built. See kubestellar/hive#3963.
+	if len(actionable.PRs.StaleDrafts) > 0 {
+		b.WriteString(fmt.Sprintf("\nYOUR STALE DRAFT PRs (%d, >48h old — finish, mark ready, or close):\n", len(actionable.PRs.StaleDrafts)))
+		for _, d := range actionable.PRs.StaleDrafts {
+			title := d.Title
+			const maxDraftTitleRunes = 70
+			if runes := []rune(title); len(runes) > maxDraftTitleRunes {
+				title = string(runes[:maxDraftTitleRunes])
+			}
+			b.WriteString(fmt.Sprintf("  %s#%d %s\n", d.Repo, d.Number, title))
+		}
+	}
+
 	if knowledgeSection := s.primeKnowledge(scannerIssues); knowledgeSection != "" {
 		b.WriteString("\n")
 		b.WriteString(knowledgeSection)

--- a/v2/pkg/scheduler/stale_draft_message_test.go
+++ b/v2/pkg/scheduler/stale_draft_message_test.go
@@ -1,0 +1,73 @@
+package scheduler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// ---------------------------------------------------------------------------
+// buildScannerMessage — stale-draft section (kubestellar/hive#3963)
+// ---------------------------------------------------------------------------
+
+// actionableWithStaleDrafts returns an ActionableResult whose PRs carry the
+// given StaleDrafts. Items stays empty: a draft is never actionable work, it
+// only appears in the dedicated stale-draft section.
+func actionableWithStaleDrafts(drafts []github.PullRequest) *github.ActionableResult {
+	return &github.ActionableResult{
+		Issues: github.IssueResult{},
+		PRs: github.PRResult{
+			StaleDrafts: drafts,
+		},
+		Hold: github.HoldResult{},
+	}
+}
+
+func TestScannerMessage_StaleDraftsListed(t *testing.T) {
+	s := newScheduler()
+	drafts := []github.PullRequest{
+		{Repo: "test-org/console", Number: 42, Title: "feat: half-finished thing", Draft: true},
+		{Repo: "test-org/hive", Number: 7, Title: "wip: export adapters", Draft: true},
+	}
+	msg := s.buildScannerMessage(nil, actionableWithStaleDrafts(drafts))
+
+	if !strings.Contains(msg, "YOUR STALE DRAFT PRs (2, >48h old — finish, mark ready, or close):") {
+		t.Errorf("missing stale-draft header with count, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "test-org/console#42 feat: half-finished thing") {
+		t.Errorf("missing first stale draft line, got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "test-org/hive#7 wip: export adapters") {
+		t.Errorf("missing second stale draft line, got:\n%s", msg)
+	}
+}
+
+// TestScannerMessage_NoStaleDraftsNoSection is the negative control: with no
+// stale drafts the section must be absent entirely, so the scanner is never
+// shown an empty nag list to act on.
+func TestScannerMessage_NoStaleDraftsNoSection(t *testing.T) {
+	s := newScheduler()
+	msg := s.buildScannerMessage(nil, emptyActionable())
+	if strings.Contains(msg, "STALE DRAFT") {
+		t.Errorf("stale-draft section must be absent when there are none, got:\n%s", msg)
+	}
+}
+
+func TestScannerMessage_StaleDraftTitleTruncated(t *testing.T) {
+	s := newScheduler()
+	// 80 runes of multi-byte text: truncation must count runes, not bytes.
+	longTitle := strings.Repeat("é", 80)
+	drafts := []github.PullRequest{
+		{Repo: "test-org/hive", Number: 9, Title: longTitle, Draft: true},
+	}
+	msg := s.buildScannerMessage(nil, actionableWithStaleDrafts(drafts))
+
+	want := "test-org/hive#9 " + strings.Repeat("é", 70) + "\n"
+	if !strings.Contains(msg, want) {
+		t.Errorf("expected title truncated to 70 runes, got:\n%s", msg)
+	}
+	if strings.Contains(msg, strings.Repeat("é", 71)) {
+		t.Errorf("title not truncated: found 71+ runes of the original title")
+	}
+}


### PR DESCRIPTION
## The bug

`fetchPRs` drops **every** draft PR before the actionable list is built:

```go
if pr.GetDraft() {
    continue
}
```

But the scanner kick prompt (`buildScannerMessage`) already tells the agent, in its own workflow step 2:

> "Close stale drafts (>48h, needs-rebase + dco-no, or fix already merged)"

That instruction had nothing to act on. A draft the App opened and never returned to becomes invisible to every future kick, forever — it never reaches the actionable list a kick prompt is even built from. There's no mechanism anywhere that revisits it.

## Observed live

Two App-authored draft PRs (`feat(export): add Proxmox vzdump adapter`, `feat(move): support Incus as move destination`), **both fully green on CI**, sat untouched for a week. Not because anything was blocking them — CI passed cleanly on both — but because no agent was ever shown they existed after the cycle that opened them ended.

## Fix

Add a `StaleDrafts` channel to `PRResult`, populated only for:

- the **App's own** drafts (`appBotLogin` match) — a human's stale draft is their call, not hive's to nag about; hive has no standing to close or finish someone else's WIP
- **older than 48h** — the same threshold the prompt text already names, so a draft from the current cycle isn't flagged as "stale" before the agent has even had a chance to return to it

Neither this list nor a plain draft is ever added to `Items` (the normal actionable list) — a draft still cannot be merged and must never be treated as ready work. This only adds *visibility*, not eligibility.

`buildScannerMessage` renders the list as `YOUR STALE DRAFT PRs (N, >48h old — finish, mark ready, or close)`, giving the existing step-2 instruction a real list to act on.

## Tests

`stale_draft_test.go`:
- an App-authored draft >48h old is surfaced in `StaleDrafts` and absent from `Items`
- a **recent** App-authored draft (1h old) is not surfaced — still-in-progress this cycle
- a **human-authored** draft, even 500h old, is not surfaced — not hive's to touch

Existing `pkg/github` and `pkg/scheduler` suites pass unchanged, including `TestFetchPRs_DraftFiltered`, confirming ordinary drafts still stay out of the actionable list exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)