### PR TITLE
🐛 fix(config): de-materialize stale login_patterns so #3959 defaults reach existing hives

### DIFF
--- a/src/cmd/hive/login_patterns_overrides_test.go
+++ b/src/cmd/hive/login_patterns_overrides_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/snapshot"
+)
+
+// #4041: the legacy state-overrides migration replays a persisted
+// sensing_login list over the loaded config. A list byte-identical to the
+// pre-#3959 defaults is the old defaults materialized by an earlier save —
+// replaying it would re-pin the false-positive-prone generic patterns over
+// the corrected code defaults. It must be skipped; a genuinely customized
+// list must still replay verbatim.
+
+// legacySensingLogin mirrors pkg/config's legacyDefaultLoginPatterns (frozen;
+// duplicated here because the source list is deliberately unexported).
+var legacySensingLogin = []string{
+	"please log in",
+	"authentication required",
+	"not logged in",
+	"login required",
+	"session expired",
+	"token expired",
+	"unauthorized.*401",
+	"gh auth login",
+	"claude login",
+	"copilot auth",
+}
+
+func TestApplyConfigOverrides_SkipsLegacyDefaultSensingLogin(t *testing.T) {
+	// Sanity: the local copy must still match the config package's frozen set,
+	// or this test would silently stop guarding the replay path.
+	if !config.IsLegacyDefaultLoginPatterns(legacySensingLogin) {
+		t.Fatal("legacySensingLogin fixture no longer matches config's frozen legacy set")
+	}
+
+	cfg := &config.Config{
+		Governor: config.GovernorConfig{
+			Sensing: config.SensingConfig{
+				// What applyDefaults left in place: the corrected defaults.
+				LoginPatterns: []string{"Please run /login", "Not logged in"},
+			},
+		},
+	}
+	applyConfigOverrides(cfg, &snapshot.ConfigOverrides{
+		SensingLogin: append([]string(nil), legacySensingLogin...),
+	})
+	got := cfg.Governor.Sensing.LoginPatterns
+	if len(got) != 2 || got[0] != "Please run /login" || got[1] != "Not logged in" {
+		t.Fatalf("legacy-default sensing_login was replayed over the corrected defaults: %v", got)
+	}
+}
+
+// Positive control: a customized sensing_login override still replays.
+func TestApplyConfigOverrides_ReplaysCustomSensingLogin(t *testing.T) {
+	cfg := &config.Config{
+		Governor: config.GovernorConfig{
+			Sensing: config.SensingConfig{
+				LoginPatterns: []string{"Please run /login"},
+			},
+		},
+	}
+	custom := []string{"my own pattern", "copilot auth"}
+	applyConfigOverrides(cfg, &snapshot.ConfigOverrides{
+		SensingLogin: append([]string(nil), custom...),
+	})
+	got := cfg.Governor.Sensing.LoginPatterns
+	if len(got) != len(custom) {
+		t.Fatalf("custom sensing_login not replayed: %v", got)
+	}
+	for i := range custom {
+		if got[i] != custom[i] {
+			t.Fatalf("custom sensing_login mutated: got %v, want %v", got, custom)
+		}
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6793,7 +6793,13 @@ func applyConfigOverrides(cfg *config.Config, o *snapshot.ConfigOverrides) {
 	if len(o.SensingCLIExclude) > 0 {
 		cfg.Governor.Sensing.CLIExcludePatterns = o.SensingCLIExclude
 	}
-	if len(o.SensingLogin) > 0 {
+	// #4041: a persisted sensing_login that is byte-identical to the
+	// pre-#3959 default set carries no operator intent — it is the old
+	// defaults materialized by an earlier save. Replaying it here would
+	// re-pin the false-positive-prone generic patterns over the corrected
+	// code defaults the config layer just applied. Skip it; a genuinely
+	// customized list still replays verbatim.
+	if len(o.SensingLogin) > 0 && !config.IsLegacyDefaultLoginPatterns(o.SensingLogin) {
 		cfg.Governor.Sensing.LoginPatterns = o.SensingLogin
 	}
 	if o.SensingTTL != nil {

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -1927,6 +1927,71 @@ type SensingConfig struct {
 	PullbackSeconds    int      `yaml:"pullback_seconds"`
 }
 
+// defaultLoginPatterns is the built-in login-detector pattern set (#3959):
+// every entry matches a CLI's own login CHROME, never ordinary English, so an
+// agent is not paused for merely reading or discussing an auth error. It is a
+// named var (not an inline literal in applyDefaults) so persistence can
+// recognize "this list IS the default" and skip writing it — see
+// redactedForPersist, which is what keeps the default set from being
+// materialized into saved configs and pinned there forever (#4041).
+var defaultLoginPatterns = []string{
+	// claude: exact prompt strings from Claude Code's login screens.
+	"Please run /login",
+	"Not logged in",
+	// gh / copilot / gemini: the commands their CLIs tell the user to run.
+	"gh auth login",
+	"claude login",
+	"copilot auth",
+	"gemini auth login",
+	// bob: its API-key entry prompts.
+	"Enter Bob-Shell API Key",
+	"Paste your API key here",
+}
+
+// legacyDefaultLoginPatterns is the pre-#3959 default login-detector list,
+// frozen verbatim (values AND order) as it shipped from the day the field
+// existed until da9f6ff2. It exists only for migration: every hive that saved
+// its config in that window has this exact list materialized as explicit
+// values (Save() marshals defaults along with everything else), which
+// permanently defeated the #3959 defaults fix because defaults only apply to
+// an empty list (#4041). Never extend or reorder it — a byte-identical match
+// is the evidence that the list carries no operator intent.
+var legacyDefaultLoginPatterns = []string{
+	"please log in",
+	"authentication required",
+	"not logged in",
+	"login required",
+	"session expired",
+	"token expired",
+	"unauthorized.*401",
+	"gh auth login",
+	"claude login",
+	"copilot auth",
+}
+
+// IsLegacyDefaultLoginPatterns reports whether list is byte-identical (same
+// entries, same order) to the pre-#3959 default login-pattern set. Exported
+// because cmd/hive's legacy state-overrides migration replays a persisted
+// sensing_login list over the loaded config, which is the same materialized-
+// defaults hazard applyDefaults migrates in the config file itself (#4041).
+func IsLegacyDefaultLoginPatterns(list []string) bool {
+	return stringSlicesEqual(list, legacyDefaultLoginPatterns)
+}
+
+// stringSlicesEqual is an exact element-wise comparison (no normalization —
+// migration must only ever fire on a byte-identical match).
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 type HealthConfig struct {
 	HealthcheckInterval int  `yaml:"healthcheck_interval"`
 	RestartCooldown     int  `yaml:"restart_cooldown"`
@@ -3650,6 +3715,19 @@ func (c *Config) applyDefaults() {
 			"resets [0-9]+(:[0-9]+)?[aApP][mM]",
 		}
 	}
+	// #4041: hives that saved their config while the pre-#3959 defaults were
+	// in effect have that generic list MATERIALIZED as explicit values in
+	// their persisted config (Save() marshals the whole struct, defaults
+	// included), and "defaults only apply to an empty list" meant the #3959
+	// fix could never reach them — a live hosted hive's quality agent flapped
+	// on `(?i)copilot auth` for days with restart_count 83. A list that is
+	// byte-identical to the old default set expresses no operator intent, so
+	// treat it as "default": drop it and let the corrected defaults apply. A
+	// list that differs in ANY way is an operator's, and stays verbatim.
+	if IsLegacyDefaultLoginPatterns(c.Governor.Sensing.LoginPatterns) {
+		log.Printf("[config] migrating login_patterns: persisted list matches the pre-#3959 defaults verbatim — dropping it so the corrected defaults apply (customized lists are never touched)")
+		c.Governor.Sensing.LoginPatterns = nil
+	}
 	if len(c.Governor.Sensing.LoginPatterns) == 0 {
 		// Each pattern must match the CLI's own login CHROME, never ordinary
 		// English. The login-detector matches these against the agent's PANE —
@@ -3664,19 +3742,7 @@ func (c *Config) applyDefaults() {
 		// at kick time, so exposure scales with kick frequency. Reproduced on
 		// demand by typing "authentication required" into a healthy agent's
 		// input box (unsubmitted — just rendered on the pane) and kicking it.
-		c.Governor.Sensing.LoginPatterns = []string{
-			// claude: exact prompt strings from Claude Code's login screens.
-			"Please run /login",
-			"Not logged in",
-			// gh / copilot / gemini: the commands their CLIs tell the user to run.
-			"gh auth login",
-			"claude login",
-			"copilot auth",
-			"gemini auth login",
-			// bob: its API-key entry prompts.
-			"Enter Bob-Shell API Key",
-			"Paste your API key here",
-		}
+		c.Governor.Sensing.LoginPatterns = append([]string(nil), defaultLoginPatterns...)
 	}
 	if c.Governor.Sensing.TTLSeconds == 0 {
 		c.Governor.Sensing.TTLSeconds = defaultSensingTTLSeconds
@@ -4570,6 +4636,18 @@ func (c *Config) redactedForPersist() *Config {
 	cp := *c
 	cp.OTel.Headers = envRedactedHeaders(cp.OTel.Headers)
 	cp.Tracing.Headers = envRedactedHeaders(cp.Tracing.Headers)
+	// #4041: never write the built-in login-pattern defaults as explicit
+	// values. applyDefaults fills LoginPatterns on load, so by save time the
+	// in-memory list always LOOKS explicit; marshaling it pins today's
+	// defaults into the persisted config, where "defaults only apply to an
+	// empty list" freezes them forever — exactly how every pre-#3959 hive
+	// ended up stuck with the false-positive-prone generic list. A list equal
+	// to the current defaults expresses no operator intent: persist it as
+	// absent so future default fixes reach existing hives. An operator-
+	// customized list differs from the defaults and is persisted verbatim.
+	if stringSlicesEqual(cp.Governor.Sensing.LoginPatterns, defaultLoginPatterns) {
+		cp.Governor.Sensing.LoginPatterns = nil
+	}
 	return &cp
 }
 

--- a/src/pkg/config/login_patterns_migration_test.go
+++ b/src/pkg/config/login_patterns_migration_test.go
@@ -1,0 +1,265 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// These tests pin the #4041 login_patterns de-materialization contract.
+//
+// Background: Save() marshals the whole Config, and applyDefaults() fills
+// LoginPatterns on every load — so any hive that ever saved its config had
+// the era's DEFAULT login patterns written into the persisted file as if an
+// operator had chosen them. Because defaults only apply to an empty list,
+// the #3959 defaults fix (generic English phrases → CLI login chrome) never
+// reached those hives: on a live hosted hive the quality agent flapped on
+// `(?i)copilot auth` for days (restart_count 83 at first trip) because the
+// pre-#3959 list was pinned in its PVC runtime config.
+//
+// The contract:
+//  1. a persisted list byte-identical to the pre-#3959 defaults is migrated
+//     (dropped, so the current defaults apply);
+//  2. a customized list is preserved verbatim — operator intent is sacred;
+//  3. a list equal to the CURRENT defaults loads unchanged;
+//  4. Save() never writes a default-equal list, so future default fixes
+//     reach existing hives instead of being pinned out forever.
+
+// legacyLoginPatternsYAML is the exact materialized block observed in the
+// frostyard incident's /data/hive.yaml.runtime (#4041) — the pre-#3959
+// defaults, including the `copilot auth` entry the second hosted hive's
+// quality agent flapped on as `(?i)copilot auth`.
+const legacyLoginPatternsYAML = `
+        - please log in
+        - authentication required
+        - not logged in
+        - login required
+        - session expired
+        - token expired
+        - unauthorized.*401
+        - gh auth login
+        - claude login
+        - copilot auth
+`
+
+func writeSensingConfig(t *testing.T, loginPatternsYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	sensing := ""
+	if loginPatternsYAML != "" {
+		sensing = "  sensing:\n    login_patterns:\n" + loginPatternsYAML
+	}
+	content := `project:
+  org: testorg
+  repos:
+    - repo1
+github:
+  app_id: 3568013
+agents:
+  scanner:
+    backend: claude
+governor:
+` + sensing
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	return path
+}
+
+func assertPatternsEqual(t *testing.T, got, want []string, context string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %d patterns %v, want %d %v", context, len(got), got, len(want), want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s: pattern[%d] = %q, want %q (got %v)", context, i, got[i], want[i], got)
+		}
+	}
+}
+
+// The frostyard regression: a persisted list byte-identical to the pre-#3959
+// defaults must be treated as "default" and migrated so the corrected
+// defaults apply.
+func TestLoginPatterns_LegacyDefaultListMigratedToCurrentDefaults(t *testing.T) {
+	path := writeSensingConfig(t, legacyLoginPatternsYAML)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"legacy-default list must migrate to the current defaults")
+	// The generic English phrases that caused the false positives must be gone.
+	for _, p := range cfg.Governor.Sensing.LoginPatterns {
+		switch p {
+		case "authentication required", "please log in", "session expired",
+			"token expired", "login required", "unauthorized.*401":
+			t.Fatalf("pre-#3959 generic pattern %q survived migration", p)
+		}
+	}
+}
+
+// Operator intent is sacred: ANY deviation from the legacy default set —
+// even removing a single entry — means the list is customized and must load
+// verbatim.
+func TestLoginPatterns_CustomizedListPreservedVerbatim(t *testing.T) {
+	cases := map[string]struct {
+		yaml string
+		want []string
+	}{
+		"fully custom": {
+			yaml: "        - my own pattern\n        - another one\n",
+			want: []string{"my own pattern", "another one"},
+		},
+		"legacy list minus one entry": {
+			yaml: `
+        - please log in
+        - authentication required
+        - not logged in
+        - login required
+        - session expired
+        - token expired
+        - unauthorized.*401
+        - gh auth login
+        - claude login
+`,
+			want: []string{"please log in", "authentication required", "not logged in",
+				"login required", "session expired", "token expired", "unauthorized.*401",
+				"gh auth login", "claude login"},
+		},
+		"legacy list plus one entry": {
+			yaml: legacyLoginPatternsYAML + "        - operator addition\n",
+			want: append(append([]string(nil), legacyDefaultLoginPatterns...), "operator addition"),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeSensingConfig(t, tc.yaml)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, tc.want,
+				"customized list must be preserved verbatim")
+		})
+	}
+}
+
+// A list equal to the CURRENT defaults loads unchanged — migration only ever
+// fires on the legacy set.
+func TestLoginPatterns_NewDefaultListLoadsUnchanged(t *testing.T) {
+	var b strings.Builder
+	for _, p := range defaultLoginPatterns {
+		b.WriteString("        - \"" + p + "\"\n")
+	}
+	path := writeSensingConfig(t, b.String())
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"current-default list must load unchanged")
+}
+
+// The materialization source itself: Save() must not write a default-equal
+// login_patterns list into the persisted config. This is what lets a FUTURE
+// defaults fix reach existing hives — the exact mechanism that pinned the
+// pre-#3959 list into every hive's PVC config forever.
+func TestSave_DoesNotMaterializeDefaultLoginPatterns(t *testing.T) {
+	path := writeSensingConfig(t, "")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Defaults are live in memory (the detector needs them)...
+	assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"defaults must be applied in memory")
+
+	// Keep the PVC-runtime side-write inside the sandboxed temp dir.
+	origRuntime := RuntimeConfigFile
+	RuntimeConfigFile = filepath.Join(t.TempDir(), "hive.yaml.runtime")
+	defer func() { RuntimeConfigFile = origRuntime }()
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading saved config: %v", err)
+	}
+	var persisted struct {
+		Governor struct {
+			Sensing struct {
+				LoginPatterns []string `yaml:"login_patterns"`
+			} `yaml:"sensing"`
+		} `yaml:"governor"`
+	}
+	if err := yaml.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("parsing saved config: %v", err)
+	}
+	if len(persisted.Governor.Sensing.LoginPatterns) != 0 {
+		t.Fatalf("Save materialized default login_patterns into the config: %v",
+			persisted.Governor.Sensing.LoginPatterns)
+	}
+
+	// ...and a reload still gets the (current) defaults.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	assertPatternsEqual(t, reloaded.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"defaults must apply again after a save/reload cycle")
+}
+
+// Positive control for the persist rule: a genuinely customized list IS
+// written, survives the round-trip verbatim, and is never migrated.
+func TestSave_PersistsCustomizedLoginPatternsVerbatim(t *testing.T) {
+	path := writeSensingConfig(t, "")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	custom := []string{"Device code: [A-Z0-9]{4}-[A-Z0-9]{4}", "my-forge login"}
+	cfg.Governor.Sensing.LoginPatterns = append([]string(nil), custom...)
+
+	origRuntime := RuntimeConfigFile
+	RuntimeConfigFile = filepath.Join(t.TempDir(), "hive.yaml.runtime")
+	defer func() { RuntimeConfigFile = origRuntime }()
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	assertPatternsEqual(t, reloaded.Governor.Sensing.LoginPatterns, custom,
+		"customized list must survive a save/reload cycle verbatim")
+}
+
+// IsLegacyDefaultLoginPatterns is exported for cmd/hive's state-overrides
+// replay; pin its exactness here so the migration can only ever fire on a
+// byte-identical match.
+func TestIsLegacyDefaultLoginPatterns_Exactness(t *testing.T) {
+	if !IsLegacyDefaultLoginPatterns(append([]string(nil), legacyDefaultLoginPatterns...)) {
+		t.Fatal("exact legacy list not recognized")
+	}
+	reordered := append([]string(nil), legacyDefaultLoginPatterns...)
+	reordered[0], reordered[1] = reordered[1], reordered[0]
+	if IsLegacyDefaultLoginPatterns(reordered) {
+		t.Fatal("reordered list must NOT be treated as the legacy defaults")
+	}
+	if IsLegacyDefaultLoginPatterns(legacyDefaultLoginPatterns[:len(legacyDefaultLoginPatterns)-1]) {
+		t.Fatal("truncated list must NOT be treated as the legacy defaults")
+	}
+	if IsLegacyDefaultLoginPatterns(nil) {
+		t.Fatal("empty list must NOT be treated as the legacy defaults")
+	}
+	if IsLegacyDefaultLoginPatterns(defaultLoginPatterns) {
+		t.Fatal("the CURRENT defaults must NOT be treated as the legacy defaults")
+	}
+}


### PR DESCRIPTION
## Summary

Fix B from #4041: existing hives have the pre-#3959 false-positive-prone `login_patterns` **materialized as explicit values** in their persisted config, which permanently defeats the #3959 defaults fix ("defaults only apply to an empty list"). On one hosted hive the quality agent has flapped on `(?i)copilot auth` since 08-15 with restart_count 83 at first trip.

### Why it happened
`applyDefaults()` fills `LoginPatterns` on every load, and `Save()` marshals the whole struct — so any hive that ever saved its config (every pause toggle does) wrote the era's defaults into `/data/hive.yaml.runtime` as if an operator had chosen them.

### The fix
1. **Migrate on load**: a persisted list **byte-identical** (values and order) to the frozen pre-#3959 default set expresses no operator intent — it is dropped with a clear log line so the corrected code defaults apply. Any deviation, even a single entry removed, means the list is customized and is preserved verbatim. A customized list is NEVER clobbered.
2. **Fix the materialization source**: `redactedForPersist()` now persists a default-equal list as absent, so future default corrections reach existing hives instead of being pinned out forever. Customized lists persist verbatim (positive control included).
3. **Guard the legacy state-overrides replay** (`sensing_login` in `hive-state.json`): the same byte-identical check keeps it from re-pinning the old list over the corrected defaults after the config-file migration.

### Tests
- `TestLoginPatterns_LegacyDefaultListMigratedToCurrentDefaults` — the frostyard regression fixture (exact materialized block from the incident, including the `copilot auth` entry)
- `TestLoginPatterns_CustomizedListPreservedVerbatim` — fully custom / legacy-minus-one / legacy-plus-one
- `TestLoginPatterns_NewDefaultListLoadsUnchanged`
- `TestSave_DoesNotMaterializeDefaultLoginPatterns` + `TestSave_PersistsCustomizedLoginPatternsVerbatim` (positive control)
- `TestIsLegacyDefaultLoginPatterns_Exactness` — reordered/truncated/empty/current-defaults all rejected
- `TestApplyConfigOverrides_SkipsLegacyDefaultSensingLogin` + `TestApplyConfigOverrides_ReplaysCustomSensingLogin`

Fixes #4041 (together with the pause-provenance PR; this one closes the systemic latent bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)