### PR TITLE
✨ Expose governor.vllm and governor.llm-d inference auth in Model Gateways settings tab

### DIFF
--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -1638,8 +1638,10 @@ const (
 // gateway, which entitlement-filters /v1/models per API key and hides
 // key-gated models from anonymous callers.
 type InferenceAuthConfig struct {
-	APIKeyEnv  string `yaml:"api_key_env"`  // env var NAME holding the key; never the key value
-	APIKeyFile string `yaml:"api_key_file"` // path to a file holding the key
+	APIKeyHeader string `yaml:"api_key_header,omitempty" json:"api_key_header,omitempty"` // header NAME the key is sent in (default "Authorization")
+	APIKeyEnv    string `yaml:"api_key_env" json:"api_key_env"`                           // env var NAME holding the key; never the key value
+	APIKeyFile   string `yaml:"api_key_file" json:"api_key_file"`                         // path to a file holding the key
+	Endpoint     string `yaml:"endpoint,omitempty" json:"endpoint,omitempty"`             // optional endpoint override for this backend
 }
 
 // ResolveAPIKey returns the backend's discovery API key using the

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -160,6 +160,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	// Live key validation (pasted or saved key) — see bob_key_probe.go.
 	s.mux.HandleFunc("POST /api/config/governor/bob/test", s.handleGovernorBobKeyTest)
 	s.mux.HandleFunc("POST /api/config/governor/litellm/test", s.handleGovernorLiteLLMTest)
+	s.mux.HandleFunc("GET /api/config/governor/inference-auth", s.handleGovernorInferenceAuthGet)
+	s.mux.HandleFunc("PUT /api/config/governor/inference-auth", s.handleGovernorInferenceAuthPut)
 	s.mux.HandleFunc("GET /api/config/governor/gateways", s.handleGovernorGatewaysList)
 	s.mux.HandleFunc("PUT /api/config/governor/gateways", s.handleGovernorGatewaysUpsert)
 	s.mux.HandleFunc("DELETE /api/config/governor/gateways/{name}", s.handleGovernorGatewaysDelete)

--- a/src/pkg/dashboard/api_governor_inference_auth.go
+++ b/src/pkg/dashboard/api_governor_inference_auth.go
@@ -1,0 +1,136 @@
+package dashboard
+
+// Inference-auth settings (governor.vllm / governor.llm-d) for the Model
+// Gateways config tab (#4217). LiteLLM auth is already exposed there; this
+// closes the asymmetry for the self-hosted backends. Only key REFERENCES are
+// accepted and returned — a header NAME, an env var NAME, a file PATH, and an
+// optional endpoint override. The key VALUE never enters hive.yaml, logs, or
+// API responses.
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// inferenceAuthSectionResponse builds the safe JSON shape for one backend's
+// InferenceAuthConfig. Everything in the struct is a reference (names/paths),
+// so it is safe to serialize verbatim.
+func inferenceAuthSectionResponse(c config.InferenceAuthConfig) map[string]interface{} {
+	return map[string]interface{}{
+		"api_key_header": c.APIKeyHeader,
+		"api_key_env":    c.APIKeyEnv,
+		"api_key_file":   c.APIKeyFile,
+		"endpoint":       c.Endpoint,
+	}
+}
+
+// handleGovernorInferenceAuthGet returns the vllm/llm-d discovery-auth
+// configuration. References only — never a key value.
+func (s *Server) handleGovernorInferenceAuthGet(w http.ResponseWriter, r *http.Request) {
+	gov := &s.deps.Config.Governor
+	jsonResponse(w, map[string]interface{}{
+		"vllm": inferenceAuthSectionResponse(gov.VLLM),
+		"llmd": inferenceAuthSectionResponse(gov.LLMD),
+	})
+}
+
+// inferenceAuthBody is one backend's section of the PUT body. Pointer fields
+// distinguish "absent — leave unchanged" from "empty — clear it", the same
+// contract as handleGovernorLiteLLM.
+type inferenceAuthBody struct {
+	APIKeyHeader *string `json:"api_key_header"`
+	APIKeyEnv    *string `json:"api_key_env"`
+	APIKeyFile   *string `json:"api_key_file"`
+	Endpoint     *string `json:"endpoint"`
+}
+
+// applyInferenceAuthBody validates one backend's submitted fields against a
+// copy of its current config and returns the updated copy, or a non-empty
+// error message. Guardrails mirror handleGovernorLiteLLM: an env/file NAME
+// field must never hold a key VALUE, and a key file path must stay inside the
+// managed secrets dirs.
+func applyInferenceAuthBody(cur config.InferenceAuthConfig, body *inferenceAuthBody) (config.InferenceAuthConfig, string) {
+	if body == nil {
+		return cur, ""
+	}
+	if body.APIKeyHeader != nil {
+		cur.APIKeyHeader = strings.TrimSpace(*body.APIKeyHeader)
+	}
+	if body.APIKeyEnv != nil {
+		keyEnv := strings.TrimSpace(*body.APIKeyEnv)
+		if looksLikeAPIKeyValue(keyEnv) {
+			return cur, "this looks like an API key — api_key_env takes an environment variable NAME (e.g. HIVE_VLLM_API_KEY)"
+		}
+		cur.APIKeyEnv = keyEnv
+	}
+	if body.APIKeyFile != nil {
+		keyFile := strings.TrimSpace(*body.APIKeyFile)
+		if !strings.HasPrefix(keyFile, "/") && looksLikeAPIKeyValue(keyFile) {
+			return cur, "this looks like an API key — api_key_file takes a file PATH (e.g. /secrets/vllm_api_key)"
+		}
+		// SECURITY (audit N8, CWE-200/918): same confinement as the gateway
+		// and LiteLLM handlers — reject an out-of-root path at the door.
+		if keyFile != "" && !config.SecretFilePathAllowed(keyFile) {
+			return cur, "api_key_file must be under /secrets or " + config.WritableSecretsDir
+		}
+		cur.APIKeyFile = keyFile
+	}
+	if body.Endpoint != nil {
+		endpoint := strings.TrimSpace(*body.Endpoint)
+		if endpoint != "" {
+			if err := validateGatewayEndpoint(endpoint); err != nil {
+				return cur, err.Error()
+			}
+		}
+		cur.Endpoint = endpoint
+	}
+	return cur, ""
+}
+
+// handleGovernorInferenceAuthPut updates governor.vllm / governor.llm-d from
+// the Model Gateways tab. Each backend section is optional; within a section,
+// absent fields are left untouched. Persists via the same secret-free overlay
+// path as every other governor-config writer.
+func (s *Server) handleGovernorInferenceAuthPut(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	var body struct {
+		VLLM *inferenceAuthBody `json:"vllm"`
+		LLMD *inferenceAuthBody `json:"llmd"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	gov := &s.deps.Config.Governor
+	// Validate both sections against copies before mutating either, so a bad
+	// llm-d field cannot leave a half-applied vllm change behind.
+	vllm, msg := applyInferenceAuthBody(gov.VLLM, body.VLLM)
+	if msg != "" {
+		jsonError(w, "vllm: "+msg, http.StatusBadRequest)
+		return
+	}
+	llmd, msg := applyInferenceAuthBody(gov.LLMD, body.LLMD)
+	if msg != "" {
+		jsonError(w, "llm-d: "+msg, http.StatusBadRequest)
+		return
+	}
+	gov.VLLM = vllm
+	gov.LLMD = llmd
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after inference-auth update", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_inference_auth", auditDetail("section", "inference-auth"), "")
+	s.refreshAndPersist()
+
+	jsonResponse(w, map[string]interface{}{
+		"ok":     true,
+		"status": "updated",
+		"vllm":   inferenceAuthSectionResponse(gov.VLLM),
+		"llmd":   inferenceAuthSectionResponse(gov.LLMD),
+	})
+}

--- a/src/pkg/dashboard/api_governor_inference_auth_test.go
+++ b/src/pkg/dashboard/api_governor_inference_auth_test.go
@@ -1,0 +1,90 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---- vLLM / llm-d inference auth (#4217) ----
+
+func TestInferenceAuth_Get(t *testing.T) {
+	s := covApiServer(t)
+	rec := doGet(s, "/api/config/governor/inference-auth")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inference-auth get: %d", rec.Code)
+	}
+	var out map[string]map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"vllm", "llmd"} {
+		if _, ok := out[k]; !ok {
+			t.Fatalf("missing %q section: %s", k, rec.Body.String())
+		}
+	}
+}
+
+func TestInferenceAuth_PutAndRoundTrip(t *testing.T) {
+	s := covApiServer(t)
+	rec := doPut(s, "/api/config/governor/inference-auth", map[string]any{
+		"vllm": map[string]any{
+			"api_key_header": "Authorization",
+			"api_key_env":    "VLLM_API_KEY",
+			"endpoint":       "https://vllm.example.com/v1",
+		},
+		"llmd": map[string]any{
+			"api_key_env": "LLMD_API_KEY",
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inference-auth put: %d (%s)", rec.Code, rec.Body.String())
+	}
+	gov := s.deps.Config.Governor
+	if gov.VLLM.APIKeyHeader != "Authorization" || gov.VLLM.APIKeyEnv != "VLLM_API_KEY" ||
+		gov.VLLM.Endpoint != "https://vllm.example.com/v1" {
+		t.Fatalf("vllm not applied: %+v", gov.VLLM)
+	}
+	if gov.LLMD.APIKeyEnv != "LLMD_API_KEY" {
+		t.Fatalf("llmd not applied: %+v", gov.LLMD)
+	}
+	// Absent fields left untouched; explicit empty clears.
+	rec = doPut(s, "/api/config/governor/inference-auth", map[string]any{
+		"vllm": map[string]any{"api_key_env": ""},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("inference-auth clear: %d", rec.Code)
+	}
+	gov = s.deps.Config.Governor
+	if gov.VLLM.APIKeyEnv != "" {
+		t.Fatalf("api_key_env not cleared: %+v", gov.VLLM)
+	}
+	if gov.VLLM.APIKeyHeader != "Authorization" || gov.VLLM.Endpoint != "https://vllm.example.com/v1" {
+		t.Fatalf("absent fields were wiped: %+v", gov.VLLM)
+	}
+}
+
+func TestInferenceAuth_PutRejectsBad(t *testing.T) {
+	s := covApiServer(t)
+	if rec := doPutRaw(s, "/api/config/governor/inference-auth", "bad"); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad body: %d", rec.Code)
+	}
+	// Key VALUE in the env-name field → 400 guardrail.
+	if rec := doPut(s, "/api/config/governor/inference-auth", map[string]any{
+		"vllm": map[string]any{"api_key_env": "sk-abcdef1234567890abcdef1234567890"},
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("key-value in env name: %d (%s)", rec.Code, rec.Body.String())
+	}
+	// Out-of-root key file path → 400 confinement.
+	if rec := doPut(s, "/api/config/governor/inference-auth", map[string]any{
+		"llmd": map[string]any{"api_key_file": "/etc/passwd"},
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("out-of-root key file: %d (%s)", rec.Code, rec.Body.String())
+	}
+	// Invalid endpoint → 400.
+	if rec := doPut(s, "/api/config/governor/inference-auth", map[string]any{
+		"vllm": map[string]any{"endpoint": "not a url"},
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad endpoint: %d (%s)", rec.Code, rec.Body.String())
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -15234,6 +15234,7 @@ function burnAreaChart() {
         // renders the manager into its container.
         if (tabId === 'Model Gateways') {
           loadGateways();
+          loadInferenceAuth();
         }
         // The Forge App tab renders a shell synchronously, then loads the
         // credential inventory (fingerprints only) from the spoke.
@@ -16099,7 +16100,73 @@ function burnAreaChart() {
         </div>
         <div id="openrouter-fund-host"></div>
         <div id="gateways-form-host"></div>
-        <div id="gateways-list-host"><div style="color:var(--muted);font-size:0.8rem">Loading gateways…</div></div>`;
+        <div id="gateways-list-host"><div style="color:var(--muted);font-size:0.8rem">Loading gateways…</div></div>
+        <div id="inference-auth-host"><div style="color:var(--muted);font-size:0.8rem">Loading inference auth…</div></div>`;
+    }
+
+    // ---- vLLM / llm-d discovery auth (#4217) --------------------------------
+    // governor.vllm / governor.llm-d (InferenceAuthConfig) were YAML-only while
+    // LiteLLM auth is exposed above. These sections take key REFERENCES only —
+    // a header NAME, an env var NAME, and an optional endpoint override — never
+    // a key value, matching the server's secret-free overlay contract.
+    async function loadInferenceAuth() {
+      const host = document.getElementById('inference-auth-host');
+      if (!host) return;
+      try {
+        const res = await fetch('/api/config/governor/inference-auth');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        host.innerHTML = renderInferenceAuthSection('vllm', 'vLLM', data.vllm || {})
+          + renderInferenceAuthSection('llmd', 'llm-d', data.llmd || {});
+      } catch (e) {
+        host.innerHTML = `<div style="color:var(--red);font-size:0.8rem">Failed to load inference auth: ${esc(e.message)}</div>`;
+      }
+    }
+
+    function renderInferenceAuthSection(id, label, cfg) {
+      const defEnv = id === 'vllm' ? 'VLLM_API_KEY' : 'LLMD_API_KEY';
+      return `
+        <div style="border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-bottom:10px;background:var(--surface)">
+          <div style="font-weight:600;font-size:0.9rem;margin-bottom:4px">${esc(label)} discovery auth</div>
+          <div style="font-size:0.74rem;color:var(--muted);margin-bottom:10px">
+            Optional auth for the ${esc(label)} backend's <code>/v1/models</code> discovery. Plain ${esc(label)}
+            servers need no key, but the endpoint may be a key-gated gateway. References only — the key value is
+            never stored in config.
+          </div>
+          <div class="config-field" style="margin-bottom:10px">
+            <label>API key header <span class="config-info">i<span class="config-tooltip">Header NAME the key is sent in. Leave blank for the default (Authorization).</span></span></label>
+            <input type="text" value="${esc(cfg.api_key_header || '')}" placeholder="Authorization" onchange="saveInferenceAuthField('${id}', 'api_key_header', this.value)" style="width:100%">
+          </div>
+          <div class="config-field" style="margin-bottom:10px">
+            <label>API key env var <span class="config-info">i<span class="config-tooltip">Environment variable NAME holding the key — never paste the key value here.</span></span></label>
+            <input type="text" value="${esc(cfg.api_key_env || '')}" placeholder="${esc(defEnv)}" onchange="saveInferenceAuthField('${id}', 'api_key_env', this.value)" style="width:100%">
+          </div>
+          <div class="config-field" style="margin-bottom:4px">
+            <label>Endpoint override (optional) <span class="config-info">i<span class="config-tooltip">OpenAI-compatible base URL used instead of the default for this backend. Leave blank to keep the default.</span></span></label>
+            <input type="text" value="${esc(cfg.endpoint || '')}" placeholder="https://…/v1" onchange="saveInferenceAuthField('${id}', 'endpoint', this.value)" style="width:100%">
+          </div>
+        </div>`;
+    }
+
+    async function saveInferenceAuthField(backend, field, value) {
+      const payload = {};
+      payload[backend] = {};
+      payload[backend][field] = value.trim();
+      try {
+        const res = await fetch('/api/config/governor/inference-auth', {
+          method: 'PUT',
+          headers: _inceptionAuthHeaders(),
+          body: JSON.stringify(payload)
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          showToast(data.error || ('Failed to save (HTTP ' + res.status + ')'), 'error');
+          return;
+        }
+        showToast((backend === 'vllm' ? 'vLLM' : 'llm-d') + ' auth saved', 'success');
+      } catch (e) {
+        showToast('Failed to save: ' + e.message, 'error');
+      }
     }
 
     // ---- OpenRouter scan-to-fund -------------------------------------------


### PR DESCRIPTION
**Problem:** `governor.vllm` and `governor.llm-d` (InferenceAuthConfig) were YAML-only, while LiteLLM auth is already exposed in Model Gateways — vLLM/llm-d operators could not configure discovery auth via the UI.

**Changes:**
- New `GET/PUT /api/config/governor/inference-auth` returning/saving `{vllm, llmd}` — references only (header NAME, env var NAME, file PATH, optional endpoint override); the key VALUE never enters hive.yaml, logs, or responses.
- PUT carries the same guardrails as the LiteLLM/gateway writers: key-value-in-name-field rejection, secret-path confinement, endpoint validation, owner-only.
- Extends `InferenceAuthConfig` with `api_key_header` and `endpoint` (omitempty — existing configs unaffected).
- Model Gateways tab now renders vLLM and llm-d discovery-auth sections (API key header, API key env var, endpoint override), matching the existing LiteLLM style.
- Tests: GET shape, PUT round-trip with absent-vs-empty semantics, and rejection of bad bodies/key-values/out-of-root paths/bad endpoints.

Closes #4217