### PR TITLE
✨ Split upgrade state from upgrade action: 'Upgrade available' button replaces the cryptic 'queued' pill

### DIFF
--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -14508,10 +14508,14 @@ function burnAreaChart() {
           html += ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆</span>`;
           if (v.autoUpgrade) {
             // Hub-managed: the hub rolls the upgrade automatically, so no manual
-            // button — show a "managed" hint instead.
-            html += ` <span style="color:var(--muted);font-size:0.68rem;margin-left:6px;white-space:nowrap" title="This hive is upgraded automatically by the hub (auto-upgrade). Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">managed</span>`;
+            // button — a passive state badge, worded to match the hub dashboard's
+            // "Queued for auto-upgrade", with the target named in the tooltip.
+            html += ` <span style="color:var(--muted);font-size:0.68rem;margin-left:6px;white-space:nowrap;padding:1px 7px;border-radius:999px;border:1px solid var(--border)" title="This hive is upgraded automatically by the hub (auto-upgrade). Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Queued for auto-upgrade</span>`;
           } else {
-            html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Upgrade</button>`;
+            // Manual path: name the action AND the target — "Upgrade available →
+            // <sha>" — with a hover state, so the button cannot be misread as a
+            // status label (real feedback: owners could not find how to upgrade).
+            html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" onmouseover="this.style.filter='brightness(1.15)'" onmouseout="this.style.filter=''" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">↑ Upgrade available → ${escapeHtml(v.latestShort || 'latest')}</button>`;
           }
         } else if (v.latestHash) {
           html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -10980,8 +10980,10 @@ const dashboardHTML = `<!DOCTYPE html>
     ];
 
     /* Header labels for the Upgrade-state dimension. Named constants so the
-       of() grouper and the sort comparator can never drift on a string typo. */
-    var HIVE_UPGRADE_GROUP_QUEUED = 'Queued (ready, not yet upgrading)';
+       of() grouper and the sort comparator can never drift on a string typo.
+       "Queued for auto-upgrade" matches the row badge and the facet pill —
+       three surfaces, one wording. */
+    var HIVE_UPGRADE_GROUP_QUEUED = 'Queued for auto-upgrade (not yet upgrading)';
     var HIVE_UPGRADE_GROUP_UPGRADING = 'Upgrading';
     var HIVE_UPGRADE_GROUP_UPTODATE = 'Up to date';
 
@@ -12198,7 +12200,7 @@ const dashboardHTML = `<!DOCTYPE html>
 
       var values = [
         {key: UPGRADE_FILTER_UPGRADING, label: 'Upgrading'},
-        {key: UPGRADE_FILTER_QUEUED, label: 'Queued'}
+        {key: UPGRADE_FILTER_QUEUED, label: 'Queued for auto-upgrade'}
       ];
       var body = '<div class="facet-values">' + (values || []).map(function(v) {
         var on = _dashUpgradeFilter === v.key;
@@ -14208,30 +14210,48 @@ const dashboardHTML = `<!DOCTYPE html>
                renderUpgradeElapsed), so a healthy fleet looks unchanged. */
             upgradeIcon = '<span title="' + progressTitle + '" style="font-size:0.7rem;white-space:nowrap;opacity:0.8;color:var(--muted)"><span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.3);border-top-color:currentColor;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:4px"></span>' + progressLabel + '</span>' + renderUpgradeElapsed(h);
           } else if (!isCurrent && !latestUnknown && isHosted && h.role === 'owner' && h.autoUpgrade) {
-            /* A daily-mode hive is NOT upgrading "shortly" — saying so would be
-               a lie the operator would notice hours later. Name the window and
-               keep the click-to-upgrade-now escape hatch, which is the manual
-               path and is never gated by the schedule. */
+            /* STATE and ACTION are split. The old single "queued" pill WAS the
+               click-to-upgrade affordance, and owners could not find it (real
+               feedback: "that line that says 'queued' is the upgrade button —
+               it's not straightforward"). The badge now only NAMES the state
+               and its target; the manual escape hatch — never gated by the
+               schedule — is its own labelled "Upgrade now" action beside it.
+               A daily-mode hive is NOT upgrading "shortly" — saying so would be
+               a lie the operator would notice hours later, so the window is
+               still named on the badge. */
             var queuedDaily = h.autoUpgradeMode === AUTO_UPGRADE_DAILY;
-            var queuedLabel = queuedDaily ? 'queued · 1pm ET' : 'queued';
+            var queuedLabel = queuedDaily ? 'Queued for auto-upgrade · 1pm ET' : 'Queued for auto-upgrade';
+            /* The tooltip names the TARGET — SHA plus the tracked
+               branch/channel label — so "queued for what?" never needs a
+               second click to answer. */
             var queuedTitle = queuedDaily
-              ? 'Auto-upgrade will apply ' + esc(branchLatest) + ' at the next 1pm ET window — click to upgrade now' + esc(buildingHint)
-              : 'Auto-upgrade will apply ' + esc(branchLatest) + ' shortly — click to upgrade now' + esc(buildingHint);
+              ? 'Auto-upgrade will apply ' + branchLatest + ' (' + versionLabel(versionSel) + ') at the next 1pm ET window' + buildingHint
+              : 'Auto-upgrade will apply ' + branchLatest + ' (' + versionLabel(versionSel) + ') shortly' + buildingHint;
             /* escAttr, not esc, for the title: esc() leaves quotes intact and a
                branch name or commit subject carrying one would break out of the
                attribute. jsArg supplies its own quotes for the handler args. */
-            upgradeIcon = '<span id="upgrade-' + escAttr(h.id) + '" role="button" tabindex="0"' +
+            upgradeIcon = '<span title="' + escAttr(queuedTitle) + '" style="' + UPGRADE_STATE_BADGE_STYLE + '">' + esc(queuedLabel) + '</span>' +
+              '<span id="upgrade-' + escAttr(h.id) + '" role="button" tabindex="0"' +
               ' onclick="upgradeHive(' + jsArg(h.id) + ',' + jsArg(sha) + ',' + jsArg(branchName) + ')"' +
               ' onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();upgradeHive(' + jsArg(h.id) + ',' + jsArg(sha) + ',' + jsArg(branchName) + ')}"' +
-              ' title="' + escAttr(queuedTitle) + '" style="' + UPGRADE_LINK_STYLE + ';color:var(--muted);font-size:0.7rem;text-decoration-style:dashed">' + esc(queuedLabel) + '</span>';
+              ' title="' + escAttr('Upgrade to ' + branchLatest + ' now instead of waiting for auto-upgrade' + buildingHint) + '" style="' + UPGRADE_LINK_STYLE + ';color:var(--green);font-weight:600;font-size:0.7rem">Upgrade now</span>';
           } else if (!isCurrent && !latestUnknown && isHosted && h.role === 'owner') {
-            /* Text-with-an-underline rather than a filled button: on its own
-               line the padding bought no extra affordance and cost 8px of row
-               height. Green still marks it as the go-forward action. */
+            /* Manual path (auto-upgrade OFF): a real primary-ish button, not
+               text-with-an-underline. The bare word "Upgrade" read as a label,
+               not an action; naming the target ("Upgrade available → <sha>")
+               plus the box, the ↑ glyph and a hover state make it unmissably
+               the thing to click. */
+            var latestShort = branchLatest ? String(branchLatest).substring(0, 7) : 'latest';
             upgradeIcon = '<span id="upgrade-' + escAttr(h.id) + '" role="button" tabindex="0"' +
               ' onclick="upgradeHive(' + jsArg(h.id) + ',' + jsArg(sha) + ',' + jsArg(branchName) + ')"' +
               ' onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();upgradeHive(' + jsArg(h.id) + ',' + jsArg(sha) + ',' + jsArg(branchName) + ')}"' +
-              ' title="' + escAttr('Current: ' + sha + ' → Latest: ' + branchLatest + buildingHint) + '" style="' + UPGRADE_LINK_STYLE + ';color:var(--green);font-weight:600;font-size:0.7rem">Upgrade</span>';
+              ' onmouseover="this.style.background=\'' + UPGRADE_BTN_HOVER_BG + '\'" onmouseout="this.style.background=\'' + UPGRADE_BTN_BG + '\'"' +
+              ' title="' + escAttr('Current: ' + sha + ' → Latest: ' + branchLatest + buildingHint) + '" style="' + UPGRADE_BTN_STYLE + '">↑ Upgrade available → ' + esc(latestShort) + '</span>';
+          } else if (!isCurrent && !latestUnknown && isHosted) {
+            /* Non-owners get the STATE with no action: they cannot trigger the
+               upgrade, so a button would be a lie, but saying nothing made a
+               behind hive read as current. Passive badge, no handler. */
+            upgradeIcon = '<span title="' + escAttr('A newer build is available (' + branchLatest + ') — the hive owner or an admin can trigger the upgrade') + '" style="' + UPGRADE_STATE_BADGE_STYLE + '">Update available</span>';
           } else if (latestUnknown && isHosted && h.role === 'owner') {
             upgradeIcon = '<span title="Waiting for latest version…" style="font-size:0.7rem;color:var(--muted);white-space:nowrap;cursor:not-allowed;opacity:0.5">Upgrade</span>';
           }
@@ -15000,10 +15020,12 @@ const dashboardHTML = `<!DOCTYPE html>
        is pinned to AUTO_SELECT_H_PX rather than left to the UA's default
        control height, which is taller.
 
-       What actually sets the width now is the LONGEST upgrade label,
-       "queued · 1pm ET" at 90.4px — not the select, which measures 77px. The
-       old width was set by that label and the "Auto: daily 1pm ET" select
-       sitting on ONE line together.
+       What actually sets the width now is the LONGEST upgrade label — the
+       "Queued for auto-upgrade · 1pm ET" badge plus its "Upgrade now" action
+       (the state/action split that answers the "the 'queued' line IS the
+       upgrade button?" confusion) — not the select, which measures 77px.
+       The old width was set by the "queued · 1pm ET" label and the
+       "Auto: daily 1pm ET" select sitting on ONE line together.
 
        Non-owner rows are UNCHANGED: they still get at most two lines (28.9px),
        under the two-line name cell's 40.3px, which continues to set their
@@ -15048,6 +15070,21 @@ const dashboardHTML = `<!DOCTYPE html>
        click target. The underline plus the pointer cursor is what says
        "clickable"; colour alone would not, and would fail in one theme. */
     var UPGRADE_LINK_STYLE = 'cursor:pointer;text-decoration:underline;text-underline-offset:2px;white-space:nowrap';
+    /* The manual-path upgrade affordance (auto-upgrade OFF) is a real
+       primary-ish button again: real users could not find the upgrade action
+       when it was quiet text, so this trades a few px of row height for an
+       unmissable target. Background is declared separately so the hover state
+       can restore it without re-stating the whole style. */
+    var UPGRADE_BTN_BG = 'rgba(63,185,80,0.15)';
+    var UPGRADE_BTN_HOVER_BG = 'rgba(63,185,80,0.3)';
+    var UPGRADE_BTN_STYLE = 'cursor:pointer;white-space:nowrap;display:inline-block;padding:2px 8px;border-radius:4px;' +
+      'background:' + UPGRADE_BTN_BG + ';color:var(--green);border:1px solid rgba(63,185,80,0.4);font-weight:600;font-size:0.7rem';
+    /* Passive upgrade-STATE badge: "Queued for auto-upgrade" and the
+       non-owner "Update available". Deliberately affordance-free (no cursor,
+       no underline, no handler) — the state/action split only works if the
+       state never looks clickable. */
+    var UPGRADE_STATE_BADGE_STYLE = 'display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.65rem;' +
+      'background:var(--surface);color:var(--muted);border:1px solid var(--border);white-space:nowrap';
 
     /* Visibility toggle switch geometry, used by the Location cell's owner
        branch. A 36x20 track with a 16px knob inset 2px is the standard iOS-style

--- a/src/pkg/hub/upgrade_affordance_ux_test.go
+++ b/src/pkg/hub/upgrade_affordance_ux_test.go
@@ -1,0 +1,122 @@
+package hub
+
+// Upgrade STATE vs upgrade ACTION (issue #4097). The old single "queued" pill
+// WAS the click-to-upgrade affordance and real owners could not find it
+// ("that line that says 'queued' is the upgrade button — it's not
+// straightforward"). These tests pin the split:
+//   - queued (behind + auto-upgrade ON):  passive "Queued for auto-upgrade"
+//     badge PLUS an explicit "Upgrade now" action beside it;
+//   - behind + auto-upgrade OFF (owner):  an obvious "↑ Upgrade available →
+//     <sha>" button with a hover state;
+//   - behind, non-owner:                  passive "Update available" badge
+//     with no handler;
+//   - the facet filter and grouping labels use the same wording, while the
+//     internal state constants ('upgrading'/'queued') stay unchanged so no
+//     hiveUpgradeState consumer breaks.
+
+import (
+	"strings"
+	"testing"
+)
+
+// The queued state renders a passive badge (state) and a separate labelled
+// "Upgrade now" affordance (action). If they fuse back into one clickable
+// pill, the confusion this split exists to fix comes straight back.
+func TestQueuedStateSplitsBadgeFromUpgradeNowAction(t *testing.T) {
+	body := funcBody(t, "var buildRow = function(")
+	for _, want := range []string{
+		"'Queued for auto-upgrade · 1pm ET' : 'Queued for auto-upgrade'",
+		// The badge is affordance-free: styled by the shared state-badge
+		// constant, with no role/onclick of its own.
+		`'<span title="' + escAttr(queuedTitle) + '" style="' + UPGRADE_STATE_BADGE_STYLE + '">' + esc(queuedLabel) + '</span>'`,
+		// The action is its own element, keyboard-operable, wired to the SAME
+		// upgradeHive call the old pill triggered.
+		">Upgrade now</span>",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("queued rendering is missing %q; the state badge and the "+
+				"Upgrade now action must be separate elements", want)
+		}
+	}
+	// The tooltip must name the target, not just say "queued".
+	if !strings.Contains(body, "'Auto-upgrade will apply ' + branchLatest + ' (' + versionLabel(versionSel) + ')") {
+		t.Error("the queued badge tooltip no longer names the target SHA and " +
+			"branch/channel; 'queued for what?' becomes unanswerable again")
+	}
+}
+
+// The manual path (auto-upgrade OFF) is a real button that names the action
+// AND the target, with a hover state — not a quiet underlined word.
+func TestManualUpgradeIsAnObviousButtonNamingTheTarget(t *testing.T) {
+	body := funcBody(t, "var buildRow = function(")
+	for _, want := range []string{
+		"↑ Upgrade available → ' + esc(latestShort)",
+		`style="' + UPGRADE_BTN_STYLE + '"`,
+		"onmouseover=\"this.style.background=\\'' + UPGRADE_BTN_HOVER_BG + '\\'\"",
+		"onmouseout=\"this.style.background=\\'' + UPGRADE_BTN_BG + '\\'\"",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the manual upgrade affordance is missing %q; it must read "+
+				"as an actionable button, not a passive label", want)
+		}
+	}
+}
+
+// Non-owners see the state ("Update available") but never an action: they
+// cannot trigger the upgrade, so a button would be a lie.
+func TestNonOwnersGetPassiveUpdateAvailableBadge(t *testing.T) {
+	body := funcBody(t, "var buildRow = function(")
+	idx := strings.Index(body, ">Update available</span>")
+	if idx < 0 {
+		t.Fatal("non-owner rows no longer show the passive 'Update available' " +
+			"badge; a behind hive reads as current to everyone but the owner")
+	}
+	// The badge's own <span> (the segment from its opening tag to the label)
+	// must carry no click handler.
+	open := strings.LastIndex(body[:idx], "<span")
+	if open < 0 {
+		t.Fatal("could not locate the Update available span opening tag")
+	}
+	if strings.Contains(body[open:idx], "onclick") {
+		t.Error("the non-owner 'Update available' badge has an onclick handler; " +
+			"it must be a passive state badge")
+	}
+}
+
+// The named style constants exist (no magic inline styles) and the two
+// visual vocabularies stay distinct: buttons look clickable, badges do not.
+func TestUpgradeAffordanceStyleConstantsAreNamed(t *testing.T) {
+	for _, decl := range []string{
+		"var UPGRADE_BTN_BG = ",
+		"var UPGRADE_BTN_HOVER_BG = ",
+		"var UPGRADE_BTN_STYLE = ",
+		"var UPGRADE_STATE_BADGE_STYLE = ",
+	} {
+		if !strings.Contains(dashboardHTML, decl) {
+			t.Errorf("missing named style constant: %s (no magic values in this file)", decl)
+		}
+	}
+	if !strings.Contains(dashboardHTML, "var UPGRADE_BTN_STYLE = 'cursor:pointer;") {
+		t.Error("UPGRADE_BTN_STYLE lost its pointer cursor; the button no longer signals clickability")
+	}
+	if strings.Contains(dashboardHTML, "var UPGRADE_STATE_BADGE_STYLE = 'cursor:pointer") {
+		t.Error("UPGRADE_STATE_BADGE_STYLE has a pointer cursor; a state badge must never look clickable")
+	}
+}
+
+// Facet filter and group-by wording matches the row badge, while the internal
+// state values stay 'upgrading'/'queued' so every hiveUpgradeState consumer
+// (filter, facet counter, grouping) keeps working unchanged.
+func TestUpgradeFilterLabelsMatchNewWordingWithoutRenamingStates(t *testing.T) {
+	for _, want := range []string{
+		"var UPGRADE_FILTER_UPGRADING = 'upgrading';",
+		"var UPGRADE_FILTER_QUEUED = 'queued';",
+		"{key: UPGRADE_FILTER_QUEUED, label: 'Queued for auto-upgrade'}",
+		"var HIVE_UPGRADE_GROUP_QUEUED = 'Queued for auto-upgrade (not yet upgrading)';",
+	} {
+		if !strings.Contains(dashboardHTML, want) {
+			t.Errorf("missing %q; the display labels must follow the new wording "+
+				"while the state constants stay stable", want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4097

## Problem

Real user feedback: a spoke owner could not find how to upgrade their hive — *"that line that says 'queued' is the upgrade button — it's not straightforward"*. Upgrade **state** and upgrade **action** were fused into one ambiguous, quietly-styled pill.

## Change: split state from action

### Hub dashboard (My Hives Version cell, `src/pkg/hub/saas.go`)

| State | Before | After |
|---|---|---|
| Behind + auto-upgrade **ON** (owner) | one clickable dashed-underline pill reading `queued` / `queued · 1pm ET` (the click WAS the upgrade) | passive **"Queued for auto-upgrade"** badge (` · 1pm ET` kept in daily mode) whose tooltip names the target SHA and tracked branch/channel, **plus** an explicit green **"Upgrade now"** link beside it wired to the same `upgradeHive()` call |
| Behind + auto-upgrade **OFF** (owner) | quiet underlined word `Upgrade` | primary-ish button **"↑ Upgrade available → \<short sha\>"** with hover state (named constants `UPGRADE_BTN_STYLE` / `UPGRADE_BTN_BG` / `UPGRADE_BTN_HOVER_BG`), same `upgradeHive()` action, still `role="button" tabindex="0"` + Enter/Space operable |
| Behind (non-owner) | nothing — a behind hive read as current | passive **"Update available"** badge, no handler |
| Upgrading / Switching to X | spinner + label | **unchanged** |

Facets/grouping: the upgrade-state filter pill label is now **"Queued for auto-upgrade"** and the group-by header **"Queued for auto-upgrade (not yet upgrading)"** — display-only; the internal state constants `'upgrading'` / `'queued'` and `hiveUpgradeState` / `hiveIsUpgradingNow` are untouched, so every consumer (filter, facet counter, grouping) keeps working.

### Spoke navbar (`src/pkg/dashboard/static/index.html`)

- Manual button now reads **"↑ Upgrade available → \<short sha\>"** with a hover state (same `selfUpgrade()` → `POST /api/self-upgrade` action).
- The hub-managed hint `managed` now reads **"Queued for auto-upgrade"** as a passive badge, tooltip unchanged (names current → latest).

## Reconciliation with recent PRs

- **#4089** (owner-role normalization): built on as-is — all owner gating remains `h.role === 'owner'`, which now correctly matches true owners. Nothing re-implemented; the duplicated comment line in `handleMyHives` was left alone.
- **#4093** (per-agent token refresh port): `src/pkg/agent/` untouched; saas.go changes are confined to the Version-cell upgrade affordance, its style constants, and the upgrade-facet/group labels.

## Tests

New `src/pkg/hub/upgrade_affordance_ux_test.go` pins the split (badge and action are separate elements, target named in tooltip, hover state present, non-owner badge has no `onclick`, style constants named, filter labels updated without renaming state constants).

## Validation

- `go build ./...` ✅
- `go vet ./pkg/hub/ ./pkg/dashboard/` ✅
- `go test ./pkg/hub/` ✅ (127s)
- `go test ./pkg/dashboard/` ✅ (39s)
