### PR TITLE
✨ feat(attribution): model + reasoning-effort footer on PRs, Live Activity, and hub-side verification

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1406,7 +1406,7 @@ func main() {
 		// lazily per backend and cached. Only launch descriptors flow here —
 		// never tokens, keys, or prompt content.
 		ghClient.SetAttributionResolver(func(agentName string) github.InvocationMeta {
-			backend, model, known := agentMgr.InvocationMetadata(agentName)
+			backend, model, effort, known := agentMgr.InvocationMetadata(agentName)
 			if !known {
 				if ac, inCfg := cfg.Agents[agentName]; inCfg {
 					backend, model = ac.Backend, ac.Model
@@ -1419,7 +1419,10 @@ func main() {
 				// bob self-selects (no catalog): requested model is honestly
 				// "auto" — see github.RequestedModel for the known follow-up
 				// on discovering bob's internal routing.
-				Model:       github.RequestedModel(backend, model),
+				Model: github.RequestedModel(backend, model),
+				// Reasoning effort as resolved by the launcher; empty (omitted)
+				// for backends without a hub-side effort dial (#4083).
+				Effort:      effort,
 				Tool:        tool,
 				ToolVersion: toolVersion,
 			}

--- a/src/pkg/agent/invocation_metadata_test.go
+++ b/src/pkg/agent/invocation_metadata_test.go
@@ -8,13 +8,16 @@ import (
 
 // TestInvocationMetadata pins the contract the invocation-attribution trail
 // depends on: the EFFECTIVE backend/model (runtime overrides win over config),
-// and ok=false for an agent the manager does not know.
+// the launcher-resolved effort (agy's required --effort pairing; empty —
+// omitted, never guessed — everywhere else), and ok=false for an agent the
+// manager does not know.
 func TestInvocationMetadata(t *testing.T) {
 	tests := []struct {
 		name        string
 		agent       *AgentProcess
 		wantBackend string
 		wantModel   string
+		wantEffort  string
 	}{
 		{
 			name:        "config values with no overrides",
@@ -42,6 +45,25 @@ func TestInvocationMetadata(t *testing.T) {
 			wantBackend: "",
 			wantModel:   "",
 		},
+		{
+			// #4083: agy is launched with --effort agyDefaultEffort whenever a
+			// model is given (agy requires the pair), so the attribution trail
+			// records that same effort.
+			name:        "agy with a model reports the launcher's effort",
+			agent:       &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "agy", Model: "gemini-3-pro"}},
+			wantBackend: "agy",
+			wantModel:   "gemini-3-pro",
+			wantEffort:  agyDefaultEffort,
+		},
+		{
+			// agy without a model is launched with NO --model/--effort pair, so
+			// no effort is recorded.
+			name:        "agy without a model reports no effort",
+			agent:       &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "agy"}},
+			wantBackend: "agy",
+			wantModel:   "",
+			wantEffort:  "",
+		},
 	}
 
 	for _, tc := range tests {
@@ -49,13 +71,13 @@ func TestInvocationMetadata(t *testing.T) {
 			m := testManager(acmmLevelPushCapable)
 			m.agents["a"] = tc.agent
 
-			backend, model, ok := m.InvocationMetadata("a")
+			backend, model, effort, ok := m.InvocationMetadata("a")
 			if !ok {
 				t.Fatal("InvocationMetadata: ok=false for a known agent")
 			}
-			if backend != tc.wantBackend || model != tc.wantModel {
-				t.Errorf("InvocationMetadata = (%q, %q), want (%q, %q)",
-					backend, model, tc.wantBackend, tc.wantModel)
+			if backend != tc.wantBackend || model != tc.wantModel || effort != tc.wantEffort {
+				t.Errorf("InvocationMetadata = (%q, %q, %q), want (%q, %q, %q)",
+					backend, model, effort, tc.wantBackend, tc.wantModel, tc.wantEffort)
 			}
 		})
 	}
@@ -65,7 +87,7 @@ func TestInvocationMetadata(t *testing.T) {
 // on ok=false, so an unknown name must report exactly that — not guesses.
 func TestInvocationMetadataUnknownAgent(t *testing.T) {
 	m := testManager(acmmLevelPushCapable)
-	if backend, model, ok := m.InvocationMetadata("nobody"); ok || backend != "" || model != "" {
-		t.Errorf("unknown agent must be (\"\", \"\", false); got (%q, %q, %v)", backend, model, ok)
+	if backend, model, effort, ok := m.InvocationMetadata("nobody"); ok || backend != "" || model != "" || effort != "" {
+		t.Errorf("unknown agent must be (\"\", \"\", \"\", false); got (%q, %q, %q, %v)", backend, model, effort, ok)
 	}
 }

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -6279,25 +6279,35 @@ func (m *Manager) AuthorizeMerge(agentName string, fileUID int) error {
 	return nil
 }
 
-// InvocationMetadata reports the effective backend and model the hive invokes
-// for the named agent, accounting for runtime overrides — the launch-time
-// truth the invocation-attribution trail records (see pkg/github/attribution
-// .go). ok=false when the agent is unknown to the manager (the caller then
-// falls back to static config). Read-only under RLock; called from the
-// PR-request watcher goroutine, never from the launch path.
-func (m *Manager) InvocationMetadata(agentName string) (backend, model string, ok bool) {
+// InvocationMetadata reports the effective backend, model, and reasoning
+// effort the hive invokes for the named agent, accounting for runtime
+// overrides — the launch-time truth the invocation-attribution trail records
+// (see pkg/github/attribution.go). effort is empty when the launch command
+// carries no effort dial for this backend (only agy's --effort is hub-resolved
+// today, via agyDefaultEffort; see kubestellar/hive#4083). ok=false when the
+// agent is unknown to the manager (the caller then falls back to static
+// config). Read-only under RLock; called from the PR-request watcher
+// goroutine, never from the launch path.
+func (m *Manager) InvocationMetadata(agentName string) (backend, model, effort string, ok bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	agent, exists := m.agents[agentName]
 	if !exists {
-		return "", "", false
+		return "", "", "", false
 	}
 	backend = effectiveBackend(agent)
 	model = agent.Config.Model
 	if agent.ModelOverride != "" {
 		model = agent.ModelOverride
 	}
-	return backend, model, true
+	// Mirror the launch command: agy is passed --effort agyDefaultEffort
+	// whenever a model is given (it requires the pair); every other backend is
+	// launched without a hub-side effort, so the field stays empty (omitted
+	// from the trailer) rather than guessed.
+	if backend == "agy" && model != "" {
+		effort = agyDefaultEffort
+	}
+	return backend, model, effort, true
 }
 
 // filteredEnv returns os.Environ() with write-capable tokens removed for advisory agents.

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -5471,21 +5471,44 @@ function ccTaskRefLink(task){
   if(!m)return '<span class="ref">'+esc(task)+'</span>';
   return ccIssueLinkHTML({repo:m[1],number:m[2]},task,'ref');
 }
+// hiveLoadout is the ONE shared formatter for an activity entry's model loadout
+// (#4084): "via <cli> CLI with <model> (<effort>)" — the same wording the PR
+// footer uses — degrading gracefully: no effort drops the parens, no model drops
+// the "with", no cli renders nothing at all (never a bare "()" or dangling
+// "with"). Everything is esc()'d here so neither feed can interpolate a raw
+// cli/model/effort string again. cls picks the page's existing muted style
+// ('ref' on the ops rail, 'feed-cli' on the onboarding feed). Exported on
+// window so the onboarding feed's separate script reuses this exact function
+// instead of drifting its own copy.
+function hiveLoadout(e,cls){
+  if(!e||!e.cli)return '';
+  var s='via '+esc(e.cli)+' CLI';
+  if(e.model){
+    s+=' with '+esc(e.model);
+    if(e.effort)s+=' ('+esc(e.effort)+')';
+  }
+  return ' <span class="'+(cls||'ref')+'">'+s+'</span>';
+}
+window.hiveLoadout=hiveLoadout;
 function ccNarrate(e){
   var icons={joined:'🟢',left:'⚪',"picked up":'🔧',completed:'✅',failed:'❌',promoted:'🎖️'};
   var ic=icons[e.action]||'⚡';
   var who='<span class="who">'+esc(e.username||'someone')+'</span>';
   var ref=e.task?' <span class="ref">'+esc(e.task)+'</span>':'';
   var pickedRef=e.task?' '+ccTaskRefLink(e.task):'';
+  // #4084: every event line carries the loadout suffix — an operator watching
+  // the rail can see WHICH model picked up / completed / fumbled a task, not
+  // just that one joined.
+  var loadout=hiveLoadout(e,'ref');
   var body;
   switch(e.action){
-    case 'joined': body=who+' entered the hive'+(e.cli?' <span class="ref">via '+esc(e.cli)+'</span>':''); break;
-    case 'left': body=who+' left the hive'; break;
-    case 'picked up': body=who+' grabbed'+pickedRef; break;
-    case 'completed': body=who+' completed'+ref; break;
-    case 'failed': body=who+' hit a snag on'+ref; break;
-    case 'promoted': body=who+' was promoted to <b>'+esc(e.task||e.role||'contributor')+'</b>'; break;
-    default: body=who+' '+esc(e.action)+ref;
+    case 'joined': body=who+' entered the hive'+loadout; break;
+    case 'left': body=who+' left the hive'+loadout; break;
+    case 'picked up': body=who+' grabbed'+pickedRef+loadout; break;
+    case 'completed': body=who+' completed'+ref+loadout; break;
+    case 'failed': body=who+' hit a snag on'+ref+loadout; break;
+    case 'promoted': body=who+' was promoted to <b>'+esc(e.task||e.role||'contributor')+'</b>'+loadout; break;
+    default: body=who+' '+esc(e.action)+ref+loadout;
   }
   return {ic:ic,body:body,ts:e.timestamp};
 }
@@ -5934,7 +5957,10 @@ const icon=icons[e.action]||'⚡';
 const verb=verbs[e.action]||e.action;
 const taskInfo=e.task?' <span class="feed-cli">'+e.task+'</span>':'';
 const role=e.role?' as <span class="feed-role">'+e.role+'</span>':'';
-const cliModel=e.cli?(e.model?' <span class="feed-cli">via '+e.cli+' CLI with '+e.model+'</span>':' <span class="feed-cli">via '+e.cli+' CLI</span>'):'';
+// #4084: same shared formatter as the ops rail (exported from the command-center
+// script above), so the two feeds render the identical "via <cli> CLI with
+// <model> (<effort>)" string and e.cli/e.model/e.effort are HTML-escaped.
+const cliModel=window.hiveLoadout?window.hiveLoadout(e,'feed-cli'):'';
 return '<div class="feed-entry"'+(i===0&&isNew?' style="background:rgba(63,185,80,.08)"':'')+'>'+
 '<div class="feed-text">'+icon+' <b>'+e.username+'</b> '+verb+taskInfo+role+cliModel+'</div>'+
 '<span class="feed-time">'+t+' '+tz+'</span></div>'

--- a/src/pkg/dashboard/contribute_agent_roles_test.go
+++ b/src/pkg/dashboard/contribute_agent_roles_test.go
@@ -137,7 +137,7 @@ func TestAgentRoleDoubleClaimUsesContributorLease(t *testing.T) {
 
 func TestAgentRoleAuditEntryRecordsContributorAndRole(t *testing.T) {
 	hub, _ := roleTestHub(t)
-	hub.addActivity("alice", "picked up", "scanner", "copilot", "gpt", "contributor ran scanner task: issue myorg/repo#1")
+	hub.addActivity("alice", "picked up", "scanner", "copilot", "gpt", "", "contributor ran scanner task: issue myorg/repo#1")
 	entries := hub.RecentActivity()
 	if len(entries) == 0 {
 		t.Fatal("expected activity entry")

--- a/src/pkg/dashboard/contribute_attribution_test.go
+++ b/src/pkg/dashboard/contribute_attribution_test.go
@@ -1,0 +1,159 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+// #4083/#4084 shared prerequisite: the relay has been sending reasoning_effort
+// on auth_response all along — the hub's message struct must not silently drop
+// it at JSON decode any more.
+func TestWSMessage_DecodesReasoningEffort(t *testing.T) {
+	raw := `{"type":"auth_response","cli_backend":"codex","model":"gpt-5.6-terra","reasoning_effort":"high"}`
+	var msg WSMessage
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.ReasoningEffort != "high" {
+		t.Errorf("ReasoningEffort = %q, want %q (field silently dropped?)", msg.ReasoningEffort, "high")
+	}
+}
+
+// #4084: effort threads through addActivity to the stored/served entries, and
+// entries persisted before the field simply carry none.
+func TestAddActivity_CarriesEffort(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	hub := NewContributeWSHub(logger, nil)
+	hub.addActivity("alice", "picked up", "scanner", "codex", "gpt-5.6-terra", "high", "issue o/r#1: t")
+	hub.addActivity("bob", "joined", "", "bob", "", "", "")
+
+	entries := hub.RecentActivity()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Effort != "high" || entries[0].CLI != "codex" || entries[0].Model != "gpt-5.6-terra" {
+		t.Errorf("entry 0 loadout = (%q, %q, %q)", entries[0].CLI, entries[0].Model, entries[0].Effort)
+	}
+	if entries[1].Effort != "" {
+		t.Errorf("no-effort entry must omit effort, got %q", entries[1].Effort)
+	}
+	// The JSON the feed consumes omits an unknown effort rather than sending "".
+	b, err := json.Marshal(entries[1])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "effort") {
+		t.Errorf("empty effort must be omitted from JSON, got %s", b)
+	}
+}
+
+// #4084: the fleet view surfaces the handshake-declared effort read-only.
+func TestFleetSnapshot_CarriesEffort(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	hub := NewContributeWSHub(logger, nil)
+	hub.connections["c1"] = &ContributorConnection{
+		profile:         &ContributorProfile{ContributorID: "c1", GitHubUsername: "alice"},
+		cliBackend:      "codex",
+		model:           "gpt-5.6-terra",
+		reasoningEffort: "high",
+	}
+	snap := hub.FleetSnapshot()
+	if len(snap.Clankers) != 1 {
+		t.Fatalf("expected 1 clanker, got %d", len(snap.Clankers))
+	}
+	if snap.Clankers[0].Effort != "high" {
+		t.Errorf("FleetClanker.Effort = %q, want %q", snap.Clankers[0].Effort, "high")
+	}
+}
+
+// #4085: the assignment prompt ships the LITERAL footer line, interpolated from
+// the hub's handshake record, degrading to no instruction at all when the hub
+// knows nothing to state.
+func TestAttributionPromptInstruction(t *testing.T) {
+	got := attributionPromptInstruction("codex", "gpt-5.6-terra", "high")
+	if !strings.Contains(got, "'— hive: backend=codex model=gpt-5.6-terra effort=high'") {
+		t.Errorf("instruction missing literal trailer: %q", got)
+	}
+	// No effort → the line simply has no effort pair.
+	got = attributionPromptInstruction("codex", "gpt-5.6-terra", "")
+	if strings.Contains(got, "effort") {
+		t.Errorf("no-effort instruction must omit effort: %q", got)
+	}
+	// bob self-selects: model is honestly "auto" (RequestedModel).
+	got = attributionPromptInstruction("bob", "", "")
+	if !strings.Contains(got, "backend=bob model=auto") {
+		t.Errorf("bob instruction = %q", got)
+	}
+	// Nothing known → no instruction, never a dangling sentence.
+	if got := attributionPromptInstruction("", "", ""); got != "" {
+		t.Errorf("unknown loadout must produce no instruction, got %q", got)
+	}
+}
+
+// #4085 verify-don't-trust: on a verified completion the hub appends the
+// missing trailer to the PR with its own handshake record of the connection,
+// and never stacks a second one on a body that already carries it.
+func TestReconcilePRAttribution_AppendsMissingTrailer(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	prBody := "Fixes #3\n\nAgent-written body."
+	var patched string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/pulls/7", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			var req struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			patched = req.Body
+			prBody = req.Body
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number":   7,
+			"html_url": "https://github.com/myorg/repo1/pull/7",
+			"body":     prBody,
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	s := NewServer(0, logger)
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ts.URL, "myorg", []string{"repo1"}, logger)
+	s.RegisterAPI(deps)
+	hub := NewContributeWSHub(logger, s)
+
+	hub.reconcilePRAttribution("https://github.com/myorg/repo1/pull/7", "alice", "codex", "gpt-5.6-terra", "high")
+	want := "— hive: backend=codex model=gpt-5.6-terra effort=high"
+	if !strings.HasSuffix(patched, want) {
+		t.Fatalf("PATCHed body = %q, want suffix %q", patched, want)
+	}
+
+	// Second reconciliation (retry / duplicate completion): exactly one line.
+	patched = ""
+	hub.reconcilePRAttribution("https://github.com/myorg/repo1/pull/7", "alice", "codex", "gpt-5.6-terra", "high")
+	if patched != "" {
+		t.Errorf("second reconciliation must be a no-op, PATCHed %q", patched)
+	}
+	if strings.Count(prBody, ghpkg.AttributionTrailerPrefix) != 1 {
+		t.Errorf("body must carry exactly one trailer, got %d in %q",
+			strings.Count(prBody, ghpkg.AttributionTrailerPrefix), prBody)
+	}
+}
+
+// Degradation: no GitHub client / empty URL must be silent no-ops (the read
+// loop calls this fire-and-forget on every verified completion).
+func TestReconcilePRAttribution_DegradesQuietly(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	hub := NewContributeWSHub(logger, nil)
+	hub.reconcilePRAttribution("", "alice", "codex", "m", "high")
+	hub.reconcilePRAttribution("https://github.com/o/r/pull/1", "alice", "codex", "m", "high")
+}

--- a/src/pkg/dashboard/contribute_sse_test.go
+++ b/src/pkg/dashboard/contribute_sse_test.go
@@ -108,7 +108,7 @@ func TestSSEStreamsAppendedActivity(t *testing.T) {
 
 	// Append a real activity event — this is the exact fan-in point join/leave/
 	// pick-up/complete all funnel through.
-	hub.addActivity("kylerankin", "picked up", "contributor", "claude", "sonnet", "projectbluefin/common#796")
+	hub.addActivity("kylerankin", "picked up", "contributor", "claude", "sonnet", "", "projectbluefin/common#796")
 
 	// The event must reach the stream as an SSE data frame carrying the username.
 	waitFor(t, func() bool {
@@ -136,7 +136,7 @@ func TestSSEHelloReplaysRecentActivity(t *testing.T) {
 	s := NewServer(0, slog.Default())
 	s.registerContributeRoutes()
 	hub := s.contributeHub
-	hub.addActivity("castrojo", "completed", "trusted", "claude", "opus", "projectbluefin/common#707")
+	hub.addActivity("castrojo", "completed", "trusted", "claude", "opus", "", "projectbluefin/common#707")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/kubestellar/hive/pkg/config"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
 )
 
 const (
@@ -71,11 +72,17 @@ var wsUpgrader = websocket.Upgrader{
 }
 
 type ContributorConnection struct {
-	ws           *websocket.Conn
-	profile      *ContributorProfile
-	cliBackend   string
-	model        string
-	role         string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
+	ws         *websocket.Conn
+	profile    *ContributorProfile
+	cliBackend string
+	model      string
+	// reasoningEffort is the reasoning effort the relay declared at handshake
+	// (auth_response reasoning_effort, from AGENT_REASONING_EFFORT). Stored
+	// read-only next to cliBackend/model, surfaced on ActivityEntry/FleetClanker
+	// and used for the PR attribution trailer (#4083/#4084/#4085). Empty for a
+	// relay with no effort configured — omitted everywhere, never guessed.
+	reasoningEffort string
+	role            string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
 	clientRole   string // relay-requested HIVE_AGENT_ROLE; owner assignment may override it
 	assignedRole string // owner-selected role; "none" forces general work
 	connectedAt  time.Time
@@ -203,7 +210,13 @@ type WSMessage struct {
 	RegistrationToken string `json:"registration_token,omitempty"`
 	CLIBackend        string `json:"cli_backend,omitempty"`
 	Model             string `json:"model,omitempty"`
-	TaskID            string `json:"task_id,omitempty"`
+	// ReasoningEffort is the reasoning effort the relay resolved at launch
+	// (AGENT_REASONING_EFFORT / its agy fallback), declared on auth_response
+	// alongside cli_backend/model. The relay has been sending it since before
+	// #4083; declaring it here stops encoding/json from silently dropping it.
+	// Advisory launch metadata only — never routed or gated on.
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	TaskID          string `json:"task_id,omitempty"`
 	// TaskGen is the assignment GENERATION / lease token for this task (kubestellar/
 	// hive#2568, the Gate). The hub stamps it on task_assign; the relay echoes it back
 	// on task_progress / task_complete / task_failed. The hub rejects any completion or
@@ -320,7 +333,11 @@ type ActivityEntry struct {
 	Role      string `json:"role,omitempty"`
 	CLI       string `json:"cli,omitempty"`
 	Model     string `json:"model,omitempty"`
-	Task      string `json:"task,omitempty"`
+	// Effort is the reasoning effort behind this event's connection, when the
+	// relay declared one at handshake (#4084). Omitted otherwise — entries
+	// persisted before this field simply render without it.
+	Effort string `json:"effort,omitempty"`
+	Task   string `json:"task,omitempty"`
 }
 
 type ContributeWSHub struct {
@@ -757,7 +774,7 @@ func (h *ContributeWSHub) saveActivity() {
 
 const activityDebounceSecs = 60
 
-func (h *ContributeWSHub) addActivity(username, action, role, cli, model, task string) {
+func (h *ContributeWSHub) addActivity(username, action, role, cli, model, effort, task string) {
 	h.activityMu.Lock()
 	if len(h.activity) > 0 && (action == "joined" || action == "left") {
 		last := h.activity[len(h.activity)-1]
@@ -775,6 +792,7 @@ func (h *ContributeWSHub) addActivity(username, action, role, cli, model, task s
 		Role:      role,
 		CLI:       cli,
 		Model:     model,
+		Effort:    effort,
 		Task:      task,
 	}
 	h.activity = append(h.activity, entry)
@@ -1634,7 +1652,7 @@ func (h *ContributeWSHub) bookAndRevokeReleased(targets []releaseTarget, reason,
 		)
 		// #2568: record the operator's reason in the activity log so the release is
 		// auditable (the reason rides in the Task field alongside the task id).
-		h.addActivity(username, activityVerb+": "+reason, tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		h.addActivity(username, activityVerb+": "+reason, tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.conn.reasoningEffort, tgt.task.TaskID)
 		// Push the EXISTING task_revoke message so the relay stops cleanly and
 		// re-readies. Best-effort: if the socket is already gone the disconnect path
 		// has (or will) release it anyway; the cooldown above is already booked. The
@@ -1803,7 +1821,7 @@ func (h *ContributeWSHub) RequeueContributorTask(contributorID, reason string) (
 			username = tgt.conn.profile.GitHubUsername
 		}
 		taskDesc := fmt.Sprintf("%s %s#%d: %s", msg.Kind, msg.Repo, msg.Number, msg.Title)
-		h.addActivity(username, "reassigned by yank", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, taskDesc)
+		h.addActivity(username, "reassigned by yank", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.conn.reasoningEffort, taskDesc)
 		h.logger.Info("[contribute-ws] clanker reassigned after yank",
 			"username", username, "task", msg.TaskID, "repo", msg.Repo, "number", msg.Number)
 		if !h.requireExplicitAccept() {
@@ -2018,15 +2036,19 @@ type FleetClanker struct {
 	GitHubUsername string        `json:"github_username,omitempty"`
 	CLIBackend     string        `json:"cli_backend,omitempty"`
 	Model          string        `json:"model,omitempty"`
-	Role           string        `json:"role,omitempty"`
-	ClientRole     string        `json:"client_role,omitempty"`
-	AssignedRole   string        `json:"assigned_agent_role,omitempty"`
-	RoleMismatch   string        `json:"role_mismatch,omitempty"`
-	TrustTier      string        `json:"trust_tier,omitempty"`
-	ConnectedAt    string        `json:"connected_at,omitempty"`
-	LastActivity   string        `json:"last_activity,omitempty"`
-	Stale          bool          `json:"stale,omitempty"`
-	CurrentTask    *WSTaskAssign `json:"current_task,omitempty"`
+	// Effort is the reasoning effort the relay declared at handshake (#4084),
+	// surfaced read-only exactly like CLIBackend/Model. Omitted when the relay
+	// declared none. Never routed or gated on.
+	Effort       string        `json:"effort,omitempty"`
+	Role         string        `json:"role,omitempty"`
+	ClientRole   string        `json:"client_role,omitempty"`
+	AssignedRole string        `json:"assigned_agent_role,omitempty"`
+	RoleMismatch string        `json:"role_mismatch,omitempty"`
+	TrustTier    string        `json:"trust_tier,omitempty"`
+	ConnectedAt  string        `json:"connected_at,omitempty"`
+	LastActivity string        `json:"last_activity,omitempty"`
+	Stale        bool          `json:"stale,omitempty"`
+	CurrentTask  *WSTaskAssign `json:"current_task,omitempty"`
 	// IdleReason is the machine-readable reason this clanker currently has no work
 	// (#2546): one of the taskUnavailable* reasons last sent to it. Empty when the
 	// clanker is actively working (CurrentTask set) or has never been refused. It
@@ -2119,6 +2141,7 @@ func (h *ContributeWSHub) FleetSnapshot() FleetSnapshot {
 		fc := FleetClanker{
 			CLIBackend:   c.cliBackend,
 			Model:        c.model,
+			Effort:       c.reasoningEffort,
 			Role:         c.role,
 			ClientRole:   c.clientRole,
 			AssignedRole: c.assignedRole,
@@ -2325,15 +2348,16 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	for _, c := range h.connections {
 		c.mu.Lock()
 		out = append(out, ContributorConnection{
-			profile:      c.profile,
-			cliBackend:   c.cliBackend,
-			model:        c.model,
-			role:         c.role,
-			clientRole:   c.clientRole,
-			assignedRole: c.assignedRole,
-			connectedAt:  c.connectedAt,
-			currentTask:  c.currentTask,
-			tmuxOutput:   append([]string{}, c.tmuxOutput...),
+			profile:         c.profile,
+			cliBackend:      c.cliBackend,
+			model:           c.model,
+			reasoningEffort: c.reasoningEffort,
+			role:            c.role,
+			clientRole:      c.clientRole,
+			assignedRole:    c.assignedRole,
+			connectedAt:     c.connectedAt,
+			currentTask:     c.currentTask,
+			tmuxOutput:      append([]string{}, c.tmuxOutput...),
 		})
 		c.mu.Unlock()
 	}
@@ -2448,7 +2472,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			delete(h.connections, connID)
 			h.mu.Unlock()
 			h.logger.Info("[contribute-ws] disconnected", "username", contributor.profile.GitHubUsername)
-			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend, contributor.model, "")
+			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, "")
 		}
 		conn.Close()
 	}()
@@ -2588,10 +2612,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 			contributor = &ContributorConnection{
-				ws:           conn,
-				profile:      profile,
-				cliBackend:   msg.CLIBackend,
-				model:        msg.Model,
+				ws:              conn,
+				profile:         profile,
+				cliBackend:      msg.CLIBackend,
+				model:           msg.Model,
+				reasoningEffort: strings.TrimSpace(msg.ReasoningEffort),
 				role:         requestedRole,
 				clientRole:   clientRole,
 				assignedRole: assignedRole,
@@ -2652,7 +2677,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"cli", msg.CLIBackend,
 				"role", requestedRole,
 			)
-			h.addActivity(profile.GitHubUsername, "joined", requestedRole, msg.CLIBackend, msg.Model, "")
+			h.addActivity(profile.GitHubUsername, "joined", requestedRole, msg.CLIBackend, msg.Model, msg.ReasoningEffort, "")
 
 			select {
 			case authDone <- contributor:
@@ -2746,7 +2771,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				if task.Role != "" {
 					taskDesc = fmt.Sprintf("contributor ran %s task: %s", task.Role, taskDesc)
 				}
-				h.addActivity(contributor.profile.GitHubUsername, "picked up", contributor.role, contributor.cliBackend, contributor.model, taskDesc)
+				h.addActivity(contributor.profile.GitHubUsername, "picked up", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, taskDesc)
 				h.logger.Info("[contribute-ws] task assigned",
 					"username", contributor.profile.GitHubUsername,
 					"task", task.TaskID,
@@ -2970,6 +2995,15 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					if completedTask != nil && h.verifyReportedPR(completedTask.Repo, msg.PRURL, contributor.profile.GitHubUsername) {
 						verifiedPR = msg.PRURL
 					}
+					// #4085: on a VERIFIED PR, make sure its body carries the
+					// attribution trailer — the local-mode relay and MCP paths
+					// never pass through a creation-time stamp. Async so a slow
+					// GitHub round-trip can never stall this read loop; the
+					// loadout fields are immutable after handshake.
+					if verifiedPR != "" {
+						go h.reconcilePRAttribution(verifiedPR, contributor.profile.GitHubUsername,
+							contributor.cliBackend, contributor.model, contributor.reasoningEffort)
+					}
 					// #3987: normalize the completion's verdict. A verified PR always
 					// wins (shipped); with none, only an explicit no_work_needed is
 					// honoured and everything else — including the absent field every
@@ -2986,7 +3020,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						h.markTaskCompletedVerdict(completedTask.Repo, completedTask.Number, verifiedPR,
 							verdict, contributor.profile.GitHubUsername, strings.TrimSpace(msg.VerdictReason))
 					}
-					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
+					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, msg.TaskID)
 					h.logger.Info("[contribute-ws] task complete",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
@@ -3021,6 +3055,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					promotedUser := contributor.profile.GitHubUsername
 					promotedCLI := contributor.cliBackend
 					promotedModel := contributor.model
+					promotedEffort := contributor.reasoningEffort
 					contributor.mu.Unlock()
 					// #2390-era command center: narrate the promotion as its own
 					// activity event so the Operations dev-log and achievement pops
@@ -3028,7 +3063,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					// Read-only signalling — it changes no control behaviour and is
 					// emitted only on the real newcomer -> contributor transition.
 					if promoted {
-						h.addActivity(promotedUser, "promoted", "contributor", promotedCLI, promotedModel, "contributor")
+						h.addActivity(promotedUser, "promoted", "contributor", promotedCLI, promotedModel, promotedEffort, "contributor")
 					}
 					_ = saveContributorProfile(contributor.profile)
 				} else {
@@ -3115,7 +3150,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					}
 					contributor.mu.Unlock()
 
-					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
+					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, msg.TaskID)
 					h.logger.Info("[contribute-ws] task failed",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
@@ -3533,7 +3568,7 @@ func (h *ContributeWSHub) reclaimExpiredLeases(now time.Time) int {
 			"number", tgt.task.Number,
 			"lease_ttl", wsTaskTimeout.String(),
 		)
-		h.addActivity(username, "lease expired: auto-released", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.task.TaskID)
+		h.addActivity(username, "lease expired: auto-released", tgt.conn.role, tgt.conn.cliBackend, tgt.conn.model, tgt.conn.reasoningEffort, tgt.task.TaskID)
 		if tgt.conn.ws != nil {
 			_ = tgt.conn.send(WSMessage{
 				Type:   "task_revoke",
@@ -3725,6 +3760,69 @@ func (h *ContributeWSHub) taskUnavailable(reason string) *WSMessage {
 		Type:   "task_unavailable",
 		Seq:    h.nextSeq(),
 		Reason: reason,
+	}
+}
+
+// contributorAttributionMeta builds the invocation-attribution metadata for a
+// contributor connection from what the HUB recorded at the auth handshake
+// (backend / model / reasoning effort) — never from an agent's self-report
+// (#4085). Agent stays empty: the PR's author IS the contributor, so repeating
+// an identity in the trailer would add nothing; the username still reaches the
+// audit entry via EnsurePRAttribution's extra pairs.
+func contributorAttributionMeta(cli, model, effort string) ghpkg.InvocationMeta {
+	return ghpkg.InvocationMeta{
+		Backend: strings.TrimSpace(cli),
+		Model:   ghpkg.RequestedModel(strings.TrimSpace(cli), strings.TrimSpace(model)),
+		Effort:  strings.TrimSpace(effort),
+	}
+}
+
+// attributionPromptInstruction renders the assignment-prompt rule that tells a
+// contributor's agent to end its PR body with the attribution footer — shipping
+// the LITERAL line to paste (interpolated from the hub's own record of this
+// connection's backend/model/effort), never a description of how to derive it:
+// an agent cannot be trusted to introspect its own model id (#4085). Empty when
+// the hub knows nothing to state (no backend declared), so the prompt gains no
+// dangling instruction. The hub-side reconciliation (reconcilePRAttribution)
+// still backstops an agent that ignores this.
+func attributionPromptInstruction(cli, model, effort string) string {
+	trailer := contributorAttributionMeta(cli, model, effort).Trailer()
+	if trailer == "" {
+		return ""
+	}
+	return fmt.Sprintf("End your PR body with this exact attribution line, verbatim, on its own line at the very bottom: '%s'.", trailer)
+}
+
+// reconcilePRAttribution is the #4085 verify-don't-trust step: on a completion
+// whose PR the hub has VERIFIED, make sure the PR body carries the attribution
+// trailer, appending it with the App token when missing. It acts on
+// task_complete — a message every relay sends in EVERY mode — so coverage is
+// identical for local-mode relays, containerized relays, and MCP-opened PRs
+// (the populations the creation-time trailer of #4083 cannot reach). The
+// stamped values are the hub's own handshake record of this connection, not
+// anything the agent asserted. Best-effort by design: a failure is logged and
+// never affects completion handling, cooldowns, or trust credit.
+func (h *ContributeWSHub) reconcilePRAttribution(prURL, username, cli, model, effort string) {
+	if prURL == "" {
+		return
+	}
+	if h.server == nil || h.server.deps == nil || h.server.deps.GHClient == nil {
+		return
+	}
+	ctx := h.server.deps.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	meta := contributorAttributionMeta(cli, model, effort)
+	updated, err := h.server.deps.GHClient.EnsurePRAttribution(ctx, prURL, meta)
+	switch {
+	case err != nil:
+		h.logger.Warn("[contribute-ws] PR attribution reconcile failed (advisory)",
+			"pr_url", prURL, "username", username, "error", err)
+	case updated:
+		h.logger.Info("[contribute-ws] PR attribution trailer reconciled onto PR",
+			"pr_url", prURL, "username", username,
+			"cli", cli, "model", model, "effort", effort)
 	}
 }
 
@@ -4368,6 +4466,15 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	prompt := buildTaskPrompt(chosen.repoFull, chosen.number, chosen.title)
 	if requestedRole != "" {
 		prompt = buildRoleTaskPrompt(chosen.repoFull, chosen.number, chosen.title, requestedRole, h.roleKickPrompt(requestedRole))
+	}
+	// #4085: ship the literal attribution footer the agent must end its PR body
+	// with, interpolated from the hub's handshake record of THIS connection —
+	// the values the agent itself cannot reliably introspect. The hub-side
+	// reconciliation on task_complete backstops an agent that skips it. The
+	// loadout fields are set once at handshake and never mutated, so reading
+	// them without c.mu here is safe (same as the addActivity call sites).
+	if instr := attributionPromptInstruction(c.cliBackend, c.model, c.reasoningEffort); instr != "" {
+		prompt += " " + instr
 	}
 
 	// #2568: mint a fresh assignment generation for this task. It is stamped on the

--- a/src/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/src/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -40,14 +40,14 @@ func TestCovK2_AddActivityAndRecent(t *testing.T) {
 	hub, _ := covK2Hub(t)
 
 	// A normal activity entry.
-	hub.addActivity("alice", "task_complete", "scanner", "claude", "sonnet", "repo#1")
+	hub.addActivity("alice", "task_complete", "scanner", "claude", "sonnet", "", "repo#1")
 
 	// joined/left dedup: a second identical joined within the debounce window is dropped.
-	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "")
-	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "")
+	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "", "")
+	hub.addActivity("bob", "joined", "reviewer", "copilot", "gpt", "", "")
 
 	// A left action for the same user still records.
-	hub.addActivity("bob", "left", "reviewer", "copilot", "gpt", "")
+	hub.addActivity("bob", "left", "reviewer", "copilot", "gpt", "", "")
 
 	recent := hub.RecentActivity()
 	if len(recent) == 0 {
@@ -65,7 +65,7 @@ func TestCovK2_AddActivityCap(t *testing.T) {
 	hub, _ := covK2Hub(t)
 	// Push beyond the cap; the ring buffer keeps only the tail.
 	for i := 0; i < maxActivityEntries+10; i++ {
-		hub.addActivity("u", "task_complete", "scanner", "claude", "sonnet", "t")
+		hub.addActivity("u", "task_complete", "scanner", "claude", "sonnet", "", "t")
 	}
 	if got := len(hub.RecentActivity()); got != maxActivityEntries {
 		t.Fatalf("expected activity capped at %d, got %d", maxActivityEntries, got)

--- a/src/pkg/dashboard/coverage_boost_test.go
+++ b/src/pkg/dashboard/coverage_boost_test.go
@@ -1334,8 +1334,8 @@ func TestContributeWSHub_AddActivity(t *testing.T) {
 		completedTasks: make(map[string]time.Time),
 		logger:         slog.Default(),
 	}
-	hub.addActivity("user1", "joined", "scanner", "claude", "sonnet", "")
-	hub.addActivity("user2", "picked up", "", "claude", "sonnet", "task-1")
+	hub.addActivity("user1", "joined", "scanner", "claude", "sonnet", "", "")
+	hub.addActivity("user2", "picked up", "", "claude", "sonnet", "", "task-1")
 
 	activity := hub.RecentActivity()
 	if len(activity) != 2 {
@@ -1349,8 +1349,8 @@ func TestContributeWSHub_AddActivity_Debounce(t *testing.T) {
 		completedTasks: make(map[string]time.Time),
 		logger:         slog.Default(),
 	}
-	hub.addActivity("user1", "joined", "", "", "", "")
-	hub.addActivity("user1", "joined", "", "", "", "")
+	hub.addActivity("user1", "joined", "", "", "", "", "")
+	hub.addActivity("user1", "joined", "", "", "", "", "")
 
 	activity := hub.RecentActivity()
 	if len(activity) != 1 {

--- a/src/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/src/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -865,7 +865,7 @@ func TestHandleContributeActivityNilHub(t *testing.T) {
 func TestHandleContributeActivityWithHubExtra(t *testing.T) {
 	srv := newFullServer(t)
 	srv.contributeHub = NewContributeWSHub(slog.Default(), nil)
-	srv.contributeHub.addActivity("user1", "joined", "newcomer", "claude", "sonnet", "")
+	srv.contributeHub.addActivity("user1", "joined", "newcomer", "claude", "sonnet", "", "")
 
 	req := httptest.NewRequest("GET", "/api/contribute/activity", nil)
 	w := httptest.NewRecorder()

--- a/src/pkg/github/attribution.go
+++ b/src/pkg/github/attribution.go
@@ -53,6 +53,11 @@ const (
 	// is refreshed (EditComment) roughly once a minute; those updates are NOT
 	// audited — only the initial creation, a once-per-issue event.
 	AuditActionAdvisoryCommented = "advisory_commented"
+	// AuditActionPRAttributionReconciled is the audit action recorded when the
+	// hub appends a missing attribution trailer to a PR AFTER it was opened on
+	// a path the hive could not mediate (local-mode relay, MCP, post-open body
+	// edits) — see EnsurePRAttribution and kubestellar/hive#4085.
+	AuditActionPRAttributionReconciled = "pr_attribution_reconciled"
 )
 
 // System "agent" names recorded for creations no single coding agent
@@ -96,6 +101,12 @@ type InvocationMeta struct {
 	// Model is the model REQUESTED at launch. For backends that self-select
 	// (bob), this is honestly "auto" — see RequestedModel.
 	Model string
+	// Effort is the reasoning effort REQUESTED at launch (e.g. "low", "medium",
+	// "high") for backends that expose one: codex takes it via
+	// `-c model_reasoning_effort`, agy via `--effort` (which it REQUIRES
+	// alongside --model). Empty when the backend has no effort dial or none was
+	// requested — omitted from the trailer, never guessed (kubestellar/hive#4083).
+	Effort string
 	// Tool is the display name for the version field (e.g. "bobshell"); the
 	// trailer renders it as "<tool>=<version>".
 	Tool string
@@ -120,6 +131,7 @@ func (m InvocationMeta) pairs() []string {
 	add("agent", m.Agent)
 	add("backend", m.Backend)
 	add("model", m.Model)
+	add("effort", m.Effort)
 	if ver := strings.TrimSpace(m.ToolVersion); ver != "" {
 		tool := strings.TrimSpace(m.Tool)
 		if tool == "" {
@@ -133,7 +145,7 @@ func (m InvocationMeta) pairs() []string {
 
 // Trailer renders the one-line visible trailer, e.g.:
 //
-//	— hive: agent=quality backend=bob model=auto bobshell=1.0.6 session=abc123
+//	— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2
 //
 // Unknown fields are omitted; all-unknown metadata renders "" (no trailer at
 // all rather than a bare prefix).

--- a/src/pkg/github/attribution_test.go
+++ b/src/pkg/github/attribution_test.go
@@ -25,6 +25,29 @@ func TestAttributionTrailer_AllFields(t *testing.T) {
 	}
 }
 
+// #4083: effort renders between model and the tool version when known, and is
+// OMITTED entirely (no bare "effort=") when the backend has no effort dial.
+func TestAttributionTrailer_Effort(t *testing.T) {
+	m := InvocationMeta{
+		Agent: "quality", Backend: "codex", Model: "gpt-5.6-terra",
+		Effort: "high", Tool: "codex", ToolVersion: "0.5.2",
+	}
+	want := "— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2"
+	if got := m.Trailer(); got != want {
+		t.Errorf("Trailer() = %q, want %q", got, want)
+	}
+	// No effort → the field disappears, never renders empty.
+	m.Effort = ""
+	if got := m.Trailer(); strings.Contains(got, "effort") {
+		t.Errorf("empty effort must be omitted, got %q", got)
+	}
+	// Whitespace-only effort is unknown too.
+	m.Effort = "  "
+	if got := m.Trailer(); strings.Contains(got, "effort") {
+		t.Errorf("blank effort must be omitted, got %q", got)
+	}
+}
+
 func TestAttributionTrailer_OmitsUnknownFields(t *testing.T) {
 	m := InvocationMeta{Agent: "scanner", Backend: "claude"}
 	want := "— hive: agent=scanner backend=claude"

--- a/src/pkg/github/pr_attribution_reconcile.go
+++ b/src/pkg/github/pr_attribution_reconcile.go
@@ -1,0 +1,68 @@
+package github
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// EnsurePRAttribution reconciles the invocation-attribution trailer onto a PR
+// the hive could NOT stamp at creation time (kubestellar/hive#4085): a
+// local-mode contributor relay runs the contributor's own `gh` (no wrapper),
+// and a GitHub-MCP `create_pull_request` never touches `gh` at all — so their
+// PR bodies reach GitHub exactly as the agent wrote them. This closes that gap
+// hub-side, after the fact, using the hub's OWN record of the connection's
+// backend/model/effort (from the auth handshake) rather than the agent's
+// self-report.
+//
+// It fetches the PR body and, when no AttributionTrailerPrefix line is present,
+// appends the trailer via AppendTrailer (idempotent — a body the agent already
+// stamped, or one a previous reconciliation stamped, is left untouched, so a PR
+// touched by two mechanisms ends up with exactly one line). The visible edit is
+// gated by the same governor.attribution_trailer toggle as the creation-time
+// path; the audit entry is recorded whenever an edit is actually made.
+//
+// Returns updated=true only when the PR body was actually edited. All failures
+// are returned for the caller to log — a reconciliation failure must never
+// affect task-completion handling.
+func (c *Client) EnsurePRAttribution(ctx context.Context, prURL string, m InvocationMeta) (updated bool, err error) {
+	if c == nil || c.client == nil {
+		return false, ErrNoGitHubClient
+	}
+	ref, err := ParsePRURL(prURL)
+	if err != nil {
+		return false, err
+	}
+	trailer := m.Trailer()
+	if trailer == "" {
+		// All-unknown metadata: there is nothing honest to stamp.
+		return false, nil
+	}
+	if !c.attributionTrailerOn() {
+		// Same operator toggle as the creation-time trailer: when the visible
+		// line is suppressed there, do not retro-stamp it here either.
+		return false, nil
+	}
+	pr, _, err := c.client.PullRequests.Get(ctx, ref.Owner, ref.Repo, ref.Number)
+	if err != nil {
+		return false, err
+	}
+	body := pr.GetBody()
+	if strings.Contains(body, AttributionTrailerPrefix) {
+		// Already stamped (by the agent following its instruction, by the
+		// creation-time path, or by an earlier reconciliation) — never stack.
+		return false, nil
+	}
+	newBody := AppendTrailer(body, m)
+	if newBody == body {
+		return false, nil
+	}
+	if _, _, err := c.client.PullRequests.Edit(ctx, ref.Owner, ref.Repo, ref.Number, &gh.PullRequest{Body: gh.Ptr(newBody)}); err != nil {
+		return false, err
+	}
+	c.recordCreationAudit(AuditActionPRAttributionReconciled, m,
+		"repo", ref.FullName(), "number", strconv.Itoa(ref.Number), "url", prURL)
+	return true, nil
+}

--- a/src/pkg/github/pr_attribution_reconcile_test.go
+++ b/src/pkg/github/pr_attribution_reconcile_test.go
@@ -1,0 +1,143 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// reconcileTestClient serves GET /repos/myorg/repo1/pulls/7 with the given
+// body and records any PATCH (Edit) it receives. Returns the client and a
+// pointer to the last PATCHed body ("" until an edit happens).
+func reconcileTestClient(t *testing.T, prBody string) (*Client, *string) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	patched := new(string)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/myorg/repo1/pulls/7", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			var req struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			*patched = req.Body
+			prBody = req.Body
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number":   7,
+			"html_url": "https://github.com/myorg/repo1/pull/7",
+			"body":     prBody,
+		})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return NewClientForTest(ts.URL, "myorg", []string{"repo1"}, logger), patched
+}
+
+const reconcileURL = "https://github.com/myorg/repo1/pull/7"
+
+// #4085 happy path: a PR whose body carries no trailer (a local-mode relay or
+// MCP-opened PR) is amended with the hub-recorded backend/model/effort.
+func TestEnsurePRAttribution_AppendsWhenMissing(t *testing.T) {
+	c, patched := reconcileTestClient(t, "Fixes #12\n\nSome agent-written body.")
+	m := InvocationMeta{Backend: "codex", Model: "gpt-5.6-terra", Effort: "high"}
+
+	updated, err := c.EnsurePRAttribution(context.Background(), reconcileURL, m)
+	if err != nil {
+		t.Fatalf("EnsurePRAttribution: %v", err)
+	}
+	if !updated {
+		t.Fatal("expected the PR body to be updated")
+	}
+	want := "Fixes #12\n\nSome agent-written body.\n\n— hive: backend=codex model=gpt-5.6-terra effort=high"
+	if *patched != want {
+		t.Errorf("patched body = %q, want %q", *patched, want)
+	}
+}
+
+// A body that already carries the trailer — written by the agent following its
+// prompt instruction, stamped at creation, or reconciled once already — is left
+// untouched: exactly one trailer, never two (idempotence, #4085).
+func TestEnsurePRAttribution_NoOpWhenPresent(t *testing.T) {
+	body := "Body.\n\n" + AttributionTrailerPrefix + " backend=codex model=gpt-5.6-terra effort=high"
+	c, patched := reconcileTestClient(t, body)
+	m := InvocationMeta{Backend: "codex", Model: "gpt-5.6-terra", Effort: "high"}
+
+	updated, err := c.EnsurePRAttribution(context.Background(), reconcileURL, m)
+	if err != nil {
+		t.Fatalf("EnsurePRAttribution: %v", err)
+	}
+	if updated || *patched != "" {
+		t.Errorf("must not stack a second trailer: updated=%v patched=%q", updated, *patched)
+	}
+}
+
+// All-unknown metadata has nothing honest to stamp: no lookup result matters,
+// no edit is made.
+func TestEnsurePRAttribution_EmptyMetaNoOp(t *testing.T) {
+	c, patched := reconcileTestClient(t, "Body.")
+	updated, err := c.EnsurePRAttribution(context.Background(), reconcileURL, InvocationMeta{})
+	if err != nil {
+		t.Fatalf("EnsurePRAttribution: %v", err)
+	}
+	if updated || *patched != "" {
+		t.Errorf("empty meta must be a no-op: updated=%v patched=%q", updated, *patched)
+	}
+}
+
+// The visible reconciliation honours the same governor.attribution_trailer
+// toggle as the creation-time trailer.
+func TestEnsurePRAttribution_RespectsTrailerToggle(t *testing.T) {
+	c, patched := reconcileTestClient(t, "Body.")
+	c.SetAttributionHooks(AttributionHooks{TrailerEnabled: func() bool { return false }})
+	m := InvocationMeta{Backend: "codex", Model: "gpt-5.6-terra"}
+
+	updated, err := c.EnsurePRAttribution(context.Background(), reconcileURL, m)
+	if err != nil {
+		t.Fatalf("EnsurePRAttribution: %v", err)
+	}
+	if updated || *patched != "" {
+		t.Errorf("toggle off must suppress the edit: updated=%v patched=%q", updated, *patched)
+	}
+}
+
+// A malformed URL and a nil client both fail cleanly — the caller logs and
+// moves on; completion handling must never be affected.
+func TestEnsurePRAttribution_ErrorPaths(t *testing.T) {
+	c, _ := reconcileTestClient(t, "Body.")
+	if _, err := c.EnsurePRAttribution(context.Background(), "not-a-pr-url", InvocationMeta{Backend: "codex"}); err == nil {
+		t.Error("expected an error for an unparseable PR URL")
+	}
+	var nilClient *Client
+	if _, err := nilClient.EnsurePRAttribution(context.Background(), reconcileURL, InvocationMeta{Backend: "codex"}); err == nil {
+		t.Error("expected ErrNoGitHubClient for a nil client")
+	}
+}
+
+// A successful reconciliation records the audit entry with the artifact
+// coordinates and the hub-recorded loadout.
+func TestEnsurePRAttribution_Audits(t *testing.T) {
+	c, _ := reconcileTestClient(t, "Body.")
+	var gotAction, gotDetail string
+	c.SetAttributionAudit(func(action, detail, agent string) {
+		gotAction, gotDetail = action, detail
+	})
+	m := InvocationMeta{Backend: "codex", Model: "gpt-5.6-terra", Effort: "high"}
+	if _, err := c.EnsurePRAttribution(context.Background(), reconcileURL, m); err != nil {
+		t.Fatalf("EnsurePRAttribution: %v", err)
+	}
+	if gotAction != AuditActionPRAttributionReconciled {
+		t.Errorf("audit action = %q, want %q", gotAction, AuditActionPRAttributionReconciled)
+	}
+	for _, part := range []string{"repo=myorg/repo1", "number=7", "url=" + reconcileURL, "effort=high"} {
+		if !strings.Contains(gotDetail, part) {
+			t.Errorf("audit detail %q missing %q", gotDetail, part)
+		}
+	}
+}


### PR DESCRIPTION
## What

Implements the three related model-attribution issues in one PR, since they share a wire-format prerequisite:

- **#4083** — every hive-mediated PR footer now records `effort=` alongside backend/model: `— hive: agent=quality backend=codex model=gpt-5.6-terra effort=high codex=0.5.2`
- **#4084** — the Live Activity feed (ops rail **and** onboarding page) shows `via codex CLI with gpt-5.6-terra (high)` on **every** event, via one shared formatter
- **#4085** — PRs the hive cannot intercept (local-mode relay, MCP, post-open edits) are instructed **and** verified: the assignment prompt ships the literal footer line, and the hub reconciles the trailer onto any verified-completion PR that lacks one

## Shared prerequisite

`bin/contributor-relay.sh` has been sending `reasoning_effort` on `auth_response` all along; the hub's `WSMessage` struct didn't declare it, so `encoding/json` silently dropped it. It is now declared, stored on `ContributorConnection`, and threaded to `ActivityEntry`, `FleetClanker`, the assignment prompt, and the reconciler.

## #4083 — footer on hive-mediated PRs

- `InvocationMeta.Effort`, rendered between `model` and the tool version; omitted (never a bare `effort=`) when unknown
- `Manager.InvocationMetadata` reports the launcher-resolved effort — agy's required `--effort` pairing (`agyDefaultEffort`) when a model is set; empty elsewhere, mirroring the actual launch command — and the `main.go` resolver forwards it to the PR-request watcher's `AppendTrailer` path
- `governor.attribution_trailer=false` still suppresses the visible line; the audit entry is unchanged

## #4084 — Live Activity

- One shared JS formatter `hiveLoadout(e,cls)` used by **both** pages so they cannot drift: `via <cli> CLI with <model> (<effort>)`, degrading gracefully (no effort → no parens; no model → `via bob CLI`; no cli → nothing)
- Applied to **every** `ccNarrate()` action on the ops rail (previously CLI-only, `joined`-only), rendered in the existing muted `.ref`/`.feed-cli` styles
- `e.cli`/`e.model`/`e.effort` are now HTML-escaped on the onboarding feed (previously interpolated raw)
- `FleetClanker.Effort` so the fleet table can show the loadout too

## #4085 — instruct + verify on unmediated paths

- The assignment prompt now ends with the **literal** line to paste (interpolated from the hub's own handshake record — an agent cannot be trusted to introspect its model id): `End your PR body with this exact attribution line … '— hive: backend=codex model=gpt-5.6-terra effort=high'`
- **Hub-side reconciliation (option (a) from the issue):** on a `task_complete` whose PR the hub has *verified* (#2565 path), `EnsurePRAttribution` fetches the body and appends the trailer with the App token when missing. It acts on `task_complete` — sent by every relay in **every** mode — so local-mode, containerized, and MCP-opened PRs behave identically. Values come from the hub's record, not the agent's claim. Reuses `AppendTrailer`'s idempotence guard, so a PR touched by two mechanisms ends up with exactly one line. Gated by the same `governor.attribution_trailer` toggle; audited as `pr_attribution_reconciled`. Best-effort and async — a reconcile failure never affects completion handling, cooldowns, or trust credit.
- Human PRs untouched: reconciliation only ever fires on a verified contributor-relay completion
- Deliberately **not** added to `ghAuthInstructions()`: that block is shared and per-agent-agnostic by design, pod agents can't know their own model (a guessed self-report is worse than nothing), and the `hive-open-pr` path already stamps them mechanically — instructing them would just pre-empt the authoritative stamp via the idempotence guard

## Tests

- effort present / absent (field omitted, no bare `effort=`) / whitespace-only
- no-stacking on retry, creation-time + reconcile double-touch → exactly one line
- `reasoning_effort` survives JSON decode → `ActivityEntry` → `FleetSnapshot`
- reconcile: appends when missing, no-op when present, empty-meta no-op, toggle-off no-op, error paths, audit entry
- prompt instruction degradation cases; `InvocationMetadata` agy effort cases

`go build ./...`, `go vet ./...` clean; `pkg/github`, `pkg/dashboard`, `pkg/agent`, `pkg/scheduler`, `cmd/hive` all pass (`cmd/bd` and two `pkg/config` token-cache tests fail identically on clean v4 — pre-existing local-environment quirks)

Fixes #4083
Fixes #4084
Fixes #4085