### PR TITLE
🐛 fix(contribute): honour non-closing PR references so in-flight work stops being re-offered

### DIFF
--- a/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
+++ b/v2/pkg/dashboard/contribute_ws_claimed_issue_test.go
@@ -188,3 +188,44 @@ func TestClaimedIssue_NoHookLeavesSelectionUnchanged(t *testing.T) {
 		t.Fatalf("expected first eligible issue #353 with no claim data, got #%d", msg.Number)
 	}
 }
+
+// referenceClaim is the #3980 signal: an open PR that is demonstrably working
+// the issue but deliberately did NOT claim to close it ("Refs #N"), because it
+// only partially addresses it. The agent-side FilterClaimedIssues ignores these;
+// the contribute queue must not.
+func referenceClaim(repo string, number int) ghpkg.IssueClaim {
+	return ghpkg.IssueClaim{
+		Repo: repo, Issue: number,
+		PRNumber: 3898, PRRepo: repo,
+		PRURL:      "https://github.com/projectbluefin/dakota/pull/3898",
+		PRAuthor:   "Danathar",
+		ObservedAt: time.Now(),
+		Reference:  true,
+	}
+}
+
+// TestClaimedIssue_ReferenceClaimSkipped replays #3980: the contributor's own
+// open PR referenced the issue without a closing keyword, so nothing suppressed
+// it and the queue re-offered the same work every cooldown window, forever.
+// A reference claim must withhold the issue and offer the next one instead.
+func TestClaimedIssue_ReferenceClaimSkipped(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+	s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+		if repo == "projectbluefin/dakota" && number == 353 {
+			return referenceClaim(repo, number), true
+		}
+		return ghpkg.IssueClaim{}, false
+	}
+
+	msg := hub.selectTask(claimedIssueConn())
+	if msg == nil {
+		t.Fatal("expected a message from selectTask")
+	}
+	if msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %q (reason %q)", msg.Type, msg.Reason)
+	}
+	if msg.Number != 360 {
+		t.Fatalf("reference-claimed issue was re-offered: got #%d, want #360", msg.Number)
+	}
+}

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -61,10 +61,12 @@ type Dependencies struct {
 	// IssueClaimed reports whether an open PR — hive-authored OR from an
 	// external contributor — already claims to fix the given issue
 	// (kubestellar/hive#3768). It is backed by the governor's duplicate-PR
-	// claim ledger, which parses `Fixes #N` / `Closes #N` references (and a
-	// branch-name heuristic) out of every open PR each eval cycle and persists
-	// them across restarts. The contribute selectTask consults it so an issue
-	// with a fix already in flight is never offered to another contributor.
+	// claim ledger, which parses `Fixes #N` / `Closes #N` references (a
+	// branch-name heuristic, and since #3980 non-closing `Refs #N` references
+	// as weak claims) out of every open PR each eval cycle and persists them
+	// across restarts. The contribute selectTask consults it so an issue with a
+	// fix already in flight is never offered to another contributor — including
+	// one whose PR deliberately did not claim to close it.
 	// repo is tried in the same spelling the ledger keys on (the config repo
 	// form); a nil func means "no claim data" and disables the check.
 	IssueClaimed func(repo string, number int) (ghpkg.IssueClaim, bool)

--- a/v2/pkg/github/prclaims.go
+++ b/v2/pkg/github/prclaims.go
@@ -89,6 +89,45 @@ type IssueClaim struct {
 	// recorded hive-authored claims — unmarshal as hive-authored (false),
 	// keeping their agent-side suppression intact across the upgrade.
 	ExternalAuthor bool `json:"external_author,omitempty"`
+	// Reference marks a WEAK claim, recovered from a non-closing reference
+	// ("Refs #N", "Part of #N") rather than a closing keyword
+	// (kubestellar/hive#3980). Such a PR is demonstrably working the issue but
+	// deliberately does not claim to close it — the correct convention when a
+	// PR only partially addresses an issue, or when the remainder is gated on a
+	// maintainer decision. Before this existed, writing `Refs #N` instead of
+	// `Fixes #N` made the work invisible to the guard, and the contribute queue
+	// re-offered the issue every cooldown window forever.
+	//
+	// Like ExternalAuthor, the field GRADES the claim rather than deciding for
+	// its consumers: the contribute queue honours reference claims (that is the
+	// loop being closed), while FilterClaimedIssues ignores them so agent work
+	// on a partially-addressed issue is never frozen behind a PR that never
+	// claimed to finish it. Also omitempty-false, so pre-#3980 ledgers unmarshal
+	// as strong claims and keep their existing suppression across the upgrade.
+	Reference bool `json:"reference,omitempty"`
+}
+
+// claimRank orders claims by evidential strength, highest first. It exists so
+// insertLocked can resolve key collisions with a single comparison instead of a
+// growing pile of pairwise special cases.
+//
+// A closing keyword outranks a bare reference (an explicit "this closes it" is
+// stronger evidence than "this is about it"), and within each tier a
+// hive-authored PR outranks an external one — the #3768 precedence rule, which
+// exists so the agent-side filter can never be blinded by an external PR racing
+// the map. Equal ranks let the later claim win, matching the pre-#3980 behavior
+// of a plain map assignment.
+func claimRank(c IssueClaim) int {
+	switch {
+	case !c.Reference && !c.ExternalAuthor:
+		return 3
+	case !c.Reference && c.ExternalAuthor:
+		return 2
+	case c.Reference && !c.ExternalAuthor:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // Key identifies the issue a claim covers.
@@ -125,10 +164,18 @@ var claimRefPattern = regexp.MustCompile(
 // supplies the repository for bare `#N` references. Results are de-duplicated
 // and returned in first-seen order. A nil/empty text yields no claims.
 func ParseClaimedIssues(text, defaultRepo string) []ClaimedRef {
+	return parseRefs(claimRefPattern, text, defaultRepo)
+}
+
+// parseRefs is the shared body behind ParseClaimedIssues and
+// ParseReferencedIssues. Both patterns expose the same three capture groups
+// (keyword, optional owner/repo, issue number), so the extraction, repo
+// defaulting and de-duplication are identical and live here once.
+func parseRefs(pattern *regexp.Regexp, text, defaultRepo string) []ClaimedRef {
 	if text == "" {
 		return nil
 	}
-	matches := claimRefPattern.FindAllStringSubmatch(text, -1)
+	matches := pattern.FindAllStringSubmatch(text, -1)
 	if len(matches) == 0 {
 		return nil
 	}
@@ -161,6 +208,58 @@ func ParseClaimedIssues(text, defaultRepo string) []ClaimedRef {
 type ClaimedRef struct {
 	Repo  string
 	Issue int
+}
+
+// referenceKeywords are the idioms a PR uses to say "I am working on this
+// issue" WITHOUT claiming to close it (kubestellar/hive#3980). Longest
+// alternatives are listed first so the intended word wins the match.
+//
+// The set is deliberately narrow. "relates to", "related to" and "see" are
+// EXCLUDED: they mark a topical cross-reference ("unlike #12", "see #12 for
+// background"), not a statement that this PR does work on that issue, and
+// treating them as claims would let a passing mention withhold an issue from
+// the contribute queue.
+var referenceKeywords = []string{
+	"references", "referencing", "refs", "ref",
+	"addresses", "addressing", "addressed", "address",
+	"contributes to", "part of", "towards", "toward",
+}
+
+// referenceRefPattern matches a non-closing reference keyword followed by an
+// issue reference, allowing a bounded run of prose between the two:
+//
+//	(?i)                          case-insensitive
+//	\b(references|refs|...)\b     a reference keyword as a whole word
+//	[^.\n#]{0,40}?                lazy, bounded gap — see below
+//	(?:([\w.-]+/[\w.-]+))?#(\d+)  optional owner/repo prefix, then #N
+//
+// The gap exists because these keywords are written as prose, not as the
+// machine-readable trailer a closing keyword conventionally is. The real PR
+// that motivated #3980 reads "Addresses a `ci-maintainer` finding from the
+// #2364 advisory digest" — keyword and reference separated by six words. A
+// strict `keyword\s+#N` would miss it.
+//
+// The gap is bounded three ways so it cannot swallow a whole paragraph and
+// attach a keyword to an unrelated number further down: at most 40 characters,
+// lazily matched, and containing no '.', newline, or '#'. Excluding '.' stops
+// it crossing a sentence boundary; excluding '#' stops it skipping over a
+// nearer reference to reach a further one.
+//
+// A false positive here costs one issue not being OFFERED to the contribute
+// queue while that PR stays open, and is released as soon as the PR closes.
+// It cannot suppress agent work — FilterClaimedIssues ignores reference claims.
+var referenceRefPattern = regexp.MustCompile(
+	`(?i)\b(` + strings.Join(referenceKeywords, "|") + `)\b[^.\n#]{0,40}?(?:([\w.-]+/[\w.-]+))?#(\d+)`)
+
+// ParseReferencedIssues extracts every issue this text REFERENCES without
+// claiming to close (kubestellar/hive#3980). defaultRepo supplies the
+// repository for bare `#N` references. Results are de-duplicated and returned
+// in first-seen order; nil/empty text yields no refs.
+//
+// It is the weak-evidence companion to ParseClaimedIssues and is only consulted
+// when that (and the branch-name heuristic) found nothing at all.
+func ParseReferencedIssues(text, defaultRepo string) []ClaimedRef {
+	return parseRefs(referenceRefPattern, text, defaultRepo)
 }
 
 // branchIssuePattern matches the branch-naming conventions agents use to encode
@@ -302,6 +401,26 @@ func (c *Client) FetchClaims(ctx context.Context, identity HiveIdentity) ([]Issu
 					}
 				}
 
+				// Third and weakest tier (#3980): a PR that references an issue
+				// without a closing keyword ("Refs #N", "Part of #N") and whose
+				// branch name carries no issue number. Such a PR is working the
+				// issue but deliberately not claiming to finish it, and until
+				// now produced NO claim at all — so the contribute queue kept
+				// re-offering an issue whose work was already open in a PR.
+				//
+				// Ordered last on purpose. The two tiers above are unchanged and
+				// still win, so no claim that exists today changes its target or
+				// its strength; this only fills in PRs that previously yielded
+				// nothing. Marked Reference so FilterClaimedIssues can keep
+				// agent work flowing on a partially-addressed issue.
+				reference := false
+				if len(refs) == 0 {
+					if refRefs := ParseReferencedIssues(text, repo); len(refRefs) > 0 {
+						refs = refRefs
+						reference = true
+					}
+				}
+
 				for _, ref := range refs {
 					claims = append(claims, IssueClaim{
 						Repo:           ref.Repo,
@@ -312,6 +431,7 @@ func (c *Client) FetchClaims(ctx context.Context, identity HiveIdentity) ([]Issu
 						PRAuthor:       author,
 						ObservedAt:     now,
 						ExternalAuthor: external,
+						Reference:      reference,
 					})
 				}
 			}
@@ -407,7 +527,7 @@ func LoadClaimLedger(path string, logger *slog.Logger) (*ClaimLedger, error) {
 // exclusively, as LoadClaimLedger does before publishing it).
 func (l *ClaimLedger) insertLocked(c IssueClaim) {
 	key := c.Key()
-	if existing, ok := l.claims[key]; ok && !existing.ExternalAuthor && c.ExternalAuthor {
+	if existing, ok := l.claims[key]; ok && claimRank(c) < claimRank(existing) {
 		return
 	}
 	l.claims[key] = c
@@ -556,7 +676,9 @@ func (l *ClaimLedger) Save() error {
 type RedStaleFunc func(prRepo string, prNumber int) bool
 
 // FilterClaimedIssues removes from result every issue an open hive-authored PR
-// already claims, logging each suppression with the claiming PR's URL.
+// already claims to CLOSE, logging each suppression with the claiming PR's URL.
+// External claims (#3768) and weak reference claims (#3980) are both skipped
+// here and exist for the contribute queue, which consults the ledger directly.
 //
 // redStale (may be nil) is Fix #3's release valve: when it reports the claiming
 // PR is red+stale, the issue is NOT suppressed — it is kept actionable so a
@@ -583,6 +705,18 @@ func FilterClaimedIssues(result *ActionableResult, ledger *ClaimLedger, redStale
 		// pipeline. External claims exist for the contribute queue, which
 		// consults the ledger directly (dashboard selectTask).
 		if claim.ExternalAuthor {
+			kept = append(kept, issue)
+			continue
+		}
+		// #3980: a REFERENCE claim ("Refs #N") never suppresses agent work
+		// either. The claiming PR explicitly declined to say it closes the
+		// issue, so the issue is by definition not finished — freezing agent
+		// work behind it would strand exactly the partially-addressed issues
+		// this weak tier exists to notice. It still suppresses contribute
+		// dispatch, which consults the ledger directly (selectTask), because
+		// re-handing a contributor work its own open PR already covers is the
+		// waste #3980 reported.
+		if claim.Reference {
 			kept = append(kept, issue)
 			continue
 		}

--- a/v2/pkg/github/prclaims_reference_test.go
+++ b/v2/pkg/github/prclaims_reference_test.go
@@ -1,0 +1,348 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These tests are the #3980 regression suite.
+//
+// A contributor's open PR kept failing to suppress its own issue because it
+// referenced the issue WITHOUT a closing keyword — "Refs #3498 — no `Fixes`
+// keyword, deliberately", the correct convention when a PR only partially
+// addresses an issue. The claim ledger recorded nothing, so the contribute
+// queue re-offered the issue every cooldown window, forever. Doing the right
+// thing was what made the work invisible.
+
+func TestParseReferencedIssues(t *testing.T) {
+	const defaultRepo = "kubestellar/hive"
+
+	tests := []struct {
+		name string
+		text string
+		want []ClaimedRef
+	}{
+		// Every supported reference idiom.
+		{"refs", "Refs #1", []ClaimedRef{{defaultRepo, 1}}},
+		{"ref", "ref #2", []ClaimedRef{{defaultRepo, 2}}},
+		{"references", "References #3", []ClaimedRef{{defaultRepo, 3}}},
+		{"referencing", "referencing #4", []ClaimedRef{{defaultRepo, 4}}},
+		{"addresses", "Addresses #5", []ClaimedRef{{defaultRepo, 5}}},
+		{"address", "address #6", []ClaimedRef{{defaultRepo, 6}}},
+		{"addressing", "Addressing #7", []ClaimedRef{{defaultRepo, 7}}},
+		{"addressed", "addressed #8", []ClaimedRef{{defaultRepo, 8}}},
+		{"part of", "Part of #9", []ClaimedRef{{defaultRepo, 9}}},
+		{"towards", "Towards #10", []ClaimedRef{{defaultRepo, 10}}},
+		{"toward", "toward #11", []ClaimedRef{{defaultRepo, 11}}},
+		{"contributes to", "Contributes to #12", []ClaimedRef{{defaultRepo, 12}}},
+
+		{"case-insensitive", "REFS #423", []ClaimedRef{{defaultRepo, 423}}},
+		{"colon separator", "Refs: #13", []ClaimedRef{{defaultRepo, 13}}},
+		{"cross-repo form", "Refs owner/other#55", []ClaimedRef{{"owner/other", 55}}},
+
+		// The two real PR bodies from the #3980 report. These are the whole
+		// point of the change; if either regresses, the reported loop returns.
+		{
+			name: "real PR #3898 body (issue 3498)",
+			text: "Refs #3498 — no `Fixes` keyword, deliberately. The issue left the scaling curve open",
+			want: []ClaimedRef{{defaultRepo, 3498}},
+		},
+		{
+			name: "real PR #3979 body (issue 2364), keyword six words from the ref",
+			text: "Addresses a `ci-maintainer` finding from the #2364 advisory digest:",
+			want: []ClaimedRef{{defaultRepo, 2364}},
+		},
+
+		// Deliberately NOT claims: a topical cross-reference is not a statement
+		// that this PR does work on that issue.
+		{"see is excluded", "see #12 for background", nil},
+		{"related to is excluded", "related to #12", nil},
+		{"relates to is excluded", "relates to #12", nil},
+		{"bare mention is excluded", "unlike #12, this uses a map", nil},
+		{"bare number is excluded", "#12", nil},
+		{"empty text", "", nil},
+
+		// Gap bounds. The gap exists for prose like PR #3979, but must not let
+		// a keyword reach across a sentence or past a nearer reference.
+		{
+			name: "gap cannot cross a sentence boundary",
+			text: "Refs the earlier discussion. #123",
+			want: nil,
+		},
+		{
+			name: "gap stops at a nearer reference",
+			text: "Addresses #100 which supersedes #200",
+			want: []ClaimedRef{{defaultRepo, 100}},
+		},
+		{
+			name: "gap cannot cross a newline",
+			text: "Refs the thing\n#123",
+			want: nil,
+		},
+		// The gap is measured from the end of the keyword, so it includes the
+		// separating space: "Refs " + 39 filler = exactly 40.
+		{
+			name: "gap at the 40-char bound still matches",
+			text: "Refs " + strings.Repeat("x", 39) + "#123",
+			want: []ClaimedRef{{defaultRepo, 123}},
+		},
+		{
+			name: "gap one past the 40-char bound does not match",
+			text: "Refs " + strings.Repeat("x", 40) + "#123",
+			want: nil,
+		},
+
+		{
+			name: "de-duplicates repeated references to one issue",
+			text: "Refs #1 and is part of #1",
+			want: []ClaimedRef{{defaultRepo, 1}},
+		},
+		{
+			name: "multiple distinct issues, first-seen order",
+			text: "Refs #7. Part of #3.",
+			want: []ClaimedRef{{defaultRepo, 7}, {defaultRepo, 3}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseReferencedIssues(tt.text, defaultRepo)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseReferencedIssues(%q) = %+v, want %+v", tt.text, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("ref[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestParseClaimedIssuesStillIgnoresNonClosingRefs pins the deliberate
+// separation between the two parsers. The closing parser must NOT start
+// matching references — its results suppress agent work, and a PR that says
+// "Refs #N" has explicitly declined to claim it closes the issue.
+func TestParseClaimedIssuesStillIgnoresNonClosingRefs(t *testing.T) {
+	for _, text := range []string{
+		"Refs #1", "Part of #2", "Addresses #3", "Towards #4", "see #5",
+	} {
+		if got := ParseClaimedIssues(text, "r"); got != nil {
+			t.Errorf("ParseClaimedIssues(%q) = %+v, want nil (closing keywords only)", text, got)
+		}
+	}
+	// Positive control: the closing parser still works.
+	if got := ParseClaimedIssues("Fixes #6", "r"); len(got) != 1 || got[0].Issue != 6 {
+		t.Fatalf("closing parser regressed: %+v", got)
+	}
+}
+
+// TestFetchClaimsReferenceTier pins the three-tier precedence. The reference
+// tier is LAST on purpose: it only fills in PRs that previously produced no
+// claim at all, so no claim that existed before this change moves target or
+// changes strength.
+func TestFetchClaimsReferenceTier(t *testing.T) {
+	prWithBranch := func(number int, title, body, branch string) map[string]any {
+		p := pr(number, "clubanderson", title, body)
+		p["head"] = map[string]any{"ref": branch}
+		return p
+	}
+
+	tests := []struct {
+		name          string
+		prs           []map[string]any
+		wantIssue     int
+		wantReference bool
+		wantNoClaim   bool
+	}{
+		{
+			name:          "reference recovers a PR that claimed nothing before",
+			prs:           []map[string]any{prWithBranch(3898, "autoscale", "Refs #3498 — no `Fixes` keyword, deliberately.", "feat/governor-autoscale-thresholds")},
+			wantIssue:     3498,
+			wantReference: true,
+		},
+		{
+			name:          "closing keyword still wins over a reference",
+			prs:           []map[string]any{prWithBranch(1, "t", "Fixes #100. Also refs #200.", "scratch")},
+			wantIssue:     100,
+			wantReference: false,
+		},
+		{
+			name:          "branch heuristic still wins over a reference",
+			prs:           []map[string]any{prWithBranch(2, "t", "Refs #200", "issue-443")},
+			wantIssue:     443,
+			wantReference: false,
+		},
+		{
+			name:        "a passing mention still claims nothing",
+			prs:         []map[string]any{prWithBranch(3, "t", "unlike #999, this uses a map", "scratch")},
+			wantNoClaim: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := prClaimServer(t, tt.prs, http.StatusOK)
+			c := NewClientForTest(srv.URL, "kubestellar", []string{"hive"}, testLogger())
+			claims, err := c.FetchClaims(context.Background(), HiveIdentity{AIAuthor: "clubanderson"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantNoClaim {
+				if len(claims) != 0 {
+					t.Fatalf("expected no claims, got %+v", claims)
+				}
+				return
+			}
+			if len(claims) != 1 {
+				t.Fatalf("expected exactly one claim, got %+v", claims)
+			}
+			if claims[0].Issue != tt.wantIssue {
+				t.Errorf("Issue = %d, want %d", claims[0].Issue, tt.wantIssue)
+			}
+			if claims[0].Reference != tt.wantReference {
+				t.Errorf("Reference = %v, want %v", claims[0].Reference, tt.wantReference)
+			}
+		})
+	}
+}
+
+// TestFilterClaimedIssuesIgnoresReferenceClaims: a reference claim must never
+// suppress AGENT work. The claiming PR explicitly declined to say it closes the
+// issue, so freezing agents behind it would strand exactly the
+// partially-addressed issues this weak tier exists to notice.
+func TestFilterClaimedIssuesIgnoresReferenceClaims(t *testing.T) {
+	result := &ActionableResult{}
+	result.Issues.Items = []Issue{
+		{Repo: "kubestellar/hive", Number: 3498, Title: "referenced, not closed"},
+		{Repo: "kubestellar/hive", Number: 3499, Title: "genuinely claimed"},
+	}
+	result.Issues.Count = 2
+
+	l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+	l.Reconcile([]IssueClaim{
+		{Repo: "kubestellar/hive", Issue: 3498, PRNumber: 3898, PRRepo: "kubestellar/hive",
+			PRAuthor: "clubanderson", ObservedAt: time.Now(), Reference: true},
+		{Repo: "kubestellar/hive", Issue: 3499, PRNumber: 3899, PRRepo: "kubestellar/hive",
+			PRAuthor: "clubanderson", ObservedAt: time.Now()},
+	}, true)
+
+	suppressed := FilterClaimedIssues(result, l, nil, testLogger())
+	if suppressed != 1 {
+		t.Fatalf("suppressed = %d, want 1 (only the closing claim)", suppressed)
+	}
+	if len(result.Issues.Items) != 1 || result.Issues.Items[0].Number != 3498 {
+		t.Fatalf("reference-claimed issue must stay actionable for agents, got %+v", result.Issues.Items)
+	}
+}
+
+// TestClaimLedgerReferencePrecedence: a weak reference claim must never
+// displace a strong closing claim for the same issue, in either arrival order
+// or across a non-authoritative refresh — the #3768 precedence rule, extended.
+func TestClaimLedgerReferencePrecedence(t *testing.T) {
+	strong := IssueClaim{
+		Repo: "r", Issue: 1, PRNumber: 10, PRRepo: "r",
+		PRURL: "strong-pr", PRAuthor: "clubanderson", ObservedAt: time.Now(),
+	}
+	weak := IssueClaim{
+		Repo: "r", Issue: 1, PRNumber: 20, PRRepo: "r",
+		PRURL: "weak-pr", PRAuthor: "clubanderson", ObservedAt: time.Now(),
+		Reference: true,
+	}
+
+	t.Run("strong first", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{strong, weak}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.Reference || got.PRNumber != 10 {
+			t.Fatalf("closing claim must win, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("weak first", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{weak, strong}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.Reference || got.PRNumber != 10 {
+			t.Fatalf("closing claim must win regardless of order, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("partial refresh cannot demote a closing claim", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{strong}, true)
+		l.Reconcile([]IssueClaim{weak}, false)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.Reference || got.PRNumber != 10 {
+			t.Fatalf("partial fetch must not demote a closing claim, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("reference-only claim is still recorded for the contribute queue", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{weak}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || !got.Reference || got.PRNumber != 20 {
+			t.Fatalf("reference claim must be present, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("external precedence still holds within the closing tier", func(t *testing.T) {
+		ext := strong
+		ext.PRNumber = 30
+		ext.ExternalAuthor = true
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{ext, strong}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.ExternalAuthor || got.PRNumber != 10 {
+			t.Fatalf("#3768 hive precedence regressed, got %+v (ok=%v)", got, ok)
+		}
+	})
+}
+
+// TestClaimLedgerBackCompatPreThreeNineEightZero: a ledger written before
+// #3980 has no `reference` field. Every entry it holds was a closing-keyword
+// (or branch-derived) claim, so it must load as a STRONG claim and keep
+// suppressing agent work across the upgrade.
+func TestClaimLedgerBackCompatPreThreeNineEightZero(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pr-claims.json")
+	oldFormat := fmt.Sprintf(`{
+  "saved_at": %[1]q,
+  "claims": [
+    {
+      "repo": "kubestellar/hive",
+      "issue": 42,
+      "pr_number": 100,
+      "pr_repo": "kubestellar/hive",
+      "pr_url": "https://github.com/kubestellar/hive/pull/100",
+      "pr_author": "clubanderson",
+      "observed_at": %[1]q
+    }
+  ]
+}`, time.Now().Format(time.RFC3339))
+	if err := os.WriteFile(path, []byte(oldFormat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := LoadClaimLedger(path, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := l.Lookup("kubestellar/hive", 42)
+	if !ok {
+		t.Fatal("pre-#3980 claim did not load")
+	}
+	if got.Reference {
+		t.Error("pre-#3980 claim must load as a strong (non-reference) claim")
+	}
+
+	// Positive control: it must still suppress agent work.
+	result := &ActionableResult{}
+	result.Issues.Items = []Issue{{Repo: "kubestellar/hive", Number: 42}}
+	result.Issues.Count = 1
+	if suppressed := FilterClaimedIssues(result, l, nil, testLogger()); suppressed != 1 {
+		t.Fatalf("pre-#3980 claim stopped suppressing agent work: suppressed=%d", suppressed)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the claim-parsing half of #3980: the contribute queue kept handing a contributor issues that its **own open PR was already working**, once per cooldown window, indefinitely.

Each re-offer burned a complete task cycle — fresh CLI turn, full context, tokens — for the agent to re-derive "I already did this, there is nothing new to ship," then go idle without opening a PR, which immediately re-armed the short no-PR cooldown and scheduled the next pointless re-offer. Observed cycling across #2364, #3498 and #2547 in a single session.

This is the same class of symptom #3792 fixed for `Fixes`-keyword PRs (and #3768 before it), through a path that fix does not cover.

## Root cause

`ParseClaimedIssues` only records a claim from a **closing keyword**. Its comment is explicit that this is deliberate: *"Non-closing mentions ('see #12', 'related to #12') deliberately do NOT match."*

But "this PR only partially addresses the issue, so do **not** claim to close it" is exactly the convention a careful contributor follows. PR #3898 says so in its own body:

> Refs #3498 — no `Fixes` keyword, deliberately. The issue left the scaling curve open (...). Both are maintainer calls.

So the PR recorded no claim, `Dependencies.IssueClaimed` reported the issue unclaimed, and `selectTask` offered it again. **Doing the right thing is what made the work invisible.** The `issueFromBranchName` fallback did not rescue it either — neither motivating PR carries an issue number in its branch (`feat/governor-autoscale-thresholds`, `fix/v2-tests-notify-on-cancel`).

## What changed

A third, weakest claim tier, following the existing `ExternalAuthor` precedent of *grading* a claim rather than deciding for its consumers:

- **`IssueClaim.Reference`** marks a weak claim parsed from a non-closing reference.
- **`ParseReferencedIssues`** recognises `refs` / `references` / `addresses` / `part of` / `towards` / `contributes to`. It allows a bounded run of prose between keyword and reference, because these are written as prose rather than as a machine-readable trailer — the second motivating PR reads `Addresses a ci-maintainer finding from the #2364 advisory digest`, six words apart. The gap is bounded three ways so it cannot swallow a paragraph: ≤40 chars, lazy, and containing no `.`, newline or `#` (no crossing a sentence, no skipping past a nearer reference).
- `see` / `related to` / `relates to` are **excluded** — a topical cross-reference is not a statement that this PR does work on the issue, and treating it as one would let a passing mention withhold an issue from the queue.
- **`FetchClaims`** consults the new tier **last**, so no claim that exists today changes target or strength; it only fills in PRs that previously produced nothing at all.
- **`FilterClaimedIssues` ignores reference claims**, so agent work on a partially-addressed issue is never frozen behind a PR that never claimed to finish it. The contribute queue honours them — that is the loop being closed.
- **`insertLocked`** now resolves collisions through `claimRank`, preserving #3768's hive-over-external rule while adding closing-over-reference.

Pre-#3980 ledgers unmarshal as strong claims and keep their existing suppression, with a back-compat test pinning that.

## Test plan

New `v2/pkg/github/prclaims_reference_test.go` plus one end-to-end case in the existing #3768 suite:

- [x] Every supported reference idiom, case-insensitivity, colon separators, cross-repo `owner/repo#N`, de-duplication
- [x] **Both real PR bodies from the report** — if either regresses, the reported loop returns
- [x] Exclusions: `see` / `related to` / `relates to` / bare mention / bare `#N`
- [x] Gap bounds: cannot cross a sentence or newline; stops at a nearer reference; 40-char boundary tested on both sides
- [x] `ParseClaimedIssues` still ignores non-closing refs (pins the deliberate separation) with a positive control
- [x] Three-tier precedence in `FetchClaims`: closing wins, branch wins, reference only when both yield nothing
- [x] `FilterClaimedIssues` leaves reference-claimed issues actionable for agents while still suppressing closing claims
- [x] Ledger precedence in both arrival orders and across a non-authoritative refresh; #3768 external precedence still holds
- [x] Pre-#3980 ledger loads as a strong claim and still suppresses agent work
- [x] `selectTask` skips a reference-claimed issue and offers the next one (`TestClaimedIssue_ReferenceClaimSkipped`)

`go test ./pkg/github/ ./pkg/dashboard/` pass in full; `go build ./...`, `go vet` and `gofmt` clean on every touched file.

## Scope

`Refs #3980` — no `Fixes` keyword, deliberately, which is precisely the convention this PR teaches the ledger to read.

It closes the claim-parsing half only. The second half reported in #3980 — a completion carrying no PR URL is indistinguishable on the wire from *"the agent correctly determined there is nothing to ship"*, so a correct no-op verdict earns the **shortest** cooldown and the fastest re-offer — needs a protocol change on both relay and hub, plus a decision on how much authority a self-reported verdict should carry over a 168h lockout. That is a maintainer call, so it is left open rather than guessed at.

Worth noting the issue also suggests a per-(contributor, issue) repeat-dispatch cap as a backstop, which would bound the blast radius of any future parsing gap regardless of how the above lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
