### PR TITLE
🐛 fix(apiproxy): separate client-auth gate from upstream-key swap

### DIFF
--- a/src/cmd/apiproxy/main.go
+++ b/src/cmd/apiproxy/main.go
@@ -21,7 +21,7 @@ func proxyAuthTokenFromEnv(getenv func(string) string, warnf func(string, ...any
 	}
 	authToken = getenv("ANTHROPIC_API_KEY")
 	if authToken != "" {
-		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY. Unauthenticated callers will be granted the host Anthropic key. Set PROXY_AUTH_TOKEN to restrict access.")
+		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY to enable the proxy auth gate. Unauthenticated callers will be rejected. Set PROXY_AUTH_TOKEN explicitly to avoid using the host Anthropic key as the gate token.")
 	}
 	return authToken
 }

--- a/src/cmd/apiproxy/main.go
+++ b/src/cmd/apiproxy/main.go
@@ -14,16 +14,20 @@ import (
 
 const defaultProxyHost = "127.0.0.1"
 
-func proxyAuthTokenFromEnv(getenv func(string) string, warnf func(string, ...any)) string {
-	authToken := getenv("PROXY_AUTH_TOKEN")
-	if authToken != "" {
-		return authToken
+// clientAuthTokenFromEnv returns the token callers must present to the proxy.
+// An empty result leaves the proxy an open relay, so a warning is emitted.
+func clientAuthTokenFromEnv(getenv func(string) string, warnf func(string, ...any)) string {
+	token := getenv("PROXY_AUTH_TOKEN")
+	if token == "" {
+		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; the proxy will accept unauthenticated callers and may grant them the host upstream key. Set PROXY_AUTH_TOKEN to require caller authentication.")
 	}
-	authToken = getenv("ANTHROPIC_API_KEY")
-	if authToken != "" {
-		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; falling back to ANTHROPIC_API_KEY to enable the proxy auth gate. Unauthenticated callers will be rejected. Set PROXY_AUTH_TOKEN explicitly to avoid using the host Anthropic key as the gate token.")
-	}
-	return authToken
+	return token
+}
+
+// upstreamAPIKeyFromEnv returns the credential the proxy swaps in on the
+// outbound request when the caller has no upstream credential of its own.
+func upstreamAPIKeyFromEnv(getenv func(string) string) string {
+	return getenv("ANTHROPIC_API_KEY")
 }
 
 func main() {
@@ -74,8 +78,9 @@ func main() {
 		logWriter.Encode(entry)
 	}
 
-	authToken := proxyAuthTokenFromEnv(os.Getenv, log.Printf)
-	proxy, err := apiproxy.New(*upstream, handler, authToken)
+	clientAuthToken := clientAuthTokenFromEnv(os.Getenv, log.Printf)
+	upstreamAPIKey := upstreamAPIKeyFromEnv(os.Getenv)
+	proxy, err := apiproxy.New(*upstream, handler, upstreamAPIKey, clientAuthToken)
 	if err != nil {
 		log.Fatalf("failed to create proxy: %v", err)
 	}

--- a/src/cmd/apiproxy/main_test.go
+++ b/src/cmd/apiproxy/main_test.go
@@ -33,6 +33,9 @@ func TestProxyAuthTokenFromEnvWarnsOnAnthropicFallback(t *testing.T) {
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "PROXY_AUTH_TOKEN is unset") {
 		t.Fatalf("expected actionable fallback warning, got %#v", warnings)
 	}
+	if strings.Contains(warnings[0], "Unauthenticated callers will be granted") {
+		t.Fatalf("warning must not claim unauthenticated callers receive the host key: %q", warnings[0])
+	}
 }
 
 func TestProxyAuthTokenFromEnvPrefersProxyAuthToken(t *testing.T) {

--- a/src/cmd/apiproxy/main_test.go
+++ b/src/cmd/apiproxy/main_test.go
@@ -12,33 +12,28 @@ func TestDefaultProxyHostIsLoopback(t *testing.T) {
 	}
 }
 
-func TestProxyAuthTokenFromEnvWarnsOnAnthropicFallback(t *testing.T) {
+func TestClientAuthTokenFromEnvWarnsWhenUnset(t *testing.T) {
 	var warnings []string
 	getenv := func(key string) string {
 		switch key {
-		case "PROXY_AUTH_TOKEN":
-			return ""
 		case "ANTHROPIC_API_KEY":
 			return "sk-ant"
 		default:
 			return ""
 		}
 	}
-	token := proxyAuthTokenFromEnv(getenv, func(format string, args ...any) {
+	token := clientAuthTokenFromEnv(getenv, func(format string, args ...any) {
 		warnings = append(warnings, fmt.Sprintf(format, args...))
 	})
-	if token != "sk-ant" {
-		t.Fatalf("token = %q, want ANTHROPIC_API_KEY fallback", token)
+	if token != "" {
+		t.Fatalf("token = %q, want empty when PROXY_AUTH_TOKEN is unset", token)
 	}
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "PROXY_AUTH_TOKEN is unset") {
-		t.Fatalf("expected actionable fallback warning, got %#v", warnings)
-	}
-	if strings.Contains(warnings[0], "Unauthenticated callers will be granted") {
-		t.Fatalf("warning must not claim unauthenticated callers receive the host key: %q", warnings[0])
+		t.Fatalf("expected actionable warning when the gate is disabled, got %#v", warnings)
 	}
 }
 
-func TestProxyAuthTokenFromEnvPrefersProxyAuthToken(t *testing.T) {
+func TestClientAuthTokenFromEnvUsesProxyAuthToken(t *testing.T) {
 	var warnings []string
 	getenv := func(key string) string {
 		switch key {
@@ -50,13 +45,31 @@ func TestProxyAuthTokenFromEnvPrefersProxyAuthToken(t *testing.T) {
 			return ""
 		}
 	}
-	token := proxyAuthTokenFromEnv(getenv, func(format string, args ...any) {
+	token := clientAuthTokenFromEnv(getenv, func(format string, args ...any) {
 		warnings = append(warnings, fmt.Sprintf(format, args...))
 	})
 	if token != "proxy-token" {
 		t.Fatalf("token = %q, want PROXY_AUTH_TOKEN", token)
 	}
 	if len(warnings) != 0 {
-		t.Fatalf("expected no fallback warning when PROXY_AUTH_TOKEN is set, got %#v", warnings)
+		t.Fatalf("expected no warning when PROXY_AUTH_TOKEN is set, got %#v", warnings)
+	}
+}
+
+// The upstream key is read from ANTHROPIC_API_KEY only; it must never double as
+// the caller-facing gate token.
+func TestUpstreamAPIKeyFromEnvIgnoresProxyAuthToken(t *testing.T) {
+	getenv := func(key string) string {
+		switch key {
+		case "PROXY_AUTH_TOKEN":
+			return "proxy-token"
+		case "ANTHROPIC_API_KEY":
+			return "sk-ant-upstream"
+		default:
+			return ""
+		}
+	}
+	if got := upstreamAPIKeyFromEnv(getenv); got != "sk-ant-upstream" {
+		t.Fatalf("upstream key = %q, want ANTHROPIC_API_KEY", got)
 	}
 }

--- a/src/docs/apiproxy.md
+++ b/src/docs/apiproxy.md
@@ -2,8 +2,10 @@
 
 `cmd/apiproxy` is a small Anthropic-compatible HTTP proxy used to observe agent
 model traffic. It forwards requests to an upstream API and emits JSON event logs
-for requests/responses and SSE chunks. It can inject an upstream API key when the
-client request does not already carry a valid `Authorization` or `X-Api-Key` header.
+for requests/responses and SSE chunks. When a host key is configured, callers
+must provide a valid `Authorization` or `X-Api-Key` header or the proxy returns
+`401 Unauthorized`; the host key is never used to authenticate an unauthenticated
+caller.
 
 ## Run
 
@@ -27,8 +29,8 @@ Environment:
 
 | Name | Purpose |
 |---|---|
-| `PROXY_AUTH_TOKEN` | Preferred upstream API key used to set an outbound bearer Authorization header when the client did not send a valid key. |
-| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. The proxy logs a warning when this fallback is used because any client that can reach the proxy can use the host Anthropic key. |
+| `PROXY_AUTH_TOKEN` | Preferred upstream API key. Requests must still carry a valid caller `Authorization` or `X-Api-Key` header; this key is only used for the upstream request. |
+| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. The proxy logs a warning when this fallback is used; it is also used as the host key and requests without caller authentication are rejected. |
 
 ## Deployment notes
 
@@ -36,4 +38,6 @@ The binary listens on `127.0.0.1:<port>` by default. Treat `--host 0.0.0.0` as
 an explicit compatibility opt-in for deployments that need cross-container or
 cross-pod access, and pair it with network policy/firewall controls.
 Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in production —
-configure `PROXY_AUTH_TOKEN` explicitly instead.
+configure `PROXY_AUTH_TOKEN` explicitly instead. This controls which host key is
+used upstream, while caller authentication remains mandatory whenever either
+variable supplies a host key.

--- a/src/docs/apiproxy.md
+++ b/src/docs/apiproxy.md
@@ -2,18 +2,35 @@
 
 `cmd/apiproxy` is a small Anthropic-compatible HTTP proxy used to observe agent
 model traffic. It forwards requests to an upstream API and emits JSON event logs
-for requests/responses and SSE chunks. When a host key is configured, callers
-must provide a valid `Authorization` or `X-Api-Key` header or the proxy returns
-`401 Unauthorized`; the host key is never used to authenticate an unauthenticated
-caller.
+for requests/responses and SSE chunks.
+
+Two independent credentials are involved:
+
+- **Client auth token** (`PROXY_AUTH_TOKEN`) — what callers must present *to the
+  proxy*. When it is set, every request must carry either
+  `Authorization: Bearer <PROXY_AUTH_TOKEN>` or `X-Api-Key: <PROXY_AUTH_TOKEN>`,
+  otherwise the proxy returns `401 Unauthorized` without logging or forwarding
+  the request. The comparison is constant time. The gate token is stripped from
+  the request and never forwarded upstream.
+- **Upstream API key** (`ANTHROPIC_API_KEY`) — what the proxy sends *upstream*.
+  Once a caller passes the gate, the proxy injects this key as
+  `Authorization: Bearer <ANTHROPIC_API_KEY>` unless the caller supplied its own
+  real upstream credential (a non-dummy `Authorization`/`X-Api-Key`), which is
+  forwarded as-is. This preserves the dummy-key workflow used by agent CLIs.
+
+The two are deliberately separate so that the host upstream key is never an
+implicit credential for anyone who can reach the listener. If `PROXY_AUTH_TOKEN`
+is unset the proxy is an open relay and logs a warning at startup.
 
 ## Run
 
 ```bash
 go build -o bin/apiproxy ./cmd/apiproxy
-PROXY_AUTH_TOKEN=... bin/apiproxy --port 9000 --upstream https://api.anthropic.com --log apiproxy.jsonl
+PROXY_AUTH_TOKEN=... ANTHROPIC_API_KEY=... \
+  bin/apiproxy --port 9000 --upstream https://api.anthropic.com --log apiproxy.jsonl
 # To expose beyond the local host, opt in explicitly:
-PROXY_AUTH_TOKEN=... bin/apiproxy --host 0.0.0.0 --port 9000 --upstream https://api.anthropic.com
+PROXY_AUTH_TOKEN=... ANTHROPIC_API_KEY=... \
+  bin/apiproxy --host 0.0.0.0 --port 9000 --upstream https://api.anthropic.com
 ```
 
 Flags verified from `cmd/apiproxy/main.go`:
@@ -29,15 +46,15 @@ Environment:
 
 | Name | Purpose |
 |---|---|
-| `PROXY_AUTH_TOKEN` | Preferred upstream API key. Requests must still carry a valid caller `Authorization` or `X-Api-Key` header; this key is only used for the upstream request. |
-| `ANTHROPIC_API_KEY` | Fallback upstream API key if `PROXY_AUTH_TOKEN` is unset. The proxy logs a warning when this fallback is used; it is also used as the host key and requests without caller authentication are rejected. |
+| `PROXY_AUTH_TOKEN` | Client auth token callers must present to the proxy (`Authorization: Bearer <token>` or `X-Api-Key: <token>`). Validated with a constant-time compare and stripped before the upstream request. When unset, the proxy accepts unauthenticated callers and logs a warning. |
+| `ANTHROPIC_API_KEY` | Upstream API key injected on the outbound request when the caller did not supply its own real upstream credential. Never used to authenticate callers. |
 
 ## Deployment notes
 
 The binary listens on `127.0.0.1:<port>` by default. Treat `--host 0.0.0.0` as
 an explicit compatibility opt-in for deployments that need cross-container or
 cross-pod access, and pair it with network policy/firewall controls.
-Avoid relying on the `ANTHROPIC_API_KEY` fallback upstream key in production —
-configure `PROXY_AUTH_TOKEN` explicitly instead. This controls which host key is
-used upstream, while caller authentication remains mandatory whenever either
-variable supplies a host key.
+Always configure `PROXY_AUTH_TOKEN` in production: without it the proxy accepts
+any caller and will happily lend them the host `ANTHROPIC_API_KEY`. Use a
+high-entropy random value distinct from the upstream key, and rotate the two
+independently.

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -65,8 +65,8 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `HIVE_BOB_API_URL` | No | `https://api.us-east.bob.ibm.com` | Bob key-test endpoint base URL override. |
 | `BOBSHELL_API_KEY` | Required by Bob CLI when Hive injects or contributor mode uses Bob | none | API key name read by bobshell itself. |
 | `COPILOT_GITHUB_TOKEN` | No | dashboard device-flow token file, if present | Copilot completion/model-discovery token and explicit agent injection. |
-| `ANTHROPIC_API_KEY` | Required by `cmd/apiproxy` unless `PROXY_AUTH_TOKEN` is set; agent inference backends receive a synthetic value | none | Anthropic-compatible API key for apiproxy auth or CLI compatibility. |
-| `PROXY_AUTH_TOKEN` | No | `ANTHROPIC_API_KEY` | Preferred auth token for `cmd/apiproxy`. |
+| `ANTHROPIC_API_KEY` | Required by `cmd/apiproxy` to inject an upstream key; agent inference backends receive a synthetic value | none | Anthropic-compatible **upstream** API key. Never used to authenticate callers of `cmd/apiproxy`. |
+| `PROXY_AUTH_TOKEN` | Recommended for `cmd/apiproxy`; when unset the proxy accepts unauthenticated callers | none | **Client auth token** callers must present to `cmd/apiproxy` via `Authorization: Bearer` or `X-Api-Key`. Validated in constant time and stripped before the upstream request. |
 | `CONTEXT7_API_KEY` | No | none | Optional key for Context7 knowledge API integration. |
 | `GOOSE_PROVIDER` | No | Goose CLI default | Provider passed through Goose backend/model resolution. |
 | `GOOSE_MODEL` | No | Goose CLI default | Model passed through Goose backend/model resolution and contributor relay fallback. |

--- a/src/pkg/apiproxy/proxy.go
+++ b/src/pkg/apiproxy/proxy.go
@@ -270,6 +270,14 @@ func (p *Proxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) 
 
 // ServeHTTP implements http.Handler.
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// A configured host key must never be used as an implicit credential for
+	// callers that can reach this listener. Require callers to identify
+	// themselves before the director can add the upstream key.
+	if p.apiKey != "" && !isValidAuth(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if p.handler != nil {
 		body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyLog))
 		if err == nil {

--- a/src/pkg/apiproxy/proxy.go
+++ b/src/pkg/apiproxy/proxy.go
@@ -3,6 +3,7 @@ package apiproxy
 import (
 	"bufio"
 	"bytes"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ const (
 	sseEventMsgDelta   = "message_delta"
 	sseEventMsgStop    = "message_stop"
 	sseEventContentDlt = "content_block_delta"
+	bearerPrefix       = "Bearer "
 )
 
 // Event represents a logged API interaction.
@@ -46,11 +48,16 @@ type Proxy struct {
 	upstream     *url.URL
 	reverseProxy *httputil.ReverseProxy
 	handler      EventHandler
-	apiKey       string
-	mu           sync.RWMutex
+	// apiKey is the upstream credential swapped in on the outbound request.
+	apiKey string
+	// clientAuthToken is the credential callers must present to this proxy. It
+	// is deliberately distinct from apiKey so a configured upstream key is
+	// never an implicit credential for anyone who can reach the listener.
+	clientAuthToken string
+	mu              sync.RWMutex
 }
 
-func New(upstreamURL string, handler EventHandler, apiKey string) (*Proxy, error) {
+func New(upstreamURL string, handler EventHandler, apiKey, clientAuthToken string) (*Proxy, error) {
 	if upstreamURL == "" {
 		upstreamURL = defaultUpstream
 	}
@@ -60,9 +67,10 @@ func New(upstreamURL string, handler EventHandler, apiKey string) (*Proxy, error
 	}
 
 	p := &Proxy{
-		upstream: u,
-		handler:  handler,
-		apiKey:   apiKey,
+		upstream:        u,
+		handler:         handler,
+		apiKey:          apiKey,
+		clientAuthToken: clientAuthToken,
 	}
 
 	p.reverseProxy = &httputil.ReverseProxy{
@@ -89,6 +97,35 @@ func isValidAuth(req *http.Request) bool {
 	return false
 }
 
+// validateClientAuth reports whether the caller presented the configured client
+// auth token in either an `Authorization: Bearer` or `X-Api-Key` header. The
+// comparison is constant time so the token cannot be recovered through response
+// timing.
+func validateClientAuth(r *http.Request, expectedToken string) bool {
+	if expectedToken == "" {
+		return false
+	}
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, bearerPrefix) {
+		token := strings.TrimPrefix(auth, bearerPrefix)
+		if subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1 {
+			return true
+		}
+	}
+	key := r.Header.Get("X-Api-Key")
+	return key != "" && subtle.ConstantTimeCompare([]byte(key), []byte(expectedToken)) == 1
+}
+
+// stripClientAuth removes headers whose value is exactly the proxy-local gate
+// token so it is never forwarded upstream.
+func stripClientAuth(r *http.Request, token string) {
+	if auth := r.Header.Get("Authorization"); strings.TrimPrefix(auth, bearerPrefix) == token && strings.HasPrefix(auth, bearerPrefix) {
+		r.Header.Del("Authorization")
+	}
+	if r.Header.Get("X-Api-Key") == token {
+		r.Header.Del("X-Api-Key")
+	}
+}
+
 func (p *Proxy) director(req *http.Request) {
 	req.URL.Scheme = p.upstream.Scheme
 	req.URL.Host = p.upstream.Host
@@ -98,8 +135,11 @@ func (p *Proxy) director(req *http.Request) {
 	// Negligible overhead for a local proxy; allows line-by-line SSE parsing.
 	req.Header.Del("Accept-Encoding")
 
+	// Swap in the upstream key when the caller did not bring an upstream
+	// credential of its own. Gate credentials have already been stripped by
+	// ServeHTTP, so anything left here is a caller-supplied upstream key.
 	if p.apiKey != "" && !isValidAuth(req) {
-		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+		req.Header.Set("Authorization", bearerPrefix+p.apiKey)
 		req.Header.Del("X-Api-Key")
 	}
 }
@@ -270,12 +310,19 @@ func (p *Proxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) 
 
 // ServeHTTP implements http.Handler.
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// A configured host key must never be used as an implicit credential for
-	// callers that can reach this listener. Require callers to identify
-	// themselves before the director can add the upstream key.
-	if p.apiKey != "" && !isValidAuth(r) {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
+	// Gate on the client-provided auth token, which is separate from the
+	// upstream key: a configured upstream key must never act as an implicit
+	// credential for anyone who can reach this listener. Rejected requests are
+	// neither logged nor forwarded upstream.
+	if p.clientAuthToken != "" {
+		if !validateClientAuth(r, p.clientAuthToken) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		// The gate token is proxy-local and must never reach the upstream. Once
+		// stripped, any remaining credential is a caller-supplied upstream key
+		// and the director decides whether to swap in the configured one.
+		stripClientAuth(r, p.clientAuthToken)
 	}
 
 	if p.handler != nil {

--- a/src/pkg/apiproxy/proxy_test.go
+++ b/src/pkg/apiproxy/proxy_test.go
@@ -43,7 +43,7 @@ func (e *eventRecorder) byDirection(dir string) []Event {
 // ---- New ----
 
 func TestNewDefaultsToAnthropicUpstream(t *testing.T) {
-	p, err := New("", nil, "")
+	p, err := New("", nil, "", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -53,13 +53,13 @@ func TestNewDefaultsToAnthropicUpstream(t *testing.T) {
 }
 
 func TestNewRejectsInvalidUpstream(t *testing.T) {
-	if _, err := New("://not a url", nil, ""); err == nil {
+	if _, err := New("://not a url", nil, "", ""); err == nil {
 		t.Fatal("an unparseable upstream URL must be rejected")
 	}
 }
 
 func TestNewAcceptsCustomUpstream(t *testing.T) {
-	p, err := New("http://localhost:9999", nil, "")
+	p, err := New("http://localhost:9999", nil, "", "")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestIsValidAuth(t *testing.T) {
 // With no real caller auth, the configured key is injected and the dummy
 // X-Api-Key removed so upstream sees exactly one credential.
 func TestDirectorInjectsConfiguredKey(t *testing.T) {
-	p, err := New("https://upstream.example", nil, "secret-key")
+	p, err := New("https://upstream.example", nil, "secret-key", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestDirectorInjectsConfiguredKey(t *testing.T) {
 
 // A caller's real credentials must be left alone.
 func TestDirectorPreservesCallerAuth(t *testing.T) {
-	p, err := New("https://upstream.example", nil, "secret-key")
+	p, err := New("https://upstream.example", nil, "secret-key", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestDirectorPreservesCallerAuth(t *testing.T) {
 
 // With no configured key the proxy must not invent one.
 func TestDirectorWithoutConfiguredKeyLeavesAuthAlone(t *testing.T) {
-	p, err := New("https://upstream.example", nil, "")
+	p, err := New("https://upstream.example", nil, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestDirectorWithoutConfiguredKeyLeavesAuthAlone(t *testing.T) {
 // Accept-Encoding must be stripped so upstream returns plaintext SSE the proxy
 // can parse line by line.
 func TestDirectorStripsAcceptEncoding(t *testing.T) {
-	p, err := New("https://upstream.example", nil, "")
+	p, err := New("https://upstream.example", nil, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestDirectorStripsAcceptEncoding(t *testing.T) {
 
 // The request must be retargeted at the upstream host.
 func TestDirectorRetargetsUpstream(t *testing.T) {
-	p, err := New("https://upstream.example", nil, "")
+	p, err := New("https://upstream.example", nil, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestServeHTTPLogsRequestAndForwardsBody(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "")
+	p, err := New(upstream.URL, rec.handler, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +242,7 @@ func TestServeHTTPHandlesNonJSONBody(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "")
+	p, err := New(upstream.URL, rec.handler, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +267,7 @@ func TestServeHTTPWithoutHandler(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	p, err := New(upstream.URL, nil, "")
+	p, err := New(upstream.URL, nil, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestResponseLoggedAndPassedThrough(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "")
+	p, err := New(upstream.URL, rec.handler, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func TestErrorResponseIsLogged(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "")
+	p, err := New(upstream.URL, rec.handler, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func TestSSEStreamIsLoggedAndPassedThrough(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "")
+	p, err := New(upstream.URL, rec.handler, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +458,7 @@ func TestSSEIgnoresMalformedDataLines(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "")
+	p, err := New(upstream.URL, rec.handler, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestSSEWithNoRecognisedEvents(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "")
+	p, err := New(upstream.URL, rec.handler, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,11 +504,11 @@ func TestSSEWithNoRecognisedEvents(t *testing.T) {
 	}
 }
 
-// ---- auth gate ----
+// ---- client auth gate ----
 
-// A configured host key is never used for an unauthenticated caller. The
-// request must be rejected before it reaches the upstream or request logger.
-func TestServeHTTPRejectsUnauthenticatedCaller(t *testing.T) {
+// With a client auth token configured, an unauthenticated caller is rejected
+// before the request reaches the upstream or the request logger.
+func TestServeHTTPWithClientAuthTokenRequired(t *testing.T) {
 	var upstreamCalls int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upstreamCalls++
@@ -517,7 +517,7 @@ func TestServeHTTPRejectsUnauthenticatedCaller(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "host-api-key")
+	p, err := New(upstream.URL, rec.handler, "host-api-key", "gate-token")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,9 +537,83 @@ func TestServeHTTPRejectsUnauthenticatedCaller(t *testing.T) {
 	}
 }
 
-// A caller with valid auth remains eligible for proxying and receives the
-// normal upstream response.
-func TestServeHTTPAllowsAuthenticatedCaller(t *testing.T) {
+// A caller presenting the wrong token is rejected even though the header looks
+// like a plausible credential.
+func TestServeHTTPWithInvalidClientToken(t *testing.T) {
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer upstream.Close()
+
+	cases := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"wrong bearer", map[string]string{"Authorization": "Bearer " + strings.Repeat("w", 40)}},
+		{"wrong x-api-key", map[string]string{"X-Api-Key": strings.Repeat("w", 40)}},
+		{"token prefix only", map[string]string{"Authorization": "Bearer gate"}},
+		{"upstream key replayed as gate token", map[string]string{"X-Api-Key": "host-api-key"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New(upstream.URL, nil, "host-api-key", "gate-token")
+			if err != nil {
+				t.Fatal(err)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			w := httptest.NewRecorder()
+			p.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+	if upstreamCalls != 0 {
+		t.Fatalf("rejected requests reached upstream %d time(s)", upstreamCalls)
+	}
+}
+
+// The documented dummy-key swap still works: a caller authenticated with the
+// gate token has the upstream key injected on its behalf.
+func TestServeHTTPInjectsUpstreamKeyForDummyClientToken(t *testing.T) {
+	var gotAuth, gotAPIKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("X-Api-Key")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	p, err := New(upstream.URL, nil, "host-api-key", "gate-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("X-Api-Key", "gate-token")
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+	if gotAuth != "Bearer host-api-key" {
+		t.Fatalf("upstream Authorization = %q, want the injected upstream key", gotAuth)
+	}
+	if gotAPIKey != "" {
+		t.Fatalf("the gate token must not be forwarded upstream, got %q", gotAPIKey)
+	}
+}
+
+// A caller that authenticates with the gate token via a bearer header also gets
+// the upstream key swapped in, and the gate token never leaves the proxy.
+func TestServeHTTPSwapsGateBearerForUpstreamKey(t *testing.T) {
 	var gotAuth string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
@@ -547,33 +621,71 @@ func TestServeHTTPAllowsAuthenticatedCaller(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	p, err := New(upstream.URL, nil, "host-api-key")
+	gateToken := strings.Repeat("g", 40)
+	p, err := New(upstream.URL, nil, "host-api-key", gateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	callerAuth := "Bearer " + strings.Repeat("c", 40)
-	req.Header.Set("Authorization", callerAuth)
+	req.Header.Set("Authorization", "Bearer "+gateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
 	}
-	if gotAuth != callerAuth {
-		t.Fatalf("upstream Authorization = %q, want caller credential", gotAuth)
+	if gotAuth != "Bearer host-api-key" {
+		t.Fatalf("upstream Authorization = %q, want the injected upstream key", gotAuth)
+	}
+	if strings.Contains(gotAuth, gateToken) {
+		t.Fatal("the gate token must never be forwarded upstream")
 	}
 }
 
-// With no configured host key, the proxy remains an unauthenticated relay.
-func TestServeHTTPWithoutConfiguredKeyAllowsUnauthenticatedCaller(t *testing.T) {
+// A caller carrying its own real upstream credential has it forwarded as-is,
+// once it has passed the gate.
+func TestServeHTTPForwardsClientKeyWhenPresent(t *testing.T) {
+	var gotAuth, gotAPIKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("X-Api-Key")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	callerKey := strings.Repeat("c", 40)
+	p, err := New(upstream.URL, nil, "host-api-key", "gate-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("X-Api-Key", "gate-token") // passes the gate
+	req.Header.Set("Authorization", "Bearer "+callerKey)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+	if gotAuth != "Bearer "+callerKey {
+		t.Fatalf("upstream Authorization = %q, want the caller's own key forwarded as-is", gotAuth)
+	}
+	if gotAPIKey != "" {
+		t.Fatalf("the gate token must not be forwarded upstream, got %q", gotAPIKey)
+	}
+}
+
+// Without a gate token the proxy stays an open relay, preserving the previous
+// local-development behaviour.
+func TestServeHTTPWithoutClientAuthTokenAllowsUnauthenticatedCaller(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer upstream.Close()
 
-	p, err := New(upstream.URL, nil, "")
+	p, err := New(upstream.URL, nil, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -587,12 +699,43 @@ func TestServeHTTPWithoutConfiguredKeyAllowsUnauthenticatedCaller(t *testing.T) 
 	}
 }
 
+// validateClientAuth must accept only an exact token match.
+func TestValidateClientAuth(t *testing.T) {
+	token := strings.Repeat("t", 40)
+
+	cases := []struct {
+		name     string
+		expected string
+		headers  map[string]string
+		want     bool
+	}{
+		{"no headers", token, nil, false},
+		{"matching bearer", token, map[string]string{"Authorization": "Bearer " + token}, true},
+		{"matching x-api-key", token, map[string]string{"X-Api-Key": token}, true},
+		{"mismatched bearer", token, map[string]string{"Authorization": "Bearer " + strings.Repeat("x", 40)}, false},
+		{"non-bearer scheme", token, map[string]string{"Authorization": "Basic " + token}, false},
+		{"empty expected token", "", map[string]string{"X-Api-Key": token}, false},
+		{"empty x-api-key with empty token", "", map[string]string{"X-Api-Key": ""}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			if got := validateClientAuth(req, tc.expected); got != tc.want {
+				t.Fatalf("validateClientAuth = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // ---- errorHandler ----
 
 // An unreachable upstream must yield 502 rather than a hang or a panic.
 func TestUnreachableUpstreamYields502(t *testing.T) {
 	// Port 1 on loopback is not listening.
-	p, err := New("http://127.0.0.1:1", nil, "")
+	p, err := New("http://127.0.0.1:1", nil, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/pkg/apiproxy/proxy_test.go
+++ b/src/pkg/apiproxy/proxy_test.go
@@ -504,6 +504,89 @@ func TestSSEWithNoRecognisedEvents(t *testing.T) {
 	}
 }
 
+// ---- auth gate ----
+
+// A configured host key is never used for an unauthenticated caller. The
+// request must be rejected before it reaches the upstream or request logger.
+func TestServeHTTPRejectsUnauthenticatedCaller(t *testing.T) {
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer upstream.Close()
+
+	rec := &eventRecorder{}
+	p, err := New(upstream.URL, rec.handler, "host-api-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-opus-4"}`))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if upstreamCalls != 0 {
+		t.Fatalf("unauthenticated request reached upstream %d time(s)", upstreamCalls)
+	}
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("unauthenticated request was logged: %+v", got)
+	}
+}
+
+// A caller with valid auth remains eligible for proxying and receives the
+// normal upstream response.
+func TestServeHTTPAllowsAuthenticatedCaller(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	p, err := New(upstream.URL, nil, "host-api-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	callerAuth := "Bearer " + strings.Repeat("c", 40)
+	req.Header.Set("Authorization", callerAuth)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+	if gotAuth != callerAuth {
+		t.Fatalf("upstream Authorization = %q, want caller credential", gotAuth)
+	}
+}
+
+// With no configured host key, the proxy remains an unauthenticated relay.
+func TestServeHTTPWithoutConfiguredKeyAllowsUnauthenticatedCaller(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	p, err := New(upstream.URL, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
 // ---- errorHandler ----
 
 // An unreachable upstream must yield 502 rather than a hang or a panic.


### PR DESCRIPTION
Supersedes #4070 (includes its commit) and #4069.

## Problem

The auth gate added in #4070 reuses `isValidAuth()` — the *same* predicate `director()` uses to decide whether to inject the upstream key:

```go
// ServeHTTP
if p.apiKey != "" && !isValidAuth(r) { 401 }
// director
if p.apiKey != "" && !isValidAuth(req) { inject upstream key }
```

Any request reaching `director()` has already passed `isValidAuth()`, so the injection branch is **dead code**. This silently breaks the documented dummy-key workflow (agent CLIs send `sk-ant-dummy…` and rely on the proxy swapping in the real key) — those callers now get a 401.

## Fix (Option A: separate the two credentials)

- `Proxy` gains `clientAuthToken`, distinct from the upstream `apiKey`.
- `ServeHTTP` gates on `validateClientAuth()`, which compares `Authorization: Bearer …` / `X-Api-Key` against the token using `crypto/subtle.ConstantTimeCompare`.
- The gate token is **stripped** from the request before proxying, so it never leaks upstream.
- `director()` keeps injecting the upstream key when the caller brought no real upstream credential — the dummy-key feature is preserved.
- `ANTHROPIC_API_KEY` can no longer serve as the caller-facing gate token; `PROXY_AUTH_TOKEN` is now purely the client gate, `ANTHROPIC_API_KEY` purely the upstream key.
- Rejected requests are neither logged nor forwarded.

Flow: client presents `PROXY_AUTH_TOKEN` → proxy validates in constant time → strips it → injects `ANTHROPIC_API_KEY` → upstream.

## Tests

```
cd src && go test ./cmd/apiproxy ./pkg/apiproxy -count=1 -race   # ok
cd src && go build ./... && go vet ./cmd/apiproxy ./pkg/apiproxy # ok
```

New coverage: `TestServeHTTPWithClientAuthTokenRequired`, `TestServeHTTPWithInvalidClientToken` (incl. replaying the upstream key as the gate token), `TestServeHTTPInjectsUpstreamKeyForDummyClientToken`, `TestServeHTTPSwapsGateBearerForUpstreamKey`, `TestServeHTTPForwardsClientKeyWhenPresent`, `TestServeHTTPWithoutClientAuthTokenAllowsUnauthenticatedCaller`, `TestValidateClientAuth`, plus split env-var tests in `cmd/apiproxy`.

## Docs

`src/docs/apiproxy.md` and `src/docs/env-vars.md` now describe the two credentials independently.

Fixes #4068