### PR TITLE
✨ sso: widen session cookie domain to .kubestellar.io and add whoami endpoint (#4171)

### DIFF
--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -424,6 +424,7 @@ always resolved server-side from the validated token.
 | `GET` | `/api/auth/callback` | Hub handler-specific | OAuth Callback | `pkg/hub/oauth.go:38` |
 | `GET` | `/api/auth/user` | Hub handler-specific | Auth User | `pkg/hub/oauth.go:39` |
 | `POST` | `/api/auth/logout` | Hub handler-specific | Logout | `pkg/hub/oauth.go:40` |
+| `GET` | `/api/saas/whoami` | Hub handler-specific | Whoami SSO Identity | `pkg/hub/saas.go:500` |
 | `GET` | `/api/openrouter/connect/start` | Hub auth | Hub Open Router Start | `pkg/hub/openrouter.go:49` |
 | `GET` | `/api/openrouter/qr` | Hub auth | Hub Open Router QR | `pkg/hub/openrouter.go:50` |
 | `GET` | `/api/openrouter/models` | Hub auth | Hub Open Router Models | `pkg/hub/openrouter.go:51` |

--- a/src/pkg/hub/dibs_sso_whoami_test.go
+++ b/src/pkg/hub/dibs_sso_whoami_test.go
@@ -1,0 +1,383 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSessionCookieDomainForHost verifies host-based cookie domain resolution.
+func TestSessionCookieDomainForHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"hive.kubestellar.io", ".kubestellar.io"},
+		{"dibs.kubestellar.io", ".kubestellar.io"},
+		{"hosted-hive-1.hive.kubestellar.io", ".kubestellar.io"},
+		{"kubestellar.io", ".kubestellar.io"},
+		{"hive.kubestellar.io:443", ".kubestellar.io"},
+		{"dibs.kubestellar.io:8443", ".kubestellar.io"},
+		{"localhost", ""},
+		{"localhost:8080", ""},
+		{"127.0.0.1", ""},
+		{"127.0.0.1:3000", ""},
+		{"example.com", ""},
+		{"evil.kubestellar.io.attacker.com", ""},
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		got := sessionCookieDomainForHost(tc.host)
+		if got != tc.want {
+			t.Errorf("sessionCookieDomainForHost(%q) = %q, want %q", tc.host, got, tc.want)
+		}
+	}
+}
+
+// TestMintSessionCookiesDomainScoping verifies that cookie minting scopes to .kubestellar.io
+// for kubestellar.io hosts and host-only for localhost/dev.
+func TestMintSessionCookiesDomainScoping(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	// 1. Host under kubestellar.io
+	recProd := httptest.NewRecorder()
+	if !s.mintSessionCookiesForHost(recProd, "hive.kubestellar.io", "github:alice") {
+		t.Fatal("mintSessionCookiesForHost failed for hive.kubestellar.io")
+	}
+	cookiesProd := recProd.Result().Cookies()
+	var prodCookie *http.Cookie
+	for _, c := range cookiesProd {
+		if c.Name == "hive_hub_user" {
+			prodCookie = c
+			break
+		}
+	}
+	if prodCookie == nil {
+		t.Fatal("no hive_hub_user cookie minted for production host")
+	}
+	if prodCookie.Domain != ".kubestellar.io" && prodCookie.Domain != "kubestellar.io" {
+		t.Errorf("prod cookie Domain = %q, want %q", prodCookie.Domain, ".kubestellar.io")
+	}
+	if !prodCookie.Secure || !prodCookie.HttpOnly || prodCookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("prod cookie lost hardening: Secure=%v HttpOnly=%v SameSite=%v",
+			prodCookie.Secure, prodCookie.HttpOnly, prodCookie.SameSite)
+	}
+
+	// 2. Localhost dev host
+	recDev := httptest.NewRecorder()
+	if !s.mintSessionCookiesForHost(recDev, "localhost:8080", "github:alice") {
+		t.Fatal("mintSessionCookiesForHost failed for localhost")
+	}
+	cookiesDev := recDev.Result().Cookies()
+	var devCookie *http.Cookie
+	for _, c := range cookiesDev {
+		if c.Name == "hive_hub_user" {
+			devCookie = c
+			break
+		}
+	}
+	if devCookie == nil {
+		t.Fatal("no hive_hub_user cookie minted for dev host")
+	}
+	if devCookie.Domain != "" {
+		t.Errorf("dev cookie Domain = %q, want empty (host-only)", devCookie.Domain)
+	}
+}
+
+// TestLogoutClearsBothNewAndLegacyDomains verifies that handleLogout clears both
+// .kubestellar.io and .hive.kubestellar.io domains on logout.
+func TestLogoutClearsBothNewAndLegacyDomains(t *testing.T) {
+	s := f10f15Server(t)
+
+	// Logout request from hive.kubestellar.io
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Host = "hive.kubestellar.io"
+	s.handleLogout(rec, req)
+
+	var clearedParent, clearedLegacy bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != "hive_hub_user" || c.MaxAge >= 0 {
+			continue
+		}
+		if c.Domain == ".kubestellar.io" || c.Domain == "kubestellar.io" {
+			clearedParent = true
+		}
+		if c.Domain == ".hive.kubestellar.io" || c.Domain == "hive.kubestellar.io" {
+			clearedLegacy = true
+		}
+	}
+
+	if !clearedParent {
+		t.Error("logout did not clear .kubestellar.io cookie")
+	}
+	if !clearedLegacy {
+		t.Error("logout did not clear legacy .hive.kubestellar.io cookie")
+	}
+}
+
+// TestDualCookieAcceptanceDuringRollout verifies that when multiple hive_hub_user cookies
+// are present in the request (e.g. legacy + new, or invalid + valid), authentication
+// succeeds as long as at least one valid cookie is present.
+func TestDualCookieAcceptanceDuringRollout(t *testing.T) {
+	s := f10f15Server(t)
+	mkUser(t, "alice")
+
+	// Valid cookie for alice
+	rec := httptest.NewRecorder()
+	if !s.mintSessionCookies(rec, "github:alice") {
+		t.Fatal("mintSessionCookies failed")
+	}
+	var validCookieVal string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			validCookieVal = c.Value
+		}
+	}
+	if validCookieVal == "" {
+		t.Fatal("no valid cookie value")
+	}
+
+	invalidCookieVal := "invalid.signature.cookie"
+
+	// Case 1: First cookie invalid, second cookie valid
+	req1 := httptest.NewRequest(http.MethodGet, "/api/saas/whoami", nil)
+	req1.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: invalidCookieVal})
+	req1.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: validCookieVal})
+
+	user1 := s.getRealAuthUser(req1)
+	if user1 != "alice" && user1 != "github:alice" {
+		t.Errorf("getRealAuthUser with invalid+valid cookies = %q, want alice", user1)
+	}
+
+	recWhoami := httptest.NewRecorder()
+	s.handleWhoami(recWhoami, req1)
+	if recWhoami.Code != http.StatusOK {
+		t.Errorf("handleWhoami with invalid+valid cookies returned status %d, want 200", recWhoami.Code)
+	}
+
+	// Case 2: First cookie valid, second cookie invalid
+	req2 := httptest.NewRequest(http.MethodGet, "/api/auth/user", nil)
+	req2.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: validCookieVal})
+	req2.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: invalidCookieVal})
+
+	recAuthUser := httptest.NewRecorder()
+	s.handleAuthUser(recAuthUser, req2)
+	var authUserResp map[string]any
+	if err := json.Unmarshal(recAuthUser.Body.Bytes(), &authUserResp); err != nil {
+		t.Fatalf("json parse error: %v", err)
+	}
+	if authUserResp["authenticated"] != true {
+		t.Errorf("handleAuthUser with valid+invalid cookies returned authenticated=false, want true")
+	}
+}
+
+// TestWhoamiEndpoint tests the GET /api/saas/whoami endpoint thoroughly.
+func TestWhoamiEndpoint(t *testing.T) {
+	s := f10f15Server(t)
+
+	// Create GitHub user "alice" without extra profile fields
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "alice",
+		CanonicalID:    "github:alice",
+		Provider:       "github",
+		Hives:          map[string]string{},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	// Create GitHub user "bob" with enriched profile
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "bob",
+		CanonicalID:    "github:bob",
+		Provider:       "github",
+		DisplayName:    "Bob Jones",
+		Email:          "bob@example.com",
+		AvatarURL:      "https://example.com/bob.png",
+		Hives:          map[string]string{},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	// Create OIDC user "google:1078" with enriched profile
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "google:1078",
+		CanonicalID:    "google:1078",
+		Provider:       "google",
+		DisplayName:    "Carol Danvers",
+		Email:          "carol@google.com",
+		AvatarURL:      "https://lh3.google.com/carol",
+		Hives:          map[string]string{},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	// 1. Unauthenticated request -> 401
+	{
+		req := httptest.NewRequest(http.MethodGet, "/api/saas/whoami", nil)
+		rec := httptest.NewRecorder()
+		s.handleWhoami(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("unauthenticated /api/saas/whoami code = %d, want 401", rec.Code)
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Cache-Control = %q, want no-store", cc)
+		}
+		var errBody map[string]string
+		if err := json.Unmarshal(rec.Body.Bytes(), &errBody); err != nil {
+			t.Fatalf("json parse error: %v", err)
+		}
+		if errBody["error"] != "unauthorized" {
+			t.Errorf("error msg = %q, want unauthorized", errBody["error"])
+		}
+	}
+
+	// 2. Forged cookie -> 401
+	{
+		req := httptest.NewRequest(http.MethodGet, "/api/saas/whoami", nil)
+		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "forged.value"})
+		rec := httptest.NewRecorder()
+		s.handleWhoami(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("forged cookie /api/saas/whoami code = %d, want 401", rec.Code)
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Cache-Control = %q, want no-store", cc)
+		}
+	}
+
+	// 3. GitHub user alice (default derived avatar, empty display_name and email) -> 200
+	{
+		recMint := httptest.NewRecorder()
+		s.mintSessionCookies(recMint, "github:alice")
+		var cookieVal string
+		for _, c := range recMint.Result().Cookies() {
+			if c.Name == "hive_hub_user" {
+				cookieVal = c.Value
+			}
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/saas/whoami", nil)
+		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: cookieVal})
+		rec := httptest.NewRecorder()
+		s.handleWhoami(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("alice /api/saas/whoami code = %d, want 200. Body: %s", rec.Code, rec.Body.String())
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Cache-Control = %q, want no-store", cc)
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+
+		var resp whoamiResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("json parse error: %v", err)
+		}
+		if resp.Username != "alice" {
+			t.Errorf("alice username = %q, want alice", resp.Username)
+		}
+		if resp.AvatarURL != "https://github.com/alice.png" {
+			t.Errorf("alice avatar_url = %q, want https://github.com/alice.png", resp.AvatarURL)
+		}
+		if resp.DisplayName != "" {
+			t.Errorf("alice display_name = %q, want empty", resp.DisplayName)
+		}
+		if resp.Email != "" {
+			t.Errorf("alice email = %q, want empty", resp.Email)
+		}
+	}
+
+	// 4. GitHub user bob (enriched fields) -> 200
+	{
+		recMint := httptest.NewRecorder()
+		s.mintSessionCookies(recMint, "github:bob")
+		var cookieVal string
+		for _, c := range recMint.Result().Cookies() {
+			if c.Name == "hive_hub_user" {
+				cookieVal = c.Value
+			}
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/saas/whoami", nil)
+		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: cookieVal})
+		rec := httptest.NewRecorder()
+		s.handleWhoami(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("bob /api/saas/whoami code = %d, want 200. Body: %s", rec.Code, rec.Body.String())
+		}
+		var resp whoamiResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("json parse error: %v", err)
+		}
+		if resp.Username != "bob" {
+			t.Errorf("bob username = %q, want bob", resp.Username)
+		}
+		if resp.DisplayName != "Bob Jones" {
+			t.Errorf("bob display_name = %q, want 'Bob Jones'", resp.DisplayName)
+		}
+		if resp.Email != "bob@example.com" {
+			t.Errorf("bob email = %q, want 'bob@example.com'", resp.Email)
+		}
+		if resp.AvatarURL != "https://example.com/bob.png" {
+			t.Errorf("bob avatar_url = %q, want 'https://example.com/bob.png'", resp.AvatarURL)
+		}
+	}
+
+	// 5. OIDC user Carol (canonical provider:sub key) -> 200
+	{
+		recMint := httptest.NewRecorder()
+		s.mintSessionCookies(recMint, "google:1078")
+		var cookieVal string
+		for _, c := range recMint.Result().Cookies() {
+			if c.Name == "hive_hub_user" {
+				cookieVal = c.Value
+			}
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/saas/whoami", nil)
+		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: cookieVal})
+		rec := httptest.NewRecorder()
+		s.handleWhoami(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("carol /api/saas/whoami code = %d, want 200. Body: %s", rec.Code, rec.Body.String())
+		}
+		var resp whoamiResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("json parse error: %v", err)
+		}
+		if resp.Username != "google:1078" {
+			t.Errorf("carol username = %q, want 'google:1078'", resp.Username)
+		}
+		if resp.DisplayName != "Carol Danvers" {
+			t.Errorf("carol display_name = %q, want 'Carol Danvers'", resp.DisplayName)
+		}
+		if resp.Email != "carol@google.com" {
+			t.Errorf("carol email = %q, want 'carol@google.com'", resp.Email)
+		}
+		if resp.AvatarURL != "https://lh3.google.com/carol" {
+			t.Errorf("carol avatar_url = %q, want 'https://lh3.google.com/carol'", resp.AvatarURL)
+		}
+	}
+
+	// 6. Non-GET method -> 405
+	{
+		req := httptest.NewRequest(http.MethodPost, "/api/saas/whoami", nil)
+		rec := httptest.NewRecorder()
+		s.handleWhoami(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("POST /api/saas/whoami code = %d, want 405", rec.Code)
+		}
+		if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+			t.Errorf("Cache-Control = %q, want no-store", cc)
+		}
+	}
+}

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,6 +21,13 @@ import (
 const (
 	oauthTimeout     = 10 * time.Second
 	cookieMaxAgeDays = 7 // login session cookie lifetime
+
+	// sessionCookieDomain is the parent domain scope for SSO across *.kubestellar.io.
+	sessionCookieDomain = ".kubestellar.io"
+
+	// legacySessionCookieDomain is the previous scope (.hive.kubestellar.io),
+	// cleared on logout during rollout transition.
+	legacySessionCookieDomain = ".hive.kubestellar.io"
 
 	// cookieSessionTTL is the SIGNED lifetime baked into a v3 session cookie
 	// (audit F10). Derived from cookieMaxAgeDays so the enforced expiry and the
@@ -513,8 +521,8 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// From here the two paths converge: mint the session cookie over the
 	// canonical id (the Ed25519 signing machinery signs an opaque string, so
 	// this is provider-agnostic) and persist the user record.
-	if !s.mintSessionCookies(w, canonicalID) {
-		return // mintSessionCookies wrote the error
+	if !s.mintSessionCookiesForHost(w, r.Host, canonicalID) {
+		return // mintSessionCookiesForHost wrote the error
 	}
 
 	saasUser := ensureSaaSUser(canonicalID)
@@ -732,7 +740,31 @@ func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (log
 // but has no revocation store, so a revoked session can still reach a spoke
 // until its expiry. Closing that requires the spoke to ask the hub on the
 // terminal path; it is tracked separately and called out in hub_session_revocation.go.
-func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
+// sessionCookieDomainForHost returns the cookie Domain attribute for a given
+// request host. Under kubestellar.io (e.g. hive.kubestellar.io, dibs.kubestellar.io)
+// it returns ".kubestellar.io" so sibling first-party products can participate
+// in SSO. For localhost, 127.0.0.1, or other local/dev hosts it returns "" so
+// browsers store a host-only cookie.
+func sessionCookieDomainForHost(host string) string {
+	h := host
+	if strings.Contains(h, ":") {
+		if parsed, _, err := net.SplitHostPort(h); err == nil {
+			h = parsed
+		} else {
+			h = strings.Split(h, ":")[0]
+		}
+	}
+	h = strings.ToLower(strings.TrimSpace(h))
+	if h == "kubestellar.io" || strings.HasSuffix(h, ".kubestellar.io") {
+		return sessionCookieDomain
+	}
+	return ""
+}
+
+// mintSessionCookiesForHost sets the hub session cookie with Domain scoped
+// appropriately for the request host. Under kubestellar.io it scopes to
+// .kubestellar.io; for local/dev hosts it keeps host-only cookies.
+func (s *HubServer) mintSessionCookiesForHost(w http.ResponseWriter, host string, canonicalID string) bool {
 	// ROTATION (master-key-rotation.md, follow-on PR #1): mint under the CURRENT
 	// generation and stamp its ID into the signed claims, so the verifier can
 	// select one key instead of trying each and so telemetry can see which key
@@ -756,42 +788,24 @@ func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
 		return false
 	}
-	// AUDIT F4, DELIBERATELY NOT CHANGED — read before "fixing" this.
+	// AUDIT F4 + #4171:
+	// The session cookie is minted with Domain=.kubestellar.io so that sibling
+	// first-party products (like Dibs at dibs.kubestellar.io) and hosted spoke
+	// dashboards (*.hive.kubestellar.io) can receive it for SSO. Local/dev
+	// hosts keep host-only cookies (Domain="").
 	//
-	// The audit asks for a host-only `__Host-` session cookie. That is correct
-	// in the abstract and NOT safely applicable here, because this cookie is
-	// load-bearing across a trust boundary: it is minted by the hub (Go) and
-	// verified INDEPENDENTLY by every spoke's Node proxy
-	// (src/proxy/server.js — verifyHubUserCookieEither, and the WebSocket
-	// terminal path). The proxy can only verify a cookie the browser actually
-	// sends it, and the browser only sends this one to <id>.hive.kubestellar.io
-	// BECAUSE of the Domain attribute below. Dropping Domain (which __Host-
-	// additionally forbids outright) would stop the cookie reaching any spoke
-	// and log every hosted tenant out of their own dashboard and terminal —
-	// a fleet-wide outage across ~62 hives, and precisely the flag-day auth
-	// change that caused incident #2773.
-	//
-	// The verify-both/mint-new pattern used for the N2 Ed25519 cutover
-	// (hub_cookie.go) does NOT rescue this. That pattern works when both
-	// formats travel the same path and only the VERIFIER must learn a new
-	// shape. Here the change is to the cookie's delivery scope: a host-only
-	// cookie is never transmitted to the spoke at all, so there is no request
-	// in which a spoke could verify it, no matter what it accepts. Making this
-	// safe needs a real design change (e.g. a distinct spoke-scoped session
-	// cookie minted per tenant at SSO handoff), not a rollout trick.
-	//
-	// What this PR does instead is remove the sibling's ability to USE the
-	// cookie it receives: an untrusted tenant can no longer author an accepted
-	// mutation (isSameOriginAsHub) nor read a credentialed CORS response. The
-	// cookie still travels to siblings — a real, ACCEPTED residual risk that a
-	// hostile tenant can read it only if some other bug lets them (it stays
-	// HttpOnly + Secure), which is why the spoke-scoped-session redesign is
-	// tracked as follow-up rather than closed.
+	// Security tradeoff: Widening the cookie scope from .hive.kubestellar.io
+	// to .kubestellar.io exposes the session cookie to sibling first-party
+	// subdomains under kubestellar.io. Sibling hosted tenants on
+	// *.hive.kubestellar.io already received it today; widening to
+	// .kubestellar.io adds sibling first-party products only. The cookie
+	// remains HttpOnly and Secure.
+	domain := sessionCookieDomainForHost(host)
 	cookie := &http.Cookie{
 		Name:     "hive_hub_user",
 		Value:    cookieValue,
 		Path:     "/",
-		Domain:   ".hive.kubestellar.io",
+		Domain:   domain,
 		MaxAge:   86400 * cookieMaxAgeDays,
 		HttpOnly: true,
 		Secure:   true,
@@ -799,6 +813,10 @@ func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string
 	}
 	http.SetCookie(w, cookie)
 	return true
+}
+
+func (s *HubServer) mintSessionCookies(w http.ResponseWriter, canonicalID string) bool {
+	return s.mintSessionCookiesForHost(w, "hive.kubestellar.io", canonicalID)
 }
 
 // oidcNonceFromCookie returns the OIDC replay nonce this browser was issued at
@@ -854,18 +872,22 @@ func (s *HubServer) displayIdentity(identity string) (login, avatarURL string) {
 }
 
 func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
-	cookie, err := r.Cookie("hive_hub_user")
-	if err != nil || cookie.Value == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"authenticated":false}`))
-		return
-	}
 	// Trust the carried username only when its signature verifies; a legacy
 	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
 	// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
 	// F10: also enforces a v3 cookie's signed expiry and revocation state.
-	username, ok := s.verifyHubUserCookie(cookie.Value)
-	if !ok || loadSaaSUser(username) == nil {
+	// #4171: Accept either cookie copy during the domain-widening transition
+	// (browsers may hold both .hive.kubestellar.io and .kubestellar.io).
+	var username string
+	for _, cookie := range r.Cookies() {
+		if cookie.Name == "hive_hub_user" && cookie.Value != "" {
+			if u, ok := s.verifyHubUserCookie(cookie.Value); ok && loadSaaSUser(u) != nil {
+				username = u
+				break
+			}
+		}
+	}
+	if username == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))
 		return
@@ -928,22 +950,39 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	//
 	// The browser's copy is cleared unconditionally regardless, below: a client
 	// with a corrupt or expired cookie must still be able to clear it.
-	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
-		if _, ok := s.verifyHubUserCookie(c.Value); ok {
-			s.revokeHubSessionCookie(c.Value)
-		} else {
-			// Not an error path worth surfacing to the client — an expired or
-			// already-revoked cookie logging out is entirely normal — but it is
-			// worth counting, because a spike is what an enumeration attempt
-			// against this route looks like.
-			s.logger.Debug("logout: unverifiable session cookie, nothing to revoke")
+	// #4171: Revoke all verifiable session cookies presented (in case the browser
+	// holds multiple copies during transition).
+	for _, c := range r.Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			if _, ok := s.verifyHubUserCookie(c.Value); ok {
+				s.revokeHubSessionCookie(c.Value)
+			} else {
+				// Not an error path worth surfacing to the client — an expired or
+				// already-revoked cookie logging out is entirely normal — but it is
+				// worth counting, because a spike is what an enumeration attempt
+				// against this route looks like.
+				s.logger.Debug("logout: unverifiable session cookie, nothing to revoke")
+			}
 		}
 	}
+
+	// #4171: Clear both the new domain (.kubestellar.io) and the legacy domain
+	// (.hive.kubestellar.io) so that pre-existing and new sessions are cleared.
 	http.SetCookie(w, &http.Cookie{
 		Name:     "hive_hub_user",
 		Value:    "",
 		Path:     "/",
-		Domain:   ".hive.kubestellar.io",
+		Domain:   sessionCookieDomain,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     "hive_hub_user",
+		Value:    "",
+		Path:     "/",
+		Domain:   legacySessionCookieDomain,
 		MaxAge:   -1,
 		HttpOnly: true,
 		Secure:   true,

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -497,6 +497,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/upgrade-pause", s.requireAdmin(s.handleGetUpgradePause))
 	s.mux.HandleFunc("POST /api/saas/upgrade-pause", s.requireAdmin(s.handleSetUpgradePause))
 	s.mux.HandleFunc("GET /api/saas/auth-check", s.handleSaaSAuthCheck)
+	s.mux.HandleFunc("GET /api/saas/whoami", s.handleWhoami)
 	s.mux.HandleFunc("POST /api/saas/user-token", s.requireAuth(s.handleUserToken))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/access", s.requireAuth(s.handleAccessList))
 	s.mux.HandleFunc("GET /api/saas/grantable-users", s.requireAuth(s.handleGrantableUsers))
@@ -766,8 +767,10 @@ func isNonBrowserAPIRequest(r *http.Request) bool {
 	// presence, not by validity: an INVALID cookie still means a browser sent
 	// one, and letting a bogus cookie value re-enable the bearer bypass would be
 	// a trivially attacker-satisfiable condition.
-	if c, err := r.Cookie("hive_hub_user"); err == nil && c.Value != "" {
-		return false
+	for _, c := range r.Cookies() {
+		if c.Name == "hive_hub_user" && c.Value != "" {
+			return false
+		}
 	}
 	return true
 }
@@ -855,18 +858,21 @@ func originHost(raw string) (string, bool) {
 // resolveIdentity — never inside it — so the write-block and the admin gate can
 // always reason about who is really driving the request.
 func (s *HubServer) getRealAuthUser(r *http.Request) string {
-	cookie, err := r.Cookie("hive_hub_user")
-	if err == nil && cookie.Value != "" {
-		// The cookie value is only trusted when its HMAC signature verifies
-		// against the hub secret. A legacy unsigned cookie or a forged value
-		// fails here and is treated as logged out, so the user re-authenticates
-		// through the normal login flow (which re-mints a signed cookie).
-		// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
-		// F10: verifyHubUserCookie additionally enforces a v3 cookie's SIGNED
-		// expiry and its revocation state, which MaxAge alone never did.
-		if username, ok := s.verifyHubUserCookie(cookie.Value); ok {
-			if loadSaaSUser(username) != nil {
-				return username
+	// The cookie value is only trusted when its signature verifies against
+	// the hub secret. A legacy unsigned cookie or a forged value fails here
+	// and is treated as logged out, so the user re-authenticates through the
+	// normal login flow (which re-mints a signed cookie).
+	// N2: accept v2 (Ed25519) or, during rollout only, the legacy HMAC format.
+	// F10: verifyHubUserCookie additionally enforces a v3 cookie's SIGNED
+	// expiry and its revocation state, which MaxAge alone never did.
+	// #4171: Accept either cookie copy during transition (browsers may hold both
+	// .hive.kubestellar.io and .kubestellar.io).
+	for _, cookie := range r.Cookies() {
+		if cookie.Name == "hive_hub_user" && cookie.Value != "" {
+			if username, ok := s.verifyHubUserCookie(cookie.Value); ok {
+				if loadSaaSUser(username) != nil {
+					return username
+				}
 			}
 		}
 	}
@@ -8546,6 +8552,69 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 }
 
+type whoamiResponse struct {
+	Username    string `json:"username"`
+	DisplayName string `json:"display_name"`
+	Email       string `json:"email"`
+	AvatarURL   string `json:"avatar_url"`
+}
+
+// handleWhoami serves GET /api/saas/whoami. Sibling first-party products (like
+// Dibs at dibs.kubestellar.io) call this endpoint with the ambient hive_hub_user
+// session cookie to resolve the authenticated user's stable identity key and profile.
+func (s *HubServer) handleWhoami(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	username := s.getRealAuthUser(r)
+	if username == "" {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	u := loadSaaSUser(username)
+	if u == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	provider, subject, _ := parseCanonical(canonicalizeLegacy(username))
+	var stableKey string
+	if provider == legacyProvider {
+		stableKey = subject
+	} else {
+		stableKey = canonicalizeLegacy(username)
+	}
+
+	displayName := u.DisplayName
+	if displayName == "" && u.FullName != "" {
+		displayName = u.FullName
+	}
+
+	avatarURL := u.AvatarURL
+	if avatarURL == "" && provider == legacyProvider {
+		avatarURL = fmt.Sprintf("https://github.com/%s.png", subject)
+	}
+
+	resp := whoamiResponse{
+		Username:    stableKey,
+		DisplayName: displayName,
+		Email:       u.Email,
+		AvatarURL:   avatarURL,
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
 func isUnfurlBot(ua string) bool {
 	bots := []string{"Slackbot", "Slack-ImgProxy", "Discordbot", "Twitterbot", "facebookexternalhit", "LinkedInBot", "WhatsApp", "TelegramBot"}
 	for _, b := range bots {
@@ -8573,8 +8642,14 @@ func (s *HubServer) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(ogFallbackHTML))
 		return
 	}
-	cookie, err := r.Cookie("hive_hub_user")
-	if err != nil || cookie.Value == "" {
+	var hasCookie bool
+	for _, cookie := range r.Cookies() {
+		if cookie.Name == "hive_hub_user" && cookie.Value != "" {
+			hasCookie = true
+			break
+		}
+	}
+	if !hasCookie {
 		http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
 		return
 	}

--- a/src/pkg/hub/static/openapi.yaml
+++ b/src/pkg/hub/static/openapi.yaml
@@ -116,6 +116,50 @@ paths:
       summary: Logout
       description: Clears the authentication cookie.
 
+  /api/saas/whoami:
+    get:
+      tags: [Auth]
+      summary: Whoami identity info
+      description: Resolves the authenticated user's stable identity key and profile from session cookie.
+      security:
+        - cookieAuth: []
+      responses:
+        '200':
+          description: Authenticated user identity and profile
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                example: no-store
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  username:
+                    type: string
+                    description: Stable identity key (bare GitHub login or provider:sub)
+                  display_name:
+                    type: string
+                  email:
+                    type: string
+                  avatar_url:
+                    type: string
+        '401':
+          description: Unauthenticated
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                example: no-store
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+
   /api/saas/my-hives:
     get:
       tags: [Dashboard]


### PR DESCRIPTION
## Summary

Addresses #4171: allows sibling products (such as Dibs at `dibs.kubestellar.io`) to participate in single sign-on with Hive Hub (`hive.kubestellar.io`).

### Key Changes

1. **Session Cookie Domain Scoping**:
   - Updates `mintSessionCookiesForHost` to mint `hive_hub_user` with `Domain=.kubestellar.io` when the request host is under `kubestellar.io` (e.g. `hive.kubestellar.io`, `dibs.kubestellar.io`, `*.hive.kubestellar.io`).
   - Keeps host-only cookies (`Domain=""`) for localhost/dev environments.
   - Updates `handleLogout` to clear both the new `.kubestellar.io` domain and legacy `.hive.kubestellar.io` domain with `MaxAge: -1`.
   - Accepts either cookie copy during rollout transition across `getRealAuthUser`, `handleAuthUser`, `handleDashboard`, and `isNonBrowserAPIRequest`.

2. **`GET /api/saas/whoami` Endpoint**:
   - Implements `GET /api/saas/whoami` (`Cache-Control: no-store`, `Content-Type: application/json`, GET only).
   - Returns 200 with `{"username", "display_name", "email", "avatar_url"}` for verified sessions.
   - Returns stable identity key for `username` (bare GitHub login for GitHub users, canonical `provider:sub` for OIDC users).
   - Populates `display_name`, `email`, and `avatar_url` from the enriched `SaaSUser` record (with fallback to derived GitHub avatar for GitHub users).
   - Returns 401 for unauthenticated or forged requests and 405 for non-GET methods.

3. **Documentation & Specs**:
   - Updates `src/pkg/hub/static/openapi.yaml` and `src/docs/api-reference.md`.
   - Documents security tradeoffs in `oauth.go`.

4. **Testing**:
   - Adds unit and regression tests in `src/pkg/hub/dibs_sso_whoami_test.go` covering host domain scoping, dual-cookie transition acceptance, logout multi-domain clearing, and `/api/saas/whoami` endpoint behavior.

Fixes #4171

— hive: backend=agy

---
Gemini 3.7 flash high reasoning