### PR TITLE
🌱 ci(docker): drop broken Go cache transport, scope gha layer cache to tmux-builder stage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,42 +92,40 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
 
-      # src/Dockerfile's Go steps use BuildKit cache mounts (id=hive-go-build /
-      # hive-go-mod) so the always-re-executed compile (no-cache-filters, the
-      # #3760 defense) is incremental instead of from-scratch. Cache MOUNT
-      # contents are NOT transported by cache-from/cache-to type=gha — the gha
-      # backend only carries layer cache (moby/buildkit#1512) — so on an
-      # ephemeral runner the mounts would start empty every build. Persist them
-      # with actions/cache plus the inject/extract helper builds below.
-      # Key on the commit with a slug-scoped restore-key so every build saves
-      # its warmed cache and the next one starts from the newest prior state.
-      - name: Restore Go compile caches
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ runner.temp }}/gocache
-          key: docker-gocache-${{ steps.slug.outputs.slug }}-${{ github.sha }}
-          restore-keys: |
-            docker-gocache-${{ steps.slug.outputs.slug }}-
-
-      # Copy the restored host directories INTO the builder's cache mounts.
-      # Uses the same digest-pinned golang image as src/Dockerfile's builder
-      # stage (no new supply-chain surface). --no-cache: these two throwaway
-      # builds must always execute; the cache mounts themselves are unaffected
-      # by layer-cache settings. continue-on-error: this is a pure
-      # optimization — if injection breaks, the mounts start empty and the
-      # build is merely slower, so it must never block publishing an image.
-      - name: Inject Go caches into BuildKit cache mounts
+      # NOTE on Go compile caching (removed actions/cache transport, #4114):
+      # measurement showed the Go compile in this image is only ~25-50s, and
+      # the inject/extract transport never worked — every extract found the
+      # cache mounts empty (each actions/cache save was 273 bytes), so every
+      # "warm" run was actually cold while paying the transport's fixed cost.
+      # src/Dockerfile keeps its BuildKit cache mounts (free, and a no-op when
+      # empty) so any future runner-local BuildKit state still benefits, but we
+      # no longer round-trip them through actions/cache.
+      #
+      # LAYER CACHE STRATEGY: `no-cache-filters: builder,runtime` (the #3760
+      # stale-binary defense, see below) forces every layer of the builder and
+      # runtime stages to re-execute on every build — so a whole-image
+      # `cache-to: type=gha,mode=max` export bought almost nothing while
+      # costing 2-4 minutes per job to upload multi-GB layer sets. The ONLY
+      # stage that can legitimately be served from cache is `tmux-builder`
+      # (pinned base image + pinned tmux tarball; not listed in
+      # no-cache-filters). Warm exactly that stage: a targeted `--target
+      # tmux-builder` build seeds the builder's local layer cache from a small
+      # dedicated gha scope (and refreshes it with mode=max — cheap, tmux-stage
+      # layers only). The main build then hits those layers locally and does
+      # NO cache export at all. continue-on-error: pure optimization — if the
+      # gha cache service hiccups, the main build just recompiles tmux.
+      - name: Warm tmux-builder layer cache
         continue-on-error: true
-        run: |
-          mkdir -p "${{ runner.temp }}/gocache/go-build" "${{ runner.temp }}/gocache/go-mod"
-          docker buildx build --no-cache --file - "${{ runner.temp }}/gocache" <<'EOF'
-          FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83
-          COPY . /cache-in
-          RUN --mount=type=cache,id=hive-go-build,target=/cache/go-build \
-              --mount=type=cache,id=hive-go-mod,target=/cache/go-mod \
-              cp -a /cache-in/go-build/. /cache/go-build/ && \
-              cp -a /cache-in/go-mod/. /cache/go-mod/
-          EOF
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: src/Dockerfile
+          platforms: ${{ matrix.platform }}
+          target: tmux-builder
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=tmux-${{ steps.slug.outputs.slug }}
+          cache-to: type=gha,scope=tmux-${{ steps.slug.outputs.slug }},mode=max
 
       - name: Build and push by digest
         id: build
@@ -140,9 +138,7 @@ jobs:
             GIT_HASH=${{ github.sha }}
             GIT_BRANCH=${{ github.ref_name }}
           # STALE-BINARY FIX (unblocks the #3760 fix in the SHIPPED image).
-          # The GHA cache scope below is keyed on the platform slug only
-          # (linux-amd64 / linux-arm64), NOT the commit — so it persists across
-          # every commit on the branch. `no-cache-filters: builder` alone rebuilt
+          # `no-cache-filters: builder` alone rebuilt
           # a fresh /hive in the `builder` stage but let BuildKit serve the FINAL
           # (`runtime`) stage's `COPY --from=builder /hive` layer AND the
           # subsequent fresh-inode rewrite RUN from that persistent cache — so the
@@ -170,27 +166,11 @@ jobs:
           # branch build without pushing so the image is still validated (CI
           # gate) but nothing lands on GHCR.
           outputs: type=image,name=ghcr.io/kubestellar/hive,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
-          cache-from: type=gha,scope=${{ steps.slug.outputs.slug }}
-          cache-to: type=gha,scope=${{ steps.slug.outputs.slug }},mode=max
-
-      # Copy the (now warmed) cache mounts back OUT to the host so the
-      # actions/cache post step persists them for the next build. Runs before
-      # the freshness probe so a probe failure still saves the compile cache.
-      # continue-on-error: cache plumbing must never block publishing.
-      - name: Extract Go caches from BuildKit cache mounts
-        continue-on-error: true
-        run: |
-          rm -rf "${{ runner.temp }}/gocache" && mkdir -p "${{ runner.temp }}/gocache"
-          docker buildx build --no-cache --file - --output "type=local,dest=${{ runner.temp }}/gocache" "${{ runner.temp }}/gocache" <<'EOF'
-          FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS collect
-          RUN --mount=type=cache,id=hive-go-build,target=/cache/go-build \
-              --mount=type=cache,id=hive-go-mod,target=/cache/go-mod \
-              mkdir -p /out/go-build /out/go-mod && \
-              cp -a /cache/go-build/. /out/go-build/ && \
-              cp -a /cache/go-mod/. /out/go-mod/
-          FROM scratch
-          COPY --from=collect /out/ /
-          EOF
+          # tmux-builder layers come from the local cache warmed above; every
+          # other stage is forced to re-execute by no-cache-filters, so there
+          # is nothing worth exporting — deliberately NO cache-to here (the
+          # whole-image mode=max export measured 130-225s per job for ~0 reuse)
+          cache-from: type=gha,scope=tmux-${{ steps.slug.outputs.slug }}
 
       # FRESHNESS ASSERTION (#3760 regression guard): run the image this job
       # just produced and assert the ldflags-embedded commit equals the commit


### PR DESCRIPTION
Fixes #4121

## Problem

Warm-cache v4 pushes after #4114 showed **zero net win** (7.5 min vs ~5.5–6 pre-merge). Step-level log analysis of the `build` jobs:

### amd64 `build` job breakdown

| Step | pre-#4114 (95905175780) | post cold (95910019043) | post "warm" (95914522115) |
|---|---|---|---|
| Job total | 5:49 | 7:10 | 6:59 |
| actions/cache restore | — | 0s (miss) | 0s (hit, **273 B**) |
| Inject helper build | — | 6s | 5s |
| Build and push by digest | 5:31 | 5:53 | 5:41 |
| … Go compile (`builder 8/8`) | 46.4s | 24.4s | **52.4s — still cold** |
| … `cache-to: type=gha,mode=max` export | **129.9s** | **225.3s** | **170.2s** |
| … export+push image layers | 50.2s | 51.2s | 74.7s |
| Extract helper build | — | 0.4s (**54 B** copied) | 0.4s (**54 B** copied) |
| actions/cache save | — | 1s (272 B) | 1s (273 B) |
| Freshness probe (pull+run pushed digest) | — | 48s | 48s |

## Root cause

1. **The cache-mount transport never transported anything.** Every extract found the `hive-go-build`/`hive-go-mod` mounts empty immediately after the build warmed them on the same builder — every actions/cache save was 272–273 bytes, so every run compiled cold. Most likely BuildKit GC in the ephemeral builder evicts the `exec.cachemount` records under the disk pressure of the multi-GB `mode=max` export that runs between compile and extract.
2. **Even working, it can't win**: the Go compile is only 24–52s; round-tripping a multi-hundred-MB GOCACHE through actions/cache + helper builds costs more than it saves.
3. **Pre-existing waste exposed by the measurement**: `cache-to: type=gha,mode=max` uploads the full layer set for 130–225s/job, but `no-cache-filters: builder,runtime` (the #3760 defense — kept) forces all of those layers to re-execute anyway. The only stage the layer cache can serve is `tmux-builder`.

## Fix (both hard constraints kept verbatim)

- `no-cache-filters: builder,runtime` — **unchanged**.
- Freshness guard (embedded commit == `github.sha`, pushed-digest probe on push, `--load` rebuild on PR) — **unchanged**.
- Removed: actions/cache restore/save + inject/extract helper builds (~10s fixed cost, 0 benefit).
- Replaced whole-image `cache-from/cache-to type=gha,mode=max` with a targeted `--target tmux-builder` warm build (`continue-on-error`) against a small `tmux-<slug>` gha scope; the main build reads that scope and exports **no** cache. Warm case: seconds. Cold case: one tmux compile + tiny export.
- `src/Dockerfile` cache mounts stay — free, no-op when empty, and preserve any future runner-local caching.

## Expected timings

| | before (current v4) | after |
|---|---|---|
| amd64 build job | ~7:00 | **~4:45–5:30** (drops 170–225s export + ~10s transport) |
| whole workflow | ~7.5 min | **~5–5.5 min** (beats the pre-#4114 baseline even with the 48s probe retained) |

## Validation

- `actionlint`: clean on changed job (remaining SC2046 warnings are pre-existing in the untouched merge jobs).
- No local Docker daemon available in this environment, so no local buildx run; the first v4 push after merge will confirm timings.
