### PR TITLE
docs: remove internal cluster names from v2 branch docs

### DIFF
--- a/v2/docs/cross-cluster-migration.md
+++ b/v2/docs/cross-cluster-migration.md
@@ -1,30 +1,30 @@
 # Migrating a Hosted Hive Between Clusters (vanilla Kubernetes → OpenShift)
 
 This guide documents the manual procedure for moving a hosted hive from one
-cluster to another, using a real migration as the reference: the `kellyaa`
-hive, moved from **hive-oke** (vanilla Kubernetes, OKE) to **vllm-d**
+cluster to another, using a real migration as the reference: a hive moved from
+a **hub-reachable cluster** (vanilla Kubernetes) to a **heartbeat-only cluster**
 (OpenShift). Every gotcha below was hit during that migration.
 
 Moving a hive between clusters is a **manual procedure**. The hub used to
 expose a `POST /api/saas/hives/{id}/migrate` endpoint that automated it as
 "fresh provision on the target + deprovision of the source"; it was removed
 because the automation was not worth the maintenance it demanded — it could
-not work at all when the hub had no `kubectl` path to the target (the vllm-d
-case), and it was actively destructive when run after a manual move, since it
-found no source secrets to copy and provisioned a credential-less hive over a
-working deployment.
+not work at all when the hub had no `kubectl` path to the target (the
+heartbeat-only case), and it was actively destructive when run after a manual
+move, since it found no source secrets to copy and provisioned a
+credential-less hive over a working deployment.
 
 ## Background: how the two clusters differ
 
-**hive-oke (vanilla Kubernetes).** Dashboards are reached via
+**Hub-reachable cluster (vanilla Kubernetes).** Dashboards are reached via
 `*.hive.kubestellar.io`. The hub's nginx ingress performs authentication
 (`auth-url` pointing at `/api/saas/auth-check`) and injects `X-Hive-User` /
 `X-Hive-Role` headers into proxied requests. Spokes on this cluster do **not**
 need their own OAuth configuration — the hub is the auth proxy.
 
-**vllm-d (OpenShift).** The hub has **no network path** to this cluster; the
-spoke reports in via heartbeats only. Dashboards are therefore exposed
-directly via OpenShift Routes on `*.apps.fmaas-vllm-d.fmaas.res.ibm.com`, and
+**Heartbeat-only cluster (OpenShift).** The hub has **no network path** to this
+cluster; the spoke reports in via heartbeats only. Dashboards are therefore
+exposed directly via OpenShift Routes on `*.apps.<your-cluster-domain>`, and
 each spoke must run its **own GitHub device-flow login** — there is no hub
 auth proxy in front of it.
 
@@ -45,8 +45,8 @@ From the source namespace (`hive-hosted-<hive-id>`), copy to the target:
 
 ### 2. Create the Service and Routes
 
-Mirror an existing vllm-d hive (e.g. `osscar`) rather than writing these from
-scratch.
+Mirror an existing hive already running on the target (heartbeat-only) cluster
+rather than writing these from scratch.
 
 **Service** named `hive`, selector `app=hive` plus the hive-id label, with
 two ports:
@@ -57,7 +57,7 @@ two ports:
 | `dashboard` | 3002 |
 
 **Two OpenShift Routes**, both with host
-`<hive-id>.apps.fmaas-vllm-d.fmaas.res.ibm.com` and TLS edge termination with
+`<hive-id>.apps.<your-cluster-domain>` and TLS edge termination with
 `insecureEdgeTerminationPolicy: Redirect`:
 
 | Route | Path | targetPort |
@@ -77,14 +77,14 @@ Add to `hive.yaml`:
 ```yaml
 github:
   # Public Hive GitHub App client ID — enables device-flow dashboard login.
-  # Required on vllm-d because there is no hub auth proxy in front of the
-  # dashboard. Without it the login page errors:
+  # Required on a heartbeat-only cluster because there is no hub auth proxy in
+  # front of the dashboard. Without it the login page errors:
   #   "oauth_client_id not configured"
   oauth_client_id: Ov23ligE2p0gjXg6xAUf
 
 hub:
   # The spoke reports this URL in its heartbeats.
-  dashboard_url: https://<hive-id>.apps.fmaas-vllm-d.fmaas.res.ibm.com
+  dashboard_url: https://<hive-id>.apps.<your-cluster-domain>
 ```
 
 > **Gotcha — the heartbeat owns `dashboardUrl`.** The hub registry's
@@ -163,8 +163,8 @@ These live on the hub pod's PVC — **back them up first** (`kubectl cp` or a
 
 **`/data/saas/hives/<hive-id>/meta.json`:**
 
-- `cluster_id` → `vllm-d`
-- `subdomain` → `<hive-id>.apps.fmaas-vllm-d.fmaas.res.ibm.com`
+- `cluster_id` → the target (heartbeat-only) cluster's ID
+- `subdomain` → `<hive-id>.apps.<your-cluster-domain>`
 
 **`/data/hub-registry.json`:** update the hive's entry — `clusterId` /
 `clusterName`. You can leave `dashboardUrl` alone: once step 3 is done, the
@@ -183,13 +183,13 @@ attached to one node anyway). Before deleting, decide whether any
 pre-migration PVC data needs to be kept.
 
 ```sh
-kubectl --context hive-oke delete namespace hive-hosted-<hive-id>
+kubectl --context <source-cluster> delete namespace hive-hosted-<hive-id>
 ```
 
 ### 6. Verify
 
 - Dashboard returns 200 at
-  `https://<hive-id>.apps.fmaas-vllm-d.fmaas.res.ibm.com`.
+  `https://<hive-id>.apps.<your-cluster-domain>`.
 - GitHub sign-in (device flow) works on the spoke's login page.
 - Hub registry shows the hive on the new cluster with fresh heartbeats.
 - The **My Hives → Dashboard** button targets the new URL (i.e. the

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -6,12 +6,13 @@ This guide documents how hosted hives are provisioned, covering both paths:
   the hub can reach with `kubectl`. This is the normal path.
 - **Manual provisioning** — hand-applied manifests, required when the hub has
   **no network path** to the target cluster (a *heartbeat-only* cluster). This
-  is the situation on **vllm-d**.
+  is the situation on any **heartbeat-only** cluster.
 
 Every command and manifest below was executed and verified while standing up a
-pool of ten placeholder hives — five on **vllm-d** (manual) and five on
-**hive-oke** (automated) — so the procedure is real, not aspirational. Where a
-step has a non-obvious failure mode, it is called out as a **Gotcha**.
+pool of ten placeholder hives — five on a **heartbeat-only** cluster (manual)
+and five on a **hub-reachable** cluster (automated) — so the procedure is real,
+not aspirational. Where a step has a non-obvious failure mode, it is called out
+as a **Gotcha**.
 
 ---
 
@@ -20,36 +21,38 @@ step has a non-obvious failure mode, it is called out as a **Gotcha**.
 The provisioning path is dictated entirely by whether the hub can `kubectl` to
 the target cluster.
 
-| | **hive-oke** (vanilla Kubernetes) | **vllm-d** (OpenShift) |
+| | **Hub-reachable cluster** (vanilla Kubernetes) | **Heartbeat-only cluster** (OpenShift) |
 |---|---|---|
 | Hub reachability | Hub **can** `kubectl` → **automated** provisioning | Hub is **heartbeat-only** → **manual** provisioning |
-| Dashboard routing | nginx **Ingress**, host `<id>.hive.kubestellar.io` | OpenShift **Route**, host `<id>.apps.fmaas-vllm-d.fmaas.res.ibm.com` |
+| Dashboard routing | nginx **Ingress**, host `<id>.hive.kubestellar.io` | OpenShift **Route**, host `<id>.apps.<your-cluster-domain>` |
 | Auth in front of the dashboard | Hub's nginx ingress runs `auth-url` → `/api/saas/auth-check`, injecting `X-Hive-User` / `X-Hive-Role`. Spokes need **no** own OAuth. | No hub auth proxy. Each spoke runs its **own** GitHub device-flow login (`oauth_client_id`, `hub_proxied: false`). |
 | Pod security | Standard Kubernetes; empty `securityContext`. | OpenShift SCC. The pod **must** run under the `anyuid` SCC (the entrypoint `chown`s the PVC as root). Without it the pod lands on `restricted-v2` and crash-loops. |
 | Storage | RWX volume, default storage class. | RWX on `ocs-storagecluster-cephfs`. |
 | Which methods it serves | **Public** methods (claude / copilot / gemini — subscription CLIs). | **Private** methods (litellm / vllm / llm-d — self-hosted inference). |
 
 > **Why methods map to clusters.** Public-method hives run subscription CLIs and
-> need no in-cluster inference, so they live on the hub's own cluster (hive-oke).
-> Private-method hives point at a self-hosted inference endpoint that lives on
-> vllm-d, so the hive runs there too — and vllm-d is heartbeat-only, which is
-> exactly why it needs the manual path.
+> need no in-cluster inference, so they live on the hub's own (hub-reachable)
+> cluster. Private-method hives point at a self-hosted inference endpoint that
+> lives on the heartbeat-only cluster, so the hive runs there too — and that
+> cluster is heartbeat-only, which is exactly why it needs the manual path.
 
 ---
 
 ## Prerequisites (both paths)
 
-- `kubectl` access with a context per cluster (`hive-oke`, `vllm-d`).
-- The hub is running on **hive-oke** in namespace `hive-hub`, backed by a RWX
-  PVC named `hive-hub-data-rwx` mounted at `/data`. The hub's SaaS store lives
-  at `/data/saas/hives/<id>/meta.json`; its fleet registry at
+- `kubectl` access with a context per cluster (one for the hub-reachable
+  cluster, one for the heartbeat-only cluster).
+- The hub is running on the **hub-reachable** cluster in namespace `hive-hub`,
+  backed by a RWX PVC named `hive-hub-data-rwx` mounted at `/data`. The hub's
+  SaaS store lives at `/data/saas/hives/<id>/meta.json`; its fleet registry at
   `/data/hub-registry.json`.
-- For manual (vllm-d) provisioning: the `system:openshift:scc:anyuid`
-  ClusterRole must exist (it does by default on OpenShift).
+- For manual (heartbeat-only cluster) provisioning: the
+  `system:openshift:scc:anyuid` ClusterRole must exist (it does by default on
+  OpenShift).
 
 ---
 
-## Path A — Automated provisioning (hive-oke)
+## Path A — Automated provisioning (hub-reachable cluster)
 
 The hub exposes `POST /api/saas/hives` (`handleCreateHive`). It generates the
 hive ID, creates the namespace + RBAC + PVC + Service + Ingress + Deployment,
@@ -62,11 +65,11 @@ simply the username, validated against the SaaS user store. From **inside the
 hub pod** (localhost), that is all you need:
 
 ```bash
-HUB_POD=$(kubectl --context hive-oke -n hive-hub get pods -l app=hive-hub \
+HUB_POD=$(kubectl --context <hub-reachable-cluster> -n hive-hub get pods -l app=hive-hub \
   --no-headers | grep Running | awk '{print $1}' | head -1)
 
-kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- curl -s -X POST \
-  -H "Cookie: hive_hub_user=clubanderson" \
+kubectl --context <hub-reachable-cluster> -n hive-hub exec "$HUB_POD" -- curl -s -X POST \
+  -H "Cookie: hive_hub_user=<hub-admin-login>" \
   -H "Content-Type: application/json" \
   -d '{
         "org": "myorg",
@@ -74,7 +77,7 @@ kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- curl -s -X POST \
         "primary_repo": "myrepo",
         "project_name": "My Hive",
         "acmm_level": 2,
-        "cluster_id": "hive-oke",
+        "cluster_id": "<hub-reachable-cluster>",
         "auth_method": "app",
         "app_id": "999999999",
         "installation_id": "",
@@ -106,7 +109,7 @@ The generated ID is `hosted-<org>-<primary_repo>-<4char>`.
 | `org`, `repos` | **Required, non-empty.** `repos` is comma-separated. |
 | `primary_repo` | Hosts the advisory issue and default markings. |
 | `acmm_level` | Starting autonomy. **Default new hives to `2`** (Advisory (Instructed) / advisory-only). |
-| `cluster_id` | `hive-oke` (the `defaultClusterID`). |
+| `cluster_id` | the hub-reachable cluster's ID (the `defaultClusterID`). |
 | `auth_method` | `app` or a token. |
 | `app_id` / `installation_id` / `app_private_key` | Three auth shapes: **token** (`github_token` starts `ghp_`/`github_pat_`); **app now** (all three set); **app later** — `app_id` set, `installation_id` **and** `app_private_key` **empty**. The last is the placeholder case: pass the sentinel `app_id: 999999999` (see [Placeholder `app_id`](#placeholder-app_id)) and the hive provisions into dashboard-only mode until the owner installs the App from the dashboard. |
 | `is_public` | Pointer. **Absent defaults to public.** Send `false` explicitly for a private hive. |
@@ -128,10 +131,10 @@ the main structural difference between the two `meta.json` shapes.
 
 ---
 
-## Path B — Manual provisioning (vllm-d)
+## Path B — Manual provisioning (heartbeat-only cluster)
 
-The hub cannot reach vllm-d, so every object is applied by hand with
-`kubectl --context vllm-d`. The full set, in order:
+The hub cannot reach a heartbeat-only cluster, so every object is applied by hand
+with `kubectl --context <heartbeat-only-cluster>`. The full set, in order:
 
 1. Namespace
 2. ServiceAccount (`hive-sa`)
@@ -148,10 +151,10 @@ The hub cannot reach vllm-d, so every object is applied by hand with
 Set these shell variables for the target hive:
 
 ```bash
-CTX=vllm-d
+CTX=<heartbeat-only-cluster>    # kubectl context for the target cluster
 ID=hosted-myorg-myrepo          # the hive ID
 NS=hive-hosted-$ID              # namespace is always hive-hosted-<id>
-ROUTE_HOST=$ID.apps.fmaas-vllm-d.fmaas.res.ibm.com
+ROUTE_HOST=$ID.apps.<your-cluster-domain>
 IMAGE=ghcr.io/kubestellar/hive:v2-latest
 SC=ocs-storagecluster-cephfs
 
@@ -259,7 +262,7 @@ data:
     project:
       org: myorg                      # a POOL PLACEHOLDER can seed any bootstrap org here; the
       repos: [myrepo]                 # AUTHORITATIVE identity is the meta.json org
-      primary_repo: myrepo            # (available-vllmd-<date>-<suffix>), which is what the hub
+      primary_repo: myrepo            # (available-<cluster>-<date>-<suffix>), which is what the hub
                                       # renders — see Placeholder pools below
     agents:
       guide:   { backend: copilot, model: claude-sonnet-4-6, enabled: true }
@@ -277,8 +280,8 @@ data:
     dashboard:
       port: 3002
       authorized_users:
-        - owner-github-login:owner    # a POOL PLACEHOLDER lists the pool owner: clubanderson:owner
-      hub_proxied: false              # vllm-d has no hub auth proxy → direct device-flow
+        - owner-github-login:owner    # a POOL PLACEHOLDER lists the pool owner: <hub-admin-login>:owner
+      hub_proxied: false              # heartbeat-only cluster has no hub auth proxy → direct device-flow
     hub:
       enabled: true
       url: https://hive.kubestellar.io
@@ -320,9 +323,10 @@ YAML
 > when the App is installed. To do it by hand, patch the PVC overlay
 > (`/data/hive.yaml.dashboard`, **not** the ConfigMap) and restart the pod.
 
-> **Gotcha — `hub_proxied` must be `false` on vllm-d.** vllm-d has no hub nginx
-> auth proxy. If `hub_proxied` is `true`, dashboard sign-in enters an OAuth
-> redirect loop. On hive-oke it is the opposite — the hub proxy handles auth.
+> **Gotcha — `hub_proxied` must be `false` on a heartbeat-only cluster.** A
+> heartbeat-only cluster has no hub nginx auth proxy. If `hub_proxied` is `true`,
+> dashboard sign-in enters an OAuth redirect loop. On the hub-reachable cluster
+> it is the opposite — the hub proxy handles auth.
 
 ### B.5 Secret
 
@@ -498,14 +502,14 @@ YAML
 > heartbeat *attempts*, not successes. A hub that is down, firewalled, or
 > rejecting beats leaves the process perfectly healthy, and restarting it
 > cannot fix a network partition — an earlier version gated liveness on
-> heartbeat freshness and crash-looped healthy spokes on firewalled clusters
-> (vllm-d). Heartbeat freshness is reported by `/api/health/deep` under the
+> heartbeat freshness and crash-looped healthy spokes on firewalled
+> (heartbeat-only) clusters. Heartbeat freshness is reported by `/api/health/deep` under the
 > `hub_heartbeat` check, and the hub greys the hive's dot on its own.
 > Spokes deployed before this fix need a redeploy (or a probe patch) to stop
 > restarting on hub outages.
 
 > **Gotcha — some clusters enforce an `owner` label.** A `ValidatingAdmissionPolicy`
-> on vllm-d requires an `owner` label on `PersistentVolumeClaim`, `ConfigMap`,
+> on the heartbeat-only cluster requires an `owner` label on `PersistentVolumeClaim`, `ConfigMap`,
 > `Secret`, `Service`, and `Deployment`. Objects still apply without it, but each
 > emits a warning. Add `owner: <github-login>` to every `metadata.labels` block
 > to silence them.
@@ -535,7 +539,7 @@ no hub restart.
 
 ```bash
 ID=hosted-myorg-myrepo
-HUB_POD=$(kubectl --context hive-oke -n hive-hub get pods -l app=hive-hub \
+HUB_POD=$(kubectl --context <hub-reachable-cluster> -n hive-hub get pods -l app=hive-hub \
   --no-headers | grep Running | awk '{print $1}' | head -1)
 
 cat > /tmp/meta.json <<JSON
@@ -552,18 +556,18 @@ cat > /tmp/meta.json <<JSON
   "subdomain": "",
   "auto_upgrade": true,
   "is_public": false,
-  "cluster_id": "vllm-d"
+  "cluster_id": "<heartbeat-only-cluster>"
 }
 JSON
 
-kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- \
+kubectl --context <hub-reachable-cluster> -n hive-hub exec "$HUB_POD" -- \
   sh -c "mkdir -p /data/saas/hives/${ID}"
-kubectl --context hive-oke -n hive-hub cp /tmp/meta.json \
+kubectl --context <hub-reachable-cluster> -n hive-hub cp /tmp/meta.json \
   hive-hub/"$HUB_POD":/data/saas/hives/${ID}/meta.json
 ```
 
 **Visibility rule.** `handleMyHives` shows a hive to a user when the user is its
-`owner`, has a role on it, **or** is the hub admin (`clubanderson`) — even if the
+`owner`, has a role on it, **or** is the hub admin — even if the
 hive has no fleet-registry entry (never heartbeated). So a hive with
 `owner: <someone>` in its `meta.json` appears in that person's My Hives (and the
 admin's) as soon as the file exists.
@@ -652,9 +656,9 @@ A **placeholder** is a fully-provisioned but idle hive, waiting to be claimed �
 so a request for access is satisfied in seconds instead of the full 5–10 minute
 provision. Two pools, one per method type:
 
-- **vllm-d** placeholders serve **private** methods — provisioned manually
+- **Heartbeat-only-cluster** placeholders serve **private** methods — provisioned manually
   (Path B) and left running at **`replicas: 1`**.
-- **hive-oke** placeholders serve **public** methods — provisioned via the API
+- **Hub-reachable-cluster** placeholders serve **public** methods — provisioned via the API
   (Path A) and left running at **`replicas: 1`**.
 
 > **Gotcha — placeholder IDs are date + random suffix, NOT sequential integers.**
@@ -675,8 +679,8 @@ provision. Two pools, one per method type:
 > exist — against both the hub meta dirs and the target cluster's namespaces:
 >
 > ```bash
-> kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- ls /data/saas/hives/   # existing hive IDs
-> kubectl --context vllm-d get ns | grep hive-hosted-hosted-available-vllmd        # existing namespaces
+> kubectl --context <hub-cluster> -n hive-hub exec "$HUB_POD" -- ls /data/saas/hives/   # existing hive IDs
+> kubectl --context <heartbeat-only-cluster> get ns | grep hive-hosted-hosted-available        # existing namespaces
 > ```
 
 Provision each placeholder as above at **`replicas: 1`**. The pod boots
@@ -684,11 +688,11 @@ immediately, lands on the `anyuid` SCC, and heartbeats to the hub as an
 available slot ready to be claimed. Both pools stay at `replicas: 1`:
 
 ```bash
-# manual (vllm-d): apply the Deployment at replicas: 1 (it boots and heartbeats).
+# manual (heartbeat-only cluster): apply the Deployment at replicas: 1 (it boots and heartbeats).
 # If you applied it at 0, scale it up:
-kubectl --context vllm-d -n "$NS" scale deploy/hive --replicas=1
+kubectl --context <heartbeat-only-cluster> -n "$NS" scale deploy/hive --replicas=1
 
-# automated (hive-oke): the API already provisions at replicas=1 — leave it there.
+# automated (hub-reachable cluster): the API already provisions at replicas=1 — leave it there.
 ```
 
 > **Gotcha — do NOT scale placeholders to 0.** A `replicas: 0` slot is **not
@@ -702,7 +706,7 @@ visibility), **`status: "available"`**, and **`acmm_level: 2`**. Set `org` to a
 **unique** value per slot — `available-vllmd-<YYMMDD>-<suffix>` mirroring the
 `id`'s date-suffix — with **empty** `repos: []` and `primary_repo: ""` (they get
 their real values when the slot is claimed). The `meta.json` also carries
-`github_host` because vllm-d placeholders target GitHub Enterprise
+`github_host` because heartbeat-only-cluster placeholders target GitHub Enterprise
 (`github.ibm.com`), not `github.com`:
 
 ```json
@@ -716,11 +720,11 @@ their real values when the slot is claimed). The `meta.json` also carries
   "acmm_level": 2,
   "status": "available",
   "created_at": "",
-  "subdomain": "hosted-available-vllmd-260806-1bo3.apps.fmaas-vllm-d.fmaas.res.ibm.com",
+  "subdomain": "hosted-available-260806-1bo3.apps.<your-cluster-domain>",
   "claim_delivered": false,
   "auto_upgrade": true,
   "is_public": false,
-  "cluster_id": "vllm-d",
+  "cluster_id": "<heartbeat-only-cluster>",
   "github_host": "github.ibm.com"
 }
 ```
@@ -733,23 +737,23 @@ their real values when the slot is claimed). The `meta.json` also carries
 
 ### Verify a provisioned placeholder
 
-A correct vllm-d placeholder runs at `replicas: 1` with its pod up (`Running`,
+A correct heartbeat-only-cluster placeholder runs at `replicas: 1` with its pod up (`Running`,
 `ready`, `restartCount: 0`) on the `anyuid` SCC, its `hive-anyuid` binding points
 at its **own** namespace, its PVC is `Bound`, its `livez` returns 200, and its hub
 `meta.json` exists. This set verified all ten placeholders in the 2026-08-06 batch:
 
 ```bash
 ID=hosted-available-vllmd-<date>-<suffix>; NS=hive-hosted-$ID
-kubectl --context vllm-d -n $NS get deploy hive -o jsonpath='{.spec.replicas}'          # must be 1
-POD=$(kubectl --context vllm-d -n $NS get pod -l app=hive -o jsonpath='{.items[0].metadata.name}')
-kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.status.phase}'              # must be Running
-kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.metadata.annotations.openshift\.io/scc}'  # must be anyuid
-kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.status.containerStatuses[0].ready}'       # must be true
-kubectl --context vllm-d -n $NS get pod $POD -o jsonpath='{.status.containerStatuses[0].restartCount}' # must be 0
-kubectl --context vllm-d -n $NS exec $POD -c hive -- curl -s -o /dev/null -w '%{http_code}' localhost:3002/api/livez  # must be 200
-kubectl --context vllm-d -n $NS get rolebinding hive-anyuid -o jsonpath='{.subjects[0].namespace}'  # must equal $NS
-kubectl --context vllm-d -n $NS get pvc hive-data -o jsonpath='{.status.phase}'         # must be Bound
-kubectl --context hive-oke -n hive-hub exec $HUB_POD -- test -f /data/saas/hives/$ID/meta.json  # must exist
+kubectl --context <heartbeat-only-cluster> -n $NS get deploy hive -o jsonpath='{.spec.replicas}'          # must be 1
+POD=$(kubectl --context <heartbeat-only-cluster> -n $NS get pod -l app=hive -o jsonpath='{.items[0].metadata.name}')
+kubectl --context <heartbeat-only-cluster> -n $NS get pod $POD -o jsonpath='{.status.phase}'              # must be Running
+kubectl --context <heartbeat-only-cluster> -n $NS get pod $POD -o jsonpath='{.metadata.annotations.openshift\.io/scc}'  # must be anyuid
+kubectl --context <heartbeat-only-cluster> -n $NS get pod $POD -o jsonpath='{.status.containerStatuses[0].ready}'       # must be true
+kubectl --context <heartbeat-only-cluster> -n $NS get pod $POD -o jsonpath='{.status.containerStatuses[0].restartCount}' # must be 0
+kubectl --context <heartbeat-only-cluster> -n $NS exec $POD -c hive -- curl -s -o /dev/null -w '%{http_code}' localhost:3002/api/livez  # must be 200
+kubectl --context <heartbeat-only-cluster> -n $NS get rolebinding hive-anyuid -o jsonpath='{.subjects[0].namespace}'  # must equal $NS
+kubectl --context <heartbeat-only-cluster> -n $NS get pvc hive-data -o jsonpath='{.status.phase}'         # must be Bound
+kubectl --context <hub-cluster> -n hive-hub exec $HUB_POD -- test -f /data/saas/hives/$ID/meta.json  # must exist
 ```
 
 > **The `hive-anyuid` subject-namespace check is still load-bearing at apply
@@ -817,14 +821,14 @@ labels rather than written as an empty/invalid label.
 Given a hive name, find its namespace:
 
 ```bash
-kubectl --context hive-oke get ns \
+kubectl --context <hub-cluster> get ns \
   -l hive.kubestellar.io/hive-name=tradingasbuddies
 ```
 
 Given a namespace, find the hive that owns it:
 
 ```bash
-kubectl --context hive-oke get ns hive-hosted-hosted-available-oke-01-placeholder-bb95 \
+kubectl --context <hub-cluster> get ns hive-hosted-hosted-available-oke-01-placeholder-bb95 \
   -o jsonpath='{.metadata.annotations.hive\.kubestellar\.io/display-name}'
 # -> TradingAsBuddies
 ```
@@ -900,7 +904,7 @@ hive owner doesn't need `kubectl` at all to find it:
 # delete the workload namespace
 kubectl --context "$CTX" delete ns "$NS"
 # remove the hub SaaS record
-kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- \
+kubectl --context <hub-cluster> -n hive-hub exec "$HUB_POD" -- \
   rm -rf /data/saas/hives/"$ID"
 # if it ever heartbeated, also drop its registry entry (see the placeholder gotcha)
 ```
@@ -919,7 +923,7 @@ kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- \
 | Pod won't boot: `github.token or github.app_id is required` | `github.app_id` empty in the seed | Set the placeholder sentinel `app_id: 999999999` — exactly that value, see [Placeholder `app_id`](#placeholder-app_id). Any other stand-in number is treated as a real App |
 | Pod `CrashLoopBackOff` with `failed to init GitHub App auth` / `reading app key ...: no such file`, restarts climbing, hive offline on the hub, rollout stuck with two crashlooping pods | A non-sentinel placeholder `app_id` plus a real `installation_id`, and no private key at `key_file`. Older builds exited before the listener bound, so nothing was visible in the dashboard | Set `app_id` to the real App ID and install the PEM at `key_file` (or set `app_id` to the sentinel `999999999` to park the hive in dashboard-only mode). Patch `/data/hive.yaml.dashboard` and restart. Current builds boot degraded and show the reason in the GitHub App banner instead of crashlooping |
 | Dashboard banner: "GitHub App private key could not be loaded from ..." | A real `app_id` + `installation_id`, but no readable PEM at the resolved path | The banner names the exact path tried and the resolution order (`$GH_APP_KEY_FILE` → `github.key_file` → PVC `/data/gh-app-key.pem` → provisioning mount `/secrets/gh-app-key.pem`). Write the PEM to that path, or point `github.key_file` at one |
-| Dashboard sign-in redirect loop (vllm-d) | `hub_proxied: true` on a cluster with no hub auth proxy | Set `hub_proxied: false` on the PVC overlay |
+| Dashboard sign-in redirect loop (heartbeat-only cluster) | `hub_proxied: true` on a cluster with no hub auth proxy | Set `hub_proxied: false` on the PVC overlay |
 | Hive online but **Upgrade** → `hive not found` | No `meta.json` on the hub | Create `/data/saas/hives/<id>/meta.json` |
 | Not visible in My Hives | No `meta.json`, or `owner` doesn't match | Create/patch `meta.json` with the right `owner` |
 | ConfigMap edits have no effect | PVC overlay is authoritative | Edit `/data/hive.yaml.dashboard`, not the ConfigMap |


### PR DESCRIPTION
Scrubs internal cluster/host names (vllm-d, hive-oke, fmaas route host) from the v2 (sunset) branch docs, matching the v4 treatment. Meaning-preserving: hub-reachable vs heartbeat-only cluster distinction kept; kubectl --context values and route hosts genericized to placeholders. Files: v2/docs/manual-provisioning.md, v2/docs/cross-cluster-migration.md. Verified: no vllm-d/hive-oke/a-ks-wec2/fmaas remain in v2/docs.