### PR TITLE
docs: scrub internal cluster names from source comments + inference README

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -372,7 +372,7 @@ RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bi
 # CAP_NET_ADMIN in its EFFECTIVE set so the MITM proxy can stamp SO_MARK on its
 # own upstream dials and be exempted from the forced-egress iptables REDIRECT
 # (on OpenShift/OVN xt_owner is ABSENT, so the owner-UID exemptions silently fail
-# to load and SO_MARK is the ONLY remaining exemption — observed live on vllm-d,
+# to load and SO_MARK is the ONLY remaining exemption — observed live on the heartbeat-only cluster,
 # where the proxy's own :443 dials looped into the REDIRECT and 502'd every forge
 # request). setsockopt(SO_MARK) requires CAP_NET_ADMIN in the caller's EFFECTIVE
 # set, and the hive process is dropped to non-root `dev`.

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -268,7 +268,7 @@ func perAppIDKeyPath(appID int64) string {
 // The filename NAMES the App, so a key can only ever be found under the App it
 // was delivered for. The generic /data/gh-app-key.pem carries no such evidence:
 // a key written there for one App silently becomes "the key" for whatever
-// app_id the config later claims, which is how all 33 vllm-d spokes ended up
+// app_id the config later claims, which is how all 33 heartbeat-only-cluster spokes ended up
 // signing as the public App with the GHE key and getting
 // 404 Integration not found.
 //
@@ -496,7 +496,7 @@ func resolveAppKeyFile(configured, envOverride string, appID int64) string {
 		// typed by an operator. Until /secrets was included here, a provisioned
 		// hive could never change forges: the hub could correct app_id all it
 		// liked and the spoke kept signing with the provisioned key, which on
-		// the a-ks-wec2 pool was a placeholder matching NEITHER real App.
+		// the spoke-cluster pool was a placeholder matching NEITHER real App.
 		if v == spokeAppKeyPath || v == spokeProvisionedAppKeyPath {
 			if p := perAppIDKeyPath(appID); p != "" {
 				if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
@@ -3608,7 +3608,7 @@ func main() {
 			// /data/gh-app-key.pem carries no evidence of which App signed it, so
 			// a key delivered for one App silently becomes "the key" for whatever
 			// app_id the config later claims. On 2026-07-31 that is exactly what
-			// happened: all 33 vllm-d spokes had key_file pinned to the generic
+			// happened: all 33 heartbeat-only-cluster spokes had key_file pinned to the generic
 			// path holding the GHE key, so correcting app_id to the public App
 			// still produced 404 Integration not found — the right key was
 			// already on disk at gh-app-key-3568013.pem and unreachable, because
@@ -3730,7 +3730,7 @@ func main() {
 			// stored one that outlives the App it was derived for: once written,
 			// it short-circuits resolveAppKeyFile on every later boot, so a
 			// corrected app_id keeps signing with the previous App's key. That is
-			// what left all 33 vllm-d spokes pinned to the GHE key.
+			// what left all 33 heartbeat-only-cluster spokes pinned to the GHE key.
 			//
 			// Leaving it empty lets derivation run every time, so the key always
 			// tracks the App actually in effect. An operator-set key_file still
@@ -3784,7 +3784,7 @@ func main() {
 
 			// Resolve the key file the same way startup does, so a hive whose
 			// only correct key arrived as an ADDITIONAL per-app-id key (no
-			// primary key_file configured — the exact vllm-d state) still finds
+			// primary key_file configured — the exact heartbeat-only-cluster state) still finds
 			// it: resolveAppKeyFile prefers /data/gh-app-key-<appid>.pem for the
 			// app_id we now claim. An explicit key_file still wins outright.
 			rebuildKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
@@ -3861,7 +3861,7 @@ func main() {
 			// The hub assigned this (previously placeholder) hive a real project.
 			// Reconcile our running project config so agents work the claimed
 			// org/repos at the claimed maturity level. This is the ONLY delivery
-			// channel on heartbeat-only clusters (vllm-d) — no kubectl push is
+			// channel on heartbeat-only clusters (the heartbeat-only cluster) — no kubectl push is
 			// possible. The hub keeps sending this every beat until we report the
 			// matching project back, so an idempotent no-op when already matched
 			// is expected and cheap.
@@ -3975,7 +3975,7 @@ func main() {
 		}), hub.GatewayConfigCallback(func(gw *hub.HeartbeatGatewayConfig) {
 			// The hub funded an OpenRouter gateway on this hive's behalf (scan-to-
 			// fund from My Hives) and delivered it over the heartbeat channel — the
-			// only path that reaches a firewalled/heartbeat-only spoke (vllm-d). We
+			// only path that reaches a firewalled/heartbeat-only spoke (the heartbeat-only cluster). We
 			// store the key in our OWN per-gateway secret-file store and create the
 			// "openrouter" gateway. The hub drains the delivery after sending, so
 			// this fires once per fund; the key value is never logged.

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -89,7 +89,7 @@ if [ "$IS_KUBERNETES" = "true" ]; then
   # Why this is the right way round: the ConfigMap is frozen at provision
   # time and cannot be written by anything at runtime (the hub has only
   # `get` on ConfigMaps, spoke RBAC omits them entirely, and the hub has no
-  # kubectl path to vllm-d at all). The runtime config on the PVC is the
+  # kubectl path to the heartbeat-only cluster at all). The runtime config on the PVC is the
   # only layer any component can actually write. Treating the writable
   # layer as the input — instead of merging it over a frozen one on every
   # boot — is what removes the "which layer wins" question that cost about
@@ -796,7 +796,7 @@ print('[entrypoint] UID map written to /var/run/hive/uid-map.json')
       #     the proxy's traffic.
       #
       # REGRESSION HISTORY: PR #2678 replaced the working owner-UID exemption with
-      # a MARK-ONLY exemption. That was verified only on OpenShift/vllm-d. On the
+      # a MARK-ONLY exemption. That was verified only on OpenShift / the heartbeat-only cluster. On the
       # LIVE OKE console hive the SO_MARK did NOT reliably stick on the proxy's
       # outbound sockets, so its OWN :443 to api.github.com hit the REDIRECT rule,
       # looped back into itself (:18443) → EPERM/ECONNREFUSED/EOF → no GitHub App
@@ -814,7 +814,7 @@ print('[entrypoint] UID map written to /var/run/hive/uid-map.json')
       # failure into a fail-closed FATAL crash-loop: on 2026-08-13 three
       # spokes sharing one node rolled simultaneously at the daily upgrade
       # window and kept re-colliding in synchronized backoff for three
-      # hours (a-ks-wec2). Jittered retries break the lockstep; the real
+      # hours (a spoke cluster). Jittered retries break the lockstep; the real
       # iptables error is logged instead of discarded.
       _ipt_chain_ok=false
       _ipt_try=0

--- a/src/deploy/inference/hive-epp-rbac.yaml
+++ b/src/deploy/inference/hive-epp-rbac.yaml
@@ -1,7 +1,7 @@
 ---
 # Durable RBAC + InferencePool for the LIVE endpoint-picker (EPP) pod.
 #
-# Background (kubestellar/hive#2341): the running cluster (vllm-d) has an
+# Background (kubestellar/hive#2341): the running cluster (the heartbeat-only cluster) has an
 # ad-hoc EPP Deployment whose ServiceAccount is `hive-llm-d-epp` in namespace
 # `hive-inference`, started with:
 #     --pool-name=hive-vllm-pool --pool-namespace=hive-inference

--- a/src/deploy/k8s/backup-cronjob.yaml
+++ b/src/deploy/k8s/backup-cronjob.yaml
@@ -182,7 +182,7 @@ spec:
               persistentVolumeClaim:
                 claimName: hive-hub-data-rwx
                 readOnly: true
-            # Kubeconfigs for remote spoke clusters (e.g. vllm-d). Without
+            # Kubeconfigs for remote spoke clusters (e.g. the heartbeat-only cluster). Without
             # this, spokes on remote clusters cannot be captured.
             - name: kubeconfigs
               secret:

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1384,7 +1384,7 @@ var cliPaneMarkers = []string{
 	bobInputPlaceholderDefault,
 	bobProductMarker,
 	// codex's markers. Codex 0.144.1's TUI renders NONE of the entries above:
-	// verified live (daviddiaz "Visual Hive", hive-oke) — an idle codex pane
+	// verified live (daviddiaz "Visual Hive", the hub-reachable cluster) — an idle codex pane
 	// contained no "❯", "goose", "Claude"/"Gemini" chrome, or bob strings, only
 	// the "›" (U+203A) input caret and the "OpenAI Codex" banner. Without these
 	// two entries waitForCLIReadyForAgent can never see a booted codex, so its
@@ -5291,7 +5291,7 @@ const codexBackend = "codex"
 // the "❯" (U+276F) used by the other TUIs and by the consent-screen menu, so it
 // never collides with paneShowsConsentScreen's "❯"-selected-line check.
 //
-// Verified live on Codex 0.144.1 (daviddiaz "Visual Hive", hive-oke): an idle
+// Verified live on Codex 0.144.1 (daviddiaz "Visual Hive", the hub-reachable cluster): an idle
 // scanner pane sitting at its prompt rendered this caret with placeholder
 // ghost-text ("› Improve documentation in @filename", "› Explain this
 // codebase") and contained ZERO "❯", "goose is ready", "> Enter to send", or

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -2719,12 +2719,12 @@ type DashboardConfig struct {
 	AuthorizedUsers []string `yaml:"authorized_users"`
 	// HubProxied is true when this hive sits behind the hub's nginx auth-proxy,
 	// which authenticates every request and injects trusted X-Hive-User/X-Hive-Role
-	// headers (hive-oke hosted hives). When true the hive TRUSTS those headers and
+	// headers (hub-reachable-cluster hosted hives). When true the hive TRUSTS those headers and
 	// keeps the shared-token path enabled even if AuthorizedUsers is non-empty —
 	// nginx is the gate, and the allowlist is informational (Access tab) only.
 	//
 	// When false (the default) a non-empty AuthorizedUsers list means this is a
-	// STANDALONE direct-route spoke with no nginx in front (vllm-d), so it must
+	// STANDALONE direct-route spoke with no nginx in front (the heartbeat-only cluster), so it must
 	// strip client-supplied identity headers and enforce per-user device-flow
 	// authz itself. Decoupling these two meanings fixes hub-proxied hives being
 	// wrongly forced into direct-route mode (which broke their dashboard link and

--- a/src/pkg/config/provenance.go
+++ b/src/pkg/config/provenance.go
@@ -258,7 +258,7 @@ const (
 	// wrong: "ibm-hive" existed only in _test.go fixtures — it appears in no
 	// production config, in no cluster entry, and on none of the 51 fleet
 	// spokes (live clusters.json carries github_app_slug
-	// "kubestellar-hive-ghe" for vllm-d). Relaxing the rule for an invented
+	// "kubestellar-hive-ghe" for the heartbeat-only cluster). Relaxing the rule for an invented
 	// fixture left a GHE App under a non-"ghe" slug passing validation, which
 	// is precisely the shape this package exists to reject.
 	EnterpriseGitHubAppSlug = "kubestellar-hive-ghe"
@@ -403,7 +403,7 @@ func IdentitySetIssues(gh GitHubConfig) []string {
 	// disagree with each other.
 	if gh.AppID != 0 {
 		// An empty api_url is not a public one when base_url already names GHE:
-		// pooled/placeholder GHE hives and the vllm-d cluster record carry
+		// pooled/placeholder GHE hives and the heartbeat-only cluster's record carry
 		// exactly one of the two. Only claim a contradiction when api_url is
 		// populated, or when NEITHER url names the forge (the incident shape,
 		// which the app_id rule above catches on its own).
@@ -419,7 +419,7 @@ func IdentitySetIssues(gh GitHubConfig) []string {
 		// explicit that a GHE hive legitimately carries
 		// api_url: https://github.ibm.com/api/v3 with base_url: "" (pooled and
 		// placeholder GHE hives all do), and the symmetric case — a declared GHE
-		// base_url with api_url unset — is the shape of the vllm-d cluster
+		// base_url with api_url unset — is the shape of the heartbeat-only cluster
 		// record. Treating either silence as "public github.com" makes these two
 		// rules fire on VALID configs.
 		//

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -2703,7 +2703,7 @@ func (s *Server) handleAuthorizedUsersList(w http.ResponseWriter, r *http.Reques
 	sort.Slice(out, func(i, j int) bool { return out[i].Username < out[j].Username })
 	jsonResponse(w, map[string]any{
 		// enforced == this is a direct-route spoke that gates logins by this list
-		// (vllm-d); false means hub-proxied (hive-oke), where nginx gates instead.
+		// (the heartbeat-only cluster); false means hub-proxied (the hub-reachable cluster), where nginx gates instead.
 		"users":    out,
 		"enforced": len(entries) > 0,
 	})

--- a/src/pkg/dashboard/terminal_proxy.go
+++ b/src/pkg/dashboard/terminal_proxy.go
@@ -40,7 +40,7 @@ func ttydPort() int {
 // Ingress/Route that is supposed to peel off /terminal to the Node proxy
 // (port 3001) does not exist on every spoke — clicking "▶ terminal" then
 // landed on the static FileServer here and returned a bare Go
-// "404 page not found" (task #39, vllm-d hosted spokes). Serving /terminal
+// "404 page not found" (task #39, heartbeat-only-cluster hosted spokes). Serving /terminal
 // from this server makes the link work regardless of which Service port the
 // cluster's route actually targets, and puts terminal access behind the same
 // authenticate() middleware as the rest of the dashboard (session cookie,

--- a/src/pkg/hub/auth_audit.go
+++ b/src/pkg/hub/auth_audit.go
@@ -29,7 +29,7 @@ const (
 	authAuditStartupDelay = 5 * time.Minute
 
 	// authAuditProbeTimeout bounds each per-spoke probe. Firewalled/unreachable
-	// spokes (vllm-d from the hub) simply time out and are reported as
+	// spokes (the heartbeat-only cluster from the hub) simply time out and are reported as
 	// "unreachable", never as open.
 	authAuditProbeTimeout = 8 * time.Second
 
@@ -83,7 +83,7 @@ func (s *HubServer) runAuthAudit(ctx context.Context, client *http.Client) {
 
 	var open []string
 	probed, unreachable := 0, 0
-	// Per-cluster tallies so a whole cluster going dark (vllm-d has been
+	// Per-cluster tallies so a whole cluster going dark (the heartbeat-only cluster has been
 	// intermittently unreachable from the hub) is reported as ONE outage rather
 	// than as N individually broken hives.
 	clusterProbed := map[string]int{}
@@ -143,7 +143,7 @@ func (s *HubServer) runAuthAudit(ctx context.Context, client *http.Client) {
 // HTTP status (0 when the request never completed), wideOpen and reachable.
 // wideOpen is true only on a 200 (dashboard served to anyone). A 30x/401/403
 // means protected. A transport error means unreachable (e.g. a firewalled
-// vllm-d spoke the hub can't reach), never counted as open.
+// heartbeat-only-cluster spoke the hub can't reach), never counted as open.
 //
 // The status is returned so callers can distinguish a SERVING spoke from one
 // whose ingress answered with an error: reachable only says the HTTP exchange

--- a/src/pkg/hub/cluster_app_key.go
+++ b/src/pkg/hub/cluster_app_key.go
@@ -227,9 +227,9 @@ func (i *clusterAppIdentity) HasKey() bool {
 // nil — and every downstream reconcile silently became a no-op.
 //
 // That is exactly how the placeholder-sentinel repair shipped in #2333 was
-// prevented from ever running on the hive-oke cluster: the operator added
-// "github_app_id" to clusters.json as instructed, but hive-oke has no
-// <clusterID>.pem (only vllm-d does), so appIdentityForCluster returned nil and
+// prevented from ever running on the hub-reachable cluster: the operator added
+// "github_app_id" to clusters.json as instructed, but the hub-reachable cluster has no
+// <clusterID>.pem (only the heartbeat-only cluster does), so appIdentityForCluster returned nil and
 // appKeyConfigForHeartbeat bailed before decideAppKeySync's sentinel branch was
 // ever consulted. The repair was unreachable in production for the one cluster
 // it was written for.
@@ -261,7 +261,7 @@ func (s *HubServer) appIdentityForHive(h *SaaSHive, clusterID string) *clusterAp
 		// missing from clusters.json got no answer at all, beat after beat —
 		// the hub logged "cluster names no github app — cannot repair" and
 		// offered a remedy (set github_app_id on the cluster) for a cluster
-		// entry that does not exist. Five a-ks-wec2 spokes stayed on
+		// entry that does not exist. Five spoke-cluster spokes stayed on
 		// config.PlaceholderAppID that way.
 		//
 		// A hive's ELECTED forge does not depend on the cluster registry, and
@@ -340,7 +340,7 @@ func (s *HubServer) appIdentityForHive(h *SaaSHive, clusterID string) *clusterAp
 // only way a spoke received an App at assign was an admin pasting app_id,
 // installation_id AND a PEM into the dialog — all three, or nothing was sent.
 // Leave one blank and the hive kept config.PlaceholderAppID, which is how five
-// spokes on a-ks-wec2 sat in dashboard-only mode carrying 999999999 while the
+// spokes on a spoke cluster sat in dashboard-only mode carrying 999999999 while the
 // hub knew their forge was github.ibm.com and held that App's key the whole
 // time.
 //
@@ -552,7 +552,7 @@ const (
 	// App identity is the only thing that can fix it.
 	appKeyReasonPlaceholderAppID = "spoke still carries the placeholder app_id sentinel"
 	// appKeyReasonPublicHiveOnGHECluster is the class fix for a github.com hive
-	// parked on a GitHub-Enterprise-default cluster (vllm-d). The hive's meta
+	// parked on a GitHub-Enterprise-default cluster (the heartbeat-only cluster). The hive's meta
 	// pins it to public github.com (github_base_url:"public" / "https://github.com")
 	// even though its cluster's default App is the GHE App. Pushing the cluster's
 	// GHE key as the hive's PRIMARY every beat overwrites its github.com app_id and
@@ -588,7 +588,7 @@ const (
 	// class), and a public-host hive whose spoke was wrongly flipped onto the
 	// GHE App (the alchemy class, mis-flipped by the cluster-keyed guard #2713
 	// shipped). Judging it on the CLUSTER's forge instead is exactly what
-	// force-flipped every github.com project on the vllm-d cluster to app 5686.
+	// force-flipped every github.com project on the heartbeat-only cluster to app 5686.
 	appKeyReasonWrongForgeApp = "hive carries an app_id registered on a different github host"
 )
 
@@ -662,7 +662,7 @@ const (
 // forge). Combined with a non-zero spoke app_id that differs from the identity
 // being delivered, that proves the spoke's App names nothing on the host this
 // hive uses. It is judged on the HIVE's forge, never the cluster's: a cluster
-// hosts hives of BOTH forges (vllm-d carries github.ibm.com projects beside
+// hosts hives of BOTH forges (the heartbeat-only cluster carries github.ibm.com projects beside
 // github.com ones), so cluster membership alone proves nothing about any one
 // hive. See appKeyReasonWrongForgeApp.
 //
@@ -849,7 +849,7 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 	//
 	// The 2026-08-05 fleet regression is why this is emphatically NOT
 	// "clusterIsGHE": #2713 shipped this branch keyed on clusterDefaultForge, so
-	// every hive on the GHE-default vllm-d cluster whose spoke reported the
+	// every hive on the GHE-default heartbeat-only cluster whose spoke reported the
 	// public App — including the github.com projects that cluster also hosts
 	// (ibm/alchemy-logging: org "ibm" lives on public github.com) — was
 	// "repaired" onto app 5686 / github.ibm.com and 404'd on every token mint.

--- a/src/pkg/hub/clusters_registry.go
+++ b/src/pkg/hub/clusters_registry.go
@@ -19,7 +19,7 @@ import (
 // is drift-prone with nothing to correct it.
 //
 // WHY THIS FIX IS A LOADER AND NOT A RECONCILER. The registry is not derivable
-// from the fleet: two of its three clusters (vllm-d, a-ks-wec2) are pull_only
+// from the fleet: two of its three clusters (the heartbeat-only cluster, a spoke cluster) are pull_only
 // BY DESIGN and the hub cannot reach them to enumerate anything. There is no
 // in-cluster source that could re-generate this file, so a reconciler would
 // have to invent one — and a new source of truth for the file that gates all
@@ -32,7 +32,7 @@ import (
 // on a JSON parse error. An empty registry is not a degraded registry, it is an
 // inverted one: clusterForHive falls through both its lookups and returns nil
 // for EVERY hive, so a truncated write silently disables the hub's writes to
-// hive-oke — the one cluster it can reach — while logging a single line and
+// the hub-reachable cluster — the one cluster it can reach — while logging a single line and
 // coming up otherwise healthy. A half-written file produced by an interrupted
 // `kubectl cp` (exactly the mechanism that left the .bak sibling) lands
 // squarely in this case.
@@ -50,7 +50,7 @@ import (
 // reason hub-generations.json differs: a corrupt acks file can be discarded
 // because losing an ack merely un-silences an alert — the safe direction. A
 // corrupt REGISTRY must not be discarded and replaced with a synthesized
-// default, because the default names only hive-oke and would silently strand
+// default, because the default names only the hub-reachable cluster and would silently strand
 // every hive on the two pull-only clusters, re-routing their App and host
 // resolution to the wrong cluster. The bad bytes are left on disk under this
 // suffix so an operator can see what arrived.
@@ -114,7 +114,7 @@ const (
 	clustersLoaded clustersLoadOutcome = iota
 	// clustersAbsent: the file is ENOENT. A POSITIVE fact, not an absence of
 	// information — a hub with no registry has never been given one, so the
-	// synthesized hive-oke default is exactly right. This is the documented
+	// synthesized hub-reachable-cluster default is exactly right. This is the documented
 	// backward-compatibility path for a fresh or Compose deployment and it is
 	// preserved verbatim.
 	clustersAbsent
@@ -124,7 +124,7 @@ const (
 	//
 	// THIS IS THE CASE THAT MUST NOT YIELD AN EMPTY MAP, and must not fall back
 	// to the default either. The hub knows a registry was placed here and
-	// cannot tell what it says. Returning empty disables writes to hive-oke;
+	// cannot tell what it says. Returning empty disables writes to the hub-reachable cluster;
 	// returning the default silently re-routes every pull-only hive. Both are
 	// widenings of the blast radius of a corrupt file, so the hub refuses.
 	clustersUntrusted

--- a/src/pkg/hub/forge.go
+++ b/src/pkg/hub/forge.go
@@ -421,8 +421,8 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve the App identity for the TARGET forge from CLUSTER CONFIG. No App
-	// ID or slug is hardcoded anywhere in Go: hive-oke names its github.com App
-	// and vllm-d names its github.ibm.com App, both in clusters.json, exactly as
+	// ID or slug is hardcoded anywhere in Go: the hub-reachable cluster names its github.com App
+	// and the heartbeat-only cluster names its github.ibm.com App, both in clusters.json, exactly as
 	// resolveProvisionAppID already reads them.
 	cluster := s.clusterForHive(h)
 	identity, missing := s.forgeIdentityForTarget(cluster, target)
@@ -617,7 +617,7 @@ const forgeIdentityRemedy = "populate the target cluster's entry in /data/saas/c
 // carry identity for BOTH forges (see ClusterConfig.Forges) and a hive elects
 // one. So this refuses only a target the cluster has no identity FOR, rather
 // than every target differing from the cluster's own host. That is the change
-// that unblocks a public election on the GHE-default vllm-d cluster, which
+// that unblocks a public election on the GHE-default heartbeat-only cluster, which
 // previously 409'd with "the target forge identity is incomplete" — leaving
 // seven public hives that had already elected github.com unrepairable.
 //

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -1515,7 +1515,7 @@ func ingressHostExists(ctx context.Context, client *http.Client, cfg *inClusterC
 // This exists because the DashboardURL fallback used to synthesise
 // "<hiveID>.<hub's host>", which silently assumes every spoke is fronted by the
 // hub's own wildcard domain. That holds only for spokes co-located with the hub
-// (hive-oke, where *.hive.kubestellar.io IS the router). On any other cluster —
+// (the hub-reachable cluster, where *.hive.kubestellar.io IS the router). On any other cluster —
 // an OpenShift pool on *.apps.<cluster>, an IKS pool — the synthesised host
 // resolves, via the hub's wildcard, to the HUB's router, which has no backend
 // for that name and answers 503. The hub then linked users at a hostname that
@@ -1903,11 +1903,11 @@ type HeartbeatAppKey struct {
 // the hub to a spoke via the heartbeat response. It mirrors the AuthorizedUsers
 // mechanism: when an admin assigns a pre-provisioned "placeholder" hive to a
 // requesting user, the hub cannot push the new project config to a
-// heartbeat-only spoke (e.g. vllm-d) over kubectl. Delivering it in the
+// heartbeat-only spoke (e.g. the heartbeat-only cluster) over kubectl. Delivering it in the
 // heartbeat response lets the spoke reconcile its running config
 // (cfg.Project.Org/Repos/PrimaryRepo and ACMM level) every beat until it
 // matches what the hub recorded — the only channel that works uniformly for
-// both reachable (hive-oke) and heartbeat-only (vllm-d) clusters.
+// both reachable (the hub-reachable cluster) and heartbeat-only (the heartbeat-only cluster) clusters.
 type HeartbeatProjectConfig struct {
 	Org         string   `json:"org"`
 	Repos       []string `json:"repos"`
@@ -1941,7 +1941,7 @@ type HeartbeatProjectConfig struct {
 // HeartbeatGatewayConfig carries an OpenRouter model gateway (funded via the
 // hub's scan-to-fund flow) from the hub to a spoke via the heartbeat response.
 // It mirrors HeartbeatProjectConfig: for a firewalled/heartbeat-only spoke
-// (vllm-d) the hub cannot POST to the spoke's dashboard over the network, so it
+// (the heartbeat-only cluster) the hub cannot POST to the spoke's dashboard over the network, so it
 // delivers the gateway in the heartbeat response and the spoke stores the key in
 // its OWN per-gateway secret-file store. The Key is a secret VALUE — it travels
 // only over the TLS heartbeat channel, is never logged, and the spoke writes it
@@ -1990,7 +1990,7 @@ type HeartbeatResponse struct {
 	IsPublic        *bool                     `json:"is_public,omitempty"`
 	// AuthorizedUsers is the hub's authoritative per-hive access list, as
 	// "username:role" entries. The hub can't reach heartbeat-only spokes (e.g.
-	// vllm-d) over kubectl, and those spokes authorize their own device-flow
+	// the heartbeat-only cluster) over kubectl, and those spokes authorize their own device-flow
 	// logins against a local allowlist — so a grant made in the hub's Manage
 	// Access UI would never reach them. Delivering the list in the heartbeat
 	// response lets the spoke reconcile its allowlist every beat, so access
@@ -2003,11 +2003,11 @@ type HeartbeatResponse struct {
 	// The hub keeps sending it every beat until the spoke reconciles and reports
 	// the matching project. nil means "no reconcile needed" — leave the spoke's
 	// project config alone. This is the ONLY delivery channel for heartbeat-only
-	// clusters (vllm-d) the hub cannot reach over kubectl.
+	// clusters (the heartbeat-only cluster) the hub cannot reach over kubectl.
 	ProjectConfig *HeartbeatProjectConfig `json:"project_config,omitempty"`
 	// PendingGateway carries a funded model gateway (OpenRouter scan-to-fund) the
 	// hub minted on the spoke's behalf. It is the delivery channel for
-	// firewalled/heartbeat-only spokes (vllm-d) the hub cannot POST to directly.
+	// firewalled/heartbeat-only spokes (the heartbeat-only cluster) the hub cannot POST to directly.
 	// nil means "nothing to deliver". The hub sends it once (drained on delivery)
 	// rather than every beat, since it carries a secret key value.
 	PendingGateway *HeartbeatGatewayConfig `json:"pending_gateway,omitempty"`

--- a/src/pkg/hub/hive_identity.go
+++ b/src/pkg/hub/hive_identity.go
@@ -26,7 +26,7 @@ import (
 //	forgeIdentityForTarget  (forge.go)           — the forge endpoint.
 //
 // Four answers to one question is the bug class. On 2026-07-31 a clusters.json
-// edit stamped the GHE App onto public-GitHub hives on the vllm-d cluster; a
+// edit stamped the GHE App onto public-GitHub hives on the heartbeat-only cluster; a
 // hand-applied repair to torch-spyre was overwritten six seconds later:
 //
 //	16:44:11  using GitHub App authentication   app_id=3568013   (correct)
@@ -38,7 +38,7 @@ import (
 // # THE SPOKE PULLS; THE HUB ANSWERS
 //
 // The spoke initiates the heartbeat and converges on the response. The hub has
-// no network path to the vllm-d API server at all, so there is no "push" to
+// no network path to the heartbeat-only cluster's API server at all, so there is no "push" to
 // fix. A spoke-side repair therefore cannot hold — the hub must answer
 // correctly, and every spoke then converges on its own next beat with no
 // per-spoke editing. That is what makes this one change repair the whole set.
@@ -48,7 +48,7 @@ import (
 // Every rule here is expressed in terms of app_id and the hive's recorded host.
 // It deliberately does NOT key on api_url/base_url/app_slug string markers:
 // those are EMPTY on ~41 of ~50 fleet spokes (the healthy console hive on
-// hive-oke runs all three empty), so a marker-based rule is unreachable in
+// the hub-reachable cluster runs all three empty), so a marker-based rule is unreachable in
 // production while passing happily against hand-built fixtures. app_id is
 // always populated.
 
@@ -163,7 +163,7 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 	// FORGE IS PER-HIVE, NOT PER-CLUSTER. A CLAIMED hive that records no host
 	// defaults to PUBLIC github.com — the documented meaning of an empty
 	// github_host ("empty means public github.com", SaaSHive) — NOT to its
-	// cluster's forge. The vllm-d cluster hosts BOTH github.ibm.com projects
+	// cluster's forge. The heartbeat-only cluster hosts BOTH github.ibm.com projects
 	// (certus, EPM, …) AND github.com projects (ibm/alchemy-logging: the org
 	// "ibm" lives on public github.com). Inheriting the CLUSTER's GHE forge for
 	// a claimed hive that never recorded a GHE host is what force-flipped every
@@ -239,12 +239,12 @@ func ResolveHiveIdentity(h *SaaSHive, cluster *ClusterConfig) HiveIdentity {
 // ResolveHiveIdentityInFleet is ResolveHiveIdentity with a fleet-wide fallback
 // for the elected forge's App.
 //
-// A cluster entry has ONE identity slot today, so vllm-d — a GHE-default
+// A cluster entry has ONE identity slot today, so the heartbeat-only cluster — a GHE-default
 // cluster — names no public App at all. ResolveHiveIdentity therefore returns
 // forge=github.com with AppID=0 for torch-spyre: correct, and not yet useful,
 // because a repair needs an actual App to authenticate as.
 //
-// The fleet already knows that App: hive-oke names it, and appKeysByAppID
+// The fleet already knows that App: the hub-reachable cluster names it, and appKeysByAppID
 // indexes every App the hub holds a key for. A GitHub App ID is a per-forge
 // constant, not per-cluster state, so borrowing the public App for a hive that
 // elected public is correct by construction — it is the SAME App every other
@@ -404,7 +404,7 @@ func normalizeHiveForge(h *SaaSHive, cluster *ClusterConfig) bool {
 	// set. Removing the gate breaks no test today. It stays because it states
 	// the invariant that matters — never erase a hive's only record of its
 	// forge, which would drop it onto the cluster default and turn a public
-	// hive on vllm-d into a GHE one — and because a future change to
+	// hive on the heartbeat-only cluster into a GHE one — and because a future change to
 	// electedForgeForHive could make it reachable. Flagged rather than left
 	// looking verified.
 	if elected != "" {
@@ -430,7 +430,7 @@ func normalizeHiveForge(h *SaaSHive, cluster *ClusterConfig) bool {
 // fields: clusterDefaultForge said github.ibm.com while this said github.com.
 //
 // That split is the regression this whole file exists to prevent, reintroduced
-// one layer down. A vllm-d entry written as
+// one layer down. A heartbeat-only-cluster entry written as
 //
 //	{ "default_forge": "github.ibm.com",
 //	  "forges": { "github.ibm.com": { "app_id": 5686, "app_slug": "..." } } }
@@ -515,7 +515,7 @@ func defaultForgeIdentity(c *ClusterConfig, forge string) ClusterForgeIdentity {
 //
 // Today a cluster entry has ONE identity slot, so this can only answer for the
 // cluster's own forge. That is the honest state of clusters.json and the reason
-// a public election on the GHE-default vllm-d cluster still resolves to "no App
+// a public election on the GHE-default heartbeat-only cluster still resolves to "no App
 // named": the hub genuinely does not know one. Per-forge cluster entries are a
 // follow-up; isolating the lookup here means that change lands in one function
 // rather than across every caller.
@@ -529,7 +529,7 @@ func clusterAppForForge(c *ClusterConfig, forge string) (clusterAppIdentity, boo
 	// dual-forge one.
 	//
 	// Reading only the flat fields is what left this unable to answer for a
-	// hive that elected a forge its cluster does not default to: on vllm-d — a
+	// hive that elected a forge its cluster does not default to: on the heartbeat-only cluster — a
 	// GHE-default cluster hosting hives that elected github.com — it returned
 	// "no App", so the resolver produced app_id 0 and 26 hives stayed broken
 	// even with a public App named in `forges`.
@@ -585,7 +585,7 @@ func (i HiveIdentity) AppIDString() string {
 // assembled from every cluster's config.
 //
 // This is what lets a hive elect a forge its OWN cluster does not serve and
-// still be handed a real App: vllm-d names only the GHE App, but hive-oke names
+// still be handed a real App: the heartbeat-only cluster names only the GHE App, but the hub-reachable cluster names
 // the public one, and a github.com App is the same App everywhere.
 //
 // Deterministic on collision (two clusters naming different Apps on one forge):

--- a/src/pkg/hub/hub_generations_store.go
+++ b/src/pkg/hub/hub_generations_store.go
@@ -376,7 +376,7 @@ func (s *HubServer) fleetObservation() fleetObservationSummary {
 }
 
 // unreachableClusterSuffix renders cluster IDs for an operator-facing message.
-// Cluster IDs are non-secret registry identifiers (e.g. "vllm-d"); no key
+// Cluster IDs are non-secret registry identifiers (e.g. "heartbeat-only-cluster"); no key
 // material, hive name, or env value passes through here.
 func unreachableClusterSuffix(clusters []string) string {
 	if len(clusters) == 0 {
@@ -545,7 +545,7 @@ func (s *HubServer) rotateMasterSecret(now time.Time, force bool) (*generationSe
 	//
 	// F19 wires the derivation path to the live set, which means a rotation now
 	// actually reaches the fleet. F21 measured that 44 of the 70 hosted spokes
-	// sit on pull_only clusters (vllm-d, a-ks-wec2) that the reconcile sweep
+	// sit on pull_only clusters (the heartbeat-only cluster, a spoke cluster) that the reconcile sweep
 	// structurally cannot read or patch — by design, and that is not changing
 	// until the Option D wrapped-master delivery path lands. Those two facts
 	// together are dangerous in a way neither is alone: before F19 a rotation

--- a/src/pkg/hub/openrouter.go
+++ b/src/pkg/hub/openrouter.go
@@ -7,7 +7,7 @@ package hub
 // the hub. On return, the hub exchanges the code for a user-controlled OpenRouter
 // API key and delivers it to the target hive as a model gateway named
 // "openrouter" via the heartbeat channel (the only channel that reaches
-// firewalled/heartbeat-only spokes like vllm-d uniformly). The spoke stores the
+// firewalled/heartbeat-only spokes like the heartbeat-only cluster uniformly). The spoke stores the
 // key in its OWN per-gateway secret-file store — the hub never persists the key.
 //
 // SECURITY:

--- a/src/pkg/hub/pullonly_upgrade.go
+++ b/src/pkg/hub/pullonly_upgrade.go
@@ -61,7 +61,7 @@ import (
 //
 // The gate below is therefore keyed on heartbeat history, which is the correct
 // predicate on EVERY cluster: a hive that cannot collect an instruction must not
-// be handed one, whether it sits on hive-oke or vllm-d.
+// be handed one, whether it sits on the hub-reachable cluster or the heartbeat-only cluster.
 
 // PUSH-PATH RETIREMENT: WHAT THIS PR DOES AND DOES NOT MAKE DROPPABLE.
 //
@@ -75,7 +75,7 @@ import (
 //
 //  1. NODE STATS (saas.go ~2000: `kubectl get nodes -o json`, ~1993 `top nodes`,
 //     ~2126 node summary). The heartbeat fallback beside it fires only when the
-//     kubectl query ERRORS or times out — on a reachable cluster like hive-oke
+//     kubectl query ERRORS or times out — on a reachable cluster like the hub-reachable cluster
 //     the kubectl path succeeds, so the spoke is never asked. Drop the
 //     kubeconfig and this does not fail over; it just stops reporting.
 //
@@ -83,12 +83,12 @@ import (
 //     but cannot currently answer on either cluster:
 //       - it requires the metrics API FIRST and returns nil if that fails
 //         (cluster_metrics.go ~59), and nodes.metrics.k8s.io is not granted to
-//         hive-sa on hive-oke OR vllm-d;
+//         hive-sa on the hub-reachable cluster OR the heartbeat-only cluster;
 //       - it is gated on HIVE_CLUSTER_ID (cmd/hive/main.go ~3310), which
 //         provisioning does not emit;
 //       - node-read RBAC is not in the provisioning template (saas_provision.go)
-//         at all — where it exists on vllm-d it was granted out-of-band.
-//     Verified live 2026-08-14: on hive-oke, `auth can-i list nodes` and
+//         at all — where it exists on the heartbeat-only cluster it was granted out-of-band.
+//     Verified live 2026-08-14: on the hub-reachable cluster, `auth can-i list nodes` and
 //     `list nodes.metrics.k8s.io` as the spoke's hive-sa are both "no".
 //
 //  2. PROVISIONING itself (saas_provision.go) creates namespaces, Deployments

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -1471,8 +1471,8 @@ func clusterIDForSaaSHive(sh SaaSHive) string {
 // ensureClusterIDForClaim stamps a non-blank cluster_id onto a hive that is
 // about to be persisted by a claim/assign. This is the data-integrity guard
 // for the observed bug where CLAIMED hives lost cluster_id in their meta.json
-// and then fell back to defaultClusterID (hive-oke) in clusterForHive — which
-// mis-routed App/host resolution for hives that actually run on vllm-d.
+// and then fell back to defaultClusterID (the hub-reachable cluster) in clusterForHive — which
+// mis-routed App/host resolution for hives that actually run on the heartbeat-only cluster.
 //
 // Precedence, most-trusted first:
 //  1. The hive's OWN non-blank ClusterID (the placeholder already belongs to a
@@ -3306,7 +3306,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 
 	hiveID := generateHiveID(req.Org, primaryRepo)
 
-	// Determine which cluster to provision on. Default to hive-oke if unspecified.
+	// Determine which cluster to provision on. Default to the hub-reachable cluster if unspecified.
 	clusterID := req.ClusterID
 	if clusterID == "" {
 		clusterID = defaultClusterID
@@ -3416,7 +3416,7 @@ func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
 // authorized_users allowlist before minting a session (see dashboard.handleSSO).
 //
 // If SSO can't be used (no hub secret, or the spoke reported no dashboard URL),
-// it falls back to redirecting straight to the dashboard URL (or the hive-oke
+// it falls back to redirecting straight to the dashboard URL (or the hub-reachable-cluster
 // host), preserving today's behavior — the spoke will then prompt for login.
 func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
@@ -3446,7 +3446,7 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve the spoke's base URL: prefer the heartbeat-reported dashboard URL
-	// (correct for firewalled spokes), fall back to the hive-oke host pattern.
+	// (correct for firewalled spokes), fall back to the hub-reachable-cluster host pattern.
 	base := ""
 	s.mu.RLock()
 	for i := range s.registry.Hives {
@@ -4088,8 +4088,8 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		// The hub can't reach this hive's cluster over kubectl (e.g. vllm-d
-		// from the hive-oke hub). Fall back to the heartbeat path: record the
+		// The hub can't reach this hive's cluster over kubectl (e.g. the heartbeat-only cluster
+		// from the hub-reachable-cluster hub). Fall back to the heartbeat path: record the
 		// target tag; the spoke — which has in-cluster RBAC (hive-self-upgrade
 		// role) to patch its own deployment — applies it on its next
 		// heartbeat. This is the ONLY path that works for unreachable
@@ -6923,7 +6923,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 
 	// Approving now ASSIGNS an available placeholder instead of just bumping
 	// quota for a manual provision. Pick the pool from the request's auth_method
-	// (private → vllm-d/GPU pool, otherwise → hive-oke/public pool). If no
+	// (private → the heartbeat-only cluster / GPU pool, otherwise → the hub-reachable cluster / public pool). If no
 	// placeholder is available in that pool, tell the admin to provision more.
 	pool := poolClusterForAuthMethod(pr.AuthMethod)
 	hiveID := strings.TrimSpace(approveBody.HiveID)
@@ -7007,7 +7007,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	h.Error = ""
 	// Preserve the placeholder's real cluster before ANY cluster-derived
 	// resolution below (host backfill uses s.clusterForHive(h), which silently
-	// returns hive-oke when ClusterID is blank). The placeholder was picked
+	// returns the hub-reachable cluster when ClusterID is blank). The placeholder was picked
 	// from `pool`, so a blank cluster_id here can only mean the placeholder was
 	// created without one — stamp the pool it came from rather than leaving a
 	// blank that later resolves to the wrong (default) cluster's App/host.
@@ -7088,7 +7088,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	// user record for Hives[hiveID], NOT from h.Owner. Without this the
 	// assignment set h.Owner correctly but the new owner never appeared under
 	// Manage Access — only the admin who provisioned the placeholder did — and
-	// on a heartbeat-only cluster (vllm-d) that stale list is what gets
+	// on a heartbeat-only cluster (the heartbeat-only cluster) that stale list is what gets
 	// delivered to the spoke.
 	user := loadSaaSUser(targetUsername)
 	if user == nil {
@@ -7171,13 +7171,13 @@ func (s *HubServer) handleDenyProvision(w http.ResponseWriter, r *http.Request) 
 }
 
 // authMethodPrivate is the request auth_method value that routes a provision
-// request to the private/GPU placeholder pool (vllm-d). Any other value (the
-// default) routes to the public pool (hive-oke).
+// request to the private/GPU placeholder pool (the heartbeat-only cluster). Any other value (the
+// default) routes to the public pool (the hub-reachable cluster).
 const authMethodPrivate = "private"
 
 // poolClusterForAuthMethod maps a provision request's auth_method to the
 // placeholder pool it should draw from: private methods → the GPU pool
-// (vllm-d, heartbeat-only); everything else → the public pool (hive-oke).
+// (the heartbeat-only cluster); everything else → the public pool (the hub-reachable cluster).
 func poolClusterForAuthMethod(authMethod string) string {
 	if strings.EqualFold(authMethod, authMethodPrivate) || strings.EqualFold(authMethod, gpuClusterID) {
 		return gpuClusterID
@@ -7186,7 +7186,7 @@ func poolClusterForAuthMethod(authMethod string) string {
 }
 
 // clusterIDForHive returns the effective cluster ID of a SaaS hive, treating an
-// empty cluster_id as the default (hive-oke) — matching clusterForHive's own
+// empty cluster_id as the default (the hub-reachable cluster) — matching clusterForHive's own
 // fallback so pool matching agrees with cluster resolution.
 func clusterIDForHive(h *SaaSHive) string {
 	if h.ClusterID == "" {
@@ -7423,7 +7423,7 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 //   - Claimed hive with a non-empty meta VanityURL: return it. A vanity URL is
 //     only non-empty because it was VALIDATED as servable at provision/assign
 //     time (addVanityHostToIngress succeeded, or a cluster wildcard/OpenShift
-//     route already serves it, e.g. vllm-d's hosted-...apps.fmaas-vllm-d... host).
+//     route already serves it, e.g. the heartbeat-only cluster's hosted OpenShift-route host).
 //     Trusting it here means the hub shows/links the friendly host the instant a
 //     hive is claimed, instead of waiting for the spoke to adopt+report it back.
 //   - Claimed hive with an empty VanityURL: "" — never mint an unvalidated host
@@ -7494,7 +7494,7 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		// (org/repos/ACMM) alone; reconciling from a stale record wiped/downgraded
 		// live hives. BUT the vanity URL is independent of project completeness: a
 		// claimed hive can carry a validated meta vanity_url (set at provision,
-		// e.g. vllmd-10's hosted-...apps.fmaas-vllm-d... route) while its meta's
+		// e.g. a hive's hosted OpenShift-route on the heartbeat-only cluster) while its meta's
 		// org/repos/ACMM are still stale/empty. Without pushing it, the spoke never
 		// adopts the vanity URL and the hub keeps showing the raw placeholder host
 		// forever (the placeholder-URL-persists bug). Push the URL alone — never
@@ -7567,7 +7567,7 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	// the retroactive repair, or an admin editing the host later — has
 	// ClaimDelivered == true and a matching vanity URL, so every gate above is
 	// false and the reconcile returns nil forever. The spoke would then keep
-	// talking to api.github.com against a GitHub Enterprise org (the vllm-d /
+	// talking to api.github.com against a GitHub Enterprise org (the heartbeat-only cluster /
 	// hosted-available-vllmd-01 failure). Push whenever we have a GHE API URL
 	// to deliver and the spoke reports a DIFFERENT one.
 	//
@@ -7597,7 +7597,7 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	// ("invalid repo name"), /api/livez then fails on the stale heartbeat, and
 	// the kubelet restarts the pod in a loop. Normalizing here repairs an
 	// already-broken hive over the heartbeat, which is the only channel that
-	// reaches a firewalled cluster (vllm-d).
+	// reaches a firewalled cluster (the heartbeat-only cluster).
 	pushRepos := make([]string, 0, len(h.Repos))
 	for _, r := range h.Repos {
 		if rr := sanitizeRepoEntry(r); rr != "" {
@@ -7688,8 +7688,8 @@ type AssignHiveRequest struct {
 // (admin-only). It rewrites the hive's meta.json to the real project and clears
 // its "available" status, then delivers the new project config — and any GitHub
 // App creds — to the spoke via the heartbeat response. This works uniformly for
-// both reachable (hive-oke) and heartbeat-only (vllm-d) clusters: NO hub→spoke
-// push or kubectl is used, so a vllm-d claim is delivered entirely by heartbeat.
+// both reachable (the hub-reachable cluster) and heartbeat-only (the heartbeat-only cluster) clusters: NO hub→spoke
+// push or kubectl is used, so a heartbeat-only-cluster claim is delivered entirely by heartbeat.
 func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	if !isHubAdmin(s.getAuthUser(r)) {
 		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
@@ -7728,7 +7728,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// ("github.ibm.com") and no org — clear body.Org in that case so the
 	// isValidName check below rejects it, instead of the raw hostname (which
 	// isValidName accepts, dots and all) silently becoming the org. That
-	// host-as-org bug produced the two broken github.ibm.com claims on vllm-d.
+	// host-as-org bug produced the two broken github.ibm.com claims on the heartbeat-only cluster.
 	if h, o := normalizeOrgRef(body.Org); h != "" {
 		body.Org = o // may be "" for a bare-host paste — rejected just below
 		if body.GitHubHost == "" {
@@ -7821,10 +7821,10 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	h.Owner = body.Owner
 	h.Org = body.Org
 	// Preserve the placeholder's real cluster before the host backfill below,
-	// which resolves via s.clusterForHive(h) and would fall back to hive-oke on
+	// which resolves via s.clusterForHive(h) and would fall back to the hub-reachable cluster on
 	// a blank cluster_id. The admin assigns a specific placeholder, so its own
 	// ClusterID is authoritative; only a placeholder created without one lands
-	// on the default here (never a silent blank that mis-routes to hive-oke).
+	// on the default here (never a silent blank that mis-routes to the hub-reachable cluster).
 	s.ensureClusterIDForClaim(h, "")
 	// Record the GHE host (if any) so the heartbeat can point this spoke at the
 	// right GitHub API. Never blank an existing value with an empty one.
@@ -7851,7 +7851,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// nothing else ever fills it in: projectConfigForHiveID pushes
 	// gheAPIURLForHost(h.GitHubHost), which is empty for those hives, so the
 	// spoke keeps api.github.com and the public app_id even though the cluster
-	// is a GHE cluster (observed on vllm-d: hosted-available-vllmd-01 has
+	// is a GHE cluster (observed on the heartbeat-only cluster: hosted-available-vllmd-01 has
 	// base_url: "" / api_url: "" against a github.ibm.com cluster). The hive's
 	// own value always wins; this only fills a blank.
 	if host := backfillGitHubHostFromCluster(h, s.clusterForHive(h)); host != "" {
@@ -7885,7 +7885,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// cluster) between this save and the HTTP response, which held the admin's
 	// assign dialog hostage for ~a minute whenever the cluster was slow or
 	// unreachable (each kubectl call eats a ~45s TCP dial timeout on the
-	// heartbeat-only vllm-d pool — the same disease #2730 cured on the
+	// heartbeat-only cluster pool — the same disease #2730 cured on the
 	// heartbeat path). The mint — same host preference (name-bearing Option B
 	// host, org/repo fallback), same servability seam, same "never adopt an
 	// unservable host" rule — now runs in the background via
@@ -7902,7 +7902,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// list by scanning every user record for Hives[hiveID], NOT from h.Owner —
 	// so without this the assignment set h.Owner correctly while Manage Access
 	// still showed only the admin who provisioned the placeholder. On a
-	// heartbeat-only cluster (vllm-d) that stale list is what reaches the spoke.
+	// heartbeat-only cluster (the heartbeat-only cluster) that stale list is what reaches the spoke.
 	assignee := loadSaaSUser(body.Owner)
 	if assignee == nil {
 		assignee = ensureSaaSUser(body.Owner)
@@ -7922,7 +7922,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// webhook path uses — storePendingGitHubAppConfig queues them for the next
 	// heartbeat response (consumePendingGitHubAppConfig in handleHeartbeat). We
 	// deliberately do NOT call pushGitHubConfigToSpoke here: it requires a
-	// reachable dashboardURL and would fail for vllm-d. The heartbeat path
+	// reachable dashboardURL and would fail for the heartbeat-only cluster. The heartbeat path
 	// covers both clusters uniformly.
 	appDelivered := false
 	if body.AppID != "" && body.InstallationID != "" && strings.TrimSpace(body.AppPrivateKey) != "" {
@@ -7978,7 +7978,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// The project config itself is delivered by handleHeartbeat via
 	// projectConfigForHiveID on the next beat — it keeps sending until the spoke
 	// reports the matching project. No hub→spoke push or kubectl is needed, so
-	// this works for the heartbeat-only vllm-d pool as well as hive-oke.
+	// this works for the heartbeat-only cluster pool as well as the hub-reachable cluster.
 
 	s.logger.Info("audit: placeholder hive assigned",
 		"hive_id", hiveID,
@@ -13385,7 +13385,7 @@ const dashboardHTML = `<!DOCTYPE html>
           // EVERYONE on a public hive, regardless of access status. Use the
           // hive's heartbeat-reported dashboard URL (resolvedBase), NOT a
           // hardcoded <id>.hive.kubestellar.io host. Firewalled spokes (e.g.
-          // vllm-d on *.apps.fmaas-vllm-d.fmaas.res.ibm.com) live on a different
+          // the heartbeat-only cluster on its OpenShift-route domain) live on a different
           // domain, so the hardcoded host 503'd/failed to resolve.
           var cBase = resolvedBase(h);
           var contributeAction = cBase
@@ -17215,8 +17215,8 @@ const dashboardHTML = `<!DOCTYPE html>
             var regEntry = (_hiveRegistry || []).find(function(h) { return h.id === hid; });
             var hiveName = regEntry ? (regEntry.name || hid) : hid;
             // Prefer the hive's heartbeat-reported dashboard URL so firewalled
-            // spokes (vllm-d etc.) link to their real route, not a dead
-            // <id>.hive.kubestellar.io host. Fall back to the hive-oke pattern.
+            // spokes (the heartbeat-only cluster etc.) link to their real route, not a dead
+            // <id>.hive.kubestellar.io host. Fall back to the hub-reachable-cluster pattern.
             var linkBase = (regEntry && regEntry.dashboardUrl && !regEntry.dashboardUrl.includes('localhost'))
               ? regEntry.dashboardUrl : (isHosted ? 'https://' + esc(hid) + '.hive.kubestellar.io' : '');
             var linkLabel = linkBase.replace(/^https?:\/\//, '');

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -230,12 +230,12 @@ type ClusterConfig struct {
 	// fields above give a cluster exactly ONE identity slot, which made a
 	// cluster's forge a PIN rather than a DEFAULT. On 2026-07-31 that cost seven
 	// hives their identity: adding github_app_slug: kubestellar-hive-ghe to the
-	// vllm-d entry handed a GHE App to every public-GitHub hive on the cluster,
+	// the heartbeat-only cluster's entry handed a GHE App to every public-GitHub hive on the cluster,
 	// because there was nowhere else for a public identity to live. Those hives
 	// had already ELECTED github.com in their meta.json github_host — the hub
 	// knew the right answer and had no field in which to act on it.
 	//
-	// Per the platform owner: "vllm-d is used for GHE, but gh can be elected."
+	// Per the platform owner: "the heartbeat-only cluster is used for GHE, but gh can be elected."
 	// A cluster's forge is a DEFAULT with per-hive election. This map is what
 	// makes a public election on a GHE-default cluster RESOLVABLE instead of
 	// 409-ing as "incomplete".
@@ -414,17 +414,17 @@ func readSAToken() string {
 
 // loadClusters reads the clusters config file and returns a validated
 // map of cluster ID → ClusterConfig. If the file does not exist, it
-// returns a single default entry for hive-oke (backward compatibility).
+// returns a single default entry for the hub-reachable cluster (backward compatibility).
 //
 // AUDIT 8 / §6 ITEM 11. This used to return an EMPTY map when the file existed
 // but did not parse. That is the most dangerous of the three possible answers:
 // clusterForHive falls through both its lookups on an empty registry and
 // returns nil for EVERY hive, so a truncated or hand-mangled file silently
-// disabled the hub's writes to hive-oke — the one cluster it can reach — while
+// disabled the hub's writes to the hub-reachable cluster — the one cluster it can reach — while
 // the hub came up otherwise healthy. The registry now fails CLOSED: see
 // loadClustersChecked and clustersLoadOutcome in clusters_registry.go.
 //
-// The ABSENT case is unchanged and still returns the hive-oke default; a hub
+// The ABSENT case is unchanged and still returns the hub-reachable-cluster default; a hub
 // that was never given a registry has not lost one.
 func loadClusters(logger *slog.Logger) map[string]ClusterConfig {
 	clusters, outcome := loadClustersChecked(logger)
@@ -433,7 +433,7 @@ func loadClusters(logger *slog.Logger) map[string]ClusterConfig {
 		//
 		// WHY FATAL RATHER THAN A DEGRADED START. NewHubServer returns no error,
 		// so the only alternatives available here are the two this fix exists to
-		// remove: come up with an empty registry (writes to hive-oke silently
+		// remove: come up with an empty registry (writes to the hub-reachable cluster silently
 		// off) or come up on the synthesized default (every pull-only hive
 		// silently re-routed to the hub's own cluster). Both present as a
 		// healthy hub. A hub that refuses to start is loud, is caught by the
@@ -805,7 +805,7 @@ func resolveProvisionAppID(reqAppID string, h *SaaSHive, cluster *ClusterConfig)
 // projectConfigForHiveID pushes gheAPIURLForHost("") == "" on every heartbeat
 // — which the spoke reads as "leave mine alone". The result is a hive on a GHE
 // cluster still pointing at api.github.com with the public app_id (observed on
-// vllm-d: hosted-available-vllmd-01 in org "katamari" has base_url: "",
+// the heartbeat-only cluster: a hosted-available hive in org "katamari" has base_url: "",
 // api_url: "", app_id: 3568013 against a github.ibm.com cluster).
 //
 // This only ever fills a blank: a hive that already carries a host — including
@@ -848,10 +848,10 @@ func backfillGitHubHostFromCluster(h *SaaSHive, cluster *ClusterConfig) string {
 // (rewrote a blank-or-public github_host to the cluster's GHE host whenever the
 // spoke reported the public forge). Both are gone, on purpose.
 //
-// A cluster hosts hives of BOTH forges: vllm-d carries github.ibm.com projects
+// A cluster hosts hives of BOTH forges: the heartbeat-only cluster carries github.ibm.com projects
 // (certus, EPM, …) beside github.com projects (ibm/alchemy-logging — the org
 // "ibm" lives on public github.com). At 23:56Z on 2026-08-05, minutes after the
-// cluster-keyed guard shipped, it rewrote github_host on every vllm-d hive whose
+// cluster-keyed guard shipped, it rewrote github_host on every heartbeat-only-cluster hive whose
 // spoke reported the public App — github.com projects included — and the
 // delivery that followed flipped their spokes onto app 5686 / github.ibm.com,
 // degrading 9 of them with "404 Not Found" on every token mint. Cluster
@@ -1169,7 +1169,7 @@ const gitHubAppStillRequiredNote = "github_host repaired; a hive still carrying 
 // never on the request path: the kubectl calls below can hang for minutes
 // against an unreachable cluster, and a heartbeat response delayed past the
 // spoke's 10s client timeout is a response the spoke never sees (which is how
-// claim delivery to vllm-d silently broke). The guards below still return
+// claim delivery to the heartbeat-only cluster silently broke). The guards below still return
 // before any network call or write in the overwhelmingly common no-op case.
 func (s *HubServer) repairVanityURLForHive(hiveID string) bool {
 	h := loadSaaSHive(hiveID)
@@ -1319,7 +1319,7 @@ func (s *HubServer) reconcileStaleVanityURL(hiveID string, h *SaaSHive, cluster 
 // It exists because the repair is only cheap on its NO-OP paths. When it
 // actually has work to do it shells out to kubectl against the hive's cluster
 // (existingVanityHost, then addVanityHostToIngress), and against a cluster the
-// hub cannot reach — vllm-d is heartbeat-only — those calls hang until their
+// hub cannot reach — the heartbeat-only cluster is heartbeat-only — those calls hang until their
 // TCP dials time out: ~90 seconds per attempt observed live. Called
 // synchronously from handleHeartbeat, that stall pushed every heartbeat
 // response past the spoke's 10s client timeout (heartbeatTimeout), so the
@@ -1370,7 +1370,7 @@ func (s *HubServer) kickVanityURLRepairAsync(hiveID string) {
 // handleAssignHive and handleApproveProvision used to run this work
 // SYNCHRONOUSLY between persisting the assignment and writing the HTTP
 // response. Every call shells out to kubectl against the hive's cluster, and
-// against a cluster the hub cannot reach — vllm-d is heartbeat-only — those
+// against a cluster the hub cannot reach — the heartbeat-only cluster is heartbeat-only — those
 // calls hang until their TCP dials time out (~45s each, ~90s observed for the
 // vanity mint alone), so the admin's assign dialog sat on a pending fetch for
 // about a minute. Nothing here is needed for the response semantics: the claim
@@ -1421,7 +1421,7 @@ func (s *HubServer) kickClaimClusterWorkAsync(hiveID string) {
 // host built from the hive's display name (Option B — see
 // hosted_namespace_identity.go), fall back to the org/repo-derived host, make
 // it servable through the same seam as the retroactive repair, and only adopt
-// a host that IS servable (the vllm-d 503 rule). On failure VanityURL stays
+// a host that IS servable (the heartbeat-only-cluster 503 rule). On failure VanityURL stays
 // empty, every read path keeps the working placeholder host, and the
 // heartbeat-kicked repair retries later — exactly as before.
 //
@@ -1447,7 +1447,7 @@ func (s *HubServer) mintClaimVanityURL(hiveID string) {
 		// Do NOT adopt a host we could not make servable — leaving VanityURL
 		// empty makes every read path fall back to the working placeholder
 		// host, and the heartbeat repair re-attempts adoption once a route
-		// exists (the cluster-wildcard/vllm-d case included).
+		// exists (the cluster-wildcard / heartbeat-only-cluster case included).
 		s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
 			"keeping the working placeholder host; the heartbeat repair will retry",
 			"hive", hiveID, "host", vanityHost, "cluster", cluster.ID, "error", err)
@@ -2460,7 +2460,7 @@ data:
           git_sync: false
     dashboard:
       port: {{.DashboardPort}}
-      # hub_proxied is true ONLY on the nginx-ingress path (hive-oke), where the
+      # hub_proxied is true ONLY on the nginx-ingress path (the hub-reachable cluster), where the
       # hub's auth-proxy (see the auth-url/auth-signin/auth-response-headers
       # annotations below) authenticates every request and injects trusted
       # X-Hive-User/X-Hive-Role headers. That keeps the hive from flipping into
@@ -2468,7 +2468,7 @@ data:
       # (which would strip those headers and disable the shared token, breaking
       # the dashboard link and the snapshot preview).
       #
-      # On the OpenShift-Route path (vllm-d) there is NO nginx auth-proxy — the
+      # On the OpenShift-Route path (the heartbeat-only cluster) there is NO nginx auth-proxy — the
       # hive is reached directly — so it stays hub_proxied:false and correctly
       # enforces per-user device-flow authz itself from authorized_users.
       hub_proxied: {{.IsNginxIngress}}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -907,9 +907,9 @@ type HubServer struct {
 	heartbeatUpgrade map[string]string
 
 	// clusterUnreachableUntil suppresses kubectl against clusters the hub has
-	// just proven it cannot route to (firewalled GPU clusters like vllm-d).
+	// just proven it cannot route to (firewalled GPU clusters like the heartbeat-only cluster).
 	// Without this, triggerAutoUpgrades() paid a full dial timeout PER HIVE PER
-	// CYCLE — 15 vllm-d hives serialized into ~30 minutes of blocking, which
+	// CYCLE — 15 heartbeat-only-cluster hives serialized into ~30 minutes of blocking, which
 	// starved the hub's own auto-upgrade check at the end of the same loop and
 	// left the hub pinned to an old SHA indefinitely. Key: cluster ID, value:
 	// the time after which kubectl may be retried.
@@ -2088,7 +2088,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// assigned a pre-provisioned placeholder reconciles its running project
 	// config. Mirrors AuthorizedUsers: the hub keeps sending it every beat
 	// until the spoke reports the matching project. This is the ONLY channel
-	// that reaches heartbeat-only clusters (vllm-d) — the hub cannot push
+	// that reaches heartbeat-only clusters (the heartbeat-only cluster) — the hub cannot push
 	// config there over kubectl. A nil return means "spoke already matches, or
 	// no SaaS record / still a placeholder" — send nothing.
 	// Org/repos/primary_repo/ACMM are operator-controlled on the spoke dashboard
@@ -2103,7 +2103,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// (empty = public github.com), never from its cluster's default — a cluster
 	// hosts hives of both forges. The per-beat blank-fill-from-cluster and the
 	// cluster-keyed "GHE guard" that used to run here are gone: on 2026-08-05
-	// the guard rewrote github_host on every vllm-d hive whose spoke reported
+	// the guard rewrote github_host on every heartbeat-only-cluster hive whose spoke reported
 	// the public App — github.com projects included — and 9 spokes were flipped
 	// onto an App that 404'd every token mint.
 	//
@@ -2136,7 +2136,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	//
 	// ASYNC, deliberately. The repair shells out to kubectl against the hive's
 	// cluster (existingVanityHost, then addVanityHostToIngress), and on a
-	// cluster the hub cannot reach (vllm-d is heartbeat-only/firewalled) each
+	// cluster the hub cannot reach (the heartbeat-only cluster is heartbeat-only/firewalled) each
 	// call blocks until its TCP dial times out — ~90s per beat observed live.
 	// The spoke's heartbeat client gives up after heartbeatTimeout (10s), so
 	// running the repair synchronously here meant EVERY response built below —

--- a/src/pkg/hub/sso.go
+++ b/src/pkg/hub/sso.go
@@ -12,7 +12,7 @@ import (
 
 // SSO handoff: the hub mints a short-lived, ASYMMETRICALLY-signed token that lets
 // an already-hub-authenticated admin/user open a direct-route spoke (e.g. a
-// firewalled vllm-d hive) WITHOUT a second GitHub device-flow login. The hub signs
+// firewalled heartbeat-only-cluster hive) WITHOUT a second GitHub device-flow login. The hub signs
 // the token with an Ed25519 PRIVATE key that never leaves the hub; the spoke
 // verifies it with only the corresponding PUBLIC key. The spoke confirms the
 // carried user is in its authorized_users allowlist and mints a local session.

--- a/src/pkg/hub/static/index.html
+++ b/src/pkg/hub/static/index.html
@@ -1222,11 +1222,11 @@
 
     // contributeBase returns the spoke's real base URL for building /contribute
     // links. Prefers the heartbeat-reported dashboardUrl (correct for firewalled
-    // spokes like vllm-d, which live on a different domain), and falls back to
-    // the hive-oke host pattern only when no dashboardUrl was reported. Accepts
+    // spokes like the heartbeat-only cluster, which live on a different domain), and falls back to
+    // the hub-reachable-cluster host pattern only when no dashboardUrl was reported. Accepts
     // either a hive object or a hive id (looked up in _allMainHives). Previously
     // these links hardcoded <id>.hive.kubestellar.io, which was a dead host for
-    // every non-hive-oke spoke.
+    // every non-hub-reachable-cluster spoke.
     function contributeBase(hiveOrId) {
       var h = (typeof hiveOrId === 'string')
         ? (_allMainHives || []).find(function(x) { return x.id === hiveOrId; })

--- a/src/pkg/hub/url_reachability.go
+++ b/src/pkg/hub/url_reachability.go
@@ -46,7 +46,7 @@ const (
 
 	// urlClusterOutageRatio is the share of a cluster's probed hives that must
 	// fail before the failures are treated as a single cluster-wide outage
-	// instead of per-hive breakage. vllm-d has been intermittently unreachable
+	// instead of per-hive breakage. the heartbeat-only cluster has been intermittently unreachable
 	// from the hub, and a partition there must not raise 30 separate alerts.
 	urlClusterOutageRatio = 0.5
 
@@ -79,7 +79,7 @@ const (
 //   - 30x: redirected to login. The hub's own spokes do this, so it is the
 //     single most common healthy answer and must never read as a failure.
 //   - 401/403: an authenticated endpoint refusing an anonymous caller. This is
-//     what every vllm-d spoke returns via its OAuth proxy — healthy.
+//     what every heartbeat-only-cluster spoke returns via its OAuth proxy — healthy.
 //
 // Anything else (5xx, 404, and any transport error) is a failure.
 func urlHealthyStatus(status int) bool {

--- a/src/scripts/check-suid-contract.sh
+++ b/src/scripts/check-suid-contract.sh
@@ -134,7 +134,7 @@ check "dev is a member of hive-launch" \
 # The hive process needs CAP_NET_ADMIN in its EFFECTIVE set so the MITM proxy can
 # stamp SO_MARK on its own upstream dials and be exempted from the forced-egress
 # iptables REDIRECT (on OpenShift/OVN, where xt_owner is absent, SO_MARK is the
-# ONLY exemption that works — refs #2674/#2678, observed live on vllm-d).
+# ONLY exemption that works — refs #2674/#2678, observed live on the heartbeat-only cluster).
 #
 # It USED to carry this as a FILE capability (setcap cap_net_admin+ep). That is
 # now FORBIDDEN: the kernel refuses execve of a file-capped binary whenever the


### PR DESCRIPTION
## Summary

Scrubs the private cluster/host names `vllm-d`, `hive-oke`, and `a-ks-wec2` from **source-file comments** (Go/`//`, shell/YAML/`#`, block `*`, and inline `//` inside embedded HTML/JS). These leaked internal infra topology to anyone browsing the repo (including external overlay authors who reference the inference base).

**Replacements** (role-based, generic):
- `vllm-d` → "the heartbeat-only cluster"
- `hive-oke` → "the hub-reachable cluster"
- `a-ks-wec2` → "a spoke cluster"

The **engineering meaning of every comment is preserved** — App-key pinning, pull-only reconcile, MARK-only `SO_MARK` exemption, heartbeat-only vs hub-proxied routing, GHE-default resolution, etc. Only the private *name* was swapped. A couple of comments that embedded the internal FQDN example (`hosted-...apps.fmaas-vllm-d...`) were genericized to "hosted OpenShift-route" so no `fmaas-vllm-d.fmaas.res.ibm.com` fragment is left behind.

## Scope

- **Comment lines only**, across 26 files: **127 lines** changed (127 insertions / 127 deletions — pure 1-for-1, no structural change).
- Plus the `inference/` area: the one real comment hit is `hive-epp-rbac.yaml` line 4. (The `README.md`/`kustomization.yaml` `vllm-d` grep hits are the `vllm-deployment.yaml` filename, not the cluster — left as-is.)

## Deliberately KEPT (would break things if renamed)

1. **Functional `deploy_vllm_d` / `deploy-vllm-d` / `vLLM-d` dashboard stat-key** — wired to a real GitHub Actions job (`src/pkg/github/health.go`, `status_builder.go`, `dashboard/api.go` data field, `dashboard/static/index.html`, `deploy/data/agents/*/stats.json`). Renaming breaks the health tile.
2. **Cluster-ID DATA in non-comment code** — `const defaultClusterID`/`gpuClusterID` in `saas_provision.go`, the `clusterBadge` JS in `saas.go`, the `webhook.go` fallback assignments, and the `clusters_registry.go` log string.
3. **All `*_test.go` fixtures** — `ClusterID: "vllm-d"` etc. are assertion data. Zero test files touched.
4. **`vllm-deployment.yaml` / `vllm` backend names** in `inference/README.md` + `kustomization.yaml` — the real vllm example deployment, not the private cluster.

## Verification

- `git diff --name-only | grep _test.go` → empty ✅
- Literal `deploy_vllm_d|deploy-vllm-d|vLLM-d` in diff → empty ✅
- Every one of the 254 diff lines is a comment ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)