### PR TITLE
🐛 fix(relay): recognize Codex no-work verdict prefix

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1180,8 +1180,10 @@ function detectNoWorkVerdict(lines) {
   if (!Array.isArray(lines) || lines.length === 0) return null;
   // Anchored at line start: the task PROMPT quotes the marker mid-sentence
   // ("...the exact form 'HIVE_VERDICT: ...'"), and an anchored match keeps
-  // that instruction echo from reading as the agent's own verdict.
-  const VERDICT_RE = /^\s*HIVE_VERDICT:\s*no_work_needed\b[\s:—–-]*(.*)$/i;
+  // that instruction echo from reading as the agent's own verdict. Codex
+  // renders its completed assistant messages with a leading bullet, which is
+  // presentation chrome rather than part of the verdict.
+  const VERDICT_RE = /^\s*(?:•\s*)?HIVE_VERDICT:\s*no_work_needed\b[\s:—–-]*(.*)$/i;
   // Scan newest-first so the agent's final conclusion wins over anything it
   // merely quoted or considered earlier in the transcript.
   for (let i = lines.length - 1; i >= 0; i--) {

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1449,7 +1449,8 @@ const CODEX_COMPLETED_NO_WORK_PANE = [
   // Codex may leave many old tool rows above the completed turn.
   ...Array.from({ length: 20 }, (_, i) => `  checked upstream evidence ${i}`),
   '',
-  'HIVE_VERDICT: no_work_needed — upstream PR #4066 already implements issue #4065.',
+  // Codex prefixes completed assistant output with this bullet in tmux.
+  '• HIVE_VERDICT: no_work_needed — upstream PR #4066 already implements issue #4065.',
   '─ Worked for 1m 59s ─',
   '',
   '› ',
@@ -1489,6 +1490,17 @@ test('codex no-work verdict is COMPLETE despite stale activity in scrollback', (
     assert.strictEqual(
       relay.classifyTmuxPane(CODEX_COMPLETED_NO_WORK_PANE), relay.PANE_STATE_IDLE_COMPLETE,
       'an old Codex Running row must not keep a completed no-work turn in WORKING');
+  } finally { teardown(relay); }
+});
+
+test('a bullet-prefixed Codex no-work verdict is reported as task_complete', () => {
+  const relay = loadRelay({ backend: 'codex', paneText: CODEX_COMPLETED_NO_WORK_PANE });
+  try {
+    assignTask(relay, 'ct-codex-no-work');
+    relay.__crashTick();
+    const complete = relay.__sent.find(m => m.type === 'task_complete');
+    assert.ok(complete, 'the live Codex pane shape must complete the task rather than remain working');
+    assert.strictEqual(complete.verdict, 'no_work_needed');
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
## Summary

- recognize the `• ` presentation prefix Codex adds to completed assistant output
- retain the anchored verdict match that rejects an echoed task instruction
- cover the real pane shape through `task_complete` and its `no_work_needed` verdict

## Root cause

Codex rendered a valid completion as:

```text
• HIVE_VERDICT: no_work_needed — <reason>
```

The relay accepted only whitespace before `HIVE_VERDICT`, so it classified the
idle pane as working and kept the task active. The bullet is UI chrome, not
part of the verdict.

## Validation

- `node --check < bin/contributor-relay.sh`
- `node bin/contributor-relay.test.js` (94/94 passed)
