### PR TITLE
✨ ui: surface the getting-started guide in 4 prominent places

### DIFF
--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -2924,6 +2924,7 @@
       <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
       <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
+      <a class="oc-nav-item" href="https://docs.kubestellar.io/docs/hive/getting-started" target="_blank" rel="noopener noreferrer" title="Zero to Automation: the beginner guide to running your hive, level by level"><span class="oc-nav-emoji">📖</span><span class="oc-nav-text">Getting Started Guide</span></a>
       <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Report an Issue</span></a>
     </div>
     <div class="system-gauges" id="system-gauges">
@@ -21049,6 +21050,7 @@ function burnAreaChart() {
         _welcomeOpenSteps.add(firstUndone ? firstUndone.id : WELCOME_STEPS[0].id);
       }
       let html = '';
+      html += '<div class="welcome-intro">New to Hive? Start here → <a href="https://docs.kubestellar.io/docs/hive/getting-started" target="_blank" rel="noopener noreferrer" style="color:var(--accent);font-weight:600">Zero to Automation: Your Getting Started Guide</a></div>';
       let n = 0;
       for (const step of WELCOME_STEPS) {
         n++;

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -8819,6 +8819,7 @@ const dashboardHTML = `<!DOCTYPE html>
         <p class="section-label">Dashboard</p>
         <h1>My Hives</h1>
         <p class="subtitle">Hive instances you own or have access to</p>
+        <p style="margin-top:8px;padding:8px 14px;border:1px solid var(--line);border-radius:8px;background:rgba(244,199,95,0.08);font-size:0.85rem">👋 New to Hive? Read the <a href="https://docs.kubestellar.io/docs/hive/getting-started" target="_blank" rel="noopener" style="color:var(--amber);font-weight:700">Getting Started Guide</a> before diving in.</p>
         <p id="latest-image-sha" style="font-size:0.7rem;color:var(--muted);margin-top:4px"></p>
         <!-- Image-pulls sparkline: 30-day daily-delta of container-image PULLS
              of the public spoke image (ghcr.io/kubestellar/hive:v2). Gauges

--- a/src/pkg/hub/static/index.html
+++ b/src/pkg/hub/static/index.html
@@ -651,6 +651,7 @@
           <a class="button primary" href="/get-started">Request a Hive</a>
           <a class="button secondary" href="#how-it-works">See how it works</a>
           <a class="button tertiary" href="https://arxiv.org/abs/2604.09388" target="_blank">Read the ACMM paper</a>
+          <a class="button tertiary" href="https://docs.kubestellar.io/docs/hive/getting-started" target="_blank" rel="noopener noreferrer">📖 New to Hive? Getting Started Guide</a>
         </div>
         <div class="hero-proof" id="hero-proof">
           <div>


### PR DESCRIPTION
Follow-up to the getting-started docs series (#4090-#4104). Links the new guide from four prominent UI locations:

1. **Spoke welcome dialog** — New to Hive? callout at the top of the Getting Started checklist modal (src/pkg/dashboard/static/index.html, renderWelcomeDialog)
2. **Spoke lower-left nav** — 📖 Getting Started Guide item directly above Report an Issue (src/pkg/dashboard/static/index.html)
3. **Hub landing hero** — guide button alongside the Read the ACMM paper link (src/pkg/hub/static/index.html)
4. **Hub My Hives dashboard** — 👋 banner right under the page subtitle, the first thing a user sees (src/pkg/hub/saas.go)

All four link to https://docs.kubestellar.io/docs/hive/getting-started. go build and go vet pass on pkg/hub and pkg/dashboard.