### PR TITLE
🐛 fix(gh-wrapper): author-gated listing works again for staff agents — trusted bot-identity file for App installation tokens

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -31,6 +31,26 @@ REAL_GH="${HIVE_GH_WRAPPER_REAL_GH:-/opt/hive/bin/gh-real}"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
 CONTRIBUTOR_MODE_MARKER="/etc/hive/contributor-mode"
 
+# Trusted bot-identity file (#4044). Staff agents authenticate with GitHub App
+# INSTALLATION tokens (ghs_…), for which `gh api user` structurally 403s —
+# there is no user identity behind a server-to-server token — so the #3982
+# oracle can never resolve for them. The hive process, which MINTS every tier
+# token and therefore knows the App bot login ("<app-slug>[bot]"), writes that
+# login here alongside the per-agent token caches. The directory is owned by
+# dev and not writable by any agent UID, so — like CONTRIBUTOR_MODE_MARKER —
+# this is an image/runtime property the caller cannot forge. The path is a
+# CONSTANT for the same reason as #3249: an env-selected path would let an
+# agent point the identity check at a file it controls.
+#
+# HIVE_GH_WRAPPER_BOT_LOGIN_FILE is honored ONLY while the test harness's
+# HIVE_GH_WRAPPER_REAL_GH override is active, where it grants nothing: a caller
+# who can substitute the gh binary itself has already bypassed every gate this
+# identity feeds (see the REAL_GH comment above). Unset in production.
+BOT_LOGIN_FILE="/var/run/hive-metrics/agent-tokens/gh-bot-login"
+if [[ -n "${HIVE_GH_WRAPPER_REAL_GH:-}" && -n "${HIVE_GH_WRAPPER_BOT_LOGIN_FILE:-}" ]]; then
+  BOT_LOGIN_FILE="$HIVE_GH_WRAPPER_BOT_LOGIN_FILE"
+fi
+
 # Contributor mode is an image property, not a caller-controlled environment
 # toggle. Keep this path constant: an agent can set its own environment and must
 # not be able to redirect the trust check to an agent-writable marker (#3249).
@@ -322,7 +342,18 @@ _extract_author() {
 }
 
 # Resolve the authenticated GitHub login. Initialize the cache internally so a
-# caller-controlled environment cannot seed a trusted identity.
+# caller-controlled environment cannot seed a trusted identity (#3982).
+#
+# Two oracles, both unspoofable by the agent (#4044):
+#   1. The trusted bot-identity file — written by the hive process (which mints
+#      the tier tokens) into a directory no agent UID can write. This is the
+#      ONLY oracle that can work for staff agents: their App installation
+#      tokens have no /user identity, so `gh api user` 403s unconditionally.
+#   2. `gh api user` — the server-side identity of the token itself. Works for
+#      user tokens (contributor mode) and remains the fallback whenever the
+#      file is absent, so the contributor path is unchanged.
+# A caller-writable path or environment variable must never be consulted:
+# fail-closed is preserved when NEITHER oracle resolves.
 HIVE_AUTH_LOGIN_CACHED=""
 _resolve_self_login() {
   if [[ -n "$HIVE_AUTH_LOGIN_CACHED" ]]; then
@@ -330,9 +361,16 @@ _resolve_self_login() {
     return 0
   fi
 
-  local login
-  if ! login="$("$REAL_GH" api user --jq '.login' 2>/dev/null)"; then
-    return 1
+  local login=""
+  if ! _contributor_mode && [[ -f "$BOT_LOGIN_FILE" && -r "$BOT_LOGIN_FILE" ]]; then
+    # Single-line file; strip whitespace/newline. An empty or unreadable file
+    # falls through to the API oracle (and from there to fail-closed).
+    login="$(tr -d '[:space:]' < "$BOT_LOGIN_FILE" 2>/dev/null || true)"
+  fi
+  if [[ -z "$login" ]]; then
+    if ! login="$("$REAL_GH" api user --jq '.login' 2>/dev/null)"; then
+      return 1
+    fi
   fi
   if [[ -z "$login" ]]; then
     return 1
@@ -372,10 +410,43 @@ _author_matches_login() {
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
   if author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
     if [[ "$author_value" = "@me" ]]; then
-      : # GitHub resolves @me server-side to the authenticated token identity.
+      # GitHub resolves @me server-side ONLY for user tokens. An App
+      # installation token has no user identity, so for staff agents @me is
+      # rejected by the API itself and there would be NO working self-listing
+      # form at all (#4044). Map @me to the trusted resolved identity for
+      # staff agents; contributor mode keeps the server-side resolution.
+      if ! _contributor_mode; then
+        if ! _resolve_self_login >/dev/null; then
+          echo "⛔ BLOCKED: gh $subcmd list --author @me cannot work with an App installation token (it has no /user identity, #4044)," >&2
+          echo "and no trusted identity is available to substitute: ${BOT_LOGIN_FILE} is missing/empty and 'gh api user' did not resolve." >&2
+          echo "The hive writes that file when it mints agent tokens — report this to the operator so identity delivery is repaired." >&2
+          exit 1
+        fi
+        _atme_rewritten=()
+        _atme_expect=false
+        for _atme_arg in "${args[@]}"; do
+          if [[ "$_atme_expect" = true ]]; then
+            _atme_expect=false
+            [[ "$_atme_arg" = "@me" ]] && _atme_arg="$HIVE_AUTH_LOGIN_CACHED"
+          else
+            case "$_atme_arg" in
+              --author|-A) _atme_expect=true ;;
+              --author=@me) _atme_arg="--author=${HIVE_AUTH_LOGIN_CACHED}" ;;
+              -A=@me) _atme_arg="-A=${HIVE_AUTH_LOGIN_CACHED}" ;;
+              -A@me) _atme_arg="-A${HIVE_AUTH_LOGIN_CACHED}" ;;
+            esac
+          fi
+          _atme_rewritten+=("$_atme_arg")
+        done
+        args=("${_atme_rewritten[@]}")
+        # The wrapper's tail executes `exec "$REAL_GH" "$@"` — rewrite the
+        # positional parameters too, or the substitution would never ship.
+        set -- "${args[@]}"
+      fi
     elif ! _resolve_self_login >/dev/null; then
       echo "⛔ BLOCKED: gh $subcmd list --author requires authenticated GitHub identity." >&2
-      echo "Could not resolve the current token identity with 'gh api user --jq .login'." >&2
+      echo "Could not resolve the current token identity: no trusted identity file at ${BOT_LOGIN_FILE} (written by the hive when it mints agent tokens)" >&2
+      echo "and 'gh api user --jq .login' did not resolve (expected for App installation tokens, which have no /user identity)." >&2
       exit 1
     elif _author_matches_login "$author_value" "$HIVE_AUTH_LOGIN_CACHED"; then
       : # Match: authenticated login, case-insensitive, with optional [bot] suffix.

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -377,6 +377,147 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── #4044: author gate must work for App INSTALLATION tokens ─────────────────
+# Staff agents hold ghs_ installation tokens, for which `gh api user` 403s
+# unconditionally — the #3982 oracle could NEVER resolve for them, so every
+# author-gated list failed closed fleet-wide. The fix: the hive (which mints
+# the tokens) publishes the bot login to a trusted file in the agent-token dir
+# (dev-owned; no agent UID can write it). These tests drive the wrapper with a
+# stub that reproduces the 403, exactly like production installation tokens.
+#
+# HIVE_GH_WRAPPER_BOT_LOGIN_FILE relocates the trusted file for the harness
+# only — the wrapper honors it solely under HIVE_GH_WRAPPER_REAL_GH, where the
+# caller already substitutes the gh binary itself and the override grants
+# nothing new.
+echo "-- author gate resolves staff identity from the trusted file (#4044) --"
+
+# Stub reproducing an App installation token: /user is structurally
+# unavailable (HTTP 403 "Resource not accessible by integration").
+INSTALL_STUB="${WORK}/gh-stub-installation"
+cat >"$INSTALL_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${STUB_LOG}"
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "user" ]; then
+  echo "gh: Resource not accessible by integration (HTTP 403)" >&2
+  exit 1
+fi
+exit 0
+STUBEOF
+chmod +x "$INSTALL_STUB"
+
+# Stub reproducing a USER token (contributor path): /user resolves normally.
+USER_STUB="${WORK}/gh-stub-usertoken"
+cat >"$USER_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${STUB_LOG}"
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "user" ]; then
+  echo "someuser"
+fi
+exit 0
+STUBEOF
+chmod +x "$USER_STUB"
+
+TRUSTED_LOGIN_FILE="${WORK}/gh-bot-login"
+printf 'test-app[bot]\n' >"$TRUSTED_LOGIN_FILE"
+
+# run_author_wrapper <stub> <login-file> [extra VAR=val...] -- <args...>
+# Reports "exit=<rc> last=<final stub argv> ::: <wrapper output>" so assertions
+# can pin both the decision and WHAT was forwarded to gh.
+run_author_wrapper() {
+  local stub="$1" login_file="$2"; shift 2
+  local extra_env=()
+  while [ $# -gt 0 ] && [ "$1" != "--" ]; do extra_env+=("$1"); shift; done
+  [ "${1:-}" = "--" ] && shift
+  : >"$STUB_LOG"
+  local out rc
+  # ${arr[@]+...} keeps the empty-array case safe under `set -u` on bash 3.x.
+  out="$(
+    env ${extra_env[@]+"${extra_env[@]}"} \
+    HIVE_GH_WRAPPER_REAL_GH="$stub" \
+    HIVE_GH_WRAPPER_BOT_LOGIN_FILE="$login_file" \
+    STUB_LOG="$STUB_LOG" \
+    HIVE_AGENT="testagent" \
+    HIVE_AGENT_ID="testagent" \
+    HIVE_AGENT_MODE="ISSUES_PRS_MERGE" \
+    HIVE_ACMM_LEVEL=5 \
+    HIVE_AGENT_TOKEN_CACHE="$TOKEN_CACHE" \
+    HIVE_CONTRIBUTOR_MODE="false" \
+    bash "$WRAPPER" "$@" 2>&1
+  )"
+  rc=$?
+  local last
+  last="$(tail -n 1 "$STUB_LOG" 2>/dev/null)"
+  echo "exit=${rc} last=${last} ::: ${out}"
+}
+
+assert_author() {
+  local label="$1" result="$2" want="$3"
+  if [[ "$result" == $want ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        got '$result'"
+    echo "        want glob '$want'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# THE regression: an installation-token agent with the trusted file present
+# must be able to list its own items — and only its own.
+assert_author "installation token + trusted file: self-listing by bot login works" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=0 last=issue list --repo owner/repo --author test-app\[bot\] ::: *"
+assert_author "matching is [bot]-suffix-insensitive (bare slug allowed)" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- pr list --repo owner/repo --author test-app)" \
+  "exit=0 last=pr list --repo owner/repo --author test-app ::: *"
+# @me has no server-side meaning for an installation token — the wrapper must
+# substitute the trusted identity, or there is no working self-listing form.
+assert_author "--author @me is rewritten to the trusted bot identity" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- pr list --repo owner/repo --author @me)" \
+  "exit=0 last=pr list --repo owner/repo --author test-app\[bot\] ::: *"
+assert_author "--author=@me equals-form is rewritten too" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- pr list --repo owner/repo --author=@me)" \
+  "exit=0 last=pr list --repo owner/repo --author=test-app\[bot\] ::: *"
+
+# The gate itself must keep gating: a foreign author is still refused.
+assert_author "trusted file does not open listing OTHER authors" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- issue list --repo owner/repo --author someone-else)" \
+  "exit=1 last= ::: *must match the authenticated GitHub identity*"
+
+# Fail-closed is preserved when no trusted identity exists: the installation
+# token cannot resolve /user, so with the file missing there is NO oracle.
+assert_author "missing trusted file + installation token: explicit author fails closed" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/no-such-login-file" -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=1 last=api user --jq .login ::: *requires authenticated GitHub identity*"
+: >"${WORK}/empty-login-file"
+assert_author "EMPTY trusted file + installation token: fails closed (no empty identity)" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/empty-login-file" -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=1 last=api user --jq .login ::: *requires authenticated GitHub identity*"
+assert_author "missing trusted file + installation token: @me fails closed with the #4044 diagnosis" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/no-such-login-file" -- pr list --repo owner/repo --author @me)" \
+  "exit=1 last=api user --jq .login ::: *cannot work with an App installation token*"
+
+# POSITIVE CONTROL (the #3982 invariant): agent-controlled environment must
+# never seed the trusted identity. With no trusted file and a 403ing /user,
+# these env vars are the ONLY place the claimed identity appears — if any of
+# them were consulted, this listing would succeed.
+assert_author "env vars cannot seed the identity (#3982 invariant holds)" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/no-such-login-file" \
+      HIVE_AUTH_LOGIN_CACHED="test-app[bot]" HIVE_BOT_LOGIN="test-app[bot]" GITHUB_USER="test-app[bot]" \
+      -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=1 last=api user --jq .login ::: *requires authenticated GitHub identity*"
+
+# USER-token path unchanged: with no trusted file, `gh api user` remains the
+# oracle — resolves, matches, mismatches refuse. (Contributor mode itself is an
+# image marker the harness cannot plant; the oracle chain is what's under test.)
+assert_author "user token without trusted file still resolves via gh api user" \
+  "$(run_author_wrapper "$USER_STUB" "${WORK}/no-such-login-file" -- issue list --repo owner/repo --author someuser)" \
+  "exit=0 last=issue list --repo owner/repo --author someuser ::: *"
+assert_author "user token without trusted file still refuses a foreign author" \
+  "$(run_author_wrapper "$USER_STUB" "${WORK}/no-such-login-file" -- issue list --repo owner/repo --author someone-else)" \
+  "exit=1 last=api user --jq .login ::: *must match the authenticated GitHub identity*"
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -360,6 +360,12 @@ if [ "$(id -u)" = "0" ]; then
 
   mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
   mkdir -p /var/run/hive-metrics/agent-tokens && chown dev:node /var/run/hive-metrics/agent-tokens 2>/dev/null || true
+  # 0755 explicitly, not umask-dependent: gh-wrapper.sh's author gate trusts
+  # the bot-identity file in this directory BECAUSE no agent UID can write here
+  # (#4044). Group is "node" — which every agent is a member of — so a
+  # group-writable mode would let any agent swap that file and spoof the
+  # identity the gate validates against. Re-asserted on every boot.
+  chmod 755 /var/run/hive-metrics/agent-tokens 2>/dev/null || true
 
   # Fix permissions on bind-mounted secret files (host may own them as
   # a different UID with mode 600, making them unreadable by dev/UID 1001)

--- a/src/pkg/github/agent_token_delivery_test.go
+++ b/src/pkg/github/agent_token_delivery_test.go
@@ -271,3 +271,69 @@ func TestWriteAgentToken_MissingPreCreatedFileWarnsAccurately(t *testing.T) {
 		t.Errorf("degraded-path file mode %o is readable beyond the owner", info.Mode().Perm())
 	}
 }
+
+// TestWriteAgentToken_PublishesTrustedBotIdentityFile is the delivery half of
+// the #4044 fix: staff agents authenticate with App installation tokens, for
+// which `gh api user` structurally 403s, so gh-wrapper.sh's author gate can
+// only learn "who am I" from a file this process writes out-of-band of the
+// agent. Every mint must publish the bot login next to the token caches,
+// world-readable (it is public metadata) in a directory agents cannot write.
+func TestWriteAgentToken_PublishesTrustedBotIdentityFile(t *testing.T) {
+	const wantLogin = "test-app[bot]"
+	auth, _, closeFn := newFakeAppAuth(t, "ghs-identity")
+	defer closeFn()
+	useTempCacheDir(t)
+	auth.SetBotLogin(wantLogin)
+
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken: %v", err)
+	}
+
+	data, err := os.ReadFile(BotLoginFilePath())
+	if err != nil {
+		t.Fatalf("trusted bot-identity file was not published: %v", err)
+	}
+	if string(data) != wantLogin {
+		t.Errorf("bot-identity file content = %q, want %q", string(data), wantLogin)
+	}
+
+	info, err := os.Stat(BotLoginFilePath())
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != botLoginFilePerms {
+		t.Errorf("bot-identity file mode = %o, want %o (agents must be able to READ it; the dir denies writes)", info.Mode().Perm(), botLoginFilePerms)
+	}
+
+	// A rotated slug (config refresh reinits the client) must replace the file.
+	const rotatedLogin = "rotated-app[bot]"
+	auth.SetBotLogin(rotatedLogin)
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken after rotation: %v", err)
+	}
+	data, err = os.ReadFile(BotLoginFilePath())
+	if err != nil {
+		t.Fatalf("re-reading bot-identity file: %v", err)
+	}
+	if string(data) != rotatedLogin {
+		t.Errorf("bot-identity file after rotation = %q, want %q", string(data), rotatedLogin)
+	}
+}
+
+// TestWriteAgentToken_NoBotLoginPublishesNothing pins the App-less/unusable-App
+// posture: with no bot login recorded (cfg.GitHub.BotLogin() returns "" when
+// HasUsableApp() is false), no identity file may appear — the wrapper's author
+// gate must stay fail-closed rather than trusting an empty identity — and
+// token delivery itself must be unaffected.
+func TestWriteAgentToken_NoBotLoginPublishesNothing(t *testing.T) {
+	auth, _, closeFn := newFakeAppAuth(t, "ghs-no-identity")
+	defer closeFn()
+	useTempCacheDir(t)
+
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken: %v", err)
+	}
+	if _, err := os.Stat(BotLoginFilePath()); !os.IsNotExist(err) {
+		t.Errorf("bot-identity file must not exist without a bot login (stat err = %v)", err)
+	}
+}

--- a/src/pkg/github/app.go
+++ b/src/pkg/github/app.go
@@ -57,6 +57,22 @@ const (
 	// Directory must be traversable by every agent UID so each can open its
 	// own 0640 file; the files themselves carry the per-agent restriction.
 	agentTokenCacheDirPerms = 0o755
+
+	// botLoginFileName is the trusted bot-identity file gh-wrapper.sh's author
+	// gate reads (#4044). App installation tokens have no /user identity —
+	// `gh api user` 403s for every staff agent — so the wrapper cannot resolve
+	// "who am I" from the token itself. This process DOES know: it mints every
+	// tier token as "<app-slug>[bot]". Publishing that login into the
+	// agent-token cache dir (dev-owned, mode 0755 — no agent UID can write it)
+	// gives the wrapper an identity oracle the agent cannot spoof, preserving
+	// the #3982 fail-closed/anti-spoof posture while making author-gated
+	// self-listing work again.
+	botLoginFileName = "gh-bot-login"
+	// botLoginFilePerms: world-readable on purpose — the bot login is public
+	// metadata (it appears on every PR the App authors), and every agent UID
+	// must be able to read it. The security property is UNWRITABILITY (dir
+	// owned by dev), not secrecy.
+	botLoginFilePerms = 0o644
 )
 
 // agentTokenCacheDir is the directory holding per-agent token caches. It is a
@@ -75,6 +91,10 @@ type AppAuth struct {
 	mu          sync.RWMutex
 	cachedToken string
 	tokenExpiry time.Time
+	// botLogin is the App bot identity ("<app-slug>[bot]") this installation's
+	// tokens act as. Set via SetBotLogin at client wiring time; when non-empty,
+	// WriteAgentToken publishes it to the trusted bot-identity file (#4044).
+	botLogin string
 }
 
 func NewAppAuth(appID, installationID int64, keyFile string, logger *slog.Logger, apiURL string) (*AppAuth, error) {
@@ -322,6 +342,65 @@ func AgentTokenCachePath(agentName string) string {
 	return agentTokenCacheDir + "/gh-token-" + agentName + ".cache"
 }
 
+// BotLoginFilePath returns the trusted bot-identity file path read by
+// gh-wrapper.sh's author gate (#4044).
+func BotLoginFilePath() string {
+	return agentTokenCacheDir + "/" + botLoginFileName
+}
+
+// SetBotLogin records the App bot login ("<app-slug>[bot]") so token delivery
+// can publish it to the trusted bot-identity file. Empty (no usable App)
+// leaves the file unwritten and the wrapper's author gate fail-closed.
+func (a *AppAuth) SetBotLogin(login string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.botLogin = login
+}
+
+// publishBotLogin writes the trusted bot-identity file the gh wrapper's author
+// gate reads (#4044). Failure is deliberately SOFT (warn, never error): the
+// file only widens what an agent can list; without it the gate stays exactly
+// as fail-closed as before this file existed, whereas failing token delivery
+// over it would take down every GitHub operation to protect a listing.
+func (a *AppAuth) publishBotLogin() {
+	a.mu.RLock()
+	login := a.botLogin
+	a.mu.RUnlock()
+	if login == "" {
+		return
+	}
+
+	path := BotLoginFilePath()
+	if cur, err := os.ReadFile(path); err == nil && string(cur) == login {
+		return // already current — skip the write (called on every token refresh)
+	}
+
+	// Write-temp-then-rename, the OPPOSITE of the token caches' in-place rule:
+	// this file is dev-owned world-readable (no pre-created ownership to
+	// preserve), it is shared by every agent, and concurrent launch paths call
+	// this without coordination — rename keeps every reader seeing a complete
+	// login, never a torn write.
+	tmp, err := os.CreateTemp(agentTokenCacheDir, botLoginFileName+".tmp-")
+	if err != nil {
+		a.logger.Warn("cannot publish bot identity file — author-gated gh listing will stay fail-closed for staff agents (#4044)", "path", path, "error", err)
+		return
+	}
+	defer os.Remove(tmp.Name()) // no-op after a successful rename
+	_, werr := tmp.WriteString(login)
+	if werr == nil {
+		werr = tmp.Chmod(botLoginFilePerms)
+	}
+	if cerr := tmp.Close(); werr == nil {
+		werr = cerr
+	}
+	if werr == nil {
+		werr = os.Rename(tmp.Name(), path)
+	}
+	if werr != nil {
+		a.logger.Warn("cannot publish bot identity file — author-gated gh listing will stay fail-closed for staff agents (#4044)", "path", path, "error", werr)
+	}
+}
+
 // WriteAgentToken mints a tier-scoped token for the given agent and writes it
 // into that agent's pre-created cache file.
 //
@@ -355,6 +434,11 @@ func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, a
 	if err := os.MkdirAll(agentTokenCacheDir, agentTokenCacheDirPerms); err != nil {
 		return fmt.Errorf("creating agent token dir: %w", err)
 	}
+
+	// Publish the trusted bot-identity file alongside the token (#4044). Every
+	// mint/refresh path re-asserts it, so a pod that lost /var/run self-heals
+	// within one token-refresh interval. Soft-fails internally — see doc.
+	a.publishBotLogin()
 
 	cachePath := AgentTokenCachePath(agentName)
 	preCreated := true
@@ -447,6 +531,13 @@ func NewClientFromApp(auth *AppAuth, org string, repos []string, logger *slog.Lo
 }
 
 func NewClientFromAppWithBotLogin(auth *AppAuth, org string, repos []string, logger *slog.Logger, appBotLogin string) *Client {
+	// This factory is the one place where the AppAuth that mints agent tokens
+	// meets the resolved bot login (cfg.GitHub.BotLogin()), including every
+	// config-refresh/reinit path in main.go. Recording it here is what lets
+	// WriteAgentToken publish the trusted bot-identity file for the gh
+	// wrapper's author gate (#4044) without threading the login through each
+	// call site separately.
+	auth.SetBotLogin(appBotLogin)
 	transport := &appTransport{
 		auth: auth,
 		base: http.DefaultTransport,


### PR DESCRIPTION
## Summary

Since #3982, `_resolve_self_login` resolves the caller's identity **exclusively** via `gh api user` (fail-closed, env untrusted). The anti-spoof goal was right, but the oracle can never succeed for staff agents: they authenticate with GitHub App **installation** tokens (`ghs_…`), and `GET /user` structurally 403s for any server-to-server token — there is no user identity behind it. Every author-gated listing (`gh issue list --author …`, `gh pr list --author …`, and `--author @me`, which the API equally cannot resolve) therefore failed closed for **all** staff agents, unconditionally — half of the live fleet-owner outage alongside #4043 (fixed by #4047, which this PR stacks on textually in the same files).

## Fix — keep the anti-spoof property, restore a trusted oracle

**Identity mechanism: a trusted bot-identity file, delivered out-of-band of the agent.**

- The hive process is the party that **mints every tier token**, so it already knows exactly which identity those tokens act as: `cfg.GitHub.BotLogin()` = `<app-slug>[bot]`. `AppAuth` now records that login (`SetBotLogin`, wired in `NewClientFromAppWithBotLogin` — the one place the minting `AppAuth` and the resolved bot login meet, covering initial wiring and every config-refresh/reinit path in `main.go`), and `WriteAgentToken` publishes it to `/var/run/hive-metrics/agent-tokens/gh-bot-login` on every mint/refresh (atomic tmp+rename; self-heals within one 40-min refresh interval; soft-fails so identity publication can never take down token delivery).
- `gh-wrapper.sh`'s `_resolve_self_login` reads that file **first** (staff path), falling back to `gh api user` (contributor/user-token path, unchanged). Neither oracle resolving still fails closed.
- `--author @me` is rewritten to the trusted identity for staff agents: `@me` has no server-side meaning for an installation token, so without the substitution there is no working self-listing form at all.

**Why an agent cannot spoof it (the #3982 invariant holds):**

- The file lives in the agent-token cache dir: owned `dev`, mode `0755` (now asserted explicitly in `entrypoint.sh`, not left to umask — group is `node`, which every agent UID is a member of, so a group-write bit would be exactly the spoofing hole). No agent UID can create, replace, or modify anything there; only the hive process (dev) writes it. Same trust pattern as the `/etc/hive/contributor-mode` marker and the pre-created token caches.
- The wrapper reads it at a **constant** path (#3249 pattern): an env-selected path would let the agent point the gate at a file it controls. `HIVE_GH_WRAPPER_BOT_LOGIN_FILE` exists for the test harness only and is honored solely under `HIVE_GH_WRAPPER_REAL_GH`, where the caller already substitutes the gh binary itself — so the override grants nothing new.
- Agent environment is still never consulted for identity; the file's content is world-readable public metadata (the bot's login appears on every PR it authors) — the security property is unwritability, not secrecy.
- Fail-closed posture is preserved everywhere identity genuinely cannot be resolved: missing file, empty file, unreadable file, no usable App (`BotLogin()` returns `""` → nothing is ever published).

## Tests

`bin/test_gh_wrapper_gates.sh` (on top of #4047's final state) — new section drives the wrapper with a stub that reproduces the installation-token 403 exactly:
- installation token + trusted file: self-listing works (`--author "test-app[bot]"`, bare slug, `@me`, `--author=@me` — the `@me` forms assert the forwarded argv was rewritten and contains no `@me`)
- trusted file does **not** open listing other authors (gate still gates)
- missing / empty trusted file: fail-closed preserved, with the `api user` fallback attempt visible in the stub log
- **positive control (#3982 invariant):** `HIVE_AUTH_LOGIN_CACHED` / `HIVE_BOT_LOGIN` / `GITHUB_USER` in the agent env cannot seed identity — listing still refused
- user-token oracle unchanged: `gh api user` still resolves/matches/refuses without a trusted file

`src/pkg/github/agent_token_delivery_test.go`:
- `TestWriteAgentToken_PublishesTrustedBotIdentityFile` — file published with the exact login, mode `0644`, and replaced on slug rotation
- `TestWriteAgentToken_NoBotLoginPublishesNothing` — App-less hive publishes nothing; token delivery unaffected

Fixes #4044
