### PR TITLE
🐛 fix(beads): preserve audit fields in archive records

### DIFF
--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -240,25 +240,16 @@ func (s *Store) evictOldClosed() {
 	}
 }
 
-// appendArchiveEntry writes one compact archive record, reporting whether the
-// record actually reached disk. Callers use that to decide whether removing the
-// bead is safe: an in-memory-only retirement is forgotten on restart.
+// appendArchiveEntry writes one archive record, reporting whether the record
+// actually reached disk. Callers use that to decide whether removing the bead
+// is safe: an in-memory-only retirement is forgotten on restart. The record
+// contents come from newArchivedBead — the same builder Archive() uses — so
+// eviction preserves exactly what archival preserves (#3971).
 func (s *Store) appendArchiveEntry(b *Bead) bool {
 	if b == nil {
 		return false
 	}
-	entry := ArchivedBead{
-		ID:          b.ID,
-		Title:       b.Title,
-		Type:        b.Type,
-		Priority:    b.Priority,
-		ExternalRef: b.ExternalRef,
-		ArchivedAt:  time.Now().UTC(),
-	}
-	if b.ClosedAt != nil {
-		entry.ClosedAt = b.ClosedAt.Time
-	}
-	data, err := json.Marshal(entry)
+	data, err := json.Marshal(newArchivedBead(b))
 	if err != nil {
 		return false
 	}
@@ -688,18 +679,54 @@ func (s *Store) Count() int {
 const archiveFileName = "archive.jsonl"
 
 // ArchivedBead is the compact representation written to the archive log.
+//
+// It carries the audit fields — Status, Actor, Metadata, CreatedAt — alongside
+// the identity fields. Earlier versions dropped these (#3971), which destroyed
+// the merge-outcome metadata (pr_merged, pr_ref, fix_attempts) and the
+// who/what/when needed to compute the ACMM advisor's MergeSuccessRate from
+// history (#3972). Heavy free-text fields (Notes) are still intentionally
+// excluded to keep archive entries compact.
 type ArchivedBead struct {
-	ID          string    `json:"id"`
-	Title       string    `json:"title"`
-	Type        BeadType  `json:"type"`
-	Priority    Priority  `json:"priority"`
-	ExternalRef string    `json:"external_ref,omitempty"`
-	ClosedAt    time.Time `json:"closed_at,omitempty"`
-	ArchivedAt  time.Time `json:"archived_at"`
+	ID          string                 `json:"id"`
+	Title       string                 `json:"title"`
+	Type        BeadType               `json:"type"`
+	Status      Status                 `json:"status,omitempty"`
+	Priority    Priority               `json:"priority"`
+	Actor       string                 `json:"actor,omitempty"`
+	ExternalRef string                 `json:"external_ref,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	CreatedAt   time.Time              `json:"created_at,omitempty"`
+	ClosedAt    time.Time              `json:"closed_at,omitempty"`
+	ArchivedAt  time.Time              `json:"archived_at"`
 }
 
-// Archive writes a compact summary of the bead to archive.jsonl, then removes
-// it from the store. This preserves an audit trail without the full bead weight.
+// newArchivedBead builds the archive record for a bead. It is the single
+// source of truth for what an archive entry contains, shared by Archive() and
+// the eviction path's appendArchiveEntry() so the two removal paths cannot
+// preserve different data (#3971): before this existed, each built its own
+// entry inline, and both silently dropped the audit fields.
+func newArchivedBead(b *Bead) ArchivedBead {
+	entry := ArchivedBead{
+		ID:          b.ID,
+		Title:       b.Title,
+		Type:        b.Type,
+		Status:      b.Status,
+		Priority:    b.Priority,
+		Actor:       b.Actor,
+		ExternalRef: b.ExternalRef,
+		Metadata:    b.Metadata,
+		CreatedAt:   b.CreatedAt.Time,
+		ArchivedAt:  time.Now().UTC(),
+	}
+	if b.ClosedAt != nil {
+		entry.ClosedAt = b.ClosedAt.Time
+	}
+	return entry
+}
+
+// Archive writes the bead's audit record (including status, actor, metadata,
+// and timestamps — see ArchivedBead) to archive.jsonl, then removes it from
+// the store. Notes are dropped to keep the archive compact.
 func (s *Store) Archive(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -709,19 +736,7 @@ func (s *Store) Archive(id string) error {
 		return fmt.Errorf("bead %s not found", id)
 	}
 
-	entry := ArchivedBead{
-		ID:          b.ID,
-		Title:       b.Title,
-		Type:        b.Type,
-		Priority:    b.Priority,
-		ExternalRef: b.ExternalRef,
-		ArchivedAt:  time.Now().UTC(),
-	}
-	if b.ClosedAt != nil {
-		entry.ClosedAt = b.ClosedAt.Time
-	}
-
-	data, err := json.Marshal(entry)
+	data, err := json.Marshal(newArchivedBead(b))
 	if err != nil {
 		return fmt.Errorf("marshaling archive entry: %w", err)
 	}

--- a/v2/pkg/beads/beads_archive_dataloss_test.go
+++ b/v2/pkg/beads/beads_archive_dataloss_test.go
@@ -1,0 +1,174 @@
+package beads
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readArchiveEntries parses archive.jsonl into a map keyed by bead ID.
+func readArchiveEntries(t *testing.T, dir string) map[string]ArchivedBead {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, archiveFileName))
+	if err != nil {
+		t.Fatalf("reading archive file: %v", err)
+	}
+	entries := make(map[string]ArchivedBead)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e ArchivedBead
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("parsing archive line %q: %v", line, err)
+		}
+		entries[e.ID] = e
+	}
+	return entries
+}
+
+// TestArchive_PreservesAuditFields is the regression test for #3971: the
+// archive record must preserve the merge-outcome metadata (pr_merged, pr_ref,
+// fix_attempts), the actor, the status, and CreatedAt — the fields the ACMM
+// advisor's MergeSuccessRate (#3972) needs to be computed from history.
+// Before the fix, ArchivedBead silently dropped all of them, so this test
+// fails against the unfixed code (the JSON has no such keys and the asserted
+// values come back zero).
+func TestArchive_PreservesAuditFields(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	b, err := s.Create("merged feature", TypeFeature, PriorityHigh, "merge-bot", "org/repo#42")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for k, v := range map[string]string{
+		"pr_merged":    "true",
+		"pr_ref":       "org/repo#42",
+		"fix_attempts": "2",
+	} {
+		if err := s.SetMetadata(b.ID, k, v); err != nil {
+			t.Fatalf("SetMetadata %s: %v", k, err)
+		}
+	}
+	if err := s.Close(b.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := s.Archive(b.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	entries := readArchiveEntries(t, dir)
+	e, ok := entries[b.ID]
+	if !ok {
+		t.Fatalf("archive missing entry for %s: %v", b.ID, entries)
+	}
+	if got := e.Metadata["pr_merged"]; got != "true" {
+		t.Errorf("archived metadata pr_merged = %v, want \"true\"", got)
+	}
+	if got := e.Metadata["pr_ref"]; got != "org/repo#42" {
+		t.Errorf("archived metadata pr_ref = %v, want \"org/repo#42\"", got)
+	}
+	if got := e.Metadata["fix_attempts"]; got != "2" {
+		t.Errorf("archived metadata fix_attempts = %v, want \"2\"", got)
+	}
+	if e.Actor != "merge-bot" {
+		t.Errorf("archived actor = %q, want \"merge-bot\"", e.Actor)
+	}
+	if e.Status != StatusClosed {
+		t.Errorf("archived status = %q, want %q", e.Status, StatusClosed)
+	}
+	if e.CreatedAt.IsZero() {
+		t.Errorf("archived created_at is zero, want the bead's creation time")
+	}
+	if e.ClosedAt.IsZero() {
+		t.Errorf("archived closed_at is zero, want the bead's close time")
+	}
+}
+
+// TestEvictOldClosed_ArchivePreservesAuditFields is the eviction-path half of
+// the #3971 regression: every bead removed by evictOldClosed must carry its
+// full audit record (actor, metadata, status, created_at) into archive.jsonl,
+// exactly as Archive() does — both paths share newArchivedBead. Before the
+// fix, eviction wrote the same field-stripped record as Archive, so this test
+// fails against the unfixed code with empty actor/metadata in every entry.
+func TestEvictOldClosed_ArchivePreservesAuditFields(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store.mu.Lock()
+	// Inject beads directly into the map to avoid 5000+ disk writes,
+	// matching the existing eviction test pattern.
+	const extra = 10
+	total := maxBeadCount + extra
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("bead-%05d", i)
+		status := StatusOpen
+		if i%2 == 0 {
+			status = StatusClosed
+		}
+		store.beads[id] = &Bead{
+			ID:       id,
+			Title:    fmt.Sprintf("test bead %d", i),
+			Type:     TypeTask,
+			Status:   status,
+			Priority: PriorityLow,
+			Actor:    "scanner",
+			Metadata: map[string]interface{}{
+				"pr_merged": "true",
+				"pr_ref":    fmt.Sprintf("org/repo#%d", i),
+			},
+			CreatedAt: flexTime{time.Now().UTC().Add(-time.Duration(total-i) * time.Minute)},
+			UpdatedAt: flexTime{time.Now().UTC().Add(-time.Duration(total-i) * time.Minute)},
+		}
+	}
+
+	before := make(map[string]bool, len(store.beads))
+	for id := range store.beads {
+		before[id] = true
+	}
+	store.evictOldClosed()
+	var evicted []string
+	for id := range before {
+		if _, still := store.beads[id]; !still {
+			evicted = append(evicted, id)
+		}
+	}
+	store.mu.Unlock()
+
+	if len(evicted) == 0 {
+		t.Fatalf("expected eviction to remove beads (total=%d, cap=%d)", total, maxBeadCount)
+	}
+
+	entries := readArchiveEntries(t, dir)
+	for _, id := range evicted {
+		e, ok := entries[id]
+		if !ok {
+			t.Errorf("evicted bead %s has no archive record", id)
+			continue
+		}
+		if e.Actor != "scanner" {
+			t.Errorf("archived actor for %s = %q, want \"scanner\"", id, e.Actor)
+		}
+		if got := e.Metadata["pr_merged"]; got != "true" {
+			t.Errorf("archived metadata pr_merged for %s = %v, want \"true\"", id, got)
+		}
+		if e.Status != StatusClosed {
+			t.Errorf("archived status for %s = %q, want %q", id, e.Status, StatusClosed)
+		}
+		if e.CreatedAt.IsZero() {
+			t.Errorf("archived created_at for %s is zero, want the bead's creation time", id)
+		}
+	}
+}


### PR DESCRIPTION
## What

Completes #3971 by fixing the audit-field data loss in bead archival, in `v2/pkg/beads/beads.go`:

**`ArchivedBead` discarded the audit fields.** It kept only `ID`, `Title`, `Type`, `Priority`, `ExternalRef`, `ClosedAt`, `ArchivedAt` — dropping `Metadata` (losing `pr_merged`, `pr_ref`, `fix_attempts`), `Actor`, `Status`, and `CreatedAt`, while its doc comment claimed it "preserves an audit trail". Those fields are now preserved (same types as `Bead`). `Notes` remains intentionally excluded — the full-bead-weight concern is legitimate for free text. Doc comments updated to say what is now true.

The archive record was also built inline in two places — `Archive()` and the eviction path's `appendArchiveEntry()` — which is exactly how the two removal paths could preserve different data. Both now share a single builder, `newArchivedBead()`, so they cannot drift apart again.

**Scope note:** the eviction half of #3971 (bare `delete(s.beads, id)` with no archive record) was independently fixed on `v4` by #3904, which made `evictOldClosed` archive-and-retire each victim with a keep-on-failure guard. This PR completes the issue: the shared record that both paths write now actually preserves the who/what/when.

## Why

`v2/pkg/acmmadvisor/acmmadvisor.go` gates autonomy on `MergeSuccessRate` — "merged cleanly without being reverted or abandoned". Computing that historically requires exactly the fields being destroyed: the merge-outcome metadata, the actor, and the timestamps. The archival path is live in production today (`v2/pkg/knowledge/bead_lifecycle.go` calls `store.Archive(...)` from the retention sweep), so every archived bead was losing this data. #3972 (wiring the real metric) is blocked on this fix.

## Orphan-file check

Checked whether eviction's map delete also left orphaned per-bead state on disk: it does not. `persist()` rewrites `beads.json` wholesale (single JSON array, no per-bead files), and `evictOldClosed` is only called from `Create()`, which calls `persist()` immediately after — so disk stays consistent and no load-path change is needed. (`archive.jsonl` is append-only by design and is additionally read at startup by `loadRetired()` from #3904; entries with more fields remain fully compatible with that reader, which only consumes `id`.)

## Tests

New regression tests in `v2/pkg/beads/beads_archive_dataloss_test.go`:

- `TestArchive_PreservesAuditFields` — archives a bead carrying `pr_merged=true`, `pr_ref`, `fix_attempts`, and a distinct actor; reads back `archive.jsonl` and asserts metadata, actor, status, `created_at`, and `closed_at` all survive.
- `TestEvictOldClosed_ArchivePreservesAuditFields` — fills the store past `maxBeadCount` (direct map injection, matching the existing eviction-test pattern), triggers eviction, and asserts every evicted bead's archive record carries its actor, metadata, status, and `created_at`.

**Verified the tests fail against the unfixed code**: with `beads.go` at the current `v4` base, the audit-field assertions cannot even compile (`ArchivedBead` has no `Metadata`/`Actor`/`Status`/`CreatedAt` fields), and the values asserted are precisely the ones the old record never wrote — the tests cannot pass both before and after.

```
$ go test ./pkg/beads/ -count=1
ok  	github.com/kubestellar/hive/v2/pkg/beads	0.460s
```

All pre-existing beads tests — including the #3904 retirement suite (`TestEvictOldClosed_RetiresEvictedBeadsAndArchivesThem`, `TestEvictOldClosed_ArchiveFailureKeepsTheBead`, restart-survival tests) — pass unchanged.

Fixes #3971
