### PR TITLE
🐛 fix(contribute): clone the branch the hub is built from, not a hardcoded v2

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -298,8 +298,15 @@ var (
 )
 
 // defaultUpstreamBranch is the fallback branch for the self-version check
-// when the build did not inject a branch (e.g. local `go run`).
-const defaultUpstreamBranch = "v2"
+// when the build did not inject a branch (e.g. local `go run`), and for the
+// clone command on the contribute onboarding page.
+//
+// v4, not v2: v2 is no longer maintained, so a build with no injected branch
+// was comparing itself against — and telling contributors to clone — a branch
+// that no longer receives the code this binary is built from. This is the same
+// stale-constant defect upgradeBranchOrDefault documents in pkg/hub, where a
+// hardcoded "v2" default resolved upgrade targets against a foreign branch.
+const defaultUpstreamBranch = "v4"
 
 func SetGitVersion(hash, short string) {
 	versionHash = hash

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -785,7 +785,16 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	projectNameJS := jsStringLiteral(projectName)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, `<!DOCTYPE html>
+	// {{HIVE_BRANCH}} is substituted into the TEMPLATE, before Fprintf renders
+	// it, so the onboarding clone command names the branch this hub is actually
+	// built from instead of a hardcoded one (kubestellar/hive#3990).
+	//
+	// It is a pre-pass rather than another %s because this format string carries
+	// eleven positional arguments across several thousand lines; inserting a
+	// verb mid-template would renumber every argument after it. Substituting on
+	// the template also means no rendered value — project name, Host header —
+	// can ever contain the sentinel and be rewritten by it.
+	fmt.Fprintf(w, strings.ReplaceAll(`<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Contribute to %s</title>
 <style>
 /* Michroma display face, base64-embedded (no network fonts). Used ONLY by the
@@ -1877,7 +1886,7 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 <pre id="copy-cmds" style="color:#e6edf3;font-size:.85rem;margin:0;overflow-x:auto;white-space:pre"># Default shown: macOS + Claude Code + containerized mode.
 # Use the OS / CLI / Mode / Runtime selectors above to customize.
 brew install just gh
-git clone -b v2 https://github.com/kubestellar/hive && cd hive
+git clone -b {{HIVE_BRANCH}} https://github.com/kubestellar/hive && cd hive
 export HIVE_HUB=%s
 # Optional: export HIVE_AGENT_ROLE=scanner (or a granted privileged role such as ci-maintainer) to claim a spoke-agent lane.
 just contribute-setup claude
@@ -1922,14 +1931,14 @@ linux:'curl --proto \'=https\' --tlsv1.2 -sSf https://just.systems/install.sh | 
 windows:'winget install --id Casey.Just --exact\nwinget install --id GitHub.cli'
 };
 var roleHelp='# Optional: export HIVE_AGENT_ROLE=scanner (or a granted privileged role such as ci-maintainer) to claim a spoke-agent lane.\n';
-var containerTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\nROLEHELPjust contribute-setup CLI\njust contribute-hive';
-var hostTpl='PREREQ\nINSTALL\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\nROLEHELPjust contribute-setup CLI\njust contribute-hive CLI local';
+var containerTpl='PREREQ\ngit clone -b {{HIVE_BRANCH}} https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\nROLEHELPjust contribute-setup CLI\njust contribute-hive';
+var hostTpl='PREREQ\nINSTALL\ngit clone -b {{HIVE_BRANCH}} https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\nROLEHELPjust contribute-setup CLI\njust contribute-hive CLI local';
 // Kubernetes (#2549): register locally, then generate + apply a headless
 // contributor workload (Deployment, #2660) into a cluster you already have.
 // just contribute-k8s prints the manifest; it never touches your cluster on
 // its own, so you can read it before piping to kubectl. Only the headless-
 // capable backends run this way (see K8S_HEADLESS_BACKENDS).
-var k8sTpl='PREREQ\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\nROLEHELPjust contribute-setup CLI\n# Review the manifest, then apply into your current kube-context:\njust contribute-k8s hive-contributor | kubectl apply -f -\nkubectl -n hive-contributor rollout status deploy/hive-contributor';
+var k8sTpl='PREREQ\ngit clone -b {{HIVE_BRANCH}} https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\nROLEHELPjust contribute-setup CLI\n# Review the manifest, then apply into your current kube-context:\njust contribute-k8s hive-contributor | kubectl apply -f -\nkubectl -n hive-contributor rollout status deploy/hive-contributor';
 // Backends with a verified headless (non-interactive) entry point — must match
 // HEADLESS_BACKENDS in bin/contributor-relay.sh and the Justfile. A pod has no
 // TTY, so only these run in a cluster; anything else refuses work at startup.
@@ -2086,7 +2095,7 @@ function defaultPromptFor(v){
     'The hive hub is: '+hubURL+'\n\n'+
     'Please walk me through, step by step, using the official setup:\n'+
     '  1. Install the prerequisites (just, gh) for my OS.\n'+
-    '  2. git clone -b v2 https://github.com/kubestellar/hive && cd hive\n'+
+    '  2. git clone -b {{HIVE_BRANCH}} https://github.com/kubestellar/hive && cd hive\n'+
     '  3. export HIVE_HUB='+hubURL+'\n'+
     '     For multiple hives, HIVE_HUB can be comma-separated when HIVE_REGISTRATION_TOKEN has matching tokens in the same order.\n'+
     '  4. just contribute-setup '+v+'\n'+
@@ -5924,7 +5933,7 @@ fetch('/api/version').then(function(r){return r.json()}).then(function(d){
   el.innerHTML=dot+' Hive v'+d.version+' ('+d.short+')' + (d.behind?' · <span style="color:#d29922">update available</span>':' · up to date');
 }).catch(function(){});
 </script>
-</body></html>`, projectName, michromaFontFaceCSS, customStyleHeadHTML, projectName, len(profiles), tierBoxes.String(), hubURL, hubURLJS, projectNameJS, tierTableRows, customStyleNoticeHTML)
+</body></html>`, "{{HIVE_BRANCH}}", upstreamBranch()), projectName, michromaFontFaceCSS, customStyleHeadHTML, projectName, len(profiles), tierBoxes.String(), hubURL, hubURLJS, projectNameJS, tierTableRows, customStyleNoticeHTML)
 }
 
 // ── Registration ───────────────────────────────────────────────────────────

--- a/v2/pkg/dashboard/api_contribute_clone_branch_test.go
+++ b/v2/pkg/dashboard/api_contribute_clone_branch_test.go
@@ -1,0 +1,110 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The onboarding page hardcoded `git clone -b v2`, so every contributor who
+// copy-pasted it cloned a branch the hub is not built from
+// (kubestellar/hive#3990). That is not a cosmetic drift: the v2 relay speaks
+// contributor protocol 1.1 while the hub speaks 1.2, so the copied command
+// produced a client the hub had to flag as a protocol-drifted peer.
+//
+// The clone branch must track the branch THIS hub was built from — not a
+// constant, and deliberately not "whatever branch is newest upstream": a
+// contributor's relay has to match the hub it is joining, which is the same
+// reasoning pkg/hub's upgradeBranchOrDefault records for upgrade targets.
+
+// withGitBranch sets the built-from branch for one test and restores it after,
+// so these cases cannot leak into the rest of the package.
+func withGitBranch(t *testing.T, branch string) {
+	t.Helper()
+	prev := versionBranch
+	SetGitBranch(branch)
+	t.Cleanup(func() { SetGitBranch(prev) })
+}
+
+func renderContributeLanding(t *testing.T) string {
+	t.Helper()
+	srv := newFullServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	rec := httptest.NewRecorder()
+	srv.handleContributeLanding(rec, req)
+	return rec.Body.String()
+}
+
+// TestContributeCloneBranchFollowsBuildBranch: a hub built from v4 must hand
+// out `-b v4`, and must never emit the old hardcoded v2 or a raw sentinel.
+func TestContributeCloneBranchFollowsBuildBranch(t *testing.T) {
+	withGitBranch(t, "v4")
+	html := renderContributeLanding(t)
+
+	if !strings.Contains(html, "git clone -b v4 https://github.com/kubestellar/hive") {
+		t.Error("onboarding page does not clone the branch the hub was built from (v4)")
+	}
+	if strings.Contains(html, "clone -b v2 ") {
+		t.Error("onboarding page still hands out the unmaintained v2 branch")
+	}
+	if strings.Contains(html, "{{HIVE_BRANCH}}") {
+		t.Error("unsubstituted {{HIVE_BRANCH}} sentinel leaked into the rendered page")
+	}
+}
+
+// TestContributeCloneBranchTracksADifferentBranch pins that the value is really
+// derived, not just re-hardcoded to v4: a hub built from another branch hands
+// out that branch instead.
+func TestContributeCloneBranchTracksADifferentBranch(t *testing.T) {
+	withGitBranch(t, "v5-experimental")
+	html := renderContributeLanding(t)
+
+	if !strings.Contains(html, "git clone -b v5-experimental https://github.com/kubestellar/hive") {
+		t.Error("clone branch did not follow the hub's own build branch")
+	}
+	if strings.Contains(html, "git clone -b v4 https://github.com/kubestellar/hive") {
+		t.Error("clone branch is still pinned to v4 rather than derived")
+	}
+}
+
+// TestContributeCloneBranchUnknownBuildFallsBack: a build with no injected
+// branch (local `go run`, where gitBranch stays "unknown") must fall back to the
+// maintained default rather than emitting "unknown" into a copy-paste command.
+func TestContributeCloneBranchUnknownBuildFallsBack(t *testing.T) {
+	for _, branch := range []string{"", "unknown"} {
+		t.Run("branch="+branch, func(t *testing.T) {
+			withGitBranch(t, branch)
+			html := renderContributeLanding(t)
+
+			if strings.Contains(html, "git clone -b unknown") || strings.Contains(html, "git clone -b  ") {
+				t.Fatal("a build with no injected branch emitted an unusable clone command")
+			}
+			if !strings.Contains(html, "git clone -b "+defaultUpstreamBranch+" https://github.com/kubestellar/hive") {
+				t.Errorf("fallback did not use defaultUpstreamBranch (%q)", defaultUpstreamBranch)
+			}
+		})
+	}
+}
+
+// TestDefaultUpstreamBranchIsMaintained guards the constant itself. v2 is no
+// longer maintained (see pkg/hub upgradeBranchOrDefault), so a fallback pointing
+// at it is the exact stale-constant defect this fix removes.
+func TestDefaultUpstreamBranchIsMaintained(t *testing.T) {
+	if defaultUpstreamBranch == "v2" {
+		t.Fatal("defaultUpstreamBranch is back to the unmaintained v2 branch")
+	}
+}
+
+// TestContributeCloneBranchAppliesToEveryCopyPasteSurface: the page carries the
+// clone line five times — the default <pre>, the container/host/k8s JS
+// templates, and the prefilled assistant prompt. A fix that reached only the
+// visible one would still mislead anyone who switched Mode or copied the prompt.
+func TestContributeCloneBranchAppliesToEveryCopyPasteSurface(t *testing.T) {
+	withGitBranch(t, "v4")
+	html := renderContributeLanding(t)
+
+	if got := strings.Count(html, "git clone -b v4 https://github.com/kubestellar/hive"); got != 5 {
+		t.Errorf("clone command appears with the right branch %d times; want 5 (pre block, container/host/k8s templates, prompt)", got)
+	}
+}

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -450,7 +450,7 @@
       <p>Run Hive v2 on your own machine with Docker Compose. Your agents, your repos, your infrastructure.</p>
     </div>
     <div class="alt-card">
-      <pre><code>git clone -b v2 https://github.com/kubestellar/hive.git
+      <pre><code>git clone -b v4 https://github.com/kubestellar/hive.git
 cd hive/v2
 
 cp hive.yaml.example hive.yaml


### PR DESCRIPTION
## Summary

The contribute onboarding page tells every contributor to run:

```
git clone -b v2 https://github.com/kubestellar/hive && cd hive
```

**`v2` is no longer maintained.** `v4` is the repository default branch and is **477 commits ahead**. Contributors have been hand-editing the command to `v4` to get a working client.

This is not cosmetic drift — the two branches ship different wire protocols:

| | relay protocol | hub protocol |
|---|---|---|
| `v2` | **1.1** | 1.2 |
| `v4` | **1.2** | 1.2 |

So the command as printed produces a client the hub has to flag as a protocol-drifted peer, via the very detection added in #3930.

## Fix

Derive the branch from `upstreamBranch()` — the branch this binary was **built from** (injected via `-X main.gitBranch` in the image build), which already backs the self-version check. The command now self-corrects as the fleet moves between branches instead of pinning a constant that silently rots.

That mirrors the reasoning already recorded in `pkg/hub`'s `upgradeBranchOrDefault`:

> The hub's OWN branch is the right fallback: it is what the hub is built from, so it is the only branch the hub can honestly assume [...] and it self-corrects as the fleet moves between branches instead of pinning a constant that silently rots.

### Why the hub's branch, and not "the latest" or "the released" one

- **Not "newest branch":** a contributor's relay has to speak the protocol of the hub it is joining. That is exactly what the 1.1-against-1.2 mismatch above demonstrates — if a `v5` were cut tomorrow, "latest" would reintroduce the same defect in the other direction.
- **Not "latest release":** there is nothing to pin to. The repo carries **no git tags and no GitHub releases**, and the `stable`/`candidate`/`edge` release channels are *container image* retags, not git refs — `git clone` cannot target them.

### Why a sentinel pre-pass rather than another `%s`

That format string carries **eleven positional arguments across several thousand lines**; inserting a verb mid-template would renumber every argument after it. Substituting `{{HIVE_BRANCH}}` on the *template* — before `Fprintf` renders it — also guarantees no rendered value (project name, `Host` header) can contain the sentinel and be rewritten by it.

## Also

- `defaultUpstreamBranch` `v2` → `v4`. It is the fallback when no branch was injected (local `go run`); pointing it at an unmaintained branch is the same stale-constant defect.
- The hub's `get-started.html` self-host snippet carried the identical hardcoded clone.

## Explicitly NOT touched

The operational branch defaults in `pkg/hub` (`server.go:1155`, `server.go:2021`, `saas_bulk.go:98`) also hardcode `"v2"`. Those decide what branch hosted spokes **track and upgrade onto** — deployment semantics and a maintainer call, not a docs fix. Flagging them rather than bundling them; happy to follow up if you want them changed.

## Test plan

New `api_contribute_clone_branch_test.go`, all passing:

- [x] Hub built from `v4` emits `-b v4`; never the old `v2`; no unsubstituted sentinel leaks
- [x] **Genuinely derived, not re-hardcoded** — a hub built from `v5-experimental` emits that branch and *not* `v4`
- [x] A build with no injected branch (`""`/`"unknown"`, i.e. local `go run`) falls back cleanly instead of emitting `git clone -b unknown`
- [x] `defaultUpstreamBranch` guard fails if it ever returns to `v2`
- [x] **All five copy-paste surfaces** counted — default `<pre>`, container/host/k8s mode templates, and the prefilled assistant prompt — so a fix reaching only the visible one cannot pass
- [x] `go test ./pkg/dashboard/ ./pkg/hub/` both green; `go build ./...`, `go vet`, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
