### PR TITLE
🐛 fix(relay): a confirmed pane stall Ctrl-C'd a LIVE agent CLI once, then typed the relaunch into it as a prompt

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -667,6 +667,30 @@ function recoverWedgedShell() {
   } catch (_) {}
 }
 
+// quitLiveCLI stops an agent CLI that is STILL RUNNING in the pane, so the
+// pane falls back to a shell and a subsequent relaunch types its command at a
+// shell prompt rather than into the CLI as a chat message.
+//
+// Why two Ctrl-Cs and not one: recoverWedgedShell() above sends a single C-c,
+// which is right for its case (a DEAD CLI leaving a wedged bash PS2 prompt).
+// For a LIVE agent CLI, one C-c only cancels the current turn — claude, codex
+// and agy all stay running — so the relaunch command that follows is delivered
+// to the CLI as a prompt. That is exactly the #2203 wedge shape. The second
+// C-c, with the same delays the memory-cleanup restart path has used since
+// #2596, is what actually exits the CLI.
+//
+// Best-effort by design: if tmux is unreachable the caller is already on a
+// failure path, and a relaunch that lands badly is recovered by the
+// armCLIReadyWait() contract rather than by anything here.
+function quitLiveCLI() {
+  try {
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
+    sleepMs(1000);
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
+    sleepMs(2000);
+  } catch (_) {}
+}
+
 // capturePaneText returns the current pane contents, or "" if tmux can't be
 // reached. Extracted so the readiness classifier and the blocking-prompt
 // dismissal can look at the SAME text without capturing twice, and so the
@@ -1064,10 +1088,7 @@ function tmuxSendKeys(text) {
       // instead of restarting again (issue #2596).
       lastResetAtCount = tasksCompletedCount;
       console.log(`Restarting ${BACKEND} CLI for memory cleanup (task ${tasksCompletedCount})`);
-      execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
-      sleepMs(1000);
-      execSync(`tmux send-keys -t ${TMUX_SESSION} C-c`, { timeout: 15000 });
-      sleepMs(2000);
+      quitLiveCLI();
       // Queue this prompt and hand delivery to the readiness callback.
       // Previously the restart set cliReady=false and then FELL THROUGH to the
       // send loop below, typing the prompt into a pane where the CLI had just
@@ -1763,8 +1784,18 @@ function progressTick() {
       // (observed live: a slow `gh pr create` returned, with a real PR link,
       // seconds after the stall verdict). Relaunch it so the NEXT task starts
       // on a demonstrably fresh CLI, rather than risking its prompt landing on
-      // top of whatever the abandoned turn still produces — the same reason
-      // the CLI-died branch above relaunches before failing the task.
+      // top of whatever the abandoned turn still produces.
+      //
+      // quitLiveCLI() FIRST, and that ordering is load-bearing. Reaching this
+      // line proves the CLI is alive: the `presence.isShell` guard earlier in
+      // this function returns before the completion check whenever the pane has
+      // fallen back to a shell, so a confirmed stall is by construction a pane
+      // whose foreground program is still the agent CLI. relaunchCLI() on its
+      // own only clears a wedged SHELL (recoverWedgedShell's single C-c); against
+      // a live CLI that cancels the turn without exiting, and the launch command
+      // is then typed into the CLI as a chat prompt — #2203 again, and worse here
+      // because the "prompt" is a shell command an agent may simply run.
+      quitLiveCLI();
       try {
         console.log(`Relaunching ${BACKEND} after a confirmed pane stall: ${relaunchCLI()}`);
       } catch (e) {
@@ -2105,6 +2136,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     launchCommandWithCwd,
     cliProcessLooksGone,
     paneForegroundCommand,
+    quitLiveCLI,
     CLI_GONE_CONFIRMATIONS,
     PANE_STALL_TIMEOUT_MS,
     // Backdate the stall clock so a test can cross the timeout without

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -481,6 +481,61 @@ test('a stalled pane hands the task back as an environment failure once confirme
   } finally { teardown(relay); }
 });
 
+test('a confirmed stall QUITS the live CLI before relaunching, so the launch command is never typed into it as a prompt', () => {
+  // Reaching the stall path PROVES the CLI is alive: the `presence.isShell`
+  // guard earlier in progressTick() returns before the completion check
+  // whenever the pane has fallen back to a shell, so a confirmed stall is by
+  // construction a pane still running the agent CLI.
+  //
+  // relaunchCLI() alone is calibrated for the opposite case. The single C-c in
+  // recoverWedgedShell() clears a wedged bash PS2 prompt, but against a LIVE
+  // claude/codex/agy it only cancels the current turn — the CLI stays up, and
+  // the launch command that follows is delivered to it as a chat message. That
+  // is the #2203 wedge with a shell command as the payload, so the quit has to
+  // happen first and has to be the two-C-c sequence the memory-cleanup restart
+  // path has used since #2596.
+  const relay = loadRelay({
+    backend: 'agy',
+    paneText: 'a frozen pane with no idle prompt and nothing happening',
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-stall-quit');
+    relay.__stallTick();
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();   // confirmation 1
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    const before = relay.__tmuxSends().length;
+    relay.__stallTick();   // confirmation 2 -> quit + relaunch + fail
+    const sends = relay.__tmuxSends().slice(before);
+
+    const launchIdx = sends.findIndex(c => /agy/.test(c));
+    assert.ok(launchIdx >= 0, `expected the CLI to be relaunched: ${JSON.stringify(sends)}`);
+
+    // At least the two quitLiveCLI() Ctrl-Cs must precede the launch command.
+    // One is NOT enough and is the whole point of this test.
+    const ctrlCsBeforeLaunch = sends.slice(0, launchIdx).filter(c => /C-c\s*$/.test(c)).length;
+    assert.ok(ctrlCsBeforeLaunch >= 2,
+      `a live CLI needs two Ctrl-Cs to exit before the relaunch is typed; saw ${ctrlCsBeforeLaunch} in ${JSON.stringify(sends)}`);
+
+    // And the fix must not have cost the behaviour #4064 added.
+    const failed = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(failed.length, 1, 'the task is still handed back after the quit+relaunch');
+    assert.strictEqual(failed[0].failure_kind, 'environment');
+  } finally { teardown(relay); }
+});
+
+test('quitLiveCLI sends two Ctrl-Cs and nothing else — a single one only cancels a turn', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    const before = relay.__tmuxSends().length;
+    relay.quitLiveCLI();
+    const sends = relay.__tmuxSends().slice(before);
+    assert.strictEqual(sends.length, 2, `expected exactly two sends, got ${JSON.stringify(sends)}`);
+    assert.ok(sends.every(c => /C-c\s*$/.test(c)), `both must be Ctrl-C: ${JSON.stringify(sends)}`);
+  } finally { teardown(relay); }
+});
+
 test('a pane that reaches real IDLE_COMPLETE between stall ticks is reported as a normal completion, PR and all', () => {
   // The exact live scenario: paneText starts frozen (mid stall), then -- before
   // the SECOND confirmation tick -- the CLI's real completion appears, agy back


### PR DESCRIPTION
## The bug

Follow-up to #4064 — this is a regression that PR introduced, found while reviewing it after merge.

#4064 added a CLI relaunch to the confirmed-stall path so the next task could not land its prompt on top of an abandoned turn. **The intent was right; the mechanism was borrowed from the wrong branch.**

**Reaching the stall path proves the CLI is alive.** The `presence.isShell` guard earlier in `progressTick()` returns before the completion check whenever the pane has fallen back to a shell, so a confirmed stall is *by construction* a pane whose foreground program is still the agent CLI. That is the exact inverse of the CLI-died branch that #4064's commit message cited as precedent:

> Once a stall IS confirmed, the CLI is now also relaunched before the task is failed — **the same order the CLI-died branch already uses.**

The order is the same. The precondition is not, and that is the one difference that matters.

**`relaunchCLI()` does not kill anything.** Its only termination is the single `C-c` inside `recoverWedgedShell()`, which is calibrated for a *dead* CLI leaving a wedged bash PS2 prompt (#2203). Against a live claude/codex/agy, one `C-c` cancels the current turn and leaves the CLI running — so the launch command that follows is delivered to the CLI **as a chat message**. That is the #2203 wedge shape, and worse than the usual case, because the payload is `cd <path> && <cli> --model …` — a shell command an agent running with permissions bypassed may simply execute, nesting a CLI inside the pane.

## The fix

**The correct sequence was already in this file.** The memory-cleanup restart at `bin/contributor-relay.sh:1067` — the one other caller that stops a *live* CLI — has sent `C-c`, sleep, `C-c`, sleep since #2596, and its comment already names this exact failure:

> Previously the restart set cliReady=false and then FELL THROUGH to the send loop below, typing the prompt into a pane where the CLI had just been Ctrl-C'd and had not come back — the exact sequence in #2203.

So this extracts that sequence verbatim as `quitLiveCLI()`, calls it from **both** sites so the two cannot drift, and has the stall path quit before relaunching. No new timing constants, no new behaviour on any other path.

## Severity, stated honestly

Narrow. The trigger is rare — a byte-identical pane for `PANE_STALL_TIMEOUT_MS` (20 min) plus `PANE_STALL_CONFIRM_TICKS` confirmations — and `armCLIReadyWait()` already hands the task back if the relaunch never reaches a prompt, so it degrades to a handback rather than a silent permanent wedge. What it costs today is a confused pane, and possibly a nested CLI, at exactly the moment things are already going wrong. This makes the pane recover cleanly instead of leaning on that backstop.

## Tests

- A confirmed stall must emit **at least two** `C-c` sends *before* the launch command — one is not enough, which is the whole point — while still handing the task back as an `environment` failure.
- `quitLiveCLI()` sends exactly two `C-c` and nothing else.

**Verified non-vacuous:** reverting only the stall-path `quitLiveCLI()` call, leaving the rest of the change in place, fails the first test (100/101). With the fix, **101/101 relay tests pass.**

---
*Reviewed and fixed by Claude Opus 5.*
