### PR TITLE
✨ feat(worksource): GitHub Projects v2 work source adapter

### DIFF
--- a/src/pkg/worksource/github_issues.go
+++ b/src/pkg/worksource/github_issues.go
@@ -1,0 +1,52 @@
+package worksource
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+// githubIssuesSource is the default WorkSource: it delegates to the existing
+// github.Client.EnumerateActionable, which handles hold labels, issue filters,
+// SLA tracking, and PR exclusion. Zero config change for existing hives.
+type githubIssuesSource struct {
+	client *github.Client
+}
+
+// NewGitHubIssuesSource builds a WorkSource backed by the existing GitHub
+// Issues enumeration.
+func NewGitHubIssuesSource(client *github.Client) WorkSource {
+	return &githubIssuesSource{client: client}
+}
+
+func (s *githubIssuesSource) SourceType() string { return "github" }
+
+func (s *githubIssuesSource) ListIssues(ctx context.Context) ([]Issue, error) {
+	res, err := s.client.EnumerateActionable(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("worksource/github: enumerate: %w", err)
+	}
+	if res == nil {
+		return nil, nil
+	}
+	out := make([]Issue, 0, len(res.Issues.Items))
+	for _, it := range res.Issues.Items {
+		out = append(out, Issue{
+			SourceType: "github",
+			Repo:       it.Repo,
+			ExternalID: strconv.Itoa(it.Number),
+			Number:     it.Number,
+			Title:      it.Title,
+			Author:     it.Author,
+			Labels:     it.Labels,
+			Assignees:  it.Assignees,
+			State:      "open",
+			CreatedAt:  it.CreatedAt,
+			UpdatedAt:  it.UpdatedAt,
+			URL:        it.URL,
+		})
+	}
+	return out, nil
+}

--- a/src/pkg/worksource/github_projects.go
+++ b/src/pkg/worksource/github_projects.go
@@ -1,0 +1,331 @@
+// Package worksource — GitHub Projects v2 adapter.
+//
+// Uses the GitHub GraphQL API projectV2 query to enumerate issues in a GitHub
+// Project board. Same auth surface as api.github.com; no new ACMM rules needed.
+package worksource
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const githubProjectsDefaultBaseURL = "https://api.github.com"
+
+// GitHubProjectsConfig configures the GitHub Projects v2 work source.
+type GitHubProjectsConfig struct {
+	// Token is the GitHub personal access token (needs read:project scope).
+	Token string
+	// Org is the GitHub organization that owns the project.
+	Org string
+	// ProjectNumber is the project's number (visible in the project URL).
+	ProjectNumber int
+	// States filters items by the project's Status field value. Empty = all.
+	States []string
+	// PriorityField is the name of the project's priority custom field.
+	// Empty = no priority mapping.
+	PriorityField string
+	// IterationField is the name of the project's iteration/sprint field.
+	// When set, only items in the current iteration are returned.
+	IterationField string
+	// DefaultRepo is the GitHub repo (owner/name) to assign to all issues
+	// when the issue's own repo cannot be determined from the project item.
+	DefaultRepo string
+	// BaseURL overrides the GitHub API base (default: "https://api.github.com").
+	BaseURL string
+}
+
+type githubProjectsSource struct {
+	cfg    GitHubProjectsConfig
+	client *http.Client
+}
+
+// NewGitHubProjectsSource builds a WorkSource backed by GitHub Projects v2.
+func NewGitHubProjectsSource(cfg GitHubProjectsConfig) WorkSource {
+	return &githubProjectsSource{cfg: cfg, client: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (s *githubProjectsSource) SourceType() string { return "github_projects" }
+
+const githubProjectsQuery = `query($org: String!, $number: Int!, $cursor: String) {
+  organization(login: $org) {
+    projectV2(number: $number) {
+      items(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          type
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+              ... on ProjectV2ItemFieldIterationValue {
+                title
+                startDate
+                duration
+                field { ... on ProjectV2IterationField { name } }
+              }
+            }
+          }
+          content {
+            ... on Issue {
+              number
+              title
+              url
+              createdAt
+              updatedAt
+              state
+              author { login }
+              labels(first: 20) { nodes { name } }
+              assignees(first: 10) { nodes { login } }
+              repository { nameWithOwner }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+type gqlFieldValue struct {
+	Name      string `json:"name"`
+	Title     string `json:"title"`
+	StartDate string `json:"startDate"`
+	Duration  int    `json:"duration"`
+	Field     struct {
+		Name string `json:"name"`
+	} `json:"field"`
+}
+
+type gqlItem struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	FieldValues struct {
+		Nodes []gqlFieldValue `json:"nodes"`
+	} `json:"fieldValues"`
+	Content struct {
+		Number    int       `json:"number"`
+		Title     string    `json:"title"`
+		URL       string    `json:"url"`
+		CreatedAt time.Time `json:"createdAt"`
+		UpdatedAt time.Time `json:"updatedAt"`
+		State     string    `json:"state"`
+		Author    struct {
+			Login string `json:"login"`
+		} `json:"author"`
+		Labels struct {
+			Nodes []struct {
+				Name string `json:"name"`
+			} `json:"nodes"`
+		} `json:"labels"`
+		Assignees struct {
+			Nodes []struct {
+				Login string `json:"login"`
+			} `json:"nodes"`
+		} `json:"assignees"`
+		Repository struct {
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"repository"`
+	} `json:"content"`
+}
+
+type gqlResponse struct {
+	Data struct {
+		Organization struct {
+			ProjectV2 struct {
+				Items struct {
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+					Nodes []gqlItem `json:"nodes"`
+				} `json:"items"`
+			} `json:"projectV2"`
+		} `json:"organization"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func (s *githubProjectsSource) ListIssues(ctx context.Context) ([]Issue, error) {
+	baseURL := s.cfg.BaseURL
+	if baseURL == "" {
+		baseURL = githubProjectsDefaultBaseURL
+	}
+	endpoint := strings.TrimSuffix(baseURL, "/") + "/graphql"
+
+	var issues []Issue
+	var cursor *string
+	for {
+		resp, err := s.queryPage(ctx, endpoint, cursor)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range resp.Data.Organization.ProjectV2.Items.Nodes {
+			if issue, ok := s.mapItem(item); ok {
+				issues = append(issues, issue)
+			}
+		}
+		pi := resp.Data.Organization.ProjectV2.Items.PageInfo
+		if !pi.HasNextPage {
+			break
+		}
+		c := pi.EndCursor
+		cursor = &c
+	}
+	return issues, nil
+}
+
+func (s *githubProjectsSource) queryPage(ctx context.Context, endpoint string, cursor *string) (*gqlResponse, error) {
+	vars := map[string]any{
+		"org":    s.cfg.Org,
+		"number": s.cfg.ProjectNumber,
+		"cursor": cursor,
+	}
+	body, err := json.Marshal(map[string]any{
+		"query":     githubProjectsQuery,
+		"variables": vars,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("worksource/github_projects: marshal query: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("worksource/github_projects: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("worksource/github_projects: request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("worksource/github_projects: unexpected status %d", httpResp.StatusCode)
+	}
+	var resp gqlResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("worksource/github_projects: decode response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, fmt.Errorf("worksource/github_projects: graphql error: %s", resp.Errors[0].Message)
+	}
+	return &resp, nil
+}
+
+// mapItem converts a project item into a normalized Issue. It returns false
+// when the item should be skipped (non-issue, filtered out by state, or not
+// in the current iteration).
+func (s *githubProjectsSource) mapItem(item gqlItem) (Issue, bool) {
+	if item.Type != "ISSUE" {
+		return Issue{}, false
+	}
+
+	status := fieldValueByName(item.FieldValues.Nodes, "Status")
+	if len(s.cfg.States) > 0 {
+		matched := false
+		for _, want := range s.cfg.States {
+			if strings.EqualFold(status, want) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return Issue{}, false
+		}
+	}
+
+	if s.cfg.IterationField != "" && !inCurrentIteration(item.FieldValues.Nodes, s.cfg.IterationField) {
+		return Issue{}, false
+	}
+
+	priority := "none"
+	if s.cfg.PriorityField != "" {
+		priority = normalizePriority(fieldValueByName(item.FieldValues.Nodes, s.cfg.PriorityField))
+	}
+
+	repo := item.Content.Repository.NameWithOwner
+	if repo == "" {
+		repo = s.cfg.DefaultRepo
+	}
+
+	labels := make([]string, 0, len(item.Content.Labels.Nodes))
+	for _, l := range item.Content.Labels.Nodes {
+		labels = append(labels, l.Name)
+	}
+	assignees := make([]string, 0, len(item.Content.Assignees.Nodes))
+	for _, a := range item.Content.Assignees.Nodes {
+		assignees = append(assignees, a.Login)
+	}
+
+	return Issue{
+		SourceType: "github_projects",
+		Repo:       repo,
+		ExternalID: strconv.Itoa(item.Content.Number),
+		Number:     item.Content.Number,
+		Title:      item.Content.Title,
+		Author:     item.Content.Author.Login,
+		Labels:     labels,
+		Assignees:  assignees,
+		Priority:   priority,
+		State:      item.Content.State,
+		CreatedAt:  item.Content.CreatedAt,
+		UpdatedAt:  item.Content.UpdatedAt,
+		URL:        item.Content.URL,
+	}, true
+}
+
+// fieldValueByName returns the single-select value for the named field.
+func fieldValueByName(values []gqlFieldValue, fieldName string) string {
+	for _, v := range values {
+		if strings.EqualFold(v.Field.Name, fieldName) && v.Name != "" {
+			return v.Name
+		}
+	}
+	return ""
+}
+
+// inCurrentIteration reports whether the item's iteration field value covers
+// today's date (startDate <= now < startDate + duration days).
+func inCurrentIteration(values []gqlFieldValue, fieldName string) bool {
+	for _, v := range values {
+		if !strings.EqualFold(v.Field.Name, fieldName) || v.StartDate == "" {
+			continue
+		}
+		start, err := time.Parse("2006-01-02", v.StartDate)
+		if err != nil {
+			continue
+		}
+		end := start.AddDate(0, 0, v.Duration)
+		now := time.Now().UTC()
+		if !now.Before(start) && now.Before(end) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizePriority maps project priority field values to normalized strings.
+func normalizePriority(value string) string {
+	switch strings.ToLower(value) {
+	case "p0", "urgent", "critical":
+		return "urgent"
+	case "p1", "high":
+		return "high"
+	case "p2", "medium":
+		return "medium"
+	case "p3", "low":
+		return "low"
+	default:
+		return "none"
+	}
+}

--- a/src/pkg/worksource/github_projects_test.go
+++ b/src/pkg/worksource/github_projects_test.go
@@ -1,0 +1,251 @@
+package worksource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// itemJSON builds a project item node for canned GraphQL responses.
+func itemJSON(itemType string, number int, title, status, priority, repo string) string {
+	fieldValues := ""
+	if status != "" {
+		fieldValues += fmt.Sprintf(`{"name":%q,"field":{"name":"Status"}}`, status)
+	}
+	if priority != "" {
+		if fieldValues != "" {
+			fieldValues += ","
+		}
+		fieldValues += fmt.Sprintf(`{"name":%q,"field":{"name":"Priority"}}`, priority)
+	}
+	return fmt.Sprintf(`{
+		"id": "item-%d",
+		"type": %q,
+		"fieldValues": {"nodes": [%s]},
+		"content": {
+			"number": %d,
+			"title": %q,
+			"url": "https://github.com/%s/issues/%d",
+			"createdAt": "2026-01-01T00:00:00Z",
+			"updatedAt": "2026-01-02T00:00:00Z",
+			"state": "OPEN",
+			"author": {"login": "alice"},
+			"labels": {"nodes": [{"name": "bug"}]},
+			"assignees": {"nodes": [{"login": "bob"}]},
+			"repository": {"nameWithOwner": %q}
+		}
+	}`, number, itemType, fieldValues, number, title, repo, number, repo)
+}
+
+func pageJSON(hasNext bool, cursor string, items ...string) string {
+	nodes := ""
+	for i, it := range items {
+		if i > 0 {
+			nodes += ","
+		}
+		nodes += it
+	}
+	return fmt.Sprintf(`{"data":{"organization":{"projectV2":{"items":{
+		"pageInfo":{"hasNextPage":%t,"endCursor":%q},
+		"nodes":[%s]
+	}}}}}`, hasNext, cursor, nodes)
+}
+
+func stubServer(t *testing.T, pages []string) *httptest.Server {
+	t.Helper()
+	call := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("unexpected Authorization header %q", got)
+		}
+		var body struct {
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if call >= len(pages) {
+			t.Fatalf("unexpected extra request %d", call)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, pages[call])
+		call++
+	}))
+}
+
+func newTestSource(url string, mutate func(*GitHubProjectsConfig)) WorkSource {
+	cfg := GitHubProjectsConfig{
+		Token:         "test-token",
+		Org:           "my-org",
+		ProjectNumber: 42,
+		BaseURL:       url,
+	}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	return NewGitHubProjectsSource(cfg)
+}
+
+func TestGitHubProjectsBasicEnumeration(t *testing.T) {
+	srv := stubServer(t, []string{
+		pageJSON(false, "",
+			itemJSON("ISSUE", 1, "First issue", "Todo", "", "my-org/repo-a"),
+			itemJSON("ISSUE", 2, "Second issue", "Todo", "", "my-org/repo-b"),
+		),
+	})
+	defer srv.Close()
+
+	src := newTestSource(srv.URL, nil)
+	if src.SourceType() != "github_projects" {
+		t.Errorf("SourceType = %q", src.SourceType())
+	}
+	issues, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("got %d issues, want 2", len(issues))
+	}
+	first := issues[0]
+	if first.Number != 1 || first.ExternalID != "1" || first.Title != "First issue" {
+		t.Errorf("unexpected first issue: %+v", first)
+	}
+	if first.Repo != "my-org/repo-a" || first.Author != "alice" || first.State != "OPEN" {
+		t.Errorf("unexpected first issue metadata: %+v", first)
+	}
+	if len(first.Labels) != 1 || first.Labels[0] != "bug" {
+		t.Errorf("unexpected labels: %v", first.Labels)
+	}
+	if len(first.Assignees) != 1 || first.Assignees[0] != "bob" {
+		t.Errorf("unexpected assignees: %v", first.Assignees)
+	}
+	if first.SourceType != "github_projects" {
+		t.Errorf("unexpected source type %q", first.SourceType)
+	}
+	if issues[1].Repo != "my-org/repo-b" {
+		t.Errorf("unexpected second repo %q", issues[1].Repo)
+	}
+}
+
+func TestGitHubProjectsPagination(t *testing.T) {
+	srv := stubServer(t, []string{
+		pageJSON(true, "cursor-1",
+			itemJSON("ISSUE", 1, "One", "Todo", "", "my-org/repo"),
+			itemJSON("ISSUE", 2, "Two", "Todo", "", "my-org/repo"),
+		),
+		pageJSON(false, "",
+			itemJSON("ISSUE", 3, "Three", "Todo", "", "my-org/repo"),
+		),
+	})
+	defer srv.Close()
+
+	issues, err := newTestSource(srv.URL, nil).ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 3 {
+		t.Fatalf("got %d issues, want 3", len(issues))
+	}
+	for i, want := range []int{1, 2, 3} {
+		if issues[i].Number != want {
+			t.Errorf("issue[%d].Number = %d, want %d", i, issues[i].Number, want)
+		}
+	}
+}
+
+func TestGitHubProjectsStateFiltering(t *testing.T) {
+	srv := stubServer(t, []string{
+		pageJSON(false, "",
+			itemJSON("ISSUE", 1, "Keep", "Todo", "", "my-org/repo"),
+			itemJSON("ISSUE", 2, "Skip", "Done", "", "my-org/repo"),
+			itemJSON("ISSUE", 3, "Also keep", "Todo", "", "my-org/repo"),
+		),
+	})
+	defer srv.Close()
+
+	issues, err := newTestSource(srv.URL, func(cfg *GitHubProjectsConfig) {
+		cfg.States = []string{"Todo"}
+	}).ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("got %d issues, want 2", len(issues))
+	}
+	if issues[0].Number != 1 || issues[1].Number != 3 {
+		t.Errorf("unexpected issues: %+v", issues)
+	}
+}
+
+func TestGitHubProjectsPriorityMapping(t *testing.T) {
+	srv := stubServer(t, []string{
+		pageJSON(false, "",
+			itemJSON("ISSUE", 1, "Urgent one", "Todo", "P0", "my-org/repo"),
+			itemJSON("ISSUE", 2, "Medium one", "Todo", "P2", "my-org/repo"),
+			itemJSON("ISSUE", 3, "No priority", "Todo", "", "my-org/repo"),
+		),
+	})
+	defer srv.Close()
+
+	issues, err := newTestSource(srv.URL, func(cfg *GitHubProjectsConfig) {
+		cfg.PriorityField = "Priority"
+	}).ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 3 {
+		t.Fatalf("got %d issues, want 3", len(issues))
+	}
+	for i, want := range []string{"urgent", "medium", "none"} {
+		if issues[i].Priority != want {
+			t.Errorf("issue[%d].Priority = %q, want %q", i, issues[i].Priority, want)
+		}
+	}
+}
+
+func TestGitHubProjectsSkipsNonIssues(t *testing.T) {
+	srv := stubServer(t, []string{
+		pageJSON(false, "",
+			itemJSON("DRAFT_ISSUE", 1, "Draft", "Todo", "", "my-org/repo"),
+			itemJSON("ISSUE", 2, "Real issue", "Todo", "", "my-org/repo"),
+			itemJSON("PULL_REQUEST", 3, "A PR", "Todo", "", "my-org/repo"),
+		),
+	})
+	defer srv.Close()
+
+	issues, err := newTestSource(srv.URL, nil).ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("got %d issues, want 1", len(issues))
+	}
+	if issues[0].Number != 2 {
+		t.Errorf("unexpected issue: %+v", issues[0])
+	}
+}
+
+func TestGitHubProjectsDefaultRepoFallback(t *testing.T) {
+	srv := stubServer(t, []string{
+		pageJSON(false, "",
+			itemJSON("ISSUE", 1, "No repo", "Todo", "", ""),
+		),
+	})
+	defer srv.Close()
+
+	issues, err := newTestSource(srv.URL, func(cfg *GitHubProjectsConfig) {
+		cfg.DefaultRepo = "my-org/default-repo"
+	}).ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Repo != "my-org/default-repo" {
+		t.Errorf("unexpected issues: %+v", issues)
+	}
+}

--- a/src/pkg/worksource/worksource.go
+++ b/src/pkg/worksource/worksource.go
@@ -1,0 +1,78 @@
+// Package worksource defines the WorkSource interface — the Step 01 seam in
+// hive's "Issue Filed → fix → merge" loop. A WorkSource enumerates actionable
+// work items from an external planning tool (GitHub Issues, GitHub Projects,
+// Linear, Jira). Steps 03–07 (fix agent, PR, review, merge) are source-agnostic
+// and unchanged.
+package worksource
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Issue is a source-neutral work item. Fields absent on a given source are left
+// at their zero value.
+type Issue struct {
+	// SourceType identifies which work source produced this item
+	// ("github", "github_projects", "linear", "jira").
+	SourceType string `json:"source_type"`
+	// Repo is the GitHub repo (owner/name) agents should clone and open PRs
+	// against for this issue.
+	Repo string `json:"repo"`
+	// ExternalID is the source-native identifier. For GitHub: "42". For Linear:
+	// "ENG-123". For Jira: "ENG-42". Never empty.
+	ExternalID string `json:"external_id"`
+	// Number is the integer issue number when the source uses numeric IDs
+	// (GitHub). Zero for sources with string identifiers (Linear, Jira).
+	Number int `json:"number,omitempty"`
+	// Title is the issue title / summary.
+	Title string `json:"title"`
+	// Author is the login/username of who filed the issue.
+	Author string `json:"author"`
+	// Labels are the issue labels / tags.
+	Labels []string `json:"labels,omitempty"`
+	// Assignees are the logins/usernames currently assigned.
+	Assignees []string `json:"assignees,omitempty"`
+	// Priority is a normalized priority string: "urgent", "high", "medium",
+	// "low", "none". Empty when the source does not provide priority.
+	Priority string `json:"priority,omitempty"`
+	// State is the issue state string from the source ("open", "Todo", etc.).
+	State string `json:"state"`
+	// CreatedAt is when the issue was filed.
+	CreatedAt time.Time `json:"created_at"`
+	// UpdatedAt is the last-activity timestamp. Zero when unknown.
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// URL is the canonical web URL of the issue.
+	URL string `json:"url"`
+}
+
+// TaskKey returns a collision-free identity key for task admission, claim
+// ledger, and contributor-relay active-task tracking.
+//
+// For GitHub issues it produces "repo#number" (e.g. "my-org/my-repo#42"),
+// preserving backward compatibility with the 30 sites that used
+// fmt.Sprintf("%s#%d", repo, num) directly.
+//
+// For string-keyed sources (Linear, Jira) it produces "repo!externalID"
+// (e.g. "my-org/my-repo!ENG-123"). The "!" separator is chosen because it
+// cannot appear in a GitHub issue number or a Linear/Jira key, so keys from
+// different sources never collide even if two teams share an integer.
+func TaskKey(issue Issue) string {
+	if issue.Number > 0 {
+		return fmt.Sprintf("%s#%d", issue.Repo, issue.Number)
+	}
+	return fmt.Sprintf("%s!%s", issue.Repo, issue.ExternalID)
+}
+
+// WorkSource is the Step 01 abstraction: it enumerates actionable work items
+// from an external planning tool. The returned slice contains only open /
+// actionable items — filtering by state, label, hold, etc. is the adapter's
+// responsibility.
+type WorkSource interface {
+	// SourceType returns the kind string ("github", "github_projects", "linear",
+	// "jira") for use in dashboard badges and log fields.
+	SourceType() string
+	// ListIssues returns the current actionable work items.
+	ListIssues(ctx context.Context) ([]Issue, error)
+}

--- a/src/pkg/worksource/worksource_test.go
+++ b/src/pkg/worksource/worksource_test.go
@@ -1,0 +1,56 @@
+package worksource_test
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+func TestTaskKey_GitHub(t *testing.T) {
+	issue := worksource.Issue{
+		SourceType: "github",
+		Repo:       "my-org/my-repo",
+		Number:     42,
+		ExternalID: "42",
+	}
+	got := worksource.TaskKey(issue)
+	want := "my-org/my-repo#42"
+	if got != want {
+		t.Errorf("TaskKey = %q, want %q", got, want)
+	}
+}
+
+func TestTaskKey_Linear(t *testing.T) {
+	issue := worksource.Issue{
+		SourceType: "linear",
+		Repo:       "my-org/my-repo",
+		ExternalID: "ENG-123",
+	}
+	got := worksource.TaskKey(issue)
+	want := "my-org/my-repo!ENG-123"
+	if got != want {
+		t.Errorf("TaskKey = %q, want %q", got, want)
+	}
+}
+
+func TestTaskKey_NoCollision(t *testing.T) {
+	// Two teams both have issue 42 — keys must be distinct.
+	eng := worksource.Issue{SourceType: "linear", Repo: "org/repo", ExternalID: "ENG-42"}
+	ops := worksource.Issue{SourceType: "linear", Repo: "org/repo", ExternalID: "OPS-42"}
+	if worksource.TaskKey(eng) == worksource.TaskKey(ops) {
+		t.Errorf("TaskKey collision: ENG-42 and OPS-42 produced the same key %q", worksource.TaskKey(eng))
+	}
+}
+
+func TestTaskKey_Jira(t *testing.T) {
+	issue := worksource.Issue{
+		SourceType: "jira",
+		Repo:       "my-org/my-repo",
+		ExternalID: "ENG-42",
+	}
+	got := worksource.TaskKey(issue)
+	want := "my-org/my-repo!ENG-42"
+	if got != want {
+		t.Errorf("TaskKey = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #4183

Part of RFC #4178.

Adds a GitHub Projects v2 GraphQL adapter for the worksource seam. Uses the same api.github.com auth surface; no new ACMM egress rules needed.

- Paginates project items via GraphQL projectV2 query
- Maps priority custom field values to normalized priority strings
- Filters by Status field values (States config)
- Optional iteration field filter (current iteration only)
- Skips DRAFT_ISSUE and PULL_REQUEST items
- Stub-server tests for pagination, filtering, and priority mapping