### PR TITLE
✨ manage-access: show provider identity icons beside user names

### DIFF
--- a/src/pkg/hub/grantable_users_test.go
+++ b/src/pkg/hub/grantable_users_test.go
@@ -269,7 +269,11 @@ func TestGrantableUserProvider(t *testing.T) {
 		want string
 	}{
 		{name: "stored provider wins", user: SaaSUser{GitHubUsername: "google:123", Provider: "google"}, want: "google"},
+		{name: "stored ms alias normalizes to microsoft", user: SaaSUser{GitHubUsername: "ms:AAAA", Provider: "ms"}, want: "microsoft"},
 		{name: "prefix classifies a legacy record", user: SaaSUser{GitHubUsername: "ibmid:650"}, want: "ibmid"},
+		{name: "microsoft prefix", user: SaaSUser{GitHubUsername: "microsoft:AAAA"}, want: "microsoft"},
+		{name: "ms prefix normalizes to microsoft", user: SaaSUser{GitHubUsername: "ms:AAAA"}, want: "microsoft"},
+		{name: "github.com/ prefixed key classifies as github", user: SaaSUser{GitHubUsername: "github.com/octocat"}, want: "github"},
 		{name: "plain login defaults to github", user: SaaSUser{GitHubUsername: "octocat"}, want: "github"},
 	}
 	for _, tc := range tests {
@@ -348,6 +352,38 @@ func TestManageAccessDialogHasUserSearch(t *testing.T) {
 		`e.label.toLowerCase().indexOf(q) !== -1 || e.id.toLowerCase().indexOf(q) !== -1`,
 		// Fallback for older hub payloads that only carry bare usernames.
 		`data.entries || (data.users || []).map`,
+	} {
+		if !strings.Contains(dashboardHTML, want) {
+			t.Errorf("dashboardHTML missing %q", want)
+		}
+	}
+}
+
+// TestManageAccessProviderIcons pins the provider-icon UI: the dashboard must
+// classify raw identity keys by prefix, carry inline SVG marks (no external
+// fetches, CSP-safe) for known providers, render an icon beside each name in
+// the existing access rows, and prepend an emoji mark (native <option>
+// elements cannot render SVG) in the Add User picker.
+func TestManageAccessProviderIcons(t *testing.T) {
+	for _, want := range []string{
+		// Prefix classification logic, including the ms → microsoft alias and
+		// the github.com/ + bare-login → github fallbacks.
+		`function identityProviderFromKey(key)`,
+		`if (key.indexOf('github.com/') === 0) return 'github';`,
+		`if (p === 'ms') return 'microsoft';`,
+		// Inline SVG marks for the known providers.
+		`var PROVIDER_ICON_SVG = {`,
+		`github: '<svg viewBox="0 0 16 16"`,
+		`google: '<svg viewBox="0 0 48 48"`,
+		`microsoft: '<svg viewBox="0 0 23 23"`,
+		`ibmid: '<svg viewBox="0 0 16 16"`,
+		// Emoji fallbacks for the <select>, plus the generic-person default.
+		`var PROVIDER_EMOJI = { google: '🔵', ibmid: '🔷', microsoft: '🟦', github: '🐙' };`,
+		`PROVIDER_ICON_SVG[provider] || '👤'`,
+		`(PROVIDER_EMOJI[provider] || '👤')`,
+		// Icons applied in both the existing rows and the Add User picker.
+		`providerIconHTML(identityProviderFromKey(u.username))`,
+		`providerOptionEmoji(e.provider || identityProviderFromKey(e.id))`,
 	} {
 		if !strings.Contains(dashboardHTML, want) {
 			t.Errorf("dashboardHTML missing %q", want)

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -6161,15 +6161,24 @@ func splitIdentityKey(key string) (provider, sub string) {
 	return "", key
 }
 
+// normalizeIdentityProvider maps provider aliases onto their canonical name
+// so the picker classifies "ms:…" identities the same as "microsoft:…" ones.
+func normalizeIdentityProvider(p string) string {
+	if p == "ms" {
+		return "microsoft"
+	}
+	return p
+}
+
 // grantableUserProvider reports the identity provider for a roster entry,
 // preferring the stored Provider field and falling back to the prefix of the
 // identity key so legacy records still classify correctly.
 func grantableUserProvider(u *SaaSUser) string {
 	if u.Provider != "" {
-		return u.Provider
+		return normalizeIdentityProvider(u.Provider)
 	}
 	if p, _ := splitIdentityKey(u.GitHubUsername); p != "" {
-		return p
+		return normalizeIdentityProvider(p)
 	}
 	return "github"
 }
@@ -18705,13 +18714,56 @@ const dashboardHTML = `<!DOCTYPE html>
        human label (label — what the owner reads). */
     var _grantableUsers = [];
 
-    /* accessOptionText renders one dropdown row: the friendly label, plus a
-       short parenthesised hint of the underlying ID when the two differ so an
-       owner can tell two "Jane Doe"s apart without seeing a full raw token. */
+    /* identityProviderFromKey classifies a raw identity key by its prefix so
+       the UI can show a provider mark next to the name: "google:…" → google,
+       "ibmid:…" → ibmid, "microsoft:…" or "ms:…" → microsoft, a "github.com/…"
+       prefix or a bare login (no prefix at all) → github. Unknown prefixes
+       pass through unchanged and render as the generic person icon. */
+    function identityProviderFromKey(key) {
+      key = String(key || '');
+      if (key.indexOf('github.com/') === 0) return 'github';
+      var m = key.match(/^([a-z][a-z0-9_-]*):/);
+      if (!m) return 'github';
+      var p = m[1];
+      if (p === 'ms') return 'microsoft';
+      return p;
+    }
+
+    /* PROVIDER_ICON_SVG: small inline SVG provider marks — inline so no
+       external fetches happen (CSP-safe). Sized 14px to sit alongside the
+       0.85rem row labels. Providers without an SVG fall back to emoji. */
+    var PROVIDER_ICON_SVG = {
+      github: '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>',
+      google: '<svg viewBox="0 0 48 48" width="14" height="14" aria-hidden="true"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/></svg>',
+      microsoft: '<svg viewBox="0 0 23 23" width="14" height="14" aria-hidden="true"><rect x="1" y="1" width="10" height="10" fill="#f25022"/><rect x="12" y="1" width="10" height="10" fill="#7fba00"/><rect x="1" y="12" width="10" height="10" fill="#00a4ef"/><rect x="12" y="12" width="10" height="10" fill="#ffb900"/></svg>',
+      ibmid: '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><g fill="#0f62fe"><rect x="1" y="3" width="14" height="2"/><rect x="1" y="7" width="14" height="2"/><rect x="1" y="11" width="14" height="2"/></g></svg>'
+    };
+
+    /* PROVIDER_EMOJI: plain-text stand-ins for native <select> options, which
+       cannot render SVG. Anything unmapped shows the generic person glyph. */
+    var PROVIDER_EMOJI = { google: '🔵', ibmid: '🔷', microsoft: '🟦', github: '🐙' };
+
+    /* providerIconHTML returns a small inline icon (SVG when we have one,
+       emoji otherwise) vertically aligned with the label text beside it. */
+    function providerIconHTML(provider) {
+      var body = PROVIDER_ICON_SVG[provider] || '👤';
+      return '<span title="' + esc(provider || 'unknown provider') + '" style="display:inline-flex;align-items:center;vertical-align:middle;margin-right:5px;width:14px;height:14px;line-height:1;font-size:12px">' + body + '</span>';
+    }
+
+    /* providerOptionEmoji is the <option>-safe variant of providerIconHTML. */
+    function providerOptionEmoji(provider) {
+      return (PROVIDER_EMOJI[provider] || '👤') + ' ';
+    }
+
+    /* accessOptionText renders one dropdown row: a provider mark, the friendly
+       label, plus a short parenthesised hint of the underlying ID when the two
+       differ so an owner can tell two "Jane Doe"s apart without seeing a full
+       raw token. */
     function accessOptionText(e) {
-      if (!e.id || e.id === e.label) return e.label;
+      var icon = providerOptionEmoji(e.provider || identityProviderFromKey(e.id));
+      if (!e.id || e.id === e.label) return icon + e.label;
       var hint = e.id.length > 24 ? e.id.slice(0, 24) + '…' : e.id;
-      return e.label + ' (' + hint + ')';
+      return icon + e.label + ' (' + hint + ')';
     }
 
     /* renderAccessUserOptions rebuilds the select from _grantableUsers,
@@ -18802,7 +18854,7 @@ const dashboardHTML = `<!DOCTYPE html>
               ROLES.map(function(r) { return '<option value="' + r + '"' + (r === u.role ? ' selected' : '') + '>' + r + '</option>'; }).join('') +
             '</select>';
           return '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border)">' +
-            '<div>' + avatar + '<span style="font-size:0.85rem">' + esc(u.username) + '</span></div>' +
+            '<div>' + avatar + providerIconHTML(identityProviderFromKey(u.username)) + '<span style="font-size:0.85rem">' + esc(u.username) + '</span></div>' +
             '<div style="display:flex;align-items:center;gap:8px">' +
             roleControl +
             removeBtn +


### PR DESCRIPTION
Extends the Manage Access user list to show provider identity icons next to each user's name, in both the existing user rows and the Add User dropdown/search added in #4138.

## Provider detection (from the raw identity key prefix)
- `google:` → Google G icon
- `ibmid:` → IBM bars icon
- `microsoft:` / `ms:` → Microsoft squares icon (backend now normalizes the `ms` alias)
- `github.com/` prefix or bare username → GitHub octocat icon
- any other prefix → generic 👤

## Implementation
- Inline SVG icons (14px, vertically aligned with the label) — no external fetches, CSP-safe
- The Add User `<select>` uses emoji marks (🔵/🔷/🟦/🐙/👤) since native `<option>` elements cannot render SVG
- Search, role dropdown, and remove button behavior unchanged

## Tests
- Extended `TestGrantableUserProvider` for `ms:`, `microsoft:`, and `github.com/` prefixes
- New `TestManageAccessProviderIcons` pinning the prefix-classification JS, inline SVG marks, emoji fallbacks, and icon application in both lists

Part of #4137