### PR TITLE
🌱 CI wall-clock: fold coverage into sharded test job; Go cache mounts + image freshness guard

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -4,17 +4,16 @@ on:
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:
-  # The floor is only meaningful if it runs BEFORE code lands. Without this the
-  # gate was hourly-only, so a PR could drop a package below its floor and merge
-  # green — which is exactly what happened in #2350.
+  # No pull_request trigger anymore (#4112). The pre-merge half of this gate —
+  # added in #2350's aftermath and moved to v4 in #3903 — now lives in
+  # v2-tests.yml's `coverage` job, which parses the coverprofile emitted by the
+  # SAME sharded `go test -short -race -count=1` run that gates the PR, so PRs
+  # run the test suite exactly once instead of twice. This workflow remains the
+  # scheduled hourly monitor for the v4 branch, including the
+  # create-issue-on-coverage-drop machinery below.
   #
-  # v4 added here (#3903): development moved to v4 and this filter still said
-  # v2, so the pre-merge half of the gate had silently stopped covering every PR
-  # that actually lands. `src/**` is the Go module directory on BOTH branches —
-  # it is the module path, not the branch name — so the path filter is unchanged.
-  pull_request:
-    branches: [v2, v4]
-    paths: ['src/**']
+  # KEEP THE FLOORS IN SYNC: PKG_THRESHOLD below is duplicated in
+  # v2-tests.yml's coverage job; a floor change must land in both.
 
 permissions:
   contents: read
@@ -52,16 +51,23 @@ jobs:
       # escalation, forge, mint, planning, timeline, agentparse, outputschema),
       # so every one of them had never been subject to any floor.
       #
-      # On `pull_request` we must NOT pin a branch: a fixed `ref:` makes the
-      # runner do `git checkout --force -B <branch> refs/remotes/origin/<branch>`
-      # and measure the BASE branch, so the gate reports the base's numbers no
-      # matter what the PR changes. That made the gate simultaneously useless
-      # and misleading — a PR that fixed coverage still failed, and a PR that
-      # broke it would still have passed. Leaving `ref` empty checks out the PR
-      # merge commit, which is the code that is actually about to land.
+      # On `schedule`/`workflow_dispatch` there is no PR ref, so pin explicitly
+      # to the branch whose floor this gate reports on hourly.
+      #
+      # That branch is now v4 (#3903). It was v2, and v2 is sunset — the fleet
+      # runs v4 and v2 is no longer a merge target, so the gate was measuring a
+      # branch nobody can fix. The practical effect was worse than "stale
+      # numbers": v4 carries 14 packages that do not exist on v2 at all
+      # (ioscan, sandbox, intent, pushbroker, tracing, review, retro,
+      # escalation, forge, mint, planning, timeline, agentparse, outputschema),
+      # so every one of them had never been subject to any floor.
+      #
+      # (This workflow no longer runs on pull_request — the pre-merge floor
+      # check lives in v2-tests.yml now, see #4112 — so the ref can be pinned
+      # unconditionally.)
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.ref || 'v4' }}
+          ref: 'v4'
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -97,6 +103,9 @@ jobs:
           # floor so the gate still catches regressions below their real ceiling,
           # rather than blocking forever on untestable code. Raise these toward 90
           # as seams are added; do not add new entries without justification here.
+          #
+          # KEEP IN SYNC with the copy of this map in v2-tests.yml's coverage
+          # job (the pre-merge half of this gate, #4112).
           declare -A PKG_THRESHOLD=(
             [dashboard]=78   # ~20% is inception tmux watcher + copilot/claude device-flow + /data file I/O + k8s
             [hub]=87         # kubectl-shelling + live-GitHub paths; see #2355. Was 89 against v2's 89.9%; v4 measures 87.6%.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,6 +92,43 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
 
+      # src/Dockerfile's Go steps use BuildKit cache mounts (id=hive-go-build /
+      # hive-go-mod) so the always-re-executed compile (no-cache-filters, the
+      # #3760 defense) is incremental instead of from-scratch. Cache MOUNT
+      # contents are NOT transported by cache-from/cache-to type=gha — the gha
+      # backend only carries layer cache (moby/buildkit#1512) — so on an
+      # ephemeral runner the mounts would start empty every build. Persist them
+      # with actions/cache plus the inject/extract helper builds below.
+      # Key on the commit with a slug-scoped restore-key so every build saves
+      # its warmed cache and the next one starts from the newest prior state.
+      - name: Restore Go compile caches
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/gocache
+          key: docker-gocache-${{ steps.slug.outputs.slug }}-${{ github.sha }}
+          restore-keys: |
+            docker-gocache-${{ steps.slug.outputs.slug }}-
+
+      # Copy the restored host directories INTO the builder's cache mounts.
+      # Uses the same digest-pinned golang image as src/Dockerfile's builder
+      # stage (no new supply-chain surface). --no-cache: these two throwaway
+      # builds must always execute; the cache mounts themselves are unaffected
+      # by layer-cache settings. continue-on-error: this is a pure
+      # optimization — if injection breaks, the mounts start empty and the
+      # build is merely slower, so it must never block publishing an image.
+      - name: Inject Go caches into BuildKit cache mounts
+        continue-on-error: true
+        run: |
+          mkdir -p "${{ runner.temp }}/gocache/go-build" "${{ runner.temp }}/gocache/go-mod"
+          docker buildx build --no-cache --file - "${{ runner.temp }}/gocache" <<'EOF'
+          FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83
+          COPY . /cache-in
+          RUN --mount=type=cache,id=hive-go-build,target=/cache/go-build \
+              --mount=type=cache,id=hive-go-mod,target=/cache/go-mod \
+              cp -a /cache-in/go-build/. /cache/go-build/ && \
+              cp -a /cache-in/go-mod/. /cache/go-mod/
+          EOF
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -135,6 +172,68 @@ jobs:
           outputs: type=image,name=ghcr.io/kubestellar/hive,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
           cache-from: type=gha,scope=${{ steps.slug.outputs.slug }}
           cache-to: type=gha,scope=${{ steps.slug.outputs.slug }},mode=max
+
+      # Copy the (now warmed) cache mounts back OUT to the host so the
+      # actions/cache post step persists them for the next build. Runs before
+      # the freshness probe so a probe failure still saves the compile cache.
+      # continue-on-error: cache plumbing must never block publishing.
+      - name: Extract Go caches from BuildKit cache mounts
+        continue-on-error: true
+        run: |
+          rm -rf "${{ runner.temp }}/gocache" && mkdir -p "${{ runner.temp }}/gocache"
+          docker buildx build --no-cache --file - --output "type=local,dest=${{ runner.temp }}/gocache" "${{ runner.temp }}/gocache" <<'EOF'
+          FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS collect
+          RUN --mount=type=cache,id=hive-go-build,target=/cache/go-build \
+              --mount=type=cache,id=hive-go-mod,target=/cache/go-mod \
+              mkdir -p /out/go-build /out/go-mod && \
+              cp -a /cache/go-build/. /out/go-build/ && \
+              cp -a /cache/go-mod/. /out/go-mod/
+          FROM scratch
+          COPY --from=collect /out/ /
+          EOF
+
+      # FRESHNESS ASSERTION (#3760 regression guard): run the image this job
+      # just produced and assert the ldflags-embedded commit equals the commit
+      # being built. `hive --version` prints "hive 3.0.0 (commit <short7>,
+      # branch <b>)" where <short7> is baked from /repo/.git at compile time.
+      #
+      # - push builds: probe the EXACT pushed artifact by digest — the most
+      #   direct possible evidence that what landed on GHCR is fresh.
+      # - PR builds (push=false): nothing is pushed and push-by-digest output
+      #   doesn't load into the local daemon, so re-run the build with --load.
+      #   On this same builder every layer of the forced-fresh build above is
+      #   in local cache, so the rebuild is seconds and yields those exact
+      #   layers. If BuildKit ever resolved a STALE binary layer instead, the
+      #   embedded hash would differ from github.sha and this step fails loudly
+      #   — a stale layer can make this check fail, never silently pass.
+      - name: Assert embedded commit matches build (freshness guard)
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.gate.outputs.push }}" = "true" ]; then
+            IMG="ghcr.io/kubestellar/hive@${{ steps.build.outputs.digest }}"
+            docker pull "$IMG"
+          else
+            IMG=hive-freshness-probe:local
+            docker buildx build --load \
+              -f src/Dockerfile \
+              --build-arg GIT_HASH="$EXPECTED_SHA" \
+              --build-arg GIT_BRANCH="${{ github.ref_name }}" \
+              -t "$IMG" .
+          fi
+          ACTUAL=$(docker run --rm --entrypoint /usr/local/bin/hive "$IMG" --version)
+          echo "image reports: $ACTUAL"
+          echo "expected commit: ${EXPECTED_SHA::7} (from $EXPECTED_SHA)"
+          case "$ACTUAL" in
+            *"commit ${EXPECTED_SHA::7},"*)
+              echo "Freshness OK: embedded commit matches the built SHA"
+              ;;
+            *)
+              echo "::error::STALE BINARY: image reports '$ACTUAL' but this build is $EXPECTED_SHA. The published/validated image does not contain the code of this commit."
+              exit 1
+              ;;
+          esac
 
       - name: Export digest
         if: needs.gate.outputs.push == 'true'

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -21,7 +21,26 @@ permissions:
   issues: write
 
 jobs:
-  test:
+  # The unit tests are sharded into two parallel jobs to cut PR wall-clock:
+  # ./pkg/hub is by far the largest single package (it alone dominates the
+  # serial run), so it gets a shard to itself and EVERYTHING ELSE runs in the
+  # other shard. The "rest" shard's package list is computed with `go list`
+  # by EXCLUDING pkg/hub — never by enumerating inclusions — so a newly added
+  # package always lands in a shard automatically and can never be silently
+  # untested. Both shards use the exact same flags as the old single job:
+  # -short -race -count=1.
+  #
+  # Each shard also emits -coverprofile from the SAME invocation. The
+  # `coverage` job below consumes those artifacts, so the per-package
+  # coverage-floor gate no longer needs its own duplicate test run on PRs
+  # (coverage-hourly.yml is schedule/dispatch-only now; its hourly monitoring
+  # and issue-filing behavior is unchanged).
+  test-shard:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [hub, rest]
+    name: test (${{ matrix.shard }})
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -41,12 +60,209 @@ jobs:
       # them. Fixing those tests without also running them just resets the same
       # trap. All of ./cmd/... passes under -short -race.
       - name: Test
-        run: go test ./pkg/... ./cmd/... -short -race -count=1
+        run: |
+          set -o pipefail
+          case "${{ matrix.shard }}" in
+            hub)
+              PKGS="./pkg/hub/..."
+              ;;
+            rest)
+              # Everything except pkg/hub (which the other shard runs).
+              # Exclusion, not enumeration: new packages are picked up here
+              # automatically. The anchored regex only drops pkg/hub and its
+              # subpackages — pkg/hubbackup et al. stay in this shard.
+              PKGS=$(go list ./pkg/... ./cmd/... | grep -Ev '^github\.com/kubestellar/hive/pkg/hub(/|$)')
+              ;;
+          esac
+          # shellcheck disable=SC2086 # PKGS is a deliberate word-split list
+          go test $PKGS -short -race -count=1 -coverprofile=coverage-${{ matrix.shard }}.out \
+            2>&1 | tee test-${{ matrix.shard }}.log
+
+      # Uploaded even on failure so the coverage job (and humans) can inspect
+      # the raw `go test` output. `warn` not `error`: on a compile failure the
+      # coverprofile is never written, and this upload must not mask the real
+      # test failure with an artifact error.
+      - name: Upload shard coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-shard-${{ matrix.shard }}
+          path: |
+            src/coverage-${{ matrix.shard }}.out
+            src/test-${{ matrix.shard }}.log
+          if-no-files-found: warn
+          retention-days: 1
+
+  # Stable aggregate context named "test", preserved from the pre-shard job so
+  # anything keyed on the check name (branch protection, tide, humans' muscle
+  # memory) keeps working. Fails iff any shard failed.
+  test:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: test-shard
+    steps:
+      - name: Check shard results
+        run: |
+          result="${{ needs.test-shard.result }}"
+          echo "shard matrix result: $result"
+          [ "$result" = "success" ]
+
+  # Per-package coverage-floor gate, moved here from coverage-hourly.yml's
+  # pull_request trigger (#4112) so PRs run the test suite exactly ONCE: this
+  # job only parses the shard artifacts produced above — it runs no tests.
+  # PR-only: on the 15-minute schedule the hourly coverage workflow remains
+  # the monitoring + issue-filing authority.
+  coverage:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: test-shard
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Needed only for `go tool cover -func`, which resolves the profile's
+      # file:line spans against the source tree to compute the total.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache-dependency-path: src/go.sum
+
+      - name: Download shard coverage artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: test-shard-*
+          path: src
+          merge-multiple: true
+
+      - name: Check per-package coverage
+        run: |
+          THRESHOLD=90
+          FAILED=""
+          BROKEN=""
+          REPORT=""
+
+          # Per-package threshold overrides. A handful of packages are heavily
+          # coupled to the live runtime (fixed /data,/proc,/var/run paths, real
+          # github.com/platform.claude.com device-flow, a live tmux agent buffer,
+          # an in-cluster k8s serviceaccount) and cannot be exercised hermetically
+          # in CI without invasive production seams. They get a documented lower
+          # floor so the gate still catches regressions below their real ceiling,
+          # rather than blocking forever on untestable code. Raise these toward 90
+          # as seams are added; do not add new entries without justification here.
+          #
+          # KEEP IN SYNC with coverage-hourly.yml, which applies the same floors
+          # on its hourly scheduled run.
+          declare -A PKG_THRESHOLD=(
+            [dashboard]=78   # ~20% is inception tmux watcher + copilot/claude device-flow + /data file I/O + k8s
+            [hub]=87         # kubectl-shelling + live-GitHub paths; see #2355. Was 89 against v2's 89.9%; v4 measures 87.6%.
+            [agent]=89       # pre-existing shortfall inherited from #2350, NOT a new regression. See #2355.
+
+            # ── Floors recorded when the gate moved from v2 to v4 (#3903) ─────
+            # A RATCHET, NOT A TARGET — see coverage-hourly.yml for the full
+            # rationale. Raise these toward 90 as tests land; never raise one to
+            # paper over a drop.
+            [intent]=65
+            [sandbox]=67
+            [ioscan]=71
+            [pushbroker]=72
+            [tracing]=76
+            [review]=80
+            [retro]=82
+            [github]=88
+            [hivectl]=88
+            [knowledge]=89
+            [scheduler]=89
+            [escalation]=89
+            [proxy]=89
+          )
+
+          # The shard logs are the `go test -coverprofile` output of the ONE
+          # test run this PR gets; classify every line. Three cases matter:
+          #
+          #   ok    <pkg>  coverage: X.Y%   -> scored against its floor
+          #   FAIL  <pkg>                   -> hard failure (cannot be scored)
+          #   ?     <pkg>  [no test files]  -> hard failure (a package with zero
+          #                                    tests must never stay green)
+          #
+          # Only ./pkg/... is subject to floors, matching the historical gate
+          # (coverage-hourly measured ./pkg/... only); ./cmd/... lines from the
+          # rest shard are ignored here — the shards themselves already fail on
+          # any cmd test failure.
+          cat test-hub.log test-rest.log > cover-run.log
+
+          while IFS= read -r line; do
+            case "$line" in
+              ok*|FAIL*|\?*)
+                pkgpath=$(echo "$line" | awk '{print $2}')
+                case "$pkgpath" in
+                  github.com/kubestellar/hive/pkg/*) ;;
+                  *) continue ;;
+                esac
+                ;;
+              *) continue ;;
+            esac
+            pkg=${pkgpath##*/}
+            case "$line" in
+              ok*)
+                pct=$(echo "$line" | grep -o '[0-9]*\.[0-9]*%' | tr -d '%')
+                if [ -z "$pct" ]; then continue; fi
+                int_pct=$(echo "$pct" | cut -d. -f1)
+                pkg_threshold=${PKG_THRESHOLD[$pkg]:-$THRESHOLD}
+                if [ "$int_pct" -lt "$pkg_threshold" ]; then
+                  FAILED="${FAILED}${pkg}: ${pct}% (floor ${pkg_threshold}%)\n"
+                fi
+                REPORT="${REPORT}${pkg}: ${pct}%\n"
+                ;;
+              FAIL*)
+                BROKEN="${BROKEN}${pkg}: TESTS FAILING\n"
+                REPORT="${REPORT}${pkg}: FAIL\n"
+                ;;
+              \?*)
+                BROKEN="${BROKEN}${pkg}: NO TEST FILES\n"
+                REPORT="${REPORT}${pkg}: no tests\n"
+                ;;
+            esac
+          done < cover-run.log
+
+          # Combine the shard profiles into one for the total. The shards
+          # partition the package set (no overlap), so concatenation minus the
+          # duplicate mode: header is a valid merged profile. Restricting to
+          # pkg/ lines keeps the total comparable to the historical gate,
+          # which measured ./pkg/... only.
+          head -n 1 coverage-hub.out > coverage.out
+          grep -h '^github.com/kubestellar/hive/pkg/' coverage-hub.out coverage-rest.out >> coverage.out
+
+          TOTAL=$(go tool cover -func=coverage.out 2>/dev/null | grep '^total:' | awk '{print $3}')
+          echo "Total coverage: ${TOTAL:-unavailable}"
+
+          {
+            echo "## Per-package coverage"
+            echo ""
+            echo "Total (./pkg/...): ${TOTAL:-unavailable}"
+            echo ""
+            echo -e "${REPORT}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -n "$BROKEN" ] || [ -n "$FAILED" ]; then
+            {
+              [ -n "$BROKEN" ] && echo -e "### Packages that cannot be scored\n${BROKEN}"
+              [ -n "$FAILED" ] && echo -e "### Packages below their floor\n${FAILED}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo ""
+            echo "COVERAGE GATE FAILED:"
+            [ -n "$BROKEN" ] && echo -e "${BROKEN}"
+            [ -n "$FAILED" ] && echo -e "${FAILED}"
+            exit 1
+          fi
+
+          echo "All packages meet their coverage floor" >> "$GITHUB_STEP_SUMMARY"
 
   create-issue-on-failure:
     if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    needs: test
+    needs: test-shard
     permissions:
       contents: read
       issues: write
@@ -57,7 +273,7 @@ jobs:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sha = context.sha.substring(0, 7);
-            const wasCancelled = '${{ needs.test.result }}' === 'cancelled';
+            const wasCancelled = '${{ needs.test-shard.result }}' === 'cancelled';
             const kind = wasCancelled ? 'cancelled (likely timed out)' : 'failure';
             const title = `[Tests] v2 test ${wasCancelled ? 'cancelled' : 'failure'} on ${sha}`;
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -9,9 +9,15 @@ FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a51
 RUN apk add --no-cache git
 WORKDIR /src
 
-# Layer 1: cache Go module downloads (only re-runs when go.mod/go.sum change)
+# Layer 1: cache Go module downloads (only re-runs when go.mod/go.sum change).
+# The cache MOUNT (id=hive-go-mod) makes the always-re-executed download (see
+# no-cache-filters in docker.yml) a no-op when the module cache is already
+# populated. Mount contents never become image layers, so nothing here can
+# ship a stale artifact — the mount is an input cache for `go`, which
+# verifies modules against go.sum regardless of where they come from.
 COPY src/go.mod src/go.sum ./
-RUN go mod download
+RUN --mount=type=cache,id=hive-go-mod,target=/go/pkg/mod \
+    go mod download
 
 # Layer 2: copy source and build (re-runs on any source change)
 COPY .git /repo/.git
@@ -19,7 +25,16 @@ COPY src/ .
 
 ARG GIT_HASH=unknown
 ARG GIT_BRANCH=unknown
-RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
+# Cache mounts for GOCACHE (/tmp/gobuild, matching the GOCACHE= below) and the
+# module cache. docker.yml's `no-cache-filters: builder,runtime` still forces
+# this RUN to re-execute on every build — that is the #3760 stale-binary
+# defense and it stays — the mounts only make the re-executed compile
+# INCREMENTAL. Correctness is `go`'s own: the build cache is keyed by content
+# hash of every input, so a stale or corrupted cache entry can never produce a
+# binary that differs from a cold build. The linker always writes /hive fresh.
+RUN --mount=type=cache,id=hive-go-build,target=/tmp/gobuild \
+    --mount=type=cache,id=hive-go-mod,target=/go/pkg/mod \
+    GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     GIT_SHORT=$(git -C /repo rev-parse --short=7 HEAD 2>/dev/null || echo "unknown") && \
     if [ "$GIT_BRANCH" = "unknown" ] || [ -z "$GIT_BRANCH" ]; then GIT_BRANCH=$(git -C /repo rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"); fi && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive && \


### PR DESCRIPTION
Fixes #4112

## What

### a) PR gate: shard tests + fold coverage in (v2-tests.yml, coverage-hourly.yml)

Before, a PR touching `src/**` ran the unit test suite **three times**: once in `v2-tests.yml` (`go test ./pkg/... ./cmd/... -short -race -count=1`, the ~8 min long pole), and twice more in `coverage-hourly.yml`'s `pull_request` trigger (once with `-race -coverprofile`, once plain `-cover` for the per-package parse).

Now:

- **`test` is sharded into 2 parallel matrix jobs** — `test (hub)` runs `./pkg/hub/...` (the giant package) and `test (rest)` runs everything else. The rest shard's package list is computed dynamically via `go list ./pkg/... ./cmd/...` **excluding** `pkg/hub` with an anchored regex (`^…/pkg/hub(/|$)`, so `pkg/hubbackup` stays in rest) — exclusion, not enumeration, so a newly added package always lands in a shard and can never be silently untested. Flags identical everywhere: `-short -race -count=1` (both untouched, per scope).
- **Each shard emits `-coverprofile` from that same invocation** and uploads profile + raw log as artifacts.
- **A new parse-only `coverage` job in v2-tests.yml** (PR-only) downloads the shard artifacts and applies the exact per-package floor gate from coverage-hourly.yml: same `PKG_THRESHOLD` map (cross-referenced "keep in sync" comments in both files), same hard failure for `FAIL` and `[no test files]` packages, same step summary. Floors apply to `./pkg/...` only, exactly as before (`./cmd/...` lines are ignored by the gate; the shards themselves fail on any cmd test failure). The two shard profiles are combined by concatenation minus the duplicate `mode:` line — valid because the shards partition the package set with zero overlap — and the total comes from `go tool cover -func` on the merged profile.
- **A stable aggregate `test` job** (fails iff any shard failed) preserves the pre-shard check-run name for anything keyed on it (tide, humans).
- **`coverage-hourly.yml` loses only its `pull_request` trigger.** The hourly scheduled monitor, its own full test run against a now-unconditionally-pinned `v4` ref, and the `create-issue-on-coverage-drop` machinery are unchanged. `create-issue-on-failure` in v2-tests stays gated on `github.event_name == 'schedule'`.

### b) Container build: incremental compiles + freshness guard (docker.yml, src/Dockerfile)

- **BuildKit cache mounts** on the builder stage's `go mod download` and `go build` steps (`id=hive-go-mod` → `/go/pkg/mod`, `id=hive-go-build` → `/tmp/gobuild`, matching the existing `GOCACHE=/tmp/gobuild`; the builder stage runs as root with default `GOPATH=/go`). `no-cache-filters: builder,runtime` is **untouched** — those layers still always re-execute (the #3760 stale-binary defense); the mounts only make the re-executed compile incremental. No `# syntax=` directive was added: `RUN --mount=type=cache` is supported by the built-in Dockerfile frontend of every BuildKit the pinned setup-buildx-action provisions, and an unpinned `docker/dockerfile:1` frontend fetch would contradict this repo's digest-pinning convention.
- **Verified claim from the plan:** `cache-from/cache-to: type=gha` does **not** transport cache-mount contents, even with `mode=max` — the gha backend carries layer cache only ([moby/buildkit#1512](https://github.com/moby/buildkit/issues/1512), still open; confirmed by BuildKit maintainers). On ephemeral runners bare cache mounts would therefore start empty every build and buy nothing. So the mounts are persisted explicitly: `actions/cache` (pinned by SHA, keyed per platform slug + commit with a slug-scoped restore-key) plus tiny inject/extract helper builds that copy the host directory into/out of the named cache mounts. The helpers reuse the **same digest-pinned golang image** as the Dockerfile's builder stage (no new supply-chain surface), run with `--no-cache`, and are `continue-on-error` — cache plumbing is a pure optimization and must never block publishing an image. The cache dir lives in `${{ runner.temp }}`, outside the workspace, so it never bloats a build context.
- **Freshness assertion** after the per-arch build: run the just-built image (`docker run --rm --entrypoint /usr/local/bin/hive <img> --version`, which prints the ldflags-baked commit) and assert the embedded short SHA equals `${{ github.sha }}`; the job fails loudly with `::error::` on mismatch.
  - **Push builds** probe `ghcr.io/kubestellar/hive@<digest>` — the *exact pushed artifact*, the most direct possible evidence.
  - **PR builds** (`push=false`, push-by-digest loads nothing into the daemon) probe a `docker buildx build --load` rerun on the same builder: every layer of the immediately preceding forced-fresh build is in local cache, so it takes seconds and yields those exact layers.
- provenance/sbom:false, push-by-digest, `oci-mediatypes=false`, the HEAD-staleness check, and concurrency settings are all untouched. Scope kept to the main image (`src/Dockerfile` + `build` job) per plan; `Dockerfile.hub` / `build-hub` can get the same treatment as a follow-up.

## Safety analysis

**Why the cache mounts cannot serve a stale binary.** Three independent reasons: (1) cache-mount contents are *inputs to the compiler*, never image layers — nothing in a mount can ship; (2) Go's build cache is keyed by content hash of every input (source, flags, toolchain), so a stale/corrupt entry can never make `go build` emit a binary that differs from a cold build — at worst it's a cache miss; the linker writes `/hive` fresh every time; (3) `go.sum` verification governs the module cache regardless of where modules come from. And `no-cache-filters: builder,runtime` still forces every binary-bearing layer to re-execute each build, exactly as before this PR. On top of that, the new freshness probe converts any *future* stale-layer regression from a silent bad publish into a red job: a stale image can make the check fail, never silently pass.

**Why the shards cover all packages.** Shard B is derived by *exclusion* from the full `go list ./pkg/... ./cmd/...` output, so A∪B is total by construction. Verified locally at this commit: 58 packages total = 1 (hub) + 57 (rest), union exact (`diff` clean), intersection empty (`comm -12` = 0).

## Expected timings

| Path | Before | After |
|---|---|---|
| PR gate | ~8 min serial test job **+** a duplicate double test run in Coverage Hourly | ~max(hub shard, rest shard) ≈ 4–5 min, + a ~30–60 s parse-only coverage job overlapping nothing |
| Docker per-arch build | full-module compile + `go mod download` every build | first run primes the cache; subsequent runs: mod download ≈ no-op, compile incremental (typically 1–3 min saved per arch) |

## Validated locally

- `go build ./...` clean (unaffected).
- Shard partition proof via `go list` (58 = 1 + 57, no overlap/omission).
- `actionlint` on all three modified workflows: zero new findings (the 6 SC2046 warnings it reports exist identically on base `v4`).
- The coverage-gate parse script was extracted from the workflow YAML and executed against **real** `go test -short -race -coverprofile` shard logs plus synthetic edge lines: per-package floors applied, `FAIL` and `[no test files]` packages hard-fail, `cmd/...` lines correctly ignored, merged-profile total computed, happy path exits 0.

## What only the first CI runs can prove

- Docker daemon wasn't running on the dev machine, so the inject/extract helper builds and the freshness probe weren't executed locally — both are `continue-on-error`/fail-loud respectively, so a problem there is visible, not silent. The first docker.yml run on this branch exercises the PR-build (`--load`) probe path; the first push to `v4` after merge exercises the pushed-digest path and primes the compile caches.
- Artifact hand-off between the shard jobs and the coverage job (upload/download names and paths) is exercised by this PR's own v2-tests run.
