### PR TITLE
✨ feature(acmm): wire a real baseline merge-success rate into the ACMM advisor

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2150,17 +2150,21 @@ func main() {
 	}
 
 	dashSrv.RegisterAPI(&dashboard.Dependencies{
-		Config:                cfg,
-		AgentMgr:              agentMgr,
-		Governor:              gov,
-		GHClient:              ghClient,
-		GHAppAuth:             appAuth,
-		Tokens:                tokenCollector,
-		Knowledge:             knowledgeAPI,
-		Inception:             inceptionEngine,
-		Nous:                  nousState,
-		Scheduler:             sched,
-		MetricsCollector:      metricsCollector,
+		Config:           cfg,
+		AgentMgr:         agentMgr,
+		Governor:         gov,
+		GHClient:         ghClient,
+		GHAppAuth:        appAuth,
+		Tokens:           tokenCollector,
+		Knowledge:        knowledgeAPI,
+		Inception:        inceptionEngine,
+		Nous:             nousState,
+		Scheduler:        sched,
+		MetricsCollector: metricsCollector,
+		// #3972: hand the ACMM advisor the SAME cached fleet-stats collector
+		// the heartbeat reads, so its merge-success signal reuses the existing
+		// 30-minute collect loop instead of issuing a second GitHub fetch.
+		FleetStats:            fleetStatsCollector,
 		BeadSynthesizer:       beadSynth,
 		BeadStores:            beadStores,
 		BeadStoreLoadFailures: beadStoreLoadFailures,

--- a/v2/pkg/dashboard/api_acmm_recommendation.go
+++ b/v2/pkg/dashboard/api_acmm_recommendation.go
@@ -41,23 +41,29 @@ func (s *Server) handleACMMRecommendation(w http.ResponseWriter, r *http.Request
 // buildACMMStatusInputs assembles the forge-neutral advisor inputs from the
 // signals the dashboard already gathers. It is nil-safe at every step: a nil
 // Server, nil deps, nil config, or nil cached status all collapse to safe zero
-// values rather than panicking. It fabricates nothing — signals the hive does
-// not yet track (green-CI streak, merge-success rate) are left at zero, which
-// the advisor treats as "not yet earned" rather than inventing a number.
+// values rather than panicking. It fabricates nothing — a signal the hive does
+// not yet track (green-CI streak) is left at zero, which the advisor treats as
+// "not yet earned" rather than inventing a number.
 func (s *Server) buildACMMStatusInputs() acmmadvisor.StatusInputs {
 	in := acmmadvisor.StatusInputs{
 		// A hive with no explicit level detects as MinLevel (L1); see
 		// detectACMMLevel. Zero-value fallbacks keep this at a safe default.
 		CurrentLevel: acmmadvisor.MinLevel,
-		// GreenStreak and MergeSuccessRate are intentionally left at zero: the
-		// hive does not yet track a real green-CI streak or a merge-success
-		// rate as first-class signals, and the advisor must never fabricate
-		// them. They therefore read as "unknown / not yet earned", which only
-		// ever makes the advisor MORE conservative (it will not propose a raise
-		// on the strength of a made-up streak). When those signals become
-		// available, populate them here.
-		// TODO(acmm-signals): thread a real GreenStreak / MergeSuccessRate from
-		// CI/merge history once tracked.
+		// GreenStreak is intentionally left at zero: the hive does not yet
+		// track a real green-CI streak as a first-class signal, and the
+		// advisor must never fabricate one. It therefore reads as "unknown /
+		// not yet earned", which only ever makes the advisor MORE conservative
+		// (it will not propose a raise on the strength of a made-up streak).
+		// When the signal becomes available, populate it here.
+		// TODO(acmm-signals): thread a real GreenStreak from CI history once
+		// tracked.
+		//
+		// MergeSuccessRate IS real as of #3972: it is populated below from the
+		// fleet-stats collector's cached 90-day merged/rejected counts. See
+		// mergeSuccessRateFromFleetStats for what it measures and its known
+		// weaknesses (size-gameable, single-judgment, censored); the
+		// survival-adjusted term ("without being reverted") remains follow-up
+		// work blocked by #3971.
 	}
 
 	var cfg *config.Config
@@ -67,6 +73,19 @@ func (s *Server) buildACMMStatusInputs() acmmadvisor.StatusInputs {
 	if cfg != nil {
 		in.CurrentLevel = detectACMMLevel(cfg)
 		in.HasQualityAgent = hasQualityAgent(cfg)
+	}
+
+	// Baseline merge-success rate (#3972), read from the fleet-stats collector
+	// cache the heartbeat already maintains — no fresh GitHub call. When the
+	// collector has never completed a collect, or the 90-day window holds no
+	// resolved PRs, the signal STAYS at zero ("unknown / not yet earned")
+	// rather than being reported as a measured 0.0 or a vacuous 1.0 — the
+	// advisor gates autonomy on this value, and the never-fabricate contract
+	// above applies to absence-of-data exactly as it does to GreenStreak.
+	if s != nil && s.deps != nil {
+		if rate, measured := mergeSuccessRateFromFleetStats(s.deps.FleetStats); measured {
+			in.MergeSuccessRate = rate
+		}
 	}
 
 	// Live queue/coverage signals come from the most recent status snapshot the
@@ -94,6 +113,31 @@ func hasQualityAgent(cfg *config.Config) bool {
 	}
 	_, ok := cfg.Agents[qualityAgentName]
 	return ok
+}
+
+// mergeSuccessRateFromFleetStats derives the advisor's baseline merge-success
+// rate from the fleet-stats collector's cached counts: merged / (merged +
+// closed-unmerged) over the trailing 90-day window (#3972). Nil-safe: a nil
+// collector, a collector that has never completed a collect, or a window with
+// no resolved PRs all return measured=false, and the caller leaves the signal
+// at its conservative zero instead of fabricating a rate.
+//
+// Caveats (condensed; full discussion on the counts method): the ratio is
+// gameable by PR size — the console's self-improvement loop literally learned
+// "keep changes under 50 lines for best acceptance rate" (Goodhart observed
+// in-project); it measures one maintainer's judgment; and it is censored,
+// counting only proposed work — it was green throughout the 2026-08-14 fleet
+// outage. These weaknesses are WHY the survival term ("merged AND not
+// reverted") exists as the #3972 follow-up, blocked today by #3971 (beads
+// archival destroys the post-merge history it needs). The denominator
+// deliberately counts superseded/duplicate PRs as non-successes: stricter,
+// and harder to game by re-proposing the same change.
+func mergeSuccessRateFromFleetStats(fc *FleetStatsCollector) (rate float64, measured bool) {
+	counts, ready := fc.Snapshot()
+	if !ready {
+		return 0, false
+	}
+	return counts.BaselineMergeSuccessRate()
 }
 
 // coverageFromAgentMetrics extracts the integer coverage percentage from the

--- a/v2/pkg/dashboard/api_acmm_recommendation_test.go
+++ b/v2/pkg/dashboard/api_acmm_recommendation_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubestellar/hive/v2/pkg/acmmadvisor"
 	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
 
 // TestHandleACMMRecommendationEmpty verifies the endpoint is safe with a
@@ -133,9 +134,70 @@ func TestBuildACMMStatusInputs_ReadsLiveSignals(t *testing.T) {
 	if in.CoveragePct != 88 {
 		t.Fatalf("CoveragePct = %v, want 88", in.CoveragePct)
 	}
-	// Signals the hive does not track must remain zero (never fabricated).
+	// GreenStreak is still untracked and must remain zero (never fabricated).
+	// MergeSuccessRate must also read zero here: no fleet-stats collector is
+	// wired into deps, so the signal is unknown, not measured (#3972).
 	if in.GreenStreak != 0 || in.MergeSuccessRate != 0 {
 		t.Fatalf("GreenStreak/MergeSuccessRate should be 0, got %d / %v", in.GreenStreak, in.MergeSuccessRate)
+	}
+}
+
+// TestBuildACMMStatusInputs_MergeSuccessRate verifies the #3972 wiring: when
+// the fleet-stats collector holds a completed collect, the advisor input is
+// the real merged/(merged+rejected) ratio — no longer the hardcoded zero —
+// and when counts are absent or the window is empty the input stays at the
+// honest, conservative zero instead of a fabricated rate.
+func TestBuildACMMStatusInputs_MergeSuccessRate(t *testing.T) {
+	cases := []struct {
+		name string
+		fc   *FleetStatsCollector
+		want float64
+	}{
+		{
+			name: "measured ratio flows through",
+			// 30 merged / 10 rejected over the window → 0.75. Before #3972
+			// this input was hardcoded to 0, so this case fails against the
+			// unfixed behavior.
+			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{PRsMerged: 30, PRsRejected: 10}, ready: true},
+			want: 0.75,
+		},
+		{
+			name: "nil collector stays zero",
+			fc:   nil,
+			want: 0,
+		},
+		{
+			name: "collector never collected stays zero",
+			fc:   &FleetStatsCollector{},
+			want: 0,
+		},
+		{
+			name: "empty window stays zero, not a fabricated 1.0",
+			// A successful collect that found no resolved PRs: the rate is
+			// unknown, and the advisor must not see a measured value.
+			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{}, ready: true},
+			want: 0,
+		},
+		{
+			name: "all rejected reads as measured zero",
+			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{PRsRejected: 5}, ready: true},
+			want: 0,
+		},
+		{
+			name: "all merged reads as measured 1.0",
+			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{PRsMerged: 4}, ready: true},
+			want: 1.0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServer()
+			s.deps = &Dependencies{FleetStats: tc.fc}
+			in := s.buildACMMStatusInputs()
+			if in.MergeSuccessRate != tc.want {
+				t.Fatalf("MergeSuccessRate = %v, want %v", in.MergeSuccessRate, tc.want)
+			}
+		})
 	}
 }
 

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -31,8 +31,16 @@ type Dependencies struct {
 	Nous             *NousState
 	Scheduler        *scheduler.Scheduler
 	MetricsCollector *MetricsCollector
-	BeadSynthesizer  *knowledge.BeadSynthesizer
-	BeadStores       map[string]*beads.Store
+	// FleetStats is the spoke's fleet-stat contribution collector (PRs
+	// merged/rejected over the trailing 90-day window, cached, refreshed on a
+	// 30-minute timer). The ACMM advisor derives its baseline merge-success
+	// rate from this cache (#3972), so wiring the SAME collector the heartbeat
+	// already uses keeps the advisor read-only and adds zero GitHub traffic.
+	// Nil is safe: Snapshot() on a nil collector reports ready=false and the
+	// advisor leaves the signal at its conservative zero.
+	FleetStats      *FleetStatsCollector
+	BeadSynthesizer *knowledge.BeadSynthesizer
+	BeadStores      map[string]*beads.Store
 	// BeadStoreLoadFailures counts configured bead stores that failed to open at
 	// startup and were therefore LEFT OUT of BeadStores entirely. The dependency
 	// admission gate (contribute_admission_deps.go) needs this because it cannot

--- a/v2/pkg/github/fleet_stats.go
+++ b/v2/pkg/github/fleet_stats.go
@@ -25,6 +25,45 @@ type FleetContribCounts struct {
 	CVEsClosed int `json:"cves_closed"`
 }
 
+// BaselineMergeSuccessRate returns the fraction (0.0–1.0) of this window's
+// resolved PRs that merged — PRsMerged / (PRsMerged + PRsRejected) — plus a
+// measured flag. It is the phase-1 merge-success signal for the ACMM advisor
+// (#3972): a plain landed-vs-rejected ratio over the counts the fleet-stats
+// collector already gathers, with no extra API traffic.
+//
+// measured is false when the window holds no resolved PRs at all. Callers must
+// then treat the rate as UNKNOWN — never as a perfect 1.0 or a failing 0.0 —
+// because the advisor uses this value as an autonomy gate and must not act on
+// a number that was never observed (the "never fabricate" contract in
+// pkg/dashboard buildACMMStatusInputs).
+//
+// Known weaknesses, kept deliberately (they are why the survival term exists
+// as follow-up):
+//   - Gameable by PR size: optimizing for acceptance rewards tiny, safe
+//     changes (the console's self-improvement loop literally learned "keep
+//     changes under 50 lines for best acceptance rate" — Goodhart observed
+//     in-project).
+//   - Measures one maintainer's judgment at merge time, not the change's
+//     actual quality.
+//   - Censored: it only counts proposed work, so it says nothing about harm
+//     from work that merged — this metric was green throughout the 2026-08-14
+//     fleet outage.
+//   - The denominator's is:closed is:unmerged search counts superseded and
+//     duplicate PRs as non-successes. That is intended: stricter, and harder
+//     to game by re-proposing the same change.
+//
+// "Baseline" in the name leaves room for a survival-adjusted variant
+// ("merged AND not reverted within N days") to slot in beside it. That term
+// is blocked on #3971 — beads archival currently destroys the post-merge
+// history it needs — and is tracked as the #3972 follow-up.
+func (c FleetContribCounts) BaselineMergeSuccessRate() (rate float64, measured bool) {
+	resolved := c.PRsMerged + c.PRsRejected
+	if resolved <= 0 {
+		return 0, false
+	}
+	return float64(c.PRsMerged) / float64(resolved), true
+}
+
 // fleetStatsWindowDays is the trailing window (in days) over which merged and
 // rejected PR counts are measured. Ninety days keeps the number current
 // ("what has the fleet done lately") without being a lifetime figure that only

--- a/v2/pkg/github/fleet_stats_test.go
+++ b/v2/pkg/github/fleet_stats_test.go
@@ -69,6 +69,58 @@ func TestSearchCVEPRCount(t *testing.T) {
 	}
 }
 
+// TestBaselineMergeSuccessRate covers the phase-1 merge-success ratio (#3972):
+// the normal mixed case, both degenerate all-merged / all-rejected extremes
+// (which ARE measured — 1.0 and 0.0 are real observations when PRs resolved in
+// the window), and the empty window, which must report measured=false so the
+// ACMM advisor never gates autonomy on a rate that was never observed.
+func TestBaselineMergeSuccessRate(t *testing.T) {
+	tests := []struct {
+		name         string
+		counts       FleetContribCounts
+		wantRate     float64
+		wantMeasured bool
+	}{
+		{
+			name:         "normal mix",
+			counts:       FleetContribCounts{PRsMerged: 30, PRsRejected: 10},
+			wantRate:     0.75,
+			wantMeasured: true,
+		},
+		{
+			name: "zero denominator is unmeasured, not 1.0 or 0.0",
+			// No resolved PRs in the window: the rate is UNKNOWN. Reporting a
+			// number here would fabricate an autonomy-gate signal.
+			counts:       FleetContribCounts{},
+			wantRate:     0,
+			wantMeasured: false,
+		},
+		{
+			name:         "all merged",
+			counts:       FleetContribCounts{PRsMerged: 7},
+			wantRate:     1.0,
+			wantMeasured: true,
+		},
+		{
+			name:         "all rejected",
+			counts:       FleetContribCounts{PRsRejected: 5},
+			wantRate:     0.0,
+			wantMeasured: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rate, measured := tt.counts.BaselineMergeSuccessRate()
+			if measured != tt.wantMeasured {
+				t.Fatalf("measured = %v, want %v", measured, tt.wantMeasured)
+			}
+			if rate != tt.wantRate {
+				t.Errorf("rate = %v, want %v", rate, tt.wantRate)
+			}
+		})
+	}
+}
+
 func TestComputeFleetContribCounts(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## What

Replaces the hardcoded `MergeSuccessRate = 0` in the ACMM advisor input (`v2/pkg/dashboard/api_acmm_recommendation.go`) with a real, phase-1 baseline signal: `merged / (merged + closed-unmerged)` over the trailing 90-day window.

## How

The fleet-stats collector already fetches both halves of the ratio (`is:merged` and `is:closed is:unmerged` counts in `v2/pkg/github/fleet_stats.go`) and caches them on a 30-minute loop for the heartbeat. This PR reuses that plumbing — **no second GitHub fetch**:

- `FleetContribCounts.BaselineMergeSuccessRate() (rate float64, measured bool)` — the ratio lives on the counts type in `pkg/github`, next to the searches that produce it.
- `dashboard.Dependencies` gains a `FleetStats *FleetStatsCollector` field; `cmd/hive/main.go` passes the same collector instance the heartbeat snapshots. The collector and the advisor input builder are both in `pkg/dashboard`, so this is the smallest honest bridge — one struct field, no new package edges.
- `buildACMMStatusInputs` populates the signal only when `measured` is true; the `TODO(acmm-signals)` comment now covers GreenStreak alone.

## Zero-denominator handling (the never-fabricate contract)

The advisor gates autonomy (L4 ≥ 0.70, L5 ≥ 0.85, L6 ≥ 0.95) on this value, so an empty window must not read as a measured 1.0 or 0.0. `BaselineMergeSuccessRate` returns `measured=false` when no PRs resolved in the window, and the input then **stays at the conservative zero** — the same "unknown / not yet earned" shape GreenStreak's absence already uses (`StatusInputs` has no has-data field, and zero fails every floor, which is exactly the conservative behavior). A collector that has never completed a collect (`ready=false`) is treated identically.

## Known weaknesses (documented in code, kept deliberately)

- **Gameable by PR size** — the console's self-improvement loop literally learned "keep changes under 50 lines for best acceptance rate" (Goodhart observed in-project).
- **Measures one maintainer's judgment** at merge time, not the change's quality.
- **Censored** — counts only proposed work; this metric was green throughout the 2026-08-14 fleet outage.
- The `is:closed is:unmerged` denominator counts superseded/duplicate PRs as non-successes — **intended**: stricter, and harder to game by re-proposing the same change.

These are why the survival term ("merged AND not reverted within N days") exists as follow-up. That term is **out of scope here and blocked by #3971** (beads archival destroys the post-merge history it needs); the `Baseline` name leaves room for a survival-adjusted variant to slot in beside it.

## Tests

- `TestBaselineMergeSuccessRate` (pkg/github): table test — normal mix (0.75), zero denominator → `measured=false`, all-merged (1.0), all-rejected (0.0, still measured).
- `TestBuildACMMStatusInputs_MergeSuccessRate` (pkg/dashboard): asserts the advisor input carries the real ratio when counts are present, and stays honestly zero for nil collector / never-collected / empty window.
- Verified the fail-on-unfixed property: with the wiring reverted to the old hardcoded zero, the `measured ratio flows through` and `all merged` cases fail (`MergeSuccessRate = 0, want 0.75 / 1`); with the fix they pass. The absence cases pass either way by design — they encode the preserved never-fabricate contract, not the fix. The ratio-method table test cannot fail pre-fix since the method is new.

Targeted `go test ./pkg/github/ ./pkg/dashboard/` (acmm + fleet-stats runs) pass locally.

Fixes #3972
