### PR TITLE
🐛 fix(hub,dashboard): spoke owners can see Upgrade option in hub and spoke navbar

### DIFF
--- a/src/pkg/hub/owner_role_normalization_test.go
+++ b/src/pkg/hub/owner_role_normalization_test.go
@@ -1,0 +1,328 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// These tests pin the #4081 fix: a stale/demoted stored role
+// (SaaSUser.Hives[hiveID]) must never hide owner-gated affordances (the My
+// Hives Upgrade link, the spoke's requireOwnerRole gate behind the auth
+// proxy) from the hive's TRUE (canonical) owner. Owners are elevated only on
+// their OWN hives; other users' roles are forwarded verbatim.
+
+// demotedOwnerFixture stores a user whose stored role for their own hive has
+// been demoted to "read" — the corruption handleApproveAccess used to write.
+func demotedOwnerFixture(t *testing.T, s *HubServer, username, hiveID string) {
+	t.Helper()
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{
+		{ID: hiveID, Owner: username, Online: true},
+	}
+	s.mu.Unlock()
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: username,
+		Hives:          map[string]string{hiveID: "read"},
+	}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+}
+
+func TestMyHivesNormalizesDemotedRoleForTrueOwner(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	demotedOwnerFixture(t, s, "spoke-owner", "owned-hive")
+
+	rec := httptest.NewRecorder()
+	s.handleMyHives(rec, reqWithUser(http.MethodGet, "/api/saas/my-hives", "", "spoke-owner"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Hives []MyHiveEntry `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hives := resp.Hives
+	var found bool
+	for _, h := range hives {
+		if h.ID == "owned-hive" {
+			found = true
+			if h.Role != "owner" {
+				t.Errorf("role = %q, want owner (demoted stored role must not mask the true owner)", h.Role)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("owned-hive missing from my-hives")
+	}
+
+	// The demoted stored role must be healed so the auth proxy and every
+	// other stored-role reader sees owner on the next request too.
+	u := loadSaaSUser("spoke-owner")
+	if u == nil || u.Hives["owned-hive"] != "owner" {
+		t.Errorf("stored role = %q, want owner (healed)", u.Hives["owned-hive"])
+	}
+}
+
+func TestMyHivesNormalizesDemotedRoleForHostedHiveOwner(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	// Hosted hive with NO registry entry — only the SaaS meta record — and a
+	// demoted stored role for its owner.
+	if err := saveSaaSHive(&SaaSHive{ID: "hosted-norm", Owner: "hosted-owner", ClusterID: "hive-oke", Org: "org", PrimaryRepo: "repo"}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "hosted-owner",
+		Hives:          map[string]string{"hosted-norm": "read"},
+	}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	s.handleMyHives(rec, reqWithUser(http.MethodGet, "/api/saas/my-hives", "", "hosted-owner"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Hives []MyHiveEntry `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hives := resp.Hives
+	var found bool
+	for _, h := range hives {
+		if h.ID == "hosted-norm" {
+			found = true
+			if h.Role != "owner" {
+				t.Errorf("role = %q, want owner", h.Role)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("hosted-norm missing from my-hives")
+	}
+}
+
+func TestMyHivesDoesNotElevateNonOwner(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "someone-elses-hive", Owner: "real-owner", Online: true},
+	}
+	s.mu.Unlock()
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "just-a-reader",
+		Hives:          map[string]string{"someone-elses-hive": "read"},
+	}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	s.handleMyHives(rec, reqWithUser(http.MethodGet, "/api/saas/my-hives", "", "just-a-reader"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Hives []MyHiveEntry `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hives := resp.Hives
+	for _, h := range hives {
+		if h.ID == "someone-elses-hive" && h.Role != "read" {
+			t.Errorf("role = %q, want read (non-owners must never be elevated)", h.Role)
+		}
+	}
+}
+
+func TestAccessStatusNormalizesDemotedRoleForTrueOwner(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	demotedOwnerFixture(t, s, "spoke-owner", "owned-hive")
+
+	rec := httptest.NewRecorder()
+	s.handleAccessStatus(rec, reqWithUser(http.MethodGet, "/api/saas/access-status", "", "spoke-owner"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var resp struct {
+		Hives map[string]struct {
+			Role   string `json:"role"`
+			Status string `json:"status"`
+		} `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, ok := resp.Hives["owned-hive"]
+	if !ok {
+		t.Fatal("owned-hive missing from access-status")
+	}
+	if got.Role != "owner" {
+		t.Errorf("role = %q, want owner", got.Role)
+	}
+}
+
+func TestSaaSAuthCheckElevatesTrueOwnerRole(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	demotedOwnerFixture(t, s, "spoke-owner", "owned-hive")
+
+	req := reqWithUser(http.MethodGet, "/api/saas/auth-check?hive=owned-hive", "", "spoke-owner")
+	req.Header.Set("X-Original-URI", "/api/self-upgrade")
+	rec := httptest.NewRecorder()
+	s.handleSaaSAuthCheck(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-Hive-Role"); got != "owner" {
+		t.Errorf("X-Hive-Role = %q, want owner (spoke requireOwnerRole gates on this header)", got)
+	}
+	if got := rec.Header().Get("X-Hive-User"); got != "spoke-owner" {
+		t.Errorf("X-Hive-User = %q, want spoke-owner", got)
+	}
+}
+
+func TestSaaSAuthCheckElevatesSaaSHiveOwnerRole(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	if err := saveSaaSHive(&SaaSHive{ID: "hosted-auth", Owner: "hosted-owner", ClusterID: "hive-oke", Org: "org", PrimaryRepo: "repo"}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "hosted-owner",
+		Hives:          map[string]string{"hosted-auth": "read"},
+	}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	req := reqWithUser(http.MethodGet, "/api/saas/auth-check?hive=hosted-auth", "", "hosted-owner")
+	req.Header.Set("X-Original-URI", "/api/self-upgrade")
+	rec := httptest.NewRecorder()
+	s.handleSaaSAuthCheck(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-Hive-Role"); got != "owner" {
+		t.Errorf("X-Hive-Role = %q, want owner", got)
+	}
+}
+
+func TestSaaSAuthCheckForwardsNonOwnerRoleVerbatim(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "owned-hive", Owner: "real-owner", Online: true},
+	}
+	s.mu.Unlock()
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "just-a-reader",
+		Hives:          map[string]string{"owned-hive": "read"},
+	}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	req := reqWithUser(http.MethodGet, "/api/saas/auth-check?hive=owned-hive", "", "just-a-reader")
+	req.Header.Set("X-Original-URI", "/api/self-upgrade")
+	rec := httptest.NewRecorder()
+	s.handleSaaSAuthCheck(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-Hive-Role"); got != "read" {
+		t.Errorf("X-Hive-Role = %q, want read (non-owners must never be elevated)", got)
+	}
+}
+
+func TestApproveAccessDoesNotDemoteOwner(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	hiveID := "hosted-approve"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "the-owner", ClusterID: "hive-oke", Org: "org", PrimaryRepo: "repo"}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "the-owner",
+		Hives:          map[string]string{hiveID: "owner"},
+	}); err != nil {
+		t.Fatalf("save owner: %v", err)
+	}
+	// The owner somehow has a pending access request against their own hive
+	// (the reproduction path for the original demotion).
+	saveAccessRequests(hiveID, []AccessRequest{{Username: "the-owner", Status: "pending"}})
+
+	rec := httptest.NewRecorder()
+	req := setPathValues(reqWithUser(http.MethodPut, "/approve", "", "the-owner"),
+		map[string]string{"id": hiveID, "username": "the-owner"})
+	s.handleApproveAccess(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	u := loadSaaSUser("the-owner")
+	if u == nil || u.Hives[hiveID] != "owner" {
+		t.Errorf("stored role = %q, want owner (approve must not demote an owner)", u.Hives[hiveID])
+	}
+}
+
+func TestApproveAccessStillGrantsReadToRegularUser(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	hiveID := "hosted-approve2"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "the-owner", ClusterID: "hive-oke", Org: "org", PrimaryRepo: "repo"}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "the-owner",
+		Hives:          map[string]string{hiveID: "owner"},
+	}); err != nil {
+		t.Fatalf("save owner: %v", err)
+	}
+	saveAccessRequests(hiveID, []AccessRequest{{Username: "newcomer", Status: "pending"}})
+
+	rec := httptest.NewRecorder()
+	req := setPathValues(reqWithUser(http.MethodPut, "/approve", "", "the-owner"),
+		map[string]string{"id": hiveID, "username": "newcomer"})
+	s.handleApproveAccess(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	u := loadSaaSUser("newcomer")
+	if u == nil || u.Hives[hiveID] != "read" {
+		t.Errorf("stored role = %q, want read", u.Hives[hiveID])
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2825,6 +2825,15 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
+			// A stale/demoted stored role must not hide owner-gated UI (the
+			// Upgrade link, auto-upgrade controls) from the hive's TRUE owner.
+			// Normalize to owner for the admin (as before) AND for the
+			// canonical owner of this hive — owners are only elevated on their
+			// OWN hives (#4081).
+			if role != "owner" && canonicalEqual(h.Owner, username) {
+				role = "owner"
+				user.Hives[h.ID] = "owner" // heal the demoted stored role
+			}
 			if isAdmin && role != "owner" {
 				role = "owner"
 			}
@@ -2858,6 +2867,13 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(hiveID, "hosted-") || strings.HasPrefix(hiveID, "saas-") {
 			sh := loadSaaSHive(hiveID)
 			if sh != nil {
+				// Same owner normalization as the registry loop above: the
+				// meta record's canonical owner outranks a demoted stored
+				// role (#4081).
+				if role != "owner" && canonicalEqual(sh.Owner, username) {
+					role = "owner"
+					user.Hives[hiveID] = "owner"
+				}
 				entry := MyHiveEntry{
 					RegistryEntry: RegistryEntry{
 						ID:          sh.ID,
@@ -3140,6 +3156,11 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 	isAdmin := isHubAdmin(username)
 	for _, h := range allHives {
 		if role, ok := user.Hives[h.ID]; ok {
+			// Owner normalization mirroring handleMyHives: a stale/demoted
+			// stored role must not mask the hive's TRUE owner (#4081).
+			if role != "owner" && canonicalEqual(h.Owner, username) {
+				role = "owner"
+			}
 			hiveAccess[h.ID] = hiveAccessInfo{Role: role, Status: "accepted"}
 			continue
 		}
@@ -6006,6 +6027,33 @@ func userIsHiveOwner(username string, h *SaaSHive) bool {
 	return u != nil && u.Hives != nil && u.Hives[h.ID] == "owner"
 }
 
+// userOwnsHive reports whether username is the TRUE (canonical) owner of the
+// hive identified by hiveID, resolving through the live registry first and
+// the SaaS meta record second. Unlike userIsHiveOwner it never consults
+// stored per-user roles or hub-admin status, so it is safe to use for
+// owner-only role elevation without widening admin behavior (#4081).
+func (s *HubServer) userOwnsHive(username, hiveID string) bool {
+	if username == "" || hiveID == "" {
+		return false
+	}
+	var regOwner string
+	s.mu.Lock()
+	for _, h := range s.registry.Hives {
+		if h.ID == hiveID {
+			regOwner = h.Owner
+			break
+		}
+	}
+	s.mu.Unlock()
+	if regOwner != "" && canonicalEqual(regOwner, username) {
+		return true
+	}
+	if sh := loadSaaSHive(hiveID); sh != nil && canonicalEqual(sh.Owner, username) {
+		return true
+	}
+	return false
+}
+
 func (s *HubServer) handleAccessList(w http.ResponseWriter, r *http.Request) {
 	hiveID := r.PathValue("id")
 	username := s.getAuthUser(r)
@@ -6408,7 +6456,12 @@ func (s *HubServer) handleApproveAccess(w http.ResponseWriter, r *http.Request) 
 
 	const defaultApproveRole = "read"
 	target := ensureSaaSUser(targetUsername)
-	target.Hives[hiveID] = defaultApproveRole
+	// Never demote the hive's TRUE owner (or an already-granted owner) to the
+	// default role — this unconditional overwrite is how owners lost their
+	// stored role and, with it, every owner-gated affordance (#4081).
+	if target.Hives[hiveID] != "owner" && !canonicalEqual(h.Owner, targetUsername) {
+		target.Hives[hiveID] = defaultApproveRole
+	}
 	saveSaaSUser(target)
 
 	s.logger.Info("audit: access approved via PUT", "hive", hiveID, "target", targetUsername, "by", approver)
@@ -8198,6 +8251,15 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 	}
 
 	role, ok := user.Hives[hiveID]
+	// The spoke enforces owner-gated actions (requireOwnerRole, e.g.
+	// POST /api/self-upgrade) from X-Hive-Role alone, so a stale/demoted
+	// stored role would lock the hive's TRUE owner out of their own spoke.
+	// Elevate the canonical owner — scoped to their OWN hive — before
+	// forwarding the role (#4081).
+	if role != "owner" && s.userOwnsHive(username, hiveID) {
+		role = "owner"
+		ok = true
+	}
 	if !ok {
 		http.Error(w, "no access to this hive", http.StatusForbidden)
 		return


### PR DESCRIPTION
## Summary

Fixes #4081.

A spoke OWNER could not see the Upgrade affordance in the hub "My Hives" dashboard or use owner-gated actions on their spoke (`POST /api/self-upgrade` behind `requireOwnerRole`), while the hub admin could.

## Root cause

A user's stored role for their own hive (`SaaSUser.Hives[hiveID]`) could be demoted (e.g. `handleApproveAccess` unconditionally overwrote it with `read`). The stored-role-first branches then served the demoted role:

- `handleMyHives`: the admin-only normalization (`isAdmin && role != "owner"`) left the true owner demoted, hiding the Upgrade link / auto-upgrade controls
- `handleAccessStatus`: same stored-role-first pattern
- `handleSaaSAuthCheck`: forwarded the demoted role verbatim as `X-Hive-Role`, so the spoke's `requireOwnerRole` rejected the true owner

Meanwhile `handleUpgradeHive` → `userIsHiveOwner` DID recognize the owner via `canonicalEqual` — purely a role-serving/visibility gap.

## Fix

Apply the same owner normalization the admin already gets to the hive's canonical owner, scoped to their OWN hives only:

- `handleMyHives`: elevate + heal the demoted stored role (registry and hosted-hive loops)
- `handleAccessStatus`: elevate the served role
- `handleSaaSAuthCheck`: elevate `X-Hive-Role` via new `userOwnsHive` helper (registry owner first, SaaS meta second; never consults stored roles or admin status)
- `handleApproveAccess`: never demote an existing/true owner to the default approve role (the corruption source)

Admin and non-owner behavior unchanged.

## Tests

New `owner_role_normalization_test.go` covers: owner elevation + stored-role healing in my-hives (registry and hosted), access-status elevation, auth-check `X-Hive-Role` elevation (registry and SaaS hives), non-owner roles forwarded verbatim, and approve-access no longer demoting owners while still granting `read` to regular users.

`go build ./... && go vet ./... && go test ./pkg/hub/... ./pkg/dashboard/... -count=1` — all green.