### PR TITLE
🐛 fix(relay): the CLI-liveness probe could never see a dead CLI, so task prompts were typed into a bare shell

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -672,6 +672,83 @@ function recoverWedgedShell() {
 // dismissal can look at the SAME text without capturing twice, and so the
 // dismissal can see WHICH prompt is on screen rather than re-deriving it from
 // a state enum that has already thrown that detail away.
+// Shell names that mean the pane fell back to a prompt — i.e. whatever the
+// relay launched is no longer the pane's foreground program.
+const PANE_SHELL_COMMANDS = new Set(['bash', 'sh', 'zsh', 'fish', 'dash', 'ksh', 'ash', 'tcsh', 'csh']);
+
+// How many consecutive shell readings (one per progress tick) are required
+// before the CLI is declared gone. One is not enough: a tool call can briefly
+// put a shell in the pane's foreground while the CLI is very much alive.
+const CLI_GONE_CONFIRMATIONS = 2;
+let consecutiveShellReadings = 0;
+
+// paneForegroundCommand asks tmux what the pane is actually RUNNING. Empty when
+// tmux cannot answer (session gone, tmux missing) — an unknown, never a death.
+function paneForegroundCommand() {
+  try {
+    return execSync(
+      `tmux display-message -p -t ${TMUX_SESSION} '#{pane_current_command}' 2>/dev/null`,
+      { encoding: 'utf8', timeout: 15000 }
+    ).toString().trim();
+  } catch (_) {
+    return '';
+  }
+}
+
+// cliProcessLooksGone reports whether the agent CLI has left the pane.
+//
+// It replaces a substring scan of the WHOLE process table:
+//
+//   procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || …
+//
+// which could not do this job. Two independent defects, both observed live:
+//
+//  1. The relay's own machinery carries the backend's name. For agy the
+//     launcher (`just contribute-hive agy local`) and the tmux session itself
+//     (`tmux attach -t hive-agy-5b4f`) both contain "agy", so the probe was
+//     pinned alive no matter what happened to the CLI.
+//  2. The other CLI names were OR'd in unconditionally, whatever BACKEND was.
+//     Any contributor with Claude Code running — i.e. most of them — reported
+//     a live CLI for every backend, forever.
+//
+// With the probe stuck true the relay never relaunched a dead CLI, cliReady
+// stayed latched, and task prompts were typed into a bare shell: exactly the
+// #2203 bug-2 wedge the send gate exists to prevent.
+//
+// The pane's own foreground command answers the real question, and it cannot be
+// confused by anything outside the pane. Two consecutive readings are required
+// so that a tool call which briefly fronts a shell does not read as a death —
+// the expensive mistake, since it restarts a CLI that is working. A CLI that
+// really exited leaves the pane at a prompt permanently, so it still trips on
+// the following tick; the stall backstop in progressTick is the second net.
+//
+// Note the pane TEXT is deliberately not consulted: a CLI that dies leaves its
+// last frame on screen, ready-chrome and all, so requiring that chrome to be
+// gone would re-introduce exactly the blindness this replaces.
+function probeCLIPresence() {
+  const fg = paneForegroundCommand();
+  const isShell = !!fg && PANE_SHELL_COMMANDS.has(fg);
+  if (!isShell) {
+    consecutiveShellReadings = 0;
+  } else {
+    consecutiveShellReadings++;
+  }
+  return { isShell, gone: isShell && consecutiveShellReadings >= CLI_GONE_CONFIRMATIONS };
+}
+
+function cliProcessLooksGone() {
+  return probeCLIPresence().gone;
+}
+
+// paneIsRunningShell answers "is the pane at a prompt RIGHT NOW", without
+// touching the confirmation counter. Used by the send gate, where one reading
+// is enough: typing a prompt into a shell is never right, and the cost of
+// waiting a tick when we are wrong is nil.
+function paneIsRunningShell() {
+  const fg = paneForegroundCommand();
+  return !!fg && PANE_SHELL_COMMANDS.has(fg);
+}
+
 function capturePaneText() {
   try {
     return execSync(
@@ -919,9 +996,32 @@ function tmuxSendKeys(text) {
   // keystrokes land on bash, whose readline chokes on the apostrophes in the
   // prompt and drops the pane into PS2 continuation, wedging it permanently.
   // Queue instead; flushPendingTask() delivers it once readiness is confirmed.
+  //
+  // cliReady is a LATCH: set once the CLI is confirmed up, cleared only by a
+  // relaunch. When the liveness probe could not tell the CLI apart from the
+  // relay's own processes (see cliProcessLooksGone), a CLI that died was never
+  // relaunched, the latch stayed true, and this gate waved the prompt straight
+  // through into a bare shell — observed live, with the hub's task prompt
+  // executing as shell commands. So re-confirm against the LIVE pane before
+  // typing; the per-backend readiness patterns already exist in getCLIState().
   if (!cliReady) {
     console.log('CLI not ready — queuing task prompt instead of typing into the pane');
     pendingTask = text;
+    return;
+  }
+  if (paneIsRunningShell()) {
+    console.log(`Pane is at a shell prompt, not ${BACKEND} — queuing task prompt instead of typing it into the shell`);
+    pendingTask = text;
+    {
+      // The latch was STALE: the CLI exited without the relay noticing. Drop it
+      // and bring the CLI back, or the queued prompt has nothing to flush into.
+      cliReady = false;
+      try {
+        console.log(`Relaunching ${BACKEND} after a stale readiness latch: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('Failed to relaunch after a stale readiness latch:', e.message);
+      }
+    }
     return;
   }
   try {
@@ -1324,6 +1424,9 @@ let lastPaneChangeAt = 0;
 function resetPaneStallClock() {
   lastPaneFingerprint = null;
   lastPaneChangeAt = Date.now();
+  // A new task also starts with a clean CLI-liveness count: shell readings from
+  // the previous task say nothing about this one.
+  consecutiveShellReadings = 0;
 }
 
 // paneStalled records the current pane content and reports whether it has been
@@ -1457,15 +1560,11 @@ function progressTick() {
   if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
 
   try {
-    let procs = '';
-    try {
-      if (fs.existsSync('/proc')) {
-        procs = execSync(`for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`, { encoding: 'utf8', timeout: 15000 });
-      } else {
-        procs = execSync(`ps -eo command 2>/dev/null`, { encoding: 'utf8', timeout: 15000 });
-      }
-    } catch (_) { procs = BACKEND; }
-    const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
+    // See probeCLIPresence(): this asks the PANE what it is running, rather than
+    // grepping the whole process table for the backend's name — a scan the
+    // relay's own launcher and tmux session always satisfied.
+    const presence = probeCLIPresence();
+    const cliAlive = !presence.gone;
     // bob is not a persistent REPL: it exits at the end of every turn ("Bob
     // goes to sleep 💤"). For bob an exited process is the normal completion
     // signal, not a crash, so it must fall through to the checkTmuxIdle()
@@ -1505,6 +1604,20 @@ function progressTick() {
       }
       // environment: the agent CLI process died; nothing was judged about the work.
       failCurrentTask('CLI process exited — restarted', { kind: 'environment' });
+      return;
+    }
+    // A pane sitting at a shell is never evidence that the AGENT finished: the
+    // CLI is simply not there. Without this, the first (still unconfirmed)
+    // shell reading falls through to the completion check below, where the
+    // dead CLI's LAST FRAME — ready chrome and all, still on screen — reads as
+    // "agent idle" and reports a task nobody did as completed. Hold here and
+    // let the next tick either confirm the death or clear it.
+    //
+    // bob is exempt: it exits at the end of every turn, so for bob a shell pane
+    // IS the completion signal (see cliExitIsNormal above).
+    if (presence.isShell && !cliExitIsNormal) {
+      console.warn(`Pane is at a shell prompt, not ${BACKEND} — awaiting confirmation before judging the task`);
+      send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: captureTmuxLines(TMUX_TAIL_LINES) });
       return;
     }
   } catch (_) {}
@@ -1901,6 +2014,9 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
     paneStalled,
     resetPaneStallClock,
+    cliProcessLooksGone,
+    paneForegroundCommand,
+    CLI_GONE_CONFIRMATIONS,
     PANE_STALL_TIMEOUT_MS,
     // Backdate the stall clock so a test can cross the timeout without
     // sleeping — the two ticks it needs otherwise land in the same millisecond.

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -53,6 +53,11 @@ function loadRelay({ backend = 'copilot', backendBinary = null, model = '', reas
       if (typeof state === 'string' && state.includes('\n')) return state;
       return 'dev@host:~$ \n';
     }
+    if (/display-message/.test(cmd)) {
+      // The relay asks the PANE what it is running (pane_current_command).
+      // procAlive:false models a CLI that exited and left the pane at a shell.
+      return procAlive ? `${backend}\n` : 'bash\n';
+    }
     if (/cmdline|ps -eo/.test(cmd)) {
       // The relay's liveness probe greps this for the backend name. When the
       // CLI is "dead" the pane is a bare shell — and crucially the string must
@@ -237,6 +242,57 @@ const AGY_WEDGED_PANE = [
   '────────────────────────────────────────────',
   '? for shortcuts',
 ].join('\n');
+
+// --- CLI liveness: ask the PANE, not the process table --------------------
+//
+// The old probe substring-matched the whole process table for the backend's
+// name, OR'd with every other CLI's name unconditionally. Observed live: the
+// relay's own launcher (`just contribute-hive agy local`) and its tmux session
+// (`hive-agy-5b4f`) both contain "agy", and any box running Claude Code matched
+// 'claude' whatever the backend was — so a dead CLI was never detected, was
+// never relaunched, cliReady stayed latched, and the hub's task prompt was typed
+// into a bare shell.
+test('a shell in the pane is only a death after consecutive confirmations', () => {
+  const relay = loadRelay({ backend: 'agy', procAlive: false });
+  try {
+    assert.strictEqual(relay.cliProcessLooksGone(), false,
+      'one shell reading may just be a foreground tool call — never restart on it');
+    assert.strictEqual(relay.cliProcessLooksGone(), true,
+      `${relay.CLI_GONE_CONFIRMATIONS} consecutive shell readings mean the CLI really left`);
+  } finally { teardown(relay); }
+});
+
+test('a pane running the CLI is never reported gone, and clears the count', () => {
+  const relay = loadRelay({ backend: 'agy', procAlive: true });
+  try {
+    assert.strictEqual(relay.cliProcessLooksGone(), false);
+    assert.strictEqual(relay.cliProcessLooksGone(), false,
+      'a live CLI must never accumulate toward a death, however long it runs');
+  } finally { teardown(relay); }
+});
+
+test('a task prompt is never typed into a pane that is running a shell', () => {
+  // The latch says ready — as it did in production, because nothing had
+  // detected the CLI leaving — but the pane is a shell. The prompt must be
+  // queued and the CLI relaunched, NOT typed at the shell.
+  const relay = loadRelay({ backend: 'agy', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    const PROMPT = "You are a contributor to the kubestellar/hive hive. Work on issue #4030.";
+    const before = relay.__tmuxSends().length;
+    relay.tmuxSendKeys(PROMPT);
+
+    assert.strictEqual(relay.getPendingTask(), PROMPT,
+      'the prompt must be queued for the readiness callback, not typed into the shell');
+    assert.strictEqual(relay.getCliReady(), false,
+      'a stale readiness latch must be dropped once the pane is seen to be a shell');
+    const sends = relay.__tmuxSends().slice(before);
+    assert.ok(!sends.some(c => c.includes('contributor to the kubestellar/hive hive')),
+      `the prompt text must never reach the pane: ${JSON.stringify(sends)}`);
+    assert.ok(sends.some(c => /agy/.test(c)),
+      `the CLI must be relaunched so the queued prompt has somewhere to go: ${JSON.stringify(sends)}`);
+  } finally { teardown(relay); }
+});
 
 test('agy at its idle prompt is COMPLETE even with stale narration on screen', () => {
   const relay = loadRelay({ backend: 'agy' });
@@ -616,8 +672,12 @@ test('crash restarts are capped and end in a permanent failure', () => {
     assert.ok(cap <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
 
     // Simulate the hub reassigning the same work item after each failure.
+    // TWO ticks per assignment: a CLI death is only declared once the pane has
+    // read as a shell on consecutive checks, so a single transient reading
+    // cannot restart a CLI that is merely running a foreground tool call.
     for (let i = 0; i <= cap; i++) {
       assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
       relay.__crashTick();
     }
 
@@ -643,6 +703,8 @@ test('a reassignment of a given-up task is rejected, not retried', () => {
     assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
     for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
       assignTask(relay, `ct-421-${i}`);
+      // Two ticks: a death needs consecutive shell readings to be confirmed.
+      relay.__crashTick();
       relay.__crashTick();
     }
     const before = relay.__sent.length;
@@ -665,6 +727,8 @@ test('after give-up a DIFFERENT task is still accepted', () => {
     assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
     for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
       assignTask(relay, `ct-421-${i}`);
+      // Two ticks: a death needs consecutive shell readings to be confirmed.
+      relay.__crashTick();
       relay.__crashTick();
     }
     assert.strictEqual(relay.getCurrentTask(), null, 'precondition: no active task after give-up');


### PR DESCRIPTION
> **Stacks on #4026.** The first commit here is that PR's; review the second, or merge #4026 first and it drops out of the diff. They touch the same file, which is why they are stacked rather than parallel.

## Symptom

Observed live on an agy contributor: the CLI exited, the relay never noticed, and the hub's task prompt was **typed into the shell** the pane had fallen back to — the terminal showed the prompt executing as shell commands, its first characters eaten by readline:

```
dbaggett at rig in .
u are a contributor to the kubestellar/hive hive. Work on issue kubestellar/hive#4030 …
```

This is precisely the wedge the send gate exists to prevent (`#2203, bug 2`). The gate was intact — everything upstream of it was blind.

## Cause

```js
const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot')
              || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
```

A substring match over the **whole process table**. Two independent defects, both reproduced on the affected machine:

1. **The relay's own machinery carries the backend's name.** For agy, `just contribute-hive agy local` (the launcher) and `tmux attach -t hive-agy-5b4f` (the session) both contain `agy`:
   ```
   1805845 just contribute-hive agy local
   1806321 tmux attach -t hive-agy-5b4f
   ```
   The probe was *structurally incapable* of reporting a death for this backend.
2. **The other CLI names were OR'd in unconditionally**, whatever `BACKEND` was. Any contributor with Claude Code running — most of them — reported a live CLI for every backend, forever.

With the probe stuck true, `relaunchCLI()` never ran, so `cliReady` — a latch, cleared only by a relaunch — stayed true, and the gate waved the prompt through into bash.

## Fix

Either half alone would have stopped it; both are here.

- **Liveness asks the pane what it is running** (`tmux display-message -p '#{pane_current_command}'`), which nothing outside the pane can influence. A death requires `CLI_GONE_CONFIRMATIONS` consecutive shell readings, so a foreground tool call is not mistaken for one — the expensive error, since it restarts a working CLI. The pane **text** is deliberately not consulted: a dead CLI leaves its last frame on screen, ready-chrome and all, so requiring that chrome to be gone would re-introduce the same blindness.
- **The send gate re-confirms against the live pane** rather than trusting the latch. A pane at a shell prompt queues the prompt, drops the stale latch, and relaunches the CLI so the queued prompt has somewhere to flush to.

Also: **a shell pane can no longer reach the completion check.** Before the death is confirmed, the dead CLI's last frame classified as "agent idle" and would report a task nobody performed as `completed`. `bob` is exempt — it exits at the end of every turn, so for bob a shell pane *is* the completion signal.

## Tests

- one shell reading is never a death; consecutive readings are;
- a pane running the CLI never accumulates toward a death;
- **a task prompt is never typed into a pane running a shell** — it is queued, the stale latch is dropped, and the CLI is relaunched;
- crash-detection tests now tick twice per assignment, the honest consequence of requiring confirmation.

87/87 relay tests pass; the Go tests that read this file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)