### PR TITLE
feat(reach): error-rate deltas per deploy window + hub status reach table (#3995)

### DIFF
--- a/src/docs/design/pr-reach-telemetry.md
+++ b/src/docs/design/pr-reach-telemetry.md
@@ -99,14 +99,41 @@ per hive on the registry entry. Storage only: no endpoint, no mapping, no UI
 until #3994. The entry keys `component` / `commit` / `spans_total` /
 `spans_error` / `first_seen` / `last_seen` are 2b's fixed read interface.
 
-## What phase 2+ needs (deferred)
+Phase 2b implementation (#3994): the D3 mapping with the honest
+`unattributable` bucket (both path eras — `src/...` primary, `v2/...` legacy
+aliases, because merged-PR file lists are immutable), the ancestry join
+(compare-API adapter by default, real git via `HIVE_REACH_REPO_DIR`), D4
+deploy windows derived from commits hives REPORT RUNNING, first-execution
+latency, the never-ran flag, and `GET /api/reach` behind `requireAdmin`.
 
-- **Error-rate deltas pre/post merge**: compare span error status rates for a
-  component across the commit boundary that introduced a PR. Needs span status
-  discipline (`span.SetStatus` on failure paths) audited per component first.
-- **First-execution latency**: time from merge → first span carrying a
-  `hive.commit` that contains the PR. Needs a merge-SHA → containing-build
-  index (the hub already stores per-spoke `GitHash`; join there).
+Phase 2c implementation (#3995, final): error-rate deltas per deploy window,
+plus the reach table on the hub's /dashboard status surface. The hub keeps
+only each hive's LATEST report, so 2c adds bounded retention: on heartbeat
+receive, the report's rolling `window_1h` bucket (equivalent-period windows —
+cumulative-since-boot counts would compare unequal periods) folds into a
+fleet-level per-component ring of hourly buckets, summed per (hour, component,
+running commit) — 168 windows (7 days) per component, a fleet-level component
+cap, per-bucket commit fan-out cap, oldest-first eviction, over-cap input
+clipped AND logged. A per-(component, hive) cursor dedupes re-reports of the
+same rolling window (heartbeats beat faster than windows roll). Persisted in
+its own file, `/data/reach-history.json`, atomic writes on a dirty-gated
+cadence, re-bounded on load. The delta per (component, deploy-window): error
+ratio in windows AFTER the deployed commit first appears (that commit's spans
+only, so staggered-rollout old-binary traffic never dilutes it) vs an EQUAL
+count of windows immediately BEFORE (the whole old regime); `measured=false`
+whenever either side lacks data — on a fleet that auto-converges in ~a minute,
+a commit older than the retained history legitimately reads unmeasured, and
+that must never be rendered as a zero delta. Known limitation, accepted: the
+windows are fleet sums, so one high-volume spoke can skew a window's ratio.
+
+## Deferred beyond the epic
+
+- **Advisor wiring**: reach-derived advisor inputs (e.g. a NeverRanFraction
+  with the `(value, measured)` shape) need a data path from the hub's fleet
+  store to the spoke-side advisor (`buildACMMStatusInputs`), which does not
+  exist — the spoke cannot see fleet reach, and fabricating an always-
+  unmeasured field helps nobody. Follow-up, deliberately not forced into 2c;
+  reach-derived signals must never gate promotion while unmeasurable.
 - **Per-hive distinct counts**: `count_distinct(hive.id)` per (commit,
   component) — the raw data lands with phase 1, the aggregation/query layer is
   future work.

--- a/src/pkg/hub/hub_filesystem_test.go
+++ b/src/pkg/hub/hub_filesystem_test.go
@@ -32,6 +32,7 @@ func helperSetupTempDirs(t *testing.T) func() {
 	oldProv := provisionRequestsDir
 	oldAutoUpgrade := hubAutoUpgradePath
 	oldUpgradePause := upgradePausePath
+	oldReachHistory := reachHistoryPath
 
 	saasUsersDir = filepath.Join(dir, "users")
 	saasHivesDir = filepath.Join(dir, "hives")
@@ -39,6 +40,7 @@ func helperSetupTempDirs(t *testing.T) func() {
 	provisionRequestsDir = filepath.Join(dir, "provision-requests")
 	hubAutoUpgradePath = filepath.Join(dir, "hub-auto-upgrade")
 	upgradePausePath = filepath.Join(dir, "upgrade-pause.json")
+	reachHistoryPath = filepath.Join(dir, "reach-history.json")
 
 	os.MkdirAll(saasUsersDir, 0o755)
 	os.MkdirAll(saasHivesDir, 0o755)
@@ -52,6 +54,7 @@ func helperSetupTempDirs(t *testing.T) func() {
 		provisionRequestsDir = oldProv
 		hubAutoUpgradePath = oldAutoUpgrade
 		upgradePausePath = oldUpgradePause
+		reachHistoryPath = oldReachHistory
 	}
 }
 

--- a/src/pkg/hub/reach_api.go
+++ b/src/pkg/hub/reach_api.go
@@ -319,7 +319,15 @@ func (s *HubServer) handleReach(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	analyzer := &reach.Analyzer{Ancestry: s.reachAncestry, Reporter: reporter}
+	// History (#3995, phase 2c) feeds the per-deploy-window error deltas.
+	// s.reachHistory is nil on bare test servers; both the interface hop and
+	// AttachErrorDeltas are nil-safe, and a nil history simply leaves
+	// ErrorDeltas absent — unmeasured, never fabricated.
+	var history reach.HistorySource
+	if s.reachHistory != nil {
+		history = s.reachHistory
+	}
+	analyzer := &reach.Analyzer{Ancestry: s.reachAncestry, Reporter: reporter, History: history}
 	resp := reachResponse{
 		GeneratedAt:     time.Now().UTC(),
 		HivesReporting:  len(reports),
@@ -337,6 +345,10 @@ func (s *HubServer) handleReach(w http.ResponseWriter, r *http.Request) {
 			report.DeployWindow = assignment.DeployedCommit
 			report.SharedWith = assignment.SharedWith
 		}
+		// Error-rate deltas (#3995) attach AFTER window assignment — the
+		// delta is keyed on the deploy window (D4), which Analyze alone
+		// cannot know. Shared across the PRs in SharedWith by construction.
+		analyzer.AttachErrorDeltas(&report)
 		resp.Reports = append(resp.Reports, report)
 	}
 

--- a/src/pkg/hub/reach_api_test.go
+++ b/src/pkg/hub/reach_api_test.go
@@ -267,3 +267,109 @@ func TestCompareAncestry(t *testing.T) {
 		t.Error("empty ancestor: want error")
 	}
 }
+
+// TestHandleReachErrorDeltas (#3995, phase 2c): the handler attaches
+// per-component error-rate deltas from the retention store AFTER window
+// assignment, with exact numeric values — and a PR whose deploy window has no
+// retained before-history answers measured=false, never a fabricated zero.
+func TestHandleReachErrorDeltas(t *testing.T) {
+	mergedAt := time.Now().UTC().Add(-4 * time.Hour)
+	firstRun := mergedAt.Add(30 * time.Minute)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.reachPRSource = &fakeReachPRSource{prs: map[int]reach.PRInfo{
+		3995: {
+			Number:      3995,
+			MergeCommit: "cafe123",
+			MergedAt:    mergedAt,
+			Files:       []string{"src/pkg/hub/reach_history.go"},
+		},
+	}}
+	srv.reachReporter = &reach.StubReachReporter{Reports: map[string][]reach.ComponentReach{
+		"hive-a": {{Component: "hub", Commit: "beef456", SpansTotal: 7, FirstSeen: firstRun, LastSeen: firstRun}},
+	}}
+	srv.reachAncestry = &fakeReachAncestry{pairs: map[[2]string]bool{
+		{"cafe123", "beef456"}: true,
+	}}
+
+	// Retention: a mixed-fleet history — one hive still on the old build
+	// (the before regime), one on the deployed build (after). Before rate
+	// 10/100 = 0.10, after rate 30/100 = 0.30, delta +0.20 over 1 window.
+	store, _, _ := newTestHistoryStore(t)
+	now := time.Now().UTC()
+	store.Append("hive-b", histReport("hub", "01dc0de", now.Add(-3*time.Hour), 100, 10), now)
+	store.Append("hive-a", histReport("hub", "beef456", now.Add(-90*time.Minute), 100, 30), now)
+	srv.reachHistory = store
+
+	req := httptest.NewRequest("GET", "/api/reach?pr=3995", nil)
+	w := httptest.NewRecorder()
+	srv.handleReach(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, body=%s", w.Code, w.Body.String())
+	}
+	// The wire shape is part of the contract: field names are what the
+	// dashboard table reads.
+	for _, key := range []string{"error_deltas", "error_rate_before", "error_rate_after", "windows_compared", "measured"} {
+		if !strings.Contains(w.Body.String(), key) {
+			t.Errorf("response missing %q:\n%s", key, w.Body.String())
+		}
+	}
+
+	var resp struct {
+		Reports []reach.PRReachReport `json:"reports"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, w.Body.String())
+	}
+	if len(resp.Reports) != 1 {
+		t.Fatalf("Reports = %d, want 1", len(resp.Reports))
+	}
+	report := resp.Reports[0]
+	if report.DeployWindow != "beef456" {
+		t.Fatalf("DeployWindow = %q, want beef456", report.DeployWindow)
+	}
+	if len(report.ErrorDeltas) != 1 {
+		t.Fatalf("ErrorDeltas = %+v, want exactly one (component hub)", report.ErrorDeltas)
+	}
+	d := report.ErrorDeltas[0]
+	if d.Component != "hub" || !d.Measured {
+		t.Fatalf("delta = %+v, want measured for hub", d)
+	}
+	const eps = 1e-9
+	if diff := d.ErrorRateBefore - 0.10; diff > eps || diff < -eps {
+		t.Errorf("ErrorRateBefore = %v, want 0.10", d.ErrorRateBefore)
+	}
+	if diff := d.ErrorRateAfter - 0.30; diff > eps || diff < -eps {
+		t.Errorf("ErrorRateAfter = %v, want 0.30", d.ErrorRateAfter)
+	}
+	if diff := d.Delta - 0.20; diff > eps || diff < -eps {
+		t.Errorf("Delta = %v, want 0.20", d.Delta)
+	}
+	if d.WindowsCompared != 1 {
+		t.Errorf("WindowsCompared = %d, want 1", d.WindowsCompared)
+	}
+
+	// Converged-fleet case (the dominant one in production): wipe the old
+	// build's history so no before-side exists — the delta must come back
+	// present but UNMEASURED, with zeroed numbers.
+	converged, _, _ := newTestHistoryStore(t)
+	converged.Append("hive-a", histReport("hub", "beef456", now.Add(-90*time.Minute), 100, 30), now)
+	srv.reachHistory = converged
+
+	w = httptest.NewRecorder()
+	srv.handleReach(w, httptest.NewRequest("GET", "/api/reach?pr=3995", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("converged: got %d, body=%s", w.Code, w.Body.String())
+	}
+	resp.Reports = nil
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("converged: bad JSON: %v", err)
+	}
+	if len(resp.Reports) != 1 || len(resp.Reports[0].ErrorDeltas) != 1 {
+		t.Fatalf("converged: deltas = %+v, want one entry", resp.Reports)
+	}
+	cd := resp.Reports[0].ErrorDeltas[0]
+	if cd.Measured || cd.Delta != 0 || cd.ErrorRateBefore != 0 || cd.ErrorRateAfter != 0 || cd.WindowsCompared != 0 {
+		t.Errorf("converged fleet delta = %+v, want unmeasured with zeroed numbers", cd)
+	}
+}

--- a/src/pkg/hub/reach_dashboard_test.go
+++ b/src/pkg/hub/reach_dashboard_test.go
@@ -1,0 +1,55 @@
+package hub
+
+// Surface tests for the PR Reach table on the hub /dashboard status surface
+// (#3995, phase 2c of #3973). dashboardHTML is a single served string, so
+// these pin the load-bearing wiring: the section exists, it is fed from
+// /api/reach (the admin-gated endpoint that actually serves fleet reach —
+// never a spoke-side surface that cannot see it), it renders unmeasured
+// deltas as the word "unmeasured" (distinguishable from a numeric zero), and
+// it participates in the page's poll cycle. The existing brace-balance test
+// (dashboard_js_structure_test.go) covers the new script's syntax class.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDashboardReachSectionWired(t *testing.T) {
+	for _, marker := range []string{
+		// Markup: the collapsible admin section, cluster-health pattern.
+		`id="reach-section"`,
+		`id="reach-table-container"`,
+		`id="reach-summary-bar"`,
+		// Data source: the hub's own admin-gated reach endpoint.
+		`fetch('/api/reach')`,
+		// Poll wiring: initial load plus the slow reach interval.
+		`loadReach();`,
+		`setInterval(loadReach, REACH_POLL_MS)`,
+		// Admin gating mirror: the panel hides on 403 like cluster health.
+		`if (!_isAdmin) return;`,
+		// Table columns the epic promised: reach, latency, delta, flags.
+		`Reach (hives)`,
+		`First exec`,
+		`Error Δ`,
+		// Never-ran and D4 co-attribution surface as labeled flags.
+		`never ran`,
+		`shared`,
+	} {
+		if !strings.Contains(dashboardHTML, marker) {
+			t.Errorf("dashboardHTML missing %q — the reach table is not fully wired", marker)
+		}
+	}
+}
+
+// TestDashboardReachUnmeasuredDistinguishable: the never-fabricate contract
+// at the UI layer — an unmeasured delta renders as the WORD "unmeasured",
+// and the renderer branches on the measured flag rather than treating a
+// missing number as 0.0.
+func TestDashboardReachUnmeasuredDistinguishable(t *testing.T) {
+	if !strings.Contains(dashboardHTML, ">unmeasured</span>") {
+		t.Error("dashboardHTML never renders the literal 'unmeasured' state")
+	}
+	if !strings.Contains(dashboardHTML, "d.measured") {
+		t.Error("dashboardHTML delta renderer does not branch on the measured flag")
+	}
+}

--- a/src/pkg/hub/reach_history.go
+++ b/src/pkg/hub/reach_history.go
@@ -1,0 +1,497 @@
+package hub
+
+// Fleet-level error-rate history retention (#3995, phase 2c of #3973).
+//
+// The registry stores only each hive's LATEST component_reach report (2a's
+// deliberate design) — sufficient for reach, useless for before/after error
+// deltas. This store keeps a bounded ring of HOURLY activity buckets per
+// component, fed on heartbeat receive from the report's rolling window_1h
+// bucket (equivalent-period windows — cumulative-since-boot counts would
+// compare unequal periods), SUMMED across hives per (hour bucket, component,
+// running commit). Per-hive history is deliberately NOT kept — it would
+// multiply storage by fleet size for no consumer; the only per-hive state is
+// one O(1) dedupe cursor so a hive re-reporting the same window can never
+// double-count.
+//
+// All input is a sanitized-but-still-spoke-authored ReachReport, so the store
+// defends itself again: window timestamps must parse and fall inside the ring
+// span, counts are clamped non-negative, the component set and per-bucket
+// commit fan-out are capped, and over-cap input is CLIPPED AND LOGGED, never
+// silently absorbed. Honest limitation the caps cannot remove: windows are
+// fleet sums, so one high-volume (or hostile-within-clamps) spoke can skew a
+// window's error ratio; see ComputeErrorDelta's caution note.
+//
+// Persisted in its own file (reachHistoryPath), the same own-file pattern 2a
+// chose for /data/reach-state.json: atomic tmp+rename writes on a modest
+// cadence plus a final save at shutdown, loaded (and re-bounded — a
+// hand-edited file must not bypass the caps) at hub boot.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/reach"
+	"github.com/kubestellar/hive/pkg/tracing"
+)
+
+// reachHistoryPath is the DEFAULT on-disk history file — its own file beside
+// the registry, per the epic's resolved persistence pattern. A var (not a
+// const) only so hub_filesystem_test.go can swap it, mirroring registryPath.
+var reachHistoryPath = "/data/reach-history.json"
+
+const (
+	// reachHistoryWindows bounds the ring per component: 7 days of hourly
+	// buckets (#3995). A week holds several deploy cadences of before/after
+	// context on this fleet while keeping the whole store trivially small
+	// (~168 buckets × components).
+	reachHistoryWindows = 7 * 24
+
+	// maxReachHistoryComponents caps DISTINCT tracked components fleet-wide.
+	// Component names are code-defined, so the fleet's true set is the same
+	// ~dozen every spoke reports (per-spoke cap tracing.MaxReachComponents);
+	// double that cap absorbs mixed-version fleets without letting hostile
+	// name churn grow hub memory. Over-cap components are clipped and logged.
+	maxReachHistoryComponents = 2 * tracing.MaxReachComponents
+
+	// maxReachHistoryCommitsPerBucket caps distinct commits recorded per
+	// (component, hour bucket). Real fleets deploy a handful of commits per
+	// hour at the very most; more is a hostile or broken reporter, clipped
+	// and logged.
+	maxReachHistoryCommitsPerBucket = 8
+
+	// maxReachHistoryCursors caps per-component dedupe cursors (one per
+	// reporting hive). The fleet is ~10² hives; 1024 leaves generous headroom
+	// while bounding what a flood of fabricated hive IDs can allocate.
+	// Over-cap eviction drops the stalest cursor (oldest bucket) — worst
+	// case that hive's next report re-adds one window's counts.
+	maxReachHistoryCursors = 1024
+
+	// reachHistoryFutureSkew tolerates spoke clocks running slightly ahead;
+	// window starts further in the future than this are hostile or broken
+	// and are dropped (and counted).
+	reachHistoryFutureSkew = 5 * time.Minute
+
+	// reachHistorySaveInterval is the persistence cadence: at most one write
+	// per interval, dirty-gated — the same modest, off-hot-path cadence 2a
+	// uses spoke-side. Heartbeats arrive ~1/min/hive, so this bounds writes
+	// to one per minute regardless of fleet size.
+	reachHistorySaveInterval = time.Minute
+
+	// maxReachHistoryOverflowLogs caps the once-per-name over-cap log set so
+	// hostile name churn cannot grow it without bound (the same 256 bound
+	// the spoke-side reach registry uses for its overflow log set).
+	maxReachHistoryOverflowLogs = 256
+)
+
+// reachHistorySample is one persisted ring entry: fleet-summed spans for
+// (hour bucket, commit) within a component.
+type reachHistorySample struct {
+	WindowStart time.Time `json:"window_start"`
+	Commit      string    `json:"commit"`
+	SpansTotal  int64     `json:"spans_total"`
+	SpansError  int64     `json:"spans_error"`
+}
+
+// reachHiveCursor is the per-(component, hive) dedupe cursor: the last spoke
+// window folded into the ring, identified by the spoke's own raw window
+// start (its identity for one rolling window) plus the running commit. It
+// lets a re-report of the same window contribute only its INCREMENT.
+// Persisted with the ring: losing cursors across a hub restart would make
+// the next heartbeat re-add counts a previous process already summed.
+type reachHiveCursor struct {
+	RawStart   string    `json:"raw_start"`
+	Bucket     time.Time `json:"bucket"`
+	Commit     string    `json:"commit"`
+	SpansTotal int64     `json:"spans_total"`
+	SpansError int64     `json:"spans_error"`
+}
+
+// reachComponentHistory is one component's ring plus its dedupe cursors.
+type reachComponentHistory struct {
+	Samples []reachHistorySample       `json:"samples"` // oldest bucket first
+	Cursors map[string]reachHiveCursor `json:"cursors"` // keyed by hive ID
+}
+
+// reachHistoryFile is the on-disk shape.
+type reachHistoryFile struct {
+	Components map[string]*reachComponentHistory `json:"components"`
+}
+
+// reachHistoryStore is the hub's bounded, persisted retention. Safe for
+// concurrent use; Append runs on the heartbeat path, ComponentWindows on
+// /api/reach requests.
+type reachHistoryStore struct {
+	mu         sync.Mutex
+	path       string
+	logger     *slog.Logger
+	components map[string]*reachComponentHistory
+
+	// clippedComponents / droppedSamples count refused input — the visible
+	// residue of the caps, mirrored in logs so a clip is never silent.
+	clippedComponents int64
+	droppedSamples    int64
+	// loggedOverflow keeps the over-cap component log once-per-name, itself
+	// capped so hostile churn cannot grow it.
+	loggedOverflow map[string]bool
+
+	dirty    bool
+	lastSave time.Time
+}
+
+// newReachHistoryStore builds the store and loads any persisted history from
+// path. A missing file is a normal first boot; a corrupt file starts empty
+// (loudly) rather than blocking hub startup on telemetry state.
+func newReachHistoryStore(path string, logger *slog.Logger) *reachHistoryStore {
+	s := &reachHistoryStore{
+		path:           path,
+		logger:         logger,
+		components:     make(map[string]*reachComponentHistory),
+		loggedOverflow: make(map[string]bool),
+		// Start the save clock now so a burst of boot-time heartbeats does
+		// not trigger an immediate write before the interval has ever run.
+		lastSave: time.Now(),
+	}
+	s.load()
+	return s
+}
+
+// load reads and re-bounds the persisted file. Every cap is re-applied: the
+// file is hub-authored, but a hand-edited or corrupt one must not bypass the
+// bounds (the same discipline as tracing.LoadReachState).
+func (s *reachHistoryStore) load() {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			s.logger.Warn("reach history load failed; starting empty (#3995)", "path", s.path, "error", err)
+		}
+		return
+	}
+	var file reachHistoryFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		s.logger.Warn("reach history parse failed; starting empty (#3995)", "path", s.path, "error", err)
+		return
+	}
+	trimmed := 0
+	for name, hist := range file.Components {
+		if name == "" || hist == nil {
+			continue
+		}
+		if len(s.components) >= maxReachHistoryComponents {
+			trimmed++
+			continue
+		}
+		if hist.Cursors == nil {
+			hist.Cursors = make(map[string]reachHiveCursor)
+		}
+		for len(hist.Cursors) > maxReachHistoryCursors {
+			evictOldestCursor(hist)
+		}
+		sort.Slice(hist.Samples, func(i, j int) bool {
+			return hist.Samples[i].WindowStart.Before(hist.Samples[j].WindowStart)
+		})
+		// Negative counts or empty commits cannot be produced by Append; a
+		// file carrying them is corrupt or edited. Drop rather than trust.
+		clean := hist.Samples[:0]
+		for _, sm := range hist.Samples {
+			if sm.Commit == "" || sm.SpansTotal < 0 || sm.SpansError < 0 {
+				trimmed++
+				continue
+			}
+			clean = append(clean, sm)
+		}
+		hist.Samples = clean
+		trimBucketBound(hist)
+		s.components[name] = hist
+	}
+	if trimmed > 0 {
+		s.logger.Warn("reach history load re-bounded out-of-cap entries (#3995)", "trimmed", trimmed)
+	}
+	s.logger.Info("reach history loaded (#3995)", "path", s.path, "components", len(s.components))
+}
+
+// evictOldestCursor drops the cursor with the oldest bucket.
+func evictOldestCursor(hist *reachComponentHistory) {
+	oldestKey := ""
+	var oldest time.Time
+	for k, c := range hist.Cursors {
+		if oldestKey == "" || c.Bucket.Before(oldest) {
+			oldestKey, oldest = k, c.Bucket
+		}
+	}
+	if oldestKey != "" {
+		delete(hist.Cursors, oldestKey)
+	}
+}
+
+// trimBucketBound enforces the ring bound: at most reachHistoryWindows
+// DISTINCT hour buckets per component, evicting oldest-first. Samples are
+// kept oldest-first, so eviction is a front cut at a bucket boundary.
+func trimBucketBound(hist *reachComponentHistory) {
+	for {
+		distinct := 0
+		var prev time.Time
+		for i, sm := range hist.Samples {
+			if i == 0 || !sm.WindowStart.Equal(prev) {
+				distinct++
+				prev = sm.WindowStart
+			}
+		}
+		if distinct <= reachHistoryWindows || len(hist.Samples) == 0 {
+			return
+		}
+		// Cut every sample in the oldest bucket.
+		oldest := hist.Samples[0].WindowStart
+		cut := 0
+		for cut < len(hist.Samples) && hist.Samples[cut].WindowStart.Equal(oldest) {
+			cut++
+		}
+		hist.Samples = append(hist.Samples[:0], hist.Samples[cut:]...)
+	}
+}
+
+// Append folds one hive's sanitized reach report into the fleet history.
+// Called on heartbeat receive with the OUTPUT of sanitizeComponentReach —
+// never the raw payload — and only for beats that actually carried a fresh
+// report (the carry-forward path must not re-append stale windows; its
+// re-reports would be deduped by the cursor anyway, but skipping them is
+// cheaper and clearer). nil-safe on both receiver and report.
+func (s *reachHistoryStore) Append(hiveID string, report *tracing.ReachReport, now time.Time) {
+	if s == nil || report == nil || hiveID == "" {
+		return
+	}
+	s.mu.Lock()
+	droppedThisCall := 0
+	clippedThisCall := 0
+	for _, entry := range report.Entries {
+		if entry.Component == "" || entry.Commit == "" || entry.Window1h == nil {
+			// No component/commit attribution or no rolling window — nothing
+			// a delta could ever use. Not hostile, just not history input.
+			continue
+		}
+		start, err := time.Parse(time.RFC3339, entry.Window1h.Start)
+		if err != nil {
+			// sanitizeComponentReach blanks unparseable times, so "" lands
+			// here; anything else non-parsing means corrupted storage.
+			droppedThisCall++
+			continue
+		}
+		start = start.UTC()
+		ringSpan := time.Duration(reachHistoryWindows) * time.Hour
+		if start.After(now.Add(reachHistoryFutureSkew)) || start.Before(now.Add(-ringSpan)) {
+			// Out-of-range window: a future timestamp is a broken or hostile
+			// clock; one older than the ring would be evicted immediately (or
+			// worse, poison the "before" side of a delta with ancient data).
+			droppedThisCall++
+			continue
+		}
+		winTotal := clampInt64(entry.Window1h.SpansTotal, 0, maxReachSpanCount)
+		winErr := clampInt64(entry.Window1h.SpansError, 0, maxReachSpanCount)
+
+		hist, ok := s.components[entry.Component]
+		if !ok {
+			if len(s.components) >= maxReachHistoryComponents {
+				clippedThisCall++
+				s.noteComponentOverflowLocked(entry.Component)
+				continue
+			}
+			hist = &reachComponentHistory{Cursors: make(map[string]reachHiveCursor)}
+			s.components[entry.Component] = hist
+		}
+
+		// Spoke windows have arbitrary starts; bucket onto the hourly grid so
+		// cross-hive summation is meaningful (see reach.HistorySample).
+		bucket := start.Truncate(time.Hour)
+
+		cursor, hasCursor := hist.Cursors[hiveID]
+		switch {
+		case hasCursor && cursor.RawStart == entry.Window1h.Start && cursor.Commit == entry.Commit:
+			// Same spoke window re-reported: contribute only the INCREMENT
+			// since the last beat — the dedupe that keeps a window from
+			// double-counting. Window counters are cumulative within their
+			// window, so a decrease means the spoke restarted mid-window and
+			// resumed lower; clamping the increment at zero undercounts that
+			// sliver rather than ever double-counting.
+			deltaTotal := winTotal - cursor.SpansTotal
+			deltaErr := winErr - cursor.SpansError
+			if deltaTotal < 0 {
+				deltaTotal = 0
+			}
+			if deltaErr < 0 {
+				deltaErr = 0
+			}
+			if deltaTotal > 0 || deltaErr > 0 {
+				if !s.addSampleLocked(hist, bucket, entry.Commit, deltaTotal, deltaErr) {
+					clippedThisCall++
+				}
+			}
+			cursor.SpansTotal, cursor.SpansError = winTotal, winErr
+			hist.Cursors[hiveID] = cursor
+		case hasCursor && bucket.Before(cursor.Bucket):
+			// A window OLDER than the hive's last folded one: out-of-order
+			// replay (or a clock yanked backwards). Folding it could
+			// double-count a window already summed — drop it.
+			droppedThisCall++
+		default:
+			// New spoke window (first report from this hive, a rolled
+			// window, or a new running commit): contribute its full counts.
+			if winTotal > 0 || winErr > 0 {
+				if !s.addSampleLocked(hist, bucket, entry.Commit, winTotal, winErr) {
+					clippedThisCall++
+				}
+			}
+			if !hasCursor && len(hist.Cursors) >= maxReachHistoryCursors {
+				evictOldestCursor(hist)
+			}
+			hist.Cursors[hiveID] = reachHiveCursor{
+				RawStart:   entry.Window1h.Start,
+				Bucket:     bucket,
+				Commit:     entry.Commit,
+				SpansTotal: winTotal,
+				SpansError: winErr,
+			}
+		}
+		trimBucketBound(hist)
+		s.dirty = true
+	}
+	s.droppedSamples += int64(droppedThisCall)
+	s.clippedComponents += int64(clippedThisCall)
+	s.mu.Unlock()
+
+	if droppedThisCall > 0 || clippedThisCall > 0 {
+		// The clip/drop is visible, never silent (#3995): one aggregate line
+		// per offending beat, not one per entry, so a hostile spoke cannot
+		// use the log as an amplification channel either.
+		s.logger.Warn("reach history: refused out-of-bounds input (#3995)",
+			"hive_id", hiveID, "dropped_windows", droppedThisCall, "clipped_over_cap", clippedThisCall)
+	}
+	s.maybeSave(now)
+}
+
+// noteComponentOverflowLocked logs an over-cap component once per name, with
+// the once-set itself capped. Callers hold s.mu.
+func (s *reachHistoryStore) noteComponentOverflowLocked(component string) {
+	if s.loggedOverflow[component] || len(s.loggedOverflow) >= maxReachHistoryOverflowLogs {
+		return
+	}
+	s.loggedOverflow[component] = true
+	s.logger.Warn("reach history: component cap reached, new component refused (#3995)",
+		"component", component, "cap", maxReachHistoryComponents)
+}
+
+// addSampleLocked adds counts into the (bucket, commit) sample, creating it
+// if the per-bucket commit cap allows. Returns false when the cap refused a
+// NEW commit for the bucket. Callers hold s.mu.
+func (s *reachHistoryStore) addSampleLocked(hist *reachComponentHistory, bucket time.Time, commit string, total, errs int64) bool {
+	commitsInBucket := 0
+	insertAt := len(hist.Samples)
+	for i := range hist.Samples {
+		sm := &hist.Samples[i]
+		if sm.WindowStart.Equal(bucket) {
+			if sm.Commit == commit {
+				sm.SpansTotal += total
+				sm.SpansError += errs
+				return true
+			}
+			commitsInBucket++
+		}
+		if bucket.Before(sm.WindowStart) && insertAt == len(hist.Samples) {
+			insertAt = i
+		}
+	}
+	if commitsInBucket >= maxReachHistoryCommitsPerBucket {
+		return false
+	}
+	sample := reachHistorySample{WindowStart: bucket, Commit: commit, SpansTotal: total, SpansError: errs}
+	hist.Samples = append(hist.Samples, reachHistorySample{})
+	copy(hist.Samples[insertAt+1:], hist.Samples[insertAt:])
+	hist.Samples[insertAt] = sample
+	return true
+}
+
+// ComponentWindows implements reach.HistorySource: a snapshot of one
+// component's fleet history, oldest bucket first.
+func (s *reachHistoryStore) ComponentWindows(component string) []reach.HistorySample {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hist, ok := s.components[component]
+	if !ok || len(hist.Samples) == 0 {
+		return nil
+	}
+	out := make([]reach.HistorySample, 0, len(hist.Samples))
+	for _, sm := range hist.Samples {
+		out = append(out, reach.HistorySample{
+			WindowStart: sm.WindowStart,
+			Commit:      sm.Commit,
+			SpansTotal:  sm.SpansTotal,
+			SpansError:  sm.SpansError,
+		})
+	}
+	return out
+}
+
+// maybeSave persists when dirty and the save interval has elapsed. Marshal
+// happens under the lock (the store is small by construction); the file write
+// happens outside it, mirroring saveRegistryNow's atomic tmp+rename.
+func (s *reachHistoryStore) maybeSave(now time.Time) {
+	s.mu.Lock()
+	if !s.dirty || now.Sub(s.lastSave) < reachHistorySaveInterval {
+		s.mu.Unlock()
+		return
+	}
+	data, err := s.marshalLocked()
+	s.dirty = false
+	s.lastSave = now
+	s.mu.Unlock()
+	if err != nil {
+		s.logger.Warn("reach history marshal failed (#3995)", "error", err)
+		return
+	}
+	s.write(data)
+}
+
+// SaveNow flushes unconditionally when dirty — the shutdown hook, so the
+// final partial minute of history survives a roll.
+func (s *reachHistoryStore) SaveNow() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if !s.dirty {
+		s.mu.Unlock()
+		return
+	}
+	data, err := s.marshalLocked()
+	s.dirty = false
+	s.lastSave = time.Now()
+	s.mu.Unlock()
+	if err != nil {
+		s.logger.Warn("reach history marshal failed (#3995)", "error", err)
+		return
+	}
+	s.write(data)
+}
+
+// marshalLocked renders the persisted shape. Callers hold s.mu.
+func (s *reachHistoryStore) marshalLocked() ([]byte, error) {
+	return json.MarshalIndent(reachHistoryFile{Components: s.components}, "", "  ")
+}
+
+// write lands data atomically (tmp + rename). Failures are logged, not
+// fatal: history is telemetry, and the next dirty interval retries.
+func (s *reachHistoryStore) write(data []byte) {
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		s.logger.Warn("reach history save failed (#3995)", "path", tmp, "error", err)
+		return
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		s.logger.Warn("reach history rename failed (#3995)", "path", s.path, "error", err)
+	}
+}

--- a/src/pkg/hub/reach_history_test.go
+++ b/src/pkg/hub/reach_history_test.go
@@ -1,0 +1,428 @@
+package hub
+
+// Tests for the fleet-level error-rate history retention (#3995, phase 2c of
+// #3973). The store's input is spoke-authored (sanitized upstream but still
+// hostile in spirit), so the load-bearing assertions are the bounds: the ring
+// evicts oldest-first at its window cap, over-cap components are clipped AND
+// logged (never silently absorbed), a hive re-reporting the same rolling
+// window never double-counts, out-of-range timestamps are refused, and every
+// cap is re-applied on load so a hand-edited file cannot bypass them.
+//
+// Fixtures are production-possible states only: multi-hive mixed-commit
+// fleets, never one hive reporting two commits at once (2a's loader drops
+// other-commit entries on upgrade, so that state cannot exist).
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/tracing"
+)
+
+// newTestHistoryStore builds a store persisting under t.TempDir, returning
+// the store, its path, and a buffer capturing its log output.
+func newTestHistoryStore(t *testing.T) (*reachHistoryStore, string, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	path := filepath.Join(t.TempDir(), "reach-history.json")
+	return newReachHistoryStore(path, logger), path, &buf
+}
+
+// histReport builds a single-entry sanitized-shape report whose rolling
+// window starts at start.
+func histReport(component, commit string, start time.Time, winTotal, winErr int64) *tracing.ReachReport {
+	return &tracing.ReachReport{Entries: []tracing.ReachEntry{{
+		Component:  component,
+		Commit:     commit,
+		SpansTotal: winTotal,
+		SpansError: winErr,
+		FirstSeen:  start.UTC().Format(time.RFC3339),
+		LastSeen:   start.UTC().Format(time.RFC3339),
+		Window1h: &tracing.ReachWindow{
+			Start:      start.UTC().Format(time.RFC3339),
+			SpansTotal: winTotal,
+			SpansError: winErr,
+		},
+	}}}
+}
+
+// TestReachHistorySumsAcrossHives: a mixed fleet reporting into the same hour
+// bucket sums per (bucket, commit) — two hives on the same commit fold into
+// one sample; a hive on a different (older) commit lands its own sample.
+// histNow is a fixed clock for the store tests: mid-hour, so minute-offset
+// window starts below stay inside one bucket deterministically (a real
+// time.Now() near an hour boundary would make bucket membership flaky).
+var histNow = time.Date(2026, 8, 17, 12, 30, 0, 0, time.UTC)
+
+func TestReachHistorySumsAcrossHives(t *testing.T) {
+	store, _, _ := newTestHistoryStore(t)
+	now := histNow
+	start := now.Add(-25 * time.Minute) // 12:05 — same bucket through +8m offsets
+
+	store.Append("hive-a", histReport("hub", "beef456", start, 100, 10), now)
+	store.Append("hive-b", histReport("hub", "beef456", start.Add(2*time.Minute), 50, 5), now)
+	store.Append("hive-c", histReport("hub", "01dc0de", start.Add(time.Minute), 30, 3), now)
+
+	windows := store.ComponentWindows("hub")
+	if len(windows) != 2 {
+		t.Fatalf("samples = %d, want 2 (one per commit in the bucket): %+v", len(windows), windows)
+	}
+	byCommit := map[string][2]int64{}
+	for _, w := range windows {
+		byCommit[w.Commit] = [2]int64{w.SpansTotal, w.SpansError}
+	}
+	if got := byCommit["beef456"]; got != [2]int64{150, 15} {
+		t.Errorf("beef456 sum = %v, want {150 15}", got)
+	}
+	if got := byCommit["01dc0de"]; got != [2]int64{30, 3} {
+		t.Errorf("01dc0de sum = %v, want {30 3}", got)
+	}
+}
+
+// TestReachHistoryDedupesReReportedWindow is the dedupe guard: the same hive
+// re-reporting the SAME rolling window (heartbeats beat far more often than
+// windows roll) must contribute only its increment, never a second full copy.
+// Removing the cursor increment branch in Append makes this fail with a
+// doubled total (verified during development).
+func TestReachHistoryDedupesReReportedWindow(t *testing.T) {
+	store, _, _ := newTestHistoryStore(t)
+	now := histNow
+	start := now.Add(-25 * time.Minute)
+
+	// Same window reported three times as it fills: 40 → 40 (idle beat) → 100.
+	store.Append("hive-a", histReport("hub", "beef456", start, 40, 4), now)
+	store.Append("hive-a", histReport("hub", "beef456", start, 40, 4), now)
+	store.Append("hive-a", histReport("hub", "beef456", start, 100, 10), now)
+
+	windows := store.ComponentWindows("hub")
+	if len(windows) != 1 {
+		t.Fatalf("samples = %d, want 1: %+v", len(windows), windows)
+	}
+	if windows[0].SpansTotal != 100 || windows[0].SpansError != 10 {
+		t.Errorf("sample = {%d %d}, want {100 10} — re-reports must not double-count",
+			windows[0].SpansTotal, windows[0].SpansError)
+	}
+
+	// A mid-window spoke restart resumes lower: the negative increment is
+	// clamped to zero (a small undercount), never subtracted or re-added.
+	store.Append("hive-a", histReport("hub", "beef456", start, 60, 6), now)
+	windows = store.ComponentWindows("hub")
+	if windows[0].SpansTotal != 100 || windows[0].SpansError != 10 {
+		t.Errorf("after lower re-report: sample = {%d %d}, want unchanged {100 10}",
+			windows[0].SpansTotal, windows[0].SpansError)
+	}
+}
+
+// TestReachHistoryRingBound: the per-component ring holds at most
+// reachHistoryWindows distinct hour buckets, evicting oldest-first.
+func TestReachHistoryRingBound(t *testing.T) {
+	store, _, _ := newTestHistoryStore(t)
+	base := histNow.Truncate(time.Hour)
+
+	// Fill the ring exactly: reachHistoryWindows buckets, all valid at histNow.
+	for i := reachHistoryWindows - 1; i >= 0; i-- {
+		start := base.Add(-time.Duration(i) * time.Hour).Add(5 * time.Minute)
+		store.Append("hive-a", histReport("hub", "beef456", start, int64(i+1), 0), histNow)
+	}
+	if got := len(store.ComponentWindows("hub")); got != reachHistoryWindows {
+		t.Fatalf("precondition: ring holds %d buckets, want %d", got, reachHistoryWindows)
+	}
+
+	// An hour later a new window arrives: the ring is over-full and must
+	// evict its OLDEST bucket, keeping exactly reachHistoryWindows.
+	later := histNow.Add(time.Hour)
+	store.Append("hive-a", histReport("hub", "beef456", base.Add(time.Hour).Add(5*time.Minute), 7, 0), later)
+
+	windows := store.ComponentWindows("hub")
+	if len(windows) != reachHistoryWindows {
+		t.Fatalf("ring holds %d buckets after overflow, want exactly %d", len(windows), reachHistoryWindows)
+	}
+	oldestKept := windows[0].WindowStart
+	wantOldest := base.Add(-time.Duration(reachHistoryWindows-2) * time.Hour)
+	if !oldestKept.Equal(wantOldest) {
+		t.Errorf("oldest kept bucket = %v, want %v (eviction must be oldest-first)", oldestKept, wantOldest)
+	}
+	newest := windows[len(windows)-1].WindowStart
+	if !newest.Equal(base.Add(time.Hour)) {
+		t.Errorf("newest bucket = %v, want %v (the new window must have landed)", newest, base.Add(time.Hour))
+	}
+}
+
+// TestReachHistoryComponentCapClippedAndLogged: a new component past the cap
+// is refused, the refusal is counted, and it is LOGGED — never silent.
+// Removing the cap check in Append makes this fail (verified during
+// development).
+func TestReachHistoryComponentCapClippedAndLogged(t *testing.T) {
+	store, _, logBuf := newTestHistoryStore(t)
+	now := histNow
+	start := now.Add(-25 * time.Minute)
+
+	for i := 0; i < maxReachHistoryComponents; i++ {
+		store.Append("hive-a", histReport(fmt.Sprintf("comp%04d", i), "beef456", start, 1, 0), now)
+	}
+	store.Append("hive-a", histReport("one-too-many", "beef456", start, 1, 0), now)
+
+	if got := store.ComponentWindows("one-too-many"); got != nil {
+		t.Errorf("over-cap component was tracked: %+v", got)
+	}
+	store.mu.Lock()
+	clipped := store.clippedComponents
+	tracked := len(store.components)
+	store.mu.Unlock()
+	if tracked != maxReachHistoryComponents {
+		t.Errorf("tracked components = %d, want capped at %d", tracked, maxReachHistoryComponents)
+	}
+	if clipped == 0 {
+		t.Error("clippedComponents = 0, want > 0 (the clip must be counted)")
+	}
+	if !strings.Contains(logBuf.String(), "component cap") {
+		t.Error("over-cap clip was not logged — clips must be visible, never silent")
+	}
+	// Components already inside the cap keep accumulating normally (a second
+	// hive reporting an earlier hour — no cursor, so no ordering guard).
+	store.Append("hive-b", histReport("comp0000", "beef456", start.Add(-time.Hour), 5, 1), now)
+	if got := store.ComponentWindows("comp0000"); len(got) != 2 {
+		t.Errorf("in-cap component stopped accumulating: %+v", got)
+	}
+}
+
+// TestReachHistoryRefusesHostileWindows: unparseable, far-future, and
+// ancient window starts are dropped and counted; entries without a commit or
+// rolling window are skipped as non-input.
+func TestReachHistoryRefusesHostileWindows(t *testing.T) {
+	store, _, logBuf := newTestHistoryStore(t)
+	now := time.Now().UTC()
+
+	hostile := &tracing.ReachReport{Entries: []tracing.ReachEntry{
+		// Unparseable start (sanitizeComponentReach blanks invalid times).
+		{Component: "hub", Commit: "beef456", Window1h: &tracing.ReachWindow{Start: "", SpansTotal: 10}},
+		// Future window: a broken or lying clock.
+		{Component: "hub", Commit: "beef456", Window1h: &tracing.ReachWindow{
+			Start: now.Add(2 * time.Hour).Format(time.RFC3339), SpansTotal: 10}},
+		// Older than the ring span: would poison the "before" side.
+		{Component: "hub", Commit: "beef456", Window1h: &tracing.ReachWindow{
+			Start: now.Add(-10 * 24 * time.Hour).Format(time.RFC3339), SpansTotal: 10}},
+		// No commit: unattributable to a binary, not history input.
+		{Component: "hub", Commit: "", Window1h: &tracing.ReachWindow{
+			Start: now.Add(-time.Minute).Format(time.RFC3339), SpansTotal: 10}},
+		// No rolling window at all.
+		{Component: "hub", Commit: "beef456"},
+	}}
+	store.Append("hive-a", hostile, now)
+
+	if got := store.ComponentWindows("hub"); got != nil {
+		t.Errorf("hostile input landed in the ring: %+v", got)
+	}
+	store.mu.Lock()
+	dropped := store.droppedSamples
+	store.mu.Unlock()
+	// The three timestamp offenders count as drops; the commit-less and
+	// window-less entries are non-input, not hostile.
+	if dropped != 3 {
+		t.Errorf("droppedSamples = %d, want 3", dropped)
+	}
+	if !strings.Contains(logBuf.String(), "refused out-of-bounds input") {
+		t.Error("hostile drop was not logged")
+	}
+}
+
+// TestReachHistoryOutOfOrderWindowDropped: a window OLDER than the hive's
+// last folded bucket is a replay and must not be re-summed.
+func TestReachHistoryOutOfOrderWindowDropped(t *testing.T) {
+	store, _, _ := newTestHistoryStore(t)
+	now := time.Now().UTC()
+	newer := now.Add(-30 * time.Minute)
+	older := now.Add(-3 * time.Hour)
+
+	store.Append("hive-a", histReport("hub", "beef456", newer, 100, 10), now)
+	store.Append("hive-a", histReport("hub", "beef456", older, 40, 4), now)
+
+	windows := store.ComponentWindows("hub")
+	if len(windows) != 1 || !windows[0].WindowStart.Equal(newer.Truncate(time.Hour)) {
+		t.Errorf("out-of-order window was folded: %+v", windows)
+	}
+}
+
+// TestReachHistoryCommitsPerBucketCap: distinct commits per (component, hour
+// bucket) are capped; the over-cap commit is refused and counted.
+func TestReachHistoryCommitsPerBucketCap(t *testing.T) {
+	store, _, _ := newTestHistoryStore(t)
+	now := histNow
+	start := now.Add(-25 * time.Minute) // 12:05 — +8m offsets stay in-bucket
+
+	// One hive per commit: a hive reports ONE running commit at a time (2a's
+	// loader guarantees it), so commit fan-out in a bucket comes from many
+	// hives on different builds.
+	for i := 0; i < maxReachHistoryCommitsPerBucket+1; i++ {
+		hive := fmt.Sprintf("hive-%02d", i)
+		commit := fmt.Sprintf("c0mm1t%02d", i)
+		store.Append(hive, histReport("hub", commit, start.Add(time.Duration(i)*time.Minute), 10, 1), now)
+	}
+	windows := store.ComponentWindows("hub")
+	if len(windows) != maxReachHistoryCommitsPerBucket {
+		t.Errorf("bucket holds %d commits, want capped at %d", len(windows), maxReachHistoryCommitsPerBucket)
+	}
+	store.mu.Lock()
+	clipped := store.clippedComponents
+	store.mu.Unlock()
+	if clipped == 0 {
+		t.Error("over-cap commit refusal was not counted")
+	}
+}
+
+// TestReachHistoryPersistRoundTrip: SaveNow → fresh store → identical
+// windows, and the dedupe cursor survives the restart — the production case
+// where a hub rolls mid-window and the next heartbeat re-reports a window
+// the previous process already summed.
+func TestReachHistoryPersistRoundTrip(t *testing.T) {
+	store, path, _ := newTestHistoryStore(t)
+	now := time.Now().UTC()
+	start := now.Add(-30 * time.Minute)
+
+	store.Append("hive-a", histReport("hub", "beef456", start, 40, 4), now)
+	store.SaveNow()
+
+	reloaded := newReachHistoryStore(path, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	windows := reloaded.ComponentWindows("hub")
+	if len(windows) != 1 || windows[0].SpansTotal != 40 || windows[0].SpansError != 4 {
+		t.Fatalf("round-trip windows = %+v, want one {40 4} sample", windows)
+	}
+
+	// The same window re-reported (grown) after the "restart": only the
+	// increment lands. Without persisted cursors this would re-add 100.
+	reloaded.Append("hive-a", histReport("hub", "beef456", start, 100, 10), now)
+	windows = reloaded.ComponentWindows("hub")
+	if len(windows) != 1 || windows[0].SpansTotal != 100 || windows[0].SpansError != 10 {
+		t.Errorf("post-restart re-report = %+v, want one {100 10} sample (cursor must survive restarts)", windows)
+	}
+}
+
+// TestReachHistoryLoadReboundsCorruptFile: every cap and clamp re-applies at
+// load — negative counts, empty commits, and over-bound windows in a
+// hand-edited file must not enter memory.
+func TestReachHistoryLoadReboundsCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "reach-history.json")
+
+	base := time.Now().UTC().Truncate(time.Hour)
+	var samples []string
+	// More distinct buckets than the ring allows…
+	for i := 0; i < reachHistoryWindows+10; i++ {
+		samples = append(samples, fmt.Sprintf(
+			`{"window_start":%q,"commit":"beef456","spans_total":1,"spans_error":0}`,
+			base.Add(-time.Duration(i)*time.Hour).Format(time.RFC3339)))
+	}
+	// …plus corrupt entries that must be dropped.
+	samples = append(samples,
+		`{"window_start":"2026-08-17T10:00:00Z","commit":"beef456","spans_total":-5,"spans_error":0}`,
+		`{"window_start":"2026-08-17T10:00:00Z","commit":"","spans_total":5,"spans_error":0}`)
+	content := fmt.Sprintf(`{"components":{"hub":{"samples":[%s],"cursors":{}}}}`, strings.Join(samples, ","))
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	store := newReachHistoryStore(path, slog.New(slog.NewTextHandler(&buf, nil)))
+	windows := store.ComponentWindows("hub")
+	if len(windows) > reachHistoryWindows {
+		t.Errorf("loaded %d buckets, want re-bounded to %d", len(windows), reachHistoryWindows)
+	}
+	for _, w := range windows {
+		if w.SpansTotal < 0 || w.Commit == "" {
+			t.Errorf("corrupt sample survived load: %+v", w)
+		}
+	}
+	if !strings.Contains(buf.String(), "re-bounded") {
+		t.Error("load re-bounding was not logged")
+	}
+}
+
+// TestReachHistoryConcurrentAccess exercises Append vs ComponentWindows under
+// the race detector (run with -race): heartbeats and /api/reach requests are
+// concurrent in production.
+func TestReachHistoryConcurrentAccess(t *testing.T) {
+	store, _, _ := newTestHistoryStore(t)
+	now := time.Now().UTC()
+	start := now.Add(-30 * time.Minute)
+
+	var wg sync.WaitGroup
+	const writers = 4
+	const iterations = 50
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			hive := fmt.Sprintf("hive-%d", w)
+			for i := 0; i < iterations; i++ {
+				store.Append(hive, histReport("hub", "beef456", start, int64(i), 0), now)
+			}
+		}(w)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < writers*iterations; i++ {
+			store.ComponentWindows("hub")
+		}
+	}()
+	wg.Wait()
+}
+
+// TestHeartbeatFoldsReachHistory: the end-to-end receive path — a heartbeat
+// carrying component_reach with a rolling window lands in the history store
+// via the SANITIZED report, a repeat beat dedupes, and a second hive sums.
+func TestHeartbeatFoldsReachHistory(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+	var buf bytes.Buffer
+	s.reachHistory = newReachHistoryStore(filepath.Join(t.TempDir(), "rh.json"), slog.New(slog.NewTextHandler(&buf, nil)))
+
+	start := time.Now().UTC().Add(-30 * time.Minute).Format(time.RFC3339)
+	body := func(hive string, winTotal, winErr int64) string {
+		return fmt.Sprintf(`{"hive_id":%q,"org":"kubestellar","component_reach":{"entries":[
+			{"component":"hub","commit":"abc1234","spans_total":%d,"spans_error":%d,
+			 "first_seen":%q,"last_seen":%q,
+			 "window_1h":{"start":%q,"spans_total":%d,"spans_error":%d}}]}}`,
+			hive, winTotal, winErr, start, start, start, winTotal, winErr)
+	}
+
+	if rec := postHeartbeat(t, s, body("h1", 40, 4)); rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	// The same beat again (same window, same counts): dedupe, no growth.
+	if rec := postHeartbeat(t, s, body("h1", 40, 4)); rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d", rec.Code)
+	}
+	// A second hive in the same hour: sums.
+	if rec := postHeartbeat(t, s, body("h2", 10, 1)); rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d", rec.Code)
+	}
+
+	windows := s.reachHistory.ComponentWindows("hub")
+	if len(windows) != 1 {
+		t.Fatalf("windows = %+v, want one summed bucket", windows)
+	}
+	if windows[0].SpansTotal != 50 || windows[0].SpansError != 5 {
+		t.Errorf("bucket = {%d %d}, want {50 5} (h1 deduped + h2 summed)",
+			windows[0].SpansTotal, windows[0].SpansError)
+	}
+	// A beat WITHOUT component_reach must not touch history (nil report —
+	// the carry-forward path keeps the registry copy, not the ring).
+	if rec := postHeartbeat(t, s, `{"hive_id":"h1","org":"kubestellar"}`); rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d", rec.Code)
+	}
+	windows = s.reachHistory.ComponentWindows("hub")
+	if len(windows) != 1 || windows[0].SpansTotal != 50 {
+		t.Errorf("report-less beat mutated history: %+v", windows)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -8878,6 +8878,17 @@ const dashboardHTML = `<!DOCTYPE html>
         <div id="cluster-health-grid" style="display:grid;grid-template-columns:repeat(2,1fr);gap:12px"></div>
       </div>
     </div>
+
+    <div id="reach-section" style="display:none;margin-top:48px">
+      <div onclick="toggleReach()" style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;margin-bottom:16px">
+        <span id="reach-toggle" style="font-size:0.7rem;color:var(--muted);transition:transform 0.2s">&#9654;</span>
+        <h2 style="font-size:1.3rem;color:var(--accent);margin:0">PR Reach</h2>
+        <span id="reach-summary-bar" style="font-size:0.8rem;color:var(--muted);margin-left:8px"></span>
+      </div>
+      <div id="reach-body" style="display:none">
+        <div class="table-wrap" id="reach-table-container"></div>
+      </div>
+    </div>
   </div>
 
   <footer class="footer">
@@ -15984,6 +15995,133 @@ const dashboardHTML = `<!DOCTYPE html>
       }
     }
 
+    // --- PR Reach Panel (#3995, phase 2c of #3973) ---
+    // Admin-only, same contract as the Cluster Health panel above: hidden
+    // until /api/reach answers OK, hidden again on 403, collapse state in
+    // localStorage. Polls far slower than cluster health — every load fans
+    // out merged-PR + ancestry lookups hub-side (GitHub API), so 5 minutes
+    // is the courtesy floor, and reach itself moves at heartbeat cadence.
+    var REACH_POLL_MS = 300000;
+    var _reachCollapsed = localStorage.getItem('hive-reach-collapsed') !== 'false';
+
+    function toggleReach() {
+      _reachCollapsed = !_reachCollapsed;
+      localStorage.setItem('hive-reach-collapsed', _reachCollapsed ? 'true' : 'false');
+      var body = document.getElementById('reach-body');
+      var toggle = document.getElementById('reach-toggle');
+      if (body) body.style.display = _reachCollapsed ? 'none' : '';
+      if (toggle) toggle.style.transform = _reachCollapsed ? '' : 'rotate(90deg)';
+    }
+
+    /* Renders merge→first-execution latency compactly; null means nothing
+       qualifying has executed yet and must read as absent, never as 0. */
+    function reachLatency(seconds) {
+      if (seconds == null || !isFinite(seconds) || seconds < 0) return '<span style="color:var(--muted)">—</span>';
+      var SEC_PER_MIN = 60, SEC_PER_HOUR = 3600, SEC_PER_DAY = 86400;
+      if (seconds < SEC_PER_HOUR) return Math.round(seconds / SEC_PER_MIN) + 'm';
+      if (seconds < SEC_PER_DAY) return (seconds / SEC_PER_HOUR).toFixed(1) + 'h';
+      return (seconds / SEC_PER_DAY).toFixed(1) + 'd';
+    }
+
+    /* Renders the error-delta cell from a report's per-component deltas.
+       The measured flag is the contract (#3995): an unmeasured delta must be
+       DISTINGUISHABLE from a measured zero, so unmeasured renders as the word
+       "unmeasured", never as 0.0. Measured deltas show the worst (largest
+       magnitude) component, red when errors rose, green when they fell; the
+       tooltip itemizes every component either way. */
+    function reachDeltaCell(deltas) {
+      deltas = deltas || [];
+      var measured = deltas.filter(function(d) { return d && d.measured; });
+      var PCT = 100;
+      var tip = deltas.map(function(d) {
+        if (!d) return '';
+        if (!d.measured) return d.component + ': unmeasured';
+        return d.component + ': ' + (d.delta >= 0 ? '+' : '') + (d.delta * PCT).toFixed(2) +
+          'pp over ' + d.windows_compared + 'w (' + (d.error_rate_before * PCT).toFixed(2) +
+          '% -> ' + (d.error_rate_after * PCT).toFixed(2) + '%)';
+      }).filter(Boolean).join('\n');
+      if (!measured.length) {
+        return '<span style="color:var(--muted)" title="' + esc(tip || 'No deploy window observed yet, or not enough before/after history') + '">unmeasured</span>';
+      }
+      var worst = measured[0];
+      measured.forEach(function(d) { if (Math.abs(d.delta) > Math.abs(worst.delta)) worst = d; });
+      var color = worst.delta > 0 ? 'var(--red)' : (worst.delta < 0 ? 'var(--green)' : 'var(--muted)');
+      var sign = worst.delta >= 0 ? '+' : '';
+      return '<span style="color:' + color + ';font-family:monospace" title="' + esc(tip) + '">' +
+        sign + (worst.delta * PCT).toFixed(2) + 'pp</span>';
+    }
+
+    function renderReachRow(r) {
+      var comps = (r.attribution && r.attribution.components) || [];
+      var coveragePct = Math.round(((r.attribution && r.attribution.coverage) || 0) * 100);
+      var compCell = comps.length
+        ? '<span title="Attribution coverage ' + coveragePct + '% of changed files">' + esc(comps.join(', ')) + '</span>'
+        : '<span style="color:var(--muted)" title="No changed file maps to an instrumented component (docs/workflows/deploy)">unattributable</span>';
+      var hives = r.reach_hives || [];
+      var reachCell = r.reach_count
+        ? '<span title="' + esc(hives.join(', ')) + '">' + r.reach_count + '</span>'
+        : '<span style="color:var(--muted)">0</span>';
+      var flags = [];
+      if (r.never_ran) flags.push('<span style="padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(239,68,68,0.15);color:var(--red);border:1px solid rgba(239,68,68,0.3)" title="Merged and deployed, but no touched component has executed anywhere in ' + (r.never_ran_threshold_days || 0) + ' days — the category acceptance-rate cannot see">never ran</span>');
+      else if (!r.deployed) flags.push('<span style="padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)" title="No hive reports running a commit containing this PR yet (merged is not deployed)">not deployed</span>');
+      if ((r.shared_with || []).length) flags.push('<span style="padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(128,191,255,0.15);color:#80bfff;border:1px solid rgba(128,191,255,0.3)" title="Co-deployed with PR ' + esc((r.shared_with || []).map(function(n) { return '#' + n; }).join(', ')) + ' — reach and deltas are shared by construction (D4)">shared</span>');
+      return '<tr>' +
+        '<td style="white-space:nowrap"><a href="https://github.com/kubestellar/hive/pull/' + r.pr + '" target="_blank">#' + r.pr + '</a>' +
+        (r.title ? ' <span style="color:var(--muted);font-size:0.75rem" title="' + esc(r.title) + '">' + esc(r.title.length > 48 ? r.title.slice(0, 48) + '…' : r.title) + '</span>' : '') + '</td>' +
+        '<td>' + compCell + '</td>' +
+        '<td>' + reachCell + '</td>' +
+        '<td>' + reachLatency(r.first_execution_latency_seconds) + '</td>' +
+        '<td>' + reachDeltaCell(r.error_deltas) + '</td>' +
+        '<td style="white-space:nowrap">' + (flags.join(' ') || '<span style="color:var(--muted)">—</span>') + '</td>' +
+        '</tr>';
+    }
+
+    async function loadReach() {
+      if (!_isAdmin) return;
+      try {
+        var resp = await fetch('/api/reach');
+        if (resp.status === 403) {
+          document.getElementById('reach-section').style.display = 'none';
+          return;
+        }
+        /* 503 = hub running without GitHub credentials: no PR facts exist, so
+           the section stays hidden rather than rendering an empty shell. */
+        if (!resp.ok) return;
+        var data = await resp.json();
+        document.getElementById('reach-section').style.display = '';
+
+        var reports = data.reports || [];
+        var summaryBar = document.getElementById('reach-summary-bar');
+        if (summaryBar) {
+          var neverRan = reports.filter(function(r) { return r.never_ran; }).length;
+          var reached = reports.filter(function(r) { return (r.reach_count || 0) > 0; }).length;
+          summaryBar.textContent = reports.length + ' merged PR' + (reports.length !== 1 ? 's' : '') +
+            ' · ' + (data.hives_reporting || 0) + ' hives reporting · ' + reached + ' reached' +
+            (neverRan ? ' · ' + neverRan + ' never ran' : '');
+        }
+
+        var body = document.getElementById('reach-body');
+        var toggle = document.getElementById('reach-toggle');
+        if (!_reachCollapsed) {
+          if (body) body.style.display = '';
+          if (toggle) toggle.style.transform = 'rotate(90deg)';
+        }
+
+        var container = document.getElementById('reach-table-container');
+        if (!container) return;
+        if (!reports.length) {
+          container.innerHTML = '<div style="color:var(--muted);font-size:0.85rem">No recently merged PRs to report on</div>';
+          return;
+        }
+        container.innerHTML =
+          '<table class="hive-table"><thead><tr>' +
+          '<th style="text-align:left">PR</th><th>Components</th><th title="Distinct hives running a commit containing the PR whose touched components executed since merge">Reach (hives)</th><th title="Merge to first qualifying execution anywhere in the fleet">First exec</th><th title="Span error-rate after vs before the PR&#39;s deploy window; unmeasured when either side lacks data (#3995)">Error Δ</th><th>Flags</th>' +
+          '</tr></thead><tbody>' + reports.map(renderReachRow).join('') + '</tbody></table>';
+      } catch(e) {
+        console.error('reach error:', e);
+      }
+    }
+
     async function loadClusters() {
       try {
         var resp = await fetch('/api/hub/clusters');
@@ -16240,6 +16378,7 @@ const dashboardHTML = `<!DOCTYPE html>
       await loadAdminUsers();
       if (!_adminLoaded) setTimeout(loadAdminUsers, 2000);
       loadClusterHealth();
+      loadReach();
       loadClusters();
       handleOpenRouterReturn();
     }
@@ -16251,6 +16390,7 @@ const dashboardHTML = `<!DOCTYPE html>
     startAssignCounterTicker();
     setInterval(loadAdminUsers, POLL_INTERVAL_MS);
     setInterval(loadClusterHealth, CLUSTER_HEALTH_POLL_MS);
+    setInterval(loadReach, REACH_POLL_MS);
     var _refreshTimer = null;
     var REFRESH_DEBOUNCE_MS = 500;
     function debouncedRefresh() {

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -1091,6 +1091,12 @@ type HubServer struct {
 	reachReporter reach.ReachReporter
 	reachPRSource reach.PRSource
 	reachAncestry reach.Ancestry
+
+	// reachHistory is the fleet-level error-rate retention (#3995, phase 2c):
+	// hourly per-component activity buckets folded in on heartbeat receive,
+	// persisted to reachHistoryPath, read by /api/reach for before/after
+	// deltas. nil on bare test servers; every touch point is nil-safe.
+	reachHistory *reachHistoryStore
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.
@@ -1234,6 +1240,9 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		// commit_order.go's cache (no repo clone ships in the hub image).
 		reachReporter: &reach.StubReachReporter{},
 		reachAncestry: newReachAncestry(logger),
+		// Fleet error-rate history (#3995, phase 2c): loads its persisted
+		// ring from disk here, before the first heartbeat can append.
+		reachHistory: newReachHistoryStore(reachHistoryPath, logger),
 	}
 
 	// Restore any persisted rotation BEFORE anything mints or verifies. A hub
@@ -1398,6 +1407,11 @@ func (s *HubServer) Start(port int) error {
 }
 
 func (s *HubServer) Shutdown(timeout time.Duration) error {
+	// Flush the reach history's final partial save interval (#3995) — the
+	// same durability courtesy the registry gets from its synchronous saves.
+	// Before the listener check: a server shut down before Start still owes
+	// its history a flush, and SaveNow is nil-safe and dirty-gated.
+	s.reachHistory.SaveNow()
 	s.httpMu.Lock()
 	srv := s.httpServer
 	s.httpMu.Unlock()
@@ -1670,6 +1684,17 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// Component reach (#3993): sanitized + clipped, never the raw spoke
 		// report — see sanitizeComponentReach for the bounds. Storage only.
 		ComponentReach: sanitizeComponentReach(payload.ComponentReach),
+	}
+
+	// Fleet error-rate history (#3995, phase 2c): fold this beat's rolling
+	// window_1h buckets into the hub's per-component retention ring. Runs on
+	// the SANITIZED report only, and only when the beat actually carried one
+	// — entry.ComponentReach is still the fresh value here; the carry-forward
+	// of a previous report (below) never reaches this call, so a restarting
+	// spoke's stale report is not re-appended (the dedupe cursor would refuse
+	// it anyway, but not appending is cheaper and clearer).
+	if entry.ComponentReach != nil {
+		s.reachHistory.Append(entry.ID, entry.ComponentReach, time.Now())
 	}
 
 	// Populate ClusterID and the authoritative ProvStatus from the SaaS hive

--- a/src/pkg/reach/history.go
+++ b/src/pkg/reach/history.go
@@ -1,0 +1,212 @@
+package reach
+
+// Error-rate deltas per deploy window (#3995, phase 2c of #3973).
+//
+// The hub stores only each hive's LATEST component_reach report (2a's
+// deliberate design) — sufficient for reach, useless for before/after. Phase
+// 2c adds a fleet-level per-component history of hourly windows on the hub
+// (pkg/hub/reach_history.go); this file holds the shapes that history is read
+// through and the pure delta computation over it.
+//
+// D4 semantics (accepted design, #3973): the delta is keyed on the DEPLOY
+// WINDOW, not the PR — the deployed commit AssignWindows attributed the PR to.
+// Co-deployed PRs therefore share one delta by construction and are labeled
+// shared; this package never reimplements windowing (two implementations that
+// can disagree would be a correctness bug — windows.go is the one authority).
+
+import (
+	"sort"
+	"time"
+)
+
+// minCommitMatchLen is the shortest commit-id prefix accepted as identifying
+// a commit when comparing a short spoke-reported SHA against another id.
+// Seven hex chars is git's own default abbreviation floor; anything shorter
+// is too collision-prone to attribute error rates to.
+const minCommitMatchLen = 7
+
+// HistorySample is one fleet-summed activity bucket for a component:
+// spans_total/spans_error accumulated across every reporting hive whose
+// rolling 1h window fell into this hour, split by the commit that was
+// RUNNING (the anchoring rule — a window's errors belong to the binary that
+// produced them, never to a tag).
+type HistorySample struct {
+	// WindowStart is the hour bucket (UTC, truncated to the hour). Spoke
+	// rolling windows have arbitrary starts, so the hub buckets them onto a
+	// common hourly grid to make cross-hive summation meaningful; the up-to-1h
+	// smear this introduces is inherent and applies equally to both sides of a
+	// delta.
+	WindowStart time.Time `json:"window_start"`
+	Commit      string    `json:"commit"`
+	SpansTotal  int64     `json:"spans_total"`
+	SpansError  int64     `json:"spans_error"`
+}
+
+// HistorySource is the seam between this package and the hub's retention
+// store, mirroring ReachReporter's role for the latest-report store.
+type HistorySource interface {
+	// ComponentWindows returns the fleet-level history samples for one
+	// component, oldest WindowStart first. The returned slice is a snapshot
+	// the caller may read freely; an untracked component returns nil.
+	ComponentWindows(component string) []HistorySample
+}
+
+// StubHistorySource is the in-memory HistorySource used by tests and as the
+// safe default: absent data reads as "no history", never as zero error rate.
+type StubHistorySource struct {
+	// Windows, when non-nil, maps component → samples (oldest first).
+	Windows map[string][]HistorySample
+}
+
+// ComponentWindows implements HistorySource.
+func (s *StubHistorySource) ComponentWindows(component string) []HistorySample {
+	if s == nil || s.Windows == nil {
+		return nil
+	}
+	return s.Windows[component]
+}
+
+// ComponentErrorDelta is the per-(component, deploy-window) error-rate delta:
+// the error ratio in windows AFTER the deployed commit first appears versus an
+// equal count of windows immediately BEFORE. Measured is FALSE whenever either
+// side lacks data (deploy never observed, no before-history, or zero spans on
+// a side) — unmeasured must be distinguishable from zero-delta everywhere this
+// surfaces, so consumers MUST check Measured before reading the numbers.
+type ComponentErrorDelta struct {
+	Component string `json:"component"`
+	// ErrorRateBefore / ErrorRateAfter are span-error ratios in [0,1].
+	ErrorRateBefore float64 `json:"error_rate_before"`
+	ErrorRateAfter  float64 `json:"error_rate_after"`
+	// Delta is after − before: positive means errors ROSE after the deploy.
+	Delta float64 `json:"delta"`
+	// WindowsCompared is the per-side window count (equal by construction).
+	WindowsCompared int  `json:"windows_compared"`
+	Measured        bool `json:"measured"`
+}
+
+// commitsMatch reports whether two commit ids identify the same commit,
+// tolerating the short-vs-full SHA mismatch between spoke reports (ldflags
+// short hash) and other sources: exact equality, or one being a prefix of the
+// other with at least minCommitMatchLen characters.
+func commitsMatch(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	shorter, longer := a, b
+	if len(shorter) > len(longer) {
+		shorter, longer = longer, shorter
+	}
+	return len(shorter) >= minCommitMatchLen && longer[:len(shorter)] == shorter
+}
+
+// ComputeErrorDelta computes the D4 error-rate delta for one component across
+// the deploy window that shipped deployedCommit. samples is the component's
+// fleet history, oldest first (HistorySource.ComponentWindows order).
+//
+// Semantics, exactly:
+//   - the boundary is the earliest bucket where deployedCommit is observed
+//     RUNNING (never a merge or tag event — the #3816 anchoring rule);
+//   - the AFTER side counts only spans attributed to deployedCommit, so a
+//     staggered rollout's old-binary traffic never dilutes the new code's
+//     ratio;
+//   - the BEFORE side counts all pre-boundary traffic (the old regime,
+//     whichever commits it ran);
+//   - both sides use an EQUAL count of windows, taken adjacent to the
+//     boundary (the most comparable regimes).
+//
+// A caution the numbers cannot express: windows are summed across hives, so
+// one high-volume spoke CAN dominate — and therefore skew — a window's ratio.
+// The clamps upstream bound how far, but they cannot make a fleet sum immune
+// to a single loud reporter; treat small deltas accordingly.
+func ComputeErrorDelta(samples []HistorySample, component, deployedCommit string) ComponentErrorDelta {
+	out := ComponentErrorDelta{Component: component}
+	if deployedCommit == "" || len(samples) == 0 {
+		return out
+	}
+
+	// Group samples into buckets, ascending. The input contract is sorted,
+	// but a stable delta must not depend on a caller honoring it — re-sort.
+	byBucket := map[time.Time][]HistorySample{}
+	for _, s := range samples {
+		byBucket[s.WindowStart] = append(byBucket[s.WindowStart], s)
+	}
+	buckets := make([]time.Time, 0, len(byBucket))
+	for b := range byBucket {
+		buckets = append(buckets, b)
+	}
+	sort.Slice(buckets, func(i, j int) bool { return buckets[i].Before(buckets[j]) })
+
+	// Boundary: earliest bucket where the deployed commit was seen running.
+	boundary := -1
+	for i, b := range buckets {
+		for _, s := range byBucket[b] {
+			if commitsMatch(s.Commit, deployedCommit) {
+				boundary = i
+				break
+			}
+		}
+		if boundary >= 0 {
+			break
+		}
+	}
+	if boundary < 0 {
+		// Deploy never observed in the retained history — unmeasured, and
+		// distinguishable from "measured, delta 0".
+		return out
+	}
+
+	// AFTER: buckets from the boundary on that carry deployed-commit traffic.
+	var afterBuckets []time.Time
+	for _, b := range buckets[boundary:] {
+		for _, s := range byBucket[b] {
+			if commitsMatch(s.Commit, deployedCommit) {
+				afterBuckets = append(afterBuckets, b)
+				break
+			}
+		}
+	}
+	beforeBuckets := buckets[:boundary]
+
+	compared := len(afterBuckets)
+	if len(beforeBuckets) < compared {
+		compared = len(beforeBuckets)
+	}
+	if compared == 0 {
+		return out
+	}
+	// Equal counts, adjacent to the boundary: the LAST `compared` before
+	// windows and the FIRST `compared` after windows.
+	beforeBuckets = beforeBuckets[len(beforeBuckets)-compared:]
+	afterBuckets = afterBuckets[:compared]
+
+	var beforeTotal, beforeErr, afterTotal, afterErr int64
+	for _, b := range beforeBuckets {
+		for _, s := range byBucket[b] {
+			beforeTotal += s.SpansTotal
+			beforeErr += s.SpansError
+		}
+	}
+	for _, b := range afterBuckets {
+		for _, s := range byBucket[b] {
+			if commitsMatch(s.Commit, deployedCommit) {
+				afterTotal += s.SpansTotal
+				afterErr += s.SpansError
+			}
+		}
+	}
+	if beforeTotal <= 0 || afterTotal <= 0 {
+		// A ratio over zero executions is undefined; reporting it as 0.0
+		// would fabricate a perfect error rate from absence of data.
+		return out
+	}
+
+	out.ErrorRateBefore = float64(beforeErr) / float64(beforeTotal)
+	out.ErrorRateAfter = float64(afterErr) / float64(afterTotal)
+	out.Delta = out.ErrorRateAfter - out.ErrorRateBefore
+	out.WindowsCompared = compared
+	out.Measured = true
+	return out
+}

--- a/src/pkg/reach/history_test.go
+++ b/src/pkg/reach/history_test.go
@@ -1,0 +1,239 @@
+package reach
+
+// Tests for the D4 error-rate delta (#3995, phase 2c of #3973). The
+// load-bearing assertions are PER-COMPONENT NUMERIC delta values (not just
+// shape counts), the divide-by-zero guard (a zero-span side must read as
+// unmeasured, never as NaN or a fabricated 0.0 error rate), and the dominant
+// production case on this fleet: auto-upgrade converges in ~a minute, so a
+// commit whose pre-deploy history was never retained must come back
+// measured=false — before-side absence is normal, not an edge.
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+)
+
+// histBucket returns the n-th hourly bucket of a fixed test day.
+func histBucket(n int) time.Time {
+	return time.Date(2026, 8, 17, n, 0, 0, 0, time.UTC)
+}
+
+func TestComputeErrorDelta(t *testing.T) {
+	const oldCommit = "01dc0de"
+	const newCommit = "beef456"
+
+	cases := []struct {
+		name       string
+		samples    []HistorySample
+		deployed   string
+		wantBefore float64
+		wantAfter  float64
+		wantDelta  float64
+		wantWin    int
+		measured   bool
+	}{
+		{
+			name: "measured both sides, exact per-component rates",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 100, SpansError: 10},
+				{WindowStart: histBucket(1), Commit: oldCommit, SpansTotal: 100, SpansError: 10},
+				{WindowStart: histBucket(2), Commit: newCommit, SpansTotal: 100, SpansError: 20},
+				{WindowStart: histBucket(3), Commit: newCommit, SpansTotal: 100, SpansError: 20},
+			},
+			deployed:   newCommit,
+			wantBefore: 0.1, wantAfter: 0.2, wantDelta: 0.1, wantWin: 2, measured: true,
+		},
+		{
+			name: "staggered rollout: old-binary traffic after the boundary never dilutes the new code's ratio",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 100, SpansError: 10},
+				{WindowStart: histBucket(1), Commit: newCommit, SpansTotal: 100, SpansError: 20},
+				// A laggard hive still on the old binary in the after window,
+				// erroring wildly: must not count toward the after side.
+				{WindowStart: histBucket(1), Commit: oldCommit, SpansTotal: 1000, SpansError: 1000},
+			},
+			deployed:   newCommit,
+			wantBefore: 0.1, wantAfter: 0.2, wantDelta: 0.1, wantWin: 1, measured: true,
+		},
+		{
+			name: "converged fleet with no retained before-history is UNMEASURED (the dominant production case)",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: newCommit, SpansTotal: 100, SpansError: 5},
+				{WindowStart: histBucket(1), Commit: newCommit, SpansTotal: 100, SpansError: 5},
+			},
+			deployed: newCommit,
+			measured: false,
+		},
+		{
+			name: "deploy never observed running is unmeasured",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 100, SpansError: 10},
+			},
+			deployed: newCommit,
+			measured: false,
+		},
+		{
+			name: "zero-span before side is unmeasured, never a divide-by-zero",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 0, SpansError: 0},
+				{WindowStart: histBucket(1), Commit: newCommit, SpansTotal: 10, SpansError: 1},
+			},
+			deployed: newCommit,
+			measured: false,
+		},
+		{
+			name: "zero-span after side is unmeasured, never a divide-by-zero",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 10, SpansError: 1},
+				{WindowStart: histBucket(1), Commit: newCommit, SpansTotal: 0, SpansError: 0},
+			},
+			deployed: newCommit,
+			measured: false,
+		},
+		{
+			name: "equal counts taken adjacent to the boundary, not from deep history",
+			samples: []HistorySample{
+				// An ancient terrible window that a naive whole-history
+				// average would drag in (100% errors)…
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 100, SpansError: 100},
+				{WindowStart: histBucket(1), Commit: oldCommit, SpansTotal: 100, SpansError: 0},
+				{WindowStart: histBucket(2), Commit: oldCommit, SpansTotal: 100, SpansError: 0},
+				// …one after-window means one before-window: bucket 2 only.
+				{WindowStart: histBucket(3), Commit: newCommit, SpansTotal: 100, SpansError: 0},
+			},
+			deployed:   newCommit,
+			wantBefore: 0, wantAfter: 0, wantDelta: 0, wantWin: 1, measured: true,
+		},
+		{
+			name: "short spoke SHA matches a full deploy SHA by prefix",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 100, SpansError: 10},
+				{WindowStart: histBucket(1), Commit: "beef456", SpansTotal: 100, SpansError: 30},
+			},
+			deployed:   "beef456aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			wantBefore: 0.1, wantAfter: 0.3, wantDelta: 0.2, wantWin: 1, measured: true,
+		},
+		{
+			name: "a sub-minimum prefix does not match (collision guard)",
+			samples: []HistorySample{
+				{WindowStart: histBucket(0), Commit: oldCommit, SpansTotal: 100, SpansError: 10},
+				{WindowStart: histBucket(1), Commit: "beef45", SpansTotal: 100, SpansError: 30},
+			},
+			deployed: "beef456aaaaaaaa",
+			measured: false,
+		},
+		{
+			name:     "no samples at all is unmeasured",
+			samples:  nil,
+			deployed: newCommit,
+			measured: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ComputeErrorDelta(tc.samples, "hub", tc.deployed)
+			if got.Component != "hub" {
+				t.Errorf("Component = %q, want hub", got.Component)
+			}
+			if got.Measured != tc.measured {
+				t.Fatalf("Measured = %v, want %v (unmeasured must be distinguishable from zero-delta)", got.Measured, tc.measured)
+			}
+			if !tc.measured {
+				// The unmeasured contract: every numeric field zero, so no
+				// consumer can mistake absence of data for a measured 0.0.
+				if got.ErrorRateBefore != 0 || got.ErrorRateAfter != 0 || got.Delta != 0 || got.WindowsCompared != 0 {
+					t.Errorf("unmeasured delta carries numbers: %+v", got)
+				}
+				return
+			}
+			const eps = 1e-9
+			if math.Abs(got.ErrorRateBefore-tc.wantBefore) > eps {
+				t.Errorf("ErrorRateBefore = %v, want %v", got.ErrorRateBefore, tc.wantBefore)
+			}
+			if math.Abs(got.ErrorRateAfter-tc.wantAfter) > eps {
+				t.Errorf("ErrorRateAfter = %v, want %v", got.ErrorRateAfter, tc.wantAfter)
+			}
+			if math.Abs(got.Delta-tc.wantDelta) > eps {
+				t.Errorf("Delta = %v, want %v", got.Delta, tc.wantDelta)
+			}
+			if got.WindowsCompared != tc.wantWin {
+				t.Errorf("WindowsCompared = %d, want %d", got.WindowsCompared, tc.wantWin)
+			}
+			// The result must always survive JSON encoding: a NaN from a
+			// removed divide-guard fails Marshal outright at runtime, which
+			// would break /api/reach's whole response.
+			if _, err := json.Marshal(got); err != nil {
+				t.Errorf("delta does not JSON-encode: %v", err)
+			}
+		})
+	}
+}
+
+// TestComputeErrorDeltaUnsortedInput: the delta must not depend on callers
+// honoring the oldest-first contract.
+func TestComputeErrorDeltaUnsortedInput(t *testing.T) {
+	samples := []HistorySample{
+		{WindowStart: histBucket(3), Commit: "beef456", SpansTotal: 100, SpansError: 20},
+		{WindowStart: histBucket(0), Commit: "01dc0de", SpansTotal: 100, SpansError: 10},
+		{WindowStart: histBucket(2), Commit: "beef456", SpansTotal: 100, SpansError: 20},
+		{WindowStart: histBucket(1), Commit: "01dc0de", SpansTotal: 100, SpansError: 10},
+	}
+	got := ComputeErrorDelta(samples, "hub", "beef456")
+	if !got.Measured || got.WindowsCompared != 2 || math.Abs(got.Delta-0.1) > 1e-9 {
+		t.Errorf("unsorted input mis-computed: %+v", got)
+	}
+}
+
+// TestAttachErrorDeltas: deltas attach per attributable component AFTER
+// window assignment, include unmeasured components (never dropped), and stay
+// absent entirely without a deploy window or history source.
+func TestAttachErrorDeltas(t *testing.T) {
+	history := &StubHistorySource{Windows: map[string][]HistorySample{
+		"hub": {
+			{WindowStart: histBucket(0), Commit: "01dc0de", SpansTotal: 100, SpansError: 10},
+			{WindowStart: histBucket(1), Commit: "beef456", SpansTotal: 100, SpansError: 30},
+		},
+		// "governor" has no history at all.
+	}}
+	a := &Analyzer{History: history}
+
+	report := PRReachReport{
+		DeployWindow: "beef456",
+		Attribution:  Attribute([]string{"src/pkg/hub/saas.go", "src/pkg/governor/governor.go"}),
+	}
+	a.AttachErrorDeltas(&report)
+	if len(report.ErrorDeltas) != 2 {
+		t.Fatalf("ErrorDeltas = %d entries, want 2 (one per attributable component, unmeasured included): %+v",
+			len(report.ErrorDeltas), report.ErrorDeltas)
+	}
+	byComponent := map[string]ComponentErrorDelta{}
+	for _, d := range report.ErrorDeltas {
+		byComponent[d.Component] = d
+	}
+	hub := byComponent["hub"]
+	if !hub.Measured || math.Abs(hub.Delta-0.2) > 1e-9 || math.Abs(hub.ErrorRateBefore-0.1) > 1e-9 || math.Abs(hub.ErrorRateAfter-0.3) > 1e-9 {
+		t.Errorf("hub delta = %+v, want measured before=0.1 after=0.3 delta=0.2", hub)
+	}
+	gov := byComponent["governor"]
+	if gov.Component != "governor" || gov.Measured {
+		t.Errorf("governor delta = %+v, want present and unmeasured", gov)
+	}
+
+	// No deploy window → no deltas, not zero-valued deltas.
+	undeployed := PRReachReport{Attribution: report.Attribution}
+	a.AttachErrorDeltas(&undeployed)
+	if undeployed.ErrorDeltas != nil {
+		t.Errorf("ErrorDeltas without a deploy window = %+v, want nil", undeployed.ErrorDeltas)
+	}
+
+	// No history source → no deltas.
+	noHistory := &Analyzer{}
+	withWindow := PRReachReport{DeployWindow: "beef456", Attribution: report.Attribution}
+	noHistory.AttachErrorDeltas(&withWindow)
+	if withWindow.ErrorDeltas != nil {
+		t.Errorf("ErrorDeltas without a history source = %+v, want nil", withWindow.ErrorDeltas)
+	}
+}

--- a/src/pkg/reach/metrics.go
+++ b/src/pkg/reach/metrics.go
@@ -72,6 +72,15 @@ type PRReachReport struct {
 	// A PR with no attributable components (docs-only) never raises it.
 	NeverRan              bool `json:"never_ran"`
 	NeverRanThresholdDays int  `json:"never_ran_threshold_days"`
+
+	// ErrorDeltas (#3995, phase 2c) carries one per-component error-rate
+	// delta for this PR's deploy window — after-vs-before, D4-shared with the
+	// PRs in SharedWith by construction. Filled by AttachErrorDeltas AFTER
+	// window assignment (a lone PR cannot know its deploy window); nil when
+	// the PR has no observed deploy window or the analyzer has no history
+	// source. Entries with Measured=false are emitted, never dropped —
+	// "unmeasured" must stay distinguishable from "measured, zero delta".
+	ErrorDeltas []ComponentErrorDelta `json:"error_deltas,omitempty"`
 }
 
 // Analyzer joins merged-PR facts against the fleet's reach reports. All
@@ -81,6 +90,9 @@ type PRReachReport struct {
 type Analyzer struct {
 	Ancestry Ancestry
 	Reporter ReachReporter
+	// History is the fleet-level error-rate history (#3995); nil means no
+	// retention is available and ErrorDeltas legitimately stay nil.
+	History HistorySource
 	// NeverRanAfter is the never-ran grace period; zero means
 	// NeverRanThreshold() (env-tunable default).
 	NeverRanAfter time.Duration
@@ -166,4 +178,20 @@ func (a *Analyzer) Analyze(pr PRInfo) (PRReachReport, error) {
 		report.NeverRan = true
 	}
 	return report, nil
+}
+
+// AttachErrorDeltas fills report.ErrorDeltas (#3995) once the caller has
+// assigned the PR's deploy window via AssignWindows — deliberately a second
+// step, because the delta is keyed on the deploy window (D4) and Analyze runs
+// per-PR before windows exist. No-op without a history source or an observed
+// deploy window: an unmeasurable delta is ABSENT, never fabricated. Every
+// attributable component gets an entry, including unmeasured ones.
+func (a *Analyzer) AttachErrorDeltas(report *PRReachReport) {
+	if a == nil || a.History == nil || report == nil || report.DeployWindow == "" {
+		return
+	}
+	for _, component := range report.Attribution.Components {
+		report.ErrorDeltas = append(report.ErrorDeltas,
+			ComputeErrorDelta(a.History.ComponentWindows(component), component, report.DeployWindow))
+	}
 }


### PR DESCRIPTION
## Motivation & Context

Phase 2c — the **final phase** of the PR reach telemetry epic #3973 — per the accepted design (D1–D4) and the 2026-08-17 addendum. Supersedes #4018, whose independent reading of the scope converged on the same complements-never-collapsed framing (credit where due); it predated the 2b wiring (`RegistryReachReporter`, `722d1317`) and the retention design below, which is the heart of 2c. The review findings from #4018 were incorporated (details at the end).

## The core problem: deltas need history

The hub stores only each hive's LATEST `component_reach` report (2a's deliberate design) — sufficient for reach, useless for before/after. Computing "before" from laggard hives still running the old commit fails on this fleet: auto-upgrade converges in ~60s, so that delta goes nil forever after convergence.

**New: bounded hub-side retention** (`src/pkg/hub/reach_history.go`)
- On heartbeat receive (beside `sanitizeComponentReach`), the report's rolling **`window_1h`** bucket — equivalent-period windows, never cumulative-since-boot counts, which would compare unequal periods — folds into a fleet-level per-component ring of hourly buckets, **summed per (hour bucket, component, running commit)**. Per-hive history is deliberately not kept.
- **Dedupe**: heartbeats beat faster than windows roll, so a per-(component, hive) cursor makes a re-reported window contribute only its increment — never a second full copy. The cursor is persisted, so a hub restart cannot re-sum a window the previous process already counted.
- **Bounds** (all named consts): 168 windows per component (7 days), fleet-level component cap (2× the per-spoke cap), per-bucket commit fan-out cap, cursor cap; eviction oldest-first; **over-cap input clipped and LOGGED**, never silent.
- **Hostile input**: window timestamps must parse and fall inside the ring span (future-skew tolerance, age floor), counts clamped non-negative, out-of-order replays refused. Acknowledged limitation the caps cannot remove: windows are fleet sums, so one high-volume spoke can skew a window's ratio (documented in code).
- **Persistence**: own file `/data/reach-history.json` (2a's own-file pattern), atomic tmp+rename, dirty-gated cadence, flushed at shutdown, **re-bounded on load** so a hand-edited file cannot bypass the caps.

## The delta (D4 semantics, exact)

`src/pkg/reach/history.go` — pure computation, keyed on the deploy window from 2b's `windows.go` co-attribution (**no second windowing implementation**; two that can disagree would be a correctness bug). Per (component, deploy-window):
- boundary = earliest bucket where the deployed commit is observed RUNNING (#3816 anchoring rule);
- **after** side counts only the deployed commit's spans, so staggered-rollout old-binary traffic never dilutes the new code's ratio;
- **before** side counts the whole old regime, equal window count, adjacent to the boundary;
- emits `error_rate_before`, `error_rate_after`, `delta`, `windows_compared`, `measured` — **`measured=false` whenever either side lacks data**. On this fleet the converged case (no retained before-history) is the dominant one and reads unmeasured, never a fabricated 0.0.

## Surface (deliberately small)

1. **`/api/reach`**: each PR report now carries `error_deltas` (attached after window assignment; shared across co-deployed PRs by construction, labeled via the existing `shared_with`).
2. **One table** on the hub's `/dashboard` status surface, following the admin-only Cluster Health section pattern exactly (collapse state, 403 hides, `.hive-table`): PR, components (+coverage tooltip), reach (hives), first-exec latency, **error Δ or the literal word "unmeasured"**, never-ran / not-deployed / D4-shared flags. Reach data lives on the hub (registry + ring), so the table lives beside the endpoint that serves it — no spoke-side dead table, no new page, no charts. Slow poll (5 min): each load fans out GitHub queries hub-side.
3. **Advisor: deliberately not wired.** The spoke-side advisor (`buildACMMStatusInputs`) has no data path to the hub's fleet store — any reach field there would be permanently unmeasured, and an unmeasurable signal must never gate promotion. Recorded as an explicit follow-up in the design doc (`docs/design/pr-reach-telemetry.md`), which also gains the 2b/2c implementation record.

## Testing

`go test ./pkg/reach/ ./pkg/hub/ ./pkg/dashboard/ -count=1` — all green; `-race` green on the new concurrent code (store Append vs reader).

- **Per-component numeric delta assertions** (not shape counts): exact before/after/delta values, incl. a staggered-rollout fixture proving old-commit traffic is excluded from the after side.
- **Divide-by-zero fixture**: a zero-span side is unmeasured — plus a JSON-encode assertion so a removed guard's NaN can't silently break `/api/reach` at runtime.
- **Converged-fleet fixture** (dominant production case): before side absent → `measured=false`, zeroed numbers, entry still present.
- **Ring bounding** (169th bucket evicts oldest-first), **component-cap clip is counted AND logged**, commit-fan-out cap, hostile timestamps refused and logged.
- **Dedupe**: same hive re-reporting one window (idle beat, grown beat, mid-window restart) never double-counts; persistence round-trip proves the cursor survives a hub restart.
- **Production-possible fixtures only**: multi-hive mixed-commit fleets — never one hive reporting two commits (a state 2a's loader prevents).
- End-to-end: heartbeat → sanitize → fold; `/api/reach` response carries measured deltas with exact values; dashboard surface wiring pinned (incl. the `unmeasured` literal and the `measured`-flag branch).
- **Guard-removal verification, performed**: the dedupe test, component-cap test, timestamp-clamp test, and divide-by-zero test were each run against their guard removed and **each FAILS** (dedupe → doubled totals; cap → cap exceeded + missing log; clamp → hostile windows land; divide-guard → NaN/measured-on-empty).

## #4018 review findings incorporated

1. Retention ring instead of laggard-hive comparison; rates sourced from `window_1h`, not cumulative counts.
2. No advisor promotion gates on the new signal (no `acmmadvisor` changes at all; unmeasured is visibly distinct everywhere it surfaces).
3. Table placed hub-side next to `/api/reach`, not in the spoke SPA that cannot see fleet reach.
4. Per-component numeric delta assertions + divide-by-zero fixture + converged-fleet unmeasured case.
5. Production-possible fixtures (multi-hive mixed fleets; single-hive dedupe case).

Fixes #3995
Part of #3973