### PR TITLE
🐛 fix(contribute): no_work_needed completion verdict parks maintainer-gated issues instead of re-offering them forever

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -607,8 +607,13 @@ function runHeadlessTask(task) {
       console.log(`Headless task ${task.task_id} completed (exit 0)`);
       const prURL = detectPRURL(outTail, task.repo);
       if (prURL) console.log(`Detected PR for ${task.task_id}: ${prURL}`);
+      // #3987: only report a no_work_needed verdict when no PR was shipped —
+      // a visible PR contradicts "nothing shippable" (the hub would override
+      // the claim with "shipped" anyway).
+      const noWork = prURL ? null : detectNoWorkVerdict(outTail);
+      if (noWork) console.log(`Detected no_work_needed verdict for ${task.task_id}: ${noWork.reason || '(no reason)'}`);
       writeHeadlessStatus(HEADLESS_STATE_DONE, { task_id: task.task_id, pr_url: prURL });
-      send({ type: 'task_complete', seq: nextSeq(), task_id: task.task_id, task_gen: task.task_gen, result: 'completed', summary: 'Headless one-shot invocation exited 0', tmux_output: outTail, pr_url: prURL });
+      send({ type: 'task_complete', seq: nextSeq(), task_id: task.task_id, task_gen: task.task_gen, result: 'completed', summary: 'Headless one-shot invocation exited 0', tmux_output: outTail, pr_url: prURL, verdict: noWork ? noWork.verdict : undefined, verdict_reason: noWork ? noWork.reason : undefined });
       currentTask = null;
       taskAssignedAt = 0;
       tasksCompletedCount++;
@@ -1027,6 +1032,40 @@ function detectPRURL(lines, repo) {
   return repoMatch || anyMatch;
 }
 
+// Best-effort scan of the agent's recent output for the no_work_needed
+// sentinel (kubestellar/hive#3987). The hub's task prompt instructs the agent:
+// when it affirmatively determines there is NOTHING shippable (the remainder
+// is gated on an unanswered maintainer decision, or merged PRs already cover
+// it), it prints a line of the exact form
+//   HIVE_VERDICT: no_work_needed — <short reason>
+// instead of opening a PR. Reported on task_complete as verdict/verdict_reason
+// so the hub can park the issue for the long offer-suppression window instead
+// of re-offering it every short-cooldown period forever (the #2547 shape that
+// escalation only bounded). Returns null when no marker is found — the hub
+// then treats the completion exactly as an idle one (today's semantics). The
+// marker spelling must stay in sync with buildTaskPrompt in
+// src/pkg/dashboard/contribute_ws.go.
+function detectNoWorkVerdict(lines) {
+  if (!Array.isArray(lines) || lines.length === 0) return null;
+  // Anchored at line start: the task PROMPT quotes the marker mid-sentence
+  // ("...the exact form 'HIVE_VERDICT: ...'"), and an anchored match keeps
+  // that instruction echo from reading as the agent's own verdict.
+  const VERDICT_RE = /^\s*HIVE_VERDICT:\s*no_work_needed\b[\s:—–-]*(.*)$/i;
+  // Scan newest-first so the agent's final conclusion wins over anything it
+  // merely quoted or considered earlier in the transcript.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const m = VERDICT_RE.exec(lines[i]);
+    if (!m) continue;
+    const reason = (m[1] || '').trim();
+    // tmux may wrap the prompt's instruction so its quoted marker lands at a
+    // visual line start; its giveaway is the literal "<short reason>"
+    // placeholder. Never treat that echo as a real verdict.
+    if (reason.startsWith('<')) continue;
+    return { verdict: 'no_work_needed', reason };
+  }
+  return null;
+}
+
 // True while a bob CLI process is alive. bob exits at the end of every turn,
 // so "process gone" means the turn finished — see the bob branch of
 // checkTmuxIdle(). Matches the launch command rather than the bare name so a
@@ -1385,7 +1424,12 @@ function progressTick() {
     // Empty when no PR link is found — the hub then applies the short cooldown.
     const prURL = detectPRURL(tmuxLines, currentTask.repo);
     if (prURL) console.log(`Detected PR for ${currentTask.task_id}: ${prURL}`);
-    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines, pr_url: prURL });
+    // #3987: only report a no_work_needed verdict when no PR was shipped — a
+    // visible PR contradicts "nothing shippable" (the hub would override the
+    // claim with "shipped" anyway).
+    const noWork = prURL ? null : detectNoWorkVerdict(tmuxLines);
+    if (noWork) console.log(`Detected no_work_needed verdict for ${currentTask.task_id}: ${noWork.reason || '(no reason)'}`);
+    send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, result: 'completed', summary: noWork ? 'Agent returned to idle (reported no_work_needed)' : 'Agent returned to idle', tmux_output: tmuxLines, pr_url: prURL, verdict: noWork ? noWork.verdict : undefined, verdict_reason: noWork ? noWork.reason : undefined });
     // bob exits after each turn, so the pane is now a bare shell. Bring it
     // back up before the next task, or the prompt would be typed into bash
     // ("-bash: <prompt>: command not found") and silently lost.

--- a/src/pkg/dashboard/contribute_protocol.go
+++ b/src/pkg/dashboard/contribute_protocol.go
@@ -72,6 +72,13 @@ const (
 	// from contributor relays and, when allowed by hive config/tier/grants, shapes
 	// assignments with the matching spoke agent's prompt.
 	capAgentRoleClaim = "agent_role_claim"
+	// capCompletionVerdict: the hub accepts an OPTIONAL verdict field on
+	// task_complete (#3987) — "no_work_needed" lets a relay report that the
+	// agent affirmatively determined nothing is shippable (maintainer-gated
+	// remainder / already covered by merged work), earning the issue a long
+	// offer-pool suppression instead of the short idle cooldown loop. Purely
+	// additive: a relay that never sends the field behaves exactly as before.
+	capCompletionVerdict = "completion_verdict"
 )
 
 // serverCapabilities returns the capability set this hub advertises on auth_ok.
@@ -85,6 +92,7 @@ func serverCapabilities() []string {
 		capCapabilityDeclare,
 		capCredentialAfterAccept,
 		capAgentRoleClaim,
+		capCompletionVerdict,
 	}
 }
 

--- a/src/pkg/dashboard/contribute_sse.go
+++ b/src/pkg/dashboard/contribute_sse.go
@@ -274,6 +274,14 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 			if h.isTaskInCooldown(repo.Full, number) {
 				continue
 			}
+			// #3987: a live no_work_needed verdict withholds the issue from the
+			// offer pool, and ReadyQueue is the read-only projection of exactly
+			// that pool — the two surfaces must agree (same contract the claim
+			// ledger admission pins). The hive AGENT pipeline does not read
+			// this ledger anywhere.
+			if h.isSuppressedByNoWorkVerdict(repo.Full, number, issueUpdatedAtFromMap(issue)) {
+				continue
+			}
 			if h.isTaskInFailureCooldown(repo.Full, number) {
 				continue
 			}

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -269,6 +270,30 @@ type WSMessage struct {
 	// #2356 duplicate-detection work. Field naming follows the PRURL
 	// convention in src/pkg/github/prclaims.go.
 	PRURL string `json:"pr_url,omitempty"`
+	// Verdict is the OPTIONAL, client-declared outcome of a task_complete
+	// (kubestellar/hive#3987): "shipped" (a PR was opened), "idle" (returned to
+	// idle without an affirmative conclusion — today's semantics and what an
+	// absent field normalizes to, so relays written before this keep working
+	// unchanged), or "no_work_needed" (the agent affirmatively determined
+	// nothing is shippable — e.g. the issue's remainder is gated on an
+	// unanswered maintainer decision, or merged PRs already cover it: the
+	// #2547 shape that #3980's escalation only BOUNDS).
+	//
+	// Self-reported and therefore weak evidence, like FailureKind above: the
+	// hub honours it ONLY to lengthen how long the issue is withheld from the
+	// contribute OFFER pool (see markTaskCompletedVerdict /
+	// isSuppressedByNoWorkVerdict). It never grants trust credit or promotion,
+	// never closes or labels anything on GitHub, and never touches the hive
+	// agent pipeline's selection. A verified PR overrides any claimed value
+	// (normalizeCompletionVerdict).
+	Verdict string `json:"verdict,omitempty"`
+	// VerdictReason optionally carries a machine-readable reason for a
+	// no_work_needed verdict ("maintainer_gated", "already_covered", or free
+	// text the relay scraped from the agent's output). Audit-only: it is
+	// stored with the verdict and logged so an operator can see WHY an issue
+	// keeps yielding no work — precisely the signal needed to go answer the
+	// gating question. Truncated server-side to noWorkReasonMaxLen.
+	VerdictReason string `json:"verdict_reason,omitempty"`
 	// Permanent marks a task_failed the relay will not retry: it exhausted its
 	// per-task CLI-restart budget and gave up (see MAX_TASK_CLI_RESTARTS in
 	// bin/contributor-relay.sh). Reassigning the same work item to the same
@@ -367,8 +392,30 @@ type ContributeWSHub struct {
 	// that ships a verified PR, or by noPRStreakResetAfter of quiet. Guarded
 	// by completedMu.
 	noPRStreaks map[string]noPRStreakRecord
-	completedMu sync.Mutex
-	selectMu    sync.Mutex
+	// noWorkVerdicts records, per "repo#number", the most recent
+	// contributor-reported no_work_needed completion verdict (#3987): the agent
+	// affirmatively determined the issue has nothing shippable (the #2547
+	// shape — shippable parts merged, remainder maintainer-gated, no open PR
+	// left to claim it, so no claim of any kind survives the next rescan).
+	// While a verdict is live the issue is withheld from the contribute OFFER
+	// pool (selectTask + ReadyQueue) for the long with-PR-cooldown window
+	// instead of cycling on the short no-PR ladder forever.
+	//
+	// Invalidation beats suppression: the verdict is VOID the moment the issue
+	// shows activity newer than the verdict (issue updated_at > RecordedAt),
+	// so a genuinely reopened issue — the maintainer answered, new commits or
+	// comments landed — is offered again immediately. When the issue's
+	// updated_at is unknown, the check fails OPEN (no suppression). The
+	// verdict is contributor-reported (weak evidence): it only ever suppresses
+	// offers — it never closes issues, never feeds trust/promotion, and never
+	// gates the hive agent pipeline. SEPARATE map from completedTasks for the
+	// same reason noPRStreaks is: the loop's signature is the completion entry
+	// EXPIRING before the next dispatch, so this must survive that sweep.
+	// Guarded by completedMu; persisted in the same PVC-backed ledger dir as
+	// the cooldowns so a pod restart does not forget the verdict.
+	noWorkVerdicts map[string]noWorkVerdictRecord
+	completedMu    sync.Mutex
+	selectMu       sync.Mutex
 	// assignmentTimes records, per contributor identity (identityOf), the wall-clock
 	// times of the task_assign messages that identity has been handed. It backs the
 	// #2436/#2566 per-tier rate gate: tier_limits.max_per_hour / max_per_day were
@@ -569,6 +616,24 @@ const completedNoPRCooldownHours = 4
 // weeks = 2× the default cap, so one full capped cycle plus slack.
 const noPRStreakResetAfter = 14 * 24 * time.Hour
 
+// completionVerdict* are the recognized values of WSMessage.Verdict on
+// task_complete (#3987). Anything else — including an absent field, which is
+// what every relay written before this sends — normalizes to idle, i.e.
+// byte-for-byte today's behavior (see normalizeCompletionVerdict).
+const (
+	completionVerdictShipped      = "shipped"
+	completionVerdictIdle         = "idle"
+	completionVerdictNoWorkNeeded = "no_work_needed"
+)
+
+// noWorkReasonMaxLen caps the client-supplied VerdictReason before it is stored
+// in the PVC-backed verdict ledger and echoed into logs: the field is scraped
+// from arbitrary agent output, so an unbounded value would let a confused (or
+// hostile) relay bloat the ledger file. 200 runes comfortably fits the
+// machine-readable reasons ("maintainer_gated", "already_covered") plus a short
+// free-text explanation.
+const noWorkReasonMaxLen = 200
+
 // failedTaskCooldownMinutes is the SHORT cooldown applied to an issue when a
 // contributor reports task_failed (#2435). It is deliberately far shorter than
 // the completion cooldowns above: a failure is often purely environmental
@@ -637,6 +702,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		failedTasks:           make(map[string]time.Time),
 		consecutiveFailures:   make(map[string]int),
 		noPRStreaks:           make(map[string]noPRStreakRecord),
+		noWorkVerdicts:        make(map[string]noWorkVerdictRecord),
 		assignmentTimes:       make(map[string][]time.Time),
 		leases:                make(map[string]*taskLease),
 		yankExclusions:        make(map[string]time.Time),
@@ -647,6 +713,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	hub.loadCompletedTasks()
 	hub.loadFailedTasks()
 	hub.loadNoPRStreaks()
+	hub.loadNoWorkVerdicts()
 	hub.loadActivity()
 	go hub.cleanupLoop()
 	return hub
@@ -843,6 +910,180 @@ func (h *ContributeWSHub) advanceNoPRStreakLocked(key string, ceiling time.Durat
 	return cooldown
 }
 
+// noWorkVerdictsFileName is the on-disk ledger for no_work_needed completion
+// verdicts (#3987), living in the same PVC-backed contributors dir as the
+// cooldown/streak ledgers so a hub pod restart does not forget a verdict.
+// The full path comes from noWorkVerdictsPath(), which honours
+// HIVE_CONTRIBUTORS_DIR exactly as the contributor profiles do — that is what
+// lets the persistence round-trip test point it at a temp dir.
+const noWorkVerdictsFileName = "no-work-verdicts.json"
+
+func noWorkVerdictsPath() string {
+	return filepath.Join(getContributorsDir(), noWorkVerdictsFileName)
+}
+
+// noWorkVerdictRecord is the in-memory and on-disk shape of one no_work_needed
+// verdict (#3987). RecordedAt anchors both the suppression window and the
+// invalidation comparison (issue updated_at newer than RecordedAt voids the
+// verdict). SuppressHours snapshots the operator's with-PR cooldown at record
+// time so a later config change cannot retroactively stretch an old verdict;
+// 0 (an older entry) falls back to the completedTaskCooldownHours default.
+// Reporter/Reason are audit-only.
+type noWorkVerdictRecord struct {
+	RecordedAt    time.Time `json:"recorded_at"`
+	SuppressHours float64   `json:"suppress_hours,omitempty"`
+	Reporter      string    `json:"reporter,omitempty"`
+	Reason        string    `json:"reason,omitempty"`
+}
+
+// suppressWindow is how long, from RecordedAt, this verdict withholds the
+// issue from the contribute offer pool (absent earlier invalidation).
+func (r noWorkVerdictRecord) suppressWindow() time.Duration {
+	if r.SuppressHours > 0 {
+		return time.Duration(r.SuppressHours * float64(time.Hour))
+	}
+	return completedTaskCooldownHours * time.Hour
+}
+
+func (h *ContributeWSHub) loadNoWorkVerdicts() {
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	data, err := os.ReadFile(noWorkVerdictsPath())
+	if err != nil {
+		return
+	}
+	records := make(map[string]noWorkVerdictRecord)
+	if json.Unmarshal(data, &records) != nil {
+		return
+	}
+	for k, rec := range records {
+		if rec.RecordedAt.IsZero() {
+			continue
+		}
+		// Drop entries already past their own suppression window so a stale
+		// verdict is never resurrected across a restart.
+		if time.Since(rec.RecordedAt) >= rec.suppressWindow() {
+			continue
+		}
+		if h.noWorkVerdicts != nil {
+			h.noWorkVerdicts[k] = rec
+		}
+	}
+	h.logger.Info("[contribute-ws] loaded no-work verdicts", "count", len(h.noWorkVerdicts))
+}
+
+func (h *ContributeWSHub) saveNoWorkVerdicts() {
+	h.completedMu.Lock()
+	saved := make(map[string]noWorkVerdictRecord, len(h.noWorkVerdicts))
+	for k, rec := range h.noWorkVerdicts {
+		if time.Since(rec.RecordedAt) >= rec.suppressWindow() {
+			continue
+		}
+		saved[k] = rec
+	}
+	h.completedMu.Unlock()
+	data, err := json.Marshal(saved)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] no-work verdicts marshal failed", "error", err)
+		return
+	}
+	path := noWorkVerdictsPath()
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		h.logger.Warn("[contribute-ws] no-work verdicts write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		h.logger.Warn("[contribute-ws] no-work verdicts rename failed", "error", err)
+	}
+}
+
+// normalizeCompletionVerdict maps the client-reported verdict plus the
+// SERVER-side PR verification outcome to the verdict the hub acts on (#3987).
+// A VERIFIED PR always wins ("shipped") regardless of what the client claimed —
+// the self-reported field can neither hide nor fabricate shipped work. With no
+// verified PR, only an exact (case-insensitive) no_work_needed is honoured;
+// anything else — absent, unknown, or a claimed "shipped" whose PR failed
+// verification — normalizes to idle, which is byte-for-byte today's behavior,
+// so relays that never learn the field keep working unchanged.
+func normalizeCompletionVerdict(reported, verifiedPR string) string {
+	if verifiedPR != "" {
+		return completionVerdictShipped
+	}
+	if strings.EqualFold(strings.TrimSpace(reported), completionVerdictNoWorkNeeded) {
+		return completionVerdictNoWorkNeeded
+	}
+	return completionVerdictIdle
+}
+
+// isSuppressedByNoWorkVerdict reports whether a live no_work_needed verdict
+// (#3987) withholds this issue from the contribute OFFER pool. It is consulted
+// ONLY by the two offer surfaces — selectTask and ReadyQueue — never by the
+// hive agent pipeline, and it can only ever exclude an offer: it closes and
+// labels nothing.
+//
+// Invalidation beats suppression. The verdict is discarded (and the issue
+// offerable again) when:
+//   - the issue shows activity NEWER than the verdict (issueUpdatedAt after
+//     RecordedAt): the maintainer answered, commits or comments landed, the
+//     decision the remainder was gated on may have arrived; or
+//   - the suppression window (the with-PR cooldown snapshotted at record time)
+//     has elapsed.
+//
+// When the issue's updated_at is UNKNOWN (zero — an older status producer that
+// does not carry the field), the check fails OPEN: we cannot prove the issue
+// has been quiet since the verdict, and suppressing genuinely reopened work is
+// the one failure mode this feature must not have. The record is kept (not
+// discarded) so a later snapshot that does carry updated_at can still honour
+// or void it. Like every completion cooldown, the operator kill-switch
+// disables the exclusion entirely.
+func (h *ContributeWSHub) isSuppressedByNoWorkVerdict(repo string, number int, issueUpdatedAt time.Time) bool {
+	if !h.cooldownEnabled() {
+		return false
+	}
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	rec, ok := h.noWorkVerdicts[key]
+	if !ok {
+		h.completedMu.Unlock()
+		return false
+	}
+	expired := time.Since(rec.RecordedAt) >= rec.suppressWindow()
+	voided := !issueUpdatedAt.IsZero() && issueUpdatedAt.After(rec.RecordedAt)
+	if expired || voided {
+		delete(h.noWorkVerdicts, key)
+		h.completedMu.Unlock()
+		h.saveNoWorkVerdicts()
+		h.logger.Info("[contribute-ws] no-work verdict lifted",
+			"key", key, "expired", expired, "voided_by_activity", voided)
+		return false
+	}
+	h.completedMu.Unlock()
+	if issueUpdatedAt.IsZero() {
+		// Activity unknown → fail open. See doc comment.
+		return false
+	}
+	return true
+}
+
+// issueUpdatedAtFromMap extracts the issue's GitHub updated_at from the
+// map[string]any shape selectTask/ReadyQueue read out of ActionableIssues.
+// ghpkg.Issue.UpdatedAt marshals as an RFC3339 string; anything absent or
+// unparseable yields the zero time, which isSuppressedByNoWorkVerdict treats
+// as "activity unknown" (fail open).
+func issueUpdatedAtFromMap(issue map[string]any) time.Time {
+	s, _ := issue["updated_at"].(string)
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
 // failedTaskRecord is the on-disk shape of one failed-task entry (#2435). It
 // preserves the last-failure time and the running consecutive-failure count so a
 // hub restart does not reset a quarantine — otherwise a bounce would re-admit a
@@ -1003,6 +1244,20 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 // by isTaskInCooldown; the prURL is retained for stats/audit and #2356
 // duplicate detection.
 func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL string) {
+	h.markTaskCompletedVerdict(repo, number, prURL, completionVerdictIdle, "", "")
+}
+
+// markTaskCompletedVerdict is markTaskCompleted plus the completion's
+// normalized verdict (#3987). A no_work_needed verdict — the agent
+// affirmatively determined nothing is shippable, as opposed to merely going
+// idle — additionally records a durable entry in the noWorkVerdicts ledger,
+// which withholds the issue from the OFFER pool for the full with-PR cooldown
+// window unless/until the issue shows newer activity (see
+// isSuppressedByNoWorkVerdict). The regular escalating no-PR cooldown is still
+// booked as the backstop, so behavior for relays that never learn the verdict
+// field — and for hubs where the verdict is later voided — is unchanged.
+// reporter/reason are audit-only and stored with the verdict.
+func (h *ContributeWSHub) markTaskCompletedVerdict(repo string, number int, prURL, verdict, reporter, reason string) {
 	key := fmt.Sprintf("%s#%d", repo, number)
 	// The WITH-PR period is operator-tunable (Config.Hub.ContributeCooldownHours,
 	// default completedTaskCooldownHours). We still RECORD this even when cooldown
@@ -1013,17 +1268,41 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	withPRCooldown := h.configuredWithPRCooldown()
 	h.completedMu.Lock()
 	var cooldown time.Duration
+	verdictLedgerDirty := false
 	if prURL != "" {
 		cooldown = withPRCooldown
 		// A shipped, verified PR ends any no-PR streak: the issue's next no-PR
 		// completion (if any) starts back at the short base cooldown.
 		delete(h.noPRStreaks, key)
+		// It also voids any standing no_work_needed verdict (#3987): real work
+		// just landed, so "nothing is shippable" is no longer true.
+		if _, had := h.noWorkVerdicts[key]; had {
+			delete(h.noWorkVerdicts, key)
+			verdictLedgerDirty = true
+		}
 	} else {
 		// #3980: repeated no-PR completions escalate geometrically (4h → 8h →
 		// …, capped at the with-PR cooldown) so a "nothing to ship" loop —
 		// e.g. an issue whose remaining work is maintainer-gated (#2547) —
 		// cannot burn a full contributor task cycle every 4h forever.
 		cooldown = h.advanceNoPRStreakLocked(key, withPRCooldown)
+		// #3987: an affirmative no_work_needed verdict eliminates that loop
+		// rather than just bounding it — the issue is withheld from the offer
+		// pool for the full with-PR window, subject to invalidation by newer
+		// issue activity. Only the OFFER surfaces read this ledger; the
+		// escalating cooldown above still stands as the backstop.
+		if verdict == completionVerdictNoWorkNeeded {
+			if len(reason) > noWorkReasonMaxLen {
+				reason = reason[:noWorkReasonMaxLen]
+			}
+			h.noWorkVerdicts[key] = noWorkVerdictRecord{
+				RecordedAt:    time.Now(),
+				SuppressHours: withPRCooldown.Hours(),
+				Reporter:      reporter,
+				Reason:        reason,
+			}
+			verdictLedgerDirty = true
+		}
 	}
 	h.completedTasks[key] = time.Now()
 	if h.completedTaskCooldown != nil {
@@ -1052,6 +1331,9 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 	h.completedMu.Unlock()
 	h.saveCompletedTasks()
 	h.saveNoPRStreaks()
+	if verdictLedgerDirty {
+		h.saveNoWorkVerdicts()
+	}
 	if failureCleared {
 		h.saveFailedTasks()
 	}
@@ -2688,13 +2970,21 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					if completedTask != nil && h.verifyReportedPR(completedTask.Repo, msg.PRURL, contributor.profile.GitHubUsername) {
 						verifiedPR = msg.PRURL
 					}
+					// #3987: normalize the completion's verdict. A verified PR always
+					// wins (shipped); with none, only an explicit no_work_needed is
+					// honoured and everything else — including the absent field every
+					// pre-#3987 relay sends — is idle, i.e. today's exact semantics.
+					verdict := normalizeCompletionVerdict(msg.Verdict, verifiedPR)
 					if completedTask != nil {
 						// #2393 item 7 + #2565: the full week-long cooldown is applied
 						// only for a VERIFIED PR; an unverified or no-PR completion gets
 						// the short cooldown so the issue is not locked for a week (and,
 						// per #2492/#2557, still gets a non-zero cooldown so it is not
-						// instantly re-offered in a tight loop).
-						h.markTaskCompleted(completedTask.Repo, completedTask.Number, verifiedPR)
+						// instantly re-offered in a tight loop). #3987: a no_work_needed
+						// verdict additionally books the durable offer-suppression
+						// verdict (see markTaskCompletedVerdict).
+						h.markTaskCompletedVerdict(completedTask.Repo, completedTask.Number, verifiedPR,
+							verdict, contributor.profile.GitHubUsername, strings.TrimSpace(msg.VerdictReason))
 					}
 					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task complete",
@@ -2702,6 +2992,8 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						"task", msg.TaskID,
 						"result", msg.Result,
 						"pr_verified", verifiedPR != "",
+						"verdict", verdict,
+						"verdict_reason", strings.TrimSpace(msg.VerdictReason),
 					)
 					contributor.mu.Lock()
 					contributor.profile.TasksCompleted++
@@ -3463,7 +3755,18 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 			"re-forking). Then 'cd' into that checkout, read the issue, "+
 			"understand what's needed, and take action. "+
 			"Push your branch to your fork remote, then open a PR from your fork. "+
-			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
+			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN'). "+
+			// #3987: the no_work_needed sentinel. The relay scrapes this exact
+			// marker from the agent's output and reports it as the completion
+			// verdict, so an issue whose remainder is maintainer-gated stops
+			// re-entering the offer pool every cooldown window. Keep the marker
+			// spelling in sync with detectNoWorkVerdict in
+			// bin/contributor-relay.sh.
+			"If you determine there is genuinely NOTHING shippable — for example the "+
+			"remaining work is blocked on an unanswered maintainer decision, or merged "+
+			"PRs already cover everything actionable — do NOT open a PR; instead print "+
+			"a single line of the exact form 'HIVE_VERDICT: no_work_needed — <short reason>' "+
+			"and stop.",
 		repoFull, repoFull, number, title, repoFull, repoFull,
 	)
 }
@@ -3840,6 +4143,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				continue
 			}
 			if h.isTaskInCooldown(repo.Full, number) {
+				continue
+			}
+			// #3987: skip an issue with a live no_work_needed completion verdict
+			// (the #2547 shape — shippable parts merged, remainder maintainer-
+			// gated, no open PR left for the claim ledger to see). The verdict
+			// is voided the moment the issue shows activity newer than it, so a
+			// genuinely reopened issue comes straight back into the pool.
+			if h.isSuppressedByNoWorkVerdict(repo.Full, number, issueUpdatedAtFromMap(issue)) {
 				continue
 			}
 			// #2435: skip an issue still inside its short post-failure cooldown or

--- a/src/pkg/dashboard/contribute_ws_no_work_verdict_test.go
+++ b/src/pkg/dashboard/contribute_ws_no_work_verdict_test.go
@@ -1,0 +1,418 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// #3987 suite: the fourth member of the duplicate/re-offer family
+// (#3768 → #3792 → #3980). The residual #2547 shape: an issue's shippable
+// parts land via merged `Part of #N` PRs, the remainder is deliberately
+// maintainer-gated, and — merged PRs not being open PRs — the next claim
+// rescan finds NO claim of any kind, so the issue re-enters the contribute
+// offer pool forever. #3980's escalating no-PR cooldown only BOUNDS that
+// loop; the no_work_needed completion verdict eliminates it, with
+// invalidation-by-issue-activity as the guard against ever suppressing
+// genuinely reopened work.
+
+// noWorkIssue builds the ActionableIssues map shape carrying an updated_at,
+// the field isSuppressedByNoWorkVerdict compares against the verdict's
+// RecordedAt. A zero updatedAt omits the field (an older status producer).
+func noWorkIssue(number int, title string, updatedAt time.Time) map[string]any {
+	issue := map[string]any{
+		"number": float64(number),
+		"title":  title,
+		"url":    "https://github.com/myorg/repo1/issues/" + itoa(number),
+		"author": "someone",
+	}
+	if !updatedAt.IsZero() {
+		issue["updated_at"] = updatedAt.UTC().Format(time.RFC3339)
+	}
+	return issue
+}
+
+func noWorkConn() *ContributorConnection {
+	return &ContributorConnection{
+		profile:  &ContributorProfile{GitHubUsername: "ct-nw", ContributorID: "c-nw", TrustTier: "contributor"},
+		lastPong: time.Now(),
+	}
+}
+
+// sweepCompletion ages the issue's completion entry past its short no-PR
+// cooldown and lets isTaskInCooldown's sweep collect it — the exact state a
+// live hub is in between re-offers, and the reason the pre-#3987 hub had
+// nothing left to suppress the issue with.
+func sweepCompletion(t *testing.T, hub *ContributeWSHub, repo string, number int) {
+	t.Helper()
+	key := noPRKey(repo, number)
+	hub.completedMu.Lock()
+	hub.completedTasks[key] = time.Now().Add(-(completedNoPRCooldownHours + 1) * time.Hour)
+	hub.completedMu.Unlock()
+	if hub.isTaskInCooldown(repo, number) {
+		t.Fatalf("setup: %s should have left its short cooldown", key)
+	}
+}
+
+// TestNoWorkVerdict_SuppressesReofferAfterCooldownSweep replays the #2547 loop
+// from #3980's incident table: a no_work_needed completion, the short cooldown
+// entry expiring and being swept, no open PR claim of any kind — and the issue
+// must STILL not be re-offered, while unrelated work is.
+func TestNoWorkVerdict_SuppressesReofferAfterCooldownSweep(t *testing.T) {
+	hub, s := covK2Hub(t)
+	const repo = "myorg/repo1"
+
+	// The verdict was recorded now; the issue's last GitHub activity predates it.
+	hub.markTaskCompletedVerdict(repo, 61, "", completionVerdictNoWorkNeeded, "ct-nw", "maintainer_gated")
+	sweepCompletion(t, hub, repo, 61)
+
+	staleActivity := time.Now().Add(-24 * time.Hour)
+	setStatusIssues(s,
+		noWorkIssue(61, "maintainer-gated remainder", staleActivity),
+		noWorkIssue(62, "unrelated admissible issue", staleActivity),
+	)
+
+	msg := hub.selectTask(noWorkConn())
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign for the unrelated issue, got %+v", msg)
+	}
+	if msg.Number != 62 {
+		t.Fatalf("no_work_needed issue was re-offered: got #%d, want #62", msg.Number)
+	}
+
+	// With ONLY the verdict-suppressed issue present, the contributor gets an
+	// explicit no_matching_work — never the same dead-end issue again.
+	conn := noWorkConn()
+	setStatusIssues(s, noWorkIssue(61, "maintainer-gated remainder", staleActivity))
+	msg2 := hub.selectTask(conn)
+	if msg2 == nil || msg2.Type != "task_unavailable" || msg2.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("expected task_unavailable/%s, got %+v", taskUnavailableNoMatchingWork, msg2)
+	}
+}
+
+// TestNoWorkVerdict_IdleCompletionStillReoffered is the positive control and
+// the old-relay compatibility pin: a completion WITHOUT the verdict field (the
+// plain markTaskCompleted path every pre-#3987 relay drives) books only the
+// escalating short cooldown, and once that elapses the issue IS offered again
+// — byte-for-byte today's behavior.
+func TestNoWorkVerdict_IdleCompletionStillReoffered(t *testing.T) {
+	hub, s := covK2Hub(t)
+	const repo = "myorg/repo1"
+
+	hub.markTaskCompleted(repo, 63, "")
+	sweepCompletion(t, hub, repo, 63)
+
+	setStatusIssues(s, noWorkIssue(63, "idle completion, no verdict", time.Now().Add(-24*time.Hour)))
+	msg := hub.selectTask(noWorkConn())
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 63 {
+		t.Fatalf("idle completion must not earn the long verdict suppression: got %+v", msg)
+	}
+}
+
+// TestNoWorkVerdict_IssueActivityVoidsVerdict is the invalidation positive
+// control — the one failure mode this feature must not have is suppressing
+// genuinely reopened work. Issue activity NEWER than the verdict (the
+// maintainer answered, commits/comments landed) voids it: the issue is offered
+// again and the ledger entry is gone.
+func TestNoWorkVerdict_IssueActivityVoidsVerdict(t *testing.T) {
+	hub, s := covK2Hub(t)
+	const repo = "myorg/repo1"
+
+	hub.markTaskCompletedVerdict(repo, 64, "", completionVerdictNoWorkNeeded, "ct-nw", "maintainer_gated")
+	sweepCompletion(t, hub, repo, 64)
+
+	// New activity: updated_at AFTER the verdict's RecordedAt.
+	setStatusIssues(s, noWorkIssue(64, "maintainer answered", time.Now().Add(time.Minute)))
+	msg := hub.selectTask(noWorkConn())
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 64 {
+		t.Fatalf("issue activity must void the verdict and re-admit the issue: got %+v", msg)
+	}
+
+	hub.completedMu.Lock()
+	_, still := hub.noWorkVerdicts[noPRKey(repo, 64)]
+	hub.completedMu.Unlock()
+	if still {
+		t.Fatal("voided verdict must be removed from the ledger, not just bypassed")
+	}
+}
+
+// TestNoWorkVerdict_UnknownUpdatedAtFailsOpen: when the status producer does
+// not carry updated_at (older snapshot), we cannot prove the issue has been
+// quiet since the verdict, so the check fails OPEN — the issue is offered and
+// the record is kept for a later snapshot that does carry the field.
+func TestNoWorkVerdict_UnknownUpdatedAtFailsOpen(t *testing.T) {
+	hub, s := covK2Hub(t)
+	const repo = "myorg/repo1"
+
+	hub.markTaskCompletedVerdict(repo, 65, "", completionVerdictNoWorkNeeded, "ct-nw", "")
+	sweepCompletion(t, hub, repo, 65)
+
+	setStatusIssues(s, noWorkIssue(65, "no updated_at available", time.Time{}))
+	msg := hub.selectTask(noWorkConn())
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 65 {
+		t.Fatalf("unknown issue activity must fail open (offer), got %+v", msg)
+	}
+
+	hub.completedMu.Lock()
+	_, still := hub.noWorkVerdicts[noPRKey(repo, 65)]
+	hub.completedMu.Unlock()
+	if !still {
+		t.Fatal("fail-open on unknown activity must KEEP the verdict record")
+	}
+}
+
+// TestNoWorkVerdict_ExpiryLiftsSuppression: a verdict older than its
+// suppression window (the with-PR cooldown snapshotted at record time) no
+// longer suppresses, and the expired entry is swept from the ledger.
+func TestNoWorkVerdict_ExpiryLiftsSuppression(t *testing.T) {
+	hub, s := covK2Hub(t)
+	const repo = "myorg/repo1"
+	key := noPRKey(repo, 66)
+
+	hub.markTaskCompletedVerdict(repo, 66, "", completionVerdictNoWorkNeeded, "ct-nw", "already_covered")
+	sweepCompletion(t, hub, repo, 66)
+
+	hub.completedMu.Lock()
+	rec := hub.noWorkVerdicts[key]
+	rec.RecordedAt = time.Now().Add(-rec.suppressWindow() - time.Hour)
+	hub.noWorkVerdicts[key] = rec
+	hub.completedMu.Unlock()
+
+	setStatusIssues(s, noWorkIssue(66, "verdict expired", time.Now().Add(-rec.suppressWindow()-2*time.Hour)))
+	msg := hub.selectTask(noWorkConn())
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 66 {
+		t.Fatalf("expired verdict must not suppress, got %+v", msg)
+	}
+
+	hub.completedMu.Lock()
+	_, still := hub.noWorkVerdicts[key]
+	hub.completedMu.Unlock()
+	if still {
+		t.Fatal("expired verdict must be swept from the ledger")
+	}
+}
+
+// TestNoWorkVerdict_ClearedByShippedCompletion: a later completion that ships
+// a verified PR voids any standing verdict — real work landed, so "nothing is
+// shippable" is no longer true.
+func TestNoWorkVerdict_ClearedByShippedCompletion(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	const repo = "myorg/repo1"
+	key := noPRKey(repo, 67)
+
+	hub.markTaskCompletedVerdict(repo, 67, "", completionVerdictNoWorkNeeded, "ct-nw", "")
+	hub.completedMu.Lock()
+	_, have := hub.noWorkVerdicts[key]
+	hub.completedMu.Unlock()
+	if !have {
+		t.Fatal("setup: verdict should be recorded")
+	}
+
+	hub.markTaskCompleted(repo, 67, "https://github.com/myorg/repo1/pull/9")
+	hub.completedMu.Lock()
+	_, still := hub.noWorkVerdicts[key]
+	hub.completedMu.Unlock()
+	if still {
+		t.Fatal("a shipped completion must void the standing no-work verdict")
+	}
+}
+
+// TestNormalizeCompletionVerdict pins the trust-order of the verdict field: a
+// server-VERIFIED PR always wins; without one, only an explicit (case- and
+// whitespace-insensitive) no_work_needed is honoured; everything else —
+// including the absent field every pre-#3987 relay sends and a self-claimed
+// "shipped" whose PR failed verification — normalizes to idle.
+func TestNormalizeCompletionVerdict(t *testing.T) {
+	cases := []struct {
+		reported, verifiedPR, want string
+	}{
+		{"", "", completionVerdictIdle},
+		{"no_work_needed", "", completionVerdictNoWorkNeeded},
+		{"  No_Work_Needed  ", "", completionVerdictNoWorkNeeded},
+		{"shipped", "", completionVerdictIdle},                                        // claimed shipped, nothing verified
+		{"garbage", "", completionVerdictIdle},                                        // unknown value
+		{"no_work_needed", "https://github.com/o/r/pull/1", completionVerdictShipped}, // verified PR wins
+		{"", "https://github.com/o/r/pull/1", completionVerdictShipped},
+	}
+	for _, c := range cases {
+		if got := normalizeCompletionVerdict(c.reported, c.verifiedPR); got != c.want {
+			t.Errorf("normalizeCompletionVerdict(%q, %q) = %q, want %q", c.reported, c.verifiedPR, got, c.want)
+		}
+	}
+}
+
+// TestNoWorkVerdict_PersistsAcrossRestart: the verdict must survive a hub pod
+// restart via the PVC-backed ledger — otherwise every deploy would re-admit
+// every parked dead-end issue. An entry past its own suppression window is NOT
+// resurrected.
+func TestNoWorkVerdict_PersistsAcrossRestart(t *testing.T) {
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", t.TempDir())
+	const repo = "myorg/repo1"
+
+	hub1, _ := covK2Hub(t)
+	hub1.markTaskCompletedVerdict(repo, 68, "", completionVerdictNoWorkNeeded, "ct-nw", "maintainer_gated")
+
+	// Stale entry: written to disk aged past its window, must be dropped on load.
+	hub1.completedMu.Lock()
+	hub1.noWorkVerdicts[noPRKey(repo, 69)] = noWorkVerdictRecord{
+		RecordedAt:    time.Now().Add(-completedTaskCooldownHours*time.Hour - time.Hour),
+		SuppressHours: completedTaskCooldownHours,
+	}
+	hub1.completedMu.Unlock()
+	// saveNoWorkVerdicts itself skips expired entries; write the live one.
+	hub1.saveNoWorkVerdicts()
+
+	// Simulated restart: a fresh hub loads the ledger from disk.
+	hub2, _ := covK2Hub(t)
+	hub2.completedMu.Lock()
+	rec, live := hub2.noWorkVerdicts[noPRKey(repo, 68)]
+	_, stale := hub2.noWorkVerdicts[noPRKey(repo, 69)]
+	hub2.completedMu.Unlock()
+	if !live {
+		t.Fatal("verdict must survive a hub restart via the on-disk ledger")
+	}
+	if rec.Reporter != "ct-nw" || rec.Reason != "maintainer_gated" {
+		t.Fatalf("audit fields must round-trip, got %+v", rec)
+	}
+	if stale {
+		t.Fatal("an entry past its suppression window must not be resurrected on load")
+	}
+	if !hub2.isSuppressedByNoWorkVerdict(repo, 68, time.Now().Add(-24*time.Hour)) {
+		t.Fatal("restored verdict must still suppress the offer")
+	}
+}
+
+// TestNoWorkVerdict_OfferSurfacesOnly_StatusUntouched pins the trust doctrine:
+// the contributor-reported verdict may ONLY suppress offers. The two offer
+// surfaces (selectTask, ReadyQueue) must agree — the same contract the claim
+// ledger admission pins — while the status payload's ActionableIssues, the set
+// the hive AGENT pipeline reads, is left completely untouched.
+func TestNoWorkVerdict_OfferSurfacesOnly_StatusUntouched(t *testing.T) {
+	hub, s := covK2Hub(t)
+	const repo = "myorg/repo1"
+
+	hub.markTaskCompletedVerdict(repo, 70, "", completionVerdictNoWorkNeeded, "ct-nw", "maintainer_gated")
+	sweepCompletion(t, hub, repo, 70)
+
+	stale := time.Now().Add(-24 * time.Hour)
+	setStatusIssues(s,
+		noWorkIssue(70, "verdict-parked issue", stale),
+		noWorkIssue(71, "free issue", stale),
+	)
+
+	queue := hub.ReadyQueue(readyQueueDefaultLimit)
+	if len(queue) != 1 || queue[0].Number != 71 {
+		t.Fatalf("ReadyQueue must exclude the verdict-parked issue and keep #71, got %+v", queue)
+	}
+
+	msg := hub.selectTask(noWorkConn())
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 71 {
+		t.Fatalf("selectTask must agree with ReadyQueue and offer only #71, got %+v", msg)
+	}
+
+	// The agent pipeline's source of truth is NOT filtered: both issues are
+	// still present in the status payload. The verdict never mutates status,
+	// never closes anything on GitHub, and has no reader outside the two offer
+	// surfaces above.
+	s.statusMu.RLock()
+	issues := s.status.Repos[0].ActionableIssues
+	s.statusMu.RUnlock()
+	if len(issues) != 2 {
+		t.Fatalf("status ActionableIssues must be untouched by the verdict, got %d entries", len(issues))
+	}
+}
+
+// TestNoWorkVerdict_NeverGrantsTrustCredit drives the REAL WebSocket
+// task_complete handler end to end: a completion carrying verdict
+// no_work_needed (and no PR) records the verdict with the reporting
+// contributor, but earns zero TasksWithPR, no promotion — the verdict is
+// weak, self-reported evidence and must never feed the PR-gated trust path.
+func TestNoWorkVerdict_NeverGrantsTrustCredit(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"verdict-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("register response: %v", err)
+	}
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "repo1",
+				Full: "myorg/repo1",
+				ActionableIssues: []any{
+					noWorkIssue(80, "maintainer-gated issue", time.Now().Add(-24*time.Hour)),
+				},
+			},
+		},
+	}
+	s.statusMu.Unlock()
+
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 2})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", assign)
+	}
+	conn.WriteJSON(WSMessage{
+		Type: "task_complete", TaskID: assign.TaskID, Result: "no_work",
+		Verdict: "no_work_needed", VerdictReason: "maintainer_gated",
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	p := findContributor(reg["contributor_id"])
+	if p == nil {
+		t.Fatal("contributor not found")
+	}
+	if p.TasksCompleted != 1 {
+		t.Fatalf("completion itself must still be recorded, got TasksCompleted=%d", p.TasksCompleted)
+	}
+	if p.TasksWithPR != 0 {
+		t.Fatalf("no_work_needed must NEVER count as a PR-shipping task, got TasksWithPR=%d", p.TasksWithPR)
+	}
+	if p.TrustTier != "newcomer" {
+		t.Fatalf("no_work_needed must never promote, got tier %q", p.TrustTier)
+	}
+
+	hub := s.contributeHub
+	hub.completedMu.Lock()
+	rec, ok := hub.noWorkVerdicts["myorg/repo1#80"]
+	hub.completedMu.Unlock()
+	if !ok {
+		t.Fatal("handler must record the no-work verdict for the completed issue")
+	}
+	if rec.Reporter != "verdict-user" || rec.Reason != "maintainer_gated" {
+		t.Fatalf("verdict audit fields wrong: %+v", rec)
+	}
+
+	// End-to-end replay of the loop's tail: the issue must not be offered to
+	// the next ready contributor even though its short cooldown entry is aged
+	// out and swept.
+	sweepCompletion(t, hub, "myorg/repo1", 80)
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 3})
+	next := readMsg(t, conn)
+	if next.Type != "task_unavailable" || next.Reason != taskUnavailableNoMatchingWork {
+		t.Fatalf("verdict-parked issue must not be re-offered, got %+v", next)
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -143,13 +143,21 @@ func (c *Client) SetAppBotLogin(login string) {
 }
 
 type Issue struct {
-	Repo           string    `json:"repo"`
-	Number         int       `json:"number"`
-	Title          string    `json:"title"`
-	Author         string    `json:"author"`
-	Labels         []string  `json:"labels"`
-	Assignees      []string  `json:"assignees"`
-	CreatedAt      time.Time `json:"created_at"`
+	Repo      string    `json:"repo"`
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	Author    string    `json:"author"`
+	Labels    []string  `json:"labels"`
+	Assignees []string  `json:"assignees"`
+	CreatedAt time.Time `json:"created_at"`
+	// UpdatedAt is GitHub's last-activity timestamp for the issue (new commits
+	// referencing it, comments, label/assignee changes, …). It is the
+	// invalidation signal for the contribute queue's no_work_needed verdict
+	// (kubestellar/hive#3987): a verdict recorded BEFORE this timestamp is void,
+	// so fresh activity on a previously "nothing to ship" issue re-opens it for
+	// offers. Zero when produced by an older enumerator; consumers must fail
+	// OPEN (treat activity as unknown → do not suppress) in that case.
+	UpdatedAt      time.Time `json:"updated_at,omitempty"`
 	AgeMinutes     int       `json:"age_minutes"`
 	URL            string    `json:"url"`
 	IsTracker      bool      `json:"is_tracker"`
@@ -532,6 +540,7 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 			Labels:     labels,
 			Assignees:  extractAssignees(issue.Assignees),
 			CreatedAt:  issue.GetCreatedAt().Time,
+			UpdatedAt:  issue.GetUpdatedAt().Time,
 			AgeMinutes: ageMinutes,
 			URL:        issue.GetHTMLURL(),
 			IsTracker:  isTracker(issue.GetTitle(), labels),


### PR DESCRIPTION
Fixes #3987

Fourth member of the duplicate/re-offer family (#3768 → #3792 → #3980, PRs #3985/#3989).

## The residual (#2547 shape)

An issue's shippable parts land via merged `Part of #N` PRs; the remainder is deliberately gated on an unanswered maintainer design/ROUTE decision, so the issue stays open. Merged PRs are not open PRs: on the next authoritative claim rescan there is **no claim of any kind** left — hard, soft, external, or reference — so the issue re-enters the contribute offer pool. The dispatched agent correctly concludes "nothing to ship", goes idle without a PR, the hub books a no-PR cooldown, and the cycle repeats. #3985 + #3989 only **bound** this loop (soft-ref claims, escalating no-PR cooldown); this PR eliminates it with the completion verdict the issue proposes.

## Mechanism

**Protocol (additive).** `task_complete` gains an optional `verdict` field — `shipped` / `idle` / `no_work_needed` — plus an audit-only `verdict_reason` (`maintainer_gated`, `already_covered`, or scraped free text, truncated server-side). An absent field normalizes to `idle`, byte-for-byte today's semantics, so every pre-#3987 relay keeps working unchanged. A server-**verified** PR always normalizes to `shipped` — the self-reported field can neither hide nor fabricate shipped work. The hub advertises `completion_verdict` in `server_capabilities`.

**Hub.** A `no_work_needed` completion still books the #3989 escalating no-PR cooldown as the backstop, and additionally records a durable entry in a new `noWorkVerdicts` ledger (`/data/contributors/no-work-verdicts.json`, same PVC-backed dir as the cooldown ledgers, restored on boot) that withholds the issue from the **offer pool** for the operator's with-PR cooldown window, snapshotted at record time.

**Invalidation beats suppression.** The verdict is void — entry deleted, issue immediately offerable — when:
- the issue shows GitHub activity **newer** than the verdict (`updated_at` now carried on `ghpkg.Issue` and compared at offer time: the maintainer answered, commits/comments landed);
- its suppression window elapses; or
- a later completion ships a verified PR.

When `updated_at` is unknown (older status producer) the check fails **open**: suppressing genuinely reopened work is the one failure mode this feature must not have.

**Trust doctrine.** The verdict is contributor-reported, weak evidence. It is read only by the two offer surfaces — `selectTask` and `ReadyQueue`, which must agree (same contract the claim-ledger admission pins). It never feeds `TasksWithPR`/promotion, never closes or labels anything on GitHub, and the status payload's `ActionableIssues` — what the hive agent pipeline reads — is untouched. Worst a lying client can do is park one issue for one with-PR window, until any activity on the issue voids it.

**Relay.** `bin/contributor-relay.sh` scrapes the `HIVE_VERDICT: no_work_needed — <reason>` sentinel (the task prompt now teaches it) newest-first, line-anchored and placeholder-guarded so the prompt's own instruction echo in the pane can never read as a verdict, and only when no PR URL was detected.

## Tests (`contribute_ws_no_work_verdict_test.go`)

- `TestNoWorkVerdict_SuppressesReofferAfterCooldownSweep` — replay of the #2547 loop from #3980's incident table: completion entry aged + swept, no claim left, issue still not re-offered while unrelated work is.
- `TestNoWorkVerdict_IdleCompletionStillReoffered` — positive control / old-relay compat: no verdict field ⇒ today's exact behavior.
- `TestNoWorkVerdict_IssueActivityVoidsVerdict` — invalidation positive control: newer `updated_at` re-admits the issue and removes the ledger entry.
- `TestNoWorkVerdict_UnknownUpdatedAtFailsOpen` — unknown activity ⇒ offer anyway, record kept.
- `TestNoWorkVerdict_ExpiryLiftsSuppression` — window elapse sweeps the entry.
- `TestNoWorkVerdict_ClearedByShippedCompletion` — a verified-PR completion voids a standing verdict.
- `TestNormalizeCompletionVerdict` — trust order: verified PR wins; claimed `shipped` without verification ⇒ idle; unknown values ⇒ idle.
- `TestNoWorkVerdict_PersistsAcrossRestart` — PVC round-trip across a simulated restart; expired entries not resurrected; audit fields intact.
- `TestNoWorkVerdict_OfferSurfacesOnly_StatusUntouched` — ReadyQueue agrees with selectTask; status `ActionableIssues` (agent-pipeline source) unfiltered.
- `TestNoWorkVerdict_NeverGrantsTrustCredit` — end-to-end WS handler: verdict recorded with reporter, `TasksWithPR` stays 0, no promotion, and the parked issue yields `no_matching_work` on the next ready.

Targeted `go vet ./pkg/dashboard ./pkg/github` clean; full `pkg/github` suite and the neighboring #3985/#3989/#3768/#2435 regression suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)