### PR TITLE
✨ manage-access: show last-active timestamp per user

### DIFF
--- a/src/pkg/hub/access_hover_test.go
+++ b/src/pkg/hub/access_hover_test.go
@@ -116,3 +116,81 @@ func TestAccessAvatarTitleCarriesStats(t *testing.T) {
 		t.Error("the live-ring wrapper still hard-codes a title that shadows the avatar tooltip")
 	}
 }
+
+// TestLatestUserActivity pins the "last active" derivation for the Manage
+// Access list (#4146): the latest of LastLogin / LastEngagedAt / LastActionAt
+// wins, blanks and unparseable values are skipped, and a user with no activity
+// at all yields "" (which the UI renders as "—").
+func TestLatestUserActivity(t *testing.T) {
+	cases := []struct {
+		name string
+		u    SaaSUser
+		want string
+	}{
+		{"never active", SaaSUser{GitHubUsername: "ghost"}, ""},
+		{"login only", SaaSUser{LastLogin: "2026-01-02T03:04:05Z"}, "2026-01-02T03:04:05Z"},
+		{"action beats login", SaaSUser{
+			LastLogin:    "2026-01-02T03:04:05Z",
+			LastActionAt: "2026-02-01T00:00:00Z",
+		}, "2026-02-01T00:00:00Z"},
+		{"engaged beats both", SaaSUser{
+			LastLogin:     "2026-01-02T03:04:05Z",
+			LastEngagedAt: "2026-03-01T00:00:00Z",
+			LastActionAt:  "2026-02-01T00:00:00Z",
+		}, "2026-03-01T00:00:00Z"},
+		{"garbage skipped, valid wins", SaaSUser{
+			LastLogin:    "not-a-timestamp",
+			LastActionAt: "2026-02-01T00:00:00Z",
+		}, "2026-02-01T00:00:00Z"},
+		{"all garbage yields never", SaaSUser{LastLogin: "yesterday-ish"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := latestUserActivity(&tc.u); got != tc.want {
+				t.Errorf("latestUserActivity = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAccessForHiveLastActive pins that LastActive rides for EVERY viewer of an
+// access row — unlike the admin-only engagement stats — because "is this
+// account dormant?" is the owner-level question Manage Access answers (#4146).
+func TestAccessForHiveLastActive(t *testing.T) {
+	users := []SaaSUser{
+		{
+			GitHubUsername: "active-user",
+			Hives:          map[string]string{"h1": "owner"},
+			LastLogin:      "2026-01-02T03:04:05Z",
+			LastActionAt:   "2026-02-01T00:00:00Z",
+		},
+		{GitHubUsername: "dormant-user", Hives: map[string]string{"h1": "read"}},
+	}
+	for _, admin := range []bool{true, false} {
+		got := accessForHive("h1", users, admin)
+		if len(got) != 2 {
+			t.Fatalf("admin=%v: want 2 entries, got %d", admin, len(got))
+		}
+		if got[0].LastActive != "2026-02-01T00:00:00Z" {
+			t.Errorf("admin=%v: active user LastActive = %q, want 2026-02-01T00:00:00Z", admin, got[0].LastActive)
+		}
+		if got[1].LastActive != "" {
+			t.Errorf("admin=%v: dormant user LastActive = %q, want empty (never)", admin, got[1].LastActive)
+		}
+	}
+}
+
+// TestManageAccessRowShowsLastActive pins the Manage Access row markup: a
+// relative last-active span for users with activity, and a "—" placeholder for
+// users who have never been active.
+func TestManageAccessRowShowsLastActive(t *testing.T) {
+	for _, snippet := range []string{
+		"esc(timelineAgo(u.last_active) || fmtUserTS(u.last_active))",
+		`title="Last active ' + esc(fmtUserTS(u.last_active)) + '"`,
+		`title="Never active on this hub">—</span>`,
+	} {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("dashboardHTML missing %q", snippet)
+		}
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -5978,6 +5978,38 @@ type HiveAccessEntry struct {
 	// the stats above, and omitempty/absent for records without data yet.
 	EngagedSeconds int64  `json:"engaged_seconds,omitempty"`
 	LastActionAt   string `json:"last_action_at,omitempty"`
+	// LastActive is the RFC3339 time of this user's most recent hub activity —
+	// the latest of their last login, last engaged beat, and last audited
+	// action (see latestUserActivity). Unlike the engagement stats above it
+	// rides for EVERY owner-visible row, not just for admins: "is this account
+	// dormant?" is exactly the owner-level question the Manage Access list
+	// answers when deciding on access changes (#4146). omitempty — absent means
+	// the user has never been active, which the UI renders as "—".
+	LastActive string `json:"last_active,omitempty"`
+}
+
+// latestUserActivity returns the RFC3339 timestamp of u's most recent hub
+// activity — the latest of LastLogin, LastEngagedAt, and LastActionAt — or ""
+// when the user has never been active. Timestamps are parsed rather than
+// compared lexically so legacy records with mixed UTC offsets still order
+// correctly; an unparseable value is skipped, never surfaced.
+func latestUserActivity(u *SaaSUser) string {
+	var best time.Time
+	var bestStr string
+	for _, ts := range []string{u.LastLogin, u.LastEngagedAt, u.LastActionAt} {
+		if strings.TrimSpace(ts) == "" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			continue
+		}
+		if t.After(best) {
+			best = t
+			bestStr = ts
+		}
+	}
+	return bestStr
 }
 
 // accessForHive returns who can sign in to a hive, newest-role-agnostic and
@@ -5998,6 +6030,9 @@ func accessForHive(hiveID string, users []SaaSUser, includeAdminOnly bool) []Hiv
 				Role:     role,
 				FullName: u.FullName,
 				SlackID:  u.SlackID,
+				// Coarse last-active rides for every viewer of the row (see the
+				// field doc) — only the granular stats below stay admin-only.
+				LastActive: latestUserActivity(&u),
 			}
 			if includeAdminOnly {
 				entry.Notes = u.Notes
@@ -18801,9 +18836,16 @@ const dashboardHTML = `<!DOCTYPE html>
             '<select class="role-select role-' + u.role.replace(' ','-') + '" style="font-size:0.7rem;padding:2px 6px;border-radius:9999px;cursor:pointer" title="Change this user\'s permission" onchange="changeAccessRole(\'' + esc(u.username) + '\', this.value, \'' + esc(u.role) + '\')">' +
               ROLES.map(function(r) { return '<option value="' + r + '"' + (r === u.role ? ' selected' : '') + '>' + r + '</option>'; }).join('') +
             '</select>';
+          /* Last-active is coarse and relative on purpose ("3d ago") — the
+             owner's question is "is this account dormant?", not "when exactly".
+             The absolute time rides in the title. "—" means never active. */
+          var lastActive = u.last_active ?
+            '<span style="font-size:0.7rem;color:var(--muted)" title="Last active ' + esc(fmtUserTS(u.last_active)) + '">' + esc(timelineAgo(u.last_active) || fmtUserTS(u.last_active)) + '</span>' :
+            '<span style="font-size:0.7rem;color:var(--muted)" title="Never active on this hub">—</span>';
           return '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border)">' +
             '<div>' + avatar + '<span style="font-size:0.85rem">' + esc(u.username) + '</span></div>' +
             '<div style="display:flex;align-items:center;gap:8px">' +
+            lastActive +
             roleControl +
             removeBtn +
             '</div></div>';


### PR DESCRIPTION
Shows a relative last-active time per user in the Manage Access list so owners can identify inactive accounts before deciding on access changes.

## Changes
- `HiveAccessEntry` gains a `last_active` field, populated for every owner-visible row (unlike the admin-only engagement stats) via a new `latestUserActivity` helper — the latest of `LastLogin`, `LastEngagedAt`, and `LastActionAt` already tracked per user.
- Manage Access rows render the relative time (reusing `timelineAgo`, e.g. "3d ago") with the absolute timestamp in the tooltip; users with no activity show "—" with a "Never active on this hub" tooltip.
- Tests: `TestLatestUserActivity`, `TestAccessForHiveLastActive`, `TestManageAccessRowShowsLastActive`.

## Acceptance criteria
- [x] Each user row shows relative last-active time when available
- [x] Shows "—" for users who have never accessed the hive
- [x] Sourced from existing session/activity data already tracked per user

Fixes #4146