### PR TITLE
fix(ci): notify on cancelled/timed-out v2 Tests runs, not just failures

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: go test ./pkg/... -short -race -count=1
 
   create-issue-on-failure:
-    if: failure() && github.event_name == 'schedule'
+    if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -51,7 +51,9 @@ jobs:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sha = context.sha.substring(0, 7);
-            const title = `[Tests] v2 test failure on ${sha}`;
+            const wasCancelled = '${{ needs.test.result }}' === 'cancelled';
+            const kind = wasCancelled ? 'cancelled (likely timed out)' : 'failure';
+            const title = `[Tests] v2 test ${wasCancelled ? 'cancelled' : 'failure'} on ${sha}`;
 
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -60,13 +62,13 @@ jobs:
               labels: 'ci-failure',
               per_page: 10,
             });
-            const dup = existing.data.find(i => i.title.startsWith('[Tests] v2 test failure'));
+            const dup = existing.data.find(i => i.title.startsWith('[Tests] v2 test'));
             if (dup) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: dup.number,
-                body: `Another failure on \`${sha}\`: ${runUrl}`,
+                body: `Another ${kind} on \`${sha}\`: ${runUrl}`,
               });
               return;
             }
@@ -75,6 +77,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title,
-              body: `## Test Failure\n\n- **Commit:** \`${context.sha}\`\n- **Run:** ${runUrl}\n- **Branch:** v2\n\nScheduled test run failed. See the [workflow run](${runUrl}) for details.`,
+              body: `## Test ${wasCancelled ? 'Cancelled' : 'Failure'}\n\n- **Commit:** \`${context.sha}\`\n- **Run:** ${runUrl}\n- **Branch:** v2\n\nScheduled test run was ${kind}. See the [workflow run](${runUrl}) for details.`,
               labels: ['ci-failure', 'kind/bug'],
             });


### PR DESCRIPTION
## Summary

Addresses a `ci-maintainer` finding from the #2364 advisory digest:

> **[workflow-gap]** v2-tests.yml: create-issue-on-failure silently skips cancelled (timed-out) runs
> The create-issue-on-failure job in v2-tests.yml uses condition `if: failure() && github.event_name == schedule`. When the test job is cancelled (e.g. due to job timeout, or a runner preemption), GitHub sets conclusion=cancelled on the job — which does NOT satisfy `failure()`. As a result, scheduled v2-test runs that time out produce zero notification to operators.

I verified this is still live on the current `v4` default branch (the workflow's condition was untouched). Note: most other findings in the #2364 digest I checked (SSRF guards, `requireOwnerRole` gates, `hub_keys.go`/`audit.go` coverage gaps, `contribute_ws.go` pendingToken cleanup) turned out to already be fixed by prior merged PRs — the digest just hasn't pruned them. This one was a genuine, still-open gap.

- `create-issue-on-failure` now runs on `(failure() || cancelled())`, matching the digest's suggested fix.
- The filed issue's title/body distinguish a genuine test failure from a cancellation/timeout, so operators aren't misled about which happened.
- Kept the duplicate-detection prefix (`[Tests] v2 test`) broad enough to still dedupe across both failure and cancellation issues into one thread.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/v2-tests.yml'))"` — YAML parses cleanly
- [x] Manually traced both branches of the new `if` conditions in the `github-script` step
- [ ] No way to trigger an actual cancelled scheduled run from a PR; this is exercised for real the next time a scheduled run times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)