### PR TITLE
🐛 advisory: stop the digest wedging silently on a missing pinned issue

### DIFF
--- a/src/cmd/hive/advisory_wedge_test.go
+++ b/src/cmd/hive/advisory_wedge_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard"
+)
+
+func TestPrimaryAdvisoryRepo(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want string
+	}{
+		{"nil config", nil, ""},
+		{"primary wins", &config.Config{Project: config.ProjectConfig{PrimaryRepo: "org/a", Repos: []string{"org/b"}}}, "org/a"},
+		{"falls back to first repo", &config.Config{Project: config.ProjectConfig{Repos: []string{"org/b", "org/c"}}}, "org/b"},
+		{"nothing configured", &config.Config{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := primaryAdvisoryRepo(tc.cfg); got != tc.want {
+				t.Fatalf("primaryAdvisoryRepo = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The per-cycle re-ensure must fire for a repo that never resolved AND for one
+// whose recorded number is the failed-ensure zero value — the state that left
+// certus posting nowhere for six days (#4167).
+func TestAdvisoryIssueUnresolved(t *testing.T) {
+	issues := map[string]int{"org/zero": 0, "org/ok": 42}
+	if !advisoryIssueUnresolved(issues, "org/missing") {
+		t.Error("a repo with no entry must be treated as unresolved")
+	}
+	if !advisoryIssueUnresolved(issues, "org/zero") {
+		t.Error("a recorded issue number of 0 must be treated as unresolved")
+	}
+	if advisoryIssueUnresolved(issues, "org/ok") {
+		t.Error("a resolved issue number must not trigger a re-ensure")
+	}
+}
+
+// A hive with findings but no advisory issue must report a post ERROR to the
+// hub. Before #4167 this path was a silent skip, so the spoke reported neither a
+// post time nor an error and the hub read it as "not an advisory participant" —
+// a wedged digest that was indistinguishable from a healthy PR-only hive.
+func TestMissingAdvisoryIssueIsReportedAsPostError(t *testing.T) {
+	msg := advisoryIssueMissingError("org/repo")
+	if !strings.Contains(msg, "org/repo") {
+		t.Fatalf("the recorded error must name the repo, got %q", msg)
+	}
+
+	srv := dashboard.NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if _, _, errMsg := srv.AdvisoryState(); errMsg != "" {
+		t.Fatalf("fresh server should report no advisory error, got %q", errMsg)
+	}
+
+	srv.RecordAdvisoryError(msg)
+	postedAt, _, errMsg := srv.AdvisoryState()
+	if errMsg != msg {
+		t.Fatalf("advisory error not surfaced to the heartbeat: got %q, want %q", errMsg, msg)
+	}
+	if !postedAt.IsZero() {
+		t.Fatal("recording an error must not advance the last-successful-post time")
+	}
+
+	// A later successful post clears it, so the pill self-heals.
+	srv.RecordAdvisoryPost(3)
+	if _, _, errMsg := srv.AdvisoryState(); errMsg != "" {
+		t.Fatalf("a successful post must clear the advisory error, got %q", errMsg)
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -4710,6 +4710,42 @@ func classifyGitHubAppWriteForbidden(ctx context.Context, appAuth *github.AppAut
 	return d.Message(), github.AppStateWriteForbidden
 }
 
+// primaryAdvisoryRepo returns the repo the advisory digest is posted to: the
+// configured primary repo, falling back to the first listed repo. Shared by the
+// boot ensure, the per-cycle re-ensure, and the post path so all three can never
+// disagree about WHICH repo's pinned issue the digest belongs to.
+func primaryAdvisoryRepo(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.Project.PrimaryRepo != "" {
+		return cfg.Project.PrimaryRepo
+	}
+	if len(cfg.Project.Repos) > 0 {
+		return cfg.Project.Repos[0]
+	}
+	return ""
+}
+
+// advisoryIssueUnresolved reports whether the pinned advisory issue for repo is
+// still unknown, i.e. the digest has nowhere to go. A recorded 0 counts as
+// unresolved: it is the zero value a failed ensure would leave behind, and
+// posting to issue 0 is not a thing.
+func advisoryIssueUnresolved(advisoryIssues map[string]int, repo string) bool {
+	num, ok := advisoryIssues[repo]
+	return !ok || num <= 0
+}
+
+// advisoryIssueMissingError is the error recorded (and reported to the hub) when
+// a hive has findings to publish but no advisory issue to publish them to. It is
+// deliberately an ERROR rather than a silent skip: the hub's staleness gate
+// treats a hive reporting neither a post time nor an error as "not an advisory
+// participant" and never alarms, which is how a wedged digest went unnoticed for
+// six days in #4167.
+func advisoryIssueMissingError(repo string) string {
+	return fmt.Sprintf("no advisory issue resolved for %s — digest not posted", repo)
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -4745,17 +4781,25 @@ func runEvalCycle(
 		return
 	}
 
-	if dashSrv.IsGitHubAppRequired() {
-		primaryRepo := cfg.Project.PrimaryRepo
-		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
-			primaryRepo = cfg.Project.Repos[0]
-		}
-		if primaryRepo != "" && ghClient != nil {
+	// Re-ensure the pinned advisory issue whenever it is still unresolved, not
+	// only while the App banner is up (#4167). The startup ensure can fail for
+	// reasons that deliberately do NOT raise that banner — a rate limit, a 5xx,
+	// a search-API blip — and the old gate meant such a hive kept an empty
+	// advisoryIssues map for the rest of the process lifetime: every later
+	// digest silently found no issue to post to, so the pinned comment froze at
+	// whatever it last said. Retrying here is cheap (one search per eval cycle
+	// only while unresolved, nothing once resolved) and is the difference
+	// between a transient boot error and a permanently wedged digest.
+	if primaryRepo := primaryAdvisoryRepo(cfg); primaryRepo != "" && ghClient != nil {
+		if advisoryIssueUnresolved(advisoryIssues, primaryRepo) {
 			num, retryErr := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
 			if retryErr == nil {
 				advisoryIssues[primaryRepo] = num
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
-				logger.Info("advisory issue created on retry", "repo", primaryRepo, "number", num)
+				logger.Info("advisory issue resolved on retry", "repo", primaryRepo, "number", num)
+			} else {
+				logger.Warn("advisory issue still unresolved — digest cannot be posted this cycle",
+					"repo", primaryRepo, "error", retryErr)
 			}
 		}
 	}
@@ -5141,10 +5185,7 @@ func runEvalCycle(
 				"resolved_count", len(digest.RecentlyResolved),
 			)
 
-			primaryRepo := cfg.Project.PrimaryRepo
-			if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
-				primaryRepo = cfg.Project.Repos[0]
-			}
+			primaryRepo := primaryAdvisoryRepo(cfg)
 			// Repo entries may be org-qualified ("org/repo"); the digest
 			// linkifier needs the bare repo name alongside the org.
 			org, repoName := cfg.Project.Org, primaryRepo
@@ -5293,6 +5334,20 @@ func runEvalCycle(
 								"count", len(healed), "titles", strings.Join(healed, "; "))
 						}
 					}
+				} else {
+					// No pinned advisory issue for this repo, yet there IS
+					// something to publish. This used to be a completely silent
+					// skip (#4167): the digest stopped updating, the spoke
+					// reported neither a post time nor an error, and the hub's
+					// staleness gate therefore read the hive as "not an advisory
+					// participant" and never raised the pill — a wedged digest
+					// that looked exactly like a healthy PR-only hive. Record it
+					// as a post FAILURE so the hub flags the hive stale with the
+					// real cause, and log it once per cycle for the operator.
+					msg := advisoryIssueMissingError(primaryRepo)
+					dashSrv.RecordAdvisoryError(msg)
+					logger.Warn("advisory digest not posted: no pinned advisory issue",
+						"repo", primaryRepo, "findings", digest.TotalCount)
 				}
 			}
 		}

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -98,6 +98,33 @@ may render under one finding type in a single severity section — that one exis
 to keep the comment inside GitHub's 65,536-character limit and is not
 configurable.
 
+## The digest stopped updating
+
+The digest is posted to one pinned issue per repo, titled **🐝 Hive Advisory
+Report**. Three things can stop it, and all three now surface rather than fail
+quietly:
+
+- **The pinned issue could not be resolved.** The hive ensures the issue at boot;
+  if that call fails (rate limit, 5xx, search-API blip) it is retried on every
+  eval cycle until it succeeds. While it is unresolved and there are findings to
+  publish, the spoke records a post error — `no advisory issue resolved for
+  <repo>` — so the hub flags the hive's digest stale with that cause instead of
+  reading it as a hive that simply does not post advisories.
+- **Someone closed the pinned issue.** The hive reopens the existing issue rather
+  than filing a new one. Filing a new one splits the digest: the hive writes to
+  the new issue while everyone subscribed to the old one watches a comment that
+  never changes again — which looks exactly like a wedged digest. If a repo
+  already has several `🐝 Hive Advisory Report` issues from before this behavior,
+  close the stale duplicates and keep the one the hive is currently updating (the
+  one with the newest digest comment).
+- **The App cannot write.** A 403 on the digest post raises the App banner with
+  its specific cause; the hub pill carries the same string.
+
+To check freshness: the hive's row on the hub shows the last successful post
+time and any error; on the spoke, `posted advisory digest` is logged at INFO on
+every successful update, and `advisory digest not posted` at WARN when there is
+nothing to post to.
+
 ## Related
 
 - [`bd` beads CLI](beads-cli.md) — inspecting advisory beads directly, including

--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -289,7 +289,7 @@ func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int
 		State:       "open",
 		Sort:        "created",
 		Direction:   "desc",
-		ListOptions: gh.ListOptions{PerPage: 50},
+		ListOptions: gh.ListOptions{PerPage: 50, Page: 1},
 	}
 	for page := 0; page < maxPagesToScan; page++ {
 		allIssues, _, scanErr := c.client.Issues.ListByRepo(ctx, owner, repo, listOpts)
@@ -311,5 +311,52 @@ func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int
 		}
 		listOpts.ListOptions.Page++
 	}
+
+	// Fallback 3: a CLOSED advisory issue is REUSED, not replaced (#4167).
+	// The issue says "do not close this issue", but people close it anyway —
+	// and creating a fresh one then splits the digest: the hive writes to the
+	// new issue while everyone who subscribed to the old one watches a comment
+	// that never updates again, which reads exactly like a wedged digest. So
+	// reopen the most recent closed one and keep posting to the URL people
+	// already follow. Only after this finds nothing does the caller create.
+	if num, ok := c.findClosedAdvisoryIssue(ctx, owner, repo); ok {
+		if _, _, err := c.client.Issues.Edit(ctx, owner, repo, num, &gh.IssueRequest{State: gh.Ptr("open")}); err != nil {
+			// Cannot reopen (permissions, locked). Report NOT-FOUND rather than
+			// the closed number: posting a digest to a closed issue would be
+			// invisible, and the caller's create path at least yields a live one.
+			c.logger.Warn("found closed advisory issue but could not reopen it",
+				slog.Int("number", num), slog.String("error", err.Error()))
+			return 0, nil
+		}
+		c.logger.Info("reopened closed advisory issue instead of creating a duplicate",
+			slog.String("repo", repo), slog.Int("number", num))
+		c.ensureAdvisoryLabel(ctx, owner, repo, num)
+		return num, nil
+	}
 	return 0, nil
+}
+
+// findClosedAdvisoryIssue returns the most recently updated CLOSED advisory
+// issue for a repo, if one exists. Split out from findAdvisoryIssue so the
+// "reuse the issue people already subscribe to" rule is testable on its own.
+func (c *Client) findClosedAdvisoryIssue(ctx context.Context, owner, repo string) (int, bool) {
+	opts := &gh.IssueListByRepoOptions{
+		State:       "closed",
+		Sort:        "updated",
+		Direction:   "desc",
+		ListOptions: gh.ListOptions{PerPage: 50, Page: 1},
+	}
+	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+	if err != nil {
+		return 0, false
+	}
+	for _, issue := range issues {
+		if issue.IsPullRequest() {
+			continue
+		}
+		if issue.GetTitle() == advisoryTitle {
+			return issue.GetNumber(), true
+		}
+	}
+	return 0, false
 }

--- a/src/pkg/github/advisory_reopen_test.go
+++ b/src/pkg/github/advisory_reopen_test.go
@@ -1,0 +1,123 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// advisoryReopenMux builds a GitHub stub whose repo has NO open advisory issue
+// but one closed one, so EnsureAdvisoryIssue must take the reuse path.
+// reopenStatus is what the reopen PATCH answers with.
+func advisoryReopenMux(t *testing.T, org, repo string, closedNum int, reopenStatus int, created *bool, reopened *bool) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "items": []any{}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/labels", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"name": advisoryLabelName})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, closedNum), func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"name": advisoryLabelName}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d", org, repo, closedNum), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			*reopened = true
+			if reopenStatus != http.StatusOK {
+				w.WriteHeader(reopenStatus)
+				_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": closedNum, "title": advisoryTitle, "state": "open"})
+		}
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			*created = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 999, "title": advisoryTitle})
+			return
+		}
+		if r.URL.Query().Get("state") == "closed" {
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"number": closedNum, "title": advisoryTitle, "state": "closed"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+	return mux
+}
+
+// A closed advisory issue must be REOPENED, never duplicated: the digest has to
+// keep landing on the issue subscribers already watch, otherwise their comment
+// silently stops updating and looks like a wedged hive (#4167).
+func TestEnsureAdvisoryIssue_ReopensClosedInsteadOfDuplicating(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var created, reopened bool
+	server := httptest.NewServer(advisoryReopenMux(t, org, repo, 55, http.StatusOK, &created, &reopened))
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	num, err := c.EnsureAdvisoryIssue(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("EnsureAdvisoryIssue: %v", err)
+	}
+	if num != 55 {
+		t.Errorf("issue number = %d, want 55 (the reopened issue)", num)
+	}
+	if !reopened {
+		t.Error("closed advisory issue should have been reopened")
+	}
+	if created {
+		t.Error("a duplicate advisory issue was created despite a reusable closed one")
+	}
+}
+
+// When the closed issue cannot be reopened, the hive must still end up with a
+// LIVE issue to post to — posting into a closed issue would be invisible.
+func TestEnsureAdvisoryIssue_CreatesWhenReopenForbidden(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var created, reopened bool
+	server := httptest.NewServer(advisoryReopenMux(t, org, repo, 55, http.StatusForbidden, &created, &reopened))
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	num, err := c.EnsureAdvisoryIssue(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("EnsureAdvisoryIssue: %v", err)
+	}
+	if !reopened {
+		t.Error("reopen should have been attempted")
+	}
+	if !created {
+		t.Error("a new advisory issue should have been created after the reopen failed")
+	}
+	if num != 999 {
+		t.Errorf("issue number = %d, want 999 (the newly created issue)", num)
+	}
+}
+
+// findClosedAdvisoryIssue must ignore pull requests and unrelated issues.
+func TestFindClosedAdvisoryIssue_IgnoresPRsAndOtherTitles(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"number": 7, "title": advisoryTitle, "pull_request": map[string]any{"url": "x"}},
+			{"number": 8, "title": "something else"},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	if num, ok := c.findClosedAdvisoryIssue(context.Background(), org, repo); ok {
+		t.Errorf("findClosedAdvisoryIssue = %d, want no match", num)
+	}
+}

--- a/src/pkg/hub/advisory_staleness_test.go
+++ b/src/pkg/hub/advisory_staleness_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -171,5 +172,23 @@ func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
 	}
 	if _, ok := m["advisory_error"]; ok {
 		t.Fatalf("advisory_error must be omitted when empty")
+	}
+}
+
+// A spoke that has NEVER posted since its last restart but reports a post error
+// is a participant with a broken digest path — exactly the #4167 shape, where
+// the advisory issue could not be resolved so nothing was ever posted. Gate 1
+// must accept the error alone as proof of participation, otherwise the wedge
+// stays invisible for as long as the process lives.
+func TestAdvisoryStale_NeverPostedButErroredIsStale(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = "" // no successful post since restart
+	e.AdvisoryError = "no advisory issue resolved for org/repo — digest not posted"
+	stale, reason := advisoryStale(e, advNow)
+	if !stale {
+		t.Fatal("a reported post error with no successful post must still flag the digest stale")
+	}
+	if !strings.Contains(reason, "no advisory issue resolved") {
+		t.Fatalf("the reason must carry the reported cause, got %q", reason)
 	}
 }


### PR DESCRIPTION
## Problem

Certus's advisory digest was six days old (#4167) and nothing alarmed. Three code paths conspire to produce exactly that: a digest that stops updating, on a hive the hub reads as perfectly healthy.

## Root cause

1. **The pinned advisory issue was only re-ensured while the App banner was up.** The boot-time `EnsureAdvisoryIssue` can fail for reasons that deliberately do NOT raise that banner — a rate limit, a 5xx, a search-API blip. When it did, `advisoryIssues` stayed empty for the rest of the process lifetime and no later cycle ever retried.

2. **The post path then returned silently.** The `if issueNum, ok := advisoryIssues[repo]; ok && issueNum > 0` guard had no `else`: no log, no `RecordAdvisoryError`. The spoke reported neither a post time nor an error, and the hub's staleness gate 1 treats that pair as "not an advisory participant" — so a wedged hive was indistinguishable from a healthy PR-only one and the pill never lit. Six days of silence.

3. **A closed advisory issue produced a duplicate.** `findAdvisoryIssue` searched `is:open` only, so a closed pinned issue caused a brand-new one to be filed. That splits the digest: the hive writes to the new issue while everyone subscribed to the old one watches a comment that never changes again — which reads exactly like a wedged digest. (`kubestellar/console` currently carries several `🐝 Hive Advisory Report` issues from this path.)

## Fix

- Re-ensure the pinned issue on every eval cycle while it is unresolved, and log the failure when it still is.
- Record a post error (`no advisory issue resolved for <repo>`) when there are findings but nowhere to publish them, so the hub flags the hive stale **with the real cause** instead of reading it as a non-participant.
- Reopen an existing closed advisory issue instead of filing a duplicate; create only if the reopen fails, since posting into a closed issue is invisible.
- Fix the fallback title scan re-requesting page 1 twice (its third page was never scanned, so a busy repo could miss an unlabeled advisory issue and duplicate it).

## Tests

- `TestEnsureAdvisoryIssue_ReopensClosedInsteadOfDuplicating` — closed issue is reopened, no duplicate created.
- `TestEnsureAdvisoryIssue_CreatesWhenReopenForbidden` — a 403 on reopen still yields a live issue.
- `TestFindClosedAdvisoryIssue_IgnoresPRsAndOtherTitles`
- `TestAdvisoryIssueUnresolved` / `TestPrimaryAdvisoryRepo` — the re-ensure gate, including the failed-ensure `0` value.
- `TestMissingAdvisoryIssueIsReportedAsPostError` — the miss reaches the heartbeat as an error, does not advance the last-post time, and self-clears on the next successful post.
- `TestAdvisoryStale_NeverPostedButErroredIsStale` — hub side: an error with no successful post since restart still flags stale.

## Verifying digest freshness

- Spoke logs `posted advisory digest` at INFO on every successful update; `advisory digest not posted: no pinned advisory issue` at WARN otherwise.
- Hub hive row shows the last successful post time and any error.
- On the target repo, the single open `🐝 Hive Advisory Report` issue's digest comment carries a fresh timestamp. If a repo has several, close the duplicates and keep the one with the newest digest comment — the hive will now reuse it even if it gets closed by mistake.

`src/docs/advisory.md` gains a "The digest stopped updating" troubleshooting section covering all three.

Closes #4167
