### PR TITLE
🐛 manage-access: normalize user identity labels and add user search

### DIFF
--- a/src/pkg/hub/grantable_users_test.go
+++ b/src/pkg/hub/grantable_users_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -193,6 +194,163 @@ func TestHandleGrantableUsersSkipsRecordsWithoutUsername(t *testing.T) {
 	for _, u := range decodeUsers(t, rec) {
 		if u == "" {
 			t.Errorf("roster contains an empty username: %v", decodeUsers(t, rec))
+		}
+	}
+}
+
+// TestGrantableUserLabel pins the display-label preference order for the
+// Manage Access picker: provider-asserted display name, then a plain GitHub
+// login, then email, then linked GitHub login, then a truncated
+// "provider: subject…" fallback. The label is display-only — the identity key
+// used for grants is always the record's GitHubUsername and never changes.
+func TestGrantableUserLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		user SaaSUser
+		want string
+	}{
+		{
+			name: "plain github login stays as-is",
+			user: SaaSUser{GitHubUsername: "octocat"},
+			want: "octocat",
+		},
+		{
+			name: "github-prefixed key drops the prefix",
+			user: SaaSUser{GitHubUsername: "github:octocat"},
+			want: "octocat",
+		},
+		{
+			name: "display name wins over everything",
+			user: SaaSUser{GitHubUsername: "google:107812345678901234567", DisplayName: "Jane Doe", Email: "jane@example.com"},
+			want: "Jane Doe",
+		},
+		{
+			name: "email beats the raw google id",
+			user: SaaSUser{GitHubUsername: "google:107812345678901234567", Email: "jane@example.com"},
+			want: "jane@example.com",
+		},
+		{
+			name: "linked github login beats the raw ibmid",
+			user: SaaSUser{GitHubUsername: "ibmid:650001ABCD", LinkedGitHubLogin: "jane-gh"},
+			want: "jane-gh",
+		},
+		{
+			name: "opaque microsoft token-like sub is truncated with provider prefix",
+			user: SaaSUser{GitHubUsername: "microsoft:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+			want: "microsoft: AAAAAAAAAAAA…",
+		},
+		{
+			name: "short opaque sub is shown whole",
+			user: SaaSUser{GitHubUsername: "ibmid:65001"},
+			want: "ibmid: 65001",
+		},
+		{
+			name: "display name wins for a plain github user too",
+			user: SaaSUser{GitHubUsername: "octocat", DisplayName: "The Octocat"},
+			want: "The Octocat",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := tc.user
+			if got := grantableUserLabel(&u); got != tc.want {
+				t.Errorf("grantableUserLabel(%+v) = %q, want %q", tc.user, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGrantableUserProvider pins provider classification: the stored Provider
+// field wins, else the identity-key prefix, else github (legacy plain login).
+func TestGrantableUserProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		user SaaSUser
+		want string
+	}{
+		{name: "stored provider wins", user: SaaSUser{GitHubUsername: "google:123", Provider: "google"}, want: "google"},
+		{name: "prefix classifies a legacy record", user: SaaSUser{GitHubUsername: "ibmid:650"}, want: "ibmid"},
+		{name: "plain login defaults to github", user: SaaSUser{GitHubUsername: "octocat"}, want: "github"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u := tc.user
+			if got := grantableUserProvider(&u); got != tc.want {
+				t.Errorf("grantableUserProvider(%+v) = %q, want %q", tc.user, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleGrantableUsersEntriesCarryNormalizedLabels checks the enriched
+// payload: each entry pairs the STABLE identity key (id — what the grant POST
+// must send) with the normalized human label, entries sort by that label, and
+// the legacy "users" array still carries the raw IDs for older dashboards.
+func TestHandleGrantableUsersEntriesCarryNormalizedLabels(t *testing.T) {
+	withTempSaaSDirs(t)
+	putUser(t, "alice")
+	putHiveOwnedBy(t, "hive-1", "alice")
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "google:107812345678901234567", DisplayName: "Jane Doe"}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "microsoft:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	rec := getGrantableUsers(t, grantableTestServer(), "alice")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Users   []string             `json:"users"`
+		Entries []grantableUserEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	wantEntries := []grantableUserEntry{
+		{ID: "alice", Label: "alice", Provider: "github"},
+		{ID: "google:107812345678901234567", Label: "Jane Doe", Provider: "google"},
+		{ID: "microsoft:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", Label: "microsoft: AAAAAAAAAAAA…", Provider: "microsoft"},
+	}
+	if len(resp.Entries) != len(wantEntries) {
+		t.Fatalf("entries = %+v, want %+v", resp.Entries, wantEntries)
+	}
+	for i, want := range wantEntries {
+		if resp.Entries[i] != want {
+			t.Errorf("entries[%d] = %+v, want %+v", i, resp.Entries[i], want)
+		}
+	}
+	// Legacy field unchanged: raw stable IDs, sorted.
+	wantUsers := []string{"alice", "google:107812345678901234567", "microsoft:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}
+	if len(resp.Users) != len(wantUsers) {
+		t.Fatalf("users = %v, want %v", resp.Users, wantUsers)
+	}
+	for i := range wantUsers {
+		if resp.Users[i] != wantUsers[i] {
+			t.Errorf("users = %v, want %v", resp.Users, wantUsers)
+			break
+		}
+	}
+}
+
+// TestManageAccessDialogHasUserSearch pins the search affordance in the
+// Manage Access dialog: a search input wired to the client-side filter, and a
+// dropdown renderer that matches case-insensitively against both the friendly
+// label and the raw identity key.
+func TestManageAccessDialogHasUserSearch(t *testing.T) {
+	for _, want := range []string{
+		`id="access-user-search"`,
+		`oninput="filterAccessUserDropdown()"`,
+		`function filterAccessUserDropdown()`,
+		`function renderAccessUserOptions(filter)`,
+		`e.label.toLowerCase().indexOf(q) !== -1 || e.id.toLowerCase().indexOf(q) !== -1`,
+		// Fallback for older hub payloads that only carry bare usernames.
+		`data.entries || (data.users || []).map`,
+	} {
+		if !strings.Contains(dashboardHTML, want) {
+			t.Errorf("dashboardHTML missing %q", want)
 		}
 	}
 }

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -6107,14 +6108,105 @@ func (s *HubServer) handleGrantableUsers(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	names := make([]string, 0)
+	entries := make([]grantableUserEntry, 0)
 	for _, u := range listAllSaaSUsers() {
-		if u.GitHubUsername != "" {
-			names = append(names, u.GitHubUsername)
+		if u.GitHubUsername == "" {
+			continue
 		}
+		u := u
+		names = append(names, u.GitHubUsername)
+		entries = append(entries, grantableUserEntry{
+			ID:       u.GitHubUsername,
+			Label:    grantableUserLabel(&u),
+			Provider: grantableUserProvider(&u),
+		})
 	}
 	sort.Strings(names)
+	// Sort by the label an owner actually reads in the picker, falling back to
+	// the stable ID so two identical display names still order deterministically.
+	sort.Slice(entries, func(i, j int) bool {
+		li, lj := strings.ToLower(entries[i].Label), strings.ToLower(entries[j].Label)
+		if li != lj {
+			return li < lj
+		}
+		return entries[i].ID < entries[j].ID
+	})
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"users": names})
+	// "users" (bare stable IDs) is kept for back-compat with older dashboards;
+	// "entries" adds the normalized display label alongside the same stable ID
+	// so the picker can show a human name while still granting by identity key.
+	json.NewEncoder(w).Encode(map[string]any{"users": names, "entries": entries})
+}
+
+// grantableUserEntry is one row of the Manage Access "Add User" picker: the
+// stable identity key used for permission grants plus the friendly label an
+// owner should see instead of a raw provider ID.
+type grantableUserEntry struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// identityProviderPrefixRE matches wire-form provider-prefixed identity keys
+// like "google:107812...", "ibmid:6500...", "microsoft:AAAA...". A plain
+// GitHub login can never match: GitHub logins cannot contain ":".
+var identityProviderPrefixRE = regexp.MustCompile(`^([a-z][a-z0-9_-]*):(.+)$`)
+
+// splitIdentityKey breaks a provider-prefixed identity key ("google:1078")
+// into its provider and raw subject. A plain login returns ("", key).
+func splitIdentityKey(key string) (provider, sub string) {
+	if m := identityProviderPrefixRE.FindStringSubmatch(key); m != nil {
+		return m[1], m[2]
+	}
+	return "", key
+}
+
+// grantableUserProvider reports the identity provider for a roster entry,
+// preferring the stored Provider field and falling back to the prefix of the
+// identity key so legacy records still classify correctly.
+func grantableUserProvider(u *SaaSUser) string {
+	if u.Provider != "" {
+		return u.Provider
+	}
+	if p, _ := splitIdentityKey(u.GitHubUsername); p != "" {
+		return p
+	}
+	return "github"
+}
+
+// maxOpaqueIDLabelLen bounds how much of a raw opaque subject the fallback
+// label shows before truncating — enough to disambiguate, short enough that a
+// token-like Microsoft sub doesn't blow out the dropdown.
+const maxOpaqueIDLabelLen = 12
+
+// grantableUserLabel derives the friendly display label for a user in the
+// Manage Access picker. It NEVER changes the identity key used for grants —
+// display only. Preference order:
+//  1. provider-asserted DisplayName from the OIDC name claim
+//  2. a plain GitHub login (already human-recognizable)
+//  3. the provider email claim (display only, never the key)
+//  4. an optional linked GitHub login
+//  5. a truncated "provider: subject…" rendering of the raw key, so even a
+//     record with no human-readable claims stays scannable instead of a wall
+//     of token characters.
+func grantableUserLabel(u *SaaSUser) string {
+	if u.DisplayName != "" {
+		return u.DisplayName
+	}
+	provider, sub := splitIdentityKey(u.GitHubUsername)
+	if provider == "" || provider == "github" {
+		return sub
+	}
+	if u.Email != "" {
+		return u.Email
+	}
+	if u.LinkedGitHubLogin != "" {
+		return u.LinkedGitHubLogin
+	}
+	if len(sub) > maxOpaqueIDLabelLen {
+		sub = sub[:maxOpaqueIDLabelLen] + "…"
+	}
+	return provider + ": " + sub
 }
 
 func (s *HubServer) handleAccessAdd(w http.ResponseWriter, r *http.Request) {
@@ -18402,6 +18494,9 @@ const dashboardHTML = `<!DOCTYPE html>
       </div>
       <div style="margin-top:16px;border-top:1px solid var(--border);padding-top:16px">
         <h3 style="font-size:0.9rem;margin-bottom:8px;color:var(--text)">Add User</h3>
+        <input id="access-user-search" type="text" placeholder="Search users..." autocomplete="off"
+          oninput="filterAccessUserDropdown()"
+          style="width:100%;box-sizing:border-box;margin-bottom:8px;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
         <div style="display:flex;gap:8px">
           <select id="access-username" style="flex:1;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem"><option value="">Select user...</option></select>
           <select id="access-role" style="padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
@@ -18604,27 +18699,75 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
     }
 
+    /* The roster fetched from grantable-users, kept so the search box can
+       re-filter without another network round trip. Each entry carries the
+       stable identity key (id — what the grant POST sends) and the normalized
+       human label (label — what the owner reads). */
+    var _grantableUsers = [];
+
+    /* accessOptionText renders one dropdown row: the friendly label, plus a
+       short parenthesised hint of the underlying ID when the two differ so an
+       owner can tell two "Jane Doe"s apart without seeing a full raw token. */
+    function accessOptionText(e) {
+      if (!e.id || e.id === e.label) return e.label;
+      var hint = e.id.length > 24 ? e.id.slice(0, 24) + '…' : e.id;
+      return e.label + ' (' + hint + ')';
+    }
+
+    /* renderAccessUserOptions rebuilds the select from _grantableUsers,
+       keeping only entries whose label OR raw id matches the filter
+       (case-insensitive). The current selection is preserved when it
+       survives the filter so typing never silently discards a choice. */
+    function renderAccessUserOptions(filter) {
+      var sel = document.getElementById('access-username');
+      if (!sel) return;
+      var prev = sel.value;
+      var q = (filter || '').toLowerCase();
+      var matches = _grantableUsers.filter(function(e) {
+        if (!q) return true;
+        return e.label.toLowerCase().indexOf(q) !== -1 || e.id.toLowerCase().indexOf(q) !== -1;
+      });
+      if (!_grantableUsers.length) {
+        sel.innerHTML = '<option value="">No users yet — they must sign in to the hub once</option>';
+        return;
+      }
+      if (!matches.length) {
+        sel.innerHTML = '<option value="">No users match "' + esc(filter) + '"</option>';
+        return;
+      }
+      sel.innerHTML = '<option value="">Select user...</option>' + matches.map(function(e) {
+        return '<option value="' + esc(e.id) + '">' + esc(accessOptionText(e)) + '</option>';
+      }).join('');
+      if (prev && matches.some(function(e) { return e.id === prev; })) sel.value = prev;
+    }
+
+    function filterAccessUserDropdown() {
+      var box = document.getElementById('access-user-search');
+      renderAccessUserOptions(box ? box.value : '');
+    }
+
     async function loadAccessUserDropdown() {
       var sel = document.getElementById('access-username');
       if (!sel) return;
+      var box = document.getElementById('access-user-search');
+      if (box) box.value = '';
       try {
         // grantable-users, NOT admin/users: the latter is admin-only, so every
         // non-admin owner got a 403 and an empty dropdown with no explanation.
         var resp = await fetch('/api/saas/grantable-users');
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
         var data = await resp.json();
-        var users = (data.users || []);
-        if (!users.length) {
-          sel.innerHTML = '<option value="">No users yet — they must sign in to the hub once</option>';
-          return;
-        }
-        sel.innerHTML = '<option value="">Select user...</option>' + users.map(function(u) {
-          return '<option value="' + esc(u) + '">' + esc(u) + '</option>';
-        }).join('');
+        // Prefer the enriched entries (stable id + normalized label); fall back
+        // to the bare username list from an older hub, where id doubles as label.
+        _grantableUsers = (data.entries || (data.users || []).map(function(u) {
+          return { id: u, label: u };
+        })).filter(function(e) { return e && e.id; });
+        renderAccessUserOptions('');
       } catch(e) {
         // Never leave the control looking merely empty — an empty dropdown is
         // indistinguishable from "no such users", which is what made this
         // confusing in the first place.
+        _grantableUsers = [];
         sel.innerHTML = '<option value="">Could not load users</option>';
       }
     }


### PR DESCRIPTION
## Summary

Fixes the Manage Access dialog showing raw/opaque provider user IDs (`google:<id>`, `ibmid:<id>`, token-like `microsoft:<sub>`) in the Add User dropdown, and adds in-dialog search.

### Identity rendering
- `/api/saas/grantable-users` now returns enriched `entries` pairing the **stable identity key** (unchanged — still what the grant POST sends) with a normalized display label, preferring: provider-asserted DisplayName → plain GitHub login → email → linked GitHub login → truncated `provider: subject…` fallback.
- Legacy `users` array retained for back-compat with older dashboards; the frontend falls back to it when `entries` is absent.
- Handles mixed identity sources (GitHub, Google, IBMid, Microsoft, custom).

### Search/filter UX
- New search input above the Add User dropdown; filters case-insensitively against both normalized label and raw identity key.
- Dropdown selection is preserved when it survives the filter; keyboard usability of the native `<select>` unchanged.

### Safety
- Owner-only mutation enforcement and permission-grant semantics untouched — display-only change plus additive payload field.

### Tests
- Label normalization preference order (`TestGrantableUserLabel`)
- Provider classification (`TestGrantableUserProvider`)
- Enriched payload shape/sorting + legacy field back-compat (`TestHandleGrantableUsersEntriesCarryNormalizedLabels`)
- Search UI wiring (`TestManageAccessDialogHasUserSearch`)
- `go test ./pkg/hub/ -run 'Grantable|ManageAccess|Access'` ✅

Closes #4137