### PR TITLE
✨ relay: auto-detect running model from the CLI session transcript when AGENT_MODEL is unset

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -12,7 +12,10 @@
 //                           hubs, provide one comma-separated token per hub in
 //                           the same order as HIVE_HUB
 //   AGENT_BACKEND          — CLI backend name (claude, copilot, gemini, etc.)
-//   AGENT_MODEL            — model override (optional)
+//   AGENT_MODEL            — model override (optional). When unset, the relay
+//                           auto-detects the running model from the CLI's own
+//                           session transcript for claude/copilot/bob (#4117);
+//                           other backends report no model, as before.
 //   AGENT_REASONING_EFFORT — reasoning effort override (optional). Consumed by
 //                           codex (-c model_reasoning_effort) and by agy
 //                           (--effort low|medium|high); ignored elsewhere.
@@ -499,6 +502,198 @@ function effectiveReasoningEffort() {
   // agy is the only backend whose effort is conditional on a model being passed.
   if (BACKEND === 'agy') return modelFlagFor() ? agyEffort : '';
   return REASONING_EFFORT || '';
+}
+
+// --- Model auto-detection from the CLI's own session transcript (#4117) ----
+//
+// AGENT_MODEL is optional and launch-time-only: most contributors never set it
+// (Live Activity then shows just "via claude CLI"), and even a set value goes
+// stale the moment the session switches models (`/model` in claude). For the
+// backends whose CLIs keep a local session transcript that records which model
+// served each turn — the same files src/pkg/tokens/*_scanner.go already reads
+// for cost attribution — the relay can report the model ACTUALLY in use.
+//
+// Precedence is explicit and fixed: AGENT_MODEL if set (the contributor's
+// intent overrides detection — e.g. a claude pointed at a LiteLLM proxy whose
+// transcript records a spoofed name) → the model detected from the CLI's own
+// transcript → '' (today's degrade, unchanged). Backends with no known local
+// transcript format (codex, agy, goose, pi, aider, litellm, …) always take the
+// last branch — no regression, no guess.
+//
+// Privacy: transcripts contain the task prompt and file contents. Detection
+// reads only the TAIL bytes needed to find the latest turn's model field,
+// extracts that single field, and never logs or transmits anything else.
+const MODEL_DETECT_HOME = process.env.HOME || require('os').homedir() || '';
+// Tail window per read. A transcript line is one JSON turn; 64 KiB comfortably
+// covers the last few turns of every observed format without pulling a whole
+// multi-megabyte session into memory.
+const MODEL_DETECT_TAIL_BYTES = 65536;
+const CLAUDE_PROJECTS_DIR = process.env.HIVE_CLAUDE_PROJECTS_DIR || path.join(MODEL_DETECT_HOME, '.claude', 'projects');
+const COPILOT_SESSIONS_DIR = process.env.HIVE_COPILOT_SESSIONS_DIR || path.join(MODEL_DETECT_HOME, '.copilot', 'session-state');
+const BOB_HOME_DIR = process.env.HIVE_BOB_DIR || path.join(MODEL_DETECT_HOME, '.bob');
+
+// readFileTail returns at most the last maxBytes of a file as UTF-8, without
+// reading the rest — the "minimal tail" privacy bound above.
+function readFileTail(file, maxBytes) {
+  const fd = fs.openSync(file, 'r');
+  try {
+    const size = fs.fstatSync(fd).size;
+    const start = Math.max(0, size - maxBytes);
+    const len = size - start;
+    const buf = Buffer.alloc(len);
+    fs.readSync(fd, buf, 0, len, start);
+    return buf.toString('utf8');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// newestByMtime picks the most recently modified path from a list, or null.
+function newestByMtime(files) {
+  let best = null;
+  let bestMtime = -1;
+  for (const f of files) {
+    try {
+      const m = fs.statSync(f).mtimeMs;
+      if (m > bestMtime) { bestMtime = m; best = f; }
+    } catch (_) {}
+  }
+  return best;
+}
+
+// tailLinesReversed parses the tail of a JSONL file and yields each line's
+// parsed JSON from NEWEST to oldest, skipping unparseable lines (the first
+// tail line is usually a mid-line cut).
+function tailLinesReversed(file) {
+  const lines = readFileTail(file, MODEL_DETECT_TAIL_BYTES).split('\n');
+  const out = [];
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    try { out.push(JSON.parse(line)); } catch (_) {}
+  }
+  return out;
+}
+
+// looksLikeModelName rejects placeholder values some transcripts record for
+// error/synthetic turns (claude logs "<synthetic>") — better no model than a
+// confidently wrong one.
+function looksLikeModelName(m) {
+  return typeof m === 'string' && m !== '' && !m.startsWith('<');
+}
+
+// detectClaudeModel: newest ~/.claude/projects/*/*.jsonl, latest assistant
+// turn's message.model (same source claude_scanner.go aggregates for cost).
+function detectClaudeModel() {
+  const files = [];
+  for (const d of fs.readdirSync(CLAUDE_PROJECTS_DIR, { withFileTypes: true })) {
+    if (!d.isDirectory()) continue;
+    const dir = path.join(CLAUDE_PROJECTS_DIR, d.name);
+    for (const f of fs.readdirSync(dir)) {
+      if (f.endsWith('.jsonl')) files.push(path.join(dir, f));
+    }
+  }
+  const newest = newestByMtime(files);
+  if (!newest) return '';
+  for (const obj of tailLinesReversed(newest)) {
+    const m = obj && obj.message && obj.message.model;
+    if (looksLikeModelName(m)) return m;
+  }
+  return '';
+}
+
+// detectCopilotModel: newest ~/.copilot/session-state/*/events.jsonl, latest
+// event carrying a model field (session.start selectedModel, per-tool model,
+// or shutdown currentModel — same fields copilot_scanner.go reads).
+function detectCopilotModel() {
+  const files = [];
+  for (const d of fs.readdirSync(COPILOT_SESSIONS_DIR, { withFileTypes: true })) {
+    if (!d.isDirectory()) continue;
+    files.push(path.join(COPILOT_SESSIONS_DIR, d.name, 'events.jsonl'));
+  }
+  const newest = newestByMtime(files);
+  if (!newest) return '';
+  for (const obj of tailLinesReversed(newest)) {
+    const data = (obj && obj.data) || {};
+    const m = data.model || data.currentModel || data.selectedModel;
+    if (looksLikeModelName(m)) return m;
+  }
+  return '';
+}
+
+// Bob session recordings are one JSON document, not JSONL, so a byte tail
+// cannot be parsed. Cap what we are willing to read instead; sessions past
+// this size just report no model rather than ballooning relay memory.
+const BOB_MAX_SESSION_BYTES = 5242880; // 5 MiB
+// detectBobModel: newest ~/.bob/tmp/*/chats/*.json, last message with a
+// per-message model field (same shape bob_scanner.go reads).
+function detectBobModel() {
+  const files = [];
+  const tmpDir = path.join(BOB_HOME_DIR, 'tmp');
+  for (const d of fs.readdirSync(tmpDir, { withFileTypes: true })) {
+    if (!d.isDirectory()) continue;
+    const chats = path.join(tmpDir, d.name, 'chats');
+    let entries;
+    try { entries = fs.readdirSync(chats); } catch (_) { continue; }
+    for (const f of entries) {
+      if (f.endsWith('.json')) files.push(path.join(chats, f));
+    }
+  }
+  const newest = newestByMtime(files);
+  if (!newest) return '';
+  if (fs.statSync(newest).size > BOB_MAX_SESSION_BYTES) return '';
+  const session = JSON.parse(fs.readFileSync(newest, 'utf8'));
+  const messages = Array.isArray(session && session.messages) ? session.messages : [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (looksLikeModelName(messages[i] && messages[i].model)) return messages[i].model;
+  }
+  return '';
+}
+
+const MODEL_DETECTORS = { claude: detectClaudeModel, copilot: detectCopilotModel, bob: detectBobModel };
+
+// The last model detected from the transcript. Refreshed at auth and on every
+// progress tick, so a mid-session `/model` switch is reflected within one
+// PROGRESS_REPORT_INTERVAL_MS.
+let detectedModel = '';
+
+// detectRunningModel reads the transcript once and returns the model, or ''.
+// Never throws; never runs at all when AGENT_MODEL is set (explicit intent
+// wins, so there is nothing to detect) or the backend has no known transcript.
+function detectRunningModel() {
+  if (MODEL) return '';
+  const detector = MODEL_DETECTORS[BACKEND];
+  if (!detector) return '';
+  try { return sanitizeDeclaredValue(detector() || ''); } catch (_) { return ''; }
+}
+
+// refreshDetectedModel re-detects and returns the model currently in effect
+// under the fixed precedence (AGENT_MODEL → detected → '').
+function refreshDetectedModel() {
+  const m = detectRunningModel();
+  if (m && m !== detectedModel) {
+    detectedModel = m;
+    console.log(`Detected running model from ${BACKEND} session transcript: ${m}`);
+  }
+  return effectiveModel();
+}
+
+// effectiveModel is the model counterpart of effectiveReasoningEffort(): the
+// single source of truth for the model actually reported to the hub.
+function effectiveModel() {
+  return MODEL || detectedModel || '';
+}
+
+// progressModelFields returns the optional model/effort fields piggybacked on
+// periodic task_progress reports, so the hub can track a mid-session model
+// switch. Empty values are omitted entirely (an older hub ignores the fields).
+function progressModelFields() {
+  const out = {};
+  const model = effectiveModel();
+  const effort = effectiveReasoningEffort();
+  if (model) out.model = model;
+  if (effort) out.reasoning_effort = effort;
+  return out;
 }
 
 function buildLaunchCommand() {
@@ -1680,6 +1875,11 @@ function progressTick() {
   if (!currentTask) return;
   if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
 
+  // #4117: re-detect the running model each tick so a mid-session model switch
+  // (claude `/model`) reaches the hub within one progress interval, piggybacked
+  // on the task_progress reports below.
+  refreshDetectedModel();
+
   try {
     // See probeCLIPresence(): this asks the PANE what it is running, rather than
     // grepping the whole process table for the backend's name — a scan the
@@ -1738,7 +1938,7 @@ function progressTick() {
     // IS the completion signal (see cliExitIsNormal above).
     if (presence.isShell && !cliExitIsNormal) {
       console.warn(`Pane is at a shell prompt, not ${BACKEND} — awaiting confirmation before judging the task`);
-      send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: captureTmuxLines(TMUX_TAIL_LINES) });
+      send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: captureTmuxLines(TMUX_TAIL_LINES), ...progressModelFields() });
       return;
     }
   } catch (_) {}
@@ -1804,6 +2004,7 @@ function progressTick() {
       attention: true,
       summary: 'Agent is waiting for human input in the tmux pane',
       tmux_output: tmuxLines,
+      ...progressModelFields(),
     });
   } else {
     // Stall backstop: a pane frozen this long is not evidence of work, and
@@ -1842,7 +2043,7 @@ function progressTick() {
     if (stallConfirmCount > 0) {
       console.warn(`Pane unchanged for ${Math.round(PANE_STALL_TIMEOUT_MS / 60000)}+ minutes — confirming before giving up on ${currentTask.task_id} (${stallConfirmCount}/${PANE_STALL_CONFIRM_TICKS})`);
     }
-    send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: tmuxLines });
+    send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, status: 'working', tmux_output: tmuxLines, ...progressModelFields() });
   }
 }
 
@@ -1863,7 +2064,10 @@ function handleMessage(data, hub) {
         seq: nextSeq(),
         registration_token: hub.regToken,
         cli_backend: BACKEND,
-        model: MODEL,
+        // #4117: AGENT_MODEL if set, else the model detected from the CLI's
+        // own session transcript, else '' (today's degrade for backends with
+        // no known transcript format).
+        model: refreshDetectedModel(),
         reasoning_effort: effectiveReasoningEffort() || undefined,
         role: AGENT_ROLE,
         // #2547 declare half + #2567: additive, optional self-report of runtime
@@ -2181,6 +2385,12 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     restartBackoffMs,
     NO_MODEL_FLAG_BACKENDS,
     effectiveReasoningEffort,
+    // Model auto-detection from the CLI session transcript (#4117).
+    detectRunningModel,
+    refreshDetectedModel,
+    effectiveModel,
+    progressModelFields,
+    __setDetectedModel: (v) => { detectedModel = v; },
     MAX_TASK_CLI_RESTARTS,
     setCliReady: (v) => { cliReady = v; },
     getCliReady: () => cliReady,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -2427,6 +2427,175 @@ test('task_assign with an unwritable token cache path does not crash the relay',
 });
 
 // ---------------------------------------------------------------------------
+// #4117 — auto-detect the running model from the CLI's own session transcript
+// when AGENT_MODEL is unset. Precedence: AGENT_MODEL → detected → ''.
+// ---------------------------------------------------------------------------
+
+// Builds a claude-style transcript fixture: ~/.claude/projects/<hash>/x.jsonl
+// with assistant turns recording message.model. Returns the projects dir and
+// the session file path (so tests can append a later turn = /model switch).
+function makeClaudeFixture(turns) {
+  const scratchRoot = path.join(__dirname, '..', '.relay-test-tmp');
+  fs.mkdirSync(scratchRoot, { recursive: true });
+  const root = fs.mkdtempSync(path.join(scratchRoot, 'model-detect-'));
+  const projDir = path.join(root, 'projects', '-home-dev-work');
+  fs.mkdirSync(projDir, { recursive: true });
+  const file = path.join(projDir, 'session-abc.jsonl');
+  fs.writeFileSync(file, turns.map(t => JSON.stringify(t)).join('\n') + '\n');
+  return { root, projectsDir: path.join(root, 'projects'), file };
+}
+
+function assistantTurn(model) {
+  return { type: 'assistant', timestamp: new Date().toISOString(), message: { model, usage: { input_tokens: 1, output_tokens: 1 } } };
+}
+
+test('#4117: claude model is detected from the newest transcript when AGENT_MODEL is unset', () => {
+  const fx = makeClaudeFixture([assistantTurn('claude-opus-5-20260101')]);
+  const relay = loadRelay({ backend: 'claude', model: '', env: { HIVE_CLAUDE_PROJECTS_DIR: fx.projectsDir } });
+  try {
+    assert.strictEqual(relay.refreshDetectedModel(), 'claude-opus-5-20260101');
+    assert.strictEqual(relay.effectiveModel(), 'claude-opus-5-20260101');
+  } finally {
+    teardown(relay);
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('#4117: explicit AGENT_MODEL wins over a transcript recording a different model', () => {
+  const fx = makeClaudeFixture([assistantTurn('claude-transcript-model')]);
+  const relay = loadRelay({ backend: 'claude', model: 'my-explicit-model', env: { HIVE_CLAUDE_PROJECTS_DIR: fx.projectsDir } });
+  try {
+    assert.strictEqual(relay.refreshDetectedModel(), 'my-explicit-model');
+    assert.strictEqual(relay.detectRunningModel(), '',
+      'detection must not even run when AGENT_MODEL is set — explicit intent wins');
+    // auth_response carries the explicit value, unconditionally.
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.strictEqual(auth.model, 'my-explicit-model');
+  } finally {
+    teardown(relay);
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('#4117: auth_response reports the detected model when AGENT_MODEL is unset', () => {
+  const fx = makeClaudeFixture([assistantTurn('claude-sonnet-5-20260101')]);
+  const relay = loadRelay({ backend: 'claude', model: '', env: { HIVE_CLAUDE_PROJECTS_DIR: fx.projectsDir } });
+  try {
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.strictEqual(auth.model, 'claude-sonnet-5-20260101');
+  } finally {
+    teardown(relay);
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('#4117: a mid-session model switch is picked up by the progress tick and sent on task_progress', () => {
+  const fx = makeClaudeFixture([assistantTurn('claude-sonnet-5-20260101')]);
+  const relay = loadRelay({ backend: 'claude', model: '', cliStates: ['working'], env: { HIVE_CLAUDE_PROJECTS_DIR: fx.projectsDir } });
+  try {
+    assert.strictEqual(relay.refreshDetectedModel(), 'claude-sonnet-5-20260101');
+    // The session switches models (`/model`): the CLI appends a turn served by
+    // the NEW model to its own transcript.
+    fs.appendFileSync(fx.file, JSON.stringify(assistantTurn('claude-opus-5-20260101')) + '\n');
+    relay.setCurrentTask({ task_id: 'mt-1', task_gen: 3, kind: 'issue', repo: 'foo/bar', number: 1, title: 'x' });
+    relay.__stallTick(); // one progress tick, grace period elapsed
+    const prog = relay.__sent.filter(m => m.type === 'task_progress').pop();
+    assert.ok(prog, 'the tick must send a task_progress');
+    assert.strictEqual(prog.model, 'claude-opus-5-20260101',
+      'task_progress must carry the model detected AFTER the mid-session switch');
+    assert.strictEqual(relay.effectiveModel(), 'claude-opus-5-20260101');
+  } finally {
+    teardown(relay);
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('#4117: synthetic placeholder turns are skipped in favor of the last real model', () => {
+  const fx = makeClaudeFixture([assistantTurn('claude-opus-5-20260101'), assistantTurn('<synthetic>')]);
+  const relay = loadRelay({ backend: 'claude', model: '', env: { HIVE_CLAUDE_PROJECTS_DIR: fx.projectsDir } });
+  try {
+    assert.strictEqual(relay.refreshDetectedModel(), 'claude-opus-5-20260101');
+  } finally {
+    teardown(relay);
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test('#4117: copilot model is detected from the newest events.jsonl', () => {
+  const scratchRoot = path.join(__dirname, '..', '.relay-test-tmp');
+  fs.mkdirSync(scratchRoot, { recursive: true });
+  const root = fs.mkdtempSync(path.join(scratchRoot, 'model-detect-'));
+  const sessDir = path.join(root, 'session-state', 'sess-1');
+  fs.mkdirSync(sessDir, { recursive: true });
+  fs.writeFileSync(path.join(sessDir, 'events.jsonl'), [
+    JSON.stringify({ type: 'session.start', data: { sessionId: 'sess-1', selectedModel: 'gpt-5.4' } }),
+    JSON.stringify({ type: 'tool.complete', data: { model: 'gpt-5.6-luna' } }),
+  ].join('\n') + '\n');
+  const relay = loadRelay({ backend: 'copilot', model: '', env: { HIVE_COPILOT_SESSIONS_DIR: path.join(root, 'session-state') } });
+  try {
+    assert.strictEqual(relay.refreshDetectedModel(), 'gpt-5.6-luna',
+      'the LATEST model-bearing event must win, not the session.start value');
+  } finally {
+    teardown(relay);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('#4117: bob model is detected from the last message of the newest chat recording', () => {
+  const scratchRoot = path.join(__dirname, '..', '.relay-test-tmp');
+  fs.mkdirSync(scratchRoot, { recursive: true });
+  const root = fs.mkdtempSync(path.join(scratchRoot, 'model-detect-'));
+  const chats = path.join(root, 'tmp', 'uuid-1', 'chats');
+  fs.mkdirSync(chats, { recursive: true });
+  fs.writeFileSync(path.join(chats, 'sess.json'), JSON.stringify({
+    sessionId: 'sess',
+    messages: [
+      { type: 'user', content: 'hi' },
+      { type: 'bob-shell', content: 'x', model: 'standard' },
+      { type: 'bob-shell', content: 'y', model: 'premium' },
+    ],
+  }));
+  const relay = loadRelay({ backend: 'bob', model: '', env: { HIVE_BOB_DIR: root } });
+  try {
+    assert.strictEqual(relay.refreshDetectedModel(), 'premium');
+  } finally {
+    teardown(relay);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('#4117: unsupported backends detect nothing and degrade to today\'s behavior', () => {
+  // A claude transcript exists on disk, but codex has no scanner — detection
+  // must not guess from another CLI's files.
+  const fx = makeClaudeFixture([assistantTurn('claude-opus-5-20260101')]);
+  for (const backend of ['codex', 'agy', 'goose', 'pi', 'aider', 'litellm']) {
+    const relay = loadRelay({ backend, model: '', env: { HIVE_CLAUDE_PROJECTS_DIR: fx.projectsDir } });
+    try {
+      assert.strictEqual(relay.refreshDetectedModel(), '', `${backend} must not detect a model`);
+      assert.deepStrictEqual(Object.keys(relay.progressModelFields()).filter(k => k === 'model'), [],
+        `${backend} must not piggyback a model on task_progress`);
+    } finally {
+      teardown(relay);
+    }
+  }
+  fs.rmSync(fx.root, { recursive: true, force: true });
+});
+
+test('#4117: detection failure (missing log root) is silent and reports no model', () => {
+  const relay = loadRelay({ backend: 'claude', model: '', env: { HIVE_CLAUDE_PROJECTS_DIR: path.join(__dirname, 'does-not-exist-4117') } });
+  try {
+    assert.strictEqual(relay.refreshDetectedModel(), '');
+    relay.handleMessage(JSON.stringify({ type: 'auth_challenge' }));
+    const auth = relay.__sent.find(m => m.type === 'auth_response');
+    assert.strictEqual(auth.model || '', '', 'auth_response must degrade to no model, exactly as before');
+  } finally {
+    teardown(relay);
+  }
+});
+
+// ---------------------------------------------------------------------------
 
 let failed = 0;
 // RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -2941,6 +2941,25 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				contributor.tmuxOutput = msg.TmuxOutput
+				// #4117: the relay re-detects the running model from the CLI's own
+				// session transcript on every progress tick and piggybacks it here, so
+				// a mid-session model switch (claude `/model`) is reflected instead of
+				// staying stuck at the connect-time value. Same pattern as the
+				// auth-time handler: only non-empty values overwrite — an older relay
+				// omits both fields and nothing changes. Advisory display metadata,
+				// exactly like the auth_response values it refreshes.
+				if msg.Model != "" {
+					contributor.model = msg.Model
+					if contributor.profile != nil {
+						contributor.profile.Model = msg.Model
+					}
+				}
+				if msg.ReasoningEffort != "" {
+					contributor.reasoningEffort = msg.ReasoningEffort
+					if contributor.profile != nil {
+						contributor.profile.ReasoningEffort = msg.ReasoningEffort
+					}
+				}
 				// SECURITY (v4, kept over v2 #3153): v4 deliberately has NO
 				// client-driven resume path here. A task_progress for a task the hub
 				// does not already track is resumed ONLY through the authoritative

--- a/src/pkg/dashboard/contribute_ws_progress_model_test.go
+++ b/src/pkg/dashboard/contribute_ws_progress_model_test.go
@@ -1,0 +1,178 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_ws_progress_model_test.go — kubestellar/hive#4117: the relay
+// re-detects the running model from the CLI's own session transcript and
+// piggybacks optional model/reasoning_effort fields on periodic task_progress
+// reports. The hub must update contributor.model / contributor.reasoningEffort
+// (and the profile mirrors) when the fields are present, so a mid-session
+// `/model` switch is reflected instead of staying stuck at the connect-time
+// auth_response value — and must change NOTHING when the fields are absent
+// (an older relay omits them).
+
+// authWithModel registers a contributor and authenticates its WS connection,
+// declaring the given connect-time model/effort in auth_response.
+func authWithModel(t *testing.T, s *Server, ts *httptest.Server, username, model, effort string) (*websocket.Conn, map[string]string) {
+	t.Helper()
+	body := `{"github_username":"` + username + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("register decode: %v", err)
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	readMsg(t, conn) // auth_challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude", Model: model, ReasoningEffort: effort})
+	readMsg(t, conn) // auth_ok
+	return conn, reg
+}
+
+// waitForModel polls the contributor connection until its model matches want
+// (or the deadline passes), returning the final observed model/effort pair.
+func waitForModel(h *ContributeWSHub, contributorID, want string, window time.Duration) (string, string) {
+	deadline := time.Now().Add(window)
+	var model, effort string
+	for {
+		h.mu.RLock()
+		for _, c := range h.connections {
+			c.mu.Lock()
+			if c.profile != nil && c.profile.ContributorID == contributorID {
+				model, effort = c.model, c.reasoningEffort
+			}
+			c.mu.Unlock()
+		}
+		h.mu.RUnlock()
+		if model == want || time.Now().After(deadline) {
+			return model, effort
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestTaskProgressUpdatesModelMidSession proves the #4117 consume path: a
+// task_progress carrying model/reasoning_effort for the connection's held task
+// updates the connection record, so the mid-session value supersedes the
+// connect-time one.
+func TestTaskProgressUpdatesModelMidSession(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	conn, reg := authWithModel(t, s, ts, "modelswitcher", "claude-sonnet-5", "medium")
+	defer conn.Close()
+
+	holder := mustConn(t, s.contributeHub, reg["contributor_id"])
+	if holder.model != "claude-sonnet-5" || holder.reasoningEffort != "medium" {
+		t.Fatalf("connect-time model/effort not recorded: got %q/%q", holder.model, holder.reasoningEffort)
+	}
+
+	// The hub tracks a task on this connection (routine-progress branch, not
+	// the lease-resume branch).
+	holder.mu.Lock()
+	holder.currentTask = &WSTaskAssign{TaskID: "ct-4117", Kind: "issue", Repo: "myorg/repo1", Number: 1}
+	holder.currentTaskGen = 7
+	holder.mu.Unlock()
+
+	// Mid-session the relay's periodic tick detects a model switch and
+	// piggybacks the new value on its routine progress report.
+	conn.WriteJSON(WSMessage{Type: "task_progress", TaskID: "ct-4117", TaskGen: 7, Status: "working", Model: "claude-opus-5", ReasoningEffort: "high"})
+
+	model, effort := waitForModel(s.contributeHub, reg["contributor_id"], "claude-opus-5", 2*time.Second)
+	if model != "claude-opus-5" {
+		t.Fatalf("task_progress model was not consumed: connection still reports %q (want claude-opus-5)", model)
+	}
+	if effort != "high" {
+		t.Fatalf("task_progress reasoning_effort was not consumed: connection reports %q (want high)", effort)
+	}
+	holder.mu.Lock()
+	profModel, profEffort := holder.profile.Model, holder.profile.ReasoningEffort
+	holder.mu.Unlock()
+	if profModel != "claude-opus-5" || profEffort != "high" {
+		t.Fatalf("profile mirrors not updated: got %q/%q", profModel, profEffort)
+	}
+}
+
+// TestTaskProgressWithoutModelChangesNothing pins the no-regression leg: an
+// older relay (or a backend with no detectable transcript — codex, agy, goose,
+// pi, aider, litellm) omits the fields, and the connect-time values must
+// survive untouched. An empty string must never clobber a known model.
+func TestTaskProgressWithoutModelChangesNothing(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	conn, reg := authWithModel(t, s, ts, "legacyrelay", "gpt-5.4", "low")
+	defer conn.Close()
+
+	holder := mustConn(t, s.contributeHub, reg["contributor_id"])
+	holder.mu.Lock()
+	holder.currentTask = &WSTaskAssign{TaskID: "ct-4117-b", Kind: "issue", Repo: "myorg/repo1", Number: 2}
+	holder.currentTaskGen = 3
+	holder.mu.Unlock()
+
+	// Progress with NO model fields — today's relay shape for unsupported
+	// backends and for every relay written before #4117.
+	conn.WriteJSON(WSMessage{Type: "task_progress", TaskID: "ct-4117-b", TaskGen: 3, Status: "working", TmuxOutput: []string{"still working"}})
+
+	// Wait until the progress was definitely consumed (tmuxOutput recorded),
+	// then assert the model/effort are untouched.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		holder.mu.Lock()
+		consumed := len(holder.tmuxOutput) == 1 && holder.tmuxOutput[0] == "still working"
+		holder.mu.Unlock()
+		if consumed || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	holder.mu.Lock()
+	model, effort := holder.model, holder.reasoningEffort
+	holder.mu.Unlock()
+	if model != "gpt-5.4" || effort != "low" {
+		t.Fatalf("a task_progress without model fields mutated model/effort: got %q/%q (want gpt-5.4/low)", model, effort)
+	}
+}
+
+// TestTaskProgressStaleGenerationDoesNotUpdateModel: the #2568 Gate runs
+// BEFORE the #4117 consume — a stale-generation straggler must not overwrite
+// the current owner's model either.
+func TestTaskProgressStaleGenerationDoesNotUpdateModel(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	conn, reg := authWithModel(t, s, ts, "staleworker", "claude-sonnet-5", "")
+	defer conn.Close()
+
+	holder := mustConn(t, s.contributeHub, reg["contributor_id"])
+	holder.mu.Lock()
+	holder.currentTask = &WSTaskAssign{TaskID: "ct-4117-c", Kind: "issue", Repo: "myorg/repo1", Number: 3}
+	holder.currentTaskGen = 9
+	holder.mu.Unlock()
+
+	// A straggler echoing an OLDER generation carries a model — it must be
+	// rejected wholesale by the Gate, model included.
+	conn.WriteJSON(WSMessage{Type: "task_progress", TaskID: "ct-4117-c", TaskGen: 4, Status: "working", Model: "spoofed-model"})
+
+	model, _ := waitForModel(s.contributeHub, reg["contributor_id"], "spoofed-model", 400*time.Millisecond)
+	if model == "spoofed-model" {
+		t.Fatalf("a stale-generation task_progress updated the model — the #2568 Gate must reject the whole message")
+	}
+	if model != "claude-sonnet-5" {
+		t.Fatalf("model unexpectedly changed to %q", model)
+	}
+}


### PR DESCRIPTION
Closes #4117

## What

The model shown in Live Activity / PR footers came only from `AGENT_MODEL` — optional, usually unset, and launch-time-only (a claude `/model` switch was never reflected). This makes the relay report the model **actually in use** for the backends whose CLIs keep a local session transcript, and keeps today's behavior everywhere else.

## How

**Relay (`bin/contributor-relay.sh`)**
- New detection for **claude / copilot / bob**, reading the same session-log roots `src/pkg/tokens/*_scanner.go` already scans for cost attribution, but last-turn-only:
  - claude: newest `~/.claude/projects/*/*.jsonl`, latest assistant turn's `message.model` (placeholder `<synthetic>` turns skipped)
  - copilot: newest `~/.copilot/session-state/*/events.jsonl`, latest event carrying `model`/`currentModel`/`selectedModel`
  - bob: newest `~/.bob/tmp/*/chats/*.json`, last per-message `model`
- **Precedence, fixed:** explicit `AGENT_MODEL` → detected model → `''` (today's degrade). Detection never even runs when `AGENT_MODEL` is set.
- **Mid-session switches:** detection is re-run on every `progressTick()`, and the periodic `task_progress` reports piggyback optional `model` / `reasoning_effort` fields — so a `/model` switch reaches the hub within one `PROGRESS_REPORT_INTERVAL_MS`. `auth_response` uses the same effective value at connect.
- **Privacy:** only the minimal tail (64 KiB) needed to find the latest turn's model field is read; nothing but the model field is extracted, logged, or transmitted. Detected values pass through `sanitizeDeclaredValue`.

**Hub (`src/pkg/dashboard/contribute_ws.go`)**
- The routine `task_progress` branch updates `contributor.model` / `contributor.reasoningEffort` (and profile mirrors) when the fields are present — same pattern as the auth-time handler — behind the existing #2568 stale-generation gate. Absent fields change nothing.

## No regression

- codex / agy / goose / pi / aider / litellm: no detector, so they report exactly what they do today (CLI name only, unless `AGENT_MODEL` is set).
- Older relays omit the new fields; the hub path is a no-op for them.
- Headless mode untouched (no periodic tick there, per the issue's non-goals).

## Tests

- Relay (`bin/contributor-relay.test.js`, 9 new): detection per backend, explicit-`AGENT_MODEL` precedence, mid-session switch surfacing in the tick's `task_progress`, synthetic-turn skipping, unsupported-backend and missing-log-root degrade.
- Hub (`contribute_ws_progress_model_test.go`, 3 new): mid-session update consumed, empty fields never clobber connect-time values, stale-generation straggler cannot update the model.

All 116 relay tests and the full `pkg/dashboard` Go suite pass; `go vet` clean.
