### PR TITLE
fix(ci): harden dashboard lint filename handling

### DIFF
--- a/.github/workflows/dashboard-lint.yml
+++ b/.github/workflows/dashboard-lint.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'dashboard/**'
 
+permissions:
+  contents: read
+
 jobs:
   syntax-check:
     runs-on: ubuntu-latest
@@ -15,12 +18,12 @@ jobs:
 
       - name: Extract and syntax-check inline JavaScript
         run: |
-          for html_file in $(find dashboard -name '*.html'); do
+          find dashboard -type f -name '*.html' -print0 | while IFS= read -r -d '' html_file; do
             echo "Checking $html_file..."
             # Extract all <script> blocks (handles multiple blocks per file)
-            node -e "
+            node - "$html_file" <<'NODE'
               const fs = require('fs');
-              const html = fs.readFileSync('$html_file', 'utf8');
+              const html = fs.readFileSync(process.argv[2], 'utf8');
               const re = /<script[^>]*>([\s\S]*?)<\/script>/gi;
               let match, idx = 0;
               while ((match = re.exec(html)) !== null) {
@@ -31,11 +34,11 @@ jobs:
                 idx++;
               }
               console.log('Extracted ' + idx + ' script block(s)');
-            "
+          NODE
             # Syntax-check each extracted block
             for block in /tmp/block_*.js; do
               [ -f "$block" ] || continue
-              echo "  Parsing $(basename $block)..."
+              echo "  Parsing $(basename -- "$block")..."
               node --check "$block"
             done
             rm -f /tmp/block_*.js


### PR DESCRIPTION
## Summary

- pass dashboard HTML paths to Node as positional arguments instead of interpolating them into `node -e` source
- process filenames with NUL-delimited `find` output
- restrict the workflow token to `contents: read`

## Validation

- `actionlint .github/workflows/dashboard-lint.yml`
- `git diff --check`
- exercised the Node path handoff with a filename containing a double quote

Fixes #4125

— hive: backend=codex