### PR TITLE
✨ ui(governor): expose eval_interval_s and attribution_trailer in General tab

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -138,6 +138,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/litellm", s.handleGovernorLiteLLM)
 	s.mux.HandleFunc("PUT /api/config/governor/trajectory", s.handleGovernorTrajectory)
 	s.mux.HandleFunc("PUT /api/config/governor/features", s.handleGovernorFeatures)
+	s.mux.HandleFunc("GET /api/config/governor/general-advanced", s.handleGovernorGeneralAdvancedGet)
+	s.mux.HandleFunc("PUT /api/config/governor/general-advanced", s.handleGovernorGeneralAdvancedPut)
 	s.mux.HandleFunc("GET /api/config/governor/advisory", s.handleGovernorAdvisoryGet)
 	s.mux.HandleFunc("PUT /api/config/governor/advisory", s.handleGovernorAdvisoryPut)
 	s.mux.HandleFunc("GET /api/config/governor/work-source", s.handleGovernorWorkSourceGet)
@@ -4127,6 +4129,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			// switch from this, so an untouched hive shows it on.
 			"attributionTrailer": cfg.Governor.AttributionTrailerEnabled(),
 		},
+		"general_advanced": generalAdvancedSectionResponse(cfg),
 		"hub": map[string]interface{}{
 			"enabled": cfg.Hub.Enabled,
 			// namespace is read-only, runtime-derived display info (never

--- a/src/pkg/dashboard/api_governor_general_advanced.go
+++ b/src/pkg/dashboard/api_governor_general_advanced.go
@@ -1,0 +1,87 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// Bounds for the governor eval interval the dashboard accepts, matching the
+// existing sensing writer (handleGovernorSensing). 0 is the UNSET sentinel
+// that config defaulting resolves back to the built-in default, so accepting
+// it would silently discard the operator's edit.
+const (
+	minGeneralEvalIntervalS = 10    // 10 seconds minimum
+	maxGeneralEvalIntervalS = 86400 // 24 hours
+)
+
+// handleGovernorGeneralAdvancedGet returns the general-tab advanced settings
+// (governor eval interval and the attribution-trailer toggle) so the Governor
+// dialog's General tab can prefill its controls. OWNER-ONLY, matching the rest
+// of the governor-config surface.
+func (s *Server) handleGovernorGeneralAdvancedGet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, generalAdvancedSectionResponse(s.deps.Config))
+}
+
+// handleGovernorGeneralAdvancedPut updates the general-tab advanced settings.
+// Every field is a pointer, so an absent key leaves that setting untouched —
+// the same "only what you send is changed" contract the other governor-config
+// writers use.
+func (s *Server) handleGovernorGeneralAdvancedPut(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		EvalIntervalS      *int  `json:"eval_interval_s"`
+		AttributionTrailer *bool `json:"attribution_trailer"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	// --- validate before mutating anything ---
+	if body.EvalIntervalS != nil && (*body.EvalIntervalS < minGeneralEvalIntervalS || *body.EvalIntervalS > maxGeneralEvalIntervalS) {
+		jsonError(w, fmt.Sprintf("eval_interval_s must be between %d and %d", minGeneralEvalIntervalS, maxGeneralEvalIntervalS), http.StatusBadRequest)
+		return
+	}
+
+	// --- apply ---
+	cfg := s.deps.Config
+	if body.EvalIntervalS != nil {
+		cfg.Governor.EvalIntervalS = *body.EvalIntervalS
+	}
+	if body.AttributionTrailer != nil {
+		v := *body.AttributionTrailer
+		cfg.Governor.AttributionTrailer = &v
+	}
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after general-advanced update", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_general_advanced", auditDetail("section", "general_advanced"), "")
+	s.refreshAndPersist()
+	jsonResponse(w, generalAdvancedSectionResponse(cfg))
+}
+
+// generalAdvancedSectionResponse renders the general-tab advanced settings for
+// the dashboard, resolving attribution_trailer's tri-state to the boolean the
+// hive actually acts on so the UI never has to know the default.
+func generalAdvancedSectionResponse(cfg *config.Config) map[string]interface{} {
+	return map[string]interface{}{
+		"eval_interval_s":     cfg.Governor.EvalIntervalS,
+		"attribution_trailer": cfg.Governor.AttributionTrailerEnabled(),
+	}
+}

--- a/src/pkg/dashboard/api_governor_general_advanced_test.go
+++ b/src/pkg/dashboard/api_governor_general_advanced_test.go
@@ -1,0 +1,90 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// generalAdvancedValue reads the general-advanced payload from its GET
+// endpoint.
+func generalAdvancedValue(t *testing.T, s *Server) (int, bool) {
+	t.Helper()
+	rec := doOwnerGet(s, "/api/config/governor/general-advanced")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET general-advanced: %d", rec.Code)
+	}
+	var resp struct {
+		EvalIntervalS      int  `json:"eval_interval_s"`
+		AttributionTrailer bool `json:"attribution_trailer"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp.EvalIntervalS, resp.AttributionTrailer
+}
+
+func TestGovGeneralAdvanced_GetAndPut(t *testing.T) {
+	s := govServer(t)
+
+	// Untouched config → attribution defaults ON.
+	if _, on := generalAdvancedValue(t, s); !on {
+		t.Fatal("attribution_trailer must default to on")
+	}
+
+	// Non-owner GET → 403 (owner-only surface).
+	if rec := doGet(s, "/api/config/governor/general-advanced"); rec.Code != http.StatusForbidden {
+		t.Fatalf("non-owner GET: expected 403, got %d", rec.Code)
+	}
+
+	// Bad body → 400.
+	if rec := doPutRaw(s, "/api/config/governor/general-advanced", "bad"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad body: expected 400, got %d", rec.Code)
+	}
+
+	// Out-of-range eval interval → 400, nothing stored.
+	if rec := doPut(s, "/api/config/governor/general-advanced", map[string]any{"eval_interval_s": 5}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("interval 5: expected 400, got %d", rec.Code)
+	}
+	if rec := doPut(s, "/api/config/governor/general-advanced", map[string]any{"eval_interval_s": 90000}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("interval 90000: expected 400, got %d", rec.Code)
+	}
+
+	// Valid interval persists.
+	if rec := doPut(s, "/api/config/governor/general-advanced", map[string]any{"eval_interval_s": 120}); rec.Code != http.StatusOK {
+		t.Fatalf("put interval: %d", rec.Code)
+	}
+	if s.deps.Config.Governor.EvalIntervalS != 120 {
+		t.Fatalf("EvalIntervalS = %d, want 120", s.deps.Config.Governor.EvalIntervalS)
+	}
+	if got, _ := generalAdvancedValue(t, s); got != 120 {
+		t.Fatalf("GET eval_interval_s = %d, want 120", got)
+	}
+
+	// Toggle attribution OFF: stored as an explicit false pointer.
+	if rec := doPut(s, "/api/config/governor/general-advanced", map[string]any{"attribution_trailer": false}); rec.Code != http.StatusOK {
+		t.Fatalf("put false: %d", rec.Code)
+	}
+	if s.deps.Config.Governor.AttributionTrailer == nil || *s.deps.Config.Governor.AttributionTrailer {
+		t.Fatal("explicit false must be stored as an explicit false pointer")
+	}
+	if _, on := generalAdvancedValue(t, s); on {
+		t.Fatal("GET must reflect the trailer off")
+	}
+
+	// Absent fields → no change (partial-update convention).
+	if rec := doPut(s, "/api/config/governor/general-advanced", map[string]any{}); rec.Code != http.StatusOK {
+		t.Fatalf("put empty: %d", rec.Code)
+	}
+	if got, on := generalAdvancedValue(t, s); got != 120 || on {
+		t.Fatalf("empty body must not change stored values: got %d/%v", got, on)
+	}
+
+	// Toggle back ON.
+	if rec := doPut(s, "/api/config/governor/general-advanced", map[string]any{"attribution_trailer": true}); rec.Code != http.StatusOK {
+		t.Fatalf("put true: %d", rec.Code)
+	}
+	if _, on := generalAdvancedValue(t, s); !on {
+		t.Fatal("GET must reflect the trailer back on")
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -18282,7 +18282,9 @@ function burnAreaChart() {
       const currentId = (window._lastStatus || {}).hiveId || '';
       const currentACMMLevel = (window._lastStatus || {}).acmmLevel || 0;
       const attrib = (_configState.data || {}).attribution || {};
-      const attribOn = attrib.attributionTrailer !== false; // default on
+      const genAdv = (_configState.data || {}).general_advanced || {};
+      const attribOn = genAdv.attribution_trailer !== undefined ? genAdv.attribution_trailer !== false : attrib.attributionTrailer !== false; // default on
+      const evalInterval = genAdv.eval_interval_s || 0;
       const traj = (_configState.data || {}).trajectory || {};
       const trajOn = traj.enabled !== false; // default on
       const trajReady = traj.reviewerReady === true;
@@ -18315,9 +18317,14 @@ function burnAreaChart() {
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Each level applies a curated agent pack. Change&hellip; opens the level selector.</span>
           <div style="margin-top:8px">${securityPostureStripHtml()}</div>
         </div>
+        <div class="config-field" style="margin-top:14px">
+          <label>Eval interval (seconds) <span class="config-info">i<span class="config-tooltip">How often the governor evaluates the hive (sensing, mode ladder, agent kicks). Default 60. Lower = more responsive, more API calls.</span></span></label>
+          <input type="number" min="10" max="86400" value="${evalInterval || ''}" placeholder="60" onchange="saveGovGeneralAdvanced('eval_interval_s', this.value === '' ? null : parseInt(this.value,10))" style="width:140px">
+          <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Changes take effect on next restart.</span>
+        </div>
         <div class="config-toggle" style="margin-top:14px">
-          <div class="config-toggle-switch ${attribOn ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="attribution" data-key="attributionTrailer"></div>
-          <span class="config-toggle-label">Attribution Trailer <span class="config-info">i<span class="config-tooltip">Append attribution trailer (agent, backend, model) to agent-created PRs and issues &mdash; audit log always records regardless. Hive-wide: one setting for all agents.</span></span></span>
+          <div class="config-toggle-switch ${attribOn ? 'on' : ''}" onclick="toggleAttributionTrailer(this)"></div>
+          <span class="config-toggle-label">Show attribution trailer on PRs/issues <span class="config-info">i<span class="config-tooltip">Append attribution trailer (agent, backend, model) to agent-created PRs and issues &mdash; audit log always records regardless. Hive-wide: one setting for all agents.</span></span></span>
         </div>
         <div class="config-field" style="border-top:1px solid var(--border);margin-top:18px;padding-top:16px">
           <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap">
@@ -18359,6 +18366,45 @@ function burnAreaChart() {
             </div>
           </div>
         </div>`;
+    }
+
+    async function saveGovGeneralAdvanced(field, value) {
+      if (value === null) return; // empty input — leave the setting untouched
+      try {
+        const body = {}; body[field] = value;
+        const res = await fetch('/api/config/governor/general-advanced', {
+          method: 'PUT',
+          headers: _inceptionAuthHeaders(),
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) throw new Error(await saveErrorMessage(res));
+        const data = await res.json();
+        _configState.data.general_advanced = data;
+        showToast('Governor settings updated — effective on next restart');
+      } catch (err) {
+        showToast('Failed to update governor settings: ' + err.message, 'error');
+      }
+    }
+
+    async function toggleAttributionTrailer(el) {
+      const turningOn = !el.classList.contains('on');
+      el.classList.toggle('on');
+      try {
+        const res = await fetch('/api/config/governor/general-advanced', {
+          method: 'PUT',
+          headers: _inceptionAuthHeaders(),
+          body: JSON.stringify({ attribution_trailer: turningOn }),
+        });
+        if (!res.ok) throw new Error(await saveErrorMessage(res));
+        const data = await res.json();
+        _configState.data.general_advanced = data;
+        if (!_configState.data.attribution) _configState.data.attribution = {};
+        _configState.data.attribution.attributionTrailer = turningOn;
+        showToast('Attribution trailer ' + (turningOn ? 'enabled' : 'disabled'));
+      } catch (err) {
+        el.classList.toggle('on'); // revert on failure
+        showToast('Failed to update attribution trailer: ' + err.message, 'error');
+      }
     }
 
     async function toggleTrajectoryReview(el) {


### PR DESCRIPTION
Exposes `governor.eval_interval_s` and `governor.attribution_trailer` in the Governor dialog's **General** tab.

- New owner-only `GET/PUT /api/config/governor/general-advanced` endpoints following the existing governor-config handler pattern (overlay save via `saveConfig()`, partial-update pointer body, validation before mutation).
- General tab UI: **Eval interval (seconds)** number input and **Show attribution trailer on PRs/issues** toggle, both saving via the new endpoint.
- Tests covering defaults, validation bounds, partial updates, and the owner gate.

Closes #4212