### PR TITLE
docs: correct v4 accuracy drift in v2/docs (retired image tag, phantom env var, ACMM gate level)

### DIFF
--- a/v2/docs/env-vars.md
+++ b/v2/docs/env-vars.md
@@ -30,7 +30,6 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `HIVE_METRICS_TOKEN` | Yes when metrics enabled | none | Bearer token for `/metrics` (`Authorization: Bearer <token>`; Prometheus `bearer_token`). `/metrics` bypasses dashboard session auth, so this token is its only guard; the cost/agent series are never served without it. |
 | `HIVE_METRICS_FILE` | No | `/var/run/hive-metrics/contribute.json` | Contributor metrics JSON file override. |
 | `HIVE_COPILOT_INTEGRATION_ID` | No | compiled Copilot integration id | Overrides the integration id used by Copilot model discovery. |
-| `HIVE_PROXY_PROOF_REQUIRED` | No | `false` | Requires the internal proxy proof header when set to `true`. |
 | `HIVE_CONTRIBUTORS_DIR` | No | hub default | Contributor registry directory override. |
 | `HIVE_FEDERATION_REGISTRY_PATH` | No | `/data/federation/registry.json` | Federation registry path override. |
 | `HIVE_WEBHOOK_SECRET` | No | none | HMAC secret for the spoke `/webhook` channel. |

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -171,7 +171,7 @@ CTX=vllm-d
 ID=hosted-myorg-myrepo          # the hive ID
 NS=hive-hosted-$ID              # namespace is always hive-hosted-<id>
 ROUTE_HOST=$ID.apps.fmaas-vllm-d.fmaas.res.ibm.com
-IMAGE=ghcr.io/kubestellar/hive:v2-latest
+IMAGE=ghcr.io/kubestellar/hive:v4-latest   # what the hub provisioner stamps by default (saas_provision.go); use `stable` for production
 SC=ocs-storagecluster-cephfs
 
 # The hub heartbeat secret — the SAME for every spoke on a given hub. Copy it

--- a/v2/docs/planning-intelligence.md
+++ b/v2/docs/planning-intelligence.md
@@ -117,7 +117,7 @@ the feature: *click ⧉ Plan on any issue, or add the `plan` label on GitHub.*
 
 ```yaml
 # Auto-plan issues carrying the `plan`/`epic` label. Omit to use the ACMM gate
-# (on at L4+); set explicitly to force on/off.
+# (on at L5+); set explicitly to force on/off.
 planning:
   plan_from_label: true
 


### PR DESCRIPTION
## What

A focused accuracy audit of `v2/docs/*.md` (plus `adr/` and `design/`) against the **current v4 code**, on the theory that docs written for v2 had drifted. Good news: most high-risk docs were already brought current by the recent v4 doc sweep (#3830) and follow-ups (#3849 route-reader, #3760/#3879 exit-code, security-model/net-admin). This PR contains only the **demonstrable factual errors** that survived, each a single wrong value contradicted by v4 source. No prose rewrites.

## Corrections (before → after + citation)

**1. `manual-provisioning.md` — retired image tag in the hosted-spoke example**
- before: `IMAGE=ghcr.io/kubestellar/hive:v2-latest`
- after: `IMAGE=ghcr.io/kubestellar/hive:v4-latest   # ...; use `stable` for production`
- why: the hub provisioner defaults hosted spokes to `v4-latest` (`v2/pkg/hub/saas_provision.go:1862`), and `operator-reference.md` already flags `v2-latest` as the retired v2 rolling tag ("Do not use it for new deployments"). The manual example told operators to hand-provision with exactly the retired tag.

**2. `env-vars.md` — fabricated env var row removed**
- before: `| \`HIVE_PROXY_PROOF_REQUIRED\` | No | \`false\` | Requires the internal proxy proof header when set to \`true\`. |`
- after: (row deleted)
- why: no such env var exists — zero `Getenv`/`LookupEnv` hits across `v2/pkg`, `v2/cmd`, `v2/deploy`. The proxy-proof toggle is a compile-time package var `proxyProofRequired` whose default is **`true` / fail-closed** (`v2/pkg/dashboard/server.go:61`), the inverse of the documented `false`, and it is not operator-tunable. The row was wrong on existence, default, and tunability.

**3. `planning-intelligence.md` — wrong ACMM gate level in a config comment**
- before: `# (on at L4+); set explicitly to force on/off.`
- after: `# (on at L5+); set explicitly to force on/off.`
- why: the `plan_from_label` ACMM gate is L5 (`const planFromLabelMinACMM = 5`, `v2/pkg/config/config.go:296`; enforced `config.go:310`). The doc's own body already says "still only fires at ACMM **L5+**" (line 46), so the inline comment contradicted both the code and the surrounding prose.

## Audit result (for the record)

Categorized ~70 docs. **The security / networking / provisioning / channels docs are all v4-ACCURATE** — the NET_ADMIN runtime-ambient-cap model, per-hive Ed25519 keys (`derivePerHiveKey`), master-key rotation, `hive-route-reader` RBAC, and `stable/candidate/edge` channels are all correctly described (verified against `entrypoint.sh`, `Dockerfile`, `v2/pkg/hub/`). ACMM docs correctly use the new capability names with the old numeric-era names as `formerly` parentheticals matching the pack YAML. No stale `git clone -b v2` / file-cap / crash-on-missing-cap claims remain in any doc.

## Follow-ups (NOT in this PR — need a larger human rewrite or live elsewhere)

- **`ioscan.md` is entirely inverted / stale.** It states "`ioscan` is not present in v2 HEAD… no `ioscan` package, no `ioscan:` config block… Operators should not enable ioscan." In v4 this is false: `v2/pkg/ioscan/` is fully implemented (canary.go, enforce.go, classifier.go, hook.go) and wired into the proxy (`v2/pkg/proxy/github_proxy.go` canary scan), and `v2/hive.yaml.example:17` ships the `ioscan:` block. This needs a full rewrite documenting the real package/schema/fail-modes/canary behavior — left for a human/follow-up rather than blind-rewritten here.
- **`deployment-scripts.md:9` ("clones the `v2` branch")** accurately describes the *script*, which really does `git clone --branch v2` (`v2/deploy/bootstrap-lxc.sh:55,57`) and uses `raw.githubusercontent.com/kubestellar/hive/v2/...` bootstrap URLs. The staleness is in the **LXC scripts**, not the doc — fixing the doc to say v4 would make it wrong about the script. Flagged so the scripts (not docs) can be updated to v4.
- **`cncf-reference-architecture.md:167`** cites an external arXiv ID (`2604.09388`) that is future-dated/placeholder — unverifiable from the codebase, worth a human glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
