### PR TITLE
✨ v5: journaled re-entrant contribute turn — RFC #4002 stage 2

### DIFF
--- a/src/docs/design/reentrant-turn-model.md
+++ b/src/docs/design/reentrant-turn-model.md
@@ -196,6 +196,106 @@ A complete prototype has been implemented in [`pkg/turn`](../../pkg/turn) and va
 - **ACMM Gated Operator Pauses**: Verified that side-effectful write tools at ACMM L4 enter `StatusWaitingApproval`, pause execution, and seamlessly resume upon receiving operator approval (`TestOperatorApprovalPauseAndResume`).
 - **Subagent Synchronization**: Verified that background subagent task completions delivered in `TurnInput` update state and conversation transcript cleanly (`TestSubagentSynchronization`).
 - **Scrub-on-Persist**: The serialized envelope is the durable, handoff-able form of the conversation, and transcripts are secret-bearing (tokens, repo contents, tool output). `ToJSON`/`ToPrettyJSON` therefore redact credential-shaped substrings from every content-bearing field via `pkg/logscrub` — the fleet's single reusable scrubber — before serialization; in-memory state used by `Step` is never scrubbed (`TestToJSONScrubsSecretsOnPersist`).
+- **Journaled Re-entrancy (stage 2)**: Side-effectful operations are journaled with content-derived idempotency keys and survive a kill at every operation boundary with exactly-once effects (`TestKillMidTurnReplayExactlyOnce`). See Section 5a for the key design, the write protocol, the widened scrub boundary, and the residual non-re-entrant surfaces.
+
+---
+
+## 5a. Stage 2 — The Journaled, Re-entrant Turn (hard problem 1 + 3)
+
+Stage 2 implements the mandated spike deliverable from the maintainer review: a journaled, re-entrant contribute-headless turn with a kill-mid-turn replay test. It closes hard problem 1 (tool-execution idempotency) and completes hard problem 3's scrub boundary. It is **prototype only** — nothing in the live agent loop or the running contribute path constructs any of it; it is exercised entirely by tests.
+
+New files, all additive within the existing package: [`journal.go`](../../pkg/turn/journal.go), [`journaled_exec.go`](../../pkg/turn/journaled_exec.go), [`replay_test.go`](../../pkg/turn/replay_test.go).
+
+### The idempotency-key design
+
+Every side-effectful operation is identified by a key that must satisfy two constraints in tension:
+
+1. **Stable across re-entry** — recomputable in a fresh process from the persisted envelope alone. This excludes everything ambient: timestamps, random nonces, PIDs, attempt counters, process-local sequence numbers.
+2. **Unique per logical effect** — two genuinely different effects must not collide. Collision is the *worse* failure: a duplicate PR is visible and embarrassing, whereas a suppressed second comment is silent under-performance nobody notices.
+
+The derivation is a length-prefixed SHA-256 over the semantic content of the effect and nothing else:
+
+```
+key = v1 + sha256( version | session_id | kind | repo | target | body )[:32]
+```
+
+| Field | Why it is in the key |
+| :--- | :--- |
+| `session_id` | Scopes the key to one task's turn sequence, so two agents posting an identical comment on the same issue are distinct operations. Handoff preserves `SessionID`, which is what keeps the key stable across processes and spokes. |
+| `kind` + `repo` + `target` | Locate the effect. |
+| `body` | The content hash — what separates "post comment A" from "post comment B", and equally what makes a *replay* of comment A recognizable as the same operation. |
+
+Deliberately **excluded**: `ToolCallID`. Model-assigned call IDs are freshly minted on every inference, so a re-entry that re-runs the LLM step would produce a new ID for a semantically identical effect and defeat the mechanism entirely. The ID is recorded on the entry for traceability but never keyed on. Fields are length-prefixed so `("ab","c")` cannot hash the same as `("a","bc")`. The `v1` prefix is the escape hatch: bumping it invalidates all prior keys without making old journals unreadable.
+
+**On the "natural GitHub idempotency surrogate" alternative.** GitHub exposes no idempotency-key header on the writes we care about. The available surrogates are all *query-after-the-fact*: search for an open PR from head branch X, list comments and match the body. This design uses them — but as **reconciliation**, not as the key. They cost a round trip, they are eventually consistent, and critically they cannot be computed offline, which violates constraint 1. The content hash is the primary key; the remote query is the tie-breaker for the single state where the local journal cannot know the answer.
+
+This mirrors what `pkg/github` already does ad hoc: `CreatePR` dedupes on the head branch and reports reuse via `CreatePRResult.AlreadyExisted`. `EffectResult.AlreadyExisted` reuses that vocabulary rather than inventing a parallel one.
+
+**Lineage.** At-least-once delivery over non-idempotent GitHub writes is exactly the duplicate-work class the fleet eradicated one incident at a time: [#3768](https://github.com/kubestellar/hive/issues/3768) → [#3792](https://github.com/kubestellar/hive/pull/3792) (issues re-offered while an open PR already claimed them) → [#3980](https://github.com/kubestellar/hive/issues/3980) (non-closing `Refs #N` PRs re-offered every cooldown window, forever) → [#3987](https://github.com/kubestellar/hive/issues/3987) (maintainer-gated issues with only merged reference PRs re-entering the pool, fixed by the `no_work_needed` verdict in #3997). Each was the same bug — a task re-entering a pool and re-performing an effect whose completion was not durably recorded — patched at a different layer. This journal is the generalization: **record the effect, not the attempt.**
+
+### The write protocol
+
+`JournaledExecutor.Do` performs one operation exactly once across any number of re-entries:
+
+1. Derive the key (offline, stable).
+2. **Succeeded entry → short-circuit.** Return the recorded `ExternalRef` without touching the remote.
+3. **Ambiguous entry → reconcile.** Intent was written, outcome was not; ask the remote whether the effect landed. Found → settle as succeeded. Not found → fall through and perform.
+4. **Write `OpIntended` and persist it.** If persistence fails, the effect is never attempted — an unpersisted intent is an unprotected write on the next re-entry.
+5. Perform the effect.
+6. Settle with the outcome and persist again.
+
+The window between 4 and 6 is the only place a crash can leave ambiguity, and step 3 is what closes it on the next entry. The three-state `OpStatus` (`intended` / `succeeded` / `failed`) exists precisely so re-entry can distinguish *never started* from *may have happened* from *definitely happened* — a two-state journal cannot express the middle case, and the middle case is the whole problem.
+
+### The scrub boundary — verdict
+
+**The pre-existing boundary was correct but its coverage was incomplete, and stage 2 widened it.**
+
+`ToJSON`/`ToPrettyJSON` were already the single persistence boundary, already routing every content-bearing field through `logscrub.ScrubString` — the fleet's canonical scrubber (GitHub tokens, AWS keys, bearer tokens, JWTs, PEM private-key blocks, hive canaries), the same machinery guarding stderr and logs. `Clone`/`Step` correctly do **not** scrub: in-memory state must stay intact or the agent would read redacted content back as fact. That design is sound and unchanged.
+
+What stage 2 added is a new secret-bearing surface that the existing scrub did not cover — the journal itself:
+
+| Journal field | Exposure |
+| :--- | :--- |
+| `Error` | Raw remote error text. **The most common accidental credential channel of the three** — git and gh routinely echo authenticated URLs into failure messages. |
+| `ExternalRef` | Can carry an `x-access-token:…@github.com` authenticated URL. |
+| `Target` | Can carry a branch name minted from a token-bearing remote. |
+| `IdempotencyKey` | A hash. Needs no scrubbing and **must not be altered** — scrubbing it would break re-entry matching and cause replay. Explicitly left untouched. |
+
+`OpIntent.Body` participates in the key but is never stored on the entry, so scrubbing can never destabilize a key. `TestReplayPersistedArtifactCarriesNoCredential` asserts both halves: no plaintext credential in the artifact, *and* every key still resolving after the scrub.
+
+### What the replay test proves
+
+`TestKillMidTurnReplayExactlyOnce` is table-driven over **every operation boundary** in a contribute-shaped turn (comment → push → PR create → label). Each op contributes two boundaries — the intent persist and the settle persist — for **8 kill sites**. `killablePersister` fails the write at boundary *N*, so death occurs *before* that envelope reaches disk (the strictly harder case). The only thing crossing the simulated process boundary is the serialized JSON, so no in-memory state can leak into the recovery.
+
+| Boundary | Position | What re-entry must do |
+| :--- | :--- | :--- |
+| 1, 3, 5, 7 (odd) | Intent write, pre-effect | Nothing landed → perform normally. Exactly-once holds with no remote help. |
+| 2, 4, 6, 8 (even) | Settle write, post-effect | Effect landed but is unrecorded → **must reconcile, not replay.** This is the duplicate-PR window. |
+
+Assertions per case: **(a)** exactly-once effects, counted at the fake GitHub surface (calls actually made to the remote), not inferred from the journal's own bookkeeping; **(b)** the same terminal verdict (`shipped`, the contribute plane's vocabulary) and an effect summary identical to the control, with no operation left ambiguous; **(c)** no credential in the persisted artifact.
+
+Supporting tests: `TestReplayReconcilesAmbiguousIntent` (the post-effect/pre-settle window resolves by query, not guesswork); `TestReplayNotFoundAfterIntentPerformsEffect` (**the anti-vacuity control** — a journal that simply skipped every ambiguous entry would pass the exactly-once test while silently dropping work); `TestIntentIsPersistedBeforeEffect` (runs *without* a reconciler, since reconciliation otherwise masks the ordering bug, and since effects with no queryable surrogate — a push, a bare comment — have no reconciler in practice); `TestReplayWithoutReconcilerStillNeverDuplicatesSettledEffects`; `TestIdempotencyKeyStability`.
+
+**Positive control**: an unkilled run establishes the reference effect set, verdict, and boundary count, and the test fails if that control produces no effects or duplicates — so the kill cases cannot pass vacuously.
+
+**Mutation-checked.** Per the lesson of audits 6 and 7 (every finding hid behind a test passing for the wrong reason), the suite was verified by breaking the implementation four ways and confirming a red: removing the already-done short-circuit (12 assertions fire); removing reconciliation (reproduces the duplicate-PR bug exactly, at every even boundary); treating ambiguous entries as always-landed (caught by the anti-vacuity control); and performing the effect before persisting intent. The fourth mutant initially **survived** — reconciliation masked it — which is why `TestIntentIsPersistedBeforeEffect` exists.
+
+### Pending-approval operation shape (#4000)
+
+`OpApprovalWait` and `SuspendForApproval` exist so a turn blocked on an operator decision is a **journaled, re-enterable position** rather than in-process suspended state. This is why re-entrancy had to come before handoff: an operator-approval wait *is* a suspended turn.
+
+**Shape only.** No approvals UI, inbox, or routing is built here — that is #4000's scope. The wait performs no external effect, never counts as a landed effect, is rejected by `Do` (which is for side-effectful ops), and re-entering while still pending does not mint a second wait. Consistent with the L6 throughput contract on #4000: `auto-approve` resolves synchronously in-loop and never enters this lane; the journal entry is for the operator lane only.
+
+### Residual — what is still NOT re-entrant
+
+Recorded honestly, because the value of this stage is knowing precisely where the guarantee stops:
+
+1. **The LLM call is not journaled.** A crash between inference and the first op re-runs inference. This is usually benign (it costs tokens, not correctness) but it is *not* free: a non-deterministic model may choose a different tool call on re-entry, so mid-turn recovery can diverge in plan even while every already-landed effect stays protected. Journaling inference responses by prompt hash is the obvious next step.
+2. **Reconciliation is only as good as its query.** Effects with no reliable remote surrogate — a push (a force-push can hide it), a comment on a high-traffic thread — cannot be reconciled with certainty. For those, exactly-once degrades to at-most-once-per-boundary. `TestReplayWithoutReconcilerStillNeverDuplicatesSettledEffects` measures exactly this weaker property.
+3. **Persistence is assumed atomic and durable.** `Persister` is an interface with a test implementation. A real one must do tmp-write + `os.Rename` (the pattern the no-work-verdict ledger already uses in `contribute_ws.go`) and survive a torn write. A partially written envelope is currently unhandled.
+4. **`Runner.Step` does not use the journal.** The two are deliberately decoupled in this prototype. Wiring the journal into the tool-execution operation of `Step` — including the `PendingApprovals` re-execution gap the RFC already names — is Phase 2 work.
+5. **No cross-process claim integration.** Per hard problem 2, handoff must reuse the contribute plane's atomic offer→claim path rather than parallel it. Nothing here touches claims, and the replay test simulates re-entry *within* one logical claim holder. Two processes racing on the same envelope are not covered — the journal makes re-entry safe, not concurrency safe.
+6. **The journal grows unboundedly** within a session and is not compacted, unlike `Messages`.
 
 ---
 
@@ -217,11 +317,11 @@ A complete prototype has been implemented in [`pkg/turn`](../../pkg/turn) and va
 
 ### Open Hard Problems (from maintainer review of #4002)
 
-The maintainer review on #4002 names three hard problems this prototype does **not** yet solve; they are the acceptance bar for Phase 2, recorded here so the prototype is not mistaken for a complete design:
+The maintainer review on #4002 names three hard problems. **Stage 2 (Section 5a) closes problem 1 and completes problem 3's scrub boundary**; problem 2 remains open and is the acceptance bar for Phase 2. Status is tracked below so the prototype is neither mistaken for a complete design nor undersold:
 
-1. **Tool-execution idempotency on re-entry.** A turn that dies *after* a side-effectful operation (PR opened, comment posted) and is re-entered will replay it. Every tool operation must be journaled inside the envelope with an idempotency key, and the design must pass a kill-mid-turn replay test: kill the process at each operation boundary, re-enter from the persisted envelope, and assert exactly-once effects. The current prototype checkpoints at turn boundaries only; `TestDurableStateHandoffAcrossProcessRestarts` is the turn-boundary case, not the mid-turn one. The same gap applies to `PendingApprovals`: an operator decision redelivered after a crash between execution and persistence would re-execute the tool.
+1. **Tool-execution idempotency on re-entry — ADDRESSED in stage 2 (Section 5a), with residuals.** Side-effectful operations are now journaled inside the envelope with a content-derived idempotency key under a before/after write protocol, and the mandated kill-mid-turn replay test passes over all 8 operation boundaries of a contribute-shaped turn. The guarantee is bounded: see the six residual non-re-entrant surfaces in Section 5a — most importantly that the LLM call itself is not journaled, that reconciliation is only as strong as its remote query, and that `Runner.Step` does not yet use the journal. The `PendingApprovals` re-execution gap named in the original review is **not** yet closed in `Step`; only the pending-approval *operation shape* exists (`OpApprovalWait`).
 2. **Handoff must reuse the claim machinery, not parallel it.** Cross-node handoff (Section 4, Pattern A) is a task re-entering a pool. Whatever queue carries the envelope must go through the existing atomic offer→claim path and completion-verdict recording in the contribute plane, not introduce a parallel claim system.
-3. **The conversation blob is a secret-bearing artifact.** Addressed in part by scrub-on-persist above; the remaining design questions — who may read a persisted envelope, and its authorization boundary when it crosses spokes on handoff — are Phase 3 prerequisites.
+3. **The conversation blob is a secret-bearing artifact.** The scrub boundary is now complete over every persisted field, including the journal surfaces stage 2 added (Section 5a, "The scrub boundary — verdict"). The remaining questions are authorization, not redaction: who may read a persisted envelope, and its trust boundary when it crosses spokes on handoff. Those are Phase 3 prerequisites.
 
 Additional Phase 2 constraints from the maintainer positions on #4000: the ACMM ladder hard-coded in `toolapprove.Decide` is illustrative — the production decision function must read the ACMM packs (`pkg/config/acmm_packs.go`) rather than re-hardcode thresholds, must map each level's *current* permitted behavior 1:1 on day one, and at L6 must resolve synchronously in-loop with no queue residence (the scan lane must never become a hidden serialization point). From #4001: production hooks must fire on the durable commit of a transition (outbox over the journaled record), not on the in-memory flip as the prototype's `HookHandler` callbacks do.
 

--- a/src/pkg/turn/envelope.go
+++ b/src/pkg/turn/envelope.go
@@ -40,6 +40,18 @@ func (e SessionEnvelope) scrubbedForPersist() SessionEnvelope {
 		out.PendingApprovals[i].ToolCall.Arguments = logscrub.ScrubString(out.PendingApprovals[i].ToolCall.Arguments)
 		out.PendingApprovals[i].Verdict.Rationale = logscrub.ScrubString(out.PendingApprovals[i].Verdict.Rationale)
 	}
+	// The journal is persisted with the envelope and is equally secret-bearing:
+	// Target can carry a branch name minted from a token-bearing remote URL,
+	// ExternalRef can carry an authenticated URL, and Error is raw remote error
+	// text — the most common accidental credential channel of the three. The
+	// idempotency key itself is a hash and needs no scrubbing, and must not be
+	// altered: scrubbing it would break re-entry matching.
+	for i := range out.Journal.Entries {
+		out.Journal.Entries[i].Repo = logscrub.ScrubString(out.Journal.Entries[i].Repo)
+		out.Journal.Entries[i].Target = logscrub.ScrubString(out.Journal.Entries[i].Target)
+		out.Journal.Entries[i].ExternalRef = logscrub.ScrubString(out.Journal.Entries[i].ExternalRef)
+		out.Journal.Entries[i].Error = logscrub.ScrubString(out.Journal.Entries[i].Error)
+	}
 	return out
 }
 

--- a/src/pkg/turn/journal.go
+++ b/src/pkg/turn/journal.go
@@ -1,0 +1,302 @@
+package turn
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// OpKind classifies a journaled operation by the kind of side effect it has on
+// the outside world. Only side-effectful kinds need idempotency protection;
+// read-only operations are replayable for free and are not journaled.
+type OpKind string
+
+const (
+	// OpPRCreate opens a pull request. Non-idempotent at the GitHub API level:
+	// a replayed create yields a second PR.
+	OpPRCreate OpKind = "pr_create"
+	// OpPREdit edits an existing pull request (title/body/base).
+	OpPREdit OpKind = "pr_edit"
+	// OpComment posts an issue or PR comment. The canonical duplicate-effect
+	// shape: replay yields a visible double-post.
+	OpComment OpKind = "comment"
+	// OpPush pushes commits to a branch.
+	OpPush OpKind = "push"
+	// OpLabel adds or removes labels on an issue or PR. Naturally idempotent on
+	// GitHub's side, but journaled anyway so replay accounting is uniform.
+	OpLabel OpKind = "label"
+	// OpApprovalWait is a suspended operator-approval wait (#4000). It performs
+	// no external effect itself; it exists so a turn blocked on an operator
+	// decision is a journaled, re-enterable position rather than in-process
+	// suspended state. See the shape note in the stage-2 design section.
+	OpApprovalWait OpKind = "approval_wait"
+)
+
+// sideEffectful reports whether a kind mutates external state and therefore
+// must be replay-protected by its idempotency key.
+func (k OpKind) sideEffectful() bool {
+	return k != OpApprovalWait
+}
+
+// OpStatus is the journaled lifecycle position of a single operation. The
+// three states exist precisely so that re-entry can distinguish "never
+// started" from "may have happened" from "definitely happened".
+type OpStatus string
+
+const (
+	// OpIntended is written BEFORE the effect is attempted. A record found in
+	// this state on re-entry is the ambiguous case: the process died between
+	// declaring intent and recording the outcome, so the effect may or may not
+	// have landed. It must be reconciled (looked up), never blindly replayed.
+	OpIntended OpStatus = "intended"
+	// OpSucceeded is written AFTER the effect landed, carrying the external
+	// result reference. Re-entry short-circuits these: already done.
+	OpSucceeded OpStatus = "succeeded"
+	// OpFailed is written after a terminal failure. Re-entry may retry.
+	OpFailed OpStatus = "failed"
+)
+
+// JournalEntry is the durable record of one side-effectful operation inside a
+// turn. It is written to the envelope twice: once as OpIntended before the
+// effect is attempted, and once again — same IdempotencyKey, same slot — as
+// OpSucceeded or OpFailed after. That before/after pair is what makes a turn
+// re-enterable at an operation boundary instead of only at a turn boundary.
+type JournalEntry struct {
+	// IdempotencyKey is the stable, content-derived identity of the logical
+	// effect. See DeriveIdempotencyKey for the derivation and its rationale.
+	IdempotencyKey string   `json:"idempotency_key"`
+	Kind           OpKind   `json:"kind"`
+	Status         OpStatus `json:"status"`
+	// Repo is the "owner/name" the effect targets, empty for non-repo effects.
+	Repo string `json:"repo,omitempty"`
+	// Target is the secondary subject within the repo (issue/PR number, branch).
+	Target string `json:"target,omitempty"`
+	// ToolCallID ties the entry back to the model-requested tool call that
+	// produced it, so a transcript and its journal can be cross-read.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	// ExternalRef is the identity the remote assigned to the effect (PR URL,
+	// comment ID, pushed SHA). Populated only on OpSucceeded. This is what a
+	// re-entering process returns instead of re-performing the effect.
+	ExternalRef string `json:"external_ref,omitempty"`
+	// Error records a terminal failure reason on OpFailed.
+	Error string `json:"error,omitempty"`
+	// Attempts counts how many times execution has been entered for this key,
+	// across process lifetimes. >1 means a re-entry occurred.
+	Attempts   int       `json:"attempts"`
+	IntendedAt time.Time `json:"intended_at"`
+	SettledAt  time.Time `json:"settled_at,omitempty"`
+}
+
+// Done reports whether the effect is known to have landed.
+func (e JournalEntry) Done() bool { return e.Status == OpSucceeded }
+
+// Ambiguous reports whether the entry is in the crash-window state: intent was
+// recorded but no outcome was. The effect may or may not exist remotely, so it
+// must be reconciled against the remote rather than replayed or skipped.
+func (e JournalEntry) Ambiguous() bool { return e.Status == OpIntended }
+
+// OpIntent describes a side-effectful operation a turn is about to perform.
+// It is the input to the journal; the key is derived from it.
+type OpIntent struct {
+	Kind OpKind
+	Repo string
+	// Target is the issue/PR number or branch the effect applies to.
+	Target string
+	// Body is the semantic payload of the effect — comment text, PR
+	// title+body, label set, pushed tree-ish. It participates in the key so
+	// that two genuinely different effects of the same kind on the same target
+	// are distinct operations, while a replay of the same effect is not.
+	Body string
+	// ToolCallID is the originating model tool call, recorded but deliberately
+	// NOT part of the key. See DeriveIdempotencyKey.
+	ToolCallID string
+}
+
+// idempotencyKeyVersion prefixes every derived key. Bumping it deliberately
+// invalidates all prior keys, which is the escape hatch if the derivation
+// itself ever has to change: old journals stay readable, new keys never
+// collide with them.
+const idempotencyKeyVersion = "v1"
+
+// DeriveIdempotencyKey computes the stable identity of a logical side effect.
+//
+// Design (RFC #4002 stage 2). The key must satisfy two opposing constraints:
+//
+//  1. STABLE ACROSS RE-ENTRY — recomputing it in a fresh process, from the
+//     persisted envelope alone, must yield the same value. This rules out
+//     anything ambient: no timestamps, no random nonces, no PIDs, no
+//     process-local counters, no attempt numbers.
+//  2. UNIQUE PER LOGICAL EFFECT — two different intended effects must not
+//     collide, or the journal would suppress a real second operation and the
+//     turn would silently under-perform (a failure mode strictly worse than a
+//     duplicate, because it is invisible).
+//
+// The derivation is therefore a hash over the semantic content of the effect
+// and nothing else:
+//
+//	sha256(version | session | kind | repo | target | body)
+//
+// Field-by-field rationale:
+//
+//   - SessionID scopes the key to one task's turn sequence. Without it, two
+//     different agents posting the identical comment on the same issue would
+//     collide and the second would be suppressed. Handoff preserves SessionID,
+//     so this stays stable across processes — which is the whole point.
+//   - Kind + Repo + Target locate the effect.
+//   - Body is the content hash. It is what distinguishes "post comment A" from
+//     "post comment B" on the same issue, and equally what makes a replay of
+//     "post comment A" recognizable as the same operation.
+//
+// Deliberately EXCLUDED:
+//
+//   - ToolCallID. Model-assigned call IDs are freshly generated on every
+//     inference, so a re-entry that re-runs the LLM step would produce a new
+//     ID for a semantically identical effect and defeat the whole mechanism.
+//     The ID is recorded on the entry for traceability but never keyed on.
+//   - Timestamps and attempt counters, per constraint 1.
+//
+// On the "natural GitHub idempotency surrogate" alternative: GitHub exposes no
+// idempotency-key header on the writes we care about (unlike Stripe). The
+// available surrogates are all *query-after-the-fact* — search for an open PR
+// from head branch X, list comments and match the body. Those are genuinely
+// useful and this design uses them, but as RECONCILIATION for the ambiguous
+// OpIntended window (see Reconciler), not as the key itself: they cost a round
+// trip, they are eventually consistent, and they cannot be computed offline.
+// The content hash is the primary key; the remote query is the tie-breaker for
+// the one state where the local journal cannot know the answer.
+//
+// Lineage: at-least-once delivery over non-idempotent GitHub writes is exactly
+// the duplicate-work class the fleet eradicated one incident at a time in
+// #3768 → #3792 → #3980 → #3987. Each of those was the same bug — a task
+// re-entering a pool and re-performing an effect whose completion was not
+// durably recorded — patched at a different layer. This journal is the
+// generalization: record the effect, not the attempt.
+func DeriveIdempotencyKey(sessionID string, in OpIntent) string {
+	h := sha256.New()
+	// Length-prefix every field so that concatenation is unambiguous and
+	// ("ab","c") cannot hash the same as ("a","bc").
+	for _, part := range []string{
+		idempotencyKeyVersion,
+		sessionID,
+		string(in.Kind),
+		in.Repo,
+		in.Target,
+		in.Body,
+	} {
+		fmt.Fprintf(h, "%d:%s|", len(part), part)
+	}
+	return idempotencyKeyVersion + "-" + hex.EncodeToString(h.Sum(nil))[:32]
+}
+
+// Journal is the ordered list of operation records carried inside the
+// envelope. Order is the operation-boundary sequence of the turn; the map-free
+// slice representation keeps the JSON stable and diffable.
+type Journal struct {
+	Entries []JournalEntry `json:"entries,omitempty"`
+}
+
+// Lookup returns the entry for a key and whether it exists.
+func (j *Journal) Lookup(key string) (JournalEntry, bool) {
+	for _, e := range j.Entries {
+		if e.IdempotencyKey == key {
+			return e, true
+		}
+	}
+	return JournalEntry{}, false
+}
+
+// RecordIntent writes (or re-writes) the pre-execution OpIntended record for a
+// key and returns the entry plus the prior entry if one existed. Calling it a
+// second time for the same key increments Attempts — that counter is the
+// journal's own evidence that a re-entry happened.
+func (j *Journal) RecordIntent(key string, in OpIntent, now time.Time) (JournalEntry, JournalEntry, bool) {
+	for i := range j.Entries {
+		if j.Entries[i].IdempotencyKey != key {
+			continue
+		}
+		prior := j.Entries[i]
+		// A settled entry is never downgraded back to intended; callers must
+		// consult Lookup first. Only the attempt counter moves.
+		if prior.Status == OpIntended {
+			j.Entries[i].Attempts++
+		}
+		return j.Entries[i], prior, true
+	}
+	e := JournalEntry{
+		IdempotencyKey: key,
+		Kind:           in.Kind,
+		Status:         OpIntended,
+		Repo:           in.Repo,
+		Target:         in.Target,
+		ToolCallID:     in.ToolCallID,
+		Attempts:       1,
+		IntendedAt:     now,
+	}
+	j.Entries = append(j.Entries, e)
+	return e, JournalEntry{}, false
+}
+
+// Settle writes the post-execution outcome for a key.
+func (j *Journal) Settle(key string, status OpStatus, externalRef, errStr string, now time.Time) {
+	for i := range j.Entries {
+		if j.Entries[i].IdempotencyKey != key {
+			continue
+		}
+		j.Entries[i].Status = status
+		j.Entries[i].ExternalRef = externalRef
+		j.Entries[i].Error = errStr
+		j.Entries[i].SettledAt = now
+		return
+	}
+}
+
+// Ambiguous returns every entry stuck in the intended-but-unsettled state.
+// A re-entering process must reconcile each of these before proceeding.
+func (j *Journal) Ambiguous() []JournalEntry {
+	var out []JournalEntry
+	for _, e := range j.Entries {
+		if e.Ambiguous() {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// EffectCount returns the number of successfully landed effects, optionally
+// filtered by kind. Tests assert exactly-once against this.
+func (j *Journal) EffectCount(kinds ...OpKind) int {
+	want := map[OpKind]bool{}
+	for _, k := range kinds {
+		want[k] = true
+	}
+	n := 0
+	for _, e := range j.Entries {
+		if !e.Done() {
+			continue
+		}
+		if len(want) > 0 && !want[e.Kind] {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// Summary renders a stable, sorted one-line-per-effect digest of the landed
+// effects. Two runs that produced identical effects produce identical
+// summaries, which is how the replay test compares a killed-and-resumed run
+// against its unkilled positive control.
+func (j *Journal) Summary() string {
+	var lines []string
+	for _, e := range j.Entries {
+		if !e.Done() {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s %s/%s -> %s", e.Kind, e.Repo, e.Target, e.ExternalRef))
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}

--- a/src/pkg/turn/journaled_exec.go
+++ b/src/pkg/turn/journaled_exec.go
@@ -1,0 +1,187 @@
+package turn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// EffectResult is the outcome of one side-effectful operation against the
+// remote. ExternalRef is the remote-assigned identity of the effect.
+//
+// AlreadyExisted mirrors github.CreatePRResult.AlreadyExisted deliberately:
+// pkg/github already dedupes PR creation on the head branch and reports reuse
+// with that field, so the journal reuses the vocabulary rather than inventing
+// a parallel one. A sink may set it when the remote itself recognized the
+// effect as pre-existing; the journal treats reuse and fresh creation
+// identically for exactly-once purposes.
+type EffectResult struct {
+	ExternalRef    string
+	Output         string
+	AlreadyExisted bool
+}
+
+// EffectSink performs the actual external write. Implementations are the thin
+// GitHub surface (create PR, post comment, push, label); tests substitute a
+// counting fake so exactly-once can be asserted at the call boundary rather
+// than inferred from the journal alone.
+type EffectSink interface {
+	Perform(ctx context.Context, in OpIntent) (EffectResult, error)
+}
+
+// Reconciler resolves the ambiguous OpIntended window: intent was journaled,
+// then the process died before the outcome was. The effect may or may not
+// exist remotely, and the local journal cannot know which. Reconcile asks the
+// remote.
+//
+// This is where the "natural GitHub idempotency surrogate" lives: an
+// implementation searches for an open PR from the head branch, or lists
+// comments matching the body, and returns the existing ref if found. It is a
+// query, not a key — see DeriveIdempotencyKey for why the key itself must be
+// computable offline.
+type Reconciler interface {
+	// Reconcile reports whether the effect already exists remotely, and its
+	// reference if so.
+	Reconcile(ctx context.Context, in OpIntent) (ref string, found bool, err error)
+}
+
+// Persister durably stores the envelope at an operation boundary. The journal
+// only protects against replay if the intent record actually reaches disk
+// before the effect is attempted — that ordering is the entire guarantee.
+type Persister interface {
+	Persist(ctx context.Context, env SessionEnvelope) error
+}
+
+// ErrKilled is returned by a Persister that simulates a process death at a
+// chosen operation boundary. The replay test injects it to cut a turn at each
+// boundary in turn; production Persisters never return it.
+var ErrKilled = errors.New("turn: process killed at operation boundary")
+
+// JournaledExecutor performs side-effectful operations under the journal's
+// before/after protocol. It is deliberately separate from Runner: this is a
+// prototype surface exercised by tests, and nothing in the live agent loop or
+// the running contribute path constructs one.
+type JournaledExecutor struct {
+	Sink       EffectSink
+	Reconciler Reconciler
+	Persister  Persister
+	// Now is injectable for deterministic tests; defaults to time.Now().UTC.
+	Now func() time.Time
+}
+
+func (x *JournaledExecutor) now() time.Time {
+	if x.Now != nil {
+		return x.Now()
+	}
+	return time.Now().UTC()
+}
+
+// Do executes one side-effectful operation exactly once across any number of
+// re-entries, mutating env's journal in place.
+//
+// The protocol, in the order that makes it safe:
+//
+//  1. Derive the key from the intent (offline, stable).
+//  2. Consult the journal. A succeeded entry short-circuits — the effect is
+//     already done, return its recorded ref without touching the remote.
+//  3. An ambiguous entry (intent written, outcome not) is reconciled against
+//     the remote before anything else. Found means the pre-crash attempt
+//     landed; settle it as succeeded and return. Not found means it did not;
+//     fall through and perform it.
+//  4. Otherwise write the OpIntended record and PERSIST IT. If persistence
+//     fails, the effect is never attempted — an unpersisted intent would be
+//     an unprotected write on the next re-entry.
+//  5. Perform the effect.
+//  6. Settle the journal with the outcome and persist again.
+//
+// The window between 4 and 6 is the only place a crash can leave ambiguity,
+// and step 3 is what closes it on the next entry.
+func (x *JournaledExecutor) Do(ctx context.Context, env *SessionEnvelope, in OpIntent) (EffectResult, error) {
+	if env == nil {
+		return EffectResult{}, fmt.Errorf("turn: nil envelope")
+	}
+	if !in.Kind.sideEffectful() {
+		return EffectResult{}, fmt.Errorf("turn: %s is not a side-effectful op", in.Kind)
+	}
+
+	key := DeriveIdempotencyKey(env.SessionID, in)
+
+	// (2) Already done — the exactly-once short circuit.
+	if prior, ok := env.Journal.Lookup(key); ok && prior.Done() {
+		return EffectResult{ExternalRef: prior.ExternalRef}, nil
+	}
+
+	// (3) Ambiguous window — ask the remote what actually happened.
+	if prior, ok := env.Journal.Lookup(key); ok && prior.Ambiguous() && x.Reconciler != nil {
+		ref, found, err := x.Reconciler.Reconcile(ctx, in)
+		if err != nil {
+			return EffectResult{}, fmt.Errorf("reconcile %s: %w", key, err)
+		}
+		if found {
+			env.Journal.Settle(key, OpSucceeded, ref, "", x.now())
+			if perr := x.persist(ctx, *env); perr != nil {
+				return EffectResult{}, perr
+			}
+			return EffectResult{ExternalRef: ref}, nil
+		}
+	}
+
+	// (4) Record intent and persist BEFORE performing.
+	env.Journal.RecordIntent(key, in, x.now())
+	if err := x.persist(ctx, *env); err != nil {
+		return EffectResult{}, err
+	}
+
+	// (5) Perform.
+	if x.Sink == nil {
+		return EffectResult{}, fmt.Errorf("turn: no EffectSink configured")
+	}
+	res, err := x.Sink.Perform(ctx, in)
+	if err != nil {
+		env.Journal.Settle(key, OpFailed, "", err.Error(), x.now())
+		if perr := x.persist(ctx, *env); perr != nil {
+			return EffectResult{}, perr
+		}
+		return EffectResult{}, err
+	}
+
+	// (6) Settle and persist.
+	env.Journal.Settle(key, OpSucceeded, res.ExternalRef, "", x.now())
+	if perr := x.persist(ctx, *env); perr != nil {
+		return EffectResult{}, perr
+	}
+	return res, nil
+}
+
+func (x *JournaledExecutor) persist(ctx context.Context, env SessionEnvelope) error {
+	if x.Persister == nil {
+		return nil
+	}
+	return x.Persister.Persist(ctx, env)
+}
+
+// SuspendForApproval journals a pending-approval position (#4000) without
+// performing any external effect. An operator-approval wait is a suspended
+// turn, which is exactly why re-entrancy had to come first: the envelope must
+// be able to name "we are stopped here, awaiting a human" as durable state
+// rather than a blocked goroutine.
+//
+// This is the SHAPE only. No approvals UI, no inbox, no routing — those are
+// #4000's scope and are not built here. What exists is the guarantee that a
+// turn suspended on approval is a journaled, re-enterable position.
+func (x *JournaledExecutor) SuspendForApproval(ctx context.Context, env *SessionEnvelope, in OpIntent) (JournalEntry, error) {
+	if env == nil {
+		return JournalEntry{}, fmt.Errorf("turn: nil envelope")
+	}
+	in.Kind = OpApprovalWait
+	key := DeriveIdempotencyKey(env.SessionID, in)
+	if prior, ok := env.Journal.Lookup(key); ok {
+		return prior, nil
+	}
+	e, _, _ := env.Journal.RecordIntent(key, in, x.now())
+	if err := x.persist(ctx, *env); err != nil {
+		return JournalEntry{}, err
+	}
+	return e, nil
+}

--- a/src/pkg/turn/replay_test.go
+++ b/src/pkg/turn/replay_test.go
@@ -1,0 +1,605 @@
+package turn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Fake GitHub surface
+//
+// The fake counts calls per logical effect. Exactly-once is asserted at THIS
+// boundary — the number of times the remote was actually asked to do
+// something — not merely from the journal's own bookkeeping, which could agree
+// with itself while still double-posting.
+// ---------------------------------------------------------------------------
+
+type fakeGitHub struct {
+	// calls counts Perform invocations per "kind repo/target: body".
+	calls map[string]int
+	// created records the effects that exist remotely, in creation order.
+	created []string
+	// reconcileCalls counts lookups, to prove reconciliation actually ran.
+	reconcileCalls int
+	seq            int
+}
+
+func newFakeGitHub() *fakeGitHub {
+	return &fakeGitHub{calls: map[string]int{}}
+}
+
+func effectID(in OpIntent) string {
+	return fmt.Sprintf("%s %s/%s: %s", in.Kind, in.Repo, in.Target, in.Body)
+}
+
+func (f *fakeGitHub) Perform(ctx context.Context, in OpIntent) (EffectResult, error) {
+	id := effectID(in)
+	f.calls[id]++
+	f.seq++
+	ref := fmt.Sprintf("https://github.test/%s/%s#%d", in.Repo, in.Kind, f.seq)
+	f.created = append(f.created, id)
+	return EffectResult{ExternalRef: ref}, nil
+}
+
+// Reconcile is the "natural GitHub idempotency surrogate": ask the remote
+// whether this effect already exists. Mirrors github.CreatePR's head-branch
+// lookup and its AlreadyExisted result.
+func (f *fakeGitHub) Reconcile(ctx context.Context, in OpIntent) (string, bool, error) {
+	f.reconcileCalls++
+	id := effectID(in)
+	for i, c := range f.created {
+		if c == id {
+			return fmt.Sprintf("https://github.test/%s/%s#%d", in.Repo, in.Kind, i+1), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// duplicates returns every effect the remote was asked to perform more than
+// once. A non-empty result is the duplicate-PR/comment bug class from
+// #3768 → #3792 → #3980 → #3987.
+func (f *fakeGitHub) duplicates() []string {
+	var dups []string
+	for id, n := range f.calls {
+		if n > 1 {
+			dups = append(dups, fmt.Sprintf("%s (performed %d times)", id, n))
+		}
+	}
+	return dups
+}
+
+// ---------------------------------------------------------------------------
+// Killable persister
+//
+// Persist is the operation boundary. killAt selects which boundary crossing
+// dies; every Persist call is one boundary, so counting them and failing at
+// index N cuts the turn precisely at the Nth boundary.
+// ---------------------------------------------------------------------------
+
+type killablePersister struct {
+	// saved is the last successfully persisted envelope JSON — the ONLY state
+	// a re-entering process is allowed to read. Deliberately stored as
+	// serialized bytes, not a struct, so a test cannot accidentally carry
+	// in-memory state across the simulated process boundary.
+	saved []byte
+	// boundary counts Persist calls made so far.
+	boundary int
+	// killAt is the 1-based boundary at which to simulate process death.
+	// Zero means never kill (the positive control).
+	killAt int
+}
+
+func (p *killablePersister) Persist(ctx context.Context, env SessionEnvelope) error {
+	p.boundary++
+	if p.killAt > 0 && p.boundary == p.killAt {
+		// Death BEFORE the write lands: the envelope at this boundary never
+		// reaches disk. This is the strictly harder case — it is what creates
+		// the ambiguous window when the death happens on an intent write.
+		return ErrKilled
+	}
+	// ToJSON applies scrub-on-persist, so the durable artifact the test
+	// inspects is exactly what production would write.
+	b, err := env.ToJSON()
+	if err != nil {
+		return err
+	}
+	p.saved = b
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// The workload under test
+//
+// A contribute-shaped turn: comment on the issue, push the branch, open the
+// PR, label it. Four side-effectful ops, run in order, each journaled. The
+// function is written to be re-entrant — calling it again with the recovered
+// envelope resumes rather than restarts.
+// ---------------------------------------------------------------------------
+
+const (
+	testRepo    = "kubestellar/hive"
+	testIssue   = "4002"
+	testBranch  = "fix-4002"
+	testSession = "sess-replay-1"
+)
+
+func workloadOps() []OpIntent {
+	return []OpIntent{
+		{Kind: OpComment, Repo: testRepo, Target: testIssue, Body: "on it", ToolCallID: "tc-1"},
+		{Kind: OpPush, Repo: testRepo, Target: testBranch, Body: "abc123", ToolCallID: "tc-2"},
+		{Kind: OpPRCreate, Repo: testRepo, Target: testBranch, Body: "fix: the thing", ToolCallID: "tc-3"},
+		{Kind: OpLabel, Repo: testRepo, Target: testIssue, Body: "triage/accepted", ToolCallID: "tc-4"},
+	}
+}
+
+// runWorkload executes the ops in order against env, stopping at the first
+// error (which, for ErrKilled, simulates the process dying mid-turn). It
+// returns the terminal verdict when it completes.
+func runWorkload(ctx context.Context, x *JournaledExecutor, env *SessionEnvelope) (string, error) {
+	for _, op := range workloadOps() {
+		if _, err := x.Do(ctx, env, op); err != nil {
+			return "", err
+		}
+	}
+	// Terminal verdict, in the contribute plane's vocabulary: a PR landed, so
+	// this task shipped. (completionVerdictShipped in pkg/dashboard.)
+	env.Status = StatusCompleted
+	return "shipped", nil
+}
+
+func newEnv() SessionEnvelope {
+	return SessionEnvelope{
+		SessionID:   testSession,
+		ACMMLevel:   4,
+		WorkingRepo: testRepo,
+		Status:      StatusActive,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestKillMidTurnReplayExactlyOnce is the acceptance test mandated by the
+// #4002 maintainer review: kill the process at EACH operation boundary,
+// re-enter from the persisted envelope, and assert exactly-once effects.
+// ---------------------------------------------------------------------------
+
+func TestKillMidTurnReplayExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+
+	// --- Positive control: an unkilled run. -------------------------------
+	// Establishes the reference effect set and verdict, and proves the
+	// workload actually performs effects (without which every kill case below
+	// would pass vacuously).
+	controlGH := newFakeGitHub()
+	controlP := &killablePersister{}
+	controlEnv := newEnv()
+	controlX := &JournaledExecutor{Sink: controlGH, Reconciler: controlGH, Persister: controlP}
+
+	controlVerdict, err := runWorkload(ctx, controlX, &controlEnv)
+	if err != nil {
+		t.Fatalf("positive control failed: %v", err)
+	}
+	if controlVerdict != "shipped" {
+		t.Fatalf("positive control verdict = %q, want shipped", controlVerdict)
+	}
+	wantEffects := len(workloadOps())
+	if got := len(controlGH.created); got != wantEffects {
+		t.Fatalf("positive control performed %d effects, want %d", got, wantEffects)
+	}
+	if dups := controlGH.duplicates(); len(dups) > 0 {
+		t.Fatalf("positive control itself duplicated: %v", dups)
+	}
+	controlSummary := controlEnv.Journal.Summary()
+	if controlSummary == "" {
+		t.Fatal("positive control produced an empty effect summary; comparisons below would be vacuous")
+	}
+	// The control crossed this many boundaries; every one is a kill site.
+	totalBoundaries := controlP.boundary
+	if totalBoundaries < wantEffects*2 {
+		t.Fatalf("expected at least %d boundaries (intent+settle per op), got %d",
+			wantEffects*2, totalBoundaries)
+	}
+
+	// --- Table-driven kill at every boundary. -----------------------------
+	for boundary := 1; boundary <= totalBoundaries; boundary++ {
+		t.Run(fmt.Sprintf("kill_at_boundary_%02d", boundary), func(t *testing.T) {
+			gh := newFakeGitHub()
+			p := &killablePersister{killAt: boundary}
+			env := newEnv()
+			x := &JournaledExecutor{Sink: gh, Reconciler: gh, Persister: p}
+
+			// Attempt 1: dies at the chosen boundary.
+			_, err := runWorkload(ctx, x, &env)
+			if !errors.Is(err, ErrKilled) {
+				t.Fatalf("attempt 1: expected ErrKilled at boundary %d, got %v", boundary, err)
+			}
+
+			// The process is now gone. Everything in memory is forfeit: the
+			// only thing that survives is what reached disk.
+			var recovered SessionEnvelope
+			if p.saved != nil {
+				recovered, err = ParseEnvelope(p.saved)
+				if err != nil {
+					t.Fatalf("re-entry: parse persisted envelope: %v", err)
+				}
+			} else {
+				// Killed at the very first boundary: nothing persisted, so a
+				// re-entering process starts from the task's initial state.
+				recovered = newEnv()
+			}
+
+			// Attempt 2: re-enter from the persisted envelope, no kill.
+			p.killAt = 0
+			verdict, err := runWorkload(ctx, x, &recovered)
+			if err != nil {
+				t.Fatalf("re-entry failed: %v", err)
+			}
+
+			// (a) EXACTLY-ONCE EFFECTS.
+			if dups := gh.duplicates(); len(dups) > 0 {
+				t.Errorf("duplicate effects after kill at boundary %d: %v", boundary, dups)
+			}
+			if got := len(gh.created); got != wantEffects {
+				t.Errorf("performed %d effects across both attempts, want exactly %d (created: %v)",
+					got, wantEffects, gh.created)
+			}
+
+			// (b) SAME TERMINAL VERDICT as the unkilled control.
+			if verdict != controlVerdict {
+				t.Errorf("verdict = %q, want %q", verdict, controlVerdict)
+			}
+			if recovered.Status != StatusCompleted {
+				t.Errorf("status = %q, want %q", recovered.Status, StatusCompleted)
+			}
+			// The set of landed effects must match the control exactly. Refs
+			// are position-derived in the fake, and an interrupted run
+			// performs the same effects in the same order, so the summaries
+			// are directly comparable.
+			if got := recovered.Journal.Summary(); got != controlSummary {
+				t.Errorf("effect summary diverged from control.\n got:\n%s\nwant:\n%s", got, controlSummary)
+			}
+
+			// No operation may be left unsettled once the turn completes.
+			if amb := recovered.Journal.Ambiguous(); len(amb) > 0 {
+				t.Errorf("%d operations left ambiguous after completion: %+v", len(amb), amb)
+			}
+
+			// (c) NO CREDENTIAL IN THE PERSISTED ARTIFACT — asserted
+			// separately and more thoroughly in
+			// TestReplayPersistedArtifactCarriesNoCredential.
+			if strings.Contains(string(p.saved), fakeToken) {
+				t.Error("persisted artifact contains an unscrubbed credential")
+			}
+		})
+	}
+}
+
+// TestReplayReconcilesAmbiguousIntent proves the mechanism that makes the
+// hardest boundary safe: a death AFTER the effect landed but BEFORE the
+// outcome was recorded. The journal cannot know locally whether the effect
+// happened, so it must ask the remote — and must not replay.
+func TestReplayReconcilesAmbiguousIntent(t *testing.T) {
+	ctx := context.Background()
+	gh := newFakeGitHub()
+	env := newEnv()
+	op := OpIntent{Kind: OpComment, Repo: testRepo, Target: testIssue, Body: "hello"}
+
+	// Hand-construct the ambiguous state: intent journaled, effect performed
+	// remotely, outcome never recorded. This is exactly what a crash in the
+	// window between step 5 and step 6 of the protocol leaves behind.
+	key := DeriveIdempotencyKey(env.SessionID, op)
+	env.Journal.RecordIntent(key, op, env.CreatedAt)
+	if _, err := gh.Perform(ctx, op); err != nil {
+		t.Fatalf("seed effect: %v", err)
+	}
+	if got := gh.calls[effectID(op)]; got != 1 {
+		t.Fatalf("seed: expected 1 remote call, got %d", got)
+	}
+
+	x := &JournaledExecutor{Sink: gh, Reconciler: gh, Persister: &killablePersister{}}
+	res, err := x.Do(ctx, &env, op)
+	if err != nil {
+		t.Fatalf("Do on ambiguous entry: %v", err)
+	}
+
+	if gh.reconcileCalls == 0 {
+		t.Error("reconciliation never ran; the ambiguous window was resolved by guesswork")
+	}
+	if got := gh.calls[effectID(op)]; got != 1 {
+		t.Errorf("effect performed %d times, want exactly 1 — the pre-crash effect was replayed", got)
+	}
+	if res.ExternalRef == "" {
+		t.Error("expected the reconciled external ref to be returned")
+	}
+	entry, ok := env.Journal.Lookup(key)
+	if !ok || !entry.Done() {
+		t.Errorf("journal entry not settled after reconciliation: %+v", entry)
+	}
+}
+
+// TestReplayNotFoundAfterIntentPerformsEffect is the counterpart positive
+// control: an ambiguous entry whose effect did NOT land must be performed on
+// re-entry. Without this, a journal that simply skipped every ambiguous entry
+// would pass the exactly-once test while silently dropping work — the
+// invisible failure mode.
+func TestReplayNotFoundAfterIntentPerformsEffect(t *testing.T) {
+	ctx := context.Background()
+	gh := newFakeGitHub()
+	env := newEnv()
+	op := OpIntent{Kind: OpComment, Repo: testRepo, Target: testIssue, Body: "never landed"}
+
+	key := DeriveIdempotencyKey(env.SessionID, op)
+	env.Journal.RecordIntent(key, op, env.CreatedAt)
+
+	x := &JournaledExecutor{Sink: gh, Reconciler: gh, Persister: &killablePersister{}}
+	if _, err := x.Do(ctx, &env, op); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if got := gh.calls[effectID(op)]; got != 1 {
+		t.Errorf("effect performed %d times, want exactly 1 — an unlanded effect must be performed on re-entry", got)
+	}
+	entry, _ := env.Journal.Lookup(key)
+	if !entry.Done() {
+		t.Errorf("entry not settled: %+v", entry)
+	}
+}
+
+// TestReplayPersistedArtifactCarriesNoCredential is acceptance criterion (c):
+// the durable artifact that a re-entering process (or another spoke) reads
+// must contain no plaintext credential, including in the journal fields added
+// by stage 2.
+func TestReplayPersistedArtifactCarriesNoCredential(t *testing.T) {
+	ctx := context.Background()
+	gh := newFakeGitHub()
+	p := &killablePersister{}
+	env := newEnv()
+
+	// Seed the transcript and the journal with credential-shaped strings in
+	// every field that stage 2 added to the persisted surface.
+	env.AddMessage(RoleUser, "clone with "+fakeToken)
+	env.Journal.Entries = append(env.Journal.Entries, JournalEntry{
+		IdempotencyKey: "v1-deadbeef",
+		Kind:           OpPush,
+		Status:         OpFailed,
+		Repo:           testRepo,
+		Target:         "branch-" + fakeToken,
+		ExternalRef:    "https://x-access-token:" + fakeToken + "@github.com/o/r",
+		Error:          "remote rejected: bad credentials for " + fakeToken,
+	})
+
+	x := &JournaledExecutor{Sink: gh, Reconciler: gh, Persister: p}
+	if _, err := runWorkload(ctx, x, &env); err != nil {
+		t.Fatalf("workload: %v", err)
+	}
+
+	if p.saved == nil {
+		t.Fatal("nothing persisted")
+	}
+	artifact := string(p.saved)
+
+	// Positive control: the in-memory envelope really does carry the secret,
+	// so a passing assertion below is meaningful.
+	inMemory := env.Clone()
+	foundInMemory := false
+	for _, e := range inMemory.Journal.Entries {
+		if strings.Contains(e.Error, fakeToken) || strings.Contains(e.ExternalRef, fakeToken) {
+			foundInMemory = true
+		}
+	}
+	if !foundInMemory {
+		t.Fatal("positive control failed: fixture lost the secret before persistence")
+	}
+
+	if strings.Contains(artifact, fakeToken) {
+		t.Error("persisted artifact contains a plaintext credential")
+	}
+	if !strings.Contains(artifact, "[REDACTED]") {
+		t.Error("expected redaction markers in the persisted artifact")
+	}
+
+	// The scrubbed artifact must still be a usable resume point: keys must
+	// survive scrubbing intact, or re-entry would fail to match and replay.
+	restored, err := ParseEnvelope(p.saved)
+	if err != nil {
+		t.Fatalf("parse scrubbed artifact: %v", err)
+	}
+	for _, op := range workloadOps() {
+		key := DeriveIdempotencyKey(testSession, op)
+		entry, ok := restored.Journal.Lookup(key)
+		if !ok {
+			t.Errorf("idempotency key %s missing after scrub — re-entry would replay %s", key, op.Kind)
+			continue
+		}
+		if !entry.Done() {
+			t.Errorf("entry for %s not settled in the scrubbed artifact", op.Kind)
+		}
+	}
+}
+
+// TestIdempotencyKeyStability locks the two properties the whole design rests
+// on: keys are stable across processes, and distinct effects get distinct keys.
+func TestIdempotencyKeyStability(t *testing.T) {
+	base := OpIntent{Kind: OpComment, Repo: testRepo, Target: testIssue, Body: "hello", ToolCallID: "tc-1"}
+
+	// Stable: same semantic effect, recomputed, yields the same key.
+	if a, b := DeriveIdempotencyKey(testSession, base), DeriveIdempotencyKey(testSession, base); a != b {
+		t.Errorf("key not stable across recomputation: %s vs %s", a, b)
+	}
+
+	// Stable across a DIFFERENT tool call ID: a re-entry that re-runs
+	// inference gets a fresh call ID for the same semantic effect, and that
+	// must not change the key.
+	reentered := base
+	reentered.ToolCallID = "tc-99-fresh-after-reentry"
+	if a, b := DeriveIdempotencyKey(testSession, base), DeriveIdempotencyKey(testSession, reentered); a != b {
+		t.Error("key changed with ToolCallID; re-entry after re-inference would replay the effect")
+	}
+
+	// Distinct: every field that locates or defines the effect must move it.
+	variants := map[string]OpIntent{
+		"kind":   {Kind: OpLabel, Repo: base.Repo, Target: base.Target, Body: base.Body},
+		"repo":   {Kind: base.Kind, Repo: "other/repo", Target: base.Target, Body: base.Body},
+		"target": {Kind: base.Kind, Repo: base.Repo, Target: "9999", Body: base.Body},
+		"body":   {Kind: base.Kind, Repo: base.Repo, Target: base.Target, Body: "different"},
+	}
+	baseKey := DeriveIdempotencyKey(testSession, base)
+	for name, v := range variants {
+		if DeriveIdempotencyKey(testSession, v) == baseKey {
+			t.Errorf("key collision: %s change did not alter the key", name)
+		}
+	}
+
+	// Session-scoped: two agents doing the identical thing are distinct ops.
+	if DeriveIdempotencyKey("other-session", base) == baseKey {
+		t.Error("key collision across sessions; one agent's effect would suppress another's")
+	}
+
+	// Field-boundary safety: ("ab","c") must not hash like ("a","bc").
+	x := DeriveIdempotencyKey(testSession, OpIntent{Kind: OpComment, Repo: "ab", Target: "c"})
+	y := DeriveIdempotencyKey(testSession, OpIntent{Kind: OpComment, Repo: "a", Target: "bc"})
+	if x == y {
+		t.Error("field-boundary collision: concatenation is ambiguous")
+	}
+}
+
+// TestIntentIsPersistedBeforeEffect locks the ordering that the entire
+// guarantee rests on: the OpIntended record must reach durable storage BEFORE
+// the effect is attempted. If the effect is performed first, a crash in that
+// window leaves no journal trace at all, and re-entry replays blind.
+//
+// Reconciliation would normally mask this — the remote lookup finds the orphan
+// effect and adopts it — so this test runs WITHOUT a Reconciler, which is also
+// the honest configuration for any effect that has no queryable surrogate
+// (a push, a bare comment on a busy thread). Without the ordering, that class
+// of effect duplicates.
+func TestIntentIsPersistedBeforeEffect(t *testing.T) {
+	ctx := context.Background()
+	gh := newFakeGitHub()
+	op := OpIntent{Kind: OpPush, Repo: testRepo, Target: testBranch, Body: "abc123"}
+
+	// Kill at the first boundary. With correct ordering that boundary is the
+	// intent write, so the effect is never performed on attempt 1.
+	p := &killablePersister{killAt: 1}
+	env := newEnv()
+	x := &JournaledExecutor{Sink: gh, Persister: p} // no Reconciler, deliberately
+
+	if _, err := x.Do(ctx, &env, op); !errors.Is(err, ErrKilled) {
+		t.Fatalf("attempt 1: want ErrKilled, got %v", err)
+	}
+	if got := gh.calls[effectID(op)]; got != 0 {
+		t.Fatalf("effect performed %d times before its intent was durable; "+
+			"a crash here is an unjournaled write and re-entry cannot detect it", got)
+	}
+
+	// Re-enter and complete.
+	p.killAt = 0
+	recovered := newEnv()
+	if p.saved != nil {
+		var err error
+		if recovered, err = ParseEnvelope(p.saved); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+	}
+	if _, err := x.Do(ctx, &recovered, op); err != nil {
+		t.Fatalf("re-entry: %v", err)
+	}
+	if got := gh.calls[effectID(op)]; got != 1 {
+		t.Errorf("effect performed %d times across both attempts, want exactly 1", got)
+	}
+}
+
+// TestReplayWithoutReconcilerStillNeverDuplicatesSettledEffects runs the full
+// kill table with NO reconciler, isolating what the local journal alone
+// guarantees. Settled effects are still protected by the journal; the
+// post-effect/pre-settle window is the one that genuinely needs the remote
+// (proven by TestReplayReconcilesAmbiguousIntent), so here we assert the
+// weaker but still essential property: no effect is performed more than twice,
+// and every already-settled effect is skipped outright.
+func TestReplayWithoutReconcilerStillNeverDuplicatesSettledEffects(t *testing.T) {
+	ctx := context.Background()
+	for boundary := 1; boundary <= 8; boundary++ {
+		t.Run(fmt.Sprintf("boundary_%02d", boundary), func(t *testing.T) {
+			gh := newFakeGitHub()
+			p := &killablePersister{killAt: boundary}
+			env := newEnv()
+			x := &JournaledExecutor{Sink: gh, Persister: p} // no Reconciler
+
+			if _, err := runWorkload(ctx, x, &env); !errors.Is(err, ErrKilled) {
+				t.Fatalf("want ErrKilled, got %v", err)
+			}
+			recovered := newEnv()
+			if p.saved != nil {
+				var err error
+				if recovered, err = ParseEnvelope(p.saved); err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+			}
+			p.killAt = 0
+			if _, err := runWorkload(ctx, x, &recovered); err != nil {
+				t.Fatalf("re-entry: %v", err)
+			}
+
+			// Odd boundaries are intent writes: nothing landed, so re-entry is
+			// clean and exactly-once holds even without a reconciler.
+			if boundary%2 == 1 {
+				if dups := gh.duplicates(); len(dups) > 0 {
+					t.Errorf("kill on an intent boundary must never duplicate, got %v", dups)
+				}
+			}
+			// No effect may ever be performed more than twice: at most one
+			// pre-crash attempt plus one re-entry attempt. More than that
+			// means the journal is not suppressing settled effects at all.
+			for id, n := range gh.calls {
+				if n > 2 {
+					t.Errorf("effect %s performed %d times; settled effects are not being suppressed", id, n)
+				}
+			}
+		})
+	}
+}
+
+// TestPendingApprovalOpShape asserts that a suspended operator-approval wait
+// is representable as a journaled, re-enterable position (#4000). Shape only:
+// no approvals UI, inbox, or routing is built here.
+func TestPendingApprovalOpShape(t *testing.T) {
+	ctx := context.Background()
+	env := newEnv()
+	x := &JournaledExecutor{Sink: newFakeGitHub(), Persister: &killablePersister{}}
+
+	in := OpIntent{Repo: testRepo, Target: testIssue, Body: "delete the production namespace", ToolCallID: "tc-danger"}
+	entry, err := x.SuspendForApproval(ctx, &env, in)
+	if err != nil {
+		t.Fatalf("SuspendForApproval: %v", err)
+	}
+	if entry.Kind != OpApprovalWait {
+		t.Errorf("kind = %q, want %q", entry.Kind, OpApprovalWait)
+	}
+	if !entry.Ambiguous() {
+		t.Error("a pending approval must sit in the unsettled state until an operator decides")
+	}
+
+	// Re-entering while still pending must not duplicate the wait.
+	again, err := x.SuspendForApproval(ctx, &env, in)
+	if err != nil {
+		t.Fatalf("re-entry SuspendForApproval: %v", err)
+	}
+	if again.IdempotencyKey != entry.IdempotencyKey {
+		t.Error("re-entry minted a second approval wait for the same request")
+	}
+	if n := len(env.Journal.Entries); n != 1 {
+		t.Errorf("journal has %d entries, want 1", n)
+	}
+
+	// An approval wait performs no external effect.
+	if env.Journal.EffectCount() != 0 {
+		t.Error("an approval wait must not count as a landed effect")
+	}
+
+	// It is not routable through Do, which is for side-effectful ops only.
+	if _, err := x.Do(ctx, &env, OpIntent{Kind: OpApprovalWait}); err == nil {
+		t.Error("Do must reject a non-side-effectful op kind")
+	}
+}

--- a/src/pkg/turn/types.go
+++ b/src/pkg/turn/types.go
@@ -59,21 +59,27 @@ const (
 // Because all execution state lives in the envelope, an agent session can be persisted
 // to disk, checkpointed, or handed off across processes / spokes between turns.
 type SessionEnvelope struct {
-	SessionID        string                     `json:"session_id"`
-	Agent            toolapprove.AgentIdentity  `json:"agent"`
-	ACMMLevel        int                        `json:"acmm_level"`
-	TurnCount        int                        `json:"turn_count"`
-	MaxTurns         int                        `json:"max_turns"`
-	Status           SessionStatus              `json:"status"`
-	Messages         []Message                  `json:"messages"`
-	WorkingRepo      string                     `json:"working_repo,omitempty"`
-	WorkingBranch    string                     `json:"working_branch,omitempty"`
-	BeadID           string                     `json:"bead_id,omitempty"`
-	Variables        map[string]string          `json:"variables,omitempty"`
-	Subagents        map[string]string          `json:"subagents,omitempty"` // subagent sessionID -> status
-	PendingApprovals []PendingApproval          `json:"pending_approvals,omitempty"`
-	CreatedAt        time.Time                  `json:"created_at"`
-	UpdatedAt        time.Time                  `json:"updated_at"`
+	SessionID        string                    `json:"session_id"`
+	Agent            toolapprove.AgentIdentity `json:"agent"`
+	ACMMLevel        int                       `json:"acmm_level"`
+	TurnCount        int                       `json:"turn_count"`
+	MaxTurns         int                       `json:"max_turns"`
+	Status           SessionStatus             `json:"status"`
+	Messages         []Message                 `json:"messages"`
+	WorkingRepo      string                    `json:"working_repo,omitempty"`
+	WorkingBranch    string                    `json:"working_branch,omitempty"`
+	BeadID           string                    `json:"bead_id,omitempty"`
+	Variables        map[string]string         `json:"variables,omitempty"`
+	Subagents        map[string]string         `json:"subagents,omitempty"` // subagent sessionID -> status
+	PendingApprovals []PendingApproval         `json:"pending_approvals,omitempty"`
+	// Journal records every side-effectful operation attempted in this session
+	// with its idempotency key and outcome (RFC #4002 stage 2). It travels
+	// inside the envelope precisely so that re-entry — in a fresh process,
+	// after a crash, or on another spoke — can determine "already done"
+	// without re-performing the effect. See journal.go.
+	Journal   Journal   `json:"journal,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // PendingApproval holds state for a tool call paused awaiting operator approval.


### PR DESCRIPTION
## Summary

Stage 2 of the #4002 RFC: **the journaled, re-entrant turn prototype with a kill-mid-turn replay test** — the milestone the maintainer position named as the gate before any handoff work. Closes hard problem 1 (tool-execution idempotency) and completes hard problem 3's scrub boundary. Hard problem 2 (handoff reusing the claim machinery) remains open and untouched, by design.

Base is `v5`; `v4` is not touched. New files are additive inside the existing `pkg/turn` package to keep the conflict surface minimal as v5 tracks v4 merges.

**Prototype only.** Nothing in the live agent loop or the running contribute path constructs any of this — `Runner.Step` is deliberately not wired to the journal. It is exercised entirely by tests.

## 1. Idempotency-key design

```
key = v1 + sha256( version | session_id | kind | repo | target | body )[:32]
```

Two constraints in tension: **stable across re-entry** (recomputable in a fresh process from the persisted envelope alone — so no timestamps, nonces, PIDs, or attempt counters) and **unique per logical effect** (collision is the worse failure: a duplicate PR is visible, a suppressed second comment is silent under-performance).

`session_id` scopes the key so two agents posting an identical comment are distinct ops, and it survives handoff. `body` is the content hash that separates "post comment A" from "post comment B" while making a *replay* of A recognizable. Fields are length-prefixed so `("ab","c")` can't hash like `("a","bc")`.

`ToolCallID` is **deliberately excluded** — model call IDs are re-minted on every inference, so a re-entry that re-runs the LLM step would produce a new ID for a semantically identical effect and defeat the whole mechanism. Recorded for traceability, never keyed on.

On the "natural GitHub idempotency surrogate": GitHub exposes no idempotency-key header on these writes. The surrogates (find open PR by head branch, match comment bodies) are *query-after-the-fact* — they cost a round trip, are eventually consistent, and can't be computed offline. So they're used as **reconciliation**, not as the key. This mirrors what `pkg/github` already does: `CreatePR` dedupes on head branch and reports reuse via `CreatePRResult.AlreadyExisted`; `EffectResult.AlreadyExisted` reuses that vocabulary rather than inventing a parallel one.

**Lineage** (cited in the design notes): at-least-once delivery over non-idempotent GitHub writes is the duplicate-work class eradicated one layer at a time in #3768 → #3792 → #3980 → #3987. Each was the same bug — a task re-entering a pool and re-performing an effect whose completion wasn't durably recorded. This journal generalizes it: **record the effect, not the attempt.**

## 2. Scrub boundary — verdict

**The pre-existing boundary was correct; its coverage was incomplete, and this widens it.**

`ToJSON`/`ToPrettyJSON` were already the single persistence boundary routing content through `logscrub` (the canonical scrubber), and `Clone`/`Step` correctly do *not* scrub. Unchanged. What stage 2 added is a new secret-bearing surface the existing scrub didn't cover — the journal:

| Field | Exposure |
| :--- | :--- |
| `Error` | Raw remote error text — **the most common accidental credential channel**; git/gh echo authenticated URLs into failures |
| `ExternalRef` | Can carry `x-access-token:…@github.com` |
| `Target` | Branch name minted from a token-bearing remote |
| `IdempotencyKey` | A hash — **deliberately left untouched**; scrubbing it would break re-entry matching and cause replay |

`OpIntent.Body` feeds the key but is never stored, so scrubbing can't destabilize a key. The test asserts both halves: no plaintext credential in the artifact, *and* every key still resolving after the scrub.

## 3. What the replay test proves

`TestKillMidTurnReplayExactlyOnce` is table-driven over **all 8 operation boundaries** of a contribute-shaped turn (comment → push → PR create → label; each op = intent persist + settle persist). The persister fails the write at boundary N, so death occurs *before* that envelope reaches disk — the harder case. Only serialized JSON crosses the simulated process boundary, so no in-memory state can leak into recovery.

| Boundary | Position | What re-entry must do |
| :--- | :--- | :--- |
| 1,3,5,7 | intent write, pre-effect | nothing landed → perform normally |
| 2,4,6,8 | settle write, post-effect | effect landed but unrecorded → **reconcile, not replay** — the duplicate-PR window |

Per case: **(a)** exactly-once effects counted at the fake GitHub surface (actual remote calls, not the journal's own bookkeeping); **(b)** same terminal verdict (`shipped`) and an effect summary identical to the control, nothing left ambiguous; **(c)** no credential in the persisted artifact.

**Positive control**: an unkilled run establishes the reference set and fails if it produces no effects or duplicates — so kill cases can't pass vacuously. `TestReplayNotFoundAfterIntentPerformsEffect` is the anti-vacuity control for the opposite direction: a journal that merely *skipped* ambiguous entries would pass exactly-once while silently dropping work.

**Mutation-checked**, per the audit 6/7 lesson that findings hide behind tests passing for the wrong reason. Broke the implementation four ways: removed the already-done short-circuit (12 assertions fire); removed reconciliation (reproduces the duplicate-PR bug exactly, at every even boundary); treated ambiguous as always-landed (caught by the anti-vacuity control); performed the effect before persisting intent. **The fourth mutant initially survived** — reconciliation masked it — which is why `TestIntentIsPersistedBeforeEffect` exists, running deliberately without a reconciler.

## 4. Pending-approval op shape (#4000)

`OpApprovalWait` + `SuspendForApproval`: a turn blocked on an operator decision is a **journaled, re-enterable position** rather than a blocked goroutine. That's precisely why re-entrancy came first — an approval wait *is* a suspended turn.

Shape only. No approvals UI, inbox, or routing. The wait performs no external effect, never counts as a landed effect, is rejected by `Do`, and re-entering while pending doesn't mint a second wait. Consistent with the L6 throughput contract: `auto-approve` resolves synchronously in-loop and never enters this lane.

## 5. Residual — what is still NOT re-entrant

Recorded honestly in design Section 5a, because the value here is knowing where the guarantee stops:

1. **The LLM call is not journaled** — a crash between inference and the first op re-runs inference. Costs tokens, not correctness, but a non-deterministic model may pick a different tool call, so recovery can diverge in *plan* even while landed effects stay protected.
2. **Reconciliation is only as good as its query** — a push (force-push can hide it) or a comment on a busy thread has no reliable surrogate. There, exactly-once degrades to at-most-once-per-boundary.
3. **Persistence assumed atomic** — a real `Persister` needs tmp-write + `os.Rename` (the pattern the no-work-verdict ledger already uses); torn writes unhandled.
4. **`Runner.Step` doesn't use the journal** — including the `PendingApprovals` re-execution gap the RFC already names. Phase 2.
5. **No claim integration** — the journal makes re-entry safe, not *concurrency* safe. Two processes racing on one envelope is out of scope (hard problem 2).
6. **The journal grows unboundedly** and is not compacted, unlike `Messages`.

## Testing

`go vet` and `go test -race` clean on the three touched packages. `pkg/turn` coverage 90.3%.

Related: #4002 (RFC), #4000 (tool approval), #4001 (hooks). Builds on #4020 and #4036.
