### PR TITLE
✨ feat(worksource): Work Source settings tab in governor config dialog

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -140,6 +140,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/features", s.handleGovernorFeatures)
 	s.mux.HandleFunc("GET /api/config/governor/advisory", s.handleGovernorAdvisoryGet)
 	s.mux.HandleFunc("PUT /api/config/governor/advisory", s.handleGovernorAdvisoryPut)
+	s.mux.HandleFunc("GET /api/config/governor/work-source", s.handleGovernorWorkSourceGet)
+	s.mux.HandleFunc("PUT /api/config/governor/work-source", s.handleGovernorWorkSourcePut)
 	s.mux.HandleFunc("PUT /api/config/governor/security", s.handleGovernorSecurity)
 	// Backup encryption key: presence-only status, set, and clear. The key
 	// value is never returned by any of these (#4129).
@@ -4113,12 +4115,13 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"compress":   cfg.Governor.Logging.Compress,
 			"level":      cfg.Governor.Logging.Level,
 		},
-		"litellm":    litellmSectionResponse(&cfg.Governor.LiteLLM),
-		"trajectory": trajectorySectionResponse(&cfg.Governor),
-		"classifier": classifierSectionResponse(),
-		"features":   featuresSectionResponse(cfg),
-		"advisory":   advisorySectionResponse(cfg),
-		"security":   securitySectionResponse(cfg),
+		"litellm":     litellmSectionResponse(&cfg.Governor.LiteLLM),
+		"trajectory":  trajectorySectionResponse(&cfg.Governor),
+		"classifier":  classifierSectionResponse(),
+		"features":    featuresSectionResponse(cfg),
+		"advisory":    advisorySectionResponse(cfg),
+		"work_source": workSourceSectionResponse(cfg),
+		"security":    securitySectionResponse(cfg),
 		"attribution": map[string]interface{}{
 			// Effective value (default ON when unset) — the UI renders the
 			// switch from this, so an untouched hive shows it on.

--- a/src/pkg/dashboard/api_governor_features.go
+++ b/src/pkg/dashboard/api_governor_features.go
@@ -303,3 +303,167 @@ func advisorySectionResponse(cfg *config.Config) map[string]interface{} {
 		"pr_autoclose":   a.PRAutoCloseEnabled(),
 	}
 }
+
+// handleGovernorWorkSourceGet returns the work_source config so the Governor
+// dialog's Work Source tab can prefill its controls. OWNER-ONLY, matching the
+// rest of the governor-config surface.
+func (s *Server) handleGovernorWorkSourceGet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, workSourceSectionResponse(s.deps.Config))
+}
+
+// handleGovernorWorkSourcePut updates the work_source config. Only the type
+// and per-source credential/setting fields are accepted; team lists for Linear
+// are complex nested structures that remain YAML-only (same as the advisory
+// config's complex sub-structs).
+func (s *Server) handleGovernorWorkSourcePut(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Type           *string `json:"type"`
+		GitHubProjects *struct {
+			Org            *string  `json:"org"`
+			ProjectNumber  *int     `json:"project_number"`
+			States         []string `json:"states"`
+			PriorityField  *string  `json:"priority_field"`
+			IterationField *string  `json:"iteration_field"`
+			DefaultRepo    *string  `json:"default_repo"`
+		} `json:"github_projects"`
+		Linear *struct {
+			APIKey     *string  `json:"api_key"`
+			HoldLabels []string `json:"hold_labels"`
+		} `json:"linear"`
+		Jira *struct {
+			BaseURL     *string  `json:"base_url"`
+			Email       *string  `json:"email"`
+			APIToken    *string  `json:"api_token"`
+			ProjectKeys []string `json:"project_keys"`
+			JQL         *string  `json:"jql"`
+			Repo        *string  `json:"repo"`
+			HoldLabels  []string `json:"hold_labels"`
+		} `json:"jira"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	// --- validate before mutating anything ---
+	if body.Type != nil {
+		switch *body.Type {
+		case "", "github", "github_projects", "linear", "jira":
+		default:
+			jsonError(w, "type must be one of: github, github_projects, linear, jira", http.StatusBadRequest)
+			return
+		}
+	}
+
+	// --- apply ---
+	cfg := s.deps.Config
+	ws := &cfg.Governor.WorkSource
+	if body.Type != nil {
+		ws.Type = *body.Type
+	}
+	if body.GitHubProjects != nil {
+		g := body.GitHubProjects
+		if g.Org != nil {
+			ws.GitHubProjects.Org = *g.Org
+		}
+		if g.ProjectNumber != nil {
+			ws.GitHubProjects.ProjectNumber = *g.ProjectNumber
+		}
+		if g.States != nil {
+			ws.GitHubProjects.States = g.States
+		}
+		if g.PriorityField != nil {
+			ws.GitHubProjects.PriorityField = *g.PriorityField
+		}
+		if g.IterationField != nil {
+			ws.GitHubProjects.IterationField = *g.IterationField
+		}
+		if g.DefaultRepo != nil {
+			ws.GitHubProjects.DefaultRepo = *g.DefaultRepo
+		}
+	}
+	if body.Linear != nil {
+		l := body.Linear
+		if l.APIKey != nil {
+			ws.Linear.APIKey = *l.APIKey
+		}
+		if l.HoldLabels != nil {
+			ws.Linear.HoldLabels = l.HoldLabels
+		}
+	}
+	if body.Jira != nil {
+		j := body.Jira
+		if j.BaseURL != nil {
+			ws.Jira.BaseURL = *j.BaseURL
+		}
+		if j.Email != nil {
+			ws.Jira.Email = *j.Email
+		}
+		if j.APIToken != nil {
+			ws.Jira.APIToken = *j.APIToken
+		}
+		if j.ProjectKeys != nil {
+			ws.Jira.ProjectKeys = j.ProjectKeys
+		}
+		if j.JQL != nil {
+			ws.Jira.JQL = *j.JQL
+		}
+		if j.Repo != nil {
+			ws.Jira.Repo = *j.Repo
+		}
+		if j.HoldLabels != nil {
+			ws.Jira.HoldLabels = j.HoldLabels
+		}
+	}
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after work-source update", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_work_source", auditDetail("section", "work_source"), "")
+	s.refreshAndPersist()
+	jsonResponse(w, workSourceSectionResponse(cfg))
+}
+
+// workSourceSectionResponse renders WorkSourceConfig for the dashboard's
+// Work Source tab and the governor config GET payload.
+func workSourceSectionResponse(cfg *config.Config) map[string]interface{} {
+	ws := cfg.Governor.WorkSource
+	return map[string]interface{}{
+		"type": ws.Type,
+		"github_projects": map[string]interface{}{
+			"org":             ws.GitHubProjects.Org,
+			"project_number":  ws.GitHubProjects.ProjectNumber,
+			"states":          ws.GitHubProjects.States,
+			"priority_field":  ws.GitHubProjects.PriorityField,
+			"iteration_field": ws.GitHubProjects.IterationField,
+			"default_repo":    ws.GitHubProjects.DefaultRepo,
+		},
+		"linear": map[string]interface{}{
+			"api_key":     ws.Linear.APIKey,
+			"hold_labels": ws.Linear.HoldLabels,
+		},
+		"jira": map[string]interface{}{
+			"base_url":     ws.Jira.BaseURL,
+			"email":        ws.Jira.Email,
+			"api_token":    ws.Jira.APIToken,
+			"project_keys": ws.Jira.ProjectKeys,
+			"jql":          ws.Jira.JQL,
+			"repo":         ws.Jira.Repo,
+			"hold_labels":  ws.Jira.HoldLabels,
+		},
+	}
+}

--- a/src/pkg/dashboard/api_governor_worksource_test.go
+++ b/src/pkg/dashboard/api_governor_worksource_test.go
@@ -1,0 +1,191 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type workSourceAPIResponse struct {
+	Type           string `json:"type"`
+	GitHubProjects struct {
+		Org            string   `json:"org"`
+		ProjectNumber  int      `json:"project_number"`
+		States         []string `json:"states"`
+		PriorityField  string   `json:"priority_field"`
+		IterationField string   `json:"iteration_field"`
+		DefaultRepo    string   `json:"default_repo"`
+	} `json:"github_projects"`
+	Linear struct {
+		APIKey     string   `json:"api_key"`
+		HoldLabels []string `json:"hold_labels"`
+	} `json:"linear"`
+	Jira struct {
+		BaseURL     string   `json:"base_url"`
+		Email       string   `json:"email"`
+		APIToken    string   `json:"api_token"`
+		ProjectKeys []string `json:"project_keys"`
+		JQL         string   `json:"jql"`
+		Repo        string   `json:"repo"`
+		HoldLabels  []string `json:"hold_labels"`
+	} `json:"jira"`
+}
+
+func getWorkSourceSettings(t *testing.T, s *Server) workSourceAPIResponse {
+	t.Helper()
+	rec := doOwnerGet(s, "/api/config/governor/work-source")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET work-source settings: %d — %s", rec.Code, rec.Body.String())
+	}
+	var resp workSourceAPIResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding work-source settings: %v", err)
+	}
+	return resp
+}
+
+// TestGovWorkSource_RequiresOwner pins the gate: the work source decides which
+// external system's credentials the hive uses, so a non-owner must not be able
+// to read or redirect it.
+func TestGovWorkSource_RequiresOwner(t *testing.T) {
+	s := govServer(t)
+	if rec := doGet(s, "/api/config/governor/work-source"); rec.Code != http.StatusForbidden {
+		t.Errorf("unauthenticated GET = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/work-source", nil)
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("unauthenticated PUT = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+// TestGovWorkSource_DefaultGet verifies a fresh hive reports the GitHub Issues
+// default (empty type) with zero sub-configs.
+func TestGovWorkSource_DefaultGet(t *testing.T) {
+	s := govServer(t)
+	got := getWorkSourceSettings(t, s)
+	if got.Type != "" {
+		t.Errorf("Type = %q, want empty (GitHub Issues default)", got.Type)
+	}
+	if got.GitHubProjects.Org != "" || got.Linear.APIKey != "" || got.Jira.BaseURL != "" {
+		t.Errorf("fresh hive has non-zero sub-config: %+v", got)
+	}
+}
+
+// TestGovWorkSource_LinearRoundTrip switches to Linear, sets the API key, and
+// verifies the subsequent GET reflects both.
+func TestGovWorkSource_LinearRoundTrip(t *testing.T) {
+	s := govServer(t)
+	rec := doPut(s, "/api/config/governor/work-source", map[string]any{
+		"type":   "linear",
+		"linear": map[string]any{"api_key": "${LINEAR_API_KEY}", "hold_labels": []string{"hold", "blocked"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put linear work-source: %d — %s", rec.Code, rec.Body.String())
+	}
+	got := getWorkSourceSettings(t, s)
+	if got.Type != "linear" {
+		t.Errorf("Type = %q, want linear", got.Type)
+	}
+	if got.Linear.APIKey != "${LINEAR_API_KEY}" {
+		t.Errorf("Linear.APIKey = %q", got.Linear.APIKey)
+	}
+	if len(got.Linear.HoldLabels) != 2 || got.Linear.HoldLabels[0] != "hold" {
+		t.Errorf("Linear.HoldLabels = %v", got.Linear.HoldLabels)
+	}
+}
+
+// TestGovWorkSource_JiraRoundTrip switches to Jira and verifies the sub-config
+// persists, including partial updates leaving untouched fields alone.
+func TestGovWorkSource_JiraRoundTrip(t *testing.T) {
+	s := govServer(t)
+	rec := doPut(s, "/api/config/governor/work-source", map[string]any{
+		"type": "jira",
+		"jira": map[string]any{
+			"base_url":     "https://myorg.atlassian.net",
+			"email":        "bot@myorg.com",
+			"project_keys": []string{"ENG", "OPS"},
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put jira work-source: %d — %s", rec.Code, rec.Body.String())
+	}
+	got := getWorkSourceSettings(t, s)
+	if got.Type != "jira" || got.Jira.BaseURL != "https://myorg.atlassian.net" || got.Jira.Email != "bot@myorg.com" {
+		t.Fatalf("jira settings = %+v", got.Jira)
+	}
+	if len(got.Jira.ProjectKeys) != 2 {
+		t.Errorf("Jira.ProjectKeys = %v", got.Jira.ProjectKeys)
+	}
+
+	// Partial update: absent keys leave their settings alone.
+	if rec := doPut(s, "/api/config/governor/work-source", map[string]any{
+		"jira": map[string]any{"jql": "project = ENG AND status = Todo"},
+	}); rec.Code != http.StatusOK {
+		t.Fatalf("partial put: %d", rec.Code)
+	}
+	got = getWorkSourceSettings(t, s)
+	if got.Jira.JQL != "project = ENG AND status = Todo" {
+		t.Errorf("Jira.JQL = %q", got.Jira.JQL)
+	}
+	if got.Jira.BaseURL != "https://myorg.atlassian.net" || got.Jira.Email != "bot@myorg.com" {
+		t.Errorf("partial put changed untouched fields: %+v", got.Jira)
+	}
+}
+
+// TestGovWorkSource_GitHubProjectsRoundTrip covers the Projects v2 sub-config.
+func TestGovWorkSource_GitHubProjectsRoundTrip(t *testing.T) {
+	s := govServer(t)
+	rec := doPut(s, "/api/config/governor/work-source", map[string]any{
+		"type": "github_projects",
+		"github_projects": map[string]any{
+			"org":             "my-org",
+			"project_number":  42,
+			"states":          []string{"Todo", "Backlog"},
+			"priority_field":  "Priority",
+			"iteration_field": "Sprint",
+			"default_repo":    "my-org/my-repo",
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put github_projects work-source: %d — %s", rec.Code, rec.Body.String())
+	}
+	got := getWorkSourceSettings(t, s)
+	g := got.GitHubProjects
+	if got.Type != "github_projects" || g.Org != "my-org" || g.ProjectNumber != 42 ||
+		g.PriorityField != "Priority" || g.IterationField != "Sprint" || g.DefaultRepo != "my-org/my-repo" {
+		t.Fatalf("github_projects settings = %+v", g)
+	}
+	if len(g.States) != 2 {
+		t.Errorf("States = %v", g.States)
+	}
+}
+
+// TestGovWorkSource_ResetToDefault verifies type "" returns the hive to the
+// GitHub Issues default.
+func TestGovWorkSource_ResetToDefault(t *testing.T) {
+	s := govServer(t)
+	if rec := doPut(s, "/api/config/governor/work-source", map[string]any{"type": "linear"}); rec.Code != http.StatusOK {
+		t.Fatalf("put linear: %d", rec.Code)
+	}
+	if rec := doPut(s, "/api/config/governor/work-source", map[string]any{"type": ""}); rec.Code != http.StatusOK {
+		t.Fatalf("put empty type: %d", rec.Code)
+	}
+	if got := getWorkSourceSettings(t, s); got.Type != "" {
+		t.Errorf("Type = %q, want empty after reset", got.Type)
+	}
+}
+
+// TestGovWorkSource_InvalidType refuses unknown source types.
+func TestGovWorkSource_InvalidType(t *testing.T) {
+	s := govServer(t)
+	rec := doPut(s, "/api/config/governor/work-source", map[string]any{"type": "asana"})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid type = %d, want %d — %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := getWorkSourceSettings(t, s); got.Type != "" {
+		t.Errorf("rejected PUT mutated config: Type = %q", got.Type)
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -14764,7 +14764,7 @@ function burnAreaChart() {
     // which is read-only hub-synced user/role data. It sits next to Model
     // Gateways because both are backend configuration.
     const GOVERNOR_BOB_TAB = 'Bob';
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Features', 'Advisory', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Security'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Features', 'Advisory', 'Work Source', 'Hub', 'Forge App', 'Model Gateways', GOVERNOR_BOB_TAB, 'Variables', 'Security'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -15374,6 +15374,7 @@ function burnAreaChart() {
         case 'Access': return renderGovSecurity(d.security || {});
         case 'Features': return renderGovFeatures(d.features || {});
         case 'Advisory': return renderGovAdvisory(d.advisory || {});
+        case 'Work Source': return renderGovWorkSource(d.work_source || {});
         case 'Hub': return renderGovHub(d.hub || {});
         case 'Forge App': return renderGovForgeApp();
         case 'Model Gateways': return renderGovGateways();
@@ -19408,6 +19409,139 @@ function burnAreaChart() {
             <span class="config-toggle-label">Close findings fixed by a merged PR <span style="color:var(--muted);font-weight:400">— match merged PR titles against open findings</span></span>
           </div>
         </div>`;
+    }
+
+    // markWorkSourceDirty records a work-source edit under the 'work-source'
+    // dirty section (the generic Save dispatcher PUTs it to
+    // /api/config/governor/work-source). Keys use dot notation for nested
+    // sub-source fields, e.g. 'github_projects.org' — split and merged into a
+    // nested object so the server receives the same shape as hive.yaml. The
+    // live _configState.data.work_source copy is updated too, so re-renders
+    // (the type dropdown swaps sub-forms) keep unsaved edits.
+    function markWorkSourceDirty(path, value) {
+      if (!_configState.dirty['work-source']) _configState.dirty['work-source'] = {};
+      if (!_configState.data.work_source) _configState.data.work_source = {};
+      const parts = path.split('.');
+      let dirtyObj = _configState.dirty['work-source'];
+      let dataObj = _configState.data.work_source;
+      for (let i = 0; i < parts.length - 1; i++) {
+        if (!dirtyObj[parts[i]]) dirtyObj[parts[i]] = {};
+        if (!dataObj[parts[i]]) dataObj[parts[i]] = {};
+        dirtyObj = dirtyObj[parts[i]];
+        dataObj = dataObj[parts[i]];
+      }
+      dirtyObj[parts[parts.length - 1]] = value;
+      dataObj[parts[parts.length - 1]] = value;
+    }
+
+    // renderGovWorkSource renders the work_source settings: which external planning
+    // tool hive reads work items from (Step 01 of the loop). Saved to
+    // /api/config/governor/work-source.
+    function renderGovWorkSource(ws) {
+      ws = ws || {};
+      const type = ws.type || '';
+      const ghp = ws.github_projects || {};
+      const lin = ws.linear || {};
+      const jira = ws.jira || {};
+
+      const typeOpts = [
+        ['', 'GitHub Issues (default)'],
+        ['github_projects', 'GitHub Projects v2'],
+        ['linear', 'Linear'],
+        ['jira', 'Jira Cloud'],
+      ].map(([v, l]) => `<option value="${v}" ${type === v ? 'selected' : ''}>${l}</option>`).join('');
+
+      return `
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">
+          Choose where hive reads work items from. Steps 03–07 (fix agent, PR, review, merge) are
+          unaffected — agents still open pull requests on GitHub.
+        </p>
+
+        <div class="config-field" style="margin-bottom:20px">
+          <label>Work source <span class="config-info">i<span class="config-tooltip">GitHub Issues is the default and requires no config. GitHub Projects, Linear, and Jira are opt-in — add credentials below after selecting.</span></span></label>
+          <select onchange="markWorkSourceDirty('type',this.value);renderConfigTab('Work Source')">${typeOpts}</select>
+        </div>
+
+        ${type === 'github_projects' ? `
+        <div style="border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:14px">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">GitHub Projects v2</div>
+          <div class="config-field">
+            <label>Org</label>
+            <input type="text" placeholder="my-org" value="${esc(ghp.org||'')}" onchange="markWorkSourceDirty('github_projects.org',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Project number</label>
+            <input type="number" min="1" step="1" value="${ghp.project_number||''}" placeholder="42" onchange="markWorkSourceDirty('github_projects.project_number',Number(this.value)||0)">
+          </div>
+          <div class="config-field">
+            <label>Status filter <span class="config-info">i<span class="config-tooltip">Comma-separated Status field values to include, e.g. "Todo, Backlog". Leave empty for all open items.</span></span></label>
+            <input type="text" placeholder="Todo, Backlog" value="${esc((ghp.states||[]).join(', '))}" onchange="markWorkSourceDirty('github_projects.states',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+          </div>
+          <div class="config-field">
+            <label>Priority field <span class="config-info">i<span class="config-tooltip">Name of the project's priority custom field, e.g. "Priority". Leave empty if not using priority.</span></span></label>
+            <input type="text" placeholder="Priority" value="${esc(ghp.priority_field||'')}" onchange="markWorkSourceDirty('github_projects.priority_field',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Iteration field <span class="config-info">i<span class="config-tooltip">Name of the project's sprint/iteration field. When set, only items in the current iteration are shown. Leave empty to include all.</span></span></label>
+            <input type="text" placeholder="Sprint" value="${esc(ghp.iteration_field||'')}" onchange="markWorkSourceDirty('github_projects.iteration_field',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Default repo <span class="config-info">i<span class="config-tooltip">Fallback repo (owner/name) agents clone when an issue has no repository. Usually leave empty if your project only tracks one repo.</span></span></label>
+            <input type="text" placeholder="my-org/my-repo" value="${esc(ghp.default_repo||'')}" onchange="markWorkSourceDirty('github_projects.default_repo',this.value.trim())">
+          </div>
+        </div>` : ''}
+
+        ${type === 'linear' ? `
+        <div style="border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:14px">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">Linear</div>
+          <div class="config-field">
+            <label>API key <span class="config-info">i<span class="config-tooltip">Linear personal API key (Settings → API → Personal API keys). Stored as a secret reference; use \${ENV_VAR} syntax to avoid putting the raw key in config.</span></span></label>
+            <input type="text" placeholder="\${LINEAR_API_KEY}" value="${esc(lin.api_key||'')}" onchange="markWorkSourceDirty('linear.api_key',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Hold labels <span class="config-info">i<span class="config-tooltip">Comma-separated Linear label names that gate an issue (like GitHub's "hold" label). Issues carrying any of these labels are excluded.</span></span></label>
+            <input type="text" placeholder="hold, blocked" value="${esc((lin.hold_labels||[]).join(', '))}" onchange="markWorkSourceDirty('linear.hold_labels',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+          </div>
+          <p style="font-size:0.72rem;color:var(--muted);margin:8px 0 0">Teams are configured in <code>hive.yaml</code> — each team maps to a GitHub repo agents clone.</p>
+        </div>` : ''}
+
+        ${type === 'jira' ? `
+        <div style="border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:14px">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">Jira Cloud</div>
+          <div class="config-field">
+            <label>Base URL</label>
+            <input type="text" placeholder="https://myorg.atlassian.net" value="${esc(jira.base_url||'')}" onchange="markWorkSourceDirty('jira.base_url',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Email</label>
+            <input type="email" placeholder="bot@myorg.com" value="${esc(jira.email||'')}" onchange="markWorkSourceDirty('jira.email',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>API token <span class="config-info">i<span class="config-tooltip">Atlassian API token from id.atlassian.com → Security → API tokens. Use \${JIRA_API_TOKEN} to reference an environment variable.</span></span></label>
+            <input type="text" placeholder="\${JIRA_API_TOKEN}" value="${esc(jira.api_token||'')}" onchange="markWorkSourceDirty('jira.api_token',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Project keys <span class="config-info">i<span class="config-tooltip">Comma-separated Jira project keys, e.g. "ENG, OPS". Used to build the default JQL query.</span></span></label>
+            <input type="text" placeholder="ENG, OPS" value="${esc((jira.project_keys||[]).join(', '))}" onchange="markWorkSourceDirty('jira.project_keys',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+          </div>
+          <div class="config-field">
+            <label>JQL override <span class="config-info">i<span class="config-tooltip">Optional. Leave empty to use the default: "project in (&lt;keys&gt;) AND statusCategory != Done AND issuetype != Epic".</span></span></label>
+            <input type="text" placeholder="project = ENG AND status = Todo" value="${esc(jira.jql||'')}" onchange="markWorkSourceDirty('jira.jql',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Repo <span class="config-info">i<span class="config-tooltip">GitHub repo (owner/name) agents clone for these issues.</span></span></label>
+            <input type="text" placeholder="my-org/my-repo" value="${esc(jira.repo||'')}" onchange="markWorkSourceDirty('jira.repo',this.value.trim())">
+          </div>
+          <div class="config-field">
+            <label>Hold labels</label>
+            <input type="text" placeholder="hold, blocked" value="${esc((jira.hold_labels||[]).join(', '))}" onchange="markWorkSourceDirty('jira.hold_labels',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+          </div>
+        </div>` : ''}
+
+        ${type === '' ? `
+        <div style="font-size:0.75rem;color:var(--muted);background:color-mix(in srgb,var(--accent) 7%,transparent);border:1px solid color-mix(in srgb,var(--accent) 20%,transparent);border-radius:6px;padding:10px 12px">
+          <b>Using GitHub Issues</b> — hive reads open issues from the repos listed in the Repos tab. No additional configuration needed.
+        </div>` : ''}`;
     }
 
     function addSensingItem(key, inputId) {


### PR DESCRIPTION
Adds a Work Source tab to the governor settings dialog. Operators can switch between GitHub Issues (default), GitHub Projects v2, Linear, and Jira without editing hive.yaml.

- Dropdown to select source type; conditional sub-forms for GH Projects, Linear, Jira
- GET /api/config/governor/work-source + PUT handler
- Owner-only (matching other governor config handlers)
- Round-trip tests

Refs #4187, RFC #4178, follows #4195.