### PR TITLE
🐛 fix(contribute): pin the CLI's working directory — a tmux server with a deleted cwd killed every agy task

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -489,10 +489,36 @@ contribute-hive backend="" mode="docker": check-version
         fi
       fi
 
-      # Create tmux session with the CLI
+      # Create tmux session with the CLI.
+      #
+      # The launch command CDs into the repo first. That is not belt-and-braces:
+      # a long-lived tmux server keeps its own working directory, and when that
+      # directory is deleted (here: a nested clone's v2/pkg/agent, orphaned when
+      # the repo renamed v2/ -> src/) every pane the server forks inherits the
+      # dead cwd. The pane's shell says so — "shell-init: error retrieving
+      # current directory" — and a backend that requires a resolvable cwd then
+      # dies seconds after its first task. agy exits 2 that way; claude, codex
+      # and goose happen to tolerate it, which is why this hid for so long.
+      #
+      # -c is NOT sufficient on its own: on a server whose own cwd is gone,
+      # `tmux new-session -c <valid path>` still forks the pane into the deleted
+      # directory (verified against tmux on Fedora 44). It is passed anyway
+      # because it IS correct on a healthy server; the cd is what carries the
+      # fix.
       tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-      tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50
-      tmux send-keys -t "$TMUX_SESSION" "${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
+      tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50 -c "$PWD"
+      tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$PWD") && ${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
+
+      # Surface a poisoned tmux server rather than letting the backend die a
+      # silent, unexplained death 30 seconds into its first task.
+      PANE_PATH="$(tmux display-message -p -t "$TMUX_SESSION" '#{pane_current_path}' 2>/dev/null || echo '')"
+      case "$PANE_PATH" in
+        *"(deleted)"|"")
+          echo "WARNING: this tmux server's working directory no longer exists (pane reports: ${PANE_PATH:-unknown})." >&2
+          echo "         The cd above works around it, but panes you open by hand will start in a dead directory." >&2
+          echo "         Fix it for good with: tmux kill-server   (ends all tmux sessions, then rerun this recipe)" >&2
+          ;;
+      esac
 
       # Start the relay
       export HIVE_AGENT_SESSION="$TMUX_SESSION"

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -456,6 +456,21 @@ if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
   tmux new-session -d -s "$TMUX_SESSION" -c "$HIVE_WORKSPACE_DIR" -x 200 -y 50
 fi
 
+# kubestellar/hive#4046: a long-lived tmux SERVER (this container can run one
+# for its whole lifetime) keeps its own working directory, and every pane it
+# forks afterward inherits it — even a pane started with an explicit, valid
+# `-c`, if the server's own cwd is already gone. That is exactly the shape of
+# directory HIVE_WORKSPACE_DIR is: agents clone into subdirectories of it
+# (contribute_ws.go's assignment prompt), so pinning the launch's `cd` at
+# HIVE_WORKSPACE_DIR itself would re-create the trap the moment that directory
+# is ever removed and recreated out from under a still-running server. `cd`
+# into $HOME instead — a directory nothing in the task lifecycle deletes or
+# recreates — so the CLI always starts somewhere resolvable regardless of what
+# happens to the workspace subtree underneath it; the CLI's own per-task `cd`
+# into $HIVE_WORKSPACE_DIR/<repo> (per the assignment prompt) is unchanged.
+HIVE_AGENT_CWD="${HOME}"
+mkdir -p "$HIVE_AGENT_CWD"
+
 # Start the relay in the background
 echo "Starting ClankeR relay connection to hub..."
 node "${SCRIPT_DIR}/contributor-relay.sh" &
@@ -528,7 +543,12 @@ fi
 # relay launches a one-shot CLI per task, and one-shot invocations do not draw
 # the trust/theme/onboarding dialogs this loop dismisses.
 if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
-  tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG $REASONING_FLAG" Enter
+  # kubestellar/hive#4046: `-c` on new-session above is NOT sufficient once the
+  # server's own cwd is already gone — verified: new-session with a valid `-c`
+  # still forks the pane into the dead directory. The `cd` in the literal
+  # launch line is what actually carries the fix; -c is defense-in-depth for a
+  # healthy server.
+  tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$HIVE_AGENT_CWD") && $CMD $PERM_FLAG $MODEL_FLAG $REASONING_FLAG" Enter
 
   # Auto-dismiss startup prompts (workspace trust, theme picker, etc.)
   AUTO_DISMISS_ATTEMPTS=10

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1381,12 +1381,28 @@ function checkTmuxPaneState() {
 
 // Relaunch the backend CLI in the tmux session using the flags from
 // backends.conf, the same way contributor-agent.sh first launched it.
+// launchCommandWithCwd prefixes the launch with a cd into the relay's own
+// working directory (the repo root, where `just contribute-hive` starts node).
+//
+// A relaunch lands in whatever directory the pane's shell is sitting in, and a
+// long-lived tmux server can hand out a cwd that no longer exists — every pane
+// it forks inherits the dead directory, the shell prints "shell-init: error
+// retrieving current directory", and a backend that needs a resolvable cwd dies
+// shortly after its first task (agy exits 2; claude/codex/goose tolerate it).
+// The Justfile pins the cwd for the FIRST launch; without this, the first
+// relaunch would silently undo that.
+function launchCommandWithCwd(launchCmd) {
+  const cwd = process.cwd();
+  if (!cwd) return launchCmd;
+  return `cd ${shellQuote(cwd)} && ${launchCmd}`;
+}
+
 function relaunchCLI() {
   const launchCmd = buildLaunchCommand();
   // The pane may be wedged in bash PS2 continuation; clear it or the relaunch
   // command is swallowed as more continuation text and never runs.
   recoverWedgedShell();
-  execSync(`tmux send-keys -t ${TMUX_SESSION} ${shellQuote(launchCmd)} Enter`, { timeout: 15000 });
+  execSync(`tmux send-keys -t ${TMUX_SESSION} ${shellQuote(launchCommandWithCwd(launchCmd))} Enter`, { timeout: 15000 });
   // The CLI is NOT up yet. cliReady must stay false until the readiness
   // classifier positively confirms it, or a task prompt sent in the meantime
   // is typed as literal keystrokes into a bare shell (issue #2203, bug 2).
@@ -2014,6 +2030,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
     paneStalled,
     resetPaneStallClock,
+    launchCommandWithCwd,
     cliProcessLooksGone,
     paneForegroundCommand,
     CLI_GONE_CONFIRMATIONS,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -252,6 +252,36 @@ const AGY_WEDGED_PANE = [
 // 'claude' whatever the backend was — so a dead CLI was never detected, was
 // never relaunched, cliReady stayed latched, and the hub's task prompt was typed
 // into a bare shell.
+// --- Relaunch must pin the working directory --------------------------------
+//
+// A long-lived tmux server can hand every pane it forks a cwd that no longer
+// exists (observed: a nested clone's v2/pkg/agent, orphaned when the repo
+// renamed v2/ -> src/). The shell reports "shell-init: error retrieving current
+// directory" and a backend needing a resolvable cwd dies shortly after its
+// first task — agy exits 2 that way. The Justfile pins the cwd for the first
+// launch; a relaunch that dropped the cd would silently undo it.
+test('a relaunch cds into the relay cwd before starting the CLI', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    const launched = relay.launchCommandWithCwd('agy --dangerously-skip-permissions');
+    assert.match(launched, /^cd .+ && agy --dangerously-skip-permissions$/,
+      `relaunch must pin the cwd, got: ${launched}`);
+    assert.ok(launched.includes(process.cwd()),
+      `the cd target must be the relay's own cwd: ${launched}`);
+  } finally { teardown(relay); }
+});
+
+test('relaunchCLI sends the cd-prefixed command to tmux', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    const before = relay.__tmuxSends().length;
+    relay.relaunchCLI();
+    const sends = relay.__tmuxSends().slice(before);
+    assert.ok(sends.some(c => /cd .+ && /.test(c)),
+      `the relaunch typed into the pane must carry the cd: ${JSON.stringify(sends)}`);
+  } finally { teardown(relay); }
+});
+
 test('a shell in the pane is only a death after consecutive confirmations', () => {
   const relay = loadRelay({ backend: 'agy', procAlive: false });
   try {

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -242,6 +242,28 @@ The shipped relay declares `environment` only where the cause is unambiguous (CL
 
 Whether the hub should ever *act* on client declarations — the ROUTE half of [#2547](https://github.com/kubestellar/hive/issues/2547) — remains an open maintainer decision, and needs task-side requirements metadata that does not exist yet.
 
+## Troubleshooting: the backend dies seconds after every task
+
+Symptom: the CLI starts fine and sits at its prompt, the relay reports `CLI ready` and `Task prompt sent to CLI`, and then the backend exits a few seconds later with a non-zero status — no crash, no log, no message. The pane falls back to a shell, and (on a relay without the liveness fix) subsequent task prompts get typed into that shell.
+
+Check the pane's working directory:
+
+```bash
+tmux display-message -p -t <session> '#{pane_current_path}'
+```
+
+If it ends in `(deleted)` — or the pane's shell printed `shell-init: error retrieving current directory` when it started, or your prompt shows the directory as `.` — the tmux **server** is holding a working directory that no longer exists, and every pane it forks inherits it. This happens when the server was started from a directory that was later removed (for example a nested clone's `v2/pkg/agent`, orphaned when the repo renamed `v2/` to `src/`).
+
+Backends differ here: `agy` refuses to run without a resolvable working directory and exits `2`; `claude`, `codex` and `goose` tolerate it, so the same server looks fine for them.
+
+`just contribute-hive` now `cd`s into the repo as part of the launch command, which works around a poisoned server, and warns when it detects one. To clear it properly:
+
+```bash
+tmux kill-server    # ends ALL tmux sessions, then start the relay again
+```
+
+Note that `tmux new-session -c <path>` does **not** fix this on an already-poisoned server: the pane is still forked into the deleted directory.
+
 ## Protocol compatibility
 
 Both sides state a contributor-protocol version: the hub advertises its own on `auth_ok`, and the relay declares `relay_protocol_version` in `auth_response`. Since [#2547](https://github.com/kubestellar/hive/issues/2547) both sides also **compare** them, so an old relay against a new hub is something you are told about rather than something you infer from misbehaviour:

--- a/src/pkg/dashboard/contribute_pane_cwd_test.go
+++ b/src/pkg/dashboard/contribute_pane_cwd_test.go
@@ -19,16 +19,28 @@ import (
 // `tmux new-session -c <valid path>` does NOT rescue this: on a server whose own
 // cwd is gone, the pane is still forked into the deleted directory. Only a cd in
 // the launch command itself is reliable, so these tests pin the cd — reading the
-// Justfile rather than restating it, so the recipe cannot regress quietly.
+// Justfile (and, for the container entrypoint below, contributor-agent.sh)
+// rather than restating them, so neither spawn site can regress quietly.
+//
+// The Justfile's local-mode recipe and contributor-relay.sh's relaunchCLI() were
+// fixed first; contributor-agent.sh — the DEFAULT docker/container-mode
+// entrypoint (`just contribute-hive` defaults to mode="docker") — launches the
+// CLI the identical way and is just as exposed, so it gets the identical fix and
+// the identical style of regression test.
 
-func justfileSource(t *testing.T) string {
+func fileSource(t *testing.T, relPath string) string {
 	t.Helper()
-	path := filepath.Join("..", "..", "..", "Justfile")
+	path := filepath.Join("..", "..", "..", relPath)
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(raw)
+}
+
+func justfileSource(t *testing.T) string {
+	t.Helper()
+	return fileSource(t, "Justfile")
 }
 
 // contributeHiveLaunchBlock returns the lines of contribute-hive that create the
@@ -47,11 +59,28 @@ func contributeHiveLaunchBlock(t *testing.T) string {
 	return src[start : start+end]
 }
 
-func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
-	block := contributeHiveLaunchBlock(t)
+// contributorAgentLaunchBlock returns the lines of contributor-agent.sh (the
+// container entrypoint) that create the tmux session and type the CLI launch
+// command into it — the container-mode counterpart of contributeHiveLaunchBlock.
+func contributorAgentLaunchBlock(t *testing.T) string {
+	t.Helper()
+	src := fileSource(t, "bin/contributor-agent.sh")
+	start := strings.Index(src, "Create the tmux session for the agent")
+	if start < 0 {
+		t.Fatal("tmux session creation block not found in contributor-agent.sh")
+	}
+	end := strings.Index(src[start:], "Auto-dismiss startup prompts")
+	if end < 0 {
+		t.Fatal("end of the session creation block not found in contributor-agent.sh")
+	}
+	return src[start : start+end]
+}
 
-	// The load-bearing half: the launch command itself must cd first, so the CLI
-	// starts in a real directory whatever cwd the tmux server hands the pane.
+// requireCdBeforeCmd asserts the send-keys line launching $CMD in block cds
+// first, so the CLI starts in a real directory whatever cwd the tmux server
+// forked the pane into.
+func requireCdBeforeCmd(t *testing.T, block, label string) {
+	t.Helper()
 	sendKeys := ""
 	for _, line := range strings.Split(block, "\n") {
 		if strings.Contains(line, "send-keys") && strings.Contains(line, "$CMD") {
@@ -60,13 +89,21 @@ func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
 		}
 	}
 	if sendKeys == "" {
-		t.Fatal("no send-keys line launching $CMD found in the block")
+		t.Fatalf("%s: no send-keys line launching $CMD found in the block", label)
 	}
 	if !strings.Contains(sendKeys, "cd ") {
-		t.Errorf("the CLI launch must cd into the repo first — a tmux server can hand the pane a DELETED cwd, "+
-			"and a backend that needs a resolvable one then dies seconds into its first task: %s",
-			strings.TrimSpace(sendKeys))
+		t.Errorf("%s: the CLI launch must cd into a durable directory first — a tmux server can hand the pane a "+
+			"DELETED cwd, and a backend that needs a resolvable one then dies seconds into its first task: %s",
+			label, strings.TrimSpace(sendKeys))
 	}
+}
+
+func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
+	block := contributeHiveLaunchBlock(t)
+
+	// The load-bearing half: the launch command itself must cd first, so the CLI
+	// starts in a real directory whatever cwd the tmux server hands the pane.
+	requireCdBeforeCmd(t, block, "Justfile contribute-hive")
 
 	// Defense in depth, correct on a healthy server (but not sufficient alone).
 	if !strings.Contains(block, "new-session") || !strings.Contains(block, "-c ") {
@@ -80,5 +117,34 @@ func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
 	}
 	if !strings.Contains(block, "tmux kill-server") {
 		t.Error("the warning must tell the contributor how to fix a poisoned tmux server")
+	}
+}
+
+// TestContributorAgentPinsPaneWorkingDirectory covers the DEFAULT docker/
+// container-mode spawn site (bin/contributor-agent.sh), which launches the CLI
+// into the exact same kind of tmux pane as the Justfile's local-mode recipe but
+// was originally missed by the #4046 fix: it relied on `-c "$HIVE_WORKSPACE_DIR"`
+// alone, which this suite's sibling test already demonstrates is not sufficient
+// once the tmux server's own cwd is gone.
+//
+// It must also NOT cd into $HIVE_WORKSPACE_DIR itself: that is the very
+// directory agents clone per-task repos into (contribute_ws.go's assignment
+// prompt), so pinning the launch there would recreate the trap the first time
+// that directory is removed and recreated under a still-running server. The cd
+// target must be a directory the task lifecycle never deletes or recreates —
+// $HOME, the container's own home directory.
+func TestContributorAgentPinsPaneWorkingDirectory(t *testing.T) {
+	block := contributorAgentLaunchBlock(t)
+
+	requireCdBeforeCmd(t, block, "contributor-agent.sh")
+
+	if strings.Contains(block, `cd $(printf %q "$HIVE_WORKSPACE_DIR")`) {
+		t.Error("the launch must not cd into $HIVE_WORKSPACE_DIR itself — that is the per-task clone directory " +
+			"the task lifecycle can delete and recreate, which would reintroduce the #4046 trap")
+	}
+
+	// Defense in depth, correct on a healthy server (but not sufficient alone).
+	if !strings.Contains(block, "new-session") || !strings.Contains(block, "-c ") {
+		t.Error("new-session should also pass -c so a healthy server starts the pane in the right directory")
 	}
 }

--- a/src/pkg/dashboard/contribute_pane_cwd_test.go
+++ b/src/pkg/dashboard/contribute_pane_cwd_test.go
@@ -1,0 +1,84 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A contributor's agy backend died ~30s after every task delivery, exiting 2,
+// with no crash, no log and no signal. The cause was not agy, the relay or the
+// prompt: the tmux SERVER had been running since a Go test created it hours
+// earlier, holding a working directory inside a nested clone — v2/pkg/agent,
+// orphaned when the repo renamed v2/ -> src/. Every pane that server forked
+// inherited the deleted cwd ("shell-init: error retrieving current directory"),
+// and agy refuses to run without a resolvable one. claude/codex/goose tolerate
+// it, which is why it looked backend-specific.
+//
+// `tmux new-session -c <valid path>` does NOT rescue this: on a server whose own
+// cwd is gone, the pane is still forked into the deleted directory. Only a cd in
+// the launch command itself is reliable, so these tests pin the cd — reading the
+// Justfile rather than restating it, so the recipe cannot regress quietly.
+
+func justfileSource(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "Justfile")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+// contributeHiveLaunchBlock returns the lines of contribute-hive that create the
+// tmux session and type the CLI launch command into it.
+func contributeHiveLaunchBlock(t *testing.T) string {
+	t.Helper()
+	src := justfileSource(t)
+	start := strings.Index(src, "Create tmux session with the CLI")
+	if start < 0 {
+		t.Fatal("tmux session creation block not found in the Justfile")
+	}
+	end := strings.Index(src[start:], "# Start the relay")
+	if end < 0 {
+		t.Fatal("end of the session creation block not found in the Justfile")
+	}
+	return src[start : start+end]
+}
+
+func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
+	block := contributeHiveLaunchBlock(t)
+
+	// The load-bearing half: the launch command itself must cd first, so the CLI
+	// starts in a real directory whatever cwd the tmux server hands the pane.
+	sendKeys := ""
+	for _, line := range strings.Split(block, "\n") {
+		if strings.Contains(line, "send-keys") && strings.Contains(line, "$CMD") {
+			sendKeys = line
+			break
+		}
+	}
+	if sendKeys == "" {
+		t.Fatal("no send-keys line launching $CMD found in the block")
+	}
+	if !strings.Contains(sendKeys, "cd ") {
+		t.Errorf("the CLI launch must cd into the repo first — a tmux server can hand the pane a DELETED cwd, "+
+			"and a backend that needs a resolvable one then dies seconds into its first task: %s",
+			strings.TrimSpace(sendKeys))
+	}
+
+	// Defense in depth, correct on a healthy server (but not sufficient alone).
+	if !strings.Contains(block, "new-session") || !strings.Contains(block, "-c ") {
+		t.Error("new-session should also pass -c so a healthy server starts the pane in the right directory")
+	}
+
+	// A poisoned server must be reported, not silently worked around: without a
+	// message, the next person debugs an unexplained backend exit for hours.
+	if !strings.Contains(block, "pane_current_path") {
+		t.Error("the recipe must check the pane's working directory and warn when it is gone")
+	}
+	if !strings.Contains(block, "tmux kill-server") {
+		t.Error("the warning must tell the contributor how to fix a poisoned tmux server")
+	}
+}


### PR DESCRIPTION
## Symptom

An agy contributor's CLI died a few seconds after **every** task delivery. It started fine, sat at its prompt, the relay logged `CLI ready` then `Task prompt sent to CLI` — and then it was gone. No crash, no log, no message. The pane fell back to a shell, and the next task prompt got typed into that shell.

## What it wasn't

Each ruled out by direct test on the affected machine:

| suspect | result |
|---|---|
| the relay's `Escape` / `C-a` / `C-k` before each prompt | agy survives |
| the literal 1100-char prompt + `ENTER_COUNT=3` | agy survives |
| the repo as cwd | agy survives |
| task content (#3848 / #4037 / #4041) | dies on all |
| pane environment | 109 vars, identical to a working hand-run |
| recent relay changes (#4026, #4039) | dies with the pre-#4026 relay too |
| account / quota | `agy -p` returns `ok`, exit 0 |
| coredump / OOM / signal | none — a wrapper captured `AGY_EXIT=2` |

Driving agy by hand through the relay's exact key sequence, with the real prompt, in the same directory, it completed an entire hive task and stayed up.

## What it was

```
pane_current_path = '.../hive/kubestellar/hive/v2/pkg/agent (deleted)'
```

The pane's working directory did not exist. That path belonged to a nested clone and was orphaned when the repo renamed `v2/` → `src/`. The tmux **server** had been holding it since a Go test created the server hours earlier, so every pane it forked started there. The shell announced it each time —

```
shell-init: error retrieving current directory: getcwd: cannot access parent directories
```

— and `agy`, which needs a resolvable cwd, exits `2` about thirty seconds in. `claude`, `codex` and `goose` tolerate a dead cwd, so the same server looked perfectly healthy for them, which is why this read as agy-specific.

The reason my hand-runs always worked: I typed `cd <repo> && agy …`. The Justfile sends only `$CMD $PERM_FLAG`.

## Fix

- **The launch command cds into the repo first.** This is the load-bearing change.
- **`-c "$PWD"` on `new-session` as well** — correct on a healthy server, but *not* sufficient alone. Verified: on a server whose own cwd is gone, `tmux new-session -c <valid path>` **still** forks the pane into the deleted directory.
- **`relaunchCLI()` gets the same prefix.** It rebuilds the launch line on every restart (memory-cleanup restarts, crash recovery, a stale readiness latch), so without it the first relaunch silently undoes what the Justfile pinned.
- **The recipe now warns on a poisoned server** instead of letting a backend die unexplained: it checks `pane_current_path` after creating the session and points at `tmux kill-server`, which is the only thing that really clears it.

## Tests

- the relaunch command carries the `cd`, and reaches tmux that way;
- a Go test reads the **Justfile itself** (not a restatement) and pins the `cd`, the `-c`, and the warning, so none of them can regress quietly.

89/89 relay tests, full `pkg/dashboard` package green.

## Docs

A troubleshooting entry keyed on the symptom — "backend dies seconds after every task" — because the failure gives you nothing to search for: no log line, no exit message, just a prompt that quietly shows `.` as your directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)