### PR TITLE
🌱 CI wall-clock: split the rest test shard — balanced buckets + intra-package pkg/agent slices (~8.3 → ~3 min)

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -20,27 +20,40 @@ permissions:
   contents: read
   issues: write
 
+# ── Sharding layout (#4118) ──────────────────────────────────────────────────
+# The suite is split so PR wall-clock ≈ the slowest single piece, not the sum.
+# Measured on CI (v4, ubuntu-latest, -short -race): pkg/hub ≈ 117s and
+# pkg/agent ≈ 429s of TEST time each — every other package is ≤ 51s and they
+# all run concurrently inside one `go test` invocation. Round-robin over the
+# 840 sorted agent test names measures a worst slice of ~127s at N=5. So:
+#
+#   test (hub)         ./pkg/hub/...          its own job, starts immediately
+#   test (agent i/N)   ./pkg/agent            N jobs, each running a
+#                                             deterministic 1/N slice of the
+#                                             package's test FUNCTIONS via -run
+#                                             (the package is a serial 429s
+#                                             monolith; package-level sharding
+#                                             cannot help it) — starts
+#                                             immediately, self-partitions
+#   list-packages      go list minus hub/agent, greedily bucketed by measured
+#                      weight into R balanced groups (job outputs → matrix)
+#   test (rest i/R)    one bucket each
+#
+# Every shard uses the exact same flags: -short -race -count=1 (untouched),
+# plus -coverprofile for the parse-only coverage gate below.
+#
+# Completeness invariants (nothing can be silently untested):
+#  - rest buckets are computed by EXCLUDING hub/agent from the full `go list`
+#    and PARTITIONING the remainder — a new package always lands in a bucket,
+#    a removed one just disappears from its bucket.
+#  - agent slices partition the sorted `go test -list` output round-robin —
+#    a new test function always lands in a slice. Anchored full-name regexes
+#    (^(A|B|...)$) make slices pairwise disjoint and jointly exhaustive.
+#  - the aggregate `test` job (the required-check name) fails closed: it
+#    requires list-packages AND every shard to succeed.
 jobs:
-  # The unit tests are sharded into two parallel jobs to cut PR wall-clock:
-  # ./pkg/hub is by far the largest single package (it alone dominates the
-  # serial run), so it gets a shard to itself and EVERYTHING ELSE runs in the
-  # other shard. The "rest" shard's package list is computed with `go list`
-  # by EXCLUDING pkg/hub — never by enumerating inclusions — so a newly added
-  # package always lands in a shard automatically and can never be silently
-  # untested. Both shards use the exact same flags as the old single job:
-  # -short -race -count=1.
-  #
-  # Each shard also emits -coverprofile from the SAME invocation. The
-  # `coverage` job below consumes those artifacts, so the per-package
-  # coverage-floor gate no longer needs its own duplicate test run on PRs
-  # (coverage-hourly.yml is schedule/dispatch-only now; its hourly monitoring
-  # and issue-filing behavior is unchanged).
-  test-shard:
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [hub, rest]
-    name: test (${{ matrix.shard }})
+  test-hub:
+    name: test (hub)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -53,30 +66,11 @@ jobs:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
 
-      # ./cmd/... is included deliberately. It used to be ./pkg/... only, so no
-      # workflow anywhere ran the cmd tests — v2-ci.yml builds and vets but does
-      # not test. Four cmd/bd tests were consequently merged already-failing and
-      # stayed red on the default branch, undetected, because nothing ever ran
-      # them. Fixing those tests without also running them just resets the same
-      # trap. All of ./cmd/... passes under -short -race.
       - name: Test
         run: |
           set -o pipefail
-          case "${{ matrix.shard }}" in
-            hub)
-              PKGS="./pkg/hub/..."
-              ;;
-            rest)
-              # Everything except pkg/hub (which the other shard runs).
-              # Exclusion, not enumeration: new packages are picked up here
-              # automatically. The anchored regex only drops pkg/hub and its
-              # subpackages — pkg/hubbackup et al. stay in this shard.
-              PKGS=$(go list ./pkg/... ./cmd/... | grep -Ev '^github\.com/kubestellar/hive/pkg/hub(/|$)')
-              ;;
-          esac
-          # shellcheck disable=SC2086 # PKGS is a deliberate word-split list
-          go test $PKGS -short -race -count=1 -coverprofile=coverage-${{ matrix.shard }}.out \
-            2>&1 | tee test-${{ matrix.shard }}.log
+          go test ./pkg/hub/... -short -race -count=1 -coverprofile=coverage-hub.out \
+            2>&1 | tee test-hub.log
 
       # Uploaded even on failure so the coverage job (and humans) can inspect
       # the raw `go test` output. `warn` not `error`: on a compile failure the
@@ -86,57 +80,245 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-shard-${{ matrix.shard }}
+          name: test-shard-hub
           path: |
-            src/coverage-${{ matrix.shard }}.out
-            src/test-${{ matrix.shard }}.log
+            src/coverage-hub.out
+            src/test-hub.log
           if-no-files-found: warn
           retention-days: 1
 
-  # Stable aggregate context named "test", preserved from the pre-shard job so
-  # anything keyed on the check name (branch protection, tide, humans' muscle
-  # memory) keeps working. Fails iff any shard failed.
-  test:
-    if: always()
+  # pkg/agent is a single package whose tests take ~429s serially on CI — it
+  # was the entire "rest" shard's wall clock. Package-granular sharding cannot
+  # split a package, so each of these jobs runs a deterministic 1/N slice of
+  # the package's test functions. The slice is computed INSIDE the job (no
+  # dependency on list-packages, so these start at t=0): every job derives the
+  # same sorted `go test -list` output from the same commit and takes rows
+  # where NR mod N == idx-1 — pairwise disjoint, jointly exhaustive, and a new
+  # test function always lands in exactly one slice. N is ${{ strategy.job-total }},
+  # so adding an index to the matrix rebalances automatically.
+  #
+  # Each slice produces a PARTIAL coverage profile for pkg/agent; the coverage
+  # job below merges them by summing per-block counts before scoring, so the
+  # agent floor is applied to the union, never to a partial run.
+  test-agent:
+    name: test (agent ${{ matrix.idx }}/5)
+    strategy:
+      fail-fast: false
+      matrix:
+        idx: [1, 2, 3, 4, 5]
     runs-on: ubuntu-latest
-    needs: test-shard
-    steps:
-      - name: Check shard results
-        run: |
-          result="${{ needs.test-shard.result }}"
-          echo "shard matrix result: $result"
-          [ "$result" = "success" ]
-
-  # Per-package coverage-floor gate, moved here from coverage-hourly.yml's
-  # pull_request trigger (#4112) so PRs run the test suite exactly ONCE: this
-  # job only parses the shard artifacts produced above — it runs no tests.
-  # PR-only: on the 15-minute schedule the hourly coverage workflow remains
-  # the monitoring + issue-filing authority.
-  coverage:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    needs: test-shard
     defaults:
       run:
         working-directory: src
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Needed only for `go tool cover -func`, which resolves the profile's
-      # file:line spans against the source tree to compute the total.
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
 
+      - name: Test slice of pkg/agent
+        env:
+          IDX: ${{ matrix.idx }}
+          TOTAL: ${{ strategy.job-total }}
+        run: |
+          set -o pipefail
+          # -list compiles the test binary (cached for the run below) and
+          # prints top-level Test/Example/Fuzz function names. All three kinds
+          # are included so none can fall out of every slice; Benchmarks are
+          # not run by `go test` without -bench, matching the unsharded run.
+          go test ./pkg/agent -short -list '.*' | grep -E '^(Test|Example|Fuzz)' | LC_ALL=C sort > all-tests.txt
+          if [ ! -s all-tests.txt ]; then
+            echo "::error::go test -list produced no test functions for pkg/agent — refusing to run an empty slice (fail closed)"
+            exit 1
+          fi
+          awk -v n="$TOTAL" -v i="$IDX" 'NR % n == i - 1' all-tests.txt > slice.txt
+          echo "slice $IDX/$TOTAL: $(wc -l < slice.txt) of $(wc -l < all-tests.txt) test functions"
+          RUN="^($(paste -sd'|' slice.txt))$"
+          go test ./pkg/agent -short -race -count=1 -run "$RUN" -coverprofile=coverage-agent-"$IDX".out \
+            2>&1 | tee test-agent-"$IDX".log
+
+      - name: Upload shard coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-shard-agent-${{ matrix.idx }}
+          path: |
+            src/coverage-agent-${{ matrix.idx }}.out
+            src/test-agent-${{ matrix.idx }}.log
+          if-no-files-found: warn
+          retention-days: 1
+
+  # Partition everything EXCEPT pkg/hub and pkg/agent (which have dedicated
+  # jobs above) into R balanced buckets, published as a matrix for test-rest.
+  # Greedy longest-processing-time assignment over static weight hints
+  # (measured seconds on CI under -short -race; unlisted packages default to
+  # 3s — they are all ≤ 8s). The hints only affect BALANCE, never MEMBERSHIP:
+  # a stale weight makes a bucket slower, not a package untested.
+  list-packages:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.partition.outputs.matrix }}
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache-dependency-path: src/go.sum
+
+      - name: Partition packages into balanced buckets
+        id: partition
+        run: |
+          R=3
+          # Anchored: drops pkg/hub and its subpackages (the hub job runs
+          # ./pkg/hub/...) and exactly pkg/agent (the agent jobs run it).
+          # pkg/hubbackup et al. stay here.
+          go list ./pkg/... ./cmd/... \
+            | grep -Ev '^github\.com/kubestellar/hive/pkg/hub(/|$)' \
+            | grep -Ev '^github\.com/kubestellar/hive/pkg/agent$' \
+            | LC_ALL=C sort > rest-pkgs.txt
+          if [ ! -s rest-pkgs.txt ]; then
+            echo "::error::go list produced no rest packages — failing closed"
+            exit 1
+          fi
+
+          weight() {
+            case "$1" in
+              */pkg/github)    echo 51 ;;
+              */pkg/dashboard) echo 48 ;;
+              */pkg/proxy)     echo 47 ;;
+              */pkg/hubbackup) echo 29 ;;
+              */pkg/config)    echo 23 ;;
+              */cmd/hive)      echo 16 ;;
+              */pkg/discord)   echo 15 ;;
+              *)               echo 3  ;;
+            esac
+          }
+
+          # Deterministic greedy LPT: stable-sort by weight desc (name asc on
+          # ties), assign each package to the currently lightest bucket
+          # (lowest index on ties).
+          while read -r p; do
+            echo "$(weight "$p") $p"
+          done < rest-pkgs.txt | sort -k1,1nr -k2,2 > weighted.txt
+
+          declare -a LOAD BUCKET
+          for ((i=0; i<R; i++)); do LOAD[i]=0; BUCKET[i]=""; done
+          while read -r w p; do
+            best=0
+            for ((i=1; i<R; i++)); do
+              if [ "${LOAD[i]}" -lt "${LOAD[best]}" ]; then best=$i; fi
+            done
+            BUCKET[best]="${BUCKET[best]} $p"
+            LOAD[best]=$(( LOAD[best] + w ))
+          done < weighted.txt
+
+          INCLUDE=""
+          for ((i=0; i<R; i++)); do
+            pkgs="${BUCKET[i]# }"
+            echo "bucket $((i+1))/$R (weight ${LOAD[i]}): $pkgs"
+            [ -n "$INCLUDE" ] && INCLUDE="$INCLUDE,"
+            INCLUDE="$INCLUDE{\"idx\":$((i+1)),\"total\":$R,\"pkgs\":\"$pkgs\"}"
+          done
+          echo "matrix={\"include\":[$INCLUDE]}" >> "$GITHUB_OUTPUT"
+
+  test-rest:
+    name: test (rest ${{ matrix.idx }}/${{ matrix.total }})
+    needs: list-packages
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.list-packages.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache-dependency-path: src/go.sum
+
+      # ./cmd/... is included in the partition deliberately. It used to be
+      # ./pkg/... only, so no workflow anywhere ran the cmd tests — four cmd/bd
+      # tests were consequently merged already-failing and stayed red on the
+      # default branch, undetected. All of ./cmd/... passes under -short -race.
+      - name: Test
+        env:
+          PKGS: ${{ matrix.pkgs }}
+        run: |
+          set -o pipefail
+          if [ -z "$PKGS" ]; then
+            echo "::error::empty package bucket — failing closed"
+            exit 1
+          fi
+          # shellcheck disable=SC2086 # PKGS is a deliberate word-split list
+          go test $PKGS -short -race -count=1 -coverprofile=coverage-rest-${{ matrix.idx }}.out \
+            2>&1 | tee test-rest-${{ matrix.idx }}.log
+
+      - name: Upload shard coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-shard-rest-${{ matrix.idx }}
+          path: |
+            src/coverage-rest-${{ matrix.idx }}.out
+            src/test-rest-${{ matrix.idx }}.log
+          if-no-files-found: warn
+          retention-days: 1
+
+  # Stable aggregate context named "test", preserved from the pre-shard job so
+  # anything keyed on the check name (branch protection, tide, humans' muscle
+  # memory) keeps working. Fails closed: every shard AND the partition job
+  # must succeed — a failed/skipped partition means packages may not have run.
+  test:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [list-packages, test-hub, test-agent, test-rest]
+    steps:
+      - name: Check shard results
+        run: |
+          echo "list-packages: ${{ needs.list-packages.result }}"
+          echo "test-hub:      ${{ needs.test-hub.result }}"
+          echo "test-agent:    ${{ needs.test-agent.result }}"
+          echo "test-rest:     ${{ needs.test-rest.result }}"
+          [ "${{ needs.list-packages.result }}" = "success" ]
+          [ "${{ needs.test-hub.result }}" = "success" ]
+          [ "${{ needs.test-agent.result }}" = "success" ]
+          [ "${{ needs.test-rest.result }}" = "success" ]
+
+  # Per-package coverage-floor gate (#4112): parse-only, consumes the shard
+  # artifacts — it runs no tests, so PRs run the suite exactly once. PR-only:
+  # on the 15-minute schedule the hourly coverage workflow remains the
+  # monitoring + issue-filing authority.
+  #
+  # Scoring is computed from the coverage PROFILES, not from the `ok ...
+  # coverage: X%` log lines: the agent slices each emit a PARTIAL percentage
+  # for pkg/agent, so per-block counts from ALL shard profiles are merged
+  # (summed) first and every package is scored on the union. For unsplit
+  # packages this yields the identical number `go test` prints. The logs are
+  # still parsed for the two states a profile cannot express: FAIL and
+  # `? ... [no test files]` — both hard failures, as before.
+  coverage:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [test-hub, test-agent, test-rest]
+    steps:
       - name: Download shard coverage artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: test-shard-*
-          path: src
+          path: shards
           merge-multiple: true
 
       - name: Check per-package coverage
+        working-directory: shards
         run: |
           THRESHOLD=90
           FAILED=""
@@ -178,64 +360,76 @@ jobs:
             [proxy]=89
           )
 
-          # The shard logs are the `go test -coverprofile` output of the ONE
-          # test run this PR gets; classify every line. Three cases matter:
-          #
-          #   ok    <pkg>  coverage: X.Y%   -> scored against its floor
-          #   FAIL  <pkg>                   -> hard failure (cannot be scored)
-          #   ?     <pkg>  [no test files]  -> hard failure (a package with zero
-          #                                    tests must never stay green)
-          #
-          # Only ./pkg/... is subject to floors, matching the historical gate
-          # (coverage-hourly measured ./pkg/... only); ./cmd/... lines from the
-          # rest shard are ignored here — the shards themselves already fail on
-          # any cmd test failure.
-          cat test-hub.log test-rest.log > cover-run.log
+          # Merge every shard profile: per-block counts are summed, so the N
+          # partial pkg/agent profiles combine into the package's true
+          # coverage. Blocks are keyed by (location, statement count); package
+          # = the directory of the block's file. Emits "pkg pct" lines plus a
+          # TOTAL over ./pkg/... — the same statements-covered/statements
+          # definition `go test -cover` prints, so floors are unchanged.
+          awk '
+            FNR == 1 { next }              # skip each file'\''s "mode:" line
+            {
+              file = $1; sub(/:[^:]*$/, "", file)
+              pkg = file; sub(/\/[^\/]+$/, "", pkg)
+              key = pkg "|" $1 "|" $2
+              stmts[key] = $2; owner[key] = pkg
+              count[key] += $3
+            }
+            END {
+              for (k in count) {
+                p = owner[k]
+                tot[p] += stmts[k]
+                if (count[k] > 0) cov[p] += stmts[k]
+              }
+              gt = 0; gc = 0
+              for (p in tot) {
+                printf "%s %.1f\n", p, cov[p] * 100 / tot[p]
+                if (p ~ /^github\.com\/kubestellar\/hive\/pkg\//) {
+                  gt += tot[p]; gc += cov[p]
+                }
+              }
+              if (gt > 0) printf "TOTAL %.1f\n", gc * 100 / gt
+            }
+          ' coverage-*.out > pkg-pcts.txt
 
-          while IFS= read -r line; do
-            case "$line" in
-              ok*|FAIL*|\?*)
-                pkgpath=$(echo "$line" | awk '{print $2}')
-                case "$pkgpath" in
-                  github.com/kubestellar/hive/pkg/*) ;;
-                  *) continue ;;
-                esac
-                ;;
-              *) continue ;;
-            esac
+          TOTAL=$(awk '$1 == "TOTAL" {print $2 "%"}' pkg-pcts.txt)
+          echo "Total coverage (./pkg/...): ${TOTAL:-unavailable}"
+
+          # Classify every package exactly once from the combined logs.
+          # Floors apply to ./pkg/... only, matching the historical gate
+          # (./cmd/... lines are ignored here; the shards themselves already
+          # fail on any cmd test failure).
+          cat test-*.log > cover-run.log
+          grep -E '^(ok|FAIL|\?)' cover-run.log \
+            | awk '$2 ~ /^github\.com\/kubestellar\/hive\/pkg\// {print $1, $2}' \
+            | LC_ALL=C sort -u > pkg-states.txt
+
+          while read -r state pkgpath; do
             pkg=${pkgpath##*/}
-            case "$line" in
-              ok*)
-                pct=$(echo "$line" | grep -o '[0-9]*\.[0-9]*%' | tr -d '%')
+            case "$state" in
+              ok)
+                # A package that also has a FAIL line anywhere is broken; the
+                # FAIL branch handles it. (An agent slice could be ok while
+                # another failed — but any FAIL also fails that shard job.)
+                pct=$(awk -v p="$pkgpath" '$1 == p {print $2}' pkg-pcts.txt)
                 if [ -z "$pct" ]; then continue; fi
-                int_pct=$(echo "$pct" | cut -d. -f1)
+                int_pct=${pct%.*}
                 pkg_threshold=${PKG_THRESHOLD[$pkg]:-$THRESHOLD}
                 if [ "$int_pct" -lt "$pkg_threshold" ]; then
                   FAILED="${FAILED}${pkg}: ${pct}% (floor ${pkg_threshold}%)\n"
                 fi
                 REPORT="${REPORT}${pkg}: ${pct}%\n"
                 ;;
-              FAIL*)
+              FAIL)
                 BROKEN="${BROKEN}${pkg}: TESTS FAILING\n"
                 REPORT="${REPORT}${pkg}: FAIL\n"
                 ;;
-              \?*)
+              \?)
                 BROKEN="${BROKEN}${pkg}: NO TEST FILES\n"
                 REPORT="${REPORT}${pkg}: no tests\n"
                 ;;
             esac
-          done < cover-run.log
-
-          # Combine the shard profiles into one for the total. The shards
-          # partition the package set (no overlap), so concatenation minus the
-          # duplicate mode: header is a valid merged profile. Restricting to
-          # pkg/ lines keeps the total comparable to the historical gate,
-          # which measured ./pkg/... only.
-          head -n 1 coverage-hub.out > coverage.out
-          grep -h '^github.com/kubestellar/hive/pkg/' coverage-hub.out coverage-rest.out >> coverage.out
-
-          TOTAL=$(go tool cover -func=coverage.out 2>/dev/null | grep '^total:' | awk '{print $3}')
-          echo "Total coverage: ${TOTAL:-unavailable}"
+          done < pkg-states.txt
 
           {
             echo "## Per-package coverage"
@@ -262,7 +456,7 @@ jobs:
   create-issue-on-failure:
     if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    needs: test-shard
+    needs: [list-packages, test-hub, test-agent, test-rest]
     permissions:
       contents: read
       issues: write
@@ -273,7 +467,13 @@ jobs:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sha = context.sha.substring(0, 7);
-            const wasCancelled = '${{ needs.test-shard.result }}' === 'cancelled';
+            const results = [
+              '${{ needs.test-hub.result }}',
+              '${{ needs.test-agent.result }}',
+              '${{ needs.test-rest.result }}',
+              '${{ needs.list-packages.result }}',
+            ];
+            const wasCancelled = results.includes('cancelled');
             const kind = wasCancelled ? 'cancelled (likely timed out)' : 'failure';
             const title = `[Tests] v2 test ${wasCancelled ? 'cancelled' : 'failure'} on ${sha}`;
 


### PR DESCRIPTION
Fixes #4118

## Why the plan changed shape (data)

Post-#4114 v4 data: `test (hub)` = 2.8 min, `test (rest)` = 8.1 min. Before splitting `rest` by package, I measured **per-package** times from the live v4 CI logs:

| package | CI test time |
|---|---|
| **pkg/agent** | **429.2s** |
| pkg/github | ~51s |
| pkg/dashboard | ~48s |
| pkg/proxy | ~47s |
| pkg/hubbackup | ~29s |
| everything else (50 pkgs) | ≤ 23s each |

`go test` already runs package test binaries concurrently within one job, so the rest shard's 8.1 min *was* pkg/agent's 429s + setup — **no package-level partition can ever beat ~7.5 min**. Three rest shards alone would have moved nothing. To hit ~3 min, pkg/agent (a single package, 840 serial test functions, no `t.Parallel`) has to be split *internally*.

## New layout (same flags everywhere: `-short -race -count=1`, untouched)

| job | what | starts |
|---|---|---|
| `test (hub)` | `./pkg/hub/...` (117s) | t=0 |
| `test (agent i/5)` ×5 | deterministic 1/5 slice of pkg/agent's test functions via `-run '^(A\|B\|…)$'` | t=0 (self-partitioning, no dependency) |
| `list-packages` | partitions `go list ./pkg/... ./cmd/...` minus hub/agent into 3 balanced buckets → matrix via job outputs | t=0 |
| `test (rest i/3)` ×3 | one bucket each | after list-packages (~40s) |
| `test` | aggregate required-check name; **fails closed** on any shard OR partition failure | end |
| `coverage` | parse-only gate over ALL shard artifacts (PR-only) | end |

**Agent slices** are round-robin (`NR % 5`) over the `LC_ALL=C`-sorted output of `go test -list '.*'`, computed inside each job from the same commit: pairwise disjoint, jointly exhaustive, and a new test function always lands in exactly one slice. `Test`/`Example`/`Fuzz` names are all included so nothing can fall out of every slice (pkg/agent currently has 840 Tests, 0 Examples/Fuzz); Benchmarks aren't run without `-bench`, matching the unsharded behavior. Fails closed if `-list` returns nothing. The slices are computed in-job rather than in `list-packages` deliberately: it removes a ~40–60s serial dependency from the critical path (the `-list` compile is free — it warms the same build cache the test run needs), and a partition bug still fails the shard, which fails the aggregate.

**Rest buckets** are built exactly as required: `list-packages` computes the full `go list` (minus `pkg/hub(/|$)` and exactly `pkg/agent`), then deterministic greedy LPT over static weight hints from the measured table above (unlisted packages weight 3). Weights affect **balance only, never membership** — a stale hint makes a bucket slower, not a package untested. Buckets land at weights 127/125/124 for the current 56 packages. Empty list ⇒ fail closed; empty bucket ⇒ shard fails closed.

**Coverage gate** now scores every package from the **merged profiles** (per-block count summation, block keyed by location+stmt-count, package derived from the block's file path) instead of the `ok … coverage: X%` log lines, because agent slices each print a *partial* percentage. For unsplit packages the merged number is mathematically identical to what `go test` prints (same statements-covered/statements definition). Same `PKG_THRESHOLD` floors, same hard failures for `FAIL` / `? [no test files]` from the logs, same step summary. Bonus: the job needs no checkout/setup-go anymore — pure artifact parsing.

`create-issue-on-failure` behavior unchanged (schedule-gated), now watching all shard jobs + partition, and reports "cancelled" if any of them was cancelled.

## Expected timings

- hub: ~2.9 min (unchanged, the new floor)
- agent slices: worst measured slice ≈ 127s local ≈ ~120s CI + ~70–100s setup/compile ⇒ ~3.2–3.5 min
- rest buckets: ~40s partition + ~2 min bucket ⇒ ~2.7 min end-to-end
- **PR gate: ~8.3 min → ~3–3.5 min** (bounded by hub / worst agent slice)

## Validated locally

- `actionlint` clean on the workflow.
- **Rest partition exact**: 3 buckets ∪ = the full 56-package `go list` output (58 total − hub − agent), `diff` clean, `sort -u` shows no duplicates; weights 127/125/124.
- **Agent slices exact**: 5 slices of the real 840-test list reunion to exactly the sorted full list (diff clean), 168 tests each.
- **Merge correctness**: pkg/tracing was split into 2 real slices producing partial profiles of **58.5%** and **78.6%**; the gate's awk merge scores it at exactly **86.0%** — the same number a full unsplit run prints. Floors, `FAIL`, `[no test files]`, and cmd/-line exclusion all verified against real+synthetic logs; happy path exits 0, violations exit 1.
- Per-test timing distribution measured with `go test -json` (826 passing tests, max single test 19.3s, sum 451s local) to pick N=5 (worst slice 127s) over N=3/4.

## What this PR's own CI run will prove

Live shard wall-clock for `test (agent i/5)` and `test (rest i/3)`, the artifact fan-in to the rewritten coverage job with 9 shards, and the aggregate `test` check. (This workflow file is in the PR's `paths`, so the run triggers here.)
