### PR TITLE
🐛 fix(hub): spoke owners see and can trigger Upgrade (hub + spoke navbar)

### DIFF
--- a/v2/pkg/hub/owner_upgrade_visibility_test.go
+++ b/v2/pkg/hub/owner_upgrade_visibility_test.go
@@ -1,0 +1,192 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// These tests pin the fix for #4081: a hive's TRUE owner whose stored
+// user.Hives role was demoted (e.g. an access approval overwrote the owner's
+// grant with "read") must still be served role "owner" everywhere the admin
+// is, so the Upgrade affordance is visible in the hub AND the spoke sees
+// X-Hive-Role: owner. Without the fix only the hub admin was normalized.
+
+// TestMyHivesNormalizesTrueOwnerRole: the registry owner with a stale "read"
+// entry in user.Hives gets role "owner" in the my-hives payload (the gate the
+// dashboard's Upgrade link renders on), and the stored role is repaired.
+func TestMyHivesNormalizesTrueOwnerRole(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const username = "true-owner"
+	u := ensureSaaSUser(username)
+	u.Hives["hosted-ownerviz"] = "read" // stale demotion
+	saveSaaSUser(u)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	now := time.Now().Format(time.RFC3339)
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "hosted-ownerviz", Owner: "true-owner", Online: true, Name: "org/repo", HiveType: "hosted", GitHash: "abc1234", LastHeartbeat: now},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req.AddCookie(testAuthCookie(username))
+	w := httptest.NewRecorder()
+	srv.handleMyHives(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Hives []struct {
+			ID   string `json:"id"`
+			Role string `json:"role"`
+		} `json:"hives"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	found := false
+	for _, h := range resp.Hives {
+		if h.ID == "hosted-ownerviz" {
+			found = true
+			if h.Role != "owner" {
+				t.Errorf("true owner served role %q, want owner", h.Role)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("owned hive missing from my-hives payload")
+	}
+
+	// The repair must persist so the spoke auth proxy reads "owner" too.
+	if got := loadSaaSUser(username).Hives["hosted-ownerviz"]; got != "owner" {
+		t.Errorf("stored role = %q, want owner (repair must persist)", got)
+	}
+}
+
+// TestMyHivesKeepsGrantedNonOwnerRole: a user who is NOT the hive owner keeps
+// their granted role — the normalization is scoped to the true owner (+admin).
+func TestMyHivesKeepsGrantedNonOwnerRole(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const username = "just-a-reader"
+	u := ensureSaaSUser(username)
+	u.Hives["hosted-ownerviz2"] = "read"
+	saveSaaSUser(u)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	now := time.Now().Format(time.RFC3339)
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "hosted-ownerviz2", Owner: "someone-else", Online: true, Name: "org/repo", HiveType: "hosted", LastHeartbeat: now},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req.AddCookie(testAuthCookie(username))
+	w := httptest.NewRecorder()
+	srv.handleMyHives(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Hives []struct {
+			ID   string `json:"id"`
+			Role string `json:"role"`
+		} `json:"hives"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, h := range resp.Hives {
+		if h.ID == "hosted-ownerviz2" && h.Role != "read" {
+			t.Errorf("granted reader served role %q, want read", h.Role)
+		}
+	}
+}
+
+// TestAuthCheckElevatesTrueOwnerRole: the spoke auth proxy must forward
+// X-Hive-Role: owner for the hive's true owner even when the stored role was
+// demoted — the spoke's requireOwnerRole gates /api/self-upgrade on it.
+func TestAuthCheckElevatesTrueOwnerRole(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const username = "spoke-owner"
+	u := ensureSaaSUser(username)
+	u.Hives["hosted-spoke-own"] = "read" // stale demotion
+	saveSaaSUser(u)
+	saveSaaSHive(&SaaSHive{ID: "hosted-spoke-own", Owner: username, ClusterID: "hive-oke"})
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=hosted-spoke-own", nil)
+	req.AddCookie(testAuthCookie(username))
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("X-Hive-Role"); got != "owner" {
+		t.Errorf("X-Hive-Role = %q, want owner", got)
+	}
+}
+
+// TestAuthCheckStillRejectsStranger: the owner elevation must not open the
+// proxy to users with no grant and no ownership.
+func TestAuthCheckStillRejectsStranger(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const username = "stranger"
+	ensureSaaSUser(username)
+	saveSaaSHive(&SaaSHive{ID: "hosted-not-yours", Owner: "someone-else", ClusterID: "hive-oke"})
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=hosted-not-yours", nil)
+	req.AddCookie(testAuthCookie(username))
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("stranger status = %d, want 403", w.Code)
+	}
+}
+
+// TestAuthCheckKeepsGrantedNonOwnerRole: a granted reader on someone else's
+// hive still reaches the spoke with their real (non-owner) role.
+func TestAuthCheckKeepsGrantedNonOwnerRole(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const username = "reader-two"
+	u := ensureSaaSUser(username)
+	u.Hives["hosted-read-only"] = "read"
+	saveSaaSUser(u)
+	saveSaaSHive(&SaaSHive{ID: "hosted-read-only", Owner: "someone-else", ClusterID: "hive-oke"})
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=hosted-read-only", nil)
+	req.AddCookie(testAuthCookie(username))
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("X-Hive-Role"); got != "read" {
+		t.Errorf("X-Hive-Role = %q, want read", got)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2644,8 +2644,17 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
-			if isAdmin && role != "owner" {
+			// Normalize the hive's TRUE owner to "owner" exactly like the admin:
+			// a stale demoted role in user.Hives (e.g. an access approval that
+			// overwrote the owner's grant with "read") must not hide owner-only
+			// affordances such as the Upgrade link (#4081). Persisting the repair
+			// also heals the spoke auth proxy, which forwards this stored role
+			// as X-Hive-Role.
+			if role != "owner" && (isAdmin || canonicalEqual(h.Owner, username)) {
 				role = "owner"
+				if !isAdmin {
+					user.Hives[h.ID] = "owner"
+				}
 			}
 			entry := MyHiveEntry{RegistryEntry: h, Role: role, AutoUpgrade: autoUpgradeMap[h.ID], AutoUpgradeMode: autoUpgradeModeMap[h.ID]}
 			enrichFromSaaSMeta(&entry)
@@ -2949,6 +2958,12 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
+			// Same true-owner normalization as handleMyHives (#4081): the
+			// registry owner's stored role can be stale-demoted, and the owner
+			// check below is unreachable once this branch matches.
+			if role != "owner" && (isAdmin || canonicalEqual(h.Owner, username)) {
+				role = "owner"
+			}
 			hiveAccess[h.ID] = hiveAccessInfo{Role: role, Status: "accepted"}
 			continue
 		}
@@ -7791,6 +7806,17 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 	}
 
 	role, ok := user.Hives[hiveID]
+	// Elevate the hive's TRUE owner (and the hub admin) to the owner role the
+	// spoke expects, mirroring handleMyHives (#4081). Without this, a
+	// stale-demoted stored role (or a missing map entry) reaches the spoke as
+	// X-Hive-Role and its requireOwnerRole gate rejects the owner's own
+	// self-upgrade. userIsHiveOwner is scoped to THIS hive, so a user is never
+	// elevated on a hive they do not own.
+	if !ok || role != "owner" {
+		if userIsHiveOwner(username, loadSaaSHive(hiveID)) {
+			role, ok = "owner", true
+		}
+	}
 	if !ok {
 		http.Error(w, "no access to this hive", http.StatusForbidden)
 		return


### PR DESCRIPTION
Fixes #4081

## Root cause
The hub normalized a stale-demoted stored role to `owner` **only for the hub admin**, never for the hive's actual owner. A user's stored role for their own hive (`SaaSUser.Hives[hiveID]`) can be overwritten with a non-owner value (e.g. `handleApproveAccess` unconditionally writes `read` — `v2/pkg/hub/saas.go`), after which:

1. **Hub My Hives** — `handleMyHives` served the demoted role because the stored-role branch wins before the `canonicalEqual(h.Owner, username)` check is reached, and the normalization `if isAdmin && role != "owner"` applied to the admin only. The dashboard renders the Upgrade link / queued pill / auto-upgrade select only when `h.role === 'owner'`, so the true owner saw nothing while the admin (force-normalized to owner on every row) saw it.
2. **Spoke navbar / API** — `handleSaaSAuthCheck` forwarded `user.Hives[hiveID]` verbatim as `X-Hive-Role`, so the spoke's `requireOwnerRole` (`v2/pkg/dashboard/api.go`) rejected the owner's `POST /api/self-upgrade` and the spoke treated the owner as read-only.

The per-hive upgrade API itself (`handleUpgradeHive` → `userIsHiveOwner`) already accepted the true owner — this was purely a role-serving/visibility gap.

## Fix (minimal, surgical)
Apply the same owner normalization the admin already gets to the hive's TRUE owner, scoped to their own hives:
- `handleMyHives`: elevate on canonical `Owner` match and persist the repaired role (heals the proxy path too).
- `handleAccessStatus`: same normalization for the access map.
- `handleSaaSAuthCheck`: elevate via `userIsHiveOwner(username, loadSaaSHive(hiveID))` (canonical owner match, granted owner, or hub admin) so the spoke receives `X-Hive-Role: owner`.

Admin behavior unchanged; granted `read`/`read-write` users keep their roles; strangers still get 403 (all pinned by tests).

## Tests
New `v2/pkg/hub/owner_upgrade_visibility_test.go`:
- true owner with stale `read` grant is served role `owner` in my-hives and the stored role is repaired
- granted non-owner keeps their role in my-hives
- auth-check forwards `X-Hive-Role: owner` for the true owner with a stale role
- auth-check still 403s strangers and keeps `read` for granted readers

## Validation
- `go build ./...` ✅ `go vet ./...` ✅ (from `v2/`)
- `go test ./pkg/hub/` full suite ✅ (54s, all pass)