### PR TITLE
🐛 Refresh per-agent scoped token caches for the full agent session lifetime

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1212,8 +1212,14 @@ func main() {
 	}
 	if appAuth != nil {
 		agentMgr.SetAppAuth(appAuth)
-		go agentMgr.StartAgentTokenRefresh(ctx)
 	}
+	// Start the per-agent token refresh loop UNCONDITIONALLY. It no-ops until
+	// App auth is wired, and on hosted spokes that wiring happens AFTER boot
+	// (heartbeat delivery / config API reinit / config reload). Gating this on
+	// appAuth != nil at boot meant those hives never refreshed per-agent token
+	// caches: agent sessions outlived their scoped token, gh 401'd and printed
+	// "gh auth login", and the login-detector auto-paused the agent (#4072).
+	go agentMgr.StartAgentTokenRefresh(ctx)
 
 	// PR-open-as-the-App-bot: agents push their branch (App-token credential
 	// helper) then drop a request file; the hive opens the PR here with the App
@@ -1987,6 +1993,10 @@ func main() {
 			ghClient = newClient
 			appAuth = newAppAuth
 			agentMgr.SetAppAuth(newAppAuth)
+			// Deliver fresh per-agent scoped tokens to already-running agents
+			// immediately — the periodic refresh loop only ticks every 40m,
+			// far too long for agents whose caches are empty or stale (#4072).
+			go agentMgr.RefreshAgentTokens(ctx)
 			dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 			logger.Info("github client reinitialized via config API", "app_id", newAppID, "installation_id", newInstallationID)
 
@@ -2386,6 +2396,8 @@ func main() {
 					ghClient = newClient
 					appAuth = newAppAuth
 					agentMgr.SetAppAuth(newAppAuth)
+					// Immediate per-agent token delivery — see #4072.
+					go agentMgr.RefreshAgentTokens(ctx)
 					dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 					logger.Info("github app auth rebuilt after config reload",
 						"app_id", cfg.GitHub.AppID,
@@ -3475,6 +3487,11 @@ func main() {
 				ghClient = newClient
 				appAuth = newAppAuth
 				agentMgr.SetAppAuth(newAppAuth)
+				// Immediate per-agent token delivery: hosted spokes get their
+				// App creds via this heartbeat path AFTER agents have already
+				// launched (with empty 0-byte caches), so waiting for the next
+				// 40-minute tick guarantees a window of gh 401s (#4072).
+				go agentMgr.RefreshAgentTokens(ctx)
 				dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 				dashSrv.SetGitHubAppRequired(false)
 				dashSrv.ClearPendingGitHubAppInstall()
@@ -4245,7 +4262,7 @@ func runEvalCycle(
 	}
 
 	// Scan agent panes for login-required patterns and pause + notify if detected
-	scanForLoginRequired(cfg, agentMgr, notifier, dashSrv, logger)
+	scanForLoginRequired(ctx, cfg, agentMgr, notifier, dashSrv, logger)
 
 	agentStatuses := agentMgr.AllStatuses()
 
@@ -4476,6 +4493,7 @@ func loginCommandForBackend(backend string) string {
 // scanForLoginRequired checks each running agent's tmux pane output for login-required
 // patterns. When a match is found, the agent is paused and a notification is sent.
 func scanForLoginRequired(
+	ctx context.Context,
 	cfg *config.Config,
 	agentMgr *agent.Manager,
 	notifier *notify.Notifier,
@@ -4523,6 +4541,17 @@ func scanForLoginRequired(
 					"agent", name,
 					"pattern", re.String(),
 				)
+
+				// Attempt a per-agent token re-cache BEFORE pausing. On an
+				// App-authenticated hive the likeliest cause of a "gh auth
+				// login" prompt is an expired scoped-token cache (#4072);
+				// re-minting it now means the operator's Resume immediately
+				// works instead of 401ing straight back into this pause.
+				// Best-effort: hives without App auth (or agents without a
+				// dedicated UID) simply skip it.
+				if refreshErr := agentMgr.RefreshAgentTokenFor(ctx, name); refreshErr == nil {
+					logger.Info("re-cached per-agent scoped token before login-detector pause", "agent", name)
+				}
 
 				// Pause the agent instead of restarting
 				if pauseErr := agentMgr.Pause(name, "login-detector", "login required detected"); pauseErr != nil {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -449,13 +449,43 @@ func (m *Manager) SetAppAuth(auth AppTokenMinter) {
 	m.appAuth = auth
 }
 
-const agentTokenRefreshInterval = 40 * time.Minute
+const (
+	// defaultAgentTokenRefreshInterval is how often per-agent scoped token
+	// cache files are rewritten. Installation tokens expire after 1 hour;
+	// refreshing at 40-minute intervals keeps a valid token on disk with a
+	// 20-minute safety margin.
+	defaultAgentTokenRefreshInterval = 40 * time.Minute
+	// AgentTokenRefreshIntervalEnv overrides the refresh interval with a Go
+	// duration string (e.g. "30m"). Invalid or non-positive values fall back
+	// to the default.
+	AgentTokenRefreshIntervalEnv = "HIVE_AGENT_TOKEN_REFRESH_INTERVAL"
+)
+
+// agentTokenRefreshInterval resolves the per-agent token refresh interval
+// from AgentTokenRefreshIntervalEnv, falling back to the default.
+func agentTokenRefreshInterval() time.Duration {
+	if v := os.Getenv(AgentTokenRefreshIntervalEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultAgentTokenRefreshInterval
+}
 
 // StartAgentTokenRefresh refreshes per-agent scoped tokens for all running
 // agents on a timer. Tokens expire after 1 hour; this refreshes at 40-minute
-// intervals so there's always a valid token on disk.
+// intervals (configurable via HIVE_AGENT_TOKEN_REFRESH_INTERVAL) so there's
+// always a valid token on disk.
+//
+// Safe to start even before an App auth is wired: refreshAgentTokens no-ops
+// while m.appAuth is nil, so hives whose GitHub App credentials arrive AFTER
+// boot (heartbeat delivery, config API reinit, config reload) start refreshing
+// as soon as SetAppAuth is called. Previously this loop was only started when
+// the App was configured at boot, so hosted spokes never refreshed per-agent
+// caches: agent sessions outlived their token, `gh` 401'd and printed
+// "gh auth login", and the login-detector auto-paused the agent.
 func (m *Manager) StartAgentTokenRefresh(ctx context.Context) {
-	ticker := time.NewTicker(agentTokenRefreshInterval)
+	ticker := time.NewTicker(agentTokenRefreshInterval())
 	defer ticker.Stop()
 	for {
 		select {
@@ -465,6 +495,43 @@ func (m *Manager) StartAgentTokenRefresh(ctx context.Context) {
 			m.refreshAgentTokens(ctx)
 		}
 	}
+}
+
+// RefreshAgentTokens immediately rewrites every running agent's per-agent
+// scoped token cache. Called when GitHub App auth is wired late (heartbeat
+// delivery, config API reinit, config reload) so agents that were already
+// running get a valid cache right away instead of waiting for the next tick.
+func (m *Manager) RefreshAgentTokens(ctx context.Context) {
+	m.refreshAgentTokens(ctx)
+}
+
+// RefreshAgentTokenFor re-mints and re-caches the scoped token for a single
+// agent, using the same tier logic as launch. Used by the login-detector to
+// attempt a token re-cache before pausing: the likeliest cause of a `gh`
+// "gh auth login" prompt on an App-authenticated hive is an expired cached
+// token, so refreshing it means a subsequent Resume works immediately.
+// Returns an error when the agent is unknown, has no UID, or no App auth is
+// wired.
+func (m *Manager) RefreshAgentTokenFor(ctx context.Context, name string) error {
+	m.mu.RLock()
+	auth := m.appAuth
+	agent, ok := m.agents[name]
+	m.mu.RUnlock()
+
+	if auth == nil {
+		return fmt.Errorf("no github app auth wired")
+	}
+	if !ok {
+		return fmt.Errorf("agent %s not found", name)
+	}
+	if agent.UID <= 0 {
+		return fmt.Errorf("agent %s has no dedicated UID", name)
+	}
+	tier := m.agentMode(agent).TokenTier()
+	if err := auth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
+		return fmt.Errorf("re-caching scoped token for %s: %w", name, err)
+	}
+	return nil
 }
 
 func (m *Manager) refreshAgentTokens(ctx context.Context) {
@@ -5333,6 +5400,8 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	// would be an unsynchronized read.
 	resumeBackend := agent.effectiveBackend()
 	resumeModel := agent.effectiveModel()
+	appAuth := m.appAuth
+	resumeUID := agent.UID
 	agent.Paused = false
 	agent.Config.Paused = false
 	persistPause := m.persistPauseCallback
@@ -5369,6 +5438,19 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 		"reason", reason,
 	))
 	if needsRelaunch {
+		// A pause can easily outlive the scoped token's 1-hour lifetime (the
+		// login-detector pause path exists precisely because tokens expired),
+		// so re-mint the per-agent cache before relaunching — otherwise the
+		// resumed agent's first gh call reads a stale cache and 401s straight
+		// back into the login-detector pause. Best-effort: launch proceeds on
+		// failure exactly like the Start path. Gated identically to Start —
+		// no App auth or no dedicated UID means there is no cache to refresh.
+		if appAuth != nil && resumeUID > 0 {
+			if err := m.RefreshAgentTokenFor(ctx, name); err != nil {
+				m.logger.Warn("per-agent token re-cache on resume failed; agent may resume with a stale token",
+					"agent", name, "error", err)
+			}
+		}
 		if err := m.ensureTmuxSession(agent); err != nil {
 			return err
 		}

--- a/v2/pkg/agent/token_refresh_test.go
+++ b/v2/pkg/agent/token_refresh_test.go
@@ -1,0 +1,170 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// syncedMinter is a race-safe fake for tests where the refresh loop mints
+// from its own goroutine while the test polls.
+type syncedMinter struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *syncedMinter) WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return nil
+}
+
+func (s *syncedMinter) snapshotCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// ---------------------------------------------------------------------------
+// #4072: per-agent scoped token caches must keep refreshing for the whole
+// lifetime of an agent session, and the refresh machinery must be reachable
+// even when GitHub App auth is wired after boot.
+// ---------------------------------------------------------------------------
+
+func TestAgentTokenRefreshInterval_Default(t *testing.T) {
+	t.Setenv(AgentTokenRefreshIntervalEnv, "")
+	if got := agentTokenRefreshInterval(); got != defaultAgentTokenRefreshInterval {
+		t.Errorf("expected default %v, got %v", defaultAgentTokenRefreshInterval, got)
+	}
+}
+
+func TestAgentTokenRefreshInterval_EnvOverride(t *testing.T) {
+	t.Setenv(AgentTokenRefreshIntervalEnv, "15m")
+	if got := agentTokenRefreshInterval(); got != 15*time.Minute {
+		t.Errorf("expected 15m from env override, got %v", got)
+	}
+}
+
+func TestAgentTokenRefreshInterval_InvalidFallsBack(t *testing.T) {
+	for _, bad := range []string{"not-a-duration", "-5m", "0s"} {
+		t.Setenv(AgentTokenRefreshIntervalEnv, bad)
+		if got := agentTokenRefreshInterval(); got != defaultAgentTokenRefreshInterval {
+			t.Errorf("env %q: expected default %v, got %v", bad, defaultAgentTokenRefreshInterval, got)
+		}
+	}
+}
+
+// TestRefreshAgentTokens_Exported proves the exported immediate-refresh entry
+// point (used by the late App-auth wiring paths in main: heartbeat delivery,
+// config API reinit, config reload) mints tokens for running agents.
+func TestRefreshAgentTokens_Exported(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"runner": {Backend: "claude"},
+		"idler":  {Backend: "claude"},
+	}, discardLogger(), ProjectContext{ACMMLevel: 5})
+
+	fm := &fakeMinter{}
+	m.SetAppAuth(fm)
+	m.mu.Lock()
+	m.agents["runner"].State = StateRunning
+	m.agents["runner"].UID = 2001
+	m.agents["idler"].State = StateStopped
+	m.agents["idler"].UID = 2002
+	m.mu.Unlock()
+
+	m.RefreshAgentTokens(context.Background())
+	if fm.calls != 1 {
+		t.Errorf("expected exactly the running agent to be refreshed (1 mint), got %d", fm.calls)
+	}
+}
+
+// TestStartAgentTokenRefresh_TicksWithEnvInterval proves the loop actually
+// rewrites running agents' caches on the (env-configured) interval — the
+// production failure was this loop never being started, so token caches were
+// written once at agent start and then rotted until gh 401'd.
+func TestStartAgentTokenRefresh_TicksWithEnvInterval(t *testing.T) {
+	t.Setenv(AgentTokenRefreshIntervalEnv, "10ms")
+
+	m := NewManager(map[string]config.AgentConfig{"runner": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	fm := &syncedMinter{}
+	m.SetAppAuth(fm)
+	m.mu.Lock()
+	m.agents["runner"].State = StateRunning
+	m.agents["runner"].UID = 2001
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		m.StartAgentTokenRefresh(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for fm.snapshotCalls() == 0 {
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("refresh loop never minted a token within 2s at a 10ms interval")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("StartAgentTokenRefresh did not return after cancel")
+	}
+}
+
+func TestRefreshAgentTokenFor_Success(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{"guide": {Backend: "claude"}}, discardLogger(), ProjectContext{ACMMLevel: 5})
+	fm := &fakeMinter{}
+	m.SetAppAuth(fm)
+	m.mu.Lock()
+	m.agents["guide"].UID = 2003
+	m.mu.Unlock()
+
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err != nil {
+		t.Fatalf("RefreshAgentTokenFor: %v", err)
+	}
+	if fm.calls != 1 {
+		t.Errorf("expected 1 mint, got %d", fm.calls)
+	}
+}
+
+func TestRefreshAgentTokenFor_Errors(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{"guide": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+
+	// No App auth wired.
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err == nil {
+		t.Error("expected error when no app auth is wired")
+	}
+
+	fm := &fakeMinter{}
+	m.SetAppAuth(fm)
+
+	// Unknown agent.
+	if err := m.RefreshAgentTokenFor(context.Background(), "ghost"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error for unknown agent, got %v", err)
+	}
+
+	// No dedicated UID (zero value) — nothing to scope to.
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err == nil || !strings.Contains(err.Error(), "no dedicated UID") {
+		t.Errorf("expected no-UID error, got %v", err)
+	}
+
+	// Mint failure is wrapped.
+	m.mu.Lock()
+	m.agents["guide"].UID = 2004
+	m.mu.Unlock()
+	fm.fail = true
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err == nil || !strings.Contains(err.Error(), "re-caching scoped token") {
+		t.Errorf("expected wrapped mint error, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #4072

## Root cause

`Manager.StartAgentTokenRefresh` (the 40-minute per-agent scoped-token refresh loop) already existed, but `cmd/hive/main.go` only started it when `appAuth != nil` **at boot**. On hosted spokes (e.g. hosted-available-vllmd-07) the GitHub App credentials arrive **after** boot — via heartbeat delivery, the config API reinit, or a config reload. All three paths call `agentMgr.SetAppAuth(newAppAuth)` but never started the loop, so per-agent caches under `/var/run/hive-metrics/agent-tokens/gh-token-<agent>.cache` were written exactly once at agent start ("per-agent token cached" pairing with "audit: agent started") and then rotted.

The observed production chain: agent session outlives its ~1h scoped token → the `gh` wrapper exports the stale cache as `GH_TOKEN` → `HTTP 401 ... Try authenticating with: gh auth login` → login-detector (`(?i)gh auth login`) auto-pauses the agent → dashboard Restart preserves paused state → agent stays down until manual Resume. Idle agents launched before App-cred delivery also carried 0-byte caches → empty `GH_TOKEN` → guaranteed 401.

## Fix

- **Start the refresh loop unconditionally at boot** (`refreshAgentTokens` already no-ops safely while no App auth is wired), so refreshing begins the moment `SetAppAuth` happens — however late.
- **Immediate delivery on late wiring**: each of the three late `SetAppAuth` sites now kicks a new exported `Manager.RefreshAgentTokens(ctx)` so already-running agents (including ones with empty pre-created caches) get valid tokens right away instead of waiting up to 40 minutes for the next tick.
- **Re-mint on Resume relaunch**: a pause easily outlives the token lifetime; `Resume` now re-caches the agent's scoped token (via new `RefreshAgentTokenFor`, which reuses the exact tier logic from launch — `agentMode(agent).TokenTier()` → `WriteAgentToken`) before relaunching, so a resumed agent cannot 401 straight back into the login-detector pause.
- **Login-detector re-cache**: when the detector fires, the hive best-effort re-caches that agent's scoped token *before* pausing, so the operator's Resume immediately works with a fresh token.
- **Configurable interval**: `HIVE_AGENT_TOKEN_REFRESH_INTERVAL` (Go duration, default `40m`; invalid/non-positive values fall back to the default). No magic numbers — named constants `defaultAgentTokenRefreshInterval` / `AgentTokenRefreshIntervalEnv`.

No scoping logic is duplicated: every path funnels through the existing `AppTokenMinter.WriteAgentToken` with the tier resolved by the same `agentMode(...).TokenTier()` used at launch.

## Follow-up (noted in #4072)

Consider skipping the pause entirely when the re-cache succeeds (with a per-agent cooldown to avoid refresh loops on genuine auth failures), and pre-warming caches for idle/on-demand agents so a 0-byte cache can never be exported as an empty `GH_TOKEN`.

## Testing

- New `v2/pkg/agent/token_refresh_test.go`: env-interval resolution (default / override / invalid fallback), exported `RefreshAgentTokens` refreshing only running agents, the refresh loop actually ticking and minting (race-safe fake, `-race`), and `RefreshAgentTokenFor` success + all error paths.
- `go build ./...` — clean.
- `go vet ./pkg/agent ./cmd/hive` — clean.
- `go test ./pkg/agent/ ./pkg/github/ ./cmd/hive/` — all pass.
- `golangci-lint` findings are all pre-existing; none touch the changed code.
