### PR TITLE
🐛 dashboard: budget save wrongly denied for owner — grant owner to shared-token operators

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -1389,10 +1389,11 @@ func pauseToggleResponse(w http.ResponseWriter, status, agent string, changed, p
 // requireOwnerRole returns true when authenticate established owner-level access.
 // A client-supplied X-Hive-Role is not enough: authenticate strips inbound role
 // headers before auth and sets ownerRoleVerifiedHeader only for trusted owner
-// sessions or proof-verified hub proxy identities. Owner-only mutations must
-// require its server-only verification marker, so legacy/proofless proxy
-// headers and shared-token requests fail closed instead of trusting spoofable
-// client input.
+// sessions, proof-verified hub proxy identities, or shared-token operators
+// (X-Hive-Internal / bearer token — possession of the secret is the owner
+// credential on those deployments). Owner-only mutations must require its
+// server-only verification marker, so legacy/proofless proxy headers fail
+// closed instead of trusting spoofable client input.
 func requireOwnerRole(w http.ResponseWriter, r *http.Request) bool {
 	role := r.Header.Get("X-Hive-Role")
 	if !isOwnerRole(role) || r.Header.Get(ownerRoleVerifiedHeader) != "true" {

--- a/src/pkg/dashboard/budget_owner_gate_4134_test.go
+++ b/src/pkg/dashboard/budget_owner_gate_4134_test.go
@@ -1,0 +1,157 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for #4134: "Failed to save budget: owner access required"
+// shown to the hive OWNER. The dashboard UI authenticates with the shared
+// dashboard token (Authorization: Bearer <token> from localStorage, or via the
+// local gateway which injects X-Hive-Internal), but the F14 owner-provenance
+// hardening only set the server-side owner verification marker for per-user
+// sessions and proof-verified hub identities — so on every token-secured
+// spoke the operator's own budget save was denied by requireOwnerRole.
+//
+// These tests run PUT /api/config/governor/budget through the FULL middleware
+// stack (authenticate → roleEnforcement → mux), exactly as a browser request
+// arrives.
+
+const budget4134Token = "shared-secret-token-4134"
+
+// seedBudget4134 stores a known-good budget so a partial update validates.
+func seedBudget4134(s *Server) {
+	s.deps.Config.Governor.Budget.TotalTokens = 1000
+	s.deps.Config.Governor.Budget.PeriodDays = 7
+	s.deps.Config.Governor.Budget.CriticalPct = 90
+}
+
+func putBudget4134(s *Server, decorate func(*http.Request)) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget",
+		strings.NewReader(`{"totalTokens":50000}`))
+	req.Header.Set("Content-Type", "application/json")
+	if decorate != nil {
+		decorate(req)
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+// Owner success — bearer shared token (how the dashboard UI authenticates on
+// a token-secured spoke reached directly).
+func TestBudgetSave4134_OwnerViaBearerToken(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = budget4134Token
+	seedBudget4134(s)
+
+	w := putBudget4134(s, func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer "+s.authToken)
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner budget save via bearer token = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000 {
+		t.Fatalf("totalTokens = %d, want 50000 (save did not persist)", got)
+	}
+}
+
+// Owner success — gateway path (local proxy strips client identity headers
+// and injects X-Hive-Internal with the shared token).
+func TestBudgetSave4134_OwnerViaInternalToken(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = budget4134Token
+	seedBudget4134(s)
+
+	w := putBudget4134(s, func(r *http.Request) {
+		r.Header.Set("X-Hive-Internal", s.authToken)
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner budget save via internal token = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000 {
+		t.Fatalf("totalTokens = %d, want 50000 (save did not persist)", got)
+	}
+}
+
+// Owner success — verified owner session (device-flow login).
+func TestBudgetSave4134_OwnerViaSession(t *testing.T) {
+	s := newDirectRouteServer(t, "owneruser")
+	seedBudget4134(s)
+	sid := s.createUserSession("owneruser", "owner")
+
+	w := putBudget4134(s, func(r *http.Request) {
+		r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner budget save via session = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// Non-owner denial — a read-role session must still be blocked.
+func TestBudgetSave4134_ReadSessionDenied(t *testing.T) {
+	s := newDirectRouteServer(t, "readuser")
+	seedBudget4134(s)
+	sid := s.createUserSession("readuser", "read")
+
+	w := putBudget4134(s, func(r *http.Request) {
+		r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("read-role budget save = %d, want 403; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 1000 {
+		t.Fatalf("totalTokens = %d, want 1000 (denied save must not persist)", got)
+	}
+}
+
+// Non-owner denial — a non-owner (read-write) session lacks the owner gate.
+func TestBudgetSave4134_NonOwnerSessionDenied(t *testing.T) {
+	s := newDirectRouteServer(t, "rwuser")
+	seedBudget4134(s)
+	sid := s.createUserSession("rwuser", "read-write")
+
+	w := putBudget4134(s, func(r *http.Request) {
+		r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("read-write budget save = %d, want 403; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// Spoof denial — owner identity headers without any credential are stripped
+// and rejected; the fix must not reopen header spoofing.
+func TestBudgetSave4134_SpoofedOwnerHeadersDenied(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = budget4134Token
+	seedBudget4134(s)
+
+	w := putBudget4134(s, func(r *http.Request) {
+		r.Header.Set("X-Hive-User", "attacker")
+		r.Header.Set("X-Hive-Role", "owner")
+		r.Header.Set(ownerRoleVerifiedHeader, "true")
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("spoofed owner headers budget save = %d, want 401; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 1000 {
+		t.Fatalf("totalTokens = %d, want 1000 (spoofed save must not persist)", got)
+	}
+}
+
+// Wrong-token denial — possession of the secret, not its mere mention, is the
+// owner credential.
+func TestBudgetSave4134_WrongBearerTokenDenied(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = budget4134Token
+	seedBudget4134(s)
+
+	w := putBudget4134(s, func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer not-the-token")
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong bearer token budget save = %d, want 401; body=%q", w.Code, w.Body.String())
+	}
+}

--- a/src/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/src/pkg/dashboard/dashboard_owner_authz_test.go
@@ -34,7 +34,13 @@ func TestOwnerOnlyAgentControlsRejectNonOwners(t *testing.T) {
 	}
 }
 
-func TestOwnerOnlyMutationsRejectSharedTokenWithoutRole(t *testing.T) {
+// TestOwnerOnlyMutationsAllowSharedBearerToken pins the #4134 fix: the shared
+// dashboard token IS the operator credential on token-secured spokes (the
+// dashboard UI itself sends it as Authorization: Bearer from localStorage), so
+// presenting it must grant the server-set owner role. Before the fix every
+// owner-gated save (budget, pause, breaker...) failed with "owner access
+// required" for the legitimate operator.
+func TestOwnerOnlyMutationsAllowSharedBearerToken(t *testing.T) {
 	tests := []struct {
 		name string
 		path string
@@ -55,34 +61,36 @@ func TestOwnerOnlyMutationsRejectSharedTokenWithoutRole(t *testing.T) {
 
 			s.Handler().ServeHTTP(w, req)
 
-			if w.Code != http.StatusForbidden {
-				t.Fatalf("shared-token request without server role status = %d, want 403", w.Code)
+			if w.Code != http.StatusOK {
+				t.Fatalf("shared-token operator request status = %d, want 200; body=%q", w.Code, w.Body.String())
 			}
 		})
 	}
 }
 
-func TestOwnerOnlyMutationsRejectSpoofedOwnerRoleWithSharedToken(t *testing.T) {
+func TestOwnerOnlyMutationsRejectSpoofedOwnerRoleWithWrongToken(t *testing.T) {
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"
 	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
-	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	req.Header.Set("Authorization", "Bearer wrong-token")
 	req.Header.Set("X-Hive-User", "attacker")
 	req.Header.Set("X-Hive-Role", "owner")
 	w := httptest.NewRecorder()
 
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("spoofed owner role with shared token status = %d, want 403", w.Code)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("spoofed owner role with wrong token status = %d, want 401", w.Code)
 	}
 }
 
+// TestOwnerOnlyMutationsRejectSpoofedOwnerVerificationMarker: the server-only
+// verification marker is stripped from inbound requests, so spoofing it (with
+// role headers, without any valid credential) gains nothing.
 func TestOwnerOnlyMutationsRejectSpoofedOwnerVerificationMarker(t *testing.T) {
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"
 	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
-	req.Header.Set("Authorization", "Bearer "+s.authToken)
 	req.Header.Set("X-Hive-User", "attacker")
 	req.Header.Set("X-Hive-Role", "owner")
 	req.Header.Set("X-Hive-Owner-Role-Verified", "true")
@@ -90,12 +98,16 @@ func TestOwnerOnlyMutationsRejectSpoofedOwnerVerificationMarker(t *testing.T) {
 
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("spoofed owner verification marker with shared token status = %d, want 403", w.Code)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("spoofed owner verification marker without credential status = %d, want 401", w.Code)
 	}
 }
 
-func TestOwnerOnlyMutationsRejectInternalSharedTokenWithoutVerifiedRole(t *testing.T) {
+// TestOwnerOnlyMutationsAllowInternalSharedToken pins the #4134 fix for the
+// gateway path: the local proxy authenticates the browser, strips client
+// identity headers, and injects X-Hive-Internal — that request is the
+// operator and must pass owner-gated endpoints.
+func TestOwnerOnlyMutationsAllowInternalSharedToken(t *testing.T) {
 	s := newFullServer(t)
 	s.authToken = "shared-secret-token"
 	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
@@ -104,8 +116,25 @@ func TestOwnerOnlyMutationsRejectInternalSharedTokenWithoutVerifiedRole(t *testi
 
 	s.Handler().ServeHTTP(w, req)
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("internal shared token owner status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// A per-user session always scopes an internal-token request DOWN: a read-role
+// session riding alongside X-Hive-Internal must not inherit owner.
+func TestOwnerOnlyMutationsRejectReadSessionWithInternalAuth(t *testing.T) {
+	s := newDirectRouteServer(t, "readuser")
+	sid := s.createUserSession("readuser", "read")
+	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(w, req)
+
 	if w.Code != http.StatusForbidden {
-		t.Fatalf("internal shared token without verified role status = %d, want 403", w.Code)
+		t.Fatalf("read session with internal auth status = %d, want 403; body=%q", w.Code, w.Body.String())
 	}
 }
 

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -1012,6 +1012,20 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 				if isOwnerRole(sess.Role) {
 					r.Header.Set(ownerRoleVerifiedHeader, "true")
 				}
+			} else {
+				// No per-user session to scope this request down: the shared
+				// internal token IS the operator credential on this path (the
+				// local gateway authenticates the browser with the same token,
+				// strips client identity headers, then injects X-Hive-Internal).
+				// Grant owner with the server-set verified marker so owner-only
+				// mutations (budget save, pause, etc.) work for the operator.
+				// Inbound identity headers were already stripped above, so this
+				// cannot be reached by spoofing — only by presenting the secret,
+				// which is owner-equivalent by definition. Without this, the F14
+				// provenance hardening locked the real owner out of owner-gated
+				// endpoints on every shared-token deployment (#4134).
+				r.Header.Set("X-Hive-Role", config.RoleOwner)
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
 			}
 		}
 
@@ -1092,6 +1106,15 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			expected := "Bearer " + s.authToken
 			if secureCompare(token, expected) || secureCompare(token, s.authToken) {
 				trusted = true
+				// Same reasoning as the X-Hive-Internal path above: the shared
+				// dashboard token is the operator credential, and the dashboard
+				// UI itself authenticates with it (Authorization: Bearer from
+				// localStorage) on token-secured spokes reached directly. The
+				// per-user session path already ran and did not match, and
+				// inbound identity headers were stripped, so granting owner here
+				// requires possession of the secret — nothing less (#4134).
+				r.Header.Set("X-Hive-Role", config.RoleOwner)
+				r.Header.Set(ownerRoleVerifiedHeader, "true")
 			}
 		}
 


### PR DESCRIPTION
## Root cause

The F14 owner-provenance hardening (dfb5f4ff) made owner-only mutations require a server-set verification marker (`X-Hive-Owner-Role-Verified`), set by `authenticate` only for:
- per-user owner sessions (device flow), and
- proof-verified hub-proxied owner identities.

Requests authenticated by the **shared dashboard token** were left trusted but **role-less**. That is exactly how the dashboard UI authenticates outside the hub proxy:
- `Authorization: Bearer <token>` from localStorage (`_inceptionAuthHeaders()` in `static/index.html`), and
- the local gateway (`proxy/server.js`), which authenticates the browser with the same token, strips client identity headers, and injects `X-Hive-Internal`.

So on every token-secured spoke, `requireOwnerRole` denied the legitimate operator's own saves — on certus this surfaced as the toast **"Failed to save budget: owner access required"** (PUT `/api/config/governor/budget`).

## Fix

In `authenticate`, when a request proves possession of the shared token (`X-Hive-Internal` or bearer/query token) and no per-user session scopes it down, set `X-Hive-Role: owner` plus the server-only verified marker. Possession of the secret is the operator credential on these deployments — the same threat model as before F14.

## Security boundary preserved

- Inbound `X-Hive-User`/`X-Hive-Role`/verified-marker headers are still stripped before auth — spoofing without the secret is still rejected (401).
- Wrong token → 401. Proofless hub identity headers → 401.
- A per-user session always takes precedence: read/read-write sessions are still denied (403), even alongside `X-Hive-Internal`.
- Bearer path remains disabled on direct-route (allowlist) spokes.

## Tests

New `budget_owner_gate_4134_test.go` runs PUT `/api/config/governor/budget` through the full middleware stack: owner success via bearer token, internal token, and owner session; denial for read and read-write sessions, spoofed owner headers, and wrong token. Updated `dashboard_owner_authz_test.go` to pin the new shared-token-operator semantics while keeping all spoof/wrong-credential rejections.

`go test ./pkg/dashboard/` passes (full package), `go vet` clean.

Closes #4134