### PR TITLE
🐛 fix(gh-wrapper): label injection must never fail the operation (fleet-owner outage)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -67,17 +67,28 @@ if ! _contributor_mode; then
   # back to either would silently escalate every agent to full privilege and
   # defeat per-agent tier scoping. A missing scoped token must FAIL LOUD so the
   # operator fixes token delivery — it must never quietly escalate.
-  if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
+  # -r and -s as well as -f (#4043): an unreadable cache made the `cat` inside
+  # the `export` assignment fail with its status MASKED by export's own exit 0
+  # (so even `set -e` never saw it), and an empty pre-created cache (pod rolled,
+  # token not yet re-minted) passed -f outright — both exported an EMPTY
+  # GH_TOKEN and sent every gh call out UNAUTHENTICATED ("please run gh auth
+  # login"), instead of the fail-loud this gate promises.
+  if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" && -r "${HIVE_AGENT_TOKEN_CACHE}" && -s "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
     export GH_TOKEN="$(cat "$HIVE_AGENT_TOKEN_CACHE")"
   else
-    echo "⛔ BLOCKED: per-agent scoped GitHub token not available (${HIVE_AGENT_TOKEN_CACHE:-HIVE_AGENT_TOKEN_CACHE unset})." >&2
+    echo "⛔ BLOCKED: per-agent scoped GitHub token not available, unreadable, or empty (${HIVE_AGENT_TOKEN_CACHE:-HIVE_AGENT_TOKEN_CACHE unset})." >&2
     echo "   Refusing to fall back to the shared full-privilege App token — that would defeat per-agent tier scoping (audit H3)." >&2
     echo "   The hive delivers a scoped token per agent; report this to the operator so token delivery is repaired." >&2
     exit 1
   fi
-  printf '{"ts":"%s","agent":"%s","uid":%d,"op":"gh","cmd":"gh %s"}\n' \
+  # The group wraps the append so a failed REDIRECTION is silenced too: `>> f
+  # 2>/dev/null` only mutes the printf, and when the log's directory is not
+  # writable by the agent UID the shell's own "Permission denied" line leaked
+  # into stderr on EVERY gh call, priming agents to read later denials as
+  # permission errors (#4043).
+  { printf '{"ts":"%s","agent":"%s","uid":%d,"op":"gh","cmd":"gh %s"}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${HIVE_AGENT:-unknown}" "$(id -u)" "$*" \
-    >> "$TOKEN_ACCESS_LOG" 2>/dev/null || true
+    >> "$TOKEN_ACCESS_LOG"; } 2>/dev/null || true
 fi
 
 # Contributor mode — extra restrictions for remote contributor agents
@@ -784,9 +795,15 @@ if [[ -n "$AGENT_NAME" ]]; then
   fi
 
   # Ensure labels exist on the repo (cached per-session to avoid repeated API calls).
-  LABEL_CACHE="/tmp/.hive-labels-ensured"
+  #
+  # The cache MUST be keyed per target repo (#4043): a single global flag meant
+  # whichever repo an agent touched first got the labels created, and every
+  # other repo was skipped for the life of the pod — leaving the injected
+  # hive/<id> label missing there, which made every `gh pr edit`/`gh issue edit`
+  # on those repos fail with "'hive/<id>' not found". Verified live on a fleet
+  # owner's hive: only the first-touched repos carried the current label.
+  LABEL_CACHE_BASE="/tmp/.hive-labels-ensured"
   _ensure_labels() {
-    [[ -f "$LABEL_CACHE" ]] && return 0
     local repo_flag=""
     for arg in "${args[@]}"; do
       case "$arg" in
@@ -796,13 +813,18 @@ if [[ -n "$AGENT_NAME" ]]; then
       esac
     done
     [[ "$repo_flag" = "next" ]] && repo_flag=""
+    # owner/repo → owner_repo; repo names are [A-Za-z0-9_.-] so '/' is the only
+    # separator to neutralize. No --repo means "current directory's repo" —
+    # cache that under its own key rather than sharing one with named repos.
+    local cache="${LABEL_CACHE_BASE}-${repo_flag//\//_}"
+    [[ -f "$cache" ]] && return 0
     local rf=""
     [[ -n "$repo_flag" ]] && rf="--repo $repo_flag"
     "$REAL_GH" label create "agent/${AGENT_DISPLAY_NAME}" --description "Work by the ${AGENT_DISPLAY_NAME} agent" --color 6f42c1 $rf 2>/dev/null || true
     if [[ -n "$HIVE_INSTANCE_ID" ]]; then
       "$REAL_GH" label create "hive/${HIVE_INSTANCE_ID}" --description "Hive instance ${HIVE_INSTANCE_ID}" --color 1d76db $rf 2>/dev/null || true
     fi
-    touch "$LABEL_CACHE"
+    touch "$cache"
   }
 
   # Extract issue/PR number and repo from args (for post-action labeling).
@@ -826,8 +848,13 @@ if [[ -n "$AGENT_NAME" ]]; then
     issue/create|pr/create)
       _ensure_labels
       _inject_identity
-      "$REAL_GH" "${args[@]}" --label "$LABELS_CSV"
-      rc=$?
+      # `|| rc=$?` (not `cmd; rc=$?`): this script runs under `set -e`, so a
+      # bare failing gh exited the wrapper BEFORE rc was ever read — the
+      # unlabeled retry below was dead code, and a missing injected label
+      # failed the whole create (#4043). gh resolves label names before
+      # mutating, so the retry cannot double-create.
+      rc=0
+      "$REAL_GH" "${args[@]}" --label "$LABELS_CSV" || rc=$?
       if [ $rc -ne 0 ]; then
         exec "$REAL_GH" "${args[@]}"
       fi
@@ -835,7 +862,18 @@ if [[ -n "$AGENT_NAME" ]]; then
       ;;
     issue/edit|pr/edit)
       _ensure_labels
-      exec "$REAL_GH" "$@" --add-label "$LABELS_CSV"
+      # Label injection is provenance metadata, not a security gate. gh applies
+      # an edit atomically, so a missing label (repo not yet ensured, create
+      # denied, label deleted) failed the ENTIRE edit with "'<label>' not found"
+      # — agents read that as a permissions failure and route around the wrapper
+      # (#4043). Mirror the create arm: try labeled, retry unlabeled on failure.
+      # `|| rc=$?` keeps the retry alive under `set -e` (see create arm above).
+      rc=0
+      "$REAL_GH" "$@" --add-label "$LABELS_CSV" || rc=$?
+      if [ $rc -ne 0 ]; then
+        exec "$REAL_GH" "$@"
+      fi
+      exit $rc
       ;;
     pr/merge)
       _ensure_labels

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -275,6 +275,108 @@ assert_reached "read-only gh api reaches gh" \
 assert_blocked "pr merge passes the surface gate and is held by eligibility" \
   "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123)" eligibility
 
+# ── #4043: label injection is best-effort, never a wall ──────────────────────
+# The edit/create arms append the agent/hive provenance labels. When the label
+# does not exist on the target repo, gh fails the WHOLE operation with
+# "'<label>' not found" — which took down a fleet owner's edit lane. The
+# wrapper must retry without labels. This stub simulates gh's behavior by
+# failing any invocation that carries a label-injection flag; the wrapper runs
+# under `set -e`, so these tests also pin that the retry is not dead code.
+echo "-- label injection falls back instead of failing the operation (#4043) --"
+LABEL_STUB="${WORK}/gh-stub-labelfail"
+cat >"$LABEL_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${STUB_LOG}"
+case " $* " in
+  *" --add-label "*|*" --label "*) exit 1 ;;
+esac
+exit 0
+STUBEOF
+chmod +x "$LABEL_STUB"
+
+# run_label_wrapper <args...> — like run_wrapper but with the label-failing
+# stub, and it reports the LAST stub invocation so the assertions can prove the
+# retry dropped the injected labels. Per-repo ensure caches live in /tmp; clear
+# ours so the label-create calls are deterministic.
+run_label_wrapper() {
+  : >"$STUB_LOG"
+  rm -f /tmp/.hive-labels-ensured-owner_repo
+  local out rc last
+  out="$(
+    HIVE_GH_WRAPPER_REAL_GH="$LABEL_STUB" \
+    STUB_LOG="$STUB_LOG" \
+    HIVE_AGENT="testagent" \
+    HIVE_AGENT_ID="testagent" \
+    HIVE_AGENT_MODE="ISSUES_PRS_MERGE" \
+    HIVE_ACMM_LEVEL=5 \
+    HIVE_AGENT_TOKEN_CACHE="$TOKEN_CACHE" \
+    HIVE_CONTRIBUTOR_MODE="false" \
+    bash "$WRAPPER" "$@" 2>&1
+  )"
+  rc=$?
+  rm -f /tmp/.hive-labels-ensured-owner_repo
+  last="$(tail -n 1 "$STUB_LOG" 2>/dev/null)"
+  echo "exit=${rc} last=${last}"
+}
+
+result="$(run_label_wrapper pr edit 5 --repo owner/repo --title x)"
+if [[ "$result" == "exit=0 last=pr edit 5 --repo owner/repo --title x" ]]; then
+  echo "  PASS: pr edit retries without injected labels and succeeds"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: pr edit retries without injected labels and succeeds"
+  echo "        got '$result', want exit=0 with an unlabeled final retry"
+  FAIL=$((FAIL + 1))
+fi
+
+result="$(run_label_wrapper issue edit 7 --repo owner/repo --add-assignee z)"
+if [[ "$result" == "exit=0 last=issue edit 7 --repo owner/repo --add-assignee z" ]]; then
+  echo "  PASS: issue edit retries without injected labels and succeeds"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: issue edit retries without injected labels and succeeds"
+  echo "        got '$result', want exit=0 with an unlabeled final retry"
+  FAIL=$((FAIL + 1))
+fi
+
+result="$(run_label_wrapper issue create --repo owner/repo --title t --body b)"
+if [[ "$result" == exit=0* && "$result" != *"--label"* ]]; then
+  echo "  PASS: issue create retries without injected labels and succeeds"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: issue create retries without injected labels and succeeds"
+  echo "        got '$result', want exit=0 with an unlabeled final retry"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── #4043: empty per-agent token cache must fail LOUD, not go unauthenticated ─
+# A pre-created-but-not-yet-minted (0-byte) cache passed the old -f check and
+# exported an EMPTY GH_TOKEN, sending every call out unauthenticated. Direct
+# invocation (not run_wrapper) because the harness treats this gate's message
+# as a harness error elsewhere.
+echo "-- empty token cache fails loud (#4043) --"
+EMPTY_CACHE="${WORK}/empty-token"
+: >"$EMPTY_CACHE"
+out="$(
+  HIVE_GH_WRAPPER_REAL_GH="$STUB" \
+  STUB_LOG="$STUB_LOG" \
+  HIVE_AGENT="testagent" \
+  HIVE_AGENT_ID="testagent" \
+  HIVE_AGENT_MODE="ISSUES_PRS_MERGE" \
+  HIVE_AGENT_TOKEN_CACHE="$EMPTY_CACHE" \
+  HIVE_CONTRIBUTOR_MODE="false" \
+  bash "$WRAPPER" issue view 1 --repo owner/repo 2>&1
+)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"per-agent scoped GitHub token not available"* ]]; then
+  echo "  PASS: empty token cache blocks with the fail-loud message"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: empty token cache blocks with the fail-loud message"
+  echo "        got rc=$rc out='$out'"
+  FAIL=$((FAIL + 1))
+fi
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Fixes #4043

## What broke (live fleet-owner report: agents "dead in the water — permissions issues")

Reproduced live on the affected spoke, as an agent UID through the installed wrapper:

```
$ gh pr edit 315 --repo <owner>/<repo> --title "docs: repair design plan template link"
'hive/<id>' not found
exit code 1
```

## The five defects fixed (all bin/gh-wrapper.sh)

1. **Edit lane fail-closed on provenance labels**: `issue/edit|pr/edit` did `exec gh "$@" --add-label <agent+hive labels>` — one shot. A label missing on the target repo failed the whole edit. Now: try labeled, retry unlabeled on failure (label injection is provenance metadata, not a security gate).
2. **Create arm's retry was dead code**: the wrapper runs under `set -e`, so the bare failing `gh` exited before `rc=$?` was ever read. Both arms now use `|| rc=$?`.
3. **`_ensure_labels` session cache was repo-blind**: one global `/tmp/.hive-labels-ensured` flag meant only the first-touched repo per pod session ever got the labels created — verified live: exactly the un-ensured repos were the broken ones. Cache is now keyed per target repo.
4. **Empty/unreadable token cache went out unauthenticated**: a pre-created 0-byte cache (pod rolled, token not yet re-minted) passed `-f`, and `export GH_TOKEN=$(cat ...)` masks a failed cat — every call ran unauthenticated instead of the H3 gate's promised fail-loud. Now also checks `-r` and `-s`.
5. **Audit-append stderr noise**: when the token-access log dir is unwritable by the agent UID, the shell's redirection failure printed `Permission denied` on EVERY gh call (the `2>/dev/null` covered only the printf). The redirect is now inside a silenced group.

## Tests

New behavioural section in `bin/test_gh_wrapper_gates.sh`: a stub gh that rejects label-injection flags pins that pr/issue edit and issue create retry unlabeled and succeed (also pinning that the retry is alive under `set -e`), and that an empty token cache blocks with the fail-loud message.

Companion issues from the same investigation (not fixed here): #4044 (author-gate identity oracle can never work for App installation tokens), #4045 (security: agent CLI backend re-exports a live GITHUB_TOKEN into agent shells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)