### PR TITLE
🔒 sec(dashboard,proxy): close the script-src element half with sha256 hashes (#3848 part 1)

### DIFF
--- a/src/docs/adr/0016-csp-script-src-scope.md
+++ b/src/docs/adr/0016-csp-script-src-scope.md
@@ -1,0 +1,103 @@
+# ADR-0016: Scope `script-src` as two directives, close the element half with hashes
+
+Status: Accepted
+
+## Context
+
+The dashboard's Content-Security-Policy carried one blanket `script-src 'self'
+'unsafe-inline'`, on both CSP emitters — the Go spoke server
+([securityHeaders](../../pkg/dashboard/server.go)) and the Node proxy
+([proxy/server.js](../../proxy/server.js)). That directive was the residual of
+[kubestellar/hive#3315](https://github.com/kubestellar/hive/issues/3315): the
+token-injection half of that finding was fixed by #3844, but any XSS in the
+dashboard origin could still execute an injected inline `<script>` and, for
+example, read the pasted `HIVE_DASHBOARD_TOKEN` out of `localStorage`.
+[#3848](https://github.com/kubestellar/hive/issues/3848) part 1 (and its
+duplicate, [#3907](https://github.com/kubestellar/hive/issues/3907)) track
+closing it.
+
+[ADR-0015](0015-csp-style-src-scope.md) established the decomposition for
+`style-src`, and the identical asymmetry decides `script-src`:
+
+| Inline script form | Count | Covered by a hash? |
+| --- | --- | --- |
+| `on*="…"` handler attributes (`static/index.html`) | 426 | **No** |
+| `on*=` handlers built as strings, injected via 169 `innerHTML` sites | ~145 | **No** |
+| Inline `<script>` elements across every served document | 9 | Yes |
+
+CSP hashes and nonces apply to *elements*, never to event-handler attributes
+(`script-src-attr` accepts only `'none'`, `'unsafe-inline'`, or
+`'unsafe-hashes'` plus per-attribute-value hashes — rejected here for the same
+maintainability reasons ADR-0015 rejected it for styles). So the element half
+is closable today and the attribute half is not: it requires an
+event-delegation refactor of the 21k-line SPA, which remains the open scope of
+#3848.
+
+## Decision
+
+`script-src` becomes three directives, on both emitters:
+
+```text
+script-src      'self' 'unsafe-inline'      ← CSP2 fallback, UNCHANGED
+script-src-elem 'self' 'sha256-…' …         ← inline <script> elements: CLOSED
+script-src-attr 'unsafe-inline'             ← on*= attributes: STAGED (#3848)
+```
+
+- **`script-src-elem` carries a sha256 hash for every inline `<script>` this
+  server actually serves, and no `'unsafe-inline'`.** In every CSP3 browser an
+  injected inline `<script>` matches no hash and does not execute.
+- **Hashes, not nonces — deliberately.** The SPA document is pre-gzipped once
+  at startup with a strong ETag (#3863). A per-response nonce requires
+  rewriting the document per request, which forfeits both the 4× transfer win
+  and the 304 revalidation path. A hash is a pure function of the bytes already
+  being served: for the byte-stable documents (the embedded SPA, the
+  device-flow login page) the allowlist is computed once at startup; for
+  documents whose script content varies per response (`/contribute`, whose
+  `hubURL` derives from the Host header; `/snapshot`, built at runtime) the
+  handler stamps the allowlist from the finished document before the first
+  write (`applyDocumentScriptSrcElem`).
+- **The CSP2 fallback `script-src` keeps `'unsafe-inline'` and must never
+  carry the hashes.** Per CSP2, the presence of a hash source makes a browser
+  ignore `'unsafe-inline'` in the same directive — so a browser that
+  understands hashes but not `script-src-elem`/`-attr` (Firefox < 108) would
+  block all 426+ inline handlers and blank the dashboard. Keeping the fallback
+  hash-free means pre-CSP3 browsers enforce exactly what they enforced before
+  this change: no regression, no new protection.
+- **`script-src-attr 'unsafe-inline'` is STAGED, not accepted.** Unlike
+  `style-src-attr` (a permanent acceptance, ADR-0015), the handler attributes
+  *can* be eliminated by refactoring the SPA to delegated `addEventListener`
+  wiring, and #3848 remains open for exactly that. The tripwire test
+  `TestCSPScriptSrcAttrUnsafeInlineIsStaged` fails the moment that refactor
+  lands, and must then be inverted — never relaxed.
+- Documents whose bytes this code never renders keep the blanket CSP2 policy:
+  `/terminal` (ttyd's own UI, streamed through a reverse proxy) on both
+  emitters, and on the Node proxy additionally the Go-rendered `/contribute`,
+  `/leaderboard` and `/snapshot` documents, whose authoritative per-document
+  policy is stamped by the Go upstream.
+
+## Residual risk
+
+What this ADR accepts, stated plainly:
+
+- **Injected `on*=` handler attributes still execute in every browser** while
+  `script-src-attr 'unsafe-inline'` stands — markup injection such as
+  `<img src=x onerror=…>` remains an executable XSS primitive. Closing it is
+  the remaining scope of #3848.
+- **Pre-CSP3 browsers (e.g. Firefox < 108) gain nothing**: they enforce only
+  the unchanged fallback.
+- The dashboard credential still lives in `localStorage` (operator-pasted);
+  moving it out is tracked separately in #3315's recommendation trail.
+- The hub SaaS SPA ([pkg/hub/saas.go](../../pkg/hub/saas.go)) serves no CSP
+  header at all today; it is outside both emitters this ADR covers.
+
+## Consequences
+
+- An XSS that injects an inline `<script>` element is neutralized in all
+  current browsers — the highest-value primitive is closed on both emitters.
+- Every handler that renders a NEW inline `<script>` into a served document
+  must either be byte-stable (then its document belongs in the startup set) or
+  call `applyDocumentScriptSrcElem` with the finished document; the
+  hash-coverage tests in `csp_script_src_test.go` fail otherwise.
+- When #3848's event-delegation refactor lands, `script-src-attr` drops
+  `'unsafe-inline'`, the fallback `script-src` can finally drop it too, and
+  the tripwire is inverted to pin the closed state.

--- a/src/docs/adr/README.md
+++ b/src/docs/adr/README.md
@@ -51,3 +51,4 @@ What becomes easier, harder, safer, or riskier because of this decision?
 - [ADR-0013: CEL triggers over normalized forge events](0013-cel-triggers.md)
 - [ADR-0014: Hub/spoke fleet over heartbeat callbacks](0014-hub-spoke.md)
 - [ADR-0015: Scope `style-src` as two directives and accept inline style attributes](0015-csp-style-src-scope.md)
+- [ADR-0016: Scope `script-src` as two directives, close the element half with hashes](0016-csp-script-src-scope.md)

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -870,6 +870,11 @@ func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=60")
+	// The snapshot document is built at runtime by build-snapshot.mjs and then
+	// rewritten above, so its inline <script> content is only known here. Stamp
+	// the CSP script-src-elem hash allowlist from the exact bytes being served
+	// (#3848 part 1 / #3907, see csp_script_src.go).
+	applyDocumentScriptSrcElem(w, []byte(html))
 	w.Write([]byte(html))
 }
 

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/rand"
@@ -794,7 +795,15 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	// verb mid-template would renumber every argument after it. Substituting on
 	// the template also means no rendered value — project name, Host header —
 	// can ever contain the sentinel and be rewritten by it.
-	fmt.Fprintf(w, strings.ReplaceAll(`<!DOCTYPE html>
+	//
+	// Rendered into a buffer, not straight to w: this page's inline <script>
+	// content varies per response (hubURL derives from the Host header, and the
+	// optional custom-style script from the ?style= query), so its CSP
+	// script-src-elem hashes can only be computed from the finished document.
+	// applyDocumentScriptSrcElem below stamps them before the first Write
+	// (#3848 part 1 / #3907, see csp_script_src.go).
+	var page bytes.Buffer
+	fmt.Fprintf(&page, strings.ReplaceAll(`<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Contribute to %s</title>
 <style>
 /* Michroma display face, base64-embedded (no network fonts). Used ONLY by the
@@ -5937,6 +5946,8 @@ fetch('/api/version').then(function(r){return r.json()}).then(function(d){
 }).catch(function(){});
 </script>
 </body></html>`, "{{HIVE_BRANCH}}", upstreamBranch()), projectName, michromaFontFaceCSS, customStyleHeadHTML, projectName, len(profiles), tierBoxes.String(), hubURL, hubURLJS, projectNameJS, tierTableRows, customStyleNoticeHTML)
+	applyDocumentScriptSrcElem(w, page.Bytes())
+	w.Write(page.Bytes())
 }
 
 // ── Registration ───────────────────────────────────────────────────────────

--- a/src/pkg/dashboard/csp_script_src.go
+++ b/src/pkg/dashboard/csp_script_src.go
@@ -1,0 +1,149 @@
+package dashboard
+
+// csp_script_src.go — the script-src half of kubestellar/hive#3848 (#3907).
+//
+// #3844 staged the removal of script-src 'unsafe-inline'; #3933 (ADR-0015)
+// then scoped style-src into its element/attribute halves because the two have
+// different futures. This file applies the SAME decomposition to script-src,
+// because the same asymmetry decides it:
+//
+//   - Inline <script> ELEMENTS take sha256 hashes. Every inline script this
+//     server sends is either embedded in the binary (static/index.html, the
+//     device-flow login page) or rendered by a handler that holds the complete
+//     document before writing it — so the exact allowlist is computable, at
+//     startup for the static documents and per response for the rendered ones.
+//     That half is CLOSED here: script-src-elem carries hashes and no
+//     'unsafe-inline'. Hashes — not nonces — deliberately: the SPA document is
+//     pre-gzipped once at startup with a strong ETag (#3863, static_index.go),
+//     and a per-response nonce would force a re-render + re-compress per
+//     request and defeat the ETag entirely. Hashes are a pure function of the
+//     bytes already being served, so the #3863 caching design is untouched.
+//
+//   - Inline on*= EVENT-HANDLER attributes (426 in static/index.html alone,
+//     plus ~145 more built as strings and injected through innerHTML sites)
+//     have no nonce and no hash form under script-src-elem semantics; only
+//     script-src-attr 'unsafe-hashes' could pin them, at a hash per distinct
+//     attribute value — rejected for the same reason ADR-0015 rejected it for
+//     styles. That half is STAGED as script-src-attr 'unsafe-inline' behind an
+//     event-delegation refactor of the SPA. See ADR-0016 and the tripwire
+//     TestCSPScriptSrcAttrUnsafeInlineIsStaged.
+//
+//   - script-src itself stays 'self' 'unsafe-inline' as the CSP2 fallback, and
+//     MUST NOT carry the hashes: per CSP2 §7.15, the presence of a hash makes
+//     a browser ignore 'unsafe-inline' in the same directive, so a browser
+//     that understands hashes but not script-src-elem/-attr (Firefox < 108)
+//     would block every inline handler and blank the dashboard. Browsers with
+//     CSP3 use the two explicit halves and never consult the fallback.
+//
+// Net effect: in every current browser an injected inline <script> no longer
+// executes (it cannot match a hash), while the served UI keeps working
+// everywhere. Injected on*= attributes remain executable until the delegation
+// refactor lands — stated, not hidden; see ADR-0016 "Residual risk".
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"io/fs"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// inlineScriptRe matches a <script ...>…</script> element and captures its
+// attribute list and its raw text content. (?s) lets the content span lines;
+// (?i) matches the tag case-insensitively, as the HTML tokenizer does. The
+// non-greedy body stops at the first </script>, which is exactly where the
+// HTML tokenizer ends the element regardless of JS syntax — jsStringLiteral
+// guarantees no served script carries a raw "</script" inside its content
+// (TestJSStringLiteralEscapesScriptContext), so regex and browser agree on
+// every document this server produces.
+var inlineScriptRe = regexp.MustCompile(`(?is)<script\b([^>]*)>(.*?)</script>`)
+
+// scriptSrcAttrRe detects a src= attribute on a <script> tag: external scripts
+// are covered by URL sources ('self', pinned CDNs), not hashes.
+var scriptSrcAttrRe = regexp.MustCompile(`(?i)(^|\s)src\s*=`)
+
+// extractInlineScripts returns the raw text content of every inline <script>
+// element in doc, in document order. Scripts with a src= attribute are
+// skipped; everything else — including non-executable data blocks — is
+// included, because hashing our own known content is harmless and keeps the
+// extraction rule simple enough to audit.
+func extractInlineScripts(doc []byte) [][]byte {
+	var scripts [][]byte
+	for _, m := range inlineScriptRe.FindAllSubmatch(doc, -1) {
+		if scriptSrcAttrRe.Match(m[1]) {
+			continue
+		}
+		scripts = append(scripts, m[2])
+	}
+	return scripts
+}
+
+// cspScriptHash renders content as a CSP hash-source token. The digest is over
+// the element's exact text bytes (WHATWG CSP §8.2 "is element's inline
+// behavior allowed"), base64 standard encoding with padding.
+func cspScriptHash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "'sha256-" + base64.StdEncoding.EncodeToString(sum[:]) + "'"
+}
+
+// scriptSrcElemSources builds the source list for script-src-elem covering
+// every inline script in doc: 'self' plus one hash per distinct script.
+func scriptSrcElemSources(doc []byte) string {
+	sources := []string{"'self'"}
+	seen := map[string]bool{}
+	for _, script := range extractInlineScripts(doc) {
+		h := cspScriptHash(script)
+		if !seen[h] {
+			seen[h] = true
+			sources = append(sources, h)
+		}
+	}
+	return strings.Join(sources, " ")
+}
+
+var (
+	baseScriptSrcElemOnce    sync.Once
+	baseScriptSrcElemSources string
+)
+
+// baseScriptSrcElem returns the startup-computed script-src-elem source list
+// covering the two documents whose bytes are fixed for the life of the
+// process: the embedded SPA (static/index.html, served verbatim by both
+// static_index.go and the plain file server) and the device-flow login page
+// (a const, served to any unauthenticated browser path). Computed once, like
+// the #3863 gzip/ETag precomputation it must stay compatible with.
+func baseScriptSrcElem() string {
+	baseScriptSrcElemOnce.Do(func() {
+		var docs []byte
+		if raw, err := fs.ReadFile(staticFS, "static/index.html"); err == nil {
+			docs = append(docs, raw...)
+		}
+		docs = append(docs, []byte(loginPage)...)
+		baseScriptSrcElemSources = scriptSrcElemSources(docs)
+	})
+	return baseScriptSrcElemSources
+}
+
+// applyDocumentScriptSrcElem replaces the script-src-elem directive of the
+// already-set CSP header with the hash allowlist for doc — the complete
+// rendered document the handler is about to write. Handlers whose HTML varies
+// per response (the /contribute landing, the /snapshot document) call this
+// after rendering and before the first Write, so the policy always describes
+// exactly the bytes being served. A response with no CSP header (not routed
+// through securityHeaders, e.g. a bare test recorder) is left untouched.
+func applyDocumentScriptSrcElem(w http.ResponseWriter, doc []byte) {
+	csp := w.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		return
+	}
+	parts := strings.Split(csp, ";")
+	for i, part := range parts {
+		if strings.HasPrefix(strings.TrimSpace(part), "script-src-elem") {
+			parts[i] = " script-src-elem " + scriptSrcElemSources(doc)
+			w.Header().Set("Content-Security-Policy", strings.TrimSpace(strings.Join(parts, ";")))
+			return
+		}
+	}
+}

--- a/src/pkg/dashboard/csp_script_src_test.go
+++ b/src/pkg/dashboard/csp_script_src_test.go
@@ -1,0 +1,442 @@
+package dashboard
+
+import (
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// csp_script_src_test.go covers the script-src half of kubestellar/hive#3848
+// (filed again as #3907) — the counterpart of csp_style_src_test.go, written in
+// the same shape ADR-0015 established and ADR-0016 continues.
+//
+// The old tripwire (TestCSPScriptSrcUnsafeInlineIsStaged) demanded inversion,
+// not relaxation, when the refactor landed. The refactor landed for the ELEMENT
+// half only, so the inversion here is scoped exactly to it:
+//
+//   - script-src-elem: CLOSED — hash allowlist, no 'unsafe-inline'. Pinned by
+//     TestCSPScriptSrcElemUnsafeInlineIsClosed plus the per-document coverage
+//     tests, which recompute every served inline script's hash and demand it
+//     be allowlisted.
+//   - script-src-attr: STAGED — 'unsafe-inline' remains for the 426+ inline
+//     on*= handler attributes until the event-delegation refactor (#3848).
+//     TestCSPScriptSrcAttrUnsafeInlineIsStaged is the new tripwire.
+//   - script-src: the CSP2 fallback stays 'self' 'unsafe-inline' and must stay
+//     HASH-FREE — a hash in that directive would make hash-aware pre-CSP3
+//     browsers ignore 'unsafe-inline' and blank the dashboard.
+
+// sha256SourceRe matches a CSP sha256 hash source token.
+var sha256SourceRe = regexp.MustCompile(`'sha256-[A-Za-z0-9+/]+=*'`)
+
+// TestCSPScriptSrcScopedIntoElemAndAttr is the #3848 part-1 deliverable shape:
+// script-src is no longer one blanket token — both CSP3 halves are present,
+// and the CSP2 fallback keeps exactly its old permissiveness.
+func TestCSPScriptSrcScopedIntoElemAndAttr(t *testing.T) {
+	csp := servedCSP(t)
+
+	for _, name := range []string{"script-src", "script-src-elem", "script-src-attr"} {
+		if cspDirective(csp, name) == "" {
+			t.Errorf("CSP is missing %q — the two script halves must be scoped separately (#3848, ADR-0016)\n got: %s", name, csp)
+		}
+	}
+
+	// The fallback must keep permitting what it always permitted: a pre-CSP3
+	// browser sees ONLY this directive, and tightening it is not this change's
+	// job (that is the event-delegation refactor's).
+	fallback := cspDirective(csp, "script-src")
+	if !strings.Contains(fallback, "'self'") || !strings.Contains(fallback, "'unsafe-inline'") {
+		t.Errorf("script-src fallback must stay permissive for pre-CSP3 browsers, got %q", fallback)
+	}
+
+	// THE LOAD-BEARING NEGATIVE: the fallback must never carry a hash. Per
+	// CSP2, a hash source makes the browser ignore 'unsafe-inline' in the same
+	// directive — so a browser that understands hashes but not
+	// script-src-elem/-attr (Firefox < 108) would block all 426+ inline on*=
+	// handlers and blank the dashboard. The hashes belong in script-src-elem
+	// and ONLY there.
+	if sha256SourceRe.MatchString(fallback) {
+		t.Errorf("script-src fallback carries a sha256 source (%q) — this DISABLES "+
+			"'unsafe-inline' on hash-aware pre-CSP3 browsers and blanks every inline "+
+			"handler; hashes may only appear in script-src-elem (ADR-0016)", fallback)
+	}
+}
+
+// TestCSPScriptSrcElemUnsafeInlineIsClosed is the INVERSION the old tripwire
+// demanded, scoped to the half that actually landed: inline <script> elements
+// are hash-allowlisted and 'unsafe-inline' is gone from script-src-elem, so an
+// injected inline <script> does not execute in any CSP3 browser.
+//
+// Do not relax this. If a legitimate new inline script stops matching, the fix
+// is to serve it through a hashed path (startup set for byte-stable documents,
+// applyDocumentScriptSrcElem for rendered ones) — never to re-admit
+// 'unsafe-inline' here, which CSP3 browsers would honour for injected scripts
+// too the moment the hashes were ever removed.
+func TestCSPScriptSrcElemUnsafeInlineIsClosed(t *testing.T) {
+	elem := cspDirective(servedCSP(t), "script-src-elem")
+	if elem == "" {
+		t.Fatal("CSP must declare script-src-elem explicitly (#3848, ADR-0016)")
+	}
+	if !strings.Contains(elem, "'self'") {
+		t.Errorf("script-src-elem must allowlist 'self' for same-origin script files, got %q", elem)
+	}
+	if strings.Contains(elem, "'unsafe-inline'") {
+		t.Errorf("script-src-elem has regressed to 'unsafe-inline' (got %q) — the element "+
+			"half of #3848 is CLOSED via hashes and must stay closed (ADR-0016)", elem)
+	}
+	if strings.Contains(elem, "'unsafe-eval'") {
+		t.Errorf("script-src-elem must never permit 'unsafe-eval', got %q", elem)
+	}
+	// COUNT FLOOR: the startup set covers the embedded SPA (2 inline scripts)
+	// and the device-flow login page (1). Fewer hashes than documents means the
+	// allowlist stopped covering something that is still being served — which
+	// blanks it — or the extraction broke, which is the same failure.
+	if got := len(sha256SourceRe.FindAllString(elem, -1)); got < 3 {
+		t.Errorf("script-src-elem carries %d sha256 sources, want >= 3 "+
+			"(2 for static/index.html + 1 for the login page); allowlist or extraction broke: %q", got, elem)
+	}
+}
+
+// TestCSPScriptSrcAttrUnsafeInlineIsStaged is the TRIPWIRE for the half that is
+// NOT closed, replacing the old whole-directive tripwire per #3848's own
+// instruction to invert-not-relax as halves land.
+//
+// script-src-attr still carries 'unsafe-inline' because the SPA wires 426
+// inline on*= attributes (plus ~145 more built as strings and injected through
+// innerHTML sites), and CSP offers no nonce and no elem-hash form for handler
+// attributes. Until the event-delegation refactor lands, an injected on*=
+// attribute still executes — stated in ADR-0016 "Residual risk", not hidden.
+//
+// When that refactor lands, this test FAILS by design. Do not relax it —
+// INVERT it (assert 'unsafe-inline' absent from script-src-attr AND from the
+// script-src fallback, which becomes droppable at the same moment), and update
+// ADR-0016's status in the same PR.
+func TestCSPScriptSrcAttrUnsafeInlineIsStaged(t *testing.T) {
+	attr := cspDirective(servedCSP(t), "script-src-attr")
+	if attr == "" {
+		t.Fatal("CSP must declare script-src-attr explicitly (#3848, ADR-0016)")
+	}
+	if !strings.Contains(attr, "'unsafe-inline'") {
+		t.Fatalf("script-src-attr no longer has 'unsafe-inline' (got %q).\n"+
+			"This is GOOD NEWS: the event-delegation half of #3848 appears to have landed.\n"+
+			"Invert this test into an assertion that 'unsafe-inline' is ABSENT here and in "+
+			"the script-src fallback, so it can never come back, and update ADR-0016 in the "+
+			"same PR.", attr)
+	}
+	// 'unsafe-hashes' would mean a hash per distinct handler-attribute value,
+	// regenerated on every UI edit — rejected in ADR-0016 exactly as ADR-0015
+	// rejected it for style attributes.
+	if strings.Contains(attr, "'unsafe-hashes'") {
+		t.Errorf("script-src-attr must not use 'unsafe-hashes' (got %q) — ADR-0016 rejects "+
+			"per-attribute hash enumeration as unmaintainable", attr)
+	}
+	if strings.Contains(attr, "'self'") {
+		t.Errorf("script-src-attr carries 'self' (%q), which is meaningless for handler "+
+			"attributes — they have no URL source", attr)
+	}
+}
+
+// TestEmbeddedIndexScriptsSatisfyCSPHashes proves the SPA document actually
+// passes the policy served with it — recomputing each inline script's hash from
+// the response body and demanding it be allowlisted — AND that the #3863
+// startup-pre-gzip + strong-ETag design survives, which is the entire reason
+// this migration uses hashes instead of nonces.
+func TestEmbeddedIndexScriptsSatisfyCSPHashes(t *testing.T) {
+	raw, err := fs.ReadFile(staticFS, "static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded SPA document: %v", err)
+	}
+
+	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
+	handler := s.securityHeaders(newIndexDocument(raw))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	// #3863 invariants: still pre-gzipped, still carrying a strong ETag.
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip — the hash migration must not cost the #3863 compression", got)
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("ETag missing — the hash migration must not cost the #3863 revalidation path")
+	}
+
+	// The served body (decompressed) is byte-identical to the embedded source,
+	// so hashes computed at startup from the embed describe the served bytes.
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("body is not valid gzip: %v", err)
+	}
+	body, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("decompressing body: %v", err)
+	}
+	if string(body) != string(raw) {
+		t.Fatal("served SPA bytes differ from the embedded document — startup hashes would not match")
+	}
+
+	// POSITIVE CONTROL + COUNT FLOOR: the document still contains its scripts.
+	scripts := extractInlineScripts(body)
+	if len(scripts) != 2 {
+		t.Fatalf("extracted %d inline scripts from static/index.html, want 2 — "+
+			"if the SPA gained or lost a script block, update this floor AND confirm the new "+
+			"block is served hashed", len(scripts))
+	}
+	elem := cspDirective(rec.Header().Get("Content-Security-Policy"), "script-src-elem")
+	for i, script := range scripts {
+		if h := cspScriptHash(script); !strings.Contains(elem, h) {
+			t.Errorf("inline script #%d of the served SPA is not allowlisted (%s missing) — "+
+				"the dashboard would render BLANK in every CSP3 browser\n elem: %s", i, h, elem)
+		}
+	}
+
+	// #3863 invariant: revalidation still yields a 304 with no body, and the
+	// 304 carries the same CSP so a revalidated page is governed identically.
+	req304 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req304.Header.Set("If-None-Match", etag)
+	rec304 := httptest.NewRecorder()
+	handler.ServeHTTP(rec304, req304)
+	if rec304.Code != http.StatusNotModified {
+		t.Fatalf("If-None-Match revalidation status = %d, want 304", rec304.Code)
+	}
+	if got := cspDirective(rec304.Header().Get("Content-Security-Policy"), "script-src-elem"); got != elem {
+		t.Errorf("304 response CSP script-src-elem differs from the 200's\n 200: %s\n 304: %s", elem, got)
+	}
+}
+
+// TestLoginPageScriptSatisfiesCSPHashes covers the other byte-stable document
+// in the startup set: the device-flow login page, served with the same base
+// header to every unauthenticated browser path.
+func TestLoginPageScriptSatisfiesCSPHashes(t *testing.T) {
+	scripts := extractInlineScripts([]byte(loginPage))
+	if len(scripts) != 1 {
+		t.Fatalf("extracted %d inline scripts from the login page, want 1 — "+
+			"update the floor AND the startup hash set together", len(scripts))
+	}
+	elem := cspDirective(servedCSP(t), "script-src-elem")
+	if h := cspScriptHash(scripts[0]); !strings.Contains(elem, h) {
+		t.Errorf("the login page's inline script is not allowlisted (%s missing) — "+
+			"sign-in would break in every CSP3 browser\n elem: %s", h, elem)
+	}
+}
+
+// TestContributePageScriptsSatisfyPerResponseCSP proves the per-response lane:
+// the /contribute document's inline scripts vary with the request (hubURL from
+// the Host header), so its handler must stamp hashes computed from the exact
+// bytes it writes. Two different Hosts produce two different documents, and
+// each response's policy must cover its own body.
+func TestContributePageScriptsSatisfyPerResponseCSP(t *testing.T) {
+	srv := newFullServer(t)
+
+	render := func(host string) (elem string, body []byte) {
+		t.Helper()
+		handler := srv.securityHeaders(http.HandlerFunc(srv.handleContributeLanding))
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+		req.Host = host
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("contribute landing status = %d, want 200", rec.Code)
+		}
+		return cspDirective(rec.Header().Get("Content-Security-Policy"), "script-src-elem"), rec.Body.Bytes()
+	}
+
+	for _, host := range []string{"hub.example.com", "other-hub.example.org:8443"} {
+		elem, body := render(host)
+		if strings.Contains(elem, "'unsafe-inline'") {
+			t.Errorf("host %s: script-src-elem must not carry 'unsafe-inline', got %q", host, elem)
+		}
+		scripts := extractInlineScripts(body)
+		// COUNT FLOOR: the page ships 4 unconditional inline script blocks
+		// today; zero or few means extraction broke and the policy is vacuous.
+		if len(scripts) < 4 {
+			t.Fatalf("host %s: extracted %d inline scripts from /contribute, want >= 4", host, len(scripts))
+		}
+		for i, script := range scripts {
+			if h := cspScriptHash(script); !strings.Contains(elem, h) {
+				t.Errorf("host %s: /contribute inline script #%d not allowlisted (%s missing) — "+
+					"the page would render dead in every CSP3 browser", host, i, h)
+			}
+		}
+	}
+
+	// The two documents differ (different hubURL), so at least one hash must
+	// differ too — proving the header really is computed per response rather
+	// than baked once.
+	elemA, _ := render("hub.example.com")
+	elemB, _ := render("other-hub.example.org:8443")
+	if elemA == elemB {
+		t.Error("script-src-elem identical across different Hosts — per-response hashing is not happening")
+	}
+}
+
+// TestApplyDocumentScriptSrcElem pins the header-rewrite helper the dynamic
+// handlers depend on.
+func TestApplyDocumentScriptSrcElem(t *testing.T) {
+	doc := []byte(`<html><head><script>alert("ours")</script></head></html>`)
+	wantHash := cspScriptHash([]byte(`alert("ours")`))
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Security-Policy",
+		"default-src 'self'; script-src 'self' 'unsafe-inline'; script-src-elem 'self' 'sha256-stale='; script-src-attr 'unsafe-inline'; style-src 'self'")
+	applyDocumentScriptSrcElem(rec, doc)
+	csp := rec.Header().Get("Content-Security-Policy")
+
+	elem := cspDirective(csp, "script-src-elem")
+	if !strings.Contains(elem, wantHash) {
+		t.Errorf("rewritten script-src-elem missing the document's hash: %q", elem)
+	}
+	if strings.Contains(elem, "sha256-stale=") {
+		t.Errorf("rewritten script-src-elem kept a stale hash: %q", elem)
+	}
+	// Neighbouring directives must be untouched.
+	for _, want := range []string{"default-src 'self'", "script-src 'self' 'unsafe-inline'", "script-src-attr 'unsafe-inline'", "style-src 'self'"} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("rewrite disturbed a neighbouring directive: %q missing from %q", want, csp)
+		}
+	}
+
+	// A script-free document yields a hash-free (but still closed) directive.
+	rec2 := httptest.NewRecorder()
+	rec2.Header().Set("Content-Security-Policy", "script-src-elem 'self' 'sha256-stale='")
+	applyDocumentScriptSrcElem(rec2, []byte("<html>no scripts</html>"))
+	if got := cspDirective(rec2.Header().Get("Content-Security-Policy"), "script-src-elem"); got != "script-src-elem 'self'" {
+		t.Errorf("script-free document: script-src-elem = %q, want \"script-src-elem 'self'\"", got)
+	}
+
+	// No CSP header (not routed through securityHeaders): leave untouched.
+	rec3 := httptest.NewRecorder()
+	applyDocumentScriptSrcElem(rec3, doc)
+	if got := rec3.Header().Get("Content-Security-Policy"); got != "" {
+		t.Errorf("helper invented a CSP header out of nothing: %q", got)
+	}
+}
+
+// TestDynamicHTMLHandlersStampDocumentCSP asserts the gate IN SOURCE: both
+// handlers that render per-response HTML documents must call
+// applyDocumentScriptSrcElem before writing. The /snapshot lane reads its
+// document from /data at runtime, so this source-level pin is what a unit test
+// can hold it to; TestContributePageScriptsSatisfyPerResponseCSP covers the
+// /contribute lane end-to-end as well.
+func TestDynamicHTMLHandlersStampDocumentCSP(t *testing.T) {
+	for file, wantCalls := range map[string]int{
+		"api_contribute.go": 1, // handleContributeLanding
+		"api.go":            1, // handleSnapshotPage
+	} {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		if got := strings.Count(string(src), "applyDocumentScriptSrcElem(w"); got < wantCalls {
+			t.Errorf("%s calls applyDocumentScriptSrcElem %d times, want >= %d — a rendered "+
+				"document served without its per-response hashes renders BLANK in CSP3 browsers", file, got, wantCalls)
+		}
+	}
+}
+
+// TestTerminalPathKeepsBlanketScriptSrc pins the deliberate exclusion: ttyd's
+// UI is reverse-proxied — this server never holds its document bytes — so
+// /terminal keeps the blanket CSP2 policy instead of a hash allowlist computed
+// from the WRONG document, which would brick the terminal.
+func TestTerminalPathKeepsBlanketScriptSrc(t *testing.T) {
+	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
+	handler := s.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	for _, path := range []string{"/terminal", "/terminal/ws"} {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		csp := rec.Header().Get("Content-Security-Policy")
+		if cspDirective(csp, "script-src-elem") != "" {
+			t.Errorf("%s: script-src-elem present — a hash allowlist for a document this server "+
+				"never renders would brick ttyd\n got: %s", path, csp)
+		}
+		fallback := cspDirective(csp, "script-src")
+		if !strings.Contains(fallback, "'unsafe-inline'") {
+			t.Errorf("%s: terminal responses must keep the blanket script-src, got %q", path, fallback)
+		}
+	}
+}
+
+// TestServedDocumentsHaveNoScriptInHTMLComments pins the precondition that
+// keeps the hash extraction and the browser's HTML tokenizer in agreement: a
+// literal "<script" inside an HTML comment is text to the browser but a tag to
+// the extraction regex, which would both hash a phantom script and miss a real
+// one — i.e. serve a policy that blanks the page. No document we hash may
+// contain one.
+func TestServedDocumentsHaveNoScriptInHTMLComments(t *testing.T) {
+	htmlCommentRe := regexp.MustCompile(`(?s)<!--.*?-->`)
+
+	index, err := fs.ReadFile(staticFS, "static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded SPA document: %v", err)
+	}
+	docs := map[string][]byte{
+		"static/index.html": index,
+		"loginPage":         []byte(loginPage),
+	}
+
+	srv := newFullServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	req.Host = "hub.example.com"
+	srv.handleContributeLanding(rec, req)
+	docs["/contribute"] = rec.Body.Bytes()
+
+	for name, doc := range docs {
+		for _, comment := range htmlCommentRe.FindAll(doc, -1) {
+			if strings.Contains(strings.ToLower(string(comment)), "<script") {
+				t.Errorf("%s: HTML comment contains \"<script\" (%.80s…) — this desynchronizes "+
+					"CSP hash extraction from the browser's tokenizer; reword the comment", name, comment)
+			}
+		}
+	}
+}
+
+// TestCSPScriptSrcRationaleIsWritten pins the deliverable's written half, as
+// TestCSPStyleSrcRationaleIsWritten does for ADR-0015: the staged
+// script-src-attr allowance is legitimate only while its rationale and
+// residual risk are on record and discoverable.
+func TestCSPScriptSrcRationaleIsWritten(t *testing.T) {
+	const adr = "../../docs/adr/0016-csp-script-src-scope.md"
+	body, err := os.ReadFile(adr)
+	if err != nil {
+		t.Fatalf("ADR-0016 is missing (%v).\nscript-src-attr 'unsafe-inline' is STAGED only because "+
+			"a written rationale exists (#3848/#3907); without it the allowance is undocumented again.", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"script-src-elem", // the closed half is named
+		"script-src-attr", // and distinguished from the staged half
+		"Status: Accepted",
+		"Residual risk",
+		"#3863", // the hashes-not-nonces constraint is recorded
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("ADR-0016 does not mention %q — the rationale must state what is closed, "+
+				"what is staged, and why hashes", want)
+		}
+	}
+
+	index, err := os.ReadFile("../../docs/adr/README.md")
+	if err != nil {
+		t.Fatalf("reading ADR index: %v", err)
+	}
+	if !strings.Contains(string(index), "0016-csp-script-src-scope.md") {
+		t.Error("ADR-0016 is not linked from the ADR index — an unlinked ADR is one nobody finds")
+	}
+}

--- a/src/pkg/dashboard/csp_token_test.go
+++ b/src/pkg/dashboard/csp_token_test.go
@@ -63,43 +63,15 @@ func TestCSPDirectivesPinned(t *testing.T) {
 	}
 }
 
-// TestCSPScriptSrcUnsafeInlineIsStaged documents the REMAINING half of #3315.
-//
-// script-src still carries 'unsafe-inline' because the dashboard is
-// server-rendered HTML with roughly 400 inline on*= handlers plus several
-// inline <script> blocks (static/index.html, api_contribute.go, and the
-// device-flow login page in server.go). Removing the directive today blanks
-// the UI, so it is staged behind a nonce/handler-extraction refactor.
-//
-// This test is deliberately written as a TRIPWIRE, not an endorsement: when the
-// refactor lands, script-src loses 'unsafe-inline', this test FAILS, and whoever
-// does that work must invert it into the "must be absent" assertion below --
-// which is already written and enabled for the directives that are safe today.
-func TestCSPScriptSrcUnsafeInlineIsStaged(t *testing.T) {
-	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
-	handler := s.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
-
-	scriptSrc := cspDirective(rec.Header().Get("Content-Security-Policy"), "script-src")
-	if scriptSrc == "" {
-		t.Fatal("CSP must declare an explicit script-src directive")
-	}
-	if !strings.Contains(scriptSrc, "'self'") {
-		t.Errorf("script-src must allowlist 'self', got %q", scriptSrc)
-	}
-	if strings.Contains(scriptSrc, "'unsafe-eval'") {
-		t.Errorf("script-src must never permit 'unsafe-eval', got %q", scriptSrc)
-	}
-	if !strings.Contains(scriptSrc, "'unsafe-inline'") {
-		t.Fatalf("script-src no longer has 'unsafe-inline' (got %q).\n"+
-			"This is GOOD NEWS: the #3315 follow-up appears to have landed.\n"+
-			"Invert this test into an assertion that 'unsafe-inline' is ABSENT, "+
-			"so it can never come back.", scriptSrc)
-	}
-}
+// The tripwire that lived here — TestCSPScriptSrcUnsafeInlineIsStaged — has
+// been INVERTED, exactly as its own instructions and #3848 required, for the
+// half that landed: script-src is now scoped into its element and attribute
+// halves (#3848 part 1 / #3907, ADR-0016), and the closed element half is
+// pinned by TestCSPScriptSrcElemUnsafeInlineIsClosed in csp_script_src_test.go.
+// The attribute half is still staged behind the event-delegation refactor and
+// carries its own tripwire there (TestCSPScriptSrcAttrUnsafeInlineIsStaged),
+// and the CSP2 fallback's deliberate 'unsafe-inline' is pinned by
+// TestCSPScriptSrcScopedIntoElemAndAttr.
 
 // TestJSStringLiteralEscapesScriptContext covers the encode-at-the-sink helper
 // used for the values injected into the /contribute inline <script> (#3315),

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -864,25 +864,47 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		}
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
-		// SECURITY (#3315): script-src still carries 'unsafe-inline' because the
-		// dashboard is server-rendered HTML with inline on*= handlers and
-		// several inline <script> blocks (static/index.html, api_contribute.go,
-		// the device-flow login page below). Dropping it today would blank the
-		// UI, so it is staged behind a nonce/handler refactor — see #3315/#3848.
-		// Measured on v4 for #3848: 437 inline on*= attributes in
-		// static/index.html plus ~145 more BUILT AS STRINGS inside the page's
-		// own JavaScript and injected through 169 innerHTML/insertAdjacentHTML
-		// sites. A nonce cannot cover ANY of them — nonces apply to <script>
-		// elements, never to event-handler attributes — so completing script-src
-		// is an event-delegation refactor of the SPA, not a nonce threading
-		// exercise. TestCSPScriptSrcUnsafeInlineIsStaged stays as the tripwire.
+		// SECURITY (#3315 → #3848 part 1, #3907): script-src is scoped into its
+		// element and attribute halves, the same decomposition ADR-0015 applied
+		// to style-src, because the same asymmetry decides it — see ADR-0016 and
+		// csp_script_src.go for the full rationale:
 		//
-		// What IS enforced here: the secret that 'unsafe-inline' used to expose
-		// is gone. The dashboard token is never rendered into the page (see
-		// serveIndex in proxy/server.js and handleAuthToken in api.go), so an
-		// inline-script XSS has no token to steal from the served HTML.
-		// form-action 'self' is added to stop an injected <form> from posting
-		// credentials off-origin, which does NOT depend on inline scripts.
+		//   script-src-elem 'self' 'sha256-…'  — inline <script> ELEMENTS.
+		//     CLOSED. Every inline script this server sends is hash-allowlisted:
+		//     the embedded SPA and the device-flow login page at startup
+		//     (baseScriptSrcElem), the per-response documents (/contribute,
+		//     /snapshot) by applyDocumentScriptSrcElem over the exact bytes
+		//     served. No 'unsafe-inline': an injected inline <script> cannot
+		//     match a hash and does not execute in any CSP3 browser. Hashes, not
+		//     nonces, so the #3863 startup-pre-gzip + strong-ETag design for the
+		//     SPA document is untouched.
+		//
+		//   script-src-attr 'unsafe-inline'  — inline on*= HANDLER attributes.
+		//     STAGED, not accepted: 426 on*= attributes in static/index.html
+		//     plus ~145 more built as strings and injected through 169
+		//     innerHTML/insertAdjacentHTML sites. Neither nonces nor elem-hashes
+		//     apply to attributes, so closing this half is an event-delegation
+		//     refactor of the SPA (#3848), and until then an injected on*=
+		//     attribute still executes. TestCSPScriptSrcAttrUnsafeInlineIsStaged
+		//     is the tripwire: invert it, never relax it.
+		//
+		//   script-src 'self' 'unsafe-inline'  — the CSP2 fallback, unchanged,
+		//     and it must NEVER carry the hashes: a hash in this directive makes
+		//     hash-aware browsers ignore 'unsafe-inline' here, and a browser
+		//     that knows hashes but not script-src-elem/-attr (Firefox < 108)
+		//     would then block every inline handler and blank the dashboard.
+		//     Pre-CSP3 browsers keep exactly today's behaviour.
+		//
+		// The secret that 'unsafe-inline' used to expose is gone regardless: the
+		// dashboard token is never rendered into the page (see serveIndex in
+		// proxy/server.js and handleAuthToken in api.go), so an inline-script
+		// XSS has no token to steal from the served HTML. form-action 'self'
+		// stops an injected <form> from posting credentials off-origin.
+		//
+		// /terminal is excluded from the split: those responses are ttyd's own
+		// UI streamed through a reverse proxy, this server never sees the
+		// document bytes to hash, and a wrong allowlist there would brick the
+		// terminal. It keeps the blanket CSP2 policy it has always had.
 		//
 		// style-src (#3848 part 2) is scoped as TWO directives rather than one
 		// blanket allowance, because the two halves have different futures:
@@ -905,8 +927,12 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		// Both are listed AFTER the style-src fallback, which browsers without
 		// CSP3 support use instead; the effective policy is identical either way,
 		// so this split names the decision without changing behaviour.
+		scriptDirectives := "script-src 'self' 'unsafe-inline'; script-src-elem " + baseScriptSrcElem() + "; script-src-attr 'unsafe-inline'"
+		if r.URL.Path == "/terminal" || strings.HasPrefix(r.URL.Path, "/terminal/") {
+			scriptDirectives = "script-src 'self' 'unsafe-inline'"
+		}
 		w.Header().Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors "+frameAncestors)
+			"default-src 'self'; "+scriptDirectives+"; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors "+frameAncestors)
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		next.ServeHTTP(w, r)
 	})

--- a/src/proxy/csp_script_src_elem.test.js
+++ b/src/proxy/csp_script_src_elem.test.js
@@ -1,0 +1,244 @@
+import { createServer, request as httpRequest } from 'http';
+import { strict as assert } from 'assert';
+import { spawn } from 'child_process';
+import { writeFileSync, mkdtempSync, rmSync, readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { createHash } from 'crypto';
+import path from 'path';
+
+// Covers the script-src half of kubestellar/hive#3848 (#3907) on the proxy —
+// the Node-side counterpart of csp_script_src_test.go, mirroring ADR-0016:
+//
+//   script-src      'self' 'unsafe-inline' …  <- CSP2 fallback, UNCHANGED and
+//                                               hash-free (a hash here disables
+//                                               'unsafe-inline' on hash-aware
+//                                               pre-CSP3 browsers and blanks
+//                                               every inline on*= handler)
+//   script-src-elem 'self' cdn 'sha256-…'     <- inline <script> elements:
+//                                               CLOSED — only the SPA's own
+//                                               inline scripts can execute
+//   script-src-attr 'unsafe-inline'           <- on*= attributes: STAGED
+//
+// Go-rendered documents (/contribute, /leaderboard, /snapshot) and ttyd's UI
+// (/terminal) keep the blanket policy: the Go upstream stamps its own
+// per-document hashes, and http-proxy-middleware copies upstream headers over
+// ours — which test 3 PROVES empirically rather than assumes.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROXY_PORT = 19061;
+const GO_PORT = 19062;
+const TTYD_PORT = 19063;
+
+// The mock SPA carries two DISTINCT inline scripts (so the hash count is
+// checkable), one external script (which must NOT be hashed — it is covered by
+// URL sources), and an inline on*= handler (covered by script-src-attr).
+const INLINE_ONE = "console.log('hive-inline-one');";
+const INLINE_TWO = "window.__hive = 'inline-two';\nconsole.log(window.__hive);";
+const INDEX_MARKER = 'hive-dashboard-index-marker';
+const INDEX_HTML = `<!doctype html><html><head><title>Hive</title>
+<script>${INLINE_ONE}</script>
+<script src="/app.js"></script>
+</head><body onload="console.log('handler')"><div id="${INDEX_MARKER}">dashboard</div>
+<script>${INLINE_TWO}</script>
+</body></html>`;
+
+const sha256Source = (s) => `'sha256-${createHash('sha256').update(s, 'utf8').digest('base64')}'`;
+
+// A recognisable upstream CSP so test 3 can prove upstream-wins on proxied docs.
+const UPSTREAM_CSP = "default-src 'self'; script-src-elem 'self' 'sha256-UPSTREAM-SENTINEL='";
+
+let staticDir;
+let goServer;
+
+function setupMockGoBackend() {
+  const server = createServer((req, res) => {
+    if (req.url === '/api/snapshot/frame-ancestors') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ origins: [] }));
+      return;
+    }
+    if (req.url.startsWith('/contribute')) {
+      res.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Content-Security-Policy': UPSTREAM_CSP,
+      });
+      res.end('<!doctype html><html><body>contribute page</body></html>');
+      return;
+    }
+    res.writeHead(404);
+    res.end('not found');
+  });
+  return new Promise((resolve) => server.listen(GO_PORT, () => resolve(server)));
+}
+
+function startProxy(extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        HIVE_PROXY_PORT: String(PROXY_PORT),
+        HIVE_API_PORT: String(GO_PORT),
+        HIVE_TTYD_PORT: String(TTYD_PORT),
+        HIVE_STATIC_DIR: staticDir,
+        NODE_ENV: 'test',
+        ...extraEnv,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', (d) => {
+      if (!started && d.toString().includes('hive-proxy')) {
+        started = true;
+        resolve(proc);
+      }
+    });
+    proc.stderr.on('data', (d) => { if (!started) console.error('proxy stderr:', d.toString()); });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('proxy start timeout')); }, 10000);
+  });
+}
+
+function get(pathname, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port: PROXY_PORT, path: pathname, method: 'GET', headers },
+      (res) => {
+        let body = '';
+        res.on('data', (c) => { body += c; });
+        res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+const directive = (csp, name) =>
+  (csp || '').split(';').map((s) => s.trim()).find((s) => s === name || s.startsWith(`${name} `)) || '';
+
+async function stop(proc) {
+  if (!proc) return;
+  proc.kill('SIGKILL');
+  await new Promise((r) => proc.once('exit', r));
+}
+
+async function main() {
+  staticDir = mkdtempSync(path.join(tmpdir(), 'hive-csp-elem-test-'));
+  writeFileSync(path.join(staticDir, 'index.html'), INDEX_HTML);
+  goServer = await setupMockGoBackend();
+
+  const proxy = await startProxy();
+  try {
+    // -------------------------------------------------------------------
+    // 1. The SPA document is served under the scoped policy, every one of
+    //    its inline scripts hash-allowlisted, and the element half CLOSED.
+    // -------------------------------------------------------------------
+    const res = await get('/');
+    assert.equal(res.status, 200, 'dashboard index must be served');
+    assert.ok(res.body.includes(INDEX_MARKER), 'positive control: real page content came back');
+
+    const csp = res.headers['content-security-policy'];
+    assert.ok(csp, 'Content-Security-Policy header must be present');
+
+    const elem = directive(csp, 'script-src-elem');
+    assert.ok(elem, 'CSP must declare script-src-elem (#3848 part 1, ADR-0016)');
+    assert.ok(!elem.includes("'unsafe-inline'"),
+      `script-src-elem must not carry 'unsafe-inline' — the element half is CLOSED: ${elem}`);
+    assert.ok(elem.includes("'self'"), `script-src-elem must allowlist 'self': ${elem}`);
+    assert.ok(elem.includes('https://cdn.redoc.ly'),
+      `script-src-elem must keep the pinned Redoc CDN for /api-docs: ${elem}`);
+    for (const inline of [INLINE_ONE, INLINE_TWO]) {
+      assert.ok(elem.includes(sha256Source(inline)),
+        `served inline script not allowlisted (${sha256Source(inline)}) — the SPA would render BLANK: ${elem}`);
+    }
+    // The external script must be covered by URL sources, never hashed: hash
+    // count equals the INLINE count exactly.
+    const hashCount = (elem.match(/'sha256-[A-Za-z0-9+/]+=*'/g) || []).length;
+    assert.equal(hashCount, 2,
+      `script-src-elem must carry exactly the 2 inline-script hashes, got ${hashCount}: ${elem}`);
+
+    const attr = directive(csp, 'script-src-attr');
+    assert.ok(attr.includes("'unsafe-inline'"),
+      `script-src-attr must keep 'unsafe-inline' until the #3848 event-delegation refactor — ` +
+      `dropping it silently kills every inline on*= handler: ${csp}`);
+
+    // The CSP2 fallback: unchanged, and LOAD-BEARINGLY hash-free — a hash in
+    // script-src makes hash-aware pre-CSP3 browsers (Firefox < 108) ignore
+    // 'unsafe-inline' and blank every inline handler.
+    const fallback = directive(csp, 'script-src');
+    assert.ok(fallback.includes("'self'") && fallback.includes("'unsafe-inline'"),
+      `script-src fallback must stay permissive for pre-CSP3 browsers: ${fallback}`);
+    assert.ok(!/'sha256-/.test(fallback),
+      `script-src fallback must NEVER carry hashes (disables 'unsafe-inline' on ` +
+      `hash-aware pre-CSP3 browsers): ${fallback}`);
+    assert.ok(!fallback.includes("'unsafe-eval'"), 'script-src must never permit unsafe-eval');
+    console.log('  ok: SPA served hash-allowlisted; element half closed, attr staged, fallback intact');
+
+    // -------------------------------------------------------------------
+    // 2. SPA deep links get the same scoped policy (same document served).
+    // -------------------------------------------------------------------
+    const deep = await get('/agents');
+    assert.equal(deep.status, 200, 'SPA fallback route must render');
+    assert.equal(directive(deep.headers['content-security-policy'], 'script-src-elem'), elem,
+      'deep-link routes must carry the same script-src-elem allowlist');
+    console.log('  ok: deep-link routes carry the same allowlist');
+
+    // -------------------------------------------------------------------
+    // 3. Proxied Go-rendered documents: the proxy sends the BLANKET policy
+    //    (no elem directive it cannot compute), and the upstream's own CSP
+    //    header wins end-to-end — proven, not assumed.
+    // -------------------------------------------------------------------
+    const contribute = await get('/contribute');
+    assert.equal(contribute.status, 200, 'contribute page must proxy through');
+    assert.equal(contribute.headers['content-security-policy'], UPSTREAM_CSP,
+      'the Go upstream CSP must reach the client verbatim on proxied documents — ' +
+      'http-proxy-middleware stopped copying upstream headers over ours, which the ' +
+      'blanket-policy design depends on');
+    console.log('  ok: upstream Go CSP wins on proxied documents (verified, not assumed)');
+
+    // -------------------------------------------------------------------
+    // 4. /api-docs (rendered by the proxy, zero inline scripts): scoped
+    //    policy applies, and Redoc's pinned CDN stays loadable.
+    // -------------------------------------------------------------------
+    const docs = await get('/api-docs');
+    assert.equal(docs.status, 200, 'api-docs must render');
+    const docsElem = directive(docs.headers['content-security-policy'], 'script-src-elem');
+    assert.ok(docsElem.includes('https://cdn.redoc.ly'),
+      `api-docs must keep the SRI-pinned Redoc CDN loadable: ${docsElem}`);
+    const docsInlineScripts = (docs.body.match(/<script\b(?![^>]*\ssrc\s*=)[^>]*>/gi) || []).length;
+    assert.equal(docsInlineScripts, 0,
+      'api-docs must carry no inline scripts — its policy hashes none');
+    console.log('  ok: api-docs stays functional under the closed element half');
+
+    // -------------------------------------------------------------------
+    // 5. SOURCE GUARD: the fallback directive in server.js must stay literal
+    //    and hash-free, so a refactor cannot quietly merge the hash list into
+    //    it and trip the CSP2 'unsafe-inline'-suppression footgun.
+    // -------------------------------------------------------------------
+    const src = readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+    assert.ok(src.includes(`"script-src 'self' 'unsafe-inline' https://cdn.redoc.ly"`),
+      'server.js must keep the literal, hash-free script-src fallback');
+    assert.ok(/script-src-attr 'unsafe-inline'/.test(src),
+      'server.js must declare script-src-attr explicitly');
+    console.log('  ok: source guard — fallback literal and hash-free');
+  } finally {
+    await stop(proxy);
+  }
+}
+
+main()
+  .then(() => {
+    goServer?.close();
+    if (staticDir) rmSync(staticDir, { recursive: true, force: true });
+    console.log('csp_script_src_elem.test.js: OK');
+    process.exit(0);
+  })
+  .catch((err) => {
+    goServer?.close();
+    if (staticDir) rmSync(staticDir, { recursive: true, force: true });
+    console.error('csp_script_src_elem.test.js: FAIL');
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/proxy/csp_token_injection.test.js
+++ b/src/proxy/csp_token_injection.test.js
@@ -198,13 +198,12 @@ async function main() {
     assert.match(csp, /form-action 'self'/, "CSP must set form-action 'self'");
     assert.match(csp, /frame-ancestors 'none'/, 'CSP must deny framing by default');
 
-    // #3315 STAGED: script-src still carries 'unsafe-inline' because the
-    // dashboard is server-rendered with ~400 inline on*= handlers and several
-    // inline <script> blocks. This assertion documents the remaining exposure
-    // and MUST be inverted to a "does not contain" check by the follow-up that
-    // moves those handlers out of the markup. Failing here means the refactor
-    // landed and this guard needs flipping -- see #3315.
-    const scriptSrc = csp.split(';').map(s => s.trim()).find(s => s.startsWith('script-src'));
+    // #3848 part 1 landed: script-src is now scoped (see ADR-0016 and
+    // csp_script_src_elem.test.js, which owns the elem/attr assertions). What
+    // this test pins is the CSP2 FALLBACK, which deliberately keeps
+    // 'unsafe-inline' — hash-free — for pre-CSP3 browsers; dropping it there is
+    // the event-delegation refactor's moment (#3848), not before.
+    const scriptSrc = csp.split(';').map(s => s.trim()).find(s => s === 'script-src' || s.startsWith('script-src '));
     assert.ok(scriptSrc, 'CSP must declare an explicit script-src');
     assert.ok(
       scriptSrc.includes("'self'"),

--- a/src/proxy/package.json
+++ b/src/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node csp_token_injection.test.js"
+    "test": "node server.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node csp_token_injection.test.js && node csp_script_src_elem.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/src/proxy/server.js
+++ b/src/proxy/server.js
@@ -775,13 +775,70 @@ async function snapshotFrameAncestors() {
   }
 }
 
+// ── CSP script-src scoping (#3848 part 1 / #3907, mirrors Go securityHeaders) ──
+//
+// script-src is split into its CSP3 halves, exactly like the Go spoke server:
+//   script-src-elem 'self' cdn + sha256 hashes — inline <script> ELEMENTS,
+//     CLOSED: only this proxy's own inline scripts (the SPA document's) can
+//     execute; an injected inline <script> matches no hash and is blocked.
+//   script-src-attr 'unsafe-inline' — the SPA's ~426 inline on*= handler
+//     attributes, STAGED behind an event-delegation refactor (#3848). Hashes
+//     and nonces do not exist for attributes.
+//   script-src (fallback) keeps 'self' 'unsafe-inline' UNCHANGED for pre-CSP3
+//     browsers, and must never carry the hashes: a hash there makes hash-aware
+//     browsers ignore 'unsafe-inline' in the same directive, blanking the UI
+//     on browsers that know hashes but not -elem/-attr (Firefox < 108).
+//
+// Hashes are computed from the exact index.html bytes this proxy serves —
+// lazily, because the dashboard file can be built after startup (see
+// serveIndex). Documents this proxy does NOT render — the Go-rendered
+// /contribute, /leaderboard and /snapshot pages, and ttyd's own UI under
+// /terminal — keep the blanket CSP2 policy: the Go upstream stamps its own
+// per-document hash policy on the pages it renders (http-proxy-middleware
+// copies upstream headers over ours), and a hash allowlist computed from the
+// WRONG document would blank exactly those pages if that copy ever changed.
+function computeInlineScriptHashes(html) {
+  const hashes = [];
+  const scriptRe = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  for (const m of html.matchAll(scriptRe)) {
+    if (/(^|\s)src\s*=/i.test(m[1])) continue; // external: covered by URL sources
+    const h = `'sha256-${crypto.createHash('sha256').update(m[2], 'utf8').digest('base64')}'`;
+    if (!hashes.includes(h)) hashes.push(h);
+  }
+  return hashes;
+}
+
+let indexScriptHashes = null;
+function spaScriptElemHashes() {
+  if (indexScriptHashes) return indexScriptHashes;
+  if (!indexHtml) {
+    try { indexHtml = fs.readFileSync(indexPath, 'utf8'); } catch { return []; }
+  }
+  indexScriptHashes = computeInlineScriptHashes(indexHtml);
+  return indexScriptHashes;
+}
+
+// Paths whose HTML this proxy does not render itself; they keep the blanket
+// CSP2 script-src (see the comment above).
+const UPSTREAM_DOC_PATHS = ['/contribute', '/leaderboard', '/snapshot', '/terminal'];
+function isUpstreamDocPath(p) {
+  return UPSTREAM_DOC_PATHS.some((base) => p === base || p.startsWith(`${base}/`));
+}
+
 app.use(async (req, res, next) => {
   const frameAllowlist = req.path === '/snapshot' ? await snapshotFrameAncestors() : [];
   const snapshotFramingAllowed = frameAllowlist.length > 0;
   const frameAncestors = snapshotFramingAllowed ? frameAllowlist.join(' ') : "'none'";
+  const scriptDirectives = isUpstreamDocPath(req.path)
+    ? ["script-src 'self' 'unsafe-inline' https://cdn.redoc.ly"]
+    : [
+        "script-src 'self' 'unsafe-inline' https://cdn.redoc.ly",
+        `script-src-elem ${["'self'", 'https://cdn.redoc.ly', ...spaScriptElemHashes()].join(' ')}`,
+        "script-src-attr 'unsafe-inline'",
+      ];
   res.setHeader('Content-Security-Policy', [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://cdn.redoc.ly",
+    ...scriptDirectives,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "worker-src blob:",
     "img-src 'self' data: https:",


### PR DESCRIPTION
## What

Closes the **inline `<script>` element half** of the `script-src 'unsafe-inline'` residual (#3315's remaining half, tracked by #3848 part 1 and re-filed as #3907), on both CSP emitters — the Go spoke server and the Node proxy — using the exact decomposition #3933/ADR-0015 established for `style-src`:

```text
script-src      'self' 'unsafe-inline'   ← CSP2 fallback, UNCHANGED and hash-free
script-src-elem 'self' 'sha256-…' …      ← inline <script> elements: CLOSED
script-src-attr 'unsafe-inline'          ← on*= handler attributes: STAGED (#3848)
```

`Fixes #3907`. **#3848 stays open** — see "What this does NOT close" below.

In every CSP3 browser, an injected inline `<script>` now matches no hash and does not execute. No browser loses a working dashboard: pre-CSP3 browsers see only the unchanged fallback, and the handler attributes stay permitted via `script-src-attr` until the event-delegation refactor.

## Dedupe

#3907 (sec-check, 2026-08) is a duplicate of **#3848 part 1** (the operator-authored staging tracker from the #3315 verification sweep). This PR `Fixes` #3907 because what it requested — "migrate to per-route nonces or hashes for existing inline scripts" — is exactly what lands here for every inline script both emitters serve. #3848 remains the canonical tracker for the un-closable-today remainder (handler delegation); a status comment goes there.

## Hashes, not nonces — the design decision

#3907 suggested nonces. #3933 already flagged the collision: since #3863 the SPA document is **pre-gzipped once at startup with a strong ETag**, and a per-response nonce would force a re-render + re-compress per request and kill the 304 path — undoing a measured 4× transfer win. A sha256 hash is a pure function of the bytes already being served, so:

- **byte-stable documents** (embedded SPA, device-flow login page) → allowlist computed **once at startup** (`baseScriptSrcElem`), #3863 design untouched — `TestEmbeddedIndexScriptsSatisfyCSPHashes` pins gzip + ETag + 304 alongside the hashes;
- **per-response documents** (`/contribute`, whose `hubURL` comes from the Host header; `/snapshot`, built at runtime) → the handler renders to a buffer and stamps hashes from the exact bytes served (`applyDocumentScriptSrcElem`).

## Inline-script inventory (every site, and how each gets its allowance)

Go spoke emitter (`src/pkg/dashboard/server.go` `securityHeaders`):

| # | Document | Inline scripts | Allowance |
|---|---|---|---|
| 1–2 | `static/index.html` (SPA; also the file the proxy serves) | 2 | startup hash set, from the embedded bytes |
| 3 | device-flow login page (`server.go` `loginPage` const) | 1 | startup hash set |
| 4–7 | `/contribute` landing (`api_contribute.go`: onboarding IIFE, init-order IIFE, ops IIFE, activity-poll + version-fetch blocks) | 4 | per-response hashes (buffer render) |
| 8 | `/contribute?style=` custom-style one-liner (conditional) | 0–1 | per-response hashes (same buffer) |
| 9 | `/snapshot` document (`build-snapshot.mjs` output, mutated at serve time) | ≥1 | per-response hashes over the final bytes |
| — | `ssoErrorPage`, API-docs page (`api_contribute.go:7867`), snapshot "not published" page | 0 | nothing to hash |
| — | `/terminal` (ttyd's own UI, reverse-proxied byte stream) | unknowable here | **excluded**: keeps the blanket CSP2 policy — hashing a document this server never holds would brick the terminal |

Node proxy emitter (`src/proxy/server.js`):

| Document | Inline scripts | Allowance |
|---|---|---|
| `STATIC_DIR/index.html` (SPA copy, `serveIndex` + deep links) | 2 | hashes computed lazily from the served file |
| `/api-docs` (Redoc) | 0 (external, SRI-pinned) | `https://cdn.redoc.ly` stays in `script-src-elem` |
| proxied `/contribute`, `/leaderboard`, `/snapshot` | rendered by Go | proxy sends the blanket policy; the Go upstream's per-document CSP reaches the client verbatim — **verified empirically** in the new proxy test, not assumed |
| `/terminal` (ttyd) | — | excluded, blanket policy |

Out of scope, stated: the hub SaaS SPA (`src/pkg/hub/saas.go`, 155 `on*=` attributes + 4 inline script sites incl. GA4) serves **no CSP header at all** today — it is outside both emitters and recorded in ADR-0016's residual-risk section. `src/pkg/snapshot/builder.go`'s page is written by the agent CLI to local disk, not served under either emitter.

## What this does NOT close (the honest part)

`script-src-attr 'unsafe-inline'` stays: the SPA wires **426 inline `on*=` attributes** (plus ~145 more built as strings through 169 `innerHTML` sites), and CSP has no nonce and no elem-hash form for handler attributes. Until the #3848 event-delegation refactor, **injected `on*=` attributes (e.g. `<img src=x onerror=…>`) still execute** — ADR-0016 says so in plain words. The CSP2 fallback also deliberately keeps `'unsafe-inline'` **and must stay hash-free**: per CSP2, a hash source suppresses `'unsafe-inline'` in the same directive, so hashes in the fallback would blank every handler on hash-aware pre-CSP3 browsers (Firefox < 108). That trap is pinned by tests on both emitters.

Per #3848's instruction, the old tripwire is **inverted, not relaxed**, scoped to the half that landed: `TestCSPScriptSrcElemUnsafeInlineIsClosed` pins the closed element half; `TestCSPScriptSrcAttrUnsafeInlineIsStaged` is the re-armed tripwire for the staged half. `style-src-elem` stays staged per ADR-0015's sequencing (its precondition — inline script fully closed — is still not met while `script-src-attr` is open).

## Headless verification (real browser, exact served header + bytes)

Served the SPA, `/contribute`, and the login page with their exact rendered CSP headers to headless Chromium:

- zero CSP violations from the pages' own scripts; all executed (`window.hiveURLWithHash` defined; contribute's prompt textarea filled, activity feed polled, `window.ccProjectName` set; login's `startFlow` defined);
- **negative control**: a DOM-injected inline `<script>` was refused on every page (console shows the `script-src-elem` violation) — the exact attack this issue is about, demonstrably closed;
- inline `onclick` handlers still fire (`script-src-attr` half intact).

## Tests

Go — `csp_script_src_test.go` (10): `TestCSPScriptSrcScopedIntoElemAndAttr` (incl. the hash-free-fallback invariant), `TestCSPScriptSrcElemUnsafeInlineIsClosed` (count floor ≥ 3), `TestCSPScriptSrcAttrUnsafeInlineIsStaged` (tripwire), `TestEmbeddedIndexScriptsSatisfyCSPHashes` (hash coverage + #3863 gzip/ETag/304 invariants + CSP-on-304), `TestLoginPageScriptSatisfiesCSPHashes`, `TestContributePageScriptsSatisfyPerResponseCSP` (two Hosts; proves per-response), `TestApplyDocumentScriptSrcElem`, `TestDynamicHTMLHandlersStampDocumentCSP` (gate asserted in source — covers the `/snapshot` lane a unit test can't reach), `TestTerminalPathKeepsBlanketScriptSrc`, `TestServedDocumentsHaveNoScriptInHTMLComments` (pins the tokenizer/extraction agreement precondition), plus `TestCSPScriptSrcRationaleIsWritten` (ADR-0016 exists + indexed).

Node — `csp_script_src_elem.test.js` (spawned proxy): SPA hash-allowlisted & served intact, elem closed, attr staged, fallback literal & hash-free (source guard too), exact-inline-count hash check (external `src=` never hashed), deep links identical, `/api-docs` functional, and upstream-CSP-wins proven end-to-end. Existing `csp_token_injection.test.js` updated only in its staged-state comment.

### Regression replay

| # | Neutered | Caught by |
|---|---|---|
| 1 | `'unsafe-inline'` restored to `script-src-elem` | `TestCSPScriptSrcElemUnsafeInlineIsClosed` |
| 2 | `/contribute` stops stamping per-response hashes | `TestContributePageScriptsSatisfyPerResponseCSP` + `TestDynamicHTMLHandlersStampDocumentCSP` |
| 3 | hashes merged into the `script-src` fallback | `TestCSPScriptSrcScopedIntoElemAndAttr` |

Each confirmed failing, then restored green. Full `pkg/dashboard` suite passes; full proxy suite (`npm test`, all 8 files) passes.
