### PR TITLE
🔒 fix(ci): add explicit permissions blocks to prune-ghcr and dashboard-lint workflows

### DIFF
--- a/.github/workflows/dashboard-lint.yml
+++ b/.github/workflows/dashboard-lint.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'dashboard/**'
 
+permissions:
+  contents: read
+
 jobs:
   syntax-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/prune-ghcr.yml
+++ b/.github/workflows/prune-ghcr.yml
@@ -20,6 +20,10 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+  packages: read  # only to list versions; deletion uses GHCR_PRUNE_TOKEN
+
 jobs:
   prune:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit minimal top-level `permissions:` blocks to `.github/workflows/prune-ghcr.yml` and `.github/workflows/dashboard-lint.yml`.

## Changes

- `.github/workflows/prune-ghcr.yml`: Add top-level `permissions: { contents: read, packages: read }` to restrict `GITHUB_TOKEN` to read-only access (package version deletion uses `GHCR_PRUNE_TOKEN`).
- `.github/workflows/dashboard-lint.yml`: Add top-level `permissions: { contents: read }` required by `actions/checkout`.

## Security Rationale

When workflows lack an explicit `permissions:` block, `GITHUB_TOKEN` inherits default repository or organization permissions, which may grant broader access (such as `write-all`) than needed. Declaring minimal permissions enforces the principle of least privilege and hardens workflow execution.

Closes #4126

---
Gemini 3.7 flash high reasoning

— hive: backend=agy