### PR TITLE
✨ manage-access: time-limited / expiring access grants

### DIFF
--- a/src/pkg/hub/access_expiry.go
+++ b/src/pkg/hub/access_expiry.go
@@ -1,0 +1,164 @@
+package hub
+
+// Time-limited access grants (#4150).
+//
+// An owner may attach an OPTIONAL expiry to any Manage Access grant. The
+// expiry rides on the user record next to the role itself (SaaSUser.HiveExpiry,
+// hive ID → RFC3339 instant) so a grant and its lifetime always travel — and
+// are persisted — together. No expiry means permanent, which keeps every
+// pre-#4150 record byte-identical and behaviorally unchanged.
+//
+// Enforcement is two-layered, and the layers are deliberately independent:
+//
+//  1. ON-ACCESS (authoritative): loadSaaSUser prunes expired grants from the
+//     in-memory record at READ time, on the wall clock. Every consumer of a
+//     user's role — requireAuth-gated handlers, userIsHiveOwner, accessForHive,
+//     the heartbeat's authorized-users push to spokes — resolves roles through
+//     loadSaaSUser/listAllSaaSUsers, so an expired grant stops working at its
+//     expiry instant whether or not the sweep below ever runs.
+//  2. BACKGROUND SWEEP (persistence + audit): sweepExpiredAccessIfDue, ticked
+//     from the hub's SHA-poller loop, rewrites the pruned records to disk and
+//     stamps a timeline event so the revocation is visible in the hive's
+//     Activity Timeline. It reads the RAW json files (not loadSaaSUser, whose
+//     read-time prune would hide exactly the entries this sweep must persist).
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// accessExpirySweepInterval throttles the expiry persistence sweep. The SHA
+// poller ticks every 2 min but expiry granularity is a calendar date, so
+// persisting/auditing at most every 10 min is plenty. NOTE this throttles
+// PERSISTENCE AND THE TIMELINE EVENT ONLY — an expired grant is refused at
+// read time by loadSaaSUser's prune whether or not this sweep ever runs.
+const accessExpirySweepInterval = 10 * time.Minute
+
+// accessExpiryDateLayout is the bare-date form the Manage Access date picker
+// submits ("2026-09-01"). A bare date means "access is valid THROUGH that
+// day, UTC" — it canonicalizes to 00:00 UTC of the following day.
+const accessExpiryDateLayout = "2006-01-02"
+
+// parseAccessExpiry canonicalizes an owner-supplied expiry into a UTC instant.
+// It accepts either a bare date (valid through that day, UTC) or a full
+// RFC3339 timestamp. The zero time with a nil error is never returned for a
+// non-empty input.
+func parseAccessExpiry(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("empty expiry")
+	}
+	if d, err := time.Parse(accessExpiryDateLayout, raw); err == nil {
+		return d.UTC().Add(24 * time.Hour), nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("expiry must be YYYY-MM-DD or RFC3339: %w", err)
+	}
+	return t.UTC(), nil
+}
+
+// accessGrantExpired reports whether the stored expiry string marks a grant
+// as expired at now. A missing/blank expiry is permanent; an UNPARSEABLE
+// expiry is treated as permanent rather than as expired, so a corrupt field
+// can never silently lock a user out — it merely stops limiting them, which
+// the owner can see and fix in Manage Access.
+func accessGrantExpired(expiry string, now time.Time) bool {
+	expiry = strings.TrimSpace(expiry)
+	if expiry == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, expiry)
+	if err != nil {
+		return false
+	}
+	return !now.Before(t)
+}
+
+// pruneExpiredHiveGrants removes every expired grant from u (both the role in
+// Hives and its HiveExpiry entry) and drops orphaned expiry entries whose
+// grant is already gone. It returns the hive IDs whose grants were revoked,
+// so the sweep can stamp per-hive timeline events. It never writes to disk.
+func pruneExpiredHiveGrants(u *SaaSUser, now time.Time) []string {
+	if u == nil || len(u.HiveExpiry) == 0 {
+		return nil
+	}
+	var revoked []string
+	for hiveID, expiry := range u.HiveExpiry {
+		if _, granted := u.Hives[hiveID]; !granted {
+			// Orphaned expiry (grant removed through another path): clean it up
+			// but do not report a revocation — there was nothing to revoke.
+			delete(u.HiveExpiry, hiveID)
+			continue
+		}
+		if accessGrantExpired(expiry, now) {
+			delete(u.Hives, hiveID)
+			delete(u.HiveExpiry, hiveID)
+			revoked = append(revoked, hiveID)
+		}
+	}
+	return revoked
+}
+
+// sweepExpiredAccessIfDue runs the expiry persistence sweep only if at least
+// accessExpirySweepInterval has elapsed since the last run. Same throttle
+// pattern (and same guarding mutex) as reconcileNetAdminIfDue: poller-loop-only
+// state. Safe to call from the poller loop every tick.
+func (s *HubServer) sweepExpiredAccessIfDue() {
+	s.clusterUnreachableMu.Lock()
+	due := s.lastAccessExpirySweep.IsZero() ||
+		time.Since(s.lastAccessExpirySweep) >= accessExpirySweepInterval
+	if due {
+		s.lastAccessExpirySweep = time.Now()
+	}
+	s.clusterUnreachableMu.Unlock()
+	if !due {
+		return
+	}
+	s.sweepExpiredAccess(time.Now())
+}
+
+// sweepExpiredAccess persists the revocation of every expired grant and stamps
+// a timeline event on each affected hive. It reads the raw user files —
+// loadSaaSUser's read-time prune (layer 1) would hide exactly the expired
+// entries this sweep exists to persist and audit.
+func (s *HubServer) sweepExpiredAccess(now time.Time) {
+	entries, err := os.ReadDir(saasUsersDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(saasUsersDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var u SaaSUser
+		if json.Unmarshal(data, &u) != nil {
+			continue
+		}
+		roles := map[string]string{}
+		for hiveID := range u.HiveExpiry {
+			roles[hiveID] = u.Hives[hiveID]
+		}
+		revoked := pruneExpiredHiveGrants(&u, now)
+		if len(revoked) == 0 {
+			continue
+		}
+		if err := saveSaaSUser(&u); err != nil {
+			s.logger.Warn("access expiry sweep: save failed", "user", u.GitHubUsername, "error", err)
+			continue
+		}
+		for _, hiveID := range revoked {
+			s.logger.Info("audit: access expired", "hive", hiveID, "target", u.GitHubUsername, "role", roles[hiveID])
+			s.recordTimeline(hiveID, TimelineAccess,
+				fmt.Sprintf("access for %s expired (was %s)", u.GitHubUsername, roles[hiveID]), "system")
+		}
+	}
+}

--- a/src/pkg/hub/access_expiry_test.go
+++ b/src/pkg/hub/access_expiry_test.go
@@ -1,0 +1,265 @@
+package hub
+
+// Tests for time-limited access grants (#4150): expiry parsing, read-time
+// pruning in loadSaaSUser, the persistence sweep, and the handleAccessAdd
+// set/preserve/clear semantics. Reuses the temp-dir and cookie fixtures from
+// grantable_users_test.go.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseAccessExpiry(t *testing.T) {
+	t.Run("bare date is valid through that day UTC", func(t *testing.T) {
+		got, err := parseAccessExpiry("2030-06-15")
+		if err != nil {
+			t.Fatalf("parseAccessExpiry: %v", err)
+		}
+		want := time.Date(2030, 6, 16, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+	t.Run("rfc3339 passes through in UTC", func(t *testing.T) {
+		got, err := parseAccessExpiry("2030-06-15T12:30:00+02:00")
+		if err != nil {
+			t.Fatalf("parseAccessExpiry: %v", err)
+		}
+		want := time.Date(2030, 6, 15, 10, 30, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+	for _, bad := range []string{"", "  ", "not-a-date", "2030-13-45"} {
+		if _, err := parseAccessExpiry(bad); err == nil {
+			t.Errorf("parseAccessExpiry(%q): want error, got nil", bad)
+		}
+	}
+}
+
+func TestAccessGrantExpired(t *testing.T) {
+	now := time.Date(2030, 1, 1, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name   string
+		expiry string
+		want   bool
+	}{
+		{"empty is permanent", "", false},
+		{"future not expired", now.Add(time.Hour).Format(time.RFC3339), false},
+		{"past expired", now.Add(-time.Hour).Format(time.RFC3339), true},
+		{"exact instant expired", now.Format(time.RFC3339), true},
+		// A corrupt field must fail OPEN (permanent), never lock a user out.
+		{"unparseable is permanent", "garbage", false},
+	}
+	for _, c := range cases {
+		if got := accessGrantExpired(c.expiry, now); got != c.want {
+			t.Errorf("%s: accessGrantExpired(%q) = %v, want %v", c.name, c.expiry, got, c.want)
+		}
+	}
+}
+
+func TestPruneExpiredHiveGrants(t *testing.T) {
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	u := &SaaSUser{
+		GitHubUsername: "alice",
+		Hives: map[string]string{
+			"h-expired":   "read-write",
+			"h-future":    "read",
+			"h-permanent": "owner",
+		},
+		HiveExpiry: map[string]string{
+			"h-expired": now.Add(-time.Minute).Format(time.RFC3339),
+			"h-future":  now.Add(time.Hour).Format(time.RFC3339),
+			"h-orphan":  now.Add(-time.Minute).Format(time.RFC3339),
+		},
+	}
+	revoked := pruneExpiredHiveGrants(u, now)
+	if len(revoked) != 1 || revoked[0] != "h-expired" {
+		t.Fatalf("revoked = %v, want [h-expired]", revoked)
+	}
+	if _, ok := u.Hives["h-expired"]; ok {
+		t.Error("expired grant still present")
+	}
+	if u.Hives["h-future"] != "read" || u.Hives["h-permanent"] != "owner" {
+		t.Errorf("live grants disturbed: %v", u.Hives)
+	}
+	if _, ok := u.HiveExpiry["h-orphan"]; ok {
+		t.Error("orphaned expiry entry not cleaned")
+	}
+	if _, ok := u.HiveExpiry["h-future"]; !ok {
+		t.Error("future expiry dropped")
+	}
+}
+
+func TestLoadSaaSUserPrunesExpiredGrantsOnRead(t *testing.T) {
+	withTempSaaSDirs(t)
+	err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "bob",
+		Hives:          map[string]string{"h1": "read-write", "h2": "read"},
+		HiveExpiry: map[string]string{
+			"h1": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	u := loadSaaSUser("bob")
+	if u == nil {
+		t.Fatal("loadSaaSUser returned nil")
+	}
+	if _, ok := u.Hives["h1"]; ok {
+		t.Error("expired grant survived read-time prune")
+	}
+	if u.Hives["h2"] != "read" {
+		t.Errorf("unbounded grant disturbed: %v", u.Hives)
+	}
+}
+
+func TestSweepExpiredAccessPersistsAndAudits(t *testing.T) {
+	withTempSaaSDirs(t)
+	s := grantableTestServer()
+	err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "carol",
+		Hives:          map[string]string{"h1": "merger"},
+		HiveExpiry: map[string]string{
+			"h1": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	s.sweepExpiredAccess(time.Now())
+	// The prune must be PERSISTED: bypass loadSaaSUser's read-time filter and
+	// check the raw record.
+	raw, err := readSaaSUserFile("carol")
+	if err != nil {
+		t.Fatalf("readSaaSUserFile: %v", err)
+	}
+	var u SaaSUser
+	if err := json.Unmarshal(raw, &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := u.Hives["h1"]; ok {
+		t.Error("sweep did not persist the revocation")
+	}
+	if _, ok := u.HiveExpiry["h1"]; ok {
+		t.Error("sweep did not persist the expiry cleanup")
+	}
+}
+
+// postAccess calls handleAccessAdd as username for hive h1 with the raw body.
+func postAccess(t *testing.T, s *HubServer, username, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/hives/h1/access", strings.NewReader(body))
+	req.SetPathValue("id", "h1")
+	req.AddCookie(&http.Cookie{
+		Name:  "hive_hub_user",
+		Value: mintHubUserCookieValueV2(deriveDomainKey(grantableTestSecret, infoSessionEd25519Seed), username),
+	})
+	rec := httptest.NewRecorder()
+	s.handleAccessAdd(rec, req)
+	return rec
+}
+
+func TestHandleAccessAddExpirySemantics(t *testing.T) {
+	withTempSaaSDirs(t)
+	s := grantableTestServer()
+	putHiveOwnedBy(t, "h1", "owner1")
+	putUser(t, "owner1")
+	putUser(t, "dave")
+
+	t.Run("grant with expiry stores canonical instant", func(t *testing.T) {
+		rec := postAccess(t, s, "owner1", `{"username":"dave","role":"read","expires_at":"2099-06-15"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body=%q", rec.Code, rec.Body.String())
+		}
+		u := loadSaaSUser("dave")
+		want := time.Date(2099, 6, 16, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+		if u.HiveExpiry["h1"] != want {
+			t.Fatalf("expiry = %q, want %q", u.HiveExpiry["h1"], want)
+		}
+	})
+
+	t.Run("role change without expires_at preserves expiry", func(t *testing.T) {
+		rec := postAccess(t, s, "owner1", `{"username":"dave","role":"read-write"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body=%q", rec.Code, rec.Body.String())
+		}
+		u := loadSaaSUser("dave")
+		if u.Hives["h1"] != "read-write" {
+			t.Fatalf("role = %q", u.Hives["h1"])
+		}
+		if u.HiveExpiry["h1"] == "" {
+			t.Fatal("role change cleared the expiry; it must be preserved")
+		}
+	})
+
+	t.Run("empty expires_at clears expiry", func(t *testing.T) {
+		rec := postAccess(t, s, "owner1", `{"username":"dave","role":"read-write","expires_at":""}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body=%q", rec.Code, rec.Body.String())
+		}
+		u := loadSaaSUser("dave")
+		if _, ok := u.HiveExpiry["h1"]; ok {
+			t.Fatal("empty expires_at did not clear the expiry")
+		}
+	})
+
+	t.Run("past expiry rejected", func(t *testing.T) {
+		rec := postAccess(t, s, "owner1", `{"username":"dave","role":"read","expires_at":"2001-01-01"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("garbage expiry rejected", func(t *testing.T) {
+		rec := postAccess(t, s, "owner1", `{"username":"dave","role":"read","expires_at":"whenever"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("expiry on the only owner rejected", func(t *testing.T) {
+		// owner1 is the hive's only granted owner: give them the stored role
+		// first, then try to time-limit it.
+		if rec := postAccess(t, s, "owner1", `{"username":"owner1","role":"owner"}`); rec.Code != http.StatusOK {
+			t.Fatalf("seed owner grant: status = %d", rec.Code)
+		}
+		rec := postAccess(t, s, "owner1", `{"username":"owner1","role":"owner","expires_at":"2099-01-01"}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400 (body=%q)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("expiry on a co-owner allowed once another owner exists", func(t *testing.T) {
+		rec := postAccess(t, s, "owner1", `{"username":"dave","role":"owner","expires_at":"2099-01-01"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body=%q", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func TestAccessListIncludesExpiry(t *testing.T) {
+	withTempSaaSDirs(t)
+	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "erin",
+		Hives:          map[string]string{"h1": "read"},
+		HiveExpiry:     map[string]string{"h1": future},
+	})
+	if err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	access := accessForHive("h1", listAllSaaSUsers(), false)
+	if len(access) != 1 {
+		t.Fatalf("access rows = %d, want 1", len(access))
+	}
+	if access[0].ExpiresAt != future {
+		t.Errorf("ExpiresAt = %q, want %q", access[0].ExpiresAt, future)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -258,6 +258,12 @@ type SaaSUser struct {
 	CreatedAt      string            `json:"created_at"`
 	LastLogin      string            `json:"last_login"`
 	Hives          map[string]string `json:"hives"`
+	// HiveExpiry optionally bounds a grant in Hives: hive ID → RFC3339 UTC
+	// instant after which that grant is revoked (#4150). Grants without an
+	// entry are permanent — omitempty keeps every pre-expiry record
+	// byte-identical on disk. Enforced at read time by loadSaaSUser's prune
+	// and persisted/audited by sweepExpiredAccess (access_expiry.go).
+	HiveExpiry     map[string]string `json:"hive_expiry,omitempty"`
 	SaaSQuota      int               `json:"saas_quota"`
 	Blocked        bool              `json:"blocked"`
 	EncryptedToken string            `json:"encrypted_token,omitempty"`
@@ -1067,6 +1073,12 @@ func loadSaaSUser(username string) *SaaSUser {
 	if u.LoginCount == 0 && strings.TrimSpace(u.LastLogin) != "" {
 		u.LoginCount = 1
 	}
+	// On-access expiry enforcement (#4150): drop expired grants at READ time so
+	// every consumer of a role — auth gates, accessForHive, the heartbeat's
+	// authorized-users push — sees the revocation the instant it is due, on the
+	// wall clock. Read-time only, never written here; sweepExpiredAccess
+	// (access_expiry.go) persists the prune and stamps the timeline event.
+	pruneExpiredHiveGrants(&u, time.Now())
 	return &u
 }
 
@@ -5121,6 +5133,12 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// expired generation at every verify, on the wall clock, whether or not
 	// this ever runs. See hub_generations_retire.go.
 	s.retireExpiredGenerationsIfDue()
+	// Persist and audit the revocation of expired Manage Access grants (#4150).
+	// Throttled internally to accessExpirySweepInterval. This lane PERSISTS the
+	// prune and stamps the timeline event; it is not what enforces expiry —
+	// loadSaaSUser already drops an expired grant at every read, on the wall
+	// clock, whether or not this ever runs. See access_expiry.go.
+	s.sweepExpiredAccessIfDue()
 	// Record the per-release image-pulls snapshot (external-adoption chart). The
 	// call is internally guarded to snapshot only when the v2 release SHA advances,
 	// so ticking it alongside the frequent SHA poll is cheap — no separate
@@ -5150,6 +5168,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		s.reconcileNetAdminIfDue()
 		s.reconcilePerHiveEnvIfDue()
 		s.retireExpiredGenerationsIfDue()
+		s.sweepExpiredAccessIfDue()
 		s.maybeSnapshotImagePulls(ctx, time.Now())
 		changed := false
 		for branch, sha := range newSHAs {
@@ -5957,6 +5976,10 @@ func authorizedUsersForHiveID(hiveID string) []string {
 type HiveAccessEntry struct {
 	Username string `json:"username"`
 	Role     string `json:"role"`
+	// ExpiresAt is the grant's optional expiry (RFC3339 UTC, #4150) copied from
+	// the user's HiveExpiry so Manage Access can show and edit it. omitempty —
+	// a permanent grant renders exactly as before.
+	ExpiresAt string `json:"expires_at,omitempty"`
 	// Contact metadata copied from the user's record so the My Hives avatar hover
 	// can show WHO someone is, not just their GitHub handle. FullName and SlackID
 	// ride for every owner/admin-visible access row. Notes is admin-maintained CRM
@@ -6028,10 +6051,11 @@ func accessForHive(hiveID string, users []SaaSUser, includeAdminOnly bool) []Hiv
 	for _, u := range users {
 		if role, ok := u.Hives[hiveID]; ok {
 			entry := HiveAccessEntry{
-				Username: u.GitHubUsername,
-				Role:     role,
-				FullName: u.FullName,
-				SlackID:  u.SlackID,
+				Username:  u.GitHubUsername,
+				Role:      role,
+				ExpiresAt: u.HiveExpiry[hiveID],
+				FullName:  u.FullName,
+				SlackID:   u.SlackID,
 				// Coarse last-active rides for every viewer of the row (see the
 				// field doc) — only the granular stats below stay admin-only.
 				LastActive: latestUserActivity(&u),
@@ -6270,6 +6294,13 @@ func (s *HubServer) handleAccessAdd(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Username string `json:"username"`
 		Role     string `json:"role"`
+		// ExpiresAt is the grant's optional expiry (#4150). Pointer semantics:
+		//   absent (nil)  → preserve the target's existing expiry, so a plain
+		//                   role change never silently clears a time limit
+		//   ""            → clear the expiry (grant becomes permanent)
+		//   "YYYY-MM-DD"  → valid through that day, UTC
+		//   RFC3339       → exact instant
+		ExpiresAt *string `json:"expires_at"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Username == "" || body.Role == "" {
 		http.Error(w, `{"error":"username and role required"}`, http.StatusBadRequest)
@@ -6279,22 +6310,83 @@ func (s *HubServer) handleAccessAdd(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"role must be read, read-write, merger, or owner"}`, http.StatusBadRequest)
 		return
 	}
+	var expiresAt string
+	if body.ExpiresAt != nil && strings.TrimSpace(*body.ExpiresAt) != "" {
+		t, err := parseAccessExpiry(*body.ExpiresAt)
+		if err != nil {
+			http.Error(w, `{"error":"expiry must be a YYYY-MM-DD date or RFC3339 timestamp"}`, http.StatusBadRequest)
+			return
+		}
+		if !t.After(time.Now()) {
+			http.Error(w, `{"error":"expiry must be in the future"}`, http.StatusBadRequest)
+			return
+		}
+		expiresAt = t.Format(time.RFC3339)
+	}
+	// An expiring owner grant on the hive's ONLY owner would auto-revoke into
+	// an ownerless hive — the same orphaning handleAccessRemove refuses. Block
+	// it here rather than special-casing the sweep, so the owner learns at set
+	// time instead of the hive silently degrading later.
+	if expiresAt != "" && body.Role == "owner" {
+		ownerCount := 0
+		for _, u := range listAllSaaSUsers() {
+			if u.Hives[hiveID] == "owner" && !canonicalEqual(u.GitHubUsername, body.Username) {
+				ownerCount++
+			}
+		}
+		if ownerCount == 0 {
+			http.Error(w, `{"error":"cannot set an expiry on the only owner"}`, http.StatusBadRequest)
+			return
+		}
+	}
 	target := ensureSaaSUser(body.Username)
 	// Distinguish a fresh grant from a role change so the audit trail answers
 	// "who changed X's role, from what, and when" (#4148) — a bare "granted as
 	// merger" entry hides the fact the user was previously an owner.
 	prevRole := target.Hives[hiveID]
+	prevExpiry := target.HiveExpiry[hiveID]
 	target.Hives[hiveID] = body.Role
+	switch {
+	case body.ExpiresAt == nil:
+		// Preserve any existing expiry: a role change is not an extension.
+	case expiresAt == "":
+		delete(target.HiveExpiry, hiveID)
+	default:
+		if target.HiveExpiry == nil {
+			target.HiveExpiry = map[string]string{}
+		}
+		target.HiveExpiry[hiveID] = expiresAt
+	}
 	saveSaaSUser(target)
+	// The stored (possibly preserved) expiry after the update, for the audit
+	// trail; "" means permanent.
+	newExpiry := target.HiveExpiry[hiveID]
+	auditExpiry := newExpiry
+	if auditExpiry == "" {
+		auditExpiry = "never"
+	}
+	expiryNote := ""
+	if newExpiry != "" {
+		expiryNote = " (expires " + newExpiry + ")"
+	}
 	switch {
 	case prevRole == "":
-		s.logger.Info("audit: access granted", "hive", hiveID, "target", body.Username, "role", body.Role, "by", username)
+		s.logger.Info("audit: access granted", "hive", hiveID, "target", body.Username, "role", body.Role, "expires", auditExpiry, "by", username)
 		s.recordTimeline(hiveID, TimelineAccess,
-			fmt.Sprintf("access granted to %s as %s", body.Username, body.Role), username)
+			fmt.Sprintf("access granted to %s as %s%s", body.Username, body.Role, expiryNote), username)
 	case prevRole != body.Role:
-		s.logger.Info("audit: role changed", "hive", hiveID, "target", body.Username, "from", prevRole, "to", body.Role, "by", username)
+		s.logger.Info("audit: role changed", "hive", hiveID, "target", body.Username, "from", prevRole, "to", body.Role, "expires", auditExpiry, "by", username)
 		s.recordTimeline(hiveID, TimelineAccess,
-			fmt.Sprintf("role for %s changed: %s → %s", body.Username, prevRole, body.Role), username)
+			fmt.Sprintf("role for %s changed: %s → %s%s", body.Username, prevRole, body.Role, expiryNote), username)
+	case newExpiry != prevExpiry:
+		// Expiry-only change (extend, shorten, or clear): still a permission
+		// change, so it belongs in the append-only log like any other.
+		detail := fmt.Sprintf("access expiry for %s cleared (now permanent)", body.Username)
+		if newExpiry != "" {
+			detail = fmt.Sprintf("access for %s now expires %s", body.Username, newExpiry)
+		}
+		s.logger.Info("audit: access expiry changed", "hive", hiveID, "target", body.Username, "expires", auditExpiry, "by", username)
+		s.recordTimeline(hiveID, TimelineAccess, detail, username)
 	default:
 		// Same role re-granted: a no-op — do not pollute the append-only log.
 	}
@@ -6333,6 +6425,7 @@ func (s *HubServer) handleAccessRemove(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	delete(target.Hives, hiveID)
+	delete(target.HiveExpiry, hiveID)
 	saveSaaSUser(target)
 	s.logger.Info("audit: access revoked", "hive", hiveID, "target", targetUsername, "by", username)
 	s.recordTimeline(hiveID, TimelineAccess,
@@ -18606,6 +18699,8 @@ const dashboardHTML = `<!DOCTYPE html>
             <option value="merger" title="Everything Read-Write grants, plus approve and queue other contributors' work for auto-merge.">Merger</option>
             <option value="owner" title="Full control: manage access, settings and budget for this hive.">Owner</option>
           </select>
+          <input id="access-expiry" type="date" title="Optional expiry — leave empty for permanent access. Access is revoked automatically after this date (UTC)."
+            style="padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
           <button onclick="addAccess()" class="btn-primary" style="padding:8px 16px;font-size:0.8rem">Add</button>
         </div>
         <div id="access-role-hint" style="margin-top:6px;font-size:0.72rem;color:var(--muted);line-height:1.4"></div>
@@ -19099,6 +19194,15 @@ const dashboardHTML = `<!DOCTYPE html>
           var lastActive = u.last_active ?
             '<span style="font-size:0.7rem;color:var(--muted)" title="Last active ' + esc(fmtUserTS(u.last_active)) + '">' + esc(timelineAgo(u.last_active) || fmtUserTS(u.last_active)) + '</span>' :
             '<span style="font-size:0.7rem;color:var(--muted)" title="Never active on this hub">—</span>';
+          // The expiry editor doubles as the display: it shows the grant's
+          // last valid day when set, and empty means permanent. Changing it
+          // extends (or clears) the expiry; the last owner cannot be expired
+          // for the same reason they cannot be removed or demoted.
+          var expiryControl = isLastOwner ? '' :
+            '<input type="date" class="access-expiry-input" value="' + esc(expiryToDateInput(u.expires_at)) + '"' +
+            ' onchange="changeAccessExpiry(\'' + esc(u.username) + '\', \'' + esc(u.role) + '\', this.value)"' +
+            ' title="Optional expiry — empty means permanent. Access is revoked automatically after this date (UTC)."' +
+            ' style="font-size:0.65rem;padding:2px 4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:' + (u.expires_at ? 'var(--amber)' : 'var(--muted)') + '">';
           return '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border)">' +
             '<div>' + avatar + providerIconHTML(identityProviderFromKey(u.username)) + '<span style="font-size:0.85rem">' + esc(u.username) + '</span>' +
             /* Empty placeholder the async GitHub profile lookup fills in
@@ -19108,6 +19212,7 @@ const dashboardHTML = `<!DOCTYPE html>
             '<div style="display:flex;align-items:center;gap:8px">' +
             lastActive +
             roleControl +
+            expiryControl +
             removeBtn +
             '</div></div>';
         }).join('');
@@ -19156,21 +19261,54 @@ const dashboardHTML = `<!DOCTYPE html>
       hiveToast('Access list exported', 'success');
     }
 
+    /* expiryToDateInput maps a stored RFC3339 expiry to the value a
+       <input type=date> shows: the grant's LAST VALID day (UTC). The server
+       canonicalizes a picked date D to midnight UTC of D+1, so stepping the
+       instant back one second always lands on the through-day, for exact
+       midnights and arbitrary timestamps alike. Empty in → empty out. */
+    function expiryToDateInput(iso) {
+      if (!iso) return '';
+      var t = Date.parse(iso);
+      if (isNaN(t)) return '';
+      return new Date(t - 1000).toISOString().slice(0, 10);
+    }
+
     async function addAccess() {
       var username = document.getElementById('access-username').value;
       var role = document.getElementById('access-role').value;
+      var expiry = document.getElementById('access-expiry').value;
       if (!username) { hiveToast('Select a user', 'error'); return; }
       try {
         var resp = await fetch('/api/saas/hives/' + encodeURIComponent(_accessHiveId) + '/access', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({username: username, role: role})
+          // expires_at always rides on the Add path: the picked date, or ""
+          // (permanent) when the picker was left empty — never omitted, so a
+          // re-add of an existing user resets the expiry to what the form shows.
+          body: JSON.stringify({username: username, role: role, expires_at: expiry || ''})
         });
         if (!resp.ok) { var d = await resp.json(); hiveToast(d.error || 'Failed', 'error'); return; }
         document.getElementById('access-username').value = '';
+        document.getElementById('access-expiry').value = '';
         loadAccessList();
         loadAccessAuditLog();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
+    }
+
+    /* changeAccessExpiry sets, extends, or clears (empty value) the expiry on
+       an existing grant. The role is re-sent unchanged — the add endpoint
+       upserts — and expires_at carries the new bound ("" = permanent). */
+    async function changeAccessExpiry(username, role, value) {
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(_accessHiveId) + '/access', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({username: username, role: role, expires_at: value || ''})
+        });
+        if (!resp.ok) { var d = await resp.json().catch(function(){return {};}); hiveToast(d.error || 'Failed to change expiry', 'error'); loadAccessList(); return; }
+        hiveToast(value ? username + '\'s access now expires ' + value : username + '\'s access is now permanent', 'success');
+        loadAccessList();
+      } catch(e) { hiveToast('Error: ' + e.message, 'error'); loadAccessList(); }
     }
 
     async function changeAccessRole(username, newRole, oldRole) {

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -937,6 +937,14 @@ type HubServer struct {
 	// whether or not this sweep ever runs — so a missed tick delays rewriting
 	// hub-generations.json, never extends the acceptance window.
 	lastGenerationRetire time.Time
+	// lastAccessExpirySweep throttles the expired-access persistence sweep
+	// (access_expiry.go). Same rationale and same guarding mutex as the sweeps
+	// above: poller-loop-only state.
+	//
+	// NOTE this throttles PERSISTENCE AND THE TIMELINE EVENT ONLY. An expired
+	// grant stops being honored at read time via loadSaaSUser's prune, on the
+	// wall clock, whether or not this sweep ever runs.
+	lastAccessExpirySweep time.Time
 	// perHiveEnvSeen is the Deployment-SOURCED convergence view backing
 	// PerHiveEnvSnapshot: hive ID → what the hub last actually read off that
 	// hive's Deployment. Deliberately NOT derived from heartbeat recency (see

--- a/src/pkg/hub/static/openapi.yaml
+++ b/src/pkg/hub/static/openapi.yaml
@@ -216,7 +216,12 @@ paths:
     post:
       tags: [Access]
       summary: Grant access
-      description: Add a user with a role. Cannot have zero owners.
+      description: >
+        Add a user with a role, or update an existing grant. Cannot have zero
+        owners. An optional expires_at bounds the grant in time: after that
+        instant the role is revoked automatically. Omitting expires_at
+        preserves an existing expiry; sending an empty string clears it
+        (permanent).
       security:
         - cookieAuth: []
       parameters:
@@ -237,6 +242,12 @@ paths:
                 role:
                   type: string
                   enum: [read, read-write, owner]
+                expires_at:
+                  type: string
+                  description: >
+                    Optional expiry as YYYY-MM-DD (valid through that day, UTC)
+                    or RFC3339. Empty string clears the expiry; omitted
+                    preserves any existing expiry.
 
   /api/saas/hives/{id}/access/{username}:
     delete:


### PR DESCRIPTION
Implements time-limited access grants in Manage Access.

## What
- **Optional expiry date picker** when adding a user, plus an inline per-row date editor in each user row — shows the expiry when set, extends on change, and clears to permanent when emptied
- **Auto-revoke on expiry**, two independent layers:
  - **On-access validation**: `loadSaaSUser` prunes expired grants at read time on the wall clock, so every role consumer (auth gates, `accessForHive`, heartbeat's authorized-users push to spokes) sees the revocation the instant it is due
  - **Background sweep**: ticked from the hub poller loop (throttled to 10 min), persists the prune to disk and stamps an `access expired` timeline event
- **Owner can clear/extend**: re-posting with `expires_at` set extends; empty string clears (permanent); omitting the field preserves the existing expiry so a plain role change never silently clears a time limit
- **No expiry = permanent**: `hive_expiry` is `omitempty`, so all pre-existing user records round-trip byte-identical and default behavior is unchanged
- Guard: the only owner cannot be given an expiry (same orphaning rule as remove/demote)
- OpenAPI spec updated for the new `expires_at` field

## Testing
- `go test ./pkg/hub/` passes (new tests cover parsing, read-time prune, sweep persistence, and all `handleAccessAdd` set/preserve/clear/reject semantics)
- `go vet` / `go build ./...` clean

Fixes #4150