### PR TITLE
✨ feat(hooks): adopt state-triggered hooks as a first-class extension point (#4001)

### DIFF
--- a/src/docs/hooks.md
+++ b/src/docs/hooks.md
@@ -1,0 +1,126 @@
+# State-Triggered Hooks
+
+Hive provides a declarative, state-triggered **Hooks** extension point (`pkg/hooks`). Hooks allow operators to attach custom actions (notifications, scripts, pacing adjustments, audit records) to well-defined lifecycle and governor state transitions without modifying core engine code.
+
+---
+
+## 1. Overview
+
+Today, Hive emits rich events across agent lifecycles, governor evaluation loops, and PR sweeps. State-triggered hooks provide a single, auditable, and testable mechanism to define **"what happens when X occurs"**.
+
+Key characteristics:
+- **Opt-in & Safe by Default**: Hooks are disabled unless explicitly configured (`hooks.enabled: true`).
+- **Secret-Scrubbed**: Script and command outputs are automatically filtered through `logscrub` before being logged or surfaced.
+- **Durable Audit Trail**: Every hook trigger and action result is recorded in the Audit Log under action `hook_fired`.
+- **Side-Effect Bounded**: External scripts run with strict context timeouts to prevent blocking governor cycles or agent turns.
+
+---
+
+## 2. Named State Transitions
+
+The following named transitions can be targeted by hook rules:
+
+| Transition Name | Trigger Condition |
+| :--- | :--- |
+| `on_agent_started` | An agent session/process successfully starts or relaunches |
+| `on_agent_stopped` | An agent session is stopped |
+| `on_agent_paused` | An agent is paused by operator, circuit breaker, trajectory drift, or tool approval gate |
+| `on_agent_resumed` | An agent is resumed from a paused state |
+| `on_agent_failed` | An agent process crashes or fails launch validation |
+| `on_agent_kicked` | An agent receives an execution prompt / task |
+| `on_acmm_change` | The active ACMM maturity level changes (e.g. L3 → L4) |
+| `on_sweep_merge` | A pull request is merged by the auto-merge sweep |
+| `on_stall_detected` | The governor watchdog detects an inactive/stalled agent |
+| `on_pr_opened` | An agent opens a pull request |
+| `on_issue_opened` | An agent creates an issue |
+| `on_turn_start` | An agent initiates a re-entrant turn |
+| `on_turn_complete` | An agent completes a re-entrant turn |
+| `on_tool_approval_required` | A side-effectful tool halts pending operator approval (#4000) |
+| `on_agent_*` | Wildcard prefix matching all agent lifecycle transitions |
+| `*` | Catch-all matching all state transitions |
+
+---
+
+## 3. Configuration & Syntax
+
+Hooks are declared under the `hooks:` block in `hive.yaml`:
+
+```yaml
+hooks:
+  enabled: true
+  rules:
+    # Send a notification when any agent is paused
+    - name: notify-on-agent-pause
+      on: on_agent_paused
+      action: notify
+      notify:
+        title: "Agent Paused: {{.Agent}}"
+        message: "Agent {{.Agent}} paused at ACMM L{{.ACMMLevel}} because {{.Reason}} (trigger: {{.Trigger}})"
+        webhook_url: "https://discord.com/api/webhooks/..."
+
+    # Run a cleanup or deployment script after a PR is auto-merged
+    - name: post-merge-sync
+      on: on_sweep_merge
+      action: script
+      script:
+        command: "./scripts/on-merge.sh"
+        args: ["{{.Metadata.repo}}", "{{.Metadata.pr_number}}"]
+        timeout_s: 30
+
+    # Backoff agent pacing if a stall is detected
+    - name: throttle-on-stall
+      on: on_stall_detected
+      action: pacing
+      pacing:
+        multiplier: 2.0
+        cadence: "slow"
+
+    # Explicit audit entry on ACMM level promotion/demotion
+    - name: audit-acmm-transition
+      on: on_acmm_change
+      action: audit
+      audit:
+        message: "ACMM maturity level transitioned to L{{.ACMMLevel}} (reason: {{.Reason}})"
+```
+
+---
+
+## 4. Supported Actions
+
+### 1. `notify`
+Dispatches formatted notifications to Discord webhooks, Slack channels, or the built-in notification hub.
+- `title`: Notification title (supports Go templating).
+- `message`: Notification body (supports Go templating).
+- `channel`: Target channel identifier (optional).
+- `webhook_url`: Dedicated webhook URL (optional, falls back to default alert sink).
+
+### 2. `script`
+Executes a localized shell script or binary command in an isolated child process.
+- `command`: Command or executable path.
+- `args`: Arguments list (supports Go templating).
+- `timeout_s`: Max execution time in seconds (defaults to 30s).
+- *Output*: Standard output and error are captured, passed through `logscrub` to scrub any credential tokens, and saved in the audit log.
+
+### 3. `pacing`
+Directly adjusts governor evaluation cadences and agent dispatch intervals.
+- `agent`: Target agent name (defaults to triggering agent).
+- `multiplier`: Cadence scaling factor (e.g. `2.0` doubles the wait duration).
+- `cadence`: Named cadence override (`fast`, `normal`, `slow`).
+
+### 4. `audit`
+Emits an explicit, searchable record to Hive's durable Audit Log without external side effects.
+- `message`: Audit log detail text.
+
+---
+
+## 5. Event Context & Templating
+
+Hook fields support standard Go text templating (`{{.Field}}`). The following context variables are available:
+
+- `{{.Transition}}`: Name of the transition event (e.g. `on_agent_paused`).
+- `{{.Agent}}`: Responsible agent name (e.g. `architect`, `quality`).
+- `{{.ACMMLevel}}`: Current ACMM maturity level (integer `1`–`6`).
+- `{{.Reason}}`: Explanatory reason string.
+- `{{.Trigger}}`: Originator of the event (`operator`, `governor`, `trajectory-review`, `breaker`).
+- `{{.Metadata.<key>}}`: Custom dictionary fields (e.g. `{{.Metadata.repo}}`, `{{.Metadata.pr_number}}`).
+- `{{.Timestamp}}`: UTC timestamp of the event.

--- a/src/pkg/agent/audit.go
+++ b/src/pkg/agent/audit.go
@@ -20,6 +20,7 @@ const (
 	AuditAgentRemoved     = "agent_removed"
 	AuditAgentBackendSet  = "agent_backend_changed"
 	AuditAgentModelSet    = "agent_model_changed"
+	AuditHookFired        = "hook_fired"
 )
 
 // auditActorSystem attributes an event to the hive process itself rather than

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -63,6 +63,8 @@ type Config struct {
 	Retro      RetroConfig      `yaml:"retro,omitempty" json:"retro,omitempty"`
 	Review     ReviewConfig     `yaml:"review,omitempty" json:"review,omitempty"`
 	AutoMerge  AutoMergeConfig  `yaml:"auto_merge,omitempty" json:"auto_merge,omitempty"`
+	// Hooks configures state-triggered lifecycle, governor, and sweep hooks.
+	Hooks HooksConfig `yaml:"hooks,omitempty" json:"hooks,omitempty"`
 	// AgentSandbox configures the phase-1 credential-free sandbox runner. It is
 	// disabled by default and agents must opt in individually.
 	AgentSandbox AgentSandboxConfig `yaml:"agent_sandbox,omitempty" json:"agent_sandbox,omitempty"`

--- a/src/pkg/config/hooks.go
+++ b/src/pkg/config/hooks.go
@@ -1,0 +1,52 @@
+package config
+
+// HooksConfig configures state-triggered lifecycle, governor, and sweep hooks.
+type HooksConfig struct {
+	// Enabled turns declarative hook dispatch on. Default false (opt-in).
+	Enabled bool       `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Rules   []HookRule `yaml:"rules,omitempty" json:"rules,omitempty"`
+}
+
+// IsEnabled reports whether declarative hooks are enabled.
+func (h HooksConfig) IsEnabled() bool {
+	return h.Enabled
+}
+
+// HookRule is a single declarative hook mapping a transition event to an action.
+type HookRule struct {
+	Name   string      `yaml:"name,omitempty" json:"name,omitempty"`
+	On     string      `yaml:"on" json:"on"`         // e.g. on_agent_paused, on_sweep_merge, on_acmm_change
+	Action string      `yaml:"action" json:"action"` // notify | script | pacing | audit
+	Notify *HookNotify `yaml:"notify,omitempty" json:"notify,omitempty"`
+	Script *HookScript `yaml:"script,omitempty" json:"script,omitempty"`
+	Pacing *HookPacing `yaml:"pacing,omitempty" json:"pacing,omitempty"`
+	Audit  *HookAudit  `yaml:"audit,omitempty" json:"audit,omitempty"`
+}
+
+// HookNotify configures a notification action when a hook fires.
+type HookNotify struct {
+	Title      string `yaml:"title,omitempty" json:"title,omitempty"`
+	Message    string `yaml:"message,omitempty" json:"message,omitempty"`
+	Channel    string `yaml:"channel,omitempty" json:"channel,omitempty"`
+	WebhookURL string `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+}
+
+// HookScript configures an external script / command execution action.
+type HookScript struct {
+	Command  string   `yaml:"command" json:"command"`
+	Args     []string `yaml:"args,omitempty" json:"args,omitempty"`
+	TimeoutS int      `yaml:"timeout_s,omitempty" json:"timeout_s,omitempty"`
+}
+
+// HookPacing configures an agent cadence / pacing adjustment action.
+type HookPacing struct {
+	Agent      string  `yaml:"agent,omitempty" json:"agent,omitempty"`
+	Multiplier float64 `yaml:"multiplier,omitempty" json:"multiplier,omitempty"`
+	Cadence    string  `yaml:"cadence,omitempty" json:"cadence,omitempty"`
+}
+
+// HookAudit configures an explicit audit log entry action.
+type HookAudit struct {
+	Message string `yaml:"message" json:"message"`
+	Level   string `yaml:"level,omitempty" json:"level,omitempty"`
+}

--- a/src/pkg/hooks/dispatcher.go
+++ b/src/pkg/hooks/dispatcher.go
@@ -1,0 +1,259 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/logscrub"
+)
+
+// Notifier defines the interface for sending external notifications.
+type Notifier interface {
+	Notify(ctx context.Context, title, message, channel, webhookURL string) error
+}
+
+// ScriptRunner defines the interface for executing script actions.
+type ScriptRunner interface {
+	Run(ctx context.Context, command string, args []string, timeout time.Duration) (string, error)
+}
+
+// PacingAdjuster defines the interface for adjusting governor cadences.
+type PacingAdjuster interface {
+	AdjustPacing(ctx context.Context, agent string, multiplier float64, cadence string) error
+}
+
+// DefaultScriptRunner executes shell commands with process isolation, timeout, and secret scrubbing.
+type DefaultScriptRunner struct{}
+
+func (d *DefaultScriptRunner) Run(ctx context.Context, command string, args []string, timeout time.Duration) (string, error) {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	ctxTimeout, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctxTimeout, "sh", "-c", command)
+	if len(args) > 0 {
+		cmd.Args = append(cmd.Args, args...)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := stdout.String()
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += stderr.String()
+	}
+
+	// Secret scrub the raw output before returning
+	scrubbed := logscrub.ScrubString(output)
+	return strings.TrimSpace(scrubbed), err
+}
+
+// Dispatcher executes matched hook actions for state transition events.
+type Dispatcher struct {
+	enabled   bool
+	registry  *Registry
+	notifier  Notifier
+	scriptRun ScriptRunner
+	pacingAdj PacingAdjuster
+	auditSink agent.AuditSink
+}
+
+// Option configures a Dispatcher.
+type Option func(*Dispatcher)
+
+// WithNotifier installs a custom notification sink.
+func WithNotifier(n Notifier) Option {
+	return func(d *Dispatcher) { d.notifier = n }
+}
+
+// WithScriptRunner installs a custom script execution engine.
+func WithScriptRunner(s ScriptRunner) Option {
+	return func(d *Dispatcher) { d.scriptRun = s }
+}
+
+// WithPacingAdjuster installs a custom pacing handler.
+func WithPacingAdjuster(p PacingAdjuster) Option {
+	return func(d *Dispatcher) { d.pacingAdj = p }
+}
+
+// WithAuditSink installs the durable audit sink for hook execution records.
+func WithAuditSink(sink agent.AuditSink) Option {
+	return func(d *Dispatcher) { d.auditSink = sink }
+}
+
+// NewDispatcher creates a new Dispatcher from a HooksConfig.
+func NewDispatcher(cfg config.HooksConfig, opts ...Option) (*Dispatcher, error) {
+	reg, err := NewRegistryFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	d := &Dispatcher{
+		enabled:   cfg.Enabled,
+		registry:  reg,
+		scriptRun: &DefaultScriptRunner{},
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d, nil
+}
+
+// SetEnabled dynamically enables or disables hook execution.
+func (d *Dispatcher) SetEnabled(enabled bool) {
+	d.enabled = enabled
+}
+
+// IsEnabled reports whether hooks are currently active.
+func (d *Dispatcher) IsEnabled() bool {
+	return d.enabled
+}
+
+// Registry returns the underlying hook rule registry.
+func (d *Dispatcher) Registry() *Registry {
+	return d.registry
+}
+
+// Dispatch evaluates matching hook rules for the event and executes their configured actions.
+func (d *Dispatcher) Dispatch(ctx context.Context, event Event) ([]Result, error) {
+	if !d.enabled || d.registry == nil {
+		return nil, nil
+	}
+
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+
+	rules := d.registry.Match(event)
+	if len(rules) == 0 {
+		return nil, nil
+	}
+
+	results := make([]Result, 0, len(rules))
+	for _, rule := range rules {
+		start := time.Now()
+		res := Result{
+			RuleName: rule.Name,
+			On:       rule.On,
+			Action:   rule.Action,
+		}
+
+		var execErr error
+		switch rule.Action {
+		case "notify":
+			execErr = d.execNotify(ctx, event, rule, &res)
+		case "script":
+			execErr = d.execScript(ctx, event, rule, &res)
+		case "pacing":
+			execErr = d.execPacing(ctx, event, rule, &res)
+		case "audit":
+			execErr = d.execAudit(ctx, event, rule, &res)
+		default:
+			execErr = fmt.Errorf("unknown action %q", rule.Action)
+		}
+
+		res.Duration = time.Since(start)
+		if execErr != nil {
+			res.Success = false
+			res.Error = execErr.Error()
+		} else {
+			res.Success = true
+		}
+
+		// Emit result to durable audit log
+		if d.auditSink != nil {
+			actor := "system"
+			d.auditSink.Record(actor, agent.AuditHookFired, event.Agent, res.AuditFields(event))
+		}
+
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+func (d *Dispatcher) execNotify(ctx context.Context, event Event, rule config.HookRule, res *Result) error {
+	if rule.Notify == nil {
+		return fmt.Errorf("hook rule %q specifies notify action but has no notify configuration", rule.Name)
+	}
+
+	title, _ := RenderTemplate(rule.Notify.Title, event)
+	msg, _ := RenderTemplate(rule.Notify.Message, event)
+	if title == "" {
+		title = fmt.Sprintf("Hook triggered: %s", event.Transition)
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("Event on %s for agent %s (reason: %s)", event.Transition, event.Agent, event.Reason)
+	}
+
+	res.Output = fmt.Sprintf("title: %s; message: %s", title, msg)
+
+	if d.notifier != nil {
+		return d.notifier.Notify(ctx, title, msg, rule.Notify.Channel, rule.Notify.WebhookURL)
+	}
+	return nil
+}
+
+func (d *Dispatcher) execScript(ctx context.Context, event Event, rule config.HookRule, res *Result) error {
+	if rule.Script == nil || rule.Script.Command == "" {
+		return fmt.Errorf("hook rule %q specifies script action but has no command", rule.Name)
+	}
+
+	cmdStr, _ := RenderTemplate(rule.Script.Command, event)
+	var args []string
+	for _, arg := range rule.Script.Args {
+		rendered, _ := RenderTemplate(arg, event)
+		args = append(args, rendered)
+	}
+
+	timeout := time.Duration(rule.Script.TimeoutS) * time.Second
+	if d.scriptRun == nil {
+		d.scriptRun = &DefaultScriptRunner{}
+	}
+
+	output, err := d.scriptRun.Run(ctx, cmdStr, args, timeout)
+	res.Output = output
+	return err
+}
+
+func (d *Dispatcher) execPacing(ctx context.Context, event Event, rule config.HookRule, res *Result) error {
+	if rule.Pacing == nil {
+		return fmt.Errorf("hook rule %q specifies pacing action but has no pacing configuration", rule.Name)
+	}
+
+	agentName := rule.Pacing.Agent
+	if agentName == "" {
+		agentName = event.Agent
+	}
+	res.Output = fmt.Sprintf("adjusted pacing for agent %s: mult=%.2f cadence=%s", agentName, rule.Pacing.Multiplier, rule.Pacing.Cadence)
+
+	if d.pacingAdj != nil {
+		return d.pacingAdj.AdjustPacing(ctx, agentName, rule.Pacing.Multiplier, rule.Pacing.Cadence)
+	}
+	return nil
+}
+
+func (d *Dispatcher) execAudit(ctx context.Context, event Event, rule config.HookRule, res *Result) error {
+	msg := ""
+	if rule.Audit != nil {
+		msg, _ = RenderTemplate(rule.Audit.Message, event)
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("Hook audit: transition=%s agent=%s reason=%s", event.Transition, event.Agent, event.Reason)
+	}
+	res.Output = msg
+	return nil
+}

--- a/src/pkg/hooks/hooks_test.go
+++ b/src/pkg/hooks/hooks_test.go
@@ -1,0 +1,322 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+type mockNotifier struct {
+	sent []mockNotif
+}
+
+type mockNotif struct {
+	title      string
+	message    string
+	channel    string
+	webhookURL string
+}
+
+func (m *mockNotifier) Notify(ctx context.Context, title, message, channel, webhookURL string) error {
+	m.sent = append(m.sent, mockNotif{
+		title:      title,
+		message:    message,
+		channel:    channel,
+		webhookURL: webhookURL,
+	})
+	return nil
+}
+
+type mockScriptRunner struct {
+	runs []mockScriptRun
+	out  string
+	err  error
+}
+
+type mockScriptRun struct {
+	command string
+	args    []string
+	timeout time.Duration
+}
+
+func (m *mockScriptRunner) Run(ctx context.Context, command string, args []string, timeout time.Duration) (string, error) {
+	m.runs = append(m.runs, mockScriptRun{command: command, args: args, timeout: timeout})
+	return m.out, m.err
+}
+
+type mockPacingAdjuster struct {
+	adjustments []mockPacingAdj
+}
+
+type mockPacingAdj struct {
+	agent      string
+	multiplier float64
+	cadence    string
+}
+
+func (m *mockPacingAdjuster) AdjustPacing(ctx context.Context, agent string, multiplier float64, cadence string) error {
+	m.adjustments = append(m.adjustments, mockPacingAdj{
+		agent:      agent,
+		multiplier: multiplier,
+		cadence:    cadence,
+	})
+	return nil
+}
+
+type fakeAuditSink struct {
+	records []recordedAudit
+}
+
+type recordedAudit struct {
+	actor     string
+	action    string
+	agentName string
+	fields    map[string]any
+}
+
+func (f *fakeAuditSink) Record(actor, action, agentName string, fields map[string]any) {
+	f.records = append(f.records, recordedAudit{
+		actor:     actor,
+		action:    action,
+		agentName: agentName,
+		fields:    fields,
+	})
+}
+
+// TestHooksDisabledByDefault asserts that with enabled:false, dispatch is a clean no-op.
+func TestHooksDisabledByDefault(t *testing.T) {
+	cfg := config.HooksConfig{
+		Enabled: false,
+		Rules: []config.HookRule{
+			{On: OnAgentPaused, Action: "notify", Notify: &config.HookNotify{Title: "Paused"}},
+		},
+	}
+	notif := &mockNotifier{}
+	d, err := NewDispatcher(cfg, WithNotifier(notif))
+	if err != nil {
+		t.Fatalf("NewDispatcher error: %v", err)
+	}
+
+	results, err := d.Dispatch(context.Background(), Event{Transition: OnAgentPaused, Agent: "scanner"})
+	if err != nil {
+		t.Fatalf("Dispatch error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results when disabled, got %d", len(results))
+	}
+	if len(notif.sent) != 0 {
+		t.Errorf("expected 0 notifications when disabled, got %d", len(notif.sent))
+	}
+}
+
+// TestNamedTransitionsAndTemplating tests event matching and template rendering.
+func TestNamedTransitionsAndTemplating(t *testing.T) {
+	cfg := config.HooksConfig{
+		Enabled: true,
+		Rules: []config.HookRule{
+			{
+				Name:   "notify-on-pause",
+				On:     OnAgentPaused,
+				Action: "notify",
+				Notify: &config.HookNotify{
+					Title:   "Agent Paused: {{.Agent}}",
+					Message: "Agent {{.Agent}} paused at ACMM L{{.ACMMLevel}} because {{.Reason}} (trigger: {{.Trigger}})",
+				},
+			},
+			{
+				Name:   "run-on-merge",
+				On:     OnSweepMerge,
+				Action: "script",
+				Script: &config.HookScript{
+					Command:  "./scripts/post-merge.sh",
+					Args:     []string{"{{.Metadata.repo}}", "{{.Metadata.pr}}"},
+					TimeoutS: 15,
+				},
+			},
+			{
+				Name:   "adjust-pacing-on-stall",
+				On:     OnStallDetected,
+				Action: "pacing",
+				Pacing: &config.HookPacing{
+					Multiplier: 2.0,
+					Cadence:    "slow",
+				},
+			},
+			{
+				Name:   "audit-on-acmm-change",
+				On:     OnACMMChange,
+				Action: "audit",
+				Audit: &config.HookAudit{
+					Message: "Maturity changed to L{{.ACMMLevel}}: {{.Reason}}",
+				},
+			},
+		},
+	}
+
+	notif := &mockNotifier{}
+	script := &mockScriptRunner{out: "post-merge complete"}
+	pacing := &mockPacingAdjuster{}
+	sink := &fakeAuditSink{}
+
+	d, err := NewDispatcher(cfg,
+		WithNotifier(notif),
+		WithScriptRunner(script),
+		WithPacingAdjuster(pacing),
+		WithAuditSink(sink),
+	)
+	if err != nil {
+		t.Fatalf("NewDispatcher error: %v", err)
+	}
+
+	// 1. Fire on_agent_paused
+	evPause := Event{
+		Transition: OnAgentPaused,
+		Agent:      "quality",
+		ACMMLevel:  4,
+		Reason:     "trajectory drift detected",
+		Trigger:    "trajectory-reviewer",
+	}
+	res1, err := d.Dispatch(context.Background(), evPause)
+	if err != nil {
+		t.Fatalf("Dispatch pause error: %v", err)
+	}
+	if len(res1) != 1 || !res1[0].Success {
+		t.Fatalf("expected 1 successful result for pause: %+v", res1)
+	}
+	if len(notif.sent) != 1 {
+		t.Fatalf("expected 1 notification sent, got %d", len(notif.sent))
+	}
+	if notif.sent[0].title != "Agent Paused: quality" {
+		t.Errorf("title = %q, want 'Agent Paused: quality'", notif.sent[0].title)
+	}
+	if !strings.Contains(notif.sent[0].message, "trajectory drift detected") {
+		t.Errorf("unexpected message content: %s", notif.sent[0].message)
+	}
+
+	// 2. Fire on_sweep_merge
+	evMerge := Event{
+		Transition: OnSweepMerge,
+		Metadata:   map[string]any{"repo": "kubestellar/hive", "pr": 4010},
+	}
+	res2, err := d.Dispatch(context.Background(), evMerge)
+	if err != nil {
+		t.Fatalf("Dispatch merge error: %v", err)
+	}
+	if len(res2) != 1 || !res2[0].Success {
+		t.Fatalf("expected 1 successful result for merge: %+v", res2)
+	}
+	if len(script.runs) != 1 {
+		t.Fatalf("expected 1 script run, got %d", len(script.runs))
+	}
+	if len(script.runs[0].args) != 2 || script.runs[0].args[0] != "kubestellar/hive" || script.runs[0].args[1] != "4010" {
+		t.Errorf("script args mismatch: %v", script.runs[0].args)
+	}
+
+	// 3. Fire on_stall_detected
+	evStall := Event{
+		Transition: OnStallDetected,
+		Agent:      "architect",
+	}
+	res3, err := d.Dispatch(context.Background(), evStall)
+	if err != nil {
+		t.Fatalf("Dispatch stall error: %v", err)
+	}
+	if len(res3) != 1 || !res3[0].Success {
+		t.Fatalf("expected 1 successful result for stall: %+v", res3)
+	}
+	if len(pacing.adjustments) != 1 || pacing.adjustments[0].agent != "architect" || pacing.adjustments[0].multiplier != 2.0 {
+		t.Errorf("pacing adjustment mismatch: %+v", pacing.adjustments)
+	}
+
+	// 4. Fire on_acmm_change
+	evACMM := Event{
+		Transition: OnACMMChange,
+		ACMMLevel:  5,
+		Reason:     "promoted by admin",
+	}
+	res4, err := d.Dispatch(context.Background(), evACMM)
+	if err != nil {
+		t.Fatalf("Dispatch acmm error: %v", err)
+	}
+	if len(res4) != 1 || !res4[0].Success {
+		t.Fatalf("expected 1 successful result for acmm change: %+v", res4)
+	}
+
+	// Verify AuditSink recorded every event under AuditHookFired
+	if len(sink.records) != 4 {
+		t.Errorf("expected 4 audit records, got %d", len(sink.records))
+	}
+	for _, rec := range sink.records {
+		if rec.action != agent.AuditHookFired {
+			t.Errorf("expected action %q, got %q", agent.AuditHookFired, rec.action)
+		}
+	}
+}
+
+// TestWildcardAndPrefixMatching tests rule matching with patterns like on_agent_* and *.
+func TestWildcardAndPrefixMatching(t *testing.T) {
+	cfg := config.HooksConfig{
+		Enabled: true,
+		Rules: []config.HookRule{
+			{Name: "agent-wildcard", On: "on_agent_*", Action: "audit"},
+			{Name: "catch-all", On: "*", Action: "audit"},
+		},
+	}
+	d, err := NewDispatcher(cfg)
+	if err != nil {
+		t.Fatalf("NewDispatcher error: %v", err)
+	}
+
+	// on_agent_resumed matches both on_agent_* and *
+	res1, _ := d.Dispatch(context.Background(), Event{Transition: OnAgentResumed, Agent: "scanner"})
+	if len(res1) != 2 {
+		t.Errorf("expected 2 matches for on_agent_resumed, got %d", len(res1))
+	}
+
+	// on_pr_opened matches only *
+	res2, _ := d.Dispatch(context.Background(), Event{Transition: OnPROpened})
+	if len(res2) != 1 {
+		t.Errorf("expected 1 match for on_pr_opened, got %d", len(res2))
+	}
+}
+
+// TestScriptOutputSecretScrubbing verifies that leaked credentials in script output are scrubbed.
+func TestScriptOutputSecretScrubbing(t *testing.T) {
+	runner := &DefaultScriptRunner{}
+	// Echoes a token string
+	secret := "ghp_123456789012345678901234567890123456"
+	out, err := runner.Run(context.Background(), fmt.Sprintf("echo 'Token is %s'", secret), nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("script run error: %v", err)
+	}
+	if strings.Contains(out, secret) {
+		t.Errorf("raw secret was NOT scrubbed from script output: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED") && !strings.Contains(out, "ghp_") {
+		t.Logf("output scrubbed: %q", out)
+	}
+}
+
+// TestInvalidRuleValidation asserts malformed rules are rejected at construction time.
+func TestInvalidRuleValidation(t *testing.T) {
+	invalidConfigs := []config.HooksConfig{
+		{
+			Rules: []config.HookRule{{On: "", Action: "notify"}},
+		},
+		{
+			Rules: []config.HookRule{{On: "on_agent_paused", Action: "invalid_action"}},
+		},
+	}
+
+	for i, cfg := range invalidConfigs {
+		_, err := NewDispatcher(cfg)
+		if err == nil {
+			t.Errorf("case %d: expected error for invalid rule config, got nil", i)
+		}
+	}
+}

--- a/src/pkg/hooks/registry.go
+++ b/src/pkg/hooks/registry.go
@@ -1,0 +1,96 @@
+package hooks
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// Registry manages declarative hook rules and matches them against state transition events.
+type Registry struct {
+	mu    sync.RWMutex
+	rules []config.HookRule
+}
+
+// NewRegistry creates a new empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		rules: make([]config.HookRule, 0),
+	}
+}
+
+// NewRegistryFromConfig builds a Registry populated from a HooksConfig.
+func NewRegistryFromConfig(cfg config.HooksConfig) (*Registry, error) {
+	reg := NewRegistry()
+	for _, rule := range cfg.Rules {
+		if err := reg.Register(rule); err != nil {
+			return nil, err
+		}
+	}
+	return reg, nil
+}
+
+// Register adds and validates a single hook rule.
+func (r *Registry) Register(rule config.HookRule) error {
+	on := strings.TrimSpace(rule.On)
+	if on == "" {
+		return fmt.Errorf("hook rule missing 'on' transition")
+	}
+
+	action := strings.ToLower(strings.TrimSpace(rule.Action))
+	switch action {
+	case "notify", "script", "pacing", "audit":
+		// valid
+	default:
+		return fmt.Errorf("unknown hook action %q (supported: notify, script, pacing, audit)", rule.Action)
+	}
+
+	rule.On = on
+	rule.Action = action
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rules = append(r.rules, rule)
+	return nil
+}
+
+// Rules returns a copy of all currently registered rules.
+func (r *Registry) Rules() []config.HookRule {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]config.HookRule, len(r.rules))
+	copy(out, r.rules)
+	return out
+}
+
+// Match returns all rules matching the transition specified in the Event.
+func (r *Registry) Match(event Event) []config.HookRule {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var matches []config.HookRule
+	for _, rule := range r.rules {
+		if matchTransition(rule.On, event.Transition) {
+			matches = append(matches, rule)
+		}
+	}
+	return matches
+}
+
+func matchTransition(pattern, transition string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	transition = strings.ToLower(strings.TrimSpace(transition))
+
+	if pattern == "*" || pattern == transition {
+		return true
+	}
+
+	if strings.HasSuffix(pattern, "*") {
+		prefix := strings.TrimSuffix(pattern, "*")
+		return strings.HasPrefix(transition, prefix)
+	}
+
+	return false
+}

--- a/src/pkg/hooks/template.go
+++ b/src/pkg/hooks/template.go
@@ -1,0 +1,26 @@
+package hooks
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+)
+
+// RenderTemplate evaluates a template string against the event data.
+func RenderTemplate(tmplStr string, event Event) (string, error) {
+	if !strings.Contains(tmplStr, "{{") {
+		return tmplStr, nil
+	}
+
+	tmpl, err := template.New("hook").Option("missingkey=zero").Parse(tmplStr)
+	if err != nil {
+		return tmplStr, err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, event); err != nil {
+		return tmplStr, err
+	}
+
+	return buf.String(), nil
+}

--- a/src/pkg/hooks/types.go
+++ b/src/pkg/hooks/types.go
@@ -1,0 +1,89 @@
+package hooks
+
+import (
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// Named, hookable state transitions across Hive.
+const (
+	// Agent lifecycle transitions
+	OnAgentStarted = "on_agent_started"
+	OnAgentStopped = "on_agent_stopped"
+	OnAgentPaused  = "on_agent_paused"
+	OnAgentResumed = "on_agent_resumed"
+	OnAgentFailed  = "on_agent_failed"
+	OnAgentKicked  = "on_agent_kicked"
+
+	// Governor & sweep transitions
+	OnACMMChange    = "on_acmm_change"
+	OnSweepMerge    = "on_sweep_merge"
+	OnStallDetected = "on_stall_detected"
+	OnPROpened      = "on_pr_opened"
+	OnIssueOpened   = "on_issue_opened"
+
+	// Turn & tool transitions
+	OnTurnStart            = "on_turn_start"
+	OnTurnComplete         = "on_turn_complete"
+	OnToolApprovalRequired = "on_tool_approval_required"
+	OnToolApproved         = "on_tool_approved"
+	OnToolDenied           = "on_tool_denied"
+)
+
+// Event carries structured metadata for a triggered state transition.
+type Event struct {
+	Transition string         `json:"transition"`
+	Agent      string         `json:"agent,omitempty"`
+	ACMMLevel  int            `json:"acmm_level,omitempty"`
+	Reason     string         `json:"reason,omitempty"`
+	Trigger    string         `json:"trigger,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	Timestamp  time.Time      `json:"timestamp"`
+}
+
+// Result records the execution outcome of one hook action.
+type Result struct {
+	RuleName string        `json:"rule_name"`
+	On       string        `json:"on"`
+	Action   string        `json:"action"`
+	Success  bool          `json:"success"`
+	Output   string        `json:"output,omitempty"`
+	Error    string        `json:"error,omitempty"`
+	Duration time.Duration `json:"duration"`
+}
+
+// AuditFields returns structured key-value pairs formatted for AuditSink.Record.
+func (r Result) AuditFields(event Event) map[string]any {
+	fields := map[string]any{
+		"hook_name":  r.RuleName,
+		"transition": r.On,
+		"action":     r.Action,
+		"success":    r.Success,
+		"duration":   r.Duration.String(),
+	}
+	if event.Agent != "" {
+		fields["agent"] = event.Agent
+	}
+	if event.ACMMLevel > 0 {
+		fields["acmm_level"] = event.ACMMLevel
+	}
+	if event.Reason != "" {
+		fields["reason"] = event.Reason
+	}
+	if event.Trigger != "" {
+		fields["trigger"] = event.Trigger
+	}
+	if r.Output != "" {
+		fields["output"] = r.Output
+	}
+	if r.Error != "" {
+		fields["error"] = r.Error
+	}
+	return fields
+}
+
+// ActionHandler is the interface for executing a specific hook action type.
+type ActionHandler interface {
+	Execute(event Event, rule config.HookRule) (Result, error)
+}


### PR DESCRIPTION
## Summary

Introduces declarative, state-triggered **Hooks** as a first-class extension point in Hive (`pkg/hooks` and `pkg/config`).

### Features

- **Named Hookable Transitions**: Supports transitions across agent lifecycles, governor cycles, sweep operations, and turns:
  - Agent lifecycle: `on_agent_started`, `on_agent_stopped`, `on_agent_paused`, `on_agent_resumed`, `on_agent_failed`, `on_agent_kicked`.
  - Governor / sweep: `on_acmm_change`, `on_sweep_merge`, `on_stall_detected`, `on_pr_opened`, `on_issue_opened`.
  - Turns & tools: `on_turn_start`, `on_turn_complete`, `on_tool_approval_required`.
  - Pattern matching: wildcard support (e.g. `on_agent_*`, `*`).
- **Declarative Actions**:
  - `notify`: Formatted notifications to webhooks (Discord, Slack, etc.) or alert sinks.
  - `script`: Sandboxed command/script execution with timeout enforcement.
  - `pacing`: Dynamic governor cadence / pacing adjustment.
  - `audit`: Explicit structured audit logging.
- **Context Templating**: Interpolates event context (`{{.Agent}}`, `{{.Reason}}`, `{{.Trigger}}`, `{{.ACMMLevel}}`, `{{.Metadata.<key>}}`).
- **Guardrails & Security**:
  - Opt-in and side-effect-safe by default (`hooks.enabled: false` default).
  - Script output is automatically scrubbed with `logscrub` to prevent credential leakage.
  - Execution results and durations are emitted to `AuditSink` under `AuditHookFired` (`"hook_fired"`).
- **Documentation & Tests**:
  - Operator guide in `src/docs/hooks.md`.
  - Comprehensive unit test suite in `src/pkg/hooks/hooks_test.go`.

Fixes #4001