### PR TITLE
docs: fix 404 links in v2/docs/README.md (hive intro page)

### DIFF
--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -2,79 +2,79 @@
 
 Documentation for the current Hive line (branch `v4`; the code and docs live under the historically named `v2/` directory — the doubled `v2` in repo paths is the directory name, not a branch). The `v2` branch was retired in August 2026.
 
-Start with [Architecture](architecture.md) for the system overview, then use the topic guides below.
+Start with [Architecture](../architecture.md) for the system overview, then use the topic guides below.
 
 ## Operations
 
-- [Manual provisioning](manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
-- [Self-hosted hub deployment](hub-deployment.md) — `HIVE_MODE=hub`, hub storage, heartbeat secrets, and SaaS spoke registration.
-- [`CAP_NET_ADMIN` and self-hosted spokes](net-admin-requirement.md) — the container runs with or without `NET_ADMIN`; granting it (`--cap-add NET_ADMIN` / `securityContext.capabilities.add`) enables the full forced-proxy-egress gate, and what the degraded best-effort mode means without it.
-- [Config layering](config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
-- [Operator reference](operator-reference.md) — top-level config blocks, hive flags/env, GitHub token scopes, and image provenance.
-- [Release channels](release-channels.md) — `stable`/`candidate`/`edge` moving image tags, switching a hive to a channel, and the `stable (v4)` version pill.
-- [The `auto-update` Compose profile](auto-update-profile.md) — what unattended Watchtower updates cost you, what the Docker socket proxy does and does **not** fix, and why Kubernetes should not use this profile at all.
-- [Environment variable reference](env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
-- [Troubleshooting](troubleshooting.md) — container logs, config validation, agent tmux sessions, dashboard auth, and GitHub credential checks.
-- [Cross-cluster migration](cross-cluster-migration.md) — the manual procedure for moving a hive between clusters.
-- [Dashboard route and health checks](health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
-- [Network and port requirements](network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
-- [TLS, HTTPS, and certificates](tls-setup.md) — termination patterns and certificate ownership.
-- [Security notes](security.md) — log scrubbing and secret redaction guarantees/limits.
-- [Token collection and usage tracking](token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
-- [Notifications](notifications.md) — ntfy, Slack, and Discord alert channels, plus the two-way [Discord bot](../../discord/README.md).
-- [Public snapshots](snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
-- [hivectl](hivectl.md) — command-line client for the dashboard API.
-- [`bd` beads CLI](beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
-- [Backup and restore](backup-restore.md) — `hive-backup`, Kubernetes CronJob, and spoke backup scope.
-- [Deployment helper scripts](deployment-scripts.md) — Proxmox LXC and blue-green Compose helpers.
-- [`bin/` pipeline script index](../../bin/README.md) — map of the 45 deterministic pipeline and operational shell/Python scripts, grouped by function.
-- [Dashboard API reference](api-reference.md) — pragmatic route index for dashboard and hub endpoints.
-- [Dashboard OpenAPI spec](../../dashboard/openapi.json) — machine-readable REST API reference for integrations.
-- [ioscan status](ioscan.md) — the untrusted-input scanner/canary feature (live and default-on in v4).
-- [Deployment scripts](../deploy/README.md) — inventory of v2 deployment helpers, including dashboard TTY panes and `hive-panes`.
+- [Manual provisioning](../manual-provisioning.md) — heartbeat-only cluster provisioning, hub access roles, and common gotchas.
+- [Self-hosted hub deployment](https://github.com/kubestellar/hive/blob/v4/v2/docs/hub-deployment.md) — `HIVE_MODE=hub`, hub storage, heartbeat secrets, and SaaS spoke registration.
+- [`CAP_NET_ADMIN` and self-hosted spokes](https://github.com/kubestellar/hive/blob/v4/v2/docs/net-admin-requirement.md) — the container runs with or without `NET_ADMIN`; granting it (`--cap-add NET_ADMIN` / `securityContext.capabilities.add`) enables the full forced-proxy-egress gate, and what the degraded best-effort mode means without it.
+- [Config layering](https://github.com/kubestellar/hive/blob/v4/v2/docs/config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
+- [Operator reference](https://github.com/kubestellar/hive/blob/v4/v2/docs/operator-reference.md) — top-level config blocks, hive flags/env, GitHub token scopes, and image provenance.
+- [Release channels](../release-channels.md) — `stable`/`candidate`/`edge` moving image tags, switching a hive to a channel, and the `stable (v4)` version pill.
+- [The `auto-update` Compose profile](https://github.com/kubestellar/hive/blob/v4/v2/docs/auto-update-profile.md) — what unattended Watchtower updates cost you, what the Docker socket proxy does and does **not** fix, and why Kubernetes should not use this profile at all.
+- [Environment variable reference](https://github.com/kubestellar/hive/blob/v4/v2/docs/env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.
+- [Troubleshooting](../troubleshooting.md) — container logs, config validation, agent tmux sessions, dashboard auth, and GitHub credential checks.
+- [Cross-cluster migration](https://github.com/kubestellar/hive/blob/v4/v2/docs/cross-cluster-migration.md) — the manual procedure for moving a hive between clusters.
+- [Dashboard route and health checks](https://github.com/kubestellar/hive/blob/v4/v2/docs/health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
+- [Network and port requirements](https://github.com/kubestellar/hive/blob/v4/v2/docs/network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
+- [TLS, HTTPS, and certificates](https://github.com/kubestellar/hive/blob/v4/v2/docs/tls-setup.md) — termination patterns and certificate ownership.
+- [Security notes](https://github.com/kubestellar/hive/blob/v4/v2/docs/security.md) — log scrubbing and secret redaction guarantees/limits.
+- [Token collection and usage tracking](https://github.com/kubestellar/hive/blob/v4/v2/docs/token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
+- [Notifications](https://github.com/kubestellar/hive/blob/v4/v2/docs/notifications.md) — ntfy, Slack, and Discord alert channels, plus the two-way [Discord bot](https://github.com/kubestellar/hive/blob/v4/discord/README.md).
+- [Public snapshots](https://github.com/kubestellar/hive/blob/v4/v2/docs/snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
+- [hivectl](../hivectl.md) — command-line client for the dashboard API.
+- [`bd` beads CLI](https://github.com/kubestellar/hive/blob/v4/v2/docs/beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
+- [Backup and restore](https://github.com/kubestellar/hive/blob/v4/v2/docs/backup-restore.md) — `hive-backup`, Kubernetes CronJob, and spoke backup scope.
+- [Deployment helper scripts](https://github.com/kubestellar/hive/blob/v4/v2/docs/deployment-scripts.md) — Proxmox LXC and blue-green Compose helpers.
+- [`bin/` pipeline script index](https://github.com/kubestellar/hive/blob/v4/bin/README.md) — map of the 45 deterministic pipeline and operational shell/Python scripts, grouped by function.
+- [Dashboard API reference](https://github.com/kubestellar/hive/blob/v4/v2/docs/api-reference.md) — pragmatic route index for dashboard and hub endpoints.
+- [Dashboard OpenAPI spec](https://github.com/kubestellar/hive/blob/v4/dashboard/openapi.json) — machine-readable REST API reference for integrations.
+- [ioscan status](https://github.com/kubestellar/hive/blob/v4/v2/docs/ioscan.md) — the untrusted-input scanner/canary feature (live and default-on in v4).
+- [Deployment scripts](https://github.com/kubestellar/hive/blob/v4/v2/deploy/README.md) — inventory of v2 deployment helpers, including dashboard TTY panes and `hive-panes`.
 
 ## Contributors and access
 
-- [ClankeR contributor relay](contributor-relay.md) — local contributor setup, multi-hub subscriptions, and role requests.
-- [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md) — newcomer/contributor/trusted/merger/advisor semantics, **Acting as**, grants, and delegatable roles.
-- [Credly badges](credly-badges.md) — planned integration design; currently a placeholder mapping only.
+- [ClankeR contributor relay](../contributor-relay.md) — local contributor setup, multi-hub subscriptions, and role requests.
+- [Contributor trust tiers and delegated agent roles](https://github.com/kubestellar/hive/blob/v4/v2/docs/contributor-trust-and-roles.md) — newcomer/contributor/trusted/merger/advisor semantics, **Acting as**, grants, and delegatable roles.
+- [Credly badges](https://github.com/kubestellar/hive/blob/v4/v2/docs/credly-badges.md) — planned integration design; currently a placeholder mapping only.
 
 ## Configuration and agents
 
-- [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
-- [Supervisor agent](supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
-- [Custom dashboard stylesheets](custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
-- [Portable AgentDefinition format](../AGENT-DEFINITION.md) — standalone YAML schema for importing/exporting agent definitions.
-- [Knowledge curator](knowledge-curator.md) — automatic fact extraction and promotion knobs.
-- [Agent peer-awareness logging (pluk)](agent-logging.md) — pluk log format, `hive-panes`, availability, and retention.
-- [Strategy Lab (Nous)](strategy-lab.md) — experiment lifecycle, dashboard/API configuration, fast-fail bounds, and the gate-decision flow. No `nous:` block in `hive.yaml`.
-- [GitHub App setup](github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
-- [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
-- [Inception](inception.md) — operator guide to the L1 brainstorm/inception workflow: phases, API, and template variables.
-- [ACMM policy fragments](../../examples/acmm/README.md) — per-level ACMM policy references.
-- [Sandbox isolation and agent guardrails](sandbox-isolation.md) — isolation layers and operator guardrail notes.
-- [Per-agent gh restrictions](../../config/restrictions/README.md) — file-based wrapper denials in `/etc/hive/restrictions/`.
-- [Podman rootless CI](podman-rootless-ci.md) — rootless Podman contract for `contribute-hive`.
-- [CLI backend setup](../../docs/backend-setup.md) — setup notes for Claude, Copilot, Goose, Bob, Pi, Codex, and Aider.
-- [Inference backends](../../docs/inference-backends.md) — vLLM, llm-d, LiteLLM, and Model Gateway troubleshooting.
-- [apiproxy](apiproxy.md) — Anthropic-compatible proxy logging and deployment notes.
-- [v1 to v2 migration](../../docs/migration-v1-v2.md) — migration checklist and rollback notes.
+- [Agent configuration](../agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
+- [Supervisor agent](https://github.com/kubestellar/hive/blob/v4/v2/docs/supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
+- [Custom dashboard stylesheets](https://github.com/kubestellar/hive/blob/v4/v2/docs/custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
+- [Portable AgentDefinition format](https://github.com/kubestellar/hive/blob/v4/v2/AGENT-DEFINITION.md) — standalone YAML schema for importing/exporting agent definitions.
+- [Knowledge curator](https://github.com/kubestellar/hive/blob/v4/v2/docs/knowledge-curator.md) — automatic fact extraction and promotion knobs.
+- [Agent peer-awareness logging (pluk)](https://github.com/kubestellar/hive/blob/v4/v2/docs/agent-logging.md) — pluk log format, `hive-panes`, availability, and retention.
+- [Strategy Lab (Nous)](https://github.com/kubestellar/hive/blob/v4/v2/docs/strategy-lab.md) — experiment lifecycle, dashboard/API configuration, fast-fail bounds, and the gate-decision flow. No `nous:` block in `hive.yaml`.
+- [GitHub App setup](https://github.com/kubestellar/hive/blob/v4/v2/docs/github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
+- [ACMM policy matrix](../acmm-policy-matrix.md) — capability levels and policy modes.
+- [Inception](https://github.com/kubestellar/hive/blob/v4/v2/docs/inception.md) — operator guide to the L1 brainstorm/inception workflow: phases, API, and template variables.
+- [ACMM policy fragments](https://github.com/kubestellar/hive/blob/v4/examples/acmm/README.md) — per-level ACMM policy references.
+- [Sandbox isolation and agent guardrails](https://github.com/kubestellar/hive/blob/v4/v2/docs/sandbox-isolation.md) — isolation layers and operator guardrail notes.
+- [Per-agent gh restrictions](https://github.com/kubestellar/hive/blob/v4/config/restrictions/README.md) — file-based wrapper denials in `/etc/hive/restrictions/`.
+- [Podman rootless CI](https://github.com/kubestellar/hive/blob/v4/v2/docs/podman-rootless-ci.md) — rootless Podman contract for `contribute-hive`.
+- [CLI backend setup](https://github.com/kubestellar/hive/blob/v4/docs/backend-setup.md) — setup notes for Claude, Copilot, Goose, Bob, Pi, Codex, and Aider.
+- [Inference backends](https://github.com/kubestellar/hive/blob/v4/docs/inference-backends.md) — vLLM, llm-d, LiteLLM, and Model Gateway troubleshooting.
+- [apiproxy](https://github.com/kubestellar/hive/blob/v4/v2/docs/apiproxy.md) — Anthropic-compatible proxy logging and deployment notes.
+- [v1 to v2 migration](https://github.com/kubestellar/hive/blob/v4/docs/migration-v1-v2.md) — migration checklist and rollback notes.
 
 ## Architecture and design
 
-- [Architecture](architecture.md) — process model, governor loop, guardrails, hub/spoke, and walkthrough.
-- [CNCF reference architecture](cncf-reference-architecture.md) — CNCF submission/reference template.
-- [Knowledge system design](design/knowledge-system.md) — llm-wiki layers, subscriptions, and APIs.
-- [Trajectory review](trajectory-review.md) — trajectory safety lane and review signals.
+- [Architecture](../architecture.md) — process model, governor loop, guardrails, hub/spoke, and walkthrough.
+- [CNCF reference architecture](https://github.com/kubestellar/hive/blob/v4/v2/docs/cncf-reference-architecture.md) — CNCF submission/reference template.
+- [Knowledge system design](https://github.com/kubestellar/hive/blob/v4/v2/docs/design/knowledge-system.md) — llm-wiki layers, subscriptions, and APIs.
+- [Trajectory review](https://github.com/kubestellar/hive/blob/v4/v2/docs/trajectory-review.md) — trajectory safety lane and review signals.
 
 ## Historical/design notes
 
-Some documents describe planned or design-only work rather than live features. Those pages are marked at the top, for example [Credly badges](credly-badges.md).
+Some documents describe planned or design-only work rather than live features. Those pages are marked at the top, for example [Credly badges](https://github.com/kubestellar/hive/blob/v4/v2/docs/credly-badges.md).
 
 ## Security (v4)
 
-- [Security model — operator guide](security-model.md) — Ed25519-only sessions/SSO, per-hive keys, master key rotation, forced proxy egress and `CAP_NET_ADMIN`, privilege model, and supply-chain posture.
-- [Security threat model](security-threat-model.md) — actors, boundaries, layered defenses, known gaps, and reporting.
-- [Architecture Decision Records](adr/README.md) — lightweight ADR process and records 0001-0010.
-- [Intent verification](intent-verification.md) — tier-based change authorization for merge eligibility.
-- [Rootless Podman CI seam](podman-rootless-ci.md) — documented test intent and static contract for contributor-container runtime handling.
+- [Security model — operator guide](../security-model.md) — Ed25519-only sessions/SSO, per-hive keys, master key rotation, forced proxy egress and `CAP_NET_ADMIN`, privilege model, and supply-chain posture.
+- [Security threat model](https://github.com/kubestellar/hive/blob/v4/v2/docs/security-threat-model.md) — actors, boundaries, layered defenses, known gaps, and reporting.
+- [Architecture Decision Records](https://github.com/kubestellar/hive/blob/v4/v2/docs/adr/README.md) — lightweight ADR process and records 0001-0010.
+- [Intent verification](https://github.com/kubestellar/hive/blob/v4/v2/docs/intent-verification.md) — tier-based change authorization for merge eligibility.
+- [Rootless Podman CI seam](https://github.com/kubestellar/hive/blob/v4/v2/docs/podman-rootless-ci.md) — documented test intent and static contract for contributor-container runtime handling.


### PR DESCRIPTION
## Problem

The Hive documentation index (`v2/docs/README.md`) is promoted to the docs site and rendered at [`/docs/hive/overview/introduction`](https://docs.kubestellar.io/docs/hive/overview/introduction). Nearly every link in its **Operations**, **Contributors and access**, **Configuration and agents**, **Architecture and design**, and **Security** sections was a 404 on the docs site.

Root cause: the link index used GitHub-repo-relative markdown links that work in GitHub's file browser but not on the promoted page:

- A bare `foo.md` resolves against the render URL `/docs/hive/overview/introduction`, so it became `/docs/hive/overview/foo` -> 404. The published page actually lives one level up at `/docs/hive/foo`.
- `../../`-style links (`../../bin/README.md`, `../deploy/README.md`, `../AGENT-DEFINITION.md`, `../../dashboard/openapi.json`, `../../discord/README.md`, `../../docs/*`, etc.) point at repo files **outside `v2/docs/`** that are not published to the docs site at all -> 404 with no valid site target.

## Fix

All link **text and trailing descriptions are preserved**; only the targets changed.

**Category A — target has a published docs-site page (9 links).** Rewrote bare `foo.md` -> `../foo.md` so it resolves to the published page under `/docs/hive/`. This matches the working cross-link pattern already used by the promoted `overview/intro.md` (e.g. `../security-model.md`).

| Link | New target | Verified live |
|------|-----------|---------------|
| Architecture (x2) | `../architecture.md` | `/docs/hive/architecture` 200 |
| Manual provisioning | `../manual-provisioning.md` | 200 |
| Release channels | `../release-channels.md` | 200 |
| Troubleshooting | `../troubleshooting.md` | 200 |
| hivectl | `../hivectl.md` | 200 |
| ClankeR contributor relay | `../contributor-relay.md` | 200 |
| Agent configuration | `../agent-configuration.md` | 200 |
| ACMM policy matrix | `../acmm-policy-matrix.md` | 200 |
| Security model | `../security-model.md` | 200 |

**Category B — target is not published to the docs site (all remaining links).** These repo docs (and files outside `v2/docs/`) have no docs-site page, so they were repointed to absolute GitHub blob URLs on the **v4** branch — the same convention the docs site already uses (e.g. the published `backup-dr.md` links back to `blob/v4/v2/docs/backup-restore.md`). Covers, among ~35 links: `hub-deployment`, `net-admin-requirement`, `config-layering`, `operator-reference`, `auto-update-profile`, `env-vars`, `cross-cluster-migration`, `health-checks`, `network-requirements`, `tls-setup`, `security`, `token-tracking`, `notifications`, `snapshots`, `beads-cli`, `backup-restore`, `deployment-scripts`, `api-reference`, `ioscan`, `contributor-trust-and-roles`, `credly-badges`, `supervisor`, `custom-stylesheets`, `knowledge-curator`, `agent-logging`, `strategy-lab`, `github-app-setup`, `inception`, `sandbox-isolation`, `podman-rootless-ci`, `apiproxy`, `cncf-reference-architecture`, `design/knowledge-system`, `trajectory-review`, `security-threat-model`, `intent-verification`, `adr/README`, plus the out-of-tree targets `bin/README.md`, `dashboard/openapi.json`, `discord/README.md`, `examples/acmm/README.md`, `config/restrictions/README.md`, `v2/deploy/README.md`, `v2/AGENT-DEFINITION.md`, and `docs/{backend-setup,inference-backends,migration-v1-v2}.md`.

**Every rewritten target was verified**: all 9 Category-A slugs return HTTP 200 on the live docs site, and all 47 unique Category-B blob paths exist on the `v4` branch. No links were removed; no target 404s.

## Out of scope: "View Source" / "Compose a PR" links

The page's built-in **View Source** / **Compose a PR** buttons point at `github.com/kubestellar/hive/blob/main/docs/readme.md` and `/edit/main/...` — but hive has **no `main` branch** (default is `v4`) and the file is at `v2/docs/README.md`, not `docs/readme.md`. These are generated by the docs-site theme's `editUrl` config in **kubestellar/docs**, not by this file's content, so they cannot be fixed here. The promotion script `scripts/sync-hive-docs.ts` in kubestellar/docs already correctly targets `blob/v4/v2/docs/...` for its injected "Synced from Hive" header, so the stale `blob/main/docs/...` source button is a separate theme-config item in kubestellar/docs that a maintainer should address there.
