### PR TITLE
🐛 Port per-agent token refresh lifetime fix to v4 (+ auth-check stranger-403 test)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1387,8 +1387,14 @@ func main() {
 	if appAuth != nil {
 		agentMgr.SetAppAuth(appAuth)
 		agentMgr.SetSandboxPushMinter(pushbroker.GitHubAppMinter{Auth: appAuth})
-		go agentMgr.StartAgentTokenRefresh(ctx)
 	}
+	// Start the per-agent token refresh loop UNCONDITIONALLY. It no-ops until
+	// App auth is wired, and on hosted spokes that wiring happens AFTER boot
+	// (heartbeat delivery / config API reinit / config reload). Gating this on
+	// appAuth != nil at boot meant those hives never refreshed per-agent token
+	// caches: agent sessions outlived their scoped token, gh 401'd and printed
+	// "gh auth login", and the login-detector auto-paused the agent (#4072).
+	go agentMgr.StartAgentTokenRefresh(ctx)
 	if ghClient != nil {
 		agentMgr.SetSandboxPRClient(ghClient)
 	}
@@ -2284,6 +2290,10 @@ func main() {
 			ghClient = newClient
 			appAuth = newAppAuth
 			agentMgr.SetAppAuth(newAppAuth)
+			// Deliver fresh per-agent scoped tokens to already-running agents
+			// immediately — the periodic refresh loop only ticks every 40m,
+			// far too long for agents whose caches are empty or stale (#4072).
+			go agentMgr.RefreshAgentTokens(ctx)
 			dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 			logger.Info("github client reinitialized via config API", "app_id", newAppID, "installation_id", newInstallationID)
 
@@ -2691,6 +2701,8 @@ func main() {
 					ghClient = newClient
 					appAuth = newAppAuth
 					agentMgr.SetAppAuth(newAppAuth)
+					// Immediate per-agent token delivery — see #4072.
+					go agentMgr.RefreshAgentTokens(ctx)
 					agentMgr.SetSandboxPushMinter(pushbroker.GitHubAppMinter{Auth: newAppAuth})
 					agentMgr.SetSandboxPRClient(newClient)
 					dashSrv.UpdateGitHubClient(newClient, newAppAuth)
@@ -3839,6 +3851,11 @@ func main() {
 				ghClient = newClient
 				appAuth = newAppAuth
 				agentMgr.SetAppAuth(newAppAuth)
+				// Immediate per-agent token delivery: hosted spokes get their
+				// App creds via this heartbeat path AFTER agents have already
+				// launched (with empty 0-byte caches), so waiting for the next
+				// 40-minute tick guarantees a window of gh 401s (#4072).
+				go agentMgr.RefreshAgentTokens(ctx)
 				dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 				dashSrv.SetGitHubAppRequired(false)
 				dashSrv.ClearPendingGitHubAppInstall()
@@ -4982,7 +4999,7 @@ func runEvalCycle(
 	}
 
 	// Scan agent panes for login-required patterns and pause + notify if detected
-	scanForLoginRequired(cfg, agentMgr, notifier, dashSrv, logger)
+	scanForLoginRequired(ctx, cfg, agentMgr, notifier, dashSrv, logger)
 
 	agentStatuses := agentMgr.AllStatuses()
 
@@ -5289,6 +5306,7 @@ func loginCommandForBackend(backend string) string {
 // scanForLoginRequired checks each running agent's tmux pane output for login-required
 // patterns. When a match is found, the agent is paused and a notification is sent.
 func scanForLoginRequired(
+	ctx context.Context,
 	cfg *config.Config,
 	agentMgr *agent.Manager,
 	notifier *notify.Notifier,
@@ -5336,6 +5354,17 @@ func scanForLoginRequired(
 					"agent", name,
 					"pattern", re.String(),
 				)
+
+				// Attempt a per-agent token re-cache BEFORE pausing. On an
+				// App-authenticated hive the likeliest cause of a "gh auth
+				// login" prompt is an expired scoped-token cache (#4072);
+				// re-minting it now means the operator's Resume immediately
+				// works instead of 401ing straight back into this pause.
+				// Best-effort: hives without App auth (or agents without a
+				// dedicated UID) simply skip it.
+				if refreshErr := agentMgr.RefreshAgentTokenFor(ctx, name); refreshErr == nil {
+					logger.Info("re-cached per-agent scoped token before login-detector pause", "agent", name)
+				}
 
 				// Pause the agent instead of restarting
 				if pauseErr := agentMgr.Pause(name, "login-detector", "login required detected"); pauseErr != nil {

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -707,13 +707,43 @@ func writeAgentCredFile(path, token string, agentUID int) error {
 	return nil
 }
 
-const agentTokenRefreshInterval = 40 * time.Minute
+const (
+	// defaultAgentTokenRefreshInterval is how often per-agent scoped token
+	// cache files are rewritten. Installation tokens expire after 1 hour;
+	// refreshing at 40-minute intervals keeps a valid token on disk with a
+	// 20-minute safety margin.
+	defaultAgentTokenRefreshInterval = 40 * time.Minute
+	// AgentTokenRefreshIntervalEnv overrides the refresh interval with a Go
+	// duration string (e.g. "30m"). Invalid or non-positive values fall back
+	// to the default.
+	AgentTokenRefreshIntervalEnv = "HIVE_AGENT_TOKEN_REFRESH_INTERVAL"
+)
+
+// agentTokenRefreshInterval resolves the per-agent token refresh interval
+// from AgentTokenRefreshIntervalEnv, falling back to the default.
+func agentTokenRefreshInterval() time.Duration {
+	if v := os.Getenv(AgentTokenRefreshIntervalEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultAgentTokenRefreshInterval
+}
 
 // StartAgentTokenRefresh refreshes per-agent scoped tokens for all running
 // agents on a timer. Tokens expire after 1 hour; this refreshes at 40-minute
-// intervals so there's always a valid token on disk.
+// intervals (configurable via HIVE_AGENT_TOKEN_REFRESH_INTERVAL) so there's
+// always a valid token on disk.
+//
+// Safe to start even before an App auth is wired: refreshAgentTokens no-ops
+// while m.appAuth is nil, so hives whose GitHub App credentials arrive AFTER
+// boot (heartbeat delivery, config API reinit, config reload) start refreshing
+// as soon as SetAppAuth is called. Previously this loop was only started when
+// the App was configured at boot, so hosted spokes never refreshed per-agent
+// caches: agent sessions outlived their token, `gh` 401'd and printed
+// "gh auth login", and the login-detector auto-paused the agent.
 func (m *Manager) StartAgentTokenRefresh(ctx context.Context) {
-	ticker := time.NewTicker(agentTokenRefreshInterval)
+	ticker := time.NewTicker(agentTokenRefreshInterval())
 	defer ticker.Stop()
 	for {
 		select {
@@ -723,6 +753,43 @@ func (m *Manager) StartAgentTokenRefresh(ctx context.Context) {
 			m.refreshAgentTokens(ctx)
 		}
 	}
+}
+
+// RefreshAgentTokens immediately rewrites every running agent's per-agent
+// scoped token cache. Called when GitHub App auth is wired late (heartbeat
+// delivery, config API reinit, config reload) so agents that were already
+// running get a valid cache right away instead of waiting for the next tick.
+func (m *Manager) RefreshAgentTokens(ctx context.Context) {
+	m.refreshAgentTokens(ctx)
+}
+
+// RefreshAgentTokenFor re-mints and re-caches the scoped token for a single
+// agent, using the same tier logic as launch. Used by the login-detector to
+// attempt a token re-cache before pausing: the likeliest cause of a `gh`
+// "gh auth login" prompt on an App-authenticated hive is an expired cached
+// token, so refreshing it means a subsequent Resume works immediately.
+// Returns an error when the agent is unknown, has no UID, or no App auth is
+// wired.
+func (m *Manager) RefreshAgentTokenFor(ctx context.Context, name string) error {
+	m.mu.RLock()
+	auth := m.appAuth
+	agent, ok := m.agents[name]
+	m.mu.RUnlock()
+
+	if auth == nil {
+		return fmt.Errorf("no github app auth wired")
+	}
+	if !ok {
+		return fmt.Errorf("agent %s not found", name)
+	}
+	if agent.UID <= 0 {
+		return fmt.Errorf("agent %s has no dedicated UID", name)
+	}
+	tier := m.agentMode(agent).TokenTier()
+	if err := auth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
+		return fmt.Errorf("re-caching scoped token for %s: %w", name, err)
+	}
+	return nil
 }
 
 func (m *Manager) refreshAgentTokens(ctx context.Context) {

--- a/src/pkg/agent/token_refresh_test.go
+++ b/src/pkg/agent/token_refresh_test.go
@@ -1,0 +1,170 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// syncedMinter is a race-safe fake for tests where the refresh loop mints
+// from its own goroutine while the test polls.
+type syncedMinter struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *syncedMinter) WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return nil
+}
+
+func (s *syncedMinter) snapshotCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// ---------------------------------------------------------------------------
+// #4072: per-agent scoped token caches must keep refreshing for the whole
+// lifetime of an agent session, and the refresh machinery must be reachable
+// even when GitHub App auth is wired after boot.
+// ---------------------------------------------------------------------------
+
+func TestAgentTokenRefreshInterval_Default(t *testing.T) {
+	t.Setenv(AgentTokenRefreshIntervalEnv, "")
+	if got := agentTokenRefreshInterval(); got != defaultAgentTokenRefreshInterval {
+		t.Errorf("expected default %v, got %v", defaultAgentTokenRefreshInterval, got)
+	}
+}
+
+func TestAgentTokenRefreshInterval_EnvOverride(t *testing.T) {
+	t.Setenv(AgentTokenRefreshIntervalEnv, "15m")
+	if got := agentTokenRefreshInterval(); got != 15*time.Minute {
+		t.Errorf("expected 15m from env override, got %v", got)
+	}
+}
+
+func TestAgentTokenRefreshInterval_InvalidFallsBack(t *testing.T) {
+	for _, bad := range []string{"not-a-duration", "-5m", "0s"} {
+		t.Setenv(AgentTokenRefreshIntervalEnv, bad)
+		if got := agentTokenRefreshInterval(); got != defaultAgentTokenRefreshInterval {
+			t.Errorf("env %q: expected default %v, got %v", bad, defaultAgentTokenRefreshInterval, got)
+		}
+	}
+}
+
+// TestRefreshAgentTokens_Exported proves the exported immediate-refresh entry
+// point (used by the late App-auth wiring paths in main: heartbeat delivery,
+// config API reinit, config reload) mints tokens for running agents.
+func TestRefreshAgentTokens_Exported(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"runner": {Backend: "claude"},
+		"idler":  {Backend: "claude"},
+	}, discardLogger(), ProjectContext{ACMMLevel: 5})
+
+	fm := &fakeMinter{}
+	m.SetAppAuth(fm)
+	m.mu.Lock()
+	m.agents["runner"].State = StateRunning
+	m.agents["runner"].UID = 2001
+	m.agents["idler"].State = StateStopped
+	m.agents["idler"].UID = 2002
+	m.mu.Unlock()
+
+	m.RefreshAgentTokens(context.Background())
+	if fm.calls != 1 {
+		t.Errorf("expected exactly the running agent to be refreshed (1 mint), got %d", fm.calls)
+	}
+}
+
+// TestStartAgentTokenRefresh_TicksWithEnvInterval proves the loop actually
+// rewrites running agents' caches on the (env-configured) interval — the
+// production failure was this loop never being started, so token caches were
+// written once at agent start and then rotted until gh 401'd.
+func TestStartAgentTokenRefresh_TicksWithEnvInterval(t *testing.T) {
+	t.Setenv(AgentTokenRefreshIntervalEnv, "10ms")
+
+	m := NewManager(map[string]config.AgentConfig{"runner": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	fm := &syncedMinter{}
+	m.SetAppAuth(fm)
+	m.mu.Lock()
+	m.agents["runner"].State = StateRunning
+	m.agents["runner"].UID = 2001
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		m.StartAgentTokenRefresh(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for fm.snapshotCalls() == 0 {
+		select {
+		case <-deadline:
+			cancel()
+			t.Fatal("refresh loop never minted a token within 2s at a 10ms interval")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("StartAgentTokenRefresh did not return after cancel")
+	}
+}
+
+func TestRefreshAgentTokenFor_Success(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{"guide": {Backend: "claude"}}, discardLogger(), ProjectContext{ACMMLevel: 5})
+	fm := &fakeMinter{}
+	m.SetAppAuth(fm)
+	m.mu.Lock()
+	m.agents["guide"].UID = 2003
+	m.mu.Unlock()
+
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err != nil {
+		t.Fatalf("RefreshAgentTokenFor: %v", err)
+	}
+	if fm.calls != 1 {
+		t.Errorf("expected 1 mint, got %d", fm.calls)
+	}
+}
+
+func TestRefreshAgentTokenFor_Errors(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{"guide": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+
+	// No App auth wired.
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err == nil {
+		t.Error("expected error when no app auth is wired")
+	}
+
+	fm := &fakeMinter{}
+	m.SetAppAuth(fm)
+
+	// Unknown agent.
+	if err := m.RefreshAgentTokenFor(context.Background(), "ghost"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error for unknown agent, got %v", err)
+	}
+
+	// No dedicated UID (zero value) — nothing to scope to.
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err == nil || !strings.Contains(err.Error(), "no dedicated UID") {
+		t.Errorf("expected no-UID error, got %v", err)
+	}
+
+	// Mint failure is wrapped.
+	m.mu.Lock()
+	m.agents["guide"].UID = 2004
+	m.mu.Unlock()
+	fm.fail = true
+	if err := m.RefreshAgentTokenFor(context.Background(), "guide"); err == nil || !strings.Contains(err.Error(), "re-caching scoped token") {
+		t.Errorf("expected wrapped mint error, got %v", err)
+	}
+}

--- a/src/pkg/hub/owner_role_normalization_test.go
+++ b/src/pkg/hub/owner_role_normalization_test.go
@@ -263,6 +263,40 @@ func TestSaaSAuthCheckForwardsNonOwnerRoleVerbatim(t *testing.T) {
 	}
 }
 
+// TestSaaSAuthCheckStillRejectsStranger pins the 403 path THROUGH the owner
+// elevation: a known user with no stored role for a hive they do not own must
+// still be rejected — userOwnsHive setting ok=true must never open a hive to
+// a stranger (#4081).
+func TestSaaSAuthCheckStillRejectsStranger(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := newHandlerHub()
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{
+		{ID: "owned-hive", Owner: "real-owner", Online: true},
+	}
+	s.mu.Unlock()
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "total-stranger",
+		Hives:          map[string]string{},
+	}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	req := reqWithUser(http.MethodGet, "/api/saas/auth-check?hive=owned-hive", "", "total-stranger")
+	req.Header.Set("X-Original-URI", "/api/self-upgrade")
+	rec := httptest.NewRecorder()
+	s.handleSaaSAuthCheck(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (stranger must not gain access via owner elevation)", rec.Code)
+	}
+	if got := rec.Header().Get("X-Hive-Role"); got != "" {
+		t.Errorf("X-Hive-Role = %q, want empty for a rejected stranger", got)
+	}
+}
+
 func TestApproveAccessDoesNotDemoteOwner(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()


### PR DESCRIPTION
Port of #4074 to v4, plus one small test delta on top of #4089.

## Scope change
This PR originally also ported the #4081 owner-visibility fix (#4082), but #4089 landed the same fix on v4 independently and more completely (owner normalization in handleMyHives incl. the meta-record loop, handleAccessStatus, handleSaaSAuthCheck via the new `userOwnsHive` helper, PLUS fixing the root corruption in handleApproveAccess). The ported fix-1 commit was dropped in favor of #4089's implementation.

## Commit 1: refresh per-agent scoped token caches for the full agent session lifetime (Refs #4072, original PR #4074)

The 40-min per-agent token refresh loop was only started when GitHub App auth existed at boot; hosted spokes get App creds after boot via `SetAppAuth`, so the loop never ran, caches went stale, gh 401'd, and the login-detector auto-paused agents.

Ported:
- Start `StartAgentTokenRefresh` unconditionally at boot (no-ops until App auth is wired).
- Immediate exported `RefreshAgentTokens` kick at all three late `SetAppAuth` sites (config API reinit, config reload, heartbeat delivery).
- `RefreshAgentTokenFor` re-caches the agent's token when the login-detector fires, before pausing, so a subsequent Resume works immediately.
- Refresh interval configurable via `HIVE_AGENT_TOKEN_REFRESH_INTERVAL` (default 40m).
- `pkg/agent/token_refresh_test.go` (7 tests).

**Not ported** (already present on v4): the Resume-path token re-mint — v4's `Resume` already re-mints via `mintAgentTokenUnlocked` (#3962).

## Commit 2: pin stranger 403 through the auth-check owner elevation (Refs #4081)

The only gap found when diffing the dropped fix-1 against #4089: its elevation branch in `handleSaaSAuthCheck` sets `ok = true` when `userOwnsHive` matches, but no test covered the rejection path THROUGH that branch. Adds `TestSaaSAuthCheckStillRejectsStranger` to `owner_role_normalization_test.go`: a known user with no stored role for a hive they don't own must still get 403 with no `X-Hive-Role`. No code changes; reuses #4089's helpers — no duplicate helpers or redundant tests.

## Validation (from `src/`, on top of current v4)
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./pkg/hub/` ✅ (119.8s)
- `go test ./pkg/agent/` ✅ (461.0s)