### PR TITLE
🐛 hub: surface advisory digests that were stale but suppressed (#4167)

### DIFF
--- a/docs/advisory-staleness.md
+++ b/docs/advisory-staleness.md
@@ -1,0 +1,57 @@
+# Advisory digest staleness — what the hub flags, and what it deliberately does not
+
+The hub shows a **stale advisory** pill (and raises a warning alert) when a hive
+that *should* be posting an advisory digest has quietly stopped. The rule lives
+in `src/pkg/hub/advisory_staleness.go` and is evaluated on read, so the browser
+never re-derives it.
+
+## Signals
+
+| Signal | Produced by | Notes |
+| --- | --- | --- |
+| `AdvisoryLastPostedAt` | spoke, `RecordAdvisoryPost` after a **successful** digest post | in spoke memory only; empty until the first success |
+| `AdvisoryError` | spoke, `RecordAdvisoryError` on a failed post **attempt** | cleared by the next success |
+| `GitHubAppState` / `GitHubAppRequired` / `PendingGitHubAppInstall` | spoke App diagnosis | decides whether silence is expected |
+
+## The gates
+
+1. **Participation** — no post time *and* no error means "not an advisory hive
+   (or a spoke too old to report)". Unknown, never stale.
+2. **Reported error** — flagged with its cause, unless the App is still
+   *undelivered* (`appAwaitingDelivery`: not-installed, no-app-assigned,
+   key-missing, pending install, or an unclassified spoke with the install
+   banner up). An App that *has* been delivered but cannot write is a fault the
+   operator must see.
+3. **Age** — with no error reported, a post time older than
+   `advisoryStaleThreshold` (90 min) is stale, but only when the App can write
+   at all (`appCanWriteForAdvisory`). Unparseable timestamps are unknown.
+
+## Suppression matrix (#4167)
+
+| Scenario | Behaviour before | Expected | Fix |
+| --- | --- | --- | --- |
+| Digest post 403s on a delivered App | The same failure raised `GitHubAppRequired` / `write-forbidden`, which suppressed the error path — **no pill** | Flag stale with the reported cause | Gate 2 now suppresses a reported error only while the App is *undelivered* (`appAwaitingDelivery`) |
+| Spoke restarts while the digest path is wedged | `AdvisoryLastPostedAt` reset to empty each restart → read as "not participating" → **never flagged, forever** | Timestamp keeps ageing across restarts | Hub carries the last known post time forward (`carryAdvisoryPostTime`), guarded on the primary repo being unchanged |
+| Hive is re-tenanted (placeholder reclaimed) | n/a | Clean advisory history for the new project | Carry-forward skipped when `PrimaryRepo` changes |
+| No pinned advisory issue resolvable | Silent skip: the spoke reports neither post time nor error, so a hive that has *never* posted looks like a PR-only hive | Flag stale once the hive has posted at least once | Carry-forward keeps the last post time ageing, so the wedge surfaces on the age path; the spoke-side "record the skip as an error" change is tracked separately on #4167 |
+| App never installed / key never delivered | Suppressed | Suppressed — onboarding, not a fault | unchanged (expected suppression) |
+| Aged digest, App cannot write, no error reported | Suppressed | Suppressed — no evidence the hive tried | unchanged (expected suppression); counted as `hidden_stale` in diagnostics |
+| Hive offline | Row pill hidden (offline state dominates) | Unchanged in the UI | counted as `hidden_stale` in diagnostics so fleet-level staleness is still visible |
+| Pure PR/merge hive | Suppressed | Suppressed | unchanged (expected suppression) |
+
+## Diagnostics
+
+Suppression is intentional in several of the rows above, which makes "how many
+hives are silently stale?" unanswerable from the pill alone. The hub therefore
+measures it:
+
+- `GET /api/saas/admin/advisory-diagnostics` (admin-only) returns per-hive
+  classification (`stale`, `fresh`, `not-participating`,
+  `suppressed-app-undelivered`, `suppressed-app-cannot-write`,
+  `unknown-timestamp`), the digest age in minutes, the reporting spoke version,
+  and a fleet `hidden_stale` count.
+- The same roll-up is logged every 30 minutes as a single `advisory diagnostics`
+  line, so prevalence can be read off hub logs without calling the endpoint.
+
+Diagnostics are read-only measurement: they never change a pill, an alert, or a
+registry entry.

--- a/src/cmd/hive/advisory_wedge_test.go
+++ b/src/cmd/hive/advisory_wedge_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard"
+)
+
+func TestPrimaryAdvisoryRepo(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want string
+	}{
+		{"nil config", nil, ""},
+		{"primary wins", &config.Config{Project: config.ProjectConfig{PrimaryRepo: "org/a", Repos: []string{"org/b"}}}, "org/a"},
+		{"falls back to first repo", &config.Config{Project: config.ProjectConfig{Repos: []string{"org/b", "org/c"}}}, "org/b"},
+		{"nothing configured", &config.Config{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := primaryAdvisoryRepo(tc.cfg); got != tc.want {
+				t.Fatalf("primaryAdvisoryRepo = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The per-cycle re-ensure must fire for a repo that never resolved AND for one
+// whose recorded number is the failed-ensure zero value — the state that left
+// certus posting nowhere for six days (#4167).
+func TestAdvisoryIssueUnresolved(t *testing.T) {
+	issues := map[string]int{"org/zero": 0, "org/ok": 42}
+	if !advisoryIssueUnresolved(issues, "org/missing") {
+		t.Error("a repo with no entry must be treated as unresolved")
+	}
+	if !advisoryIssueUnresolved(issues, "org/zero") {
+		t.Error("a recorded issue number of 0 must be treated as unresolved")
+	}
+	if advisoryIssueUnresolved(issues, "org/ok") {
+		t.Error("a resolved issue number must not trigger a re-ensure")
+	}
+}
+
+// A hive with findings but no advisory issue must report a post ERROR to the
+// hub. Before #4167 this path was a silent skip, so the spoke reported neither a
+// post time nor an error and the hub read it as "not an advisory participant" —
+// a wedged digest that was indistinguishable from a healthy PR-only hive.
+func TestMissingAdvisoryIssueIsReportedAsPostError(t *testing.T) {
+	msg := advisoryIssueMissingError("org/repo")
+	if !strings.Contains(msg, "org/repo") {
+		t.Fatalf("the recorded error must name the repo, got %q", msg)
+	}
+
+	srv := dashboard.NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if _, _, errMsg := srv.AdvisoryState(); errMsg != "" {
+		t.Fatalf("fresh server should report no advisory error, got %q", errMsg)
+	}
+
+	srv.RecordAdvisoryError(msg)
+	postedAt, _, errMsg := srv.AdvisoryState()
+	if errMsg != msg {
+		t.Fatalf("advisory error not surfaced to the heartbeat: got %q, want %q", errMsg, msg)
+	}
+	if !postedAt.IsZero() {
+		t.Fatal("recording an error must not advance the last-successful-post time")
+	}
+
+	// A later successful post clears it, so the pill self-heals.
+	srv.RecordAdvisoryPost(3)
+	if _, _, errMsg := srv.AdvisoryState(); errMsg != "" {
+		t.Fatalf("a successful post must clear the advisory error, got %q", errMsg)
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -4710,6 +4710,42 @@ func classifyGitHubAppWriteForbidden(ctx context.Context, appAuth *github.AppAut
 	return d.Message(), github.AppStateWriteForbidden
 }
 
+// primaryAdvisoryRepo returns the repo the advisory digest is posted to: the
+// configured primary repo, falling back to the first listed repo. Shared by the
+// boot ensure, the per-cycle re-ensure, and the post path so all three can never
+// disagree about WHICH repo's pinned issue the digest belongs to.
+func primaryAdvisoryRepo(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.Project.PrimaryRepo != "" {
+		return cfg.Project.PrimaryRepo
+	}
+	if len(cfg.Project.Repos) > 0 {
+		return cfg.Project.Repos[0]
+	}
+	return ""
+}
+
+// advisoryIssueUnresolved reports whether the pinned advisory issue for repo is
+// still unknown, i.e. the digest has nowhere to go. A recorded 0 counts as
+// unresolved: it is the zero value a failed ensure would leave behind, and
+// posting to issue 0 is not a thing.
+func advisoryIssueUnresolved(advisoryIssues map[string]int, repo string) bool {
+	num, ok := advisoryIssues[repo]
+	return !ok || num <= 0
+}
+
+// advisoryIssueMissingError is the error recorded (and reported to the hub) when
+// a hive has findings to publish but no advisory issue to publish them to. It is
+// deliberately an ERROR rather than a silent skip: the hub's staleness gate
+// treats a hive reporting neither a post time nor an error as "not an advisory
+// participant" and never alarms, which is how a wedged digest went unnoticed for
+// six days in #4167.
+func advisoryIssueMissingError(repo string) string {
+	return fmt.Sprintf("no advisory issue resolved for %s — digest not posted", repo)
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -4745,17 +4781,25 @@ func runEvalCycle(
 		return
 	}
 
-	if dashSrv.IsGitHubAppRequired() {
-		primaryRepo := cfg.Project.PrimaryRepo
-		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
-			primaryRepo = cfg.Project.Repos[0]
-		}
-		if primaryRepo != "" && ghClient != nil {
+	// Re-ensure the pinned advisory issue whenever it is still unresolved, not
+	// only while the App banner is up (#4167). The startup ensure can fail for
+	// reasons that deliberately do NOT raise that banner — a rate limit, a 5xx,
+	// a search-API blip — and the old gate meant such a hive kept an empty
+	// advisoryIssues map for the rest of the process lifetime: every later
+	// digest silently found no issue to post to, so the pinned comment froze at
+	// whatever it last said. Retrying here is cheap (one search per eval cycle
+	// only while unresolved, nothing once resolved) and is the difference
+	// between a transient boot error and a permanently wedged digest.
+	if primaryRepo := primaryAdvisoryRepo(cfg); primaryRepo != "" && ghClient != nil {
+		if advisoryIssueUnresolved(advisoryIssues, primaryRepo) {
 			num, retryErr := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
 			if retryErr == nil {
 				advisoryIssues[primaryRepo] = num
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
-				logger.Info("advisory issue created on retry", "repo", primaryRepo, "number", num)
+				logger.Info("advisory issue resolved on retry", "repo", primaryRepo, "number", num)
+			} else {
+				logger.Warn("advisory issue still unresolved — digest cannot be posted this cycle",
+					"repo", primaryRepo, "error", retryErr)
 			}
 		}
 	}
@@ -5141,10 +5185,7 @@ func runEvalCycle(
 				"resolved_count", len(digest.RecentlyResolved),
 			)
 
-			primaryRepo := cfg.Project.PrimaryRepo
-			if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
-				primaryRepo = cfg.Project.Repos[0]
-			}
+			primaryRepo := primaryAdvisoryRepo(cfg)
 			// Repo entries may be org-qualified ("org/repo"); the digest
 			// linkifier needs the bare repo name alongside the org.
 			org, repoName := cfg.Project.Org, primaryRepo
@@ -5293,6 +5334,20 @@ func runEvalCycle(
 								"count", len(healed), "titles", strings.Join(healed, "; "))
 						}
 					}
+				} else {
+					// No pinned advisory issue for this repo, yet there IS
+					// something to publish. This used to be a completely silent
+					// skip (#4167): the digest stopped updating, the spoke
+					// reported neither a post time nor an error, and the hub's
+					// staleness gate therefore read the hive as "not an advisory
+					// participant" and never raised the pill — a wedged digest
+					// that looked exactly like a healthy PR-only hive. Record it
+					// as a post FAILURE so the hub flags the hive stale with the
+					// real cause, and log it once per cycle for the operator.
+					msg := advisoryIssueMissingError(primaryRepo)
+					dashSrv.RecordAdvisoryError(msg)
+					logger.Warn("advisory digest not posted: no pinned advisory issue",
+						"repo", primaryRepo, "findings", digest.TotalCount)
 				}
 			}
 		}

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -98,6 +98,33 @@ may render under one finding type in a single severity section — that one exis
 to keep the comment inside GitHub's 65,536-character limit and is not
 configurable.
 
+## The digest stopped updating
+
+The digest is posted to one pinned issue per repo, titled **🐝 Hive Advisory
+Report**. Three things can stop it, and all three now surface rather than fail
+quietly:
+
+- **The pinned issue could not be resolved.** The hive ensures the issue at boot;
+  if that call fails (rate limit, 5xx, search-API blip) it is retried on every
+  eval cycle until it succeeds. While it is unresolved and there are findings to
+  publish, the spoke records a post error — `no advisory issue resolved for
+  <repo>` — so the hub flags the hive's digest stale with that cause instead of
+  reading it as a hive that simply does not post advisories.
+- **Someone closed the pinned issue.** The hive reopens the existing issue rather
+  than filing a new one. Filing a new one splits the digest: the hive writes to
+  the new issue while everyone subscribed to the old one watches a comment that
+  never changes again — which looks exactly like a wedged digest. If a repo
+  already has several `🐝 Hive Advisory Report` issues from before this behavior,
+  close the stale duplicates and keep the one the hive is currently updating (the
+  one with the newest digest comment).
+- **The App cannot write.** A 403 on the digest post raises the App banner with
+  its specific cause; the hub pill carries the same string.
+
+To check freshness: the hive's row on the hub shows the last successful post
+time and any error; on the spoke, `posted advisory digest` is logged at INFO on
+every successful update, and `advisory digest not posted` at WARN when there is
+nothing to post to.
+
 ## Related
 
 - [`bd` beads CLI](beads-cli.md) — inspecting advisory beads directly, including

--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -289,7 +289,7 @@ func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int
 		State:       "open",
 		Sort:        "created",
 		Direction:   "desc",
-		ListOptions: gh.ListOptions{PerPage: 50},
+		ListOptions: gh.ListOptions{PerPage: 50, Page: 1},
 	}
 	for page := 0; page < maxPagesToScan; page++ {
 		allIssues, _, scanErr := c.client.Issues.ListByRepo(ctx, owner, repo, listOpts)
@@ -311,5 +311,52 @@ func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int
 		}
 		listOpts.ListOptions.Page++
 	}
+
+	// Fallback 3: a CLOSED advisory issue is REUSED, not replaced (#4167).
+	// The issue says "do not close this issue", but people close it anyway —
+	// and creating a fresh one then splits the digest: the hive writes to the
+	// new issue while everyone who subscribed to the old one watches a comment
+	// that never updates again, which reads exactly like a wedged digest. So
+	// reopen the most recent closed one and keep posting to the URL people
+	// already follow. Only after this finds nothing does the caller create.
+	if num, ok := c.findClosedAdvisoryIssue(ctx, owner, repo); ok {
+		if _, _, err := c.client.Issues.Edit(ctx, owner, repo, num, &gh.IssueRequest{State: gh.Ptr("open")}); err != nil {
+			// Cannot reopen (permissions, locked). Report NOT-FOUND rather than
+			// the closed number: posting a digest to a closed issue would be
+			// invisible, and the caller's create path at least yields a live one.
+			c.logger.Warn("found closed advisory issue but could not reopen it",
+				slog.Int("number", num), slog.String("error", err.Error()))
+			return 0, nil
+		}
+		c.logger.Info("reopened closed advisory issue instead of creating a duplicate",
+			slog.String("repo", repo), slog.Int("number", num))
+		c.ensureAdvisoryLabel(ctx, owner, repo, num)
+		return num, nil
+	}
 	return 0, nil
+}
+
+// findClosedAdvisoryIssue returns the most recently updated CLOSED advisory
+// issue for a repo, if one exists. Split out from findAdvisoryIssue so the
+// "reuse the issue people already subscribe to" rule is testable on its own.
+func (c *Client) findClosedAdvisoryIssue(ctx context.Context, owner, repo string) (int, bool) {
+	opts := &gh.IssueListByRepoOptions{
+		State:       "closed",
+		Sort:        "updated",
+		Direction:   "desc",
+		ListOptions: gh.ListOptions{PerPage: 50, Page: 1},
+	}
+	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+	if err != nil {
+		return 0, false
+	}
+	for _, issue := range issues {
+		if issue.IsPullRequest() {
+			continue
+		}
+		if issue.GetTitle() == advisoryTitle {
+			return issue.GetNumber(), true
+		}
+	}
+	return 0, false
 }

--- a/src/pkg/github/advisory_reopen_test.go
+++ b/src/pkg/github/advisory_reopen_test.go
@@ -1,0 +1,123 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// advisoryReopenMux builds a GitHub stub whose repo has NO open advisory issue
+// but one closed one, so EnsureAdvisoryIssue must take the reuse path.
+// reopenStatus is what the reopen PATCH answers with.
+func advisoryReopenMux(t *testing.T, org, repo string, closedNum int, reopenStatus int, created *bool, reopened *bool) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "items": []any{}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/labels", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"name": advisoryLabelName})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, closedNum), func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"name": advisoryLabelName}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d", org, repo, closedNum), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			*reopened = true
+			if reopenStatus != http.StatusOK {
+				w.WriteHeader(reopenStatus)
+				_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": closedNum, "title": advisoryTitle, "state": "open"})
+		}
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			*created = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 999, "title": advisoryTitle})
+			return
+		}
+		if r.URL.Query().Get("state") == "closed" {
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"number": closedNum, "title": advisoryTitle, "state": "closed"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+	return mux
+}
+
+// A closed advisory issue must be REOPENED, never duplicated: the digest has to
+// keep landing on the issue subscribers already watch, otherwise their comment
+// silently stops updating and looks like a wedged hive (#4167).
+func TestEnsureAdvisoryIssue_ReopensClosedInsteadOfDuplicating(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var created, reopened bool
+	server := httptest.NewServer(advisoryReopenMux(t, org, repo, 55, http.StatusOK, &created, &reopened))
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	num, err := c.EnsureAdvisoryIssue(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("EnsureAdvisoryIssue: %v", err)
+	}
+	if num != 55 {
+		t.Errorf("issue number = %d, want 55 (the reopened issue)", num)
+	}
+	if !reopened {
+		t.Error("closed advisory issue should have been reopened")
+	}
+	if created {
+		t.Error("a duplicate advisory issue was created despite a reusable closed one")
+	}
+}
+
+// When the closed issue cannot be reopened, the hive must still end up with a
+// LIVE issue to post to — posting into a closed issue would be invisible.
+func TestEnsureAdvisoryIssue_CreatesWhenReopenForbidden(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var created, reopened bool
+	server := httptest.NewServer(advisoryReopenMux(t, org, repo, 55, http.StatusForbidden, &created, &reopened))
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	num, err := c.EnsureAdvisoryIssue(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("EnsureAdvisoryIssue: %v", err)
+	}
+	if !reopened {
+		t.Error("reopen should have been attempted")
+	}
+	if !created {
+		t.Error("a new advisory issue should have been created after the reopen failed")
+	}
+	if num != 999 {
+		t.Errorf("issue number = %d, want 999 (the newly created issue)", num)
+	}
+}
+
+// findClosedAdvisoryIssue must ignore pull requests and unrelated issues.
+func TestFindClosedAdvisoryIssue_IgnoresPRsAndOtherTitles(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"number": 7, "title": advisoryTitle, "pull_request": map[string]any{"url": "x"}},
+			{"number": 8, "title": "something else"},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	if num, ok := c.findClosedAdvisoryIssue(context.Background(), org, repo); ok {
+		t.Errorf("findClosedAdvisoryIssue = %d, want no match", num)
+	}
+}

--- a/src/pkg/hub/advisory_diagnostics.go
+++ b/src/pkg/hub/advisory_diagnostics.go
@@ -1,0 +1,246 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+)
+
+// Advisory-staleness DIAGNOSTICS (#4167).
+//
+// advisoryStale() answers one question per hive — "light the pill or not" — and
+// deliberately stays silent in every ambiguous case. That is the right rule for
+// an alarm, but it makes the FLEET question unanswerable from the outside: when
+// certus's digest froze for six days with no pill, there was no way to tell
+// whether the fleet had one wedged hive or twenty, because "not stale" covers
+// "healthy", "not an advisory hive", "App never delivered" and "suppressed"
+// alike.
+//
+// This file re-runs the same gates and REPORTS WHICH ONE decided, without
+// changing any of them. Nothing here feeds the pill, the alert list or any other
+// operator-visible verdict: it is pure measurement, so the fleet's suppression
+// profile can be quantified (endpoint on demand, log line every cycle) instead
+// of inferred hive by hive.
+
+// Advisory diagnosis classes. Stable strings — they are the JSON payload's keys
+// and the log line's counters, so operators and dashboards can chart them.
+const (
+	// advisoryClassStale: the hub IS flagging this hive (pill + alert).
+	advisoryClassStale = "stale"
+	// advisoryClassFresh: posted inside the threshold with no error — healthy.
+	advisoryClassFresh = "fresh"
+	// advisoryClassNotParticipating: gate 1 — the spoke reports neither a post
+	// time nor an error. Expected for a PR/merge-only hive; ALSO what a spoke
+	// too old to report the fields looks like, which is why the payload carries
+	// the version alongside.
+	advisoryClassNotParticipating = "not-participating"
+	// advisoryClassAppUndelivered: a post error suppressed because the App has
+	// not been delivered yet (never installed / no key). Expected quiet.
+	advisoryClassAppUndelivered = "suppressed-app-undelivered"
+	// advisoryClassAppCannotWrite: an aged timestamp suppressed because the App
+	// cannot write and the spoke reported no error to prove it even tried.
+	advisoryClassAppCannotWrite = "suppressed-app-cannot-write"
+	// advisoryClassUnknownTimestamp: a reported post time that will not parse.
+	advisoryClassUnknownTimestamp = "unknown-timestamp"
+)
+
+// AdvisoryDiagnosis is the per-hive answer: which gate decided, what the spoke
+// reported, and — for the suppressed classes — whether the digest WOULD have
+// been flagged had that gate not fired. The last field is the one that measures
+// hidden staleness, so a fleet-wide count of it is the prevalence number.
+type AdvisoryDiagnosis struct {
+	HiveID string `json:"hive_id"`
+	Name   string `json:"name,omitempty"`
+	Online bool   `json:"online"`
+	Class  string `json:"class"`
+	// Reason is the stale reason when flagged, or the cause of suppression.
+	Reason string `json:"reason,omitempty"`
+	// LastPostedAt / AgeMinutes: what the spoke reported and how old it is.
+	// AgeMinutes is -1 when there is no parseable timestamp.
+	LastPostedAt string `json:"last_posted_at,omitempty"`
+	AgeMinutes   int64  `json:"age_minutes"`
+	Error        string `json:"error,omitempty"`
+	AppState     string `json:"app_state,omitempty"`
+	// Version and GitHash identify the spoke build, which is how a
+	// "not-participating" hive running an OLD image is told apart from a
+	// genuine PR-only hive.
+	Version string `json:"version,omitempty"`
+	GitHash string `json:"git_hash,omitempty"`
+	// HiddenStale is true when the digest is (or has aged) past the threshold
+	// but no pill is shown — either because a gate suppressed it, or because
+	// the row renders the pill only while the hive is online.
+	HiddenStale bool `json:"hidden_stale,omitempty"`
+}
+
+// AdvisoryDiagnosticsReport is the fleet roll-up: counts per class plus the
+// per-hive detail, newest-problem-first so the head of the list is the useful
+// part when it is long.
+type AdvisoryDiagnosticsReport struct {
+	GeneratedAt string `json:"generated_at"`
+	TotalHives  int    `json:"total_hives"`
+	// Counts is class → number of hives.
+	Counts map[string]int `json:"counts"`
+	// HiddenStale is how many hives have an aged/errored digest that NO pill
+	// reports. This is the false-negative prevalence number.
+	HiddenStale int                 `json:"hidden_stale"`
+	Hives       []AdvisoryDiagnosis `json:"hives"`
+}
+
+// diagnoseAdvisory classifies ONE hive by re-running the staleness gates in the
+// same order advisoryStale() applies them, and records which one decided.
+func diagnoseAdvisory(e RegistryEntry, now time.Time) AdvisoryDiagnosis {
+	d := AdvisoryDiagnosis{
+		HiveID:       e.ID,
+		Name:         e.Name,
+		Online:       e.Online,
+		LastPostedAt: e.AdvisoryLastPostedAt,
+		AgeMinutes:   -1,
+		Error:        e.AdvisoryError,
+		AppState:     e.GitHubAppState,
+		Version:      e.Version,
+		GitHash:      e.GitHash,
+	}
+	postedAt, parseErr := time.Parse(time.RFC3339, e.AdvisoryLastPostedAt)
+	aged := false
+	if parseErr == nil {
+		d.AgeMinutes = int64(now.Sub(postedAt) / time.Minute)
+		aged = now.Sub(postedAt) > advisoryStaleThreshold
+	}
+
+	if stale, reason := advisoryStale(e, now); stale {
+		d.Class = advisoryClassStale
+		d.Reason = reason
+		// The row pill is rendered only for an ONLINE hive, so a flagged
+		// offline hive is still an unseen stale digest at the fleet level.
+		d.HiddenStale = !e.Online
+		return d
+	}
+
+	switch {
+	case e.AdvisoryLastPostedAt == "" && e.AdvisoryError == "":
+		d.Class = advisoryClassNotParticipating
+		d.Reason = "spoke reports no advisory post time and no advisory error"
+	case e.AdvisoryError != "":
+		// Only appAwaitingDelivery can suppress a reported error.
+		d.Class = advisoryClassAppUndelivered
+		d.Reason = "post error suppressed while the GitHub App is undelivered"
+		d.HiddenStale = true
+	case !appCanWriteForAdvisory(e):
+		d.Class = advisoryClassAppCannotWrite
+		d.Reason = "aged digest suppressed because the GitHub App cannot write"
+		d.HiddenStale = aged
+	case parseErr != nil:
+		d.Class = advisoryClassUnknownTimestamp
+		d.Reason = "spoke reported an unparseable advisory post time"
+	default:
+		d.Class = advisoryClassFresh
+	}
+	return d
+}
+
+// buildAdvisoryDiagnostics rolls the per-hive diagnoses into the fleet report.
+// Unassigned pool slots are excluded for the same reason every claimed-hive
+// alert rule excludes them: a placeholder runs no advisory agents, so counting
+// it as "not participating" would drown the signal. isAvailableRegistryEntry is
+// the SHARED predicate (server.go) rather than a local org-prefix test: a
+// freshly-claimed hive keeps reporting the "available-" org until it adopts the
+// pushed config, and dropping it here would hide exactly the newly-onboarded
+// population most likely to have an undelivered App.
+func buildAdvisoryDiagnostics(entries []RegistryEntry, now time.Time) AdvisoryDiagnosticsReport {
+	rep := AdvisoryDiagnosticsReport{
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		Counts:      map[string]int{},
+	}
+	for _, e := range entries {
+		if isAvailableRegistryEntry(e) {
+			continue
+		}
+		d := diagnoseAdvisory(e, now)
+		rep.Counts[d.Class]++
+		if d.HiddenStale {
+			rep.HiddenStale++
+		}
+		rep.Hives = append(rep.Hives, d)
+		rep.TotalHives++
+	}
+	// Problems first (hidden staleness, then flagged staleness), then oldest
+	// digest first inside each group, then by ID so the order is deterministic.
+	sort.SliceStable(rep.Hives, func(i, j int) bool {
+		a, b := rep.Hives[i], rep.Hives[j]
+		if a.HiddenStale != b.HiddenStale {
+			return a.HiddenStale
+		}
+		aStale, bStale := a.Class == advisoryClassStale, b.Class == advisoryClassStale
+		if aStale != bStale {
+			return aStale
+		}
+		if a.AgeMinutes != b.AgeMinutes {
+			return a.AgeMinutes > b.AgeMinutes
+		}
+		return a.HiveID < b.HiveID
+	})
+	return rep
+}
+
+// advisoryDiagnostics snapshots the registry and builds the report.
+func (s *HubServer) advisoryDiagnostics(now time.Time) AdvisoryDiagnosticsReport {
+	s.mu.RLock()
+	entries := make([]RegistryEntry, len(s.registry.Hives))
+	copy(entries, s.registry.Hives)
+	s.mu.RUnlock()
+	return buildAdvisoryDiagnostics(entries, now)
+}
+
+// logAdvisoryDiagnostics emits the fleet suppression profile as ONE structured
+// log line. This is what makes the prevalence question answerable without fleet
+// database access: the next cycle after this ships, the hub says how many hives
+// are stale, how many are hidden, and why.
+func (s *HubServer) logAdvisoryDiagnostics(rep AdvisoryDiagnosticsReport) {
+	s.logger.Info("advisory diagnostics",
+		"hives", rep.TotalHives,
+		"stale", rep.Counts[advisoryClassStale],
+		"hidden_stale", rep.HiddenStale,
+		"fresh", rep.Counts[advisoryClassFresh],
+		"not_participating", rep.Counts[advisoryClassNotParticipating],
+		"suppressed_app_undelivered", rep.Counts[advisoryClassAppUndelivered],
+		"suppressed_app_cannot_write", rep.Counts[advisoryClassAppCannotWrite],
+		"unknown_timestamp", rep.Counts[advisoryClassUnknownTimestamp],
+	)
+}
+
+// advisoryDiagnosticsInterval is how often the hub logs the fleet profile. The
+// staleness threshold is 90 minutes, so half an hour samples every hive several
+// times inside one stale window while costing one log line per sample.
+const advisoryDiagnosticsInterval = 30 * time.Minute
+
+// StartAdvisoryDiagnostics logs the fleet advisory-suppression profile on a
+// timer. Read-only: it never mutates the registry and never raises an alert.
+func (s *HubServer) StartAdvisoryDiagnostics(ctx context.Context) {
+	if testing.Testing() {
+		return
+	}
+	ticker := time.NewTicker(advisoryDiagnosticsInterval)
+	defer ticker.Stop()
+	s.logAdvisoryDiagnostics(s.advisoryDiagnostics(time.Now()))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.logAdvisoryDiagnostics(s.advisoryDiagnostics(time.Now()))
+		}
+	}
+}
+
+// handleAdvisoryDiagnostics serves GET /api/saas/admin/advisory-diagnostics.
+// Registered behind requireAdmin: the payload names every hive in the fleet
+// along with its App state — the same exposure class as cluster-health.
+func (s *HubServer) handleAdvisoryDiagnostics(w http.ResponseWriter, r *http.Request) {
+	rep := s.advisoryDiagnostics(time.Now())
+	s.logAdvisoryDiagnostics(rep)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(rep)
+}

--- a/src/pkg/hub/advisory_diagnostics_test.go
+++ b/src/pkg/hub/advisory_diagnostics_test.go
@@ -1,0 +1,191 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// The diagnostics are pure MEASUREMENT: every hive must be classified by the
+// gate that actually decided its verdict, and hidden staleness must be counted
+// — that count is the prevalence answer #4167 asks for.
+
+func TestDiagnoseAdvisory_ClassifiesEachGate(t *testing.T) {
+	old := rfc3339Ago(advisoryStaleThreshold + time.Hour)
+
+	cases := []struct {
+		name        string
+		entry       RegistryEntry
+		wantClass   string
+		wantHidden  bool
+		wantHasName bool
+	}{
+		{
+			name:      "fresh digest",
+			entry:     func() RegistryEntry { e := advisoryModeEntry(); e.Online = true; return e }(),
+			wantClass: advisoryClassFresh,
+		},
+		{
+			name: "flagged stale",
+			entry: func() RegistryEntry {
+				e := advisoryModeEntry()
+				e.Online = true
+				e.AdvisoryLastPostedAt = old
+				return e
+			}(),
+			wantClass: advisoryClassStale,
+		},
+		{
+			name: "flagged stale but offline — no row pill renders",
+			entry: func() RegistryEntry {
+				e := advisoryModeEntry()
+				e.Online = false
+				e.AdvisoryLastPostedAt = old
+				return e
+			}(),
+			wantClass:  advisoryClassStale,
+			wantHidden: true,
+		},
+		{
+			name:      "not participating",
+			entry:     RegistryEntry{ID: "pr-only", Online: true, GitHubAppState: "ok"},
+			wantClass: advisoryClassNotParticipating,
+		},
+		{
+			name: "error suppressed by undelivered app",
+			entry: func() RegistryEntry {
+				e := advisoryModeEntry()
+				e.Online = true
+				e.GitHubAppState = "not-installed"
+				e.AdvisoryError = "403 Resource not accessible by integration"
+				return e
+			}(),
+			wantClass:  advisoryClassAppUndelivered,
+			wantHidden: true,
+		},
+		{
+			name: "aged digest suppressed by non-writing app",
+			entry: func() RegistryEntry {
+				e := advisoryModeEntry()
+				e.Online = true
+				e.GitHubAppState = "write-forbidden"
+				e.AdvisoryLastPostedAt = old
+				return e
+			}(),
+			wantClass:  advisoryClassAppCannotWrite,
+			wantHidden: true,
+		},
+		{
+			name: "unparseable timestamp",
+			entry: func() RegistryEntry {
+				e := advisoryModeEntry()
+				e.Online = true
+				e.AdvisoryLastPostedAt = "not-a-timestamp"
+				return e
+			}(),
+			wantClass: advisoryClassUnknownTimestamp,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := diagnoseAdvisory(tc.entry, advNow)
+			if d.Class != tc.wantClass {
+				t.Fatalf("class = %q, want %q (reason %q)", d.Class, tc.wantClass, d.Reason)
+			}
+			if d.HiddenStale != tc.wantHidden {
+				t.Fatalf("hidden_stale = %v, want %v", d.HiddenStale, tc.wantHidden)
+			}
+		})
+	}
+}
+
+// A suppressed hive whose digest is NOT actually aged is not hidden staleness —
+// nothing is being concealed, so it must not inflate the prevalence count.
+func TestDiagnoseAdvisory_FreshDigestUnderNonWritingAppIsNotHidden(t *testing.T) {
+	e := advisoryModeEntry() // posted 5 minutes ago
+	e.Online = true
+	e.GitHubAppState = "write-forbidden"
+	d := diagnoseAdvisory(e, advNow)
+	if d.Class != advisoryClassAppCannotWrite {
+		t.Fatalf("class = %q, want %q", d.Class, advisoryClassAppCannotWrite)
+	}
+	if d.HiddenStale {
+		t.Fatalf("a digest posted 5 minutes ago is not hidden staleness")
+	}
+}
+
+func TestBuildAdvisoryDiagnostics_CountsAndExcludesPlaceholders(t *testing.T) {
+	old := rfc3339Ago(advisoryStaleThreshold + time.Hour)
+	entries := []RegistryEntry{
+		// Healthy.
+		func() RegistryEntry { e := advisoryModeEntry(); e.ID = "a"; e.Online = true; return e }(),
+		// Flagged.
+		func() RegistryEntry {
+			e := advisoryModeEntry()
+			e.ID, e.Online, e.AdvisoryLastPostedAt = "b", true, old
+			return e
+		}(),
+		// Hidden: aged under a non-writing App.
+		func() RegistryEntry {
+			e := advisoryModeEntry()
+			e.ID, e.Online, e.AdvisoryLastPostedAt, e.GitHubAppState = "c", true, old, "write-forbidden"
+			return e
+		}(),
+		// Unassigned pool slot: must not be counted at all.
+		{ID: "placeholder", Org: placeholderOrgPrefix + "1", ProvStatus: statusAvailable},
+	}
+
+	rep := buildAdvisoryDiagnostics(entries, advNow)
+	if rep.TotalHives != 3 {
+		t.Fatalf("placeholders must be excluded: total = %d, want 3", rep.TotalHives)
+	}
+	if rep.Counts[advisoryClassFresh] != 1 || rep.Counts[advisoryClassStale] != 1 ||
+		rep.Counts[advisoryClassAppCannotWrite] != 1 {
+		t.Fatalf("unexpected class counts: %#v", rep.Counts)
+	}
+	if rep.HiddenStale != 1 {
+		t.Fatalf("hidden_stale = %d, want 1", rep.HiddenStale)
+	}
+	// Problems sort first, hidden staleness ahead of the flagged one.
+	if len(rep.Hives) != 3 || rep.Hives[0].HiveID != "c" || rep.Hives[1].HiveID != "b" {
+		t.Fatalf("report must lead with hidden then flagged staleness, got %v",
+			[]string{rep.Hives[0].HiveID, rep.Hives[1].HiveID, rep.Hives[2].HiveID})
+	}
+}
+
+// A freshly-claimed hive keeps reporting the "available-" org until it adopts
+// the pushed config, so the placeholder exclusion must use the shared
+// status-aware predicate. Dropping it here would hide exactly the newly
+// onboarded population most likely to have an undelivered App.
+func TestBuildAdvisoryDiagnostics_IncludesAssignedHiveStillReportingPlaceholderOrg(t *testing.T) {
+	e := advisoryModeEntry()
+	e.ID, e.Online = "just-claimed", true
+	e.Org = placeholderOrgPrefix + "7"
+	e.ProvStatus = statusAssigned
+	e.GitHubAppState = "not-installed"
+	e.AdvisoryError = "403 Resource not accessible by integration"
+
+	rep := buildAdvisoryDiagnostics([]RegistryEntry{e}, advNow)
+	if rep.TotalHives != 1 {
+		t.Fatalf("an assigned hive must be measured even while it reports the placeholder org, total = %d", rep.TotalHives)
+	}
+	if rep.Counts[advisoryClassAppUndelivered] != 1 {
+		t.Fatalf("unexpected class counts: %#v", rep.Counts)
+	}
+}
+
+// The age is reported in minutes so an operator can see HOW stale, and is -1
+// (not 0) when there is no parseable timestamp — unknown must never read as
+// "posted just now".
+func TestDiagnoseAdvisory_AgeMinutes(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(120 * time.Minute)
+	if got := diagnoseAdvisory(e, advNow).AgeMinutes; got != 120 {
+		t.Fatalf("age_minutes = %d, want 120", got)
+	}
+	e.AdvisoryLastPostedAt = ""
+	e.AdvisoryError = "boom"
+	if got := diagnoseAdvisory(e, advNow).AgeMinutes; got != -1 {
+		t.Fatalf("unknown age must be -1, got %d", got)
+	}
+}

--- a/src/pkg/hub/advisory_false_negative_test.go
+++ b/src/pkg/hub/advisory_false_negative_test.go
@@ -1,0 +1,148 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// Regression cover for the advisory-staleness FALSE NEGATIVES found while
+// investigating #4167: cases where a hive's digest was genuinely wedged and the
+// hub reported nothing. Each test names the scenario it locks down.
+
+// FALSE NEGATIVE 1 — self-suppressing post failure.
+//
+// The 403 that wedges the digest is the SAME event that makes the spoke raise
+// GitHubAppRequired and classify itself "write-forbidden". Gating the reported
+// error on appCanWriteForAdvisory therefore let the failure silence its own
+// alarm: participation was proven, the failure was proven, and the pill stayed
+// dark. A DELIVERED App that cannot write must be flagged.
+func TestAdvisoryStale_DeliveredAppWriteFailureIsSurfaced(t *testing.T) {
+	cases := []struct {
+		name  string
+		mutfn func(*RegistryEntry)
+	}{
+		{"write-forbidden with banner raised", func(e *RegistryEntry) {
+			e.GitHubAppState = "write-forbidden"
+			e.GitHubAppRequired = true
+		}},
+		{"insufficient-permissions", func(e *RegistryEntry) {
+			e.GitHubAppState = "insufficient-permissions"
+		}},
+		{"wrong-installation", func(e *RegistryEntry) {
+			e.GitHubAppState = "wrong-installation"
+		}},
+		{"key-invalid", func(e *RegistryEntry) {
+			e.GitHubAppState = "key-invalid"
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := advisoryModeEntry()
+			e.AdvisoryError = "403 Resource not accessible by integration"
+			tc.mutfn(&e)
+			stale, reason := advisoryStale(e, advNow)
+			if !stale {
+				t.Fatalf("a delivered App whose advisory post FAILED must be flagged stale")
+			}
+			if reason == "" {
+				t.Fatalf("the flag must carry the reported cause")
+			}
+		})
+	}
+}
+
+// The onboarding suppression must survive that change: an App nobody has
+// installed or keyed yet is expected to fail, and must stay quiet.
+func TestAdvisoryStale_UndeliveredAppStillSuppressesError(t *testing.T) {
+	cases := []struct {
+		name  string
+		mutfn func(*RegistryEntry)
+	}{
+		{"not-installed", func(e *RegistryEntry) { e.GitHubAppState = "not-installed" }},
+		{"no-app-assigned", func(e *RegistryEntry) { e.GitHubAppState = "no-app-assigned" }},
+		{"key-missing", func(e *RegistryEntry) { e.GitHubAppState = "key-missing" }},
+		{"pending install", func(e *RegistryEntry) { e.PendingGitHubAppInstall = true }},
+		{"old spoke: banner up, no state", func(e *RegistryEntry) {
+			e.GitHubAppState = ""
+			e.GitHubAppRequired = true
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := advisoryModeEntry()
+			e.AdvisoryError = "403 Resource not accessible by integration"
+			tc.mutfn(&e)
+			if stale, reason := advisoryStale(e, advNow); stale {
+				t.Fatalf("an undelivered App's post error must not alarm, got %q", reason)
+			}
+		})
+	}
+}
+
+// The AGE path keeps the broad app-can-write gate: with no error reported there
+// is no evidence the hive even attempted a post, so a non-writing App's silence
+// stays expected.
+func TestAdvisoryStale_AgePathKeepsBroadAppGate(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Hour)
+	e.GitHubAppState = "write-forbidden"
+	if stale, _ := advisoryStale(e, advNow); stale {
+		t.Fatalf("an aged digest with NO reported error must stay suppressed for a non-writing App")
+	}
+}
+
+// FALSE NEGATIVE 2 — restart amnesia.
+//
+// advisoryLastPostedAt lives only in the spoke's memory, so every restart
+// reports it EMPTY until the next successful post. Empty is exactly what gate 1
+// reads as "not an advisory participant", so a hive whose digest path wedges
+// across a restart can never be flagged: it cannot post (so the field never
+// returns) and the hub cannot tell it from a PR-only hive. The hub therefore
+// carries the last known value forward.
+func TestHeartbeat_CarriesAdvisoryPostTimeAcrossRestart(t *testing.T) {
+	posted := time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+	prev := RegistryEntry{
+		ID:                   "hosted-restart",
+		PrimaryRepo:          "acme/widgets",
+		AdvisoryLastPostedAt: posted,
+	}
+	fresh := RegistryEntry{
+		ID:          "hosted-restart",
+		PrimaryRepo: "acme/widgets",
+		// The restarted spoke reports nothing.
+		AdvisoryLastPostedAt: "",
+	}
+	carryAdvisoryPostTime(&fresh, prev)
+	if fresh.AdvisoryLastPostedAt != posted {
+		t.Fatalf("last advisory post time must survive a spoke restart, got %q", fresh.AdvisoryLastPostedAt)
+	}
+	// And the carried value must age into a stale flag, which is the whole
+	// point of preserving it.
+	fresh.GitHubAppState = "ok"
+	if stale, _ := advisoryStale(fresh, time.Now()); !stale {
+		t.Fatalf("a carried-forward post time older than the threshold must flag stale")
+	}
+}
+
+// A fresh report always wins over the carried value — the spoke is the source
+// of truth whenever it has one.
+func TestHeartbeat_FreshAdvisoryPostTimeWins(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	prev := RegistryEntry{ID: "h", PrimaryRepo: "acme/widgets", AdvisoryLastPostedAt: "2020-01-01T00:00:00Z"}
+	fresh := RegistryEntry{ID: "h", PrimaryRepo: "acme/widgets", AdvisoryLastPostedAt: now}
+	carryAdvisoryPostTime(&fresh, prev)
+	if fresh.AdvisoryLastPostedAt != now {
+		t.Fatalf("a reported post time must never be overwritten by the carried one")
+	}
+}
+
+// A reclaimed placeholder is a DIFFERENT project on the same hive ID, so it must
+// not inherit the previous tenant's advisory history and be alarmed for it.
+func TestHeartbeat_AdvisoryPostTimeNotCarriedAcrossRepoChange(t *testing.T) {
+	prev := RegistryEntry{ID: "h", PrimaryRepo: "acme/widgets", AdvisoryLastPostedAt: "2020-01-01T00:00:00Z"}
+	fresh := RegistryEntry{ID: "h", PrimaryRepo: "other/project"}
+	carryAdvisoryPostTime(&fresh, prev)
+	if fresh.AdvisoryLastPostedAt != "" {
+		t.Fatalf("a re-tenanted hive must start with a clean advisory history, got %q", fresh.AdvisoryLastPostedAt)
+	}
+}

--- a/src/pkg/hub/advisory_staleness.go
+++ b/src/pkg/hub/advisory_staleness.go
@@ -46,6 +46,65 @@ func appCanWriteForAdvisory(e RegistryEntry) bool {
 	}
 }
 
+// appAwaitingDelivery reports whether a hive's App has not been DELIVERED yet —
+// never installed, never assigned, or its key never handed over. This is the
+// narrow subset of "cannot write" whose silence is an ONBOARDING state rather
+// than a fault: nobody has finished wiring the hive up, so nothing about it is
+// broken and nothing should alarm.
+//
+// It exists because appCanWriteForAdvisory is too broad to gate a REPORTED post
+// error (#4167). A spoke only records AdvisoryError from a real post attempt,
+// and the most common such error — a 403 on the digest comment — makes the
+// spoke raise GitHubAppRequired and classify itself "write-forbidden" in the
+// SAME cycle. Gating the error on appCanWriteForAdvisory therefore let the
+// failure suppress its own alarm: the hive proved it is an advisory participant
+// AND that its digest is wedged, and the pill went dark anyway. An App that has
+// been delivered but cannot write is a fault the operator must see; an App that
+// was never delivered is not.
+//
+// An unclassified state ("" — a spoke too old to report one) counts as awaiting
+// delivery only when the install banner is up, which is the one signal such a
+// spoke does report.
+func appAwaitingDelivery(e RegistryEntry) bool {
+	if e.PendingGitHubAppInstall {
+		return true
+	}
+	switch e.GitHubAppState {
+	case "not-installed", "no-app-assigned", "key-missing":
+		return true
+	case "":
+		return e.GitHubAppRequired
+	default:
+		return false
+	}
+}
+
+// carryAdvisoryPostTime preserves the last known advisory-post time on a
+// heartbeat that reports none (#4167).
+//
+// advisoryLastPostedAt lives ONLY in the spoke's memory, so every restart
+// reports it empty until the next SUCCESSFUL post — and an empty value is
+// exactly what the hub's staleness gate reads as "not an advisory participant".
+// A hive whose digest path wedges across a restart therefore went silent
+// forever: it could never post (so the field never came back) and the hub could
+// never tell it apart from a healthy PR-only hive. Preserving the previous value
+// lets the timestamp keep AGEING across the restart, which is the whole signal.
+//
+// Guarded on the hive still pointing at the same primary repo: a reclaimed or
+// reassigned placeholder is a DIFFERENT project on the same hive ID, and must
+// start from a clean advisory history rather than inherit — and be alarmed for —
+// the previous tenant's post time. A fresh report always wins; the spoke is the
+// source of truth whenever it has one.
+func carryAdvisoryPostTime(entry *RegistryEntry, prev RegistryEntry) {
+	if entry == nil {
+		return
+	}
+	if entry.AdvisoryLastPostedAt == "" && prev.AdvisoryLastPostedAt != "" &&
+		entry.PrimaryRepo == prev.PrimaryRepo {
+		entry.AdvisoryLastPostedAt = prev.AdvisoryLastPostedAt
+	}
+}
+
 // advisoryStale reports whether a hive's advisory digest should be flagged as
 // stale as of now, together with a short human-readable reason for the pill's
 // tooltip. It is THE discriminator between "genuinely broken" (the signal an
@@ -59,11 +118,16 @@ func appCanWriteForAdvisory(e RegistryEntry) bool {
 //     is skipped here. This is why the gate needs no separate "is advisory mode"
 //     flag from the hub: participation is proven by the spoke having reported
 //     one of these fields at all.
-//  2. The hive's App can WRITE (appCanWriteForAdvisory). A not-installed hive,
-//     one running without credentials, or one whose key was never delivered
-//     legitimately cannot post and must not alarm.
-//  3. Either the last successful post is older than advisoryStaleThreshold, OR
+//  2. Either the last successful post is older than advisoryStaleThreshold, OR
 //     the most recent post attempt errored (AdvisoryError set).
+//  3. The suppression that applies to the branch taken:
+//     - a reported ERROR is suppressed only while the App is still awaiting
+//     delivery (appAwaitingDelivery) — an undelivered App's failure is an
+//     onboarding symptom, but a delivered App that cannot write is a fault the
+//     operator must see, even though the same failure raises the App banner.
+//     - an AGED timestamp is suppressed whenever the App cannot write at all
+//     (appCanWriteForAdvisory): with no error reported there is no proof the
+//     hive even tried, so its silence is expected.
 //
 // An empty/unparseable AdvisoryLastPostedAt with no AdvisoryError is UNKNOWN and
 // returns false — never a false alarm — matching the rule the codebase already
@@ -76,18 +140,25 @@ func advisoryStale(e RegistryEntry, now time.Time) (stale bool, reason string) {
 		return false, ""
 	}
 
-	// Gate 2: an App that cannot write is expected to be quiet, not broken.
+	// Gate 2a: a failed post attempt is a stale signal on its own, and the most
+	// specific one — surface the reported cause. Only an App that was never
+	// delivered suppresses it (#4167): gating this on the broader
+	// appCanWriteForAdvisory let a write-forbidden digest failure raise the App
+	// banner and thereby silence the very pill it should have lit.
+	if e.AdvisoryError != "" {
+		if appAwaitingDelivery(e) {
+			return false, ""
+		}
+		return true, "last advisory post failed: " + e.AdvisoryError
+	}
+
+	// Gate 2b: with no error reported, an App that cannot write is expected to
+	// be quiet, not broken.
 	if !appCanWriteForAdvisory(e) {
 		return false, ""
 	}
 
-	// Gate 3a: a failed post attempt is a stale signal on its own, and the most
-	// specific one — surface the reported cause.
-	if e.AdvisoryError != "" {
-		return true, "last advisory post failed: " + e.AdvisoryError
-	}
-
-	// Gate 3b: no error, so decide on age. An unparseable timestamp is treated
+	// Gate 3: no error, so decide on age. An unparseable timestamp is treated
 	// as UNKNOWN (not stale) so a malformed spoke value never false-alarms.
 	postedAt, err := time.Parse(time.RFC3339, e.AdvisoryLastPostedAt)
 	if err != nil {

--- a/src/pkg/hub/advisory_staleness_test.go
+++ b/src/pkg/hub/advisory_staleness_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -171,5 +172,23 @@ func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
 	}
 	if _, ok := m["advisory_error"]; ok {
 		t.Fatalf("advisory_error must be omitted when empty")
+	}
+}
+
+// A spoke that has NEVER posted since its last restart but reports a post error
+// is a participant with a broken digest path — exactly the #4167 shape, where
+// the advisory issue could not be resolved so nothing was ever posted. Gate 1
+// must accept the error alone as proof of participation, otherwise the wedge
+// stays invisible for as long as the process lives.
+func TestAdvisoryStale_NeverPostedButErroredIsStale(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = "" // no successful post since restart
+	e.AdvisoryError = "no advisory issue resolved for org/repo — digest not posted"
+	stale, reason := advisoryStale(e, advNow)
+	if !stale {
+		t.Fatal("a reported post error with no successful post must still flag the digest stale")
+	}
+	if !strings.Contains(reason, "no advisory issue resolved") {
+		t.Fatalf("the reason must carry the reported cause, got %q", reason)
 	}
 }

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -553,6 +553,11 @@ func (s *HubServer) registerSaaSRoutes() {
 	// names hives fleet-wide — the same exposure class as cluster-health
 	// directly above, so the same requireAdmin gate.
 	s.mux.HandleFunc("GET /api/reach", s.requireAdmin(s.handleReach))
+	// Advisory-staleness diagnostics (#4167): the read-only fleet view of WHICH
+	// gate decided each hive's advisory verdict, and how many stale digests no
+	// pill is reporting. Names hives fleet-wide with their App state, so the
+	// same requireAdmin gate as cluster-health and /api/reach above.
+	s.mux.HandleFunc("GET /api/saas/admin/advisory-diagnostics", s.requireAdmin(s.handleAdvisoryDiagnostics))
 	// Acknowledging a fleet alert is an operator action on the operator's own
 	// view, so it is admin-only (see alerts.go).
 	s.mux.HandleFunc("POST /api/saas/admin/alert-ack", s.requireAdmin(s.handleAlertAck))
@@ -587,6 +592,10 @@ func (s *HubServer) registerSaaSRoutes() {
 		// Periodically probe every spoke's unauthenticated /api/status and alert
 		// on any that answer 200 (wide open) — catches auth drift automatically.
 		go s.StartAuthAudit(context.Background())
+		// Advisory-suppression profile (#4167): one structured log line every
+		// cycle saying how many hives are stale and how many are stale but
+		// UNREPORTED. Read-only measurement — no alert, no registry write.
+		go s.StartAdvisoryDiagnostics(context.Background())
 	}
 }
 

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -1881,6 +1881,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			if entry.ComponentReach == nil && h.ComponentReach != nil {
 				entry.ComponentReach = h.ComponentReach
 			}
+			// Advisory post time survives a spoke restart — see
+			// carryAdvisoryPostTime for why that is the difference between a
+			// wedged digest being flagged and being invisible forever.
+			carryAdvisoryPostTime(&entry, h)
 			branchForLatest := payload.GitBranch
 			if branchForLatest == "" {
 				branchForLatest = "v2"


### PR DESCRIPTION
## Investigation

`certus`'s digest was stale for six days with no pill, so the question was whether the suppression is fleet-wide. Reading the path end-to-end (spoke `RecordAdvisoryPost`/`RecordAdvisoryError` -> heartbeat -> hub ingest -> `advisoryStale` -> row pill/alert) found two suppression paths that hide a genuinely wedged digest on **any** hive, not just certus.

## Matrix

| Scenario | Current behavior | Expected | Fix |
| --- | --- | --- | --- |
| Digest post 403s on a **delivered** App | The failure itself raises `GitHubAppRequired` / `write-forbidden`, which suppressed the error gate -> **no pill** | Flag stale with the reported cause | Error is now suppressed only while the App is *undelivered* (`appAwaitingDelivery`) |
| Spoke restarts while the digest path is wedged | `AdvisoryLastPostedAt` is spoke-memory only -> empty every restart -> read as "not participating" -> **never flagged, forever** | Timestamp keeps ageing across restarts | Hub carries the last post time forward (`carryAdvisoryPostTime`), guarded on unchanged `PrimaryRepo` |
| Re-tenanted placeholder | n/a | Clean advisory history | Carry-forward skipped when `PrimaryRepo` changes |
| App never installed / key never delivered | Suppressed | Suppressed - onboarding, not a fault | unchanged (expected) |
| Aged digest, App cannot write, **no error reported** | Suppressed | Suppressed - no evidence the hive tried | unchanged (expected); counted as `hidden_stale` |
| Hive offline | Row pill hidden | Unchanged in UI | counted as `hidden_stale` in diagnostics |
| Pure PR/merge hive | Suppressed | Suppressed | unchanged (expected) |

## Prevalence

No fleet data access from here, so prevalence is measured rather than guessed on the next cycle:

- `GET /api/saas/admin/advisory-diagnostics` (admin-only, read-only) - per-hive class (`stale`, `fresh`, `not-participating`, `suppressed-app-undelivered`, `suppressed-app-cannot-write`, `unknown-timestamp`), digest age in minutes, reporting spoke version, and a fleet `hidden_stale` count.
- The same roll-up is logged every 30 min as one structured `advisory diagnostics` line.

Diagnostics change no pill, alert or registry entry.

## Tests

- `advisory_false_negative_test.go` - delivered-App write failure is surfaced (4 states); undelivered App still suppresses (5 states); age path keeps the broad gate; restart carry-forward, fresh-report-wins, and repo-change reset.
- `advisory_diagnostics_test.go` - one case per gate class, hidden-stale accounting, placeholder exclusion via the shared status-aware predicate (incl. an assigned hive still reporting the `available-` org), age-minutes semantics.
- `go vet ./pkg/hub/` + full `go test ./pkg/hub/` pass.

Docs: `docs/advisory-staleness.md`.

Refs #4167
