### PR TITLE
✨ feat(contribute): bring agy up to parity — picker entry, verified headless mode, correct staging path

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -160,9 +160,18 @@ contribute-check-backend backend="claude":
         if command -v agy &>/dev/null; then
           echo "agy CLI detected ($(agy --version 2>&1 | head -1))"
           echo "  Models: gemini-3.6-flash, claude-sonnet-4-6, gpt-oss-120b, and more"
-          echo "  Set model: --model gemini-3.6-flash-high"
+          echo "  Set model: export AGENT_MODEL=gemini-3.6-flash-high"
+          echo "  Effort:    export AGENT_REASONING_EFFORT=low|medium|high (agy needs --effort with --model)"
+          # agy signs in through an interactive Google OAuth flow (browser URL
+          # plus a pasted code) and offers no API-key mode, so run it on the
+          # HOST: a container cannot inherit the sign-in. Sign in once with a
+          # bare `agy` before starting the relay.
+          echo "  Sign in once interactively (run: agy) — agy's Google OAuth cannot be"
+          echo "  completed by an unattended container, so run this backend on the host:"
+          echo "    just contribute-hive agy local"
         else
-          echo "ERROR: agy CLI not found. Install: https://antigravity.dev"
+          echo "ERROR: agy CLI not found. Install: https://antigravity.google/product/antigravity-cli"
+          echo "  Homebrew: brew install --cask antigravity-cli"
           exit 1
         fi
         ;;
@@ -608,7 +617,21 @@ contribute-hive backend="" mode="docker": check-version
           fi
           ;;
         agy)
-          if [ -d "${HOME}/.antigravitycli" ]; then
+          # agy 1.1.x keeps its state under ${HOME}/.gemini/antigravity-cli,
+          # NOT the ${HOME}/.antigravitycli this recipe staged before — on a
+          # 1.1.13 install that legacy path does not exist at all, so the mount
+          # was a silent no-op. Stage whichever is present (legacy first-run
+          # installs may still use the old path) so neither layout is dropped.
+          #
+          # Staging state is NOT the same as staging a session: agy authenticates
+          # through an interactive Google OAuth flow and keeps no credential file
+          # under HOME that a container can inherit (verified on 1.1.13 — a clean
+          # container asks for a browser login regardless of what is mounted).
+          # The /contribute page therefore offers agy in HOST mode only.
+          if [ -d "${HOME}/.gemini/antigravity-cli" ]; then
+            stage_copy "${HOME}/.gemini/antigravity-cli" "antigravity-cli"
+            CLI_MOUNTS="-v ${CLI_STAGE}/antigravity-cli:/home/dev/.gemini/antigravity-cli${VOLSUF}"
+          elif [ -d "${HOME}/.antigravitycli" ]; then
             stage_copy "${HOME}/.antigravitycli" ".antigravitycli"
             CLI_MOUNTS="-v ${CLI_STAGE}/.antigravitycli:/home/dev/.antigravitycli${VOLSUF}"
           fi
@@ -840,11 +863,17 @@ contribute-k8s namespace="hive-contributor" outfile="" image_tag="v4":
     # (waiting/working/done/failed). Kept in step with HEADLESS_STATUS_FILE's
     # default in bin/contributor-relay.sh; the probe below reads this exact path.
     readonly HEADLESS_STATUS_FILE="/tmp/contributor-headless-status.json"
-    # Backends with a verified non-interactive (headless) entry point — must
-    # match HEADLESS_BACKENDS in bin/contributor-relay.sh. A headless pod on any
-    # OTHER backend (bob/agy/pi) refuses work LOUDLY at startup, so we warn
-    # here rather than emit a manifest that will crash-loop with no explanation.
-    # goose joined this set in #2828 via its `goose run` one-shot sub-command.
+    # Backends a CLUSTER can run headless. A headless pod on any OTHER backend
+    # (bob/pi) refuses work LOUDLY at startup, so we warn here rather than emit
+    # a manifest that will crash-loop with no explanation. goose joined this set
+    # in #2828 via its `goose run` one-shot sub-command.
+    #
+    # This is deliberately a SUBSET of HEADLESS_BACKENDS in
+    # bin/contributor-relay.sh, which lists CLI capability only: agy has a
+    # verified print mode (`agy -p`) and runs headless on a HOST, but it
+    # authenticates through an interactive Google OAuth flow with no API-key
+    # mode, so a pod has no way to sign in. Do NOT add agy here to "resync" the
+    # two lists — a pod would start, fail auth, and crash-loop.
     readonly HEADLESS_BACKENDS="claude litellm copilot codex goose"
     # Memory sizing: the contributor image is ~2.7GiB unpacked and each task
     # spawns a real coding-CLI + a repo build/test, so requests are deliberately

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -13,7 +13,9 @@
 //                           the same order as HIVE_HUB
 //   AGENT_BACKEND          — CLI backend name (claude, copilot, gemini, etc.)
 //   AGENT_MODEL            — model override (optional)
-//   AGENT_REASONING_EFFORT — Codex reasoning effort override (optional)
+//   AGENT_REASONING_EFFORT — reasoning effort override (optional). Consumed by
+//                           codex (-c model_reasoning_effort) and by agy
+//                           (--effort low|medium|high); ignored elsewhere.
 //   HIVE_AGENT_ROLE        — optional spoke agent role to claim (scanner,
 //                           quality, outreach, etc.; hub-enforced)
 //   HIVE_AGENT_SESSION     — tmux session name for the agent (default: contributor)
@@ -425,6 +427,19 @@ function warnOnProtocolDrift(hub, hubVersion) {
 // "Cannot read properties of undefined (reading 'maxTokens')" (bobshell 1.0.6).
 const NO_MODEL_FLAG_BACKENDS = ['amazonq', 'goose', 'bob'];
 
+// agy (Google's Antigravity CLI) REQUIRES --effort whenever --model is given:
+// without it agy warns "--model <m> requires --effort (available: low, medium,
+// high)" and silently IGNORES the model, so the contributor's configured model
+// never takes effect. AGY_DEFAULT_EFFORT mirrors agyDefaultEffort in the
+// hub-side launcher (src/pkg/agent/manager.go) so a relay agent and a pod agent
+// resolve the same effort. AGENT_REASONING_EFFORT can override it, but only
+// with a value agy actually accepts — codex's vocabulary is wider (it takes
+// "minimal"), and forwarding an unknown token here would make agy reject the
+// pairing and drop the model again.
+const AGY_DEFAULT_EFFORT = 'low';
+const AGY_EFFORTS = ['low', 'medium', 'high'];
+const agyEffort = AGY_EFFORTS.includes(REASONING_EFFORT) ? REASONING_EFFORT : AGY_DEFAULT_EFFORT;
+
 // Single source of truth for the CLI launch command (issue #2203, bug 1).
 // contributor-agent.sh builds "$CMD $PERM_FLAG $MODEL_FLAG" for the FIRST
 // launch; every restart path in this file previously rebuilt only "$CMD $PERM"
@@ -461,7 +476,10 @@ function buildLaunchCommand() {
   const reasoningFlag = BACKEND === 'codex' && REASONING_EFFORT
     ? `-c 'model_reasoning_effort="${REASONING_EFFORT}"'`
     : '';
-  cachedLaunchCommand = [cmd, perm, modelFlag, reasoningFlag].filter(Boolean).join(' ');
+  // Paired with modelFlag, never on its own: agy without --model needs no
+  // --effort, and passing one alone would be a flag agy has no model to apply.
+  const agyEffortFlag = BACKEND === 'agy' && modelFlag ? `--effort ${agyEffort}` : '';
+  cachedLaunchCommand = [cmd, perm, modelFlag, reasoningFlag, agyEffortFlag].filter(Boolean).join(' ');
   return cachedLaunchCommand;
 }
 
@@ -480,7 +498,7 @@ function buildLaunchCommand() {
 //          prompt is appended as the final, distinct argv element.
 //
 // Backends NOT listed here have no known non-interactive entry point (bob /
-// agy / pi drive an interactive TUI), so headless mode refuses them LOUDLY at
+// pi drive an interactive TUI), so headless mode refuses them LOUDLY at
 // task time rather than silently stalling. Extending this table is how a
 // future PR adds a backend once its headless invocation is verified.
 const HEADLESS_BACKENDS = {
@@ -503,6 +521,16 @@ const HEADLESS_BACKENDS = {
   // that `run`, `-t` and `--no-session` all exist and that a failed run exits
   // non-zero, which is the exit-code contract runHeadlessTask() relies on.
   goose: { flag: ['run', '--no-session', '-t'] },
+  // agy -p "<prompt>" — Antigravity's print mode ("Run a single prompt
+  // non-interactively and print the response", `agy --help`). Verified against
+  // agy 1.1.13: a print-mode run answers on stdout and exits 0, which is the
+  // exit-code contract runHeadlessTask() relies on. NOTE this makes agy
+  // headless-capable on a HOST only — agy's sign-in is an interactive Google
+  // OAuth flow (browser URL + pasted code) with no API-key mode, and a fresh
+  // container has nothing to inherit it from, which is why agy stays OUT of
+  // K8S_HEADLESS_BACKENDS on the /contribute page and out of the contributor
+  // image. The capability and the credential are separate questions.
+  agy: { flag: '-p' },
 };
 
 // headlessSupportsBackend reports whether the configured backend has a known
@@ -524,11 +552,14 @@ function buildHeadlessArgv(prompt) {
   const permArgs = perm ? perm.split(/\s+/).filter(Boolean) : [];
   const modelArgs = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? ['--model', MODEL] : [];
   const reasoningArgs = BACKEND === 'codex' && REASONING_EFFORT ? ['-c', `model_reasoning_effort="${REASONING_EFFORT}"`] : [];
+  // Same --model/--effort pairing the interactive launch enforces, so headless
+  // agy honors the configured model instead of silently falling back.
+  const agyEffortArgs = BACKEND === 'agy' && modelArgs.length ? ['--effort', agyEffort] : [];
   // spec.flag is a single token for most backends, or an array of leading
   // tokens for backends needing a sub-command plus a flag (goose). Normalize
   // to an array so both shapes spread the same way ahead of the prompt.
   const oneShotArgs = Array.isArray(spec.flag) ? spec.flag : [spec.flag];
-  const args = [...permArgs, ...modelArgs, ...reasoningArgs, ...oneShotArgs, prompt];
+  const args = [...permArgs, ...modelArgs, ...reasoningArgs, ...agyEffortArgs, ...oneShotArgs, prompt];
   return { bin: cmd, args };
 }
 

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -214,6 +214,54 @@ test('bob never receives --model even when AGENT_MODEL is set', () => {
   } finally { teardown(relay); }
 });
 
+test('agy pairs --effort with --model, and omits it when no model is set', () => {
+  // agy warns "--model <m> requires --effort (available: low, medium, high)"
+  // and then IGNORES the model, so the two flags must travel together. Mirrors
+  // agyDefaultEffort ("low") in the hub-side launcher.
+  const withModel = loadRelay({ backend: 'agy', model: 'gemini-3.6-flash-high' });
+  try {
+    const cmd = withModel.buildLaunchCommand();
+    assert.match(cmd, /--model gemini-3\.6-flash-high/, `expected model flag, got: ${cmd}`);
+    assert.match(cmd, /--effort low/, `agy dropped the required --effort: ${cmd}`);
+  } finally { teardown(withModel); }
+
+  const noModel = loadRelay({ backend: 'agy' });
+  try {
+    const cmd = noModel.buildLaunchCommand();
+    assert.ok(!/--effort/.test(cmd), `--effort belongs only with --model, got: ${cmd}`);
+  } finally { teardown(noModel); }
+});
+
+test('agy effort honors AGENT_REASONING_EFFORT but rejects values agy cannot take', () => {
+  // codex's vocabulary is wider than agy's ("minimal" is valid for codex only).
+  // Forwarding an unknown token would make agy reject the pairing and drop the
+  // model again, so anything outside low|medium|high falls back to the default.
+  const good = loadRelay({ backend: 'agy', model: 'm', reasoningEffort: 'high' });
+  try {
+    assert.match(good.buildLaunchCommand(), /--effort high/);
+  } finally { teardown(good); }
+
+  const bogus = loadRelay({ backend: 'agy', model: 'm', reasoningEffort: 'minimal' });
+  try {
+    const cmd = bogus.buildLaunchCommand();
+    assert.match(cmd, /--effort low/, `unknown effort must fall back to low, got: ${cmd}`);
+    assert.ok(!/minimal/.test(cmd), `agy must not receive codex-only effort values: ${cmd}`);
+  } finally { teardown(bogus); }
+});
+
+test('agy headless argv carries the same --model/--effort pairing', () => {
+  const relay = loadRelay({ backend: 'agy', mode: 'headless', model: 'gemini-3.6-flash-high' });
+  try {
+    const a = relay.buildHeadlessArgv('review this');
+    const i = a.args.indexOf('--effort');
+    assert.ok(i >= 0, `headless agy dropped --effort: ${JSON.stringify(a.args)}`);
+    assert.strictEqual(a.args[i + 1], 'low');
+    assert.ok(a.args.includes('--model'), `headless agy dropped --model: ${JSON.stringify(a.args)}`);
+    // The prompt still has to be the final, distinct element after -p.
+    assert.deepStrictEqual(a.args.slice(-2), ['-p', 'review this']);
+  } finally { teardown(relay); }
+});
+
 test('amazonq and goose are also excluded from --model', () => {
   for (const backend of ['amazonq', 'goose']) {
     const relay = loadRelay({ backend, model: 'some-model' });
@@ -1038,9 +1086,12 @@ test('buildHeadlessArgv maps each supported backend to its one-shot invocation',
     // goose needs its `run` sub-command AND -t (whose VALUE is the prompt) —
     // two leading tokens, unlike every other entry (#2828).
     { backend: 'goose', tail: ['run', '--no-session', '-t', PROMPT] },
+    // agy -p "<prompt>" — Antigravity's print mode. Headless CAPABILITY only:
+    // agy still cannot sign in inside a pod (interactive Google OAuth, no
+    // API-key mode), which is why the k8s manifest generator keeps warning.
+    { backend: 'agy', tail: ['-p', PROMPT] },
     // Interactive-TUI backends with no known one-shot entry point.
     { backend: 'bob', tail: null },
-    { backend: 'agy', tail: null },
     { backend: 'pi', tail: null },
   ]) {
     const relay = loadRelay({ backend: tc.backend, mode: 'headless' });

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -34,7 +34,8 @@ Important environment variables:
 | --- | --- | --- |
 | `HIVE_HUB` | value from `contributor.env`, else public hub default | WebSocket hub(s) to subscribe to. Use comma-separated URLs for multi-hub mode. Direct Compose reads the registered value from the mounted config file. |
 | `HIVE_REGISTRATION_TOKEN` | value from `contributor.env` | Registration token(s), positional with `HIVE_HUB` when multiple hubs are listed. Required; run `just contribute-setup` / `just contribute-register` first. |
-| `AGENT_BACKEND` | `claude` | CLI/backend to run (`claude`, `copilot`, `goose`, `bob`, `codex`, `litellm`, etc., depending on image support and credentials). |
+| `AGENT_BACKEND` | `claude` | CLI/backend to run (`claude`, `copilot`, `goose`, `bob`, `codex`, `litellm`, `agy`, etc., depending on image support and credentials). `agy` is not in the contributor image and cannot inherit a sign-in, so run it with `just contribute-hive agy local`. |
+| `AGENT_REASONING_EFFORT` | unset | Reasoning effort override. Consumed by `codex` (`-c model_reasoning_effort`) and by `agy` (`--effort low\|medium\|high`, required whenever a model is set, else agy ignores the model). Ignored by other backends. |
 | `AGENT_MODEL` | unset | Optional model override passed to the contributor agent. |
 | `CONTRIBUTOR_MODE` | `interactive` | `interactive` keeps a tmux/TTY session. `headless` is for one-shot/no-TTY task delivery. |
 
@@ -81,7 +82,7 @@ kubectl apply -f relay.yaml
 kubectl -n my-namespace rollout status deploy/hive-contributor
 ```
 
-The generated pod sets `CONTRIBUTOR_MODE=headless` because Kubernetes pods have no TTY; interactive tmux mode would stall. Headless mode is currently verified for `claude`, `litellm`, `copilot`, `codex`, and `goose`. The Deployment has one replica per registered contributor identity and uses readiness/liveness probes that read the relay's headless status file (`waiting`, `working`, `done` pass; missing/failed state fails).
+The generated pod sets `CONTRIBUTOR_MODE=headless` because Kubernetes pods have no TTY; interactive tmux mode would stall. Headless mode is currently verified for `claude`, `litellm`, `copilot`, `codex`, `goose`, and `agy` (`agy -p`, verified on 1.1.13) — but **`agy` is host-only**: it signs in through an interactive Google OAuth flow with no API-key mode, so a pod cannot authenticate and `just contribute-k8s` deliberately keeps warning for it. Headless `agy` works on a host that has already signed in. The Deployment has one replica per registered contributor identity and uses readiness/liveness probes that read the relay's headless status file (`waiting`, `working`, `done` pass; missing/failed state fails).
 
 The generated Secret contains the registration token and `GH_TOKEN` as Kubernetes Secret data. Treat it as sensitive cluster-readable material and prefer a pinned image tag/digest for repeatable operation.
 

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -1845,6 +1845,7 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 <option value="llm-d" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# llm-d — self-hosted OpenAI-compatible endpoint\nexport HIVE_LITELLM_ENDPOINT=http://your-llm-d-host:8000/v1\nexport HIVE_LITELLM_API_KEY=sk-your-llm-d-key  # only if your endpoint needs one">llm-d (self-hosted)</option>
 <option value="bob" data-install="" data-host-install="curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash" data-model-flag="" data-default-model="" data-env="# Bob (IBM bobshell) — get a key at https://bob.ibm.com (Scope: Inference).\n# Exported locally, never sent to the hive.\nexport BOBSHELL_API_KEY=your-bob-api-key">Bob</option>
 <option value="watsonx" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# IBM watsonx.ai — OpenAI-compatible gateway, bring your own project + key.\n# watsonx auth is an IAM-minted JWT, not a raw bearer key — your local\n# Claude-Code setup or a small local proxy handles the token exchange.\n# Exported locally, never sent to the hive.\nexport HIVE_LITELLM_ENDPOINT=https://us-south.ml.cloud.ibm.com/ml/gateway/v1\nexport HIVE_LITELLM_API_KEY=your-ibm-cloud-api-key\nexport WATSONX_PROJECT_ID=your-watsonx-project-id">watsonx.ai (IBM Granite + your key)</option>
+<option value="agy" data-install="" data-host-install="# Antigravity CLI (Google): https://antigravity.google/product/antigravity-cli\nbrew install --cask antigravity-cli\nagy   # sign in once with your Google account, interactively, then exit" data-model-flag="--model" data-default-model="" data-env="# Optional: agy effort — REQUIRED alongside a model, or agy ignores the model.\n# export AGENT_REASONING_EFFORT=low   # low|medium|high">Antigravity (agy)</option>
 <option value="other" data-install="" data-host-install="# Install your CLI tool" data-model-flag="" data-default-model="">Other (host only)</option>
 </select>
 </span>
@@ -1877,6 +1878,13 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 <div id="k8s-note" style="display:none;margin-bottom:12px;background:#161b22;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:6px;padding:12px 14px;font-size:.85rem;color:#c9d1d9;line-height:1.5">
 <strong style="color:#e6edf3">Kubernetes is the advanced path.</strong> It needs a cluster, a kubeconfig and RBAC &mdash; not a first-timer&rsquo;s happy path. The workload runs the relay <strong>headless</strong> (no TTY), so only headless-capable backends work in a cluster: <strong>Claude Code, LiteLLM, Copilot, Codex</strong>. Other backends will refuse work at pod startup.<br>
 <span style="color:#8b949e">Credential note (interim): the generated Secret stores a long-lived personal <code>GH_TOKEN</code> &mdash; base64, not encrypted, and readable by anyone with <code>get secrets</code> in that namespace or by cluster-scoped operators/backups. That is materially more exposed than a <code>0600</code> file on your laptop. Revoke any time with <code>gh auth logout</code>. Gating the credential on explicit task acceptance is tracked in <a href="https://github.com/kubestellar/hive/issues/2537" target="_blank" rel="noopener" style="color:#58a6ff">#2537</a> and is not solved by this path.</span>
+</div>
+<!-- Host-only note. Shown for backends the containerized/Kubernetes paths cannot
+     run, so the mode flip to Host is explained rather than mysterious: "other"
+     has no image, and agy's Google sign-in is interactive with no API-key mode,
+     so no unattended container can hold a session. -->
+<div id="hostonly-note" style="display:none;margin-bottom:12px;background:#161b22;border:1px solid #30363d;border-left:3px solid #d29922;border-radius:6px;padding:12px 14px;font-size:.85rem;color:#c9d1d9;line-height:1.5">
+<strong style="color:#e6edf3">This backend runs on your host, not in a container.</strong> The mode selector has been switched to <strong>Host</strong> for you. <strong>Antigravity (agy)</strong> signs in through an interactive Google OAuth flow &mdash; a browser URL plus a pasted code, with no API-key mode &mdash; so a container or pod has no session to inherit, and the contributor image does not ship the binary. Run <code>agy</code> once to sign in, then start the relay on the host. Its print mode (<code>agy -p</code>) is verified, so headless host runs work; Kubernetes does not.
 </div>
 <div id="multi-hub-note" style="margin-bottom:12px;background:#161b22;border:1px solid #30363d;border-left:3px solid #58a6ff;border-radius:6px;padding:12px 14px;font-size:.85rem;color:#c9d1d9;line-height:1.5">
 <strong style="color:#e6edf3">Contribute to multiple hives:</strong> after registering with each hive, set <code>HIVE_HUB</code> to comma-separated WebSocket URLs and <code>HIVE_REGISTRATION_TOKEN</code> to the matching comma-separated tokens in the same order. One relay shares one CLI/tmux session, works on one task at a time, keeps each hub connected with its own heartbeat, and rotates only when the active hub says no task is available. Added by <a href="https://github.com/hanthor" target="_blank" rel="noopener" style="color:#58a6ff">@hanthor</a> in <a href="https://github.com/kubestellar/hive/pull/2846" target="_blank" rel="noopener" style="color:#58a6ff">#2846</a>.
@@ -1944,6 +1952,18 @@ var k8sTpl='PREREQ\ngit clone -b {{HIVE_BRANCH}} https://github.com/kubestellar/
 // HEADLESS_BACKENDS in bin/contributor-relay.sh and the Justfile. A pod has no
 // TTY, so only these run in a cluster; anything else refuses work at startup.
 var K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1,goose:1};
+// Backends that can only run on the contributor's own host. "other" has no
+// image by definition. agy is host-only for a different reason: it signs in
+// through an interactive Google OAuth flow (browser URL + pasted code) with no
+// API-key mode, so neither a container nor a pod can inherit a contributor's
+// session — verified against agy 1.1.13, where a clean container demands a
+// fresh browser login no matter what is mounted, and the contributor image does
+// not ship the binary either. Selecting one flips Mode to Host rather than
+// generating commands that cannot work. NOTE agy IS headless-capable on a host
+// (agy -p, see HEADLESS_BACKENDS in bin/contributor-relay.sh); it is the
+// credential, not the capability, that keeps it out of K8S_HEADLESS_BACKENDS.
+var HOST_ONLY_BACKENDS=['other','agy'];
+function isHostOnly(c){return HOST_ONLY_BACKENDS.indexOf(c)>=0;}
 var modelRow=document.getElementById('model-row');
 var modelInput=document.getElementById('model-input');
 function updateCmds(){update();}
@@ -1955,13 +1975,11 @@ var opt=sel.options[sel.selectedIndex];
 var mode=modeSel.value;
 var modelFlag=opt.getAttribute('data-model-flag')||'';
 var model=(modelInput.value||'').trim();
-if(cli==='other')mode='host';
-if(mode==='containerized'&&cli==='other'){modeSel.value='host';mode='host';}
-// #2549 Kubernetes mode. "other" has no image, so it can't run in a cluster;
-// fall back to host. Show the k8s note only in this mode.
-if(mode==='kubernetes'&&cli==='other'){modeSel.value='host';mode='host';}
+if(isHostOnly(cli)&&mode!=='host'){modeSel.value='host';mode='host';}
 var k8sNote=document.getElementById('k8s-note');
 if(k8sNote)k8sNote.style.display=(mode==='kubernetes')?'block':'none';
+var hostOnlyNote=document.getElementById('hostonly-note');
+if(hostOnlyNote)hostOnlyNote.style.display=isHostOnly(cli)?'block':'none';
 modelRow.style.display=(modelFlag||cli==='goose')?'flex':'none';
 var modelLine='';
 if(model){
@@ -2039,6 +2057,7 @@ vllm:'<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 5l4 14 3-9 3 9 4-1
 'llm-d':'<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="5" width="16" height="14" rx="2" fill="none" stroke="#4d9375" stroke-width="1.5"/><path d="M8 9h4a3 3 0 0 1 0 6H8V9Z" fill="none" stroke="#4d9375" stroke-width="1.5" stroke-linejoin="round"/></svg>',
 bob:'<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="2" fill="none" stroke="#1f70c1" stroke-width="1.5"/><path d="M9 8h3.5a2 2 0 0 1 0 4H9V8ZM9 12h4a2 2 0 0 1 0 4H9v-4Z" fill="none" stroke="#1f70c1" stroke-width="1.3" stroke-linejoin="round"/></svg>',
 watsonx:'<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="8" fill="none" stroke="#1f70c1" stroke-width="1.5"/><path d="M12 7v10M8.5 9.5l7 5M15.5 9.5l-7 5" stroke="#1f70c1" stroke-width="1.4" stroke-linecap="round"/></svg>',
+agy:'<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4.5 19 19H5z" fill="none" stroke="#a78bfa" stroke-width="1.6" stroke-linejoin="round"/><path d="M12 20.5v-5" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"/><circle cx="12" cy="10.5" r="1.4" fill="#a78bfa"/></svg>',
 other:'<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="6" width="16" height="12" rx="2" fill="none" stroke="#8b949e" stroke-width="1.5"/><path d="M8 12h.01M12 12h.01M16 12h.01" stroke="#8b949e" stroke-width="2.2" stroke-linecap="round"/></svg>'
 };
 var CLIENTS={
@@ -2058,6 +2077,7 @@ vllm:{name:'vLLM',tag:'self-hosted'},
 'llm-d':{name:'llm-d',tag:'self-hosted'},
 bob:{name:'Bob',tag:'IBM'},
 watsonx:{name:'watsonx.ai',tag:'IBM'},
+agy:{name:'Antigravity',tag:'Google (host)'},
 other:{name:'Other',tag:'host only'}
 };
 var tilesEl=document.getElementById('client-tiles');

--- a/src/pkg/dashboard/api_contribute_test.go
+++ b/src/pkg/dashboard/api_contribute_test.go
@@ -417,8 +417,10 @@ func TestContributeLandingHasWatsonxOption(t *testing.T) {
 // run-mode reasons about and pins whether it is headless-capable, so adding a
 // backend forces an explicit decision here rather than silently defaulting to
 // "no headless mode". goose is capable via its `goose run --no-session -t`
-// one-shot sub-command (#2828); bob/agy/pi drive an interactive TUI with no
-// known non-interactive entry point, so they must keep warning.
+// one-shot sub-command (#2828); bob/pi drive an interactive TUI with no known
+// non-interactive entry point, so they must keep warning. agy keeps warning
+// for a DIFFERENT reason — it has a print mode, but no way to sign in inside a
+// pod — which is why the reason string is pinned alongside the boolean.
 func TestContributeK8sHeadlessCapability(t *testing.T) {
 	setupContributeEnv(t)
 	s := NewServer(0, slog.Default())
@@ -433,6 +435,22 @@ func TestContributeK8sHeadlessCapability(t *testing.T) {
 	}
 	body := w.Body.String()
 
+	// Scan ONLY the capability map's own literal. A bare strings.Contains for
+	// "<backend>:1" over the whole page matches any other JS object that
+	// happens to use the same key (HOST_ONLY_BACKENDS did exactly that), which
+	// would silently turn this pin into a page-wide grep.
+	const mapKey = "K8S_HEADLESS_BACKENDS={"
+	i := strings.Index(body, mapKey)
+	if i < 0 {
+		t.Fatalf("K8S_HEADLESS_BACKENDS literal not found on the page")
+	}
+	rest := body[i+len(mapKey):]
+	j := strings.Index(rest, "}")
+	if j < 0 {
+		t.Fatalf("K8S_HEADLESS_BACKENDS literal is unterminated")
+	}
+	capabilityMap := rest[:j]
+
 	for _, tc := range []struct {
 		backend  string
 		headless bool
@@ -445,11 +463,16 @@ func TestContributeK8sHeadlessCapability(t *testing.T) {
 		{"watsonx", true, "OpenAI-compatible endpoint via the claude binary"},
 		{"goose", true, "goose run --no-session -t one-shot sub-command (#2828)"},
 		{"bob", false, "interactive TUI, no known one-shot entry point"},
-		{"agy", false, "interactive TUI, no known one-shot entry point"},
+		// agy DOES have a one-shot mode (`agy -p`, in the relay's own
+		// HEADLESS_BACKENDS since this change) but stays false HERE: this list
+		// gates the Kubernetes path, and agy signs in through an interactive
+		// Google OAuth flow with no API-key mode, so a pod can never
+		// authenticate. Capability and credential are separate questions.
+		{"agy", false, "headless-capable (agy -p) but cannot sign in inside a pod"},
 		{"pi", false, "interactive TUI, no known one-shot entry point"},
 	} {
 		// The capability map is emitted as a JS object literal keyed by backend.
-		present := strings.Contains(body, tc.backend+":1")
+		present := strings.Contains(capabilityMap, tc.backend+":1")
 		if present != tc.headless {
 			t.Errorf("K8S_HEADLESS_BACKENDS headless=%v for %q, want %v (%s)",
 				present, tc.backend, tc.headless, tc.why)

--- a/src/pkg/dashboard/contribute_branded_entrypoints_test.go
+++ b/src/pkg/dashboard/contribute_branded_entrypoints_test.go
@@ -184,3 +184,48 @@ func TestContributeCodexOnboardingSurface(t *testing.T) {
 		t.Errorf("codex must sit next to Claude Code in the CLI select: claude=%d codex=%d other=%d", iClaude, iCodex, iOther)
 	}
 }
+
+// TestContributeAgyHostOnlySurface pins agy (Google's Antigravity CLI) as a
+// picker entry that is honest about its one real limit. agy already had a
+// Justfile preflight, a backends.conf perm flag and relay readiness/idle
+// patterns, so interactive HOST runs work — but the contributor image does not
+// ship the binary and agy's sign-in is an interactive Google OAuth flow with no
+// API-key mode, so no container or pod can inherit a session. The page
+// therefore offers it in host mode only and says why, rather than generating
+// containerized commands that cannot work.
+func TestContributeAgyHostOnlySurface(t *testing.T) {
+	body := renderContributePage(t)
+
+	for _, want := range []string{
+		// The CLI select option, with the vendor's install path.
+		`<option value="agy"`,
+		`brew install --cask antigravity-cli`,
+		// agy needs --effort whenever a model is set, or it ignores the model.
+		`AGENT_REASONING_EFFORT=low`,
+		// Tile metadata + emblem, tagged so the host-only constraint is visible
+		// before a contributor commits to it.
+		`agy:{name:'Antigravity',tag:'Google (host)'}`,
+		// Host-only forcing + the note that explains the mode flip.
+		`var HOST_ONLY_BACKENDS=['other','agy']`,
+		`id="hostonly-note"`,
+		`interactive Google OAuth flow`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("agy onboarding surface missing %q", want)
+		}
+	}
+
+	// The host-only fallback must still cover "other" — the entry that had this
+	// behavior before agy joined it — and must switch the visible selector, not
+	// just the local variable, or the generated commands and the UI disagree.
+	if !strings.Contains(body, `if(isHostOnly(cli)&&mode!=='host'){modeSel.value='host';mode='host';}`) {
+		t.Error("host-only backends must flip the mode selector itself, not only the local mode")
+	}
+
+	// agy must NOT be advertised for Kubernetes: a pod cannot complete its
+	// OAuth, so the k8s capability map stays without it (see
+	// TestContributeK8sHeadlessCapability for the full enumeration).
+	if strings.Contains(body, "K8S_HEADLESS_BACKENDS={claude:1,litellm:1,copilot:1,codex:1,watsonx:1,goose:1,agy:1") {
+		t.Error("agy must stay out of K8S_HEADLESS_BACKENDS — a pod cannot complete agy's sign-in")
+	}
+}


### PR DESCRIPTION
## What

agy (Google's **Antigravity CLI**) was half-wired. It already had a Justfile preflight, a `backends.conf` perm flag and relay readiness/idle patterns — so interactive host runs worked — but it was invisible on `/contribute`, and three things around it were wrong. All findings verified against a real **agy 1.1.13** install.

### 1. It *is* headless-capable; the repo said it wasn't

`agy --help` documents `-p/--print` — "Run a single prompt non-interactively and print the response". A print-mode run answers on stdout and exits 0, which is exactly the exit-code contract `runHeadlessTask()` relies on. Meanwhile `contributor-relay.sh` asserted "bob / agy / pi drive an interactive TUI" with no one-shot entry point, and `src/docs/contributor-relay.md` repeated it. agy now joins `HEADLESS_BACKENDS` with `{ flag: '-p' }`.

### 2. `--model` was silently doing nothing

The relay launched `agy --model X`. agy then warns `--model <m> requires --effort (available: low, medium, high)` and **ignores the model** — the hub-side launcher already knows this (`agyDefaultEffort` in `src/pkg/agent/manager.go`), the relay didn't. Both the interactive launch command and the headless argv now pair `--effort` with `--model`, defaulting to `low` to match the hub. `AGENT_REASONING_EFFORT` can override it, but only with `low|medium|high` — codex's vocabulary is wider (`minimal`), and forwarding an unknown token would make agy reject the pairing and drop the model again.

### 3. The container staging path didn't exist

`just contribute-hive` staged `${HOME}/.antigravitycli`. On a 1.1.x install that path is absent — agy keeps state under `${HOME}/.gemini/antigravity-cli` — so the mount was a silent no-op. Now stages whichever layout is present.

## Host-only, and honest about it

agy is offered in **Host** mode only. Its sign-in is an interactive Google OAuth flow — browser URL plus a pasted code, with no API-key mode — so no unattended container can hold a session. I ran the official `linux-x64` build in a clean container: it demands a fresh browser login regardless of what is mounted, and the contributor image doesn't ship the binary either.

Selecting agy therefore flips Mode to Host — generalizing the fallback the `other` entry already had into `HOST_ONLY_BACKENDS` — and shows a note explaining the flip, instead of generating containerized commands that cannot work.

That also means agy deliberately stays **out** of `K8S_HEADLESS_BACKENDS` and out of the Justfile's k8s list. Both now document the divergence from the relay's table so nobody "resyncs" them: capability and credential are separate questions, and a pod that starts and then fails auth would just crash-loop.

## Also

`TestContributeK8sHeadlessCapability` grepped the *whole page* for `"<backend>:1"`, so it matched any other JS object literal using the same key (my first draft of `HOST_ONLY_BACKENDS` tripped it). It now scans only the capability map's own literal.

## Tests

- `bin/contributor-relay.test.js`: agy moved to the one-shot table; new tests for the `--model`/`--effort` pairing, the rejection of efforts agy can't take, and the headless argv. **80/80 pass.**
- `src/pkg/dashboard`: new `TestContributeAgyHostOnlySurface` (option, install line, tile metadata, host-only forcing, the note, and that agy stays out of the k8s map); `TestContributeK8sHeadlessCapability`'s agy row keeps `false` with the corrected reason. Full package passes.
- `just contribute-check agy` run against the real CLI: preflight passes and prints the new model/effort/sign-in guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)