### PR TITLE
🐛 fix(contribute): escalate the no-PR completion cooldown + pin draft-claim and ledger-lifecycle invariants

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -354,8 +354,21 @@ type ContributeWSHub struct {
 	// A permanent failure (msg.Permanent) counts as permanentFailureWeight toward
 	// the threshold. Guarded by completedMu.
 	consecutiveFailures map[string]int
-	completedMu         sync.Mutex
-	selectMu            sync.Mutex
+	// noPRStreaks counts CONSECUTIVE no-PR completions per "repo#number"
+	// (kubestellar/hive#3980). Each one doubles the next no-PR cooldown
+	// (advanceNoPRStreakLocked), so an issue that keeps "completing" with
+	// nothing to ship — e.g. the #2547 shape, where the shippable parts
+	// merged and the rest is maintainer-gated but the issue stays open —
+	// backs off geometrically instead of burning a full contributor task
+	// cycle every completedNoPRCooldownHours forever. Deliberately a
+	// SEPARATE map from completedTasks: the loop's signature is precisely
+	// that the completion entry EXPIRES (and is swept) before the next
+	// dispatch, so the streak must survive that sweep. Reset by a completion
+	// that ships a verified PR, or by noPRStreakResetAfter of quiet. Guarded
+	// by completedMu.
+	noPRStreaks map[string]noPRStreakRecord
+	completedMu sync.Mutex
+	selectMu    sync.Mutex
 	// assignmentTimes records, per contributor identity (identityOf), the wall-clock
 	// times of the task_assign messages that identity has been handed. It backs the
 	// #2436/#2566 per-tier rate gate: tier_limits.max_per_hour / max_per_day were
@@ -545,6 +558,17 @@ const completedTaskCooldownHours = 168
 // the same day.
 const completedNoPRCooldownHours = 4
 
+// noPRStreakResetAfter is how long a no-PR completion streak (#3980) survives
+// without another no-PR completion before it forgets itself and the next
+// no-PR cooldown starts back at completedNoPRCooldownHours. It must be LONGER
+// than the streak's own cooldown cap (the with-PR cooldown, default
+// completedTaskCooldownHours = 168h): the whole point is that the issue is
+// only re-dispatched AFTER its escalated cooldown expires, so a reset window
+// shorter than the cap would wipe the streak before the capped re-offer ever
+// happened and the backoff could never reach — or hold — its ceiling. Two
+// weeks = 2× the default cap, so one full capped cycle plus slack.
+const noPRStreakResetAfter = 14 * 24 * time.Hour
+
 // failedTaskCooldownMinutes is the SHORT cooldown applied to an issue when a
 // contributor reports task_failed (#2435). It is deliberately far shorter than
 // the completion cooldowns above: a failure is often purely environmental
@@ -612,6 +636,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		completedTaskPRURL:    make(map[string]string),
 		failedTasks:           make(map[string]time.Time),
 		consecutiveFailures:   make(map[string]int),
+		noPRStreaks:           make(map[string]noPRStreakRecord),
 		assignmentTimes:       make(map[string][]time.Time),
 		leases:                make(map[string]*taskLease),
 		yankExclusions:        make(map[string]time.Time),
@@ -621,6 +646,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	}
 	hub.loadCompletedTasks()
 	hub.loadFailedTasks()
+	hub.loadNoPRStreaks()
 	hub.loadActivity()
 	go hub.cleanupLoop()
 	return hub
@@ -719,6 +745,103 @@ type completedTaskRecord struct {
 }
 
 const failedTasksFile = "/data/contributors/failed-tasks.json"
+
+const noPRStreaksFile = "/data/contributors/no-pr-streaks.json"
+
+// noPRStreakRecord is the in-memory and on-disk shape of one no-PR completion
+// streak (#3980). LastAt is the most recent no-PR completion; the streak is
+// discarded once it is older than noPRStreakResetAfter — enforced lazily on
+// advance, on save, and on load, so a hub bounce cannot resurrect a stale
+// streak and the map cannot grow without bound.
+type noPRStreakRecord struct {
+	Count  int       `json:"count"`
+	LastAt time.Time `json:"last_at"`
+}
+
+func (h *ContributeWSHub) loadNoPRStreaks() {
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	data, err := os.ReadFile(noPRStreaksFile)
+	if err != nil {
+		return
+	}
+	records := make(map[string]noPRStreakRecord)
+	if json.Unmarshal(data, &records) != nil {
+		return
+	}
+	for k, rec := range records {
+		if rec.Count <= 0 || rec.LastAt.IsZero() {
+			continue
+		}
+		if time.Since(rec.LastAt) >= noPRStreakResetAfter {
+			continue
+		}
+		if h.noPRStreaks != nil {
+			h.noPRStreaks[k] = rec
+		}
+	}
+	h.logger.Info("[contribute-ws] loaded no-PR streaks", "count", len(h.noPRStreaks))
+}
+
+func (h *ContributeWSHub) saveNoPRStreaks() {
+	h.completedMu.Lock()
+	saved := make(map[string]noPRStreakRecord, len(h.noPRStreaks))
+	for k, rec := range h.noPRStreaks {
+		if time.Since(rec.LastAt) >= noPRStreakResetAfter {
+			continue
+		}
+		saved[k] = rec
+	}
+	h.completedMu.Unlock()
+	data, err := json.Marshal(saved)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] no-PR streaks marshal failed", "error", err)
+		return
+	}
+	os.MkdirAll("/data/contributors", 0o755)
+	tmpPath := noPRStreaksFile + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		h.logger.Warn("[contribute-ws] no-PR streaks write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, noPRStreaksFile); err != nil {
+		h.logger.Warn("[contribute-ws] no-PR streaks rename failed", "error", err)
+	}
+}
+
+// advanceNoPRStreakLocked books one more consecutive no-PR completion against
+// key and returns the escalated cooldown to apply (#3980): the base
+// completedNoPRCooldownHours doubled per prior streak entry, capped at the
+// operator's with-PR cooldown. 4h → 8h → 16h → … keeps the original "another
+// contributor can retry soon" behavior for a first idle completion, while an
+// issue that repeatedly yields "nothing to ship" — however a future parsing
+// gap lets that happen — converges to at most one wasted task cycle per
+// with-PR cooldown period instead of one every 4h forever. Callers must hold
+// completedMu.
+func (h *ContributeWSHub) advanceNoPRStreakLocked(key string, ceiling time.Duration) time.Duration {
+	if h.noPRStreaks == nil {
+		h.noPRStreaks = make(map[string]noPRStreakRecord)
+	}
+	rec := h.noPRStreaks[key]
+	if rec.Count > 0 && time.Since(rec.LastAt) >= noPRStreakResetAfter {
+		rec = noPRStreakRecord{}
+	}
+	rec.Count++
+	rec.LastAt = time.Now()
+	h.noPRStreaks[key] = rec
+
+	cooldown := completedNoPRCooldownHours * time.Hour
+	for i := 1; i < rec.Count; i++ {
+		if cooldown >= ceiling {
+			break
+		}
+		cooldown *= 2
+	}
+	if cooldown > ceiling {
+		cooldown = ceiling
+	}
+	return cooldown
+}
 
 // failedTaskRecord is the on-disk shape of one failed-task entry (#2435). It
 // preserves the last-failure time and the running consecutive-failure count so a
@@ -873,20 +996,35 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 // the full completedTaskCooldownHours (real work landed — don't re-dispatch for
 // a week), while a completion WITHOUT one — the agent merely returned to idle —
 // gets the short completedNoPRCooldownHours so an issue where nothing shipped
-// is not locked out for a week. The chosen expiry is stored per task and honored
+// is not locked out for a week. Since #3980 that short cooldown escalates on
+// CONSECUTIVE no-PR completions of the same issue (see advanceNoPRStreakLocked)
+// so a correct "nothing to ship" verdict cannot loop every 4h indefinitely.
+// The chosen expiry is stored per task and honored
 // by isTaskInCooldown; the prURL is retained for stats/audit and #2356
 // duplicate detection.
 func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL string) {
 	key := fmt.Sprintf("%s#%d", repo, number)
-	cooldown := completedNoPRCooldownHours * time.Hour
-	if prURL != "" {
-		// The WITH-PR period is operator-tunable (Config.Hub.ContributeCooldownHours,
-		// default completedTaskCooldownHours). We still RECORD this even when cooldown
-		// is disabled — isTaskInCooldown short-circuits the gating, so the history is
-		// kept for stats/audit but never excludes the issue.
-		cooldown = h.configuredWithPRCooldown()
-	}
+	// The WITH-PR period is operator-tunable (Config.Hub.ContributeCooldownHours,
+	// default completedTaskCooldownHours). We still RECORD this even when cooldown
+	// is disabled — isTaskInCooldown short-circuits the gating, so the history is
+	// kept for stats/audit but never excludes the issue. It also caps the no-PR
+	// escalation below. Read before taking completedMu: it walks server config,
+	// which the lock has no business covering.
+	withPRCooldown := h.configuredWithPRCooldown()
 	h.completedMu.Lock()
+	var cooldown time.Duration
+	if prURL != "" {
+		cooldown = withPRCooldown
+		// A shipped, verified PR ends any no-PR streak: the issue's next no-PR
+		// completion (if any) starts back at the short base cooldown.
+		delete(h.noPRStreaks, key)
+	} else {
+		// #3980: repeated no-PR completions escalate geometrically (4h → 8h →
+		// …, capped at the with-PR cooldown) so a "nothing to ship" loop —
+		// e.g. an issue whose remaining work is maintainer-gated (#2547) —
+		// cannot burn a full contributor task cycle every 4h forever.
+		cooldown = h.advanceNoPRStreakLocked(key, withPRCooldown)
+	}
 	h.completedTasks[key] = time.Now()
 	if h.completedTaskCooldown != nil {
 		h.completedTaskCooldown[key] = cooldown
@@ -913,6 +1051,7 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	}
 	h.completedMu.Unlock()
 	h.saveCompletedTasks()
+	h.saveNoPRStreaks()
 	if failureCleared {
 		h.saveFailedTasks()
 	}

--- a/v2/pkg/dashboard/contribute_ws_nopr_backoff_test.go
+++ b/v2/pkg/dashboard/contribute_ws_nopr_backoff_test.go
@@ -1,0 +1,135 @@
+package dashboard
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// #3980 backstop suite: a completion that ships nothing ("the agent correctly
+// determined there is nothing to ship") used to earn the FASTEST re-offer
+// (completedNoPRCooldownHours = 4h) every single time, so an issue whose
+// remaining work is maintainer-gated (#2547: the shippable parts merged, no
+// open PR left to claim it) was re-dispatched every 4h forever. The escalating
+// no-PR cooldown bounds that loop regardless of any future claim-parsing gap.
+
+// noPRKey mirrors markTaskCompleted's key derivation.
+func noPRKey(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+func recordedCooldown(t *testing.T, hub *ContributeWSHub, key string) time.Duration {
+	t.Helper()
+	hub.completedMu.Lock()
+	defer hub.completedMu.Unlock()
+	d, ok := hub.completedTaskCooldown[key]
+	if !ok {
+		t.Fatalf("no cooldown recorded for %s", key)
+	}
+	return d
+}
+
+// TestNoPRCooldownEscalatesGeometrically: consecutive no-PR completions of the
+// same issue double the cooldown from the 4h base up to the with-PR cap, so
+// the waste converges to at most one task cycle per cap period.
+func TestNoPRCooldownEscalatesGeometrically(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/escalation"
+	key := noPRKey(repo, 1)
+
+	base := completedNoPRCooldownHours * time.Hour
+	capD := hub.configuredWithPRCooldown()
+	want := base
+	for i := 0; i < 8; i++ {
+		hub.markTaskCompleted(repo, 1, "")
+		if got := recordedCooldown(t, hub, key); got != want {
+			t.Fatalf("completion %d: cooldown = %v, want %v", i+1, got, want)
+		}
+		want *= 2
+		if want > capD {
+			want = capD
+		}
+	}
+	// After 8 rounds (4h→…→168h cap on round 7) the cooldown must be pinned
+	// at the cap, not still doubling.
+	if got := recordedCooldown(t, hub, key); got != capD {
+		t.Fatalf("escalation must cap at the with-PR cooldown: got %v, want %v", got, capD)
+	}
+}
+
+// TestNoPRCooldownStreakSurvivesCooldownSweep pins the loop's exact shape: the
+// completion entry EXPIRES (and isTaskInCooldown sweeps it) before the next
+// dispatch, so the streak must live outside the swept maps or every re-offer
+// would restart the ladder at 4h and the loop would never slow down.
+func TestNoPRCooldownStreakSurvivesCooldownSweep(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/sweep"
+	key := noPRKey(repo, 2)
+
+	hub.markTaskCompleted(repo, 2, "")
+
+	// Age the completion past its 4h cooldown and let the sweep collect it,
+	// exactly as happens between re-offers on a live hub.
+	hub.completedMu.Lock()
+	hub.completedTasks[key] = time.Now().Add(-5 * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown(repo, 2) {
+		t.Fatal("aged completion should have left cooldown")
+	}
+	hub.completedMu.Lock()
+	_, stillPresent := hub.completedTasks[key]
+	hub.completedMu.Unlock()
+	if stillPresent {
+		t.Fatal("expected the sweep to remove the expired completion entry")
+	}
+
+	// The NEXT no-PR completion must continue the ladder (8h), not restart it.
+	hub.markTaskCompleted(repo, 2, "")
+	if got := recordedCooldown(t, hub, key); got != 8*time.Hour {
+		t.Fatalf("streak must survive the cooldown sweep: got %v, want 8h", got)
+	}
+}
+
+// TestNoPRCooldownResetByShippedPR: a completion that ships a (verified) PR
+// books the full with-PR cooldown and ends the streak, so a later no-PR
+// completion starts back at the 4h base — the original #2393 behavior for a
+// first idle completion is preserved.
+func TestNoPRCooldownResetByShippedPR(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/reset"
+	key := noPRKey(repo, 3)
+
+	hub.markTaskCompleted(repo, 3, "")
+	hub.markTaskCompleted(repo, 3, "")
+	if got := recordedCooldown(t, hub, key); got != 8*time.Hour {
+		t.Fatalf("setup: expected 8h after two no-PR completions, got %v", got)
+	}
+
+	hub.markTaskCompleted(repo, 3, "https://github.com/x/y/pull/9")
+	if got := recordedCooldown(t, hub, key); got != hub.configuredWithPRCooldown() {
+		t.Fatalf("with-PR completion must book the full cooldown, got %v", got)
+	}
+
+	hub.markTaskCompleted(repo, 3, "")
+	if got := recordedCooldown(t, hub, key); got != completedNoPRCooldownHours*time.Hour {
+		t.Fatalf("streak must reset after a shipped PR: got %v, want %v", got, completedNoPRCooldownHours*time.Hour)
+	}
+}
+
+// TestNoPRCooldownStreakForgetsAfterQuiet: a streak older than
+// noPRStreakResetAfter is discarded, so ancient history cannot slow down an
+// issue that has been out of circulation for weeks.
+func TestNoPRCooldownStreakForgetsAfterQuiet(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "nopr-backoff/quiet"
+	key := noPRKey(repo, 4)
+
+	hub.completedMu.Lock()
+	hub.noPRStreaks[key] = noPRStreakRecord{Count: 5, LastAt: time.Now().Add(-noPRStreakResetAfter - time.Hour)}
+	hub.completedMu.Unlock()
+
+	hub.markTaskCompleted(repo, 4, "")
+	if got := recordedCooldown(t, hub, key); got != completedNoPRCooldownHours*time.Hour {
+		t.Fatalf("stale streak must reset to the base cooldown: got %v", got)
+	}
+}

--- a/v2/pkg/dashboard/contribute_ws_reference_replay_test.go
+++ b/v2/pkg/dashboard/contribute_ws_reference_replay_test.go
@@ -1,0 +1,86 @@
+package dashboard
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// Lifecycle replay for #3980, wiring a REAL ClaimLedger in as the
+// Dependencies.IssueClaimed hook (the stub-based suppression test lives in
+// contribute_ws_claimed_issue_test.go). This pins the dashboard-side contract
+// against the actual ledger semantics across the claim's whole life: while the
+// referencing PR is open its issue is withheld from every contributor, and the
+// authoritative rescan after the PR closes releases the issue back into the
+// offer pool — the cooldown path alone must not be what ends the suppression.
+
+// openReferenceClaim mirrors the incident: PR #3898 saying "Refs #3498",
+// deliberately non-closing.
+func openReferenceClaim(repo string, number int) ghpkg.IssueClaim {
+	return ghpkg.IssueClaim{
+		Repo: repo, Issue: number,
+		PRNumber: 3898, PRRepo: repo,
+		PRURL:          "https://github.com/projectbluefin/dakota/pull/3898",
+		PRAuthor:       "Danathar",
+		ObservedAt:     time.Now(),
+		ExternalAuthor: true,
+		Reference:      true,
+	}
+}
+
+func TestReferenceClaim_LedgerLifecycleReplay(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+
+	ledger := ghpkg.NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), s.logger)
+	ledger.Reconcile([]ghpkg.IssueClaim{openReferenceClaim("projectbluefin/dakota", 353)}, true)
+	s.deps.IssueClaimed = ledger.Lookup
+
+	// Round 1: #353 is reference-claimed by the open Refs-PR, so the
+	// contributor is handed #360 instead of re-deriving "I already did this".
+	connA := claimedIssueConn()
+	hub.mu.Lock()
+	hub.connections["conn-a"] = connA
+	hub.mu.Unlock()
+	msg := hub.selectTask(connA)
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 360 {
+		t.Fatalf("reference-claimed #353 must be skipped for #360, got %+v", msg)
+	}
+
+	// Round 2: with #360 active and #353 still claimed, a second contributor
+	// gets an explicit negative-ack — never the claimed issue.
+	connB := &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct-b", ContributorID: "c-b", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+	hub.mu.Lock()
+	hub.connections["conn-b"] = connB
+	hub.mu.Unlock()
+	if msg := hub.selectTask(connB); msg == nil || msg.Type != "task_unavailable" || msg.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("expected task_unavailable/no_matching_work while the claim holds, got %+v", msg)
+	}
+
+	// Round 3: the Refs-PR closes; the authoritative rescan sees no open PRs,
+	// releases the claim, and #353 re-enters the offer pool.
+	ledger.Reconcile(nil, true)
+	if msg := hub.selectTask(connB); msg == nil || msg.Type != "task_assign" || msg.Number != 353 {
+		t.Fatalf("released issue must be offerable again, got %+v", msg)
+	}
+}
+
+// TestReferenceClaim_EmptyLedgerPositiveControl proves the suppression above
+// comes from the claim and nothing else: the same real-ledger wiring with an
+// EMPTY ledger leaves selection exactly as before.
+func TestReferenceClaim_EmptyLedgerPositiveControl(t *testing.T) {
+	hub, s := covK2Hub(t)
+	claimedIssueStatus(s)
+	ledger := ghpkg.NewClaimLedger(filepath.Join(t.TempDir(), "l.json"), s.logger)
+	s.deps.IssueClaimed = ledger.Lookup
+
+	msg := hub.selectTask(claimedIssueConn())
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 353 {
+		t.Fatalf("with no claims, first eligible issue #353 must be offered, got %+v", msg)
+	}
+}

--- a/v2/pkg/github/prclaims_draft_pin_test.go
+++ b/v2/pkg/github/prclaims_draft_pin_test.go
@@ -1,0 +1,69 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// #3970 interaction pin. FetchClaims lists open PRs itself
+// (PullRequests.List, state=open) and never filters on GetDraft(), so a draft
+// PR registers its claim exactly like a ready one — a draft is still "someone
+// is on it" for offer suppression. That is independent of fetchPRs, the
+// actionable-list path #3970 (b3c92682) changed to surface the App's own stale
+// drafts: the two listings do not share code, so neither drops nor
+// double-counts the other's items. These tests pin that a future draft filter
+// in either path cannot silently blind the claim ledger.
+
+// draftPR mirrors pr() with the draft flag set.
+func draftPR(number int, author, title, body string) map[string]any {
+	p := pr(number, author, title, body)
+	p["draft"] = true
+	return p
+}
+
+func TestFetchClaimsDraftPRsStillClaim(t *testing.T) {
+	tests := []struct {
+		name          string
+		prs           []map[string]any
+		wantIssue     int
+		wantReference bool
+	}{
+		{
+			// The #3980 shape as a draft: still one claim, still a weak
+			// reference — the contribute queue must not re-offer the issue
+			// just because the covering PR is a draft.
+			name:          "draft with a non-closing reference claims once, as a reference",
+			prs:           []map[string]any{draftPR(3898, "Danathar", "wip", "Refs #3498 — no `Fixes` keyword, deliberately.")},
+			wantIssue:     3498,
+			wantReference: true,
+		},
+		{
+			name:          "draft with a closing keyword hard-claims once",
+			prs:           []map[string]any{draftPR(500, "clubanderson", "wip", "Fixes #301")},
+			wantIssue:     301,
+			wantReference: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := prClaimServer(t, tt.prs, http.StatusOK)
+			c := NewClientForTest(srv.URL, "torch-spyre", []string{"spyre-inference"}, testLogger())
+			claims, err := c.FetchClaims(context.Background(), HiveIdentity{AIAuthor: "clubanderson"})
+			if err != nil {
+				t.Fatalf("FetchClaims: %v", err)
+			}
+			// Exactly one claim: drafts are neither dropped nor double-counted.
+			if len(claims) != 1 {
+				t.Fatalf("expected exactly one claim from a draft PR, got %+v", claims)
+			}
+			if claims[0].Issue != tt.wantIssue {
+				t.Errorf("Issue = %d, want %d", claims[0].Issue, tt.wantIssue)
+			}
+			if claims[0].Reference != tt.wantReference {
+				t.Errorf("Reference = %v, want %v", claims[0].Reference, tt.wantReference)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3980
Refs #3985

Additive follow-up to #3985 — the issue author's claim-parsing fix — carrying the pieces its scope section deliberately left open, plus two regression pins salvaged from the duplicate PR #3986 (closed in its favor).

## 1. Escalating no-PR completion cooldown

#3985 fixed the *suppression* half of #3980: an open `Refs #N` PR now claims its issue. This PR bounds the *cooldown* half. A `task_complete` without a verified PR used to book a flat 4h cooldown every time, so an issue that keeps yielding "nothing to ship" — the #2547 shape, where every referenced PR has **merged** and the remainder is maintainer-gated, leaving *no open-PR claim of any kind* to suppress it — was re-dispatched every 4h forever, burning a full contributor task cycle per round with no exit state.

Consecutive no-PR completions of the same issue now double the cooldown — 4h → 8h → 16h → … — capped at the operator's with-PR cooldown (168h default). This is the repeat-dispatch backstop the issue asked for "regardless": whatever future parsing gap appears, per-issue waste converges to ~one task cycle per week instead of six per day, while a *first* idle completion keeps today's 4h ("another contributor can retry soon") behavior exactly.

Design notes:

- **The streak lives outside the swept completion maps, deliberately.** The loop's signature is precisely that the completion entry *expires* (and `isTaskInCooldown` sweeps it) before the next dispatch — a streak stored beside the cooldown would be wiped before every re-offer and the backoff could never rise. `TestNoPRCooldownStreakSurvivesCooldownSweep` pins exactly this.
- Persisted to `/data/contributors/no-pr-streaks.json` (same atomic-rename pattern as the failed-task ledger) so a hub bounce cannot reset the ladder.
- Reset by a completion that ships a **verified** PR, or by two weeks of quiet (`noPRStreakResetAfter` = 2× the default cap, so one full capped re-offer cycle fits before the streak can forget itself — a shorter window would wipe the streak before the capped re-offer ever happened).
- Self-reported data changes nothing here: the verdict authority question (a lying client, a correct `no_work_needed`) is untouched and tracked as #3987; this only changes how fast the *same* unverified signal repeats.

## 2. Draft-claim pin (#3970 interaction)

`FetchClaims` lists open PRs itself (`PullRequests.List`, state=open) and never filters on `GetDraft()`, so a draft PR registers its claim — closing or `Reference` — exactly once. That is independent of `fetchPRs`, the actionable-list path #3970 changed to surface the App's own stale drafts; the two listings share no code. `TestFetchClaimsDraftPRsStillClaim` pins both directions (not dropped, not double-counted) so a future draft filter in either path cannot silently blind the claim ledger and quietly resurrect the #3980 loop for draft PRs.

## 3. Ledger-lifecycle replay

The existing #3980 dashboard test stubs `IssueClaimed`; `TestReferenceClaim_LedgerLifecycleReplay` wires a **real** `ClaimLedger` in as the hook and replays the whole loop against actual ledger semantics: reference-claimed issue skipped → next issue offered → `no_matching_work` while the claim holds → issue offerable again once the authoritative rescan releases the closed PR's claim. Plus an empty-ledger positive control proving the suppression comes from the claim and nothing else.

## Why this closes #3980

- Re-offer loop for open `Refs #N` PRs: fixed by #3985.
- "Nothing to ship" earning the fastest possible retry, unboundedly: bounded here (geometric backoff, capped).
- The remaining protocol-level improvement — a completion carrying a `no_work_needed` verdict with its own long cooldown — is scoped precisely in #3987 with mechanism and acceptance criteria, so the residual has a tracked home.

## Tests

- `TestNoPRCooldownEscalatesGeometrically`, `TestNoPRCooldownStreakSurvivesCooldownSweep`, `TestNoPRCooldownResetByShippedPR`, `TestNoPRCooldownStreakForgetsAfterQuiet` (dashboard)
- `TestFetchClaimsDraftPRsStillClaim` (github)
- `TestReferenceClaim_LedgerLifecycleReplay`, `TestReferenceClaim_EmptyLedgerPositiveControl` (dashboard)

Targeted `go vet` and `go test -run` green on both packages on top of the #3985 merge.
