### PR TITLE
✨ feat(worksource): config block, factory, governor wiring, and dashboard source badge

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -81,6 +81,7 @@ import (
 	"github.com/kubestellar/hive/pkg/tracing"
 	"github.com/kubestellar/hive/pkg/trajectory"
 	"github.com/kubestellar/hive/pkg/watsonx"
+	"github.com/kubestellar/hive/pkg/worksource"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -3252,7 +3253,12 @@ func main() {
 				PrimaryRepo:             cfg.Project.PrimaryRepo,
 				ACMMLevel:               acmmLvl,
 				Agents:                  agents,
-				Governor:                hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
+				Governor: hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs, WorkSource: func() string {
+					if t := cfg.Governor.WorkSource.Type; t != "" && t != "github" {
+						return t
+					}
+					return ""
+				}()},
 				// Tokens carries the spoke's authoritative cumulative token
 				// total (same store the dashboard token panel and governor
 				// budget read). It flows to the hub's My Hives token column so
@@ -4810,6 +4816,27 @@ func runEvalCycle(
 	if err != nil {
 		logger.Error("failed to enumerate actionable items", "error", err)
 		return
+	}
+
+	// If a non-default work source is configured, overlay its issues onto
+	// the actionable result. PRs always come from GitHub.
+	if wsType := cfg.Governor.WorkSource.Type; wsType != "" && wsType != "github" {
+		ghToken := cfg.GitHub.Token
+		if ghToken == "" {
+			ghToken = os.Getenv("HIVE_GITHUB_TOKEN")
+		}
+		ws, wsErr := worksource.FromConfig(cfg.Governor.WorkSource, ghClient, ghToken, cfg.Project.Org, logger)
+		if wsErr != nil {
+			logger.Warn("work_source config error, falling back to GitHub Issues", "error", wsErr)
+		} else if wsIssues, listErr := ws.ListIssues(ctx); listErr != nil {
+			logger.Warn("work_source enumeration failed, falling back to GitHub Issues", "source", ws.SourceType(), "error", listErr)
+		} else {
+			// Replace the Issues portion of actionable with worksource results.
+			actionable.Issues = github.IssueResult{
+				Count: len(wsIssues),
+				Items: worksource.ToGitHubIssues(wsIssues),
+			}
+		}
 	}
 
 	ghClient.EnrichCIStatus(ctx, actionable.PRs.Items)

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -982,6 +982,60 @@ type GovernorConfig struct {
 	// digest shows, and how long a finding may go un-reconfirmed before the
 	// hive retires it. See AdvisoryConfig.
 	Advisory AdvisoryConfig `yaml:"advisory,omitempty" json:"advisory,omitempty"`
+
+	// WorkSource selects where hive reads work items (Step 01 of the loop).
+	// Absent or type="" defaults to GitHub Issues — backward-compatible for
+	// all existing hives.
+	WorkSource WorkSourceConfig `yaml:"work_source,omitempty" json:"work_source,omitempty"`
+}
+
+// WorkSourceConfig selects where hive reads work items (Step 01 of the loop).
+// Absent or type="" defaults to GitHub Issues — backward-compatible for all
+// existing hives.
+type WorkSourceConfig struct {
+	// Type selects the work source: "" | "github" | "github_projects" | "linear" | "jira"
+	Type string `yaml:"type" json:"type"`
+	// GitHubProjects configures the GitHub Projects v2 adapter.
+	GitHubProjects GitHubProjectsSourceConfig `yaml:"github_projects,omitempty" json:"github_projects,omitempty"`
+	// Linear configures the Linear GraphQL adapter.
+	Linear LinearSourceConfig `yaml:"linear,omitempty" json:"linear,omitempty"`
+	// Jira configures the Jira Cloud REST v3 adapter.
+	Jira JiraSourceConfig `yaml:"jira,omitempty" json:"jira,omitempty"`
+}
+
+// GitHubProjectsSourceConfig configures the GitHub Projects v2 work source.
+type GitHubProjectsSourceConfig struct {
+	ProjectNumber  int      `yaml:"project_number" json:"project_number"`
+	Org            string   `yaml:"org,omitempty" json:"org,omitempty"`
+	States         []string `yaml:"states,omitempty" json:"states,omitempty"`
+	PriorityField  string   `yaml:"priority_field,omitempty" json:"priority_field,omitempty"`
+	IterationField string   `yaml:"iteration_field,omitempty" json:"iteration_field,omitempty"`
+	DefaultRepo    string   `yaml:"default_repo,omitempty" json:"default_repo,omitempty"`
+}
+
+// LinearSourceConfig configures the Linear GraphQL work source.
+type LinearSourceConfig struct {
+	APIKey     string                   `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	Teams      []LinearTeamSourceConfig `yaml:"teams,omitempty" json:"teams,omitempty"`
+	HoldLabels []string                 `yaml:"hold_labels,omitempty" json:"hold_labels,omitempty"`
+}
+
+// LinearTeamSourceConfig maps one Linear team to the GitHub repo agents work in.
+type LinearTeamSourceConfig struct {
+	Key    string   `yaml:"key" json:"key"`
+	Repo   string   `yaml:"repo" json:"repo"`
+	States []string `yaml:"states,omitempty" json:"states,omitempty"`
+}
+
+// JiraSourceConfig configures the Jira Cloud REST v3 work source.
+type JiraSourceConfig struct {
+	BaseURL     string   `yaml:"base_url" json:"base_url"`
+	Email       string   `yaml:"email" json:"email"`
+	APIToken    string   `yaml:"api_token,omitempty" json:"api_token,omitempty"`
+	ProjectKeys []string `yaml:"project_keys,omitempty" json:"project_keys,omitempty"`
+	JQL         string   `yaml:"jql,omitempty" json:"jql,omitempty"`
+	Repo        string   `yaml:"repo,omitempty" json:"repo,omitempty"`
+	HoldLabels  []string `yaml:"hold_labels,omitempty" json:"hold_labels,omitempty"`
 }
 
 // AdvisoryConfig controls the advisory digest's size and the lifecycle of the

--- a/src/pkg/config/worksource_config_test.go
+++ b/src/pkg/config/worksource_config_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestWorkSourceConfig_YAMLRoundTrip marshals and unmarshals a fully populated
+// WorkSourceConfig for each source type and verifies every field survives.
+func TestWorkSourceConfig_YAMLRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  WorkSourceConfig
+	}{
+		{"github_projects", WorkSourceConfig{
+			Type: "github_projects",
+			GitHubProjects: GitHubProjectsSourceConfig{
+				ProjectNumber:  12,
+				Org:            "my-org",
+				States:         []string{"Todo", "In Progress"},
+				PriorityField:  "Priority",
+				IterationField: "Sprint",
+				DefaultRepo:    "my-org/my-repo",
+			},
+		}},
+		{"linear", WorkSourceConfig{
+			Type: "linear",
+			Linear: LinearSourceConfig{
+				APIKey: "lin_key",
+				Teams: []LinearTeamSourceConfig{
+					{Key: "ENG", Repo: "my-org/my-repo", States: []string{"Todo", "Backlog"}},
+				},
+				HoldLabels: []string{"hold", "blocked"},
+			},
+		}},
+		{"jira", WorkSourceConfig{
+			Type: "jira",
+			Jira: JiraSourceConfig{
+				BaseURL:     "https://myorg.atlassian.net",
+				Email:       "ops@example.com",
+				APIToken:    "tok",
+				ProjectKeys: []string{"ENG", "OPS"},
+				JQL:         "project = ENG",
+				Repo:        "my-org/my-repo",
+				HoldLabels:  []string{"hold"},
+			},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := yaml.Marshal(tc.cfg)
+			if err != nil {
+				t.Fatalf("yaml.Marshal: %v", err)
+			}
+			var got WorkSourceConfig
+			if err := yaml.Unmarshal(data, &got); err != nil {
+				t.Fatalf("yaml.Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.cfg) {
+				t.Errorf("yaml round trip mismatch:\n got %+v\nwant %+v", got, tc.cfg)
+			}
+
+			jdata, err := json.Marshal(tc.cfg)
+			if err != nil {
+				t.Fatalf("json.Marshal: %v", err)
+			}
+			var jgot WorkSourceConfig
+			if err := json.Unmarshal(jdata, &jgot); err != nil {
+				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(jgot, tc.cfg) {
+				t.Errorf("json round trip mismatch:\n got %+v\nwant %+v", jgot, tc.cfg)
+			}
+		})
+	}
+}
+
+// TestGovernorConfig_WorkSourceAbsent pins backward compatibility: a governor
+// block with no work_source key yields the zero WorkSourceConfig (Type ""),
+// which the factory maps to the default GitHub Issues source.
+func TestGovernorConfig_WorkSourceAbsent(t *testing.T) {
+	var g GovernorConfig
+	if err := yaml.Unmarshal([]byte("eval_interval_s: 60\n"), &g); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if g.WorkSource.Type != "" {
+		t.Errorf("WorkSource.Type = %q, want empty (GitHub Issues default)", g.WorkSource.Type)
+	}
+}
+
+// TestGovernorConfig_WorkSourceParsed verifies the work_source block parses
+// from a governor-level YAML document.
+func TestGovernorConfig_WorkSourceParsed(t *testing.T) {
+	src := `
+work_source:
+  type: linear
+  linear:
+    api_key: lin_key
+    teams:
+      - key: ENG
+        repo: my-org/my-repo
+        states: [Todo]
+    hold_labels: [hold]
+`
+	var g GovernorConfig
+	if err := yaml.Unmarshal([]byte(src), &g); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if g.WorkSource.Type != "linear" {
+		t.Fatalf("Type = %q, want linear", g.WorkSource.Type)
+	}
+	if g.WorkSource.Linear.APIKey != "lin_key" {
+		t.Errorf("APIKey = %q", g.WorkSource.Linear.APIKey)
+	}
+	if len(g.WorkSource.Linear.Teams) != 1 || g.WorkSource.Linear.Teams[0].Repo != "my-org/my-repo" {
+		t.Errorf("Teams = %+v", g.WorkSource.Linear.Teams)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -350,6 +350,10 @@ type GovernorSummary struct {
 	Mode   string `json:"mode"`
 	Issues int    `json:"issues"`
 	PRs    int    `json:"prs"`
+	// WorkSource is the configured work source type ("github_projects",
+	// "linear", "jira"). Empty for the default GitHub Issues source; the hub
+	// dashboard only badges non-default sources.
+	WorkSource string `json:"work_source,omitempty"`
 }
 
 type ContributorSummary struct {

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -9002,6 +9002,12 @@ const dashboardHTML = `<!DOCTYPE html>
     .table-wrap::-webkit-scrollbar-thumb:hover { background: var(--muted); }
     .table-wrap.has-scroll { padding-bottom: 4px; border-bottom: 2px solid var(--line); }
     .hive-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+    /* Work-source badge: shown next to the issue count when a hive reads work
+       from a non-default source (GitHub Projects, Linear, Jira). */
+    .ws-badge { display:inline-block; font-size:10px; font-weight:600; padding:1px 6px; border-radius:3px; margin-left:4px; vertical-align:middle; }
+    .ws-badge--github_projects { background:#1a3a5c; color:#58a6ff; }
+    .ws-badge--linear { background:#2d1b69; color:#a78bfa; }
+    .ws-badge--jira { background:#0052cc; color:#fff; }
     .hive-table th { text-align: center; padding: 10px 12px; border-bottom: 2px solid var(--line); color: var(--muted); font-weight: 600; font-size: 0.75rem; white-space: nowrap; text-transform: uppercase; letter-spacing: 0.5px; }
     .hive-table td { padding: 12px; border-bottom: 1px solid #ffffff0a; vertical-align: middle; text-align: center; }
     .hive-table td:first-child { text-align: left; }
@@ -9383,6 +9389,15 @@ const dashboardHTML = `<!DOCTYPE html>
     // spoke-reported, i.e. untrusted. Use escAttr for anything interpolated
     // into an attribute; esc() remains correct for text nodes.
     function escAttr(s) { return esc(s).replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
+    /* wsBadge renders a small work-source badge ("Linear", "Jira", "GH Projects")
+       next to a hive's issue count when the spoke reads work from a non-default
+       source. Empty/default ("", "github") renders nothing. */
+    function wsBadge(ws) {
+      if (!ws || ws === 'github') return '';
+      var labels = { github_projects: 'GH Projects', linear: 'Linear', jira: 'Jira' };
+      var cls = /^[a-z_]+$/.test(ws) ? ws : 'unknown';
+      return '<span class="ws-badge ws-badge--' + cls + '" title="Work source: ' + escAttr(ws) + '">' + esc(labels[ws] || ws) + '</span>';
+    }
 
     /* ---- Clickable user avatars ---------------------------------------
        Every face in this dashboard is a link to that person's GitHub profile.
@@ -14939,7 +14954,7 @@ const dashboardHTML = `<!DOCTYPE html>
              controls (actionableIssues, actionablePRs, activeContributors). */
           '<td style="font-size:0.72rem">' +
             '<div style="' + STACKED_CELL_STYLE + ';align-items:flex-start">' +
-              '<div style="' + STACKED_LINE_STYLE + '" title="Actionable issues"><span style="color:var(--muted);min-width:24px;display:inline-block">Iss</span>' + sparkline(h.issueHistory, '#f59e0b', 40, 12) + (h.actionableIssues || 0) + '</div>' +
+              '<div style="' + STACKED_LINE_STYLE + '" title="Actionable issues"><span style="color:var(--muted);min-width:24px;display:inline-block">Iss</span>' + sparkline(h.issueHistory, '#f59e0b', 40, 12) + (h.actionableIssues || 0) + wsBadge(h.workSource) + '</div>' +
               '<div style="' + STACKED_LINE_STYLE + '" title="Actionable PRs"><span style="color:var(--muted);min-width:24px;display:inline-block">PRs</span>' + sparkline(h.prHistory, '#3b82f6', 40, 12) + (h.actionablePRs || 0) + '</div>' +
               '<div style="' + STACKED_LINE_STYLE + '" title="Active contributors"><span style="color:var(--muted);min-width:24px;display:inline-block">Ctr</span>' + (h.activeContributors || 0) + '</div>' +
             '</div>' +

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -155,14 +155,18 @@ type RegistryEntry struct {
 	// RouteExists is the spoke's in-cluster confirmation that an Ingress or
 	// OpenShift Route exists for DashboardURL's host. Nil means an old spoke
 	// did not report it; unknown means it could not verify (for example RBAC).
-	RouteExists        *RouteExistenceCheck  `json:"routeExists,omitempty"`
-	SnapshotURL        string                `json:"snapshotUrl,omitempty"`
-	ACMMLevel          int                   `json:"acmmLevel"`
-	AgentCount         int                   `json:"agentCount"`
-	GovernorMode       string                `json:"governorMode"`
-	TotalTokens24h     int64                 `json:"totalTokens24h"`
-	ActionableIssues   int                   `json:"actionableIssues"`
-	ActionablePRs      int                   `json:"actionablePRs"`
+	RouteExists      *RouteExistenceCheck `json:"routeExists,omitempty"`
+	SnapshotURL      string               `json:"snapshotUrl,omitempty"`
+	ACMMLevel        int                  `json:"acmmLevel"`
+	AgentCount       int                  `json:"agentCount"`
+	GovernorMode     string               `json:"governorMode"`
+	TotalTokens24h   int64                `json:"totalTokens24h"`
+	ActionableIssues int                  `json:"actionableIssues"`
+	ActionablePRs    int                  `json:"actionablePRs"`
+	// WorkSource is the spoke's configured non-default work source type
+	// ("github_projects", "linear", "jira"). Empty for GitHub Issues (the
+	// default) — the dashboard only shows a badge when non-empty.
+	WorkSource         string                `json:"workSource,omitempty"`
 	ContributorCount   int                   `json:"contributorCount"`
 	ActiveContributors int                   `json:"activeContributors"`
 	Owner              string                `json:"owner,omitempty"`
@@ -1600,6 +1604,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		TotalTokens24h:     clampInt64(payload.Tokens24h, 0, 100_000_000_000),
 		ActionableIssues:   clampInt(payload.Governor.Issues, 0, 10_000),
 		ActionablePRs:      clampInt(payload.Governor.PRs, 0, 10_000),
+		WorkSource:         sanitizeHeartbeatField(payload.Governor.WorkSource),
 		ContributorCount:   clampInt(payload.Contributors.Registered, 0, 10_000),
 		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
 		Owner:              sanitizeHeartbeatField(payload.Owner),

--- a/src/pkg/worksource/adapt.go
+++ b/src/pkg/worksource/adapt.go
@@ -1,0 +1,25 @@
+package worksource
+
+import "github.com/kubestellar/hive/pkg/github"
+
+// ToGitHubIssues converts a worksource Issue slice into the github.Issue shape
+// that the scheduler and governor consume. GitHub-native fields not present in
+// the worksource type (AgeMinutes, IsTracker, ComplexityTier, ModelRec, Lane)
+// are left at their zero values and will be populated downstream by classify.
+func ToGitHubIssues(issues []Issue) []github.Issue {
+	out := make([]github.Issue, len(issues))
+	for i, ws := range issues {
+		out[i] = github.Issue{
+			Repo:      ws.Repo,
+			Number:    ws.Number,
+			Title:     ws.Title,
+			Author:    ws.Author,
+			Labels:    ws.Labels,
+			Assignees: ws.Assignees,
+			CreatedAt: ws.CreatedAt,
+			UpdatedAt: ws.UpdatedAt,
+			URL:       ws.URL,
+		}
+	}
+	return out
+}

--- a/src/pkg/worksource/adapt_test.go
+++ b/src/pkg/worksource/adapt_test.go
@@ -1,0 +1,59 @@
+package worksource
+
+import (
+	"testing"
+	"time"
+)
+
+// TestToGitHubIssues verifies the normalized worksource Issue fields map onto
+// the github.Issue shape the scheduler consumes.
+func TestToGitHubIssues(t *testing.T) {
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	updated := created.Add(time.Hour)
+	in := []Issue{
+		{
+			SourceType: "linear",
+			Repo:       "my-org/my-repo",
+			ExternalID: "ENG-123",
+			Number:     0,
+			Title:      "Fix the flux capacitor",
+			Author:     "doc",
+			Labels:     []string{"bug", "urgent"},
+			Assignees:  []string{"marty"},
+			CreatedAt:  created,
+			UpdatedAt:  updated,
+			URL:        "https://linear.app/eng/issue/ENG-123",
+		},
+	}
+	out := ToGitHubIssues(in)
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	g := out[0]
+	if g.Repo != "my-org/my-repo" || g.Number != 0 || g.Title != "Fix the flux capacitor" ||
+		g.Author != "doc" || g.URL != "https://linear.app/eng/issue/ENG-123" {
+		t.Errorf("scalar fields not mapped: %+v", g)
+	}
+	if len(g.Labels) != 2 || g.Labels[0] != "bug" {
+		t.Errorf("labels not mapped: %v", g.Labels)
+	}
+	if len(g.Assignees) != 1 || g.Assignees[0] != "marty" {
+		t.Errorf("assignees not mapped: %v", g.Assignees)
+	}
+	if !g.CreatedAt.Equal(created) || !g.UpdatedAt.Equal(updated) {
+		t.Errorf("timestamps not mapped: created=%v updated=%v", g.CreatedAt, g.UpdatedAt)
+	}
+	// GitHub-native fields must stay zero — populated downstream by classify.
+	if g.AgeMinutes != 0 || g.IsTracker || g.ComplexityTier != "" || g.ModelRec != "" || g.Lane != "" {
+		t.Errorf("github-native fields must be zero: %+v", g)
+	}
+}
+
+// TestToGitHubIssues_Empty pins that an empty input gives an empty (non-nil)
+// slice so IssueResult.Items is never nil after an overlay.
+func TestToGitHubIssues_Empty(t *testing.T) {
+	out := ToGitHubIssues(nil)
+	if out == nil || len(out) != 0 {
+		t.Errorf("want empty non-nil slice, got %v", out)
+	}
+}

--- a/src/pkg/worksource/factory.go
+++ b/src/pkg/worksource/factory.go
@@ -1,0 +1,61 @@
+package worksource
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+// FromConfig constructs the WorkSource for a governor from its WorkSourceConfig.
+// When cfg.Type is "" or "github", returns a githubIssuesSource wrapping the
+// existing ghClient — no config change needed for existing hives.
+func FromConfig(cfg config.WorkSourceConfig, ghClient *github.Client, ghToken, ghOrg string, logger *slog.Logger) (WorkSource, error) {
+	switch cfg.Type {
+	case "", "github":
+		return NewGitHubIssuesSource(ghClient), nil
+	case "github_projects":
+		c := cfg.GitHubProjects
+		return NewGitHubProjectsSource(GitHubProjectsConfig{
+			Token:          ghToken,
+			Org:            coalesce(c.Org, ghOrg),
+			ProjectNumber:  c.ProjectNumber,
+			States:         c.States,
+			PriorityField:  c.PriorityField,
+			IterationField: c.IterationField,
+			DefaultRepo:    c.DefaultRepo,
+		}), nil
+	case "linear":
+		c := cfg.Linear
+		teams := make([]LinearTeamConfig, len(c.Teams))
+		for i, t := range c.Teams {
+			teams[i] = LinearTeamConfig{Key: t.Key, Repo: t.Repo, States: t.States}
+		}
+		return NewLinearSource(LinearConfig{
+			APIKey:     c.APIKey,
+			Teams:      teams,
+			HoldLabels: c.HoldLabels,
+		}, nil), nil
+	case "jira":
+		c := cfg.Jira
+		return NewJiraSource(JiraConfig{
+			BaseURL:     c.BaseURL,
+			Email:       c.Email,
+			APIToken:    c.APIToken,
+			ProjectKeys: c.ProjectKeys,
+			JQL:         c.JQL,
+			Repo:        c.Repo,
+			HoldLabels:  c.HoldLabels,
+		}), nil
+	default:
+		return nil, fmt.Errorf("unknown work_source type %q (want github, github_projects, linear, or jira)", cfg.Type)
+	}
+}
+
+func coalesce(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/src/pkg/worksource/factory_test.go
+++ b/src/pkg/worksource/factory_test.go
@@ -1,0 +1,108 @@
+package worksource
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestFromConfig_SourceTypes verifies FromConfig returns the adapter whose
+// SourceType matches each configured type, and that "" and "github" both map
+// to the default GitHub Issues source (backward compatibility).
+func TestFromConfig_SourceTypes(t *testing.T) {
+	logger := slog.Default()
+	cases := []struct {
+		cfgType string
+		want    string
+	}{
+		{"", "github"},
+		{"github", "github"},
+		{"github_projects", "github_projects"},
+		{"linear", "linear"},
+		{"jira", "jira"},
+	}
+	for _, tc := range cases {
+		cfg := config.WorkSourceConfig{Type: tc.cfgType}
+		ws, err := FromConfig(cfg, nil, "tok", "my-org", logger)
+		if err != nil {
+			t.Fatalf("FromConfig(%q): %v", tc.cfgType, err)
+		}
+		if got := ws.SourceType(); got != tc.want {
+			t.Errorf("FromConfig(%q).SourceType() = %q, want %q", tc.cfgType, got, tc.want)
+		}
+	}
+}
+
+// TestFromConfig_UnknownType verifies an unrecognized type is a hard error,
+// not a silent fallback.
+func TestFromConfig_UnknownType(t *testing.T) {
+	_, err := FromConfig(config.WorkSourceConfig{Type: "gitlab"}, nil, "", "", slog.Default())
+	if err == nil {
+		t.Fatal("FromConfig with unknown type should error")
+	}
+}
+
+// TestFromConfig_GitHubProjectsOrgFallback verifies the org falls back to the
+// hive's project org when the source config does not set one.
+func TestFromConfig_GitHubProjectsOrgFallback(t *testing.T) {
+	cfg := config.WorkSourceConfig{
+		Type:           "github_projects",
+		GitHubProjects: config.GitHubProjectsSourceConfig{ProjectNumber: 7},
+	}
+	ws, err := FromConfig(cfg, nil, "tok", "fallback-org", slog.Default())
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+	src, ok := ws.(*githubProjectsSource)
+	if !ok {
+		t.Fatalf("expected *githubProjectsSource, got %T", ws)
+	}
+	if src.cfg.Org != "fallback-org" {
+		t.Errorf("Org = %q, want fallback-org", src.cfg.Org)
+	}
+	if src.cfg.Token != "tok" {
+		t.Errorf("Token = %q, want tok", src.cfg.Token)
+	}
+	if src.cfg.ProjectNumber != 7 {
+		t.Errorf("ProjectNumber = %d, want 7", src.cfg.ProjectNumber)
+	}
+}
+
+// TestFromConfig_LinearTeamsMapped verifies team config translates to
+// LinearTeamConfig entries.
+func TestFromConfig_LinearTeamsMapped(t *testing.T) {
+	cfg := config.WorkSourceConfig{
+		Type: "linear",
+		Linear: config.LinearSourceConfig{
+			APIKey: "lin_key",
+			Teams: []config.LinearTeamSourceConfig{
+				{Key: "ENG", Repo: "my-org/my-repo", States: []string{"Todo"}},
+			},
+			HoldLabels: []string{"hold"},
+		},
+	}
+	ws, err := FromConfig(cfg, nil, "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+	src, ok := ws.(*LinearSource)
+	if !ok {
+		t.Fatalf("expected *LinearSource, got %T", ws)
+	}
+	if len(src.cfg.Teams) != 1 || src.cfg.Teams[0].Key != "ENG" || src.cfg.Teams[0].Repo != "my-org/my-repo" {
+		t.Errorf("teams not mapped: %+v", src.cfg.Teams)
+	}
+	if src.cfg.APIKey != "lin_key" {
+		t.Errorf("APIKey = %q", src.cfg.APIKey)
+	}
+}
+
+func TestCoalesce(t *testing.T) {
+	if coalesce("a", "b") != "a" {
+		t.Error("coalesce should prefer first non-empty")
+	}
+	if coalesce("", "b") != "b" {
+		t.Error("coalesce should fall back to second")
+	}
+}


### PR DESCRIPTION
Closes #4187

Completes RFC #4178 Phase 1 implementation.

- `WorkSourceConfig` added to `GovernorConfig` (backward-compat: absent = GitHub Issues)
- `worksource.FromConfig` factory wires config to the right adapter
- `worksource.ToGitHubIssues` adapter for scheduler compatibility
- Governor eval loop uses configured WorkSource when type is non-default
- Dashboard badge (Linear/purple, GH Projects/blue, Jira/blue) shown when non-default source is active
- Config round-trip + factory + adapter mapping tests
