### PR TITLE
✨ feat(worksource): WorkSource interface, TaskKey helper, and default GitHub Issues adapter

### DIFF
--- a/src/pkg/worksource/github_issues.go
+++ b/src/pkg/worksource/github_issues.go
@@ -1,0 +1,52 @@
+package worksource
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+// githubIssuesSource is the default WorkSource: it delegates to the existing
+// github.Client.EnumerateActionable, which handles hold labels, issue filters,
+// SLA tracking, and PR exclusion. Zero config change for existing hives.
+type githubIssuesSource struct {
+	client *github.Client
+}
+
+// NewGitHubIssuesSource builds a WorkSource backed by the existing GitHub
+// Issues enumeration.
+func NewGitHubIssuesSource(client *github.Client) WorkSource {
+	return &githubIssuesSource{client: client}
+}
+
+func (s *githubIssuesSource) SourceType() string { return "github" }
+
+func (s *githubIssuesSource) ListIssues(ctx context.Context) ([]Issue, error) {
+	res, err := s.client.EnumerateActionable(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("worksource/github: enumerate: %w", err)
+	}
+	if res == nil {
+		return nil, nil
+	}
+	out := make([]Issue, 0, len(res.Issues.Items))
+	for _, it := range res.Issues.Items {
+		out = append(out, Issue{
+			SourceType: "github",
+			Repo:       it.Repo,
+			ExternalID: strconv.Itoa(it.Number),
+			Number:     it.Number,
+			Title:      it.Title,
+			Author:     it.Author,
+			Labels:     it.Labels,
+			Assignees:  it.Assignees,
+			State:      "open",
+			CreatedAt:  it.CreatedAt,
+			UpdatedAt:  it.UpdatedAt,
+			URL:        it.URL,
+		})
+	}
+	return out, nil
+}

--- a/src/pkg/worksource/worksource.go
+++ b/src/pkg/worksource/worksource.go
@@ -1,0 +1,78 @@
+// Package worksource defines the WorkSource interface — the Step 01 seam in
+// hive's "Issue Filed → fix → merge" loop. A WorkSource enumerates actionable
+// work items from an external planning tool (GitHub Issues, GitHub Projects,
+// Linear, Jira). Steps 03–07 (fix agent, PR, review, merge) are source-agnostic
+// and unchanged.
+package worksource
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Issue is a source-neutral work item. Fields absent on a given source are left
+// at their zero value.
+type Issue struct {
+	// SourceType identifies which work source produced this item
+	// ("github", "github_projects", "linear", "jira").
+	SourceType string `json:"source_type"`
+	// Repo is the GitHub repo (owner/name) agents should clone and open PRs
+	// against for this issue.
+	Repo string `json:"repo"`
+	// ExternalID is the source-native identifier. For GitHub: "42". For Linear:
+	// "ENG-123". For Jira: "ENG-42". Never empty.
+	ExternalID string `json:"external_id"`
+	// Number is the integer issue number when the source uses numeric IDs
+	// (GitHub). Zero for sources with string identifiers (Linear, Jira).
+	Number int `json:"number,omitempty"`
+	// Title is the issue title / summary.
+	Title string `json:"title"`
+	// Author is the login/username of who filed the issue.
+	Author string `json:"author"`
+	// Labels are the issue labels / tags.
+	Labels []string `json:"labels,omitempty"`
+	// Assignees are the logins/usernames currently assigned.
+	Assignees []string `json:"assignees,omitempty"`
+	// Priority is a normalized priority string: "urgent", "high", "medium",
+	// "low", "none". Empty when the source does not provide priority.
+	Priority string `json:"priority,omitempty"`
+	// State is the issue state string from the source ("open", "Todo", etc.).
+	State string `json:"state"`
+	// CreatedAt is when the issue was filed.
+	CreatedAt time.Time `json:"created_at"`
+	// UpdatedAt is the last-activity timestamp. Zero when unknown.
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// URL is the canonical web URL of the issue.
+	URL string `json:"url"`
+}
+
+// TaskKey returns a collision-free identity key for task admission, claim
+// ledger, and contributor-relay active-task tracking.
+//
+// For GitHub issues it produces "repo#number" (e.g. "my-org/my-repo#42"),
+// preserving backward compatibility with the 30 sites that used
+// fmt.Sprintf("%s#%d", repo, num) directly.
+//
+// For string-keyed sources (Linear, Jira) it produces "repo!externalID"
+// (e.g. "my-org/my-repo!ENG-123"). The "!" separator is chosen because it
+// cannot appear in a GitHub issue number or a Linear/Jira key, so keys from
+// different sources never collide even if two teams share an integer.
+func TaskKey(issue Issue) string {
+	if issue.Number > 0 {
+		return fmt.Sprintf("%s#%d", issue.Repo, issue.Number)
+	}
+	return fmt.Sprintf("%s!%s", issue.Repo, issue.ExternalID)
+}
+
+// WorkSource is the Step 01 abstraction: it enumerates actionable work items
+// from an external planning tool. The returned slice contains only open /
+// actionable items — filtering by state, label, hold, etc. is the adapter's
+// responsibility.
+type WorkSource interface {
+	// SourceType returns the kind string ("github", "github_projects", "linear",
+	// "jira") for use in dashboard badges and log fields.
+	SourceType() string
+	// ListIssues returns the current actionable work items.
+	ListIssues(ctx context.Context) ([]Issue, error)
+}

--- a/src/pkg/worksource/worksource_test.go
+++ b/src/pkg/worksource/worksource_test.go
@@ -1,0 +1,56 @@
+package worksource_test
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+func TestTaskKey_GitHub(t *testing.T) {
+	issue := worksource.Issue{
+		SourceType: "github",
+		Repo:       "my-org/my-repo",
+		Number:     42,
+		ExternalID: "42",
+	}
+	got := worksource.TaskKey(issue)
+	want := "my-org/my-repo#42"
+	if got != want {
+		t.Errorf("TaskKey = %q, want %q", got, want)
+	}
+}
+
+func TestTaskKey_Linear(t *testing.T) {
+	issue := worksource.Issue{
+		SourceType: "linear",
+		Repo:       "my-org/my-repo",
+		ExternalID: "ENG-123",
+	}
+	got := worksource.TaskKey(issue)
+	want := "my-org/my-repo!ENG-123"
+	if got != want {
+		t.Errorf("TaskKey = %q, want %q", got, want)
+	}
+}
+
+func TestTaskKey_NoCollision(t *testing.T) {
+	// Two teams both have issue 42 — keys must be distinct.
+	eng := worksource.Issue{SourceType: "linear", Repo: "org/repo", ExternalID: "ENG-42"}
+	ops := worksource.Issue{SourceType: "linear", Repo: "org/repo", ExternalID: "OPS-42"}
+	if worksource.TaskKey(eng) == worksource.TaskKey(ops) {
+		t.Errorf("TaskKey collision: ENG-42 and OPS-42 produced the same key %q", worksource.TaskKey(eng))
+	}
+}
+
+func TestTaskKey_Jira(t *testing.T) {
+	issue := worksource.Issue{
+		SourceType: "jira",
+		Repo:       "my-org/my-repo",
+		ExternalID: "ENG-42",
+	}
+	got := worksource.TaskKey(issue)
+	want := "my-org/my-repo!ENG-42"
+	if got != want {
+		t.Errorf("TaskKey = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #4185

Part of RFC #4178.

- New `pkg/worksource` package with `WorkSource` interface
- Normalized `worksource.Issue` struct with `SourceType`, `ExternalID`, `Priority`
- `TaskKey` helper: collision-free identity key (backward-compatible for GitHub numeric issues)
- `githubIssuesSource` default adapter wrapping `github.Client.EnumerateActionable`
- Tests for TaskKey including cross-team collision avoidance
