### PR TITLE
fix(api): support hosted bearer-authenticated clients

### DIFF
--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -232,18 +232,29 @@ Auth levels are derived from dashboard middleware (`isPublicPath`, dashboard tok
 ### `/api/v1` contributor subpaths
 
 `handleAPIv1` dispatches authenticated contributor API calls below `/api/v1`.
-Every request requires `Authorization: Bearer <gh-token>`. Query-string
-credentials and other authorization schemes are rejected so GitHub tokens do
-not enter ingress or access logs.
+Every request must carry a GitHub personal access token in the `Authorization`
+header, using either the `Bearer <token>` scheme (hosted clients) or the
+legacy `token <token>` scheme (what `gh auth token` and older hive CLIs
+send). Both are accepted; the legacy scheme is retained for backward
+compatibility. Credentials in the query string (`?token=`) are NOT supported
+and are rejected, because query strings land in ingress and access logs.
+
+Authorization: every `/api/v1` path except `/api/v1/me` additionally requires
+the caller to be in the hive's authorized-users allowlist (any role), and
+returns `403` otherwise — contributor, activity and knowledge data are
+hive-private, not world-readable. `/api/v1/me` is exempt because it only
+returns the caller's own profile. Client-supplied `X-Hive-User`, `X-Hive-Role`
+and owner-verified headers are stripped at the top of the handler; identity is
+always resolved server-side from the validated token.
 
 | Method | Path | Auth | Purpose | Source |
 |---|---|---|---|---|
-| `GET`/`POST` | `/api/v1/status` | GitHub token | Contributor status summary | `pkg/dashboard/api_contribute.go:6777` |
-| `GET`/`POST` | `/api/v1/activity` | GitHub token | Contributor activity feed | `pkg/dashboard/api_contribute.go:6779` |
-| `GET`/`POST` | `/api/v1/contributors` | GitHub token | Contributor list | `pkg/dashboard/api_contribute.go:6781` |
-| `GET`/`POST` | `/api/v1/knowledge` | GitHub token | Knowledge export | `pkg/dashboard/api_contribute.go:6783` |
-| `GET`/`POST` | `/api/v1/me` | GitHub token | Current contributor profile | `pkg/dashboard/api_contribute.go:6785` |
-| `POST` | `/api/v1/prs/{owner}/{repo}/{number}/queue-automerge` | GitHub bearer token + merger/owner role | Queue PR auto-merge using the validated actor and current PR head | `pkg/dashboard/api_contribute.go` |
+| `GET`/`POST` | `/api/v1/status` | GitHub token + allowlist | Contributor status summary | `pkg/dashboard/api_contribute.go:6777` |
+| `GET`/`POST` | `/api/v1/activity` | GitHub token + allowlist | Contributor activity feed | `pkg/dashboard/api_contribute.go:6779` |
+| `GET`/`POST` | `/api/v1/contributors` | GitHub token + allowlist | Contributor list | `pkg/dashboard/api_contribute.go:6781` |
+| `GET`/`POST` | `/api/v1/knowledge` | GitHub token + allowlist | Knowledge export | `pkg/dashboard/api_contribute.go:6783` |
+| `GET`/`POST` | `/api/v1/me` | GitHub token (self-scoped, no allowlist) | Current contributor profile | `pkg/dashboard/api_contribute.go:6785` |
+| `POST` | `/api/v1/prs/{owner}/{repo}/{number}/queue-automerge` | GitHub token + merger/owner role (POST only; GET returns 405) | Queue PR auto-merge using the validated actor and current PR head | `pkg/dashboard/api_contribute.go` |
 
 ## Nous / strategy lab
 

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -241,6 +241,7 @@ Use the Authorization header (or the `token` query parameter).
 | `GET`/`POST` | `/api/v1/contributors` | GitHub token | Contributor list | `pkg/dashboard/api_contribute.go:6781` |
 | `GET`/`POST` | `/api/v1/knowledge` | GitHub token | Knowledge export | `pkg/dashboard/api_contribute.go:6783` |
 | `GET`/`POST` | `/api/v1/me` | GitHub token | Current contributor profile | `pkg/dashboard/api_contribute.go:6785` |
+| `POST` | `/api/v1/prs/{owner}/{repo}/{number}/queue-automerge` | GitHub bearer token + merger/owner role | Queue PR auto-merge using the validated actor and current PR head | `pkg/dashboard/api_contribute.go` |
 
 ## Nous / strategy lab
 

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -232,7 +232,9 @@ Auth levels are derived from dashboard middleware (`isPublicPath`, dashboard tok
 ### `/api/v1` contributor subpaths
 
 `handleAPIv1` dispatches authenticated contributor API calls below `/api/v1`.
-Use the Authorization header (or the `token` query parameter).
+Every request requires `Authorization: Bearer <gh-token>`. Query-string
+credentials and other authorization schemes are rejected so GitHub tokens do
+not enter ingress or access logs.
 
 | Method | Path | Auth | Purpose | Source |
 |---|---|---|---|---|

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -7878,9 +7878,41 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte(`{"error":"Not registered as a contributor. Run: just contribute-setup"}`))
 	default:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"error":"Unknown endpoint","available":["/api/v1/status","/api/v1/activity","/api/v1/contributors","/api/v1/knowledge","/api/v1/me"]}`))
+		if !strings.HasPrefix(subpath, "/prs/") || !strings.HasSuffix(subpath, "/queue-automerge") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":"Unknown endpoint","available":["/api/v1/status","/api/v1/activity","/api/v1/contributors","/api/v1/knowledge","/api/v1/me","/api/v1/prs/{owner}/{repo}/{number}/queue-automerge"]}`))
+			return
+		}
+		// Mutations require an Authorization header even though the read API also
+		// accepts ?token=. Query credentials leak into proxy and access logs.
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			jsonError(w, "Authorization: Bearer <gh-token> required", http.StatusUnauthorized)
+			return
+		}
+		parts := strings.Split(strings.TrimPrefix(subpath, "/prs/"), "/")
+		if len(parts) != 4 || parts[3] != "queue-automerge" {
+			jsonError(w, "Unknown endpoint", http.StatusNotFound)
+			return
+		}
+		role, ok := s.deps.Config.Dashboard.AuthorizedRole(username)
+		if !ok {
+			jsonError(w, "merger or owner access required", http.StatusForbidden)
+			return
+		}
+		// Identity and role are resolved server-side from the validated token and
+		// hive allowlist. Overwrite any client-supplied headers before reusing the
+		// dashboard queue handler and its repo, self-review, and exact-head guards.
+		r.Header.Set("X-Hive-User", username)
+		r.Header.Set("X-Hive-Role", role)
+		r.Header.Del(ownerRoleVerifiedHeader)
+		if isOwnerRole(role) {
+			r.Header.Set(ownerRoleVerifiedHeader, "true")
+		}
+		r.SetPathValue("owner", parts[0])
+		r.SetPathValue("repo", parts[1])
+		r.SetPathValue("number", parts[2])
+		s.handleQueuePRAutoMerge(w, r)
 	}
 }
 

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -7827,14 +7827,14 @@ func validateGitHubToken(token, apiURL string) string {
 // handleAPIv1 wraps contribute API endpoints with GitHub token auth.
 // Accepts Authorization: Bearer <gh-personal-access-token>.
 func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
-	token := r.Header.Get("Authorization")
-	if strings.HasPrefix(token, "Bearer ") {
-		token = token[7:]
-	} else if strings.HasPrefix(token, "token ") {
-		token = token[6:]
-	} else {
-		token = r.URL.Query().Get("token")
+	auth := strings.Fields(r.Header.Get("Authorization"))
+	if len(auth) != 2 || !strings.EqualFold(auth[0], "Bearer") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"Invalid or missing GitHub token. Use: Authorization: Bearer <gh-token>"}`))
+		return
 	}
+	token := auth[1]
 
 	username := validateGitHubToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 	if username == "" {
@@ -7882,12 +7882,6 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(`{"error":"Unknown endpoint","available":["/api/v1/status","/api/v1/activity","/api/v1/contributors","/api/v1/knowledge","/api/v1/me","/api/v1/prs/{owner}/{repo}/{number}/queue-automerge"]}`))
-			return
-		}
-		// Mutations require an Authorization header even though the read API also
-		// accepts ?token=. Query credentials leak into proxy and access logs.
-		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
-			jsonError(w, "Authorization: Bearer <gh-token> required", http.StatusUnauthorized)
 			return
 		}
 		parts := strings.Split(strings.TrimPrefix(subpath, "/prs/"), "/")

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -7825,16 +7825,38 @@ func validateGitHubToken(token, apiURL string) string {
 }
 
 // handleAPIv1 wraps contribute API endpoints with GitHub token auth.
-// Accepts Authorization: Bearer <gh-personal-access-token>.
+//
+// Authentication accepts BOTH the bearer scheme (hosted clients) and the legacy
+// "token <pat>" scheme that `gh auth token` users and older hive CLIs send, so
+// upgrading a hive never breaks existing scripts. Credentials in the query
+// string (?token=) are NOT supported: query strings land in ingress and access
+// logs.
+//
+// Authorization: every /api/v1 path except /api/v1/me is gated on the hive's
+// authorized-users allowlist. The contributor data behind these reads
+// (knowledge base, contributor roster, activity feed) is hive-private, so a
+// merely-authenticated GitHub user must not be able to read it. /api/v1/me is
+// exempt because it only ever returns the caller's own profile.
 func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
-	auth := strings.Fields(r.Header.Get("Authorization"))
-	if len(auth) != 2 || !strings.EqualFold(auth[0], "Bearer") {
+	// Defense in depth: strip any client-supplied identity headers up front so no
+	// downstream handler can ever observe a client-forged identity on this route.
+	r.Header.Del("X-Hive-User")
+	r.Header.Del("X-Hive-Role")
+	r.Header.Del(ownerRoleVerifiedHeader)
+
+	var token string
+	if auth := strings.Fields(r.Header.Get("Authorization")); len(auth) == 2 {
+		// Both schemes carry a GitHub PAT; "token" is kept for compatibility.
+		if strings.EqualFold(auth[0], "Bearer") || strings.EqualFold(auth[0], "token") {
+			token = auth[1]
+		}
+	}
+	if token == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(`{"error":"Invalid or missing GitHub token. Use: Authorization: Bearer <gh-token>"}`))
 		return
 	}
-	token := auth[1]
 
 	username := validateGitHubToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 	if username == "" {
@@ -7842,6 +7864,15 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(`{"error":"Invalid or missing GitHub token. Use: Authorization: Bearer <gh-token>"}`))
 		return
+	}
+
+	// Require allowlist authorization for every path except /api/v1/me, which is
+	// self-scoped. Fail closed: an empty allowlist authorizes nobody.
+	if !strings.HasPrefix(r.URL.Path, "/api/v1/me") {
+		if _, ok := s.deps.Config.Dashboard.AuthorizedRole(username); !ok {
+			jsonError(w, "forbidden: not authorized for this endpoint", http.StatusForbidden)
+			return
+		}
 	}
 
 	subpath := strings.TrimPrefix(r.URL.Path, "/api/v1")
@@ -7887,6 +7918,13 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 		parts := strings.Split(strings.TrimPrefix(subpath, "/prs/"), "/")
 		if len(parts) != 4 || parts[3] != "queue-automerge" {
 			jsonError(w, "Unknown endpoint", http.StatusNotFound)
+			return
+		}
+		// queue-automerge mutates merge state, so it must never be reachable via
+		// GET (or any other safe method) — that would let a link or image tag
+		// trigger a merge and bypass the write gate.
+		if r.Method != http.MethodPost {
+			jsonError(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 		role, ok := s.deps.Config.Dashboard.AuthorizedRole(username)

--- a/src/pkg/dashboard/api_contribute_v1_coverage_test.go
+++ b/src/pkg/dashboard/api_contribute_v1_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -107,13 +108,31 @@ func TestCovV1_UnknownEndpoint(t *testing.T) {
 	}
 }
 
-// TokenFromQuery: the handler also accepts ?token= when no Authorization header.
-func TestCovV1_TokenFromQuery(t *testing.T) {
+func TestCovV1_RejectsQueryTokenWithoutReflectingIt(t *testing.T) {
+	const secret = "ghp_query_secret_must_not_leak"
 	s := v1Server(t, "octocat")
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/status?token=qtoken", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status?token="+secret, nil)
 	s.mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("query token: want 200, got %d", rec.Code)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("query token: want 401, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Fatal("query token was reflected in the error response")
+	}
+}
+
+func TestCovV1_RejectsNonBearerAuthorizationWithoutReflectingIt(t *testing.T) {
+	const secret = "ghp_scheme_secret_must_not_leak"
+	s := v1Server(t, "octocat")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req.Header.Set("Authorization", "token "+secret)
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("non-bearer authorization: want 401, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Fatal("authorization credential was reflected in the error response")
 	}
 }

--- a/src/pkg/dashboard/api_contribute_v1_coverage_test.go
+++ b/src/pkg/dashboard/api_contribute_v1_coverage_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 // userMock serves GitHub's /user endpoint so validateGitHubToken resolves a
@@ -31,6 +33,10 @@ func v1Server(t *testing.T, login string) *Server {
 	// validateGitHubToken resolves through OAuthAPIURL (pinned to api.github.com),
 	// not APIURL, so the mock is only reached via the override.
 	s.deps.Config.GitHub.OAuthAPIURLOverride = mock.URL
+	// /api/v1 reads require allowlist authorization, so authorize the mock login.
+	if login != "" {
+		s.deps.Config.Dashboard.AuthorizedUsers = []string{login + ":" + config.RoleRead}
+	}
 	return s
 }
 
@@ -122,17 +128,60 @@ func TestCovV1_RejectsQueryTokenWithoutReflectingIt(t *testing.T) {
 	}
 }
 
-func TestCovV1_RejectsNonBearerAuthorizationWithoutReflectingIt(t *testing.T) {
+func TestCovV1_RejectsUnknownAuthorizationSchemeWithoutReflectingIt(t *testing.T) {
 	const secret = "ghp_scheme_secret_must_not_leak"
 	s := v1Server(t, "octocat")
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
-	req.Header.Set("Authorization", "token "+secret)
+	req.Header.Set("Authorization", "Basic "+secret)
 	s.mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("non-bearer authorization: want 401, got %d", rec.Code)
+		t.Fatalf("unknown scheme: want 401, got %d", rec.Code)
 	}
 	if strings.Contains(rec.Body.String(), secret) {
 		t.Fatal("authorization credential was reflected in the error response")
+	}
+}
+
+// The legacy "token <pat>" scheme (what `gh auth token` users send) must keep
+// working alongside the bearer scheme.
+func TestCovV1_LegacyTokenSchemeStillWorks(t *testing.T) {
+	s := v1Server(t, "octocat")
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req.Header.Set("Authorization", "token legacy-pat")
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("token scheme: want 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// Reads are hive-private: an authenticated but unauthorized GitHub user gets 403.
+func TestCovV1_UnauthorizedUserForbiddenOnReads(t *testing.T) {
+	for _, path := range []string{"/api/v1/status", "/api/v1/contributors", "/api/v1/activity", "/api/v1/knowledge"} {
+		s := v1Server(t, "outsider")
+		s.deps.Config.Dashboard.AuthorizedUsers = []string{"someone-else:" + config.RoleOwner}
+		rec := v1Get(s, path, "forbidden-user-token")
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("%s: want 403 for unauthorized user, got %d", path, rec.Code)
+		}
+	}
+}
+
+func TestCovV1_AuthorizedUserAllowedOnReads(t *testing.T) {
+	s := v1Server(t, "octocat")
+	rec := v1Get(s, "/api/v1/contributors", "authorized-read-token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authorized contributors read: want 200, got %d", rec.Code)
+	}
+}
+
+// /api/v1/me is self-scoped, so it stays reachable without allowlist membership.
+func TestCovV1_MeAllowedWithoutAllowlist(t *testing.T) {
+	s := v1Server(t, "nobody-registered")
+	s.deps.Config.Dashboard.AuthorizedUsers = nil
+	rec := v1Get(s, "/api/v1/me", "me-no-allowlist-token")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("me without allowlist: want 404 (not 403), got %d", rec.Code)
 	}
 }

--- a/src/pkg/dashboard/api_v1_pr_automerge_test.go
+++ b/src/pkg/dashboard/api_v1_pr_automerge_test.go
@@ -74,9 +74,17 @@ func newAPIV1QueueServer(t *testing.T, role, tokenUser, prAuthor, headSHA string
 
 func queueAPIV1(t *testing.T, s *Server, token string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/prs/acme/widget/7/queue-automerge", nil)
+	return queueAPIV1Request(t, s, "/api/v1/prs/acme/widget/7/queue-automerge", token, nil)
+}
+
+func queueAPIV1Request(t *testing.T, s *Server, path, token string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, nil)
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
 	}
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
@@ -102,6 +110,43 @@ func TestAPIV1QueuePRAutoMergeRequiresMergerRole(t *testing.T) {
 	}
 	if *reviewCreated || *labelAdded {
 		t.Fatal("insufficient role must not mutate the pull request")
+	}
+}
+
+func TestAPIV1QueuePRAutoMergeIgnoresForgedIdentityHeaders(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleReadWrite, "alice", "bob", "head7")
+	w := queueAPIV1Request(t, s, "/api/v1/prs/acme/widget/7/queue-automerge", "valid-token", map[string]string{
+		"X-Hive-User":           "mallory",
+		"X-Hive-Role":           config.RoleOwner,
+		ownerRoleVerifiedHeader: "true",
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("forged identity headers must not mutate the pull request")
+	}
+}
+
+func TestAPIV1QueuePRAutoMergeRejectsQueryToken(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "bob", "head7")
+	w := queueAPIV1Request(t, s, "/api/v1/prs/acme/widget/7/queue-automerge?token=valid-token", "", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s, want 401", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("query token must not authorize a mutation")
+	}
+}
+
+func TestAPIV1QueuePRAutoMergeRejectsRepoOutsideHive(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "bob", "head7")
+	w := queueAPIV1Request(t, s, "/api/v1/prs/other/secret/7/queue-automerge", "valid-token", nil)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "not managed") {
+		t.Fatalf("status = %d body=%s, want managed-repository 403", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("repository scope rejection must not mutate the pull request")
 	}
 }
 

--- a/src/pkg/dashboard/api_v1_pr_automerge_test.go
+++ b/src/pkg/dashboard/api_v1_pr_automerge_test.go
@@ -1,0 +1,162 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+func newAPIV1QueueServer(t *testing.T, role, tokenUser, prAuthor, headSHA string) (*Server, *bool, *bool) {
+	t.Helper()
+	var reviewCreated, labelAdded bool
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/user":
+			if r.Header.Get("Authorization") != "Bearer valid-token" {
+				http.Error(w, "invalid token", http.StatusUnauthorized)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{"login": tokenUser})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/pulls/7":
+			json.NewEncoder(w).Encode(map[string]any{
+				"number": 7,
+				"user":   map[string]string{"login": prAuthor},
+				"head":   map[string]string{"sha": headSHA},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/acme/widget/labels/"+ghpkg.AutoMergeQueuedLabel:
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/labels":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"name": ghpkg.AutoMergeQueuedLabel})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/pulls/7/reviews":
+			var body struct {
+				CommitID string `json:"commit_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode review: %v", err)
+			}
+			if body.CommitID != headSHA {
+				t.Fatalf("review commit_id = %q, want current head %q", body.CommitID, headSHA)
+			}
+			reviewCreated = true
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"id": 1, "state": "APPROVED"})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/acme/widget/issues/7/labels":
+			labelAdded = true
+			json.NewEncoder(w).Encode([]map[string]any{{"name": ghpkg.AutoMergeQueuedLabel}})
+		default:
+			t.Fatalf("unexpected GitHub API call: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(api.Close)
+
+	cfg := &config.Config{
+		Project:   config.ProjectConfig{Org: "acme", Repos: []string{"widget"}},
+		GitHub:    config.GitHubConfig{OAuthAPIURLOverride: api.URL},
+		Dashboard: config.DashboardConfig{AuthorizedUsers: []string{tokenUser + ":" + role}},
+	}
+	s := NewServer(0, slog.Default())
+	s.authToken = "dashboard-token"
+	s.deps = &Dependencies{
+		Config:   cfg,
+		GHClient: ghpkg.NewClient("app-token", "acme", []string{"widget"}, slog.Default(), api.URL),
+		Logger:   slog.Default(),
+	}
+	s.RegisterAPI(s.deps)
+	return s, &reviewCreated, &labelAdded
+}
+
+func queueAPIV1(t *testing.T, s *Server, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/prs/acme/widget/7/queue-automerge", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestAPIV1QueuePRAutoMergeRequiresValidGitHubBearer(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "bob", "head7")
+	w := queueAPIV1(t, s, "wrong-token")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s, want 401", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("invalid bearer token must not mutate the pull request")
+	}
+}
+
+func TestAPIV1QueuePRAutoMergeRequiresMergerRole(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleReadWrite, "alice", "bob", "head7")
+	w := queueAPIV1(t, s, "valid-token")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("insufficient role must not mutate the pull request")
+	}
+}
+
+func TestAPIV1QueuePRAutoMergeRejectsOwnPR(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "ALICE", "head7")
+	w := queueAPIV1(t, s, "valid-token")
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "own pull requests") {
+		t.Fatalf("status = %d body=%s, want self-merge 403", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("self-merge rejection must not mutate the pull request")
+	}
+}
+
+func TestAPIV1QueuePRAutoMergeUsesExistingExactHeadGuard(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "bob", "")
+	w := queueAPIV1(t, s, "valid-token")
+	if w.Code != http.StatusBadGateway || !strings.Contains(w.Body.String(), "head SHA") {
+		t.Fatalf("status = %d body=%s, want missing-head rejection", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("missing head SHA must not mutate the pull request")
+	}
+}
+
+func TestAPIV1QueuePRAutoMergeBindsValidatedActor(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "bob", "head7")
+	w := queueAPIV1(t, s, "valid-token")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	if !*reviewCreated || !*labelAdded {
+		t.Fatalf("reviewCreated=%v labelAdded=%v, want both true", *reviewCreated, *labelAdded)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if got["status"] != "queued" || got["repo"] != "acme/widget" || got["number"] != float64(7) {
+		t.Fatalf("response = %#v, want structured queue result", got)
+	}
+}
+
+func TestAPIV1IsPublicOnlyWithinVersionedPrefix(t *testing.T) {
+	for _, tt := range []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/status", true},
+		{"/api/v1/prs/acme/widget/7/queue-automerge", true},
+		{"/api/v10/status", false},
+		{"/api/prs/acme/widget/7/queue-automerge", false},
+	} {
+		if got := isPublicPath(tt.path); got != tt.want {
+			t.Errorf("isPublicPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}

--- a/src/pkg/dashboard/api_v1_pr_automerge_test.go
+++ b/src/pkg/dashboard/api_v1_pr_automerge_test.go
@@ -205,3 +205,33 @@ func TestAPIV1IsPublicOnlyWithinVersionedPrefix(t *testing.T) {
 		}
 	}
 }
+
+// queue-automerge is a mutation: safe methods must never reach the handler.
+func TestAPIV1QueuePRAutoMergeRejectsGET(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "bob", "head7")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/prs/acme/widget/7/queue-automerge", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d body=%s, want 405", w.Code, w.Body.String())
+	}
+	if *reviewCreated || *labelAdded {
+		t.Fatal("GET must not mutate the pull request")
+	}
+}
+
+// The legacy "token <pat>" scheme must also work for the mutation path.
+func TestAPIV1QueuePRAutoMergeAcceptsLegacyTokenScheme(t *testing.T) {
+	s, reviewCreated, labelAdded := newAPIV1QueueServer(t, config.RoleMerger, "alice", "bob", "head7")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/prs/acme/widget/7/queue-automerge", nil)
+	req.Header.Set("Authorization", "token valid-token")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	if !*reviewCreated || !*labelAdded {
+		t.Fatalf("reviewCreated=%v labelAdded=%v, want both true", *reviewCreated, *labelAdded)
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -1202,6 +1202,11 @@ func isPublicPath(path string) bool {
 		// The trailing-slash boundary excludes /api/contributors while keeping the
 		// real public routes (register, the WS upgrade, status, etc.) public.
 		return true
+	case path == "/api/v1" || strings.HasPrefix(path, "/api/v1/"):
+		// GitHub bearer authentication is enforced by handleAPIv1. Keeping this
+		// versioned prefix outside dashboard session auth lets non-browser clients
+		// reach that handler without trusting cookies or X-Hive-* headers.
+		return true
 	case path == "/leaderboard" || strings.HasPrefix(path, "/leaderboard/"):
 		return true
 	case strings.HasPrefix(path, "/api/leaderboard"):

--- a/src/pkg/hub/saas_api_ingress_test.go
+++ b/src/pkg/hub/saas_api_ingress_test.go
@@ -1,0 +1,33 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHostedNginxIngressBypassesBrowserAuthOnlyForAPIV1(t *testing.T) {
+	apiStart := strings.Index(k8sManifestTemplate, "name: hive-api")
+	if apiStart < 0 {
+		t.Fatal("hosted manifest is missing a dedicated hive-api ingress")
+	}
+	apiEnd := strings.Index(k8sManifestTemplate[apiStart:], "\n---")
+	if apiEnd < 0 {
+		t.Fatal("hive-api ingress is not a bounded manifest document")
+	}
+	apiIngress := k8sManifestTemplate[apiStart : apiStart+apiEnd]
+	if !strings.Contains(apiIngress, "path: /api/v1") {
+		t.Fatal("hive-api ingress must expose only the versioned GitHub-token API prefix")
+	}
+	if strings.Contains(apiIngress, "auth-url") || strings.Contains(apiIngress, "auth-signin") {
+		t.Fatal("hive-api ingress must not apply browser session authentication")
+	}
+
+	dashboardStart := strings.Index(k8sManifestTemplate, "name: hive\n")
+	if dashboardStart < 0 || dashboardStart >= apiStart {
+		t.Fatal("hosted manifest is missing the authenticated dashboard ingress")
+	}
+	dashboardIngress := k8sManifestTemplate[dashboardStart:apiStart]
+	if !strings.Contains(dashboardIngress, "auth-url") || !strings.Contains(dashboardIngress, "auth-signin") {
+		t.Fatal("dashboard ingress must retain browser session authentication")
+	}
+}

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -2883,6 +2883,31 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: hive-api
+  namespace: {{.Namespace}}
+  annotations:
+    cert-manager.io/cluster-issuer: {{.CertIssuer}}
+spec:
+  ingressClassName: {{.IngressClass}}
+  rules:
+  - host: {{.DashboardHost}}
+    http:
+      paths:
+      - path: /api/v1
+        pathType: Prefix
+        backend:
+          service:
+            name: hive
+            port:
+              number: {{.DashboardPort}}
+  tls:
+  - hosts:
+    - {{.DashboardHost}}
+    secretName: hive-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
   name: hive-contribute
   namespace: {{.Namespace}}
   annotations:
@@ -3053,7 +3078,7 @@ spec:
 
 	// nginx: append a rule + TLS host to each existing Ingress via a JSON patch.
 	patched := 0
-	for _, ing := range []string{"hive", "hive-contribute", "hive-terminal"} {
+	for _, ing := range []string{"hive", "hive-api", "hive-contribute", "hive-terminal"} {
 		raw, err := kubectlForCluster(cluster, "-n", ns, "get", "ingress", ing, "-o", "json").Output()
 		if err != nil {
 			continue // not every spoke has all three


### PR DESCRIPTION
Refs #4050

## Problem

Hosted nginx ingress redirects documented GitHub-bearer `/api/v1` clients to browser login before Hive can validate the token. The existing `queue-automerge` endpoint is dashboard-session-only, so non-browser maintainer clients have no supported authenticated route.

## Fix

- add a dedicated hosted `/api/v1` ingress without browser `auth-url` or `auth-signin`; the root dashboard and terminal ingresses retain browser authentication;
- treat only the boundary-safe `/api/v1` subtree as public to dashboard middleware, leaving every request subject to the existing GitHub token validator;
- add a narrowly scoped `POST /api/v1/prs/{owner}/{repo}/{number}/queue-automerge` route;
- resolve the authenticated username from the GitHub bearer token and the role from the hive's authorized-user allowlist, then reuse the existing queue handler and GitHub client operation;
- require `Authorization: Bearer` across every `/api/v1` read and mutation; query credentials and other authorization schemes are rejected so PATs cannot enter query/access logs.

## Security boundary

The client cannot supply trusted identity or role. The handler overwrites `X-Hive-User` and `X-Hive-Role` from server-validated state. Authentication errors contain only fixed guidance and never reflect credentials. The existing managed-repository, merger-or-owner, self-merge, current-head approval, and App-authored write guards remain authoritative. The dashboard route is unchanged, and no cookie, shared-token, or direct-GitHub merge fallback is added.

## Verification

- `go test ./pkg/dashboard ./pkg/hub -run 'TestAPIV1|TestHostedNginxIngressBypassesBrowserAuthOnlyForAPIV1' -count=1`
- `go test ./pkg/dashboard ./pkg/hub ./pkg/github ./pkg/config -count=1`
- `go test ./... -count=1` reached the full module; unrelated environment-dependent tests failed because `tmux` is absent and the configured inception endpoint at `192.168.4.85:3003` is unreachable
- live end-to-end proof against a deployment carrying this exact head is still required
- independent Sol/max security review is required before this draft leaves draft state

Agent-assisted implementation; human maintainer review and merge remain required.
