### PR TITLE
🐛 fix(hub): leaked background commit-order resolves reached the real GitHub API from unit tests, flaking the coverage gate

### DIFF
--- a/src/pkg/hub/commit_order_test.go
+++ b/src/pkg/hub/commit_order_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +15,9 @@ import (
 // ============================================================
 
 // resetCommitOrderState clears the ancestry cache/in-flight maps and restores
-// the real compare fetcher after the test. All fetcher writes happen under
+// the suite-default compare fetcher (the offline TestMain stub — the real
+// network fetcher is never active during tests) after the test. All fetcher
+// writes happen under
 // commitOrderMu — the mutex commitAtOrAheadOfTarget captures the var under —
 // so a background resolve leaked from another test can never race them.
 func resetCommitOrderState(t *testing.T) {
@@ -340,5 +343,62 @@ func TestTriggerAutoUpgradesClearsSurpassedManualTarget(t *testing.T) {
 	}
 	if armed {
 		t.Error("expected stale heartbeat fallback drained, not re-armed")
+	}
+}
+
+// The production compare fetcher's HTTP behaviour, exercised directly against
+// a local server. TestMain replaces the fetchCommitCompareStatus var with an
+// offline stub for the whole suite (background resolves must never reach the
+// real GitHub API from unit tests), so this is the one place the real
+// implementation runs — via the realFetchCommitCompareStatus handle captured
+// before the swap.
+func TestFetchCommitCompareStatusHTTP(t *testing.T) {
+	if realFetchCommitCompareStatus == nil {
+		t.Fatal("TestMain did not capture the real compare fetcher")
+	}
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    string
+		wantErr bool
+	}{
+		{"ahead", func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.URL.Path, "/repos/kubestellar/hive/compare/aaaaaaa...bbbbbbb") {
+				t.Errorf("unexpected compare path %s", r.URL.Path)
+			}
+			w.Write([]byte(`{"status":"ahead"}`))
+		}, "ahead", false},
+		{"non-200", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}, "", true},
+		{"empty status", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{}`))
+		}, "", true},
+		{"bad json", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{`))
+		}, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+			oldBase := githubAPIBase
+			githubAPIBase = srv.URL
+			defer func() { githubAPIBase = oldBase }()
+
+			status, err := realFetchCommitCompareStatus("aaaaaaa", "bbbbbbb", slog.Default())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got status %q", status)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if status != tc.want {
+				t.Errorf("status = %q, want %q", status, tc.want)
+			}
+		})
 	}
 }

--- a/src/pkg/hub/main_test.go
+++ b/src/pkg/hub/main_test.go
@@ -1,9 +1,16 @@
 package hub
 
 import (
+	"fmt"
+	"log/slog"
 	"os"
 	"testing"
 )
+
+// realFetchCommitCompareStatus preserves the production compare fetcher so its
+// HTTP behaviour stays directly testable (TestFetchCommitCompareStatusHTTP)
+// after TestMain swaps the package var for the offline default below.
+var realFetchCommitCompareStatus func(base, head string, logger *slog.Logger) (string, error)
 
 // TestMain isolates the hub test suite from any real Kubernetes cluster.
 //
@@ -38,5 +45,27 @@ func TestMain(m *testing.M) {
 	// KUBECONFIG could equally point a real kubectl at a real cluster for the
 	// non-InCluster branch, so neutralize it to a path that cannot exist.
 	os.Setenv("KUBECONFIG", os.DevNull)
+
+	// Commit-order ancestry resolves are kicked as BACKGROUND goroutines from
+	// the heartbeat completion chain, the orphan sweep and triggerAutoUpgrades
+	// (commitAtOrAheadOfTarget). Any test that crosses those paths with an
+	// unresolved SHA pair — most don't even know they do — would otherwise
+	// launch a REAL GitHub compare call with a 10s budget
+	// (commitCompareTimeout). One slow call is exactly the 2026-08-17 coverage
+	// red at bb2d554d: a leaked resolver outlived three consecutive 2s
+	// waitForCommitOrderResolvers deadlines in sha_poll_coverage_test.go, so
+	// TestListRepoBranches{,Error} and TestFetchBranchSHAImageReady failed on
+	// an otherwise green branch. Default the fetcher to an instant offline
+	// error: errors are never cached, so semantics match "resolution pending"
+	// (fail-closed — an unknown pair never reads as complete), and tests that
+	// need definitive answers already stub via stubCommitCompare or
+	// seedCommitOrder. Held under commitOrderMu per the var's contract.
+	commitOrderMu.Lock()
+	realFetchCommitCompareStatus = fetchCommitCompareStatus
+	fetchCommitCompareStatus = func(base, head string, _ *slog.Logger) (string, error) {
+		return "", fmt.Errorf("commit-order compare %s...%s: network disabled in unit tests (stub via stubCommitCompare)", base, head)
+	}
+	commitOrderMu.Unlock()
+
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
## What broke

The 22:02 UTC Coverage Hourly run at bb2d554d ([run 32074166826](https://github.com/kubestellar/hive/actions/runs/32074166826)) reported `hub: TESTS FAILING`:

- `TestListRepoBranches` (2.00s)
- `TestListRepoBranchesError` (2.00s)
- `TestFetchBranchSHAImageReady` (2.00s)

All three died in `waitForCommitOrderResolvers` (`sha_poll_coverage_test.go`): "timed out waiting for 1 commit order resolver(s)". The next hourly run at b1469036 ([32078732974](https://github.com/kubestellar/hive/actions/runs/32078732974)) was green with only docs commits in between — the branch was never actually broken; this is a race, and the coverage gate cannot score hub while it fires.

(The 16:02–18:05 reds that day were a different, pre-existing condition: the `agent` package coverage ratchet, not hub.)

## Root cause

`commitAtOrAheadOfTarget` (heartbeat completion at `server.go:1911`/`2289`, orphan sweep at `stale_upgrade.go:183`, `triggerAutoUpgrades` at `saas.go:5315`) kicks a deduplicated **background** `resolveCommitOrder` goroutine whose default `fetchCommitCompareStatus` performs a real HTTPS call to `githubAPIBase` with a 10s budget (`commitCompareTimeout`). Any earlier test crossing one of those paths with an unresolved SHA pair — without stubbing the fetcher — leaks that goroutine into subsequent tests.

The red run's timeline matches a **single** leaked resolver: the three sha-poll tests failed their 2s entry waits at +2s/+4s/+6s, and the fourth (`TestFetchBranchSHAImageBuilding`) passed — the call drained inside its 10s budget.

## Fix (at the seam, not per test)

- `TestMain` installs an instant offline `fetchCommitCompareStatus` (error return). Errors are never cached, so the semantics are exactly "resolution pending" — the existing fail-closed default where an unknown pair never reads as complete. No invariant is weakened: the unresolved-ancestry regression tests (`TestHandleHeartbeatKeepsLatchWhileAncestryUnresolved`, `TestEvaluateOrphanedUpgradeAheadOfTargetIsConverged`) already stubbed an erroring fetcher and are unchanged; tests needing definitive answers keep using `stubCommitCompare`/`seedCommitOrder`.
- The real fetcher stays covered — its original function is captured in `realFetchCommitCompareStatus` before the swap, and the new `TestFetchCommitCompareStatusHTTP` exercises ahead / non-200 / empty-status / bad-json against a local `httptest` server (its first direct coverage; previously reachable only over the live network).
- Unit tests no longer emit real `api.github.com` traffic as a side effect.

## Verification

- `go test ./pkg/hub/ -run 'TestListRepoBranches$|TestListRepoBranchesError$|TestFetchBranchSHAImageReady$' -count=1` — green
- Full `go test ./pkg/hub/ -count=1` — green (229s)
- `go vet ./pkg/hub/` — clean

Fixes #4022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
