### PR TITLE
✨ feat(pause): surface pause provenance — WHO paused WHAT WHEN, everywhere a pause is read

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -150,7 +150,13 @@ const reachStatePath = "/data/reach-state.json"
 // upgrade beat can never report different pictures of the same agent.
 func agentActivityFor(mgr *agent.Manager, name string, proc *agent.AgentProcess) hub.AgentActivity {
 	act := hub.AgentActivity{
-		Paused:         proc.Paused,
+		Paused: proc.Paused,
+		// Pause provenance (#4041): ride WHO/WHY/WHEN to the hub so the
+		// fleet view can tell a deliberate owner quiesce from a malfunction.
+		PausedTrigger:  proc.PausedTrigger,
+		PausedReason:   proc.PausedReason,
+		PausedBy:       proc.PausedBy,
+		PausedAt:       proc.PausedAt,
 		NeedsLogin:     proc.NeedsLogin,
 		LastActivityAt: proc.LastPaneChange,
 		// A missing tmux session is only meaningful for an agent the manager
@@ -3018,16 +3024,15 @@ func main() {
 	}
 	// One visible "hive restarted" marker per boot, so the audit log shows a
 	// restart happened (and at what build) instead of only a burst of
-	// per-agent agent_start rows. Include a count of persisted pauses being
-	// restored so the operator can confirm pause state survived the restart.
-	pausedCount := 0
-	for _, ac := range cfg.EnabledAgents() {
-		if ac.Paused {
-			pausedCount++
-		}
-	}
+	// per-agent agent_start rows. Include the persisted pauses being restored
+	// so the operator can confirm pause state survived the restart — broken
+	// down by trigger, and EXCLUDING agents that are startup-paused by design
+	// (on-demand agents like brainstorm), whose inclusion turned "restoring 9
+	// paused agent(s)" into a false systemic-incident signal on every upgrade
+	// restart of a deliberately owner-quiesced fleet (#4041).
 	dashSrv.AuditLog("system", "hive_restart",
-		fmt.Sprintf("build=%s version=%s; restoring %d paused agent(s)", gitShort, "3.0.0", pausedCount), "")
+		fmt.Sprintf("build=%s version=%s; %s", gitShort, "3.0.0",
+			pausedRestoreDetail(cfg.EnabledAgents(), onDemandFromPack, agentMgr.AllStatuses())), "")
 
 	// Mark the dashboard READY as soon as the HTTP server can serve requests —
 	// which is NOW: config is loaded, GitHub client/App auth are wired, the
@@ -5524,6 +5529,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			LastKick:        proc.LastKick,
 			PausedReason:    proc.PausedReason,
 			PausedTrigger:   proc.PausedTrigger,
+			PausedBy:        proc.PausedBy,
 		}
 		if !proc.PausedAt.IsZero() {
 			t := proc.PausedAt

--- a/src/cmd/hive/pause_provenance_boot_test.go
+++ b/src/cmd/hive/pause_provenance_boot_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/snapshot"
+)
+
+// #4041 boot-side provenance: the persisted actor must survive a restart, and
+// the "restoring N paused agent(s)" boot line must (a) exclude agents that are
+// startup-paused BY DESIGN (on-demand, e.g. brainstorm) and (b) break the
+// remainder down by trigger — the inflated bare count is what made a
+// deliberate owner quiesce read as a fresh systemic event on every upgrade
+// restart of the frostyard fleet.
+
+func TestRestoreAgentRuntimeState_ReplaysPausedBy(t *testing.T) {
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: "testorg", Repos: []string{"r"}},
+		Agents: map[string]config.AgentConfig{
+			"scanner": {Backend: "claude", Enabled: true},
+		},
+	}
+	statePath := filepath.Join(t.TempDir(), "hive-state.json")
+	pausedAt := time.Date(2026, 8, 14, 16, 10, 10, 0, time.UTC)
+	if err := snapshot.SaveState(statePath, &snapshot.PersistedState{
+		Agents: map[string]snapshot.AgentState{
+			"scanner": {
+				Paused:        true,
+				PausedAt:      &pausedAt,
+				PausedTrigger: "dashboard-api",
+				PausedReason:  "manual pause",
+				PausedBy:      "bketelsen",
+			},
+		},
+	}, restoreTestLogger()); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	saved, err := snapshot.LoadState(statePath, restoreTestLogger())
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	m := agent.NewManager(cfg.Agents, restoreTestLogger(), agent.ProjectContext{})
+	restoreAgentRuntimeState(saved, cfg, m, restoreTestLogger())
+
+	proc, err := m.GetStatus("scanner")
+	if err != nil || proc == nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if proc.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q after restart, want %q (actor downgraded to anonymous on restore)", proc.PausedBy, "bketelsen")
+	}
+	if proc.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", proc.PausedTrigger, "dashboard-api")
+	}
+	if !proc.PausedAt.Equal(pausedAt) {
+		t.Errorf("PausedAt = %v, want %v", proc.PausedAt, pausedAt)
+	}
+}
+
+func pausedProc(trigger string) *agent.AgentProcess {
+	return &agent.AgentProcess{Paused: true, PausedTrigger: trigger}
+}
+
+// The frostyard shape: 8 owner-paused staff agents plus the always-startup-
+// paused on-demand brainstorm. The old line said "restoring 9 paused
+// agent(s)"; the new one must say 8, attribute them, and report the by-design
+// one separately.
+func TestPausedRestoreDetail_ExcludesByDesignOnDemand(t *testing.T) {
+	enabled := map[string]config.AgentConfig{}
+	statuses := map[string]*agent.AgentProcess{}
+	staff := []string{"scanner", "quality", "ci-maintainer", "architect", "guide", "sec-check", "strategist", "supervisor"}
+	for _, name := range staff {
+		enabled[name] = config.AgentConfig{Enabled: true, Paused: true}
+		statuses[name] = pausedProc("dashboard-api")
+	}
+	enabled["brainstorm"] = config.AgentConfig{Enabled: true, Paused: true, OnDemand: true}
+	statuses["brainstorm"] = pausedProc("startup")
+	enabled["running-agent"] = config.AgentConfig{Enabled: true}
+
+	got := pausedRestoreDetail(enabled, nil, statuses)
+	want := "restoring 8 paused agent(s) (dashboard-api: 8); 1 on-demand agent(s) startup-paused by design"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "9") {
+		t.Errorf("by-design startup-paused agent leaked into the headline count: %q", got)
+	}
+}
+
+// An agent that is on-demand via its PACK definition (not its own config)
+// must be excluded the same way.
+func TestPausedRestoreDetail_ExcludesPackOnDemand(t *testing.T) {
+	enabled := map[string]config.AgentConfig{
+		"brainstorm": {Enabled: true, Paused: true},
+		"scanner":    {Enabled: true, Paused: true},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"brainstorm": pausedProc("startup"),
+		"scanner":    pausedProc("dashboard-api"),
+	}
+	got := pausedRestoreDetail(enabled, map[string]bool{"brainstorm": true}, statuses)
+	want := "restoring 1 paused agent(s) (dashboard-api: 1); 1 on-demand agent(s) startup-paused by design"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}
+
+// Mixed triggers appear sorted; an agent the manager has no provenance for
+// still counts, under "unknown" — the total must always add up.
+func TestPausedRestoreDetail_BreaksDownByTrigger(t *testing.T) {
+	enabled := map[string]config.AgentConfig{
+		"a": {Enabled: true, Paused: true},
+		"b": {Enabled: true, Paused: true},
+		"c": {Enabled: true, Paused: true},
+		"d": {Enabled: true, Paused: true},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"a": pausedProc("dashboard-api"),
+		"b": pausedProc("dashboard-api"),
+		"c": pausedProc("login-detector"),
+		// "d" missing from statuses entirely.
+	}
+	got := pausedRestoreDetail(enabled, nil, statuses)
+	want := "restoring 4 paused agent(s) (dashboard-api: 2, login-detector: 1, unknown: 1)"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}
+
+func TestPausedRestoreDetail_NothingPaused(t *testing.T) {
+	enabled := map[string]config.AgentConfig{
+		"scanner": {Enabled: true},
+	}
+	got := pausedRestoreDetail(enabled, nil, map[string]*agent.AgentProcess{})
+	want := "restoring 0 paused agent(s)"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}

--- a/src/cmd/hive/state_restore.go
+++ b/src/cmd/hive/state_restore.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 
 	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/config"
@@ -23,6 +26,62 @@ import (
 // swallowed here while "backend override restored" was logged unconditionally,
 // so the operator saw a successful restore of a value that was already gone.
 // Failures are now logged as the failures they are.
+// pausedRestoreDetail builds the "restoring N paused agent(s)" fragment of
+// the boot audit line. Two lessons from #4041 are baked in:
+//
+//   - On-demand agents (agent config on_demand, or on-demand per their pack
+//     definition) are startup-paused BY DESIGN — brainstorm is triggered by
+//     inception only and has never run at boot. Counting them alongside real
+//     restored pauses inflated "restoring 9 paused agent(s)" on a hive whose
+//     owner had paused 8, and that inflated bare count is what made a
+//     deliberate quiesce read as a fresh systemic event on every upgrade
+//     restart. They are reported separately, never in the headline count.
+//   - The bare count says nothing about WHO paused WHAT. The per-trigger
+//     breakdown ("dashboard-api: 8") lets a fleet owner reading logs tell an
+//     owner-initiated mass pause from a login-detector cascade at a glance.
+//
+// statuses carries the manager's post-restore pause provenance; agents
+// missing from it (not yet registered) count under the "unknown" trigger
+// rather than being dropped — the total must always add up.
+func pausedRestoreDetail(enabled map[string]config.AgentConfig, onDemandFromPack map[string]bool, statuses map[string]*agent.AgentProcess) string {
+	restored := 0
+	byDesign := 0
+	byTrigger := map[string]int{}
+	for name, ac := range enabled {
+		if !ac.Paused {
+			continue
+		}
+		if ac.OnDemand || onDemandFromPack[name] {
+			byDesign++
+			continue
+		}
+		restored++
+		trigger := "unknown"
+		if proc, ok := statuses[name]; ok && proc != nil && strings.TrimSpace(proc.PausedTrigger) != "" {
+			trigger = proc.PausedTrigger
+		}
+		byTrigger[trigger]++
+	}
+
+	detail := fmt.Sprintf("restoring %d paused agent(s)", restored)
+	if len(byTrigger) > 0 {
+		triggers := make([]string, 0, len(byTrigger))
+		for t := range byTrigger {
+			triggers = append(triggers, t)
+		}
+		sort.Strings(triggers)
+		parts := make([]string, 0, len(triggers))
+		for _, t := range triggers {
+			parts = append(parts, fmt.Sprintf("%s: %d", t, byTrigger[t]))
+		}
+		detail += " (" + strings.Join(parts, ", ") + ")"
+	}
+	if byDesign > 0 {
+		detail += fmt.Sprintf("; %d on-demand agent(s) startup-paused by design", byDesign)
+	}
+	return detail
+}
+
 func restoreAgentRuntimeState(saved *snapshot.PersistedState, cfg *config.Config, agentMgr *agent.Manager, logger *slog.Logger) {
 	for name, as := range saved.Agents {
 		if _, inConfig := cfg.Agents[name]; !inConfig {
@@ -38,9 +97,12 @@ func restoreAgentRuntimeState(saved *snapshot.PersistedState, cfg *config.Config
 			if trigger == "" {
 				trigger = "state-restore"
 			}
-			_ = agentMgr.Pause(name, trigger, reason)
+			// Replay the acting user too (#4041): without it, every restart
+			// downgraded an owner-attributed pause to an anonymous one, and a
+			// deliberate quiesce read like a malfunction days later.
+			_ = agentMgr.PauseBy(name, trigger, reason, as.PausedBy)
 			if as.PausedAt != nil {
-				agentMgr.SeedPauseState(name, *as.PausedAt, trigger, reason)
+				agentMgr.SeedPauseState(name, *as.PausedAt, trigger, reason, as.PausedBy)
 			}
 		}
 		if as.PinnedCLI != "" {

--- a/src/pkg/agent/agent_unit_test.go
+++ b/src/pkg/agent/agent_unit_test.go
@@ -290,7 +290,7 @@ func TestSeedPauseStateUnit(t *testing.T) {
 	}, slog.Default(), ProjectContext{})
 
 	now := time.Now()
-	m.SeedPauseState("scanner", now, "test-trigger", "test-reason")
+	m.SeedPauseState("scanner", now, "test-trigger", "test-reason", "test-user")
 	m.mu.RLock()
 	agent := m.agents["scanner"]
 	m.mu.RUnlock()

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -119,18 +119,26 @@ var defaultTmuxSocket string
 const BreakerTrigger = "fleet-breaker"
 
 type AgentProcess struct {
-	Name              string
-	ID                string
-	Config            config.AgentConfig
-	State             ProcessState
-	PID               int
-	UID               int
-	StartedAt         *time.Time
-	LastKick          *time.Time
-	Paused            bool
-	PausedAt          time.Time
-	PausedReason      string
-	PausedTrigger     string
+	Name          string
+	ID            string
+	Config        config.AgentConfig
+	State         ProcessState
+	PID           int
+	UID           int
+	StartedAt     *time.Time
+	LastKick      *time.Time
+	Paused        bool
+	PausedAt      time.Time
+	PausedReason  string
+	PausedTrigger string
+	// PausedBy is the acting user behind the pause when one is known — the
+	// authenticated dashboard user for a dashboard-api pause, empty for
+	// system-initiated pauses (login-detector, fleet-breaker, acmm-pack).
+	// It exists because trigger+reason alone made a deliberate owner
+	// quiesce indistinguishable from a malfunction days later (#4041): the
+	// audit log had the actor, but nothing the UI or the fleet view reads
+	// carried it.
+	PausedBy          string
 	PinnedCLI         string
 	PinnedModel       string
 	ModelOverride     string
@@ -4626,6 +4634,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		PausedAt:        a.PausedAt,
 		PausedReason:    a.PausedReason,
 		PausedTrigger:   a.PausedTrigger,
+		PausedBy:        a.PausedBy,
 		PinnedCLI:       a.PinnedCLI,
 		PinnedModel:     a.PinnedModel,
 		ModelOverride:   a.ModelOverride,
@@ -4895,7 +4904,7 @@ var (
 )
 
 const (
-	sharedConfigDesiredMode    = 0o660
+	sharedConfigDesiredMode = 0o660
 	// agyDefaultEffort is the reasoning effort passed alongside agy's --model.
 	// agy requires --effort whenever --model is given and otherwise ignores the
 	// model entirely; "low" is the effort agy defaults to on its own, so this
@@ -6553,7 +6562,18 @@ func (m *Manager) KillSession(name string) error {
 	return nil
 }
 
+// Pause pauses an agent with no attributed acting user — the right call for
+// system-initiated pauses (login-detector, fleet-breaker, acmm-pack, state
+// restore of a pause whose actor is unknown). A pause performed on behalf of
+// a person goes through PauseBy so provenance survives (#4041).
 func (m *Manager) Pause(name, trigger, reason string) error {
+	return m.PauseBy(name, trigger, reason, "")
+}
+
+// PauseBy pauses an agent and records WHO asked for it. `by` is the acting
+// user (the authenticated dashboard user for a dashboard-api pause); empty
+// means "no human actor" — never fabricate one.
+func (m *Manager) PauseBy(name, trigger, reason, by string) error {
 	m.mu.Lock()
 
 	agent, ok := m.agents[name]
@@ -6566,6 +6586,7 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 	agent.PausedAt = time.Now()
 	agent.PausedReason = reason
 	agent.PausedTrigger = trigger
+	agent.PausedBy = by
 	if agent.State == StateRunning {
 		if agent.cancel != nil {
 			agent.cancel()
@@ -6586,6 +6607,7 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 		"name", name,
 		"trigger", trigger,
 		"reason", reason,
+		"by", by,
 		"backend", agent.Config.Backend,
 		"restart_count", agent.RestartCount,
 	)
@@ -6604,13 +6626,14 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 	return nil
 }
 
-func (m *Manager) SeedPauseState(name string, pausedAt time.Time, trigger, reason string) {
+func (m *Manager) SeedPauseState(name string, pausedAt time.Time, trigger, reason, by string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if agent, ok := m.agents[name]; ok {
 		agent.PausedAt = pausedAt
 		agent.PausedTrigger = trigger
 		agent.PausedReason = reason
+		agent.PausedBy = by
 	}
 }
 
@@ -6641,6 +6664,7 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	agent.PausedAt = time.Time{}
 	agent.PausedReason = ""
 	agent.PausedTrigger = ""
+	agent.PausedBy = ""
 	needsRelaunch := agent.State == StatePaused
 	if m.agentSandboxEnabledLocked(agent) {
 		if needsRelaunch {

--- a/src/pkg/agent/manager_coverage2_test.go
+++ b/src/pkg/agent/manager_coverage2_test.go
@@ -1259,7 +1259,7 @@ func TestGetOutput_PrefersPaneOverBuffer(t *testing.T) {
 func TestSeedPauseState_NotFound(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	// Should not panic
-	m.SeedPauseState("nonexistent", time.Now(), "test", "test")
+	m.SeedPauseState("nonexistent", time.Now(), "test", "test", "")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/agent/pause_provenance_test.go
+++ b/src/pkg/agent/pause_provenance_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// #4041: pause provenance — WHO paused WHAT WHEN — must live on the agent
+// state itself, not only in the audit log, or a deliberate owner quiesce is
+// indistinguishable from a malfunction days later.
+
+func provenanceTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return NewManager(map[string]config.AgentConfig{
+		"scanner": {Backend: "claude"},
+	}, discardLogger(), ProjectContext{})
+}
+
+// Positive control: a pause performed on behalf of a person records the actor.
+func TestPauseBy_RecordsActor(t *testing.T) {
+	m := provenanceTestManager(t)
+	if err := m.PauseBy("scanner", "dashboard-api", "manual pause", "bketelsen"); err != nil {
+		t.Fatalf("PauseBy: %v", err)
+	}
+	status, err := m.GetStatus("scanner")
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if !status.Paused {
+		t.Fatal("agent not paused")
+	}
+	if status.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q", status.PausedBy, "bketelsen")
+	}
+	if status.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", status.PausedTrigger, "dashboard-api")
+	}
+	if status.PausedReason != "manual pause" {
+		t.Errorf("PausedReason = %q, want %q", status.PausedReason, "manual pause")
+	}
+	if status.PausedAt.IsZero() {
+		t.Error("PausedAt not set")
+	}
+}
+
+// A system-initiated pause must never fabricate a human actor.
+func TestPause_LeavesActorEmpty(t *testing.T) {
+	m := provenanceTestManager(t)
+	if err := m.Pause("scanner", "login-detector", "login required detected"); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	status, _ := m.GetStatus("scanner")
+	if status.PausedBy != "" {
+		t.Errorf("PausedBy = %q, want empty for a system-initiated pause", status.PausedBy)
+	}
+	if status.PausedTrigger != "login-detector" {
+		t.Errorf("PausedTrigger = %q, want %q", status.PausedTrigger, "login-detector")
+	}
+}
+
+// Resume clears the whole provenance set — stale WHO/WHY/WHEN on a running
+// agent would be worse than none.
+func TestResume_ClearsProvenance(t *testing.T) {
+	m := provenanceTestManager(t)
+	if err := m.PauseBy("scanner", "dashboard-api", "manual pause", "bketelsen"); err != nil {
+		t.Fatalf("PauseBy: %v", err)
+	}
+	// The relaunch half may fail without a live tmux; provenance is cleared
+	// before it either way, and that clearing is the contract under test.
+	_ = m.Resume(context.Background(), "scanner", "dashboard-api", "manual resume")
+	status, _ := m.GetStatus("scanner")
+	if status.Paused {
+		t.Fatal("agent still paused after Resume")
+	}
+	if status.PausedBy != "" || status.PausedTrigger != "" || status.PausedReason != "" {
+		t.Errorf("provenance not cleared: by=%q trigger=%q reason=%q",
+			status.PausedBy, status.PausedTrigger, status.PausedReason)
+	}
+	if !status.PausedAt.IsZero() {
+		t.Errorf("PausedAt not cleared: %v", status.PausedAt)
+	}
+}
+
+// SeedPauseState (the boot-restore path) replays the persisted actor, so
+// provenance survives restarts instead of downgrading to anonymous.
+func TestSeedPauseState_ReplaysActor(t *testing.T) {
+	m := provenanceTestManager(t)
+	pausedAt := time.Date(2026, 8, 14, 16, 10, 10, 0, time.UTC)
+	m.SeedPauseState("scanner", pausedAt, "dashboard-api", "manual pause", "bketelsen")
+	status, _ := m.GetStatus("scanner")
+	if status.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q", status.PausedBy, "bketelsen")
+	}
+	if !status.PausedAt.Equal(pausedAt) {
+		t.Errorf("PausedAt = %v, want %v", status.PausedAt, pausedAt)
+	}
+}

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -1427,7 +1427,10 @@ func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.deps.AgentMgr.Pause(name, "dashboard-api", "manual pause"); err != nil {
+	// Record the acting user on the pause itself (#4041): the audit log has
+	// always known who clicked, but the agent state did not, so a deliberate
+	// owner mass-pause was indistinguishable from a malfunction days later.
+	if err := s.deps.AgentMgr.PauseBy(name, "dashboard-api", "manual pause", requestUser(r)); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/src/pkg/dashboard/audit.go
+++ b/src/pkg/dashboard/audit.go
@@ -198,12 +198,20 @@ func (s *Server) handleAuditLog(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]any{"entries": entries})
 }
 
-func (s *Server) auditFromRequest(r *http.Request, action, detail, agent string) {
+// requestUser resolves the acting user behind an authenticated dashboard
+// request — the X-Hive-User header set by the auth proxy, or "local" for an
+// unproxied deployment. Shared by the audit log and the pause-provenance
+// path (#4041) so "who did this" is answered identically everywhere.
+func requestUser(r *http.Request) string {
 	user := r.Header.Get("X-Hive-User")
 	if user == "" {
 		user = "local"
 	}
-	s.audit.Log(user, action, detail, agent)
+	return user
+}
+
+func (s *Server) auditFromRequest(r *http.Request, action, detail, agent string) {
+	s.audit.Log(requestUser(r), action, detail, agent)
 }
 
 // AuditLog records an audit event from non-HTTP contexts (governor eval,

--- a/src/pkg/dashboard/pause_provenance_api_test.go
+++ b/src/pkg/dashboard/pause_provenance_api_test.go
@@ -1,0 +1,110 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #4041 dashboard-side provenance: pausing via the API must record WHO acted,
+// and the agent payload the frontend renders must carry the full WHO/WHY/WHEN
+// so a paused fleet explains itself.
+
+func doOwnerPostAs(s *Server, path, user string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	markOwnerRequest(req)
+	if user != "" {
+		req.Header.Set("X-Hive-User", user)
+	}
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// Positive control: a pause via the API records the authenticated actor on
+// the agent state itself, not only in the audit log.
+func TestHandlePause_RecordsActingUser(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", "bketelsen"); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	proc, err := deps.AgentMgr.GetStatus("scanner")
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if proc.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q (actor lost on the API pause path)", proc.PausedBy, "bketelsen")
+	}
+	if proc.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", proc.PausedTrigger, "dashboard-api")
+	}
+}
+
+// Without an auth proxy the acting user resolves to "local" — same rule the
+// audit log has always used, so the two surfaces can never disagree.
+func TestHandlePause_NoUserHeaderRecordsLocal(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", ""); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	proc, _ := deps.AgentMgr.GetStatus("scanner")
+	if proc.PausedBy != "local" {
+		t.Errorf("PausedBy = %q, want %q", proc.PausedBy, "local")
+	}
+}
+
+// The agent payload carries the full provenance for the frontend to render.
+func TestAgentPayload_CarriesPauseProvenance(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", "bketelsen"); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	payload := BuildAgentOnlyStatus(deps.Governor.GetState(), deps.AgentMgr.AllStatuses(), deps.Config)
+	var found bool
+	for _, a := range payload.Agents {
+		if a.Name != "scanner" {
+			continue
+		}
+		found = true
+		if !a.Paused {
+			t.Fatal("scanner not paused in payload")
+		}
+		if a.PausedBy != "bketelsen" {
+			t.Errorf("payload PausedBy = %q, want %q", a.PausedBy, "bketelsen")
+		}
+		if a.PausedTrigger != "dashboard-api" {
+			t.Errorf("payload PausedTrigger = %q, want %q", a.PausedTrigger, "dashboard-api")
+		}
+		if a.PausedReason != "manual pause" {
+			t.Errorf("payload PausedReason = %q, want %q", a.PausedReason, "manual pause")
+		}
+		if a.PausedAt == "" {
+			t.Error("payload PausedAt empty")
+		}
+	}
+	if !found {
+		t.Fatal("scanner missing from payload")
+	}
+	_ = s
+}
+
+// Resuming clears the provenance from the payload — a running agent must not
+// wear a stale "paused by ..." explanation.
+func TestAgentPayload_ProvenanceClearedOnResume(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", "bketelsen"); rec.Code != http.StatusOK {
+		t.Fatalf("pause status = %d, want 200", rec.Code)
+	}
+	// A real resume may fail without a live tmux (same tolerance as
+	// TestHandleResume_RealTransitionReportsChangedTrue); provenance clearing
+	// happens before the relaunch half either way.
+	_ = doOwnerPostAs(s, "/api/resume/scanner", "bketelsen")
+	proc, _ := deps.AgentMgr.GetStatus("scanner")
+	if proc.Paused {
+		t.Skip("resume did not complete in this environment")
+	}
+	if proc.PausedBy != "" || proc.PausedTrigger != "" {
+		t.Errorf("provenance not cleared on resume: by=%q trigger=%q", proc.PausedBy, proc.PausedTrigger)
+	}
+	_ = s
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -387,6 +387,7 @@ type FrontendAgent struct {
 	PausedAt         string `json:"pausedAt,omitempty"`
 	PausedReason     string `json:"pausedReason,omitempty"`
 	PausedTrigger    string `json:"pausedTrigger,omitempty"`
+	PausedBy         string `json:"pausedBy,omitempty"`
 	OffByCadence     bool   `json:"offByCadence"`
 	NeedsLogin       bool   `json:"needsLogin"`
 	AuthAvailable    bool   `json:"authAvailable"`

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4114,6 +4114,25 @@
     let _ocSummaryTailing = true;
     let _ocSummaryScrollTop = null;
 
+    // One human-readable sentence answering WHO paused this agent, WHY and
+    // WHEN — e.g. "paused by bketelsen via dashboard, 3d ago" or
+    // "login-detector: login required detected, 2h ago". #4041: without
+    // this, a deliberately owner-quiesced fleet was indistinguishable from
+    // a malfunctioning one days later.
+    function pauseProvenanceLine(a) {
+      const trigger = a.pausedTrigger || '';
+      const ago = a.pausedAt ? pillAge(a.pausedAt) : '';
+      let line;
+      if (trigger === 'dashboard-api') {
+        line = 'paused by ' + (a.pausedBy || 'an operator') + ' via dashboard';
+      } else if (trigger) {
+        line = trigger + ': ' + (a.pausedReason || 'paused');
+      } else {
+        line = a.pausedReason || 'paused';
+      }
+      return ago ? line + ', ' + ago : line;
+    }
+
     function pauseInfoIcon(a) {
       // A manual/persisted pause carries its reason/trigger even when the
       // current governor mode's cadence is also pause/off — the operator
@@ -4122,8 +4141,10 @@
       if (!a.paused) return '';
       const reason = a.pausedReason || 'unknown';
       const trigger = a.pausedTrigger || 'unknown';
+      const by = a.pausedBy || '';
       const at = a.pausedAt ? new Date(a.pausedAt).toLocaleString() : 'unknown';
-      return `<span class="pause-info" title="${esc(reason)} (${esc(trigger)})">ℹ️<span class="pause-tooltip">Reason: ${esc(reason)}<br>Trigger: ${esc(trigger)}<br>Since: ${esc(at)}</span></span>`;
+      const ago = a.pausedAt ? pillAge(a.pausedAt) : '';
+      return `<span class="pause-info" title="${esc(pauseProvenanceLine(a))}">ℹ️<span class="pause-tooltip">${esc(pauseProvenanceLine(a))}<br>Reason: ${esc(reason)}<br>Trigger: ${esc(trigger)}${by ? '<br>By: ' + esc(by) : ''}<br>Since: ${esc(at)}${ago ? ' (' + esc(ago) + ')' : ''}</span></span>`;
     }
 
     // Volatile stat fields of the focused agent-detail panel, factored out so

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -476,6 +476,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			PausedAt:      formatOptionalTime(proc.PausedAt),
 			PausedReason:  proc.PausedReason,
 			PausedTrigger: proc.PausedTrigger,
+			PausedBy:      proc.PausedBy,
 			OffByCadence:  offByCadence,
 			CLI:           cli,
 			Model:         model,

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -267,6 +267,17 @@ type AgentSummary struct {
 	// Paused set, so the two are not interchangeable. The hub's inactive-agent
 	// rule keys off this to guarantee a deliberate pause is never alerted on.
 	Paused bool `json:"paused,omitempty"`
+	// Pause provenance (#4041): WHO/WHY/WHEN, so the fleet view can tell a
+	// deliberate owner quiesce ("paused by <owner> via dashboard, 3d ago")
+	// from a malfunction. All empty on a non-paused agent; PausedBy is empty
+	// when no human actor is known (login-detector, fleet-breaker, ...).
+	// PausedAt is RFC3339. The audit trail on the spoke has always had this —
+	// nothing the hub reads did, which is what turned a legitimate mass pause
+	// into a multi-day incident investigation.
+	PausedTrigger string `json:"pausedTrigger,omitempty"`
+	PausedReason  string `json:"pausedReason,omitempty"`
+	PausedBy      string `json:"pausedBy,omitempty"`
+	PausedAt      string `json:"pausedAt,omitempty"`
 	// NeedsLogin is true when the agent's CLI is sitting on a login /
 	// device-code prompt. This is the "running but not logged in" state: the
 	// session is alive, the CLI process is alive, and the agent still cannot do
@@ -298,6 +309,10 @@ type AgentSummary struct {
 // one of the two paths is a signal that quietly disappears mid-upgrade.
 type AgentActivity struct {
 	Paused         bool
+	PausedTrigger  string
+	PausedReason   string
+	PausedBy       string
+	PausedAt       time.Time
 	NeedsLogin     bool
 	SessionMissing bool
 	StartedAt      time.Time
@@ -313,8 +328,14 @@ func NewAgentSummary(name, state, mode string, act AgentActivity) AgentSummary {
 		State:          state,
 		Mode:           mode,
 		Paused:         act.Paused,
+		PausedTrigger:  act.PausedTrigger,
+		PausedReason:   act.PausedReason,
+		PausedBy:       act.PausedBy,
 		NeedsLogin:     act.NeedsLogin,
 		SessionMissing: act.SessionMissing,
+	}
+	if !act.PausedAt.IsZero() {
+		as.PausedAt = act.PausedAt.UTC().Format(time.RFC3339)
 	}
 	if !act.StartedAt.IsZero() {
 		as.StartedAt = act.StartedAt.UTC().Format(time.RFC3339)

--- a/src/pkg/hub/pause_provenance_summary_test.go
+++ b/src/pkg/hub/pause_provenance_summary_test.go
@@ -1,0 +1,56 @@
+package hub
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #4041 hub-side provenance: the per-agent summaries riding the heartbeat
+// into the My Hives payload must carry WHO/WHY/WHEN for a paused agent, so
+// the fleet view can tell a deliberate owner quiesce from a malfunction.
+
+func TestNewAgentSummary_CarriesPauseProvenance(t *testing.T) {
+	pausedAt := time.Date(2026, 8, 14, 16, 10, 10, 0, time.UTC)
+	as := NewAgentSummary("scanner", "paused", "", AgentActivity{
+		Paused:        true,
+		PausedTrigger: "dashboard-api",
+		PausedReason:  "manual pause",
+		PausedBy:      "bketelsen",
+		PausedAt:      pausedAt,
+	})
+	if !as.Paused {
+		t.Fatal("Paused not set")
+	}
+	if as.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", as.PausedTrigger, "dashboard-api")
+	}
+	if as.PausedReason != "manual pause" {
+		t.Errorf("PausedReason = %q, want %q", as.PausedReason, "manual pause")
+	}
+	if as.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q", as.PausedBy, "bketelsen")
+	}
+	if as.PausedAt != "2026-08-14T16:10:10Z" {
+		t.Errorf("PausedAt = %q, want RFC3339 %q", as.PausedAt, "2026-08-14T16:10:10Z")
+	}
+}
+
+// A zero PausedAt must serialize as ABSENT — never as a bogus year-1 string
+// the fleet view would render as a 2000-year-old pause.
+func TestNewAgentSummary_ZeroPausedAtOmitted(t *testing.T) {
+	as := NewAgentSummary("scanner", "running", "", AgentActivity{})
+	if as.PausedAt != "" {
+		t.Fatalf("PausedAt = %q, want empty for a zero time", as.PausedAt)
+	}
+	raw, err := json.Marshal(as)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, field := range []string{"pausedAt", "pausedTrigger", "pausedReason", "pausedBy"} {
+		if strings.Contains(string(raw), field) {
+			t.Errorf("non-paused agent summary leaks %q: %s", field, raw)
+		}
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -10475,8 +10475,11 @@ const dashboardHTML = `<!DOCTYPE html>
     /* Bump on ANY change to the hive row shape consumed by renderHives().
        v2: rows carry trackedChannel (the hub-persisted release-channel
        selection the version pill renders); a v1 cache would repaint a
-       channel-pinned hive as its bare branch for the pre-network paint. */
-    var HIVES_CACHE_VERSION = 2;
+       channel-pinned hive as its bare branch for the pre-network paint.
+       v3 (#4041): agent rows carry pause provenance (pausedTrigger/
+       pausedReason/pausedBy/pausedAt) rendered into the Agents tooltip; a
+       v2 cache would paint paused agents provenance-less until the poll. */
+    var HIVES_CACHE_VERSION = 3;
     /* 10 minutes: long enough to cover a reload or a tab restore, short enough
        that a cached fleet is never wildly out of date before the poll lands. */
     var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;
@@ -13761,6 +13764,37 @@ const dashboardHTML = `<!DOCTYPE html>
       }
       return false;
     }
+    /* One phrase answering WHO paused an agent, WHY and WHEN, from the pause
+       provenance the spoke reports over the heartbeat (#4041) — e.g.
+       "paused by bketelsen via dashboard, 3d ago" or "paused (login-detector:
+       login required detected), 2h ago". A deliberate owner quiesce must read
+       differently from a malfunction in the fleet view. Old cached rows and
+       old spokes lack the fields; falls back to a bare "paused". */
+    function agentPauseProvenance(a) {
+      var line;
+      if (a.pausedTrigger === 'dashboard-api') {
+        line = 'paused by ' + (a.pausedBy || 'an operator') + ' via dashboard';
+      } else if (a.pausedTrigger) {
+        line = 'paused (' + a.pausedTrigger + (a.pausedReason ? ': ' + a.pausedReason : '') + ')';
+      } else {
+        line = 'paused';
+      }
+      if (a.pausedAt) {
+        /* Self-contained relative age (coarse on purpose): timelineAgo lives
+           in a later <script> block, and renderHives can run during this
+           block's init (paintCachedHives) before that block is parsed. */
+        var t = Date.parse(a.pausedAt);
+        if (!isNaN(t)) {
+          var PAUSE_MS_PER_MIN = 60000, PAUSE_MIN_PER_HOUR = 60, PAUSE_HOURS_PER_DAY = 24;
+          var mins = Math.floor((Date.now() - t) / PAUSE_MS_PER_MIN);
+          if (mins < 1) line += ', just now';
+          else if (mins < PAUSE_MIN_PER_HOUR) line += ', ' + mins + 'm ago';
+          else if (mins < PAUSE_MIN_PER_HOUR * PAUSE_HOURS_PER_DAY) line += ', ' + Math.floor(mins / PAUSE_MIN_PER_HOUR) + 'h ago';
+          else line += ', ' + Math.floor(mins / (PAUSE_MIN_PER_HOUR * PAUSE_HOURS_PER_DAY)) + 'd ago';
+        }
+      }
+      return line;
+    }
     function renderHives(allHives, force) {
       allHives = allHives || [];
       /* Defer the whole render while a branch/channel menu is open. Skipping
@@ -14332,7 +14366,7 @@ const dashboardHTML = `<!DOCTYPE html>
               '<div style="' + STACKED_LINE_STYLE + '">' + journeyBadge(h.journey) + '</div>' +
             '</div>' +
           '</td>' +
-          '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
+          '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; if (a.paused) label += ' — ' + agentPauseProvenance(a); return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
           '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
           /* ACTIVITY: Issues, PRs and Contributors — three mini-stats that were

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -849,9 +849,9 @@ type HubServer struct {
 	upgradePause       UpgradePauseState
 	upgradePauseLoaded bool
 	upgradePauseMu     sync.Mutex // guards upgradePause + upgradePauseLoaded
-	httpServer      *http.Server
-	httpMu          sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
-	clusters        map[string]ClusterConfig
+	httpServer         *http.Server
+	httpMu             sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
+	clusters           map[string]ClusterConfig
 
 	// vanityHostServable overrides how the retroactive vanity-URL repair makes a
 	// vanity host servable (see makeVanityHostServable). nil in production, where
@@ -1624,6 +1624,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// inactive-agent rule, never as evidence of idleness.
 				payload.Agents[i].StartedAt = sanitizeHeartbeatField(payload.Agents[i].StartedAt)
 				payload.Agents[i].LastActivityAt = sanitizeHeartbeatField(payload.Agents[i].LastActivityAt)
+				// Pause provenance (#4041). Trigger and actor are identifiers
+				// ("dashboard-api", a GitHub login); the reason is prose the
+				// hover renders to a human; the timestamp keeps its colons via
+				// the HTML-escaping sanitizer, same as the entry's StartedAt.
+				payload.Agents[i].PausedTrigger = sanitizeHeartbeatField(payload.Agents[i].PausedTrigger)
+				payload.Agents[i].PausedBy = sanitizeHeartbeatField(payload.Agents[i].PausedBy)
+				payload.Agents[i].PausedReason = sanitizeProseField(payload.Agents[i].PausedReason)
+				payload.Agents[i].PausedAt = sanitizeField(payload.Agents[i].PausedAt)
 			}
 			const maxAgents = 50
 			if len(payload.Agents) > maxAgents {

--- a/src/pkg/hub/spark_downsample_test.go
+++ b/src/pkg/hub/spark_downsample_test.go
@@ -145,7 +145,7 @@ func TestDashboardHivesCacheIsBoundedAndVersioned(t *testing.T) {
 		snippet string
 	}{
 		{"cache key", "var LS_HIVES_CACHE = 'hive-my-hives-cache';"},
-		{"schema version", "var HIVES_CACHE_VERSION = 2;"},
+		{"schema version", "var HIVES_CACHE_VERSION = 3;"},
 		{"named TTL constant", "var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;"},
 		{"named row cap", "var HIVES_CACHE_MAX_ROWS = 200;"},
 		{"version is enforced on read", "if (!c || c.version !== HIVES_CACHE_VERSION) return null;"},

--- a/src/pkg/snapshot/state.go
+++ b/src/pkg/snapshot/state.go
@@ -70,10 +70,14 @@ type ConfigOverrides struct {
 }
 
 type AgentState struct {
-	Paused          bool             `json:"paused"`
-	PausedAt        *time.Time       `json:"paused_at,omitempty"`
-	PausedReason    string           `json:"paused_reason,omitempty"`
-	PausedTrigger   string           `json:"paused_trigger,omitempty"`
+	Paused        bool       `json:"paused"`
+	PausedAt      *time.Time `json:"paused_at,omitempty"`
+	PausedReason  string     `json:"paused_reason,omitempty"`
+	PausedTrigger string     `json:"paused_trigger,omitempty"`
+	// PausedBy is the acting user behind the pause when one is known (the
+	// authenticated dashboard user); empty for system-initiated pauses.
+	// Persisted so pause provenance survives restarts (#4041).
+	PausedBy        string           `json:"paused_by,omitempty"`
 	PinnedCLI       string           `json:"pinned_cli,omitempty"`
 	PinnedModel     string           `json:"pinned_model,omitempty"`
 	ModelOverride   string           `json:"model_override,omitempty"`


### PR DESCRIPTION
## Summary

Fix A from #4041. A deliberate owner mass-pause of the frostyard fleet read as a systemic malfunction three days later because nothing the dashboard, the hub fleet view, or the boot log renders says WHO paused WHAT WHEN — and the boot line inflated the count with the always-startup-paused on-demand `brainstorm` ("restoring 9 paused agent(s)" for an 8-agent quiesce).

### Agent state
- `Manager.PauseBy(name, trigger, reason, by)` records the acting user; `Pause` delegates with empty (a system pause never fabricates an actor); `Resume` clears the whole provenance set.
- `PausedBy` rides `snapshot()`, `hive-state.json` persist and boot restore, so provenance survives restarts instead of downgrading to anonymous.

### Spoke dashboard
- `/api/pause` records the authenticated `X-Hive-User` (same resolution the audit log has always used, factored into a shared `requestUser`).
- The agent payload carries `pausedBy`; the paused-agent info tooltip now leads with one human sentence: **"paused by bketelsen via dashboard, 3d ago"** / **"login-detector: login required detected, 2h ago"**, plus the full Reason/Trigger/By/Since breakdown.

### Hub / My Hives
- `AgentSummary` rides `pausedTrigger`/`pausedReason`/`pausedBy`/`pausedAt` over the heartbeat — all `omitempty`, so zero payload cost on non-paused agents — sanitized at ingest like every other spoke-reported field (identifiers strict, reason as prose, timestamp HTML-escaped like the entry's StartedAt so RFC3339 survives).
- The My Hives Agents tooltip renders the provenance line per paused agent, so the fleet view distinguishes deliberate-quiesce from malfunction.
- `HIVES_CACHE_VERSION` 2 → 3 (agent rows changed shape; the instant-paint cache must not paint provenance-less rows with new code).

### Boot log
`restoring N paused agent(s)` now **excludes** agents startup-paused **by design** (on-demand — config flag or pack definition) and breaks the restored count down by trigger:
`restoring 8 paused agent(s) (dashboard-api: 8); 1 on-demand agent(s) startup-paused by design`

### Tests
- `TestPauseBy_RecordsActor` (positive control) / `TestPause_LeavesActorEmpty` / `TestResume_ClearsProvenance` / `TestSeedPauseState_ReplaysActor`
- `TestHandlePause_RecordsActingUser` / `TestHandlePause_NoUserHeaderRecordsLocal` / `TestAgentPayload_CarriesPauseProvenance` / `TestAgentPayload_ProvenanceClearedOnResume`
- `TestRestoreAgentRuntimeState_ReplaysPausedBy`
- `TestPausedRestoreDetail_ExcludesByDesignOnDemand` (the frostyard 8+1 shape, asserts the bare 9 never appears) / `_ExcludesPackOnDemand` / `_BreaksDownByTrigger` (unknown-trigger agents still counted) / `_NothingPaused`
- `TestNewAgentSummary_CarriesPauseProvenance` / `TestNewAgentSummary_ZeroPausedAtOmitted`

Fixes #4041 (together with the login_patterns de-materialization PR #4051).

🤖 Generated with [Claude Code](https://claude.com/claude-code)