### PR TITLE
🐛 fix(relay): a pane-stall failure could misreport a task that finished moments later, with a real PR

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1434,12 +1434,35 @@ function relaunchCLI() {
 // test suite, a slow clone) for many minutes without drawing anything new.
 const PANE_STALL_TIMEOUT_MS = Number(process.env.HIVE_PANE_STALL_TIMEOUT_MS) || 20 * 60 * 1000;
 
+// Observed live (kubestellar/hive): a task crossed PANE_STALL_TIMEOUT_MS while
+// agy sat blocked on a slow `gh pr create` network round trip. The relay
+// declared it a failure and moved on to the next task, and the pane then, only
+// seconds to minutes later, printed the CLI's real completion summary — with a
+// genuine PR link. The pane fingerprint at the instant of the stall check
+// cannot contain output that has not streamed in yet, so checking it harder at
+// that single instant cannot fix this; giving the CLI a FEW more ticks to
+// reach a real PANE_STATE_IDLE_COMPLETE (which already runs full PR/no-work
+// detection, see detectPRURL/detectNoWorkVerdict below) can. So the stall
+// verdict must be CONFIRMED on this many consecutive ticks — each
+// PROGRESS_REPORT_INTERVAL_MS apart, and each one re-running
+// checkTmuxPaneState() first — before the relay gives up. A tick where the
+// pane has since gone idle-complete, or produced any new output, exits this
+// path before the confirm count is ever consulted.
+const PANE_STALL_CONFIRM_TICKS = Math.max(1, Number(process.env.HIVE_PANE_STALL_CONFIRM_TICKS) || 2);
+
 let lastPaneFingerprint = null;
 let lastPaneChangeAt = 0;
+// How many CONSECUTIVE ticks paneStalled() has now returned true. Distinct
+// from the fingerprint clock above: that clock says "how long has it been
+// unchanged", this says "how many chances has the CLI had to prove otherwise
+// since we first noticed". Reset by resetPaneStallClock() and by any tick
+// where paneStalled() is false (new output resets the whole stall story).
+let stallConfirmCount = 0;
 
 function resetPaneStallClock() {
   lastPaneFingerprint = null;
   lastPaneChangeAt = Date.now();
+  stallConfirmCount = 0;
   // A new task also starts with a clean CLI-liveness count: shell readings from
   // the previous task say nothing about this one.
   consecutiveShellReadings = 0;
@@ -1461,6 +1484,21 @@ function paneStalled(tmuxLines) {
   if (!fingerprint) return false;
   if (!lastPaneChangeAt) { lastPaneChangeAt = now; return false; }
   return now - lastPaneChangeAt >= PANE_STALL_TIMEOUT_MS;
+}
+
+// paneStallConfirmed wraps paneStalled() with the multi-tick confirmation
+// described above it. Any tick where paneStalled() is false (new output
+// appeared) resets the count — the CLI gets full credit for proving it is not
+// stuck, not just a one-shot escape. Kept separate from paneStalled() itself
+// so tests of the underlying timeout signal are unaffected by the confirm
+// gate, and vice versa.
+function paneStallConfirmed(tmuxLines) {
+  if (!paneStalled(tmuxLines)) {
+    stallConfirmCount = 0;
+    return false;
+  }
+  stallConfirmCount++;
+  return stallConfirmCount >= PANE_STALL_CONFIRM_TICKS;
 }
 
 function flushPendingTask() {
@@ -1703,12 +1741,29 @@ function progressTick() {
   } else {
     // Stall backstop: a pane frozen this long is not evidence of work, and
     // continuing to report "working" would renew the hub's lease forever.
-    if (paneStalled(tmuxLines)) {
+    // Confirmed over PANE_STALL_CONFIRM_TICKS ticks rather than acted on
+    // immediately — see the comment above PANE_STALL_CONFIRM_TICKS for why a
+    // single instant cannot distinguish "stuck" from "about to finish".
+    if (paneStallConfirmed(tmuxLines)) {
+      // The CLI may still be mid-turn on the task we are about to give up on
+      // (observed live: a slow `gh pr create` returned, with a real PR link,
+      // seconds after the stall verdict). Relaunch it so the NEXT task starts
+      // on a demonstrably fresh CLI, rather than risking its prompt landing on
+      // top of whatever the abandoned turn still produces — the same reason
+      // the CLI-died branch above relaunches before failing the task.
+      try {
+        console.log(`Relaunching ${BACKEND} after a confirmed pane stall: ${relaunchCLI()}`);
+      } catch (e) {
+        console.error('Failed to relaunch after a confirmed pane stall:', e.message);
+      }
       failCurrentTask(
-        `no pane activity for ${Math.round(PANE_STALL_TIMEOUT_MS / 60000)} minutes — the agent CLI is not visibly working`,
+        `no pane activity for ${Math.round(PANE_STALL_TIMEOUT_MS / 60000)}+ minutes, confirmed over ${PANE_STALL_CONFIRM_TICKS} checks — the agent CLI is not visibly working`,
         { kind: 'environment' }
       );
       return;
+    }
+    if (stallConfirmCount > 0) {
+      console.warn(`Pane unchanged for ${Math.round(PANE_STALL_TIMEOUT_MS / 60000)}+ minutes — confirming before giving up on ${currentTask.task_id} (${stallConfirmCount}/${PANE_STALL_CONFIRM_TICKS})`);
     }
     send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: tmuxLines });
   }
@@ -2029,7 +2084,10 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     // Run one progress tick with the grace period already elapsed.
     __crashTick: () => { taskAssignedAt = Date.now() - TASK_GRACE_PERIOD_MS - 1; progressTick(); },
     paneStalled,
+    paneStallConfirmed,
     resetPaneStallClock,
+    PANE_STALL_CONFIRM_TICKS,
+    getStallConfirmCount: () => stallConfirmCount,
     launchCommandWithCwd,
     cliProcessLooksGone,
     paneForegroundCommand,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -44,7 +44,10 @@ function loadRelay({ backend = 'copilot', backendBinary = null, model = '', reas
     if (/capture-pane/.test(cmd)) {
       // paneText, when given, is returned verbatim — for tests that need a
       // REAL pane rendering (e.g. a codex modal menu) rather than one of the
-      // three synthetic states below.
+      // three synthetic states below. A function is called fresh each capture
+      // (tests that need the pane to CHANGE partway through, e.g. a late
+      // completion arriving after a stall confirmation tick).
+      if (typeof paneText === 'function') return paneText();
       if (paneText !== null) return paneText;
       const state = cliStates[Math.min(stateIdx++, cliStates.length - 1)];
       // Panes that getCLIState()/checkTmuxIdle() classify per backend.
@@ -370,7 +373,12 @@ test('an unchanging pane trips the stall backstop; any change resets it', () => 
   } finally { teardown(relay); }
 });
 
-test('a stalled pane hands the task back as an environment failure', () => {
+test('a stalled pane is NOT failed on the first confirmation tick', () => {
+  // Observed live: a task can cross PANE_STALL_TIMEOUT_MS while the CLI is
+  // blocked on a slow network call (a `gh pr create` round trip), then print
+  // its real completion — with a real PR link — moments later. The relay must
+  // not act on the very first tick that crosses the timeout; it needs to give
+  // the CLI PANE_STALL_CONFIRM_TICKS chances to prove it was about to finish.
   const relay = loadRelay({
     backend: 'agy',
     paneText: 'a frozen pane with no idle prompt and nothing happening',
@@ -380,13 +388,90 @@ test('a stalled pane hands the task back as an environment failure', () => {
     assignTask(relay, 't-stall');
     relay.__stallTick();   // records the fingerprint, reports working
     relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
-    relay.__stallTick();   // same pane past the timeout -> give the task back
+    relay.__stallTick();   // first tick past the timeout -> confirmation 1, not a failure yet
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_failed').length, 0,
+      'the first tick past the stall timeout must not fail the task on its own');
+    assert.strictEqual(relay.getStallConfirmCount(), 1);
+    assert.strictEqual(relay.getCurrentTask() && relay.getCurrentTask().task_id, 't-stall',
+      'the task must still be held while confirmation is pending');
+  } finally { teardown(relay); }
+});
+
+test('a pane that recovers between stall ticks is NOT failed, and the confirm count resets', () => {
+  let capture = 'a frozen pane with no idle prompt and nothing happening';
+  const relay = loadRelay({ backend: 'agy', paneText: () => capture });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-recover');
+    relay.__stallTick();
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();   // confirmation 1
+    assert.strictEqual(relay.getStallConfirmCount(), 1);
+    // New output appears -- the CLI was never actually stuck.
+    capture = 'a frozen pane with no idle prompt and nothing happening, plus fresh output this time';
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS);
+    relay.__stallTick();
+    assert.strictEqual(relay.getStallConfirmCount(), 0,
+      'any new pane content must reset the confirm count, not just delay the verdict');
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_failed').length, 0);
+  } finally { teardown(relay); }
+});
+
+test('a stalled pane hands the task back as an environment failure once confirmed, and relaunches the CLI', () => {
+  const relay = loadRelay({
+    backend: 'agy',
+    paneText: 'a frozen pane with no idle prompt and nothing happening',
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-stall');
+    relay.__stallTick();
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();   // confirmation 1 — not yet failed (see the test above)
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    const before = relay.__tmuxSends().length;
+    relay.__stallTick();   // confirmation 2 (== PANE_STALL_CONFIRM_TICKS) -> give the task back
     const failed = relay.__sent.filter(m => m.type === 'task_failed');
     assert.strictEqual(failed.length, 1, `expected one task_failed, got ${JSON.stringify(relay.__sent.map(m => m.type))}`);
     assert.strictEqual(failed[0].failure_kind, 'environment',
       'a frozen pane says nothing about the WORK, so the failure is the environment kind');
     assert.match(failed[0].reason, /no pane activity/);
+    assert.match(failed[0].reason, new RegExp(String(relay.PANE_STALL_CONFIRM_TICKS)),
+      'the failure reason should name how many checks confirmed it, for anyone reading the log');
     assert.strictEqual(relay.getCurrentTask(), null, 'the relay must let go of the task, not keep renewing its lease');
+    // The CLI is relaunched so the NEXT task cannot land its prompt on top of
+    // whatever the abandoned turn is still doing in the background.
+    const sends = relay.__tmuxSends().slice(before);
+    assert.ok(sends.some(c => /agy/.test(c)),
+      `a confirmed stall must relaunch the CLI: ${JSON.stringify(sends)}`);
+  } finally { teardown(relay); }
+});
+
+test('a pane that reaches real IDLE_COMPLETE between stall ticks is reported as a normal completion, PR and all', () => {
+  // The exact live scenario: paneText starts frozen (mid stall), then -- before
+  // the SECOND confirmation tick -- the CLI's real completion appears, agy back
+  // at its idle prompt with a PR link in the output. checkTmuxPaneState() must
+  // win over the stall path on that tick, so the task is reported completed
+  // with the PR, not failed.
+  let capture = 'a frozen pane with no idle prompt and nothing happening';
+  const relay = loadRelay({ backend: 'agy', paneText: () => capture });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-late-finish');
+    relay.__stallTick();
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();   // confirmation 1
+    assert.strictEqual(relay.getStallConfirmCount(), 1);
+    // The slow network call the pane was blocked on finally returns.
+    capture = 'Pull request opened: foo/bar#4061 https://github.com/foo/bar/pull/4061\n? for shortcuts';
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();
+    const completed = relay.__sent.filter(m => m.type === 'task_complete');
+    assert.strictEqual(completed.length, 1,
+      `late completion must be reported as completed, not failed: ${JSON.stringify(relay.__sent.map(m => m.type))}`);
+    assert.strictEqual(completed[0].pr_url, 'https://github.com/foo/bar/pull/4061',
+      'the PR that actually landed must be credited, not lost to the stall path');
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_failed').length, 0);
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
## Symptom

Observed live on an agy contributor. Two consecutive tasks were reported to the hub as `failed`, both at **exactly 24:01** from pickup:

```
11:45:32Z  picked up  issue #4060
12:09:33Z  failed     ct-kubestellar/hive-4060-1787053532
12:09:34Z  picked up  issue #4062
12:33:35Z  failed     ct-kubestellar/hive-4062-1787054974
```

That is `PANE_STALL_TIMEOUT_MS` (20 min, #4026) plus tick alignment — the stall backstop, not a crash.

**But the work had actually succeeded.** The pane for #4060 shows agy committing, pushing, and opening a pull request; verified independently against the GitHub API rather than trusting the agent's self-report:

```
#4061 [OPEN] head=Danathar:fix/stale-v2-url-refs
      "🐛 fix(docs,dashboard,deploy): replace stale v2 branch refs with HEAD in URLs"
      body: "Fixes #4060"
```

The CLI was blocked on a slow `gh pr create` round trip when the timeout expired. The relay declared `environment` failure and moved on; the completion — with the PR link — printed moments later.

## Why the fix isn't "inspect the pane harder"

The pane fingerprint **at the instant of the stall check** cannot contain output that has not streamed in yet, so no smarter inspection of that one snapshot helps. The CLI needs *more chances* to reach a real completion before the relay gives up — the same reasoning as `CLI_GONE_CONFIRMATIONS` in #4039: one reading can't distinguish "stuck" from "about to finish".

## Fix

- `paneStalled()` — the pure timeout signal — is **unchanged** and still directly tested.
- New `paneStallConfirmed()` requires the stall to hold across `PANE_STALL_CONFIRM_TICKS` consecutive ticks (default **2**, ~2 min apart, overridable via `HIVE_PANE_STALL_CONFIRM_TICKS`).
- Each confirmation tick still runs `checkTmuxPaneState()` **first**. That is the existing, correctly-instrumented completion path (`detectPRURL` / `detectNoWorkVerdict`), so a CLI that reaches real `PANE_STATE_IDLE_COMPLETE` on a confirmation tick is reported as a **normal completion with its PR credited**, and never reaches the failure path.
- **Any** genuinely new pane content resets the confirm count to zero — full credit for proving it wasn't stuck, not a one-time reprieve.
- Once a stall *is* confirmed, the CLI is **relaunched before** the task is failed, matching the order the CLI-died branch already uses. Previously the abandoned turn's process was left running; this incident's PR happened to land before the next prompt was typed, but nothing guaranteed that — a mid-turn CLI receiving the next task's prompt is the #2203 wedge shape.

## Cost of the change

Worst case adds one confirmation interval (~2 min) before a genuinely wedged task is handed back. The hub's own `wsTaskTimeout` reclaim (30 min) is unaffected and still bounds the outer case.

## Tests

- the first tick past the timeout must **not** fail the task on its own;
- new pane content between ticks resets the confirm count;
- a confirmed stall fails the task **and** relaunches the CLI (reason string names the confirmation count);
- **the live scenario**: a pane reaching idle-complete *with a PR link* between confirmation ticks is reported `task_complete` with `pr_url` set, and never `task_failed`.

The harness's `paneText` option now also accepts a function, so a test can vary captured pane content across ticks.

**92/92 relay tests pass.**

_Investigated and written with Claude Sonnet 5 (auto effort)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)