### PR TITLE
✨ manage-access: append-only audit log for permission changes

### DIFF
--- a/src/pkg/hub/access_log_test.go
+++ b/src/pkg/hub/access_log_test.go
@@ -1,0 +1,188 @@
+package hub
+
+// Tests for the Manage Access permission-change audit log (#4148):
+// handleAccessAdd must record a distinguishable timeline entry for a fresh
+// grant vs a role change (with actor), and handleAccessLog must expose only
+// access/ownership events to hive owners.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newAccessLogTestServer seeds a hive "h1" owned by "creator" with one
+// read-role member "member", backed by temp dirs and an in-memory timeline.
+func newAccessLogTestServer(t *testing.T) *HubServer {
+	t.Helper()
+	cleanup := helperSetupTempDirs(t)
+	t.Cleanup(cleanup)
+
+	origDir := timelineDir
+	timelineDir = t.TempDir()
+	t.Cleanup(func() { timelineDir = origDir })
+
+	for user, hives := range map[string]map[string]string{
+		"creator":        {"h1": "owner"},
+		"member":         {"h1": "read"},
+		hubAdminUsername: {},
+	} {
+		if err := saveSaaSUser(&SaaSUser{GitHubUsername: user, Hives: hives}); err != nil {
+			t.Fatalf("save user %q: %v", user, err)
+		}
+	}
+	if err := saveSaaSHive(&SaaSHive{ID: "h1", Owner: "creator"}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	return &HubServer{
+		logger:    slog.Default(),
+		hubSecret: testHubSecret,
+		// Mirror newHandlerHub: resolveIdentity's impersonation verifier fails
+		// closed on hub-admin cookies without a generation set.
+		keyGenerations: legacyGenerationSet(testHubSecret),
+		timeline:       newTimelineStore(),
+	}
+}
+
+func accessLogEvents(t *testing.T, s *HubServer, username string) ([]TimelineEvent, int) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodGet, "/access-log", "", username), "id", "h1")
+	s.handleAccessLog(rec, req)
+	if rec.Code != http.StatusOK {
+		return nil, rec.Code
+	}
+	var body struct {
+		Events []TimelineEvent `json:"events"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode access-log body: %v", err)
+	}
+	return body.Events, rec.Code
+}
+
+func doAccessAdd(t *testing.T, s *HubServer, actor, body string) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/access", body, actor), "id", "h1")
+	s.handleAccessAdd(rec, req)
+	return rec.Code
+}
+
+func TestAccessAddRecordsGrantAndRoleChangeAudit(t *testing.T) {
+	s := newAccessLogTestServer(t)
+
+	// Fresh grant.
+	if code := doAccessAdd(t, s, "creator", `{"username":"newbie","role":"read-write"}`); code != http.StatusOK {
+		t.Fatalf("grant status = %d, want 200", code)
+	}
+	// Role change for an existing member.
+	if code := doAccessAdd(t, s, "creator", `{"username":"member","role":"merger"}`); code != http.StatusOK {
+		t.Fatalf("role-change status = %d, want 200", code)
+	}
+	// Re-granting the identical role must NOT append a new entry.
+	if code := doAccessAdd(t, s, "creator", `{"username":"member","role":"merger"}`); code != http.StatusOK {
+		t.Fatalf("noop re-grant status = %d, want 200", code)
+	}
+
+	events, code := accessLogEvents(t, s, "creator")
+	if code != http.StatusOK {
+		t.Fatalf("access-log status = %d, want 200", code)
+	}
+	if len(events) != 2 {
+		t.Fatalf("access-log events = %d, want 2 (grant + role change, no noop entry): %+v", len(events), events)
+	}
+	// Newest first: role change, then grant.
+	change, grant := events[0], events[1]
+	if change.Detail != "role for member changed: read → merger" {
+		t.Errorf("role-change detail = %q", change.Detail)
+	}
+	if grant.Detail != "access granted to newbie as read-write" {
+		t.Errorf("grant detail = %q", grant.Detail)
+	}
+	for _, ev := range events {
+		if ev.Actor != "creator" {
+			t.Errorf("event actor = %q, want creator (detail %q)", ev.Actor, ev.Detail)
+		}
+		if ev.TS == "" {
+			t.Errorf("event missing timestamp (detail %q)", ev.Detail)
+		}
+		if ev.Kind != TimelineAccess {
+			t.Errorf("event kind = %q, want %q", ev.Kind, TimelineAccess)
+		}
+	}
+}
+
+func TestAccessRemoveRecordsRevocationAudit(t *testing.T) {
+	s := newAccessLogTestServer(t)
+
+	rec := httptest.NewRecorder()
+	req := setPathValues(reqWithUser(http.MethodDelete, "/access", "", "creator"),
+		map[string]string{"id": "h1", "username": "member"})
+	s.handleAccessRemove(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("remove status = %d, want 200", rec.Code)
+	}
+
+	events, _ := accessLogEvents(t, s, "creator")
+	if len(events) != 1 {
+		t.Fatalf("access-log events = %d, want 1: %+v", len(events), events)
+	}
+	if events[0].Detail != "access revoked from member" || events[0].Actor != "creator" {
+		t.Errorf("revocation event = %+v", events[0])
+	}
+}
+
+func TestAccessLogFiltersToPermissionEvents(t *testing.T) {
+	s := newAccessLogTestServer(t)
+	s.recordTimeline("h1", TimelineVersionChanged, "version abc → def", "")
+	s.recordTimeline("h1", TimelineAccess, "access granted to x as read", "creator")
+	s.recordTimeline("h1", TimelineOwnership, "ownership transferred to y", "creator")
+	s.recordTimeline("h1", TimelineHealthChanged, "health ok → degraded", "")
+
+	events, code := accessLogEvents(t, s, "creator")
+	if code != http.StatusOK {
+		t.Fatalf("access-log status = %d, want 200", code)
+	}
+	if len(events) != 2 {
+		t.Fatalf("access-log events = %d, want 2 (access + ownership only): %+v", len(events), events)
+	}
+	if events[0].Kind != TimelineOwnership || events[1].Kind != TimelineAccess {
+		t.Errorf("filtered kinds = %q, %q; want ownership then access (newest first)", events[0].Kind, events[1].Kind)
+	}
+}
+
+func TestAccessLogAuthorization(t *testing.T) {
+	s := newAccessLogTestServer(t)
+	s.recordTimeline("h1", TimelineAccess, "access granted to x as read", "creator")
+
+	cases := []struct {
+		name     string
+		username string
+		wantCode int
+	}{
+		{name: "creator", username: "creator", wantCode: http.StatusOK},
+		{name: "hub admin", username: hubAdminUsername, wantCode: http.StatusOK},
+		{name: "non-owner member", username: "member", wantCode: http.StatusForbidden},
+		{name: "unknown user", username: "stranger", wantCode: http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, code := accessLogEvents(t, s, tc.username)
+			if code != tc.wantCode {
+				t.Errorf("access-log status = %d, want %d", code, tc.wantCode)
+			}
+		})
+	}
+
+	t.Run("unknown hive", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := setPathValue(reqWithUser(http.MethodGet, "/access-log", "", "creator"), "id", "nope")
+		s.handleAccessLog(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("unknown-hive status = %d, want 404", rec.Code)
+		}
+	})
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -499,6 +499,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/request-access", s.requireAuth(s.handleRequestAccess))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/requests", s.requireAuth(s.handleGetRequests))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/timeline", s.requireAuth(s.handleHiveTimeline))
+	s.mux.HandleFunc("GET /api/saas/hives/{id}/access-log", s.requireAuth(s.handleAccessLog))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", s.requireAuth(s.handleApproveRequest))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", s.requireAuth(s.handleDenyRequest))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", s.requireAuth(s.handleApproveAccess))
@@ -6243,11 +6244,24 @@ func (s *HubServer) handleAccessAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	target := ensureSaaSUser(body.Username)
+	// Distinguish a fresh grant from a role change so the audit trail answers
+	// "who changed X's role, from what, and when" (#4148) — a bare "granted as
+	// merger" entry hides the fact the user was previously an owner.
+	prevRole := target.Hives[hiveID]
 	target.Hives[hiveID] = body.Role
 	saveSaaSUser(target)
-	s.logger.Info("audit: access granted", "hive", hiveID, "target", body.Username, "role", body.Role, "by", username)
-	s.recordTimeline(hiveID, TimelineAccess,
-		fmt.Sprintf("access granted to %s as %s", body.Username, body.Role), username)
+	switch {
+	case prevRole == "":
+		s.logger.Info("audit: access granted", "hive", hiveID, "target", body.Username, "role", body.Role, "by", username)
+		s.recordTimeline(hiveID, TimelineAccess,
+			fmt.Sprintf("access granted to %s as %s", body.Username, body.Role), username)
+	case prevRole != body.Role:
+		s.logger.Info("audit: role changed", "hive", hiveID, "target", body.Username, "from", prevRole, "to", body.Role, "by", username)
+		s.recordTimeline(hiveID, TimelineAccess,
+			fmt.Sprintf("role for %s changed: %s → %s", body.Username, prevRole, body.Role), username)
+	default:
+		// Same role re-granted: a no-op — do not pollute the append-only log.
+	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "granted"})
 }
@@ -18501,6 +18515,11 @@ const dashboardHTML = `<!DOCTYPE html>
         <h3 style="font-size:0.9rem;margin-bottom:8px;color:var(--accent)">Pending Requests</h3>
         <div id="pending-requests"><span style="color:var(--muted);font-size:0.8rem">Loading...</span></div>
       </div>
+      <div style="margin-top:12px;border-top:1px solid var(--border);padding-top:12px">
+        <h3 style="font-size:0.9rem;margin-bottom:4px;color:var(--accent)">Audit Log</h3>
+        <p style="font-size:0.72rem;color:var(--muted);margin:0 0 8px">Every grant, role change and removal — who did it and when. Append-only.</p>
+        <div id="access-audit-log" style="max-height:180px;overflow-y:auto"><span style="color:var(--muted);font-size:0.8rem">Loading...</span></div>
+      </div>
       <div style="margin-top:16px;border-top:1px solid var(--border);padding-top:16px">
         <h3 style="font-size:0.9rem;margin-bottom:8px;color:var(--text)">Add User</h3>
         <input id="access-user-search" type="text" placeholder="Search users..." autocomplete="off"
@@ -18661,6 +18680,41 @@ const dashboardHTML = `<!DOCTYPE html>
       await loadAccessList();
       await loadAccessUserDropdown();
       await loadPendingRequests();
+      await loadAccessAuditLog();
+    }
+
+    /* Audit log for permission changes (#4148): a read-only, append-only view
+       sourced from the hive timeline, filtered server-side to access/ownership
+       events. Only owners can open Manage Access, and the endpoint enforces
+       the same rule, so a non-owner never sees this. */
+    async function loadAccessAuditLog() {
+      var el = document.getElementById('access-audit-log');
+      if (!el) return;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(_accessHiveId) + '/access-log');
+        if (!resp.ok) {
+          el.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">Audit log unavailable</span>';
+          return;
+        }
+        var data = await resp.json();
+        var events = (data && data.events) || [];
+        if (!events.length) {
+          el.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">No permission changes recorded yet</span>';
+          return;
+        }
+        /* Server returns newest first; render in that order. */
+        el.innerHTML = events.map(function(ev) {
+          var actor = ev.actor
+            ? '<span style="color:var(--muted);font-size:0.7rem;margin-left:6px">by ' + esc(ev.actor) + '</span>'
+            : '';
+          return '<div style="padding:6px 0;border-bottom:1px solid var(--border)">' +
+            '<div style="font-size:0.78rem;color:var(--text);word-break:break-word">' + esc(ev.detail || '') + actor + '</div>' +
+            '<div style="font-size:0.66rem;color:var(--muted);margin-top:2px" title="' + esc(ev.ts || '') + '">' + esc(timelineAgo(ev.ts)) + '</div>' +
+            '</div>';
+        }).join('');
+      } catch(e) {
+        el.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">Audit log unavailable</span>';
+      }
     }
 
     async function loadPendingRequests() {
@@ -18698,6 +18752,7 @@ const dashboardHTML = `<!DOCTYPE html>
         });
         loadPendingRequests();
         loadAccessList();
+        loadAccessAuditLog();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
     }
 
@@ -18705,6 +18760,7 @@ const dashboardHTML = `<!DOCTYPE html>
       try {
         await fetch('/api/saas/hives/' + encodeURIComponent(_accessHiveId) + '/requests/' + encodeURIComponent(username) + '/deny', {method: 'POST'});
         loadPendingRequests();
+        loadAccessAuditLog();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
     }
 
@@ -18879,6 +18935,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!resp.ok) { var d = await resp.json(); hiveToast(d.error || 'Failed', 'error'); return; }
         document.getElementById('access-username').value = '';
         loadAccessList();
+        loadAccessAuditLog();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
     }
 
@@ -18898,6 +18955,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!resp.ok) { var d = await resp.json().catch(function(){return {};}); hiveToast(d.error || 'Failed to change role', 'error'); loadAccessList(); return; }
         hiveToast(username + ' is now ' + newRole, 'success');
         loadAccessList();
+        loadAccessAuditLog();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); loadAccessList(); }
     }
 
@@ -18906,6 +18964,7 @@ const dashboardHTML = `<!DOCTYPE html>
       try {
         await fetch('/api/saas/hives/' + encodeURIComponent(_accessHiveId) + '/access/' + encodeURIComponent(username), {method: 'DELETE'});
         loadAccessList();
+        loadAccessAuditLog();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
     }
 

--- a/src/pkg/hub/timeline.go
+++ b/src/pkg/hub/timeline.go
@@ -572,3 +572,43 @@ func (s *HubServer) handleHiveTimeline(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"events": events})
 }
+
+// handleAccessLog serves GET /api/saas/hives/{id}/access-log — the
+// permission-change audit trail shown in the Manage Access dialog (#4148).
+//
+// It is a filtered VIEW over the same append-only timeline store that
+// records every grant, role change, removal, request approval/denial and
+// ownership transfer: no separate log is kept, so the two can never
+// disagree. Entries carry actor + timestamp and are immutable once written
+// (the store only ever appends; pruning is oldest-first at the retention
+// cap).
+//
+// Authorization matches the Manage Access endpoints themselves
+// (handleAccessList et al): the hive's owner — creator, granted owner role,
+// or hub admin — may read it. This is deliberately WIDER than
+// handleHiveTimeline's creator-only rule, because anyone who can change
+// permissions must be able to audit permission changes.
+func (s *HubServer) handleAccessLog(w http.ResponseWriter, r *http.Request) {
+	hiveID := r.PathValue("id")
+	username := s.getAuthUser(r)
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if !userIsHiveOwner(username, h) {
+		http.Error(w, `{"error":"only the owner can view the access audit log"}`, http.StatusForbidden)
+		return
+	}
+	all := s.timeline.recent(hiveID, timelineMaxEvents)
+	events := make([]TimelineEvent, 0, len(all))
+	for _, ev := range all {
+		// Ownership transfers change who holds the top permission, so they
+		// belong in a permission-change audit alongside access events.
+		if ev.Kind == TimelineAccess || ev.Kind == TimelineOwnership {
+			events = append(events, ev)
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"events": events})
+}


### PR DESCRIPTION
Closes #4148

## What

Adds a permission-change audit log to Manage Access: every grant, role change and removal is recorded with **actor + timestamp**, and owners see it inline in the dialog.

## How

- **Sourced from existing audit infrastructure**: no new log is kept — the hive's existing append-only, bounded, PVC-persisted timeline store (`timeline.go`) already records `TimelineAccess`/`TimelineOwnership` events for grants, removals, request approvals/denials and ownership transfers.
- `handleAccessAdd` now distinguishes a **fresh grant** ("access granted to X as read-write") from a **role change** ("role for X changed: read → merger"), and skips a same-role re-grant so the append-only log isn't polluted with no-ops.
- New endpoint `GET /api/saas/hives/{id}/access-log`: a read-only, filtered view (access + ownership kinds) over the timeline, authorized by the exact same owner rule as the other Manage Access endpoints (`userIsHiveOwner`: creator, granted owner role, or hub admin).
- Manage Access dialog gains an **Audit Log** section that loads on open and refreshes after every grant, role change, removal, approval and denial.

## Acceptance criteria

- [x] Every grant, role change, and removal is logged with actor + timestamp
- [x] Audit log visible to owners (inline in dialog)
- [x] Log entries are immutable (append-only store; only oldest-first pruning at the retention cap)
- [x] Sourced from existing audit infrastructure (hive timeline store)

## Tests

New `access_log_test.go`: grant vs role-change vs no-op entries, revocation entries, kind filtering, and authorization (creator/admin 200, member/stranger 403, unknown hive 404). Full `pkg/hub` suite passes.