### PR TITLE
🧹 fix(security-audit-9): correct stale DENYLIST comment (L1) and make SSRF-guard tests hermetic (L3)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -200,19 +200,31 @@ for arg in "${args[@]}"; do
   esac
 done
 
-# ── GENERAL COMMAND-SURFACE ALLOWLIST (#3840, F6/F7 residual) ────────────────
+# ── GENERAL COMMAND-SURFACE ALLOWLIST (#3840 F6/F7 residual; added in #3854) ─
 #
-# Everything below this point is a DENYLIST: each gate names a specific thing an
-# agent must not do (`pr merge`, `issue create`, mutating `gh api`, ...) and the
-# script ends in a bare `exec "$REAL_GH" "$@"`. So any subcommand nobody thought
-# to enumerate reached real GitHub with the App token attached. That is the same
-# failure shape as the mode `case` with no default arm (fixed in ce9d19aa):
-# unenumerated input takes the permissive branch.
+# WHAT THIS GATE IS (read this before touching `_gh_surface_allowed`):
+# `_gh_surface_allowed` below is a deny-by-default ALLOWLIST, not a denylist.
+# A subcommand/action pair reaches real `gh` only if it is EXPLICITLY named in
+# the `case` arms; anything unenumerated is rejected. Removing an arm therefore
+# BLOCKS a verb, and the way to permit a new verb is to ADD an arm — never to
+# "add it to a deny list". Do not restructure this into a denylist: that is the
+# exact bug #3854 fixed, and audit finding L1 (2026-08-17 security review)
+# flagged the stale wording here for misleading a future maintainer into
+# weakening the gate.
 #
-# This was not theoretical. Against the stub harness, on v4 @ c9ea2cc8, EVERY
-# one of these reached gh with rc=0 — including in NO_GITHUB mode, the most
-# restrictive mode there is, because the mode gates only ever inspect
-# `subcmd = issue|pr`:
+# WHY (historical, pre-#3854): every gate FURTHER BELOW this block is still a
+# denylist — each names a specific thing an agent must not do (`pr merge`,
+# `issue create`, mutating `gh api`, ...) and the script ends in a bare
+# `exec "$REAL_GH" "$@"`. Before this allowlist existed, any subcommand nobody
+# thought to enumerate reached real GitHub with the App token attached. That is
+# the same failure shape as the mode `case` with no default arm (fixed in
+# ce9d19aa): unenumerated input takes the permissive branch.
+#
+# This was not theoretical. Against the stub harness, on v4 @ c9ea2cc8 (i.e.
+# BEFORE the allowlist below landed in #3854), EVERY one of these reached gh
+# with rc=0 — including in NO_GITHUB mode, the most restrictive mode there is,
+# because the mode gates only ever inspect `subcmd = issue|pr`. All of them are
+# rejected today because none is on the allowlist:
 #
 #   NO_GITHUB     gh auth token                 → reached gh  (exfiltrates the token)
 #   NO_GITHUB     gh secret set FOO --body bar  → reached gh  (writes Actions secrets)

--- a/src/pkg/dashboard/api_coverage_test.go
+++ b/src/pkg/dashboard/api_coverage_test.go
@@ -304,6 +304,9 @@ func TestHandleKnowledgeSubsList_WithKnowledge(t *testing.T) {
 }
 
 func TestHandleKnowledgeSubsAdd_WithKnowledge(t *testing.T) {
+	// L3: keep this hermetic — the subscription URL below must classify as
+	// public without an external DNS lookup.
+	stubPrivateURLResolver(t, "example.com")
 	s, _, wiki := apiServerWithKnowledge(t)
 	defer wiki.Close()
 
@@ -325,6 +328,8 @@ func TestHandleKnowledgeSubsAdd_MissingURL(t *testing.T) {
 }
 
 func TestHandleKnowledgeSubsAdd_DefaultLayer(t *testing.T) {
+	// L3: keep this hermetic — see stubPrivateURLResolver.
+	stubPrivateURLResolver(t, "new.com")
 	s, _, wiki := apiServerWithKnowledge(t)
 	defer wiki.Close()
 
@@ -336,6 +341,8 @@ func TestHandleKnowledgeSubsAdd_DefaultLayer(t *testing.T) {
 }
 
 func TestHandleKnowledgeSubsRemove_WithKnowledge(t *testing.T) {
+	// L3: keep this hermetic — see stubPrivateURLResolver.
+	stubPrivateURLResolver(t, "example.com")
 	s, _, wiki := apiServerWithKnowledge(t)
 	defer wiki.Close()
 
@@ -2330,6 +2337,8 @@ func TestHandleIssueCosts_WithCollector(t *testing.T) {
 // ---- handleKnowledgeSubsAdd with all fields ----
 
 func TestHandleKnowledgeSubsAdd_AllFields(t *testing.T) {
+	// L3: keep this hermetic — see stubPrivateURLResolver.
+	stubPrivateURLResolver(t, "example.com")
 	s, _, wiki := apiServerWithKnowledge(t)
 	defer wiki.Close()
 	rec := doPost(s, "/api/knowledge/subscriptions", map[string]string{

--- a/src/pkg/dashboard/private_url_resolver_testhelper_test.go
+++ b/src/pkg/dashboard/private_url_resolver_testhelper_test.go
@@ -1,0 +1,75 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Audit finding L3 (2026-08-17 security review): several knowledge-subscription
+// tests in this package asserted the NON-private branch of isPrivateURL using
+// public hostnames such as "example.com". isPrivateURL resolves DNS and FAILS
+// CLOSED when resolution errors — correct, intended production behaviour — so
+// those tests passed only on a machine with working external DNS and failed
+// closed in a network-isolated CI sandbox. The tests were non-hermetic; the
+// guard was not wrong. The fix is to give the test control of resolution, never
+// to soften the guard.
+//
+// stubPrivateURLResolver installs a deterministic, in-process resolver for the
+// duration of one test and restores the production resolver afterwards. It
+// resolves any host the caller lists to publicTestResolvedAddr — a
+// documentation-range address deliberately OUTSIDE every private prefix
+// isPrivateURL blocks — so a public hostname is classified public without a
+// single external DNS query.
+//
+// Any host NOT listed returns an error, which isPrivateURL treats as private
+// (fail-closed), so a test that starts touching an unexpected hostname fails
+// loudly rather than silently inheriting a permissive answer. Production is
+// untouched: privateURLResolver stays defaultHostResolver everywhere except
+// inside a test that calls this helper. Mirrors the identical helper in
+// pkg/hub.
+func stubPrivateURLResolver(t *testing.T, publicHosts ...string) {
+	t.Helper()
+
+	allowed := make(map[string]struct{}, len(publicHosts))
+	for _, h := range publicHosts {
+		allowed[strings.ToLower(h)] = struct{}{}
+	}
+
+	orig := privateURLResolver
+	privateURLResolver = func(_ context.Context, host string) ([]string, error) {
+		if _, ok := allowed[strings.ToLower(host)]; ok {
+			return []string{publicTestResolvedAddr}, nil
+		}
+		return nil, fmt.Errorf("stubPrivateURLResolver: host %q not registered as public in this test", host)
+	}
+	t.Cleanup(func() { privateURLResolver = orig })
+}
+
+// publicTestResolvedAddr is the address stubPrivateURLResolver returns for
+// hosts a test declares public. 203.0.113.0/24 is TEST-NET-3 (RFC 5737),
+// reserved for documentation, so it is guaranteed never to be routed and never
+// to collide with any private range isPrivateURL blocks.
+const publicTestResolvedAddr = "203.0.113.10"
+
+// TestStubPrivateURLResolverIsFailClosed is the positive control for the helper
+// above: it proves the stub does not accidentally make isPrivateURL permissive.
+func TestStubPrivateURLResolverIsFailClosed(t *testing.T) {
+	stubPrivateURLResolver(t, "registered.example")
+
+	if isPrivateURL(context.Background(), "https://registered.example") {
+		t.Error("registered public host classified private; stub resolver is not wired in")
+	}
+	if !isPrivateURL(context.Background(), "https://unregistered.example") {
+		t.Error("unregistered host must fail closed (private), got public")
+	}
+	// Literal private addresses are rejected before resolution ever happens,
+	// so the stub cannot whitelist them.
+	if !isPrivateURL(context.Background(), "https://127.0.0.1") {
+		t.Error("loopback literal must stay private with the stub installed")
+	}
+	if !isPrivateURL(context.Background(), "https://192.168.1.1") {
+		t.Error("RFC1918 literal must stay private with the stub installed")
+	}
+}

--- a/src/pkg/hub/hub_coverage_boost_test.go
+++ b/src/pkg/hub/hub_coverage_boost_test.go
@@ -1142,6 +1142,9 @@ func TestHandleContributeStatusNoHive(t *testing.T) {
 }
 
 func TestHandleContributeStatusWithPublicHive(t *testing.T) {
+	// L3: keep this hermetic — the hive's DashboardURL below must classify as
+	// public without an external DNS lookup.
+	stubPrivateURLResolver(t, "example.com")
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()

--- a/src/pkg/hub/hub_test.go
+++ b/src/pkg/hub/hub_test.go
@@ -148,6 +148,14 @@ func TestSecureCompareHub(t *testing.T) {
 }
 
 func TestIsPrivateURL(t *testing.T) {
+	// L3: the public-hostname rows below used to perform a REAL DNS lookup, so
+	// this test failed closed in a network-isolated sandbox. Resolution is now
+	// stubbed for exactly these three hosts; every private row is still decided
+	// by the literal-prefix checks that run before resolution, and an
+	// unregistered host still fails closed (see
+	// TestStubPrivateURLResolverIsFailClosed). The guard itself is unchanged.
+	stubPrivateURLResolver(t, "github.com", "api.github.com", "hive.kubestellar.io")
+
 	tests := []struct {
 		url  string
 		want bool

--- a/src/pkg/hub/private_url_resolver_testhelper_test.go
+++ b/src/pkg/hub/private_url_resolver_testhelper_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Audit finding L3 (2026-08-17 security review): several tests in this package
+// asserted the NON-private branch of isPrivateURL using public hostnames such
+// as "example.com". isPrivateURL resolves DNS and FAILS CLOSED when resolution
+// errors — correct, intended production behaviour — so those tests passed only
+// on a machine with working external DNS and failed closed in a
+// network-isolated CI sandbox. The tests were non-hermetic; the guard was not
+// wrong. The fix is to give the test control of resolution, never to soften the
+// guard.
+//
+// stubPrivateURLResolver installs a deterministic, in-process resolver for the
+// duration of one test and restores the production resolver afterwards. It
+// resolves any host to publicTestResolvedAddr — a documentation-range address
+// that is deliberately OUTSIDE every private prefix isPrivateURL blocks — so a
+// public hostname is classified public without a single external DNS query.
+//
+// It resolves ONLY hosts the caller lists. Any other host returns an error,
+// which isPrivateURL treats as private (fail-closed), so a test that starts
+// touching an unexpected hostname fails loudly instead of silently inheriting a
+// permissive answer. Production is untouched: privateURLResolver is
+// defaultHostResolver everywhere except inside a test that calls this helper.
+func stubPrivateURLResolver(t *testing.T, publicHosts ...string) {
+	t.Helper()
+
+	allowed := make(map[string]struct{}, len(publicHosts))
+	for _, h := range publicHosts {
+		allowed[strings.ToLower(h)] = struct{}{}
+	}
+
+	orig := privateURLResolver
+	privateURLResolver = func(_ context.Context, host string) ([]string, error) {
+		if _, ok := allowed[strings.ToLower(host)]; ok {
+			return []string{publicTestResolvedAddr}, nil
+		}
+		return nil, fmt.Errorf("stubPrivateURLResolver: host %q not registered as public in this test", host)
+	}
+	t.Cleanup(func() { privateURLResolver = orig })
+}
+
+// publicTestResolvedAddr is the address stubPrivateURLResolver returns for
+// hosts a test declares public. 203.0.113.0/24 is TEST-NET-3 (RFC 5737),
+// reserved for documentation, so it is guaranteed never to be routed and never
+// to collide with any private range isPrivateURL blocks.
+const publicTestResolvedAddr = "203.0.113.10"
+
+// TestStubPrivateURLResolverIsFailClosed is the positive control for the helper
+// above: it proves the stub does not accidentally make isPrivateURL permissive.
+// An unregistered host must still be reported private, and the private-prefix
+// checks must still fire even for a host the stub was told is public.
+func TestStubPrivateURLResolverIsFailClosed(t *testing.T) {
+	stubPrivateURLResolver(t, "registered.example")
+
+	if isPrivateURL(context.Background(), "https://registered.example") {
+		t.Error("registered public host classified private; stub resolver is not wired in")
+	}
+	if !isPrivateURL(context.Background(), "https://unregistered.example") {
+		t.Error("unregistered host must fail closed (private), got public")
+	}
+	// Literal private addresses are rejected before resolution ever happens,
+	// so the stub cannot whitelist them.
+	if !isPrivateURL(context.Background(), "https://127.0.0.1") {
+		t.Error("loopback literal must stay private with the stub installed")
+	}
+	if !isPrivateURL(context.Background(), "https://192.168.1.1") {
+		t.Error("RFC1918 literal must stay private with the stub installed")
+	}
+}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -3543,6 +3543,24 @@ func (s *HubServer) handleContributeWSProxy(w http.ResponseWriter, r *http.Reque
 // slow or malicious DNS server cannot block the caller indefinitely.
 const privateURLDNSTimeout = 5 * time.Second
 
+// hostResolver is the DNS seam used by isPrivateURL. Production ALWAYS uses
+// defaultHostResolver — this indirection exists only so tests can supply a
+// deterministic resolution result and stay hermetic in a network-isolated CI
+// sandbox (audit finding L3, 2026-08-17 security review). Tests that override
+// it must restore it via t.Cleanup. The fail-closed contract below (a resolver
+// error means "private") is unchanged and must stay that way: swapping the
+// resolver changes only WHERE answers come from, never how failures are
+// treated. Mirrors the identical seam in pkg/dashboard.
+type hostResolver func(ctx context.Context, host string) ([]string, error)
+
+var privateURLResolver hostResolver = defaultHostResolver
+
+func defaultHostResolver(ctx context.Context, host string) ([]string, error) {
+	resolveCtx, cancel := context.WithTimeout(ctx, privateURLDNSTimeout)
+	defer cancel()
+	return (&net.Resolver{}).LookupHost(resolveCtx, host)
+}
+
 func isPrivateURL(ctx context.Context, rawURL string) bool {
 	for _, scheme := range []string{"https://", "http://", "wss://", "ws://"} {
 		if strings.HasPrefix(rawURL, scheme) {
@@ -3565,10 +3583,7 @@ func isPrivateURL(ctx context.Context, rawURL string) bool {
 	}
 
 	// Resolve hostname to catch DNS names that map to private IPs (DNS rebinding).
-	resolveCtx, cancel := context.WithTimeout(ctx, privateURLDNSTimeout)
-	defer cancel()
-	resolver := &net.Resolver{}
-	addrs, err := resolver.LookupHost(resolveCtx, host)
+	addrs, err := privateURLResolver(ctx, host)
 	if err != nil {
 		// If DNS fails, treat as private (fail-closed) to prevent bypass.
 		return true

--- a/src/pkg/hub/server_engagement_coverage_test.go
+++ b/src/pkg/hub/server_engagement_coverage_test.go
@@ -217,6 +217,9 @@ func TestApplyUserLastActions_SkipsInvalidUsernames(t *testing.T) {
 }
 
 func TestFindContributeHive_ReturnsFirstEligible(t *testing.T) {
+	// L3: keep this hermetic — the eligible hive's public DashboardURL must
+	// resolve without an external DNS lookup.
+	stubPrivateURLResolver(t, "example.com")
 	s := engagementTestHub()
 	s.registry.Hives = []RegistryEntry{
 		{ID: "offline", Online: false, IsPublic: true, DashboardURL: "https://example.com", Owner: "u1"},
@@ -275,6 +278,9 @@ func TestHandleContributeStatus_NoHiveAvailable(t *testing.T) {
 }
 
 func TestHandleContributeStatus_HiveAvailable(t *testing.T) {
+	// L3: keep this hermetic — prod-1's public DashboardURL must resolve
+	// without an external DNS lookup.
+	stubPrivateURLResolver(t, "example.com")
 	s := engagementTestHub()
 	s.registry.Hives = []RegistryEntry{
 		{ID: "prod-1", Name: "ProdHive", Org: "acme", Online: true, IsPublic: true,


### PR DESCRIPTION
Fixes two **low/hygiene** findings from the ninth security audit (`SECURITY-REVIEW-2026-08-17.md`).

> **No production security logic is altered by either change.** L1 is comment-only. L3 changes a call site to go through an injectable variable whose production value is the same resolver as before; `isPrivateURL`'s fail-closed branch is byte-for-byte unchanged in both packages.

> Note on paths: the audit was run at `d89121f5`, before the `v2/` → `src/` rename (#3996). All paths below are translated to their current locations.

---

## L1 — stale "DENYLIST" comment misdescribes an allowlist

`bin/gh-wrapper.sh` (now ~line 203) opened its `_gh_surface_allowed` header with:

> `# Everything below this point is a DENYLIST: ...`

That sentence accurately described the **pre-#3854** state. The code it sits directly above is a **deny-by-default ALLOWLIST**: a subcommand/action pair reaches real `gh` only if explicitly named in a `case` arm. The audit rated this "misleading-maintainer" — a future reader could delete an arm believing they were removing a *deny* entry, when removing an arm actually **blocks** a verb, or could restructure the gate into an actual denylist and reintroduce the exact bug #3854 fixed.

**Changed (comment-only):**
- The header now leads with the allowlist semantics: deny-by-default, only explicitly-allowed surfaces pass, adding a verb means adding an arm, and an explicit "do not restructure this into a denylist" warning citing **#3854** and **finding L1**.
- The denylist narrative is retained but relabelled as historical ("WHY (historical, pre-#3854)"), since every gate *further below* genuinely is still a denylist ending in a bare `exec "$REAL_GH" "$@"` — that context is worth keeping, it just isn't describing this block.
- The exploit table is re-tensed: those commands reached `gh` at `c9ea2cc8` *before* the allowlist landed, and all are rejected today.
- Section header now cites #3854 alongside #3840.

**Verification:** `git diff bin/gh-wrapper.sh` filtered to non-comment lines is **empty** — zero logic changed.

```
$ bash bin/test_gh_wrapper_gates.sh
=== 50 passed, 0 failed ===
```

(The audit cited 46/46; the suite has grown to 50 since `d89121f5`. 0 failures.)

---

## L3 — tests required external DNS and failed closed in isolated CI

`isPrivateURL` resolves DNS and **fails closed** when resolution errors. That is the correct, intended production behaviour and is **not** changed here. The defect was that several tests asserted the *non-private* branch using real public hostnames (`example.com`, `github.com`, …), so they passed only on a machine with working external DNS and failed closed in a network-isolated sandbox. **The tests were non-hermetic; the guard was right.**

I identified the affected tests empirically by forcing every resolution to error (temporary `TestMain` scaffolding, since removed) rather than by grepping for `example.com`. That found **8**, not the 6 the audit listed — the extra two are in the same two clusters and had the same root cause:

| Package | Test |
|---|---|
| `pkg/hub` | `TestHandleContributeStatusWithPublicHive` |
| `pkg/hub` | `TestFindContributeHive_ReturnsFirstEligible` |
| `pkg/hub` | `TestHandleContributeStatus_HiveAvailable` |
| `pkg/hub` | `TestIsPrivateURL` |
| `pkg/dashboard` | `TestHandleKnowledgeSubsAdd_WithKnowledge` |
| `pkg/dashboard` | `TestHandleKnowledgeSubsAdd_DefaultLayer` |
| `pkg/dashboard` | `TestHandleKnowledgeSubsRemove_WithKnowledge` |
| `pkg/dashboard` | `TestHandleKnowledgeSubsAdd_AllFields` |

### Fix — approach 1/2 (inject a resolver). Nothing is skipped.

- **`pkg/dashboard` already had the seam**: `var privateURLResolver hostResolver = defaultHostResolver`. The four tests now drive it. **No production file in `pkg/dashboard` changed at all.**
- **`pkg/hub` had no seam**, so it gained the *identical* one (`hostResolver` / `privateURLResolver` / `defaultHostResolver`), and `isPrivateURL` now calls `privateURLResolver(ctx, host)` instead of constructing `&net.Resolver{}` inline. Same resolver, same 5s `privateURLDNSTimeout`, same fail-closed `if err != nil { return true }`.
- **Shared helper `stubPrivateURLResolver(t, publicHosts...)`** (one per package, `_test.go` only): resolves **only** the hosts a test names to `203.0.113.10` — TEST-NET-3 (RFC 5737), reserved for documentation, guaranteed never routable and outside every private prefix the guard blocks. Any *unnamed* host returns an error, so it **still fails closed** — a test that starts touching an unexpected hostname fails loudly instead of silently inheriting a permissive answer. Restored via `t.Cleanup`.
- **Positive control** `TestStubPrivateURLResolverIsFailClosed` in **both** packages asserts the stub cannot make the guard permissive: an unregistered host stays private, and `127.0.0.1` / `192.168.1.1` literals stay private with the stub installed.

No `t.Skip` was used, so there is **no SSRF coverage loss**.

### How hermeticity was verified

The operator's machine has working DNS, so a green run proves nothing on its own. I verified by **forcing all external resolution to fail** — temporary `TestMain` scaffolding injecting a resolver that unconditionally returns an error, which is strictly harsher than a no-DNS sandbox (it fails instantly, with no host able to resolve):

**Before the fix** (scaffolding on `origin/v4`) — 8 failures, matching the finding:
```
--- FAIL: TestHandleContributeStatusWithPublicHive
--- FAIL: TestIsPrivateURL
--- FAIL: TestFindContributeHive_ReturnsFirstEligible
--- FAIL: TestHandleContributeStatus_HiveAvailable
--- FAIL: TestHandleKnowledgeSubsAdd_WithKnowledge
--- FAIL: TestHandleKnowledgeSubsAdd_DefaultLayer
--- FAIL: TestHandleKnowledgeSubsRemove_WithKnowledge
--- FAIL: TestHandleKnowledgeSubsAdd_AllFields
```

**After the fix**, same scaffolding, all resolution still failing — both packages fully green:
```
ok  github.com/kubestellar/hive/pkg/hub        136.069s
ok  github.com/kubestellar/hive/pkg/dashboard   38.899s
```

The scaffolding was then **removed**; it is not in this branch. Final run on the committed tree with real network:
```
ok  github.com/kubestellar/hive/pkg/hub        123.731s
ok  github.com/kubestellar/hive/pkg/dashboard   39.699s
```

---

## Diff stat

```
 bin/gh-wrapper.sh                              | 34 +++++++++++++++++---------
 src/pkg/dashboard/api_coverage_test.go         |  9 +++++++
 src/pkg/hub/hub_coverage_boost_test.go         |  3 +++
 src/pkg/hub/hub_test.go                        |  8 ++++++
 src/pkg/hub/server.go                          | 23 ++++++++++++++---
 src/pkg/hub/server_engagement_coverage_test.go |  6 +++++
 + src/pkg/hub/private_url_resolver_testhelper_test.go       (new, test-only)
 + src/pkg/dashboard/private_url_resolver_testhelper_test.go (new, test-only)
```

The only non-test production changes are `bin/gh-wrapper.sh` (comments) and the `src/pkg/hub/server.go` resolver seam.

## Not done, deliberately

`isPrivateURL`'s fail-closed behaviour was **not** weakened in either package. Making the tests pass by treating a DNS error as "public" would have converted a hygiene finding into a real SSRF regression.
