### PR TITLE
fix(scheduler,policies): stop PR templates auto-closing multi-phase epics

### DIFF
--- a/v2/pkg/policies/defaults/architect-full.md
+++ b/v2/pkg/policies/defaults/architect-full.md
@@ -52,7 +52,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[architect] refactor: <short description>" \
-  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number>\n\n---\n*Filed by architect agent (ACMM L6 — full mode)*" \
+  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by architect agent (ACMM L6 — full mode)*" \
   --label "architecture"
 ```
 

--- a/v2/pkg/policies/defaults/architect-holdgated.md
+++ b/v2/pkg/policies/defaults/architect-holdgated.md
@@ -51,7 +51,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[architect] refactor: <short description>" \
-  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number>\n\n---\n*Filed by architect agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by architect agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "architecture,hold"
 ```
 

--- a/v2/pkg/policies/defaults/ci-maintainer-full.md
+++ b/v2/pkg/policies/defaults/ci-maintainer-full.md
@@ -32,7 +32,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[ci-maintainer] fix: <short description>" \
-  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by ci-maintainer agent (ACMM L6 — full mode)*" \
+  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by ci-maintainer agent (ACMM L6 — full mode)*" \
   --label "ci"
 ```
 

--- a/v2/pkg/policies/defaults/ci-maintainer-holdgated.md
+++ b/v2/pkg/policies/defaults/ci-maintainer-holdgated.md
@@ -44,7 +44,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[ci-maintainer] fix: <short description>" \
-  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by ci-maintainer agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by ci-maintainer agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "ci,hold"
 ```
 

--- a/v2/pkg/policies/defaults/guide-full.md
+++ b/v2/pkg/policies/defaults/guide-full.md
@@ -33,7 +33,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[guide] docs: <short description>" \
-  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number>\n\n---\n*Filed by guide agent (ACMM L6 — full mode)*" \
+  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by guide agent (ACMM L6 — full mode)*" \
   --label "documentation"
 ```
 

--- a/v2/pkg/policies/defaults/guide-holdgated.md
+++ b/v2/pkg/policies/defaults/guide-holdgated.md
@@ -34,7 +34,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[guide] docs: <short description>" \
-  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number>\n\n---\n*Filed by guide agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by guide agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "documentation,hold"
 ```
 

--- a/v2/pkg/policies/defaults/quality-full.md
+++ b/v2/pkg/policies/defaults/quality-full.md
@@ -48,7 +48,7 @@ Issue types: `coverage-gap`, `missing-workflow`, `test-infrastructure`, `coverag
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[quality] <short description of test improvement>" \
-  --body "## Test Improvement\n\n<what this PR adds/changes>\n\nFixes #<issue-number>\n\n---\n*Filed by quality agent (ACMM L4/L6 — full mode)*" \
+  --body "## Test Improvement\n\n<what this PR adds/changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by quality agent (ACMM L4/L6 — full mode)*" \
   --label "quality,testing"
 ```
 

--- a/v2/pkg/policies/defaults/quality-holdgated.md
+++ b/v2/pkg/policies/defaults/quality-holdgated.md
@@ -62,7 +62,7 @@ gh pr create --repo "$HIVE_REPO" \
 <what this PR adds/changes>
 
 ## Related Issue
-Fixes #<issue-number> (if applicable)
+Fixes #<issue-number> (if applicable, and only if this fully resolves it — use Refs #<issue-number> instead for an epic/multi-phase tracker)
 
 ---
 *Filed by quality agent (hold-gated mode). Human review required.*" \

--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -73,7 +73,7 @@ Steps:
 8. git commit -s -m "[scanner] fix: <short description covering all issues>"
 9. git push -u origin scanner/fix-<lowest-number>
 10. Open the PR with **`hive-open-pr`** (the hive opens it as the App bot):
-    `hive-open-pr --repo <org>/<repo> --head scanner/fix-<lowest-number> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>"` (repeat Fixes keyword for each issue).
+    `hive-open-pr --repo <org>/<repo> --head scanner/fix-<lowest-number> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>"` (repeat Fixes keyword for each issue -- only for issues this PR fully resolves; use Refs #<n> instead for any that are epics/multi-phase trackers).
     Do NOT use the GitHub MCP `create_pull_request` / `create_pull_request_with_copilot`, and do NOT run raw `gh pr create` — both author the PR as the login user. `hive-open-pr` is the only sanctioned way to open a PR; the hive opens it with the App token so it is authored by the App bot. `gh pr create` is auto-redirected to `hive-open-pr` for you, but call `hive-open-pr` directly.
 11. git worktree remove /tmp/scanner-fix-<lowest-number>
 12. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint

--- a/v2/pkg/policies/defaults/scanner-full.md
+++ b/v2/pkg/policies/defaults/scanner-full.md
@@ -36,7 +36,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[scanner] fix: <short description>" \
-  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number>\n\n---\n*Filed by scanner agent (ACMM L6 — full mode)*"
+  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by scanner agent (ACMM L6 — full mode)*"
 ```
 
 ## Writing Beads

--- a/v2/pkg/policies/defaults/scanner-holdgated.md
+++ b/v2/pkg/policies/defaults/scanner-holdgated.md
@@ -36,7 +36,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[scanner] fix: <short description>" \
-  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number>\n\n---\n*Filed by scanner agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by scanner agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "hold"
 ```
 

--- a/v2/pkg/policies/defaults/sec-check-full.md
+++ b/v2/pkg/policies/defaults/sec-check-full.md
@@ -49,7 +49,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[sec-check] fix: <short description>" \
-  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by sec-check agent (ACMM L6 — full mode)*" \
+  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by sec-check agent (ACMM L6 — full mode)*" \
   --label "security"
 ```
 

--- a/v2/pkg/policies/defaults/sec-check-holdgated.md
+++ b/v2/pkg/policies/defaults/sec-check-holdgated.md
@@ -48,7 +48,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[sec-check] fix: <short description>" \
-  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "security,hold"
 ```
 

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -597,7 +597,7 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 
 	b.WriteString("\nWORKFLOW:\n")
 	b.WriteString("  1. Check beads (`bd list --status open`) for context from previous cycles\n")
-	b.WriteString("  2. Quick merges + cleanup (10 min cap) — merge PRs whose required checks are GREEN using a squash merge via your App token (MCP `merge_pull_request` with `merge_method: \"squash\"`, or `gh pr merge --squash`). Do NOT use `--admin` — never force-merge past pending or failing CI; wait for the required checks to pass. Ensure `Fixes #<issue>` in body. Close stale drafts (>48h, needs-rebase + dco-no, or fix already merged). `@dependabot rebase` stale ones. Move on after 10 min.\n")
+	b.WriteString("  2. Quick merges + cleanup (10 min cap) — merge PRs whose required checks are GREEN using a squash merge via your App token (MCP `merge_pull_request` with `merge_method: \"squash\"`, or `gh pr merge --squash`). Do NOT use `--admin` — never force-merge past pending or failing CI; wait for the required checks to pass. Ensure the PR body cites the issue it addresses: `Fixes #<issue>` only if this PR fully resolves it; if `<issue>` is an epic or multi-phase tracker and this PR completes just one phase, use `Refs #<issue>` or `Part of #<issue>` instead — those keywords do not auto-close on merge. Close stale drafts (>48h, needs-rebase + dco-no, or fix already merged). `@dependabot rebase` stale ones. Move on after 10 min.\n")
 	b.WriteString("  3. Fix blockers — find the ONE fix that unblocks the most PRs/issues. Clone, fix, push, merge.\n")
 	b.WriteString("  4. Crank quick fixes — launch background agents using the Agent tool (run_in_background: true) to fix remaining issues in parallel. One PR per issue, move fast.\n")
 
@@ -721,7 +721,12 @@ func (s *Scheduler) ghAuthInstructions(agentName string) string {
   'git commit' an explicit --author: let the App identity stand.
 - To OPEN A PULL REQUEST, use `+"`hive-open-pr`"+` — the hive opens it with the
   App token so it is authored by the App bot ("<slug>[bot]"), never the login user:
-    hive-open-pr --repo <org>/<repo> --head <your-branch> --title "<title>" --body "<body with Fixes #N>"
+    hive-open-pr --repo <org>/<repo> --head <your-branch> --title "<title>" --body "<body citing the issue>"
+  Cite the issue correctly: `+"`Fixes #N`"+` / `+"`Closes #N`"+` ONLY if this PR is the
+  final phase and fully resolves issue N — those keywords auto-close it on
+  merge. If N is an epic or multi-phase tracker and this PR completes only
+  part of it, use `+"`Refs #N`"+` or `+"`Part of #N`"+` instead (non-closing), so the
+  tracker stays open until every listed phase actually lands.
   Do NOT open PRs with the GitHub MCP (create_pull_request / create_pull_request_with_copilot)
   or raw 'gh pr create' — those author the PR as the Copilot login user. 'gh pr create'
   is auto-redirected to hive-open-pr, but prefer calling hive-open-pr directly.

--- a/v2/policies/architect-full.md
+++ b/v2/policies/architect-full.md
@@ -52,7 +52,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[architect] refactor: <short description>" \
-  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number>\n\n---\n*Filed by architect agent (ACMM L6 — full mode)*" \
+  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by architect agent (ACMM L6 — full mode)*" \
   --label "architecture"
 ```
 

--- a/v2/policies/architect-holdgated.md
+++ b/v2/policies/architect-holdgated.md
@@ -51,7 +51,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[architect] refactor: <short description>" \
-  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number>\n\n---\n*Filed by architect agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Refactor\n\n<what this changes structurally and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by architect agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "architecture,hold"
 ```
 

--- a/v2/policies/ci-maintainer-full.md
+++ b/v2/policies/ci-maintainer-full.md
@@ -34,7 +34,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[ci-maintainer] fix: <short description>" \
-  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by ci-maintainer agent (ACMM L6 — full mode)*" \
+  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by ci-maintainer agent (ACMM L6 — full mode)*" \
   --label "ci"
 ```
 

--- a/v2/policies/ci-maintainer-holdgated.md
+++ b/v2/policies/ci-maintainer-holdgated.md
@@ -46,7 +46,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[ci-maintainer] fix: <short description>" \
-  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by ci-maintainer agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## CI Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by ci-maintainer agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "ci,hold"
 ```
 

--- a/v2/policies/guide-full.md
+++ b/v2/policies/guide-full.md
@@ -35,7 +35,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[guide] docs: <short description>" \
-  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number>\n\n---\n*Filed by guide agent (ACMM L6 — full mode)*" \
+  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by guide agent (ACMM L6 — full mode)*" \
   --label "documentation"
 ```
 

--- a/v2/policies/guide-holdgated.md
+++ b/v2/policies/guide-holdgated.md
@@ -36,7 +36,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[guide] docs: <short description>" \
-  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number>\n\n---\n*Filed by guide agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Documentation Fix\n\n<what this PR adds/changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by guide agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "documentation,hold"
 ```
 

--- a/v2/policies/quality-full.md
+++ b/v2/policies/quality-full.md
@@ -48,7 +48,7 @@ Issue types: `coverage-gap`, `missing-workflow`, `test-infrastructure`, `coverag
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[quality] <short description of test improvement>" \
-  --body "## Test Improvement\n\n<what this PR adds/changes>\n\nFixes #<issue-number>\n\n---\n*Filed by quality agent (ACMM L4/L6 — full mode)*" \
+  --body "## Test Improvement\n\n<what this PR adds/changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by quality agent (ACMM L4/L6 — full mode)*" \
   --label "quality,testing"
 ```
 

--- a/v2/policies/quality-holdgated.md
+++ b/v2/policies/quality-holdgated.md
@@ -62,7 +62,7 @@ gh pr create --repo "$HIVE_REPO" \
 <what this PR adds/changes>
 
 ## Related Issue
-Fixes #<issue-number> (if applicable)
+Fixes #<issue-number> (if applicable, and only if this fully resolves it — use Refs #<issue-number> instead for an epic/multi-phase tracker)
 
 ---
 *Filed by quality agent (hold-gated mode). Human review required.*" \

--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -70,7 +70,7 @@ Steps:
 7. git add the changed files
 8. git commit -s -m "[scanner] fix: <short description covering all issues>"
 9. git push -u origin scanner/fix-<lowest-number>
-10. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>" (repeat Fixes keyword for each issue)
+10. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<n1>, Fixes #<n2>, Fixes #<n3>" (repeat Fixes keyword for each issue -- only for issues this PR fully resolves; use Refs #<n> instead for any that are epics/multi-phase trackers)
 11. git worktree remove /tmp/scanner-fix-<lowest-number>
 12. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint
 ```

--- a/v2/policies/scanner-full.md
+++ b/v2/policies/scanner-full.md
@@ -36,7 +36,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[scanner] fix: <short description>" \
-  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number>\n\n---\n*Filed by scanner agent (ACMM L6 — full mode)*"
+  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by scanner agent (ACMM L6 — full mode)*"
 ```
 
 ## Writing Beads

--- a/v2/policies/scanner-holdgated.md
+++ b/v2/policies/scanner-holdgated.md
@@ -37,7 +37,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[scanner] fix: <short description>" \
-  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number>\n\n---\n*Filed by scanner agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by scanner agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "hold"
 ```
 

--- a/v2/policies/sec-check-full.md
+++ b/v2/policies/sec-check-full.md
@@ -51,7 +51,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[sec-check] fix: <short description>" \
-  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by sec-check agent (ACMM L6 — full mode)*" \
+  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by sec-check agent (ACMM L6 — full mode)*" \
   --label "security"
 ```
 

--- a/v2/policies/sec-check-holdgated.md
+++ b/v2/policies/sec-check-holdgated.md
@@ -50,7 +50,7 @@ gh issue create --repo "$HIVE_REPO" \
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[sec-check] fix: <short description>" \
-  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number>\n\n---\n*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
+  --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "security,hold"
 ```
 


### PR DESCRIPTION
Fixes #4065

## The bug

Every agent role's PR-body guidance hardcoded a bare `Fixes #<issue-number>` with no conditional on what kind of issue is being referenced — in both the shared `ghAuthInstructions()` Go helper (`v2/pkg/scheduler/scheduler.go`) included for every role, and each role's policy template (scanner, architect, quality, guide, sec-check, ci-maintainer, in both `pkg/policies/defaults/*.md` and `policies/*.md`).

Nowhere did this guidance distinguish "this PR fully resolves the issue" (where `Fixes`/`Closes` is correct — GitHub auto-closes on merge) from "this PR addresses one phase of a multi-phase epic" (where auto-closing is wrong). Observed live: an agent opened a documentation-only PR against an epic tracker, its own diff explicitly said several phases "remain a design proposal... does not commit their implementation," yet the PR body's templated `Fixes #N` auto-closed the epic anyway. Full writeup in #4065.

## The fix

- `ghAuthInstructions()` and the merge-sweep step in `scheduler.go` now say: use `Fixes #N`/`Closes #N` only if the PR is the final phase and fully resolves the issue; use `Refs #N` or `Part of #N` (non-closing) if the issue is an epic/multi-phase tracker and this PR completes only part of it.
- Every role's policy template updated with the same conditional (the codebase already had the right non-closing idiom in one place — `scanner-automerge.md`'s `"Part of #N"` for decomposed child issues — this extends it to cover epics generally).

Build + vet clean; `pkg/scheduler` and `pkg/policies` tests pass (two pre-existing `pkg/policies` failures are unrelated — a `master` vs `main` default-branch assumption in the test fixtures, reproducible identically on unmodified `v4`).