### PR TITLE
fix(apiproxy): reject unauthenticated host-key requests

### DIFF
--- a/src/cmd/apiproxy/main.go
+++ b/src/cmd/apiproxy/main.go
@@ -21,7 +21,7 @@ func proxyAuthTokenFromEnv(getenv func(string) string, warnf func(string, ...any
 	}
 	authToken = getenv("ANTHROPIC_API_KEY")
 	if authToken != "" {
-		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
+		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY to enable the proxy auth gate. Unauthenticated callers will be rejected. Set PROXY_AUTH_TOKEN explicitly to avoid using the host Anthropic key as the gate token.")
 	}
 	return authToken
 }

--- a/src/cmd/apiproxy/main_test.go
+++ b/src/cmd/apiproxy/main_test.go
@@ -33,6 +33,9 @@ func TestProxyAuthTokenFromEnvWarnsOnAnthropicFallback(t *testing.T) {
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "PROXY_AUTH_TOKEN is unset") {
 		t.Fatalf("expected actionable fallback warning, got %#v", warnings)
 	}
+	if strings.Contains(warnings[0], "Unauthenticated callers will be granted") {
+		t.Fatalf("warning must not claim unauthenticated callers receive the host key: %q", warnings[0])
+	}
 }
 
 func TestProxyAuthTokenFromEnvPrefersProxyAuthToken(t *testing.T) {

--- a/src/docs/apiproxy.md
+++ b/src/docs/apiproxy.md
@@ -2,8 +2,10 @@
 
 `cmd/apiproxy` is a small Anthropic-compatible HTTP proxy used to observe agent
 model traffic. It forwards requests to an upstream API and emits JSON event logs
-for requests/responses and SSE chunks. It can inject an upstream API key when the
-client request does not already carry a valid `Authorization` or `X-Api-Key` header.
+for requests/responses and SSE chunks. When a host key is configured, callers
+must provide a valid `Authorization` or `X-Api-Key` header or the proxy returns
+`401 Unauthorized`; the host key is never used to authenticate an unauthenticated
+caller.
 
 ## Run
 
@@ -27,8 +29,8 @@ Environment:
 
 | Name | Purpose |
 |---|---|
-| `PROXY_AUTH_TOKEN` | Preferred upstream API key used to set an outbound bearer Authorization header when the client did not send a valid key. |
-| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. The proxy logs a warning when this fallback is used because any client that can reach the proxy can use the host Anthropic key. |
+| `PROXY_AUTH_TOKEN` | Preferred upstream API key. Requests must still carry a valid caller `Authorization` or `X-Api-Key` header; this key is only used for the upstream request. |
+| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. The proxy logs a warning when this fallback is used; it is also used as the host key and requests without caller authentication are rejected. |
 
 ## Deployment notes
 
@@ -36,4 +38,6 @@ The binary listens on `127.0.0.1:<port>` by default. Treat `--host 0.0.0.0` as
 an explicit compatibility opt-in for deployments that need cross-container or
 cross-pod access, and pair it with network policy/firewall controls.
 Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in production —
-configure `PROXY_AUTH_TOKEN` explicitly instead.
+configure `PROXY_AUTH_TOKEN` explicitly instead. This controls which host key is
+used upstream, while caller authentication remains mandatory whenever either
+variable supplies a host key.

--- a/src/pkg/apiproxy/proxy.go
+++ b/src/pkg/apiproxy/proxy.go
@@ -270,6 +270,14 @@ func (p *Proxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) 
 
 // ServeHTTP implements http.Handler.
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// A configured host key must never be used as an implicit credential for
+	// callers that can reach this listener. Require callers to identify
+	// themselves before the director can add the upstream key.
+	if p.apiKey != "" && !isValidAuth(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if p.handler != nil {
 		body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyLog))
 		if err == nil {

--- a/src/pkg/apiproxy/proxy_test.go
+++ b/src/pkg/apiproxy/proxy_test.go
@@ -504,6 +504,89 @@ func TestSSEWithNoRecognisedEvents(t *testing.T) {
 	}
 }
 
+// ---- auth gate ----
+
+// A configured host key is never used for an unauthenticated caller. The
+// request must be rejected before it reaches the upstream or request logger.
+func TestServeHTTPRejectsUnauthenticatedCaller(t *testing.T) {
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer upstream.Close()
+
+	rec := &eventRecorder{}
+	p, err := New(upstream.URL, rec.handler, "host-api-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-opus-4"}`))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if upstreamCalls != 0 {
+		t.Fatalf("unauthenticated request reached upstream %d time(s)", upstreamCalls)
+	}
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("unauthenticated request was logged: %+v", got)
+	}
+}
+
+// A caller with valid auth remains eligible for proxying and receives the
+// normal upstream response.
+func TestServeHTTPAllowsAuthenticatedCaller(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	p, err := New(upstream.URL, nil, "host-api-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	callerAuth := "Bearer " + strings.Repeat("c", 40)
+	req.Header.Set("Authorization", callerAuth)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+	if gotAuth != callerAuth {
+		t.Fatalf("upstream Authorization = %q, want caller credential", gotAuth)
+	}
+}
+
+// With no configured host key, the proxy remains an unauthenticated relay.
+func TestServeHTTPWithoutConfiguredKeyAllowsUnauthenticatedCaller(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	p, err := New(upstream.URL, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
 // ---- errorHandler ----
 
 // An unreachable upstream must yield 502 rather than a hang or a panic.


### PR DESCRIPTION
## Summary
- reject requests without valid `Authorization` or `X-Api-Key` before forwarding
- ensure blocked requests are neither logged nor sent upstream
- add regression tests and update warning/deployment documentation

Fixes #4068

## Tests
- `cd src && go test ./cmd/apiproxy ./pkg/apiproxy`
- `cd src && go test ./pkg/apiproxy -race`
- `git diff --check`

Signed-off-by: Danathar <dbaggett@users.noreply.github.com>