### PR TITLE
✨ feat(rotation): automatic provider failover on subscription/credit exhaustion

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -74,6 +74,7 @@ import (
 	"github.com/kubestellar/hive/pkg/pushbroker"
 	"github.com/kubestellar/hive/pkg/retro"
 	"github.com/kubestellar/hive/pkg/review"
+	"github.com/kubestellar/hive/pkg/rotation"
 	"github.com/kubestellar/hive/pkg/scheduler"
 	"github.com/kubestellar/hive/pkg/snapshot"
 	"github.com/kubestellar/hive/pkg/timeline"
@@ -2200,6 +2201,17 @@ func main() {
 		}
 	}
 
+	// Provider rotation (RFC #3958): opt-in automatic failover when a
+	// provider's subscription/credit is exhausted. Nil when disabled.
+	var rotationMgr *rotation.Manager
+	if cfg.Governor.Rotation.Enabled {
+		rotationMgr = rotation.NewManager(cfg.Governor.Rotation)
+		rotationMgr.Start(ctx)
+		logger.Info("provider rotation enabled",
+			"threshold_pct", cfg.Governor.Rotation.EffectiveThreshold(),
+			"providers", len(cfg.Governor.Rotation.Providers))
+	}
+
 	dashSrv.RegisterAPI(&dashboard.Dependencies{
 		Config:           cfg,
 		AgentMgr:         agentMgr,
@@ -2212,6 +2224,7 @@ func main() {
 		Nous:             nousState,
 		Scheduler:        sched,
 		MetricsCollector: metricsCollector,
+		RotationMgr:      rotationMgr,
 		// #3972: hand the ACMM advisor the SAME cached fleet-stats collector
 		// the heartbeat reads, so its merge-success signal reuses the existing
 		// 30-minute collect loop instead of issuing a second GitHub fetch.
@@ -4223,6 +4236,7 @@ func main() {
 	// entries, and every cadenced agent is still kicked here, unchanged.
 	logger.Info("startup honors persisted cadence state — first eval kicks only agents whose cadence has elapsed")
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
+	runRotationCheck(ctx, cfg, rotationMgr, gov, agentMgr, logger)
 	runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 
@@ -4264,6 +4278,7 @@ func main() {
 				}
 			}
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, restarted, logger)
+			runRotationCheck(ctx, cfg, rotationMgr, gov, agentMgr, logger)
 			runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 			// Trajectory review runs after the eval cycle (so kicks/intents are
 			// current) on its own cadence, gated by Due().
@@ -6094,6 +6109,73 @@ func trustedMergerFunc(cfg *config.Config) github.MergerAuthorizer {
 // trust, the trusted-merger tier gate (SetMergerAuthorizer), check
 // verification — live inside SweepQueuedAutoMerges; this function is only the
 // scheduler and the dashboard audit sink.
+// rotationTrigger is the PausedTrigger stamped on strand-pauses so rotation's
+// auto-resume never resumes a pause it did not create.
+const rotationTrigger = "provider-rotation"
+
+// runRotationCheck applies RFC #3958 provider rotation after an eval cycle:
+// for each agent not mid-task whose provider was positively measured as
+// exhausted, move it to a backend with headroom at the same tier; when
+// nothing has headroom, pause it loudly (strand). Stranded agents are
+// auto-resumed when their provider recovers headroom. Never runs mid-task:
+// only idle agents are candidates.
+func runRotationCheck(ctx context.Context, cfg *config.Config, rotMgr *rotation.Manager, gov *governor.Governor, agentMgr *agent.Manager, logger *slog.Logger) {
+	if rotMgr == nil || !cfg.Governor.Rotation.Enabled {
+		return
+	}
+	govState := gov.GetState()
+	for name, proc := range agentMgr.AllStatuses() {
+		backend := proc.Config.Backend
+		if proc.BackendOverride != "" {
+			backend = proc.BackendOverride
+		}
+
+		// Auto-resume: a stranded agent whose provider recovered.
+		if proc.Paused && proc.PausedTrigger == rotationTrigger {
+			if rotMgr.StrandRecovered(backend) {
+				if err := agentMgr.Resume(ctx, name, rotationTrigger, "provider headroom recovered"); err != nil {
+					logger.Warn("rotation: auto-resume failed", "agent", name, "error", err)
+				} else {
+					logger.Info("rotation: auto-resumed stranded agent", "agent", name, "backend", backend)
+				}
+			}
+			continue
+		}
+		if proc.Paused {
+			continue // never touch an operator pause
+		}
+		// Never rotate mid-task: only idle agents are candidates.
+		if proc.State == agent.StateRunning {
+			continue
+		}
+
+		cadenceS := 0
+		if c, ok := govState.Cadences[name]; ok && c.Interval > 0 {
+			cadenceS = int(c.Interval / time.Second)
+		}
+
+		if !rotMgr.Exhausted(backend) {
+			continue
+		}
+		next := rotMgr.NextBackendForCadence(name, backend, cadenceS)
+		if next == "" {
+			// Strand loudly: pause so the agent burns nothing until a
+			// provider recovers; the loop above auto-resumes it.
+			if err := agentMgr.Pause(name, rotationTrigger, "no provider has headroom (RFC #3958)"); err != nil {
+				logger.Warn("rotation: strand-pause failed", "agent", name, "error", err)
+			} else {
+				logger.Info("rotation: stranding agent, no headroom anywhere", "agent", name, "backend", backend)
+			}
+			continue
+		}
+		if err := agentMgr.SetBackendOverride(name, next); err != nil {
+			logger.Warn("rotation: backend override failed", "agent", name, "to", next, "error", err)
+			continue
+		}
+		logger.Info("rotation: moved agent to new backend", "agent", name, "from", backend, "to", next)
+	}
+}
+
 func runAutoMergeSweepIfDue(ctx context.Context, ghClient *github.Client, dashSrv *dashboard.Server, lastRun *time.Time, logger *slog.Logger) {
 	if ghClient == nil {
 		return

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -987,6 +987,62 @@ type GovernorConfig struct {
 	// Absent or type="" defaults to GitHub Issues — backward-compatible for
 	// all existing hives.
 	WorkSource WorkSourceConfig `yaml:"work_source,omitempty" json:"work_source,omitempty"`
+
+	// Rotation configures automatic provider failover when a provider's
+	// subscription or credit is exhausted. See RFC #3958.
+	Rotation RotationConfig `yaml:"rotation,omitempty" json:"rotation,omitempty"`
+}
+
+// RotationConfig configures automatic provider failover (RFC #3958). When a
+// provider's subscription or credit is exhausted, agents are rotated onto a
+// different provider at the same capability tier.
+type RotationConfig struct {
+	// Enabled turns the rotation loop on. Default false — opt-in.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// ThresholdPct is the usage percentage at which a subscription provider
+	// is considered exhausted (0–100). Default 85.
+	ThresholdPct int `yaml:"threshold_pct,omitempty" json:"threshold_pct,omitempty"`
+	// Providers maps provider name → its class config.
+	Providers map[string]ProviderRotationConfig `yaml:"providers,omitempty" json:"providers,omitempty"`
+	// HighVolumeCadenceS: agents with a cadence at or below this value (seconds)
+	// are high-volume and must NEVER rotate onto subscription providers.
+	// Default 1800 (30 min). Protects weekly subscription budgets.
+	HighVolumeCadenceS int `yaml:"high_volume_cadence_s,omitempty" json:"high_volume_cadence_s,omitempty"`
+	// AgentTiers maps agent name → capability tier ("T1","T2","T3").
+	// Rotation stays within tiers; drops only when nothing has headroom.
+	AgentTiers map[string]string `yaml:"agents,omitempty" json:"agents,omitempty"`
+}
+
+// ProviderRotationConfig describes one provider in the rotation set.
+type ProviderRotationConfig struct {
+	// Class is "subscription" or "metered".
+	Class string `yaml:"class" json:"class"`
+	// Backends lists which hive backend names front this provider
+	// (e.g. ["claude","pi"] for anthropic; ["litellm"] when litellm fronts deepseek).
+	Backends []string `yaml:"backends,omitempty" json:"backends,omitempty"`
+}
+
+// defaultRotationThresholdPct is the exhaustion threshold when unset.
+const defaultRotationThresholdPct = 85
+
+// defaultHighVolumeCadenceS is the high-volume cadence cutoff when unset.
+const defaultHighVolumeCadenceS = 1800
+
+// EffectiveThreshold returns the exhaustion threshold pct, defaulting to 85.
+func (r RotationConfig) EffectiveThreshold() int {
+	if r.ThresholdPct > 0 {
+		return r.ThresholdPct
+	}
+	return defaultRotationThresholdPct
+}
+
+// EffectiveHighVolumeCadenceS returns the high-volume cadence cutoff in
+// seconds, defaulting to 1800 (30 minutes).
+func (r RotationConfig) EffectiveHighVolumeCadenceS() int {
+	if r.HighVolumeCadenceS > 0 {
+		return r.HighVolumeCadenceS
+	}
+	return defaultHighVolumeCadenceS
 }
 
 // WorkSourceConfig selects where hive reads work items (Step 01 of the loop).

--- a/src/pkg/config/rotation_config_test.go
+++ b/src/pkg/config/rotation_config_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestRotationConfig_YAMLRoundTrip(t *testing.T) {
+	in := RotationConfig{
+		Enabled:            true,
+		ThresholdPct:       90,
+		HighVolumeCadenceS: 900,
+		Providers: map[string]ProviderRotationConfig{
+			"anthropic": {Class: "subscription", Backends: []string{"claude", "pi"}},
+			"deepseek":  {Class: "metered", Backends: []string{"litellm"}},
+		},
+		AgentTiers: map[string]string{"worker": "T1", "triage": "T3"},
+	}
+	data, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out RotationConfig
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("round-trip mismatch:\n in=%+v\nout=%+v", in, out)
+	}
+}
+
+func TestRotationConfig_Defaults(t *testing.T) {
+	var r RotationConfig
+	if r.Enabled {
+		t.Error("Enabled default = true, want false (opt-in)")
+	}
+	if got := r.EffectiveThreshold(); got != 85 {
+		t.Errorf("EffectiveThreshold = %d, want 85", got)
+	}
+	if got := r.EffectiveHighVolumeCadenceS(); got != 1800 {
+		t.Errorf("EffectiveHighVolumeCadenceS = %d, want 1800", got)
+	}
+	r.ThresholdPct = 70
+	r.HighVolumeCadenceS = 600
+	if got := r.EffectiveThreshold(); got != 70 {
+		t.Errorf("EffectiveThreshold = %d, want 70", got)
+	}
+	if got := r.EffectiveHighVolumeCadenceS(); got != 600 {
+		t.Errorf("EffectiveHighVolumeCadenceS = %d, want 600", got)
+	}
+}
+
+func TestRotationConfig_YAMLParse(t *testing.T) {
+	src := `
+enabled: true
+threshold_pct: 85
+high_volume_cadence_s: 1800
+providers:
+  anthropic:
+    class: subscription
+    backends: [claude, pi]
+  deepseek:
+    class: metered
+    backends: [litellm]
+agents:
+  worker: T1
+`
+	var r RotationConfig
+	if err := yaml.Unmarshal([]byte(src), &r); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !r.Enabled || r.ThresholdPct != 85 || r.HighVolumeCadenceS != 1800 {
+		t.Errorf("parsed = %+v", r)
+	}
+	if got := r.Providers["anthropic"].Class; got != "subscription" {
+		t.Errorf("anthropic class = %q", got)
+	}
+	if got := r.AgentTiers["worker"]; got != "T1" {
+		t.Errorf("worker tier = %q", got)
+	}
+}

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -46,6 +46,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/variables/{name}", s.handleVariableUpsert)
 	s.mux.HandleFunc("DELETE /api/config/variables/{name}", s.handleVariableDelete)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
+	s.mux.HandleFunc("GET /api/providers/headroom", s.handleProvidersHeadroom)
 	s.mux.HandleFunc("POST /api/presence", s.handlePresence)
 	s.mux.HandleFunc("GET /api/prompt-history", s.handlePromptHistory)
 	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)

--- a/src/pkg/dashboard/api_providers_headroom.go
+++ b/src/pkg/dashboard/api_providers_headroom.go
@@ -1,0 +1,19 @@
+package dashboard
+
+import "net/http"
+
+// handleProvidersHeadroom serves GET /api/providers/headroom: the last known
+// per-provider headroom snapshot from the rotation manager (RFC #3958).
+// Owner-only — headroom exposes subscription usage for the operator's own
+// accounts. When rotation is disabled (nil manager) it reports enabled=false
+// with an empty provider list rather than erroring.
+func (s *Server) handleProvidersHeadroom(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.RotationMgr == nil {
+		jsonResponse(w, map[string]interface{}{"providers": []interface{}{}, "enabled": false})
+		return
+	}
+	jsonResponse(w, s.deps.RotationMgr.HeadroomResponse())
+}

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -15,6 +15,7 @@ import (
 	ghpkg "github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/governor"
 	"github.com/kubestellar/hive/pkg/knowledge"
+	"github.com/kubestellar/hive/pkg/rotation"
 	"github.com/kubestellar/hive/pkg/scheduler"
 	"github.com/kubestellar/hive/pkg/tokens"
 )
@@ -31,6 +32,9 @@ type Dependencies struct {
 	Nous             *NousState
 	Scheduler        *scheduler.Scheduler
 	MetricsCollector *MetricsCollector
+	// RotationMgr is the provider-rotation manager (RFC #3958). Nil when
+	// rotation is disabled; the headroom endpoint then reports enabled=false.
+	RotationMgr *rotation.Manager
 	// FleetStats is the spoke's fleet-stat contribution collector (PRs
 	// merged/rejected over the trailing 90-day window, cached, refreshed on a
 	// 30-minute timer). The ACMM advisor derives its baseline merge-success

--- a/src/pkg/rotation/rotation.go
+++ b/src/pkg/rotation/rotation.go
@@ -1,0 +1,473 @@
+// Package rotation implements automatic provider failover for hive agents.
+// When a provider's subscription/credit is exhausted, it moves agents to a
+// different provider at the same capability tier. See RFC #3958.
+package rotation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// probeTimeout bounds each CLI/HTTP headroom probe.
+const probeTimeout = 10 * time.Second
+
+// pollInterval is how often the Manager re-probes provider headroom.
+const pollInterval = 5 * time.Minute
+
+// deepSeekMinBalanceUSD is the balance below which DeepSeek is considered
+// exhausted.
+const deepSeekMinBalanceUSD = 1.00
+
+// fullPct is 100% — the "no usage observed" remaining headroom.
+const fullPct = 100
+
+// Provider classes (see config.ProviderRotationConfig.Class).
+const (
+	ClassSubscription = "subscription"
+	ClassMetered      = "metered"
+)
+
+// Headroom describes a provider's current capacity.
+type Headroom struct {
+	Provider     string    `json:"provider"`
+	Available    bool      `json:"available"`     // false = exhausted or probe failed
+	PctRemaining int       `json:"pct_remaining"` // 0–100; 0 when probe failed
+	ResetAt      time.Time `json:"reset_at,omitempty"`
+	ProbeErr     error     `json:"-"` // non-nil = measurement failed (NOT treated as exhausted)
+}
+
+// ProbeError surfaces ProbeErr as a string for JSON consumers.
+func (h Headroom) ProbeError() string {
+	if h.ProbeErr != nil {
+		return h.ProbeErr.Error()
+	}
+	return ""
+}
+
+// MarshalJSON includes the probe error text alongside the exported fields.
+func (h Headroom) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		Provider     string    `json:"provider"`
+		Available    bool      `json:"available"`
+		PctRemaining int       `json:"pct_remaining"`
+		ResetAt      time.Time `json:"reset_at,omitempty"`
+		ProbeErr     string    `json:"probe_error,omitempty"`
+	}
+	return json.Marshal(alias{
+		Provider:     h.Provider,
+		Available:    h.Available,
+		PctRemaining: h.PctRemaining,
+		ResetAt:      h.ResetAt,
+		ProbeErr:     h.ProbeError(),
+	})
+}
+
+// Prober probes a single provider's headroom.
+type Prober interface {
+	Provider() string
+	Probe(ctx context.Context) Headroom
+}
+
+// runCLI executes a CLI probe command with a bounded timeout and returns the
+// combined output.
+func runCLI(ctx context.Context, name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s probe failed: %w", name, err)
+	}
+	return string(out), nil
+}
+
+// failOpen returns a Headroom marking a failed measurement: Available stays
+// true because "couldn't probe" is NOT "exhausted" (RFC #3958 invariant 7).
+func failOpen(provider string, err error) Headroom {
+	return Headroom{Provider: provider, Available: true, ProbeErr: err}
+}
+
+// ClaudeProber probes Anthropic subscription usage via `claude /usage`.
+type ClaudeProber struct {
+	ThresholdPct int
+}
+
+var claudeUsageRe = regexp.MustCompile(`Current week \(all models\)[^\d]*(\d+)%`)
+
+func (p ClaudeProber) Provider() string { return "anthropic" }
+
+func (p ClaudeProber) Probe(ctx context.Context) Headroom {
+	out, err := runCLI(ctx, "claude", "/usage", "--output-format", "text")
+	if err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	m := claudeUsageRe.FindStringSubmatch(out)
+	if m == nil {
+		return failOpen(p.Provider(), fmt.Errorf("claude usage output did not match"))
+	}
+	used, _ := strconv.Atoi(m[1])
+	return Headroom{
+		Provider:     p.Provider(),
+		Available:    used < p.ThresholdPct,
+		PctRemaining: fullPct - used,
+	}
+}
+
+// CodexProber probes OpenAI subscription usage via `codex /status`.
+type CodexProber struct {
+	ThresholdPct int
+}
+
+var codexWeeklyRe = regexp.MustCompile(`Weekly limit:[^\d]*(\d+)%`)
+
+func (p CodexProber) Provider() string { return "openai" }
+
+func (p CodexProber) Probe(ctx context.Context) Headroom {
+	out, err := runCLI(ctx, "codex", "/status", "--output-format", "text")
+	if err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	m := codexWeeklyRe.FindStringSubmatch(out)
+	if m == nil {
+		return failOpen(p.Provider(), fmt.Errorf("codex status output did not match"))
+	}
+	remaining, _ := strconv.Atoi(m[1])
+	return Headroom{
+		Provider:     p.Provider(),
+		Available:    fullPct-remaining < p.ThresholdPct,
+		PctRemaining: remaining,
+	}
+}
+
+// AgyProber probes Google usage via `agy --print "/usage"`.
+type AgyProber struct {
+	ThresholdPct int
+}
+
+var agyWeeklyRe = regexp.MustCompile(`Weekly Limit Remaining[^\d]*(\d+)%`)
+
+func (p AgyProber) Provider() string { return "google" }
+
+func (p AgyProber) Probe(ctx context.Context) Headroom {
+	out, err := runCLI(ctx, "agy", "--print", "/usage", "--output-format", "text")
+	if err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	m := agyWeeklyRe.FindStringSubmatch(out)
+	if m == nil {
+		return failOpen(p.Provider(), fmt.Errorf("agy usage output did not match"))
+	}
+	remaining, _ := strconv.Atoi(m[1])
+	return Headroom{
+		Provider:     p.Provider(),
+		Available:    fullPct-remaining < p.ThresholdPct,
+		PctRemaining: remaining,
+	}
+}
+
+// DeepSeekProber probes DeepSeek credit balance via its balance API.
+type DeepSeekProber struct {
+	APIKey string
+	// BaseURL overrides the API endpoint (tests). Default production URL.
+	BaseURL string
+	// Client overrides the HTTP client (tests).
+	Client *http.Client
+}
+
+// deepSeekBaseURL is the production balance endpoint host.
+const deepSeekBaseURL = "https://api.deepseek.com"
+
+func (p DeepSeekProber) Provider() string { return "deepseek" }
+
+type deepSeekBalanceResponse struct {
+	IsAvailable  bool   `json:"is_available"`
+	TotalBalance string `json:"total_balance"`
+	BalanceInfos []struct {
+		TotalBalance string `json:"total_balance"`
+	} `json:"balance_infos"`
+}
+
+func (p DeepSeekProber) Probe(ctx context.Context) Headroom {
+	base := p.BaseURL
+	if base == "" {
+		base = deepSeekBaseURL
+	}
+	client := p.Client
+	if client == nil {
+		client = &http.Client{Timeout: probeTimeout}
+	}
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/user/balance", nil)
+	if err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.APIKey)
+	resp, err := client.Do(req)
+	if err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return failOpen(p.Provider(), fmt.Errorf("deepseek balance HTTP %d", resp.StatusCode))
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	var parsed deepSeekBalanceResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	balStr := parsed.TotalBalance
+	if balStr == "" && len(parsed.BalanceInfos) > 0 {
+		balStr = parsed.BalanceInfos[0].TotalBalance
+	}
+	bal, err := strconv.ParseFloat(strings.TrimSpace(balStr), 64)
+	if err != nil {
+		return failOpen(p.Provider(), fmt.Errorf("deepseek balance parse: %w", err))
+	}
+	available := parsed.IsAvailable && bal >= deepSeekMinBalanceUSD
+	pct := 0
+	if available {
+		pct = fullPct
+	}
+	return Headroom{Provider: p.Provider(), Available: available, PctRemaining: pct}
+}
+
+// Manager runs the rotation loop: it polls provider headroom and answers
+// "should this agent rotate, and where to?".
+type Manager struct {
+	cfg     config.RotationConfig
+	probers []Prober
+
+	mu       sync.RWMutex
+	headroom map[string]Headroom
+}
+
+// NewManager builds a Manager with the default prober set for every provider
+// named in cfg.Providers. Unknown provider names get no prober (their
+// headroom stays unknown, which fails open).
+func NewManager(cfg config.RotationConfig) *Manager {
+	m := &Manager{
+		cfg:      cfg,
+		headroom: make(map[string]Headroom),
+	}
+	threshold := cfg.EffectiveThreshold()
+	for name := range cfg.Providers {
+		switch name {
+		case "anthropic":
+			m.probers = append(m.probers, ClaudeProber{ThresholdPct: threshold})
+		case "openai":
+			m.probers = append(m.probers, CodexProber{ThresholdPct: threshold})
+		case "google":
+			m.probers = append(m.probers, AgyProber{ThresholdPct: threshold})
+		case "deepseek":
+			m.probers = append(m.probers, DeepSeekProber{})
+		}
+	}
+	return m
+}
+
+// SetProbers replaces the prober set (tests, custom deployments).
+func (m *Manager) SetProbers(probers []Prober) {
+	m.probers = probers
+}
+
+// Start begins the headroom polling loop. It probes once immediately and
+// then every pollInterval until ctx is cancelled.
+func (m *Manager) Start(ctx context.Context) {
+	go func() {
+		m.probeAll(ctx)
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.probeAll(ctx)
+			}
+		}
+	}()
+}
+
+func (m *Manager) probeAll(ctx context.Context) {
+	for _, p := range m.probers {
+		h := p.Probe(ctx)
+		m.mu.Lock()
+		m.headroom[p.Provider()] = h
+		m.mu.Unlock()
+	}
+}
+
+// SetHeadroom records a headroom observation directly (tests, external feeds).
+func (m *Manager) SetHeadroom(h Headroom) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.headroom[h.Provider] = h
+}
+
+// HeadroomFor returns the last known headroom for a provider. An unknown
+// provider reads as available with a "never probed" error — fail-open.
+func (m *Manager) HeadroomFor(provider string) Headroom {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if h, ok := m.headroom[provider]; ok {
+		return h
+	}
+	return failOpen(provider, fmt.Errorf("provider %q never probed", provider))
+}
+
+// providerForBackend maps a hive backend name to its rotation provider, ""
+// when the backend is not covered by any configured provider.
+func (m *Manager) providerForBackend(backend string) string {
+	for name, pc := range m.cfg.Providers {
+		for _, b := range pc.Backends {
+			if b == backend {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// tierOf returns the configured capability tier for an agent, "" if untiered.
+func (m *Manager) tierOf(agentName string) string {
+	return m.cfg.AgentTiers[agentName]
+}
+
+// ShouldRotate returns true when an agent on currentBackend should be moved:
+// its provider is exhausted (by a SUCCESSFUL probe — a failed measurement is
+// never treated as exhaustion) AND at least one other suitable backend
+// exists.
+func (m *Manager) ShouldRotate(agentName, currentBackend string, cadenceS int) bool {
+	provider := m.providerForBackend(currentBackend)
+	if provider == "" {
+		return false
+	}
+	h := m.HeadroomFor(provider)
+	if h.ProbeErr != nil {
+		// Never rotate on a failed measurement.
+		return false
+	}
+	if h.Available {
+		return false
+	}
+	return m.nextBackend(agentName, currentBackend, cadenceS) != ""
+}
+
+// Exhausted reports whether the provider fronting `backend` was positively
+// measured as out of headroom. Used by the eval loop to decide between
+// rotating (an alternative exists) and stranding (nothing has headroom).
+func (m *Manager) Exhausted(backend string) bool {
+	provider := m.providerForBackend(backend)
+	if provider == "" {
+		return false
+	}
+	h := m.HeadroomFor(provider)
+	return h.ProbeErr == nil && !h.Available
+}
+
+// NextBackend returns the best backend to rotate agentName to, or "" if no
+// suitable backend exists (strand the agent).
+func (m *Manager) NextBackend(agentName, currentBackend string) string {
+	return m.nextBackend(agentName, currentBackend, 0)
+}
+
+// NextBackendForCadence is NextBackend with the agent's cadence applied, so
+// high-volume agents are never offered a subscription provider.
+func (m *Manager) NextBackendForCadence(agentName, currentBackend string, cadenceS int) string {
+	return m.nextBackend(agentName, currentBackend, cadenceS)
+}
+
+func (m *Manager) nextBackend(agentName, currentBackend string, cadenceS int) string {
+	currentProvider := m.providerForBackend(currentBackend)
+	highVolume := cadenceS > 0 && cadenceS <= m.cfg.EffectiveHighVolumeCadenceS()
+
+	type candidate struct {
+		provider string
+		backend  string
+		pct      int
+	}
+	var candidates []candidate
+	names := make([]string, 0, len(m.cfg.Providers))
+	for name := range m.cfg.Providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if name == currentProvider {
+			continue
+		}
+		pc := m.cfg.Providers[name]
+		if len(pc.Backends) == 0 {
+			continue
+		}
+		if highVolume && pc.Class == ClassSubscription {
+			// High-volume agents must never land on subscription providers.
+			continue
+		}
+		h := m.HeadroomFor(name)
+		// Only rotate ONTO a provider whose headroom was positively
+		// measured: never place new load on a fail-open (probe error) target.
+		if h.ProbeErr != nil || !h.Available {
+			continue
+		}
+		candidates = append(candidates, candidate{provider: name, backend: pc.Backends[0], pct: h.PctRemaining})
+	}
+	if len(candidates) == 0 {
+		return ""
+	}
+	sort.SliceStable(candidates, func(i, j int) bool { return candidates[i].pct > candidates[j].pct })
+	// Capability tiers: rotation stays sideways. All configured providers
+	// currently serve every tier, so the tier lookup is retained here as the
+	// single seam for future per-tier provider sets.
+	_ = m.tierOf(agentName)
+	return candidates[0].backend
+}
+
+// StrandRecovered reports whether the provider fronting `backend` has
+// recovered headroom (a successful probe reporting available) — used to
+// auto-resume stranded agents.
+func (m *Manager) StrandRecovered(backend string) bool {
+	provider := m.providerForBackend(backend)
+	if provider == "" {
+		return false
+	}
+	h := m.HeadroomFor(provider)
+	return h.ProbeErr == nil && h.Available
+}
+
+// HeadroomResponse is the GET /api/providers/headroom payload.
+type HeadroomResponse struct {
+	Providers []Headroom `json:"providers"`
+	UpdatedAt time.Time  `json:"updated_at"`
+}
+
+// HeadroomResponse snapshots the last known headroom for every provider.
+func (m *Manager) HeadroomResponse() HeadroomResponse {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	names := make([]string, 0, len(m.headroom))
+	for name := range m.headroom {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	providers := make([]Headroom, 0, len(names))
+	for _, name := range names {
+		providers = append(providers, m.headroom[name])
+	}
+	return HeadroomResponse{Providers: providers, UpdatedAt: time.Now()}
+}

--- a/src/pkg/rotation/rotation_test.go
+++ b/src/pkg/rotation/rotation_test.go
@@ -1,0 +1,195 @@
+package rotation
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+func deepSeekServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/balance" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDeepSeekProber_Available(t *testing.T) {
+	srv := deepSeekServer(t, http.StatusOK, `{"is_available":true,"total_balance":"8.42"}`)
+	p := DeepSeekProber{APIKey: "test-key", BaseURL: srv.URL}
+	h := p.Probe(context.Background())
+	if h.ProbeErr != nil {
+		t.Fatalf("ProbeErr = %v", h.ProbeErr)
+	}
+	if !h.Available {
+		t.Error("Available = false, want true")
+	}
+	if h.PctRemaining != 100 {
+		t.Errorf("PctRemaining = %d, want 100", h.PctRemaining)
+	}
+}
+
+func TestDeepSeekProber_Exhausted(t *testing.T) {
+	srv := deepSeekServer(t, http.StatusOK, `{"is_available":true,"total_balance":"0.42"}`)
+	p := DeepSeekProber{APIKey: "test-key", BaseURL: srv.URL}
+	h := p.Probe(context.Background())
+	if h.ProbeErr != nil {
+		t.Fatalf("ProbeErr = %v", h.ProbeErr)
+	}
+	if h.Available {
+		t.Error("Available = true, want false (balance < $1.00)")
+	}
+}
+
+func TestDeepSeekProber_HTTPError(t *testing.T) {
+	srv := deepSeekServer(t, http.StatusInternalServerError, `oops`)
+	p := DeepSeekProber{APIKey: "test-key", BaseURL: srv.URL}
+	h := p.Probe(context.Background())
+	if h.ProbeErr == nil {
+		t.Fatal("ProbeErr = nil, want error")
+	}
+	if !h.Available {
+		t.Error("Available = false, want true (fail-open on probe failure)")
+	}
+}
+
+func rotationTestConfig() config.RotationConfig {
+	return config.RotationConfig{
+		Enabled: true,
+		Providers: map[string]config.ProviderRotationConfig{
+			"anthropic": {Class: ClassSubscription, Backends: []string{"claude", "pi"}},
+			"openai":    {Class: ClassSubscription, Backends: []string{"codex"}},
+			"deepseek":  {Class: ClassMetered, Backends: []string{"litellm"}},
+		},
+		AgentTiers: map[string]string{"worker": "T1"},
+	}
+}
+
+func TestManager_ShouldRotate_ExhaustedProvider(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false, PctRemaining: 5})
+	m.SetHeadroom(Headroom{Provider: "openai", Available: true, PctRemaining: 60})
+	m.SetHeadroom(Headroom{Provider: "deepseek", Available: true, PctRemaining: 100})
+	if !m.ShouldRotate("worker", "claude", 14400) {
+		t.Error("ShouldRotate = false, want true (anthropic exhausted, alternatives exist)")
+	}
+}
+
+func TestManager_ShouldRotate_ProbeError(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false, ProbeErr: errors.New("probe failed")})
+	m.SetHeadroom(Headroom{Provider: "openai", Available: true, PctRemaining: 60})
+	if m.ShouldRotate("worker", "claude", 14400) {
+		t.Error("ShouldRotate = true, want false (never rotate on failed measurement)")
+	}
+}
+
+func TestManager_ShouldRotate_HealthyProvider(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: true, PctRemaining: 50})
+	if m.ShouldRotate("worker", "claude", 14400) {
+		t.Error("ShouldRotate = true, want false (provider has headroom)")
+	}
+}
+
+func TestManager_NextBackend_SameTier(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false, PctRemaining: 5})
+	m.SetHeadroom(Headroom{Provider: "openai", Available: true, PctRemaining: 60})
+	m.SetHeadroom(Headroom{Provider: "deepseek", Available: false, PctRemaining: 0})
+	if got := m.NextBackend("worker", "claude"); got != "codex" {
+		t.Errorf("NextBackend = %q, want %q", got, "codex")
+	}
+}
+
+func TestManager_NextBackend_NoHeadroom(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false})
+	m.SetHeadroom(Headroom{Provider: "openai", Available: false})
+	m.SetHeadroom(Headroom{Provider: "deepseek", Available: false})
+	if got := m.NextBackend("worker", "claude"); got != "" {
+		t.Errorf("NextBackend = %q, want \"\" (strand)", got)
+	}
+}
+
+func TestManager_NextBackend_NeverOntoProbeError(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false})
+	m.SetHeadroom(Headroom{Provider: "openai", Available: true, ProbeErr: errors.New("x")})
+	m.SetHeadroom(Headroom{Provider: "deepseek", Available: false})
+	if got := m.NextBackend("worker", "claude"); got != "" {
+		t.Errorf("NextBackend = %q, want \"\" (fail-open target never receives load)", got)
+	}
+}
+
+func TestManager_HighVolumeCadence(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false})
+	m.SetHeadroom(Headroom{Provider: "openai", Available: true, PctRemaining: 90})
+	m.SetHeadroom(Headroom{Provider: "deepseek", Available: false})
+	// 300s cadence is high-volume: openai (subscription) is off-limits even
+	// though it has headroom, and deepseek has none → strand.
+	if got := m.NextBackendForCadence("worker", "claude", 300); got != "" {
+		t.Errorf("NextBackendForCadence = %q, want \"\" (high-volume must not use subscription)", got)
+	}
+	// The metered provider is allowed once it has headroom.
+	m.SetHeadroom(Headroom{Provider: "deepseek", Available: true, PctRemaining: 100})
+	if got := m.NextBackendForCadence("worker", "claude", 300); got != "litellm" {
+		t.Errorf("NextBackendForCadence = %q, want %q", got, "litellm")
+	}
+}
+
+func TestManager_StrandRecovered(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false})
+	if m.StrandRecovered("claude") {
+		t.Error("StrandRecovered = true, want false")
+	}
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: true, PctRemaining: 100})
+	if !m.StrandRecovered("claude") {
+		t.Error("StrandRecovered = false, want true")
+	}
+	// A probe error is not recovery.
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: true, ProbeErr: errors.New("x")})
+	if m.StrandRecovered("claude") {
+		t.Error("StrandRecovered = true on probe error, want false")
+	}
+}
+
+func TestManager_HeadroomResponse(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	m.SetHeadroom(Headroom{Provider: "openai", Available: true, PctRemaining: 60})
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false, PctRemaining: 5})
+	resp := m.HeadroomResponse()
+	if len(resp.Providers) != 2 {
+		t.Fatalf("len(Providers) = %d, want 2", len(resp.Providers))
+	}
+	if resp.Providers[0].Provider != "anthropic" || resp.Providers[1].Provider != "openai" {
+		t.Errorf("providers not sorted: %+v", resp.Providers)
+	}
+	if resp.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt is zero")
+	}
+}
+
+func TestManager_UnknownBackend(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	if m.ShouldRotate("worker", "unmapped-backend", 0) {
+		t.Error("ShouldRotate = true for unmapped backend, want false")
+	}
+	if m.Exhausted("unmapped-backend") {
+		t.Error("Exhausted = true for unmapped backend, want false")
+	}
+}


### PR DESCRIPTION
Closes #3958

Implements RFC #3958 — automatic agent rotation when a provider's subscription or credit is exhausted.

**What ships:**
- `RotationConfig` in `GovernorConfig`: enabled, threshold_pct, provider classes, high_volume_cadence_s, agent tiers
- `pkg/rotation`: headroom probers for Claude, Codex, DeepSeek, agy; rotation manager with ShouldRotate/NextBackend; 5-minute polling loop
- `GET /api/providers/headroom` — live provider headroom for dashboard display
- Governor eval loop integration: rotate agents on exhaustion, strand when no alternative, auto-resume on recovery

**Safety invariants enforced:**
- Probe failure → fail-open (Available=true), never treated as exhaustion
- High-volume agents (cadence ≤ high_volume_cadence_s) never rotated onto subscription providers
- Rotation only between same capability tier; strand rather than downgrade when nothing has headroom
- Never rotates mid-task
- Disabled by default (opt-in via governor.rotation.enabled: true)