### PR TITLE
feat(dashboard): show exact model + reasoning effort on every Live Activity event (#4084)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1832,7 +1832,7 @@ function handleMessage(data, hub) {
         registration_token: hub.regToken,
         cli_backend: BACKEND,
         model: MODEL,
-        reasoning_effort: REASONING_EFFORT || undefined,
+        reasoning_effort: (BACKEND === 'agy' && MODEL) ? agyEffort : (REASONING_EFFORT || undefined),
         role: AGENT_ROLE,
         // #2547 declare half + #2567: additive, optional self-report of runtime
         // posture and protocol version. An older hub ignores these unknown fields.

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -696,6 +696,36 @@ test('auth_response includes optional HIVE_AGENT_ROLE', () => {
   } finally { teardown(relay); }
 });
 
+test('auth_response includes AGENT_REASONING_EFFORT when set', () => {
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'codex', AGENT_MODEL: 'gpt-5.6-terra', AGENT_REASONING_EFFORT: 'high' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.reasoning_effort, 'high');
+  } finally { teardown(relay); }
+});
+
+test('auth_response defaults reasoning_effort to low for agy with model', () => {
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'agy', AGENT_MODEL: 'gemini-3.7-flash' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.reasoning_effort, 'low');
+  } finally { teardown(relay); }
+});
+
+test('auth_response omits reasoning_effort when empty and not agy-with-model', () => {
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'claude', AGENT_MODEL: 'claude-sonnet-5' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.reasoning_effort, undefined);
+  } finally { teardown(relay); }
+});
+
 test('relaunchCLI() leaves cliReady false until readiness is confirmed', () => {
   const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
   try {

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -180,6 +180,7 @@ type ContributorProfile struct {
 	PreferredRole     string `json:"preferred_role,omitempty"`
 	CLIBackend        string `json:"cli_backend,omitempty"`
 	Model             string `json:"model,omitempty"`
+	ReasoningEffort   string `json:"reasoning_effort,omitempty"`
 	AvatarURL         string `json:"avatar_url,omitempty"`
 	// InvitedBy records the GitHub username of the TRUSTED/advisor contributor
 	// who invited this person via a trusted invite link (issue #2598). It is
@@ -5471,15 +5472,33 @@ function ccTaskRefLink(task){
   if(!m)return '<span class="ref">'+esc(task)+'</span>';
   return ccIssueLinkHTML({repo:m[1],number:m[2]},task,'ref');
 }
+function ccFormatLoadout(e,cls){
+  if(!e||!e.cli)return '';
+  var c=esc(e.cli);
+  var m=e.model?esc(e.model):'';
+  var ef=e.effort?esc(e.effort):'';
+  var text='via '+c+' CLI';
+  if(m){
+    text+=' with '+m;
+    if(ef){
+      text+=' ('+ef+')';
+    }
+  }
+  return ' <span class="'+(cls||'feed-cli')+'">'+text+'</span>';
+}
+window.ccFormatLoadout=ccFormatLoadout;
+window.esc=esc;
+
 function ccNarrate(e){
   var icons={joined:'🟢',left:'⚪',"picked up":'🔧',completed:'✅',failed:'❌',promoted:'🎖️'};
   var ic=icons[e.action]||'⚡';
   var who='<span class="who">'+esc(e.username||'someone')+'</span>';
   var ref=e.task?' <span class="ref">'+esc(e.task)+'</span>':'';
   var pickedRef=e.task?' '+ccTaskRefLink(e.task):'';
+  var loadout=ccFormatLoadout(e,'ref');
   var body;
   switch(e.action){
-    case 'joined': body=who+' entered the hive'+(e.cli?' <span class="ref">via '+esc(e.cli)+'</span>':''); break;
+    case 'joined': body=who+' entered the hive'; break;
     case 'left': body=who+' left the hive'; break;
     case 'picked up': body=who+' grabbed'+pickedRef; break;
     case 'completed': body=who+' completed'+ref; break;
@@ -5487,7 +5506,7 @@ function ccNarrate(e){
     case 'promoted': body=who+' was promoted to <b>'+esc(e.task||e.role||'contributor')+'</b>'; break;
     default: body=who+' '+esc(e.action)+ref;
   }
-  return {ic:ic,body:body,ts:e.timestamp};
+  return {ic:ic,body:body+loadout,ts:e.timestamp};
 }
 function ccRenderLog(){
   var el=document.getElementById('cc-log');if(!el)return;
@@ -5932,11 +5951,11 @@ const icons={joined:'🟢',left:'🔴','picked up':'🔧',completed:'✅',failed
 const verbs={joined:'entered the hive',left:'left the hive','picked up':'picked up','completed':'completed','failed':'failed'};
 const icon=icons[e.action]||'⚡';
 const verb=verbs[e.action]||e.action;
-const taskInfo=e.task?' <span class="feed-cli">'+e.task+'</span>':'';
-const role=e.role?' as <span class="feed-role">'+e.role+'</span>':'';
-const cliModel=e.cli?(e.model?' <span class="feed-cli">via '+e.cli+' CLI with '+e.model+'</span>':' <span class="feed-cli">via '+e.cli+' CLI</span>'):'';
+const taskInfo=e.task?' <span class="feed-cli">'+esc(e.task)+'</span>':'';
+const role=e.role?' as <span class="feed-role">'+esc(e.role)+'</span>':'';
+const cliModel=(window.ccFormatLoadout||ccFormatLoadout)(e,'feed-cli');
 return '<div class="feed-entry"'+(i===0&&isNew?' style="background:rgba(63,185,80,.08)"':'')+'>'+
-'<div class="feed-text">'+icon+' <b>'+e.username+'</b> '+verb+taskInfo+role+cliModel+'</div>'+
+'<div class="feed-text">'+icon+' <b>'+esc(e.username)+'</b> '+verb+taskInfo+role+cliModel+'</div>'+
 '<span class="feed-time">'+t+' '+tz+'</span></div>'
 }).join('');
 if(f.innerHTML!==html){f.innerHTML=html;if(isNew)f.scrollTop=0;}

--- a/src/pkg/dashboard/contribute_agent_roles_test.go
+++ b/src/pkg/dashboard/contribute_agent_roles_test.go
@@ -137,7 +137,7 @@ func TestAgentRoleDoubleClaimUsesContributorLease(t *testing.T) {
 
 func TestAgentRoleAuditEntryRecordsContributorAndRole(t *testing.T) {
 	hub, _ := roleTestHub(t)
-	hub.addActivity("alice", "picked up", "scanner", "copilot", "gpt", "contributor ran scanner task: issue myorg/repo#1")
+	hub.addActivity("alice", "picked up", "scanner", "copilot", "gpt", "", "contributor ran scanner task: issue myorg/repo#1")
 	entries := hub.RecentActivity()
 	if len(entries) == 0 {
 		t.Fatal("expected activity entry")

--- a/src/pkg/dashboard/contribute_live_activity_model_effort_test.go
+++ b/src/pkg/dashboard/contribute_live_activity_model_effort_test.go
@@ -1,0 +1,111 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestActivityEntry_EffortJSONSerialization(t *testing.T) {
+	entry := ActivityEntry{
+		Username: "alice",
+		Action:   "picked up",
+		Role:     "contributor",
+		CLI:      "codex",
+		Model:    "gpt-5.6-terra",
+		Effort:   "high",
+		Task:     "task-123",
+	}
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal ActivityEntry failed: %v", err)
+	}
+	if !strings.Contains(string(raw), `"effort":"high"`) {
+		t.Errorf("expected effort in JSON, got %s", string(raw))
+	}
+
+	var decoded ActivityEntry
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal ActivityEntry failed: %v", err)
+	}
+	if decoded.Effort != "high" || decoded.CLI != "codex" || decoded.Model != "gpt-5.6-terra" {
+		t.Errorf("decoded = %+v, want effort=high, cli=codex, model=gpt-5.6-terra", decoded)
+	}
+
+	// Empty effort should be omitted from JSON
+	entryNoEffort := ActivityEntry{
+		Username: "bob",
+		Action:   "joined",
+		CLI:      "bob",
+	}
+	rawNoEffort, err := json.Marshal(entryNoEffort)
+	if err != nil {
+		t.Fatalf("marshal ActivityEntry without effort failed: %v", err)
+	}
+	if strings.Contains(string(rawNoEffort), `"effort"`) {
+		t.Errorf("empty effort should be omitted, got %s", string(rawNoEffort))
+	}
+}
+
+func TestContributeWSHub_AddActivity_EffortStored(t *testing.T) {
+	hub := &ContributeWSHub{
+		connections:    make(map[string]*ContributorConnection),
+		completedTasks: make(map[string]time.Time),
+		logger:         slog.Default(),
+	}
+	hub.addActivity("alice", "picked up", "contributor", "codex", "gpt-5.6-terra", "high", "task-1")
+
+	acts := hub.RecentActivity()
+	if len(acts) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(acts))
+	}
+	if acts[0].Effort != "high" || acts[0].CLI != "codex" || acts[0].Model != "gpt-5.6-terra" {
+		t.Errorf("activity entry = %+v, want effort=high, cli=codex, model=gpt-5.6-terra", acts[0])
+	}
+}
+
+func TestContributePage_LoadoutFormattingPresence(t *testing.T) {
+	body := renderContributePage(t)
+
+	// ccFormatLoadout function must exist and be exported on window
+	if !strings.Contains(body, "function ccFormatLoadout(e,cls){") {
+		t.Error("ccFormatLoadout helper is missing from /contribute page")
+	}
+	if !strings.Contains(body, "window.ccFormatLoadout=ccFormatLoadout;") {
+		t.Error("ccFormatLoadout is not published on window")
+	}
+
+	// ccNarrate must format loadout and append to all event types
+	if !strings.Contains(body, "var loadout=ccFormatLoadout(e,'ref');") {
+		t.Error("ccNarrate does not compute loadout via ccFormatLoadout")
+	}
+	if !strings.Contains(body, "return {ic:ic,body:body+loadout,ts:e.timestamp};") {
+		t.Error("ccNarrate does not append loadout to body")
+	}
+
+	// Onboarding activity feed must use ccFormatLoadout and escape username/task/role
+	if !strings.Contains(body, "ccFormatLoadout)(e,'feed-cli')") {
+		t.Error("onboarding activity feed does not use ccFormatLoadout")
+	}
+	if !strings.Contains(body, "<b>'+esc(e.username)+'</b>") {
+		t.Error("onboarding activity feed does not escape username")
+	}
+}
+
+func TestFleetClanker_ReasoningEffortJSONSerialization(t *testing.T) {
+	clanker := FleetClanker{
+		ContributorID:   "c1",
+		CLIBackend:      "codex",
+		Model:           "gpt-5.6-terra",
+		ReasoningEffort: "high",
+	}
+	raw, err := json.Marshal(clanker)
+	if err != nil {
+		t.Fatalf("marshal FleetClanker failed: %v", err)
+	}
+	if !strings.Contains(string(raw), `"reasoning_effort":"high"`) {
+		t.Errorf("expected reasoning_effort in FleetClanker JSON, got %s", string(raw))
+	}
+}

--- a/src/pkg/dashboard/contribute_sse_test.go
+++ b/src/pkg/dashboard/contribute_sse_test.go
@@ -108,7 +108,7 @@ func TestSSEStreamsAppendedActivity(t *testing.T) {
 
 	// Append a real activity event — this is the exact fan-in point join/leave/
 	// pick-up/complete all funnel through.
-	hub.addActivity("kylerankin", "picked up", "contributor", "claude", "sonnet", "projectbluefin/common#796")
+	hub.addActivity("kylerankin", "picked up", "contributor", "claude", "sonnet", "", "projectbluefin/common#796")
 
 	// The event must reach the stream as an SSE data frame carrying the username.
 	waitFor(t, func() bool {
@@ -136,7 +136,7 @@ func TestSSEHelloReplaysRecentActivity(t *testing.T) {
 	s := NewServer(0, slog.Default())
 	s.registerContributeRoutes()
 	hub := s.contributeHub
-	hub.addActivity("castrojo", "completed", "trusted", "claude", "opus", "projectbluefin/common#707")
+	hub.addActivity("castrojo", "completed", "trusted", "claude", "opus", "", "projectbluefin/common#707")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -71,15 +71,16 @@ var wsUpgrader = websocket.Upgrader{
 }
 
 type ContributorConnection struct {
-	ws           *websocket.Conn
-	profile      *ContributorProfile
-	cliBackend   string
-	model        string
-	role         string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
-	clientRole   string // relay-requested HIVE_AGENT_ROLE; owner assignment may override it
-	assignedRole string // owner-selected role; "none" forces general work
-	connectedAt  time.Time
-	currentTask  *WSTaskAssign
+	ws              *websocket.Conn
+	profile         *ContributorProfile
+	cliBackend      string
+	model           string
+	reasoningEffort string
+	role            string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
+	clientRole      string // relay-requested HIVE_AGENT_ROLE; owner assignment may override it
+	assignedRole    string // owner-selected role; "none" forces general work
+	connectedAt     time.Time
+	currentTask     *WSTaskAssign
 	// currentTaskGen is the assignment GENERATION stamped on currentTask (kubestellar/
 	// hive#2568, the Gate). It is a monotonically increasing token minted per
 	// assignment (task_assign, and the task_progress RESUME path that adopts a task).
@@ -203,6 +204,7 @@ type WSMessage struct {
 	RegistrationToken string `json:"registration_token,omitempty"`
 	CLIBackend        string `json:"cli_backend,omitempty"`
 	Model             string `json:"model,omitempty"`
+	ReasoningEffort   string `json:"reasoning_effort,omitempty"`
 	TaskID            string `json:"task_id,omitempty"`
 	// TaskGen is the assignment GENERATION / lease token for this task (kubestellar/
 	// hive#2568, the Gate). The hub stamps it on task_assign; the relay echoes it back
@@ -320,6 +322,7 @@ type ActivityEntry struct {
 	Role      string `json:"role,omitempty"`
 	CLI       string `json:"cli,omitempty"`
 	Model     string `json:"model,omitempty"`
+	Effort    string `json:"effort,omitempty"`
 	Task      string `json:"task,omitempty"`
 }
 
@@ -757,7 +760,7 @@ func (h *ContributeWSHub) saveActivity() {
 
 const activityDebounceSecs = 60
 
-func (h *ContributeWSHub) addActivity(username, action, role, cli, model, task string) {
+func (h *ContributeWSHub) addActivity(username, action, role, cli, model, effort, task string) {
 	h.activityMu.Lock()
 	if len(h.activity) > 0 && (action == "joined" || action == "left") {
 		last := h.activity[len(h.activity)-1]
@@ -775,6 +778,7 @@ func (h *ContributeWSHub) addActivity(username, action, role, cli, model, task s
 		Role:      role,
 		CLI:       cli,
 		Model:     model,
+		Effort:    effort,
 		Task:      task,
 	}
 	h.activity = append(h.activity, entry)
@@ -1634,7 +1638,7 @@ func (h *ContributeWSHub) bookAndRevokeReleased(targets []releaseTarget, reason,
 		)
 		// #2568: record the operator's reason in the activity log so the release is
 		// auditable (the reason rides in the Task field alongside the task id).
-		h.addActivity(username, activityVerb+": "+reason, tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		h.addActivity(username, activityVerb+": "+reason, tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.conn.reasoningEffort, tgt.task.TaskID)
 		// Push the EXISTING task_revoke message so the relay stops cleanly and
 		// re-readies. Best-effort: if the socket is already gone the disconnect path
 		// has (or will) release it anyway; the cooldown above is already booked. The
@@ -1803,7 +1807,7 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID, reason string) (
 			username = tgt.conn.profile.GitHubUsername
 		}
 		taskDesc := fmt.Sprintf("%s %s#%d: %s", msg.Kind, msg.Repo, msg.Number, msg.Title)
-		h.addActivity(username, "reassigned by yank", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, taskDesc)
+		h.addActivity(username, "reassigned by yank", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.conn.reasoningEffort, taskDesc)
 		h.logger.Info("[contribute-ws] clanker reassigned after yank",
 			"username", username, "task", msg.TaskID, "repo", msg.Repo, "number", msg.Number)
 		if !h.requireExplicitAccept() {
@@ -2014,19 +2018,20 @@ func (h *ContributeWSHub) SetContributorAgentRoleGrants(contributorID string, gr
 // carries only what the contributor handshake already put on the wire plus the
 // live connection timing the hub already tracks — no secrets, no new state.
 type FleetClanker struct {
-	ContributorID  string        `json:"contributor_id"`
-	GitHubUsername string        `json:"github_username,omitempty"`
-	CLIBackend     string        `json:"cli_backend,omitempty"`
-	Model          string        `json:"model,omitempty"`
-	Role           string        `json:"role,omitempty"`
-	ClientRole     string        `json:"client_role,omitempty"`
-	AssignedRole   string        `json:"assigned_agent_role,omitempty"`
-	RoleMismatch   string        `json:"role_mismatch,omitempty"`
-	TrustTier      string        `json:"trust_tier,omitempty"`
-	ConnectedAt    string        `json:"connected_at,omitempty"`
-	LastActivity   string        `json:"last_activity,omitempty"`
-	Stale          bool          `json:"stale,omitempty"`
-	CurrentTask    *WSTaskAssign `json:"current_task,omitempty"`
+	ContributorID   string        `json:"contributor_id"`
+	GitHubUsername  string        `json:"github_username,omitempty"`
+	CLIBackend      string        `json:"cli_backend,omitempty"`
+	Model           string        `json:"model,omitempty"`
+	ReasoningEffort string        `json:"reasoning_effort,omitempty"`
+	Role            string        `json:"role,omitempty"`
+	ClientRole      string        `json:"client_role,omitempty"`
+	AssignedRole    string        `json:"assigned_agent_role,omitempty"`
+	RoleMismatch    string        `json:"role_mismatch,omitempty"`
+	TrustTier       string        `json:"trust_tier,omitempty"`
+	ConnectedAt     string        `json:"connected_at,omitempty"`
+	LastActivity    string        `json:"last_activity,omitempty"`
+	Stale           bool          `json:"stale,omitempty"`
+	CurrentTask     *WSTaskAssign `json:"current_task,omitempty"`
 	// IdleReason is the machine-readable reason this clanker currently has no work
 	// (#2546): one of the taskUnavailable* reasons last sent to it. Empty when the
 	// clanker is actively working (CurrentTask set) or has never been refused. It
@@ -2117,14 +2122,15 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 	for _, c := range h.connections {
 		c.mu.Lock()
 		fc := FleetClanker{
-			CLIBackend:   c.cliBackend,
-			Model:        c.model,
-			Role:         c.role,
-			ClientRole:   c.clientRole,
-			AssignedRole: c.assignedRole,
-			ConnectedAt:  c.connectedAt.UTC().Format(time.RFC3339),
-			LastActivity: c.lastPong.UTC().Format(time.RFC3339),
-			Stale:        time.Since(c.lastPong) > wsHeartbeatTimeout,
+			CLIBackend:      c.cliBackend,
+			Model:           c.model,
+			ReasoningEffort: c.reasoningEffort,
+			Role:            c.role,
+			ClientRole:      c.clientRole,
+			AssignedRole:    c.assignedRole,
+			ConnectedAt:     c.connectedAt.UTC().Format(time.RFC3339),
+			LastActivity:    c.lastPong.UTC().Format(time.RFC3339),
+			Stale:           time.Since(c.lastPong) > wsHeartbeatTimeout,
 		}
 		if c.assignedRole != "" && normalizeAgentRole(c.clientRole) != "" && normalizeAgentRole(c.clientRole) != effectiveAssignedAgentRole(c.assignedRole) {
 			if c.assignedRole == "none" {
@@ -2325,15 +2331,16 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	for _, c := range h.connections {
 		c.mu.Lock()
 		out = append(out, ContributorConnection{
-			profile:      c.profile,
-			cliBackend:   c.cliBackend,
-			model:        c.model,
-			role:         c.role,
-			clientRole:   c.clientRole,
-			assignedRole: c.assignedRole,
-			connectedAt:  c.connectedAt,
-			currentTask:  c.currentTask,
-			tmuxOutput:   append([]string{}, c.tmuxOutput...),
+			profile:         c.profile,
+			cliBackend:      c.cliBackend,
+			model:           c.model,
+			reasoningEffort: c.reasoningEffort,
+			role:            c.role,
+			clientRole:      c.clientRole,
+			assignedRole:    c.assignedRole,
+			connectedAt:     c.connectedAt,
+			currentTask:     c.currentTask,
+			tmuxOutput:      append([]string{}, c.tmuxOutput...),
 		})
 		c.mu.Unlock()
 	}
@@ -2448,7 +2455,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			delete(h.connections, connID)
 			h.mu.Unlock()
 			h.logger.Info("[contribute-ws] disconnected", "username", contributor.profile.GitHubUsername)
-			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend, contributor.model, "")
+			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, "")
 		}
 		conn.Close()
 	}()
@@ -2533,6 +2540,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if msg.Model != "" {
 				profile.Model = msg.Model
 			}
+			if msg.ReasoningEffort != "" {
+				profile.ReasoningEffort = msg.ReasoningEffort
+			}
 			if profile.AvatarURL == "" {
 				profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
 			}
@@ -2588,16 +2598,17 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 			contributor = &ContributorConnection{
-				ws:           conn,
-				profile:      profile,
-				cliBackend:   msg.CLIBackend,
-				model:        msg.Model,
-				role:         requestedRole,
-				clientRole:   clientRole,
-				assignedRole: assignedRole,
-				connectedAt:  time.Now(),
-				lastPong:     time.Now(),
-				capabilities: caps,
+				ws:              conn,
+				profile:         profile,
+				cliBackend:      msg.CLIBackend,
+				model:           msg.Model,
+				reasoningEffort: msg.ReasoningEffort,
+				role:            requestedRole,
+				clientRole:      clientRole,
+				assignedRole:    assignedRole,
+				connectedAt:     time.Now(),
+				lastPong:        time.Now(),
+				capabilities:    caps,
 			}
 
 			// Hand the slot over from the pending counter to h.connections
@@ -2652,7 +2663,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"cli", msg.CLIBackend,
 				"role", requestedRole,
 			)
-			h.addActivity(profile.GitHubUsername, "joined", requestedRole, msg.CLIBackend, msg.Model, "")
+			h.addActivity(profile.GitHubUsername, "joined", requestedRole, msg.CLIBackend, msg.Model, msg.ReasoningEffort, "")
 
 			select {
 			case authDone <- contributor:
@@ -2746,7 +2757,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				if task.Role != "" {
 					taskDesc = fmt.Sprintf("contributor ran %s task: %s", task.Role, taskDesc)
 				}
-				h.addActivity(contributor.profile.GitHubUsername, "picked up", contributor.role, contributor.cliBackend, contributor.model, taskDesc)
+				h.addActivity(contributor.profile.GitHubUsername, "picked up", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, taskDesc)
 				h.logger.Info("[contribute-ws] task assigned",
 					"username", contributor.profile.GitHubUsername,
 					"task", task.TaskID,
@@ -2986,7 +2997,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						h.markTaskCompletedVerdict(completedTask.Repo, completedTask.Number, verifiedPR,
 							verdict, contributor.profile.GitHubUsername, strings.TrimSpace(msg.VerdictReason))
 					}
-					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
+					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, msg.TaskID)
 					h.logger.Info("[contribute-ws] task complete",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
@@ -3021,6 +3032,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					promotedUser := contributor.profile.GitHubUsername
 					promotedCLI := contributor.cliBackend
 					promotedModel := contributor.model
+					promotedEffort := contributor.reasoningEffort
 					contributor.mu.Unlock()
 					// #2390-era command center: narrate the promotion as its own
 					// activity event so the Operations dev-log and achievement pops
@@ -3028,7 +3040,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					// Read-only signalling — it changes no control behaviour and is
 					// emitted only on the real newcomer -> contributor transition.
 					if promoted {
-						h.addActivity(promotedUser, "promoted", "contributor", promotedCLI, promotedModel, "contributor")
+						h.addActivity(promotedUser, "promoted", "contributor", promotedCLI, promotedModel, promotedEffort, "contributor")
 					}
 					_ = saveContributorProfile(contributor.profile)
 				} else {
@@ -3115,7 +3127,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					}
 					contributor.mu.Unlock()
 
-					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
+					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, msg.TaskID)
 					h.logger.Info("[contribute-ws] task failed",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
@@ -3533,7 +3545,7 @@ func (h *ContributeWSHub) reclaimExpiredLeases(now time.Time) int {
 			"number", tgt.task.Number,
 			"lease_ttl", wsTaskTimeout.String(),
 		)
-		h.addActivity(username, "lease expired: auto-released", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		h.addActivity(username, "lease expired: auto-released", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.conn.reasoningEffort, tgt.task.TaskID)
 		if tgt.conn.ws != nil {
 			_ = tgt.conn.send(WSMessage{
 				Type:   "task_revoke",

--- a/src/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/src/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -40,14 +40,14 @@ func TestCovK2_AddActivityAndRecent(t *testing.T) {
 	hub, _ := covK2Hub(t)
 
 	// A normal activity entry.
-	hub.addActivity("alice", "task_complete", "scanner", "claude", "sonnet", "repo#1")
+	hub.addActivity("alice", "task_complete", "scanner", "claude", "sonnet", "", "repo#1")
 
 	// joined/left dedup: a second identical joined within the debounce window is dropped.
-	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "")
-	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "")
+	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "", "")
+	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "", "")
 
 	// A left action for the same user still records.
-	hub.addActivity("bob", "left", "reviewer", "copilot", "gpt", "")
+	hub.addActivity("bob", "left", "reviewer", "copilot", "gpt", "", "")
 
 	recent := hub.RecentActivity()
 	if len(recent) == 0 {
@@ -65,7 +65,7 @@ func TestCovK2_AddActivityCap(t *testing.T) {
 	hub, _ := covK2Hub(t)
 	// Push beyond the cap; the ring buffer keeps only the tail.
 	for i := 0; i < maxActivityEntries+10; i++ {
-		hub.addActivity("u", "task_complete", "scanner", "claude", "sonnet", "t")
+		hub.addActivity("u", "task_complete", "scanner", "claude", "sonnet", "", "t")
 	}
 	if got := len(hub.RecentActivity()); got != maxActivityEntries {
 		t.Fatalf("expected activity capped at %d, got %d", maxActivityEntries, got)

--- a/src/pkg/dashboard/coverage_boost_test.go
+++ b/src/pkg/dashboard/coverage_boost_test.go
@@ -1334,8 +1334,8 @@ func TestContributeWSHub_AddActivity(t *testing.T) {
 		completedTasks: make(map[string]time.Time),
 		logger:         slog.Default(),
 	}
-	hub.addActivity("user1", "joined", "scanner", "claude", "sonnet", "")
-	hub.addActivity("user2", "picked up", "", "claude", "sonnet", "task-1")
+	hub.addActivity("user1", "joined", "scanner", "claude", "sonnet", "", "")
+	hub.addActivity("user2", "picked up", "", "claude", "sonnet", "", "task-1")
 
 	activity := hub.RecentActivity()
 	if len(activity) != 2 {
@@ -1349,8 +1349,8 @@ func TestContributeWSHub_AddActivity_Debounce(t *testing.T) {
 		completedTasks: make(map[string]time.Time),
 		logger:         slog.Default(),
 	}
-	hub.addActivity("user1", "joined", "", "", "", "")
-	hub.addActivity("user1", "joined", "", "", "", "")
+	hub.addActivity("user1", "joined", "", "", "", "", "")
+	hub.addActivity("user1", "joined", "", "", "", "", "")
 
 	activity := hub.RecentActivity()
 	if len(activity) != 1 {

--- a/src/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/src/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -865,7 +865,7 @@ func TestHandleContributeActivityNilHub(t *testing.T) {
 func TestHandleContributeActivityWithHubExtra(t *testing.T) {
 	srv := newFullServer(t)
 	srv.contributeHub = NewContributeWSHub(slog.Default(), nil)
-	srv.contributeHub.addActivity("user1", "joined", "newcomer", "claude", "sonnet", "")
+	srv.contributeHub.addActivity("user1", "joined", "newcomer", "claude", "sonnet", "", "")
 
 	req := httptest.NewRequest("GET", "/api/contribute/activity", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Resolves #4084

## Summary
- **Effort in ActivityEntry & Fleet**: Added `Effort` to `ActivityEntry`, and `ReasoningEffort` to `WSMessage`, `ContributorConnection`, `ContributorProfile`, and `FleetClanker`.
- **Threaded `effort` through `addActivity()`**: Updated `addActivity()` signature and all call sites in `contribute_ws.go` (joined, left, picked up, completed, failed, promoted, lease expired, operator release, yank reassign) so that the contributor's reasoning effort is recorded on all activity entries.
- **Shared Loadout Formatter**: Added `ccFormatLoadout(e, cls)` in the dashboard frontend with HTML escaping via `esc()`, formatting as `via <cli> CLI with <model> (<effort>)` with graceful degradation (e.g. `via codex CLI with gpt-5.6-terra`, `via codex CLI`, or empty when no CLI is set, never rendering bare parentheses or dangling separators).
- **Operations Rail**: Updated `ccNarrate()` to append the loadout suffix across all activity events (joined, left, picked up, completed, failed, promoted, and default).
- **Onboarding Live Activity Feed**: Switched to `ccFormatLoadout()` and ensured proper HTML-escaping (`esc()`) on `e.username`, `e.task`, `e.role`, `e.cli`, and `e.model`.
- **Relay `auth_response`**: Relay sends `reasoning_effort` (resolving default `agyEffort` for `agy` with a model, and `AGENT_REASONING_EFFORT` when set).
- **Unit Tests**: Added tests in `src/pkg/dashboard/contribute_live_activity_model_effort_test.go` and `bin/contributor-relay.test.js`.

## Test Plan
- `go test -v ./pkg/dashboard` in `src/` passes.
- `node bin/contributor-relay.test.js` (104/104 tests pass).
- Full test suite passes.

— hive: agent=contributor backend=agy model=gemini-3.7-flash effort=high