### PR TITLE
✨ Expose escalation breaker config in governor Health tab

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -133,6 +133,10 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/config/governor/budget/reset", s.handleGovernorBudgetReset)
 	s.mux.HandleFunc("PUT /api/config/governor/notifications", s.handleGovernorNotifications)
 	s.mux.HandleFunc("PUT /api/config/governor/health", s.handleGovernorHealth)
+	// Escalation breaker is a top-level Config field (not GovernorConfig), but
+	// its UI lives on the governor Health tab — see api_escalation.go.
+	s.mux.HandleFunc("GET /api/config/escalation", s.handleEscalationGet)
+	s.mux.HandleFunc("PUT /api/config/escalation", s.handleEscalationPut)
 	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
 	s.mux.HandleFunc("PUT /api/config/governor/attribution", s.handleGovernorAttribution)
 	s.mux.HandleFunc("PUT /api/config/governor/hub", s.handleGovernorHub)

--- a/src/pkg/dashboard/api_escalation.go
+++ b/src/pkg/dashboard/api_escalation.go
@@ -1,0 +1,80 @@
+package dashboard
+
+import (
+	"net/http"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// handleEscalationGet returns the top-level escalation breaker settings
+// (Config.Escalation) so the Governor Health tab can prefill its controls.
+//
+// OWNER-ONLY, matching the write side and the rest of the governor-config
+// surface: the escalation breaker decides when a struggling agent is handed to
+// a human, so its state is operator-sensitive.
+func (s *Server) handleEscalationGet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, escalationSectionResponse(s.deps.Config))
+}
+
+// handleEscalationPut updates the escalation breaker settings. Every field is a
+// pointer, so an absent key leaves that setting untouched — the same "only what
+// you send is changed" contract the other governor-config writers use.
+// saveConfig() persists a secret-free overlay that the entrypoint merges on
+// restart.
+func (s *Server) handleEscalationPut(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Disabled  *bool `json:"disabled"`
+		Threshold *int  `json:"threshold"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	// --- validate before mutating anything ---
+	if body.Threshold != nil && *body.Threshold < 0 {
+		jsonError(w, "threshold must be 0 (default) or greater", http.StatusBadRequest)
+		return
+	}
+
+	// --- apply ---
+	cfg := s.deps.Config
+	if body.Disabled != nil {
+		cfg.Escalation.Disabled = *body.Disabled
+	}
+	if body.Threshold != nil {
+		cfg.Escalation.Threshold = *body.Threshold
+	}
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after escalation update", "error", err)
+	}
+	s.auditFromRequest(r, "config_escalation", auditDetail("section", "escalation"), "")
+	s.refreshAndPersist()
+	jsonResponse(w, escalationSectionResponse(cfg))
+}
+
+// escalationSectionResponse renders EscalationConfig for the dashboard,
+// resolving the zero-threshold default so the UI never has to know it.
+func escalationSectionResponse(cfg *config.Config) map[string]interface{} {
+	e := cfg.Escalation
+	return map[string]interface{}{
+		"disabled":            e.Disabled,
+		"threshold":           e.Threshold,
+		"effective_threshold": e.EffectiveThreshold(),
+	}
+}


### PR DESCRIPTION
Exposes the top-level `escalation` config (EscalationConfig) in the governor **Health** settings tab.

- New owner-only endpoints `GET/PUT /api/config/escalation` (overlay-save pattern, `src/pkg/dashboard/api_escalation.go`)
- Health tab gains an **Escalation Breaker** section:
  - "Escalation breaker enabled" toggle (inverted display of `Disabled`)
  - "Red-attempt threshold" number input (placeholder 3)
  - Tooltip: escalates to a human after N consecutive red attempts; disable only in test environments
- Save flow special-cases the escalation section since it is a top-level Config field, not under `/governor`

Closes #4214