### PR TITLE
🐛 fix(relay): let agy idle detection cross the input box's closing rule

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1409,8 +1409,20 @@ function classifyTmuxPane(text) {
     // builds render a bare input line followed by the model footer instead.
     // Keep the bare ">" constrained to that footer so a Markdown quote in
     // an in-flight response cannot be mistaken for an idle prompt.
+    //
+    // The input box is CLOSED by a second box-drawing rule between the ">" and
+    // the footer, so the gap is not pure whitespace and "\s*" cannot cross it.
+    // Observed live: a turn that finished and opened kubestellar/hive#4127 sat
+    // at this exact idle chrome, classified WORKING, and was killed 20 minutes
+    // later by the progressTick() stall backstop and reported as an
+    // `environment` FAILURE — for a task that had shipped a real PR. Allow the
+    // rule character (U+2500) in the gap so the footer is reachable.
+    //
+    // Safety direction is preserved by the footer itself: while a turn is in
+    // flight agy renders "esc to cancel" on that same line, which is neither
+    // whitespace nor a rule, so a busy pane still cannot match here.
     hasIdlePrompt = /\? for shortcuts/.test(text) ||
-      /(?:^|\n)>\s*\n\s*\n\s*Gemini\b[^\n]*\s*$/m.test(agyTail);
+      /(?:^|\n)>\s*\n[\s─]*\n?\s*Gemini\b[^\n]*\s*$/m.test(agyTail);
     hasCompletionMarker = true;
     isWorking = /Running|Searching|Reading|Writing|Editing/i.test(agyTail);
   } else {

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -246,9 +246,16 @@ const AGY_WEDGED_PANE = [
   '? for shortcuts',
 ].join('\n');
 
-// Live agy/Gemini pane after opening kubestellar/hive#4079. Newer builds no
-// longer print "? for shortcuts" at rest: their idle chrome is a bare input
-// prompt followed by the selected-model footer.
+// Live agy/Gemini pane after opening a PR. Newer builds no longer print
+// "? for shortcuts" at rest: their idle chrome is a bare input prompt followed
+// by the selected-model footer. The chrome below (both rules, the blank rows,
+// and the right-aligned footer) is reproduced from a real
+// `tmux capture-pane -p` of a finished turn; the PR line stays synthetic
+// because a sibling test asserts URL extraction against it.
+//
+// The earlier version of this fixture omitted the rule that CLOSES the input
+// box, and the footer padding, so it matched a regex that the real pane did
+// not. That is how the wedge below shipped green.
 const AGY_GEMINI_IDLE_PANE = [
   '● Bash(gh pr create --repo kubestellar/hive ...)',
   ...Array.from({ length: 20 }, (_, i) => `  completed test step ${i}`),
@@ -257,7 +264,25 @@ const AGY_GEMINI_IDLE_PANE = [
   '────────────────────────────────────────────',
   '>',
   '',
-  'Gemini 3.7 Flash · high',
+  '',
+  '────────────────────────────────────────────',
+  '                                        Gemini 3.7 Flash · high',
+].join('\n');
+
+// The same pane while the turn is still IN FLIGHT. agy replaces the idle hint
+// with "esc to cancel" on the footer line, so this must NOT read as idle: a
+// busy agent reported complete is the worse direction of this bug.
+const AGY_GEMINI_WORKING_PANE = [
+  '● Read(/home/dev/workspace/kubestellar/hive/.github/workflows/prune-ghcr.yml)',
+  '● Edit(/home/dev/workspace/kubestellar/hive/.github/workflows/prune-ghcr.yml) (ctrl+o to expand)',
+  '⣷  Editing files...',
+  '└ Tip: Use /diff to view uncommitted changes in your workspace.',
+  '────────────────────────────────────────────',
+  '>',
+  '',
+  '',
+  '────────────────────────────────────────────',
+  'esc to cancel                           Gemini 3.7 Flash · high',
 ].join('\n');
 
 // --- CLI liveness: ask the PANE, not the process table --------------------
@@ -356,6 +381,32 @@ test('agy Gemini footer with a bare prompt is COMPLETE', () => {
     assert.strictEqual(
       relay.classifyTmuxPane(AGY_GEMINI_IDLE_PANE), relay.PANE_STATE_IDLE_COMPLETE,
       'a finished current agy/Gemini pane must not remain working because its old footer changed');
+  } finally { teardown(relay); }
+});
+
+// Regression for the wedge that shipped past the fixture above: the input box
+// is closed by a second rule, so the gap between ">" and the footer is not pure
+// whitespace. Live, this classified WORKING after the turn opened
+// kubestellar/hive#4127, and the stall backstop failed the task 20 minutes
+// later as `environment` — a shipped PR recorded as a failure.
+test('agy idle pane with a closing rule under the input box is COMPLETE', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    assert.strictEqual(
+      relay.classifyTmuxPane(AGY_GEMINI_IDLE_PANE), relay.PANE_STATE_IDLE_COMPLETE,
+      'the rule closing agy\'s input box must not hide the model footer');
+  } finally { teardown(relay); }
+});
+
+// The opposite direction, and the one that must never regress: an in-flight
+// turn renders "esc to cancel" on the footer line. Reporting THAT complete
+// would hand the hub a half-done task and abandon real work.
+test('agy pane still working ("esc to cancel") is not COMPLETE', () => {
+  const relay = loadRelay({ backend: 'agy' });
+  try {
+    assert.notStrictEqual(
+      relay.classifyTmuxPane(AGY_GEMINI_WORKING_PANE), relay.PANE_STATE_IDLE_COMPLETE,
+      'an in-flight agy turn must never be reported as a finished one');
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
## Problem

A contributor relay on the `agy` backend reports every **successful** task as a failure.

Observed live on this repo. A task read #4126, edited both workflows, pushed a branch and opened **#4127** — then sat at agy's idle prompt for 20 minutes until the `progressTick()` stall backstop killed it:

```
Pane unchanged for 20+ minutes — confirming before giving up on ct-kubestellar/hive-4126-1787145194 (1/2)
Relaunching agy after a confirmed pane stall: agy --dangerously-skip-permissions
Task ct-kubestellar/hive-4126-1787145194 failed [environment]: no pane activity for 20+ minutes,
  confirmed over 2 checks — the agent CLI is not visibly working
```

A shipped PR booked as an `environment` failure is not just log noise:

- the contributor loses the completed-task credit that **tier promotion** is counted from, so they cannot progress toward the tiers that gate delegated roles;
- the issue accrues **consecutive-failure weight** toward the 6-hour quarantine (`consecutiveFailureQuarantineThreshold`) while already being solved;
- ~20 minutes of lease is burned per task, plus a CLI relaunch.

## Root cause

#4080 taught the classifier agy's newer idle chrome — a bare `>` followed by the model footer. But agy **closes** its input box with a second box-drawing rule, so the real pane is:

```
────────────────────────────────
>


────────────────────────────────
                    Gemini 3.7 Flash · high
```

`U+2500` is not whitespace, so `\s*` in

```js
/(?:^|\n)>\s*\n\s*\n\s*Gemini\b[^\n]*\s*$/m
```

can never reach the footer. `hasIdlePrompt` stays false, `classifyTmuxPane()` falls through to `return PANE_STATE_WORKING`, and the relay renews the hub's lease on an agent that finished minutes ago. The pane never changes again, so the stall backstop is the only exit — and it exits as a failure.

Verified by running the shipped classifier against a live `tmux capture-pane -p` of the finished #4127 turn: `state: WORKING, hasIdlePrompt: false`.

## Why CI did not catch it

`AGY_GEMINI_IDLE_PANE` omitted the closing rule and the footer padding, so the fixture matched a regex the real pane did not. The fixture is now reproduced from a live capture, and **that pre-existing test fails without this change**.

## Fix

Allow the rule character in the gap between `>` and the footer.

Safety direction is preserved by the footer itself: while a turn is in flight agy renders `esc to cancel` on that same line, which is neither whitespace nor a rule, so a busy pane still cannot match. That direction — reporting a working agent as complete, the worse bug — is now pinned by its own test.

## Tests

`node --test bin/contributor-relay.test.js` → **109/109**. With `bin/contributor-relay.sh` reverted to the current `v4` blob:

```
FAIL agy Gemini footer with a bare prompt is COMPLETE
FAIL agy idle pane with a closing rule under the input box is COMPLETE
ok   agy pane still working ("esc to cancel") is not COMPLETE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)