### PR TITLE
feat(tracing): version-stamp spans for PR reach attribution (#3973)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1027,6 +1027,13 @@ func main() {
 		SampleRatio: otelCfg.SampleRatio,
 		HiveID:      cfg.HiveID,
 		Branch:      cfg.Policies.Branch,
+		// Reach anchors (#3973): gitShort is the ldflags-baked commit of THIS
+		// binary (already canonicalized to 7 chars above), and the image ref is
+		// the Deployment-declared image (cached — warmed by the release-channel
+		// read at startup; "" outside a cluster). Spans attribute to the code
+		// that actually runs, not to the merge/publish event (#3816).
+		Commit: gitShort,
+		Image:  hub.SelfDeploymentImage(),
 	})
 	if traceErr != nil {
 		logger.Warn("tracing init failed; continuing without tracing", "error", traceErr)

--- a/v2/docs/design/pr-reach-telemetry.md
+++ b/v2/docs/design/pr-reach-telemetry.md
@@ -1,0 +1,93 @@
+# PR reach telemetry (#3973)
+
+Status: phase 1 landed (version-stamped spans + component attribute); phases 2+ pending.
+
+## The problem
+
+Every quality signal we have — acceptance rate, coverage, CI — measures work at
+proposal or approval time. None answers the question that actually matters for
+merged code: **did it ever run in production, on how many hives, and did error
+rates move?** The framing is *reach*, not execution-time: a nil-check that
+executes once a month and prevents data loss matters more than a hot loop that
+runs constantly.
+
+## Anchoring rule: merged ≠ deployed ≠ running
+
+Reach MUST attribute to the commit actually executing, never to the merge or
+publish event. We have seen the published digest advance while the running
+binary stayed old (#3816); without a running-commit anchor, undeployed code
+reads as "unused" and the metric lies. The only trustworthy version source is
+the SHA baked into the binary at build time (the same ldflags value
+`hive --version` prints), not any tag, channel, or Deployment spec.
+
+## What phase 1 emits
+
+Resource attributes, on every span from every process with tracing enabled
+(`pkg/tracing.Init`, values wired in `cmd/hive/main.go`):
+
+| Attribute         | Source                                    | Meaning |
+|-------------------|-------------------------------------------|---------|
+| `service.version` | ldflags `main.gitShort` (7-char SHA)      | Commit of the RUNNING binary; standard semconv, so backends group by it natively |
+| `hive.commit`     | same value                                | Explicit alias alongside the other `hive.*` identity attrs |
+| `hive.image`      | `hub.SelfDeploymentImage()` (cached read) | Deployment-DECLARED image ref; informational |
+| `hive.id`, `hive.branch` | config (pre-existing)              | Per-hive / per-branch dimensions |
+
+Rules:
+
+- A build without ldflags injection (`gitShort == "unknown"`) stamps **no**
+  version attributes. Reach queries must never group spans under a placeholder
+  pseudo-commit.
+- `hive.image` is deliberately separate from `hive.commit` because the two can
+  disagree (#3816): the Deployment spec can declare a digest the pod never
+  pulled. Disagreement is itself signal (declared-but-not-running code), but
+  `hive.commit` is always the authoritative anchor. Empty outside a cluster.
+
+Span attribute, added automatically by `tracing.StartSpan` with zero call-site
+changes:
+
+- `hive.component` — the prefix of the span name before the first dot, under
+  the existing `<component>.<operation>` naming convention
+  (`governor.eval_cycle` → `governor`, `pr.merged` → `pr`).
+
+## The coarse PR → reach mapping (phase 1 granularity)
+
+Per the options weighed in #3973, phase 1 is **package-level**, not per-PR:
+
+1. A PR's changed files map to packages (`v2/pkg/governor/...` → `governor`,
+   `v2/cmd/hive/...` → the components whose spans main.go emits).
+2. Package maps to the `hive.component` values its spans carry.
+3. Reach query: spans where `hive.commit` ∈ {SHAs at-or-after the merge that
+   contain the PR} AND `hive.component` ∈ {the PR's components}, grouped by
+   `hive.id` for fleet distribution.
+
+This is deliberately coarse: it answers "has the subsystem this PR touched
+executed on a build containing it, and on how many hives" — not "did this exact
+diff's lines run." Line/function-level attribution is out of scope for phase 1
+(cost and cardinality; see the issue's options list).
+
+## What phase 2+ needs (deferred)
+
+- **Error-rate deltas pre/post merge**: compare span error status rates for a
+  component across the commit boundary that introduced a PR. Needs span status
+  discipline (`span.SetStatus` on failure paths) audited per component first.
+- **First-execution latency**: time from merge → first span carrying a
+  `hive.commit` that contains the PR. Needs a merge-SHA → containing-build
+  index (the hub already stores per-spoke `GitHash`; join there).
+- **Per-hive distinct counts**: `count_distinct(hive.id)` per (commit,
+  component) — the raw data lands with phase 1, the aggregation/query layer is
+  future work.
+- **Finer-than-package mapping**, if ever justified: per-function span naming
+  or PR-annotation of spans. Explicitly rejected for phase 1.
+
+Non-goals at any phase soon: dashboards, an aggregation service, new HTTP
+endpoints. Phase 1 is emit-only; queries run in whatever OTLP backend the
+collector feeds.
+
+## Testing
+
+`pkg/tracing/tracing_test.go` asserts: commit/image attributes present on the
+resource (`newResource`), placeholder `unknown` version omitted, empty image
+omitted, `hive.component` auto-attached by `StartSpan`, and the span-name →
+component mapping. Version *injection* is the linker's job (Dockerfile
+`-ldflags -X main.gitShort=...`); tests cover the plumbing function, not the
+linker.

--- a/v2/pkg/tracing/semconv.go
+++ b/v2/pkg/tracing/semconv.go
@@ -20,6 +20,12 @@ const (
 	AttrHiveLane         = "hive.lane"
 	AttrHiveACMMLevel    = "hive.acmm_level"
 	AttrHiveGovernorMode = "hive.governor.mode"
+	// AttrHiveComponent is the coarse package/component a span belongs to,
+	// derived from the span-name prefix before the first dot ("governor",
+	// "agent", "pr", ...). It is the phase-1 reach dimension for #3973: a PR's
+	// changed files map to components, and (hive.commit, hive.component) on
+	// span data answers "did that component ever run on the merged commit".
+	AttrHiveComponent = "hive.component"
 
 	attrEventKind = "hive.timeline.kind"
 	attrEventID   = "event.id"

--- a/v2/pkg/tracing/tracing.go
+++ b/v2/pkg/tracing/tracing.go
@@ -3,7 +3,9 @@
 // tracing.enabled=false) Init installs a no-op TracerProvider, so StartSpan and
 // friends cost effectively nothing and never touch the network. When enabled it
 // wires an OTLP/HTTP exporter and a batching SDK TracerProvider, tagged with a
-// "hive" service name plus hive-id and branch resource attributes.
+// "hive" service name plus hive-id, branch, and running-commit resource
+// attributes (service.version / hive.commit / hive.image — the PR-reach
+// anchors of #3973).
 //
 // Nothing in this package panics on missing configuration. Callers can always
 // call Tracer/StartSpan unconditionally; when disabled they get the global
@@ -38,6 +40,17 @@ const (
 	// fullSampleRatio is the sampling ratio applied when the configured ratio
 	// is unset/zero: sample everything so "enabled:true" alone yields traces.
 	fullSampleRatio = 1.0
+
+	// DefaultServiceName is the fallback OTLP service.name when the caller
+	// passes none; it mirrors config.DefaultOTelServiceName without importing
+	// the config package (this package stays independently testable).
+	DefaultServiceName = "hive"
+
+	// unknownVersion is the ldflags default cmd/hive ships when no commit was
+	// injected at build time (see `var gitShort` in cmd/hive). A version equal
+	// to it is NOT stamped onto the resource: reach attribution (#3973) must
+	// never group spans under a placeholder that isn't a real commit.
+	unknownVersion = "unknown"
 )
 
 // Resource attribute keys for hive-specific identity. These are package-level
@@ -46,6 +59,15 @@ const (
 var (
 	attrHiveID  = attribute.Key("hive.id")
 	attrBranchK = attribute.Key("hive.branch")
+	// attrCommitK stamps every span with the commit SHA baked into the RUNNING
+	// binary at build time (ldflags), the reach anchor for #3973: a published
+	// digest can advance while the binary stays old (#3816), so reach must
+	// attribute to what actually executes, never to the merge/publish event.
+	attrCommitK = attribute.Key("hive.commit")
+	// attrImageK records the Deployment-declared image ref (digest or tag) when
+	// known at runtime. Informational only: the declared ref can be newer than
+	// the running binary (#3816) — hive.commit is the authoritative anchor.
+	attrImageK = attribute.Key("hive.image")
 )
 
 // Config is the minimal set of tracing settings this package needs. It mirrors
@@ -69,6 +91,15 @@ type Config struct {
 	// HiveID and Branch are recorded as resource attributes for correlation.
 	HiveID string
 	Branch string
+	// Commit is the git commit SHA baked into the running binary (the same
+	// ldflags value `hive --version` prints). Recorded as both service.version
+	// and hive.commit so span data is attributable to the code that actually
+	// ran — the PR-reach anchor for #3973.
+	Commit string
+	// Image is the Deployment-declared container image ref (ideally a digest)
+	// when known at runtime, recorded as hive.image. Empty outside a cluster;
+	// an empty value omits the attribute rather than recording "".
+	Image string
 }
 
 // noopShutdown is returned whenever tracing is disabled or fails to initialize;
@@ -112,27 +143,7 @@ func Init(ctx context.Context, cfg Config) (func(context.Context) error, error) 
 		return noopShutdown, err
 	}
 
-	serviceName := strings.TrimSpace(cfg.ServiceName)
-	if serviceName == "" {
-		serviceName = "hive"
-	}
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(serviceName),
-			attrHiveID.String(cfg.HiveID),
-			attrBranchK.String(cfg.Branch),
-		),
-	)
-	if err != nil {
-		// Fall back to a bare resource rather than aborting tracing entirely.
-		res = resource.NewSchemaless(
-			semconv.ServiceName(serviceName),
-			attrHiveID.String(cfg.HiveID),
-			attrBranchK.String(cfg.Branch),
-		)
-	}
+	res := newResource(cfg)
 
 	ratio := cfg.SampleRatio
 	if ratio <= 0 {
@@ -150,6 +161,49 @@ func Init(ctx context.Context, cfg Config) (func(context.Context) error, error) 
 	return tp.Shutdown, nil
 }
 
+// newResource builds the OTLP resource identifying this hive process. Factored
+// out of Init so the identity attributes — especially the #3973 reach anchors
+// service.version / hive.commit / hive.image — are testable without an
+// exporter or network.
+func newResource(cfg Config) *resource.Resource {
+	serviceName := strings.TrimSpace(cfg.ServiceName)
+	if serviceName == "" {
+		serviceName = DefaultServiceName
+	}
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(serviceName),
+		attrHiveID.String(cfg.HiveID),
+		attrBranchK.String(cfg.Branch),
+	}
+	// Version stamping (#3973): the build-time commit becomes service.version
+	// (standard semconv, so any OTel backend groups by it out of the box) and
+	// hive.commit (explicit, greppable alongside the other hive.* identity
+	// attrs). Only stamped when the build actually injected a SHA — an ldflags
+	// default like "unknown" would poison reach queries with a fake version.
+	if commit := strings.TrimSpace(cfg.Commit); commit != "" && commit != unknownVersion {
+		attrs = append(attrs,
+			semconv.ServiceVersion(commit),
+			attrCommitK.String(commit),
+		)
+	}
+	// The Deployment-declared image ref, when the process could read it. Kept
+	// separate from hive.commit because the two CAN disagree (#3816) and that
+	// disagreement is itself signal: declared-but-not-running code.
+	if img := strings.TrimSpace(cfg.Image); img != "" {
+		attrs = append(attrs, attrImageK.String(img))
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(semconv.SchemaURL, attrs...),
+	)
+	if err != nil {
+		// Fall back to a bare resource rather than aborting tracing entirely.
+		res = resource.NewSchemaless(attrs...)
+	}
+	return res
+}
+
 // Tracer returns a named tracer from the global provider. When tracing is
 // disabled this is the global no-op tracer. Passing an empty name uses the
 // package default instrumentation scope.
@@ -164,6 +218,23 @@ func Tracer(name string) trace.Tracer {
 // derived context and the span. When tracing is disabled the returned span is a
 // no-op and the context is unchanged in any observable way. The caller MUST end
 // the span (typically `defer span.End()`).
+//
+// Every span automatically carries hive.component derived from its name (see
+// SpanComponent), so package-level reach (#3973) is queryable without any
+// call-site changes.
 func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	attrs = append(attrs, attribute.String(AttrHiveComponent, SpanComponent(name)))
 	return Tracer(instrumentationName).Start(ctx, name, trace.WithAttributes(attrs...))
+}
+
+// SpanComponent extracts the coarse component from a span name: the prefix
+// before the first dot under the existing "<component>.<operation>" naming
+// convention ("governor.eval_cycle" → "governor"). A name with no dot is its
+// own component. This is the deliberate phase-1 granularity for #3973 —
+// component-level, not per-PR.
+func SpanComponent(name string) string {
+	if i := strings.IndexByte(name, '.'); i > 0 {
+		return name[:i]
+	}
+	return name
 }

--- a/v2/pkg/tracing/tracing_test.go
+++ b/v2/pkg/tracing/tracing_test.go
@@ -366,6 +366,124 @@ func TestTimelineSpanAttributes_GenAIAndHiveAttrs(t *testing.T) {
 	}
 }
 
+// resourceAttrs flattens a resource into a key→string map for assertions.
+func resourceAttrs(t *testing.T, cfg Config) map[attribute.Key]string {
+	t.Helper()
+	res := newResource(cfg)
+	if res == nil {
+		t.Fatal("newResource returned nil")
+	}
+	out := map[attribute.Key]string{}
+	for _, kv := range res.Attributes() {
+		out[kv.Key] = kv.Value.AsString()
+	}
+	return out
+}
+
+// TestNewResource_StampsCommitAndImage verifies the #3973 reach anchors: the
+// running commit lands on the resource as BOTH service.version (standard
+// semconv) and hive.commit, and the Deployment-declared image ref as
+// hive.image, alongside the pre-existing identity attributes.
+func TestNewResource_StampsCommitAndImage(t *testing.T) {
+	attrs := resourceAttrs(t, Config{
+		ServiceName: "hive",
+		HiveID:      "hive-abc",
+		Branch:      "v4",
+		Commit:      "eede356",
+		Image:       "ghcr.io/kubestellar/hive@sha256:deadbeef",
+	})
+
+	if got := attrs["service.version"]; got != "eede356" {
+		t.Errorf("service.version = %q, want eede356", got)
+	}
+	if got := attrs["hive.commit"]; got != "eede356" {
+		t.Errorf("hive.commit = %q, want eede356", got)
+	}
+	if got := attrs["hive.image"]; got != "ghcr.io/kubestellar/hive@sha256:deadbeef" {
+		t.Errorf("hive.image = %q", got)
+	}
+	// Pre-existing identity attributes must survive the refactor.
+	if attrs["service.name"] != "hive" || attrs["hive.id"] != "hive-abc" || attrs["hive.branch"] != "v4" {
+		t.Errorf("identity attrs = name %q id %q branch %q",
+			attrs["service.name"], attrs["hive.id"], attrs["hive.branch"])
+	}
+}
+
+// TestNewResource_OmitsPlaceholderVersion verifies that a build without ldflags
+// injection (Commit is "unknown" or empty) stamps NO version attributes: reach
+// queries must never group spans under a placeholder pseudo-commit.
+func TestNewResource_OmitsPlaceholderVersion(t *testing.T) {
+	for _, commit := range []string{"", "unknown", "  "} {
+		attrs := resourceAttrs(t, Config{ServiceName: "hive", Commit: commit})
+		if v, ok := attrs["service.version"]; ok {
+			t.Errorf("Commit=%q: service.version unexpectedly present (%q)", commit, v)
+		}
+		if v, ok := attrs["hive.commit"]; ok {
+			t.Errorf("Commit=%q: hive.commit unexpectedly present (%q)", commit, v)
+		}
+	}
+	// Empty image likewise omits hive.image rather than recording "".
+	attrs := resourceAttrs(t, Config{ServiceName: "hive"})
+	if v, ok := attrs["hive.image"]; ok {
+		t.Errorf("hive.image unexpectedly present for empty Image (%q)", v)
+	}
+}
+
+// TestNewResource_DefaultServiceName verifies the empty-ServiceName fallback
+// still applies after the newResource refactor.
+func TestNewResource_DefaultServiceName(t *testing.T) {
+	attrs := resourceAttrs(t, Config{})
+	if attrs["service.name"] != DefaultServiceName {
+		t.Errorf("service.name = %q, want %q", attrs["service.name"], DefaultServiceName)
+	}
+}
+
+// TestSpanComponent covers the coarse span-name→component mapping (#3973
+// phase-1 granularity).
+func TestSpanComponent(t *testing.T) {
+	cases := map[string]string{
+		"governor.eval_cycle":           "governor",
+		"agent.kick":                    "agent",
+		"pr.merged":                     "pr",
+		"hive.timeline":                 "hive",
+		"nodot":                         "nodot",
+		"":                              "",
+		".leading_dot_is_own_component": ".leading_dot_is_own_component",
+	}
+	for name, want := range cases {
+		if got := SpanComponent(name); got != want {
+			t.Errorf("SpanComponent(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestStartSpan_AddsComponentAttribute verifies every span started via
+// StartSpan automatically carries hive.component derived from its name, with
+// no call-site changes (#3973).
+func TestStartSpan_AddsComponentAttribute(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	_, span := StartSpan(context.Background(), "governor.eval_cycle")
+	span.End()
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(ended))
+	}
+	var component string
+	for _, kv := range ended[0].Attributes() {
+		if string(kv.Key) == AttrHiveComponent {
+			component = kv.Value.AsString()
+		}
+	}
+	if component != "governor" {
+		t.Errorf("hive.component = %q, want governor", component)
+	}
+}
+
 func TestStartTimelineSpan_RecordsMappedSpan(t *testing.T) {
 	recorder := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))


### PR DESCRIPTION
## Phase 1 of PR-reach telemetry

Every existing quality signal (acceptance rate, coverage, CI) measures work at proposal/approval time; none answers whether merged code ever actually ran. This PR lands the cheap, load-bearing foundation: making span data attributable to the commit that is actually executing.

### What phase 1 delivers

- **Version-stamped resource** — every span now carries:
  - `service.version` + `hive.commit`: the ldflags-baked commit of the *running* binary (the same value `hive --version` prints). This is the anchoring rule from the issue: reach must attribute to what actually runs, never the merge/publish event — #3816 showed the published digest can advance while the binary stays old, and without this anchor undeployed code reads as "unused".
  - `hive.image`: the Deployment-declared image ref via the existing cached `hub.SelfDeploymentImage()` read (warm from the release-channel lookup at startup; empty outside a cluster). Kept separate from `hive.commit` because the two can disagree (#3816) and that disagreement is itself signal.
  - Builds without ldflags injection (`gitShort == "unknown"`) stamp **no** version attributes, so reach queries never group spans under a placeholder pseudo-commit.
- **`hive.component` span attribute** — `tracing.StartSpan` auto-derives the component from the span-name prefix under the existing `<component>.<operation>` convention (`governor.eval_cycle` → `governor`). Zero call-site churn; this is the coarse package-level reach dimension.
- **Testable plumbing** — resource construction factored into `newResource()`; tests assert commit/image attributes present, placeholder version omitted, and the component attribute auto-attached (`tracetest` recorder, no network). The linker's ldflags injection itself is not tested — only the plumbing function.
- **Design note** — `v2/docs/design/pr-reach-telemetry.md`: what phase 1 emits, the changed-files → component mapping, the merged≠deployed anchoring rule, and phase-2 needs.

### Deliberately deferred (phase 2+)

- Error-rate deltas pre/post merge (needs a span-status discipline audit per component first)
- First-execution latency (merge → first span on a containing build)
- Per-hive distinct-count aggregation and any query/dashboard layer
- Finer-than-package attribution (per-PR/per-function) — rejected for phase 1 per the issue's options list
- No new endpoints, no aggregation service, no dashboards — phase 1 is emit-only

Builds on the existing live OTel integration (`pkg/tracing`, opt-in via the `otel:` config block); no parallel telemetry path introduced.

Part of #3973
