### PR TITLE
✨ backup: make the backup encryption key configurable via Governor config (fixes #4129)

### DIFF
--- a/docs/HUB_DISASTER_RECOVERY.md
+++ b/docs/HUB_DISASTER_RECOVERY.md
@@ -481,9 +481,15 @@ in.
 The archive contains GitHub App private keys, so it is **always** sealed with
 AES-256-GCM using the same code path as the hub backup.
 
-- The key comes from **`HIVE_BACKUP_KEY`** on the spoke, with **no default**.
-  If it is unset the endpoint returns `412 Precondition Failed` and refuses —
-  it never streams plaintext credentials to a browser.
+- The key comes from **governor config** (`governor.backup.key_file`, set by the
+  hive owner in the dashboard under **Governor Config → Security → Backup**), or
+  from **`HIVE_BACKUP_KEY`** on the spoke as a fallback. There is **no default**.
+  Governor config exists because hosted spoke owners have no deployment-env
+  access, so an env-only key made backup unavailable to them (#4129). The value
+  is written to `/data/secrets/backup_encryption_key` (mode `0600`); `hive.yaml`
+  records the path only, and the value is never returned by an API or logged.
+  If no source supplies a key the endpoint returns `412 Precondition Failed` and
+  refuses — it never streams plaintext credentials to a browser.
 - The key is **not in the archive** and is not derivable from it. An artifact
   carrying its own decryption key is not encrypted. The owner must have the key
   escrowed separately, or the backup is unreadable.
@@ -491,7 +497,9 @@ AES-256-GCM using the same code path as the hub backup.
   it cannot be pulled by a cross-origin navigation or `<img>` tag.
 
 The UI states plainly that the file is encrypted and that the key is not
-included.
+included, and a `412` refusal deep-links the owner to the Governor Config panel
+where they can set the key themselves. Clearing the key from that panel restores
+the refusal — there is no path that produces an unencrypted archive.
 
 ## Authorization
 
@@ -509,7 +517,9 @@ control. The archive shares the hub format, so the same tooling reads it.
 ```bash
 # 0. Decrypt and verify. Uses the SAME archive format as the hub backup,
 #    so hive-backup verifies and extracts it unchanged.
-export HIVE_BACKUP_KEY=<the key escrowed for THIS hive>
+export HIVE_BACKUP_KEY=<the key escrowed for THIS hive — the same value set in
+                        Governor Config → Security → Backup, if that is where
+                        it was configured>
 hive-backup verify -file hive-spoke-backup-<id>-<ts>.tar.gz.enc
 hive-backup extract -file hive-spoke-backup-<id>-<ts>.tar.gz.enc -dest ./restore
 
@@ -585,8 +595,11 @@ ownership to match the surrounding directories rather than loosening the mode.
   build refuses with no key; missing files recorded rather than silently
   dropped; hostile hive IDs cannot escape the filename.
 - Handler tests cover: `403` for `read`/`read-write`/`write`/`viewer` on both
-  endpoints, `412` with no `HIVE_BACKUP_KEY` and no download offered,
-  `no-store` caching, and an `.enc` attachment.
+  endpoints and on all three backup-key config endpoints, `412` with no key from
+  any source and no download offered, `no-store` caching, an `.enc` attachment,
+  a backup that succeeds (and decrypts) with a key set only through governor
+  config, a `412` again after the key is cleared, and no key value in any
+  response, in `hive.yaml`, or in the stored config struct.
 - Archives are extracted through `hubbackup.Extract`, proving both backups
   share one format and one restore path.
 - Spoke layout, `hive.yaml`/`hive.yaml.runtime` divergence, bead directory names

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -25,7 +25,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Public snapshots](https://github.com/kubestellar/hive/blob/v4/src/docs/snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [`bd` beads CLI](https://github.com/kubestellar/hive/blob/v4/src/docs/beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
-- [Backup and restore](https://github.com/kubestellar/hive/blob/v4/src/docs/backup-restore.md) — `hive-backup`, Kubernetes CronJob, and spoke backup scope.
+- [Backup and restore](https://github.com/kubestellar/hive/blob/v4/src/docs/backup-restore.md) — `hive-backup`, Kubernetes CronJob, spoke backup scope, and setting the backup encryption key from Governor Config (hosted flow).
 - [Deployment helper scripts](https://github.com/kubestellar/hive/blob/v4/src/docs/deployment-scripts.md) — Proxmox LXC and blue-green Compose helpers.
 - [`bin/` pipeline script index](https://github.com/kubestellar/hive/blob/v4/bin/README.md) — map of the 45 deterministic pipeline and operational shell/Python scripts, grouped by function.
 - [Dashboard API reference](https://github.com/kubestellar/hive/blob/v4/src/docs/api-reference.md) — pragmatic route index for dashboard and hub endpoints.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -55,7 +55,7 @@ Read the tree top to bottom and you can answer "who set this?" for any value:
 
 - **The platform owns the seed.** In Kubernetes, an init container re-copies the ConfigMap to `/etc/hive/hive.yaml` on every boot. The entrypoint then merges the dashboard overlay over it — but the ConfigMap stays authoritative for the hub/admin-managed keys (`acmm_level`, `hub.is_public`).
 - **You (via the dashboard) own the overlay.** Every dashboard save writes `/data/hive.yaml.dashboard`, so a LiteLLM endpoint or agent tweak survives pod restarts and upgrades.
-- **Secrets never enter YAML.** `hive.yaml` stores only env var *names* (`api_key_env`) and key file *paths* (`api_key_file`) — never key values. Values live in `/data/secrets/` (dashboard-entered) or `/secrets/` (Kubernetes Secret mounts). Because `Config.Save()` writes the whole config back to disk, a key value in YAML would be persisted in plaintext — so the code refuses the pattern entirely.
+- **Secrets never enter YAML.** `hive.yaml` stores only env var *names* (`api_key_env`) and key file *paths* (`api_key_file`, `governor.backup.key_file`) — never key values. Values live in `/data/secrets/` (dashboard-entered) or `/secrets/` (Kubernetes Secret mounts). Because `Config.Save()` writes the whole config back to disk, a key value in YAML would be persisted in plaintext — so the code refuses the pattern entirely.
 
 ## Anatomy of an agent
 

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -90,6 +90,9 @@ Auth levels are derived from dashboard middleware (`isPublicPath`, dashboard tok
 | `PUT` | `/api/config/governor/hub` | Dashboard auth/session | Governor Hub | `pkg/dashboard/api.go:130` |
 | `PUT` | `/api/config/governor/litellm` | Dashboard auth/session | Governor Lite LLM | `pkg/dashboard/api.go:131` |
 | `PUT` | `/api/config/governor/trajectory` | Dashboard auth/session | Governor Trajectory | `pkg/dashboard/api.go:132` |
+| `GET` | `/api/config/governor/backup` | Owner only | Backup Key Status (presence + safe source label; never the key value) | `pkg/dashboard/backup_key.go` |
+| `PUT` | `/api/config/governor/backup` | Owner only | Backup Key Set (64-hex AES-256 key; stored 0600, path-only in `hive.yaml`) | `pkg/dashboard/backup_key.go` |
+| `DELETE` | `/api/config/governor/backup` | Owner only | Backup Key Clear (backups are refused again) | `pkg/dashboard/backup_key.go` |
 | `GET` | `/api/config/governor/bob` | Dashboard auth/session | Governor Bob Status | `pkg/dashboard/api.go:136` |
 | `PUT` | `/api/config/governor/bob` | Dashboard auth/session | Governor Bob Key | `pkg/dashboard/api.go:137` |
 | `DELETE` | `/api/config/governor/bob` | Dashboard auth/session | Governor Bob Key Clear | `pkg/dashboard/api.go:138` |
@@ -319,8 +322,8 @@ always resolved server-side from the validated token.
 | `POST` | `/api/presence` | Dashboard auth/session | Presence | `pkg/dashboard/api.go:48` |
 | `GET` | `/api/prompt-history` | Dashboard auth/session | Prompt History | `pkg/dashboard/api.go:49` |
 | `POST` | `/api/self-upgrade` | Dashboard auth/session | Self Upgrade | `pkg/dashboard/api.go:50` |
-| `GET` | `/api/backup/status` | Dashboard auth/session | Backup Status | `pkg/dashboard/api.go:53` |
-| `POST` | `/api/backup` | Dashboard auth/session | Backup Download | `pkg/dashboard/api.go:54` |
+| `GET` | `/api/backup/status` | Owner only | Backup Status — `available:false` with a reason when no encryption key is configured | `pkg/dashboard/api.go:53` |
+| `POST` | `/api/backup` | Owner only | Backup Download — `412` when no encryption key is configured (never an unencrypted archive) | `pkg/dashboard/api.go:54` |
 | `POST` | `/api/banner-dismissed` | Dashboard auth/session | Banner Dismissed | `pkg/dashboard/api.go:55` |
 | `GET` | `/api/history` | Dashboard auth/session | History | `pkg/dashboard/api.go:59` |
 | `GET` | `/api/timeline` | Dashboard auth/session | Timeline | `pkg/dashboard/api.go:61` |

--- a/src/docs/backup-restore.md
+++ b/src/docs/backup-restore.md
@@ -63,7 +63,33 @@ Before applying it, create Secret `hive-hub-backup-key` with key `backup-key`, e
 
 ## Owner-triggered spoke backup
 
-`pkg/spokebackup` is complementary: it backs up one spoke on demand for its owner and includes the spoke's bead ledger. It is encrypted with the same `HIVE_BACKUP_KEY` mechanism and is sized for browser download, not nightly fleet DR. It includes `hive.yaml.dashboard`, runtime config files, `hive-id`, `hive-state.json`, GitHub App keys, and `/data/beads/*`; it skips bulk/derived data and live dashboard sessions.
+`pkg/spokebackup` is complementary: it backs up one spoke on demand for its owner and includes the spoke's bead ledger. It uses the same AES-256-GCM sealing as the hub path and is sized for browser download, not nightly fleet DR. It includes `hive.yaml.dashboard`, runtime config files, `hive-id`, `hive-state.json`, GitHub App keys, and `/data/beads/*`; it skips bulk/derived data and live dashboard sessions.
+
+### Setting the backup encryption key (hosted flow)
+
+A hive owner sets the key from the dashboard: **Governor Config → Security → Backup → Set key**. This is the supported path for hosted hives, whose owners have no deployment-env or cluster access.
+
+```bash
+openssl rand -hex 32   # paste the 64-hex-character result into the dialog
+```
+
+What happens on save:
+
+- the value is written to `/data/secrets/backup_encryption_key`, mode `0600`;
+- `hive.yaml` records only the **path** (`governor.backup.key_file`) and the optional label (`governor.backup.key_name`) — never the value;
+- the key never appears in an API response, in a log line, or in the archive itself.
+
+Resolution order at backup time is governor config first, then the environment:
+
+1. `governor.backup.key_file` (set by the dialog above);
+2. `/data/secrets/backup_encryption_key` (the PVC default);
+3. `/secrets/backup_encryption_key` (an admin-managed Kubernetes Secret mount);
+4. `governor.backup.key_env`, if named;
+5. `HIVE_BACKUP_KEY` on the deployment — the original path, still supported.
+
+**Security note.** There is no default key and no plaintext fallback: with no key from any source, `GET /api/backup/status` reports `available: false` and `POST /api/backup` returns `412` — a backup is refused rather than written unencrypted, because the archive carries this hive's GitHub App private keys. Clearing the key (**Clear key** in the same panel) restores that refusal.
+
+**Escrow the key.** It is not stored inside the archive, so a backup without its key is unrestorable. Replacing the key does not re-encrypt existing archives; keep the old key to restore them.
 
 ## Docker Compose
 
@@ -101,7 +127,13 @@ The `pkg/spokebackup` path works for a Compose spoke. It reads the data director
 - `GET /api/backup/status` reports whether a backup can run.
 - `POST /api/backup` builds and streams an encrypted archive.
 
-Both endpoints are owner-only. They require the `X-Hive-Role: owner` header. They require `HIVE_BACKUP_KEY` in the container environment, a 64-character hex AES-256 key. The shipped compose files do not pass `HIVE_BACKUP_KEY`. Add it to `.env` and add `HIVE_BACKUP_KEY=${HIVE_BACKUP_KEY}` to the `environment` block of the `hive` service.
+Both endpoints are owner-only. They require the `X-Hive-Role: owner` header. They require a 64-character hex AES-256 key from either source: set it from **Governor Config → Security → Backup** (stored on the `/data` volume, so it survives `docker compose up` cycles), or pass `HIVE_BACKUP_KEY` in the container environment. The shipped compose files do not pass `HIVE_BACKUP_KEY`; to use the env path, add it to `.env` and add `HIVE_BACKUP_KEY=${HIVE_BACKUP_KEY}` to the `environment` block of the `hive` service.
+
+Managing the key from the dashboard is also owner-only:
+
+- `GET /api/config/governor/backup` — presence, usability, and a safe source label (`file:<path>` / `env:<NAME>`); never the value.
+- `PUT /api/config/governor/backup` — `{"encryptionKey":"<64 hex>","keyName":"escrowed in 1Password"}`.
+- `DELETE /api/config/governor/backup` — removes the stored key; backups are refused again.
 
 The archive contains the spoke config files (`hive.yaml.dashboard`, `hive.yaml.runtime` or the legacy `hive.yaml.bak`), `hive-id`, `hive-state.json`, the GitHub App private keys, and `beads/`. It is encrypted and sized for browser download, not nightly fleet DR.
 
@@ -135,7 +167,7 @@ To restore:
 
 4. Run `docker compose up -d`.
 
-The entrypoint restores the runtime config at boot. Escrow `HIVE_BACKUP_KEY` outside the host.
+The entrypoint restores the runtime config at boot. Escrow the backup encryption key outside the host — the dashboard-set key lives on the `hive-data` volume, so losing the volume loses both the backups' key and the data it protects.
 
 Fixes #2986.
 Fixes #2942.

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -84,7 +84,7 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `HIVE_HUB_SLACK_BOT_TOKEN` | No | none | Slack bot token for hub Slack notifications. |
 | `HIVE_NTFY_SERVER` | No | none | ntfy server for hub auth-audit alerts. |
 | `HIVE_NTFY_TOPIC` | No | none | ntfy topic for hub auth-audit alerts. |
-| `HIVE_BACKUP_KEY` | Yes for hub DR backups and browser spoke backups | none | 64-character hex or base64 AES-256 key. Unset makes backup creation fail. |
+| `HIVE_BACKUP_KEY` | Yes for hub DR backups; optional for spoke backups | none | 64-character hex AES-256 key. For spoke backups it is now a **fallback**: owners set the key from Governor Config → Security → Backup (`governor.backup.key_file`), which takes precedence and needs no deployment access. With no key from any source, backup creation fails rather than writing plaintext. |
 | `HIVE_BACKUP_BUCKET` | Required for OCI upload mode | none | OCI Object Storage bucket for hub backup archives. |
 | `HIVE_BACKUP_DATA_DIR` | No | `/data` | Hub data directory used by `hive-backup`. |
 | `HIVE_BACKUP_RETENTION` | No | `30` | Number of backup archives to retain. |

--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -158,3 +158,7 @@ kubectl -n hive delete pvc -l app.kubernetes.io/name=hive
 ```
 
 `/data` holds the dashboard config overlay, persisted tokens, logs, and other state; deleting it discards dashboard edits and cached credentials. Back up first if you need any of it — see [Backup & restore](backup-restore.md).
+
+### "backup encryption key is not configured on this hive, so a backup would be unencrypted; refusing"
+
+Expected, and deliberate: the archive carries this hive's GitHub App private keys, so hive refuses to build one without a key. Set one in **Governor Config → Security → Backup → Set key** (`openssl rand -hex 32`) and retry — no deployment or cluster access is needed. `HIVE_BACKUP_KEY` on the deployment still works as a fallback for self-hosted hives. Escrow the key: it is not inside the archive, so a backup without it cannot be restored.

--- a/src/pkg/config/backup.go
+++ b/src/pkg/config/backup.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// Backup encryption-key resolution.
+//
+// The self-service backup is sealed with AES-256-GCM and there is NO default
+// key: an unconfigured hive refuses to produce a backup rather than stream
+// GitHub App private keys to a browser in plaintext.
+//
+// Historically the key could only arrive through the HIVE_BACKUP_KEY
+// environment variable, which is set on the deployment. Hosted spoke owners do
+// not have deployment-env access, so backup was unavailable to exactly the
+// users who cannot rebuild a lost hive by hand (#4129). The key is therefore
+// also settable through governor config: the dashboard writes the value to a
+// 0600 file on the PVC and hive.yaml records only that PATH — the same
+// path-not-value rule already used for the bob and LiteLLM API keys, and the
+// reason Config.Save() can round-trip the config without leaking a secret.
+const (
+	// BackupKeyEnv is the deployment environment variable holding the
+	// hex-encoded AES-256 backup key. It remains supported as a fallback for
+	// hives that already set it.
+	BackupKeyEnv = "HIVE_BACKUP_KEY"
+
+	// DefaultBackupKeyFile is the read-only Kubernetes Secret mount consulted
+	// when governor.backup.key_file is unset, mirroring DefaultBobAPIKeyFile.
+	DefaultBackupKeyFile = "/secrets/backup_encryption_key"
+
+	// WritableBackupKeyFile is the PVC-backed location a hosted spoke owner
+	// can write the key to from the dashboard, with no cluster or deployment
+	// access. Referenced by path only; never by value.
+	WritableBackupKeyFile = WritableSecretsDir + "/backup_encryption_key"
+)
+
+// BackupConfig locates the self-service backup encryption key. It holds a file
+// PATH and an env var NAME — never the key value itself.
+type BackupConfig struct {
+	// KeyFile is the path to a file containing the hex-encoded AES-256 key.
+	// Set by the dashboard when an owner configures the key through governor
+	// config.
+	KeyFile string `yaml:"key_file,omitempty" json:"key_file,omitempty"`
+
+	// KeyEnv names an alternative environment variable to read the key from.
+	// Empty means BackupKeyEnv.
+	KeyEnv string `yaml:"key_env,omitempty" json:"key_env,omitempty"`
+
+	// KeyName is an operator-chosen LABEL ("escrowed in 1Password") recorded
+	// so an owner can tell which key material this hive uses without ever
+	// seeing the value. Safe to serialize.
+	KeyName string `yaml:"key_name,omitempty" json:"key_name,omitempty"`
+}
+
+// ResolveKey returns the raw (still unvalidated) backup key, or "" when none
+// is configured anywhere.
+//
+// Governor config wins over the environment so a spoke owner can rotate the
+// key themselves; the env var stays as the fallback for existing deployments.
+func (c *BackupConfig) ResolveKey() string {
+	key, _ := c.ResolveKeyWithSource()
+	return key
+}
+
+// ResolveKeySource reports WHERE the key was found without exposing the value:
+// "file:<path>", "env:<NAME>", or "" when unconfigured. Safe to log and safe
+// to return from an API.
+func (c *BackupConfig) ResolveKeySource() string {
+	_, source := c.ResolveKeyWithSource()
+	return source
+}
+
+// ResolveKeyWithSource returns the raw key and its safe source label. It is
+// nil-receiver safe so callers without a config (the hub cron backup) can
+// resolve the environment fallback through the same code path.
+func (c *BackupConfig) ResolveKeyWithSource() (string, string) {
+	if c == nil {
+		// No config in hand means no governor-config path to honour: this is
+		// the hub cron backup and the hive-backup CLI, whose key is the
+		// escrowed env var. Probing the well-known spoke key files here would
+		// let a stray PVC file silently outrank the escrowed key and seal an
+		// archive nobody can decrypt at restore time.
+		if key := strings.TrimSpace(os.Getenv(BackupKeyEnv)); key != "" {
+			return key, "env:" + BackupKeyEnv
+		}
+		return "", ""
+	}
+	envName := strings.TrimSpace(c.KeyEnv)
+	files := []string{c.KeyFile, WritableBackupKeyFile, DefaultBackupKeyFile}
+	seen := map[string]bool{"": true}
+	for _, f := range files {
+		if seen[f] {
+			continue
+		}
+		seen[f] = true
+		if data, err := os.ReadFile(f); err == nil {
+			if key := strings.TrimSpace(string(data)); key != "" {
+				return key, "file:" + f
+			}
+		}
+	}
+	if envName != "" {
+		if key := strings.TrimSpace(os.Getenv(envName)); key != "" {
+			return key, "env:" + envName
+		}
+	}
+	if key := strings.TrimSpace(os.Getenv(BackupKeyEnv)); key != "" {
+		return key, "env:" + BackupKeyEnv
+	}
+	return "", ""
+}

--- a/src/pkg/config/backup_test.go
+++ b/src/pkg/config/backup_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Backup key resolution (#4129): hosted spoke owners cannot set deployment
+// env vars, so governor config must be able to supply the key — while
+// HIVE_BACKUP_KEY keeps working for hives that already set it.
+
+const backupCfgTestKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func writeBackupKeyFile(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "backup_encryption_key")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestBackupResolveKeyUnconfigured(t *testing.T) {
+	t.Setenv(BackupKeyEnv, "")
+	var bc BackupConfig
+	if key, source := bc.ResolveKeyWithSource(); key != "" || source != "" {
+		t.Fatalf("unconfigured resolve = (%q, %q), want empty", key, source)
+	}
+}
+
+func TestBackupResolveKeyFromEnvFallback(t *testing.T) {
+	t.Setenv(BackupKeyEnv, backupCfgTestKey)
+	var bc BackupConfig
+	key, source := bc.ResolveKeyWithSource()
+	if key != backupCfgTestKey {
+		t.Fatalf("key = %q, want the env value", key)
+	}
+	if source != "env:"+BackupKeyEnv {
+		t.Fatalf("source = %q, want env:%s", source, BackupKeyEnv)
+	}
+}
+
+// The configured file wins over the environment: that is what lets a hosted
+// owner rotate the key themselves on a hive whose deployment sets one.
+func TestBackupResolveKeyFilePrecedesEnv(t *testing.T) {
+	t.Setenv(BackupKeyEnv, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	path := writeBackupKeyFile(t, backupCfgTestKey+"\n")
+	bc := BackupConfig{KeyFile: path}
+
+	key, source := bc.ResolveKeyWithSource()
+	if key != backupCfgTestKey {
+		t.Fatalf("key = %q, want the configured file's value (trailing newline trimmed)", key)
+	}
+	if source != "file:"+path {
+		t.Fatalf("source = %q, want file:%s", source, path)
+	}
+}
+
+// A whitespace-only file is the same hazard as no file at all: it must not
+// look configured, or the hive would claim backups work and then fail.
+func TestBackupResolveKeyIgnoresBlankFile(t *testing.T) {
+	t.Setenv(BackupKeyEnv, "")
+	bc := BackupConfig{KeyFile: writeBackupKeyFile(t, "  \n\t")}
+	if key, source := bc.ResolveKeyWithSource(); key != "" || source != "" {
+		t.Fatalf("blank file resolve = (%q, %q), want empty", key, source)
+	}
+}
+
+func TestBackupResolveKeyCustomEnvName(t *testing.T) {
+	t.Setenv("HIVE_ALT_BACKUP_KEY", backupCfgTestKey)
+	t.Setenv(BackupKeyEnv, "")
+	bc := BackupConfig{KeyEnv: "HIVE_ALT_BACKUP_KEY"}
+	if _, source := bc.ResolveKeyWithSource(); source != "env:HIVE_ALT_BACKUP_KEY" {
+		t.Fatalf("source = %q, want env:HIVE_ALT_BACKUP_KEY", source)
+	}
+}
+
+// ResolveKeySource is what APIs and logs use, so it must never expose value.
+func TestBackupResolveKeySourceIsPathOnly(t *testing.T) {
+	t.Setenv(BackupKeyEnv, "")
+	path := writeBackupKeyFile(t, backupCfgTestKey)
+	bc := BackupConfig{KeyFile: path}
+	if got := bc.ResolveKeySource(); got == backupCfgTestKey {
+		t.Fatal("ResolveKeySource returned the key value")
+	}
+}
+
+// A nil receiver is the hub cron backup / hive-backup CLI path: env ONLY, no
+// panic. It must not consult the well-known spoke key files — a stray file on
+// a mounted PVC silently outranking the escrowed HIVE_BACKUP_KEY would seal
+// archives with a key nobody holds, discovered only during a restore.
+func TestBackupResolveKeyNilReceiverIsEnvOnly(t *testing.T) {
+	t.Setenv(BackupKeyEnv, backupCfgTestKey)
+	var bc *BackupConfig
+	key, source := bc.ResolveKeyWithSource()
+	if key != backupCfgTestKey {
+		t.Fatalf("nil-receiver resolve = %q, want the env value", key)
+	}
+	if source != "env:"+BackupKeyEnv {
+		t.Fatalf("nil-receiver source = %q, want env:%s", source, BackupKeyEnv)
+	}
+
+	t.Setenv(BackupKeyEnv, "")
+	if key, source := bc.ResolveKeyWithSource(); key != "" || source != "" {
+		t.Fatalf("nil-receiver with no env = (%q, %q), want empty", key, source)
+	}
+}

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -944,7 +944,12 @@ type GovernorConfig struct {
 	// Bob holds the IBM bobshell CLI backend's API-key location. Required for
 	// agents with backend "bob": bobshell's browser SSO flow cannot complete in
 	// a headless pod.
-	Bob        BobConfig        `yaml:"bob"`
+	Bob BobConfig `yaml:"bob"`
+	// Backup holds the location of the self-service backup encryption key.
+	// It records a PATH only, never the key value: hosted spoke owners have no
+	// deployment-env access, so the key has to be settable through this
+	// (governor) config surface rather than only through HIVE_BACKUP_KEY.
+	Backup     BackupConfig     `yaml:"backup,omitempty" json:"backup,omitempty"`
 	Trajectory TrajectoryConfig `yaml:"trajectory"`
 	Replan     ReplanConfig     `yaml:"replan"`
 	// Gateways is the list of named model gateways (OpenAI-compatible endpoints

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -139,6 +139,11 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/trajectory", s.handleGovernorTrajectory)
 	s.mux.HandleFunc("PUT /api/config/governor/features", s.handleGovernorFeatures)
 	s.mux.HandleFunc("PUT /api/config/governor/security", s.handleGovernorSecurity)
+	// Backup encryption key: presence-only status, set, and clear. The key
+	// value is never returned by any of these (#4129).
+	s.mux.HandleFunc("GET /api/config/governor/backup", s.handleBackupKeyStatus)
+	s.mux.HandleFunc("PUT /api/config/governor/backup", s.handleBackupKeySet)
+	s.mux.HandleFunc("DELETE /api/config/governor/backup", s.handleBackupKeyClear)
 	// bob API key: PUT sets/replaces, DELETE revokes. Both are non-GET, so the
 	// roleEnforcement middleware already 403s a read-only role — no separate
 	// authorization rule is needed or wanted here.

--- a/src/pkg/dashboard/backup_api.go
+++ b/src/pkg/dashboard/backup_api.go
@@ -23,6 +23,11 @@ import (
 // read cannot hold a dashboard connection open indefinitely.
 const backupBuildTimeout = spokebackup.BuildTimeout
 
+// backupKeyConfigPath is the dashboard location of the backup-encryption-key
+// setting, returned to the UI so an owner who cannot reach deployment env
+// still learns where to configure it.
+const backupKeyConfigPath = "governor:Security"
+
 // Owner checks below mirror handleConfigDownload and handleSelfUpgrade: an
 // empty role means no per-user identity is in play (an open/dev spoke), which
 // those handlers already treat as owner.
@@ -43,17 +48,22 @@ func (s *Server) handleBackupStatus(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "owner access required", http.StatusForbidden)
 		return
 	}
-	_, err := hubbackup.LoadKey()
+	_, source, err := hubbackup.ResolveKeyWithSource(s.backupKeyConfig())
 	if err != nil {
 		jsonResponse(w, map[string]interface{}{
 			"available": false,
 			// The reason is operator-facing configuration state, not a secret:
-			// it names the missing environment variable, never a key value.
-			"reason": "backup encryption key is not configured on this hive",
+			// it names where to set a key, never a key value.
+			"reason": "backup encryption key is not configured on this hive — " +
+				"set one in Settings → Governor → Security → Backup encryption key",
+			// configPath lets the UI deep-link to the setting instead of
+			// telling a hosted owner to edit a deployment they cannot see.
+			"configPath": backupKeyConfigPath,
 		})
 		return
 	}
-	jsonResponse(w, map[string]interface{}{"available": true})
+	// source is the safe "file:<path>" / "env:<NAME>" label, never the key.
+	jsonResponse(w, map[string]interface{}{"available": true, "source": source})
 }
 
 // handleBackupDownload builds an encrypted backup of this spoke and streams it
@@ -73,12 +83,15 @@ func (s *Server) handleBackupDownload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// No key means no backup. Refusing here is deliberate: the alternative is
-	// streaming GitHub App private keys to a browser in plaintext.
-	key, err := hubbackup.LoadKey()
+	// streaming GitHub App private keys to a browser in plaintext. The key is
+	// resolved from governor config first so a hosted owner can configure it
+	// without deployment-env access, with HIVE_BACKUP_KEY as the fallback.
+	key, err := hubbackup.ResolveKey(s.backupKeyConfig())
 	if err != nil {
 		jsonError(w,
 			"backup encryption key is not configured on this hive, so a backup "+
-				"would be unencrypted; refusing", http.StatusPreconditionFailed)
+				"would be unencrypted; refusing — set a key in Settings → Governor "+
+				"→ Security → Backup encryption key", http.StatusPreconditionFailed)
 		return
 	}
 

--- a/src/pkg/dashboard/backup_api_test.go
+++ b/src/pkg/dashboard/backup_api_test.go
@@ -144,3 +144,14 @@ func TestBackupResponseIsNotCacheable(t *testing.T) {
 		t.Errorf("X-Hive-Backup-Encrypted = %q", enc)
 	}
 }
+
+// mustDecodeBackupTestKey returns the raw bytes of backupTestKey, so a test
+// can prove an archive really was sealed with the configured key.
+func mustDecodeBackupTestKey(t *testing.T) []byte {
+	t.Helper()
+	k, err := hex.DecodeString(backupTestKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}

--- a/src/pkg/dashboard/backup_key.go
+++ b/src/pkg/dashboard/backup_key.go
@@ -1,0 +1,240 @@
+package dashboard
+
+// Storage for the self-service backup encryption key entered from the spoke
+// dashboard's governor Security tab (#4129).
+//
+// Before this, the key could only come from HIVE_BACKUP_KEY on the deployment.
+// A hosted spoke owner has no deployment-env access, so "Back up this hive"
+// was permanently refused for exactly the users who cannot rebuild a lost hive
+// by hand. The key is now settable through governor config: the VALUE is
+// written to a 0600 PVC file and hive.yaml records only the resulting PATH
+// (governor.backup.key_file), mirroring the bob/LiteLLM key stores.
+//
+// The key value must never be logged, echoed in an API response, or written
+// to hive.yaml. Fail-closed is preserved end to end: clearing the key makes
+// the backup endpoint refuse again.
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/hubbackup"
+)
+
+const (
+	// backupKeyFileMode is owner-read/write only. Unlike the bob key, this
+	// file is read by the hive process itself, never by an agent UID, so it
+	// needs no group bit.
+	backupKeyFileMode = 0o600
+
+	// backupKeyDirMode matches the PVC secrets directory used by the sibling
+	// key stores.
+	backupKeyDirMode = 0o700
+
+	// backupKeyNameMaxLen bounds the optional human LABEL for the key
+	// ("escrowed in 1Password"). It is a display string, not the secret.
+	backupKeyNameMaxLen = 128
+
+	// backupKeyHexLen is the exact length of a hex-encoded AES-256 key.
+	backupKeyHexLen = 64
+)
+
+// writableBackupKeyFile is a package var (not a const) so tests can point it
+// at a temp dir. The production value never changes at runtime.
+var writableBackupKeyFile = config.WritableBackupKeyFile
+
+// backupKeyConfig returns the live governor backup config, or nil when the
+// server has no config wired (unit tests, dev servers). A nil result still
+// resolves the HIVE_BACKUP_KEY fallback: *config.BackupConfig methods are
+// nil-receiver safe.
+func (s *Server) backupKeyConfig() *config.BackupConfig {
+	if s == nil || s.deps == nil || s.deps.Config == nil {
+		return nil
+	}
+	return &s.deps.Config.Governor.Backup
+}
+
+// handleBackupKeyStatus serves GET /api/config/governor/backup. It reports
+// PRESENCE and the safe source label only — never the key value.
+func (s *Server) handleBackupKeyStatus(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	bc := s.backupKeyConfig()
+	source := bc.ResolveKeySource()
+	// Presence alone is not enough to promise a working backup: a truncated
+	// or non-hex key is configured but unusable, and an owner should learn
+	// that here rather than from a failed backup.
+	usable := true
+	reason := ""
+	if source == "" {
+		usable = false
+	} else if _, _, err := hubbackup.ResolveKeyWithSource(bc); err != nil {
+		usable = false
+		reason = err.Error()
+	}
+	keyName := ""
+	if bc != nil {
+		keyName = bc.KeyName
+	}
+	jsonResponse(w, map[string]interface{}{
+		"ok":         true,
+		"configured": source != "",
+		"usable":     usable,
+		"source":     source,
+		"keyName":    keyName,
+		"algorithm":  "aes-256-gcm",
+		"reason":     reason,
+	})
+}
+
+// handleBackupKeySet serves PUT /api/config/governor/backup. Owner-only: the
+// key decrypts an archive containing this hive's GitHub App private keys.
+func (s *Server) handleBackupKeySet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	var body struct {
+		EncryptionKey *string `json:"encryptionKey"`
+		KeyName       *string `json:"keyName"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if body.EncryptionKey == nil {
+		jsonError(w, "encryptionKey is required", http.StatusBadRequest)
+		return
+	}
+	key := strings.TrimSpace(*body.EncryptionKey)
+	if key == "" {
+		// Distinct from DELETE: an empty PUT is a mistake, not an intentional
+		// revoke, so say so rather than silently disabling backups.
+		jsonError(w, "encryptionKey is empty — paste a 64-character hex key "+
+			"(openssl rand -hex 32), or use Clear to remove the existing one",
+			http.StatusBadRequest)
+		return
+	}
+	// Validate BEFORE storing: a key that cannot seal an archive would leave
+	// the hive looking configured while every backup still failed.
+	if len(key) != backupKeyHexLen {
+		jsonError(w, fmt.Sprintf("encryptionKey must be exactly %d hex characters "+
+			"(a 32-byte AES-256 key); generate one with: openssl rand -hex 32", backupKeyHexLen),
+			http.StatusBadRequest)
+		return
+	}
+	if _, err := hex.DecodeString(key); err != nil {
+		// The hex error names the offending byte, so it is not wrapped in.
+		jsonError(w, "encryptionKey must be hex characters only (0-9, a-f); "+
+			"generate one with: openssl rand -hex 32", http.StatusBadRequest)
+		return
+	}
+	var keyName string
+	nameProvided := body.KeyName != nil
+	if nameProvided {
+		keyName = strings.TrimSpace(*body.KeyName)
+		if len(keyName) > backupKeyNameMaxLen {
+			jsonError(w, fmt.Sprintf("keyName is too long (limit %d characters)", backupKeyNameMaxLen),
+				http.StatusBadRequest)
+			return
+		}
+	}
+
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config not available", http.StatusInternalServerError)
+		return
+	}
+	cfg := s.deps.Config
+	keyFile, err := storeBackupKey(key)
+	if err != nil {
+		// redactSecret guards against the key surfacing through a filesystem
+		// error that happened to embed it.
+		jsonError(w, "failed to store backup encryption key: "+redactSecret(err.Error(), key),
+			http.StatusInternalServerError)
+		return
+	}
+	cfg.Governor.Backup.KeyFile = keyFile
+	if nameProvided {
+		cfg.Governor.Backup.KeyName = keyName
+	}
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after backup key update", "error", err)
+	}
+	// Path only — the value is never logged.
+	s.logger.Info("backup encryption key stored", "key_file", keyFile)
+	s.auditFromRequest(r, "config_governor_backup_key",
+		auditDetail("section", "backup", "action", "set"), "")
+	s.refreshAndPersist()
+
+	jsonResponse(w, map[string]interface{}{
+		"ok":         true,
+		"status":     "updated",
+		"configured": true,
+		"source":     cfg.Governor.Backup.ResolveKeySource(),
+		"keyName":    cfg.Governor.Backup.KeyName,
+	})
+}
+
+// handleBackupKeyClear serves DELETE /api/config/governor/backup. Removing the
+// key is a deliberate, fail-closed action: backups are refused again until a
+// new key is set (an env-provided key, if any, remains as the fallback).
+func (s *Server) handleBackupKeyClear(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config not available", http.StatusInternalServerError)
+		return
+	}
+	cfg := s.deps.Config
+	paths := []string{cfg.Governor.Backup.KeyFile, writableBackupKeyFile}
+	seen := map[string]bool{"": true}
+	for _, p := range paths {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			s.logger.Warn("could not remove backup key file", "path", p, "error", err)
+		}
+	}
+	cfg.Governor.Backup.KeyFile = ""
+	cfg.Governor.Backup.KeyName = ""
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after backup key clear", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_backup_key",
+		auditDetail("section", "backup", "action", "clear"), "")
+	s.refreshAndPersist()
+
+	jsonResponse(w, map[string]interface{}{
+		"ok":         true,
+		"status":     "cleared",
+		"configured": cfg.Governor.Backup.ResolveKeySource() != "",
+		"source":     cfg.Governor.Backup.ResolveKeySource(),
+	})
+}
+
+// storeBackupKey writes the key VALUE to the PVC and returns the path to
+// record in hive.yaml. Only the path is ever returned or logged.
+func storeBackupKey(key string) (string, error) {
+	path := writableBackupKeyFile
+	if err := os.MkdirAll(filepath.Dir(path), backupKeyDirMode); err != nil {
+		return "", fmt.Errorf("create secrets directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(key+"\n"), backupKeyFileMode); err != nil {
+		return "", fmt.Errorf("write key file: %w", err)
+	}
+	// A pre-existing file keeps its old mode through WriteFile, so tighten it
+	// explicitly rather than trusting the create path.
+	if err := os.Chmod(path, backupKeyFileMode); err != nil {
+		return "", fmt.Errorf("chmod key file: %w", err)
+	}
+	return path, nil
+}

--- a/src/pkg/dashboard/backup_key_test.go
+++ b/src/pkg/dashboard/backup_key_test.go
@@ -1,0 +1,288 @@
+package dashboard
+
+// Tests for the governor-config backup encryption key (#4129). Hosted spoke
+// owners have no deployment-env access, so the key must be settable through
+// governor config — while the fail-closed rule (no key ⇒ no backup) and the
+// no-leak rule (the value never appears in a response, config, or log-facing
+// struct) both survive.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/hubbackup"
+)
+
+// pointBackupKeyAtTempDir redirects the PVC key path at a temp dir for the
+// duration of a test and returns the path.
+func pointBackupKeyAtTempDir(t *testing.T) string {
+	t.Helper()
+	orig := writableBackupKeyFile
+	p := filepath.Join(t.TempDir(), "secrets", "backup_encryption_key")
+	writableBackupKeyFile = p
+	t.Cleanup(func() { writableBackupKeyFile = orig })
+	return p
+}
+
+// newBackupKeyTestServer builds a Server with a live config whose SourcePath
+// is empty, so saveConfig is a no-op and the handlers exercise everything else.
+func newBackupKeyTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := NewServer(0, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	s.deps = &Dependencies{Config: &config.Config{}}
+	return s
+}
+
+func putBackupKey(t *testing.T, s *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/backup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	markOwnerRequest(req)
+	rec := httptest.NewRecorder()
+	s.handleBackupKeySet(rec, req)
+	return rec
+}
+
+// TestBackupKeySetThroughGovernorConfigEnablesBackup is the acceptance
+// criterion: with NO HIVE_BACKUP_KEY on the deployment, an owner sets the key
+// through governor config and the backup then succeeds.
+func TestBackupKeySetThroughGovernorConfigEnablesBackup(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	t.Setenv("HIVE_SPOKE_BACKUP_DATA_DIR", t.TempDir())
+	keyPath := pointBackupKeyAtTempDir(t)
+	s := newBackupKeyTestServer(t)
+
+	// Before: refused.
+	req := httptest.NewRequest(http.MethodPost, "/api/backup", nil)
+	markOwnerRequest(req)
+	rec := httptest.NewRecorder()
+	s.handleBackupDownload(rec, req)
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("pre-config backup status = %d, want 412", rec.Code)
+	}
+
+	// Configure the key the way a hosted owner does — through the API only.
+	if rec := putBackupKey(t, s, `{"encryptionKey":"`+backupTestKey()+`","keyName":"escrowed"}`); rec.Code != http.StatusOK {
+		t.Fatalf("PUT key status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if s.deps.Config.Governor.Backup.KeyFile != keyPath {
+		t.Fatalf("key_file = %q, want %q", s.deps.Config.Governor.Backup.KeyFile, keyPath)
+	}
+
+	// After: the same request succeeds and the archive is encrypted.
+	req = httptest.NewRequest(http.MethodPost, "/api/backup", nil)
+	markOwnerRequest(req)
+	rec = httptest.NewRecorder()
+	s.handleBackupDownload(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("post-config backup status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if enc := rec.Header().Get("X-Hive-Backup-Encrypted"); enc != "aes-256-gcm" {
+		t.Errorf("X-Hive-Backup-Encrypted = %q, want aes-256-gcm", enc)
+	}
+	// The archive must actually open with the configured key — proof it was
+	// sealed with the governor-config key and not left in the clear.
+	if _, err := hubbackup.Open(mustDecodeBackupTestKey(t), rec.Body.Bytes()); err != nil {
+		t.Fatalf("archive does not decrypt with the configured key: %v", err)
+	}
+}
+
+// TestBackupKeyStatusNeverEchoesKey — presence-only status, for the UI.
+func TestBackupKeyStatusNeverEchoesKey(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	pointBackupKeyAtTempDir(t)
+	s := newBackupKeyTestServer(t)
+
+	get := func() map[string]interface{} {
+		req := httptest.NewRequest(http.MethodGet, "/api/config/governor/backup", nil)
+		markOwnerRequest(req)
+		rec := httptest.NewRecorder()
+		s.handleBackupKeyStatus(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), backupTestKey()) {
+			t.Fatal("status response echoed the backup key")
+		}
+		var d map[string]interface{}
+		if err := json.Unmarshal(rec.Body.Bytes(), &d); err != nil {
+			t.Fatalf("bad json: %v", err)
+		}
+		return d
+	}
+
+	if d := get(); d["configured"] != false || d["usable"] != false {
+		t.Errorf("unconfigured status = %v, want configured/usable false", d)
+	}
+
+	if rec := putBackupKey(t, s, `{"encryptionKey":"`+backupTestKey()+`","keyName":"escrowed"}`); rec.Code != http.StatusOK {
+		t.Fatalf("PUT key status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	d := get()
+	if d["configured"] != true || d["usable"] != true {
+		t.Errorf("configured status = %v, want configured/usable true", d)
+	}
+	if d["keyName"] != "escrowed" {
+		t.Errorf("keyName = %v, want the operator label", d["keyName"])
+	}
+	if src, _ := d["source"].(string); !strings.HasPrefix(src, "file:") {
+		t.Errorf("source = %q, want a file: label (path only, never the value)", src)
+	}
+}
+
+// TestBackupKeyNeverLandsInConfigOrResponse locks the no-leak rule: the value
+// goes to a 0600 file, and the config struct (which is serialized to
+// hive.yaml and rendered by config APIs) holds only the path.
+func TestBackupKeyNeverLandsInConfigOrResponse(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	keyPath := pointBackupKeyAtTempDir(t)
+	s := newBackupKeyTestServer(t)
+
+	rec := putBackupKey(t, s, `{"encryptionKey":"`+backupTestKey()+`","keyName":"escrowed"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT key status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), backupTestKey()) {
+		t.Fatal("PUT response echoed the backup key")
+	}
+	blob, err := json.Marshal(s.deps.Config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), backupTestKey()) {
+		t.Fatal("the key value was stored in the hive config")
+	}
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("key file not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("key file mode = %o, want 600", perm)
+	}
+}
+
+// TestBackupKeyRejectsMalformedValues — a key that cannot seal an archive must
+// be refused at save time, not discovered during a backup.
+func TestBackupKeyRejectsMalformedValues(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	keyPath := pointBackupKeyAtTempDir(t)
+	s := newBackupKeyTestServer(t)
+
+	for _, tc := range []struct{ name, body string }{
+		{"empty", `{"encryptionKey":"  "}`},
+		{"missing", `{}`},
+		{"too short", `{"encryptionKey":"abcd"}`},
+		{"non-hex", `{"encryptionKey":"zz23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := putBackupKey(t, s, tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body %s)", rec.Code, rec.Body.String())
+			}
+			if _, err := os.Stat(keyPath); err == nil {
+				t.Fatal("a rejected key must not be written to disk")
+			}
+			if s.deps.Config.Governor.Backup.KeyFile != "" {
+				t.Fatal("a rejected key must not be recorded in config")
+			}
+		})
+	}
+}
+
+// TestBackupKeyClearRefusesBackupsAgain — fail-closed after a revoke.
+func TestBackupKeyClearRefusesBackupsAgain(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	t.Setenv("HIVE_SPOKE_BACKUP_DATA_DIR", t.TempDir())
+	keyPath := pointBackupKeyAtTempDir(t)
+	s := newBackupKeyTestServer(t)
+
+	if rec := putBackupKey(t, s, `{"encryptionKey":"`+backupTestKey()+`"}`); rec.Code != http.StatusOK {
+		t.Fatalf("PUT key status = %d", rec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/config/governor/backup", nil)
+	markOwnerRequest(req)
+	rec := httptest.NewRecorder()
+	s.handleBackupKeyClear(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Errorf("key file still present after clear: %v", err)
+	}
+	if s.deps.Config.Governor.Backup.KeyFile != "" {
+		t.Error("key_file still recorded after clear")
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/backup", nil)
+	markOwnerRequest(req)
+	rec = httptest.NewRecorder()
+	s.handleBackupDownload(rec, req)
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("backup after clear = %d, want 412 (fail-closed)", rec.Code)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); cd != "" {
+		t.Errorf("must not offer a download when refusing: %q", cd)
+	}
+}
+
+// TestBackupKeyEndpointsDenyNonOwners — the key decrypts an archive holding
+// this hive's GitHub App private keys, so only the owner may touch it.
+func TestBackupKeyEndpointsDenyNonOwners(t *testing.T) {
+	pointBackupKeyAtTempDir(t)
+	s := newBackupKeyTestServer(t)
+
+	for _, role := range []string{"read", "read-write", "write", "viewer"} {
+		for _, tc := range []struct {
+			name string
+			fn   func(http.ResponseWriter, *http.Request)
+			verb string
+		}{
+			{"status", s.handleBackupKeyStatus, http.MethodGet},
+			{"set", s.handleBackupKeySet, http.MethodPut},
+			{"clear", s.handleBackupKeyClear, http.MethodDelete},
+		} {
+			req := httptest.NewRequest(tc.verb, "/api/config/governor/backup",
+				strings.NewReader(`{"encryptionKey":"`+backupTestKey()+`"}`))
+			req.Header.Set("X-Hive-Role", role)
+			rec := httptest.NewRecorder()
+			tc.fn(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("%s as %q: status = %d, want 403", tc.name, role, rec.Code)
+			}
+		}
+	}
+}
+
+// TestBackupStatusAvailableFromGovernorConfig — the UI probe must report the
+// menu entry as usable when the key came from governor config, not only from
+// the deployment environment.
+func TestBackupStatusAvailableFromGovernorConfig(t *testing.T) {
+	t.Setenv("HIVE_BACKUP_KEY", "")
+	pointBackupKeyAtTempDir(t)
+	s := newBackupKeyTestServer(t)
+
+	if rec := putBackupKey(t, s, `{"encryptionKey":"`+backupTestKey()+`"}`); rec.Code != http.StatusOK {
+		t.Fatalf("PUT key status = %d", rec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/backup/status", nil)
+	markOwnerRequest(req)
+	rec := httptest.NewRecorder()
+	s.handleBackupStatus(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"available":true`) {
+		t.Errorf("expected available:true, got %s", body)
+	}
+	if strings.Contains(body, backupTestKey()) {
+		t.Fatal("status response echoed the backup key")
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -3011,7 +3011,7 @@
                check, so hiding this is UX, not the security boundary. -->
           <button type="button" id="oc-gh-menu-backup" onclick="downloadHiveBackup()" style="display:none;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem;line-height:1.35">
             Back up this hive
-            <span style="display:block;font-size:0.68rem;color:var(--muted)">Encrypted · includes beads</span>
+            <span style="display:block;font-size:0.68rem;color:var(--muted)">Encrypted · includes beads · needs a backup key (Governor → Security)</span>
           </button>
           <a href="/api/docs" target="_blank" style="display:block;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">API Docs ↗</a>
           <button onclick="ghLogout()" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem">Sign out</button>
@@ -19104,6 +19104,12 @@ function burnAreaChart() {
         </div>
         <p style="font-size:0.72rem;color:var(--muted);margin:6px 0 0">Per-agent opt-in lives on each agent's General tab. Current effective posture: ${Number(sec.sandboxedAgents || 0)}/${Number(sec.totalAgents || 0)} agents sandboxed.</p>`;
 
+      /* Backup encryption key: painted asynchronously from presence-only
+         status so the key value never travels to the browser. */
+      loadBackupKeyStatus();
+      const backupKey = `
+        <div id="gov-backup-key-host"><div style="color:var(--muted);font-size:0.8rem">Loading…</div></div>`;
+
       return `
         ${securityModelDatalistHtml()}${agentList}
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:10px">Security posture and access controls saved through the dashboard overlay.</p>
@@ -19112,7 +19118,176 @@ function burnAreaChart() {
         ${renderSecuritySection('Access', renderGovAccess())}
         ${renderSecuritySection('Input Defense', inputDefense)}
         ${renderSecuritySection('Merge Gates', mergeGates)}
-        ${renderSecuritySection('Isolation', isolation)}`;
+        ${renderSecuritySection('Isolation', isolation)}
+        ${renderSecuritySection('Backup', backupKey)}`;
+    }
+
+    /* loadBackupKeyStatus fetches presence-only backup-key status and paints
+       the Backup panel. The response carries `configured`/`usable` and a safe
+       `source` string ("file:<path>" / "env:<NAME>") — never the key value.
+       The DOM target is resolved AFTER the await, because the caller assigns
+       the tab HTML only once this function has already started. */
+    async function loadBackupKeyStatus() {
+      let host = null;
+      try {
+        const r = await fetch('/api/config/governor/backup');
+        host = document.getElementById('gov-backup-key-host');
+        if (!host) return;
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        renderBackupKeyPanel(host, d);
+      } catch (e) {
+        host = host || document.getElementById('gov-backup-key-host');
+        if (host) host.innerHTML = '<div style="color:var(--red);font-size:0.8rem">Failed to load backup key status: ' + esc(e.message) + '</div>';
+      }
+    }
+
+    /* renderBackupKeyPanel paints the backup credential card. Only presence,
+       the safe source label and the operator-chosen key NAME reach this
+       function; the key value never does. */
+    function renderBackupKeyPanel(host, d) {
+      if (!host) return;
+      d = d || {};
+      const configured = d.configured === true;
+      const usable = d.usable === true;
+      const source = d.source || '';
+      const nameLabel = configured && d.keyName
+        ? ' <strong style="color:var(--fg)">' + esc(d.keyName) + '</strong>'
+        : '';
+      let statusLine;
+      if (configured && usable) {
+        statusLine = '<span style="color:var(--green)">✓ Key set — backups are enabled</span>' + nameLabel +
+          (source ? ' <span style="color:var(--muted)">(' + esc(source) + ')</span>' : '');
+      } else if (configured) {
+        statusLine = '<span style="color:var(--red)">✗ Key is unusable — backups are refused.</span>' +
+          (d.reason ? ' <span style="color:var(--muted)">' + esc(d.reason) + '</span>' : '');
+      } else {
+        statusLine = '<span style="color:var(--muted)">No key set — backups are refused, because an unencrypted backup would expose this hive\u2019s GitHub App private keys.</span>';
+      }
+      host.innerHTML = `
+        <div style="border:1px solid var(--border);border-radius:8px;padding:14px;background:var(--surface);max-width:640px">
+          <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px">
+            <span style="font-weight:600;font-size:0.9rem">Backup encryption key</span>
+            <span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid #4589ff;color:#4589ff">AES-256-GCM</span>
+            <span style="flex:1"></span>
+            ${configured ? '<button data-action="backupKeyClear" style="padding:4px 12px;border:1px solid var(--red);border-radius:6px;background:var(--bg);color:var(--red);cursor:pointer;font-size:0.74rem">Clear key</button>' : ''}
+            <button data-action="backupKeySet" style="padding:4px 12px;border:none;border-radius:6px;background:#0f62fe;color:#fff;cursor:pointer;font-size:0.74rem;font-weight:600">${configured ? 'Replace key' : 'Set key'}</button>
+          </div>
+          <div style="font-size:0.78rem;margin-bottom:8px">${statusLine}</div>
+          <div style="font-size:0.74rem;color:var(--muted);line-height:1.5">
+            Sets the key that seals <b>Back up this hive</b> archives. Setting it here needs no
+            deployment or cluster access, so hosted hive owners can turn on their own backups.
+            The value is written to a 0600 file on this hive and never appears in hive.yaml,
+            logs, or any API response — and it is <b>not inside the archive</b>, so escrow it
+            somewhere safe: without it a backup cannot be restored. Clearing it disables
+            backups again rather than producing an unencrypted one.
+          </div>
+          <div id="backup-key-inline-status" style="font-size:0.74rem;min-height:18px;margin-top:8px"></div>
+        </div>`;
+
+      const setBtn = host.querySelector('[data-action="backupKeySet"]');
+      if (setBtn) setBtn.addEventListener('click', () => openBackupKeyDialog(configured));
+      const clearBtn = host.querySelector('[data-action="backupKeyClear"]');
+      if (clearBtn) clearBtn.addEventListener('click', clearBackupKey);
+    }
+
+    /* openBackupKeyDialog collects a 64-character hex key. The field is a
+       password input and its value is sent once, over the same-origin PUT —
+       it is never read back, so a replace is a blind overwrite by design. */
+    function openBackupKeyDialog(configured) {
+      let overlay = document.getElementById('backup-key-overlay');
+      if (overlay) overlay.remove();
+      overlay = document.createElement('div');
+      overlay.id = 'backup-key-overlay';
+      overlay.className = 'gh-auth-overlay cred-dialog-overlay';
+      overlay.innerHTML =
+        '<div class="gh-auth-modal" style="max-width:560px;text-align:left">' +
+        '<h3 style="margin:0 0 8px">' + (configured ? 'Replace' : 'Set') + ' backup encryption key</h3>' +
+        '<p style="color:var(--muted);font-size:0.8rem;line-height:1.5;margin:0 0 8px">' +
+        'Generate one with <code>openssl rand -hex 32</code> and store it outside this hive. ' +
+        'Backups are encrypted with it and the key is not included in the archive, so a lost key means an unrestorable backup.' +
+        (configured ? ' Replacing the key does not re-encrypt existing archives — keep the old key to restore them.' : '') +
+        '</p>' +
+        '<label for="backup-key-name-input" style="display:block;font-size:0.78rem;color:var(--muted);margin:8px 0 4px">Key label (optional, e.g. "escrowed in 1Password")</label>' +
+        '<input id="backup-key-name-input" type="text" autocomplete="off" spellcheck="false" maxlength="128" ' +
+        'style="width:100%;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg)">' +
+        '<label for="backup-key-input" style="display:block;font-size:0.78rem;color:var(--muted);margin:10px 0 4px">Encryption key (64 hex characters)</label>' +
+        '<input id="backup-key-input" type="password" autocomplete="off" spellcheck="false" placeholder="64 hex characters" ' +
+        'style="width:100%;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-family:var(--font-mono)">' +
+        '<div id="backup-key-status" style="color:var(--muted);font-size:0.8rem;min-height:20px;margin:6px 0"></div>' +
+        '<div style="display:flex;gap:8px;justify-content:flex-end">' +
+        '<button id="backup-key-cancel" class="gh-cancel" style="margin-top:0">Cancel</button>' +
+        '<button id="backup-key-save" style="background:#0f62fe;color:#fff;border:none;padding:6px 16px;border-radius:6px;cursor:pointer">Save key</button>' +
+        '</div></div>';
+      document.body.appendChild(overlay);
+      overlay.style.display = 'flex';
+
+      const input = document.getElementById('backup-key-input');
+      const statusEl = document.getElementById('backup-key-status');
+      const setStatus = (msg, color) => {
+        if (statusEl) { statusEl.textContent = msg; statusEl.style.color = color || 'var(--muted)'; }
+      };
+      if (input) input.focus();
+
+      const close = () => { overlay.remove(); };
+      const cancelBtn = document.getElementById('backup-key-cancel');
+      if (cancelBtn) cancelBtn.addEventListener('click', close);
+
+      const saveBtn = document.getElementById('backup-key-save');
+      if (saveBtn) saveBtn.addEventListener('click', async () => {
+        const key = (input && input.value || '').trim();
+        if (!key) { setStatus('Paste a 64-character hex key.', 'var(--red)'); return; }
+        if (!/^[0-9a-fA-F]{64}$/.test(key)) {
+          setStatus('A backup key is exactly 64 hex characters (openssl rand -hex 32).', 'var(--red)');
+          return;
+        }
+        const nameInput = document.getElementById('backup-key-name-input');
+        saveBtn.disabled = true;
+        setStatus('Saving…');
+        try {
+          const resp = await fetch('/api/config/governor/backup', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ encryptionKey: key, keyName: (nameInput && nameInput.value || '').trim() })
+          });
+          const d = await resp.json().catch(() => ({}));
+          if (!resp.ok) throw new Error(d && d.error ? d.error : 'HTTP ' + resp.status);
+          if (input) input.value = '';
+          close();
+          showToast('Backup encryption key saved — backups are enabled for this hive', 'success');
+          refreshBackupKeyPanel();
+        } catch (e) {
+          setStatus('Save failed: ' + e.message, 'var(--red)');
+        } finally {
+          saveBtn.disabled = false;
+        }
+      });
+    }
+
+    /* clearBackupKey removes the stored key. Fail-closed: after this, backups
+       are refused again (unless the deployment still supplies HIVE_BACKUP_KEY). */
+    async function clearBackupKey() {
+      if (!confirm('Clear the backup encryption key?\n\nBackups will be refused until a new key is set, and archives sealed with the old key still need that old key to restore.')) return;
+      const statusEl = document.getElementById('backup-key-inline-status');
+      const setStatus = (msg, color) => {
+        if (statusEl) { statusEl.textContent = msg; statusEl.style.color = color || 'var(--muted)'; }
+      };
+      try {
+        const resp = await fetch('/api/config/governor/backup', { method: 'DELETE' });
+        const d = await resp.json().catch(() => ({}));
+        if (!resp.ok) throw new Error(d && d.error ? d.error : 'HTTP ' + resp.status);
+        setStatus('');
+        showToast('Backup encryption key cleared — backups are now refused', 'success');
+        refreshBackupKeyPanel();
+      } catch (e) {
+        setStatus('Clear failed: ' + e.message, 'var(--red)');
+      }
+    }
+
+    /* refreshBackupKeyPanel repaints the Backup panel after a set/clear, but
+       only if the Security tab is still mounted. */
+    function refreshBackupKeyPanel() {
+      if (document.getElementById('gov-backup-key-host')) loadBackupKeyStatus();
     }
 
     // renderGovFeatures renders operational features that are not security posture
@@ -20131,9 +20306,12 @@ function burnAreaChart() {
     /* Owner-only self-service backup.
        POSTs (not a plain link) because the response body carries GitHub App
        private keys: keeping it fetch-only keeps it off the cross-origin
-       navigation path. The archive arrives already encrypted with the hive's
-       HIVE_BACKUP_KEY — the browser never sees that key, and it is NOT in the
-       file, so the owner must have it escrowed to restore. */
+       navigation path. The archive arrives already encrypted with this hive's
+       backup encryption key — set in Governor Config → Security → Backup, or
+       supplied by the deployment as HIVE_BACKUP_KEY. The browser never sees
+       that key, and it is NOT in the file, so the owner must have it escrowed
+       to restore. With no key configured the server refuses (412) rather than
+       producing an unencrypted archive. */
     async function downloadHiveBackup() {
       const btn = document.getElementById('oc-gh-menu-backup');
       if (btn && btn.dataset.busy === '1') return;
@@ -20151,6 +20329,13 @@ function burnAreaChart() {
           let msg = 'Backup failed (' + resp.status + ')';
           try { const d = await resp.json(); if (d && d.error) msg = d.error; } catch (e) { /* non-JSON body */ }
           showToast(msg, 'error');
+          /* 412 is the fail-closed refusal: no encryption key is configured.
+             Take the owner straight to the setting they can change themselves
+             instead of leaving them with an error about a deployment they may
+             have no access to. */
+          if (resp.status === 412 && typeof welcomeShowConfigTab === 'function') {
+            welcomeShowConfigTab('Security');
+          }
           return;
         }
         const blob = await resp.blob();
@@ -20171,7 +20356,8 @@ function burnAreaChart() {
         const files = resp.headers.get('X-Hive-Backup-Files') || '0';
         showToast(
           'Encrypted backup downloaded — ' + files + ' files, ' + beadDirs +
-          ' bead ledgers. Decrypt with this hive’s HIVE_BACKUP_KEY; the key is not in the file.',
+          ' bead ledgers. Decrypt with this hive’s backup encryption key ' +
+          '(Governor Config → Security → Backup); the key is not in the file.',
           'success');
       } catch (e) {
         showToast('Backup failed: ' + (e && e.message ? e.message : 'network error'), 'error');
@@ -21033,6 +21219,7 @@ function burnAreaChart() {
       { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.', onclick: "welcomeShowSection('knowledge-section')" },
       { id: 'contributors', label: 'ClankeR (Contributor Relay)', desc: 'let outside contributors drive agents, with a leaderboard.', onclick: "welcomeShowSection('contributors-section')" },
       { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Governor Config → Hub).', onclick: "welcomeShowConfigTab('Hub')" },
+      { id: 'backup', label: 'Backups', desc: 'set a backup encryption key, then download an encrypted archive of this hive from your account menu. No deployment or cluster access needed — the key is set right here (Governor Config → Security → Backup). Backups are refused while no key is set, so an archive is never written unencrypted.', onclick: "welcomeShowConfigTab('Security')" },
       { id: 'trajectory', label: 'Trajectory Review <span class="welcome-more-tag">advanced</span>', desc: 'an LLM reviewer periodically reads each running agent’s transcript and pauses or alerts you if the agent drifts from the task it was given. Needs one OpenAI-compatible reviewer endpoint (LiteLLM, vLLM, or llm-d) — without it the lane stays inert (Governor Config → General).', onclick: `welcomeShowConfigTab('${TRAJECTORY_CONFIG_TAB}')` },
       { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.', onclick: 'toggleLayout()' }
     ];

--- a/src/pkg/hubbackup/backup.go
+++ b/src/pkg/hubbackup/backup.go
@@ -13,9 +13,11 @@
 //
 // # Encryption
 //
-// The archive is a tar.gz sealed with AES-256-GCM. The key comes from the
-// HIVE_BACKUP_KEY environment variable and has NO default — an unset key is a
-// hard error, never a silent plaintext write.
+// The archive is a tar.gz sealed with AES-256-GCM. The key comes from governor
+// config (governor.backup.key_file, settable from the dashboard by a hosted
+// spoke owner) or, as a fallback, the HIVE_BACKUP_KEY environment variable. It
+// has NO default — an unresolvable key is a hard error, never a silent
+// plaintext write.
 //
 // HIVE_BACKUP_KEY is deliberately INDEPENDENT of /data/saas/hmac.key. hmac.key
 // is itself part of the backup payload; deriving the backup key from it would
@@ -40,13 +42,17 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 // Environment variable names. No secret has a default value.
 const (
-	// EnvBackupKey holds the hex- or base64-encoded AES-256 key used to seal
-	// the archive. Unset is a fatal error.
-	EnvBackupKey = "HIVE_BACKUP_KEY"
+	// EnvBackupKey holds the hex-encoded AES-256 key used to seal the archive.
+	// It is the deployment-level fallback; governor.backup.key_file takes
+	// precedence so hosted owners can configure a key without env access.
+	// No key from any source is a fatal error.
+	EnvBackupKey = config.BackupKeyEnv
 
 	// EnvDataDir overrides the hub data directory (test seam).
 	EnvDataDir = "HIVE_BACKUP_DATA_DIR"
@@ -180,23 +186,52 @@ type Manifest struct {
 // LoadKey reads and validates the AES-256 backup key from the environment.
 // It returns an error when unset so callers fail loudly rather than writing
 // an unencrypted archive.
+//
+// Callers that have a hive config in hand should prefer ResolveKey, which also
+// honours the governor-config key file a hosted spoke owner can set without
+// deployment-env access (#4129). LoadKey stays strictly env-only: the hub cron
+// backup and the hive-backup CLI seal and open archives with the key an
+// operator escrowed, and a key file that happened to exist on a mounted volume
+// must never outrank it.
 func LoadKey() ([]byte, error) {
-	raw := strings.TrimSpace(os.Getenv(EnvBackupKey))
+	return ResolveKey(nil)
+}
+
+// ResolveKey validates the backup key located by cfg (governor config file
+// first, HIVE_BACKUP_KEY as the fallback). A nil cfg resolves the environment
+// only.
+//
+// Fail-closed is the whole point: every failure path returns an error and no
+// key, so a caller can never proceed to write a plaintext archive.
+func ResolveKey(cfg *config.BackupConfig) ([]byte, error) {
+	key, _, err := ResolveKeyWithSource(cfg)
+	return key, err
+}
+
+// ResolveKeyWithSource additionally reports WHERE the key came from, in the
+// safe-to-log "file:<path>" / "env:<NAME>" form. The value is never returned
+// as a string and never appears in an error message.
+func ResolveKeyWithSource(cfg *config.BackupConfig) ([]byte, string, error) {
+	raw, source := cfg.ResolveKeyWithSource()
 	if raw == "" {
-		return nil, fmt.Errorf(
-			"%s is not set: refusing to write an unencrypted backup "+
-				"(generate one with: openssl rand -hex 32)", EnvBackupKey)
+		return nil, "", fmt.Errorf(
+			"no backup encryption key is configured: refusing to write an "+
+				"unencrypted backup (set one in Settings → Governor → Security → "+
+				"Backup encryption key, or set %s on the deployment; generate one "+
+				"with: openssl rand -hex 32)", EnvBackupKey)
 	}
 	key, err := hex.DecodeString(raw)
 	if err != nil {
-		return nil, fmt.Errorf("%s must be %d hex characters (%d-byte AES-256 key): %w",
-			EnvBackupKey, aesKeySize*2, aesKeySize, err)
+		// The decode error from hex reports the offending BYTE, so it is
+		// deliberately not wrapped in: it would echo part of the key.
+		return nil, "", fmt.Errorf("backup encryption key (%s) must be %d hex characters (%d-byte AES-256 key)",
+			source, aesKeySize*2, aesKeySize)
 	}
 	if len(key) != aesKeySize {
-		return nil, fmt.Errorf("%s decoded to %d bytes, want %d (AES-256)",
-			EnvBackupKey, len(key), aesKeySize)
+		return nil, "", fmt.Errorf("backup encryption key (%s) decoded to %d bytes, want %d (AES-256)",
+			source, len(key), aesKeySize)
 	}
-	return key, nil
+	return key, source, nil
 }
 
 // Seal encrypts plaintext with AES-256-GCM, returning nonce||ciphertext.
@@ -232,7 +267,7 @@ func Open(key, data []byte) ([]byte, error) {
 	}
 	plaintext, err := gcm.Open(nil, data[:gcm.NonceSize()], data[gcm.NonceSize():], nil)
 	if err != nil {
-		return nil, fmt.Errorf("decrypt failed (wrong %s, or archive corrupted): %w",
+		return nil, fmt.Errorf("decrypt failed (wrong backup encryption key — governor.backup.key_file or %s — or archive corrupted): %w",
 			EnvBackupKey, err)
 	}
 	return plaintext, nil

--- a/src/pkg/hubbackup/backup_test.go
+++ b/src/pkg/hubbackup/backup_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 // testKey is a deterministic non-secret AES-256 key used only by tests.
@@ -578,5 +580,66 @@ func TestN18_OversizeArchiveMemberIsRejected(t *testing.T) {
 	dest := t.TempDir()
 	if _, err := Extract(key, sealed, dest); err == nil {
 		t.Fatal("N18: an archive member larger than the restore limit was accepted — a decompression bomb can OOM the hub")
+	}
+}
+
+// Governor-config key resolution (#4129). A hosted spoke owner has no
+// deployment-env access, so ResolveKey must accept a key file named by
+// governor config — while keeping the env fallback and the fail-closed
+// refusal when neither supplies one.
+
+func TestResolveKeyFromGovernorConfigFile(t *testing.T) {
+	t.Setenv(EnvBackupKey, "")
+	path := filepath.Join(t.TempDir(), "backup_encryption_key")
+	if err := os.WriteFile(path, []byte(testKey+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	key, source, err := ResolveKeyWithSource(&config.BackupConfig{KeyFile: path})
+	if err != nil {
+		t.Fatalf("configured key must resolve without the env var: %v", err)
+	}
+	if len(key) != aesKeySize {
+		t.Fatalf("key len = %d, want %d", len(key), aesKeySize)
+	}
+	if source != "file:"+path {
+		t.Fatalf("source = %q, want file:%s", source, path)
+	}
+	// The safe source label is what gets logged and returned by APIs.
+	if strings.Contains(source, testKey) {
+		t.Fatal("source label leaked the key value")
+	}
+}
+
+// Fail-closed with a config present but empty: the refusal must still be the
+// explicit one, so an operator learns their backup would have been plaintext.
+func TestResolveKeyRefusesWhenNeitherSourceSet(t *testing.T) {
+	t.Setenv(EnvBackupKey, "")
+	_, _, err := ResolveKeyWithSource(&config.BackupConfig{
+		KeyFile: filepath.Join(t.TempDir(), "does-not-exist"),
+	})
+	if err == nil {
+		t.Fatal("expected a refusal when no source supplies a key")
+	}
+	if !strings.Contains(err.Error(), "refusing to write an unencrypted backup") {
+		t.Fatalf("want the explicit refusal, got %v", err)
+	}
+}
+
+// A malformed configured key must fail closed too, and the error must not
+// echo the (bad) key material back to a caller or a log.
+func TestResolveKeyRejectsMalformedConfiguredKeyWithoutEcho(t *testing.T) {
+	t.Setenv(EnvBackupKey, "")
+	path := filepath.Join(t.TempDir(), "backup_encryption_key")
+	const bad = "zz23456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if err := os.WriteFile(path, []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ResolveKeyWithSource(&config.BackupConfig{KeyFile: path})
+	if err == nil {
+		t.Fatal("a non-hex key must be rejected")
+	}
+	if strings.Contains(err.Error(), bad) {
+		t.Fatalf("error echoed key material: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #4129

## Problem

`Back up this hive` was refused unless `HIVE_BACKUP_KEY` was set on the deployment. Hosted spoke owners have no deployment-env access, so self-service backup was unavailable to exactly the users who cannot rebuild a lost hive by hand. The fail-closed policy was right; the configurability was in the wrong layer.

## What changed

**Governor config surface** — `governor.backup.key_file` / `key_env` / `key_name` (`src/pkg/config/backup.go`). Owners set the key from **Governor Config → Security → Backup**:

- `GET /api/config/governor/backup` — presence, usability, and a safe source label (`file:<path>` / `env:<NAME>`). Never the value.
- `PUT /api/config/governor/backup` — validates a 64-hex AES-256 key, writes it to `/data/secrets/backup_encryption_key` mode `0600`, records the **path** in `hive.yaml`.
- `DELETE /api/config/governor/backup` — removes it; backups are refused again.

All three are owner-only.

**Runtime resolution** — `hubbackup.ResolveKey(cfg)`: governor key file → PVC default → Secret mount → named env var → `HIVE_BACKUP_KEY`. Existing env-configured hives are unaffected. `hubbackup.LoadKey()` (hub cron backup, `hive-backup` CLI) stays strictly env-only, so a stray key file on a mounted volume can never outrank the escrowed key and produce archives nobody can decrypt.

**Fail-closed preserved** — no key from any source ⇒ `GET /api/backup/status` returns `available:false` with a reason, `POST /api/backup` returns `412` and no download. There is no path that writes an unencrypted archive.

**No secret leakage** — the value never appears in a response, in `hive.yaml`, or in a log line; only the source label does. Hex-decode errors are not wrapped in (they name the offending byte).

**UI** — Backup panel in the Security tab (set / replace / clear, with status and escrow warning), a "Backups" entry in the welcome checklist, updated account-menu and toast copy, and a `412` failure now deep-links to the setting instead of naming a deployment the owner cannot see.

**Docs** — `src/docs/backup-restore.md` (hosted flow + security note), `api-reference.md`, `env-vars.md`, `troubleshooting.md`, `README.md`, `agent-configuration.md`, `docs/HUB_DISASTER_RECOVERY.md`.

## Tests

New: backup succeeds and the archive decrypts when the key comes only from Governor config; status is presence-only; the value never lands in the config struct, the response, or a world-readable file (0600 asserted); malformed keys rejected at save time; clear ⇒ `412` again; non-owners get `403` on all three endpoints; config resolution precedence incl. nil-receiver env-only.

```
go build ./...                                   # OK
go test ./pkg/dashboard/ ./pkg/hubbackup/ -count=1   # ok, ok
go test ./pkg/config/ -run Backup -count=1           # ok
go vet ./pkg/config/ ./pkg/hubbackup/ ./pkg/dashboard/   # clean
node --check (all inline dashboard script blocks)        # clean
```