### PR TITLE
✨ feat(worksource): Jira Cloud REST v3 work source adapter (Phase 1 read-only)

### DIFF
--- a/src/pkg/worksource/jira.go
+++ b/src/pkg/worksource/jira.go
@@ -1,0 +1,237 @@
+package worksource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// JiraConfig configures the Jira Cloud REST API v3 work source adapter
+// (Phase 1, read-only).
+type JiraConfig struct {
+	// BaseURL is the Jira Cloud instance root, e.g. "https://myorg.atlassian.net".
+	BaseURL string
+	// Email is the Atlassian account email for Basic auth.
+	Email string
+	// APIToken is the Jira API token (Atlassian account → Security → API tokens).
+	// Stored as a secret reference; the actual value is resolved from env by the caller.
+	APIToken string
+	// ProjectKeys is the list of Jira project keys to enumerate, e.g. ["ENG","OPS"].
+	ProjectKeys []string
+	// JQL is an optional JQL override. When empty, the adapter builds a default
+	// JQL: "project in (<keys>) AND statusCategory != Done AND issuetype != Epic"
+	JQL string
+	// Repo is the GitHub repo (owner/name) agents clone for these issues.
+	Repo string
+	// PriorityField is the Jira field name for priority (default: "priority").
+	PriorityField string
+	// HoldLabels are Jira label values that gate an issue (like GitHub "hold").
+	HoldLabels []string
+}
+
+// jiraMaxResults is the page size requested from the Jira search API.
+const jiraMaxResults = 100
+
+// jiraSource is the Jira Cloud WorkSource adapter.
+type jiraSource struct {
+	cfg    JiraConfig
+	client *http.Client
+}
+
+// NewJiraSource builds a WorkSource backed by the Jira Cloud REST API v3.
+func NewJiraSource(cfg JiraConfig) WorkSource {
+	if cfg.PriorityField == "" {
+		cfg.PriorityField = "priority"
+	}
+	return &jiraSource{
+		cfg:    cfg,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (s *jiraSource) SourceType() string { return "jira" }
+
+// jql returns the effective JQL: the configured override, or the default
+// built from ProjectKeys.
+func (s *jiraSource) jql() string {
+	if s.cfg.JQL != "" {
+		return s.cfg.JQL
+	}
+	return fmt.Sprintf("project in (%s) AND statusCategory != Done AND issuetype != Epic",
+		strings.Join(s.cfg.ProjectKeys, ","))
+}
+
+// Jira search response wire types (only the fields we read).
+type jiraSearchResponse struct {
+	StartAt    int         `json:"startAt"`
+	MaxResults int         `json:"maxResults"`
+	Total      int         `json:"total"`
+	Issues     []jiraIssue `json:"issues"`
+}
+
+type jiraIssue struct {
+	Key    string     `json:"key"`
+	Fields jiraFields `json:"fields"`
+}
+
+type jiraFields struct {
+	Summary  string        `json:"summary"`
+	Status   *jiraNamed    `json:"status"`
+	Priority *jiraNamed    `json:"priority"`
+	Assignee *jiraUser     `json:"assignee"`
+	Reporter *jiraUser     `json:"reporter"`
+	Labels   []string      `json:"labels"`
+	Created  jiraTimestamp `json:"created"`
+	Updated  jiraTimestamp `json:"updated"`
+}
+
+type jiraNamed struct {
+	Name string `json:"name"`
+}
+
+type jiraUser struct {
+	DisplayName string `json:"displayName"`
+}
+
+// jiraTimestamp parses Jira's "2006-01-02T15:04:05.000-0700" timestamps, and
+// falls back to RFC 3339.
+type jiraTimestamp struct {
+	time.Time
+}
+
+func (t *jiraTimestamp) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	parsed, err := time.Parse("2006-01-02T15:04:05.000-0700", s)
+	if err != nil {
+		parsed, err = time.Parse(time.RFC3339, s)
+		if err != nil {
+			return fmt.Errorf("worksource/jira: parse timestamp %q: %w", s, err)
+		}
+	}
+	t.Time = parsed
+	return nil
+}
+
+// normalizeJiraPriority maps Jira priority names (across common naming
+// schemes) to the worksource Priority strings.
+func normalizeJiraPriority(name string) string {
+	switch strings.ToLower(name) {
+	case "highest", "critical", "blocker", "p0":
+		return "urgent"
+	case "high", "p1":
+		return "high"
+	case "medium", "p2":
+		return "medium"
+	case "low", "lowest", "p3", "p4":
+		return "low"
+	default:
+		return "none"
+	}
+}
+
+// hasHoldLabel reports whether any issue label matches a configured hold label.
+func (s *jiraSource) hasHoldLabel(labels []string) bool {
+	for _, l := range labels {
+		for _, h := range s.cfg.HoldLabels {
+			if l == h {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *jiraSource) ListIssues(ctx context.Context) ([]Issue, error) {
+	var out []Issue
+	startAt := 0
+	for {
+		page, err := s.searchPage(ctx, startAt)
+		if err != nil {
+			return nil, err
+		}
+		for _, it := range page.Issues {
+			if s.hasHoldLabel(it.Fields.Labels) {
+				continue
+			}
+			out = append(out, s.toIssue(it))
+		}
+		if page.StartAt+page.MaxResults >= page.Total || len(page.Issues) == 0 {
+			break
+		}
+		startAt = page.StartAt + page.MaxResults
+	}
+	return out, nil
+}
+
+func (s *jiraSource) searchPage(ctx context.Context, startAt int) (*jiraSearchResponse, error) {
+	q := url.Values{}
+	q.Set("jql", s.jql())
+	q.Set("fields", "summary,status,priority,assignee,reporter,labels,created,updated")
+	q.Set("maxResults", fmt.Sprintf("%d", jiraMaxResults))
+	q.Set("startAt", fmt.Sprintf("%d", startAt))
+	reqURL := strings.TrimSuffix(s.cfg.BaseURL, "/") + "/rest/api/3/search?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("worksource/jira: build request: %w", err)
+	}
+	req.SetBasicAuth(s.cfg.Email, s.cfg.APIToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("worksource/jira: search: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("worksource/jira: read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("worksource/jira: search returned %d: %s", resp.StatusCode, string(body))
+	}
+	var page jiraSearchResponse
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("worksource/jira: decode response: %w", err)
+	}
+	return &page, nil
+}
+
+func (s *jiraSource) toIssue(it jiraIssue) Issue {
+	iss := Issue{
+		SourceType: "jira",
+		Repo:       s.cfg.Repo,
+		ExternalID: it.Key,
+		Number:     0,
+		Title:      it.Fields.Summary,
+		Labels:     it.Fields.Labels,
+		Priority:   "none",
+		CreatedAt:  it.Fields.Created.Time,
+		UpdatedAt:  it.Fields.Updated.Time,
+		URL:        strings.TrimSuffix(s.cfg.BaseURL, "/") + "/browse/" + it.Key,
+	}
+	if it.Fields.Status != nil {
+		iss.State = it.Fields.Status.Name
+	}
+	if it.Fields.Priority != nil {
+		iss.Priority = normalizeJiraPriority(it.Fields.Priority.Name)
+	}
+	if it.Fields.Reporter != nil {
+		iss.Author = it.Fields.Reporter.DisplayName
+	}
+	if it.Fields.Assignee != nil {
+		iss.Assignees = []string{it.Fields.Assignee.DisplayName}
+	}
+	return iss
+}

--- a/src/pkg/worksource/jira_test.go
+++ b/src/pkg/worksource/jira_test.go
@@ -1,0 +1,235 @@
+package worksource
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type jiraTestIssue struct {
+	Key      string
+	Summary  string
+	Priority string // empty = absent
+	Status   string
+	Assignee string
+	Reporter string
+	Labels   []string
+}
+
+func jiraIssueJSON(it jiraTestIssue) map[string]any {
+	fields := map[string]any{
+		"summary": it.Summary,
+		"labels":  it.Labels,
+		"created": "2024-01-02T03:04:05.000+0000",
+		"updated": "2024-01-03T03:04:05.000+0000",
+	}
+	if it.Status != "" {
+		fields["status"] = map[string]any{"name": it.Status}
+	}
+	if it.Priority != "" {
+		fields["priority"] = map[string]any{"name": it.Priority}
+	}
+	if it.Assignee != "" {
+		fields["assignee"] = map[string]any{"displayName": it.Assignee}
+	}
+	if it.Reporter != "" {
+		fields["reporter"] = map[string]any{"displayName": it.Reporter}
+	}
+	return map[string]any{"key": it.Key, "fields": fields}
+}
+
+// newJiraServer serves a fixed set of issues with Jira-style pagination and
+// records requests via the callback.
+func newJiraServer(t *testing.T, issues []jiraTestIssue, onReq func(*http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/3/search" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if onReq != nil {
+			onReq(r)
+		}
+		startAt := 0
+		fmt.Sscanf(r.URL.Query().Get("startAt"), "%d", &startAt)
+		end := startAt + jiraMaxResults
+		if end > len(issues) {
+			end = len(issues)
+		}
+		var page []map[string]any
+		if startAt < len(issues) {
+			for _, it := range issues[startAt:end] {
+				page = append(page, jiraIssueJSON(it))
+			}
+		}
+		resp := map[string]any{
+			"startAt":    startAt,
+			"maxResults": jiraMaxResults,
+			"total":      len(issues),
+			"issues":     page,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestJiraBasicEnumeration(t *testing.T) {
+	srv := newJiraServer(t, []jiraTestIssue{
+		{Key: "ENG-1", Summary: "First", Status: "Todo", Reporter: "Alice", Assignee: "Bob", Priority: "High"},
+		{Key: "ENG-2", Summary: "Second", Status: "Backlog", Reporter: "Carol"},
+	}, nil)
+	defer srv.Close()
+
+	src := NewJiraSource(JiraConfig{
+		BaseURL: srv.URL, Email: "bot@x.com", APIToken: "tok",
+		ProjectKeys: []string{"ENG"}, Repo: "my-org/my-repo",
+	})
+	if src.SourceType() != "jira" {
+		t.Errorf("SourceType = %q, want jira", src.SourceType())
+	}
+	got, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d issues, want 2", len(got))
+	}
+	first := got[0]
+	if first.ExternalID != "ENG-1" || first.Number != 0 || first.Title != "First" ||
+		first.Author != "Alice" || first.State != "Todo" || first.Repo != "my-org/my-repo" ||
+		first.SourceType != "jira" || first.Priority != "high" {
+		t.Errorf("unexpected first issue: %+v", first)
+	}
+	if len(first.Assignees) != 1 || first.Assignees[0] != "Bob" {
+		t.Errorf("assignees = %v, want [Bob]", first.Assignees)
+	}
+	if got[1].Assignees != nil {
+		t.Errorf("unassigned issue should have nil assignees, got %v", got[1].Assignees)
+	}
+	if first.CreatedAt.IsZero() || first.UpdatedAt.IsZero() {
+		t.Errorf("timestamps not parsed: %+v", first)
+	}
+	if first.URL != srv.URL+"/browse/ENG-1" {
+		t.Errorf("URL = %q", first.URL)
+	}
+}
+
+func TestJiraPagination(t *testing.T) {
+	var issues []jiraTestIssue
+	for i := 1; i <= 150; i++ {
+		issues = append(issues, jiraTestIssue{Key: fmt.Sprintf("ENG-%d", i), Summary: "x", Status: "Todo"})
+	}
+	var requests int
+	srv := newJiraServer(t, issues, func(*http.Request) { requests++ })
+	defer srv.Close()
+
+	src := NewJiraSource(JiraConfig{BaseURL: srv.URL, ProjectKeys: []string{"ENG"}, Repo: "o/r"})
+	got, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 150 {
+		t.Errorf("got %d issues, want 150", len(got))
+	}
+	if requests != 2 {
+		t.Errorf("made %d requests, want 2", requests)
+	}
+	if got[100].ExternalID != "ENG-101" {
+		t.Errorf("issue 100 = %q, want ENG-101", got[100].ExternalID)
+	}
+}
+
+func TestJiraDefaultJQL(t *testing.T) {
+	var gotJQL string
+	srv := newJiraServer(t, nil, func(r *http.Request) { gotJQL = r.URL.Query().Get("jql") })
+	defer srv.Close()
+
+	src := NewJiraSource(JiraConfig{BaseURL: srv.URL, ProjectKeys: []string{"ENG", "OPS"}, Repo: "o/r"})
+	if _, err := src.ListIssues(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := "project in (ENG,OPS) AND statusCategory != Done AND issuetype != Epic"
+	if gotJQL != want {
+		t.Errorf("jql = %q, want %q", gotJQL, want)
+	}
+}
+
+func TestJiraCustomJQL(t *testing.T) {
+	var gotJQL string
+	srv := newJiraServer(t, nil, func(r *http.Request) { gotJQL = r.URL.Query().Get("jql") })
+	defer srv.Close()
+
+	custom := "status in (Todo, Backlog) AND assignee is EMPTY"
+	src := NewJiraSource(JiraConfig{BaseURL: srv.URL, ProjectKeys: []string{"ENG"}, JQL: custom, Repo: "o/r"})
+	if _, err := src.ListIssues(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if gotJQL != custom {
+		t.Errorf("jql = %q, want %q", gotJQL, custom)
+	}
+}
+
+func TestJiraPriorityMapping(t *testing.T) {
+	srv := newJiraServer(t, []jiraTestIssue{
+		{Key: "ENG-1", Summary: "a", Priority: "Highest"},
+		{Key: "ENG-2", Summary: "b", Priority: "Medium"},
+		{Key: "ENG-3", Summary: "c"}, // absent
+	}, nil)
+	defer srv.Close()
+
+	src := NewJiraSource(JiraConfig{BaseURL: srv.URL, ProjectKeys: []string{"ENG"}, Repo: "o/r"})
+	got, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"urgent", "medium", "none"}
+	for i, w := range want {
+		if got[i].Priority != w {
+			t.Errorf("issue %s priority = %q, want %q", got[i].ExternalID, got[i].Priority, w)
+		}
+	}
+}
+
+func TestJiraHoldLabelFiltering(t *testing.T) {
+	srv := newJiraServer(t, []jiraTestIssue{
+		{Key: "ENG-1", Summary: "held", Labels: []string{"hold"}},
+		{Key: "ENG-2", Summary: "blocked", Labels: []string{"other", "blocked"}},
+		{Key: "ENG-3", Summary: "free", Labels: []string{"bug"}},
+	}, nil)
+	defer srv.Close()
+
+	src := NewJiraSource(JiraConfig{
+		BaseURL: srv.URL, ProjectKeys: []string{"ENG"}, Repo: "o/r",
+		HoldLabels: []string{"hold", "blocked"},
+	})
+	got, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ExternalID != "ENG-3" {
+		t.Errorf("got %+v, want only ENG-3", got)
+	}
+}
+
+func TestJiraAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := newJiraServer(t, nil, func(r *http.Request) { gotAuth = r.Header.Get("Authorization") })
+	defer srv.Close()
+
+	src := NewJiraSource(JiraConfig{
+		BaseURL: srv.URL, Email: "bot@myorg.com", APIToken: "secret-token",
+		ProjectKeys: []string{"ENG"}, Repo: "o/r",
+	})
+	if _, err := src.ListIssues(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("bot@myorg.com:secret-token"))
+	if gotAuth != want {
+		t.Errorf("Authorization = %q, want %q", gotAuth, want)
+	}
+}


### PR DESCRIPTION
Closes #4186

Part of RFC #4178.

- Jira Cloud REST API v3 adapter using GET /rest/api/3/search
- HTTP Basic auth (email + api_token)
- Default JQL built from project_keys; configurable override
- Priority normalization across Jira naming variants (Highest/Critical/Blocker→urgent, etc.)
- Hold-label filtering
- Pagination via startAt/maxResults
- No new Go dependencies (stdlib only)
- All auth sent over HTTPS to customer's Atlassian instance