### PR TITLE
✨ hub: notify owner on new access request via Slack

### DIFF
--- a/src/pkg/hub/access_notify.go
+++ b/src/pkg/hub/access_notify.go
@@ -1,0 +1,83 @@
+package hub
+
+// Owner notification for new access requests (issue #4149).
+//
+// When a user files a NEW pending access request for a hive, the hive's owner
+// gets a push notification through the hub's existing notification config: a
+// Slack DM via the same HIVE_HUB_SLACK_BOT_TOKEN + slack_id plumbing the
+// operator messaging endpoints use (slack.go). There is no hub-side email
+// sender, so Slack is the only push channel; the dashboard's pending-requests
+// banner remains the in-app notification either way.
+//
+// Deduplication is inherited, not reimplemented: handleRequestAccess rejects a
+// request while one from the same user is already pending, and this notifier
+// only runs after a request is actually persisted — so a requester hammering
+// the endpoint can never generate more than one notification per pending
+// request.
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// hubDashboardBaseURL resolves the hub's public origin for building links in
+// notifications. Same env-var precedence as hubDomainSuffix
+// (url_reachability.go); falls back to the canonical public origin.
+func hubDashboardBaseURL() string {
+	for _, key := range []string{"HIVE_HUB_PUBLIC_URL", "HIVE_PUBLIC_URL", "HIVE_HUB_BASE_URL", "HIVE_DASHBOARD_URL", "HIVE_HUB_URL"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return strings.TrimRight(v, "/")
+		}
+	}
+	return hubPublicURL
+}
+
+// accessRequestReviewLink builds the one-click deep link that opens the
+// dashboard's Manage Access modal for the hive (handled client-side by the
+// manage_access query param, next to the existing request_hive deep link).
+func accessRequestReviewLink(hiveID string) string {
+	return hubDashboardBaseURL() + "/dashboard?manage_access=" + url.QueryEscape(hiveID)
+}
+
+// notifyOwnerAccessRequest DMs the hive owner about a newly filed pending
+// access request. Every skip is logged, never silent: no owner, no bot token,
+// no user record and no slack_id are all expected states for some hives, and
+// the log line is how an operator learns why a notification did not go out.
+//
+// The actual send runs on a background goroutine (deliverSlackMessages), so
+// this never delays the requester's HTTP response.
+func (s *HubServer) notifyOwnerAccessRequest(hiveID, owner, requester, note string) {
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		// An unclaimed placeholder has no owner to notify.
+		return
+	}
+	token := strings.TrimSpace(os.Getenv(slackTokenEnvVar))
+	if token == "" {
+		s.logger.Info("access request notification skipped: no slack bot token configured",
+			"hive", hiveID, "owner", owner, "requester", requester)
+		return
+	}
+	u := loadSaaSUser(owner)
+	if u == nil {
+		s.logger.Warn("access request notification skipped: owner has no user record",
+			"hive", hiveID, "owner", owner, "requester", requester)
+		return
+	}
+	recipients, _ := resolveSlackRecipients([]SaaSUser{*u})
+	if len(recipients) == 0 {
+		s.logger.Info("access request notification skipped: owner has no slack_id",
+			"hive", hiveID, "owner", owner, "requester", requester)
+		return
+	}
+
+	message := fmt.Sprintf(
+		"🔑 New access request for hive %s\n%s requested access: %q\nReview and approve: %s",
+		hiveID, requester, note, accessRequestReviewLink(hiveID))
+
+	s.logger.Info("audit: access request notification queued",
+		"hive", hiveID, "owner", owner, "requester", requester)
+	go s.deliverSlackMessages(token, "access-request", message, recipients, requester)
+}

--- a/src/pkg/hub/access_notify_test.go
+++ b/src/pkg/hub/access_notify_test.go
@@ -1,0 +1,172 @@
+package hub
+
+// Tests for the owner notification on a new access request (issue #4149,
+// access_notify.go): the Slack DM goes out exactly once per new pending
+// request, carries the requester username and the one-click review link, and
+// every configured-but-unreachable state degrades to a logged skip rather than
+// an error surfaced to the requester.
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// slackNotifyWaitTimeout bounds how long a test waits for the background
+// deliverSlackMessages goroutine to hit the fake endpoint.
+const slackNotifyWaitTimeout = 2 * time.Second
+
+func TestRequestAccessNotifiesOwnerViaSlack(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	got := make(chan map[string]string, 1)
+	withFakeSlackEndpoint(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		got <- body
+		io.WriteString(w, `{"ok":true}`)
+	})
+	t.Setenv(slackTokenEnvVar, "xoxb-test")
+	t.Setenv("HIVE_HUB_PUBLIC_URL", "https://hub.example.com")
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", SlackID: "U0WNER", Hives: map[string]string{"h1": "owner"}})
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
+	mkUser(t, "requester")
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/req", `{"note":"need to debug"}`, "requester"), "id", "h1")
+	s.handleRequestAccess(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("request access status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	select {
+	case msg := <-got:
+		if msg["channel"] != "U0WNER" {
+			t.Errorf("DM went to channel %q, want the owner's slack_id U0WNER", msg["channel"])
+		}
+		text := msg["text"]
+		if !strings.Contains(text, "requester") {
+			t.Errorf("notification %q does not name the requester", text)
+		}
+		if !strings.Contains(text, "https://hub.example.com/dashboard?manage_access=h1") {
+			t.Errorf("notification %q does not carry the one-click review link", text)
+		}
+		if !strings.Contains(text, "need to debug") {
+			t.Errorf("notification %q does not carry the requester's note", text)
+		}
+	case <-time.After(slackNotifyWaitTimeout):
+		t.Fatal("owner was never notified: no Slack DM reached the endpoint")
+	}
+}
+
+// A duplicate pending request is rejected before anything is saved, so it must
+// also never re-notify — that rejection IS the anti-spam deduplication.
+func TestRequestAccessDoesNotRenotifyWhilePending(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	got := make(chan struct{}, 4)
+	withFakeSlackEndpoint(t, func(w http.ResponseWriter, r *http.Request) {
+		got <- struct{}{}
+		io.WriteString(w, `{"ok":true}`)
+	})
+	t.Setenv(slackTokenEnvVar, "xoxb-test")
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", SlackID: "U0WNER", Hives: map[string]string{"h1": "owner"}})
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
+	mkUser(t, "requester")
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/req", `{"note":"first"}`, "requester"), "id", "h1")
+	s.handleRequestAccess(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first request status = %d", rec.Code)
+	}
+	select {
+	case <-got:
+	case <-time.After(slackNotifyWaitTimeout):
+		t.Fatal("first request never notified")
+	}
+
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPost, "/req", `{"note":"again"}`, "requester"), "id", "h1")
+	s.handleRequestAccess(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("duplicate request status = %d, want 400", rec.Code)
+	}
+	select {
+	case <-got:
+		t.Error("duplicate pending request re-notified the owner — notification spam")
+	case <-time.After(100 * time.Millisecond):
+		// Correct: no second DM.
+	}
+}
+
+// Missing config never breaks the request itself: no bot token and no
+// slack_id both mean the request is stored and 200-OK'd, just without a DM.
+func TestRequestAccessSucceedsWhenNotificationUnconfigured(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	sent := make(chan struct{}, 1)
+	withFakeSlackEndpoint(t, func(w http.ResponseWriter, r *http.Request) {
+		sent <- struct{}{}
+		io.WriteString(w, `{"ok":true}`)
+	})
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
+	mkUser(t, "requester")
+
+	// No token configured.
+	t.Setenv(slackTokenEnvVar, "")
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/req", `{"note":"x"}`, "requester"), "id", "h1")
+	s.handleRequestAccess(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("request with no slack token status = %d, want 200", rec.Code)
+	}
+
+	// Token configured but owner has no slack_id (and no user record at all).
+	t.Setenv(slackTokenEnvVar, "xoxb-test")
+	saveSaaSHive(&SaaSHive{ID: "h2", Owner: "owner"})
+	rec = httptest.NewRecorder()
+	req = setPathValue(reqWithUser(http.MethodPost, "/req", `{"note":"x"}`, "requester"), "id", "h2")
+	s.handleRequestAccess(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("request with unreachable owner status = %d, want 200", rec.Code)
+	}
+
+	select {
+	case <-sent:
+		t.Error("a DM was sent despite the notification path being unconfigured")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAccessRequestReviewLinkEscapesHiveID(t *testing.T) {
+	t.Setenv("HIVE_HUB_PUBLIC_URL", "https://hub.example.com/")
+	link := accessRequestReviewLink("my hive&x")
+	want := "https://hub.example.com/dashboard?manage_access=my+hive%26x"
+	if link != want {
+		t.Errorf("link = %q, want %q", link, want)
+	}
+}
+
+func TestHubDashboardBaseURLFallsBackToPublicURL(t *testing.T) {
+	for _, key := range []string{"HIVE_HUB_PUBLIC_URL", "HIVE_PUBLIC_URL", "HIVE_HUB_BASE_URL", "HIVE_DASHBOARD_URL", "HIVE_HUB_URL"} {
+		t.Setenv(key, "")
+	}
+	if got := hubDashboardBaseURL(); got != hubPublicURL {
+		t.Errorf("base URL = %q, want fallback %q", got, hubPublicURL)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -6394,6 +6394,11 @@ func (s *HubServer) handleRequestAccess(w http.ResponseWriter, r *http.Request) 
 	})
 	saveAccessRequests(hiveID, reqs)
 
+	// Push-notify the owner (Slack DM where configured — access_notify.go).
+	// Placed after the pending-duplicate rejection above, so a request that was
+	// already pending can never fire a second notification.
+	s.notifyOwnerAccessRequest(hiveID, h.Owner, username, note)
+
 	s.logger.Info("audit: access requested", "hive", hiveID, "by", username)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "requested"})
@@ -15478,6 +15483,14 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function autoRequestAccessFromUrl() {
       var params = new URLSearchParams(window.location.search);
+      // Deep link from an access-request notification (access_notify.go):
+      // open Manage Access directly so the owner lands on the pending request.
+      var manageId = params.get('manage_access');
+      if (manageId) {
+        window.history.replaceState({}, '', '/dashboard');
+        openAccessModal(manageId, '');
+        return;
+      }
       var hiveId = params.get('request_hive');
       if (!hiveId) return;
       window.history.replaceState({}, '', '/dashboard');


### PR DESCRIPTION
Fixes #4149

## What
When a user files a **new** pending access request for a hive, the hive's owner now gets a push notification through the hub's existing notification config: a Slack DM via the same `HIVE_HUB_SLACK_BOT_TOKEN` + `slack_id` plumbing the operator messaging endpoints already use.

## How
- **`access_notify.go`** — `notifyOwnerAccessRequest` resolves the owner's Slack recipient and delivers via the existing paced `deliverSlackMessages` background sender. The message names the requester, carries the justification note, and includes a one-click review link.
- **One-click link** — new `?manage_access=<hiveID>` dashboard deep link (next to the existing `request_hive` deep link) that opens the Manage Access modal directly on the pending request.
- **Dedup / no spam** — inherited from `handleRequestAccess`'s existing already-pending rejection, which runs *before* the notifier: a repeat request while one is pending can never re-notify. Pinned by test.
- **Graceful degradation** — no bot token, no owner, no user record, or no `slack_id` all degrade to a logged skip; the access request itself always succeeds. (There is no hub-side email sender, so Slack is the only push channel; the dashboard pending-requests banner remains the in-app notification.)

## Acceptance criteria
- [x] Owner receives notification on new pending access request
- [x] Notification channel follows existing hive notification config (Slack where set up)
- [x] Notification includes requester username and one-click link to approve
- [x] No notification spam — deduplicate if request already pending

## Testing
- `go build ./...`, `go vet ./pkg/hub` clean
- New tests: DM content (requester + link + note), no re-notify while pending, unconfigured paths still 200, link escaping, base-URL fallback
- Full `go test ./pkg/hub` passes