### PR TITLE
fix(dashboard): workspace cleanup must never sweep agent workspaces that are git clones

### DIFF
--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -15,9 +15,56 @@ import (
 )
 
 const (
-	workspaceCleanupInterval = 1 * time.Hour
-	workspaceMaxAge          = 2 * time.Hour
+	// Env knobs for the workspace sweep. Defaults preserve the historical
+	// behavior (enabled, hourly sweep, 2h max age); operators can disable the
+	// sweep or tune its cadence without a rebuild.
+	workspaceCleanupEnabledEnv  = "HIVE_WORKSPACE_CLEANUP_ENABLED"
+	workspaceCleanupIntervalEnv = "HIVE_WORKSPACE_CLEANUP_INTERVAL"
+	workspaceMaxAgeEnv          = "HIVE_WORKSPACE_CLEANUP_MAX_AGE"
+
+	// workspaceCleanupIntervalDefault is how often the sweep runs.
+	workspaceCleanupIntervalDefault = 1 * time.Hour
+	// workspaceMaxAgeDefault is how old an entry must be before it is
+	// considered stale and removed.
+	workspaceMaxAgeDefault = 2 * time.Hour
 )
+
+// workspaceCleanupEnabled reports whether the background sweep runs at all.
+// On by default; an operator opts out with HIVE_WORKSPACE_CLEANUP_ENABLED=0
+// (or false/no/off). Any other value — including unset — keeps it enabled.
+func workspaceCleanupEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(workspaceCleanupEnabledEnv))) {
+	case "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
+// workspaceCleanupInterval returns the sweep cadence, from
+// HIVE_WORKSPACE_CLEANUP_INTERVAL (Go duration, e.g. "30m") or the default.
+func workspaceCleanupInterval() time.Duration {
+	return durationFromEnv(workspaceCleanupIntervalEnv, workspaceCleanupIntervalDefault)
+}
+
+// workspaceMaxAge returns the staleness threshold, from
+// HIVE_WORKSPACE_CLEANUP_MAX_AGE (Go duration, e.g. "6h") or the default.
+func workspaceMaxAge() time.Duration {
+	return durationFromEnv(workspaceMaxAgeEnv, workspaceMaxAgeDefault)
+}
+
+// durationFromEnv parses a Go duration from the named env var, falling back
+// to def when unset, unparseable, or non-positive.
+func durationFromEnv(env string, def time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(env))
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
 
 // agentWorkspaceRoot is the directory swept for stale agent workspace
 // artifacts. A package var (not a const) so tests can point it at a temp
@@ -27,11 +74,17 @@ var agentWorkspaceRoot = "/data/agents"
 // StartWorkspaceCleanup runs a background loop that periodically sweeps
 // /data/agents/*/ for stale workspace artifacts and removes them.
 func StartWorkspaceCleanup(ctx context.Context, logger *slog.Logger, audit *AuditLog) {
-	logger.Info("workspace cleanup enabled", "interval", workspaceCleanupInterval, "max_age", workspaceMaxAge)
+	if !workspaceCleanupEnabled() {
+		logger.Info("workspace cleanup disabled", "env", workspaceCleanupEnabledEnv)
+		return
+	}
+
+	interval := workspaceCleanupInterval()
+	logger.Info("workspace cleanup enabled", "interval", interval, "max_age", workspaceMaxAge())
 
 	sweepWorkspaces(logger, audit)
 
-	ticker := time.NewTicker(workspaceCleanupInterval)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -54,6 +107,7 @@ func sweepWorkspaces(logger *slog.Logger, audit *AuditLog) {
 	removedDirs := 0
 	removedFiles := 0
 	failed := 0
+	maxAge := workspaceMaxAge()
 	now := time.Now()
 
 	for _, agentEntry := range agentDirs {
@@ -63,11 +117,35 @@ func sweepWorkspaces(logger *slog.Logger, audit *AuditLog) {
 		agentName := agentEntry.Name()
 		agentPath := filepath.Join(agentWorkspaceRoot, agentName)
 
+		// GIT-CLONE GUARD: a workspace root that IS a git clone must never be
+		// swept. On hosted spoke hive-hosted-hosted-available-vllmd-07 (tenant
+		// hive z-aiops-unite/ui) the sec-check agent's workspace root was its
+		// clone of the tenant repo; this sweep deleted every non-dot top-level
+		// entry 73 times since Aug 11, leaving 940 unstaged working-tree
+		// deletions (.git survived only because isSkippedEntry skips
+		// dot-entries) and wiping the agent's in-flight work every ~2 idle
+		// hours. The same sweep removed the quality agent's api-server-work
+		// clone. The check is per-workspace root, for a .git DIRECTORY or a
+		// .git FILE (linked worktrees use a file).
+		//
+		// Tradeoff: we skip the whole workspace rather than consulting the git
+		// index to remove only untracked entries. Reading the index from this
+		// code path would add a dependency and new failure modes (locked or
+		// mid-rewrite index, detached worktrees); the sweep exists for
+		// scratch-dir hygiene, and a git clone is not scratch.
+		if isGitClone(agentPath) {
+			logger.Info("workspace cleanup: workspace is a git clone; skipping sweep",
+				"agent", agentName)
+			continue
+		}
+
 		entries, err := os.ReadDir(agentPath)
 		if err != nil {
 			continue
 		}
 
+		agentRemovedDirs := 0
+		agentRemovedFiles := 0
 		for _, entry := range entries {
 			name := entry.Name()
 			if isSkippedEntry(name) {
@@ -80,7 +158,7 @@ func sweepWorkspaces(logger *slog.Logger, audit *AuditLog) {
 				continue
 			}
 			age := now.Sub(info.ModTime())
-			if age < workspaceMaxAge {
+			if age < maxAge {
 				continue
 			}
 
@@ -93,7 +171,7 @@ func sweepWorkspaces(logger *slog.Logger, audit *AuditLog) {
 				}
 				logger.Info("workspace cleanup: removed stale dir",
 					"agent", agentName, "dir", name, "age", age.Round(time.Minute))
-				removedDirs++
+				agentRemovedDirs++
 			} else {
 				if err := removeTree(entryPath); err != nil {
 					logger.Warn("workspace cleanup: failed to remove stale file",
@@ -101,9 +179,20 @@ func sweepWorkspaces(logger *slog.Logger, audit *AuditLog) {
 					failed++
 					continue
 				}
-				removedFiles++
+				// Log file removals too — during the vllmd-07 incident only
+				// directory removals were logged, which hid the scale of the
+				// working-tree destruction for a week.
+				logger.Info("workspace cleanup: removed stale file",
+					"agent", agentName, "file", name, "age", age.Round(time.Minute))
+				agentRemovedFiles++
 			}
 		}
+		if agentRemovedDirs > 0 || agentRemovedFiles > 0 {
+			logger.Info("workspace cleanup: agent sweep summary",
+				"agent", agentName, "removed_dirs", agentRemovedDirs, "removed_files", agentRemovedFiles)
+		}
+		removedDirs += agentRemovedDirs
+		removedFiles += agentRemovedFiles
 	}
 
 	logger.Info("workspace cleanup complete",
@@ -181,6 +270,15 @@ func removeTree(path string) error {
 			err, ownerName, lookupErr, shellErr)
 	}
 	return nil
+}
+
+// isGitClone reports whether dir is the root of a git checkout: it contains a
+// .git entry, either a directory (normal clone) or a file (linked worktree's
+// "gitdir:" pointer). Lstat so a symlinked .git also counts — any .git
+// presence means the directory holds a working tree the sweep must not touch.
+func isGitClone(dir string) bool {
+	_, err := os.Lstat(filepath.Join(dir, ".git"))
+	return err == nil
 }
 
 // fileOwnerName returns the username that owns the given path.

--- a/v2/pkg/dashboard/workspace_cleanup_test.go
+++ b/v2/pkg/dashboard/workspace_cleanup_test.go
@@ -1,6 +1,9 @@
 package dashboard
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -121,7 +124,156 @@ func TestSweepWorkspacesSkipsRecent(t *testing.T) {
 		t.Fatal(err)
 	}
 	age := time.Since(info.ModTime())
-	if age >= workspaceMaxAge {
+	if age >= workspaceMaxAge() {
 		t.Fatalf("test workspace should be recent, got age %v", age)
+	}
+}
+
+// sweepTestLogger returns a logger that discards output, for driving
+// sweepWorkspaces directly in tests.
+func sweepTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newSweepAgentDir points agentWorkspaceRoot at a fresh temp root (restored on
+// cleanup) and creates one agent workspace under it, populated with a stale
+// directory (with a file inside) and a stale top-level file. It returns the
+// agent dir plus the two stale paths.
+func newSweepAgentDir(t *testing.T, agent string) (agentDir, staleDir, staleFile string) {
+	t.Helper()
+	root := t.TempDir()
+	orig := agentWorkspaceRoot
+	agentWorkspaceRoot = root
+	t.Cleanup(func() { agentWorkspaceRoot = orig })
+
+	agentDir = filepath.Join(root, agent)
+	staleDir = filepath.Join(agentDir, "src")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, "handler.go"), []byte("package x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleFile = filepath.Join(agentDir, "main.go")
+	if err := os.WriteFile(staleFile, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * workspaceMaxAge())
+	for _, p := range []string{staleDir, staleFile} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return agentDir, staleDir, staleFile
+}
+
+// TestSweepSkipsGitCloneWorkspaceDir is the regression test for the vllmd-07
+// incident: an agent workspace root that is itself a git clone (sec-check's
+// workspace WAS its clone of the tenant repo) must not be swept, no matter how
+// stale its tracked entries look. Before the git-clone guard, sweepWorkspaces
+// deleted both stale entries here — this test fails against the unfixed code.
+func TestSweepSkipsGitCloneWorkspaceDir(t *testing.T) {
+	agentDir, staleDir, staleFile := newSweepAgentDir(t, "sec-check")
+	if err := os.MkdirAll(filepath.Join(agentDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepWorkspaces(sweepTestLogger(), nil)
+
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Errorf("stale dir inside git clone was removed: %v", err)
+	}
+	if _, err := os.Stat(staleFile); err != nil {
+		t.Errorf("stale file inside git clone was removed: %v", err)
+	}
+}
+
+// TestSweepSkipsGitCloneWorkspaceWorktreeFile covers the linked-worktree case:
+// a .git FILE (a "gitdir:" pointer), not a directory, must also trigger the
+// guard. Fails against the unfixed code the same way as the dir case.
+func TestSweepSkipsGitCloneWorkspaceWorktreeFile(t *testing.T) {
+	agentDir, staleDir, staleFile := newSweepAgentDir(t, "quality")
+	if err := os.WriteFile(filepath.Join(agentDir, ".git"),
+		[]byte("gitdir: /data/agents/quality/.repos/ui/.git/worktrees/wt1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepWorkspaces(sweepTestLogger(), nil)
+
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Errorf("stale dir inside git worktree was removed: %v", err)
+	}
+	if _, err := os.Stat(staleFile); err != nil {
+		t.Errorf("stale file inside git worktree was removed: %v", err)
+	}
+}
+
+// TestSweepStillCleansNonGitWorkspace guards the feature itself: a workspace
+// with NO .git entry must still have its stale entries removed.
+func TestSweepStillCleansNonGitWorkspace(t *testing.T) {
+	_, staleDir, staleFile := newSweepAgentDir(t, "scratch-agent")
+
+	sweepWorkspaces(sweepTestLogger(), nil)
+
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Errorf("stale dir in non-git workspace should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
+		t.Errorf("stale file in non-git workspace should be removed, stat err=%v", err)
+	}
+}
+
+// TestStartWorkspaceCleanupDisabled verifies the config gate: with
+// HIVE_WORKSPACE_CLEANUP_ENABLED=false, StartWorkspaceCleanup returns without
+// running even the initial sweep, so stale entries survive.
+func TestStartWorkspaceCleanupDisabled(t *testing.T) {
+	_, staleDir, staleFile := newSweepAgentDir(t, "scratch-agent")
+	t.Setenv(workspaceCleanupEnabledEnv, "false")
+
+	// Cancelled context: if the gate were broken, the enabled path would still
+	// run its initial sweep before returning.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	StartWorkspaceCleanup(ctx, sweepTestLogger(), nil)
+
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Errorf("sweep ran while disabled; stale dir removed: %v", err)
+	}
+	if _, err := os.Stat(staleFile); err != nil {
+		t.Errorf("sweep ran while disabled; stale file removed: %v", err)
+	}
+}
+
+// TestWorkspaceCleanupEnvKnobs covers the env parsing: enable/disable values
+// and duration overrides with fallback to defaults on bad input.
+func TestWorkspaceCleanupEnvKnobs(t *testing.T) {
+	for _, v := range []string{"", "1", "true", "yes", "on", "garbage"} {
+		t.Setenv(workspaceCleanupEnabledEnv, v)
+		if !workspaceCleanupEnabled() {
+			t.Errorf("value %q: expected enabled", v)
+		}
+	}
+	for _, v := range []string{"0", "false", "no", "off", " OFF "} {
+		t.Setenv(workspaceCleanupEnabledEnv, v)
+		if workspaceCleanupEnabled() {
+			t.Errorf("value %q: expected disabled", v)
+		}
+	}
+
+	t.Setenv(workspaceCleanupIntervalEnv, "30m")
+	if got := workspaceCleanupInterval(); got != 30*time.Minute {
+		t.Errorf("interval override: got %v, want 30m", got)
+	}
+	t.Setenv(workspaceCleanupIntervalEnv, "not-a-duration")
+	if got := workspaceCleanupInterval(); got != workspaceCleanupIntervalDefault {
+		t.Errorf("bad interval: got %v, want default %v", got, workspaceCleanupIntervalDefault)
+	}
+	t.Setenv(workspaceMaxAgeEnv, "6h")
+	if got := workspaceMaxAge(); got != 6*time.Hour {
+		t.Errorf("max-age override: got %v, want 6h", got)
+	}
+	t.Setenv(workspaceMaxAgeEnv, "-1h")
+	if got := workspaceMaxAge(); got != workspaceMaxAgeDefault {
+		t.Errorf("negative max-age: got %v, want default %v", got, workspaceMaxAgeDefault)
 	}
 }


### PR DESCRIPTION
## Incident

On hosted spoke `hive-hosted-hosted-available-vllmd-07` (tenant hive `z-aiops-unite/ui`), the sec-check agent's workspace root **is** its git clone of `https://github.ibm.com/z-aiops-unite/ui`. The hourly workspace-cleanup sweep treated every non-dot top-level entry as stale scratch and deleted them **73 times since Aug 11** ("workspace cleanup: removed stale dir" in `/data/logs/hive.log`), leaving **940 unstaged working-tree deletions**. `.git` survived only because `isSkippedEntry()` skips dot-entries. The tenant's agent reported "the repository is in a corrupted state" and no CVE PRs could survive — work was wiped every ~2 idle hours. The same sweep also removed the `quality` agent's `api-server-work` clone (Aug 11). `git fsck` was clean throughout: this is working-tree destruction, not repo corruption. Only directory removals were logged (never files), which hid the scale for a week.

## Fix

1. **Git-clone guard (core fix):** in `sweepWorkspaces()`, if an agent's workspace root contains a `.git` entry — directory **or** file (linked worktrees use a `gitdir:` pointer file) — the workspace is skipped entirely, with an INFO log saying why. The check is per-workspace root, not per-entry.
   - *Tradeoff (also stated in a comment at the guard):* skip-entirely was chosen over consulting the git index to sweep only untracked files. Reading the index from this code path adds a dependency and new failure modes (locked/mid-rewrite index, detached worktrees); the sweep exists for scratch-dir hygiene, and a git clone is not scratch.
2. **Config gate:** the sweep — previously started unconditionally from `cmd/hive/main.go` with no off switch — is now tunable via env with named-constant defaults that preserve current behavior (enabled, 1h interval, 2h max age), following the existing env-knob pattern (`HIVE_METRICS_ENABLED`, `HIVE_DOSSIER_CACHE_MAX_ENTRIES`):
   - `HIVE_WORKSPACE_CLEANUP_ENABLED` (default on; `0|false|no|off` disables)
   - `HIVE_WORKSPACE_CLEANUP_INTERVAL` (Go duration, default `1h`)
   - `HIVE_WORKSPACE_CLEANUP_MAX_AGE` (Go duration, default `2h`)
3. **Logging:** file removals are now logged at INFO (they were silent), and each swept agent gets a per-sweep summary (`removed_dirs`/`removed_files`); the global end-of-sweep summary is unchanged.

## Tests

Extended `workspace_cleanup_test.go` (shared helper `newSweepAgentDir`, no duplicated fixtures):

- `.git/` directory + stale entries → nothing removed
- `.git` **file** (worktree case) + stale entries → nothing removed
- non-git workspace with stale entries → still swept (regression guard for the feature itself)
- `HIVE_WORKSPACE_CLEANUP_ENABLED=false` → `StartWorkspaceCleanup` returns without sweeping
- env-knob parsing (enable/disable variants, duration overrides, bad-input fallback to defaults)

**Verified the two git-guard tests FAIL against the unfixed sweep** (guard temporarily removed): both assert survival of files the current code deletes —

```
--- FAIL: TestSweepSkipsGitCloneWorkspaceDir           stale dir/file inside git clone was removed
--- FAIL: TestSweepSkipsGitCloneWorkspaceWorktreeFile  stale dir/file inside git worktree was removed
```

With the fix, `go test ./pkg/dashboard/ -run 'Workspace|Sweep|IsSkipped|RemoveTree|FileOwner' -count=1` — all 13 pass, including the pre-existing `TestCovD_SweepWorkspaces`.

## Note on CI

The `coverage` check is currently red on every PR from an unrelated base regression (`agent: 87.7% vs floor 89`) — not introduced here.
