### PR TITLE
fix: rate limit nginx authentication endpoints

### DIFF
--- a/src/deploy/nginx.conf
+++ b/src/deploy/nginx.conf
@@ -48,14 +48,21 @@ http {
         limit_req_status 429;
 
         location /api/ {
-            # These nested locations inherit the proxy and security-header
-            # settings above while applying the stricter auth-only bucket.
+            # These nested locations inherit the proxy_set_header /
+            # security-header / timeout settings above while applying the
+            # stricter auth-only bucket. proxy_pass is the one directive
+            # nginx does NOT inherit into a nested location: without it the
+            # request terminates in the empty block and falls through to
+            # static-file serving (a stock nginx 404), silently breaking
+            # every auth path. Each nested location must repeat it.
             location = /api/auth/token {
                 limit_req zone=auth_limit burst=10 nodelay;
+                proxy_pass http://hive_api;
             }
 
             location /api/gh-user-auth/ {
                 limit_req zone=device_flow_limit burst=10 nodelay;
+                proxy_pass http://hive_api;
             }
 
             proxy_pass http://hive_api;
@@ -92,8 +99,11 @@ http {
             # SSO is a public handoff endpoint because the signed token is the
             # credential. It still needs the same per-client throttle as the
             # device-flow routes to limit replay and brute-force traffic.
+            # proxy_pass must be repeated here (nested locations do not
+            # inherit it -- see the /api/ block above).
             location = /sso {
                 limit_req zone=auth_limit burst=10 nodelay;
+                proxy_pass http://hive_api;
             }
 
             proxy_pass http://hive_api;

--- a/src/deploy/nginx.conf
+++ b/src/deploy/nginx.conf
@@ -11,6 +11,17 @@ http {
         server hive:3001;
     }
 
+    # Authentication endpoints are intentionally cheap to call for a browser,
+    # but expensive to call at scale: /api/auth/token exposes whether a
+    # dashboard token is configured, while the device-flow and SSO paths mint
+    # sessions. Keep the bucket keyed on the binary address form so IPv4 and
+    # IPv6 clients use the same compact fixed-size key representation.
+    limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/m;
+    # GitHub's device-flow client polls about every five seconds while waiting
+    # for approval. Keep that public subtree throttled without rejecting a
+    # normal login after the initial burst.
+    limit_req_zone $binary_remote_addr zone=device_flow_limit:10m rate=15r/m;
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         '' close;
@@ -32,8 +43,21 @@ http {
         # this line, anything resolving "localhost" to ::1 -- container
         # healthchecks, IPv6 clients -- gets ECONNREFUSED. See issue #2774.
         listen [::]:3001;
+        # Return the HTTP status clients can recognize as throttling instead
+        # of nginx's default 503 for requests rejected by limit_req.
+        limit_req_status 429;
 
         location /api/ {
+            # These nested locations inherit the proxy and security-header
+            # settings above while applying the stricter auth-only bucket.
+            location = /api/auth/token {
+                limit_req zone=auth_limit burst=10 nodelay;
+            }
+
+            location /api/gh-user-auth/ {
+                limit_req zone=device_flow_limit burst=10 nodelay;
+            }
+
             proxy_pass http://hive_api;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -65,6 +89,13 @@ http {
         }
 
         location / {
+            # SSO is a public handoff endpoint because the signed token is the
+            # credential. It still needs the same per-client throttle as the
+            # device-flow routes to limit replay and brute-force traffic.
+            location = /sso {
+                limit_req zone=auth_limit burst=10 nodelay;
+            }
+
             proxy_pass http://hive_api;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/src/pkg/config/gateway_nginx_dualstack_test.go
+++ b/src/pkg/config/gateway_nginx_dualstack_test.go
@@ -152,3 +152,43 @@ func TestGatewayDoesNotSetFrameOptionsOrHSTS(t *testing.T) {
 			"this guard should be updated instead of just deleted")
 	}
 }
+
+// TestGatewayAuthRateLimiting pins the ingress throttle for the public
+// authentication paths tracked by issue #3906. Keep this check path-specific:
+// placing limit_req on the whole /api/ location would throttle ordinary
+// dashboard reads and still would not document which credential-bearing paths
+// are protected.
+func TestGatewayAuthRateLimiting(t *testing.T) {
+	conf := readNginxConf(t)
+
+	zone := regexp.MustCompile(`(?m)^\s*limit_req_zone\s+\$binary_remote_addr\s+zone=auth_limit:10m\s+rate=5r/m;`)
+	if !zone.MatchString(conf) {
+		t.Fatal("nginx.conf must define the per-client auth_limit zone at 5 requests per minute")
+	}
+	deviceFlowZone := regexp.MustCompile(`(?m)^\s*limit_req_zone\s+\$binary_remote_addr\s+zone=device_flow_limit:10m\s+rate=15r/m;`)
+	if !deviceFlowZone.MatchString(conf) {
+		t.Fatal("nginx.conf must define a device-flow zone at 15 requests per minute")
+	}
+
+	if !regexp.MustCompile(`(?m)^\s*limit_req_status\s+429;`).MatchString(conf) {
+		t.Fatal("nginx.conf must return 429 when an auth request exceeds its rate limit")
+	}
+
+	for _, tc := range []struct {
+		path string
+		zone string
+	}{
+		{path: "/api/auth/token", zone: "auth_limit"},
+		{path: "/api/gh-user-auth/", zone: "device_flow_limit"},
+		{path: "/sso", zone: "auth_limit"},
+	} {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			location := regexp.QuoteMeta(tc.path)
+			pattern := regexp.MustCompile(`(?ms)^\s*location\s+(?:=\s+)?` + location + `\s*\{.*?^\s*limit_req\s+zone=` + regexp.QuoteMeta(tc.zone) + `\s+burst=10\s+nodelay;`)
+			if !pattern.MatchString(conf) {
+				t.Errorf("nginx.conf auth location %q is missing limit_req zone=%s burst=10 nodelay", tc.path, tc.zone)
+			}
+		})
+	}
+}

--- a/src/pkg/config/gateway_nginx_dualstack_test.go
+++ b/src/pkg/config/gateway_nginx_dualstack_test.go
@@ -184,10 +184,27 @@ func TestGatewayAuthRateLimiting(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.path, func(t *testing.T) {
+			// Capture the location's own block body ([^}]* -- these auth
+			// locations contain no nested braces) so both assertions are
+			// scoped INSIDE the block, not satisfied by a directive that
+			// happens to appear later in the file.
 			location := regexp.QuoteMeta(tc.path)
-			pattern := regexp.MustCompile(`(?ms)^\s*location\s+(?:=\s+)?` + location + `\s*\{.*?^\s*limit_req\s+zone=` + regexp.QuoteMeta(tc.zone) + `\s+burst=10\s+nodelay;`)
-			if !pattern.MatchString(conf) {
+			block := regexp.MustCompile(`(?ms)^\s*location\s+(?:=\s+)?` + location + `\s*\{([^}]*)\}`)
+			m := block.FindStringSubmatch(conf)
+			if m == nil {
+				t.Fatalf("nginx.conf is missing a dedicated location block for %q", tc.path)
+			}
+			body := m[1]
+			if !regexp.MustCompile(`(?m)^\s*limit_req\s+zone=` + regexp.QuoteMeta(tc.zone) + `\s+burst=10\s+nodelay;`).MatchString(body) {
 				t.Errorf("nginx.conf auth location %q is missing limit_req zone=%s burst=10 nodelay", tc.path, tc.zone)
+			}
+			// proxy_pass is NOT inherited into nested locations. Without its
+			// own proxy_pass the block terminates the request and nginx falls
+			// back to static-file serving: every auth path 404s and login is
+			// bricked while this structural test stays green. Pin the
+			// directive inside the block itself.
+			if !regexp.MustCompile(`(?m)^\s*proxy_pass\s+http://hive_api;`).MatchString(body) {
+				t.Errorf("nginx.conf auth location %q must carry its own proxy_pass (nested locations do not inherit it; omitting it 404s the auth path)", tc.path)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add per-client nginx request zones for authentication-sensitive routes
- throttle `/api/auth/token` and `/sso` at 5 requests per minute, with a burst of 10
- throttle GitHub device-flow routes at 15 requests per minute so normal five-second polling remains usable
- return `429 Too Many Requests` when the auth throttle is exceeded
- add regression coverage that pins each protected location to its intended zone

## Why

The gateway previously proxied authentication-sensitive paths without an ingress limit. A reachable hive could therefore receive unlimited token-enumeration, device-flow, or SSO handoff attempts from one client address. The ordinary `/api/` and `/` proxy paths remain unthrottled.

Fixes #3906

## Validation

- `GOCACHE=/tmp/hive-go-cache CC=/usr/bin/gcc go test ./pkg/config -count=1`
- `git diff --check`
- nginx container syntax validation was unavailable because neither a local nginx binary nor the `nginx:1-alpine` image is installed; the existing configuration test and static directive checks pass.

Contributor: GPT 5.6 luna high.
