### PR TITLE
🐛 dashboard-lint: fix shell/Node injection via unescaped filename interpolation

### DIFF
--- a/.github/scripts/check-inline-js.js
+++ b/.github/scripts/check-inline-js.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+
+// Syntax-checks the inline <script> blocks of the HTML files whose paths are
+// given as command line arguments. Paths are never interpolated into a shell
+// or JavaScript string, so any filename (quotes, spaces, metacharacters) is
+// handled safely.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCRIPT_BLOCK_RE = /<script[^>]*>([\s\S]*?)<\/script>/gi;
+
+function checkFile(htmlFile, tmpDir) {
+  const html = fs.readFileSync(htmlFile, 'utf8');
+  let match;
+  let idx = 0;
+  const blocks = [];
+
+  SCRIPT_BLOCK_RE.lastIndex = 0;
+  while ((match = SCRIPT_BLOCK_RE.exec(html)) !== null) {
+    const js = match[1].trim();
+    if (!js) continue;
+    const outFile = path.join(tmpDir, `block_${idx}.js`);
+    fs.writeFileSync(outFile, js);
+    blocks.push(outFile);
+    idx++;
+  }
+  console.log(`Extracted ${idx} script block(s)`);
+
+  let failed = false;
+  for (const block of blocks) {
+    console.log(`  Parsing ${path.basename(block)}...`);
+    try {
+      execFileSync(process.execPath, ['--check', block], { stdio: 'inherit' });
+    } catch (err) {
+      failed = true;
+    }
+    fs.rmSync(block, { force: true });
+  }
+  return !failed;
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.log('No HTML files to check.');
+    return 0;
+  }
+
+  const tmpRoot = process.env.RUNNER_TEMP || os.tmpdir();
+  const tmpDir = fs.mkdtempSync(path.join(tmpRoot, 'inline-js-'));
+  let ok = true;
+  try {
+    for (const htmlFile of files) {
+      console.log(`Checking ${htmlFile}...`);
+      if (!checkFile(htmlFile, tmpDir)) ok = false;
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  if (!ok) {
+    console.error('Syntax errors found in inline script block(s).');
+    return 1;
+  }
+  console.log('All script blocks passed syntax check.');
+  return 0;
+}
+
+process.exit(main());

--- a/.github/workflows/dashboard-lint.yml
+++ b/.github/workflows/dashboard-lint.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'dashboard/**'
 
+permissions:
+  contents: read
+
 jobs:
   syntax-check:
     runs-on: ubuntu-latest
@@ -15,29 +18,5 @@ jobs:
 
       - name: Extract and syntax-check inline JavaScript
         run: |
-          for html_file in $(find dashboard -name '*.html'); do
-            echo "Checking $html_file..."
-            # Extract all <script> blocks (handles multiple blocks per file)
-            node -e "
-              const fs = require('fs');
-              const html = fs.readFileSync('$html_file', 'utf8');
-              const re = /<script[^>]*>([\s\S]*?)<\/script>/gi;
-              let match, idx = 0;
-              while ((match = re.exec(html)) !== null) {
-                const js = match[1].trim();
-                if (!js) continue;
-                const outFile = '/tmp/block_' + idx + '.js';
-                fs.writeFileSync(outFile, js);
-                idx++;
-              }
-              console.log('Extracted ' + idx + ' script block(s)');
-            "
-            # Syntax-check each extracted block
-            for block in /tmp/block_*.js; do
-              [ -f "$block" ] || continue
-              echo "  Parsing $(basename $block)..."
-              node --check "$block"
-            done
-            rm -f /tmp/block_*.js
-          done
-          echo "All script blocks passed syntax check."
+          find dashboard -name '*.html' -print0 \
+            | xargs -0 --no-run-if-empty node .github/scripts/check-inline-js.js


### PR DESCRIPTION
## Summary

Fixes the CI injection risk in `.github/workflows/dashboard-lint.yml`, where each HTML path was interpolated unescaped into a `node -e "..."` string, allowing a filename containing `"`, backticks or `$(...)` to execute arbitrary code on the runner.

## Changes

- Extracted the inline-JS extraction/syntax-check logic into `.github/scripts/check-inline-js.js`; HTML paths arrive as `process.argv` and are never interpolated into a shell or JS string.
- Workflow now uses `find dashboard -name '*.html' -print0 | xargs -0 --no-run-if-empty node .github/scripts/check-inline-js.js`, safely handling quotes, spaces and shell metacharacters.
- Block files are written to a `mkdtemp` dir under `RUNNER_TEMP` and cleaned up; `node --check` is invoked via `execFileSync` (no shell).
- Added least-privilege `permissions: contents: read`.

## Validation

- `find dashboard -name '*.html' -print0 | xargs -0 node .github/scripts/check-inline-js.js` → passes on `dashboard/index.html`.
- Hostile filenames (`x"; require(1);__.html`, `bad file $(id) \`whoami\`.html`, `broken'quote.html`) are processed literally with no code execution; a deliberately broken script block still fails the check with exit 1.

Closes #4125