### PR TITLE
✨ v5: tool-approval decision point + operator queue — RFC #4000

### DIFF
--- a/src/cmd/hive/approvalwire.go
+++ b/src/cmd/hive/approvalwire.go
@@ -1,0 +1,143 @@
+package main
+
+// Approval-desk startup wiring (RFC #4000).
+//
+// Mirrors celwire.go: one construction helper called during startup, fail-closed
+// on malformed rules, and a total no-op when the feature block is absent.
+//
+// The desk is DEFAULT OFF (`tool_approval.enabled: false`). With it off this
+// file returns nil for both the desk and the inbox, no hook is installed on the
+// GitHub client, and the dashboard's Approvals panel reports "not enabled". A
+// hive that upgrades onto this build and changes no config behaves exactly as
+// it did before.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/kubestellar/hive/pkg/config"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/toolapprove"
+)
+
+// buildApprovalDesk constructs the desk and its durable operator inbox from
+// config.
+//
+// Fail-closed on a malformed rule set: the error is logged and BOTH return
+// values are nil, so the hive runs with the desk disabled and every legacy gate
+// still authoritative. That is strictly safer than running with a half-applied
+// rule set, and it matches celEngineFor's posture — a bad rule must never crash
+// the fleet nor silently change what is permitted.
+func buildApprovalDesk(cfg *config.Config, logger *slog.Logger) (*toolapprove.Desk, *toolapprove.Inbox) {
+	desk, inbox, err := toolapprove.DeskFromConfig(cfg, nil, logger)
+	if err != nil {
+		if logger != nil {
+			logger.Error("tool-approval: rejecting malformed approval rules; approval desk disabled until fixed",
+				"error", err)
+		}
+		return nil, nil
+	}
+	if desk != nil && logger != nil {
+		logger.Info("tool-approval: approval desk enabled",
+			"rules", len(desk.RuleNames()), "acmm_level", toolapprove.ACMMLevelOf(cfg))
+	}
+	return desk, inbox
+}
+
+// newSelfMergeDeskHook adapts the desk to the GitHub client's narrow
+// ApprovalDeskHook signature, for the self-authored auto-merge sweep — the one
+// real producer wired in this slice.
+//
+// Behavior per PR:
+//
+//   - auto-approve  → allow the merge, in-loop, nothing persisted. This is the
+//     L6 path and it must stay allocation-light: no queue, no disk.
+//   - operator-approve → withhold the merge and park the request in the durable
+//     inbox for an operator. Enqueue is idempotent, so a PR the sweep re-sees
+//     every tick produces ONE inbox row, not one per tick.
+//   - deny → withhold, nothing queued.
+//
+// Idempotency across a granted verdict: before withholding, the hook checks the
+// resolved journal. An operator who already granted this exact request gets the
+// merge on the next sweep tick, and the journal's Executed flag keeps a
+// re-delivery from merging twice.
+func newSelfMergeDeskHook(
+	desk *toolapprove.Desk,
+	inbox *toolapprove.Inbox,
+	cfg *config.Config,
+	logger *slog.Logger,
+) ghpkg.ApprovalDeskHook {
+	acmmLevel := toolapprove.ACMMLevelOf(cfg)
+
+	return func(ctx context.Context, in ghpkg.ApprovalDeskRequest) (bool, string) {
+		req := toolapprove.Request{
+			Kind:        toolapprove.KindSelfMerge,
+			Repo:        in.Repo,
+			Number:      in.Number,
+			Author:      in.Author,
+			Title:       in.Title,
+			Labels:      in.Labels,
+			ChecksGreen: in.ChecksGreen,
+			Tool: toolapprove.ToolRequest{
+				Tool:   "hive-merge",
+				Target: in.HeadSHA,
+			},
+		}
+
+		// A verdict this operator already granted must merge, and must merge
+		// only once. Consult the journal before the desk so a granted request
+		// is not re-queued for approval it already has.
+		id := toolapprove.DeriveIdempotencyKey(req)
+		if rec, ok := inbox.ResolvedRecordFor(id); ok {
+			if !rec.Approved {
+				return false, "approval-desk-rejected"
+			}
+			if rec.Executed {
+				// Already merged under this grant. Withhold rather than merge a
+				// second time — the sweep's own "closed"/"gone" checks would
+				// usually catch this first, but the journal is the authority.
+				return false, "approval-desk-already-executed"
+			}
+			if err := inbox.MarkExecuted(id); err != nil && logger != nil {
+				logger.Warn("tool-approval: could not mark approval executed",
+					"id", id, "error", err)
+			}
+			return true, ""
+		}
+
+		v := desk.Resolve(ctx, req, acmmLevel)
+
+		switch v.Decision {
+		case toolapprove.DecisionAutoApprove:
+			// THROUGHPUT CONTRACT: resolved synchronously, in-loop, nothing
+			// enqueued and nothing persisted. Do not add I/O to this branch.
+			return true, ""
+
+		case toolapprove.DecisionOperatorApprove:
+			if _, err := inbox.Enqueue(req, v); err != nil {
+				// An already-resolved request is not an error worth logging as
+				// one: it means the operator resolved it between the journal
+				// read above and here. Withhold; the next tick reads the
+				// journal and proceeds.
+				if !errors.Is(err, toolapprove.ErrAlreadyResolved) && logger != nil {
+					logger.Warn("tool-approval: could not enqueue pending approval",
+						"repo", in.Repo, "pr", in.Number, "error", err)
+				}
+			} else if logger != nil {
+				logger.Info("tool-approval: self-merge parked for operator approval",
+					"repo", in.Repo, "pr", in.Number, "rule", v.Rule,
+					"acmm_level", acmmLevel, "rationale", v.Rationale)
+			}
+			return false, "approval-desk-pending-operator"
+
+		default: // DecisionDeny, and DecisionSecurityScan which Resolve never returns
+			if logger != nil {
+				logger.Info("tool-approval: self-merge withheld",
+					"repo", in.Repo, "pr", in.Number, "decision", string(v.Decision),
+					"rationale", v.Rationale)
+			}
+			return false, "approval-desk-denied"
+		}
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1385,6 +1385,15 @@ func main() {
 	// Gated on a real client + usable App — with no App there is no bot to author
 	// as, and requests simply accumulate rather than opening under a wrong
 	// identity. ghClient uses the App installation token (see ghAuth wiring).
+
+	// Approval desk (RFC #4000): the single tool-approval decision point plus
+	// its durable operator-lane inbox. Both are nil unless
+	// `tool_approval.enabled` is set — the default — so this costs nothing and
+	// changes nothing on a hive that has not opted in. Built here, before the
+	// auto-merge sweep is started below, because the sweep is the one producer
+	// wired in this slice. Also handed to the dashboard for the Approvals panel.
+	approvalDesk, approvalInbox := buildApprovalDesk(cfg, logger)
+
 	if ghClient != nil && cfg.GitHub.HasUsableApp() {
 		// Attribution resolver: effective backend/model from the manager
 		// (runtime overrides included), falling back to the configured values
@@ -1482,6 +1491,13 @@ func main() {
 		// never start this loop regardless of the flag above — see
 		// AutoMergeConfig.SelfAuthoredAutoMergeAllowed. StartSelfAuthoredAutoMergeSweep
 		// itself no-ops (with a one-time INFO log) when acmmAllowed is false.
+		// Approval desk (RFC #4000). Installed BEFORE the sweep starts so the
+		// first tick already consults it. A nil desk (the default —
+		// `tool_approval.enabled` is false) installs no hook, leaving the
+		// sweep's behavior byte-identical to the pre-desk build.
+		if approvalDesk != nil && approvalInbox != nil {
+			ghClient.SetApprovalDesk(newSelfMergeDeskHook(approvalDesk, approvalInbox, cfg, logger))
+		}
 		ghClient.StartSelfAuthoredAutoMergeSweep(ctx, cfg.AutoMerge.MaxMerges, cfg.AutoMerge.SelfAuthoredAutoMergeAllowed(cfg.ACMMLevel), cfg.ACMMLevel)
 	}
 
@@ -2192,9 +2208,13 @@ func main() {
 		BeadSynthesizer:       beadSynth,
 		BeadStores:            beadStores,
 		BeadStoreLoadFailures: beadStoreLoadFailures,
-		Logger:                logger,
-		Ctx:                   ctx,
-		RefreshFunc:           refreshDashboard,
+		// RFC #4000 approval desk. Nil unless `tool_approval.enabled`, in which
+		// case the Approvals panel renders as "not enabled".
+		ApprovalDesk:  approvalDesk,
+		ApprovalInbox: approvalInbox,
+		Logger:        logger,
+		Ctx:           ctx,
+		RefreshFunc:   refreshDashboard,
 		// #3768: give the contribute queue read access to the duplicate-PR
 		// claim ledger, so an issue any open PR (hive-authored or a human
 		// contributor's) already claims to fix is never offered to another

--- a/src/docs/design/tool-approval-desk.md
+++ b/src/docs/design/tool-approval-desk.md
@@ -1,0 +1,305 @@
+# The Tool-Approval Desk
+
+Status: implemented (vertical slice), default-off — RFC [#4000](https://github.com/kubestellar/hive/issues/4000)
+
+The desk is the single decision point every approval-shaped request resolves
+through. It replaces four independently-grown gates with one testable function,
+keys the answer on the hive's ACMM level, lets operators express policy as data,
+and produces an auditable record of *why* each action was allowed or blocked.
+
+---
+
+## 1. The problem: four gates, one shape
+
+Hive did not have a decision point. It had four, each grown out of its own
+incident, each implementing the same `(requested action, ACMM level, identity) →
+verdict` shape with a different failure mode:
+
+| Gate | Location | Failure mode it grew from |
+| --- | --- | --- |
+| Self-merge | `SelfMergeMinACMMLevel` / `AutoMergeConfig.SelfAuthoredAutoMergeAllowed` (`pkg/config/config.go`) | The self-authored sweep originally had **no ACMM check at all** — an L4 hive wrongly self-merged its own PR, and the gate was bolted on afterward. |
+| Plan approval | `PlanAutoApproveForLevel` (`pkg/config/acmm_packs.go`) | A separate pack lookup consulted only by the decomposition path. |
+| Plan-from-label | `PlanningConfig.PlanFromLabelEnabled` (`pkg/config/config.go`) | A third, independent level check. |
+| Merge queue | `isTrustedMerger` + `latestHiveQueueApproval` (`pkg/github/automerge_sweep.go`) | Role- and review-based approval implemented *inside* the sweep. |
+
+The desk is the refactor all four were independently converging on.
+
+---
+
+## 2. The decision point
+
+`toolapprove.Desk.Resolve` resolves every request to one of four verdicts:
+
+```
+auto-approve | security-scan | operator-approve | deny
+```
+
+It evaluates three layers **in a fixed order**:
+
+```
+  1. BASE POLICY   hard guardrails, tool policy, agent mode, repo allowlist,
+                   and the ACMM level mapping the legacy gate encoded
+                        ↓
+  2. OPERATOR RULES CEL expressions from config; may steer a request
+                   into a different lane
+                        ↓
+  3. ACMM CEILING  applied LAST, unconditionally — a rule can never approve
+                   above the hive's level
+```
+
+That ordering is the entire safety argument. **Rules are an input to a decision
+the ceiling always has the final word on.** A rule asking for `auto-approve` on
+an L1 hive is clamped to `operator-approve`, the clamp is recorded on the
+verdict (`CeilingApplied`), and it shows up in the audit record. Pinned by
+`TestACMMCeilingClampsPermissiveRule` and `TestACMMCeilingNeverExceedsLevel`.
+
+### The ceiling
+
+`ACMMCeiling(level)` gives the most permissive **lane** a level may enter:
+
+| Level | Ceiling | Meaning |
+| --- | --- | --- |
+| L0–L2 | `operator-approve` | Nothing side-effectful resolves without a human. |
+| L3–L5 | `security-scan` | May reach `auto-approve`, but only *via* a green scan. |
+| L6+ | `auto-approve` | Full autonomy; the desk is an audit record, not a gate. |
+
+An unknown or negative level clamps to the most restrictive lane, so a
+mis-parsed or absent `acmm_level` can never widen authority
+(`TestACMMCeilingUnknownLevelFailsClosed`).
+
+Hard guardrails — direct PR creation, direct PR merge, explicit tool denies,
+repo allowlist, agent-mode restrictions — are **not rule-overridable**. Letting
+config relax them would reopen exactly the holes they were added to close
+(`TestRuleCannotOverrideHardDeny`).
+
+---
+
+## 3. Rules as data
+
+Approval rules are CEL expressions in config, compiled at load, reusing the
+posture `pkg/celtrigger` already established:
+
+- **Malformed rules are rejected at config load**, not at decision time. A typo
+  like `request.checks_gren` is a compile error because `RuleRequest` is
+  registered as a native CEL type.
+- **A runtime evaluation error is a no-match**, never a match. A broken rule
+  silently stops widening authority; it can never accidentally grant it.
+- **Evaluation cost is bounded** (`maxRuleEvalCost`), so a pathological
+  expression cannot stall the decision point that sits in every agent turn.
+
+```yaml
+tool_approval:
+  enabled: true
+  rules:
+    # The canonical case: bulk-approve green dependabot patch bumps, while a
+    # feature PR is NOT swept up.
+    - name: green-dependabot-patch
+      expr: |
+        request.kind == "self-merge" && request.checks_green &&
+        request.author == "dependabot[bot]" &&
+        request.title.startsWith("chore(deps)")
+      action: auto-approve
+
+    # Hold anything touching guardrail-critical paths, at any level.
+    - name: workflows-need-human
+      expr: request.file_path.startsWith(".github/workflows/")
+      action: operator-approve
+      priority: 100
+```
+
+The `request` activation exposes: `kind`, `tool`, `agent`, `repo`, `number`,
+`labels`, `author`, `title`, `checks_green`, `read_only`, `side_effectful`,
+`command`, `file_path`, plus a `hasLabel(request.labels, "…")` helper.
+
+`RuleRequest` is deliberately a **separate type** from the internal `Request`:
+it is a stable, documented policy surface, so internal refactors cannot silently
+break every deployed rule.
+
+---
+
+## 4. The L6 throughput contract
+
+From the maintainer's binding addendum — the desk **must not reduce the
+effective autonomy or throughput of high-ACMM hives**. Four requirements, each
+with a test:
+
+**1. Auto-approve is synchronous and in-loop.** A request resolving to
+`auto-approve` never enters a queue and never waits on any external process.
+This is enforced *structurally*, not by convention: `Inbox.Enqueue` **refuses**
+any verdict that is not `operator-approve`, returning `ErrNotOperatorLane`.
+There is no code path by which an auto-approved request reaches durable storage.
+
+> `TestL6AutoApproveNeverQueues` points the inbox at a temp path and asserts the
+> file **does not exist** after a full L6 auto-approve flow. A future change
+> that starts journaling auto-approvals "for the audit trail" fails here.
+> `TestL6RuleAutoApproveNeverQueues` covers the rule-driven path.
+
+**2. The scan lane must not become a hidden serialization point.** A verdict
+that is already `auto-approve` or `operator-approve` returns without consulting
+the scanner, so a slow scanner never taxes an L6 turn whose answer is always
+yes.
+
+> `TestL6AutoApproveIsSynchronous` wires a scanner that *fails the test if
+> called* and blocks forever if it is, then asserts the resolve completes.
+
+**3. Migration maps current behavior 1:1.** Whatever a level auto-permits today,
+the desk auto-permits on day one. New restrictions arrive only as explicit,
+audited policy changes — never as conservative shipped defaults.
+
+> `pkg/toolapprove/parity.go` computes each legacy gate's answer by calling **the
+> same config predicates the production gate calls**, and `parity_test.go`
+> asserts equivalence for every level 0–7. Because both sides delegate to the
+> real predicates, a future threshold change moves them together and the tests
+> keep passing — they pin *equivalence*, not a table that would rot.
+> `TestNoConservativeDowngradeAtHighAutonomy` states requirement 3 directly.
+
+**4. Operator-lane items at L6 are probable policy bugs.** An inbox that quietly
+accumulates on a hive whose level says "full autonomy" is a misconfiguration
+signal. `Inbox.PendingAtFullAutonomy` surfaces them, the API returns
+`policy_bug_count`, and the dashboard renders a warning banner rather than
+letting them wait politely (`TestPendingAtFullAutonomyIsFlagged`).
+
+Unchanged and deliberate: operator kill-switches and the `hold` label sit
+**above** the desk at every level.
+
+---
+
+## 5. The operator queue
+
+Durable, **operator-lane only**, at `/data/approvals/inbox.json` on the spoke's
+PVC (override with `tool_approval.inbox_path`).
+
+An approval that waits overnight must survive a spoke roll — hives auto-roll
+frequently, so an in-memory pending list would be wiped by the very machinery it
+is meant to outlive. The store follows the idiom already used by the hub's
+upgrade-pause kill switch and the contribute ledger:
+
+- One small JSON file, loaded lazily on first use.
+- Written **atomically** (temp file in the same directory, then rename), so a
+  crash mid-write leaves either the old file or the new one, never a truncated
+  inbox.
+- A missing or corrupt file degrades to "empty" rather than wedging the hive.
+- Growth is bounded (`maxInboxEntries`, `maxJournalEntries`, 30-day journal
+  retention).
+
+`TestInboxSurvivesRestart` constructs a **second, independent** `Inbox` over the
+same path — which is exactly what a spoke roll looks like from the inbox's point
+of view — and asserts pending items and the resolved journal both survive.
+
+### Idempotency
+
+Every request carries an idempotency key: either caller-supplied, or derived by
+`DeriveIdempotencyKey` from the fields that identify *what* is being requested
+(lane, tool, target, arguments — hashed in sorted key order so map iteration
+cannot make the same request hash two different ways). Timestamps and
+per-delivery metadata are deliberately excluded, which is what makes a
+re-delivery match.
+
+Resolution is two-phase — **resolve → execute → mark executed** — so a crash
+between "approved" and "actually ran" is distinguishable on restart: the former
+is safe to retry, the latter must not be.
+
+- `Enqueue` on an already-resolved request returns `ErrAlreadyResolved`.
+- `Resolve` on an already-journaled ID returns `ErrAlreadyResolved` with the
+  original record and does **not** journal a second time.
+- The API surfaces a replayed resolve as **409 Conflict**, returning the
+  original outcome so a client can reconcile stale UI.
+
+> `TestGrantedVerdictDoesNotDoubleExecute` is the direct assertion.
+> `TestIdempotencyKeyDistinguishesDifferentRequests` is its positive control —
+> without it, "idempotency" could just mean "everything is a duplicate".
+
+**Reconciliation with #4002 stage 2:** the turn model's journaled re-entrant
+turn is landing concurrently. This slice defines its own key derivation and
+keeps it *additive* — `Request.IdempotencyKey` accepts an externally-supplied
+key, so once stage 2's per-operation identity lands, the turn runner passes its
+own key and the desk journals under that identity instead of deriving one. No
+schema change is required on either side.
+
+---
+
+## 6. API
+
+All three endpoints are **owner-gated** via `requireOwnerRole`, which requires
+both the owner role *and* the server-verified marker header — the same bar
+token-access and backup enforce. Approving a pending tool call is at least as
+privileged: a granted verdict lets an agent take an action the ACMM level
+otherwise reserved for a human.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/approvals` | List pending; returns rows, rule chips, `policy_bug_count`. |
+| `POST` | `/api/approvals/resolve` | Resolve one. 409 on replay. |
+| `POST` | `/api/approvals/bulk` | Resolve many. |
+
+### Bulk is never a parallel path
+
+`/api/approvals/bulk` calls `Inbox.ResolveMany`, which calls `Inbox.Resolve`
+once per item — **the same function the single-item handler calls**. Likewise
+`Desk.ResolveBatch` calls `Desk.Resolve` per request. This mirrors how
+`runBulkAction`/`applyBulkAction` in `pkg/hub/saas_bulk.go` decompose a bulk
+request into per-item authorized operations, and it is what RFC #4000 requires:
+*a bulk approve is N individual evaluations through the same decision function
+every agent request goes through.*
+
+Partial failure is the normal case (another operator may have resolved an item
+between the list and the click), so the response is a **per-item result list**,
+not a single boolean.
+
+> `TestResolveBatchEqualsNIndividualResolves` asserts
+> `ResolveBatch(reqs) == [Resolve(r) for r in reqs]` across every level and
+> every lane. `TestResolveManyEqualsNIndividualResolutions` does the same for
+> the inbox path. `TestApprovalsSourceGate` additionally pins the owner gate at
+> the *source* level with a count floor, so a refactor cannot silently drop it.
+
+---
+
+## 7. Operator UX
+
+The **Approvals** panel appears in the spoke dashboard only when the desk is
+enabled — a hive that has not opted in sees no new chrome.
+
+- A **pending-count badge** on the section header, hidden at zero.
+- **Rule chips as filters**: narrow to "everything the `large-diff` rule would
+  hold", then bulk-resolve just those.
+- **Multi-select** with Approve/Reject-selected actions.
+- **Each row shows which rule would resolve it** — re-evaluated server-side
+  against the *current* rule set rather than replayed from the enqueue-time
+  verdict, so editing policy is immediately visible in the queue. This is the
+  "tuning knobs embedded in the review loop" the fleet-owner feedback asked for.
+- A **policy-bug banner** when items are queued at L6.
+
+---
+
+## 8. What is wired today
+
+One real producer, **behind a default-OFF flag**: the self-authored auto-merge
+sweep (`pkg/github/automerge_desk.go`).
+
+It is the cheapest honest producer — already exactly the shape the desk
+generalizes, it is the gate whose incident history the RFC cites, and it needs
+no new call site because the sweep already computes repo, number, author, and a
+real `ChecksGreen` from `commitGreen`.
+
+The consultation happens **after** the sweep's own eligibility checks, so the
+desk can only ever *withhold* a merge the legacy gate already permitted — it can
+never widen authority. That asymmetry is what makes enabling the flag safe to
+try on a live hive.
+
+With `tool_approval.enabled: false` (the default) no hook is installed and
+`consultApprovalDesk` allows unconditionally: **shipping this changes nothing
+about any running hive** (`TestNoDeskInstalledIsNoOp`).
+
+### Remaining
+
+- Migrate the other three gates (plan approval, plan-from-label, queued merge)
+  onto the desk at their call sites. Parity functions and tests already exist
+  for all three; only the call-site swap remains.
+- Route `security-scan` through the sec-check agent surface
+  (`buildSecCheckMessage`) rather than the in-process `DefaultSecurityScanner`,
+  with the async/post-hoc path for pattern-matched-known-safe requests that
+  requirement 2 anticipates.
+- Suspend/resume an operator-approval wait as a #4002 re-entrant turn, and adopt
+  stage 2's idempotency key (see §5).
+- An `on_approval_pending` hook (#4001) so an L6 policy bug alerts rather than
+  waiting.

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -53,16 +53,21 @@ type Config struct {
 	Tracing OTelConfig `yaml:"tracing,omitempty"`
 	// Triggers is an additive list of CEL-based declarative agent triggers.
 	// Default empty → existing label/governor triggering is unchanged.
-	Triggers   []TriggerRule    `yaml:"triggers,omitempty" json:"triggers,omitempty"`
-	Mint       MintConfig       `yaml:"mint,omitempty"`
-	Ioscan     IoscanConfig     `yaml:"ioscan,omitempty" json:"ioscan,omitempty"`
-	Classifier ClassifierConfig `yaml:"classifier,omitempty" json:"classifier,omitempty"`
-	Planning   PlanningConfig   `yaml:"planning,omitempty" json:"planning,omitempty"`
-	Intent     IntentConfig     `yaml:"intent,omitempty" json:"intent,omitempty"`
-	Escalation EscalationConfig `yaml:"escalation,omitempty" json:"escalation,omitempty"`
-	Retro      RetroConfig      `yaml:"retro,omitempty" json:"retro,omitempty"`
-	Review     ReviewConfig     `yaml:"review,omitempty" json:"review,omitempty"`
-	AutoMerge  AutoMergeConfig  `yaml:"auto_merge,omitempty" json:"auto_merge,omitempty"`
+	Triggers []TriggerRule `yaml:"triggers,omitempty" json:"triggers,omitempty"`
+	// ToolApproval configures the approval desk (RFC #4000): the single
+	// decision point every approval-shaped request resolves through, plus the
+	// operator rules that steer it. Additive and DEFAULT-OFF — an absent block
+	// leaves every existing gate in charge and behavior byte-identical.
+	ToolApproval ToolApprovalConfig `yaml:"tool_approval,omitempty" json:"tool_approval,omitempty"`
+	Mint         MintConfig         `yaml:"mint,omitempty"`
+	Ioscan       IoscanConfig       `yaml:"ioscan,omitempty" json:"ioscan,omitempty"`
+	Classifier   ClassifierConfig   `yaml:"classifier,omitempty" json:"classifier,omitempty"`
+	Planning     PlanningConfig     `yaml:"planning,omitempty" json:"planning,omitempty"`
+	Intent       IntentConfig       `yaml:"intent,omitempty" json:"intent,omitempty"`
+	Escalation   EscalationConfig   `yaml:"escalation,omitempty" json:"escalation,omitempty"`
+	Retro        RetroConfig        `yaml:"retro,omitempty" json:"retro,omitempty"`
+	Review       ReviewConfig       `yaml:"review,omitempty" json:"review,omitempty"`
+	AutoMerge    AutoMergeConfig    `yaml:"auto_merge,omitempty" json:"auto_merge,omitempty"`
 	// AgentSandbox configures the phase-1 credential-free sandbox runner. It is
 	// disabled by default and agents must opt in individually.
 	AgentSandbox AgentSandboxConfig `yaml:"agent_sandbox,omitempty" json:"agent_sandbox,omitempty"`
@@ -159,6 +164,48 @@ type TriggerRule struct {
 	Expr     string `yaml:"expr" json:"expr"`
 	Agent    string `yaml:"agent" json:"agent"`
 	Priority int    `yaml:"priority,omitempty" json:"priority,omitempty"`
+}
+
+// ToolApprovalConfig configures the approval desk (RFC #4000).
+//
+// The desk consolidates four independently-grown gates onto one decision point.
+// Because a silent behavior change on upgrade day is exactly what the RFC's
+// throughput contract forbids, the whole block is opt-in: with Enabled=false
+// (the default) no producer consults the desk and every legacy gate stays
+// authoritative. Turning it on does NOT change what a level permits — the desk
+// reproduces current behavior 1:1 (see pkg/toolapprove/parity.go) — it makes
+// the decision inspectable and gives operators a place to hang rules.
+type ToolApprovalConfig struct {
+	// Enabled turns the desk on for wired producers. Default false.
+	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	// Rules are operator-authored CEL approval rules, evaluated in priority
+	// order. A rule can steer a request into a lane but can NEVER approve above
+	// the hive's ACMM level: the ceiling is applied after rule evaluation,
+	// unconditionally. Malformed rules are rejected at config load.
+	Rules []ToolApprovalRule `yaml:"rules,omitempty" json:"rules,omitempty"`
+	// InboxPath overrides where pending operator approvals persist. Empty uses
+	// the package default (/data/approvals/inbox.json) on the durable PVC.
+	InboxPath string `yaml:"inbox_path,omitempty" json:"inbox_path,omitempty"`
+}
+
+// ToolApprovalRule is one declarative approval rule. Mirrors TriggerRule's
+// shape so operators writing `triggers:` already know how to write these.
+type ToolApprovalRule struct {
+	// Name identifies the rule in verdicts, audit records, and the dashboard's
+	// filter chips. Required and unique.
+	Name string `yaml:"name" json:"name"`
+	// Expr is a CEL expression over the `request` activation. Must return bool.
+	// Example: request.kind == "self-merge" && request.checks_green &&
+	//          request.author == "dependabot[bot]"
+	Expr string `yaml:"expr" json:"expr"`
+	// Action is one of auto-approve, security-scan, operator-approve.
+	Action string `yaml:"action" json:"action"`
+	// Priority orders competing rules; higher wins. Ties keep file order.
+	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+	// MinACMMLevel optionally scopes the rule to hives at or above a level.
+	// This is scoping convenience, not the safety mechanism — the ACMM ceiling
+	// is what actually bounds a rule's reach.
+	MinACMMLevel int `yaml:"min_acmm_level,omitempty" json:"min_acmm_level,omitempty"`
 }
 
 // MintConfig configures the OIDC token mint service (pkg/mint). It is additive

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -35,6 +35,10 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.deps = deps
 	s.loadSidebarFromDisk()
 	s.registerContributeRoutes()
+	// Approval desk (RFC #4000). Routes register unconditionally; the handlers
+	// report "not enabled" when deps.ApprovalInbox is nil, so a disabled desk is
+	// an honest 200 the panel can render rather than a 404 that looks broken.
+	s.registerApprovalRoutes()
 
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
 	s.mux.HandleFunc("GET /api/style", s.handleStyle)

--- a/src/pkg/dashboard/api_approvals.go
+++ b/src/pkg/dashboard/api_approvals.go
@@ -1,0 +1,325 @@
+package dashboard
+
+// Operator approval desk API (RFC #4000).
+//
+//	GET  /api/approvals            — list pending operator-lane approvals
+//	POST /api/approvals/resolve    — resolve ONE approval
+//	POST /api/approvals/bulk       — resolve MANY, as N individual resolutions
+//
+// All three are owner-gated with requireOwnerRole, which additionally demands
+// the server-verified marker header — the same bar the token-access, backup,
+// and governor-security endpoints enforce. Approving a pending tool call is at
+// least as privileged as those: a granted verdict lets an agent take an action
+// the hive's ACMM level otherwise reserved for a human.
+//
+// The bulk path is deliberately NOT a parallel implementation. It calls
+// Inbox.ResolveMany, which calls Inbox.Resolve once per item — the same
+// function the single-item handler calls — and returns a per-item result list.
+// This mirrors runBulkAction/applyBulkAction in pkg/hub/saas_bulk.go, and it is
+// the shape RFC #4000 requires: "a bulk approve is N individual evaluations
+// through the same decision function every agent request goes through".
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/toolapprove"
+)
+
+// maxBulkApprovalsPerRequest caps how many approvals one bulk call may resolve.
+// The canonical case from fleet-owner feedback is "bulk approve fifty green
+// dependabot PRs", so this covers a select-all comfortably while keeping a
+// buggy or malicious client from asking the hive to journal an unbounded number
+// of resolutions in one request.
+const maxBulkApprovalsPerRequest = 200
+
+// maxApprovalRequestBodyBytes caps a request body. The largest legitimate body
+// is a bulk call carrying maxBulkApprovalsPerRequest 32-char IDs plus a short
+// rationale, so 64KiB is generous — the same ceiling saas_bulk.go applies.
+const maxApprovalRequestBodyBytes = 64 * 1024
+
+// registerApprovalRoutes wires the desk endpoints. Kept in its own file and its
+// own register function so this feature's diff does not collide with the
+// concurrently-edited route tables, matching registerBulkRoutes' rationale.
+func (s *Server) registerApprovalRoutes() {
+	s.mux.HandleFunc("GET /api/approvals", s.handleApprovalsList)
+	s.mux.HandleFunc("POST /api/approvals/resolve", s.handleApprovalResolve)
+	s.mux.HandleFunc("POST /api/approvals/bulk", s.handleApprovalBulk)
+}
+
+// approvalInbox returns the server's inbox, or nil when the desk is disabled.
+// Every handler tolerates nil by reporting an empty, disabled desk rather than
+// erroring: with the feature off the panel should render as "not enabled", not
+// as a broken endpoint.
+func (s *Server) approvalInbox() *toolapprove.Inbox {
+	if s.deps == nil {
+		return nil
+	}
+	return s.deps.ApprovalInbox
+}
+
+// approvalDesk returns the server's desk, or nil when disabled.
+func (s *Server) approvalDesk() *toolapprove.Desk {
+	if s.deps == nil {
+		return nil
+	}
+	return s.deps.ApprovalDesk
+}
+
+// ApprovalRow is one pending item as the dashboard renders it.
+type ApprovalRow struct {
+	ID        string `json:"id"`
+	Kind      string `json:"kind"`
+	Tool      string `json:"tool"`
+	Agent     string `json:"agent"`
+	Repo      string `json:"repo,omitempty"`
+	Number    int    `json:"number,omitempty"`
+	Title     string `json:"title,omitempty"`
+	Rationale string `json:"rationale"`
+	QueuedAt  string `json:"queued_at"`
+	ACMMLevel int    `json:"acmm_level"`
+	// Rule is the operator rule that WOULD resolve this item, re-evaluated live
+	// against the current rule set rather than replayed from the enqueue-time
+	// verdict. An operator editing rules sees the effect on the pending queue
+	// immediately, which is the "tuning knobs embedded in the review loop"
+	// behavior the fleet-owner feedback asked for.
+	Rule string `json:"rule,omitempty"`
+	// RuleAction is what that rule asks for.
+	RuleAction string `json:"rule_action,omitempty"`
+	// PolicyBug marks an item queued on a hive at ACMM L6+. Per requirement 4
+	// of the throughput contract, an inbox accumulating at full autonomy is a
+	// misconfiguration signal, not a normal wait — the UI renders these
+	// distinctly rather than letting them sit politely.
+	PolicyBug bool `json:"policy_bug,omitempty"`
+}
+
+// ApprovalsResponse is the GET /api/approvals body.
+type ApprovalsResponse struct {
+	// Enabled reports whether the desk is configured on this hive.
+	Enabled bool `json:"enabled"`
+	// Count is the pending total — the dashboard's badge value.
+	Count int `json:"count"`
+	// Items are the pending rows.
+	Items []ApprovalRow `json:"items"`
+	// RuleChips are the distinct rule names across pending items, for filters.
+	RuleChips []string `json:"rule_chips"`
+	// PolicyBugCount is how many pending items are queued at L6+.
+	PolicyBugCount int `json:"policy_bug_count"`
+	// ACMMLevel is the hive's current level, so the panel can explain why a
+	// lane resolved the way it did.
+	ACMMLevel int `json:"acmm_level"`
+}
+
+// handleApprovalsList returns the pending operator-lane approvals.
+func (s *Server) handleApprovalsList(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
+	inbox := s.approvalInbox()
+	if inbox == nil {
+		jsonResponse(w, ApprovalsResponse{Enabled: false, Items: []ApprovalRow{}, RuleChips: []string{}})
+		return
+	}
+
+	desk := s.approvalDesk()
+	pending := inbox.List()
+	rows := make([]ApprovalRow, 0, len(pending))
+	policyBugs := 0
+
+	for _, p := range pending {
+		row := ApprovalRow{
+			ID:        p.ID,
+			Kind:      p.Request.Kind,
+			Tool:      p.Verdict.Tool,
+			Agent:     p.Verdict.Agent,
+			Repo:      p.Request.Repo,
+			Number:    p.Request.Number,
+			Title:     p.Request.Title,
+			Rationale: p.Verdict.Rationale,
+			QueuedAt:  p.QueuedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			ACMMLevel: p.ACMMLevel,
+		}
+		// Re-evaluate which rule would resolve this item against the CURRENT
+		// rule set, so the panel reflects live policy rather than a snapshot.
+		if desk != nil {
+			if m, ok := desk.WouldMatchRule(p.Request, p.ACMMLevel); ok {
+				row.Rule = m.Name
+				row.RuleAction = string(m.Action)
+			}
+		}
+		if p.ACMMLevel >= 6 {
+			row.PolicyBug = true
+			policyBugs++
+		}
+		rows = append(rows, row)
+	}
+
+	chips := inbox.RuleChips()
+	if chips == nil {
+		chips = []string{}
+	}
+
+	jsonResponse(w, ApprovalsResponse{
+		Enabled:        true,
+		Count:          len(rows),
+		Items:          rows,
+		RuleChips:      chips,
+		PolicyBugCount: policyBugs,
+		ACMMLevel:      s.currentACMMLevel(),
+	})
+}
+
+// ApprovalResolveRequest is the POST /api/approvals/resolve body.
+type ApprovalResolveRequest struct {
+	ID        string `json:"id"`
+	Approved  bool   `json:"approved"`
+	Rationale string `json:"rationale,omitempty"`
+}
+
+// handleApprovalResolve resolves ONE pending approval.
+func (s *Server) handleApprovalResolve(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	inbox := s.approvalInbox()
+	if inbox == nil {
+		jsonError(w, "approval desk is not enabled on this hive", http.StatusNotFound)
+		return
+	}
+
+	var req ApprovalResolveRequest
+	if err := decodeApprovalBody(r, &req); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.ID) == "" {
+		jsonError(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	operator := approvalOperator(r)
+	rec, err := inbox.Resolve(req.ID, req.Approved, operator, req.Rationale)
+	if err != nil {
+		// A replayed resolve is a 409, not a 500: the caller's intent was
+		// already satisfied and re-executing is exactly what the journal
+		// prevents. The original outcome is returned so the client can
+		// reconcile its stale UI.
+		if strings.Contains(err.Error(), toolapprove.ErrAlreadyResolved.Error()) {
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error":       err.Error(),
+				"id":          rec.ID,
+				"approved":    rec.Approved,
+				"executed":    rec.Executed,
+				"resolved_at": rec.ResolvedAt,
+			})
+			return
+		}
+		jsonError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	s.auditFromRequest(r, "approval-resolve",
+		auditDetail("id", req.ID, "approved", fmt.Sprintf("%t", req.Approved)), "")
+
+	jsonResponse(w, map[string]any{
+		"ok":          true,
+		"id":          rec.ID,
+		"approved":    rec.Approved,
+		"resolved_at": rec.ResolvedAt,
+		"pending":     inbox.Count(),
+	})
+}
+
+// ApprovalBulkRequest is the POST /api/approvals/bulk body.
+type ApprovalBulkRequest struct {
+	IDs       []string `json:"ids"`
+	Approved  bool     `json:"approved"`
+	Rationale string   `json:"rationale,omitempty"`
+}
+
+// handleApprovalBulk resolves MANY approvals as N individual resolutions.
+//
+// Partial failure is the normal case (an item may have been resolved by another
+// operator between the list and the click), so the response is a per-item
+// result list rather than a single boolean — the same contract BulkHiveResult
+// establishes for bulk hive actions.
+func (s *Server) handleApprovalBulk(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	inbox := s.approvalInbox()
+	if inbox == nil {
+		jsonError(w, "approval desk is not enabled on this hive", http.StatusNotFound)
+		return
+	}
+
+	var req ApprovalBulkRequest
+	if err := decodeApprovalBody(r, &req); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(req.IDs) == 0 {
+		jsonError(w, "ids is required", http.StatusBadRequest)
+		return
+	}
+	if len(req.IDs) > maxBulkApprovalsPerRequest {
+		jsonError(w, fmt.Sprintf("too many ids: %d (max %d)", len(req.IDs), maxBulkApprovalsPerRequest),
+			http.StatusBadRequest)
+		return
+	}
+
+	operator := approvalOperator(r)
+	// N individual resolutions through the SAME Resolve the single path uses.
+	results := inbox.ResolveMany(req.IDs, req.Approved, operator, req.Rationale)
+
+	okCount := 0
+	for _, res := range results {
+		if res.Ok {
+			okCount++
+		}
+	}
+
+	s.auditFromRequest(r, "approval-bulk",
+		auditDetail("count", fmt.Sprintf("%d", len(req.IDs)),
+			"resolved", fmt.Sprintf("%d", okCount),
+			"approved", fmt.Sprintf("%t", req.Approved)), "")
+
+	jsonResponse(w, map[string]any{
+		"ok":       true,
+		"results":  results,
+		"resolved": okCount,
+		"pending":  inbox.Count(),
+	})
+}
+
+// decodeApprovalBody reads a bounded JSON body.
+func decodeApprovalBody(r *http.Request, dst any) error {
+	defer r.Body.Close()
+	dec := json.NewDecoder(http.MaxBytesReader(nil, r.Body, maxApprovalRequestBodyBytes))
+	if err := dec.Decode(dst); err != nil {
+		return fmt.Errorf("invalid request body: %w", err)
+	}
+	return nil
+}
+
+// approvalOperator resolves who is resolving, for the journal and audit log.
+func approvalOperator(r *http.Request) string {
+	if u := r.Header.Get("X-Hive-User"); u != "" {
+		return u
+	}
+	return "local"
+}
+
+// currentACMMLevel reads the hive's configured level for display, defaulting to
+// the most restrictive reading when unset — the same fail-closed default
+// toolapprove.ACMMLevelOf applies.
+func (s *Server) currentACMMLevel() int {
+	if s.deps == nil || s.deps.Config == nil || s.deps.Config.ACMMLevel == nil {
+		return 0
+	}
+	return *s.deps.Config.ACMMLevel
+}

--- a/src/pkg/dashboard/api_approvals_test.go
+++ b/src/pkg/dashboard/api_approvals_test.go
@@ -1,0 +1,264 @@
+package dashboard
+
+// Approval desk API: authorization, listing, single and bulk resolve.
+//
+// The authorization tests matter most. Approving a pending tool call lets an
+// agent take an action the hive's ACMM level otherwise reserved for a human, so
+// these endpoints must be owner-gated exactly like token-access and backup.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/toolapprove"
+)
+
+// approvalServer wires a dashboard server with an enabled desk over a temp
+// inbox, and seeds n pending operator-lane approvals.
+func approvalServer(t *testing.T, n int) (*Server, *toolapprove.Inbox) {
+	t.Helper()
+	s, deps := apiServer(t)
+
+	inbox := toolapprove.NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	eng, err := toolapprove.CompileRules([]toolapprove.Rule{{
+		Name:   "needs-human",
+		Expr:   `request.kind == "self-merge"`,
+		Action: toolapprove.RuleActionOperatorApprove,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	deps.ApprovalDesk = toolapprove.NewDesk(eng, nil)
+	deps.ApprovalInbox = inbox
+
+	for i := 1; i <= n; i++ {
+		req := toolapprove.Request{
+			Kind:   toolapprove.KindSelfMerge,
+			Repo:   "kubestellar/hive",
+			Number: i,
+			Author: "hive-app[bot]",
+			Tool:   toolapprove.ToolRequest{Tool: "hive-merge"},
+		}
+		v := toolapprove.Verdict{
+			Decision:  toolapprove.DecisionOperatorApprove,
+			ACMMLevel: 4,
+			Tool:      "hive-merge",
+			Rule:      "needs-human",
+		}
+		if _, err := inbox.Enqueue(req, v); err != nil {
+			t.Fatalf("seed enqueue: %v", err)
+		}
+	}
+	return s, inbox
+}
+
+// TestApprovalsRequireOwnerRole is the behavioural authorization guard on all
+// three endpoints.
+func TestApprovalsRequireOwnerRole(t *testing.T) {
+	s, _ := approvalServer(t, 2)
+
+	if rec := doGet(s, "/api/approvals"); rec.Code != http.StatusForbidden {
+		t.Errorf("non-owner GET /api/approvals = %d, want 403 — a read-only user "+
+			"must not enumerate pending approvals (they quote tool arguments)", rec.Code)
+	}
+
+	for _, path := range []string{"/api/approvals/resolve", "/api/approvals/bulk"} {
+		rec := doNonOwnerPost(s, path, map[string]any{"id": "x", "ids": []string{"x"}, "approved": true})
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("non-owner POST %s = %d, want 403 — a non-owner must not be able "+
+				"to grant an agent an action the ACMM level reserved for a human", path, rec.Code)
+		}
+	}
+}
+
+// TestApprovalsReadWriteRoleRejected pins that a contributor (read-write) role
+// is not sufficient — only owner.
+func TestApprovalsReadWriteRoleRejected(t *testing.T) {
+	s, _ := approvalServer(t, 1)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/approvals", nil)
+	req.Header.Set("X-Hive-Role", "read-write")
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("read-write GET /api/approvals = %d, want 403", rec.Code)
+	}
+}
+
+// TestApprovalsOwnerMarkerRequired pins that claiming the owner role without
+// the SERVER-VERIFIED marker is refused — a spoofed header must not suffice.
+func TestApprovalsOwnerMarkerRequired(t *testing.T) {
+	s, _ := approvalServer(t, 1)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/approvals", nil)
+	req.Header.Set("X-Hive-Role", "owner")
+	// Deliberately NO ownerRoleVerifiedHeader — this is the spoof case.
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("owner role WITHOUT the server-verified marker = %d, want 403 — "+
+			"a client-supplied role header must never be sufficient", rec.Code)
+	}
+}
+
+// TestApprovalsListReturnsPending is the positive control: with a real owner,
+// the endpoint returns the seeded rows and the rule that would resolve them.
+func TestApprovalsListReturnsPending(t *testing.T) {
+	s, _ := approvalServer(t, 3)
+
+	rec := doOwnerGet(s, "/api/approvals")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner GET /api/approvals = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp ApprovalsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Enabled {
+		t.Error("response reports the desk disabled although an inbox is wired")
+	}
+	if resp.Count != 3 || len(resp.Items) != 3 {
+		t.Fatalf("count=%d items=%d, want 3 and 3", resp.Count, len(resp.Items))
+	}
+	for _, item := range resp.Items {
+		if item.Rule != "needs-human" {
+			t.Errorf("row %s does not show which rule would resolve it: %q", item.ID, item.Rule)
+		}
+		if item.Kind != toolapprove.KindSelfMerge {
+			t.Errorf("row %s lost its kind: %q", item.ID, item.Kind)
+		}
+	}
+	if len(resp.RuleChips) != 1 || resp.RuleChips[0] != "needs-human" {
+		t.Errorf("RuleChips = %v, want [needs-human]", resp.RuleChips)
+	}
+}
+
+// TestApprovalsDisabledDeskReportsCleanly pins that a hive without the feature
+// gets an honest "not enabled" 200 rather than a 404 that looks broken.
+func TestApprovalsDisabledDeskReportsCleanly(t *testing.T) {
+	s, _ := apiServer(t) // no ApprovalDesk / ApprovalInbox
+
+	rec := doOwnerGet(s, "/api/approvals")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner GET with desk disabled = %d, want 200", rec.Code)
+	}
+	var resp ApprovalsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Enabled {
+		t.Error("desk reports enabled with no inbox wired")
+	}
+	if resp.Items == nil {
+		t.Error("Items is null rather than an empty array — the UI would need a null guard")
+	}
+}
+
+// TestApprovalResolveSingle exercises the single-item resolve path end to end.
+func TestApprovalResolveSingle(t *testing.T) {
+	s, inbox := approvalServer(t, 2)
+	id := inbox.List()[0].ID
+
+	rec := doOwnerPost(s, "/api/approvals/resolve", map[string]any{"id": id, "approved": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resolve = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := inbox.Count(); got != 1 {
+		t.Errorf("after resolving 1 of 2, %d pending, want 1", got)
+	}
+
+	// Re-resolving the same ID must be a 409, not a second execution.
+	rec = doOwnerPost(s, "/api/approvals/resolve", map[string]any{"id": id, "approved": true})
+	if rec.Code != http.StatusConflict {
+		t.Errorf("re-resolve = %d, want 409 — a replayed grant must not double-execute", rec.Code)
+	}
+}
+
+// TestApprovalBulkResolvesEachIndividually pins that the bulk endpoint returns
+// a per-item result list and actually resolves each item.
+func TestApprovalBulkResolvesEachIndividually(t *testing.T) {
+	s, inbox := approvalServer(t, 5)
+
+	var ids []string
+	for _, p := range inbox.List() {
+		ids = append(ids, p.ID)
+	}
+
+	rec := doOwnerPost(s, "/api/approvals/bulk", map[string]any{"ids": ids, "approved": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bulk = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Results  []toolapprove.BulkResolveResult `json:"results"`
+		Resolved int                             `json:"resolved"`
+		Pending  int                             `json:"pending"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 5 {
+		t.Fatalf("bulk returned %d per-item results for 5 ids", len(resp.Results))
+	}
+	if resp.Resolved != 5 || resp.Pending != 0 {
+		t.Errorf("resolved=%d pending=%d, want 5 and 0", resp.Resolved, resp.Pending)
+	}
+	if inbox.Count() != 0 {
+		t.Errorf("%d items still pending after a bulk approve of all", inbox.Count())
+	}
+}
+
+// TestApprovalBulkRejectsOversizedBatch pins the blast-radius cap.
+func TestApprovalBulkRejectsOversizedBatch(t *testing.T) {
+	s, _ := approvalServer(t, 1)
+
+	ids := make([]string, maxBulkApprovalsPerRequest+1)
+	for i := range ids {
+		ids[i] = "id"
+	}
+	rec := doOwnerPost(s, "/api/approvals/bulk", map[string]any{"ids": ids, "approved": true})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("oversized bulk = %d, want 400", rec.Code)
+	}
+}
+
+// TestApprovalsSourceGate is the source-level invariant, mirroring the pattern
+// used for token-access: every handler in this file must carry the owner gate,
+// so a sync merge or refactor cannot silently drop it.
+func TestApprovalsSourceGate(t *testing.T) {
+	raw := f16ReadSource(t, "api_approvals.go")
+
+	for _, handler := range []string{"handleApprovalsList", "handleApprovalResolve", "handleApprovalBulk"} {
+		body := f16HandlerBody(t, raw, handler)
+		if !strings.Contains(body, "requireOwnerRole(w, r)") {
+			t.Errorf("%s has no requireOwnerRole gate — a non-owner could resolve pending "+
+				"approvals and grant agents actions the ACMM level reserved for a human. "+
+				"Restore the gate; do not remove this test.", handler)
+		}
+	}
+
+	// Count floor: three handlers, three gates. A refactor that collapses the
+	// handlers must not reduce the number of gates.
+	got := len(regexp.MustCompile(`requireOwnerRole\(w, r\)`).FindAllString(raw, -1))
+	if got < 3 {
+		t.Errorf("api_approvals.go has %d requireOwnerRole gates, want at least 3", got)
+	}
+}
+
+// doNonOwnerPost posts WITHOUT the owner headers.
+func doNonOwnerPost(s *Server, path string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(b)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubestellar/hive/pkg/knowledge"
 	"github.com/kubestellar/hive/pkg/scheduler"
 	"github.com/kubestellar/hive/pkg/tokens"
+	"github.com/kubestellar/hive/pkg/toolapprove"
 )
 
 type Dependencies struct {
@@ -78,6 +79,16 @@ type Dependencies struct {
 	// repo is tried in the same spelling the ledger keys on (the config repo
 	// form); a nil func means "no claim data" and disables the check.
 	IssueClaimed func(repo string, number int) (ghpkg.IssueClaim, bool)
+
+	// ApprovalDesk is the single tool-approval decision point (RFC #4000). Nil
+	// when `tool_approval.enabled` is false — the default — in which case every
+	// legacy gate stays authoritative and the Approvals panel renders as "not
+	// enabled". Never construct a desk here as a fallback: a nil desk IS the
+	// signal that the feature is off.
+	ApprovalDesk *toolapprove.Desk
+	// ApprovalInbox is the durable operator-lane queue backing the desk. Nil
+	// exactly when ApprovalDesk is nil (both come from DeskFromConfig).
+	ApprovalInbox *toolapprove.Inbox
 }
 
 type NousState struct {

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -3136,6 +3136,27 @@
     </div>
   </div>
 
+  <!-- Approvals desk (RFC #4000). Hidden until /api/approvals reports the desk
+       enabled, so a hive that has not opted in sees no new chrome. -->
+  <div id="approvals-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('approvals-section')"><span class="section-chevron">▼</span> ✋ Approvals <span id="approvals-badge" title="Pending operator approvals" style="display:none;font-size:0.62em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px;background:color-mix(in srgb, var(--yellow) 25%, transparent);color:var(--text)">0</span></h2>
+    <div class="section-body">
+      <div id="approvals-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
+        <!-- Policy-bug banner: an inbox accumulating on a full-autonomy hive is
+             a misconfiguration signal, not a normal wait (#4000 requirement 4). -->
+        <div id="approvals-policy-bug" style="display:none;margin-bottom:10px;padding:8px 10px;border-radius:6px;background:color-mix(in srgb, var(--red) 12%, transparent);border:1px solid color-mix(in srgb, var(--red) 40%, transparent);font-size:0.75rem"></div>
+        <div id="approvals-chips" style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px;font-size:0.72rem"></div>
+        <div id="approvals-actions" style="display:none;gap:8px;align-items:center;margin-bottom:10px;font-size:0.75rem">
+          <button class="btn" onclick="approvalsResolveSelected(true)">Approve selected</button>
+          <button class="btn" onclick="approvalsResolveSelected(false)">Reject selected</button>
+          <span class="muted" id="approvals-selected-count"></span>
+        </div>
+        <div id="approvals-list"></div>
+        <div id="approvals-empty" class="muted" style="font-size:0.78rem">No pending approvals.</div>
+      </div>
+    </div>
+  </div>
+
   <div id="platform-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
     <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('platform-section')"><span class="section-chevron">▼</span> 🧩 Platform</h2>
     <div class="section-body">
@@ -8618,9 +8639,161 @@ function burnAreaChart() {
       } catch (e) { /* transient — leave last render in place */ }
     }
 
+    // ---- Approvals desk (RFC #4000) -------------------------------------
+    // Pending operator-lane approvals. The panel stays hidden entirely unless
+    // the desk is enabled, so a hive that has not opted in sees no new chrome.
+    //
+    // Filter chips are rule names: an operator narrows the list to "everything
+    // the large-diff rule would hold" and bulk-resolves just those. Each row
+    // shows WHICH rule would resolve it, re-evaluated server-side against the
+    // current rule set, so editing policy is visible immediately in the queue.
+    let _approvalsSelected = new Set();
+    let _approvalsRuleFilter = null;
+    let _approvalsLast = null;
+
+    async function fetchApprovals() {
+      try {
+        const r = await fetch('/api/approvals');
+        if (!r.ok) return;               // 403 for non-owners: leave hidden
+        renderApprovals(await r.json());
+      } catch (e) { /* transient — leave last render in place */ }
+    }
+
+    function renderApprovals(dto) {
+      _approvalsLast = dto;
+      const section = document.getElementById('approvals-section');
+      if (!section) return;
+      if (!dto || !dto.enabled) { section.style.display = 'none'; return; }
+      section.style.display = '';
+
+      const items = dto.items || [];
+
+      // Badge: pending count, hidden at zero so a quiet desk is not noise.
+      const badge = document.getElementById('approvals-badge');
+      if (badge) {
+        badge.textContent = String(dto.count || 0);
+        badge.style.display = (dto.count > 0) ? '' : 'none';
+      }
+
+      // Requirement 4: items queued at full autonomy are probable policy bugs.
+      const bug = document.getElementById('approvals-policy-bug');
+      if (bug) {
+        if (dto.policy_bug_count > 0) {
+          bug.style.display = '';
+          bug.innerHTML = '⚠️ <strong>' + dto.policy_bug_count + '</strong> item(s) are waiting on a hive at ACMM L6 (full autonomy). ' +
+            'An inbox that accumulates at L6 usually means a policy rule is over-restrictive, not that a human is needed.';
+        } else {
+          bug.style.display = 'none';
+        }
+      }
+
+      // Rule chips as filters.
+      const chips = document.getElementById('approvals-chips');
+      if (chips) {
+        const names = dto.rule_chips || [];
+        let html = renderApprovalChip(null, 'All', _approvalsRuleFilter === null);
+        for (const n of names) html += renderApprovalChip(n, n, _approvalsRuleFilter === n);
+        chips.innerHTML = html;
+      }
+
+      const shown = _approvalsRuleFilter
+        ? items.filter(i => i.rule === _approvalsRuleFilter)
+        : items;
+
+      // Drop selections for rows that no longer exist (resolved elsewhere).
+      const live = new Set(items.map(i => i.id));
+      for (const id of Array.from(_approvalsSelected)) if (!live.has(id)) _approvalsSelected.delete(id);
+
+      const list = document.getElementById('approvals-list');
+      const empty = document.getElementById('approvals-empty');
+      if (empty) empty.style.display = shown.length ? 'none' : '';
+      if (list) list.innerHTML = shown.map(renderApprovalRow).join('');
+
+      updateApprovalsActions();
+    }
+
+    function renderApprovalChip(value, label, active) {
+      const bg = active ? 'color-mix(in srgb, var(--accent) 25%, transparent)' : 'transparent';
+      return '<button class="repo-chip-btn" style="background:' + bg + '" ' +
+        'onclick="approvalsSetFilter(' + (value === null ? 'null' : JSON.stringify(value)) + ')">' +
+        escapeHtml(label) + '</button>';
+    }
+
+    function renderApprovalRow(it) {
+      const checked = _approvalsSelected.has(it.id) ? ' checked' : '';
+      const target = it.repo ? (it.repo + (it.number ? '#' + it.number : '')) : (it.tool || '');
+      const ruleChip = it.rule
+        ? '<span style="padding:1px 6px;border-radius:8px;font-size:0.66rem;background:color-mix(in srgb, var(--accent) 18%, transparent)">' +
+            escapeHtml(it.rule) + ' → ' + escapeHtml(it.rule_action || '') + '</span>'
+        : '<span class="muted" style="font-size:0.66rem">base policy</span>';
+      const bugMark = it.policy_bug ? ' <span title="Queued at ACMM L6 — probable policy bug">⚠️</span>' : '';
+
+      return '<div style="display:flex;gap:8px;align-items:flex-start;padding:7px 0;border-top:1px solid var(--border);font-size:0.75rem">' +
+        '<input type="checkbox"' + checked + ' onchange="approvalsToggle(' + JSON.stringify(it.id) + ')">' +
+        '<div style="flex:1;min-width:0">' +
+          '<div><strong>' + escapeHtml(target) + '</strong>' + bugMark +
+            ' <span class="muted">' + escapeHtml(it.kind || '') + '</span></div>' +
+          '<div class="muted" style="font-size:0.7rem;margin-top:2px">' + escapeHtml(it.rationale || '') + '</div>' +
+          '<div style="margin-top:3px">' + ruleChip + '</div>' +
+        '</div>' +
+        '<div style="display:flex;gap:5px">' +
+          '<button class="btn" onclick="approvalsResolveOne(' + JSON.stringify(it.id) + ',true)">Approve</button>' +
+          '<button class="btn" onclick="approvalsResolveOne(' + JSON.stringify(it.id) + ',false)">Reject</button>' +
+        '</div>' +
+      '</div>';
+    }
+
+    function updateApprovalsActions() {
+      const actions = document.getElementById('approvals-actions');
+      const count = document.getElementById('approvals-selected-count');
+      if (!actions) return;
+      actions.style.display = _approvalsSelected.size ? 'flex' : 'none';
+      if (count) count.textContent = _approvalsSelected.size + ' selected';
+    }
+
+    function approvalsSetFilter(rule) {
+      _approvalsRuleFilter = rule;
+      if (_approvalsLast) renderApprovals(_approvalsLast);
+    }
+
+    function approvalsToggle(id) {
+      if (_approvalsSelected.has(id)) _approvalsSelected.delete(id);
+      else _approvalsSelected.add(id);
+      updateApprovalsActions();
+    }
+
+    async function approvalsResolveOne(id, approved) {
+      try {
+        await fetch('/api/approvals/resolve', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: id, approved: approved })
+        });
+      } catch (e) { /* surfaced by the refetch below */ }
+      _approvalsSelected.delete(id);
+      fetchApprovals();
+    }
+
+    // Bulk resolve. The server decomposes this into N individual resolutions
+    // through the same path the single-item button uses — this is a UI
+    // convenience, never a separate decision path.
+    async function approvalsResolveSelected(approved) {
+      const ids = Array.from(_approvalsSelected);
+      if (!ids.length) return;
+      try {
+        await fetch('/api/approvals/bulk', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids: ids, approved: approved })
+        });
+      } catch (e) { /* surfaced by the refetch below */ }
+      _approvalsSelected.clear();
+      fetchApprovals();
+    }
+
     // Prime both panels and poll them on a modest independent interval. Do not
     // block initial paint: these run after the main poll is already wired.
-    function v4RefreshPanels() { fetchACMMReco(); fetchLifecycle(); }
+    function v4RefreshPanels() { fetchACMMReco(); fetchLifecycle(); fetchApprovals(); }
     v4RefreshPanels();
     setInterval(v4RefreshPanels, V4_PANELS_POLL_MS);
 

--- a/src/pkg/github/automerge_desk.go
+++ b/src/pkg/github/automerge_desk.go
@@ -1,0 +1,116 @@
+package github
+
+// Approval-desk hook for the self-authored auto-merge sweep — the ONE real
+// producer wired in the RFC #4000 vertical slice.
+//
+// Why this producer: the self-merge gate is the cheapest honest one to migrate.
+// It is already the exact shape the desk generalizes — (requested action, ACMM
+// level, identity) → verdict — it is the gate whose history the RFC cites (the
+// sweep originally had NO ACMM check, which is how an L4 hive wrongly
+// self-merged its own PR), and it needs no new call site: the sweep already
+// computes everything the desk's Request wants (repo, number, author, and a
+// real ChecksGreen from commitGreen).
+//
+// DEFAULT OFF. The hook is nil unless a caller installs one via
+// SetApprovalDesk, and a nil hook means trySweepSelfAuthoredPR behaves exactly
+// as it does today. This is the "live behavior is unchanged until enabled"
+// requirement: shipping this file changes nothing about any running hive.
+//
+// When the desk IS enabled, the sweep's own ACMM gate stays in place upstream
+// (StartSelfAuthoredAutoMergeSweep still refuses to start below the floor), so
+// the desk is strictly an ADDITIONAL, inspectable consultation on top — it can
+// withhold a merge the legacy gate would have allowed, and it can route one
+// into the operator inbox, but it can never permit a merge the legacy gate
+// refused. That asymmetry is what makes enabling the flag safe to try on a
+// live hive.
+
+import (
+	"context"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// labelNames flattens a PR's labels to their names for rule matching. A nil
+// label (possible in sparse API responses) is skipped rather than panicking.
+func labelNames(labels []*gh.Label) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l == nil {
+			continue
+		}
+		if name := l.GetName(); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// ApprovalDeskHook is the desk consultation the sweep performs per PR. It
+// returns allow=true to proceed with the merge, or allow=false with a reason
+// that the sweep reports as a normal skip.
+//
+// The signature is deliberately narrow — no toolapprove types — so pkg/github
+// does not take a dependency on the desk package. The caller (cmd/hive, which
+// already owns both) closes over the desk and the inbox and adapts. This keeps
+// the concurrent #4002 turn work free to reshape toolapprove internals without
+// touching the GitHub client.
+type ApprovalDeskHook func(ctx context.Context, req ApprovalDeskRequest) (allow bool, reason string)
+
+// ApprovalDeskRequest carries what the desk needs to resolve a self-merge.
+type ApprovalDeskRequest struct {
+	// Kind is always the self-merge lane for this producer; carried explicitly
+	// so one hook implementation can serve additional producers later.
+	Kind string
+	// Repo is the display repo, "org/name".
+	Repo string
+	// Number is the PR number.
+	Number int
+	// Author is the PR author's login (the App bot, on this path).
+	Author string
+	// Title is the PR title, for rule matching.
+	Title string
+	// Labels are the PR's labels, for rule matching.
+	Labels []string
+	// ChecksGreen reports the sweep's own commitGreen verdict. The canonical
+	// bulk-approve rule ("fifty green dependabot PRs") is written over this.
+	ChecksGreen bool
+	// HeadSHA pins which commit was evaluated, so a verdict is attributable to
+	// a specific tree rather than to "the PR".
+	HeadSHA string
+}
+
+// ApprovalDeskKindSelfMerge names the lane this producer feeds. It mirrors
+// toolapprove.KindSelfMerge without importing it.
+const ApprovalDeskKindSelfMerge = "self-merge"
+
+// SetApprovalDesk installs the approval-desk hook. Passing nil removes it,
+// restoring pre-desk behavior. A nil client is a no-op.
+//
+// Not guarded by a mutex because it is called once during startup wiring,
+// before any sweep goroutine starts — the same lifecycle every other
+// Client field setter on this type assumes.
+func (c *Client) SetApprovalDesk(hook ApprovalDeskHook) {
+	if c == nil {
+		return
+	}
+	c.approvalDesk = hook
+}
+
+// consultApprovalDesk runs the desk hook if one is installed. With no hook it
+// returns allow=true, which is what makes this whole feature a no-op by
+// default: the sweep proceeds exactly as it did before the desk existed.
+func (c *Client) consultApprovalDesk(ctx context.Context, req ApprovalDeskRequest) (bool, string) {
+	if c == nil || c.approvalDesk == nil {
+		return true, ""
+	}
+	allow, reason := c.approvalDesk(ctx, req)
+	if !allow && reason == "" {
+		// A hook that refuses without a reason still produces an actionable
+		// skip line rather than a mystery.
+		reason = "approval-desk-withheld"
+	}
+	return allow, reason
+}

--- a/src/pkg/github/automerge_desk_test.go
+++ b/src/pkg/github/automerge_desk_test.go
@@ -1,0 +1,132 @@
+package github
+
+// The wired producer: the self-authored auto-merge sweep's desk consultation.
+//
+// The most important property here is the DEFAULT: shipping this code must not
+// change any running hive. That is what TestNoDeskInstalledIsNoOp pins.
+
+import (
+	"context"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// TestNoDeskInstalledIsNoOp is the default-OFF guarantee. With no hook
+// installed, the consultation allows unconditionally, so the sweep behaves
+// exactly as it did before the desk existed.
+func TestNoDeskInstalledIsNoOp(t *testing.T) {
+	c := &Client{}
+	allow, reason := c.consultApprovalDesk(context.Background(), ApprovalDeskRequest{
+		Kind: ApprovalDeskKindSelfMerge, Repo: "kubestellar/hive", Number: 1,
+	})
+	if !allow {
+		t.Fatalf("with no desk installed the sweep must proceed unchanged; got allow=false reason=%q", reason)
+	}
+	if reason != "" {
+		t.Errorf("no-op consultation produced a reason: %q", reason)
+	}
+
+	// A nil client is also safe — the sweep's own nil guards rely on it.
+	var nilClient *Client
+	if allow, _ := nilClient.consultApprovalDesk(context.Background(), ApprovalDeskRequest{}); !allow {
+		t.Error("nil client consultation returned allow=false")
+	}
+}
+
+// TestSetApprovalDeskInstallsAndRemoves pins the setter, including that passing
+// nil restores pre-desk behavior (the operator's escape hatch).
+func TestSetApprovalDeskInstallsAndRemoves(t *testing.T) {
+	c := &Client{}
+	called := false
+	c.SetApprovalDesk(func(context.Context, ApprovalDeskRequest) (bool, string) {
+		called = true
+		return false, "withheld-by-test"
+	})
+
+	allow, reason := c.consultApprovalDesk(context.Background(), ApprovalDeskRequest{Number: 1})
+	if !called {
+		t.Fatal("installed hook was not called")
+	}
+	if allow || reason != "withheld-by-test" {
+		t.Errorf("hook result not honored: allow=%v reason=%q", allow, reason)
+	}
+
+	// Removing it restores the no-op.
+	c.SetApprovalDesk(nil)
+	if allow, _ := c.consultApprovalDesk(context.Background(), ApprovalDeskRequest{Number: 1}); !allow {
+		t.Error("SetApprovalDesk(nil) did not restore pre-desk behavior")
+	}
+}
+
+// TestWithheldHookAlwaysProducesAReason pins that a refusal is always
+// actionable in the sweep's skip log, never a mystery blank.
+func TestWithheldHookAlwaysProducesAReason(t *testing.T) {
+	c := &Client{}
+	c.SetApprovalDesk(func(context.Context, ApprovalDeskRequest) (bool, string) {
+		return false, "" // a sloppy hook
+	})
+	allow, reason := c.consultApprovalDesk(context.Background(), ApprovalDeskRequest{Number: 1})
+	if allow {
+		t.Fatal("a refusing hook was treated as allowing")
+	}
+	if reason == "" {
+		t.Error("a refusal with no reason produced an empty skip reason — the sweep log would be unactionable")
+	}
+}
+
+// TestApprovalDeskReceivesRequestFields pins that the sweep hands the desk the
+// fields operator rules are written against — a rule over checks_green or
+// author is useless if the producer never populates them.
+func TestApprovalDeskReceivesRequestFields(t *testing.T) {
+	c := &Client{}
+	var got ApprovalDeskRequest
+	c.SetApprovalDesk(func(_ context.Context, in ApprovalDeskRequest) (bool, string) {
+		got = in
+		return true, ""
+	})
+
+	want := ApprovalDeskRequest{
+		Kind:        ApprovalDeskKindSelfMerge,
+		Repo:        "kubestellar/hive",
+		Number:      4000,
+		Author:      "hive-app[bot]",
+		Title:       "fix: a thing",
+		Labels:      []string{"kind/bug"},
+		ChecksGreen: true,
+		HeadSHA:     "deadbeef",
+	}
+	c.consultApprovalDesk(context.Background(), want)
+
+	if got.Repo != want.Repo || got.Number != want.Number || got.Author != want.Author {
+		t.Errorf("identity fields not passed through: %+v", got)
+	}
+	if !got.ChecksGreen {
+		t.Error("ChecksGreen was not passed through — the canonical dependabot rule depends on it")
+	}
+	if got.HeadSHA != want.HeadSHA {
+		t.Error("HeadSHA was not passed through — a verdict must be attributable to a specific tree")
+	}
+	if len(got.Labels) != 1 || got.Labels[0] != "kind/bug" {
+		t.Errorf("Labels not passed through: %v", got.Labels)
+	}
+}
+
+// TestLabelNames pins the label flattening, including the nil-element case that
+// sparse API responses can produce.
+func TestLabelNames(t *testing.T) {
+	if got := labelNames(nil); got != nil {
+		t.Errorf("labelNames(nil) = %v, want nil", got)
+	}
+
+	labels := []*gh.Label{
+		{Name: gh.Ptr("kind/bug")},
+		nil, // must not panic
+		{Name: gh.Ptr("")},
+		{Name: gh.Ptr("hold")},
+	}
+	got := labelNames(labels)
+	if len(got) != 2 || got[0] != "kind/bug" || got[1] != "hold" {
+		t.Errorf("labelNames = %v, want [kind/bug hold] (nil and empty skipped)", got)
+	}
+}

--- a/src/pkg/github/automerge_sweep.go
+++ b/src/pkg/github/automerge_sweep.go
@@ -534,6 +534,24 @@ func (c *Client) trySweepSelfAuthoredPR(ctx context.Context, displayRepo, owner,
 		return AutoMergeSweepEvent{}, reason, nil
 	}
 
+	// Approval desk (RFC #4000). Consulted AFTER the sweep's own eligibility
+	// checks so the desk only ever sees requests the legacy gate already
+	// permits — it can withhold a merge, never widen authority beyond what
+	// SelfAuthoredAutoMergeAllowed already granted upstream. No-op when no hook
+	// is installed, which is the default; see automerge_desk.go.
+	if allow, deskReason := c.consultApprovalDesk(ctx, ApprovalDeskRequest{
+		Kind:        ApprovalDeskKindSelfMerge,
+		Repo:        displayRepo,
+		Number:      number,
+		Author:      author,
+		Title:       pr.GetTitle(),
+		Labels:      labelNames(pr.Labels),
+		ChecksGreen: true, // commitGreen returned green immediately above
+		HeadSHA:     evaluatedHeadSHA,
+	}); !allow {
+		return AutoMergeSweepEvent{}, deskReason, nil
+	}
+
 	// Re-verify the head SHA immediately before merging: a push landing
 	// between the green-check above and the merge call below must never be
 	// squashed without having gone through commitGreen itself.

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -45,6 +45,11 @@ type Client struct {
 	canaryRegistry   *ioscan.CanaryRegistry
 	canaryLeakFunc   func(ioscan.CanaryLeak)
 	appBotLogin      string // "<app-slug>[bot]" when the client authenticates as a GitHub App
+	// approvalDesk is the RFC #4000 approval-desk consultation performed per PR
+	// by the self-authored auto-merge sweep. nil (the default) means the sweep
+	// behaves exactly as it did before the desk existed. Set by SetApprovalDesk
+	// during startup wiring; see automerge_desk.go.
+	approvalDesk ApprovalDeskHook
 	// prAuthz gates PR-open requests from the request-file watcher against the
 	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
 	// StartPRRequestWatcher.

--- a/src/pkg/toolapprove/bulk_parity_test.go
+++ b/src/pkg/toolapprove/bulk_parity_test.go
@@ -1,0 +1,193 @@
+package toolapprove
+
+// Bulk == N individual decisions.
+//
+// RFC #4000 is explicit that a bulk approve must never become a parallel
+// decision path: "a bulk approve is N individual evaluations through the same
+// decision function every agent request goes through". These tests pin that
+// equivalence rather than merely testing that the bulk path returns something.
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// mixedRequests spans every lane, so an equivalence that only held for one
+// decision would show up here.
+func mixedRequests() []Request {
+	return []Request{
+		// read-only → auto-approve at every level
+		{Kind: KindAgentTool, Tool: ToolRequest{Tool: "read", Arguments: map[string]any{"file_path": "a.go"}}, Agent: AgentIdentity{Name: "r"}},
+		// side-effectful write
+		{Kind: KindAgentTool, Tool: ToolRequest{Tool: "write", Arguments: map[string]any{"file_path": "b.go", "content": "x"}}, Agent: AgentIdentity{Name: "w"}},
+		// hard-denied guardrail
+		{Kind: KindAgentTool, Tool: ToolRequest{Tool: "mcp__github__create_pull_request"}, Agent: AgentIdentity{Name: "p"}},
+		// self-merge, green
+		{Kind: KindSelfMerge, Repo: "kubestellar/hive", Number: 1, Author: "dependabot[bot]", ChecksGreen: true, Tool: ToolRequest{Tool: "hive-merge"}},
+		// self-merge, red
+		{Kind: KindSelfMerge, Repo: "kubestellar/hive", Number: 2, Author: "someone", ChecksGreen: false, Tool: ToolRequest{Tool: "hive-merge"}},
+		// plan approval
+		{Kind: KindPlanApproval, Tool: ToolRequest{Tool: "plan"}, Agent: AgentIdentity{Name: "architect"}},
+		// bash command
+		{Kind: KindAgentTool, Tool: ToolRequest{Tool: "bash", Arguments: map[string]any{"command": "go test ./..."}}, Agent: AgentIdentity{Name: "t"}},
+	}
+}
+
+// TestResolveBatchEqualsNIndividualResolves is the equivalence assertion, run
+// across every ACMM level so a level-specific divergence cannot hide.
+func TestResolveBatchEqualsNIndividualResolves(t *testing.T) {
+	eng, err := CompileRules([]Rule{{
+		Name:   "green-dependabot",
+		Expr:   `request.kind == "self-merge" && request.checks_green && request.author == "dependabot[bot]"`,
+		Action: RuleActionAutoApprove,
+	}, {
+		Name:     "red-goes-to-operator",
+		Expr:     `request.kind == "self-merge" && !request.checks_green`,
+		Action:   RuleActionOperatorApprove,
+		Priority: 10,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	desk := NewDesk(eng, passingScanner{})
+	reqs := mixedRequests()
+
+	for level := 0; level <= 7; level++ {
+		batch := desk.ResolveBatch(context.Background(), reqs, level)
+
+		individual := make([]Verdict, 0, len(reqs))
+		for _, r := range reqs {
+			individual = append(individual, desk.Resolve(context.Background(), r, level))
+		}
+
+		if len(batch) != len(individual) {
+			t.Fatalf("L%d: batch returned %d verdicts, individual returned %d", level, len(batch), len(individual))
+		}
+		for i := range batch {
+			if !reflect.DeepEqual(batch[i], individual[i]) {
+				t.Errorf("L%d item %d (%s/%s): bulk verdict differs from the individual verdict\n bulk:       %+v\n individual: %+v\n"+
+					"a bulk approve MUST be N individual evaluations through the same decision function",
+					level, i, reqs[i].Kind, reqs[i].Tool.Tool, batch[i], individual[i])
+			}
+		}
+	}
+}
+
+// TestResolveBatchPreservesOrder pins that results line up with inputs — a
+// per-item result list is only useful if item i's verdict is at index i.
+func TestResolveBatchPreservesOrder(t *testing.T) {
+	desk := NewDesk(nil, passingScanner{})
+	reqs := mixedRequests()
+	got := desk.ResolveBatch(context.Background(), reqs, 4)
+
+	if len(got) != len(reqs) {
+		t.Fatalf("got %d verdicts for %d requests", len(got), len(reqs))
+	}
+	for i, v := range got {
+		if v.Kind != reqs[i].Kind {
+			t.Errorf("index %d: verdict kind %q does not match request kind %q — results are misaligned",
+				i, v.Kind, reqs[i].Kind)
+		}
+	}
+}
+
+// TestResolveManyEqualsNIndividualResolutions is the same equivalence for the
+// INBOX's bulk path, which is what the API's /bulk endpoint calls.
+func TestResolveManyEqualsNIndividualResolutions(t *testing.T) {
+	// Two inboxes seeded identically: one resolved in bulk, one item by item.
+	bulkInbox := NewInbox(filepath.Join(t.TempDir(), "bulk.json"))
+	oneInbox := NewInbox(filepath.Join(t.TempDir(), "one.json"))
+
+	var ids []string
+	for n := 1; n <= 5; n++ {
+		id, err := bulkInbox.Enqueue(pendingRequest(n), operatorVerdict())
+		if err != nil {
+			t.Fatalf("seed bulk: %v", err)
+		}
+		if _, err := oneInbox.Enqueue(pendingRequest(n), operatorVerdict()); err != nil {
+			t.Fatalf("seed individual: %v", err)
+		}
+		ids = append(ids, id)
+	}
+
+	bulkResults := bulkInbox.ResolveMany(ids, true, "operator", "batch approve")
+
+	for i, id := range ids {
+		_, err := oneInbox.Resolve(id, true, "operator", "batch approve")
+		ok := err == nil
+		if bulkResults[i].Ok != ok {
+			t.Errorf("item %d: bulk ok=%v, individual ok=%v", i, bulkResults[i].Ok, ok)
+		}
+	}
+
+	if bulkInbox.Count() != oneInbox.Count() {
+		t.Errorf("after resolution: bulk inbox has %d pending, individual has %d",
+			bulkInbox.Count(), oneInbox.Count())
+	}
+	for _, id := range ids {
+		b, okB := bulkInbox.ResolvedRecordFor(id)
+		o, okO := oneInbox.ResolvedRecordFor(id)
+		if okB != okO || b.Approved != o.Approved {
+			t.Errorf("journal divergence for %s: bulk=%+v individual=%+v", id, b, o)
+		}
+	}
+}
+
+// TestResolveManyReportsPartialFailure pins that partial failure is per-item
+// rather than aborting the batch — the normal case when another operator
+// resolved an item between the list and the click.
+func TestResolveManyReportsPartialFailure(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+
+	good1, _ := inbox.Enqueue(pendingRequest(1), operatorVerdict())
+	good2, _ := inbox.Enqueue(pendingRequest(2), operatorVerdict())
+
+	results := inbox.ResolveMany([]string{good1, "does-not-exist", good2}, true, "operator", "")
+	if len(results) != 3 {
+		t.Fatalf("got %d results for 3 ids", len(results))
+	}
+	if !results[0].Ok || !results[2].Ok {
+		t.Error("valid items failed alongside the invalid one — a bad ID must not abort the batch")
+	}
+	if results[1].Ok {
+		t.Error("a nonexistent ID reported success")
+	}
+	if results[1].Error == "" {
+		t.Error("a failed item carries no error message")
+	}
+	if got := inbox.Count(); got != 0 {
+		t.Errorf("both valid items should be resolved; %d still pending", got)
+	}
+}
+
+// TestResolveManyIsIdempotent pins that re-submitting a bulk approve does not
+// double-execute — the bulk path inherits the single path's journal.
+func TestResolveManyIsIdempotent(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	var ids []string
+	for n := 1; n <= 3; n++ {
+		id, _ := inbox.Enqueue(pendingRequest(n), operatorVerdict())
+		ids = append(ids, id)
+	}
+
+	first := inbox.ResolveMany(ids, true, "operator", "")
+	for i, r := range first {
+		if !r.Ok {
+			t.Fatalf("first bulk resolve item %d failed: %s", i, r.Error)
+		}
+	}
+
+	// Re-submit the identical batch (a double-clicked button, a retried request).
+	second := inbox.ResolveMany(ids, true, "operator", "")
+	for i, r := range second {
+		if r.Ok {
+			t.Errorf("re-submitted bulk item %d succeeded again — that is a double execution", i)
+		}
+		if !strings.Contains(r.Error, ErrAlreadyResolved.Error()) {
+			t.Errorf("item %d: expected an already-resolved error, got %q", i, r.Error)
+		}
+	}
+}

--- a/src/pkg/toolapprove/desk.go
+++ b/src/pkg/toolapprove/desk.go
@@ -1,0 +1,417 @@
+package toolapprove
+
+// The approval desk: the ONE decision point every approval-shaped request
+// resolves through.
+//
+// RFC #4000 diagnosed four independently-grown gates, each the same shape —
+// (requested action, ACMM level, identity) → verdict — with four different
+// failure modes:
+//
+//   - config.SelfMergeMinACMMLevel / AutoMergeConfig.SelfAuthoredAutoMergeAllowed
+//   - config.PlanAutoApproveForLevel        (decomposition path only)
+//   - config.PlanningConfig.PlanFromLabelEnabled
+//   - github.isTrustedMerger + latestHiveQueueApproval (inside the sweep)
+//
+// Desk.Resolve is the convergence point those four were reaching for. It does
+// not delete them — call sites migrate onto the desk incrementally, and
+// MigrationParity (parity.go) pins that the desk's answer equals the legacy
+// gate's answer for every level, so a migration can never silently downgrade a
+// hive.
+//
+// Three layers, evaluated in a fixed order:
+//
+//  1. The BASE verdict from Decide (hard guardrails, tool policy, ACMM level).
+//  2. Operator RULES as data — CEL expressions from config, evaluated through
+//     the existing celtrigger posture (compile-time rejection of malformed
+//     rules, runtime error = no-match). A rule may relax the base verdict.
+//  3. The ACMM CEILING, applied LAST and unconditionally. A rule can never
+//     approve above the hive's level. This ordering is the whole safety
+//     argument: rules are advisory input to a decision the ceiling always has
+//     the final word on. Test-pinned in desk_ceiling_test.go.
+//
+// The L6 throughput contract (#4000 comment 5321778076) is a property of this
+// file, not of the caller: Resolve is synchronous and allocation-light, and a
+// request that resolves to auto-approve returns DIRECTLY from here having
+// touched no queue, no store, and no external process. Only the operator lane
+// reaches the durable inbox, and only via the caller's explicit Enqueue.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RuleAction is the resolution an operator rule requests when its expression
+// matches. The set is deliberately smaller than Decision: a rule may steer a
+// request into a lane, but "deny" is the base policy's and the ceiling's
+// prerogative, never a rule's alone.
+type RuleAction string
+
+const (
+	// RuleActionAutoApprove asks that a matching request resolve immediately,
+	// subject to the ACMM ceiling.
+	RuleActionAutoApprove RuleAction = "auto-approve"
+	// RuleActionSecurityScan routes a matching request through the scanner.
+	RuleActionSecurityScan RuleAction = "security-scan"
+	// RuleActionOperatorApprove sends a matching request to the operator inbox.
+	// Always permitted: escalation is never gated by the ceiling.
+	RuleActionOperatorApprove RuleAction = "operator-approve"
+)
+
+// Valid reports whether the action is one the desk understands.
+func (a RuleAction) Valid() bool {
+	switch a {
+	case RuleActionAutoApprove, RuleActionSecurityScan, RuleActionOperatorApprove:
+		return true
+	}
+	return false
+}
+
+// decisionForAction maps a rule action onto the decision it requests.
+func (a RuleAction) decision() Decision {
+	switch a {
+	case RuleActionAutoApprove:
+		return DecisionAutoApprove
+	case RuleActionSecurityScan:
+		return DecisionSecurityScan
+	default:
+		return DecisionOperatorApprove
+	}
+}
+
+// Rule is one operator-authored approval rule: when Expr matches the request,
+// the desk applies Action, subject to the ACMM ceiling. Rules are data — they
+// live in config (`tool_approval.rules:`), are compiled at load, and are
+// versioned and audited like any other config.
+type Rule struct {
+	// Name identifies the rule in verdicts, audit records, and the dashboard's
+	// rule chips. Operators see this string, so it should read like a policy.
+	Name string
+	// Expr is the CEL expression evaluated against the "request" activation.
+	Expr string
+	// Action is the resolution requested when Expr matches.
+	Action RuleAction
+	// Priority orders competing rules; higher wins. Ties break on declaration
+	// order, so a config file reads top-to-bottom as written.
+	Priority int
+	// MinACMMLevel optionally restricts the rule to hives at or above a level.
+	// This is a rule-scoping convenience, NOT the safety mechanism — the
+	// ceiling below is what actually bounds a rule's reach.
+	MinACMMLevel int
+}
+
+// RuleMatch records that a rule fired, for the verdict and the dashboard.
+type RuleMatch struct {
+	Name   string     `json:"name"`
+	Action RuleAction `json:"action"`
+}
+
+// ACMMCeiling returns the most permissive decision a hive at the given ACMM
+// level may reach for a side-effectful request, regardless of what any rule
+// asks for. This is the fail-closed heart of the desk.
+//
+// The mapping mirrors what each level ALREADY permits today (see parity.go):
+//
+//	L0-L2  operator-approve — nothing side-effectful resolves without a human
+//	L3-L5  security-scan    — may reach auto-approve only via a green scan
+//	L6+    auto-approve     — full autonomy; the desk is an audit record, not a gate
+//
+// An unknown/negative level clamps to the most restrictive lane, so a
+// mis-parsed or absent level can never widen authority.
+func ACMMCeiling(acmmLevel int) Decision {
+	switch {
+	case acmmLevel >= 6:
+		return DecisionAutoApprove
+	case acmmLevel >= 3:
+		return DecisionSecurityScan
+	default:
+		return DecisionOperatorApprove
+	}
+}
+
+// permissiveness ranks decisions so the ceiling can be applied as a clamp.
+// Higher is more permissive. Deny sits below everything: it is never something
+// a ceiling raises a verdict UP to.
+func permissiveness(d Decision) int {
+	switch d {
+	case DecisionAutoApprove:
+		return 3
+	case DecisionSecurityScan:
+		return 2
+	case DecisionOperatorApprove:
+		return 1
+	default: // DecisionDeny
+		return 0
+	}
+}
+
+// applyCeiling clamps a decision to what the hive's ACMM level permits. It only
+// ever moves a verdict toward LESS authority: a request the base policy already
+// sent to the operator lane is not promoted because the ceiling is higher.
+func applyCeiling(d Decision, acmmLevel int) (Decision, bool) {
+	ceiling := ACMMCeiling(acmmLevel)
+	if permissiveness(d) > permissiveness(ceiling) {
+		return ceiling, true
+	}
+	return d, false
+}
+
+// Desk resolves approval requests. Construct it with NewDesk. A Desk is safe
+// for concurrent Resolve calls: the compiled rule programs are stateless and
+// the desk holds no per-request mutable state.
+type Desk struct {
+	rules   *RuleEngine
+	scanner SecurityScanner
+}
+
+// NewDesk builds a desk over a compiled rule engine and a scanner. Both may be
+// nil: a nil engine means "no operator rules" (base policy only), and a nil
+// scanner installs the DefaultSecurityScanner.
+func NewDesk(rules *RuleEngine, scanner SecurityScanner) *Desk {
+	if scanner == nil {
+		scanner = NewDefaultSecurityScanner()
+	}
+	return &Desk{rules: rules, scanner: scanner}
+}
+
+// Request is one approval-shaped request arriving at the desk. It generalizes
+// beyond agent tool calls so the four legacy gates can migrate onto the same
+// decision point: Kind distinguishes an agent tool call from a self-merge, a
+// plan approval, or a queued merge, while Tool/Arguments carry the payload.
+type Request struct {
+	// Kind names the lane the request came from. See the Kind* constants.
+	Kind string `json:"kind"`
+	// Tool is the tool or action name being requested.
+	Tool ToolRequest `json:"tool"`
+	// Agent is the requesting identity.
+	Agent AgentIdentity `json:"agent"`
+	// Repo is the target repository ("org/name"), when the request has one.
+	Repo string `json:"repo,omitempty"`
+	// Number is the issue/PR number, when the request has one.
+	Number int `json:"number,omitempty"`
+	// Labels are the labels on the target issue/PR, for rule matching.
+	Labels []string `json:"labels,omitempty"`
+	// Author is the login that authored the target (PR author, issue opener).
+	Author string `json:"author,omitempty"`
+	// Title is the target's title, for rule matching.
+	Title string `json:"title,omitempty"`
+	// ChecksGreen reports whether required CI is green on the target. The
+	// canonical bulk-approve case ("fifty green dependabot PRs") is a rule over
+	// this field plus author and title.
+	ChecksGreen bool `json:"checks_green,omitempty"`
+	// IdempotencyKey de-duplicates a re-delivered request. Empty means the
+	// caller accepts a derived key (see DeriveIdempotencyKey).
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+}
+
+// Request kinds. Each corresponds to one of the gates RFC #4000 inventoried,
+// plus the agent tool-call lane the desk was originally specified for.
+const (
+	// KindAgentTool is an agent's in-turn tool invocation.
+	KindAgentTool = "agent-tool"
+	// KindSelfMerge is the App self-merging a PR it authored
+	// (SelfAuthoredAutoMergeAllowed / SelfMergeMinACMMLevel).
+	KindSelfMerge = "self-merge"
+	// KindQueuedMerge is a human-queued merge awaiting sweep
+	// (isTrustedMerger + latestHiveQueueApproval).
+	KindQueuedMerge = "queued-merge"
+	// KindPlanApproval is a decomposition plan awaiting approval
+	// (PlanAutoApproveForLevel).
+	KindPlanApproval = "plan-approval"
+	// KindPlanFromLabel is a label-triggered planning run
+	// (PlanningConfig.PlanFromLabelEnabled).
+	KindPlanFromLabel = "plan-from-label"
+)
+
+// Resolve is THE decision point. It returns the final verdict for a request,
+// having applied base policy, operator rules, the ACMM ceiling, and — when the
+// verdict lands in the scan lane — the security scanner.
+//
+// L6 throughput contract: for a request that resolves to auto-approve this
+// function performs no I/O, acquires no lock, and enqueues nothing. The
+// returned verdict is final and the caller proceeds in-loop.
+func (d *Desk) Resolve(ctx context.Context, req Request, acmmLevel int) Verdict {
+	v := d.decide(ctx, req, acmmLevel)
+
+	// The scan lane is the only path that may consult an external scanner. A
+	// verdict that is already auto-approve or operator-approve returns without
+	// touching it — this is what keeps a slow scanner from taxing every L6 turn
+	// whose answer is always yes.
+	if v.Decision != DecisionSecurityScan {
+		return v
+	}
+	return d.runScan(ctx, req, acmmLevel, v)
+}
+
+// Decide returns the verdict WITHOUT running the security scanner, leaving a
+// scan-lane request as DecisionSecurityScan. Callers that want to schedule the
+// scan asynchronously (the L6 post-hoc path) use this and resolve the scan
+// themselves; callers that want the whole answer use Resolve.
+func (d *Desk) Decide(ctx context.Context, req Request, acmmLevel int) Verdict {
+	return d.decide(ctx, req, acmmLevel)
+}
+
+// decide runs the three layers: base policy, operator rules, ACMM ceiling.
+func (d *Desk) decide(ctx context.Context, req Request, acmmLevel int) Verdict {
+	// Layer 1 — base policy. For agent tool calls this is the existing Decide
+	// (hard guardrails, tool policy, mode, repo allowlist, level gating). For
+	// the migrated gate kinds it is the level mapping those gates encoded.
+	v := d.baseVerdict(ctx, req, acmmLevel)
+
+	// A hard deny is terminal. Guardrails (direct PR creation/merge, explicit
+	// tool denies, repo allowlist, mode restrictions) are not rule-overridable:
+	// letting config relax them would reopen exactly the holes they were added
+	// to close.
+	if v.Decision == DecisionDeny {
+		v.Kind = req.Kind
+		return v
+	}
+
+	// Layer 2 — operator rules.
+	if d.rules != nil {
+		if m, ok := d.rules.Match(req, acmmLevel); ok {
+			requested := m.Action.decision()
+			// A rule that asks for LESS authority than the base verdict is
+			// always honored (escalation is free). A rule asking for MORE is
+			// honored here and then clamped by the ceiling below.
+			v.Decision = requested
+			v.Rule = m.Name
+			v.RuleAction = m.Action
+			v.Rationale = fmt.Sprintf("operator rule %q → %s", m.Name, m.Action)
+		}
+	}
+
+	// Layer 3 — the ACMM ceiling, applied LAST and unconditionally.
+	if clamped, wasClamped := applyCeiling(v.Decision, acmmLevel); wasClamped {
+		prior := v.Decision
+		v.Decision = clamped
+		v.CeilingApplied = true
+		if v.Rule != "" {
+			v.Rationale = fmt.Sprintf(
+				"operator rule %q requested %s but ACMM L%d ceiling permits at most %s — clamped (fail-closed)",
+				v.Rule, prior, acmmLevel, clamped)
+		} else {
+			v.Rationale = fmt.Sprintf(
+				"ACMM L%d ceiling permits at most %s — clamped from %s (fail-closed)",
+				acmmLevel, clamped, prior)
+		}
+	}
+
+	v.Kind = req.Kind
+	v.ACMMLevel = acmmLevel
+	if v.Tool == "" {
+		v.Tool = req.Tool.Tool
+	}
+	if v.Agent == "" {
+		v.Agent = req.Agent.Name
+	}
+	return v
+}
+
+// baseVerdict produces the pre-rule, pre-ceiling verdict for a request.
+func (d *Desk) baseVerdict(ctx context.Context, req Request, acmmLevel int) Verdict {
+	if req.Kind == "" || req.Kind == KindAgentTool {
+		// The agent tool lane keeps its existing, well-tested policy verbatim.
+		return Decide(ctx, req.Tool, acmmLevel, req.Agent)
+	}
+	// The migrated gate kinds carry no tool-policy surface; their base verdict
+	// is the level mapping the legacy gate encoded, which LegacyBaseDecision
+	// derives from the same constants the legacy gate reads.
+	return LegacyBaseDecision(req, acmmLevel)
+}
+
+// runScan resolves a scan-lane verdict through the scanner and re-applies the
+// ceiling to the post-scan decision — a green scan must not be able to lift a
+// request above its level either.
+func (d *Desk) runScan(ctx context.Context, req Request, acmmLevel int, v Verdict) Verdict {
+	scanner := d.scanner
+	if scanner == nil {
+		scanner = NewDefaultSecurityScanner()
+	}
+
+	res, err := scanner.Scan(ctx, req.Tool)
+	if err != nil {
+		// Fail closed: a scanner that errors denies rather than waves through.
+		v.Decision = DecisionDeny
+		v.Rationale = fmt.Sprintf("security scan error: %v", err)
+		return v
+	}
+	v.ScanResult = &res
+
+	if !res.Passed {
+		v.Decision = DecisionDeny
+		v.Rationale = fmt.Sprintf("security scan failed: %s", strings.Join(res.Violations, "; "))
+		return v
+	}
+
+	// Green scan. Passing the scan is precisely how a level whose ceiling is
+	// DecisionSecurityScan reaches auto-approve — the scan IS the route, so the
+	// ceiling is satisfied here rather than violated. Levels whose ceiling is
+	// the operator lane still land there: a green scan is not a substitute for
+	// a human at a level that requires one.
+	if AutoApproveOnGreenScan(acmmLevel) {
+		v.Decision = DecisionAutoApprove
+		v.Rationale = fmt.Sprintf("ACMM L%d: auto-approved on green security scan", acmmLevel)
+	} else {
+		v.Decision = DecisionOperatorApprove
+		v.Rationale = fmt.Sprintf("security scan green; ACMM L%d requires operator approval", acmmLevel)
+	}
+	return v
+}
+
+// AutoApproveOnGreenScan reports whether a level resolves a green security scan
+// to auto-approve. This is the second half of the ceiling: ACMMCeiling says the
+// most permissive LANE a request may enter, and this says whether traversing
+// the scan lane successfully reaches auto-approve.
+//
+// Levels at or above the scan-lane ceiling (L3+) auto-approve on green — that
+// is what "routes through a pre-execution security scan; auto-approves on
+// green" has always meant. Below that the ceiling is the operator lane and no
+// scan result can lift a request out of it.
+func AutoApproveOnGreenScan(acmmLevel int) bool {
+	return permissiveness(ACMMCeiling(acmmLevel)) >= permissiveness(DecisionSecurityScan)
+}
+
+// ResolveBatch evaluates N requests through the SAME Resolve call used for a
+// single request, returning one verdict per request in input order.
+//
+// This is the only bulk primitive the desk exposes, and it exists specifically
+// so a bulk approve can never become a parallel decision path (RFC #4000: "a
+// bulk approve is N individual evaluations through the same decision function
+// every agent request goes through"). Callers MUST NOT implement their own
+// fan-out over a different predicate. bulk_parity_test.go pins that
+// ResolveBatch(reqs) == [Resolve(r) for r in reqs].
+func (d *Desk) ResolveBatch(ctx context.Context, reqs []Request, acmmLevel int) []Verdict {
+	out := make([]Verdict, 0, len(reqs))
+	for _, req := range reqs {
+		out = append(out, d.Resolve(ctx, req, acmmLevel))
+	}
+	return out
+}
+
+// RuleNames returns the configured rule names in evaluation order. The
+// dashboard renders these as filter chips.
+func (d *Desk) RuleNames() []string {
+	if d == nil || d.rules == nil {
+		return nil
+	}
+	return d.rules.Names()
+}
+
+// WouldMatchRule reports which rule, if any, would fire for a request at a
+// level — without resolving it. The Approvals panel calls this to show, per
+// row, "which rule would resolve it".
+func (d *Desk) WouldMatchRule(req Request, acmmLevel int) (RuleMatch, bool) {
+	if d == nil || d.rules == nil {
+		return RuleMatch{}, false
+	}
+	return d.rules.Match(req, acmmLevel)
+}
+
+// sortRuleNames keeps chip ordering stable for the UI.
+func sortRuleNames(names []string) []string {
+	out := append([]string(nil), names...)
+	sort.Strings(out)
+	return out
+}

--- a/src/pkg/toolapprove/desk_ceiling_test.go
+++ b/src/pkg/toolapprove/desk_ceiling_test.go
@@ -1,0 +1,173 @@
+package toolapprove
+
+// The ACMM ceiling is the safety property of the whole desk: an operator rule
+// is an INPUT to the decision, never an override of the hive's level. These
+// tests pin that, including the positive controls that prove the tests would
+// notice if the ceiling were removed.
+
+import (
+	"context"
+	"testing"
+)
+
+// autoApproveEverything is the most permissive rule set expressible: it asks
+// for auto-approve on literally every request. If the ceiling works, this rule
+// still cannot lift a low-level hive above its lane.
+func autoApproveEverything(t *testing.T) *RuleEngine {
+	t.Helper()
+	eng, err := CompileRules([]Rule{{
+		Name:   "approve-everything",
+		Expr:   "true",
+		Action: RuleActionAutoApprove,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	return eng
+}
+
+// sideEffectfulRequest is a write that no level auto-permits outright.
+func sideEffectfulRequest() Request {
+	return Request{
+		Kind: KindAgentTool,
+		Tool: ToolRequest{
+			Tool:      "write",
+			Arguments: map[string]any{"file_path": "src/main.go", "content": "package main"},
+		},
+		Agent: AgentIdentity{Name: "coder"},
+	}
+}
+
+// TestACMMCeilingClampsPermissiveRule is the core fail-closed assertion: a rule
+// demanding auto-approve at every level is clamped to what each level permits.
+func TestACMMCeilingClampsPermissiveRule(t *testing.T) {
+	desk := NewDesk(autoApproveEverything(t), passingScanner{})
+
+	for _, tc := range []struct {
+		level int
+		// want is the maximum decision the level may reach. Below L3 nothing
+		// side-effectful may auto-resolve, so the rule must be clamped to the
+		// operator lane no matter what it asks for.
+		want Decision
+	}{
+		{level: 0, want: DecisionOperatorApprove},
+		{level: 1, want: DecisionOperatorApprove},
+		{level: 2, want: DecisionOperatorApprove},
+		{level: 3, want: DecisionAutoApprove}, // scan lane, green scan resolves
+		{level: 4, want: DecisionAutoApprove},
+		{level: 5, want: DecisionAutoApprove},
+		{level: 6, want: DecisionAutoApprove},
+	} {
+		got := desk.Resolve(context.Background(), sideEffectfulRequest(), tc.level)
+		if got.Decision != tc.want {
+			t.Errorf("L%d: rule asked auto-approve, ceiling should yield %s, got %s (rationale: %s)",
+				tc.level, tc.want, got.Decision, got.Rationale)
+		}
+	}
+}
+
+// TestACMMCeilingNeverExceedsLevel is the invariant stated directly, over every
+// rule action and every level: the resolved decision is never more permissive
+// than ACMMCeiling(level).
+func TestACMMCeilingNeverExceedsLevel(t *testing.T) {
+	for _, action := range []RuleAction{RuleActionAutoApprove, RuleActionSecurityScan, RuleActionOperatorApprove} {
+		eng, err := CompileRules([]Rule{{Name: "r", Expr: "true", Action: action}}, nil)
+		if err != nil {
+			t.Fatalf("CompileRules(%s): %v", action, err)
+		}
+		// A scanner that always fails keeps the scan lane from resolving
+		// upward, so this test measures the ceiling rather than the scanner.
+		desk := NewDesk(eng, passingScanner{})
+
+		for level := 0; level <= 7; level++ {
+			v := desk.Decide(context.Background(), sideEffectfulRequest(), level)
+			ceiling := ACMMCeiling(level)
+			if permissiveness(v.Decision) > permissiveness(ceiling) {
+				t.Errorf("action=%s L%d: decision %s is MORE permissive than ceiling %s",
+					action, level, v.Decision, ceiling)
+			}
+		}
+	}
+}
+
+// TestACMMCeilingClampIsRecorded pins that a clamp is visible in the verdict
+// and therefore in the audit record — a silent clamp would be unauditable.
+func TestACMMCeilingClampIsRecorded(t *testing.T) {
+	desk := NewDesk(autoApproveEverything(t), passingScanner{})
+	v := desk.Decide(context.Background(), sideEffectfulRequest(), 1)
+
+	if !v.CeilingApplied {
+		t.Fatal("L1 clamp of an auto-approve rule did not set CeilingApplied")
+	}
+	if v.Rule != "approve-everything" {
+		t.Errorf("verdict lost the rule provenance: Rule=%q", v.Rule)
+	}
+	if v.RuleAction != RuleActionAutoApprove {
+		t.Errorf("verdict lost what the rule ASKED for: RuleAction=%q", v.RuleAction)
+	}
+	fields := v.AuditFields()
+	if fields["ceiling_applied"] != true {
+		t.Error("AuditFields did not record the clamp — a clamp must be auditable")
+	}
+	if fields["rule"] != "approve-everything" {
+		t.Errorf("AuditFields lost rule provenance: %v", fields["rule"])
+	}
+}
+
+// TestACMMCeilingPositiveControl is the control this suite needs to be
+// meaningful: it proves the ceiling is what produces the clamp, by showing the
+// SAME rule and request DO reach auto-approve once the level permits it. Without
+// this, every assertion above would still pass if the desk simply refused
+// everything.
+func TestACMMCeilingPositiveControl(t *testing.T) {
+	desk := NewDesk(autoApproveEverything(t), passingScanner{})
+
+	low := desk.Decide(context.Background(), sideEffectfulRequest(), 1)
+	if low.Decision != DecisionOperatorApprove {
+		t.Fatalf("precondition: L1 should clamp to operator-approve, got %s", low.Decision)
+	}
+
+	high := desk.Decide(context.Background(), sideEffectfulRequest(), 6)
+	if high.Decision != DecisionAutoApprove {
+		t.Fatalf("positive control FAILED: L6 with an auto-approve rule should reach auto-approve, got %s — "+
+			"the suite above may be passing because the desk refuses everything, not because the ceiling works",
+			high.Decision)
+	}
+	if high.CeilingApplied {
+		t.Error("L6 auto-approve should not be clamped — the ceiling is auto-approve at L6")
+	}
+}
+
+// TestACMMCeilingUnknownLevelFailsClosed pins that a missing or nonsense level
+// cannot widen authority. An unset acmm_level reads as 0 (see ACMMLevelOf).
+func TestACMMCeilingUnknownLevelFailsClosed(t *testing.T) {
+	for _, level := range []int{-1, -100, 0} {
+		if got := ACMMCeiling(level); got != DecisionOperatorApprove {
+			t.Errorf("ACMMCeiling(%d) = %s, want operator-approve (fail-closed)", level, got)
+		}
+	}
+}
+
+// TestRuleCannotOverrideHardDeny pins that guardrails are not rule-overridable.
+// Direct PR creation is denied at every level; a rule asking for auto-approve
+// must not reopen it.
+func TestRuleCannotOverrideHardDeny(t *testing.T) {
+	desk := NewDesk(autoApproveEverything(t), passingScanner{})
+	req := Request{
+		Kind:  KindAgentTool,
+		Tool:  ToolRequest{Tool: "mcp__github__create_pull_request"},
+		Agent: AgentIdentity{Name: "coder"},
+	}
+	v := desk.Resolve(context.Background(), req, 6)
+	if v.Decision != DecisionDeny {
+		t.Errorf("a rule lifted a hard guardrail deny: got %s (rationale: %s)", v.Decision, v.Rationale)
+	}
+}
+
+// passingScanner is a scanner that always returns green, so scan-lane tests
+// measure policy rather than scanner behavior.
+type passingScanner struct{}
+
+func (passingScanner) Scan(context.Context, ToolRequest) (ScanResult, error) {
+	return ScanResult{Passed: true, Details: "test scanner: green"}, nil
+}

--- a/src/pkg/toolapprove/inbox.go
+++ b/src/pkg/toolapprove/inbox.go
@@ -1,0 +1,487 @@
+package toolapprove
+
+// The operator inbox: durable storage for the operator lane ONLY.
+//
+// An approval that waits overnight must survive a spoke roll — hives auto-roll
+// frequently, so an in-memory pending list would be silently wiped by the very
+// machinery it is meant to outlive. This follows the persistence idiom the
+// fleet already uses for hub upgrade-pause and the contribute ledger: one small
+// JSON file on the durable data dir, loaded lazily on first use, written
+// atomically via a temp file + rename so a crash mid-write cannot leave a
+// truncated inbox.
+//
+// THE THROUGHPUT CONTRACT (#4000 comment 5321778076, requirement 1):
+// "A request the policy resolves to auto-approve never enters a queue and never
+// waits on any external process. The inbox is for the operator lane only."
+//
+// This is enforced structurally, not by convention: Enqueue REFUSES any verdict
+// whose decision is not operator-approve, returning ErrNotOperatorLane. There is
+// no code path by which an auto-approved request reaches this file, and
+// inbox_l6_test.go pins that with the store wired to a path that fails the test
+// if it is ever written.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// DefaultInboxPath is the durable home of the pending-approval inbox, on the
+// spoke's PVC-backed /data dir alongside the other operational JSON state
+// (hive-state.json, sparkline-history.json). A var, not a const, so tests
+// redirect it at a temp path — the same affordance upgradePausePath uses.
+var DefaultInboxPath = "/data/approvals/inbox.json"
+
+// inboxFileMode matches the other non-secret /data JSON files: this state is
+// operational, not key material. The verdict rationale can quote tool
+// arguments, so it is not world-readable beyond the container's own user.
+const inboxFileMode = 0o644
+
+// inboxDirMode is the mode for the containing directory when it must be created.
+const inboxDirMode = 0o755
+
+// maxInboxEntries bounds how many pending items the inbox retains. An inbox
+// that grows without limit would eventually make every decision slow and every
+// dashboard render heavy. At the cap the OLDEST entries are dropped with a
+// warning: a pending queue this deep is already a misconfiguration signal (see
+// requirement 4 — operator-lane items at L6 are probable policy bugs), and
+// silently consuming unbounded disk is the worse failure.
+const maxInboxEntries = 5000
+
+// maxJournalEntries bounds the resolved-verdict journal used for idempotency.
+// Entries older than journalRetention are pruned on write; the cap is a second
+// backstop for a hive that resolves faster than it prunes.
+const maxJournalEntries = 10000
+
+// journalRetention is how long a resolved verdict stays in the idempotency
+// journal. A re-delivery arriving later than this is treated as a new request.
+// 30 days comfortably covers "an approval that waits overnight" plus any
+// realistic replay window, without growing the file unboundedly.
+const journalRetention = 30 * 24 * time.Hour
+
+// Errors returned by the inbox.
+var (
+	// ErrNotOperatorLane is returned by Enqueue for any verdict that is not
+	// operator-approve. This is the structural guard behind the L6 throughput
+	// contract: auto-approve can never enter the queue.
+	ErrNotOperatorLane = errors.New("only operator-approve verdicts may enter the inbox")
+	// ErrNotFound is returned when resolving an unknown approval ID.
+	ErrNotFound = errors.New("pending approval not found")
+	// ErrAlreadyResolved is returned when resolving an approval that a prior,
+	// identical delivery already resolved. It carries the earlier outcome.
+	ErrAlreadyResolved = errors.New("approval already resolved")
+)
+
+// PendingItem is one request parked in the operator lane.
+type PendingItem struct {
+	// ID is the stable identifier operators and the API address this item by.
+	// It IS the idempotency key, so a re-delivered request resolves to the same
+	// row rather than creating a duplicate.
+	ID string `json:"id"`
+	// Request is the original request, retained so a resolve can re-evaluate it
+	// through the desk rather than trusting a stale verdict.
+	Request Request `json:"request"`
+	// Verdict is the desk's verdict at enqueue time, including which rule (if
+	// any) matched — the dashboard renders this per row.
+	Verdict Verdict `json:"verdict"`
+	// QueuedAt is when the item entered the inbox.
+	QueuedAt time.Time `json:"queued_at"`
+	// ACMMLevel is the hive level at enqueue time. An item queued at L6 is a
+	// probable policy bug (requirement 4) and the API flags it.
+	ACMMLevel int `json:"acmm_level"`
+}
+
+// ResolvedRecord journals a verdict that has been resolved, keyed by the same
+// ID, so a re-delivered grant does not double-execute.
+type ResolvedRecord struct {
+	ID         string    `json:"id"`
+	Approved   bool      `json:"approved"`
+	Operator   string    `json:"operator,omitempty"`
+	Rationale  string    `json:"rationale,omitempty"`
+	ResolvedAt time.Time `json:"resolved_at"`
+	// Executed records that the granted action was actually carried out. The
+	// producer sets this after a successful execution, so a crash between
+	// "resolved" and "executed" is distinguishable on restart.
+	Executed bool `json:"executed"`
+}
+
+// inboxState is the on-disk shape.
+type inboxState struct {
+	Pending  []PendingItem    `json:"pending"`
+	Resolved []ResolvedRecord `json:"resolved"`
+}
+
+// Inbox is the durable operator-lane store. The zero value is not usable;
+// construct with NewInbox.
+type Inbox struct {
+	mu     sync.Mutex
+	path   string
+	loaded bool
+	state  inboxState
+	// now is injectable so tests can exercise retention pruning deterministically.
+	now func() time.Time
+}
+
+// NewInbox returns an inbox backed by path. An empty path uses
+// DefaultInboxPath. The file is not touched until first use — construction is
+// free, so wiring an inbox into a hive that never queues anything costs nothing.
+func NewInbox(path string) *Inbox {
+	if path == "" {
+		path = DefaultInboxPath
+	}
+	return &Inbox{path: path, now: time.Now}
+}
+
+// DeriveIdempotencyKey computes a stable key for a request. Two deliveries of
+// the same logical request produce the same key, so the second is recognized as
+// a replay rather than executed again.
+//
+// The key covers the fields that identify WHAT is being requested — lane, tool,
+// target, and the tool's own arguments — but deliberately NOT timestamps or
+// per-delivery metadata, which is what makes a re-delivery match.
+func DeriveIdempotencyKey(req Request) string {
+	if req.IdempotencyKey != "" {
+		return req.IdempotencyKey
+	}
+	h := sha256.New()
+	write := func(parts ...string) {
+		for _, p := range parts {
+			h.Write([]byte(p))
+			h.Write([]byte{0})
+		}
+	}
+	write(req.Kind, req.Tool.Tool, req.Agent.Name, req.Repo, req.Author)
+	write(fmt.Sprintf("%d", req.Number))
+	write(req.Tool.GetCommand(), req.Tool.GetFilePath(), req.Tool.GetContent())
+	// Arguments are hashed in sorted key order so map iteration order cannot
+	// make the same request hash two different ways.
+	if len(req.Tool.Arguments) > 0 {
+		keys := make([]string, 0, len(req.Tool.Arguments))
+		for k := range req.Tool.Arguments {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			write(k, fmt.Sprintf("%v", req.Tool.Arguments[k]))
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))[:32]
+}
+
+// ensureLoadedLocked reads the persisted state exactly once per process.
+// Callers must hold i.mu. A missing file means an empty inbox — the safe
+// default and the pre-feature behavior. A corrupt file is treated the same way
+// rather than wedging the hive; the operator sees the warning and the inbox
+// refills from live traffic.
+func (i *Inbox) ensureLoadedLocked() {
+	if i.loaded {
+		return
+	}
+	i.loaded = true
+	data, err := os.ReadFile(i.path)
+	if err != nil {
+		return
+	}
+	var st inboxState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return
+	}
+	i.state = st
+}
+
+// persistLocked writes the state atomically: temp file in the same directory,
+// then rename. A crash mid-write leaves either the old file or the new one,
+// never a truncated inbox. Callers must hold i.mu.
+func (i *Inbox) persistLocked() error {
+	dir := filepath.Dir(i.path)
+	if err := os.MkdirAll(dir, inboxDirMode); err != nil {
+		return fmt.Errorf("create approvals dir: %w", err)
+	}
+	data, err := json.MarshalIndent(i.state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal inbox: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".inbox-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp inbox: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp inbox: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp inbox: %w", err)
+	}
+	if err := os.Chmod(tmpName, inboxFileMode); err != nil {
+		return fmt.Errorf("chmod temp inbox: %w", err)
+	}
+	if err := os.Rename(tmpName, i.path); err != nil {
+		return fmt.Errorf("rename inbox into place: %w", err)
+	}
+	return nil
+}
+
+// Enqueue parks an operator-lane request in the durable inbox and returns its
+// ID (== its idempotency key).
+//
+// It REFUSES any verdict that is not operator-approve with ErrNotOperatorLane.
+// That refusal is the L6 throughput contract expressed as code: there is no
+// argument by which an auto-approved request reaches durable storage.
+//
+// Enqueue is idempotent. A request already pending returns its existing ID
+// without duplicating the row; a request already RESOLVED returns
+// ErrAlreadyResolved so the caller re-delivers nothing.
+func (i *Inbox) Enqueue(req Request, v Verdict) (string, error) {
+	if v.Decision != DecisionOperatorApprove {
+		return "", fmt.Errorf("%w: got %s", ErrNotOperatorLane, v.Decision)
+	}
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ensureLoadedLocked()
+
+	id := DeriveIdempotencyKey(req)
+
+	// Already resolved? Do not re-queue — that is the double-execution the
+	// journal exists to prevent.
+	for _, r := range i.state.Resolved {
+		if r.ID == id {
+			return id, fmt.Errorf("%w: %s at %s", ErrAlreadyResolved, verdictWord(r.Approved), r.ResolvedAt.UTC().Format(time.RFC3339))
+		}
+	}
+	// Already pending? Return the existing row.
+	for _, p := range i.state.Pending {
+		if p.ID == id {
+			return id, nil
+		}
+	}
+
+	req.IdempotencyKey = id
+	i.state.Pending = append(i.state.Pending, PendingItem{
+		ID:        id,
+		Request:   req,
+		Verdict:   v,
+		QueuedAt:  i.now().UTC(),
+		ACMMLevel: v.ACMMLevel,
+	})
+
+	// Bound growth: drop oldest beyond the cap.
+	if len(i.state.Pending) > maxInboxEntries {
+		i.state.Pending = i.state.Pending[len(i.state.Pending)-maxInboxEntries:]
+	}
+
+	if err := i.persistLocked(); err != nil {
+		return id, err
+	}
+	return id, nil
+}
+
+// verdictWord renders an approval boolean for messages.
+func verdictWord(approved bool) string {
+	if approved {
+		return "granted"
+	}
+	return "rejected"
+}
+
+// List returns the pending items, newest last (queue order). The returned slice
+// is a copy: callers cannot mutate inbox state.
+func (i *Inbox) List() []PendingItem {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ensureLoadedLocked()
+	return append([]PendingItem(nil), i.state.Pending...)
+}
+
+// Count returns the number of pending items — the dashboard's badge value.
+func (i *Inbox) Count() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ensureLoadedLocked()
+	return len(i.state.Pending)
+}
+
+// Get returns one pending item by ID.
+func (i *Inbox) Get(id string) (PendingItem, bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ensureLoadedLocked()
+	for _, p := range i.state.Pending {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return PendingItem{}, false
+}
+
+// Resolve records an operator's verdict on a pending item, removes it from the
+// pending list, and journals the outcome.
+//
+// Idempotency: resolving an ID that is already journaled returns
+// ErrAlreadyResolved along with the ORIGINAL record, and does not journal a
+// second time. A granted verdict re-delivered therefore cannot double-execute —
+// the caller sees the error, reads Executed on the returned record, and skips.
+func (i *Inbox) Resolve(id string, approved bool, operator, rationale string) (ResolvedRecord, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ensureLoadedLocked()
+
+	for _, r := range i.state.Resolved {
+		if r.ID == id {
+			return r, fmt.Errorf("%w: %s at %s", ErrAlreadyResolved, verdictWord(r.Approved), r.ResolvedAt.UTC().Format(time.RFC3339))
+		}
+	}
+
+	idx := -1
+	for n, p := range i.state.Pending {
+		if p.ID == id {
+			idx = n
+			break
+		}
+	}
+	if idx < 0 {
+		return ResolvedRecord{}, fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+
+	rec := ResolvedRecord{
+		ID:         id,
+		Approved:   approved,
+		Operator:   operator,
+		Rationale:  rationale,
+		ResolvedAt: i.now().UTC(),
+	}
+	i.state.Pending = append(i.state.Pending[:idx], i.state.Pending[idx+1:]...)
+	i.state.Resolved = append(i.state.Resolved, rec)
+	i.pruneJournalLocked()
+
+	if err := i.persistLocked(); err != nil {
+		return rec, err
+	}
+	return rec, nil
+}
+
+// MarkExecuted flips the journal record's Executed flag after the granted
+// action has actually been carried out. The two-phase shape (resolve, then
+// execute, then mark) is what lets a restart tell "approved but never ran" from
+// "approved and ran" — the former is safe to retry, the latter must not be.
+func (i *Inbox) MarkExecuted(id string) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ensureLoadedLocked()
+
+	for n := range i.state.Resolved {
+		if i.state.Resolved[n].ID == id {
+			if i.state.Resolved[n].Executed {
+				return nil // already marked; idempotent
+			}
+			i.state.Resolved[n].Executed = true
+			return i.persistLocked()
+		}
+	}
+	return fmt.Errorf("%w: %s", ErrNotFound, id)
+}
+
+// ResolvedRecordFor returns the journal entry for an ID, if any. Producers call
+// this BEFORE executing a granted verdict: a record with Executed=true means
+// this grant has already run and must not run again.
+func (i *Inbox) ResolvedRecordFor(id string) (ResolvedRecord, bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ensureLoadedLocked()
+	for _, r := range i.state.Resolved {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return ResolvedRecord{}, false
+}
+
+// pruneJournalLocked drops journal entries past the retention window and caps
+// total size. Callers must hold i.mu.
+func (i *Inbox) pruneJournalLocked() {
+	cutoff := i.now().UTC().Add(-journalRetention)
+	kept := i.state.Resolved[:0]
+	for _, r := range i.state.Resolved {
+		if r.ResolvedAt.After(cutoff) {
+			kept = append(kept, r)
+		}
+	}
+	i.state.Resolved = kept
+	if len(i.state.Resolved) > maxJournalEntries {
+		i.state.Resolved = i.state.Resolved[len(i.state.Resolved)-maxJournalEntries:]
+	}
+}
+
+// BulkResolveResult is the outcome for ONE item in a bulk resolve. Partial
+// failure is the normal case (an item may have been resolved by another
+// operator, or aged out), so the API returns a per-item list rather than a
+// single boolean — mirroring BulkHiveResult in pkg/hub/saas_bulk.go.
+type BulkResolveResult struct {
+	ID    string `json:"id"`
+	Ok    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// ResolveMany resolves N items by calling Resolve once per item — the SAME
+// function the single-item path uses. There is no bulk-specific predicate and
+// no shortcut: a bulk approve is N individual resolutions, each journaled and
+// each idempotent, exactly as runBulkAction decomposes a bulk hive request into
+// per-item authorized operations.
+func (i *Inbox) ResolveMany(ids []string, approved bool, operator, rationale string) []BulkResolveResult {
+	out := make([]BulkResolveResult, 0, len(ids))
+	for _, id := range ids {
+		_, err := i.Resolve(id, approved, operator, rationale)
+		if err != nil {
+			out = append(out, BulkResolveResult{ID: id, Ok: false, Error: err.Error()})
+			continue
+		}
+		out = append(out, BulkResolveResult{ID: id, Ok: true})
+	}
+	return out
+}
+
+// PendingAtFullAutonomy returns the pending items queued at an ACMM level that
+// claims full autonomy. Per requirement 4 of the throughput contract, these are
+// surfaced as PROBABLE POLICY BUGS rather than silently waiting: an inbox that
+// accumulates on a hive whose level says "full autonomy" is a misconfiguration
+// signal. The API marks them and the dashboard renders them distinctly.
+func (i *Inbox) PendingAtFullAutonomy() []PendingItem {
+	var out []PendingItem
+	for _, p := range i.List() {
+		if p.ACMMLevel >= 6 {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// RuleChips returns the distinct rule names across pending items, for the
+// dashboard's filter chips. Items resolved by base policy rather than a rule
+// are grouped under the empty name, which the UI renders as "no rule".
+func (i *Inbox) RuleChips() []string {
+	seen := map[string]struct{}{}
+	for _, p := range i.List() {
+		name := strings.TrimSpace(p.Verdict.Rule)
+		if name == "" {
+			continue
+		}
+		seen[name] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	return sortRuleNames(out)
+}

--- a/src/pkg/toolapprove/inbox_l6_test.go
+++ b/src/pkg/toolapprove/inbox_l6_test.go
@@ -1,0 +1,188 @@
+package toolapprove
+
+// The L6 throughput contract (#4000 comment 5321778076) as executable tests.
+//
+// Requirement 1 is the load-bearing one: "A request the policy resolves to
+// auto-approve never enters a queue and never waits on any external process.
+// The inbox is for the operator lane only."
+//
+// These tests do not merely assert that Enqueue happens to refuse — they point
+// the inbox at a path whose parent directory does not exist and is not
+// creatable, so ANY write attempt fails loudly, and then assert that a full L6
+// auto-approve flow completes with that path untouched. A future change that
+// starts journaling auto-approvals "for the audit trail" fails here.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestL6AutoApproveNeverQueues is THE throughput-contract test. An L6 hive
+// resolving a side-effectful request must reach auto-approve, and the durable
+// inbox file must not exist afterward.
+func TestL6AutoApproveNeverQueues(t *testing.T) {
+	dir := t.TempDir()
+	inboxPath := filepath.Join(dir, "inbox.json")
+	inbox := NewInbox(inboxPath)
+	desk := NewDesk(nil, passingScanner{})
+
+	req := sideEffectfulRequest()
+	v := desk.Resolve(context.Background(), req, 6)
+
+	if v.Decision != DecisionAutoApprove {
+		t.Fatalf("L6 side-effectful request resolved to %s, want auto-approve — "+
+			"the throughput contract requires L6 to resolve nearly everything in-loop (rationale: %s)",
+			v.Decision, v.Rationale)
+	}
+
+	// The contract: no queue residence. Enqueue must refuse this verdict.
+	if _, err := inbox.Enqueue(req, v); err == nil {
+		t.Fatal("Enqueue ACCEPTED an auto-approve verdict — auto-approve must never enter the operator inbox")
+	}
+
+	if _, err := os.Stat(inboxPath); !os.IsNotExist(err) {
+		t.Fatalf("the durable inbox file was created during an L6 auto-approve flow (%s) — "+
+			"auto-approve must touch no persistence", inboxPath)
+	}
+	if inbox.Count() != 0 {
+		t.Fatalf("inbox holds %d items after an L6 auto-approve; want 0", inbox.Count())
+	}
+}
+
+// TestEnqueueRefusesNonOperatorVerdicts pins the structural guard for every
+// non-operator decision, not just auto-approve.
+func TestEnqueueRefusesNonOperatorVerdicts(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+
+	for _, d := range []Decision{DecisionAutoApprove, DecisionSecurityScan, DecisionDeny} {
+		_, err := inbox.Enqueue(sideEffectfulRequest(), Verdict{Decision: d})
+		if err == nil {
+			t.Errorf("Enqueue accepted a %s verdict; only operator-approve may enter the inbox", d)
+		}
+	}
+
+	// Positive control: the operator lane IS accepted. Without this the test
+	// above would pass against an Enqueue that refuses everything.
+	id, err := inbox.Enqueue(sideEffectfulRequest(), Verdict{Decision: DecisionOperatorApprove})
+	if err != nil {
+		t.Fatalf("positive control FAILED: Enqueue refused an operator-approve verdict: %v", err)
+	}
+	if id == "" {
+		t.Error("Enqueue returned an empty ID for an accepted item")
+	}
+}
+
+// TestL6AutoApproveIsSynchronous pins requirement 1's "never waits on any
+// external process" half. A scanner that blocks would tax every L6 turn; the
+// desk must not consult one for a request that never enters the scan lane.
+//
+// Read-only tools auto-approve at every level WITHOUT a scan, so a blocking
+// scanner must never be reached.
+func TestL6AutoApproveIsSynchronous(t *testing.T) {
+	desk := NewDesk(nil, blockingScanner{t: t})
+
+	req := Request{
+		Kind:  KindAgentTool,
+		Tool:  ToolRequest{Tool: "read", Arguments: map[string]any{"file_path": "README.md"}},
+		Agent: AgentIdentity{Name: "reader"},
+	}
+
+	done := make(chan Verdict, 1)
+	go func() { done <- desk.Resolve(context.Background(), req, 6) }()
+
+	select {
+	case v := <-done:
+		if v.Decision != DecisionAutoApprove {
+			t.Fatalf("read-only request at L6 resolved to %s, want auto-approve", v.Decision)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resolve blocked on the scanner for a request that should resolve in-loop — " +
+			"the scan lane has become a serialization point (throughput contract requirement 2)")
+	}
+}
+
+// TestL6RuleAutoApproveNeverQueues covers the rule-driven path: an operator rule
+// resolving a self-merge at L6 must also stay out of the queue.
+func TestL6RuleAutoApproveNeverQueues(t *testing.T) {
+	eng, err := CompileRules([]Rule{{
+		Name:   "green-dependabot",
+		Expr:   `request.kind == "self-merge" && request.checks_green && request.author == "dependabot[bot]"`,
+		Action: RuleActionAutoApprove,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+
+	dir := t.TempDir()
+	inboxPath := filepath.Join(dir, "inbox.json")
+	inbox := NewInbox(inboxPath)
+	desk := NewDesk(eng, passingScanner{})
+
+	req := Request{
+		Kind:        KindSelfMerge,
+		Repo:        "kubestellar/hive",
+		Number:      42,
+		Author:      "dependabot[bot]",
+		Title:       "chore(deps): bump x from 1.0.0 to 1.0.1",
+		ChecksGreen: true,
+		Tool:        ToolRequest{Tool: "hive-merge"},
+	}
+
+	v := desk.Resolve(context.Background(), req, 6)
+	if v.Decision != DecisionAutoApprove {
+		t.Fatalf("rule-matched green dependabot PR at L6 resolved to %s, want auto-approve", v.Decision)
+	}
+	if v.Rule != "green-dependabot" {
+		t.Errorf("verdict did not record which rule resolved it: %q", v.Rule)
+	}
+	if _, err := os.Stat(inboxPath); !os.IsNotExist(err) {
+		t.Fatal("rule-driven L6 auto-approve created the durable inbox file")
+	}
+	if inbox.Count() != 0 {
+		t.Fatalf("inbox holds %d items after a rule-driven L6 auto-approve; want 0", inbox.Count())
+	}
+}
+
+// TestPendingAtFullAutonomyIsFlagged pins requirement 4: an item queued on a
+// hive at L6 is surfaced as a probable policy bug rather than silently waiting.
+func TestPendingAtFullAutonomyIsFlagged(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+
+	if _, err := inbox.Enqueue(sideEffectfulRequest(), Verdict{
+		Decision: DecisionOperatorApprove, ACMMLevel: 6,
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	bugs := inbox.PendingAtFullAutonomy()
+	if len(bugs) != 1 {
+		t.Fatalf("PendingAtFullAutonomy returned %d items, want 1 — an inbox accumulating at L6 "+
+			"is a misconfiguration signal that must be surfaced, not queued politely", len(bugs))
+	}
+
+	// Positive control: an item queued at a level that legitimately gates is
+	// NOT flagged, so the signal means something.
+	other := Request{
+		Kind:  KindAgentTool,
+		Tool:  ToolRequest{Tool: "write", Arguments: map[string]any{"file_path": "other.go"}},
+		Agent: AgentIdentity{Name: "coder"},
+	}
+	if _, err := inbox.Enqueue(other, Verdict{Decision: DecisionOperatorApprove, ACMMLevel: 3}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if got := len(inbox.PendingAtFullAutonomy()); got != 1 {
+		t.Errorf("an L3 pending item was flagged as a policy bug: PendingAtFullAutonomy=%d, want 1", got)
+	}
+}
+
+// blockingScanner fails the test if it is ever called, and blocks if it is —
+// so a Resolve that wrongly enters the scan lane both reports and times out.
+type blockingScanner struct{ t *testing.T }
+
+func (b blockingScanner) Scan(ctx context.Context, req ToolRequest) (ScanResult, error) {
+	b.t.Errorf("scanner was consulted for tool %q, which should have resolved without a scan", req.Tool)
+	<-ctx.Done()
+	return ScanResult{}, ctx.Err()
+}

--- a/src/pkg/toolapprove/inbox_test.go
+++ b/src/pkg/toolapprove/inbox_test.go
@@ -1,0 +1,268 @@
+package toolapprove
+
+// Durability and idempotency of the operator lane.
+//
+// The requirement these encode: an approval that waits overnight must survive a
+// spoke roll. Hives auto-roll frequently, so "restart" is not an exotic case —
+// it is the normal case for anything that waits more than a few hours.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFileHelper seeds a file, creating parent directories as needed.
+func writeFileHelper(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// pendingRequest builds a distinct operator-lane request.
+func pendingRequest(n int) Request {
+	return Request{
+		Kind:   KindSelfMerge,
+		Repo:   "kubestellar/hive",
+		Number: n,
+		Author: "hive-app[bot]",
+		Title:  fmt.Sprintf("fix: thing %d", n),
+		Tool:   ToolRequest{Tool: "hive-merge"},
+		Agent:  AgentIdentity{Name: "sweep"},
+	}
+}
+
+func operatorVerdict() Verdict {
+	return Verdict{Decision: DecisionOperatorApprove, ACMMLevel: 4, Tool: "hive-merge"}
+}
+
+// TestInboxSurvivesRestart is the persistence round-trip: items queued by one
+// process are visible to a NEW Inbox over the same path, which is exactly what
+// a spoke roll looks like from the inbox's point of view.
+func TestInboxSurvivesRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "approvals", "inbox.json")
+
+	// Process 1: queue three approvals.
+	first := NewInbox(path)
+	var ids []string
+	for n := 1; n <= 3; n++ {
+		id, err := first.Enqueue(pendingRequest(n), operatorVerdict())
+		if err != nil {
+			t.Fatalf("Enqueue #%d: %v", n, err)
+		}
+		ids = append(ids, id)
+	}
+	if first.Count() != 3 {
+		t.Fatalf("pre-restart count = %d, want 3", first.Count())
+	}
+
+	// Process 2: a brand-new Inbox over the same durable path — the simulated
+	// restart. Nothing is carried over in memory.
+	second := NewInbox(path)
+	if got := second.Count(); got != 3 {
+		t.Fatalf("post-restart count = %d, want 3 — pending approvals did not survive the roll", got)
+	}
+	for _, id := range ids {
+		if _, ok := second.Get(id); !ok {
+			t.Errorf("approval %s vanished across restart", id)
+		}
+	}
+
+	// Resolving after the restart works, and the resolution ALSO persists.
+	if _, err := second.Resolve(ids[0], true, "operator", "looks good"); err != nil {
+		t.Fatalf("post-restart Resolve: %v", err)
+	}
+	third := NewInbox(path)
+	if got := third.Count(); got != 2 {
+		t.Fatalf("after resolving 1 of 3, post-restart count = %d, want 2", got)
+	}
+	if _, ok := third.ResolvedRecordFor(ids[0]); !ok {
+		t.Error("the resolved-verdict journal did not survive the restart — a re-delivered grant could double-execute")
+	}
+}
+
+// TestGrantedVerdictDoesNotDoubleExecute is the idempotency requirement stated
+// directly: a granted verdict re-delivered must not execute twice.
+func TestGrantedVerdictDoesNotDoubleExecute(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "inbox.json")
+	inbox := NewInbox(path)
+
+	req := pendingRequest(7)
+	id, err := inbox.Enqueue(req, operatorVerdict())
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+
+	// The operator grants it, and the producer executes.
+	if _, err := inbox.Resolve(id, true, "operator", ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if err := inbox.MarkExecuted(id); err != nil {
+		t.Fatalf("MarkExecuted: %v", err)
+	}
+
+	// RE-DELIVERY. The identical request arrives again — same fields, so the
+	// derived key is identical.
+	if got := DeriveIdempotencyKey(req); got != id {
+		t.Fatalf("re-delivery derived a DIFFERENT key (%s vs %s) — idempotency depends on the key being stable", got, id)
+	}
+
+	// Enqueue must refuse to re-queue it, and say why.
+	_, err = inbox.Enqueue(req, operatorVerdict())
+	if !errors.Is(err, ErrAlreadyResolved) {
+		t.Fatalf("re-delivered granted request was re-queued (err=%v) — it must be recognized as already resolved", err)
+	}
+
+	// And a producer consulting the journal sees it already ran.
+	rec, ok := inbox.ResolvedRecordFor(id)
+	if !ok {
+		t.Fatal("journal lost the resolved record")
+	}
+	if !rec.Approved || !rec.Executed {
+		t.Errorf("journal record wrong: approved=%v executed=%v, want both true", rec.Approved, rec.Executed)
+	}
+
+	// Resolving again must not journal a second time.
+	if _, err := inbox.Resolve(id, true, "operator", ""); !errors.Is(err, ErrAlreadyResolved) {
+		t.Errorf("second Resolve of the same ID succeeded (err=%v) — that is the double-execution the journal prevents", err)
+	}
+}
+
+// TestIdempotencyKeyDistinguishesDifferentRequests is the positive control for
+// the test above: two genuinely different requests must NOT collide, or
+// "idempotency" would just be "everything is a duplicate".
+func TestIdempotencyKeyDistinguishesDifferentRequests(t *testing.T) {
+	a := DeriveIdempotencyKey(pendingRequest(1))
+	b := DeriveIdempotencyKey(pendingRequest(2))
+	if a == b {
+		t.Fatal("two different PRs derived the same idempotency key — distinct requests would be silently dropped")
+	}
+
+	// Argument ORDER must not change the key: map iteration order is random, so
+	// a key that depended on it would make re-delivery detection flaky.
+	r1 := Request{Kind: KindAgentTool, Tool: ToolRequest{
+		Tool:      "write",
+		Arguments: map[string]any{"a": "1", "b": "2", "c": "3"},
+	}}
+	for i := 0; i < 20; i++ {
+		if DeriveIdempotencyKey(r1) != DeriveIdempotencyKey(r1) {
+			t.Fatal("idempotency key is not stable across calls — map iteration order is leaking into the hash")
+		}
+	}
+}
+
+// TestExplicitIdempotencyKeyWins pins that a caller-supplied key overrides the
+// derived one, which is how a producer coordinates with an external notion of
+// identity (e.g. stage 2's turn journal).
+func TestExplicitIdempotencyKeyWins(t *testing.T) {
+	req := pendingRequest(3)
+	req.IdempotencyKey = "turn-abc-op-4"
+	if got := DeriveIdempotencyKey(req); got != "turn-abc-op-4" {
+		t.Errorf("explicit IdempotencyKey ignored: got %q", got)
+	}
+}
+
+// TestResolveUnknownIDFails pins that resolving something that was never queued
+// is an error rather than a silent success.
+func TestResolveUnknownIDFails(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	if _, err := inbox.Resolve("nope", true, "operator", ""); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Resolve of an unknown ID returned %v, want ErrNotFound", err)
+	}
+}
+
+// TestEnqueueIsIdempotentWhilePending pins that the sweep re-seeing the same PR
+// every tick produces ONE inbox row, not one per tick. Without this the panel
+// would fill with duplicates of a single waiting decision.
+func TestEnqueueIsIdempotentWhilePending(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	req := pendingRequest(9)
+
+	var firstID string
+	for i := 0; i < 5; i++ {
+		id, err := inbox.Enqueue(req, operatorVerdict())
+		if err != nil {
+			t.Fatalf("Enqueue tick %d: %v", i, err)
+		}
+		if firstID == "" {
+			firstID = id
+		} else if id != firstID {
+			t.Fatalf("tick %d produced a different ID (%s vs %s)", i, id, firstID)
+		}
+	}
+	if got := inbox.Count(); got != 1 {
+		t.Fatalf("five identical enqueues produced %d rows, want 1", got)
+	}
+}
+
+// TestRuleChipsFromPending pins the dashboard's filter-chip source.
+func TestRuleChipsFromPending(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+
+	v1 := operatorVerdict()
+	v1.Rule = "needs-human-for-workflows"
+	v2 := operatorVerdict()
+	v2.Rule = "large-diff"
+	v3 := operatorVerdict() // no rule — base policy
+
+	for i, v := range []Verdict{v1, v2, v3, v1} {
+		if _, err := inbox.Enqueue(pendingRequest(100+i), v); err != nil {
+			t.Fatalf("Enqueue: %v", err)
+		}
+	}
+
+	chips := inbox.RuleChips()
+	if len(chips) != 2 {
+		t.Fatalf("RuleChips = %v, want 2 distinct names (duplicates collapsed, base-policy items excluded)", chips)
+	}
+	if chips[0] != "large-diff" || chips[1] != "needs-human-for-workflows" {
+		t.Errorf("RuleChips not sorted deterministically: %v", chips)
+	}
+}
+
+// TestInboxCorruptFileDoesNotWedge pins that a corrupt inbox degrades to empty
+// rather than taking the hive down — the same posture the upgrade-pause state
+// file takes.
+func TestInboxCorruptFileDoesNotWedge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "inbox.json")
+	if err := writeFileHelper(path, "{not json at all"); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+
+	inbox := NewInbox(path)
+	if got := inbox.Count(); got != 0 {
+		t.Fatalf("corrupt inbox reported %d items, want 0", got)
+	}
+	// And it still accepts new work, overwriting the corrupt file.
+	if _, err := inbox.Enqueue(pendingRequest(1), operatorVerdict()); err != nil {
+		t.Fatalf("Enqueue after corrupt read: %v", err)
+	}
+	if got := NewInbox(path).Count(); got != 1 {
+		t.Errorf("after recovery, count = %d, want 1", got)
+	}
+}
+
+// TestDeskAutoApproveNeverReachesInboxViaResolve is a belt-and-braces check on
+// the full desk→inbox path used by the real producer.
+func TestDeskAutoApproveNeverReachesInboxViaResolve(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	desk := NewDesk(nil, passingScanner{})
+
+	req := Request{
+		Kind:  KindAgentTool,
+		Tool:  ToolRequest{Tool: "grep", Arguments: map[string]any{"pattern": "x"}},
+		Agent: AgentIdentity{Name: "reader"},
+	}
+	v := desk.Resolve(context.Background(), req, 6)
+	if v.Decision != DecisionAutoApprove {
+		t.Fatalf("read-only tool resolved to %s", v.Decision)
+	}
+	if _, err := inbox.Enqueue(req, v); err == nil {
+		t.Fatal("auto-approve verdict entered the inbox")
+	}
+}

--- a/src/pkg/toolapprove/parity.go
+++ b/src/pkg/toolapprove/parity.go
@@ -1,0 +1,136 @@
+package toolapprove
+
+// Migration parity for the four gates RFC #4000 inventoried.
+//
+// The binding constraint from the maintainer's throughput addendum: "Migration
+// maps current behavior 1:1. Whatever a given ACMM level auto-permits today,
+// the desk auto-permits on day one. New restrictions arrive only as explicit,
+// audited policy changes — never as conservative shipped defaults that silently
+// downgrade every high-autonomy hive on upgrade day."
+//
+// This file is how that constraint is kept honest. Each legacy gate gets:
+//
+//   - a LegacyGate* function that computes the gate's answer by calling the
+//     SAME config constants and predicates the production gate calls, and
+//   - a case in LegacyBaseDecision that maps that answer onto a desk verdict.
+//
+// parity_test.go then asserts, for EVERY ACMM level 0..7, that the desk's
+// verdict for a request permits exactly what the legacy gate permits. Because
+// the parity functions delegate to the real config predicates rather than
+// re-encoding thresholds, a future change to (say) SelfMergeMinACMMLevel moves
+// both sides together and the test keeps passing — which is the point: the test
+// pins EQUIVALENCE, not a hardcoded table that would rot.
+
+import (
+	"fmt"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// LegacyGateSelfMerge reports whether the App-self-merge sweep may merge a PR
+// the App itself authored, at the given ACMM level.
+//
+// Delegates to config.AutoMergeConfig.SelfAuthoredAutoMergeAllowed — the same
+// predicate SweepSelfAuthoredAutoMerges consults — so the desk cannot drift
+// from the gate it is replacing. The gate history is recorded on
+// SelfMergeMinACMMLevel: the sweep originally had NO ACMM check, which is how
+// an L4 hive wrongly self-merged its own PR.
+func LegacyGateSelfMerge(cfg config.AutoMergeConfig, acmmLevel int) bool {
+	lvl := acmmLevel
+	return cfg.SelfAuthoredAutoMergeAllowed(&lvl)
+}
+
+// LegacyGatePlanAutoApprove reports whether a decomposition plan auto-approves
+// at the given level, delegating to config.PlanAutoApproveForLevel (the pack
+// lookup the decomposition path uses).
+func LegacyGatePlanAutoApprove(acmmLevel int) bool {
+	return config.PlanAutoApproveForLevel(acmmLevel)
+}
+
+// LegacyGatePlanFromLabel reports whether the label planning trigger may fire
+// at the given level, delegating to config.PlanningConfig.PlanFromLabelEnabled.
+func LegacyGatePlanFromLabel(p config.PlanningConfig, acmmLevel int) bool {
+	return p.PlanFromLabelEnabled(acmmLevel)
+}
+
+// LegacyGateQueuedMerge reports whether a queued merge may proceed. Unlike the
+// other three this gate is identity-based rather than level-based: the sweep
+// requires a trusted merger's queue approval (isTrustedMerger +
+// latestHiveQueueApproval). The desk models that as "an approval that already
+// happened", so trusted=true resolves and trusted=false goes to the operator
+// lane rather than being denied outright.
+func LegacyGateQueuedMerge(trustedApproval bool) bool {
+	return trustedApproval
+}
+
+// LegacyBaseDecision produces the pre-rule, pre-ceiling verdict for the
+// non-agent-tool request kinds, computed from the legacy gate predicates above
+// so day-one behavior matches byte for byte.
+//
+// The ceiling in Desk.decide is applied on top of this, but note that for these
+// kinds the base verdict is ALREADY derived from the level, so the ceiling is
+// a no-op in the common case — it exists to bound operator rules, not to
+// second-guess the legacy mapping.
+func LegacyBaseDecision(req Request, acmmLevel int) Verdict {
+	v := Verdict{
+		Kind:      req.Kind,
+		Tool:      req.Tool.Tool,
+		ACMMLevel: acmmLevel,
+		Agent:     req.Agent.Name,
+	}
+
+	switch req.Kind {
+	case KindSelfMerge:
+		// Parity note: the legacy gate ALSO requires AutoMergeConfig.Enabled and
+		// the self-authored toggle. Those are carried by the caller's config and
+		// checked at the call site before the request reaches the desk; the desk
+		// reproduces only the LEVEL half of the gate, which is the half that was
+		// bolted on after the L4 incident.
+		if acmmLevel >= config.SelfMergeMinACMMLevel {
+			v.Decision = DecisionAutoApprove
+			v.Rationale = fmt.Sprintf(
+				"ACMM L%d >= self-merge floor L%d: App-authored PR may self-merge",
+				acmmLevel, config.SelfMergeMinACMMLevel)
+		} else {
+			v.Decision = DecisionOperatorApprove
+			v.Rationale = fmt.Sprintf(
+				"ACMM L%d is below the self-merge floor L%d: App-authored PR requires operator approval",
+				acmmLevel, config.SelfMergeMinACMMLevel)
+		}
+
+	case KindPlanApproval:
+		if LegacyGatePlanAutoApprove(acmmLevel) {
+			v.Decision = DecisionAutoApprove
+			v.Rationale = fmt.Sprintf("ACMM L%d pack sets plan_auto_approve: plan approved without operator", acmmLevel)
+		} else {
+			v.Decision = DecisionOperatorApprove
+			v.Rationale = fmt.Sprintf("ACMM L%d pack does not set plan_auto_approve: plan requires operator approval", acmmLevel)
+		}
+
+	case KindPlanFromLabel:
+		// PlanFromLabelEnabled takes a PlanningConfig; the zero value carries
+		// the same defaults the config loader applies when the block is absent,
+		// which is the behavior an unconfigured hive has today.
+		if LegacyGatePlanFromLabel(config.PlanningConfig{}, acmmLevel) {
+			v.Decision = DecisionAutoApprove
+			v.Rationale = fmt.Sprintf("ACMM L%d permits the plan-from-label trigger", acmmLevel)
+		} else {
+			v.Decision = DecisionOperatorApprove
+			v.Rationale = fmt.Sprintf("ACMM L%d does not permit the plan-from-label trigger without operator approval", acmmLevel)
+		}
+
+	case KindQueuedMerge:
+		// A queued merge carries its own prior approval signal. The desk treats
+		// a trusted-merger queue approval as satisfying the operator lane.
+		v.Decision = DecisionOperatorApprove
+		v.Rationale = "queued merge awaiting trusted-merger approval"
+
+	default:
+		// An unknown kind fails closed into the operator lane. A request the
+		// desk does not recognize must never auto-resolve.
+		v.Decision = DecisionOperatorApprove
+		v.Rationale = fmt.Sprintf("unrecognized request kind %q: routed to operator approval (fail-closed)", req.Kind)
+	}
+
+	return v
+}

--- a/src/pkg/toolapprove/parity_test.go
+++ b/src/pkg/toolapprove/parity_test.go
@@ -1,0 +1,136 @@
+package toolapprove
+
+// Migration parity: whatever a given ACMM level auto-permits TODAY, the desk
+// auto-permits on day one.
+//
+// This is the constraint the maintainer's throughput addendum makes
+// non-negotiable — "New restrictions arrive only as explicit, audited policy
+// changes — never as conservative shipped defaults that silently downgrade
+// every high-autonomy hive on upgrade day."
+//
+// The tests compare the desk against the LEGACY predicates themselves (the same
+// config functions the production gates call), not against a hardcoded table.
+// A future change to a threshold therefore moves both sides together and these
+// keep passing — they pin EQUIVALENCE, which is what must not break.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestSelfMergeParityAcrossLevels pins the desk against
+// AutoMergeConfig.SelfAuthoredAutoMergeAllowed at every level.
+func TestSelfMergeParityAcrossLevels(t *testing.T) {
+	// A desk with NO operator rules is the day-one configuration: a hive that
+	// enables the feature and writes no rules must behave exactly as before.
+	desk := NewDesk(nil, passingScanner{})
+	amc := config.AutoMergeConfig{SelfAuthored: boolPtr(true)}
+
+	req := Request{
+		Kind:        KindSelfMerge,
+		Repo:        "kubestellar/hive",
+		Number:      1,
+		Author:      "hive-app[bot]",
+		ChecksGreen: true,
+		Tool:        ToolRequest{Tool: "hive-merge"},
+	}
+
+	for level := 0; level <= 7; level++ {
+		legacyAllows := LegacyGateSelfMerge(amc, level)
+		v := desk.Resolve(context.Background(), req, level)
+		deskAllows := v.Decision == DecisionAutoApprove
+
+		if deskAllows != legacyAllows {
+			t.Errorf("L%d self-merge: legacy gate allows=%v, desk allows=%v (decision %s, rationale %q) — "+
+				"migration must map current behavior 1:1",
+				level, legacyAllows, deskAllows, v.Decision, v.Rationale)
+		}
+	}
+}
+
+// TestPlanApprovalParityAcrossLevels pins the desk against
+// config.PlanAutoApproveForLevel.
+func TestPlanApprovalParityAcrossLevels(t *testing.T) {
+	desk := NewDesk(nil, passingScanner{})
+	req := Request{Kind: KindPlanApproval, Tool: ToolRequest{Tool: "plan"}, Agent: AgentIdentity{Name: "architect"}}
+
+	for level := 0; level <= 7; level++ {
+		legacyAllows := LegacyGatePlanAutoApprove(level)
+		v := desk.Resolve(context.Background(), req, level)
+		deskAllows := v.Decision == DecisionAutoApprove
+
+		if deskAllows != legacyAllows {
+			t.Errorf("L%d plan approval: legacy PlanAutoApproveForLevel=%v, desk allows=%v (decision %s) — "+
+				"the decomposition path must see identical behavior",
+				level, legacyAllows, deskAllows, v.Decision)
+		}
+	}
+}
+
+// TestPlanFromLabelParityAcrossLevels pins the desk against
+// PlanningConfig.PlanFromLabelEnabled with the default (absent-block) config.
+func TestPlanFromLabelParityAcrossLevels(t *testing.T) {
+	desk := NewDesk(nil, passingScanner{})
+	req := Request{Kind: KindPlanFromLabel, Tool: ToolRequest{Tool: "plan"}, Agent: AgentIdentity{Name: "architect"}}
+
+	for level := 0; level <= 7; level++ {
+		legacyAllows := LegacyGatePlanFromLabel(config.PlanningConfig{}, level)
+		v := desk.Resolve(context.Background(), req, level)
+		deskAllows := v.Decision == DecisionAutoApprove
+
+		if deskAllows != legacyAllows {
+			t.Errorf("L%d plan-from-label: legacy PlanFromLabelEnabled=%v, desk allows=%v (decision %s)",
+				level, legacyAllows, deskAllows, v.Decision)
+		}
+	}
+}
+
+// TestNoConservativeDowngradeAtHighAutonomy is the addendum's requirement 3
+// stated as a single assertion: at L6, a hive with the desk enabled and NO
+// rules configured must auto-permit everything it auto-permitted before.
+//
+// This is the test that would fail if someone shipped a "safe" default that
+// routed high-autonomy traffic through the operator lane.
+func TestNoConservativeDowngradeAtHighAutonomy(t *testing.T) {
+	desk := NewDesk(nil, passingScanner{})
+
+	// Every request an L6 hive resolves today without a human.
+	for _, req := range []Request{
+		{Kind: KindAgentTool, Tool: ToolRequest{Tool: "read", Arguments: map[string]any{"file_path": "a.go"}}, Agent: AgentIdentity{Name: "r"}},
+		{Kind: KindAgentTool, Tool: ToolRequest{Tool: "write", Arguments: map[string]any{"file_path": "a.go", "content": "package a"}}, Agent: AgentIdentity{Name: "w"}},
+		{Kind: KindAgentTool, Tool: ToolRequest{Tool: "bash", Arguments: map[string]any{"command": "go build ./..."}}, Agent: AgentIdentity{Name: "b"}},
+		{Kind: KindSelfMerge, Repo: "kubestellar/hive", Number: 1, Author: "hive-app[bot]", ChecksGreen: true, Tool: ToolRequest{Tool: "hive-merge"}},
+		{Kind: KindPlanApproval, Tool: ToolRequest{Tool: "plan"}, Agent: AgentIdentity{Name: "architect"}},
+	} {
+		v := desk.Resolve(context.Background(), req, 6)
+		if v.Decision != DecisionAutoApprove {
+			t.Errorf("L6 %s/%s resolved to %s, want auto-approve — enabling the desk with no rules "+
+				"must not downgrade a high-autonomy hive (rationale: %s)",
+				req.Kind, req.Tool.Tool, v.Decision, v.Rationale)
+		}
+	}
+}
+
+// TestUnknownKindFailsClosed pins that a request kind the desk does not know
+// goes to the operator lane rather than auto-resolving.
+func TestUnknownKindFailsClosed(t *testing.T) {
+	desk := NewDesk(nil, passingScanner{})
+	v := desk.Resolve(context.Background(), Request{Kind: "something-new", Tool: ToolRequest{Tool: "x"}}, 6)
+	if v.Decision != DecisionOperatorApprove {
+		t.Errorf("unknown request kind resolved to %s, want operator-approve (fail-closed)", v.Decision)
+	}
+}
+
+// TestLegacyQueuedMergeGate documents the identity-based gate's mapping.
+func TestLegacyQueuedMergeGate(t *testing.T) {
+	if !LegacyGateQueuedMerge(true) {
+		t.Error("a trusted-merger approval should permit a queued merge")
+	}
+	if LegacyGateQueuedMerge(false) {
+		t.Error("an untrusted queuer must not permit a queued merge")
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/src/pkg/toolapprove/rules.go
+++ b/src/pkg/toolapprove/rules.go
@@ -1,0 +1,287 @@
+package toolapprove
+
+// Approval rules as data.
+//
+// Operators declare approval policy as CEL expressions in config rather than as
+// code. This reuses the posture the fleet already settled on in pkg/celtrigger
+// (RFC #4000: "we already have a declarative, fail-closed rule engine … approval
+// rules should be the same engine and the same posture"):
+//
+//   - Rules compile at config load. A malformed expression is an error the
+//     operator sees at load time, never a fleet crash at decision time.
+//   - A runtime evaluation error is treated as NO-MATCH, never as a match. A
+//     broken rule silently stops widening authority; it can never accidentally
+//     grant it.
+//   - Evaluation cost is bounded, so a pathological expression cannot stall the
+//     decision point that sits in every agent turn.
+//
+// What a rule may NOT do is escape the hive's ACMM level: Desk.decide applies
+// the ceiling after rule evaluation, unconditionally. A rule is an input to the
+// decision, not an override of it.
+
+import (
+	"fmt"
+	"log/slog"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/ext"
+)
+
+// maxRuleEvalCost bounds CEL runtime work per rule evaluation. The decision
+// point runs in every agent turn, so the budget is deliberately tighter than
+// celtrigger's event-time budget: approval rules are field comparisons and
+// small label scans, not comprehensions over large collections. A rule that
+// exceeds this fails closed as no-match and warns so the operator can see why
+// it stopped firing.
+const maxRuleEvalCost uint64 = 5_000
+
+// activationVarRequest is the CEL variable name the request is exposed under.
+const activationVarRequest = "request"
+
+// RuleRequest is the flattened, CEL-visible view of an approval request. It is
+// a separate type from Request on purpose: it is a stable, documented policy
+// surface that operator rules are written against, so internal refactors of
+// Request cannot silently break every deployed rule.
+type RuleRequest struct {
+	// Kind is the request lane, e.g. "agent-tool", "self-merge". event.kind analogue.
+	Kind string `cel:"kind"`
+	// Tool is the tool or action name being requested.
+	Tool string `cel:"tool"`
+	// Agent is the requesting agent's name.
+	Agent string `cel:"agent"`
+	// Repo is the target repository, "org/name".
+	Repo string `cel:"repo"`
+	// Number is the target issue/PR number, 0 when not applicable.
+	Number int `cel:"number"`
+	// Labels are the labels on the target.
+	Labels []string `cel:"labels"`
+	// Author is the login that authored the target.
+	Author string `cel:"author"`
+	// Title is the target's title.
+	Title string `cel:"title"`
+	// ChecksGreen reports whether required CI is green on the target.
+	ChecksGreen bool `cel:"checks_green"`
+	// ReadOnly reports whether the requested tool is a read-only inspection tool.
+	ReadOnly bool `cel:"read_only"`
+	// SideEffectful is the negation of ReadOnly, exposed for readable rules.
+	SideEffectful bool `cel:"side_effectful"`
+	// Command is the shell command, for bash-shaped requests ("" otherwise).
+	Command string `cel:"command"`
+	// FilePath is the file target, for write-shaped requests ("" otherwise).
+	FilePath string `cel:"file_path"`
+}
+
+// ruleRequest flattens a Request into its CEL-visible form.
+func ruleRequest(req Request) RuleRequest {
+	labels := req.Labels
+	if labels == nil {
+		labels = []string{}
+	}
+	ro := req.Tool.IsReadOnly()
+	return RuleRequest{
+		Kind:          req.Kind,
+		Tool:          req.Tool.Tool,
+		Agent:         req.Agent.Name,
+		Repo:          req.Repo,
+		Number:        req.Number,
+		Labels:        labels,
+		Author:        req.Author,
+		Title:         req.Title,
+		ChecksGreen:   req.ChecksGreen,
+		ReadOnly:      ro,
+		SideEffectful: !ro,
+		Command:       req.Tool.GetCommand(),
+		FilePath:      req.Tool.GetFilePath(),
+	}
+}
+
+// activation renders the request as a CEL activation keyed by "request".
+func (r RuleRequest) activation() map[string]any {
+	return map[string]any{activationVarRequest: r}
+}
+
+// compiledApprovalRule pairs a Rule with its compiled CEL program.
+type compiledApprovalRule struct {
+	rule    Rule
+	program cel.Program
+}
+
+// RuleEngine holds the compiled approval rule set. Construct it with
+// CompileRules. Safe for concurrent Match calls.
+type RuleEngine struct {
+	env    *cel.Env
+	rules  []compiledApprovalRule
+	logger *slog.Logger
+}
+
+// newRuleEnv builds the CEL environment exposing the request. Registering
+// RuleRequest as a native type means an unknown field is a COMPILE error, so a
+// typo in a rule is caught at config load rather than silently never matching.
+func newRuleEnv() (*cel.Env, error) {
+	return cel.NewEnv(
+		// Register RuleRequest as a native type so field access is type-checked
+		// at Compile time — a typo like `request.checks_gren` is a config-load
+		// error, not a rule that silently never fires. cel:"..." tags name the
+		// fields, exactly as celtrigger does for NormalizedEvent.
+		ext.NativeTypes(reflect.TypeOf(RuleRequest{}), ext.ParseStructTags(true)),
+		cel.Variable(activationVarRequest, cel.ObjectType("toolapprove.RuleRequest")),
+		// hasLabel(request.labels, "dependabot") — reads better than the `in` form.
+		cel.Function("hasLabel",
+			cel.Overload("approval_hasLabel_list_string",
+				[]*cel.Type{cel.ListType(cel.DynType), cel.StringType},
+				cel.BoolType,
+				cel.BinaryBinding(approvalHasLabel),
+			),
+		),
+	)
+}
+
+// approvalHasLabel implements hasLabel(list, needle). Non-list / non-string
+// inputs yield false rather than erroring, keeping evaluation fail-closed.
+func approvalHasLabel(listVal, needleVal ref.Val) ref.Val {
+	needle, ok := needleVal.Value().(string)
+	if !ok {
+		return types.Bool(false)
+	}
+	lister, ok := listVal.(traits.Lister)
+	if !ok {
+		return types.Bool(false)
+	}
+	it := lister.Iterator()
+	for it.HasNext() == types.True {
+		if s, isStr := it.Next().Value().(string); isStr && s == needle {
+			return types.Bool(true)
+		}
+	}
+	return types.Bool(false)
+}
+
+// CompileRules builds a RuleEngine from operator rules. It fails closed: any
+// malformed expression, unknown action, or empty name returns an error and NO
+// engine, so the operator rejects the config instead of running a fleet with a
+// rule set that half-parsed. An empty rule list yields a valid engine that
+// never matches — preserving pre-feature behavior exactly.
+func CompileRules(rules []Rule, logger *slog.Logger) (*RuleEngine, error) {
+	env, err := newRuleEnv()
+	if err != nil {
+		return nil, fmt.Errorf("build approval rule CEL environment: %w", err)
+	}
+	eng := &RuleEngine{env: env, logger: logger}
+	if len(rules) == 0 {
+		return eng, nil
+	}
+
+	seen := make(map[string]struct{}, len(rules))
+	compiled := make([]compiledApprovalRule, 0, len(rules))
+	for i, r := range rules {
+		name := strings.TrimSpace(r.Name)
+		if name == "" {
+			return nil, fmt.Errorf("approval rule #%d: name is required", i+1)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("approval rule %q: duplicate name", name)
+		}
+		seen[name] = struct{}{}
+
+		if !r.Action.Valid() {
+			return nil, fmt.Errorf("approval rule %q: unknown action %q (want auto-approve, security-scan, or operator-approve)", name, r.Action)
+		}
+		if strings.TrimSpace(r.Expr) == "" {
+			return nil, fmt.Errorf("approval rule %q: expr is required", name)
+		}
+
+		ast, iss := env.Compile(r.Expr)
+		if iss != nil && iss.Err() != nil {
+			return nil, fmt.Errorf("approval rule %q: %w", name, iss.Err())
+		}
+		if ast.OutputType() != cel.BoolType {
+			return nil, fmt.Errorf("approval rule %q: expression must evaluate to bool, got %s", name, ast.OutputType())
+		}
+		prg, err := env.Program(ast,
+			cel.CostLimit(maxRuleEvalCost),
+			cel.InterruptCheckFrequency(100),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("approval rule %q: build program: %w", name, err)
+		}
+		r.Name = name
+		compiled = append(compiled, compiledApprovalRule{rule: r, program: prg})
+	}
+
+	// Higher priority first; declaration order breaks ties so a config file
+	// reads top-to-bottom as written.
+	sort.SliceStable(compiled, func(i, j int) bool {
+		return compiled[i].rule.Priority > compiled[j].rule.Priority
+	})
+	eng.rules = compiled
+	return eng, nil
+}
+
+// Match returns the first (highest-priority) rule whose expression matches the
+// request, or ok=false when none do.
+//
+// Fail-closed on every error path: a rule whose MinACMMLevel excludes this hive
+// is skipped, an evaluation error is a no-match, a non-bool result is a
+// no-match, and a cost-budget interrupt is a no-match with a warning. None of
+// these can produce a match, so a broken rule never grants authority.
+func (e *RuleEngine) Match(req Request, acmmLevel int) (RuleMatch, bool) {
+	if e == nil || len(e.rules) == 0 {
+		return RuleMatch{}, false
+	}
+	act := ruleRequest(req).activation()
+
+	for _, cr := range e.rules {
+		if cr.rule.MinACMMLevel > 0 && acmmLevel < cr.rule.MinACMMLevel {
+			continue
+		}
+		out, _, err := cr.program.Eval(act)
+		if err != nil {
+			e.warn("approval rule evaluation failed — treating as no-match",
+				"rule", cr.rule.Name, "error", err)
+			continue
+		}
+		b, ok := out.Value().(bool)
+		if !ok {
+			e.warn("approval rule did not evaluate to bool — treating as no-match",
+				"rule", cr.rule.Name)
+			continue
+		}
+		if b {
+			return RuleMatch{Name: cr.rule.Name, Action: cr.rule.Action}, true
+		}
+	}
+	return RuleMatch{}, false
+}
+
+// Names returns the configured rule names in evaluation order.
+func (e *RuleEngine) Names() []string {
+	if e == nil {
+		return nil
+	}
+	out := make([]string, 0, len(e.rules))
+	for _, cr := range e.rules {
+		out = append(out, cr.rule.Name)
+	}
+	return out
+}
+
+// Len reports how many rules are compiled.
+func (e *RuleEngine) Len() int {
+	if e == nil {
+		return 0
+	}
+	return len(e.rules)
+}
+
+func (e *RuleEngine) warn(msg string, args ...any) {
+	if e == nil || e.logger == nil {
+		return
+	}
+	e.logger.Warn(msg, args...)
+}

--- a/src/pkg/toolapprove/rules_test.go
+++ b/src/pkg/toolapprove/rules_test.go
@@ -1,0 +1,162 @@
+package toolapprove
+
+// Rules-as-data: compile-time rejection, fail-closed evaluation, and the
+// canonical operator cases from the RFC.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCompileRejectsMalformedRules pins the fail-closed compile posture: an
+// operator learns about a bad rule at config load, not at decision time.
+func TestCompileRejectsMalformedRules(t *testing.T) {
+	for name, rule := range map[string]Rule{
+		"syntax error":     {Name: "a", Expr: "request.kind ==", Action: RuleActionAutoApprove},
+		"unknown field":    {Name: "b", Expr: `request.no_such_field == "x"`, Action: RuleActionAutoApprove},
+		"not a bool":       {Name: "c", Expr: `request.kind`, Action: RuleActionAutoApprove},
+		"unknown action":   {Name: "d", Expr: "true", Action: RuleAction("merge-it")},
+		"empty name":       {Name: "", Expr: "true", Action: RuleActionAutoApprove},
+		"empty expression": {Name: "e", Expr: "  ", Action: RuleActionAutoApprove},
+	} {
+		if _, err := CompileRules([]Rule{rule}, nil); err == nil {
+			t.Errorf("%s: CompileRules accepted a rule it should reject", name)
+		}
+	}
+}
+
+// TestCompileRejectsDuplicateNames pins that rule names stay unique — they are
+// the operator-facing identifier in verdicts, audit records, and filter chips.
+func TestCompileRejectsDuplicateNames(t *testing.T) {
+	_, err := CompileRules([]Rule{
+		{Name: "dup", Expr: "true", Action: RuleActionAutoApprove},
+		{Name: "dup", Expr: "false", Action: RuleActionOperatorApprove},
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("duplicate rule names should be rejected, got err=%v", err)
+	}
+}
+
+// TestEmptyRuleSetNeverMatches pins the additive default: no rules means no
+// behavior change.
+func TestEmptyRuleSetNeverMatches(t *testing.T) {
+	eng, err := CompileRules(nil, nil)
+	if err != nil {
+		t.Fatalf("CompileRules(nil): %v", err)
+	}
+	if eng.Len() != 0 {
+		t.Errorf("empty rule set compiled %d rules", eng.Len())
+	}
+	if _, ok := eng.Match(sideEffectfulRequest(), 6); ok {
+		t.Error("an empty rule set matched a request")
+	}
+}
+
+// TestCanonicalDependabotRule is the case the RFC names directly: bulk approve
+// of green dependabot patch bumps, while a feature PR is NOT swept up.
+func TestCanonicalDependabotRule(t *testing.T) {
+	eng, err := CompileRules([]Rule{{
+		Name: "green-dependabot-patch",
+		Expr: `request.kind == "self-merge" && request.checks_green &&
+		        request.author == "dependabot[bot]" && request.title.startsWith("chore(deps)")`,
+		Action: RuleActionAutoApprove,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+
+	green := Request{
+		Kind: KindSelfMerge, Author: "dependabot[bot]", ChecksGreen: true,
+		Title: "chore(deps): bump golang.org/x/net from 0.1.0 to 0.1.1",
+	}
+	if m, ok := eng.Match(green, 6); !ok || m.Name != "green-dependabot-patch" {
+		t.Errorf("the canonical green dependabot patch bump did not match: ok=%v m=%+v", ok, m)
+	}
+
+	// The rule MUST distinguish a feature PR from a patch bump — the RFC calls
+	// this out explicitly as the thing operators do not want swept up.
+	feature := Request{
+		Kind: KindSelfMerge, Author: "somebody", ChecksGreen: true,
+		Title: "feat: add a whole new subsystem",
+	}
+	if _, ok := eng.Match(feature, 6); ok {
+		t.Error("a feature PR matched the dependabot patch rule — the rule must distinguish them")
+	}
+
+	// A red dependabot PR must not match either.
+	red := green
+	red.ChecksGreen = false
+	if _, ok := eng.Match(red, 6); ok {
+		t.Error("a RED dependabot PR matched a rule requiring green checks")
+	}
+}
+
+// TestRulePriorityOrdering pins that the highest-priority matching rule wins.
+func TestRulePriorityOrdering(t *testing.T) {
+	eng, err := CompileRules([]Rule{
+		{Name: "low", Expr: "true", Action: RuleActionAutoApprove, Priority: 1},
+		{Name: "high", Expr: "true", Action: RuleActionOperatorApprove, Priority: 100},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	m, ok := eng.Match(sideEffectfulRequest(), 6)
+	if !ok {
+		t.Fatal("no rule matched")
+	}
+	if m.Name != "high" {
+		t.Errorf("priority ignored: matched %q, want %q", m.Name, "high")
+	}
+}
+
+// TestRuleMinACMMLevelScoping pins that a level-scoped rule is skipped below
+// its floor.
+func TestRuleMinACMMLevelScoping(t *testing.T) {
+	eng, err := CompileRules([]Rule{{
+		Name: "only-high", Expr: "true", Action: RuleActionAutoApprove, MinACMMLevel: 5,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	if _, ok := eng.Match(sideEffectfulRequest(), 3); ok {
+		t.Error("a rule with MinACMMLevel=5 matched at L3")
+	}
+	if _, ok := eng.Match(sideEffectfulRequest(), 5); !ok {
+		t.Error("a rule with MinACMMLevel=5 did not match at L5")
+	}
+}
+
+// TestHasLabelHelper pins the label convenience function.
+func TestHasLabelHelper(t *testing.T) {
+	eng, err := CompileRules([]Rule{{
+		Name: "held", Expr: `hasLabel(request.labels, "hold")`, Action: RuleActionOperatorApprove,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	if _, ok := eng.Match(Request{Labels: []string{"bug", "hold"}}, 6); !ok {
+		t.Error("hasLabel did not find a present label")
+	}
+	if _, ok := eng.Match(Request{Labels: []string{"bug"}}, 6); ok {
+		t.Error("hasLabel matched an absent label")
+	}
+	// A nil label slice must not panic or match.
+	if _, ok := eng.Match(Request{}, 6); ok {
+		t.Error("hasLabel matched on a request with no labels")
+	}
+}
+
+// TestRuleNamesAreStable pins the chip ordering source.
+func TestRuleNamesAreStable(t *testing.T) {
+	eng, err := CompileRules([]Rule{
+		{Name: "b", Expr: "false", Action: RuleActionAutoApprove, Priority: 5},
+		{Name: "a", Expr: "false", Action: RuleActionAutoApprove, Priority: 9},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	names := eng.Names()
+	if len(names) != 2 || names[0] != "a" || names[1] != "b" {
+		t.Errorf("Names() = %v, want evaluation order [a b] (priority 9 before 5)", names)
+	}
+}

--- a/src/pkg/toolapprove/types.go
+++ b/src/pkg/toolapprove/types.go
@@ -126,6 +126,22 @@ type Verdict struct {
 	ACMMLevel  int         `json:"acmm_level"`
 	Agent      string      `json:"agent"`
 	ScanResult *ScanResult `json:"scan_result,omitempty"`
+
+	// Kind is the request lane this verdict resolved (see the desk's Kind*
+	// constants). Empty for verdicts produced by the pre-desk Decide/Resolve
+	// entry points, which only ever handled agent tool calls.
+	Kind string `json:"kind,omitempty"`
+	// Rule names the operator rule that resolved this request, when one fired.
+	// The dashboard shows this per row so an operator can see WHICH rule would
+	// resolve an item, and audit records carry it as the policy provenance.
+	Rule string `json:"rule,omitempty"`
+	// RuleAction is what that rule asked for. It may differ from Decision when
+	// the ACMM ceiling clamped the request — keeping both is what makes a
+	// clamp visible in the audit trail rather than silent.
+	RuleAction RuleAction `json:"rule_action,omitempty"`
+	// CeilingApplied reports that the hive's ACMM ceiling reduced this verdict
+	// below what base policy or a rule asked for.
+	CeilingApplied bool `json:"ceiling_applied,omitempty"`
 }
 
 // AutoApproved reports whether the tool call is permitted without further gates.
@@ -161,6 +177,19 @@ func (v Verdict) AuditFields() map[string]any {
 		if len(v.ScanResult.Violations) > 0 {
 			fields["violations"] = strings.Join(v.ScanResult.Violations, "; ")
 		}
+	}
+	// Policy provenance. RFC #4000 asks the verdict record to carry enough
+	// metadata for the UI to render the relevant knob inline, and a clamp must
+	// be visible in the audit trail rather than silent.
+	if v.Kind != "" {
+		fields["kind"] = v.Kind
+	}
+	if v.Rule != "" {
+		fields["rule"] = v.Rule
+		fields["rule_action"] = string(v.RuleAction)
+	}
+	if v.CeilingApplied {
+		fields["ceiling_applied"] = true
 	}
 	return fields
 }

--- a/src/pkg/toolapprove/wire.go
+++ b/src/pkg/toolapprove/wire.go
@@ -1,0 +1,56 @@
+package toolapprove
+
+// Config → desk wiring. Mirrors pkg/celtrigger/wire.go: one entry point called
+// after config load, fail-closed on malformed rules, and a no-op when the
+// feature block is absent.
+
+import (
+	"log/slog"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// DeskFromConfig builds a Desk and its operator Inbox from loaded config.
+//
+// Fail-closed: a malformed rule returns an error and NO desk, so the operator
+// rejects the config at load rather than discovering at decision time that half
+// the rule set compiled. Callers treat a non-nil error as fatal to startup, the
+// same posture celtrigger.CompileFromConfig established.
+//
+// Returns (nil, nil, nil) when the feature is disabled — the default. A nil
+// desk is the signal to every producer to keep using its legacy gate, so an
+// upgrade with no config change is byte-identical in behavior.
+func DeskFromConfig(cfg *config.Config, scanner SecurityScanner, logger *slog.Logger) (*Desk, *Inbox, error) {
+	if cfg == nil || !cfg.ToolApproval.Enabled {
+		return nil, nil, nil
+	}
+
+	rules := make([]Rule, 0, len(cfg.ToolApproval.Rules))
+	for _, r := range cfg.ToolApproval.Rules {
+		rules = append(rules, Rule{
+			Name:         r.Name,
+			Expr:         r.Expr,
+			Action:       RuleAction(r.Action),
+			Priority:     r.Priority,
+			MinACMMLevel: r.MinACMMLevel,
+		})
+	}
+
+	engine, err := CompileRules(rules, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return NewDesk(engine, scanner), NewInbox(cfg.ToolApproval.InboxPath), nil
+}
+
+// ACMMLevelOf reads the hive's configured ACMM level, defaulting to the most
+// restrictive lane when unset. An absent level must never widen authority —
+// the same fail-closed reading SelfAuthoredAutoMergeAllowed applies to its nil
+// level pointer.
+func ACMMLevelOf(cfg *config.Config) int {
+	if cfg == nil || cfg.ACMMLevel == nil {
+		return 0
+	}
+	return *cfg.ACMMLevel
+}

--- a/src/pkg/toolapprove/wire_test.go
+++ b/src/pkg/toolapprove/wire_test.go
@@ -1,0 +1,291 @@
+package toolapprove
+
+// Config → desk wiring, the UI accessors, and the error paths.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestDeskFromConfigDisabledByDefault is the additive guarantee: an absent or
+// disabled tool_approval block yields no desk, which is every producer's signal
+// to keep using its legacy gate.
+func TestDeskFromConfigDisabledByDefault(t *testing.T) {
+	for name, cfg := range map[string]*config.Config{
+		"nil config":   nil,
+		"absent block": {},
+		"explicit off": {ToolApproval: config.ToolApprovalConfig{Enabled: false}},
+	} {
+		desk, inbox, err := DeskFromConfig(cfg, nil, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", name, err)
+		}
+		if desk != nil || inbox != nil {
+			t.Errorf("%s: expected no desk and no inbox, got desk=%v inbox=%v", name, desk != nil, inbox != nil)
+		}
+	}
+}
+
+// TestDeskFromConfigEnabledBuildsBoth is the positive control.
+func TestDeskFromConfigEnabledBuildsBoth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "inbox.json")
+	cfg := &config.Config{
+		ToolApproval: config.ToolApprovalConfig{
+			Enabled:   true,
+			InboxPath: path,
+			Rules: []config.ToolApprovalRule{
+				{Name: "hold-workflows", Expr: `request.file_path.startsWith(".github/workflows/")`, Action: "operator-approve", Priority: 10},
+				{Name: "green-deps", Expr: `request.checks_green && request.author == "dependabot[bot]"`, Action: "auto-approve"},
+			},
+		},
+	}
+
+	desk, inbox, err := DeskFromConfig(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("DeskFromConfig: %v", err)
+	}
+	if desk == nil || inbox == nil {
+		t.Fatal("enabled config produced no desk/inbox")
+	}
+
+	names := desk.RuleNames()
+	if len(names) != 2 || names[0] != "hold-workflows" {
+		t.Errorf("RuleNames = %v, want hold-workflows first (priority 10)", names)
+	}
+
+	// The inbox must honor the configured path, not the package default.
+	if _, err := inbox.Enqueue(pendingRequest(1), operatorVerdict()); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("inbox did not persist at the configured path %s: %v", path, err)
+	}
+}
+
+// TestDeskFromConfigRejectsMalformedRules pins the fail-closed load posture:
+// a bad rule is an error and NO desk, so the operator fixes config rather than
+// running a fleet with a half-applied rule set.
+func TestDeskFromConfigRejectsMalformedRules(t *testing.T) {
+	cfg := &config.Config{
+		ToolApproval: config.ToolApprovalConfig{
+			Enabled: true,
+			Rules:   []config.ToolApprovalRule{{Name: "bad", Expr: "request.nope == 1", Action: "auto-approve"}},
+		},
+	}
+	desk, inbox, err := DeskFromConfig(cfg, nil, nil)
+	if err == nil {
+		t.Fatal("a malformed rule was accepted at config load")
+	}
+	if desk != nil || inbox != nil {
+		t.Error("a failed compile still produced a desk/inbox — it must fail closed")
+	}
+}
+
+// TestACMMLevelOfFailsClosed pins that an unset level reads as the most
+// restrictive value rather than defaulting to something permissive.
+func TestACMMLevelOfFailsClosed(t *testing.T) {
+	if got := ACMMLevelOf(nil); got != 0 {
+		t.Errorf("ACMMLevelOf(nil) = %d, want 0", got)
+	}
+	if got := ACMMLevelOf(&config.Config{}); got != 0 {
+		t.Errorf("ACMMLevelOf(unset level) = %d, want 0 (fail-closed)", got)
+	}
+	six := 6
+	if got := ACMMLevelOf(&config.Config{ACMMLevel: &six}); got != 6 {
+		t.Errorf("ACMMLevelOf(6) = %d, want 6", got)
+	}
+}
+
+// TestWouldMatchRuleDrivesThePanel pins the accessor the Approvals panel uses to
+// show, per row, which rule would resolve an item.
+func TestWouldMatchRuleDrivesThePanel(t *testing.T) {
+	eng, err := CompileRules([]Rule{{
+		Name: "self-merge-holds", Expr: `request.kind == "self-merge"`, Action: RuleActionOperatorApprove,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	desk := NewDesk(eng, passingScanner{})
+
+	m, ok := desk.WouldMatchRule(Request{Kind: KindSelfMerge}, 4)
+	if !ok || m.Name != "self-merge-holds" || m.Action != RuleActionOperatorApprove {
+		t.Errorf("WouldMatchRule = (%+v, %v), want the self-merge-holds rule", m, ok)
+	}
+
+	if _, ok := desk.WouldMatchRule(Request{Kind: KindAgentTool}, 4); ok {
+		t.Error("WouldMatchRule matched a request no rule covers")
+	}
+
+	// A desk with no rules, and a nil desk, must both answer safely rather than
+	// panicking — the panel calls this on every row.
+	if _, ok := NewDesk(nil, nil).WouldMatchRule(Request{Kind: KindSelfMerge}, 4); ok {
+		t.Error("a rule-less desk reported a match")
+	}
+	var nilDesk *Desk
+	if _, ok := nilDesk.WouldMatchRule(Request{}, 0); ok {
+		t.Error("a nil desk reported a match")
+	}
+	if names := nilDesk.RuleNames(); names != nil {
+		t.Errorf("nil desk RuleNames = %v, want nil", names)
+	}
+}
+
+// TestRuleEngineNilSafety pins the nil-receiver paths the desk relies on.
+func TestRuleEngineNilSafety(t *testing.T) {
+	var e *RuleEngine
+	if e.Len() != 0 {
+		t.Error("nil engine Len != 0")
+	}
+	if e.Names() != nil {
+		t.Error("nil engine Names != nil")
+	}
+	if _, ok := e.Match(Request{}, 6); ok {
+		t.Error("nil engine matched")
+	}
+	e.warn("should not panic")
+}
+
+// TestScannerErrorFailsClosed pins that a scanner that errors DENIES rather
+// than waving the request through.
+func TestScannerErrorFailsClosed(t *testing.T) {
+	desk := NewDesk(nil, erroringScanner{})
+	v := desk.Resolve(context.Background(), sideEffectfulRequest(), 5)
+	if v.Decision != DecisionDeny {
+		t.Errorf("a scanner error resolved to %s, want deny (fail-closed)", v.Decision)
+	}
+}
+
+// TestScanViolationDenies pins the failed-scan path.
+func TestScanViolationDenies(t *testing.T) {
+	desk := NewDesk(nil, failingScanner{})
+	v := desk.Resolve(context.Background(), sideEffectfulRequest(), 6)
+	if v.Decision != DecisionDeny {
+		t.Errorf("a failed scan resolved to %s, want deny", v.Decision)
+	}
+	if v.ScanResult == nil || v.ScanResult.Passed {
+		t.Error("the verdict did not carry the failing scan result")
+	}
+}
+
+// TestGreenScanBelowScanCeilingStillNeedsOperator pins that a green scan cannot
+// lift a low-level hive out of the operator lane.
+func TestGreenScanBelowScanCeilingStillNeedsOperator(t *testing.T) {
+	if AutoApproveOnGreenScan(2) {
+		t.Error("L2 must not auto-approve on a green scan")
+	}
+	if !AutoApproveOnGreenScan(3) {
+		t.Error("L3 should auto-approve on a green scan")
+	}
+}
+
+// TestNewDeskInstallsDefaultScanner pins that a nil scanner does not mean
+// "no scanning".
+func TestNewDeskInstallsDefaultScanner(t *testing.T) {
+	desk := NewDesk(nil, nil)
+	if desk.scanner == nil {
+		t.Fatal("NewDesk(nil, nil) left the scanner nil — scan-lane requests would have no scanner")
+	}
+	// A destructive command must be caught by the default scanner.
+	req := Request{
+		Kind:  KindAgentTool,
+		Tool:  ToolRequest{Tool: "bash", Arguments: map[string]any{"command": "rm -rf /"}},
+		Agent: AgentIdentity{Name: "x"},
+	}
+	if v := desk.Resolve(context.Background(), req, 6); v.Decision != DecisionDeny {
+		t.Errorf("destructive command resolved to %s, want deny", v.Decision)
+	}
+}
+
+// TestNewInboxDefaultsPath pins that an empty path falls back to the package
+// default rather than writing to the process working directory.
+func TestNewInboxDefaultsPath(t *testing.T) {
+	if got := NewInbox("").path; got != DefaultInboxPath {
+		t.Errorf("NewInbox(\"\").path = %q, want %q", got, DefaultInboxPath)
+	}
+}
+
+// TestMarkExecutedUnknownID pins the not-found path.
+func TestMarkExecutedUnknownID(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	if err := inbox.MarkExecuted("nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("MarkExecuted(unknown) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestMarkExecutedIsIdempotent pins that marking twice is safe — a producer
+// retrying after a partial failure must not error.
+func TestMarkExecutedIsIdempotent(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	id, _ := inbox.Enqueue(pendingRequest(1), operatorVerdict())
+	if _, err := inbox.Resolve(id, true, "op", ""); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if err := inbox.MarkExecuted(id); err != nil {
+		t.Fatalf("first MarkExecuted: %v", err)
+	}
+	if err := inbox.MarkExecuted(id); err != nil {
+		t.Errorf("second MarkExecuted: %v, want nil (idempotent)", err)
+	}
+}
+
+// TestPersistFailureIsReported pins that an unwritable inbox surfaces an error
+// rather than silently dropping a pending approval on the floor.
+func TestPersistFailureIsReported(t *testing.T) {
+	dir := t.TempDir()
+	// A FILE where the inbox wants a directory: MkdirAll must fail.
+	blocker := filepath.Join(dir, "blocked")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	inbox := NewInbox(filepath.Join(blocker, "inbox.json"))
+
+	if _, err := inbox.Enqueue(pendingRequest(1), operatorVerdict()); err == nil {
+		t.Error("Enqueue reported success although the inbox could not be persisted — " +
+			"a pending approval that is not durable must not look durable")
+	}
+}
+
+// TestGetMissingID pins the miss path of Get.
+func TestGetMissingID(t *testing.T) {
+	inbox := NewInbox(filepath.Join(t.TempDir(), "inbox.json"))
+	if _, ok := inbox.Get("nope"); ok {
+		t.Error("Get returned ok for an unknown ID")
+	}
+	if _, ok := inbox.ResolvedRecordFor("nope"); ok {
+		t.Error("ResolvedRecordFor returned ok for an unknown ID")
+	}
+}
+
+// TestVerdictWordBothBranches keeps the journal messages honest.
+func TestVerdictWordBothBranches(t *testing.T) {
+	if verdictWord(true) != "granted" || verdictWord(false) != "rejected" {
+		t.Error("verdictWord produced the wrong label")
+	}
+}
+
+// TestLegacyBaseDecisionQueuedMerge pins the queued-merge lane mapping.
+func TestLegacyBaseDecisionQueuedMerge(t *testing.T) {
+	v := LegacyBaseDecision(Request{Kind: KindQueuedMerge}, 6)
+	if v.Decision != DecisionOperatorApprove {
+		t.Errorf("queued merge base decision = %s, want operator-approve", v.Decision)
+	}
+}
+
+// erroringScanner always errors.
+type erroringScanner struct{}
+
+func (erroringScanner) Scan(context.Context, ToolRequest) (ScanResult, error) {
+	return ScanResult{}, errors.New("scanner exploded")
+}
+
+// failingScanner always returns a failed scan.
+type failingScanner struct{}
+
+func (failingScanner) Scan(context.Context, ToolRequest) (ScanResult, error) {
+	return ScanResult{Passed: false, Violations: []string{"test violation"}}, nil
+}


### PR DESCRIPTION
Implements RFC #4000 as a working vertical slice on `v5`. Builds on the `toolapprove` embryo landed via #4020 rather than duplicating it, and consumes `pkg/turn`'s op interface without restructuring it (stage 2 is in flight there concurrently).

## 1. The decision point

`Desk.Resolve` (`pkg/toolapprove/desk.go`) resolves every approval-shaped request to `auto-approve | security-scan | operator-approve | deny`, evaluating three layers **in a fixed order**:

```
1. BASE POLICY    guardrails, tool policy, agent mode, repo allowlist, ACMM level mapping
2. OPERATOR RULES CEL from config; may steer a request into a different lane
3. ACMM CEILING   applied LAST, unconditionally
```

That ordering is the whole safety argument: **rules are an input to a decision the ceiling always has the final word on.** A rule asking `auto-approve` on an L1 hive is clamped, the clamp is recorded on the verdict (`CeilingApplied`) and in the audit fields. Hard guardrails (direct PR create/merge, explicit denies, repo allowlist, mode) are **not** rule-overridable.

`ACMMCeiling`: L0–L2 → `operator-approve`, L3–L5 → `security-scan`, L6+ → `auto-approve`. An unknown/negative level clamps to the most restrictive lane.

The four inventoried gates get parity functions in `parity.go` that call **the same config predicates the production gates call** (`SelfAuthoredAutoMergeAllowed`, `PlanAutoApproveForLevel`, `PlanFromLabelEnabled`, plus the trusted-merger mapping) — so the tests pin *equivalence*, not a hardcoded table that would rot when a threshold moves.

## 2. Rules as data — the existing CEL engine

`rules.go` reuses `celtrigger`'s posture exactly: compile at config load (malformed → error, no engine), runtime eval error → **no-match**, bounded eval cost. `RuleRequest` is registered as a native CEL type so `request.checks_gren` is a *compile* error, and it is deliberately a separate type from the internal `Request` so refactors cannot silently break deployed rules.

The canonical case from fleet-owner feedback works and is tested — green dependabot patch bumps auto-approve while a feature PR is **not** swept up.

## 3. The L6 throughput contract

Treated as non-negotiable; each of the four requirements has a test.

1. **Auto-approve never queues** — enforced *structurally*: `Inbox.Enqueue` refuses any non-`operator-approve` verdict (`ErrNotOperatorLane`). `TestL6AutoApproveNeverQueues` asserts the inbox file **is never created** during a full L6 flow, so a future change that starts journaling auto-approvals fails here.
2. **Scan lane is not a serialization point** — `TestL6AutoApproveIsSynchronous` wires a scanner that fails the test if called and blocks forever if it is.
3. **Migration is 1:1** — `TestNoConservativeDowngradeAtHighAutonomy` plus per-gate parity across levels 0–7.
4. **L6 operator-lane items are probable policy bugs** — `PendingAtFullAutonomy`, `policy_bug_count` in the API, warning banner in the UI.

While implementing this I hit a real bug in my own first cut: clamping *after* a green scan knocked L3–L5 back down to the `security-scan` lane, a nonsense terminal state that broke both the ceiling and plan-approval parity tests. Fixed by separating the two halves of the ceiling — `ACMMCeiling` gives the most permissive **lane**, `AutoApproveOnGreenScan` says whether traversing that lane reaches auto-approve. The scan **is** the route, so passing it satisfies the ceiling rather than violating it.

## 4. Durable queue — operator lane only

`/data/approvals/inbox.json` on the PVC, following the hub upgrade-pause / contribute-ledger idiom: lazy load, **atomic** temp+rename write, corrupt file degrades to empty rather than wedging the hive, bounded growth + 30-day journal retention.

Idempotency: `DeriveIdempotencyKey` hashes what identifies the request (arguments in sorted key order, so map iteration cannot make one request hash two ways) and excludes timestamps, which is what makes a re-delivery match. Resolution is two-phase — **resolve → execute → mark executed** — so a crash between "approved" and "actually ran" is distinguishable on restart. Replay surfaces as **409** carrying the original outcome.

**Reconciliation with #4002 stage 2:** kept additive. `Request.IdempotencyKey` accepts an externally-supplied key, so when stage 2's per-operation identity lands the turn runner passes its own key and the desk journals under that identity — no schema change on either side.

## 5. API

`GET /api/approvals`, `POST /api/approvals/resolve`, `POST /api/approvals/bulk` — all `requireOwnerRole` with the server-verified marker.

**Bulk is never a parallel path.** It calls `Inbox.ResolveMany` → `Inbox.Resolve` per item, the same function the single handler calls; `Desk.ResolveBatch` likewise calls `Desk.Resolve` per request. Mirrors `runBulkAction`/`applyBulkAction`. Partial failure is normal, so the response is a per-item result list.

## 6. Dashboard

Approvals panel: pending-count badge, **rule chips as filters**, multi-select + bulk resolve, and each row showing which rule would resolve it — re-evaluated server-side against the *current* rule set rather than replayed from the enqueue-time verdict, so editing policy is immediately visible in the queue. Hidden entirely when the desk is off.

## 7. Producer — one, real, default-OFF

The self-authored auto-merge sweep. Cheapest honest choice: already the exact shape the desk generalizes, it is the gate whose incident history the RFC cites, and it needs no new call site (repo, number, author and a real `ChecksGreen` from `commitGreen` are already computed).

The consultation sits **after** the sweep's own eligibility checks, so the desk can only ever *withhold* a merge the legacy gate already permitted — never widen authority. That asymmetry makes enabling the flag safe to try live. With `tool_approval.enabled: false` (the default) no hook is installed and the sweep is byte-identical to before (`TestNoDeskInstalledIsNoOp`).

## Tests

ACMM ceiling fail-closed w/ positive control; L6 never queues; L6 never touches the scanner; bulk == N individual decisions (every level, every lane); persistence round-trip across a simulated restart (a second `Inbox` over the same path); granted verdict does not double-execute; non-owner refused **behaviourally and at source level** (count floor, so collapsing handlers cannot drop a gate); migration parity per gate across levels 0–7.

I mutation-verified the two security-critical suites rather than trusting green: removing the ceiling clamp turns 4 ceiling tests red, and deleting one `requireOwnerRole` turns 4 API tests red including the source-gate count floor.

Targeted `go vet` + tests clean on `toolapprove`, `dashboard`, `github`, `turn`, `config`. Two `pkg/config` failures (`TestExportEmitsShellExportOnBothPaths`, `TestSharedCacheIsCreatedPrivate`) are **pre-existing on clean v5** — verified by stashing.

Docs: `src/docs/design/tool-approval-desk.md`.

## Remaining

- Swap the other three gates onto the desk at their call sites (parity functions + tests already exist for all three).
- Route `security-scan` through the sec-check agent surface, with the async/post-hoc path requirement 2 anticipates.
- Suspend/resume the operator wait as a #4002 re-entrant turn; adopt stage 2's idempotency key.
- `on_approval_pending` hook (#4001) so an L6 policy bug alerts rather than waiting.

Refs #4000