### PR TITLE
🐛 fix(agent): Restart's lost-race guard no-op'd every restart of a running agent; restore pkg/agent over its 89% coverage floor

### DIFF
--- a/v2/pkg/agent/agy_launch_test.go
+++ b/v2/pkg/agent/agy_launch_test.go
@@ -1,0 +1,83 @@
+package agent
+
+// Launch-command test for the agy (Antigravity CLI) backend added in #3910.
+// The contract under pin is the flag set the commit's analysis established:
+//
+//   - --dangerously-skip-permissions is ALWAYS passed — without it agy blocks
+//     on a per-tool approval prompt no one is attached to answer;
+//   - a configured model is passed as --model <m> --effort <agyDefaultEffort>,
+//     because agy silently IGNORES --model without --effort — dropping the
+//     effort flag would make the configured model a no-op while looking fine.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// installAgyStub writes an agy stub into the stub bin dir already on PATH
+// (TestMain does not pre-create one — agy postdates the original stub list).
+// It renders the ❯ ready marker so readiness gates resolve and no launch
+// goroutine outlives the test, then echoes stdin like the other stubs.
+func installAgyStub(t *testing.T) {
+	t.Helper()
+	p := filepath.Join(stubBinDir, "agy")
+	script := "#!/bin/sh\nprintf '\\342\\235\\257 ready\\n'\nexec cat\n"
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing agy stub: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(p) })
+}
+
+// TestStart_AgyLaunchCommandLine launches a real agy-backed agent (stub
+// binary, real tmux) and asserts the command line actually typed into the
+// pane carries the #3910 flag contract. The pane is read via CaptureFullLog
+// so wrapped lines are joined before matching.
+func TestStart_AgyLaunchCommandLine(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	forceFastPaneShell(t)
+	installAgyStub(t)
+
+	// "gemini-pro" survives normalizeModelName unchanged (no trailing digit
+	// segment), so the assertion below sees the configured model verbatim.
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("agy", "gemini-pro"),
+	}, discardLogger(), ProjectContext{})
+
+	if err := m.Start(t.Context(), "worker"); err != nil {
+		t.Fatalf("Start(agy): %v", err)
+	}
+	defer cleanupAgent(t, m, "worker")
+
+	// The launch line is typed into the pane in chunks; poll the joined
+	// capture until the full command is visible.
+	deadline := time.Now().Add(30 * time.Second)
+	var pane string
+	for time.Now().Before(deadline) {
+		out, err := m.CaptureFullLog("worker")
+		if err == nil && strings.Contains(out, "--effort") {
+			pane = out
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if pane == "" {
+		out, _ := m.CaptureFullLog("worker")
+		t.Fatalf("agy launch command never appeared in the pane; capture: %q", out)
+	}
+
+	if !strings.Contains(pane, "--dangerously-skip-permissions") {
+		t.Error("agy launched without --dangerously-skip-permissions — it will block on a per-tool approval prompt no one answers")
+	}
+	if !strings.Contains(pane, "--model gemini-pro --effort "+agyDefaultEffort) {
+		t.Errorf("agy launched without '--model gemini-pro --effort %s' — agy silently ignores --model without --effort, so the configured model would never take effect; pane: %q",
+			agyDefaultEffort, pane)
+	}
+}

--- a/v2/pkg/agent/enters_prompt_guard_test.go
+++ b/v2/pkg/agent/enters_prompt_guard_test.go
@@ -1,0 +1,87 @@
+package agent
+
+// Test for the #3919 root-cause fix in tmuxSendEntersForAgent: the repeated
+// "insurance" Enters exist only to make sure a typed line ran, and must STOP
+// once a known blocking prompt is on screen — an Enter at that point is no
+// longer insurance, it is an ANSWER, and codex's update menu pre-selects the
+// destructive option ("1. Update now" → npm install -g as the agent UID →
+// EACCES → dead CLI, on every launch).
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"log/slog"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// syncBuffer is a bytes.Buffer safe for a logger that may be written from
+// another goroutine (the race detector runs in CI).
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// entersGuardManager builds a manager whose visible-pane seam serves the given
+// pane content and whose logger records into the returned buffer. The agent's
+// session does not exist, so the raw Enter sends are harmless no-ops — the
+// behaviour under test is the guard's early return, observable in the log.
+func entersGuardManager(t *testing.T, pane string) (*Manager, *AgentProcess, *syncBuffer) {
+	t.Helper()
+	logBuf := &syncBuffer{}
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("codex", "gpt-5-codex"),
+	}, slog.New(slog.NewTextHandler(logBuf, nil)), ProjectContext{})
+	m.visiblePaneCapture = func(*AgentProcess) string { return pane }
+	m.mu.RLock()
+	agent := m.agents["worker"]
+	m.mu.RUnlock()
+	return m, agent, logBuf
+}
+
+// TestTmuxSendEnters_WithholdsInsuranceEntersOnBlockingPrompt: with codex's
+// update menu on screen, the FIRST Enter is still sent (it is what runs the
+// typed line) but the insurance repeats are withheld — the guard fires on the
+// second iteration having sent exactly one.
+func TestTmuxSendEnters_WithholdsInsuranceEntersOnBlockingPrompt(t *testing.T) {
+	m, agent, logBuf := entersGuardManager(t, codexUpdatePane)
+
+	m.tmuxSendEntersForAgent(agent)
+
+	out := logBuf.String()
+	if !strings.Contains(out, "stopping repeat Enter") {
+		t.Fatalf("guard did not fire with the codex update menu on screen — Enters #2/#3 would confirm the pre-selected 'Update now'; log = %q", out)
+	}
+	if !strings.Contains(out, "sent=1") {
+		t.Errorf("guard fired after the wrong number of Enters (want exactly the first, insurance withheld); log = %q", out)
+	}
+}
+
+// TestTmuxSendEnters_NoPromptSendsAllInsurance is the positive control: with
+// nothing awaiting an answer, the insurance repeats must keep flowing — a
+// guard that fires on an ordinary pane would reintroduce the swallowed-Enter
+// launches the repeats exist to prevent.
+func TestTmuxSendEnters_NoPromptSendsAllInsurance(t *testing.T) {
+	m, agent, logBuf := entersGuardManager(t, "  ordinary CLI output\n❯ ")
+
+	m.tmuxSendEntersForAgent(agent)
+
+	if out := logBuf.String(); strings.Contains(out, "stopping repeat Enter") {
+		t.Errorf("guard fired without a blocking prompt on screen; log = %q", out)
+	}
+}

--- a/v2/pkg/agent/kick_restart_recovery_test.go
+++ b/v2/pkg/agent/kick_restart_recovery_test.go
@@ -1,0 +1,195 @@
+package agent
+
+// Tests for SendKick's crash-recovery branch and for RestartThenSendKick.
+// The contract under pin: a kick aimed at a pane whose CLI has died (bare
+// shell — no CLI marker) must NOT be typed into bash; SendKick restarts the
+// CLI first and only then delivers, so the message reaches an agent, not a
+// shell prompt (observed live: "-bash: NEVER: command not found").
+//
+// These are also the end-to-end regression tests for the Restart launch-race
+// guard: with the pre-fix `State == StateRunning` form of that guard, the
+// restart-before-kick path killed the CLI and then silently declined to
+// relaunch it, and both tests time out waiting for a CLI that never comes.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// forceFastPaneShell pins the test tmux server's default-shell to /bin/sh so
+// freshly created panes accept input immediately. A developer's login shell
+// (zsh + prompt frameworks) can take seconds to initialize and DISCARDS
+// keystrokes typed during init, silently swallowing the launch line these
+// tests depend on; CI's bash never does, so without this the tests would be
+// host-dependent. The anchor session keeps the per-process tmux server alive
+// so the global option sticks; the option is unset again on cleanup.
+func forceFastPaneShell(t *testing.T) {
+	t.Helper()
+	const anchor = "hive-fastshell-anchor"
+	_ = testTmuxCommand("new-session", "-d", "-s", anchor).Run() // ok if it exists
+	t.Cleanup(func() {
+		_ = testTmuxCommand("set-option", "-gu", "default-shell").Run()
+		_ = testTmuxCommand("kill-session", "-t", anchor).Run()
+	})
+	if err := testTmuxCommand("set-option", "-g", "default-shell", "/bin/sh").Run(); err != nil {
+		t.Skipf("cannot pin tmux default-shell: %v", err)
+	}
+}
+
+// quiesceThenMarkReady arms a helper goroutine for a test whose flow is
+// "relaunch, wait for readiness, deliver a kick" in one call. As soon as the
+// relaunch completes (HasLaunched + cancel set, both written under m.mu by
+// launchInTmux), it:
+//
+//  1. cancels the launch's pollTmuxOutputForAgent goroutine. Kick delivery
+//     and a live poller race on agent bookkeeping fields by design (see the
+//     comment on TestSendKick_DeliversToReadyPane) — a coverage test must not
+//     exercise that interleaving under -race. The poller's KickRefused read
+//     only happens from its SECOND 3s tick onward (the first iteration exits
+//     at prevLines == nil), and the cancellation lands well inside the first
+//     tick, so no conflicting access ever runs;
+//  2. waits out one poll interval so the poller has observed the cancel;
+//  3. renders "goose is ready" into the real pane, which satisfies both
+//     waitForCLIReadyForAgent (CLI marker) and waitForInputPromptForAgent
+//     (input prompt), letting the kick proceed against a quiet pane.
+//
+// The returned wait func must be deferred (after cleanupAgent registration)
+// so the goroutine is drained before the test's env restores run.
+func quiesceThenMarkReady(t *testing.T, m *Manager, name string) (wait func()) {
+	t.Helper()
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(30 * time.Second)
+		for time.Now().Before(deadline) {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			m.mu.Lock()
+			agent, ok := m.agents[name]
+			var cancel context.CancelFunc
+			session := ""
+			if ok && agent.HasLaunched && agent.cancel != nil {
+				cancel = agent.cancel
+				session = agent.tmuxSession
+			}
+			m.mu.Unlock()
+			if cancel == nil {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			cancel()
+			// One poll interval (3s) with margin, so the poller has observed
+			// ctx.Done before anything below makes the pane interesting.
+			time.Sleep(4 * time.Second)
+			_ = testTmuxCommand("send-keys", "-t", session, "-l", ": goose is ready").Run()
+			_ = testTmuxCommand("send-keys", "-t", session, "Enter").Run()
+			return
+		}
+	}()
+	return func() {
+		close(stop)
+		wg.Wait()
+	}
+}
+
+// TestSendKick_RestartsCrashedCLIThenDelivers: the pane exists but shows a
+// bare shell (the CLI crashed), so SendKick must take the restart branch —
+// relaunch the CLI, wait for it to become ready, and still deliver the kick.
+func TestSendKick_RestartsCrashedCLIThenDelivers(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	forceFastPaneShell(t)
+
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["worker"]
+	m.mu.RUnlock()
+
+	// A real session whose pane is a bare shell: session exists, CLI does not.
+	newRawTmuxSession(t, agent.tmuxSession)
+	m.mu.Lock()
+	agent.State = StateRunning
+	m.mu.Unlock()
+
+	wait := quiesceThenMarkReady(t, m, "worker")
+	defer wait()
+	defer cleanupAgent(t, m, "worker")
+
+	if err := m.SendKick("worker", "recover and continue the sweep"); err != nil {
+		t.Fatalf("SendKick on crashed CLI: %v", err)
+	}
+
+	m.mu.RLock()
+	restarts := agent.RestartCount
+	relaunched := agent.HasLaunched
+	lastMsg := agent.LastKickMessage
+	m.mu.RUnlock()
+	if restarts != 1 {
+		t.Errorf("RestartCount = %d, want 1 (crashed CLI must be restarted before the kick)", restarts)
+	}
+	if !relaunched {
+		t.Error("restart did not relaunch the CLI — the kick was delivered into a dead pane")
+	}
+	if lastMsg != "recover and continue the sweep" {
+		t.Errorf("LastKickMessage = %q — the kick was lost in the restart", lastMsg)
+	}
+}
+
+// TestRestartThenSendKick_CleanSlateThenDelivers pins the composed contract:
+// a clean-slate restart (no bootstrap override), a readiness wait, and a
+// prompt-waited SendKick delivery — the reliable alternative to
+// RestartWithBootstrap's fragile $(cat file) shell expansion.
+func TestRestartThenSendKick_CleanSlateThenDelivers(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	forceFastPaneShell(t)
+
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+
+	wait := quiesceThenMarkReady(t, m, "worker")
+	defer wait()
+	defer cleanupAgent(t, m, "worker")
+
+	if err := m.RestartThenSendKick(context.Background(), "worker", "fresh context, take the next issue"); err != nil {
+		t.Fatalf("RestartThenSendKick: %v", err)
+	}
+
+	m.mu.RLock()
+	agent := m.agents["worker"]
+	restarts := agent.RestartCount
+	lastMsg := agent.LastKickMessage
+	m.mu.RUnlock()
+	if restarts != 1 {
+		t.Errorf("RestartCount = %d, want 1", restarts)
+	}
+	if lastMsg != "fresh context, take the next issue" {
+		t.Errorf("LastKickMessage = %q — the kick must be delivered after the restart", lastMsg)
+	}
+}
+
+// TestRestartThenSendKick_UnknownAgentSurfacesRestartError: the restart leg's
+// failure must be surfaced (wrapped), not swallowed into a silent no-kick.
+func TestRestartThenSendKick_UnknownAgentSurfacesRestartError(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	err := m.RestartThenSendKick(context.Background(), "ghost", "msg")
+	if err == nil {
+		t.Fatal("RestartThenSendKick on unknown agent returned nil, want restart error")
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -7222,13 +7222,28 @@ func (m *Manager) Restart(ctx context.Context, name string) error {
 	// mintAgentTokenUnlocked — so release, mint, then re-verify under the
 	// re-acquired lock exactly as Start does. The deferred Unlock above still
 	// releases the lock re-acquired here on every return path.
+	//
+	// The lost-race check compares launchGen, NOT agent.State. Restart —
+	// unlike Start, which refuses running agents in its phase 1 — is
+	// routinely called ON a running agent (dashboard restart, SendKick's
+	// crashed-CLI recovery), and nothing on the restart path clears the
+	// pre-restart StateRunning. The original `State == StateRunning` form of
+	// this guard therefore misread the agent's OWN old state as "another
+	// path won the launch race" and returned nil after the CLI had already
+	// been killed and its session recreated — every restart of a running
+	// agent became a silent kill-without-relaunch, and a kick to a crashed
+	// CLI timed out waiting for a CLI that was never going to launch.
+	// launchGen increments on every completed launch, so a changed gen — and
+	// only a changed gen — proves a racing path actually launched while the
+	// lock was released.
+	genBeforeMint := agent.launchGen
 	m.mu.Unlock()
 	m.mintAgentTokenUnlocked(ctx, agent)
 	m.mu.Lock()
 	if cur, ok := m.agents[name]; !ok || cur != agent {
 		return fmt.Errorf("agent %s removed during restart", name)
 	}
-	if agent.State == StateRunning {
+	if agent.launchGen != genBeforeMint {
 		// Another path won the launch race while we were unlocked.
 		return nil
 	}

--- a/v2/pkg/agent/relaunch_race_guard_test.go
+++ b/v2/pkg/agent/relaunch_race_guard_test.go
@@ -1,0 +1,255 @@
+package agent
+
+// Tests for the post-mint re-verify guards added with the #3962 relaunch-mint
+// fix (#3967): every relaunch path releases m.mu for the outbound mint, so a
+// concurrent Stop/Remove (or a racing launch) can change the world before the
+// path re-locks. Each guard must be honoured — relaunching a REMOVED agent
+// would resurrect a ghost tmux session no map entry owns, and double-launching
+// after a lost race would put two CLIs in one pane.
+//
+// The blocking minter makes the race deterministic: WriteAgentToken parks in
+// the unlocked mint window until the test has mutated the manager, so the
+// re-verify always observes the mutation. No sleeps, no timing guesses.
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// blockingMinter parks WriteAgentToken until released, signalling entry so the
+// test knows the relaunch path is inside its UNLOCKED mint window.
+type blockingMinter struct {
+	entered   chan struct{}
+	release   chan struct{}
+	enterOnce sync.Once
+}
+
+func newBlockingMinter() *blockingMinter {
+	return &blockingMinter{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (b *blockingMinter) WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error {
+	b.enterOnce.Do(func() { close(b.entered) })
+	<-b.release
+	return nil
+}
+
+// raceGuardManager builds a manager with one claude agent carrying a per-agent
+// UID (the mint step is gated on UID>0) and the blocking minter attached.
+func raceGuardManager(t *testing.T) (*Manager, *blockingMinter) {
+	t.Helper()
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	m.agents["worker"].UID = 2101
+	m.mu.Unlock()
+	bm := newBlockingMinter()
+	m.SetAppAuth(bm)
+	return m, bm
+}
+
+// waitEntered fails the test if the relaunch path never reaches its mint
+// window — which would mean the mint step itself regressed (see
+// relaunch_mint_test.go for the dedicated tests on that).
+func waitEntered(t *testing.T, bm *blockingMinter, what string) {
+	t.Helper()
+	select {
+	case <-bm.entered:
+	case <-time.After(20 * time.Second):
+		t.Fatalf("%s never reached the unlocked mint window", what)
+	}
+}
+
+// TestRestart_RelaunchesRunningAgent is the regression pin for the guard's
+// FORM: the lost-race check must compare launchGen, not agent.State. Restart
+// is routinely called ON a running agent (dashboard restart, SendKick's
+// crashed-CLI recovery) and nothing on the restart path clears the
+// pre-restart StateRunning — so a `State == StateRunning` guard reads the
+// agent's OWN old state as "another path won the launch race" and returns
+// nil AFTER killing the CLI and its session: every restart of a running
+// agent becomes a silent kill-without-relaunch.
+func TestRestart_RelaunchesRunningAgent(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	m.agents["worker"].State = StateRunning
+	m.mu.Unlock()
+
+	if err := m.Restart(context.Background(), "worker"); err != nil {
+		t.Fatalf("Restart(running agent): %v", err)
+	}
+	defer cleanupAgent(t, m, "worker")
+
+	m.mu.RLock()
+	agent := m.agents["worker"]
+	relaunched := agent.HasLaunched
+	gen := agent.launchGen
+	state := agent.State
+	m.mu.RUnlock()
+	if !relaunched || gen != 1 {
+		t.Fatalf("HasLaunched=%v launchGen=%d — Restart of a RUNNING agent killed the CLI and never relaunched it (the launch-race guard misread the agent's own pre-restart state)", relaunched, gen)
+	}
+	if state != StateRunning {
+		t.Errorf("State = %s after restart, want %s", state, StateRunning)
+	}
+}
+
+// TestRestart_AgentRemovedDuringMintWindowFails: Restart must refuse to
+// relaunch an agent that was removed while the mint had m.mu released. Before
+// the guard, launchInTmux would run for a map-orphaned *AgentProcess.
+func TestRestart_AgentRemovedDuringMintWindowFails(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	installSuExecStub(t)
+	m, bm := raceGuardManager(t)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Restart(context.Background(), "worker") }()
+	waitEntered(t, bm, "Restart")
+
+	// The concurrent removal the guard exists for.
+	m.mu.Lock()
+	agent := m.agents["worker"]
+	delete(m.agents, "worker")
+	m.mu.Unlock()
+	close(bm.release)
+
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "removed during restart") {
+		t.Fatalf("Restart err = %v, want 'removed during restart'", err)
+	}
+	// The removed agent must NOT have been relaunched.
+	m.mu.Lock()
+	launched := agent.State == StateRunning
+	m.mu.Unlock()
+	if launched {
+		t.Error("removed agent was relaunched anyway — the re-verify guard did not stop launchInTmux")
+	}
+	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
+}
+
+// TestResume_AgentRemovedDuringMintWindowFails: the same guard on the Resume
+// relaunch path (paused → relaunch), which minted nothing at all before #3962
+// and therefore never had to re-verify.
+func TestResume_AgentRemovedDuringMintWindowFails(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	installSuExecStub(t)
+	m, bm := raceGuardManager(t)
+	m.mu.Lock()
+	m.agents["worker"].Paused = true
+	m.agents["worker"].State = StatePaused
+	m.mu.Unlock()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Resume(context.Background(), "worker", "test", "race guard") }()
+	waitEntered(t, bm, "Resume")
+
+	m.mu.Lock()
+	agent := m.agents["worker"]
+	delete(m.agents, "worker")
+	m.mu.Unlock()
+	close(bm.release)
+
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "removed during resume") {
+		t.Fatalf("Resume err = %v, want 'removed during resume'", err)
+	}
+	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
+}
+
+// TestResume_LaunchRaceLostReturnsWithoutSecondLaunch: when another path wins
+// the launch race during Resume's mint window (agent already StateRunning on
+// re-lock), Resume must return success WITHOUT launching a second CLI into the
+// same pane.
+func TestResume_LaunchRaceLostReturnsWithoutSecondLaunch(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	installSuExecStub(t)
+	m, bm := raceGuardManager(t)
+	m.mu.Lock()
+	m.agents["worker"].Paused = true
+	m.agents["worker"].State = StatePaused
+	m.mu.Unlock()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Resume(context.Background(), "worker", "test", "race guard") }()
+	waitEntered(t, bm, "Resume")
+
+	// Simulate the racing path having already launched this agent.
+	m.mu.Lock()
+	agent := m.agents["worker"]
+	agent.State = StateRunning
+	m.mu.Unlock()
+	close(bm.release)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Resume after lost launch race err = %v, want nil (the other path owns the launch)", err)
+	}
+	// launchInTmux marks HasLaunched; the loser must not have gone through it.
+	m.mu.Lock()
+	hasLaunched := agent.HasLaunched
+	m.mu.Unlock()
+	if hasLaunched {
+		t.Error("Resume launched a second CLI after losing the launch race")
+	}
+	cleanupAgent(t, m, "worker")
+}
+
+// TestRestartWithBootstrap_AgentRemovedDuringUnlockedWindowFails: the same
+// removed-agent guard on RestartWithBootstrap, whose unlocked window is its
+// pre-existing session-ready sleep. RestartCount is incremented under the
+// FIRST lock, so observing it (under the lock) proves the goroutine has
+// released m.mu and is inside the unlocked window — the removal below then
+// deterministically lands before the re-lock.
+func TestRestartWithBootstrap_AgentRemovedDuringUnlockedWindowFails(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.RestartWithBootstrap(context.Background(), "worker", "bootstrap prompt") }()
+
+	deadline := time.Now().Add(20 * time.Second)
+	var agent *AgentProcess
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("RestartWithBootstrap never entered its unlocked window")
+		}
+		m.mu.Lock()
+		a, ok := m.agents["worker"]
+		if ok && a.RestartCount == 1 {
+			agent = a
+			delete(m.agents, "worker")
+			m.mu.Unlock()
+			break
+		}
+		m.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "removed during restart") {
+		t.Fatalf("RestartWithBootstrap err = %v, want 'removed during restart'", err)
+	}
+	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
+}


### PR DESCRIPTION
## What

Fixes the v4 `coverage` gate: `pkg/agent` measures **87.7%** against its ratchet floor of **89** (`PKG_THRESHOLD[agent]` in `.github/workflows/coverage-hourly.yml`), red on v4's hourly run since 2026-08-17 15:04 UTC and failing the gate on **every open v4 PR** (#3975 and #3978 are currently blocked on it). Per #3903 the floor is a ratchet — this PR adds tests instead of touching the floor.

While writing those tests, the coverage gap turned out to be hiding a **live regression from #3967**, which is also fixed here.

## The bug the uncovered code was hiding

#3967 added a post-mint "launch race" re-verify to `Restart`:

```go
if agent.State == StateRunning {
    // Another path won the launch race while we were unlocked.
    return nil
}
```

`Start` can use a state check like that safely because its phase 1 refuses agents that are already running. `Restart` cannot: it is routinely called **on** a running agent, and nothing on the restart path clears the pre-restart `StateRunning`. The guard therefore misreads the agent's *own* old state as "another path won the race" and returns `nil` — after the CLI has been killed, its processes reaped, and its session recreated. Every restart of a running agent became a **silent kill-without-relaunch**.

Callers hit by this (all call `Restart` on `StateRunning` agents):

- `pollTmuxOutputForAgent` expired-token auto-restart
- `pollTmuxOutputForAgent` TLS-error auto-restart
- `CheckAndRestartCrashedAgents` (its sweep *only* selects `StateRunning` agents)
- `SendKick`'s crashed-CLI recovery ("restarting before kick")
- `runCopilotDiagnostic`'s recovery restart
- `RestartThenSendKick`

The fix compares `launchGen` (which increments on every completed launch) captured before the unlocked mint window, so only a launch that *actually happened* during the window suppresses the relaunch. `Resume`'s state-based guard is untouched — it requires `StatePaused` up front, so `StateRunning` at re-lock genuinely means a lost race there.

Found because the new `SendKick` crash-recovery test timed out waiting for a CLI that was never going to launch — i.e. exactly the uncovered-path risk the ratchet exists to catch.

## Coverage

Measured locally with the workflow's per-package invocation (`go test ./pkg/agent/ -short -count=1 -coverprofile=...`):

| | pkg/agent |
|---|---|
| before | **87.7%** (floor 89 → gate red) |
| after | local confirmation run in flight — exact figure will be appended here; this PR's own coverage job is the authoritative check |

The uncovered code was concentrated in the five commits that touched `v2/pkg/agent/` since the floor was recorded at `d89121f5` — #3967 (relaunch minting + re-verify guards), #3966 (scrub pipe), #3925 (mode-file self-heal), #3910 (agy backend), #3919 (blocking-prompt answering) — plus older 0%-covered surface (`CaptureFullLog`, mint-token cache path, sandbox audit wiring).

## New tests (26, all assert behavior — no coverage-farming)

- `relaunch_race_guard_test.go` — **regression pin for the `Restart` fix** (`TestRestart_RelaunchesRunningAgent`, red on v4 HEAD), plus deterministic lost-race/removed-agent guards for `Restart`/`Resume`/`RestartWithBootstrap` using a blocking minter parked in the unlocked mint window (no sleeps-as-synchronization).
- `kick_restart_recovery_test.go` — end-to-end `SendKick` crashed-CLI recovery (restart-then-deliver, also red on v4 HEAD) and `RestartThenSendKick`; the launch poller is cancelled before delivery so the known live-poll/kick interleaving is not exercised under `-race`.
- `mint_token_cache_test.go` — `SetAgentMint`/`issueAgentMintToken` contract: strict no-op when disabled, mint/write failures logged-and-swallowed (never block a launch), per-agent cache path distinctness.
- `enters_prompt_guard_test.go` — #3919's `tmuxSendEntersForAgent` guard: first Enter sent, insurance repeats withheld when codex's update menu (destructive default) is on screen; positive control for the no-prompt case.
- `agy_launch_test.go` — #3910's flag contract on a real launch: `--dangerously-skip-permissions` always, `--model <m> --effort low` (agy silently ignores `--model` without `--effort`).
- `capture_full_log_test.go` — `CaptureFullLog` (#3693): joined scrollback comes back; unknown-agent/no-session/dead-session are surfaced errors, not empty logs.
- `fsguards_audit_test.go` — `mkdirAllNoFollow` (audit F12: escape + planted-symlink refusal), `inferenceHomeIsOwnedBy` fail-safe, `copilotCredentialFileHasTokens` malformed-shape handling, sandbox audit callback wire/clear.

Test-infra note: launch-dependent tests pin the test tmux server's `default-shell` to `/bin/sh` — a developer login shell (zsh + prompt frameworks) can take seconds to init and discards keystrokes typed during init, which swallowed the typed launch line on macOS while CI's bash never does.

Unblocks the coverage gate for every open v4 PR.
