### PR TITLE
feat(attribution): show the exact model + reasoning effort at the bottom of every PR (#4083)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1801,7 +1801,7 @@ function handleMessage(data, hub) {
         registration_token: hub.regToken,
         cli_backend: BACKEND,
         model: MODEL,
-        reasoning_effort: REASONING_EFFORT || undefined,
+        reasoning_effort: (BACKEND === 'agy' && MODEL) ? agyEffort : (REASONING_EFFORT || undefined),
         role: AGENT_ROLE,
         // #2547 declare half + #2567: additive, optional self-report of runtime
         // posture and protocol version. An older hub ignores these unknown fields.

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -641,6 +641,36 @@ test('auth_response includes optional HIVE_AGENT_ROLE', () => {
   } finally { teardown(relay); }
 });
 
+test('auth_response includes AGENT_REASONING_EFFORT when set', () => {
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'codex', AGENT_MODEL: 'gpt-5.6-terra', AGENT_REASONING_EFFORT: 'high' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.reasoning_effort, 'high');
+  } finally { teardown(relay); }
+});
+
+test('auth_response defaults reasoning_effort to low for agy with model', () => {
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'agy', AGENT_MODEL: 'gemini-3.7-flash' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.reasoning_effort, 'low');
+  } finally { teardown(relay); }
+});
+
+test('auth_response omits reasoning_effort when empty and not agy-with-model', () => {
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'claude', AGENT_MODEL: 'claude-sonnet-5' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.reasoning_effort, undefined);
+  } finally { teardown(relay); }
+});
+
 test('relaunchCLI() leaves cliReady false until readiness is confirmed', () => {
   const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
   try {

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1406,10 +1406,13 @@ func main() {
 		// lazily per backend and cached. Only launch descriptors flow here —
 		// never tokens, keys, or prompt content.
 		ghClient.SetAttributionResolver(func(agentName string) github.InvocationMeta {
-			backend, model, known := agentMgr.InvocationMetadata(agentName)
+			backend, model, effort, known := agentMgr.InvocationMetadata(agentName)
 			if !known {
 				if ac, inCfg := cfg.Agents[agentName]; inCfg {
 					backend, model = ac.Backend, ac.Model
+					if backend == "agy" && model != "" {
+						effort = "low"
+					}
 				}
 			}
 			tool, toolVersion := github.ResolveToolVersion(backend)
@@ -1420,6 +1423,7 @@ func main() {
 				// "auto" — see github.RequestedModel for the known follow-up
 				// on discovering bob's internal routing.
 				Model:       github.RequestedModel(backend, model),
+				Effort:      effort,
 				Tool:        tool,
 				ToolVersion: toolVersion,
 			}

--- a/src/pkg/agent/invocation_metadata_test.go
+++ b/src/pkg/agent/invocation_metadata_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestInvocationMetadata pins the contract the invocation-attribution trail
-// depends on: the EFFECTIVE backend/model (runtime overrides win over config),
+// depends on: the EFFECTIVE backend/model/effort (runtime overrides win over config),
 // and ok=false for an agent the manager does not know.
 func TestInvocationMetadata(t *testing.T) {
 	tests := []struct {
@@ -15,12 +15,14 @@ func TestInvocationMetadata(t *testing.T) {
 		agent       *AgentProcess
 		wantBackend string
 		wantModel   string
+		wantEffort  string
 	}{
 		{
 			name:        "config values with no overrides",
 			agent:       &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude", Model: "claude-opus-4-6"}},
 			wantBackend: "claude",
 			wantModel:   "claude-opus-4-6",
+			wantEffort:  "",
 		},
 		{
 			name: "backend override wins over config",
@@ -28,6 +30,7 @@ func TestInvocationMetadata(t *testing.T) {
 				BackendOverride: "copilot"},
 			wantBackend: "copilot",
 			wantModel:   "claude-opus-4-6",
+			wantEffort:  "",
 		},
 		{
 			name: "model override wins over config",
@@ -35,12 +38,28 @@ func TestInvocationMetadata(t *testing.T) {
 				ModelOverride: "claude-haiku-4-5"},
 			wantBackend: "claude",
 			wantModel:   "claude-haiku-4-5",
+			wantEffort:  "",
+		},
+		{
+			name:        "agy with model resolves default effort",
+			agent:       &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "agy", Model: "gemini-3.7-flash"}},
+			wantBackend: "agy",
+			wantModel:   "gemini-3.7-flash",
+			wantEffort:  "low",
+		},
+		{
+			name:        "agy without model has no effort",
+			agent:       &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "agy"}},
+			wantBackend: "agy",
+			wantModel:   "",
+			wantEffort:  "",
 		},
 		{
 			name:        "empty config stays empty (omitted, never guessed)",
 			agent:       &AgentProcess{Name: "a"},
 			wantBackend: "",
 			wantModel:   "",
+			wantEffort:  "",
 		},
 	}
 
@@ -49,13 +68,13 @@ func TestInvocationMetadata(t *testing.T) {
 			m := testManager(acmmLevelPushCapable)
 			m.agents["a"] = tc.agent
 
-			backend, model, ok := m.InvocationMetadata("a")
+			backend, model, effort, ok := m.InvocationMetadata("a")
 			if !ok {
 				t.Fatal("InvocationMetadata: ok=false for a known agent")
 			}
-			if backend != tc.wantBackend || model != tc.wantModel {
-				t.Errorf("InvocationMetadata = (%q, %q), want (%q, %q)",
-					backend, model, tc.wantBackend, tc.wantModel)
+			if backend != tc.wantBackend || model != tc.wantModel || effort != tc.wantEffort {
+				t.Errorf("InvocationMetadata = (%q, %q, %q), want (%q, %q, %q)",
+					backend, model, effort, tc.wantBackend, tc.wantModel, tc.wantEffort)
 			}
 		})
 	}
@@ -65,7 +84,7 @@ func TestInvocationMetadata(t *testing.T) {
 // on ok=false, so an unknown name must report exactly that — not guesses.
 func TestInvocationMetadataUnknownAgent(t *testing.T) {
 	m := testManager(acmmLevelPushCapable)
-	if backend, model, ok := m.InvocationMetadata("nobody"); ok || backend != "" || model != "" {
-		t.Errorf("unknown agent must be (\"\", \"\", false); got (%q, %q, %v)", backend, model, ok)
+	if backend, model, effort, ok := m.InvocationMetadata("nobody"); ok || backend != "" || model != "" || effort != "" {
+		t.Errorf("unknown agent must be (\"\", \"\", \"\", false); got (%q, %q, %q, %v)", backend, model, effort, ok)
 	}
 }

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -6279,25 +6279,28 @@ func (m *Manager) AuthorizeMerge(agentName string, fileUID int) error {
 	return nil
 }
 
-// InvocationMetadata reports the effective backend and model the hive invokes
-// for the named agent, accounting for runtime overrides — the launch-time
-// truth the invocation-attribution trail records (see pkg/github/attribution
+// InvocationMetadata reports the effective backend, model, and reasoning effort
+// the hive invokes for the named agent, accounting for runtime overrides — the
+// launch-time truth the invocation-attribution trail records (see pkg/github/attribution
 // .go). ok=false when the agent is unknown to the manager (the caller then
 // falls back to static config). Read-only under RLock; called from the
 // PR-request watcher goroutine, never from the launch path.
-func (m *Manager) InvocationMetadata(agentName string) (backend, model string, ok bool) {
+func (m *Manager) InvocationMetadata(agentName string) (backend, model, effort string, ok bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	agent, exists := m.agents[agentName]
 	if !exists {
-		return "", "", false
+		return "", "", "", false
 	}
 	backend = effectiveBackend(agent)
 	model = agent.Config.Model
 	if agent.ModelOverride != "" {
 		model = agent.ModelOverride
 	}
-	return backend, model, true
+	if backend == "agy" && model != "" {
+		effort = agyDefaultEffort
+	}
+	return backend, model, effort, true
 }
 
 // filteredEnv returns os.Environ() with write-capable tokens removed for advisory agents.

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -180,6 +180,7 @@ type ContributorProfile struct {
 	PreferredRole     string `json:"preferred_role,omitempty"`
 	CLIBackend        string `json:"cli_backend,omitempty"`
 	Model             string `json:"model,omitempty"`
+	ReasoningEffort   string `json:"reasoning_effort,omitempty"`
 	AvatarURL         string `json:"avatar_url,omitempty"`
 	// InvitedBy records the GitHub username of the TRUSTED/advisor contributor
 	// who invited this person via a trusted invite link (issue #2598). It is

--- a/src/pkg/dashboard/contribute_attribution_reconcile_test.go
+++ b/src/pkg/dashboard/contribute_attribution_reconcile_test.go
@@ -1,0 +1,120 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+func TestWSMessage_ReasoningEffortJSON(t *testing.T) {
+	raw := `{"type":"auth_response","cli_backend":"codex","model":"gpt-5.6-terra","reasoning_effort":"high"}`
+	var msg WSMessage
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatalf("unmarshal WSMessage failed: %v", err)
+	}
+	if msg.CLIBackend != "codex" || msg.Model != "gpt-5.6-terra" || msg.ReasoningEffort != "high" {
+		t.Errorf("unmarshaled msg = %+v, want backend=codex, model=gpt-5.6-terra, effort=high", msg)
+	}
+
+	encoded, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal WSMessage failed: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"reasoning_effort":"high"`) {
+		t.Errorf("marshaled msg missing reasoning_effort: %s", string(encoded))
+	}
+}
+
+func TestContributeWSHub_ReconcilePRAttribution(t *testing.T) {
+	var mu sync.Mutex
+	var patchedBody string
+	var patchCount int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case "GET":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":   42,
+				"html_url": "https://github.com/myorg/repo1/pull/42",
+				"body":     "Initial PR description\nFixes #5",
+				"user":     map[string]any{"login": "alice"},
+				"base": map[string]any{
+					"repo": map[string]any{
+						"name":      "repo1",
+						"full_name": "myorg/repo1",
+						"owner":     map[string]any{"login": "myorg"},
+					},
+				},
+			})
+		case "PATCH", "POST":
+			raw, _ := io.ReadAll(r.Body)
+			var patch map[string]any
+			_ = json.Unmarshal(raw, &patch)
+			mu.Lock()
+			if b, ok := patch["body"].(string); ok {
+				patchedBody = b
+			}
+			patchCount++
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":   42,
+				"html_url": "https://github.com/myorg/repo1/pull/42",
+				"body":     patchedBody,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewServer(0, logger)
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, logger)
+	s.RegisterAPI(deps)
+	hub := NewContributeWSHub(logger, s)
+
+	conn := &ContributorConnection{
+		cliBackend:      "codex",
+		model:           "gpt-5.6-terra",
+		reasoningEffort: "high",
+		role:            "quality",
+		profile: &ContributorProfile{
+			GitHubUsername: "alice",
+		},
+		capabilities: &ContributorCapabilities{
+			AgentCLIVersion: "0.5.2",
+		},
+	}
+
+	prURL := "https://github.com/myorg/repo1/pull/42"
+	hub.reconcilePRAttribution(prURL, conn)
+
+	mu.Lock()
+	count := patchCount
+	gotBody := patchedBody
+	mu.Unlock()
+
+	if count != 1 {
+		t.Fatalf("expected 1 PATCH call, got %d", count)
+	}
+
+	wantTrailer := "— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2"
+	if !strings.Contains(gotBody, wantTrailer) {
+		t.Errorf("reconciled PR body missing expected trailer: got %q, want trailer %q", gotBody, wantTrailer)
+	}
+	if !strings.Contains(gotBody, "Initial PR description\nFixes #5") {
+		t.Errorf("reconciled PR body dropped initial content: got %q", gotBody)
+	}
+}

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/kubestellar/hive/pkg/config"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
 )
 
 const (
@@ -71,15 +72,16 @@ var wsUpgrader = websocket.Upgrader{
 }
 
 type ContributorConnection struct {
-	ws           *websocket.Conn
-	profile      *ContributorProfile
-	cliBackend   string
-	model        string
-	role         string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
-	clientRole   string // relay-requested HIVE_AGENT_ROLE; owner assignment may override it
-	assignedRole string // owner-selected role; "none" forces general work
-	connectedAt  time.Time
-	currentTask  *WSTaskAssign
+	ws              *websocket.Conn
+	profile         *ContributorProfile
+	cliBackend      string
+	model           string
+	reasoningEffort string
+	role            string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
+	clientRole      string // relay-requested HIVE_AGENT_ROLE; owner assignment may override it
+	assignedRole    string // owner-selected role; "none" forces general work
+	connectedAt     time.Time
+	currentTask     *WSTaskAssign
 	// currentTaskGen is the assignment GENERATION stamped on currentTask (kubestellar/
 	// hive#2568, the Gate). It is a monotonically increasing token minted per
 	// assignment (task_assign, and the task_progress RESUME path that adopts a task).
@@ -203,6 +205,7 @@ type WSMessage struct {
 	RegistrationToken string `json:"registration_token,omitempty"`
 	CLIBackend        string `json:"cli_backend,omitempty"`
 	Model             string `json:"model,omitempty"`
+	ReasoningEffort   string `json:"reasoning_effort,omitempty"`
 	TaskID            string `json:"task_id,omitempty"`
 	// TaskGen is the assignment GENERATION / lease token for this task (kubestellar/
 	// hive#2568, the Gate). The hub stamps it on task_assign; the relay echoes it back
@@ -1394,6 +1397,44 @@ func (h *ContributeWSHub) verifyReportedPR(assignedRepo, prURL, contributorUsern
 	return false
 }
 
+// reconcilePRAttribution reconciles the attribution trailer on a verified PR
+// reported by a contributor relay (kubestellar/hive#4083). It uses the hub's own
+// record of the connection (cliBackend, model, reasoningEffort) rather than
+// self-reported metadata.
+func (h *ContributeWSHub) reconcilePRAttribution(prURL string, contributor *ContributorConnection) {
+	if h.server == nil || h.server.deps == nil || h.server.deps.GHClient == nil || contributor == nil {
+		return
+	}
+	ctx := h.server.deps.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	contributor.mu.Lock()
+	meta := ghpkg.InvocationMeta{
+		Agent:   contributor.role,
+		Backend: contributor.cliBackend,
+		Model:   ghpkg.RequestedModel(contributor.cliBackend, contributor.model),
+		Effort:  contributor.reasoningEffort,
+	}
+	if contributor.capabilities != nil && contributor.capabilities.AgentCLIVersion != "" {
+		meta.Tool = contributor.cliBackend
+		meta.ToolVersion = contributor.capabilities.AgentCLIVersion
+	}
+	username := ""
+	if contributor.profile != nil {
+		username = contributor.profile.GitHubUsername
+	}
+	contributor.mu.Unlock()
+
+	if err := h.server.deps.GHClient.ReconcilePRAttribution(ctx, prURL, meta); err != nil {
+		h.logger.Warn("[contribute-ws] PR attribution reconciliation failed",
+			"pr_url", prURL,
+			"username", username,
+			"error", err.Error(),
+		)
+	}
+}
+
 // cooldownEnabled reports whether post-completion cooldown gating is turned on
 // for this hive. It reads the operator toggle (Config.Hub.ContributeCooldownEnabled)
 // through the config resolver, which defaults to ENABLED when unset. A hub built
@@ -2014,19 +2055,20 @@ func (h *ContributeWSHub) SetContributorAgentRoleGrants(contributorID string, gr
 // carries only what the contributor handshake already put on the wire plus the
 // live connection timing the hub already tracks — no secrets, no new state.
 type FleetClanker struct {
-	ContributorID  string        `json:"contributor_id"`
-	GitHubUsername string        `json:"github_username,omitempty"`
-	CLIBackend     string        `json:"cli_backend,omitempty"`
-	Model          string        `json:"model,omitempty"`
-	Role           string        `json:"role,omitempty"`
-	ClientRole     string        `json:"client_role,omitempty"`
-	AssignedRole   string        `json:"assigned_agent_role,omitempty"`
-	RoleMismatch   string        `json:"role_mismatch,omitempty"`
-	TrustTier      string        `json:"trust_tier,omitempty"`
-	ConnectedAt    string        `json:"connected_at,omitempty"`
-	LastActivity   string        `json:"last_activity,omitempty"`
-	Stale          bool          `json:"stale,omitempty"`
-	CurrentTask    *WSTaskAssign `json:"current_task,omitempty"`
+	ContributorID   string        `json:"contributor_id"`
+	GitHubUsername  string        `json:"github_username,omitempty"`
+	CLIBackend      string        `json:"cli_backend,omitempty"`
+	Model           string        `json:"model,omitempty"`
+	ReasoningEffort string        `json:"reasoning_effort,omitempty"`
+	Role            string        `json:"role,omitempty"`
+	ClientRole      string        `json:"client_role,omitempty"`
+	AssignedRole    string        `json:"assigned_agent_role,omitempty"`
+	RoleMismatch    string        `json:"role_mismatch,omitempty"`
+	TrustTier       string        `json:"trust_tier,omitempty"`
+	ConnectedAt     string        `json:"connected_at,omitempty"`
+	LastActivity    string        `json:"last_activity,omitempty"`
+	Stale           bool          `json:"stale,omitempty"`
+	CurrentTask     *WSTaskAssign `json:"current_task,omitempty"`
 	// IdleReason is the machine-readable reason this clanker currently has no work
 	// (#2546): one of the taskUnavailable* reasons last sent to it. Empty when the
 	// clanker is actively working (CurrentTask set) or has never been refused. It
@@ -2117,14 +2159,15 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 	for _, c := range h.connections {
 		c.mu.Lock()
 		fc := FleetClanker{
-			CLIBackend:   c.cliBackend,
-			Model:        c.model,
-			Role:         c.role,
-			ClientRole:   c.clientRole,
-			AssignedRole: c.assignedRole,
-			ConnectedAt:  c.connectedAt.UTC().Format(time.RFC3339),
-			LastActivity: c.lastPong.UTC().Format(time.RFC3339),
-			Stale:        time.Since(c.lastPong) > wsHeartbeatTimeout,
+			CLIBackend:      c.cliBackend,
+			Model:           c.model,
+			ReasoningEffort: c.reasoningEffort,
+			Role:            c.role,
+			ClientRole:      c.clientRole,
+			AssignedRole:    c.assignedRole,
+			ConnectedAt:     c.connectedAt.UTC().Format(time.RFC3339),
+			LastActivity:    c.lastPong.UTC().Format(time.RFC3339),
+			Stale:           time.Since(c.lastPong) > wsHeartbeatTimeout,
 		}
 		if c.assignedRole != "" && normalizeAgentRole(c.clientRole) != "" && normalizeAgentRole(c.clientRole) != effectiveAssignedAgentRole(c.assignedRole) {
 			if c.assignedRole == "none" {
@@ -2325,15 +2368,16 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	for _, c := range h.connections {
 		c.mu.Lock()
 		out = append(out, ContributorConnection{
-			profile:      c.profile,
-			cliBackend:   c.cliBackend,
-			model:        c.model,
-			role:         c.role,
-			clientRole:   c.clientRole,
-			assignedRole: c.assignedRole,
-			connectedAt:  c.connectedAt,
-			currentTask:  c.currentTask,
-			tmuxOutput:   append([]string{}, c.tmuxOutput...),
+			profile:         c.profile,
+			cliBackend:      c.cliBackend,
+			model:           c.model,
+			reasoningEffort: c.reasoningEffort,
+			role:            c.role,
+			clientRole:      c.clientRole,
+			assignedRole:    c.assignedRole,
+			connectedAt:     c.connectedAt,
+			currentTask:     c.currentTask,
+			tmuxOutput:      append([]string{}, c.tmuxOutput...),
 		})
 		c.mu.Unlock()
 	}
@@ -2533,6 +2577,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if msg.Model != "" {
 				profile.Model = msg.Model
 			}
+			if msg.ReasoningEffort != "" {
+				profile.ReasoningEffort = msg.ReasoningEffort
+			}
 			if profile.AvatarURL == "" {
 				profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
 			}
@@ -2588,16 +2635,17 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 			contributor = &ContributorConnection{
-				ws:           conn,
-				profile:      profile,
-				cliBackend:   msg.CLIBackend,
-				model:        msg.Model,
-				role:         requestedRole,
-				clientRole:   clientRole,
-				assignedRole: assignedRole,
-				connectedAt:  time.Now(),
-				lastPong:     time.Now(),
-				capabilities: caps,
+				ws:              conn,
+				profile:         profile,
+				cliBackend:      msg.CLIBackend,
+				model:           msg.Model,
+				reasoningEffort: msg.ReasoningEffort,
+				role:            requestedRole,
+				clientRole:      clientRole,
+				assignedRole:    assignedRole,
+				connectedAt:     time.Now(),
+				lastPong:        time.Now(),
+				capabilities:    caps,
 			}
 
 			// Hand the slot over from the pending counter to h.connections
@@ -2969,6 +3017,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					verifiedPR := ""
 					if completedTask != nil && h.verifyReportedPR(completedTask.Repo, msg.PRURL, contributor.profile.GitHubUsername) {
 						verifiedPR = msg.PRURL
+						h.reconcilePRAttribution(msg.PRURL, contributor)
 					}
 					// #3987: normalize the completion's verdict. A verified PR always
 					// wins (shipped); with none, only an explicit no_work_needed is

--- a/src/pkg/github/attribution.go
+++ b/src/pkg/github/attribution.go
@@ -2,12 +2,16 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	gh "github.com/google/go-github/v72/github"
 )
 
 // This file is the invocation-attribution trail for artifacts the hive itself
@@ -96,6 +100,9 @@ type InvocationMeta struct {
 	// Model is the model REQUESTED at launch. For backends that self-select
 	// (bob), this is honestly "auto" — see RequestedModel.
 	Model string
+	// Effort is the reasoning effort (e.g. "low", "medium", "high", "minimal")
+	// requested at launch for backends that support it. Omitted when empty.
+	Effort string
 	// Tool is the display name for the version field (e.g. "bobshell"); the
 	// trailer renders it as "<tool>=<version>".
 	Tool string
@@ -120,6 +127,7 @@ func (m InvocationMeta) pairs() []string {
 	add("agent", m.Agent)
 	add("backend", m.Backend)
 	add("model", m.Model)
+	add("effort", m.Effort)
 	if ver := strings.TrimSpace(m.ToolVersion); ver != "" {
 		tool := strings.TrimSpace(m.Tool)
 		if tool == "" {
@@ -346,4 +354,59 @@ func (c *Client) recordCreationAudit(action string, m InvocationMeta, extra ...s
 	}
 	c.logger.Info("attribution audit (no audit sink wired yet)",
 		slog.String("action", action), slog.String("detail", detail), slog.String("agent", m.Agent))
+}
+
+// ReconcilePRAttribution ensures the PR at prURL carries an attribution trailer
+// matching meta, appending one via the GitHub API if missing. It is idempotent:
+// if the body already contains the trailer prefix, it no-ops without editing.
+// The audit entry is written unconditionally regardless of the trailer toggle.
+func (c *Client) ReconcilePRAttribution(ctx context.Context, prURL string, meta InvocationMeta) error {
+	if c == nil || c.client == nil {
+		return ErrNoGitHubClient
+	}
+	ref, err := ParsePRURL(prURL)
+	if err != nil {
+		return fmt.Errorf("reconcile attribution: invalid PR URL %q: %w", prURL, err)
+	}
+
+	defer func() {
+		c.recordCreationAudit(AuditActionAgentPRCreated, meta,
+			"repo", ref.FullName(),
+			"number", strconv.Itoa(ref.Number),
+			"url", prURL,
+			"reconciled", "true",
+		)
+	}()
+
+	if !c.attributionTrailerOn() {
+		return nil
+	}
+
+	pr, _, err := c.client.PullRequests.Get(ctx, ref.Owner, ref.Repo, ref.Number)
+	if err != nil {
+		return fmt.Errorf("reconcile attribution: get PR %s#%d: %w", ref.FullName(), ref.Number, err)
+	}
+	if pr == nil {
+		return fmt.Errorf("reconcile attribution: PR %s#%d not found", ref.FullName(), ref.Number)
+	}
+
+	body := pr.GetBody()
+	newBody := AppendTrailer(body, meta)
+	if newBody == body {
+		// Already has trailer, or meta is empty: nothing to do.
+		return nil
+	}
+
+	_, _, err = c.client.PullRequests.Edit(ctx, ref.Owner, ref.Repo, ref.Number, &gh.PullRequest{
+		Body: gh.Ptr(newBody),
+	})
+	if err != nil {
+		return fmt.Errorf("reconcile attribution: edit PR %s#%d: %w", ref.FullName(), ref.Number, err)
+	}
+	c.logger.Info("ReconcilePRAttribution: appended attribution trailer to PR",
+		slog.String("repo", ref.FullName()),
+		slog.Int("number", ref.Number),
+		slog.String("trailer", meta.Trailer()),
+	)
+	return nil
 }

--- a/src/pkg/github/attribution_test.go
+++ b/src/pkg/github/attribution_test.go
@@ -16,12 +16,35 @@ import (
 
 func TestAttributionTrailer_AllFields(t *testing.T) {
 	m := InvocationMeta{
-		Agent: "quality", Backend: "bob", Model: "auto",
-		Tool: "bobshell", ToolVersion: "1.0.6", Session: "abc123",
+		Agent: "quality", Backend: "codex", Model: "gpt-5.6-terra", Effort: "high",
+		Tool: "codex", ToolVersion: "0.5.2", Session: "abc123",
 	}
-	want := "— hive: agent=quality backend=bob model=auto bobshell=1.0.6 session=abc123"
+	want := "— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2 session=abc123"
 	if got := m.Trailer(); got != want {
 		t.Errorf("Trailer() = %q, want %q", got, want)
+	}
+}
+
+func TestAttributionTrailer_EffortVariations(t *testing.T) {
+	// Effort present: emitted between model and tool
+	mWithEffort := InvocationMeta{
+		Agent: "quality", Backend: "agy", Model: "gemini-3.7-flash", Effort: "low", Tool: "agy", ToolVersion: "1.0.0",
+	}
+	wantWithEffort := "— hive: agent=quality backend=agy model=gemini-3.7-flash effort=low agy=1.0.0"
+	if got := mWithEffort.Trailer(); got != wantWithEffort {
+		t.Errorf("Trailer() with effort = %q, want %q", got, wantWithEffort)
+	}
+
+	// Effort absent: completely omitted, no bare "effort=" token
+	mNoEffort := InvocationMeta{
+		Agent: "quality", Backend: "claude", Model: "claude-sonnet-5", Tool: "claude", ToolVersion: "2.0.0",
+	}
+	wantNoEffort := "— hive: agent=quality backend=claude model=claude-sonnet-5 claude=2.0.0"
+	if got := mNoEffort.Trailer(); got != wantNoEffort {
+		t.Errorf("Trailer() without effort = %q, want %q", got, wantNoEffort)
+	}
+	if strings.Contains(mNoEffort.Trailer(), "effort") {
+		t.Errorf("Trailer() should omit effort completely when empty, got %q", mNoEffort.Trailer())
 	}
 }
 
@@ -213,5 +236,159 @@ func TestPRRequestWatcher_TrailerOffStillAudits(t *testing.T) {
 	}
 	if !strings.Contains(audits[0].detail, "backend=claude") {
 		t.Errorf("audit detail = %q", audits[0].detail)
+	}
+}
+
+// reconcilePRMock returns a test server that serves GET and PATCH on /repos/o/r/pulls/12.
+func reconcilePRMock(t *testing.T, initialBody string, editedBody *string, editCount *int) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	currentBody := initialBody
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/o/r/pulls/12"):
+			mu.Lock()
+			b := currentBody
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":   12,
+				"html_url": "https://github.com/o/r/pull/12",
+				"body":     b,
+				"user":     map[string]any{"login": "contributor-user"},
+				"base": map[string]any{
+					"repo": map[string]any{"full_name": "o/r"},
+				},
+			})
+		case (r.Method == "PATCH" || r.Method == "POST") && strings.HasSuffix(r.URL.Path, "/repos/o/r/pulls/12"):
+			raw, _ := io.ReadAll(r.Body)
+			var patch map[string]any
+			_ = json.Unmarshal(raw, &patch)
+			mu.Lock()
+			if b, ok := patch["body"].(string); ok {
+				currentBody = b
+				if editedBody != nil {
+					*editedBody = b
+				}
+			}
+			if editCount != nil {
+				*editCount++
+			}
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":   12,
+				"html_url": "https://github.com/o/r/pull/12",
+				"body":     currentBody,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestReconcilePRAttribution_AppendsTrailer(t *testing.T) {
+	var edited string
+	var editCount int
+	srv := reconcilePRMock(t, "Initial PR description\nFixes #10", &edited, &editCount)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	var audits []auditRec
+	c.SetAttributionHooks(AttributionHooks{
+		TrailerEnabled: func() bool { return true },
+		Audit:          func(action, detail, agent string) { audits = append(audits, auditRec{action, detail, agent}) },
+	})
+
+	meta := InvocationMeta{
+		Agent:       "quality",
+		Backend:     "codex",
+		Model:       "gpt-5.6-terra",
+		Effort:      "high",
+		Tool:        "codex",
+		ToolVersion: "0.5.2",
+	}
+
+	err := c.ReconcilePRAttribution(context.Background(), "https://github.com/o/r/pull/12", meta)
+	if err != nil {
+		t.Fatalf("ReconcilePRAttribution failed: %v", err)
+	}
+
+	if editCount != 1 {
+		t.Fatalf("expected 1 edit call, got %d", editCount)
+	}
+	wantTrailer := "— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2"
+	if !strings.Contains(edited, wantTrailer) {
+		t.Errorf("edited body missing trailer: %q", edited)
+	}
+	if !strings.Contains(edited, "Initial PR description\nFixes #10") {
+		t.Errorf("edited body missing original description: %q", edited)
+	}
+
+	if len(audits) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(audits))
+	}
+	if audits[0].action != AuditActionAgentPRCreated {
+		t.Errorf("audit action = %q, want %q", audits[0].action, AuditActionAgentPRCreated)
+	}
+	if !strings.Contains(audits[0].detail, "effort=high") || !strings.Contains(audits[0].detail, "reconciled=true") {
+		t.Errorf("audit detail = %q", audits[0].detail)
+	}
+}
+
+func TestReconcilePRAttribution_IdempotentAlreadyHasTrailer(t *testing.T) {
+	var edited string
+	var editCount int
+	initial := "Fixes #10\n\n— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2"
+	srv := reconcilePRMock(t, initial, &edited, &editCount)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	meta := InvocationMeta{
+		Agent:   "quality",
+		Backend: "codex",
+		Model:   "gpt-5.6-terra",
+		Effort:  "high",
+	}
+
+	err := c.ReconcilePRAttribution(context.Background(), "https://github.com/o/r/pull/12", meta)
+	if err != nil {
+		t.Fatalf("ReconcilePRAttribution failed: %v", err)
+	}
+
+	// Body already had trailer, so editCount must remain 0 (no edit API call).
+	if editCount != 0 {
+		t.Errorf("expected 0 edit calls when trailer already present, got %d", editCount)
+	}
+}
+
+func TestReconcilePRAttribution_TrailerOffStillAudits(t *testing.T) {
+	var edited string
+	var editCount int
+	srv := reconcilePRMock(t, "Fixes #10", &edited, &editCount)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	var audits []auditRec
+	c.SetAttributionHooks(AttributionHooks{
+		TrailerEnabled: func() bool { return false },
+		Audit:          func(action, detail, agent string) { audits = append(audits, auditRec{action, detail, agent}) },
+	})
+
+	meta := InvocationMeta{
+		Agent:   "quality",
+		Backend: "claude",
+		Model:   "claude-sonnet-5",
+	}
+
+	err := c.ReconcilePRAttribution(context.Background(), "https://github.com/o/r/pull/12", meta)
+	if err != nil {
+		t.Fatalf("ReconcilePRAttribution failed: %v", err)
+	}
+
+	if editCount != 0 {
+		t.Errorf("expected 0 edit calls with trailer disabled, got %d", editCount)
+	}
+	if len(audits) != 1 {
+		t.Fatalf("expected 1 audit entry with trailer disabled, got %d", len(audits))
 	}
 }


### PR DESCRIPTION
Resolves #4083

## Summary
- Plumb reasoning effort end-to-end through `WSMessage`, `ContributorConnection`, and `ContributorProfile` in the contribute WebSocket hub.
- Add `Effort` to `InvocationMeta`, emit it from `pairs()` between `model` and the tool version (e.g. `— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2`), and populate it for pod agents from the agent manager (including `agyDefaultEffort`).
- Reconcile attribution trailers for contributor-relay PRs upon completion verification via GitHub API, ensuring PRs from both local and containerized contributors carry uniform, non-duplicating attribution trailers with the hub's authoritative connection records.
- Relay `auth_response` includes resolved reasoning effort (`agyEffort` for `agy` with a model, and `AGENT_REASONING_EFFORT` when provided).
- Unit tests covering trailer formatting, effort variations (present vs omitted), no-stacking idempotence, and hub PR reconciliation.

## Test Plan
- Unit tests in `pkg/github` (`TestAttributionTrailer_AllFields`, `TestAttributionTrailer_EffortVariations`, `TestReconcilePRAttribution_*`).
- Unit tests in `pkg/agent` (`TestInvocationMetadata`).
- Unit tests in `pkg/dashboard` (`TestWSMessage_ReasoningEffortJSON`, `TestContributeWSHub_ReconcilePRAttribution`).
- Full Go test suite across all packages passes (`go test ./cmd/... ./pkg/...`).
- Node.js relay test suite (`node bin/contributor-relay.test.js` - 102/102 tests pass).

— hive: agent=contributor backend=agy model=gemini-3.7-flash effort=high