### PR TITLE
🐛 fix(contribute): stop local mode launching the agent inside this repo

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -527,9 +527,29 @@ contribute-hive backend="" mode="docker": check-version
       # directory (verified against tmux on Fedora 44). It is passed anyway
       # because it IS correct on a healthy server; the cd is what carries the
       # fix.
+      # ...but that cd must NOT land in this repo. In local mode $PWD is the hive
+      # checkout the relay was launched from — which is also a clone of the repo
+      # the agent is assigned to work on. The assignment prompt says to reuse an
+      # existing clone rather than re-fork ("if that directory already has a
+      # clone from a prior task, 'cd' into it"), so an agent that starts there
+      # reasonably concludes it is already in its checkout and works in place.
+      #
+      # Observed live on kubestellar/hive#4167 with HIVE_WORKSPACE_DIR correctly
+      # set and its directory present: agy never ran `gh repo fork` at all, and
+      # edited the relay's own source tree instead. An earlier task branch-
+      # switched the checkout out from under the running relay.
+      #
+      # The container entrypoint does not have this problem: it roots the
+      # session at the workspace and launches the CLI from $HOME
+      # (bin/contributor-agent.sh). Mirror that here so both paths agree. $HOME
+      # also satisfies the #4046 constraint above — nothing in the task
+      # lifecycle deletes or recreates it, unlike the workspace subtree the
+      # agent clones into.
+      export HIVE_AGENT_CWD="${HOME}"
+      mkdir -p "$HIVE_AGENT_CWD"
       tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-      tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50 -c "$PWD"
-      tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$PWD") && ${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
+      tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50 -c "$HIVE_WORKSPACE_DIR"
+      tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$HIVE_AGENT_CWD") && ${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
 
       # Surface a poisoned tmux server rather than letting the backend die a
       # silent, unexplained death 30 seconds into its first task.

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -468,7 +468,7 @@ fi
 # recreates — so the CLI always starts somewhere resolvable regardless of what
 # happens to the workspace subtree underneath it; the CLI's own per-task `cd`
 # into $HIVE_WORKSPACE_DIR/<repo> (per the assignment prompt) is unchanged.
-HIVE_AGENT_CWD="${HOME}"
+export HIVE_AGENT_CWD="${HOME}"
 mkdir -p "$HIVE_AGENT_CWD"
 
 # Start the relay in the background

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -47,6 +47,10 @@ const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
 const REASONING_EFFORT = process.env.AGENT_REASONING_EFFORT || '';
 const AGENT_ROLE = (process.env.HIVE_AGENT_ROLE || '').trim();
+// Neutral directory both entrypoints launch the CLI from ($HOME). Used to pin
+// the cwd on relaunch; see launchCommandWithCwd for why the relay's own cwd is
+// the wrong answer in local mode.
+const AGENT_CWD = (process.env.HIVE_AGENT_CWD || '').trim();
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
 // Where the hub-delivered, task-scoped token is written (injectGhToken). This
 // deliberately does NOT default to /var/run/hive-metrics/gh-app-token.cache:
@@ -1665,8 +1669,17 @@ function checkTmuxPaneState() {
 // shortly after its first task (agy exits 2; claude/codex/goose tolerate it).
 // The Justfile pins the cwd for the FIRST launch; without this, the first
 // relaunch would silently undo that.
+//
+// Prefer HIVE_AGENT_CWD, which both entrypoints export for exactly this: it is
+// the neutral directory they launch the CLI from ($HOME). process.cwd() is the
+// RELAY's directory, which in local mode is the hive checkout `just
+// contribute-hive` was run from — also a clone of the repo the agent is
+// assigned to work on. Relaunching there puts the agent back in the tree it
+// must not treat as its checkout, silently undoing the launch-side fix on the
+// first stall recovery. Fall back to process.cwd() so an older entrypoint that
+// does not export the variable keeps its previous behaviour.
 function launchCommandWithCwd(launchCmd) {
-  const cwd = process.cwd();
+  const cwd = AGENT_CWD || process.cwd();
   if (!cwd) return launchCmd;
   return `cd ${shellQuote(cwd)} && ${launchCmd}`;
 }

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -302,14 +302,32 @@ const AGY_GEMINI_WORKING_PANE = [
 // directory" and a backend needing a resolvable cwd dies shortly after its
 // first task — agy exits 2 that way. The Justfile pins the cwd for the first
 // launch; a relaunch that dropped the cd would silently undo it.
-test('a relaunch cds into the relay cwd before starting the CLI', () => {
+test('a relaunch cds somewhere resolvable before starting the CLI', () => {
   const relay = loadRelay({ backend: 'agy' });
   try {
     const launched = relay.launchCommandWithCwd('agy --dangerously-skip-permissions');
     assert.match(launched, /^cd .+ && agy --dangerously-skip-permissions$/,
       `relaunch must pin the cwd, got: ${launched}`);
+    // With no HIVE_AGENT_CWD exported (an older entrypoint), the relay's own
+    // cwd remains the fallback, so this keeps its previous behaviour.
     assert.ok(launched.includes(process.cwd()),
-      `the cd target must be the relay's own cwd: ${launched}`);
+      `without HIVE_AGENT_CWD the cd target must be the relay's cwd: ${launched}`);
+  } finally { teardown(relay); }
+});
+
+// In local mode the relay's own cwd IS the hive checkout `just contribute-hive`
+// was run from — which is also a clone of the repo the agent is assigned to
+// work on. Relaunching there puts the agent back in the one tree it must not
+// adopt as its checkout, undoing the launch-side fix on the first stall
+// recovery. Both entrypoints export HIVE_AGENT_CWD ($HOME) for this.
+test('a relaunch prefers HIVE_AGENT_CWD over the relay cwd', () => {
+  const relay = loadRelay({ backend: 'agy', env: { HIVE_AGENT_CWD: '/home/agent' } });
+  try {
+    const launched = relay.launchCommandWithCwd('agy --dangerously-skip-permissions');
+    assert.match(launched, /^cd '?\/home\/agent'? && agy --dangerously-skip-permissions$/,
+      `relaunch must cd into HIVE_AGENT_CWD, got: ${launched}`);
+    assert.ok(!launched.includes(`cd ${process.cwd()} `),
+      `relaunch must not land back in the relay's own checkout: ${launched}`);
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
Follow-up to #4142. That set `HIVE_WORKSPACE_DIR` in local mode, which was necessary but not sufficient — the agent still starts in, and works in, the hive checkout the relay was launched from.

## Problem

Local mode roots both the tmux session and the CLI launch at `$PWD`:

```sh
tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50 -c "$PWD"
tmux send-keys  -t "$TMUX_SESSION" "cd $(printf %q "$PWD") && $CMD $PERM_FLAG" Enter
```

`$PWD` is the hive checkout — which is also a clone of the repo the agent is assigned to work on. The assignment prompt explicitly permits reusing an existing clone:

> `gh repo fork … $HIVE_WORKSPACE_DIR/<owner>/<repo>` **(or, if that directory already has a clone from a prior task, `cd` into it and `git fetch` instead of re-forking)**

So an agent that starts inside one reasonably concludes it is already in its checkout.

## Observed

On `kubestellar/hive#4167`, with #4142 merged and working:

```
relay env:              HIVE_WORKSPACE_DIR=/home/dbaggett/workspace   ← set
workspace dir exists:   yes                                          ← created by #4142
workspace clone exists: NO                                           ← never cloned
gh repo fork executed:  0                                            ← never attempted
agy cwd:                /var/home/dbaggett/bluefin/hive              ← the relay's own repo
```

agy went straight to `Read(~/bluefin/hive/src/cmd/hive/main.go)` and `go test ./pkg/hub`, and began editing there. An earlier task on the same setup ran `git checkout -B sec/fix-workflow-permissions origin/v4` in that checkout — so the tree the running relay had been started from was no longer the tree it was reading. A task that happens to touch `bin/contributor-relay.sh` would edit the relay's source while it runs.

This is not reproducible on demand — it depends on the agent's judgement — but the divergence below is unconditional.

## The divergence

|  | session `-c` | CLI launched from |
|---|---|---|
| container (`bin/contributor-agent.sh`) | `$HIVE_WORKSPACE_DIR` | `$HOME` |
| local (`Justfile`) | `$PWD` (this repo) | `$PWD` (this repo) |

The container entrypoint never had this bug. This makes local mode match it.

`$HOME` also satisfies the #4046 constraint: nothing in the task lifecycle deletes or recreates it, unlike the workspace subtree agents clone into, so the launch `cd` still lands somewhere resolvable on a tmux server whose own cwd is gone.

## Who this actually affects

Narrower than it looks, which is likely why it survived this long.

The collision needs `$PWD` to be a clone of the **assigned** repo, not just any repo. Contributing to some *other* project from a hive checkout is fine: the agent finds a repo that is not the one it was told to work on and clones into the workspace correctly. Same mode, same backend, no bug.

So the affected population is **local-mode contributors working on hive itself** — hive's own contributors. Everyone else on local mode is unaffected, and container mode is unaffected outright (the repo is not even mounted; `WORKDIR /home/dev`).

`agy` is over-represented in that population because it is host-only — its Google OAuth flow has no API-key mode, so it cannot authenticate in a container and `just contribute-k8s` warns about it. Local mode is not a preference for agy contributors, it is the only option. But the bug is **mode-specific, not backend-specific**: any backend launched into a checkout of its own assigned repo can make the same call.

## Why the relay changes too

Fixing only the launch would be undone on the first stall recovery:

```js
function launchCommandWithCwd(launchCmd) {
  const cwd = process.cwd();   // the RELAY's dir — the same checkout
```

Both entrypoints now export `HIVE_AGENT_CWD` and the relay prefers it, falling back to `process.cwd()` so an older entrypoint that does not export it keeps its current behaviour.

## Tests

`node --test bin/contributor-relay.test.js` → **119/119**. Reverting only `bin/contributor-relay.sh`:

```
ok   a relaunch cds somewhere resolvable before starting the CLI
FAIL a relaunch prefers HIVE_AGENT_CWD over the relay cwd
```

`just --list` parses; the `contribute-hive` recipe body and `bin/contributor-agent.sh` both pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
