### PR TITLE
📖 docs: update Docker Compose quick start for v4 layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 /config/agent.env
 examples/kubestellar/agents/agent.env
 
+# Environment variables / credentials
+.env
+.env.*
+*.env
+
 # Beads ledger — runtime state, not source code
 .beads/
 node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,13 @@ Thank you for helping improve KubeStellar Hive. This guide is for contributing c
 
 ## Branches
 
-Use `v2` as the base branch for Hive v2 work and PRs unless a maintainer asks otherwise. The `main` branch is not the active target for v2 changes. The `v4` branch is a separate forward-looking/synchronization line; do not target it for ordinary v2 fixes.
+Use `v4` as the base branch for Hive work and PRs unless a maintainer asks otherwise. The `main` branch is not the active target for changes.
 
 Before starting work:
 
 ```bash
 git fetch origin
-git switch -c <topic-branch> origin/v2
+git switch -c <topic-branch> origin/v4
 ```
 
 ## Local development
@@ -44,7 +44,7 @@ git switch -c <topic-branch> origin/v2
 See [docs/development.md](docs/development.md) for the full local setup guide. The short path is:
 
 ```bash
-cd v2
+cd src
 go build ./...
 go test ./...
 ```

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Hive separates decisions into two layers: a **deterministic pipeline** of shell 
 - `git`, and a GitHub token (PAT or App) for the org you want the hive to work on
 
 ```bash
-git clone -b v2 https://github.com/kubestellar/hive.git
-cd hive/v2
+git clone https://github.com/kubestellar/hive.git
+cd hive
 
-cp hive.yaml.example hive.yaml
-export HIVE_GITHUB_TOKEN=ghp_...
-docker compose up -d
+cp src/hive.yaml.example src/hive.yaml
+echo "HIVE_GITHUB_TOKEN=ghp_..." > .env
+docker compose -f src/docker-compose.yaml up -d
 ```
 
 Dashboard at `http://localhost:3001`.
@@ -28,8 +28,8 @@ The pre-built image tag is documented in [src/docs/operator-reference.md#image-p
 To build from source instead of pulling the pre-built image:
 
 ```bash
-docker compose build
-docker compose up -d
+docker compose -f src/docker-compose.yaml build
+docker compose -f src/docker-compose.yaml up -d
 ```
 
 ## Kubernetes Deployment
@@ -303,7 +303,7 @@ running on your own machine:
 
 ```bash
 brew install just gh
-git clone -b v2 https://github.com/kubestellar/hive && cd hive
+git clone https://github.com/kubestellar/hive && cd hive
 just contribute-setup claude
 just contribute-hive
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Local development
 
-This guide describes the local workflow for contributing to the Hive Go codebase on the `v2` branch.
+This guide describes the local workflow for contributing to the Hive Go codebase on the `v4` branch.
 
 ## Prerequisites
 
@@ -14,26 +14,26 @@ This guide describes the local workflow for contributing to the Hive Go codebase
 ## Clone and branch
 
 ```bash
-git clone -b v2 https://github.com/kubestellar/hive.git
+git clone https://github.com/kubestellar/hive.git
 cd hive
-git switch -c <topic-branch> origin/v2
+git switch -c <topic-branch> origin/v4
 ```
 
-Use `v2` as the PR base for ordinary Hive development. Rebase or recreate your branch from a fresh `origin/v2` before opening or updating a PR.
+Use `v4` as the PR base for ordinary Hive development. Rebase or recreate your branch from a fresh `origin/v4` before opening or updating a PR.
 
 ## Build
 
 Build every package in the Go module:
 
 ```bash
-cd v2
+cd src
 go build ./...
 ```
 
 To build only the main Hive binary during quick iteration:
 
 ```bash
-cd v2
+cd src
 go build ./cmd/hive
 ```
 
@@ -42,7 +42,7 @@ go build ./cmd/hive
 Run the module tests from `src/`:
 
 ```bash
-cd v2
+cd src
 go test ./...
 ```
 
@@ -51,7 +51,7 @@ The `src/test/` package contains integration/regression coverage and may exercis
 Useful narrower loops:
 
 ```bash
-cd v2
+cd src
 go test ./pkg/...
 go test ./cmd/hive
 ```
@@ -64,10 +64,10 @@ Run `gofmt` on Go files you edit:
 gofmt -w path/to/file.go
 ```
 
-The v2 CI workflow runs `go vet ./...` after building the Hive binary. Reproduce that check locally from the Go module:
+The v4 CI workflow runs `go vet ./...` after building the Hive binary. Reproduce that check locally from the Go module:
 
 ```bash
-cd v2
+cd src
 go vet ./...
 ```
 
@@ -78,13 +78,12 @@ There is no public `just lint` recipe in the current root `Justfile`; use `go ve
 The quickest operator path remains Docker Compose from the root README:
 
 ```bash
-cd v2
-cp hive.yaml.example hive.yaml
-export HIVE_GITHUB_TOKEN=ghp_...
-docker compose up -d
+cp src/hive.yaml.example src/hive.yaml
+echo "HIVE_GITHUB_TOKEN=ghp_..." > .env
+docker compose -f src/docker-compose.yaml up -d
 ```
 
-For source-level debugging, build with `go build ./cmd/hive` and run the generated binary with a local `hive.yaml`. Keep real tokens in your shell or local ignored files, never in commits.
+For source-level debugging, build with `go build ./cmd/hive` from `src/` and run the generated binary with a local `src/hive.yaml`. Keep real tokens in your shell or local ignored `.env` files, never in commits.
 
 ## Just recipes
 
@@ -107,7 +106,7 @@ Deployment and development tasks that are not listed by `just --list` are not pu
 
 ## Before opening a PR
 
-1. Rebase on the latest `origin/v2`.
+1. Rebase on the latest `origin/v4`.
 2. Run the build and tests that match your change.
 3. Commit with DCO sign-off: `git commit -s`.
-4. Open a PR against `v2` with an emoji-prefixed title, testing notes, and `Fixes #...` lines for closing issues.
+4. Open a PR against `v4` with an emoji-prefixed title, testing notes, and `Fixes #...` lines for closing issues.

--- a/docs/getting-started-contributing.md
+++ b/docs/getting-started-contributing.md
@@ -21,16 +21,15 @@ build/test commands, see [`docs/development.md`](development.md).
 For most changes you do **not** need a cluster.
 
 - **Go code:** you need Go (see [`docs/development.md`](development.md) for the
-  version and `make`/`just` targets). `cd v2 && go build ./...` compiles the
+  version and `make`/`just` targets). `cd src && go build ./...` compiles the
   binary; that's enough to iterate on most code.
 - **Docs:** no toolchain needed — edit Markdown and preview locally.
 - **Running the whole thing:** the fastest full run is Docker Compose from the
-  repo's [Quick Start](../README.md#quick-start-docker-compose) (`cd v2 &&
-  docker compose up -d`). You only need Kubernetes for deployment-specific work.
+  repo's [Quick Start](../README.md#quick-start-docker-compose) (`docker compose -f src/docker-compose.yaml up -d`). You only need Kubernetes for deployment-specific work.
 
 ## 3. Test a change without a cluster
 
-- **Go:** `cd v2 && go test ./...` runs the unit suite. Most tests are
+- **Go:** `cd src && go test ./...` runs the unit suite. Most tests are
   hermetic; a few need env like `kubectl` and are skipped otherwise. See the
   Test section of [`docs/development.md`](development.md).
 - **Shell scripts:** `*.test.sh` / `*.test.js` files under
@@ -68,7 +67,7 @@ contribution:
 
 ## 6. Review and CI: what to expect
 
-- Open your PR against the **`v2`** branch (the active development branch).
+- Open your PR against the **`v4`** branch (the active development branch).
 - CI runs build, tests, a coverage check, and container image builds. Some
   checks (Playwright, `tide`) are non-blocking. The **required** checks are the
   build/test/coverage/docker ones.

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,6 +1,8 @@
 /hive
 *.exe
 hive.yaml
+.env
+.env.*
 secrets/
 src/coverage.out
 /bin/

--- a/src/README.md
+++ b/src/README.md
@@ -7,14 +7,14 @@ AI agent orchestrator for GitHub repositories. A single Go binary that enumerate
 ### Option A: Pre-built image (recommended)
 
 ```bash
-git clone -b v2 https://github.com/kubestellar/hive.git
-cd hive/v2
+git clone https://github.com/kubestellar/hive.git
+cd hive
 
-cp hive.yaml.example hive.yaml
-# Edit hive.yaml — set your org, repos, and agent config
+cp src/hive.yaml.example src/hive.yaml
+# Edit src/hive.yaml — set your org, repos, and agent config
 
-export HIVE_GITHUB_TOKEN=ghp_...
-docker compose up -d
+echo "HIVE_GITHUB_TOKEN=ghp_..." > .env
+docker compose -f src/docker-compose.yaml up -d
 
 # Dashboard at http://localhost:3001
 ```
@@ -22,29 +22,29 @@ docker compose up -d
 ### Option B: Build from source
 
 ```bash
-git clone -b v2 https://github.com/kubestellar/hive.git
-cd hive/v2
+git clone https://github.com/kubestellar/hive.git
+cd hive
 
-cp hive.yaml.example hive.yaml
-# Edit hive.yaml — set your org, repos, and agent config
+cp src/hive.yaml.example src/hive.yaml
+# Edit src/hive.yaml — set your org, repos, and agent config
 
-export HIVE_GITHUB_TOKEN=ghp_...
-docker compose build
-docker compose up -d
+echo "HIVE_GITHUB_TOKEN=ghp_..." > .env
+docker compose -f src/docker-compose.yaml build
+docker compose -f src/docker-compose.yaml up -d
 ```
 
 ### Pre-built image
 
-The default `docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`. To build from source instead, run `docker compose build` before `docker compose up -d`.
+The default `src/docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`. To build from source instead, run `docker compose -f src/docker-compose.yaml build` before `docker compose -f src/docker-compose.yaml up -d`.
 
 For tag provenance, digest pinning, and the release/tagging flow, see [docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest](docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest).
 
 ### Troubleshooting
 
 - **Rancher Desktop / Lima**: Volume mounts from `/tmp` may fail silently (file appears as directory inside container). Clone the repo under your home directory instead.
-- **Gateway won't start**: The gateway depends on the hive health check (120s start period). If it times out, run the hive container directly: `docker run -d --name hive --cap-add NET_ADMIN -p 3001:3001 -v ./hive.yaml:/etc/hive/hive.yaml -e HIVE_GITHUB_TOKEN=$HIVE_GITHUB_TOKEN ghcr.io/kubestellar/hive:v2-latest` (the `--cap-add NET_ADMIN` enables the full forced-proxy-egress gate — see below).
+- **Gateway won't start**: The gateway depends on the hive health check (120s start period). If it times out, run the hive container directly: `docker run -d --name hive --cap-add NET_ADMIN -p 3001:3001 -v ./src/hive.yaml:/etc/hive/hive.yaml -e HIVE_GITHUB_TOKEN=$HIVE_GITHUB_TOKEN ghcr.io/kubestellar/hive:v2-latest` (the `--cap-add NET_ADMIN` enables the full forced-proxy-egress gate — see below).
 - **Forced-proxy-egress gate is degraded / `SO_MARK unavailable` in logs**: the container runs fine without `NET_ADMIN`, but the proxy's SO_MARK self-exemption needs it. Grant `NET_ADMIN` (`--cap-add NET_ADMIN` for docker/podman, `securityContext.capabilities.add: ["NET_ADMIN"]` for Kubernetes) for the full egress gate; without it the spoke stays in best-effort/degraded egress mode. See [docs/net-admin-requirement.md](docs/net-admin-requirement.md).
-- **Policy clone errors in logs**: The example config has a placeholder policy repo. Comment out the `policies:` section in `hive.yaml` if you don't have a custom policy repo.
+- **Policy clone errors in logs**: The example config has a placeholder policy repo. Comment out the `policies:` section in `src/hive.yaml` if you don't have a custom policy repo.
 
 ## Command-line client
 
@@ -76,7 +76,7 @@ See [docs/README.md](docs/README.md) for the full v2 documentation index, includ
 kubectl apply -f deploy/k8s/namespace.yaml
 kubectl -n hive create secret generic hive-secrets \
   --from-literal=HIVE_GITHUB_TOKEN=ghp_...
-kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
+kubectl create configmap hive-config -n hive --from-file=hive.yaml=src/hive.yaml
 kubectl apply -f deploy/k8s/pvc.yaml
 kubectl apply -f deploy/k8s/deployment.yaml
 kubectl apply -f deploy/k8s/service.yaml
@@ -89,7 +89,7 @@ hub-fronted URL probing, and alert hysteresis.
 
 ## Configuration
 
-All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `hive.yaml.example` for the commented example, [docs/operator-reference.md](docs/operator-reference.md) for operator-only knobs, token scopes, and image provenance, [docs/config-layering.md](docs/config-layering.md) for runtime precedence/provenance, [docs/agent-configuration.md](docs/agent-configuration.md) for agent fields and ACMM packs, [AGENT-DEFINITION.md](AGENT-DEFINITION.md) for the portable agent YAML format, [../docs/backend-setup.md](../docs/backend-setup.md) for CLI backend setup, and [../docs/migration-v1-v2.md](../docs/migration-v1-v2.md) for migration from v1.
+All config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See `src/hive.yaml.example` for the commented example, [docs/operator-reference.md](docs/operator-reference.md) for operator-only knobs, token scopes, and image provenance, [docs/config-layering.md](docs/config-layering.md) for runtime precedence/provenance, [docs/agent-configuration.md](docs/agent-configuration.md) for agent fields and ACMM packs, [AGENT-DEFINITION.md](AGENT-DEFINITION.md) for the portable agent YAML format, [../docs/backend-setup.md](../docs/backend-setup.md) for CLI backend setup, and [../docs/migration-v1-v2.md](../docs/migration-v1-v2.md) for migration from v1.
 
 ```yaml
 project:

--- a/src/docs/backup-restore.md
+++ b/src/docs/backup-restore.md
@@ -142,19 +142,19 @@ The archive contains the spoke config files (`hive.yaml.dashboard`, `hive.yaml.r
 Back up the named volume and the secrets directory from the host:
 
 ```bash
-docker run --rm -v v2_hive-data:/data -v "$(pwd)":/backup alpine tar czf /backup/hive-data-$(date +%F).tar.gz -C /data .
-tar czf secrets-$(date +%F).tar.gz ./secrets
+docker run --rm -v src_hive-data:/data -v "$(pwd)":/backup alpine tar czf /backup/hive-data-$(date +%F).tar.gz -C /data .
+tar czf secrets-$(date +%F).tar.gz ./src/secrets
 ```
 
-Docker Compose prefixes named volumes with the project name. With `cd v2 && docker compose up -d`, the project is `v2`, so the volume is `v2_hive-data`. `docker volume ls` shows the real name.
+Docker Compose prefixes named volumes with the project name. When running `docker compose -f src/docker-compose.yaml up -d`, the volume is `src_hive-data`. `docker volume ls` shows the real name.
 
 To restore:
 
-1. Create a fresh named volume with `docker volume create v2_hive-data`. `docker compose up -d` also creates it when it is missing.
+1. Create a fresh named volume with `docker volume create src_hive-data`. `docker compose -f src/docker-compose.yaml up -d` also creates it when it is missing.
 2. Extract the volume tarball into the volume:
 
    ```bash
-   docker run --rm -v v2_hive-data:/data -v "$(pwd)":/backup alpine tar xzf /backup/hive-data-$(date +%F).tar.gz -C /data
+   docker run --rm -v src_hive-data:/data -v "$(pwd)":/backup alpine tar xzf /backup/hive-data-$(date +%F).tar.gz -C /data
    ```
 
    Use the archive name from the backup step. The example recreates the current-date name.
@@ -165,7 +165,7 @@ To restore:
    tar xzf secrets-$(date +%F).tar.gz
    ```
 
-4. Run `docker compose up -d`.
+4. Run `docker compose -f src/docker-compose.yaml up -d`.
 
 The entrypoint restores the runtime config at boot. Escrow the backup encryption key outside the host — the dashboard-set key lives on the `hive-data` volume, so losing the volume loses both the backups' key and the data it protects.
 

--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -9,10 +9,9 @@ Start most investigations from the dashboard and the service logs, then drop to 
 Docker Compose deployments define `hive` and `gateway` services in `src/docker-compose.yaml`. The Hive process healthcheck calls `http://127.0.0.1:3002/api/health`; the gateway publishes `3001` and proxies to Hive. Start with:
 
 ```bash
-cd v2
-docker compose ps
-docker compose logs hive --tail=200
-docker compose logs gateway --tail=100
+docker compose -f src/docker-compose.yaml ps
+docker compose -f src/docker-compose.yaml logs hive --tail=200
+docker compose -f src/docker-compose.yaml logs gateway --tail=100
 ```
 
 Kubernetes deployments use namespace `hive`, Deployment `hive`, Service `hive`, and probes on `/api/health` and `/api/livez` in `src/deploy/k8s/deployment.yaml`:
@@ -158,8 +157,8 @@ There is no `uninstall.sh`/`install.sh` on the containerized runtime. To start f
 
 ```bash
 # Docker Compose (deletes the named /data volume — see Backup & restore first)
-docker compose down -v
-docker compose up -d
+docker compose -f src/docker-compose.yaml down -v
+docker compose -f src/docker-compose.yaml up -d
 
 # Kubernetes (deletes the PVC-backed state)
 kubectl -n hive delete deploy/hive

--- a/src/pkg/hub/static/get-started.html
+++ b/src/pkg/hub/static/get-started.html
@@ -450,14 +450,14 @@
       <p>Run Hive v2 on your own machine with Docker Compose. Your agents, your repos, your infrastructure.</p>
     </div>
     <div class="alt-card">
-      <pre><code>git clone -b v4 https://github.com/kubestellar/hive.git
-cd hive/v2
+      <pre><code>git clone https://github.com/kubestellar/hive.git
+cd hive
 
-cp hive.yaml.example hive.yaml
-# Edit hive.yaml: set your org, repos, and GitHub token
+cp src/hive.yaml.example src/hive.yaml
+# Edit src/hive.yaml: set your org, repos, and GitHub token
 
-export HIVE_GITHUB_TOKEN=ghp_your_token_here
-docker compose up -d
+echo "HIVE_GITHUB_TOKEN=ghp_your_token_here" > .env
+docker compose -f src/docker-compose.yaml up -d
 
 # Open the dashboard
 open http://localhost:3001</code></pre>


### PR DESCRIPTION
## Summary

Updates Docker Compose quick start instructions and configuration references across documentation to reflect the v4 repository layout (#4179):

- Updates Compose commands to reference `src/docker-compose.yaml` (using `docker compose -f src/docker-compose.yaml up -d` / `build`) for both pre-built image and source-build workflows.
- Updates configuration paths from `hive.yaml.example` to `src/hive.yaml.example` and `src/hive.yaml`.
- Replaces inline token exports in Quick Start examples with passing `HIVE_GITHUB_TOKEN` through a local ignored `.env` file (`echo "HIVE_GITHUB_TOKEN=ghp_..." > .env`).
- Adds `.env`, `.env.*`, and `*.env` ignore patterns to root `.gitignore` and `src/.gitignore`.
- Updates development and contribution documentation (`docs/development.md`, `docs/getting-started-contributing.md`, `CONTRIBUTING.md`) to reflect `v4` as the active development branch and `src/` as the Go module directory.
- Updates troubleshooting and backup/restore guides to reference `src/docker-compose.yaml` and `src_hive-data` volume naming.

Fixes #4179

---
Gemini 3.7 flash high reasoning

— hive: backend=agy