### PR TITLE
✨ feat(hub): SSO with Dibs — widen session cookie to .kubestellar.io and add /api/saas/whoami

### DIFF
--- a/src/pkg/hub/hub_cookie_v3_test.go
+++ b/src/pkg/hub/hub_cookie_v3_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -289,7 +290,7 @@ func TestF10_MintingHasFlippedToV3(t *testing.T) {
 	mkUser(t, "alice")
 
 	rec := httptest.NewRecorder()
-	if !s.mintSessionCookies(rec, "github:alice") {
+	if !s.mintSessionCookies(rec, httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login", nil), "github:alice") {
 		t.Fatal("mintSessionCookies failed")
 	}
 	var value string

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -513,7 +513,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// From here the two paths converge: mint the session cookie over the
 	// canonical id (the Ed25519 signing machinery signs an opaque string, so
 	// this is provider-agnostic) and persist the user record.
-	if !s.mintSessionCookies(w, canonicalID) {
+	if !s.mintSessionCookies(w, r, canonicalID) {
 		return // mintSessionCookies wrote the error
 	}
 
@@ -732,7 +732,7 @@ func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (log
 // but has no revocation store, so a revoked session can still reach a spoke
 // until its expiry. Closing that requires the spoke to ask the hub on the
 // terminal path; it is tracked separately and called out in hub_session_revocation.go.
-func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
+func (s *HubServer) mintSessionCookies(w http.ResponseWriter, r *http.Request, canonicalID string) bool {
 	// ROTATION (master-key-rotation.md, follow-on PR #1): mint under the CURRENT
 	// generation and stamp its ID into the signed claims, so the verifier can
 	// select one key instead of trying each and so telemetry can see which key
@@ -787,11 +787,47 @@ func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string
 	// hostile tenant can read it only if some other bug lets them (it stays
 	// HttpOnly + Secure), which is why the spoke-scoped-session redesign is
 	// tracked as follow-up rather than closed.
+	//
+	// #4171 WIDENS the Domain one level, from .hive.kubestellar.io to
+	// .kubestellar.io (derived, not hard-coded — sessionCookieDomain in
+	// saas.go), so first-party sibling products (dibs.kubestellar.io) receive
+	// the cookie and can SSO against /api/saas/whoami. This does not change the
+	// F4 analysis above: every host that received the cookie before (all
+	// *.hive.kubestellar.io spoke dashboards — deeper subdomains of the new
+	// parent scope) still receives it, and the hosts ADDED are exclusively
+	// hive-operated first-party services on *.kubestellar.io, not tenant-
+	// controlled origins. The tenant-side risk profile is therefore unchanged,
+	// and the same isSameOriginAsHub containment applies. Local/dev hosts get
+	// a host-only cookie instead (a browser rejects a non-covering Domain).
+	// SameSite=Lax stays correct: dibs.kubestellar.io and the hub are
+	// same-SITE (same registrable domain), so the browser attaches the cookie
+	// to dibs requests without needing SameSite=None.
+	domain := sessionCookieDomain(r.Host)
+	// Rollout hygiene (#4171): a pre-widening session cookie scoped
+	// Domain=.hive.kubestellar.io is a SEPARATE jar entry from the one minted
+	// below, and the browser would send both under the same name. Expire the
+	// legacy-scoped copy in the same response so a fresh login converges to
+	// exactly one session cookie. (Requests that still carry both in the
+	// interim are handled by hubSessionCookieValues, which tries every copy.)
+	// Emitted BEFORE the real cookie so anything scanning Set-Cookie in order
+	// finds the live session last.
+	if domain != "" && domain != hubDomainSuffix {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "hive_hub_user",
+			Value:    "",
+			Path:     "/",
+			Domain:   hubDomainSuffix,
+			MaxAge:   -1,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
 	cookie := &http.Cookie{
 		Name:     "hive_hub_user",
 		Value:    cookieValue,
 		Path:     "/",
-		Domain:   ".hive.kubestellar.io",
+		Domain:   domain,
 		MaxAge:   86400 * cookieMaxAgeDays,
 		HttpOnly: true,
 		Secure:   true,
@@ -854,18 +890,20 @@ func (s *HubServer) displayIdentity(identity string) (login, avatarURL string) {
 }
 
 func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
-	cookie, err := r.Cookie("hive_hub_user")
-	if err != nil || cookie.Value == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"authenticated":false}`))
-		return
-	}
-	// Trust the carried username only when its signature verifies; a legacy
+	// Trust a carried username only when its signature verifies; a legacy
 	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
 	// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
 	// F10: also enforces a v3 cookie's signed expiry and revocation state.
-	username, ok := s.verifyHubUserCookie(cookie.Value)
-	if !ok || loadSaaSUser(username) == nil {
+	// #4171: every hive_hub_user copy is tried (the domain-widening rollout can
+	// briefly leave two in the jar), matching getRealAuthUser.
+	var username string
+	for _, value := range hubSessionCookieValues(r) {
+		if u, ok := s.verifyHubUserCookie(value); ok && loadSaaSUser(u) != nil {
+			username = u
+			break
+		}
+	}
+	if username == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))
 		return
@@ -928,9 +966,13 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	//
 	// The browser's copy is cleared unconditionally regardless, below: a client
 	// with a corrupt or expired cookie must still be able to clear it.
-	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
-		if _, ok := s.verifyHubUserCookie(c.Value); ok {
-			s.revokeHubSessionCookie(c.Value)
+	// #4171: revoke EVERY verifiable copy — the domain-widening rollout can
+	// leave two hive_hub_user cookies (legacy .hive.kubestellar.io scope and
+	// the new parent scope) carrying different session IDs, and logging out
+	// must kill both sessions, not just whichever the jar sent first.
+	for _, value := range hubSessionCookieValues(r) {
+		if _, ok := s.verifyHubUserCookie(value); ok {
+			s.revokeHubSessionCookie(value)
 		} else {
 			// Not an error path worth surfacing to the client — an expired or
 			// already-revoked cookie logging out is entirely normal — but it is
@@ -939,16 +981,26 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 			s.logger.Debug("logout: unverifiable session cookie, nothing to revoke")
 		}
 	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     "hive_hub_user",
-		Value:    "",
-		Path:     "/",
-		Domain:   ".hive.kubestellar.io",
-		MaxAge:   -1,
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	// Clear the browser's copy under the SAME Domain minting used — a deletion
+	// only removes the jar entry whose domain matches. Also clear the legacy
+	// .hive.kubestellar.io-scoped entry (#4171 rollout: a pre-widening session
+	// is a separate jar entry that a parent-scoped deletion cannot remove).
+	clearDomains := []string{sessionCookieDomain(r.Host)}
+	if clearDomains[0] != "" && clearDomains[0] != hubDomainSuffix {
+		clearDomains = append(clearDomains, hubDomainSuffix)
+	}
+	for _, domain := range clearDomains {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "hive_hub_user",
+			Value:    "",
+			Path:     "/",
+			Domain:   domain,
+			MaxAge:   -1,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"ok":true}`))
 }

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -497,6 +498,12 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/upgrade-pause", s.requireAdmin(s.handleGetUpgradePause))
 	s.mux.HandleFunc("POST /api/saas/upgrade-pause", s.requireAdmin(s.handleSetUpgradePause))
 	s.mux.HandleFunc("GET /api/saas/auth-check", s.handleSaaSAuthCheck)
+	// Sibling-product identity bridge (#4171): dibs.kubestellar.io forwards the
+	// browser's hive_hub_user cookie here server-to-server to resolve the
+	// session. Registered GET-only via the method pattern, and WITHOUT
+	// requireAuth so the unauthenticated answer is the exact 401 JSON shape the
+	// dibs bridge expects rather than the generic middleware error.
+	s.mux.HandleFunc("GET /api/saas/whoami", s.handleSaaSWhoami)
 	s.mux.HandleFunc("POST /api/saas/user-token", s.requireAuth(s.handleUserToken))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/access", s.requireAuth(s.handleAccessList))
 	s.mux.HandleFunc("GET /api/saas/grantable-users", s.requireAuth(s.handleGrantableUsers))
@@ -774,6 +781,62 @@ const hubCanonicalHost = "hive.kubestellar.io"
 // isTrustedRedirectTarget — and deliberately NOT a CSRF or CORS boundary.
 const hubDomainSuffix = ".hive.kubestellar.io"
 
+// sessionCookieParentDomain is the registrable parent domain the hub session
+// cookie is scoped to, so first-party sibling products on other kubestellar.io
+// subdomains (dibs.kubestellar.io) receive it and can SSO against the hub via
+// GET /api/saas/whoami. Derived from hubCanonicalHost (its parent domain)
+// rather than spelled out so the two can never disagree.
+func sessionCookieParentDomain() string {
+	if _, parent, ok := strings.Cut(hubCanonicalHost, "."); ok {
+		return parent
+	}
+	return hubCanonicalHost
+}
+
+// sessionCookieDomain returns the Domain attribute the hub session cookie
+// (hive_hub_user) must carry for a request served on host, or "" for a
+// host-only cookie.
+//
+// Production (any host under kubestellar.io, including the hub itself) gets
+// Domain=.kubestellar.io so that BOTH consumers of the cookie receive it:
+//   - every hosted spoke's Node proxy on <id>.hive.kubestellar.io, which
+//     independently verifies it for the tenant dashboard and terminal (the
+//     original reason the cookie carried Domain=.hive.kubestellar.io); and
+//   - sibling first-party products such as dibs.kubestellar.io, which read it
+//     and call back to /api/saas/whoami (#4171).
+//
+// Local/dev hosts (localhost, 127.0.0.1, anything not under kubestellar.io)
+// get a host-only cookie: a browser rejects a Set-Cookie whose Domain does not
+// cover the request host, so widening there would break local login outright.
+func sessionCookieDomain(host string) string {
+	h := host
+	if hp, _, err := net.SplitHostPort(host); err == nil {
+		h = hp
+	}
+	parent := sessionCookieParentDomain()
+	if h == parent || strings.HasSuffix(h, "."+parent) {
+		return "." + parent
+	}
+	return ""
+}
+
+// hubSessionCookieValues returns every hive_hub_user value on the request, in
+// jar order. During the .kubestellar.io domain-widening rollout (#4171) a
+// browser may briefly hold TWO copies of the cookie — the legacy
+// .hive.kubestellar.io-scoped one and the new parent-scoped one — and it sends
+// both under the same name. Callers must try each candidate rather than
+// trusting whichever copy the jar happens to order first, or a stale legacy
+// cookie would shadow a fresh session (and vice versa) until re-login.
+func hubSessionCookieValues(r *http.Request) []string {
+	var vals []string
+	for _, c := range r.Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			vals = append(vals, c.Value)
+		}
+	}
+	return vals
+}
+
 // isSameOriginAsHub reports whether raw names the hub's own origin, i.e. the
 // only origin permitted to drive a state-changing request or to receive a
 // credentialed CORS response.
@@ -846,8 +909,9 @@ func originHost(raw string) (string, bool) {
 // resolveIdentity — never inside it — so the write-block and the admin gate can
 // always reason about who is really driving the request.
 func (s *HubServer) getRealAuthUser(r *http.Request) string {
-	cookie, err := r.Cookie("hive_hub_user")
-	if err == nil && cookie.Value != "" {
+	// Every hive_hub_user copy is tried, not just the first (see
+	// hubSessionCookieValues — the domain-widening rollout can leave two).
+	for _, value := range hubSessionCookieValues(r) {
 		// The cookie value is only trusted when its HMAC signature verifies
 		// against the hub secret. A legacy unsigned cookie or a forged value
 		// fails here and is treated as logged out, so the user re-authenticates
@@ -855,7 +919,7 @@ func (s *HubServer) getRealAuthUser(r *http.Request) string {
 		// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
 		// F10: verifyHubUserCookie additionally enforces a v3 cookie's SIGNED
 		// expiry and its revocation state, which MaxAge alone never did.
-		if username, ok := s.verifyHubUserCookie(cookie.Value); ok {
+		if username, ok := s.verifyHubUserCookie(value); ok {
 			if loadSaaSUser(username) != nil {
 				return username
 			}
@@ -8463,6 +8527,65 @@ func (s *HubServer) spokeProxyAuthToken(hiveID string) string {
 	s.spokeProxyAuthMu.Unlock()
 
 	return token
+}
+
+// handleSaaSWhoami resolves the hub session for a sibling first-party product
+// (#4171). Dibs (dibs.kubestellar.io) has no login of its own: it forwards the
+// browser's hive_hub_user cookie here server-to-server and expects
+//
+//	200 {"username","display_name","email","avatar_url"}
+//
+// for a valid session, or 401 JSON otherwise.
+//
+// username is the STABLE identity key: the bare GitHub login for GitHub users
+// (byte-identical to what every pre-multi-provider consumer keys on), or the
+// hub's canonical "provider:sub" form for OIDC users — never a display name,
+// never an email (emails are reassignable; subs are not). display_name/email/
+// avatar_url come from the enriched SaaSUser record (DisplayName et al are
+// refreshed on every completed login).
+//
+// Deliberately no CORS headers: the caller is a server, not a browser, and
+// adding credentialed CORS here would hand the session identity to scripts.
+// Cache-Control: no-store because the answer is per-session and revocable.
+func (s *HubServer) handleSaaSWhoami(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	username := s.getAuthUser(r)
+	if username == "" {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"not authenticated"}`))
+		return
+	}
+	user := loadSaaSUser(username)
+	if user == nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"not authenticated"}`))
+		return
+	}
+	// Bare login for GitHub identities, canonical provider:sub for the rest —
+	// exactly the key SaaSUser records are stored and looked up under.
+	stableKey := username
+	if provider, subject, ok := parseCanonical(canonicalizeLegacy(username)); ok && provider == legacyProvider {
+		stableKey = subject
+	}
+	displayLogin, avatar := s.displayIdentity(username)
+	displayName := user.DisplayName
+	if displayName == "" {
+		// GitHub users have no provider-asserted name claim stored; the display
+		// login (their bare GitHub login) is the established fallback.
+		displayName = displayLogin
+	}
+	data, err := json.Marshal(map[string]string{
+		"username":     stableKey,
+		"display_name": displayName,
+		"email":        user.Email,
+		"avatar_url":   avatar,
+	})
+	if err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
 }
 
 func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/hub/saas_sibling_origin_test.go
+++ b/src/pkg/hub/saas_sibling_origin_test.go
@@ -215,11 +215,18 @@ func TestImpersonateCookieIsHostOnly(t *testing.T) {
 // change deliberately does not fix, so the decision is explicit in the suite
 // rather than an unexplained omission.
 //
-// hive_hub_user MUST keep Domain=.hive.kubestellar.io: each spoke's Node proxy
-// (src/proxy/server.js) independently verifies this cookie to authenticate the
-// tenant dashboard and terminal, and it can only verify a cookie the browser
-// sends it — which happens solely because of that Domain attribute. Making it
-// host-only or __Host- would log every hosted tenant out fleet-wide.
+// hive_hub_user MUST keep a Domain that covers <id>.hive.kubestellar.io: each
+// spoke's Node proxy (src/proxy/server.js) independently verifies this cookie
+// to authenticate the tenant dashboard and terminal, and it can only verify a
+// cookie the browser sends it — which happens solely because of that Domain
+// attribute. Making it host-only or __Host- would log every hosted tenant out
+// fleet-wide.
+//
+// #4171 widened the scope from .hive.kubestellar.io to the parent
+// .kubestellar.io so sibling first-party products (dibs.kubestellar.io)
+// receive it too — every spoke host is a deeper subdomain of that scope and
+// still receives the cookie. Logout must clear BOTH scopes: a pre-widening
+// session is a separate jar entry a parent-scoped deletion cannot remove.
 //
 // If you are here because you want the __Host- prefix the audit asked for: the
 // prerequisite is a spoke-scoped session minted at SSO handoff, so the hub
@@ -231,14 +238,13 @@ func TestImpersonateCookieIsHostOnly(t *testing.T) {
 func TestSessionCookieStillDomainScopedForSpokes(t *testing.T) {
 	s := newHandlerHub()
 	rec := httptest.NewRecorder()
-	s.handleLogout(rec, httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil))
+	s.handleLogout(rec, httptest.NewRequest(http.MethodPost, "https://hive.kubestellar.io/api/auth/logout", nil))
 
-	var found bool
+	domains := map[string]bool{}
 	for _, c := range rec.Result().Cookies() {
 		if c.Name != "hive_hub_user" {
 			continue
 		}
-		found = true
 		if c.Domain == "" {
 			t.Fatal("hive_hub_user is no longer domain-scoped. Each spoke's Node proxy " +
 				"(src/proxy/server.js) verifies this cookie and only receives it because of the " +
@@ -249,9 +255,20 @@ func TestSessionCookieStillDomainScopedForSpokes(t *testing.T) {
 		if !c.Secure || !c.HttpOnly {
 			t.Errorf("hive_hub_user lost hardening: Secure=%v HttpOnly=%v", c.Secure, c.HttpOnly)
 		}
+		if c.MaxAge >= 0 {
+			t.Errorf("logout cookie for Domain=%q is not a deletion (MaxAge=%d)", c.Domain, c.MaxAge)
+		}
+		domains[c.Domain] = true
 	}
-	if !found {
+	if len(domains) == 0 {
 		t.Fatal("handleLogout emitted no hive_hub_user cookie")
+	}
+	if !domains["kubestellar.io"] {
+		t.Errorf("logout does not clear the parent-scoped (#4171) session cookie, got domains %v", domains)
+	}
+	if !domains["hive.kubestellar.io"] {
+		t.Errorf("logout does not clear the legacy .hive.kubestellar.io-scoped session cookie "+
+			"(a pre-widening session is a separate jar entry), got domains %v", domains)
 	}
 }
 

--- a/src/pkg/hub/session_f10_f15_test.go
+++ b/src/pkg/hub/session_f10_f15_test.go
@@ -51,7 +51,7 @@ func TestF10ProductionMintsV3(t *testing.T) {
 	mkUser(t, "alice")
 
 	rec := httptest.NewRecorder()
-	if !s.mintSessionCookies(rec, "github:alice") {
+	if !s.mintSessionCookies(rec, httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login", nil), "github:alice") {
 		t.Fatal("mintSessionCookies failed")
 	}
 
@@ -92,7 +92,7 @@ func TestF10SignedExpiryIsEnforcedNotAdvisory(t *testing.T) {
 	s := f10f15Server(t)
 	mkUser(t, "alice")
 	rec := httptest.NewRecorder()
-	if !s.mintSessionCookies(rec, "github:alice") {
+	if !s.mintSessionCookies(rec, httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login", nil), "github:alice") {
 		t.Fatal("mint failed")
 	}
 	var value string
@@ -123,7 +123,7 @@ func TestF10LogoutActuallyRevokes(t *testing.T) {
 	mkUser(t, "alice")
 
 	rec := httptest.NewRecorder()
-	if !s.mintSessionCookies(rec, "github:alice") {
+	if !s.mintSessionCookies(rec, httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login", nil), "github:alice") {
 		t.Fatal("mint failed")
 	}
 	var value string
@@ -202,7 +202,7 @@ func TestF15LegitimateLogoutStillRevokes(t *testing.T) {
 	mkUser(t, "alice")
 
 	rec := httptest.NewRecorder()
-	if !s.mintSessionCookies(rec, "github:alice") {
+	if !s.mintSessionCookies(rec, httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login", nil), "github:alice") {
 		t.Fatal("mint failed")
 	}
 	var value string

--- a/src/pkg/hub/static/api-docs.html
+++ b/src/pkg/hub/static/api-docs.html
@@ -243,7 +243,7 @@
 
         <div class="card">
           <strong>Step 1: Login via browser</strong>
-          <p>Visit <a href="/login">/login</a> &mdash; you'll be redirected to GitHub to authorize. After approval, a <code>hive_hub_user</code> cookie is set on <code>.hive.kubestellar.io</code>.</p>
+          <p>Visit <a href="/login">/login</a> &mdash; you'll be redirected to GitHub to authorize. After approval, a <code>hive_hub_user</code> cookie is set on <code>.kubestellar.io</code>.</p>
         </div>
 
         <div class="card">

--- a/src/pkg/hub/whoami_sso_test.go
+++ b/src/pkg/hub/whoami_sso_test.go
@@ -1,0 +1,289 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ============================================================
+// #4171 — SSO with sibling first-party products (dibs.kubestellar.io).
+//
+// Two halves, both pinned here:
+//   1. GET /api/saas/whoami — the identity bridge dibs calls server-to-server
+//      with the browser's forwarded hive_hub_user cookie.
+//   2. The session cookie's Domain widening from .hive.kubestellar.io to the
+//      parent .kubestellar.io (so siblings receive it), including the
+//      host-only fallback for local/dev hosts and logout clearing both scopes.
+// ============================================================
+
+func TestWhoamiGitHubUser(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "octocat")
+
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/whoami", nil)
+	req.AddCookie(testAuthCookie("octocat"))
+	rec := httptest.NewRecorder()
+	s.handleSaaSWhoami(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("whoami with a valid session = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store — the answer is per-session and revocable", cc)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("whoami body is not JSON: %v", err)
+	}
+	// username must be the STABLE key: the bare GitHub login, exactly what
+	// every SaaSUser record and hive grant is keyed on.
+	if got["username"] != "octocat" {
+		t.Errorf("username = %q, want octocat (bare GitHub login)", got["username"])
+	}
+	if got["display_name"] != "octocat" {
+		t.Errorf("display_name = %q, want the login fallback for a GitHub user with no stored DisplayName", got["display_name"])
+	}
+	if got["avatar_url"] != "https://github.com/octocat.png" {
+		t.Errorf("avatar_url = %q, want the derived GitHub avatar", got["avatar_url"])
+	}
+	if _, ok := got["email"]; !ok {
+		t.Error("email key missing from whoami payload")
+	}
+}
+
+func TestWhoamiOIDCUserUsesCanonicalKey(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	if err := saveSaaSUser(&SaaSUser{
+		CanonicalID: "google:1078",
+		Provider:    "google",
+		DisplayName: "Ada Lovelace",
+		Email:       "ada@example.com",
+		AvatarURL:   "https://lh3.example/pic.png",
+		Hives:       map[string]string{},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/whoami", nil)
+	req.AddCookie(testAuthCookie("google:1078"))
+	rec := httptest.NewRecorder()
+	s.handleSaaSWhoami(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("whoami with a valid OIDC session = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("whoami body is not JSON: %v", err)
+	}
+	// The stable key for an OIDC user is the canonical provider:sub form —
+	// NEVER the display name or email (emails are reassignable, subs are not).
+	if got["username"] != "google:1078" {
+		t.Errorf("username = %q, want the canonical provider:sub key google:1078", got["username"])
+	}
+	if got["display_name"] != "Ada Lovelace" {
+		t.Errorf("display_name = %q, want the provider-asserted DisplayName", got["display_name"])
+	}
+	if got["email"] != "ada@example.com" {
+		t.Errorf("email = %q, want the stored provider email", got["email"])
+	}
+	if got["avatar_url"] != "https://lh3.example/pic.png" {
+		t.Errorf("avatar_url = %q, want the stored provider avatar", got["avatar_url"])
+	}
+}
+
+func TestWhoamiUnauthenticated(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	cases := []struct {
+		name   string
+		cookie *http.Cookie
+	}{
+		{"no cookie", nil},
+		{"forged cookie", &http.Cookie{Name: "hive_hub_user", Value: "attacker-chosen"}},
+		{"valid signature, no such user", testAuthCookie("ghost-user-xyz")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/whoami", nil)
+			if tc.cookie != nil {
+				req.AddCookie(tc.cookie)
+			}
+			rec := httptest.NewRecorder()
+			s.handleSaaSWhoami(rec, req)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("whoami (%s) = %d, want 401", tc.name, rec.Code)
+			}
+			var got map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("401 body must be JSON for the dibs bridge, got %q: %v", rec.Body.String(), err)
+			}
+			if got["error"] == "" {
+				t.Errorf("401 body carries no error field: %q", rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestWhoamiIsGETOnly pins the mux method pattern: dibs only ever issues GET,
+// and there is no reason to let this route answer anything else.
+func TestWhoamiIsGETOnly(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := NewHubServer(0, slog.Default(), "", "")
+	req := httptest.NewRequest(http.MethodPost, "https://hive.kubestellar.io/api/saas/whoami", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /api/saas/whoami = %d, want 405", rec.Code)
+	}
+}
+
+// TestSessionCookieDomainWidenedToParent pins the #4171 scope: minted on the
+// production hub host, the session cookie must carry Domain=.kubestellar.io so
+// BOTH the hosted spokes (*.hive.kubestellar.io — deeper subdomains, still
+// covered) and sibling products (dibs.kubestellar.io) receive it. The mint
+// must also expire the legacy .hive.kubestellar.io-scoped copy so a fresh
+// login converges to one session cookie.
+func TestSessionCookieDomainWidenedToParent(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/auth/callback", nil)
+	if !s.mintSessionCookies(rec, req, "github:alice") {
+		t.Fatal("mintSessionCookies failed")
+	}
+
+	var live, legacyClear *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != "hive_hub_user" {
+			continue
+		}
+		if c.Value != "" {
+			live = c
+		} else {
+			legacyClear = c
+		}
+	}
+	if live == nil {
+		t.Fatal("mint emitted no live hive_hub_user cookie")
+	}
+	if live.Domain != "kubestellar.io" {
+		t.Fatalf("session cookie Domain = %q, want .kubestellar.io — dibs.kubestellar.io never receives it otherwise", live.Domain)
+	}
+	if !live.Secure || !live.HttpOnly || live.SameSite != http.SameSiteLaxMode {
+		t.Errorf("session cookie lost hardening: Secure=%v HttpOnly=%v SameSite=%v", live.Secure, live.HttpOnly, live.SameSite)
+	}
+	if legacyClear == nil {
+		t.Fatal("mint did not expire the legacy .hive.kubestellar.io-scoped copy — the jar would hold two sessions")
+	}
+	if legacyClear.Domain != "hive.kubestellar.io" || legacyClear.MaxAge >= 0 {
+		t.Errorf("legacy clear cookie Domain=%q MaxAge=%d, want .hive.kubestellar.io with MaxAge<0", legacyClear.Domain, legacyClear.MaxAge)
+	}
+}
+
+// TestSessionCookieHostOnlyForLocalDev pins the fallback: on a host that is
+// not under kubestellar.io the Domain attribute must be omitted entirely — a
+// browser rejects a Set-Cookie whose Domain does not cover the request host,
+// so widening there would break local login outright.
+func TestSessionCookieHostOnlyForLocalDev(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	for _, host := range []string{"localhost:8080", "127.0.0.1:8080", "hub.example.internal"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://"+host+"/api/auth/callback", nil)
+		if !s.mintSessionCookies(rec, req, "github:alice") {
+			t.Fatal("mintSessionCookies failed")
+		}
+		for _, c := range rec.Result().Cookies() {
+			if c.Name == "hive_hub_user" && c.Domain != "" {
+				t.Errorf("host %s: session cookie carries Domain=%q, want host-only", host, c.Domain)
+			}
+		}
+	}
+
+	// Logout on a dev host must clear the same host-only cookie.
+	rec := httptest.NewRecorder()
+	s.handleLogout(rec, httptest.NewRequest(http.MethodPost, "http://localhost:8080/api/auth/logout", nil))
+	var cleared bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != "hive_hub_user" {
+			continue
+		}
+		cleared = true
+		if c.Domain != "" {
+			t.Errorf("dev logout clears Domain=%q, want host-only to match the mint", c.Domain)
+		}
+		if c.MaxAge >= 0 {
+			t.Errorf("dev logout cookie is not a deletion (MaxAge=%d)", c.MaxAge)
+		}
+	}
+	if !cleared {
+		t.Fatal("dev logout emitted no hive_hub_user deletion")
+	}
+}
+
+// TestSessionAcceptsEitherCookieCopy pins the rollout behaviour: while a
+// browser holds both the legacy .hive.kubestellar.io-scoped cookie and the new
+// parent-scoped one, it sends BOTH under the same name, in jar order the hub
+// does not control. The hub must find the valid session regardless of which
+// copy comes first.
+func TestSessionAcceptsEitherCookieCopy(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "alice")
+
+	valid := testAuthCookie("alice")
+	stale := &http.Cookie{Name: "hive_hub_user", Value: "stale-or-forged"}
+
+	for _, order := range [][]*http.Cookie{{stale, valid}, {valid, stale}} {
+		req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/whoami", nil)
+		for _, c := range order {
+			req.AddCookie(c)
+		}
+		if got := s.getRealAuthUser(req); got != "alice" {
+			t.Errorf("with cookie order %q first: getRealAuthUser = %q, want alice", order[0].Value, got)
+		}
+	}
+}
+
+// TestSessionCookieDomainDerivation pins sessionCookieDomain itself so the
+// host classification is explicit.
+func TestSessionCookieDomainDerivation(t *testing.T) {
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"hive.kubestellar.io", ".kubestellar.io"},
+		{"hive.kubestellar.io:443", ".kubestellar.io"},
+		{"kubestellar.io", ".kubestellar.io"},
+		{"dibs.kubestellar.io", ".kubestellar.io"},
+		{"myspoke.hive.kubestellar.io", ".kubestellar.io"},
+		{"localhost", ""},
+		{"localhost:8080", ""},
+		{"127.0.0.1:9090", ""},
+		{"example.com", ""},
+		// A lookalike must NOT be treated as under the parent domain.
+		{"evilkubestellar.io", ""},
+		{"kubestellar.io.evil.com", ""},
+	}
+	for _, tc := range cases {
+		if got := sessionCookieDomain(tc.host); got != tc.want {
+			t.Errorf("sessionCookieDomain(%q) = %q, want %q", tc.host, got, tc.want)
+		}
+	}
+}

--- a/src/proxy/server.js
+++ b/src/proxy/server.js
@@ -174,7 +174,8 @@ const SNAPSHOT_FRAME_ANCESTORS_FALLBACK = parseSnapshotFrameAncestors(process.en
 // HIVE_ID is this spoke's own hive identity, injected by the hub at provision
 // time (mirrors the HIVE_ID env the Go dashboard reads). It is the anchor for
 // per-hive terminal authorization: a hub-user cookie is authenticated hub-wide
-// (the `hive_hub_user` cookie is scoped to .hive.kubestellar.io, so ANY hive's
+// (the `hive_hub_user` cookie is scoped to .kubestellar.io — widened from
+// .hive.kubestellar.io for sibling-product SSO, hive#4171 — so ANY hive's
 // domain receives it), so the signature check alone proves only "some hub user",
 // never "a user allowed on THIS hive".
 const HIVE_ID = process.env.HIVE_ID || '';


### PR DESCRIPTION
Enables single sign-on between hive hub and its sibling product **Dibs** (dibs.kubestellar.io). Dibs's auth bridge has no login of its own: it forwards the browser's `hive_hub_user` cookie to `GET {HUB}/api/saas/whoami` and expects `200 {"username","display_name","email","avatar_url"}` or 401.

Fixes #4171

## What changed

### 1. Session cookie widened to `Domain=.kubestellar.io`

- `mintSessionCookies` / `handleLogout` now derive the Domain via `sessionCookieDomain(r.Host)` (parent domain of `hubCanonicalHost` — not hard-coded): any host under `kubestellar.io` gets `Domain=.kubestellar.io`; anything else (localhost, 127.0.0.1, dev hosts) gets a **host-only** cookie, since a browser rejects a Set-Cookie whose Domain does not cover the request host.
- `Secure`, `HttpOnly`, `Path=/` unchanged. **SameSite=Lax stays correct**: dibs.kubestellar.io and the hub share the registrable domain `kubestellar.io`, so they are same-*site* and the browser attaches the Lax cookie to dibs requests without needing `SameSite=None`.
- **Logout clears both scopes**: a pre-widening `.hive.kubestellar.io`-scoped session is a separate jar entry a parent-scoped deletion cannot remove, so logout emits deletions for both, and revokes *every* verifiable cookie copy server-side.
- **Rollout / re-login note**: until a user re-logs-in (or logs out) they may briefly hold two `hive_hub_user` cookies; the browser sends both under one name in jar order the hub doesn't control. All session reads (`getRealAuthUser`, `handleAuthUser`) now try **every** copy via `hubSessionCookieValues`, so existing sessions keep working regardless of order. A fresh login also expires the legacy-scoped copy in the same response, so the jar converges to one cookie.

### 2. `GET /api/saas/whoami`

- 200 `{"username","display_name","email","avatar_url"}` for a valid session; 401 JSON otherwise.
- `username` is the **stable identity key**: bare GitHub login for GitHub users, canonical `provider:sub` for OIDC users — exactly the key `SaaSUser` records are stored under. `display_name`/`email`/`avatar_url` come from the enriched record (OIDC identity work), with the login/derived-avatar fallback for GitHub users.
- Reuses the existing verification chain (`getAuthUser` → `verifyHubUserCookie` → `loadSaaSUser`).
- Hardened: `Cache-Control: no-store`, GET-only via the mux method pattern, **no CORS** (dibs calls it server-to-server; credentialed CORS would hand session identity to scripts).

## Security analysis of the domain widening

- **Who received the cookie before**: the hub plus every hosted spoke dashboard on `<id>.hive.kubestellar.io` (~62 tenant-operated origins) — that Domain is load-bearing, each spoke's Node proxy independently verifies the cookie (see the F4 note in oauth.go; dropping it caused-class incident #2773).
- **Who is added by widening to `.kubestellar.io`**: only first-party, hive-operated services on direct `*.kubestellar.io` subdomains (dibs). The spoke dashboards are *deeper* subdomains of the new scope, so they receive the cookie exactly as before — no change for them, and no new tenant-controlled origin gains it. The tenant-side risk profile is therefore **unchanged**, and the existing F4 containment (`isSameOriginAsHub` refusing sibling-authored mutations and credentialed CORS; HttpOnly+Secure on the cookie) applies identically.
- Residual risk remains what it was: the cookie travels to tenant spoke origins; the tracked follow-up (spoke-scoped session at SSO handoff) is unaffected by this PR.
- The `.hive.kubestellar.io`-pinning regression test (`TestSessionCookieStillDomainScopedForSpokes`) was updated to pin the new invariant: the cookie must stay domain-scoped so spokes receive it, and logout must clear both scopes.

## Tests

- `whoami`: 200 for GitHub user (bare login + derived avatar), 200 for OIDC user (canonical `provider:sub` key + stored DisplayName/Email/AvatarURL), 401 for no/forged/orphan cookie (JSON body), 405 for POST, `no-store` header.
- Cookie Domain: `.kubestellar.io` on login at the hub host (plus legacy-copy expiry), host-only on localhost/dev, logout clears both scopes (and host-only on dev), accept-either ordering, and `sessionCookieDomain` classification incl. lookalike hosts (`evilkubestellar.io`, `kubestellar.io.evil.com`).
- `go build ./...`, `go vet ./pkg/hub/`, and `go test ./pkg/hub/ -short -race -count=1` all pass.
