### PR TITLE
🔄 sync: top up v5 with latest v4

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -96,6 +96,18 @@ jobs:
         working-directory: .
         run: bash bin/test_gh_auth_native_no_cat.sh
 
+      # #4045: agent CLI backends (observed live: Copilot CLI) re-export their
+      # own live GitHub credential as GITHUB_TOKEN into every tool shell they
+      # spawn — after all launch-path scrubbing — letting a wrapper-denied
+      # agent write to repos via raw curl, outside every gh-wrapper control.
+      # This EXECUTES shells the way a backend spawns them (token in the spawn
+      # env) and asserts the BASH_ENV scrub leaves them token-less, with
+      # positive controls that the probe can see a leak and that the wrapper
+      # still authenticates from the per-agent cache.
+      - name: agent shell token scrub (#4045)
+        working-directory: .
+        run: bash bin/test_agent_env_scrub.sh
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'

--- a/Justfile
+++ b/Justfile
@@ -489,10 +489,36 @@ contribute-hive backend="" mode="docker": check-version
         fi
       fi
 
-      # Create tmux session with the CLI
+      # Create tmux session with the CLI.
+      #
+      # The launch command CDs into the repo first. That is not belt-and-braces:
+      # a long-lived tmux server keeps its own working directory, and when that
+      # directory is deleted (here: a nested clone's v2/pkg/agent, orphaned when
+      # the repo renamed v2/ -> src/) every pane the server forks inherits the
+      # dead cwd. The pane's shell says so — "shell-init: error retrieving
+      # current directory" — and a backend that requires a resolvable cwd then
+      # dies seconds after its first task. agy exits 2 that way; claude, codex
+      # and goose happen to tolerate it, which is why this hid for so long.
+      #
+      # -c is NOT sufficient on its own: on a server whose own cwd is gone,
+      # `tmux new-session -c <valid path>` still forks the pane into the deleted
+      # directory (verified against tmux on Fedora 44). It is passed anyway
+      # because it IS correct on a healthy server; the cd is what carries the
+      # fix.
       tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-      tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50
-      tmux send-keys -t "$TMUX_SESSION" "${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
+      tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50 -c "$PWD"
+      tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$PWD") && ${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
+
+      # Surface a poisoned tmux server rather than letting the backend die a
+      # silent, unexplained death 30 seconds into its first task.
+      PANE_PATH="$(tmux display-message -p -t "$TMUX_SESSION" '#{pane_current_path}' 2>/dev/null || echo '')"
+      case "$PANE_PATH" in
+        *"(deleted)"|"")
+          echo "WARNING: this tmux server's working directory no longer exists (pane reports: ${PANE_PATH:-unknown})." >&2
+          echo "         The cd above works around it, but panes you open by hand will start in a dead directory." >&2
+          echo "         Fix it for good with: tmux kill-server   (ends all tmux sessions, then rerun this recipe)" >&2
+          ;;
+      esac
 
       # Start the relay
       export HIVE_AGENT_SESSION="$TMUX_SESSION"

--- a/bin/README.md
+++ b/bin/README.md
@@ -44,6 +44,7 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `gh-wrapper.sh` | Enforcement | `gh` wrapper that injects App tokens and enforces global/per-agent restriction rules from `/etc/hive/restrictions/<agent-id>.json`. |
 | `hive-open-pr.sh` | Enforcement | Agent-side wrapper for PR creation requests. It writes a request file for the Hive watcher so PRs are opened by the GitHub App bot and pass the same ACMM authorization checks. |
 | `setup-proxy-iptables.sh` | Enforcement | Installs iptables rules in the container to force GitHub HTTPS traffic through the ACMM proxy even if an agent unsets proxy variables. |
+| `agent-env-scrub.sh` | Enforcement | Sourced (never executed) at the start of every shell in an agent's process tree, via `BASH_ENV`/`ENV` from `agent-launch.sh` and an `/etc/bash.bashrc` guard, to unset the live GitHub credentials backend CLIs re-export into agent tool shells (#4045). |
 | `hive-config.sh` | Config | Shared shell config reader that exposes project, repo, agent, dashboard, health, and policy values parsed from `hive-project.yaml`. |
 
 ## Deployment and local operation

--- a/bin/agent-env-scrub.sh
+++ b/bin/agent-env-scrub.sh
@@ -1,0 +1,48 @@
+# agent-env-scrub.sh — shell-boundary credential scrub for agent tool shells.
+#
+# SECURITY (#4045): agent CLI backends re-export their own live GitHub
+# credentials into the shells they spawn for tool calls. Observed live on a
+# Copilot-backed fleet: the CLI authenticates from its persistent credential
+# store (/data/copilot-user-token) and sets GITHUB_TOKEN in the environment of
+# every tool shell — AFTER all of the hive's launch-path scrubbing (#3931) has
+# run. A wrapper-denied agent then fell back to
+#   curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/...
+# and succeeded at a repo write, bypassing every gh-wrapper control (allowlist
+# #3854, mode/ACMM gates, merge eligibility, authorship routing, provenance).
+#
+# This file is SOURCED — never executed — at the start of every shell in the
+# agent's process tree, via BASH_ENV/ENV exported by agent-launch.sh (tool
+# shells, which are non-interactive) and via the /etc/bash.bashrc guard the
+# Dockerfile installs (interactive shells). Because the unset runs at CHILD
+# shell startup, it neutralizes tokens however they arrived: inherited from the
+# session env, or set explicitly in the spawn env by the backend CLI itself —
+# the #4045 mechanism, which no amount of parent-side scrubbing can reach.
+#
+# What this deliberately does NOT break:
+#   - The backend CLI process keeps its own auth. The CLI (node/binary) never
+#     sources this file; COPILOT_GITHUB_TOKEN / GITHUB_TOKEN stay in ITS env
+#     for Copilot API auth and the built-in GitHub MCP server (the sanctioned,
+#     hive-mediated write path under github.app_authored_prs).
+#   - gh-wrapper.sh still authenticates: it sources this at startup (losing
+#     only inherited token env, which it must never trust anyway — audit H3)
+#     and then exports GH_TOKEN itself from HIVE_AGENT_TOKEN_CACHE, which is a
+#     PATH, not a credential, and is deliberately not scrubbed.
+#   - git-credential-hive.sh reads the per-agent cache file directly; hive-merge
+#     and hive-open-pr likewise never rely on inherited token env.
+#
+# Residual (documented, closed elsewhere): a same-uid agent can still read a
+# backend CLI's /proc/<pid>/environ deliberately. That extraction lane — and
+# any smuggled credential — is closed at the transport by the MITM proxy's
+# Authorization strip/inject (#1861, PR #4032): the proxy, not the agent env,
+# decides what credential GitHub ever sees.
+#
+# POSIX sh compatible (dash-safe): no bashisms, and `unset` of an absent
+# variable is not an error. Keep the variable list in sync with
+# bin/test_agent_env_scrub.sh, which source-asserts every name below.
+unset GITHUB_TOKEN
+unset GH_TOKEN
+unset GH_ENTERPRISE_TOKEN
+unset GITHUB_ENTERPRISE_TOKEN
+unset COPILOT_GITHUB_TOKEN
+unset GITHUB_COPILOT_TOKEN
+unset HIVE_GITHUB_TOKEN

--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -202,6 +202,36 @@ if [[ "$BACKEND" == "copilot" ]]; then
   fi
 fi
 
+# SECURITY (#4045): the backend CLI re-exports live GitHub credentials into
+# the tool shells it spawns. The Copilot CLI authenticates from its own
+# persistent store (or COPILOT_GITHUB_TOKEN above) and sets GITHUB_TOKEN in
+# every shell it runs for the agent — after all launch-path scrubbing (#3931)
+# has already happened, so unsetting here cannot reach it. Observed live: a
+# wrapper-denied agent fell back to raw
+#   curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/...
+# and performed a repo write outside every gh-wrapper control.
+#
+# BASH_ENV is sourced by every NON-INTERACTIVE bash at startup — i.e. by each
+# tool shell the CLI spawns, INCLUDING ones the CLI hands an explicit
+# GITHUB_TOKEN in the spawn env — so the scrub runs inside the child, at the
+# only boundary that sees the backend's re-export. ENV covers interactive
+# POSIX-mode shells the same way. The CLI process itself is not a shell and
+# never sources this file, so its own auth (COPILOT_GITHUB_TOKEN, the
+# app_authored_prs GITHUB_TOKEN for the built-in GitHub MCP server) is
+# untouched: this changes what the AGENT'S SHELLS see, not what the backend
+# can do. gh-wrapper.sh and git-credential-hive.sh keep working — both
+# authenticate from HIVE_AGENT_TOKEN_CACHE (a path, deliberately not
+# scrubbed), never from inherited token env. Interactive shells get the same
+# scrub from the /etc/bash.bashrc guard installed by the Dockerfile.
+AGENT_ENV_SCRUB="${SCRIPT_DIR}/agent-env-scrub.sh"
+[[ -f "$AGENT_ENV_SCRUB" ]] || AGENT_ENV_SCRUB="/usr/local/bin/agent-env-scrub.sh"
+if [[ -f "$AGENT_ENV_SCRUB" ]]; then
+  export BASH_ENV="$AGENT_ENV_SCRUB"
+  export ENV="$AGENT_ENV_SCRUB"
+else
+  echo "[agent-launch] WARN: agent-env-scrub.sh not found — backend-exported GitHub tokens will be visible in agent tool shells (#4045)" >&2
+fi
+
 # Scrub GitHub token patterns and JWTs from stderr before writing to disk.
 scrub_tokens() {
   sed -u -E \

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -456,6 +456,21 @@ if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
   tmux new-session -d -s "$TMUX_SESSION" -c "$HIVE_WORKSPACE_DIR" -x 200 -y 50
 fi
 
+# kubestellar/hive#4046: a long-lived tmux SERVER (this container can run one
+# for its whole lifetime) keeps its own working directory, and every pane it
+# forks afterward inherits it — even a pane started with an explicit, valid
+# `-c`, if the server's own cwd is already gone. That is exactly the shape of
+# directory HIVE_WORKSPACE_DIR is: agents clone into subdirectories of it
+# (contribute_ws.go's assignment prompt), so pinning the launch's `cd` at
+# HIVE_WORKSPACE_DIR itself would re-create the trap the moment that directory
+# is ever removed and recreated out from under a still-running server. `cd`
+# into $HOME instead — a directory nothing in the task lifecycle deletes or
+# recreates — so the CLI always starts somewhere resolvable regardless of what
+# happens to the workspace subtree underneath it; the CLI's own per-task `cd`
+# into $HIVE_WORKSPACE_DIR/<repo> (per the assignment prompt) is unchanged.
+HIVE_AGENT_CWD="${HOME}"
+mkdir -p "$HIVE_AGENT_CWD"
+
 # Start the relay in the background
 echo "Starting ClankeR relay connection to hub..."
 node "${SCRIPT_DIR}/contributor-relay.sh" &
@@ -528,7 +543,12 @@ fi
 # relay launches a one-shot CLI per task, and one-shot invocations do not draw
 # the trust/theme/onboarding dialogs this loop dismisses.
 if [[ "$CONTRIBUTOR_MODE" == "interactive" ]]; then
-  tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG $REASONING_FLAG" Enter
+  # kubestellar/hive#4046: `-c` on new-session above is NOT sufficient once the
+  # server's own cwd is already gone — verified: new-session with a valid `-c`
+  # still forks the pane into the dead directory. The `cd` in the literal
+  # launch line is what actually carries the fix; -c is defense-in-depth for a
+  # healthy server.
+  tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$HIVE_AGENT_CWD") && $CMD $PERM_FLAG $MODEL_FLAG $REASONING_FLAG" Enter
 
   # Auto-dismiss startup prompts (workspace trust, theme picker, etc.)
   AUTO_DISMISS_ATTEMPTS=10

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -672,6 +672,83 @@ function recoverWedgedShell() {
 // dismissal can look at the SAME text without capturing twice, and so the
 // dismissal can see WHICH prompt is on screen rather than re-deriving it from
 // a state enum that has already thrown that detail away.
+// Shell names that mean the pane fell back to a prompt — i.e. whatever the
+// relay launched is no longer the pane's foreground program.
+const PANE_SHELL_COMMANDS = new Set(['bash', 'sh', 'zsh', 'fish', 'dash', 'ksh', 'ash', 'tcsh', 'csh']);
+
+// How many consecutive shell readings (one per progress tick) are required
+// before the CLI is declared gone. One is not enough: a tool call can briefly
+// put a shell in the pane's foreground while the CLI is very much alive.
+const CLI_GONE_CONFIRMATIONS = 2;
+let consecutiveShellReadings = 0;
+
+// paneForegroundCommand asks tmux what the pane is actually RUNNING. Empty when
+// tmux cannot answer (session gone, tmux missing) — an unknown, never a death.
+function paneForegroundCommand() {
+  try {
+    return execSync(
+      `tmux display-message -p -t ${TMUX_SESSION} '#{pane_current_command}' 2>/dev/null`,
+      { encoding: 'utf8', timeout: 15000 }
+    ).toString().trim();
+  } catch (_) {
+    return '';
+  }
+}
+
+// cliProcessLooksGone reports whether the agent CLI has left the pane.
+//
+// It replaces a substring scan of the WHOLE process table:
+//
+//   procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || …
+//
+// which could not do this job. Two independent defects, both observed live:
+//
+//  1. The relay's own machinery carries the backend's name. For agy the
+//     launcher (`just contribute-hive agy local`) and the tmux session itself
+//     (`tmux attach -t hive-agy-5b4f`) both contain "agy", so the probe was
+//     pinned alive no matter what happened to the CLI.
+//  2. The other CLI names were OR'd in unconditionally, whatever BACKEND was.
+//     Any contributor with Claude Code running — i.e. most of them — reported
+//     a live CLI for every backend, forever.
+//
+// With the probe stuck true the relay never relaunched a dead CLI, cliReady
+// stayed latched, and task prompts were typed into a bare shell: exactly the
+// #2203 bug-2 wedge the send gate exists to prevent.
+//
+// The pane's own foreground command answers the real question, and it cannot be
+// confused by anything outside the pane. Two consecutive readings are required
+// so that a tool call which briefly fronts a shell does not read as a death —
+// the expensive mistake, since it restarts a CLI that is working. A CLI that
+// really exited leaves the pane at a prompt permanently, so it still trips on
+// the following tick; the stall backstop in progressTick is the second net.
+//
+// Note the pane TEXT is deliberately not consulted: a CLI that dies leaves its
+// last frame on screen, ready-chrome and all, so requiring that chrome to be
+// gone would re-introduce exactly the blindness this replaces.
+function probeCLIPresence() {
+  const fg = paneForegroundCommand();
+  const isShell = !!fg && PANE_SHELL_COMMANDS.has(fg);
+  if (!isShell) {
+    consecutiveShellReadings = 0;
+  } else {
+    consecutiveShellReadings++;
+  }
+  return { isShell, gone: isShell && consecutiveShellReadings >= CLI_GONE_CONFIRMATIONS };
+}
+
+function cliProcessLooksGone() {
+  return probeCLIPresence().gone;
+}
+
+// paneIsRunningShell answers "is the pane at a prompt RIGHT NOW", without
+// touching the confirmation counter. Used by the send gate, where one reading
+// is enough: typing a prompt into a shell is never right, and the cost of
+// waiting a tick when we are wrong is nil.
+function paneIsRunningShell() {
+  const fg = paneForegroundCommand();
+  return !!fg && PANE_SHELL_COMMANDS.has(fg);
+}
+
 function capturePaneText() {
   try {
     return execSync(
@@ -919,9 +996,32 @@ function tmuxSendKeys(text) {
   // keystrokes land on bash, whose readline chokes on the apostrophes in the
   // prompt and drops the pane into PS2 continuation, wedging it permanently.
   // Queue instead; flushPendingTask() delivers it once readiness is confirmed.
+  //
+  // cliReady is a LATCH: set once the CLI is confirmed up, cleared only by a
+  // relaunch. When the liveness probe could not tell the CLI apart from the
+  // relay's own processes (see cliProcessLooksGone), a CLI that died was never
+  // relaunched, the latch stayed true, and this gate waved the prompt straight
+  // through into a bare shell — observed live, with the hub's task prompt
+  // executing as shell commands. So re-confirm against the LIVE pane before
+  // typing; the per-backend readiness patterns already exist in getCLIState().
   if (!cliReady) {
     console.log('CLI not ready — queuing task prompt instead of typing into the pane');
     pendingTask = text;
+    return;
+  }
+  if (paneIsRunningShell()) {
+    console.log(`Pane is at a shell prompt, not ${BACKEND} — queuing task prompt instead of typing it into the shell`);
+    pendingTask = text;
+    {
+      // The latch was STALE: the CLI exited without the relay noticing. Drop it
+      // and bring the CLI back, or the queued prompt has nothing to flush into.
+      cliReady = false;
+      try {
+        console.log(`Relaunching ${BACKEND} after a stale readiness latch: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('Failed to relaunch after a stale readiness latch:', e.message);
+      }
+    }
     return;
   }
   try {
@@ -1324,6 +1424,9 @@ let lastPaneChangeAt = 0;
 function resetPaneStallClock() {
   lastPaneFingerprint = null;
   lastPaneChangeAt = Date.now();
+  // A new task also starts with a clean CLI-liveness count: shell readings from
+  // the previous task say nothing about this one.
+  consecutiveShellReadings = 0;
 }
 
 // paneStalled records the current pane content and reports whether it has been
@@ -1457,15 +1560,11 @@ function progressTick() {
   if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
 
   try {
-    let procs = '';
-    try {
-      if (fs.existsSync('/proc')) {
-        procs = execSync(`for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`, { encoding: 'utf8', timeout: 15000 });
-      } else {
-        procs = execSync(`ps -eo command 2>/dev/null`, { encoding: 'utf8', timeout: 15000 });
-      }
-    } catch (_) { procs = BACKEND; }
-    const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
+    // See probeCLIPresence(): this asks the PANE what it is running, rather than
+    // grepping the whole process table for the backend's name — a scan the
+    // relay's own launcher and tmux session always satisfied.
+    const presence = probeCLIPresence();
+    const cliAlive = !presence.gone;
     // bob is not a persistent REPL: it exits at the end of every turn ("Bob
     // goes to sleep 💤"). For bob an exited process is the normal completion
     // signal, not a crash, so it must fall through to the checkTmuxIdle()
@@ -1505,6 +1604,20 @@ function progressTick() {
       }
       // environment: the agent CLI process died; nothing was judged about the work.
       failCurrentTask('CLI process exited — restarted', { kind: 'environment' });
+      return;
+    }
+    // A pane sitting at a shell is never evidence that the AGENT finished: the
+    // CLI is simply not there. Without this, the first (still unconfirmed)
+    // shell reading falls through to the completion check below, where the
+    // dead CLI's LAST FRAME — ready chrome and all, still on screen — reads as
+    // "agent idle" and reports a task nobody did as completed. Hold here and
+    // let the next tick either confirm the death or clear it.
+    //
+    // bob is exempt: it exits at the end of every turn, so for bob a shell pane
+    // IS the completion signal (see cliExitIsNormal above).
+    if (presence.isShell && !cliExitIsNormal) {
+      console.warn(`Pane is at a shell prompt, not ${BACKEND} — awaiting confirmation before judging the task`);
+      send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: captureTmuxLines(TMUX_TAIL_LINES) });
       return;
     }
   } catch (_) {}
@@ -1901,6 +2014,9 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
     paneStalled,
     resetPaneStallClock,
+    cliProcessLooksGone,
+    paneForegroundCommand,
+    CLI_GONE_CONFIRMATIONS,
     PANE_STALL_TIMEOUT_MS,
     // Backdate the stall clock so a test can cross the timeout without
     // sleeping — the two ticks it needs otherwise land in the same millisecond.

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1381,12 +1381,28 @@ function checkTmuxPaneState() {
 
 // Relaunch the backend CLI in the tmux session using the flags from
 // backends.conf, the same way contributor-agent.sh first launched it.
+// launchCommandWithCwd prefixes the launch with a cd into the relay's own
+// working directory (the repo root, where `just contribute-hive` starts node).
+//
+// A relaunch lands in whatever directory the pane's shell is sitting in, and a
+// long-lived tmux server can hand out a cwd that no longer exists — every pane
+// it forks inherits the dead directory, the shell prints "shell-init: error
+// retrieving current directory", and a backend that needs a resolvable cwd dies
+// shortly after its first task (agy exits 2; claude/codex/goose tolerate it).
+// The Justfile pins the cwd for the FIRST launch; without this, the first
+// relaunch would silently undo that.
+function launchCommandWithCwd(launchCmd) {
+  const cwd = process.cwd();
+  if (!cwd) return launchCmd;
+  return `cd ${shellQuote(cwd)} && ${launchCmd}`;
+}
+
 function relaunchCLI() {
   const launchCmd = buildLaunchCommand();
   // The pane may be wedged in bash PS2 continuation; clear it or the relaunch
   // command is swallowed as more continuation text and never runs.
   recoverWedgedShell();
-  execSync(`tmux send-keys -t ${TMUX_SESSION} ${shellQuote(launchCmd)} Enter`, { timeout: 15000 });
+  execSync(`tmux send-keys -t ${TMUX_SESSION} ${shellQuote(launchCommandWithCwd(launchCmd))} Enter`, { timeout: 15000 });
   // The CLI is NOT up yet. cliReady must stay false until the readiness
   // classifier positively confirms it, or a task prompt sent in the meantime
   // is typed as literal keystrokes into a bare shell (issue #2203, bug 2).
@@ -2014,6 +2030,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
     paneStalled,
     resetPaneStallClock,
+    launchCommandWithCwd,
     cliProcessLooksGone,
     paneForegroundCommand,
     CLI_GONE_CONFIRMATIONS,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -252,6 +252,36 @@ const AGY_WEDGED_PANE = [
 // 'claude' whatever the backend was — so a dead CLI was never detected, was
 // never relaunched, cliReady stayed latched, and the hub's task prompt was typed
 // into a bare shell.
+// --- Relaunch must pin the working directory --------------------------------
+//
+// A long-lived tmux server can hand every pane it forks a cwd that no longer
+// exists (observed: a nested clone's v2/pkg/agent, orphaned when the repo
+// renamed v2/ -> src/). The shell reports "shell-init: error retrieving current
+// directory" and a backend needing a resolvable cwd dies shortly after its
+// first task — agy exits 2 that way. The Justfile pins the cwd for the first
+// launch; a relaunch that dropped the cd would silently undo it.
+test('a relaunch cds into the relay cwd before starting the CLI', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    const launched = relay.launchCommandWithCwd('agy --dangerously-skip-permissions');
+    assert.match(launched, /^cd .+ && agy --dangerously-skip-permissions$/,
+      `relaunch must pin the cwd, got: ${launched}`);
+    assert.ok(launched.includes(process.cwd()),
+      `the cd target must be the relay's own cwd: ${launched}`);
+  } finally { teardown(relay); }
+});
+
+test('relaunchCLI sends the cd-prefixed command to tmux', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    const before = relay.__tmuxSends().length;
+    relay.relaunchCLI();
+    const sends = relay.__tmuxSends().slice(before);
+    assert.ok(sends.some(c => /cd .+ && /.test(c)),
+      `the relaunch typed into the pane must carry the cd: ${JSON.stringify(sends)}`);
+  } finally { teardown(relay); }
+});
+
 test('a shell in the pane is only a death after consecutive confirmations', () => {
   const relay = loadRelay({ backend: 'agy', procAlive: false });
   try {

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -53,6 +53,11 @@ function loadRelay({ backend = 'copilot', backendBinary = null, model = '', reas
       if (typeof state === 'string' && state.includes('\n')) return state;
       return 'dev@host:~$ \n';
     }
+    if (/display-message/.test(cmd)) {
+      // The relay asks the PANE what it is running (pane_current_command).
+      // procAlive:false models a CLI that exited and left the pane at a shell.
+      return procAlive ? `${backend}\n` : 'bash\n';
+    }
     if (/cmdline|ps -eo/.test(cmd)) {
       // The relay's liveness probe greps this for the backend name. When the
       // CLI is "dead" the pane is a bare shell — and crucially the string must
@@ -237,6 +242,57 @@ const AGY_WEDGED_PANE = [
   '────────────────────────────────────────────',
   '? for shortcuts',
 ].join('\n');
+
+// --- CLI liveness: ask the PANE, not the process table --------------------
+//
+// The old probe substring-matched the whole process table for the backend's
+// name, OR'd with every other CLI's name unconditionally. Observed live: the
+// relay's own launcher (`just contribute-hive agy local`) and its tmux session
+// (`hive-agy-5b4f`) both contain "agy", and any box running Claude Code matched
+// 'claude' whatever the backend was — so a dead CLI was never detected, was
+// never relaunched, cliReady stayed latched, and the hub's task prompt was typed
+// into a bare shell.
+test('a shell in the pane is only a death after consecutive confirmations', () => {
+  const relay = loadRelay({ backend: 'agy', procAlive: false });
+  try {
+    assert.strictEqual(relay.cliProcessLooksGone(), false,
+      'one shell reading may just be a foreground tool call — never restart on it');
+    assert.strictEqual(relay.cliProcessLooksGone(), true,
+      `${relay.CLI_GONE_CONFIRMATIONS} consecutive shell readings mean the CLI really left`);
+  } finally { teardown(relay); }
+});
+
+test('a pane running the CLI is never reported gone, and clears the count', () => {
+  const relay = loadRelay({ backend: 'agy', procAlive: true });
+  try {
+    assert.strictEqual(relay.cliProcessLooksGone(), false);
+    assert.strictEqual(relay.cliProcessLooksGone(), false,
+      'a live CLI must never accumulate toward a death, however long it runs');
+  } finally { teardown(relay); }
+});
+
+test('a task prompt is never typed into a pane that is running a shell', () => {
+  // The latch says ready — as it did in production, because nothing had
+  // detected the CLI leaving — but the pane is a shell. The prompt must be
+  // queued and the CLI relaunched, NOT typed at the shell.
+  const relay = loadRelay({ backend: 'agy', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    const PROMPT = "You are a contributor to the kubestellar/hive hive. Work on issue #4030.";
+    const before = relay.__tmuxSends().length;
+    relay.tmuxSendKeys(PROMPT);
+
+    assert.strictEqual(relay.getPendingTask(), PROMPT,
+      'the prompt must be queued for the readiness callback, not typed into the shell');
+    assert.strictEqual(relay.getCliReady(), false,
+      'a stale readiness latch must be dropped once the pane is seen to be a shell');
+    const sends = relay.__tmuxSends().slice(before);
+    assert.ok(!sends.some(c => c.includes('contributor to the kubestellar/hive hive')),
+      `the prompt text must never reach the pane: ${JSON.stringify(sends)}`);
+    assert.ok(sends.some(c => /agy/.test(c)),
+      `the CLI must be relaunched so the queued prompt has somewhere to go: ${JSON.stringify(sends)}`);
+  } finally { teardown(relay); }
+});
 
 test('agy at its idle prompt is COMPLETE even with stale narration on screen', () => {
   const relay = loadRelay({ backend: 'agy' });
@@ -616,8 +672,12 @@ test('crash restarts are capped and end in a permanent failure', () => {
     assert.ok(cap <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
 
     // Simulate the hub reassigning the same work item after each failure.
+    // TWO ticks per assignment: a CLI death is only declared once the pane has
+    // read as a shell on consecutive checks, so a single transient reading
+    // cannot restart a CLI that is merely running a foreground tool call.
     for (let i = 0; i <= cap; i++) {
       assignTask(relay, `ct-421-${i}`);
+      relay.__crashTick();
       relay.__crashTick();
     }
 
@@ -643,6 +703,8 @@ test('a reassignment of a given-up task is rejected, not retried', () => {
     assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
     for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
       assignTask(relay, `ct-421-${i}`);
+      // Two ticks: a death needs consecutive shell readings to be confirmed.
+      relay.__crashTick();
       relay.__crashTick();
     }
     const before = relay.__sent.length;
@@ -665,6 +727,8 @@ test('after give-up a DIFFERENT task is still accepted', () => {
     assert.ok(relay.MAX_TASK_CLI_RESTARTS <= CAP_SANITY_LIMIT, 'cap must be small enough to drive here');
     for (let i = 0; i <= relay.MAX_TASK_CLI_RESTARTS; i++) {
       assignTask(relay, `ct-421-${i}`);
+      // Two ticks: a death needs consecutive shell readings to be confirmed.
+      relay.__crashTick();
       relay.__crashTick();
     }
     assert.strictEqual(relay.getCurrentTask(), null, 'precondition: no active task after give-up');

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -31,6 +31,26 @@ REAL_GH="${HIVE_GH_WRAPPER_REAL_GH:-/opt/hive/bin/gh-real}"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
 CONTRIBUTOR_MODE_MARKER="/etc/hive/contributor-mode"
 
+# Trusted bot-identity file (#4044). Staff agents authenticate with GitHub App
+# INSTALLATION tokens (ghs_…), for which `gh api user` structurally 403s —
+# there is no user identity behind a server-to-server token — so the #3982
+# oracle can never resolve for them. The hive process, which MINTS every tier
+# token and therefore knows the App bot login ("<app-slug>[bot]"), writes that
+# login here alongside the per-agent token caches. The directory is owned by
+# dev and not writable by any agent UID, so — like CONTRIBUTOR_MODE_MARKER —
+# this is an image/runtime property the caller cannot forge. The path is a
+# CONSTANT for the same reason as #3249: an env-selected path would let an
+# agent point the identity check at a file it controls.
+#
+# HIVE_GH_WRAPPER_BOT_LOGIN_FILE is honored ONLY while the test harness's
+# HIVE_GH_WRAPPER_REAL_GH override is active, where it grants nothing: a caller
+# who can substitute the gh binary itself has already bypassed every gate this
+# identity feeds (see the REAL_GH comment above). Unset in production.
+BOT_LOGIN_FILE="/var/run/hive-metrics/agent-tokens/gh-bot-login"
+if [[ -n "${HIVE_GH_WRAPPER_REAL_GH:-}" && -n "${HIVE_GH_WRAPPER_BOT_LOGIN_FILE:-}" ]]; then
+  BOT_LOGIN_FILE="$HIVE_GH_WRAPPER_BOT_LOGIN_FILE"
+fi
+
 # Contributor mode is an image property, not a caller-controlled environment
 # toggle. Keep this path constant: an agent can set its own environment and must
 # not be able to redirect the trust check to an agent-writable marker (#3249).
@@ -322,7 +342,18 @@ _extract_author() {
 }
 
 # Resolve the authenticated GitHub login. Initialize the cache internally so a
-# caller-controlled environment cannot seed a trusted identity.
+# caller-controlled environment cannot seed a trusted identity (#3982).
+#
+# Two oracles, both unspoofable by the agent (#4044):
+#   1. The trusted bot-identity file — written by the hive process (which mints
+#      the tier tokens) into a directory no agent UID can write. This is the
+#      ONLY oracle that can work for staff agents: their App installation
+#      tokens have no /user identity, so `gh api user` 403s unconditionally.
+#   2. `gh api user` — the server-side identity of the token itself. Works for
+#      user tokens (contributor mode) and remains the fallback whenever the
+#      file is absent, so the contributor path is unchanged.
+# A caller-writable path or environment variable must never be consulted:
+# fail-closed is preserved when NEITHER oracle resolves.
 HIVE_AUTH_LOGIN_CACHED=""
 _resolve_self_login() {
   if [[ -n "$HIVE_AUTH_LOGIN_CACHED" ]]; then
@@ -330,9 +361,16 @@ _resolve_self_login() {
     return 0
   fi
 
-  local login
-  if ! login="$("$REAL_GH" api user --jq '.login' 2>/dev/null)"; then
-    return 1
+  local login=""
+  if ! _contributor_mode && [[ -f "$BOT_LOGIN_FILE" && -r "$BOT_LOGIN_FILE" ]]; then
+    # Single-line file; strip whitespace/newline. An empty or unreadable file
+    # falls through to the API oracle (and from there to fail-closed).
+    login="$(tr -d '[:space:]' < "$BOT_LOGIN_FILE" 2>/dev/null || true)"
+  fi
+  if [[ -z "$login" ]]; then
+    if ! login="$("$REAL_GH" api user --jq '.login' 2>/dev/null)"; then
+      return 1
+    fi
   fi
   if [[ -z "$login" ]]; then
     return 1
@@ -372,10 +410,43 @@ _author_matches_login() {
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
   if author_value="$(_extract_author)" && [[ -n "$author_value" ]]; then
     if [[ "$author_value" = "@me" ]]; then
-      : # GitHub resolves @me server-side to the authenticated token identity.
+      # GitHub resolves @me server-side ONLY for user tokens. An App
+      # installation token has no user identity, so for staff agents @me is
+      # rejected by the API itself and there would be NO working self-listing
+      # form at all (#4044). Map @me to the trusted resolved identity for
+      # staff agents; contributor mode keeps the server-side resolution.
+      if ! _contributor_mode; then
+        if ! _resolve_self_login >/dev/null; then
+          echo "⛔ BLOCKED: gh $subcmd list --author @me cannot work with an App installation token (it has no /user identity, #4044)," >&2
+          echo "and no trusted identity is available to substitute: ${BOT_LOGIN_FILE} is missing/empty and 'gh api user' did not resolve." >&2
+          echo "The hive writes that file when it mints agent tokens — report this to the operator so identity delivery is repaired." >&2
+          exit 1
+        fi
+        _atme_rewritten=()
+        _atme_expect=false
+        for _atme_arg in "${args[@]}"; do
+          if [[ "$_atme_expect" = true ]]; then
+            _atme_expect=false
+            [[ "$_atme_arg" = "@me" ]] && _atme_arg="$HIVE_AUTH_LOGIN_CACHED"
+          else
+            case "$_atme_arg" in
+              --author|-A) _atme_expect=true ;;
+              --author=@me) _atme_arg="--author=${HIVE_AUTH_LOGIN_CACHED}" ;;
+              -A=@me) _atme_arg="-A=${HIVE_AUTH_LOGIN_CACHED}" ;;
+              -A@me) _atme_arg="-A${HIVE_AUTH_LOGIN_CACHED}" ;;
+            esac
+          fi
+          _atme_rewritten+=("$_atme_arg")
+        done
+        args=("${_atme_rewritten[@]}")
+        # The wrapper's tail executes `exec "$REAL_GH" "$@"` — rewrite the
+        # positional parameters too, or the substitution would never ship.
+        set -- "${args[@]}"
+      fi
     elif ! _resolve_self_login >/dev/null; then
       echo "⛔ BLOCKED: gh $subcmd list --author requires authenticated GitHub identity." >&2
-      echo "Could not resolve the current token identity with 'gh api user --jq .login'." >&2
+      echo "Could not resolve the current token identity: no trusted identity file at ${BOT_LOGIN_FILE} (written by the hive when it mints agent tokens)" >&2
+      echo "and 'gh api user --jq .login' did not resolve (expected for App installation tokens, which have no /user identity)." >&2
       exit 1
     elif _author_matches_login "$author_value" "$HIVE_AUTH_LOGIN_CACHED"; then
       : # Match: authenticated login, case-insensitive, with optional [bot] suffix.

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -67,17 +67,28 @@ if ! _contributor_mode; then
   # back to either would silently escalate every agent to full privilege and
   # defeat per-agent tier scoping. A missing scoped token must FAIL LOUD so the
   # operator fixes token delivery — it must never quietly escalate.
-  if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
+  # -r and -s as well as -f (#4043): an unreadable cache made the `cat` inside
+  # the `export` assignment fail with its status MASKED by export's own exit 0
+  # (so even `set -e` never saw it), and an empty pre-created cache (pod rolled,
+  # token not yet re-minted) passed -f outright — both exported an EMPTY
+  # GH_TOKEN and sent every gh call out UNAUTHENTICATED ("please run gh auth
+  # login"), instead of the fail-loud this gate promises.
+  if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" && -r "${HIVE_AGENT_TOKEN_CACHE}" && -s "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
     export GH_TOKEN="$(cat "$HIVE_AGENT_TOKEN_CACHE")"
   else
-    echo "⛔ BLOCKED: per-agent scoped GitHub token not available (${HIVE_AGENT_TOKEN_CACHE:-HIVE_AGENT_TOKEN_CACHE unset})." >&2
+    echo "⛔ BLOCKED: per-agent scoped GitHub token not available, unreadable, or empty (${HIVE_AGENT_TOKEN_CACHE:-HIVE_AGENT_TOKEN_CACHE unset})." >&2
     echo "   Refusing to fall back to the shared full-privilege App token — that would defeat per-agent tier scoping (audit H3)." >&2
     echo "   The hive delivers a scoped token per agent; report this to the operator so token delivery is repaired." >&2
     exit 1
   fi
-  printf '{"ts":"%s","agent":"%s","uid":%d,"op":"gh","cmd":"gh %s"}\n' \
+  # The group wraps the append so a failed REDIRECTION is silenced too: `>> f
+  # 2>/dev/null` only mutes the printf, and when the log's directory is not
+  # writable by the agent UID the shell's own "Permission denied" line leaked
+  # into stderr on EVERY gh call, priming agents to read later denials as
+  # permission errors (#4043).
+  { printf '{"ts":"%s","agent":"%s","uid":%d,"op":"gh","cmd":"gh %s"}\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${HIVE_AGENT:-unknown}" "$(id -u)" "$*" \
-    >> "$TOKEN_ACCESS_LOG" 2>/dev/null || true
+    >> "$TOKEN_ACCESS_LOG"; } 2>/dev/null || true
 fi
 
 # Contributor mode — extra restrictions for remote contributor agents
@@ -784,9 +795,15 @@ if [[ -n "$AGENT_NAME" ]]; then
   fi
 
   # Ensure labels exist on the repo (cached per-session to avoid repeated API calls).
-  LABEL_CACHE="/tmp/.hive-labels-ensured"
+  #
+  # The cache MUST be keyed per target repo (#4043): a single global flag meant
+  # whichever repo an agent touched first got the labels created, and every
+  # other repo was skipped for the life of the pod — leaving the injected
+  # hive/<id> label missing there, which made every `gh pr edit`/`gh issue edit`
+  # on those repos fail with "'hive/<id>' not found". Verified live on a fleet
+  # owner's hive: only the first-touched repos carried the current label.
+  LABEL_CACHE_BASE="/tmp/.hive-labels-ensured"
   _ensure_labels() {
-    [[ -f "$LABEL_CACHE" ]] && return 0
     local repo_flag=""
     for arg in "${args[@]}"; do
       case "$arg" in
@@ -796,13 +813,18 @@ if [[ -n "$AGENT_NAME" ]]; then
       esac
     done
     [[ "$repo_flag" = "next" ]] && repo_flag=""
+    # owner/repo → owner_repo; repo names are [A-Za-z0-9_.-] so '/' is the only
+    # separator to neutralize. No --repo means "current directory's repo" —
+    # cache that under its own key rather than sharing one with named repos.
+    local cache="${LABEL_CACHE_BASE}-${repo_flag//\//_}"
+    [[ -f "$cache" ]] && return 0
     local rf=""
     [[ -n "$repo_flag" ]] && rf="--repo $repo_flag"
     "$REAL_GH" label create "agent/${AGENT_DISPLAY_NAME}" --description "Work by the ${AGENT_DISPLAY_NAME} agent" --color 6f42c1 $rf 2>/dev/null || true
     if [[ -n "$HIVE_INSTANCE_ID" ]]; then
       "$REAL_GH" label create "hive/${HIVE_INSTANCE_ID}" --description "Hive instance ${HIVE_INSTANCE_ID}" --color 1d76db $rf 2>/dev/null || true
     fi
-    touch "$LABEL_CACHE"
+    touch "$cache"
   }
 
   # Extract issue/PR number and repo from args (for post-action labeling).
@@ -826,8 +848,13 @@ if [[ -n "$AGENT_NAME" ]]; then
     issue/create|pr/create)
       _ensure_labels
       _inject_identity
-      "$REAL_GH" "${args[@]}" --label "$LABELS_CSV"
-      rc=$?
+      # `|| rc=$?` (not `cmd; rc=$?`): this script runs under `set -e`, so a
+      # bare failing gh exited the wrapper BEFORE rc was ever read — the
+      # unlabeled retry below was dead code, and a missing injected label
+      # failed the whole create (#4043). gh resolves label names before
+      # mutating, so the retry cannot double-create.
+      rc=0
+      "$REAL_GH" "${args[@]}" --label "$LABELS_CSV" || rc=$?
       if [ $rc -ne 0 ]; then
         exec "$REAL_GH" "${args[@]}"
       fi
@@ -835,7 +862,18 @@ if [[ -n "$AGENT_NAME" ]]; then
       ;;
     issue/edit|pr/edit)
       _ensure_labels
-      exec "$REAL_GH" "$@" --add-label "$LABELS_CSV"
+      # Label injection is provenance metadata, not a security gate. gh applies
+      # an edit atomically, so a missing label (repo not yet ensured, create
+      # denied, label deleted) failed the ENTIRE edit with "'<label>' not found"
+      # — agents read that as a permissions failure and route around the wrapper
+      # (#4043). Mirror the create arm: try labeled, retry unlabeled on failure.
+      # `|| rc=$?` keeps the retry alive under `set -e` (see create arm above).
+      rc=0
+      "$REAL_GH" "$@" --add-label "$LABELS_CSV" || rc=$?
+      if [ $rc -ne 0 ]; then
+        exec "$REAL_GH" "$@"
+      fi
+      exit $rc
       ;;
     pr/merge)
       _ensure_labels

--- a/bin/test_agent_env_scrub.sh
+++ b/bin/test_agent_env_scrub.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Behavioural + source tests for the #4045 fix: backend CLIs re-export live
+# GitHub credentials (GITHUB_TOKEN et al.) into the tool shells they spawn for
+# agents, bypassing every gh-wrapper control. bin/agent-env-scrub.sh, sourced
+# via BASH_ENV at CHILD shell startup, must neutralize the token no matter how
+# it arrived — inherited or set explicitly in the spawn env by the CLI (the
+# observed mechanism, which parent-side scrubbing like #3931 cannot reach).
+#
+# Doctrine (audit 6/7): every block-assertion here has a positive control that
+# proves the probe can detect the leak, and the sanctioned paths (gh-wrapper
+# auth, backend-process auth) are asserted ALIVE — a scrub that broke them
+# would get reverted wholesale, which is worse than the vulnerability.
+#
+# No token material is real anywhere in this file; probes assert presence/
+# absence, never values.
+#
+# Run: bash bin/test_agent_env_scrub.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRUB="${REPO_ROOT}/bin/agent-env-scrub.sh"
+AGENT_LAUNCH="${REPO_ROOT}/bin/agent-launch.sh"
+WRAPPER="${REPO_ROOT}/bin/gh-wrapper.sh"
+DOCKERFILE="${REPO_ROOT}/src/Dockerfile"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+# The single source of truth for what the scrub must cover. Adding a var here
+# without adding it to agent-env-scrub.sh fails the source assertions below.
+SCRUBBED_VARS=(
+  GITHUB_TOKEN
+  GH_TOKEN
+  GH_ENTERPRISE_TOKEN
+  GITHUB_ENTERPRISE_TOKEN
+  COPILOT_GITHUB_TOKEN
+  GITHUB_COPILOT_TOKEN
+  HIVE_GITHUB_TOKEN
+)
+
+# probe_child <BASH_ENV-value or ""> <extra env assignments...>
+# Spawns a bash -c child the way a backend CLI spawns a tool shell — with the
+# given vars set in the SPAWN env (env(1), exactly how the Copilot CLI hands
+# GITHUB_TOKEN to its shell tool) — and reports each scrubbed var as
+# name=present|absent.
+probe_child() {
+  local bash_env="$1"; shift
+  local probe='out=""; for v in GITHUB_TOKEN GH_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN COPILOT_GITHUB_TOKEN GITHUB_COPILOT_TOKEN HIVE_GITHUB_TOKEN; do if [ -n "$(eval "printf %s \"\${$v:-}\"")" ]; then out="$out $v=present"; else out="$out $v=absent"; fi; done; printf "%s" "$out"'
+  if [ -n "$bash_env" ]; then
+    env "$@" BASH_ENV="$bash_env" bash -c "$probe"
+  else
+    # -u BASH_ENV: the runner's own env must not accidentally scrub the
+    # positive control.
+    env -u BASH_ENV "$@" bash -c "$probe"
+  fi
+}
+
+FAKE_ENV=(
+  GITHUB_TOKEN="fake-github-token-for-test"
+  GH_TOKEN="fake-gh-token-for-test"
+  GH_ENTERPRISE_TOKEN="fake-ghe-token-for-test"
+  GITHUB_ENTERPRISE_TOKEN="fake-github-ent-token-for-test"
+  COPILOT_GITHUB_TOKEN="fake-copilot-token-for-test"
+  GITHUB_COPILOT_TOKEN="fake-copilot2-token-for-test"
+  HIVE_GITHUB_TOKEN="fake-hive-token-for-test"
+)
+
+echo "=== #4045: backend-exported tokens must not survive into agent tool shells ==="
+
+# ── POSITIVE CONTROL first: the probe must be able to SEE a leak ─────────────
+# Without this, a broken probe (or a probe run without the vars) would make
+# every absence-assertion below pass vacuously — the exact failure mode audit 6
+# kept finding.
+echo "-- positive control: unscrubbed shell shows every token --"
+result="$(probe_child "" "${FAKE_ENV[@]}")"
+if [[ "$result" != *"=absent"* && "$result" == *"GITHUB_TOKEN=present"* ]]; then
+  pass "probe detects all injected tokens when no scrub is wired"
+else
+  fail "probe detects all injected tokens when no scrub is wired" "got:$result"
+fi
+
+# ── The #4045 replay: CLI sets tokens in the tool shell's spawn env ──────────
+echo "-- scrubbed tool shell: every known token var is absent --"
+result="$(probe_child "$SCRUB" "${FAKE_ENV[@]}")"
+if [[ "$result" != *"=present"* ]]; then
+  pass "all ${#SCRUBBED_VARS[@]} token vars absent in a BASH_ENV-scrubbed child"
+else
+  fail "all ${#SCRUBBED_VARS[@]} token vars absent in a BASH_ENV-scrubbed child" "got:$result"
+fi
+
+# The literal incident shape: the shell expansion the bypass relied on must
+# come up empty, so the raw-curl fallback sends "Bearer " and 401s.
+result="$(env "${FAKE_ENV[@]}" BASH_ENV="$SCRUB" bash -c 'printf "Bearer %s" "${GITHUB_TOKEN:-}"')"
+if [ "$result" = "Bearer " ]; then
+  pass "incident replay: 'Authorization: Bearer \$GITHUB_TOKEN' expands empty"
+else
+  fail "incident replay: 'Authorization: Bearer \$GITHUB_TOKEN' expands empty" "expansion was non-empty"
+fi
+
+# Nested re-export: even a shell whose PARENT was scrubbed gets the token
+# re-injected by the CLI layer per spawn — each new bash must re-scrub because
+# BASH_ENV stays exported down the tree.
+result="$(env "${FAKE_ENV[@]}" BASH_ENV="$SCRUB" bash -c 'GITHUB_TOKEN=fake-reexported-by-cli bash -c "printf %s \"\${GITHUB_TOKEN:+present}\""')"
+if [ -z "$result" ]; then
+  pass "a token re-exported into a NESTED shell is scrubbed again"
+else
+  fail "a token re-exported into a NESTED shell is scrubbed again" "nested shell saw the token"
+fi
+
+# ── Scrub must not strip what the sanctioned paths need ──────────────────────
+echo "-- non-credential env survives the scrub --"
+result="$(env HIVE_AGENT_TOKEN_CACHE="/var/run/x" HIVE_ACMM_LEVEL=3 HTTPS_PROXY="http://127.0.0.1:3128" BASH_ENV="$SCRUB" bash -c 'printf "%s %s %s" "${HIVE_AGENT_TOKEN_CACHE:+cache}" "${HIVE_ACMM_LEVEL:+acmm}" "${HTTPS_PROXY:+proxy}"')"
+if [ "$result" = "cache acmm proxy" ]; then
+  pass "HIVE_AGENT_TOKEN_CACHE / ACMM / proxy vars pass through untouched"
+else
+  fail "HIVE_AGENT_TOKEN_CACHE / ACMM / proxy vars pass through untouched" "got '$result'"
+fi
+
+# ── SANCTIONED-PATH CONTROL: gh-wrapper still authenticates under the scrub ──
+# The wrapper sources the scrub at startup (it is a bash script under the
+# agent's BASH_ENV), losing any inherited token env — which it must never trust
+# anyway (H3) — then exports GH_TOKEN itself from HIVE_AGENT_TOKEN_CACHE. The
+# stub asserts the token it sees is exactly the CACHE one, proving (a) the
+# wrapper path is alive and (b) the stale inherited token was replaced.
+echo "-- gh-wrapper authenticates from the per-agent cache under the scrub --"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+TOKEN_CACHE="${WORK}/token"
+echo "ghs_fake_cache_token_for_test" >"$TOKEN_CACHE"
+STUB="${WORK}/gh-stub"
+STUB_LOG="${WORK}/stub.log"
+# The stub is /bin/sh ON PURPOSE: a bash stub would itself source BASH_ENV at
+# startup and scrub the GH_TOKEN the wrapper just exported — the REAL gh is a
+# Go binary and sources nothing, so /bin/sh (which reads neither BASH_ENV nor
+# non-interactive ENV) models it correctly.
+cat >"$STUB" <<'STUBEOF'
+#!/bin/sh
+if [ "${GH_TOKEN:-}" = "ghs_fake_cache_token_for_test" ]; then
+  echo "CACHE_TOKEN_OK" >> "${STUB_LOG}"
+elif [ -n "${GH_TOKEN:-}" ]; then
+  echo "WRONG_TOKEN" >> "${STUB_LOG}"
+else
+  echo "UNAUTHENTICATED" >> "${STUB_LOG}"
+fi
+exit 0
+STUBEOF
+chmod +x "$STUB"
+: >"$STUB_LOG"
+out="$(
+  env "${FAKE_ENV[@]}" \
+    BASH_ENV="$SCRUB" \
+    HIVE_GH_WRAPPER_REAL_GH="$STUB" \
+    STUB_LOG="$STUB_LOG" \
+    HIVE_AGENT="testagent" \
+    HIVE_AGENT_ID="testagent" \
+    HIVE_AGENT_MODE="ISSUES_PRS_MERGE" \
+    HIVE_ACMM_LEVEL=5 \
+    HIVE_AGENT_TOKEN_CACHE="$TOKEN_CACHE" \
+    HIVE_CONTRIBUTOR_MODE="false" \
+    bash "$WRAPPER" pr view 1 --repo owner/repo 2>&1
+)"
+rc=$?
+stub_saw="$(cat "$STUB_LOG" 2>/dev/null | tail -n1)"
+if [ "$rc" -eq 0 ] && [ "$stub_saw" = "CACHE_TOKEN_OK" ]; then
+  pass "wrapper reached gh with the CACHE token (inherited fakes discarded)"
+else
+  fail "wrapper reached gh with the CACHE token (inherited fakes discarded)" "rc=$rc stub_saw='${stub_saw:-nothing}' out=$(echo "$out" | head -n2 | tr '\n' ' ')"
+fi
+
+# ── The scrub file must be POSIX-sh safe (tool shells may be /bin/sh) ────────
+echo "-- scrub is sh-compatible --"
+if sh -c ". '$SCRUB'" 2>/dev/null; then
+  pass "agent-env-scrub.sh sources cleanly under sh"
+else
+  fail "agent-env-scrub.sh sources cleanly under sh"
+fi
+
+# ── Source-level invariants (drift guards) ───────────────────────────────────
+echo "-- source invariants --"
+for v in "${SCRUBBED_VARS[@]}"; do
+  if grep -qE "^unset[[:space:]]+${v}\$" "$SCRUB"; then
+    pass "scrub unsets ${v}"
+  else
+    fail "scrub unsets ${v}" "add 'unset ${v}' to bin/agent-env-scrub.sh"
+  fi
+done
+if grep -qE 'unset[[:space:]].*HIVE_AGENT_TOKEN_CACHE' "$SCRUB"; then
+  fail "scrub must NOT unset HIVE_AGENT_TOKEN_CACHE (it is a path the wrapper and git credential helper depend on)"
+else
+  pass "scrub leaves HIVE_AGENT_TOKEN_CACHE alone"
+fi
+if grep -qE '^\s*export BASH_ENV="\$AGENT_ENV_SCRUB"' "$AGENT_LAUNCH" && grep -qE '^\s*export ENV="\$AGENT_ENV_SCRUB"' "$AGENT_LAUNCH"; then
+  pass "agent-launch.sh wires BASH_ENV and ENV to the scrub"
+else
+  fail "agent-launch.sh wires BASH_ENV and ENV to the scrub" "the #4045 boundary is not installed for tool shells"
+fi
+if grep -q 'bin/agent-env-scrub.sh /usr/local/bin/agent-env-scrub.sh' "$DOCKERFILE"; then
+  pass "Dockerfile ships agent-env-scrub.sh"
+else
+  fail "Dockerfile ships agent-env-scrub.sh" "the launcher's fallback path /usr/local/bin/agent-env-scrub.sh would be empty in the image"
+fi
+if grep -q 'agent-env-scrub.sh' "$DOCKERFILE" && grep -q 'bash.bashrc' "$DOCKERFILE"; then
+  pass "Dockerfile installs the interactive-shell (/etc/bash.bashrc) arm"
+else
+  fail "Dockerfile installs the interactive-shell (/etc/bash.bashrc) arm"
+fi
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -377,6 +377,147 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── #4044: author gate must work for App INSTALLATION tokens ─────────────────
+# Staff agents hold ghs_ installation tokens, for which `gh api user` 403s
+# unconditionally — the #3982 oracle could NEVER resolve for them, so every
+# author-gated list failed closed fleet-wide. The fix: the hive (which mints
+# the tokens) publishes the bot login to a trusted file in the agent-token dir
+# (dev-owned; no agent UID can write it). These tests drive the wrapper with a
+# stub that reproduces the 403, exactly like production installation tokens.
+#
+# HIVE_GH_WRAPPER_BOT_LOGIN_FILE relocates the trusted file for the harness
+# only — the wrapper honors it solely under HIVE_GH_WRAPPER_REAL_GH, where the
+# caller already substitutes the gh binary itself and the override grants
+# nothing new.
+echo "-- author gate resolves staff identity from the trusted file (#4044) --"
+
+# Stub reproducing an App installation token: /user is structurally
+# unavailable (HTTP 403 "Resource not accessible by integration").
+INSTALL_STUB="${WORK}/gh-stub-installation"
+cat >"$INSTALL_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${STUB_LOG}"
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "user" ]; then
+  echo "gh: Resource not accessible by integration (HTTP 403)" >&2
+  exit 1
+fi
+exit 0
+STUBEOF
+chmod +x "$INSTALL_STUB"
+
+# Stub reproducing a USER token (contributor path): /user resolves normally.
+USER_STUB="${WORK}/gh-stub-usertoken"
+cat >"$USER_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${STUB_LOG}"
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "user" ]; then
+  echo "someuser"
+fi
+exit 0
+STUBEOF
+chmod +x "$USER_STUB"
+
+TRUSTED_LOGIN_FILE="${WORK}/gh-bot-login"
+printf 'test-app[bot]\n' >"$TRUSTED_LOGIN_FILE"
+
+# run_author_wrapper <stub> <login-file> [extra VAR=val...] -- <args...>
+# Reports "exit=<rc> last=<final stub argv> ::: <wrapper output>" so assertions
+# can pin both the decision and WHAT was forwarded to gh.
+run_author_wrapper() {
+  local stub="$1" login_file="$2"; shift 2
+  local extra_env=()
+  while [ $# -gt 0 ] && [ "$1" != "--" ]; do extra_env+=("$1"); shift; done
+  [ "${1:-}" = "--" ] && shift
+  : >"$STUB_LOG"
+  local out rc
+  # ${arr[@]+...} keeps the empty-array case safe under `set -u` on bash 3.x.
+  out="$(
+    env ${extra_env[@]+"${extra_env[@]}"} \
+    HIVE_GH_WRAPPER_REAL_GH="$stub" \
+    HIVE_GH_WRAPPER_BOT_LOGIN_FILE="$login_file" \
+    STUB_LOG="$STUB_LOG" \
+    HIVE_AGENT="testagent" \
+    HIVE_AGENT_ID="testagent" \
+    HIVE_AGENT_MODE="ISSUES_PRS_MERGE" \
+    HIVE_ACMM_LEVEL=5 \
+    HIVE_AGENT_TOKEN_CACHE="$TOKEN_CACHE" \
+    HIVE_CONTRIBUTOR_MODE="false" \
+    bash "$WRAPPER" "$@" 2>&1
+  )"
+  rc=$?
+  local last
+  last="$(tail -n 1 "$STUB_LOG" 2>/dev/null)"
+  echo "exit=${rc} last=${last} ::: ${out}"
+}
+
+assert_author() {
+  local label="$1" result="$2" want="$3"
+  if [[ "$result" == $want ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "        got '$result'"
+    echo "        want glob '$want'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# THE regression: an installation-token agent with the trusted file present
+# must be able to list its own items — and only its own.
+assert_author "installation token + trusted file: self-listing by bot login works" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=0 last=issue list --repo owner/repo --author test-app\[bot\] ::: *"
+assert_author "matching is [bot]-suffix-insensitive (bare slug allowed)" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- pr list --repo owner/repo --author test-app)" \
+  "exit=0 last=pr list --repo owner/repo --author test-app ::: *"
+# @me has no server-side meaning for an installation token — the wrapper must
+# substitute the trusted identity, or there is no working self-listing form.
+assert_author "--author @me is rewritten to the trusted bot identity" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- pr list --repo owner/repo --author @me)" \
+  "exit=0 last=pr list --repo owner/repo --author test-app\[bot\] ::: *"
+assert_author "--author=@me equals-form is rewritten too" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- pr list --repo owner/repo --author=@me)" \
+  "exit=0 last=pr list --repo owner/repo --author=test-app\[bot\] ::: *"
+
+# The gate itself must keep gating: a foreign author is still refused.
+assert_author "trusted file does not open listing OTHER authors" \
+  "$(run_author_wrapper "$INSTALL_STUB" "$TRUSTED_LOGIN_FILE" -- issue list --repo owner/repo --author someone-else)" \
+  "exit=1 last= ::: *must match the authenticated GitHub identity*"
+
+# Fail-closed is preserved when no trusted identity exists: the installation
+# token cannot resolve /user, so with the file missing there is NO oracle.
+assert_author "missing trusted file + installation token: explicit author fails closed" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/no-such-login-file" -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=1 last=api user --jq .login ::: *requires authenticated GitHub identity*"
+: >"${WORK}/empty-login-file"
+assert_author "EMPTY trusted file + installation token: fails closed (no empty identity)" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/empty-login-file" -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=1 last=api user --jq .login ::: *requires authenticated GitHub identity*"
+assert_author "missing trusted file + installation token: @me fails closed with the #4044 diagnosis" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/no-such-login-file" -- pr list --repo owner/repo --author @me)" \
+  "exit=1 last=api user --jq .login ::: *cannot work with an App installation token*"
+
+# POSITIVE CONTROL (the #3982 invariant): agent-controlled environment must
+# never seed the trusted identity. With no trusted file and a 403ing /user,
+# these env vars are the ONLY place the claimed identity appears — if any of
+# them were consulted, this listing would succeed.
+assert_author "env vars cannot seed the identity (#3982 invariant holds)" \
+  "$(run_author_wrapper "$INSTALL_STUB" "${WORK}/no-such-login-file" \
+      HIVE_AUTH_LOGIN_CACHED="test-app[bot]" HIVE_BOT_LOGIN="test-app[bot]" GITHUB_USER="test-app[bot]" \
+      -- issue list --repo owner/repo --author 'test-app[bot]')" \
+  "exit=1 last=api user --jq .login ::: *requires authenticated GitHub identity*"
+
+# USER-token path unchanged: with no trusted file, `gh api user` remains the
+# oracle — resolves, matches, mismatches refuse. (Contributor mode itself is an
+# image marker the harness cannot plant; the oracle chain is what's under test.)
+assert_author "user token without trusted file still resolves via gh api user" \
+  "$(run_author_wrapper "$USER_STUB" "${WORK}/no-such-login-file" -- issue list --repo owner/repo --author someuser)" \
+  "exit=0 last=issue list --repo owner/repo --author someuser ::: *"
+assert_author "user token without trusted file still refuses a foreign author" \
+  "$(run_author_wrapper "$USER_STUB" "${WORK}/no-such-login-file" -- issue list --repo owner/repo --author someone-else)" \
+  "exit=1 last=api user --jq .login ::: *must match the authenticated GitHub identity*"
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1

--- a/bin/test_gh_wrapper_gates.sh
+++ b/bin/test_gh_wrapper_gates.sh
@@ -275,6 +275,108 @@ assert_reached "read-only gh api reaches gh" \
 assert_blocked "pr merge passes the surface gate and is held by eligibility" \
   "$(run_wrapper "ISSUES_PRS_MERGE" 5 -- pr merge 123)" eligibility
 
+# ── #4043: label injection is best-effort, never a wall ──────────────────────
+# The edit/create arms append the agent/hive provenance labels. When the label
+# does not exist on the target repo, gh fails the WHOLE operation with
+# "'<label>' not found" — which took down a fleet owner's edit lane. The
+# wrapper must retry without labels. This stub simulates gh's behavior by
+# failing any invocation that carries a label-injection flag; the wrapper runs
+# under `set -e`, so these tests also pin that the retry is not dead code.
+echo "-- label injection falls back instead of failing the operation (#4043) --"
+LABEL_STUB="${WORK}/gh-stub-labelfail"
+cat >"$LABEL_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${STUB_LOG}"
+case " $* " in
+  *" --add-label "*|*" --label "*) exit 1 ;;
+esac
+exit 0
+STUBEOF
+chmod +x "$LABEL_STUB"
+
+# run_label_wrapper <args...> — like run_wrapper but with the label-failing
+# stub, and it reports the LAST stub invocation so the assertions can prove the
+# retry dropped the injected labels. Per-repo ensure caches live in /tmp; clear
+# ours so the label-create calls are deterministic.
+run_label_wrapper() {
+  : >"$STUB_LOG"
+  rm -f /tmp/.hive-labels-ensured-owner_repo
+  local out rc last
+  out="$(
+    HIVE_GH_WRAPPER_REAL_GH="$LABEL_STUB" \
+    STUB_LOG="$STUB_LOG" \
+    HIVE_AGENT="testagent" \
+    HIVE_AGENT_ID="testagent" \
+    HIVE_AGENT_MODE="ISSUES_PRS_MERGE" \
+    HIVE_ACMM_LEVEL=5 \
+    HIVE_AGENT_TOKEN_CACHE="$TOKEN_CACHE" \
+    HIVE_CONTRIBUTOR_MODE="false" \
+    bash "$WRAPPER" "$@" 2>&1
+  )"
+  rc=$?
+  rm -f /tmp/.hive-labels-ensured-owner_repo
+  last="$(tail -n 1 "$STUB_LOG" 2>/dev/null)"
+  echo "exit=${rc} last=${last}"
+}
+
+result="$(run_label_wrapper pr edit 5 --repo owner/repo --title x)"
+if [[ "$result" == "exit=0 last=pr edit 5 --repo owner/repo --title x" ]]; then
+  echo "  PASS: pr edit retries without injected labels and succeeds"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: pr edit retries without injected labels and succeeds"
+  echo "        got '$result', want exit=0 with an unlabeled final retry"
+  FAIL=$((FAIL + 1))
+fi
+
+result="$(run_label_wrapper issue edit 7 --repo owner/repo --add-assignee z)"
+if [[ "$result" == "exit=0 last=issue edit 7 --repo owner/repo --add-assignee z" ]]; then
+  echo "  PASS: issue edit retries without injected labels and succeeds"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: issue edit retries without injected labels and succeeds"
+  echo "        got '$result', want exit=0 with an unlabeled final retry"
+  FAIL=$((FAIL + 1))
+fi
+
+result="$(run_label_wrapper issue create --repo owner/repo --title t --body b)"
+if [[ "$result" == exit=0* && "$result" != *"--label"* ]]; then
+  echo "  PASS: issue create retries without injected labels and succeeds"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: issue create retries without injected labels and succeeds"
+  echo "        got '$result', want exit=0 with an unlabeled final retry"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── #4043: empty per-agent token cache must fail LOUD, not go unauthenticated ─
+# A pre-created-but-not-yet-minted (0-byte) cache passed the old -f check and
+# exported an EMPTY GH_TOKEN, sending every call out unauthenticated. Direct
+# invocation (not run_wrapper) because the harness treats this gate's message
+# as a harness error elsewhere.
+echo "-- empty token cache fails loud (#4043) --"
+EMPTY_CACHE="${WORK}/empty-token"
+: >"$EMPTY_CACHE"
+out="$(
+  HIVE_GH_WRAPPER_REAL_GH="$STUB" \
+  STUB_LOG="$STUB_LOG" \
+  HIVE_AGENT="testagent" \
+  HIVE_AGENT_ID="testagent" \
+  HIVE_AGENT_MODE="ISSUES_PRS_MERGE" \
+  HIVE_AGENT_TOKEN_CACHE="$EMPTY_CACHE" \
+  HIVE_CONTRIBUTOR_MODE="false" \
+  bash "$WRAPPER" issue view 1 --repo owner/repo 2>&1
+)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"per-agent scoped GitHub token not available"* ]]; then
+  echo "  PASS: empty token cache blocks with the fail-loud message"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: empty token cache blocks with the fail-loud message"
+  echo "        got rc=$rc out='$out'"
+  FAIL=$((FAIL + 1))
+fi
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -357,6 +357,12 @@ COPY src/deploy/data/ /opt/hive/seed-data/
 COPY src/deploy/ttyd-tmux.sh /usr/local/bin/ttyd-tmux.sh
 COPY src/deploy/hive-panes.sh /usr/local/bin/hive-panes
 COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credential-hive.sh /usr/local/bin/
+# SECURITY (#4045): sourced (not executed) by every shell in an agent's process
+# tree — via BASH_ENV/ENV from agent-launch.sh for non-interactive tool shells,
+# and via the /etc/bash.bashrc guard below for interactive ones — to unset the
+# GitHub credentials backend CLIs re-export into the shells they spawn. No exec
+# bit on purpose: it must only ever be sourced.
+COPY bin/agent-env-scrub.sh /usr/local/bin/agent-env-scrub.sh
 COPY bin/hive-open-pr.sh /usr/local/bin/hive-open-pr
 COPY bin/hive-merge.sh /usr/local/bin/hive-merge
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
@@ -367,6 +373,13 @@ COPY config/backends.conf /usr/local/etc/hive/backends.conf
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bin/gh-app-token.sh \
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
     /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-merge
+
+# SECURITY (#4045): interactive-shell arm of the agent credential scrub.
+# BASH_ENV (exported by agent-launch.sh) only reaches NON-interactive shells;
+# an interactive bash a backend CLI spawns for the agent reads
+# /etc/bash.bashrc instead. Gated on the agent-identity env agent-launch.sh
+# exports, so an operator's own `kubectl exec` shell is untouched.
+RUN printf '\n# hive #4045: scrub backend-exported GitHub credentials from agent shells\n[ -n "${HIVE_AGENT:-}${HIVE_AGENT_ID:-}" ] && . /usr/local/bin/agent-env-scrub.sh || true\n' >> /etc/bash.bashrc
 
 # SECURITY (audit F5-egress / refs #2674, #2678, #3760): the hive process needs
 # CAP_NET_ADMIN in its EFFECTIVE set so the MITM proxy can stamp SO_MARK on its

--- a/src/cmd/hive/login_patterns_overrides_test.go
+++ b/src/cmd/hive/login_patterns_overrides_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/snapshot"
+)
+
+// #4041: the legacy state-overrides migration replays a persisted
+// sensing_login list over the loaded config. A list byte-identical to the
+// pre-#3959 defaults is the old defaults materialized by an earlier save —
+// replaying it would re-pin the false-positive-prone generic patterns over
+// the corrected code defaults. It must be skipped; a genuinely customized
+// list must still replay verbatim.
+
+// legacySensingLogin mirrors pkg/config's legacyDefaultLoginPatterns (frozen;
+// duplicated here because the source list is deliberately unexported).
+var legacySensingLogin = []string{
+	"please log in",
+	"authentication required",
+	"not logged in",
+	"login required",
+	"session expired",
+	"token expired",
+	"unauthorized.*401",
+	"gh auth login",
+	"claude login",
+	"copilot auth",
+}
+
+func TestApplyConfigOverrides_SkipsLegacyDefaultSensingLogin(t *testing.T) {
+	// Sanity: the local copy must still match the config package's frozen set,
+	// or this test would silently stop guarding the replay path.
+	if !config.IsLegacyDefaultLoginPatterns(legacySensingLogin) {
+		t.Fatal("legacySensingLogin fixture no longer matches config's frozen legacy set")
+	}
+
+	cfg := &config.Config{
+		Governor: config.GovernorConfig{
+			Sensing: config.SensingConfig{
+				// What applyDefaults left in place: the corrected defaults.
+				LoginPatterns: []string{"Please run /login", "Not logged in"},
+			},
+		},
+	}
+	applyConfigOverrides(cfg, &snapshot.ConfigOverrides{
+		SensingLogin: append([]string(nil), legacySensingLogin...),
+	})
+	got := cfg.Governor.Sensing.LoginPatterns
+	if len(got) != 2 || got[0] != "Please run /login" || got[1] != "Not logged in" {
+		t.Fatalf("legacy-default sensing_login was replayed over the corrected defaults: %v", got)
+	}
+}
+
+// Positive control: a customized sensing_login override still replays.
+func TestApplyConfigOverrides_ReplaysCustomSensingLogin(t *testing.T) {
+	cfg := &config.Config{
+		Governor: config.GovernorConfig{
+			Sensing: config.SensingConfig{
+				LoginPatterns: []string{"Please run /login"},
+			},
+		},
+	}
+	custom := []string{"my own pattern", "copilot auth"}
+	applyConfigOverrides(cfg, &snapshot.ConfigOverrides{
+		SensingLogin: append([]string(nil), custom...),
+	})
+	got := cfg.Governor.Sensing.LoginPatterns
+	if len(got) != len(custom) {
+		t.Fatalf("custom sensing_login not replayed: %v", got)
+	}
+	for i := range custom {
+		if got[i] != custom[i] {
+			t.Fatalf("custom sensing_login mutated: got %v, want %v", got, custom)
+		}
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -150,7 +150,13 @@ const reachStatePath = "/data/reach-state.json"
 // upgrade beat can never report different pictures of the same agent.
 func agentActivityFor(mgr *agent.Manager, name string, proc *agent.AgentProcess) hub.AgentActivity {
 	act := hub.AgentActivity{
-		Paused:         proc.Paused,
+		Paused: proc.Paused,
+		// Pause provenance (#4041): ride WHO/WHY/WHEN to the hub so the
+		// fleet view can tell a deliberate owner quiesce from a malfunction.
+		PausedTrigger:  proc.PausedTrigger,
+		PausedReason:   proc.PausedReason,
+		PausedBy:       proc.PausedBy,
+		PausedAt:       proc.PausedAt,
 		NeedsLogin:     proc.NeedsLogin,
 		LastActivityAt: proc.LastPaneChange,
 		// A missing tmux session is only meaningful for an agent the manager
@@ -3018,16 +3024,15 @@ func main() {
 	}
 	// One visible "hive restarted" marker per boot, so the audit log shows a
 	// restart happened (and at what build) instead of only a burst of
-	// per-agent agent_start rows. Include a count of persisted pauses being
-	// restored so the operator can confirm pause state survived the restart.
-	pausedCount := 0
-	for _, ac := range cfg.EnabledAgents() {
-		if ac.Paused {
-			pausedCount++
-		}
-	}
+	// per-agent agent_start rows. Include the persisted pauses being restored
+	// so the operator can confirm pause state survived the restart — broken
+	// down by trigger, and EXCLUDING agents that are startup-paused by design
+	// (on-demand agents like brainstorm), whose inclusion turned "restoring 9
+	// paused agent(s)" into a false systemic-incident signal on every upgrade
+	// restart of a deliberately owner-quiesced fleet (#4041).
 	dashSrv.AuditLog("system", "hive_restart",
-		fmt.Sprintf("build=%s version=%s; restoring %d paused agent(s)", gitShort, "3.0.0", pausedCount), "")
+		fmt.Sprintf("build=%s version=%s; %s", gitShort, "3.0.0",
+			pausedRestoreDetail(cfg.EnabledAgents(), onDemandFromPack, agentMgr.AllStatuses())), "")
 
 	// Mark the dashboard READY as soon as the HTTP server can serve requests —
 	// which is NOW: config is loaded, GitHub client/App auth are wired, the
@@ -5524,6 +5529,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			LastKick:        proc.LastKick,
 			PausedReason:    proc.PausedReason,
 			PausedTrigger:   proc.PausedTrigger,
+			PausedBy:        proc.PausedBy,
 		}
 		if !proc.PausedAt.IsZero() {
 			t := proc.PausedAt

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6793,7 +6793,13 @@ func applyConfigOverrides(cfg *config.Config, o *snapshot.ConfigOverrides) {
 	if len(o.SensingCLIExclude) > 0 {
 		cfg.Governor.Sensing.CLIExcludePatterns = o.SensingCLIExclude
 	}
-	if len(o.SensingLogin) > 0 {
+	// #4041: a persisted sensing_login that is byte-identical to the
+	// pre-#3959 default set carries no operator intent — it is the old
+	// defaults materialized by an earlier save. Replaying it here would
+	// re-pin the false-positive-prone generic patterns over the corrected
+	// code defaults the config layer just applied. Skip it; a genuinely
+	// customized list still replays verbatim.
+	if len(o.SensingLogin) > 0 && !config.IsLegacyDefaultLoginPatterns(o.SensingLogin) {
 		cfg.Governor.Sensing.LoginPatterns = o.SensingLogin
 	}
 	if o.SensingTTL != nil {

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1095,6 +1095,10 @@ func main() {
 	// Dashboard login now requests no scope and no user write-token is persisted.
 
 	gov := governor.New(cfg.Governor, cfg.EnabledAgents(), logger)
+	// Default mode thresholds scale with how many repos the hive watches, so
+	// the mode ladder means the same thing on a 3-repo hive as on a 39-repo
+	// one (#3498). Explicit thresholds are unaffected.
+	gov.SetRepoCount(cfg.Project.RepoCount())
 	sched := scheduler.New(cfg, logger)
 
 	// Wire the GitHub prompt-source resolver so agents may source their kick
@@ -2618,6 +2622,9 @@ func main() {
 		// Re-sync subsystems that cache config values
 		ghClient.SetRepos(cfg.Project.Repos)
 		gov.UpdateConfig(cfg.Governor)
+		// A reload can add or archive repos, which moves every scaled default
+		// threshold — re-sync it alongside the repo list above.
+		gov.SetRepoCount(cfg.Project.RepoCount())
 		agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 
 		// Re-apply live agent definitions (definition_source) on reload so an

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1087,6 +1087,10 @@ func main() {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 		ghClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 	}
+	// Unconditional (nil-safe, zero value = no filtering): the issue filter
+	// gates which issues become actionable at all, so it must be installed
+	// even when no exempt labels are configured.
+	ghClient.SetIssueFilter(cfg.Project.IssueFilter)
 	// The user write-token client (userGHClient) was removed: every GitHub write
 	// — issues, PRs, comments, merges, and the advisory digest — now goes through
 	// the hive's App installation token (ghClient / kubestellar-hive[bot]). The
@@ -1583,6 +1587,7 @@ func main() {
 				ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				ghClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 			}
+			ghClient.SetIssueFilter(cfg.Project.IssueFilter)
 			logger.Info("migrated config overrides from state to hive.yaml",
 				"repos", cfg.Project.Repos)
 
@@ -2261,6 +2266,7 @@ func main() {
 				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 				newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 			}
+			newClient.SetIssueFilter(cfg.Project.IssueFilter)
 			if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
 				newClient.SetRequiredChecks(set)
 			}
@@ -2668,6 +2674,7 @@ func main() {
 						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 						newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 					}
+					newClient.SetIssueFilter(cfg.Project.IssueFilter)
 					if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
 						newClient.SetRequiredChecks(set)
 					}
@@ -3816,6 +3823,7 @@ func main() {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 					newClient.SetAutoMergeLabel(normalizedAutoMergeLabel(cfg.Governor.Labels.AutoMerge))
 				}
+				newClient.SetIssueFilter(cfg.Project.IssueFilter)
 				if set, ok := cfg.AutoMerge.RequiredCheckSet(); ok {
 					newClient.SetRequiredChecks(set)
 				}
@@ -3914,12 +3922,17 @@ func main() {
 			vanityMatched := pc.DashboardURL == "" || cfg.Hub.DashboardURL == pc.DashboardURL
 			authorMatched := pc.AIAuthor == "" || cfg.Project.AIAuthor == pc.AIAuthor
 			apiURLMatched := pc.GitHubAPIURL == "" || cfg.GitHub.APIURL == pc.GitHubAPIURL
+			// Issue filter: nil means "the hub is not speaking to this field"
+			// (mirrors AIAuthor's empty-means-keep), so the hub's every-beat
+			// echo can never blank a locally configured filter.
+			issueFilterMatched := pc.IssueFilter == nil || cfg.Project.IssueFilter.Equal(*pc.IssueFilter)
 			if cfg.Project.Org == pc.Org &&
 				sameStringSlice(cfg.Project.Repos, pc.Repos) &&
 				cfg.Project.PrimaryRepo == pc.PrimaryRepo &&
 				curACMM == pc.ACMMLevel &&
 				authorMatched &&
 				apiURLMatched &&
+				issueFilterMatched &&
 				vanityMatched {
 				return // already reconciled
 			}
@@ -3941,6 +3954,16 @@ func main() {
 			// kept the fleet-stats collector disabled on every hive.
 			if pc.AIAuthor != "" {
 				cfg.Project.AIAuthor = pc.AIAuthor
+			}
+			// Adopt a hub-delivered issue filter only when the hub actually
+			// sent one (non-nil). A push without the field leaves the spoke's
+			// locally configured filter untouched — the org/repos assignments
+			// above never wipe it either, so a local filter SURVIVES claim
+			// delivery. A non-nil but EMPTY filter is an explicit clear.
+			if pc.IssueFilter != nil && !cfg.Project.IssueFilter.Equal(*pc.IssueFilter) {
+				logger.Info("adopting issue filter from hub heartbeat",
+					"require_labels", pc.IssueFilter.RequireLabels)
+				cfg.Project.IssueFilter = *pc.IssueFilter
 			}
 			// Adopt a GitHub Enterprise API URL when the hub sends one. Empty
 			// means "leave mine alone" — the spoke's own default is already
@@ -3971,8 +3994,11 @@ func main() {
 			cfg.ACMMLevel = &level
 
 			// Re-sync the GitHub client that caches the repo list (mirrors the
-			// config-watcher reload path).
+			// config-watcher reload path). The issue filter is cached the same
+			// way, so re-install it too — a hub-delivered filter must take
+			// effect on the next enumeration, not the next restart.
 			ghClient.SetRepos(cfg.Project.Repos)
+			ghClient.SetIssueFilter(cfg.Project.IssueFilter)
 
 			// Persist to the PVC overlay so the claim survives a pod restart
 			// (config save writes the overlay hive.yaml, same as level switches).

--- a/src/cmd/hive/pause_provenance_boot_test.go
+++ b/src/cmd/hive/pause_provenance_boot_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/snapshot"
+)
+
+// #4041 boot-side provenance: the persisted actor must survive a restart, and
+// the "restoring N paused agent(s)" boot line must (a) exclude agents that are
+// startup-paused BY DESIGN (on-demand, e.g. brainstorm) and (b) break the
+// remainder down by trigger — the inflated bare count is what made a
+// deliberate owner quiesce read as a fresh systemic event on every upgrade
+// restart of the frostyard fleet.
+
+func TestRestoreAgentRuntimeState_ReplaysPausedBy(t *testing.T) {
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: "testorg", Repos: []string{"r"}},
+		Agents: map[string]config.AgentConfig{
+			"scanner": {Backend: "claude", Enabled: true},
+		},
+	}
+	statePath := filepath.Join(t.TempDir(), "hive-state.json")
+	pausedAt := time.Date(2026, 8, 14, 16, 10, 10, 0, time.UTC)
+	if err := snapshot.SaveState(statePath, &snapshot.PersistedState{
+		Agents: map[string]snapshot.AgentState{
+			"scanner": {
+				Paused:        true,
+				PausedAt:      &pausedAt,
+				PausedTrigger: "dashboard-api",
+				PausedReason:  "manual pause",
+				PausedBy:      "bketelsen",
+			},
+		},
+	}, restoreTestLogger()); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	saved, err := snapshot.LoadState(statePath, restoreTestLogger())
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	m := agent.NewManager(cfg.Agents, restoreTestLogger(), agent.ProjectContext{})
+	restoreAgentRuntimeState(saved, cfg, m, restoreTestLogger())
+
+	proc, err := m.GetStatus("scanner")
+	if err != nil || proc == nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if proc.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q after restart, want %q (actor downgraded to anonymous on restore)", proc.PausedBy, "bketelsen")
+	}
+	if proc.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", proc.PausedTrigger, "dashboard-api")
+	}
+	if !proc.PausedAt.Equal(pausedAt) {
+		t.Errorf("PausedAt = %v, want %v", proc.PausedAt, pausedAt)
+	}
+}
+
+func pausedProc(trigger string) *agent.AgentProcess {
+	return &agent.AgentProcess{Paused: true, PausedTrigger: trigger}
+}
+
+// The frostyard shape: 8 owner-paused staff agents plus the always-startup-
+// paused on-demand brainstorm. The old line said "restoring 9 paused
+// agent(s)"; the new one must say 8, attribute them, and report the by-design
+// one separately.
+func TestPausedRestoreDetail_ExcludesByDesignOnDemand(t *testing.T) {
+	enabled := map[string]config.AgentConfig{}
+	statuses := map[string]*agent.AgentProcess{}
+	staff := []string{"scanner", "quality", "ci-maintainer", "architect", "guide", "sec-check", "strategist", "supervisor"}
+	for _, name := range staff {
+		enabled[name] = config.AgentConfig{Enabled: true, Paused: true}
+		statuses[name] = pausedProc("dashboard-api")
+	}
+	enabled["brainstorm"] = config.AgentConfig{Enabled: true, Paused: true, OnDemand: true}
+	statuses["brainstorm"] = pausedProc("startup")
+	enabled["running-agent"] = config.AgentConfig{Enabled: true}
+
+	got := pausedRestoreDetail(enabled, nil, statuses)
+	want := "restoring 8 paused agent(s) (dashboard-api: 8); 1 on-demand agent(s) startup-paused by design"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "9") {
+		t.Errorf("by-design startup-paused agent leaked into the headline count: %q", got)
+	}
+}
+
+// An agent that is on-demand via its PACK definition (not its own config)
+// must be excluded the same way.
+func TestPausedRestoreDetail_ExcludesPackOnDemand(t *testing.T) {
+	enabled := map[string]config.AgentConfig{
+		"brainstorm": {Enabled: true, Paused: true},
+		"scanner":    {Enabled: true, Paused: true},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"brainstorm": pausedProc("startup"),
+		"scanner":    pausedProc("dashboard-api"),
+	}
+	got := pausedRestoreDetail(enabled, map[string]bool{"brainstorm": true}, statuses)
+	want := "restoring 1 paused agent(s) (dashboard-api: 1); 1 on-demand agent(s) startup-paused by design"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}
+
+// Mixed triggers appear sorted; an agent the manager has no provenance for
+// still counts, under "unknown" — the total must always add up.
+func TestPausedRestoreDetail_BreaksDownByTrigger(t *testing.T) {
+	enabled := map[string]config.AgentConfig{
+		"a": {Enabled: true, Paused: true},
+		"b": {Enabled: true, Paused: true},
+		"c": {Enabled: true, Paused: true},
+		"d": {Enabled: true, Paused: true},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"a": pausedProc("dashboard-api"),
+		"b": pausedProc("dashboard-api"),
+		"c": pausedProc("login-detector"),
+		// "d" missing from statuses entirely.
+	}
+	got := pausedRestoreDetail(enabled, nil, statuses)
+	want := "restoring 4 paused agent(s) (dashboard-api: 2, login-detector: 1, unknown: 1)"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}
+
+func TestPausedRestoreDetail_NothingPaused(t *testing.T) {
+	enabled := map[string]config.AgentConfig{
+		"scanner": {Enabled: true},
+	}
+	got := pausedRestoreDetail(enabled, nil, map[string]*agent.AgentProcess{})
+	want := "restoring 0 paused agent(s)"
+	if got != want {
+		t.Errorf("detail = %q, want %q", got, want)
+	}
+}

--- a/src/cmd/hive/state_restore.go
+++ b/src/cmd/hive/state_restore.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 
 	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/config"
@@ -23,6 +26,62 @@ import (
 // swallowed here while "backend override restored" was logged unconditionally,
 // so the operator saw a successful restore of a value that was already gone.
 // Failures are now logged as the failures they are.
+// pausedRestoreDetail builds the "restoring N paused agent(s)" fragment of
+// the boot audit line. Two lessons from #4041 are baked in:
+//
+//   - On-demand agents (agent config on_demand, or on-demand per their pack
+//     definition) are startup-paused BY DESIGN — brainstorm is triggered by
+//     inception only and has never run at boot. Counting them alongside real
+//     restored pauses inflated "restoring 9 paused agent(s)" on a hive whose
+//     owner had paused 8, and that inflated bare count is what made a
+//     deliberate quiesce read as a fresh systemic event on every upgrade
+//     restart. They are reported separately, never in the headline count.
+//   - The bare count says nothing about WHO paused WHAT. The per-trigger
+//     breakdown ("dashboard-api: 8") lets a fleet owner reading logs tell an
+//     owner-initiated mass pause from a login-detector cascade at a glance.
+//
+// statuses carries the manager's post-restore pause provenance; agents
+// missing from it (not yet registered) count under the "unknown" trigger
+// rather than being dropped — the total must always add up.
+func pausedRestoreDetail(enabled map[string]config.AgentConfig, onDemandFromPack map[string]bool, statuses map[string]*agent.AgentProcess) string {
+	restored := 0
+	byDesign := 0
+	byTrigger := map[string]int{}
+	for name, ac := range enabled {
+		if !ac.Paused {
+			continue
+		}
+		if ac.OnDemand || onDemandFromPack[name] {
+			byDesign++
+			continue
+		}
+		restored++
+		trigger := "unknown"
+		if proc, ok := statuses[name]; ok && proc != nil && strings.TrimSpace(proc.PausedTrigger) != "" {
+			trigger = proc.PausedTrigger
+		}
+		byTrigger[trigger]++
+	}
+
+	detail := fmt.Sprintf("restoring %d paused agent(s)", restored)
+	if len(byTrigger) > 0 {
+		triggers := make([]string, 0, len(byTrigger))
+		for t := range byTrigger {
+			triggers = append(triggers, t)
+		}
+		sort.Strings(triggers)
+		parts := make([]string, 0, len(triggers))
+		for _, t := range triggers {
+			parts = append(parts, fmt.Sprintf("%s: %d", t, byTrigger[t]))
+		}
+		detail += " (" + strings.Join(parts, ", ") + ")"
+	}
+	if byDesign > 0 {
+		detail += fmt.Sprintf("; %d on-demand agent(s) startup-paused by design", byDesign)
+	}
+	return detail
+}
+
 func restoreAgentRuntimeState(saved *snapshot.PersistedState, cfg *config.Config, agentMgr *agent.Manager, logger *slog.Logger) {
 	for name, as := range saved.Agents {
 		if _, inConfig := cfg.Agents[name]; !inConfig {
@@ -38,9 +97,12 @@ func restoreAgentRuntimeState(saved *snapshot.PersistedState, cfg *config.Config
 			if trigger == "" {
 				trigger = "state-restore"
 			}
-			_ = agentMgr.Pause(name, trigger, reason)
+			// Replay the acting user too (#4041): without it, every restart
+			// downgraded an owner-attributed pause to an anonymous one, and a
+			// deliberate quiesce read like a malfunction days later.
+			_ = agentMgr.PauseBy(name, trigger, reason, as.PausedBy)
 			if as.PausedAt != nil {
-				agentMgr.SeedPauseState(name, *as.PausedAt, trigger, reason)
+				agentMgr.SeedPauseState(name, *as.PausedAt, trigger, reason, as.PausedBy)
 			}
 		}
 		if as.PinnedCLI != "" {

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -360,6 +360,12 @@ if [ "$(id -u)" = "0" ]; then
 
   mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
   mkdir -p /var/run/hive-metrics/agent-tokens && chown dev:node /var/run/hive-metrics/agent-tokens 2>/dev/null || true
+  # 0755 explicitly, not umask-dependent: gh-wrapper.sh's author gate trusts
+  # the bot-identity file in this directory BECAUSE no agent UID can write here
+  # (#4044). Group is "node" — which every agent is a member of — so a
+  # group-writable mode would let any agent swap that file and spoof the
+  # identity the gate validates against. Re-asserted on every boot.
+  chmod 755 /var/run/hive-metrics/agent-tokens 2>/dev/null || true
 
   # Fix permissions on bind-mounted secret files (host may own them as
   # a different UID with mode 600, making them unreadable by dev/UID 1001)

--- a/src/deploy/k8s/deployment.yaml
+++ b/src/deploy/k8s/deployment.yaml
@@ -73,6 +73,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+              # OpenShift: NO stock SCC (including `anyuid`) permits adding
+              # these capabilities, so on OpenShift this pod is rejected at
+              # admission unless a cluster-admin has applied the optional
+              # ../kustomize/overlays/openshift-netadmin overlay (dedicated
+              # `hive-netadmin` SCC + RoleBinding). If the cluster cannot grant
+              # NET_ADMIN at all, the deliberate degraded-mode alternative is
+              # HIVE_PROXY_ADVISORY_OK=true (forced proxy egress becomes
+              # advisory) — see ../kustomize/overlays/standalone/
+              # patch-advisory-mode.yaml and src/docs/net-admin-requirement.md.
               add:
                 - NET_ADMIN # ACMM proxy iptables redirect of outbound :443
                 - SETUID # su-exec dev->per-agent UID switch

--- a/src/deploy/kustomize/overlays/openshift-netadmin/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/openshift-netadmin/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# OpenShift capability-grant overlay — OPTIONAL, OpenShift-ONLY, and it
+# REQUIRES cluster-admin to apply (SecurityContextConstraints is a
+# cluster-scoped, admin-only resource).
+#
+# What it is: the dedicated `hive-netadmin` SCC plus the RBAC that lets the
+# `hive` ServiceAccount use it. This is the same SCC/RoleBinding pattern the
+# managed fleet's hub provisions out-of-band; standalone installs have no hub,
+# so a cluster-admin applies this overlay once instead.
+#
+# Why you need it on OpenShift: the base deployment (../../../k8s) requests
+# `capabilities.add` (NET_ADMIN + the su-exec set) and starts as root. NO stock
+# SCC admits that pod — `restricted-v2` forbids root and the caps, and `anyuid`
+# (what ../openshift binds) permits root but forbids ADDING capabilities. With
+# only the stock SCCs the ReplicaSet is rejected at admission with
+# "unable to validate against any security context constraint". The
+# `hive-netadmin` SCC is restricted-v2 loosened by EXACTLY what the base
+# deployment declares — see scc-hive-netadmin.yaml — and nothing else (not
+# privileged, no host access).
+#
+# What it deliberately does NOT include: the workload base. Granting the SCC is
+# a one-time cluster-admin action, decoupled from deploying/upgrading the app,
+# so applying this overlay never re-applies (or reverts) the deployment:
+#
+#   # cluster-admin, once:
+#   oc apply -k src/deploy/kustomize/overlays/openshift-netadmin
+#   # then the app itself (standalone and/or openshift overlays), as usual:
+#   oc apply -k src/deploy/kustomize/overlays/standalone
+#
+# Plain-Kubernetes clusters: do NOT apply this (the SCC API does not exist
+# there); the base stays cluster-agnostic. If your cluster cannot grant
+# NET_ADMIN at all, the deliberate degraded-mode alternative is
+# `HIVE_PROXY_ADVISORY_OK=true` — see
+# ../standalone/patch-advisory-mode.yaml and src/docs/net-admin-requirement.md.
+
+resources:
+  - scc-hive-netadmin.yaml
+  - rolebinding.yaml

--- a/src/deploy/kustomize/overlays/openshift-netadmin/rolebinding.yaml
+++ b/src/deploy/kustomize/overlays/openshift-netadmin/rolebinding.yaml
@@ -1,0 +1,45 @@
+# RBAC that lets the base `hive` ServiceAccount be admitted under the
+# `hive-netadmin` SCC. SCC access is granted via the `use` verb on the named
+# SCC resource; the SCC's own users/groups lists stay empty so this RBAC is the
+# single place the grant is visible and revocable.
+#
+# Both objects require cluster-admin to apply (ClusterRole is cluster-scoped,
+# and binding an SCC is a privilege escalation only an admin can perform).
+#
+# Naming matches the managed fleet's out-of-band pattern: SCC `hive-netadmin`,
+# RoleBinding `hive-netadmin-scc`.
+#
+# The subject is the SA the base actually uses: deployment.yaml sets
+# `serviceAccountName: hive` (defined in dashboard-route-rbac.yaml) — NOT
+# `hive-sa`.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hive-netadmin-scc
+  labels:
+    app.kubernetes.io/name: hive
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - hive-netadmin
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-netadmin-scc
+  namespace: hive
+  labels:
+    app.kubernetes.io/name: hive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hive-netadmin-scc
+subjects:
+  - kind: ServiceAccount
+    name: hive
+    namespace: hive

--- a/src/deploy/kustomize/overlays/openshift-netadmin/scc-hive-netadmin.yaml
+++ b/src/deploy/kustomize/overlays/openshift-netadmin/scc-hive-netadmin.yaml
@@ -1,0 +1,82 @@
+# `hive-netadmin` — a dedicated SCC that is `restricted-v2` loosened by EXACTLY
+# what the base deployment (src/deploy/k8s/deployment.yaml) declares, and
+# nothing else. Every field below that is not called out as a delta carries the
+# stock restricted-v2 value: no privileged containers, no host
+# network/ports/PID/IPC, no hostPath volumes, drop-ALL still required,
+# runtime/default seccomp still required.
+#
+# Deltas from restricted-v2 (each one exists because the base pod needs it):
+#
+#   allowedCapabilities        The six capabilities the deployment's
+#                              `capabilities.add` lists (it still drops ALL
+#                              first). An SCC admits a pod only if every added
+#                              cap is in this list — allowing only NET_ADMIN
+#                              would still reject the pod, so the su-exec set
+#                              is listed too, mirroring deployment.yaml 1:1.
+#   runAsUser: RunAsAny        The entrypoint starts as root (iptables REDIRECT,
+#                              PVC chown) and then drops to `dev`;
+#                              MustRunAsRange would force a namespace-range UID
+#                              and break that. This also makes the `anyuid`
+#                              binding unnecessary when this SCC is granted.
+#   fsGroup: RunAsAny          The pod pins fsGroup 1002 (hive-launch — the
+#                              audit-N5 secrets-readability split), which is
+#                              outside any namespace's allocated range.
+#   allowPrivilegeEscalation   true: the agent-UID switch runs through the SUID
+#                              su-exec helper; `false` would set no_new_privs
+#                              and disable all SUID binaries (see the C6
+#                              rationale in deployment.yaml).
+#
+# Applying this file requires cluster-admin. It grants nothing by itself —
+# access is via the `use` RBAC in rolebinding.yaml, scoped to the single
+# `hive` ServiceAccount in the `hive` namespace (users/groups deliberately
+# empty).
+#
+# Verify after apply (pod annotation names the SCC that admitted it):
+#   oc -n hive get pod -l app.kubernetes.io/name=hive \
+#     -o jsonpath='{.items[0].metadata.annotations.openshift\.io/scc}'
+#   # MUST print "hive-netadmin"
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: hive-netadmin
+  labels:
+    app.kubernetes.io/name: hive
+allowPrivilegedContainer: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowedCapabilities:
+  - NET_ADMIN # ACMM proxy iptables redirect of outbound :443
+  - SETUID # su-exec dev->per-agent UID switch
+  - SETGID
+  - SETPCAP
+  - CHOWN # chown per-agent dirs/beads to the agent UID
+  - DAC_OVERRIDE
+defaultAddCapabilities: null
+requiredDropCapabilities:
+  - ALL
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+users: []
+groups: []

--- a/src/deploy/kustomize/overlays/openshift/anyuid-scc-rolebinding.yaml
+++ b/src/deploy/kustomize/overlays/openshift/anyuid-scc-rolebinding.yaml
@@ -13,7 +13,11 @@
 # Verify after apply:
 #   oc -n hive get pod -l app.kubernetes.io/name=hive \
 #     -o jsonpath='{.items[0].metadata.annotations.openshift\.io/scc}'
-#   # MUST print "anyuid" — "restricted-v2" means this binding did not take.
+#   # "restricted-v2" means this binding did not take. Note: because the base
+#   # deployment also ADDS capabilities (which anyuid forbids), on a correctly
+#   # set-up cluster the pod is actually admitted by the `hive-netadmin` SCC
+#   # from ../openshift-netadmin — the annotation then prints "hive-netadmin",
+#   # and this anyuid binding is redundant-but-harmless.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/src/deploy/kustomize/overlays/openshift/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/openshift/kustomization.yaml
@@ -12,6 +12,14 @@ kind: Kustomization
 #
 # It changes NOTHING about the workload itself; the base deployment already
 # carries the correct securityContext (fsGroup 1002, NET_ADMIN + su-exec caps).
+#
+# NOTE (capabilities): `anyuid` permits root but does NOT permit ADDING
+# capabilities, and the base deployment requests NET_ADMIN + the su-exec set —
+# so on a cluster with only stock SCCs the pod is still rejected at admission.
+# A cluster-admin must also apply the ../openshift-netadmin overlay (dedicated
+# `hive-netadmin` SCC), which additionally permits root and therefore makes
+# the anyuid binding below redundant-but-harmless. See that overlay's
+# kustomization.yaml and src/docs/net-admin-requirement.md.
 
 resources:
   - ../../../k8s

--- a/src/deploy/kustomize/overlays/standalone/README.md
+++ b/src/deploy/kustomize/overlays/standalone/README.md
@@ -41,15 +41,26 @@ token).
 
 - **Cluster GRANTS NET_ADMIN (most do):** do nothing. The full gate comes up
   automatically. This is the recommended, fail-closed default.
-- **Cluster DENIES NET_ADMIN:** the entrypoint FATALs and the pod crash-loops
-  (`FATAL: refusing to start ... capability model would be advisory-only`). To
-  start anyway in **advisory-only** mode, uncomment the
-  `- path: patch-advisory-mode.yaml` line in `kustomization.yaml`. That sets
-  `HIVE_PROXY_ADVISORY_OK=true`. **Trade-off:** the egress gate becomes
-  best-effort, not enforced — an agent could bypass the proxy. Only do this if
-  you accept that.
+- **Cluster DENIES NET_ADMIN:** two possible signatures, two remedies.
+  - *OpenShift admission rejection* — the pod never starts; `oc -n hive get
+    events` shows `unable to validate against any security context constraint`
+    (no stock SCC, `anyuid` included, permits the capabilities the base
+    deployment adds). **Remedy:** a cluster-admin applies the
+    `../openshift-netadmin` overlay (dedicated `hive-netadmin` SCC + RoleBinding)
+    — this is the real fix; the full gate then comes up.
+  - *Runtime FATAL* — the pod starts but crash-loops with
+    `FATAL: refusing to start ... capability model would be advisory-only` and
+    **exit code 77** (EX_NOPERM) when the container's bounding set lacks
+    `CAP_NET_ADMIN` (any other cause of that FATAL exits 1). **Remedy** if you
+    cannot grant the capability: start anyway in **advisory-only** mode by
+    uncommenting the `- path: patch-advisory-mode.yaml` line in
+    `kustomization.yaml` (sets `HIVE_PROXY_ADVISORY_OK=true`). **Trade-off:**
+    forced proxy egress becomes advisory — best-effort, not enforced — so an
+    agent could bypass the proxy. Only do this if you accept that.
 
-See `src/docs/net-admin-requirement.md` for the full explanation.
+Not sure which case you're in? Run the checks in
+`src/docs/manual-provisioning.md` ("Does your cluster grant NET_ADMIN?"), and
+see `src/docs/net-admin-requirement.md` for the full explanation.
 
 ## Install
 

--- a/src/deploy/kustomize/overlays/standalone/kustomization.yaml
+++ b/src/deploy/kustomize/overlays/standalone/kustomization.yaml
@@ -42,4 +42,7 @@ patches:
   # 3. NET_ADMIN escape hatch (COMMENTED OUT by default). Uncomment ONLY on a
   #    locked-down cluster that DENIES NET_ADMIN — see README "The NET_ADMIN
   #    decision". Leaving it commented keeps the fail-CLOSED security gate.
+  #    On OpenShift, prefer the real fix: have a cluster-admin apply the
+  #    ../openshift-netadmin overlay (dedicated `hive-netadmin` SCC) so the
+  #    full gate comes up instead of degrading to advisory mode.
   # - path: patch-advisory-mode.yaml

--- a/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml
+++ b/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml
@@ -11,9 +11,14 @@
 #   security gate comes up automatically.
 #
 #   On a cluster that DENIES NET_ADMIN, the entrypoint cannot establish the
-#   redirect and FATALs (exit 1, "refusing to start ... capability model would
-#   be advisory-only") — a fail-CLOSED crash loop. Setting
+#   redirect and FATALs ("refusing to start ... capability model would be
+#   advisory-only") — a fail-CLOSED crash loop, with exit code 77 (EX_NOPERM)
+#   when the bounding set lacks CAP_NET_ADMIN (any other cause of the same
+#   FATAL exits 1 — see src/docs/net-admin-requirement.md). Setting
 #   HIVE_PROXY_ADVISORY_OK=true tells it to start anyway in ADVISORY-ONLY mode.
+#   On OpenShift, prefer the real fix over this patch: a cluster-admin applies
+#   ../openshift-netadmin (dedicated `hive-netadmin` SCC) and the full gate
+#   comes up.
 #
 # SECURITY TRADE-OFF: advisory mode means the MITM egress gate is best-effort,
 # not enforced — an agent with a raw token could bypass the proxy. Only enable

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -42,6 +42,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
+- [Governor mode thresholds](https://github.com/kubestellar/hive/blob/v4/src/docs/governor-thresholds.md) — how idle/quiet/busy/surge thresholds scale with repo count, the `threshold_scaling` curves, and when explicit thresholds win.
 - [Supervisor agent](https://github.com/kubestellar/hive/blob/v4/src/docs/supervisor.md) — supervisor policy modes, bead roles, and when to enable the orchestration lane.
 - [Custom dashboard stylesheets](https://github.com/kubestellar/hive/blob/v4/src/docs/custom-stylesheets.md) — operator-supplied CSS for the dashboard and public snapshot.
 - [Portable AgentDefinition format](https://github.com/kubestellar/hive/blob/v4/src/AGENT-DEFINITION.md) — standalone YAML schema for importing/exporting agent definitions.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -229,7 +229,7 @@ Pin a model when reproducibility matters more than the governor's budget optimiz
 
 ## Cadences and the governor
 
-Agents don't schedule themselves. The **governor** evaluates the work queue every `eval_interval_s` (default 300s), computes a mode from queue depth — **idle → quiet → busy → surge** (default thresholds: quiet > 2, busy > 10, surge > 20; override with `threshold:`) — and kicks each agent on the cadence that mode assigns it:
+Agents don't schedule themselves. The **governor** evaluates the work queue every `eval_interval_s` (default 300s), computes a mode from queue depth — **idle → quiet → busy → surge** (default thresholds: quiet > 2, busy > 10, surge > 20 **per watched repo**; override with `threshold:`) — and kicks each agent on the cadence that mode assigns it:
 
 ```yaml
 governor:
@@ -250,6 +250,7 @@ governor:
       architect: pause     # "pause" stops kicks for this agent in this mode
 ```
 
+- **Thresholds scale with repo count.** The *default* thresholds above are per-repo bases, multiplied by `len(project.repos)` — so `surge` is 20 on a 1-repo hive and 780 on a 39-repo one, and the mode ladder means the same thing at any hive size. A `threshold:` you set yourself is used verbatim and never scaled. Tune the curve with `governor.threshold_scaling` (`linear` default, `sqrt`, `none`). See [Governor mode thresholds](governor-thresholds.md), which also covers the ACMM-pack interaction.
 - **Mutually exclusive modes.** Each per-agent, per-mode cadence is either an interval (`5m`, `2h`, `pause`) or a time-of-day schedule — never both. Config load and API writes reject mixed forms with a 400/error.
 - **Time-of-day schedules.** Use `times: ["HH:MM"]` with optional `days` (`mon` … `sun`) and a required IANA `tz`. The timezone is stored explicitly and displayed with the schedule; it does not float with the viewer.
 - **Advanced cron.** Power users can provide a constrained five-field cron expression plus `tz`. Hive evaluates these with robfig/cron and schedule-local timezone handling.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -302,6 +302,36 @@ Resolution order: the agent's explicit `kick_template` wins; otherwise the ACMM 
 
 Portable agents bundle everything — config plus a `promptTemplate` — in a single `AgentDefinition` YAML you can import from a URL in the dashboard. The reference schema is [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md), and a worked example lives at [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
 
+## Label policy: which issues agents may work
+
+There is exactly **one** label-policy surface for the hive's own agents — the **Governor Configuration → Labels** tab — and it has two polarities:
+
+| Polarity | Config | Meaning |
+|---|---|---|
+| **Exempt (deny-list)** | `governor.labels.exempt` (+ permanent `hold`/`on-hold`/`hold/review`, `do-not-merge`) | "**Never** touch issues labeled with these." Everything else is eligible. This has always existed. |
+| **Required (allow-list)** | `project.issue_filter.require_labels` | "**Only** touch issues labeled with these." Empty = every issue is eligible. **This is what "only work approved issues" means.** |
+
+By default a hive treats **every open issue** in its repos as candidate work. Projects that gate automation on a maintainer's explicit approval label want the require polarity: a maintainer reviews an issue, applies the approval/queue label, and only then may agents touch it. (A fleet running against a busy upstream repo hit exactly this — the hive opened a PR for an issue the owner had not yet labeled for agent work; an exempt list cannot express that policy, because it can only name what to avoid, not demand a label be present.)
+
+```yaml
+project:
+  org: my-org
+  repos: [my-org/common]
+  issue_filter:
+    require_labels: [approved-for-agents]   # agents may ONLY work these issues
+```
+
+Semantics:
+
+- **Absent/empty `require_labels` = no gate** — existing hives are unchanged; there is no default-on filtering.
+- An issue must carry **at least one** required label to be eligible. Matching is case-insensitive and **exact** (a prefix like `approved-for-agents-maybe` does not satisfy `approved-for-agents` — prefix matching would over-admit through an approval gate).
+- **Exempt wins on conflict**: an issue carrying both an exempt label and a required label stays excluded. There is deliberately no separate `exclude_labels` field — the exempt list *is* the exclusion mechanism, applied first.
+- PRs and the Hold list are unaffected: open PRs are in-flight work, and held issues still appear under On Hold.
+
+Both polarities are enforced at **enumeration** — the point where GitHub issues become the hive's actionable set — not in the prompt. A filtered issue never enters the queue, never appears in a kick, never triggers plan-from-label, and cannot be re-selected by a confused (or prompt-injected) agent re-listing the repo. Kick prompts additionally state the active require policy so agents know the list is intentionally short. Both lists are edited on the Labels tab; an active require gate is also noted read-only under **Repositories**, and hub-managed hives can receive `issue_filter` with their project config over the heartbeat.
+
+**Not the same thing as the contribute filters.** `hub.contribute_labels_mode` + its label list gate which issues are *handed out to external contributors* over `/contribute` — they have never gated the hive's **own** agents, so an operator who allow-listed a queue label there (a common setup for routing labeled issues to contributors) still had a hive whose own scanner could work every other open issue. `project.issue_filter.require_labels` is the agent-side gate; configure both if you want the same label to govern both lanes.
+
 ## When to add what
 
 | Add… | …when |

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -242,6 +242,28 @@ The shipped relay declares `environment` only where the cause is unambiguous (CL
 
 Whether the hub should ever *act* on client declarations — the ROUTE half of [#2547](https://github.com/kubestellar/hive/issues/2547) — remains an open maintainer decision, and needs task-side requirements metadata that does not exist yet.
 
+## Troubleshooting: the backend dies seconds after every task
+
+Symptom: the CLI starts fine and sits at its prompt, the relay reports `CLI ready` and `Task prompt sent to CLI`, and then the backend exits a few seconds later with a non-zero status — no crash, no log, no message. The pane falls back to a shell, and (on a relay without the liveness fix) subsequent task prompts get typed into that shell.
+
+Check the pane's working directory:
+
+```bash
+tmux display-message -p -t <session> '#{pane_current_path}'
+```
+
+If it ends in `(deleted)` — or the pane's shell printed `shell-init: error retrieving current directory` when it started, or your prompt shows the directory as `.` — the tmux **server** is holding a working directory that no longer exists, and every pane it forks inherits it. This happens when the server was started from a directory that was later removed (for example a nested clone's `v2/pkg/agent`, orphaned when the repo renamed `v2/` to `src/`).
+
+Backends differ here: `agy` refuses to run without a resolvable working directory and exits `2`; `claude`, `codex` and `goose` tolerate it, so the same server looks fine for them.
+
+`just contribute-hive` now `cd`s into the repo as part of the launch command, which works around a poisoned server, and warns when it detects one. To clear it properly:
+
+```bash
+tmux kill-server    # ends ALL tmux sessions, then start the relay again
+```
+
+Note that `tmux new-session -c <path>` does **not** fix this on an already-poisoned server: the pane is still forked into the deleted directory.
+
 ## Protocol compatibility
 
 Both sides state a contributor-protocol version: the hub advertises its own on `auth_ok`, and the relay declares `relay_protocol_version` in `auth_response`. Since [#2547](https://github.com/kubestellar/hive/issues/2547) both sides also **compare** them, so an old relay against a new hub is something you are told about rather than something you infer from misbehaviour:

--- a/src/docs/design/master-delivery-wrapped.md
+++ b/src/docs/design/master-delivery-wrapped.md
@@ -40,16 +40,16 @@ spokes there is no delivery path.
 `KubectlReachable()` (`src/pkg/hub/saas_provision.go:368-376`) tests `PullOnly` first and
 returns false unconditionally. Per the operator correction of 2026-08-14,
 `pull_only` is an **intentional architectural boundary on both clusters** — the
-hub is not meant to hold write credentials into `vllm-d` or `a-ks-wec2`. The
+hub is not meant to hold write credentials into the heartbeat-only clusters. The
 field's own doc comment already says this plainly: a pull-only cluster's spokes
 "connect outbound over the heartbeat and nothing here can kubectl into them"
 (`src/pkg/hub/saas_provision.go:207-208`).
 
 | Cluster | Spokes | `pull_only` | Reconcile reach |
 |---|---:|---|---|
-| `hive-oke` (in-cluster) | 22 | no | reachable |
-| `vllm-d` | 39 | **yes, by design** | unreachable |
-| `a-ks-wec2` | 5 | **yes, by design** | unreachable |
+| the hub-reachable cluster (in-cluster) | 22 | no | reachable |
+| a heartbeat-only cluster | 39 | **yes, by design** | unreachable |
+| another heartbeat-only cluster | 5 | **yes, by design** | unreachable |
 | **Total** | **66** | | **22 / 44** |
 
 All 44 are one homogeneous category. There is no "cheap RBAC win" subset.
@@ -430,7 +430,7 @@ Step 4's carrier has direct precedent. `HeartbeatResponse.PendingGateway`
 (`src/pkg/hub/heartbeat.go:1728-1733`) is a **secret** delivered on the heartbeat response,
 queued hub-side (`src/pkg/hub/openrouter.go:217`), drained on delivery, and its doc
 comment states its purpose: "the delivery channel for firewalled/heartbeat-only
-spokes (vllm-d) the hub cannot POST to directly ... The hub sends it once
+spokes (on a heartbeat-only cluster) the hub cannot POST to directly ... The hub sends it once
 (drained on delivery) rather than every beat, since it carries a secret key
 value." Wrapped-master delivery is the same shape with a strictly stronger
 payload — sealed rather than plaintext — so it should reuse the queue/drain
@@ -570,7 +570,7 @@ inconsistency, and it should carry a comment saying so, or a future tidy-up will
 
 ### What still needs owner buy-in
 
-Steps 1–5 need **nothing** from the owners of `vllm-d` or `a-ks-wec2` — no
+Steps 1–5 need **nothing** from the owners of the heartbeat-only clusters — no
 RBAC, no network, no manifest change. The spoke rolls itself via a mechanism
 already in use on those clusters.
 
@@ -578,7 +578,7 @@ Step 6 (the provisioning enrolment value) changes the manifest applied when a
 *new* hive is created on those clusters. That is a provisioning-time change on
 someone else's cluster and **does need their agreement**, though it grants the
 hub no new access — it adds a projected secret to a Deployment the operator
-already applies. → flag for `vllm-d` / `a-ks-wec2` owners.
+already applies. → flag for the heartbeat-only clusters owners.
 
 Nothing in this design asks either cluster to accept inbound connections from
 the hub, grant the hub RBAC, or weaken `pull_only`. That is the point.
@@ -740,7 +740,7 @@ stands unchanged.
   the wrapping private key and the master. Out of scope, and unchanged from
   today.
 - A hostile spoke *operator*. They legitimately control the pod. Unchanged.
-- Cluster admins on `vllm-d` / `a-ks-wec2`. They can read the PVC. Unchanged,
+- Cluster admins on the heartbeat-only clusters. They can read the PVC. Unchanged,
   and inherent to hosting on someone else's cluster.
 
 **Does rotation remain a remedy for a leaked master?**
@@ -975,7 +975,7 @@ hours (§3). These are policy numbers with no derivation behind them and should
 be set by whoever operates the rotation cadence. They must be named constants
 with comments recording the reasoning, per the house standard.
 
-**OQ-5 — Does step 6 have `vllm-d` / `a-ks-wec2` owner agreement?** It changes
+**OQ-5 — Does step 6 have the heartbeat-only clusters owner agreement?** It changes
 the provisioning manifest on their clusters, though it grants the hub no new
 access (§6). Steps 1–5 need nothing from them.
 

--- a/src/docs/governor-thresholds.md
+++ b/src/docs/governor-thresholds.md
@@ -1,0 +1,106 @@
+# Governor mode thresholds and repo-count scaling
+
+The governor picks a mode — **idle → quiet → busy → surge** — by comparing queue depth (actionable issues + open PRs, summed across every repo the hive watches) against three thresholds. The mode then selects each agent's kick cadence, so the thresholds are what decide how hard the hive works.
+
+## The problem the scaling solves
+
+Queue depth scales with how many repos a hive watches; the thresholds did not. A fixed `surge: 20` therefore encoded an implicit repo count:
+
+- A 39-repo hive naturally carries a queue in the low hundreds. Against absolute thresholds it sat in **SURGE permanently**, running the most aggressive cadences even though the per-repo backlog was small. Observed live: queue ~210 against a threshold of 70.
+- A 3-repo hive with the same thresholds would idle through a backlog that is genuinely deep *per repo*.
+
+Every hive with a different repo count had to hand-tune, and re-tune whenever repos were added or archived.
+
+## What happens by default
+
+The **default** thresholds are now per-repo base values, multiplied by the number of repos in `project.repos`:
+
+| | base (1 repo) | 3 repos | 39 repos |
+|---|---:|---:|---:|
+| `surge` | 20 | 60 | 780 |
+| `busy` | 10 | 30 | 390 |
+| `quiet` | 2 | 6 | 78 |
+
+A hive watching one repo (or none — `primary_repo` still counts as one) gets exactly the numbers it got before, so single-repo hives see no change at all.
+
+The effect is that the mode ladder means the same thing at any hive size: **surge is "20+ items per repo"** rather than "20 items, however many repos you watch".
+
+## Choosing a curve
+
+```yaml
+governor:
+  threshold_scaling: linear   # linear (default) | sqrt | none
+```
+
+| Value | Factor | When to use |
+|---|---|---|
+| `linear` (default) | `× repo_count` | The general case. Exactly equivalent to comparing per-repo queue pressure against the base thresholds. |
+| `sqrt` | `× ceil(√repo_count)` | Hives whose queue depth does not grow linearly with repo count — many small, quiet repos alongside a few busy ones. Reaches surge sooner than linear. |
+| `none` | `× 1` | Treat the thresholds as absolute queue depths. This is the behavior from before scaling existed. |
+
+For 39 repos, `linear` surges at 780 and `sqrt` at 140 (`ceil(√39) = 7`). Note that `sqrt` and `linear` are identical at 1 and 2 repos and only separate from 3 onward, because the ceiling cannot produce a factor below 2 until 5 repos.
+
+An unrecognized value is rejected at config load.
+
+## Explicit thresholds always win
+
+A threshold you set yourself is used **verbatim and never scaled**:
+
+```yaml
+governor:
+  modes:
+    surge:
+      threshold: 300     # used as-is on a 39-repo hive, not 300 × 39
+```
+
+So a hive that already hand-tuned its way around this problem keeps working unchanged, and dragging a handle in the dashboard's **Governor → Thresholds** tab pins that threshold to an absolute value.
+
+A threshold of `0` counts as **unset**, not as an explicit zero — mode entries often exist only to carry cadences, and a literal zero would put every non-empty queue in that mode.
+
+### Mixing explicit and scaled thresholds
+
+Because explicit values are not scaled, mixing them with scaled defaults can put the ladder out of order. On a 39-repo hive:
+
+```yaml
+governor:
+  modes:
+    surge:
+      threshold: 70      # explicit → stays 70
+    # busy and quiet unset → scaled to 390 and 78
+```
+
+`busy` (390) now sits **above** `surge` (70). The governor tests surge first and returns on the first threshold the queue exceeds, so BUSY becomes unreachable. The governor logs a warning naming all three effective values when it detects this:
+
+```
+governor mode thresholds are not in descending order — a mode is unreachable
+  surge=70 busy=390 quiet=78 repo_count=39 threshold_scaling=linear
+```
+
+It warns rather than silently reordering, because the inversion comes from a number you set. Either set all three explicitly, or remove the explicit one so all three scale together.
+
+## Known limitation: ACMM packs seed explicit thresholds
+
+ACMM level packs (`v2/pkg/config/packs/level-*.yaml`) write `surge`/`busy`/`quiet` thresholds into `governor.modes` when a level is applied — for example L4–L6 seed `surge: 10, busy: 5, quiet: 2`.
+
+Those land in config as **explicit** values, and nothing distinguishes a pack-seeded default from one an operator typed. So on a hive that has applied an ACMM level, **scaling does not engage**: rule "explicit always wins" takes precedence and the pack's absolute numbers are used.
+
+If your hive applied a pack and you want scaling, clear the thresholds you want scaled:
+
+```yaml
+governor:
+  modes:
+    surge:
+      # threshold omitted → scaled default
+      scanner: 5m
+```
+
+Resolving this properly requires tracking whether a threshold was pack-seeded or operator-set, which config does not currently record.
+
+## Where the numbers are shown
+
+The dashboard governor gauge and the **Governor → Thresholds** settings tab both display the **effective** thresholds — the same values the governor laddered on, resolved through the same code path — along with the watched repo count. The settings sliders edit the base values.
+
+## Related
+
+- [Agent configuration → Cadences and the governor](agent-configuration.md#cadences-and-the-governor)
+- Issue [#3498](https://github.com/kubestellar/hive/issues/3498)

--- a/src/docs/manual-provisioning.md
+++ b/src/docs/manual-provisioning.md
@@ -150,14 +150,30 @@ kustomize edit set image ghcr.io/kubestellar/hive=ghcr.io/kubestellar/hive:<tag>
 kubectl apply -k .
 ```
 
-**On OpenShift.** The standalone overlay does not create a Route or grant the
-`anyuid` SCC. The
-[`overlays/openshift`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift)
-overlay supplies exactly those two OpenShift-only deltas — a `Route` exposing the
-`dashboard` port (3002) and the `anyuid` SCC RoleBinding the pod needs (it starts
-as root to set up the ACMM iptables and chown the PVC). A standalone deployment
-on OpenShift composes **standalone + these platform deltas**. Two equivalent
-ways:
+**On OpenShift.** The standalone overlay does not create a Route or grant any
+SCC. Two more pieces supply the OpenShift-only deltas:
+
+- The
+  [`overlays/openshift`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift)
+  overlay — a `Route` exposing the `dashboard` port (3002) and the `anyuid` SCC
+  RoleBinding (the pod starts as root to set up the ACMM iptables and chown the
+  PVC).
+- The
+  [`overlays/openshift-netadmin`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift-netadmin)
+  overlay — the dedicated `hive-netadmin` SCC + RoleBinding, applied **once by a
+  cluster-admin**. This one is **not optional on OpenShift**: the base
+  deployment *adds* capabilities (`NET_ADMIN` + the su-exec set), and no stock
+  SCC — `anyuid` included — permits adding them, so without this grant the pod
+  is rejected at admission (`unable to validate against any security context
+  constraint`). The SCC is `restricted-v2` loosened by exactly what the base
+  deployment declares (see the manifest comments) — not `privileged`. See
+  [Does your cluster grant NET_ADMIN?](#does-your-cluster-grant-net_admin) to
+  check your cluster first.
+
+A standalone deployment on OpenShift composes **standalone + these platform
+deltas** (the SCC grant is applied separately, by cluster-admin:
+`oc apply -k src/deploy/kustomize/overlays/openshift-netadmin`). For the
+app-level overlays, two equivalent ways:
 
 - **Combined overlay (recommended):** in your own copy of the standalone
   `kustomization.yaml`, add `route.yaml` and `anyuid-scc-rolebinding.yaml` as
@@ -198,19 +214,113 @@ forced-proxy-egress `iptables` REDIRECT that enforces the ACMM MITM egress proxy
 - **Cluster GRANTS `NET_ADMIN` (most do):** nothing to do — the full,
   fail-closed egress gate comes up automatically. This is the recommended
   default.
-- **Cluster DENIES `NET_ADMIN`:** the entrypoint **FATALs** (exit 1, refusing to
-  start with an advisory-only capability model — `src/deploy/entrypoint.sh`
-  around line 770) and the pod crash-loops. The **only** escape hatch is setting
-  `HIVE_PROXY_ADVISORY_OK=true`, provided by the **commented-out**
-  [`patch-advisory-mode.yaml`](https://github.com/kubestellar/hive/blob/v4/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml)
-  — uncomment its `- path: patch-advisory-mode.yaml` line in your
-  `kustomization.yaml`.
+- **Cluster DENIES `NET_ADMIN`:** the entrypoint **FATALs** (refusing to start
+  with an advisory-only capability model — `src/deploy/entrypoint.sh`) and the
+  pod crash-loops, with **exit code 77** when the missing capability is the
+  cause (see the checks section below for what 77 means and how to read it).
+  Two remedies:
+  1. **Grant the capability (preferred — full gate).** On OpenShift, a
+     cluster-admin applies the
+     [`overlays/openshift-netadmin`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift-netadmin)
+     overlay (dedicated `hive-netadmin` SCC + RoleBinding); on plain Kubernetes,
+     ensure the namespace's Pod Security admission allows the capability (see
+     below).
+  2. **Deliberately run degraded.** Set `HIVE_PROXY_ADVISORY_OK=true` via the
+     **commented-out**
+     [`patch-advisory-mode.yaml`](https://github.com/kubestellar/hive/blob/v4/src/deploy/kustomize/overlays/standalone/patch-advisory-mode.yaml)
+     — uncomment its `- path: patch-advisory-mode.yaml` line in your
+     `kustomization.yaml`.
 
-**Security trade-off (one honest sentence):** in advisory-only mode the MITM
-egress gate is best-effort rather than enforced, so an agent holding a raw token
-could bypass the proxy policy — acceptable for a single-tenant hive whose owner
-controls every repo and agent, but not a control you should silently disable on a
-shared one.
+**Security trade-off (one honest sentence):** in advisory-only mode forced
+proxy egress becomes advisory — the MITM egress gate is best-effort rather than
+enforced, so an agent holding a raw token could bypass the proxy policy —
+acceptable for a single-tenant hive whose owner controls every repo and agent,
+but not a control you should silently disable on a shared one.
+
+### Does your cluster grant NET_ADMIN?
+
+The question every firewalled-cluster adopter hits first. Three checks, from
+authoritative to empirical — run them **before** deploying and you'll know
+which of the two remedies above (if either) you need.
+
+**1. Ask OpenShift directly (`scc-subject-review` dry-run).** This is the
+authoritative answer: it evaluates the *actual* pod spec against every SCC the
+`hive` ServiceAccount can use, without creating anything:
+
+```bash
+# From your (placeholder-swapped) overlay directory — build the real manifests
+# and let OpenShift judge them as the hive SA:
+kubectl kustomize . > /tmp/hive-rendered.yaml
+oc -n hive policy scc-subject-review -z hive -f /tmp/hive-rendered.yaml
+```
+
+Read the `ALLOWED BY` column for the `hive` Deployment: an SCC name (e.g.
+`hive-netadmin`) means admission will pass under that SCC; `<none>` means **no
+SCC admits the pod** — deploying now would leave the ReplicaSet stuck with
+`unable to validate against any security context constraint` events and no pod
+at all.
+
+**2. Which SCCs allow the capability, and who can use them?**
+
+```bash
+# SCCs that would permit adding NET_ADMIN (allowedCapabilities contains it or "*"),
+# plus privileged SCCs (which imply all capabilities):
+oc get scc -o json | jq -r '.items[]
+  | select(((.allowedCapabilities // []) | index("NET_ADMIN") or index("*"))
+           or .allowPrivilegedContainer == true)
+  | .metadata.name'
+
+# For each candidate, is the hive SA allowed to use it?
+oc adm policy who-can use scc/hive-netadmin
+# Look for system:serviceaccount:hive:hive in the output.
+```
+
+On a stock cluster the first query returns only `privileged` / `node-exporter`
+style SCCs the hive SA cannot (and should not) use — that is the "cluster
+denies" case until `hive-netadmin` is applied. On plain Kubernetes (no SCC API)
+the equivalent gate is [Pod Security admission](https://kubernetes.io/docs/concepts/security/pod-security-standards/):
+check `kubectl get ns hive -o jsonpath='{.metadata.labels}'` — an
+`pod-security.kubernetes.io/enforce: baseline` (or `restricted`) label denies
+`NET_ADMIN`; the capability needs `privileged` enforcement (or no enforcement)
+on the namespace.
+
+**3. The 30-second probe pod (empirical).** Runs as the same ServiceAccount,
+requests only `NET_ADMIN`, prints its own capability bounding set, and exits:
+
+```bash
+oc -n hive run netadmin-probe --restart=Never --image=busybox:1.36 \
+  --overrides='{"spec":{"serviceAccountName":"hive","containers":[{"name":"netadmin-probe","image":"busybox:1.36","command":["sh","-c","grep CapBnd /proc/self/status"],"securityContext":{"capabilities":{"drop":["ALL"],"add":["NET_ADMIN"]}}}]}}'
+oc -n hive logs netadmin-probe && oc -n hive delete pod netadmin-probe
+```
+
+Two outcomes: the `run` is **rejected at admission** (`unable to validate
+against any security context constraint`) — the cluster denies the capability;
+or the pod runs and prints `CapBnd: 0000000000001000` — bit 12 (`0x1000`,
+`CAP_NET_ADMIN`) is set and the cluster grants it. (The probe requests *only*
+`NET_ADMIN`; the real deployment also adds the su-exec capability set, so treat
+check 1 as the authoritative pre-flight and this probe as the quick smoke
+test.)
+
+**Reading the failure after the fact — the exit-77 signature.** If the pod was
+*admitted* but the container's bounding set still lacks `CAP_NET_ADMIN` (e.g.
+an admission webhook stripped the capability, or a hand-edited manifest dropped
+the request), the entrypoint refuses to start and exits with a **distinct code,
+77** (sysexits.h `EX_NOPERM`), after logging:
+
+```
+[entrypoint] FATAL: refusing to start. Grant NET_ADMIN + install iptables, or set HIVE_PROXY_ADVISORY_OK=true to deliberately run in advisory mode.
+[entrypoint] FATAL: CAP_NET_ADMIN is not in the container's capability bounding set — exiting 77 (EX_NOPERM) rather than 1.
+```
+
+```bash
+kubectl -n hive get pod -l app.kubernetes.io/name=hive \
+  -o jsonpath='{.items[0].status.containerStatuses[0].lastState.terminated.exitCode}'
+```
+
+`77` means precisely "grant the capability (or opt into advisory mode)"; any
+*other* cause of the same FATAL (no `iptables` binary, netfilter lock
+contention) exits `1`, since granting `NET_ADMIN` would not fix those. Full
+rationale: [net-admin-requirement.md](net-admin-requirement.md).
 
 ### Firewall / egress (locked-down cluster)
 

--- a/src/docs/net-admin-requirement.md
+++ b/src/docs/net-admin-requirement.md
@@ -113,7 +113,31 @@ securityContext:
       - NET_ADMIN
 ```
 
-(The bundled `src/deploy/k8s/deployment.yaml` already declares this.)
+(The bundled `src/deploy/k8s/deployment.yaml` already declares this.) If the
+namespace enforces Pod Security admission, note that the `baseline` and
+`restricted` profiles deny `NET_ADMIN` — the namespace needs `privileged`
+enforcement (or none) for the request to be honored.
+
+### OpenShift
+
+Declaring the capability is not enough on OpenShift: an SCC must *permit*
+adding it, and no stock SCC (`anyuid` included) does — the pod is rejected at
+admission (`unable to validate against any security context constraint`). A
+cluster-admin applies the bundled
+[`overlays/openshift-netadmin`](https://github.com/kubestellar/hive/tree/v4/src/deploy/kustomize/overlays/openshift-netadmin)
+overlay once:
+
+```bash
+oc apply -k src/deploy/kustomize/overlays/openshift-netadmin
+```
+
+It creates a dedicated `hive-netadmin` SCC — `restricted-v2` loosened by
+exactly the capabilities the deployment declares, not `privileged` — plus the
+`use` RBAC scoped to the `hive` ServiceAccount. To check ahead of time whether
+your cluster already grants the capability (and to read the exit-77 signature
+after the fact), see the
+[Does your cluster grant NET_ADMIN?](manual-provisioning.md#does-your-cluster-grant-net_admin)
+checks in the provisioning guide.
 
 ### Rootless Podman
 

--- a/src/pkg/agent/agent_unit_test.go
+++ b/src/pkg/agent/agent_unit_test.go
@@ -290,7 +290,7 @@ func TestSeedPauseStateUnit(t *testing.T) {
 	}, slog.Default(), ProjectContext{})
 
 	now := time.Now()
-	m.SeedPauseState("scanner", now, "test-trigger", "test-reason")
+	m.SeedPauseState("scanner", now, "test-trigger", "test-reason", "test-user")
 	m.mu.RLock()
 	agent := m.agents["scanner"]
 	m.mu.RUnlock()

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -119,18 +119,26 @@ var defaultTmuxSocket string
 const BreakerTrigger = "fleet-breaker"
 
 type AgentProcess struct {
-	Name              string
-	ID                string
-	Config            config.AgentConfig
-	State             ProcessState
-	PID               int
-	UID               int
-	StartedAt         *time.Time
-	LastKick          *time.Time
-	Paused            bool
-	PausedAt          time.Time
-	PausedReason      string
-	PausedTrigger     string
+	Name          string
+	ID            string
+	Config        config.AgentConfig
+	State         ProcessState
+	PID           int
+	UID           int
+	StartedAt     *time.Time
+	LastKick      *time.Time
+	Paused        bool
+	PausedAt      time.Time
+	PausedReason  string
+	PausedTrigger string
+	// PausedBy is the acting user behind the pause when one is known — the
+	// authenticated dashboard user for a dashboard-api pause, empty for
+	// system-initiated pauses (login-detector, fleet-breaker, acmm-pack).
+	// It exists because trigger+reason alone made a deliberate owner
+	// quiesce indistinguishable from a malfunction days later (#4041): the
+	// audit log had the actor, but nothing the UI or the fleet view reads
+	// carried it.
+	PausedBy          string
 	PinnedCLI         string
 	PinnedModel       string
 	ModelOverride     string
@@ -4626,6 +4634,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		PausedAt:        a.PausedAt,
 		PausedReason:    a.PausedReason,
 		PausedTrigger:   a.PausedTrigger,
+		PausedBy:        a.PausedBy,
 		PinnedCLI:       a.PinnedCLI,
 		PinnedModel:     a.PinnedModel,
 		ModelOverride:   a.ModelOverride,
@@ -4895,7 +4904,7 @@ var (
 )
 
 const (
-	sharedConfigDesiredMode    = 0o660
+	sharedConfigDesiredMode = 0o660
 	// agyDefaultEffort is the reasoning effort passed alongside agy's --model.
 	// agy requires --effort whenever --model is given and otherwise ignores the
 	// model entirely; "low" is the effort agy defaults to on its own, so this
@@ -6553,7 +6562,18 @@ func (m *Manager) KillSession(name string) error {
 	return nil
 }
 
+// Pause pauses an agent with no attributed acting user — the right call for
+// system-initiated pauses (login-detector, fleet-breaker, acmm-pack, state
+// restore of a pause whose actor is unknown). A pause performed on behalf of
+// a person goes through PauseBy so provenance survives (#4041).
 func (m *Manager) Pause(name, trigger, reason string) error {
+	return m.PauseBy(name, trigger, reason, "")
+}
+
+// PauseBy pauses an agent and records WHO asked for it. `by` is the acting
+// user (the authenticated dashboard user for a dashboard-api pause); empty
+// means "no human actor" — never fabricate one.
+func (m *Manager) PauseBy(name, trigger, reason, by string) error {
 	m.mu.Lock()
 
 	agent, ok := m.agents[name]
@@ -6566,6 +6586,7 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 	agent.PausedAt = time.Now()
 	agent.PausedReason = reason
 	agent.PausedTrigger = trigger
+	agent.PausedBy = by
 	if agent.State == StateRunning {
 		if agent.cancel != nil {
 			agent.cancel()
@@ -6586,6 +6607,7 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 		"name", name,
 		"trigger", trigger,
 		"reason", reason,
+		"by", by,
 		"backend", agent.Config.Backend,
 		"restart_count", agent.RestartCount,
 	)
@@ -6604,13 +6626,14 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 	return nil
 }
 
-func (m *Manager) SeedPauseState(name string, pausedAt time.Time, trigger, reason string) {
+func (m *Manager) SeedPauseState(name string, pausedAt time.Time, trigger, reason, by string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if agent, ok := m.agents[name]; ok {
 		agent.PausedAt = pausedAt
 		agent.PausedTrigger = trigger
 		agent.PausedReason = reason
+		agent.PausedBy = by
 	}
 }
 
@@ -6641,6 +6664,7 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	agent.PausedAt = time.Time{}
 	agent.PausedReason = ""
 	agent.PausedTrigger = ""
+	agent.PausedBy = ""
 	needsRelaunch := agent.State == StatePaused
 	if m.agentSandboxEnabledLocked(agent) {
 		if needsRelaunch {

--- a/src/pkg/agent/manager_coverage2_test.go
+++ b/src/pkg/agent/manager_coverage2_test.go
@@ -1259,7 +1259,7 @@ func TestGetOutput_PrefersPaneOverBuffer(t *testing.T) {
 func TestSeedPauseState_NotFound(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	// Should not panic
-	m.SeedPauseState("nonexistent", time.Now(), "test", "test")
+	m.SeedPauseState("nonexistent", time.Now(), "test", "test", "")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/agent/pause_provenance_test.go
+++ b/src/pkg/agent/pause_provenance_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// #4041: pause provenance — WHO paused WHAT WHEN — must live on the agent
+// state itself, not only in the audit log, or a deliberate owner quiesce is
+// indistinguishable from a malfunction days later.
+
+func provenanceTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return NewManager(map[string]config.AgentConfig{
+		"scanner": {Backend: "claude"},
+	}, discardLogger(), ProjectContext{})
+}
+
+// Positive control: a pause performed on behalf of a person records the actor.
+func TestPauseBy_RecordsActor(t *testing.T) {
+	m := provenanceTestManager(t)
+	if err := m.PauseBy("scanner", "dashboard-api", "manual pause", "bketelsen"); err != nil {
+		t.Fatalf("PauseBy: %v", err)
+	}
+	status, err := m.GetStatus("scanner")
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if !status.Paused {
+		t.Fatal("agent not paused")
+	}
+	if status.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q", status.PausedBy, "bketelsen")
+	}
+	if status.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", status.PausedTrigger, "dashboard-api")
+	}
+	if status.PausedReason != "manual pause" {
+		t.Errorf("PausedReason = %q, want %q", status.PausedReason, "manual pause")
+	}
+	if status.PausedAt.IsZero() {
+		t.Error("PausedAt not set")
+	}
+}
+
+// A system-initiated pause must never fabricate a human actor.
+func TestPause_LeavesActorEmpty(t *testing.T) {
+	m := provenanceTestManager(t)
+	if err := m.Pause("scanner", "login-detector", "login required detected"); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	status, _ := m.GetStatus("scanner")
+	if status.PausedBy != "" {
+		t.Errorf("PausedBy = %q, want empty for a system-initiated pause", status.PausedBy)
+	}
+	if status.PausedTrigger != "login-detector" {
+		t.Errorf("PausedTrigger = %q, want %q", status.PausedTrigger, "login-detector")
+	}
+}
+
+// Resume clears the whole provenance set — stale WHO/WHY/WHEN on a running
+// agent would be worse than none.
+func TestResume_ClearsProvenance(t *testing.T) {
+	m := provenanceTestManager(t)
+	if err := m.PauseBy("scanner", "dashboard-api", "manual pause", "bketelsen"); err != nil {
+		t.Fatalf("PauseBy: %v", err)
+	}
+	// The relaunch half may fail without a live tmux; provenance is cleared
+	// before it either way, and that clearing is the contract under test.
+	_ = m.Resume(context.Background(), "scanner", "dashboard-api", "manual resume")
+	status, _ := m.GetStatus("scanner")
+	if status.Paused {
+		t.Fatal("agent still paused after Resume")
+	}
+	if status.PausedBy != "" || status.PausedTrigger != "" || status.PausedReason != "" {
+		t.Errorf("provenance not cleared: by=%q trigger=%q reason=%q",
+			status.PausedBy, status.PausedTrigger, status.PausedReason)
+	}
+	if !status.PausedAt.IsZero() {
+		t.Errorf("PausedAt not cleared: %v", status.PausedAt)
+	}
+}
+
+// SeedPauseState (the boot-restore path) replays the persisted actor, so
+// provenance survives restarts instead of downgrading to anonymous.
+func TestSeedPauseState_ReplaysActor(t *testing.T) {
+	m := provenanceTestManager(t)
+	pausedAt := time.Date(2026, 8, 14, 16, 10, 10, 0, time.UTC)
+	m.SeedPauseState("scanner", pausedAt, "dashboard-api", "manual pause", "bketelsen")
+	status, _ := m.GetStatus("scanner")
+	if status.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q", status.PausedBy, "bketelsen")
+	}
+	if !status.PausedAt.Equal(pausedAt) {
+		t.Errorf("PausedAt = %v, want %v", status.PausedAt, pausedAt)
+	}
+}

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -1927,6 +1927,71 @@ type SensingConfig struct {
 	PullbackSeconds    int      `yaml:"pullback_seconds"`
 }
 
+// defaultLoginPatterns is the built-in login-detector pattern set (#3959):
+// every entry matches a CLI's own login CHROME, never ordinary English, so an
+// agent is not paused for merely reading or discussing an auth error. It is a
+// named var (not an inline literal in applyDefaults) so persistence can
+// recognize "this list IS the default" and skip writing it — see
+// redactedForPersist, which is what keeps the default set from being
+// materialized into saved configs and pinned there forever (#4041).
+var defaultLoginPatterns = []string{
+	// claude: exact prompt strings from Claude Code's login screens.
+	"Please run /login",
+	"Not logged in",
+	// gh / copilot / gemini: the commands their CLIs tell the user to run.
+	"gh auth login",
+	"claude login",
+	"copilot auth",
+	"gemini auth login",
+	// bob: its API-key entry prompts.
+	"Enter Bob-Shell API Key",
+	"Paste your API key here",
+}
+
+// legacyDefaultLoginPatterns is the pre-#3959 default login-detector list,
+// frozen verbatim (values AND order) as it shipped from the day the field
+// existed until da9f6ff2. It exists only for migration: every hive that saved
+// its config in that window has this exact list materialized as explicit
+// values (Save() marshals defaults along with everything else), which
+// permanently defeated the #3959 defaults fix because defaults only apply to
+// an empty list (#4041). Never extend or reorder it — a byte-identical match
+// is the evidence that the list carries no operator intent.
+var legacyDefaultLoginPatterns = []string{
+	"please log in",
+	"authentication required",
+	"not logged in",
+	"login required",
+	"session expired",
+	"token expired",
+	"unauthorized.*401",
+	"gh auth login",
+	"claude login",
+	"copilot auth",
+}
+
+// IsLegacyDefaultLoginPatterns reports whether list is byte-identical (same
+// entries, same order) to the pre-#3959 default login-pattern set. Exported
+// because cmd/hive's legacy state-overrides migration replays a persisted
+// sensing_login list over the loaded config, which is the same materialized-
+// defaults hazard applyDefaults migrates in the config file itself (#4041).
+func IsLegacyDefaultLoginPatterns(list []string) bool {
+	return stringSlicesEqual(list, legacyDefaultLoginPatterns)
+}
+
+// stringSlicesEqual is an exact element-wise comparison (no normalization —
+// migration must only ever fire on a byte-identical match).
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 type HealthConfig struct {
 	HealthcheckInterval int  `yaml:"healthcheck_interval"`
 	RestartCooldown     int  `yaml:"restart_cooldown"`
@@ -3650,6 +3715,19 @@ func (c *Config) applyDefaults() {
 			"resets [0-9]+(:[0-9]+)?[aApP][mM]",
 		}
 	}
+	// #4041: hives that saved their config while the pre-#3959 defaults were
+	// in effect have that generic list MATERIALIZED as explicit values in
+	// their persisted config (Save() marshals the whole struct, defaults
+	// included), and "defaults only apply to an empty list" meant the #3959
+	// fix could never reach them — a live hosted hive's quality agent flapped
+	// on `(?i)copilot auth` for days with restart_count 83. A list that is
+	// byte-identical to the old default set expresses no operator intent, so
+	// treat it as "default": drop it and let the corrected defaults apply. A
+	// list that differs in ANY way is an operator's, and stays verbatim.
+	if IsLegacyDefaultLoginPatterns(c.Governor.Sensing.LoginPatterns) {
+		log.Printf("[config] migrating login_patterns: persisted list matches the pre-#3959 defaults verbatim — dropping it so the corrected defaults apply (customized lists are never touched)")
+		c.Governor.Sensing.LoginPatterns = nil
+	}
 	if len(c.Governor.Sensing.LoginPatterns) == 0 {
 		// Each pattern must match the CLI's own login CHROME, never ordinary
 		// English. The login-detector matches these against the agent's PANE —
@@ -3664,19 +3742,7 @@ func (c *Config) applyDefaults() {
 		// at kick time, so exposure scales with kick frequency. Reproduced on
 		// demand by typing "authentication required" into a healthy agent's
 		// input box (unsubmitted — just rendered on the pane) and kicking it.
-		c.Governor.Sensing.LoginPatterns = []string{
-			// claude: exact prompt strings from Claude Code's login screens.
-			"Please run /login",
-			"Not logged in",
-			// gh / copilot / gemini: the commands their CLIs tell the user to run.
-			"gh auth login",
-			"claude login",
-			"copilot auth",
-			"gemini auth login",
-			// bob: its API-key entry prompts.
-			"Enter Bob-Shell API Key",
-			"Paste your API key here",
-		}
+		c.Governor.Sensing.LoginPatterns = append([]string(nil), defaultLoginPatterns...)
 	}
 	if c.Governor.Sensing.TTLSeconds == 0 {
 		c.Governor.Sensing.TTLSeconds = defaultSensingTTLSeconds
@@ -4570,6 +4636,18 @@ func (c *Config) redactedForPersist() *Config {
 	cp := *c
 	cp.OTel.Headers = envRedactedHeaders(cp.OTel.Headers)
 	cp.Tracing.Headers = envRedactedHeaders(cp.Tracing.Headers)
+	// #4041: never write the built-in login-pattern defaults as explicit
+	// values. applyDefaults fills LoginPatterns on load, so by save time the
+	// in-memory list always LOOKS explicit; marshaling it pins today's
+	// defaults into the persisted config, where "defaults only apply to an
+	// empty list" freezes them forever — exactly how every pre-#3959 hive
+	// ended up stuck with the false-positive-prone generic list. A list equal
+	// to the current defaults expresses no operator intent: persist it as
+	// absent so future default fixes reach existing hives. An operator-
+	// customized list differs from the defaults and is persisted verbatim.
+	if stringSlicesEqual(cp.Governor.Sensing.LoginPatterns, defaultLoginPatterns) {
+		cp.Governor.Sensing.LoginPatterns = nil
+	}
 	return &cp
 }
 

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"math"
 	"net/netip"
 	"net/url"
 	"os"
@@ -957,6 +958,155 @@ type GovernorConfig struct {
 	// so turning this off never removes the operator's ability to answer "which
 	// backend/model produced this PR?".
 	AttributionTrailer *bool `yaml:"attribution_trailer,omitempty"`
+
+	// ThresholdScaling selects how the DEFAULT mode thresholds scale with the
+	// number of repos this hive watches (#3498). An explicit
+	// governor.modes.<mode>.threshold is never scaled — it always wins.
+	//
+	// Valid values: "" (= linear) | linear | sqrt | none.
+	// See EffectiveThreshold for the resolution rules and why linear is the
+	// default.
+	ThresholdScaling string `yaml:"threshold_scaling,omitempty" json:"threshold_scaling,omitempty"`
+}
+
+// Default governor mode thresholds, in queue items (actionable issues + open
+// PRs). These are the per-repo BASE values: a hive watching one repo surges at
+// 20 items, and EffectiveThreshold scales them for hives watching more.
+//
+// They live here rather than in pkg/governor because two callers need the same
+// answer — the governor, which decides the mode, and the dashboard gauge, which
+// tells the operator which numbers produced it. Those were independently
+// duplicated constants before #3498; scaling one and not the other would have
+// made the gauge disagree with the governor it describes.
+const (
+	DefaultThresholdSurge = 20
+	DefaultThresholdBusy  = 10
+	DefaultThresholdQuiet = 2
+)
+
+// Threshold scaling curves (GovernorConfig.ThresholdScaling).
+const (
+	// ThresholdScalingLinear multiplies the base threshold by the repo count.
+	// This is the default, and it is exactly equivalent to comparing PER-REPO
+	// queue pressure against the base thresholds — the mode ladder then means
+	// the same thing on a 3-repo hive as on a 39-repo one. The issue considered
+	// normalizing the queue instead (queue / repos) and rejected it because it
+	// changes the number the dashboard displays; scaling the thresholds reaches
+	// the same outcome while leaving the displayed queue depth alone.
+	ThresholdScalingLinear = "linear"
+	// ThresholdScalingSqrt multiplies by ceil(sqrt(repos)) instead — a gentler
+	// curve for hives whose queue depth does not grow linearly with repo count
+	// (many small, quiet repos alongside a few busy ones). It reaches SURGE
+	// sooner than linear does.
+	ThresholdScalingSqrt = "sqrt"
+	// ThresholdScalingNone disables scaling: the base thresholds are used as
+	// absolute queue depths, which is the behavior from before #3498.
+	ThresholdScalingNone = "none"
+)
+
+// ValidThresholdScalings are the accepted threshold_scaling values. "" means
+// "unset", which resolves to linear.
+var ValidThresholdScalings = map[string]bool{
+	"":                     true,
+	ThresholdScalingLinear: true,
+	ThresholdScalingSqrt:   true,
+	ThresholdScalingNone:   true,
+}
+
+// ValidateThresholdScaling reports whether v is an accepted scaling curve.
+func ValidateThresholdScaling(v string) bool { return ValidThresholdScalings[v] }
+
+// ThresholdScalingMode returns the configured scaling curve with its default
+// applied. Unset means linear: the whole point of #3498 is that a hive which
+// says nothing gets thresholds matched to its size.
+//
+// An unrecognized value also resolves to linear rather than silently disabling
+// scaling — config load rejects bad values outright, so reaching this with one
+// means the value came from a path that skipped validation, and defaulting to
+// the documented behavior beats defaulting to "off" for reasons nobody can see.
+func (g GovernorConfig) ThresholdScalingMode() string {
+	switch g.ThresholdScaling {
+	case ThresholdScalingSqrt:
+		return ThresholdScalingSqrt
+	case ThresholdScalingNone:
+		return ThresholdScalingNone
+	default:
+		return ThresholdScalingLinear
+	}
+}
+
+// ScaleThreshold applies a scaling curve to a base threshold for a hive
+// watching repoCount repos.
+//
+// repoCount is clamped to at least 1, so a hive with no repos: list — or one
+// that watches a single repo via primary_repo — gets the unscaled base rather
+// than a threshold of zero, which would put every non-empty queue in SURGE.
+func ScaleThreshold(base, repoCount int, scaling string) int {
+	if base <= 0 {
+		return base
+	}
+	if repoCount < 1 {
+		repoCount = 1
+	}
+	switch scaling {
+	case ThresholdScalingNone:
+		return base
+	case ThresholdScalingSqrt:
+		return base * int(math.Ceil(math.Sqrt(float64(repoCount))))
+	default:
+		return base * repoCount
+	}
+}
+
+// EffectiveThreshold resolves the queue depth at which modeName engages, for a
+// hive watching repoCount repos.
+//
+// Resolution, in order:
+//
+//  1. An explicit governor.modes.<mode>.threshold greater than zero wins and is
+//     returned UNSCALED. An operator who hand-tuned a number meant that number,
+//     and #3498 is explicit that hand-tuned hives see no behavior change.
+//  2. Otherwise the base default for surge/busy/quiet, scaled by repo count.
+//  3. Any other mode name has no threshold (0). computeMode only ladders over
+//     surge/busy/quiet — idle is the fallthrough — so a threshold on `idle` or
+//     on a custom mode has never been consulted.
+//
+// A threshold of exactly zero in config counts as UNSET, matching the existing
+// thresholdFor behavior: mode entries frequently exist only to carry cadences,
+// and a literal zero would put every non-empty queue in that mode.
+//
+// KNOWN LIMITATION: ACMM packs seed explicit thresholds (pkg/config/packs/
+// level-*.yaml write surge/busy/quiet), and rule 1 cannot tell a pack-seeded
+// default from a hand-tuned value. On a hive that applied a pack, scaling
+// therefore does not engage. See docs/governor-thresholds.md.
+func (g GovernorConfig) EffectiveThreshold(modeName string, repoCount int) int {
+	if mode, ok := g.Modes[modeName]; ok && mode.Threshold > 0 {
+		return mode.Threshold
+	}
+
+	var base int
+	switch modeName {
+	case "surge":
+		base = DefaultThresholdSurge
+	case "busy":
+		base = DefaultThresholdBusy
+	case "quiet":
+		base = DefaultThresholdQuiet
+	default:
+		return 0
+	}
+
+	return ScaleThreshold(base, repoCount, g.ThresholdScalingMode())
+}
+
+// RepoCount returns the number of repos this hive watches, for threshold
+// scaling. A hive with an empty repos: list still watches at least its primary
+// repo, so the floor is 1.
+func (p ProjectConfig) RepoCount() int {
+	if n := len(p.Repos); n > 0 {
+		return n
+	}
+	return 1
 }
 
 // AttributionTrailerEnabled reports whether the visible attribution trailer on
@@ -3836,6 +3986,9 @@ func (c *Config) validate() error {
 		return err
 	} else {
 		c.Dashboard.SnapshotFrameAncestors = normalized
+	}
+	if !ValidateThresholdScaling(c.Governor.ThresholdScaling) {
+		return fmt.Errorf("governor: invalid threshold_scaling %q (must be linear, sqrt, or none)", c.Governor.ThresholdScaling)
 	}
 	for modeName, mode := range c.Governor.Modes {
 		for agentName, cadence := range mode.Cadences {

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -558,6 +558,11 @@ type ProjectConfig struct {
 	// GitHub-only configs are unaffected. Use ForgeKind() to read it with the
 	// default applied.
 	Forge string `yaml:"forge,omitempty"`
+	// IssueFilter gates which open issues agents may initiate work on: the
+	// require_labels allow-list ("only work issues labeled X"). The exclude
+	// polarity is Governor.Labels.Exempt, which wins on conflict. Absent/empty
+	// = no filtering, the pre-existing behavior. See IssueFilterConfig.
+	IssueFilter IssueFilterConfig `yaml:"issue_filter,omitempty"`
 }
 
 const (

--- a/src/pkg/config/issue_filter.go
+++ b/src/pkg/config/issue_filter.go
@@ -1,0 +1,85 @@
+package config
+
+import "strings"
+
+// IssueFilterConfig gates which open issues agents may INITIATE work on: an
+// issue is eligible only if it carries at least one of RequireLabels (the
+// allow-list polarity). It exists for projects whose maintainers gate
+// automation on an explicit approval label: without an allowlist, a hive works
+// every actionable issue in its repos, which surprises owners who expected
+// "only issues I have labeled for automation".
+//
+// This is deliberately ONLY the require half. The EXCLUDE polarity ("never
+// touch issues labeled X") already exists as governor.labels.exempt — the
+// dashboard's Governor Configuration → Labels tab — plus the permanent
+// hold/do-not-merge labels. There is exactly one exclusion mechanism and one
+// require mechanism; this type does not duplicate the former. Precedence is
+// by construction: fetchIssues applies hold/exempt BEFORE this filter, so an
+// issue that is both exempt and approval-labeled stays excluded.
+//
+// The filter is enforced at enumeration (github.Client.fetchIssues) — the
+// same choice point as the hold/exempt checks and upstream of the
+// duplicate-PR claim guard — so a refused issue never enters the actionable
+// set, never reaches a kick prompt, and cannot be re-selected by a confused
+// or prompt-injected agent re-listing the repo.
+//
+// Semantics:
+//   - Absent/empty: current behavior EXACTLY — every issue is eligible. There
+//     is no default-on filtering; that would silently idle every existing
+//     hive whose repos use no approval label.
+//   - Non-empty RequireLabels: an issue is eligible only if it carries AT
+//     LEAST ONE of these labels (case-insensitive exact match).
+//
+// Matching is deliberately EXACT (case-insensitive), not substring/prefix:
+// a require-gate that prefix-matched would over-admit ("approved-for-review"
+// admitting under "approved"), which is the unsafe direction for an approval
+// gate. The exempt/hold checks keep their own looser matching; this filter
+// does not change them.
+type IssueFilterConfig struct {
+	RequireLabels []string `yaml:"require_labels,omitempty" json:"require_labels,omitempty"`
+}
+
+// IsZero reports whether the filter is absent/empty — i.e. no filtering at all.
+func (f IssueFilterConfig) IsZero() bool {
+	return len(f.RequireLabels) == 0
+}
+
+// Equal reports whether two filters are identical (order-sensitive, exact).
+// Used by the heartbeat reconcile to decide whether a hub push changes anything.
+func (f IssueFilterConfig) Equal(o IssueFilterConfig) bool {
+	if len(f.RequireLabels) != len(o.RequireLabels) {
+		return false
+	}
+	for i := range f.RequireLabels {
+		if f.RequireLabels[i] != o.RequireLabels[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// labelMatches reports a case-insensitive exact match, ignoring surrounding
+// whitespace on the configured side (a stray space in YAML must not silently
+// disable an approval gate).
+func labelMatches(configured, actual string) bool {
+	return strings.EqualFold(strings.TrimSpace(configured), actual)
+}
+
+// Admits reports whether an issue carrying the given labels is eligible for
+// agent work under this filter. An empty filter admits everything (see the
+// type comment for the full contract). Exclusion is not this method's job:
+// governor.labels.exempt and the hold labels are applied by the caller before
+// this filter, which is what makes "exclude wins" hold by construction.
+func (f IssueFilterConfig) Admits(labels []string) bool {
+	if len(f.RequireLabels) == 0 {
+		return true
+	}
+	for _, l := range labels {
+		for _, req := range f.RequireLabels {
+			if labelMatches(req, l) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/src/pkg/config/issue_filter_test.go
+++ b/src/pkg/config/issue_filter_test.go
@@ -1,0 +1,84 @@
+package config
+
+import "testing"
+
+// TestIssueFilterAdmits_AbsentAdmitsAll is the regression pin: a zero-value
+// filter must admit EVERYTHING — including issues with no labels at all —
+// because absent config means "current behavior exactly". A default-on filter
+// would silently idle every existing hive.
+func TestIssueFilterAdmits_AbsentAdmitsAll(t *testing.T) {
+	var f IssueFilterConfig
+	if !f.IsZero() {
+		t.Fatal("zero-value filter must report IsZero")
+	}
+	for _, labels := range [][]string{nil, {}, {"bug"}, {"approved"}, {"anything", "else"}} {
+		if !f.Admits(labels) {
+			t.Errorf("zero-value filter refused labels %v — absent config must change nothing", labels)
+		}
+	}
+}
+
+// TestIssueFilterAdmits_RequireLabel: positive control (the labeled issue IS
+// admitted) plus the refusal for the unlabeled one — so the test cannot pass
+// by refusing everything.
+func TestIssueFilterAdmits_RequireLabel(t *testing.T) {
+	f := IssueFilterConfig{RequireLabels: []string{"approved-for-agents"}}
+	if f.IsZero() {
+		t.Fatal("filter with require_labels must not report IsZero")
+	}
+	if !f.Admits([]string{"bug", "approved-for-agents"}) {
+		t.Error("positive control failed: issue carrying the required label was refused")
+	}
+	if !f.Admits([]string{"Approved-For-Agents"}) {
+		t.Error("label match must be case-insensitive")
+	}
+	if f.Admits([]string{"bug"}) {
+		t.Error("issue without the required label was admitted")
+	}
+	if f.Admits(nil) {
+		t.Error("unlabeled issue was admitted despite require_labels")
+	}
+	// Exact match only: a prefix must NOT satisfy an approval gate.
+	if f.Admits([]string{"approved-for-agents-maybe"}) {
+		t.Error("prefix-extended label satisfied the require gate — matching must be exact")
+	}
+}
+
+// TestIssueFilterAdmits_RequireAnyOf: multiple require labels are OR'd.
+func TestIssueFilterAdmits_RequireAnyOf(t *testing.T) {
+	f := IssueFilterConfig{RequireLabels: []string{"clanker", "triage-accepted"}}
+	if !f.Admits([]string{"triage-accepted"}) {
+		t.Error("issue with the second of two require labels was refused")
+	}
+	if !f.Admits([]string{"clanker"}) {
+		t.Error("issue with the first of two require labels was refused")
+	}
+	if f.Admits([]string{"triage"}) {
+		t.Error("near-miss label admitted")
+	}
+}
+
+// TestIssueFilterAdmits_ConfigWhitespaceTrimmed: a stray space in YAML must not
+// silently disable an approval gate.
+func TestIssueFilterAdmits_ConfigWhitespaceTrimmed(t *testing.T) {
+	f := IssueFilterConfig{RequireLabels: []string{" approved "}}
+	if !f.Admits([]string{"approved"}) {
+		t.Error("whitespace-padded configured label failed to match")
+	}
+}
+
+func TestIssueFilterEqual(t *testing.T) {
+	a := IssueFilterConfig{RequireLabels: []string{"x", "y"}}
+	if !a.Equal(IssueFilterConfig{RequireLabels: []string{"x", "y"}}) {
+		t.Error("identical filters reported unequal")
+	}
+	if a.Equal(IssueFilterConfig{RequireLabels: []string{"x"}}) {
+		t.Error("filters with different require sets reported equal")
+	}
+	if (IssueFilterConfig{}).Equal(a) {
+		t.Error("zero filter reported equal to a configured one")
+	}
+	if !(IssueFilterConfig{}).Equal(IssueFilterConfig{}) {
+		t.Error("two zero filters reported unequal")
+	}
+}

--- a/src/pkg/config/login_patterns_migration_test.go
+++ b/src/pkg/config/login_patterns_migration_test.go
@@ -1,0 +1,265 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// These tests pin the #4041 login_patterns de-materialization contract.
+//
+// Background: Save() marshals the whole Config, and applyDefaults() fills
+// LoginPatterns on every load — so any hive that ever saved its config had
+// the era's DEFAULT login patterns written into the persisted file as if an
+// operator had chosen them. Because defaults only apply to an empty list,
+// the #3959 defaults fix (generic English phrases → CLI login chrome) never
+// reached those hives: on a live hosted hive the quality agent flapped on
+// `(?i)copilot auth` for days (restart_count 83 at first trip) because the
+// pre-#3959 list was pinned in its PVC runtime config.
+//
+// The contract:
+//  1. a persisted list byte-identical to the pre-#3959 defaults is migrated
+//     (dropped, so the current defaults apply);
+//  2. a customized list is preserved verbatim — operator intent is sacred;
+//  3. a list equal to the CURRENT defaults loads unchanged;
+//  4. Save() never writes a default-equal list, so future default fixes
+//     reach existing hives instead of being pinned out forever.
+
+// legacyLoginPatternsYAML is the exact materialized block observed in the
+// frostyard incident's /data/hive.yaml.runtime (#4041) — the pre-#3959
+// defaults, including the `copilot auth` entry the second hosted hive's
+// quality agent flapped on as `(?i)copilot auth`.
+const legacyLoginPatternsYAML = `
+        - please log in
+        - authentication required
+        - not logged in
+        - login required
+        - session expired
+        - token expired
+        - unauthorized.*401
+        - gh auth login
+        - claude login
+        - copilot auth
+`
+
+func writeSensingConfig(t *testing.T, loginPatternsYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	sensing := ""
+	if loginPatternsYAML != "" {
+		sensing = "  sensing:\n    login_patterns:\n" + loginPatternsYAML
+	}
+	content := `project:
+  org: testorg
+  repos:
+    - repo1
+github:
+  app_id: 3568013
+agents:
+  scanner:
+    backend: claude
+governor:
+` + sensing
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	return path
+}
+
+func assertPatternsEqual(t *testing.T, got, want []string, context string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %d patterns %v, want %d %v", context, len(got), got, len(want), want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s: pattern[%d] = %q, want %q (got %v)", context, i, got[i], want[i], got)
+		}
+	}
+}
+
+// The frostyard regression: a persisted list byte-identical to the pre-#3959
+// defaults must be treated as "default" and migrated so the corrected
+// defaults apply.
+func TestLoginPatterns_LegacyDefaultListMigratedToCurrentDefaults(t *testing.T) {
+	path := writeSensingConfig(t, legacyLoginPatternsYAML)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"legacy-default list must migrate to the current defaults")
+	// The generic English phrases that caused the false positives must be gone.
+	for _, p := range cfg.Governor.Sensing.LoginPatterns {
+		switch p {
+		case "authentication required", "please log in", "session expired",
+			"token expired", "login required", "unauthorized.*401":
+			t.Fatalf("pre-#3959 generic pattern %q survived migration", p)
+		}
+	}
+}
+
+// Operator intent is sacred: ANY deviation from the legacy default set —
+// even removing a single entry — means the list is customized and must load
+// verbatim.
+func TestLoginPatterns_CustomizedListPreservedVerbatim(t *testing.T) {
+	cases := map[string]struct {
+		yaml string
+		want []string
+	}{
+		"fully custom": {
+			yaml: "        - my own pattern\n        - another one\n",
+			want: []string{"my own pattern", "another one"},
+		},
+		"legacy list minus one entry": {
+			yaml: `
+        - please log in
+        - authentication required
+        - not logged in
+        - login required
+        - session expired
+        - token expired
+        - unauthorized.*401
+        - gh auth login
+        - claude login
+`,
+			want: []string{"please log in", "authentication required", "not logged in",
+				"login required", "session expired", "token expired", "unauthorized.*401",
+				"gh auth login", "claude login"},
+		},
+		"legacy list plus one entry": {
+			yaml: legacyLoginPatternsYAML + "        - operator addition\n",
+			want: append(append([]string(nil), legacyDefaultLoginPatterns...), "operator addition"),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeSensingConfig(t, tc.yaml)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, tc.want,
+				"customized list must be preserved verbatim")
+		})
+	}
+}
+
+// A list equal to the CURRENT defaults loads unchanged — migration only ever
+// fires on the legacy set.
+func TestLoginPatterns_NewDefaultListLoadsUnchanged(t *testing.T) {
+	var b strings.Builder
+	for _, p := range defaultLoginPatterns {
+		b.WriteString("        - \"" + p + "\"\n")
+	}
+	path := writeSensingConfig(t, b.String())
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"current-default list must load unchanged")
+}
+
+// The materialization source itself: Save() must not write a default-equal
+// login_patterns list into the persisted config. This is what lets a FUTURE
+// defaults fix reach existing hives — the exact mechanism that pinned the
+// pre-#3959 list into every hive's PVC config forever.
+func TestSave_DoesNotMaterializeDefaultLoginPatterns(t *testing.T) {
+	path := writeSensingConfig(t, "")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Defaults are live in memory (the detector needs them)...
+	assertPatternsEqual(t, cfg.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"defaults must be applied in memory")
+
+	// Keep the PVC-runtime side-write inside the sandboxed temp dir.
+	origRuntime := RuntimeConfigFile
+	RuntimeConfigFile = filepath.Join(t.TempDir(), "hive.yaml.runtime")
+	defer func() { RuntimeConfigFile = origRuntime }()
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading saved config: %v", err)
+	}
+	var persisted struct {
+		Governor struct {
+			Sensing struct {
+				LoginPatterns []string `yaml:"login_patterns"`
+			} `yaml:"sensing"`
+		} `yaml:"governor"`
+	}
+	if err := yaml.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("parsing saved config: %v", err)
+	}
+	if len(persisted.Governor.Sensing.LoginPatterns) != 0 {
+		t.Fatalf("Save materialized default login_patterns into the config: %v",
+			persisted.Governor.Sensing.LoginPatterns)
+	}
+
+	// ...and a reload still gets the (current) defaults.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	assertPatternsEqual(t, reloaded.Governor.Sensing.LoginPatterns, defaultLoginPatterns,
+		"defaults must apply again after a save/reload cycle")
+}
+
+// Positive control for the persist rule: a genuinely customized list IS
+// written, survives the round-trip verbatim, and is never migrated.
+func TestSave_PersistsCustomizedLoginPatternsVerbatim(t *testing.T) {
+	path := writeSensingConfig(t, "")
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	custom := []string{"Device code: [A-Z0-9]{4}-[A-Z0-9]{4}", "my-forge login"}
+	cfg.Governor.Sensing.LoginPatterns = append([]string(nil), custom...)
+
+	origRuntime := RuntimeConfigFile
+	RuntimeConfigFile = filepath.Join(t.TempDir(), "hive.yaml.runtime")
+	defer func() { RuntimeConfigFile = origRuntime }()
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	assertPatternsEqual(t, reloaded.Governor.Sensing.LoginPatterns, custom,
+		"customized list must survive a save/reload cycle verbatim")
+}
+
+// IsLegacyDefaultLoginPatterns is exported for cmd/hive's state-overrides
+// replay; pin its exactness here so the migration can only ever fire on a
+// byte-identical match.
+func TestIsLegacyDefaultLoginPatterns_Exactness(t *testing.T) {
+	if !IsLegacyDefaultLoginPatterns(append([]string(nil), legacyDefaultLoginPatterns...)) {
+		t.Fatal("exact legacy list not recognized")
+	}
+	reordered := append([]string(nil), legacyDefaultLoginPatterns...)
+	reordered[0], reordered[1] = reordered[1], reordered[0]
+	if IsLegacyDefaultLoginPatterns(reordered) {
+		t.Fatal("reordered list must NOT be treated as the legacy defaults")
+	}
+	if IsLegacyDefaultLoginPatterns(legacyDefaultLoginPatterns[:len(legacyDefaultLoginPatterns)-1]) {
+		t.Fatal("truncated list must NOT be treated as the legacy defaults")
+	}
+	if IsLegacyDefaultLoginPatterns(nil) {
+		t.Fatal("empty list must NOT be treated as the legacy defaults")
+	}
+	if IsLegacyDefaultLoginPatterns(defaultLoginPatterns) {
+		t.Fatal("the CURRENT defaults must NOT be treated as the legacy defaults")
+	}
+}

--- a/src/pkg/config/threshold_scaling_test.go
+++ b/src/pkg/config/threshold_scaling_test.go
@@ -1,0 +1,289 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Governor mode thresholds gate a queue depth that grows with the number of
+// repos a hive watches, so a fixed threshold encodes an implicit repo count
+// (#3498). These tests pin the scaling curves and, more importantly, the
+// resolution order — an explicitly configured threshold must never be scaled.
+
+func TestScaleThreshold_Linear(t *testing.T) {
+	tests := []struct {
+		repos int
+		base  int
+		want  int
+	}{
+		{repos: 1, base: 20, want: 20},
+		{repos: 3, base: 20, want: 60},
+		{repos: 39, base: 20, want: 780},
+		{repos: 39, base: 10, want: 390},
+		{repos: 39, base: 2, want: 78},
+		// A hive with no repos configured still watches its primary repo.
+		{repos: 0, base: 20, want: 20},
+		{repos: -5, base: 20, want: 20},
+	}
+	for _, tt := range tests {
+		if got := ScaleThreshold(tt.base, tt.repos, ThresholdScalingLinear); got != tt.want {
+			t.Errorf("ScaleThreshold(%d, %d, linear) = %d, want %d", tt.base, tt.repos, got, tt.want)
+		}
+	}
+}
+
+func TestScaleThreshold_Sqrt(t *testing.T) {
+	tests := []struct {
+		repos int
+		base  int
+		want  int
+	}{
+		{repos: 1, base: 20, want: 20},   // ceil(sqrt(1)) = 1
+		{repos: 3, base: 20, want: 40},   // ceil(sqrt(3)) = 2
+		{repos: 4, base: 20, want: 40},   // ceil(sqrt(4)) = 2
+		{repos: 39, base: 20, want: 140}, // ceil(sqrt(39)) = 7
+	}
+	for _, tt := range tests {
+		if got := ScaleThreshold(tt.base, tt.repos, ThresholdScalingSqrt); got != tt.want {
+			t.Errorf("ScaleThreshold(%d, %d, sqrt) = %d, want %d", tt.base, tt.repos, got, tt.want)
+		}
+	}
+}
+
+// sqrt must never exceed linear, and must be strictly below it once the curves
+// separate — otherwise the option is mislabeled in the config docs and the UI.
+//
+// They TIE at 1 and 2 repos, because ceil(sqrt(2)) == 2: the ceiling cannot
+// produce a factor below 2 until 5 repos, where ceil(sqrt(5)) == 3. Asserting
+// strict inequality everywhere fails at repos=2, which is how this test found
+// the real shape of the curve rather than the one assumed when writing it.
+func TestScaleThreshold_SqrtIsNeverHarsherThanLinear(t *testing.T) {
+	for _, repos := range []int{1, 2, 3, 4, 5, 10, 39, 100} {
+		lin := ScaleThreshold(20, repos, ThresholdScalingLinear)
+		sq := ScaleThreshold(20, repos, ThresholdScalingSqrt)
+		if sq > lin {
+			t.Errorf("repos=%d: sqrt (%d) exceeds linear (%d)", repos, sq, lin)
+		}
+		if sq < 20 {
+			t.Errorf("repos=%d: sqrt (%d) fell below the base threshold", repos, sq)
+		}
+	}
+
+	// Where the curves have separated, the gap must be real and must widen —
+	// that separation is the entire reason sqrt is offered.
+	for _, repos := range []int{3, 5, 10, 39, 100} {
+		lin := ScaleThreshold(20, repos, ThresholdScalingLinear)
+		sq := ScaleThreshold(20, repos, ThresholdScalingSqrt)
+		if sq >= lin {
+			t.Errorf("repos=%d: sqrt (%d) should be strictly below linear (%d)", repos, sq, lin)
+		}
+	}
+}
+
+func TestScaleThreshold_None(t *testing.T) {
+	for _, repos := range []int{1, 3, 39, 500} {
+		if got := ScaleThreshold(20, repos, ThresholdScalingNone); got != 20 {
+			t.Errorf("repos=%d: scaling none = %d, want the base 20", repos, got)
+		}
+	}
+}
+
+// A zero or negative base has no meaningful scaling; multiplying it would still
+// be zero, but returning it untouched keeps "0 means unset" intact for callers.
+func TestScaleThreshold_NonPositiveBaseUnchanged(t *testing.T) {
+	for _, base := range []int{0, -1} {
+		if got := ScaleThreshold(base, 39, ThresholdScalingLinear); got != base {
+			t.Errorf("ScaleThreshold(%d, 39, linear) = %d, want %d", base, got, base)
+		}
+	}
+}
+
+func TestThresholdScalingMode_DefaultsToLinear(t *testing.T) {
+	tests := map[string]string{
+		"":       ThresholdScalingLinear,
+		"linear": ThresholdScalingLinear,
+		"sqrt":   ThresholdScalingSqrt,
+		"none":   ThresholdScalingNone,
+		// Config load rejects these; reaching here means validation was
+		// bypassed, and the documented default beats a silent opt-out.
+		"nonsense": ThresholdScalingLinear,
+		"LINEAR":   ThresholdScalingLinear,
+	}
+	for in, want := range tests {
+		g := GovernorConfig{ThresholdScaling: in}
+		if got := g.ThresholdScalingMode(); got != want {
+			t.Errorf("ThresholdScalingMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// THE core guarantee of #3498: a hand-tuned threshold is returned verbatim.
+// Scaling an operator's explicit 300 by a 39-repo hive would produce 11700 and
+// silently break every hive that already worked around this bug by hand.
+func TestEffectiveThreshold_ExplicitIsNeverScaled(t *testing.T) {
+	g := GovernorConfig{
+		Modes: map[string]ModeConfig{
+			"surge": {Threshold: 300},
+			"busy":  {Threshold: 200},
+			"quiet": {Threshold: 100},
+		},
+	}
+	for _, repos := range []int{1, 39, 500} {
+		if got := g.EffectiveThreshold("surge", repos); got != 300 {
+			t.Errorf("repos=%d: explicit surge = %d, want 300", repos, got)
+		}
+		if got := g.EffectiveThreshold("busy", repos); got != 200 {
+			t.Errorf("repos=%d: explicit busy = %d, want 200", repos, got)
+		}
+		if got := g.EffectiveThreshold("quiet", repos); got != 100 {
+			t.Errorf("repos=%d: explicit quiet = %d, want 100", repos, got)
+		}
+	}
+}
+
+func TestEffectiveThreshold_DefaultsScale(t *testing.T) {
+	g := GovernorConfig{}
+
+	// One repo must reproduce the pre-#3498 numbers exactly.
+	if got := g.EffectiveThreshold("surge", 1); got != 20 {
+		t.Errorf("1-repo surge = %d, want the historical 20", got)
+	}
+	if got := g.EffectiveThreshold("busy", 1); got != 10 {
+		t.Errorf("1-repo busy = %d, want the historical 10", got)
+	}
+	if got := g.EffectiveThreshold("quiet", 1); got != 2 {
+		t.Errorf("1-repo quiet = %d, want the historical 2", got)
+	}
+
+	// The reported hive: 39 repos.
+	if got := g.EffectiveThreshold("surge", 39); got != 780 {
+		t.Errorf("39-repo surge = %d, want 780", got)
+	}
+}
+
+// A one-repo hive must get the historical constants under EVERY curve — the
+// curves only diverge in how they grow, never at the identity point.
+func TestEffectiveThreshold_IdentityAtOneRepoForEveryCurve(t *testing.T) {
+	for _, scaling := range []string{"", ThresholdScalingLinear, ThresholdScalingSqrt, ThresholdScalingNone} {
+		g := GovernorConfig{ThresholdScaling: scaling}
+		if got := g.EffectiveThreshold("surge", 1); got != 20 {
+			t.Errorf("scaling=%q: 1-repo surge = %d, want 20", scaling, got)
+		}
+		if got := g.EffectiveThreshold("busy", 1); got != 10 {
+			t.Errorf("scaling=%q: 1-repo busy = %d, want 10", scaling, got)
+		}
+		if got := g.EffectiveThreshold("quiet", 1); got != 2 {
+			t.Errorf("scaling=%q: 1-repo quiet = %d, want 2", scaling, got)
+		}
+	}
+}
+
+// A mode entry that exists only to carry cadences has Threshold 0. Treating
+// that as an explicit zero would put every non-empty queue in that mode.
+func TestEffectiveThreshold_ZeroMeansUnset(t *testing.T) {
+	g := GovernorConfig{
+		Modes: map[string]ModeConfig{
+			"surge": {Threshold: 0, Cadences: map[string]Cadence{"scanner": "5m"}},
+		},
+	}
+	if got := g.EffectiveThreshold("surge", 3); got != 60 {
+		t.Errorf("threshold 0 with cadences = %d, want the scaled default 60", got)
+	}
+}
+
+// computeMode only ladders over surge/busy/quiet; idle is the fallthrough. A
+// threshold on any other mode has never been consulted and must not start
+// being invented here.
+func TestEffectiveThreshold_UnknownModesHaveNoDefault(t *testing.T) {
+	g := GovernorConfig{}
+	for _, name := range []string{"idle", "", "custom", "unknown"} {
+		if got := g.EffectiveThreshold(name, 39); got != 0 {
+			t.Errorf("EffectiveThreshold(%q) = %d, want 0", name, got)
+		}
+	}
+	// An explicit threshold on a custom mode is still returned, unscaled —
+	// pkg/governor's thresholdFor has always honored one.
+	g.Modes = map[string]ModeConfig{"custom": {Threshold: 7}}
+	if got := g.EffectiveThreshold("custom", 39); got != 7 {
+		t.Errorf("explicit custom threshold = %d, want 7", got)
+	}
+}
+
+// Mixed sources are legal and are the case most likely to surprise: the
+// explicit value stays put while the others scale around it.
+func TestEffectiveThreshold_MixedExplicitAndScaled(t *testing.T) {
+	g := GovernorConfig{Modes: map[string]ModeConfig{"surge": {Threshold: 70}}}
+
+	if got := g.EffectiveThreshold("surge", 39); got != 70 {
+		t.Errorf("explicit surge = %d, want 70", got)
+	}
+	if got := g.EffectiveThreshold("busy", 39); got != 390 {
+		t.Errorf("scaled busy = %d, want 390", got)
+	}
+	// This ladder is inverted (busy above surge); pkg/governor warns about it.
+	// Recorded here so the arithmetic behind that warning is pinned.
+	if g.EffectiveThreshold("busy", 39) <= g.EffectiveThreshold("surge", 39) {
+		t.Fatal("fixture no longer produces the inverted ladder it exists to document")
+	}
+}
+
+func TestEffectiveThreshold_ScalingNoneRestoresAbsoluteBehavior(t *testing.T) {
+	g := GovernorConfig{ThresholdScaling: ThresholdScalingNone}
+	if got := g.EffectiveThreshold("surge", 39); got != 20 {
+		t.Errorf("scaling none on a 39-repo hive = %d, want the absolute 20", got)
+	}
+}
+
+func TestRepoCount_FloorsAtOne(t *testing.T) {
+	if got := (ProjectConfig{}).RepoCount(); got != 1 {
+		t.Errorf("no repos = %d, want 1", got)
+	}
+	if got := (ProjectConfig{Repos: []string{"a", "b", "c"}}).RepoCount(); got != 3 {
+		t.Errorf("3 repos = %d, want 3", got)
+	}
+}
+
+func TestValidateThresholdScaling(t *testing.T) {
+	for _, v := range []string{"", "linear", "sqrt", "none"} {
+		if !ValidateThresholdScaling(v) {
+			t.Errorf("ValidateThresholdScaling(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"Linear", "SQRT", "log", "true", "off", "1"} {
+		if ValidateThresholdScaling(v) {
+			t.Errorf("ValidateThresholdScaling(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestValidate_RejectsBadThresholdScaling(t *testing.T) {
+	c := &Config{
+		Project:  ProjectConfig{Org: "my-org"},
+		GitHub:   GitHubConfig{Token: "t"},
+		Agents:   map[string]AgentConfig{"scanner": {Backend: "claude"}},
+		Governor: GovernorConfig{ThresholdScaling: "logarithmic"},
+	}
+	err := c.validate()
+	if err == nil {
+		t.Fatal("validate() accepted an invalid threshold_scaling")
+	}
+	for _, want := range []string{"threshold_scaling", "logarithmic"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func TestValidate_AcceptsEveryThresholdScaling(t *testing.T) {
+	for _, v := range []string{"", "linear", "sqrt", "none"} {
+		c := &Config{
+			Project:  ProjectConfig{Org: "my-org"},
+			GitHub:   GitHubConfig{Token: "t"},
+			Agents:   map[string]AgentConfig{"scanner": {Backend: "claude"}},
+			Governor: GovernorConfig{ThresholdScaling: v},
+		}
+		if err := c.validate(); err != nil {
+			t.Errorf("validate() rejected threshold_scaling %q: %v", v, err)
+		}
+	}
+}

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -1427,7 +1427,10 @@ func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.deps.AgentMgr.Pause(name, "dashboard-api", "manual pause"); err != nil {
+	// Record the acting user on the pause itself (#4041): the audit log has
+	// always known who clicked, but the agent state did not, so a deliberate
+	// owner mass-pause was indistinguishable from a malfunction days later.
+	if err := s.deps.AgentMgr.PauseBy(name, "dashboard-api", "manual pause", requestUser(r)); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -126,6 +126,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/governor", s.handleGovernorConfigGet)
 	s.mux.HandleFunc("PUT /api/config/governor/sensing", s.handleGovernorSensing)
 	s.mux.HandleFunc("PUT /api/config/governor/thresholds", s.handleGovernorThresholds)
+	s.mux.HandleFunc("PUT /api/config/governor/threshold-scaling", s.handleGovernorThresholdScaling)
 	s.mux.HandleFunc("PUT /api/config/governor/labels", s.handleGovernorLabels)
 	s.mux.HandleFunc("PUT /api/config/governor/budget", s.handleGovernorBudget)
 	s.mux.HandleFunc("POST /api/config/governor/budget/reset", s.handleGovernorBudgetReset)
@@ -410,6 +411,10 @@ func (s *Server) saveConfig() error {
 	}
 	if s.deps.Governor != nil {
 		s.deps.Governor.UpdateConfig(s.deps.Config.Governor)
+		// The dashboard can add or remove repos, which moves every scaled
+		// default threshold (#3498). Without this, a repo change would not
+		// reach the governor until the next process restart.
+		s.deps.Governor.SetRepoCount(s.deps.Config.Project.RepoCount())
 	}
 	return nil
 }
@@ -4002,6 +4007,18 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	// The raw map above is what the operator SET (0 = unset). The governor
+	// ladders on the resolved values, which for an unset mode are the defaults
+	// scaled by repo count (#3498). Send both, so the settings panel can show
+	// the numbers actually in force next to the ones being edited instead of
+	// falling back to its own copy of the unscaled defaults.
+	repoCount := cfg.Project.RepoCount()
+	effectiveThresholds := map[string]int{
+		"quiet": cfg.Governor.EffectiveThreshold("quiet", repoCount),
+		"busy":  cfg.Governor.EffectiveThreshold("busy", repoCount),
+		"surge": cfg.Governor.EffectiveThreshold("surge", repoCount),
+	}
+
 	// Build full org/repo paths
 	org := cfg.Project.Org
 	repos := make([]string, 0, len(cfg.Project.Repos))
@@ -4037,12 +4054,15 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 	}
 
 	jsonResponse(w, map[string]interface{}{
-		"agents":      agents,
-		"thresholds":  thresholds,
-		"labels":      cfg.Governor.Labels.Exempt,
-		"holdLabels":  github.HoldLabels,
-		"repos":       repos,
-		"primaryRepo": primaryRepo,
+		"agents":              agents,
+		"thresholds":          thresholds,
+		"effectiveThresholds": effectiveThresholds,
+		"thresholdScaling":    cfg.Governor.ThresholdScalingMode(),
+		"repoCount":           repoCount,
+		"labels":              cfg.Governor.Labels.Exempt,
+		"holdLabels":          github.HoldLabels,
+		"repos":               repos,
+		"primaryRepo":         primaryRepo,
 		"budget": map[string]interface{}{
 			"totalTokens": cfg.Governor.Budget.TotalTokens,
 			"periodDays":  cfg.Governor.Budget.PeriodDays,
@@ -4275,6 +4295,51 @@ func (s *Server) handleGovernorThresholds(w http.ResponseWriter, r *http.Request
 	}
 
 	s.auditFromRequest(r, "config_governor_thresholds", auditDetail("section", "thresholds"), "")
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// handleGovernorThresholdScaling sets how the DEFAULT mode thresholds scale
+// with the hive's repo count (#3498).
+//
+// It is a separate route from handleGovernorThresholds because that one's body
+// is a flat map[string]int of mode name to threshold; a string curve does not
+// fit it, and widening it to map[string]any would put a parse branch on the
+// path every threshold drag already takes.
+func (s *Server) handleGovernorThresholdScaling(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+
+	var body struct {
+		ThresholdScaling string `json:"thresholdScaling"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	scaling := sanitizeString(body.ThresholdScaling)
+	// Same gate as config.validate, so the write path cannot persist a value
+	// that fails the next config load.
+	if !config.ValidateThresholdScaling(scaling) {
+		jsonError(w, "thresholdScaling must be one of: linear, sqrt, none (or empty for the default)", http.StatusBadRequest)
+		return
+	}
+	s.deps.Config.Governor.ThresholdScaling = scaling
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after threshold scaling update", "error", err)
+	}
+
+	// Changing the curve moves every scaled threshold, so re-evaluate now
+	// rather than leaving the hive on the old ladder until the next eval tick —
+	// matching what a threshold drag already does.
+	if s.deps.EnumerateFunc != nil {
+		go s.deps.EnumerateFunc()
+	}
+
+	s.auditFromRequest(r, "config_governor_threshold_scaling", auditDetail("section", "thresholdScaling"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -667,7 +667,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	// github.ibm.com hive for github.com. ResolvedBaseURL falls back to the api_url
 	// host in exactly that case (mirrors HostLabel).
 	githubBaseURL := cfg.GitHub.ResolvedBaseURL()
-	jsonResponse(w, map[string]interface{}{
+	resp := map[string]interface{}{
 		"org":       cfg.Project.Org,
 		"repos":     cfg.Project.Repos,
 		"ai_author": cfg.Project.AIAuthor,
@@ -681,7 +681,15 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"hub_url":             cfg.Hub.URL,
 		"hive_id":             cfg.HiveID,
 		"github_base_url":     githubBaseURL,
-	})
+	}
+	// The active project.issue_filter, read-only: which issues agents may
+	// initiate work on, by label. Omitted entirely when no filter is
+	// configured so the payload (and the UI note keyed off it) stays quiet
+	// for the ordinary unfiltered hive.
+	if !cfg.Project.IssueFilter.IsZero() {
+		resp["issue_filter"] = cfg.Project.IssueFilter
+	}
+	jsonResponse(w, resp)
 }
 
 func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
@@ -4061,8 +4069,13 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		"repoCount":           repoCount,
 		"labels":              cfg.Governor.Labels.Exempt,
 		"holdLabels":          github.HoldLabels,
-		"repos":               repos,
-		"primaryRepo":         primaryRepo,
+		// requireLabels is the OPPOSITE polarity from "labels" (exempt):
+		// project.issue_filter.require_labels — when non-empty, agents may
+		// ONLY initiate work on issues carrying at least one of them. Edited
+		// on the same Labels tab so operators have one place for label policy.
+		"requireLabels": cfg.Project.IssueFilter.RequireLabels,
+		"repos":         repos,
+		"primaryRepo":   primaryRepo,
 		"budget": map[string]interface{}{
 			"totalTokens": cfg.Governor.Budget.TotalTokens,
 			"periodDays":  cfg.Governor.Budget.PeriodDays,
@@ -4349,40 +4362,63 @@ func (s *Server) handleGovernorLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Both label polarities save through this one endpoint (the Labels tab
+	// edits both). POINTER-typed so an absent key means "unchanged" — a save
+	// that only touched the require list must not wipe the exempt list to
+	// empty, and vice versa.
 	var body struct {
-		Labels []string `json:"labels"`
+		Labels        *[]string `json:"labels"`
+		RequireLabels *[]string `json:"require_labels"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
-	if err := validateGovernorLabels(body.Labels); err != nil {
-		jsonError(w, err.Error(), http.StatusBadRequest)
-		return
+	if body.Labels != nil {
+		if err := validateGovernorLabels(*body.Labels); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if body.RequireLabels != nil {
+		if err := validateGovernorLabels(*body.RequireLabels); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
-	filtered := make([]string, 0, len(body.Labels))
-	for _, l := range body.Labels {
-		isPermanent := false
-		for _, h := range github.HoldLabels {
-			if l == h {
-				isPermanent = true
-				break
+	if body.Labels != nil {
+		filtered := make([]string, 0, len(*body.Labels))
+		for _, l := range *body.Labels {
+			isPermanent := false
+			for _, h := range github.HoldLabels {
+				if l == h {
+					isPermanent = true
+					break
+				}
+			}
+			for _, p := range github.PermanentExemptLabels {
+				if l == p {
+					isPermanent = true
+					break
+				}
+			}
+			if !isPermanent {
+				filtered = append(filtered, l)
 			}
 		}
-		for _, p := range github.PermanentExemptLabels {
-			if l == p {
-				isPermanent = true
-				break
-			}
-		}
-		if !isPermanent {
-			filtered = append(filtered, l)
+		s.deps.Config.Governor.Labels.Exempt = filtered
+		if s.deps.GHClient != nil {
+			s.deps.GHClient.SetExemptLabels(filtered)
 		}
 	}
-	s.deps.Config.Governor.Labels.Exempt = filtered
-	if s.deps.GHClient != nil {
-		s.deps.GHClient.SetExemptLabels(filtered)
+	if body.RequireLabels != nil {
+		// The require gate (project.issue_filter): empty list = filter off.
+		// Takes effect on the next enumeration via the scan client.
+		s.deps.Config.Project.IssueFilter.RequireLabels = *body.RequireLabels
+		if s.deps.GHClient != nil {
+			s.deps.GHClient.SetIssueFilter(s.deps.Config.Project.IssueFilter)
+		}
 	}
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after label update", "error", err)

--- a/src/pkg/dashboard/audit.go
+++ b/src/pkg/dashboard/audit.go
@@ -198,12 +198,20 @@ func (s *Server) handleAuditLog(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]any{"entries": entries})
 }
 
-func (s *Server) auditFromRequest(r *http.Request, action, detail, agent string) {
+// requestUser resolves the acting user behind an authenticated dashboard
+// request — the X-Hive-User header set by the auth proxy, or "local" for an
+// unproxied deployment. Shared by the audit log and the pause-provenance
+// path (#4041) so "who did this" is answered identically everywhere.
+func requestUser(r *http.Request) string {
 	user := r.Header.Get("X-Hive-User")
 	if user == "" {
 		user = "local"
 	}
-	s.audit.Log(user, action, detail, agent)
+	return user
+}
+
+func (s *Server) auditFromRequest(r *http.Request, action, detail, agent string) {
+	s.audit.Log(requestUser(r), action, detail, agent)
 }
 
 // AuditLog records an audit event from non-HTTP contexts (governor eval,

--- a/src/pkg/dashboard/contribute_pane_cwd_test.go
+++ b/src/pkg/dashboard/contribute_pane_cwd_test.go
@@ -19,16 +19,28 @@ import (
 // `tmux new-session -c <valid path>` does NOT rescue this: on a server whose own
 // cwd is gone, the pane is still forked into the deleted directory. Only a cd in
 // the launch command itself is reliable, so these tests pin the cd — reading the
-// Justfile rather than restating it, so the recipe cannot regress quietly.
+// Justfile (and, for the container entrypoint below, contributor-agent.sh)
+// rather than restating them, so neither spawn site can regress quietly.
+//
+// The Justfile's local-mode recipe and contributor-relay.sh's relaunchCLI() were
+// fixed first; contributor-agent.sh — the DEFAULT docker/container-mode
+// entrypoint (`just contribute-hive` defaults to mode="docker") — launches the
+// CLI the identical way and is just as exposed, so it gets the identical fix and
+// the identical style of regression test.
 
-func justfileSource(t *testing.T) string {
+func fileSource(t *testing.T, relPath string) string {
 	t.Helper()
-	path := filepath.Join("..", "..", "..", "Justfile")
+	path := filepath.Join("..", "..", "..", relPath)
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(raw)
+}
+
+func justfileSource(t *testing.T) string {
+	t.Helper()
+	return fileSource(t, "Justfile")
 }
 
 // contributeHiveLaunchBlock returns the lines of contribute-hive that create the
@@ -47,11 +59,28 @@ func contributeHiveLaunchBlock(t *testing.T) string {
 	return src[start : start+end]
 }
 
-func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
-	block := contributeHiveLaunchBlock(t)
+// contributorAgentLaunchBlock returns the lines of contributor-agent.sh (the
+// container entrypoint) that create the tmux session and type the CLI launch
+// command into it — the container-mode counterpart of contributeHiveLaunchBlock.
+func contributorAgentLaunchBlock(t *testing.T) string {
+	t.Helper()
+	src := fileSource(t, "bin/contributor-agent.sh")
+	start := strings.Index(src, "Create the tmux session for the agent")
+	if start < 0 {
+		t.Fatal("tmux session creation block not found in contributor-agent.sh")
+	}
+	end := strings.Index(src[start:], "Auto-dismiss startup prompts")
+	if end < 0 {
+		t.Fatal("end of the session creation block not found in contributor-agent.sh")
+	}
+	return src[start : start+end]
+}
 
-	// The load-bearing half: the launch command itself must cd first, so the CLI
-	// starts in a real directory whatever cwd the tmux server hands the pane.
+// requireCdBeforeCmd asserts the send-keys line launching $CMD in block cds
+// first, so the CLI starts in a real directory whatever cwd the tmux server
+// forked the pane into.
+func requireCdBeforeCmd(t *testing.T, block, label string) {
+	t.Helper()
 	sendKeys := ""
 	for _, line := range strings.Split(block, "\n") {
 		if strings.Contains(line, "send-keys") && strings.Contains(line, "$CMD") {
@@ -60,13 +89,21 @@ func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
 		}
 	}
 	if sendKeys == "" {
-		t.Fatal("no send-keys line launching $CMD found in the block")
+		t.Fatalf("%s: no send-keys line launching $CMD found in the block", label)
 	}
 	if !strings.Contains(sendKeys, "cd ") {
-		t.Errorf("the CLI launch must cd into the repo first — a tmux server can hand the pane a DELETED cwd, "+
-			"and a backend that needs a resolvable one then dies seconds into its first task: %s",
-			strings.TrimSpace(sendKeys))
+		t.Errorf("%s: the CLI launch must cd into a durable directory first — a tmux server can hand the pane a "+
+			"DELETED cwd, and a backend that needs a resolvable one then dies seconds into its first task: %s",
+			label, strings.TrimSpace(sendKeys))
 	}
+}
+
+func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
+	block := contributeHiveLaunchBlock(t)
+
+	// The load-bearing half: the launch command itself must cd first, so the CLI
+	// starts in a real directory whatever cwd the tmux server hands the pane.
+	requireCdBeforeCmd(t, block, "Justfile contribute-hive")
 
 	// Defense in depth, correct on a healthy server (but not sufficient alone).
 	if !strings.Contains(block, "new-session") || !strings.Contains(block, "-c ") {
@@ -80,5 +117,34 @@ func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
 	}
 	if !strings.Contains(block, "tmux kill-server") {
 		t.Error("the warning must tell the contributor how to fix a poisoned tmux server")
+	}
+}
+
+// TestContributorAgentPinsPaneWorkingDirectory covers the DEFAULT docker/
+// container-mode spawn site (bin/contributor-agent.sh), which launches the CLI
+// into the exact same kind of tmux pane as the Justfile's local-mode recipe but
+// was originally missed by the #4046 fix: it relied on `-c "$HIVE_WORKSPACE_DIR"`
+// alone, which this suite's sibling test already demonstrates is not sufficient
+// once the tmux server's own cwd is gone.
+//
+// It must also NOT cd into $HIVE_WORKSPACE_DIR itself: that is the very
+// directory agents clone per-task repos into (contribute_ws.go's assignment
+// prompt), so pinning the launch there would recreate the trap the first time
+// that directory is removed and recreated under a still-running server. The cd
+// target must be a directory the task lifecycle never deletes or recreates —
+// $HOME, the container's own home directory.
+func TestContributorAgentPinsPaneWorkingDirectory(t *testing.T) {
+	block := contributorAgentLaunchBlock(t)
+
+	requireCdBeforeCmd(t, block, "contributor-agent.sh")
+
+	if strings.Contains(block, `cd $(printf %q "$HIVE_WORKSPACE_DIR")`) {
+		t.Error("the launch must not cd into $HIVE_WORKSPACE_DIR itself — that is the per-task clone directory " +
+			"the task lifecycle can delete and recreate, which would reintroduce the #4046 trap")
+	}
+
+	// Defense in depth, correct on a healthy server (but not sufficient alone).
+	if !strings.Contains(block, "new-session") || !strings.Contains(block, "-c ") {
+		t.Error("new-session should also pass -c so a healthy server starts the pane in the right directory")
 	}
 }

--- a/src/pkg/dashboard/contribute_pane_cwd_test.go
+++ b/src/pkg/dashboard/contribute_pane_cwd_test.go
@@ -1,0 +1,84 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A contributor's agy backend died ~30s after every task delivery, exiting 2,
+// with no crash, no log and no signal. The cause was not agy, the relay or the
+// prompt: the tmux SERVER had been running since a Go test created it hours
+// earlier, holding a working directory inside a nested clone — v2/pkg/agent,
+// orphaned when the repo renamed v2/ -> src/. Every pane that server forked
+// inherited the deleted cwd ("shell-init: error retrieving current directory"),
+// and agy refuses to run without a resolvable one. claude/codex/goose tolerate
+// it, which is why it looked backend-specific.
+//
+// `tmux new-session -c <valid path>` does NOT rescue this: on a server whose own
+// cwd is gone, the pane is still forked into the deleted directory. Only a cd in
+// the launch command itself is reliable, so these tests pin the cd — reading the
+// Justfile rather than restating it, so the recipe cannot regress quietly.
+
+func justfileSource(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "Justfile")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+// contributeHiveLaunchBlock returns the lines of contribute-hive that create the
+// tmux session and type the CLI launch command into it.
+func contributeHiveLaunchBlock(t *testing.T) string {
+	t.Helper()
+	src := justfileSource(t)
+	start := strings.Index(src, "Create tmux session with the CLI")
+	if start < 0 {
+		t.Fatal("tmux session creation block not found in the Justfile")
+	}
+	end := strings.Index(src[start:], "# Start the relay")
+	if end < 0 {
+		t.Fatal("end of the session creation block not found in the Justfile")
+	}
+	return src[start : start+end]
+}
+
+func TestContributeHivePinsPaneWorkingDirectory(t *testing.T) {
+	block := contributeHiveLaunchBlock(t)
+
+	// The load-bearing half: the launch command itself must cd first, so the CLI
+	// starts in a real directory whatever cwd the tmux server hands the pane.
+	sendKeys := ""
+	for _, line := range strings.Split(block, "\n") {
+		if strings.Contains(line, "send-keys") && strings.Contains(line, "$CMD") {
+			sendKeys = line
+			break
+		}
+	}
+	if sendKeys == "" {
+		t.Fatal("no send-keys line launching $CMD found in the block")
+	}
+	if !strings.Contains(sendKeys, "cd ") {
+		t.Errorf("the CLI launch must cd into the repo first — a tmux server can hand the pane a DELETED cwd, "+
+			"and a backend that needs a resolvable one then dies seconds into its first task: %s",
+			strings.TrimSpace(sendKeys))
+	}
+
+	// Defense in depth, correct on a healthy server (but not sufficient alone).
+	if !strings.Contains(block, "new-session") || !strings.Contains(block, "-c ") {
+		t.Error("new-session should also pass -c so a healthy server starts the pane in the right directory")
+	}
+
+	// A poisoned server must be reported, not silently worked around: without a
+	// message, the next person debugs an unexplained backend exit for hours.
+	if !strings.Contains(block, "pane_current_path") {
+		t.Error("the recipe must check the pane's working directory and warn when it is gone")
+	}
+	if !strings.Contains(block, "tmux kill-server") {
+		t.Error("the warning must tell the contributor how to fix a poisoned tmux server")
+	}
+}

--- a/src/pkg/dashboard/governor_threshold_gauge_test.go
+++ b/src/pkg/dashboard/governor_threshold_gauge_test.go
@@ -1,0 +1,182 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/governor"
+)
+
+// The dashboard gauge explains the governor's current mode with a set of
+// thresholds. Before #3498 it kept its OWN copy of the defaults; once the
+// governor started scaling them by repo count, that copy would have described
+// the mode with numbers that did not produce it.
+
+func gaugeConfig(repos []string, gov config.GovernorConfig) *config.Config {
+	return &config.Config{
+		Project:  config.ProjectConfig{Org: "my-org", Repos: repos},
+		Governor: gov,
+	}
+}
+
+func TestBuildGovernor_ThresholdsScaleWithRepoCount(t *testing.T) {
+	repos := make([]string, 39)
+	for i := range repos {
+		repos[i] = "repo"
+	}
+
+	got := buildGovernor(governor.State{Mode: governor.ModeBusy}, gaugeConfig(repos, config.GovernorConfig{}))
+
+	if got.Thresholds.Surge != 780 {
+		t.Errorf("gauge surge = %d, want 780", got.Thresholds.Surge)
+	}
+	if got.Thresholds.Busy != 390 {
+		t.Errorf("gauge busy = %d, want 390", got.Thresholds.Busy)
+	}
+	if got.Thresholds.Quiet != 78 {
+		t.Errorf("gauge quiet = %d, want 78", got.Thresholds.Quiet)
+	}
+}
+
+// The property that actually matters: whatever the config, the gauge must show
+// exactly the numbers the governor laddered on. This compares the two
+// independently-reached answers rather than restating one of them.
+func TestBuildGovernor_GaugeAgreesWithGovernor(t *testing.T) {
+	cases := []struct {
+		name  string
+		repos int
+		gov   config.GovernorConfig
+	}{
+		{name: "defaults, single repo", repos: 1},
+		{name: "defaults, many repos", repos: 39},
+		{
+			name:  "hand-tuned",
+			repos: 39,
+			gov: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+				"surge": {Threshold: 300}, "busy": {Threshold: 200}, "quiet": {Threshold: 100},
+			}},
+		},
+		{
+			name:  "mixed explicit and scaled",
+			repos: 39,
+			gov:   config.GovernorConfig{Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}}},
+		},
+		{name: "scaling disabled", repos: 39, gov: config.GovernorConfig{ThresholdScaling: config.ThresholdScalingNone}},
+		{name: "sqrt scaling", repos: 39, gov: config.GovernorConfig{ThresholdScaling: config.ThresholdScalingSqrt}},
+		{
+			name:  "mode entry with cadences but no threshold",
+			repos: 12,
+			gov: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+				"busy": {Cadences: map[string]config.Cadence{"scanner": "5m"}},
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repos := make([]string, tc.repos)
+			for i := range repos {
+				repos[i] = "repo"
+			}
+			cfg := gaugeConfig(repos, tc.gov)
+
+			gauge := buildGovernor(governor.State{}, cfg)
+
+			// What the governor itself would use, via the same exported
+			// resolver pkg/governor calls.
+			wantSurge := cfg.Governor.EffectiveThreshold("surge", tc.repos)
+			wantBusy := cfg.Governor.EffectiveThreshold("busy", tc.repos)
+			wantQuiet := cfg.Governor.EffectiveThreshold("quiet", tc.repos)
+
+			if gauge.Thresholds.Surge != wantSurge {
+				t.Errorf("gauge surge = %d, governor uses %d", gauge.Thresholds.Surge, wantSurge)
+			}
+			if gauge.Thresholds.Busy != wantBusy {
+				t.Errorf("gauge busy = %d, governor uses %d", gauge.Thresholds.Busy, wantBusy)
+			}
+			if gauge.Thresholds.Quiet != wantQuiet {
+				t.Errorf("gauge quiet = %d, governor uses %d", gauge.Thresholds.Quiet, wantQuiet)
+			}
+		})
+	}
+}
+
+// A hive with no repos: list still watches its primary repo, so the gauge must
+// show the unscaled defaults rather than zeros.
+func TestBuildGovernor_NoReposShowsUnscaledDefaults(t *testing.T) {
+	got := buildGovernor(governor.State{}, gaugeConfig(nil, config.GovernorConfig{}))
+
+	if got.Thresholds.Surge != 20 || got.Thresholds.Busy != 10 || got.Thresholds.Quiet != 2 {
+		t.Errorf("no-repo gauge = %+v, want the unscaled 20/10/2", got.Thresholds)
+	}
+}
+
+// Editing the repo list from the Repos tab moves every scaled default, so the
+// repo count has to reach the governor at save time (saveConfig re-syncs it,
+// alongside Governor.UpdateConfig). Nothing covered that end to end: the
+// governor tests drive SetRepoCount directly, and the gauge tests never go
+// through a handler.
+//
+// This is asserted through the MODE rather than through a getter, because the
+// mode is what the operator actually sees change, and it only moves if the new
+// count genuinely reached thresholdFor. A save path that persisted the repos
+// but left the governor stale would keep the hive in SURGE — the exact symptom
+// #3498 is about — until the next periodic reload happened to correct it.
+func TestHandleGovernorRepos_ResyncsGovernorRepoCount(t *testing.T) {
+	srv := newFullServer(t)
+	gov := srv.deps.Governor
+
+	// Baseline: the fixture watches one repo, so surge is the unscaled 20 and a
+	// queue of 60 is a surge.
+	gov.Evaluate(60, 0, 0, 0)
+	if got := gov.GetState().Mode; got != governor.ModeSurge {
+		t.Fatalf("baseline mode = %q, want %q — the fixture should start at one repo", got, governor.ModeSurge)
+	}
+
+	body := `{"repos":["testrepo","r2","r3","r4","r5"],"primaryRepo":"testrepo"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Five repos scale surge to 100 and busy to 50, so the SAME queue depth is
+	// now BUSY. Still SURGE means the governor never saw the new count.
+	gov.Evaluate(60, 0, 0, 0)
+	if got := gov.GetState().Mode; got != governor.ModeBusy {
+		t.Errorf("mode after adding repos = %q, want %q — the save path did not re-sync the governor's repo count", got, governor.ModeBusy)
+	}
+}
+
+// The reject path restores the previous repo list and returns before saving, so
+// it must leave the repo count alone too. A governor scaled for a repo set that
+// was never persisted would ladder on thresholds no config explains.
+func TestHandleGovernorRepos_RejectedEditLeavesRepoCountAlone(t *testing.T) {
+	srv := newFullServer(t)
+	gov := srv.deps.Governor
+
+	// No primaryRepo among the submitted repos — the handler 400s and restores.
+	body := `{"repos":["r1","r2","r3","r4","r5"]}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a repo list with no default, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Still the one-repo ladder: a queue of 60 is a surge at surge=20. If the
+	// rejected list had reached the governor, surge would be 100 and this would
+	// come back BUSY.
+	gov.Evaluate(60, 0, 0, 0)
+	if got := gov.GetState().Mode; got != governor.ModeSurge {
+		t.Errorf("mode after a REJECTED repo edit = %q, want %q — a rejected edit must not move the repo count", got, governor.ModeSurge)
+	}
+}

--- a/src/pkg/dashboard/pause_provenance_api_test.go
+++ b/src/pkg/dashboard/pause_provenance_api_test.go
@@ -1,0 +1,110 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// #4041 dashboard-side provenance: pausing via the API must record WHO acted,
+// and the agent payload the frontend renders must carry the full WHO/WHY/WHEN
+// so a paused fleet explains itself.
+
+func doOwnerPostAs(s *Server, path, user string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	markOwnerRequest(req)
+	if user != "" {
+		req.Header.Set("X-Hive-User", user)
+	}
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// Positive control: a pause via the API records the authenticated actor on
+// the agent state itself, not only in the audit log.
+func TestHandlePause_RecordsActingUser(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", "bketelsen"); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	proc, err := deps.AgentMgr.GetStatus("scanner")
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if proc.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q (actor lost on the API pause path)", proc.PausedBy, "bketelsen")
+	}
+	if proc.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", proc.PausedTrigger, "dashboard-api")
+	}
+}
+
+// Without an auth proxy the acting user resolves to "local" — same rule the
+// audit log has always used, so the two surfaces can never disagree.
+func TestHandlePause_NoUserHeaderRecordsLocal(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", ""); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	proc, _ := deps.AgentMgr.GetStatus("scanner")
+	if proc.PausedBy != "local" {
+		t.Errorf("PausedBy = %q, want %q", proc.PausedBy, "local")
+	}
+}
+
+// The agent payload carries the full provenance for the frontend to render.
+func TestAgentPayload_CarriesPauseProvenance(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", "bketelsen"); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	payload := BuildAgentOnlyStatus(deps.Governor.GetState(), deps.AgentMgr.AllStatuses(), deps.Config)
+	var found bool
+	for _, a := range payload.Agents {
+		if a.Name != "scanner" {
+			continue
+		}
+		found = true
+		if !a.Paused {
+			t.Fatal("scanner not paused in payload")
+		}
+		if a.PausedBy != "bketelsen" {
+			t.Errorf("payload PausedBy = %q, want %q", a.PausedBy, "bketelsen")
+		}
+		if a.PausedTrigger != "dashboard-api" {
+			t.Errorf("payload PausedTrigger = %q, want %q", a.PausedTrigger, "dashboard-api")
+		}
+		if a.PausedReason != "manual pause" {
+			t.Errorf("payload PausedReason = %q, want %q", a.PausedReason, "manual pause")
+		}
+		if a.PausedAt == "" {
+			t.Error("payload PausedAt empty")
+		}
+	}
+	if !found {
+		t.Fatal("scanner missing from payload")
+	}
+	_ = s
+}
+
+// Resuming clears the provenance from the payload — a running agent must not
+// wear a stale "paused by ..." explanation.
+func TestAgentPayload_ProvenanceClearedOnResume(t *testing.T) {
+	s, deps := apiServer(t)
+	if rec := doOwnerPostAs(s, "/api/pause/scanner", "bketelsen"); rec.Code != http.StatusOK {
+		t.Fatalf("pause status = %d, want 200", rec.Code)
+	}
+	// A real resume may fail without a live tmux (same tolerance as
+	// TestHandleResume_RealTransitionReportsChangedTrue); provenance clearing
+	// happens before the relaunch half either way.
+	_ = doOwnerPostAs(s, "/api/resume/scanner", "bketelsen")
+	proc, _ := deps.AgentMgr.GetStatus("scanner")
+	if proc.Paused {
+		t.Skip("resume did not complete in this environment")
+	}
+	if proc.PausedBy != "" || proc.PausedTrigger != "" {
+		t.Errorf("provenance not cleared on resume: by=%q trigger=%q", proc.PausedBy, proc.PausedTrigger)
+	}
+	_ = s
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -387,6 +387,7 @@ type FrontendAgent struct {
 	PausedAt         string `json:"pausedAt,omitempty"`
 	PausedReason     string `json:"pausedReason,omitempty"`
 	PausedTrigger    string `json:"pausedTrigger,omitempty"`
+	PausedBy         string `json:"pausedBy,omitempty"`
 	OffByCadence     bool   `json:"offByCadence"`
 	NeedsLogin       bool   `json:"needsLogin"`
 	AuthAvailable    bool   `json:"authAvailable"`

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -15300,7 +15300,7 @@ function burnAreaChart() {
       switch (tab) {
         case 'General': return renderGovGeneral();
         case 'Agents': return renderGovAgents(d.agents || []);
-        case 'Thresholds': return renderGovThresholds(d.thresholds || {});
+        case 'Thresholds': return renderGovThresholds(d);
         case 'Labels': return renderGovLabels(d.labels || [], d.holdLabels || []);
         case 'Repos': return renderGovRepos(d.repos || []);
         case 'Budget': return renderGovBudget(d.budget || {});
@@ -18383,14 +18383,33 @@ function burnAreaChart() {
     const THRESH_BAR_MAX = 200;
     const THRESH_COLORS = { idle: 'var(--green)', quiet: 'var(--blue)', busy: 'var(--yellow)', surge: 'var(--red)' };
 
-    function renderGovThresholds(t) {
+    function renderGovThresholds(d) {
+      const t = (d && d.thresholds) || {};
       const merged = Object.assign({}, t, _configState.dirty.thresholds || {});
       const q = merged.quiet || 2, b = merged.busy || 10, s = merged.surge || 20;
+      // The handles edit BASE thresholds; the governor ladders on the effective
+      // ones, which for an unset mode are the base scaled by repo count (#3498).
+      // Show both — a 39-repo hive surges at 780, far past this bar's range, and
+      // a slider reading 20 with no further explanation would be a lie.
+      const eff = (d && d.effectiveThresholds) || {};
+      const repoCount = (d && d.repoCount) || 1;
+      const scaling = ((d && d.thresholdScaling) || 'linear');
+      const scalingDirty = (_configState.dirty['threshold-scaling'] || {}).thresholdScaling;
+      const activeScaling = scalingDirty !== undefined ? scalingDirty : scaling;
+      const scaled = activeScaling !== 'none' && repoCount > 1;
+      const effNote = scaled && eff.surge
+        ? `<p style="font-size:0.75rem;color:var(--muted);margin:-12px 0 20px">
+             In force for <strong>${repoCount}</strong> watched repos:
+             quiet <strong>${eff.quiet}</strong> · busy <strong>${eff.busy}</strong> · surge <strong>${eff.surge}</strong>.
+             Dragging a handle pins that threshold to an absolute value and opts it out of scaling.
+           </p>`
+        : '';
       const qPct = (q / THRESH_BAR_MAX) * 100;
       const bPct = (b / THRESH_BAR_MAX) * 100;
       const sPct = (s / THRESH_BAR_MAX) * 100;
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:20px">Drag the handles to set issue-count thresholds for governor mode transitions.</p>
+        ${effNote}
         <div class="thresh-bar-wrap">
           <div class="thresh-bar-track" id="thresh-track"
                style="background:linear-gradient(to right,
@@ -18420,6 +18439,13 @@ function burnAreaChart() {
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from idle to quiet mode. Below this count, agents run at their idle cadence.">Quiet</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-quiet" value="${q}" oninput="setThreshFromInput('quiet',this.value)"></div>
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from quiet to busy mode. Agents increase their kick frequency to handle the growing workload.">Busy</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-busy" value="${b}" oninput="setThreshFromInput('busy',this.value)"></div>
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from busy to surge mode. Maximum agent activity — monitor your token budget closely at this level.">Surge</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-surge" value="${s}" oninput="setThreshFromInput('surge',this.value)"></div>
+        </div>
+        <div class="config-field" style="margin-top:20px">
+          <label title="How the thresholds above scale with the number of repos this hive watches. Queue depth grows with repo count, so a fixed threshold means a large hive sits in surge permanently while a small one idles. Linear (default) compares per-repo pressure. Sqrt is gentler for hives with many quiet repos. None uses the numbers above as absolute queue depths. A threshold you set explicitly is never scaled.">Threshold scaling <span class="config-info">i<span class="config-tooltip">Scales the thresholds above by how many repos the hive watches, so the mode ladder means the same thing on a 3-repo hive as on a 39-repo one. Linear multiplies by the repo count (equivalent to comparing per-repo queue pressure). Sqrt multiplies by ceil(sqrt(repos)) — gentler, reaches surge sooner. None uses absolute numbers, the behavior from before this option existed. Thresholds you set by hand are never scaled.</span></span></label>
+          <select id="cfg-threshold-scaling" onchange="markDirty('threshold-scaling','thresholdScaling',this.value)">
+            ${[['linear', 'linear — × repo count (default)'], ['sqrt', 'sqrt — × ceil(√repos), gentler'], ['none', 'none — absolute queue depths']]
+              .map(([v, label]) => `<option value="${v}" ${activeScaling === v ? 'selected' : ''}>${label}</option>`).join('')}
+          </select>
         </div>`;
     }
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4114,6 +4114,25 @@
     let _ocSummaryTailing = true;
     let _ocSummaryScrollTop = null;
 
+    // One human-readable sentence answering WHO paused this agent, WHY and
+    // WHEN — e.g. "paused by bketelsen via dashboard, 3d ago" or
+    // "login-detector: login required detected, 2h ago". #4041: without
+    // this, a deliberately owner-quiesced fleet was indistinguishable from
+    // a malfunctioning one days later.
+    function pauseProvenanceLine(a) {
+      const trigger = a.pausedTrigger || '';
+      const ago = a.pausedAt ? pillAge(a.pausedAt) : '';
+      let line;
+      if (trigger === 'dashboard-api') {
+        line = 'paused by ' + (a.pausedBy || 'an operator') + ' via dashboard';
+      } else if (trigger) {
+        line = trigger + ': ' + (a.pausedReason || 'paused');
+      } else {
+        line = a.pausedReason || 'paused';
+      }
+      return ago ? line + ', ' + ago : line;
+    }
+
     function pauseInfoIcon(a) {
       // A manual/persisted pause carries its reason/trigger even when the
       // current governor mode's cadence is also pause/off — the operator
@@ -4122,8 +4141,10 @@
       if (!a.paused) return '';
       const reason = a.pausedReason || 'unknown';
       const trigger = a.pausedTrigger || 'unknown';
+      const by = a.pausedBy || '';
       const at = a.pausedAt ? new Date(a.pausedAt).toLocaleString() : 'unknown';
-      return `<span class="pause-info" title="${esc(reason)} (${esc(trigger)})">ℹ️<span class="pause-tooltip">Reason: ${esc(reason)}<br>Trigger: ${esc(trigger)}<br>Since: ${esc(at)}</span></span>`;
+      const ago = a.pausedAt ? pillAge(a.pausedAt) : '';
+      return `<span class="pause-info" title="${esc(pauseProvenanceLine(a))}">ℹ️<span class="pause-tooltip">${esc(pauseProvenanceLine(a))}<br>Reason: ${esc(reason)}<br>Trigger: ${esc(trigger)}${by ? '<br>By: ' + esc(by) : ''}<br>Since: ${esc(at)}${ago ? ' (' + esc(ago) + ')' : ''}</span></span>`;
     }
 
     // Volatile stat fields of the focused agent-detail panel, factored out so

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -3101,6 +3101,11 @@
   <div class="repos" id="repos-section">
     <h2 class="section-header-toggle" onclick="toggleSection('repos-section')"><span class="section-chevron">▼</span> Repositories <span id="repos-host-badge" title="Every repo in this hive is on this single GitHub host" style="font-size:0.62em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px"></span> <button class="config-gear" onclick="event.stopPropagation();openConfigDialog('governor',null,'Repos')" title="Manage monitored repositories" style="font-size:0.7em;vertical-align:middle">⚙️</button></h2>
     <div class="section-body">
+      <!-- Read-only view of project.issue_filter: which issues agents may
+           initiate work on, by label. Hidden unless a filter is configured;
+           populated from /api/config at boot. Enforcement lives server-side
+           at enumeration — this note only surfaces the active policy. -->
+      <div id="repos-issue-filter" style="display:none;font-size:0.75rem;color:var(--muted);margin:0 0 8px"></div>
       <div class="repo-grid" id="repos"></div>
     </div>
   </div>
@@ -14664,6 +14669,19 @@ function burnAreaChart() {
       const ocEl = document.getElementById("oc-project-name");
       if (ocEl && repoDisplay) ocEl.textContent = repoDisplay;
       if (repoDisplay) window._primaryRepo = repoDisplay;
+      // Read-only issue-filter note under Repositories. Present in /api/config
+      // only when project.issue_filter is configured (edit it on Governor
+      // Configuration → Labels, "Required labels"); textContent (never
+      // innerHTML) because label names are repo-controlled text.
+      const iflt = cfg.issue_filter || null;
+      const ifltReq = (iflt && iflt.require_labels) || [];
+      if (ifltReq.length) {
+        const note = document.getElementById('repos-issue-filter');
+        if (note) {
+          note.textContent = '🏷️ Issue filter active — agents only work issues labeled: ' + ifltReq.join(', ');
+          note.style.display = '';
+        }
+      }
     }).catch(() => {});
 
     // Initial fetch then SSE — these two are critical for first paint
@@ -15301,7 +15319,7 @@ function burnAreaChart() {
         case 'General': return renderGovGeneral();
         case 'Agents': return renderGovAgents(d.agents || []);
         case 'Thresholds': return renderGovThresholds(d);
-        case 'Labels': return renderGovLabels(d.labels || [], d.holdLabels || []);
+        case 'Labels': return renderGovLabels(d.labels || [], d.holdLabels || [], d.requireLabels || []);
         case 'Repos': return renderGovRepos(d.repos || []);
         case 'Budget': return renderGovBudget(d.budget || {});
         case 'Notifications': return renderGovNotifications(d.notifications || {});
@@ -18515,7 +18533,7 @@ function burnAreaChart() {
       }
     }
 
-    function renderGovLabels(labels, holdLabels) {
+    function renderGovLabels(labels, holdLabels, requireLabels) {
       const permanentLabels = (holdLabels || []).concat(['do-not-merge']);
       const staticList = permanentLabels.map(l =>
         `<div class="config-list-item" style="opacity:0.7"><span>${esc(l)}</span><span style="font-size:0.65rem;color:var(--muted);margin-left:auto;margin-right:8px">permanent</span></div>`
@@ -18523,8 +18541,16 @@ function burnAreaChart() {
       const list = labels.map((l, i) =>
         `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" onclick="removeListItem('labels','list',${i})">✕</button></div>`
       ).join('');
+      // Required labels (allow-list) — the OPPOSITE polarity from the exempt
+      // list above: exempt = "never touch these", required = "ONLY touch
+      // these". Stored as project.issue_filter.require_labels and enforced at
+      // the actionable scan, not just in prompts.
+      const reqList = (requireLabels || []).map((l, i) =>
+        `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" onclick="removeListItem('labels','require',${i})">✕</button></div>`
+      ).join('');
       return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Labels that filter issues from the actionable issues list and PRs from the mergeable PRs list. Agents receive these filtered lists as variable substitutions in their kick prompts.</p>
+        <h4 style="margin:0 0 6px">Exempt labels (deny-list)</h4>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Labels that filter issues <b>out</b> of the actionable issues list and PRs out of the mergeable PRs list — issues carrying one of these are never agent work. Agents receive the filtered lists as variable substitutions in their kick prompts.</p>
         <p style="font-size:0.7rem;color:var(--muted);margin-bottom:8px;font-style:italic">Permanent labels cannot be removed. Hold labels also appear in the On Hold section of the dashboard.</p>
         <div class="config-list">
           ${staticList}
@@ -18533,6 +18559,15 @@ function burnAreaChart() {
           <div class="config-list-add">
             <input type="text" id="cfg-label-input" placeholder="label name" title="GitHub label name to exempt from actionable issues and mergeable PRs.">
             <button onclick="addListItem('labels','list','cfg-label-input')" title="Add this label to the exempt list">+ Add</button>
+          </div>
+        </div>
+        <h4 style="margin:18px 0 6px">Required labels (allow-list)</h4>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">The opposite polarity: when this list is non-empty, agents may <b>only</b> initiate work on issues carrying at least one of these labels — "only work approved issues". Empty = every issue is eligible (the default). Exempt labels above still win on conflict; PRs and the Hold list are unaffected. Matching is exact (case-insensitive).</p>
+        <div class="config-list">
+          ${reqList || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No required labels — agents may work every actionable issue</div>'}
+          <div class="config-list-add">
+            <input type="text" id="cfg-require-label-input" placeholder="label name" title="GitHub label an issue must carry before agents may work it (e.g. an approval/queue label).">
+            <button onclick="addListItem('labels','require','cfg-require-label-input')" title="Add this label to the required (allow) list">+ Add</button>
           </div>
         </div>`;
     }
@@ -19387,9 +19422,15 @@ function burnAreaChart() {
         _configState.data.hooks[key].push(val);
         markDirty('hooks', key, _configState.data.hooks[key]);
       } else if (section === 'labels') {
-        if (!_configState.data.labels) _configState.data.labels = [];
-        _configState.data.labels.push(val);
-        markDirty('labels', 'labels', _configState.data.labels);
+        if (key === 'require') {
+          if (!_configState.data.requireLabels) _configState.data.requireLabels = [];
+          _configState.data.requireLabels.push(val);
+          markDirty('labels', 'require_labels', _configState.data.requireLabels);
+        } else {
+          if (!_configState.data.labels) _configState.data.labels = [];
+          _configState.data.labels.push(val);
+          markDirty('labels', 'labels', _configState.data.labels);
+        }
       } else if (section === 'repos') {
         // Repos go through the async host-check + App-access workflow, which
         // owns input clearing and re-render on success. Return here so the
@@ -19406,8 +19447,13 @@ function burnAreaChart() {
         _configState.data.hooks[key].splice(index, 1);
         markDirty('hooks', key, _configState.data.hooks[key]);
       } else if (section === 'labels') {
-        _configState.data.labels.splice(index, 1);
-        markDirty('labels', 'labels', _configState.data.labels);
+        if (key === 'require') {
+          _configState.data.requireLabels.splice(index, 1);
+          markDirty('labels', 'require_labels', _configState.data.requireLabels);
+        } else {
+          _configState.data.labels.splice(index, 1);
+          markDirty('labels', 'labels', _configState.data.labels);
+        }
       } else if (section === 'repos') {
         _configState.data.repos.splice(index, 1);
         markDirty('repos', 'repos', _configState.data.repos);

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -476,6 +476,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			PausedAt:      formatOptionalTime(proc.PausedAt),
 			PausedReason:  proc.PausedReason,
 			PausedTrigger: proc.PausedTrigger,
+			PausedBy:      proc.PausedBy,
 			OffByCadence:  offByCadence,
 			CLI:           cli,
 			Model:         model,

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -901,28 +901,17 @@ func cadenceDisplay(c config.Cadence) string {
 }
 
 func buildGovernor(state governor.State, cfg *config.Config) FrontendGovernor {
-	const (
-		defaultQuiet = 2
-		defaultBusy  = 10
-		defaultSurge = 20
-	)
-
+	// The gauge must show the thresholds the governor ACTUALLY laddered on, or
+	// it explains the current mode with numbers that did not produce it. This
+	// used to be a private copy of the defaults plus its own explicit-wins
+	// check; both now come from config.EffectiveThreshold, which is the same
+	// call pkg/governor makes. Scaling by repo count (#3498) is what made the
+	// duplication actively wrong rather than merely redundant.
+	repos := cfg.Project.RepoCount()
 	thresholds := FrontendThresholds{
-		Quiet: defaultQuiet,
-		Busy:  defaultBusy,
-		Surge: defaultSurge,
-	}
-
-	// Threshold zero means unset (mode entry present only for cadences);
-	// keep the defaults so the gauge matches the governor's evaluation.
-	if m, ok := cfg.Governor.Modes["quiet"]; ok && m.Threshold > 0 {
-		thresholds.Quiet = m.Threshold
-	}
-	if m, ok := cfg.Governor.Modes["busy"]; ok && m.Threshold > 0 {
-		thresholds.Busy = m.Threshold
-	}
-	if m, ok := cfg.Governor.Modes["surge"]; ok && m.Threshold > 0 {
-		thresholds.Surge = m.Threshold
+		Quiet: cfg.Governor.EffectiveThreshold("quiet", repos),
+		Busy:  cfg.Governor.EffectiveThreshold("busy", repos),
+		Surge: cfg.Governor.EffectiveThreshold("surge", repos),
 	}
 
 	nextKick := ""

--- a/src/pkg/github/agent_token_delivery_test.go
+++ b/src/pkg/github/agent_token_delivery_test.go
@@ -271,3 +271,69 @@ func TestWriteAgentToken_MissingPreCreatedFileWarnsAccurately(t *testing.T) {
 		t.Errorf("degraded-path file mode %o is readable beyond the owner", info.Mode().Perm())
 	}
 }
+
+// TestWriteAgentToken_PublishesTrustedBotIdentityFile is the delivery half of
+// the #4044 fix: staff agents authenticate with App installation tokens, for
+// which `gh api user` structurally 403s, so gh-wrapper.sh's author gate can
+// only learn "who am I" from a file this process writes out-of-band of the
+// agent. Every mint must publish the bot login next to the token caches,
+// world-readable (it is public metadata) in a directory agents cannot write.
+func TestWriteAgentToken_PublishesTrustedBotIdentityFile(t *testing.T) {
+	const wantLogin = "test-app[bot]"
+	auth, _, closeFn := newFakeAppAuth(t, "ghs-identity")
+	defer closeFn()
+	useTempCacheDir(t)
+	auth.SetBotLogin(wantLogin)
+
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken: %v", err)
+	}
+
+	data, err := os.ReadFile(BotLoginFilePath())
+	if err != nil {
+		t.Fatalf("trusted bot-identity file was not published: %v", err)
+	}
+	if string(data) != wantLogin {
+		t.Errorf("bot-identity file content = %q, want %q", string(data), wantLogin)
+	}
+
+	info, err := os.Stat(BotLoginFilePath())
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != botLoginFilePerms {
+		t.Errorf("bot-identity file mode = %o, want %o (agents must be able to READ it; the dir denies writes)", info.Mode().Perm(), botLoginFilePerms)
+	}
+
+	// A rotated slug (config refresh reinits the client) must replace the file.
+	const rotatedLogin = "rotated-app[bot]"
+	auth.SetBotLogin(rotatedLogin)
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken after rotation: %v", err)
+	}
+	data, err = os.ReadFile(BotLoginFilePath())
+	if err != nil {
+		t.Fatalf("re-reading bot-identity file: %v", err)
+	}
+	if string(data) != rotatedLogin {
+		t.Errorf("bot-identity file after rotation = %q, want %q", string(data), rotatedLogin)
+	}
+}
+
+// TestWriteAgentToken_NoBotLoginPublishesNothing pins the App-less/unusable-App
+// posture: with no bot login recorded (cfg.GitHub.BotLogin() returns "" when
+// HasUsableApp() is false), no identity file may appear — the wrapper's author
+// gate must stay fail-closed rather than trusting an empty identity — and
+// token delivery itself must be unaffected.
+func TestWriteAgentToken_NoBotLoginPublishesNothing(t *testing.T) {
+	auth, _, closeFn := newFakeAppAuth(t, "ghs-no-identity")
+	defer closeFn()
+	useTempCacheDir(t)
+
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken: %v", err)
+	}
+	if _, err := os.Stat(BotLoginFilePath()); !os.IsNotExist(err) {
+		t.Errorf("bot-identity file must not exist without a bot login (stat err = %v)", err)
+	}
+}

--- a/src/pkg/github/app.go
+++ b/src/pkg/github/app.go
@@ -57,6 +57,22 @@ const (
 	// Directory must be traversable by every agent UID so each can open its
 	// own 0640 file; the files themselves carry the per-agent restriction.
 	agentTokenCacheDirPerms = 0o755
+
+	// botLoginFileName is the trusted bot-identity file gh-wrapper.sh's author
+	// gate reads (#4044). App installation tokens have no /user identity —
+	// `gh api user` 403s for every staff agent — so the wrapper cannot resolve
+	// "who am I" from the token itself. This process DOES know: it mints every
+	// tier token as "<app-slug>[bot]". Publishing that login into the
+	// agent-token cache dir (dev-owned, mode 0755 — no agent UID can write it)
+	// gives the wrapper an identity oracle the agent cannot spoof, preserving
+	// the #3982 fail-closed/anti-spoof posture while making author-gated
+	// self-listing work again.
+	botLoginFileName = "gh-bot-login"
+	// botLoginFilePerms: world-readable on purpose — the bot login is public
+	// metadata (it appears on every PR the App authors), and every agent UID
+	// must be able to read it. The security property is UNWRITABILITY (dir
+	// owned by dev), not secrecy.
+	botLoginFilePerms = 0o644
 )
 
 // agentTokenCacheDir is the directory holding per-agent token caches. It is a
@@ -75,6 +91,10 @@ type AppAuth struct {
 	mu          sync.RWMutex
 	cachedToken string
 	tokenExpiry time.Time
+	// botLogin is the App bot identity ("<app-slug>[bot]") this installation's
+	// tokens act as. Set via SetBotLogin at client wiring time; when non-empty,
+	// WriteAgentToken publishes it to the trusted bot-identity file (#4044).
+	botLogin string
 }
 
 func NewAppAuth(appID, installationID int64, keyFile string, logger *slog.Logger, apiURL string) (*AppAuth, error) {
@@ -322,6 +342,65 @@ func AgentTokenCachePath(agentName string) string {
 	return agentTokenCacheDir + "/gh-token-" + agentName + ".cache"
 }
 
+// BotLoginFilePath returns the trusted bot-identity file path read by
+// gh-wrapper.sh's author gate (#4044).
+func BotLoginFilePath() string {
+	return agentTokenCacheDir + "/" + botLoginFileName
+}
+
+// SetBotLogin records the App bot login ("<app-slug>[bot]") so token delivery
+// can publish it to the trusted bot-identity file. Empty (no usable App)
+// leaves the file unwritten and the wrapper's author gate fail-closed.
+func (a *AppAuth) SetBotLogin(login string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.botLogin = login
+}
+
+// publishBotLogin writes the trusted bot-identity file the gh wrapper's author
+// gate reads (#4044). Failure is deliberately SOFT (warn, never error): the
+// file only widens what an agent can list; without it the gate stays exactly
+// as fail-closed as before this file existed, whereas failing token delivery
+// over it would take down every GitHub operation to protect a listing.
+func (a *AppAuth) publishBotLogin() {
+	a.mu.RLock()
+	login := a.botLogin
+	a.mu.RUnlock()
+	if login == "" {
+		return
+	}
+
+	path := BotLoginFilePath()
+	if cur, err := os.ReadFile(path); err == nil && string(cur) == login {
+		return // already current — skip the write (called on every token refresh)
+	}
+
+	// Write-temp-then-rename, the OPPOSITE of the token caches' in-place rule:
+	// this file is dev-owned world-readable (no pre-created ownership to
+	// preserve), it is shared by every agent, and concurrent launch paths call
+	// this without coordination — rename keeps every reader seeing a complete
+	// login, never a torn write.
+	tmp, err := os.CreateTemp(agentTokenCacheDir, botLoginFileName+".tmp-")
+	if err != nil {
+		a.logger.Warn("cannot publish bot identity file — author-gated gh listing will stay fail-closed for staff agents (#4044)", "path", path, "error", err)
+		return
+	}
+	defer os.Remove(tmp.Name()) // no-op after a successful rename
+	_, werr := tmp.WriteString(login)
+	if werr == nil {
+		werr = tmp.Chmod(botLoginFilePerms)
+	}
+	if cerr := tmp.Close(); werr == nil {
+		werr = cerr
+	}
+	if werr == nil {
+		werr = os.Rename(tmp.Name(), path)
+	}
+	if werr != nil {
+		a.logger.Warn("cannot publish bot identity file — author-gated gh listing will stay fail-closed for staff agents (#4044)", "path", path, "error", werr)
+	}
+}
+
 // WriteAgentToken mints a tier-scoped token for the given agent and writes it
 // into that agent's pre-created cache file.
 //
@@ -355,6 +434,11 @@ func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, a
 	if err := os.MkdirAll(agentTokenCacheDir, agentTokenCacheDirPerms); err != nil {
 		return fmt.Errorf("creating agent token dir: %w", err)
 	}
+
+	// Publish the trusted bot-identity file alongside the token (#4044). Every
+	// mint/refresh path re-asserts it, so a pod that lost /var/run self-heals
+	// within one token-refresh interval. Soft-fails internally — see doc.
+	a.publishBotLogin()
 
 	cachePath := AgentTokenCachePath(agentName)
 	preCreated := true
@@ -447,6 +531,13 @@ func NewClientFromApp(auth *AppAuth, org string, repos []string, logger *slog.Lo
 }
 
 func NewClientFromAppWithBotLogin(auth *AppAuth, org string, repos []string, logger *slog.Logger, appBotLogin string) *Client {
+	// This factory is the one place where the AppAuth that mints agent tokens
+	// meets the resolved bot login (cfg.GitHub.BotLogin()), including every
+	// config-refresh/reinit path in main.go. Recording it here is what lets
+	// WriteAgentToken publish the trusted bot-identity file for the gh
+	// wrapper's author gate (#4044) without threading the login through each
+	// call site separately.
+	auth.SetBotLogin(appBotLogin)
 	transport := &appTransport{
 		auth: auth,
 		base: http.DefaultTransport,

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -34,6 +34,19 @@ type Client struct {
 	reposMu      sync.RWMutex
 	repos        []string
 	exemptLabels []string
+	// issueFilter is the operator's project.issue_filter (require_labels
+	// allow-list) gating which issues become actionable at all. The exclude
+	// polarity is NOT here — it is exemptLabels above (governor.labels.exempt,
+	// the dashboard Labels tab), the pre-existing single exclusion mechanism,
+	// which fetchIssues applies first so it wins on conflict. Enforced in
+	// fetchIssues — the choice point where issues enter the actionable set —
+	// so everything downstream (governor counts, scheduler kicks, plan-from-
+	// label, the contribute queue) inherits it and no agent-side re-listing
+	// can bypass it. Guarded because config reload / hub heartbeat delivery
+	// re-applies it while the enumeration goroutine reads it. Zero value =
+	// admit everything (pre-existing behavior).
+	issueFilterMu sync.RWMutex
+	issueFilter   config.IssueFilterConfig
 	// autoMergeLabel is the configured merger-queue label. Guarded because
 	// config reload re-applies it while request handlers read it.
 	autoMergeLabelMu sync.RWMutex
@@ -489,6 +502,7 @@ func (c *Client) splitRepo(repo string) (owner, repoName string) {
 }
 
 func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (actionable []Issue, held []HoldItem, totalIssues int, err error) {
+	issueFilter := c.getIssueFilter()
 	owner, repoName := c.splitRepo(repo)
 	opts := &gh.IssueListByRepoOptions{
 		State:       "open",
@@ -527,6 +541,21 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 		}
 
 		if c.isExempt(labels) {
+			continue
+		}
+
+		// project.issue_filter (require_labels) — THE choice point for
+		// label-gated agent work. An issue the filter refuses never becomes
+		// actionable: it is invisible to the governor's queue counts, every
+		// kick prompt, plan-from-label, and the contribute queue, so no
+		// downstream consumer (or prompt-injected agent re-listing the repo)
+		// can select it. Zero-value filter admits everything — pre-existing
+		// behavior, verified by regression tests. Deliberately AFTER the
+		// hold/exempt checks: held issues keep appearing in the Hold list
+		// exactly as before, and the EXCLUDE polarity stays the sole property
+		// of governor.labels.exempt (the dashboard Labels tab) — which
+		// therefore wins over the require gate by construction.
+		if !issueFilter.Admits(labels) {
 			continue
 		}
 
@@ -986,6 +1015,25 @@ func (c *Client) SetExemptLabels(labels []string) {
 		return
 	}
 	c.exemptLabels = labels
+}
+
+// SetIssueFilter installs the operator's project.issue_filter. Nil-receiver
+// safe for the same reason as SetRepos: the config-reload / heartbeat-delivery
+// paths re-apply it unconditionally, and a hive that booted without GitHub
+// credentials runs with a nil *Client.
+func (c *Client) SetIssueFilter(f config.IssueFilterConfig) {
+	if c == nil {
+		return
+	}
+	c.issueFilterMu.Lock()
+	defer c.issueFilterMu.Unlock()
+	c.issueFilter = f
+}
+
+func (c *Client) getIssueFilter() config.IssueFilterConfig {
+	c.issueFilterMu.RLock()
+	defer c.issueFilterMu.RUnlock()
+	return c.issueFilter
 }
 
 // SetAutoMergeLabel is nil-receiver safe for the same reason as SetRepos. An

--- a/src/pkg/github/issue_filter_test.go
+++ b/src/pkg/github/issue_filter_test.go
@@ -1,0 +1,170 @@
+package github
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// These tests pin project.issue_filter enforcement at THE choice point —
+// EnumerateActionable/fetchIssues, where GitHub issues become the hive's
+// actionable set. An issue the filter refuses must never enter
+// Issues.Items: everything downstream (governor queue counts, scheduler
+// kicks, plan-from-label, the contribute queue) consumes that set, so
+// refusal here is what makes the gate un-bypassable by a re-listing agent.
+
+func filterTestIssues() []wireIssue {
+	return []wireIssue{
+		{Number: 1, Title: "approved work", User: wireUser{"alice"},
+			Labels: []wireLabel{{Name: "bug"}, {Name: "approved-for-agents"}}, CreatedAt: hoursAgo(3)},
+		{Number: 2, Title: "unapproved work", User: wireUser{"bob"},
+			Labels: []wireLabel{{Name: "bug"}}, CreatedAt: hoursAgo(2)},
+		{Number: 3, Title: "approved but exempted", User: wireUser{"carol"},
+			Labels: []wireLabel{{Name: "approved-for-agents"}, {Name: "no-ai"}}, CreatedAt: hoursAgo(1)},
+	}
+}
+
+func enumerateWithFilter(t *testing.T, f config.IssueFilterConfig, exempt []string) *ActionableResult {
+	t.Helper()
+	org, repo := "testorg", "testrepo"
+	mux := buildMux(t, org, repo, filterTestIssues(), nil)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	c := newTestClient(t, server, org, []string{repo})
+	c.SetIssueFilter(f)
+	if len(exempt) > 0 {
+		c.SetExemptLabels(exempt)
+	}
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	return result
+}
+
+func actionableNumbers(result *ActionableResult) map[int]bool {
+	nums := make(map[int]bool)
+	for _, is := range result.Issues.Items {
+		nums[is.Number] = true
+	}
+	return nums
+}
+
+// TestEnumerateActionable_IssueFilterRequireLabel: with require_labels set,
+// only labeled issues become actionable. Positive control (issue #1 IS
+// admitted) plus a count floor, so the test cannot pass by admitting nothing.
+func TestEnumerateActionable_IssueFilterRequireLabel(t *testing.T) {
+	result := enumerateWithFilter(t, config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+	}, nil)
+	nums := actionableNumbers(result)
+	if !nums[1] {
+		t.Error("positive control failed: issue #1 carries the required label but is not actionable")
+	}
+	if nums[2] {
+		t.Error("issue #2 lacks the required label but entered the actionable set — the choice-point gate is not enforced")
+	}
+	if got := result.Issues.Count; got != 2 {
+		t.Errorf("Issues.Count = %d, want 2 (issues #1 and #3)", got)
+	}
+}
+
+// TestEnumerateActionable_ExemptWinsOverRequire pins the ONE-exclusion-story
+// composition: the exclude polarity lives in governor.labels.exempt (the
+// dashboard Labels tab), not in issue_filter, and it runs BEFORE the require
+// gate — so an issue carrying both an exempt label and the approval label
+// stays excluded. This is the "exclude wins over require" conflict rule,
+// delivered by the pre-existing mechanism rather than a duplicate one.
+func TestEnumerateActionable_ExemptWinsOverRequire(t *testing.T) {
+	result := enumerateWithFilter(t, config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+	}, []string{"no-ai"})
+	nums := actionableNumbers(result)
+	if !nums[1] {
+		t.Error("positive control failed: issue #1 refused")
+	}
+	if nums[3] {
+		t.Error("issue #3 carries a governor exempt label but entered the actionable set — exemption must win over the require gate")
+	}
+	if nums[2] {
+		t.Error("issue #2 lacks the required label but entered the actionable set")
+	}
+	if got := result.Issues.Count; got != 1 {
+		t.Errorf("Issues.Count = %d, want 1 (only issue #1)", got)
+	}
+}
+
+// TestEnumerateActionable_NoIssueFilterUnchanged is the regression pin: with
+// no filter configured (the state of every existing hive), enumeration is
+// byte-for-byte the old behavior — all three issues actionable.
+func TestEnumerateActionable_NoIssueFilterUnchanged(t *testing.T) {
+	result := enumerateWithFilter(t, config.IssueFilterConfig{}, nil)
+	if got := result.Issues.Count; got != 3 {
+		t.Errorf("Issues.Count = %d, want 3 — absent filter must change nothing", got)
+	}
+	nums := actionableNumbers(result)
+	for _, n := range []int{1, 2, 3} {
+		if !nums[n] {
+			t.Errorf("issue #%d missing from actionable set with no filter configured", n)
+		}
+	}
+}
+
+// TestEnumerateActionable_IssueFilterDoesNotTouchPRs: the filter gates which
+// ISSUES agents may initiate work on. Open PRs are in-flight work and must
+// keep flowing regardless of their labels.
+func TestEnumerateActionable_IssueFilterDoesNotTouchPRs(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	prs := []wirePR{
+		{Number: 10, Title: "fix in flight", User: wireUser{"alice"},
+			Labels: []wireLabel{{Name: "bug"}}, CreatedAt: hoursAgo(1)},
+	}
+	mux := buildMux(t, org, repo, nil, prs)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	c := newTestClient(t, server, org, []string{repo})
+	c.SetIssueFilter(config.IssueFilterConfig{RequireLabels: []string{"approved-for-agents"}})
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	if result.PRs.Count != 1 {
+		t.Errorf("PRs.Count = %d, want 1 — the issue filter must not gate PRs", result.PRs.Count)
+	}
+}
+
+// TestEnumerateActionable_IssueFilterKeepsHold: hold-labeled issues keep
+// appearing in the Hold list even when they would fail the require gate — the
+// filter runs after the hold check, preserving the operator's hold view.
+func TestEnumerateActionable_IssueFilterKeepsHold(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	issues := []wireIssue{
+		{Number: 5, Title: "parked", User: wireUser{"dave"},
+			Labels: []wireLabel{{Name: "hold"}}, CreatedAt: hoursAgo(1)},
+	}
+	mux := buildMux(t, org, repo, issues, nil)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	c := newTestClient(t, server, org, []string{repo})
+	c.SetIssueFilter(config.IssueFilterConfig{RequireLabels: []string{"approved-for-agents"}})
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	if result.Hold.Issues != 1 {
+		t.Errorf("Hold.Issues = %d, want 1 — the issue filter must not hide held items", result.Hold.Issues)
+	}
+	if result.Issues.Count != 0 {
+		t.Errorf("Issues.Count = %d, want 0", result.Issues.Count)
+	}
+}
+
+// TestSetIssueFilter_NilReceiver: the setter must be nil-receiver safe, like
+// SetRepos/SetExemptLabels — a hive without GitHub credentials runs with a
+// nil *Client and the reload paths call the setter unconditionally.
+func TestSetIssueFilter_NilReceiver(t *testing.T) {
+	var c *Client
+	c.SetIssueFilter(config.IssueFilterConfig{RequireLabels: []string{"x"}}) // must not panic
+}

--- a/src/pkg/governor/governor.go
+++ b/src/pkg/governor/governor.go
@@ -207,6 +207,22 @@ type Governor struct {
 	budget       BudgetInfo
 	now          func() time.Time
 
+	// repoCount is how many repos this hive watches, used to scale the DEFAULT
+	// mode thresholds (#3498). Set via SetRepoCount; defaults to 1 so a
+	// governor constructed without one behaves exactly as before scaling
+	// existed.
+	repoCount int
+
+	// lastLadderWarn is the inverted ladder most recently warned about, so the
+	// warning fires on the TRANSITION rather than on every re-check. Both
+	// callers of warnIfLadderInvertedLocked run on hot paths — UpdateConfig on
+	// the ~2-minute reload loop and on every dashboard config save — so an
+	// undeduplicated warning would emit a WARN every couple of minutes forever
+	// on a hive whose ladder is inverted. Zero value means "nothing warned
+	// about"; it is cleared when the ladder becomes healthy so a later
+	// re-inversion is reported again.
+	lastLadderWarn ladderSnapshot
+
 	// resumeKicks records the last crash-recovery resume kick granted per
 	// agent (see AllowResumeKick). In-memory only: after a process restart
 	// the startup path re-kicks every eligible agent anyway, so persisting
@@ -243,6 +259,9 @@ func New(cfg config.GovernorConfig, agents map[string]config.AgentConfig, logger
 		agentReports: make(map[string]AgentReportRecord),
 		resumeKicks:  make(map[string]time.Time),
 		now:          time.Now,
+		// 1 repo = scaling is a no-op, so a governor built without a repo count
+		// ladders on the same absolute numbers it always did.
+		repoCount: 1,
 		budget: BudgetInfo{
 			ByAgent: make(map[string]int64),
 			ByModel: make(map[string]int64),
@@ -254,6 +273,9 @@ func (g *Governor) UpdateConfig(cfg config.GovernorConfig) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.cfg = cfg
+	// New config can change both the explicit thresholds and the scaling curve,
+	// either of which can invert the ladder.
+	g.warnIfLadderInvertedLocked()
 }
 
 func (g *Governor) UpdateAgents(agents map[string]config.AgentConfig) {
@@ -365,23 +387,101 @@ func (g *Governor) computeMode(queueDepth int) Mode {
 	return ModeIdle
 }
 
+// ladderSnapshot is the set of effective thresholds an inversion warning was
+// last emitted for. Comparable by design (all scalars) so deduplication is a
+// plain equality check. warned distinguishes "warned about a ladder that
+// happens to be all zeros" from the zero value meaning "never warned".
+type ladderSnapshot struct {
+	surge     int
+	busy      int
+	quiet     int
+	repoCount int
+	warned    bool
+}
+
+// thresholdFor returns the queue depth at which modeName engages.
+//
+// The resolution — explicit config wins, otherwise a repo-count-scaled default
+// — lives in config.EffectiveThreshold so the dashboard gauge resolves the
+// identical number. A mode entry may exist only to carry cadences, with its
+// threshold unset (zero); that still falls through to the defaults, because a
+// zero threshold would put every non-empty queue in that mode.
 func (g *Governor) thresholdFor(modeName string) int {
-	// A mode entry may exist only for cadences with threshold unset
-	// (zero). Zero thresholds would make every non-empty queue surge,
-	// so fall through to the defaults in that case.
-	if mode, ok := g.cfg.Modes[modeName]; ok && mode.Threshold > 0 {
-		return mode.Threshold
+	return g.cfg.EffectiveThreshold(modeName, g.repoCount)
+}
+
+// SetRepoCount tells the governor how many repos this hive watches, so the
+// DEFAULT mode thresholds can scale with hive size (#3498).
+//
+// It is a separate setter rather than a New/UpdateConfig parameter because the
+// count comes from config.Project, not GovernorConfig, and because it changes
+// on a different schedule than the governor config does — a dashboard repo edit
+// moves it without touching governor settings. It sits beside the existing
+// ghClient.SetRepos call on the reload path for the same reason.
+//
+// A count below 1 is treated as 1: a hive with an empty repos: list still
+// watches its primary repo, and a zero would collapse every scaled threshold to
+// zero and pin the hive in SURGE.
+func (g *Governor) SetRepoCount(n int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if n < 1 {
+		n = 1
 	}
-	switch modeName {
-	case "surge":
-		return 20
-	case "busy":
-		return 10
-	case "quiet":
-		return 2
-	default:
-		return 0
+	if n == g.repoCount {
+		return
 	}
+	g.repoCount = n
+	g.warnIfLadderInvertedLocked()
+}
+
+// warnIfLadderInvertedLocked logs when the effective thresholds do not descend
+// surge > busy > quiet.
+//
+// computeMode tests surge first and returns on the first threshold the queue
+// exceeds, so a ladder out of order silently makes a mode unreachable. Mixing
+// sources is what newly makes this reachable: before #3498 the three thresholds
+// were either all defaults or all hand-set at comparable magnitudes, whereas an
+// explicit surge=70 now sits alongside a scaled busy=390 on a 39-repo hive, and
+// BUSY can never be entered.
+//
+// It warns rather than reorders. The inversion is produced by the operator's
+// own explicit value, and silently overriding a number they set would be a
+// worse surprise than telling them it is being ignored.
+//
+// The warning is DEDUPLICATED on the ladder it describes, because both callers
+// re-check on paths that run constantly: UpdateConfig fires on the ~2-minute
+// reload loop and on every dashboard config save, whether or not anything
+// changed. Warning each time would put a WARN in the log every couple of
+// minutes on a hive that is merely mis-tuned — and an explicit surge beside a
+// scaled busy is precisely the configuration #3498 was reported from, so that
+// would be the loudest on exactly the hives the change is meant to help. A
+// changed inversion is new information and warns again; a repaired ladder
+// clears the memo so a later re-inversion is not swallowed.
+//
+// Caller must hold g.mu.
+func (g *Governor) warnIfLadderInvertedLocked() {
+	surge := g.cfg.EffectiveThreshold("surge", g.repoCount)
+	busy := g.cfg.EffectiveThreshold("busy", g.repoCount)
+	quiet := g.cfg.EffectiveThreshold("quiet", g.repoCount)
+
+	if surge > busy && busy > quiet {
+		g.lastLadderWarn = ladderSnapshot{}
+		return
+	}
+	cur := ladderSnapshot{surge: surge, busy: busy, quiet: quiet, repoCount: g.repoCount, warned: true}
+	if cur == g.lastLadderWarn {
+		return
+	}
+	g.lastLadderWarn = cur
+	g.logger.Warn("governor mode thresholds are not in descending order — a mode is unreachable",
+		"surge", surge,
+		"busy", busy,
+		"quiet", quiet,
+		"repo_count", g.repoCount,
+		"threshold_scaling", g.cfg.ThresholdScalingMode(),
+		"hint", "an explicit governor.modes.<mode>.threshold is never scaled; set the others explicitly too, or remove it to let all three scale",
+	)
 }
 
 // updateCadences recomputes every agent's effective cadence for the current

--- a/src/pkg/governor/governor_threshold_scaling_test.go
+++ b/src/pkg/governor/governor_threshold_scaling_test.go
@@ -1,0 +1,293 @@
+package governor
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// #3498: the mode ladder gates a queue depth that grows with repo count, so
+// fixed thresholds put a large hive in permanent SURGE while a small one idles.
+// These tests cover the governor side — that the repo count reaches
+// thresholdFor, that the mode ladder moves with it, and that a governor which
+// was never told a repo count behaves exactly as it always did.
+
+func scalingLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+// A governor constructed without SetRepoCount must ladder on the historical
+// absolute numbers. Every existing test in this package relies on it, and so
+// does any embedder that has not been updated.
+func TestThresholdFor_DefaultsToUnscaledWhenRepoCountUnset(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	if got := g.thresholdFor("surge"); got != 20 {
+		t.Errorf("surge = %d, want the historical 20", got)
+	}
+	if got := g.thresholdFor("busy"); got != 10 {
+		t.Errorf("busy = %d, want the historical 10", got)
+	}
+	if got := g.thresholdFor("quiet"); got != 2 {
+		t.Errorf("quiet = %d, want the historical 2", got)
+	}
+}
+
+func TestSetRepoCount_ScalesDefaultThresholds(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	if got := g.thresholdFor("surge"); got != 780 {
+		t.Errorf("39-repo surge = %d, want 780", got)
+	}
+	if got := g.thresholdFor("busy"); got != 390 {
+		t.Errorf("39-repo busy = %d, want 390", got)
+	}
+	if got := g.thresholdFor("quiet"); got != 78 {
+		t.Errorf("39-repo quiet = %d, want 78", got)
+	}
+}
+
+func TestSetRepoCount_FloorsAtOne(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	for _, n := range []int{0, -1} {
+		g.SetRepoCount(n)
+		if got := g.thresholdFor("surge"); got != 20 {
+			t.Errorf("SetRepoCount(%d): surge = %d, want the unscaled 20 — a zero would pin the hive in SURGE", n, got)
+		}
+	}
+}
+
+// The reported scenario, end to end: a 39-repo hive carrying ~210 actionable
+// items sat in SURGE permanently. With scaled defaults the same queue is no
+// longer a surge, because 210 items across 39 repos is ~5 per repo.
+func TestComputeMode_LargeHiveLeavesPermanentSurge(t *testing.T) {
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+
+	g.SetRepoCount(1)
+	if got := g.computeMode(210); got != ModeSurge {
+		t.Fatalf("1-repo hive at queue 210 = %s, want SURGE (the pre-fix behavior)", got)
+	}
+
+	g.SetRepoCount(39)
+	if got := g.computeMode(210); got == ModeSurge {
+		t.Error("39-repo hive at queue 210 is still SURGE — the reported bug is not fixed")
+	}
+}
+
+// The same per-repo pressure must produce the same mode regardless of hive
+// size. That equivalence is the point of the feature: the ladder stops
+// encoding an implicit repo count.
+func TestComputeMode_SameMoodAtSamePerRepoPressure(t *testing.T) {
+	small := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+	small.SetRepoCount(3)
+	large := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, slog.Default())
+	large.SetRepoCount(39)
+
+	// 15 items per repo is comfortably into BUSY (base busy=10, surge=20).
+	if got, want := small.computeMode(15*3), large.computeMode(15*39); got != want {
+		t.Errorf("3-repo hive = %s but 39-repo hive = %s at the same per-repo pressure", got, want)
+	}
+	// 25 per repo clears the surge base on both.
+	if got := small.computeMode(25 * 3); got != ModeSurge {
+		t.Errorf("3-repo hive at 25/repo = %s, want SURGE", got)
+	}
+	if got := large.computeMode(25 * 39); got != ModeSurge {
+		t.Errorf("39-repo hive at 25/repo = %s, want SURGE", got)
+	}
+}
+
+// Hand-tuned hives must see no behavior change whatsoever — that promise is
+// what makes this a defaults-only change.
+func TestComputeMode_ExplicitThresholdsIgnoreRepoCount(t *testing.T) {
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{
+			"surge": {Threshold: 300},
+			"busy":  {Threshold: 200},
+			"quiet": {Threshold: 100},
+		},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+
+	for _, repos := range []int{1, 39, 500} {
+		g.SetRepoCount(repos)
+		if got := g.computeMode(210); got != ModeBusy {
+			t.Errorf("repos=%d: hand-tuned hive at queue 210 = %s, want BUSY", repos, got)
+		}
+	}
+}
+
+func TestThresholdFor_ScalingNoneRestoresAbsoluteBehavior(t *testing.T) {
+	cfg := config.GovernorConfig{ThresholdScaling: config.ThresholdScalingNone}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	if got := g.thresholdFor("surge"); got != 20 {
+		t.Errorf("scaling none = %d, want the absolute 20", got)
+	}
+	if got := g.computeMode(210); got != ModeSurge {
+		t.Errorf("scaling none at queue 210 = %s, want SURGE (opted out)", got)
+	}
+}
+
+func TestThresholdFor_SqrtScaling(t *testing.T) {
+	cfg := config.GovernorConfig{ThresholdScaling: config.ThresholdScalingSqrt}
+	g := New(cfg, map[string]config.AgentConfig{}, slog.Default())
+	g.SetRepoCount(39)
+
+	if got := g.thresholdFor("surge"); got != 140 {
+		t.Errorf("sqrt surge = %d, want 140", got)
+	}
+}
+
+// An explicit threshold is never scaled, so mixing one with scaled defaults can
+// leave BUSY above SURGE — computeMode tests surge first and returns, making
+// BUSY unreachable. The governor must say so rather than let a mode silently
+// disappear.
+func TestSetRepoCount_WarnsOnInvertedLadder(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	out := buf.String()
+	if !strings.Contains(out, "not in descending order") {
+		t.Fatalf("no inversion warning logged; got %q", out)
+	}
+	// The warning has to carry the numbers, or an operator cannot act on it.
+	for _, want := range []string{"surge=70", "busy=390", "repo_count=39"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning does not include %q; got %q", want, out)
+		}
+	}
+
+	// And the inversion is real: BUSY cannot be entered.
+	if got := g.computeMode(200); got != ModeSurge {
+		t.Errorf("queue 200 with the inverted ladder = %s, want SURGE (busy unreachable)", got)
+	}
+}
+
+func TestSetRepoCount_NoWarningOnHealthyLadder(t *testing.T) {
+	var buf bytes.Buffer
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	if strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("warned about a correctly ordered ladder: %q", buf.String())
+	}
+}
+
+// UpdateConfig can introduce an inversion on its own (new explicit thresholds,
+// or a changed scaling curve), so it must run the same check.
+func TestUpdateConfig_WarnsOnInvertedLadder(t *testing.T) {
+	var buf bytes.Buffer
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+	buf.Reset()
+
+	g.UpdateConfig(config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	})
+
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("UpdateConfig did not re-check the ladder; got %q", buf.String())
+	}
+}
+
+// SetRepoCount is called on every config reload, including reloads that did not
+// touch the repo list. Re-warning on each one would spam the log.
+func TestSetRepoCount_UnchangedCountIsQuiet(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(cfg, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+	buf.Reset()
+
+	g.SetRepoCount(39)
+	if buf.Len() != 0 {
+		t.Errorf("re-setting the same repo count logged again: %q", buf.String())
+	}
+}
+
+// UpdateConfig runs on EVERY periodic config reload (main.go's ~2-minute loop)
+// and again on every dashboard config save, not only when something changed.
+// Re-warning each time would emit a WARN every couple of minutes forever on a
+// hive whose ladder is inverted — and an inverted ladder is exactly what the
+// #3498 reporter's hive has (explicit surge=70 beside a scaled busy). That is
+// against this codebase's own norm for the reload path, which is deliberately
+// kept quiet so a healthy hive does not spam.
+//
+// The warning must fire on the TRANSITION into an inverted ladder, then stay
+// quiet while nothing about it changes.
+func TestUpdateConfig_InvertedLadderWarnsOnceNotEveryReload(t *testing.T) {
+	var buf bytes.Buffer
+	inverted := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	buf.Reset()
+	g.UpdateConfig(inverted)
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Fatalf("first UpdateConfig did not warn; got %q", buf.String())
+	}
+
+	// Ten more reloads that change nothing at all.
+	buf.Reset()
+	for i := 0; i < 10; i++ {
+		g.UpdateConfig(inverted)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("re-warned on an unchanged inverted ladder %d times: %q",
+			strings.Count(buf.String(), "not in descending order"), buf.String())
+	}
+}
+
+// Suppression must be keyed on the ladder itself, not latched forever: a
+// DIFFERENT inversion is new information and has to be reported, or an operator
+// who edits one threshold and makes things worse hears nothing.
+func TestUpdateConfig_ChangedInversionWarnsAgain(t *testing.T) {
+	var buf bytes.Buffer
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+	g.UpdateConfig(config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	})
+
+	buf.Reset()
+	g.UpdateConfig(config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 50}},
+	})
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("a different inversion was suppressed; got %q", buf.String())
+	}
+}
+
+// And a ladder that gets FIXED and later breaks again must warn again — the
+// suppression is a dedupe, not a one-shot.
+func TestUpdateConfig_ReinversionAfterRepairWarnsAgain(t *testing.T) {
+	var buf bytes.Buffer
+	inverted := config.GovernorConfig{
+		Modes: map[string]config.ModeConfig{"surge": {Threshold: 70}},
+	}
+	g := New(config.GovernorConfig{}, map[string]config.AgentConfig{}, scalingLogger(&buf))
+	g.SetRepoCount(39)
+
+	g.UpdateConfig(inverted)
+	g.UpdateConfig(config.GovernorConfig{}) // repaired: all three scale together
+	buf.Reset()
+
+	g.UpdateConfig(inverted)
+	if !strings.Contains(buf.String(), "not in descending order") {
+		t.Errorf("re-inversion after a repair was suppressed; got %q", buf.String())
+	}
+}

--- a/src/pkg/hub/commit_order_test.go
+++ b/src/pkg/hub/commit_order_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +15,9 @@ import (
 // ============================================================
 
 // resetCommitOrderState clears the ancestry cache/in-flight maps and restores
-// the real compare fetcher after the test. All fetcher writes happen under
+// the suite-default compare fetcher (the offline TestMain stub — the real
+// network fetcher is never active during tests) after the test. All fetcher
+// writes happen under
 // commitOrderMu — the mutex commitAtOrAheadOfTarget captures the var under —
 // so a background resolve leaked from another test can never race them.
 func resetCommitOrderState(t *testing.T) {
@@ -340,5 +343,62 @@ func TestTriggerAutoUpgradesClearsSurpassedManualTarget(t *testing.T) {
 	}
 	if armed {
 		t.Error("expected stale heartbeat fallback drained, not re-armed")
+	}
+}
+
+// The production compare fetcher's HTTP behaviour, exercised directly against
+// a local server. TestMain replaces the fetchCommitCompareStatus var with an
+// offline stub for the whole suite (background resolves must never reach the
+// real GitHub API from unit tests), so this is the one place the real
+// implementation runs — via the realFetchCommitCompareStatus handle captured
+// before the swap.
+func TestFetchCommitCompareStatusHTTP(t *testing.T) {
+	if realFetchCommitCompareStatus == nil {
+		t.Fatal("TestMain did not capture the real compare fetcher")
+	}
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    string
+		wantErr bool
+	}{
+		{"ahead", func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.URL.Path, "/repos/kubestellar/hive/compare/aaaaaaa...bbbbbbb") {
+				t.Errorf("unexpected compare path %s", r.URL.Path)
+			}
+			w.Write([]byte(`{"status":"ahead"}`))
+		}, "ahead", false},
+		{"non-200", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}, "", true},
+		{"empty status", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{}`))
+		}, "", true},
+		{"bad json", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{`))
+		}, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+			oldBase := githubAPIBase
+			githubAPIBase = srv.URL
+			defer func() { githubAPIBase = oldBase }()
+
+			status, err := realFetchCommitCompareStatus("aaaaaaa", "bbbbbbb", slog.Default())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got status %q", status)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if status != tc.want {
+				t.Errorf("status = %q, want %q", status, tc.want)
+			}
+		})
 	}
 }

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -267,6 +267,17 @@ type AgentSummary struct {
 	// Paused set, so the two are not interchangeable. The hub's inactive-agent
 	// rule keys off this to guarantee a deliberate pause is never alerted on.
 	Paused bool `json:"paused,omitempty"`
+	// Pause provenance (#4041): WHO/WHY/WHEN, so the fleet view can tell a
+	// deliberate owner quiesce ("paused by <owner> via dashboard, 3d ago")
+	// from a malfunction. All empty on a non-paused agent; PausedBy is empty
+	// when no human actor is known (login-detector, fleet-breaker, ...).
+	// PausedAt is RFC3339. The audit trail on the spoke has always had this —
+	// nothing the hub reads did, which is what turned a legitimate mass pause
+	// into a multi-day incident investigation.
+	PausedTrigger string `json:"pausedTrigger,omitempty"`
+	PausedReason  string `json:"pausedReason,omitempty"`
+	PausedBy      string `json:"pausedBy,omitempty"`
+	PausedAt      string `json:"pausedAt,omitempty"`
 	// NeedsLogin is true when the agent's CLI is sitting on a login /
 	// device-code prompt. This is the "running but not logged in" state: the
 	// session is alive, the CLI process is alive, and the agent still cannot do
@@ -298,6 +309,10 @@ type AgentSummary struct {
 // one of the two paths is a signal that quietly disappears mid-upgrade.
 type AgentActivity struct {
 	Paused         bool
+	PausedTrigger  string
+	PausedReason   string
+	PausedBy       string
+	PausedAt       time.Time
 	NeedsLogin     bool
 	SessionMissing bool
 	StartedAt      time.Time
@@ -313,8 +328,14 @@ func NewAgentSummary(name, state, mode string, act AgentActivity) AgentSummary {
 		State:          state,
 		Mode:           mode,
 		Paused:         act.Paused,
+		PausedTrigger:  act.PausedTrigger,
+		PausedReason:   act.PausedReason,
+		PausedBy:       act.PausedBy,
 		NeedsLogin:     act.NeedsLogin,
 		SessionMissing: act.SessionMissing,
+	}
+	if !act.PausedAt.IsZero() {
+		as.PausedAt = act.PausedAt.UTC().Format(time.RFC3339)
 	}
 	if !act.StartedAt.IsZero() {
 		as.StartedAt = act.StartedAt.UTC().Format(time.RFC3339)

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/tracing"
 )
 
@@ -1936,6 +1937,15 @@ type HeartbeatProjectConfig struct {
 	// Empty = leave the spoke's github.api_url unchanged (public github.com is
 	// the spoke's own default), so this never blanks a working config.
 	GitHubAPIURL string `json:"github_api_url,omitempty"`
+	// IssueFilter delivers the per-hive project.issue_filter (the
+	// require_labels allow-list gating which issues agents may initiate work
+	// on; exclusion stays governor.labels.exempt, spoke-owned). It rides
+	// this struct because it is part of the same project identity as
+	// org/repos. nil = the hub is not speaking to this field — the spoke keeps
+	// its locally configured filter, so the hub's every-beat echo can never
+	// blank it (the AIAuthor lesson). A non-nil but empty filter is an
+	// explicit clear.
+	IssueFilter *config.IssueFilterConfig `json:"issue_filter,omitempty"`
 }
 
 // HeartbeatGatewayConfig carries an OpenRouter model gateway (funded via the

--- a/src/pkg/hub/main_test.go
+++ b/src/pkg/hub/main_test.go
@@ -1,9 +1,16 @@
 package hub
 
 import (
+	"fmt"
+	"log/slog"
 	"os"
 	"testing"
 )
+
+// realFetchCommitCompareStatus preserves the production compare fetcher so its
+// HTTP behaviour stays directly testable (TestFetchCommitCompareStatusHTTP)
+// after TestMain swaps the package var for the offline default below.
+var realFetchCommitCompareStatus func(base, head string, logger *slog.Logger) (string, error)
 
 // TestMain isolates the hub test suite from any real Kubernetes cluster.
 //
@@ -38,5 +45,27 @@ func TestMain(m *testing.M) {
 	// KUBECONFIG could equally point a real kubectl at a real cluster for the
 	// non-InCluster branch, so neutralize it to a path that cannot exist.
 	os.Setenv("KUBECONFIG", os.DevNull)
+
+	// Commit-order ancestry resolves are kicked as BACKGROUND goroutines from
+	// the heartbeat completion chain, the orphan sweep and triggerAutoUpgrades
+	// (commitAtOrAheadOfTarget). Any test that crosses those paths with an
+	// unresolved SHA pair — most don't even know they do — would otherwise
+	// launch a REAL GitHub compare call with a 10s budget
+	// (commitCompareTimeout). One slow call is exactly the 2026-08-17 coverage
+	// red at bb2d554d: a leaked resolver outlived three consecutive 2s
+	// waitForCommitOrderResolvers deadlines in sha_poll_coverage_test.go, so
+	// TestListRepoBranches{,Error} and TestFetchBranchSHAImageReady failed on
+	// an otherwise green branch. Default the fetcher to an instant offline
+	// error: errors are never cached, so semantics match "resolution pending"
+	// (fail-closed — an unknown pair never reads as complete), and tests that
+	// need definitive answers already stub via stubCommitCompare or
+	// seedCommitOrder. Held under commitOrderMu per the var's contract.
+	commitOrderMu.Lock()
+	realFetchCommitCompareStatus = fetchCommitCompareStatus
+	fetchCommitCompareStatus = func(base, head string, _ *slog.Logger) (string, error) {
+		return "", fmt.Errorf("commit-order compare %s...%s: network disabled in unit tests (stub via stubCommitCompare)", base, head)
+	}
+	commitOrderMu.Unlock()
+
 	os.Exit(m.Run())
 }

--- a/src/pkg/hub/pause_provenance_summary_test.go
+++ b/src/pkg/hub/pause_provenance_summary_test.go
@@ -1,0 +1,56 @@
+package hub
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #4041 hub-side provenance: the per-agent summaries riding the heartbeat
+// into the My Hives payload must carry WHO/WHY/WHEN for a paused agent, so
+// the fleet view can tell a deliberate owner quiesce from a malfunction.
+
+func TestNewAgentSummary_CarriesPauseProvenance(t *testing.T) {
+	pausedAt := time.Date(2026, 8, 14, 16, 10, 10, 0, time.UTC)
+	as := NewAgentSummary("scanner", "paused", "", AgentActivity{
+		Paused:        true,
+		PausedTrigger: "dashboard-api",
+		PausedReason:  "manual pause",
+		PausedBy:      "bketelsen",
+		PausedAt:      pausedAt,
+	})
+	if !as.Paused {
+		t.Fatal("Paused not set")
+	}
+	if as.PausedTrigger != "dashboard-api" {
+		t.Errorf("PausedTrigger = %q, want %q", as.PausedTrigger, "dashboard-api")
+	}
+	if as.PausedReason != "manual pause" {
+		t.Errorf("PausedReason = %q, want %q", as.PausedReason, "manual pause")
+	}
+	if as.PausedBy != "bketelsen" {
+		t.Errorf("PausedBy = %q, want %q", as.PausedBy, "bketelsen")
+	}
+	if as.PausedAt != "2026-08-14T16:10:10Z" {
+		t.Errorf("PausedAt = %q, want RFC3339 %q", as.PausedAt, "2026-08-14T16:10:10Z")
+	}
+}
+
+// A zero PausedAt must serialize as ABSENT — never as a bogus year-1 string
+// the fleet view would render as a 2000-year-old pause.
+func TestNewAgentSummary_ZeroPausedAtOmitted(t *testing.T) {
+	as := NewAgentSummary("scanner", "running", "", AgentActivity{})
+	if as.PausedAt != "" {
+		t.Fatalf("PausedAt = %q, want empty for a zero time", as.PausedAt)
+	}
+	raw, err := json.Marshal(as)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, field := range []string{"pausedAt", "pausedTrigger", "pausedReason", "pausedBy"} {
+		if strings.Contains(string(raw), field) {
+			t.Errorf("non-paused agent summary leaks %q: %s", field, raw)
+		}
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3062,15 +3062,15 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// own "channel -> image" block above the per-branch rows, and offers
 		// them as branch-switch targets. The association is resolved from
 		// registry digests (cached), never hardcoded to a branch name.
-		"release_channels":         ReleaseChannels(),
-		"channel_targets":          getChannelTargets(getDisplaySHAs(), s.logger),
-		"hub_auto_upgrade":         isHubAutoUpgrade(),
-		"hub_upgrade_state":        s.hubUpgradeState(),
+		"release_channels":  ReleaseChannels(),
+		"channel_targets":   getChannelTargets(getDisplaySHAs(), s.logger),
+		"hub_auto_upgrade":  isHubAutoUpgrade(),
+		"hub_upgrade_state": s.hubUpgradeState(),
 		// Kill-switch state rides the top-level payload (NOT the hive-row
 		// shape, so no HIVES_CACHE_VERSION bump): the dashboard shows a
 		// prominent banner while anything is paused, and admins get toggles.
 		"upgrade_pause": s.upgradePauseSnapshot(),
-		"show_my_hives":            true,
+		"show_my_hives": true,
 		// Fleet alerts ship WITH the hive list so the "Attention needed" panel
 		// renders in the same paint as the rows it summarises — a second
 		// round-trip would make the panel pop in after the list and shift it.
@@ -7627,6 +7627,11 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		PrimaryRepo:  pushPrimary,
 		ACMMLevel:    pushACMM,
 		DashboardURL: h.VanityURL,
+		// IssueFilter rides the claim push only when the record carries one.
+		// nil (the ordinary case) tells the spoke "keep your own filter" — the
+		// echo of this struct on later beats must never blank an operator's
+		// locally configured project.issue_filter.
+		IssueFilter: h.IssueFilter,
 		// Point a GHE hive at its enterprise API. jjs-world
 		// (hosted-open-source-osscar) is the working reference: a bare
 		// primary_repo plus github.api_url = https://<host>/api/v3. Empty host

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -10475,8 +10475,11 @@ const dashboardHTML = `<!DOCTYPE html>
     /* Bump on ANY change to the hive row shape consumed by renderHives().
        v2: rows carry trackedChannel (the hub-persisted release-channel
        selection the version pill renders); a v1 cache would repaint a
-       channel-pinned hive as its bare branch for the pre-network paint. */
-    var HIVES_CACHE_VERSION = 2;
+       channel-pinned hive as its bare branch for the pre-network paint.
+       v3 (#4041): agent rows carry pause provenance (pausedTrigger/
+       pausedReason/pausedBy/pausedAt) rendered into the Agents tooltip; a
+       v2 cache would paint paused agents provenance-less until the poll. */
+    var HIVES_CACHE_VERSION = 3;
     /* 10 minutes: long enough to cover a reload or a tab restore, short enough
        that a cached fleet is never wildly out of date before the poll lands. */
     var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;
@@ -13761,6 +13764,37 @@ const dashboardHTML = `<!DOCTYPE html>
       }
       return false;
     }
+    /* One phrase answering WHO paused an agent, WHY and WHEN, from the pause
+       provenance the spoke reports over the heartbeat (#4041) — e.g.
+       "paused by bketelsen via dashboard, 3d ago" or "paused (login-detector:
+       login required detected), 2h ago". A deliberate owner quiesce must read
+       differently from a malfunction in the fleet view. Old cached rows and
+       old spokes lack the fields; falls back to a bare "paused". */
+    function agentPauseProvenance(a) {
+      var line;
+      if (a.pausedTrigger === 'dashboard-api') {
+        line = 'paused by ' + (a.pausedBy || 'an operator') + ' via dashboard';
+      } else if (a.pausedTrigger) {
+        line = 'paused (' + a.pausedTrigger + (a.pausedReason ? ': ' + a.pausedReason : '') + ')';
+      } else {
+        line = 'paused';
+      }
+      if (a.pausedAt) {
+        /* Self-contained relative age (coarse on purpose): timelineAgo lives
+           in a later <script> block, and renderHives can run during this
+           block's init (paintCachedHives) before that block is parsed. */
+        var t = Date.parse(a.pausedAt);
+        if (!isNaN(t)) {
+          var PAUSE_MS_PER_MIN = 60000, PAUSE_MIN_PER_HOUR = 60, PAUSE_HOURS_PER_DAY = 24;
+          var mins = Math.floor((Date.now() - t) / PAUSE_MS_PER_MIN);
+          if (mins < 1) line += ', just now';
+          else if (mins < PAUSE_MIN_PER_HOUR) line += ', ' + mins + 'm ago';
+          else if (mins < PAUSE_MIN_PER_HOUR * PAUSE_HOURS_PER_DAY) line += ', ' + Math.floor(mins / PAUSE_MIN_PER_HOUR) + 'h ago';
+          else line += ', ' + Math.floor(mins / (PAUSE_MIN_PER_HOUR * PAUSE_HOURS_PER_DAY)) + 'd ago';
+        }
+      }
+      return line;
+    }
     function renderHives(allHives, force) {
       allHives = allHives || [];
       /* Defer the whole render while a branch/channel menu is open. Skipping
@@ -14332,7 +14366,7 @@ const dashboardHTML = `<!DOCTYPE html>
               '<div style="' + STACKED_LINE_STYLE + '">' + journeyBadge(h.journey) + '</div>' +
             '</div>' +
           '</td>' +
-          '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
+          '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; if (a.paused) label += ' — ' + agentPauseProvenance(a); return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
           '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
           /* ACTIVITY: Issues, PRs and Contributors — three mini-stats that were

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -472,10 +472,16 @@ type SaaSHive struct {
 	GitHubHost  string   `json:"github_host,omitempty"`
 	Repos       []string `json:"repos"`
 	PrimaryRepo string   `json:"primary_repo"`
-	ACMMLevel   int      `json:"acmm_level"`
-	Status      string   `json:"status"`
-	CreatedAt   string   `json:"created_at"`
-	Subdomain   string   `json:"subdomain"`
+	// IssueFilter, when set on this record (admin-managed meta), is delivered
+	// to the spoke with the claim push so a fleet whose owner gates agent work
+	// on an approval label gets the gate from first boot. nil = never pushed;
+	// the spoke's own project.issue_filter (dashboard/config-managed) is then
+	// authoritative and is never blanked by the reconcile.
+	IssueFilter *config.IssueFilterConfig `json:"issue_filter,omitempty"`
+	ACMMLevel   int                       `json:"acmm_level"`
+	Status      string                    `json:"status"`
+	CreatedAt   string                    `json:"created_at"`
+	Subdomain   string                    `json:"subdomain"`
 	// VanityURL is the friendly dashboard URL derived from the claimed project
 	// (e.g. hosted-<org>-<repo>-*.hive.kubestellar.io), set at ASSIGN time. Its
 	// presence is the explicit marker that a placeholder has been claimed —

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -849,9 +849,9 @@ type HubServer struct {
 	upgradePause       UpgradePauseState
 	upgradePauseLoaded bool
 	upgradePauseMu     sync.Mutex // guards upgradePause + upgradePauseLoaded
-	httpServer      *http.Server
-	httpMu          sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
-	clusters        map[string]ClusterConfig
+	httpServer         *http.Server
+	httpMu             sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
+	clusters           map[string]ClusterConfig
 
 	// vanityHostServable overrides how the retroactive vanity-URL repair makes a
 	// vanity host servable (see makeVanityHostServable). nil in production, where
@@ -1624,6 +1624,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				// inactive-agent rule, never as evidence of idleness.
 				payload.Agents[i].StartedAt = sanitizeHeartbeatField(payload.Agents[i].StartedAt)
 				payload.Agents[i].LastActivityAt = sanitizeHeartbeatField(payload.Agents[i].LastActivityAt)
+				// Pause provenance (#4041). Trigger and actor are identifiers
+				// ("dashboard-api", a GitHub login); the reason is prose the
+				// hover renders to a human; the timestamp keeps its colons via
+				// the HTML-escaping sanitizer, same as the entry's StartedAt.
+				payload.Agents[i].PausedTrigger = sanitizeHeartbeatField(payload.Agents[i].PausedTrigger)
+				payload.Agents[i].PausedBy = sanitizeHeartbeatField(payload.Agents[i].PausedBy)
+				payload.Agents[i].PausedReason = sanitizeProseField(payload.Agents[i].PausedReason)
+				payload.Agents[i].PausedAt = sanitizeField(payload.Agents[i].PausedAt)
 			}
 			const maxAgents = 50
 			if len(payload.Agents) > maxAgents {

--- a/src/pkg/hub/spark_downsample_test.go
+++ b/src/pkg/hub/spark_downsample_test.go
@@ -145,7 +145,7 @@ func TestDashboardHivesCacheIsBoundedAndVersioned(t *testing.T) {
 		snippet string
 	}{
 		{"cache key", "var LS_HIVES_CACHE = 'hive-my-hives-cache';"},
-		{"schema version", "var HIVES_CACHE_VERSION = 2;"},
+		{"schema version", "var HIVES_CACHE_VERSION = 3;"},
 		{"named TTL constant", "var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;"},
 		{"named row cap", "var HIVES_CACHE_MAX_ROWS = 200;"},
 		{"version is enforced on read", "if (!c || c.version !== HIVES_CACHE_VERSION) return null;"},

--- a/src/pkg/scheduler/issue_filter_notice_test.go
+++ b/src/pkg/scheduler/issue_filter_notice_test.go
@@ -1,0 +1,73 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// The issue-filter NOTICE is prompt text only — enforcement lives at
+// enumeration (pkg/github fetchIssues), tested there. These tests pin that
+// kick prompts state the active policy so agents are never told to go look at
+// excluded issues, and that an unconfigured hive's prompts are unchanged.
+
+func newSchedulerWithFilter(f config.IssueFilterConfig) *Scheduler {
+	cfg := &config.Config{
+		Project: config.ProjectConfig{
+			Org:         "test-org",
+			Repos:       []string{"test-org/common"},
+			IssueFilter: f,
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(cfg, logger)
+}
+
+func TestScannerMessage_IssueFilterNoticePresent(t *testing.T) {
+	s := newSchedulerWithFilter(config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+	})
+	msg := s.buildScannerMessage(nil, emptyActionable())
+	if !strings.Contains(msg, "ISSUE FILTER") {
+		t.Errorf("scanner kick missing issue-filter notice:\n%s", msg)
+	}
+	if !strings.Contains(msg, "approved-for-agents") {
+		t.Errorf("scanner kick does not name the required label:\n%s", msg)
+	}
+}
+
+// TestScannerMessage_NoFilterNoNotice is the regression pin: an unconfigured
+// hive's kick prompt carries no filter text at all.
+func TestScannerMessage_NoFilterNoNotice(t *testing.T) {
+	s := newScheduler()
+	msg := s.buildScannerMessage(nil, emptyActionable())
+	if strings.Contains(msg, "ISSUE FILTER") {
+		t.Errorf("unconfigured hive's scanner kick mentions an issue filter:\n%s", msg)
+	}
+}
+
+// TestFormatIssueList_CarriesNotice: templates render issues via
+// ${ISSUE_LIST}; the notice must ride it so template-driven kicks state the
+// policy too — including when the filter leaves the list empty, which is
+// exactly when an agent is most tempted to go find work by itself.
+func TestFormatIssueList_CarriesNotice(t *testing.T) {
+	s := newSchedulerWithFilter(config.IssueFilterConfig{
+		RequireLabels: []string{"approved-for-agents"},
+	})
+	out := s.formatIssueList(nil)
+	if !strings.Contains(out, "ISSUE FILTER") {
+		t.Errorf("empty ${ISSUE_LIST} missing issue-filter notice: %q", out)
+	}
+	if !strings.Contains(out, "(none)") {
+		t.Errorf("empty ${ISSUE_LIST} lost its (none) marker: %q", out)
+	}
+
+	// Unconfigured: exact legacy output, byte for byte.
+	legacy := newScheduler().formatIssueList(nil)
+	if legacy != "(none)" {
+		t.Errorf("unconfigured empty ${ISSUE_LIST} changed: %q, want %q", legacy, "(none)")
+	}
+}

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -290,11 +290,34 @@ func (s *Scheduler) formatIssueList(issues []github.Issue) string {
 	return out
 }
 
-func (s *Scheduler) formatIssueListWithPolicy(issues []github.Issue) (string, bool) {
-	if len(issues) == 0 {
-		return "(none)", false
+// issueFilterNotice renders the operator's project.issue_filter as prompt text,
+// or "" when no filter is configured. The filter is ENFORCED upstream at
+// enumeration (github.Client.fetchIssues) — filtered issues never reach any
+// kick — so this notice is informational: it tells agents WHY the list may
+// look smaller than the repo's open issues and not to go hunting for the rest.
+// It is prepended to every issue list (${ISSUE_LIST} in kick templates and the
+// hardcoded builders alike) so no agent is ever told to look at excluded
+// issues.
+func (s *Scheduler) issueFilterNotice() string {
+	f := s.cfg.Project.IssueFilter
+	if f.IsZero() {
+		return ""
 	}
 	var b strings.Builder
+	b.WriteString("ISSUE FILTER (operator policy — already enforced; the issue list below reflects it):\n")
+	b.WriteString(fmt.Sprintf("  Agents may ONLY work issues carrying at least one of these labels: %s\n",
+		strings.Join(f.RequireLabels, ", ")))
+	b.WriteString("  ⛔ Do NOT pick up, plan, or open PRs for issues outside this list, even if you find them by listing the repo yourself.\n")
+	return b.String()
+}
+
+func (s *Scheduler) formatIssueListWithPolicy(issues []github.Issue) (string, bool) {
+	notice := s.issueFilterNotice()
+	if len(issues) == 0 {
+		return notice + "(none)", false
+	}
+	var b strings.Builder
+	b.WriteString(notice)
 	shown := 0
 	failClosed := false
 	for _, issue := range issues {
@@ -572,6 +595,7 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 
 	b.WriteString("[agent:scanner]\n")
 	b.WriteString(fmt.Sprintf("YOUR WORK LIST (pre-filtered — hold/ADOPTERS/drafts excluded, classified):\n"))
+	b.WriteString(s.issueFilterNotice())
 
 	scannerIssues := issues
 
@@ -832,6 +856,7 @@ func (s *Scheduler) buildGenericMessage(agentName string, issues []github.Issue,
 	baseName := s.cfg.BaseAgentName(agentName)
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("[agent:%s]\n", agentName))
+	b.WriteString(s.issueFilterNotice())
 
 	agentIssues := filterByLane(issues, baseName)
 	if len(agentIssues) > 0 {

--- a/src/pkg/snapshot/state.go
+++ b/src/pkg/snapshot/state.go
@@ -70,10 +70,14 @@ type ConfigOverrides struct {
 }
 
 type AgentState struct {
-	Paused          bool             `json:"paused"`
-	PausedAt        *time.Time       `json:"paused_at,omitempty"`
-	PausedReason    string           `json:"paused_reason,omitempty"`
-	PausedTrigger   string           `json:"paused_trigger,omitempty"`
+	Paused        bool       `json:"paused"`
+	PausedAt      *time.Time `json:"paused_at,omitempty"`
+	PausedReason  string     `json:"paused_reason,omitempty"`
+	PausedTrigger string     `json:"paused_trigger,omitempty"`
+	// PausedBy is the acting user behind the pause when one is known (the
+	// authenticated dashboard user); empty for system-initiated pauses.
+	// Persisted so pause provenance survives restarts (#4041).
+	PausedBy        string           `json:"paused_by,omitempty"`
 	PinnedCLI       string           `json:"pinned_cli,omitempty"`
 	PinnedModel     string           `json:"pinned_model,omitempty"`
 	ModelOverride   string           `json:"model_override,omitempty"`


### PR DESCRIPTION
Top-up merge of `v4` (production) into `v5` (the RFC implementation line, #4000/#4001/#4002).

A **merge commit, not a squash** — sync PRs preserve both histories, matching the repo's prior v2→v4 and v4→dd top-ups.

## Incoming from v4 (15 commits)

| PR | Change |
|---|---|
| #4055 | surface pause provenance — WHO paused WHAT WHEN, everywhere a pause is read (landed on v4 mid-sync and folded in via a second merge commit; no conflicts, touches no RFC package) |
| #4051 | de-materialize stale `login_patterns` so #3959 defaults reach existing hives |
| #4049 | gh-wrapper author-gated listing for staff agents — trusted bot-identity file replaces the `/user` oracle App installation tokens can never satisfy |
| #4048 | agent-launch scrubs backend-re-exported GitHub tokens from agent tool shells |
| #4046 | deleted-cwd fix pinned across three spawn sites (CLI, container entrypoint, relay pane) |
| #4047 | gh-wrapper label injection must never fail the operation; edit/create retry unlabeled; per-repo ensure cache; fail loud on empty token cache |
| #4040 | `project.issue_filter` — label-gate which issues agents may initiate work on |
| #3898 | scale default mode thresholds by repo count |
| #4035 | openshift-netadmin SCC overlay + NET_ADMIN pre-flight docs |
| #4028 | hub: leaked background commit-order resolves reached the real GitHub API from unit tests, flaking the coverage gate |
| #4027 | scrub internal cluster names from master-delivery design doc |
| #4039 | relay CLI-liveness probe could never see a dead CLI |

## Conflicts and resolution

**No merge conflicts** in either merge (the initial top-up, and the second merge that folded in #4055 after it landed on v4 mid-sync). The two branches' change sets were almost entirely disjoint — exactly one file was touched on both sides:

| File | Resolution | Rationale |
|---|---|---|
| `.github/workflows/v2-ci.yml` | Auto-merged, both sides kept — verified by hand | v5 edited the trigger lists (`branches: [v2, v4]` → `[v2, v4, v5]`, lines 5 and 11); v4 appended a new job step (`agent shell token scrub (#4045)` running `bin/test_agent_env_scrub.sh`). Non-overlapping hunks, so the v5-wins/v4-wins split did not have to be adjudicated — both intents are present in the merged file and were confirmed by grep rather than assumed from git's exit code. |

No file in the RFC packages (`src/pkg/turn/`, `src/pkg/toolapprove/`, `src/docs/design/reentrant-turn-model.md`, `agent-state-inventory.md`) was touched by v4, so the "v5 wins in the RFC packages" rule never had to fire. No shared source file was touched by both sides, so no v4 production fix could be regressed by a stale v5 copy.

## Anchor verification (on the merged tree)

Standing security anchors — all present and non-empty:

| Anchor | Result |
|---|---|
| `MintSSOToken` | 12 files |
| `verifyHeartbeatBearer` | 16 files |
| `derivePerHiveKey` | 24 files |
| `SecretFilePathAllowed` | 4 files |
| `mintHubUserCookieValueV2` | 12 files |

Tonight's anchors — all present:

| Anchor | Result |
|---|---|
| `CONTRIBUTOR_MODE_MARKER` constant, no env indirection | `bin/gh-wrapper.sh:32` — `CONTRIBUTOR_MODE_MARKER="/etc/hive/contributor-mode"`, a literal. `gh-wrapper.test.sh:49-51` rewrites the constant in a test copy and hard-fails if the literal is gone, so env indirection cannot be reintroduced silently. |
| `_extract_author` last-value semantics | `bin/gh-wrapper.sh:317` — loop over all args with `continue`, never an early `break`, so the **last** `--author`/`-A` wins; consumed at line 411. |
| Trusted bot-identity file path (#4049) | `bin/gh-wrapper.sh:34-48` — path is a CONSTANT; `HIVE_GH_WRAPPER_BOT_LOGIN_FILE` honored only under the test harness's `REAL_GH` override. Gate asserted by `bin/test_gh_wrapper_gates.sh:476`. |
| `agent-env-scrub.sh` + BASH_ENV wiring (#4048) | Script present; `unset GITHUB_TOKEN / GH_TOKEN / GH_ENTERPRISE_TOKEN / GITHUB_ENTERPRISE_TOKEN`. Exported at `bin/agent-launch.sh:229`; interactive-shell guard in `src/Dockerfile:361,378`. |
| `cd`-prefixed launches, 3 spawn sites (#4046) | `bin/contributor-relay.sh:1397` (`cd ${shellQuote(cwd)} && ${launchCmd}`), `bin/contributor-agent.sh:551` (`cd $(printf %q "$HIVE_AGENT_CWD") && …`), plus the dashboard site covered by `src/pkg/dashboard/contribute_pane_cwd_test.go`. |

## Verification

- `go build ./...` — clean
- `go vet ./pkg/turn/... ./pkg/toolapprove/...` — clean
- `go test ./pkg/turn/... ./pkg/toolapprove/...` — ok
- `go test ./pkg/dashboard/ -run 'PinsPaneWorkingDirectory|Cwd'` — ok (#4046 regression cover)
- `bin/gh-wrapper.test.sh`, `bin/test_gh_wrapper_gates.sh`, `bin/test_agent_env_scrub.sh`, `bin/test_gh_auth_native_no_cat.sh` — all pass
- `bin/contributor-relay.test.js` — pass
