### PR TITLE
✨ feat(contribute): tell contributor agents to sign off their commits

### DIFF
--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -3893,6 +3893,16 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 			"from a prior task, 'cd' into it and 'git fetch' instead of "+
 			"re-forking). Then 'cd' into that checkout, read the issue, "+
 			"understand what's needed, and take action. "+
+			// DCO is enforced on this repo (CONTRIBUTING.md) and an unsigned
+			// commit blocks the merge, but the prompt used to leave sign-off
+			// entirely to whatever each agent inferred from the repo. That
+			// varies even within one backend: two agy tasks produced one
+			// unsigned PR (#4127, fixed by hand) and one signed (#4176). Every
+			// other required step here is spelled out; this one was the
+			// exception, so say it.
+			"Commit with 'git commit -s' so every commit carries a Signed-off-by "+
+			"trailer — the DCO check blocks the merge without it, and the trailer's "+
+			"email must match the commit author's email. "+
 			"Push your branch to your fork remote, then open a PR from your fork. "+
 			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN'). "+
 			// #3987: the no_work_needed sentinel. The relay scrapes this exact

--- a/src/pkg/dashboard/contribute_ws_ops_ext_test.go
+++ b/src/pkg/dashboard/contribute_ws_ops_ext_test.go
@@ -254,3 +254,26 @@ func TestFleetSnapshot_LabelInterestsOmittedWhenEmpty(t *testing.T) {
 		t.Fatalf("label_interests should be omitted when empty: %s", raw)
 	}
 }
+
+// TestBuildTaskPrompt_InstructsDCOSignoff: DCO is enforced on this repo
+// (CONTRIBUTING.md) and an unsigned commit blocks the merge, but the prompt
+// used to leave sign-off entirely to whatever each agent inferred. That varies
+// even within one backend — two agy tasks produced one unsigned PR (#4127) and
+// one signed (#4176). Every other required step is spelled out in the prompt;
+// this pins that sign-off is too.
+func TestBuildTaskPrompt_InstructsDCOSignoff(t *testing.T) {
+	prompt := buildTaskPrompt("myorg/repo1", 101, "Actionable issue")
+
+	if !strings.Contains(prompt, "git commit -s") {
+		t.Errorf("prompt must tell the agent to commit with -s; got: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Signed-off-by") {
+		t.Errorf("prompt must name the Signed-off-by trailer; got: %q", prompt)
+	}
+	// The DCO bot compares the trailer's email to the commit author's, so a
+	// prompt that omits that turns a passing-looking sign-off into a failing
+	// check the contributor has to debug.
+	if !strings.Contains(prompt, "author") {
+		t.Errorf("prompt must state the trailer email matches the author; got: %q", prompt)
+	}
+}


### PR DESCRIPTION
## Problem

DCO is enforced on this repo — `CONTRIBUTING.md` requires a `Signed-off-by:` trailer on every commit, and the check blocks the merge without it.

`buildTaskPrompt` never mentions it.

The prompt already spells out every other required step: fork, clone into `$HIVE_WORKSPACE_DIR`, reuse an existing clone, read the issue, push to the fork remote, open a PR, use `GH_TOKEN` for `gh`, and the exact `HIVE_VERDICT: no_work_needed` sentinel. Sign-off is the one merge-gating step left entirely to whatever each agent infers from the repo.

## Why inference isn't good enough

It varies **within a single backend**. Two agy tasks against this repo:

| PR | Signed off? |
|---|---|
| #4127 | ❌ no trailer — amended and force-pushed by hand afterwards |
| #4176 | ✅ trailer present |

Same backend, same prompt, different outcomes. The contributor's experience is a red DCO check on work the agent already finished, then an amend and force-push to fix it.

I am not claiming a reliable per-backend pattern — I could not measure one; only three merged PRs carry the `— hive: backend=` marker and the sample proves nothing either way. The argument here doesn't need one: a merge-gating requirement should be stated, not inferred.

## Change

Adds to the prompt, alongside the other required steps:

> Commit with `git commit -s` so every commit carries a Signed-off-by trailer — the DCO check blocks the merge without it, and the trailer's email must match the commit author's email.

The email clause is deliberate. The DCO bot compares the trailer address to the commit author's, so a sign-off that *looks* right but uses a different address still fails, and is slower to debug than a missing one.

## Tests

New `TestBuildTaskPrompt_InstructsDCOSignoff` asserts the prompt names `git commit -s`, the `Signed-off-by` trailer, and the author-email requirement. Reverting only `contribute_ws.go` fails all three assertions:

```
--- FAIL: TestBuildTaskPrompt_InstructsDCOSignoff
    prompt must tell the agent to commit with -s
    prompt must name the Signed-off-by trailer
    prompt must state the trailer email matches the author
```

`go build ./...` clean; `pkg/dashboard` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)