### PR TITLE
docs: reconcile troubleshooting into hive canonical (verified superset for single-source sync)

### DIFF
--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -1,6 +1,8 @@
 # Hive troubleshooting
 
-This guide covers the current containerized Go service (branch `v4`; code under the `src/` directory). The older `docs/troubleshooting.md` page is for the legacy v1 systemd supervisor.
+This guide covers the current containerized Go service (branch `v4`; code under the `src/` directory). Hive runs as an in-process supervisor: the governor loop, health checks, login detection, and notifications all run inside the `hive` process — there is no separate systemd supervisor, `bin/supervisor.sh` loop, `hive-healthcheck.service` timer, or `/etc/hive/agent.env` file. Those, along with `AGENT_LOOP_PROMPT`, `AGENT_READY_MARKER`, `AGENT_AUTO_APPROVE_PHRASE`, and `install.sh`/`uninstall.sh`, belong to the legacy v1 host install and do not apply here.
+
+Start most investigations from the dashboard and the service logs, then drop to the sections below for a specific failure mode.
 
 ## Find the running service logs
 
@@ -20,6 +22,8 @@ kubectl -n hive get deploy,pod,svc,pvc
 kubectl -n hive logs deploy/hive --tail=200
 kubectl -n hive describe pod -l app.kubernetes.io/name=hive
 ```
+
+The process also writes `hive.log` under the configured logs directory (default `/data/logs`, from `governor.logging.dir`, falling back to `data.logs_dir`), and tees the same lines to stdout — so `docker compose logs` / `kubectl logs` show everything the file does. The older per-agent `AGENT_LOG_FILE` heartbeat file from v1 is not used.
 
 ## Config fails to load or save
 
@@ -46,7 +50,9 @@ Check the configured `github:` block, the `HIVE_GITHUB_TOKEN` secret/env var, or
 
 ## Agents are stuck, paused, or need CLI login
 
-Agents still run in tmux sessions managed by the v2 agent manager, but there is no v1 `AGENT_READY_MARKER` or `bin/supervisor.sh` loop. The v2 login detector scans recent tmux pane output for configured regexes and, on a match, logs `login required detected`, pauses the agent, and sends a notification that says to attach to `hive-<agent>` and run the backend login command.
+Agents run in tmux sessions named `hive-<agent>` managed by the v2 agent manager. There is no v1 `AGENT_READY_MARKER` or `bin/supervisor.sh` loop: the manager drives each agent by delivering a *kick* (its next work prompt) directly into the session and, once running, auto-dismisses the CLI's own startup consent screens.
+
+The login detector (`scanForLoginRequired` in `src/cmd/hive/main.go`) scans recent tmux pane output for the regexes in `governor.sensing.login_patterns`. On a match it logs `login required detected`, pauses the agent, and sends a high-priority notification telling you to attach to `hive-<agent>` and run that backend's login command.
 
 Useful checks from inside the Hive container/pod:
 
@@ -56,7 +62,68 @@ tmux capture-pane -t hive-scanner -p -S -80
 tmux attach -t hive-scanner
 ```
 
-Detach from tmux with `Ctrl+B`, then `D`. If the dashboard shows an agent as paused, resume it from the dashboard/API after completing the CLI login (`claude login`, `copilot auth login`, `gemini auth login`, or the backend-specific command shown in the notification).
+Detach from tmux with `Ctrl+B`, then `D` — the session keeps running.
+
+To recover a paused agent:
+
+1. Complete the CLI login for that backend outside the pause. Attach to the session (`tmux attach -t hive-<agent>`) and run the login command shown in the notification: `claude login`, `copilot auth login`, `gemini auth login`, or the backend-specific command. The picker expects an interactive OAuth/browser flow, so complete it from a terminal you control rather than leaving the unattended session blocked on it.
+2. Resume the agent from the dashboard, or `POST /api/resume/{agent}`.
+
+If an agent returns to "needs login" immediately after resuming, the credentials themselves are the problem (expired token, revoked API key, or an account-level sign-out). Re-authenticate that backend's CLI as the agent user, then resume again so the fresh session is picked up.
+
+## A permission prompt seems to block an agent
+
+On the containerized runtime you normally do **not** need to configure an auto-approve phrase. Claude Code agents launch with `--dangerously-skip-permissions` (`src/pkg/agent/manager.go`), and the manager's `dismissInferencePrompts` routine polls the pane and auto-dismisses the startup consent screens (the "Bypass Permissions mode" dialog, the custom-API-key prompt, and generic "Enter to confirm" menus) dynamically, without a hardcoded phrase list.
+
+If an agent still looks wedged on a prompt, capture the pane (`tmux capture-pane -t hive-<agent> -p -S -80`) and check the `hive` logs. A prompt whose selected default is negative (for example "No, exit") is navigated away from before Enter is sent; a genuinely novel prompt that the routine does not recognize is the case to report, along with the captured pane text.
+
+## Notifications (ntfy / Slack / Discord) never arrive
+
+Notifications are sent in-process by the notifier (`src/pkg/notify/notify.go`), configured under the top-level `notifications:` block in `hive.yaml`, not by a systemd healthcheck timer:
+
+```yaml
+notifications:
+  ntfy:
+    server: https://ntfy.sh
+    topic: my-hive-alerts
+```
+
+The Docker Compose `NTFY_SERVER` / `NTFY_TOPIC` environment variables are just passthrough for this block and, when set, override the YAML values. Fields are `notifications.ntfy.server` and `notifications.ntfy.topic` (both required); Slack and Discord use `notifications.slack.webhook` and `notifications.discord.webhook`. See [Notifications](notifications.md) for the full schema.
+
+To debug:
+
+```bash
+# 1. Does the outbound path work at all? (posting to the same topic Hive uses)
+curl -d "test" "https://ntfy.sh/my-hive-alerts"
+
+# 2. Is the block actually loaded? Grep the running config / logs.
+kubectl -n hive logs deploy/hive | grep -i notif
+```
+
+A blank or misspelled `topic` is the most common cause of "posted but nothing arrives." Note that a notification only fires on an actual event — budget warning/exhausted, an SLA breach, a login-required detection, or a fix-loop escalation — so silence when nothing is wrong is expected. There is no periodic "log went stale" ping in v4.
+
+## An agent writes a heartbeat but its work is obviously broken
+
+Liveness is judged by the governor's in-process health check, so an agent that keeps its session alive but silently no-ops its actual work can still look healthy. Two defensive habits:
+
+1. **Read the work counts, not just liveness.** If an agent reports "Issues triaged: 0" cycle after cycle in the logs, that is the signal — `kubectl -n hive logs deploy/hive | grep <agent>` or attach to the session.
+2. **Cross-check an external surface.** Confirm the effect the agent is supposed to produce (a GitHub API query for the PRs/issues it claims to have handled) rather than trusting its self-reported state.
+
+## Switching an agent's model
+
+Model selection is a per-agent config field (`agent.<name>.model`), applied at **launch time** as the CLI's `--model` flag (`src/pkg/agent/manager.go`). There is no live in-session `/model` slash command sent over tmux; changing the model means changing the config and relaunching the agent. Do this through the supported paths, which handle the restart for you:
+
+```bash
+# CLI
+hivectl agent model-set <agent> <model>
+```
+
+Or from the dashboard (which calls `POST /api/model/{agent}/{model}`). Both persist the new value, mark it operator-owned, and restart the agent session so the new `--model` takes effect (`handleModelSet` in `src/pkg/dashboard/api.go`).
+
+Two gotchas:
+
+- **Slug spelling is backend-specific.** The Claude CLI expects hyphens (`claude-opus-4-8`); Copilot uses dots (`claude-opus-4.8`). A mis-normalized slug is rejected by that backend. The dashboard offers candidate ids from live `/v1/models` discovery, with a static fallback list in `src/pkg/dashboard/cli_models.go`.
+- **A change that is not operator-owned reverts on restart.** If the model appears to "come back" to the pack default, it was set through a path that did not mark it operator-owned. The `hivectl` and dashboard routes above set operator ownership precisely to prevent that reconciliation.
 
 ## Dashboard auth and access problems
 
@@ -74,3 +141,20 @@ curl -fsS http://127.0.0.1:3002/api/livez
 ```
 
 `/api/livez` is deliberately process-focused: the Kubernetes manifest notes that stale hub heartbeat state belongs in deeper health reporting and should not crash-loop a healthy pod.
+
+## Clean reset
+
+There is no `uninstall.sh`/`install.sh` on the containerized runtime. To start from a clean state, remove the process and its `/data` state, then bring it back:
+
+```bash
+# Docker Compose (deletes the named /data volume — see Backup & restore first)
+docker compose down -v
+docker compose up -d
+
+# Kubernetes (deletes the PVC-backed state)
+kubectl -n hive delete deploy/hive
+kubectl -n hive delete pvc -l app.kubernetes.io/name=hive
+# then re-apply the manifests
+```
+
+`/data` holds the dashboard config overlay, persisted tokens, logs, and other state; deleting it discards dashboard edits and cached credentials. Back up first if you need any of it — see [Backup & restore](backup-restore.md).


### PR DESCRIPTION
## Summary

Makes `src/docs/troubleshooting.md` the verified single source for the hive troubleshooting page. The docs-site copy (in kubestellar/docs) had drifted ahead and blocked auto-sync; this reconciles its unique content **into** the hive canonical so hive becomes the superset and the two can converge.

## What changed

Ported the genuinely useful failure modes from the docs-repo copy, folded into the existing v4-organized structure (grouped by subsystem, no duplicated or contradictory entries):

- **Stuck/paused/needs-login agents** — expanded with the correct v4 recovery: complete CLI login outside the pause, then resume via dashboard / `POST /api/resume/{agent}` (not a v1 `systemctl` restart).
- **Permission prompts** — documents v4's automatic `dismissInferencePrompts` behavior instead of the legacy `AGENT_AUTO_APPROVE_PHRASE`.
- **Notifications (ntfy/Slack/Discord) never arrive** — correct `notifications:` config block and in-process trigger model.
- **Heartbeat fresh but work broken** — adapted the observability guidance to the v4 governor health check.
- **Switching an agent's model** — corrected to the v4 config-then-restart flow (`hivectl agent model-set` / `POST /api/model/{agent}/{model}`).
- **Clean reset** — `docker compose down -v` / delete deploy+PVC, replacing the legacy `install.sh`/`uninstall.sh`.

## Claims corrected vs the docs-repo copy (all stale v1 content)

- **Model switching is NOT done via `tmux send-keys '/model <slug>'`** — v4 applies `--model` at launch and restarts the agent; there is no live in-session `/model`. The stale model table (Opus 4.7 "Default", picker mechanics) was dropped.
- Dropped `AGENT_LOOP_PROMPT` / `AGENT_READY_MARKER` / `bin/supervisor.sh` / `systemctl stop/start hive` — none exist in v4 (governor kick loop replaces them).
- Dropped `hive-healthcheck.service` + `agent-healthcheck.sh` + `$AGENT_LOG_FILE` — health is in-process; logs are `/data/logs/hive.log` tee'd to stdout.
- Corrected ntfy config from bare `NTFY_SERVER`/`NTFY_TOPIC` env vars to the `notifications.ntfy.{server,topic}` block.
- Dropped `install.sh`/`uninstall.sh` clean-reinstall — replaced with container/K8s reset.
- Omitted the docs-repo "CI check rules for merging PRs" section — that is agent merge policy, not a runtime troubleshooting failure mode.

Every added command/path/config key was verified against v4 source under `src/` before porting.

## Reconcilable verdict

**Reconcilable, but the two docs were mostly NOT complementary** — the docs-repo copy was predominantly legacy v1 mechanism (systemd/supervisor/env-file) that v4 replaced, not distinct v4 failure modes. Only the *symptoms* transferred; the mechanisms were rewritten for v4. Result is a coherent superset with no v1 residue.
