### PR TITLE
✨ Expose governor.threshold_scaling in the Thresholds settings tab

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -126,6 +126,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/governor", s.handleGovernorConfigGet)
 	s.mux.HandleFunc("PUT /api/config/governor/sensing", s.handleGovernorSensing)
 	s.mux.HandleFunc("PUT /api/config/governor/thresholds", s.handleGovernorThresholds)
+	s.mux.HandleFunc("GET /api/config/governor/threshold-scaling", s.handleGovernorThresholdScalingGet)
 	s.mux.HandleFunc("PUT /api/config/governor/threshold-scaling", s.handleGovernorThresholdScaling)
 	s.mux.HandleFunc("PUT /api/config/governor/labels", s.handleGovernorLabels)
 	s.mux.HandleFunc("PUT /api/config/governor/budget", s.handleGovernorBudget)
@@ -4327,6 +4328,23 @@ func (s *Server) handleGovernorThresholds(w http.ResponseWriter, r *http.Request
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
+// handleGovernorThresholdScalingGet returns the configured threshold-scaling
+// curve (with its default applied) so the Thresholds tab can prefill its
+// select without loading the whole governor config payload. OWNER-ONLY,
+// matching the write side and the rest of the governor-config surface.
+func (s *Server) handleGovernorThresholdScalingGet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, map[string]string{
+		"threshold_scaling": s.deps.Config.Governor.ThresholdScalingMode(),
+	})
+}
+
 // handleGovernorThresholdScaling sets how the DEFAULT mode thresholds scale
 // with the hive's repo count (#3498).
 //
@@ -4341,13 +4359,20 @@ func (s *Server) handleGovernorThresholdScaling(w http.ResponseWriter, r *http.R
 
 	var body struct {
 		ThresholdScaling string `json:"thresholdScaling"`
+		// Snake-case alias so callers can send the same key the GET returns
+		// and the YAML config uses.
+		ThresholdScalingSnake string `json:"threshold_scaling"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
 
-	scaling := sanitizeString(body.ThresholdScaling)
+	raw := body.ThresholdScaling
+	if raw == "" {
+		raw = body.ThresholdScalingSnake
+	}
+	scaling := sanitizeString(raw)
 	// Same gate as config.validate, so the write path cannot persist a value
 	// that fails the next config load.
 	if !config.ValidateThresholdScaling(scaling) {

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -18473,6 +18473,13 @@ function burnAreaChart() {
       const bPct = (b / THRESH_BAR_MAX) * 100;
       const sPct = (s / THRESH_BAR_MAX) * 100;
       return `
+        <div class="config-field" style="margin-bottom:20px">
+          <label title="How issue/PR thresholds scale as repo count grows. Square-root is recommended for large hives.">Multi-repo threshold scaling <span class="config-info">i<span class="config-tooltip">How issue/PR thresholds scale as repo count grows. Square-root is recommended for large hives.</span></span></label>
+          <select id="cfg-threshold-scaling" onchange="markDirty('threshold-scaling','thresholdScaling',this.value)">
+            ${[['linear', 'Linear'], ['sqrt', 'Square-root (default)'], ['none', 'None']]
+              .map(([v, label]) => `<option value="${v}" ${activeScaling === v ? 'selected' : ''}>${label}</option>`).join('')}
+          </select>
+        </div>
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:20px">Drag the handles to set issue-count thresholds for governor mode transitions.</p>
         ${effNote}
         <div class="thresh-bar-wrap">
@@ -18504,13 +18511,6 @@ function burnAreaChart() {
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from idle to quiet mode. Below this count, agents run at their idle cadence.">Quiet</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-quiet" value="${q}" oninput="setThreshFromInput('quiet',this.value)"></div>
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from quiet to busy mode. Agents increase their kick frequency to handle the growing workload.">Busy</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-busy" value="${b}" oninput="setThreshFromInput('busy',this.value)"></div>
           <div class="config-field"><label title="Number of actionable issues at which the governor transitions from busy to surge mode. Maximum agent activity — monitor your token budget closely at this level.">Surge</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-surge" value="${s}" oninput="setThreshFromInput('surge',this.value)"></div>
-        </div>
-        <div class="config-field" style="margin-top:20px">
-          <label title="How the thresholds above scale with the number of repos this hive watches. Queue depth grows with repo count, so a fixed threshold means a large hive sits in surge permanently while a small one idles. Linear (default) compares per-repo pressure. Sqrt is gentler for hives with many quiet repos. None uses the numbers above as absolute queue depths. A threshold you set explicitly is never scaled.">Threshold scaling <span class="config-info">i<span class="config-tooltip">Scales the thresholds above by how many repos the hive watches, so the mode ladder means the same thing on a 3-repo hive as on a 39-repo one. Linear multiplies by the repo count (equivalent to comparing per-repo queue pressure). Sqrt multiplies by ceil(sqrt(repos)) — gentler, reaches surge sooner. None uses absolute numbers, the behavior from before this option existed. Thresholds you set by hand are never scaled.</span></span></label>
-          <select id="cfg-threshold-scaling" onchange="markDirty('threshold-scaling','thresholdScaling',this.value)">
-            ${[['linear', 'linear — × repo count (default)'], ['sqrt', 'sqrt — × ceil(√repos), gentler'], ['none', 'none — absolute queue depths']]
-              .map(([v, label]) => `<option value="${v}" ${activeScaling === v ? 'selected' : ''}>${label}</option>`).join('')}
-          </select>
         </div>`;
     }
 


### PR DESCRIPTION
Exposes `governor.threshold_scaling` in the governor Thresholds settings tab.

- Adds `GET /api/config/governor/threshold-scaling` → `{threshold_scaling: "sqrt"}` (owner-only, matching the governor-config surface)
- PUT now also accepts the snake_case `threshold_scaling` key
- Moves the **Multi-repo threshold scaling** select to the top of the Thresholds tab with Linear / Square-root (default) / None options and tooltip

Closes #4213