### PR TITLE
feat(dashboard): show cost-per-PR and cost-per-issue in spoke cost section

### DIFF
--- a/src/pkg/dashboard/cost.go
+++ b/src/pkg/dashboard/cost.go
@@ -84,6 +84,13 @@ type costResponse struct {
 	// the estimate without hardcoding the date.
 	PriceTableDate string `json:"price_table_date"`
 	Disclaimer     string `json:"disclaimer"`
+	// MergedPRs / ClosedIssues are all-time counts for the primary repo,
+	// matching Estimated.TotalUSD's "all-time cumulative" scope. The UI divides
+	// TotalUSD by these to derive cost-per-PR / cost-per-issue (issue #4110).
+	// Zero means "no data yet" (collector hasn't run, or GitHub is unreachable);
+	// the UI shows "—" rather than treating it as a real zero denominator.
+	MergedPRs    int `json:"merged_prs"`
+	ClosedIssues int `json:"closed_issues"`
 }
 
 // costModelEntry is one row of the estimated per-model / per-agent breakdown.
@@ -152,6 +159,14 @@ func (s *Server) handleCost(w http.ResponseWriter, r *http.Request) {
 
 	// --- Estimated cost from token counts ---
 	resp.Estimated = s.estimatedCost()
+
+	// --- Merged-PR / closed-issue counts (for cost-per-PR / cost-per-issue) ---
+	if s.deps != nil && s.deps.MetricsCollector != nil {
+		if counts := s.deps.MetricsCollector.GetPRIssueCounts(); counts != nil {
+			resp.MergedPRs = counts.MergedPRs
+			resp.ClosedIssues = counts.ClosedIssues
+		}
+	}
 
 	// --- Native cost per metered gateway ---
 	if s.deps != nil && s.deps.Config != nil {

--- a/src/pkg/dashboard/cost_coverage_test.go
+++ b/src/pkg/dashboard/cost_coverage_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/config"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/tokens"
 )
 
@@ -300,6 +301,41 @@ func TestCov_SourceForPriced(t *testing.T) {
 	}
 	if got := sourceForPriced(false); got != "unpriced" {
 		t.Errorf("unpriced -> %q", got)
+	}
+}
+
+func TestCov_HandleCost_WithPRIssueCounts(t *testing.T) {
+	s, deps := covServer(t)
+	deps.MetricsCollector = &MetricsCollector{
+		metrics:       make(map[string]any),
+		prIssueCounts: &ghpkg.PRIssueCounts{MergedPRs: 9, ClosedIssues: 4, UpdatedAt: "2026-08-18T00:00:00Z"},
+	}
+
+	rec := doGet(s, "/api/cost")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp costResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.MergedPRs != 9 {
+		t.Errorf("MergedPRs = %d, want 9", resp.MergedPRs)
+	}
+	if resp.ClosedIssues != 4 {
+		t.Errorf("ClosedIssues = %d, want 4", resp.ClosedIssues)
+	}
+}
+
+func TestCov_HandleCost_NoPRIssueCounts(t *testing.T) {
+	s, _ := covServer(t)
+	rec := doGet(s, "/api/cost")
+	var resp costResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.MergedPRs != 0 || resp.ClosedIssues != 0 {
+		t.Errorf("expected zero counts with no MetricsCollector, got merged=%d closed=%d", resp.MergedPRs, resp.ClosedIssues)
 	}
 }
 

--- a/src/pkg/dashboard/metrics_collector.go
+++ b/src/pkg/dashboard/metrics_collector.go
@@ -20,20 +20,23 @@ const (
 	httpTimeout            = 10 * time.Second
 	metricsCacheFile       = "/data/metrics/agent-metrics-cache.json"
 	mttrCacheFile          = "/data/metrics/issue-to-merge.json"
+	prIssueCountsCacheFile = "/data/metrics/pr-issue-counts.json"
 )
 
 type MetricsCollector struct {
-	ghClient    *ghpkg.Client
-	org         string
-	repo        string
-	badgeURL    string
-	aiAuthor    string
-	projectName string
-	logger      *slog.Logger
-	mu          sync.RWMutex
-	metrics     map[string]any
-	mttrMu      sync.RWMutex
-	mttr        *ghpkg.MTTRResult
+	ghClient      *ghpkg.Client
+	org           string
+	repo          string
+	badgeURL      string
+	aiAuthor      string
+	projectName   string
+	logger        *slog.Logger
+	mu            sync.RWMutex
+	metrics       map[string]any
+	mttrMu        sync.RWMutex
+	mttr          *ghpkg.MTTRResult
+	prIssueMu     sync.RWMutex
+	prIssueCounts *ghpkg.PRIssueCounts
 }
 
 func NewMetricsCollector(ghClient *ghpkg.Client, org, primaryRepo, badgeURL, aiAuthor, projectName string, logger *slog.Logger) *MetricsCollector {
@@ -52,6 +55,7 @@ func NewMetricsCollector(ghClient *ghpkg.Client, org, primaryRepo, badgeURL, aiA
 	}
 	mc.loadFromDisk()
 	mc.loadMTTRFromDisk()
+	mc.loadPRIssueCountsFromDisk()
 	return mc
 }
 
@@ -86,6 +90,14 @@ func (mc *MetricsCollector) GetMTTR() *ghpkg.MTTRResult {
 	return mc.mttr
 }
 
+// GetPRIssueCounts returns the latest merged-PR / closed-issue counts, or nil
+// if no data is available yet.
+func (mc *MetricsCollector) GetPRIssueCounts() *ghpkg.PRIssueCounts {
+	mc.prIssueMu.RLock()
+	defer mc.prIssueMu.RUnlock()
+	return mc.prIssueCounts
+}
+
 func (mc *MetricsCollector) collect(ctx context.Context) {
 	metrics := make(map[string]any)
 
@@ -99,6 +111,7 @@ func (mc *MetricsCollector) collect(ctx context.Context) {
 	metrics["architect"] = architect
 
 	mc.collectMTTR(ctx)
+	mc.collectPRIssueCounts(ctx)
 
 	mc.mu.Lock()
 	mc.metrics = metrics
@@ -133,6 +146,31 @@ func (mc *MetricsCollector) collectMTTR(ctx context.Context) {
 		"avg_minutes", result.AvgMinutes,
 		"median_minutes", result.MedianMinutes,
 		"count", result.Count,
+	)
+}
+
+// collectPRIssueCounts fetches the total merged-PR and closed-issue counts for
+// the primary repo, persists the result to disk, and stores it in memory. Used
+// by the dashboard's Cost section to derive cost-per-PR / cost-per-issue.
+func (mc *MetricsCollector) collectPRIssueCounts(ctx context.Context) {
+	if mc.ghClient == nil || mc.repo == "" {
+		return
+	}
+
+	result, err := mc.ghClient.ComputePRIssueCounts(ctx, mc.repo)
+	if err != nil {
+		mc.logger.Warn("failed to compute PR/issue counts", "error", err)
+		return
+	}
+
+	mc.prIssueMu.Lock()
+	mc.prIssueCounts = result
+	mc.prIssueMu.Unlock()
+
+	mc.savePRIssueCountsToDisk(result)
+	mc.logger.Info("PR/issue counts computed",
+		"merged_prs", result.MergedPRs,
+		"closed_issues", result.ClosedIssues,
 	)
 }
 
@@ -345,5 +383,32 @@ func (mc *MetricsCollector) saveMTTRToDisk(result *ghpkg.MTTRResult) {
 	tmpPath := mttrCacheFile + ".tmp"
 	if os.WriteFile(tmpPath, data, 0o644) == nil {
 		_ = os.Rename(tmpPath, mttrCacheFile)
+	}
+}
+
+func (mc *MetricsCollector) loadPRIssueCountsFromDisk() {
+	data, err := os.ReadFile(prIssueCountsCacheFile)
+	if err != nil {
+		return
+	}
+	var result ghpkg.PRIssueCounts
+	if json.Unmarshal(data, &result) == nil && result.UpdatedAt != "" {
+		mc.prIssueCounts = &result
+		mc.logger.Info("PR/issue counts loaded from disk cache",
+			"merged_prs", result.MergedPRs,
+			"closed_issues", result.ClosedIssues,
+		)
+	}
+}
+
+func (mc *MetricsCollector) savePRIssueCountsToDisk(result *ghpkg.PRIssueCounts) {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll("/data/metrics", 0o755)
+	tmpPath := prIssueCountsCacheFile + ".tmp"
+	if os.WriteFile(tmpPath, data, 0o644) == nil {
+		_ = os.Rename(tmpPath, prIssueCountsCacheFile)
 	}
 }

--- a/src/pkg/dashboard/metrics_collector_test.go
+++ b/src/pkg/dashboard/metrics_collector_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -335,4 +336,80 @@ func TestMetricsCollector_Start_CancelledContext(t *testing.T) {
 // encodeBase64ForTest is a helper for the test server to encode file contents.
 func encodeBase64ForTest(s string) string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestMetricsCollector_CollectPRIssueCounts_NilClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mc := &MetricsCollector{
+		repo:    "repo1",
+		logger:  logger,
+		metrics: make(map[string]any),
+	}
+	mc.collectPRIssueCounts(context.Background())
+	if got := mc.GetPRIssueCounts(); got != nil {
+		t.Errorf("GetPRIssueCounts() = %+v, want nil", got)
+	}
+}
+
+func TestMetricsCollector_CollectPRIssueCounts_EmptyRepo(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mc := &MetricsCollector{
+		logger:  logger,
+		metrics: make(map[string]any),
+	}
+	mc.collectPRIssueCounts(context.Background())
+	if got := mc.GetPRIssueCounts(); got != nil {
+		t.Errorf("GetPRIssueCounts() = %+v, want nil", got)
+	}
+}
+
+func TestMetricsCollector_CollectPRIssueCounts_WithMock(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		total := 0
+		switch {
+		case strings.Contains(q, "type:pr"):
+			total = 8
+		case strings.Contains(q, "type:issue"):
+			total = 5
+		}
+		json.NewEncoder(w).Encode(map[string]any{"total_count": total, "items": []any{}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mc := &MetricsCollector{
+		ghClient: ghpkg.NewClientForTest(srv.URL, "myorg", []string{"repo1"}, logger),
+		org:      "myorg",
+		repo:     "repo1",
+		logger:   logger,
+		metrics:  make(map[string]any),
+	}
+	mc.collectPRIssueCounts(context.Background())
+
+	got := mc.GetPRIssueCounts()
+	if got == nil {
+		t.Fatal("expected non-nil PR/issue counts")
+	}
+	if got.MergedPRs != 8 {
+		t.Errorf("MergedPRs = %d, want 8", got.MergedPRs)
+	}
+	if got.ClosedIssues != 5 {
+		t.Errorf("ClosedIssues = %d, want 5", got.ClosedIssues)
+	}
+}
+
+func TestMetricsCollector_PRIssueCounts_SaveAndLoadDisk(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mc := &MetricsCollector{
+		logger:  logger,
+		metrics: make(map[string]any),
+	}
+	// savePRIssueCountsToDisk writes to /data/metrics/ which may fail in a
+	// sandboxed test environment (read-only fs); just verify it doesn't panic.
+	mc.savePRIssueCountsToDisk(&ghpkg.PRIssueCounts{MergedPRs: 3, ClosedIssues: 2, UpdatedAt: time.Now().UTC().Format(time.RFC3339)})
+	// loadPRIssueCountsFromDisk on a missing/inaccessible file should also not panic.
+	mc.loadPRIssueCountsFromDisk()
 }

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -8388,6 +8388,8 @@ function burnAreaChart() {
           <div class="cost-subtitle">Estimated from token counts × list prices (as of ${esc(cost.price_table_date || '')}); models without an exact price use a coarse tier estimate (~). Where a metered gateway reports actual spend it refines the estimate, but the figure is always an estimate.</div>
           <div class="cost-grid">
             <div class="cost-stat"><div class="cval">${fmtUSD(est.total_usd)}<span class="cost-badge est">est.</span></div><div class="clabel">estimated total — all-time cumulative (token × list price)</div>${costSparkSvg()}</div>
+            <div class="cost-stat"><div class="cval" title="${cost.merged_prs ? `${fmtUSD(est.total_usd)} ÷ ${cost.merged_prs} merged PRs` : 'no merged PRs yet'}">${cost.merged_prs ? fmtUSD(est.total_usd / cost.merged_prs) : '—'}</div><div class="clabel">cost / PR — all-time total ÷ merged PRs</div></div>
+            <div class="cost-stat"><div class="cval" title="${cost.closed_issues ? `${fmtUSD(est.total_usd)} ÷ ${cost.closed_issues} closed issues` : 'no closed issues yet'}">${cost.closed_issues ? fmtUSD(est.total_usd / cost.closed_issues) : '—'}</div><div class="clabel">cost / issue — all-time total ÷ closed issues</div></div>
           </div>
           ${costTrendHtml()}
           ${gwCards ? `<div class="cost-gateways">${gwCards}</div>` : ''}

--- a/src/pkg/github/pr_issue_counts.go
+++ b/src/pkg/github/pr_issue_counts.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// PRIssueCounts holds the total merged-PR and closed-issue counts for a repo,
+// used by the dashboard's Cost section to derive cost-per-PR and
+// cost-per-issue efficiency metrics (issue #4110). Both counts are all-time
+// cumulative, matching the "estimated total — all-time cumulative" figure they
+// are divided into.
+type PRIssueCounts struct {
+	MergedPRs    int    `json:"merged_prs"`
+	ClosedIssues int    `json:"closed_issues"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+// ComputePRIssueCounts fetches the total number of merged pull requests and
+// closed issues for the given repo via the GitHub Search API. It deliberately
+// counts every merged PR / closed issue in the repo (not just ones authored by
+// the AI agent) since the cost figure they're divided into is the spoke's
+// total spend, not a per-author subset.
+func (c *Client) ComputePRIssueCounts(ctx context.Context, repo string) (*PRIssueCounts, error) {
+	owner, repoName := c.splitRepo(repo)
+
+	merged, err := c.searchTotal(ctx, fmt.Sprintf("repo:%s/%s type:pr is:merged", owner, repoName))
+	if err != nil {
+		return nil, fmt.Errorf("counting merged PRs for %s/%s: %w", owner, repoName, err)
+	}
+
+	closed, err := c.searchTotal(ctx, fmt.Sprintf("repo:%s/%s type:issue is:closed", owner, repoName))
+	if err != nil {
+		return nil, fmt.Errorf("counting closed issues for %s/%s: %w", owner, repoName, err)
+	}
+
+	return &PRIssueCounts{
+		MergedPRs:    merged,
+		ClosedIssues: closed,
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// searchTotal runs a GitHub search-issues query and returns the reported total
+// count. PerPage is 1 since only the total is needed, not the items.
+func (c *Client) searchTotal(ctx context.Context, qualifier string) (int, error) {
+	result, _, err := c.client.Search.Issues(ctx, qualifier, &gh.SearchOptions{
+		ListOptions: gh.ListOptions{PerPage: 1},
+	})
+	if err != nil {
+		return 0, err
+	}
+	return result.GetTotal(), nil
+}

--- a/src/pkg/github/pr_issue_counts_test.go
+++ b/src/pkg/github/pr_issue_counts_test.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestComputePRIssueCounts(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		total := 0
+		switch {
+		case strings.Contains(q, "type:pr") && strings.Contains(q, "is:merged"):
+			total = 42
+		case strings.Contains(q, "type:issue") && strings.Contains(q, "is:closed"):
+			total = 17
+		default:
+			t.Fatalf("unexpected search query: %q", q)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": total,
+			"items":       []any{},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "org", []string{"repo1"})
+	counts, err := c.ComputePRIssueCounts(context.Background(), "repo1")
+	if err != nil {
+		t.Fatalf("ComputePRIssueCounts: %v", err)
+	}
+	if counts.MergedPRs != 42 {
+		t.Errorf("MergedPRs = %d, want 42", counts.MergedPRs)
+	}
+	if counts.ClosedIssues != 17 {
+		t.Errorf("ClosedIssues = %d, want 17", counts.ClosedIssues)
+	}
+	if counts.UpdatedAt == "" {
+		t.Error("UpdatedAt is empty")
+	}
+}
+
+func TestComputePRIssueCounts_OwnerPrefixedRepo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if !strings.Contains(q, "repo:otherorg/repo2") {
+			t.Errorf("query missing repo:otherorg/repo2 qualifier: %q", q)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "items": []any{}})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "org", []string{"repo1"})
+	counts, err := c.ComputePRIssueCounts(context.Background(), "otherorg/repo2")
+	if err != nil {
+		t.Fatalf("ComputePRIssueCounts: %v", err)
+	}
+	if counts.MergedPRs != 1 || counts.ClosedIssues != 1 {
+		t.Errorf("counts = %+v, want both 1", counts)
+	}
+}
+
+func TestComputePRIssueCounts_SearchError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "org", []string{"repo1"})
+	if _, err := c.ComputePRIssueCounts(context.Background(), "repo1"); err == nil {
+		t.Error("expected error when search API fails")
+	}
+}


### PR DESCRIPTION
## Summary

Adds two derived efficiency metrics to the dashboard's Cost section, per #4110:

- **Cost/PR** — all-time estimated cost total ÷ total merged PRs (primary repo)
- **Cost/Issue** — all-time estimated cost total ÷ total closed issues (primary repo)

## Design notes

- The counts are fetched via the GitHub Search API (`is:merged` / `is:closed`, no author filter — cost/PR and cost/issue are meant to reflect the spoke's overall output, not just AI-authored items) on the existing `MetricsCollector` 5-minute collection cycle, following the same pattern already used for MTTR (`collectMTTR` / `ghpkg.ComputeMTTR`): a new `ComputePRIssueCounts` method on the GitHub client, collected each cycle, cached to `/data/metrics/pr-issue-counts.json` so a restart doesn't lose the figure, and served through `GET /api/cost` (new `merged_prs` / `closed_issues` fields).
- Both new metrics are paired with the existing **all-time cumulative** total (`estimated.total_usd`), not a rolling window — since that's the scope of the aggregate figure they sit next to in the UI, this keeps numerator and denominator on the same window by construction (the issue's "same window" note applies when the aggregate itself is windowed, which it isn't here).
- Renders as `$X.XX` next to the existing "estimated total" tile; shows `—` when the denominator is zero, per the acceptance criteria.
- Works for both hub-managed and self-hosted spokes since it depends only on the GitHub client (not on which inference backend/gateway is configured).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/dashboard/... ./pkg/github/...`
- [x] `gofmt -l` on all changed files (clean)
- [x] `go test ./pkg/dashboard/... ./pkg/github/...` (full suite, including new tests for `ComputePRIssueCounts`, the `MetricsCollector` collect/cache wiring, and the `/api/cost` payload)
- [x] Verified the modified inline `<script>` block in `index.html` still parses (no JS syntax errors)

— hive: backend=claude