### PR TITLE
🐛 fix(hub): re-scope pre-widening session cookies on dashboard load; add /api/saas/dibs/repos feed

### DIFF
--- a/src/pkg/hub/dibs_sso_followups_test.go
+++ b/src/pkg/hub/dibs_sso_followups_test.go
@@ -1,0 +1,236 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ============================================================
+// #4193 — follow-ups to the dibs SSO work in #4171/#4174.
+//
+//  1. Sessions minted BEFORE the cookie-domain widening never received the
+//     Domain=.kubestellar.io cookie: it was only issued at the OAuth callback,
+//     so already-signed-in users' browsers kept the old scope and
+//     dibs.kubestellar.io never saw the session. handleAuthUser (the one call
+//     the dashboard makes on every load) now re-issues the SAME verified
+//     session value with the widened Domain.
+//  2. GET /api/saas/dibs/repos — the public repo registry feed dibs polls
+//     every ~5 minutes (it used to 404).
+// ============================================================
+
+// TestAuthUserRemintsWideCookie pins the re-mint: an authenticated
+// /api/auth/user response must carry the live hive_hub_user cookie, with the
+// SAME value the request presented, scoped Domain=.kubestellar.io, plus the
+// legacy-scope expiry — exactly what the login callback emits.
+func TestAuthUserRemintsWideCookie(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "octocat")
+
+	presented := testAuthCookie("octocat")
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/auth/user", nil)
+	req.AddCookie(presented)
+	rec := httptest.NewRecorder()
+	s.handleAuthUser(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authenticated /api/auth/user = %d, want 200", rec.Code)
+	}
+	var live, legacyClear *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != "hive_hub_user" {
+			continue
+		}
+		if c.Value != "" {
+			live = c
+		} else {
+			legacyClear = c
+		}
+	}
+	if live == nil {
+		t.Fatal("authenticated /api/auth/user re-minted no hive_hub_user cookie — pre-widening sessions never converge to the wide scope")
+	}
+	if live.Value != presented.Value {
+		t.Errorf("re-mint changed the session value — it must re-issue the SAME verified value, not mint a new session")
+	}
+	if live.Domain != "kubestellar.io" {
+		t.Errorf("re-minted cookie Domain = %q, want .kubestellar.io", live.Domain)
+	}
+	if !live.Secure || !live.HttpOnly || live.SameSite != http.SameSiteLaxMode {
+		t.Errorf("re-minted cookie lost hardening: Secure=%v HttpOnly=%v SameSite=%v", live.Secure, live.HttpOnly, live.SameSite)
+	}
+	if legacyClear == nil {
+		t.Fatal("re-mint did not expire the legacy .hive.kubestellar.io-scoped copy")
+	}
+	if legacyClear.Domain != "hive.kubestellar.io" || legacyClear.MaxAge >= 0 {
+		t.Errorf("legacy clear cookie Domain=%q MaxAge=%d, want .hive.kubestellar.io with MaxAge<0", legacyClear.Domain, legacyClear.MaxAge)
+	}
+}
+
+// TestAuthUserRemintHostOnlyForDev pins the dev fallback: on a host outside
+// kubestellar.io the re-minted cookie must stay host-only (a browser rejects a
+// non-covering Domain, so widening would break local sessions).
+func TestAuthUserRemintHostOnlyForDev(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "octocat")
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost:8080/api/auth/user", nil)
+	req.AddCookie(testAuthCookie("octocat"))
+	rec := httptest.NewRecorder()
+	s.handleAuthUser(rec, req)
+
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" && c.Domain != "" {
+			t.Errorf("dev host re-mint carries Domain=%q, want host-only", c.Domain)
+		}
+	}
+}
+
+// TestAuthUserNoCookieForAnonymous pins that an unauthenticated request gets
+// NO Set-Cookie: re-minting is strictly for requests that already carry a
+// valid session.
+func TestAuthUserNoCookieForAnonymous(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	for _, c := range []*http.Cookie{nil, {Name: "hive_hub_user", Value: "forged"}} {
+		req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/auth/user", nil)
+		if c != nil {
+			req.AddCookie(c)
+		}
+		rec := httptest.NewRecorder()
+		s.handleAuthUser(rec, req)
+		if got := rec.Result().Cookies(); len(got) != 0 {
+			t.Errorf("anonymous /api/auth/user emitted %d Set-Cookie header(s), want none", len(got))
+		}
+	}
+}
+
+// mkDibsHive writes a hive record with the fields the dibs feed keys on.
+func mkDibsHive(t *testing.T, h SaaSHive) {
+	t.Helper()
+	if err := saveSaaSHive(&h); err != nil {
+		t.Fatalf("saveSaaSHive(%s): %v", h.ID, err)
+	}
+}
+
+// TestDibsReposShapeAndFiltering pins both halves of the feed contract: the
+// JSON field names dibs's registry client decodes (repoID/hiveID/owner/
+// description), and the inclusion rules that keep the unauthenticated answer
+// public-only (is_public, public github.com, real assigned identity).
+func TestDibsReposShapeAndFiltering(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	// Included: public hive on public github.com with a real org/repo, plus a
+	// secondary repo and a duplicate of the primary that must be deduped.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-good-1", Owner: "octocat", Org: "kubestellar",
+		PrimaryRepo: "hive", Repos: []string{"hive", "dibs"},
+		ProjectName: "KubeStellar Hive", IsPublic: true,
+	})
+	// Included: primary_repo already carrying owner/repo is the repo ID as-is.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-good-2", Owner: "hubber", Org: "some-org",
+		PrimaryRepo: "other-owner/tool", IsPublic: true,
+	})
+	// Excluded: not public.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-private", Owner: "octocat", Org: "secretcorp",
+		PrimaryRepo: "skunkworks", IsPublic: false,
+	})
+	// Excluded: GHE host — an enterprise repo's name can itself be confidential.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-ghe", Owner: "octocat", Org: "ibm-internal",
+		PrimaryRepo: "z-tool", IsPublic: true, GitHubHost: "github.ibm.com",
+	})
+	// Excluded: GHE pinned via github_base_url rather than github_host.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-ghe-base", Owner: "octocat", Org: "cisco-internal",
+		PrimaryRepo: "net-tool", IsPublic: true, GitHubBaseURL: "https://github.cisco.com",
+	})
+	// Excluded: non-GitHub forge.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-gitlab", Owner: "octocat", Org: "gl-org",
+		PrimaryRepo: "gl-repo", IsPublic: true, Forge: "gitlab",
+	})
+	// Excluded: unclaimed placeholder (synthetic inventory org, no repo).
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-available-3", Owner: "", Org: placeholderOrgPrefix + "3",
+		IsPublic: true, Status: statusAvailable,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/dibs/repos", nil)
+	rec := httptest.NewRecorder()
+	s.handleDibsRepos(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/api/saas/dibs/repos = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	// Decode into the exact shape dibs's registry client uses, keyed on the
+	// wire names — a renamed field here breaks the sibling silently.
+	var got []struct {
+		RepoID      string `json:"repoID"`
+		HiveID      string `json:"hiveID"`
+		Owner       string `json:"owner"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body is not the expected JSON array: %v (body %s)", err, rec.Body.String())
+	}
+	want := map[string]struct{ hive, owner string }{
+		"kubestellar/hive": {"hosted-good-1", "octocat"},
+		"kubestellar/dibs": {"hosted-good-1", "octocat"},
+		"other-owner/tool": {"hosted-good-2", "hubber"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("feed lists %d repos %v, want exactly the %d public github.com repos", len(got), got, len(want))
+	}
+	for _, e := range got {
+		w, ok := want[e.RepoID]
+		if !ok {
+			t.Errorf("feed leaked repo %q — only public repos of public hives may appear", e.RepoID)
+			continue
+		}
+		if e.HiveID != w.hive || e.Owner != w.owner {
+			t.Errorf("repo %s: hiveID=%q owner=%q, want %q/%q", e.RepoID, e.HiveID, e.Owner, w.hive, w.owner)
+		}
+	}
+	for _, e := range got {
+		if e.RepoID == "kubestellar/hive" && e.Description != "KubeStellar Hive" {
+			t.Errorf("description = %q, want the hive's public project name", e.Description)
+		}
+	}
+}
+
+// TestDibsReposPublicNoSession pins that the endpoint answers server-to-server
+// callers carrying no cookie at all (dibs has no hub session of its own), and
+// that an EMPTY registry still returns a JSON array, never null — dibs decodes
+// into a slice and merges, so null vs [] is the difference between a sync and
+// a decode surprise.
+func TestDibsReposPublicNoSession(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/dibs/repos", nil)
+	rec := httptest.NewRecorder()
+	s.handleDibsRepos(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no-session /api/saas/dibs/repos = %d, want 200 — dibs calls with no cookie", rec.Code)
+	}
+	if body := rec.Body.String(); body != "[]\n" {
+		t.Errorf("empty registry body = %q, want a JSON array literal []", body)
+	}
+}

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -756,6 +756,22 @@ func (s *HubServer) mintSessionCookies(w http.ResponseWriter, r *http.Request, c
 		http.Error(w, "session unavailable", http.StatusInternalServerError)
 		return false
 	}
+	setSessionCookies(w, r, cookieValue)
+	return true
+}
+
+// setSessionCookies issues the Set-Cookie pair for an already-minted session
+// value: the live hive_hub_user cookie scoped to sessionCookieDomain(r.Host),
+// preceded by an expiry of the legacy .hive.kubestellar.io-scoped copy.
+//
+// Factored out of mintSessionCookies (#4193) so the SAME cookies can be
+// re-issued outside the login callback: a session minted BEFORE the #4171
+// domain widening still rides a host-only or .hive.kubestellar.io-scoped
+// cookie the browser never sends to dibs.kubestellar.io, and only a fresh
+// Set-Cookie can rescope it. handleAuthUser re-issues the verified value on
+// every authenticated dashboard load for exactly that reason — no new crypto,
+// just the delivery scope.
+func setSessionCookies(w http.ResponseWriter, r *http.Request, cookieValue string) {
 	// AUDIT F4, DELIBERATELY NOT CHANGED — read before "fixing" this.
 	//
 	// The audit asks for a host-only `__Host-` session cookie. That is correct
@@ -834,7 +850,6 @@ func (s *HubServer) mintSessionCookies(w http.ResponseWriter, r *http.Request, c
 		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, cookie)
-	return true
 }
 
 // oidcNonceFromCookie returns the OIDC replay nonce this browser was issued at
@@ -896,10 +911,11 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	// F10: also enforces a v3 cookie's signed expiry and revocation state.
 	// #4171: every hive_hub_user copy is tried (the domain-widening rollout can
 	// briefly leave two in the jar), matching getRealAuthUser.
-	var username string
+	var username, sessionValue string
 	for _, value := range hubSessionCookieValues(r) {
 		if u, ok := s.verifyHubUserCookie(value); ok && loadSaaSUser(u) != nil {
 			username = u
+			sessionValue = value
 			break
 		}
 	}
@@ -908,6 +924,24 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
+	// #4193: re-scope the session cookie on every authenticated dashboard load.
+	// A session minted BEFORE the #4171 domain widening still rides a cookie
+	// scoped host-only or to .hive.kubestellar.io, which the browser never
+	// sends to dibs.kubestellar.io — SSO silently fails for exactly the users
+	// who were already signed in when the widening shipped, until they happen
+	// to log out and back in. Re-issuing the SAME verified value with
+	// Domain=sessionCookieDomain(r.Host) (plus the legacy-scope expiry) here
+	// converges those sessions without new crypto or a forced re-login.
+	//
+	// This endpoint and not every API call: the dashboard fetches
+	// /api/auth/user exactly once on load, so the Set-Cookie pair rides one
+	// cheap request per page view instead of spamming every poll. Re-setting
+	// an already-wide cookie is a no-op for the jar (same name/domain/path),
+	// and the refreshed MaxAge is only the browser-side hint — the session's
+	// real lifetime is the SIGNED expiry inside the value, which this does not
+	// touch. Dev/localhost hosts keep their host-only cookie via
+	// sessionCookieDomain, same as the login callback.
+	setSessionCookies(w, r, sessionValue)
 	isAdmin := isHubAdmin(username)
 	displayLogin, avatar := s.displayIdentity(username)
 	// Fold impersonation status into the auth payload the dashboard already

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -504,6 +504,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	// requireAuth so the unauthenticated answer is the exact 401 JSON shape the
 	// dibs bridge expects rather than the generic middleware error.
 	s.mux.HandleFunc("GET /api/saas/whoami", s.handleSaaSWhoami)
+	// Sibling-product repo registry (#4193): dibs polls this server-to-server
+	// (no session) every ~5 minutes to learn which repos hives manage. Public
+	// by design, so it returns ONLY already-public data — see handleDibsRepos.
+	s.mux.HandleFunc("GET /api/saas/dibs/repos", s.handleDibsRepos)
 	s.mux.HandleFunc("POST /api/saas/user-token", s.requireAuth(s.handleUserToken))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/access", s.requireAuth(s.handleAccessList))
 	s.mux.HandleFunc("GET /api/saas/grantable-users", s.requireAuth(s.handleGrantableUsers))
@@ -8595,6 +8599,106 @@ func (s *HubServer) handleSaaSWhoami(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write(data)
+}
+
+// dibsRepoEntry is one hive-managed repo in the feed dibs's registry syncs
+// from (GET /api/saas/dibs/repos, #4193). The field set and JSON names match
+// dibs's pkg/registry RepoProfile contract exactly:
+//
+//	[{"repoID":"org/name","hiveID":"...","owner":"github-login","description":"..."}]
+//
+// Owner-editable dibs fields (topics, acceptingIdeas, appetite) are dibs-local
+// state and deliberately absent here.
+type dibsRepoEntry struct {
+	RepoID      string `json:"repoID"`
+	HiveID      string `json:"hiveID"`
+	Owner       string `json:"owner"`
+	Description string `json:"description,omitempty"`
+}
+
+// handleDibsRepos lists the PUBLIC hive-managed repos for dibs's idea-matching
+// registry (#4193). Dibs polls this server-to-server with no browser session,
+// so the endpoint is deliberately unauthenticated — which is safe only because
+// every fact it returns is already public, and the inclusion rules below are
+// what make that true. A hive contributes its repos only when ALL hold:
+//
+//   - is_public: the operator opted the hive into registry visibility (the
+//     same flag that gates the public hive registry), so its project identity
+//     is already published;
+//   - it lives on PUBLIC github.com — the GitHub-family forge with no GHE
+//     host pinned at hive or cluster level (effectiveGitHubBaseURL == "").
+//     An enterprise repo's very NAME can be confidential, so GHE hives are
+//     excluded outright;
+//   - it has a real assigned identity: a non-placeholder org (the synthetic
+//     "available-<id>" inventory org never names a repo) and at least one
+//     repo recorded.
+//
+// owner is the hive owner's stable identity key — bare GitHub login for
+// GitHub users, canonical provider:sub otherwise — byte-identical to the
+// username /api/saas/whoami reports, so dibs can match a signed-in user to
+// the repos they own.
+//
+// Cache-Control allows short shared caching: the answer is public, identical
+// for every caller, and dibs re-syncs every ~5 minutes anyway.
+func (s *HubServer) handleDibsRepos(w http.ResponseWriter, r *http.Request) {
+	entries := []dibsRepoEntry{}
+	seen := map[string]bool{}
+	for _, sh := range listSaaSHives() {
+		if !sh.IsPublic {
+			continue
+		}
+		// GitHub family only — the pkg/forge adapters (gitlab/gitea) never
+		// point at github.com repos.
+		if sh.Forge != "" && sh.Forge != "github" {
+			continue
+		}
+		// GHE anywhere in the resolution chain (heartbeat-recorded host,
+		// hive-level pin, or cluster default) excludes the hive.
+		if sh.GitHubHost != "" {
+			continue
+		}
+		cluster := s.clusters[sh.ClusterID]
+		if effectiveGitHubBaseURL(&sh, &cluster) != "" {
+			continue
+		}
+		if sh.Org == "" || strings.HasPrefix(sh.Org, placeholderOrgPrefix) {
+			continue
+		}
+		// Same stable-key normalization as handleSaaSWhoami, so the two
+		// endpoints can never disagree about who a user is.
+		owner := sh.Owner
+		if provider, subject, ok := parseCanonical(canonicalizeLegacy(owner)); ok && provider == legacyProvider {
+			owner = subject
+		}
+		for _, repo := range append([]string{sh.PrimaryRepo}, sh.Repos...) {
+			if repo == "" {
+				continue
+			}
+			// A primary_repo may already carry "owner/repo" (GHE/legacy
+			// records do) — that pair IS the repo ID; otherwise the hive's
+			// org is the owner half.
+			repoID := repo
+			if !strings.Contains(repo, "/") {
+				repoID = sh.Org + "/" + repo
+			}
+			if seen[repoID] {
+				continue
+			}
+			seen[repoID] = true
+			entries = append(entries, dibsRepoEntry{
+				RepoID:      repoID,
+				HiveID:      sh.ID,
+				Owner:       owner,
+				Description: sh.ProjectName,
+			})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].RepoID < entries[j].RepoID })
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	if err := json.NewEncoder(w).Encode(entries); err != nil {
+		s.logger.Warn("dibs repos: encoding response", "error", err)
+	}
 }
 
 func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes #4193

Two follow-ups to the dibs SSO work merged in #4174.

## 1. Pre-widening sessions never got the wide cookie (production SSO failure)

The `Domain=.kubestellar.io` session cookie was only minted at the OAuth callback, so anyone signed in before #4174 shipped kept the old host-only/`.hive.kubestellar.io`-scoped cookie. The browser never sends that to `dibs.kubestellar.io`, so SSO silently failed until a manual re-login.

**Fix:** the Set-Cookie pair (wide live cookie + legacy-scope expiry) is factored out of `mintSessionCookies` into `setSessionCookies(w, r, cookieValue)`, and `handleAuthUser` — the one `/api/auth/user` call the dashboard makes on every load — now re-issues the **same verified session value** with the widened scope:

- only when the request carries a valid session (no Set-Cookie for anonymous callers);
- no new crypto — the already-parsed, verified cookie value is re-issued as-is, and the signed expiry inside it is untouched (the refreshed `MaxAge` is only the browser hint);
- confined to `/api/auth/user` (once per page view) rather than every API call;
- dev/localhost keeps its host-only cookie via the existing `sessionCookieDomain` derivation.

## 2. `GET /api/saas/dibs/repos` (hub 404'd the dibs registry poll)

Dibs polls this endpoint every ~5 minutes for the hive-managed repo registry (contract in dibs `pkg/registry`). Implemented, matching the wire shape exactly:

```json
[{"repoID":"org/name","hiveID":"...","owner":"github-login","description":"..."}]
```

`owner` uses the same stable-identity-key normalization as `/api/saas/whoami`, so dibs can match a signed-in user to their repos.

**Public endpoint, public data only.** Dibs calls server-to-server with no session, so the endpoint is unauthenticated — made safe by conservative inclusion rules. A hive contributes repos only when **all** hold:

- `is_public: true` — the operator already opted the hive into registry visibility;
- it lives on **public github.com**: GitHub-family forge (no gitlab/gitea), no GHE host at any level of the resolution chain (`github_host`, hive-level `github_base_url` pin, or cluster default via `effectiveGitHubBaseURL`) — an enterprise repo's very name can be confidential;
- a real assigned identity: non-placeholder org (`available-*` inventory slots excluded) and at least one recorded repo.

`description` is the hive's public project name. `Cache-Control: public, max-age=300` matches the poll interval. Empty registry returns `[]`, never `null`.

## Tests

- re-mint on authenticated `/api/auth/user`: same value, `Domain=.kubestellar.io`, legacy-scope expiry, hardening preserved
- host-only re-mint on dev hosts; **no** Set-Cookie for anonymous/forged-cookie requests
- `/api/saas/dibs/repos`: exact JSON shape, dedup, `owner/repo`-style `primary_repo` handling, and exclusion of private / GHE (both pin styles) / gitlab / placeholder hives
- no-session request answers 200 with `[]`

`go build ./... && go vet ./...` clean; `go test ./pkg/hub/ -short -race -count=1` passes.
