### PR TITLE
✨ feat(reach): PR→component mapping, ancestry join and read-only /api/reach (#3994)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -7036,6 +7036,21 @@ func runHub(logger *slog.Logger) {
 
 	hubSrv := hub.NewHubServer(port, logger, gitShort, gitBranch)
 
+	// /api/reach (#3994) needs merged-PR metadata (merge SHA, changed
+	// files). The hub mode has no ambient GitHub client, so reuse the
+	// standard token client when credentials exist; without a token the
+	// endpoint reports 503 rather than serving fabricated data. The base
+	// branch is the hub's own running branch — the lineage its fleet runs.
+	if ghToken := os.Getenv("HIVE_GITHUB_TOKEN"); ghToken != "" {
+		reachGH := github.NewClient(ghToken, "kubestellar", []string{"hive"}, logger, "")
+		hubSrv.SetReachPRSource(hub.NewGitHubPRSource(reachGH, gitBranch))
+	}
+	// Wire 2a's heartbeat-fed registry store into the /api/reach endpoint
+	// (#3973 epic: producer #3993 → consumer #3994). Unconditional — the
+	// registry-backed reporter has no external dependencies, and without it
+	// the endpoint would keep answering from the empty stub forever.
+	hubSrv.SetReachReporter(hubSrv.RegistryReachReporter())
+
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {

--- a/src/pkg/github/pr_reach.go
+++ b/src/pkg/github/pr_reach.go
@@ -1,0 +1,230 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// ============================================================================
+// PR facts for reach telemetry (#3994, phase 2b of #3973)
+// ============================================================================
+//
+// The /api/reach join needs three GitHub facts per PR: the merge commit SHA,
+// the merge time, and the changed-file list (input to the D3 PR→component
+// mapping). All three are IMMUTABLE once a PR is merged, so they are cached
+// permanently in bounded maps — the same drop-on-overflow discipline as
+// pkg/hub's commitOrderCache, and the mutex+map+cachedAt shape of
+// app_discovery.go. The recent-merged-PRs listing is the one answer that
+// changes over time, so it alone carries a TTL.
+
+// MergedPR is the merged-PR fact set the reach join consumes.
+type MergedPR struct {
+	Number         int
+	Title          string
+	MergeCommitSHA string
+	MergedAt       time.Time
+}
+
+// mergedPRCacheMax / prFilesCacheMax bound the permanent caches of immutable
+// merged-PR facts. PR numbers arrive from operator queries, so the key space
+// is externally influenced and must not grow forever; on overflow the whole
+// map is dropped (a re-fetch costs one API call per entry still in use —
+// simpler and safer than an LRU, per commitOrderCacheMax in pkg/hub).
+const (
+	mergedPRCacheMax = 512
+	prFilesCacheMax  = 512
+)
+
+// RecentMergedPRsTTL bounds how stale the recent-merged-PRs listing may be.
+// Five minutes matches InstallationDiscoveryTTL: fresh enough for an
+// operator-facing status endpoint, coarse enough that a dashboard poll never
+// turns into an API call loop.
+const RecentMergedPRsTTL = 5 * time.Minute
+
+// recentMergedPRsMaxPages caps the closed-PR listing walk. At 100 PRs per
+// page, five pages bounds the walk to 500 recently-updated closed PRs —
+// far more than any recent-PRs query needs, and a hard stop against paging
+// through the repo's whole history when few of them merged.
+const recentMergedPRsMaxPages = 5
+
+// listPerPage is the standard GitHub max page size, used by every paginated
+// call in this file.
+const listPerPage = 100
+
+var (
+	prReachCacheMu sync.Mutex
+	// mergedPRCache / prFilesCache hold immutable merged-PR facts forever
+	// (bounded above). Keyed "owner/repo#number".
+	mergedPRCache = map[string]MergedPR{}
+	prFilesCache  = map[string][]string{}
+	// recentMergedCache holds the one time-varying answer, keyed
+	// "owner/repo@base". Entries expire after RecentMergedPRsTTL.
+	recentMergedCache = map[string]recentMergedEntry{}
+)
+
+type recentMergedEntry struct {
+	prs      []MergedPR
+	cachedAt time.Time
+}
+
+// prCacheKey builds the "owner/repo#number" cache key.
+func prCacheKey(owner, repo string, number int) string {
+	return fmt.Sprintf("%s/%s#%d", owner, repo, number)
+}
+
+// MergedPR fetches one PR's merged facts. It errors on a PR that is not
+// merged — the reach join is defined only over merged code, and treating an
+// open PR as merged would fabricate a merge time.
+func (c *Client) MergedPR(ctx context.Context, owner, repo string, number int) (MergedPR, error) {
+	if c == nil {
+		return MergedPR{}, ErrNoGitHubClient
+	}
+	key := prCacheKey(owner, repo, number)
+	prReachCacheMu.Lock()
+	if cached, ok := mergedPRCache[key]; ok {
+		prReachCacheMu.Unlock()
+		return cached, nil
+	}
+	prReachCacheMu.Unlock()
+
+	pr, _, err := c.client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		return MergedPR{}, fmt.Errorf("fetching PR %s: %w", key, err)
+	}
+	if pr.MergedAt == nil || pr.GetMergeCommitSHA() == "" {
+		return MergedPR{}, fmt.Errorf("PR %s is not merged", key)
+	}
+	merged := MergedPR{
+		Number:         number,
+		Title:          pr.GetTitle(),
+		MergeCommitSHA: pr.GetMergeCommitSHA(),
+		MergedAt:       pr.MergedAt.Time,
+	}
+
+	prReachCacheMu.Lock()
+	if len(mergedPRCache) >= mergedPRCacheMax {
+		mergedPRCache = map[string]MergedPR{}
+	}
+	mergedPRCache[key] = merged
+	prReachCacheMu.Unlock()
+	return merged, nil
+}
+
+// ListMergedPRFiles returns the changed-file paths of a MERGED PR (immutable,
+// so cached permanently). It pages through the full list and then verifies
+// completeness against the PR's own changed-file count — GitHub truncates the
+// files endpoint on very large PRs, and a silently short list would
+// under-attribute components and understate reach (same guard as
+// fetchIntentPREvidence in cmd/hive).
+func (c *Client) ListMergedPRFiles(ctx context.Context, owner, repo string, number int) ([]string, error) {
+	if c == nil {
+		return nil, ErrNoGitHubClient
+	}
+	key := prCacheKey(owner, repo, number)
+	prReachCacheMu.Lock()
+	if cached, ok := prFilesCache[key]; ok {
+		prReachCacheMu.Unlock()
+		return cached, nil
+	}
+	prReachCacheMu.Unlock()
+
+	pr, _, err := c.client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		return nil, fmt.Errorf("fetching PR %s: %w", key, err)
+	}
+	if pr.MergedAt == nil {
+		return nil, fmt.Errorf("PR %s is not merged; refusing to cache a mutable file list", key)
+	}
+
+	var files []string
+	opts := &gh.ListOptions{PerPage: listPerPage}
+	for {
+		page, resp, err := c.client.PullRequests.ListFiles(ctx, owner, repo, number, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing PR %s files: %w", key, err)
+		}
+		for _, f := range page {
+			files = append(files, f.GetFilename())
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	if reported := pr.GetChangedFiles(); reported > len(files) {
+		return nil, fmt.Errorf("incomplete PR file list for %s: GitHub reported %d changed files but the API returned %d — refusing a partial attribution", key, reported, len(files))
+	}
+
+	prReachCacheMu.Lock()
+	if len(prFilesCache) >= prFilesCacheMax {
+		prFilesCache = map[string][]string{}
+	}
+	prFilesCache[key] = files
+	prReachCacheMu.Unlock()
+	return files, nil
+}
+
+// RecentMergedPRs lists up to limit PRs merged into base, newest merge first,
+// cached for RecentMergedPRsTTL. It walks closed PRs sorted by update
+// recency (the fetchMergedPRs pattern in pkg/knowledge) and keeps only real
+// merges into the requested base branch.
+func (c *Client) RecentMergedPRs(ctx context.Context, owner, repo, base string, limit int) ([]MergedPR, error) {
+	if c == nil {
+		return nil, ErrNoGitHubClient
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	cacheKey := fmt.Sprintf("%s/%s@%s", owner, repo, base)
+	prReachCacheMu.Lock()
+	if entry, ok := recentMergedCache[cacheKey]; ok && time.Since(entry.cachedAt) < RecentMergedPRsTTL && len(entry.prs) >= limit {
+		result := entry.prs[:limit]
+		prReachCacheMu.Unlock()
+		return result, nil
+	}
+	prReachCacheMu.Unlock()
+
+	var merged []MergedPR
+	opts := &gh.PullRequestListOptions{
+		State:       "closed",
+		Base:        base,
+		Sort:        "updated",
+		Direction:   "desc",
+		ListOptions: gh.ListOptions{PerPage: listPerPage},
+	}
+	for page := 0; page < recentMergedPRsMaxPages && len(merged) < limit; page++ {
+		prs, resp, err := c.client.PullRequests.List(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing merged PRs for %s: %w", cacheKey, err)
+		}
+		for _, pr := range prs {
+			if pr.MergedAt == nil || pr.GetMergeCommitSHA() == "" {
+				continue // closed without merging
+			}
+			merged = append(merged, MergedPR{
+				Number:         pr.GetNumber(),
+				Title:          pr.GetTitle(),
+				MergeCommitSHA: pr.GetMergeCommitSHA(),
+				MergedAt:       pr.MergedAt.Time,
+			})
+			if len(merged) >= limit {
+				break
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	prReachCacheMu.Lock()
+	if len(merged) > 0 {
+		recentMergedCache[cacheKey] = recentMergedEntry{prs: merged, cachedAt: time.Now()}
+	}
+	prReachCacheMu.Unlock()
+	return merged, nil
+}

--- a/src/pkg/github/pr_reach_test.go
+++ b/src/pkg/github/pr_reach_test.go
@@ -1,0 +1,161 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// resetPRReachCaches clears the package-level caches between tests.
+func resetPRReachCaches() {
+	prReachCacheMu.Lock()
+	mergedPRCache = map[string]MergedPR{}
+	prFilesCache = map[string][]string{}
+	recentMergedCache = map[string]recentMergedEntry{}
+	prReachCacheMu.Unlock()
+}
+
+// TestMergedPRAndFilesCached: merged-PR facts and the paginated file list
+// are fetched once and answered from cache afterwards (they are immutable),
+// and the file list follows the Link-header pagination to completion.
+func TestMergedPRAndFilesCached(t *testing.T) {
+	resetPRReachCaches()
+	prGets, fileGets := 0, 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/kubestellar/hive/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		prGets++
+		fmt.Fprint(w, `{"number":42,"title":"reach 2b","merged_at":"2026-08-10T12:00:00Z","merge_commit_sha":"cafe1234","changed_files":3}`)
+	})
+	mux.HandleFunc("GET /repos/kubestellar/hive/pulls/42/files", func(w http.ResponseWriter, r *http.Request) {
+		fileGets++
+		if r.URL.Query().Get("page") == "2" {
+			fmt.Fprint(w, `[{"filename":"v2/proxy/mitm.go"}]`)
+			return
+		}
+		w.Header().Set("Link", fmt.Sprintf(`<http://%s/repos/kubestellar/hive/pulls/42/files?page=2>; rel="next"`, r.Host))
+		fmt.Fprint(w, `[{"filename":"v2/pkg/hub/saas.go"},{"filename":"docs/x.md"}]`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	c := NewClientForTest(server.URL, "kubestellar", []string{"hive"}, slog.Default())
+
+	pr, err := c.MergedPR(context.Background(), "kubestellar", "hive", 42)
+	if err != nil {
+		t.Fatalf("MergedPR: %v", err)
+	}
+	wantMerged := MergedPR{Number: 42, Title: "reach 2b", MergeCommitSHA: "cafe1234",
+		MergedAt: time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)}
+	if pr != wantMerged {
+		t.Errorf("MergedPR = %+v, want %+v", pr, wantMerged)
+	}
+
+	files, err := c.ListMergedPRFiles(context.Background(), "kubestellar", "hive", 42)
+	if err != nil {
+		t.Fatalf("ListMergedPRFiles: %v", err)
+	}
+	if want := []string{"v2/pkg/hub/saas.go", "docs/x.md", "v2/proxy/mitm.go"}; !reflect.DeepEqual(files, want) {
+		t.Errorf("files = %v, want %v", files, want)
+	}
+	if fileGets != 2 {
+		t.Errorf("file pages fetched = %d, want 2 (pagination)", fileGets)
+	}
+
+	// Immutable facts: repeat calls are cache hits, zero new requests.
+	prevPR, prevFiles := prGets, fileGets
+	if _, err := c.MergedPR(context.Background(), "kubestellar", "hive", 42); err != nil {
+		t.Fatalf("cached MergedPR: %v", err)
+	}
+	if _, err := c.ListMergedPRFiles(context.Background(), "kubestellar", "hive", 42); err != nil {
+		t.Fatalf("cached ListMergedPRFiles: %v", err)
+	}
+	if prGets != prevPR || fileGets != prevFiles {
+		t.Errorf("cached calls hit the API (pr %d→%d, files %d→%d)", prevPR, prGets, prevFiles, fileGets)
+	}
+}
+
+// TestMergedPRNotMerged: an unmerged PR is an error for both facts and
+// files — treating it as merged would fabricate a merge time, and its file
+// list is still mutable so caching it would go stale.
+func TestMergedPRNotMerged(t *testing.T) {
+	resetPRReachCaches()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/kubestellar/hive/pulls/7", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"number":7,"title":"open","changed_files":1}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	c := NewClientForTest(server.URL, "kubestellar", []string{"hive"}, slog.Default())
+
+	if _, err := c.MergedPR(context.Background(), "kubestellar", "hive", 7); err == nil {
+		t.Error("MergedPR on open PR: want error")
+	}
+	if _, err := c.ListMergedPRFiles(context.Background(), "kubestellar", "hive", 7); err == nil {
+		t.Error("ListMergedPRFiles on open PR: want error")
+	}
+}
+
+// TestListMergedPRFilesIncomplete: when GitHub reports more changed files
+// than the files endpoint returned (truncation on huge PRs), the call FAILS
+// rather than silently under-attributing components.
+func TestListMergedPRFilesIncomplete(t *testing.T) {
+	resetPRReachCaches()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/kubestellar/hive/pulls/9", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"number":9,"merged_at":"2026-08-10T12:00:00Z","merge_commit_sha":"beef","changed_files":5}`)
+	})
+	mux.HandleFunc("GET /repos/kubestellar/hive/pulls/9/files", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `[{"filename":"a.go"}]`) // 1 of a reported 5
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	c := NewClientForTest(server.URL, "kubestellar", []string{"hive"}, slog.Default())
+
+	if _, err := c.ListMergedPRFiles(context.Background(), "kubestellar", "hive", 9); err == nil {
+		t.Fatal("want incomplete-file-list error, got nil")
+	}
+}
+
+// TestRecentMergedPRs: closed-but-unmerged PRs are filtered out, the limit
+// is honored, and the answer is TTL-cached.
+func TestRecentMergedPRs(t *testing.T) {
+	resetPRReachCaches()
+	listGets := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/kubestellar/hive/pulls", func(w http.ResponseWriter, r *http.Request) {
+		listGets++
+		if got := r.URL.Query().Get("base"); got != "v4" {
+			t.Errorf("base = %q, want v4", got)
+		}
+		fmt.Fprint(w, `[
+			{"number":30,"title":"newest","merged_at":"2026-08-12T00:00:00Z","merge_commit_sha":"c30"},
+			{"number":29,"title":"closed-not-merged"},
+			{"number":28,"title":"older","merged_at":"2026-08-11T00:00:00Z","merge_commit_sha":"c28"},
+			{"number":27,"title":"oldest","merged_at":"2026-08-10T00:00:00Z","merge_commit_sha":"c27"}
+		]`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	c := NewClientForTest(server.URL, "kubestellar", []string{"hive"}, slog.Default())
+
+	prs, err := c.RecentMergedPRs(context.Background(), "kubestellar", "hive", "v4", 2)
+	if err != nil {
+		t.Fatalf("RecentMergedPRs: %v", err)
+	}
+	if len(prs) != 2 || prs[0].Number != 30 || prs[1].Number != 28 {
+		t.Errorf("prs = %+v, want #30 then #28 (unmerged #29 skipped)", prs)
+	}
+
+	// TTL cache: an immediate repeat answers without a new request.
+	prev := listGets
+	if _, err := c.RecentMergedPRs(context.Background(), "kubestellar", "hive", "v4", 2); err != nil {
+		t.Fatalf("cached RecentMergedPRs: %v", err)
+	}
+	if listGets != prev {
+		t.Errorf("cached listing hit the API (%d→%d)", prev, listGets)
+	}
+}

--- a/src/pkg/hub/reach_api.go
+++ b/src/pkg/hub/reach_api.go
@@ -1,0 +1,345 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	hivegithub "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/reach"
+)
+
+// ============================================================================
+// /api/reach — read-only PR reach telemetry (#3994, phase 2b of #3973)
+// ============================================================================
+//
+// Joins merged PRs (changed files → components, D3) against the per-hive
+// component_reach reports phase 2a (#3993) persists from the heartbeat, via
+// the ancestry rule: a hive counts only when the commit it reports RUNNING
+// contains the PR's merge commit (the #3816 anchoring rule — merged is not
+// deployed). Co-deployed PRs share one window and are labeled shared (D4).
+//
+// Read-only by construction: no GitHub writes, no state mutation beyond the
+// caches the underlying clients already keep.
+
+// reachRepoOwner / reachRepoName pin the repo the reach join is defined
+// over — the same repo commit_order.go compares against.
+const (
+	reachRepoOwner = "kubestellar"
+	reachRepoName  = "hive"
+)
+
+// defaultReachRecentPRs / maxReachRecentPRs bound the ?recent= listing.
+// Twenty covers a typical week of merges into one branch; one hundred caps
+// the GitHub file-listing fan-out an admin query can trigger.
+const (
+	defaultReachRecentPRs = 20
+	maxReachRecentPRs     = 100
+)
+
+// reachRequestTimeout bounds one /api/reach request end-to-end (GitHub PR
+// fetches + compare-API ancestry resolves). Generous because a cold cache
+// may resolve several ancestry pairs, but finite so a wedged upstream can
+// never pin the handler.
+const reachRequestTimeout = 30 * time.Second
+
+// reachRepoDirEnv optionally points at a local git clone with real history.
+// When set, ancestry resolves via `git merge-base --is-ancestor` against
+// that clone (the epic's resolved OQ-3 answer). The hub container image
+// ships no clone, so the default is the compare-API adapter below, which
+// reuses commit_order.go's fetcher and permanent cache.
+const reachRepoDirEnv = "HIVE_REACH_REPO_DIR"
+
+// newReachAncestry picks the ancestry backend: a configured local clone
+// when reachRepoDirEnv is set, otherwise the GitHub compare API.
+func newReachAncestry(logger *slog.Logger) reach.Ancestry {
+	if dir := os.Getenv(reachRepoDirEnv); dir != "" {
+		return reach.NewGitAncestry(dir)
+	}
+	return compareAncestry{logger: logger}
+}
+
+// compareAncestry answers reach.Ancestry with the hub's EXISTING ancestry
+// primitive: the GitHub compare API behind commit_order.go. It shares that
+// file's permanent cache (ancestry is immutable) and its fetcher var (so
+// tests stub one seam for both callers). Unlike commitAtOrAheadOfTarget it
+// resolves SYNCHRONOUSLY — /api/reach runs in a request handler that holds
+// no HubServer mutex, so blocking on one bounded API call is safe and a
+// definite answer beats "false for now".
+type compareAncestry struct{ logger *slog.Logger }
+
+// IsAncestor reports whether ancestor is contained in descendant, per the
+// compare API ("ahead"/"identical" of base=ancestor, head=descendant —
+// the exact commitAtOrAheadOfTarget semantics).
+func (c compareAncestry) IsAncestor(ancestor, descendant string) (bool, error) {
+	if ancestor == "" || descendant == "" {
+		// An unknown commit must never read as reached.
+		return false, fmt.Errorf("reach ancestry: empty commit (ancestor=%q descendant=%q)", ancestor, descendant)
+	}
+	if sameCommit(ancestor, descendant) {
+		return true, nil
+	}
+	key := commitOrderKey{target: shortSHA(ancestor), reported: shortSHA(descendant)}
+
+	commitOrderMu.Lock()
+	if atOrAhead, ok := commitOrderCache[key]; ok {
+		commitOrderMu.Unlock()
+		return atOrAhead, nil
+	}
+	// Capture the fetcher under the mutex tests stub it under (see
+	// fetchCommitCompareStatus's contract in commit_order.go).
+	fetch := fetchCommitCompareStatus
+	commitOrderMu.Unlock()
+
+	status, err := fetch(key.target, key.reported, c.logger)
+	if err != nil {
+		// Errors are never cached (commit_order.go discipline): a transient
+		// failure retries on the next request instead of poisoning the pair.
+		return false, err
+	}
+	atOrAhead := status == "ahead" || status == "identical"
+
+	commitOrderMu.Lock()
+	if len(commitOrderCache) >= commitOrderCacheMax {
+		commitOrderCache = map[commitOrderKey]bool{}
+	}
+	commitOrderCache[key] = atOrAhead
+	commitOrderMu.Unlock()
+	return atOrAhead, nil
+}
+
+// githubPRSource backs reach.PRSource with the existing pkg/github client
+// (cached merged-PR facts — pkg/github/pr_reach.go). base is the branch PRs
+// must have merged into: the hub's own branch, since that is the lineage the
+// fleet it registers runs.
+type githubPRSource struct {
+	client *hivegithub.Client
+	base   string
+}
+
+// NewGitHubPRSource wraps the hub's GitHub client as the /api/reach PR
+// source. base is the merge-target branch (the hub's running branch).
+func NewGitHubPRSource(client *hivegithub.Client, base string) reach.PRSource {
+	return &githubPRSource{client: client, base: base}
+}
+
+// MergedPR implements reach.PRSource.
+func (g *githubPRSource) MergedPR(ctx context.Context, number int) (reach.PRInfo, error) {
+	pr, err := g.client.MergedPR(ctx, reachRepoOwner, reachRepoName, number)
+	if err != nil {
+		return reach.PRInfo{}, err
+	}
+	files, err := g.client.ListMergedPRFiles(ctx, reachRepoOwner, reachRepoName, number)
+	if err != nil {
+		return reach.PRInfo{}, err
+	}
+	return reach.PRInfo{
+		Number:      pr.Number,
+		Title:       pr.Title,
+		MergeCommit: pr.MergeCommitSHA,
+		MergedAt:    pr.MergedAt,
+		Files:       files,
+	}, nil
+}
+
+// RecentMergedPRs implements reach.PRSource.
+func (g *githubPRSource) RecentMergedPRs(ctx context.Context, limit int) ([]reach.PRInfo, error) {
+	merged, err := g.client.RecentMergedPRs(ctx, reachRepoOwner, reachRepoName, g.base, limit)
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]reach.PRInfo, 0, len(merged))
+	for _, pr := range merged {
+		files, err := g.client.ListMergedPRFiles(ctx, reachRepoOwner, reachRepoName, pr.Number)
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, reach.PRInfo{
+			Number:      pr.Number,
+			Title:       pr.Title,
+			MergeCommit: pr.MergeCommitSHA,
+			MergedAt:    pr.MergedAt,
+			Files:       files,
+		})
+	}
+	return infos, nil
+}
+
+// SetReachPRSource wires the GitHub-backed PR source (called from runHub
+// when GitHub credentials exist; the endpoint answers 503 until then).
+// Call before Start.
+func (s *HubServer) SetReachPRSource(src reach.PRSource) {
+	s.reachPRSource = src
+}
+
+// SetReachReporter wires phase 2a's heartbeat-fed reach store over the
+// default stub. Call before Start. This is the ONE wiring line 2a needs
+// to feed this endpoint real fleet data.
+func (s *HubServer) SetReachReporter(r reach.ReachReporter) {
+	if r != nil {
+		s.reachReporter = r
+	}
+}
+
+// RegistryReachReporter adapts the hub registry's per-hive component_reach
+// storage (phase 2a, #3993 — sanitized heartbeat reports on RegistryEntry)
+// to the reach.ReachReporter seam phase 2b reads through (#3994). This is
+// the producer→consumer wiring that completes the epic (#3973) through 2b:
+// the registry is the single source, snapshotted under the server lock, so
+// the endpoint never observes a half-written report.
+func (s *HubServer) RegistryReachReporter() reach.ReachReporter {
+	return registryReachReporter{s: s}
+}
+
+type registryReachReporter struct{ s *HubServer }
+
+func (r registryReachReporter) LatestReach() map[string][]reach.ComponentReach {
+	r.s.mu.RLock()
+	defer r.s.mu.RUnlock()
+	out := make(map[string][]reach.ComponentReach)
+	for _, h := range r.s.registry.Hives {
+		if h.ComponentReach == nil || len(h.ComponentReach.Entries) == 0 {
+			continue
+		}
+		list := make([]reach.ComponentReach, 0, len(h.ComponentReach.Entries))
+		for _, e := range h.ComponentReach.Entries {
+			// Timestamps were RFC3339-validated by sanitizeComponentReach on
+			// receipt; a parse failure here would mean corrupted storage, and
+			// the entry is skipped rather than reported with a zero time that
+			// the never-ran/first-seen logic would misread as ancient.
+			fs, errF := time.Parse(time.RFC3339, e.FirstSeen)
+			ls, errL := time.Parse(time.RFC3339, e.LastSeen)
+			if errF != nil || errL != nil {
+				continue
+			}
+			list = append(list, reach.ComponentReach{
+				Component:  e.Component,
+				Commit:     e.Commit,
+				SpansTotal: e.SpansTotal,
+				SpansError: e.SpansError,
+				FirstSeen:  fs,
+				LastSeen:   ls,
+			})
+		}
+		if len(list) > 0 {
+			out[h.ID] = list
+		}
+	}
+	return out
+}
+
+// reachResponse is the /api/reach payload.
+type reachResponse struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	// HivesReporting counts hives with a persisted component_reach report —
+	// zero until phase 2a (#3993) merges and is wired.
+	HivesReporting int `json:"hives_reporting"`
+	// DeployedCommits is the digest-anchored deploy history derived from
+	// what hives report running, oldest first (the D4 window boundaries).
+	DeployedCommits []string              `json:"deployed_commits"`
+	Reports         []reach.PRReachReport `json:"reports"`
+}
+
+// writeReachError emits the endpoint's uniform JSON error shape.
+func writeReachError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
+// handleReach serves GET /api/reach — by PR (?pr=NNN) or the recent-PRs
+// list (?recent=K, default defaultReachRecentPRs). Registered behind
+// requireAdmin in registerSaaSRoutes: the payload names hives fleet-wide,
+// exactly the cluster-health exposure class.
+func (s *HubServer) handleReach(w http.ResponseWriter, r *http.Request) {
+	src := s.reachPRSource
+	if src == nil {
+		writeReachError(w, http.StatusServiceUnavailable,
+			"reach: no GitHub PR source configured (hub is running without GitHub credentials)")
+		return
+	}
+	reporter := s.reachReporter
+	if reporter == nil {
+		reporter = &reach.StubReachReporter{}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), reachRequestTimeout)
+	defer cancel()
+
+	var prs []reach.PRInfo
+	switch {
+	case r.URL.Query().Get("pr") != "":
+		number, err := strconv.Atoi(r.URL.Query().Get("pr"))
+		if err != nil || number <= 0 {
+			writeReachError(w, http.StatusBadRequest, "invalid pr parameter")
+			return
+		}
+		pr, err := src.MergedPR(ctx, number)
+		if err != nil {
+			s.logger.Warn("reach: PR fetch failed", "pr", number, "error", err)
+			writeReachError(w, http.StatusBadGateway, fmt.Sprintf("fetching PR %d: %v", number, err))
+			return
+		}
+		prs = []reach.PRInfo{pr}
+	default:
+		limit := defaultReachRecentPRs
+		if raw := r.URL.Query().Get("recent"); raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil || parsed <= 0 || parsed > maxReachRecentPRs {
+				writeReachError(w, http.StatusBadRequest,
+					fmt.Sprintf("invalid recent parameter (1..%d)", maxReachRecentPRs))
+				return
+			}
+			limit = parsed
+		}
+		recent, err := src.RecentMergedPRs(ctx, limit)
+		if err != nil {
+			s.logger.Warn("reach: recent-PRs fetch failed", "error", err)
+			writeReachError(w, http.StatusBadGateway, fmt.Sprintf("listing recent merged PRs: %v", err))
+			return
+		}
+		prs = recent
+	}
+
+	reports := reporter.LatestReach()
+	deployed := reach.DeployedCommits(reports)
+
+	// D4 window assignment over the WHOLE queried set, so co-deployed PRs
+	// label each other. Ancestry failure aborts: partial windows would
+	// silently mis-attribute shared reach.
+	windows, err := reach.AssignWindows(deployed, prs, s.reachAncestry)
+	if err != nil {
+		s.logger.Warn("reach: window assignment failed", "error", err)
+		writeReachError(w, http.StatusBadGateway, fmt.Sprintf("resolving deploy windows: %v", err))
+		return
+	}
+
+	analyzer := &reach.Analyzer{Ancestry: s.reachAncestry, Reporter: reporter}
+	resp := reachResponse{
+		GeneratedAt:     time.Now().UTC(),
+		HivesReporting:  len(reports),
+		DeployedCommits: deployed,
+		Reports:         make([]reach.PRReachReport, 0, len(prs)),
+	}
+	for _, pr := range prs {
+		report, err := analyzer.Analyze(pr)
+		if err != nil {
+			s.logger.Warn("reach: analysis failed", "pr", pr.Number, "error", err)
+			writeReachError(w, http.StatusBadGateway, fmt.Sprintf("analyzing PR %d: %v", pr.Number, err))
+			return
+		}
+		if assignment, ok := windows[pr.Number]; ok {
+			report.DeployWindow = assignment.DeployedCommit
+			report.SharedWith = assignment.SharedWith
+		}
+		resp.Reports = append(resp.Reports, report)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/src/pkg/hub/reach_api_test.go
+++ b/src/pkg/hub/reach_api_test.go
@@ -1,0 +1,269 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/reach"
+)
+
+// fakeReachPRSource is an in-memory reach.PRSource.
+type fakeReachPRSource struct {
+	prs map[int]reach.PRInfo
+	err error
+}
+
+func (f *fakeReachPRSource) MergedPR(_ context.Context, number int) (reach.PRInfo, error) {
+	if f.err != nil {
+		return reach.PRInfo{}, f.err
+	}
+	pr, ok := f.prs[number]
+	if !ok {
+		return reach.PRInfo{}, fmt.Errorf("PR %d is not merged", number)
+	}
+	return pr, nil
+}
+
+func (f *fakeReachPRSource) RecentMergedPRs(_ context.Context, limit int) ([]reach.PRInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	var out []reach.PRInfo
+	for _, pr := range f.prs {
+		if len(out) >= limit {
+			break
+		}
+		out = append(out, pr)
+	}
+	return out, nil
+}
+
+// fakeReachAncestry answers from an explicit containment table;
+// self-ancestry implied.
+type fakeReachAncestry struct{ pairs map[[2]string]bool }
+
+func (f *fakeReachAncestry) IsAncestor(ancestor, descendant string) (bool, error) {
+	if ancestor == descendant {
+		return true, nil
+	}
+	return f.pairs[[2]string{ancestor, descendant}], nil
+}
+
+// TestReachEndpointRequiresAdmin: an unauthenticated GET /api/reach must be
+// refused by the SAME gate, with the SAME failure, as the neighboring
+// protected fleet-status route (GET /api/saas/cluster-health) — and it must
+// leak no reach data even when a data source IS configured. If the
+// requireAdmin wrapper were removed from the route registration, the request
+// would reach handleReach and answer 200 with reach data, so every assertion
+// below fails (verified by mutating the registration during development).
+func TestReachEndpointRequiresAdmin(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	// Data IS available — the gate, not a missing dependency, must refuse.
+	mergedAt := time.Now().Add(-48 * time.Hour)
+	srv.reachPRSource = &fakeReachPRSource{prs: map[int]reach.PRInfo{
+		3994: {Number: 3994, MergeCommit: "cafe123", MergedAt: mergedAt, Files: []string{"v2/pkg/hub/saas.go"}},
+	}}
+	srv.reachReporter = &reach.StubReachReporter{Reports: map[string][]reach.ComponentReach{
+		"hive-secret": {{Component: "hub", Commit: "beef456", SpansTotal: 5, FirstSeen: mergedAt.Add(time.Hour)}},
+	}}
+	srv.reachAncestry = &fakeReachAncestry{pairs: map[[2]string]bool{{"cafe123", "beef456"}: true}}
+
+	get := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", path, nil) // GET is CSRF-safe; no cookie, no bearer
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		return w
+	}
+
+	reachResp := get("/api/reach?pr=3994")
+	neighborResp := get("/api/saas/cluster-health")
+
+	if reachResp.Code != http.StatusForbidden {
+		t.Fatalf("unauthenticated /api/reach: got %d, want %d", reachResp.Code, http.StatusForbidden)
+	}
+	// EXACT parity with the neighboring requireAdmin route: same status,
+	// same body.
+	if reachResp.Code != neighborResp.Code || reachResp.Body.String() != neighborResp.Body.String() {
+		t.Errorf("auth failure differs from neighboring admin route:\n /api/reach: %d %q\n cluster-health: %d %q",
+			reachResp.Code, reachResp.Body.String(), neighborResp.Code, neighborResp.Body.String())
+	}
+	// And no data escaped around the gate.
+	for _, marker := range []string{"reach_hives", "generated_at", "hive-secret", "cafe123"} {
+		if strings.Contains(reachResp.Body.String(), marker) {
+			t.Errorf("unauthenticated response leaked reach data (%q): %s", marker, reachResp.Body.String())
+		}
+	}
+}
+
+// TestHandleReachNoSource: with no GitHub PR source wired (hub without
+// credentials), the handler reports 503 — never fabricated data.
+func TestHandleReachNoSource(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	req := httptest.NewRequest("GET", "/api/reach", nil)
+	w := httptest.NewRecorder()
+	srv.handleReach(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("got %d, want 503; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleReachBadParams: malformed queries are 400s, not upstream calls.
+func TestHandleReachBadParams(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.reachPRSource = &fakeReachPRSource{err: errors.New("must not be called")}
+	for _, q := range []string{"?pr=abc", "?pr=-1", "?recent=0", "?recent=99999", "?recent=x"} {
+		req := httptest.NewRequest("GET", "/api/reach"+q, nil)
+		w := httptest.NewRecorder()
+		srv.handleReach(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: got %d, want 400; body=%s", q, w.Code, w.Body.String())
+		}
+	}
+}
+
+// TestHandleReachSinglePR exercises the full join through the handler: D3
+// attribution with coverage, ancestry-gated reach, first-execution latency,
+// and the D4 window label derived from what the fleet reports running.
+func TestHandleReachSinglePR(t *testing.T) {
+	mergedAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	firstRun := mergedAt.Add(90 * time.Minute)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.reachPRSource = &fakeReachPRSource{prs: map[int]reach.PRInfo{
+		3994: {
+			Number:      3994,
+			MergeCommit: "cafe123",
+			MergedAt:    mergedAt,
+			Files:       []string{"v2/pkg/hub/saas.go", "v2/docs/design/pr-reach-telemetry.md"},
+		},
+	}}
+	srv.reachReporter = &reach.StubReachReporter{Reports: map[string][]reach.ComponentReach{
+		// Runs a build containing the PR and executed the touched component.
+		"hive-a": {{Component: "hub", Commit: "beef456", SpansTotal: 7, FirstSeen: firstRun, LastSeen: firstRun}},
+		// Still on a pre-PR build: contributes a deploy window, not reach.
+		"hive-b": {{Component: "hub", Commit: "old0001", SpansTotal: 9, FirstSeen: mergedAt.Add(-time.Hour), LastSeen: firstRun}},
+	}}
+	srv.reachAncestry = &fakeReachAncestry{pairs: map[[2]string]bool{
+		{"cafe123", "beef456"}: true,
+	}}
+
+	req := httptest.NewRequest("GET", "/api/reach?pr=3994", nil)
+	w := httptest.NewRecorder()
+	srv.handleReach(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		HivesReporting  int                   `json:"hives_reporting"`
+		DeployedCommits []string              `json:"deployed_commits"`
+		Reports         []reach.PRReachReport `json:"reports"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, w.Body.String())
+	}
+	if resp.HivesReporting != 2 {
+		t.Errorf("HivesReporting = %d, want 2", resp.HivesReporting)
+	}
+	if len(resp.Reports) != 1 {
+		t.Fatalf("Reports = %d, want 1", len(resp.Reports))
+	}
+	report := resp.Reports[0]
+	if got, want := report.ReachHives, []string{"hive-a"}; len(got) != 1 || got[0] != want[0] {
+		t.Errorf("ReachHives = %v, want %v", got, want)
+	}
+	if !report.Deployed {
+		t.Error("Deployed = false, want true")
+	}
+	// D3: coverage rides along, unattributable share intact (1 of 2 files).
+	if report.Attribution.Coverage != 0.5 {
+		t.Errorf("Coverage = %v, want 0.5", report.Attribution.Coverage)
+	}
+	if len(report.Attribution.UnattributableFiles) != 1 {
+		t.Errorf("UnattributableFiles = %v, want the docs file", report.Attribution.UnattributableFiles)
+	}
+	// D4: window = the deployed commit that shipped the PR.
+	if report.DeployWindow != "beef456" {
+		t.Errorf("DeployWindow = %q, want %q", report.DeployWindow, "beef456")
+	}
+	if report.FirstExecutionLatencySeconds == nil || *report.FirstExecutionLatencySeconds != (90*time.Minute).Seconds() {
+		t.Errorf("FirstExecutionLatencySeconds = %v, want %v", report.FirstExecutionLatencySeconds, (90 * time.Minute).Seconds())
+	}
+}
+
+// TestCompareAncestry pins the compare-API adapter to commit_order.go's
+// exact semantics ("ahead"/"identical" = contained), its shared permanent
+// cache, and its errors-are-not-cached discipline.
+func TestCompareAncestry(t *testing.T) {
+	anc := compareAncestry{logger: slog.Default()}
+
+	// Stub the fetcher under commitOrderMu, per its contract.
+	calls := 0
+	commitOrderMu.Lock()
+	origFetch := fetchCommitCompareStatus
+	origCache := commitOrderCache
+	commitOrderCache = map[commitOrderKey]bool{}
+	fetchCommitCompareStatus = func(base, head string, _ *slog.Logger) (string, error) {
+		calls++
+		switch base + ".." + head {
+		case "aaaaaaa..bbbbbbb":
+			return "ahead", nil
+		case "bbbbbbb..aaaaaaa":
+			return "behind", nil
+		case "ccccccc..ddddddd":
+			return "", errors.New("transient")
+		}
+		return "diverged", nil
+	}
+	commitOrderMu.Unlock()
+	defer func() {
+		commitOrderMu.Lock()
+		fetchCommitCompareStatus = origFetch
+		commitOrderCache = origCache
+		commitOrderMu.Unlock()
+	}()
+
+	if got, err := anc.IsAncestor("aaaaaaa", "bbbbbbb"); err != nil || !got {
+		t.Errorf("IsAncestor(ahead) = %v, %v; want true, nil", got, err)
+	}
+	if got, err := anc.IsAncestor("bbbbbbb", "aaaaaaa"); err != nil || got {
+		t.Errorf("IsAncestor(behind) = %v, %v; want false, nil", got, err)
+	}
+	// Same commit needs no API call.
+	preCalls := calls
+	if got, err := anc.IsAncestor("aaaaaaa", "aaaaaaa"); err != nil || !got {
+		t.Errorf("IsAncestor(self) = %v, %v; want true, nil", got, err)
+	}
+	if calls != preCalls {
+		t.Errorf("self-comparison hit the API")
+	}
+	// Cached: repeating the first query performs no new fetch.
+	preCalls = calls
+	if got, _ := anc.IsAncestor("aaaaaaa", "bbbbbbb"); !got {
+		t.Error("cached answer changed")
+	}
+	if calls != preCalls {
+		t.Error("cached pair re-fetched")
+	}
+	// Errors surface and are NOT cached: a retry fetches again.
+	if _, err := anc.IsAncestor("ccccccc", "ddddddd"); err == nil {
+		t.Error("want error from failing fetch")
+	}
+	preCalls = calls
+	anc.IsAncestor("ccccccc", "ddddddd")
+	if calls != preCalls+1 {
+		t.Error("failed pair was cached instead of retried")
+	}
+	// Empty input is an error, never an answer.
+	if _, err := anc.IsAncestor("", "bbbbbbb"); err == nil {
+		t.Error("empty ancestor: want error")
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -532,6 +532,11 @@ func (s *HubServer) registerSaaSRoutes() {
 	// state (assigned && !claim_delivered) inside the handler.
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-assignment", s.requireAdmin(s.handleResetAssignment))
 	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
+	// PR reach telemetry (#3994): the read-only join of merged PRs against
+	// the commits/components the fleet reports actually running. The payload
+	// names hives fleet-wide — the same exposure class as cluster-health
+	// directly above, so the same requireAdmin gate.
+	s.mux.HandleFunc("GET /api/reach", s.requireAdmin(s.handleReach))
 	// Acknowledging a fleet alert is an operator action on the operator's own
 	// view, so it is admin-only (see alerts.go).
 	s.mux.HandleFunc("POST /api/saas/admin/alert-ack", s.requireAdmin(s.handleAlertAck))

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kubestellar/hive/pkg/auth"
 	"github.com/kubestellar/hive/pkg/openrouter"
+	"github.com/kubestellar/hive/pkg/reach"
 	"github.com/kubestellar/hive/pkg/tracing"
 )
 
@@ -1077,6 +1078,19 @@ type HubServer struct {
 	// owning account login. Nil means use the fleet App key. Tests replace it
 	// with a fake API.
 	githubInstallationAccount func(context.Context, int64) (string, error)
+
+	// reachReporter / reachPRSource / reachAncestry are the three injected
+	// dependencies of the read-only /api/reach endpoint (#3994, phase 2b of
+	// #3973). The reporter defaults to reach.StubReachReporter until phase
+	// 2a's heartbeat-fed store lands (its wiring is a one-line
+	// SetReachReporter call); the PR source is wired from runHub when GitHub
+	// credentials exist and the handler answers 503 while it is nil; the
+	// ancestry resolver defaults to the compare-API adapter over the same
+	// cache commit_order.go uses. Set before Start, read-only afterwards —
+	// see reach_api.go.
+	reachReporter reach.ReachReporter
+	reachPRSource reach.PRSource
+	reachAncestry reach.Ancestry
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.
@@ -1214,6 +1228,12 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		alerts:                  newAlertState(),
 		revokedSessions:         newRevokedSessions(),
 		urlHealth:               newURLHealthState(),
+		// /api/reach dependencies (#3994): the stub reporter answers an
+		// empty fleet until phase 2a's store is wired via SetReachReporter;
+		// the ancestry backend defaults to the compare-API adapter over
+		// commit_order.go's cache (no repo clone ships in the hub image).
+		reachReporter: &reach.StubReachReporter{},
+		reachAncestry: newReachAncestry(logger),
 	}
 
 	// Restore any persisted rotation BEFORE anything mints or verifies. A hub

--- a/src/pkg/reach/ancestry.go
+++ b/src/pkg/reach/ancestry.go
@@ -1,0 +1,97 @@
+package reach
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Ancestry answers the one immutable question the reach join needs (#3994):
+// is `descendant` the same commit as, or a descendant of, `ancestor`? A hive
+// counts toward a PR's reach only when the commit it reports RUNNING contains
+// the PR's merge commit — the anchoring rule of #3973 ("merged is not
+// deployed", see the #3816 postmortem in the design doc).
+//
+// It is an interface so the join logic tests against an in-memory fake and
+// the hub picks the real implementation at wiring time.
+type Ancestry interface {
+	IsAncestor(ancestor, descendant string) (bool, error)
+}
+
+// GitAncestry resolves ancestry against a local git clone (per the epic's
+// resolved open question: the hub's repo clone provides the commit graph)
+// using the plumbing command built for exactly this test:
+//
+//	git -C <dir> merge-base --is-ancestor <ancestor> <descendant>
+//
+// Exit status 0 means ancestor is an ancestor of (or equal to) descendant;
+// exit status 1 means it is not; anything else is an error (unknown SHA,
+// shallow clone missing history, not a repo).
+//
+// Ancestry is immutable, so definitive answers are cached forever; the cache
+// is bounded the same way commitOrderCache in pkg/hub is — dropped wholesale
+// on overflow rather than LRU'd, because a re-resolve costs one local git
+// invocation.
+type GitAncestry struct {
+	// RepoDir is the path of the hub's repo clone. The clone must have real
+	// history (not --depth 1) for the commits being compared.
+	RepoDir string
+
+	mu    sync.Mutex
+	cache map[[2]string]bool
+}
+
+// gitAncestryCacheMax bounds the resolved-pair cache. Spokes report the
+// commit SHAs being compared, so the key space is externally influenced and
+// must not grow without bound; see commitOrderCacheMax in pkg/hub for the
+// same reasoning.
+const gitAncestryCacheMax = 4096
+
+// NewGitAncestry returns an Ancestry backed by the git clone at repoDir.
+func NewGitAncestry(repoDir string) *GitAncestry {
+	return &GitAncestry{RepoDir: repoDir, cache: map[[2]string]bool{}}
+}
+
+// IsAncestor reports whether ancestor is an ancestor of (or the same commit
+// as) descendant, per `git merge-base --is-ancestor`. Empty inputs are an
+// error: an unknown commit must never silently read as reached.
+func (g *GitAncestry) IsAncestor(ancestor, descendant string) (bool, error) {
+	if ancestor == "" || descendant == "" {
+		return false, fmt.Errorf("ancestry: empty commit (ancestor=%q descendant=%q)", ancestor, descendant)
+	}
+	key := [2]string{ancestor, descendant}
+
+	g.mu.Lock()
+	if g.cache == nil {
+		g.cache = map[[2]string]bool{}
+	}
+	if ok, hit := g.cache[key]; hit {
+		g.mu.Unlock()
+		return ok, nil
+	}
+	g.mu.Unlock()
+
+	// merge-base --is-ancestor communicates its answer via exit status:
+	// 0 = yes, 1 = no, anything else = real failure.
+	cmd := exec.Command("git", "-C", g.RepoDir, "merge-base", "--is-ancestor", ancestor, descendant)
+	out, err := cmd.CombinedOutput()
+	var answer bool
+	switch {
+	case err == nil:
+		answer = true
+	case cmd.ProcessState != nil && cmd.ProcessState.ExitCode() == 1:
+		answer = false
+	default:
+		return false, fmt.Errorf("git merge-base --is-ancestor %s %s: %w (%s)",
+			ancestor, descendant, err, strings.TrimSpace(string(out)))
+	}
+
+	g.mu.Lock()
+	if len(g.cache) >= gitAncestryCacheMax {
+		g.cache = map[[2]string]bool{}
+	}
+	g.cache[key] = answer
+	g.mu.Unlock()
+	return answer, nil
+}

--- a/src/pkg/reach/ancestry_test.go
+++ b/src/pkg/reach/ancestry_test.go
@@ -1,0 +1,105 @@
+package reach
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitRun runs one git command against dir and fails the test on error —
+// the fixture-repo pattern pkg/policies' watcher_git_test.go uses.
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %s %v", args, out, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitCommit writes a file and commits it, returning the new commit SHA.
+func gitCommit(t *testing.T, dir, file, content, msg string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", file, err)
+	}
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", msg)
+	return gitRun(t, dir, "rev-parse", "HEAD")
+}
+
+// newFixtureRepo builds a real repo in t.TempDir() with this graph:
+//
+//	c1 — c2 — c3          (main line: c3 descends from c2 descends from c1)
+//	  \
+//	   side               (side branch off c1: NOT an ancestor of c3)
+//
+// and returns the four SHAs.
+func newFixtureRepo(t *testing.T) (dir, c1, c2, c3, side string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+	dir = t.TempDir()
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %s %v", out, err)
+	}
+	gitRun(t, dir, "config", "user.email", "test@test.com")
+	gitRun(t, dir, "config", "user.name", "test")
+
+	c1 = gitCommit(t, dir, "a.txt", "one", "c1")
+	c2 = gitCommit(t, dir, "a.txt", "two", "c2")
+	c3 = gitCommit(t, dir, "a.txt", "three", "c3")
+
+	gitRun(t, dir, "checkout", "-b", "side", c1)
+	side = gitCommit(t, dir, "b.txt", "side", "side")
+	return dir, c1, c2, c3, side
+}
+
+// TestGitAncestry exercises the ancestry join's primitive against a REAL
+// commit graph: descendants qualify, ancestors and diverged branches do not,
+// a commit is its own ancestor, and unknown SHAs are errors — never a
+// silent false/true.
+func TestGitAncestry(t *testing.T) {
+	dir, c1, c2, c3, side := newFixtureRepo(t)
+	anc := NewGitAncestry(dir)
+
+	cases := []struct {
+		name                 string
+		ancestor, descendant string
+		want                 bool
+	}{
+		{"direct parent", c2, c3, true},
+		{"grandparent", c1, c3, true},
+		{"self", c2, c2, true},
+		{"reversed order", c3, c1, false},
+		{"diverged branch", c2, side, false},
+		{"branch base still counts", c1, side, true},
+	}
+	for _, tc := range cases {
+		got, err := anc.IsAncestor(tc.ancestor, tc.descendant)
+		if err != nil {
+			t.Fatalf("%s: IsAncestor: %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s: IsAncestor = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+
+	// Cached second call must agree (answers are immutable).
+	again, err := anc.IsAncestor(c1, c3)
+	if err != nil || !again {
+		t.Errorf("cached IsAncestor(c1,c3) = %v, %v; want true, nil", again, err)
+	}
+
+	// Unknown SHA and empty input are ERRORS, not answers.
+	if _, err := anc.IsAncestor("0000000000000000000000000000000000000000", c3); err == nil {
+		t.Error("unknown SHA: want error, got nil")
+	}
+	if _, err := anc.IsAncestor("", c3); err == nil {
+		t.Error("empty ancestor: want error, got nil")
+	}
+}

--- a/src/pkg/reach/mapping.go
+++ b/src/pkg/reach/mapping.go
@@ -1,0 +1,123 @@
+// Package reach implements phase 2b of the PR reach telemetry epic (#3973,
+// issue #3994): the PR→component mapping (design decision D3), deploy-window
+// co-attribution (D4), the ancestry join between merged PRs and the commits
+// hives actually report running, and the read-only /api/reach data model.
+//
+// The package is deliberately independent of phase 2a (#3993): everything the
+// join needs from the fleet arrives through the narrow ReachReporter
+// interface (see reporter.go), so this package compiles and tests green
+// before the spoke-side counters merge.
+package reach
+
+import (
+	"sort"
+	"strings"
+)
+
+// ComponentUnattributable is the honest bucket of design decision D3
+// (#3973/#3994): changed files that map to no instrumented component
+// (workflows, deploy manifests, docs, scripts, bin, ...) land here and are
+// ALWAYS reported as part of the per-PR attribution coverage — the
+// unattributable share is never silently dropped.
+const ComponentUnattributable = "unattributable"
+
+// ComponentMain is the component name for the hub/spoke entrypoint. Files
+// under src/cmd/hive/ belong to the binary's wiring rather than to a single
+// package, and phase 1 span naming has no per-file granularity there, so D3
+// maps the whole subtree to one "main" component.
+const ComponentMain = "main"
+
+// ComponentProxy is the component name for the MITM proxy subtree
+// (src/proxy/), which is not laid out under src/pkg/ but is instrumented.
+const ComponentProxy = "proxy"
+
+// Path prefixes for the D3 mapping rules (#3994). These are repo-root
+// relative paths exactly as the GitHub "list PR files" API returns them.
+// #3996 renamed the v2/ source tree to src/, but a merged PR's file list is
+// immutable history: PRs merged before the rename report v2/... paths from
+// the GitHub API forever, so each rule keeps its pre-rename legacy alias —
+// otherwise every pre-rename PR would collapse into the unattributable
+// bucket.
+const (
+	pkgPrefix         = "src/pkg/"
+	legacyPkgPrefix   = "v2/pkg/"
+	mainPrefix        = "src/cmd/hive/"
+	legacyMainPrefix  = "v2/cmd/hive/"
+	proxyPrefix       = "src/proxy/"
+	legacyProxyPrefix = "v2/proxy/"
+)
+
+// MapFile maps one changed-file path (repo-root relative, forward slashes —
+// the form the GitHub PR files API returns) to its component per D3:
+//
+//	src/pkg/<name>/**  → <name>
+//	src/cmd/hive/**    → "main"
+//	src/proxy/**       → "proxy"
+//	everything else    → ComponentUnattributable
+//
+// with the pre-#3996 v2/... spelling of each rule accepted as a legacy alias
+// (see the prefix constants above).
+//
+// A file directly under src/pkg/ (no package subdirectory) has no component
+// and is unattributable.
+func MapFile(path string) string {
+	switch {
+	case strings.HasPrefix(path, mainPrefix), strings.HasPrefix(path, legacyMainPrefix):
+		return ComponentMain
+	case strings.HasPrefix(path, proxyPrefix), strings.HasPrefix(path, legacyProxyPrefix):
+		return ComponentProxy
+	case strings.HasPrefix(path, pkgPrefix), strings.HasPrefix(path, legacyPkgPrefix):
+		rest := strings.TrimPrefix(strings.TrimPrefix(path, pkgPrefix), legacyPkgPrefix)
+		name, _, found := strings.Cut(rest, "/")
+		if !found || name == "" {
+			// A file directly under src/pkg/ belongs to no package.
+			return ComponentUnattributable
+		}
+		return name
+	default:
+		return ComponentUnattributable
+	}
+}
+
+// Attribution is the D3 result for one PR's changed files. Coverage is the
+// fraction of changed files that mapped to a component; the unattributable
+// remainder is carried explicitly (files listed) so no caller can drop it
+// without doing so on purpose.
+type Attribution struct {
+	// Components is the sorted, de-duplicated list of attributable
+	// components the PR touched. ComponentUnattributable never appears here.
+	Components []string `json:"components"`
+	// UnattributableFiles lists the changed files that mapped to no
+	// component, verbatim.
+	UnattributableFiles []string `json:"unattributable_files,omitempty"`
+	// FilesTotal / FilesAttributed give the raw counts behind Coverage.
+	FilesTotal      int `json:"files_total"`
+	FilesAttributed int `json:"files_attributed"`
+	// Coverage = FilesAttributed / FilesTotal (0 when the PR changed no
+	// files). Reported per PR, always — see D3 in #3973.
+	Coverage float64 `json:"coverage"`
+}
+
+// Attribute maps a PR's changed files to components and computes attribution
+// coverage per D3.
+func Attribute(files []string) Attribution {
+	attr := Attribution{FilesTotal: len(files)}
+	seen := map[string]bool{}
+	for _, f := range files {
+		component := MapFile(f)
+		if component == ComponentUnattributable {
+			attr.UnattributableFiles = append(attr.UnattributableFiles, f)
+			continue
+		}
+		attr.FilesAttributed++
+		if !seen[component] {
+			seen[component] = true
+			attr.Components = append(attr.Components, component)
+		}
+	}
+	sort.Strings(attr.Components)
+	if attr.FilesTotal > 0 {
+		attr.Coverage = float64(attr.FilesAttributed) / float64(attr.FilesTotal)
+	}
+	return attr
+}

--- a/src/pkg/reach/mapping_test.go
+++ b/src/pkg/reach/mapping_test.go
@@ -1,0 +1,114 @@
+package reach
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+// TestMapFile pins the D3 mapping rules of #3994 exactly: src/pkg/<name>/**
+// → <name>, src/cmd/hive/** → main, src/proxy/** → proxy, everything else →
+// the unattributable bucket — plus the pre-#3996 v2/... legacy alias of each
+// rule, because merged-PR file lists are immutable history.
+func TestMapFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"src/pkg/governor/eval.go", "governor"},
+		{"src/pkg/hub/saas.go", "hub"},
+		{"src/pkg/tracing/tracing.go", "tracing"},
+		{"src/pkg/reach/deeply/nested/file.go", "reach"},
+		{"src/cmd/hive/main.go", ComponentMain},
+		{"src/cmd/hive/sub/dir/file.go", ComponentMain},
+		{"src/proxy/mitm.go", ComponentProxy},
+		{"src/proxy/certs/ca.go", ComponentProxy},
+		// Legacy pre-#3996 spellings: PRs merged before the v2/→src/ rename
+		// report these paths from the GitHub API forever.
+		{"v2/pkg/governor/eval.go", "governor"},
+		{"v2/pkg/hub/saas.go", "hub"},
+		{"v2/pkg/reach/deeply/nested/file.go", "reach"},
+		{"v2/cmd/hive/main.go", ComponentMain},
+		{"v2/cmd/hive/sub/dir/file.go", ComponentMain},
+		{"v2/proxy/mitm.go", ComponentProxy},
+		{"v2/proxy/certs/ca.go", ComponentProxy},
+		// Unattributable: workflows, deploy, docs, scripts, bin, misc.
+		{".github/workflows/ci.yml", ComponentUnattributable},
+		{"deploy/hub/deployment.yaml", ComponentUnattributable},
+		{"src/docs/design/pr-reach-telemetry.md", ComponentUnattributable},
+		{"v2/docs/design/pr-reach-telemetry.md", ComponentUnattributable},
+		{"scripts/release.sh", ComponentUnattributable},
+		{"bin/agent-launch.sh", ComponentUnattributable},
+		{"README.md", ComponentUnattributable},
+		{"Dockerfile", ComponentUnattributable},
+		// A file directly under src/pkg/ (or legacy v2/pkg/) belongs to no
+		// package.
+		{"src/pkg/orphan.go", ComponentUnattributable},
+		{"v2/pkg/orphan.go", ComponentUnattributable},
+		// Prefix traps: names that merely start like the mapped prefixes.
+		{"src/pkgnot/file.go", ComponentUnattributable},
+		{"src/cmd/hivectl/main.go", ComponentUnattributable},
+		{"src/proxyfoo/file.go", ComponentUnattributable},
+		{"v2/pkgnot/file.go", ComponentUnattributable},
+		{"v2/cmd/hivectl/main.go", ComponentUnattributable},
+		{"v2/proxyfoo/file.go", ComponentUnattributable},
+		{"other/src/pkg/hub/saas.go", ComponentUnattributable},
+		{"other/v2/pkg/hub/saas.go", ComponentUnattributable},
+	}
+	for _, tc := range cases {
+		if got := MapFile(tc.path); got != tc.want {
+			t.Errorf("MapFile(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestAttribute covers de-duplication, sorting, the explicit unattributable
+// share, and the coverage fraction — the D3 requirement that the
+// unattributable share is never silently dropped.
+func TestAttribute(t *testing.T) {
+	files := []string{
+		"src/pkg/hub/saas.go",
+		"src/pkg/hub/heartbeat.go", // duplicate component
+		"src/pkg/tracing/tracing.go",
+		"src/cmd/hive/main.go",
+		".github/workflows/ci.yml",
+		"deploy/hub/deployment.yaml",
+	}
+	attr := Attribute(files)
+
+	if want := []string{"hub", ComponentMain, "tracing"}; !reflect.DeepEqual(attr.Components, want) {
+		t.Errorf("Components = %v, want %v", attr.Components, want)
+	}
+	if want := []string{".github/workflows/ci.yml", "deploy/hub/deployment.yaml"}; !reflect.DeepEqual(attr.UnattributableFiles, want) {
+		t.Errorf("UnattributableFiles = %v, want %v", attr.UnattributableFiles, want)
+	}
+	if attr.FilesTotal != 6 || attr.FilesAttributed != 4 {
+		t.Errorf("FilesTotal=%d FilesAttributed=%d, want 6 and 4", attr.FilesTotal, attr.FilesAttributed)
+	}
+	if want := 4.0 / 6.0; math.Abs(attr.Coverage-want) > 1e-9 {
+		t.Errorf("Coverage = %v, want %v", attr.Coverage, want)
+	}
+}
+
+// TestAttributeFullyUnattributable: a docs-only PR must report zero coverage
+// with every file accounted for — not an empty result.
+func TestAttributeFullyUnattributable(t *testing.T) {
+	attr := Attribute([]string{"README.md", "docs/guide.md"})
+	if len(attr.Components) != 0 {
+		t.Errorf("Components = %v, want none", attr.Components)
+	}
+	if len(attr.UnattributableFiles) != 2 {
+		t.Errorf("UnattributableFiles = %v, want both files", attr.UnattributableFiles)
+	}
+	if attr.Coverage != 0 {
+		t.Errorf("Coverage = %v, want 0", attr.Coverage)
+	}
+}
+
+// TestAttributeEmpty: no changed files → zero coverage, no divide-by-zero.
+func TestAttributeEmpty(t *testing.T) {
+	attr := Attribute(nil)
+	if attr.Coverage != 0 || attr.FilesTotal != 0 || attr.FilesAttributed != 0 {
+		t.Errorf("Attribute(nil) = %+v, want zero-valued counts", attr)
+	}
+}

--- a/src/pkg/reach/metrics.go
+++ b/src/pkg/reach/metrics.go
@@ -1,0 +1,169 @@
+package reach
+
+import (
+	"os"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// DefaultNeverRanDays is how long after merge a deployed-but-unexecuted PR
+// waits before the never-ran flag raises (#3994). Three days gives every
+// heartbeat cadence in the fleet several full cycles to report a first
+// execution before the PR is called unused. Tunable via
+// NeverRanDaysEnvVar.
+const DefaultNeverRanDays = 3
+
+// NeverRanDaysEnvVar overrides DefaultNeverRanDays (integer days, > 0).
+const NeverRanDaysEnvVar = "HIVE_REACH_NEVER_RAN_DAYS"
+
+// NeverRanThreshold resolves the never-ran grace period from the
+// environment, falling back to DefaultNeverRanDays on absent/invalid values.
+func NeverRanThreshold() time.Duration {
+	days := DefaultNeverRanDays
+	if raw := os.Getenv(NeverRanDaysEnvVar); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			days = parsed
+		}
+	}
+	return time.Duration(days) * 24 * time.Hour
+}
+
+// PRReachReport is the per-PR output of the phase 2b join (#3994): D3
+// attribution with explicit coverage, D4 co-attribution labels, the
+// ancestry-joined reach metrics, first-execution latency and the never-ran
+// flag.
+type PRReachReport struct {
+	PR          int       `json:"pr"`
+	Title       string    `json:"title,omitempty"`
+	MergeCommit string    `json:"merge_commit"`
+	MergedAt    time.Time `json:"merged_at"`
+
+	// Attribution carries the components plus the honest unattributable
+	// share and coverage fraction (D3).
+	Attribution Attribution `json:"attribution"`
+
+	// DeployWindow / SharedWith are the D4 labels: the deployed commit that
+	// shipped this PR ("" = merged but not yet observed running anywhere)
+	// and the other PRs riding the same deploy. Reach and latency below are
+	// shared with those PRs by construction.
+	DeployWindow string `json:"deploy_window,omitempty"`
+	SharedWith   []int  `json:"shared_with,omitempty"`
+
+	// Deployed is true when at least one hive reports running a commit that
+	// contains this PR — regardless of whether its components executed.
+	Deployed bool `json:"deployed"`
+
+	// ReachHives / ReachCount: the distinct hives whose reported commit is a
+	// descendant of the merge commit AND whose report shows one of the PR's
+	// components executing (spans_total > 0) with first_seen after merge.
+	ReachHives []string `json:"reach_hives"`
+	ReachCount int      `json:"reach_count"`
+
+	// FirstExecution is the earliest qualifying first_seen across the
+	// fleet; FirstExecutionLatencySeconds is merge → that instant. Nil when
+	// nothing qualifying has executed yet.
+	FirstExecution               *time.Time `json:"first_execution,omitempty"`
+	FirstExecutionLatencySeconds *float64   `json:"first_execution_latency_seconds,omitempty"`
+
+	// NeverRan raises when the PR is merged AND deployed AND every
+	// attributable component still shows zero qualifying executions after
+	// the grace period — the category acceptance-rate cannot see (#3973).
+	// A PR with no attributable components (docs-only) never raises it.
+	NeverRan              bool `json:"never_ran"`
+	NeverRanThresholdDays int  `json:"never_ran_threshold_days"`
+}
+
+// Analyzer joins merged-PR facts against the fleet's reach reports. All
+// dependencies are injected: Ancestry (hub repo clone or a test fake),
+// Reporter (2a's store once merged; StubReachReporter until then), the
+// never-ran grace period, and the clock.
+type Analyzer struct {
+	Ancestry Ancestry
+	Reporter ReachReporter
+	// NeverRanAfter is the never-ran grace period; zero means
+	// NeverRanThreshold() (env-tunable default).
+	NeverRanAfter time.Duration
+	// Now is the clock; nil means time.Now. Injected for tests.
+	Now func() time.Time
+}
+
+// Analyze produces the reach report for one PR. The D4 window labels
+// (DeployWindow/SharedWith) are filled by the caller via AssignWindows over
+// the full PR set — a single PR in isolation cannot know its co-riders.
+func (a *Analyzer) Analyze(pr PRInfo) (PRReachReport, error) {
+	now := time.Now
+	if a.Now != nil {
+		now = a.Now
+	}
+	grace := a.NeverRanAfter
+	if grace == 0 {
+		grace = NeverRanThreshold()
+	}
+
+	report := PRReachReport{
+		PR:                    pr.Number,
+		Title:                 pr.Title,
+		MergeCommit:           pr.MergeCommit,
+		MergedAt:              pr.MergedAt,
+		Attribution:           Attribute(pr.Files),
+		ReachHives:            []string{},
+		NeverRanThresholdDays: int(grace / (24 * time.Hour)),
+	}
+
+	touched := map[string]bool{}
+	for _, c := range report.Attribution.Components {
+		touched[c] = true
+	}
+
+	var firstExecution *time.Time
+	for hiveID, entries := range a.Reporter.LatestReach() {
+		qualified := false
+		for _, entry := range entries {
+			if entry.Commit == "" {
+				continue
+			}
+			// Ancestry gate: the hive must be RUNNING a commit that
+			// contains the PR (anchoring rule, #3973/#3816).
+			contains, err := a.Ancestry.IsAncestor(pr.MergeCommit, entry.Commit)
+			if err != nil {
+				return PRReachReport{}, err
+			}
+			if !contains {
+				continue
+			}
+			report.Deployed = true
+			// Execution gate: one of the PR's components ran on that
+			// build, first observed after the merge.
+			if !touched[entry.Component] || entry.SpansTotal <= 0 || !entry.FirstSeen.After(pr.MergedAt) {
+				continue
+			}
+			qualified = true
+			if firstExecution == nil || entry.FirstSeen.Before(*firstExecution) {
+				t := entry.FirstSeen
+				firstExecution = &t
+			}
+		}
+		if qualified {
+			report.ReachHives = append(report.ReachHives, hiveID)
+		}
+	}
+	sort.Strings(report.ReachHives)
+	report.ReachCount = len(report.ReachHives)
+
+	if firstExecution != nil {
+		report.FirstExecution = firstExecution
+		latency := firstExecution.Sub(pr.MergedAt).Seconds()
+		report.FirstExecutionLatencySeconds = &latency
+	}
+
+	// Never-ran: merged, deployed, attributable — and still nothing
+	// qualifying executed after the grace period.
+	if report.Deployed &&
+		len(report.Attribution.Components) > 0 &&
+		report.ReachCount == 0 &&
+		now().Sub(pr.MergedAt) >= grace {
+		report.NeverRan = true
+	}
+	return report, nil
+}

--- a/src/pkg/reach/metrics_test.go
+++ b/src/pkg/reach/metrics_test.go
@@ -1,0 +1,190 @@
+package reach
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+var (
+	mergedAt = time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	// wellPastGrace is comfortably beyond the default 3-day never-ran
+	// grace period after mergedAt.
+	wellPastGrace = mergedAt.Add(10 * 24 * time.Hour)
+)
+
+// analyzer builds an Analyzer over a fake fleet and a frozen clock.
+func analyzer(reports map[string][]ComponentReach, anc Ancestry, now time.Time) *Analyzer {
+	return &Analyzer{
+		Ancestry: anc,
+		Reporter: &StubReachReporter{Reports: reports},
+		Now:      func() time.Time { return now },
+	}
+}
+
+// prHub is a PR touching only the hub component (v2/pkg/hub/**).
+var prHub = PRInfo{
+	Number:      3994,
+	MergeCommit: "merge1",
+	MergedAt:    mergedAt,
+	Files:       []string{"v2/pkg/hub/saas.go", "docs/notes.md"},
+}
+
+// TestAnalyzeReach: a hive counts only when its RUNNING commit contains the
+// merge commit AND a touched component executed (spans_total > 0) with
+// first_seen after the merge — the full ancestry join of #3994.
+func TestAnalyzeReach(t *testing.T) {
+	anc := &fakeAncestry{pairs: map[string]map[string]bool{
+		"merge1": {"deployed1": true}, // deployed1 contains the PR
+	}}
+	firstRun := mergedAt.Add(2 * time.Hour)
+	reports := map[string][]ComponentReach{
+		// Qualifies: descendant commit, touched component ran post-merge.
+		"hive-good": {{Component: "hub", Commit: "deployed1", SpansTotal: 12, FirstSeen: firstRun, LastSeen: firstRun}},
+		// Later first_seen: still reaches, but must not win the latency.
+		"hive-later": {{Component: "hub", Commit: "deployed1", SpansTotal: 3, FirstSeen: mergedAt.Add(6 * time.Hour), LastSeen: mergedAt.Add(7 * time.Hour)}},
+		// Running an OLD commit that does not contain the PR: excluded.
+		"hive-stale": {{Component: "hub", Commit: "olddeploy", SpansTotal: 99, FirstSeen: firstRun, LastSeen: firstRun}},
+		// Right commit, wrong component: excluded.
+		"hive-othercomp": {{Component: "governor", Commit: "deployed1", SpansTotal: 50, FirstSeen: firstRun, LastSeen: firstRun}},
+		// Right commit and component but zero executions: excluded.
+		"hive-zero": {{Component: "hub", Commit: "deployed1", SpansTotal: 0, FirstSeen: firstRun, LastSeen: firstRun}},
+		// first_seen BEFORE the merge (clock skew / stale counter file on a
+		// pre-merge build): excluded.
+		"hive-preexisting": {{Component: "hub", Commit: "deployed1", SpansTotal: 8, FirstSeen: mergedAt.Add(-time.Hour), LastSeen: firstRun}},
+	}
+
+	report, err := analyzer(reports, anc, mergedAt.Add(24*time.Hour)).Analyze(prHub)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	if want := []string{"hive-good", "hive-later"}; !reflect.DeepEqual(report.ReachHives, want) {
+		t.Errorf("ReachHives = %v, want %v", report.ReachHives, want)
+	}
+	if report.ReachCount != 2 {
+		t.Errorf("ReachCount = %d, want 2", report.ReachCount)
+	}
+	if !report.Deployed {
+		t.Error("Deployed = false, want true")
+	}
+	if report.FirstExecution == nil || !report.FirstExecution.Equal(firstRun) {
+		t.Errorf("FirstExecution = %v, want %v", report.FirstExecution, firstRun)
+	}
+	if report.FirstExecutionLatencySeconds == nil || *report.FirstExecutionLatencySeconds != (2*time.Hour).Seconds() {
+		t.Errorf("FirstExecutionLatencySeconds = %v, want %v", report.FirstExecutionLatencySeconds, (2 * time.Hour).Seconds())
+	}
+	if report.NeverRan {
+		t.Error("NeverRan = true for a PR that ran")
+	}
+	// D3: attribution coverage rides along on every report.
+	if want := 0.5; report.Attribution.Coverage != want {
+		t.Errorf("Attribution.Coverage = %v, want %v", report.Attribution.Coverage, want)
+	}
+}
+
+// TestAnalyzeNeverRan: merged + deployed + attributable + zero qualifying
+// executions past the grace period → the flag acceptance-rate cannot see.
+func TestAnalyzeNeverRan(t *testing.T) {
+	anc := &fakeAncestry{pairs: map[string]map[string]bool{
+		"merge1": {"deployed1": true},
+	}}
+	// The build containing the PR is running, but only OTHER components
+	// executed on it — the PR's code is deployed and unused.
+	reports := map[string][]ComponentReach{
+		"hive-a": {{Component: "governor", Commit: "deployed1", SpansTotal: 100, FirstSeen: mergedAt.Add(time.Hour), LastSeen: wellPastGrace}},
+	}
+
+	report, err := analyzer(reports, anc, wellPastGrace).Analyze(prHub)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if !report.Deployed {
+		t.Error("Deployed = false, want true")
+	}
+	if report.ReachCount != 0 {
+		t.Errorf("ReachCount = %d, want 0", report.ReachCount)
+	}
+	if !report.NeverRan {
+		t.Error("NeverRan = false, want true (deployed, attributable, unused, past grace)")
+	}
+	if report.NeverRanThresholdDays != DefaultNeverRanDays {
+		t.Errorf("NeverRanThresholdDays = %d, want %d", report.NeverRanThresholdDays, DefaultNeverRanDays)
+	}
+}
+
+// TestAnalyzeNeverRanSuppressed enumerates each condition that must HOLD
+// the flag: still inside grace, not deployed anywhere, or nothing
+// attributable to execute.
+func TestAnalyzeNeverRanSuppressed(t *testing.T) {
+	containing := &fakeAncestry{pairs: map[string]map[string]bool{
+		"merge1": {"deployed1": true},
+	}}
+	deployedNoRun := map[string][]ComponentReach{
+		"hive-a": {{Component: "governor", Commit: "deployed1", SpansTotal: 1, FirstSeen: mergedAt.Add(time.Hour), LastSeen: wellPastGrace}},
+	}
+
+	t.Run("inside grace period", func(t *testing.T) {
+		report, err := analyzer(deployedNoRun, containing, mergedAt.Add(24*time.Hour)).Analyze(prHub)
+		if err != nil {
+			t.Fatalf("Analyze: %v", err)
+		}
+		if report.NeverRan {
+			t.Error("NeverRan raised inside the grace period")
+		}
+	})
+
+	t.Run("merged but not deployed", func(t *testing.T) {
+		nothingContains := &fakeAncestry{pairs: map[string]map[string]bool{}}
+		report, err := analyzer(deployedNoRun, nothingContains, wellPastGrace).Analyze(prHub)
+		if err != nil {
+			t.Fatalf("Analyze: %v", err)
+		}
+		if report.Deployed {
+			t.Error("Deployed = true, want false")
+		}
+		if report.NeverRan {
+			t.Error("NeverRan raised for an undeployed PR — that is 'not deployed', a different failure")
+		}
+	})
+
+	t.Run("docs-only PR", func(t *testing.T) {
+		docsPR := PRInfo{Number: 1, MergeCommit: "merge1", MergedAt: mergedAt, Files: []string{"README.md"}}
+		report, err := analyzer(deployedNoRun, containing, wellPastGrace).Analyze(docsPR)
+		if err != nil {
+			t.Fatalf("Analyze: %v", err)
+		}
+		if report.NeverRan {
+			t.Error("NeverRan raised for a PR with no attributable components")
+		}
+	})
+}
+
+// TestNeverRanThresholdEnv: the grace period is env-tunable with a safe
+// fallback on garbage.
+func TestNeverRanThresholdEnv(t *testing.T) {
+	t.Setenv(NeverRanDaysEnvVar, "7")
+	if got, want := NeverRanThreshold(), 7*24*time.Hour; got != want {
+		t.Errorf("NeverRanThreshold = %v, want %v", got, want)
+	}
+	t.Setenv(NeverRanDaysEnvVar, "not-a-number")
+	if got, want := NeverRanThreshold(), DefaultNeverRanDays*24*time.Hour; got != want {
+		t.Errorf("NeverRanThreshold (invalid env) = %v, want %v", got, want)
+	}
+	t.Setenv(NeverRanDaysEnvVar, "-2")
+	if got, want := NeverRanThreshold(), DefaultNeverRanDays*24*time.Hour; got != want {
+		t.Errorf("NeverRanThreshold (negative env) = %v, want %v", got, want)
+	}
+}
+
+// TestAnalyzeEmptyFleet: the pre-2a state — StubReachReporter with no data
+// — yields zero reach and no never-ran flag (nothing is known deployed).
+func TestAnalyzeEmptyFleet(t *testing.T) {
+	report, err := analyzer(nil, &fakeAncestry{}, wellPastGrace).Analyze(prHub)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.ReachCount != 0 || report.Deployed || report.NeverRan {
+		t.Errorf("empty fleet: got %+v, want zero reach, not deployed, no flag", report)
+	}
+}

--- a/src/pkg/reach/reporter.go
+++ b/src/pkg/reach/reporter.go
@@ -1,0 +1,50 @@
+package reach
+
+import "time"
+
+// ComponentReach is one spoke-reported per-component execution record — the
+// shape phase 2a (#3993) persists on the hub from the heartbeat's
+// `component_reach` payload. Field names/JSON keys mirror the 2a contract:
+// {component, commit, spans_total, spans_error, first_seen, last_seen}.
+type ComponentReach struct {
+	// Component is the hive.component span-name prefix (phase 1, #3975).
+	Component string `json:"component"`
+	// Commit is the short SHA of the binary that was RUNNING when the spans
+	// were counted — the ldflags-injected value, never a tag or Deployment
+	// digest (anchoring rule, #3973/#3816).
+	Commit string `json:"commit"`
+	// SpansTotal / SpansError are cumulative-since-boot counts for the
+	// component on that commit.
+	SpansTotal int64 `json:"spans_total"`
+	SpansError int64 `json:"spans_error"`
+	// FirstSeen / LastSeen bracket the component's observed executions.
+	FirstSeen time.Time `json:"first_seen"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+// ReachReporter is the narrow seam between this package (phase 2b, #3994)
+// and the heartbeat-fed reach store phase 2a (#3993) builds. 2b is developed
+// in parallel with 2a, so everything here reads through this one method:
+// wiring the real store when 2a merges is a construction-site change only.
+type ReachReporter interface {
+	// LatestReach returns, per hive ID, the latest persisted component_reach
+	// report. Implementations return a snapshot the caller may read freely;
+	// hives that have never reported are simply absent.
+	LatestReach() map[string][]ComponentReach
+}
+
+// StubReachReporter is the placeholder implementation used until phase 2a
+// lands: it reports an empty fleet, so every PR legitimately shows zero
+// reach rather than fabricated data. It also serves as the test double.
+type StubReachReporter struct {
+	// Reports, when non-nil, is returned verbatim (tests populate it).
+	Reports map[string][]ComponentReach
+}
+
+// LatestReach implements ReachReporter.
+func (s *StubReachReporter) LatestReach() map[string][]ComponentReach {
+	if s == nil || s.Reports == nil {
+		return map[string][]ComponentReach{}
+	}
+	return s.Reports
+}

--- a/src/pkg/reach/source.go
+++ b/src/pkg/reach/source.go
@@ -1,0 +1,17 @@
+package reach
+
+import "context"
+
+// PRSource supplies the merged-PR facts the join consumes: number, merge
+// commit, merge time and changed files. The hub backs it with the existing
+// pkg/github client (cached — see pkg/github/pr_reach.go); tests use an
+// in-memory fake. Like ReachReporter, it exists so this package depends on
+// data shapes, not on the GitHub client.
+type PRSource interface {
+	// RecentMergedPRs returns up to limit recently merged PRs, newest merge
+	// first, with Files populated.
+	RecentMergedPRs(ctx context.Context, limit int) ([]PRInfo, error)
+	// MergedPR returns one merged PR with Files populated; it errors on a PR
+	// that is not merged.
+	MergedPR(ctx context.Context, number int) (PRInfo, error)
+}

--- a/src/pkg/reach/windows.go
+++ b/src/pkg/reach/windows.go
@@ -1,0 +1,111 @@
+package reach
+
+import (
+	"sort"
+	"time"
+)
+
+// PRInfo is the merged-PR input to the join: its number, merge commit, merge
+// time and changed files (from the hub's GitHub client).
+type PRInfo struct {
+	Number      int       `json:"number"`
+	Title       string    `json:"title,omitempty"`
+	MergeCommit string    `json:"merge_commit"`
+	MergedAt    time.Time `json:"merged_at"`
+	Files       []string  `json:"-"`
+}
+
+// WindowAssignment is the D4 (#3973/#3994) co-attribution result for one PR.
+// PRs whose merge commits land between the same two DEPLOYED commits ride
+// the same deploy and therefore share reach/latency/error results BY
+// CONSTRUCTION — the shared set is labeled, never hidden behind fake per-PR
+// precision.
+type WindowAssignment struct {
+	// DeployedCommit is the first deployed commit whose history contains the
+	// PR's merge commit — the commit that actually shipped the PR. Empty
+	// when no deployed commit contains the PR yet (merged, not deployed).
+	DeployedCommit string `json:"deployed_commit,omitempty"`
+	// SharedWith lists the OTHER PR numbers in the same deploy window,
+	// sorted ascending. Empty when the deploy was 1:1.
+	SharedWith []int `json:"shared_with,omitempty"`
+}
+
+// AssignWindows groups PRs into deploy windows. deployedOldestFirst is the
+// sequence of commits observed actually running in the fleet (the
+// digest-anchored deploy history — see DeployedCommits), oldest first. Each
+// PR is assigned to the EARLIEST deployed commit that contains its merge
+// commit; PRs assigned to the same deployed commit share a window.
+//
+// Ancestry errors abort the assignment: a partial answer would silently
+// mis-attribute reach across windows.
+func AssignWindows(deployedOldestFirst []string, prs []PRInfo, anc Ancestry) (map[int]WindowAssignment, error) {
+	// windowMembers collects PR numbers per closing deployed commit.
+	windowMembers := map[string][]int{}
+	assignments := make(map[int]WindowAssignment, len(prs))
+
+	for _, pr := range prs {
+		assigned := ""
+		for _, deployed := range deployedOldestFirst {
+			contained, err := anc.IsAncestor(pr.MergeCommit, deployed)
+			if err != nil {
+				return nil, err
+			}
+			if contained {
+				assigned = deployed
+				break
+			}
+		}
+		assignments[pr.Number] = WindowAssignment{DeployedCommit: assigned}
+		if assigned != "" {
+			windowMembers[assigned] = append(windowMembers[assigned], pr.Number)
+		}
+	}
+
+	// Second pass: label each deployed PR with its co-windowed peers.
+	for prNumber, assignment := range assignments {
+		if assignment.DeployedCommit == "" {
+			continue
+		}
+		var shared []int
+		for _, peer := range windowMembers[assignment.DeployedCommit] {
+			if peer != prNumber {
+				shared = append(shared, peer)
+			}
+		}
+		sort.Ints(shared)
+		assignment.SharedWith = shared
+		assignments[prNumber] = assignment
+	}
+	return assignments, nil
+}
+
+// DeployedCommits derives the digest-anchored deploy history from the
+// fleet's reach reports: the distinct commits hives have REPORTED RUNNING
+// (never tags or Deployment specs — the #3816 anchoring rule), ordered by
+// the earliest time each commit was first seen executing. This is the
+// deployedOldestFirst input to AssignWindows.
+func DeployedCommits(reports map[string][]ComponentReach) []string {
+	firstSeen := map[string]time.Time{}
+	for _, entries := range reports {
+		for _, e := range entries {
+			if e.Commit == "" {
+				continue
+			}
+			if t, ok := firstSeen[e.Commit]; !ok || e.FirstSeen.Before(t) {
+				firstSeen[e.Commit] = e.FirstSeen
+			}
+		}
+	}
+	commits := make([]string, 0, len(firstSeen))
+	for c := range firstSeen {
+		commits = append(commits, c)
+	}
+	sort.Slice(commits, func(i, j int) bool {
+		ti, tj := firstSeen[commits[i]], firstSeen[commits[j]]
+		if ti.Equal(tj) {
+			return commits[i] < commits[j]
+		}
+		return ti.Before(tj)
+	})
+	return commits
+}

--- a/src/pkg/reach/windows_test.go
+++ b/src/pkg/reach/windows_test.go
@@ -1,0 +1,97 @@
+package reach
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// fakeAncestry answers IsAncestor from an explicit pair table — the
+// in-memory double for the join tests.
+type fakeAncestry struct {
+	// pairs[ancestor][descendant] = true means ancestor is contained in
+	// descendant. Self-ancestry is implied.
+	pairs map[string]map[string]bool
+	err   error
+}
+
+func (f *fakeAncestry) IsAncestor(ancestor, descendant string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	if ancestor == descendant {
+		return true, nil
+	}
+	return f.pairs[ancestor][descendant], nil
+}
+
+// TestAssignWindows pins D4: PRs whose merge commits land between the same
+// two deployed commits share one window and are labeled shared_with; a 1:1
+// deploy stays precise; an undeployed PR gets no window.
+func TestAssignWindows(t *testing.T) {
+	// History: prA(101), prB(102) merged, then deploy d1; prC(103) merged,
+	// then deploy d2; prD(104) merged, never deployed.
+	anc := &fakeAncestry{pairs: map[string]map[string]bool{
+		"mA": {"d1": true, "d2": true},
+		"mB": {"d1": true, "d2": true},
+		"mC": {"d2": true},
+		"mD": {},
+	}}
+	prs := []PRInfo{
+		{Number: 101, MergeCommit: "mA"},
+		{Number: 102, MergeCommit: "mB"},
+		{Number: 103, MergeCommit: "mC"},
+		{Number: 104, MergeCommit: "mD"},
+	}
+
+	got, err := AssignWindows([]string{"d1", "d2"}, prs, anc)
+	if err != nil {
+		t.Fatalf("AssignWindows: %v", err)
+	}
+
+	want := map[int]WindowAssignment{
+		// A and B batch into the d1 deploy: co-attributed, labeled shared.
+		101: {DeployedCommit: "d1", SharedWith: []int{102}},
+		102: {DeployedCommit: "d1", SharedWith: []int{101}},
+		// C deployed alone in d2: per-PR precision, nothing shared.
+		103: {DeployedCommit: "d2"},
+		// D merged but no deployed commit contains it.
+		104: {},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("AssignWindows = %+v, want %+v", got, want)
+	}
+}
+
+// TestAssignWindowsAncestryErrorAborts: a failed ancestry answer must abort
+// the whole assignment — partial windows would silently mis-attribute.
+func TestAssignWindowsAncestryErrorAborts(t *testing.T) {
+	anc := &fakeAncestry{err: errors.New("boom")}
+	_, err := AssignWindows([]string{"d1"}, []PRInfo{{Number: 1, MergeCommit: "m1"}}, anc)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+// TestDeployedCommits: deploy history is derived from what hives REPORT
+// RUNNING, ordered by first observation — never from tags (#3816).
+func TestDeployedCommits(t *testing.T) {
+	base := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	reports := map[string][]ComponentReach{
+		"hive-a": {
+			{Component: "hub", Commit: "d2", FirstSeen: base.Add(48 * time.Hour)},
+			{Component: "governor", Commit: "d1", FirstSeen: base.Add(2 * time.Hour)},
+		},
+		"hive-b": {
+			// Same d1 commit seen EARLIER on another hive: earliest wins.
+			{Component: "hub", Commit: "d1", FirstSeen: base},
+			// Empty commit (no ldflags stamp) must never become a window.
+			{Component: "hub", Commit: "", FirstSeen: base},
+		},
+	}
+	got := DeployedCommits(reports)
+	if want := []string{"d1", "d2"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("DeployedCommits = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Phase 2b of the PR reach telemetry epic — implements the accepted design's D3/D4 plus the ancestry join and the read-only endpoint (#3994). No dashboard (that is 2c, #3995), no GitHub writes.

## What's here

### D3 — PR→component mapping with an honest `unattributable` bucket (`v2/pkg/reach/mapping.go`)
- `v2/pkg/<name>/**` → `<name>`; `v2/cmd/hive/**` → `main`; `v2/proxy/**` → `proxy`; everything else (workflows, deploy, docs, scripts, bin) → `unattributable`.
- Per-PR **attribution coverage** (fraction of changed files attributable) is computed and carried on every report; the unattributable file list rides along verbatim — never silently dropped.

### D4 — deploy-window co-attribution (`v2/pkg/reach/windows.go`)
- Deploy history is derived from the commits hives **report actually running** (the #3816 anchoring rule — never tags or Deployment specs), ordered by first observation.
- Each PR is assigned to the earliest deployed commit containing its merge commit; PRs sharing a window are labeled `shared_with: [prs...]`. Per-PR precision when deploys are 1:1, explicit co-attribution when they batch — no fake precision.

### Ancestry join + metrics (`v2/pkg/reach/ancestry.go`, `metrics.go`)
- A hive counts toward a PR's reach only when its reported running commit is a **descendant of the merge commit** AND a touched component shows `spans_total > 0` with `first_seen` after the merge.
- Metrics per PR: reach (distinct hive count + list), first-execution latency (merge → earliest qualifying `first_seen`), and the **never-ran flag** — merged + deployed + attributable + zero qualifying executions past the grace period (`HIVE_REACH_NEVER_RAN_DAYS`, default 3, named const). Docs-only PRs and merged-but-undeployed PRs never raise it (those are different outcomes).
- On the resolved OQ-3 ("hub's repo clone provides the commit graph"): the hub image ships **no clone**, and the hub's existing ancestry primitive is the cached GitHub compare API in `pkg/hub/commit_order.go`. So ancestry is an interface with two backends: `reach.GitAncestry` (`git merge-base --is-ancestor` against a real clone, used when `HIVE_REACH_REPO_DIR` is set; tested against a fixture repo with real commits) and a synchronous hub-side adapter (`compareAncestry`) that reuses `commit_order.go`'s fetcher var and permanent cache — same "ahead"/"identical" semantics, same errors-are-never-cached discipline. No ad-hoc shelling out.

### Read-only `GET /api/reach` (`v2/pkg/hub/reach_api.go`)
- `?pr=NNN` for one PR, `?recent=K` (default 20, cap 100) for the recent-merges list.
- Registered in `registerSaaSRoutes` behind **`requireAdmin`**, exactly like the neighboring read-only fleet-status route `GET /api/saas/cluster-health` — the payload names hives fleet-wide, the same exposure class. The auth test asserts byte-for-byte parity with that neighbor's unauthenticated failure (403 `{"error":"admin access required"}`) and that no reach data leaks; **removing the wrapper makes the test fail** (verified: it then answers 200 with data).
- With no GitHub credentials the endpoint answers 503 — never fabricated data.

### GitHub data (`v2/pkg/github/pr_reach.go`)
- Merged-PR facts (merge SHA, merge time, changed files) via the existing `pkg/github` client. File listing is paginated with a **completeness guard** (GitHub reported-count vs returned-count — a silently short list would under-attribute and understate reach; same guard as `fetchIntentPREvidence`).
- Immutable merged facts are cached permanently in bounded drop-on-overflow maps (the `commitOrderCache` discipline); the recent-merges listing is TTL-cached (5 min, mirroring `InstallationDiscoveryTTL`). No new client, no uncached call loop.

## Parallel-work contract with 2a (#3993)

This PR **does not touch** `v2/pkg/tracing/` or the heartbeat send/receive path. Everything the join needs from the fleet arrives through one narrow seam:

```go
type ReachReporter interface {
    LatestReach() map[string][]ComponentReach // hiveID → latest report
}
type ComponentReach struct {
    Component  string    `json:"component"`
    Commit     string    `json:"commit"`
    SpansTotal int64     `json:"spans_total"`
    SpansError int64     `json:"spans_error"`
    FirstSeen  time.Time `json:"first_seen"`
    LastSeen   time.Time `json:"last_seen"`
}
```

`StubReachReporter` (empty fleet) is wired by default, so this PR compiles and tests green without 2a. **Wiring the real store after 2a merges is one line** in hub startup:

```go
hubSrv.SetReachReporter(<2a's heartbeat-fed reach store>)
```

This PR merges **after** 2a; a rebase is expected if 2a lands first.

## Test evidence

```
$ go test ./pkg/reach/ -count=1 -v
--- PASS: TestGitAncestry               (fixture repo: real commits, diverged branch, unknown SHA errors)
--- PASS: TestMapFile                   (D3 table incl. prefix traps: v2/pkgnot, v2/cmd/hivectl)
--- PASS: TestAttribute / FullyUnattributable / Empty   (coverage fraction, unattributable share)
--- PASS: TestAnalyzeReach              (ancestry gate, component gate, zero-spans gate, pre-merge first_seen gate, latency)
--- PASS: TestAnalyzeNeverRan / Suppressed / ThresholdEnv / EmptyFleet
--- PASS: TestAssignWindows / AncestryErrorAborts / TestDeployedCommits   (D4 shared_with, 1:1 precision, undeployed)
ok      github.com/kubestellar/hive/v2/pkg/reach

$ go test ./pkg/hub/ -run 'TestReachEndpointRequiresAdmin|TestHandleReach|TestCompareAncestry' -count=1
ok      github.com/kubestellar/hive/v2/pkg/hub      (endpoint auth parity w/ cluster-health, 503 w/o source, 400s, full join through handler, compare-API adapter cache semantics)

$ go test ./pkg/github/ -run 'TestMergedPR|TestListMergedPRFiles|TestRecentMergedPRs' -count=1
ok      github.com/kubestellar/hive/v2/pkg/github   (pagination, completeness guard failure, unmerged-PR refusal, caches)
```

Auth-gate negative control: with `requireAdmin` removed from the route registration, `TestReachEndpointRequiresAdmin` fails with `unauthenticated /api/reach: got 200, want 403` — the test encodes the gate, not the vulnerability.

Design refs: #3973 epic body (D1–D4, resolved OQs), `v2/docs/design/pr-reach-telemetry.md` (phase 1 anchoring rule and component attribute).

Fixes #3994
Part of #3973