### PR TITLE
🐛 fix(relay): a finished agy turn could pin the relay to "working" forever, and nothing reclaimed the task

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1227,9 +1227,25 @@ function classifyTmuxPane(text) {
     hasCompletionMarker = /completed|done|finished|tokens\)|\d+\.\d+%/i.test(text);
     isWorking = /Reading|Writing|Bash|Editing|thinking|running/i.test(text);
   } else if (BACKEND === 'agy') {
+    // Scope the activity check to the TAIL, exactly as the claude branch above
+    // does. agy narrates in plain English inside the transcript ("I am running
+    // the pkg/agent tests…", "Analyzing…"), and those lines stay on screen after
+    // the turn ends. A whole-pane, case-insensitive scan for bare verbs
+    // therefore reads a FINISHED turn as still working — forever, since the
+    // stale line never scrolls off on its own. Observed live: a pane with
+    // hasIdlePrompt=true was pinned to WORKING by a single narration line left
+    // over from the PREVIOUS task, so the relay never reported completion and
+    // kept renewing the hub's task lease; the contributor had to Ctrl-C.
+    //
+    // The marker SET is deliberately unchanged — only the window it looks at.
+    // Narrowing which verbs count would need a live agy turn to verify against,
+    // and getting that wrong would be the opposite (and worse) bug: reporting a
+    // busy agent as idle. The stall backstop in progressTick() covers whatever
+    // this still misses.
+    const agyTail = text.split('\n').slice(-15).join('\n');
     hasIdlePrompt = /\? for shortcuts/.test(text);
     hasCompletionMarker = true;
-    isWorking = /Running|Searching|Reading|Writing|Editing/i.test(text);
+    isWorking = /Running|Searching|Reading|Writing|Editing/i.test(agyTail);
   } else {
     hasIdlePrompt = />\s*$|\$\s*$/.test(text);
     hasCompletionMarker = /completed|done|finished/i.test(text);
@@ -1279,6 +1295,53 @@ function relaunchCLI() {
   // a prompt must hand its task back rather than sit on it silently.
   armCLIReadyWait();
   return launchCmd;
+}
+
+// --- Pane stall backstop ------------------------------------------------
+//
+// A relay that BELIEVES it is working renews the hub's task lease on every
+// progress report, so the hub's wedged-worker reclaim (wsTaskTimeout +
+// cleanupLoop in src/pkg/dashboard/contribute_ws.go) can never fire against it.
+// That guard only catches a relay that goes SILENT — a crash or a hang. A relay
+// stuck in a false "working" belief keeps the lease alive forever, the task
+// stays in-progress, no further work is offered, and the only way out is a
+// human pressing Ctrl-C. That is not a state a contributor should have to
+// notice, let alone fix by hand.
+//
+// So: if the pane content has not CHANGED at all for this long while we are
+// reporting "working", stop asserting progress we cannot substantiate and hand
+// the task back as an `environment` failure — the honest verdict, since a
+// frozen pane tells us nothing about whether the work itself was done. The hub
+// then requeues it through its normal release path.
+//
+// Deliberately generous: a real agent can sit on one silent command (a long
+// test suite, a slow clone) for many minutes without drawing anything new.
+const PANE_STALL_TIMEOUT_MS = Number(process.env.HIVE_PANE_STALL_TIMEOUT_MS) || 20 * 60 * 1000;
+
+let lastPaneFingerprint = null;
+let lastPaneChangeAt = 0;
+
+function resetPaneStallClock() {
+  lastPaneFingerprint = null;
+  lastPaneChangeAt = Date.now();
+}
+
+// paneStalled records the current pane content and reports whether it has been
+// byte-for-byte identical for longer than PANE_STALL_TIMEOUT_MS.
+function paneStalled(tmuxLines) {
+  const fingerprint = Array.isArray(tmuxLines) ? tmuxLines.join('\n') : String(tmuxLines || '');
+  const now = Date.now();
+  if (fingerprint !== lastPaneFingerprint) {
+    lastPaneFingerprint = fingerprint;
+    lastPaneChangeAt = now;
+    return false;
+  }
+  // An empty capture means tmux told us nothing (session gone, capture failed).
+  // That is not evidence of a stalled AGENT, and other paths already handle a
+  // missing pane, so never let it trip this backstop.
+  if (!fingerprint) return false;
+  if (!lastPaneChangeAt) { lastPaneChangeAt = now; return false; }
+  return now - lastPaneChangeAt >= PANE_STALL_TIMEOUT_MS;
 }
 
 function flushPendingTask() {
@@ -1373,6 +1436,9 @@ function startProgressReporting() {
   if (taskTimeoutHandle) clearTimeout(taskTimeoutHandle);
   if (!taskAssignedAt) taskAssignedAt = Date.now();
   lastProgressTick = Date.now();
+  // Every task starts with a clean stall clock — the previous task's pane
+  // fingerprint says nothing about this one.
+  resetPaneStallClock();
 
   taskTimeoutHandle = setTimeout(() => {
     if (currentTask) {
@@ -1506,6 +1572,15 @@ function progressTick() {
       tmux_output: tmuxLines,
     });
   } else {
+    // Stall backstop: a pane frozen this long is not evidence of work, and
+    // continuing to report "working" would renew the hub's lease forever.
+    if (paneStalled(tmuxLines)) {
+      failCurrentTask(
+        `no pane activity for ${Math.round(PANE_STALL_TIMEOUT_MS / 60000)} minutes — the agent CLI is not visibly working`,
+        { kind: 'environment' }
+      );
+      return;
+    }
     send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: tmuxLines });
   }
 }
@@ -1824,6 +1899,15 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     PANE_STATE_IDLE_COMPLETE,
     // Run one progress tick with the grace period already elapsed.
     __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
+    paneStalled,
+    resetPaneStallClock,
+    PANE_STALL_TIMEOUT_MS,
+    // Backdate the stall clock so a test can cross the timeout without
+    // sleeping — the two ticks it needs otherwise land in the same millisecond.
+    __agePaneStallClock: (ms) => { lastPaneChangeAt -= ms; },
+    // Run a progress tick past the startup grace period, as __crashTick does,
+    // so the stall backstop can be exercised without waiting it out.
+    __stallTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
     cleanup,
     restartBackoffMs,
     NO_MODEL_FLAG_BACKENDS,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -214,6 +214,96 @@ test('bob never receives --model even when AGENT_MODEL is set', () => {
   } finally { teardown(relay); }
 });
 
+// --- agy pane classification: stale narration must not pin WORKING ---------
+//
+// Verbatim shape of a real wedged pane (kubestellar/hive): agy had finished the
+// turn and printed its no_work_needed verdict, and was sitting at its idle
+// prompt. One line of narration left over from the PREVIOUS task — "I am
+// running the pkg/agent tests…" — kept the whole-pane isWorking scan true, so
+// the relay never reported completion, kept renewing the hub's task lease, and
+// the contributor had to Ctrl-C to get any further work.
+const AGY_WEDGED_PANE = [
+  'Edit(~/hive/src/pkg/agent/manager_test.go)',
+  'Bash(cd src && go test ./pkg/agent)',
+  '',
+  'I am running the pkg/agent tests with the shortened temp directory path to verify they now pass locally as well.',
+  // The turn continues for a while after that line — in the pane this fixture
+  // came from it sat 36 rows above the bottom, far outside any sane tail.
+  ...Array.from({ length: 20 }, (_, i) => `  ok  github.com/kubestellar/hive/pkg/thing${i}  0.0${i}s`),
+  '',
+  '  HIVE_VERDICT: no_work_needed — standing living document tracker, not an actionable task',
+  '────────────────────────────────────────────',
+  '>',
+  '────────────────────────────────────────────',
+  '? for shortcuts',
+].join('\n');
+
+test('agy at its idle prompt is COMPLETE even with stale narration on screen', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    assert.strictEqual(
+      relay.classifyTmuxPane(AGY_WEDGED_PANE), relay.PANE_STATE_IDLE_COMPLETE,
+      'a finished agy turn must not read as working just because an older line says "running"');
+  } finally { teardown(relay); }
+});
+
+test('agy still reads as WORKING while activity is in the tail', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    const busy = [
+      'HIVE_VERDICT: no_work_needed — an older, finished turn',
+      '',
+      'Bash(go build ./...)',
+      'Reading src/pkg/agent/manager.go',
+    ].join('\n');
+    assert.strictEqual(
+      relay.classifyTmuxPane(busy), relay.PANE_STATE_WORKING,
+      'agy with fresh activity at the bottom of the pane must stay WORKING');
+  } finally { teardown(relay); }
+});
+
+// --- Pane stall backstop ---------------------------------------------------
+//
+// The hub's wedged-worker reclaim only catches a relay that goes SILENT; one
+// that keeps reporting "working" renews the lease forever. These pin the
+// relay-side half: an unchanging pane eventually stops claiming progress.
+test('an unchanging pane trips the stall backstop; any change resets it', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    const past = () => relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    assert.strictEqual(relay.paneStalled(['same']), false, 'first sighting only records the fingerprint');
+    past();
+    assert.strictEqual(relay.paneStalled(['same']), true, 'unchanged pane past the timeout is stalled');
+    assert.strictEqual(relay.paneStalled(['different']), false, 'a changed pane restarts the clock');
+    past();
+    assert.strictEqual(relay.paneStalled(['different']), true);
+    // An empty capture is a missing pane, not a stalled agent.
+    assert.strictEqual(relay.paneStalled([]), false);
+    past();
+    assert.strictEqual(relay.paneStalled([]), false, 'an empty capture must never trip the backstop');
+  } finally { teardown(relay); }
+});
+
+test('a stalled pane hands the task back as an environment failure', () => {
+  const relay = loadRelay({
+    backend: 'agy',
+    paneText: 'a frozen pane with no idle prompt and nothing happening',
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-stall');
+    relay.__stallTick();   // records the fingerprint, reports working
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();   // same pane past the timeout -> give the task back
+    const failed = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(failed.length, 1, `expected one task_failed, got ${JSON.stringify(relay.__sent.map(m => m.type))}`);
+    assert.strictEqual(failed[0].failure_kind, 'environment',
+      'a frozen pane says nothing about the WORK, so the failure is the environment kind');
+    assert.match(failed[0].reason, /no pane activity/);
+    assert.strictEqual(relay.getCurrentTask(), null, 'the relay must let go of the task, not keep renewing its lease');
+  } finally { teardown(relay); }
+});
+
 test('agy pairs --effort with --model, and omits it when no model is set', () => {
   // agy warns "--model <m> requires --effort (available: low, medium, high)"
   // and then IGNORES the model, so the two flags must travel together. Mirrors


### PR DESCRIPTION
## Symptom

Observed on a live contributor relay. agy had finished its turn, printed its `no_work_needed` verdict, and was sitting at its idle prompt — but the relay kept sending `task_progress status:'working'`. The hub held the task in-progress, offered no further work, and the only way out was the contributor pressing Ctrl-C.

## Cause 1 — agy's `isWorking` matched prose anywhere on screen

```js
isWorking = /Running|Searching|Reading|Writing|Editing/i.test(text);   // whole pane
```

agy narrates in plain English inside its transcript, and those lines stay on screen after the turn ends. Measured against the actual wedged pane:

```
hasIdlePrompt   = true
isWorking (whole pane)   = true
isWorking (15-line tail) = false
matching lines: 1
   > "I am running the pkg/agent tests with the shortened temp directory path to verify they now pass locally as well"
```

One line of narration **from the previous task**, sitting 36 rows above the bottom, where it would never scroll off on its own.

The `claude` branch already scopes this exact check to `lastLines`; agy now does too. The marker **set** is deliberately unchanged — narrowing which verbs count needs verification against a live agy turn, and getting that wrong means reporting a busy agent as idle, which is the worse failure.

## Cause 2 — nothing could reclaim the task

`contribute_ws.go` documents the lease TTL as the guard for "a wedged-but-connected worker". It can't fire here: the relay renews that lease on every progress report, and the wedge *is* the relay believing it's working.

```js
send({ type:'task_progress', …, status:'working' })   // relay, every tick
contributor.lastLeaseRenew = time.Now()               // hub, on every one
```

So the guard only catches a relay that goes **silent**. A relay stuck in a false "working" belief renews forever.

`progressTick` now fingerprints the pane. If it hasn't changed at all for `PANE_STALL_TIMEOUT_MS` (default 20 min, overridable with `HIVE_PANE_STALL_TIMEOUT_MS`), the relay stops asserting progress it cannot substantiate and hands the task back as an `environment` failure — the honest kind, since a frozen pane says nothing about whether the work got done. The hub requeues it through its normal release path.

Deliberately generous window: a real agent can sit on one silent command (long test suite, slow clone) for many minutes. An empty capture never trips it — that's a missing pane, not a stalled agent, and other paths already handle that.

## Scope note

Several other backends (`gemini`, `goose`, `codex`, `pi`) scan the whole pane for similar bare verbs and can wedge the same way. I did not touch them here — I only have a verified reproduction for agy, and the stall backstop protects all of them regardless.

## Tests

- agy at its idle prompt with stale narration on screen classifies `IDLE_COMPLETE`; the fixture reproduces the real pane's geometry (narration outside the tail), so re-widening the window fails the test.
- agy with fresh activity in the tail still classifies `WORKING`.
- `paneStalled` trips only after the timeout, resets on any change, and never trips on an empty capture.
- A stalled pane produces exactly one `task_failed` with `failure_kind: "environment"` and the relay lets go of the task instead of renewing its lease.

84/84 relay tests pass; the Go tests that read this file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)