### PR TITLE
✨ Inject model/effort attribution footer instruction into agent assignment prompts

### DIFF
--- a/src/pkg/dashboard/contribute_prompt_attribution_test.go
+++ b/src/pkg/dashboard/contribute_prompt_attribution_test.go
@@ -1,0 +1,86 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+// --- #4105: the assignment prompt tells the agent up front the exact
+// attribution trailer its PR body must end with, built from the hub's own
+// handshake-recorded invocation values ---------------------------------------
+
+func TestAttributionPromptInstruction_FullMeta(t *testing.T) {
+	meta := ghpkg.InvocationMeta{
+		Agent:   "quality",
+		Backend: "claude",
+		Model:   "claude-opus-4",
+		Effort:  "high",
+	}
+	got := attributionPromptInstruction(meta)
+	if !strings.Contains(got, "At the bottom of your PR body, include exactly this line:") {
+		t.Fatalf("instruction missing the directive sentence: %q", got)
+	}
+	want := "— hive: agent=quality backend=claude model=claude-opus-4 effort=high"
+	if !strings.Contains(got, want) {
+		t.Fatalf("instruction missing the literal trailer %q: %q", want, got)
+	}
+}
+
+// All-unknown metadata renders no trailer, so no instruction at all — the agent
+// must never be asked to produce an empty footer.
+func TestAttributionPromptInstruction_EmptyMeta(t *testing.T) {
+	if got := attributionPromptInstruction(ghpkg.InvocationMeta{}); got != "" {
+		t.Fatalf("expected empty instruction for empty meta, got %q", got)
+	}
+}
+
+// promptInvocationMeta snapshots the hub's connection record (never
+// relay-self-reported values) and normalizes the model the same way
+// reconcilePRAttribution does, so the prompt instruction and the post-merge
+// reconciliation trailer always agree.
+func TestPromptInvocationMeta_FromConnection(t *testing.T) {
+	c := &ContributorConnection{
+		role:            "reviewer",
+		cliBackend:      "bob",
+		model:           "", // bob self-selects → normalized to "auto"
+		reasoningEffort: "medium",
+	}
+	meta := promptInvocationMeta(c)
+	if meta.Agent != "reviewer" || meta.Backend != "bob" || meta.Effort != "medium" {
+		t.Fatalf("unexpected meta: %+v", meta)
+	}
+	if meta.Model != "auto" {
+		t.Fatalf("bob backend with empty model should normalize to auto, got %q", meta.Model)
+	}
+}
+
+func TestPromptInvocationMeta_NilConnection(t *testing.T) {
+	if got := attributionPromptInstruction(promptInvocationMeta(nil)); got != "" {
+		t.Fatalf("nil connection should yield no instruction, got %q", got)
+	}
+}
+
+// End-to-end through selectTask: the shipped assignment prompt carries the
+// literal footer instruction with the connection's real model/effort values.
+func TestSelectTask_PromptCarriesAttributionInstruction(t *testing.T) {
+	hub, s := covK2Hub(t)
+	oneActionableIssue(s)
+	c := &ContributorConnection{
+		profile:         &ContributorProfile{GitHubUsername: "prompt-attrib-user", ContributorID: "c-pa", TrustTier: "trusted"},
+		cliBackend:      "claude",
+		model:           "claude-opus-4",
+		reasoningEffort: "high",
+	}
+	msg := hub.selectTask(c)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected task_assign, got %+v", msg)
+	}
+	if !strings.Contains(msg.Prompt, "At the bottom of your PR body, include exactly this line:") {
+		t.Fatalf("assignment prompt missing footer directive: %q", msg.Prompt)
+	}
+	if !strings.Contains(msg.Prompt, "— hive: backend=claude model=claude-opus-4 effort=high") {
+		t.Fatalf("assignment prompt missing real model/effort trailer: %q", msg.Prompt)
+	}
+}

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -3843,6 +3843,45 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 	)
 }
 
+// attributionPromptInstruction renders the footer instruction appended to an
+// assignment prompt (kubestellar/hive#4105). It tells the agent — up front, using
+// the hub's handshake-recorded invocation values — the exact attribution trailer
+// its PR body must end with, so agent-produced PRs carry the footer without
+// waiting for the hub-side EnsurePRAttribution reconciliation (#4088), which
+// stays in place unchanged as an idempotent safety net. Like the rest of the
+// prompt this is a pure function of non-credential metadata, so it remains safe
+// to preview in the ops tab (#2539). Returns "" when the metadata renders no
+// trailer at all (all fields unknown) — a bare prefix instruction would ask the
+// agent to produce an empty footer.
+func attributionPromptInstruction(meta ghpkg.InvocationMeta) string {
+	trailer := meta.Trailer()
+	if trailer == "" {
+		return ""
+	}
+	return " At the bottom of your PR body, include exactly this line: '" + trailer + "'."
+}
+
+// promptInvocationMeta snapshots the hub's own handshake-recorded invocation
+// metadata for a connection (never relay-self-reported values), mirroring the
+// meta built by reconcilePRAttribution so the prompt instruction (#4105) and the
+// post-merge reconciliation trailer (#4088) always agree. Caller must NOT hold
+// c.mu. Nil-safe: a nil connection yields zero metadata (and hence no footer
+// instruction).
+func promptInvocationMeta(c *ContributorConnection) ghpkg.InvocationMeta {
+	if c == nil {
+		return ghpkg.InvocationMeta{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	meta := ghpkg.InvocationMeta{
+		Agent:   c.role,
+		Backend: c.cliBackend,
+		Model:   ghpkg.RequestedModel(c.cliBackend, c.model),
+		Effort:  c.reasoningEffort,
+	}
+	return meta
+}
+
 // canonicalRepoKey maps an arbitrary, possibly client-supplied repo string to the
 // SAME canonical form the server keys everything on: FrontendRepo.Full, i.e. the
 // exact string selectTask's activeIssues guard, the failure/quarantine cooldowns,
@@ -4441,6 +4480,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	if requestedRole != "" {
 		prompt = buildRoleTaskPrompt(chosen.repoFull, chosen.number, chosen.title, requestedRole, h.roleKickPrompt(requestedRole))
 	}
+	// #4105: tell the agent up front — from the hub's own handshake-recorded
+	// invocation values — the exact attribution trailer its PR body must end
+	// with, so the footer is intentionally produced rather than appended only
+	// by the post-merge reconciliation safety net (#4088, unchanged).
+	prompt += attributionPromptInstruction(promptInvocationMeta(c))
 
 	// #2568: mint a fresh assignment generation for this task. It is stamped on the
 	// connection, shipped in task_assign below, and echoed back by the relay so a


### PR DESCRIPTION
Implements the prompt-instruction piece of the attribution series.

The assignment prompt built by `selectTask` now ends with an explicit instruction telling the agent the exact attribution trailer its PR body must include:

```
At the bottom of your PR body, include exactly this line: '— hive: agent=<agent> backend=<backend> model=<model> effort=<effort>'
```

built from the hub's handshake-recorded invocation values via the same `InvocationMeta.Trailer()` used by reconciliation, so the prompt instruction and the post-merge trailer always agree.

- `attributionPromptInstruction` renders the directive; all-unknown metadata yields no instruction (never an empty footer).
- `promptInvocationMeta` snapshots the hub's connection record (never relay-self-reported values), mirroring `reconcilePRAttribution` including `RequestedModel` normalization (bob → auto).
- `EnsurePRAttribution` reconciliation (#4088) is unchanged — idempotent safety net.
- Tests cover instruction rendering, empty/nil meta, connection snapshotting, and the end-to-end `selectTask` prompt.

Closes #4105