### PR TITLE
✨ feat(tracing): spoke-side component reach counters on the heartbeat (#3993)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -128,6 +128,14 @@ const spokeAppKeyFileMode = 0o600
 // process exit.
 const traceShutdownTimeout = 5 * time.Second
 
+// reachStatePath is where the component reach counters (#3993) persist on the
+// PVC. Deliberately its OWN file, not the main /data/hive-state.json (#3973
+// resolved OQ-2): reach state is append-mostly telemetry keyed by the running
+// commit, and a parse failure in it must never take agent/governor state down
+// with it (or vice versa). Written on the same cadence as the main state file
+// (persistState), loaded once at boot.
+const reachStatePath = "/data/reach-state.json"
+
 // perAppIDKeyPath returns the on-disk path of the key file a spoke uses for a
 // specific app_id — /data/gh-app-key-<appid>.pem. This is what lets one spoke
 // hold BOTH the github.com App key AND its cluster's GitHub Enterprise App key
@@ -1039,6 +1047,15 @@ func main() {
 		logger.Warn("tracing init failed; continuing without tracing", "error", traceErr)
 	} else if otelCfg.Enabled {
 		logger.Info("otel tracing enabled", "endpoint", otelCfg.Endpoint, "service_name", otelCfg.ServiceNameOrDefault())
+	}
+	// Component reach counters (#3993): resume this commit's counters from the
+	// PVC before any span can start. Independent of the otel block above —
+	// counters increment with or without an exporter (design D2 of #3973), so
+	// this runs unconditionally and a load failure only costs history, never
+	// counting. Counters persisted by a DIFFERENT commit are dropped inside
+	// LoadReachState: a new binary starts fresh keys naturally.
+	if err := tracing.LoadReachState(reachStatePath, gitShort, logger); err != nil {
+		logger.Warn("reach state load failed; starting with fresh counters", "error", err)
 	}
 	defer func() {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), traceShutdownTimeout)
@@ -3340,6 +3357,13 @@ func main() {
 				// on the PVC, so the hub delivers the fleet's other App keys once
 				// and then stops re-sending them.
 				GitHubAppKeysHeld: heldPerAppIDKeyFingerprints(),
+				// Component reach counters (#3993, phase 2a of #3973): per
+				// (component, running commit) span counts aggregated in-process,
+				// exporter or not (D2) — the heartbeat is the only channel that
+				// reaches every spoke, pull-only ones included (D1). nil until
+				// the first span, which the hub reads as "no data", never as
+				// zero reach. Capped at tracing.MaxReachComponents entries.
+				ComponentReach: tracing.ReachSnapshot(),
 			}
 		}, heartbeatSendInterval, logger, hub.RestartSpokeCallback(func() {
 			if up := time.Since(processStartedAt); up < spokeRestartMinUptime {
@@ -5548,6 +5572,13 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 
 	if err := snapshot.SaveState(path, state, logger); err != nil {
 		logger.Error("failed to persist state", "error", err)
+	}
+
+	// Component reach counters (#3993) ride the SAME save cadence as the main
+	// state file but live in their own file (reachStatePath — resolved OQ-2 of
+	// #3973), so a reach write failure never corrupts agent/governor state.
+	if err := tracing.SaveReachState(reachStatePath); err != nil {
+		logger.Error("failed to persist reach state", "error", err)
 	}
 
 	// Reconcile the persisted pause field from the authoritative live manager

--- a/src/docs/design/pr-reach-telemetry.md
+++ b/src/docs/design/pr-reach-telemetry.md
@@ -1,6 +1,7 @@
 # PR reach telemetry (#3973)
 
-Status: phase 1 landed (version-stamped spans + component attribute); phases 2+ pending.
+Status: phase 1 landed (version-stamped spans + component attribute); phase 2
+design accepted (2a implemented; 2b #3994 / 2c #3995 pending).
 
 ## The problem
 
@@ -64,6 +65,39 @@ This is deliberately coarse: it answers "has the subsystem this PR touched
 executed on a build containing it, and on how many hives" — not "did this exact
 diff's lines run." Line/function-level attribution is out of scope for phase 1
 (cost and cardinality; see the issue's options list).
+
+## Phase 2 (accepted)
+
+The four design decisions, accepted in #3973:
+
+- **D1 — Aggregation is spoke-side and rides the heartbeat.** A span-backend
+  query can never see the pull-only spokes, and the `otel:` exporter is opt-in
+  — most spokes export nowhere. A hub-side span query would report ~0 reach
+  for most of the fleet and call it "unused": the anchoring-rule trap, one
+  level up. The heartbeat is the outbound channel every spoke already opens.
+- **D2 — Reach counters are independent of the OTel exporter.** They hook the
+  same `tracing.StartSpan` call sites but count in-process regardless of
+  exporter config. Every spoke reports; zero new network dependencies. Spans
+  remain the deep-inspection layer where backends exist.
+- **D3 — PR→component mapping with an honest `unattributable` bucket** (2b):
+  `v2/pkg/<name>/**` → `<name>`; `v2/cmd/hive/**` → `main`; `v2/proxy/**` →
+  `proxy`; workflows/deploy/docs → `unattributable`, reported, never dropped.
+- **D4 — Co-attribution when PRs batch into one deploy** (2c): PRs sharing a
+  deploy window share reach and error-deltas by construction, labeled shared.
+  No fake precision.
+
+Phase 2a implementation (#3993): per-(component, running commit) counters —
+`spans_total`, `spans_error` (span ended with error status), `first_seen`,
+`last_seen`, cumulative-since-boot plus a rolling 1h bucket — capped at
+`tracing.MaxReachComponents` (64) with overflow counted and truncation logged,
+never silent. Persisted to `/data/reach-state.json` (its own file, not the
+main state file — resolved OQ-2) on the existing state-save cadence; commit
+keying means a new binary starts fresh keys naturally. The heartbeat carries
+the report as `component_reach`; the hub sanitizes and clips it (same 64-entry
+cap — a hostile spoke must not grow hub memory) and stores the latest report
+per hive on the registry entry. Storage only: no endpoint, no mapping, no UI
+until #3994. The entry keys `component` / `commit` / `spans_total` /
+`spans_error` / `first_seen` / `last_seen` are 2b's fixed read interface.
 
 ## What phase 2+ needs (deferred)
 

--- a/src/pkg/hub/component_reach.go
+++ b/src/pkg/hub/component_reach.go
@@ -1,0 +1,118 @@
+package hub
+
+// Hub receipt of spoke component-reach reports (#3993, phase 2a of #3973).
+//
+// The heartbeat's component_reach field is SPOKE INPUT parsed on the hub, so
+// everything in it is bounded and sanitized before it touches the registry:
+// entry count is clipped to tracing.MaxReachComponents (a hostile spoke must
+// not grow hub memory or the persisted registry without limit), strings go
+// through the identifier sanitizer with explicit length caps, counts are
+// clamped non-negative, and timestamps must parse as RFC3339 or are dropped.
+// The stored report is NEVER trusted for anything but storage here — no joins,
+// no ancestry, no endpoint, no UI; that is #3994's job.
+
+import (
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/tracing"
+)
+
+const (
+	// maxReachComponentRunes bounds a stored component name. Component names
+	// are span-name prefixes ("governor", "agent", …) — the same identifier
+	// class isValidName caps at 100 — so anything longer is garbage or abuse.
+	maxReachComponentRunes = 100
+
+	// maxReachCommitRunes bounds a stored commit id. A full git SHA is 40 hex
+	// chars; nothing legitimate is longer.
+	maxReachCommitRunes = 40
+
+	// maxReachSpanCount bounds any single reach counter. 100 billion spans
+	// mirrors the TotalTokens24h clamp: far beyond anything a real spoke can
+	// emit between boots, small enough that a hostile value cannot overflow
+	// downstream arithmetic.
+	maxReachSpanCount = 100_000_000_000
+
+	// maxReachOverflowComponents bounds the reported count of DISTINCT
+	// refused component names. The spoke's own once-per-name overflow log set
+	// is capped at 256; a report claiming more than a few times that is not
+	// describing a real registry.
+	maxReachOverflowComponents = 1024
+)
+
+// truncateReachRunes caps s at n runes. Rune-based like sanitizeField, so a
+// multi-byte sequence can never be split into invalid UTF-8.
+func truncateReachRunes(s string, n int) string {
+	if runes := []rune(s); len(runes) > n {
+		return string(runes[:n])
+	}
+	return s
+}
+
+// sanitizeReachTime accepts a spoke-reported timestamp only if it parses as
+// RFC3339, re-rendered in canonical UTC form. Anything else becomes "" —
+// which every reader must treat as "unknown", never as an epoch.
+func sanitizeReachTime(s string) string {
+	t, err := time.Parse(time.RFC3339, strings.TrimSpace(s))
+	if err != nil {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// sanitizeComponentReach validates, clips, and copies a spoke-reported reach
+// report for storage on the registry entry. nil in (old spoke / nothing
+// recorded yet) is nil out — "no data", never an error. The returned report
+// never aliases the caller's payload. Entries past tracing.MaxReachComponents
+// are dropped and surfaced in OverflowComponents so the clip is visible in the
+// stored data rather than silent.
+func sanitizeComponentReach(in *tracing.ReachReport) *tracing.ReachReport {
+	if in == nil {
+		return nil
+	}
+	out := &tracing.ReachReport{
+		OverflowSpans:      clampInt64(in.OverflowSpans, 0, maxReachSpanCount),
+		OverflowComponents: clampInt(in.OverflowComponents, 0, maxReachOverflowComponents),
+	}
+	entries := in.Entries
+	if len(entries) > tracing.MaxReachComponents {
+		// The clip itself is reach data the spoke claimed and the hub refused:
+		// fold the refused count into OverflowComponents so a hostile or buggy
+		// oversized report is visibly truncated, never silently shrunk.
+		out.OverflowComponents = clampInt(out.OverflowComponents+len(entries)-tracing.MaxReachComponents,
+			0, maxReachOverflowComponents)
+		entries = entries[:tracing.MaxReachComponents]
+	}
+	out.Entries = make([]tracing.ReachEntry, 0, len(entries))
+	for _, e := range entries {
+		component := truncateReachRunes(sanitizeHeartbeatField(e.Component), maxReachComponentRunes)
+		if component == "" {
+			// A name that sanitizes to nothing identifies nothing — drop it.
+			continue
+		}
+		entry := tracing.ReachEntry{
+			Component:  component,
+			Commit:     truncateReachRunes(sanitizeHeartbeatField(e.Commit), maxReachCommitRunes),
+			SpansTotal: clampInt64(e.SpansTotal, 0, maxReachSpanCount),
+			SpansError: clampInt64(e.SpansError, 0, maxReachSpanCount),
+			FirstSeen:  sanitizeReachTime(e.FirstSeen),
+			LastSeen:   sanitizeReachTime(e.LastSeen),
+		}
+		if e.Window1h != nil {
+			entry.Window1h = &tracing.ReachWindow{
+				Start:      sanitizeReachTime(e.Window1h.Start),
+				SpansTotal: clampInt64(e.Window1h.SpansTotal, 0, maxReachSpanCount),
+				SpansError: clampInt64(e.Window1h.SpansError, 0, maxReachSpanCount),
+			}
+		}
+		out.Entries = append(out.Entries, entry)
+	}
+	if len(out.Entries) == 0 && out.OverflowSpans == 0 && out.OverflowComponents == 0 {
+		// An empty report stores as nil so "reported nothing" and "never
+		// reported" read the same downstream — and the carry-forward on the
+		// heartbeat path keeps the previous real report instead.
+		return nil
+	}
+	return out
+}

--- a/src/pkg/hub/component_reach_test.go
+++ b/src/pkg/hub/component_reach_test.go
@@ -1,0 +1,236 @@
+package hub
+
+// Tests for hub receipt of spoke component-reach reports (#3993, phase 2a of
+// #3973). The heartbeat body is spoke INPUT, so the load-bearing assertions
+// are the receive-path bounds: an oversized report is clipped to
+// tracing.MaxReachComponents (a hostile spoke must not grow hub memory),
+// strings are sanitized, garbage counts/timestamps are neutralized — and the
+// stored shape keeps the exact JSON keys 2b reads.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/tracing"
+)
+
+// reachBody builds a heartbeat JSON body for hive h1 carrying n reach entries.
+func reachBody(t *testing.T, n int) string {
+	t.Helper()
+	entries := make([]tracing.ReachEntry, n)
+	for i := range entries {
+		entries[i] = tracing.ReachEntry{
+			Component:  fmt.Sprintf("comp%04d", i),
+			Commit:     "abc1234",
+			SpansTotal: int64(i + 1),
+			SpansError: 1,
+			FirstSeen:  "2026-08-17T10:00:00Z",
+			LastSeen:   "2026-08-17T11:00:00Z",
+		}
+	}
+	report := tracing.ReachReport{Entries: entries}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal reach report: %v", err)
+	}
+	return fmt.Sprintf(`{"hive_id":"h1","org":"kubestellar","component_reach":%s}`, data)
+}
+
+// storedReach fetches the stored report for hive id from the registry.
+func storedReach(t *testing.T, s *HubServer, id string) *tracing.ReachReport {
+	t.Helper()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, h := range s.registry.Hives {
+		if h.ID == id {
+			return h.ComponentReach
+		}
+	}
+	t.Fatalf("hive %q not in registry", id)
+	return nil
+}
+
+// TestHeartbeatComponentReach_Stored verifies the storage path end to end
+// through handleHeartbeat: a well-formed report lands on the registry entry
+// with its values intact.
+func TestHeartbeatComponentReach_Stored(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	rec := postHeartbeat(t, s, reachBody(t, 3))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	stored := storedReach(t, s, "h1")
+	if stored == nil {
+		t.Fatal("component_reach not stored")
+	}
+	if len(stored.Entries) != 3 {
+		t.Fatalf("stored entries = %d, want 3", len(stored.Entries))
+	}
+	e := stored.Entries[0]
+	if e.Component != "comp0000" || e.Commit != "abc1234" || e.SpansTotal != 1 || e.SpansError != 1 {
+		t.Errorf("stored entry mangled: %+v", e)
+	}
+	if e.FirstSeen != "2026-08-17T10:00:00Z" || e.LastSeen != "2026-08-17T11:00:00Z" {
+		t.Errorf("stored timestamps mangled: %+v", e)
+	}
+}
+
+// TestHeartbeatComponentReach_ClipsOversizedInput is the hostile-spoke bound:
+// a report with far more than tracing.MaxReachComponents entries must be
+// CLIPPED on receive — stored entries never exceed the cap, and the refused
+// count is surfaced in overflow_components rather than silently dropped.
+// (Removing the clip in sanitizeComponentReach makes this test fail.)
+func TestHeartbeatComponentReach_ClipsOversizedInput(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	const excess = 36
+	rec := postHeartbeat(t, s, reachBody(t, tracing.MaxReachComponents+excess))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	stored := storedReach(t, s, "h1")
+	if stored == nil {
+		t.Fatal("component_reach not stored")
+	}
+	if len(stored.Entries) != tracing.MaxReachComponents {
+		t.Errorf("stored entries = %d, want clipped to %d", len(stored.Entries), tracing.MaxReachComponents)
+	}
+	if stored.OverflowComponents != excess {
+		t.Errorf("overflow_components = %d, want %d (the clip must be visible, not silent)",
+			stored.OverflowComponents, excess)
+	}
+}
+
+// TestHeartbeatComponentReach_SanitizesGarbage verifies string sanitization,
+// count clamping, and timestamp validation on the receive path.
+func TestHeartbeatComponentReach_SanitizesGarbage(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	body := `{"hive_id":"h1","component_reach":{"entries":[
+		{"component":"gov<script>ernor","commit":"abc1234!!","spans_total":-5,"spans_error":9223372036854775807,"first_seen":"not-a-time","last_seen":"2026-08-17T11:00:00Z"},
+		{"component":"<>","commit":"x","spans_total":1,"spans_error":0,"first_seen":"","last_seen":""}
+	],"overflow_spans":-3}}`
+	rec := postHeartbeat(t, s, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	stored := storedReach(t, s, "h1")
+	if stored == nil {
+		t.Fatal("component_reach not stored")
+	}
+	// The all-symbols component sanitizes to "" and is dropped entirely.
+	if len(stored.Entries) != 1 {
+		t.Fatalf("stored entries = %d, want 1 (empty-name entry dropped): %+v", len(stored.Entries), stored.Entries)
+	}
+	e := stored.Entries[0]
+	if e.Component != "govscripternor" {
+		t.Errorf("component = %q, want angle brackets stripped", e.Component)
+	}
+	if e.Commit != "abc1234" {
+		t.Errorf("commit = %q, want %q", e.Commit, "abc1234")
+	}
+	if e.SpansTotal != 0 {
+		t.Errorf("negative spans_total stored as %d, want clamped to 0", e.SpansTotal)
+	}
+	if e.SpansError != maxReachSpanCount {
+		t.Errorf("absurd spans_error stored as %d, want clamped to %d", e.SpansError, int64(maxReachSpanCount))
+	}
+	if e.FirstSeen != "" {
+		t.Errorf("unparseable first_seen stored as %q, want dropped", e.FirstSeen)
+	}
+	if e.LastSeen != "2026-08-17T11:00:00Z" {
+		t.Errorf("valid last_seen mangled: %q", e.LastSeen)
+	}
+	if stored.OverflowSpans != 0 {
+		t.Errorf("negative overflow_spans stored as %d, want 0", stored.OverflowSpans)
+	}
+}
+
+// TestHeartbeatComponentReach_CarriedForwardWhenOmitted verifies a beat
+// WITHOUT component_reach preserves the previous stored report — a spoke
+// restart must not blank the hive's last real reach data.
+func TestHeartbeatComponentReach_CarriedForwardWhenOmitted(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	if rec := postHeartbeat(t, s, reachBody(t, 2)); rec.Code != http.StatusOK {
+		t.Fatalf("first heartbeat status = %d", rec.Code)
+	}
+	if rec := postHeartbeat(t, s, `{"hive_id":"h1","org":"kubestellar"}`); rec.Code != http.StatusOK {
+		t.Fatalf("second heartbeat status = %d", rec.Code)
+	}
+
+	stored := storedReach(t, s, "h1")
+	if stored == nil || len(stored.Entries) != 2 {
+		t.Fatalf("reach report not carried forward across an omitting beat: %+v", stored)
+	}
+}
+
+// TestHeartbeatPayload_ComponentReachWireShape pins the wire contract 2b
+// reads: the field is named component_reach, entries carry EXACTLY the epic's
+// keys, and a payload without reach omits the field entirely.
+func TestHeartbeatPayload_ComponentReachWireShape(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	p := HeartbeatPayload{
+		HiveID: "h1",
+		ComponentReach: &tracing.ReachReport{
+			Entries: []tracing.ReachEntry{{
+				Component:  "governor",
+				Commit:     "abc1234",
+				SpansTotal: 10,
+				SpansError: 2,
+				FirstSeen:  now,
+				LastSeen:   now,
+			}},
+		},
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	body := string(data)
+	for _, key := range []string{
+		`"component_reach"`, `"entries"`,
+		`"component":"governor"`, `"commit":"abc1234"`,
+		`"spans_total":10`, `"spans_error":2`,
+		`"first_seen"`, `"last_seen"`,
+	} {
+		if !strings.Contains(body, key) {
+			t.Errorf("payload JSON missing %s: %s", key, body)
+		}
+	}
+
+	empty, err := json.Marshal(HeartbeatPayload{HiveID: "h1"})
+	if err != nil {
+		t.Fatalf("marshal empty payload: %v", err)
+	}
+	if strings.Contains(string(empty), "component_reach") {
+		t.Errorf("nil report must omit component_reach: %s", string(empty))
+	}
+}
+
+// TestSanitizeComponentReach_NilAndEmpty pins nil-in → nil-out and
+// empty-report → nil (so the carry-forward path treats both as "no data").
+func TestSanitizeComponentReach_NilAndEmpty(t *testing.T) {
+	if got := sanitizeComponentReach(nil); got != nil {
+		t.Errorf("sanitizeComponentReach(nil) = %+v, want nil", got)
+	}
+	if got := sanitizeComponentReach(&tracing.ReachReport{}); got != nil {
+		t.Errorf("sanitizeComponentReach(empty) = %+v, want nil", got)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/tracing"
 )
 
 const (
@@ -717,6 +719,18 @@ type HeartbeatPayload struct {
 	// reporting it harmlessly and to describe what per-app-id files a spoke holds.
 	// It carries fingerprints ONLY — never key material.
 	GitHubAppKeysHeld map[string]string `json:"github_app_keys_held,omitempty"`
+	// ComponentReach carries the spoke's in-process component reach counters
+	// (#3993, phase 2a of #3973): per (component, running commit) span counts
+	// that increment REGARDLESS of whether an OTel exporter is configured, so
+	// every spoke reports — including the pull-only fleet a span backend can
+	// never see (design D1/D2). The hub stores the latest report per hive,
+	// storage only: nothing joins, maps, or renders it until #3994. Spoke-side
+	// the entry count is capped at tracing.MaxReachComponents and the hub
+	// clips oversized reports to the same cap on receive (a hostile spoke
+	// must not grow hub memory). omitempty: a spoke that has recorded no
+	// spans yet, or one too old to report reach, sends nothing — which the
+	// hub reads as "no data", never as an error and never as zero reach.
+	ComponentReach *tracing.ReachReport `json:"component_reach,omitempty"`
 	// StatsStale is true when this beat carries CACHED collected stats rather
 	// than fresh ones, because collect() timed out this cycle (see
 	// sendHeartbeat / collectWithTimeout). The beat is still a genuine liveness

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kubestellar/hive/pkg/auth"
 	"github.com/kubestellar/hive/pkg/openrouter"
+	"github.com/kubestellar/hive/pkg/tracing"
 )
 
 //go:embed static/*
@@ -296,6 +297,19 @@ type RegistryEntry struct {
 	// fleetStatsMaxAge. Zero means the spoke is too old to report it, which is
 	// treated as "not stale" so an upgrade does not blank the strip.
 	FleetStatsCollectedAt time.Time `json:"fleetStatsCollectedAt,omitempty"`
+	// ComponentReach is the LATEST component-reach report from this hive's
+	// spoke (#3993, phase 2a of #3973): per (component, running commit) span
+	// counters aggregated in-process on the spoke and carried on the
+	// heartbeat. Persisted with the registry so fleet reach survives hub
+	// restarts. STORAGE ONLY at this phase — no endpoint, no PR mapping, no
+	// ancestry join, no UI reads it until #3994; the JSON entry keys
+	// (component / commit / spans_total / spans_error / first_seen /
+	// last_seen) are 2b's fixed read interface. Always the sanitized/clipped
+	// product of sanitizeComponentReach, never the raw payload. nil means the
+	// spoke has never reported reach (old spoke, or no spans yet) — "no
+	// data", never "zero reach". Carried forward across beats that omit it so
+	// a spoke restart does not blank the last real report.
+	ComponentReach *tracing.ReachReport `json:"component_reach,omitempty"`
 	// AgentsWithModel is the spoke-reported count of agents that have a method
 	// (backend) or model assigned. nil = the spoke is too old to report it, so
 	// journey stage 2 is treated as unknown rather than unsatisfied.
@@ -1633,6 +1647,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// Preserve nil (old spoke, unknown) vs a real count — journey stage
 		// detection depends on telling those two apart.
 		AgentsWithModel: clampFleetCount(payload.AgentsWithModel),
+		// Component reach (#3993): sanitized + clipped, never the raw spoke
+		// report — see sanitizeComponentReach for the bounds. Storage only.
+		ComponentReach: sanitizeComponentReach(payload.ComponentReach),
 	}
 
 	// Populate ClusterID and the authoritative ProvStatus from the SaaS hive
@@ -1786,6 +1803,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			if entry.FleetStatsCollectedAt.IsZero() {
 				entry.FleetStatsCollectedAt = h.FleetStatsCollectedAt
+			}
+			// Carry the last real component-reach report forward when this
+			// beat omits one (#3993) — a restarting spoke reports nil until
+			// its counters warm back up from /data/reach-state.json, and
+			// overwriting with nil would blank the hive's reach history for
+			// that gap. Same pattern as the fleet-stat counts above.
+			if entry.ComponentReach == nil && h.ComponentReach != nil {
+				entry.ComponentReach = h.ComponentReach
 			}
 			branchForLatest := payload.GitBranch
 			if branchForLatest == "" {

--- a/src/pkg/tracing/reach.go
+++ b/src/pkg/tracing/reach.go
@@ -1,0 +1,446 @@
+// Component reach counters (#3993, phase 2a of #3973).
+//
+// Every span started through StartSpan increments an in-process counter keyed
+// by (component, running commit). This is design decision D2 of #3973: the
+// counters are DELIBERATELY independent of the OTel exporter. The `otel:`
+// block is opt-in per spoke and most of the fleet exports nowhere (including
+// all pull-only spokes), so a span-backend query would report ~0 reach for
+// most hives and call merged code "unused" — the same trap the phase-1
+// anchoring rule exists to prevent, one level up. Counting in-process means
+// every spoke reports reach over the heartbeat (D1) with zero new network
+// dependencies; spans remain the deep-inspection layer where backends exist.
+//
+// Hot-path cost: recording a span is a read-locked map lookup plus a handful
+// of atomic adds — no allocation, no write lock, no time formatting. The write
+// lock is taken only the first time a component name is seen (bounded at
+// MaxReachComponents times per process lifetime).
+package tracing
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// MaxReachComponents caps how many distinct components the reach registry
+	// tracks. The set rides every heartbeat and is persisted to
+	// /data/reach-state.json, so it must be bounded: span names are code-owned
+	// today (~a dozen components), but a future call site interpolating input
+	// into a span name would otherwise grow the heartbeat and the hub's
+	// per-hive storage without limit. 64 is several times the realistic
+	// component count (one per top-level package that emits spans) while
+	// keeping the worst-case payload small. Beyond the cap spans are counted
+	// in OverflowSpans and the truncation is LOGGED once per component —
+	// never silent (#3973 resolved open question OQ-1). The hub clips
+	// hostile/oversized reports to this same constant on receive.
+	MaxReachComponents = 64
+
+	// reachWindowSeconds is the length of the rolling activity bucket, in
+	// seconds: one hour. Phase 2c computes error-rate deltas per deploy window
+	// from consecutive heartbeat reports, and the cumulative-since-boot
+	// counters alone cannot expose "what happened recently" without the hub
+	// diffing beats — a 1h tumbling bucket gives 2c a recent-activity signal
+	// that survives missed beats. Seconds because the counters store unix
+	// seconds in atomics.
+	reachWindowSeconds = int64(60 * 60)
+
+	// maxOverflowLoggedComponents bounds the once-per-component truncation log
+	// set. The set exists so overflow is never silent, but it must not itself
+	// become an unbounded map fed by hostile span names; past this many
+	// distinct overflowed names one final aggregate warning is logged and
+	// further new names only increment the overflow counters.
+	maxOverflowLoggedComponents = 256
+)
+
+// ReachWindow is the rolling 1h activity bucket inside a ReachEntry. Start is
+// when the current bucket began (RFC3339 UTC); the counts cover spans since
+// then. A bucket older than 1h is reset on the next recorded span, so a stale
+// Start means the component has been idle since Start+1h.
+type ReachWindow struct {
+	Start      string `json:"start"`
+	SpansTotal int64  `json:"spans_total"`
+	SpansError int64  `json:"spans_error"`
+}
+
+// ReachEntry is one (component, running commit) reach counter as it appears on
+// the heartbeat, in /data/reach-state.json, and in the hub's per-hive storage.
+//
+// CONTRACT (#3993 → #3994): the JSON keys component / commit / spans_total /
+// spans_error / first_seen / last_seen are phase 2b's read interface and are
+// fixed by the #3973 epic — do not rename or omit them. Timestamps are RFC3339
+// UTC. The counts are cumulative since boot (or since the persisted state was
+// loaded); Window1h is the additive rolling bucket for 2c.
+type ReachEntry struct {
+	Component  string       `json:"component"`
+	Commit     string       `json:"commit"`
+	SpansTotal int64        `json:"spans_total"`
+	SpansError int64        `json:"spans_error"`
+	FirstSeen  string       `json:"first_seen"`
+	LastSeen   string       `json:"last_seen"`
+	Window1h   *ReachWindow `json:"window_1h,omitempty"`
+}
+
+// ReachReport is the full reach snapshot: what the spoke persists, what rides
+// the heartbeat as component_reach, and what the hub stores per hive. Entries
+// are sorted by component name so reports are deterministic and diffable.
+// OverflowSpans counts spans whose component was refused by the
+// MaxReachComponents cap; OverflowComponents counts the distinct refused
+// component names observed (a floor once the logging set saturates).
+type ReachReport struct {
+	Entries            []ReachEntry `json:"entries"`
+	OverflowSpans      int64        `json:"overflow_spans,omitempty"`
+	OverflowComponents int          `json:"overflow_components,omitempty"`
+}
+
+// reachCounters is the per-component hot-path state. All fields are atomics so
+// concurrent StartSpan/End calls never contend on a lock; winMu is taken only
+// on the rare window rollover (at most once per component per hour).
+type reachCounters struct {
+	firstSeen atomic.Int64 // unix seconds; 0 = never seen (set once via CAS)
+	lastSeen  atomic.Int64 // unix seconds
+	total     atomic.Int64
+	errors    atomic.Int64
+	winStart  atomic.Int64 // unix seconds; start of the current 1h bucket
+	winTotal  atomic.Int64
+	winErrors atomic.Int64
+	winMu     sync.Mutex // serializes bucket resets only
+}
+
+// rollWindow resets the 1h bucket when it has expired. The fast path is a
+// single atomic load; the mutex is only for the rollover itself. A counter
+// racing the reset can land on either side of the zeroing — an error of at
+// most a few spans once per hour, which is noise at reach granularity and the
+// deliberate price of a lock-free increment path.
+func (c *reachCounters) rollWindow(now int64) {
+	ws := c.winStart.Load()
+	if ws != 0 && now-ws < reachWindowSeconds {
+		return
+	}
+	c.winMu.Lock()
+	defer c.winMu.Unlock()
+	ws = c.winStart.Load()
+	if ws == 0 || now-ws >= reachWindowSeconds {
+		c.winStart.Store(now)
+		c.winTotal.Store(0)
+		c.winErrors.Store(0)
+	}
+}
+
+// reachState is the process-global registry. There is exactly one running
+// commit per process (the ldflags-baked SHA), so the in-memory key is the
+// component alone; the commit is attached when snapshotting. Keying the
+// PERSISTED entries by commit is what makes a new binary start fresh counters
+// naturally — LoadReachState resumes only entries whose commit matches.
+type reachState struct {
+	mu         sync.RWMutex
+	commit     string
+	logger     *slog.Logger
+	components map[string]*reachCounters
+	// overflowLogged holds component names whose truncation has already been
+	// logged, so the "never silent" guarantee costs one log line per name, not
+	// one per span. Bounded by maxOverflowLoggedComponents.
+	overflowLogged       map[string]struct{}
+	overflowLogSaturated bool
+	overflowSpans        atomic.Int64
+}
+
+var globalReach = newReachState()
+
+func newReachState() *reachState {
+	return &reachState{
+		components:     make(map[string]*reachCounters),
+		overflowLogged: make(map[string]struct{}),
+	}
+}
+
+func (r *reachState) log() *slog.Logger {
+	if r.logger != nil {
+		return r.logger
+	}
+	return slog.Default()
+}
+
+// counters returns the counter block for component, creating it under the
+// write lock on first sight. Returns nil when the MaxReachComponents cap
+// refuses a new component — the caller must count the span as overflow.
+func (r *reachState) counters(component string) *reachCounters {
+	r.mu.RLock()
+	c := r.components[component]
+	r.mu.RUnlock()
+	if c != nil {
+		return c
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if c := r.components[component]; c != nil {
+		return c
+	}
+	if len(r.components) >= MaxReachComponents {
+		r.noteOverflowLocked(component)
+		return nil
+	}
+	c = &reachCounters{}
+	r.components[component] = c
+	return c
+}
+
+// noteOverflowLocked logs a refused component's truncation exactly once per
+// name (never silent — #3993), with the logging set itself bounded so hostile
+// span names cannot grow it without limit. Caller holds r.mu.
+func (r *reachState) noteOverflowLocked(component string) {
+	if _, seen := r.overflowLogged[component]; seen {
+		return
+	}
+	if len(r.overflowLogged) >= maxOverflowLoggedComponents {
+		if !r.overflowLogSaturated {
+			r.overflowLogSaturated = true
+			r.log().Warn("reach: overflow component log set saturated — further new components are counted but no longer named (#3993)",
+				"logged_names", len(r.overflowLogged),
+				"cap", MaxReachComponents,
+			)
+		}
+		return
+	}
+	r.overflowLogged[component] = struct{}{}
+	r.log().Warn("reach: component cap reached — spans for this component are counted only in overflow_spans (#3993)",
+		"component", component,
+		"cap", MaxReachComponents,
+	)
+}
+
+// recordReachStart counts a span start for component. Called from StartSpan on
+// every span regardless of exporter configuration (D2).
+func recordReachStart(component string) {
+	c := globalReach.counters(component)
+	if c == nil {
+		globalReach.overflowSpans.Add(1)
+		return
+	}
+	now := time.Now().Unix()
+	c.firstSeen.CompareAndSwap(0, now)
+	c.lastSeen.Store(now)
+	c.rollWindow(now)
+	c.total.Add(1)
+	c.winTotal.Add(1)
+}
+
+// recordReachError counts a span that ended with error status. Read-only
+// lookup: a component refused by the cap was already counted as overflow at
+// start, so a miss here is deliberately dropped rather than re-noted.
+func recordReachError(component string) {
+	globalReach.mu.RLock()
+	c := globalReach.components[component]
+	globalReach.mu.RUnlock()
+	if c == nil {
+		return
+	}
+	now := time.Now().Unix()
+	c.lastSeen.Store(now)
+	c.rollWindow(now)
+	c.errors.Add(1)
+	c.winErrors.Add(1)
+}
+
+// formatReachTime renders a unix-seconds counter timestamp as RFC3339 UTC, the
+// format everything else on the heartbeat uses. Zero (never seen) is "".
+func formatReachTime(unixSec int64) string {
+	if unixSec == 0 {
+		return ""
+	}
+	return time.Unix(unixSec, 0).UTC().Format(time.RFC3339)
+}
+
+// ReachSnapshot returns the current reach report, or nil when nothing has been
+// recorded — nil keeps component_reach off the heartbeat entirely (omitempty)
+// for a spoke that has emitted no spans yet.
+func ReachSnapshot() *ReachReport {
+	r := globalReach
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	overflowSpans := r.overflowSpans.Load()
+	if len(r.components) == 0 && overflowSpans == 0 {
+		return nil
+	}
+	report := &ReachReport{
+		Entries:            make([]ReachEntry, 0, len(r.components)),
+		OverflowSpans:      overflowSpans,
+		OverflowComponents: len(r.overflowLogged),
+	}
+	for name, c := range r.components {
+		entry := ReachEntry{
+			Component:  name,
+			Commit:     r.commit,
+			SpansTotal: c.total.Load(),
+			SpansError: c.errors.Load(),
+			FirstSeen:  formatReachTime(c.firstSeen.Load()),
+			LastSeen:   formatReachTime(c.lastSeen.Load()),
+		}
+		if ws := c.winStart.Load(); ws != 0 {
+			entry.Window1h = &ReachWindow{
+				Start:      formatReachTime(ws),
+				SpansTotal: c.winTotal.Load(),
+				SpansError: c.winErrors.Load(),
+			}
+		}
+		report.Entries = append(report.Entries, entry)
+	}
+	sort.Slice(report.Entries, func(i, j int) bool {
+		return report.Entries[i].Component < report.Entries[j].Component
+	})
+	return report
+}
+
+// LoadReachState installs the running commit + logger on the reach registry
+// and resumes counters from a previous run of the SAME commit persisted at
+// path (its own file, /data/reach-state.json — deliberately not the main
+// state file, per #3973 resolved OQ-2). Entries persisted by a different
+// commit are dropped: the counters are keyed by commit, so a freshly upgraded
+// binary starts fresh keys naturally and never inherits reach it did not earn.
+// A missing file is a normal first boot, not an error.
+func LoadReachState(path, commit string, logger *slog.Logger) error {
+	r := globalReach
+	r.mu.Lock()
+	r.commit = commit
+	r.logger = logger
+	r.mu.Unlock()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read reach state: %w", err)
+	}
+	var report ReachReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return fmt.Errorf("parse reach state: %w", err)
+	}
+
+	now := time.Now().Unix()
+	resumed, dropped := 0, 0
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range report.Entries {
+		if e.Component == "" || e.Commit != commit {
+			dropped++
+			continue
+		}
+		if len(r.components) >= MaxReachComponents {
+			// A hand-edited or corrupt file must not bypass the cap.
+			r.noteOverflowLocked(e.Component)
+			continue
+		}
+		c := &reachCounters{}
+		c.total.Store(e.SpansTotal)
+		c.errors.Store(e.SpansError)
+		if t, err := time.Parse(time.RFC3339, e.FirstSeen); err == nil {
+			c.firstSeen.Store(t.Unix())
+		}
+		if t, err := time.Parse(time.RFC3339, e.LastSeen); err == nil {
+			c.lastSeen.Store(t.Unix())
+		}
+		// Resume the rolling bucket only while it is still current; an expired
+		// bucket restarts on the next span rather than resurrecting stale
+		// counts into a fresh hour.
+		if e.Window1h != nil {
+			if t, err := time.Parse(time.RFC3339, e.Window1h.Start); err == nil && now-t.Unix() < reachWindowSeconds {
+				c.winStart.Store(t.Unix())
+				c.winTotal.Store(e.Window1h.SpansTotal)
+				c.winErrors.Store(e.Window1h.SpansError)
+			}
+		}
+		r.components[e.Component] = c
+		resumed++
+	}
+	// Overflow is not commit-keyed in the file, so it is only trustworthy when
+	// the file demonstrably belongs to THIS commit (something resumed). A file
+	// written by a previous binary starts the new one at zero overflow, the
+	// same way its component counters start fresh.
+	if resumed > 0 && report.OverflowSpans > 0 {
+		r.overflowSpans.Store(report.OverflowSpans)
+	}
+	if resumed > 0 || dropped > 0 {
+		r.log().Info("reach state loaded (#3993)",
+			"path", path, "commit", commit, "resumed", resumed, "dropped_other_commit", dropped)
+	}
+	return nil
+}
+
+// SaveReachState writes the current reach report to path atomically
+// (tmp + rename, matching snapshot.SaveState). Called on the spoke's existing
+// state-save cadence — every eval tick and at shutdown — never on the span
+// hot path. Nothing recorded yet writes nothing (and is not an error).
+func SaveReachState(path string) error {
+	report := ReachSnapshot()
+	if report == nil {
+		return nil
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal reach state: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("write reach state: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename reach state: %w", err)
+	}
+	return nil
+}
+
+// reachSpan wraps the span returned by StartSpan so the reach error counter
+// (#3993) can observe "ended with error status" without a SpanProcessor — a
+// processor only runs when the SDK provider is installed (exporter
+// configured), and D2 requires counting without one. One small allocation per
+// span, on the span object itself (which is already heap-bound as an
+// interface); the counter increments stay atomic and lock-free.
+//
+// Status precedence follows the OTel spec: Ok is final and cannot be
+// downgraded back to Error by a later SetStatus.
+type reachSpan struct {
+	trace.Span
+	component string
+	status    atomic.Int32 // last effective codes.Code
+	ended     atomic.Bool
+}
+
+func (s *reachSpan) SetStatus(code codes.Code, description string) {
+	switch code {
+	case codes.Ok:
+		s.status.Store(int32(codes.Ok))
+	case codes.Error:
+		if codes.Code(s.status.Load()) != codes.Ok {
+			s.status.Store(int32(codes.Error))
+		}
+	}
+	s.Span.SetStatus(code, description)
+}
+
+// End counts the error exactly once even if a defer and an explicit call both
+// End the span, then delegates.
+func (s *reachSpan) End(options ...trace.SpanEndOption) {
+	if s.ended.CompareAndSwap(false, true) && codes.Code(s.status.Load()) == codes.Error {
+		recordReachError(s.component)
+	}
+	s.Span.End(options...)
+}
+
+// resetReachForTest replaces the global registry, giving tests a clean slate
+// with a chosen commit and logger. Test-only; the production registry is
+// installed once by LoadReachState at boot.
+func resetReachForTest(commit string, logger *slog.Logger) {
+	fresh := newReachState()
+	fresh.commit = commit
+	fresh.logger = logger
+	globalReach = fresh
+}

--- a/src/pkg/tracing/reach_test.go
+++ b/src/pkg/tracing/reach_test.go
@@ -1,0 +1,313 @@
+package tracing
+
+// Tests for the component reach counters (#3993, phase 2a of #3973).
+//
+// The load-bearing claims verified here:
+//   - counters increment WITHOUT any exporter configured (design D2);
+//   - concurrent increments are exact under -race;
+//   - the MaxReachComponents cap counts overflow and LOGS the truncation once
+//     per component, never silently;
+//   - persistence round-trips through the reach-state file, and a different
+//     running commit starts fresh keys;
+//   - the rolling 1h bucket resets after expiry.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// testCommit is the fake running-binary SHA reach tests key their counters by.
+const testCommit = "abc1234"
+
+// collectHandler is a minimal slog.Handler that records every message it
+// receives, so tests can assert the overflow truncation is actually logged.
+type collectHandler struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (h *collectHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *collectHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, r.Message)
+	return nil
+}
+func (h *collectHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *collectHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *collectHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.msgs)
+}
+
+// resetReach gives each test a clean registry and restores the previous global
+// tracer provider afterward. Installing the explicit no-op provider is the
+// point of most of these tests: NO exporter, NO SDK — and the counters must
+// increment anyway (D2).
+func resetReach(t *testing.T) *collectHandler {
+	t.Helper()
+	h := &collectHandler{}
+	resetReachForTest(testCommit, slog.New(h))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tracenoop.NewTracerProvider())
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		resetReachForTest("", nil)
+	})
+	return h
+}
+
+// findEntry returns the entry for component, failing the test when absent.
+func findEntry(t *testing.T, report *ReachReport, component string) ReachEntry {
+	t.Helper()
+	if report == nil {
+		t.Fatalf("reach report is nil, want an entry for %q", component)
+	}
+	for _, e := range report.Entries {
+		if e.Component == component {
+			return e
+		}
+	}
+	t.Fatalf("no reach entry for %q in %+v", component, report.Entries)
+	return ReachEntry{}
+}
+
+// TestReach_CountsWithoutExporter is design D2 verbatim: no tracing.Init, the
+// global provider is the no-op, and spans still count — total, error, first
+// and last seen, commit key, and the 1h window.
+func TestReach_CountsWithoutExporter(t *testing.T) {
+	resetReach(t)
+	ctx := context.Background()
+
+	_, ok := StartSpan(ctx, "governor.eval_cycle")
+	ok.End()
+
+	_, errSpan := StartSpan(ctx, "governor.enumerate")
+	errSpan.SetStatus(codes.Error, "boom")
+	errSpan.End()
+
+	_, other := StartSpan(ctx, "agent.kick")
+	other.End()
+
+	report := ReachSnapshot()
+	gov := findEntry(t, report, "governor")
+	if gov.SpansTotal != 2 || gov.SpansError != 1 {
+		t.Errorf("governor = total %d / error %d, want 2 / 1", gov.SpansTotal, gov.SpansError)
+	}
+	if gov.Commit != testCommit {
+		t.Errorf("governor commit = %q, want %q", gov.Commit, testCommit)
+	}
+	if gov.FirstSeen == "" || gov.LastSeen == "" {
+		t.Errorf("governor first/last seen empty: %+v", gov)
+	}
+	if gov.Window1h == nil || gov.Window1h.SpansTotal != 2 || gov.Window1h.SpansError != 1 {
+		t.Errorf("governor window = %+v, want total 2 / error 1", gov.Window1h)
+	}
+	agent := findEntry(t, report, "agent")
+	if agent.SpansTotal != 1 || agent.SpansError != 0 {
+		t.Errorf("agent = total %d / error %d, want 1 / 0", agent.SpansTotal, agent.SpansError)
+	}
+}
+
+// TestReach_OkStatusOverridesError follows the OTel status precedence: a span
+// whose status ends up Ok must not count as errored, and double-End must not
+// double-count.
+func TestReach_OkStatusOverridesError(t *testing.T) {
+	resetReach(t)
+
+	_, span := StartSpan(context.Background(), "pr.merged")
+	span.SetStatus(codes.Error, "transient")
+	span.SetStatus(codes.Ok, "")
+	span.SetStatus(codes.Error, "must not downgrade Ok")
+	span.End()
+	span.End() // second End is a no-op for counting
+
+	e := findEntry(t, ReachSnapshot(), "pr")
+	if e.SpansTotal != 1 || e.SpansError != 0 {
+		t.Errorf("pr = total %d / error %d, want 1 / 0", e.SpansTotal, e.SpansError)
+	}
+}
+
+// TestReach_ConcurrentIncrements hammers the counters from many goroutines
+// (run under -race) and requires EXACT totals — atomic counters may not lose
+// increments.
+func TestReach_ConcurrentIncrements(t *testing.T) {
+	resetReach(t)
+
+	const goroutines = 16
+	const spansPerGoroutine = 200
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < spansPerGoroutine; i++ {
+				_, span := StartSpan(context.Background(), "governor.eval_cycle")
+				if i%2 == 0 {
+					span.SetStatus(codes.Error, "boom")
+				}
+				span.End()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	e := findEntry(t, ReachSnapshot(), "governor")
+	wantTotal := int64(goroutines * spansPerGoroutine)
+	wantErr := wantTotal / 2
+	if e.SpansTotal != wantTotal || e.SpansError != wantErr {
+		t.Errorf("governor = total %d / error %d, want %d / %d",
+			e.SpansTotal, e.SpansError, wantTotal, wantErr)
+	}
+}
+
+// TestReach_ComponentCapOverflowLogged fills the registry past
+// MaxReachComponents and verifies: exactly the cap survives, the excess spans
+// are counted in overflow_spans, the distinct refused names are counted, and
+// the truncation is logged ONCE per refused component — never silent, never
+// once per span.
+func TestReach_ComponentCapOverflowLogged(t *testing.T) {
+	h := resetReach(t)
+
+	for i := 0; i < MaxReachComponents; i++ {
+		_, span := StartSpan(context.Background(), fmt.Sprintf("comp%03d.op", i))
+		span.End()
+	}
+	logsBefore := h.count()
+
+	// Three refused components, two spans each: 6 overflow spans, 3 names,
+	// and exactly 3 new log lines (one per name, not one per span).
+	const refusedComponents = 3
+	const spansPerRefused = 2
+	for i := 0; i < refusedComponents; i++ {
+		for j := 0; j < spansPerRefused; j++ {
+			_, span := StartSpan(context.Background(), fmt.Sprintf("overflow%d.op", i))
+			span.SetStatus(codes.Error, "must not panic or count against a capped component")
+			span.End()
+		}
+	}
+
+	report := ReachSnapshot()
+	if len(report.Entries) != MaxReachComponents {
+		t.Errorf("entries = %d, want exactly %d", len(report.Entries), MaxReachComponents)
+	}
+	if want := int64(refusedComponents * spansPerRefused); report.OverflowSpans != want {
+		t.Errorf("overflow_spans = %d, want %d", report.OverflowSpans, want)
+	}
+	if report.OverflowComponents != refusedComponents {
+		t.Errorf("overflow_components = %d, want %d", report.OverflowComponents, refusedComponents)
+	}
+	if got := h.count() - logsBefore; got != refusedComponents {
+		t.Errorf("truncation log lines = %d, want %d (once per refused component)", got, refusedComponents)
+	}
+}
+
+// TestReach_PersistenceRoundTrip saves counters, wipes the registry, reloads
+// for the SAME commit, and requires the counts back intact — then reloads for
+// a DIFFERENT commit and requires a fresh start (commit-keyed entries are the
+// mechanism by which a new binary never inherits reach it did not earn).
+func TestReach_PersistenceRoundTrip(t *testing.T) {
+	resetReach(t)
+	path := filepath.Join(t.TempDir(), "reach-state.json")
+
+	for i := 0; i < 5; i++ {
+		_, span := StartSpan(context.Background(), "governor.eval_cycle")
+		if i < 2 {
+			span.SetStatus(codes.Error, "boom")
+		}
+		span.End()
+	}
+	before := findEntry(t, ReachSnapshot(), "governor")
+
+	if err := SaveReachState(path); err != nil {
+		t.Fatalf("SaveReachState: %v", err)
+	}
+
+	// Same commit: counters resume.
+	resetReachForTest("", nil)
+	if err := LoadReachState(path, testCommit, slog.New(&collectHandler{})); err != nil {
+		t.Fatalf("LoadReachState (same commit): %v", err)
+	}
+	after := findEntry(t, ReachSnapshot(), "governor")
+	if after.SpansTotal != before.SpansTotal || after.SpansError != before.SpansError {
+		t.Errorf("resumed = total %d / error %d, want %d / %d",
+			after.SpansTotal, after.SpansError, before.SpansTotal, before.SpansError)
+	}
+	if after.FirstSeen != before.FirstSeen {
+		t.Errorf("resumed first_seen = %q, want %q", after.FirstSeen, before.FirstSeen)
+	}
+	if after.Window1h == nil || after.Window1h.SpansTotal != before.Window1h.SpansTotal {
+		t.Errorf("resumed window = %+v, want %+v", after.Window1h, before.Window1h)
+	}
+
+	// Different commit: fresh keys, nothing resumed.
+	resetReachForTest("", nil)
+	if err := LoadReachState(path, "def5678", slog.New(&collectHandler{})); err != nil {
+		t.Fatalf("LoadReachState (new commit): %v", err)
+	}
+	if report := ReachSnapshot(); report != nil {
+		t.Errorf("new commit resumed old counters: %+v", report)
+	}
+}
+
+// TestReach_LoadMissingFileIsFirstBoot verifies a missing state file is a
+// normal first boot, not an error.
+func TestReach_LoadMissingFileIsFirstBoot(t *testing.T) {
+	resetReach(t)
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	if err := LoadReachState(path, testCommit, nil); err != nil {
+		t.Fatalf("LoadReachState on a missing file: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("load must not create the file")
+	}
+}
+
+// TestReach_SaveNothingWritesNothing verifies an empty registry writes no file
+// — a spoke that emitted no spans has no reach state worth persisting.
+func TestReach_SaveNothingWritesNothing(t *testing.T) {
+	resetReach(t)
+	path := filepath.Join(t.TempDir(), "reach-state.json")
+	if err := SaveReachState(path); err != nil {
+		t.Fatalf("SaveReachState (empty): %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("empty registry must not write a state file")
+	}
+}
+
+// TestReach_WindowRollover exercises rollWindow directly with fabricated
+// clocks: within the hour the bucket persists, past it the bucket resets.
+func TestReach_WindowRollover(t *testing.T) {
+	c := &reachCounters{}
+	const start = int64(1_000_000)
+
+	c.rollWindow(start)
+	c.winTotal.Add(3)
+	c.winErrors.Add(1)
+
+	// Still inside the window: nothing resets.
+	c.rollWindow(start + reachWindowSeconds - 1)
+	if c.winTotal.Load() != 3 || c.winErrors.Load() != 1 || c.winStart.Load() != start {
+		t.Errorf("window reset early: start=%d total=%d err=%d",
+			c.winStart.Load(), c.winTotal.Load(), c.winErrors.Load())
+	}
+
+	// Past the window: bucket restarts at the new time with zeroed counts.
+	c.rollWindow(start + reachWindowSeconds)
+	if c.winTotal.Load() != 0 || c.winErrors.Load() != 0 || c.winStart.Load() != start+reachWindowSeconds {
+		t.Errorf("window did not reset: start=%d total=%d err=%d",
+			c.winStart.Load(), c.winTotal.Load(), c.winErrors.Load())
+	}
+}

--- a/src/pkg/tracing/tracing.go
+++ b/src/pkg/tracing/tracing.go
@@ -222,9 +222,23 @@ func Tracer(name string) trace.Tracer {
 // Every span automatically carries hive.component derived from its name (see
 // SpanComponent), so package-level reach (#3973) is queryable without any
 // call-site changes.
+//
+// Every span ALSO increments the in-process reach counters (#3993) — even when
+// no exporter is configured and the underlying span is a no-op. That is design
+// D2 of #3973: reach must be reported by every spoke, and the `otel:` exporter
+// is opt-in, so counting cannot depend on it. The returned span is a thin
+// wrapper that observes End/SetStatus for the error counter; the context
+// carries the underlying span, so child spans and any span read back via
+// trace.SpanFromContext behave exactly as before (a status set through the
+// context rather than the returned handle is invisible to reach, which is
+// acceptable at component granularity — every call site in-tree uses the
+// returned handle).
 func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
-	attrs = append(attrs, attribute.String(AttrHiveComponent, SpanComponent(name)))
-	return Tracer(instrumentationName).Start(ctx, name, trace.WithAttributes(attrs...))
+	component := SpanComponent(name)
+	attrs = append(attrs, attribute.String(AttrHiveComponent, component))
+	ctx, span := Tracer(instrumentationName).Start(ctx, name, trace.WithAttributes(attrs...))
+	recordReachStart(component)
+	return ctx, &reachSpan{Span: span, component: component}
 }
 
 // SpanComponent extracts the coarse component from a span name: the prefix


### PR DESCRIPTION
Phase 2a of the PR-reach epic, implementing the accepted design's D1/D2 (see #3973 and `v2/docs/design/pr-reach-telemetry.md`, extended here with the Phase 2 section): reach aggregation is **spoke-side** and **rides the heartbeat**, and the counters are **independent of the OTel exporter** — a spoke with no `otel:` block still counts and still reports.

## What this adds

**Spoke counters — `v2/pkg/tracing/reach.go`**
- Every `tracing.StartSpan` increments per-(component, running commit) counters: `spans_total`, `spans_error` (incremented when the span ends with error status, via a thin span wrapper — a SpanProcessor can't do this because processors only run when an exporter is installed), `first_seen`, `last_seen`.
- Two windows: cumulative-since-boot plus a rolling 1h bucket (`window_1h`) for 2c's deltas.
- Hot path: read-locked map lookup + atomic adds — no allocation, no write lock after a component's first span; the window rollover mutex is touched at most once per component per hour.
- **Cap: 64 components** (`tracing.MaxReachComponents`, named constant with the justification in its comment). Beyond it, spans count into `overflow_spans` and the truncation is **logged once per component** — never silent; the logging set itself is bounded so hostile span names can't grow it.

**Persistence**
- Own file `/data/reach-state.json` (deliberately not the main state file — resolved OQ-2), written by `persistState` on the existing state-save cadence (every eval tick + shutdown), loaded once at boot.
- Entries are commit-keyed: `LoadReachState` resumes only entries matching the running binary's commit, so a new binary starts fresh keys naturally and never inherits reach it did not earn.

**Heartbeat + hub receipt**
- `HeartbeatPayload` gains `component_reach` (omitempty — a spoke with no spans yet, or an old spoke, sends nothing and the hub reads that as "no data", never zero reach).
- The hub treats the field as hostile spoke input: `sanitizeComponentReach` **clips to the same 64-entry cap** (refusals surfaced in `overflow_components`, not silently dropped), runs the identifier sanitizer with explicit length caps on `component`/`commit`, clamps counts non-negative, and drops timestamps that don't parse as RFC3339. Bounded memory per hive by construction.
- The latest sanitized report is stored on the hive's `RegistryEntry` (persisted with the registry), carried forward across beats that omit it. **Storage only.**

## Stored shape (2b's read interface)

Stored on the registry entry as `component_reach`, and identical in `/data/reach-state.json` and on the wire:

```json
{
  "entries": [
    {
      "component": "governor",
      "commit": "abc1234",
      "spans_total": 128,
      "spans_error": 3,
      "first_seen": "2026-08-17T10:00:00Z",
      "last_seen": "2026-08-17T11:42:10Z",
      "window_1h": { "start": "2026-08-17T11:00:00Z", "spans_total": 12, "spans_error": 1 }
    }
  ],
  "overflow_spans": 0,
  "overflow_components": 0
}
```

The six entry keys are exactly the epic's contract; `window_1h` and the overflow counters are additive.

## Deliberately excluded (per the epic's phasing)

- No PR→component mapping, no ancestry join, no `/api/reach` — that's 2b (#3994).
- No error-rate deltas, no status-surface table — that's 2c (#3995).
- No new endpoint, no UI, no joins: the hub stores and nothing reads it yet.
- `component_reach` is never trusted for anything but storage.

## Test evidence

`go test -race -count=1 ./pkg/tracing/` → ok (includes exact-total concurrent increments)
`go test -count=1 ./pkg/hub/` → ok
`go test -count=1 ./cmd/hive/` → ok

Covered: counters increment with the **no-op provider installed and no exporter** (D2 verbatim); concurrent exact totals under `-race`; Ok-overrides-Error status precedence; cap + once-per-component truncation logging; persistence round-trip including fresh-keys-on-new-commit and missing-file-is-first-boot; heartbeat wire shape (field present with data, omitted without); hub receive-path clipping of a 100-entry report to 64 with the clip surfaced — **verified to FAIL with the clip removed** (`stored entries = 100, want clipped to 64`); garbage sanitization (negative/absurd counts, non-RFC3339 timestamps, markup in names); carry-forward across omitting beats.

Fixes #3993
Part of #3973
