### PR TITLE
✨ Expose agent_sandbox config in governor Security settings tab

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -143,6 +143,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/governor/work-source", s.handleGovernorWorkSourceGet)
 	s.mux.HandleFunc("PUT /api/config/governor/work-source", s.handleGovernorWorkSourcePut)
 	s.mux.HandleFunc("PUT /api/config/governor/security", s.handleGovernorSecurity)
+	s.mux.HandleFunc("GET /api/config/agent-sandbox", s.handleAgentSandboxGet)
+	s.mux.HandleFunc("PUT /api/config/agent-sandbox", s.handleAgentSandboxPut)
 	// Backup encryption key: presence-only status, set, and clear. The key
 	// value is never returned by any of these (#4129).
 	s.mux.HandleFunc("GET /api/config/governor/backup", s.handleBackupKeyStatus)

--- a/src/pkg/dashboard/api_agent_sandbox.go
+++ b/src/pkg/dashboard/api_agent_sandbox.go
@@ -1,0 +1,118 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// Bounds for the sandbox kick timeout the dashboard may set. Zero is the
+// UNSET sentinel that config defaulting resolves back to the built-in
+// default, so it is accepted; negative values are not.
+const minAgentSandboxTimeoutS = 0
+
+// handleAgentSandboxGet serves GET /api/config/agent-sandbox so the governor
+// Security tab can prefill the Agent Sandbox controls. OWNER-ONLY, matching
+// the rest of the governor-config surface: the sandbox posture decides how
+// (and whether) agents are credential-isolated.
+func (s *Server) handleAgentSandboxGet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, agentSandboxSectionResponse(s.deps.Config))
+}
+
+// handleAgentSandboxPut serves PUT /api/config/agent-sandbox. Every field is
+// a pointer so an absent key leaves that setting untouched — the same "only
+// what you send is changed" contract the governor-config writers use.
+// saveConfig() persists a secret-free overlay to the PVC that the entrypoint
+// merges on restart (see handleGovernorFeatures).
+func (s *Server) handleAgentSandboxPut(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Enabled      *bool     `json:"enabled"`
+		Image        *string   `json:"image"`
+		EnvAllowlist *[]string `json:"env_allowlist"`
+		NetworkMode  *string   `json:"network_mode"`
+		TimeoutS     *int      `json:"timeout_s"`
+		WorkspaceDir *string   `json:"workspace_dir"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	// --- validate before mutating anything ---
+	if body.NetworkMode != nil {
+		mode := strings.ToLower(strings.TrimSpace(*body.NetworkMode))
+		switch mode {
+		case "", "none", "bridge", "host":
+		default:
+			jsonError(w, "network_mode must be one of: none, bridge, host", http.StatusBadRequest)
+			return
+		}
+	}
+	if body.TimeoutS != nil && *body.TimeoutS < minAgentSandboxTimeoutS {
+		jsonError(w, "timeout_s must be 0 (default) or greater", http.StatusBadRequest)
+		return
+	}
+
+	// --- apply ---
+	cfg := s.deps.Config
+	sb := &cfg.AgentSandbox
+	if body.Enabled != nil {
+		sb.Enabled = *body.Enabled
+	}
+	if body.Image != nil {
+		sb.Image = sanitizeString(strings.TrimSpace(*body.Image))
+	}
+	if body.EnvAllowlist != nil {
+		sb.EnvAllowlist = sanitizeStringSlice(*body.EnvAllowlist)
+	}
+	if body.NetworkMode != nil {
+		sb.NetworkMode = strings.ToLower(strings.TrimSpace(*body.NetworkMode))
+	}
+	if body.TimeoutS != nil {
+		sb.TimeoutS = *body.TimeoutS
+	}
+	if body.WorkspaceDir != nil {
+		sb.WorkspaceDir = sanitizeString(strings.TrimSpace(*body.WorkspaceDir))
+	}
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after agent-sandbox update", "error", err)
+	}
+	s.auditFromRequest(r, "config_agent_sandbox", auditDetail("section", "agent_sandbox"), "")
+	s.refreshAndPersist()
+	jsonResponse(w, agentSandboxSectionResponse(cfg))
+}
+
+// agentSandboxSectionResponse renders the top-level AgentSandboxConfig for
+// the dashboard. It is secret-free by construction: the sandbox config holds
+// an image reference, an env-var NAME allowlist and paths — never values.
+func agentSandboxSectionResponse(cfg *config.Config) map[string]interface{} {
+	sb := cfg.AgentSandbox
+	allow := sb.EnvAllowlist
+	if allow == nil {
+		allow = []string{}
+	}
+	return map[string]interface{}{
+		"enabled":       sb.Enabled,
+		"image":         sb.Image,
+		"env_allowlist": allow,
+		"network_mode":  sb.NetworkMode,
+		"timeout_s":     sb.TimeoutS,
+		"workspace_dir": sb.WorkspaceDir,
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -19123,6 +19123,13 @@ function burnAreaChart() {
         </div>
         <p style="font-size:0.72rem;color:var(--muted);margin:6px 0 0">Per-agent opt-in lives on each agent's General tab. Current effective posture: ${Number(sec.sandboxedAgents || 0)}/${Number(sec.totalAgents || 0)} agents sandboxed.</p>`;
 
+      /* Agent Sandbox: painted asynchronously from the dedicated
+         /api/config/agent-sandbox endpoint so this tab stays in sync with the
+         top-level agent_sandbox config, not just the enabled bit. */
+      loadAgentSandboxConfig();
+      const agentSandbox = `
+        <div id="gov-agent-sandbox-host"><div style="color:var(--muted);font-size:0.8rem">Loading…</div></div>`;
+
       /* Backup encryption key: painted asynchronously from presence-only
          status so the key value never travels to the browser. */
       loadBackupKeyStatus();
@@ -19138,7 +19145,111 @@ function burnAreaChart() {
         ${renderSecuritySection('Input Defense', inputDefense)}
         ${renderSecuritySection('Merge Gates', mergeGates)}
         ${renderSecuritySection('Isolation', isolation)}
+        ${renderSecuritySection('Agent Sandbox', agentSandbox)}
         ${renderSecuritySection('Backup', backupKey)}`;
+    }
+
+    /* loadAgentSandboxConfig fetches the top-level agent_sandbox config and
+       paints the Agent Sandbox panel. Same async-after-render pattern as
+       loadBackupKeyStatus: the DOM target is resolved AFTER the await. */
+    async function loadAgentSandboxConfig() {
+      let host = null;
+      try {
+        const r = await fetch('/api/config/agent-sandbox');
+        host = document.getElementById('gov-agent-sandbox-host');
+        if (!host) return;
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        renderAgentSandboxPanel(host, d);
+      } catch (e) {
+        host = host || document.getElementById('gov-agent-sandbox-host');
+        if (host) host.innerHTML = '<div style="color:var(--red);font-size:0.8rem">Failed to load agent sandbox config: ' + esc(e.message) + '</div>';
+      }
+    }
+
+    /* renderAgentSandboxPanel paints the credential-free sandbox controls.
+       Saves go straight to PUT /api/config/agent-sandbox (overlay-persisted),
+       independent of the tab-level markDirty/save flow, and the panel is
+       repainted from the server's response so it always shows persisted
+       state. */
+    function renderAgentSandboxPanel(host, d) {
+      if (!host) return;
+      d = d || {};
+      const enabled = d.enabled === true;
+      const netMode = d.network_mode || 'none';
+      const netOpt = (v, label) => '<option value="' + v + '"' + (netMode === v ? ' selected' : '') + '>' + label + '</option>';
+      const warning = enabled
+        ? '<div style="border:1px solid var(--yellow,#f1c21b);border-radius:6px;padding:8px 10px;margin:0 0 10px;font-size:0.76rem;background:rgba(241,194,27,0.08)">\u26a0\ufe0f Sandbox mode changes how agents run. Test in a non-production hive first.</div>'
+        : '';
+      host.innerHTML = `
+        ${warning}
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${enabled ? 'on' : ''}" id="agent-sandbox-enabled-toggle"></div>
+          <span class="config-toggle-label">Enable credential-free agent sandbox <span class="config-info">i<span class="config-tooltip">Runs agent kicks inside a rootless container with no ambient credentials; only allowlisted environment variables are passed through.</span></span></span>
+        </div>
+        <div class="config-field-row">
+          <div class="config-field"><label>Container image</label><input type="text" id="agent-sandbox-image" value="${esc(d.image || '')}" placeholder="ghcr.io/kubestellar/hive-sandbox:latest"></div>
+          <div class="config-field"><label>Network mode</label>
+            <select id="agent-sandbox-network">${netOpt('none', 'none — no network (default)')}${netOpt('bridge', 'bridge — NATed network')}${netOpt('host', 'host — share host network')}</select>
+          </div>
+        </div>
+        <div class="config-field-row">
+          <div class="config-field"><label>Timeout (seconds)</label><input type="number" min="0" id="agent-sandbox-timeout" value="${Number(d.timeout_s) || ''}" placeholder="300"></div>
+          <div class="config-field"><label>Workspace directory</label><input type="text" id="agent-sandbox-workspace" value="${esc(d.workspace_dir || '')}" placeholder="leave empty for default"></div>
+        </div>
+        <div class="config-field"><label>Allowed environment variables <span style="font-weight:400;color:var(--muted)">(comma-separated names)</span></label><input type="text" id="agent-sandbox-env" value="${esc((d.env_allowlist || []).join(', '))}" placeholder="e.g. HOME, PATH, LANG"></div>
+        <div style="display:flex;align-items:center;gap:10px;margin-top:10px">
+          <button id="agent-sandbox-save" style="padding:5px 16px;border:none;border-radius:6px;background:#0f62fe;color:#fff;cursor:pointer;font-size:0.76rem;font-weight:600">Save sandbox settings</button>
+          <span id="agent-sandbox-status" style="font-size:0.74rem;color:var(--muted)"></span>
+        </div>`;
+
+      let pendingEnabled = enabled;
+      const toggle = host.querySelector('#agent-sandbox-enabled-toggle');
+      if (toggle) toggle.addEventListener('click', () => {
+        pendingEnabled = !pendingEnabled;
+        toggle.classList.toggle('on', pendingEnabled);
+      });
+
+      const statusEl = host.querySelector('#agent-sandbox-status');
+      const setStatus = (msg, color) => {
+        if (statusEl) { statusEl.textContent = msg; statusEl.style.color = color || 'var(--muted)'; }
+      };
+      const saveBtn = host.querySelector('#agent-sandbox-save');
+      if (saveBtn) saveBtn.addEventListener('click', async () => {
+        const timeoutRaw = (host.querySelector('#agent-sandbox-timeout').value || '').trim();
+        const timeoutS = timeoutRaw === '' ? 0 : Number(timeoutRaw);
+        if (!Number.isFinite(timeoutS) || timeoutS < 0) {
+          setStatus('Timeout must be 0 or a positive number of seconds.', 'var(--red)');
+          return;
+        }
+        const body = {
+          enabled: pendingEnabled,
+          image: (host.querySelector('#agent-sandbox-image').value || '').trim(),
+          network_mode: host.querySelector('#agent-sandbox-network').value,
+          timeout_s: Math.floor(timeoutS),
+          workspace_dir: (host.querySelector('#agent-sandbox-workspace').value || '').trim(),
+          env_allowlist: parseSecurityList(host.querySelector('#agent-sandbox-env').value)
+        };
+        setStatus('Saving…');
+        try {
+          const r = await fetch('/api/config/agent-sandbox', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+          });
+          if (!r.ok) {
+            let msg = 'HTTP ' + r.status;
+            try { msg = (await r.json()).error || msg; } catch (_) {}
+            throw new Error(msg);
+          }
+          const saved = await r.json();
+          renderAgentSandboxPanel(host, saved);
+          const st = host.querySelector('#agent-sandbox-status');
+          if (st) { st.textContent = 'Saved.'; st.style.color = 'var(--green)'; }
+        } catch (e) {
+          setStatus('Save failed: ' + e.message, 'var(--red)');
+        }
+      });
     }
 
     /* loadBackupKeyStatus fetches presence-only backup-key status and paints


### PR DESCRIPTION
Exposes the top-level `agent_sandbox` (AgentSandboxConfig) in the governor **Security** settings tab.

## Changes
- New owner-only endpoints registered in `api.go`:
  - `GET /api/config/agent-sandbox` — returns AgentSandboxConfig as JSON
  - `PUT /api/config/agent-sandbox` — pointer-field partial update, persisted to the secret-free dashboard overlay (same pattern as `api_governor_features.go`), with validation of `network_mode` (none/bridge/host) and non-negative `timeout_s`
- New **Agent Sandbox** section in `renderGovSecurity()`:
  - Enable credential-free agent sandbox toggle (default OFF)
  - Container image, network mode (none/bridge/host, default none), timeout (seconds), workspace directory, allowed environment variables (comma-separated)
  - Warning banner when enabled: "⚠️ Sandbox mode changes how agents run. Test in a non-production hive first."

Closes #4218