### PR TITLE
🐛 onboarding: clarify Forge App setup and inactive-hive reaping recovery

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -2,7 +2,7 @@
 
 Documentation for the current Hive line (branch `v4`; the code and docs live under the `src/` directory). The `v2` branch was retired in August 2026.
 
-Start with [Architecture](architecture.md) for the system overview, then use the topic guides below.
+Start with [Architecture](architecture.md) for the system overview, then use the topic guides below. New users should start with the [getting-started guide](getting-started.md) — it covers Forge App (GitHub/GHE app) setup and what to do if an inactive hosted hive is reaped.
 
 ## Operations
 
@@ -49,7 +49,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Knowledge curator](https://github.com/kubestellar/hive/blob/v4/src/docs/knowledge-curator.md) — automatic fact extraction and promotion knobs.
 - [Agent peer-awareness logging (pluk)](https://github.com/kubestellar/hive/blob/v4/src/docs/agent-logging.md) — pluk log format, `hive-panes`, availability, and retention.
 - [Strategy Lab (Nous)](https://github.com/kubestellar/hive/blob/v4/src/docs/strategy-lab.md) — experiment lifecycle, dashboard/API configuration, fast-fail bounds, and the gate-decision flow. No `nous:` block in `hive.yaml`.
-- [GitHub App setup](https://github.com/kubestellar/hive/blob/v4/src/docs/github-app-setup.md) — app creation, permissions, Setup URL, and `/gh-setup`.
+- [GitHub App setup](https://github.com/kubestellar/hive/blob/v4/src/docs/github-app-setup.md) — the Forge App on GitHub/GHE: app creation, permissions, Setup URL, and `/gh-setup`.
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [Inception](https://github.com/kubestellar/hive/blob/v4/src/docs/inception.md) — operator guide to the L1 brainstorm/inception workflow: phases, API, and template variables.
 - [ACMM policy fragments](https://github.com/kubestellar/hive/blob/v4/examples/acmm/README.md) — per-level ACMM policy references.

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -42,11 +42,15 @@ The biggest mistake new users make: seeing agent output and either (a) panicking
 
 None of the level guidance below works until your hive is connected to your git host. Do this in your **first session**:
 
-1. **Install the Forge App** (the app you install on your git host — GitHub, GitLab, Gitea, etc.). This is how Hive talks to your repo. Click **Install Forge App** from your dashboard and grant it access to your repo.
-2. **⏰ Don't put this off.** Unconfigured hive instances are reclaimed on a timer. Finish the Forge App install in your first session or your hive may be reaped.
+1. **Install the Forge App.** "Forge App" is Hive's name for the app you install on your git host — on **GitHub.com and GitHub Enterprise (GHE) it's a GitHub App**; on GitLab or Gitea it's the equivalent host app. This is how Hive talks to your repo.
+   - **From the dashboard (easiest):** click **Install Forge App** in the welcome checklist, or open **Governor Config → Forge App** and use the install link there. Grant the app access to your repo.
+   - **On GitHub.com:** the install button sends you to `github.com/apps/<app-slug>` — pick your org/repo and approve.
+   - **On GitHub Enterprise (IBM, corporate):** the same flow lives on your **GHE host**, not github.com — the install page is `https://<your-ghe-host>/github-apps/<app-slug>`. Make sure your hive is pointed at your GHE host URL (Governor Config → Forge App shows which host is configured).
+   - **Self-hosting or creating the app yourself?** See the [GitHub App setup guide](github-app-setup.md) for app creation, permissions, and the `/gh-setup` flow.
+2. **⏰ Don't put this off.** Unconfigured hive instances are reclaimed on a timer. Finish the Forge App install in your first session or your hive may be reaped — see [What if my hive disappeared?](#what-if-my-hive-disappeared-inactive-hive-reaping) below.
 3. **Wait for the first heartbeat.** After installing, a heartbeat cycle has to run (a few minutes) before everything lights up green.
 
-> **On GitHub Enterprise (IBM, corporate)?** Setup is slightly different: point Hive at your **GHE host URL**, not github.com. The Forge App install flow lives on your enterprise host.
+> **On GitHub Enterprise (IBM, corporate)?** Setup is slightly different: point Hive at your **GHE host URL**, not github.com. The Forge App install flow lives on your enterprise host — a 404 from the install button almost always means the wrong host.
 
 > 💡 **Tip: name your hive like a team member.** The `ai_author` field is the login your agents use when opening PRs. Pick a name that signals what it does — `hive-bot`, `your-repo-ai`, `proj-assistant`. A clear name means your team immediately knows which PRs are agent-authored vs human-authored.
 
@@ -57,6 +61,24 @@ None of the level guidance below works until your hive is connected to your git 
 - **Dashboard full of warnings?** Normal. Most warnings clear automatically after the Forge App is installed and the first heartbeat runs. Don't panic.
 - **"Install Forge App" gives a 404?** Usually a GHE-vs-github.com mixup, or the app isn't available on your host yet. Double-check which git host you're on.
 - **Changed a setting and nothing happened?** Agents pick up config changes on the next **heartbeat cycle**. Wait 2–3 minutes before assuming something is broken.
+- **Hive vanished from Usage / old URL times out?** Your hive was probably reaped for inactivity. See the next section — recovery is quick.
+
+---
+
+## What if my hive disappeared? (inactive-hive reaping)
+
+Hosted hives that stay **unconfigured or inactive are reclaimed ("reaped") on a timer** to free fleet capacity. When that happens:
+
+- Your hive stops appearing under **Usage** on the hub.
+- The old hive URL (`https://<id>.hive.kubestellar.io`) **times out** — it is gone, not just sleeping.
+
+**This is normal and recoverable.** Nothing is wrong with your account. To get going again:
+
+1. **Request a new hive.** Go to the hub and click **Request a hive** (the `/get-started` wizard — on the hosted hub that's [hive.kubestellar.io/get-started](https://hive.kubestellar.io/get-started)). You'll get a fresh hive with a new URL — don't wait for the old URL to come back.
+2. **Complete Step 0 right away.** Install the [Forge App](#step-0--before-you-start-do-this-first) (the GitHub/GHE app) in your **first session** on the new hive. An installed Forge App plus regular heartbeats is what keeps a hive from being reaped again.
+3. **Update your bookmarks** to the new hive URL.
+
+> 💡 **Avoid a repeat:** the reap timer targets hives that never finished setup or went quiet. Finish the Forge App install on day one and your hive will stick around.
 
 ---
 

--- a/src/docs/github-app-setup.md
+++ b/src/docs/github-app-setup.md
@@ -1,10 +1,12 @@
 # GitHub App setup
 
+> **Terminology:** the dashboard and docs call this the **Forge App** — Hive's host-neutral name for the app installed on your git host. On **GitHub.com and GitHub Enterprise (GHE)** the Forge App **is a GitHub App**; this page covers creating and installing it. Dashboard controls live under **Governor Config → Forge App**.
+
 Hive can authenticate with either a personal access token or a GitHub App. Use a GitHub App for production hives because installation tokens are scoped to selected repositories and can author PRs as the app bot when `github.app_authored_prs` is enabled.
 
 ## Create the app
 
-In GitHub, open **Settings → Developer settings → GitHub Apps → New GitHub App** (or the equivalent organization settings page).
+In GitHub, open **Settings → Developer settings → GitHub Apps → New GitHub App** (or the equivalent organization settings page). On **GitHub Enterprise**, do this on your enterprise host (`https://<your-ghe-host>/settings/apps/new`), not github.com — the app, its install page (`https://<your-ghe-host>/github-apps/<app-slug>`), and Hive's configured forge host must all be the same host.
 
 Recommended values:
 

--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -46,7 +46,17 @@ When no token or App credentials are usable, v2 starts the dashboard but disable
 - `GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.`
 - `persisted user token is invalid or expired`
 
-Check the configured `github:` block, the `HIVE_GITHUB_TOKEN` secret/env var, or the GitHub App `app_id`, `installation_id`, and `key_file`. For App setup, use the dashboard banner or `/gh-setup`; details are in [GitHub App setup](github-app-setup.md).
+Check the configured `github:` block, the `HIVE_GITHUB_TOKEN` secret/env var, or the GitHub App `app_id`, `installation_id`, and `key_file`. For App setup, use the dashboard banner or `/gh-setup`; details are in [GitHub App setup](github-app-setup.md). Note the dashboard calls the GitHub/GHE app the **Forge App** (Governor Config → Forge App).
+
+## Hosted hive disappeared or its URL times out
+
+Hosted hives that never complete setup or go inactive are **reaped on a timer**: the hive vanishes from the hub's Usage view and the old `https://<id>.hive.kubestellar.io` URL times out permanently. This is expected reclamation, not an outage. Recovery:
+
+1. **Request a new hive** from the hub's `/get-started` wizard (hosted hub: `https://hive.kubestellar.io/get-started`, the **Request a hive** button). The old URL will not come back.
+2. **Install the Forge App immediately** on the new hive — the GitHub App on GitHub.com, or the same app on your GHE host for enterprise. See [GitHub App setup](github-app-setup.md) and the [getting-started guide's Step 0](getting-started.md#step-0--before-you-start-do-this-first).
+3. An installed Forge App plus regular heartbeats keeps the new hive from being reaped again.
+
+On GitHub Enterprise, a 404 from the install link usually means the hive is pointed at github.com instead of your GHE host (or vice versa) — check the configured forge host under Governor Config → Forge App.
 
 ## Agents are stuck, paused, or need CLI login
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -20926,7 +20926,7 @@ function burnAreaChart() {
       },
       {
         id: 'github-app',
-        title: 'Install the GitHub App',
+        title: 'Install the Forge App (GitHub App)',
         // An operator-side credential failure is not an unfinished user step.
         // Return null ("cannot tell") rather than false, so the checklist does
         // not mark the user as having something left to do when the missing
@@ -20936,7 +20936,7 @@ function burnAreaChart() {
           if (ghAppIsOperatorSide(data.githubAppState)) return null;
           return data.githubAppRequired !== true;
         },
-        body: 'The GitHub App unlocks issues, advisory reports, and PRs on your primary repo — without it the hive can only observe.',
+        body: 'The <strong>Forge App</strong> — a GitHub App on GitHub.com and GitHub Enterprise — unlocks issues, advisory reports, and PRs on your primary repo; without it the hive can only observe. ⏰ <strong>Do this in your first session:</strong> hosted hives that never finish this step are reclaimed (reaped) on a timer — the hive disappears from the hub and its URL stops working. If that happens, request a new hive from the hub and complete this step right away. On GHE the install page lives on your enterprise host, not github.com. Full instructions: <a href="https://github.com/kubestellar/hive/blob/v4/src/docs/github-app-setup.md" target="_blank" rel="noopener noreferrer">Forge App (GitHub App) setup</a>.',
         autoNote: 'Checks itself once the app is detected on your repository.',
         actions: [
           { label: 'Install GitHub App', onclick: 'welcomeInstallGitHubApp()' },
@@ -21056,7 +21056,7 @@ function burnAreaChart() {
         _welcomeOpenSteps.add(firstUndone ? firstUndone.id : WELCOME_STEPS[0].id);
       }
       let html = '';
-      html += '<div class="welcome-intro">New to Hive? Start here → <a href="https://docs.kubestellar.io/docs/hive/getting-started" target="_blank" rel="noopener noreferrer" style="color:var(--accent);font-weight:600">Zero to Automation: Your Getting Started Guide</a></div>';
+      html += '<div class="welcome-intro">New to Hive? Start here → <a href="https://docs.kubestellar.io/docs/hive/getting-started" target="_blank" rel="noopener noreferrer" style="color:var(--accent);font-weight:600">Zero to Automation: Your Getting Started Guide</a><br><span style="font-size:0.85em;color:var(--muted)">⏰ Heads up: hosted hives that stay unconfigured or inactive are reaped on a timer. Install the Forge App (step 2) in your first session — and if your hive ever disappears or its URL times out, request a new one from the hub and set it up promptly.</span></div>';
       let n = 0;
       for (const step of WELCOME_STEPS) {
         n++;


### PR DESCRIPTION
Closes #4130

## What

A GHE user's hosted hive disappeared after inactivity (reaped), the old URL timed out, and the docs never explained Forge App setup paths or what to do next. This PR closes those UX gaps across docs and the dashboard welcome dialog.

## Changes

**Docs**
- `getting-started.md`: Step 0 now gives explicit Forge App install guidance for **GitHub.com and GHE** (dashboard path, install URLs, link to the GitHub App setup guide), and a new prominent **“What if my hive disappeared? (inactive-hive reaping)”** section documents reap behavior and the exact recovery flow: request a new hive via the hub `/get-started` wizard and complete Step 0 promptly.
- `github-app-setup.md`: terminology note mapping **Forge App = GitHub App on GitHub.com/GHE**, plus GHE app-creation and install-host guidance.
- `troubleshooting.md`: new **“Hosted hive disappeared or its URL times out”** section (reap behavior + recovery + GHE 404 gotcha).
- `src/docs/README.md`: points new users at the getting-started guide.

**Dashboard welcome dialog** (`static/index.html`)
- GitHub App step retitled **“Install the Forge App (GitHub App)”** with reap warning, recovery pointer, GHE note, and a link to the setup doc.
- Welcome intro warns about inactivity reaping and what to do if a hive disappears.

## Acceptance criteria

- [x] Docs include explicit Forge App guidance for both GitHub.com and GHE (with clear navigation path/link text)
- [x] Docs include inactive hive reaping behavior and recovery steps
- [x] Welcome/dashboard help text points users to these steps
- [x] Language consistently maps “Forge App” to GitHub/GHE app terminology

## Validation

- `go test ./pkg/dashboard/ -count=1` — pass (34.7s), including the welcome/gh-app/forge index.html contract tests
- Inline JS in `index.html` syntax-checked