### PR TITLE
✨ feat(config): project.issue_filter — label-gate which issues agents may initiate work on

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1087,6 +1087,10 @@ func main() {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 		ghClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 	}
+	// Unconditional (nil-safe, zero value = no filtering): the issue filter
+	// gates which issues become actionable at all, so it must be installed
+	// even when no exempt labels are configured.
+	ghClient.SetIssueFilter(cfg.Project.IssueFilter)
 	// The user write-token client (userGHClient) was removed: every GitHub write
 	// — issues, PRs, comments, merges, and the advisory digest — now goes through
 	// the hive's App installation token (ghClient / kubestellar-hive[bot]). The
@@ -1583,6 +1587,7 @@ func main() {
 				ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				ghClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 			}
+			ghClient.SetIssueFilter(cfg.Project.IssueFilter)
 			logger.Info("migrated config overrides from state to hive.yaml",
 				"repos", cfg.Project.Repos)
 
@@ -2261,6 +2266,7 @@ func main() {
 				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 			}
+			newClient.SetIssueFilter(cfg.Project.IssueFilter)
 			if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
 				newClient.SetRequiredChecks(set)
 			}
@@ -2668,6 +2674,7 @@ func main() {
 						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 						newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 					}
+					newClient.SetIssueFilter(cfg.Project.IssueFilter)
 					if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
 						newClient.SetRequiredChecks(set)
 					}
@@ -3816,6 +3823,7 @@ func main() {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 					newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 				}
+				newClient.SetIssueFilter(cfg.Project.IssueFilter)
 				if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
 					newClient.SetRequiredChecks(set)
 				}
@@ -3914,12 +3922,17 @@ func main() {
 			vanityMatched := pc.DashboardURL == "" || cfg.Hub.DashboardURL == pc.DashboardURL
 			authorMatched := pc.AIAuthor == "" || cfg.Project.AIAuthor == pc.AIAuthor
 			apiURLMatched := pc.GitHubAPIURL == "" || cfg.GitHub.APIURL == pc.GitHubAPIURL
+			// Issue filter: nil means "the hub is not speaking to this field"
+			// (mirrors AIAuthor's empty-means-keep), so the hub's every-beat
+			// echo can never blank a locally configured filter.
+			issueFilterMatched := pc.IssueFilter == nil || cfg.Project.IssueFilter.Equal(*pc.IssueFilter)
 			if cfg.Project.Org == pc.Org &&
 				sameStringSlice(cfg.Project.Repos, pc.Repos) &&
 				cfg.Project.PrimaryRepo == pc.PrimaryRepo &&
 				curACMM == pc.ACMMLevel &&
 				authorMatched &&
 				apiURLMatched &&
+				issueFilterMatched &&
 				vanityMatched {
 				return // already reconciled
 			}
@@ -3941,6 +3954,17 @@ func main() {
 			// kept the fleet-stats collector disabled on every hive.
 			if pc.AIAuthor != "" {
 				cfg.Project.AIAuthor = pc.AIAuthor
+			}
+			// Adopt a hub-delivered issue filter only when the hub actually
+			// sent one (non-nil). A push without the field leaves the spoke's
+			// locally configured filter untouched — the org/repos assignments
+			// above never wipe it either, so a local filter SURVIVES claim
+			// delivery. A non-nil but EMPTY filter is an explicit clear.
+			if pc.IssueFilter != nil && !cfg.Project.IssueFilter.Equal(*pc.IssueFilter) {
+				logger.Info("adopting issue filter from hub heartbeat",
+					"require_labels", pc.IssueFilter.RequireLabels,
+					"exclude_labels", pc.IssueFilter.ExcludeLabels)
+				cfg.Project.IssueFilter = *pc.IssueFilter
 			}
 			// Adopt a GitHub Enterprise API URL when the hub sends one. Empty
 			// means "leave mine alone" — the spoke's own default is already
@@ -3971,8 +3995,11 @@ func main() {
 			cfg.ACMMLevel = &level
 
 			// Re-sync the GitHub client that caches the repo list (mirrors the
-			// config-watcher reload path).
+			// config-watcher reload path). The issue filter is cached the same
+			// way, so re-install it too — a hub-delivered filter must take
+			// effect on the next enumeration, not the next restart.
 			ghClient.SetRepos(cfg.Project.Repos)
+			ghClient.SetIssueFilter(cfg.Project.IssueFilter)
 
 			// Persist to the PVC overlay so the claim survives a pod restart
 			// (config save writes the overlay hive.yaml, same as level switches).

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3962,8 +3962,7 @@ func main() {
 			// delivery. A non-nil but EMPTY filter is an explicit clear.
 			if pc.IssueFilter != nil && !cfg.Project.IssueFilter.Equal(*pc.IssueFilter) {
 				logger.Info("adopting issue filter from hub heartbeat",
-					"require_labels", pc.IssueFilter.RequireLabels,
-					"exclude_labels", pc.IssueFilter.ExcludeLabels)
+					"require_labels", pc.IssueFilter.RequireLabels)
 				cfg.Project.IssueFilter = *pc.IssueFilter
 			}
 			// Adopt a GitHub Enterprise API URL when the hub sends one. Empty

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -302,6 +302,31 @@ Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM 
 
 Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard. The reference schema is [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md), and a worked example lives at [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
 
+## Issue label filtering: gating agent work on approval labels
+
+By default a hive treats **every open issue** in its repos as candidate work. Some projects want the opposite: a maintainer reviews each issue and applies an approval label, and only then may automation touch it. (A fleet running against a busy upstream repo hit exactly this — the hive opened a PR for an issue the owner had not yet labeled for agent work.) `project.issue_filter` is that gate:
+
+```yaml
+project:
+  org: my-org
+  repos: [my-org/common]
+  issue_filter:
+    require_labels: [approved-for-agents]   # only these issues are agent work
+    exclude_labels: [no-ai, needs-design]   # these never are, even if approved
+```
+
+Semantics:
+
+- **Absent/empty filter = no filtering** — existing hives are unchanged; there is no default-on gate.
+- `require_labels`: an issue must carry **at least one** of these to be eligible. Matching is case-insensitive and exact.
+- `exclude_labels`: an issue carrying **any** of these is never eligible. Exclusion wins over require on conflict.
+
+The filter is enforced at **enumeration** — the point where GitHub issues become the hive's actionable set — not in the prompt. A filtered issue never enters the queue, never appears in a kick, never triggers plan-from-label, and is never offered to contributors, so a confused (or prompt-injected) agent re-listing the repo cannot select it. Kick prompts additionally state the active policy so agents know the list is intentionally short. The dashboard shows the active filter read-only under **Repositories**, and hub-managed hives can receive the filter with their project config over the heartbeat.
+
+This composes with, and does not change, the pre-existing label behaviors: `hold`/`on-hold` still parks items in the Hold list, `do-not-merge` and `governor.labels.exempt` still exclude items outright.
+
+**Not the same thing as the contribute filters.** `hub.contribute_labels_mode` + its label list gate which issues are *handed out to external contributors* over `/contribute` — they have never gated the hive's **own** agents, so an operator who allow-listed a queue label there (a common setup for routing labeled issues to contributors) still had a hive whose own scanner could work every other open issue. `project.issue_filter` is the agent-side gate; configure both if you want the same label to govern both lanes.
+
 ## When to add what
 
 | Add… | …when |

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -302,30 +302,35 @@ Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM 
 
 Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard. The reference schema is [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md), and a worked example lives at [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
 
-## Issue label filtering: gating agent work on approval labels
+## Label policy: which issues agents may work
 
-By default a hive treats **every open issue** in its repos as candidate work. Some projects want the opposite: a maintainer reviews each issue and applies an approval label, and only then may automation touch it. (A fleet running against a busy upstream repo hit exactly this — the hive opened a PR for an issue the owner had not yet labeled for agent work.) `project.issue_filter` is that gate:
+There is exactly **one** label-policy surface for the hive's own agents — the **Governor Configuration → Labels** tab — and it has two polarities:
+
+| Polarity | Config | Meaning |
+|---|---|---|
+| **Exempt (deny-list)** | `governor.labels.exempt` (+ permanent `hold`/`on-hold`/`hold/review`, `do-not-merge`) | "**Never** touch issues labeled with these." Everything else is eligible. This has always existed. |
+| **Required (allow-list)** | `project.issue_filter.require_labels` | "**Only** touch issues labeled with these." Empty = every issue is eligible. **This is what "only work approved issues" means.** |
+
+By default a hive treats **every open issue** in its repos as candidate work. Projects that gate automation on a maintainer's explicit approval label want the require polarity: a maintainer reviews an issue, applies the approval/queue label, and only then may agents touch it. (A fleet running against a busy upstream repo hit exactly this — the hive opened a PR for an issue the owner had not yet labeled for agent work; an exempt list cannot express that policy, because it can only name what to avoid, not demand a label be present.)
 
 ```yaml
 project:
   org: my-org
   repos: [my-org/common]
   issue_filter:
-    require_labels: [approved-for-agents]   # only these issues are agent work
-    exclude_labels: [no-ai, needs-design]   # these never are, even if approved
+    require_labels: [approved-for-agents]   # agents may ONLY work these issues
 ```
 
 Semantics:
 
-- **Absent/empty filter = no filtering** — existing hives are unchanged; there is no default-on gate.
-- `require_labels`: an issue must carry **at least one** of these to be eligible. Matching is case-insensitive and exact.
-- `exclude_labels`: an issue carrying **any** of these is never eligible. Exclusion wins over require on conflict.
+- **Absent/empty `require_labels` = no gate** — existing hives are unchanged; there is no default-on filtering.
+- An issue must carry **at least one** required label to be eligible. Matching is case-insensitive and **exact** (a prefix like `approved-for-agents-maybe` does not satisfy `approved-for-agents` — prefix matching would over-admit through an approval gate).
+- **Exempt wins on conflict**: an issue carrying both an exempt label and a required label stays excluded. There is deliberately no separate `exclude_labels` field — the exempt list *is* the exclusion mechanism, applied first.
+- PRs and the Hold list are unaffected: open PRs are in-flight work, and held issues still appear under On Hold.
 
-The filter is enforced at **enumeration** — the point where GitHub issues become the hive's actionable set — not in the prompt. A filtered issue never enters the queue, never appears in a kick, never triggers plan-from-label, and is never offered to contributors, so a confused (or prompt-injected) agent re-listing the repo cannot select it. Kick prompts additionally state the active policy so agents know the list is intentionally short. The dashboard shows the active filter read-only under **Repositories**, and hub-managed hives can receive the filter with their project config over the heartbeat.
+Both polarities are enforced at **enumeration** — the point where GitHub issues become the hive's actionable set — not in the prompt. A filtered issue never enters the queue, never appears in a kick, never triggers plan-from-label, and cannot be re-selected by a confused (or prompt-injected) agent re-listing the repo. Kick prompts additionally state the active require policy so agents know the list is intentionally short. Both lists are edited on the Labels tab; an active require gate is also noted read-only under **Repositories**, and hub-managed hives can receive `issue_filter` with their project config over the heartbeat.
 
-This composes with, and does not change, the pre-existing label behaviors: `hold`/`on-hold` still parks items in the Hold list, `do-not-merge` and `governor.labels.exempt` still exclude items outright.
-
-**Not the same thing as the contribute filters.** `hub.contribute_labels_mode` + its label list gate which issues are *handed out to external contributors* over `/contribute` — they have never gated the hive's **own** agents, so an operator who allow-listed a queue label there (a common setup for routing labeled issues to contributors) still had a hive whose own scanner could work every other open issue. `project.issue_filter` is the agent-side gate; configure both if you want the same label to govern both lanes.
+**Not the same thing as the contribute filters.** `hub.contribute_labels_mode` + its label list gate which issues are *handed out to external contributors* over `/contribute` — they have never gated the hive's **own** agents, so an operator who allow-listed a queue label there (a common setup for routing labeled issues to contributors) still had a hive whose own scanner could work every other open issue. `project.issue_filter.require_labels` is the agent-side gate; configure both if you want the same label to govern both lanes.
 
 ## When to add what
 

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -558,6 +558,10 @@ type ProjectConfig struct {
 	// GitHub-only configs are unaffected. Use ForgeKind() to read it with the
 	// default applied.
 	Forge string `yaml:"forge,omitempty"`
+	// IssueFilter gates which open issues agents may initiate work on, by
+	// label (require and/or exclude sets). Absent/empty = no filtering, the
+	// pre-existing behavior. See IssueFilterConfig for the full contract.
+	IssueFilter IssueFilterConfig `yaml:"issue_filter,omitempty"`
 }
 
 const (

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -558,9 +558,10 @@ type ProjectConfig struct {
 	// GitHub-only configs are unaffected. Use ForgeKind() to read it with the
 	// default applied.
 	Forge string `yaml:"forge,omitempty"`
-	// IssueFilter gates which open issues agents may initiate work on, by
-	// label (require and/or exclude sets). Absent/empty = no filtering, the
-	// pre-existing behavior. See IssueFilterConfig for the full contract.
+	// IssueFilter gates which open issues agents may initiate work on: the
+	// require_labels allow-list ("only work issues labeled X"). The exclude
+	// polarity is Governor.Labels.Exempt, which wins on conflict. Absent/empty
+	// = no filtering, the pre-existing behavior. See IssueFilterConfig.
 	IssueFilter IssueFilterConfig `yaml:"issue_filter,omitempty"`
 }
 

--- a/src/pkg/config/issue_filter.go
+++ b/src/pkg/config/issue_filter.go
@@ -1,0 +1,87 @@
+package config
+
+import "strings"
+
+// IssueFilterConfig gates which open issues agents may INITIATE work on, by
+// label. It exists for projects whose maintainers gate automation on an
+// explicit approval label: without an allowlist, a hive works every actionable
+// issue in its repos, which surprises owners who expected "only issues I have
+// labeled for automation". The filter is enforced at enumeration
+// (github.Client.fetchIssues) — the same choice point where hold/do-not-merge
+// labels and the duplicate-PR claim guard operate — so a filtered issue never
+// enters the actionable set, never reaches a kick prompt, and cannot be
+// re-selected by a confused or prompt-injected agent re-listing the repo.
+//
+// Semantics:
+//   - Absent/empty filter: current behavior EXACTLY — every issue is eligible.
+//     There is no default-on filtering; that would silently idle every
+//     existing hive whose repos use no approval label.
+//   - RequireLabels: when non-empty, an issue is eligible only if it carries
+//     AT LEAST ONE of these labels (case-insensitive exact match).
+//   - ExcludeLabels: an issue carrying ANY of these labels is never eligible.
+//     Exclusion wins over require on conflict.
+//
+// Matching is deliberately EXACT (case-insensitive), not substring/prefix:
+// a require-gate that prefix-matched would over-admit ("approved-for-review"
+// admitting under "approved"), which is the unsafe direction for an approval
+// gate. The pre-existing hold/exempt label checks keep their own looser
+// matching; this filter does not change them.
+type IssueFilterConfig struct {
+	RequireLabels []string `yaml:"require_labels,omitempty" json:"require_labels,omitempty"`
+	ExcludeLabels []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
+}
+
+// IsZero reports whether the filter is absent/empty — i.e. no filtering at all.
+func (f IssueFilterConfig) IsZero() bool {
+	return len(f.RequireLabels) == 0 && len(f.ExcludeLabels) == 0
+}
+
+// Equal reports whether two filters are identical (order-sensitive, exact).
+// Used by the heartbeat reconcile to decide whether a hub push changes anything.
+func (f IssueFilterConfig) Equal(o IssueFilterConfig) bool {
+	if len(f.RequireLabels) != len(o.RequireLabels) || len(f.ExcludeLabels) != len(o.ExcludeLabels) {
+		return false
+	}
+	for i := range f.RequireLabels {
+		if f.RequireLabels[i] != o.RequireLabels[i] {
+			return false
+		}
+	}
+	for i := range f.ExcludeLabels {
+		if f.ExcludeLabels[i] != o.ExcludeLabels[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// labelMatches reports a case-insensitive exact match, ignoring surrounding
+// whitespace on the configured side (a stray space in YAML must not silently
+// disable an approval gate).
+func labelMatches(configured, actual string) bool {
+	return strings.EqualFold(strings.TrimSpace(configured), actual)
+}
+
+// Admits reports whether an issue carrying the given labels is eligible for
+// agent work under this filter. Exclusion wins over require; an empty filter
+// admits everything (see the type comment for the full contract).
+func (f IssueFilterConfig) Admits(labels []string) bool {
+	for _, l := range labels {
+		for _, ex := range f.ExcludeLabels {
+			if labelMatches(ex, l) {
+				return false
+			}
+		}
+	}
+	if len(f.RequireLabels) == 0 {
+		return true
+	}
+	for _, l := range labels {
+		for _, req := range f.RequireLabels {
+			if labelMatches(req, l) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/src/pkg/config/issue_filter.go
+++ b/src/pkg/config/issue_filter.go
@@ -2,53 +2,56 @@ package config
 
 import "strings"
 
-// IssueFilterConfig gates which open issues agents may INITIATE work on, by
-// label. It exists for projects whose maintainers gate automation on an
-// explicit approval label: without an allowlist, a hive works every actionable
-// issue in its repos, which surprises owners who expected "only issues I have
-// labeled for automation". The filter is enforced at enumeration
-// (github.Client.fetchIssues) — the same choice point where hold/do-not-merge
-// labels and the duplicate-PR claim guard operate — so a filtered issue never
-// enters the actionable set, never reaches a kick prompt, and cannot be
-// re-selected by a confused or prompt-injected agent re-listing the repo.
+// IssueFilterConfig gates which open issues agents may INITIATE work on: an
+// issue is eligible only if it carries at least one of RequireLabels (the
+// allow-list polarity). It exists for projects whose maintainers gate
+// automation on an explicit approval label: without an allowlist, a hive works
+// every actionable issue in its repos, which surprises owners who expected
+// "only issues I have labeled for automation".
+//
+// This is deliberately ONLY the require half. The EXCLUDE polarity ("never
+// touch issues labeled X") already exists as governor.labels.exempt — the
+// dashboard's Governor Configuration → Labels tab — plus the permanent
+// hold/do-not-merge labels. There is exactly one exclusion mechanism and one
+// require mechanism; this type does not duplicate the former. Precedence is
+// by construction: fetchIssues applies hold/exempt BEFORE this filter, so an
+// issue that is both exempt and approval-labeled stays excluded.
+//
+// The filter is enforced at enumeration (github.Client.fetchIssues) — the
+// same choice point as the hold/exempt checks and upstream of the
+// duplicate-PR claim guard — so a refused issue never enters the actionable
+// set, never reaches a kick prompt, and cannot be re-selected by a confused
+// or prompt-injected agent re-listing the repo.
 //
 // Semantics:
-//   - Absent/empty filter: current behavior EXACTLY — every issue is eligible.
-//     There is no default-on filtering; that would silently idle every
-//     existing hive whose repos use no approval label.
-//   - RequireLabels: when non-empty, an issue is eligible only if it carries
-//     AT LEAST ONE of these labels (case-insensitive exact match).
-//   - ExcludeLabels: an issue carrying ANY of these labels is never eligible.
-//     Exclusion wins over require on conflict.
+//   - Absent/empty: current behavior EXACTLY — every issue is eligible. There
+//     is no default-on filtering; that would silently idle every existing
+//     hive whose repos use no approval label.
+//   - Non-empty RequireLabels: an issue is eligible only if it carries AT
+//     LEAST ONE of these labels (case-insensitive exact match).
 //
 // Matching is deliberately EXACT (case-insensitive), not substring/prefix:
 // a require-gate that prefix-matched would over-admit ("approved-for-review"
 // admitting under "approved"), which is the unsafe direction for an approval
-// gate. The pre-existing hold/exempt label checks keep their own looser
-// matching; this filter does not change them.
+// gate. The exempt/hold checks keep their own looser matching; this filter
+// does not change them.
 type IssueFilterConfig struct {
 	RequireLabels []string `yaml:"require_labels,omitempty" json:"require_labels,omitempty"`
-	ExcludeLabels []string `yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 }
 
 // IsZero reports whether the filter is absent/empty — i.e. no filtering at all.
 func (f IssueFilterConfig) IsZero() bool {
-	return len(f.RequireLabels) == 0 && len(f.ExcludeLabels) == 0
+	return len(f.RequireLabels) == 0
 }
 
 // Equal reports whether two filters are identical (order-sensitive, exact).
 // Used by the heartbeat reconcile to decide whether a hub push changes anything.
 func (f IssueFilterConfig) Equal(o IssueFilterConfig) bool {
-	if len(f.RequireLabels) != len(o.RequireLabels) || len(f.ExcludeLabels) != len(o.ExcludeLabels) {
+	if len(f.RequireLabels) != len(o.RequireLabels) {
 		return false
 	}
 	for i := range f.RequireLabels {
 		if f.RequireLabels[i] != o.RequireLabels[i] {
-			return false
-		}
-	}
-	for i := range f.ExcludeLabels {
-		if f.ExcludeLabels[i] != o.ExcludeLabels[i] {
 			return false
 		}
 	}
@@ -63,16 +66,11 @@ func labelMatches(configured, actual string) bool {
 }
 
 // Admits reports whether an issue carrying the given labels is eligible for
-// agent work under this filter. Exclusion wins over require; an empty filter
-// admits everything (see the type comment for the full contract).
+// agent work under this filter. An empty filter admits everything (see the
+// type comment for the full contract). Exclusion is not this method's job:
+// governor.labels.exempt and the hold labels are applied by the caller before
+// this filter, which is what makes "exclude wins" hold by construction.
 func (f IssueFilterConfig) Admits(labels []string) bool {
-	for _, l := range labels {
-		for _, ex := range f.ExcludeLabels {
-			if labelMatches(ex, l) {
-				return false
-			}
-		}
-	}
 	if len(f.RequireLabels) == 0 {
 		return true
 	}

--- a/src/pkg/config/issue_filter_test.go
+++ b/src/pkg/config/issue_filter_test.go
@@ -58,39 +58,6 @@ func TestIssueFilterAdmits_RequireAnyOf(t *testing.T) {
 	}
 }
 
-// TestIssueFilterAdmits_ExcludeWinsOverRequire: an issue carrying BOTH a
-// required and an excluded label is refused — exclusion is the stronger claim.
-func TestIssueFilterAdmits_ExcludeWinsOverRequire(t *testing.T) {
-	f := IssueFilterConfig{
-		RequireLabels: []string{"approved"},
-		ExcludeLabels: []string{"no-ai"},
-	}
-	if !f.Admits([]string{"approved"}) {
-		t.Error("positive control failed: approved-only issue refused")
-	}
-	if f.Admits([]string{"approved", "no-ai"}) {
-		t.Error("exclude label did not win over require label")
-	}
-	if f.Admits([]string{"no-ai"}) {
-		t.Error("excluded issue admitted")
-	}
-}
-
-// TestIssueFilterAdmits_ExcludeOnly: exclude without require admits everything
-// except the excluded labels.
-func TestIssueFilterAdmits_ExcludeOnly(t *testing.T) {
-	f := IssueFilterConfig{ExcludeLabels: []string{"wontfix"}}
-	if !f.Admits([]string{"bug"}) {
-		t.Error("exclude-only filter refused an ordinary issue")
-	}
-	if !f.Admits(nil) {
-		t.Error("exclude-only filter refused an unlabeled issue")
-	}
-	if f.Admits([]string{"WontFix"}) {
-		t.Error("excluded label admitted (case-insensitivity)")
-	}
-}
-
 // TestIssueFilterAdmits_ConfigWhitespaceTrimmed: a stray space in YAML must not
 // silently disable an approval gate.
 func TestIssueFilterAdmits_ConfigWhitespaceTrimmed(t *testing.T) {
@@ -101,12 +68,12 @@ func TestIssueFilterAdmits_ConfigWhitespaceTrimmed(t *testing.T) {
 }
 
 func TestIssueFilterEqual(t *testing.T) {
-	a := IssueFilterConfig{RequireLabels: []string{"x"}, ExcludeLabels: []string{"y"}}
-	if !a.Equal(IssueFilterConfig{RequireLabels: []string{"x"}, ExcludeLabels: []string{"y"}}) {
+	a := IssueFilterConfig{RequireLabels: []string{"x", "y"}}
+	if !a.Equal(IssueFilterConfig{RequireLabels: []string{"x", "y"}}) {
 		t.Error("identical filters reported unequal")
 	}
 	if a.Equal(IssueFilterConfig{RequireLabels: []string{"x"}}) {
-		t.Error("filters with different exclude sets reported equal")
+		t.Error("filters with different require sets reported equal")
 	}
 	if (IssueFilterConfig{}).Equal(a) {
 		t.Error("zero filter reported equal to a configured one")

--- a/src/pkg/config/issue_filter_test.go
+++ b/src/pkg/config/issue_filter_test.go
@@ -1,0 +1,117 @@
+package config
+
+import "testing"
+
+// TestIssueFilterAdmits_AbsentAdmitsAll is the regression pin: a zero-value
+// filter must admit EVERYTHING — including issues with no labels at all —
+// because absent config means "current behavior exactly". A default-on filter
+// would silently idle every existing hive.
+func TestIssueFilterAdmits_AbsentAdmitsAll(t *testing.T) {
+	var f IssueFilterConfig
+	if !f.IsZero() {
+		t.Fatal("zero-value filter must report IsZero")
+	}
+	for _, labels := range [][]string{nil, {}, {"bug"}, {"approved"}, {"anything", "else"}} {
+		if !f.Admits(labels) {
+			t.Errorf("zero-value filter refused labels %v — absent config must change nothing", labels)
+		}
+	}
+}
+
+// TestIssueFilterAdmits_RequireLabel: positive control (the labeled issue IS
+// admitted) plus the refusal for the unlabeled one — so the test cannot pass
+// by refusing everything.
+func TestIssueFilterAdmits_RequireLabel(t *testing.T) {
+	f := IssueFilterConfig{RequireLabels: []string{"approved-for-agents"}}
+	if f.IsZero() {
+		t.Fatal("filter with require_labels must not report IsZero")
+	}
+	if !f.Admits([]string{"bug", "approved-for-agents"}) {
+		t.Error("positive control failed: issue carrying the required label was refused")
+	}
+	if !f.Admits([]string{"Approved-For-Agents"}) {
+		t.Error("label match must be case-insensitive")
+	}
+	if f.Admits([]string{"bug"}) {
+		t.Error("issue without the required label was admitted")
+	}
+	if f.Admits(nil) {
+		t.Error("unlabeled issue was admitted despite require_labels")
+	}
+	// Exact match only: a prefix must NOT satisfy an approval gate.
+	if f.Admits([]string{"approved-for-agents-maybe"}) {
+		t.Error("prefix-extended label satisfied the require gate — matching must be exact")
+	}
+}
+
+// TestIssueFilterAdmits_RequireAnyOf: multiple require labels are OR'd.
+func TestIssueFilterAdmits_RequireAnyOf(t *testing.T) {
+	f := IssueFilterConfig{RequireLabels: []string{"clanker", "triage-accepted"}}
+	if !f.Admits([]string{"triage-accepted"}) {
+		t.Error("issue with the second of two require labels was refused")
+	}
+	if !f.Admits([]string{"clanker"}) {
+		t.Error("issue with the first of two require labels was refused")
+	}
+	if f.Admits([]string{"triage"}) {
+		t.Error("near-miss label admitted")
+	}
+}
+
+// TestIssueFilterAdmits_ExcludeWinsOverRequire: an issue carrying BOTH a
+// required and an excluded label is refused — exclusion is the stronger claim.
+func TestIssueFilterAdmits_ExcludeWinsOverRequire(t *testing.T) {
+	f := IssueFilterConfig{
+		RequireLabels: []string{"approved"},
+		ExcludeLabels: []string{"no-ai"},
+	}
+	if !f.Admits([]string{"approved"}) {
+		t.Error("positive control failed: approved-only issue refused")
+	}
+	if f.Admits([]string{"approved", "no-ai"}) {
+		t.Error("exclude label did not win over require label")
+	}
+	if f.Admits([]string{"no-ai"}) {
+		t.Error("excluded issue admitted")
+	}
+}
+
+// TestIssueFilterAdmits_ExcludeOnly: exclude without require admits everything
+// except the excluded labels.
+func TestIssueFilterAdmits_ExcludeOnly(t *testing.T) {
+	f := IssueFilterConfig{ExcludeLabels: []string{"wontfix"}}
+	if !f.Admits([]string{"bug"}) {
+		t.Error("exclude-only filter refused an ordinary issue")
+	}
+	if !f.Admits(nil) {
+		t.Error("exclude-only filter refused an unlabeled issue")
+	}
+	if f.Admits([]string{"WontFix"}) {
+		t.Error("excluded label admitted (case-insensitivity)")
+	}
+}
+
+// TestIssueFilterAdmits_ConfigWhitespaceTrimmed: a stray space in YAML must not
+// silently disable an approval gate.
+func TestIssueFilterAdmits_ConfigWhitespaceTrimmed(t *testing.T) {
+	f := IssueFilterConfig{RequireLabels: []string{" approved "}}
+	if !f.Admits([]string{"approved"}) {
+		t.Error("whitespace-padded configured label failed to match")
+	}
+}
+
+func TestIssueFilterEqual(t *testing.T) {
+	a := IssueFilterConfig{RequireLabels: []string{"x"}, ExcludeLabels: []string{"y"}}
+	if !a.Equal(IssueFilterConfig{RequireLabels: []string{"x"}, ExcludeLabels: []string{"y"}}) {
+		t.Error("identical filters reported unequal")
+	}
+	if a.Equal(IssueFilterConfig{RequireLabels: []string{"x"}}) {
+		t.Error("filters with different exclude sets reported equal")
+	}
+	if (IssueFilterConfig{}).Equal(a) {
+		t.Error("zero filter reported equal to a configured one")
+	}
+	if !(IssueFilterConfig{}).Equal(IssueFilterConfig{}) {
+		t.Error("two zero filters reported unequal")
+	}
+}

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -4069,8 +4069,13 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		"repoCount":           repoCount,
 		"labels":              cfg.Governor.Labels.Exempt,
 		"holdLabels":          github.HoldLabels,
-		"repos":               repos,
-		"primaryRepo":         primaryRepo,
+		// requireLabels is the OPPOSITE polarity from "labels" (exempt):
+		// project.issue_filter.require_labels — when non-empty, agents may
+		// ONLY initiate work on issues carrying at least one of them. Edited
+		// on the same Labels tab so operators have one place for label policy.
+		"requireLabels": cfg.Project.IssueFilter.RequireLabels,
+		"repos":         repos,
+		"primaryRepo":   primaryRepo,
 		"budget": map[string]interface{}{
 			"totalTokens": cfg.Governor.Budget.TotalTokens,
 			"periodDays":  cfg.Governor.Budget.PeriodDays,
@@ -4357,40 +4362,63 @@ func (s *Server) handleGovernorLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Both label polarities save through this one endpoint (the Labels tab
+	// edits both). POINTER-typed so an absent key means "unchanged" — a save
+	// that only touched the require list must not wipe the exempt list to
+	// empty, and vice versa.
 	var body struct {
-		Labels []string `json:"labels"`
+		Labels        *[]string `json:"labels"`
+		RequireLabels *[]string `json:"require_labels"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
-	if err := validateGovernorLabels(body.Labels); err != nil {
-		jsonError(w, err.Error(), http.StatusBadRequest)
-		return
+	if body.Labels != nil {
+		if err := validateGovernorLabels(*body.Labels); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if body.RequireLabels != nil {
+		if err := validateGovernorLabels(*body.RequireLabels); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
-	filtered := make([]string, 0, len(body.Labels))
-	for _, l := range body.Labels {
-		isPermanent := false
-		for _, h := range github.HoldLabels {
-			if l == h {
-				isPermanent = true
-				break
+	if body.Labels != nil {
+		filtered := make([]string, 0, len(*body.Labels))
+		for _, l := range *body.Labels {
+			isPermanent := false
+			for _, h := range github.HoldLabels {
+				if l == h {
+					isPermanent = true
+					break
+				}
+			}
+			for _, p := range github.PermanentExemptLabels {
+				if l == p {
+					isPermanent = true
+					break
+				}
+			}
+			if !isPermanent {
+				filtered = append(filtered, l)
 			}
 		}
-		for _, p := range github.PermanentExemptLabels {
-			if l == p {
-				isPermanent = true
-				break
-			}
-		}
-		if !isPermanent {
-			filtered = append(filtered, l)
+		s.deps.Config.Governor.Labels.Exempt = filtered
+		if s.deps.GHClient != nil {
+			s.deps.GHClient.SetExemptLabels(filtered)
 		}
 	}
-	s.deps.Config.Governor.Labels.Exempt = filtered
-	if s.deps.GHClient != nil {
-		s.deps.GHClient.SetExemptLabels(filtered)
+	if body.RequireLabels != nil {
+		// The require gate (project.issue_filter): empty list = filter off.
+		// Takes effect on the next enumeration via the scan client.
+		s.deps.Config.Project.IssueFilter.RequireLabels = *body.RequireLabels
+		if s.deps.GHClient != nil {
+			s.deps.GHClient.SetIssueFilter(s.deps.Config.Project.IssueFilter)
+		}
 	}
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after label update", "error", err)

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -667,7 +667,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	// github.ibm.com hive for github.com. ResolvedBaseURL falls back to the api_url
 	// host in exactly that case (mirrors HostLabel).
 	githubBaseURL := cfg.GitHub.ResolvedBaseURL()
-	jsonResponse(w, map[string]interface{}{
+	resp := map[string]interface{}{
 		"org":       cfg.Project.Org,
 		"repos":     cfg.Project.Repos,
 		"ai_author": cfg.Project.AIAuthor,
@@ -681,7 +681,15 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"hub_url":             cfg.Hub.URL,
 		"hive_id":             cfg.HiveID,
 		"github_base_url":     githubBaseURL,
-	})
+	}
+	// The active project.issue_filter, read-only: which issues agents may
+	// initiate work on, by label. Omitted entirely when no filter is
+	// configured so the payload (and the UI note keyed off it) stays quiet
+	// for the ordinary unfiltered hive.
+	if !cfg.Project.IssueFilter.IsZero() {
+		resp["issue_filter"] = cfg.Project.IssueFilter
+	}
+	jsonResponse(w, resp)
 }
 
 func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -14670,18 +14670,15 @@ function burnAreaChart() {
       if (ocEl && repoDisplay) ocEl.textContent = repoDisplay;
       if (repoDisplay) window._primaryRepo = repoDisplay;
       // Read-only issue-filter note under Repositories. Present in /api/config
-      // only when project.issue_filter is configured; textContent (never
+      // only when project.issue_filter is configured (edit it on Governor
+      // Configuration → Labels, "Required labels"); textContent (never
       // innerHTML) because label names are repo-controlled text.
       const iflt = cfg.issue_filter || null;
       const ifltReq = (iflt && iflt.require_labels) || [];
-      const ifltExc = (iflt && iflt.exclude_labels) || [];
-      if (ifltReq.length || ifltExc.length) {
+      if (ifltReq.length) {
         const note = document.getElementById('repos-issue-filter');
         if (note) {
-          const parts = [];
-          if (ifltReq.length) parts.push('agents only work issues labeled: ' + ifltReq.join(', '));
-          if (ifltExc.length) parts.push('never issues labeled: ' + ifltExc.join(', '));
-          note.textContent = '🏷️ Issue filter active — ' + parts.join(' · ');
+          note.textContent = '🏷️ Issue filter active — agents only work issues labeled: ' + ifltReq.join(', ');
           note.style.display = '';
         }
       }
@@ -15322,7 +15319,7 @@ function burnAreaChart() {
         case 'General': return renderGovGeneral();
         case 'Agents': return renderGovAgents(d.agents || []);
         case 'Thresholds': return renderGovThresholds(d);
-        case 'Labels': return renderGovLabels(d.labels || [], d.holdLabels || []);
+        case 'Labels': return renderGovLabels(d.labels || [], d.holdLabels || [], d.requireLabels || []);
         case 'Repos': return renderGovRepos(d.repos || []);
         case 'Budget': return renderGovBudget(d.budget || {});
         case 'Notifications': return renderGovNotifications(d.notifications || {});
@@ -18536,7 +18533,7 @@ function burnAreaChart() {
       }
     }
 
-    function renderGovLabels(labels, holdLabels) {
+    function renderGovLabels(labels, holdLabels, requireLabels) {
       const permanentLabels = (holdLabels || []).concat(['do-not-merge']);
       const staticList = permanentLabels.map(l =>
         `<div class="config-list-item" style="opacity:0.7"><span>${esc(l)}</span><span style="font-size:0.65rem;color:var(--muted);margin-left:auto;margin-right:8px">permanent</span></div>`
@@ -18544,8 +18541,16 @@ function burnAreaChart() {
       const list = labels.map((l, i) =>
         `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" onclick="removeListItem('labels','list',${i})">✕</button></div>`
       ).join('');
+      // Required labels (allow-list) — the OPPOSITE polarity from the exempt
+      // list above: exempt = "never touch these", required = "ONLY touch
+      // these". Stored as project.issue_filter.require_labels and enforced at
+      // the actionable scan, not just in prompts.
+      const reqList = (requireLabels || []).map((l, i) =>
+        `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" onclick="removeListItem('labels','require',${i})">✕</button></div>`
+      ).join('');
       return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Labels that filter issues from the actionable issues list and PRs from the mergeable PRs list. Agents receive these filtered lists as variable substitutions in their kick prompts.</p>
+        <h4 style="margin:0 0 6px">Exempt labels (deny-list)</h4>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Labels that filter issues <b>out</b> of the actionable issues list and PRs out of the mergeable PRs list — issues carrying one of these are never agent work. Agents receive the filtered lists as variable substitutions in their kick prompts.</p>
         <p style="font-size:0.7rem;color:var(--muted);margin-bottom:8px;font-style:italic">Permanent labels cannot be removed. Hold labels also appear in the On Hold section of the dashboard.</p>
         <div class="config-list">
           ${staticList}
@@ -18554,6 +18559,15 @@ function burnAreaChart() {
           <div class="config-list-add">
             <input type="text" id="cfg-label-input" placeholder="label name" title="GitHub label name to exempt from actionable issues and mergeable PRs.">
             <button onclick="addListItem('labels','list','cfg-label-input')" title="Add this label to the exempt list">+ Add</button>
+          </div>
+        </div>
+        <h4 style="margin:18px 0 6px">Required labels (allow-list)</h4>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">The opposite polarity: when this list is non-empty, agents may <b>only</b> initiate work on issues carrying at least one of these labels — "only work approved issues". Empty = every issue is eligible (the default). Exempt labels above still win on conflict; PRs and the Hold list are unaffected. Matching is exact (case-insensitive).</p>
+        <div class="config-list">
+          ${reqList || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No required labels — agents may work every actionable issue</div>'}
+          <div class="config-list-add">
+            <input type="text" id="cfg-require-label-input" placeholder="label name" title="GitHub label an issue must carry before agents may work it (e.g. an approval/queue label).">
+            <button onclick="addListItem('labels','require','cfg-require-label-input')" title="Add this label to the required (allow) list">+ Add</button>
           </div>
         </div>`;
     }
@@ -19408,9 +19422,15 @@ function burnAreaChart() {
         _configState.data.hooks[key].push(val);
         markDirty('hooks', key, _configState.data.hooks[key]);
       } else if (section === 'labels') {
-        if (!_configState.data.labels) _configState.data.labels = [];
-        _configState.data.labels.push(val);
-        markDirty('labels', 'labels', _configState.data.labels);
+        if (key === 'require') {
+          if (!_configState.data.requireLabels) _configState.data.requireLabels = [];
+          _configState.data.requireLabels.push(val);
+          markDirty('labels', 'require_labels', _configState.data.requireLabels);
+        } else {
+          if (!_configState.data.labels) _configState.data.labels = [];
+          _configState.data.labels.push(val);
+          markDirty('labels', 'labels', _configState.data.labels);
+        }
       } else if (section === 'repos') {
         // Repos go through the async host-check + App-access workflow, which
         // owns input clearing and re-render on success. Return here so the
@@ -19427,8 +19447,13 @@ function burnAreaChart() {
         _configState.data.hooks[key].splice(index, 1);
         markDirty('hooks', key, _configState.data.hooks[key]);
       } else if (section === 'labels') {
-        _configState.data.labels.splice(index, 1);
-        markDirty('labels', 'labels', _configState.data.labels);
+        if (key === 'require') {
+          _configState.data.requireLabels.splice(index, 1);
+          markDirty('labels', 'require_labels', _configState.data.requireLabels);
+        } else {
+          _configState.data.labels.splice(index, 1);
+          markDirty('labels', 'labels', _configState.data.labels);
+        }
       } else if (section === 'repos') {
         _configState.data.repos.splice(index, 1);
         markDirty('repos', 'repos', _configState.data.repos);

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -3101,6 +3101,11 @@
   <div class="repos" id="repos-section">
     <h2 class="section-header-toggle" onclick="toggleSection('repos-section')"><span class="section-chevron">▼</span> Repositories <span id="repos-host-badge" title="Every repo in this hive is on this single GitHub host" style="font-size:0.62em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px"></span> <button class="config-gear" onclick="event.stopPropagation();openConfigDialog('governor',null,'Repos')" title="Manage monitored repositories" style="font-size:0.7em;vertical-align:middle">⚙️</button></h2>
     <div class="section-body">
+      <!-- Read-only view of project.issue_filter: which issues agents may
+           initiate work on, by label. Hidden unless a filter is configured;
+           populated from /api/config at boot. Enforcement lives server-side
+           at enumeration — this note only surfaces the active policy. -->
+      <div id="repos-issue-filter" style="display:none;font-size:0.75rem;color:var(--muted);margin:0 0 8px"></div>
       <div class="repo-grid" id="repos"></div>
     </div>
   </div>
@@ -14664,6 +14669,22 @@ function burnAreaChart() {
       const ocEl = document.getElementById("oc-project-name");
       if (ocEl && repoDisplay) ocEl.textContent = repoDisplay;
       if (repoDisplay) window._primaryRepo = repoDisplay;
+      // Read-only issue-filter note under Repositories. Present in /api/config
+      // only when project.issue_filter is configured; textContent (never
+      // innerHTML) because label names are repo-controlled text.
+      const iflt = cfg.issue_filter || null;
+      const ifltReq = (iflt && iflt.require_labels) || [];
+      const ifltExc = (iflt && iflt.exclude_labels) || [];
+      if (ifltReq.length || ifltExc.length) {
+        const note = document.getElementById('repos-issue-filter');
+        if (note) {
+          const parts = [];
+          if (ifltReq.length) parts.push('agents only work issues labeled: ' + ifltReq.join(', '));
+          if (ifltExc.length) parts.push('never issues labeled: ' + ifltExc.join(', '));
+          note.textContent = '🏷️ Issue filter active — ' + parts.join(' · ');
+          note.style.display = '';
+        }
+      }
     }).catch(() => {});
 
     // Initial fetch then SSE — these two are critical for first paint

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -34,6 +34,16 @@ type Client struct {
 	reposMu      sync.RWMutex
 	repos        []string
 	exemptLabels []string
+	// issueFilter is the operator's project.issue_filter (require/exclude
+	// label sets) gating which issues become actionable at all. Enforced in
+	// fetchIssues — the choice point where issues enter the actionable set —
+	// so everything downstream (governor counts, scheduler kicks, plan-from-
+	// label, the contribute queue) inherits it and no agent-side re-listing
+	// can bypass it. Guarded because config reload / hub heartbeat delivery
+	// re-applies it while the enumeration goroutine reads it. Zero value =
+	// admit everything (pre-existing behavior).
+	issueFilterMu sync.RWMutex
+	issueFilter   config.IssueFilterConfig
 	// autoMergeLabel is the configured merger-queue label. Guarded because
 	// config reload re-applies it while request handlers read it.
 	autoMergeLabelMu sync.RWMutex
@@ -489,6 +499,7 @@ func (c *Client) splitRepo(repo string) (owner, repoName string) {
 }
 
 func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (actionable []Issue, held []HoldItem, totalIssues int, err error) {
+	issueFilter := c.getIssueFilter()
 	owner, repoName := c.splitRepo(repo)
 	opts := &gh.IssueListByRepoOptions{
 		State:       "open",
@@ -527,6 +538,18 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 		}
 
 		if c.isExempt(labels) {
+			continue
+		}
+
+		// project.issue_filter — THE choice point for label-gated agent work.
+		// An issue the filter refuses never becomes actionable: it is invisible
+		// to the governor's queue counts, every kick prompt, plan-from-label,
+		// and the contribute queue, so no downstream consumer (or prompt-
+		// injected agent re-listing the repo) can select it. Zero-value filter
+		// admits everything — pre-existing behavior, verified by regression
+		// tests. Deliberately AFTER the hold check so held issues keep
+		// appearing in the Hold list exactly as before.
+		if !issueFilter.Admits(labels) {
 			continue
 		}
 
@@ -986,6 +1009,25 @@ func (c *Client) SetExemptLabels(labels []string) {
 		return
 	}
 	c.exemptLabels = labels
+}
+
+// SetIssueFilter installs the operator's project.issue_filter. Nil-receiver
+// safe for the same reason as SetRepos: the config-reload / heartbeat-delivery
+// paths re-apply it unconditionally, and a hive that booted without GitHub
+// credentials runs with a nil *Client.
+func (c *Client) SetIssueFilter(f config.IssueFilterConfig) {
+	if c == nil {
+		return
+	}
+	c.issueFilterMu.Lock()
+	defer c.issueFilterMu.Unlock()
+	c.issueFilter = f
+}
+
+func (c *Client) getIssueFilter() config.IssueFilterConfig {
+	c.issueFilterMu.RLock()
+	defer c.issueFilterMu.RUnlock()
+	return c.issueFilter
 }
 
 // SetAutoMergeLabel is nil-receiver safe for the same reason as SetRepos. An

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -34,8 +34,11 @@ type Client struct {
 	reposMu      sync.RWMutex
 	repos        []string
 	exemptLabels []string
-	// issueFilter is the operator's project.issue_filter (require/exclude
-	// label sets) gating which issues become actionable at all. Enforced in
+	// issueFilter is the operator's project.issue_filter (require_labels
+	// allow-list) gating which issues become actionable at all. The exclude
+	// polarity is NOT here — it is exemptLabels above (governor.labels.exempt,
+	// the dashboard Labels tab), the pre-existing single exclusion mechanism,
+	// which fetchIssues applies first so it wins on conflict. Enforced in
 	// fetchIssues — the choice point where issues enter the actionable set —
 	// so everything downstream (governor counts, scheduler kicks, plan-from-
 	// label, the contribute queue) inherits it and no agent-side re-listing
@@ -541,14 +544,17 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 			continue
 		}
 
-		// project.issue_filter — THE choice point for label-gated agent work.
-		// An issue the filter refuses never becomes actionable: it is invisible
-		// to the governor's queue counts, every kick prompt, plan-from-label,
-		// and the contribute queue, so no downstream consumer (or prompt-
-		// injected agent re-listing the repo) can select it. Zero-value filter
-		// admits everything — pre-existing behavior, verified by regression
-		// tests. Deliberately AFTER the hold check so held issues keep
-		// appearing in the Hold list exactly as before.
+		// project.issue_filter (require_labels) — THE choice point for
+		// label-gated agent work. An issue the filter refuses never becomes
+		// actionable: it is invisible to the governor's queue counts, every
+		// kick prompt, plan-from-label, and the contribute queue, so no
+		// downstream consumer (or prompt-injected agent re-listing the repo)
+		// can select it. Zero-value filter admits everything — pre-existing
+		// behavior, verified by regression tests. Deliberately AFTER the
+		// hold/exempt checks: held issues keep appearing in the Hold list
+		// exactly as before, and the EXCLUDE polarity stays the sole property
+		// of governor.labels.exempt (the dashboard Labels tab) — which
+		// therefore wins over the require gate by construction.
 		if !issueFilter.Admits(labels) {
 			continue
 		}

--- a/src/pkg/github/issue_filter_test.go
+++ b/src/pkg/github/issue_filter_test.go
@@ -21,12 +21,12 @@ func filterTestIssues() []wireIssue {
 			Labels: []wireLabel{{Name: "bug"}, {Name: "approved-for-agents"}}, CreatedAt: hoursAgo(3)},
 		{Number: 2, Title: "unapproved work", User: wireUser{"bob"},
 			Labels: []wireLabel{{Name: "bug"}}, CreatedAt: hoursAgo(2)},
-		{Number: 3, Title: "approved but vetoed", User: wireUser{"carol"},
+		{Number: 3, Title: "approved but exempted", User: wireUser{"carol"},
 			Labels: []wireLabel{{Name: "approved-for-agents"}, {Name: "no-ai"}}, CreatedAt: hoursAgo(1)},
 	}
 }
 
-func enumerateWithFilter(t *testing.T, f config.IssueFilterConfig) *ActionableResult {
+func enumerateWithFilter(t *testing.T, f config.IssueFilterConfig, exempt []string) *ActionableResult {
 	t.Helper()
 	org, repo := "testorg", "testrepo"
 	mux := buildMux(t, org, repo, filterTestIssues(), nil)
@@ -34,6 +34,9 @@ func enumerateWithFilter(t *testing.T, f config.IssueFilterConfig) *ActionableRe
 	t.Cleanup(server.Close)
 	c := newTestClient(t, server, org, []string{repo})
 	c.SetIssueFilter(f)
+	if len(exempt) > 0 {
+		c.SetExemptLabels(exempt)
+	}
 	result, err := c.EnumerateActionable(context.Background())
 	if err != nil {
 		t.Fatalf("EnumerateActionable: %v", err)
@@ -50,12 +53,12 @@ func actionableNumbers(result *ActionableResult) map[int]bool {
 }
 
 // TestEnumerateActionable_IssueFilterRequireLabel: with require_labels set,
-// only the labeled issue becomes actionable. Positive control (issue #1 IS
+// only labeled issues become actionable. Positive control (issue #1 IS
 // admitted) plus a count floor, so the test cannot pass by admitting nothing.
 func TestEnumerateActionable_IssueFilterRequireLabel(t *testing.T) {
 	result := enumerateWithFilter(t, config.IssueFilterConfig{
 		RequireLabels: []string{"approved-for-agents"},
-	})
+	}, nil)
 	nums := actionableNumbers(result)
 	if !nums[1] {
 		t.Error("positive control failed: issue #1 carries the required label but is not actionable")
@@ -68,19 +71,22 @@ func TestEnumerateActionable_IssueFilterRequireLabel(t *testing.T) {
 	}
 }
 
-// TestEnumerateActionable_IssueFilterExcludeWins: an issue carrying both the
-// required label and an excluded label is refused.
-func TestEnumerateActionable_IssueFilterExcludeWins(t *testing.T) {
+// TestEnumerateActionable_ExemptWinsOverRequire pins the ONE-exclusion-story
+// composition: the exclude polarity lives in governor.labels.exempt (the
+// dashboard Labels tab), not in issue_filter, and it runs BEFORE the require
+// gate — so an issue carrying both an exempt label and the approval label
+// stays excluded. This is the "exclude wins over require" conflict rule,
+// delivered by the pre-existing mechanism rather than a duplicate one.
+func TestEnumerateActionable_ExemptWinsOverRequire(t *testing.T) {
 	result := enumerateWithFilter(t, config.IssueFilterConfig{
 		RequireLabels: []string{"approved-for-agents"},
-		ExcludeLabels: []string{"no-ai"},
-	})
+	}, []string{"no-ai"})
 	nums := actionableNumbers(result)
 	if !nums[1] {
 		t.Error("positive control failed: issue #1 refused")
 	}
 	if nums[3] {
-		t.Error("issue #3 carries an excluded label but entered the actionable set — exclude must win over require")
+		t.Error("issue #3 carries a governor exempt label but entered the actionable set — exemption must win over the require gate")
 	}
 	if nums[2] {
 		t.Error("issue #2 lacks the required label but entered the actionable set")
@@ -94,7 +100,7 @@ func TestEnumerateActionable_IssueFilterExcludeWins(t *testing.T) {
 // no filter configured (the state of every existing hive), enumeration is
 // byte-for-byte the old behavior — all three issues actionable.
 func TestEnumerateActionable_NoIssueFilterUnchanged(t *testing.T) {
-	result := enumerateWithFilter(t, config.IssueFilterConfig{})
+	result := enumerateWithFilter(t, config.IssueFilterConfig{}, nil)
 	if got := result.Issues.Count; got != 3 {
 		t.Errorf("Issues.Count = %d, want 3 — absent filter must change nothing", got)
 	}

--- a/src/pkg/github/issue_filter_test.go
+++ b/src/pkg/github/issue_filter_test.go
@@ -1,0 +1,164 @@
+package github
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// These tests pin project.issue_filter enforcement at THE choice point —
+// EnumerateActionable/fetchIssues, where GitHub issues become the hive's
+// actionable set. An issue the filter refuses must never enter
+// Issues.Items: everything downstream (governor queue counts, scheduler
+// kicks, plan-from-label, the contribute queue) consumes that set, so
+// refusal here is what makes the gate un-bypassable by a re-listing agent.
+
+func filterTestIssues() []wireIssue {
+	return []wireIssue{
+		{Number: 1, Title: "approved work", User: wireUser{"alice"},
+			Labels: []wireLabel{{Name: "bug"}, {Name: "approved-for-agents"}}, CreatedAt: hoursAgo(3)},
+		{Number: 2, Title: "unapproved work", User: wireUser{"bob"},
+			Labels: []wireLabel{{Name: "bug"}}, CreatedAt: hoursAgo(2)},
+		{Number: 3, Title: "approved but vetoed", User: wireUser{"carol"},
+			Labels: []wireLabel{{Name: "approved-for-agents"}, {Name: "no-ai"}}, CreatedAt: hoursAgo(1)},
+	}
+}
+
+func enumerateWithFilter(t *testing.T, f config.IssueFilterConfig) *ActionableResult {
+	t.Helper()
+	org, repo := "testorg", "testrepo"
+	mux := buildMux(t, org, repo, filterTestIssues(), nil)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	c := newTestClient(t, server, org, []string{repo})
+	c.SetIssueFilter(f)
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	return result
+}
+
+func actionableNumbers(result *ActionableResult) map[int]bool {
+	nums := make(map[int]bool)
+	for _, is := range result.Issues.Items {
+		nums[is.Number] = true
+	}
+	return nums
+}
+
+// TestEnumerateActionable_IssueFilterRequireLabel: with require_labels set,
+// only the labeled issue becomes actionable. Positive control (issue #1 IS
+// admitted) plus a count floor, so the test cannot pass by admitting nothing.
+func TestEnumerateActionable_IssueFilterRequireLabel(t *testing.T) {
+	result := enumerateWithFilter(t, config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+	})
+	nums := actionableNumbers(result)
+	if !nums[1] {
+		t.Error("positive control failed: issue #1 carries the required label but is not actionable")
+	}
+	if nums[2] {
+		t.Error("issue #2 lacks the required label but entered the actionable set — the choice-point gate is not enforced")
+	}
+	if got := result.Issues.Count; got != 2 {
+		t.Errorf("Issues.Count = %d, want 2 (issues #1 and #3)", got)
+	}
+}
+
+// TestEnumerateActionable_IssueFilterExcludeWins: an issue carrying both the
+// required label and an excluded label is refused.
+func TestEnumerateActionable_IssueFilterExcludeWins(t *testing.T) {
+	result := enumerateWithFilter(t, config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+		ExcludeLabels: []string{"no-ai"},
+	})
+	nums := actionableNumbers(result)
+	if !nums[1] {
+		t.Error("positive control failed: issue #1 refused")
+	}
+	if nums[3] {
+		t.Error("issue #3 carries an excluded label but entered the actionable set — exclude must win over require")
+	}
+	if nums[2] {
+		t.Error("issue #2 lacks the required label but entered the actionable set")
+	}
+	if got := result.Issues.Count; got != 1 {
+		t.Errorf("Issues.Count = %d, want 1 (only issue #1)", got)
+	}
+}
+
+// TestEnumerateActionable_NoIssueFilterUnchanged is the regression pin: with
+// no filter configured (the state of every existing hive), enumeration is
+// byte-for-byte the old behavior — all three issues actionable.
+func TestEnumerateActionable_NoIssueFilterUnchanged(t *testing.T) {
+	result := enumerateWithFilter(t, config.IssueFilterConfig{})
+	if got := result.Issues.Count; got != 3 {
+		t.Errorf("Issues.Count = %d, want 3 — absent filter must change nothing", got)
+	}
+	nums := actionableNumbers(result)
+	for _, n := range []int{1, 2, 3} {
+		if !nums[n] {
+			t.Errorf("issue #%d missing from actionable set with no filter configured", n)
+		}
+	}
+}
+
+// TestEnumerateActionable_IssueFilterDoesNotTouchPRs: the filter gates which
+// ISSUES agents may initiate work on. Open PRs are in-flight work and must
+// keep flowing regardless of their labels.
+func TestEnumerateActionable_IssueFilterDoesNotTouchPRs(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	prs := []wirePR{
+		{Number: 10, Title: "fix in flight", User: wireUser{"alice"},
+			Labels: []wireLabel{{Name: "bug"}}, CreatedAt: hoursAgo(1)},
+	}
+	mux := buildMux(t, org, repo, nil, prs)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	c := newTestClient(t, server, org, []string{repo})
+	c.SetIssueFilter(config.IssueFilterConfig{RequireLabels: []string{"approved-for-agents"}})
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	if result.PRs.Count != 1 {
+		t.Errorf("PRs.Count = %d, want 1 — the issue filter must not gate PRs", result.PRs.Count)
+	}
+}
+
+// TestEnumerateActionable_IssueFilterKeepsHold: hold-labeled issues keep
+// appearing in the Hold list even when they would fail the require gate — the
+// filter runs after the hold check, preserving the operator's hold view.
+func TestEnumerateActionable_IssueFilterKeepsHold(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	issues := []wireIssue{
+		{Number: 5, Title: "parked", User: wireUser{"dave"},
+			Labels: []wireLabel{{Name: "hold"}}, CreatedAt: hoursAgo(1)},
+	}
+	mux := buildMux(t, org, repo, issues, nil)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	c := newTestClient(t, server, org, []string{repo})
+	c.SetIssueFilter(config.IssueFilterConfig{RequireLabels: []string{"approved-for-agents"}})
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	if result.Hold.Issues != 1 {
+		t.Errorf("Hold.Issues = %d, want 1 — the issue filter must not hide held items", result.Hold.Issues)
+	}
+	if result.Issues.Count != 0 {
+		t.Errorf("Issues.Count = %d, want 0", result.Issues.Count)
+	}
+}
+
+// TestSetIssueFilter_NilReceiver: the setter must be nil-receiver safe, like
+// SetRepos/SetExemptLabels — a hive without GitHub credentials runs with a
+// nil *Client and the reload paths call the setter unconditionally.
+func TestSetIssueFilter_NilReceiver(t *testing.T) {
+	var c *Client
+	c.SetIssueFilter(config.IssueFilterConfig{RequireLabels: []string{"x"}}) // must not panic
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/tracing"
 )
 
@@ -1936,6 +1937,14 @@ type HeartbeatProjectConfig struct {
 	// Empty = leave the spoke's github.api_url unchanged (public github.com is
 	// the spoke's own default), so this never blanks a working config.
 	GitHubAPIURL string `json:"github_api_url,omitempty"`
+	// IssueFilter delivers the per-hive project.issue_filter (require/exclude
+	// label sets gating which issues agents may initiate work on). It rides
+	// this struct because it is part of the same project identity as
+	// org/repos. nil = the hub is not speaking to this field — the spoke keeps
+	// its locally configured filter, so the hub's every-beat echo can never
+	// blank it (the AIAuthor lesson). A non-nil but empty filter is an
+	// explicit clear.
+	IssueFilter *config.IssueFilterConfig `json:"issue_filter,omitempty"`
 }
 
 // HeartbeatGatewayConfig carries an OpenRouter model gateway (funded via the

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -1937,8 +1937,9 @@ type HeartbeatProjectConfig struct {
 	// Empty = leave the spoke's github.api_url unchanged (public github.com is
 	// the spoke's own default), so this never blanks a working config.
 	GitHubAPIURL string `json:"github_api_url,omitempty"`
-	// IssueFilter delivers the per-hive project.issue_filter (require/exclude
-	// label sets gating which issues agents may initiate work on). It rides
+	// IssueFilter delivers the per-hive project.issue_filter (the
+	// require_labels allow-list gating which issues agents may initiate work
+	// on; exclusion stays governor.labels.exempt, spoke-owned). It rides
 	// this struct because it is part of the same project identity as
 	// org/repos. nil = the hub is not speaking to this field — the spoke keeps
 	// its locally configured filter, so the hub's every-beat echo can never

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3062,15 +3062,15 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// own "channel -> image" block above the per-branch rows, and offers
 		// them as branch-switch targets. The association is resolved from
 		// registry digests (cached), never hardcoded to a branch name.
-		"release_channels":         ReleaseChannels(),
-		"channel_targets":          getChannelTargets(getDisplaySHAs(), s.logger),
-		"hub_auto_upgrade":         isHubAutoUpgrade(),
-		"hub_upgrade_state":        s.hubUpgradeState(),
+		"release_channels":  ReleaseChannels(),
+		"channel_targets":   getChannelTargets(getDisplaySHAs(), s.logger),
+		"hub_auto_upgrade":  isHubAutoUpgrade(),
+		"hub_upgrade_state": s.hubUpgradeState(),
 		// Kill-switch state rides the top-level payload (NOT the hive-row
 		// shape, so no HIVES_CACHE_VERSION bump): the dashboard shows a
 		// prominent banner while anything is paused, and admins get toggles.
 		"upgrade_pause": s.upgradePauseSnapshot(),
-		"show_my_hives":            true,
+		"show_my_hives": true,
 		// Fleet alerts ship WITH the hive list so the "Attention needed" panel
 		// renders in the same paint as the rows it summarises — a second
 		// round-trip would make the panel pop in after the list and shift it.
@@ -7627,6 +7627,11 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		PrimaryRepo:  pushPrimary,
 		ACMMLevel:    pushACMM,
 		DashboardURL: h.VanityURL,
+		// IssueFilter rides the claim push only when the record carries one.
+		// nil (the ordinary case) tells the spoke "keep your own filter" — the
+		// echo of this struct on later beats must never blank an operator's
+		// locally configured project.issue_filter.
+		IssueFilter: h.IssueFilter,
 		// Point a GHE hive at its enterprise API. jjs-world
 		// (hosted-open-source-osscar) is the working reference: a bare
 		// primary_repo plus github.api_url = https://<host>/api/v3. Empty host

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -472,10 +472,16 @@ type SaaSHive struct {
 	GitHubHost  string   `json:"github_host,omitempty"`
 	Repos       []string `json:"repos"`
 	PrimaryRepo string   `json:"primary_repo"`
-	ACMMLevel   int      `json:"acmm_level"`
-	Status      string   `json:"status"`
-	CreatedAt   string   `json:"created_at"`
-	Subdomain   string   `json:"subdomain"`
+	// IssueFilter, when set on this record (admin-managed meta), is delivered
+	// to the spoke with the claim push so a fleet whose owner gates agent work
+	// on an approval label gets the gate from first boot. nil = never pushed;
+	// the spoke's own project.issue_filter (dashboard/config-managed) is then
+	// authoritative and is never blanked by the reconcile.
+	IssueFilter *config.IssueFilterConfig `json:"issue_filter,omitempty"`
+	ACMMLevel   int                       `json:"acmm_level"`
+	Status      string                    `json:"status"`
+	CreatedAt   string                    `json:"created_at"`
+	Subdomain   string                    `json:"subdomain"`
 	// VanityURL is the friendly dashboard URL derived from the claimed project
 	// (e.g. hosted-<org>-<repo>-*.hive.kubestellar.io), set at ASSIGN time. Its
 	// presence is the explicit marker that a placeholder has been claimed —

--- a/src/pkg/scheduler/issue_filter_notice_test.go
+++ b/src/pkg/scheduler/issue_filter_notice_test.go
@@ -1,0 +1,77 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// The issue-filter NOTICE is prompt text only — enforcement lives at
+// enumeration (pkg/github fetchIssues), tested there. These tests pin that
+// kick prompts state the active policy so agents are never told to go look at
+// excluded issues, and that an unconfigured hive's prompts are unchanged.
+
+func newSchedulerWithFilter(f config.IssueFilterConfig) *Scheduler {
+	cfg := &config.Config{
+		Project: config.ProjectConfig{
+			Org:         "test-org",
+			Repos:       []string{"test-org/common"},
+			IssueFilter: f,
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(cfg, logger)
+}
+
+func TestScannerMessage_IssueFilterNoticePresent(t *testing.T) {
+	s := newSchedulerWithFilter(config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+		ExcludeLabels: []string{"no-ai"},
+	})
+	msg := s.buildScannerMessage(nil, emptyActionable())
+	if !strings.Contains(msg, "ISSUE FILTER") {
+		t.Errorf("scanner kick missing issue-filter notice:\n%s", msg)
+	}
+	if !strings.Contains(msg, "approved-for-agents") {
+		t.Errorf("scanner kick does not name the required label:\n%s", msg)
+	}
+	if !strings.Contains(msg, "no-ai") {
+		t.Errorf("scanner kick does not name the excluded label:\n%s", msg)
+	}
+}
+
+// TestScannerMessage_NoFilterNoNotice is the regression pin: an unconfigured
+// hive's kick prompt carries no filter text at all.
+func TestScannerMessage_NoFilterNoNotice(t *testing.T) {
+	s := newScheduler()
+	msg := s.buildScannerMessage(nil, emptyActionable())
+	if strings.Contains(msg, "ISSUE FILTER") {
+		t.Errorf("unconfigured hive's scanner kick mentions an issue filter:\n%s", msg)
+	}
+}
+
+// TestFormatIssueList_CarriesNotice: templates render issues via
+// ${ISSUE_LIST}; the notice must ride it so template-driven kicks state the
+// policy too — including when the filter leaves the list empty, which is
+// exactly when an agent is most tempted to go find work by itself.
+func TestFormatIssueList_CarriesNotice(t *testing.T) {
+	s := newSchedulerWithFilter(config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+	})
+	out := s.formatIssueList(nil)
+	if !strings.Contains(out, "ISSUE FILTER") {
+		t.Errorf("empty ${ISSUE_LIST} missing issue-filter notice: %q", out)
+	}
+	if !strings.Contains(out, "(none)") {
+		t.Errorf("empty ${ISSUE_LIST} lost its (none) marker: %q", out)
+	}
+
+	// Unconfigured: exact legacy output, byte for byte.
+	legacy := newScheduler().formatIssueList(nil)
+	if legacy != "(none)" {
+		t.Errorf("unconfigured empty ${ISSUE_LIST} changed: %q, want %q", legacy, "(none)")
+	}
+}

--- a/src/pkg/scheduler/issue_filter_notice_test.go
+++ b/src/pkg/scheduler/issue_filter_notice_test.go
@@ -29,7 +29,6 @@ func newSchedulerWithFilter(f config.IssueFilterConfig) *Scheduler {
 func TestScannerMessage_IssueFilterNoticePresent(t *testing.T) {
 	s := newSchedulerWithFilter(config.IssueFilterConfig{
 		RequireLabels: []string{"approved-for-agents"},
-		ExcludeLabels: []string{"no-ai"},
 	})
 	msg := s.buildScannerMessage(nil, emptyActionable())
 	if !strings.Contains(msg, "ISSUE FILTER") {
@@ -37,9 +36,6 @@ func TestScannerMessage_IssueFilterNoticePresent(t *testing.T) {
 	}
 	if !strings.Contains(msg, "approved-for-agents") {
 		t.Errorf("scanner kick does not name the required label:\n%s", msg)
-	}
-	if !strings.Contains(msg, "no-ai") {
-		t.Errorf("scanner kick does not name the excluded label:\n%s", msg)
 	}
 }
 

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -305,14 +305,8 @@ func (s *Scheduler) issueFilterNotice() string {
 	}
 	var b strings.Builder
 	b.WriteString("ISSUE FILTER (operator policy — already enforced; the issue list below reflects it):\n")
-	if len(f.RequireLabels) > 0 {
-		b.WriteString(fmt.Sprintf("  Agents may ONLY work issues carrying at least one of these labels: %s\n",
-			strings.Join(f.RequireLabels, ", ")))
-	}
-	if len(f.ExcludeLabels) > 0 {
-		b.WriteString(fmt.Sprintf("  Issues carrying any of these labels are NEVER agent work: %s\n",
-			strings.Join(f.ExcludeLabels, ", ")))
-	}
+	b.WriteString(fmt.Sprintf("  Agents may ONLY work issues carrying at least one of these labels: %s\n",
+		strings.Join(f.RequireLabels, ", ")))
 	b.WriteString("  ⛔ Do NOT pick up, plan, or open PRs for issues outside this list, even if you find them by listing the repo yourself.\n")
 	return b.String()
 }

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -290,11 +290,40 @@ func (s *Scheduler) formatIssueList(issues []github.Issue) string {
 	return out
 }
 
-func (s *Scheduler) formatIssueListWithPolicy(issues []github.Issue) (string, bool) {
-	if len(issues) == 0 {
-		return "(none)", false
+// issueFilterNotice renders the operator's project.issue_filter as prompt text,
+// or "" when no filter is configured. The filter is ENFORCED upstream at
+// enumeration (github.Client.fetchIssues) — filtered issues never reach any
+// kick — so this notice is informational: it tells agents WHY the list may
+// look smaller than the repo's open issues and not to go hunting for the rest.
+// It is prepended to every issue list (${ISSUE_LIST} in kick templates and the
+// hardcoded builders alike) so no agent is ever told to look at excluded
+// issues.
+func (s *Scheduler) issueFilterNotice() string {
+	f := s.cfg.Project.IssueFilter
+	if f.IsZero() {
+		return ""
 	}
 	var b strings.Builder
+	b.WriteString("ISSUE FILTER (operator policy — already enforced; the issue list below reflects it):\n")
+	if len(f.RequireLabels) > 0 {
+		b.WriteString(fmt.Sprintf("  Agents may ONLY work issues carrying at least one of these labels: %s\n",
+			strings.Join(f.RequireLabels, ", ")))
+	}
+	if len(f.ExcludeLabels) > 0 {
+		b.WriteString(fmt.Sprintf("  Issues carrying any of these labels are NEVER agent work: %s\n",
+			strings.Join(f.ExcludeLabels, ", ")))
+	}
+	b.WriteString("  ⛔ Do NOT pick up, plan, or open PRs for issues outside this list, even if you find them by listing the repo yourself.\n")
+	return b.String()
+}
+
+func (s *Scheduler) formatIssueListWithPolicy(issues []github.Issue) (string, bool) {
+	notice := s.issueFilterNotice()
+	if len(issues) == 0 {
+		return notice + "(none)", false
+	}
+	var b strings.Builder
+	b.WriteString(notice)
 	shown := 0
 	failClosed := false
 	for _, issue := range issues {
@@ -572,6 +601,7 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 
 	b.WriteString("[agent:scanner]\n")
 	b.WriteString(fmt.Sprintf("YOUR WORK LIST (pre-filtered — hold/ADOPTERS/drafts excluded, classified):\n"))
+	b.WriteString(s.issueFilterNotice())
 
 	scannerIssues := issues
 
@@ -832,6 +862,7 @@ func (s *Scheduler) buildGenericMessage(agentName string, issues []github.Issue,
 	baseName := s.cfg.BaseAgentName(agentName)
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("[agent:%s]\n", agentName))
+	b.WriteString(s.issueFilterNotice())
 
 	agentIssues := filterByLane(issues, baseName)
 	if len(agentIssues) > 0 {


### PR DESCRIPTION
## Why

A fleet owner expected agent work to be gated on an approval label and found the hive scanner opening a PR for an issue that carried only a triage label. Ground truth from the investigation:

- **A require-label ("only work approved issues") gate never existed for the hive's own agents, on any branch.** The exclusion polarity has always existed — the Governor Configuration → Labels tab (`governor.labels.exempt` + permanent hold/do-not-merge), enforced in `fetchIssues` — but it can only name what to *avoid*, not demand a label be *present*.
- The only allow-list label config — `hub.contribute_labels_mode: "allow"` + list — gates exclusively the `/contribute` queue handed to external contributors. It has never gated the hive's own scanner, and it is untouched here.
- Nothing was removed or renamed; the gap is that the require polarity simply did not exist. This PR adds it.

## What

**One label-policy story, two polarities, one surface** (Governor Configuration → Labels):

- **Exempt (deny-list)** — unchanged, pre-existing: `governor.labels.exempt` + permanent labels. "Never touch these."
- **Required (allow-list)** — NEW: `project.issue_filter.require_labels`. "Only touch these; empty = everything." This is what "only work approved issues" means. There is deliberately **no** `exclude_labels` field — the exempt list *is* the exclusion mechanism, and it **wins on conflict** by construction (it runs first in `fetchIssues`).

```yaml
project:
  issue_filter:
    require_labels: [approved-for-agents]   # agents may ONLY initiate work on these
```

- Absent/empty = current behavior exactly. No default-on filtering.
- Any-of, case-insensitive, exact match (prefix matching would over-admit through an approval gate).
- PRs and the Hold list are unaffected.

## Enforcement point

`github.Client.fetchIssues` — the choice point where GitHub issues become the actionable set, immediately after the existing hold/exempt checks and upstream of the #3792 claim guard. Governor queue counts, every kick prompt, plan-from-label, and the contribute queue all inherit the filter; an agent re-listing the repo cannot bypass it because refused issues never become candidate work.

Additionally:
- Kick prompts state the active policy (prepended to `${ISSUE_LIST}` and the hardcoded scanner/generic builders), so agents are never told to look for out-of-policy issues — including when the filter leaves the list empty.
- **Labels tab is the editing surface for both polarities**: a clearly separated "Required labels (allow-list)" section rides the tab's existing add/remove plumbing; the `PUT /api/config/governor/labels` body fields are pointer-typed so saving one polarity cannot blank the other.
- The filter rides `HeartbeatProjectConfig` like org/repos; `nil` = "hub not speaking to this field", so the every-beat echo can never blank a locally configured filter (the AIAuthor lesson). A hub-side `SaaSHive.IssueFilter` record is delivered with the claim push.
- Read-only note under **Repositories** + `issue_filter` in `/api/config` (omitted when unconfigured).
- Docs: `agent-configuration.md` gains a "Label policy" section presenting both polarities side by side, and the explicit distinction from the contribute filters.

## Tests

- `pkg/config`: `TestIssueFilterAdmits_AbsentAdmitsAll` (regression pin), `_RequireLabel` (positive control + exact-match), `_RequireAnyOf`, `_ConfigWhitespaceTrimmed`, `TestIssueFilterEqual`.
- `pkg/github` (choice point): `TestEnumerateActionable_IssueFilterRequireLabel` (positive control + count floor), `TestEnumerateActionable_ExemptWinsOverRequire` (exclude-wins conflict rule, delivered by the pre-existing mechanism), `_NoIssueFilterUnchanged` (regression pin), `_IssueFilterDoesNotTouchPRs`, `_IssueFilterKeepsHold`, `TestSetIssueFilter_NilReceiver`.
- `pkg/scheduler`: notice present when configured / byte-identical output when not.

Targeted `go build ./...`, `go vet`, and `go test` on config/github/scheduler/dashboard/hub pass locally (the two pre-existing `gh_app_token_script_test.go` failures reproduce on clean `origin/v4` and are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)