### PR TITLE
🐛 fix(pi): use host networking so lemonade-pi-plugin can discover models

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -626,7 +626,9 @@ contribute-hive backend="" mode="docker": check-version
       # on the contributor's HOST at their next CLI run.
       #
       # Networking: the relay only dials OUT (hub + GitHub + optional LiteLLM),
-      # so the default bridge network is sufficient. No host networking.
+      # so the default bridge network is sufficient. No host networking —
+      # with one narrow exception for the pi backend (see the pi) case below),
+      # which needs host networking to discover the host-local LLM server.
       NET_FLAGS=""
       if [[ "$RUNTIME" == "podman" ]]; then
         RUNTIME_FLAGS="--userns=keep-id"
@@ -700,6 +702,19 @@ contribute-hive backend="" mode="docker": check-version
             stage_copy "${HOME}/.pi" ".pi"
             CLI_MOUNTS="-v ${CLI_STAGE}/.pi:/home/dev/.pi${VOLSUF}"
           fi
+          # SECURITY (H6 / CWE-668) EXCEPTION: pi alone gets host networking.
+          # The lemonade-pi-plugin discovers host-local LLM models via a UDP
+          # beacon on port 13305 and HTTP fallbacks on localhost:8000/1234/
+          # 9000/8080. Under bridge networking, "localhost" inside the
+          # container is the container itself, so discovery fails with
+          # "No models available". Host networking lets the plugin reach the
+          # LLM server running on the contributor's host. The H6 protection
+          # that matters — never letting the container write into the
+          # contributor's real host CLI configs — is unaffected: ~/.pi is
+          # still copied into an ephemeral staging dir (above) that is
+          # destroyed in cleanup_container, so a poisoned agent still cannot
+          # plant config on the host.
+          NET_FLAGS="--network host"
           ;;
         agy)
           # agy 1.1.x keeps its state under ${HOME}/.gemini/antigravity-cli,


### PR DESCRIPTION
## Problem

Running the `pi` backend via `just contribute-hive` reports **"No models available"**. The container runs on Docker bridge networking, so the lemonade-pi-plugin's discovery — UDP beacon on port 13305 and HTTP fallbacks on `localhost:8000/1234/9000/8080` — hits the container's own localhost instead of the host running the LLM server.

## Fix

Set `NET_FLAGS="--network host"` in the `pi)` backend case only. All other backends keep bridge networking.

## Security (H6 / CWE-668)

Documented as a narrow, deliberate exception in the Justfile comments:
- Only `pi` gets host networking; the general "no host networking" rule stands for every other backend.
- The core H6 protection — the container can never write into the contributor's real host CLI configs — is unaffected: `~/.pi` is still copied into an ephemeral staging dir that is destroyed in `cleanup_container`.

## Validation

- `just --summary` — Justfile parses OK
- `just --dry-run contribute-hive pi docker` rendered script passes `bash -n`; `--network host` appears exactly once
- No existing test suite covers backend launch flags (no bats/shell tests in repo), so verification is via the parse/syntax checks above plus the reproduction in #4172 (container network mode → `host`, `pi --list-models` discovers 21 models)

Closes #4172