### PR TITLE
🐛 fix(relay): complete finished Codex turns

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1318,10 +1318,15 @@ function classifyTmuxPane(text) {
     hasCompletionMarker = true;
     isWorking = bobRunning && BOB_SPINNER.test(text);
   } else if (BACKEND === 'codex') {
+    // Codex retains prior tool rows in its long-lived pane.  Scope transient
+    // activity words to the tail so an old "Running" row cannot pin a
+    // completed turn in WORKING forever.
+    const codexTail = text.split('\n').slice(-15).join('\n');
     // Same marker mismatch as getCLIState(): '›' (U+203A), not '>'.
     hasIdlePrompt = /codex>|›|>\s*$/.test(text);
-    hasCompletionMarker = /completed|done|finished/i.test(text);
-    isWorking = /running|executing|thinking/i.test(text);
+    hasCompletionMarker = /completed|done|finished/i.test(text) ||
+      detectNoWorkVerdict(text.split('\n')) !== null;
+    isWorking = /running|executing|thinking/i.test(codexTail);
   } else if (BACKEND === 'pi') {
     hasIdlePrompt = /pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text);
     hasCompletionMarker = /completed|done|finished|tokens\)|\d+\.\d+%/i.test(text);

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1326,7 +1326,9 @@ function classifyTmuxPane(text) {
     hasIdlePrompt = /codex>|›|>\s*$/.test(text);
     hasCompletionMarker = /completed|done|finished/i.test(text) ||
       detectNoWorkVerdict(text.split('\n')) !== null;
-    isWorking = /running|executing|thinking/i.test(codexTail);
+    // Codex also signals an in-flight turn through its status row ("Working",
+    // "esc to interrupt") without ever printing a tool verb.
+    isWorking = /running|executing|thinking|\bworking\b|esc to interrupt/i.test(codexTail);
   } else if (BACKEND === 'pi') {
     hasIdlePrompt = /pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text);
     hasCompletionMarker = /completed|done|finished|tokens\)|\d+\.\d+%/i.test(text);

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1507,6 +1507,41 @@ test('codex still reads as WORKING while activity is in the tail', () => {
   } finally { teardown(relay); }
 });
 
+test('a pane with long diff in tail (no activity verbs) but completion_marker=true stays WORKING', () => {
+  // Regression for the tail-scope fix: narrowing the activity scan to the tail
+  // must not flip a mid-turn pane to COMPLETE just because the scrollback holds
+  // a completion word. Work is still ongoing here — codex is streaming a diff,
+  // so the tail carries neither an activity verb nor the '›' idle prompt.
+  const relay = loadRelay({ backend: 'codex' });
+  try {
+    const midTurn = [
+      '• Running git diff --stat',
+      '  done reading upstream evidence',
+      '',
+      ...Array.from({ length: 20 }, (_, i) => `+  const line${i} = compute(${i});`),
+    ].join('\n');
+    assert.strictEqual(
+      relay.classifyTmuxPane(midTurn), relay.PANE_STATE_WORKING,
+      'a mid-turn codex pane must not complete just because "done" sits in the scrollback');
+  } finally { teardown(relay); }
+});
+
+test('codex status indicators ("Working", "esc to interrupt") count as in-flight', () => {
+  const relay = loadRelay({ backend: 'codex' });
+  try {
+    for (const status of ['• Working (12s • esc to interrupt)', '  esc to interrupt']) {
+      const pane = [
+        'HIVE_VERDICT: no_work_needed — an older, finished turn',
+        '› ',
+        status,
+      ].join('\n');
+      assert.strictEqual(
+        relay.classifyTmuxPane(pane), relay.PANE_STATE_WORKING,
+        `codex status row ${JSON.stringify(status)} must read as WORKING`);
+    }
+  } finally { teardown(relay); }
+});
+
 // ---------------------------------------------------------------------------
 // Unresponsive-backend recovery: blocking modal prompts must be classified and
 // dismissed with the RIGHT key, and a CLI that never reaches its prompt must

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1443,6 +1443,18 @@ const CODEX_UPDATE_PANE = [
   '  Press enter to continue',
 ].join('\n');
 
+const CODEX_COMPLETED_NO_WORK_PANE = [
+  '• Running GH_TOKEN=... gh issue view 4065 --repo kubestellar/hive',
+  '',
+  // Codex may leave many old tool rows above the completed turn.
+  ...Array.from({ length: 20 }, (_, i) => `  checked upstream evidence ${i}`),
+  '',
+  'HIVE_VERDICT: no_work_needed — upstream PR #4066 already implements issue #4065.',
+  '─ Worked for 1m 59s ─',
+  '',
+  '› ',
+].join('\n');
+
 test('a ready codex pane is classified ready (regression: > vs \u203a, and "OpenAI Codex" not "Codex CLI")', () => {
   const relay = loadRelay({ backend: 'codex', cliStates: [CODEX_READY_PANE] });
   try {
@@ -1468,6 +1480,30 @@ test('codex numbered startup menus get explicit safe selections', () => {
     assert.strictEqual(relay.blockingPromptKey(CODEX_TRUST_PANE), '1');
     assert.strictEqual(relay.blockingPromptKey(CODEX_UPDATE_PANE), '3');
     assert.strictEqual(relay.blockingPromptKey('Do you trust this folder? (y/n)'), null);
+  } finally { teardown(relay); }
+});
+
+test('codex no-work verdict is COMPLETE despite stale activity in scrollback', () => {
+  const relay = loadRelay({ backend: 'codex' });
+  try {
+    assert.strictEqual(
+      relay.classifyTmuxPane(CODEX_COMPLETED_NO_WORK_PANE), relay.PANE_STATE_IDLE_COMPLETE,
+      'an old Codex Running row must not keep a completed no-work turn in WORKING');
+  } finally { teardown(relay); }
+});
+
+test('codex still reads as WORKING while activity is in the tail', () => {
+  const relay = loadRelay({ backend: 'codex' });
+  try {
+    const busy = [
+      'HIVE_VERDICT: no_work_needed — an older, finished turn',
+      '',
+      '› ',
+      '• Running gh issue view 4066 --repo kubestellar/hive',
+    ].join('\n');
+    assert.strictEqual(
+      relay.classifyTmuxPane(busy), relay.PANE_STATE_WORKING,
+      'recent Codex activity must still take precedence over an older verdict');
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
## Summary

- inspect Codex activity markers only in the recent tmux pane tail
- treat a real `HIVE_VERDICT: no_work_needed` as a completed turn
- cover both stale-scrollback completion and fresh-tail activity

## Root cause

Codex keeps older tool output in its interactive pane. A whole-pane match for
`Running` therefore continued to classify an idle, completed turn as working,
so the relay kept renewing the task lease instead of sending `task_complete`.

## Validation

- `node --check < bin/contributor-relay.sh`
- `node bin/contributor-relay.test.js` (91/91 passed)
