### PR TITLE
🔒 fix(gh-wrapper): constant contributor-mode marker path + last-author-wins gate (port of #2715 from dd)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -29,19 +29,15 @@ set -euo pipefail
 REAL_GH="${HIVE_GH_WRAPPER_REAL_GH:-/opt/hive/bin/gh-real}"
 [[ -x "$REAL_GH" ]] || REAL_GH="/usr/bin/gh"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
-HIVE_CONTRIBUTOR_MODE_MARKER="${HIVE_CONTRIBUTOR_MODE_MARKER:-/etc/hive/contributor-mode}"
+CONTRIBUTOR_MODE_MARKER="/etc/hive/contributor-mode"
 
-# Contributor mode comes from a root-owned marker file at the image
-# boundary. The env var HIVE_CONTRIBUTOR_MODE is caller-controlled and
-# must never switch token injection or PR routing.
-#
-# SECURITY (#3249, re-landing #3321/fb87b4c7 on v4): this guard shipped on v2
-# but was dropped from v4 by a v2->v4 sync merge that resolved bin/gh-wrapper.sh
-# in favour of the v4 side. The marker tests and the contributor Dockerfile's
-# `touch /etc/hive/contributor-mode` both survived the sync, so the regression
-# suite kept asserting a boundary the wrapper no longer enforced.
+# Contributor mode is an image property, not a caller-controlled environment
+# toggle. Keep this path constant: an agent can set its own environment and must
+# not be able to redirect the trust check to an agent-writable marker (#3249).
+# The env var HIVE_CONTRIBUTOR_MODE is equally caller-controlled and must never
+# switch token injection or PR routing.
 _contributor_mode() {
-  [[ -f "$HIVE_CONTRIBUTOR_MODE_MARKER" ]]
+  [[ -f "$CONTRIBUTOR_MODE_MARKER" ]]
 }
 
 # Guard: if the real gh binary is not installed, tell the agent to use MCP instead.
@@ -283,44 +279,70 @@ fi
 
 # ── Helpers: author validation for the list gate ──
 
-# Extract the --author value from the args array. Returns the value on stdout
-# on success (exit 0) or nothing on failure (exit 1).
+# Extract the effective --author/-A value from the args array. GitHub CLI uses
+# the last repeated value, so this deliberately scans the whole argv instead of
+# returning the first match. Returns the value on stdout on success (exit 0) or
+# nothing on failure (exit 1).
 _extract_author() {
-  local i
+  local i author_value="" found=false
   for ((i=0; i<${#args[@]}; i++)); do
-    if [[ "${args[$i]}" = --author=* ]]; then
-      printf '%s\n' "${args[$i]#--author=}"
-      return 0
+    if [[ "${args[$i]}" = --author=* || "${args[$i]}" = -A=* ]]; then
+      author_value="${args[$i]#*=}"
+      found=true
+      continue
     fi
-    if [[ "${args[$i]}" = --author ]]; then
+    if [[ "${args[$i]}" = -A?* ]]; then
+      author_value="${args[$i]#-A}"
+      found=true
+      continue
+    fi
+    if [[ "${args[$i]}" = --author || "${args[$i]}" = -A ]]; then
       if [[ $((i+1)) -lt ${#args[@]} ]] && [[ "${args[$((i+1))]}" != -* ]]; then
-        printf '%s\n' "${args[$((i+1))]}"
-        return 0
+        author_value="${args[$((i+1))]}"
+        found=true
       fi
     fi
   done
+  if $found; then
+    printf '%s\n' "$author_value"
+    return 0
+  fi
   return 1
 }
 
-# Resolve the bot's GitHub login (cached per invocation for performance).
+# Resolve the authenticated GitHub login. Initialize the cache internally so a
+# caller-controlled environment cannot seed a trusted identity.
+HIVE_AUTH_LOGIN_CACHED=""
 _resolve_self_login() {
-  if [[ -n "${HIVE_BOT_LOGIN_CACHED:-}" ]]; then
-    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-    return
+  if [[ -n "$HIVE_AUTH_LOGIN_CACHED" ]]; then
+    printf '%s\n' "$HIVE_AUTH_LOGIN_CACHED"
+    return 0
   fi
-  if [[ -n "${HIVE_BOT_LOGIN:-}" ]]; then
-    HIVE_BOT_LOGIN_CACHED="$HIVE_BOT_LOGIN"
-    printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-    return
+
+  local login
+  if ! login="$("$REAL_GH" api user --jq '.login' 2>/dev/null)"; then
+    return 1
   fi
-  if [[ -x "$REAL_GH" ]] && [[ -n "${GH_TOKEN:-}" ]]; then
-    HIVE_BOT_LOGIN_CACHED="$("$REAL_GH" api user -q '.login' 2>/dev/null || true)"
-    if [[ -n "$HIVE_BOT_LOGIN_CACHED" ]]; then
-      printf '%s\n' "$HIVE_BOT_LOGIN_CACHED"
-      return
-    fi
+  if [[ -z "$login" ]]; then
+    return 1
   fi
-  printf '%s\n' ""
+
+  HIVE_AUTH_LOGIN_CACHED="$login"
+  printf '%s\n' "$HIVE_AUTH_LOGIN_CACHED"
+}
+
+_lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+_author_matches_login() {
+  local requested_lc login_lc requested_base login_base
+  requested_lc="$(_lower "$1")"
+  login_lc="$(_lower "$2")"
+  requested_base="${requested_lc%\[bot\]}"
+  login_base="${login_lc%\[bot\]}"
+
+  [[ "$requested_lc" = "$login_lc" || "$requested_base" = "$login_base" ]]
 }
 
 # ── READ/WRITE SPLIT for GitHub lookups (fixes #2356; addresses #2393 item 6) ──
@@ -335,28 +357,25 @@ _resolve_self_login() {
 # Block gh issue list and gh pr list for NON-contributor hive agents (they consume
 # assigned work from actionable.json). Contributors are exempt so they can look
 # before they leap. `--author` self-listing is allowed only when the author value
-# matches the current agent/bot identity (fixes #3072).
+# matches the authenticated token identity (fixes #3072 and #3096).
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
-  if _contributor_mode; then
-    : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356)
-  elif author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
-    self_login="$(_resolve_self_login)"
-    if [[ -n "$self_login" ]] && [[ "$author_value" = "$self_login" ]]; then
-      : # Match: exact bot login
-    elif [[ -n "$self_login" ]] && [[ "$author_value" = "${self_login%\[bot\]}" ]]; then
-      : # Match: bot login without [bot] suffix
-    elif [[ -n "${HIVE_AGENT:-}" ]] && [[ "$author_value" = "${HIVE_AGENT}" ]]; then
-      : # Match: agent name
-    elif [[ -n "${HIVE_AGENT_DISPLAY_NAME:-}" ]] && [[ "$author_value" = "${HIVE_AGENT_DISPLAY_NAME}" ]]; then
-      : # Match: agent display name
-    elif [[ -n "${HIVE_CONTRIBUTOR_USERNAME:-}" ]] && [[ "$author_value" = "${HIVE_CONTRIBUTOR_USERNAME}" ]]; then
-      : # Match: contributor username (self-listing in contributor mode)
+  if author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
+    if [[ "$author_value" = "@me" ]]; then
+      : # GitHub resolves @me server-side to the authenticated token identity.
+    elif ! _resolve_self_login >/dev/null; then
+      echo "⛔ BLOCKED: gh $subcmd list --author requires authenticated GitHub identity." >&2
+      echo "Could not resolve the current token identity with 'gh api user --jq .login'." >&2
+      exit 1
+    elif _author_matches_login "$author_value" "$HIVE_AUTH_LOGIN_CACHED"; then
+      : # Match: authenticated login, case-insensitive, with optional [bot] suffix.
     else
-      echo "⛔ BLOCKED: gh $subcmd list --author must match the current bot/agent identity." >&2
-      echo "--author '$author_value' does not match the current identity." >&2
-      echo "Use --author with your own bot login or agent name to list your own items." >&2
+      echo "⛔ BLOCKED: gh $subcmd list --author must match the authenticated GitHub identity." >&2
+      echo "--author '$author_value' does not match token identity '$HIVE_AUTH_LOGIN_CACHED'." >&2
+      echo "Use --author @me or your authenticated login to list your own items." >&2
       exit 1
     fi
+  elif _contributor_mode; then
+    : # Allow contributor agents read-only list/search to avoid duplicate PRs (#2356).
   else
     echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
     echo "Read /var/run/hive-metrics/actionable.json instead." >&2

--- a/bin/gh-wrapper.test.sh
+++ b/bin/gh-wrapper.test.sh
@@ -43,10 +43,23 @@ chmod +x "$MOCK_GH"
 # Point the wrapper at the mock gh via the HIVE_GH_WRAPPER_REAL_GH override
 # (exported below) rather than rewriting REAL_GH with sed — the override is the
 # supported seam for pointing the wrapper at a stub binary.
-cp "$WRAPPER" "$TEST_WRAPPER"
+# Production deliberately has no environment-variable override for this trust
+# boundary (#3249). Redirect the marker only in the temporary test copy, via a
+# rewrite of the constant (portable across GNU/BSD sed).
+sed "s|CONTRIBUTOR_MODE_MARKER=\"/etc/hive/contributor-mode\"|CONTRIBUTOR_MODE_MARKER=\"${WORK_DIR}/contributor-marker\"|" "$WRAPPER" >"$TEST_WRAPPER"
+if ! grep -q "CONTRIBUTOR_MODE_MARKER=\"${WORK_DIR}/contributor-marker\"" "$TEST_WRAPPER"; then
+  echo "FATAL: failed to redirect CONTRIBUTOR_MODE_MARKER in the test copy — wrapper constant changed?" >&2
+  exit 1
+fi
 chmod +x "$TEST_WRAPPER"
 
 export GH_TOKEN="test-token-mock"
+# The production wrapper fails closed without its per-agent scoped token file.
+# Exercise the author gate behind that boundary instead of accidentally passing
+# cases because the earlier token-delivery guard rejected every invocation.
+TOKEN_CACHE="${WORK_DIR}/scoped-token"
+printf '%s\n' "test-token-mock" >"$TOKEN_CACHE"
+export HIVE_AGENT_TOKEN_CACHE="$TOKEN_CACHE"
 # All _run_test* invocations inherit this, so the wrapper resolves REAL_GH to the
 # mock instead of the real /opt/hive/bin/gh-real (absent in CI).
 export HIVE_GH_WRAPPER_REAL_GH="${MOCK_GH}"
@@ -57,12 +70,11 @@ _run_test() {
   shift 2
 
   local output rc=0
-  rm -f "${WORK_DIR}/no-contributor-marker"
+  rm -f "${WORK_DIR}/contributor-marker"
   output="$(env \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
@@ -85,12 +97,11 @@ _run_test_spoof() {
   shift 2
 
   local output rc=0
-  rm -f "${WORK_DIR}/no-contributor-marker"
+  rm -f "${WORK_DIR}/contributor-marker"
   output="$(env \
     HIVE_AGENT="octocat" \
     HIVE_AGENT_DISPLAY_NAME="octocat" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     MOCK_GH_LOGIN="scanner[bot]" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
@@ -113,12 +124,11 @@ _run_test_identity_failure() {
   shift 2
 
   local output rc=0
-  rm -f "${WORK_DIR}/no-contributor-marker"
+  rm -f "${WORK_DIR}/contributor-marker"
   output="$(env \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     MOCK_GH_FAIL_IDENTITY="true" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
@@ -141,12 +151,11 @@ _run_test_cached_env_spoof() {
   shift 2
 
   local output rc=0
-  rm -f "${WORK_DIR}/no-contributor-marker"
+  rm -f "${WORK_DIR}/contributor-marker"
   output="$(env \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
-    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
     HIVE_AUTH_LOGIN_CACHED="octocat" \
     MOCK_GH_LOGIN="test-bot[bot]" \
     GH_TOKEN="test-token-mock" \
@@ -173,7 +182,6 @@ _run_test_contributor() {
   touch "${WORK_DIR}/contributor-marker"
   output="$(env \
     HIVE_CONTRIBUTOR_MODE="true" \
-    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/contributor-marker" \
     HIVE_CONTRIBUTOR_USERNAME="test-contributor" \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
@@ -201,16 +209,18 @@ _run_test_env_only() {
   shift 2
 
   local output rc=0
-  rm -f "${WORK_DIR}/no-contributor-marker"
+  rm -f "${WORK_DIR}/contributor-marker"
+  touch "${WORK_DIR}/untrusted-contributor-marker"
   output="$(env \
     HIVE_CONTRIBUTOR_MODE="true" \
-    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/no-contributor-marker" \
+    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/untrusted-contributor-marker" \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
     MOCK_GH_LOGIN="${MOCK_GH_LOGIN:-test-bot[bot]}" \
     GH_TOKEN="test-token-mock" \
     bash "$TEST_WRAPPER" "$@" 2>&1)" || rc=$?
+  rm -f "${WORK_DIR}/untrusted-contributor-marker"
 
   if [[ "$rc" != "$expected_rc" ]]; then
     echo "FAIL: $desc"
@@ -232,7 +242,6 @@ _run_test_marker_only() {
   local output rc=0
   touch "${WORK_DIR}/contributor-marker"
   output="$(env \
-    HIVE_CONTRIBUTOR_MODE_MARKER="${WORK_DIR}/contributor-marker" \
     HIVE_AGENT="scanner" \
     HIVE_AGENT_DISPLAY_NAME="scanner" \
     HIVE_AGENT_ID="scanner" \
@@ -354,7 +363,7 @@ MOCK_GH_LOGIN="test-contributor" _run_test_contributor 0 "issue list contributor
 echo ""
 echo "=== Marker trust boundary regression tests ==="
 
-_run_test_env_only 1 "issue list with HIVE_CONTRIBUTOR_MODE=true but no marker (blocked, env var ignored)" \
+_run_test_env_only 1 "issue list with env mode and agent-selected marker (blocked, env vars ignored)" \
   issue list --repo test/repo
 
 _run_test_marker_only 0 "issue list with marker present and no env var (allowed, marker alone grants contributor mode)" \


### PR DESCRIPTION
Fixes #3249

Ports the gh-wrapper contributor-mode hardening from the dd branch (squash commit `f96c4860`, PR #2715, maintainer-accepted) to v4. Credit: this fix was authored by David Diaz (`DavidDiaz0317`) in #2715; this PR extracts its `bin/gh-wrapper.sh` + `bin/gh-wrapper.test.sh` portion and adapts it to v4's drifted wrapper (deny-by-default allowlist #3854, mode-file guards #3924).

## Why

#3837 re-landed the contributor-mode marker gate on v4, but the marker **path** stayed env-overridable:

```bash
HIVE_CONTRIBUTOR_MODE_MARKER="${HIVE_CONTRIBUTOR_MODE_MARKER:-/etc/hive/contributor-mode}"
```

An agent that controls its own environment can point the trust check at an agent-writable file and flip BOTH trust points into contributor mode: token injection (keeps/loses the per-agent scoped App token) and `gh pr create` routing (bypasses `hive-open-pr` App-bot authorship). Separately, `_extract_author` returned the FIRST `--author` match while the real gh CLI honors the LAST, so `--author <legit> --author <attacker>` passed the list gate.

## What changed

- `CONTRIBUTOR_MODE_MARKER="/etc/hive/contributor-mode"` is now a constant — an image property, not a caller-controlled toggle. No env fallback remains; both trust points read it through `_contributor_mode()`.
- `_extract_author` scans the full argv with last-repeated-value semantics and handles `--author`, `--author=`, `-A`, `-A=`, and attached `-A<value>` forms.
- The list gate validates `--author` against the authenticated token identity (`gh api user`), case-insensitive with optional `[bot]` suffix, supports `@me`, and fails closed when identity lookup fails. Caller-controlled `HIVE_AGENT` / `HIVE_AGENT_DISPLAY_NAME` / `HIVE_BOT_LOGIN*` / `HIVE_CONTRIBUTOR_USERNAME` env vars no longer grant a match, and the identity cache is initialized internally so the environment cannot seed it. Contributor-mode listing without `--author` remains allowed (#2356).

**Deliberately NOT ported** from #2715 (dd/Visual Hive feature work): the integrated/authorization workflow files, the relocation of the `pr create` routing block, and the new `hive-open-issue` routing — v4's existing pr-create routing and guard ordering are left as-is.

## Tests

`bin/gh-wrapper.test.sh` on clean v4 was asserting the fixed semantics (synced from v2 in #3562) against the unfixed wrapper — it aborted at its 9th test because every non-contributor invocation died at the scoped-token guard, so all earlier "blocked" cases passed for the wrong reason. Adapted per the dd fix:

- the marker is redirected only in the sed-rewritten temporary test copy (with a fail-loud guard if the constant ever changes), since production intentionally has no env override — this is the #3249 regression test: env-selected agent-writable marker → still blocked;
- a per-agent scoped token file (`HIVE_AGENT_TOKEN_CACHE`) is provided so the author gate itself is exercised;
- positive controls kept: marker present alone grants contributor mode; single-author self-listing allowed; multi-author spoof (`--author @me --author octocat`) blocked in both agent and contributor mode.

All 33 tests pass locally (`bash bin/gh-wrapper.test.sh`). The dd `sed -i` was adapted to a portable `sed >file` form (BSD/GNU).
