### PR TITLE
test(escalation): raise coverage above 90%

### DIFF
--- a/src/pkg/escalation/escalation_test.go
+++ b/src/pkg/escalation/escalation_test.go
@@ -67,6 +67,18 @@ func TestSweep_GreenResetsAndAbsencePrunes(t *testing.T) {
 	}
 }
 
+func TestExcerpt_ReturnsStoredEvidenceOrEmpty(t *testing.T) {
+	s := Load(filepath.Join(t.TempDir(), "streaks.json"))
+
+	s.Sweep([]Observation{obs("org/repo", 7, "sha1", true)}, 3)
+	if got := s.Excerpt("org/repo", 7); got != "ReferenceError: seedMission is not defined" {
+		t.Fatalf("Excerpt = %q, want the stored CI evidence", got)
+	}
+	if got := s.Excerpt("org/repo", 8); got != "" {
+		t.Fatalf("Excerpt for an unknown PR = %q, want empty", got)
+	}
+}
+
 func TestCommentBody_LeadsWithEvidence(t *testing.T) {
 	body := CommentBody(3, []string{"Coverage Suite", "build-gate"}, "ReferenceError: seedMission is not defined")
 	for _, want := range []string{"3 distinct fix attempts", "Coverage Suite", "seedMission is not defined", NeedsHumanLabel} {


### PR DESCRIPTION
## What changed

Adds focused coverage for `pkg/escalation.Store.Excerpt`, asserting both persisted CI evidence and the empty result for an unknown PR.

## Why

`pkg/escalation` measured 89.7% in the coverage workflow and was one of the packages below the 90% goal tracked by #3903. The new test raises it to 93.2% without changing production code or the coverage floor.

## Validation

- `go test ./pkg/escalation -short -count=1`
- `go test ./pkg/escalation -short -race -count=1`
- `go vet ./pkg/escalation`
- `gofmt -d v2/pkg/escalation/escalation_test.go`
- `git diff --check`

Refs #3903

Contributor: GPT 5.6 luna high.
