### PR TITLE
✨ feat(contribute): add OpenAI Codex to the contributor page CLI picker

### DIFF
--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -1835,6 +1835,7 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 <label style="font-size:.9rem;color:#8b949e">Choose your CLI:</label>
 <select id="cli-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">
 <option value="claude" data-install="npm i -g @anthropic-ai/claude-code" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="">Claude Code</option>
+<option value="codex" data-install="npm i -g @openai/codex" data-host-install="npm i -g @openai/codex\ncodex login --device-auth   # or export CODEX_API_KEY / OPENAI_API_KEY for API-key mode" data-model-flag="--model" data-default-model="" data-env="# Optional: Codex reasoning effort — the relay passes it as -c model_reasoning_effort.\n# export AGENT_REASONING_EFFORT=high">OpenAI Codex</option>
 <option value="copilot" data-install="" data-host-install="npm install -g @github/copilot # uses your existing gh auth" data-model-flag="--model" data-default-model="">GitHub Copilot</option>
 <option value="pi" data-install="" data-host-install="curl -fsSL https://pi.dev/install.sh | sh" data-model-flag="--model" data-default-model="">Pi</option>
 <option value="goose" data-install="" data-host-install="# Install Goose: https://github.com/block/goose/releases\n# Install Ollama: https://ollama.com/download\nollama pull llama3.2:3b\nexport GOOSE_PROVIDER=ollama GOOSE_MODEL=llama3.2:3b" data-model-flag="" data-default-model="">Goose</option>
@@ -2016,7 +2017,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 
 // ── #2548 Branded client entry points ──────────────────────────────────────
 // Per-client identity (inline SVG emblems, CSP-safe), first-class parity for
-// Claude / Copilot / Pi / Goose, a documented-only "Open in" deep-link, and a
+// Claude / Codex / Copilot / Pi / Goose, a documented-only "Open in" deep-link, and a
 // customizable copy-paste prompt. All additive: the source of truth stays
 // #cli-select, and everything degrades gracefully if this block never runs.
 //
@@ -2028,6 +2029,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 // labeled onboarding-not-contribution in the UI.
 var EMB={
 claude:'<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#d97757" d="M12 2 3.5 20h3.2l1.6-3.7h7.4L17.3 20h3.2L12 2Zm-2.4 11.2L12 7.6l2.4 5.6H9.6Z"/></svg>',
+codex:'<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4l6.93 4v8L12 20l-6.93-4V8z" fill="none" stroke="#10a37f" stroke-width="1.5" stroke-linejoin="round"/><path d="M10 10.5l2 1.5-2 1.5M13.5 15h3" stroke="#10a37f" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>',
 copilot:'<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12.5" r="8" fill="none" stroke="#e6edf3" stroke-width="1.6"/><circle cx="9" cy="12" r="1.3" fill="#e6edf3"/><circle cx="15" cy="12" r="1.3" fill="#e6edf3"/><path d="M12 4.5V2M8 5l-1-2M16 5l1-2" stroke="#e6edf3" stroke-width="1.4" stroke-linecap="round"/></svg>',
 pi:'<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 8h16" stroke="#7c93ff" stroke-width="2" stroke-linecap="round"/><path d="M9 8v10M15.5 8v7.5a2 2 0 0 0 2 2" stroke="#7c93ff" stroke-width="2" stroke-linecap="round"/></svg>',
 goose:'<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#3fb0ac" d="M6 14a6 6 0 0 1 6-6c1 0 1.6.9 1 1.7 2.5.4 4 2.4 4 5.1 0 .6-.5 1.2-1.2 1.2H8.5A2.5 2.5 0 0 1 6 13.5V14Z"/><circle cx="10.5" cy="10.8" r=".8" fill="#0d1117"/><path d="M13 9.7l2.4-1" stroke="#f0b429" stroke-width="1.4" stroke-linecap="round"/></svg>',
@@ -2046,6 +2048,7 @@ claude:{name:'Claude Code',tag:'Anthropic',peer:true,
     // Desktop with a link"). q= prefills the prompt for the user to review/send.
     href:function(p){return 'claude://claude.ai/new?q='+encodeURIComponent(p);},
     desc:'Opens Claude Desktop with a setup prompt prefilled.'}},
+codex:{name:'Codex',tag:'OpenAI',peer:true},
 copilot:{name:'GitHub Copilot',tag:'GitHub',peer:true},
 pi:{name:'Pi',tag:'pi.dev',peer:true},
 goose:{name:'Goose',tag:'Block (Ollama)',peer:true},
@@ -2069,7 +2072,7 @@ var promptTool2=document.getElementById('prompt-tool2');
 var promptEdited=false;   // once the user edits, don't clobber on same client
 var promptForClient='';   // which client the current prompt text was generated for
 function tileOrder(){
-  // Peers (Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter) first, in select order, then
+  // Peers (Claude/Codex/Copilot/Pi/Goose/LiteLLM/OpenRouter) first, in select order, then
   // the rest — so these tools lead the grid rather than being afterthoughts. This
   // is an ORDERING signal only; peer status is no longer shown as a visible badge.
   var peers=[],rest=[];

--- a/src/pkg/dashboard/contribute_branded_entrypoints_test.go
+++ b/src/pkg/dashboard/contribute_branded_entrypoints_test.go
@@ -7,7 +7,7 @@ import (
 
 // #2548 — branded client entry points (onboarding, additive). These tests pin the
 // rendered /contribute page: per-client visual identity, first-class ordering for
-// Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter (they lead the tile grid; the visible
+// Claude/Codex/Copilot/Pi/Goose/LiteLLM/OpenRouter (they lead the tile grid; the visible
 // "First-class" badge itself was removed per operator request — peer:true is now
 // an ORDERING signal only, not a rendered pill), a documented-only "Open in"
 // deep-link labeled as onboarding-not-contribution, and a full copy-pasteable
@@ -17,7 +17,7 @@ import (
 
 // TestBrandedEntryPoints_IdentityAndParity asserts the find-by-sight tile grid, the
 // per-client inline SVG emblems (CSP-safe, no external images), and first-class
-// ORDERING for Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter are all present — and
+// ORDERING for Claude/Codex/Copilot/Pi/Goose/LiteLLM/OpenRouter are all present — and
 // that the visible "First-class" pill is gone (removed per operator request; the
 // tiles themselves — emblem + name + vendor subtitle — stay).
 func TestBrandedEntryPoints_IdentityAndParity(t *testing.T) {
@@ -46,19 +46,20 @@ func TestBrandedEntryPoints_IdentityAndParity(t *testing.T) {
 		t.Error("the now-unused .ct-parity badge class must be removed, not left dangling")
 	}
 
-	// Ordering: each of the SIX first-class clients must still be marked
+	// Ordering: each of the SEVEN first-class clients must still be marked
 	// peer:true in the CLIENTS table so it leads the grid (tileOrder() puts
 	// peers first) — this is an ordering signal only now, not a rendered badge.
 	for _, peer := range []string{
-		`claude:{name:'Claude Code'`, `copilot:{name:'GitHub Copilot'`, `pi:{name:'Pi'`,
-		`goose:{name:'Goose'`, `litellm:{name:'LiteLLM'`, `openrouter:{name:'OpenRouter'`,
+		`claude:{name:'Claude Code'`, `codex:{name:'Codex'`, `copilot:{name:'GitHub Copilot'`,
+		`pi:{name:'Pi'`, `goose:{name:'Goose'`, `litellm:{name:'LiteLLM'`,
+		`openrouter:{name:'OpenRouter'`,
 	} {
 		if !strings.Contains(body, peer) {
 			t.Errorf("missing first-class client entry %q", peer)
 		}
 	}
-	if strings.Count(body, "peer:true") < 6 {
-		t.Errorf("expected >=6 peer:true (Claude/Copilot/Pi/Goose/LiteLLM/OpenRouter lead the grid), got %d", strings.Count(body, "peer:true"))
+	if strings.Count(body, "peer:true") < 7 {
+		t.Errorf("expected >=7 peer:true (Claude/Codex/Copilot/Pi/Goose/LiteLLM/OpenRouter lead the grid), got %d", strings.Count(body, "peer:true"))
 	}
 
 	// Emblems must be inline SVG (CSP-safe) — no external <img> smuggled into a tile.
@@ -97,7 +98,7 @@ func TestBrandedEntryPoints_DeepLinkLabeledOnboarding(t *testing.T) {
 	}
 
 	// Honesty: no invented vendor deep-link schemes for tools that don't document one.
-	for _, forbidden := range []string{"goose://", "copilot://", "pi://"} {
+	for _, forbidden := range []string{"goose://", "copilot://", "pi://", "codex://"} {
 		if strings.Contains(body, forbidden) {
 			t.Errorf("invented vendor deep-link scheme present: %q", forbidden)
 		}
@@ -141,5 +142,45 @@ func TestBrandedEntryPoints_ExistingSelectorsIntact(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("existing onboarding control regressed/missing: %q", want)
 		}
+	}
+}
+
+// TestContributeCodexOnboardingSurface pins Codex as a first-class picker entry.
+// Every layer below the page already supported it — `just contribute-setup codex`
+// preflights the CLI + auth, the relay drives `codex exec` headlessly and passes
+// AGENT_REASONING_EFFORT as -c model_reasoning_effort, K8S_HEADLESS_BACKENDS
+// lists it, and Dockerfile.contributor pins @openai/codex — but the CLI select
+// and the tile grid omitted it, so contributors had no path to pick it.
+func TestContributeCodexOnboardingSurface(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// The CLI select option, with the vendor's own install command.
+		`<option value="codex"`,
+		`npm i -g @openai/codex`,
+		// Auth is Codex's device login or an API key — the same two modes the
+		// Justfile preflight accepts.
+		`codex login --device-auth`,
+		// --model is honored (codex is not in the relay's NO_MODEL_FLAG_BACKENDS).
+		`data-model-flag="--model" data-default-model="" data-env="# Optional: Codex reasoning effort`,
+		// Tile metadata + emblem so it renders in the grid like its peers.
+		`codex:{name:'Codex',tag:'OpenAI',peer:true}`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("codex onboarding surface missing %q", want)
+		}
+	}
+
+	// Codex must lead the grid next to Claude Code, not trail the non-peer
+	// backends: peer:true plus an earlier position in the select (tileOrder
+	// preserves select order within the peer group).
+	iClaude := strings.Index(body, `<option value="claude"`)
+	iCodex := strings.Index(body, `<option value="codex"`)
+	iOther := strings.Index(body, `<option value="other"`)
+	if iClaude < 0 || iCodex < 0 || iOther < 0 {
+		t.Fatalf("missing select options: claude=%d codex=%d other=%d", iClaude, iCodex, iOther)
+	}
+	if !(iClaude < iCodex && iCodex < iOther) {
+		t.Errorf("codex must sit next to Claude Code in the CLI select: claude=%d codex=%d other=%d", iClaude, iCodex, iOther)
 	}
 }


### PR DESCRIPTION
## What

Adds **OpenAI Codex** to the `/contribute` page's CLI picker, right next to Claude Code:

- an `<option value="codex">` in `#cli-select` — `npm i -g @openai/codex` for host mode, plus the `codex login --device-auth` / `CODEX_API_KEY` hint that matches what the `just contribute-setup codex` preflight actually accepts, and a commented `AGENT_REASONING_EFFORT` line the relay honors
- an inline SVG emblem in `EMB` (CSP-safe, no external image)
- `codex:{name:'Codex',tag:'OpenAI',peer:true}` in `CLIENTS`, so the tile leads the grid with the other first-class clients

## Why

Everything under the page already spoke codex — the picker just never offered it:

| layer | codex support |
|---|---|
| `just contribute-setup codex` | verifies the CLI, then `$CODEX_HOME/auth.json` or `CODEX_API_KEY`/`OPENAI_API_KEY` |
| `just contribute-hive` | stages `~/.codex` into the container |
| `bin/contributor-relay.sh` | `codex exec` headless dispatch, `-c model_reasoning_effort=…`, codex-specific readiness/idle prompt matching |
| `K8S_HEADLESS_BACKENDS` (this page) | already lists `codex:1`, and the Kubernetes note already names Codex as supported |
| `Dockerfile.contributor` / `Dockerfile` | pin `@openai/codex` |

So a contributor who wanted Codex had to pick something else and hand-edit the generated commands. Asked in Discord and cleared: *"no reason – add it via pr"*.

## No deep link

The "Open in your tool" affordance stays Claude-only. OpenAI does not document a `codex://` scheme, and this page's rule is to ship only schemes the vendor documents — `codex://` is now in the honesty test's forbidden list so nobody invents one later.

## Tests

- extended `TestBrandedEntryPoints_IdentityAndParity` to pin the seventh first-class client
- extended the deep-link honesty test with `codex://`
- new `TestContributeCodexOnboardingSurface` pinning the option, install/auth lines, tile metadata, and that codex sits between Claude Code and the non-peer backends in the select

`go test ./pkg/dashboard/` passes (full package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)