### PR TITLE
fix(tests): make proxy Anthropic CONNECT test hermetic and resolve test flakes

### DIFF
--- a/src/pkg/agent/tmux_coverage_test.go
+++ b/src/pkg/agent/tmux_coverage_test.go
@@ -518,15 +518,8 @@ func TestConfirmMenuOption_SelectsOption(t *testing.T) {
 	m.mu.RUnlock()
 	agent.tmuxSession = session
 	// Render a menu: the title line, and a selected "❯" line whose text
-	// contains the wanted option. The "❯" line is typed WITHOUT the ": "
-	// comment prefix so it appears at column 0 (selectedMenuOption requires the
-	// trimmed line to start with "❯"). bash prints a harmless "command not
-	// found" below, but the typed line itself is visible in the pane.
-	if err := testTmuxCommand("send-keys", "-t", session, "-l", ": Bypass Permissions mode Enter to confirm").Run(); err != nil {
-		t.Fatal(err)
-	}
-	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
-	if err := testTmuxCommand("send-keys", "-t", session, "-l", "❯ 2. Yes I accept").Run(); err != nil {
+	// contains the wanted option. We print it with printf so the ❯ line is at column 0.
+	if err := testTmuxCommand("send-keys", "-t", session, "-l", "printf 'Bypass Permissions mode\\n❯ 2. Yes I accept\\n'").Run(); err != nil {
 		t.Fatal(err)
 	}
 	testTmuxCommand("send-keys", "-t", session, "Enter").Run()

--- a/src/pkg/policies/watcher_git_test.go
+++ b/src/pkg/policies/watcher_git_test.go
@@ -10,18 +10,23 @@ import (
 	"time"
 )
 
+func initTestGitRepo(t *testing.T, repoDir string) {
+	t.Helper()
+	if out, err := exec.Command("git", "init", repoDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %s %v", out, err)
+	}
+	exec.Command("git", "-C", repoDir, "checkout", "-B", "master").Run()
+	exec.Command("git", "-C", repoDir, "config", "user.email", "test@test.com").Run()
+	exec.Command("git", "-C", repoDir, "config", "user.name", "test").Run()
+}
+
 func TestStartWithLocalGitRepo(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")
 	}
 
 	repoDir := t.TempDir()
-	cmd := exec.Command("git", "init", repoDir)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init: %s %v", out, err)
-	}
-	exec.Command("git", "-C", repoDir, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", repoDir, "config", "user.name", "test").Run()
+	initTestGitRepo(t, repoDir)
 
 	agentDir := filepath.Join(repoDir, "agents")
 	os.MkdirAll(agentDir, 0o755)
@@ -59,9 +64,7 @@ func TestInitialCloneExistingRepo(t *testing.T) {
 	}
 
 	repoDir := t.TempDir()
-	exec.Command("git", "init", repoDir).Run()
-	exec.Command("git", "-C", repoDir, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", repoDir, "config", "user.name", "test").Run()
+	initTestGitRepo(t, repoDir)
 	os.WriteFile(filepath.Join(repoDir, "test.md"), []byte("hello"), 0o644)
 	exec.Command("git", "-C", repoDir, "add", ".").Run()
 	exec.Command("git", "-C", repoDir, "commit", "-m", "init").Run()
@@ -86,9 +89,7 @@ func TestPullNoChanges(t *testing.T) {
 	}
 
 	repoDir := t.TempDir()
-	exec.Command("git", "init", repoDir).Run()
-	exec.Command("git", "-C", repoDir, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", repoDir, "config", "user.name", "test").Run()
+	initTestGitRepo(t, repoDir)
 	os.WriteFile(filepath.Join(repoDir, "test.md"), []byte("hello"), 0o644)
 	exec.Command("git", "-C", repoDir, "add", ".").Run()
 	exec.Command("git", "-C", repoDir, "commit", "-m", "init").Run()
@@ -106,9 +107,7 @@ func TestPullWithNewCommit(t *testing.T) {
 	}
 
 	repoDir := t.TempDir()
-	exec.Command("git", "init", repoDir).Run()
-	exec.Command("git", "-C", repoDir, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", repoDir, "config", "user.name", "test").Run()
+	initTestGitRepo(t, repoDir)
 	os.WriteFile(filepath.Join(repoDir, "scanner.md"), []byte("v1"), 0o644)
 	exec.Command("git", "-C", repoDir, "add", ".").Run()
 	exec.Command("git", "-C", repoDir, "commit", "-m", "init").Run()
@@ -139,9 +138,7 @@ func TestStartLoadPoliciesError(t *testing.T) {
 	}
 
 	repoDir := t.TempDir()
-	exec.Command("git", "init", repoDir).Run()
-	exec.Command("git", "-C", repoDir, "config", "user.email", "test@test.com").Run()
-	exec.Command("git", "-C", repoDir, "config", "user.name", "test").Run()
+	initTestGitRepo(t, repoDir)
 	os.WriteFile(filepath.Join(repoDir, "test.md"), []byte("hello"), 0o644)
 	exec.Command("git", "-C", repoDir, "add", ".").Run()
 	exec.Command("git", "-C", repoDir, "commit", "-m", "init").Run()

--- a/src/pkg/proxy/inference_route.go
+++ b/src/pkg/proxy/inference_route.go
@@ -174,12 +174,32 @@ func (ir *inferenceRouter) UpdateMaxContextLen(agentName, endpoint, model string
 
 // anthropicHosts are hosts that should be intercepted when an agent has
 // an inference route configured.
+var anthropicHostsMu sync.RWMutex
 var anthropicHosts = map[string]bool{
 	"api.anthropic.com": true,
 }
 
+// RegisterAnthropicHost adds a custom hostname to the Anthropic intercept map.
+func RegisterAnthropicHost(host string) {
+	if host == "" {
+		return
+	}
+	anthropicHostsMu.Lock()
+	anthropicHosts[host] = true
+	anthropicHostsMu.Unlock()
+}
+
+// unregisterAnthropicHost removes a hostname from the Anthropic intercept map (test cleanup).
+func unregisterAnthropicHost(host string) {
+	anthropicHostsMu.Lock()
+	delete(anthropicHosts, host)
+	anthropicHostsMu.Unlock()
+}
+
 // IsAnthropicHost returns true if the host is an Anthropic API endpoint.
 func IsAnthropicHost(host string) bool {
+	anthropicHostsMu.RLock()
+	defer anthropicHostsMu.RUnlock()
 	return anthropicHosts[host]
 }
 

--- a/src/pkg/proxy/proxy_deep2_test.go
+++ b/src/pkg/proxy/proxy_deep2_test.go
@@ -385,11 +385,32 @@ func TestHandleConnectDirectAnthropicNoRoute(t *testing.T) {
 	p.inference = newInferenceRouter()
 	// No route set for any agent
 
+	// Create a local TCP server to tunnel to
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.Write([]byte("tunnel response"))
+	}()
+
+	addr := ln.Addr().String()
+	host, _, _ := net.SplitHostPort(addr)
+	RegisterAnthropicHost(host)
+	defer unregisterAnthropicHost(host)
+
 	clientConn, proxyClient := net.Pipe()
 	defer clientConn.Close()
 
-	req, _ := http.NewRequest("CONNECT", "http://api.anthropic.com:443", nil)
-	req.Host = "api.anthropic.com:443"
+	req, _ := http.NewRequest("CONNECT", "http://"+addr, nil)
+	req.Host = addr
 	req.Header.Set("Proxy-Authorization", "hive scanner")
 
 	go func() {
@@ -397,24 +418,15 @@ func TestHandleConnectDirectAnthropicNoRoute(t *testing.T) {
 		proxyClient.Close()
 	}()
 
-	// Without a route, Anthropic is not GitHub either, so tunnelDirect is called
-	// tunnel will fail to dial api.anthropic.com:443 => 502
-	buf := make([]byte, 4096)
-	var collected []byte
-	for {
-		clientConn.SetReadDeadline(time.Now().Add(3 * time.Second))
-		n, err := clientConn.Read(buf)
-		if n > 0 {
-			collected = append(collected, buf[:n]...)
-		}
-		if err != nil {
-			break
-		}
+	// Without a route for scanner, Anthropic host is not GitHub, so tunnelDirect is called.
+	// tunnelDirect connects to local listener => 200 Connection established
+	reader := bufio.NewReader(clientConn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read response: %v", err)
 	}
-	// Should get either 200 (tunnel) or 502 (failed dial)
-	response := string(collected)
-	if !strings.Contains(response, "200") && !strings.Contains(response, "502") {
-		t.Errorf("expected 200 or 502, got: %s", response)
+	if !strings.Contains(line, "200") {
+		t.Errorf("expected 200, got: %s", line)
 	}
 }
 


### PR DESCRIPTION
## Problem

CI run failed on scheduled v2-tests (issue #4076):
`TestHandleConnectDirectAnthropicNoRoute` failed with:
```
--- FAIL: TestHandleConnectDirectAnthropicNoRoute (3.00s)
    proxy_deep2_test.go:417: expected 200 or 502, got: 
```

### Cause
`TestHandleConnectDirectAnthropicNoRoute` issued a CONNECT request targeting `api.anthropic.com:443` without an inference route, triggering `p.tunnelDirect()` which attempted a live network dial with `tunnelDialTimeout` of 10s. The test placed a 3s read deadline on `clientConn`, causing a read timeout and empty response whenever the external network connection/DNS took >3s in sandboxed CI environments.

Additionally:
- `policies/watcher_git_test.go` assumed `git init` creates `master` by default; when git defaultBranch is configured to `main`, tests failed looking for `master`.
- `agent/tmux_coverage_test.go` `TestConfirmMenuOption_SelectsOption` typed keys directly at the shell prompt, failing `selectedMenuOption()`'s column-0 `❯` prefix check due to the prepended shell prompt.

## Fix
1. Add `RegisterAnthropicHost` and `unregisterAnthropicHost` helpers (with `sync.RWMutex`, matching `RegisterGitHubHost`).
2. Make `TestHandleConnectDirectAnthropicNoRoute` completely hermetic and fast by registering a local listener host and asserting 200 Connection Established without WAN dependency.
3. Explicitly checkout `-B master` after `git init` in `policies/watcher_git_test.go`.
4. Render menu option via `printf` in `agent/tmux_coverage_test.go` `TestConfirmMenuOption_SelectsOption`.

Fixes #4076