### PR TITLE
🐛 fix(apiproxy): require PROXY_AUTH_TOKEN and fail closed

### DIFF
--- a/src/cmd/apiproxy/main.go
+++ b/src/cmd/apiproxy/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -14,14 +15,19 @@ import (
 
 const defaultProxyHost = "127.0.0.1"
 
-// clientAuthTokenFromEnv returns the token callers must present to the proxy.
-// An empty result leaves the proxy an open relay, so a warning is emitted.
-func clientAuthTokenFromEnv(getenv func(string) string, warnf func(string, ...any)) string {
+// errMissingClientAuthToken reports the fail-closed startup contract: without a
+// client auth token any co-resident loopback process could have its requests
+// fulfilled with the host upstream key, so the proxy refuses to start.
+var errMissingClientAuthToken = errors.New("PROXY_AUTH_TOKEN is required: without it the proxy would accept unauthenticated callers and grant them the host upstream key")
+
+// clientAuthTokenFromEnv returns the token callers must present to the proxy,
+// or an error when it is unset so the caller can fail closed.
+func clientAuthTokenFromEnv(getenv func(string) string) (string, error) {
 	token := getenv("PROXY_AUTH_TOKEN")
 	if token == "" {
-		warnf("[sec-check WARNING] PROXY_AUTH_TOKEN is unset; the proxy will accept unauthenticated callers and may grant them the host upstream key. Set PROXY_AUTH_TOKEN to require caller authentication.")
+		return "", errMissingClientAuthToken
 	}
-	return token
+	return token, nil
 }
 
 // upstreamAPIKeyFromEnv returns the credential the proxy swaps in on the
@@ -78,7 +84,10 @@ func main() {
 		logWriter.Encode(entry)
 	}
 
-	clientAuthToken := clientAuthTokenFromEnv(os.Getenv, log.Printf)
+	clientAuthToken, err := clientAuthTokenFromEnv(os.Getenv)
+	if err != nil {
+		log.Fatalf("[sec-check] refusing to start: %v", err)
+	}
 	upstreamAPIKey := upstreamAPIKeyFromEnv(os.Getenv)
 	proxy, err := apiproxy.New(*upstream, handler, upstreamAPIKey, clientAuthToken)
 	if err != nil {

--- a/src/cmd/apiproxy/main_test.go
+++ b/src/cmd/apiproxy/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -12,8 +12,7 @@ func TestDefaultProxyHostIsLoopback(t *testing.T) {
 	}
 }
 
-func TestClientAuthTokenFromEnvWarnsWhenUnset(t *testing.T) {
-	var warnings []string
+func TestClientAuthTokenFromEnvFailsClosedWhenUnset(t *testing.T) {
 	getenv := func(key string) string {
 		switch key {
 		case "ANTHROPIC_API_KEY":
@@ -22,19 +21,19 @@ func TestClientAuthTokenFromEnvWarnsWhenUnset(t *testing.T) {
 			return ""
 		}
 	}
-	token := clientAuthTokenFromEnv(getenv, func(format string, args ...any) {
-		warnings = append(warnings, fmt.Sprintf(format, args...))
-	})
+	token, err := clientAuthTokenFromEnv(getenv)
 	if token != "" {
 		t.Fatalf("token = %q, want empty when PROXY_AUTH_TOKEN is unset", token)
 	}
-	if len(warnings) != 1 || !strings.Contains(warnings[0], "PROXY_AUTH_TOKEN is unset") {
-		t.Fatalf("expected actionable warning when the gate is disabled, got %#v", warnings)
+	if !errors.Is(err, errMissingClientAuthToken) {
+		t.Fatalf("err = %v, want errMissingClientAuthToken so the proxy refuses to start", err)
+	}
+	if !strings.Contains(err.Error(), "PROXY_AUTH_TOKEN") {
+		t.Fatalf("error %q must name the required variable", err)
 	}
 }
 
 func TestClientAuthTokenFromEnvUsesProxyAuthToken(t *testing.T) {
-	var warnings []string
 	getenv := func(key string) string {
 		switch key {
 		case "PROXY_AUTH_TOKEN":
@@ -45,14 +44,12 @@ func TestClientAuthTokenFromEnvUsesProxyAuthToken(t *testing.T) {
 			return ""
 		}
 	}
-	token := clientAuthTokenFromEnv(getenv, func(format string, args ...any) {
-		warnings = append(warnings, fmt.Sprintf(format, args...))
-	})
+	token, err := clientAuthTokenFromEnv(getenv)
+	if err != nil {
+		t.Fatalf("unexpected error when PROXY_AUTH_TOKEN is set: %v", err)
+	}
 	if token != "proxy-token" {
 		t.Fatalf("token = %q, want PROXY_AUTH_TOKEN", token)
-	}
-	if len(warnings) != 0 {
-		t.Fatalf("expected no warning when PROXY_AUTH_TOKEN is set, got %#v", warnings)
 	}
 }
 

--- a/src/docs/apiproxy.md
+++ b/src/docs/apiproxy.md
@@ -6,8 +6,8 @@ for requests/responses and SSE chunks.
 
 Two independent credentials are involved:
 
-- **Client auth token** (`PROXY_AUTH_TOKEN`) — what callers must present *to the
-  proxy*. When it is set, every request must carry either
+- **Client auth token** (`PROXY_AUTH_TOKEN`) — **required**; what callers must
+  present *to the proxy*. Every request must carry either
   `Authorization: Bearer <PROXY_AUTH_TOKEN>` or `X-Api-Key: <PROXY_AUTH_TOKEN>`,
   otherwise the proxy returns `401 Unauthorized` without logging or forwarding
   the request. The comparison is constant time. The gate token is stripped from
@@ -19,8 +19,12 @@ Two independent credentials are involved:
   forwarded as-is. This preserves the dummy-key workflow used by agent CLIs.
 
 The two are deliberately separate so that the host upstream key is never an
-implicit credential for anyone who can reach the listener. If `PROXY_AUTH_TOKEN`
-is unset the proxy is an open relay and logs a warning at startup.
+implicit credential for anyone who can reach the listener. The proxy fails
+closed: if `PROXY_AUTH_TOKEN` is unset, `cmd/apiproxy` exits with an error at
+startup, and the proxy handler refuses every request with
+`503 Service Unavailable` rather than acting as an open relay. Otherwise any
+co-resident loopback process — including a prompt-injected agent — could spend
+the host `ANTHROPIC_API_KEY` unauthenticated.
 
 ## Run
 
@@ -46,7 +50,7 @@ Environment:
 
 | Name | Purpose |
 |---|---|
-| `PROXY_AUTH_TOKEN` | Client auth token callers must present to the proxy (`Authorization: Bearer <token>` or `X-Api-Key: <token>`). Validated with a constant-time compare and stripped before the upstream request. When unset, the proxy accepts unauthenticated callers and logs a warning. |
+| `PROXY_AUTH_TOKEN` | **Required.** Client auth token callers must present to the proxy (`Authorization: Bearer <token>` or `X-Api-Key: <token>`). Validated with a constant-time compare and stripped before the upstream request. When unset, `cmd/apiproxy` refuses to start and the proxy handler answers `503`. |
 | `ANTHROPIC_API_KEY` | Upstream API key injected on the outbound request when the caller did not supply its own real upstream credential. Never used to authenticate callers. |
 
 ## Deployment notes
@@ -54,7 +58,7 @@ Environment:
 The binary listens on `127.0.0.1:<port>` by default. Treat `--host 0.0.0.0` as
 an explicit compatibility opt-in for deployments that need cross-container or
 cross-pod access, and pair it with network policy/firewall controls.
-Always configure `PROXY_AUTH_TOKEN` in production: without it the proxy accepts
-any caller and will happily lend them the host `ANTHROPIC_API_KEY`. Use a
+`PROXY_AUTH_TOKEN` is mandatory: without it the proxy would accept any caller
+and lend them the host `ANTHROPIC_API_KEY`, so the binary refuses to start. Use a
 high-entropy random value distinct from the upstream key, and rotate the two
 independently.

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -66,7 +66,7 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `BOBSHELL_API_KEY` | Required by Bob CLI when Hive injects or contributor mode uses Bob | none | API key name read by bobshell itself. |
 | `COPILOT_GITHUB_TOKEN` | No | dashboard device-flow token file, if present | Copilot completion/model-discovery token and explicit agent injection. |
 | `ANTHROPIC_API_KEY` | Required by `cmd/apiproxy` to inject an upstream key; agent inference backends receive a synthetic value | none | Anthropic-compatible **upstream** API key. Never used to authenticate callers of `cmd/apiproxy`. |
-| `PROXY_AUTH_TOKEN` | Recommended for `cmd/apiproxy`; when unset the proxy accepts unauthenticated callers | none | **Client auth token** callers must present to `cmd/apiproxy` via `Authorization: Bearer` or `X-Api-Key`. Validated in constant time and stripped before the upstream request. |
+| `PROXY_AUTH_TOKEN` | **Required** by `cmd/apiproxy`; the binary exits at startup when unset and the proxy handler returns `503` | none | **Client auth token** callers must present to `cmd/apiproxy` via `Authorization: Bearer` or `X-Api-Key`. Validated in constant time and stripped before the upstream request. Mandatory because an unauthenticated proxy would let any co-resident loopback caller spend the host `ANTHROPIC_API_KEY`. |
 | `CONTEXT7_API_KEY` | No | none | Optional key for Context7 knowledge API integration. |
 | `GOOSE_PROVIDER` | No | Goose CLI default | Provider passed through Goose backend/model resolution. |
 | `GOOSE_MODEL` | No | Goose CLI default | Model passed through Goose backend/model resolution and contributor relay fallback. |

--- a/src/pkg/apiproxy/proxy.go
+++ b/src/pkg/apiproxy/proxy.go
@@ -52,7 +52,8 @@ type Proxy struct {
 	apiKey string
 	// clientAuthToken is the credential callers must present to this proxy. It
 	// is deliberately distinct from apiKey so a configured upstream key is
-	// never an implicit credential for anyone who can reach the listener.
+	// never an implicit credential for anyone who can reach the listener. It
+	// is required: when empty every request is refused with 503.
 	clientAuthToken string
 	mu              sync.RWMutex
 }
@@ -310,20 +311,25 @@ func (p *Proxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) 
 
 // ServeHTTP implements http.Handler.
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Fail closed when no gate token is configured: an unauthenticated relay
+	// would let any co-resident loopback process spend the host upstream key.
+	if p.clientAuthToken == "" {
+		http.Error(w, "proxy misconfigured: client auth token required", http.StatusServiceUnavailable)
+		return
+	}
+
 	// Gate on the client-provided auth token, which is separate from the
 	// upstream key: a configured upstream key must never act as an implicit
 	// credential for anyone who can reach this listener. Rejected requests are
 	// neither logged nor forwarded upstream.
-	if p.clientAuthToken != "" {
-		if !validateClientAuth(r, p.clientAuthToken) {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		// The gate token is proxy-local and must never reach the upstream. Once
-		// stripped, any remaining credential is a caller-supplied upstream key
-		// and the director decides whether to swap in the configured one.
-		stripClientAuth(r, p.clientAuthToken)
+	if !validateClientAuth(r, p.clientAuthToken) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
 	}
+	// The gate token is proxy-local and must never reach the upstream. Once
+	// stripped, any remaining credential is a caller-supplied upstream key
+	// and the director decides whether to swap in the configured one.
+	stripClientAuth(r, p.clientAuthToken)
 
 	if p.handler != nil {
 		body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyLog))

--- a/src/pkg/apiproxy/proxy_test.go
+++ b/src/pkg/apiproxy/proxy_test.go
@@ -10,6 +10,10 @@ import (
 	"testing"
 )
 
+// testGateToken is the client auth token tests present to the proxy; the gate
+// is mandatory, so ServeHTTP tests must always authenticate.
+const testGateToken = "test-gate-token"
+
 // eventRecorder collects proxied events for assertion.
 type eventRecorder struct {
 	mu     sync.Mutex
@@ -203,13 +207,14 @@ func TestServeHTTPLogsRequestAndForwardsBody(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "", "")
+	p, err := New(upstream.URL, rec.handler, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	reqBody := `{"model":"claude-opus-4","messages":[]}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("X-Api-Key", testGateToken)
 	req.Header.Set("X-Hive-Agent", "scanner")
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
@@ -242,12 +247,13 @@ func TestServeHTTPHandlesNonJSONBody(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "", "")
+	p, err := New(upstream.URL, rec.handler, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("not json at all"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -267,11 +273,12 @@ func TestServeHTTPWithoutHandler(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	p, err := New(upstream.URL, nil, "", "")
+	p, err := New(upstream.URL, nil, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -293,12 +300,13 @@ func TestResponseLoggedAndPassedThrough(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "", "")
+	p, err := New(upstream.URL, rec.handler, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -329,12 +337,13 @@ func TestErrorResponseIsLogged(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "", "")
+	p, err := New(upstream.URL, rec.handler, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -379,12 +388,13 @@ func TestSSEStreamIsLoggedAndPassedThrough(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "", "")
+	p, err := New(upstream.URL, rec.handler, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -458,12 +468,13 @@ func TestSSEIgnoresMalformedDataLines(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "", "")
+	p, err := New(upstream.URL, rec.handler, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -487,12 +498,13 @@ func TestSSEWithNoRecognisedEvents(t *testing.T) {
 	defer upstream.Close()
 
 	rec := &eventRecorder{}
-	p, err := New(upstream.URL, rec.handler, "", "")
+	p, err := New(upstream.URL, rec.handler, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
@@ -677,15 +689,17 @@ func TestServeHTTPForwardsClientKeyWhenPresent(t *testing.T) {
 	}
 }
 
-// Without a gate token the proxy stays an open relay, preserving the previous
-// local-development behaviour.
-func TestServeHTTPWithoutClientAuthTokenAllowsUnauthenticatedCaller(t *testing.T) {
+// Without a gate token the proxy must fail closed: an unauthenticated relay
+// would let any co-resident loopback caller spend the host upstream key.
+func TestServeHTTPWithoutClientAuthTokenRefusesRequests(t *testing.T) {
+	var upstreamHits int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer upstream.Close()
 
-	p, err := New(upstream.URL, nil, "", "")
+	p, err := New(upstream.URL, nil, "host-api-key", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -694,8 +708,11 @@ func TestServeHTTPWithoutClientAuthTokenAllowsUnauthenticatedCaller(t *testing.T
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream hits = %d, want 0 when the proxy is misconfigured", upstreamHits)
 	}
 }
 
@@ -735,11 +752,12 @@ func TestValidateClientAuth(t *testing.T) {
 // An unreachable upstream must yield 502 rather than a hang or a panic.
 func TestUnreachableUpstreamYields502(t *testing.T) {
 	// Port 1 on loopback is not listening.
-	p, err := New("http://127.0.0.1:1", nil, "", "")
+	p, err := New("http://127.0.0.1:1", nil, "", testGateToken)
 	if err != nil {
 		t.Fatal(err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	req.Header.Set("X-Api-Key", testGateToken)
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 


### PR DESCRIPTION
## Summary

`cmd/apiproxy` only logged a warning when `PROXY_AUTH_TOKEN` was unset and kept serving, so any co-resident loopback process could have its requests fulfilled with the host `ANTHROPIC_API_KEY`. The proxy now fails closed.

## Changes

- `clientAuthTokenFromEnv` returns `errMissingClientAuthToken` when `PROXY_AUTH_TOKEN` is unset; `main` exits with a `[sec-check]` fatal instead of starting an open relay.
- `Proxy.ServeHTTP` refuses every request with `503 Service Unavailable` when no client auth token is configured (defense in depth for library callers); requests are neither logged nor forwarded upstream.
- Authenticated behavior is unchanged when the token is set: constant-time compare, `401` on mismatch, gate token stripped before the upstream request.
- Docs: `src/docs/env-vars.md` and `src/docs/apiproxy.md` mark `PROXY_AUTH_TOKEN` as **required** and explain why.
- Tests: startup refusal when unset, request-time `503` with no upstream hit, and the set-token success path.

## Verification

```
go test ./cmd/apiproxy/... ./pkg/apiproxy/...   # ok
go vet ./cmd/apiproxy/... ./pkg/apiproxy/...    # clean
```

Closes #4123