### PR TITLE
feat(deploy): openshift-netadmin SCC overlay + NET_ADMIN pre-flight docs for standalone OpenShift

### DIFF
--- a/src/deploy/k8s/deployment.yaml
+++ b/src/deploy/k8s/deployment.yaml
@@ -73,6 +73,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+              # OpenShift: NO stock SCC (including `anyuid`) permits adding
+              # these capabilities, so on OpenShift this pod is rejected at
+              # admission unless a cluster-admin has applied the optional
+              # ../kustomize/overlays/openshift-netadmin overlay (dedicated
+              # `hive-netadmin` SCC + RoleBinding). If the cluster cannot grant
+              # NET_ADMIN at all, the deliberate degraded-mode alternative is
+              # HIVE_PROXY_ADVISORY_OK=true (forced proxy egress becomes
+              # advisory) — see ../kustomize/overlays/standalone/
+              # patch-advisory-mode.yaml and src/docs/net-admin-requirement.md.
               add:
                 - NET_ADMIN # ACMM proxy iptables redirect of outbound :443
                 - SETUID # su-exec dev->per-agent UID switch

--- a/src/deploy/kustomize/overlays/openshift-netadmin/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/openshift-netadmin/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# OpenShift capability-grant overlay — OPTIONAL, OpenShift-ONLY, and it
+# REQUIRES cluster-admin to apply (SecurityContextConstraints is a
+# cluster-scoped, admin-only resource).
+#
+# What it is: the dedicated `hive-netadmin` SCC plus the RBAC that lets the
+# `hive` ServiceAccount use it. This is the same SCC/RoleBinding pattern the
+# managed fleet's hub provisions out-of-band; standalone installs have no hub,
+# so a cluster-admin applies this overlay once instead.
+#
+# Why you need it on OpenShift: the base deployment (../../../k8s) requests
+# `capabilities.add` (NET_ADMIN + the su-exec set) and starts as root. NO stock
+# SCC admits that pod — `restricted-v2` forbids root and the caps, and `anyuid`
+# (what ../openshift binds) permits root but forbids ADDING capabilities. With
+# only the stock SCCs the ReplicaSet is rejected at admission with
+# "unable to validate against any security context constraint". The
+# `hive-netadmin` SCC is restricted-v2 loosened by EXACTLY what the base
+# deployment declares — see scc-hive-netadmin.yaml — and nothing else (not
+# privileged, no host access).
+#
+# What it deliberately does NOT include: the workload base. Granting the SCC is
+# a one-time cluster-admin action, decoupled from deploying/upgrading the app,
+# so applying this overlay never re-applies (or reverts) the deployment:
+#
+#   # cluster-admin, once:
+#   oc apply -k src/deploy/kustomize/overlays/openshift-netadmin
+#   # then the app itself (standalone and/or openshift overlays), as usual:
+#   oc apply -k src/deploy/kustomize/overlays/standalone
+#
+# Plain-Kubernetes clusters: do NOT apply this (the SCC API does not exist
+# there); the base stays cluster-agnostic. If your cluster cannot grant
+# NET_ADMIN at all, the deliberate degraded-mode alternative is
+# `HIVE_PROXY_ADVISORY_OK=true` — see
+# ../standalone/patch-advisory-mode.yaml and src/docs/net-admin-requirement.md.
+
+resources:
+  - scc-hive-netadmin.yaml
+  - rolebinding.yaml

--- a/src/deploy/kustomize/overlays/openshift-netadmin/rolebinding.yaml
+++ b/src/deploy/kustomize/overlays/openshift-netadmin/rolebinding.yaml
@@ -1,0 +1,45 @@
+# RBAC that lets the base `hive` ServiceAccount be admitted under the
+# `hive-netadmin` SCC. SCC access is granted via the `use` verb on the named
+# SCC resource; the SCC's own users/groups lists stay empty so this RBAC is the
+# single place the grant is visible and revocable.
+#
+# Both objects require cluster-admin to apply (ClusterRole is cluster-scoped,
+# and binding an SCC is a privilege escalation only an admin can perform).
+#
+# Naming matches the managed fleet's out-of-band pattern: SCC `hive-netadmin`,
+# RoleBinding `hive-netadmin-scc`.
+#
+# The subject is the SA the base actually uses: deployment.yaml sets
+# `serviceAccountName: hive` (defined in dashboard-route-rbac.yaml) — NOT
+# `hive-sa`.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hive-netadmin-scc
+  labels:
+    app.kubernetes.io/name: hive
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - hive-netadmin
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-netadmin-scc
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hive-netadmin-scc
+subjects:
+  - kind: ServiceAccount
+    name: hive
+    namespace: hive

--- a/src/deploy/kustomize/overlays/openshift-netadmin/scc-hive-netadmin.yaml
+++ b/src/deploy/kustomize/overlays/openshift-netadmin/scc-hive-netadmin.yaml
@@ -1,0 +1,82 @@
+# `hive-netadmin` — a dedicated SCC that is `restricted-v2` loosened by EXACTLY
+# what the base deployment (src/deploy/k8s/deployment.yaml) declares, and
+# nothing else. Every field below that is not called out as a delta carries the
+# stock restricted-v2 value: no privileged containers, no host
+# network/ports/PID/IPC, no hostPath volumes, drop-ALL still required,
+# runtime/default seccomp still required.
+#
+# Deltas from restricted-v2 (each one exists because the base pod needs it):
+#
+#   allowedCapabilities        The six capabilities the deployment's
+#                              `capabilities.add` lists (it still drops ALL
+#                              first). An SCC admits a pod only if every added
+#                              cap is in this list — allowing only NET_ADMIN
+#                              would still reject the pod, so the su-exec set
+#                              is listed too, mirroring deployment.yaml 1:1.
+#   runAsUser: RunAsAny        The entrypoint starts as root (iptables REDIRECT,
+#                              PVC chown) and then drops to `dev`;
+#                              MustRunAsRange would force a namespace-range UID
+#                              and break that. This also makes the `anyuid`
+#                              binding unnecessary when this SCC is granted.
+#   fsGroup: RunAsAny          The pod pins fsGroup 1002 (hive-launch — the
+#                              audit-N5 secrets-readability split), which is
+#                              outside any namespace's allocated range.
+#   allowPrivilegeEscalation   true: the agent-UID switch runs through the SUID
+#                              su-exec helper; `false` would set no_new_privs
+#                              and disable all SUID binaries (see the C6
+#                              rationale in deployment.yaml).
+#
+# Applying this file requires cluster-admin. It grants nothing by itself —
+# access is via the `use` RBAC in rolebinding.yaml, scoped to the single
+# `hive` ServiceAccount in the `hive` namespace (users/groups deliberately
+# empty).
+#
+# Verify after apply (pod annotation names the SCC that admitted it):
+#   oc -n hive get pod -l app.kubernetes.io/name=hive \
+#     -o jsonpath='{.items[0].metadata.annotations.openshift\.io/scc}'
+#   # MUST print "hive-netadmin"
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: hive-netadmin
+  labels:
+    app.kubernetes.io/name: hive
+allowPrivilegedContainer: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowedCapabilities:
+  - NET_ADMIN # ACMM proxy iptables redirect of outbound :443
+  - SETUID # su-exec dev->per-agent UID switch
+  - SETGID
+  - SETPCAP
+  - CHOWN # chown per-agent dirs/beads to the agent UID
+  - DAC_OVERRIDE
+defaultAddCapabilities: null
+requiredDropCapabilities:
+  - ALL
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+users: []
+groups: []

--- a/src/deploy/kustomize/overlays/openshift/anyuid-scc-rolebinding.yaml
+++ b/src/deploy/kustomize/overlays/openshift/anyuid-scc-rolebinding.yaml
@@ -13,7 +13,11 @@
 # Verify after apply:
 #   oc -n hive get pod -l app.kubernetes.io/name=hive \
 #     -o jsonpath='{.items[0].metadata.annotations.openshift\.io/scc}'
-#   # MUST print "anyuid" — "restricted-v2" means this binding did not take.
+#   # "restricted-v2" means this binding did not take. Note: because the base
+#   # deployment also ADDS capabilities (which anyuid forbids), on a correctly
+#   # set-up cluster the pod is actually admitted by the `hive-netadmin` SCC
+#   # from ../openshift-netadmin — the annotation then prints "hive-netadmin",
+#   # and this anyuid binding is redundant-but-harmless.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/src/deploy/kustomize/overlays/openshift/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/openshift/kustomization.yaml
@@ -12,6 +12,14 @@ kind: Kustomization
 #
 # It changes NOTHING about the workload itself; the base deployment already
 # carries the correct securityContext (fsGroup 1002, NET_ADMIN + su-exec caps).
+#
+# NOTE (capabilities): `anyuid` permits root but does NOT permit ADDING
+# capabilities, and the base deployment requests NET_ADMIN + the su-exec set —
+# so on a cluster with only stock SCCs the pod is still rejected at admission.
+# A cluster-admin must also apply the ../openshift-netadmin overlay (dedicated
+# `hive-netadmin` SCC), which additionally permits root and therefore makes
+# the anyuid binding below redundant-but-harmless. See that overlay's
+# kustomization.yaml and src/docs/net-admin-requirement.md.
 
 resources:
   - ../../../k8s

--- a/src/deploy/kustomize/overlays/standalone/README.md
+++ b/src/deploy/kustomize/overlays/standalone/README.md
@@ -41,15 +41,26 @@ token).
 
 - **Cluster GRANTS NET_ADMIN (most do):** do nothing. The full gate comes up
   automatically. This is the recommended, fail-closed default.
-- **Cluster DENIES NET_ADMIN:** the entrypoint FATALs and the pod crash-loops
-  (`FATAL: refusing to start ... capability model would be advisory-only`). To
-  start anyway in **advisory-only** mode, uncomment the
-  `- path: patch-advisory-mode.yaml` line in `kustomization.yaml`. That sets
-  `HIVE_PROXY_ADVISORY_OK=true`. **Trade-off:** the egress gate becomes
-  best-effort, not enforced — an agent could bypass the proxy. Only do this if
-  you accept that.
+- **Cluster DENIES NET_ADMIN:** two possible signatures, two remedies.
+  - *OpenShift admission rejection* — the pod never starts; `oc -n hive get
+    events` shows `unable to validate against any security context constraint`
+    (no stock SCC, `anyuid` included, permits the capabilities the base
+    deployment adds). **Remedy:** a cluster-admin applies the
+    `../openshift-netadmin` overlay (dedicated `hive-netadmin` SCC + RoleBinding)
+    — this is the real fix; the full gate then comes up.
+  - *Runtime FATAL* — the pod starts but crash-loops with
+    `FATAL: refusing to start ... capability model would be advisory-only` and
+    **exit code 77** (EX_NOPERM) when the container's bounding set lacks
+    `CAP_NET_ADMIN` (any other cause of that FATAL exits 1). **Remedy** if you
+    cannot grant the capability: start anyway in **advisory-only** mode by
+    uncommenting the `- path: patch-advisory-mode.yaml` line in
+    `kustomization.yaml` (sets `HIVE_PROXY_ADVISORY_OK=true`). **Trade-off:**
+    forced proxy egress becomes advisory — best-effort, not enforced — so an
+    agent could bypass the proxy. Only do this if you accept that.
 
-See `src/docs/net-admin-requirement.md` for the full explanation.
+Not sure which case you're in? Run the checks in
+`src/docs/manual-provisioning.md` ("Does your cluster grant NET_ADMIN?"), and
+see `src/docs/net-admin-requirement.md` for the full explanation.
 
 ## Install
 

--- a/src/deploy/kustomize/overlays/standalone/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/standalone/kustomization.yaml
@@ -42,4 +42,7 @@ patches:
   # 3. NET_ADMIN escape hatch (COMMENTED OUT by default). Uncomment ONLY on a
   #    locked-down cluster that DENIES NET_ADMIN — see README "The NET_ADMIN
   #    decision". Leaving it commented keeps the fail-CLOSED security gate.
+  #    On OpenShift, prefer the real fix: have a cluster-admin apply the
+  #    ../openshift-netadmin overlay (dedicated `hive-netadmin` SCC) so the
+  #    full gate comes up instead of degrading to advisory mode.
   # - path: patch-advisory-mode.yaml

--- a/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml
+++ b/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml
@@ -11,9 +11,14 @@
 #   security gate comes up automatically.
 #
 #   On a cluster that DENIES NET_ADMIN, the entrypoint cannot establish the
-#   redirect and FATALs (exit 1, "refusing to start ... capability model would
-#   be advisory-only") — a fail-CLOSED crash loop. Setting
+#   redirect and FATALs ("refusing to start ... capability model would be
+#   advisory-only") — a fail-CLOSED crash loop, with exit code 77 (EX_NOPERM)
+#   when the bounding set lacks CAP_NET_ADMIN (any other cause of the same
+#   FATAL exits 1 — see src/docs/net-admin-requirement.md). Setting
 #   HIVE_PROXY_ADVISORY_OK=true tells it to start anyway in ADVISORY-ONLY mode.
+#   On OpenShift, prefer the real fix over this patch: a cluster-admin applies
+#   ../openshift-netadmin (dedicated `hive-netadmin` SCC) and the full gate
+#   comes up.
 #
 # SECURITY TRADE-OFF: advisory mode means the MITM egress gate is best-effort,
 # not enforced — an agent with a raw token could bypass the proxy. Only enable

--- a/src/docs/manual-provisioning.md
+++ b/src/docs/manual-provisioning.md
@@ -150,14 +150,30 @@ kustomize edit set image ghcr.io/kubestellar/hive=ghcr.io/kubestellar/hive:<tag>
 kubectl apply -k .
 ```
 
-**On OpenShift.** The standalone overlay does not create a Route or grant the
-`anyuid` SCC. The
-[`overlays/openshift`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift)
-overlay supplies exactly those two OpenShift-only deltas — a `Route` exposing the
-`dashboard` port (3002) and the `anyuid` SCC RoleBinding the pod needs (it starts
-as root to set up the ACMM iptables and chown the PVC). A standalone deployment
-on OpenShift composes **standalone + these platform deltas**. Two equivalent
-ways:
+**On OpenShift.** The standalone overlay does not create a Route or grant any
+SCC. Two more pieces supply the OpenShift-only deltas:
+
+- The
+  [`overlays/openshift`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift)
+  overlay — a `Route` exposing the `dashboard` port (3002) and the `anyuid` SCC
+  RoleBinding (the pod starts as root to set up the ACMM iptables and chown the
+  PVC).
+- The
+  [`overlays/openshift-netadmin`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift-netadmin)
+  overlay — the dedicated `hive-netadmin` SCC + RoleBinding, applied **once by a
+  cluster-admin**. This one is **not optional on OpenShift**: the base
+  deployment *adds* capabilities (`NET_ADMIN` + the su-exec set), and no stock
+  SCC — `anyuid` included — permits adding them, so without this grant the pod
+  is rejected at admission (`unable to validate against any security context
+  constraint`). The SCC is `restricted-v2` loosened by exactly what the base
+  deployment declares (see the manifest comments) — not `privileged`. See
+  [Does your cluster grant NET_ADMIN?](#does-your-cluster-grant-net_admin) to
+  check your cluster first.
+
+A standalone deployment on OpenShift composes **standalone + these platform
+deltas** (the SCC grant is applied separately, by cluster-admin:
+`oc apply -k src/deploy/kustomize/overlays/openshift-netadmin`). For the
+app-level overlays, two equivalent ways:
 
 - **Combined overlay (recommended):** in your own copy of the standalone
   `kustomization.yaml`, add `route.yaml` and `anyuid-scc-rolebinding.yaml` as
@@ -198,19 +214,113 @@ forced-proxy-egress `iptables` REDIRECT that enforces the ACMM MITM egress proxy
 - **Cluster GRANTS `NET_ADMIN` (most do):** nothing to do — the full,
   fail-closed egress gate comes up automatically. This is the recommended
   default.
-- **Cluster DENIES `NET_ADMIN`:** the entrypoint **FATALs** (exit 1, refusing to
-  start with an advisory-only capability model — `src/deploy/entrypoint.sh`
-  around line 770) and the pod crash-loops. The **only** escape hatch is setting
-  `HIVE_PROXY_ADVISORY_OK=true`, provided by the **commented-out**
-  [`patch-advisory-mode.yaml`](https://github.com/kubestellar/hive/blob/v4/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml)
-  — uncomment its `- path: patch-advisory-mode.yaml` line in your
-  `kustomization.yaml`.
+- **Cluster DENIES `NET_ADMIN`:** the entrypoint **FATALs** (refusing to start
+  with an advisory-only capability model — `src/deploy/entrypoint.sh`) and the
+  pod crash-loops, with **exit code 77** when the missing capability is the
+  cause (see the checks section below for what 77 means and how to read it).
+  Two remedies:
+  1. **Grant the capability (preferred — full gate).** On OpenShift, a
+     cluster-admin applies the
+     [`overlays/openshift-netadmin`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift-netadmin)
+     overlay (dedicated `hive-netadmin` SCC + RoleBinding); on plain Kubernetes,
+     ensure the namespace's Pod Security admission allows the capability (see
+     below).
+  2. **Deliberately run degraded.** Set `HIVE_PROXY_ADVISORY_OK=true` via the
+     **commented-out**
+     [`patch-advisory-mode.yaml`](https://github.com/kubestellar/hive/blob/v4/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml)
+     — uncomment its `- path: patch-advisory-mode.yaml` line in your
+     `kustomization.yaml`.
 
-**Security trade-off (one honest sentence):** in advisory-only mode the MITM
-egress gate is best-effort rather than enforced, so an agent holding a raw token
-could bypass the proxy policy — acceptable for a single-tenant hive whose owner
-controls every repo and agent, but not a control you should silently disable on a
-shared one.
+**Security trade-off (one honest sentence):** in advisory-only mode forced
+proxy egress becomes advisory — the MITM egress gate is best-effort rather than
+enforced, so an agent holding a raw token could bypass the proxy policy —
+acceptable for a single-tenant hive whose owner controls every repo and agent,
+but not a control you should silently disable on a shared one.
+
+### Does your cluster grant NET_ADMIN?
+
+The question every firewalled-cluster adopter hits first. Three checks, from
+authoritative to empirical — run them **before** deploying and you'll know
+which of the two remedies above (if either) you need.
+
+**1. Ask OpenShift directly (`scc-subject-review` dry-run).** This is the
+authoritative answer: it evaluates the *actual* pod spec against every SCC the
+`hive` ServiceAccount can use, without creating anything:
+
+```bash
+# From your (placeholder-swapped) overlay directory — build the real manifests
+# and let OpenShift judge them as the hive SA:
+kubectl kustomize . > /tmp/hive-rendered.yaml
+oc -n hive policy scc-subject-review -z hive -f /tmp/hive-rendered.yaml
+```
+
+Read the `ALLOWED BY` column for the `hive` Deployment: an SCC name (e.g.
+`hive-netadmin`) means admission will pass under that SCC; `<none>` means **no
+SCC admits the pod** — deploying now would leave the ReplicaSet stuck with
+`unable to validate against any security context constraint` events and no pod
+at all.
+
+**2. Which SCCs allow the capability, and who can use them?**
+
+```bash
+# SCCs that would permit adding NET_ADMIN (allowedCapabilities contains it or "*"),
+# plus privileged SCCs (which imply all capabilities):
+oc get scc -o json | jq -r '.items[]
+  | select(((.allowedCapabilities // []) | index("NET_ADMIN") or index("*"))
+           or .allowPrivilegedContainer == true)
+  | .metadata.name'
+
+# For each candidate, is the hive SA allowed to use it?
+oc adm policy who-can use scc/hive-netadmin
+# Look for system:serviceaccount:hive:hive in the output.
+```
+
+On a stock cluster the first query returns only `privileged` / `node-exporter`
+style SCCs the hive SA cannot (and should not) use — that is the "cluster
+denies" case until `hive-netadmin` is applied. On plain Kubernetes (no SCC API)
+the equivalent gate is [Pod Security admission](https://kubernetes.io/docs/concepts/security/pod-security-standards/):
+check `kubectl get ns hive -o jsonpath='{.metadata.labels}'` — an
+`pod-security.kubernetes.io/enforce: baseline` (or `restricted`) label denies
+`NET_ADMIN`; the capability needs `privileged` enforcement (or no enforcement)
+on the namespace.
+
+**3. The 30-second probe pod (empirical).** Runs as the same ServiceAccount,
+requests only `NET_ADMIN`, prints its own capability bounding set, and exits:
+
+```bash
+oc -n hive run netadmin-probe --restart=Never --image=busybox:1.36 \
+  --overrides='{"spec":{"serviceAccountName":"hive","containers":[{"name":"netadmin-probe","image":"busybox:1.36","command":["sh","-c","grep CapBnd /proc/self/status"],"securityContext":{"capabilities":{"drop":["ALL"],"add":["NET_ADMIN"]}}}]}}'
+oc -n hive logs netadmin-probe && oc -n hive delete pod netadmin-probe
+```
+
+Two outcomes: the `run` is **rejected at admission** (`unable to validate
+against any security context constraint`) — the cluster denies the capability;
+or the pod runs and prints `CapBnd: 0000000000001000` — bit 12 (`0x1000`,
+`CAP_NET_ADMIN`) is set and the cluster grants it. (The probe requests *only*
+`NET_ADMIN`; the real deployment also adds the su-exec capability set, so treat
+check 1 as the authoritative pre-flight and this probe as the quick smoke
+test.)
+
+**Reading the failure after the fact — the exit-77 signature.** If the pod was
+*admitted* but the container's bounding set still lacks `CAP_NET_ADMIN` (e.g.
+an admission webhook stripped the capability, or a hand-edited manifest dropped
+the request), the entrypoint refuses to start and exits with a **distinct code,
+77** (sysexits.h `EX_NOPERM`), after logging:
+
+```
+[entrypoint] FATAL: refusing to start. Grant NET_ADMIN + install iptables, or set HIVE_PROXY_ADVISORY_OK=true to deliberately run in advisory mode.
+[entrypoint] FATAL: CAP_NET_ADMIN is not in the container's capability bounding set — exiting 77 (EX_NOPERM) rather than 1.
+```
+
+```bash
+kubectl -n hive get pod -l app.kubernetes.io/name=hive \
+  -o jsonpath='{.items[0].status.containerStatuses[0].lastState.terminated.exitCode}'
+```
+
+`77` means precisely "grant the capability (or opt into advisory mode)"; any
+*other* cause of the same FATAL (no `iptables` binary, netfilter lock
+contention) exits `1`, since granting `NET_ADMIN` would not fix those. Full
+rationale: [net-admin-requirement.md](net-admin-requirement.md).
 
 ### Firewall / egress (locked-down cluster)
 

--- a/src/docs/net-admin-requirement.md
+++ b/src/docs/net-admin-requirement.md
@@ -113,7 +113,31 @@ securityContext:
       - NET_ADMIN
 ```
 
-(The bundled `src/deploy/k8s/deployment.yaml` already declares this.)
+(The bundled `src/deploy/k8s/deployment.yaml` already declares this.) If the
+namespace enforces Pod Security admission, note that the `baseline` and
+`restricted` profiles deny `NET_ADMIN` — the namespace needs `privileged`
+enforcement (or none) for the request to be honored.
+
+### OpenShift
+
+Declaring the capability is not enough on OpenShift: an SCC must *permit*
+adding it, and no stock SCC (`anyuid` included) does — the pod is rejected at
+admission (`unable to validate against any security context constraint`). A
+cluster-admin applies the bundled
+[`overlays/openshift-netadmin`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift-netadmin)
+overlay once:
+
+```bash
+oc apply -k src/deploy/kustomize/overlays/openshift-netadmin
+```
+
+It creates a dedicated `hive-netadmin` SCC — `restricted-v2` loosened by
+exactly the capabilities the deployment declares, not `privileged` — plus the
+`use` RBAC scoped to the `hive` ServiceAccount. To check ahead of time whether
+your cluster already grants the capability (and to read the exit-77 signature
+after the fact), see the
+[Does your cluster grant NET_ADMIN?](manual-provisioning.md#does-your-cluster-grant-net_admin)
+checks in the provisioning guide.
 
 ### Rootless Podman
 


### PR DESCRIPTION
## Driver

A real standalone adopter (hub-less hive on a firewalled OpenShift cluster) read the manual-provisioning guide and hit the question it could not answer: **how do I know if my cluster grants NET_ADMIN?** Auditing the kustomize path showed the gap is structural, not just doc-shaped.

## Audit findings

- The base deployment (`src/deploy/k8s/deployment.yaml`) already **requests** `capabilities.add: [NET_ADMIN, SETUID, SETGID, SETPCAP, CHOWN, DAC_OVERRIDE]` (drop ALL first).
- On OpenShift, **no stock SCC admits that pod**: `restricted-v2` forbids root and the caps, and `anyuid` — which is all `overlays/openshift` binds — permits root but forbids **adding** capabilities. Result on a stock cluster: ReplicaSet rejected at admission (`unable to validate against any security context constraint`). The managed fleet only works because the hub provisions a dedicated `hive-netadmin` SCC out-of-band; nothing in-tree encoded that pattern.
- The standalone docs/patch comments still said the missing-cap FATAL is `exit 1` — stale post-#3879, where the missing-`CAP_NET_ADMIN` case exits **77** (`EX_NOPERM`) distinctly (verified against `src/deploy/entrypoint.sh`).

## Changes

**New `overlays/openshift-netadmin` (grant-only, OpenShift-only, cluster-admin-only):**
- `hive-netadmin` SCC = `restricted-v2` loosened by **exactly** what the base deployment declares: the six added caps, `runAsUser: RunAsAny` (root entrypoint), `fsGroup: RunAsAny` (pinned 1002), `allowPrivilegeEscalation: true` (SUID su-exec helper). Drop-ALL and `runtime/default` seccomp still required; **not** `privileged`, no host access.
- `use` RBAC (ClusterRole + RoleBinding `hive-netadmin-scc`) scoped to the `hive` SA — fleet-matching naming, users/groups on the SCC left empty.
- Deliberately does **not** include the workload base: the one-time cluster-admin grant is decoupled from app deploys. Base stays cluster-agnostic.

**Manifest cross-refs:** `deployment.yaml` comment at `capabilities.add` points at the overlay and the `HIVE_PROXY_ADVISORY_OK=true` degraded-mode alternative; `overlays/openshift` and `overlays/standalone` comments corrected (exit-77, admission-vs-runtime signatures, prefer-the-real-fix pointer).

**Docs (authoring source; the site auto-syncs from here):**
- `manual-provisioning.md`: new **“Does your cluster grant NET_ADMIN?”** section — (1) `oc policy scc-subject-review -z hive` dry-run of the rendered manifests (authoritative), (2) which-SCCs-allow query + `oc adm policy who-can use scc/...` (with the plain-k8s Pod Security equivalent), (3) a 30-second probe pod printing `CapBnd`; plus the exit-77 signature and how to read it from `lastState.terminated.exitCode`. “The NET_ADMIN decision” now lists **both** remedies: cluster-admin applies the overlay (full gate), or advisory mode with the honest one-liner — forced proxy egress becomes advisory.
- `net-admin-requirement.md`: OpenShift section (declaring the cap is not enough; apply the overlay) + Pod Security note.

## Verification

`kubectl kustomize` renders all three touched overlays cleanly; the new overlay emits exactly SCC + ClusterRole + RoleBinding. No real cluster hostnames or internal names appear in any added content.