### PR TITLE
🐛 fix(contribute): set HIVE_WORKSPACE_DIR in local mode

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -443,6 +443,28 @@ contribute-hive backend="" mode="docker": check-version
         exit 1
       fi
 
+      # The hub's assignment prompt tells the agent to clone into
+      # "$HIVE_WORKSPACE_DIR/<owner>/<repo>" (buildTaskPrompt in
+      # src/pkg/dashboard/contribute_ws.go). Only the CONTAINER entrypoint
+      # (bin/contributor-agent.sh, via Dockerfile.contributor) ever gave that
+      # variable a value, and local mode does not run that script — so on this
+      # path it was unset and the prompt expanded to "/<owner>/<repo>", an
+      # unwritable path at filesystem root.
+      #
+      # What each agent did with that was its own improvisation. Observed live:
+      # agy silently worked in $PWD instead — which in local mode IS the hive
+      # checkout the relay was launched from, so a task branch-switched the
+      # relay's own source tree and left a nested clone inside it.
+      #
+      # agy is local-only (its Google OAuth flow cannot authenticate in a
+      # container, see contribute-k8s below), so every agy contributor is
+      # forced onto the one path that lacked this default.
+      #
+      # Same default and mkdir as the container entrypoint, so both paths agree.
+      export HIVE_WORKSPACE_DIR="${HIVE_WORKSPACE_DIR:-${HOME}/workspace}"
+      mkdir -p "$HIVE_WORKSPACE_DIR"
+      echo "Workspace: ${HIVE_WORKSPACE_DIR}"
+
       # Start ollama silently if needed for goose
       if [[ "$BACKEND" == "goose" && "${GOOSE_PROVIDER:-}" == "ollama" ]]; then
         if ! curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; then


### PR DESCRIPTION
## Problem

`just contribute-hive <backend> local` never sets `HIVE_WORKSPACE_DIR`.

The hub's assignment prompt instructs the agent to clone into `$HIVE_WORKSPACE_DIR/<owner>/<repo>` (`buildTaskPrompt`, `src/pkg/dashboard/contribute_ws.go`). But only the **container entrypoint** — `bin/contributor-agent.sh`, wired up by `Dockerfile.contributor:192` — ever gave that variable a value or created the directory:

```sh
# bin/contributor-agent.sh:447
export HIVE_WORKSPACE_DIR="${HIVE_WORKSPACE_DIR:-${HOME}/workspace}"
mkdir -p "$HIVE_WORKSPACE_DIR"
```

Local mode does not run that script. Before this change the Justfile referenced `HIVE_WORKSPACE_DIR` **zero** times and `contributor-agent.sh` **zero** times:

```console
$ grep -c HIVE_WORKSPACE_DIR Justfile
0
$ grep -c contributor-agent.sh Justfile
0
```

So the prompt expanded to an unwritable path at filesystem root:

```console
$ unset HIVE_WORKSPACE_DIR
$ echo "$HIVE_WORKSPACE_DIR/kubestellar/hive"
/kubestellar/hive
```

## Impact

What an agent does with that is improvisation, not anything the relay specified.

**Observed live:** agy silently worked in `$PWD` instead — which in local mode is the hive checkout the relay was launched *from*. One task ran `git checkout -B sec/fix-workflow-permissions origin/v4` against the relay's own source tree and left a 127 MB nested clone inside it. The contributor's checkout came back on a task branch with an untracked clone in it, and the tree the running relay had been started from was no longer the tree it was reading.

`.github/workflows/` was harmless this time. A task about the relay itself would have had the agent editing `bin/contributor-relay.sh` while that file was running.

**This is not a niche path.** `agy` cannot authenticate in a container — its Google OAuth flow has no API-key mode, which is why `contribute-k8s` warns about it and the docs mark it host-only. Every agy contributor is therefore forced onto the one launch path that lacked this default.

## Fix

Apply the same default and `mkdir` the container entrypoint already does, so the two paths agree, and echo the resolved value with the other startup lines so a wrong value is visible immediately.

An operator-supplied value still wins — `contributor.env` is sourced under `set -a` a few lines above, so `HIVE_WORKSPACE_DIR=...` there is honoured.

## Verification

```
unset (fresh contributor):   /tmp/.../workspace          exists=yes
preset (contributor.env):    /tmp/.../custom-ws          exists=yes   # user value wins
prompt expansion before:     /kubestellar/hive
prompt expansion after:      /tmp/.../workspace/kubestellar/hive
```

`just --list` parses, and the full `contribute-hive` recipe body passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)