### PR TITLE
🐛 Enrich OIDC user identities (name/email/avatar) and fix broken IBMid badge

### DIFF
--- a/src/pkg/auth/coverage_test.go
+++ b/src/pkg/auth/coverage_test.go
@@ -239,7 +239,7 @@ func TestFetchIDToken_ErrorPaths(t *testing.T) {
 	}))
 	defer srv1.Close()
 	p1 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv1.URL, ClientID: "c"}
-	if _, err := p1.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+	if _, _, err := p1.fetchIDToken(context.Background(), "code", "cb"); err == nil {
 		t.Error("non-200 token endpoint must error")
 	}
 
@@ -249,7 +249,7 @@ func TestFetchIDToken_ErrorPaths(t *testing.T) {
 	}))
 	defer srv2.Close()
 	p2 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv2.URL, ClientID: "c"}
-	if _, err := p2.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+	if _, _, err := p2.fetchIDToken(context.Background(), "code", "cb"); err == nil {
 		t.Error("token endpoint error object must error")
 	}
 
@@ -259,7 +259,7 @@ func TestFetchIDToken_ErrorPaths(t *testing.T) {
 	}))
 	defer srv3.Close()
 	p3 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv3.URL, ClientID: "c"}
-	if _, err := p3.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+	if _, _, err := p3.fetchIDToken(context.Background(), "code", "cb"); err == nil {
 		t.Error("missing id_token must error")
 	}
 
@@ -269,7 +269,7 @@ func TestFetchIDToken_ErrorPaths(t *testing.T) {
 	}))
 	defer srv4.Close()
 	p4 := &Provider{Name: "google", IsOIDC: true, TokenURL: srv4.URL, ClientID: "c"}
-	if _, err := p4.fetchIDToken(context.Background(), "code", "cb"); err == nil {
+	if _, _, err := p4.fetchIDToken(context.Background(), "code", "cb"); err == nil {
 		t.Error("malformed token response must error")
 	}
 }

--- a/src/pkg/auth/oidc_provider.go
+++ b/src/pkg/auth/oidc_provider.go
@@ -106,6 +106,11 @@ type Provider struct {
 	AuthorizeURL string
 	TokenURL     string
 	JWKSURL      string
+	// UserInfoURL is the OIDC userinfo endpoint, filled from discovery. Used only
+	// as a best-effort enrichment source when the id_token itself lacks display
+	// claims (name/email/picture) — some providers (IBMid) issue minimal
+	// id_tokens and put profile claims behind userinfo.
+	UserInfoURL string
 
 	// ClientID / ClientSecret from the provider's app registration. A provider is
 	// enabled iff ClientID is set (mirrors the hub's registerOAuth gate).
@@ -152,6 +157,17 @@ type Claims struct {
 	Name      string // display name (optional)
 	AvatarURL string // picture (optional)
 	Email     string // email (display only; NEVER the identity key)
+
+	// rawSub is the id_token's literal `sub` claim, kept for the OIDC Core
+	// §5.3.2 userinfo cross-check (userinfo's sub MUST match the id_token's).
+	// Unexported: identity decisions use Subject, never this.
+	rawSub string
+}
+
+// incomplete reports whether any display claim is missing — the trigger for the
+// best-effort userinfo enrichment fetch.
+func (c *Claims) incomplete() bool {
+	return c.Name == "" || c.Email == "" || c.AvatarURL == ""
 }
 
 // scopeString renders the space-delimited scope parameter.
@@ -194,7 +210,7 @@ func (p *Provider) Exchange(ctx context.Context, code, redirectURI, expectNonce 
 	if err := p.ensureDiscovered(ctx); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrStepDiscovery, err)
 	}
-	rawIDToken, err := p.fetchIDToken(ctx, code, redirectURI)
+	rawIDToken, accessToken, err := p.fetchIDToken(ctx, code, redirectURI)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrStepTokenExchange, err)
 	}
@@ -202,11 +218,71 @@ func (p *Provider) Exchange(ctx context.Context, code, redirectURI, expectNonce 
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrStepVerifyToken, err)
 	}
+	// Best-effort display enrichment: some providers (IBMid) issue minimal
+	// id_tokens and serve name/email/picture only from userinfo. Fills ONLY the
+	// missing display claims; identity (Subject) is never touched, and a
+	// userinfo failure never fails an already-verified login.
+	if claims.incomplete() && accessToken != "" && p.UserInfoURL != "" {
+		p.enrichFromUserInfo(ctx, claims, accessToken)
+	}
 	return claims, nil
 }
 
-// fetchIDToken posts the code to the token endpoint and returns the raw id_token.
-func (p *Provider) fetchIDToken(ctx context.Context, code, redirectURI string) (string, error) {
+// enrichFromUserInfo fetches the provider's userinfo endpoint and fills the
+// MISSING display claims (name/email/picture) on c. Per OIDC Core §5.3.2 the
+// userinfo response's `sub` MUST match the id_token's — a mismatched (or, when
+// the id_token carried one, absent) sub discards the response entirely, so a
+// confused-deputy userinfo can never relabel a verified identity. Best-effort:
+// any error is silently a no-op; the login is already verified.
+func (p *Provider) enrichFromUserInfo(ctx context.Context, c *Claims, accessToken string) {
+	req, err := http.NewRequestWithContext(ctx, "GET", p.UserInfoURL, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	info := jwt.MapClaims{}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return
+	}
+	if c.rawSub != "" && stringClaim(info, claimSub) != c.rawSub {
+		return // §5.3.2 cross-check failed — do not trust any of it
+	}
+	if c.Name == "" {
+		c.Name = displayNameFromClaims(info, p.claimName(p.NameClaim, claimName))
+	}
+	if c.Email == "" {
+		c.Email = stringClaim(info, p.claimName(p.EmailClaim, claimEmail))
+	}
+	if c.AvatarURL == "" {
+		c.AvatarURL = stringClaim(info, p.claimName(p.AvatarClaim, claimPicture))
+	}
+}
+
+// displayNameFromClaims extracts a human display name: the configured name
+// claim first, then the standard given_name + family_name composition (IBMid
+// and Entra often carry the parts without a composite `name`).
+func displayNameFromClaims(m jwt.MapClaims, nameClaim string) string {
+	if n := stringClaim(m, nameClaim); n != "" {
+		return n
+	}
+	given := stringClaim(m, claimGivenName)
+	family := stringClaim(m, claimFamilyName)
+	return strings.TrimSpace(strings.TrimSpace(given) + " " + strings.TrimSpace(family))
+}
+
+// fetchIDToken posts the code to the token endpoint and returns the raw
+// id_token plus the access_token (used only for the userinfo enrichment fetch).
+func (p *Provider) fetchIDToken(ctx context.Context, code, redirectURI string) (idToken, accessToken string, err error) {
 	form := neturlValues()
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
@@ -216,19 +292,19 @@ func (p *Provider) fetchIDToken(ctx context.Context, code, redirectURI string) (
 
 	req, err := http.NewRequestWithContext(ctx, "POST", p.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := httpClient().Do(req)
 	if err != nil {
-		return "", fmt.Errorf("token exchange: %w", err)
+		return "", "", fmt.Errorf("token exchange: %w", err)
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("token endpoint returned %d", resp.StatusCode)
+		return "", "", fmt.Errorf("token endpoint returned %d", resp.StatusCode)
 	}
 	var tok struct {
 		IDToken     string `json:"id_token"`
@@ -237,15 +313,15 @@ func (p *Provider) fetchIDToken(ctx context.Context, code, redirectURI string) (
 		ErrorDesc   string `json:"error_description"`
 	}
 	if err := json.Unmarshal(body, &tok); err != nil {
-		return "", fmt.Errorf("parse token response: %w", err)
+		return "", "", fmt.Errorf("parse token response: %w", err)
 	}
 	if tok.Error != "" {
-		return "", fmt.Errorf("token endpoint error %q: %s", tok.Error, tok.ErrorDesc)
+		return "", "", fmt.Errorf("token endpoint error %q: %s", tok.Error, tok.ErrorDesc)
 	}
 	if tok.IDToken == "" {
-		return "", errors.New("token response carried no id_token")
+		return "", "", errors.New("token response carried no id_token")
 	}
-	return tok.IDToken, nil
+	return tok.IDToken, tok.AccessToken, nil
 }
 
 // verifyIDToken validates the id_token's signature and claims, then extracts
@@ -351,9 +427,10 @@ func (p *Provider) verifyIDToken(ctx context.Context, raw, expectNonce string) (
 	}
 	return &Claims{
 		Subject:   sub,
-		Name:      stringClaim(claims, p.claimName(p.NameClaim, claimName)),
+		Name:      displayNameFromClaims(claims, p.claimName(p.NameClaim, claimName)),
 		AvatarURL: stringClaim(claims, p.claimName(p.AvatarClaim, claimPicture)),
 		Email:     stringClaim(claims, p.claimName(p.EmailClaim, claimEmail)),
+		rawSub:    stringClaim(claims, claimSub),
 	}, nil
 }
 
@@ -469,6 +546,9 @@ func (p *Provider) ensureDiscovered(ctx context.Context) error {
 	if p.JWKSURL == "" {
 		p.JWKSURL = doc.JWKSURI
 	}
+	if p.UserInfoURL == "" {
+		p.UserInfoURL = doc.UserInfoEndpoint
+	}
 	p.discovered = true
 	p.mu.Unlock()
 	return p.refreshJWKS(ctx)
@@ -504,6 +584,9 @@ type discoveryDoc struct {
 	AuthorizationEndpoint string `json:"authorization_endpoint"`
 	TokenEndpoint         string `json:"token_endpoint"`
 	JWKSURI               string `json:"jwks_uri"`
+	// UserInfoEndpoint is OPTIONAL per OIDC Discovery — absence just disables
+	// the display-claim enrichment fetch, never the login.
+	UserInfoEndpoint string `json:"userinfo_endpoint"`
 }
 
 func fetchDiscovery(ctx context.Context, issuer string) (*discoveryDoc, error) {
@@ -600,11 +683,13 @@ func rsaPublicKeyFromJWK(k jwkKey) (*rsa.PublicKey, error) {
 // --- standard claim names ---
 
 const (
-	claimSub     = "sub"
-	claimName    = "name"
-	claimPicture = "picture"
-	claimEmail   = "email"
-	claimNonce   = "nonce"
+	claimSub        = "sub"
+	claimName       = "name"
+	claimGivenName  = "given_name"
+	claimFamilyName = "family_name"
+	claimPicture    = "picture"
+	claimEmail      = "email"
+	claimNonce      = "nonce"
 )
 
 func stringClaim(m jwt.MapClaims, key string) string {

--- a/src/pkg/auth/oidc_provider_test.go
+++ b/src/pkg/auth/oidc_provider_test.go
@@ -30,6 +30,13 @@ type oidcTestServer struct {
 	discoveryIssuer string
 	// idToken is what the token endpoint returns for any code.
 	idToken string
+	// accessToken is returned alongside idToken; empty means none.
+	accessToken string
+	// userInfo, when non-nil, is served as JSON from /userinfo (Bearer-gated).
+	userInfo map[string]any
+	// userInfoCalls counts /userinfo hits, for asserting the enrichment fetch
+	// did (or did not) happen.
+	userInfoCalls int
 }
 
 func newOIDCTestServer(t *testing.T) *oidcTestServer {
@@ -50,6 +57,7 @@ func newOIDCTestServer(t *testing.T) *oidcTestServer {
 			"authorization_endpoint": ots.issuer + "/authorize",
 			"token_endpoint":         ots.issuer + "/token",
 			"jwks_uri":               ots.issuer + "/jwks",
+			"userinfo_endpoint":      ots.issuer + "/userinfo",
 		})
 	})
 	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
@@ -63,7 +71,19 @@ func newOIDCTestServer(t *testing.T) *oidcTestServer {
 		})
 	})
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]string{"id_token": ots.idToken})
+		resp := map[string]string{"id_token": ots.idToken}
+		if ots.accessToken != "" {
+			resp["access_token"] = ots.accessToken
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		ots.userInfoCalls++
+		if ots.userInfo == nil {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(ots.userInfo)
 	})
 	ots.srv = httptest.NewServer(mux)
 	ots.issuer = ots.srv.URL

--- a/src/pkg/auth/oidc_userinfo_test.go
+++ b/src/pkg/auth/oidc_userinfo_test.go
@@ -1,0 +1,155 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// minimalIDToken returns an IBMid-style minimal claim set: identity + nonce,
+// NO display claims (name/email/picture).
+func minimalIDToken(issuer, aud, nonce, sub string) jwt.MapClaims {
+	return jwt.MapClaims{
+		"iss": issuer, "aud": aud, "sub": sub,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce,
+	}
+}
+
+func TestUserInfo_EnrichesMissingDisplayClaims(t *testing.T) {
+	// The production gap: a minimal id_token stores nothing to display. The
+	// userinfo endpoint carries name/email/picture — Exchange must fill them.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID, nonce, sub = "cid", "n1", "310002H3UQ"
+	o.idToken = o.signToken(t, minimalIDToken(o.issuer, clientID, nonce, sub))
+	o.accessToken = "at-123"
+	o.userInfo = map[string]any{
+		"sub": sub, "name": "Ada Lovelace",
+		"email": "ada@example.com", "picture": "https://example.com/ada.png",
+	}
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Subject != sub {
+		t.Errorf("subject = %q", claims.Subject)
+	}
+	if claims.Name != "Ada Lovelace" || claims.Email != "ada@example.com" || claims.AvatarURL != "https://example.com/ada.png" {
+		t.Errorf("enriched claims = %+v, want userinfo display claims", claims)
+	}
+	if o.userInfoCalls != 1 {
+		t.Errorf("userinfo calls = %d, want 1", o.userInfoCalls)
+	}
+}
+
+func TestUserInfo_SkippedWhenIDTokenComplete(t *testing.T) {
+	// A complete id_token needs no enrichment: no userinfo round-trip.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID, nonce = "cid", "n1"
+	o.idToken = o.signToken(t, baseClaims(o.issuer, clientID, nonce))
+	o.accessToken = "at-123"
+	o.userInfo = map[string]any{"sub": "1078901234567890", "name": "Should Not Be Fetched"}
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Name != "A Person" {
+		t.Errorf("name = %q, want the id_token's own name", claims.Name)
+	}
+	if o.userInfoCalls != 0 {
+		t.Errorf("userinfo calls = %d, want 0 (id_token already complete)", o.userInfoCalls)
+	}
+}
+
+func TestUserInfo_SubMismatchDiscarded(t *testing.T) {
+	// OIDC Core §5.3.2: userinfo's sub MUST match the id_token's. A mismatched
+	// response must be discarded wholesale — none of its claims may be trusted.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID, nonce, sub = "cid", "n1", "real-sub"
+	o.idToken = o.signToken(t, minimalIDToken(o.issuer, clientID, nonce, sub))
+	o.accessToken = "at-123"
+	o.userInfo = map[string]any{
+		"sub": "SOMEONE-ELSE", "name": "Mallory", "email": "mallory@evil.example",
+	}
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Name != "" || claims.Email != "" {
+		t.Errorf("claims = %+v, want mismatched userinfo fully discarded", claims)
+	}
+	if claims.Subject != sub {
+		t.Errorf("subject = %q, must stay the id_token's", claims.Subject)
+	}
+}
+
+func TestUserInfo_FailureNeverFailsLogin(t *testing.T) {
+	// The login is already verified; a broken userinfo endpoint (404) must be a
+	// silent no-op, not an error.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID, nonce = "cid", "n1"
+	o.idToken = o.signToken(t, minimalIDToken(o.issuer, clientID, nonce, "s1"))
+	o.accessToken = "at-123"
+	// o.userInfo stays nil → /userinfo answers 404.
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange must not fail on userinfo error: %v", err)
+	}
+	if claims.Subject != "s1" {
+		t.Errorf("subject = %q", claims.Subject)
+	}
+}
+
+func TestUserInfo_NoAccessTokenNoFetch(t *testing.T) {
+	// A token response without access_token cannot authorize a userinfo call.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID, nonce = "cid", "n1"
+	o.idToken = o.signToken(t, minimalIDToken(o.issuer, clientID, nonce, "s1"))
+	// accessToken deliberately empty.
+	o.userInfo = map[string]any{"sub": "s1", "name": "X"}
+
+	p := googleLikeProvider(o, clientID)
+	if _, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce); err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if o.userInfoCalls != 0 {
+		t.Errorf("userinfo calls = %d, want 0 without an access token", o.userInfoCalls)
+	}
+}
+
+func TestDisplayName_GivenFamilyComposition(t *testing.T) {
+	// IBMid/Entra often carry given_name/family_name without a composite name.
+	o := newOIDCTestServer(t)
+	defer o.close()
+	const clientID, nonce = "cid", "n1"
+	c := minimalIDToken(o.issuer, clientID, nonce, "s1")
+	c["given_name"] = "Grace"
+	c["family_name"] = "Hopper"
+	c["email"] = "grace@example.com"
+	c["picture"] = "https://example.com/g.png"
+	o.idToken = o.signToken(t, c)
+
+	p := googleLikeProvider(o, clientID)
+	claims, err := p.Exchange(context.Background(), "c", o.issuer+"/cb", nonce)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if claims.Name != "Grace Hopper" {
+		t.Errorf("name = %q, want given+family composition", claims.Name)
+	}
+}

--- a/src/pkg/hub/clickable_avatars_test.go
+++ b/src/pkg/hub/clickable_avatars_test.go
@@ -25,7 +25,11 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 		{"per-hive pending request rows", "var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');"},
 		{"past requests table", "linkedAvatar(uname, PANEL_ACCESS_AVATAR_PX, uname, 'margin-right:6px')"},
 		{"pending provision cards", "var avatar = linkedAvatar(pr.username, TABLE_AVATAR_PX, pr.username, 'margin-right:8px');"},
-		{"admin users table", "var avatar = linkedAvatar(u.github_username, TABLE_AVATAR_PX,"},
+		// The admin users table routes GitHub users through linkedAvatar and OIDC
+		// users through userAvatar (stored provider avatar / initials from the
+		// real display name — provider:sub is not a github.com login).
+		{"admin users table (github path)", "? linkedAvatar(u.github_username, TABLE_AVATAR_PX,"},
+		{"admin users table (oidc path)", ": userAvatar(u, TABLE_AVATAR_PX, 'margin-right:6px');"},
 		{"access modal pending requests", "var avatar = linkedAvatar(r.username, LIST_AVATAR_PX, r.username, 'margin-right:6px');"},
 		{"access modal access list", "var avatar = linkedAvatar(u.username, LIST_AVATAR_PX,"},
 		{"nav bar viewer avatar", "avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,"},

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -467,6 +467,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		canonicalID string
 		avatarURL   string
 		email       string
+		displayName string // provider-asserted human name (OIDC name claim/userinfo)
 		ghToken     string // GitHub user access token, if any (stored encrypted)
 	)
 	if p.IsOIDC {
@@ -493,6 +494,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		canonicalID = id
 		avatarURL = claims.AvatarURL
 		email = claims.Email
+		displayName = claims.Name
 		s.logger.Info("audit: hub OIDC login", "provider", p.Name, "user", canonicalID)
 	} else {
 		login, avatar, token, ok := s.exchangeGitHubLogin(w, code)
@@ -527,6 +529,14 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 	if email != "" {
 		saasUser.Email = email
+	}
+	// Backfill-by-login: every completed login UPSERTS the display claims onto
+	// the existing record, so provider:sub users created before enrichment
+	// shipped get their name on their next sign-in — no migration. Only
+	// non-empty values overwrite, so a provider that stops sending a claim
+	// never blanks a previously-stored one.
+	if displayName != "" {
+		saasUser.DisplayName = displayName
 	}
 	// A completed callback IS a login — count it here and nowhere else.
 	// ensureSaaSUser already refreshed LastLogin; the count is the engagement
@@ -817,9 +827,9 @@ func (s *HubServer) clearOIDCNonceCookie(w http.ResponseWriter) {
 // displayIdentity returns the human-facing login label and avatar URL for a
 // canonical (or legacy bare) identity. For a GitHub user this is the bare login
 // and the derived github.com/<login>.png avatar — byte-identical to the
-// pre-multi-provider behavior. For an OIDC user it prefers the STORED avatar
-// (Google/IBMid provide a picture) and a friendly display label (email, else
-// the canonical id), never nothing.
+// pre-multi-provider behavior. For an OIDC user it prefers the STORED
+// provider-asserted display name, then email, then the canonical id — and the
+// stored avatar (Google/Microsoft provide a picture) — never nothing.
 func (s *HubServer) displayIdentity(identity string) (login, avatarURL string) {
 	provider, subject, ok := parseCanonical(canonicalizeLegacy(identity))
 	if !ok {
@@ -832,7 +842,10 @@ func (s *HubServer) displayIdentity(identity string) (login, avatarURL string) {
 	// Non-GitHub: use the stored record for a good label + avatar.
 	login = identity
 	if u := loadSaaSUser(canonicalizeLegacy(identity)); u != nil {
-		if u.Email != "" {
+		switch {
+		case u.DisplayName != "":
+			login = u.DisplayName
+		case u.Email != "":
 			login = u.Email
 		}
 		avatarURL = u.AvatarURL

--- a/src/pkg/hub/oidc_identity_enrichment_test.go
+++ b/src/pkg/hub/oidc_identity_enrichment_test.go
@@ -1,0 +1,195 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/kubestellar/hive/pkg/auth"
+)
+
+// oidcCallbackRequest builds a nonce-consistent callback request for provider p.
+func oidcCallbackRequest(providerName, stateNonce, oidcNonce string) *http.Request {
+	state := url.QueryEscape(stateNonce + oauthStateSeparator + providerName + oauthStateSeparator + "/dashboard")
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=xyz&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: oauthStateCookieName, Value: stateNonce})
+	req.AddCookie(&http.Cookie{Name: oidcNonceCookieName, Value: oidcNonce})
+	return req
+}
+
+func ibmidHubServer(f *fakeOIDCProvider, clientID string) *HubServer {
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	s.authProviders = auth.NewRegistry(&auth.Provider{
+		Name: "ibmid", DisplayName: "IBMid", IsOIDC: true,
+		Issuer: f.issuer, ClientID: clientID, Scopes: []string{"openid", "email", "profile"},
+		SubjectClaim: "uid",
+	})
+	return s
+}
+
+// TestOIDCCallback_StoresDisplayName pins that a login carrying a name claim
+// persists it as the provider-asserted DisplayName on the user record.
+func TestOIDCCallback_StoresDisplayName(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	f := newFakeOIDCProvider(t)
+	defer f.close()
+
+	const clientID, nonce, uid = "cid", "n-1", "310002H3UQ"
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss": f.issuer, "aud": clientID, "uid": uid, "sub": "ignored-when-uid-present",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": nonce, "name": "Ada Lovelace", "email": "ada@example.com",
+	})
+	s := ibmidHubServer(f, clientID)
+
+	stateNonce, _ := oauthStateNonce()
+	rec := httptest.NewRecorder()
+	s.handleOAuthCallback(rec, oidcCallbackRequest("ibmid", stateNonce, nonce))
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	u := loadSaaSUser("ibmid:" + uid)
+	if u == nil {
+		t.Fatal("expected ibmid user record")
+	}
+	if u.DisplayName != "Ada Lovelace" {
+		t.Errorf("DisplayName = %q, want Ada Lovelace", u.DisplayName)
+	}
+	if u.Email != "ada@example.com" {
+		t.Errorf("Email = %q", u.Email)
+	}
+}
+
+// TestOIDCCallback_EnrichesExistingRecordOnNextLogin is the backfill guarantee:
+// a provider:sub record created BEFORE enrichment shipped (no display claims)
+// gets name/email upserted — same record, not a new one — on its next login.
+func TestOIDCCallback_EnrichesExistingRecordOnNextLogin(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	f := newFakeOIDCProvider(t)
+	defer f.close()
+
+	const clientID, uid = "cid", "310002H3UQ"
+	s := ibmidHubServer(f, clientID)
+
+	// First login: minimal id_token — the pre-enrichment record shape.
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss": f.issuer, "aud": clientID, "uid": uid,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": "n-1",
+	})
+	n1, _ := oauthStateNonce()
+	rec := httptest.NewRecorder()
+	s.handleOAuthCallback(rec, oidcCallbackRequest("ibmid", n1, "n-1"))
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("first login status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	u := loadSaaSUser("ibmid:" + uid)
+	if u == nil || u.DisplayName != "" {
+		t.Fatalf("precondition: bare record expected, got %+v", u)
+	}
+	created := u.CreatedAt
+
+	// Second login: the provider now sends display claims. Same record must be
+	// UPDATED — not recreated — with the claims upserted.
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss": f.issuer, "aud": clientID, "uid": uid,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": "n-2", "name": "Ada Lovelace", "email": "ada@example.com",
+		"picture": "https://example.com/ada.png",
+	})
+	n2, _ := oauthStateNonce()
+	rec2 := httptest.NewRecorder()
+	s.handleOAuthCallback(rec2, oidcCallbackRequest("ibmid", n2, "n-2"))
+	if rec2.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("second login status = %d (body=%s)", rec2.Code, rec2.Body.String())
+	}
+
+	u = loadSaaSUser("ibmid:" + uid)
+	if u == nil {
+		t.Fatal("record vanished")
+	}
+	if u.DisplayName != "Ada Lovelace" || u.Email != "ada@example.com" || u.AvatarURL != "https://example.com/ada.png" {
+		t.Errorf("record not enriched: %+v", u)
+	}
+	if u.CreatedAt != created {
+		t.Errorf("CreatedAt changed %q -> %q — record was recreated, not updated", created, u.CreatedAt)
+	}
+	if u.LoginCount != 2 {
+		t.Errorf("LoginCount = %d, want 2 (same record across both logins)", u.LoginCount)
+	}
+}
+
+// TestOIDCCallback_ClaimGapNeverBlanksStoredValue: a later login missing a
+// claim must not erase what an earlier login stored.
+func TestOIDCCallback_ClaimGapNeverBlanksStoredValue(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	f := newFakeOIDCProvider(t)
+	defer f.close()
+
+	const clientID, uid = "cid", "310002H3UQ"
+	s := ibmidHubServer(f, clientID)
+
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss": f.issuer, "aud": clientID, "uid": uid,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": "n-1", "name": "Ada Lovelace", "email": "ada@example.com",
+	})
+	n1, _ := oauthStateNonce()
+	s.handleOAuthCallback(httptest.NewRecorder(), oidcCallbackRequest("ibmid", n1, "n-1"))
+
+	// Second login with NO display claims.
+	f.idToken = f.sign(t, jwt.MapClaims{
+		"iss": f.issuer, "aud": clientID, "uid": uid,
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+		"nonce": "n-2",
+	})
+	n2, _ := oauthStateNonce()
+	s.handleOAuthCallback(httptest.NewRecorder(), oidcCallbackRequest("ibmid", n2, "n-2"))
+
+	u := loadSaaSUser("ibmid:" + uid)
+	if u == nil || u.DisplayName != "Ada Lovelace" || u.Email != "ada@example.com" {
+		t.Errorf("stored display claims were blanked by a claimless login: %+v", u)
+	}
+}
+
+// TestDisplayIdentity_PrefersDisplayName pins the navbar label order for OIDC
+// users: DisplayName > Email > canonical id. GitHub users stay the bare login.
+func TestDisplayIdentity_PrefersDisplayName(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := &HubServer{logger: slog.Default()}
+
+	u := ensureSaaSUser("ibmid:310002H3UQ")
+	u.DisplayName = "Ada Lovelace"
+	u.Email = "ada@example.com"
+	u.AvatarURL = "https://example.com/ada.png"
+	saveSaaSUser(u)
+
+	login, avatar := s.displayIdentity("ibmid:310002H3UQ")
+	if login != "Ada Lovelace" {
+		t.Errorf("login = %q, want the display name", login)
+	}
+	if avatar != "https://example.com/ada.png" {
+		t.Errorf("avatar = %q", avatar)
+	}
+
+	// Without a display name, email is the label.
+	u.DisplayName = ""
+	saveSaaSUser(u)
+	if login, _ = s.displayIdentity("ibmid:310002H3UQ"); login != "ada@example.com" {
+		t.Errorf("login = %q, want the email fallback", login)
+	}
+
+	// GitHub identity: unchanged bare-login behavior.
+	if login, avatar = s.displayIdentity("octocat"); login != "octocat" || avatar != "https://github.com/octocat.png" {
+		t.Errorf("github displayIdentity = %q,%q", login, avatar)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -289,6 +289,14 @@ type SaaSUser struct {
 	Email             string `json:"email,omitempty"`
 	LinkedGitHubLogin string `json:"linked_github_login,omitempty"`
 
+	// DisplayName is the PROVIDER-ASSERTED human name from the OIDC name claim
+	// (or userinfo), refreshed on every completed login. Distinct from FullName,
+	// which is ADMIN-entered CRM text and must never be clobbered by a login.
+	// Display only — the identity key stays provider:sub. omitempty so existing
+	// records round-trip byte-identical until the user's next login enriches
+	// them (backfill-by-login, no migration).
+	DisplayName string `json:"display_name,omitempty"`
+
 	// Contact/CRM fields. Admin-maintained free text used to reach a hub user
 	// outside GitHub (and to remember what was said last time). All three are
 	// omitempty so the thousands of existing user records already on the PVC
@@ -9121,6 +9129,32 @@ const dashboardHTML = `<!DOCTYPE html>
       return avatarProfileLink(username, label, avatarImg(username, px, extraStyle));
     }
 
+    /* userDisplayLabel: the human-facing name for a stored user record. OIDC
+       users are KEYED as provider:sub (stable, but cryptic — "google:1178…");
+       what a human should see is the provider-asserted display_name, else the
+       admin-entered full_name, else the email, else (GitHub users, legacy
+       records) the username key itself. */
+    function userDisplayLabel(u) {
+      if (!u) return '';
+      return u.display_name || u.full_name || u.email || u.github_username || '';
+    }
+
+    /* userAvatar: avatar for a stored user record. Prefers the provider-stored
+       avatar_url (Google/Microsoft picture claim); GitHub users keep the derived
+       github.com/<login>.png via avatarImg. An OIDC user with no stored avatar
+       (IBMid sends no picture claim) gets initials derived from their REAL
+       display label — never from the provider:sub key (which produced tiles
+       like "M0"). Failed loads fall back to the same initials. */
+    function userAvatar(u, px, extraStyle) {
+      var label = userDisplayLabel(u);
+      var style = 'width:' + px + 'px;height:' + px + 'px;border-radius:50%;vertical-align:middle;' + (extraStyle || '');
+      if (u && u.avatar_url) {
+        return '<img src="' + escAttr(u.avatar_url) + '" alt="" style="' + style + '" ' +
+          'onerror="this.onerror=null;this.src=' + jsArg(avatarInitialsSVG(label, px)) + '">';
+      }
+      return '<img src="' + escAttr(avatarInitialsSVG(label, px)) + '" alt="" style="' + style + '">';
+    }
+
     /* Rendered avatar sizes, in CSS pixels, one per surface. They differ because
        the surfaces differ in density, not arbitrarily: the status-dot hover
        panel and the compact request/access lists are tight vertical lists; the
@@ -16650,7 +16684,7 @@ const dashboardHTML = `<!DOCTYPE html>
       var filtered = (_allUsers || []).filter(function(u) {
         if (!q) return true;
         if (!u) return false;
-        var hay = [u.github_username, u.full_name, u.slack_id, u.notes]
+        var hay = [u.github_username, u.display_name, u.email, u.full_name, u.slack_id, u.notes]
           .filter(function(v) { return !!v; }).join(' ').toLowerCase();
         return hay.includes(q);
       });
@@ -16852,7 +16886,12 @@ const dashboardHTML = `<!DOCTYPE html>
         case 'google':
           return '<svg viewBox="0 0 18 18" ' + s + '><path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z"/><path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z"/><path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z"/><path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58C13.46.89 11.42 0 9 0A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z"/></svg>';
         case 'ibmid':
-          return '<svg viewBox="0 0 24 24" fill="#1F70C1" ' + s + '><path d="M2 4h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2zm0 3.5h20v2H2z"/></svg>';
+          // Text-based IBM mark (license-safe; the striped-wordmark SVG rendered
+          // as a broken glyph at badge size). IBM blue, bold, sized to match the
+          // other 12px brand marks.
+          return '<svg viewBox="0 0 26 14" width="20" height="12" style="flex:none" aria-hidden="true">' +
+            '<text x="13" y="11" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" ' +
+            'font-size="11" font-weight="700" fill="#0f62fe">IBM</text></svg>';
         case 'redhat':
           return '<svg viewBox="0 0 24 24" fill="#EE0000" ' + s + '><path d="M16.35 14.4c1.6 0 3.9-.33 3.9-2.24a1.8 1.8 0 0 0-.04-.44l-.95-4.12c-.22-.9-.41-1.31-2-2.12-1.24-.63-3.94-1.67-4.74-1.67-.74 0-.96.96-1.85.94-.86-.02-1.5-.74-2.3-.74-.77 0-1.27.52-1.66 1.6 0 0-1.08 3.05-1.22 3.49a.83.83 0 0 0-.03.25c0 1.2 4.71 5.32 10.88 5.32M20.47 12.94c.22 1.05.22 1.16.22 1.3 0 1.8-2.02 2.79-4.67 2.79-6 0-11.25-3.51-11.25-5.83 0-.32.07-.63.18-.93C2.94 10.36 1 10.63 1 12.34c0 2.8 6.63 6.26 11.87 6.26 4.02 0 5.03-1.82 5.03-3.25 0-1.13-.97-2.4-2.43-2.41"/></svg>';
         case 'microsoft':
@@ -17461,7 +17500,11 @@ const dashboardHTML = `<!DOCTYPE html>
       return '<span class="hive-access-pop" style="display:none;position:absolute;left:0;top:calc(100% + 6px);z-index:60;' +
         'min-width:240px;max-width:320px;padding:9px 11px;border-radius:8px;border:1px solid var(--border);' +
         'background:var(--surface);box-shadow:0 6px 20px rgba(0,0,0,0.35);font-size:0.72rem;text-align:left;font-weight:400;white-space:normal">' +
-        '<div style="font-weight:700;margin-bottom:4px">' + esc(u.github_username) + '</div>' +
+        '<div style="font-weight:700;margin-bottom:4px">' + esc(userDisplayLabel(u)) +
+          (userDisplayLabel(u) !== u.github_username
+            ? '<span style="display:block;font-weight:400;font-size:0.62rem;color:var(--muted)">' + esc(u.github_username) + '</span>'
+            : '') +
+        '</div>' +
         verdictBlock +
         stats +
         '<span style="display:block;border-top:1px solid var(--border);margin:6px 0 4px"></span>' +
@@ -17486,8 +17529,14 @@ const dashboardHTML = `<!DOCTYPE html>
            open tab, a never-logged-in user, and a daily driver all looked the
            same. */
         var statusCell = statusTierBadge(u);
-        var avatar = linkedAvatar(u.github_username, TABLE_AVATAR_PX,
-          u.github_username + ' — GitHub profile', 'margin-right:6px');
+        /* GitHub users keep the linked github.com avatar; OIDC users get the
+           stored provider avatar (or initials from their real name) and no
+           GitHub profile link — provider:sub is not a github.com login. */
+        var isGitHubUser = String(u.provider || 'github').toLowerCase() === 'github';
+        var avatar = isGitHubUser
+          ? linkedAvatar(u.github_username, TABLE_AVATAR_PX,
+              u.github_username + ' — GitHub profile', 'margin-right:6px')
+          : userAvatar(u, TABLE_AVATAR_PX, 'margin-right:6px');
         var isAdmin = u.github_username === 'clubanderson';
         var hivesObj = u.hives || {};
         var registryIds = new Set((_hiveRegistry || []).map(function(h) { return h.id; }));
@@ -17529,7 +17578,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var hasPendingReq = !!_provisionRequestsByUser[u.github_username];
         var nameCell = avatar +
           '<span class="hive-access-wrap" style="position:relative;display:inline-flex;align-items:center;gap:4px;cursor:help">' +
-            '<span style="color:var(--text);font-weight:600">' + esc(u.github_username) + '</span>' +
+            '<span style="color:var(--text);font-weight:600">' + esc(userDisplayLabel(u)) + '</span>' +
             providerBadge(u) +
             (hasPendingReq ? ' <span style="color:var(--accent);font-size:0.65rem">&#9679; request</span>' : '') +
             renderUserStatsCard(u, hasPendingReq) +


### PR DESCRIPTION
Fixes #4113

## Problem

After the IBMid login fix (#4109), OIDC logins (ibmid, microsoft, google) succeed but the users appear in the hub as cryptic records:

- `microsoft:EyAJCITTprjoOw5XnC58cTqn3DJu0HM6TDqBcQKNJP0`
- `google:117852267392148623753`
- `ibmid:310002H3UQ`

with letter-tile avatars (M0/G3/IQ) built from the raw key, no display name/email anywhere, and the IBMid provider badge rendering as a broken glyph.

## Root causes (all confirmed by code inspection)

1. **Name claim discarded**: `auth.Claims.Name` was extracted from the id_token but never persisted — the hub callback only stored email and the canonical `provider:sub` key (`src/pkg/hub/oauth.go`).
2. **No userinfo fallback**: many IdPs (IBMid in particular) put `name`/`email`/`picture` in the userinfo endpoint, not the id_token. The code never called userinfo, so those claims were simply unavailable.
3. **UI renders the raw key**: the admin Users table JS rendered `u.github_username` (which holds `provider:sub` for OIDC users) as the display name and built `github.com/<key>.png` avatar URLs — a guaranteed 404 → initials of the raw key (M0/G3/IQ).
4. **Broken IBM badge**: `providerLogoSVG('ibmid')` in the dashboard JS was a malformed 5-stripe SVG that rendered as a broken glyph (the login-picker glyph in `oauth.go` is a separate, working asset).

## Fix

### pkg/auth (OIDC provider)
- Discover `userinfo_endpoint`; after id_token verification, if claims are incomplete and an access token is available, fetch userinfo (Bearer GET).
- Security: the userinfo response is discarded wholesale unless its `sub` matches the id_token `sub` (OIDC Core §5.3.2).
- Only **missing** name/email/picture are filled; userinfo failures never fail login (best-effort enrichment).
- Display name composed from `given_name + family_name` when `name` is absent.

### pkg/hub
- New `SaaSUser.DisplayName` (provider-asserted), kept separate from admin-entered `FullName` which is never clobbered.
- The callback upserts DisplayName/email on **every** login with a non-empty-only rule — so existing `provider:sub` records are backfilled on their next login, no migration needed (verified by test: same CreatedAt, LoginCount increments, claims filled).
- `displayIdentity` label preference: DisplayName > Email > canonical key (GitHub path unchanged).

### Dashboard (saas.go JS)
- New `userDisplayLabel(u)` / `userAvatar(u, px, style)` helpers; the admin Users table, stats hover card, and user search now show the human name/email; avatars use the `picture` claim (Google/Microsoft provide it) with fallback to initials derived from the **real name** (IBMid case). GitHub users keep the existing `linkedAvatar` path, unchanged.
- Canonical `provider:sub` key remains the storage key and is still shown as muted subtext in the stats card for admin traceability.
- `providerLogoSVG('ibmid')` replaced with a simple, license-safe text-based "IBM" badge in IBM blue (#0f62fe), consistent in size with the Microsoft/Google badges.

## Validation

- `go build ./...`, `go vet ./...` — clean
- `go test -p 1 ./pkg/hub/ ./pkg/auth/` (serial) — all pass, including:
  - 6 new userinfo enrichment tests (fill missing claims, skip when complete, sub-mismatch discard, failure tolerance, no-access-token, given+family composition)
  - 4 new hub tests (DisplayName persistence, upsert backfill on next login, claim gaps never blank stored values, displayIdentity preference)
  - updated dashboard pin tests (avatar helper usage per path)

## How to verify in prod

1. Deploy; have an IBMid/Google/Microsoft user log in once.
2. Admin → Users: the row should now show the person's real name and email with a proper avatar (photo for Google/Microsoft, name-initials for IBMid), and the IBM badge renders as a blue "IBM" mark.
3. Pre-existing raw `provider:sub` records enrich automatically on that user's next login — no manual action.
