### PR TITLE
🐛 fix(dashboard): Live Activity loadout dropped effort without a model, and coupled the onboarding feed to another script block

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -469,16 +469,48 @@ function resolveBackend() {
   return cachedBackendResolution;
 }
 
+// modelFlagFor reports the --model flag this backend actually receives, or ''
+// when the backend takes no --model at all. Shared by the launch command and by
+// effectiveReasoningEffort() below, which must agree on whether a model is in
+// play — agy's effort is conditional on exactly that.
+function modelFlagFor() {
+  return MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? `--model ${MODEL}` : '';
+}
+
+// effectiveReasoningEffort is the SINGLE source of truth for the effort actually
+// in effect for this launch — the value the CLI is really running with, not the
+// value the contributor happened to export.
+//
+// It exists because the effort now travels twice: onto the command line here,
+// and up to the hub in auth_response so the dashboard can show it (#4084).
+// Deriving it independently in those two places is the same drift this file
+// already warns about for the launch command itself (#2203 bug 1, the comment
+// above cachedLaunchCommand), and it would misreport in two concrete ways:
+//
+//   - agy WITHOUT a model gets no --effort flag at all, so reporting a raw
+//     AGENT_REASONING_EFFORT there advertises an effort agy never applied.
+//   - agy WITH a model gets agyEffort, which falls back to AGY_DEFAULT_EFFORT
+//     when AGENT_REASONING_EFFORT is unset or is a value agy rejects (codex's
+//     vocabulary is wider), so the raw env var is the wrong answer there too.
+//
+// Returns '' when nothing is in effect; auth_response omits the field entirely
+// in that case rather than sending an empty string.
+function effectiveReasoningEffort() {
+  // agy is the only backend whose effort is conditional on a model being passed.
+  if (BACKEND === 'agy') return modelFlagFor() ? agyEffort : '';
+  return REASONING_EFFORT || '';
+}
+
 function buildLaunchCommand() {
   if (cachedLaunchCommand) return cachedLaunchCommand;
   const { cmd, perm } = resolveBackend();
-  const modelFlag = MODEL && !NO_MODEL_FLAG_BACKENDS.includes(BACKEND) ? `--model ${MODEL}` : '';
+  const modelFlag = modelFlagFor();
   const reasoningFlag = BACKEND === 'codex' && REASONING_EFFORT
     ? `-c 'model_reasoning_effort="${REASONING_EFFORT}"'`
     : '';
   // Paired with modelFlag, never on its own: agy without --model needs no
   // --effort, and passing one alone would be a flag agy has no model to apply.
-  const agyEffortFlag = BACKEND === 'agy' && modelFlag ? `--effort ${agyEffort}` : '';
+  const agyEffortFlag = BACKEND === 'agy' && modelFlag ? `--effort ${effectiveReasoningEffort()}` : '';
   cachedLaunchCommand = [cmd, perm, modelFlag, reasoningFlag, agyEffortFlag].filter(Boolean).join(' ');
   return cachedLaunchCommand;
 }
@@ -1832,7 +1864,7 @@ function handleMessage(data, hub) {
         registration_token: hub.regToken,
         cli_backend: BACKEND,
         model: MODEL,
-        reasoning_effort: (BACKEND === 'agy' && MODEL) ? agyEffort : (REASONING_EFFORT || undefined),
+        reasoning_effort: effectiveReasoningEffort() || undefined,
         role: AGENT_ROLE,
         // #2547 declare half + #2567: additive, optional self-report of runtime
         // posture and protocol version. An older hub ignores these unknown fields.
@@ -2148,6 +2180,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     cleanup,
     restartBackoffMs,
     NO_MODEL_FLAG_BACKENDS,
+    effectiveReasoningEffort,
     MAX_TASK_CLI_RESTARTS,
     setCliReady: (v) => { cliReady = v; },
     getCliReady: () => cliReady,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -726,6 +726,50 @@ test('auth_response omits reasoning_effort when empty and not agy-with-model', (
   } finally { teardown(relay); }
 });
 
+test('auth_response reports NO effort for agy without a model — agy is given no --effort flag there', () => {
+  // agy only receives --effort when it also receives --model (buildLaunchCommand
+  // pairs them deliberately). Reporting a raw AGENT_REASONING_EFFORT in that case
+  // would advertise to the dashboard an effort agy never actually applied.
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'agy', AGENT_REASONING_EFFORT: 'high' } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.ok(auth, 'expected auth_response');
+    assert.strictEqual(auth.reasoning_effort, undefined,
+      'no --effort reaches agy without a model, so nothing should be reported');
+  } finally { teardown(relay); }
+});
+
+test('the reported effort and the launched --effort come from ONE resolver', () => {
+  // The effort now travels twice (command line + auth_response). These must not
+  // be derived independently, or they drift -- the same failure the launch
+  // command itself had in #2203 bug 1.
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'agy', AGENT_MODEL: 'gemini-3.7-flash', AGENT_REASONING_EFFORT: 'medium' } });
+  try {
+    const resolved = relay.effectiveReasoningEffort();
+    assert.strictEqual(resolved, 'medium');
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.strictEqual(auth.reasoning_effort, resolved, 'auth_response must report the resolved effort');
+    assert.match(relay.buildLaunchCommand(), new RegExp('--effort ' + resolved),
+      'the launch command must carry the SAME resolved effort');
+  } finally { teardown(relay); }
+});
+
+test('an effort agy rejects falls back to the default, and that fallback is what gets reported', () => {
+  // codex accepts "minimal"; agy does not, and agy silently drops --model when
+  // paired with an effort it rejects. AGY_DEFAULT_EFFORT is what actually runs,
+  // so that is what the dashboard must be told.
+  const relay = loadRelay({ env: { AGENT_BACKEND: 'agy', AGENT_MODEL: 'gemini-3.7-flash', AGENT_REASONING_EFFORT: 'minimal' } });
+  try {
+    assert.strictEqual(relay.effectiveReasoningEffort(), 'low');
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce: 'n' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.strictEqual(auth.reasoning_effort, 'low',
+      'reporting the raw env var here would claim an effort agy rejected');
+  } finally { teardown(relay); }
+});
+
 test('relaunchCLI() leaves cliReady false until readiness is confirmed', () => {
   const relay = loadRelay({ backend: 'copilot', cliStates: ['starting'] });
   try {

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -5472,18 +5472,28 @@ function ccTaskRefLink(task){
   if(!m)return '<span class="ref">'+esc(task)+'</span>';
   return ccIssueLinkHTML({repo:m[1],number:m[2]},task,'ref');
 }
+// ccFormatLoadout renders one contributor's loadout suffix -- the SHARED
+// formatter for both Live Activity views (the Operations rail via ccNarrate and
+// the Onboarding feed below), so the two cannot drift apart again.
+//
+//   via codex CLI with gpt-5.6-terra (high)   -- everything known
+//   via codex CLI with gpt-5.6-terra          -- no effort
+//   via codex CLI (high)                      -- effort but no model
+//   via codex CLI                             -- backend only
+//   (empty)                                   -- no backend: nothing to say
+//
+// Effort is rendered INDEPENDENTLY of model: a contributor can set
+// AGENT_REASONING_EFFORT without AGENT_MODEL (codex then runs its default model
+// at that effort), and nesting the effort inside the model branch would drop
+// exactly the value this view exists to surface. Every branch is guarded, so a
+// bare '()' or a dangling 'with' can never be emitted.
 function ccFormatLoadout(e,cls){
   if(!e||!e.cli)return '';
-  var c=esc(e.cli);
   var m=e.model?esc(e.model):'';
   var ef=e.effort?esc(e.effort):'';
-  var text='via '+c+' CLI';
-  if(m){
-    text+=' with '+m;
-    if(ef){
-      text+=' ('+ef+')';
-    }
-  }
+  var text='via '+esc(e.cli)+' CLI';
+  if(m)text+=' with '+m;
+  if(ef)text+=' ('+ef+')';
   return ' <span class="'+(cls||'feed-cli')+'">'+text+'</span>';
 }
 window.ccFormatLoadout=ccFormatLoadout;
@@ -5935,6 +5945,23 @@ window.addEventListener('scroll',function(){ccCloseQueueMenus();},true);
 </script>
 <script>
 let prevCount=0;
+// ── Cross-block helper resolution ────────────────────────────────────────────
+// esc() and ccFormatLoadout() are declared inside the OPERATIONS script block's
+// IIFE, so they are not in scope here; they reach this block only through the
+// window.* republish at the end of that IIFE. A BARE cross-IIFE reference is
+// exactly the shape that "threw ReferenceError on every dossier render" (see the
+// ccProjectName note at the top of that IIFE), and it fails closed: if that IIFE
+// ever throws before the republish -- it has regressed that way three times
+// (#2603/#2604/#2606) -- the reference throws, poll()'s catch swallows it, and
+// this feed silently freezes on a 3s loop with nothing in the console.
+// Resolve through window with REAL local fallbacks instead, so the worst case is
+// a feed that loses the loadout suffix rather than one that stops updating. The
+// esc fallback is a genuine escaper, never a pass-through: falling back to no
+// escaping would turn a rendering failure into an injection bug.
+const feedEsc=(typeof window!=='undefined'&&window.esc)||function(s){return (s==null?'':String(s))
+  .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+  .replace(/"/g,'&quot;').replace(/'/g,'&#39;');};
+const feedLoadout=(typeof window!=='undefined'&&window.ccFormatLoadout)||function(){return '';};
 async function poll(){try{
 const[statusRes,actRes]=await Promise.all([fetch('/api/contribute/status'),fetch('/api/contribute/activity')]);
 const status=await statusRes.json();
@@ -5951,11 +5978,11 @@ const icons={joined:'🟢',left:'🔴','picked up':'🔧',completed:'✅',failed
 const verbs={joined:'entered the hive',left:'left the hive','picked up':'picked up','completed':'completed','failed':'failed'};
 const icon=icons[e.action]||'⚡';
 const verb=verbs[e.action]||e.action;
-const taskInfo=e.task?' <span class="feed-cli">'+esc(e.task)+'</span>':'';
-const role=e.role?' as <span class="feed-role">'+esc(e.role)+'</span>':'';
-const cliModel=(window.ccFormatLoadout||ccFormatLoadout)(e,'feed-cli');
+const taskInfo=e.task?' <span class="feed-cli">'+feedEsc(e.task)+'</span>':'';
+const role=e.role?' as <span class="feed-role">'+feedEsc(e.role)+'</span>':'';
+const cliModel=feedLoadout(e,'feed-cli');
 return '<div class="feed-entry"'+(i===0&&isNew?' style="background:rgba(63,185,80,.08)"':'')+'>'+
-'<div class="feed-text">'+icon+' <b>'+esc(e.username)+'</b> '+verb+taskInfo+role+cliModel+'</div>'+
+'<div class="feed-text">'+icon+' <b>'+feedEsc(e.username)+'</b> '+verb+taskInfo+role+cliModel+'</div>'+
 '<span class="feed-time">'+t+' '+tz+'</span></div>'
 }).join('');
 if(f.innerHTML!==html){f.innerHTML=html;if(isNew)f.scrollTop=0;}

--- a/src/pkg/dashboard/contribute_live_activity_model_effort_test.go
+++ b/src/pkg/dashboard/contribute_live_activity_model_effort_test.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"encoding/json"
 	"log/slog"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -85,12 +86,18 @@ func TestContributePage_LoadoutFormattingPresence(t *testing.T) {
 		t.Error("ccNarrate does not append loadout to body")
 	}
 
-	// Onboarding activity feed must use ccFormatLoadout and escape username/task/role
-	if !strings.Contains(body, "ccFormatLoadout)(e,'feed-cli')") {
-		t.Error("onboarding activity feed does not use ccFormatLoadout")
+	// Onboarding activity feed must use the SHARED formatter and escape
+	// username/task/role. It reaches both through window-resolved locals rather
+	// than bare cross-IIFE identifiers — see
+	// TestOnboardingFeed_NoBareCrossIIFEReference for why that matters.
+	if !strings.Contains(body, "const cliModel=feedLoadout(e,'feed-cli');") {
+		t.Error("onboarding activity feed does not use the shared loadout formatter")
 	}
-	if !strings.Contains(body, "<b>'+esc(e.username)+'</b>") {
+	if !strings.Contains(body, "<b>'+feedEsc(e.username)+'</b>") {
 		t.Error("onboarding activity feed does not escape username")
+	}
+	if !strings.Contains(body, "feedEsc(e.task)") || !strings.Contains(body, "feedEsc(e.role)") {
+		t.Error("onboarding activity feed does not escape task/role")
 	}
 }
 
@@ -107,5 +114,122 @@ func TestFleetClanker_ReasoningEffortJSONSerialization(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), `"reasoning_effort":"high"`) {
 		t.Errorf("expected reasoning_effort in FleetClanker JSON, got %s", string(raw))
+	}
+}
+
+// extractJSFunc pulls one top-level JS function out of the rendered page by
+// brace-matching from its declaration, so the test exercises the SHIPPED source
+// rather than a copy that can drift away from it.
+func extractJSFunc(t *testing.T, page, decl string) string {
+	t.Helper()
+	start := strings.Index(page, decl)
+	if start < 0 {
+		t.Fatalf("could not find %q in the rendered page", decl)
+	}
+	depth := 0
+	for i := start; i < len(page); i++ {
+		switch page[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return page[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("unbalanced braces while extracting %q", decl)
+	return ""
+}
+
+// TestCCFormatLoadout_Behaviour runs the REAL ccFormatLoadout against the cases
+// #4084 specified. The sibling presence test only asserts that certain source
+// literals exist, which cannot catch a formatter that renders the wrong string —
+// notably dropping the effort, or emitting a bare "()" / dangling "with".
+func TestCCFormatLoadout_Behaviour(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not installed; the presence assertions elsewhere still ran")
+	}
+	page := renderContributePage(t)
+
+	script := extractJSFunc(t, page, "function esc(s){") + "\n" +
+		extractJSFunc(t, page, "function ccFormatLoadout(e,cls){") + "\n" +
+		`const cases=[
+			{cli:'codex',model:'gpt-5.6-terra',effort:'high'},
+			{cli:'codex',model:'gpt-5.6-terra'},
+			{cli:'codex',effort:'high'},
+			{cli:'bob'},
+			{},
+			null,
+			{cli:'<img src=x onerror=alert(1)>',model:'a"b',effort:"c'd"}
+		];
+		console.log(JSON.stringify(cases.map(function(c){return ccFormatLoadout(c,'feed-cli');})));`
+
+	cmd := exec.Command("node", "-e", script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node failed: %v\n%s", err, out)
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &got); err != nil {
+		t.Fatalf("could not decode node output %q: %v", out, err)
+	}
+
+	want := []string{
+		` <span class="feed-cli">via codex CLI with gpt-5.6-terra (high)</span>`,
+		` <span class="feed-cli">via codex CLI with gpt-5.6-terra</span>`,
+		// Effort without a model must still render: a codex contributor can set
+		// AGENT_REASONING_EFFORT without AGENT_MODEL, and dropping it here would
+		// lose exactly the value this feature exists to surface.
+		` <span class="feed-cli">via codex CLI (high)</span>`,
+		` <span class="feed-cli">via bob CLI</span>`,
+		// No backend: nothing honest to say, so say nothing.
+		``,
+		``,
+		` <span class="feed-cli">via &lt;img src=x onerror=alert(1)&gt; CLI with a&quot;b (c&#39;d)</span>`,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d results, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("case %d:\n got  %q\n want %q", i, got[i], want[i])
+		}
+	}
+
+	for _, g := range got {
+		if strings.Contains(g, "()") {
+			t.Errorf("a bare empty parenthesis was rendered: %q", g)
+		}
+		if strings.HasSuffix(strings.TrimSuffix(g, "</span>"), " with ") {
+			t.Errorf("a dangling 'with' was rendered: %q", g)
+		}
+	}
+}
+
+// TestOnboardingFeed_NoBareCrossIIFEReference guards the failure this page has
+// already had three times (#2603/#2604/#2606): the Onboarding feed lives in its
+// own script block, so a BARE reference to esc/ccFormatLoadout — which are
+// declared inside the Operations IIFE — throws ReferenceError the moment that
+// IIFE fails before its window.* republish. poll() swallows every throw, so the
+// symptom is a feed that silently stops updating.
+func TestOnboardingFeed_NoBareCrossIIFEReference(t *testing.T) {
+	body := renderContributePage(t)
+
+	if !strings.Contains(body, "const feedLoadout=(typeof window!=='undefined'&&window.ccFormatLoadout)||function(){return '';};") {
+		t.Error("the onboarding feed must resolve ccFormatLoadout through window with a local fallback")
+	}
+	if !strings.Contains(body, "const feedEsc=(typeof window!=='undefined'&&window.esc)||function(s){") {
+		t.Error("the onboarding feed must resolve esc through window with a local fallback")
+	}
+	// The throwing shape: window.X||X, where the right operand is the very
+	// identifier that is out of scope. It can never act as a fallback.
+	if strings.Contains(body, "(window.ccFormatLoadout||ccFormatLoadout)") {
+		t.Error("(window.ccFormatLoadout||ccFormatLoadout) throws ReferenceError instead of falling back")
+	}
+	// The fallback escaper must be a real escaper — falling back to a
+	// pass-through would turn a rendering failure into an injection bug.
+	if !strings.Contains(body, `.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')`) {
+		t.Error("the onboarding feed's fallback escaper must actually escape")
 	}
 }


### PR DESCRIPTION
Review follow-up to #4091 (which implements #4084). #4091 is sound in structure — the Go plumbing threads `reasoning_effort` correctly through `WSMessage` → `ContributorConnection` → `ActivityEntry` → `FleetClanker`, and every `addActivity()` call site was updated. These are three defects found reviewing it after merge, each with a regression test.

## 1. The loadout dropped the effort whenever the model was unknown

The effort branch was **nested inside** the model branch:

```js
if(m){
  text+=' with '+m;
  if(ef){ text+=' ('+ef+')'; }
}
```

So an event with an effort but no model rendered `via codex CLI` and silently lost the `(high)`. Not hypothetical — `AGENT_REASONING_EFFORT` is independent of `AGENT_MODEL`, and a codex contributor who sets only the effort runs its default model *at that effort*. Dropping it loses exactly the value this feature exists to surface.

Effort is now rendered independently, still guarded, so a bare `()` or a dangling `with` still cannot be emitted.

## 2. The onboarding feed made bare cross-IIFE references

`esc()` and `ccFormatLoadout()` are declared inside the **Operations** script block's IIFE and reach the onboarding block only through the `window.*` republish at the end of that IIFE. #4091 called them by bare identifier.

That is precisely the shape this page's own init-order note describes:

> ccProjectName is declared in the ONBOARDING script block's IIFE, so it is not in scope here… **a bare cross-IIFE reference threw ReferenceError on every dossier render.**

And it fails closed. If that 3,300-line IIFE throws before the republish — it has regressed that way three times (#2603/#2604/#2606, per its own comment) — the reference throws, `poll()`'s bare `catch(e){}` swallows it, and the feed **silently freezes on a 3s loop with nothing in the console**. Before this change the onboarding feed had no dependency on that block at all.

The `(window.ccFormatLoadout||ccFormatLoadout)` hedge could never help: when the left operand is `undefined`, evaluating the right operand *is* the ReferenceError. It converted a clean `undefined` into a throw.

Both are now resolved through `window` with real local fallbacks, following the documented `ccProjectName` pattern. Worst case the feed loses the loadout suffix instead of dying. **The `esc` fallback is a genuine escaper, never a pass-through** — falling back to no escaping would turn a rendering failure into an injection bug.

## 3. The relay derived the reported effort separately from the launched one

```js
reasoning_effort: (BACKEND === 'agy' && MODEL) ? agyEffort : (REASONING_EFFORT || undefined),
```

This re-derives inline what `buildLaunchCommand()` already decides — the drift this file explicitly warns about for the launch command itself (#2203 bug 1). It already misreported: **agy without a model receives no `--effort` flag at all**, yet a raw `AGENT_REASONING_EFFORT` was advertised to the dashboard as though agy had applied it.

Extracted `effectiveReasoningEffort()` as the single source of truth, used by both the launch command and `auth_response`.

## On the tests

The suite shipped with #4091 asserts only that certain **source literals** appear on the rendered page. That cannot catch a formatter that renders the wrong string — it passed against the effort-dropping code in defect 1. Added:

- **`TestCCFormatLoadout_Behaviour`** — extracts the *shipped* `esc`/`ccFormatLoadout` from the rendered page by brace-matching and runs them under node, asserting all five degradation cases plus HTML escaping. Skipped when node is absent, matching the existing `exec.LookPath("jq")` precedent in this package. **Verified non-vacuous:** the pre-fix formatter returns `via codex CLI` for the effort-without-model case and fails this test.
- **`TestOnboardingFeed_NoBareCrossIIFEReference`** — pins the window-resolved locals and rejects the throwing `window.X||X` shape.
- **Three relay tests** — no effort reported for agy without a model; the reported effort and the launched `--effort` come from one resolver; an effort agy rejects falls back to `AGY_DEFAULT_EFFORT` and that fallback is what gets reported.

107/107 relay tests and the full `pkg/dashboard` suite pass.

---
*Reviewed and fixed by Claude Opus 5.*
