### PR TITLE
🔧 ci: enable the v5 implementation branch

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -13,7 +13,7 @@ on:
   # that actually lands. `src/**` is the Go module directory on BOTH branches —
   # it is the module path, not the branch name — so the path filter is unchanged.
   pull_request:
-    branches: [v2, v4]
+    branches: [v2, v4, v5]
     paths: ['src/**']
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,13 @@ jobs:
       - name: Decide push policy
         id: decide
         env:
-          LONG_LIVED: "v2 v4 mk dd"
+          # v5 added (RFC #4000/#4001/#4002 implementation line, branched from v4
+          # HEAD): without it here the '**' trigger above still BUILDS v5 as a CI
+          # gate, but never PUSHES, so v5-latest would never exist on GHCR. This
+          # only publishes the branch-scoped v5-latest/<sha> tags — see the
+          # release_channels note below for why v5 does NOT also get
+          # stable/candidate/edge.
+          LONG_LIVED: "v2 v4 v5 mk dd"
           REF_NAME: ${{ github.ref_name }}
           EVENT: ${{ github.event_name }}
         run: |
@@ -207,6 +213,12 @@ jobs:
           # never a rebuild, and never a manual promotion step that can be
           # forgotten. Empty on every other branch, so a feature branch can never
           # move a channel out from under production.
+          # v5 intentionally NOT added to this check: stable/candidate/edge
+          # are production deploy channels that live clusters point to, and
+          # the operator wants v4 untouched by v5's existence. v5 still gets
+          # its own v5-latest tag (from LONG_LIVED above) so it can be
+          # deployed explicitly by branch, but it must never silently retag a
+          # channel out from under v4 production traffic.
           if [ "$REF_NAME" = "v4" ]; then
             echo "release_channels=stable candidate edge" >> "$GITHUB_OUTPUT"
           else
@@ -341,6 +353,12 @@ jobs:
           # never a rebuild, and never a manual promotion step that can be
           # forgotten. Empty on every other branch, so a feature branch can never
           # move a channel out from under production.
+          # v5 intentionally NOT added to this check: stable/candidate/edge
+          # are production deploy channels that live clusters point to, and
+          # the operator wants v4 untouched by v5's existence. v5 still gets
+          # its own v5-latest tag (from LONG_LIVED above) so it can be
+          # deployed explicitly by branch, but it must never silently retag a
+          # channel out from under v4 production traffic.
           if [ "$REF_NAME" = "v4" ]; then
             echo "release_channels=stable candidate edge" >> "$GITHUB_OUTPUT"
           else
@@ -485,6 +503,12 @@ jobs:
           # never a rebuild, and never a manual promotion step that can be
           # forgotten. Empty on every other branch, so a feature branch can never
           # move a channel out from under production.
+          # v5 intentionally NOT added to this check: stable/candidate/edge
+          # are production deploy channels that live clusters point to, and
+          # the operator wants v4 untouched by v5's existence. v5 still gets
+          # its own v5-latest tag (from LONG_LIVED above) so it can be
+          # deployed explicitly by branch, but it must never silently retag a
+          # channel out from under v4 production traffic.
           if [ "$REF_NAME" = "v4" ]; then
             echo "release_channels=stable candidate edge" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/podman-contract.yml
+++ b/.github/workflows/podman-contract.yml
@@ -7,6 +7,10 @@ name: Podman Rootless Contract
 # default (Option A is explicitly deferred pending broader coverage).
 
 on:
+  # v5 (kubestellar/hive#4000/#4001/#4002 implementation line) intentionally NOT
+  # added here: this contract has only ever run on v2, was never extended to v4
+  # when development moved there, and this task's scope is "mirror v4's CI onto
+  # v5" — there is no v4 behavior to mirror for this workflow.
   push:
     branches:
       - v2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
-    branches: [ "main", "v4" ]
+    branches: [ "main", "v4", "v5" ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/suid-contract.yml
+++ b/.github/workflows/suid-contract.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - v2
       - v4
+      - v5
     paths:
       - 'src/Dockerfile'
       - 'src/deploy/entrypoint.sh'
@@ -22,6 +23,7 @@ on:
     branches:
       - v2
       - v4
+      - v5
     paths:
       - 'src/Dockerfile'
       - 'src/deploy/entrypoint.sh'

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -2,13 +2,13 @@ name: v2 CI
 
 on:
   push:
-    branches: [v2, v4]
+    branches: [v2, v4, v5]
     # bin/** is in scope because the gh wrapper is a SECURITY boundary (it is the
     # merge gate behind the proxy hard-deny) and previously matched no path
     # filter at all — a change to it triggered no CI whatsoever.
     paths: ['src/**', 'bin/**', '.github/workflows/v2-ci.yml']
   pull_request:
-    branches: [v2, v4]
+    branches: [v2, v4, v5]
     # bin/** is in scope because the gh wrapper is a SECURITY boundary (it is the
     # merge gate behind the proxy hard-deny) and previously matched no path
     # filter at all — a change to it triggered no CI whatsoever.

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -13,7 +13,7 @@ on:
   # create-issue-on-failure below stays gated on `github.event_name == 'schedule'`,
   # so a red PR fails the check without also filing an issue.
   pull_request:
-    branches: [v2, v4]
+    branches: [v2, v4, v5]
     paths: ['src/**', '.github/workflows/v2-tests.yml']
 
 permissions:


### PR DESCRIPTION
## What

Enables CI for the new `v5` branch — the RFC #4000/#4001/#4002 implementation
line, branched from `v4` HEAD (`9f9a65f2`). `v4` is left untouched by design;
`v5` is where this work lands, per the operator's request to "not muddy v4."

Workflow-files-only diff. No source, deploy, or doc changes.

## Per-workflow changes

| File | Change | Reasoning |
|---|---|---|
| `coverage-hourly.yml` | `pull_request.branches: [v2, v4] → [v2, v4, v5]` | PR-gates the coverage floor on v5 PRs same as v4. Left the `schedule`/`workflow_dispatch` hardcoded `ref: 'v4'` (line 64) untouched — that pins the *hourly* gate to report on the v4 release line specifically; v5 isn't a release line yet and adding it there wasn't asked for. |
| `v2-ci.yml` | `push` and `pull_request` `branches: [v2, v4] → [v2, v4, v5]` (both lists) | Symmetric — build/vet CI now runs on v5 pushes and PRs into v5. |
| `v2-tests.yml` | `pull_request.branches: [v2, v4] → [v2, v4, v5]` | This workflow only has a `pull_request` trigger (no `push`) — there's no second list to extend. `create-issue-on-failure` stays gated on `github.event_name == 'schedule'`, unaffected by branch. |
| `suid-contract.yml` | `push` and `pull_request` `branches` lists — added `v5` | Symmetric. Contract check (su-exec pin, NET_ADMIN ambient-cap invariant) now enforced on v5 too. |
| `scorecard.yml` | `push.branches: ["main","v4"] → ["main","v4","v5"]` | OpenSSF Scorecard now scans v5 pushes. |
| `podman-contract.yml` | **No trigger change** — comment added instead | This contract has only ever run on `v2`; it was never extended to `v4` when development moved there. There's no v4 behavior to mirror onto v5, so extending it here would be adding new scope, not enabling parity. Left a comment explaining the omission. |
| `docker.yml` — `LONG_LIVED` env | `"v2 v4 mk dd" → "v2 v4 v5 mk dd"` | **Publish decision.** The `push: branches: ['**']` trigger already builds v5 as a CI gate with no change needed, but only branches in `LONG_LIVED` actually *push* to GHCR. Without v5 here, `v5-latest` would never exist — defeating the point of enabling v5 CI. This publishes only the branch-scoped `v5-latest`/`<sha>` tags. |
| `docker.yml` — `release_channels` (3 sites: main/contributor/hub images) | **Left v4-only**, `if [ "$REF_NAME" = "v4" ]`, with a reasoning comment added at each site | **Publish decision, opposite conclusion.** `stable`/`candidate`/`edge` are moving production-deploy channels that live clusters point to. Extending these to v5 would let an unreleased implementation branch silently retag production channels out from under v4 — exactly what "v4 untouched" rules out. v5 still gets its own `v5-latest` tag for explicit by-branch deployment; it just can't move the shared channel pointers. |

Grepped every workflow in `.github/workflows/` for `v4`/`v2` branch enumeration
and `github.ref_name`/`REF_NAME` conditionals; the sites above are the
complete set. `prune-ghcr.yml` needed no change — it discovers live branches
dynamically via the GitHub API rather than enumerating them. No
`nightly-release.yml` exists in this repo (the one hit for "nightly" was an
unrelated code comment in `v2-ci.yml` about supply-chain pin history).

## Bootstrap asymmetry (expected)

Until this PR itself merges, most of the workflows above structurally can't
fire on this PR — they only trigger on `pull_request` targeting branches that
don't yet include `v5` in their base-repo copy. The one check that **can** and
**should** run is `docker.yml`'s `gate` job, which triggers on `push:
branches: ['**']` regardless of base-branch lists — that's the required
`gate` check. Everything else lighting up here would be surprising; it's
expected to go green fleet-wide only after merge, on the first real commit to
`v5`.

## Post-merge verification (to be reported separately)

Will confirm the first real `v5` commit triggers `docker.yml` and that
`ghcr.io/kubestellar/hive:v5-latest` exists on GHCR via an anonymous token
manifest check, reporting the resulting digest.
