### PR TITLE
✨ feat(worksource): Linear GraphQL work source adapter (Phase 1 read-only)

### DIFF
--- a/src/pkg/worksource/linear.go
+++ b/src/pkg/worksource/linear.go
@@ -1,0 +1,262 @@
+// Package worksource — Linear GraphQL adapter.
+//
+// Phase 1 (read-only): hive reads issues from Linear and assigns them to agents.
+// Linear's native GitHub integration closes the ticket when a referenced PR
+// merges, so no write-back is needed in Phase 1.
+//
+// Security note: Linear egress is currently ungated in pkg/proxy/rules.go —
+// NeedsMITM only intercepts api.github.com. These read-only GraphQL calls pass
+// through the proxy untouched. Phase 2 (write-back via Linear MCP) will require
+// ACMM enforcement with GraphQL operation-name inspection before it is safe.
+package worksource
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// defaultLinearBaseURL is Linear's single GraphQL endpoint.
+const defaultLinearBaseURL = "https://api.linear.app/graphql"
+
+// linearPageSize is the number of issues requested per GraphQL page.
+const linearPageSize = 100
+
+// defaultLinearStates is used when a team's States list is empty.
+var defaultLinearStates = []string{"Todo", "In Progress", "Backlog"}
+
+// LinearTeamConfig maps one Linear team to the GitHub repo its agents clone.
+type LinearTeamConfig struct {
+	Key    string   // e.g. "ENG"
+	Repo   string   // GitHub repo agents clone, e.g. "my-org/my-repo"
+	States []string // Linear state names to include, e.g. ["Todo","Backlog"]
+}
+
+// LinearConfig configures the Linear work source adapter.
+type LinearConfig struct {
+	APIKey     string // LINEAR_API_KEY
+	Teams      []LinearTeamConfig
+	HoldLabels []string // label names that gate an issue (like GitHub "hold")
+	// BaseURL overrides the Linear API endpoint (default: "https://api.linear.app/graphql")
+	BaseURL string
+}
+
+// LinearSource is a read-only WorkSource backed by Linear's GraphQL API.
+type LinearSource struct {
+	cfg    LinearConfig
+	client *http.Client
+}
+
+// NewLinearSource constructs a LinearSource from cfg. A nil httpClient falls
+// back to a client with a sane timeout.
+func NewLinearSource(cfg LinearConfig, httpClient *http.Client) *LinearSource {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &LinearSource{cfg: cfg, client: httpClient}
+}
+
+// SourceType implements WorkSource.
+func (s *LinearSource) SourceType() string { return "linear" }
+
+const linearIssuesQuery = `query($teamKey: String!, $states: [String!], $cursor: String) {
+  issues(
+    filter: {
+      team: { key: { eq: $teamKey } }
+      state: { name: { in: $states } }
+    }
+    first: 100
+    after: $cursor
+  ) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      identifier
+      title
+      url
+      createdAt
+      updatedAt
+      priority
+      state { name }
+      assignee { displayName }
+      labels { nodes { name } }
+      team { key }
+    }
+  }
+}`
+
+type linearGraphQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+type linearIssueNode struct {
+	ID         string    `json:"id"`
+	Identifier string    `json:"identifier"`
+	Title      string    `json:"title"`
+	URL        string    `json:"url"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+	Priority   int       `json:"priority"`
+	State      struct {
+		Name string `json:"name"`
+	} `json:"state"`
+	Assignee *struct {
+		DisplayName string `json:"displayName"`
+	} `json:"assignee"`
+	Labels struct {
+		Nodes []struct {
+			Name string `json:"name"`
+		} `json:"nodes"`
+	} `json:"labels"`
+	Team struct {
+		Key string `json:"key"`
+	} `json:"team"`
+}
+
+type linearGraphQLResponse struct {
+	Data struct {
+		Issues struct {
+			PageInfo struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
+			Nodes []linearIssueNode `json:"nodes"`
+		} `json:"issues"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// linearPriorityString maps Linear's numeric priority to hive's normalized
+// priority strings. 0=urgent 1=high 2=medium 3=low 4=no priority.
+func linearPriorityString(p int) string {
+	switch p {
+	case 0:
+		return "urgent"
+	case 1:
+		return "high"
+	case 2:
+		return "medium"
+	case 3:
+		return "low"
+	default:
+		return "none"
+	}
+}
+
+// ListIssues implements WorkSource. It enumerates actionable issues across
+// all configured teams, skipping any issue carrying a hold label.
+func (s *LinearSource) ListIssues(ctx context.Context) ([]Issue, error) {
+	hold := make(map[string]bool, len(s.cfg.HoldLabels))
+	for _, l := range s.cfg.HoldLabels {
+		hold[l] = true
+	}
+
+	var out []Issue
+	for _, team := range s.cfg.Teams {
+		states := team.States
+		if len(states) == 0 {
+			states = defaultLinearStates
+		}
+		nodes, err := s.fetchTeamIssues(ctx, team.Key, states)
+		if err != nil {
+			return nil, fmt.Errorf("linear: team %s: %w", team.Key, err)
+		}
+	node:
+		for _, n := range nodes {
+			labels := make([]string, 0, len(n.Labels.Nodes))
+			for _, l := range n.Labels.Nodes {
+				if hold[l.Name] {
+					continue node
+				}
+				labels = append(labels, l.Name)
+			}
+			var assignees []string
+			if n.Assignee != nil && n.Assignee.DisplayName != "" {
+				assignees = []string{n.Assignee.DisplayName}
+			}
+			out = append(out, Issue{
+				SourceType: "linear",
+				Repo:       team.Repo,
+				ExternalID: n.Identifier,
+				Title:      n.Title,
+				Labels:     labels,
+				Assignees:  assignees,
+				Priority:   linearPriorityString(n.Priority),
+				State:      n.State.Name,
+				CreatedAt:  n.CreatedAt,
+				UpdatedAt:  n.UpdatedAt,
+				URL:        n.URL,
+			})
+		}
+	}
+	return out, nil
+}
+
+// fetchTeamIssues pages through the Linear issues query for one team.
+func (s *LinearSource) fetchTeamIssues(ctx context.Context, teamKey string, states []string) ([]linearIssueNode, error) {
+	var nodes []linearIssueNode
+	var cursor *string
+	for {
+		vars := map[string]interface{}{
+			"teamKey": teamKey,
+			"states":  states,
+			"cursor":  cursor,
+		}
+		resp, err := s.doQuery(ctx, vars)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, resp.Data.Issues.Nodes...)
+		if !resp.Data.Issues.PageInfo.HasNextPage {
+			return nodes, nil
+		}
+		c := resp.Data.Issues.PageInfo.EndCursor
+		cursor = &c
+	}
+}
+
+func (s *LinearSource) doQuery(ctx context.Context, vars map[string]interface{}) (*linearGraphQLResponse, error) {
+	baseURL := s.cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultLinearBaseURL
+	}
+	body, err := json.Marshal(linearGraphQLRequest{Query: linearIssuesQuery, Variables: vars})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", s.cfg.APIKey)
+
+	httpResp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(httpResp.Body, 16<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d: %s", httpResp.StatusCode, string(raw))
+	}
+	var resp linearGraphQLResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+	}
+	return &resp, nil
+}

--- a/src/pkg/worksource/linear_test.go
+++ b/src/pkg/worksource/linear_test.go
@@ -1,0 +1,269 @@
+package worksource_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+type gqlVars struct {
+	TeamKey string   `json:"teamKey"`
+	States  []string `json:"states"`
+	Cursor  *string  `json:"cursor"`
+}
+
+type gqlReq struct {
+	Query     string  `json:"query"`
+	Variables gqlVars `json:"variables"`
+}
+
+func issueNode(identifier, title string, priority int, state string, labels ...string) map[string]interface{} {
+	labelNodes := make([]map[string]string, 0, len(labels))
+	for _, l := range labels {
+		labelNodes = append(labelNodes, map[string]string{"name": l})
+	}
+	return map[string]interface{}{
+		"id":         "uuid-" + identifier,
+		"identifier": identifier,
+		"title":      title,
+		"url":        "https://linear.app/acme/issue/" + identifier,
+		"createdAt":  "2026-01-02T03:04:05Z",
+		"updatedAt":  "2026-01-03T03:04:05Z",
+		"priority":   priority,
+		"state":      map[string]string{"name": state},
+		"assignee":   nil,
+		"labels":     map[string]interface{}{"nodes": labelNodes},
+		"team":       map[string]string{"key": "X"},
+	}
+}
+
+func gqlResponse(hasNext bool, cursor string, nodes ...map[string]interface{}) map[string]interface{} {
+	if nodes == nil {
+		nodes = []map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"issues": map[string]interface{}{
+				"pageInfo": map[string]interface{}{
+					"hasNextPage": hasNext,
+					"endCursor":   cursor,
+				},
+				"nodes": nodes,
+			},
+		},
+	}
+}
+
+// serveGraphQL returns a test server whose handler decodes the GraphQL
+// request and dispatches to fn.
+func serveGraphQL(t *testing.T, fn func(vars gqlVars) map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var req gqlReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if err := json.NewEncoder(w).Encode(fn(req.Variables)); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+}
+
+func TestLinearListIssuesBasic(t *testing.T) {
+	srv := serveGraphQL(t, func(vars gqlVars) map[string]interface{} {
+		if vars.TeamKey != "ENG" {
+			t.Errorf("unexpected teamKey %q", vars.TeamKey)
+		}
+		return gqlResponse(false, "",
+			issueNode("ENG-1", "First", 1, "Todo"),
+			issueNode("ENG-2", "Second", 3, "Backlog", "bug"),
+		)
+	})
+	defer srv.Close()
+
+	src := worksource.NewLinearSource(worksource.LinearConfig{
+		APIKey:  "key",
+		BaseURL: srv.URL,
+		Teams:   []worksource.LinearTeamConfig{{Key: "ENG", Repo: "acme/app", States: []string{"Todo", "Backlog"}}},
+	}, nil)
+
+	issues, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+	got := issues[0]
+	if got.SourceType != "linear" || got.Repo != "acme/app" || got.ExternalID != "ENG-1" ||
+		got.Title != "First" || got.Priority != "high" || got.State != "Todo" ||
+		got.URL != "https://linear.app/acme/issue/ENG-1" {
+		t.Errorf("unexpected issue: %+v", got)
+	}
+	if !reflect.DeepEqual(issues[1].Labels, []string{"bug"}) {
+		t.Errorf("labels = %v, want [bug]", issues[1].Labels)
+	}
+	if src.SourceType() != "linear" {
+		t.Errorf("SourceType() = %q", src.SourceType())
+	}
+}
+
+func TestLinearListIssuesMultiTeam(t *testing.T) {
+	srv := serveGraphQL(t, func(vars gqlVars) map[string]interface{} {
+		switch vars.TeamKey {
+		case "ENG":
+			return gqlResponse(false, "", issueNode("ENG-1", "Eng work", 2, "Todo"))
+		case "OPS":
+			return gqlResponse(false, "", issueNode("OPS-9", "Ops work", 0, "Backlog"))
+		default:
+			t.Errorf("unexpected teamKey %q", vars.TeamKey)
+			return gqlResponse(false, "")
+		}
+	})
+	defer srv.Close()
+
+	src := worksource.NewLinearSource(worksource.LinearConfig{
+		APIKey:  "key",
+		BaseURL: srv.URL,
+		Teams: []worksource.LinearTeamConfig{
+			{Key: "ENG", Repo: "acme/app", States: []string{"Todo"}},
+			{Key: "OPS", Repo: "acme/infra", States: []string{"Backlog"}},
+		},
+	}, nil)
+
+	issues, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+	if issues[0].ExternalID != "ENG-1" || issues[0].Repo != "acme/app" {
+		t.Errorf("issue[0] = %+v", issues[0])
+	}
+	if issues[1].ExternalID != "OPS-9" || issues[1].Repo != "acme/infra" {
+		t.Errorf("issue[1] = %+v", issues[1])
+	}
+}
+
+func TestLinearListIssuesPagination(t *testing.T) {
+	calls := 0
+	srv := serveGraphQL(t, func(vars gqlVars) map[string]interface{} {
+		calls++
+		if calls == 1 {
+			if vars.Cursor != nil {
+				t.Errorf("first page cursor = %v, want nil", *vars.Cursor)
+			}
+			return gqlResponse(true, "cursor-1", issueNode("ENG-1", "Page one", 2, "Todo"))
+		}
+		if vars.Cursor == nil || *vars.Cursor != "cursor-1" {
+			t.Errorf("second page cursor = %v, want cursor-1", vars.Cursor)
+		}
+		return gqlResponse(false, "", issueNode("ENG-2", "Page two", 2, "Todo"))
+	})
+	defer srv.Close()
+
+	src := worksource.NewLinearSource(worksource.LinearConfig{
+		APIKey:  "key",
+		BaseURL: srv.URL,
+		Teams:   []worksource.LinearTeamConfig{{Key: "ENG", Repo: "acme/app", States: []string{"Todo"}}},
+	}, nil)
+
+	issues, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 GraphQL calls, got %d", calls)
+	}
+	if len(issues) != 2 || issues[0].ExternalID != "ENG-1" || issues[1].ExternalID != "ENG-2" {
+		t.Errorf("unexpected issues: %+v", issues)
+	}
+}
+
+func TestLinearPriorityMapping(t *testing.T) {
+	srv := serveGraphQL(t, func(vars gqlVars) map[string]interface{} {
+		return gqlResponse(false, "",
+			issueNode("ENG-1", "Urgent", 0, "Todo"),
+			issueNode("ENG-2", "Medium", 2, "Todo"),
+			issueNode("ENG-3", "NoPriority", 4, "Todo"),
+		)
+	})
+	defer srv.Close()
+
+	src := worksource.NewLinearSource(worksource.LinearConfig{
+		APIKey:  "key",
+		BaseURL: srv.URL,
+		Teams:   []worksource.LinearTeamConfig{{Key: "ENG", Repo: "acme/app", States: []string{"Todo"}}},
+	}, nil)
+
+	issues, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	want := []string{"urgent", "medium", "none"}
+	if len(issues) != len(want) {
+		t.Fatalf("expected %d issues, got %d", len(want), len(issues))
+	}
+	for i, w := range want {
+		if issues[i].Priority != w {
+			t.Errorf("issue %s priority = %q, want %q", issues[i].ExternalID, issues[i].Priority, w)
+		}
+	}
+}
+
+func TestLinearHoldLabelFiltering(t *testing.T) {
+	srv := serveGraphQL(t, func(vars gqlVars) map[string]interface{} {
+		return gqlResponse(false, "",
+			issueNode("ENG-1", "Free", 2, "Todo", "bug"),
+			issueNode("ENG-2", "Held", 2, "Todo", "bug", "blocked"),
+		)
+	})
+	defer srv.Close()
+
+	src := worksource.NewLinearSource(worksource.LinearConfig{
+		APIKey:     "key",
+		BaseURL:    srv.URL,
+		HoldLabels: []string{"hold", "blocked"},
+		Teams:      []worksource.LinearTeamConfig{{Key: "ENG", Repo: "acme/app", States: []string{"Todo"}}},
+	}, nil)
+
+	issues, err := src.ListIssues(context.Background())
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].ExternalID != "ENG-1" {
+		t.Fatalf("expected only ENG-1, got %+v", issues)
+	}
+}
+
+func TestLinearDefaultStates(t *testing.T) {
+	var gotStates []string
+	srv := serveGraphQL(t, func(vars gqlVars) map[string]interface{} {
+		gotStates = vars.States
+		return gqlResponse(false, "")
+	})
+	defer srv.Close()
+
+	src := worksource.NewLinearSource(worksource.LinearConfig{
+		APIKey:  "key",
+		BaseURL: srv.URL,
+		Teams:   []worksource.LinearTeamConfig{{Key: "ENG", Repo: "acme/app"}},
+	}, nil)
+
+	if _, err := src.ListIssues(context.Background()); err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	want := []string{"Todo", "In Progress", "Backlog"}
+	if !reflect.DeepEqual(gotStates, want) {
+		t.Errorf("states = %v, want %v", gotStates, want)
+	}
+}


### PR DESCRIPTION
Closes #4184

Part of RFC #4178.

- Linear GraphQL API adapter using a single POST to api.linear.app/graphql
- Multi-team support: each team maps to a GitHub repo for agent cloning
- Priority normalization (0=urgent … 4=none)
- Hold-label filtering (gates issues the same way GitHub hold labels do)
- Pagination via pageInfo.hasNextPage / endCursor
- No new Go dependencies (stdlib net/http + encoding/json)
- Security note in package doc: Phase 2 write-back will need ACMM GraphQL enforcement
