### PR TITLE
🐛 fix(contribute): stop re-offering issues whose open PR uses a non-closing reference (Refs #N)

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -354,8 +354,21 @@ type ContributeWSHub struct {
 	// A permanent failure (msg.Permanent) counts as permanentFailureWeight toward
 	// the threshold. Guarded by completedMu.
 	consecutiveFailures map[string]int
-	completedMu         sync.Mutex
-	selectMu            sync.Mutex
+	// noPRStreaks counts CONSECUTIVE no-PR completions per "repo#number"
+	// (kubestellar/hive#3980). Each one doubles the next no-PR cooldown
+	// (advanceNoPRStreakLocked), so an issue that keeps "completing" with
+	// nothing to ship — e.g. the #2547 shape, where the shippable parts
+	// merged and the rest is maintainer-gated but the issue stays open —
+	// backs off geometrically instead of burning a full contributor task
+	// cycle every completedNoPRCooldownHours forever. Deliberately a
+	// SEPARATE map from completedTasks: the loop's signature is precisely
+	// that the completion entry EXPIRES (and is swept) before the next
+	// dispatch, so the streak must survive that sweep. Reset by a completion
+	// that ships a verified PR, or by noPRStreakResetAfter of quiet. Guarded
+	// by completedMu.
+	noPRStreaks map[string]noPRStreakRecord
+	completedMu sync.Mutex
+	selectMu    sync.Mutex
 	// assignmentTimes records, per contributor identity (identityOf), the wall-clock
 	// times of the task_assign messages that identity has been handed. It backs the
 	// #2436/#2566 per-tier rate gate: tier_limits.max_per_hour / max_per_day were
@@ -545,6 +558,17 @@ const completedTaskCooldownHours = 168
 // the same day.
 const completedNoPRCooldownHours = 4
 
+// noPRStreakResetAfter is how long a no-PR completion streak (#3980) survives
+// without another no-PR completion before it forgets itself and the next
+// no-PR cooldown starts back at completedNoPRCooldownHours. It must be LONGER
+// than the streak's own cooldown cap (the with-PR cooldown, default
+// completedTaskCooldownHours = 168h): the whole point is that the issue is
+// only re-dispatched AFTER its escalated cooldown expires, so a reset window
+// shorter than the cap would wipe the streak before the capped re-offer ever
+// happened and the backoff could never reach — or hold — its ceiling. Two
+// weeks = 2× the default cap, so one full capped cycle plus slack.
+const noPRStreakResetAfter = 14 * 24 * time.Hour
+
 // failedTaskCooldownMinutes is the SHORT cooldown applied to an issue when a
 // contributor reports task_failed (#2435). It is deliberately far shorter than
 // the completion cooldowns above: a failure is often purely environmental
@@ -612,6 +636,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		completedTaskPRURL:    make(map[string]string),
 		failedTasks:           make(map[string]time.Time),
 		consecutiveFailures:   make(map[string]int),
+		noPRStreaks:           make(map[string]noPRStreakRecord),
 		assignmentTimes:       make(map[string][]time.Time),
 		leases:                make(map[string]*taskLease),
 		yankExclusions:        make(map[string]time.Time),
@@ -621,6 +646,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	}
 	hub.loadCompletedTasks()
 	hub.loadFailedTasks()
+	hub.loadNoPRStreaks()
 	hub.loadActivity()
 	go hub.cleanupLoop()
 	return hub
@@ -719,6 +745,103 @@ type completedTaskRecord struct {
 }
 
 const failedTasksFile = "/data/contributors/failed-tasks.json"
+
+const noPRStreaksFile = "/data/contributors/no-pr-streaks.json"
+
+// noPRStreakRecord is the in-memory and on-disk shape of one no-PR completion
+// streak (#3980). LastAt is the most recent no-PR completion; the streak is
+// discarded once it is older than noPRStreakResetAfter — enforced lazily on
+// advance, on save, and on load, so a hub bounce cannot resurrect a stale
+// streak and the map cannot grow without bound.
+type noPRStreakRecord struct {
+	Count  int       `json:"count"`
+	LastAt time.Time `json:"last_at"`
+}
+
+func (h *ContributeWSHub) loadNoPRStreaks() {
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	data, err := os.ReadFile(noPRStreaksFile)
+	if err != nil {
+		return
+	}
+	records := make(map[string]noPRStreakRecord)
+	if json.Unmarshal(data, &records) != nil {
+		return
+	}
+	for k, rec := range records {
+		if rec.Count <= 0 || rec.LastAt.IsZero() {
+			continue
+		}
+		if time.Since(rec.LastAt) >= noPRStreakResetAfter {
+			continue
+		}
+		if h.noPRStreaks != nil {
+			h.noPRStreaks[k] = rec
+		}
+	}
+	h.logger.Info("[contribute-ws] loaded no-PR streaks", "count", len(h.noPRStreaks))
+}
+
+func (h *ContributeWSHub) saveNoPRStreaks() {
+	h.completedMu.Lock()
+	saved := make(map[string]noPRStreakRecord, len(h.noPRStreaks))
+	for k, rec := range h.noPRStreaks {
+		if time.Since(rec.LastAt) >= noPRStreakResetAfter {
+			continue
+		}
+		saved[k] = rec
+	}
+	h.completedMu.Unlock()
+	data, err := json.Marshal(saved)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] no-PR streaks marshal failed", "error", err)
+		return
+	}
+	os.MkdirAll("/data/contributors", 0o755)
+	tmpPath := noPRStreaksFile + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		h.logger.Warn("[contribute-ws] no-PR streaks write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, noPRStreaksFile); err != nil {
+		h.logger.Warn("[contribute-ws] no-PR streaks rename failed", "error", err)
+	}
+}
+
+// advanceNoPRStreakLocked books one more consecutive no-PR completion against
+// key and returns the escalated cooldown to apply (#3980): the base
+// completedNoPRCooldownHours doubled per prior streak entry, capped at the
+// operator's with-PR cooldown. 4h → 8h → 16h → … keeps the original "another
+// contributor can retry soon" behavior for a first idle completion, while an
+// issue that repeatedly yields "nothing to ship" — however a future parsing
+// gap lets that happen — converges to at most one wasted task cycle per
+// with-PR cooldown period instead of one every 4h forever. Callers must hold
+// completedMu.
+func (h *ContributeWSHub) advanceNoPRStreakLocked(key string, ceiling time.Duration) time.Duration {
+	if h.noPRStreaks == nil {
+		h.noPRStreaks = make(map[string]noPRStreakRecord)
+	}
+	rec := h.noPRStreaks[key]
+	if rec.Count > 0 && time.Since(rec.LastAt) >= noPRStreakResetAfter {
+		rec = noPRStreakRecord{}
+	}
+	rec.Count++
+	rec.LastAt = time.Now()
+	h.noPRStreaks[key] = rec
+
+	cooldown := completedNoPRCooldownHours * time.Hour
+	for i := 1; i < rec.Count; i++ {
+		if cooldown >= ceiling {
+			break
+		}
+		cooldown *= 2
+	}
+	if cooldown > ceiling {
+		cooldown = ceiling
+	}
+	return cooldown
+}
 
 // failedTaskRecord is the on-disk shape of one failed-task entry (#2435). It
 // preserves the last-failure time and the running consecutive-failure count so a
@@ -873,20 +996,35 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 // the full completedTaskCooldownHours (real work landed — don't re-dispatch for
 // a week), while a completion WITHOUT one — the agent merely returned to idle —
 // gets the short completedNoPRCooldownHours so an issue where nothing shipped
-// is not locked out for a week. The chosen expiry is stored per task and honored
+// is not locked out for a week. Since #3980 that short cooldown escalates on
+// CONSECUTIVE no-PR completions of the same issue (see advanceNoPRStreakLocked)
+// so a correct "nothing to ship" verdict cannot loop every 4h indefinitely.
+// The chosen expiry is stored per task and honored
 // by isTaskInCooldown; the prURL is retained for stats/audit and #2356
 // duplicate detection.
 func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL string) {
 	key := fmt.Sprintf("%s#%d", repo, number)
-	cooldown := completedNoPRCooldownHours * time.Hour
-	if prURL != "" {
-		// The WITH-PR period is operator-tunable (Config.Hub.ContributeCooldownHours,
-		// default completedTaskCooldownHours). We still RECORD this even when cooldown
-		// is disabled — isTaskInCooldown short-circuits the gating, so the history is
-		// kept for stats/audit but never excludes the issue.
-		cooldown = h.configuredWithPRCooldown()
-	}
+	// The WITH-PR period is operator-tunable (Config.Hub.ContributeCooldownHours,
+	// default completedTaskCooldownHours). We still RECORD this even when cooldown
+	// is disabled — isTaskInCooldown short-circuits the gating, so the history is
+	// kept for stats/audit but never excludes the issue. It also caps the no-PR
+	// escalation below. Read before taking completedMu: it walks server config,
+	// which the lock has no business covering.
+	withPRCooldown := h.configuredWithPRCooldown()
 	h.completedMu.Lock()
+	var cooldown time.Duration
+	if prURL != "" {
+		cooldown = withPRCooldown
+		// A shipped, verified PR ends any no-PR streak: the issue's next no-PR
+		// completion (if any) starts back at the short base cooldown.
+		delete(h.noPRStreaks, key)
+	} else {
+		// #3980: repeated no-PR completions escalate geometrically (4h → 8h →
+		// …, capped at the with-PR cooldown) so a "nothing to ship" loop —
+		// e.g. an issue whose remaining work is maintainer-gated (#2547) —
+		// cannot burn a full contributor task cycle every 4h forever.
+		cooldown = h.advanceNoPRStreakLocked(key, withPRCooldown)
+	}
 	h.completedTasks[key] = time.Now()
 	if h.completedTaskCooldown != nil {
 		h.completedTaskCooldown[key] = cooldown
@@ -913,6 +1051,7 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	}
 	h.completedMu.Unlock()
 	h.saveCompletedTasks()
+	h.saveNoPRStreaks()
 	if failureCleared {
 		h.saveFailedTasks()
 	}

--- a/v2/pkg/dashboard/contribute_ws_nopr_backoff_test.go
+++ b/v2/pkg/dashboard/contribute_ws_nopr_backoff_test.go
@@ -1,0 +1,135 @@
+package dashboard
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// #3980 backstop suite: a completion that ships nothing ("the agent correctly
+// determined there is nothing to ship") used to earn the FASTEST re-offer
+// (completedNoPRCooldownHours = 4h) every single time, so an issue whose
+// remaining work is maintainer-gated (#2547: the shippable parts merged, no
+// open PR left to claim it) was re-dispatched every 4h forever. The escalating
+// no-PR cooldown bounds that loop regardless of any future claim-parsing gap.
+
+// noPRKey mirrors markTaskCompleted's key derivation.
+func noPRKey(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+func recordedCooldown(t *testing.T, hub *ContributeWSHub, key string) time.Duration {
+	t.Helper()
+	hub.completedMu.Lock()
+	defer hub.completedMu.Unlock()
+	d, ok := hub.completedTaskCooldown[key]
+	if !ok {
+		t.Fatalf("no cooldown recorded for %s", key)
+	}
+	return d
+}
+
+// TestNoPRCooldownEscalatesGeometrically: consecutive no-PR completions of the
+// same issue double the cooldown from the 4h base up to the with-PR cap, so
+// the waste converges to at most one task cycle per cap period.
+func TestNoPRCooldownEscalatesGeometrically(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/escalation"
+	key := noPRKey(repo, 1)
+
+	base := completedNoPRCooldownHours * time.Hour
+	capD := hub.configuredWithPRCooldown()
+	want := base
+	for i := 0; i < 8; i++ {
+		hub.markTaskCompleted(repo, 1, "")
+		if got := recordedCooldown(t, hub, key); got != want {
+			t.Fatalf("completion %d: cooldown = %v, want %v", i+1, got, want)
+		}
+		want *= 2
+		if want > capD {
+			want = capD
+		}
+	}
+	// After 8 rounds (4h→…→168h cap on round 7) the cooldown must be pinned
+	// at the cap, not still doubling.
+	if got := recordedCooldown(t, hub, key); got != capD {
+		t.Fatalf("escalation must cap at the with-PR cooldown: got %v, want %v", got, capD)
+	}
+}
+
+// TestNoPRCooldownStreakSurvivesCooldownSweep pins the loop's exact shape: the
+// completion entry EXPIRES (and isTaskInCooldown sweeps it) before the next
+// dispatch, so the streak must live outside the swept maps or every re-offer
+// would restart the ladder at 4h and the loop would never slow down.
+func TestNoPRCooldownStreakSurvivesCooldownSweep(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/sweep"
+	key := noPRKey(repo, 2)
+
+	hub.markTaskCompleted(repo, 2, "")
+
+	// Age the completion past its 4h cooldown and let the sweep collect it,
+	// exactly as happens between re-offers on a live hub.
+	hub.completedMu.Lock()
+	hub.completedTasks[key] = time.Now().Add(-5 * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown(repo, 2) {
+		t.Fatal("aged completion should have left cooldown")
+	}
+	hub.completedMu.Lock()
+	_, stillPresent := hub.completedTasks[key]
+	hub.completedMu.Unlock()
+	if stillPresent {
+		t.Fatal("expected the sweep to remove the expired completion entry")
+	}
+
+	// The NEXT no-PR completion must continue the ladder (8h), not restart it.
+	hub.markTaskCompleted(repo, 2, "")
+	if got := recordedCooldown(t, hub, key); got != 8*time.Hour {
+		t.Fatalf("streak must survive the cooldown sweep: got %v, want 8h", got)
+	}
+}
+
+// TestNoPRCooldownResetByShippedPR: a completion that ships a (verified) PR
+// books the full with-PR cooldown and ends the streak, so a later no-PR
+// completion starts back at the 4h base — the original #2393 behavior for a
+// first idle completion is preserved.
+func TestNoPRCooldownResetByShippedPR(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/reset"
+	key := noPRKey(repo, 3)
+
+	hub.markTaskCompleted(repo, 3, "")
+	hub.markTaskCompleted(repo, 3, "")
+	if got := recordedCooldown(t, hub, key); got != 8*time.Hour {
+		t.Fatalf("setup: expected 8h after two no-PR completions, got %v", got)
+	}
+
+	hub.markTaskCompleted(repo, 3, "https://github.com/x/y/pull/9")
+	if got := recordedCooldown(t, hub, key); got != hub.configuredWithPRCooldown() {
+		t.Fatalf("with-PR completion must book the full cooldown, got %v", got)
+	}
+
+	hub.markTaskCompleted(repo, 3, "")
+	if got := recordedCooldown(t, hub, key); got != completedNoPRCooldownHours*time.Hour {
+		t.Fatalf("streak must reset after a shipped PR: got %v, want %v", got, completedNoPRCooldownHours*time.Hour)
+	}
+}
+
+// TestNoPRCooldownStreakForgetsAfterQuiet: a streak older than
+// noPRStreakResetAfter is discarded, so ancient history cannot slow down an
+// issue that has been out of circulation for weeks.
+func TestNoPRCooldownStreakForgetsAfterQuiet(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/quiet"
+	key := noPRKey(repo, 4)
+
+	hub.completedMu.Lock()
+	hub.noPRStreaks[key] = noPRStreakRecord{Count: 5, LastAt: time.Now().Add(-noPRStreakResetAfter - time.Hour)}
+	hub.completedMu.Unlock()
+
+	hub.markTaskCompleted(repo, 4, "")
+	if got := recordedCooldown(t, hub, key); got != completedNoPRCooldownHours*time.Hour {
+		t.Fatalf("stale streak must reset to the base cooldown: got %v", got)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws_softclaim_test.go
+++ b/v2/pkg/dashboard/contribute_ws_softclaim_test.go
@@ -1,0 +1,98 @@
+package dashboard
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// #3980 regression suite for the contribute queue: an issue whose only open
+// work is a PR referencing it WITHOUT a closing keyword (`Refs #N`) was
+// invisible to the claim ledger, so selectTask re-offered it to the same
+// contributor every 4h cooldown window forever, burning a full task cycle per
+// re-offer. selectTask consults the ledger through Dependencies.IssueClaimed;
+// with soft references recorded as claims (pkg/github FetchClaims), the same
+// hook now suppresses this shape too. These tests wire a REAL ClaimLedger in
+// as the hook, so the dashboard-side contract is pinned against the actual
+// ledger semantics rather than a hand-rolled stub.
+
+// softClaim is the #3980 incident signal: an open PR from the contributor's
+// own client referencing the issue with `Refs #N` — deliberately non-closing
+// because the issue is maintainer-gated.
+func softClaim(repo string, number int) ghpkg.IssueClaim {
+	return ghpkg.IssueClaim{
+		Repo: repo, Issue: number,
+		PRNumber: 3898, PRRepo: repo,
+		PRURL:           "https://github.com/projectbluefin/dakota/pull/3898",
+		PRAuthor:        "Danathar",
+		ObservedAt:      time.Now(),
+		FirstObservedAt: time.Now(),
+		ExternalAuthor:  true,
+		SoftReference:   true,
+	}
+}
+
+// TestSoftClaimIssue_ReplaysThreeNineEightZero replays the full loop: while
+// the Refs-PR is open its issue must be skipped (the next admissible issue is
+// offered, then no_matching_work), and the moment an authoritative rescan
+// releases the claim — the PR merged or closed — the issue is offerable again.
+func TestSoftClaimIssue_ReplaysThreeNineEightZero(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+
+	ledger := ghpkg.NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), s.logger)
+	ledger.Reconcile([]ghpkg.IssueClaim{softClaim("projectbluefin/dakota", 353)}, true)
+	s.deps.IssueClaimed = ledger.Lookup
+
+	// Round 1: #353 is soft-claimed by the open Refs-PR, so the contributor
+	// must be handed #360 instead of burning a cycle re-deriving "I already
+	// did this".
+	connA := claimedIssueConn()
+	hub.mu.Lock()
+	hub.connections["conn-a"] = connA
+	hub.mu.Unlock()
+	msg := hub.selectTask(connA)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", msg)
+	}
+	if msg.Number != 360 {
+		t.Fatalf("soft-claimed issue was offered anyway: got #%d, want #360", msg.Number)
+	}
+
+	// Round 2: with #360 active and #353 still claimed, a second contributor
+	// gets an explicit negative-ack — never the claimed issue.
+	connB := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct-b", ContributorID: "c-b", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-b"] = connB
+	hub.mu.Unlock()
+	if msg := hub.selectTask(connB); msg == nil || msg.Type != "task_unavailable" || msg.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("expected task_unavailable/no_matching_work while claim holds, got %+v", msg)
+	}
+
+	// Round 3: the Refs-PR closes; the authoritative rescan sees no open PRs
+	// and releases the claim, so #353 re-enters the offer pool.
+	ledger.Reconcile(nil, true)
+	if msg := hub.selectTask(connB); msg == nil || msg.Type != "task_assign" || msg.Number != 353 {
+		t.Fatalf("released issue must be offerable again, got %+v", msg)
+	}
+}
+
+// TestSoftClaimIssue_PositiveControl proves the suppression comes from the
+// claim and nothing else: an EMPTY ledger wired through the same hook leaves
+// selection exactly as before, offering the first eligible issue.
+func TestSoftClaimIssue_PositiveControl(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+	ledger := ghpkg.NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), s.logger)
+	s.deps.IssueClaimed = ledger.Lookup
+
+	msg := hub.selectTask(claimedIssueConn())
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 353 {
+		t.Fatalf("with no claims, first eligible issue #353 must be offered, got %+v", msg)
+	}
+}

--- a/v2/pkg/github/prclaims.go
+++ b/v2/pkg/github/prclaims.go
@@ -56,6 +56,25 @@ const (
 	// no secrets (issue and PR numbers only), so it is world-readable like the
 	// other operational state files under /data.
 	claimLedgerFileMode = 0o644
+
+	// weakClaimAgentDeferralWindow bounds how long a WEAK claim — one from an
+	// external (non-hive) author (#3768) or one parsed from a non-closing
+	// reference like `Refs #N` (#3980) — DEFERS the hive's own agent pipeline
+	// from taking the issue (see FilterClaimedIssues). Within the window the
+	// issue is suppressed exactly like a hive-authored `Fixes` claim, so an
+	// agent does not start duplicating work someone visibly has in flight
+	// (the dakota#353 shape, kubestellar/hive#3768). Once the claiming PR has
+	// been open past the window without merging, the issue is RELEASED even
+	// though the claim persists: this is what keeps a stranger's junk PR — or
+	// a stalled soft-reference PR — from freezing the hive's pipeline forever,
+	// the invariant #3792 protected with an unconditional external-claim
+	// bypass. 72h matches claimLedgerTTL: a claim that cannot be reconfirmed
+	// for that long dies anyway, so no weak claim ever outlives its deferral
+	// authority. Contribute-queue suppression (dashboard selectTask) is NOT
+	// window-bounded — it honours every open-PR claim for as long as the PR
+	// stays open, because handing a human contributor an issue that anyone's
+	// open PR already covers is pure waste (#3980).
+	weakClaimAgentDeferralWindow = 72 * time.Hour
 )
 
 // IssueClaim records that an open pull request authored by this hive already
@@ -89,6 +108,55 @@ type IssueClaim struct {
 	// recorded hive-authored claims — unmarshal as hive-authored (false),
 	// keeping their agent-side suppression intact across the upgrade.
 	ExternalAuthor bool `json:"external_author,omitempty"`
+	// SoftReference marks a claim parsed from a NON-closing reference keyword
+	// (`Refs #N`, `Part of #N`, … — see softRefPattern) rather than a GitHub
+	// closing keyword or the branch-name heuristic (kubestellar/hive#3980).
+	// A soft reference is exactly the convention a careful PR uses when it
+	// advances an issue without finishing it, so it must stop the contribute
+	// queue re-offering the issue (the #3980 token-burn loop) — but it is a
+	// weaker signal than `Fixes` and never HARD-gates the hive's own agent
+	// pipeline; FilterClaimedIssues only defers on it for a bounded window.
+	// omitempty-false back-compat mirrors ExternalAuthor: ledgers written
+	// before #3980 only ever held closing-keyword/branch claims, which
+	// correctly unmarshal as hard (false).
+	SoftReference bool `json:"soft_reference,omitempty"`
+	// FirstObservedAt is when this PR was FIRST seen making this claim, kept
+	// stable across re-observations of the same PR (insertLocked carries it
+	// forward), unlike ObservedAt which refreshes every scan. It anchors the
+	// weakClaimAgentDeferralWindow: "how long has this weak claim been
+	// deferring the agent pipeline" must age even while the claim keeps being
+	// re-confirmed. Zero on entries written before #3980; firstObserved()
+	// falls back to ObservedAt for those.
+	FirstObservedAt time.Time `json:"first_observed_at"`
+}
+
+// firstObserved returns when the claiming PR was first seen making this claim,
+// falling back to ObservedAt for ledger entries written before #3980 (whose
+// FirstObservedAt is zero). The fallback errs toward MORE deferral only by the
+// age the old entry had already accrued, never resets it.
+func (c IssueClaim) firstObserved() time.Time {
+	if c.FirstObservedAt.IsZero() {
+		return c.ObservedAt
+	}
+	return c.FirstObservedAt
+}
+
+// strength ranks a claim for ledger-slot precedence when several open PRs
+// claim the same issue. Higher wins. A hard (closing-keyword or branch-name)
+// claim outranks a soft reference, and within each, hive-authored outranks
+// external: the agent-side filter honours only hive-hard claims unbounded, so
+// letting any weaker claim overwrite one would blind FilterClaimedIssues and
+// re-open the duplicate-PR hole (#3768's precedence rule, generalized for
+// #3980). Every claim, whatever its rank, suppresses the contribute queue.
+func (c IssueClaim) strength() int {
+	s := 0
+	if !c.SoftReference {
+		s += 2
+	}
+	if !c.ExternalAuthor {
+		s++
+	}
+	return s
 }
 
 // Key identifies the issue a claim covers.
@@ -116,19 +184,55 @@ var closingKeywords = []string{
 //	\s*:?\s+                    optional colon, then whitespace
 //	(?:([\w.-]+/[\w.-]+))?#(\d+) optional owner/repo prefix, then #N
 //
-// Non-closing mentions ("see #12", "related to #12") deliberately do NOT match:
-// only a PR that claims to close an issue should suppress work on it.
+// Recognized non-closing mentions (`Refs #12`, `Part of #12`, …) match the
+// separate softRefPattern below (#3980); everything else ("see #12", a bare
+// changelog-style "#12") matches neither pattern and claims nothing.
 var claimRefPattern = regexp.MustCompile(
 	`(?i)\b(` + strings.Join(closingKeywords, "|") + `)\b\s*:?\s+(?:([\w.-]+/[\w.-]+))?#(\d+)`)
+
+// softReferenceKeywords are the recognized NON-closing reference forms — the
+// convention a careful PR uses to link an issue it advances without claiming
+// to close it (kubestellar/hive#3980, e.g. PR #3898's deliberate "Refs #3498").
+// Regex fragments, not literals, because two forms are multi-word. The list is
+// deliberately closed: a bare `#N` mention or free prose ("see #12") must
+// never lock an issue, so only these keyword forms register.
+var softReferenceKeywords = []string{
+	`refs?`,            // Refs #N / Ref #N
+	`part\s+of`,        // Part of #N
+	`relate[sd]?\s+to`, // Relates to #N / Related to #N
+	`addresses`,        // Addresses #N
+}
+
+// softRefPattern matches a soft-reference keyword followed by an issue
+// reference, with the same case-insensitivity, optional colon, and cross-repo
+// (`owner/repo#N`) forms claimRefPattern supports.
+var softRefPattern = regexp.MustCompile(
+	`(?i)\b(` + strings.Join(softReferenceKeywords, "|") + `)\b\s*:?\s+(?:([\w.-]+/[\w.-]+))?#(\d+)`)
 
 // ParseClaimedIssues extracts every issue this text claims to close. defaultRepo
 // supplies the repository for bare `#N` references. Results are de-duplicated
 // and returned in first-seen order. A nil/empty text yields no claims.
 func ParseClaimedIssues(text, defaultRepo string) []ClaimedRef {
+	return parseIssueRefs(claimRefPattern, text, defaultRepo)
+}
+
+// ParseSoftReferencedIssues extracts every issue this text references with a
+// recognized non-closing keyword (softReferenceKeywords). Same de-duplication
+// and cross-repo semantics as ParseClaimedIssues; the two sets may overlap
+// when a text says both `Fixes #N` and `refs #N` — FetchClaims resolves that
+// overlap in favour of the closing (hard) claim.
+func ParseSoftReferencedIssues(text, defaultRepo string) []ClaimedRef {
+	return parseIssueRefs(softRefPattern, text, defaultRepo)
+}
+
+// parseIssueRefs is the shared extractor behind both keyword families. The
+// pattern must expose the optional owner/repo prefix as group 2 and the issue
+// number as group 3, as claimRefPattern and softRefPattern both do.
+func parseIssueRefs(pattern *regexp.Regexp, text, defaultRepo string) []ClaimedRef {
 	if text == "" {
 		return nil
 	}
-	matches := claimRefPattern.FindAllStringSubmatch(text, -1)
+	matches := pattern.FindAllStringSubmatch(text, -1)
 	if len(matches) == 0 {
 		return nil
 	}
@@ -236,7 +340,9 @@ func (h HiveIdentity) IsZero() bool {
 }
 
 // FetchClaims lists open PRs across the client's configured repos and returns
-// the issue claims parsed from their titles and bodies. Claims from PRs the
+// the issue claims parsed from their titles and bodies — both closing-keyword
+// (hard) claims and non-closing soft references, the latter marked
+// SoftReference (#3980). Claims from PRs the
 // hive did not author are included and marked ExternalAuthor
 // (kubestellar/hive#3768): the contribute queue needs them to stop re-offering
 // an issue a human contributor's open PR already fixes, while
@@ -287,6 +393,12 @@ func (c *Client) FetchClaims(ctx context.Context, identity HiveIdentity) ([]Issu
 				external := !identity.Matches(author)
 				// Title and body are both scanned: `Fixes #N` conventionally
 				// lives in the body, but many agents put it in the title.
+				// Note: draft PRs are included — PullRequests.List(state=open)
+				// returns them and nothing here filters on GetDraft(). That is
+				// deliberate: a draft is still "someone is on it" for offer
+				// suppression, and it is independent of fetchPRs' draft
+				// handling for the actionable list (#3963/#3970), which this
+				// scan does not share.
 				text := pr.GetTitle() + "\n" + pr.GetBody()
 				refs := ParseClaimedIssues(text, repo)
 
@@ -295,24 +407,47 @@ func (c *Client) FetchClaims(ctx context.Context, identity HiveIdentity) ([]Issu
 				// Body parsing cannot see those, but agents conventionally
 				// branch as issue-423 / fix-issue-423 / 423-some-slug, so the
 				// head ref recovers the link. Only consulted when the body and
-				// title yielded nothing, so an explicit `Fixes #N` always wins.
+				// title yielded no CLOSING reference, so an explicit `Fixes #N`
+				// always wins — and a numeric branch still hard-claims exactly
+				// as it did before #3980 even when soft references are present.
 				if len(refs) == 0 {
 					if n, ok := issueFromBranchName(headRef(pr)); ok {
 						refs = []ClaimedRef{{Repo: repo, Issue: n}}
 					}
 				}
 
-				for _, ref := range refs {
+				appendClaim := func(ref ClaimedRef, soft bool) {
 					claims = append(claims, IssueClaim{
-						Repo:           ref.Repo,
-						Issue:          ref.Issue,
-						PRNumber:       pr.GetNumber(),
-						PRRepo:         repo,
-						PRURL:          pr.GetHTMLURL(),
-						PRAuthor:       author,
-						ObservedAt:     now,
-						ExternalAuthor: external,
+						Repo:            ref.Repo,
+						Issue:           ref.Issue,
+						PRNumber:        pr.GetNumber(),
+						PRRepo:          repo,
+						PRURL:           pr.GetHTMLURL(),
+						PRAuthor:        author,
+						ObservedAt:      now,
+						FirstObservedAt: now,
+						ExternalAuthor:  external,
+						SoftReference:   soft,
 					})
+				}
+
+				hardClaimed := make(map[string]bool, len(refs))
+				for _, ref := range refs {
+					hardClaimed[claimKey(ref.Repo, ref.Issue)] = true
+					appendClaim(ref, false)
+				}
+
+				// #3980: non-closing references (`Refs #N`, `Part of #N`, …)
+				// also claim — as SOFT claims. This is what makes PR #3898's
+				// deliberate "Refs #3498 — no Fixes keyword" visible to the
+				// contribute queue instead of the issue being re-offered every
+				// cooldown window. An issue this same PR already hard-claims
+				// is skipped: the closing claim is the stronger record.
+				for _, ref := range ParseSoftReferencedIssues(text, repo) {
+					if hardClaimed[claimKey(ref.Repo, ref.Issue)] {
+						continue
+					}
+					appendClaim(ref, true)
 				}
 			}
 			if resp == nil || resp.NextPage == 0 {
@@ -399,18 +534,38 @@ func LoadClaimLedger(path string, logger *slog.Logger) (*ClaimLedger, error) {
 	return l, nil
 }
 
-// insertLocked adds a claim to the map, resolving key collisions with
-// hive-precedence: when the same issue is claimed by both a hive-authored PR
-// and an external one (#3768), the hive-authored claim wins, so the agent-side
-// filter — which honours only hive claims — can never be blinded by an
-// external PR racing it to the map. Callers must hold l.mu (or own the ledger
-// exclusively, as LoadClaimLedger does before publishing it).
+// insertLocked adds a claim to the map, resolving key collisions by claim
+// strength: hard beats soft, and within each, hive-authored beats external
+// (#3768's hive-precedence rule, generalized for #3980's soft references).
+// A weaker claim can never overwrite a stronger one, so the agent-side filter
+// — which hard-suppresses only on hive-hard claims — can never be blinded by
+// a soft or external PR racing the stronger claim to the map. Equal-strength
+// claims replace (refreshing ObservedAt); when the SAME PR is re-observed,
+// its original FirstObservedAt is carried forward so the weak-claim deferral
+// window ages instead of resetting every scan. Callers must hold l.mu (or own
+// the ledger exclusively, as LoadClaimLedger does before publishing it).
 func (l *ClaimLedger) insertLocked(c IssueClaim) {
 	key := c.Key()
-	if existing, ok := l.claims[key]; ok && !existing.ExternalAuthor && c.ExternalAuthor {
-		return
+	if existing, ok := l.claims[key]; ok {
+		if c.strength() < existing.strength() {
+			return
+		}
+		c = carryFirstObserved(existing, c)
 	}
 	l.claims[key] = c
+}
+
+// carryFirstObserved preserves the earlier FirstObservedAt when the SAME PR is
+// re-observed making the same claim, so the weak-claim deferral window ages
+// across scans instead of resetting on every refresh (#3980). A DIFFERENT PR
+// keeps its own (fresh) FirstObservedAt: a new claiming PR earns a new window.
+func carryFirstObserved(existing, c IssueClaim) IssueClaim {
+	if existing.PRRepo == c.PRRepo && existing.PRNumber == c.PRNumber {
+		if first := existing.firstObserved(); c.FirstObservedAt.IsZero() || first.Before(c.FirstObservedAt) {
+			c.FirstObservedAt = first
+		}
+	}
+	return c
 }
 
 // SetTTL overrides the entry lifetime. Intended for tests.
@@ -492,10 +647,18 @@ func (l *ClaimLedger) Reconcile(live []IssueClaim, authoritative bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if authoritative {
+		// The whole map is rebuilt, but a claim's FirstObservedAt must survive
+		// the rebuild when the same PR is re-observed — otherwise every scan
+		// would restart the weak-claim deferral window and it could never
+		// expire (#3980).
+		prev := l.claims
 		l.claims = make(map[string]IssueClaim, len(live))
 		for _, c := range live {
 			if c.Issue <= 0 || c.Repo == "" {
 				continue
+			}
+			if existing, ok := prev[c.Key()]; ok {
+				c = carryFirstObserved(existing, c)
 			}
 			l.insertLocked(c)
 		}
@@ -555,8 +718,13 @@ func (l *ClaimLedger) Save() error {
 // GENERIC: the predicate keys only off check state + commit staleness.
 type RedStaleFunc func(prRepo string, prNumber int) bool
 
-// FilterClaimedIssues removes from result every issue an open hive-authored PR
-// already claims, logging each suppression with the claiming PR's URL.
+// FilterClaimedIssues removes from result every issue an open PR already
+// claims, logging each suppression with the claiming PR's URL. A hive-authored
+// closing claim suppresses unconditionally (the original #3792 guard); a WEAK
+// claim — external authorship or a soft `Refs`-style reference (#3980) —
+// suppresses only within weakClaimAgentDeferralWindow of its first
+// observation, then releases the issue so no stranger's or stalled PR can
+// freeze the pipeline indefinitely.
 //
 // redStale (may be nil) is Fix #3's release valve: when it reports the claiming
 // PR is red+stale, the issue is NOT suppressed — it is kept actionable so a
@@ -577,20 +745,13 @@ func FilterClaimedIssues(result *ActionableResult, ledger *ClaimLedger, redStale
 			kept = append(kept, issue)
 			continue
 		}
-		// #3768: an EXTERNAL claim (a PR the hive did not author) never
-		// suppresses agent work — that is the guard's original rule, kept
-		// intact so a stranger's junk PR cannot freeze the hive's own
-		// pipeline. External claims exist for the contribute queue, which
-		// consults the ledger directly (dashboard selectTask).
-		if claim.ExternalAuthor {
-			kept = append(kept, issue)
-			continue
-		}
 		// Fix #3: release (do NOT suppress) when the claiming PR is red on a
 		// required check AND stale. The claiming PR lives in claim.PRRepo /
 		// claim.PRNumber (which may differ from the issue's repo for cross-repo
 		// closes). A healthy PR — green, pending, or a recently-moved head —
 		// fails this predicate and is still suppressed, exactly as before.
+		// Checked before the weak-claim deferral: a dead PR should not defer
+		// anything either.
 		if redStale != nil && redStale(claim.PRRepo, claim.PRNumber) {
 			kept = append(kept, issue)
 			if logger != nil {
@@ -604,6 +765,35 @@ func FilterClaimedIssues(result *ActionableResult, ledger *ClaimLedger, redStale
 				)
 			}
 			continue
+		}
+		// WEAK claims — external authorship (#3768) or a non-closing soft
+		// reference (#3980) — DEFER agent work for a bounded window instead of
+		// the old all-or-nothing: #3768/#3792 let external claims through
+		// unconditionally so a stranger's junk PR could never freeze the
+		// pipeline, but that left the original dakota#353 duplicate shape
+		// alive across the agent/contributor seam (an agent could start an
+		// issue a contributor's open PR was already fixing). Within
+		// weakClaimAgentDeferralWindow of the claim's first observation the
+		// issue is suppressed like any other claim; past it, the issue is
+		// released even though the claim persists, so the junk-PR freeze is
+		// bounded rather than possible. Only a hive-authored closing claim
+		// (the hive's own live PR) suppresses without a window.
+		if claim.ExternalAuthor || claim.SoftReference {
+			if time.Since(claim.firstObserved()) >= weakClaimAgentDeferralWindow {
+				kept = append(kept, issue)
+				if logger != nil {
+					logger.Info("weak claim past deferral window: keeping issue actionable",
+						"repo", issue.Repo,
+						"issue", issue.Number,
+						"claimed_by_pr", claim.PRNumber,
+						"pr_repo", claim.PRRepo,
+						"pr_url", claim.PRURL,
+						"external_author", claim.ExternalAuthor,
+						"soft_reference", claim.SoftReference,
+					)
+				}
+				continue
+			}
 		}
 		suppressed++
 		if logger != nil {

--- a/v2/pkg/github/prclaims_soft_test.go
+++ b/v2/pkg/github/prclaims_soft_test.go
@@ -1,0 +1,438 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #3980 regression suite: a contributor's open PR that references its issue
+// with a NON-closing keyword (`Refs #N` — deliberately not `Fixes`, because
+// the issue is maintainer-gated) was invisible to the claim ledger, so the
+// contribute queue re-offered the issue to the same contributor every 4h
+// cooldown window, forever. These tests cover the soft-reference keyword
+// grammar, FetchClaims' soft-claim records, ledger strength precedence, and
+// the bounded agent-side deferral that replaces #3792's all-or-nothing
+// external-claim bypass.
+
+func TestParseSoftReferencedIssues(t *testing.T) {
+	const defaultRepo = "torch-spyre/spyre-inference"
+
+	tests := []struct {
+		name string
+		text string
+		want []ClaimedRef
+	}{
+		// Every recognized soft keyword form.
+		{"refs", "Refs #3498", []ClaimedRef{{defaultRepo, 3498}}},
+		{"ref", "Ref #10", []ClaimedRef{{defaultRepo, 10}}},
+		{"part of", "Part of #11", []ClaimedRef{{defaultRepo, 11}}},
+		{"relates to", "Relates to #12", []ClaimedRef{{defaultRepo, 12}}},
+		{"related to", "Related to #13", []ClaimedRef{{defaultRepo, 13}}},
+		{"addresses", "Addresses #14", []ClaimedRef{{defaultRepo, 14}}},
+
+		{
+			name: "case-insensitive mixed case",
+			text: "rEfS #423",
+			want: []ClaimedRef{{defaultRepo, 423}},
+		},
+		{
+			name: "colon separator",
+			text: "Refs: #424",
+			want: []ClaimedRef{{defaultRepo, 424}},
+		},
+		{
+			name: "cross-repo form",
+			text: "Part of kubestellar/hive#2149",
+			want: []ClaimedRef{{"kubestellar/hive", 2149}},
+		},
+		{
+			name: "multi-word keyword tolerates extra whitespace",
+			text: "Part  of #30",
+			want: []ClaimedRef{{defaultRepo, 30}},
+		},
+		{
+			name: "the PR #3898 body shape from the incident",
+			text: "## Summary\n\nRefs #3498 — no `Fixes` keyword, deliberately.\n\nSigned-off-by: agent",
+			want: []ClaimedRef{{defaultRepo, 3498}},
+		},
+		{
+			name: "de-duplicates repeated refs",
+			text: "Refs #20 and again refs #20",
+			want: []ClaimedRef{{defaultRepo, 20}},
+		},
+		{
+			// A mixed body: the SOFT parser reports only the soft reference;
+			// the closing keyword belongs to ParseClaimedIssues.
+			name: "Fixes and Refs mixed — soft parser sees only the soft ref",
+			text: "Fixes #100\n\nRefs #200",
+			want: []ClaimedRef{{defaultRepo, 200}},
+		},
+
+		// Negative cases — these must NOT register.
+		{
+			name: "bare changelog-style mention never locks an issue",
+			text: "* #99 fixed the flaky test\n* #98 docs",
+			want: nil,
+		},
+		{
+			name: "prose mention without a keyword",
+			text: "See #99 for context",
+			want: nil,
+		},
+		{
+			name: "keyword embedded in a larger word does not match",
+			text: "xrefs #97 and unrelated to #96",
+			want: nil,
+		},
+		{
+			name: "git ref path is not a reference keyword",
+			text: "update refs/heads#5 handling",
+			want: nil,
+		},
+		{
+			name: "closing keywords are not soft references",
+			text: "Fixes #95, Closes #94, Resolves #93",
+			want: nil,
+		},
+		{
+			name: "issue number zero is rejected",
+			text: "Refs #0",
+			want: nil,
+		},
+		{
+			name: "empty text",
+			text: "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseSoftReferencedIssues(tt.text, defaultRepo)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseSoftReferencedIssues(%q) = %+v, want %+v", tt.text, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ref[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// draftPR mirrors pr() with the draft flag set — a draft is still "someone is
+// on it" for offer suppression, and FetchClaims must keep seeing drafts after
+// #3970 changed how fetchPRs (a separate listing) handles them.
+func draftPR(number int, author, title, body string) map[string]any {
+	p := pr(number, author, title, body)
+	p["draft"] = true
+	return p
+}
+
+func TestFetchClaimsSoftReferences(t *testing.T) {
+	tests := []struct {
+		name       string
+		prs        []map[string]any
+		wantIssues []int
+		wantSoft   []bool
+		wantExt    []bool
+	}{
+		{
+			// The exact #3980 incident shape: PR #3898's body says
+			// "Refs #3498 — no Fixes keyword, deliberately".
+			name:       "external Refs PR claims its issue as a soft external claim",
+			prs:        []map[string]any{pr(3898, "Danathar", "tests: notify on cancel", "Refs #3498 — no `Fixes` keyword, deliberately.")},
+			wantIssues: []int{3498},
+			wantSoft:   []bool{true},
+			wantExt:    []bool{true},
+		},
+		{
+			name:       "Fixes and Refs in one PR yield one hard and one soft claim",
+			prs:        []map[string]any{pr(500, "clubanderson", "fix", "Fixes #100\n\nRefs #200")},
+			wantIssues: []int{100, 200},
+			wantSoft:   []bool{false, true},
+			wantExt:    []bool{false, false},
+		},
+		{
+			name:       "Fixes and refs to the SAME issue collapse to the hard claim",
+			prs:        []map[string]any{pr(501, "clubanderson", "fix", "Fixes #100 — refs #100 in the changelog")},
+			wantIssues: []int{100},
+			wantSoft:   []bool{false},
+			wantExt:    []bool{false},
+		},
+		{
+			// #3970 interaction pin: FetchClaims lists open PRs itself and
+			// must keep counting DRAFTS as claims — once, not twice — even
+			// though fetchPRs (the actionable-list path) filters/loosens
+			// drafts separately.
+			name:       "a draft PR still claims its issue exactly once",
+			prs:        []map[string]any{draftPR(502, "outside-dev", "wip", "Refs #300")},
+			wantIssues: []int{300},
+			wantSoft:   []bool{true},
+			wantExt:    []bool{true},
+		},
+		{
+			name:       "a draft PR with a closing keyword hard-claims",
+			prs:        []map[string]any{draftPR(503, "clubanderson", "wip", "Fixes #301")},
+			wantIssues: []int{301},
+			wantSoft:   []bool{false},
+			wantExt:    []bool{false},
+		},
+		{
+			// The branch-name heuristic behaves exactly as before #3980: it
+			// fires when no CLOSING reference exists, so a numeric branch
+			// still hard-claims alongside the body's soft reference.
+			name: "numeric branch hard-claims even when a soft ref is present",
+			prs: []map[string]any{func() map[string]any {
+				p := pr(504, "clubanderson", "wip", "Refs #400")
+				p["head"] = map[string]any{"ref": "fix-401"}
+				return p
+			}()},
+			wantIssues: []int{401, 400},
+			wantSoft:   []bool{false, true},
+			wantExt:    []bool{false, false},
+		},
+		{
+			name:       "cross-repo soft reference keys on the referenced repo",
+			prs:        []map[string]any{pr(505, "outside-dev", "t", "Part of kubestellar/hive#2149")},
+			wantIssues: []int{2149},
+			wantSoft:   []bool{true},
+			wantExt:    []bool{true},
+		},
+		{
+			// Positive control for the "not every #N locks an issue" rule.
+			name:       "bare mentions claim nothing",
+			prs:        []map[string]any{pr(506, "outside-dev", "t", "see #12, and #13 is related reading")},
+			wantIssues: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := prClaimServer(t, tt.prs, http.StatusOK)
+			c := NewClientForTest(srv.URL, "torch-spyre", []string{"spyre-inference"}, testLogger())
+			claims, err := c.FetchClaims(context.Background(), HiveIdentity{AIAuthor: "clubanderson"})
+			if err != nil {
+				t.Fatalf("FetchClaims: %v", err)
+			}
+			if len(claims) != len(tt.wantIssues) {
+				t.Fatalf("got %+v, want issues %v", claims, tt.wantIssues)
+			}
+			for i, want := range tt.wantIssues {
+				if claims[i].Issue != want {
+					t.Errorf("claim[%d].Issue = %d, want %d", i, claims[i].Issue, want)
+				}
+				if claims[i].SoftReference != tt.wantSoft[i] {
+					t.Errorf("claim[%d].SoftReference = %v, want %v", i, claims[i].SoftReference, tt.wantSoft[i])
+				}
+				if claims[i].ExternalAuthor != tt.wantExt[i] {
+					t.Errorf("claim[%d].ExternalAuthor = %v, want %v", i, claims[i].ExternalAuthor, tt.wantExt[i])
+				}
+				if claims[i].FirstObservedAt.IsZero() {
+					t.Errorf("claim[%d].FirstObservedAt must be stamped on fetch", i)
+				}
+			}
+		})
+	}
+}
+
+// TestFilterClaimedIssues_SoftClaimBoundedDeferral pins the #3980 claim-scope
+// split on the agent side: a soft claim — even a hive-authored one — DEFERS
+// agent work only within weakClaimAgentDeferralWindow, while a hive-authored
+// closing claim suppresses without any window (positive control). This is the
+// junk/stalled-PR guard invariant in its bounded form.
+func TestFilterClaimedIssues_SoftClaimBoundedDeferral(t *testing.T) {
+	mk := func(soft, external bool, firstObserved time.Time) IssueClaim {
+		return IssueClaim{
+			Repo: "spyre-inference", Issue: 100,
+			PRNumber: 900, PRRepo: "spyre-inference",
+			PRURL: "u", PRAuthor: "someone",
+			ObservedAt: time.Now(), FirstObservedAt: firstObserved,
+			SoftReference: soft, ExternalAuthor: external,
+		}
+	}
+	aged := time.Now().Add(-weakClaimAgentDeferralWindow - time.Hour)
+
+	tests := []struct {
+		name           string
+		claim          IssueClaim
+		wantSuppressed int
+	}{
+		{"fresh hive soft claim defers", mk(true, false, time.Now()), 1},
+		{"aged hive soft claim releases", mk(true, false, aged), 0},
+		{"fresh external soft claim defers", mk(true, true, time.Now()), 1},
+		{"aged external soft claim releases", mk(true, true, aged), 0},
+		// Positive control: the hive's own closing claim has NO deferral
+		// window — it suppresses for as long as the PR is open, exactly as
+		// before #3980.
+		{"aged hive hard claim still suppresses", mk(false, false, aged), 1},
+		// Back-compat: a pre-#3980 ledger entry has a zero FirstObservedAt;
+		// its ObservedAt must anchor the window instead, so an old external
+		// entry past the window releases rather than deferring forever.
+		{
+			"zero FirstObservedAt falls back to ObservedAt",
+			IssueClaim{
+				Repo: "spyre-inference", Issue: 100,
+				PRNumber: 900, PRRepo: "spyre-inference",
+				PRURL: "u", PRAuthor: "someone",
+				ObservedAt:     aged,
+				ExternalAuthor: true,
+			},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ledger := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+			ledger.SetTTL(365 * 24 * time.Hour) // keep aged claims alive past the default TTL
+			ledger.Reconcile([]IssueClaim{tt.claim}, true)
+			result := &ActionableResult{Issues: IssueResult{Count: 1, Items: []Issue{
+				{Repo: "spyre-inference", Number: 100},
+			}}}
+			if got := FilterClaimedIssues(result, ledger, nil, testLogger()); got != tt.wantSuppressed {
+				t.Fatalf("suppressed = %d, want %d", got, tt.wantSuppressed)
+			}
+		})
+	}
+}
+
+// TestClaimLedgerStrengthPrecedence generalizes #3768's hive-precedence rule:
+// a soft reference must never overwrite a hard claim for the same issue in
+// either arrival order, or the agent-side filter (which hard-suppresses only
+// on hive-hard claims) could be blinded by a weaker racing PR.
+func TestClaimLedgerStrengthPrecedence(t *testing.T) {
+	hard := IssueClaim{
+		Repo: "r", Issue: 1, PRNumber: 10, PRRepo: "r",
+		PRURL: "hard-pr", PRAuthor: "clubanderson", ObservedAt: time.Now(),
+	}
+	soft := IssueClaim{
+		Repo: "r", Issue: 1, PRNumber: 20, PRRepo: "r",
+		PRURL: "soft-pr", PRAuthor: "clubanderson", ObservedAt: time.Now(),
+		SoftReference: true,
+	}
+	softExt := IssueClaim{
+		Repo: "r", Issue: 1, PRNumber: 30, PRRepo: "r",
+		PRURL: "soft-ext-pr", PRAuthor: "outside-dev", ObservedAt: time.Now(),
+		SoftReference: true, ExternalAuthor: true,
+	}
+
+	t.Run("hard first, soft cannot demote", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{hard, soft}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.SoftReference || got.PRNumber != 10 {
+			t.Fatalf("hard claim must win, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("soft first, hard takes over", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{soft, hard}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.SoftReference || got.PRNumber != 10 {
+			t.Fatalf("hard claim must win regardless of order, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("hive soft outranks external soft", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{softExt, soft}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || got.ExternalAuthor || got.PRNumber != 20 {
+			t.Fatalf("hive soft claim must win, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("soft-only claim is still recorded for the contribute queue", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		l.Reconcile([]IssueClaim{softExt}, true)
+		got, ok := l.Lookup("r", 1)
+		if !ok || !got.SoftReference || got.PRNumber != 30 {
+			t.Fatalf("soft claim must be present, got %+v (ok=%v)", got, ok)
+		}
+	})
+	t.Run("re-observing the same PR keeps its FirstObservedAt", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		first := time.Now().Add(-48 * time.Hour)
+		earlier := soft
+		earlier.FirstObservedAt = first
+		l.Reconcile([]IssueClaim{earlier}, true)
+		refreshed := soft
+		refreshed.FirstObservedAt = time.Now()
+		l.Reconcile([]IssueClaim{refreshed}, true)
+		got, _ := l.Lookup("r", 1)
+		if !got.FirstObservedAt.Equal(first) {
+			t.Fatalf("FirstObservedAt must survive re-observation: got %v, want %v — a scan-refreshed window would never expire", got.FirstObservedAt, first)
+		}
+	})
+	t.Run("a different PR gets its own FirstObservedAt", func(t *testing.T) {
+		l := NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), testLogger())
+		old := softExt
+		old.FirstObservedAt = time.Now().Add(-100 * time.Hour)
+		l.Reconcile([]IssueClaim{old}, true)
+		fresh := soft // different PR number
+		freshAt := time.Now()
+		fresh.FirstObservedAt = freshAt
+		l.Reconcile([]IssueClaim{fresh}, true)
+		got, _ := l.Lookup("r", 1)
+		if !got.FirstObservedAt.Equal(freshAt) {
+			t.Fatalf("a NEW claiming PR must not inherit the old PR's window: got %v", got.FirstObservedAt)
+		}
+	})
+}
+
+// TestSoftReferenceClaimLifecycle replays #3980 end-to-end at the ledger
+// level, mirroring #3792's replay: an open `Refs #N` PR is fetched, claims its
+// issue (so the contribute queue's IssueClaimed hook — a ledger Lookup — will
+// suppress the offer), and once the PR closes an authoritative rescan releases
+// the issue back into the offer pool.
+func TestSoftReferenceClaimLifecycle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pr-claims.json")
+	identity := HiveIdentity{AIAuthor: "clubanderson"}
+
+	// Cycle 1: the contributor's Refs-PR is open.
+	openSrv := prClaimServer(t, []map[string]any{
+		pr(3898, "Danathar", "tests: notify on cancel", "Refs #3498 — no `Fixes` keyword, deliberately."),
+	}, http.StatusOK)
+	openClient := NewClientForTest(openSrv.URL, "torch-spyre", []string{"spyre-inference"}, testLogger())
+
+	ledger, err := LoadClaimLedger(path, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, err := openClient.FetchClaims(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger.Reconcile(live, true)
+
+	claim, ok := ledger.Lookup("spyre-inference", 3498)
+	if !ok {
+		t.Fatal("the Refs-PR must claim its issue — this absence IS bug #3980")
+	}
+	if !claim.SoftReference || !claim.ExternalAuthor {
+		t.Fatalf("claim must be soft+external, got %+v", claim)
+	}
+
+	// The agent pipeline is only DEFERRED by this weak claim, never frozen:
+	// fresh → suppressed; past the window → released.
+	fresh := &ActionableResult{Issues: IssueResult{Count: 1, Items: []Issue{{Repo: "spyre-inference", Number: 3498}}}}
+	if got := FilterClaimedIssues(fresh, ledger, nil, testLogger()); got != 1 {
+		t.Fatalf("fresh weak claim should defer agent work, suppressed = %d", got)
+	}
+
+	// Cycle 2: the PR merges/closes; the authoritative rescan sees no open
+	// PRs, so the claim is released and the issue is offerable again.
+	emptySrv := prClaimServer(t, []map[string]any{}, http.StatusOK)
+	emptyClient := NewClientForTest(emptySrv.URL, "torch-spyre", []string{"spyre-inference"}, testLogger())
+	live, err = emptyClient.FetchClaims(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger.Reconcile(live, true)
+	if _, ok := ledger.Lookup("spyre-inference", 3498); ok {
+		t.Fatal("a closed PR's soft claim must release its issue back to the offer pool")
+	}
+}

--- a/v2/pkg/github/prclaims_test.go
+++ b/v2/pkg/github/prclaims_test.go
@@ -277,19 +277,37 @@ func TestFilterClaimedIssues(t *testing.T) {
 			wantRemaining:  []int{100},
 		},
 		{
-			// #3768 invariant preserved: an EXTERNAL claim (a contributor's PR)
-			// never suppresses agent work — only the contribute queue honours
-			// it. The hive-claim cases above are the positive control proving
-			// suppression still works when the claim IS hive-authored.
-			name:  "external claim never suppresses agent work",
+			// #3768→#3980: a FRESH external claim now DEFERS agent work (a
+			// contributor's open PR is a real "someone is on it" signal), so
+			// it suppresses within weakClaimAgentDeferralWindow…
+			name:  "fresh external claim defers agent work",
 			items: []Issue{{Repo: "spyre-inference", Number: 100, AgeMinutes: 5}},
 			claims: []IssueClaim{{
 				Repo: "spyre-inference", Issue: 100,
 				PRNumber: 900, PRRepo: "spyre-inference",
-				PRURL:          "https://github.com/torch-spyre/spyre-inference/pull/900",
-				PRAuthor:       "outside-dev",
-				ObservedAt:     time.Now(),
-				ExternalAuthor: true,
+				PRURL:           "https://github.com/torch-spyre/spyre-inference/pull/900",
+				PRAuthor:        "outside-dev",
+				ObservedAt:      time.Now(),
+				FirstObservedAt: time.Now(),
+				ExternalAuthor:  true,
+			}},
+			wantSuppressed: 1,
+			wantRemaining:  nil,
+		},
+		{
+			// …while an AGED external claim releases: the #3768/#3792 junk-PR
+			// invariant survives in bounded form — a stranger's PR can delay
+			// the pipeline for at most the deferral window, never freeze it.
+			name:  "aged external claim releases agent work (bounded junk-PR guard)",
+			items: []Issue{{Repo: "spyre-inference", Number: 100, AgeMinutes: 5}},
+			claims: []IssueClaim{{
+				Repo: "spyre-inference", Issue: 100,
+				PRNumber: 900, PRRepo: "spyre-inference",
+				PRURL:           "https://github.com/torch-spyre/spyre-inference/pull/900",
+				PRAuthor:        "outside-dev",
+				ObservedAt:      time.Now(),
+				FirstObservedAt: time.Now().Add(-weakClaimAgentDeferralWindow - time.Hour),
+				ExternalAuthor:  true,
 			}},
 			wantSuppressed: 0,
 			wantRemaining:  []int{100},


### PR DESCRIPTION
Fixes #3980

## The loop

A contributor client was handed the same issues every 4h cooldown window even though its own **open PRs** already addressed them — whenever the PR deliberately used a non-closing reference (`Refs #N`) because the issue is maintainer-gated. `ParseClaimedIssues` only recognized GitHub's closing keywords, so the PR was invisible to the claim ledger, `Dependencies.IssueClaimed` returned false, `selectTask` re-offered, the agent correctly concluded "nothing new to ship", went idle without a PR, earned the *shortest* cooldown (4h), and the loop closed. Observed cycling: #2364↔PR #3979, #3498↔PR #3898, and #2547 (work merged via `Part of`; issue open on a maintainer ROUTE decision).

This is the third fix in the family: #3768 (contribute queue honours external `Fixes` claims) → #3792 (ledger + hive-precedence + red-stale valve) → this.

## What changed

### 1. Non-closing references now register as SOFT claims (`v2/pkg/github/prclaims.go`)

`FetchClaims` additionally parses `Refs #N` / `Ref #N` / `Part of #N` / `Relates to #N` / `Related to #N` / `Addresses #N` — case-insensitive, optional colon, same cross-repo `owner/repo#N` grammar as the closing keywords — and records them with a new `SoftReference` flag. A bare `#N` or prose mention ("see #12", a changelog line) still never claims: the keyword list is closed. When one PR says both `Fixes #N` and `refs #N`, the hard claim wins. The branch-name heuristic is unchanged (fires only when no *closing* ref exists, still yields a hard claim).

Ledger slot collisions resolve by **strength** (hard > soft; hive-authored > external within each) — a generalization of #3792's hive-precedence rule — so a weak claim can never overwrite the claim the agent-side filter depends on.

### 2. The claim-scope split (and the agent/contributor seam)

**Contribute queue: every claim suppresses, unbounded.** Hard or soft, hive or external — if any open PR references the issue with a recognized keyword, `selectTask`/`ReadyQueue` withhold it (via the existing `IssueClaimed` hook; no dashboard admission change needed). Handing a contributor an issue that anyone's open PR visibly covers is pure waste, and a soft reference is exactly the convention a *careful* contributor uses. Suppression lasts precisely as long as the PR is open: close/merge → next authoritative rescan releases the issue.

**Agent pipeline: weak claims DEFER (72h), only hive-hard claims block.** #3792 deliberately let external claims through unconditionally so a stranger's junk PR could never freeze the hive's own pipeline — but that left the original dakota#353 duplicate shape alive across the agent/contributor seam: a hive agent could start an issue a contributor's open PR was already fixing. This PR replaces the all-or-nothing bypass with a *bounded deferral*: an external claim (`Fixes` or soft) or any soft reference suppresses agent dispatch for `weakClaimAgentDeferralWindow` (72h, matching `claimLedgerTTL`) from the claim's **first observation** (`FirstObservedAt`, carried across scans and authoritative reconciles so the window ages instead of resetting), then releases even while the PR stays open. The junk-PR invariant survives in bounded form — a stranger's PR can *delay* the pipeline at most 72h, never freeze it — and the old red-stale valve still releases dead PRs early. The regression test that previously encoded the unconditional bypass now asserts both halves: fresh external claim defers, aged external claim releases, aged hive-hard claim still suppresses (positive control).

Known residual: an adversary *churning* new junk PRs could earn a fresh 72h window per PR (each new PR gets its own `FirstObservedAt`). That is an active-spam problem, strictly narrower than the single-junk-PR freeze the invariant guards, and rate-limited by PR creation itself.

### 3. Escalating no-PR cooldown (`v2/pkg/dashboard/contribute_ws.go`)

`task_complete` without a verified PR used to book a flat 4h cooldown forever. Now consecutive no-PR completions of the same issue double it — 4h → 8h → 16h → … capped at the with-PR cooldown (operator-tunable, 168h default). The streak lives **outside** the swept completion maps (the loop's signature is precisely that the completion entry expires and is swept before the next dispatch) and is persisted to `/data/contributors/no-pr-streaks.json`; a shipped verified PR or two weeks of quiet resets it. This is the backstop the issue asked for "regardless": whatever future parsing gap appears, per-issue waste converges to ~one task cycle per week instead of six per day. It bounds — but does not fully eliminate — the #2547 shape; the clean fix (a `no_work_needed` completion verdict) is filed as the follow-up below.

### 4. Drafts × #3970

`FetchClaims` does its own `PullRequests.List(state=open)` and is independent of the `fetchPRs` path #3970 (b3c92682) modified for stale-draft surfacing. Drafts were and remain visible to the claim scan — a draft is still "someone is on it" for offer-suppression — and are counted exactly once. Now pinned by tests (`a draft PR still claims its issue exactly once`, `a draft PR with a closing keyword hard-claims`) plus a comment in `FetchClaims` so a future draft filter can't silently blind the ledger.

## Compatibility

- Pre-#3980 ledgers load unchanged: missing `soft_reference` unmarshals as hard (those ledgers only ever held closing/branch claims), and zero `first_observed_at` falls back to `ObservedAt`, so an old external entry past the window releases rather than deferring forever.
- Legacy completed-tasks records are untouched; the streak file is new and optional.

## Tests

`v2/pkg/github` (all passing, full package run):
- `TestParseSoftReferencedIssues` — keyword-form table: all six forms, mixed case, colon, cross-repo, whitespace in multi-word keywords, the literal PR #3898 body, `Refs`+`Fixes` mixed, de-dup; negatives: bare/changelog `#N`, prose, `xrefs`/`unrelated to`, `refs/heads#5`, closing keywords, `#0`, empty.
- `TestFetchClaimsSoftReferences` — soft+external incident shape, hard+soft from one PR, same-issue overlap collapses to hard, draft claims once (soft and hard), branch heuristic unchanged beside soft refs, cross-repo soft key, bare-mention positive control.
- `TestFilterClaimedIssues_SoftClaimBoundedDeferral` — fresh/aged × soft/external deferral matrix, aged hive-hard still suppresses (positive control), zero-`FirstObservedAt` back-compat.
- `TestFilterClaimedIssues` (updated) — `fresh external claim defers agent work` / `aged external claim releases agent work (bounded junk-PR guard)`.
- `TestClaimLedgerStrengthPrecedence` — soft can never demote hard in either order, hive-soft > external-soft, soft-only recorded, `FirstObservedAt` survives re-observation but not a new PR.
- `TestSoftReferenceClaimLifecycle` — end-to-end replay mirroring #3792's: fetch open Refs-PR → claim present (contribute hook blocks) + agent deferral; PR closes → authoritative rescan releases.

`v2/pkg/dashboard`:
- `TestSoftClaimIssue_ReplaysThreeNineEightZero` — selectTask replay against a **real** `ClaimLedger`: soft-claimed #353 skipped → next issue offered → `no_matching_work` while claim holds → offerable again after release.
- `TestSoftClaimIssue_PositiveControl` — empty ledger leaves selection unchanged.
- `TestNoPRCooldownEscalatesGeometrically`, `TestNoPRCooldownStreakSurvivesCooldownSweep` (the exact loop shape: streak must outlive the swept completion entry), `TestNoPRCooldownResetByShippedPR`, `TestNoPRCooldownStreakForgetsAfterQuiet`.

## Follow-up (fourth family member)

The #2547 residual — an issue whose referenced PRs are all MERGED but which stays open on a maintainer decision — has no open-PR claim to suppress it and is only *bounded* by the cooldown escalation here. The clean fix is a completion **verdict**: let the relay report `no_work_needed` distinct from an idle no-PR completion and give it a long cooldown of its own. Filed separately with the precise mechanism (issue link in comments below).
