### PR TITLE
🐛 fix IBMid OIDC login: fall back to sub when uid claim absent, add clock-skew leeway, PS* algs, step-level logging

### DIFF
--- a/src/pkg/auth/oidc_provider.go
+++ b/src/pkg/auth/oidc_provider.go
@@ -47,6 +47,38 @@ const httpTimeout = 10 * time.Second
 // is a memory-safety bound against a hostile or broken endpoint.
 const maxResponseBytes = 1 << 16
 
+// jwtClockSkewLeeway tolerates small clock drift between the hub and the
+// provider when validating exp/nbf/iat. golang-jwt v5 defaults to ZERO leeway
+// (there is no built-in "small leeway"), so without this a provider whose clock
+// is seconds ahead of ours mints id_tokens the hub rejects as "not valid yet".
+// Two minutes matches common OIDC RP practice and stays far below any token
+// lifetime.
+const jwtClockSkewLeeway = 2 * time.Minute
+
+// Step sentinels: Exchange wraps its error with exactly one of these so the hub
+// can log WHICH step of the OIDC callback failed (discovery / token exchange /
+// id_token verification) without parsing error strings. Server-side diagnostics
+// only — never shown to the user.
+var (
+	ErrStepDiscovery     = errors.New("step=discovery")
+	ErrStepTokenExchange = errors.New("step=token_exchange")
+	ErrStepVerifyToken   = errors.New("step=id_token_verify")
+)
+
+// FailedStep classifies an Exchange error by the step sentinel it wraps.
+// Returns "unknown" for a nil or unclassified error.
+func FailedStep(err error) string {
+	switch {
+	case errors.Is(err, ErrStepDiscovery):
+		return "discovery"
+	case errors.Is(err, ErrStepTokenExchange):
+		return "token_exchange"
+	case errors.Is(err, ErrStepVerifyToken):
+		return "id_token_verify"
+	}
+	return "unknown"
+}
+
 // jwksRefreshMinInterval throttles JWKS re-fetches triggered by an unknown `kid`.
 // Providers rotate signing keys occasionally; a flood of tokens with an unknown
 // kid (garbage or an attack) must not turn into a fetch-per-request DoS on the
@@ -160,13 +192,17 @@ func (p *Provider) Exchange(ctx context.Context, code, redirectURI, expectNonce 
 		return nil, errors.New("Exchange is only for OIDC providers; GitHub uses the hub's own handler")
 	}
 	if err := p.ensureDiscovered(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrStepDiscovery, err)
 	}
 	rawIDToken, err := p.fetchIDToken(ctx, code, redirectURI)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrStepTokenExchange, err)
 	}
-	return p.verifyIDToken(ctx, rawIDToken, expectNonce)
+	claims, err := p.verifyIDToken(ctx, rawIDToken, expectNonce)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrStepVerifyToken, err)
+	}
+	return claims, nil
 }
 
 // fetchIDToken posts the code to the token endpoint and returns the raw id_token.
@@ -213,17 +249,21 @@ func (p *Provider) fetchIDToken(ctx context.Context, code, redirectURI string) (
 }
 
 // verifyIDToken validates the id_token's signature and claims, then extracts
-// identity. It enforces, in order: a supported RS256/RS384/RS512 alg (never
-// "none", never HMAC — which would let a client-known secret forge a token); the
-// signing key resolved from JWKS by `kid`; iss == p.Issuer; aud contains
-// p.ClientID; exp not passed (with the library's small leeway); and nonce ==
-// expectNonce. Any failure returns an error and NO claims.
+// identity. It enforces, in order: a supported RSA alg — RS256/384/512 or the
+// RSA-PSS variants PS256/384/512 (IBMid advertises PS*), never "none", never
+// HMAC — which would let a client-known secret forge a token; the signing key
+// resolved from JWKS by `kid`; iss == p.Issuer; aud contains p.ClientID; exp not
+// passed (with jwtClockSkewLeeway tolerance — golang-jwt v5 has NO default
+// leeway); and nonce == expectNonce. Any failure returns an error and NO claims.
 func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (*Claims, error) {
 	keyFunc := func(t *jwt.Token) (interface{}, error) {
-		// Reject anything but RSA signing. "none" and HMAC ("HS*") are the two
-		// classic OIDC token-forgery vectors; the parser options below also pin
-		// valid methods, this is defense in depth on the key side.
-		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+		// Reject anything but RSA/RSA-PSS signing. "none" and HMAC ("HS*") are
+		// the two classic OIDC token-forgery vectors; the parser options below
+		// also pin valid methods, this is defense in depth on the key side. Both
+		// RS* and PS* verify against the same JWKS RSA public keys.
+		switch t.Method.(type) {
+		case *jwt.SigningMethodRSA, *jwt.SigningMethodRSAPSS:
+		default:
 			return nil, fmt.Errorf("unexpected signing method %q", t.Header["alg"])
 		}
 		kid, _ := t.Header["kid"].(string)
@@ -242,9 +282,10 @@ func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (
 	// validate it against IssuerTemplate ourselves AFTER parsing (below) and do
 	// NOT pin a fixed issuer here.
 	parserOpts := []jwt.ParserOption{
-		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512"}),
+		jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512"}),
 		jwt.WithAudience(p.ClientID),
 		jwt.WithExpirationRequired(),
+		jwt.WithLeeway(jwtClockSkewLeeway),
 	}
 	if p.IssuerTemplate == "" {
 		parserOpts = append(parserOpts, jwt.WithIssuer(p.Issuer))
@@ -285,9 +326,20 @@ func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (
 		return nil, errors.New("id_token nonce mismatch")
 	}
 
-	sub := stringClaim(claims, p.claimName(p.SubjectClaim, claimSub))
+	// Subject extraction. The configured claim (e.g. IBMid's "uid") is preferred,
+	// but discovery `claims_supported` describes what the OP can supply — mostly
+	// via userinfo — NOT what the id_token carries, and this package never calls
+	// userinfo. OIDC Core REQUIRES `sub` in every id_token, so when the override
+	// claim is absent we fall back to the standard `sub` rather than failing the
+	// whole login with "id_token has no subject". Both are provider-issued stable
+	// identifiers; neither is a reassignable email/username.
+	subjectClaim := p.claimName(p.SubjectClaim, claimSub)
+	sub := stringClaim(claims, subjectClaim)
+	if sub == "" && subjectClaim != claimSub {
+		sub = stringClaim(claims, claimSub)
+	}
 	if sub == "" {
-		return nil, errors.New("id_token has no subject")
+		return nil, fmt.Errorf("id_token has no subject (checked claim %q and %q)", subjectClaim, claimSub)
 	}
 	// Multi-tenant: namespace the subject by tenant so the SAME sub value in two
 	// different tenants yields two distinct identities ("<tenant>:<sub>"). A bare

--- a/src/pkg/auth/oidc_provider_ibmid_fix_test.go
+++ b/src/pkg/auth/oidc_provider_ibmid_fix_test.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ibmidLikeProvider mirrors the registry's IBMid spec: OIDC with
+// SubjectClaim="uid".
+func ibmidLikeProvider(o *oidcTestServer, clientID string) *Provider {
+	return &Provider{
+		Name: "ibmid", DisplayName: "IBMid", IsOIDC: true,
+		Issuer: o.issuer, ClientID: clientID, Scopes: []string{"openid", "email", "profile"},
+		SubjectClaim: "uid",
+	}
+}
+
+func TestVerify_IBMidFallsBackToSubWhenUidAbsent(t *testing.T) {
+	// The production IBMid failure: the id_token carries the OIDC-required "sub"
+	// but NOT "uid" (claims_supported describes userinfo, not the id_token).
+	// SubjectClaim="uid" must fall back to "sub" instead of failing the login.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ibm-client"
+	const nonce = "n-ibm"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": o.issuer, "aud": clientID,
+		"sub": "6500001ABC", // OIDC-required subject; no "uid" claim
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce, "email": "someone@example.com", "name": "Some One",
+	})
+	p := ibmidLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Subject != "6500001ABC" {
+		t.Errorf("subject = %q, want fallback to sub 6500001ABC", claims.Subject)
+	}
+	if claims.Email != "someone@example.com" {
+		t.Errorf("email = %q", claims.Email)
+	}
+}
+
+func TestVerify_IBMidPrefersUidOverSub(t *testing.T) {
+	// When BOTH uid and sub are present, the configured claim (uid) wins.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ibm-client"
+	const nonce = "n-ibm"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": o.issuer, "aud": clientID,
+		"uid": "2700ABC123", "sub": "opaque-sub-value",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce,
+	})
+	p := ibmidLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Subject != "2700ABC123" {
+		t.Errorf("subject = %q, want the configured uid claim to win", claims.Subject)
+	}
+}
+
+func TestVerify_NoSubjectAtAllStillFails(t *testing.T) {
+	// Neither the configured claim nor "sub" present → fail closed, naming both.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "ibm-client"
+	const nonce = "n-ibm"
+	o.idToken = o.signToken(t, jwt.MapClaims{
+		"iss": o.issuer, "aud": clientID,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce, "email": "x@example.com",
+	})
+	p := ibmidLikeProvider(o, clientID)
+	_, err := p.Exchange(context.Background(), "code", o.issuer+"/cb", nonce)
+	if err == nil {
+		t.Fatal("expected rejection when no subject claim exists")
+	}
+	if !strings.Contains(err.Error(), "no subject") {
+		t.Errorf("error = %v, want a no-subject error", err)
+	}
+}
+
+func TestVerify_AcceptsPS256(t *testing.T) {
+	// IBMid advertises PS256 among id_token_signing_alg_values_supported; the
+	// same RSA JWKS key verifies RSA-PSS signatures. Must be accepted.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	tok := jwt.NewWithClaims(jwt.SigningMethodPS256, baseClaims(o.issuer, clientID, nonce))
+	tok.Header["kid"] = o.kid
+	raw, err := tok.SignedString(o.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o.idToken = raw
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange with PS256 token: %v", err)
+	}
+	if claims.Subject == "" {
+		t.Error("PS256 token verified but subject empty")
+	}
+}
+
+func TestVerify_ToleratesSmallClockSkew(t *testing.T) {
+	// golang-jwt v5 has zero default leeway; jwtClockSkewLeeway must absorb a
+	// provider clock slightly ahead of ours (nbf/iat in the near future) and an
+	// exp marginally in the past.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	c := baseClaims(o.issuer, clientID, nonce)
+	c["iat"] = time.Now().Add(30 * time.Second).Unix() // provider clock ahead
+	c["nbf"] = time.Now().Add(30 * time.Second).Unix()
+	o.idToken = o.signToken(t, c)
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err != nil {
+		t.Fatalf("Exchange with 30s-ahead nbf/iat: %v", err)
+	}
+}
+
+func TestVerify_StillRejectsBeyondLeeway(t *testing.T) {
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID = "client-abc"
+	const nonce = "nonce-xyz"
+	c := baseClaims(o.issuer, clientID, nonce)
+	c["exp"] = time.Now().Add(-(jwtClockSkewLeeway + time.Minute)).Unix()
+	o.idToken = o.signToken(t, c)
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err == nil {
+		t.Fatal("expected rejection for token expired beyond leeway")
+	}
+}
+
+func TestFailedStep_Classification(t *testing.T) {
+	// Verification failure (nonce mismatch) → id_token_verify.
+	o := newOIDCTestServer(t)
+	const clientID = "client-abc"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, "real-nonce"))
+	p := googleLikeProvider(o, clientID)
+	_, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", "wrong-nonce")
+	if got := FailedStep(err); got != "id_token_verify" {
+		t.Errorf("FailedStep(nonce mismatch) = %q, want id_token_verify", got)
+	}
+	o.close()
+
+	// Token endpoint failure → token_exchange.
+	o2 := newOIDCTestServer(t)
+	defer o2.close()
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer broken.Close()
+	p2 := googleLikeProvider(o2, clientID)
+	if err := p2.ensureDiscovered(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	p2.TokenURL = broken.URL
+	_, err = p2.Exchange(context.Background(), "c", o2.issuer+"/cb", "n")
+	if got := FailedStep(err); got != "token_exchange" {
+		t.Errorf("FailedStep(token 500) = %q, want token_exchange", got)
+	}
+
+	// Discovery failure → discovery.
+	p3 := &Provider{Name: "x", IsOIDC: true, Issuer: "", ClientID: clientID}
+	_, err = p3.Exchange(context.Background(), "c", "cb", "n")
+	if got := FailedStep(err); got != "discovery" {
+		t.Errorf("FailedStep(no issuer) = %q, want discovery", got)
+	}
+
+	// Unclassified / nil.
+	if got := FailedStep(nil); got != "unknown" {
+		t.Errorf("FailedStep(nil) = %q, want unknown", got)
+	}
+	if got := FailedStep(errors.New("misc")); got != "unknown" {
+		t.Errorf("FailedStep(misc) = %q, want unknown", got)
+	}
+}

--- a/src/pkg/auth/registry.go
+++ b/src/pkg/auth/registry.go
@@ -148,9 +148,12 @@ var oidcSpecs = []oidcProviderSpec{
 		defaultIssuer: "", // tenant-specific (IBM App ID / w3id): must set _ISSUER
 		envPrefix:     "HIVE_HUB_OIDC_IBMID",
 		scopes:        []string{"openid", "email", "profile"},
-		// IBMid's discovery does not list "sub"; "uid" is the stable IBMid serial.
-		// Confirmed against the live IBMid discovery claims_supported (uid present,
-		// sub absent). Overridable via HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM.
+		// IBMid's discovery claims_supported lists "uid" (the stable IBMid serial)
+		// and not "sub" — but claims_supported describes userinfo, not the
+		// id_token, which per OIDC Core always carries `sub`. Prefer "uid" when
+		// the id_token includes it; the verifier falls back to the standard "sub"
+		// when it does not (see verifyIDToken). Overridable via
+		// HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM.
 		subjectClaim: "uid",
 	},
 	{

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -583,11 +583,15 @@ func (s *HubServer) resolveProvider(name string) *auth.Provider {
 // "nonce:provider:redirect". A two-part legacy state (nonce:redirect, from a
 // login begun before this deploy) yields provider "github" and treats the second
 // half as the redirect.
+//
+// Uses the SAME cookie-matched decoding as verifyOAuthStateNonce, so the
+// provider/redirect are always read from the exact state string whose nonce was
+// verified — never from a differently-decoded sibling.
 func (s *HubServer) parseCallbackState(r *http.Request) (provider, redirect string) {
 	provider = "github"
 	redirect = "/dashboard"
-	decoded, err := url.QueryUnescape(r.URL.Query().Get("state"))
-	if err != nil || decoded == "" {
+	decoded, _, ok, _ := s.matchedCallbackState(r)
+	if !ok || decoded == "" {
 		return provider, redirect
 	}
 	// Strip the already-verified nonce.
@@ -973,20 +977,92 @@ func oauthStateNonce() (string, error) {
 // Fails CLOSED: a missing cookie, a missing or malformed state, or any mismatch
 // is a rejection. Compared in constant time — the nonce is a secret, and a
 // length-or-content leak would let an attacker narrow it by timing.
+//
+// Logs (server-side only) WHY a rejection happened — no_cookie / no_state /
+// nonce_mismatch — and whether a non-standard decode depth matched, so a
+// provider that changes its state round-trip encoding is diagnosable from one
+// log line instead of a generic warn.
 func (s *HubServer) verifyOAuthStateNonce(r *http.Request) bool {
+	_, depth, ok, reason := s.matchedCallbackState(r)
+	if !ok {
+		s.logger.Warn("OAuth: state nonce rejected", "reason", reason)
+		return false
+	}
+	if depth != stateDecodeDepthStandard {
+		// Not a failure — the nonce DID match — but the provider round-tripped
+		// state at an unexpected encoding depth. Worth a log line: this is the
+		// canary for an IdP that starts re-encoding or pre-decoding state.
+		s.logger.Warn("OAuth: state matched at non-standard decode depth", "decode_depth", depth)
+	}
+	return true
+}
+
+// State decode depths, named for the matchedCallbackState log line. The hub
+// QueryEscapes state once and url.Values.Encode() escapes it again on the OIDC
+// authorize hop, so after Go's automatic query decode the STANDARD shape needs
+// exactly one more unescape (depth 1). Depth 0 is a provider that returned the
+// state pre-decoded (or the GitHub path, whose manual URL interpolation escapes
+// only once — a no-op second unescape). Depth 2 tolerates a provider that
+// re-encoded the state an extra time on the return trip.
+const (
+	stateDecodeDepthRaw      = 0
+	stateDecodeDepthStandard = 1
+	stateDecodeDepthExtra    = 2
+)
+
+// callbackStateCandidates returns plausible decodings of the callback's state
+// parameter, indexed by decode depth (see the depth constants). r.URL.Query()
+// already applied one decode; index 0 is that raw value, index 1 the standard
+// one-more-unescape shape, index 2 an extra tolerance pass. Candidates that
+// fail to unescape are simply absent — selection is gated on the cookie nonce
+// match, so a bogus candidate can never be chosen over a legitimate one.
+func callbackStateCandidates(r *http.Request) []string {
+	raw := r.URL.Query().Get("state")
+	if raw == "" {
+		return nil
+	}
+	out := []string{raw}
+	d1, err := url.QueryUnescape(raw)
+	if err != nil {
+		return out
+	}
+	out = append(out, d1)
+	if d2, err := url.QueryUnescape(d1); err == nil {
+		out = append(out, d2)
+	}
+	return out
+}
+
+// matchedCallbackState returns the decoded state whose leading nonce segment
+// matches this browser's state cookie, plus the decode depth it matched at.
+// The nonce comparison is constant-time per candidate; candidate strings derive
+// only from public URL structure, so trying up to three shapes leaks nothing.
+// On failure, reason is one of "no_cookie", "no_state", "nonce_mismatch".
+func (s *HubServer) matchedCallbackState(r *http.Request) (state string, depth int, ok bool, reason string) {
 	cookie, err := r.Cookie(oauthStateCookieName)
 	if err != nil || cookie.Value == "" {
-		return false
+		return "", 0, false, "no_cookie"
 	}
-	decoded, err := url.QueryUnescape(r.URL.Query().Get("state"))
-	if err != nil || decoded == "" {
-		return false
+	cands := callbackStateCandidates(r)
+	if len(cands) == 0 {
+		return "", 0, false, "no_state"
 	}
-	got, _, ok := strings.Cut(decoded, oauthStateSeparator)
-	if !ok || got == "" {
-		return false
+	// Standard depth first so, when several depths decode identically (a nonce
+	// is hex and unescapes to itself), the reported depth is the expected one.
+	order := []int{stateDecodeDepthStandard, stateDecodeDepthRaw, stateDecodeDepthExtra}
+	for _, i := range order {
+		if i >= len(cands) {
+			continue
+		}
+		nonce, _, found := strings.Cut(cands[i], oauthStateSeparator)
+		if !found || nonce == "" {
+			continue
+		}
+		if subtle.ConstantTimeCompare([]byte(nonce), []byte(cookie.Value)) == 1 {
+			return cands[i], i, true, ""
+		}
 	}
-	return subtle.ConstantTimeCompare([]byte(got), []byte(cookie.Value)) == 1
+	return "", 0, false, "nonce_mismatch"
 }
 
 // clearOAuthStateCookie expires the login nonce, making it single-use.

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -473,7 +473,14 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		claims, err := p.Exchange(r.Context(), code, oauthRedirectURI, s.oidcNonceFromCookie(r))
 		s.clearOIDCNonceCookie(w)
 		if err != nil {
-			s.logger.Warn("OIDC: callback verification failed", "provider", p.Name, "error", err)
+			// Server-side diagnostics only: log which step failed (discovery /
+			// token_exchange / id_token_verify) and whether this browser still
+			// carried its nonce cookie. The user sees only the generic message.
+			s.logger.Warn("OIDC: callback verification failed",
+				"provider", p.Name,
+				"step", auth.FailedStep(err),
+				"nonce_cookie_present", s.oidcNonceFromCookie(r) != "",
+				"error", err)
 			http.Error(w, "login failed — could not verify your identity", http.StatusBadGateway)
 			return
 		}

--- a/src/pkg/hub/oauth_state_encoding_test.go
+++ b/src/pkg/hub/oauth_state_encoding_test.go
@@ -1,0 +1,157 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/auth"
+)
+
+// ibmidStateHub returns a HubServer whose registry carries an ibmid provider,
+// enough for state verification and provider parsing (no Exchange happens).
+func ibmidStateHub() *HubServer {
+	return &HubServer{
+		logger: slog.Default(),
+		authProviders: auth.NewRegistry(&auth.Provider{
+			Name: "ibmid", DisplayName: "IBMid", IsOIDC: true,
+			Issuer: "https://login.ibm.com/oidc/endpoint/default", ClientID: "cid",
+		}),
+	}
+}
+
+// TestCallbackState_ProductionIBMidShape replays the EXACT state shape captured
+// from the failing production IBMid callback:
+//
+//	state=<hex-nonce>%253Aibmid%253A
+//
+// %253A is ':' escaped twice — which is precisely what the hub itself sends:
+// startProviderLogin QueryEscapes "nonce:ibmid:" once and AuthCodeURL's
+// url.Values.Encode() escapes it again, so a spec-compliant IdP returning state
+// verbatim produces %253A on the callback. This test pins that the double-decode
+// path verifies the nonce and parses provider=ibmid — i.e. the production
+// failure was NOT in state handling (a state failure returns "invalid login
+// state", HTTP 400, not the observed "could not verify your identity", 502).
+func TestCallbackState_ProductionIBMidShape(t *testing.T) {
+	s := ibmidStateHub()
+	const nonce = "f4948cc201204f6617040d9c88efda41a62beaa836c5a52a6d39dfdcba2062cc"
+	// Literal RawQuery as captured (code/grant_id present, state double-encoded).
+	target := "/api/auth/callback?code=oo0dDhveSh9UL7JhbCjKfcA_gqNG3glQWzSu7bvZbtM.jZWkqwJ1IYYXSz05GqH-o-4h9eEDwPMhWoXfLuuBHDRvpSVhuxo2hwGcaTQ5Z7KTEUlqZmMVB5JFygQj9lRdxQ" +
+		"&grant_id=7c4576a5-892a-42ef-b63d-8ee8a1f67960" +
+		"&state=" + nonce + "%253Aibmid%253A"
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+
+	if !s.verifyOAuthStateNonce(req) {
+		t.Fatal("production-shaped double-encoded state must verify against the cookie nonce")
+	}
+	provider, redirect := s.parseCallbackState(req)
+	if provider != "ibmid" {
+		t.Errorf("provider = %q, want ibmid", provider)
+	}
+	if redirect != "/dashboard" {
+		t.Errorf("redirect = %q, want /dashboard default for empty redirect", redirect)
+	}
+}
+
+// TestCallbackState_FullAuthorizeRoundTrip simulates the hub's OIDC state
+// encoding exactly (QueryEscape in startProviderLogin, then url.Values.Encode in
+// AuthCodeURL), lets a spec-compliant IdP parse the authorize query once and
+// re-encode the state verbatim onto the callback, and confirms verification +
+// provider/redirect parsing. This locks the encode/decode contract end to end.
+func TestCallbackState_FullAuthorizeRoundTrip(t *testing.T) {
+	s := ibmidStateHub()
+	nonce, _ := oauthStateNonce()
+	state := url.QueryEscape(nonce + oauthStateSeparator + "ibmid" + oauthStateSeparator + "/my-hives")
+	// The authorize hop re-encodes state (url.Values.Encode in AuthCodeURL):
+	authorizeQuery := url.Values{"state": {state}}.Encode()
+	// A compliant IdP parses the authorize query once...
+	parsed, err := url.ParseQuery(authorizeQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idpSeenState := parsed.Get("state") // single-encoded again
+	// ...and re-encodes it verbatim onto the callback:
+	callbackQuery := url.Values{"code": {"c"}, "state": {idpSeenState}}.Encode()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?"+callbackQuery, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+
+	if !s.verifyOAuthStateNonce(req) {
+		t.Fatal("round-tripped OIDC state must verify")
+	}
+	provider, redirect := s.parseCallbackState(req)
+	if provider != "ibmid" || redirect != "/my-hives" {
+		t.Errorf("provider,redirect = %q,%q, want ibmid,/my-hives", provider, redirect)
+	}
+}
+
+// TestCallbackState_ToleratesPreDecodedState covers an IdP that DECODES the
+// state before returning it (non-verbatim, seen in the wild): the callback then
+// carries the state only single-encoded, and the standard second unescape is a
+// destructive over-decode ONLY if the state contains '%'-sequences. The
+// cookie-gated candidate selection must still match.
+func TestCallbackState_ToleratesPreDecodedState(t *testing.T) {
+	s := ibmidStateHub()
+	nonce, _ := oauthStateNonce()
+	// IdP returned "nonce:ibmid:/a b" decoded; its callback encodes it once.
+	plain := nonce + oauthStateSeparator + "ibmid" + oauthStateSeparator + "/a b"
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/auth/callback?code=c&state="+url.QueryEscape(plain), nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+
+	if !s.verifyOAuthStateNonce(req) {
+		t.Fatal("pre-decoded state must still verify via the raw candidate")
+	}
+	provider, redirect := s.parseCallbackState(req)
+	if provider != "ibmid" || redirect != "/a b" {
+		t.Errorf("provider,redirect = %q,%q, want ibmid,'/a b'", provider, redirect)
+	}
+}
+
+// TestCallbackState_ToleratesExtraEncodedState covers an IdP/intermediate that
+// RE-encoded the (already double-encoded) state once more: triple-encoded on
+// the wire, matched by the depth-2 fallback candidate.
+func TestCallbackState_ToleratesExtraEncodedState(t *testing.T) {
+	s := ibmidStateHub()
+	nonce, _ := oauthStateNonce()
+	once := url.QueryEscape(nonce + oauthStateSeparator + "ibmid" + oauthStateSeparator)
+	twice := url.QueryEscape(once)
+	thrice := url.QueryEscape(twice)
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=c&state="+thrice, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+
+	if !s.verifyOAuthStateNonce(req) {
+		t.Fatal("triple-encoded state must verify via the extra-decode fallback")
+	}
+	if provider, _ := s.parseCallbackState(req); provider != "ibmid" {
+		t.Errorf("provider = %q, want ibmid", provider)
+	}
+}
+
+// TestCallbackState_StillRejectsMismatch pins fail-closed behavior: no decode
+// depth may rescue a state whose nonce is not this browser's cookie.
+func TestCallbackState_StillRejectsMismatch(t *testing.T) {
+	s := ibmidStateHub()
+	nonce, _ := oauthStateNonce()
+	other, _ := oauthStateNonce()
+	state := url.QueryEscape(url.QueryEscape(other + oauthStateSeparator + "ibmid" + oauthStateSeparator))
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=c&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+	if s.verifyOAuthStateNonce(req) {
+		t.Fatal("a foreign nonce must be rejected at every decode depth")
+	}
+
+	// Missing cookie and missing state also fail closed.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=c&state="+state, nil)
+	if s.verifyOAuthStateNonce(req2) {
+		t.Fatal("missing state cookie must be rejected")
+	}
+	req3 := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=c", nil)
+	req3.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: nonce})
+	if s.verifyOAuthStateNonce(req3) {
+		t.Fatal("missing state parameter must be rejected")
+	}
+}


### PR DESCRIPTION
Fixes #4108

## Symptom

IBMid login at hive.kubestellar.io completes the full IBM SSO sequence, then fails at `/api/auth/callback?code=...&grant_id=...` with **"login failed — could not verify your identity"** (HTTP 502). GitHub login works. (The `grant_id` param is normal for IBM Security Verify callbacks and unrelated.)

## Root cause

**Confirmed defect** — `src/pkg/auth/registry.go` hard-codes `subjectClaim: "uid"` for IBMid on the basis that IBMid discovery `claims_supported` lists `uid` and not `sub`. But `claims_supported` describes claims the OP can supply (chiefly via **userinfo**, which the hub never calls) — it does not enumerate id_token contents, and OIDC Core REQUIRES `sub` in every id_token (live IBMid discovery confirms `subject_types_supported: ["public"]`). When the IBMid id_token carries `sub` but not `uid`, `verifyIDToken` extracted an empty subject and rejected the login with `id_token has no subject` → the user-facing 502 at `src/pkg/hub/oauth.go:477`.

**Suspected contributing defects** (cannot be conclusively confirmed without the prod log line, fixed defensively):
- golang-jwt **v5's default validation leeway is zero** (the previous comment claimed "the library's small leeway"). Marginal clock skew on `exp`/`nbf`/`iat` fails verification.
- IBMid advertises **PS256/PS384/PS512**; the verifier accepted only RS* and its keyFunc type-asserted `*jwt.SigningMethodRSA`, which excludes `*jwt.SigningMethodRSAPSS`. A PS-signed id_token was rejected despite verifying under the same JWKS RSA keys.

## Changes

- `pkg/auth/oidc_provider.go`
  - Subject extraction falls back to the standard `sub` when the configured override claim (e.g. IBMid `uid`) is absent; `uid` still wins when present. Fails closed (naming both claims checked) when neither exists.
  - `jwt.WithLeeway(2m)` for clock skew.
  - Accept PS256/PS384/PS512 alongside RS256/RS384/RS512; `alg=none` and HMAC remain rejected.
  - `Exchange` wraps its error with a step sentinel; new `FailedStep(err)` classifies discovery / token_exchange / id_token_verify.
- `pkg/hub/oauth.go` — the callback failure log now includes `step` and `nonce_cookie_present` (server-side only; user-facing message unchanged).
- `pkg/auth/registry.go` — corrected the IBMid subject-claim comment.
- `pkg/auth/oidc_provider_ibmid_fix_test.go` — tests for sub-fallback, uid preference, no-subject fail-closed, PS256 acceptance, leeway (within and beyond), and step classification.

## Identity-stability note

Falling back to `sub` cannot split identities: IBMid logins have never succeeded on this path (that is this bug), so no `ibmid:<uid>` identities exist to diverge from. Users whose id_tokens do include `uid` continue to key on `uid`.

## Validation

From `src/`: `go build ./...` ✅, `go vet ./...` ✅, `go test ./pkg/auth/` ✅, `go test -p 1 ./pkg/hub/` ✅ (serial, 121s).

## How to verify in prod

1. Deploy, then attempt an IBMid login in a fresh incognito window — it should land on `/dashboard`.
2. If it still fails, the hub log now pinpoints the stage: `OIDC: callback verification failed provider=ibmid step=<discovery|token_exchange|id_token_verify> nonce_cookie_present=<bool> error=...`, and the verification errors name the exact claim problem. `HIVE_HUB_OIDC_IBMID_SUBJECT_CLAIM=sub` remains available as an env-only retune.


---

## Addendum: full captured callback URL — state encoding ruled out, hardening added (commit 0045a27f)

The operator captured the full failing URL; its double-encoded state (`%253Aibmid%253A`) is **exactly what the hub itself emits** (QueryEscape in `startProviderLogin` + `url.Values.Encode` in `AuthCodeURL`) and is correctly reversed by the callback's compensating double decode — IBMid returned state verbatim per spec. Decisive: a state failure yields `invalid login state` (400), not the observed `could not verify your identity` (502), so state verification **passed** and the failure was inside `Exchange`, as diagnosed above. Full trace in [this comment](https://github.com/kubestellar/hive/pull/4109#issuecomment-5335342235).

The second commit hardens the fragile encoding contract anyway: cookie-nonce-gated candidate decoding across depths (tolerates an IdP that pre-decodes or re-encodes state, fails closed on any mismatch), `parseCallbackState` bound to the verified candidate, reason-coded rejection logs (`no_cookie`/`no_state`/`nonce_mismatch`) plus a non-standard-depth canary warn, and regression tests pinning the literal captured production state shape and the full round-trip contract.
