### PR TITLE
feat(deploy): kustomize overlays for openshift + standalone/self-hosted hive

### DIFF
--- a/src/deploy/kustomize/overlays/openshift/anyuid-scc-rolebinding.yaml
+++ b/src/deploy/kustomize/overlays/openshift/anyuid-scc-rolebinding.yaml
@@ -1,0 +1,31 @@
+# Bind the cluster-scoped `anyuid` SCC to the base ServiceAccount `hive`.
+#
+# The Hive pod starts as root (UID 0) to install the ACMM MITM-proxy iptables
+# rules and to chown the PVC before dropping to the `dev` user. OpenShift's
+# default `restricted-v2` SCC forces a random high UID and forbids that, so the
+# pod crash-loops. Landing it on `anyuid` (which permits the container's own
+# declared UID/root) is the fix.
+#
+# The base's deployment.yaml sets `serviceAccountName: hive` and
+# dashboard-route-rbac.yaml defines that ServiceAccount, so the subject below
+# matches the SA the base actually uses (NOT `hive-sa`).
+#
+# Verify after apply:
+#   oc -n hive get pod -l app.kubernetes.io/name=hive \
+#     -o jsonpath='{.items[0].metadata.annotations.openshift\.io/scc}'
+#   # MUST print "anyuid" — "restricted-v2" means this binding did not take.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-anyuid
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: hive
+    namespace: hive

--- a/src/deploy/kustomize/overlays/openshift/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/openshift/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# OpenShift platform overlay — a THIN delta on top of the plain-Kubernetes
+# base (../../../k8s). It adds only what OpenShift needs that the base omits:
+#
+#   1. A Route (route.openshift.io/v1) to expose the dashboard — OpenShift's
+#      native ingress, which the base has no equivalent for.
+#   2. The `anyuid` SCC RoleBinding — the pod starts as root to set up the
+#      ACMM MITM-proxy iptables and to chown the PVC, so it MUST land on the
+#      `anyuid` SCC. On the default `restricted-v2` SCC it crash-loops.
+#
+# It changes NOTHING about the workload itself; the base deployment already
+# carries the correct securityContext (fsGroup 1002, NET_ADMIN + su-exec caps).
+
+resources:
+  - ../../../k8s
+  - route.yaml
+  - anyuid-scc-rolebinding.yaml

--- a/src/deploy/kustomize/overlays/openshift/route.yaml
+++ b/src/deploy/kustomize/overlays/openshift/route.yaml
@@ -1,0 +1,28 @@
+# OpenShift Route exposing the Hive dashboard on `/`.
+#
+# Targets the base Service `hive` on its named `dashboard` port (3002). The
+# base ships no Route (plain-k8s uses Ingress), so this is additive.
+#
+# TLS is edge-terminated with an HTTP->HTTPS redirect. `host` is intentionally
+# left empty so OpenShift auto-generates a default hostname
+# (hive-dashboard-<namespace>.apps.<cluster-domain>). Set `spec.host` here if
+# you need a fixed hostname, or override it in a higher overlay.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hive-dashboard
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+spec:
+  path: /
+  port:
+    targetPort: dashboard
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: hive
+    weight: 100
+  wildcardPolicy: None

--- a/src/deploy/kustomize/overlays/standalone/README.md
+++ b/src/deploy/kustomize/overlays/standalone/README.md
@@ -1,0 +1,90 @@
+# Standalone (self-hosted, hub-less) Hive overlay
+
+This Kustomize overlay deploys a **self-hosted Hive** — the "Joe" scenario: an
+operator running their own Hive against their own repos, with **no connection to
+the kubestellar hub**. It layers on the two in-repo bases:
+
+| Base | What it provides |
+|------|------------------|
+| `../../../k8s` | Core Hive workload: namespace, ConfigMap, Secret, PVC, RBAC, Deployment, Service. |
+| `../../../inference` | An in-cluster OpenAI-compatible inference backend (llama.cpp serving Qwen2.5-0.5B) plus EPP RBAC — so you get a working model endpoint without an external provider. |
+
+The overlay only adds **deltas**; it never edits the bases. A concrete,
+filled-in copy lives in [`example-joe-spyre/`](./example-joe-spyre) for
+reference.
+
+## What you MUST swap
+
+All placeholders are UPPER_SNAKE_CASE. Search for them before applying:
+
+| Placeholder | File | What to put |
+|-------------|------|-------------|
+| `YOUR_ORG`, `YOUR_REPO` | `patch-configmap.yaml` (`project:`) | Your GitHub org and repo(s). `primary_repo` must be one of `repos`. |
+| `YOUR_BOT_LOGIN` | `patch-configmap.yaml` (`project.ai_author`) | The GitHub login the agents author PRs as. |
+| `YOUR_GITHUB_LOGIN` | `patch-configmap.yaml` (`dashboard.authorized_users`) | Your GitHub login. First entry is the owner (read-write). |
+| `YOUR_OAUTH_CLIENT_ID` | `patch-configmap.yaml` (`github.oauth_client_id`) | Client ID of a GitHub OAuth App for device-flow dashboard login. For GHE, also set `github.forge` / `project.forge` to your host. |
+| litellm `endpoint` | `patch-configmap.yaml` (`governor.litellm.endpoint`) | Your OpenAI-compatible endpoint. Defaults to the in-cluster inference Service. |
+| `YOUR_RWX_STORAGE_CLASS` | `patch-pvc-storageclass.yaml` | A storage class on your cluster (RWO is fine for the default single replica). |
+| Route host (OpenShift) | see below | If you also want a Route, add the openshift overlay or set `spec.host`. |
+
+Also populate `hive-secrets` (from the base) with a GitHub App PEM **or**
+`HIVE_GITHUB_TOKEN`, and — if your litellm/inference endpoint needs auth —
+the key named by `governor.litellm.api_key_env` (default `HIVE_LITELLM_API_KEY`)
+or mounted at `api_key_file` (default `/secrets/litellm_api_key`).
+
+## The NET_ADMIN decision
+
+The base Deployment requests `CAP_NET_ADMIN`. The Hive entrypoint uses it to
+install a forced-proxy-egress `iptables` REDIRECT that enforces the ACMM MITM
+proxy (the security gate that stops an agent bypassing the proxy with a raw
+token).
+
+- **Cluster GRANTS NET_ADMIN (most do):** do nothing. The full gate comes up
+  automatically. This is the recommended, fail-closed default.
+- **Cluster DENIES NET_ADMIN:** the entrypoint FATALs and the pod crash-loops
+  (`FATAL: refusing to start ... capability model would be advisory-only`). To
+  start anyway in **advisory-only** mode, uncomment the
+  `- path: patch-advisory-mode.yaml` line in `kustomization.yaml`. That sets
+  `HIVE_PROXY_ADVISORY_OK=true`. **Trade-off:** the egress gate becomes
+  best-effort, not enforced — an agent could bypass the proxy. Only do this if
+  you accept that.
+
+See `src/docs/net-admin-requirement.md` for the full explanation.
+
+## Install
+
+```bash
+# Review the rendered manifests first:
+kubectl kustomize src/deploy/kustomize/overlays/standalone
+
+# Apply:
+kubectl apply -k src/deploy/kustomize/overlays/standalone
+
+# Watch it come up:
+kubectl -n hive rollout status deploy/hive
+kubectl -n hive-inference rollout status deploy/vllm
+```
+
+## Pinning / upgrading the image
+
+The base tracks `ghcr.io/kubestellar/hive:stable`. To pin a reviewed digest (so
+upgrades are deliberate), run from this overlay directory:
+
+```bash
+kustomize edit set image \
+  ghcr.io/kubestellar/hive=ghcr.io/kubestellar/hive@sha256:<digest>
+```
+
+That writes an `images:` entry into `kustomization.yaml` (git-tracked). To
+upgrade, bump the digest and re-apply:
+
+```bash
+kubectl apply -k src/deploy/kustomize/overlays/standalone
+```
+
+## Exposing the dashboard
+
+This overlay does not create an Ingress or Route. On OpenShift, use the
+`../openshift` overlay (or add a Route with your `spec.host`) which targets the
+base Service `hive` port `dashboard` (3002). On plain Kubernetes, add your own
+Ingress to the same Service/port.

--- a/src/deploy/kustomize/overlays/standalone/example-joe-spyre/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/standalone/example-joe-spyre/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EXAMPLE overlay — a filled-in copy of the standalone overlay showing the
+# finished shape for a fictional user "Joe" deploying to a Spyre cluster.
+#
+# ⚠️  EVERY value below is an EXAMPLE. Replace them with your own before using.
+#     This directory exists to show what a completed standalone overlay looks
+#     like — copy it, don't apply it verbatim.
+#
+# It is one directory DEEPER than the standalone overlay, so the base paths gain
+# one `../` segment: ../../../../k8s and ../../../../inference.
+# ─────────────────────────────────────────────────────────────────────────────
+
+resources:
+  - ../../../../k8s
+  - ../../../../inference
+  # EXAMPLE: Joe is on OpenShift, so he exposes the dashboard with a Route.
+  # On plain Kubernetes use an Ingress instead. Replace the host in route.yaml.
+  - route.yaml
+
+# EXAMPLE: pin a reviewed digest. Replace with a digest you have reviewed, or
+# remove to track the `stable` channel.
+images:
+  - name: ghcr.io/kubestellar/hive
+    newName: ghcr.io/kubestellar/hive
+    newTag: stable
+
+patches:
+  - path: patch-configmap.yaml
+  - path: patch-pvc-storageclass.yaml
+  # Joe's cluster GRANTS NET_ADMIN, so advisory mode is NOT enabled here (the
+  # full fail-closed security gate is used). Uncomment only on a cluster that
+  # denies NET_ADMIN — see ../README.md "The NET_ADMIN decision".
+  # - path: patch-advisory-mode.yaml

--- a/src/deploy/kustomize/overlays/standalone/example-joe-spyre/patch-configmap.yaml
+++ b/src/deploy/kustomize/overlays/standalone/example-joe-spyre/patch-configmap.yaml
@@ -1,0 +1,59 @@
+# EXAMPLE configmap patch — filled-in values for the fictional "Joe" deploy.
+# ⚠️  Replace every value with your own. See ../patch-configmap.yaml for the
+#     annotated version explaining each key and its verified config location.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hive-config
+  namespace: hive
+data:
+  hive.yaml: |
+    project:
+      org: joesorg
+      repos:
+        - joesrepo
+      ai_author: joes-hive-bot
+      primary_repo: joesrepo
+
+    acmm_level: 2
+
+    hub:
+      enabled: false
+
+    agents:
+      supervisor:
+        enabled: true
+        backend: litellm
+        beads_dir: /data/beads/supervisor
+        clear_on_kick: true
+      scanner:
+        enabled: true
+        backend: litellm
+        beads_dir: /data/beads/scanner
+        clear_on_kick: true
+      architect:
+        enabled: true
+        backend: litellm
+        beads_dir: /data/beads/architect
+        clear_on_kick: false
+
+    governor:
+      eval_interval_s: 300
+      litellm:
+        # EXAMPLE: an in-cluster litellm proxy Service. Joe runs one at
+        # litellm-svc in namespace llm-gateway. Swap for your own endpoint.
+        endpoint: http://litellm-svc.llm-gateway.svc.cluster.local:4000
+        api_key_env: HIVE_LITELLM_API_KEY
+        default_model: qwen2.5-0.5b-instruct
+
+    dashboard:
+      port: 3002
+      hub_proxied: false
+      authorized_users:
+        - joe:owner
+
+    github:
+      # EXAMPLE OAuth App client id — replace with your own.
+      oauth_client_id: Ov23liEXAMPLEjoe
+
+    notifications: {}

--- a/src/deploy/kustomize/overlays/standalone/example-joe-spyre/patch-pvc-storageclass.yaml
+++ b/src/deploy/kustomize/overlays/standalone/example-joe-spyre/patch-pvc-storageclass.yaml
@@ -1,0 +1,9 @@
+# EXAMPLE PVC storage-class patch. ⚠️  Replace with a class on YOUR cluster.
+# Joe's cluster is OpenShift Data Foundation, so he uses the CephFS RWX class.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hive-data
+  namespace: hive
+spec:
+  storageClassName: ocs-storagecluster-cephfs

--- a/src/deploy/kustomize/overlays/standalone/example-joe-spyre/route.yaml
+++ b/src/deploy/kustomize/overlays/standalone/example-joe-spyre/route.yaml
@@ -1,0 +1,24 @@
+# EXAMPLE OpenShift Route for Joe's dashboard.
+# ⚠️  Replace `spec.host` with your own cluster's apps domain (or drop `host`
+#     entirely to let OpenShift auto-generate one). Targets the base Service
+#     `hive` port `dashboard` (3002), edge TLS with HTTP->HTTPS redirect.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hive-dashboard
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+spec:
+  host: hive.apps.joes-cluster.example.com
+  path: /
+  port:
+    targetPort: dashboard
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: hive
+    weight: 100
+  wildcardPolicy: None

--- a/src/deploy/kustomize/overlays/standalone/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/standalone/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Standalone / self-hosted overlay — the hub-less "Joe" scenario.
+#
+# This is for an operator running their OWN Hive against their OWN repos, with
+# NO connection to the kubestellar hub. It layers on TWO bases:
+#
+#   ../../../k8s        the core Hive workload (namespace/configmap/secret/pvc/
+#                       rbac/deployment/service)
+#   ../../../inference  an in-cluster OpenAI-compatible inference backend
+#                       (llama.cpp serving Qwen2.5-0.5B) + EPP RBAC, so a
+#                       self-hosted user gets a working model endpoint without
+#                       wiring an external provider.
+#
+# Everything operator-specific (org/repo, owner login, storage class, OAuth
+# client id, litellm endpoint) is a PLACEHOLDER you swap. See README.md for the
+# full swap list and install/upgrade commands. A concrete, filled-in copy of
+# this overlay lives in ./example-joe-spyre for reference.
+
+resources:
+  - ../../../k8s
+  - ../../../inference
+
+# The base image tracks the `stable` channel. For a self-hosted deployment you
+# can pin a reviewed digest instead by uncommenting and setting `images:` here,
+# or (preferred, so it stays in git history) run:
+#   kustomize edit set image ghcr.io/kubestellar/hive=ghcr.io/kubestellar/hive@sha256:<digest>
+# images:
+#   - name: ghcr.io/kubestellar/hive
+#     newName: ghcr.io/kubestellar/hive
+#     newTag: stable
+
+patches:
+  # 1. Rewrite hive.yaml for the hub-less scenario (org/repo, owner, backend,
+  #    hub disabled, ACMM level). Replaces the whole ConfigMap data.
+  - path: patch-configmap.yaml
+
+  # 2. RWX storage class placeholder for the hive-data PVC.
+  - path: patch-pvc-storageclass.yaml
+
+  # 3. NET_ADMIN escape hatch (COMMENTED OUT by default). Uncomment ONLY on a
+  #    locked-down cluster that DENIES NET_ADMIN — see README "The NET_ADMIN
+  #    decision". Leaving it commented keeps the fail-CLOSED security gate.
+  # - path: patch-advisory-mode.yaml

--- a/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml
+++ b/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml
@@ -1,0 +1,34 @@
+# NET_ADMIN escape hatch — the crash-loop workaround for locked-down clusters.
+#
+# ⚠️  This patch is NOT applied by default. It is referenced (commented out) in
+# kustomization.yaml. Uncomment that line ONLY if your cluster DENIES the
+# NET_ADMIN capability the base already requests.
+#
+# Why it exists:
+#   The base deployment requests CAP_NET_ADMIN so the entrypoint can install the
+#   forced-proxy-egress iptables REDIRECT that enforces the ACMM MITM proxy. On
+#   a cluster that GRANTS NET_ADMIN (most do), you need NOTHING here — the full
+#   security gate comes up automatically.
+#
+#   On a cluster that DENIES NET_ADMIN, the entrypoint cannot establish the
+#   redirect and FATALs (exit 1, "refusing to start ... capability model would
+#   be advisory-only") — a fail-CLOSED crash loop. Setting
+#   HIVE_PROXY_ADVISORY_OK=true tells it to start anyway in ADVISORY-ONLY mode.
+#
+# SECURITY TRADE-OFF: advisory mode means the MITM egress gate is best-effort,
+# not enforced — an agent with a raw token could bypass the proxy. Only enable
+# this when you understand and accept that. The env var name is verified against
+# src/deploy/entrypoint.sh (HIVE_PROXY_ADVISORY_OK).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hive
+  namespace: hive
+spec:
+  template:
+    spec:
+      containers:
+        - name: hive
+          env:
+            - name: HIVE_PROXY_ADVISORY_OK
+              value: "true"

--- a/src/deploy/kustomize/overlays/standalone/patch-configmap.yaml
+++ b/src/deploy/kustomize/overlays/standalone/patch-configmap.yaml
@@ -1,0 +1,98 @@
+# Strategic-merge patch replacing the base `hive-config` ConfigMap's hive.yaml
+# for the hub-less / self-hosted scenario.
+#
+# A ConfigMap's `data` values are opaque strings, so this whole `hive.yaml`
+# block REPLACES the base one (there is no deep-merge inside the string). Keep
+# it complete. Every key below is verified against src/pkg/config/config.go —
+# note the exact struct locations, which are easy to get wrong:
+#   - hub.enabled ......... top-level `hub:` block  (HubConfig)
+#   - acmm_level .......... TOP-LEVEL key           (Config.ACMMLevel, *int)
+#   - agents.*.backend .... valid enum: litellm | vllm | llm-d | watsonx  (CLI
+#                           backends are copilot/claude/etc.). NOT "openrouter"
+#                           — openrouter is a gateway KIND, not a backend value.
+#   - dashboard.hub_proxied / dashboard.authorized_users  (DashboardConfig — the
+#                           runtime reads these off Dashboard, see server.go
+#                           handleLivez/isHubProxied and config.go:3175)
+#   - github.oauth_client_id  (GitHubConfig.OAuthClientID — read from GitHub,
+#                           NOT Dashboard: see dashboard device-flow auth)
+#   - governor.litellm .... LiteLLMConfig lives UNDER governor: (Config.Governor)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hive-config
+  namespace: hive
+data:
+  hive.yaml: |
+    # ── Project: your repos. SWAP these placeholders. ──────────────────────
+    project:
+      org: YOUR_ORG              # e.g. joesorg
+      repos:
+        - YOUR_REPO              # e.g. joesrepo
+      ai_author: YOUR_BOT_LOGIN  # GitHub login the agents author PRs as
+      primary_repo: YOUR_REPO    # must be one of `repos` above
+
+    # ── ACMM autonomy level. 2 = plan+approve gating (a sensible self-hosted
+    #    default). Top-level key, resolved into Config.ACMMLevel. ────────────
+    acmm_level: 2
+
+    # ── Hub DISABLED. The zero value of HubConfig.Enabled is already false, so
+    #    the base (which has no hub: block) is hub-less by default. This makes
+    #    it explicit — belt-and-suspenders so no upstream default flips it on.
+    hub:
+      enabled: false
+
+    # ── Agents. backend `litellm` routes to the in-cluster OpenAI-compatible
+    #    endpoint shipped by ../../../inference (or any litellm proxy you point
+    #    governor.litellm at). Swap to `vllm` to hit HIVE_VLLM_ENDPOINT directly.
+    agents:
+      supervisor:
+        enabled: true
+        backend: litellm
+        beads_dir: /data/beads/supervisor
+        clear_on_kick: true
+      scanner:
+        enabled: true
+        backend: litellm
+        beads_dir: /data/beads/scanner
+        clear_on_kick: true
+      architect:
+        enabled: true
+        backend: litellm
+        beads_dir: /data/beads/architect
+        clear_on_kick: false
+
+    governor:
+      eval_interval_s: 300
+      # LiteLLM inference backend (UNDER governor:, per LiteLLMConfig). Point
+      # `endpoint` at your OpenAI-compatible proxy. The in-cluster llama.cpp
+      # from ../../../inference is reachable at the HIVE_VLLM_ENDPOINT the base
+      # deployment sets; a dedicated litellm proxy would be its own Service.
+      litellm:
+        endpoint: http://vllm-svc.hive-inference.svc.cluster.local:8000
+        # api_key_env names the ENV VAR holding the key (default
+        # HIVE_LITELLM_API_KEY); api_key_file a mounted path
+        # (default /secrets/litellm_api_key). Provide whichever your proxy needs.
+        api_key_env: HIVE_LITELLM_API_KEY
+        default_model: qwen2.5-0.5b-instruct
+
+    dashboard:
+      port: 3002
+      # Standalone spoke: NOT behind the hub's nginx auth-proxy, so the hive
+      # must enforce device-flow authz itself. false is the default but set
+      # explicitly so an operator sees this is a direct-route spoke.
+      hub_proxied: false
+      # First entry is the OWNER (read-write). Add more as
+      # "login:read" / "login:owner". SWAP the placeholder login.
+      authorized_users:
+        - YOUR_GITHUB_LOGIN:owner
+
+    # ── GitHub OAuth client id for the device-flow login. Required for a
+    #    direct-route (non-hub-proxied) spoke's dashboard login. Create an OAuth
+    #    App (github.com/settings/developers, or your GHE instance) and paste its
+    #    Client ID here. For a GitHub Enterprise host, also set project.forge /
+    #    github.forge to your host (e.g. github.example.com). The client SECRET
+    #    is NOT needed for device flow.
+    github:
+      oauth_client_id: YOUR_OAUTH_CLIENT_ID
+
+    notifications: {}

--- a/src/deploy/kustomize/overlays/standalone/patch-pvc-storageclass.yaml
+++ b/src/deploy/kustomize/overlays/standalone/patch-pvc-storageclass.yaml
@@ -1,0 +1,17 @@
+# Set the storageClassName on the base `hive-data` PVC.
+#
+# SWAP `YOUR_RWX_STORAGE_CLASS` for a storage class available on YOUR cluster.
+# On OpenShift Data Foundation this is typically `ocs-storagecluster-cephfs`
+# (RWX/CephFS); on other clusters use whatever RWX (or RWO if a single replica
+# suffices) class you have — e.g. `standard`, `gp3-csi`, `longhorn`.
+#
+# The base PVC requests accessModes: ReadWriteOnce. RWX is only required if you
+# ever scale beyond a single pod or need the volume mounted elsewhere; the
+# Deployment is replicas:1 + strategy:Recreate, so RWO works for the default.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hive-data
+  namespace: hive
+spec:
+  storageClassName: YOUR_RWX_STORAGE_CLASS

--- a/src/docs/manual-provisioning.md
+++ b/src/docs/manual-provisioning.md
@@ -1,5 +1,13 @@
 # Provisioning a Hosted Hive
 
+> **Self-hosting a standalone hive (no hub)?** Most of this guide is about
+> **hub-attached** hosted hives on the KubeStellar-internal fleet (hive-oke /
+> vllm-d, shared hub, placeholder pools). If instead you are standing up your
+> **own** hub-less hive on your **own** cluster against your **own** repos, read
+> **[Standalone / self-hosted (no hub)](#standalone--self-hosted-no-hub)** below
+> and skip the hub-only Path A / Path B, `meta.json`, and placeholder-pool
+> sections — none of them apply to you.
+
 This guide documents how hosted hives are provisioned, covering both paths:
 
 - **Automated provisioning** — the hub creates everything itself, on any cluster
@@ -46,6 +54,195 @@ the target cluster.
   `/data/hub-registry.json`.
 - For manual (vllm-d) provisioning: the `system:openshift:scc:anyuid`
   ClusterRole must exist (it does by default on OpenShift).
+
+---
+
+## Standalone / self-hosted (no hub)
+
+This section is the **complete** path for the hub-less scenario: an operator
+("Joe") running their **own** hive on their **own** firewalled cluster, against
+their **own** repos, with **self-hosted inference** (litellm / vllm / llm-d) and
+**no attachment** to `hub.kubestellar.io`. Everything after this section (Path A,
+Path B, `meta.json`, placeholder pools, claiming, upgrade-via-hub) is
+**hub-only** and does **not** apply — skip it.
+
+### What "standalone" means
+
+A standalone hive has **no hub**. In `src/pkg/config/config.go` the `hub:` block
+is a `HubConfig` whose zero value has `Enabled: false`, so a config that simply
+omits `hub:` is already hub-less. Concretely, a standalone hive needs **none** of
+the hub plumbing the rest of this guide describes:
+
+- **No `HIVE_HUB_SECRET`, no `HIVE_HUB_URL`, no derived `HIVE_HEARTBEAT_KEY` /
+  `HIVE_SESSION_KEY` / `HIVE_SSO_KEY`** — those authenticate a spoke to a hub; a
+  hive with nothing to heartbeat to needs none of them.
+- **No `meta.json` / My-Hives / hub SaaS record** — there is no hub SaaS store.
+- **No claim / placeholder-pool / Upgrade steps** — placeholders and hub-driven
+  auto-upgrade are hub features. You upgrade the image yourself (below).
+
+Because there is no hub auth proxy in front of it, a standalone hive enforces its
+own dashboard login: `dashboard.hub_proxied: false` (the default) plus a
+`dashboard.authorized_users` allowlist and a `github.oauth_client_id` for the
+device-flow login. All three are covered in the swap checklist.
+
+### Install method: Kustomize
+
+Use the **Kustomize** overlays — a peer already built a base and a standalone
+overlay, so this is the least-effort, git-trackable path (no operator, no Helm
+values to reverse-engineer). The overlay layers two in-repo bases — the core
+workload (`src/deploy/k8s`) and an in-cluster OpenAI-compatible inference backend
+(`src/deploy/inference`, llama.cpp serving Qwen2.5-0.5B) — so you get a working
+model endpoint out of the box. See the overlay and its README here:
+
+- **Standalone overlay** —
+  [github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/standalone](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/standalone)
+  (annotated `patch-configmap.yaml`, `patch-pvc-storageclass.yaml`,
+  `patch-advisory-mode.yaml`, and a
+  [`README.md`](https://github.com/kubestellar/hive/blob/v4/src/deploy/kustomize/overlays/standalone/README.md)
+  with the full swap list).
+- **Filled-in example** ("Joe on Spyre") —
+  [github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/standalone/example-joe-spyre](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/standalone/example-joe-spyre).
+  Every value there is a placeholder — copy the shape, don't apply it verbatim.
+
+There are two flows. Pick based on whether you just want to *see it run* or
+you're doing a *real* deployment.
+
+**1. Remote quickstart (see the shape).** Kustomize can build straight from
+GitHub — no clone:
+
+```bash
+kubectl apply -k "https://github.com/kubestellar/hive/src/deploy/kustomize/overlays/standalone?ref=v4"
+```
+
+This applies the overlay with its **PLACEHOLDER** values (`YOUR_ORG`,
+`YOUR_OAUTH_CLIENT_ID`, `YOUR_RWX_STORAGE_CLASS`, …). It is only for seeing the
+manifest shape come up — it will **not** be a working hive, because the repo,
+storage class, OAuth app, and inference endpoint are all placeholders you must
+swap first.
+
+**2. Real path (clone → edit → apply).** This is the path you actually deploy,
+because you **must** swap values before it works:
+
+```bash
+git clone -b v4 https://github.com/kubestellar/hive.git
+cd hive/src/deploy/kustomize/overlays/standalone
+# Edit the placeholders — see "What you must swap" below:
+#   patch-configmap.yaml       (org/repos, owner login, OAuth client id, litellm endpoint)
+#   patch-pvc-storageclass.yaml (your RWX storage class)
+# Review the rendered manifests, then apply:
+kubectl kustomize .
+kubectl apply -k .
+kubectl -n hive rollout status deploy/hive
+kubectl -n hive-inference rollout status deploy/vllm
+```
+
+**Upgrading the image.** The base tracks `ghcr.io/kubestellar/hive:stable`. To
+pin a reviewed tag or digest (so upgrades are deliberate — there is no hub to
+auto-upgrade you), run from the overlay directory and re-apply:
+
+```bash
+kustomize edit set image ghcr.io/kubestellar/hive=ghcr.io/kubestellar/hive:<tag>
+# or a digest:  ...=ghcr.io/kubestellar/hive@sha256:<digest>
+kubectl apply -k .
+```
+
+**On OpenShift.** The standalone overlay does not create a Route or grant the
+`anyuid` SCC. The
+[`overlays/openshift`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift)
+overlay supplies exactly those two OpenShift-only deltas — a `Route` exposing the
+`dashboard` port (3002) and the `anyuid` SCC RoleBinding the pod needs (it starts
+as root to set up the ACMM iptables and chown the PVC). A standalone deployment
+on OpenShift composes **standalone + these platform deltas**. Two equivalent
+ways:
+
+- **Combined overlay (recommended):** in your own copy of the standalone
+  `kustomization.yaml`, add `route.yaml` and `anyuid-scc-rolebinding.yaml` as
+  additional resources — this is exactly what the
+  [`example-joe-spyre`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/standalone/example-joe-spyre)
+  overlay does (it adds its own `route.yaml`; add the SCC binding the same way).
+  Set the Route `spec.host` to your cluster's apps domain (or drop `host` to let
+  OpenShift auto-generate one).
+- **Apply both:** `kubectl apply -k <standalone>` then
+  `kubectl apply -k <openshift>` — but note the openshift overlay re-includes the
+  `src/deploy/k8s` base, so prefer the combined form to avoid re-applying the
+  base twice.
+
+### What you must swap
+
+Every value below is a placeholder in the overlay. Cited location is where the
+key is defined (config struct) and where you edit it (overlay file).
+
+| Swap | Default / placeholder | Where you edit it | Config location (`src/pkg/config/config.go`) |
+|---|---|---|---|
+| RWX/RWO `storageClassName` | `YOUR_RWX_STORAGE_CLASS` (example uses `ocs-storagecluster-cephfs`) | `patch-pvc-storageclass.yaml` | base `hive-data` PVC (`src/deploy/k8s/pvc.yaml`) — RWO is fine for the default single replica |
+| Route host domain (OpenShift) | `hive.apps.joes-cluster.example.com` (example) | `route.yaml` `spec.host` | `route.openshift.io/v1` Route |
+| `project.org` / `repos` / `primary_repo` | `YOUR_ORG` / `YOUR_REPO` | `patch-configmap.yaml` (`project:`) | `ProjectConfig` (`Org`, `Repos`, `PrimaryRepo`, `AIAuthor`) |
+| `dashboard.authorized_users` | `YOUR_GITHUB_LOGIN:owner` | `patch-configmap.yaml` (`dashboard:`) | `DashboardConfig.AuthorizedUsers` — first entry is the owner |
+| `github.oauth_client_id` | `YOUR_OAUTH_CLIENT_ID` | `patch-configmap.yaml` (`github:`) | `GitHubConfig.OAuthClientID`. The built-in default (`DefaultOAuthClientID`) is a **github.com** Hive App — if you use GitHub Enterprise (e.g. `github.ibm.com`) you must register your **own** OAuth App there and also set `project.forge` / `github.forge` to your host |
+| litellm `endpoint` + API key | in-cluster inference Service | `patch-configmap.yaml` (`governor.litellm.endpoint`) + the `hive-secrets` Secret | `LiteLLMConfig` under `Config.Governor` (`Endpoint`, `APIKeyEnv` → default `HIVE_LITELLM_API_KEY`, `APIKeyFile` → default `/secrets/litellm_api_key`, `DefaultModel`) |
+
+Also populate the base `hive-secrets` Secret with a GitHub App PEM **or**
+`HIVE_GITHUB_TOKEN`, and — if your inference endpoint needs auth — the key named
+by `governor.litellm.api_key_env` (default `HIVE_LITELLM_API_KEY`).
+
+### The NET_ADMIN decision (stated precisely)
+
+The base deployment **already requests** the `NET_ADMIN` capability
+(`src/deploy/k8s/deployment.yaml`) — the entrypoint uses it to install the
+forced-proxy-egress `iptables` REDIRECT that enforces the ACMM MITM egress proxy.
+
+- **Cluster GRANTS `NET_ADMIN` (most do):** nothing to do — the full,
+  fail-closed egress gate comes up automatically. This is the recommended
+  default.
+- **Cluster DENIES `NET_ADMIN`:** the entrypoint **FATALs** (exit 1, refusing to
+  start with an advisory-only capability model — `src/deploy/entrypoint.sh`
+  around line 770) and the pod crash-loops. The **only** escape hatch is setting
+  `HIVE_PROXY_ADVISORY_OK=true`, provided by the **commented-out**
+  [`patch-advisory-mode.yaml`](https://github.com/kubestellar/hive/blob/v4/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml)
+  — uncomment its `- path: patch-advisory-mode.yaml` line in your
+  `kustomization.yaml`.
+
+**Security trade-off (one honest sentence):** in advisory-only mode the MITM
+egress gate is best-effort rather than enforced, so an agent holding a raw token
+could bypass the proxy policy — acceptable for a single-tenant hive whose owner
+controls every repo and agent, but not a control you should silently disable on a
+shared one.
+
+### Firewall / egress (locked-down cluster)
+
+A standalone hive needs **no hub egress**. The minimal outbound allowlist is:
+
+- **Your repo's GitHub API host** — `api.github.com`, or your GHE instance's
+  `<host>/api/v3`.
+- **`ghcr.io`** (and its blob backend) — for the image pull.
+- **Your inference endpoint** — if it's in-cluster (the shipped
+  `src/deploy/inference` backend, or your own litellm/vllm Service) this is
+  **cluster-internal traffic, not external egress** at all.
+
+Hub hosts (`hub.kubestellar.io`) are **not** required. For the full egress matrix
+(ports, hosts, when each is needed) see
+[network-requirements.md](network-requirements.md); for the capability rationale
+see [net-admin-requirement.md](net-admin-requirement.md).
+
+### Agent backend
+
+Standalone uses a **self-hosted** agent backend, **not** the subscription-CLI
+backends (`copilot` / `claude`) the internal fleet's base ConfigMap uses. The
+overlay sets each agent's `backend: litellm` (valid enum values:
+`litellm` | `vllm` | `llm-d` | `watsonx`). The litellm connection config lives
+under `governor:` (`LiteLLMConfig` on `Config.Governor`):
+
+```yaml
+governor:
+  litellm:
+    endpoint: http://vllm-svc.hive-inference.svc.cluster.local:8000  # your OpenAI-compatible proxy
+    api_key_env: HIVE_LITELLM_API_KEY   # env var NAME holding the key (default)
+    default_model: qwen2.5-0.5b-instruct
+```
+
+Swap `backend: vllm` to hit `HIVE_VLLM_ENDPOINT` directly (the base deployment
+wires both `HIVE_VLLM_ENDPOINT` and `HIVE_LLMD_ENDPOINT`). Verify any key against
+`src/pkg/config/config.go` before adding it.
 
 ---
 
@@ -537,8 +734,15 @@ spec:
         # HIVE_HUB_SECRET. Manual provisioning MAY still set HIVE_HUB_SECRET as
         # shown below: the spoke derives the same sub-keys from it locally, so
         # heartbeats/SSO keep working. If you prefer least privilege, set the three
-        # HIVE_*_KEY vars instead (each = HMAC-SHA256(master, "hive-<domain>-v1")
-        # rendered as lowercase hex) and omit HIVE_HUB_SECRET entirely.
+        # HIVE_*_KEY vars instead (the hub derives them per-hive; the exact
+        # derivation lives in src/pkg/hub/hub_keys.go — heartbeat is HMAC-based
+        # while session/SSO are now Ed25519 asymmetric seeds, so do NOT assume a
+        # single HMAC(master, "hive-<domain>-v1") formula) and omit
+        # HIVE_HUB_SECRET entirely.
+        #
+        # HUB-ONLY: this whole HIVE_HUB_SECRET / derived-key block is irrelevant
+        # to a standalone (hub-less) hive — see "Standalone / self-hosted (no
+        # hub)" at the top of this guide.
         - { name: HIVE_HUB_SECRET, value: "${HUB_SECRET}" }
         - { name: HIVE_HUB_URL,    value: "https://hive.kubestellar.io" }
         # startupProbe keeps the liveness clock from starting until boot


### PR DESCRIPTION
## What

Adds Kustomize overlays under `src/deploy/kustomize/overlays/` that layer on the **existing** bases — `src/deploy/k8s` (core workload) and `src/deploy/inference` (in-cluster OpenAI-compatible model endpoint) — without modifying either base.

### `overlays/openshift` — thin platform delta
- OpenShift `Route` for the dashboard (edge TLS + HTTP→HTTPS redirect, targets Service `hive` port `dashboard`/3002).
- `anyuid` SCC `RoleBinding` bound to the base `hive` ServiceAccount. The pod starts as root for ACMM iptables setup + PVC chown, so it must land on `anyuid` rather than `restricted-v2`.
- Nothing else — the base deployment already carries the correct securityContext.

### `overlays/standalone` — hub-less self-hosted ("Joe") scenario
- Layers on **both** `../../../k8s` and `../../../inference` so a working in-cluster model endpoint ships too.
- ConfigMap patch rewrites `hive.yaml`: `hub.enabled: false` (explicit belt-and-suspenders over the zero-value default), `litellm` agent backend, `dashboard.hub_proxied: false` + `authorized_users` owner placeholder, `github.oauth_client_id` placeholder, `governor.litellm` endpoint, `acmm_level: 2`, org/repo/primary_repo placeholders.
- PVC patch exposes an RWX `storageClassName` placeholder.
- Documented `README.md`: full swap list, install/upgrade (`kubectl apply -k`, `kustomize edit set image`), and the NET_ADMIN decision.

### The NET_ADMIN nuance
The base already requests `CAP_NET_ADMIN`. On clusters that **grant** it, the full fail-closed forced-proxy-egress gate comes up automatically — no flag needed. For locked-down clusters that **deny** NET_ADMIN (where the entrypoint FATALs), a commented-out `patch-advisory-mode.yaml` sets `HIVE_PROXY_ADVISORY_OK=true` as the documented, opt-in advisory-mode escape hatch (with the security trade-off spelled out).

### `overlays/standalone/example-joe-spyre`
A concrete, filled-in copy of the standalone overlay (example org `joesorg/joesrepo`, route host, CephFS storage class, in-cluster litellm endpoint) showing the finished shape a user copies. Clearly marked as example values to replace.

## Config-key verification
Every key was verified against `src/pkg/config/config.go`:
- `authorized_users` + `hub_proxied` are read off **DashboardConfig** (server.go, config.go env merge) → placed under `dashboard:`.
- `oauth_client_id` is read off **GitHubConfig** → placed under `github:`.
- `litellm` lives under **GovernorConfig** → placed under `governor:`.
- `acmm_level` is a **top-level** `Config` field.
- `backend: litellm` is a valid `InferenceBackends` member (`vllm`/`llm-d`/`litellm`/`watsonx`). Note `openrouter` is a gateway *kind*, not a backend value, so it was NOT used.
- `HIVE_PROXY_ADVISORY_OK` verified against `src/deploy/entrypoint.sh`.

All three overlays render cleanly with `kubectl kustomize`. A companion docs PR references these exact overlay paths.