### PR TITLE
🐛 fix(bd): assert through a re-read store so the cmd/bd tests actually pass

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -34,8 +34,14 @@ jobs:
           go-version: '1.25'
           cache-dependency-path: v2/go.sum
 
+      # ./cmd/... is included deliberately. It used to be ./pkg/... only, so no
+      # workflow anywhere ran the cmd tests — v2-ci.yml builds and vets but does
+      # not test. Four cmd/bd tests were consequently merged already-failing and
+      # stayed red on the default branch, undetected, because nothing ever ran
+      # them. Fixing those tests without also running them just resets the same
+      # trap. All of ./cmd/... passes under -short -race.
       - name: Test
-        run: go test ./pkg/... -short -race -count=1
+        run: go test ./pkg/... ./cmd/... -short -race -count=1
 
   create-issue-on-failure:
     if: (failure() || cancelled()) && github.event_name == 'schedule'

--- a/v2/cmd/bd/main_test.go
+++ b/v2/cmd/bd/main_test.go
@@ -27,6 +27,29 @@ func captureStdout(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
+// reloadStore re-opens the beads store at dir, returning a handle that reflects
+// what is actually on disk right now.
+//
+// Every cmdX function opens its OWN store through openStore(), mutates it, and
+// persists. A *beads.Store handle created earlier in a test holds the in-memory
+// snapshot taken at NewStore time, and List/Ready read that map without ever
+// re-reading the file — so asserting through the original handle observes the
+// PRE-command state and reports a mutation that did happen as if it had not.
+// Four tests here did exactly that and failed from the day they were added;
+// nothing caught it because CI runs `go test ./pkg/...` and never ./cmd/....
+//
+// Re-opening is also the more faithful assertion: the real `bd` CLI is a
+// separate process per invocation, so reading persisted state is what an
+// operator actually observes.
+func reloadStore(t *testing.T, dir string) *beads.Store {
+	t.Helper()
+	s, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("reopening beads store at %s: %v", dir, err)
+	}
+	return s
+}
+
 // --- resolveDir ---
 
 func TestResolveDirBDDIROverride(t *testing.T) {
@@ -238,8 +261,8 @@ func TestCmdCloseAndReopenViaUpdate(t *testing.T) {
 		cmdClose([]string{b.ID})
 	})
 
-	// Verify closed via list.
-	items := store.List(beads.ListFilter{})
+	// Verify closed via list, re-read from disk (cmdClose used its own store).
+	items := reloadStore(t, dir).List(beads.ListFilter{})
 	found := false
 	for _, item := range items {
 		if item.ID == b.ID {
@@ -258,7 +281,7 @@ func TestCmdCloseAndReopenViaUpdate(t *testing.T) {
 		cmdUpdate([]string{b.ID, "--status", "open"})
 	})
 
-	items = store.List(beads.ListFilter{})
+	items = reloadStore(t, dir).List(beads.ListFilter{})
 	found = false
 	for _, item := range items {
 		if item.ID == b.ID {
@@ -291,7 +314,7 @@ func TestCmdUpdateMetadata(t *testing.T) {
 		cmdUpdate([]string{b.ID, "--set-metadata", "finding_type=coverage-gap"})
 	})
 
-	items := store.List(beads.ListFilter{})
+	items := reloadStore(t, dir).List(beads.ListFilter{})
 	found := false
 	for _, item := range items {
 		if item.ID == b.ID {
@@ -309,7 +332,7 @@ func TestCmdUpdateMetadata(t *testing.T) {
 		cmdUpdate([]string{b.ID, "--unset-metadata", "finding_type"})
 	})
 
-	items = store.List(beads.ListFilter{})
+	items = reloadStore(t, dir).List(beads.ListFilter{})
 	found = false
 	for _, item := range items {
 		if item.ID == b.ID {
@@ -342,7 +365,7 @@ func TestCmdUpdateClaim(t *testing.T) {
 		cmdUpdate([]string{b.ID, "--claim"})
 	})
 
-	items := store.List(beads.ListFilter{})
+	items := reloadStore(t, dir).List(beads.ListFilter{})
 	found := false
 	for _, item := range items {
 		if item.ID == b.ID {
@@ -376,7 +399,7 @@ func TestCmdReset(t *testing.T) {
 		cmdReset([]string{"--reason", "test reset"})
 	})
 
-	ready := store.Ready("")
+	ready := reloadStore(t, dir).Ready("")
 	if len(ready) != 0 {
 		t.Errorf("after reset, Ready() returned %d beads; want 0", len(ready))
 	}


### PR DESCRIPTION
## Summary

Four `cmd/bd` tests fail on the default branch and have **never passed** — `TestCmdCloseAndReopenViaUpdate`, `TestCmdUpdateMetadata`, `TestCmdUpdateClaim`, `TestCmdReset`.

I found these while running the full suite for an unrelated PR, and verified they are not mine: they reproduce identically on clean `v4`, and on `337855d4` (#3376) — the very commit that introduced them.

```
--- FAIL: TestCmdCloseAndReopenViaUpdate   after Close, status = "open"; want closed
--- FAIL: TestCmdUpdateMetadata            metadata finding_type = ""; want coverage-gap
--- FAIL: TestCmdUpdateClaim               after claim, status = "open"; want in_progress
--- FAIL: TestCmdReset                     after reset, Ready() returned 3 beads; want 0
```

## The product is fine — the tests assert through a stale handle

Each test creates a `*beads.Store`, mutates through a `cmdX` function, then asserts through **that original handle**:

```go
store, _ := beads.NewStore(dir)
b, _ := store.Create(...)
cmdClose([]string{b.ID})          // opens its OWN store via openStore(), mutates, persists
items := store.List(...)          // reads the in-memory map from NewStore time — stale
```

`Store.List`/`Ready` read the map captured at `NewStore` time and never re-read the file, so the assertion observes the **pre-command** state and reports a mutation that did happen as if it had not.

Confirmed the CLI itself round-trips correctly, so there is no product bug behind these:

```
bd create --title closable ... ; bd close <id>   =>  <id> closed
bd update <id> --status open                     =>  <id> open
```

## Fix

Assert through a freshly-opened store via a new `reloadStore` helper. That is also the more faithful assertion: the real `bd` CLI is a separate process per invocation, so persisted state is exactly what an operator observes.

**No production code is touched** — `cmd/bd/main.go` and `pkg/beads` are unchanged.

## Why CI never caught it

`v2-tests.yml` ran `go test ./pkg/...`, and `v2-ci.yml` builds and vets but does not test — so **nothing anywhere ran the `cmd` tests**. That is precisely how four already-failing tests merged and sat red undetected.

Fixing them without also running them just resets the same trap, so this PR adds `./cmd/...` to the test job. All of `./cmd/...` passes under `-short -race`:

```
ok  github.com/kubestellar/hive/v2/cmd/apiproxy  1.022s
ok  github.com/kubestellar/hive/v2/cmd/bd        1.030s
ok  github.com/kubestellar/hive/v2/cmd/hive     11.554s
```

That second hunk is separable — happy to drop it if you'd rather keep the CI surface as-is, though then these tests still go unrun.

## Test plan

- [x] `go test ./cmd/bd/` — all four pass
- [x] `go test ./cmd/... -short -race -count=1` — all green (the exact command CI will now run)
- [x] **Non-vacuity verified**: temporarily neutering `cmdClose` reproduces the original failure verbatim (`after Close, status = "open"; want closed`); restoring it passes. The assertions genuinely exercise the commands.
- [x] Failure reproduced at base `04906734` and at introducing commit `337855d4`, confirming pre-existing
- [x] CLI round-trip verified by hand against a real `BD_DIR`
- [x] `gofmt`, `go vet` clean; workflow YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
